### PR TITLE
fix(dnd-collections): enforce pointer ownership in trim gestures

### DIFF
--- a/packages/ui/dnd-collections/TrimGesture.stories.tsx
+++ b/packages/ui/dnd-collections/TrimGesture.stories.tsx
@@ -39,14 +39,17 @@ function graph() {
 
 function TrimPreviewProbe() {
   const [previewState, setPreviewState] = useState<"idle" | "live" | "cleared">("idle");
+  const [liveEffective, setLiveEffective] = useState<number | null>(null);
   const previewTrim = useCallback<TrimPreview["previewTrim"]>((_nodeId, live) => {
     setPreviewState(live ? "live" : "cleared");
+    setLiveEffective(live ? live.effectiveSeconds : null);
   }, []);
   const preview = useMemo<TrimPreview>(() => ({ previewTrim }), [previewTrim]);
 
   return (
     <TrimPreviewContext.Provider value={preview}>
       <output data-testid="trim-preview-state">{previewState}</output>
+      <output data-testid="trim-live-effective">{liveEffective ?? ""}</output>
       <NodeCard id={VIDEO_ID} trimPixelsPerSecond={TRIM_PIXELS_PER_SECOND} />
     </TrimPreviewContext.Provider>
   );
@@ -116,6 +119,73 @@ export const NoOpReleaseClearsPreview: Story = {
     ]);
     await waitFor(() => expect(previewState()).toHaveTextContent("live"));
 
+    await dispatchPointerSequence([
+      { element: document, type: "pointercancel", clientX: x, clientY: y },
+    ]);
+    await waitFor(() => expect(previewState()).toHaveTextContent("cleared"));
+  },
+};
+
+// The gesture belongs to the pointer that opened it: a non-primary pointer
+// cannot start one, and a second pointer can neither steer nor end the
+// gesture the primary owns. Initial video: full 10s, trimIn 2s, trimOut 1s,
+// so effective = 7s; the left handle grows trimIn (shrinking effective).
+export const EnforcesPointerOwnership: Story = {
+  render: () => (
+    <DndCollections initialGraph={graph()} animateMoves={false}>
+      <div className="flex flex-col gap-3">
+        <TrimPreviewProbe />
+      </div>
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    const previewState = () =>
+      canvasElement.querySelector<HTMLOutputElement>('[data-testid="trim-preview-state"]')!;
+    const liveEffective = () =>
+      canvasElement.querySelector<HTMLOutputElement>('[data-testid="trim-live-effective"]')!;
+    const leftHandle = () =>
+      nodeCard(canvasElement, VIDEO_ID)
+        .closest("[data-node-wrapper]")!
+        .querySelector<HTMLElement>('[data-trim-handle="left"]')!;
+
+    await waitForLayout(nodeCard(canvasElement, VIDEO_ID));
+    const handleRect = leftHandle().getBoundingClientRect();
+    const x = handleRect.left + handleRect.width / 2;
+    const y = handleRect.top + handleRect.height / 2;
+
+    // A non-primary pointer must not open a trim at all — no live preview.
+    await dispatchPointerSequence([
+      { element: leftHandle(), type: "pointerdown", clientX: x, clientY: y, pointerId: 5, isPrimary: false },
+      { element: document, type: "pointermove", clientX: x + TRIM_PIXELS_PER_SECOND, clientY: y, pointerId: 5, isPrimary: false },
+    ]);
+    expect(previewState()).toHaveTextContent("idle");
+
+    // The primary pointer owns the gesture: +1s of trim-in → effective 6s.
+    await dispatchPointerSequence([
+      { element: leftHandle(), type: "pointerdown", clientX: x, clientY: y },
+      { element: document, type: "pointermove", clientX: x + TRIM_PIXELS_PER_SECOND, clientY: y },
+    ]);
+    await waitFor(() => expect(previewState()).toHaveTextContent("live"));
+    expect(liveEffective()).toHaveTextContent("6");
+
+    // A second pointer's move must not steer the owner's gesture (a huge
+    // interloper delta would clamp effective to 0 if it were honored).
+    await dispatchPointerSequence([
+      { element: document, type: "pointermove", clientX: x + TRIM_PIXELS_PER_SECOND * 10, clientY: y, pointerId: 2 },
+    ]);
+    expect(liveEffective()).toHaveTextContent("6");
+
+    // ...and its cancel must not end the gesture — the preview stays live.
+    await dispatchPointerSequence([
+      { element: document, type: "pointercancel", clientX: x, clientY: y, pointerId: 2 },
+    ]);
+    expect(previewState()).toHaveTextContent("live");
+
+    // The owner still drives it: +2s of trim-in → effective 5s, then ends it.
+    await dispatchPointerSequence([
+      { element: document, type: "pointermove", clientX: x + TRIM_PIXELS_PER_SECOND * 2, clientY: y },
+    ]);
+    await waitFor(() => expect(liveEffective()).toHaveTextContent("5"));
     await dispatchPointerSequence([
       { element: document, type: "pointercancel", clientX: x, clientY: y },
     ]);

--- a/packages/ui/dnd-collections/react/trim-gesture.ts
+++ b/packages/ui/dnd-collections/react/trim-gesture.ts
@@ -123,7 +123,16 @@ export function useTrimPointerDrag(
 
   return useCallback(
     (event, pixelsPerSecond, resolve, onLive) => {
-      if (event.button !== 0 || !Number.isFinite(pixelsPerSecond) || pixelsPerSecond <= 0) return;
+      // Only the primary pointer's left button starts a trim. A secondary
+      // finger/stylus must not open a gesture (and, below, must not steer or
+      // end the one the primary owns).
+      if (
+        !event.isPrimary ||
+        event.button !== 0 ||
+        !Number.isFinite(pixelsPerSecond) ||
+        pixelsPerSecond <= 0
+      )
+        return;
       activeCleanupRef.current?.();
       // Keep the gesture off dnd-kit's item drag, the strip's pan, and (for
       // an overview grip) the overview's own move handler.
@@ -170,7 +179,8 @@ export function useTrimPointerDrag(
       }
 
       function onMove(moveEvent: PointerEvent) {
-        if (finished) return;
+        // Ignore every pointer but the one that started this gesture.
+        if (finished || moveEvent.pointerId !== pointerId) return;
         const { update, live } = resolve((moveEvent.clientX - startX) / pixelsPerSecond);
         pending = update;
         onLive?.(live);
@@ -178,7 +188,8 @@ export function useTrimPointerDrag(
       }
 
       function onUp(upEvent: PointerEvent) {
-        if (finished) return;
+        // A different pointer's release/cancel must not end this gesture.
+        if (finished || upEvent.pointerId !== pointerId) return;
         finished = true;
         removeListeners();
         releasePointerCapture();

--- a/packages/ui/dnd-collections/stories-helpers.ts
+++ b/packages/ui/dnd-collections/stories-helpers.ts
@@ -12,6 +12,10 @@ type PointerStep = Readonly<{
   clientX: number;
   clientY: number;
   delayAfterMs?: number;
+  /** Defaults to the primary pointer (id 1). Override to model a second
+   *  finger/stylus for multi-pointer and gesture-ownership tests. */
+  pointerId?: number;
+  isPrimary?: boolean;
 }>;
 
 const POINTER_INIT: PointerEventInit = {
@@ -26,7 +30,13 @@ const POINTER_INIT: PointerEventInit = {
 export async function dispatchPointerSequence(steps: readonly PointerStep[]): Promise<void> {
   for (const step of steps) {
     step.element.dispatchEvent(
-      new PointerEvent(step.type, { ...POINTER_INIT, clientX: step.clientX, clientY: step.clientY })
+      new PointerEvent(step.type, {
+        ...POINTER_INIT,
+        clientX: step.clientX,
+        clientY: step.clientY,
+        ...(step.pointerId !== undefined ? { pointerId: step.pointerId } : {}),
+        ...(step.isPrimary !== undefined ? { isPrimary: step.isPrimary } : {}),
+      })
     );
     if (step.delayAfterMs) {
       await new Promise((resolve) => setTimeout(resolve, step.delayAfterMs));


### PR DESCRIPTION
useTrimPointerDrag processed every window pointermove/up and started on any button-0 press, so a second finger/stylus could steer or end the gesture the first pointer owned (and a non-primary press could open one).

Reject non-primary starts, and filter onMove/onUp to the pointerId that opened the gesture. Extend dispatchPointerSequence with per-step pointerId/isPrimary so ownership can be tested, and add an EnforcesPointerOwnership story (verified to fail without the guards).