### PR TITLE
fix(dnd-collections): make edge auto-scroll frame-rate independent

### DIFF
--- a/packages/ui/dnd-collections/react/edge-autoscroll-math.test.ts
+++ b/packages/ui/dnd-collections/react/edge-autoscroll-math.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AUTO_SCROLL_FRAME_MS,
+  AUTO_SCROLL_MAX_CATCHUP_FRAMES,
+  edgeScrollVelocity,
+  frameScaledDistance,
+} from "./edge-autoscroll-math";
+
+describe("edgeScrollVelocity", () => {
+  it("is zero in the dead zone between the edge bands", () => {
+    expect(edgeScrollVelocity(100, 0, 200, 40, 14)).toBe(0);
+  });
+
+  it("is zero at or outside the axis ends", () => {
+    expect(edgeScrollVelocity(0, 0, 200, 40, 14)).toBe(0);
+    expect(edgeScrollVelocity(200, 0, 200, 40, 14)).toBe(0);
+    expect(edgeScrollVelocity(-10, 0, 200, 40, 14)).toBe(0);
+    expect(edgeScrollVelocity(999, 0, 200, 40, 14)).toBe(0);
+  });
+
+  it("ramps toward the origin near the start (full speed at the very edge)", () => {
+    expect(edgeScrollVelocity(0.001, 0, 200, 40, 14)).toBeCloseTo(-14, 1);
+    // Halfway into a 40px band -> half speed, still negative (toward origin).
+    expect(edgeScrollVelocity(20, 0, 200, 40, 14)).toBe(-7);
+  });
+
+  it("ramps toward the end near the end", () => {
+    expect(edgeScrollVelocity(199.999, 0, 200, 40, 14)).toBeCloseTo(14, 1);
+    expect(edgeScrollVelocity(180, 0, 200, 40, 14)).toBe(7);
+  });
+});
+
+describe("frameScaledDistance", () => {
+  it("equals the per-frame velocity at exactly one 60fps frame", () => {
+    expect(frameScaledDistance(14, AUTO_SCROLL_FRAME_MS)).toBeCloseTo(14, 10);
+  });
+
+  it("is frame-rate independent: two half-frames travel the same as one full frame", () => {
+    const full = frameScaledDistance(14, AUTO_SCROLL_FRAME_MS);
+    const twoHalves = frameScaledDistance(14, AUTO_SCROLL_FRAME_MS / 2) * 2;
+    const fourQuarters = frameScaledDistance(14, AUTO_SCROLL_FRAME_MS / 4) * 4;
+    expect(twoHalves).toBeCloseTo(full, 10);
+    expect(fourQuarters).toBeCloseTo(full, 10);
+  });
+
+  it("clamps a long stall so it cannot lurch", () => {
+    expect(frameScaledDistance(14, 100_000)).toBe(14 * AUTO_SCROLL_MAX_CATCHUP_FRAMES);
+  });
+
+  it("treats zero or negative elapsed as no movement", () => {
+    expect(frameScaledDistance(14, 0)).toBe(0);
+    expect(frameScaledDistance(14, -5)).toBe(0);
+  });
+});

