### PR TITLE
feat(dnd-collections): consumer item content slot (transparent shell)

### DIFF
--- a/packages/ui/dnd-collections/API.md
+++ b/packages/ui/dnd-collections/API.md
@@ -470,6 +470,7 @@ type DndCollectionsProps = {
   onChange?: (change: CollectionsChange) => void;
   maxHistoryEntries?: number; // cap the undo stack; positive integer, default unbounded
   animateMoves?: boolean;     // post-commit FLIP sweep, default true; one sweep for ALL views
+  components?: CollectionsComponents; // consumer pixels: ItemContent / GhostContent (see "Custom item content")
   children: ReactNode;
 };
 ```
@@ -604,6 +605,57 @@ efficiency mechanism, so a selector that allocates per call defeats it.
 
 ---
 
+## React: custom item content (`react/collections-components.tsx`)
+
+The consumer-content seam: the package owns BEHAVIOR and GEOMETRY (drag
+wiring, selection, trim gestures, aria, indicators, measurement, the card
+box); consumers own PIXELS. `NodeCard` is a visually transparent interaction
+shell that renders a content component inside its button surface —
+`DefaultItemContent` (the stock look, also exported as the reference
+implementation) unless one is registered.
+
+```ts
+type CollectionItemContentProps = Readonly<{
+  id: NodeId;
+  node: CollectionItemNode;   // stable reference — new identity ONLY on a data commit
+  childCount: number;         // collections; 0 for media
+  selected: boolean;
+  rejected: boolean;          // rejection flash — style it or ignore it
+  isDragSource: boolean;      // dimmed-in-place under the drag ghost
+  dragActivation: NodeCardDragActivation; // "handle" overlays an 18px grip bar — leave room
+}>;
+type CollectionItemContentComponent = ComponentType<CollectionItemContentProps>;
+
+type CollectionGhostContentProps = Readonly<{ node: CollectionItemNode; extraCount: number }>;
+type CollectionGhostContentComponent = ComponentType<CollectionGhostContentProps>;
+
+type CollectionsComponents = Readonly<{
+  ItemContent?: CollectionItemContentComponent;  // every card, all views
+  GhostContent?: CollectionGhostContentComponent; // the drag-overlay ghost
+}>;
+```
+
+Register once at the provider (`<DndCollections components={{ ItemContent }}>`)
+— that is what keeps cards and the drag ghost in sync from one place — or per
+view via the `itemContent` prop (which overrides the registry). Resolution:
+per-view `itemContent` → provider registry → `DefaultItemContent`.
+
+Rules, all load-bearing for the efficiency model:
+
+- **Identity-stable**: define components at module scope and wrap them in
+  `React.memo`. An inline definition is a NEW component type per render —
+  React remounts every card's content subtree (a dev warning fires once on
+  churn). The `components` object literal itself may be inline; only the
+  fields must be stable.
+- **Presentational only**: content renders inside a `<button>` — no
+  interactive elements (buttons, links, inputs). Interactivity (selection,
+  drag, trim) is the shell's job; compound primitives for custom interactive
+  placement are a planned escape hatch.
+- Nothing per-frame ever reaches content: every prop is a rarely-changing
+  primitive plus the structurally-shared `node`. Content may subscribe to
+  its own stores — that re-renders only the subscribed content, never the
+  shells (`CustomContentRenderEfficiency` asserts both directions).
+
 ## React: views (`react/node-views.tsx`, `react/history-views.tsx`)
 
 Default views — usable as-is, or as reference implementations for custom
@@ -611,9 +663,9 @@ ones (everything they do goes through the store API above).
 
 | Component | Props | Notes |
 | --- | --- | --- |
-| `CollectionPanels` | `collectionIds?: readonly NodeId[]` | One panel per id (default: the graph's roots). FLIP animation is owned by `<DndCollections animateMoves>`, not here. |
-| `CollectionPanel` | `collectionId: NodeId` | One droppable panel with its cards. |
-| `NodeCard` | `id: NodeId`, `className?: string`, `dragActivation?: NodeCardDragActivation` (`"body" \| "handle" \| "hold"`), `rovingTabIndex?: number`, `trimPixelsPerSecond?: number` | Memoized; id-only state by design — everything dynamic arrives via selectors. `className` is tailwind-merged onto wrapper AND button (sizing overrides beat the `h-24 w-32` defaults; virtual views pass `"h-full w-full"`). `dragActivation`: `"body"` (default) drags instantly from anywhere; `"handle"` renders a top grip bar as the only POINTER activator — the keyboard grab (Enter) stays on the card button in every mode; `"hold"` requires a 250ms press (fast movement is handed to surface gestures). `rovingTabIndex` (0 or -1) is for virtualized views' single-tab-stop roving focus: exactly one mounted card is `0`; it also demotes the grip to `-1` (pointer-only). A finite, positive `trimPixelsPerSecond` enables edge trim handles on media (right = image duration / video trim-out; left = video trim-in); invalid scales are treated as omitted. The card resizes LIVE during the drag when the view provides a `TrimPreview` (VirtualStrip does, via targeted `resizeItem`); without one it still trims, just without live resize. Body clicks always select; ghosts stay card-sized. Draggable + droppable. |
+| `CollectionPanels` | `collectionIds?: readonly NodeId[]`, `itemContent?` | One panel per id (default: the graph's roots). FLIP animation is owned by `<DndCollections animateMoves>`, not here. `itemContent` overrides the provider registry for these panels' cards. |
+| `CollectionPanel` | `collectionId: NodeId`, `itemContent?` | One droppable panel with its cards. |
+| `NodeCard` | `id: NodeId`, `className?: string`, `dragActivation?: NodeCardDragActivation` (`"body" \| "handle" \| "hold"`), `rovingTabIndex?: number`, `trimPixelsPerSecond?: number`, `itemContent?: CollectionItemContentComponent` | A visually transparent interaction shell — pixels come from `itemContent` → the provider registry → `DefaultItemContent` (see "Custom item content"). Memoized; id-only state by design — everything dynamic arrives via selectors. `className` is tailwind-merged onto wrapper AND button (sizing overrides beat the `h-24 w-32` defaults; virtual views pass `"h-full w-full"`). `dragActivation`: `"body"` (default) drags instantly from anywhere; `"handle"` renders a top grip bar as the only POINTER activator — the keyboard grab (Enter) stays on the card button in every mode; `"hold"` requires a 250ms press (fast movement is handed to surface gestures). `rovingTabIndex` (0 or -1) is for virtualized views' single-tab-stop roving focus: exactly one mounted card is `0`; it also demotes the grip to `-1` (pointer-only). A finite, positive `trimPixelsPerSecond` enables edge trim handles on media (right = image duration / video trim-out; left = video trim-in); invalid scales are treated as omitted. The card resizes LIVE during the drag when the view provides a `TrimPreview` (VirtualStrip does, via targeted `resizeItem`); without one it still trims, just without live resize. Body clicks always select; ghosts stay card-sized. Draggable + droppable. |
 | `NodeCardGhost` | `node: CollectionItemNode`, `extraCount: number` | The drag-overlay ghost; renders a `+N` badge when `extraCount > 0`. |
 | `UndoRedoControls` | — | Buttons bound to `store.undo`/`store.redo`, disabled off `canUndo`/`canRedo`. Announces "Change undone." / "Change redone." through the instance live region (best-effort: silent under bare `CollectionsStoreProvider` hosting). |
 | `HistoryLog` | — | Human-readable command log over `historyEntries`. |
@@ -676,6 +728,7 @@ type VirtualStripProps = {
   panToScroll?: boolean;                                 // default true — drag the surface to scroll, with momentum
   itemDragActivation?: "handle" | "hold";                // default "handle" (grip bar); "hold" = press-and-hold the body. Ignored when panToScroll is off (bodies drag instantly)
   trimPixelsPerSecond?: number;                          // enable media trim handles; set to your itemWidthFor scale. The card resizes LIVE during the drag (targeted resizeItem, no re-measure) and commits update-media on release
+  itemContent?: CollectionItemContentComponent;          // per-view card pixels; overrides the provider registry
   className?: string;
 };
 type VirtualStripHandle = {
@@ -715,6 +768,7 @@ type VirtualGridProps = {
   columns?: number;     // fixed count; omit to derive responsively from width. Non-positive-integer values fall back to responsive
   overscan?: number;    // default 2 (rows)
   height?: number;      // default 480 — scroll viewport height
+  itemContent?: CollectionItemContentComponent; // per-view card pixels; overrides the provider registry
   className?: string;
 };
 type VirtualGridHandle = {

--- a/packages/ui/dnd-collections/ARCHITECTURE.md
+++ b/packages/ui/dnd-collections/ARCHITECTURE.md
@@ -270,14 +270,29 @@ stream. The design answer has three layers:
    dispatch/undo/redo — never rebuilt per interaction notify), and
    no-op updates (`setSelection` with the same set, an unchanged
    `DropIntent`) don't notify at all.
-3. **Id-only card props.** `NodeCard` is `memo` and receives just `id`;
-   every dynamic value (node data, selection, drag-source dimming, drop
-   side, nest state) arrives through selectors returning primitives or
-   stable references. A drag over one card re-renders that card alone.
+3. **Id-only card props.** `NodeCard` is `memo` and receives just `id`
+   (plus identity-stable configuration); every dynamic value (node data,
+   selection, drag-source dimming, drop side, nest state) arrives through
+   selectors returning primitives or stable references. A drag over one
+   card re-renders that card alone.
+4. **A shell/content component boundary.** `NodeCard` is a visually
+   TRANSPARENT interaction shell — it owns behavior and geometry (drag/drop
+   wiring, selection, aria, trim handles, indicators, the card box) and
+   paints nothing. Pixels come from a memoized content component
+   (`DefaultItemContent`, or a consumer's via the provider `components`
+   registry / per-view `itemContent`), rendered with the node plus
+   rarely-changing primitives only. Because the optimization is the
+   component boundary — not the shell's hooks — consumer content inherits
+   the whole efficiency story for free, and a consumer's own store
+   subscriptions re-render only their content, never the shells. Content
+   components must be identity-stable (module scope): a new component type
+   per render REMOUNTS every card's content subtree.
 
 This is asserted, not aspirational: cards expose `data-render-count`, and
 the `RenderEfficiencyDuringDrag` story fails if a bystander card re-renders
-during mid-drag pointer jitter.
+during mid-drag pointer jitter — `CustomContentRenderEfficiency` repeats the
+assertion with consumer content and a consumer-owned external store, in both
+directions.
 
 ## dnd-kit integration decisions
 

--- a/packages/ui/dnd-collections/CLAUDE.md
+++ b/packages/ui/dnd-collections/CLAUDE.md
@@ -41,6 +41,13 @@ Repo-wide rules live in the root CLAUDE.md and `packages/ui/AGENTS.md`.
 - **Preview validity must equal commit outcome.** `isIntentInvalid` and the
   reducer enforce the same cycle rule; if you change one, change both (they
   share `isSameOrAncestor` — keep it that way).
+- **The shell/content boundary is the customization seam.** `NodeCard` is a
+  visually transparent interaction shell; ALL pixels live in the content
+  component (`DefaultItemContent` or a consumer's, via the provider
+  `components` registry / per-view `itemContent`). Never paint in the shell,
+  never move behavior (wiring, aria, trim handles, listener placement) into
+  content, and keep content components identity-stable — an inline component
+  definition remounts every card's content per render.
 - **Displaced siblings don't re-render**, so per-card effects never fire for
   the cards a commit moved — that's why FLIP is a single graph-identity
   sweep in `use-flip-graph-animation.ts`. Don't convert it to per-card

--- a/packages/ui/dnd-collections/CustomItemContent.stories.tsx
+++ b/packages/ui/dnd-collections/CustomItemContent.stories.tsx
@@ -1,0 +1,399 @@
+import { memo, useRef, useSyncExternalStore } from "react";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, userEvent, waitFor } from "storybook/test";
+
+import {
+  buildGraph,
+  mediaDurationSeconds,
+  parseNodeId,
+  type GraphNodeSpec,
+} from "./core/graph";
+import { DndCollections } from "./react/DndCollections";
+import {
+  type CollectionGhostContentProps,
+  type CollectionItemContentProps,
+} from "./react/collections-components";
+import { CollectionPanels } from "./react/node-views";
+import { VirtualStrip } from "./virtual/VirtualStrip";
+import {
+  dragHoldAt,
+  moveHeldPointer,
+  nodeCard,
+  panelOrder,
+  rectPoint,
+  releaseAt,
+  waitForLayout,
+} from "./stories-helpers";
+
+// The consumer-content seam, exercised the way a real consumer would use it:
+// module-scope memoized components registered on the provider (or per view),
+// receiving only the node + rarely-changing primitives. The efficiency
+// story is asserted in BOTH directions: drag jitter re-renders neither the
+// bystander shell nor its content, and a consumer's own external store
+// re-renders only the subscribed CONTENT, never the shells.
+
+const media = (id: string, name = id.toUpperCase()): GraphNodeSpec => ({
+  kind: "media",
+  id,
+  name,
+  durationSeconds: 4,
+});
+const collection = (
+  id: string,
+  name: string,
+  children: readonly GraphNodeSpec[] = []
+): GraphNodeSpec => ({ kind: "collection", id, name, children });
+
+function graphOrThrow(roots: readonly GraphNodeSpec[]) {
+  const result = buildGraph(roots);
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.value;
+}
+
+const meta = {
+  title: "UI/DndCollectionsCustomItemContent",
+  decorators: [
+    (Story) => (
+      <div className="min-h-screen bg-background p-8 text-foreground">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ── Timeline lookalike: the app-style clip card, built as consumer pixels ──
+
+const clipFrames = [
+  new URL("./fixtures/dog-tracking-2s.png", import.meta.url).href,
+  new URL("./fixtures/dog-exit-4s.png", import.meta.url).href,
+] as const;
+
+const CLIP_PPS = 24;
+
+/** App-style clip: filmstrip fill, VIDEO badge + amber frame when selected,
+ *  showing/full readout pill — all consumer-owned pixels. */
+const TimelineClipContent = memo(function TimelineClipContent({
+  node,
+  childCount,
+  selected,
+  isDragSource,
+}: CollectionItemContentProps) {
+  if (node.kind !== "media") {
+    return (
+      <span className="flex h-full w-full items-center justify-center rounded-md border border-border bg-muted/60 text-xs">
+        {node.name} · {childCount}
+      </span>
+    );
+  }
+  const showing = mediaDurationSeconds(node);
+  const full = node.mediaKind === "video" ? node.fullDurationSeconds : showing;
+  const posters = node.mediaKind === "video" ? (node.posterSrcs ?? []) : node.src ? [node.src] : [];
+  const frames = Math.max(1, Math.min(6, Math.round(showing / 2)));
+  return (
+    <span
+      data-timeline-clip={selected ? "selected" : "idle"}
+      className={[
+        "relative flex h-full w-full overflow-hidden rounded-md",
+        selected ? "ring-4 ring-amber-400" : "ring-1 ring-border",
+        isDragSource ? "opacity-40" : "",
+      ].join(" ")}
+    >
+      <span className="flex h-full w-full bg-zinc-900">
+        {Array.from({ length: frames }).map((_, i) => (
+          <img
+            key={i}
+            src={posters[i % Math.max(1, posters.length)]}
+            alt=""
+            draggable={false}
+            className="h-full min-w-0 flex-1 border-r border-black/60 object-cover last:border-r-0"
+          />
+        ))}
+      </span>
+      {selected && (
+        <span
+          data-timeline-clip-badge
+          className="absolute top-1 left-1 rounded bg-black/80 px-1.5 py-0.5 text-[9px] font-bold tracking-wide text-amber-300"
+        >
+          VIDEO
+        </span>
+      )}
+      <span className="absolute right-1 bottom-1 rounded bg-black/75 px-1.5 py-0.5 font-mono text-[9px] text-zinc-100 tabular-nums">
+        {showing.toFixed(2)}s / {full.toFixed(2)}s
+      </span>
+    </span>
+  );
+});
+
+function timelineGraph() {
+  return graphOrThrow([
+    {
+      kind: "collection",
+      id: "strip",
+      name: "Timeline",
+      children: [
+        { kind: "media", id: "intro", name: "Intro", src: clipFrames[0], durationSeconds: 3 },
+        {
+          kind: "media",
+          mediaKind: "video",
+          id: "vid",
+          name: "Vid",
+          posterSrcs: clipFrames,
+          fullDurationSeconds: 10,
+          trimInSeconds: 2,
+          trimOutSeconds: 1,
+        },
+        { kind: "media", id: "outro", name: "Outro", src: clipFrames[1], durationSeconds: 4 },
+      ],
+    },
+  ]);
+}
+
+export const TimelineLookalike: Story = {
+  // The end goal, as a story: consumer pixels dictate the entire card look
+  // (filmstrip, selection chrome, readout pill) while the package keeps
+  // widths-from-duration, trimming, selection, and drag behavior.
+  render: () => (
+    <DndCollections initialGraph={timelineGraph()} animateMoves={false}>
+      <div className="w-[640px] pt-10">
+        <VirtualStrip
+          collectionId={parseNodeId("strip")}
+          itemContent={TimelineClipContent}
+          itemDragActivation="hold"
+          itemWidthFor={(node) =>
+            node.kind === "media" ? mediaDurationSeconds(node) * CLIP_PPS : undefined
+          }
+          trimPixelsPerSecond={CLIP_PPS}
+        />
+      </div>
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    const vid = nodeCard(canvasElement, "vid");
+    await waitForLayout(vid);
+
+    // Widths still come from duration: vid shows 7s at 24 px/s.
+    expect(Math.round(vid.getBoundingClientRect().width)).toBe(7 * CLIP_PPS);
+    // Consumer pixels render inside the shell: pill + idle chrome.
+    expect(vid.querySelector("[data-timeline-clip]")).toHaveAttribute(
+      "data-timeline-clip",
+      "idle"
+    );
+    expect(vid.textContent).toContain("7.00s / 10.00s");
+    expect(vid.querySelector("[data-timeline-clip-badge]")).toBeNull();
+
+    // Selection is still shell behavior; the BADGE is consumer pixels.
+    const user = userEvent.setup();
+    await user.click(vid);
+    await waitFor(() => {
+      expect(nodeCard(canvasElement, "vid")).toHaveAttribute("data-selected", "true");
+      expect(vid.querySelector("[data-timeline-clip-badge]")).not.toBeNull();
+    });
+
+    // Package-owned trim handles coexist with consumer pixels (siblings of
+    // the button, so they never live inside the consumer's markup).
+    const wrapper = vid.closest("[data-node-wrapper]")!;
+    expect(wrapper.querySelector('[data-trim-handle="left"]')).not.toBeNull();
+    expect(wrapper.querySelector('[data-trim-handle="right"]')).not.toBeNull();
+  },
+};
+
+// ── Render efficiency with consumer content + a consumer store ─────────────
+
+function createTicker() {
+  let value = 0;
+  const listeners = new Set<() => void>();
+  return {
+    get: () => value,
+    bump: () => {
+      value += 1;
+      for (const listener of listeners) listener();
+    },
+    subscribe: (listener: () => void) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}
+const ticker = createTicker();
+
+/** Consumer-style content with its OWN render probe and its own external
+ *  store subscription — the shape of a real app card. */
+const ProbedContent = memo(function ProbedContent({
+  node,
+  selected,
+}: CollectionItemContentProps) {
+  const renders = useRef(0);
+  renders.current += 1;
+  const tick = useSyncExternalStore(ticker.subscribe, ticker.get, ticker.get);
+  return (
+    <span
+      data-content-render-count={renders.current}
+      className={[
+        "flex h-full w-full flex-col justify-between rounded-md border p-2 text-xs",
+        selected ? "border-primary ring-2 ring-primary" : "border-border bg-background",
+      ].join(" ")}
+    >
+      <span className="truncate">{node.name}</span>
+      <span data-content-tick className="text-[10px] text-muted-foreground">
+        tick {tick}
+      </span>
+    </span>
+  );
+});
+
+const efficiencyGraph = () =>
+  graphOrThrow([
+    collection(
+      "panel-wide",
+      "Wide Panel",
+      Array.from({ length: 24 }, (_, i) => media(`w${i}`, `W${i}`))
+    ),
+    collection("panel-target", "Target Panel", [media("t1", "T1")]),
+  ]);
+
+export const CustomContentRenderEfficiency: Story = {
+  // The efficiency guarantee survives consumer content, asserted BOTH ways:
+  // (1) drag jitter re-renders neither a bystander's shell nor its content;
+  // (2) the consumer's own store update re-renders only the subscribed
+  // content — every shell render count stays frozen.
+  render: () => (
+    <DndCollections
+      initialGraph={efficiencyGraph()}
+      animateMoves={false}
+      components={{ ItemContent: ProbedContent }}
+    >
+      <CollectionPanels />
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    const source = nodeCard(canvasElement, "w0");
+    const target = nodeCard(canvasElement, "t1");
+    const bystander = nodeCard(canvasElement, "w12");
+    await waitForLayout(target);
+    const bystanderContent = () =>
+      bystander.querySelector<HTMLElement>("[data-content-render-count]")!;
+
+    // Hold a live drag over the target's left half, settled.
+    await dragHoldAt(source, rectPoint(target, 0.15));
+    const holdPoint = rectPoint(target, 0.15);
+    await moveHeldPointer(holdPoint);
+    await waitFor(() => {
+      expect(target.parentElement?.querySelector('[data-drop-indicator="before"]')).toBeTruthy();
+    });
+
+    const shellBefore = bystander.getAttribute("data-render-count");
+    const contentBefore = bystanderContent().getAttribute("data-content-render-count");
+    // Jitter within the same intent.
+    await moveHeldPointer({ x: holdPoint.x + 3, y: holdPoint.y + 2 });
+    await moveHeldPointer({ x: holdPoint.x - 3, y: holdPoint.y - 2 });
+    await moveHeldPointer({ x: holdPoint.x + 2, y: holdPoint.y + 1 });
+    await moveHeldPointer(holdPoint);
+
+    // (1) Neither the bystander shell nor its consumer content re-rendered.
+    expect(bystander.getAttribute("data-render-count")).toBe(shellBefore);
+    expect(bystanderContent().getAttribute("data-content-render-count")).toBe(contentBefore);
+
+    await releaseAt(holdPoint);
+    await waitFor(() => {
+      expect(panelOrder(canvasElement, "panel-target")).toEqual(["w0", "t1"]);
+    });
+
+    // (2) A consumer-store update re-renders CONTENT only — shells frozen.
+    const shellAfterDrop = bystander.getAttribute("data-render-count");
+    const contentAfterDrop = Number(
+      bystanderContent().getAttribute("data-content-render-count")
+    );
+    const tickTextBefore = bystanderContent().querySelector("[data-content-tick]")!.textContent;
+    ticker.bump();
+    await waitFor(() => {
+      expect(
+        Number(bystanderContent().getAttribute("data-content-render-count"))
+      ).toBeGreaterThan(contentAfterDrop);
+      expect(
+        bystanderContent().querySelector("[data-content-tick]")!.textContent
+      ).not.toBe(tickTextBefore);
+    });
+    expect(bystander.getAttribute("data-render-count")).toBe(shellAfterDrop);
+  },
+};
+
+// ── Ghost slot + resolution order ───────────────────────────────────────────
+
+const CustomGhost = memo(function CustomGhost({ node, extraCount }: CollectionGhostContentProps) {
+  return (
+    <span
+      data-testid="custom-ghost"
+      className="flex h-full w-full items-center justify-center rounded-md bg-amber-400 text-xs font-bold text-black"
+    >
+      {node.name}
+      {extraCount > 0 ? ` +${extraCount}` : ""}
+    </span>
+  );
+});
+
+const RegistryContent = memo(function RegistryContent({ node }: CollectionItemContentProps) {
+  return (
+    <span data-content-variant="registry" className="flex h-full w-full items-center rounded-md border border-border p-2 text-xs">
+      {node.name}
+    </span>
+  );
+});
+
+const OverrideContent = memo(function OverrideContent({ node }: CollectionItemContentProps) {
+  return (
+    <span data-content-variant="override" className="flex h-full w-full items-center rounded-md border border-primary p-2 text-xs">
+      {node.name}
+    </span>
+  );
+});
+
+export const GhostAndOverrideResolution: Story = {
+  // One provider: the registry supplies ItemContent + GhostContent; the
+  // strip's per-view itemContent overrides the registry; panels fall back
+  // to the registry. The drag ghost renders the registered GhostContent.
+  render: () => (
+    <DndCollections
+      initialGraph={graphOrThrow([
+        collection("panel-a", "Panel A", [media("alpha"), media("bravo")]),
+        collection("strip", "Strip", [media("s1"), media("s2")]),
+      ])}
+      animateMoves={false}
+      components={{ ItemContent: RegistryContent, GhostContent: CustomGhost }}
+    >
+      <div className="flex w-[640px] flex-col gap-4">
+        <CollectionPanels collectionIds={[parseNodeId("panel-a")]} />
+        <VirtualStrip collectionId={parseNodeId("strip")} itemContent={OverrideContent} />
+      </div>
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    const alpha = nodeCard(canvasElement, "alpha");
+    await waitForLayout(alpha);
+    await waitForLayout(nodeCard(canvasElement, "s1"));
+
+    // Resolution order: per-view override beats the registry; the registry
+    // beats the default.
+    expect(alpha.querySelector('[data-content-variant="registry"]')).not.toBeNull();
+    expect(
+      nodeCard(canvasElement, "s1").querySelector('[data-content-variant="override"]')
+    ).not.toBeNull();
+
+    // The drag overlay renders the registered ghost pixels.
+    const bravo = nodeCard(canvasElement, "bravo");
+    await dragHoldAt(alpha, rectPoint(bravo, 0.85));
+    await waitFor(() => {
+      expect(
+        canvasElement.ownerDocument.querySelector('[data-testid="custom-ghost"]')
+      ).not.toBeNull();
+    });
+    await releaseAt(rectPoint(bravo, 0.85));
+    await waitFor(() => {
+      expect(panelOrder(canvasElement, "panel-a")).toEqual(["bravo", "alpha"]);
+    });
+  },
+};

--- a/packages/ui/dnd-collections/index.ts
+++ b/packages/ui/dnd-collections/index.ts
@@ -102,6 +102,18 @@ export {
   NodeCardGhost,
   type NodeCardDragActivation,
 } from "./react/node-views";
+// Consumer item pixels: register ItemContent/GhostContent on <DndCollections
+// components> (or per view via itemContent) — the package keeps behavior and
+// geometry, consumers keep the visible card. DefaultItemContent is the stock
+// look and the reference implementation for custom content.
+export {
+  type CollectionGhostContentComponent,
+  type CollectionGhostContentProps,
+  type CollectionItemContentComponent,
+  type CollectionItemContentProps,
+  type CollectionsComponents,
+} from "./react/collections-components";
+export { DefaultItemContent } from "./react/default-item-content";
 export { HistoryLog, UndoRedoControls } from "./react/history-views";
 export { PaletteItem, type PaletteItemProps } from "./react/palette";
 export { TrashTarget } from "./react/trash-target";

--- a/packages/ui/dnd-collections/react/DndCollections.tsx
+++ b/packages/ui/dnd-collections/react/DndCollections.tsx
@@ -45,6 +45,12 @@ import {
   type CollectionsChange,
   type CollectionsStore,
 } from "./collections-store";
+import {
+  CollectionsComponentsContext,
+  useCollectionsComponents,
+  useCollectionsComponentsValue,
+  type CollectionsComponents,
+} from "./collections-components";
 import { CollectionsContainerContext } from "./container-context";
 import { useFlipGraphAnimation } from "./use-flip-graph-animation";
 import { NodeCardGhost } from "./node-views";
@@ -76,6 +82,14 @@ export type DndCollectionsProps = Readonly<{
    * panels, virtual, and custom views. Honors `prefers-reduced-motion`.
    */
   animateMoves?: boolean;
+  /**
+   * Consumer pixels: `ItemContent` replaces every card's visible content
+   * (panels and virtual views alike; per-view `itemContent` props override
+   * it), `GhostContent` replaces the drag-overlay ghost. Registering here —
+   * rather than per card — is what keeps the ghost and the cards in sync
+   * from one place. Components MUST be identity-stable (module scope).
+   */
+  components?: CollectionsComponents;
   children: ReactNode;
 }>;
 
@@ -137,8 +151,10 @@ export function DndCollections({
   onChange,
   maxHistoryEntries,
   animateMoves = true,
+  components,
   children,
 }: DndCollectionsProps) {
+  const componentsValue = useCollectionsComponentsValue(components);
   // The store captures its options once, but callback props must stay fresh
   // — a parent passing an inline closure over its latest state expects that
   // version to be called. Route through a ref, updated in a layout effect
@@ -166,7 +182,9 @@ export function DndCollections({
 
   return (
     <CollectionsStoreProvider value={store}>
-      <DndCollectionsContext animateMoves={animateMoves}>{children}</DndCollectionsContext>
+      <CollectionsComponentsContext.Provider value={componentsValue}>
+        <DndCollectionsContext animateMoves={animateMoves}>{children}</DndCollectionsContext>
+      </CollectionsComponentsContext.Provider>
     </CollectionsStoreProvider>
   );
 }
@@ -546,8 +564,11 @@ function CollectionsDragOverlay({
   );
   const node = paletteNodes?.[0] ?? primaryNode;
   const extraCount = Math.max(0, (paletteNodes ? paletteNodes.length : activeIds.length) - 1);
+  // Consumer ghost pixels, falling back to the stock ghost — registered at
+  // the provider so cards and their drag preview stay in sync in one place.
+  const GhostContent = useCollectionsComponents().GhostContent ?? NodeCardGhost;
 
   return (
-    <DragOverlay>{node ? <NodeCardGhost node={node} extraCount={extraCount} /> : null}</DragOverlay>
+    <DragOverlay>{node ? <GhostContent node={node} extraCount={extraCount} /> : null}</DragOverlay>
   );
 }

--- a/packages/ui/dnd-collections/react/collections-components.tsx
+++ b/packages/ui/dnd-collections/react/collections-components.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  type ComponentType,
+} from "react";
+
+import { type CollectionItemNode, type NodeId } from "../core/graph";
+
+// The consumer-content seam: dnd-collections owns BEHAVIOR and GEOMETRY
+// (drag wiring, selection, trim gestures, aria, measurement, indicators);
+// consumers own PIXELS. The shell (`NodeCard`) renders a registered content
+// component inside its interactive surface and hands it the node plus a few
+// rarely-changing primitives — nothing per-frame ever reaches content, so a
+// drag over one card still re-renders that card alone.
+//
+// Components are registered ONCE at the provider (or per view) and MUST be
+// identity-stable — defined at module scope, not inline. An inline
+// definition creates a new component type per render; React then unmounts
+// and remounts every card's content subtree (component identity, not just
+// memo, is what's at stake). `useCollectionsComponentsValue` warns when it
+// sees churn.
+
+/** How item drags start on a card — see NodeCard's prop docs. */
+export type NodeCardDragActivation = "body" | "handle" | "hold";
+
+export type CollectionItemContentProps = Readonly<{
+  id: NodeId;
+  /** Stable reference — new identity ONLY on a data commit to this node. */
+  node: CollectionItemNode;
+  /** Live child count for collections; 0 for media. */
+  childCount: number;
+  selected: boolean;
+  /** Rejection flash (a refused drop) — the default content pulses a ring. */
+  rejected: boolean;
+  /** This card is being dragged (it sits dimmed in place under the ghost). */
+  isDragSource: boolean;
+  /**
+   * The card's drag-activation mode. Layout fact your pixels may need: in
+   * "handle" mode the shell overlays an 18px grip bar across the top of the
+   * card — leave room for it (the default content pads its top).
+   */
+  dragActivation: NodeCardDragActivation;
+}>;
+
+/**
+ * A consumer item renderer. Rendered INSIDE the card's <button> surface, so
+ * it must be presentational: no interactive elements (buttons, links,
+ * inputs) — interactivity belongs to the shell (selection, drag, trim).
+ * Wrap it in `React.memo` and define it at module scope.
+ */
+export type CollectionItemContentComponent = ComponentType<CollectionItemContentProps>;
+
+export type CollectionGhostContentProps = Readonly<{
+  /** The primary dragged node (pressed card / palette factory result). */
+  node: CollectionItemNode;
+  /** How many MORE items ride the drag (multi-drag) — 0 for a single item. */
+  extraCount: number;
+}>;
+
+/** The drag-overlay ghost renderer. Fills a wrapper dnd-kit sizes to the
+ *  dragged card's measured rect, so the ghost matches the real display
+ *  width — fixed OR variable (virtual strips). */
+export type CollectionGhostContentComponent = ComponentType<CollectionGhostContentProps>;
+
+export type CollectionsComponents = Readonly<{
+  /** Replaces the card pixels everywhere (panels, virtual views). Per-view
+   *  `itemContent` props override this registry entry. */
+  ItemContent?: CollectionItemContentComponent;
+  /** Replaces the drag-overlay ghost pixels. */
+  GhostContent?: CollectionGhostContentComponent;
+}>;
+
+const EMPTY_COMPONENTS: CollectionsComponents = {};
+
+export const CollectionsComponentsContext =
+  createContext<CollectionsComponents>(EMPTY_COMPONENTS);
+
+export function useCollectionsComponents(): CollectionsComponents {
+  return useContext(CollectionsComponentsContext);
+}
+
+let warnedUnstableComponents = false;
+
+/**
+ * Normalizes the provider's `components` prop into a context value whose
+ * identity follows the FIELD identities (an inline `components={{ ... }}`
+ * object literal per render is fine as long as the components themselves are
+ * stable). Warns once if a component identity churns between renders — that
+ * remounts every card's content subtree and defeats memoization.
+ */
+export function useCollectionsComponentsValue(
+  components?: CollectionsComponents
+): CollectionsComponents {
+  const ItemContent = components?.ItemContent;
+  const GhostContent = components?.GhostContent;
+  const value = useMemo<CollectionsComponents>(
+    () => (ItemContent || GhostContent ? { ItemContent, GhostContent } : EMPTY_COMPONENTS),
+    [ItemContent, GhostContent]
+  );
+
+  const previousRef = useRef(value);
+  useEffect(() => {
+    const previous = previousRef.current;
+    previousRef.current = value;
+    if (warnedUnstableComponents || previous === value) return;
+    const churned =
+      (previous.ItemContent && value.ItemContent && previous.ItemContent !== value.ItemContent) ||
+      (previous.GhostContent && value.GhostContent && previous.GhostContent !== value.GhostContent);
+    if (churned) {
+      warnedUnstableComponents = true;
+      console.warn(
+        "dnd-collections: a `components` entry changed identity between renders. " +
+          "Define ItemContent/GhostContent at module scope (a new component type per " +
+          "render remounts every card's content and defeats memoization)."
+      );
+    }
+  }, [value]);
+
+  return value;
+}

--- a/packages/ui/dnd-collections/react/default-item-content.tsx
+++ b/packages/ui/dnd-collections/react/default-item-content.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { memo } from "react";
+
+import { mediaDurationSeconds } from "../core/graph";
+import { type CollectionItemContentProps } from "./collections-components";
+import { roundSecondsForDisplay } from "./duration-format";
+import { NodeThumbnail } from "./node-thumbnail";
+
+// The package's stock card pixels — thumbnail, name, duration/child-count
+// label, selection ring, rejection flash, drag-source dimming — extracted
+// from NodeCard so consumers can swap in their own. This is also the
+// reference implementation for custom content: memoized, presentational
+// (spans only — it renders inside a <button>), and driven entirely by the
+// contract props. The card BOX (sizing, border-box position) belongs to the
+// shell; this fills it and paints everything visible.
+
+export const DefaultItemContent = memo(function DefaultItemContent({
+  node,
+  childCount,
+  selected,
+  rejected,
+  isDragSource,
+  dragActivation,
+}: CollectionItemContentProps) {
+  const isCollection = node.kind === "collection";
+  return (
+    // A span (display:flex) because content renders inside a <button>, where
+    // only phrasing content is valid HTML.
+    <span
+      className={[
+        "flex h-full w-full flex-col items-stretch justify-between rounded-md border p-2 text-left text-xs transition-all",
+        // Leave room for the shell's grip bar overlay in handle mode.
+        dragActivation === "handle" ? "pt-6" : "",
+        isCollection ? "bg-muted/60" : "bg-background",
+        selected ? "border-primary ring-2 ring-primary" : "border-border",
+        // Static red ring is the always-on rejection cue; the pulse is
+        // motion-gated so reduced-motion users still get the ring, no throb.
+        rejected ? "border-destructive ring-2 ring-destructive motion-safe:animate-pulse" : "",
+        // Dragged cards sit dimmed in place under the ghost.
+        isDragSource ? "opacity-40" : "",
+      ].join(" ")}
+    >
+      {node.kind === "media" ? (
+        <>
+          <NodeThumbnail node={node} />
+          <span className="mt-1 flex items-center justify-between gap-1">
+            <span className="truncate font-medium text-foreground">{node.name}</span>
+            <span className="shrink-0 text-[10px] text-muted-foreground">
+              {roundSecondsForDisplay(mediaDurationSeconds(node))}s
+            </span>
+          </span>
+        </>
+      ) : (
+        <>
+          <span className="truncate font-medium text-foreground">{node.name}</span>
+          <span className="text-[10px] text-muted-foreground">
+            Collection · {childCount} items
+          </span>
+        </>
+      )}
+    </span>
+  );
+});

--- a/packages/ui/dnd-collections/react/node-views.tsx
+++ b/packages/ui/dnd-collections/react/node-views.tsx
@@ -1,52 +1,73 @@
 "use client";
 
-import { memo, useCallback, useRef, type CSSProperties, type MouseEvent } from "react";
+import { memo, useCallback, useRef, type MouseEvent } from "react";
 import { useDraggable, useDroppable } from "@dnd-kit/core";
 import { twMerge } from "tailwind-merge";
 
-import {
-  getChildren,
-  mediaDurationSeconds,
-  type CollectionItemNode,
-  type NodeId,
-} from "../core/graph";
+import { getChildren, mediaDurationSeconds, type NodeId } from "../core/graph";
 import { encodeDropTarget } from "../core/intents";
 import { finitePositiveOrUndefined } from "../core/numeric";
+import {
+  useCollectionsComponents,
+  type CollectionGhostContentProps,
+  type CollectionItemContentComponent,
+  type NodeCardDragActivation,
+} from "./collections-components";
 import { useCollectionsSelector, useCollectionsStore } from "./collections-store";
 import { useCollectionsContainer } from "./container-context";
+import { DefaultItemContent } from "./default-item-content";
 import { roundSecondsForDisplay } from "./duration-format";
-import { NodeThumbnail } from "./node-thumbnail";
 import { TrimHandles } from "./trim-handles";
 
-// Default views. Each NodeCard receives ONLY its id — every dynamic value
-// arrives through selector subscriptions returning primitives (or stable
-// graph references), so a drag over one card re-renders that card alone.
-// `memo` + constant props means parents mapping stable children arrays
-// don't re-render cards either. The data-render-count attribute makes this
-// efficiency claim assertable in tests instead of aspirational.
+// Default views. Each NodeCard receives ONLY its id (plus identity-stable
+// configuration) — every dynamic value arrives through selector
+// subscriptions returning primitives (or stable graph references), so a drag
+// over one card re-renders that card alone. `memo` + constant props means
+// parents mapping stable children arrays don't re-render cards either. The
+// data-render-count attribute makes this efficiency claim assertable in
+// tests instead of aspirational.
+//
+// NodeCard is a visually TRANSPARENT interaction shell: it owns behavior and
+// geometry (drag/drop wiring, selection, aria, trim handles, indicators,
+// the card box) and paints nothing. Pixels come from a content component —
+// `DefaultItemContent` unless the consumer registered one (provider
+// `components` / per-view `itemContent`) — rendered inside the card button
+// with rarely-changing props only, so custom content inherits the whole
+// efficiency story.
 //
 // FLIP movement animation is NOT owned here — it is a provider-level sweep
 // (see DndCollections `animateMoves`) so one pass animates panels, virtual,
 // and custom views together.
 
+export type { NodeCardDragActivation } from "./collections-components";
+
 export type CollectionPanelsProps = Readonly<{
   /** Which collections to render as top-level panels. Defaults to the graph's roots. */
   collectionIds?: readonly NodeId[];
+  /** Per-view card pixels — overrides the provider `components` registry. */
+  itemContent?: CollectionItemContentComponent;
 }>;
 
-export function CollectionPanels({ collectionIds }: CollectionPanelsProps) {
+export function CollectionPanels({ collectionIds, itemContent }: CollectionPanelsProps) {
   const rootIds = useCollectionsSelector((s) => s.graph.rootIds);
   const panelIds = collectionIds ?? rootIds;
   return (
     <div className="flex flex-col gap-6">
       {panelIds.map((id) => (
-        <CollectionPanel key={id} collectionId={id} />
+        <CollectionPanel key={id} collectionId={id} itemContent={itemContent} />
       ))}
     </div>
   );
 }
 
-export function CollectionPanel({ collectionId }: { collectionId: NodeId }) {
+export function CollectionPanel({
+  collectionId,
+  itemContent,
+}: {
+  collectionId: NodeId;
+  /** Per-view card pixels — overrides the provider `components` registry. */
+  itemContent?: CollectionItemContentComponent;
+}) {
   const name = useCollectionsSelector(
     (s) => s.graph.nodesById.get(collectionId)?.name ?? String(collectionId)
   );
@@ -88,14 +109,12 @@ export function CollectionPanel({ collectionId }: { collectionId: NodeId }) {
             Drop items here
           </p>
         ) : (
-          childIds.map((id) => <NodeCard key={id} id={id} />)
+          childIds.map((id) => <NodeCard key={id} id={id} itemContent={itemContent} />)
         )}
       </div>
     </section>
   );
 }
-
-export type NodeCardDragActivation = "body" | "handle" | "hold";
 
 function joinAriaIds(...ids: readonly (string | undefined)[]): string | undefined {
   const joined = ids.filter((id): id is string => !!id).join(" ");
@@ -108,6 +127,7 @@ export const NodeCard = memo(function NodeCard({
   dragActivation = "body",
   rovingTabIndex,
   trimPixelsPerSecond,
+  itemContent,
 }: {
   id: NodeId;
   /**
@@ -116,6 +136,12 @@ export const NodeCard = memo(function NodeCard({
    * "h-full w-full" to make cards fill their (possibly variable) slot.
    */
   className?: string;
+  /**
+   * Per-card pixels — overrides the provider `components` registry, falls
+   * back to `DefaultItemContent`. MUST be identity-stable (module scope): a
+   * new component type per render remounts the content subtree.
+   */
+  itemContent?: CollectionItemContentComponent;
   /**
    * How item drags start on this card:
    * - "body" (default): instant drag from anywhere on the card.
@@ -149,6 +175,10 @@ export const NodeCard = memo(function NodeCard({
   const trimScale = finitePositiveOrUndefined(trimPixelsPerSecond);
   const store = useCollectionsStore();
   const { instructionsId } = useCollectionsContainer();
+  // Pixels: per-card override → provider registry → the stock look.
+  // (Hook called unconditionally — `??` would skip it and break hook order.)
+  const registeredContent = useCollectionsComponents().ItemContent;
+  const ItemContent = itemContent ?? registeredContent ?? DefaultItemContent;
 
   // nodesById is never re-allocated by move patches, so this reference is
   // stable across drags — the selector only "changes" if the node itself does.
@@ -213,15 +243,15 @@ export const NodeCard = memo(function NodeCard({
   if (!node) return null;
 
   const isCollection = node.kind === "collection";
-  const style: CSSProperties | undefined =
-    isDragging || isDragSource ? { opacity: 0.4 } : undefined;
 
   return (
     <div className={twMerge("group relative", className)} data-node-wrapper={id}>
+      {/* The transparent interaction shell: sizing, cursor, focus, wiring,
+          and state attributes — ZERO paint. All visible pixels (border,
+          background, rings, dimming, content) belong to ItemContent. */}
       <button
         type="button"
         ref={setRefs}
-        style={style}
         data-node-id={id}
         data-node-kind={node.kind}
         data-render-count={renderCountRef.current}
@@ -231,13 +261,8 @@ export const NodeCard = memo(function NodeCard({
         onClick={handleClick}
         className={twMerge(
           [
-            "flex h-24 w-32 flex-col items-stretch justify-between rounded-md border p-2 text-left text-xs transition-all select-none",
-            dragHandle ? "pt-6" : "cursor-grab active:cursor-grabbing",
-            isCollection ? "bg-muted/60" : "bg-background",
-            isSelected ? "border-primary ring-2 ring-primary" : "border-border",
-            // Static red ring is the always-on rejection cue; the pulse is
-            // motion-gated so reduced-motion users still get the ring, no throb.
-            isRejected ? "border-destructive ring-2 ring-destructive motion-safe:animate-pulse" : "",
+            "flex h-24 w-32 select-none",
+            dragHandle ? "" : "cursor-grab active:cursor-grabbing",
           ].join(" "),
           className
         )}
@@ -261,24 +286,17 @@ export const NodeCard = memo(function NodeCard({
         // the attribute spread above — must come after it.
         {...(rovingTabIndex !== undefined ? { tabIndex: rovingTabIndex } : {})}
       >
-        {node.kind === "media" ? (
-          <>
-            <NodeThumbnail node={node} />
-            <span className="mt-1 flex items-center justify-between gap-1">
-              <span className="truncate font-medium text-foreground">{node.name}</span>
-              <span className="shrink-0 text-[10px] text-muted-foreground">
-                {roundSecondsForDisplay(mediaDurationSeconds(node))}s
-              </span>
-            </span>
-          </>
-        ) : (
-          <>
-            <span className="truncate font-medium text-foreground">{node.name}</span>
-            <span className="text-[10px] text-muted-foreground">
-              Collection · {childCount} items
-            </span>
-          </>
-        )}
+        <ItemContent
+          id={id}
+          node={node}
+          childCount={childCount}
+          selected={isSelected}
+          rejected={isRejected}
+          // dnd-kit's isDragging covers the sub-frame gap between sensor
+          // activation and onDragStart publishing the store's drag set.
+          isDragSource={isDragging || isDragSource}
+          dragActivation={dragActivation}
+        />
       </button>
 
       {/* Grip bar: THE drag activator when dragHandle is on — listeners and
@@ -357,14 +375,10 @@ function NodeCardIndicators({
   );
 }
 
-/** Drag-overlay ghost: the primary card plus a "+N" badge for multi-drag. */
-export function NodeCardGhost({
-  node,
-  extraCount,
-}: {
-  node: CollectionItemNode;
-  extraCount: number;
-}) {
+/** Drag-overlay ghost: the primary card plus a "+N" badge for multi-drag.
+ *  The stock `GhostContent` — consumers replace it via the provider
+ *  `components` registry. */
+export function NodeCardGhost({ node, extraCount }: CollectionGhostContentProps) {
   return (
     <div
       data-testid="drag-ghost"

--- a/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
@@ -17,6 +17,7 @@ import {
   nonNegativeIntegerOr,
   positiveIntegerOrUndefined,
 } from "../core/numeric";
+import { type CollectionItemContentComponent } from "../react/collections-components";
 import { useCollectionsSelector, useCollectionsStore } from "../react/collections-store";
 import { NodeCard } from "../react/node-views";
 import { useEdgeAutoScroll } from "../react/use-edge-autoscroll";
@@ -49,6 +50,9 @@ export type VirtualGridProps = Readonly<{
   overscan?: number;
   /** Scroll viewport height. */
   height?: number;
+  /** Per-view card pixels — overrides the provider `components` registry.
+   *  MUST be identity-stable (module scope). */
+  itemContent?: CollectionItemContentComponent;
   className?: string;
 }>;
 
@@ -67,6 +71,7 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
       columns: columnsOption,
       overscan: overscanOption,
       height: heightOption,
+      itemContent,
       className,
     },
     ref
@@ -304,6 +309,7 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
                         id={id}
                         className="h-full w-full"
                         rovingTabIndex={absoluteIndex === rovingIndex ? 0 : -1}
+                        itemContent={itemContent}
                       />
                     </div>
                   );

--- a/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
@@ -19,6 +19,7 @@ import {
   finitePositiveOrUndefined,
   nonNegativeIntegerOr,
 } from "../core/numeric";
+import { type CollectionItemContentComponent } from "../react/collections-components";
 import { useCollectionsSelector, useCollectionsStore } from "../react/collections-store";
 import { findNodeElement } from "../react/node-dom";
 import { NodeCard, type NodeCardDragActivation } from "../react/node-views";
@@ -112,6 +113,9 @@ export type VirtualStripProps = Readonly<{
    * trim resizes the card by the amount dragged.
    */
   trimPixelsPerSecond?: number;
+  /** Per-view card pixels — overrides the provider `components` registry.
+   *  MUST be identity-stable (module scope). */
+  itemContent?: CollectionItemContentComponent;
   className?: string;
 }>;
 
@@ -136,6 +140,7 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
       panToScroll = true,
       itemDragActivation = "handle",
       trimPixelsPerSecond: trimPixelsPerSecondOption,
+      itemContent,
       className,
     },
     ref
@@ -627,6 +632,7 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
                     dragActivation={cardActivation}
                     rovingTabIndex={item.index === rovingIndex ? 0 : -1}
                     trimPixelsPerSecond={trimPixelsPerSecond}
+                    itemContent={itemContent}
                   />
                 </div>
               ))}


### PR DESCRIPTION
Phase 1 of consumer-owned item UI: the package keeps behavior and geometry, consumers keep the pixels.

- NodeCard is now a visually TRANSPARENT interaction shell: it owns drag/ drop wiring, selection, aria, trim handles, indicators, and the card box, and paints nothing. Pixels come from a content component rendered inside the button with rarely-changing props only ({id, node, childCount, selected, rejected, isDragSource, dragActivation}).

- DefaultItemContent (new file) is today's exact look, extracted -- the entire existing story/e2e suite passing unchanged is the proof the refactor is pixel- and behavior-identical.

- New react/collections-components.tsx: the contract types, the CollectionsComponentsContext registry, and useCollectionsComponentsValue (normalizes the provider `components` prop on field identities; warns once when a component identity churns -- an inline component definition remounts every card's content per render).

- Registration: provider-level <DndCollections components={{ ItemContent, GhostContent }}> -- one place keeps cards and the drag ghost in sync -- with per-view `itemContent` overrides on VirtualStrip, VirtualGrid,
  CollectionPanels, CollectionPanel, and NodeCard. Resolution: per-view ->
  registry -> DefaultItemContent. NodeCardGhost is now the stock GhostContent (typed against the contract).

- New CustomItemContent.stories.tsx:
  * TimelineLookalike -- the app-style clip card (filmstrip, VIDEO badge, amber selected frame, showing/full pill) built purely as consumer pixels over duration-mapped widths and package trim handles.
  * CustomContentRenderEfficiency -- the efficiency guarantee asserted in BOTH directions with consumer content: drag jitter re-renders neither a bystander shell nor its content, and a consumer-store update re-renders only subscribed content while every shell stays frozen.
  * GhostAndOverrideResolution -- resolution order + custom ghost pixels.

- Docs: API.md "Custom item content" section + prop rows; ARCHITECTURE.md efficiency story gains the shell/content boundary as layer 4; CLAUDE.md invariant added (never paint in the shell, never move behavior into content, keep content identity-stable).