### PR TITLE
refactor(dnd-collections): extract pure virtual-strip geometry

### DIFF
--- a/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
@@ -37,6 +37,12 @@ import {
   VirtualEmptyHint,
   type VirtualViewPoint,
 } from "./use-virtual-collection-view";
+import {
+  indicatorLeftOffset,
+  leftAnchorShift,
+  resolveBoundaryIndex,
+  slotSizeFor,
+} from "./virtual-strip-geometry";
 
 // 1D roving navigation: Left/Right step one item, Home/End jump to the ends.
 function resolveStripIndex(key: string, current: number, count: number): number | null {
@@ -277,7 +283,7 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
       // Crisp width via resizeItem (grows/shrinks rightward). The right-edge
       // anchor is a composited transform derived during render, applied in
       // the SAME commit as this resize (atomic — no stutter).
-      s.virtualizer.resizeItem(index, live.effectiveSeconds * (s.trimPixelsPerSecond ?? 0) + s.gap);
+      s.virtualizer.resizeItem(index, slotSizeFor(live.effectiveSeconds, s.trimPixelsPerSecond ?? 0, s.gap));
     }, []);
     const trimPreview = useMemo<TrimPreview>(() => ({ previewTrim }), [previewTrim]);
 
@@ -311,11 +317,12 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
         return childIds.length;
       }
       const contentX = point.x - content.getBoundingClientRect().left;
-      if (contentX <= 0) return 0;
-      if (contentX >= virtualizer.getTotalSize()) return childIds.length;
-      const item = virtualizer.getVirtualItemForOffset(contentX);
-      if (!item) return childIds.length;
-      return contentX < item.start + item.size / 2 ? item.index : item.index + 1;
+      const totalSize = virtualizer.getTotalSize();
+      // Only measure an item for an in-range pointer; the pure resolver applies
+      // the same before-first / past-end clamps.
+      const item =
+        contentX > 0 && contentX < totalSize ? virtualizer.getVirtualItemForOffset(contentX) : null;
+      return resolveBoundaryIndex(contentX, totalSize, childIds.length, item ?? null);
     };
     usePublishBoundary(resolveBoundaryRef, resolveBoundary);
 
@@ -450,8 +457,8 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
     let dragShiftX = 0;
     const trimBaseline = trimBaselineRef.current;
     if (liveTrim && trimBaseline && trimBaseline.nodeId === liveTrim.nodeId && liveTrim.trim.side === "left") {
-      const liveSlot = liveTrim.trim.effectiveSeconds * (trimPixelsPerSecond ?? 0) + gap;
-      dragShiftX = -(liveSlot - trimBaseline.size0);
+      const liveSlot = slotSizeFor(liveTrim.trim.effectiveSeconds, trimPixelsPerSecond ?? 0, gap);
+      dragShiftX = leftAnchorShift(liveSlot, trimBaseline.size0);
     }
     dragShiftRef.current = dragShiftX;
 
@@ -484,10 +491,10 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
     // (append at the far end) falls back to the total size.
     const boundaryLeft = (k: number): number | null => {
       if (k >= childIds.length) {
-        return Math.max(0, virtualizer.getTotalSize() - gap / 2 - 2);
+        return indicatorLeftOffset(virtualizer.getTotalSize(), gap);
       }
       const item = virtualizer.getVirtualItems().find((v) => v.index === k);
-      return item ? Math.max(0, item.start - gap / 2 - 2) : null;
+      return item ? indicatorLeftOffset(item.start, gap) : null;
     };
     const indicatorLeft = indicatorIndex !== null ? boundaryLeft(indicatorIndex) : null;
 

