### PR TITLE
feat(dnd-collections): interactive trim overview — grips trim, drag-t…

### DIFF
--- a/apps/web/tests/e2e/dnd-collections.spec.ts
+++ b/apps/web/tests/e2e/dnd-collections.spec.ts
@@ -516,6 +516,59 @@ test.describe('DndCollections E2E', () => {
     await expect(page.getByRole('button', { name: /undo/i })).toBeEnabled();
   });
 
+  test('overview: right grip trims the clip; dragging the filmstrip moves the source window', async ({
+    page,
+  }) => {
+    // OverviewPlayground pre-selects a video (full 10s, trim-in 2s, trim-out
+    // 1.5s -> showing 6.5s -> 156px). The overview's amber grips trim; dragging
+    // the filmstrip body moves the source window without changing duration.
+    await page.goto(storyPath('ui-dndcollectionsvirtual--overview-playground'));
+
+    const vid = card(page, 'vid');
+    const overview = page.locator('[data-trim-overview]');
+    const win = page.locator('[data-trim-overview-window]');
+    await vid.waitFor({ state: 'visible' });
+    await overview.waitFor({ state: 'visible' });
+    expect(Math.round((await vid.boundingBox())!.width)).toBe(156);
+
+    // Right grip in (left) 48px -> trim-out +2s -> showing 4.5s -> 108px.
+    const rightGrip = page.locator('[data-trim-overview-handle="right"]');
+    const g = (await rightGrip.boundingBox())!;
+    await page.mouse.move(g.x + g.width / 2, g.y + g.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(g.x + g.width / 2 - 48, g.y + g.height / 2, { steps: 10 });
+    await page.waitForTimeout(120);
+    await expect(async () => {
+      expect(Math.round((await vid.boundingBox())!.width)).toBe(108);
+    }).toPass();
+    const vb = (await vid.boundingBox())!;
+    const wb = (await win.boundingBox())!;
+    expect(Math.round(wb.x + wb.width)).toBe(Math.round(vb.x + vb.width)); // window on clip
+    await page.mouse.up();
+    await page.getByRole('button', { name: /undo/i }).click();
+    await expect(async () => {
+      expect(Math.round((await vid.boundingBox())!.width)).toBe(156);
+    }).toPass();
+
+    // Move: drag the filmstrip body (near its left, over the images) right 48px.
+    // Duration unchanged; the clip doesn't move; the source strip slides right.
+    const ob0 = (await overview.boundingBox())!;
+    const vidLeft0 = (await vid.boundingBox())!.x;
+    await page.mouse.move(ob0.x + 20, ob0.y + ob0.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(ob0.x + 20 + 48, ob0.y + ob0.height / 2, { steps: 10 });
+    await page.waitForTimeout(120);
+    await expect(async () => {
+      expect((await overview.boundingBox())!.x).toBeGreaterThan(ob0.x + 40);
+    }).toPass();
+    expect(Math.round((await vid.boundingBox())!.width)).toBe(156); // duration unchanged
+    expect(Math.round((await vid.boundingBox())!.x)).toBe(Math.round(vidLeft0)); // clip unmoved
+    const wb2 = (await win.boundingBox())!;
+    expect(Math.round(wb2.x)).toBe(Math.round((await vid.boundingBox())!.x)); // window on clip
+    await page.mouse.up();
+    await expect(page.getByRole('button', { name: /undo/i })).toBeEnabled();
+  });
+
   test('reorders within a collection (drop on right half = after)', async ({ page }) => {
     await page.goto(storyPath(PLAYGROUND));
 

--- a/packages/ui/dnd-collections/API.md
+++ b/packages/ui/dnd-collections/API.md
@@ -586,8 +586,9 @@ key off these):
 | `data-drop-indicator` | indicator bar | `"before"` or `"after"` on the adjacency target. |
 | `data-trim-handle` | media edge handle | `"left"` or `"right"` (left is video-only). |
 | `data-trim-preview` | trim readout | The previewed effective duration (seconds) while a handle is dragged. |
-| `data-trim-overview` | overview filmstrip (`VirtualStrip` only) | The selected video's node id. Renders directly above its clip; absent unless a video is selected AND mounted. |
+| `data-trim-overview` | overview filmstrip (`VirtualStrip` only) | The selected video's node id. Renders directly above its clip; absent unless a video is selected AND mounted. Dragging its body MOVES the source window (trim-in/out shift together, duration constant). |
 | `data-trim-overview-window` | amber "showing" window | Its left/right edges are pixel-aligned with the clip's own rendered edges (see the trim overview section below). |
+| `data-trim-overview-handle` | overview window grip | `"left"` (trim-in) or `"right"` (trim-out); dragging trims the clip, same `update-media` as the card edge handles. |
 | `data-testid="drag-ghost"` / `"drag-ghost-count"` | overlay | The ghost and its `+N` badge. |
 | `data-testid="history-log"` / `"history-empty"`, `data-history-entry` | history log | Log container / empty marker / entries. |
 

--- a/packages/ui/dnd-collections/ARCHITECTURE.md
+++ b/packages/ui/dnd-collections/ARCHITECTURE.md
@@ -205,8 +205,23 @@ scroll listeners, because it's a real DOM child of the same natively-scrolled
 container the clip lives in. `TrimPreview` (widened to `previewTrim`) carries
 the drag's live `trimInSeconds`/`trimOutSeconds` split (not just the
 resulting duration) so this alignment holds mid-drag, not only after commit;
-`VirtualStrip` keeps that live override in a ref (not the store) and clears it
-whenever `nodesById` changes identity (any commit — trim, undo, redo).
+`VirtualStrip` keeps that live override in interaction state local to the view
+(not the store, so bystander cards don't subscribe) and clears it whenever
+`nodesById` changes identity (any commit — trim, undo, redo).
+
+The overview is itself interactive, sharing the card handles' gesture core
+(`trim-gesture.ts`: `resolveTrim`, `resolveMove`, `useTrimPointerDrag` — one
+pointer lifecycle → live `previewTrim` → one `update-media` on release). Its
+amber grips TRIM (left = trim-in, right = trim-out) exactly like the card
+edges. Dragging the filmstrip body instead MOVES the source window:
+`resolveMove` shifts trim-in and trim-out together, keeping showing (and so the
+clip width) constant. Because the window sits at `anchorLeft + trimInWidth ==
+clipLeft` for ANY trim-in, a move leaves the window locked on the clip while
+the filmstrip — drawn from `anchorLeft`, which changes with trim-in — slides
+under it, so you scrub which part of the source the clip plays. A move carries
+`side: "move"`, which the left-grow anchor ignores (effective is unchanged, so
+its transform is 0 anyway). The band opts out of the strip's pan via
+`data-trim-overview`.
 
 Two properties fall out of this shape and everything else depends on them:
 

--- a/packages/ui/dnd-collections/TRIM-PHASE-B-PLAN.md
+++ b/packages/ui/dnd-collections/TRIM-PHASE-B-PLAN.md
@@ -191,11 +191,16 @@ NOOP cleanly and the handle stays view-agnostic).
 - Keep the overview slice out of the card selectors, or the render-efficiency
   guard (`RenderEfficiencyDuringDrag`) will fail.
 
-## Optional Phase B.2
+## Phase B.2 — SHIPPED
 
-- Make the **overview's** amber handles draggable too (the app trims from the
-  source window). Same `previewTrim` path; the overview handle maps pixel delta
-  → seconds at the overview's pps (== strip pps), so it stays in sync.
+- The **overview's** amber grips are draggable and trim the clip (left =
+  trim-in, right = trim-out), and dragging the **filmstrip body** MOVES the
+  source window (trim-in/out shift together, showing/duration constant) so you
+  scrub which part of the source the clip plays — the window stays locked on
+  the clip while the filmstrip slides under it. All three share one gesture
+  core with the card handles (`react/trim-gesture.ts`: `resolveTrim`,
+  `resolveMove`, `useTrimPointerDrag`) → the same `previewTrim` live path and
+  one `update-media` commit. See ARCHITECTURE.md's trim section.
 
 ## Open decisions to confirm before building
 

