### PR TITLE
perf(dnd-collections): gate autoscroll pointermove; quantize pointer …

### DIFF
--- a/packages/ui/dnd-collections/react/trim-gesture.test.ts
+++ b/packages/ui/dnd-collections/react/trim-gesture.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { parseNodeId, type ImageMediaNode, type VideoMediaNode } from "../core/graph";
+import { resolveMove, resolveTrim, TRIM_QUANTUM_SECONDS } from "./trim-gesture";
+
+// Pure-resolver coverage for the pointer trim gesture: quantization to the
+// 0.1s grid and the reducer-shared clamps. The pointer lifecycle
+// (useTrimPointerDrag) is a hook exercised by the stories; the math lives here.
+
+const video = (over: Partial<VideoMediaNode> = {}): VideoMediaNode => ({
+  id: parseNodeId("v"),
+  kind: "media",
+  mediaKind: "video",
+  name: "V",
+  fullDurationSeconds: 10,
+  trimInSeconds: 2,
+  trimOutSeconds: 1,
+  ...over,
+});
+
+const image = (over: Partial<ImageMediaNode> = {}): ImageMediaNode => ({
+  id: parseNodeId("i"),
+  kind: "media",
+  mediaKind: "image",
+  name: "I",
+  durationSeconds: 4,
+  ...over,
+});
+
+describe("resolveTrim quantization", () => {
+  it("snaps a continuous video trim-in delta to the 0.1s grid", () => {
+    // A messy pixel-derived delta (e.g. 37px / 24pps) must not persist raw.
+    const { update, live } = resolveTrim(video(), "left", 1.5416666666666665);
+    expect(update).toEqual({ mediaKind: "video", trimInSeconds: 3.5 });
+    // Effective is derived from the snapped value, so preview == commit.
+    expect(live.trimInSeconds).toBe(3.5);
+    expect(live.effectiveSeconds).toBe(10 - 3.5 - 1);
+  });
+
+  it("snaps a video trim-out (right handle) delta", () => {
+    // Right edge inward (negative delta) trims more off the end.
+    const { update } = resolveTrim(video({ trimOutSeconds: 1 }), "right", -0.9666);
+    expect(update).toEqual({ mediaKind: "video", trimOutSeconds: 2 }); // 1 - (-0.9666) -> 1.9666 -> 2.0
+  });
+
+  it("snaps an image duration delta", () => {
+    const { update } = resolveTrim(image({ durationSeconds: 4 }), "right", 1.2333);
+    expect(update).toEqual({ mediaKind: "image", durationSeconds: 5.2 });
+  });
+
+  it("rounds a sub-half-quantum nudge to no change (reducer then rejects same-position)", () => {
+    const { update } = resolveTrim(video({ trimInSeconds: 2 }), "left", 0.04);
+    expect(update).toEqual({ mediaKind: "video", trimInSeconds: 2 });
+  });
+
+  it("still clamps at the physical limit after snapping", () => {
+    // Over-drag the end far past the source: trim-out clamps to full - trim-in.
+    const { update, live } = resolveTrim(video({ trimInSeconds: 2 }), "right", -100);
+    expect(update).toEqual({ mediaKind: "video", trimOutSeconds: 8 });
+    expect(live.effectiveSeconds).toBe(0);
+  });
+
+  it("does not leave float dust on the grid", () => {
+    const { update } = resolveTrim(image({ durationSeconds: 0 }), "right", 0.3);
+    // 0.30000000000000004 would fail a strict equality on 0.3.
+    expect((update as { durationSeconds: number }).durationSeconds).toBe(0.3);
+  });
+});
+
+describe("resolveMove quantization", () => {
+  it("snaps trim-in while holding the showing duration exactly constant", () => {
+    // full 10, in 2, out 1.5 -> showing 6.5, room 3.5. Drag right +delta
+    // reveals earlier frames (trim-in decreases).
+    const node = video({ trimInSeconds: 2, trimOutSeconds: 1.5 });
+    const { update, live } = resolveMove(node, 0.966); // in -> ~1.034 -> 1.0
+    expect(update).toEqual({ mediaKind: "video", trimInSeconds: 1, trimOutSeconds: 2.5 });
+    expect(live.effectiveSeconds).toBe(6.5); // showing unchanged — the move invariant
+  });
+});
+
+describe("TRIM_QUANTUM_SECONDS", () => {
+  it("is the 0.1s grid the display path also rounds to", () => {
+    expect(TRIM_QUANTUM_SECONDS).toBe(0.1);
+  });
+});

