### PR TITLE
feat(dnd-collections): trim Phase B — left handle grows left, smoothly

### DIFF
--- a/apps/web/tests/e2e/dnd-collections.spec.ts
+++ b/apps/web/tests/e2e/dnd-collections.spec.ts
@@ -415,6 +415,107 @@ test.describe('DndCollections E2E', () => {
     await expectAligned();
   });
 
+  test('trim left-grows-left: real-mouse left drag anchors the right edge, pushes left neighbors', async ({
+    page,
+  }) => {
+    // PhaseBPlayground is a scrollable strip with a video at index 3
+    // (effective 7s -> 168px) flanked by image neighbors. Dragging its LEFT
+    // handle left grows the clip toward the left: right edge anchored, left
+    // neighbor pushed left, right neighbor stays put.
+    await page.goto(storyPath('ui-dndcollectionsvirtual--phase-b-playground'));
+
+    const vid = card(page, 'vid');
+    await vid.waitFor({ state: 'visible' });
+    const leftNeighbor = card(page, 'l2');
+    const rightNeighbor = card(page, 'r0');
+    await leftNeighbor.waitFor({ state: 'visible' });
+    await rightNeighbor.waitFor({ state: 'visible' });
+
+    expect(Math.round((await vid.boundingBox())!.width)).toBe(168);
+    const vidBox0 = (await vid.boundingBox())!;
+    const vidRight0 = vidBox0.x + vidBox0.width;
+    const l2Right0 = (await leftNeighbor.boundingBox())!.x + (await leftNeighbor.boundingBox())!.width;
+    const r0Left0 = (await rightNeighbor.boundingBox())!.x;
+
+    const leftHandle = page.locator('[data-node-wrapper="vid"] [data-trim-handle="left"]');
+    await leftHandle.waitFor({ state: 'attached' });
+    const hb = (await leftHandle.boundingBox())!;
+    const startX = hb.x + hb.width / 2;
+    const startY = hb.y + hb.height / 2;
+
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move(startX - 48, startY, { steps: 12 }); // trim-in 3s -> 1s
+    await page.waitForTimeout(150); // dwell
+
+    // Live, before release: width grew to 216, right edge anchored, left
+    // neighbor pushed left by ~48, right neighbor unmoved.
+    await expect(async () => {
+      expect(Math.round((await vid.boundingBox())!.width)).toBe(216);
+    }).toPass();
+    const vidBox1 = (await vid.boundingBox())!;
+    expect(Math.abs(vidBox1.x + vidBox1.width - vidRight0)).toBeLessThanOrEqual(1);
+    const l2Box1 = (await leftNeighbor.boundingBox())!;
+    expect(Math.round(l2Box1.x + l2Box1.width)).toBe(Math.round(l2Right0 - 48));
+    expect(Math.round((await rightNeighbor.boundingBox())!.x)).toBe(Math.round(r0Left0));
+    await expect(page.getByRole('button', { name: /undo/i })).toBeDisabled();
+
+    await page.mouse.up();
+
+    // Commit holds the anchored position (no flash).
+    await expect(page.getByRole('button', { name: /undo/i })).toBeEnabled();
+    const vidBox2 = (await vid.boundingBox())!;
+    expect(Math.round(vidBox2.width)).toBe(216);
+    expect(Math.abs(vidBox2.x + vidBox2.width - vidRight0)).toBeLessThanOrEqual(1);
+
+    // Undo reverts.
+    await page.getByRole('button', { name: /undo/i }).click();
+    await expect(async () => {
+      expect(Math.round((await vid.boundingBox())!.width)).toBe(168);
+    }).toPass();
+  });
+
+  test('trim left-shrink stays anchored: right edge held, left edge moves right, no scroll write', async ({
+    page,
+  }) => {
+    // Regression for the reported inconsistency: at the strip start dragging
+    // the left handle RIGHT (shrinking) used to clamp scrollLeft at 0 and
+    // shrink the RIGHT edge inward. Now a composited transform anchors the
+    // right edge with no per-frame scroll write (smooth + consistent).
+    await page.goto(storyPath('ui-dndcollectionsvirtual--phase-b-playground'));
+
+    const vid = card(page, 'vid');
+    await vid.waitFor({ state: 'visible' });
+    const strip = page.locator('[data-virtual-strip="strip"]');
+    expect(await strip.evaluate((el) => el.scrollLeft)).toBe(0);
+
+    const box0 = (await vid.boundingBox())!;
+    const vidRight0 = box0.x + box0.width;
+    const vidLeft0 = box0.x;
+
+    const leftHandle = page.locator('[data-node-wrapper="vid"] [data-trim-handle="left"]');
+    const hb = (await leftHandle.boundingBox())!;
+    const startX = hb.x + hb.width / 2;
+    const startY = hb.y + hb.height / 2;
+
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move(startX + 48, startY, { steps: 12 }); // trim-in 3s -> 5s
+    await page.waitForTimeout(150);
+
+    await expect(async () => {
+      expect(Math.round((await vid.boundingBox())!.width)).toBe(120);
+    }).toPass();
+    const box1 = (await vid.boundingBox())!;
+    // Right edge anchored; left edge moved right by the shrink; scroll untouched.
+    expect(Math.abs(box1.x + box1.width - vidRight0)).toBeLessThanOrEqual(1);
+    expect(Math.round(box1.x)).toBe(Math.round(vidLeft0 + 48));
+    expect(await strip.evaluate((el) => el.scrollLeft)).toBe(0);
+
+    await page.mouse.up();
+    await expect(page.getByRole('button', { name: /undo/i })).toBeEnabled();
+  });
+
   test('reorders within a collection (drop on right half = after)', async ({ page }) => {
     await page.goto(storyPath(PLAYGROUND));
 

--- a/packages/ui/dnd-collections/ARCHITECTURE.md
+++ b/packages/ui/dnd-collections/ARCHITECTURE.md
@@ -165,6 +165,30 @@ covers non-drag trims (keyboard, direct dispatch) the resizeItem path misses.
 The last preview size already matches the committed size, so there is no
 resize flash. An aborted drag (pointercancel, or a no-op) resets the preview.
 
+The LEFT handle grows the clip toward the left: its right edge stays anchored,
+the left edge follows the cursor, and left neighbors slide left. `resizeItem`
+alone can't do this — it keeps `offset[index]` fixed and only shifts LATER
+offsets right, so growth appears on the right. So a left drag pairs the resize
+with a composited **transform** on the content layer: `translateX(−(newSize −
+size0))`, where `size0` is the slot size captured at drag start
+(`trimBaselineRef`). Since viewport-x = contentX − scrollLeft + translateX,
+the item's right edge `(offset + newSize) + translateX` stays constant while
+its left edge and left neighbors move by the growth; right neighbors, shifted
+by `resizeItem`, are cancelled by the transform and stay put. The shift is
+derived from the live-trim state during render, so it lands in the SAME React
+commit as the resize (atomic — no stutter), and it's a transform rather than a
+`scrollLeft` write for two reasons: a transform isn't clamped (so shrinking a
+clip at the strip start, where `scrollLeft` can't go below 0, stays consistent
+instead of collapsing to a right-edge shrink), and it doesn't fire scroll
+events that fight the pan/auto-scroll hooks. At COMMIT the `nodesById` effect
+converts the transform into a real `scrollLeft` (`scrollLeft −= shift`) and
+clears the live-trim state, so removing the transform doesn't jump the clip —
+seamless where there's scroll room, a small snap where there isn't (the known
+native-scroll limit). An abort just clears the live-trim state (transform → 0,
+scroll untouched → revert). Gated to the left handle on a non-first item;
+index 0 keeps grow-right. The right handle is unchanged (grows right, left edge
+anchored, pure `resizeItem`).
+
 For a selected video, `VirtualStrip` also renders a `TrimOverviewStrip`
 (`trim-overview.tsx`) — the full source as a poster filmstrip with an amber
 window marking what's showing — directly above that clip's row, and reserves

--- a/packages/ui/dnd-collections/TRIM-PHASE-B-PLAN.md
+++ b/packages/ui/dnd-collections/TRIM-PHASE-B-PLAN.md
@@ -1,14 +1,27 @@
 # Trim UX — Phase B plan (left-grows-left + live overview)
 
-> Status: **planning**. Phase A shipped (amber `TrimOverview` source-window
+> Status: **SHIPPED.** Phase A shipped first (amber `TrimOverview` source-window
 > strip, `showing / full` pill, amber handles, overview locked to the strip's
-> `trimPixelsPerSecond` so the window == clip width). The "X-alignment" open
-> decision below and its prerequisite live-overview-sync mechanism have ALSO
-> shipped (ahead of the rest of this plan — see "Current state" and the
-> resolved decision below). What remains of this doc is the "left grows left"
-> scroll-anchor mechanic. Reference implementation to match:
-> `packages/ui/timeline/media/video-source-filmstrip.tsx` and the app running
-> at `http://localhost:3001/.../workbench`.
+> `trimPixelsPerSecond` so the window == clip width). Then the "X-alignment"
+> decision + its live-overview-sync mechanism shipped. Then the "left grows
+> left" mechanic (this doc's core goal) shipped: a left-handle drag anchors
+> the clip's RIGHT edge so the left edge follows the cursor and left neighbors
+> slide left. It anchors via a composited **transform** on the content layer
+> derived from live-trim state (`previewTrim`, `trimBaselineRef`,
+> `dragShiftX`), reconciled to a real `scrollLeft` at commit — NOT a per-frame
+> `scrollLeft` write (an earlier version did that and stuttered, and clamped
+> at the strip start so a shrink there wrongly shrank the right edge). See
+> `virtual/VirtualStrip.tsx` and ARCHITECTURE.md's trim section. What remains
+> is only the OPTIONAL Phase B.2 (draggable overview handles) below. Reference
+> implementation matched: `packages/ui/timeline/media/video-source-filmstrip.tsx`.
+>
+> **Known limitation (accepted):** the transform anchors consistently during
+> the drag at any scroll position, but the COMMIT converts it to native
+> `scrollLeft`, which is bounded at 0. On the FIRST item (index 0, no left
+> neighbors) the left drag keeps grow-right; and committing a left-trim on a
+> clip at the strip start can snap by the shortfall the scroll can't absorb.
+> This suits `VirtualStrip`'s large-collection purpose; a non-scrollable
+> timeline genuinely can't represent "grow past content 0" in native layout.
 
 ## Goal (from the user's recording)
 

--- a/packages/ui/dnd-collections/VirtualStrip.stories.tsx
+++ b/packages/ui/dnd-collections/VirtualStrip.stories.tsx
@@ -1095,3 +1095,188 @@ export const KeyboardTrim: Story = {
     await waitFor(() => expect(width("vid")).toBe(216));
   },
 };