--- a/packages/ui/dnd-collections/VirtualStrip.stories.tsx
+++ b/packages/ui/dnd-collections/VirtualStrip.stories.tsx
@@ -1280,3 +1280,97 @@ export const LeftHandleShrinkStaysAnchored: Story = {
 export const PhaseBPlayground: Story = {
   render: () => <PhaseBHarness />,
 };
+
+function OverviewHarness() {
+  return (
+    <DndCollections initialGraph={trimmedGraph()} animateMoves={false}>
+      <SelectOnMount id="vid" />
+      <div className="flex w-[640px] flex-col gap-3">
+        <UndoRedoControls />
+        <VirtualStrip
+          collectionId={parseNodeId("strip")}
+          itemWidthFor={(node) =>
+            node.kind === "media" ? mediaDurationSeconds(node) * TRIM_PPS : undefined
+          }
+          trimPixelsPerSecond={TRIM_PPS}
+        />
+      </div>
+    </DndCollections>
+  );
+}
+
+export const OverviewHandlesAndMove: Story = {
+  // Phase B.2: the overview is interactive. Its amber grips TRIM the clip
+  // (right grip = trim-out here) — the SAME update-media the card handles
+  // dispatch — and dragging the filmstrip body MOVES the source window
+  // (trim-in/out shift together, showing constant) so the clip width doesn't
+  // change but a different part of the source lands in the window. The window
+  // stays locked on the clip throughout; on a move the source slides under it.
+  render: () => <OverviewHarness />,
+  play: async ({ canvasElement }) => {
+    const rect = (id: string) => nodeCard(canvasElement, id).getBoundingClientRect();
+    const width = (id: string) => Math.round(rect(id).width);
+    const overview = () => canvasElement.querySelector<HTMLElement>("[data-trim-overview]")!;
+    const windowRect = () =>
+      canvasElement.querySelector<HTMLElement>("[data-trim-overview-window]")!.getBoundingClientRect();
+    const grip = (side: "left" | "right") =>
+      canvasElement.querySelector<HTMLElement>(`[data-trim-overview-handle="${side}"]`)!;
+    const holdElBy = async (el: HTMLElement, dx: number) => {
+      const r = el.getBoundingClientRect();
+      const x = r.left + r.width / 2;
+      const y = r.top + r.height / 2;
+      await dispatchPointerSequence([
+        { element: el, type: "pointerdown", clientX: x, clientY: y },
+        { element: document, type: "pointermove", clientX: x + dx, clientY: y, delayAfterMs: 40 },
+      ]);
+    };
+    const release = async () => {
+      await dispatchPointerSequence([
+        { element: document, type: "pointerup", clientX: 0, clientY: 0, delayAfterMs: 30 },
+      ]);
+    };
+    const undoButton = () => within(canvasElement).getByRole("button", { name: /undo/i });
+    const user = userEvent.setup();
+
+    await waitForLayout(nodeCard(canvasElement, "vid"));
+    // vid: full 10s, trim-in 2s, trim-out 1.5s -> showing 6.5s -> 156px.
+    expect(width("vid")).toBe(156);
+    // Overview window sits on the clip.
+    expect(Math.round(windowRect().left)).toBe(Math.round(rect("vid").left));
+    expect(Math.round(windowRect().right)).toBe(Math.round(rect("vid").right));
+
+    // 1) RIGHT grip trims trim-out: drag it in (left) 48px -> trim-out +2s ->
+    //    showing 4.5s -> 108px. The clip's LEFT edge is anchored (right-side
+    //    trim), and the window shrinks with the clip.
+    await holdElBy(grip("right"), -48);
+    await waitFor(() => expect(width("vid")).toBe(108));
+    expect(Math.round(windowRect().right)).toBe(Math.round(rect("vid").right));
+    await release();
+    await waitFor(() => expect(undoButton()).toBeEnabled());
+    expect(width("vid")).toBe(108);
+    await user.click(undoButton());
+    await waitFor(() => expect(width("vid")).toBe(156));
+
+    // 2) MOVE: drag the filmstrip body right 48px (+2s) -> trim-in 2s -> 0s,
+    //    trim-out 1.5s -> 3.5s. Showing (and the clip width) is UNCHANGED; the
+    //    clip doesn't move; the window stays on it; the source filmstrip slides
+    //    right (its content-space left grows as trim-in shrinks).
+    const vidLeft0 = rect("vid").left;
+    const overviewLeft0 = overview().getBoundingClientRect().left;
+    await holdElBy(overview(), 48); // grabs the filmstrip body, not a grip
+    await waitFor(() => {
+      expect(overview().getBoundingClientRect().left).toBeGreaterThan(overviewLeft0 + 40);
+    });
+    expect(width("vid")).toBe(156); // duration unchanged
+    expect(Math.round(rect("vid").left)).toBe(Math.round(vidLeft0)); // clip didn't move
+    expect(Math.round(windowRect().left)).toBe(Math.round(rect("vid").left)); // window on clip
+    await release();
+    await waitFor(() => expect(undoButton()).toBeEnabled());
+    expect(width("vid")).toBe(156);
+  },
+};
+
+/** Play-less twin of OverviewHandlesAndMove for the real-mouse e2e. */
+export const OverviewPlayground: Story = {
+  render: () => <OverviewHarness />,
+};

--- a/packages/ui/dnd-collections/react/trim-gesture.ts
+++ b/packages/ui/dnd-collections/react/trim-gesture.ts
@@ -1,0 +1,153 @@
+"use client";
+
+import { useCallback, type PointerEvent as ReactPointerEvent } from "react";
+
+import { type MediaNode, type VideoMediaNode } from "../core/graph";
+import { type MediaUpdate } from "../core/commands";
+import { useCollectionsStore } from "./collections-store";
+import { useTrimPreview, type LiveTrim } from "./trim-preview-context";
+
+// Shared trim-gesture core for BOTH the card edge handles (`trim-handles.tsx`)
+// and the overview window handles + filmstrip move (`trim-overview.tsx`):
+// convert pointer pixels to seconds at the caller's scale, publish a LIVE
+// preview per move (no graph mutation), and commit ONE `update-media` on
+// release (undoable) — an aborted/no-op drag snaps back. Keeping the
+// pointer lifecycle here means every trim surface behaves identically.
+
+export type TrimSide = "left" | "right";
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(value, max));
+}
+
+/** Resolve a TRIM (duration changes): a right handle on every media (image
+ *  duration / video trim-out) and a left handle on video (trim-in). Returns
+ *  the `update` to commit plus the `live` split to preview. */
+export function resolveTrim(
+  node: MediaNode,
+  side: TrimSide,
+  deltaSeconds: number
+): { update: MediaUpdate; live: LiveTrim } {
+  if (node.mediaKind === "video") {
+    if (side === "left") {
+      // Left edge inward (right, +delta) trims MORE off the start.
+      const trimInSeconds = clamp(
+        node.trimInSeconds + deltaSeconds,
+        0,
+        node.fullDurationSeconds - node.trimOutSeconds
+      );
+      return {
+        update: { mediaKind: "video", trimInSeconds },
+        live: {
+          side,
+          trimInSeconds,
+          trimOutSeconds: node.trimOutSeconds,
+          effectiveSeconds: node.fullDurationSeconds - trimInSeconds - node.trimOutSeconds,
+        },
+      };
+    }
+    // Right edge inward (left, -delta) trims MORE off the end.
+    const trimOutSeconds = clamp(
+      node.trimOutSeconds - deltaSeconds,
+      0,
+      node.fullDurationSeconds - node.trimInSeconds
+    );
+    return {
+      update: { mediaKind: "video", trimOutSeconds },
+      live: {
+        side,
+        trimInSeconds: node.trimInSeconds,
+        trimOutSeconds,
+        effectiveSeconds: node.fullDurationSeconds - node.trimInSeconds - trimOutSeconds,
+      },
+    };
+  }
+  // Image: the right edge sets the duration directly (outward = longer).
+  const durationSeconds = Math.max(0, node.durationSeconds + deltaSeconds);
+  return {
+    update: { mediaKind: "image", durationSeconds },
+    live: { side, trimInSeconds: 0, trimOutSeconds: 0, effectiveSeconds: durationSeconds },
+  };
+}
+
+/** Resolve a MOVE (video only): slide the source window without changing the
+ *  showing duration — trim-in and trim-out shift together. Dragging the
+ *  filmstrip RIGHT (+delta) reveals EARLIER frames (trim-in decreases). The
+ *  effective duration (and so the card width) is unchanged. */
+export function resolveMove(
+  node: VideoMediaNode,
+  deltaSeconds: number
+): { update: MediaUpdate; live: LiveTrim } {
+  const showing = Math.max(0, node.fullDurationSeconds - node.trimInSeconds - node.trimOutSeconds);
+  const room = Math.max(0, node.fullDurationSeconds - showing); // trim-in + trim-out
+  const trimInSeconds = clamp(node.trimInSeconds - deltaSeconds, 0, room);
+  const trimOutSeconds = Math.max(0, room - trimInSeconds);
+  return {
+    update: { mediaKind: "video", trimInSeconds, trimOutSeconds },
+    live: { side: "move", trimInSeconds, trimOutSeconds, effectiveSeconds: showing },
+  };
+}
+
+/**
+ * The pointer-drag lifecycle shared by every trim surface. Returns a
+ * `beginDrag(event, pixelsPerSecond, resolve, onLive?)` to call from an
+ * `onPointerDown`: it captures the pointer, previews each move via the view's
+ * `TrimPreview`, and commits/aborts on release. `resolve` maps the drag's
+ * delta-seconds to the update + live split; `onLive` is an optional hook for
+ * local UI (e.g. the card's readout pill), called with the live split per
+ * move and `null` on end.
+ */
+export function useTrimPointerDrag(
+  node: MediaNode
+): (
+  event: ReactPointerEvent,
+  pixelsPerSecond: number,
+  resolve: (deltaSeconds: number) => { update: MediaUpdate; live: LiveTrim },
+  onLive?: (live: LiveTrim | null) => void
+) => void {
+  const store = useCollectionsStore();
+  const trimPreview = useTrimPreview();
+  return useCallback(
+    (event, pixelsPerSecond, resolve, onLive) => {
+      if (event.button !== 0 || pixelsPerSecond <= 0) return;
+      // Keep the gesture off dnd-kit's item drag, the strip's pan, and (for
+      // an overview grip) the overview's own move handler.
+      event.preventDefault();
+      event.stopPropagation();
+      const startX = event.clientX;
+      let pending: MediaUpdate | null = null;
+      try {
+        event.currentTarget.setPointerCapture(event.pointerId);
+      } catch {
+        /* untrusted pointer (tests) — window listeners below suffice */
+      }
+
+      const onMove = (moveEvent: PointerEvent) => {
+        const { update, live } = resolve((moveEvent.clientX - startX) / pixelsPerSecond);
+        pending = update;
+        onLive?.(live);
+        trimPreview.previewTrim(node.id, live);
+      };
+      const onUp = (upEvent: PointerEvent) => {
+        window.removeEventListener("pointermove", onMove);
+        window.removeEventListener("pointerup", onUp);
+        window.removeEventListener("pointercancel", onUp);
+        onLive?.(null);
+        const update = pending;
+        pending = null;
+        if (upEvent.type === "pointercancel" || !update) {
+          // Aborted (or a no-op click): drop the live preview, snapping back.
+          trimPreview.previewTrim(node.id, null);
+          return;
+        }
+        // Commit. The view reconciles to the new data (its last preview
+        // already matches), so there is no flash.
+        store.dispatch({ type: "update-media", nodeId: node.id, update });
+      };
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", onUp);
+      window.addEventListener("pointercancel", onUp);
+    },
+    [node, store, trimPreview]
+  );
+}

