### PR TITLE
feat(dnd-collections): keyboard-accessible trash + a11y discoverability

### DIFF
--- a/packages/ui/dnd-collections/API.md
+++ b/packages/ui/dnd-collections/API.md
@@ -446,6 +446,18 @@ type KeyboardTrimAction =
 start-edge action on an image). Wired in the default views
 as **Alt+Shift+Arrow** (horizontal = end edge, vertical = video start edge).
 
+### `resolveTrashCommand(graph, nodeId, trashId): Result<MoveNodesCommand, KeyboardTrashRejection>`
+
+Keyboard "move to trash" for a focused node, resolving to the same
+`move-nodes` (append-to-trash) command a pointer drop on `<TrashTarget>`
+produces — subtrees ride along, undo restores, nothing is deleted.
+`KeyboardTrashRejection.reason`: `missing-node`, `cannot-move-root`,
+`no-trash-collection` (the id is absent or not a collection), and
+`already-in-trash`. Trashing a collection that contains trash resolves to a
+command the reducer then rejects as `would-create-cycle`. Wired in the default
+views as **Alt+Delete**, active only while a `<TrashTarget>` is mounted (it
+registers its id for the controller).
+
 ---
 
 ## React: provider (`react/DndCollections.tsx`)
@@ -502,10 +514,18 @@ layer is a separate, always-available set of quick semantic moves:
 | Alt+Home / Alt+End | `move-home` / `move-end` |
 | Alt+ArrowDown | `nest-in-neighbor` |
 | Alt+ArrowUp | `move-out` |
+| Alt+Shift+ArrowLeft / Alt+Shift+ArrowRight | Trim the end edge shorter / longer (image duration / video trim-out) |
+| Alt+Shift+ArrowUp / Alt+Shift+ArrowDown | Trim the video start edge (trim-in); images reject |
+| Alt+Delete | Move to trash (only while a `<TrashTarget>` is mounted) |
 
 Inside a `VirtualGrid`, Alt+ArrowUp / Alt+ArrowDown become row moves (± the
 column count); Alt+Enter / Alt+Backspace are the grid-safe synonyms for
 `nest-in-neighbor` / `move-out`.
+
+The pointer trim handles and the source-window overview are `aria-hidden`
+visual affordances — the accessible way to trim is a focused card plus the
+Alt+Shift bindings above. (Sliding a video's source window without changing
+its duration remains pointer-only; a keyboard equivalent is a known gap.)
 
 ---
 

--- a/packages/ui/dnd-collections/PaletteTrash.stories.tsx
+++ b/packages/ui/dnd-collections/PaletteTrash.stories.tsx
@@ -378,3 +378,38 @@ export const TrashMoveAndRestore: Story = {
     });
   },
 };
+
+export const TrashViaKeyboard: Story = {
+  // Keyboard equivalent of TrashMoveAndRestore: Alt+Delete on the focused card
+  // moves it to trash with no pointer — announces, lands focus on the neighbor
+  // that took its slot, and undo restores it.
+  render: () => <PaletteBoard />,
+  play: async ({ canvasElement }) => {
+    const trash = canvasElement.querySelector<HTMLElement>("[data-trash-target]")!;
+    await waitForLayout(nodeCard(canvasElement, "bravo"));
+
+    const user = userEvent.setup();
+    nodeCard(canvasElement, "bravo").focus();
+    await user.keyboard("{Alt>}{Delete}{/Alt}");
+
+    await waitFor(() => {
+      expect(panelOrder(canvasElement, "panel-a")).toEqual(["alpha", "charlie"]);
+      expect(trash.textContent).toMatch(/trash \(1\)/i);
+    });
+    // Announced to the polite live region.
+    await expect(
+      await within(canvasElement).findByText(/moved "bravo" to trash/i)
+    ).toBeInTheDocument();
+    // Focus followed to the sibling that took the vacated slot (charlie).
+    await waitFor(() => {
+      expect(document.activeElement?.getAttribute("data-node-id")).toBe("charlie");
+    });
+
+    // Undo restores it — nothing was deleted.
+    await user.click(within(canvasElement).getByRole("button", { name: /undo/i }));
+    await waitFor(() => {
+      expect(panelOrder(canvasElement, "panel-a")).toEqual(["alpha", "bravo", "charlie"]);
+      expect(trash.textContent).toMatch(/^trash$/i);
+    });
+  },
+};

