### PR TITLE
fix(dnd-collections): review round-2 -- FLIP whole items, overlay a11…

### DIFF
--- a/apps/web/tests/e2e/dnd-collections.spec.ts
+++ b/apps/web/tests/e2e/dnd-collections.spec.ts
@@ -375,6 +375,22 @@ test.describe('DndCollections E2E', () => {
     // Undo reverts the last trim (ordinary undoable command).
     await page.getByRole('button', { name: /undo/i }).click();
     await expect(async () => expect(await widthOf(vid)).toBe(192)).toPass();
+
+    // Alt+Shift+End SLIDES the source window later (trim-in 1s -> 2s,
+    // trim-out 1s -> 0s): the clip's width holds — the observable is the
+    // floating overview, whose anchor (clipLeft - trimIn * pps) shifts left
+    // by exactly the slide (24px at 24 px/s).
+    const overview = page.locator('[data-trim-overview="vid"]');
+    await overview.waitFor({ state: 'visible' });
+    const overviewLeft0 = (await overview.boundingBox())!.x;
+    // The undo click moved focus to the button — the chord needs the card.
+    await vid.click();
+    await expect(vid).toBeFocused();
+    await trim('End');
+    await expect(async () => {
+      expect(Math.round((await overview.boundingBox())!.x)).toBe(Math.round(overviewLeft0 - 24));
+    }).toPass();
+    expect(await widthOf(vid)).toBe(192); // duration (and width) unchanged
   });
 
   test('trim overview: amber window stays aligned to the clip during a real drag', async ({

--- a/packages/ui/dnd-collections/API.md
+++ b/packages/ui/dnd-collections/API.md
@@ -446,6 +446,20 @@ type KeyboardTrimAction =
 start-edge action on an image). Wired in the default views
 as **Alt+Shift+Arrow** (horizontal = end edge, vertical = video start edge).
 
+### `resolveWindowMoveCommand(graph, nodeId, action, stepSeconds): Result<UpdateMediaCommand, KeyboardWindowMoveRejection>`
+
+Keyboard source-window slide for a focused VIDEO: `"window-earlier"` /
+`"window-later"` shift trim-in and trim-out TOGETHER by `stepSeconds`, so
+the showing duration (and the card width) never changes — the keyboard
+equivalent of dragging the overview filmstrip. Unlike `resolveTrimCommand`,
+this resolver clamps itself (mirroring the pointer `resolveMove` math — the
+reducer's independent per-end clamps would otherwise change the duration); a
+step with no room resolves to the current values and comes back from
+`dispatch` as `same-position`, announced as a boundary.
+`KeyboardWindowMoveRejection.reason`: `missing-node`, `not-media-node`,
+`invalid-step`, and `no-source-window` (images). Wired in the default views
+as **Alt+Shift+Home / Alt+Shift+End**.
+
 ### `resolveTrashCommand(graph, nodeId, trashId): Result<MoveNodesCommand, KeyboardTrashRejection>`
 
 Keyboard "move to trash" for a focused node, resolving to the same
@@ -517,6 +531,7 @@ layer is a separate, always-available set of quick semantic moves:
 | Alt+ArrowUp | `move-out` |
 | Alt+Shift+ArrowLeft / Alt+Shift+ArrowRight | Trim the end edge shorter / longer (image duration / video trim-out) |
 | Alt+Shift+ArrowUp / Alt+Shift+ArrowDown | Trim the video start edge (trim-in); images reject |
+| Alt+Shift+Home / Alt+Shift+End | Slide the video source window earlier / later (duration unchanged); images reject |
 | Alt+Delete | Move to trash (only while a `<TrashTarget>` is mounted) |
 
 Alt+Enter / Alt+Backspace are always-available synonyms for
@@ -525,9 +540,10 @@ Alt+ArrowUp / Alt+ArrowDown become row moves (± the column count) and the
 arrow bindings are therefore unavailable for nesting.
 
 The pointer trim handles and the source-window overview are `aria-hidden`
-visual affordances — the accessible way to trim is a focused card plus the
-Alt+Shift bindings above. (Sliding a video's source window without changing
-its duration remains pointer-only; a keyboard equivalent is a known gap.)
+visual affordances — every operation they offer has a keyboard equivalent on
+the focused card: the Alt+Shift arrow bindings trim the edges, and
+Alt+Shift+Home/End slide a video's source window (trim-in/out shift
+together; the showing duration never changes).
 
 ---
 
@@ -811,7 +827,7 @@ type VirtualStripProps = {
   itemDragActivation?: "handle" | "hold";                // default "handle" (grip bar); "hold" = press-and-hold the body. Ignored when panToScroll is off (bodies drag instantly)
   trimPixelsPerSecond?: number;                          // override the trim conversion; DEFAULTS to pixelsPerSecond. Handles render when either is set; commits update-media on release. LIVE resize follows the strip's OWN width resolution (a synthesized node with the live trims runs through itemWidthFor/pixelsPerSecond) — so consumer floors hold mid-drag, and a fixed-width strip's card keeps its width (data trims, geometry doesn't)
   itemContent?: CollectionItemContentComponent;          // per-view card pixels; overrides the provider registry
-  overlay?: ReactNode;                                   // content-coordinate layer over the strip (playhead, markers): rides scroll + live-trim transform; aria-hidden, pointer-events none
+  overlay?: ReactNode;                                   // STRICTLY PRESENTATIONAL content-coordinate layer over the strip (playhead, markers): rides scroll + live-trim transform. aria-hidden + pointer-events none — no interactive/focusable children (focusable-inside-aria-hidden is an a11y violation); interactive scrubbers belong in your own layer outside the strip
   className?: string;
 };
 type VirtualStripHandle = {
@@ -836,11 +852,17 @@ a `nodes-updated` patch resizes exactly the touched slots (targeted
 `resizeItem`); a full re-measure happens only for `replaceGraph`, scale/
 layout prop changes, and the `remeasure()` handle.
 
-For overlay math, `timeToOffset({ graph, collectionId, timeSeconds,
-pixelsPerSecond, gap?, itemWidth?, minimumWidth? })` maps timeline time →
-content-x over a `pixelsPerSecond`-sized strip (media advance the clock,
-collections occupy width only; floored clips cap at their right edge; the
-transient first-item gutter is excluded). Strips sized by a custom
+For overlay math, `createTimeToOffset({ graph, collectionId,
+pixelsPerSecond, gap?, itemWidth?, minimumWidth? })` builds a timeline-time
+→ content-x lookup over a `pixelsPerSecond`-sized strip: O(n) prefix sums
+once (rebuild at commit/config cadence via `onChange` /
+`subscribeToChanges`), then `.at(t)` is O(log n) and `.cursor().at(t)` is
+O(1) amortized for monotonic consumption — the per-frame playhead path,
+ideally writing a transform imperatively rather than re-rendering React per
+frame. Mapping semantics: media advance the clock, collections occupy width
+only, floored clips cap at their right edge, out-of-range times clamp, and
+the transient first-item gutter is excluded. `timeToOffset({ ...,
+timeSeconds })` remains the one-shot convenience. Strips sized by a custom
 `itemWidthFor` need their own mapping against that same function.
 
 When `trimPixelsPerSecond` is set and a mounted video is selected,

--- a/packages/ui/dnd-collections/ARCHITECTURE.md
+++ b/packages/ui/dnd-collections/ARCHITECTURE.md
@@ -373,7 +373,10 @@ Everything semantic happens in `core/`.
   trim branch is checked before the move/grid logic so a held Shift never
   falls through to a move, and a trim keeps the card mounted, so focus stays
   put (no restore needed). Alt+Shift+↑/↓ on an image announces "trimmed at the
-  end only" (images have no start edge).
+  end only" (images have no start edge). **Alt+Shift+Home/End** slide a
+  video's source window (trim-in/out together, showing duration constant —
+  the overview filmstrip drag's keyboard equivalent, `resolveWindowMoveCommand`),
+  closing the last pointer-only trim operation.
 - The card button is always a tab stop and always carries the KEYBOARD grab
   (Enter) — in handle mode the grip is a pointer-only second stop, so the
   instructions' "Press Enter to pick it up" stays true in every mode,

--- a/packages/ui/dnd-collections/CompoundItem.stories.tsx
+++ b/packages/ui/dnd-collections/CompoundItem.stories.tsx
@@ -209,3 +209,65 @@ export const InteractiveCompoundItems: Story = {
     });
   },
 };