--- a/packages/ui/dnd-collections/react/trim-handles.tsx
+++ b/packages/ui/dnd-collections/react/trim-handles.tsx
@@ -1,11 +1,9 @@
 "use client";
 
-import { useCallback, useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
+import { useCallback, useState, type PointerEvent as ReactPointerEvent } from "react";
 
 import { mediaDurationSeconds, type MediaNode } from "../core/graph";
-import { type MediaUpdate } from "../core/commands";
-import { useCollectionsStore } from "./collections-store";
-import { useTrimPreview, type LiveTrim } from "./trim-preview-context";
+import { resolveTrim, useTrimPointerDrag, type TrimSide } from "./trim-gesture";
 
 // Edge drag-handles that TRIM a media item: a right handle on every media
 // card, plus a left handle on video (which can trim its start too). The
@@ -14,69 +12,12 @@ import { useTrimPreview, type LiveTrim } from "./trim-preview-context";
 // ONE `update-media` on release (undoable). The card resizes LIVE as the
 // handle drags, via the view's `TrimPreview` — a targeted single-item resize
 // (no full re-measure, no per-frame graph churn). The commit lands only on
-// release; an aborted drag snaps back.
+// release; an aborted drag snaps back. The pointer lifecycle is shared with
+// the overview handles/move via `useTrimPointerDrag` (see trim-gesture.ts).
 //
 // The handles are SIBLINGS of the draggable card button (not children), so a
 // pointerdown on a handle never reaches dnd-kit's item-drag sensor. They also
 // carry `data-trim-handle` so the strip's pan gesture skips them.
-
-type TrimSide = "left" | "right";
-
-/** The clamped result of dragging a handle by `deltaSeconds`. `trimInSeconds`/
- *  `trimOutSeconds` are the full pair (video only; 0 for images) — needed so a
- *  view can position trim-in-dependent UI (the overview window) live, not
- *  just react to the resulting effective duration. */
-function resolveTrim(
-  node: MediaNode,
-  side: TrimSide,
-  deltaSeconds: number
-): {
-  update: MediaUpdate;
-  effectiveSeconds: number;
-  trimInSeconds: number;
-  trimOutSeconds: number;
-} {
-  if (node.mediaKind === "video") {
-    if (side === "left") {
-      // Left edge inward (right, +delta) trims MORE off the start.
-      const trimInSeconds = clamp(
-        node.trimInSeconds + deltaSeconds,
-        0,
-        node.fullDurationSeconds - node.trimOutSeconds
-      );
-      return {
-        update: { mediaKind: "video", trimInSeconds },
-        effectiveSeconds: node.fullDurationSeconds - trimInSeconds - node.trimOutSeconds,
-        trimInSeconds,
-        trimOutSeconds: node.trimOutSeconds,
-      };
-    }
-    // Right edge inward (left, -delta) trims MORE off the end.
-    const trimOutSeconds = clamp(
-      node.trimOutSeconds - deltaSeconds,
-      0,
-      node.fullDurationSeconds - node.trimInSeconds
-    );
-    return {
-      update: { mediaKind: "video", trimOutSeconds },
-      effectiveSeconds: node.fullDurationSeconds - node.trimInSeconds - trimOutSeconds,
-      trimInSeconds: node.trimInSeconds,
-      trimOutSeconds,
-    };
-  }
-  // Image: the right edge sets the duration directly (outward = longer).
-  const durationSeconds = Math.max(0, node.durationSeconds + deltaSeconds);
-  return {
-    update: { mediaKind: "image", durationSeconds },
-    effectiveSeconds: durationSeconds,
-    trimInSeconds: 0,
-    trimOutSeconds: 0,
-  };
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.max(min, Math.min(value, max));
-}
 
 // Amber edge handles (matching the app's source-window handles): thicker,
 // with a grip line, visible-on-hover so the card stays clean at rest.
@@ -90,64 +31,19 @@ export function TrimHandles({
   node: MediaNode;
   pixelsPerSecond: number;
 }) {
-  const store = useCollectionsStore();
-  const trimPreview = useTrimPreview();
+  const beginDrag = useTrimPointerDrag(node);
   const [preview, setPreview] = useState<number | null>(null);
-  // Holds the latest resolved update across pointermove callbacks, committed
-  // once on pointerup.
-  const pendingRef = useRef<MediaUpdate | null>(null);
 
   const startTrim = useCallback(
     (side: TrimSide, event: ReactPointerEvent<HTMLDivElement>) => {
-      if (event.button !== 0 || pixelsPerSecond <= 0) return;
-      // Keep the gesture off dnd-kit's item drag and the strip's pan.
-      event.preventDefault();
-      event.stopPropagation();
-      const startX = event.clientX;
-      const startNode = node; // snapshot — the graph doesn't change until commit
-      pendingRef.current = null;
-      try {
-        event.currentTarget.setPointerCapture(event.pointerId);
-      } catch {
-        /* untrusted pointer (tests) — window listeners below suffice */
-      }
-
-      const onMove = (moveEvent: PointerEvent) => {
-        const deltaSeconds = (moveEvent.clientX - startX) / pixelsPerSecond;
-        const { update, effectiveSeconds, trimInSeconds, trimOutSeconds } = resolveTrim(
-          startNode,
-          side,
-          deltaSeconds
-        );
-        pendingRef.current = update;
-        setPreview(effectiveSeconds);
-        // Live-resize the card AND publish the live trim split (view state
-        // only; the graph commits on release). `side` lets the view anchor
-        // the right edge for a left-handle drag (grow left).
-        trimPreview.previewTrim(node.id, { side, trimInSeconds, trimOutSeconds, effectiveSeconds });
-      };
-      const onUp = (upEvent: PointerEvent) => {
-        window.removeEventListener("pointermove", onMove);
-        window.removeEventListener("pointerup", onUp);
-        window.removeEventListener("pointercancel", onUp);
-        setPreview(null);
-        const update = pendingRef.current;
-        pendingRef.current = null;
-        if (upEvent.type === "pointercancel" || !update) {
-          // Aborted (or a no-op): drop the live preview, snapping the card
-          // back to its committed size — nothing is dispatched.
-          trimPreview.previewTrim(node.id, null);
-          return;
-        }
-        // Commit. The view reconciles the card to the new data (its last
-        // preview size already matches), so there is no resize flash.
-        store.dispatch({ type: "update-media", nodeId: node.id, update });
-      };
-      window.addEventListener("pointermove", onMove);
-      window.addEventListener("pointerup", onUp);
-      window.addEventListener("pointercancel", onUp);
+      beginDrag(
+        event,
+        pixelsPerSecond,
+        (deltaSeconds) => resolveTrim(node, side, deltaSeconds),
+        (live) => setPreview(live ? live.effectiveSeconds : null)
+      );
     },
-    [node, pixelsPerSecond, store, trimPreview]
+    [beginDrag, node, pixelsPerSecond]
   );
 
   const showLeft = node.mediaKind === "video";

--- a/packages/ui/dnd-collections/react/trim-overview.tsx
+++ b/packages/ui/dnd-collections/react/trim-overview.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { memo } from "react";
+import { memo, useCallback, type PointerEvent as ReactPointerEvent } from "react";
 
 import { type VideoMediaNode } from "../core/graph";
+import { resolveMove, resolveTrim, useTrimPointerDrag, type TrimSide } from "./trim-gesture";
 
 // Source-window overview for a SELECTED video: the FULL source rendered as a
 // poster filmstrip, with an amber window marking what's currently showing
@@ -18,6 +19,13 @@ import { type VideoMediaNode } from "../core/graph";
 // listeners) — see ARCHITECTURE.md's trim section. `trimInSeconds`/
 // `trimOutSeconds` are passed in (not read from the node) so a live drag can
 // override the committed values before they land.
+//
+// It's interactive: the window's amber grips TRIM (left = trim-in, right =
+// trim-out — the same `update-media` the card handles dispatch, via the same
+// shared gesture), and dragging the filmstrip elsewhere MOVES the source
+// window (trim-in/out together, showing constant). Because the window sits at
+// `anchorLeft + trimInWidth == clipLeft` for any trim-in, a move keeps the
+// window locked on the clip while the source slides under it.
 
 const fmt1 = (s: number) => `${(Math.round(s * 10) / 10).toFixed(1)}s`;
 
@@ -58,10 +66,25 @@ export const TrimOverviewStrip = memo(function TrimOverviewStrip({
   // container clips the overflow), capped so a long source stays bounded.
   const frameCount = Math.max(1, Math.min(40, Math.ceil(fullWidth / FRAME_SIZE)));
 
+  const beginDrag = useTrimPointerDrag(node);
+  const startTrim = useCallback(
+    (side: TrimSide) => (event: ReactPointerEvent) =>
+      beginDrag(event, pixelsPerSecond, (delta) => resolveTrim(node, side, delta)),
+    [beginDrag, node, pixelsPerSecond]
+  );
+  const startMove = useCallback(
+    (event: ReactPointerEvent) => beginDrag(event, pixelsPerSecond, (delta) => resolveMove(node, delta)),
+    [beginDrag, node, pixelsPerSecond]
+  );
+
   return (
     <div
       data-trim-overview={node.id}
-      className="absolute h-11 overflow-hidden rounded-md"
+      // Dragging the filmstrip (anywhere but the amber grips, which
+      // stopPropagation) MOVES the source window. `data-trim-overview` also
+      // opts the whole band out of the strip's pan gesture.
+      onPointerDown={startMove}
+      className="absolute h-11 cursor-grab touch-none overflow-hidden rounded-md select-none active:cursor-grabbing"
       style={{ width: fullWidth, top, transform: `translateX(${anchorLeft}px)` }}
     >
       {/* Full-source filmstrip. */}
@@ -91,14 +114,22 @@ export const TrimOverviewStrip = memo(function TrimOverviewStrip({
         style={{ width: trimOut * pixelsPerSecond }}
       />
 
-      {/* The amber "showing" window. */}
+      {/* The amber "showing" window, with draggable trim grips on each edge. */}
       <div
         data-trim-overview-window
         className="absolute inset-y-0 rounded-sm border-2 border-amber-300 bg-amber-300/10 shadow-[0_0_0_1px_rgba(0,0,0,0.5)]"
         style={{ width: windowWidth, transform: `translateX(${trimInWidth}px)` }}
       >
-        <span className="absolute inset-y-0 left-0 w-2 rounded-l-sm bg-amber-200/90" />
-        <span className="absolute inset-y-0 right-0 w-2 rounded-r-sm bg-amber-200/90" />
+        <span
+          data-trim-overview-handle="left"
+          onPointerDown={startTrim("left")}
+          className="absolute inset-y-0 left-0 z-10 w-2 cursor-ew-resize rounded-l-sm bg-amber-200/90"
+        />
+        <span
+          data-trim-overview-handle="right"
+          onPointerDown={startTrim("right")}
+          className="absolute inset-y-0 right-0 z-10 w-2 cursor-ew-resize rounded-r-sm bg-amber-200/90"
+        />
       </div>
 
       {/* Full-clip readout. */}

--- a/packages/ui/dnd-collections/react/trim-preview-context.ts
+++ b/packages/ui/dnd-collections/react/trim-preview-context.ts
@@ -16,11 +16,12 @@ import { type NodeId } from "../core/graph";
 
 /** Live trim split during a drag — carries the in/out values (not just the
  *  resulting duration) so a view can position UI that depends on trimIn
- *  itself, e.g. the overview window's left edge. `side` is which handle is
- *  being dragged: a left-handle drag anchors the clip's RIGHT edge (grows
- *  left), so the view needs to know it. */
+ *  itself, e.g. the overview window's left edge. `side` is the gesture: a
+ *  "left" drag anchors the clip's RIGHT edge (grows left) so the view needs
+ *  to know it; "move" slides the source window (trim-in/out together, showing
+ *  constant) so the effective duration — and the card width — don't change. */
 export type LiveTrim = Readonly<{
-  side: "left" | "right";
+  side: "left" | "right" | "move";
   trimInSeconds: number;
   trimOutSeconds: number;
   effectiveSeconds: number;

--- a/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
@@ -61,7 +61,7 @@ function resolveStripIndex(key: string, current: number, count: number): number 
 // yields via isGestureClaimed.) Module-level so option identities are
 // stable.
 const isPannableStripSurface = (target: Element): boolean =>
-  !target.closest("[data-drag-handle], [data-trim-handle]");
+  !target.closest("[data-drag-handle], [data-trim-handle], [data-trim-overview]");
 const STRIP_PAN_DISABLED: PanWithMomentumOptions = { disabled: true };
 
 // Vertical band reserved above the row for the selected video's TrimOverview


### PR DESCRIPTION
…o-move source window

Phase B.2 plus a source-window move gesture. The overview's amber grips now trim the clip (left = trim-in, right = trim-out), dispatching the same update-media as the card edge handles. Dragging the filmstrip body MOVES the source window: resolveMove shifts trim-in and trim-out together so the showing duration (and clip width) stay constant while a different part of the source lands in the window. Because the window sits at anchorLeft + trimInWidth == clipLeft for any trim-in, a move keeps the window locked on the clip while the filmstrip slides under it — scrubbing what the clip plays, no new positioning code.

The card handles, overview grips, and move share one gesture core (react/trim-gesture.ts: resolveTrim, resolveMove, useTrimPointerDrag) → one live-preview path, one commit. Overview thumbnails are also square now (fixed 44x44, clipped) instead of stretched.

Verified: tsc clean; unit 356, storybook 296, playwright e2e 21 pass (new overview grip-trim + move coverage, story and real-mouse).


Claude-Session: https://claude.ai/code/session_012JF5VpDxLrdr2DhsmWs8yc