### PR TITLE
feat(dnd-collections): compound primitives, overview content slot, ti…

### DIFF
--- a/packages/ui/dnd-collections/API.md
+++ b/packages/ui/dnd-collections/API.md
@@ -638,12 +638,28 @@ type CollectionTrimHandleContentProps = Readonly<{
 }>;
 type CollectionTrimHandleContentComponent = ComponentType<CollectionTrimHandleContentProps>;
 
+type CollectionTrimOverviewContentProps = Readonly<{
+  node: VideoMediaNode;
+  pixelsPerSecond: number;
+  trimInSeconds: number;      // live drag values override the committed trim
+  trimOutSeconds: number;
+  fullWidth: number;          // the full source's rendered width
+}>;
+type CollectionTrimOverviewContentComponent = ComponentType<CollectionTrimOverviewContentProps>;
+
 type CollectionsComponents = Readonly<{
   ItemContent?: CollectionItemContentComponent;  // every card, all views
   GhostContent?: CollectionGhostContentComponent; // the drag-overlay ghost
   TrimHandleContent?: CollectionTrimHandleContentComponent; // pixels INSIDE the trim hit zones
+  OverviewContent?: CollectionTrimOverviewContentComponent; // the overview's filmstrip/label pixels
 }>;
 ```
+
+**The source-window overview** splits the same way: `OverviewContent`
+replaces its BACKGROUND pixels (the full-source filmstrip and labels —
+default `DefaultTrimOverviewContent`), while the package keeps the dimmed
+trimmed-room layers, the amber showing-window, its trim grips, and the
+filmstrip-move gesture.
 
 **Trim handles** follow the same split: the shell keeps each handle's HIT
 ZONE — positioning, width, cursor, the pointer gesture, and the
@@ -687,6 +703,38 @@ Rules, all load-bearing for the efficiency model:
   primitive plus the structurally-shared `node`. Content may subscribe to
   its own stores — that re-renders only the subscribed content, never the
   shells (`CustomContentRenderEfficiency` asserts both directions).
+
+## React: compound items (`react/collection-item.tsx`)
+
+The FULL-custom escape hatch for items whose DOM composition the content
+slot can't express — interactive controls inside the card, a grip placed
+anywhere, trim handles embedded in custom chrome. Behavior is delivered
+through context (no raw refs/listeners to mis-spread); the consumer owns
+every pixel AND the DOM shape:
+
+```tsx
+<CollectionItem.Root id={id} trimPixelsPerSecond={24}>
+  <CollectionItem.SelectionSurface>…visible card…</CollectionItem.SelectionSurface>
+  <button onClick={mute}>M</button>  {/* real control: no select, no drag */}
+  <CollectionItem.DragHandle>⠿</CollectionItem.DragHandle>
+  <CollectionItem.TrimHandle side="right">…grip pixels…</CollectionItem.TrimHandle>
+  <CollectionItem.DropIndicators />
+</CollectionItem.Root>
+```
+
+| Primitive | Owns |
+| --- | --- |
+| `Root` | `id`, `className?`, `trimPixelsPerSecond?`, `rovingTabIndex?`. The draggable node AND droppable (ghost/collision rects = the whole item), the narrow selector subscriptions (same as NodeCard — the efficiency story holds), `data-node-wrapper`/`data-render-count`. Renders null for missing ids. |
+| `SelectionSurface` | The focusable `<button>`: `data-node-id` (FLIP, keyboard delegation, roving focus, and e2e key off it), selection clicks (Ctrl/Cmd toggles), `aria-label`/`aria-pressed`/instructions `describedby`, and the KEYBOARD grab (Enter) — always the tab stop. |
+| `DragHandle` | Pointer-only drag activator (`data-drag-handle`, `touch-action: none`, aria-hidden) — place it anywhere; keyboard drag stays on the SelectionSurface. |
+| `TrimHandle` | `side: "left" \| "right"` + your grip pixels as children. The hit zone (default edge geometry, override via `className`), the pointer gesture, `data-trim-handle` (the strip's pan filter skips it). Renders null for collections, images' left side, or without `Root trimPixelsPerSecond`. |
+| `DropIndicators` | The stock nest overlay + before/after bars. Or draw your own from `useCollectionItemState()` (`{ id, node, childCount, selected, rejected, isDragSource, dropSide, nestState }`). |
+
+Use compound items in YOUR containers (a mapped `getChildren` list, a custom
+virtualized view): card-adjacent drops, keyboard moves, trims, undo, and
+announcements all flow through the standard pipeline. `NodeCard` remains the
+batteries-included card; reach for `CollectionItem` only when the content
+slot isn't enough.
 
 ## React: views (`react/node-views.tsx`, `react/history-views.tsx`)
 
@@ -787,6 +835,13 @@ Slot widths reconcile at COMMIT cadence through `store.subscribeToChanges`:
 a `nodes-updated` patch resizes exactly the touched slots (targeted
 `resizeItem`); a full re-measure happens only for `replaceGraph`, scale/
 layout prop changes, and the `remeasure()` handle.
+
+For overlay math, `timeToOffset({ graph, collectionId, timeSeconds,
+pixelsPerSecond, gap?, itemWidth?, minimumWidth? })` maps timeline time →
+content-x over a `pixelsPerSecond`-sized strip (media advance the clock,
+collections occupy width only; floored clips cap at their right edge; the
+transient first-item gutter is excluded). Strips sized by a custom
+`itemWidthFor` need their own mapping against that same function.
 
 When `trimPixelsPerSecond` is set and a mounted video is selected,
 `VirtualStrip` renders the source-window overview (`TrimOverviewStrip`) as a

--- a/packages/ui/dnd-collections/ARCHITECTURE.md
+++ b/packages/ui/dnd-collections/ARCHITECTURE.md
@@ -62,6 +62,13 @@ react/
   node-views.tsx            Default views: CollectionPanels / -Panel /
                             NodeCard / NodeCardGhost. Cards receive ONLY an
                             id; everything else arrives via selectors.
+  collection-item.tsx       Compound primitives (CollectionItem.Root /
+                            SelectionSurface / DragHandle / TrimHandle /
+                            DropIndicators): the full-custom escape hatch —
+                            consumer-owned DOM shape (interactive controls
+                            included) over package-owned behavior, delivered
+                            through context. Same narrow selectors as
+                            NodeCard, so the efficiency story holds.
   node-thumbnail.tsx        NodeThumbnail: image = one <img> from src; video =
                             a sequence of poster frames (never a <video>),
                             count scaling with clip length. Memoized on node.

--- a/packages/ui/dnd-collections/CompoundItem.stories.tsx
+++ b/packages/ui/dnd-collections/CompoundItem.stories.tsx
@@ -1,0 +1,211 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, userEvent, waitFor } from "storybook/test";
+
+import {
+  buildGraph,
+  getChildren,
+  mediaDurationSeconds,
+  parseNodeId,
+  type NodeId,
+} from "./core/graph";
+import { DndCollections } from "./react/DndCollections";
+import { CollectionItem, useCollectionItemState } from "./react/collection-item";
+import { useCollectionsSelector } from "./react/collections-store";
+import {
+  dispatchPointerSequence,
+  dragHoldAt,
+  dragToPoint,
+  moveHeldPointer,
+  nodeCard,
+  rectCenter,
+  rectPoint,
+  releaseAt,
+  waitForLayout,
+} from "./stories-helpers";
+
+// The compound-primitive escape hatch, exercised the way a consumer with an
+// INTERACTIVE card would use it: a custom DOM shape hosting a real button
+// (which must neither select nor drag), a grip placed by the consumer, a
+// trim handle embedded in custom chrome, and the package's drop indicators —
+// with selection, keyboard moves, drag reordering, trims, and the
+// no-bystander-re-render guarantee all intact.
+
+function compoundGraph() {
+  const result = buildGraph([
+    {
+      kind: "collection",
+      id: "panel-c",
+      name: "Panel C",
+      children: [
+        { kind: "media", id: "alpha", name: "Alpha", durationSeconds: 4 },
+        { kind: "media", id: "bravo", name: "Bravo", durationSeconds: 4 },
+        { kind: "media", id: "charlie", name: "Charlie", durationSeconds: 4 },
+      ],
+    },
+  ]);
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.value;
+}
+
+/** Consumer content reading item state through the public hook. */
+function ClipLabel() {
+  const { node } = useCollectionItemState();
+  return (
+    <>
+      <span className="truncate font-medium text-foreground">{node.name}</span>
+      {node.kind === "media" && (
+        <span data-clip-duration className="text-[10px] text-muted-foreground">
+          {mediaDurationSeconds(node).toFixed(2)}s
+        </span>
+      )}
+    </>
+  );
+}
+
+/** A fully custom item: selection surface, a REAL consumer button, a
+ *  consumer-placed grip, an embedded trim handle, package indicators. */
+function ClipItem({ id }: { id: NodeId }) {
+  const [muteClicks, setMuteClicks] = useState(0);
+  return (
+    <CollectionItem.Root id={id} trimPixelsPerSecond={24} className="h-24 w-40 shrink-0">
+      <CollectionItem.SelectionSurface className="flex h-full w-full flex-col justify-between rounded-md border border-border bg-background p-2 pt-6 text-xs data-[selected=true]:ring-2 data-[selected=true]:ring-primary">
+        <ClipLabel />
+      </CollectionItem.SelectionSurface>
+      {/* Interactive consumer control: must not select, must not drag. */}
+      <button
+        type="button"
+        data-mute={id}
+        onClick={() => setMuteClicks((clicks) => clicks + 1)}
+        className="absolute top-1 right-1 z-10 rounded bg-black/70 px-1.5 py-0.5 text-[10px] text-white"
+      >
+        M{muteClicks}
+      </button>
+      <CollectionItem.DragHandle className="absolute top-1 left-1 z-10 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+        ⠿
+      </CollectionItem.DragHandle>
+      <CollectionItem.TrimHandle side="right">
+        <span className="flex h-full w-full items-center justify-center rounded-r-md bg-amber-300/80">
+          <span className="h-3 w-0.5 rounded bg-black/50" />
+        </span>
+      </CollectionItem.TrimHandle>
+      <CollectionItem.DropIndicators />
+    </CollectionItem.Root>
+  );
+}
+
+/** A consumer-owned container: no CollectionPanel, just a mapped list. */
+function CompoundList() {
+  const childIds = useCollectionsSelector((s) => getChildren(s.graph, parseNodeId("panel-c")));
+  return (
+    <div data-testid="compound-list" className="flex gap-3">
+      {childIds.map((id) => (
+        <ClipItem key={id} id={id} />
+      ))}
+    </div>
+  );
+}
+
+const meta = {
+  title: "UI/DndCollectionsCompoundItem",
+  decorators: [
+    (Story) => (
+      <div className="min-h-screen bg-background p-8 text-foreground">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function listOrder(canvasElement: HTMLElement): string[] {
+  return [
+    ...canvasElement.querySelectorAll<HTMLElement>('[data-testid="compound-list"] [data-node-id]'),
+  ].map((el) => el.dataset.nodeId ?? "");
+}
+
+export const InteractiveCompoundItems: Story = {
+  render: () => (
+    <DndCollections initialGraph={compoundGraph()} animateMoves={false}>
+      <CompoundList />
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    await waitForLayout(nodeCard(canvasElement, "alpha"));
+    expect(listOrder(canvasElement)).toEqual(["alpha", "bravo", "charlie"]);
+    const user = userEvent.setup();
+
+    // 1) The consumer's embedded button is genuinely interactive — and
+    //    neither selects nor starts a drag.
+    const mute = canvasElement.querySelector<HTMLElement>('[data-mute="alpha"]')!;
+    await user.click(mute);
+    expect(mute.textContent).toBe("M1");
+    expect(nodeCard(canvasElement, "alpha")).not.toHaveAttribute("data-selected");
+    expect(canvasElement.ownerDocument.querySelector('[data-testid="drag-ghost"]')).toBeNull();
+
+    // 2) The SelectionSurface selects (with the standard grammar).
+    await user.click(nodeCard(canvasElement, "alpha"));
+    await waitFor(() => {
+      expect(nodeCard(canvasElement, "alpha")).toHaveAttribute("data-selected", "true");
+    });
+
+    // 3) Alt+ArrowRight semantic move works through the same keyboard
+    //    delegation (data-node-id anchors it).
+    nodeCard(canvasElement, "alpha").focus();
+    await user.keyboard("{Alt>}{ArrowRight}{/Alt}");
+    await waitFor(() => {
+      expect(listOrder(canvasElement)).toEqual(["bravo", "alpha", "charlie"]);
+    });
+
+    // 4) Pointer reordering from the CONSUMER-PLACED grip.
+    const bravoGrip = canvasElement.querySelector<HTMLElement>('[data-drag-handle="bravo"]')!;
+    await dragToPoint(bravoGrip, rectPoint(nodeCard(canvasElement, "charlie"), 0.85));
+    await waitFor(() => {
+      expect(listOrder(canvasElement)).toEqual(["alpha", "charlie", "bravo"]);
+    });
+
+    // 5) The embedded trim handle commits update-media (no live resize in a
+    //    plain list — no TrimPreview — but the data trims and undo applies).
+    const alphaTrim = canvasElement
+      .querySelector<HTMLElement>('[data-node-wrapper="alpha"]')!
+      .querySelector<HTMLElement>('[data-trim-handle="right"]')!;
+    const start = rectCenter(alphaTrim);
+    await dispatchPointerSequence([
+      { element: alphaTrim, type: "pointerdown", clientX: start.x, clientY: start.y },
+      { element: document, type: "pointermove", clientX: start.x - 24, clientY: start.y, delayAfterMs: 30 },
+      { element: document, type: "pointerup", clientX: start.x - 24, clientY: start.y, delayAfterMs: 30 },
+    ]);
+    await waitFor(() => {
+      expect(
+        canvasElement
+          .querySelector('[data-node-wrapper="alpha"]')!
+          .querySelector("[data-clip-duration]")!.textContent
+      ).toBe("3.00s");
+    });
+
+    // 6) Efficiency holds for compound items: mid-drag jitter over one item
+    //    re-renders neither the bystander's Root nor its content.
+    const alphaGrip = canvasElement.querySelector<HTMLElement>('[data-drag-handle="alpha"]')!;
+    const holdPoint = rectPoint(nodeCard(canvasElement, "bravo"), 0.15);
+    await dragHoldAt(alphaGrip, holdPoint);
+    await waitFor(() => {
+      expect(
+        canvasElement
+          .querySelector('[data-node-wrapper="bravo"]')!
+          .querySelector('[data-drop-indicator="before"]')
+      ).not.toBeNull();
+    });
+    const bystander = canvasElement.querySelector<HTMLElement>('[data-node-wrapper="charlie"]')!;
+    const bystanderBefore = bystander.getAttribute("data-render-count");
+    await moveHeldPointer({ x: holdPoint.x + 3, y: holdPoint.y + 2 });
+    await moveHeldPointer({ x: holdPoint.x - 3, y: holdPoint.y - 2 });
+    await moveHeldPointer(holdPoint);
+    expect(bystander.getAttribute("data-render-count")).toBe(bystanderBefore);
+    await releaseAt(holdPoint);
+    await waitFor(() => {
+      expect(listOrder(canvasElement)).toEqual(["charlie", "alpha", "bravo"]);
+    });
+  },
+};

--- a/packages/ui/dnd-collections/CustomItemContent.stories.tsx
+++ b/packages/ui/dnd-collections/CustomItemContent.stories.tsx
@@ -16,6 +16,7 @@ import {
   type CollectionGhostContentProps,
   type CollectionItemContentProps,
   type CollectionTrimHandleContentProps,
+  type CollectionTrimOverviewContentProps,
 } from "./react/collections-components";
 import { useCollectionsSelector } from "./react/collections-store";
 import { useLiveTrim } from "./react/live-trim";
@@ -617,6 +618,57 @@ export const CollectionItemWithFirstAndLastChildImages: Story = {
     await waitFor(() => {
       expect(collectionCard).toHaveAttribute("data-selected", "true");
       expect(cover()).toHaveAttribute("data-user-collection-bookends", "selected");
+    });
+  },
+};
+
+// ── Overview background slot ────────────────────────────────────────────────
+
+const CustomOverviewContent = memo(function CustomOverviewContent({
+  node,
+}: CollectionTrimOverviewContentProps) {
+  return (
+    <span
+      data-custom-overview
+      className="flex h-full w-full items-center justify-center bg-zinc-800 text-[10px] text-amber-300"
+    >
+      {node.name} · {node.fullDurationSeconds}s source
+    </span>
+  );
+});
+
+export const CustomOverviewSlot: Story = {
+  // OverviewContent replaces the source-window overview's BACKGROUND pixels
+  // (filmstrip + labels); the package keeps the geometry and interactivity —
+  // the amber showing-window, its trim grips, and the move gesture.
+  render: () => (
+    <DndCollections
+      initialGraph={timelineGraph()}
+      animateMoves={false}
+      components={{ OverviewContent: CustomOverviewContent }}
+    >
+      <div className="w-[640px] pt-16">
+        <VirtualStrip collectionId={parseNodeId("strip")} pixelsPerSecond={24} />
+      </div>
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    const vid = nodeCard(canvasElement, "vid");
+    await waitForLayout(vid);
+    const user = userEvent.setup();
+    await user.click(vid);
+
+    await waitFor(() => {
+      const overview = canvasElement.querySelector('[data-trim-overview="vid"]');
+      expect(overview).not.toBeNull();
+      // Consumer background pixels...
+      expect(overview!.querySelector("[data-custom-overview]")).not.toBeNull();
+      expect(overview!.textContent).toContain("Vid · 10s source");
+      expect(overview!.textContent).not.toContain("full clip"); // default label replaced
+      // ...with the package's interactive window and grips intact.
+      expect(overview!.querySelector("[data-trim-overview-window]")).not.toBeNull();
+      expect(overview!.querySelector('[data-trim-overview-handle="left"]')).not.toBeNull();
+      expect(overview!.querySelector('[data-trim-overview-handle="right"]')).not.toBeNull();
     });
   },
 };

--- a/packages/ui/dnd-collections/index.ts
+++ b/packages/ui/dnd-collections/index.ts
@@ -113,10 +113,21 @@ export {
   type CollectionItemContentProps,
   type CollectionTrimHandleContentComponent,
   type CollectionTrimHandleContentProps,
+  type CollectionTrimOverviewContentComponent,
+  type CollectionTrimOverviewContentProps,
   type CollectionsComponents,
 } from "./react/collections-components";
 export { DefaultItemContent } from "./react/default-item-content";
 export { DefaultTrimHandleContent } from "./react/trim-handles";
+export { DefaultTrimOverviewContent } from "./react/trim-overview";
+// Compound primitives — the FULL-custom escape hatch: consumer-owned DOM
+// shape (interactive controls included) over package-owned behavior,
+// delivered through context. See "Compound items" in API.md.
+export {
+  CollectionItem,
+  useCollectionItemState,
+  type CollectionItemState,
+} from "./react/collection-item";
 // Live trim values for consumer readouts: opt-in, per-move re-renders scoped
 // to the calling component only (the store is never notified mid-gesture).
 export { useLiveTrim } from "./react/live-trim";
@@ -155,9 +166,13 @@ export {
   type VirtualStripProps,
 } from "./virtual/VirtualStrip";
 // THE duration -> width conversion every sizing layer shares (committed
-// layout, live trim preview, virtualizer measurement). Consumers use it for
-// overlay/playhead math or an itemWidthFor that must agree with trims.
-export { MIN_ITEM_WIDTH, durationToWidth } from "./virtual/virtual-strip-geometry";
+// layout, live trim preview, virtualizer measurement), plus timeline-time ->
+// content-x for overlay/playhead math over pixelsPerSecond-sized strips.
+export {
+  MIN_ITEM_WIDTH,
+  durationToWidth,
+  timeToOffset,
+} from "./virtual/virtual-strip-geometry";
 export {
   VirtualGrid,
   type VirtualGridHandle,

--- a/packages/ui/dnd-collections/react/collection-item.tsx
+++ b/packages/ui/dnd-collections/react/collection-item.tsx
@@ -1,0 +1,357 @@
+"use client";
+
+import {
+  createContext,
+  memo,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  type KeyboardEventHandler,
+  type MouseEvent,
+  type PointerEventHandler,
+  type ReactNode,
+} from "react";
+import { useDraggable, useDroppable, type DraggableAttributes } from "@dnd-kit/core";
+import { twMerge } from "tailwind-merge";
+
+import {
+  getChildren,
+  type CollectionItemNode,
+  type MediaNode,
+  type NodeId,
+} from "../core/graph";
+import { encodeDropTarget } from "../core/intents";
+import { finitePositiveOrUndefined } from "../core/numeric";
+import { useCollectionsSelector, useCollectionsStore } from "./collections-store";
+import { useCollectionsContainer } from "./container-context";
+import { NodeCardIndicators } from "./node-views";
+import { resolveTrim, useTrimPointerDrag, type TrimSide } from "./trim-gesture";
+
+// Compound primitives: the FULL-custom escape hatch for items whose DOM
+// composition NodeCard's content slot can't express — interactive controls
+// inside the card, a grip placed anywhere, trim handles embedded in custom
+// chrome. Behavior stays package-owned and is delivered through context (no
+// raw refs or listener bags to mis-spread); consumers own every pixel AND
+// the DOM shape:
+//
+//   <CollectionItem.Root id={id} trimPixelsPerSecond={24}>
+//     <CollectionItem.SelectionSurface>…visible card…</CollectionItem.SelectionSurface>
+//     <button onClick={mute}>M</button>                 // consumer control: no select, no drag
+//     <CollectionItem.DragHandle>⠿</CollectionItem.DragHandle>
+//     <CollectionItem.TrimHandle side="right" />
+//     <CollectionItem.DropIndicators />
+//   </CollectionItem.Root>
+//
+// Invariants the primitives uphold so consumers don't have to: the Root is
+// the draggable node AND droppable (ghost/collision rects = the whole item);
+// `data-node-id` lives on the focusable SelectionSurface (FLIP, keyboard
+// delegation, roving focus, and e2e all key off it); the keyboard grab
+// (Enter) lives there too; the DragHandle is a pointer-only affordance; trim
+// handles are pointer-only siblings of the selection button carrying
+// `data-trim-handle` (the strip's pan filter skips them). The efficiency
+// story holds: Root subscribes through the same narrow selectors as
+// NodeCard, so a drag over one item re-renders that item alone.
+
+type CollectionItemContextValue = Readonly<{
+  id: NodeId;
+  node: CollectionItemNode;
+  childCount: number;
+  selected: boolean;
+  rejected: boolean;
+  isDragSource: boolean;
+  dropSide: "before" | "after" | null;
+  nestState: "none" | "valid" | "invalid";
+  trimPixelsPerSecond: number | undefined;
+  rovingTabIndex: number | undefined;
+  select: (event: MouseEvent) => void;
+  // dnd-kit wiring, consumed only by the primitives — not part of the
+  // public state hook.
+  attributes: DraggableAttributes;
+  listeners: Record<string, unknown> | undefined;
+}>;
+
+const CollectionItemContext = createContext<CollectionItemContextValue | null>(null);
+
+function useCollectionItemContext(component: string): CollectionItemContextValue {
+  const value = useContext(CollectionItemContext);
+  if (!value) {
+    throw new Error(`CollectionItem.${component} must be rendered inside CollectionItem.Root`);
+  }
+  return value;
+}
+
+/** The item's live state, for drawing fully custom indicators/chrome. */
+export type CollectionItemState = Readonly<{
+  id: NodeId;
+  node: CollectionItemNode;
+  childCount: number;
+  selected: boolean;
+  rejected: boolean;
+  isDragSource: boolean;
+  dropSide: "before" | "after" | null;
+  nestState: "none" | "valid" | "invalid";
+}>;
+
+export function useCollectionItemState(): CollectionItemState {
+  const ctx = useCollectionItemContext("useCollectionItemState");
+  return useMemo(
+    () => ({
+      id: ctx.id,
+      node: ctx.node,
+      childCount: ctx.childCount,
+      selected: ctx.selected,
+      rejected: ctx.rejected,
+      isDragSource: ctx.isDragSource,
+      dropSide: ctx.dropSide,
+      nestState: ctx.nestState,
+    }),
+    [ctx]
+  );
+}
+
+function joinAriaIds(...ids: readonly (string | undefined)[]): string | undefined {
+  const joined = ids.filter((id): id is string => !!id).join(" ");
+  return joined || undefined;
+}
+
+const Root = memo(function CollectionItemRoot({
+  id,
+  className,
+  trimPixelsPerSecond,
+  rovingTabIndex,
+  children,
+}: {
+  id: NodeId;
+  /** Merged onto the root div (position: relative host for your layout). */
+  className?: string;
+  /** Enables TrimHandle children at this timeline scale (px per second). */
+  trimPixelsPerSecond?: number;
+  /** Single-tab-stop roving value (0 or -1) for custom virtualized views. */
+  rovingTabIndex?: number;
+  children: ReactNode;
+}) {
+  const store = useCollectionsStore();
+  const trimScale = finitePositiveOrUndefined(trimPixelsPerSecond);
+
+  // The same narrow subscriptions NodeCard uses — this is what keeps the
+  // no-bystander-re-render guarantee intact for compound items.
+  const node = useCollectionsSelector((s) => s.graph.nodesById.get(id) ?? null);
+  const childCount = useCollectionsSelector((s) =>
+    s.graph.nodesById.get(id)?.kind === "collection" ? getChildren(s.graph, id).length : 0
+  );
+  const selected = useCollectionsSelector((s) => s.interaction.selectedIds.has(id));
+  const isDragSource = useCollectionsSelector((s) => s.interaction.activeIdSet.has(id));
+  const rejected = useCollectionsSelector((s) => s.interaction.rejectedIdSet.has(id));
+  const dropSide = useCollectionsSelector((s) => {
+    const intent = s.interaction.dropIntent;
+    return intent?.type === "insert-adjacent" && intent.targetId === id ? intent.side : null;
+  });
+  const nestState = useCollectionsSelector((s) => {
+    const intent = s.interaction.dropIntent;
+    if (intent?.type !== "nest-inside" || intent.collectionId !== id) return "none";
+    return s.interaction.dropIntentInvalid ? "invalid" : "valid";
+  });
+
+  const renderCountRef = useRef(0);
+  renderCountRef.current += 1;
+
+  const dndId = encodeDropTarget({ type: "node", nodeId: id });
+  const { attributes, listeners, setNodeRef: setDraggableRef, isDragging } = useDraggable({
+    id: dndId,
+  });
+  const { setNodeRef: setDroppableRef } = useDroppable({ id: dndId });
+  const setRefs = useCallback(
+    (element: HTMLElement | null) => {
+      setDraggableRef(element);
+      setDroppableRef(element);
+    },
+    [setDraggableRef, setDroppableRef]
+  );
+
+  const select = useCallback(
+    (event: MouseEvent) => {
+      if (event.ctrlKey || event.metaKey) store.toggleSelected(id);
+      else store.setSelection([id]);
+    },
+    [store, id]
+  );
+
+  const dragSource = isDragging || isDragSource;
+  const value = useMemo<CollectionItemContextValue | null>(
+    () =>
+      node === null
+        ? null
+        : {
+            id,
+            node,
+            childCount,
+            selected,
+            rejected,
+            isDragSource: dragSource,
+            dropSide,
+            nestState,
+            trimPixelsPerSecond: trimScale,
+            rovingTabIndex,
+            select,
+            attributes,
+            listeners,
+          },
+    [
+      id,
+      node,
+      childCount,
+      selected,
+      rejected,
+      dragSource,
+      dropSide,
+      nestState,
+      trimScale,
+      rovingTabIndex,
+      select,
+      attributes,
+      listeners,
+    ]
+  );
+
+  if (!node || !value) return null;
+
+  return (
+    <CollectionItemContext.Provider value={value}>
+      <div
+        ref={setRefs}
+        data-node-wrapper={id}
+        data-render-count={renderCountRef.current}
+        className={twMerge("group relative", className)}
+      >
+        {children}
+      </div>
+    </CollectionItemContext.Provider>
+  );
+});
+
+const SelectionSurface = memo(function CollectionItemSelectionSurface({
+  children,
+  className,
+}: {
+  children?: ReactNode;
+  className?: string;
+}) {
+  const ctx = useCollectionItemContext("SelectionSurface");
+  const { instructionsId } = useCollectionsContainer();
+  const isCollection = ctx.node.kind === "collection";
+  return (
+    <button
+      type="button"
+      data-node-id={ctx.id}
+      data-node-kind={ctx.node.kind}
+      {...(ctx.selected ? { "data-selected": "true" } : {})}
+      {...(ctx.rejected ? { "data-rejected": "true" } : {})}
+      aria-label={`${ctx.node.name}${isCollection ? ` (collection, ${ctx.childCount} items)` : ""}`}
+      aria-pressed={ctx.selected}
+      aria-describedby={joinAriaIds(instructionsId)}
+      onClick={ctx.select}
+      // The KEYBOARD grab (Enter) always lives on the selection button — the
+      // one guaranteed tab stop — matching NodeCard's grammar. (Localized
+      // cast: dnd-kit types its listener map as Record<string, Function>.)
+      onKeyDown={ctx.listeners?.onKeyDown as KeyboardEventHandler<HTMLButtonElement> | undefined}
+      {...(ctx.rovingTabIndex !== undefined ? { tabIndex: ctx.rovingTabIndex } : {})}
+      className={twMerge("select-none text-left", className)}
+    >
+      {children}
+    </button>
+  );
+});
+
+const DragHandle = memo(function CollectionItemDragHandle({
+  children,
+  className,
+}: {
+  children?: ReactNode;
+  className?: string;
+}) {
+  const ctx = useCollectionItemContext("DragHandle");
+  return (
+    <span
+      // Pointer-only affordance: keyboard grab lives on SelectionSurface, so
+      // this never becomes a redundant tab stop. data-drag-handle keeps the
+      // strip's pan-surface filter treating it as drag territory.
+      aria-hidden="true"
+      data-drag-handle={ctx.id}
+      style={{ touchAction: "none" }}
+      onPointerDown={ctx.listeners?.onPointerDown as PointerEventHandler<HTMLSpanElement> | undefined}
+      className={twMerge("cursor-grab select-none active:cursor-grabbing", className)}
+    >
+      {children}
+    </span>
+  );
+});
+
+const TrimHandle = memo(function CollectionItemTrimHandle({
+  side,
+  children,
+  className,
+}: {
+  side: TrimSide;
+  children?: ReactNode;
+  className?: string;
+}) {
+  const ctx = useCollectionItemContext("TrimHandle");
+  // Hooks run unconditionally; the render below bails for non-trimmable
+  // configurations. The cast is safe: beginDrag is only reachable from a
+  // rendered handle, which requires a media node.
+  const beginDrag = useTrimPointerDrag(ctx.node as MediaNode);
+  const trimScale = ctx.trimPixelsPerSecond;
+  const node = ctx.node;
+
+  const onPointerDown = useCallback(
+    (event: Parameters<typeof beginDrag>[0]) => {
+      if (node.kind !== "media" || trimScale === undefined) return;
+      beginDrag(event, trimScale, (deltaSeconds) =>
+        resolveTrim(node, side, deltaSeconds)
+      );
+    },
+    [beginDrag, node, trimScale, side]
+  );
+
+  if (
+    node.kind !== "media" ||
+    trimScale === undefined ||
+    (side === "left" && node.mediaKind !== "video")
+  ) {
+    return null;
+  }
+
+  return (
+    <div
+      data-trim-handle={side}
+      aria-hidden="true"
+      onPointerDown={onPointerDown}
+      // Default hit-zone geometry mirrors the stock handles; override via
+      // className. Pixels come from children.
+      className={twMerge(
+        `absolute inset-y-0 z-20 w-2 cursor-ew-resize ${side === "left" ? "left-0" : "right-0"}`,
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+});
+
+function DropIndicators() {
+  const ctx = useCollectionItemContext("DropIndicators");
+  return <NodeCardIndicators nestState={ctx.nestState} dropSide={ctx.dropSide} />;
+}
+
+/**
+ * The compound-item namespace. All primitives must render inside `Root`;
+ * everything else about the DOM shape is yours.
+ */
+export const CollectionItem = {
+  Root,
+  SelectionSurface,
+  DragHandle,
+  TrimHandle,
+  DropIndicators,
+} as const;

--- a/packages/ui/dnd-collections/react/collections-components.tsx
+++ b/packages/ui/dnd-collections/react/collections-components.tsx
@@ -9,7 +9,12 @@ import {
   type ComponentType,
 } from "react";
 
-import { type CollectionItemNode, type MediaNode, type NodeId } from "../core/graph";
+import {
+  type CollectionItemNode,
+  type MediaNode,
+  type NodeId,
+  type VideoMediaNode,
+} from "../core/graph";
 
 // The consumer-content seam: dnd-collections owns BEHAVIOR and GEOMETRY
 // (drag wiring, selection, trim gestures, aria, measurement, indicators);
@@ -91,6 +96,26 @@ export type CollectionTrimHandleContentProps = Readonly<{
 export type CollectionTrimHandleContentComponent =
   ComponentType<CollectionTrimHandleContentProps>;
 
+export type CollectionTrimOverviewContentProps = Readonly<{
+  node: VideoMediaNode;
+  pixelsPerSecond: number;
+  /** Live drag values override the node's committed trim mid-gesture. */
+  trimInSeconds: number;
+  trimOutSeconds: number;
+  /** The full source's rendered width (`fullDurationSeconds * pps`, min 1px). */
+  fullWidth: number;
+}>;
+
+/**
+ * The BACKGROUND pixels of the source-window overview (`VirtualStrip`'s
+ * floating tooltip for a selected video): the full-source filmstrip and any
+ * labels. The package keeps the overview's geometry and interactivity — the
+ * dimmed trimmed-room layers, the amber showing-window, its trim grips, and
+ * the filmstrip-move gesture. Presentational only, like the other slots.
+ */
+export type CollectionTrimOverviewContentComponent =
+  ComponentType<CollectionTrimOverviewContentProps>;
+
 export type CollectionsComponents = Readonly<{
   /** Replaces the card pixels everywhere (panels, virtual views). Per-view
    *  `itemContent` props override this registry entry. */
@@ -99,6 +124,8 @@ export type CollectionsComponents = Readonly<{
   GhostContent?: CollectionGhostContentComponent;
   /** Replaces the pixels INSIDE the trim-handle hit zones. */
   TrimHandleContent?: CollectionTrimHandleContentComponent;
+  /** Replaces the source-window overview's filmstrip/label pixels. */
+  OverviewContent?: CollectionTrimOverviewContentComponent;
 }>;
 
 const EMPTY_COMPONENTS: CollectionsComponents = {};
@@ -125,12 +152,13 @@ export function useCollectionsComponentsValue(
   const ItemContent = components?.ItemContent;
   const GhostContent = components?.GhostContent;
   const TrimHandleContent = components?.TrimHandleContent;
+  const OverviewContent = components?.OverviewContent;
   const value = useMemo<CollectionsComponents>(
     () =>
-      ItemContent || GhostContent || TrimHandleContent
-        ? { ItemContent, GhostContent, TrimHandleContent }
+      ItemContent || GhostContent || TrimHandleContent || OverviewContent
+        ? { ItemContent, GhostContent, TrimHandleContent, OverviewContent }
         : EMPTY_COMPONENTS,
-    [ItemContent, GhostContent, TrimHandleContent]
+    [ItemContent, GhostContent, TrimHandleContent, OverviewContent]
   );
 
   const previousRef = useRef(value);

--- a/packages/ui/dnd-collections/react/node-views.tsx
+++ b/packages/ui/dnd-collections/react/node-views.tsx
@@ -334,8 +334,10 @@ export const NodeCard = memo(function NodeCard({
   );
 });
 
-/** Presentational drop-preview overlays: nest highlight + before/after bars. */
-function NodeCardIndicators({
+/** Presentational drop-preview overlays: nest highlight + before/after bars.
+ *  Shared by NodeCard and CollectionItem.DropIndicators (not exported from
+ *  the package index — the compound primitive is the public seam). */
+export function NodeCardIndicators({
   nestState,
   dropSide,
 }: {

--- a/packages/ui/dnd-collections/react/trim-overview.tsx
+++ b/packages/ui/dnd-collections/react/trim-overview.tsx
@@ -3,6 +3,10 @@
 import { memo, useCallback, type PointerEvent as ReactPointerEvent } from "react";
 
 import { type VideoMediaNode } from "../core/graph";
+import {
+  useCollectionsComponents,
+  type CollectionTrimOverviewContentProps,
+} from "./collections-components";
 import { resolveMove, resolveTrim, useTrimPointerDrag, type TrimSide } from "./trim-gesture";
 
 // Source-window overview for a SELECTED video: the FULL source rendered as a
@@ -32,6 +36,47 @@ const fmt1 = (s: number) => `${(Math.round(s * 10) / 10).toFixed(1)}s`;
 // each thumbnail keeps a 1:1 aspect instead of stretching to fill the width.
 const FRAME_SIZE = 44;
 
+/** The stock overview background: the full-source poster filmstrip plus the
+ *  "full clip" readout. Consumers replace it via the `OverviewContent`
+ *  registry slot; the dims/window/grips/move gesture stay package-owned. */
+export const DefaultTrimOverviewContent = memo(function DefaultTrimOverviewContent({
+  node,
+  fullWidth,
+}: CollectionTrimOverviewContentProps) {
+  const posters = node.posterSrcs ?? [];
+  // Enough square frames to cover the strip width (ceil so the row fills; the
+  // container clips the overflow), capped so a long source stays bounded.
+  const frameCount = Math.max(1, Math.min(40, Math.ceil(fullWidth / FRAME_SIZE)));
+  return (
+    <>
+      {/* Full-source filmstrip. */}
+      <div className="flex h-full w-full">
+        {posters.length === 0 ? (
+          <span className="flex h-full w-full items-center justify-center bg-muted text-[10px] text-muted-foreground select-none">
+            No preview frames
+          </span>
+        ) : (
+          Array.from({ length: frameCount }).map((_, i) => (
+            <img
+              key={i}
+              src={posters[i % posters.length]}
+              alt=""
+              draggable={false}
+              style={{ width: FRAME_SIZE }}
+              className="h-full shrink-0 border-r border-black/60 object-cover last:border-r-0"
+            />
+          ))
+        )}
+      </div>
+
+      {/* Full-clip readout. */}
+      <span className="pointer-events-none absolute top-0.5 left-1/2 -translate-x-1/2 rounded-full bg-black/75 px-2 py-0.5 font-mono text-[9px] text-zinc-100 select-none">
+        full clip {fmt1(Math.max(0, node.fullDurationSeconds))}
+      </span>
+    </>
+  );
+});
+
 export const TrimOverviewStrip = memo(function TrimOverviewStrip({
   node,
   pixelsPerSecond,
@@ -53,10 +98,8 @@ export const TrimOverviewStrip = memo(function TrimOverviewStrip({
   const trimInWidth = trimIn * pixelsPerSecond;
   const windowWidth = Math.max(2, showing * pixelsPerSecond);
 
-  const posters = node.posterSrcs ?? [];
-  // Enough square frames to cover the strip width (ceil so the row fills; the
-  // container clips the overflow), capped so a long source stays bounded.
-  const frameCount = Math.max(1, Math.min(40, Math.ceil(fullWidth / FRAME_SIZE)));
+  const OverviewContent =
+    useCollectionsComponents().OverviewContent ?? DefaultTrimOverviewContent;
 
   const beginDrag = useTrimPointerDrag(node);
   const startTrim = useCallback(
@@ -84,25 +127,14 @@ export const TrimOverviewStrip = memo(function TrimOverviewStrip({
       className="relative h-11 cursor-grab touch-none overflow-hidden rounded-md select-none active:cursor-grabbing"
       style={{ width: fullWidth }}
     >
-      {/* Full-source filmstrip. */}
-      <div className="flex h-full w-full">
-        {posters.length === 0 ? (
-          <span className="flex h-full w-full items-center justify-center bg-muted text-[10px] text-muted-foreground select-none">
-            No preview frames
-          </span>
-        ) : (
-          Array.from({ length: frameCount }).map((_, i) => (
-            <img
-              key={i}
-              src={posters[i % posters.length]}
-              alt=""
-              draggable={false}
-              style={{ width: FRAME_SIZE }}
-              className="h-full shrink-0 border-r border-black/60 object-cover last:border-r-0"
-            />
-          ))
-        )}
-      </div>
+      {/* Background pixels (filmstrip + labels): the OverviewContent slot. */}
+      <OverviewContent
+        node={node}
+        pixelsPerSecond={pixelsPerSecond}
+        trimInSeconds={trimIn}
+        trimOutSeconds={trimOut}
+        fullWidth={fullWidth}
+      />
 
       {/* Dim the trimmed room on each side. */}
       <div className="absolute inset-y-0 left-0 bg-background/55" style={{ width: trimInWidth }} />
@@ -128,11 +160,6 @@ export const TrimOverviewStrip = memo(function TrimOverviewStrip({
           className="absolute inset-y-0 right-0 z-10 w-2 cursor-ew-resize rounded-r-sm bg-amber-200/90"
         />
       </div>
-
-      {/* Full-clip readout. */}
-      <span className="pointer-events-none absolute top-0.5 left-1/2 -translate-x-1/2 rounded-full bg-black/75 px-2 py-0.5 font-mono text-[9px] text-zinc-100 select-none">
-        full clip {fmt1(full)}
-      </span>
     </div>
   );
 });

--- a/packages/ui/dnd-collections/virtual/virtual-strip-geometry.test.ts
+++ b/packages/ui/dnd-collections/virtual/virtual-strip-geometry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { buildGraph, parseNodeId, type CollectionsGraph } from "../core/graph";
 import {
   MIN_ITEM_WIDTH,
   durationToWidth,
@@ -7,6 +8,7 @@ import {
   leftAnchorShift,
   resolveBoundaryIndex,
   slotSizeFor,
+  timeToOffset,
 } from "./virtual-strip-geometry";
 
 const item = (start: number, size: number, index: number) => ({ start, size, index });
@@ -79,6 +81,70 @@ describe("slotSizeFor", () => {
 
   it("leaves widths at or above the floor untouched", () => {
     expect(slotSizeFor(0.5, 24, 8)).toBe(20); // exactly MIN_ITEM_WIDTH
+  });
+});
+
+describe("timeToOffset", () => {
+  // [img 4s][folder (no time)][vid 10-2-1=7s][tiny 0.2s (floored)]
+  function fixture(): CollectionsGraph {
+    const result = buildGraph([
+      {
+        kind: "collection",
+        id: "strip",
+        name: "Strip",
+        children: [
+          { kind: "media", id: "img", name: "Img", durationSeconds: 4 },
+          { kind: "collection", id: "folder", name: "Folder", children: [] },
+          {
+            kind: "media",
+            mediaKind: "video",
+            id: "vid",
+            name: "Vid",
+            fullDurationSeconds: 10,
+            trimInSeconds: 2,
+            trimOutSeconds: 1,
+          },
+          { kind: "media", id: "tiny", name: "Tiny", durationSeconds: 0.2 },
+        ],
+      },
+    ]);
+    if (!result.ok) throw new Error(JSON.stringify(result.error));
+    return result.value;
+  }
+  const strip = parseNodeId("strip");
+  const at = (t: number) =>
+    timeToOffset({ graph: fixture(), collectionId: strip, timeSeconds: t, pixelsPerSecond: 24 });
+  // Layout at pps 24, gap 8, itemWidth 128:
+  // img [0, 96) · folder [104, 232) · vid [240, 408) · tiny [416, 428) (floored)
+
+  it("maps times inside a clip linearly from its content start", () => {
+    expect(at(0)).toBe(0);
+    expect(at(2)).toBe(48);
+  });
+
+  it("skips non-media widths without advancing the clock", () => {
+    // t=4 is the start of the SECOND media item, after the folder's slot.
+    expect(at(4)).toBe(240);
+    expect(at(4 + 3.5)).toBe(240 + 84);
+  });
+
+  it("caps inside a floored clip at its right edge and clamps at the ends", () => {
+    // tiny starts at t=11; its 0.2s spans 4.8px of its 12px slot.
+    expect(at(11.1)).toBeCloseTo(416 + 2.4, 5);
+    expect(at(-1)).toBe(0);
+    // Past the total duration: the last media item's right edge.
+    expect(at(999)).toBe(428);
+  });
+
+  it("returns 0 for an unknown or empty collection", () => {
+    expect(
+      timeToOffset({
+        graph: fixture(),
+        collectionId: parseNodeId("nope"),
+        timeSeconds: 5,
+        pixelsPerSecond: 24,
+      })
+    ).toBe(0);
   });
 });
 

--- a/packages/ui/dnd-collections/virtual/virtual-strip-geometry.ts
+++ b/packages/ui/dnd-collections/virtual/virtual-strip-geometry.ts
@@ -3,6 +3,13 @@
 // virtualizer, DOM, or rAF loop. VirtualStrip owns the measurements, refs, and
 // scrolling; this owns the numbers.
 
+import {
+  getChildren,
+  mediaDurationSeconds,
+  type CollectionsGraph,
+  type NodeId,
+} from "../core/graph";
+
 /** Half the drop-indicator line's width (px) — used to center it in a gap. */
 const INDICATOR_HALF_WIDTH = 2;
 
@@ -86,4 +93,62 @@ export function leftAnchorShift(liveSlotSize: number, baselineSize: number): num
   // baseline − live == −(growth); written this way so no change yields +0
   // rather than −0 (behaviorally identical, but tidier).
   return baselineSize - liveSlotSize;
+}
+
+/**
+ * Timeline time → content-x, for overlay math (a playhead at `timeSeconds`)
+ * over a `pixelsPerSecond`-sized strip. Walks the collection's children:
+ * media items advance the clock by their EFFECTIVE duration and the x by
+ * their slot width (`durationToWidth` + gap — the same conversion the strip
+ * lays out with); non-media items (collections) occupy width but no time.
+ *
+ * Semantics to be aware of:
+ * - Inside a FLOORED clip (shorter than `minimumWidth / pps`), x advances at
+ *   `pps` and caps at the clip's right edge — the clip is wider than its
+ *   time, so the playhead never overshoots it.
+ * - `timeSeconds` past the strip's total duration clamps to the last media
+ *   item's right edge; negative times clamp to 0.
+ * - The result is CONTENT coordinates, which is what the `overlay` slot
+ *   renders in. It does NOT include `VirtualStrip`'s transient first-item
+ *   gutter (`paddingStart` while a trimmed-in first video is selected) — the
+ *   one case content-x and item offsets diverge.
+ * - Assumes `pixelsPerSecond` sizing; strips sized by a custom `itemWidthFor`
+ *   need their own mapping against that same function.
+ */
+export function timeToOffset(args: {
+  graph: CollectionsGraph;
+  collectionId: NodeId;
+  timeSeconds: number;
+  pixelsPerSecond: number;
+  /** Match the strip's props: gap default 8, itemWidth default 128. */
+  gap?: number;
+  itemWidth?: number;
+  minimumWidth?: number;
+}): number {
+  const { graph, collectionId, timeSeconds, pixelsPerSecond } = args;
+  const gap = args.gap ?? 8;
+  const itemWidth = args.itemWidth ?? 128;
+  const minimumWidth = args.minimumWidth ?? MIN_ITEM_WIDTH;
+
+  let x = 0;
+  let clock = 0;
+  let lastMediaRight: number | null = null;
+  for (const childId of getChildren(graph, collectionId)) {
+    const node = graph.nodesById.get(childId);
+    if (!node) continue;
+    if (node.kind !== "media") {
+      x += Math.max(minimumWidth, itemWidth) + gap;
+      continue;
+    }
+    const duration = mediaDurationSeconds(node);
+    const width = durationToWidth(duration, pixelsPerSecond, minimumWidth);
+    if (timeSeconds < clock + duration) {
+      const within = Math.max(0, timeSeconds - clock) * pixelsPerSecond;
+      return x + Math.min(within, width);
+    }
+    clock += duration;
+    x += width + gap;
+    lastMediaRight = x - gap;
+  }
+  return lastMediaRight ?? 0;
 }


### PR DESCRIPTION
…meToOffset

The three demand-driven backlog items, shipped together:

- CollectionItem compound primitives (react/collection-item.tsx): the FULL-custom escape hatch for items whose DOM shape the content slot can't express -- interactive controls inside the card, a consumer-placed grip, trim handles embedded in custom chrome. Behavior is delivered through context (no raw refs/listener bags): Root owns the draggable/droppable wiring and NodeCard's narrow selectors (the efficiency story holds -- pinned by the story's bystander render-count assertion); SelectionSurface is the focusable button carrying data-node-id, selection, aria, and the keyboard grab; DragHandle is a pointer-only activator; TrimHandle wraps the gesture around consumer grip pixels; DropIndicators reuses the stock overlays, with useCollectionItemState for fully custom chrome. The InteractiveCompoundItems story proves an embedded real <button> neither selects nor drags while everything else (keyboard moves, grip reordering, trims, indicators) flows through the standard pipeline.

- OverviewContent registry slot: the source-window overview splits like the trim handles -- consumers replace the BACKGROUND pixels (filmstrip + labels; extracted default: DefaultTrimOverviewContent) while the package keeps the dims, amber window, grips, and move gesture. CustomOverviewSlot pins consumer pixels coexisting with package interactivity.

- timeToOffset (virtual-strip-geometry): timeline time -> content-x for overlay/playhead math over pixelsPerSecond strips. Media advance the clock, collections occupy width only, floored clips cap at their right edge, out-of-range times clamp; the transient first-item gutter is documented as excluded. Unit-tested against a mixed strip.

Docs: API.md gains the "Compound items" section, the OverviewContent contract, and the timeToOffset reference; ARCHITECTURE.md lists the new module.