--- a/packages/ui/dnd-collections/react/edge-autoscroll-math.ts
+++ b/packages/ui/dnd-collections/react/edge-autoscroll-math.ts
@@ -1,0 +1,48 @@
+// Pure geometry + timing for edge auto-scroll, split out of the hook so it can
+// be unit tested without a DOM or a rAF loop. `use-edge-autoscroll.ts` owns
+// the listeners, the rect, and the scrolling; this owns the numbers.
+
+// Baseline frame at 60fps. Velocities are expressed per-60fps-frame so the
+// historical `maxSpeed` default keeps its feel; `frameScaledDistance` turns a
+// per-frame velocity into a per-elapsed-time distance so the scroll speed no
+// longer depends on the display's refresh rate (a 120Hz screen used to scroll
+// twice as fast as a 60Hz one).
+export const AUTO_SCROLL_FRAME_MS = 1000 / 60;
+
+// Cap the catch-up after a long gap (backgrounded tab, jank) so the strip eases
+// instead of lurching a full stall's worth of scroll into one frame.
+export const AUTO_SCROLL_MAX_CATCHUP_FRAMES = 4;
+
+/**
+ * Per-frame scroll velocity (px, signed) for a pointer at `position` on a
+ * [start, end] axis. Negative in the band near `start` (scroll toward the
+ * origin), positive in the band near `end`, zero in the dead zone between and
+ * at/outside the ends. `edge` is the band width in px; `maxSpeed` the velocity
+ * at the very edge, ramping linearly to zero at the band's inner boundary.
+ */
+export function edgeScrollVelocity(
+  position: number,
+  start: number,
+  end: number,
+  edge: number,
+  maxSpeed: number
+): number {
+  if (position <= start || position >= end) return 0;
+  if (position < start + edge) return -maxSpeed * (1 - (position - start) / edge);
+  if (position > end - edge) return maxSpeed * (1 - (end - position) / edge);
+  return 0;
+}
+
+/**
+ * Distance to scroll for a frame of `elapsedMs`, given a per-60fps-frame
+ * `velocityPerFrame`. Frame-rate independent: two 8.3ms ticks travel the same
+ * distance as one 16.7ms tick. Negative/zero elapsed contributes nothing, and
+ * a long elapsed is clamped so a stall cannot lurch.
+ */
+export function frameScaledDistance(velocityPerFrame: number, elapsedMs: number): number {
+  const frames = Math.min(
+    Math.max(elapsedMs, 0) / AUTO_SCROLL_FRAME_MS,
+    AUTO_SCROLL_MAX_CATCHUP_FRAMES
+  );
+  return velocityPerFrame * frames;
+}

--- a/packages/ui/dnd-collections/react/use-edge-autoscroll.ts
+++ b/packages/ui/dnd-collections/react/use-edge-autoscroll.ts
@@ -2,6 +2,11 @@
 
 import { useEffect, useRef, type RefObject } from "react";
 import { finiteNonNegativeOr, finitePositiveOr } from "../core/numeric";
+import {
+  AUTO_SCROLL_FRAME_MS,
+  edgeScrollVelocity,
+  frameScaledDistance,
+} from "./edge-autoscroll-math";
 import { useCollectionsSelector } from "./collections-store";
 
 // Deterministic edge auto-scroll for the virtualized containers. dnd-kit's
@@ -83,7 +88,13 @@ export function useEdgeAutoScroll(
     };
 
     let frame = 0;
-    const step = () => {
+    // Scale each tick by the real elapsed time (the rAF timestamp), not a
+    // fixed per-frame amount — otherwise a 120Hz display scrolls twice as fast
+    // as a 60Hz one. First frame uses one baseline frame's worth.
+    let lastTime: number | null = null;
+    const step = (now: number) => {
+      const elapsedMs = lastTime === null ? AUTO_SCROLL_FRAME_MS : now - lastTime;
+      lastTime = now;
       const pointer = pointerRef.current;
       if (pointer) {
         const inCrossAxis =
@@ -93,16 +104,12 @@ export function useEdgeAutoScroll(
         const [position, start, end] =
           axis === "x" ? [pointer.x, rect.left, rect.right] : [pointer.y, rect.top, rect.bottom];
 
-        if (inCrossAxis && position > start && position < end) {
-          let velocity = 0;
-          if (position < start + edge) {
-            velocity = -maxSpeed * (1 - (position - start) / edge);
-          } else if (position > end - edge) {
-            velocity = maxSpeed * (1 - (end - position) / edge);
-          }
+        if (inCrossAxis) {
+          const velocity = edgeScrollVelocity(position, start, end, edge, maxSpeed);
           if (velocity !== 0) {
-            if (axis === "x") el.scrollLeft += velocity;
-            else el.scrollTop += velocity;
+            const distance = frameScaledDistance(velocity, elapsedMs);
+            if (axis === "x") el.scrollLeft += distance;
+            else el.scrollTop += distance;
           }
         }
       }


### PR DESCRIPTION
The rAF loop added a fixed per-frame velocity to scrollLeft/scrollTop, so a 120Hz display scrolled roughly twice as fast as a 60Hz one. Scale each tick by the real elapsed time from the rAF timestamp instead, clamped so a backgrounded tab or long jank frame can't lurch the scroll.

Extract the pure geometry/timing (edgeScrollVelocity, frameScaledDistance) into edge-autoscroll-math.ts so it unit-tests without a DOM or rAF loop; add edge-autoscroll-math.test.ts covering the velocity ramp, frame-rate independence (two half-frames == one full frame), the stall clamp, and non-positive elapsed. 60fps behavior is unchanged; the existing ActivationPointerSeedsEdgeAutoScroll story still passes.