### PR TITLE
feat(dnd-collections): unified duration sizing, targeted resize, over…

### DIFF
--- a/packages/ui/dnd-collections/API.md
+++ b/packages/ui/dnd-collections/API.md
@@ -557,6 +557,7 @@ type CollectionsChange = {
 | --- | --- | --- |
 | `getSnapshot` | `() => CollectionsSnapshot` | Snapshot identity changes per notify; FIELD identities change only when the field did. |
 | `subscribe` | `(listener: () => void) => () => void` | Returns unsubscribe. |
+| `subscribeToChanges` | `(listener: (change: CollectionsChange) => void) => () => void` | The committed-change feed as a multi-listener seam — same events and ordering as the `onChange` option. For consumers that need the PATCH of a commit (e.g. `VirtualStrip` resizes exactly the slots a `nodes-updated` patch touched). Fires for dispatch/undo/redo; `replaceGraph` emits nothing. |
 | `dispatch` | `(command) => Result<CollectionsPatch, CommandRejection>` | Reduce + push history + notify + `onChange`. |
 | `undo` / `redo` | `() => boolean` | False when the respective stack is empty. |
 | `replaceGraph` | `(graph: CollectionsGraph) => Result<void, GraphValidationError>` | Runtime-validates then swaps the committed graph wholesale — the escape hatch for async/server-loaded data (`initialGraph` is initial-only). Invalid input is rejected without changing or notifying the store. A successful swap clears undo/redo history (old patches can't replay on a new graph) and any in-progress drag/preview, prunes the selection to surviving ids, and — deliberately — does NOT fire `onChange` (the caller supplied this state; echoing it risks feedback loops). |
@@ -751,15 +752,17 @@ only after Enter — navigation stands down while a drag is live.
 ```ts
 type VirtualStripProps = {
   collectionId: NodeId;
-  itemWidth?: number;                                    // default 128; fallback when itemWidthFor is absent
-  itemWidthFor?: (node: CollectionItemNode) => number | undefined; // per-node width from metadata; memoized by node id
+  pixelsPerSecond?: number;                              // THE timeline scale: media widths = durationToWidth(duration, pps), and trim handles inherit it — one scale, no drift. The recommended sizing for duration-mapped strips
+  itemWidth?: number;                                    // default 128; collections and non-duration fallbacks
+  itemWidthFor?: (node: CollectionItemNode) => number | undefined; // ADVANCED per-node width override (beats pixelsPerSecond); memoized by node id
   itemHeight?: number;                                   // default 96
   gap?: number;                                          // default 8
   overscan?: number;                                     // default 4
   panToScroll?: boolean;                                 // default true — drag the surface to scroll, with momentum
   itemDragActivation?: "handle" | "hold";                // default "handle" (grip bar); "hold" = press-and-hold the body. Ignored when panToScroll is off (bodies drag instantly)
-  trimPixelsPerSecond?: number;                          // enable media trim handles; set to your itemWidthFor scale. The card resizes LIVE during the drag (targeted resizeItem, no re-measure) and commits update-media on release
+  trimPixelsPerSecond?: number;                          // override the trim conversion; DEFAULTS to pixelsPerSecond. Handles render when either is set; the card resizes LIVE during the drag and commits update-media on release
   itemContent?: CollectionItemContentComponent;          // per-view card pixels; overrides the provider registry
+  overlay?: ReactNode;                                   // content-coordinate layer over the strip (playhead, markers): rides scroll + live-trim transform; aria-hidden, pointer-events none
   className?: string;
 };
 type VirtualStripHandle = {
@@ -770,10 +773,19 @@ type VirtualStripHandle = {
 ```
 
 Numeric layout options are normalized before reaching the virtualizer:
-base widths/heights and trim scale must be finite and positive, `gap` is
-finite and non-negative, and `overscan` is a non-negative integer. Invalid
-values use the documented defaults; `itemWidthFor` may return zero for a
-fully trimmed clip, while negative/non-finite results use `itemWidth`.
+`pixelsPerSecond`, base widths/heights, and the trim scale must be finite
+and positive, `gap` is finite and non-negative, and `overscan` is a
+non-negative integer. Invalid values use the documented defaults;
+`itemWidthFor` may return zero for a fully trimmed clip, while
+negative/non-finite results use `itemWidth`. All duration-derived widths run
+through the exported `durationToWidth(seconds, pps, min = MIN_ITEM_WIDTH)` —
+committed layout, live trim preview, and virtualizer measurement share the
+one conversion, so they cannot drift; use it for overlay/playhead math too.
+
+Slot widths reconcile at COMMIT cadence through `store.subscribeToChanges`:
+a `nodes-updated` patch resizes exactly the touched slots (targeted
+`resizeItem`); a full re-measure happens only for `replaceGraph`, scale/
+layout prop changes, and the `remeasure()` handle.
 
 When `trimPixelsPerSecond` is set and a mounted video is selected,
 `VirtualStrip` renders the source-window overview (`TrimOverviewStrip`) as a
@@ -827,6 +839,7 @@ keep durable state in the collection store.
 | Attribute | Element | Meaning |
 | --- | --- | --- |
 | `data-virtual-strip` / `data-virtual-grid` | scroll container | Collection identity. |
+| `data-virtual-overlay` | overlay layer (strip) | The consumer `overlay` slot's content-coordinate wrapper (aria-hidden, pointer-events none). |
 | `data-grid-columns` | grid container | Live column count (keyboard row-move scope). |
 | `data-virtual-index` / `data-virtual-row` | slot / row wrapper | Virtualizer index. |
 | `data-drop-indicator="virtual"` / `"virtual-grid"` | indicator line | The resolved insert boundary, in content coordinates. |

--- a/packages/ui/dnd-collections/ARCHITECTURE.md
+++ b/packages/ui/dnd-collections/ARCHITECTURE.md
@@ -164,11 +164,18 @@ move. Two constraints make it fit the render model: the provided callback is
 reference-stable (ref-backed), so trim handles — which read it via context,
 bypassing NodeCard's memo — don't re-render on every strip render; and the
 preview never touches the store, so no bystander card re-renders. On release
-the commit changes `nodesById`; the strip re-measures then (identity changes
-on a commit, never on a move/drag, so it stays at commit cadence), which also
-covers non-drag trims (keyboard, direct dispatch) the resizeItem path misses.
-The last preview size already matches the committed size, so there is no
-resize flash. An aborted drag (pointercancel, or a no-op) resets the preview.
+the commit reconciles through the store's change feed (`subscribeToChanges`):
+the `nodes-updated` patch names exactly the nodes whose widths changed, so
+the strip resizes only THOSE slots (targeted `resizeItem`, commit cadence,
+never a full re-measure) — which also covers non-drag trims (keyboard,
+direct dispatch). Full `measure()` is reserved for `replaceGraph` (which
+emits no change event — detected as a nodesById identity the feed never
+saw), scale/layout prop changes, and the `remeasure()` handle. Every
+duration-derived width — committed layout, live preview, measurement — runs
+through one exported `durationToWidth` conversion, so the sizing layers
+cannot drift. The last preview size already matches the committed size, so
+there is no resize flash. An aborted drag (pointercancel, or a no-op) resets
+the preview.
 
 The LEFT handle grows the clip toward the left: its right edge stays anchored,
 the left edge follows the cursor, and left neighbors slide left. `resizeItem`

--- a/packages/ui/dnd-collections/VirtualStrip.stories.tsx
+++ b/packages/ui/dnd-collections/VirtualStrip.stories.tsx
@@ -7,6 +7,7 @@ import { useCollectionsStore } from "./react/collections-store";
 import { DndCollections } from "./react/DndCollections";
 import { UndoRedoControls } from "./react/history-views";
 import { VirtualStrip, type VirtualStripHandle } from "./virtual/VirtualStrip";
+import { durationToWidth } from "./virtual/virtual-strip-geometry";
 import {
   dispatchPointerSequence,
   dragHoldAt,
@@ -1705,5 +1706,133 @@ export const FirstItemGutterOnSelect: Story = {
       expect(overview()).toBeNull();
       expect(vidLeft()).toBe(originLeft);
     });
+  },
+};
+
+// ── pixelsPerSecond sizing + the overlay slot (Phase: sizing unification) ──
+
+function ppsGraph() {
+  const result = buildGraph([
+    {
+      kind: "collection",
+      id: "strip",
+      name: "Strip",
+      children: [
+        { kind: "media", id: "img", name: "Img", durationSeconds: 4 },
+        {
+          kind: "media",
+          mediaKind: "video",
+          id: "vid",
+          name: "Vid",
+          fullDurationSeconds: 10,
+          trimInSeconds: 0,
+          trimOutSeconds: 0,
+        },
+        { kind: "collection", id: "folder", name: "Folder", children: [] },
+      ],
+    },
+  ]);
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.value;
+}
+
+export const PixelsPerSecondSizing: Story = {
+  // pixelsPerSecond is THE scale: media widths derive from duration, trim
+  // handles inherit the same conversion (no separate trimPixelsPerSecond,
+  // no itemWidthFor), collections keep the fixed itemWidth — and a trim
+  // commit/undo reconciles slot widths through the TARGETED resize path
+  // (the nodes-updated patch resizes exactly the touched slot).
+  render: () => (
+    <DndCollections initialGraph={ppsGraph()} animateMoves={false}>
+      <div className="flex w-[640px] flex-col gap-3">
+        <UndoRedoControls />
+        <VirtualStrip collectionId={parseNodeId("strip")} pixelsPerSecond={24} />
+      </div>
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    const width = (id: string) =>
+      Math.round(nodeCard(canvasElement, id).getBoundingClientRect().width);
+    await waitForLayout(nodeCard(canvasElement, "vid"));
+
+    // Media widths = duration * pps; collections keep the fixed itemWidth.
+    expect(width("img")).toBe(96);
+    expect(width("vid")).toBe(240);
+    expect(width("folder")).toBe(128);
+
+    // Trim handles inherited the scale: right edge in 48px -> trim-out +2s
+    // -> 8s -> 192px, live before release and held after commit.
+    const handleEl = nodeCard(canvasElement, "vid")
+      .closest("[data-node-wrapper]")!
+      .querySelector<HTMLElement>('[data-trim-handle="right"]')!;
+    const start = rectCenter(handleEl);
+    await dispatchPointerSequence([
+      { element: handleEl, type: "pointerdown", clientX: start.x, clientY: start.y },
+      { element: document, type: "pointermove", clientX: start.x - 48, clientY: start.y, delayAfterMs: 30 },
+    ]);
+    await waitFor(() => expect(width("vid")).toBe(192));
+    await dispatchPointerSequence([
+      { element: document, type: "pointerup", clientX: start.x - 48, clientY: start.y, delayAfterMs: 30 },
+    ]);
+    const undoButton = within(canvasElement).getByRole("button", { name: /undo/i });
+    await waitFor(() => expect(undoButton).toBeEnabled());
+    expect(width("vid")).toBe(192);
+
+    // Undo arrives as a nodes-updated patch too: the targeted resize
+    // restores exactly this slot to 240px.
+    const user = userEvent.setup();
+    await user.click(undoButton);
+    await waitFor(() => expect(width("vid")).toBe(240));
+  },
+};
+
+export const PlayheadOverlay: Story = {
+  // The overlay slot renders in CONTENT coordinates: a playhead placed with
+  // the shared durationToWidth scale sits at its exact content x and rides
+  // scrolling for free — its viewport position shifts by exactly the scroll
+  // while its content-relative offset never changes.
+  render: () => (
+    <DndCollections initialGraph={ppsGraph()} animateMoves={false}>
+      <div className="w-[320px]">
+        <VirtualStrip
+          collectionId={parseNodeId("strip")}
+          pixelsPerSecond={24}
+          overlay={
+            <div
+              data-playhead
+              style={{
+                position: "absolute",
+                top: 0,
+                bottom: 0,
+                left: durationToWidth(5, 24),
+                width: 2,
+                background: "red",
+              }}
+            />
+          }
+        />
+      </div>
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    await waitForLayout(nodeCard(canvasElement, "img"));
+    const strip = canvasElement.querySelector<HTMLElement>('[data-virtual-strip="strip"]')!;
+    const playhead = () => canvasElement.querySelector<HTMLElement>("[data-playhead]")!;
+    const spacer = playhead().closest("[data-virtual-overlay]")!.parentElement as HTMLElement;
+    const contentOffset = () =>
+      playhead().getBoundingClientRect().left - spacer.getBoundingClientRect().left;
+
+    expect(Math.round(contentOffset())).toBe(120); // durationToWidth(5, 24)
+
+    // Scroll the strip: the playhead rides the content — viewport position
+    // shifts by exactly the scroll, content-relative offset is unchanged.
+    const viewportBefore = playhead().getBoundingClientRect().left;
+    strip.scrollLeft = 60;
+    await waitFor(() => {
+      expect(Math.round(playhead().getBoundingClientRect().left)).toBe(
+        Math.round(viewportBefore - 60)
+      );
+    });
+    expect(Math.round(contentOffset())).toBe(120);
   },
 };