--- a/packages/ui/dnd-collections/core/keyboard.test.ts
+++ b/packages/ui/dnd-collections/core/keyboard.test.ts
@@ -1,7 +1,18 @@
 import { describe, expect, test } from "vitest";
-import { buildGraph, parseNodeId, type CollectionsGraph, type GraphNodeSpec } from "./graph";
+import {
+  buildGraph,
+  getChildren,
+  parseNodeId,
+  type CollectionsGraph,
+  type GraphNodeSpec,
+} from "./graph";
 import { applyCommand } from "./commands";
-import { resolveGridRowMoveCommand, resolveKeyboardCommand, resolveTrimCommand } from "./keyboard";
+import {
+  resolveGridRowMoveCommand,
+  resolveKeyboardCommand,
+  resolveTrashCommand,
+  resolveTrimCommand,
+} from "./keyboard";
 
 const media = (id: string): GraphNodeSpec => ({ kind: "media", id, name: id });
 const collection = (id: string, children: readonly GraphNodeSpec[] = []): GraphNodeSpec => ({
@@ -299,5 +310,74 @@ describe("resolveTrimCommand", () => {
       ok: false,
       error: { reason: "same-position" },
     });
+  });
+});
+
+describe("resolveTrashCommand", () => {
+  // root: [A, B, Trash(t1)] — a designated trash collection holding one item.
+  const trashGraph = build([
+    collection("root", [media("A"), media("B"), collection("Trash", [media("t1")])]),
+  ]);
+
+  test("appends the node to the end of the trash collection", () => {
+    expect(resolveTrashCommand(trashGraph, id("A"), id("Trash"))).toEqual({
+      ok: true,
+      // Trash already holds one item (t1), so the node lands at index 1.
+      value: { type: "move-nodes", nodeIds: ["A"], toParentId: "Trash", toIndex: 1 },
+    });
+  });
+
+  test("the resolved command applies and is undoable", () => {
+    const resolved = resolveTrashCommand(trashGraph, id("A"), id("Trash"));
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    const applied = applyCommand(trashGraph, resolved.value);
+    expect(applied.ok).toBe(true);
+    if (!applied.ok) return;
+    expect(getChildren(applied.value.graph, id("Trash"))).toEqual(["t1", "A"]);
+    expect(getChildren(applied.value.graph, id("root"))).toEqual(["B", "Trash"]);
+  });
+
+  test("rejects a node already directly inside trash (no-op)", () => {
+    expect(resolveTrashCommand(trashGraph, id("t1"), id("Trash"))).toEqual({
+      ok: false,
+      error: { reason: "already-in-trash", nodeId: "t1" },
+    });
+  });
+
+  test("rejects roots and unknown nodes", () => {
+    expect(resolveTrashCommand(trashGraph, id("root"), id("Trash"))).toEqual({
+      ok: false,
+      error: { reason: "cannot-move-root", nodeId: "root" },
+    });
+    expect(resolveTrashCommand(trashGraph, id("ghost"), id("Trash"))).toEqual({
+      ok: false,
+      error: { reason: "missing-node", nodeId: "ghost" },
+    });
+  });
+
+  test("rejects a trash id that is absent or not a collection", () => {
+    expect(resolveTrashCommand(trashGraph, id("A"), id("B"))).toEqual({
+      ok: false,
+      error: { reason: "no-trash-collection", trashId: "B" },
+    });
+    expect(resolveTrashCommand(trashGraph, id("A"), id("ghost"))).toEqual({
+      ok: false,
+      error: { reason: "no-trash-collection", trashId: "ghost" },
+    });
+  });
+
+  test("resolves a command the reducer then rejects as a cycle", () => {
+    // Trashing a collection INTO one of its own descendants is a cycle. The
+    // resolver stays structural and produces the command; the reducer guards.
+    const nested = build([
+      collection("root", [collection("Outer", [collection("Inner", [])])]),
+    ]);
+    const resolved = resolveTrashCommand(nested, id("Outer"), id("Inner"));
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    const applied = applyCommand(nested, resolved.value);
+    expect(applied.ok).toBe(false);
+    if (!applied.ok) expect(applied.error.reason).toBe("would-create-cycle");
   });
 });