--- a/packages/ui/dnd-collections/virtual/virtual-strip-geometry.test.ts
+++ b/packages/ui/dnd-collections/virtual/virtual-strip-geometry.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  indicatorLeftOffset,
+  leftAnchorShift,
+  resolveBoundaryIndex,
+  slotSizeFor,
+} from "./virtual-strip-geometry";
+
+const item = (start: number, size: number, index: number) => ({ start, size, index });
+
+describe("resolveBoundaryIndex", () => {
+  it("clamps at or before the first item to 0", () => {
+    expect(resolveBoundaryIndex(0, 500, 10, item(0, 50, 0))).toBe(0);
+    expect(resolveBoundaryIndex(-5, 500, 10, item(0, 50, 0))).toBe(0);
+  });
+
+  it("clamps at or past the total size to the count", () => {
+    expect(resolveBoundaryIndex(500, 500, 10, item(450, 50, 9))).toBe(10);
+    expect(resolveBoundaryIndex(999, 500, 10, null)).toBe(10);
+  });
+
+  it("returns the count when no measured item is under the pointer", () => {
+    expect(resolveBoundaryIndex(200, 500, 10, null)).toBe(10);
+  });
+
+  it("rounds to the item in its left half, index+1 in its right half", () => {
+    // item 3 spans [120, 160); midpoint 140.
+    expect(resolveBoundaryIndex(125, 500, 10, item(120, 40, 3))).toBe(3);
+    expect(resolveBoundaryIndex(139.9, 500, 10, item(120, 40, 3))).toBe(3);
+    // Exactly the midpoint rounds to the following boundary.
+    expect(resolveBoundaryIndex(140, 500, 10, item(120, 40, 3))).toBe(4);
+    expect(resolveBoundaryIndex(155, 500, 10, item(120, 40, 3))).toBe(4);
+  });
+});
+
+describe("indicatorLeftOffset", () => {
+  it("insets half a gap plus the indicator half-width", () => {
+    expect(indicatorLeftOffset(120, 8)).toBe(114); // 120 - 4 - 2
+  });
+
+  it("never goes negative", () => {
+    expect(indicatorLeftOffset(0, 8)).toBe(0);
+    expect(indicatorLeftOffset(3, 8)).toBe(0);
+  });
+
+  it("handles a zero gap", () => {
+    expect(indicatorLeftOffset(50, 0)).toBe(48);
+  });
+});
+
+describe("slotSizeFor", () => {
+  it("is seconds*pps plus the trailing gap", () => {
+    expect(slotSizeFor(5, 24, 8)).toBe(128);
+  });
+
+  it("collapses a fully trimmed clip to just the gap", () => {
+    expect(slotSizeFor(0, 24, 8)).toBe(8);
+  });
+});
+
+describe("leftAnchorShift", () => {
+  it("negates rightward growth so the right edge stays pinned", () => {
+    expect(leftAnchorShift(140, 100)).toBe(-40); // grew 40px -> shift left 40
+  });
+
+  it("yields a positive shift when the slot shrank, and 0 for no change", () => {
+    expect(leftAnchorShift(80, 100)).toBe(20);
+    expect(leftAnchorShift(100, 100)).toBe(0);
+  });
+});

--- a/packages/ui/dnd-collections/virtual/virtual-strip-geometry.ts
+++ b/packages/ui/dnd-collections/virtual/virtual-strip-geometry.ts
@@ -1,0 +1,57 @@
+// Pure geometry for the horizontal virtual strip, split out of VirtualStrip so
+// the boundary/indicator/anchor arithmetic can be unit tested without a
+// virtualizer, DOM, or rAF loop. VirtualStrip owns the measurements, refs, and
+// scrolling; this owns the numbers.
+
+/** Half the drop-indicator line's width (px) — used to center it in a gap. */
+const INDICATOR_HALF_WIDTH = 2;
+
+/**
+ * The visible boundary index for a pointer at content-x `contentX`, given the
+ * strip's measured `totalSize` and item `count`. Before the first item -> 0;
+ * at/past the end, or with no measured item under the pointer -> `count`;
+ * otherwise the pointer's item rounded to the nearer edge by its midpoint.
+ * `item` is the virtualizer's measured item under `contentX` (null when out of
+ * range or unmeasured).
+ */
+export function resolveBoundaryIndex(
+  contentX: number,
+  totalSize: number,
+  count: number,
+  item: Readonly<{ start: number; size: number; index: number }> | null
+): number {
+  if (contentX <= 0) return 0;
+  if (contentX >= totalSize) return count;
+  if (!item) return count;
+  return contentX < item.start + item.size / 2 ? item.index : item.index + 1;
+}
+
+/**
+ * Left offset (content coords) for the drop indicator at a boundary whose gap
+ * begins at `edgeStart` — half a gap back, centered on the indicator line, and
+ * never negative. `edgeStart` is the following item's `start`, or the strip's
+ * total size when appending at the far end.
+ */
+export function indicatorLeftOffset(edgeStart: number, gap: number): number {
+  return Math.max(0, edgeStart - gap / 2 - INDICATOR_HALF_WIDTH);
+}
+
+/**
+ * Slot width (px) a clip of `effectiveSeconds` occupies at `pixelsPerSecond`,
+ * plus its trailing `gap` — the size handed to the virtualizer's `resizeItem`.
+ */
+export function slotSizeFor(effectiveSeconds: number, pixelsPerSecond: number, gap: number): number {
+  return effectiveSeconds * pixelsPerSecond + gap;
+}
+
+/**
+ * The "grows left" anchor transform (px) for a left-handle trim: `resizeItem`
+ * grew the slot rightward from `baselineSize` to `liveSlotSize`, so translate
+ * the content layer by the negated growth to pin the clip's RIGHT edge (a
+ * shrink yields a positive shift; no change yields 0).
+ */
+export function leftAnchorShift(liveSlotSize: number, baselineSize: number): number {
+  // baseline − live == −(growth); written this way so no change yields +0
+  // rather than −0 (behaviorally identical, but tidier).
+  return baselineSize - liveSlotSize;
+}


### PR DESCRIPTION
VirtualStrip's boundary/indicator/anchor arithmetic was inline and only covered indirectly by the browser story suite. Extract it into a pure, DOM-free virtual-strip-geometry.ts (resolveBoundaryIndex, indicatorLeftOffset, slotSizeFor, leftAnchorShift) and unit test it in the node project.

Behavior-preserving: the component still owns the virtualizer, refs, and scrolling and just calls these for the math. First slice of the VirtualStrip decomposition; the tangled trim/overview/indicator concerns are unchanged.