--- a/packages/ui/dnd-collections/react/trim-gesture.ts
+++ b/packages/ui/dnd-collections/react/trim-gesture.ts
@@ -25,6 +25,21 @@ function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(value, max));
 }
 
+// Pointer trims capture CONTINUOUS pixels ((clientX - startX) / pps), so a raw
+// commit stores values like 3.5416666666666665s. Snap the resolved trim to a
+// 0.1s grid so committed durations stay round and match what the UI shows
+// exactly (the display path rounds to the same 0.1s). This is an input-capture
+// decision local to the pointer gesture — the keyboard path already steps whole
+// seconds, and the reducer still owns the physical clamp. A sub-0.05s nudge
+// snaps to no change, which the reducer then rejects as same-position (tiny
+// accidental drags don't create imperceptible trims). `Math.round(x * 10) / 10`
+// avoids the float dust that `Math.round(x / 0.1) * 0.1` leaves behind.
+export const TRIM_QUANTUM_SECONDS = 0.1;
+
+function quantize(seconds: number): number {
+  return Math.round(seconds * 10) / 10;
+}
+
 /** Resolve a TRIM (duration changes): a right handle on every media (image
  *  duration / video trim-out) and a left handle on video (trim-in). Returns
  *  the `update` to commit plus the `live` split to preview. */