+
+// Phase B fixture: a strip WIDE enough to scroll (needed for the right-edge
+// anchor — a left-handle drag grows the item and shifts scrollLeft to hold
+// the right edge, which only has room on a scrollable strip), with a video at
+// index 3 (trim-in 3s of a 10s source -> effective 7s -> 168px) flanked by
+// image neighbors on both sides.
+function phaseBGraph() {
+  const children: GraphNodeSpec[] = [];
+  for (let i = 0; i < 3; i++) {
+    children.push({ kind: "media", id: `l${i}`, name: `L${i}`, src: trimDogFrames[0], durationSeconds: 4 });
+  }
+  children.push({
+    kind: "media",
+    mediaKind: "video",
+    id: "vid",
+    name: "Vid",
+    posterSrcs: trimDogFrames,
+    fullDurationSeconds: 10,
+    trimInSeconds: 3,
+    trimOutSeconds: 0,
+  });
+  for (let i = 0; i < 10; i++) {
+    children.push({ kind: "media", id: `r${i}`, name: `R${i}`, src: trimDogFrames[1], durationSeconds: 4 });
+  }
+  const result = buildGraph([{ kind: "collection", id: "strip", name: "Strip", children }]);
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.value;
+}
+
+function PhaseBHarness() {
+  return (
+    <DndCollections initialGraph={phaseBGraph()} animateMoves={false}>
+      <SelectOnMount id="vid" />
+      <div className="flex w-[640px] flex-col gap-3">
+        <UndoRedoControls />
+        <VirtualStrip
+          collectionId={parseNodeId("strip")}
+          itemWidthFor={(node) =>
+            node.kind === "media" ? mediaDurationSeconds(node) * TRIM_PPS : undefined
+          }
+          trimPixelsPerSecond={TRIM_PPS}
+        />
+      </div>
+    </DndCollections>
+  );
+}
+
+export const LeftHandleGrowsLeft: Story = {
+  // Phase B: dragging the video's LEFT handle leftward grows the clip toward
+  // the left — its RIGHT edge stays anchored, its left edge follows the
+  // cursor, and left neighbors are pushed left while right neighbors stay put.
+  // The mechanic is targeted resizeItem + a scrollLeft shift (no card
+  // re-renders, no mid-drag graph commit).
+  render: () => <PhaseBHarness />,
+  play: async ({ canvasElement }) => {
+    const rect = (id: string) => nodeCard(canvasElement, id).getBoundingClientRect();
+    const width = (id: string) => Math.round(rect(id).width);
+    const handle = (id: string, side: "left" | "right") =>
+      nodeCard(canvasElement, id)
+        .closest("[data-node-wrapper]")!
+        .querySelector<HTMLElement>(`[data-trim-handle="${side}"]`)!;
+    const holdHandleBy = async (el: HTMLElement, dx: number) => {
+      const r = el.getBoundingClientRect();
+      const y = r.top + r.height / 2;
+      const x = r.left + r.width / 2;
+      await dispatchPointerSequence([
+        { element: el, type: "pointerdown", clientX: x, clientY: y },
+        { element: document, type: "pointermove", clientX: x + dx, clientY: y, delayAfterMs: 40 },
+      ]);
+    };
+    const release = async () => {
+      await dispatchPointerSequence([
+        { element: document, type: "pointerup", clientX: 0, clientY: 0, delayAfterMs: 30 },
+      ]);
+    };
+    const undoButton = () => within(canvasElement).getByRole("button", { name: /undo/i });
+
+    await waitForLayout(nodeCard(canvasElement, "vid"));
+    // vid effective 7s -> 168px; left neighbor L2 and right neighbor R0 mount.
+    expect(width("vid")).toBe(168);
+
+    const vidRight0 = rect("vid").right;
+    const l2Right0 = rect("l2").right;
+    const r0Left0 = rect("r0").left;
+    // A left-side bystander (offset unchanged by resizeItem AND not moved by
+    // the drag geometry beyond the shared scroll shift) — its memoized card
+    // must not re-render during the gesture.
+    const bystander = nodeCard(canvasElement, "l1");
+    const renderCount0 = bystander.getAttribute("data-render-count");
+
+    // Drag the LEFT handle LEFT by 48px -> trim-in 3s -> 1s -> effective 9s
+    // -> 216px (grew by 48). Hold, without releasing, to inspect the live
+    // anchored state.
+    await holdHandleBy(handle("vid", "left"), -48);
+    await waitFor(() => expect(width("vid")).toBe(216));
+
+    // Right edge anchored (within a rounding px); left neighbor pushed left by
+    // the growth; right neighbor stays put.
+    expect(Math.abs(rect("vid").right - vidRight0)).toBeLessThanOrEqual(1);
+    expect(Math.round(rect("l2").right)).toBe(Math.round(l2Right0 - 48));
+    expect(Math.round(rect("r0").left)).toBe(Math.round(r0Left0));
+    // Overview window (vid is selected) stays aligned to the clip through the
+    // scroll-anchored drag.
+    {
+      const w = canvasElement.querySelector<HTMLElement>("[data-trim-overview-window]")!.getBoundingClientRect();
+      const v = rect("vid");
+      expect(Math.round(w.left)).toBe(Math.round(v.left));
+      expect(Math.round(w.right)).toBe(Math.round(v.right));
+    }
+    // Perf guard: no bystander re-render during the live trim.
+    expect(bystander.getAttribute("data-render-count")).toBe(renderCount0);
+
+    // Nothing committed yet.
+    expect(undoButton()).toBeDisabled();
+
+    // Release commits it; the right edge stays anchored (no flash) and the
+    // width holds at 216.
+    await release();
+    await waitFor(() => expect(undoButton()).toBeEnabled());
+    expect(width("vid")).toBe(216);
+    expect(Math.abs(rect("vid").right - vidRight0)).toBeLessThanOrEqual(1);
+
+    // Ordinary undoable command.
+    const user = userEvent.setup();
+    await user.click(undoButton());
+    await waitFor(() => expect(width("vid")).toBe(168));
+  },
+};
+
+export const LeftHandleShrinkStaysAnchored: Story = {
+  // Regression: dragging the left handle to the RIGHT (trimming in / shrinking)
+  // keeps the clip's RIGHT edge anchored and moves its LEFT edge right —
+  // CONSISTENTLY, even at the strip start where scrollLeft can't go negative.
+  // The previous imperative-scroll anchor clamped at 0 there and the right
+  // edge shrank inward instead (inconsistent). The anchor is now a composited
+  // transform (unclamped) applied atomically with the resize (no per-frame
+  // scroll write — smooth). Proven here by scrollLeft staying 0 throughout.
+  render: () => <PhaseBHarness />,
+  play: async ({ canvasElement }) => {
+    const rect = (id: string) => nodeCard(canvasElement, id).getBoundingClientRect();
+    const width = (id: string) => Math.round(rect(id).width);
+    const handle = (id: string, side: "left" | "right") =>
+      nodeCard(canvasElement, id)
+        .closest("[data-node-wrapper]")!
+        .querySelector<HTMLElement>(`[data-trim-handle="${side}"]`)!;
+    const holdHandleBy = async (el: HTMLElement, dx: number) => {
+      const r = el.getBoundingClientRect();
+      const y = r.top + r.height / 2;
+      const x = r.left + r.width / 2;
+      await dispatchPointerSequence([
+        { element: el, type: "pointerdown", clientX: x, clientY: y },
+        { element: document, type: "pointermove", clientX: x + dx, clientY: y, delayAfterMs: 40 },
+      ]);
+    };
+    const strip = canvasElement.querySelector<HTMLElement>('[data-virtual-strip="strip"]')!;
+
+    await waitForLayout(nodeCard(canvasElement, "vid"));
+    expect(width("vid")).toBe(168);
+    expect(strip.scrollLeft).toBe(0); // at the start — the old clamp case
+    const vidRight0 = rect("vid").right;
+    const vidLeft0 = rect("vid").left;
+
+    // Drag the LEFT handle RIGHT +48 -> trim-in 3s -> 5s -> effective 5s -> 120px.
+    await holdHandleBy(handle("vid", "left"), 48);
+    await waitFor(() => expect(width("vid")).toBe(120));
+
+    // Right edge stays anchored; the LEFT edge moves right by the shrink — NOT
+    // the right edge shrinking inward. And no scroll was written (smooth).
+    expect(Math.abs(rect("vid").right - vidRight0)).toBeLessThanOrEqual(1);
+    expect(Math.round(rect("vid").left)).toBe(Math.round(vidLeft0 + 48));
+    expect(strip.scrollLeft).toBe(0);
+
+    // Abort leaves the graph untouched and reverts the view.
+    await dispatchPointerSequence([
+      { element: document, type: "pointercancel", clientX: 0, clientY: 0, delayAfterMs: 30 },
+    ]);
+    await waitFor(() => expect(width("vid")).toBe(168));
+    expect(Math.round(rect("vid").right)).toBe(Math.round(vidRight0));
+  },
+};
+
+/** Play-less twin of LeftHandleGrowsLeft for the real-mouse e2e. */
+export const PhaseBPlayground: Story = {
+  render: () => <PhaseBHarness />,
+};