--- a/packages/ui/dnd-collections/core/keyboard.ts
+++ b/packages/ui/dnd-collections/core/keyboard.ts
@@ -244,3 +244,52 @@ export function resolveTrimCommand(
   }
   return { ok: true, value: { type: "update-media", nodeId, update } };
 }
+
+// Keyboard trash: move the focused node into a designated trash collection —
+// the keyboard equivalent of dropping it on the TrashTarget. Resolves to the
+// SAME move-nodes command (append to the trash collection's end), so subtrees
+// ride along and undo restores exactly like the pointer drop. Nothing is ever
+// deleted; trash is just a collection.
+export type KeyboardTrashRejection =
+  | Readonly<{ reason: "missing-node"; nodeId: NodeId }>
+  | Readonly<{ reason: "cannot-move-root"; nodeId: NodeId }>
+  /** The supplied trash id is absent or not a collection. */
+  | Readonly<{ reason: "no-trash-collection"; trashId: NodeId }>
+  /** The node is already directly inside trash — a no-op. */
+  | Readonly<{ reason: "already-in-trash"; nodeId: NodeId }>;
+
+export function resolveTrashCommand(
+  graph: CollectionsGraph,
+  nodeId: NodeId,
+  trashId: NodeId
+): Result<MoveNodesCommand, KeyboardTrashRejection> {
+  if (!graph.nodesById.has(nodeId)) {
+    return { ok: false, error: { reason: "missing-node", nodeId } };
+  }
+  const parentId = graph.parentById.get(nodeId);
+  if (parentId === undefined) {
+    return { ok: false, error: { reason: "missing-node", nodeId } };
+  }
+  if (parentId === null) {
+    return { ok: false, error: { reason: "cannot-move-root", nodeId } };
+  }
+  const trash = graph.nodesById.get(trashId);
+  if (!trash || trash.kind !== "collection") {
+    return { ok: false, error: { reason: "no-trash-collection", trashId } };
+  }
+  if (parentId === trashId) {
+    return { ok: false, error: { reason: "already-in-trash", nodeId } };
+  }
+  // Trying to trash a collection that itself contains trash resolves to a
+  // command the reducer rejects as would-create-cycle — the controller
+  // surfaces that the same way it does for keyboard moves.
+  return {
+    ok: true,
+    value: {
+      type: "move-nodes",
+      nodeIds: [nodeId],
+      toParentId: trashId,
+      toIndex: getChildren(graph, trashId).length,
+    },
+  };
+}

--- a/packages/ui/dnd-collections/index.ts
+++ b/packages/ui/dnd-collections/index.ts
@@ -72,10 +72,12 @@ export { createHistory, type CollectionsHistory, type HistoryEntry } from "./cor
 export {
   resolveGridRowMoveCommand,
   resolveKeyboardCommand,
+  resolveTrashCommand,
   resolveTrimCommand,
   type GridRowMoveRejection,
   type KeyboardMoveAction,
   type KeyboardRejection,
+  type KeyboardTrashRejection,
   type KeyboardTrimAction,
   type KeyboardTrimRejection,
 } from "./core/keyboard";

--- a/packages/ui/dnd-collections/react/DndCollections.tsx
+++ b/packages/ui/dnd-collections/react/DndCollections.tsx
@@ -27,7 +27,7 @@ import {
   type UniqueIdentifier,
 } from "@dnd-kit/core";
 