@@ -35,9 +50,11 @@ export function resolveTrim(
 ): { update: MediaUpdate; live: LiveTrim } {
   if (node.mediaKind === "video") {
     if (side === "left") {
-      // Left edge inward (right, +delta) trims MORE off the start.
+      // Left edge inward (right, +delta) trims MORE off the start. Snap to the
+      // 0.1s grid, then clamp — effective is DERIVED from the snapped value so
+      // the previewed width and the committed data agree exactly.
       const trimInSeconds = clamp(
-        node.trimInSeconds + deltaSeconds,
+        quantize(node.trimInSeconds + deltaSeconds),
         0,
         node.fullDurationSeconds - node.trimOutSeconds
       );
@@ -53,7 +70,7 @@ export function resolveTrim(
     }
     // Right edge inward (left, -delta) trims MORE off the end.
     const trimOutSeconds = clamp(
-      node.trimOutSeconds - deltaSeconds,
+      quantize(node.trimOutSeconds - deltaSeconds),
       0,
       node.fullDurationSeconds - node.trimInSeconds
     );
@@ -68,7 +85,7 @@ export function resolveTrim(
     };
   }
   // Image: the right edge sets the duration directly (outward = longer).
-  const durationSeconds = Math.max(0, node.durationSeconds + deltaSeconds);
+  const durationSeconds = Math.max(0, quantize(node.durationSeconds + deltaSeconds));
   return {
     update: { mediaKind: "image", durationSeconds },
     live: { side, trimInSeconds: 0, trimOutSeconds: 0, effectiveSeconds: durationSeconds },
@@ -85,7 +102,9 @@ export function resolveMove(
 ): { update: MediaUpdate; live: LiveTrim } {
   const showing = Math.max(0, node.fullDurationSeconds - node.trimInSeconds - node.trimOutSeconds);
   const room = Math.max(0, node.fullDurationSeconds - showing); // trim-in + trim-out
-  const trimInSeconds = clamp(node.trimInSeconds - deltaSeconds, 0, room);
+  // Snap trim-in to the 0.1s grid; trim-out is derived so `showing` (and the
+  // clip width) stays exactly constant — the defining property of a move.
+  const trimInSeconds = clamp(quantize(node.trimInSeconds - deltaSeconds), 0, room);
   const trimOutSeconds = Math.max(0, room - trimInSeconds);
   return {
     update: { mediaKind: "video", trimInSeconds, trimOutSeconds },

--- a/packages/ui/dnd-collections/react/use-edge-autoscroll.ts
+++ b/packages/ui/dnd-collections/react/use-edge-autoscroll.ts
@@ -42,27 +42,43 @@ export function useEdgeAutoScroll(
   // before the user parks at an edge; installing this listener only after
   // `dragging` becomes true would miss that position. Tracking from
   // pointerdown also keeps keyboard drags from inheriting stale mouse data.
+  //
+  // Only `pointerdown` stays bound at rest (press-frequency, cheap); the
+  // high-frequency `pointermove` — which fires on EVERY mouse move even with
+  // no button down, and once per mounted view — is attached lazily on a
+  // primary press and torn down on its release. A drag only ever happens
+  // between a primary down and its up, so the pre-activation position is still
+  // captured; idle mouse movement no longer runs N per-view handlers.
   useEffect(() => {
-    const handleDown = (event: PointerEvent) => {
-      if (!event.isPrimary) return;
-      pointerRef.current = { id: event.pointerId, x: event.clientX, y: event.clientY };
-    };
     const handleMove = (event: PointerEvent) => {
       if (pointerRef.current?.id !== event.pointerId) return;
       pointerRef.current = { id: event.pointerId, x: event.clientX, y: event.clientY };
     };
-    const handleEnd = (event: PointerEvent) => {
-      if (pointerRef.current?.id === event.pointerId) pointerRef.current = null;
-    };
-    window.addEventListener("pointerdown", handleDown, { passive: true });
-    window.addEventListener("pointermove", handleMove, { passive: true });
-    window.addEventListener("pointerup", handleEnd, { passive: true });
-    window.addEventListener("pointercancel", handleEnd, { passive: true });
-    return () => {
-      window.removeEventListener("pointerdown", handleDown);
+    const detachMove = () => {
       window.removeEventListener("pointermove", handleMove);
       window.removeEventListener("pointerup", handleEnd);
       window.removeEventListener("pointercancel", handleEnd);
+    };
+    function handleEnd(event: PointerEvent) {
+      // Only the tracked pointer's own release tears down: a foreign or
+      // non-primary pointer's up must not stop tracking the one we own.
+      if (pointerRef.current?.id !== event.pointerId) return;
+      pointerRef.current = null;
+      detachMove();
+    }
+    const handleDown = (event: PointerEvent) => {
+      if (!event.isPrimary) return;
+      pointerRef.current = { id: event.pointerId, x: event.clientX, y: event.clientY };
+      // addEventListener dedupes identical (type, listener, capture) triples,
+      // so a second primary press before release can't double-bind.
+      window.addEventListener("pointermove", handleMove, { passive: true });
+      window.addEventListener("pointerup", handleEnd, { passive: true });
+      window.addEventListener("pointercancel", handleEnd, { passive: true });
+    };
+    window.addEventListener("pointerdown", handleDown, { passive: true });
+    return () => {
+      window.removeEventListener("pointerdown", handleDown);
+      detachMove();
       pointerRef.current = null;
     };
   }, []);


### PR DESCRIPTION
…trims

Two follow-ups from the review's "things I chased" list:

- useEdgeAutoScroll: attach the high-frequency window `pointermove` only while a primary pointer is down, instead of always. It fires on every mouse move even with no button pressed, once per mounted virtual view; a drag only ever happens between a primary down and its up, so the pre-activation position is still captured while idle mouse movement no longer runs N per-view handlers. Only `pointerdown` (press-frequency) stays bound at rest. Teardown is guarded to the tracked pointer so a foreign/non-primary release can't stop tracking the owned one.

- resolveTrim/resolveMove: snap the committed value to a 0.1s grid. Pointer trims capture continuous pixels ((clientX - startX) / pps), so a raw commit stored 3.5416666666666665s; now durations stay round and match the display exactly (which rounds to the same 0.1s). effective is derived from the snapped value so preview == commit; the reducer still owns the physical clamp, and a sub-0.05s nudge snaps to no change (rejected as same-position). The keyboard path already stepped whole seconds. New trim-gesture.test.ts covers snapping, clamp-after-snap, float-dust, and the move invariant (showing held constant).

All existing story/e2e trim assertions drive whole- or half-second pixel deltas at 24/32 pps, so they already sit on the grid and are unchanged.