### PR TITLE
fix(dnd-collections): apply code-review findings

### DIFF
--- a/packages/ui/dnd-collections/PaletteTrash.stories.tsx
+++ b/packages/ui/dnd-collections/PaletteTrash.stories.tsx
@@ -390,6 +390,13 @@ export const TrashViaKeyboard: Story = {
 
     const user = userEvent.setup();
     nodeCard(canvasElement, "bravo").focus();
+
+    // The chord is EXACTLY Alt+Delete — a held Shift is left for the app/
+    // browser and must not trash. (If it did, the assertions below would see
+    // two items in trash and the wrong panel order.)
+    await user.keyboard("{Alt>}{Shift>}{Delete}{/Shift}{/Alt}");
+    expect(panelOrder(canvasElement, "panel-a")).toEqual(["alpha", "bravo", "charlie"]);
+
     await user.keyboard("{Alt>}{Delete}{/Alt}");
 
     await waitFor(() => {

--- a/packages/ui/dnd-collections/core/graph.test.ts
+++ b/packages/ui/dnd-collections/core/graph.test.ts
@@ -322,6 +322,29 @@ describe("buildGraph", () => {
     const graph = build([collection("root", [spec])]);
     expect(graph.nodesById.size).toBe(20_002);
   });
+
+  test("copies posterSrcs — mutating the caller's array never reaches the graph", () => {
+    const posterSrcs = ["a.jpg", "b.jpg"];
+    const graph = build([
+      collection("root", [
+        {
+          kind: "media",
+          mediaKind: "video",
+          id: "v1",
+          name: "V1",
+          posterSrcs,
+          fullDurationSeconds: 10,
+        },
+      ]),
+    ]);
+
+    posterSrcs.push("evil.jpg");
+    const node = graph.nodesById.get(parseNodeId("v1"));
+    expect(node?.kind === "media" && node.mediaKind === "video" ? node.posterSrcs : null).toEqual([
+      "a.jpg",
+      "b.jpg",
+    ]);
+  });
 });
 
 describe("isSameOrAncestor", () => {

--- a/packages/ui/dnd-collections/core/graph.ts
+++ b/packages/ui/dnd-collections/core/graph.ts
@@ -219,7 +219,9 @@ export function buildGraph(
               mediaKind: "video",
               name: spec.name,
               src: spec.src,
-              posterSrcs: spec.posterSrcs,
+              // Copied (like parseCollectionItemNode does): the graph is
+              // Readonly, so it must not alias an array the caller can mutate.
+              posterSrcs: spec.posterSrcs === undefined ? undefined : [...spec.posterSrcs],
               fullDurationSeconds: spec.fullDurationSeconds,
               trimInSeconds: spec.trimInSeconds ?? 0,
               trimOutSeconds: spec.trimOutSeconds ?? 0,

--- a/packages/ui/dnd-collections/react/duration-format.ts
+++ b/packages/ui/dnd-collections/react/duration-format.ts
@@ -1,0 +1,11 @@
+// Display rounding for media durations. Pointer trims commit raw
+// pixel-derived floats ((clientX - startX) / pixelsPerSecond — deliberately
+// unquantized, so the data keeps full precision for undo/persistence), which
+// means a card label or announcement rendering the value verbatim leaks
+// "3.5416666666666665s" into the UI and into speech. Round at the display
+// boundary only; whole numbers stay whole ("4", never "4.0").
+
+/** Round a seconds value to 0.1s for display. The underlying data is untouched. */
+export function roundSecondsForDisplay(seconds: number): number {
+  return Math.round(seconds * 10) / 10;
+}

--- a/packages/ui/dnd-collections/react/node-views.tsx
+++ b/packages/ui/dnd-collections/react/node-views.tsx
@@ -14,6 +14,7 @@ import { encodeDropTarget } from "../core/intents";
 import { finitePositiveOrUndefined } from "../core/numeric";
 import { useCollectionsSelector, useCollectionsStore } from "./collections-store";
 import { useCollectionsContainer } from "./container-context";
+import { roundSecondsForDisplay } from "./duration-format";
 import { NodeThumbnail } from "./node-thumbnail";
 import { TrimHandles } from "./trim-handles";
 
@@ -255,7 +256,7 @@ export const NodeCard = memo(function NodeCard({
             <span className="mt-1 flex items-center justify-between gap-1">
               <span className="truncate font-medium text-foreground">{node.name}</span>
               <span className="shrink-0 text-[10px] text-muted-foreground">
-                {mediaDurationSeconds(node)}s
+                {roundSecondsForDisplay(mediaDurationSeconds(node))}s
               </span>
             </span>
           </>
@@ -363,7 +364,9 @@ export function NodeCardGhost({
     >
       <span className="truncate font-medium text-foreground">{node.name}</span>
       <span className="text-[10px] text-muted-foreground">
-        {node.kind === "collection" ? "Collection" : `${mediaDurationSeconds(node)}s`}
+        {node.kind === "collection"
+          ? "Collection"
+          : `${roundSecondsForDisplay(mediaDurationSeconds(node))}s`}
       </span>
       {extraCount > 0 && (
         <span

--- a/packages/ui/dnd-collections/react/trim-handles.tsx
+++ b/packages/ui/dnd-collections/react/trim-handles.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useState, type PointerEvent as ReactPointerEvent } from "react";
 
 import { mediaDurationSeconds, type MediaNode } from "../core/graph";
+import { roundSecondsForDisplay } from "./duration-format";
 import { resolveTrim, useTrimPointerDrag, type TrimSide } from "./trim-gesture";
 
 // Edge drag-handles that TRIM a media item: a right handle on every media
@@ -89,13 +90,9 @@ export function TrimHandles({
           data-trim-preview={preview}
           className="pointer-events-none absolute -top-5 left-1/2 z-30 -translate-x-1/2 rounded bg-amber-300 px-1.5 py-0.5 text-[10px] font-bold text-black shadow"
         >
-          {round1(preview)}s
+          {roundSecondsForDisplay(preview)}s
         </div>
       )}
     </>
   );
-}
-
-function round1(seconds: number): number {
-  return Math.round(seconds * 10) / 10;
 }

--- a/packages/ui/dnd-collections/react/use-keyboard-controller.ts
+++ b/packages/ui/dnd-collections/react/use-keyboard-controller.ts
@@ -22,6 +22,7 @@ import {
   type KeyboardTrimRejection,
 } from "../core/keyboard";
 import { type CollectionsStore } from "./collections-store";
+import { roundSecondsForDisplay } from "./duration-format";
 import { focusNodeWhenMounted } from "./node-dom";
 
 // Semantic keyboard moves (Alt+key on a focused card), by event delegation
@@ -196,7 +197,7 @@ export function useCollectionsKeyboard(args: {
       // put — just announce the new length.
       const after = store.getSnapshot().graph.nodesById.get(nodeId);
       const seconds = after && after.kind === "media" ? mediaDurationSeconds(after) : 0;
-      announce(`Trimmed "${name}" to ${seconds}s.`);
+      announce(`Trimmed "${name}" to ${roundSecondsForDisplay(seconds)}s.`);
     },
     [store, announce]
   );
@@ -247,9 +248,12 @@ export function useCollectionsKeyboard(args: {
       const nodeId = rawId as NodeId;
 
       // Alt+Delete moves the focused card to the registered trash collection.
-      // Only consumed when a <TrashTarget> is mounted and no dnd-kit drag owns
-      // movement; otherwise the key is left for the app/browser.
+      // EXACTLY Alt+Delete: a held Shift makes it a different chord, left for
+      // the app/browser like any other unrecognized combo (the trim branch
+      // below guards held Shift the same way). Only consumed when a
+      // <TrashTarget> is mounted and no dnd-kit drag owns movement.
       if (event.key === "Delete") {
+        if (event.shiftKey) return;
         const trashId = trashRef.current;
         if (trashId === null || store.getSnapshot().interaction.isDragging) return;
         event.preventDefault();

--- a/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
@@ -38,6 +38,7 @@ import {
   type VirtualViewPoint,
 } from "./use-virtual-collection-view";
 import {
+  MIN_ITEM_WIDTH,
   indicatorLeftOffset,
   leftAnchorShift,
   resolveBoundaryIndex,
@@ -122,13 +123,6 @@ export type VirtualStripHandle = Readonly<{
   /** Drop all cached widths and re-run `itemWidthFor` (metadata/zoom changed). */
   remeasure: () => void;
 }>;
-
-// A fully trimmed clip can derive a 0px width from `itemWidthFor`. The slot
-// still needs to be visible and clickable: NodeCard's `w-full` fills the slot
-// (overriding its own `w-32` default), so a 0px slot renders an invisible,
-// unselectable card. The node's semantic duration/trim is left untouched;
-// only the rendered/measured slot is floored to this minimum.
-const MIN_ITEM_WIDTH = 12;
 
 export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
   function VirtualStrip(

--- a/packages/ui/dnd-collections/virtual/virtual-strip-geometry.test.ts
+++ b/packages/ui/dnd-collections/virtual/virtual-strip-geometry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  MIN_ITEM_WIDTH,
   indicatorLeftOffset,
   leftAnchorShift,
   resolveBoundaryIndex,
@@ -54,8 +55,15 @@ describe("slotSizeFor", () => {
     expect(slotSizeFor(5, 24, 8)).toBe(128);
   });
 
-  it("collapses a fully trimmed clip to just the gap", () => {
-    expect(slotSizeFor(0, 24, 8)).toBe(8);
+  it("floors a fully trimmed clip at the clickable minimum, like the committed layout", () => {
+    // The last live preview must equal the post-commit re-measure (which
+    // floors at MIN_ITEM_WIDTH) or the card snaps on release.
+    expect(slotSizeFor(0, 24, 8)).toBe(MIN_ITEM_WIDTH + 8);
+    expect(slotSizeFor(0.2, 24, 8)).toBe(MIN_ITEM_WIDTH + 8); // 4.8px derived -> floored
+  });
+
+  it("leaves widths at or above the floor untouched", () => {
+    expect(slotSizeFor(0.5, 24, 8)).toBe(20); // exactly MIN_ITEM_WIDTH
   });
 });
 

--- a/packages/ui/dnd-collections/virtual/virtual-strip-geometry.ts
+++ b/packages/ui/dnd-collections/virtual/virtual-strip-geometry.ts
@@ -7,6 +7,17 @@
 const INDICATOR_HALF_WIDTH = 2;
 
 /**
+ * A fully trimmed clip can derive a 0px width from its duration. The slot
+ * still needs to be visible and clickable: NodeCard's `w-full` fills the slot
+ * (overriding its own `w-32` default), so a 0px slot renders an invisible,
+ * unselectable card. Applied by BOTH the committed layout (`widthForIndex` in
+ * VirtualStrip) and the live preview (`slotSizeFor`) — they must agree, or the
+ * commit re-measure snaps the card by the floor delta on release. The node's
+ * semantic duration/trim is left untouched; only the rendered slot is floored.
+ */
+export const MIN_ITEM_WIDTH = 12;
+
+/**
  * The visible boundary index for a pointer at content-x `contentX`, given the
  * strip's measured `totalSize` and item `count`. Before the first item -> 0;
  * at/past the end, or with no measured item under the pointer -> `count`;
@@ -39,9 +50,12 @@ export function indicatorLeftOffset(edgeStart: number, gap: number): number {
 /**
  * Slot width (px) a clip of `effectiveSeconds` occupies at `pixelsPerSecond`,
  * plus its trailing `gap` — the size handed to the virtualizer's `resizeItem`.
+ * Floored at `MIN_ITEM_WIDTH` like the committed layout, so the last preview
+ * of a near-fully-trimmed clip already matches the post-commit re-measure
+ * (no resize snap on release, no invisible mid-drag sliver).
  */
 export function slotSizeFor(effectiveSeconds: number, pixelsPerSecond: number, gap: number): number {
-  return effectiveSeconds * pixelsPerSecond + gap;
+  return Math.max(MIN_ITEM_WIDTH, effectiveSeconds * pixelsPerSecond) + gap;
 }
 
 /**


### PR DESCRIPTION
Four small fixes from a full-package review:

- Floor the live trim preview at MIN_ITEM_WIDTH. slotSizeFor now applies the same clickable-minimum floor as the committed layout (widthForIndex), so a near-fully-trimmed clip can no longer shrink to an invisible sliver mid-drag and then snap up to the floored width on release -- the "last preview matches the committed size" invariant holds at the extreme too. The constant moves into virtual-strip-geometry so both paths share it.

- Round media durations at display sites. Pointer trims commit raw pixel-derived floats (deliberately unquantized data); the card label, drag ghost, and keyboard-trim announcement rendered them verbatim ("3.5416666666666665s"). New roundSecondsForDisplay (0.1s) applied at those three sites, replacing trim-handles' private round1. Data and the data-trim-preview test hook stay unrounded.

- Guard the trash chord to exactly Alt+Delete. The Delete branch ran before the shiftKey check, so Alt+Shift+Delete also trashed; a held Shift now leaves the key for the app/browser, matching how the trim branch guards the move grammar. TrashViaKeyboard pins it.

- Copy posterSrcs in buildGraph. It aliased the caller's array while parseCollectionItemNode copies; a caller mutating its own array could change Readonly node data behind the store's back.