-import { getChildren, type CollectionItemNode, type CollectionsGraph } from "../core/graph";
+import { getChildren, type CollectionItemNode, type CollectionsGraph, type NodeId } from "../core/graph";
 import {
   decodeDropTarget,
   encodeDropTarget,
@@ -206,10 +206,18 @@ function DndCollectionsContext({
   const palette = usePaletteDrag({ store, intentRef, announce });
 
   const containerRef = useRef<HTMLDivElement>(null);
-  const { handleKeyDownCapture } = useCollectionsKeyboard({ store, announce, containerRef });
+  // A mounted <TrashTarget> registers its collection id here (see
+  // container-context) so Alt+Delete can move the focused card to trash.
+  const trashRef = useRef<NodeId | null>(null);
+  const { handleKeyDownCapture } = useCollectionsKeyboard({
+    store,
+    announce,
+    containerRef,
+    trashRef,
+  });
   const instructionsId = useId();
   const containerValue = useMemo(
-    () => ({ containerRef, instructionsId }),
+    () => ({ containerRef, instructionsId, trashRef }),
     [instructionsId]
   );
 
@@ -465,7 +473,9 @@ function DndCollectionsContext({
         Press Enter to pick it up, then use the Arrow keys to move it and Enter to drop, or
         Escape to cancel. Alt plus Arrow keys move it one step at a time; Alt plus Down nests it
         into a neighboring collection and Alt plus Up moves it out. Inside a grid, Alt plus Up and
-        Down move between rows.
+        Down move between rows. For media, Alt plus Shift plus Left or Right trims the end and Alt
+        plus Shift plus Up or Down trims the start of a video. Press Alt plus Delete to move it to
+        trash.
       </p>
       <CollectionsDragOverlay paletteNodes={palette.paletteNodes} />
       <div

--- a/packages/ui/dnd-collections/react/container-context.ts
+++ b/packages/ui/dnd-collections/react/container-context.ts
@@ -1,6 +1,8 @@
 "use client";
 
-import { createContext, useContext, type RefObject } from "react";
+import { createContext, useContext, type MutableRefObject, type RefObject } from "react";
+
+import { type NodeId } from "../core/graph";
 
 // Instance-scoped plumbing the provider exposes to descendants:
 // - containerRef: the wrapper element (display: contents, layout-neutral),
@@ -8,10 +10,14 @@ import { createContext, useContext, type RefObject } from "react";
 //   multiple boards on one page (possibly reusing node ids) stay isolated.
 // - instructionsId: id of the hidden keyboard-usage instructions element,
 //   for aria-describedby on cards and grip bars.
+// - trashRef: a single slot a mounted <TrashTarget> registers its collection
+//   id into, so the keyboard controller can offer Alt+Delete "move to trash"
+//   without the provider knowing about trash. null when none is mounted.
 
 export type CollectionsContainerValue = Readonly<{
   containerRef: RefObject<HTMLElement | null>;
   instructionsId: string;
+  trashRef: MutableRefObject<NodeId | null>;
 }>;
 
 export const CollectionsContainerContext =

--- a/packages/ui/dnd-collections/react/trash-target.tsx
+++ b/packages/ui/dnd-collections/react/trash-target.tsx
@@ -1,16 +1,31 @@
 "use client";
 
+import { useEffect } from "react";
 import { useDroppable } from "@dnd-kit/core";
 import { getChildren, type NodeId } from "../core/graph";
 import { encodeDropTarget } from "../core/intents";
 import { useCollectionsSelector } from "./collections-store";
+import { useCollectionsContainer } from "./container-context";
 
 // Trash is MODELING, not machinery: a designated (usually hidden) root
 // collection. This target is nothing but a styled panel droppable for it —
 // dropping resolves append-to-collection, the standard move-nodes command
 // runs (subtrees ride along, undo restores), and nothing is ever deleted.
+// Mounting it also registers the id for the keyboard path (Alt+Delete on a
+// focused card), so trash works without a pointer.
 
 export function TrashTarget({ trashId }: { trashId: NodeId }) {
+  const { trashRef } = useCollectionsContainer();
+  // Register this instance's trash id for the keyboard controller; clear it on
+  // unmount (only if we still own the slot — a later TrashTarget may have
+  // replaced us).
+  useEffect(() => {
+    trashRef.current = trashId;
+    return () => {
+      if (trashRef.current === trashId) trashRef.current = null;
+    };
+  }, [trashRef, trashId]);
+
   const isCollection = useCollectionsSelector(
     (s) => s.graph.nodesById.get(trashId)?.kind === "collection"
   );
@@ -35,7 +50,7 @@ export function TrashTarget({ trashId }: { trashId: NodeId }) {
       ref={setNodeRef}
       role="region"
       aria-disabled={!isCollection}
-      aria-label={`Trash${count > 0 ? `, ${count} items` : ""}. Drop items here to move them to trash.`}
+      aria-label={`Trash${count > 0 ? `, ${count} items` : ""}. Drop items here, or press Alt+Delete on a focused item, to move it to trash.`}
       data-trash-target={trashId}
       data-trash-valid={isCollection}
       data-trash-state={state}

--- a/packages/ui/dnd-collections/react/trim-handles.tsx
+++ b/packages/ui/dnd-collections/react/trim-handles.tsx
@@ -54,9 +54,13 @@ export function TrimHandles({
 
   return (
     <>
+      {/* Pointer-only affordances: not focusable and aria-hidden. The
+          accessible way to trim is the focused card + Alt+Shift+Arrows
+          (see use-keyboard-controller / the sr-only instructions). */}
       {showLeft && (
         <div
           data-trim-handle="left"
+          aria-hidden="true"
           className={`${HANDLE_CLASS} left-0 rounded-l-md`}
           onPointerDown={(event) => startTrim("left", event)}
         >
@@ -65,6 +69,7 @@ export function TrimHandles({
       )}
       <div
         data-trim-handle="right"
+        aria-hidden="true"
         className={`${HANDLE_CLASS} right-0 rounded-r-md`}
         onPointerDown={(event) => startTrim("right", event)}
       >

--- a/packages/ui/dnd-collections/react/trim-overview.tsx
+++ b/packages/ui/dnd-collections/react/trim-overview.tsx
@@ -72,6 +72,12 @@ export const TrimOverviewStrip = memo(function TrimOverviewStrip({
   return (
     <div
       data-trim-overview={node.id}
+      // Pointer-only source-window visualization: aria-hidden so assistive
+      // tech isn't led into an unlabeled filmstrip. Trimming is available to
+      // the keyboard via the focused card + Alt+Shift+Arrows. (Sliding the
+      // source window without changing duration is still pointer-only — a
+      // keyboard equivalent is a known gap, tracked for a follow-up.)
+      aria-hidden="true"
       // Dragging the filmstrip (anywhere but the amber grips, which
       // stopPropagation) MOVES the source window.
       onPointerDown={startMove}

--- a/packages/ui/dnd-collections/react/use-keyboard-controller.ts
+++ b/packages/ui/dnd-collections/react/use-keyboard-controller.ts
@@ -8,14 +8,16 @@ import {
   type RefObject,
 } from "react";
 
-import { mediaDurationSeconds, type NodeId } from "../core/graph";
+import { getChildren, mediaDurationSeconds, type NodeId } from "../core/graph";
 import {
   resolveGridRowMoveCommand,
   resolveKeyboardCommand,
+  resolveTrashCommand,
   resolveTrimCommand,
   type GridRowMoveRejection,
   type KeyboardMoveAction,
   type KeyboardRejection,
+  type KeyboardTrashRejection,
   type KeyboardTrimAction,
   type KeyboardTrimRejection,
 } from "../core/keyboard";
@@ -91,16 +93,31 @@ const TRIM_REJECTION_MESSAGES: Readonly<
   "invalid-step": undefined,
 };
 
+// Alt+Delete moves the focused card to the designated trash collection (the
+// keyboard equivalent of dropping it on the TrashTarget). `undefined` = silent
+// (corrupt/out-of-scope input); keyed by the rejection union so a new reason
+// forces a decision here at compile time.
+const TRASH_REJECTION_MESSAGES: Readonly<
+  Record<KeyboardTrashRejection["reason"], string | undefined>
+> = {
+  "already-in-trash": "Already in trash.",
+  "cannot-move-root": "Top-level collections cannot be moved to trash.",
+  "missing-node": undefined,
+  "no-trash-collection": undefined,
+};
+
 export function useCollectionsKeyboard(args: {
   store: CollectionsStore;
   announce: (message: string) => void;
   containerRef: RefObject<HTMLDivElement | null>;
+  /** Where a mounted <TrashTarget> registers its id, for Alt+Delete. */
+  trashRef: RefObject<NodeId | null>;
 }): Readonly<{
   handleKeyDownCapture: (event: ReactKeyboardEvent) => void;
   /** Re-focus a card after a move unmounts/remounts it (new parent or virtual slot). */
   restoreFocus: (nodeId: NodeId, fallbackId?: NodeId) => void;
 }> {
-  const { store, announce, containerRef } = args;
+  const { store, announce, containerRef, trashRef } = args;
   const pendingFocusRef = useRef<(() => void) | null>(null);
 
   useEffect(
@@ -184,6 +201,38 @@ export function useCollectionsKeyboard(args: {
     [store, announce]
   );
 
+  const handleTrash = useCallback(
+    (nodeId: NodeId, trashId: NodeId) => {
+      const { graph } = store.getSnapshot();
+      const name = graph.nodesById.get(nodeId)?.name ?? "item";
+      // Compute the neighbor BEFORE the move so focus can land on whatever
+      // takes the vacated slot (next sibling, else previous) once the card
+      // leaves for the usually-hidden trash collection.
+      const parentId = graph.parentById.get(nodeId);
+      const siblings = parentId ? getChildren(graph, parentId) : [];
+      const selfIndex = siblings.indexOf(nodeId);
+      const neighbor = siblings[selfIndex + 1] ?? siblings[selfIndex - 1];
+
+      const resolved = resolveTrashCommand(graph, nodeId, trashId);
+      if (!resolved.ok) {
+        const message = TRASH_REJECTION_MESSAGES[resolved.error.reason];
+        if (message) announce(message);
+        return;
+      }
+      const dispatched = store.dispatch(resolved.value);
+      if (!dispatched.ok) {
+        if (dispatched.error.reason === "would-create-cycle") {
+          store.flashRejection([nodeId]);
+          announce("Cannot move a collection into itself or one of its nested collections.");
+        }
+        return;
+      }
+      announce(`Moved "${name}" to trash.`);
+      restoreFocus(neighbor ?? trashId, trashId);
+    },
+    [store, announce, restoreFocus]
+  );
+
   const handleKeyDownCapture = useCallback(
     (event: ReactKeyboardEvent) => {
       if (!event.altKey || event.ctrlKey || event.metaKey) return;
@@ -196,6 +245,18 @@ export function useCollectionsKeyboard(args: {
         card?.getAttribute("data-node-id") ?? card?.getAttribute("data-node-wrapper");
       if (!rawId) return;
       const nodeId = rawId as NodeId;
+
+      // Alt+Delete moves the focused card to the registered trash collection.
+      // Only consumed when a <TrashTarget> is mounted and no dnd-kit drag owns
+      // movement; otherwise the key is left for the app/browser.
+      if (event.key === "Delete") {
+        const trashId = trashRef.current;
+        if (trashId === null || store.getSnapshot().interaction.isDragging) return;
+        event.preventDefault();
+        event.stopPropagation();
+        handleTrash(nodeId, trashId);
+        return;
+      }
 
       const isCollectionsCommand = event.shiftKey
         ? TRIM_ACTION_BY_KEY[event.key] !== undefined
@@ -263,7 +324,7 @@ export function useCollectionsKeyboard(args: {
       // doesn't render — fall back to the destination collection's own card.
       restoreFocus(nodeId, resolved.value.toParentId);
     },
-    [store, announce, handleGridRowMove, handleTrim, restoreFocus]
+    [store, announce, trashRef, handleGridRowMove, handleTrim, handleTrash, restoreFocus]
   );
 
   return { handleKeyDownCapture, restoreFocus };


### PR DESCRIPTION
Keyboard trim (Alt+Shift+Arrows) already existed; the remaining gaps were trash (pointer-drop only), undocumented shortcuts, and unlabeled pointer handles.

- Trash: add resolveTrashCommand (core) — the keyboard equivalent of a drop on TrashTarget, resolving to the same move-nodes (append-to-trash) command (subtrees ride along, undo restores). A mounted TrashTarget registers its id via the instance context; the controller binds Alt+Delete, announces "Moved X to trash", and lands focus on the neighbor that took the slot.
- Discoverability: extend the sr-only instructions with the Alt+Shift trim and Alt+Delete trash grammar; the trash region advertises Alt+Delete; document both in API.md; export resolveTrashCommand.
- Presentational: aria-hidden the pointer-only trim handles and source-window overview — the accessible trim path is the focused card + Alt+Shift. (Sliding a video's source window without changing duration stays pointer-only; a keyboard equivalent is a noted follow-up.)

Tests: resolveTrashCommand unit coverage (append, already-in-trash, roots, invalid trash id, reducer cycle guard) and a TrashViaKeyboard story (Alt+Delete moves + announces + focuses neighbor + undo restores).