--- a/packages/ui/dnd-collections/react/trim-handles.tsx
+++ b/packages/ui/dnd-collections/react/trim-handles.tsx
@@ -122,8 +122,9 @@ export function TrimHandles({
         pendingRef.current = update;
         setPreview(effectiveSeconds);
         // Live-resize the card AND publish the live trim split (view state
-        // only; the graph commits on release).
-        trimPreview.previewTrim(node.id, { trimInSeconds, trimOutSeconds, effectiveSeconds });
+        // only; the graph commits on release). `side` lets the view anchor
+        // the right edge for a left-handle drag (grow left).
+        trimPreview.previewTrim(node.id, { side, trimInSeconds, trimOutSeconds, effectiveSeconds });
       };
       const onUp = (upEvent: PointerEvent) => {
         window.removeEventListener("pointermove", onMove);

--- a/packages/ui/dnd-collections/react/trim-overview.tsx
+++ b/packages/ui/dnd-collections/react/trim-overview.tsx
@@ -21,6 +21,11 @@ import { type VideoMediaNode } from "../core/graph";
 
 const fmt1 = (s: number) => `${(Math.round(s * 10) / 10).toFixed(1)}s`;
 
+// The strip is `h-11` (44px) tall; square frames are that wide too. Frames are
+// fixed-size and the strip clips the partial last one (overflow-hidden), so
+// each thumbnail keeps a 1:1 aspect instead of stretching to fill the width.
+const FRAME_SIZE = 44;
+
 export const TrimOverviewStrip = memo(function TrimOverviewStrip({
   node,
   pixelsPerSecond,
@@ -49,8 +54,9 @@ export const TrimOverviewStrip = memo(function TrimOverviewStrip({
   const windowWidth = Math.max(2, showing * pixelsPerSecond);
 
   const posters = node.posterSrcs ?? [];
-  const frameW = 78;
-  const frameCount = Math.max(1, Math.min(24, Math.round(fullWidth / frameW)));
+  // Enough square frames to cover the strip width (ceil so the row fills; the
+  // container clips the overflow), capped so a long source stays bounded.
+  const frameCount = Math.max(1, Math.min(40, Math.ceil(fullWidth / FRAME_SIZE)));
 
   return (
     <div
@@ -71,7 +77,8 @@ export const TrimOverviewStrip = memo(function TrimOverviewStrip({
               src={posters[i % posters.length]}
               alt=""
               draggable={false}
-              className="h-full min-w-0 flex-1 border-r border-black/60 object-cover last:border-r-0"
+              style={{ width: FRAME_SIZE }}
+              className="h-full shrink-0 border-r border-black/60 object-cover last:border-r-0"
             />
           ))
         )}

--- a/packages/ui/dnd-collections/react/trim-preview-context.ts
+++ b/packages/ui/dnd-collections/react/trim-preview-context.ts
@@ -16,8 +16,11 @@ import { type NodeId } from "../core/graph";
 
 /** Live trim split during a drag — carries the in/out values (not just the
  *  resulting duration) so a view can position UI that depends on trimIn
- *  itself, e.g. the overview window's left edge. */
+ *  itself, e.g. the overview window's left edge. `side` is which handle is
+ *  being dragged: a left-handle drag anchors the clip's RIGHT edge (grows
+ *  left), so the view needs to know it. */
 export type LiveTrim = Readonly<{
+  side: "left" | "right";
   trimInSeconds: number;
   trimOutSeconds: number;
   effectiveSeconds: number;

--- a/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef } from "react";
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 
 import { getChildren, isVideoMedia, type CollectionItemNode, type NodeId } from "../core/graph";
@@ -174,38 +182,72 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
 
     // Live trim preview: a trim handle calls this per pointer-move to resize
     // ONE card without a graph commit, AND to publish the drag's current
-    // trimIn/trimOut split — the overview needs the LIVE split (not just the
-    // resulting duration) to keep its window aligned with the clip's
-    // rendered edges while the drag is in flight. `resizeItem` updates the
-    // item's cached size and shifts the offsets after it — no full
-    // re-measure, no per-frame graph churn (the commit lands once, on
-    // release). The callback must stay reference-stable so trim handles,
-    // which read it via context, don't re-render on every strip render — so
-    // it reads/writes live values via refs instead of state.
+    // trimIn/trimOut split. Two things read that split during render: the
+    // overview (to keep its window on the clip's edges) and the right-edge
+    // ANCHOR for a left-handle drag (below). `resizeItem` updates the item's
+    // cached size and shifts the offsets after it — no full re-measure, no
+    // per-frame graph churn (the commit lands once, on release). The live
+    // split lives in state, not a ref, so clearing it on commit/abort forces
+    // the anchor transform back to 0 in the same render; the strip re-renders
+    // on every move anyway (resizeItem), so this adds no renders, and the
+    // memoized cards still don't re-render. The callback must stay
+    // reference-stable (trim handles read it via context) — it is, reading
+    // mutable inputs from a ref and calling the stable setState.
     const trimStateRef = useRef({ childIds, virtualizer, gap, trimPixelsPerSecond, widthForIndex });
     trimStateRef.current = { childIds, virtualizer, gap, trimPixelsPerSecond, widthForIndex };
-    const liveTrimRef = useRef<{ nodeId: NodeId; trim: LiveTrim } | null>(null);
+    const [liveTrim, setLiveTrim] = useState<{ nodeId: NodeId; trim: LiveTrim } | null>(null);
+    // Pre-drag slot size of the item being left-trimmed, captured once per
+    // gesture. The anchor transform is measured against THIS, not the live
+    // committed size — at the commit render `widthForIndex` already reflects
+    // the new size, which would collapse the transform to 0 a frame before
+    // the scroll reconciliation and flash. Held until commit/abort clears it.
+    const trimBaselineRef = useRef<{ nodeId: NodeId; size0: number } | null>(null);
+    // Last computed anchor shift (px), written during render; the commit
+    // effect converts it into a real scroll so removing the transform doesn't
+    // jump the anchored clip.
+    const dragShiftRef = useRef(0);
     const previewTrim = useCallback<TrimPreview["previewTrim"]>((nodeId, live) => {
       const s = trimStateRef.current;
       const index = s.childIds.indexOf(nodeId);
-      liveTrimRef.current = live && index !== -1 ? { nodeId, trim: live } : null;
-      if (index === -1) return;
-      // null resets to the item's data-derived size; otherwise mirror
-      // estimateSize (width + gap) at the caller's px-per-second scale.
-      const size =
-        live === null
-          ? s.widthForIndex(index) + s.gap
-          : live.effectiveSeconds * (s.trimPixelsPerSecond ?? 0) + s.gap;
-      s.virtualizer.resizeItem(index, size);
+
+      if (live === null || index === -1) {
+        // Abort/no-op: snap the item back to its committed size; clearing the
+        // live split resets the anchor transform to 0 (scroll untouched, so
+        // the content returns to where it started).
+        if (index !== -1) s.virtualizer.resizeItem(index, s.widthForIndex(index) + s.gap);
+        trimBaselineRef.current = null;
+        setLiveTrim(null);
+        return;
+      }
+
+      // Capture the pre-drag slot size once, for a left-handle drag on a
+      // non-first item (index 0 has no left room, so it keeps grow-right).
+      if (live.side === "left" && index > 0 && trimBaselineRef.current?.nodeId !== nodeId) {
+        trimBaselineRef.current = { nodeId, size0: s.widthForIndex(index) + s.gap };
+      }
+
+      setLiveTrim({ nodeId, trim: live });
+      // Crisp width via resizeItem (grows/shrinks rightward). The right-edge
+      // anchor is a composited transform derived during render, applied in
+      // the SAME commit as this resize (atomic — no stutter).
+      s.virtualizer.resizeItem(index, live.effectiveSeconds * (s.trimPixelsPerSecond ?? 0) + s.gap);
     }, []);
     const trimPreview = useMemo<TrimPreview>(() => ({ previewTrim }), [previewTrim]);
 
-    // A graph commit (trim release, undo/redo, any edit) invalidates any
-    // leftover live trim override — `nodesById` only gets a new identity on a
-    // commit, never on a move or a drag, so this can't fire mid-drag.
+    // On a COMMIT (nodesById gets a new identity — trim release, undo/redo,
+    // any edit; never a move/drag) convert the drag's anchor transform into a
+    // real scroll, so clearing the transform below doesn't jump the anchored
+    // clip. Where scrollLeft has no room (a clip near the strip start), this
+    // clamps and the final position snaps by the shortfall — the known limit
+    // of native-scroll anchoring; the DRAG itself stayed consistent because a
+    // transform isn't clamped. Unrelated commits have shift 0 → no-op.
     useEffect(() => {
-      liveTrimRef.current = null;
-    }, [nodesById]);
+      const shift = dragShiftRef.current;
+      if (shift !== 0 && scrollRef.current) scrollRef.current.scrollLeft -= shift;
+      dragShiftRef.current = 0;
+      trimBaselineRef.current = null;
+      setLiveTrim(null);
+    }, [nodesById, scrollRef]);
 
     // Pointer -> visible boundary index from the virtualizer's measurements
     // (O(log n), variable widths included) — never from card rects, since
@@ -289,13 +331,30 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
     // window's position/width track the drag frame-for-frame.
     const overviewTrim =
       selectedVideo &&
-      (liveTrimRef.current?.nodeId === selectedVideo.id
-        ? liveTrimRef.current.trim
+      (liveTrim?.nodeId === selectedVideo.id
+        ? liveTrim.trim
         : { trimInSeconds: selectedVideo.trimInSeconds, trimOutSeconds: selectedVideo.trimOutSeconds });
     const overviewAnchorLeft =
       selectedVideoItem && overviewTrim
         ? selectedVideoItem.start - overviewTrim.trimInSeconds * (trimPixelsPerSecond ?? 0)
         : 0;
+
+    // Right-edge anchor for a left-handle drag ("grows left"): resizeItem
+    // grew the item rightward, so translate the whole content layer by the
+    // negated growth. viewport-x = contentX − scrollLeft + dragShiftX, so the
+    // right edge (offset + newSize) stays fixed while the left edge and left
+    // neighbors slide; right neighbors, shifted by resizeItem, are cancelled
+    // and stay put. A transform (not a scrollLeft write) because it's
+    // unclamped — consistent when shrinking a clip at the strip start, where
+    // scrollLeft can't go below 0 — and composited, applied atomically with
+    // the resize (no per-frame scroll write racing it → no stutter).
+    let dragShiftX = 0;
+    const trimBaseline = trimBaselineRef.current;
+    if (liveTrim && trimBaseline && trimBaseline.nodeId === liveTrim.nodeId && liveTrim.trim.side === "left") {
+      const liveSlot = liveTrim.trim.effectiveSeconds * (trimPixelsPerSecond ?? 0) + gap;
+      dragShiftX = -(liveSlot - trimBaseline.size0);
+    }
+    dragShiftRef.current = dragShiftX;
 
     useImperativeHandle(
       ref,
@@ -362,7 +421,15 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
             ref={contentRef}
             role="row"
             aria-rowindex={1}
-            style={{ width: virtualizer.getTotalSize(), height: contentHeight, position: "relative" }}
+            style={{
+              width: virtualizer.getTotalSize(),
+              height: contentHeight,
+              position: "relative",
+              // The left-handle "grows left" anchor (0 unless a left trim is
+              // in flight). Shifts the whole content layer — clips AND the
+              // overview — so they move together and stay aligned.
+              transform: dragShiftX ? `translateX(${dragShiftX}px)` : undefined,
+            }}
           >
             {selectedVideo && selectedVideoItem && overviewTrim && trimPixelsPerSecond !== undefined && (
               <TrimOverviewStrip


### PR DESCRIPTION
Dragging a video's LEFT trim handle now grows the clip toward the left: the right edge stays anchored, the left edge follows the cursor, left neighbors slide left, right neighbors stay put. resizeItem alone only grows rightward, so a left drag pairs it with a composited translateX on the content layer, derived from live-trim state so it lands in the same React commit as the resize (atomic — no stutter). A transform (not a per-frame scrollLeft write) keeps it consistent when shrinking a clip at the strip start, where scrollLeft would clamp at 0 and wrongly shrink the right edge; at commit the transform is reconciled to a real scrollLeft. Widen LiveTrim with `side` to drive it.

Also: overview thumbnails are now square (fixed 44x44, clipped) instead of stretched to fill.

Known limit: the commit reconciles to native scroll, so a left-trim on a clip at the very start can snap by whatever scroll can't absorb; index 0 keeps grow-right. The drag itself stays smooth and consistent everywhere.

Verified: tsc clean; unit 356, storybook 294, playwright e2e 20 pass (new left-grows-left, left-shrink-anchored, and square-thumbnail coverage).


Claude-Session: https://claude.ai/code/session_012JF5VpDxLrdr2DhsmWs8yc