--- a/packages/ui/dnd-collections/index.ts
+++ b/packages/ui/dnd-collections/index.ts
@@ -154,6 +154,10 @@ export {
   type VirtualStripHandle,
   type VirtualStripProps,
 } from "./virtual/VirtualStrip";
+// THE duration -> width conversion every sizing layer shares (committed
+// layout, live trim preview, virtualizer measurement). Consumers use it for
+// overlay/playhead math or an itemWidthFor that must agree with trims.
+export { MIN_ITEM_WIDTH, durationToWidth } from "./virtual/virtual-strip-geometry";
 export {
   VirtualGrid,
   type VirtualGridHandle,

--- a/packages/ui/dnd-collections/react/collections-store.test.ts
+++ b/packages/ui/dnd-collections/react/collections-store.test.ts
@@ -249,6 +249,55 @@ describe("createCollectionsStore", () => {
     expect(store.getSnapshot().interaction.isDragging).toBe(false);
   });
 
+  test("subscribeToChanges mirrors the onChange feed and unsubscribes cleanly", () => {
+    const viaOption: string[] = [];
+    const viaSeam: string[] = [];
+    const store = createCollectionsStore(graphFixture(), {
+      onChange: (c) => viaOption.push(c.origin),
+    });
+    const interactionNotifies = vi.fn();
+    const unsubscribe = store.subscribeToChanges((change) => {
+      viaSeam.push(`${change.origin}:${change.patch.type}`);
+    });
+    store.subscribe(interactionNotifies);
+
+    store.dispatch(moveX);
+    store.undo();
+    store.redo();
+    // Interaction-only updates never reach the change feed.
+    store.setSelection([id("y")]);
+
+    expect(viaSeam).toEqual([
+      "command:nodes-moved",
+      "undo:nodes-moved",
+      "redo:nodes-moved",
+    ]);
+    expect(viaOption).toEqual(["command", "undo", "redo"]); // both feeds, same events
+
+    unsubscribe();
+    store.undo();
+    expect(viaSeam).toHaveLength(3); // no longer delivered
+    expect(viaOption).toHaveLength(4); // the option keeps receiving
+  });
+
+  test("subscribeToChanges works without an onChange option and stops on destroy", () => {
+    const store = createCollectionsStore(graphFixture());
+    const seen = vi.fn();
+    store.subscribeToChanges(seen);
+
+    store.dispatch(moveX);
+    expect(seen).toHaveBeenCalledTimes(1);
+
+    store.destroy();
+    store.dispatch({
+      type: "move-nodes",
+      nodeIds: [id("y")],
+      toParentId: id("root-b"),
+      toIndex: 0,
+    });
+    expect(seen).toHaveBeenCalledTimes(1);
+  });
+
   test("undo restores, redo replays; onChange origins are labeled", () => {
     const origins: string[] = [];
     const store = createCollectionsStore(graphFixture(), {

--- a/packages/ui/dnd-collections/react/collections-store.ts
+++ b/packages/ui/dnd-collections/react/collections-store.ts
@@ -77,6 +77,15 @@ export class InvalidInitialGraphError extends Error {
 export type CollectionsStore = Readonly<{
   getSnapshot: () => CollectionsSnapshot;
   subscribe: (listener: () => void) => () => void;
+  /**
+   * Subscribe to the COMMITTED-change feed — the same events (and ordering
+   * guarantees) as the `onChange` option, as a multi-listener seam. For
+   * views/tooling that need the PATCH of a commit (e.g. a virtual view
+   * resizing exactly the nodes a `nodes-updated` patch touched), which the
+   * snapshot deliberately doesn't carry. Fires for dispatch/undo/redo;
+   * `replaceGraph` deliberately emits nothing here either.
+   */
+  subscribeToChanges: (listener: (change: CollectionsChange) => void) => () => void;
 
   dispatch: (command: CollectionsCommand) => Result<CollectionsPatch, CommandRejection>;
   undo: () => boolean;
@@ -138,6 +147,7 @@ export function createCollectionsStore(
   };
   const history = createHistory({ maxEntries: options?.maxHistoryEntries });
   const listeners = new Set<() => void>();
+  const changeListeners = new Set<(change: CollectionsChange) => void>();
   const onChange = options?.onChange;
   const pendingChanges: CollectionsChange[] = [];
   let notificationDepth = 0;
@@ -171,12 +181,13 @@ export function createCollectionsStore(
   }
 
   function flushPendingChanges() {
-    if (!onChange || emittingChanges) return;
+    if ((!onChange && changeListeners.size === 0) || emittingChanges) return;
     emittingChanges = true;
     try {
       let change = pendingChanges.shift();
       while (change) {
-        onChange(change);
+        onChange?.(change);
+        for (const listener of changeListeners) listener(change);
         change = pendingChanges.shift();
       }
     } finally {
@@ -185,7 +196,7 @@ export function createCollectionsStore(
   }
 
   function notify(change?: CollectionsChange) {
-    if (change && onChange) pendingChanges.push(change);
+    if (change && (onChange || changeListeners.size > 0)) pendingChanges.push(change);
     snapshot = buildSnapshot();
     notificationDepth += 1;
     try {
@@ -299,6 +310,12 @@ export function createCollectionsStore(
         listeners.delete(listener);
       };
     },
+    subscribeToChanges: (listener) => {
+      changeListeners.add(listener);
+      return () => {
+        changeListeners.delete(listener);
+      };
+    },
 
     dispatch,
     undo,
@@ -391,6 +408,7 @@ export function createCollectionsStore(
         snapshot = buildSnapshot();
       }
       listeners.clear();
+      changeListeners.clear();
     },
   };
 }

--- a/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
@@ -9,10 +9,18 @@ import {
   useMemo,
   useRef,
   useState,
+  type ReactNode,
 } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 
-import { getChildren, isVideoMedia, type CollectionItemNode, type NodeId } from "../core/graph";
+import {
+  getChildren,
+  isVideoMedia,
+  mediaDurationSeconds,
+  type CollectionItemNode,
+  type CollectionsGraph,
+  type NodeId,
+} from "../core/graph";
 import {
   finiteNonNegativeOr,
   finitePositiveOr,
@@ -40,6 +48,7 @@ import {
 } from "./use-virtual-collection-view";
 import {
   MIN_ITEM_WIDTH,
+  durationToWidth,
   indicatorLeftOffset,
   leftAnchorShift,
   resolveBoundaryIndex,
@@ -85,11 +94,24 @@ const OVERVIEW_GAP = 8;
 
 export type VirtualStripProps = Readonly<{
   collectionId: NodeId;
-  /** Card width when `itemWidthFor` is absent or returns nothing for a node. */
+  /**
+   * THE timeline scale: media card widths derive from their effective
+   * duration via `durationToWidth(seconds, pixelsPerSecond)`, and — unless
+   * `trimPixelsPerSecond` overrides it — the trim handles convert drags at
+   * the same scale, so widths and trims cannot drift apart. Collections
+   * (and non-media fallbacks) use `itemWidth`. The recommended way to size
+   * a duration-mapped strip; `itemWidthFor` remains the advanced override.
+   */
+  pixelsPerSecond?: number;
+  /** Card width when duration-derived sizing doesn't apply: collections,
+   *  strips without `pixelsPerSecond`/`itemWidthFor`, or an `itemWidthFor`
+   *  miss. */
   itemWidth?: number;
   /**
-   * Per-node width from metadata (aspect ratio, duration, user data...).
-   * Evaluated lazily per index — never by rendering the node. The
+   * ADVANCED per-node width from metadata (aspect ratio, user data...) —
+   * overrides `pixelsPerSecond` sizing when both are set; keep the two on
+   * the same scale or trims will resize cards by a different amount than
+   * the drag. Evaluated lazily per index — never by rendering the node. The
    * virtualizer memoizes its measurements (keyed by the stable `getItemKey`),
    * so this runs once per layout, not once per render. After metadata loads
    * or zoom/scale changes, call `remeasure()` on the handle to recompute.
@@ -108,14 +130,25 @@ export type VirtualStripProps = Readonly<{
    */
   itemDragActivation?: "handle" | "hold";
   /**
-   * Enable media trim handles at card edges, converting the drag at this many
-   * pixels per second. Set it to the SAME scale your `itemWidthFor` uses so a
-   * trim resizes the card by the amount dragged.
+   * Override the trim handles' pixels-per-second conversion. Defaults to
+   * `pixelsPerSecond`, which is almost always what you want (one scale for
+   * widths AND trims); set explicitly only with a custom `itemWidthFor`
+   * whose scale differs. Trim handles render when either is set.
    */
   trimPixelsPerSecond?: number;
   /** Per-view card pixels — overrides the provider `components` registry.
    *  MUST be identity-stable (module scope). */
   itemContent?: CollectionItemContentComponent;
+  /**
+   * Rendered in CONTENT coordinates over the whole strip content (inside an
+   * `aria-hidden`, `pointer-events: none` layer above the cards), so it
+   * rides scrolling, auto-scroll, and the live-trim transform for free — a
+   * playhead line, region markers. Position children absolutely; convert
+   * time to x with the same `durationToWidth`/`pixelsPerSecond` scale.
+   * Re-enable pointer-events on your own elements if they must be
+   * interactive (they then sit above cards and handles — your trade-off).
+   */
+  overlay?: ReactNode;
   className?: string;
 }>;
 
@@ -132,6 +165,7 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
   function VirtualStrip(
     {
       collectionId,
+      pixelsPerSecond: pixelsPerSecondOption,
       itemWidth: itemWidthOption,
       itemWidthFor,
       itemHeight: itemHeightOption,
@@ -141,15 +175,20 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
       itemDragActivation = "handle",
       trimPixelsPerSecond: trimPixelsPerSecondOption,
       itemContent,
+      overlay,
       className,
     },
     ref
   ) {
+    const pixelsPerSecond = finitePositiveOrUndefined(pixelsPerSecondOption);
     const itemWidth = finitePositiveOr(itemWidthOption, 128);
     const itemHeight = finitePositiveOr(itemHeightOption, 96);
     const gap = finiteNonNegativeOr(gapOption, 8);
     const overscan = nonNegativeIntegerOr(overscanOption, 4);
-    const trimPixelsPerSecond = finitePositiveOrUndefined(trimPixelsPerSecondOption);
+    // One scale for widths AND trims by default: the handles inherit
+    // pixelsPerSecond unless explicitly overridden.
+    const trimPixelsPerSecond =
+      finitePositiveOrUndefined(trimPixelsPerSecondOption) ?? pixelsPerSecond;
     const store = useCollectionsStore();
     const cardActivation: NodeCardDragActivation = panToScroll ? itemDragActivation : "body";
 
@@ -174,15 +213,23 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
     const { scrollRef, contentRef, resolveBoundaryRef, setContainerRef } =
       useVirtualInsertContainer(collectionId, "vstrip");
 
-    const widthForIndex = (index: number): number => {
-      const node = nodesById.get(childIds[index]);
-      // Floor the slot at a clickable minimum: a fully trimmed clip derives a
-      // 0px width, and NodeCard's w-full would then render it 0px wide and
-      // unselectable. estimateSize and the rendered slot both read this, so
-      // layout stays consistent; the node's semantic duration is untouched.
-      const width = finiteNonNegativeOr(node ? itemWidthFor?.(node) : undefined, itemWidth);
-      return Math.max(MIN_ITEM_WIDTH, width);
+    // The committed width of a node, floored at a clickable minimum: a fully
+    // trimmed clip derives a 0px width, and NodeCard's w-full would then
+    // render it 0px wide and unselectable. estimateSize, the rendered slot,
+    // and the targeted-resize subscriber all read this, so layout stays
+    // consistent; the node's semantic duration is untouched. Resolution:
+    // itemWidthFor (advanced override) → pixelsPerSecond duration mapping
+    // (media only) → the fixed itemWidth.
+    const widthForNode = (node: CollectionItemNode | undefined): number => {
+      if (node && itemWidthFor) {
+        return Math.max(MIN_ITEM_WIDTH, finiteNonNegativeOr(itemWidthFor(node), itemWidth));
+      }
+      if (node && node.kind === "media" && pixelsPerSecond !== undefined) {
+        return durationToWidth(mediaDurationSeconds(node), pixelsPerSecond);
+      }
+      return Math.max(MIN_ITEM_WIDTH, itemWidth);
     };
+    const widthForIndex = (index: number): number => widthForNode(nodesById.get(childIds[index]));
 
     // Stable keys by node id (reorders move DOM nodes instead of repainting
     // every slot's contents) AND a stable callback identity: TanStack
@@ -223,18 +270,46 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
       paddingStart: firstItemGutter,
     });
 
-    // Variable widths come from node DATA, so a data change (a trim commit,
-    // a palette add) must re-run the cached measurements. `nodesById` only
-    // gets a new identity on such a commit — never on a move or a drag — so
-    // this stays at commit cadence, not per frame. Trim-enabled strips need
-    // it even at fixed widths: a live trim resizes slots via `resizeItem`,
-    // whose cache only `measure()` clears (TanStack's cache is key-based, so
-    // a reorder carries a stale size along) — without this, undoing a trim
-    // would leave the slot at the trimmed width. Fixed-width strips without
-    // trim handles never need it.
+    // Data-derived sizing reconciles at COMMIT cadence through the store's
+    // change feed: a `nodes-updated` patch names exactly the nodes whose
+    // widths may have changed (trim commit/undo/redo, keyboard trim), so
+    // only THOSE slots are resized — never a full re-measure. Moves, adds,
+    // and removals need nothing: TanStack's measurement cache is keyed by
+    // `getItemKey` (node id), so sizes follow reorders and new keys measure
+    // fresh. The feed fires synchronously during dispatch, before React
+    // renders, so `trimStateRef` still holds the pre-commit indexes (which
+    // updates don't change) while `update.after` carries the NEW node.
+    const sizingFromData =
+      itemWidthFor !== undefined ||
+      pixelsPerSecond !== undefined ||
+      trimPixelsPerSecond !== undefined;
+    const feedNodesRef = useRef<CollectionsGraph["nodesById"] | null>(null);
     useEffect(() => {
-      if (itemWidthFor || trimPixelsPerSecond !== undefined) virtualizer.measure();
-    }, [nodesById, itemWidthFor, trimPixelsPerSecond, virtualizer]);
+      if (!sizingFromData) return;
+      return store.subscribeToChanges((change) => {
+        feedNodesRef.current = change.graph.nodesById;
+        if (change.patch.type !== "nodes-updated") return;
+        const s = trimStateRef.current;
+        for (const update of change.patch.updates) {
+          const index = s.indexById.get(update.nodeId);
+          if (index === undefined) continue;
+          s.virtualizer.resizeItem(index, s.widthForNode(update.after) + s.gap);
+        }
+      });
+    }, [store, sizingFromData]);
+    // replaceGraph deliberately emits NO change event: a nodesById identity
+    // the feed never saw is a wholesale swap, and surviving ids may carry
+    // stale key-based sizes — drop the whole measurement cache. (Also covers
+    // the initial mount, where measuring an empty cache is free.)
+    useEffect(() => {
+      if (!sizingFromData) return;
+      if (feedNodesRef.current === nodesById) return;
+      virtualizer.measure();
+    }, [nodesById, sizingFromData, virtualizer]);
+    // A scale/layout config change re-derives every width.
+    useEffect(() => {
+      virtualizer.measure();
+    }, [pixelsPerSecond, itemWidth, gap, virtualizer]);
 
     // Live trim preview: a trim handle calls this per pointer-move to resize
     // ONE card without a graph commit, AND to publish the drag's current
@@ -249,8 +324,24 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
     // memoized cards still don't re-render. The callback must stay
     // reference-stable (trim handles read it via context) — it is, reading
     // mutable inputs from a ref and calling the stable setState.
-    const trimStateRef = useRef({ indexById, virtualizer, gap, trimPixelsPerSecond, widthForIndex, nodesById });
-    trimStateRef.current = { indexById, virtualizer, gap, trimPixelsPerSecond, widthForIndex, nodesById };
+    const trimStateRef = useRef({
+      indexById,
+      virtualizer,
+      gap,
+      trimPixelsPerSecond,
+      widthForIndex,
+      widthForNode,
+      nodesById,
+    });
+    trimStateRef.current = {
+      indexById,
+      virtualizer,
+      gap,
+      trimPixelsPerSecond,
+      widthForIndex,
+      widthForNode,
+      nodesById,
+    };
     const [liveTrim, setLiveTrim] = useState<{ nodeId: NodeId; trim: LiveTrim } | null>(null);
     // The COMMITTED node the live gesture started from. The commit effect
     // below uses it to tell this gesture's own settling commit (the node's
@@ -636,6 +727,20 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
                   />
                 </div>
               ))}
+              {/* Consumer overlay (playhead, region markers) in CONTENT
+                  coordinates: living inside the spacer means scroll,
+                  auto-scroll, and the live-trim anchor transform all apply
+                  for free. pointer-events: none so pan/drag/trim gestures
+                  pass through; aria-hidden keeps the grid tree valid. */}
+              {overlay !== undefined && (
+                <div
+                  aria-hidden="true"
+                  data-virtual-overlay
+                  style={{ position: "absolute", inset: 0, pointerEvents: "none", zIndex: 30 }}
+                >
+                  {overlay}
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/packages/ui/dnd-collections/virtual/virtual-strip-geometry.test.ts
+++ b/packages/ui/dnd-collections/virtual/virtual-strip-geometry.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   MIN_ITEM_WIDTH,
+  durationToWidth,
   indicatorLeftOffset,
   leftAnchorShift,
   resolveBoundaryIndex,
@@ -47,6 +48,20 @@ describe("indicatorLeftOffset", () => {
 
   it("handles a zero gap", () => {
     expect(indicatorLeftOffset(50, 0)).toBe(48);
+  });
+});
+
+describe("durationToWidth", () => {
+  it("is seconds*pps, floored at the clickable minimum", () => {
+    expect(durationToWidth(5, 24)).toBe(120);
+    expect(durationToWidth(0, 24)).toBe(MIN_ITEM_WIDTH);
+    expect(durationToWidth(0.2, 24)).toBe(MIN_ITEM_WIDTH); // 4.8px derived
+  });
+
+  it("honors an explicit minimum and rejects non-finite math", () => {
+    expect(durationToWidth(0, 24, 40)).toBe(40);
+    expect(durationToWidth(Number.NaN, 24)).toBe(MIN_ITEM_WIDTH);
+    expect(durationToWidth(5, Number.POSITIVE_INFINITY)).toBe(MIN_ITEM_WIDTH);
   });
 });
 

--- a/packages/ui/dnd-collections/virtual/virtual-strip-geometry.ts
+++ b/packages/ui/dnd-collections/virtual/virtual-strip-geometry.ts
@@ -48,14 +48,32 @@ export function indicatorLeftOffset(edgeStart: number, gap: number): number {
 }
 
 /**
+ * THE duration → width conversion — the single sizing invariant every layer
+ * shares: committed layout (`VirtualStrip pixelsPerSecond`), the live trim
+ * preview (`slotSizeFor`), and virtualizer measurement all run through this
+ * one function, so they cannot drift. Consumers use it too (playhead math,
+ * or an `itemWidthFor` that must agree with the trim scale). Non-finite
+ * inputs and short durations floor at `minimumWidth` — the clickable slot
+ * minimum.
+ */
+export function durationToWidth(
+  durationSeconds: number,
+  pixelsPerSecond: number,
+  minimumWidth: number = MIN_ITEM_WIDTH
+): number {
+  const width = durationSeconds * pixelsPerSecond;
+  return Number.isFinite(width) ? Math.max(minimumWidth, width) : minimumWidth;
+}
+
+/**
  * Slot width (px) a clip of `effectiveSeconds` occupies at `pixelsPerSecond`,
  * plus its trailing `gap` — the size handed to the virtualizer's `resizeItem`.
- * Floored at `MIN_ITEM_WIDTH` like the committed layout, so the last preview
- * of a near-fully-trimmed clip already matches the post-commit re-measure
- * (no resize snap on release, no invisible mid-drag sliver).
+ * Floored (via `durationToWidth`) like the committed layout, so the last
+ * preview of a near-fully-trimmed clip already matches the post-commit
+ * reconciliation (no resize snap on release, no invisible mid-drag sliver).
  */
 export function slotSizeFor(effectiveSeconds: number, pixelsPerSecond: number, gap: number): number {
-  return Math.max(MIN_ITEM_WIDTH, effectiveSeconds * pixelsPerSecond) + gap;
+  return durationToWidth(effectiveSeconds, pixelsPerSecond) + gap;
 }
 
 /**


### PR DESCRIPTION
…lay slot

Phase 3 of consumer-owned item UI: one sizing system, patch-driven slot reconciliation, and a content-coordinate overlay seam for playheads.

- durationToWidth(seconds, pps, min = MIN_ITEM_WIDTH) is THE duration -> width conversion, exported: committed layout, the live trim preview (slotSizeFor now delegates), and virtualizer measurement all share it, so the sizing layers cannot drift. Consumers use it for playhead math or an itemWidthFor that must agree with trims.

- VirtualStrip pixelsPerSecond: the recommended scale for duration-mapped strips. Media widths derive from effective duration, collections keep the fixed itemWidth, and trim handles INHERIT the same conversion (trimPixelsPerSecond becomes an explicit override) -- resolving the documented "set it to the SAME scale" foot-gun. itemWidthFor remains the advanced per-node override.

- store.subscribeToChanges: the committed-change feed as a multi-listener seam (same events/ordering as the onChange option; destroy() clears it). VirtualStrip uses it for TARGETED slot reconciliation: a nodes-updated patch resizes exactly the touched slots via resizeItem -- replacing the blanket measure() on every commit. Moves/adds/removals need nothing (TanStack's cache is key-based). Full measure() is reserved for replaceGraph -- which emits no change event, detected as a nodesById identity the feed never saw -- scale/layout prop changes, and the remeasure() handle. Side benefit: an unrelated commit mid-live-trim no longer resets the live-trimmed slot's cached size.

- VirtualStrip overlay: a consumer ReactNode rendered in CONTENT coordinates inside an aria-hidden, pointer-events-none layer above the cards -- rides scrolling, auto-scroll, and the live-trim anchor transform for free. The playhead seam.

- Stories: PixelsPerSecondSizing (duration widths, inherited trim scale, targeted-resize commit/undo restoring exact slot widths) and PlayheadOverlay (content-x placement, rides scroll with content-relative offset unchanged). Unit: durationToWidth + subscribeToChanges coverage.

- Docs: API.md (props, store row, sizing invariant, DOM-hook table) and ARCHITECTURE.md (trim reconciliation now describes the change-feed path).