### PR TITLE
feat(dnd-collections): trim-handle content slot + useLiveTrim

### DIFF
--- a/packages/ui/dnd-collections/API.md
+++ b/packages/ui/dnd-collections/API.md
@@ -623,17 +623,47 @@ type CollectionItemContentProps = Readonly<{
   rejected: boolean;          // rejection flash — style it or ignore it
   isDragSource: boolean;      // dimmed-in-place under the drag ghost
   dragActivation: NodeCardDragActivation; // "handle" overlays an 18px grip bar — leave room
+  trimEnabled: boolean;       // the shell renders trim handles on this card
 }>;
 type CollectionItemContentComponent = ComponentType<CollectionItemContentProps>;
 
 type CollectionGhostContentProps = Readonly<{ node: CollectionItemNode; extraCount: number }>;
 type CollectionGhostContentComponent = ComponentType<CollectionGhostContentProps>;
 
+type CollectionTrimHandleContentProps = Readonly<{
+  side: "left" | "right";     // left = video trim-in; right = image duration / video trim-out
+  node: MediaNode;
+  selected: boolean;
+}>;
+type CollectionTrimHandleContentComponent = ComponentType<CollectionTrimHandleContentProps>;
+
 type CollectionsComponents = Readonly<{
   ItemContent?: CollectionItemContentComponent;  // every card, all views
   GhostContent?: CollectionGhostContentComponent; // the drag-overlay ghost
+  TrimHandleContent?: CollectionTrimHandleContentComponent; // pixels INSIDE the trim hit zones
 }>;
 ```
+
+**Trim handles** follow the same split: the shell keeps each handle's HIT
+ZONE — positioning, width, cursor, the pointer gesture, and the
+sibling-of-the-button DOM shape (load-bearing for gesture arbitration) —
+while `TrimHandleContent` fills it (default: the amber grip bar,
+`DefaultTrimHandleContent`). Duration readouts are CARD content, not handle
+chrome: the showing/full pill and the live preview bubble live in
+`DefaultItemContent`, gated on `trimEnabled`, so custom content never fights
+a shell-drawn pill.
+
+### `useLiveTrim(nodeId): LiveTrim | null`
+
+Live trim values for consumer readouts (a pill that tracks the drag). Live
+trims deliberately never touch the store and the shell doesn't re-render
+mid-gesture, so live values can't arrive as props — this hook subscribes to
+a provider-level emitter instead. It returns the gesture's `LiveTrim` split
+per pointer move and `null` when the gesture settles (abort, no-op, or
+commit — the committed node then carries the same values, so there is no
+flash). Opt-in cost: the CALLING component re-renders per move — scope it to
+a leaf readout, not your whole card (see `DefaultTrimReadout` /
+`LiveTrimReadout` story); every other card stays frozen.
 
 Register once at the provider (`<DndCollections components={{ ItemContent }}>`)
 — that is what keeps cards and the drag ghost in sync from one place — or per
@@ -685,8 +715,9 @@ key off these):
 | `data-panel-id` / `data-panel-droppable` | panel section / its drop zone | Collection identity. |
 | `data-nest-state` | overlay on a collection card | `"valid"` or `"invalid"` while it's the live nest target. |
 | `data-drop-indicator` | indicator bar | `"before"` or `"after"` on the adjacency target. |
-| `data-trim-handle` | media edge handle | `"left"` or `"right"` (left is video-only). |
-| `data-trim-preview` | trim readout | The previewed effective duration (seconds) while a handle is dragged. |
+| `data-trim-handle` | media edge handle hit zone | `"left"` or `"right"` (left is video-only). Its pixels are the `TrimHandleContent` slot. |
+| `data-trim-pill` | `DefaultItemContent` readout | Showing/full duration pill (trim-enabled media cards; absent with custom content). |
+| `data-trim-preview` | `DefaultItemContent` readout | The previewed effective duration (seconds) while a handle is dragged (via `useLiveTrim`). |
 | `data-trim-overview` | overview filmstrip (`VirtualStrip` only) | The selected video's node id. Renders directly above its clip; absent unless a video is selected AND mounted. Dragging its body MOVES the source window (trim-in/out shift together, duration constant). |
 | `data-trim-overview-window` | amber "showing" window | Its left/right edges are pixel-aligned with the clip's own rendered edges (see the trim overview section below). |
 | `data-trim-overview-handle` | overview window grip | `"left"` (trim-in) or `"right"` (trim-out); dragging trims the clip, same `update-media` as the card edge handles. |

--- a/packages/ui/dnd-collections/ARCHITECTURE.md
+++ b/packages/ui/dnd-collections/ARCHITECTURE.md
@@ -146,7 +146,12 @@ The trim UI is edge handles on the card (`NodeCard trimPixelsPerSecond`),
 rendered as SIBLINGS of the draggable button so a handle press never reaches
 the item-drag sensor or the strip's pan. A handle drag converts pixels to
 seconds, clamps, and dispatches `update-media` once on release — the committed
-graph is untouched until then, exactly like a node drag.
+graph is untouched until then, exactly like a node drag. The shell/content
+split applies here too: the package owns each handle's hit zone and gesture;
+the pixels inside it are the `TrimHandleContent` slot, and duration readouts
+are card CONTENT (`DefaultItemContent`), with live drag values delivered to
+opted-in readouts over a ref-backed emitter (`useLiveTrim`) — never the
+store, so bystander cards stay frozen mid-gesture.
 
 The card resizes LIVE as the handle drags, and it does so without a graph
 commit OR a full re-measure. The view (VirtualStrip) provides a `TrimPreview`

--- a/packages/ui/dnd-collections/CustomItemContent.stories.tsx
+++ b/packages/ui/dnd-collections/CustomItemContent.stories.tsx
@@ -7,19 +7,25 @@ import {
   mediaDurationSeconds,
   parseNodeId,
   type GraphNodeSpec,
+  type MediaNode,
+  type NodeId,
 } from "./core/graph";
 import { DndCollections } from "./react/DndCollections";
 import {
   type CollectionGhostContentProps,
   type CollectionItemContentProps,
+  type CollectionTrimHandleContentProps,
 } from "./react/collections-components";
+import { useLiveTrim } from "./react/live-trim";
 import { CollectionPanels } from "./react/node-views";
 import { VirtualStrip } from "./virtual/VirtualStrip";
 import {
+  dispatchPointerSequence,
   dragHoldAt,
   moveHeldPointer,
   nodeCard,
   panelOrder,
+  rectCenter,
   rectPoint,
   releaseAt,
   waitForLayout,
@@ -151,16 +157,41 @@ function timelineGraph() {
   ]);
 }
 
+/** App-style trim-handle pixels: an amber zone whose intensity follows the
+ *  card's selection, with a grip line — filling the shell-owned hit zone. */
+const TimelineTrimHandle = memo(function TimelineTrimHandle({
+  side,
+  selected,
+}: CollectionTrimHandleContentProps) {
+  return (
+    <span
+      data-timeline-handle={side}
+      className={[
+        "flex h-full w-full items-center justify-center",
+        side === "left" ? "rounded-l-md" : "rounded-r-md",
+        selected ? "bg-amber-400" : "bg-amber-400/40",
+      ].join(" ")}
+    >
+      <span className="h-5 w-0.5 rounded bg-black/50" />
+    </span>
+  );
+});
+
 export const TimelineLookalike: Story = {
   // The end goal, as a story: consumer pixels dictate the entire card look
-  // (filmstrip, selection chrome, readout pill) while the package keeps
-  // widths-from-duration, trimming, selection, and drag behavior.
+  // (filmstrip, selection chrome, readout pill, trim-handle visuals) while
+  // the package keeps widths-from-duration, trim gestures, selection, and
+  // drag behavior. Registered at the provider so cards, handles, and ghost
+  // stay in sync from one place.
   render: () => (
-    <DndCollections initialGraph={timelineGraph()} animateMoves={false}>
+    <DndCollections
+      initialGraph={timelineGraph()}
+      animateMoves={false}
+      components={{ ItemContent: TimelineClipContent, TrimHandleContent: TimelineTrimHandle }}
+    >
       <div className="w-[640px] pt-10">
         <VirtualStrip
           collectionId={parseNodeId("strip")}
-          itemContent={TimelineClipContent}
           itemDragActivation="hold"
           itemWidthFor={(node) =>
             node.kind === "media" ? mediaDurationSeconds(node) * CLIP_PPS : undefined
@@ -183,6 +214,9 @@ export const TimelineLookalike: Story = {
     );
     expect(vid.textContent).toContain("7.00s / 10.00s");
     expect(vid.querySelector("[data-timeline-clip-badge]")).toBeNull();
+    // No duplicate readout: the default pill belongs to DefaultItemContent,
+    // which custom content replaces wholesale.
+    expect(vid.querySelector("[data-trim-pill]")).toBeNull();
 
     // Selection is still shell behavior; the BADGE is consumer pixels.
     const user = userEvent.setup();
@@ -192,11 +226,127 @@ export const TimelineLookalike: Story = {
       expect(vid.querySelector("[data-timeline-clip-badge]")).not.toBeNull();
     });
 
-    // Package-owned trim handles coexist with consumer pixels (siblings of
-    // the button, so they never live inside the consumer's markup).
+    // Package-owned trim-handle HIT ZONES coexist with consumer pixels
+    // (siblings of the button) — and their visuals are the registered
+    // TrimHandleContent, reflecting the selection.
     const wrapper = vid.closest("[data-node-wrapper]")!;
-    expect(wrapper.querySelector('[data-trim-handle="left"]')).not.toBeNull();
-    expect(wrapper.querySelector('[data-trim-handle="right"]')).not.toBeNull();
+    expect(
+      wrapper.querySelector('[data-trim-handle="left"] [data-timeline-handle="left"]')
+    ).not.toBeNull();
+    expect(
+      wrapper.querySelector('[data-trim-handle="right"] [data-timeline-handle="right"]')
+    ).not.toBeNull();
+  },
+};
+
+// ── Live trim readout via useLiveTrim ───────────────────────────────────────
+
+/** Leaf readout: the ONLY component that re-renders per trim move. */
+function LiveSeconds({ id, node }: { id: NodeId; node: MediaNode }) {
+  const live = useLiveTrim(id);
+  const seconds = live ? live.effectiveSeconds : mediaDurationSeconds(node);
+  return (
+    <span data-live-seconds={live ? "live" : "committed"} className="font-mono tabular-nums">
+      {seconds.toFixed(2)}s
+    </span>
+  );
+}
+
+const LiveReadoutContent = memo(function LiveReadoutContent({
+  id,
+  node,
+  trimEnabled,
+}: CollectionItemContentProps) {
+  const renders = useRef(0);
+  renders.current += 1;
+  return (
+    <span
+      data-content-render-count={renders.current}
+      className="flex h-full w-full flex-col justify-between rounded-md border border-border bg-background p-2 text-xs"
+    >
+      <span className="truncate">{node.name}</span>
+      {trimEnabled && node.kind === "media" && <LiveSeconds id={id} node={node} />}
+    </span>
+  );
+});
+
+export const LiveTrimReadout: Story = {
+  // A consumer duration readout that tracks the drag live via useLiveTrim:
+  // live during the gesture, committed after release — and scoped: the
+  // BYSTANDER card's content never re-renders during the trim.
+  render: () => (
+    <DndCollections
+      initialGraph={graphOrThrow([
+        {
+          kind: "collection",
+          id: "strip",
+          name: "Strip",
+          children: [
+            { kind: "media", id: "still", name: "Still", durationSeconds: 4 },
+            {
+              kind: "media",
+              mediaKind: "video",
+              id: "clip",
+              name: "Clip",
+              fullDurationSeconds: 10,
+              trimInSeconds: 0,
+              trimOutSeconds: 0,
+            },
+          ],
+        },
+      ])}
+      animateMoves={false}
+      components={{ ItemContent: LiveReadoutContent }}
+    >
+      <div className="w-[640px]">
+        <VirtualStrip
+          collectionId={parseNodeId("strip")}
+          itemWidthFor={(node) =>
+            node.kind === "media" ? mediaDurationSeconds(node) * CLIP_PPS : undefined
+          }
+          trimPixelsPerSecond={CLIP_PPS}
+        />
+      </div>
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    const clip = nodeCard(canvasElement, "clip");
+    const still = nodeCard(canvasElement, "still");
+    await waitForLayout(clip);
+    const liveSeconds = () => clip.querySelector<HTMLElement>("[data-live-seconds]")!;
+    const stillContent = () => still.querySelector<HTMLElement>("[data-content-render-count]")!;
+
+    expect(liveSeconds()).toHaveAttribute("data-live-seconds", "committed");
+    expect(liveSeconds().textContent).toBe("10.00s");
+    const bystanderBefore = stillContent().getAttribute("data-content-render-count");
+
+    // Drag the right handle IN 48px (trim-out +2s) and HOLD: the readout
+    // tracks the drag live, before any commit.
+    const handle = clip
+      .closest("[data-node-wrapper]")!
+      .querySelector<HTMLElement>('[data-trim-handle="right"]')!;
+    const start = rectCenter(handle);
+    await dispatchPointerSequence([
+      { element: handle, type: "pointerdown", clientX: start.x, clientY: start.y },
+      { element: document, type: "pointermove", clientX: start.x - 24, clientY: start.y, delayAfterMs: 30 },
+      { element: document, type: "pointermove", clientX: start.x - 48, clientY: start.y, delayAfterMs: 30 },
+    ]);
+    await waitFor(() => {
+      expect(liveSeconds()).toHaveAttribute("data-live-seconds", "live");
+      expect(liveSeconds().textContent).toBe("8.00s");
+    });
+    // The bystander's content did not re-render for someone else's trim.
+    expect(stillContent().getAttribute("data-content-render-count")).toBe(bystanderBefore);
+
+    // Release commits: the readout settles on the committed value, no flash
+    // (the last live value equals the committed one).
+    await dispatchPointerSequence([
+      { element: document, type: "pointerup", clientX: start.x - 48, clientY: start.y, delayAfterMs: 30 },
+    ]);
+    await waitFor(() => {
+      expect(liveSeconds()).toHaveAttribute("data-live-seconds", "committed");
+      expect(liveSeconds().textContent).toBe("8.00s");
+    });
   },
 };
 

--- a/packages/ui/dnd-collections/VirtualStrip.stories.tsx
+++ b/packages/ui/dnd-collections/VirtualStrip.stories.tsx
@@ -1147,9 +1147,13 @@ export const TrimMediaWithHandles: Story = {
 
     // Over-drag the end: effective duration clamps at 0 (slot width 0, so the
     // card bottoms out at its ~18px chrome — never negative, never huge).
+    // The pill (now DefaultItemContent's readout) reports 0 showing of the
+    // full 10s source.
     await dragHandleBy(handle("vid", "right")!, -600);
     await waitFor(() => expect(width("vid")).toBeLessThanOrEqual(20));
-    expect(nodeCard(canvasElement, "vid").textContent).toMatch(/(?:^|\D)0s$/);
+    expect(
+      nodeCard(canvasElement, "vid").querySelector("[data-trim-pill]")!.textContent
+    ).toBe("0.00s / 10.00s");
   },
 };
 

--- a/packages/ui/dnd-collections/index.ts
+++ b/packages/ui/dnd-collections/index.ts
@@ -111,9 +111,16 @@ export {
   type CollectionGhostContentProps,
   type CollectionItemContentComponent,
   type CollectionItemContentProps,
+  type CollectionTrimHandleContentComponent,
+  type CollectionTrimHandleContentProps,
   type CollectionsComponents,
 } from "./react/collections-components";
 export { DefaultItemContent } from "./react/default-item-content";
+export { DefaultTrimHandleContent } from "./react/trim-handles";
+// Live trim values for consumer readouts: opt-in, per-move re-renders scoped
+// to the calling component only (the store is never notified mid-gesture).
+export { useLiveTrim } from "./react/live-trim";
+export { type LiveTrim } from "./react/trim-preview-context";
 export { HistoryLog, UndoRedoControls } from "./react/history-views";
 export { PaletteItem, type PaletteItemProps } from "./react/palette";
 export { TrashTarget } from "./react/trash-target";

--- a/packages/ui/dnd-collections/react/DndCollections.tsx
+++ b/packages/ui/dnd-collections/react/DndCollections.tsx
@@ -52,6 +52,7 @@ import {
   type CollectionsComponents,
 } from "./collections-components";
 import { CollectionsContainerContext } from "./container-context";
+import { LiveTrimChannelContext, useCreateLiveTrimChannel } from "./live-trim";
 import { useFlipGraphAnimation } from "./use-flip-graph-animation";
 import { NodeCardGhost } from "./node-views";
 import { CollectionsPointerSensor } from "./pointer-sensors";
@@ -155,6 +156,9 @@ export function DndCollections({
   children,
 }: DndCollectionsProps) {
   const componentsValue = useCollectionsComponentsValue(components);
+  // Live trim values ride a ref-backed emitter (never the store): only
+  // content that opted in via useLiveTrim re-renders per trim move.
+  const liveTrimChannel = useCreateLiveTrimChannel();
   // The store captures its options once, but callback props must stay fresh
   // — a parent passing an inline closure over its latest state expects that
   // version to be called. Route through a ref, updated in a layout effect
@@ -183,7 +187,9 @@ export function DndCollections({
   return (
     <CollectionsStoreProvider value={store}>
       <CollectionsComponentsContext.Provider value={componentsValue}>
-        <DndCollectionsContext animateMoves={animateMoves}>{children}</DndCollectionsContext>
+        <LiveTrimChannelContext.Provider value={liveTrimChannel}>
+          <DndCollectionsContext animateMoves={animateMoves}>{children}</DndCollectionsContext>
+        </LiveTrimChannelContext.Provider>
       </CollectionsComponentsContext.Provider>
     </CollectionsStoreProvider>
   );

--- a/packages/ui/dnd-collections/react/collections-components.tsx
+++ b/packages/ui/dnd-collections/react/collections-components.tsx
@@ -9,7 +9,7 @@ import {
   type ComponentType,
 } from "react";
 
-import { type CollectionItemNode, type NodeId } from "../core/graph";
+import { type CollectionItemNode, type MediaNode, type NodeId } from "../core/graph";
 
 // The consumer-content seam: dnd-collections owns BEHAVIOR and GEOMETRY
 // (drag wiring, selection, trim gestures, aria, measurement, indicators);
@@ -45,6 +45,13 @@ export type CollectionItemContentProps = Readonly<{
    * card — leave room for it (the default content pads its top).
    */
   dragActivation: NodeCardDragActivation;
+  /**
+   * True when the shell renders trim handles on this card (a media node in
+   * a trim-enabled view). The default content gates its duration readout on
+   * it; pair yours with `useLiveTrim(id)` for a readout that tracks the
+   * drag live.
+   */
+  trimEnabled: boolean;
 }>;
 
 /**
@@ -67,12 +74,31 @@ export type CollectionGhostContentProps = Readonly<{
  *  width — fixed OR variable (virtual strips). */
 export type CollectionGhostContentComponent = ComponentType<CollectionGhostContentProps>;
 
+export type CollectionTrimHandleContentProps = Readonly<{
+  /** "left" = video trim-in; "right" = image duration / video trim-out. */
+  side: "left" | "right";
+  node: MediaNode;
+  selected: boolean;
+}>;
+
+/**
+ * The VISUALS inside a trim handle's hit zone. The shell keeps the zone
+ * itself — positioning, width, cursor, the pointer gesture, and its
+ * sibling-of-the-button DOM shape (load-bearing: a handle press must never
+ * reach the drag sensor or the strip's pan) — and renders this component
+ * filling it. Presentational only, like ItemContent.
+ */
+export type CollectionTrimHandleContentComponent =
+  ComponentType<CollectionTrimHandleContentProps>;
+
 export type CollectionsComponents = Readonly<{
   /** Replaces the card pixels everywhere (panels, virtual views). Per-view
    *  `itemContent` props override this registry entry. */
   ItemContent?: CollectionItemContentComponent;
   /** Replaces the drag-overlay ghost pixels. */
   GhostContent?: CollectionGhostContentComponent;
+  /** Replaces the pixels INSIDE the trim-handle hit zones. */
+  TrimHandleContent?: CollectionTrimHandleContentComponent;
 }>;
 
 const EMPTY_COMPONENTS: CollectionsComponents = {};
@@ -98,9 +124,13 @@ export function useCollectionsComponentsValue(
 ): CollectionsComponents {
   const ItemContent = components?.ItemContent;
   const GhostContent = components?.GhostContent;
+  const TrimHandleContent = components?.TrimHandleContent;
   const value = useMemo<CollectionsComponents>(
-    () => (ItemContent || GhostContent ? { ItemContent, GhostContent } : EMPTY_COMPONENTS),
-    [ItemContent, GhostContent]
+    () =>
+      ItemContent || GhostContent || TrimHandleContent
+        ? { ItemContent, GhostContent, TrimHandleContent }
+        : EMPTY_COMPONENTS,
+    [ItemContent, GhostContent, TrimHandleContent]
   );
 
   const previousRef = useRef(value);
@@ -110,7 +140,10 @@ export function useCollectionsComponentsValue(
     if (warnedUnstableComponents || previous === value) return;
     const churned =
       (previous.ItemContent && value.ItemContent && previous.ItemContent !== value.ItemContent) ||
-      (previous.GhostContent && value.GhostContent && previous.GhostContent !== value.GhostContent);
+      (previous.GhostContent && value.GhostContent && previous.GhostContent !== value.GhostContent) ||
+      (previous.TrimHandleContent &&
+        value.TrimHandleContent &&
+        previous.TrimHandleContent !== value.TrimHandleContent);
     if (churned) {
       warnedUnstableComponents = true;
       console.warn(

--- a/packages/ui/dnd-collections/react/default-item-content.tsx
+++ b/packages/ui/dnd-collections/react/default-item-content.tsx
@@ -2,26 +2,64 @@
 
 import { memo } from "react";
 
-import { mediaDurationSeconds } from "../core/graph";
+import { mediaDurationSeconds, type MediaNode, type NodeId } from "../core/graph";
 import { type CollectionItemContentProps } from "./collections-components";
 import { roundSecondsForDisplay } from "./duration-format";
+import { useLiveTrim } from "./live-trim";
 import { NodeThumbnail } from "./node-thumbnail";
 
 // The package's stock card pixels — thumbnail, name, duration/child-count
-// label, selection ring, rejection flash, drag-source dimming — extracted
-// from NodeCard so consumers can swap in their own. This is also the
-// reference implementation for custom content: memoized, presentational
-// (spans only — it renders inside a <button>), and driven entirely by the
-// contract props. The card BOX (sizing, border-box position) belongs to the
-// shell; this fills it and paints everything visible.
+// label, selection ring, rejection flash, drag-source dimming, and (on
+// trim-enabled cards) the duration readouts — extracted from NodeCard so
+// consumers can swap in their own. This is also the reference implementation
+// for custom content: memoized, presentational (spans only — it renders
+// inside a <button>), and driven entirely by the contract props plus the
+// opt-in `useLiveTrim` seam. The card BOX (sizing, border-box position)
+// belongs to the shell; this fills it and paints everything visible.
+
+/**
+ * The trim readouts: the showing/full pill (committed data) and the live
+ * preview bubble that tracks a handle drag. A LEAF component on purpose —
+ * `useLiveTrim` re-renders its caller per pointer move, so the subscription
+ * is scoped to this readout, mounted only on trim-enabled media cards; the
+ * rest of the card never re-renders mid-gesture.
+ */
+function DefaultTrimReadout({ id, node }: { id: NodeId; node: MediaNode }) {
+  const live = useLiveTrim(id);
+  const pill =
+    node.mediaKind === "video"
+      ? `${mediaDurationSeconds(node).toFixed(2)}s / ${node.fullDurationSeconds.toFixed(2)}s`
+      : `${node.durationSeconds.toFixed(2)}s`;
+  return (
+    <>
+      {/* Showing/full readout pill (bottom-right), matching the app. */}
+      <span
+        data-trim-pill
+        className="pointer-events-none absolute right-1 bottom-1 z-20 rounded bg-black/70 px-1.5 py-0.5 font-mono text-[9px] text-zinc-100 tabular-nums select-none"
+      >
+        {pill}
+      </span>
+      {live !== null && (
+        <span
+          data-trim-preview={live.effectiveSeconds}
+          className="pointer-events-none absolute -top-5 left-1/2 z-30 -translate-x-1/2 rounded bg-amber-300 px-1.5 py-0.5 text-[10px] font-bold text-black shadow"
+        >
+          {roundSecondsForDisplay(live.effectiveSeconds)}s
+        </span>
+      )}
+    </>
+  );
+}
 
 export const DefaultItemContent = memo(function DefaultItemContent({
+  id,
   node,
   childCount,
   selected,
   rejected,
   isDragSource,
   dragActivation,
+  trimEnabled,
 }: CollectionItemContentProps) {
   const isCollection = node.kind === "collection";
   return (
@@ -50,6 +88,7 @@ export const DefaultItemContent = memo(function DefaultItemContent({
               {roundSecondsForDisplay(mediaDurationSeconds(node))}s
             </span>
           </span>
+          {trimEnabled && <DefaultTrimReadout id={id} node={node} />}
         </>
       ) : (
         <>

--- a/packages/ui/dnd-collections/react/live-trim.ts
+++ b/packages/ui/dnd-collections/react/live-trim.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import { createContext, useContext, useEffect, useRef, useState } from "react";
+
+import { type NodeId } from "../core/graph";
+import { type LiveTrim } from "./trim-preview-context";
+
+// Live trim values for CONSUMER content — delivered over a ref-backed
+// emitter, deliberately outside the store. Live trims must never notify the
+// store (that is what keeps bystander cards frozen during a drag), and the
+// shell doesn't re-render mid-gesture either, so live values cannot flow to
+// content as props. `useLiveTrim(id)` is the opt-in: content that calls it
+// re-renders per pointer move — but ONLY the trimmed card's content, the one
+// card that is supposed to be changing. Everything else stays still.
+//
+// The gesture (useTrimPointerDrag) publishes alongside the view's
+// TrimPreview: the live split per move, and `null` on abort, no-op, AND
+// successful commit (the committed node then carries the same values the
+// last preview showed, so there is no flash).
+
+export type LiveTrimChannel = Readonly<{
+  publish: (nodeId: NodeId, live: LiveTrim | null) => void;
+  subscribe: (listener: (nodeId: NodeId, live: LiveTrim | null) => void) => () => void;
+}>;
+
+const NOOP_CHANNEL: LiveTrimChannel = {
+  publish: () => {},
+  subscribe: () => () => {},
+};
+
+export const LiveTrimChannelContext = createContext<LiveTrimChannel>(NOOP_CHANNEL);
+
+/** One stable channel per provider instance (mirrors the announce channel). */
+export function useCreateLiveTrimChannel(): LiveTrimChannel {
+  const channelRef = useRef<LiveTrimChannel | null>(null);
+  if (channelRef.current === null) {
+    const listeners = new Set<(nodeId: NodeId, live: LiveTrim | null) => void>();
+    channelRef.current = {
+      publish: (nodeId, live) => {
+        for (const listener of listeners) listener(nodeId, live);
+      },
+      subscribe: (listener) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+    };
+  }
+  return channelRef.current;
+}
+
+/** The gesture side of the channel (internal — trim gestures publish here). */
+export function useLiveTrimPublisher(): LiveTrimChannel["publish"] {
+  return useContext(LiveTrimChannelContext).publish;
+}
+
+/**
+ * The live trim split of a node mid-gesture, or null at rest. Opt-in for
+ * content components that render live readouts (a duration pill tracking the
+ * drag): subscribing re-renders THIS component per pointer move — scope it
+ * to a leaf (the readout), not your whole card, if the card is expensive.
+ */
+export function useLiveTrim(nodeId: NodeId): LiveTrim | null {
+  const channel = useContext(LiveTrimChannelContext);
+  const [live, setLive] = useState<LiveTrim | null>(null);
+  useEffect(() => {
+    // A gesture can't be mid-flight for a node whose readout just mounted,
+    // and unmount drops the subscription — no stale state either side.
+    return channel.subscribe((id, next) => {
+      if (id !== nodeId) return;
+      setLive((current) => (current === next ? current : next));
+    });
+  }, [channel, nodeId]);
+  return live;
+}

--- a/packages/ui/dnd-collections/react/node-views.tsx
+++ b/packages/ui/dnd-collections/react/node-views.tsx
@@ -296,6 +296,7 @@ export const NodeCard = memo(function NodeCard({
           // activation and onDragStart publishing the store's drag set.
           isDragSource={isDragging || isDragSource}
           dragActivation={dragActivation}
+          trimEnabled={trimScale !== undefined && node.kind === "media"}
         />
       </button>
 
@@ -321,7 +322,7 @@ export const NodeCard = memo(function NodeCard({
       )}
 
       {trimScale !== undefined && node.kind === "media" && (
-        <TrimHandles node={node} pixelsPerSecond={trimScale} />
+        <TrimHandles node={node} pixelsPerSecond={trimScale} selected={isSelected} />
       )}
 
       <NodeCardIndicators nestState={nestState} dropSide={dropSide} />

--- a/packages/ui/dnd-collections/react/trim-gesture.ts
+++ b/packages/ui/dnd-collections/react/trim-gesture.ts
@@ -10,6 +10,7 @@ import {
 import { type MediaNode, type VideoMediaNode } from "../core/graph";
 import { type MediaUpdate } from "../core/commands";
 import { useCollectionsStore } from "./collections-store";
+import { useLiveTrimPublisher } from "./live-trim";
 import { useTrimPreview, type LiveTrim } from "./trim-preview-context";
 
 // Shared trim-gesture core for BOTH the card edge handles (`trim-handles.tsx`)
@@ -131,6 +132,10 @@ export function useTrimPointerDrag(
 ) => void {
   const store = useCollectionsStore();
   const trimPreview = useTrimPreview();
+  // Second live-value consumer beside the view's TrimPreview: the emitter
+  // consumer content opts into via useLiveTrim (live per move, null when the
+  // gesture settles — abort, no-op, OR successful commit).
+  const publishLive = useLiveTrimPublisher();
   const activeCleanupRef = useRef<(() => void) | null>(null);
 
   useEffect(
@@ -199,6 +204,7 @@ export function useTrimPointerDrag(
         // trim committing on this node mid-gesture would otherwise strand
         // the preview bubble with a stale number.
         onLive?.(null);
+        publishLive(node.id, null);
         trimPreview.previewTrim(node.id, null);
       }
 
@@ -208,6 +214,7 @@ export function useTrimPointerDrag(
         const { update, live } = resolve((moveEvent.clientX - startX) / pixelsPerSecond);
         pending = update;
         onLive?.(live);
+        publishLive(node.id, live);
         trimPreview.previewTrim(node.id, live);
       }
 
@@ -223,12 +230,17 @@ export function useTrimPointerDrag(
         pending = null;
         if (upEvent.type === "pointercancel" || !update) {
           // Aborted (or a no-op click): drop the live preview, snapping back.
+          publishLive(node.id, null);
           trimPreview.previewTrim(node.id, null);
           return;
         }
         // Commit. The view reconciles to the new data (its last preview
         // already matches), so there is no flash.
         const dispatched = store.dispatch({ type: "update-media", nodeId: node.id, update });
+        // The emitter clears on EVERY settle, success included: subscribers'
+        // committed node now carries the same values the last live preview
+        // showed (quantize-then-clamp parity), so there is no flash.
+        publishLive(node.id, null);
         // A no-op (for example, moving away and returning to the committed
         // value before release) does not change graph identity, so views
         // cannot rely on their commit effect to clear the live preview.
@@ -240,6 +252,6 @@ export function useTrimPointerDrag(
       window.addEventListener("pointerup", onUp);
       window.addEventListener("pointercancel", onUp);
     },
-    [node, store, trimPreview]
+    [node, store, trimPreview, publishLive]
   );
 }

--- a/packages/ui/dnd-collections/react/trim-handles.tsx
+++ b/packages/ui/dnd-collections/react/trim-handles.tsx
@@ -1,57 +1,70 @@
 "use client";
 
-import { useCallback, useState, type PointerEvent as ReactPointerEvent } from "react";
+import { memo, useCallback, type PointerEvent as ReactPointerEvent } from "react";
 
-import { mediaDurationSeconds, type MediaNode } from "../core/graph";
-import { roundSecondsForDisplay } from "./duration-format";
+import { type MediaNode } from "../core/graph";
+import {
+  useCollectionsComponents,
+  type CollectionTrimHandleContentProps,
+} from "./collections-components";
 import { resolveTrim, useTrimPointerDrag, type TrimSide } from "./trim-gesture";
 
 // Edge drag-handles that TRIM a media item: a right handle on every media
 // card, plus a left handle on video (which can trim its start too). The
 // gesture converts pointer pixels to seconds via `pixelsPerSecond` (the
-// caller's timeline scale — the same one its `itemWidthFor` uses) and commits
-// ONE `update-media` on release (undoable). The card resizes LIVE as the
-// handle drags, via the view's `TrimPreview` — a targeted single-item resize
-// (no full re-measure, no per-frame graph churn). The commit lands only on
-// release; an aborted drag snaps back. The pointer lifecycle is shared with
-// the overview handles/move via `useTrimPointerDrag` (see trim-gesture.ts).
+// caller's timeline scale) and commits ONE `update-media` on release
+// (undoable); the card resizes LIVE via the view's `TrimPreview`.
 //
-// The handles are SIBLINGS of the draggable card button (not children), so a
-// pointerdown on a handle never reaches dnd-kit's item-drag sensor. They also
-// carry `data-trim-handle` so the strip's pan gesture skips them.
+// The shell/content split applies here exactly like the card: the package
+// owns the HIT ZONES — positioning, width, cursor, the pointer gesture, and
+// the sibling-of-the-button DOM shape (load-bearing: a handle press must
+// never reach dnd-kit's item-drag sensor or the strip's pan; they also carry
+// `data-trim-handle` so the pan's surface filter skips them) — while the
+// pixels INSIDE each zone come from the `TrimHandleContent` registry slot,
+// defaulting to the amber grip bar below. Duration readouts (the pill, the
+// live preview bubble) are CONTENT, not handle chrome: the default ones live
+// in `DefaultItemContent`, driven by `useLiveTrim`.
 
-// Amber edge handles (matching the app's source-window handles): thicker,
-// with a grip line, visible-on-hover so the card stays clean at rest.
-const HANDLE_CLASS =
-  "absolute inset-y-0 z-20 flex w-2 cursor-ew-resize items-center justify-center bg-amber-300 opacity-70 transition-opacity hover:opacity-100 group-hover:opacity-100";
+/** The stock handle pixels: amber fill, visible-on-hover, center grip line. */
+export const DefaultTrimHandleContent = memo(function DefaultTrimHandleContent({
+  side,
+}: CollectionTrimHandleContentProps) {
+  return (
+    <span
+      className={[
+        "flex h-full w-full items-center justify-center bg-amber-300 opacity-70 transition-opacity hover:opacity-100 group-hover:opacity-100",
+        side === "left" ? "rounded-l-md" : "rounded-r-md",
+      ].join(" ")}
+    >
+      <span className="h-4 w-0.5 rounded bg-black/45" />
+    </span>
+  );
+});
+
+/** Shell-owned hit zone: geometry + gesture; pixels from TrimHandleContent. */
+const HIT_ZONE_CLASS = "absolute inset-y-0 z-20 w-2 cursor-ew-resize";
 
 export function TrimHandles({
   node,
   pixelsPerSecond,
+  selected,
 }: {
   node: MediaNode;
   pixelsPerSecond: number;
+  selected: boolean;
 }) {
   const beginDrag = useTrimPointerDrag(node);
-  const [preview, setPreview] = useState<number | null>(null);
+  const TrimHandleContent =
+    useCollectionsComponents().TrimHandleContent ?? DefaultTrimHandleContent;
 
   const startTrim = useCallback(
     (side: TrimSide, event: ReactPointerEvent<HTMLDivElement>) => {
-      beginDrag(
-        event,
-        pixelsPerSecond,
-        (deltaSeconds) => resolveTrim(node, side, deltaSeconds),
-        (live) => setPreview(live ? live.effectiveSeconds : null)
-      );
+      beginDrag(event, pixelsPerSecond, (deltaSeconds) => resolveTrim(node, side, deltaSeconds));
     },
     [beginDrag, node, pixelsPerSecond]
   );
 
   const showLeft = node.mediaKind === "video";
-  const durationPill =
-    node.mediaKind === "video"
-      ? `${mediaDurationSeconds(node).toFixed(2)}s / ${node.fullDurationSeconds.toFixed(2)}s`
-      : `${node.durationSeconds.toFixed(2)}s`;
 
   return (
     <>
@@ -62,37 +75,20 @@ export function TrimHandles({
         <div
           data-trim-handle="left"
           aria-hidden="true"
-          className={`${HANDLE_CLASS} left-0 rounded-l-md`}
+          className={`${HIT_ZONE_CLASS} left-0`}
           onPointerDown={(event) => startTrim("left", event)}
         >
-          <span className="h-4 w-0.5 rounded bg-black/45" />
+          <TrimHandleContent side="left" node={node} selected={selected} />
         </div>
       )}
       <div
         data-trim-handle="right"
         aria-hidden="true"
-        className={`${HANDLE_CLASS} right-0 rounded-r-md`}
+        className={`${HIT_ZONE_CLASS} right-0`}
         onPointerDown={(event) => startTrim("right", event)}
       >
-        <span className="h-4 w-0.5 rounded bg-black/45" />
+        <TrimHandleContent side="right" node={node} selected={selected} />
       </div>
-
-      {/* Showing/full readout pill (bottom-right), matching the app. */}
-      <span
-        data-trim-pill
-        className="pointer-events-none absolute right-1 bottom-1 z-20 rounded bg-black/70 px-1.5 py-0.5 font-mono text-[9px] text-zinc-100 tabular-nums select-none"
-      >
-        {durationPill}
-      </span>
-
-      {preview !== null && (
-        <div
-          data-trim-preview={preview}
-          className="pointer-events-none absolute -top-5 left-1/2 z-30 -translate-x-1/2 rounded bg-amber-300 px-1.5 py-0.5 text-[10px] font-bold text-black shadow"
-        >
-          {roundSecondsForDisplay(preview)}s
-        </div>
-      )}
     </>
   );
 }


### PR DESCRIPTION
Phase 2 of consumer-owned item UI: trim visuals become consumer pixels and live trim values reach consumer readouts without touching the store.

- TrimHandleContent registry slot: the shell keeps each handle's HIT ZONE (positioning, width, cursor, the pointer gesture, and the sibling-of-the-button DOM shape -- load-bearing for gesture arbitration) and renders the registered component inside it. DefaultTrimHandleContent is the extracted amber grip bar; TrimHandles gains a `selected` prop so handle pixels can follow the card's selection (the app look integrates handles into the selected frame).

- Duration readouts move OUT of the handle layer into card content: the showing/full pill and live preview bubble now live in DefaultItemContent (new DefaultTrimReadout leaf), gated on the contract's new `trimEnabled: boolean` -- so custom content never fights a shell-drawn pill (the TimelineLookalike story pins the no-duplicate-pill guarantee). data-trim-pill / data-trim-preview hooks preserved.

- useLiveTrim(nodeId): a provider-level ref-backed emitter (same pattern as the announce channel). useTrimPointerDrag publishes the live split per move and null on every settle -- abort, no-op, AND successful commit (quantize-then-clamp parity means the committed node equals the last preview, so no flash). Opt-in cost is scoped: only the CALLING component re-renders per move; the LiveTrimReadout story asserts a bystander's content render count stays frozen through someone else's trim.

- Stories: TimelineLookalike now registers TrimHandleContent (selection- aware amber zones) and asserts the default pill is absent under custom content; new LiveTrimReadout covers live -> committed settling and the re-render scoping. The TrimMediaWithHandles over-drag assertion now reads the pill (it moved inside the button, changing the card's textContent).

- Exports: TrimHandleContent types, DefaultTrimHandleContent, useLiveTrim, LiveTrim. API.md/ARCHITECTURE.md updated (trim shell/content split, the emitter rationale, DOM-hook table).

Minor behavior note: the live preview bubble now also appears during overview-strip drags on the same node (the emitter publishes for every trim gesture; the old bubble was wired only to the card handles' onLive).