+
+export const CompoundFlipAnimatesWholeItem: Story = {
+  // FLIP animates the data-node-wrapper HOST — the whole compound item,
+  // consumer controls and handles included — not just the selection surface
+  // (which would let siblings teleport while the surface glides).
+  render: () => (
+    <DndCollections initialGraph={compoundGraph()}>
+      <CompoundList />
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    await waitForLayout(nodeCard(canvasElement, "alpha"));
+    const user = userEvent.setup();
+    nodeCard(canvasElement, "alpha").focus();
+
+    // The commit's FLIP sweep plays synchronously in the layout effect, so
+    // animations are live the moment the awaited keypress returns.
+    await user.keyboard("{Alt>}{ArrowRight}{/Alt}");
+    const wrapper = canvasElement.querySelector<HTMLElement>('[data-node-wrapper="alpha"]')!;
+    const flip = wrapper.getAnimations().flatMap((a) => {
+      if (!(a.effect instanceof KeyframeEffect)) return [];
+      const t = a.effect.getKeyframes()[0]?.transform;
+      return typeof t === "string" && t.startsWith("translate") ? [t] : [];
+    });
+    expect(flip.length).toBeGreaterThan(0);
+
+    await waitFor(() => {
+      expect(listOrder(canvasElement)).toEqual(["bravo", "alpha", "charlie"]);
+    });
+  },
+};
+
+export const CompoundKeyboardGrab: Story = {
+  // The manual Enter-grab wiring on SelectionSurface (the KeyboardSensor
+  // activator attached by hand): Enter picks the item up (ghost appears),
+  // Escape cancels cleanly.
+  render: () => (
+    <DndCollections initialGraph={compoundGraph()} animateMoves={false}>
+      <CompoundList />
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    await waitForLayout(nodeCard(canvasElement, "alpha"));
+    const user = userEvent.setup();
+    nodeCard(canvasElement, "alpha").focus();
+
+    await user.keyboard("{Enter}");
+    await waitFor(() => {
+      expect(
+        canvasElement.ownerDocument.querySelector('[data-testid="drag-ghost"]')
+      ).not.toBeNull();
+    });
+
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(
+        canvasElement.ownerDocument.querySelector('[data-testid="drag-ghost"]')
+      ).toBeNull();
+    });
+    expect(listOrder(canvasElement)).toEqual(["alpha", "bravo", "charlie"]);
+  },
+};

