### PR TITLE
feat(dnd-collections): roving-tabindex keyboard traversal for virtual…

### DIFF
--- a/packages/ui/dnd-collections/API.md
+++ b/packages/ui/dnd-collections/API.md
@@ -523,6 +523,16 @@ along unchanged. Drops over gaps and unmounted regions resolve through the
 container droppable (`insert-at-index`), not neighbor rects. Both drive their
 own edge auto-scroll (dnd-kit's never engaged for these containers).
 
+**Keyboard navigation.** Each view is `role="grid"` and a single roving tab
+stop: bare **arrow keys** move a focused index through the WHOLE collection —
+strip is 1D (Left/Right/Home/End), grid is 2D (arrows + Home/End) — scrolling
+offscreen items into view and focusing them, so a keyboard user reaches item
+500 of 1000 that was never in the DOM. `aria-rowcount`/`aria-colcount` and
+per-cell `aria-rowindex`/`aria-colindex` report the true position under
+virtualization. This is distinct from the two other arrow uses: **Alt+arrow**
+still MOVES the item (§ keyboard grammar) and dnd-kit's grabbed-arrows fire
+only after Enter — navigation stands down while a drag is live.
+
 ### `<VirtualStrip>` — horizontal, variable width
 
 ```ts

--- a/packages/ui/dnd-collections/ARCHITECTURE.md
+++ b/packages/ui/dnd-collections/ARCHITECTURE.md
@@ -224,6 +224,16 @@ typed rejections and are announced via the aria-live region — which nudges
 repeat messages with a zero-width space so identical announcements still
 fire.
 
+Inside the virtualized views there is a THIRD arrow-key role, and the three
+stay disjoint by design: **bare arrows NAVIGATE** (roving focus, in
+`useVirtualRovingFocus`), **Alt+arrows MOVE**, and dnd-kit's grabbed-arrows
+fire only after Enter. Navigation makes the container one `role="grid"` tab
+stop and moves a focused index through the whole collection — scrolling
+offscreen items in and focusing them (only the roving card is `tabIndex=0`),
+with `aria-row/colcount` + per-cell indexes exposing the real position under
+virtualization. It stands down while a drag is live (`isDragging`) or Alt/
+Ctrl/Meta are held, so it never collides with the other two.
+
 ## FLIP animation: a layer above the reducer
 
 `use-flip-graph-animation.ts` animates committed moves (drop/undo/redo). It

--- a/packages/ui/dnd-collections/VIRTUALIZATION-PLAN.md
+++ b/packages/ui/dnd-collections/VIRTUALIZATION-PLAN.md
@@ -3,9 +3,9 @@
 > **Status: historical build log.** The virtual view layer (`VirtualStrip`,
 > `VirtualGrid`) shipped; this document is kept for the decisions and gap
 > analysis behind it, not as current-state docs — see ARCHITECTURE.md and
-> API.md for those. Still open: **range selection** (§17) is not implemented,
-> and full **virtual keyboard traversal** (roving-tabindex / grid navigation)
-> remains a gap.
+> API.md for those. Virtual keyboard traversal (roving-tabindex + `role="grid"`
+> arrow navigation that scrolls offscreen items in) has since shipped. Still
+> open: **range selection** (§17).
 
 
 Target: the "Virtualized Collections Requirements" spec (horizontal strip +

--- a/packages/ui/dnd-collections/VirtualGrid.stories.tsx
+++ b/packages/ui/dnd-collections/VirtualGrid.stories.tsx
@@ -326,3 +326,48 @@ export const GridGapDropInsertsAtBoundary: Story = {
     });
   },
 };
+
+export const KeyboardRovingNavigation: Story = {
+  // §17/§20: a keyboard user traverses the 1,000-item grid in 2D with arrows —
+  // the grid is one roving tab stop, Down/Right move by row/column, and
+  // navigating to the end pulls an unmounted row into view. role="grid" +
+  // aria-rowcount expose the true size under virtualization. Bare arrows
+  // NAVIGATE; Alt+arrows still MOVE (GridKeyboardRowMoves covers that).
+  render: () => <GridHarness />,
+  play: async ({ canvasElement }) => {
+    const user = userEvent.setup();
+    const m0 = nodeCard(canvasElement, "m0");
+    await waitForLayout(m0);
+
+    const grid = canvasElement.querySelector('[data-virtual-grid="grid"]')!;
+    expect(grid.getAttribute("role")).toBe("grid");
+    expect(grid.getAttribute("aria-rowcount")).toBe(String(ITEM_COUNT / COLUMNS));
+    expect(m0.tabIndex).toBe(0);
+
+    // Down = one row (= column count); Right = one column.
+    m0.focus();
+    await user.keyboard("{ArrowDown}");
+    await waitFor(() => {
+      const m4 = nodeCard(canvasElement, "m4");
+      expect(m4.ownerDocument.activeElement).toBe(m4);
+      expect(m4.tabIndex).toBe(0);
+    });
+    await user.keyboard("{ArrowRight}");
+    await waitFor(() => {
+      const m5 = nodeCard(canvasElement, "m5");
+      expect(m5.ownerDocument.activeElement).toBe(m5);
+    });
+
+    // Navigation must NOT reorder the collection.
+    expect(gridOrder(canvasElement, "grid").slice(0, 4)).toEqual(["m0", "m1", "m2", "m3"]);
+
+    // End jumps to the last item — an unmounted, offscreen row — scrolled in.
+    expect(canvasElement.querySelector('[data-node-id="m999"]')).toBeNull();
+    await user.keyboard("{End}");
+    await waitFor(() => {
+      const last = canvasElement.querySelector<HTMLElement>('[data-node-id="m999"]');
+      expect(last).not.toBeNull();
+      expect(last!.ownerDocument.activeElement).toBe(last);
+    });
+  },
+};

--- a/packages/ui/dnd-collections/VirtualStrip.stories.tsx
+++ b/packages/ui/dnd-collections/VirtualStrip.stories.tsx
@@ -691,3 +691,44 @@ export const OffscreenFocusScrollsIntoView: Story = {
     });
   },
 };
+
+export const KeyboardRovingNavigation: Story = {
+  // §17/§20: a keyboard user traverses the WHOLE 1,000-item collection with
+  // arrows — the strip is one roving tab stop, and navigation pulls offscreen
+  // items into view. Grid semantics (role + aria-colcount/colindex) expose the
+  // true position under virtualization.
+  render: () => <StripHarness />,
+  play: async ({ canvasElement }) => {
+    const user = userEvent.setup();
+    const m0 = nodeCard(canvasElement, "m0");
+    await waitForLayout(m0);
+
+    // Roving tabindex: the first card is the single tab stop; neighbors are -1.
+    expect(m0.tabIndex).toBe(0);
+    expect(nodeCard(canvasElement, "m1").tabIndex).toBe(-1);
+    const strip = canvasElement.querySelector('[data-virtual-strip="strip"]')!;
+    expect(strip.getAttribute("role")).toBe("grid");
+    expect(strip.getAttribute("aria-colcount")).toBe("1000");
+
+    // ArrowRight roves one item and follows focus; the roving stop moves with it.
+    m0.focus();
+    await user.keyboard("{ArrowRight}");
+    await waitFor(() => {
+      const m1 = nodeCard(canvasElement, "m1");
+      expect(m1.ownerDocument.activeElement).toBe(m1);
+      expect(m1.tabIndex).toBe(0);
+      expect(nodeCard(canvasElement, "m0").tabIndex).toBe(-1);
+    });
+
+    // End jumps to the last item — unmounted and far offscreen — scrolling it
+    // into view and focusing it. This is the whole point: no Tab could reach it.
+    expect(canvasElement.querySelector('[data-node-id="m999"]')).toBeNull();
+    await user.keyboard("{End}");
+    await waitFor(() => {
+      const last = canvasElement.querySelector<HTMLElement>('[data-node-id="m999"]');
+      expect(last).not.toBeNull();
+      expect(last!.ownerDocument.activeElement).toBe(last);
+      expect(last!.tabIndex).toBe(0);
+    });
+  },
+};

--- a/packages/ui/dnd-collections/react/node-views.tsx
+++ b/packages/ui/dnd-collections/react/node-views.tsx
@@ -104,6 +104,7 @@ export const NodeCard = memo(function NodeCard({
   id,
   className,
   dragActivation = "body",
+  rovingTabIndex,
 }: {
   id: NodeId;
   /**
@@ -123,6 +124,15 @@ export const NodeCard = memo(function NodeCard({
    * ghosts remain card-sized, and body clicks still select.
    */
   dragActivation?: NodeCardDragActivation;
+  /**
+   * Roving-tabindex value (0 or -1) for virtualized views: the container is
+   * ONE tab stop and arrow keys rove between items, so exactly one mounted
+   * card is `0` at a time and the rest are `-1`. When set, the grip (handle
+   * mode) is also demoted to `-1` so the card button is the sole keyboard
+   * stop — pointer grip-drag still works; keyboard drag uses the Alt-key
+   * moves. Undefined (panels) keeps each card an independent tab stop.
+   */
+  rovingTabIndex?: number;
 }) {
   const dragHandle = dragActivation === "handle";
   const store = useCollectionsStore();
@@ -224,6 +234,9 @@ export const NodeCard = memo(function NodeCard({
             ? instructionsId
             : `${attributes["aria-describedby"]} ${instructionsId}`
         }
+        // Roving tabindex (virtual views) overrides dnd-kit's tabIndex from
+        // the attribute spread above — must come after it.
+        {...(rovingTabIndex !== undefined ? { tabIndex: rovingTabIndex } : {})}
       >
         <span className="truncate font-medium text-foreground">{node.name}</span>
         <span className="text-[10px] text-muted-foreground">
@@ -243,6 +256,9 @@ export const NodeCard = memo(function NodeCard({
           {...listeners}
           aria-label={`Drag ${node.name}`}
           aria-describedby={`${attributes["aria-describedby"]} ${instructionsId}`}
+          // In a roving (virtual) view the card button is the sole tab stop;
+          // keep the grip a pointer-only drag surface.
+          {...(rovingTabIndex !== undefined ? { tabIndex: -1 } : {})}
         >
           ⠿
         </div>

--- a/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
@@ -10,13 +10,14 @@ import {
 import { useVirtualizer } from "@tanstack/react-virtual";
 
 import { getChildren, type NodeId } from "../core/graph";
-import { useCollectionsSelector } from "../react/collections-store";
+import { useCollectionsSelector, useCollectionsStore } from "../react/collections-store";
 import { NodeCard } from "../react/node-views";
 import { useEdgeAutoScroll } from "../react/use-edge-autoscroll";
 import {
   useFocusNode,
   usePublishBoundary,
   useVirtualInsertContainer,
+  useVirtualRovingFocus,
   VirtualEmptyHint,
   type VirtualViewPoint,
 } from "./use-virtual-collection-view";
@@ -135,6 +136,52 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
     );
     const focusNode = useFocusNode(scrollRef, scrollToNode);
 
+    // Roving keyboard navigation: bare arrows move focus in 2D (±1 across a
+    // row, ±cols between rows), scrolling offscreen rows into view. Alt+arrows
+    // stay item MOVES (handled by the keyboard controller via data-grid-columns).
+    const store = useCollectionsStore();
+    const name = useCollectionsSelector(
+      (s) => s.graph.nodesById.get(collectionId)?.name ?? String(collectionId)
+    );
+    const focusByIndex = useCallback(
+      (index: number) => focusNode(childIds[index]),
+      [focusNode, childIds]
+    );
+    const resolveGridIndex = useCallback(
+      (key: string, current: number, count: number): number | null => {
+        switch (key) {
+          case "ArrowRight":
+            return current + 1;
+          case "ArrowLeft":
+            return current - 1;
+          case "ArrowDown":
+            return current + cols;
+          case "ArrowUp":
+            return current - cols;
+          case "Home":
+            return 0;
+          case "End":
+            return count - 1;
+          default:
+            return null;
+        }
+      },
+      [cols]
+    );
+    const { focusedIndex, onKeyDown } = useVirtualRovingFocus({
+      count: childIds.length,
+      isDragging: () => store.getSnapshot().interaction.isDragging,
+      focusByIndex,
+      resolveNextIndex: resolveGridIndex,
+    });
+    // Keep the roving tab stop on a MOUNTED card: rows virtualize, so if the
+    // focused card's row scrolled out, fall back to the first mounted row.
+    const mountedRows = virtualizer.getVirtualItems();
+    const focusedRow = Math.floor(focusedIndex / cols);
+    const rovingIndex = mountedRows.some((r) => r.index === focusedRow)
+      ? focusedIndex
+      : (mountedRows[0]?.index ?? 0) * cols;
+
     useImperativeHandle(
       ref,
       () => ({
@@ -172,6 +219,13 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
         // Keyboard scope marker: the provider remaps Alt+ArrowUp/Down to
         // row moves (± this many columns) for cards inside this container.
         data-grid-columns={cols}
+        // 2D grid: bare arrows rove; aria-rowcount/colcount + per-row/cell
+        // indexes expose the true position ("row 200 of 250") under virtualization.
+        role="grid"
+        aria-label={`${name}, ${childIds.length} items`}
+        aria-rowcount={rowCount}
+        aria-colcount={cols}
+        onKeyDown={onKeyDown}
         className={[
           "relative overflow-y-auto rounded-md border border-dashed border-border p-2",
           className ?? "",
@@ -192,6 +246,8 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
             <div
               key={row.key}
               data-virtual-row={row.index}
+              role="row"
+              aria-rowindex={row.index + 1}
               style={{
                 position: "absolute",
                 top: 0,
@@ -204,11 +260,23 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
             >
               {childIds
                 .slice(row.index * cols, Math.min(childIds.length, (row.index + 1) * cols))
-                .map((id) => (
-                  <div key={id} style={{ width: cellWidth, height: cellHeight }}>
-                    <NodeCard id={id} className="h-full w-full" />
-                  </div>
-                ))}
+                .map((id, colInRow) => {
+                  const absoluteIndex = row.index * cols + colInRow;
+                  return (
+                    <div
+                      key={id}
+                      role="gridcell"
+                      aria-colindex={colInRow + 1}
+                      style={{ width: cellWidth, height: cellHeight }}
+                    >
+                      <NodeCard
+                        id={id}
+                        className="h-full w-full"
+                        rovingTabIndex={absoluteIndex === rovingIndex ? 0 : -1}
+                      />
+                    </div>
+                  );
+                })}
             </div>
           ))}
         </div>

--- a/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
@@ -15,9 +15,26 @@ import {
   useFocusNode,
   usePublishBoundary,
   useVirtualInsertContainer,
+  useVirtualRovingFocus,
   VirtualEmptyHint,
   type VirtualViewPoint,
 } from "./use-virtual-collection-view";
+
+// 1D roving navigation: Left/Right step one item, Home/End jump to the ends.
+function resolveStripIndex(key: string, current: number, count: number): number | null {
+  switch (key) {
+    case "ArrowRight":
+      return current + 1;
+    case "ArrowLeft":
+      return current - 1;
+    case "Home":
+      return 0;
+    case "End":
+      return count - 1;
+    default:
+      return null;
+  }
+}
 
 // Horizontal virtualized strip: renders only visible cards + overscan out
 // of arbitrarily large collections. Cards ARE the standard NodeCard —
@@ -165,6 +182,29 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
     );
     const focusNode = useFocusNode(scrollRef, scrollToNode);
 
+    // Roving keyboard navigation (bare Left/Right/Home/End). The collection
+    // name gives the grid an accessible name.
+    const name = useCollectionsSelector(
+      (s) => s.graph.nodesById.get(collectionId)?.name ?? String(collectionId)
+    );
+    const focusByIndex = useCallback(
+      (index: number) => focusNode(childIds[index]),
+      [focusNode, childIds]
+    );
+    const { focusedIndex, onKeyDown } = useVirtualRovingFocus({
+      count: childIds.length,
+      isDragging: () => store.getSnapshot().interaction.isDragging,
+      focusByIndex,
+      resolveNextIndex: resolveStripIndex,
+    });
+    // Keep the roving tab stop on a MOUNTED card: if the focused index scrolled
+    // out of view (mouse/pan), fall back to the first mounted item so the strip
+    // stays tabbable.
+    const mountedItems = virtualizer.getVirtualItems();
+    const rovingIndex = mountedItems.some((v) => v.index === focusedIndex)
+      ? focusedIndex
+      : mountedItems[0]?.index ?? 0;
+
     useImperativeHandle(
       ref,
       () => ({
@@ -205,6 +245,14 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
       <div
         ref={setContainerRef}
         data-virtual-strip={collectionId}
+        // One-row grid: arrow keys rove across columns, and aria-colcount /
+        // aria-colindex expose the true position ("column 500 of 1000") even
+        // though only a handful of cells are mounted.
+        role="grid"
+        aria-label={`${name}, ${childIds.length} items`}
+        aria-rowcount={1}
+        aria-colcount={childIds.length}
+        onKeyDown={onKeyDown}
         className={[
           "relative overflow-x-auto rounded-md border border-dashed border-border p-2",
           className ?? "",
@@ -219,6 +267,8 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
         <VirtualEmptyHint visible={childIds.length === 0} />
         <div
           ref={contentRef}
+          role="row"
+          aria-rowindex={1}
           style={{ width: virtualizer.getTotalSize(), height: itemHeight, position: "relative" }}
         >
           {indicatorLeft !== null && (
@@ -233,6 +283,8 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
             <div
               key={item.key}
               data-virtual-index={item.index}
+              role="gridcell"
+              aria-colindex={item.index + 1}
               style={{
                 position: "absolute",
                 top: 0,
@@ -249,6 +301,7 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
                 id={childIds[item.index]}
                 className="h-full w-full"
                 dragActivation={cardActivation}
+                rovingTabIndex={item.index === rovingIndex ? 0 : -1}
               />
             </div>
           ))}

--- a/packages/ui/dnd-collections/virtual/use-virtual-collection-view.tsx
+++ b/packages/ui/dnd-collections/virtual/use-virtual-collection-view.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useCallback, useLayoutEffect, useRef, type RefObject } from "react";
+import {
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type RefObject,
+} from "react";
 import { useDroppable } from "@dnd-kit/core";
 
 import { type NodeId } from "../core/graph";
@@ -93,6 +100,54 @@ export function useFocusNode(
     },
     [scrollRef, scrollToNode]
   );
+}
+
+/**
+ * Roving-focus keyboard navigation for a virtualized view: the container is a
+ * single tab stop, and bare arrow keys move a "focused index" through the
+ * WHOLE collection — scrolling offscreen items into view and focusing them —
+ * so a keyboard user can reach item 500 of 1000 that was never in the DOM.
+ *
+ * Deliberately separate from the two existing arrow uses: Alt+arrow MOVES the
+ * item (keyboard controller), and dnd-kit's grabbed-arrows fire only after
+ * Enter — so navigation stands down while a drag is live and while Alt/Ctrl/
+ * Meta are held. Each view supplies `resolveNextIndex` for its own geometry
+ * (1D for the strip, 2D for the grid).
+ */
+export function useVirtualRovingFocus(args: {
+  count: number;
+  isDragging: () => boolean;
+  /** Scroll the index into view and focus its card once the virtualizer mounts it. */
+  focusByIndex: (index: number) => void;
+  /** Map a key + current index to the next index, or null to ignore the key. */
+  resolveNextIndex: (key: string, current: number, count: number) => number | null;
+}): Readonly<{
+  focusedIndex: number;
+  onKeyDown: (event: ReactKeyboardEvent) => void;
+}> {
+  const { count, isDragging, focusByIndex, resolveNextIndex } = args;
+  const [focusedIndex, setFocusedIndex] = useState(0);
+  const focusedRef = useRef(0);
+
+  const onKeyDown = useCallback(
+    (event: ReactKeyboardEvent) => {
+      // Alt = item move; Ctrl/Meta reserved; during a keyboard drag the sensor
+      // owns the arrows.
+      if (event.altKey || event.ctrlKey || event.metaKey || isDragging()) return;
+      const next = resolveNextIndex(event.key, focusedRef.current, count);
+      if (next === null) return;
+      event.preventDefault();
+      const clamped = Math.max(0, Math.min(next, count - 1));
+      focusedRef.current = clamped;
+      setFocusedIndex(clamped);
+      focusByIndex(clamped);
+    },
+    [count, isDragging, focusByIndex, resolveNextIndex]
+  );
+
+  // A shrinking collection can leave the focused index past the end; clamp for
+  // the roving-tabindex computation without disturbing the stored value.
+  return { focusedIndex: Math.min(focusedIndex, Math.max(0, count - 1)), onKeyDown };
 }
 
 /** The empty-collection affordance shared by strip and grid. */


### PR DESCRIPTION
… views

Keyboard users could only Tab to the ~20 mounted cards in a virtualized collection — item 500 of 1000 was unreachable. Add ARIA grid roving-focus navigation to VirtualStrip and VirtualGrid.

- New useVirtualRovingFocus hook: the container is ONE tab stop, bare arrow keys move a focused index through the WHOLE collection, scrolling offscreen items into view (reusing focusNode) and focusing them. Strip is 1D (Left/Right/Home/End); grid is 2D (arrows + Home/End). Stands down while a drag is live or Alt/Ctrl/Meta are held, so it never collides with Alt+arrow MOVES or dnd-kit's grabbed-arrows.
- NodeCard gains a rovingTabIndex prop: exactly one mounted card is tabIndex 0 at a time, the rest -1; in handle mode the grip is demoted to pointer-only so the card button is the sole keyboard stop. Panels pass nothing and keep per-card tab stops.
- Both views expose role="grid" + aria-row/colcount and per-cell aria-row/colindex, so a screen reader reports the true position ("row 200 of 250") despite virtualization. A fallback keeps the roving stop on a mounted card when the focused index scrolls away.

Tests: KeyboardRovingNavigation stories for strip and grid (roving tabindex, arrow nav, End scrolling an unmounted item into view + focusing it, no reorder). API.md / ARCHITECTURE.md / VIRTUALIZATION-PLAN.md updated.