--- a/packages/ui/dnd-collections/DndCollections.stories.tsx
+++ b/packages/ui/dnd-collections/DndCollections.stories.tsx
@@ -538,7 +538,8 @@ export const FlipAnimatesCommits: Story = {
     // moment the awaited click returns. alpha travels back left, and bravo
     // (which never re-rendered) shifts too.
     await user.click(canvas.getByRole("button", { name: /undo/i }));
-    const moved = nodeCard(canvasElement, "alpha");
+    // FLIP animates the WRAPPER (the whole item, siblings included).
+    const moved = flipHost(nodeCard(canvasElement, "alpha"));
     expect(moved.getAnimations().length).toBeGreaterThan(0);
 
     await waitFor(() => {
@@ -597,15 +598,6 @@ export const TwoInstancesStayIsolated: Story = {
     // live when the awaited click returns.
     await user.click(within(boardOne).getByRole("button", { name: /undo/i }));
 
-    // getAnimations() also reports CSS transitions (the card has
-    // transition-all), so pick out FLIP by its translate keyframe.
-    const flipTransforms = (el: HTMLElement) =>
-      el.getAnimations().flatMap((a) => {
-        if (!(a.effect instanceof KeyframeEffect)) return [];
-        const t = a.effect.getKeyframes()[0]?.transform;
-        return typeof t === "string" && t.startsWith("translate") ? [t] : [];
-      });
-
     // Board one's alpha slides home WITHIN ITS ROW: the inverted transform
     // must have a zero vertical component. A cross-instance rect collision
     // would produce a large dy (the distance between the boards).
@@ -620,24 +612,35 @@ export const TwoInstancesStayIsolated: Story = {
   },
 };
 
-// FLIP keyframe transforms of an element, excluding CSS transitions (the
-// card has transition-all) — picked out by the translate keyframe.
-function flipTransforms(el: HTMLElement): string[] {
-  return el.getAnimations().flatMap((a) => {
-    if (!(a.effect instanceof KeyframeEffect)) return [];
-    const t = a.effect.getKeyframes()[0]?.transform;
-    return typeof t === "string" && t.startsWith("translate") ? [t] : [];
-  });
+// FLIP animates the data-node-wrapper HOST (the whole item — button plus
+// sibling grip/handles/indicators), keyed by the data-node-id element.
+// Resolve a card button to the element the sweep actually animates.
+function flipHost(el: HTMLElement): HTMLElement {
+  return el.closest<HTMLElement>("[data-node-wrapper]") ?? el;
 }
 
-// The in-flight FLIP animation on an element (its translate keyframe effect),
+// FLIP keyframe transforms of a card, excluding CSS transitions (the card
+// has transition-all) — picked out by the translate keyframe.
+function flipTransforms(el: HTMLElement): string[] {
+  return flipHost(el)
+    .getAnimations()
+    .flatMap((a) => {
+      if (!(a.effect instanceof KeyframeEffect)) return [];
+      const t = a.effect.getKeyframes()[0]?.transform;
+      return typeof t === "string" && t.startsWith("translate") ? [t] : [];
+    });
+}
+
+// The in-flight FLIP animation on a card (its translate keyframe effect),
 // or undefined once it has finished/cancelled.
 function flipAnimation(el: HTMLElement): Animation | undefined {
-  return el.getAnimations().find((a) => {
-    if (!(a.effect instanceof KeyframeEffect)) return false;
-    const t = a.effect.getKeyframes()[0]?.transform;
-    return typeof t === "string" && t.startsWith("translate");
-  });
+  return flipHost(el)
+    .getAnimations()
+    .find((a) => {
+      if (!(a.effect instanceof KeyframeEffect)) return false;
+      const t = a.effect.getKeyframes()[0]?.transform;
+      return typeof t === "string" && t.startsWith("translate");
+    });
 }
 
 // Wait for an element's FLIP animation to advance past its start. A commit

--- a/packages/ui/dnd-collections/VirtualStrip.stories.tsx
+++ b/packages/ui/dnd-collections/VirtualStrip.stories.tsx
@@ -1018,7 +1018,9 @@ export const FlipAnimatesStripReorder: Story = {
     m0.focus();
     await user.keyboard("{Alt>}{ArrowRight}{/Alt}");
 
-    const flip = m0.getAnimations().flatMap((a) => {
+    // FLIP animates the data-node-wrapper HOST (whole item, siblings incl.).
+    const host = m0.closest<HTMLElement>("[data-node-wrapper]") ?? m0;
+    const flip = host.getAnimations().flatMap((a) => {
       if (!(a.effect instanceof KeyframeEffect)) return [];
       const t = a.effect.getKeyframes()[0]?.transform;
       return typeof t === "string" && t.startsWith("translate") ? [t] : [];

--- a/packages/ui/dnd-collections/core/keyboard.test.ts
+++ b/packages/ui/dnd-collections/core/keyboard.test.ts
@@ -12,6 +12,7 @@ import {
   resolveKeyboardCommand,
   resolveTrashCommand,
   resolveTrimCommand,
+  resolveWindowMoveCommand,
 } from "./keyboard";
 
 const media = (id: string): GraphNodeSpec => ({ kind: "media", id, name: id });
@@ -379,5 +380,123 @@ describe("resolveTrashCommand", () => {
     const applied = applyCommand(nested, resolved.value);
     expect(applied.ok).toBe(false);
     if (!applied.ok) expect(applied.error.reason).toBe("would-create-cycle");
+  });
+});
+
+describe("resolveWindowMoveCommand", () => {
+  // root: [img (4s image), vid (10s source, trimmed 2s in / 1s out -> 7s)]
+  const windowGraph = build([
+    collection("root", [
+      { kind: "media", id: "img", name: "img", durationSeconds: 4 },
+      {
+        kind: "media",
+        mediaKind: "video",
+        id: "vid",
+        name: "vid",
+        fullDurationSeconds: 10,
+        trimInSeconds: 2,
+        trimOutSeconds: 1,
+      },
+    ]),
+  ]);
+
+  test("slides both trims together, holding the showing duration", () => {
+    expect(resolveWindowMoveCommand(windowGraph, id("vid"), "window-earlier", 1)).toEqual({
+      ok: true,
+      value: {
+        type: "update-media",
+        nodeId: "vid",
+        update: { mediaKind: "video", trimInSeconds: 1, trimOutSeconds: 2 },
+      },
+    });
+    expect(resolveWindowMoveCommand(windowGraph, id("vid"), "window-later", 1)).toEqual({
+      ok: true,
+      value: {
+        type: "update-media",
+        nodeId: "vid",
+        update: { mediaKind: "video", trimInSeconds: 3, trimOutSeconds: 0 },
+      },
+    });
+  });
+
+  test("clamps at the room's ends — a partial step slides what's left", () => {
+    // Earlier by 5s with only 2s of trim-in: the window lands at the source
+    // start, the remainder of the step is absorbed (like the pointer move).
+    expect(resolveWindowMoveCommand(windowGraph, id("vid"), "window-earlier", 5)).toEqual({
+      ok: true,
+      value: {
+        type: "update-media",
+        nodeId: "vid",
+        update: { mediaKind: "video", trimInSeconds: 0, trimOutSeconds: 3 },
+      },
+    });
+  });
+
+  test("a step with no room resolves to the current values -> same-position at dispatch", () => {
+    // Already at the source end (trim-out 0): "later" cannot move.
+    const atEnd = build([
+      collection("root", [
+        {
+          kind: "media",
+          mediaKind: "video",
+          id: "vid",
+          name: "vid",
+          fullDurationSeconds: 10,
+          trimInSeconds: 3,
+          trimOutSeconds: 0,
+        },
+      ]),
+    ]);
+    const resolved = resolveWindowMoveCommand(atEnd, id("vid"), "window-later", 1);
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    const applied = applyCommand(atEnd, resolved.value);
+    expect(applied).toEqual({ ok: false, error: { reason: "same-position" } });
+  });
+
+  test("an untrimmed video has no room in either direction", () => {
+    const untrimmed = build([
+      collection("root", [
+        {
+          kind: "media",
+          mediaKind: "video",
+          id: "vid",
+          name: "vid",
+          fullDurationSeconds: 10,
+          trimInSeconds: 0,
+          trimOutSeconds: 0,
+        },
+      ]),
+    ]);
+    for (const action of ["window-earlier", "window-later"] as const) {
+      const resolved = resolveWindowMoveCommand(untrimmed, id("vid"), action, 1);
+      expect(resolved.ok).toBe(true);
+      if (!resolved.ok) continue;
+      expect(applyCommand(untrimmed, resolved.value)).toEqual({
+        ok: false,
+        error: { reason: "same-position" },
+      });
+    }
+  });
+
+  test("rejects images, collections, unknown nodes, and invalid steps", () => {
+    expect(resolveWindowMoveCommand(windowGraph, id("img"), "window-earlier", 1)).toEqual({
+      ok: false,
+      error: { reason: "no-source-window", nodeId: "img" },
+    });
+    expect(resolveWindowMoveCommand(windowGraph, id("root"), "window-earlier", 1)).toEqual({
+      ok: false,
+      error: { reason: "not-media-node", nodeId: "root" },
+    });
+    expect(resolveWindowMoveCommand(windowGraph, id("ghost"), "window-earlier", 1)).toEqual({
+      ok: false,
+      error: { reason: "missing-node", nodeId: "ghost" },
+    });
+    for (const step of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(resolveWindowMoveCommand(windowGraph, id("vid"), "window-later", step)).toEqual({
+        ok: false,
+        error: { reason: "invalid-step", stepSeconds: step },
+      });
+    }
   });
 });

--- a/packages/ui/dnd-collections/core/keyboard.ts
+++ b/packages/ui/dnd-collections/core/keyboard.ts
@@ -245,6 +245,62 @@ export function resolveTrimCommand(
   return { ok: true, value: { type: "update-media", nodeId, update } };
 }
 
+// Keyboard source-window move: slide a video's showing window through its
+// source without changing the showing duration — the keyboard equivalent of
+// dragging the overview filmstrip. "earlier" reveals earlier footage
+// (trim-in decreases, trim-out increases); "later" the reverse. Resolves to
+// the SAME `update-media` command every other trim surface dispatches.
+//
+// Unlike the edge-trim resolver (which sends the raw stepped value and lets
+// the reducer clamp), this resolver clamps ITSELF, mirroring the pointer
+// `resolveMove` math: both trims must shift together to hold the duration
+// constant, and the reducer's independent per-end clamps would otherwise
+// change it. A step with no room left resolves to the current values, which
+// the reducer rejects as `same-position` — the controller announces it as a
+// boundary.
+export type KeyboardWindowMoveAction = "window-earlier" | "window-later";
+
+export type KeyboardWindowMoveRejection =
+  | Readonly<{ reason: "missing-node"; nodeId: NodeId }>
+  | Readonly<{ reason: "not-media-node"; nodeId: NodeId }>
+  | Readonly<{ reason: "invalid-step"; stepSeconds: number }>
+  /** Images have no source window to slide. */
+  | Readonly<{ reason: "no-source-window"; nodeId: NodeId }>;
+
+export function resolveWindowMoveCommand(
+  graph: CollectionsGraph,
+  nodeId: NodeId,
+  action: KeyboardWindowMoveAction,
+  stepSeconds: number
+): Result<UpdateMediaCommand, KeyboardWindowMoveRejection> {
+  if (!Number.isFinite(stepSeconds) || stepSeconds <= 0) {
+    return { ok: false, error: { reason: "invalid-step", stepSeconds } };
+  }
+  const node = graph.nodesById.get(nodeId);
+  if (!node) return { ok: false, error: { reason: "missing-node", nodeId } };
+  if (node.kind !== "media") return { ok: false, error: { reason: "not-media-node", nodeId } };
+  if (node.mediaKind !== "video") {
+    return { ok: false, error: { reason: "no-source-window", nodeId } };
+  }
+
+  // The slack the window can slide through is exactly the trimmed room.
+  const room = node.trimInSeconds + node.trimOutSeconds;
+  const raw =
+    action === "window-earlier"
+      ? node.trimInSeconds - stepSeconds
+      : node.trimInSeconds + stepSeconds;
+  const trimInSeconds = Math.max(0, Math.min(raw, room));
+  const trimOutSeconds = room - trimInSeconds;
+  return {
+    ok: true,
+    value: {
+      type: "update-media",
+      nodeId,
+      update: { mediaKind: "video", trimInSeconds, trimOutSeconds },
+    },
+  };
+}
+
 // Keyboard trash: move the focused node into a designated trash collection —
 // the keyboard equivalent of dropping it on the TrashTarget. Resolves to the
 // SAME move-nodes command (append to the trash collection's end), so subtrees

--- a/packages/ui/dnd-collections/index.ts
+++ b/packages/ui/dnd-collections/index.ts
@@ -74,12 +74,15 @@ export {
   resolveKeyboardCommand,
   resolveTrashCommand,
   resolveTrimCommand,
+  resolveWindowMoveCommand,
   type GridRowMoveRejection,
   type KeyboardMoveAction,
   type KeyboardRejection,
   type KeyboardTrashRejection,
   type KeyboardTrimAction,
   type KeyboardTrimRejection,
+  type KeyboardWindowMoveAction,
+  type KeyboardWindowMoveRejection,
 } from "./core/keyboard";
 
 // React bindings (store + provider + default views)

--- a/packages/ui/dnd-collections/react/DndCollections.tsx
+++ b/packages/ui/dnd-collections/react/DndCollections.tsx
@@ -542,8 +542,9 @@ function DndCollectionsContext({
         collection and Alt plus Up moves it out; Alt plus Enter and Alt plus Backspace do the same
         nesting and un-nesting anywhere, including inside a grid, where Alt plus Up and Down move
         between rows instead. For media, Alt plus Shift plus Left or Right trims the end and Alt
-        plus Shift plus Up or Down trims the start of a video. Press Alt plus Delete to move it to
-        trash.
+        plus Shift plus Up or Down trims the start of a video, and Alt plus Shift plus Home or End
+        slides a video&apos;s source window earlier or later without changing its length. Press Alt
+        plus Delete to move it to trash.
       </p>
       {/* Palette items are external drag sources — the card instructions
           above (selection, Alt-moves) don't apply, so they reference this

--- a/packages/ui/dnd-collections/react/collections-components.tsx
+++ b/packages/ui/dnd-collections/react/collections-components.tsx
@@ -167,14 +167,15 @@ export function useCollectionsComponentsValue(
     const previous = previousRef.current;
     previousRef.current = value;
     if (process.env.NODE_ENV === "production") return;
-    // The memo above keys on exactly the three fields, so a new value
+    // The memo above keys on exactly the registry's fields, so a new value
     // identity IS a field-identity change — symmetric by construction.
     if (warnedRef.current || previous === value) return;
     warnedRef.current = true;
     console.warn(
       "dnd-collections: a `components` entry changed identity between renders. " +
-        "Define ItemContent/GhostContent/TrimHandleContent at module scope — a new " +
-        "component type per render remounts every card's content and defeats memoization."
+        "Define ItemContent/GhostContent/TrimHandleContent/OverviewContent at module " +
+        "scope — a new component type per render remounts every card's content and " +
+        "defeats memoization."
     );
   }, [value]);
 

--- a/packages/ui/dnd-collections/react/trim-overview.tsx
+++ b/packages/ui/dnd-collections/react/trim-overview.tsx
@@ -38,7 +38,22 @@ const FRAME_SIZE = 44;
 
 /** The stock overview background: the full-source poster filmstrip plus the
  *  "full clip" readout. Consumers replace it via the `OverviewContent`
- *  registry slot; the dims/window/grips/move gesture stay package-owned. */
+ *  registry slot; the dims/window/grips/move gesture stay package-owned.
+ *
+ *  Memo comparator: the contract carries live trimIn/trimOut (changing per
+ *  pointer move during a drag), but THIS renderer reads only `node` and
+ *  `fullWidth` — a shallow memo would reconcile up to 40 <img> elements per
+ *  move for nothing. Custom OverviewContent components that DO read the trim
+ *  values get standard shallow memo semantics (they registered their own
+ *  component, not this one). */
+const defaultOverviewPropsEqual = (
+  prev: CollectionTrimOverviewContentProps,
+  next: CollectionTrimOverviewContentProps
+): boolean =>
+  prev.node === next.node &&
+  prev.pixelsPerSecond === next.pixelsPerSecond &&
+  prev.fullWidth === next.fullWidth;
+
 export const DefaultTrimOverviewContent = memo(function DefaultTrimOverviewContent({
   node,
   fullWidth,
@@ -75,7 +90,7 @@ export const DefaultTrimOverviewContent = memo(function DefaultTrimOverviewConte
       </span>
     </>
   );
-});
+}, defaultOverviewPropsEqual);
 
 export const TrimOverviewStrip = memo(function TrimOverviewStrip({
   node,
@@ -116,10 +131,9 @@ export const TrimOverviewStrip = memo(function TrimOverviewStrip({
     <div
       data-trim-overview={node.id}
       // Pointer-only source-window visualization: aria-hidden so assistive
-      // tech isn't led into an unlabeled filmstrip. Trimming is available to
-      // the keyboard via the focused card + Alt+Shift+Arrows. (Sliding the
-      // source window without changing duration is still pointer-only — a
-      // keyboard equivalent is a known gap, tracked for a follow-up.)
+      // tech isn't led into an unlabeled filmstrip. Every operation it
+      // offers has a keyboard equivalent on the focused card: Alt+Shift+
+      // Arrows trim the edges, Alt+Shift+Home/End slide the source window.
       aria-hidden="true"
       // Dragging the filmstrip (anywhere but the amber grips, which
       // stopPropagation) MOVES the source window.

--- a/packages/ui/dnd-collections/react/use-flip-graph-animation.ts
+++ b/packages/ui/dnd-collections/react/use-flip-graph-animation.ts
@@ -15,9 +15,18 @@ type CardRect = Readonly<{ card: HTMLElement; nodeId: string; point: Point }>;
 
 function measureCards(container: HTMLElement): CardRect[] {
   const rects: CardRect[] = [];
-  for (const card of container.querySelectorAll<HTMLElement>("[data-node-id]")) {
-    const nodeId = card.dataset.nodeId;
+  for (const idElement of container.querySelectorAll<HTMLElement>("[data-node-id]")) {
+    const nodeId = idElement.dataset.nodeId;
     if (!nodeId) continue;
+    // Animate the WHOLE item, not just the element carrying the id: both
+    // NodeCard and CollectionItem.Root put `data-node-id` on the focusable
+    // selection button, whose SIBLINGS (grip bar, trim handles, consumer
+    // controls in compound items, indicators) live in the `data-node-wrapper`
+    // host — translating only the button would teleport everything else to
+    // the final position while the button glides. Identity stays keyed by
+    // the id element; custom views without a wrapper animate the id element
+    // itself, preserving the documented contract.
+    const card = idElement.closest<HTMLElement>("[data-node-wrapper]") ?? idElement;
     const rect = card.getBoundingClientRect();
     rects.push({ card, nodeId, point: { x: rect.left, y: rect.top } });
   }

--- a/packages/ui/dnd-collections/react/use-keyboard-controller.ts
+++ b/packages/ui/dnd-collections/react/use-keyboard-controller.ts
@@ -14,12 +14,15 @@ import {
   resolveKeyboardCommand,
   resolveTrashCommand,
   resolveTrimCommand,
+  resolveWindowMoveCommand,
   type GridRowMoveRejection,
   type KeyboardMoveAction,
   type KeyboardRejection,
   type KeyboardTrashRejection,
   type KeyboardTrimAction,
   type KeyboardTrimRejection,
+  type KeyboardWindowMoveAction,
+  type KeyboardWindowMoveRejection,
 } from "../core/keyboard";
 import { type CollectionsStore } from "./collections-store";
 import { roundSecondsForDisplay } from "./duration-format";
@@ -82,6 +85,27 @@ const TRIM_ACTION_BY_KEY: Readonly<Record<string, KeyboardTrimAction | undefined
 
 /** One keypress = one second, clamped by the reducer exactly like a drag. */
 const TRIM_STEP_SECONDS = 1;
+
+// Alt+Shift+Home/End SLIDE a video's source window (trim-in/out shift
+// together, showing duration constant) — the keyboard equivalent of dragging
+// the overview filmstrip. Home = earlier footage, End = later.
+const WINDOW_MOVE_ACTION_BY_KEY: Readonly<
+  Record<string, KeyboardWindowMoveAction | undefined>
+> = {
+  Home: "window-earlier",
+  End: "window-later",
+};
+
+// `undefined` = intentionally silent; keyed by the rejection union so a new
+// reason forces a decision here at compile time.
+const WINDOW_MOVE_REJECTION_MESSAGES: Readonly<
+  Record<KeyboardWindowMoveRejection["reason"], string | undefined>
+> = {
+  "no-source-window": "Only videos have a source window.",
+  "not-media-node": undefined,
+  "missing-node": undefined,
+  "invalid-step": undefined,
+};
 
 // `undefined` = intentionally silent (corrupt/out-of-scope input). Keyed by the
 // rejection union so a new reason forces a decision here at compile time.
@@ -214,6 +238,39 @@ export function useCollectionsKeyboard(args: {
     [store, announce]
   );
 
+  const handleWindowMove = useCallback(
+    (nodeId: NodeId, action: KeyboardWindowMoveAction) => {
+      const { graph } = store.getSnapshot();
+      const name = graph.nodesById.get(nodeId)?.name ?? "item";
+      const resolved = resolveWindowMoveCommand(graph, nodeId, action, TRIM_STEP_SECONDS);
+      if (!resolved.ok) {
+        const message = WINDOW_MOVE_REJECTION_MESSAGES[resolved.error.reason];
+        if (message) announce(message);
+        return;
+      }
+      const dispatched = store.dispatch(resolved.value);
+      if (!dispatched.ok) {
+        // No room left in that direction (or no trimmed room at all) — the
+        // resolver clamped to the current values and the reducer rejected
+        // the no-op. Announce the boundary.
+        if (dispatched.error.reason === "same-position") {
+          announce(
+            action === "window-earlier"
+              ? `"${name}" source window is at the start.`
+              : `"${name}" source window is at the end.`
+          );
+        }
+        return;
+      }
+      // A window move keeps the card mounted and its width constant — just
+      // announce the slide.
+      announce(
+        `Moved "${name}" source window ${action === "window-earlier" ? "earlier" : "later"}.`
+      );
+    },
+    [store, announce]
+  );
+
   const handleTrash = useCallback(
     (nodeId: NodeId, trashId: NodeId) => {
       const { graph } = store.getSnapshot();
@@ -289,7 +346,8 @@ export function useCollectionsKeyboard(args: {
       }
 
       const isCollectionsCommand = event.shiftKey
-        ? TRIM_ACTION_BY_KEY[event.key] !== undefined
+        ? TRIM_ACTION_BY_KEY[event.key] !== undefined ||
+          WINDOW_MOVE_ACTION_BY_KEY[event.key] !== undefined
         : KEYBOARD_ACTION_BY_KEY[event.key] !== undefined;
       if (isCollectionsCommand && store.getSnapshot().interaction.isDragging) {
         // A live dnd-kit drag owns movement until it commits or cancels. Do
@@ -301,10 +359,18 @@ export function useCollectionsKeyboard(args: {
         return;
       }
 
-      // Alt+SHIFT+Arrows TRIM the media card — checked before the move/grid
-      // logic so a held Shift never falls through to a move. (A non-arrow
-      // Shift combo is left alone: return without consuming the event.)
+      // Alt+SHIFT+Arrows TRIM the media card, Alt+SHIFT+Home/End SLIDE a
+      // video's source window — both checked before the move/grid logic so a
+      // held Shift never falls through to a move. (Any other Shift combo is
+      // left alone: return without consuming the event.)
       if (event.shiftKey) {
+        const windowAction = WINDOW_MOVE_ACTION_BY_KEY[event.key];
+        if (windowAction) {
+          event.preventDefault();
+          event.stopPropagation();
+          handleWindowMove(nodeId, windowAction);
+          return;
+        }
         const trimAction = TRIM_ACTION_BY_KEY[event.key];
         if (!trimAction) return;
         event.preventDefault();
@@ -354,7 +420,7 @@ export function useCollectionsKeyboard(args: {
       // doesn't render — fall back to the destination collection's own card.
       restoreFocus(nodeId, resolved.value.toParentId);
     },
-    [store, announce, trashRef, handleGridRowMove, handleTrim, handleTrash, restoreFocus]
+    [store, announce, trashRef, handleGridRowMove, handleTrim, handleWindowMove, handleTrash, restoreFocus]
   );
 
   return { handleKeyDownCapture, restoreFocus };

--- a/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
@@ -145,13 +145,15 @@ export type VirtualStripProps = Readonly<{
    *  MUST be identity-stable (module scope). */
   itemContent?: CollectionItemContentComponent;
   /**
-   * Rendered in CONTENT coordinates over the whole strip content (inside an
-   * `aria-hidden`, `pointer-events: none` layer above the cards), so it
-   * rides scrolling, auto-scroll, and the live-trim transform for free — a
-   * playhead line, region markers. Position children absolutely; convert
-   * time to x with the same `durationToWidth`/`pixelsPerSecond` scale.
-   * Re-enable pointer-events on your own elements if they must be
-   * interactive (they then sit above cards and handles — your trade-off).
+   * STRICTLY PRESENTATIONAL content rendered in CONTENT coordinates over the
+   * whole strip (inside an `aria-hidden`, `pointer-events: none` layer above
+   * the cards), so it rides scrolling, auto-scroll, and the live-trim
+   * transform for free — a playhead line, region markers. Position children
+   * absolutely; convert time to x with `timeToOffset`/`durationToWidth`.
+   * NO interactive or focusable elements: the layer is hidden from assistive
+   * technology, and a focusable child inside `aria-hidden` is an a11y
+   * violation (focusable-but-invisible to AT). An interactive scrubber
+   * belongs in your own positioned layer OUTSIDE the strip.
    */
   overlay?: ReactNode;
   className?: string;
@@ -778,7 +780,10 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
                   coordinates: living inside the spacer means scroll,
                   auto-scroll, and the live-trim anchor transform all apply
                   for free. pointer-events: none so pan/drag/trim gestures
-                  pass through; aria-hidden keeps the grid tree valid. */}
+                  pass through; aria-hidden keeps the grid tree valid —
+                  which is why the slot is PRESENTATIONAL ONLY (a focusable
+                  child inside aria-hidden would be reachable by keyboard
+                  yet invisible to assistive technology). */}
               {overlay != null && (
                 <div
                   aria-hidden="true"

--- a/packages/ui/dnd-collections/virtual/virtual-strip-geometry.test.ts
+++ b/packages/ui/dnd-collections/virtual/virtual-strip-geometry.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { buildGraph, parseNodeId, type CollectionsGraph } from "../core/graph";
 import {
   MIN_ITEM_WIDTH,
+  createTimeToOffset,
   durationToWidth,
   indicatorLeftOffset,
   leftAnchorShift,
@@ -145,6 +146,49 @@ describe("timeToOffset", () => {
         pixelsPerSecond: 24,
       })
     ).toBe(0);
+  });
+
+  it("createTimeToOffset: .at agrees with the one-shot wrapper everywhere", () => {
+    const lookup = createTimeToOffset({
+      graph: fixture(),
+      collectionId: strip,
+      pixelsPerSecond: 24,
+    });
+    for (const t of [-1, 0, 0.5, 2, 3.999, 4, 7.5, 10.999, 11, 11.1, 11.2, 999]) {
+      expect(lookup.at(t)).toBeCloseTo(at(t), 8);
+    }
+    expect(lookup.totalDurationSeconds).toBeCloseTo(4 + 7 + 0.2, 8);
+    expect(lookup.endOffset).toBe(428);
+  });
+
+  it("createTimeToOffset: a monotonic cursor matches .at, including seeks", () => {
+    const lookup = createTimeToOffset({
+      graph: fixture(),
+      collectionId: strip,
+      pixelsPerSecond: 24,
+    });
+    const cursor = lookup.cursor();
+    // Forward playback across every segment boundary (the O(1) path)...
+    for (let t = 0; t <= 12; t += 0.25) {
+      expect(cursor.at(t)).toBeCloseTo(lookup.at(t), 8);
+    }
+    // ...a backward seek re-anchors...
+    expect(cursor.at(1.5)).toBeCloseTo(lookup.at(1.5), 8);
+    // ...and a far-forward seek does too.
+    expect(cursor.at(11.15)).toBeCloseTo(lookup.at(11.15), 8);
+    // Independent cursors don't share state.
+    expect(lookup.cursor().at(6)).toBeCloseTo(lookup.at(6), 8);
+  });
+
+  it("createTimeToOffset: empty collections yield a constant 0", () => {
+    const lookup = createTimeToOffset({
+      graph: fixture(),
+      collectionId: parseNodeId("nope"),
+      pixelsPerSecond: 24,
+    });
+    expect(lookup.at(5)).toBe(0);
+    expect(lookup.cursor().at(5)).toBe(0);
+    expect(lookup.totalDurationSeconds).toBe(0);
   });
 });
 

--- a/packages/ui/dnd-collections/virtual/virtual-strip-geometry.ts
+++ b/packages/ui/dnd-collections/virtual/virtual-strip-geometry.ts
@@ -95,44 +95,67 @@ export function leftAnchorShift(liveSlotSize: number, baselineSize: number): num
   return baselineSize - liveSlotSize;
 }
 
-/**
- * Timeline time → content-x, for overlay math (a playhead at `timeSeconds`)
- * over a `pixelsPerSecond`-sized strip. Walks the collection's children:
- * media items advance the clock by their EFFECTIVE duration and the x by
- * their slot width (`durationToWidth` + gap — the same conversion the strip
- * lays out with); non-media items (collections) occupy width but no time.
- *
- * Semantics to be aware of:
- * - Inside a FLOORED clip (shorter than `minimumWidth / pps`), x advances at
- *   `pps` and caps at the clip's right edge — the clip is wider than its
- *   time, so the playhead never overshoots it.
- * - `timeSeconds` past the strip's total duration clamps to the last media
- *   item's right edge; negative times clamp to 0.
- * - The result is CONTENT coordinates, which is what the `overlay` slot
- *   renders in. It does NOT include `VirtualStrip`'s transient first-item
- *   gutter (`paddingStart` while a trimmed-in first video is selected) — the
- *   one case content-x and item offsets diverge.
- * - Assumes `pixelsPerSecond` sizing; strips sized by a custom `itemWidthFor`
- *   need their own mapping against that same function.
- */
-export function timeToOffset(args: {
+export type TimeToOffsetConfig = Readonly<{
   graph: CollectionsGraph;
   collectionId: NodeId;
-  timeSeconds: number;
   pixelsPerSecond: number;
   /** Match the strip's props: gap default 8, itemWidth default 128. */
   gap?: number;
   itemWidth?: number;
   minimumWidth?: number;
-}): number {
-  const { graph, collectionId, timeSeconds, pixelsPerSecond } = args;
-  const gap = args.gap ?? 8;
-  const itemWidth = args.itemWidth ?? 128;
-  const minimumWidth = args.minimumWidth ?? MIN_ITEM_WIDTH;
+}>;
 
+export type TimeToOffsetLookup = Readonly<{
+  /** Content-x for an arbitrary time — O(log n) binary search. */
+  at: (timeSeconds: number) => number;
+  /**
+   * A stateful cursor for MONOTONIC consumption — the per-frame playhead:
+   * O(1) per call while time stays in or hops to the adjacent segment
+   * (which is every frame of normal playback), O(log n) for a seek. Create
+   * one cursor per consumer loop; it never mutates the lookup.
+   */
+  cursor: () => Readonly<{ at: (timeSeconds: number) => number }>;
+  /** Total played duration (media only; collections carry no time). */
+  totalDurationSeconds: number;
+  /** Content-x of the last media item's right edge — the overflow clamp. */
+  endOffset: number;
+}>;
+
+/**
+ * Build a timeline-time → content-x lookup for overlay math (a playhead)
+ * over a `pixelsPerSecond`-sized strip. Prefix sums are built ONCE (O(n));
+ * rebuild at commit/config cadence (`onChange` / `subscribeToChanges` — a
+ * playhead's per-frame path should be `lookup.cursor().at(t)`, ideally
+ * writing a transform imperatively rather than re-rendering React per
+ * frame).
+ *
+ * Mapping semantics: media items advance the clock by their EFFECTIVE
+ * duration and the x by their slot width (`durationToWidth` + gap — the
+ * same conversion the strip lays out with); non-media items (collections)
+ * occupy width but no time. Inside a FLOORED clip x advances at `pps` and
+ * caps at the clip's right edge (the clip is wider than its time). Times
+ * past the total clamp to `endOffset`; negative times clamp to the first
+ * clip's left edge. The result is CONTENT coordinates (what the `overlay`
+ * slot renders in) and excludes `VirtualStrip`'s transient first-item
+ * gutter. Assumes `pixelsPerSecond` sizing; strips sized by a custom
+ * `itemWidthFor` need their own mapping against that same function.
+ */
+export function createTimeToOffset(config: TimeToOffsetConfig): TimeToOffsetLookup {
+  const { graph, collectionId, pixelsPerSecond } = config;
+  const gap = config.gap ?? 8;
+  const itemWidth = config.itemWidth ?? 128;
+  const minimumWidth = config.minimumWidth ?? MIN_ITEM_WIDTH;
+
+  // Time segments: media with duration > 0. Zero-duration media and
+  // collections occupy width but never own a time slice, so they only
+  // advance x. Segments are contiguous in time by construction.
+  const timeStarts: number[] = [];
+  const xStarts: number[] = [];
+  const widths: number[] = [];
+  const durations: number[] = [];
   let x = 0;
   let clock = 0;
-  let lastMediaRight: number | null = null;
+  let lastMediaRight = 0;
   for (const childId of getChildren(graph, collectionId)) {
     const node = graph.nodesById.get(childId);
     if (!node) continue;
@@ -142,13 +165,82 @@ export function timeToOffset(args: {
     }
     const duration = mediaDurationSeconds(node);
     const width = durationToWidth(duration, pixelsPerSecond, minimumWidth);
-    if (timeSeconds < clock + duration) {
-      const within = Math.max(0, timeSeconds - clock) * pixelsPerSecond;
-      return x + Math.min(within, width);
+    if (duration > 0) {
+      timeStarts.push(clock);
+      xStarts.push(x);
+      widths.push(width);
+      durations.push(duration);
+      clock += duration;
     }
-    clock += duration;
     x += width + gap;
     lastMediaRight = x - gap;
   }
-  return lastMediaRight ?? 0;
+  const count = timeStarts.length;
+  const endOffset = lastMediaRight;
+
+  /** Index of the last segment whose start time is <= t (t must be >= 0). */
+  const locate = (t: number): number => {
+    let lo = 0;
+    let hi = count - 1;
+    while (lo < hi) {
+      const mid = (lo + hi + 1) >> 1;
+      if (timeStarts[mid] <= t) lo = mid;
+      else hi = mid - 1;
+    }
+    return lo;
+  };
+
+  const offsetWithin = (index: number, t: number): number => {
+    const within = Math.max(0, t - timeStarts[index]) * pixelsPerSecond;
+    return xStarts[index] + Math.min(within, widths[index]);
+  };
+
+  const at = (timeSeconds: number): number => {
+    if (count === 0) return endOffset;
+    if (timeSeconds <= timeStarts[0]) return xStarts[0];
+    if (timeSeconds >= clock) return endOffset;
+    return offsetWithin(locate(timeSeconds), timeSeconds);
+  };
+
+  return {
+    at,
+    cursor: () => {
+      let index = 0;
+      return {
+        at: (timeSeconds: number): number => {
+          if (count === 0) return endOffset;
+          if (timeSeconds <= timeStarts[0]) return xStarts[0];
+          if (timeSeconds >= clock) return endOffset;
+          if (timeSeconds < timeStarts[index]) {
+            // Backward seek: re-anchor.
+            index = locate(timeSeconds);
+          } else if (timeSeconds >= timeStarts[index] + durations[index]) {
+            // Forward: the adjacent segment is the common playback hop (O(1));
+            // anything farther is a seek (O(log n)).
+            if (
+              index + 1 < count &&
+              timeSeconds < timeStarts[index + 1] + durations[index + 1]
+            ) {
+              index += 1;
+            } else {
+              index = locate(timeSeconds);
+            }
+          }
+          return offsetWithin(index, timeSeconds);
+        },
+      };
+    },
+    totalDurationSeconds: clock,
+    endOffset,
+  };
+}
+
+/**
+ * One-shot convenience over `createTimeToOffset` — fine for occasional
+ * lookups; for a per-frame playhead build the lookup once and use a cursor.
+ */
+export function timeToOffset(
+  args: TimeToOffsetConfig & { timeSeconds: number }
+): number {
+  return createTimeToOffset(args).at(args.timeSeconds);
 }


### PR DESCRIPTION
…y, cursor lookup, keyboard window move

All validated findings from the second external review, plus the O(1) playhead design:

- FLIP animates the data-node-wrapper HOST (el.closest fallback to the id element), so grip bars, trim handles, indicators, and compound items' consumer controls glide with the card instead of teleporting while only the selection button animates. Pre-dated compound items (handle-mode strips had it); pinned by CompoundFlipAnimatesWholeItem and the updated FLIP story helpers.

- The overlay slot is STRICTLY PRESENTATIONAL: docs no longer invite interactive children (a focusable element inside aria-hidden is reachable by keyboard yet invisible to AT); interactive scrubbers belong in a consumer layer outside the strip.

- createTimeToOffset: O(n) prefix sums once, .at(t) O(log n), .cursor().at(t) O(1) amortized for monotonic consumption (adjacent-segment hop checked before binary search) -- the per-frame playhead path. timeToOffset remains the one-shot convenience delegating to it, so semantics stay single-sourced.

- Keyboard source-window move (Alt+Shift+Home/End): resolveWindowMoveCommand slides trim-in/out together holding the showing duration -- the overview filmstrip drag's keyboard equivalent, closing the last documented pointer-only trim operation. The resolver clamps itself (mirroring the pointer resolveMove math; the reducer's independent per-end clamps would change the duration), boundaries announce via same-position, images reject as no-source-window. Instructions text, API.md grammar table and core section, unit tests, and an e2e assertion (overview anchor shifts by exactly the slide while the clip width holds) included.

- DefaultTrimOverviewContent gets a memo comparator on node/pps/fullWidth: the contract carries per-move live trim values the default renderer never reads -- shallow memo reconciled up to 40 <img> elements per pointer move for nothing. (Not a regression from the slot: the same cost existed inline before; the slot made it fixable.)

- Compound Enter-grab/Escape story pins SelectionSurface's manual KeyboardSensor wiring; the components-churn warning names all four registry entries.