### PR TITLE
feat(timeline-domain): graph-as-source-of-truth proof on the real Tim…

### DIFF
--- a/apps/media-strip-rsc/app/dnd-collections/page.tsx
+++ b/apps/media-strip-rsc/app/dnd-collections/page.tsx
@@ -13,12 +13,18 @@ export default function DndCollectionsPage() {
   return (
     <main className="mx-auto flex min-h-dvh w-full max-w-7xl flex-col gap-8 px-5 py-8 md:px-8">
       <header className="flex flex-col gap-5 border-b border-border pb-6">
-        <nav aria-label="Breadcrumb">
+        <nav aria-label="Breadcrumb" className="flex flex-wrap gap-4">
           <Link
             href="/collections/assembly"
             className="text-sm font-medium text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
           >
             Back to Media Strip
+          </Link>
+          <Link
+            href="/graph-timeline"
+            className="text-sm font-medium text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
+          >
+            Graph Timeline (architecture proof)
           </Link>
         </nav>
 

--- a/apps/media-strip-rsc/app/graph-timeline/[[...timelinePath]]/page.tsx
+++ b/apps/media-strip-rsc/app/graph-timeline/[[...timelinePath]]/page.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+import { ClientGraphTimeline } from "../../../components/graph-timeline/client-graph-timeline";
+
+export const metadata: Metadata = {
+  title: "Graph Timeline | StoryboardFlow",
+  description:
+    "The app's real TimelineDocuments rendered through the collections graph: one provider, drill-in focus, inline sub-timelines, and patch-scoped persistence.",
+};
+
+type GraphTimelinePageProps = Readonly<{
+  params: Promise<{ timelinePath?: string[] }>;
+}>;
+
+// The phase-2 proof of docs/storyboard-graph-architecture.md: the graph is
+// the structural source of truth, ONE <DndCollections> hosts every view, and
+// the route's catch-all segments are the drill-in focus path (per-view state
+// lives in the route, shared state lives in the store).
+export default async function GraphTimelinePage({ params }: GraphTimelinePageProps) {
+  const { timelinePath } = await params;
+
+  return (
+    <main className="mx-auto flex min-h-dvh w-full max-w-7xl flex-col gap-8 px-5 py-8 md:px-8">
+      <header className="flex flex-col gap-5 border-b border-border pb-6">
+        <nav aria-label="Labs">
+          <Link
+            href="/dnd-collections"
+            className="text-sm font-medium text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
+          >
+            Back to DnD Collections Lab
+          </Link>
+        </nav>
+
+        <div className="max-w-3xl">
+          <p className="text-sm font-medium uppercase tracking-[0.18em] text-primary">
+            StoryboardFlow graph architecture proof
+          </p>
+          <h1 className="mt-3 text-4xl font-semibold leading-tight text-balance md:text-5xl">
+            Graph Timeline
+          </h1>
+          <p className="mt-3 max-w-2xl text-base leading-7 text-muted-foreground text-pretty">
+            The app&apos;s real TimelineDocuments projected through the collections graph. One
+            provider owns the page: the focused timeline, every inline sub-timeline, undo, and
+            cross-timeline drags all share a single graph. Double-click a collection clip (or use a
+            sub-timeline&apos;s Focus button) to drill in — the URL is the focus path, and the
+            document for that timeline hydrates on arrival.
+          </p>
+        </div>
+      </header>
+
+      <ClientGraphTimeline timelinePath={timelinePath ?? []} />
+    </main>
+  );
+}

--- a/apps/media-strip-rsc/components/graph-timeline/client-graph-timeline.tsx
+++ b/apps/media-strip-rsc/components/graph-timeline/client-graph-timeline.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+import { Skeleton } from "@storyboard/ui/core/skeleton";
+
+const GraphTimeline = dynamic(
+  () => import("./graph-timeline").then((module) => module.GraphTimeline),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="space-y-6" aria-label="Loading graph timeline">
+        <Skeleton className="h-10 w-1/2 rounded-2xl" />
+        <Skeleton className="h-40 w-full rounded-2xl" />
+        <Skeleton className="h-64 w-full rounded-2xl" />
+      </div>
+    ),
+  },
+);
+
+export function ClientGraphTimeline({ timelinePath }: { timelinePath: string[] }) {
+  return <GraphTimeline timelinePath={timelinePath} />;
+}

--- a/apps/media-strip-rsc/components/graph-timeline/graph-timeline.tsx
+++ b/apps/media-strip-rsc/components/graph-timeline/graph-timeline.tsx
@@ -1,0 +1,593 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import {
+  createContext,
+  memo,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+
+import { Badge } from "@storyboard/ui/core/badge";
+import { Button } from "@storyboard/ui/core/button";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@storyboard/ui/core/card";
+import {
+  DndCollections,
+  UndoRedoControls,
+  VirtualStrip,
+  getChildren,
+  mediaDurationSeconds,
+  parseNodeId,
+  useCollectionsSelector,
+  useCollectionsStore,
+  useLiveTrim,
+  videoFrameCount,
+  type CollectionGhostContentProps,
+  type CollectionItemContentProps,
+  type CollectionTrimHandleContentProps,
+  type CollectionsChange,
+  type CollectionsComponents,
+  type MediaNode,
+  type NodeId,
+} from "@storyboard/ui/dnd-collections";
+import {
+  buildFocusedGraph,
+  collectAffectedCollectionIds,
+  graphChildrenToClips,
+  type DetailsById,
+  type DocumentsById,
+  type FocusedGraph,
+} from "@storyboard/timeline-domain";
+import { createInitialTimelineDocuments } from "@storyboard/ui/timeline/timeline-documents";
+import type { TimelineClip } from "@storyboard/ui/timeline/types";
+
+// The phase-2 proof of docs/storyboard-graph-architecture.md, on the app's
+// REAL data (`createInitialTimelineDocuments`):
+//
+//   - ONE <DndCollections> owns the page. The focused timeline and every
+//     inline sub-timeline are projections of the same graph, so dragging a
+//     clip between timelines, nesting it into a collection card, and undoing
+//     all of it are one store's business — no cross-provider choreography.
+//   - The URL is the focus path (per-view state lives in the route). Double-
+//     clicking a collection clip or pressing a sub-timeline's Focus button
+//     pushes its timeline id onto the path; landing there hydrates that
+//     document into a fresh graph (hydrate-on-focus).
+//   - Persistence is patch-scoped: every committed change (command, undo,
+//     redo) is mapped by `collectAffectedCollectionIds` to the documents it
+//     touched, and ONLY those are rewritten via `graphChildrenToClips` — the
+//     write path the sync panel makes visible.
+//
+// Known, deliberate trade-off: drilling in remounts the provider, so the
+// undo stack is scoped to a focus session (hydration stays out-of-band from
+// undo; see the architecture doc's open questions).
+
+const ROOT_TIMELINE_ID = "root";
+const TIMELINE_PPS = 40;
+
+// ── Session document store ──────────────────────────────────────────────────
+// Module scope stands in for the persistence layer: committed edits survive
+// drill-in navigation (which remounts the provider), so what a focus session
+// hydrates is what previous sessions wrote — a true storage round-trip.
+
+let sessionDocuments: DocumentsById = createInitialTimelineDocuments();
+
+function readDocuments(): DocumentsById {
+  return sessionDocuments;
+}
+
+function writeDocumentClips(timelineId: string, clips: TimelineClip[]) {
+  const doc = sessionDocuments[timelineId];
+  if (!doc) return;
+  sessionDocuments = { ...sessionDocuments, [timelineId]: { ...doc, clips } };
+}
+
+// ── Navigation context ──────────────────────────────────────────────────────
+// Content components are module-scope (identity-stable, per the package's
+// registry contract), so drill-in and detail lookups reach them via context.
+
+type GraphTimelineNav = Readonly<{
+  details: DetailsById;
+  openTimeline: (nodeId: NodeId) => void;
+}>;
+
+const GraphTimelineNavContext = createContext<GraphTimelineNav | null>(null);
+
+function GraphTimelineNavProvider({
+  details,
+  focusedId,
+  timelinePath,
+  children,
+}: Readonly<{
+  details: DetailsById;
+  focusedId: string;
+  timelinePath: readonly string[];
+  children: React.ReactNode;
+}>) {
+  const router = useRouter();
+  const store = useCollectionsStore();
+
+  const value = useMemo<GraphTimelineNav>(
+    () => ({
+      details,
+      openTimeline: (nodeId) => {
+        // A duplicate-reference card opens the timeline it points at.
+        const timelineId = details[nodeId as string]?.duplicateOfTimelineId ?? (nodeId as string);
+        if (timelineId === focusedId) return;
+        // Build the URL chain by walking up the LIVE graph to the focused
+        // root — the node may have been dragged under a different collection
+        // since mount, and the path must reflect where it lives now.
+        const { graph } = store.getSnapshot();
+        const chain: string[] = [timelineId];
+        let parent = graph.parentById.get(parseNodeId(timelineId)) ?? null;
+        while (parent !== null && (parent as string) !== focusedId) {
+          chain.unshift(parent as string);
+          parent = graph.parentById.get(parent) ?? null;
+        }
+        if ((parent as string | null) !== focusedId) return; // detached — no route to it
+        router.push(`/graph-timeline/${[...timelinePath, ...chain].join("/")}`);
+      },
+    }),
+    [details, focusedId, timelinePath, router, store],
+  );
+
+  return (
+    <GraphTimelineNavContext.Provider value={value}>{children}</GraphTimelineNavContext.Provider>
+  );
+}
+
+// ── Consumer pixels (module scope — identity-stable) ────────────────────────
+
+/** Live-tracking duration readout — a LEAF so only the clip being trimmed
+ *  re-renders per pointer move (useLiveTrim re-renders its caller). */
+function LiveDurationPill({ id, node }: { id: NodeId; node: MediaNode }) {
+  const live = useLiveTrim(id);
+  const showing = live ? live.effectiveSeconds : mediaDurationSeconds(node);
+  return (
+    <span className="pointer-events-none absolute right-1 bottom-1 z-10 rounded bg-black/75 px-1.5 py-0.5 font-mono text-[9px] tabular-nums text-zinc-100">
+      {node.mediaKind === "video"
+        ? `${showing.toFixed(2)}s / ${node.fullDurationSeconds.toFixed(2)}s`
+        : `${showing.toFixed(2)}s`}
+    </span>
+  );
+}
+
+const GraphClipContent = memo(function GraphClipContent({
+  id,
+  node,
+  childCount,
+  selected,
+  rejected,
+  isDragSource,
+  trimEnabled,
+}: CollectionItemContentProps) {
+  const nav = useContext(GraphTimelineNavContext);
+
+  if (node.kind === "collection") {
+    const detail = nav?.details[id as string];
+    const hydrated = detail?.hydrated === true;
+    const count = hydrated ? childCount : (detail?.itemCount ?? childCount);
+    const previews = detail?.previewItems?.slice(0, 3) ?? [];
+    return (
+      <span
+        title="Double-click to open this timeline"
+        onDoubleClick={() => nav?.openTimeline(id)}
+        className={[
+          "relative flex h-full w-full flex-col justify-between overflow-hidden rounded-md border border-dashed border-primary/40 bg-primary/[0.08] p-1.5",
+          selected ? "ring-2 ring-amber-400" : "",
+          rejected ? "ring-2 ring-red-500 motion-safe:animate-pulse" : "",
+          isDragSource ? "opacity-40" : "",
+        ].join(" ")}
+      >
+        <span className="flex min-h-0 flex-1 gap-0.5 overflow-hidden">
+          {previews.length === 0 ? (
+            <span className="flex flex-1 items-center justify-center text-[9px] text-muted-foreground">
+              {hydrated ? "Empty" : "Open to load"}
+            </span>
+          ) : (
+            previews.map((preview) => (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                key={preview.id}
+                src={preview.poster ?? preview.src}
+                alt=""
+                draggable={false}
+                loading="lazy"
+                className="h-full min-w-0 flex-1 rounded-sm object-cover"
+              />
+            ))
+          )}
+        </span>
+        <span className="mt-1 flex items-baseline justify-between gap-1">
+          <span className="truncate text-[10px] font-semibold text-foreground">{node.name}</span>
+          <span className="shrink-0 font-mono text-[9px] text-muted-foreground">{count}</span>
+        </span>
+      </span>
+    );
+  }
+
+  const isVideo = node.mediaKind === "video";
+  const posters = isVideo ? (node.posterSrcs ?? []) : node.src ? [node.src] : [];
+  const frames = isVideo ? videoFrameCount(mediaDurationSeconds(node), 6) : 1;
+  return (
+    <span
+      className={[
+        "relative flex h-full w-full overflow-hidden rounded-md bg-zinc-900",
+        selected ? "ring-2 ring-amber-400" : "ring-1 ring-white/15",
+        rejected ? "ring-2 ring-red-500 motion-safe:animate-pulse" : "",
+        isDragSource ? "opacity-40" : "",
+      ].join(" ")}
+    >
+      {posters.length === 0 ? (
+        <span className="flex h-full w-full items-center justify-center text-[10px] text-muted-foreground">
+          No preview
+        </span>
+      ) : (
+        <span className="flex h-full w-full">
+          {Array.from({ length: frames }).map((_, index) => (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              key={index}
+              src={posters[index % posters.length]}
+              alt=""
+              draggable={false}
+              loading="lazy"
+              className="h-full min-w-0 flex-1 border-r border-black/60 object-cover last:border-r-0"
+            />
+          ))}
+        </span>
+      )}
+      {trimEnabled && <LiveDurationPill id={id} node={node} />}
+    </span>
+  );
+});
+
+const GraphTrimHandle = memo(function GraphTrimHandle({
+  side,
+  selected,
+}: CollectionTrimHandleContentProps) {
+  return (
+    <span
+      className={[
+        "flex h-full w-full items-center justify-center transition-opacity",
+        side === "left" ? "rounded-l-md" : "rounded-r-md",
+        selected ? "bg-amber-400 opacity-95" : "bg-amber-400/50 opacity-0 group-hover:opacity-90",
+      ].join(" ")}
+    >
+      <span className="h-4 w-0.5 rounded bg-black/60" />
+    </span>
+  );
+});
+
+const GraphGhost = memo(function GraphGhost({ node, extraCount }: CollectionGhostContentProps) {
+  return (
+    <span className="relative flex h-full w-full flex-col justify-between rounded-md bg-zinc-900/95 p-2 text-xs shadow-2xl ring-2 ring-amber-400">
+      <span className="truncate font-semibold text-zinc-100">{node.name}</span>
+      <span className="font-mono text-[10px] text-zinc-400">
+        {node.kind === "collection" ? "Timeline" : `${mediaDurationSeconds(node).toFixed(2)}s`}
+      </span>
+      {extraCount > 0 && (
+        <span className="absolute -top-2 -right-2 flex h-6 min-w-6 items-center justify-center rounded-full bg-amber-400 px-1 text-[11px] font-bold text-black shadow">
+          +{extraCount}
+        </span>
+      )}
+    </span>
+  );
+});
+
+const GRAPH_TIMELINE_COMPONENTS: CollectionsComponents = {
+  ItemContent: GraphClipContent,
+  TrimHandleContent: GraphTrimHandle,
+  GhostContent: GraphGhost,
+};
+
+// ── Inline sub-timelines ────────────────────────────────────────────────────
+// Every collection child of the focused timeline gets its own strip UNDER
+// the parent — a second projection of the same graph in the same provider,
+// which is exactly what makes cross-timeline drags native.
+
+function SubTimelines({ focusedId, details }: { focusedId: string; details: DetailsById }) {
+  const nav = useContext(GraphTimelineNavContext);
+  // Graph identity changes only per committed change — this section re-
+  // renders at commit cadence (cheap), never per drag move.
+  const graph = useCollectionsSelector((s) => s.graph);
+  const [collapsedIds, setCollapsedIds] = useState<ReadonlySet<string>>(new Set());
+
+  const collections = getChildren(graph, parseNodeId(focusedId)).filter(
+    (childId) => graph.nodesById.get(childId)?.kind === "collection",
+  );
+  if (collections.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-3">
+      {collections.map((collectionId) => {
+        const node = graph.nodesById.get(collectionId);
+        if (node?.kind !== "collection") return null;
+        const id = collectionId as string;
+        const detail = details[id];
+        const hydrated = detail?.hydrated === true;
+        const collapsed = collapsedIds.has(id);
+        const liveCount = getChildren(graph, collectionId).length;
+
+        return (
+          <section key={id} aria-label={`Sub-timeline: ${node.name}`}>
+            <div className="mb-1.5 flex items-center gap-2">
+              <span className="h-3 w-3 rounded-sm border border-dashed border-primary/60 bg-primary/20" />
+              <h3 className="text-sm font-semibold">{node.name}</h3>
+              <Badge variant="secondary" className="font-mono text-[10px]">
+                {hydrated ? liveCount : (detail?.itemCount ?? 0)} clips
+              </Badge>
+              {!hydrated && (
+                <Badge variant="outline" className="text-[10px] text-muted-foreground">
+                  not hydrated
+                </Badge>
+              )}
+              <span className="grow" />
+              {hydrated && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() =>
+                    setCollapsedIds((current) => {
+                      const next = new Set(current);
+                      if (next.has(id)) next.delete(id);
+                      else next.add(id);
+                      return next;
+                    })
+                  }
+                >
+                  {collapsed ? "Expand" : "Collapse"}
+                </Button>
+              )}
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => nav?.openTimeline(collectionId)}
+              >
+                Focus
+              </Button>
+            </div>
+            {hydrated && !collapsed && (
+              <VirtualStrip
+                collectionId={collectionId}
+                pixelsPerSecond={TIMELINE_PPS}
+                itemHeight={64}
+                itemDragActivation="hold"
+                className="bg-black/20"
+              />
+            )}
+            {!hydrated && (
+              <p className="rounded-md border border-dashed border-border px-3 py-2 text-xs text-muted-foreground">
+                This timeline&apos;s document loads when focused — press Focus (or double-click its
+                clip above).
+              </p>
+            )}
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Persistence sync panel ──────────────────────────────────────────────────
+
+type SyncEntry = Readonly<{
+  at: number;
+  origin: CollectionsChange["origin"];
+  patchType: CollectionsChange["patch"]["type"];
+  collections: readonly string[];
+}>;
+
+function SyncPanel({ entries }: { entries: readonly SyncEntry[] }) {
+  return (
+    <div className="rounded-lg border border-border bg-card/50 p-3">
+      <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+        Patch-scoped document writes
+      </h3>
+      {entries.length === 0 ? (
+        <p className="mt-2 text-xs text-muted-foreground">
+          No writes yet — reorder, trim, nest, or undo and watch which documents get rewritten.
+        </p>
+      ) : (
+        <ol className="mt-2 flex flex-col gap-1 font-mono text-[11px] text-muted-foreground">
+          {entries.map((entry) => (
+            <li key={entry.at} className="flex flex-wrap items-baseline gap-x-2">
+              <span className="text-foreground">{entry.origin}</span>
+              <span>{entry.patchType}</span>
+              <span aria-hidden="true">→</span>
+              <span className="text-primary">
+                {entry.collections.length === 0 ? "(no stored documents)" : entry.collections.join(", ")}
+              </span>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}
+
+// ── The board (one provider per focus session) ──────────────────────────────
+
+function GraphTimelineBoard({
+  focusedId,
+  timelinePath,
+  focusedGraph,
+}: Readonly<{
+  focusedId: string;
+  timelinePath: readonly string[];
+  focusedGraph: FocusedGraph;
+}>) {
+  const { graph: initialGraph, details, missingDocuments } = focusedGraph;
+  const [syncLog, setSyncLog] = useState<readonly SyncEntry[]>([]);
+  const focusedDoc = readDocuments()[focusedId];
+
+  // The persistence write path: map the committed patch to the documents it
+  // touched, rewrite only those. `change.graph` is post-commit, so the
+  // projection reads the truth the engine just established.
+  const handleChange = useCallback(
+    (change: CollectionsChange) => {
+      const affected = collectAffectedCollectionIds(change.graph, change.patch).filter(
+        (id) => readDocuments()[id] !== undefined,
+      );
+      for (const id of affected) {
+        writeDocumentClips(id, graphChildrenToClips(change.graph, details, id));
+      }
+      setSyncLog((log) =>
+        [
+          {
+            at: Date.now(),
+            origin: change.origin,
+            patchType: change.patch.type,
+            collections: affected,
+          },
+          ...log,
+        ].slice(0, 6),
+      );
+    },
+    [details],
+  );
+
+  return (
+    <DndCollections
+      initialGraph={initialGraph}
+      components={GRAPH_TIMELINE_COMPONENTS}
+      onChange={handleChange}
+    >
+      <GraphTimelineNavProvider details={details} focusedId={focusedId} timelinePath={timelinePath}>
+        <Card>
+          <CardHeader>
+            <CardTitle>
+              <h2>{focusedDoc?.title ?? focusedId}</h2>
+            </CardTitle>
+            {focusedDoc?.description && (
+              <CardDescription>{focusedDoc.description}</CardDescription>
+            )}
+            <CardAction>
+              <UndoRedoControls />
+            </CardAction>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-5">
+            {missingDocuments.length > 0 && (
+              <p className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+                Referenced timelines without documents: {missingDocuments.join(", ")} (left as
+                placeholders).
+              </p>
+            )}
+            <VirtualStrip
+              collectionId={parseNodeId(focusedId)}
+              pixelsPerSecond={TIMELINE_PPS}
+              itemHeight={88}
+              itemDragActivation="hold"
+              className="bg-black/25"
+            />
+            <SubTimelines focusedId={focusedId} details={details} />
+            <SyncPanel entries={syncLog} />
+            <ul className="flex flex-wrap gap-x-6 gap-y-2 text-xs text-muted-foreground">
+              <li>Press-and-hold a clip to drag — including between the timelines above.</li>
+              <li>Drag a clip&apos;s amber edges to trim; drop a clip ON a dashed card to nest it.</li>
+              <li>Double-click a dashed collection clip to focus its timeline (the URL follows).</li>
+              <li>Undo/redo covers all of it — one history, because it&apos;s one graph.</li>
+            </ul>
+          </CardContent>
+        </Card>
+      </GraphTimelineNavProvider>
+    </DndCollections>
+  );
+}
+
+// ── Breadcrumbs (route state — outside the provider on purpose) ─────────────
+
+function Breadcrumbs({ timelinePath }: { timelinePath: readonly string[] }) {
+  const documents = readDocuments();
+  const crumbs = [
+    { id: ROOT_TIMELINE_ID, title: documents[ROOT_TIMELINE_ID]?.title ?? "Root", href: "/graph-timeline" },
+    ...timelinePath.map((id, index) => ({
+      id,
+      title: documents[id]?.title ?? id,
+      href: `/graph-timeline/${timelinePath.slice(0, index + 1).join("/")}`,
+    })),
+  ];
+
+  return (
+    <nav aria-label="Timeline focus path">
+      <ol className="flex flex-wrap items-center gap-1 text-sm">
+        {crumbs.map((crumb, index) => {
+          const isCurrent = index === crumbs.length - 1;
+          return (
+            <li key={crumb.href} className="flex items-center gap-1">
+              {index > 0 && (
+                <span aria-hidden="true" className="text-muted-foreground">
+                  /
+                </span>
+              )}
+              {isCurrent ? (
+                <span aria-current="page" className="font-semibold text-foreground">
+                  {crumb.title}
+                </span>
+              ) : (
+                <Link
+                  href={crumb.href}
+                  className="text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline"
+                >
+                  {crumb.title}
+                </Link>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}
+
+// ── Entry ───────────────────────────────────────────────────────────────────
+
+export function GraphTimeline({ timelinePath }: { timelinePath: string[] }) {
+  const focusedId = timelinePath[timelinePath.length - 1] ?? ROOT_TIMELINE_ID;
+  // Hydrate-on-focus: every focus change re-reads the session documents —
+  // which carry all previously committed writes — and builds a fresh graph
+  // for the focused timeline plus one level of child collections.
+  const built = useMemo(() => buildFocusedGraph(readDocuments(), focusedId), [focusedId]);
+
+  if (!built.ok) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <h2>Unknown timeline</h2>
+          </CardTitle>
+          <CardDescription>{built.error}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Link href="/graph-timeline" className="text-sm text-primary underline underline-offset-4">
+            Back to the root timeline
+          </Link>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Breadcrumbs timelinePath={timelinePath} />
+      {/* Keyed remount per focus: a focus session is a hydration boundary. */}
+      <GraphTimelineBoard
+        key={focusedId}
+        focusedId={focusedId}
+        timelinePath={timelinePath}
+        focusedGraph={built.value}
+      />
+    </div>
+  );
+}

--- a/apps/media-strip-rsc/package.json
+++ b/apps/media-strip-rsc/package.json
@@ -13,6 +13,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@storyboard/timeline-domain": "*",
     "@storyboard/ui": "*",
     "autoprefixer": "10.5.2",
     "clsx": "2.1.1",

--- a/apps/storybook/vitest.config.ts
+++ b/apps/storybook/vitest.config.ts
@@ -53,6 +53,7 @@ export default defineConfig({
           include: [
             "../../packages/ui/**/*.test.ts",
             "../../packages/ui/**/*.test.tsx",
+            "../../packages/timeline-domain/**/*.test.ts",
           ],
         },
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@storyboard/timeline-domain": "*",
         "@storyboard/ui": "*",
         "autoprefixer": "10.5.2",
         "clsx": "2.1.1",
@@ -2099,7 +2100,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
       "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
@@ -2112,7 +2112,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
@@ -2128,7 +2127,6 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
       "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/utilities": "^3.2.2",
@@ -2143,7 +2141,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
       "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
@@ -8157,6 +8154,10 @@
     },
     "node_modules/@storyboard/storybook": {
       "resolved": "apps/storybook",
+      "link": true
+    },
+    "node_modules/@storyboard/timeline-domain": {
+      "resolved": "packages/timeline-domain",
       "link": true
     },
     "node_modules/@storyboard/ui": {
@@ -26157,6 +26158,16 @@
       "version": "1.0.0",
       "dependencies": {
         "postgres": "^3.4.9"
+      },
+      "devDependencies": {
+        "@types/node": "^20"
+      }
+    },
+    "packages/timeline-domain": {
+      "name": "@storyboard/timeline-domain",
+      "version": "0.1.0",
+      "dependencies": {
+        "@storyboard/ui": "*"
       },
       "devDependencies": {
         "@types/node": "^20"

--- a/packages/timeline-domain/index.ts
+++ b/packages/timeline-domain/index.ts
@@ -1,0 +1,14 @@
+// @storyboard/timeline-domain — the storage/hydration seam between the app's
+// TimelineDocument model and the collections graph engine, per
+// docs/storyboard-graph-architecture.md. Framework-free.
+
+export {
+  buildFocusedGraph,
+  collectAffectedCollectionIds,
+  graphChildrenToClips,
+  type BuildFocusedGraphResult,
+  type ClipDetail,
+  type DetailsById,
+  type DocumentsById,
+  type FocusedGraph,
+} from "./src/adapter";

--- a/packages/timeline-domain/package.json
+++ b/packages/timeline-domain/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@storyboard/timeline-domain",
+  "version": "0.1.0",
+  "private": true,
+  "main": "index.ts",
+  "types": "index.ts",
+  "sideEffects": false,
+  "dependencies": {
+    "@storyboard/ui": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^20"
+  }
+}

--- a/packages/timeline-domain/src/adapter.test.ts
+++ b/packages/timeline-domain/src/adapter.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createInitialTimelineDocuments,
+  packTimelineClips,
+} from "@storyboard/ui/timeline/timeline-documents";
+import type { TimelineClip, TimelineDocument } from "@storyboard/ui/timeline/types";
+
+import {
+  buildFocusedGraph,
+  collectAffectedCollectionIds,
+  graphChildrenToClips,
+} from "./adapter";
+import { findGraphInvariantViolation, getChildren, parseNodeId } from "./engine";
+
+// The adapter is the storage/hydration seam of the graph architecture: real
+// TimelineDocuments in, a valid focused graph + side-table out, and clips
+// back with packing parity. These tests run it against hand fixtures AND the
+// app's actual initial documents.
+
+const base = {
+  index: 0,
+  aspect: 16 / 9,
+  trackIndex: 0,
+  startTime: 0,
+  playbackStartTime: undefined,
+  playbackDuration: undefined,
+} as const;
+
+function image(id: string, duration: number): TimelineClip {
+  return {
+    ...base,
+    id,
+    kind: "image",
+    alt: `${id} alt`,
+    src: `https://example.com/${id}.jpg`,
+    poster: `https://example.com/${id}-poster.jpg`,
+    duration,
+    sourceDuration: duration,
+    trimIn: 0,
+    trimOut: 0,
+  };
+}
+
+function video(id: string, sourceDuration: number, trimIn: number, trimOut: number): TimelineClip {
+  return {
+    ...base,
+    id,
+    kind: "video",
+    alt: `${id} alt`,
+    src: `https://example.com/${id}.mp4`,
+    poster: `https://example.com/${id}-poster.jpg`,
+    duration: sourceDuration - trimIn - trimOut,
+    sourceDuration,
+    trimIn,
+    trimOut,
+  };
+}
+
+function collectionClip(id: string, childTimelineId: string, title: string): TimelineClip {
+  return {
+    ...base,
+    id,
+    kind: "collection",
+    title,
+    childTimelineId,
+    itemCount: 2,
+    previewItems: [
+      { id: "p1", kind: "image", src: "https://example.com/p1.jpg", alt: "p1" },
+    ],
+    alt: `${title} collection`,
+    duration: 3,
+    sourceDuration: 3,
+    trimIn: 0,
+    trimOut: 0,
+  };
+}
+
+const CHILD_DOC: TimelineDocument = {
+  id: "child",
+  title: "Child timeline",
+  clips: packTimelineClips([
+    image("c-img", 2),
+    collectionClip("c-nested-clip", "grandchild", "Grandchild"),
+  ]),
+};
+
+const GRANDCHILD_DOC: TimelineDocument = {
+  id: "grandchild",
+  title: "Grandchild timeline",
+  clips: packTimelineClips([image("g-img", 1)]),
+};
+
+const ROOT_DOC: TimelineDocument = {
+  id: "focus-root",
+  title: "Focused timeline",
+  clips: packTimelineClips([
+    image("img-1", 4),
+    video("vid-1", 10, 2, 3),
+    collectionClip("col-clip-1", "child", "Child timeline"),
+  ]),
+};
+
+const DOCUMENTS = {
+  "focus-root": ROOT_DOC,
+  child: CHILD_DOC,
+  grandchild: GRANDCHILD_DOC,
+};
+
+describe("buildFocusedGraph", () => {
+  it("builds a valid graph rooted at the focused timeline, hydrating one child level", () => {
+    const result = buildFocusedGraph(DOCUMENTS, "focus-root");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const { graph, details } = result.value;
+
+    expect(findGraphInvariantViolation(graph)).toBeNull();
+    expect(graph.rootIds).toEqual(["focus-root"]);
+    // A collection clip IS its child timeline: the node id is childTimelineId.
+    expect(getChildren(graph, parseNodeId("focus-root"))).toEqual(["img-1", "vid-1", "child"]);
+
+    // Hydrated one level: the child's clips are present…
+    expect(getChildren(graph, parseNodeId("child"))).toEqual(["c-img", "grandchild"]);
+    expect(details["child"]).toMatchObject({ hydrated: true, sourceClipId: "col-clip-1" });
+    // …the grandchild is a placeholder awaiting focus/expansion.
+    expect(getChildren(graph, parseNodeId("grandchild"))).toEqual([]);
+    expect(details["grandchild"]).toMatchObject({ hydrated: false });
+  });
+
+  it("maps media fields onto nodes and app fields into the side-table", () => {
+    const result = buildFocusedGraph(DOCUMENTS, "focus-root");
+    if (!result.ok) throw new Error(result.error);
+    const { graph, details } = result.value;
+
+    expect(graph.nodesById.get(parseNodeId("vid-1"))).toMatchObject({
+      kind: "media",
+      mediaKind: "video",
+      fullDurationSeconds: 10,
+      trimInSeconds: 2,
+      trimOutSeconds: 3,
+      posterSrcs: ["https://example.com/vid-1-poster.jpg"],
+    });
+    expect(details["vid-1"]).toMatchObject({ alt: "vid-1 alt", aspect: 16 / 9 });
+    expect(details["img-1"]).toMatchObject({ sourceDuration: 4, trimIn: 0, trimOut: 0 });
+  });
+
+  it("demotes a duplicate reference to a non-navigable card instead of failing", () => {
+    const docs = {
+      ...DOCUMENTS,
+      "focus-root": {
+        ...ROOT_DOC,
+        clips: packTimelineClips([
+          collectionClip("ref-a", "child", "Child timeline"),
+          collectionClip("ref-b", "child", "Child timeline"),
+        ]),
+      },
+    };
+    const result = buildFocusedGraph(docs, "focus-root");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(getChildren(result.value.graph, parseNodeId("focus-root"))).toEqual(["child", "ref-b"]);
+    expect(result.value.details["ref-b"]).toMatchObject({ duplicateOfTimelineId: "child" });
+  });
+
+  it("reports missing child documents and leaves placeholders", () => {
+    const docs = { "focus-root": ROOT_DOC }; // child/grandchild absent
+    const result = buildFocusedGraph(docs, "focus-root");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.missingDocuments).toEqual(["child"]);
+    expect(getChildren(result.value.graph, parseNodeId("child"))).toEqual([]);
+  });
+
+  it("rejects an unknown focus target", () => {
+    expect(buildFocusedGraph(DOCUMENTS, "nope")).toMatchObject({ ok: false });
+  });
+});
+
+describe("graphChildrenToClips (round-trip)", () => {
+  it("projects back with packing parity against packTimelineClips", () => {
+    const result = buildFocusedGraph(DOCUMENTS, "focus-root");
+    if (!result.ok) throw new Error(result.error);
+    const projected = graphChildrenToClips(result.value.graph, result.value.details, "focus-root");
+    const packed = packTimelineClips(ROOT_DOC.clips.map((clip) => ({ ...clip })));
+
+    expect(projected.map((c) => c.id)).toEqual(packed.map((c) => c.id));
+    for (let i = 0; i < projected.length; i++) {
+      expect(projected[i].startTime).toBeCloseTo(packed[i].startTime, 8);
+      expect(projected[i].duration).toBeCloseTo(packed[i].duration, 8);
+      expect(projected[i].kind).toBe(packed[i].kind);
+      expect(projected[i].trimIn).toBe(packed[i].trimIn);
+      expect(projected[i].trimOut).toBe(packed[i].trimOut);
+    }
+    // The collection clip keeps its legacy id and child reference.
+    const col = projected[2];
+    expect(col.kind).toBe("collection");
+    if (col.kind === "collection") {
+      expect(col.id).toBe("col-clip-1");
+      expect(col.childTimelineId).toBe("child");
+      expect(col.itemCount).toBe(2);
+    }
+  });
+});
+
+describe("against the app's real initial documents", () => {
+  it("builds a valid graph for the root timeline and preserves clip order", () => {
+    const documents = createInitialTimelineDocuments();
+    const result = buildFocusedGraph(documents, "root");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const { graph } = result.value;
+
+    expect(findGraphInvariantViolation(graph)).toBeNull();
+    const expectedIds = documents["root"].clips.map((clip) =>
+      clip.kind === "collection" ? clip.childTimelineId : clip.id,
+    );
+    expect(getChildren(graph, parseNodeId("root"))).toEqual(expectedIds);
+  });
+
+  it("round-trips the real scene-a document's clip identities", () => {
+    const documents = createInitialTimelineDocuments();
+    const result = buildFocusedGraph(documents, "scene-a");
+    if (!result.ok) throw new Error(result.error);
+    const projected = graphChildrenToClips(result.value.graph, result.value.details, "scene-a");
+    expect(projected.map((c) => c.id)).toEqual(documents["scene-a"].clips.map((c) => c.id));
+  });
+});
+
+describe("collectAffectedCollectionIds", () => {
+  it("names the write set for moves, adds, and updates", () => {
+    const result = buildFocusedGraph(DOCUMENTS, "focus-root");
+    if (!result.ok) throw new Error(result.error);
+    const { graph } = result.value;
+
+    expect(
+      collectAffectedCollectionIds(graph, {
+        type: "nodes-moved",
+        moves: [
+          {
+            nodeId: parseNodeId("c-img"),
+            fromParentId: parseNodeId("child"),
+            fromIndex: 0,
+            toParentId: parseNodeId("focus-root"),
+            toIndex: 0,
+          },
+        ],
+      }),
+    ).toEqual(expect.arrayContaining(["child", "focus-root"]));
+
+    expect(
+      collectAffectedCollectionIds(graph, {
+        type: "nodes-updated",
+        updates: [
+          {
+            nodeId: parseNodeId("vid-1"),
+            before: graph.nodesById.get(parseNodeId("vid-1"))!,
+            after: graph.nodesById.get(parseNodeId("vid-1"))!,
+          },
+        ],
+      }),
+    ).toEqual(["focus-root"]);
+  });
+});

--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -1,0 +1,351 @@
+// TimelineDocument ⇄ CollectionsGraph adapter — the storage/hydration seam of
+// docs/storyboard-graph-architecture.md.
+//
+// The stored model (packages/ui/timeline): a map of TimelineDocuments, each a
+// flat TimelineClip[] where a collection clip references its child document
+// by `childTimelineId`. Semantically that is a containment forest — exactly
+// the graph — so this adapter:
+//
+//   - builds a graph rooted at the FOCUSED timeline (drill-in navigation is
+//     the hydration trigger), hydrating a bounded number of child levels;
+//     deeper collections become PLACEHOLDER nodes (empty children) until
+//     focused/expanded;
+//   - keeps the app-level fields the engine doesn't model (aspect, alt,
+//     posters, collection previews/counts…) in a side-table keyed by node id
+//     — the "does the engine touch it?" rule: durations/trims/src live on
+//     media nodes (the engine mutates them), everything else lives here;
+//   - projects a collection's children back to TimelineClip[] with derived
+//     startTime/index (packing math identical to packTimelineClips), which
+//     is the persistence write path.
+//
+// Identity rule: a collection clip IS its child timeline — the graph node id
+// is the childTimelineId. The legacy clip's own id is preserved in the
+// side-table (`sourceClipId`) for round-trips. If the same child is
+// referenced twice inside one hydrated area (the multi-parent case the
+// architecture assumes away), the duplicate becomes a non-navigable
+// reference card keyed by the clip's own id — surfaced, not crashed on.
+
+import {
+  CLIP_GAP_SECONDS,
+  TIMELINE_LEADING_PADDING_SECONDS,
+} from "@storyboard/ui/timeline/constants";
+import type {
+  CollectionTimelineClip,
+  TimelineClip,
+  TimelineDocument,
+} from "@storyboard/ui/timeline/types";
+
+import {
+  buildGraph,
+  getChildren,
+  mediaDurationSeconds,
+  parseNodeId,
+  type CollectionsGraph,
+  type CollectionsPatch,
+  type GraphNodeSpec,
+  type NodeId,
+} from "./engine";
+
+export type DocumentsById = Readonly<Record<string, TimelineDocument>>;
+
+/** App-level clip detail the graph deliberately doesn't model. */
+export type ClipDetail = Readonly<{
+  alt: string;
+  aspect: number;
+  trackIndex: number;
+  poster?: string;
+  playbackStartTime?: number;
+  playbackDuration?: number;
+  /** Image round-trip extras (the engine only stores an image's duration). */
+  sourceDuration?: number;
+  trimIn?: number;
+  trimOut?: number;
+  /** Collection-only. */
+  sourceClipId?: string;
+  itemCount?: number;
+  previewItems?: CollectionTimelineClip["previewItems"];
+  /** The collection clip's own display duration in its parent timeline. */
+  duration?: number;
+  /** False for placeholder collections awaiting hydration. */
+  hydrated?: boolean;
+  /** Set on a duplicate-reference card (see module comment). */
+  duplicateOfTimelineId?: string;
+}>;
+
+export type DetailsById = Readonly<Record<string, ClipDetail>>;
+
+export type FocusedGraph = Readonly<{
+  graph: CollectionsGraph;
+  details: DetailsById;
+  /** Referenced child timeline ids that had no document (left placeholders). */
+  missingDocuments: readonly string[];
+}>;
+
+export type BuildFocusedGraphResult =
+  | Readonly<{ ok: true; value: FocusedGraph }>
+  | Readonly<{ ok: false; error: string }>;
+
+type BuildContext = {
+  documents: DocumentsById;
+  details: Record<string, ClipDetail>;
+  missing: string[];
+  /** Node ids already used in the built area — duplicate references demote. */
+  used: Set<string>;
+};
+
+function mediaSpec(clip: Exclude<TimelineClip, CollectionTimelineClip>): GraphNodeSpec {
+  if (clip.kind === "video") {
+    return {
+      kind: "media",
+      mediaKind: "video",
+      id: clip.id,
+      name: clip.alt,
+      src: clip.src,
+      posterSrcs: clip.poster === undefined ? undefined : [clip.poster],
+      fullDurationSeconds: clip.sourceDuration,
+      trimInSeconds: clip.trimIn,
+      trimOutSeconds: clip.trimOut,
+    };
+  }
+  return {
+    kind: "media",
+    id: clip.id,
+    name: clip.alt,
+    src: clip.src,
+    durationSeconds: clip.duration,
+  };
+}
+
+function mediaDetail(clip: Exclude<TimelineClip, CollectionTimelineClip>): ClipDetail {
+  return {
+    alt: clip.alt,
+    aspect: clip.aspect,
+    trackIndex: clip.trackIndex,
+    ...(clip.poster === undefined ? {} : { poster: clip.poster }),
+    ...(clip.playbackStartTime === undefined ? {} : { playbackStartTime: clip.playbackStartTime }),
+    ...(clip.playbackDuration === undefined ? {} : { playbackDuration: clip.playbackDuration }),
+    ...(clip.kind === "image"
+      ? { sourceDuration: clip.sourceDuration, trimIn: clip.trimIn, trimOut: clip.trimOut }
+      : {}),
+  };
+}
+
+function collectionDetail(clip: CollectionTimelineClip, hydrated: boolean): ClipDetail {
+  return {
+    alt: clip.alt,
+    aspect: clip.aspect,
+    trackIndex: clip.trackIndex,
+    sourceClipId: clip.id,
+    itemCount: clip.itemCount,
+    ...(clip.previewItems === undefined ? {} : { previewItems: clip.previewItems }),
+    duration: clip.duration,
+    sourceDuration: clip.sourceDuration,
+    trimIn: clip.trimIn,
+    trimOut: clip.trimOut,
+    hydrated,
+  };
+}
+
+function clipSpecs(
+  ctx: BuildContext,
+  doc: TimelineDocument,
+  hydrateLevels: number,
+): GraphNodeSpec[] {
+  return doc.clips.map((clip) => {
+    if (clip.kind !== "collection") {
+      ctx.used.add(clip.id);
+      ctx.details[clip.id] = mediaDetail(clip);
+      return mediaSpec(clip);
+    }
+
+    const childId = clip.childTimelineId;
+    if (ctx.used.has(childId)) {
+      // Same child referenced twice inside the hydrated area: demote to a
+      // non-navigable reference card keyed by the clip's own id.
+      ctx.used.add(clip.id);
+      ctx.details[clip.id] = {
+        ...collectionDetail(clip, false),
+        duplicateOfTimelineId: childId,
+      };
+      return { kind: "collection", id: clip.id, name: clip.title, children: [] };
+    }
+    ctx.used.add(childId);
+
+    const childDoc = ctx.documents[childId];
+    if (childDoc && hydrateLevels > 0) {
+      ctx.details[childId] = collectionDetail(clip, true);
+      return {
+        kind: "collection",
+        id: childId,
+        name: clip.title,
+        children: clipSpecs(ctx, childDoc, hydrateLevels - 1),
+      };
+    }
+
+    if (!childDoc) ctx.missing.push(childId);
+    ctx.details[childId] = collectionDetail(clip, false);
+    return { kind: "collection", id: childId, name: clip.title, children: [] };
+  });
+}
+
+/**
+ * Build the graph for a focused timeline (drill-in navigation target).
+ * `hydrateChildLevels` controls how many collection levels below the focused
+ * timeline are loaded (default 1: the focused clips plus each child
+ * collection's own children, so inline sub-timeline expansion needs no
+ * further fetch). Deeper collections are placeholders.
+ */
+export function buildFocusedGraph(
+  documents: DocumentsById,
+  focusedId: string,
+  hydrateChildLevels = 1,
+): BuildFocusedGraphResult {
+  const focusedDoc = documents[focusedId];
+  if (!focusedDoc) {
+    return { ok: false, error: `Unknown timeline document "${focusedId}".` };
+  }
+
+  const ctx: BuildContext = {
+    documents,
+    details: {},
+    missing: [],
+    used: new Set([focusedId]),
+  };
+  const rootSpec: GraphNodeSpec = {
+    kind: "collection",
+    id: focusedId,
+    name: focusedDoc.title,
+    children: clipSpecs(ctx, focusedDoc, hydrateChildLevels),
+  };
+
+  const built = buildGraph([rootSpec]);
+  if (!built.ok) {
+    return { ok: false, error: `Could not build graph: ${JSON.stringify(built.error)}` };
+  }
+  return {
+    ok: true,
+    value: { graph: built.value, details: ctx.details, missingDocuments: ctx.missing },
+  };
+}
+
+/**
+ * Project a collection's children back to TimelineClip[] — the persistence
+ * write path. `startTime`/`index` are DERIVED with the same packing math as
+ * `packTimelineClips` (leading padding, fixed gap); durations come from the
+ * graph's media nodes (the engine's trims are the truth), everything else
+ * from the side-table.
+ */
+export function graphChildrenToClips(
+  graph: CollectionsGraph,
+  details: DetailsById,
+  collectionId: string,
+): TimelineClip[] {
+  let nextStartTime = TIMELINE_LEADING_PADDING_SECONDS;
+
+  return getChildren(graph, parseNodeId(collectionId)).map((childId, index) => {
+    const node = graph.nodesById.get(childId);
+    if (!node) throw new Error(`Graph child "${childId}" missing from nodesById.`);
+    const detail = details[childId];
+    const startTime = nextStartTime;
+
+    if (node.kind === "media") {
+      const duration = mediaDurationSeconds(node);
+      nextStartTime += duration + CLIP_GAP_SECONDS;
+      const base = {
+        id: node.id as string,
+        index,
+        alt: detail?.alt ?? node.name,
+        aspect: detail?.aspect ?? 16 / 9,
+        trackIndex: detail?.trackIndex ?? 0,
+        startTime,
+        duration,
+        ...(detail?.playbackStartTime === undefined
+          ? {}
+          : { playbackStartTime: detail.playbackStartTime }),
+        ...(detail?.playbackDuration === undefined
+          ? {}
+          : { playbackDuration: detail.playbackDuration }),
+      };
+      if (node.mediaKind === "video") {
+        return {
+          ...base,
+          kind: "video",
+          src: node.src ?? "",
+          ...(detail?.poster === undefined ? {} : { poster: detail.poster }),
+          sourceDuration: node.fullDurationSeconds,
+          trimIn: node.trimInSeconds,
+          trimOut: node.trimOutSeconds,
+        };
+      }
+      return {
+        ...base,
+        kind: "image",
+        src: node.src ?? "",
+        ...(detail?.poster === undefined ? {} : { poster: detail.poster }),
+        sourceDuration: detail?.sourceDuration ?? duration,
+        trimIn: detail?.trimIn ?? 0,
+        trimOut: detail?.trimOut ?? 0,
+      };
+    }
+
+    // Collection node → collection clip referencing it as the child timeline.
+    const duration = detail?.duration ?? 3;
+    nextStartTime += duration + CLIP_GAP_SECONDS;
+    return {
+      id: detail?.sourceClipId ?? (node.id as string),
+      index,
+      kind: "collection",
+      title: node.name,
+      childTimelineId: detail?.duplicateOfTimelineId ?? (node.id as string),
+      // Hydrated collections report their LIVE child count (nesting a clip
+      // into one must not persist the stale stored count); placeholders keep
+      // the stored count — their emptiness is unhydrated, not real.
+      itemCount: detail?.hydrated
+        ? getChildren(graph, node.id).length
+        : (detail?.itemCount ?? getChildren(graph, node.id).length),
+      ...(detail?.previewItems === undefined ? {} : { previewItems: detail.previewItems }),
+      alt: detail?.alt ?? `${node.name} collection`,
+      aspect: detail?.aspect ?? 16 / 9,
+      trackIndex: detail?.trackIndex ?? 0,
+      startTime,
+      duration,
+      sourceDuration: detail?.sourceDuration ?? duration,
+      trimIn: detail?.trimIn ?? 0,
+      trimOut: detail?.trimOut ?? 0,
+    };
+  });
+}
+
+/**
+ * The collections whose stored documents a committed change touches — the
+ * patch-scoped persistence write set.
+ */
+export function collectAffectedCollectionIds(
+  graph: CollectionsGraph,
+  patch: CollectionsPatch,
+): readonly string[] {
+  const ids = new Set<string>();
+  const parentOf = (nodeId: NodeId) => {
+    const parent = graph.parentById.get(nodeId);
+    if (parent !== undefined && parent !== null) ids.add(parent as string);
+  };
+
+  switch (patch.type) {
+    case "nodes-moved":
+      for (const move of patch.moves) {
+        ids.add(move.fromParentId as string);
+        ids.add(move.toParentId as string);
+      }
+      break;
+    case "nodes-added":
+      for (const add of patch.adds) ids.add(add.parentId as string);
+      break;
+    case "nodes-removed":
+      for (const removal of patch.removals) ids.add(removal.parentId as string);
+      break;
+    case "nodes-updated":
+      for (const update of patch.updates) parentOf(update.nodeId);
+      break;
+  }
+  return [...ids];
+}

--- a/packages/timeline-domain/src/engine.ts
+++ b/packages/timeline-domain/src/engine.ts
@@ -1,0 +1,19 @@
+// The ONE seam onto the collections graph engine (see
+// docs/storyboard-graph-architecture.md). Every other module in this package
+// imports the engine from here, never directly — the engine's home is a
+// single decision recorded in one file. Today it is the UI package's
+// framework-free `/core` entry point (no React, no dnd-kit — node-safe).
+
+export {
+  buildGraph,
+  findGraphInvariantViolation,
+  getChildren,
+  mediaDurationSeconds,
+  parseNodeId,
+  type CollectionItemNode,
+  type CollectionsGraph,
+  type CollectionsPatch,
+  type GraphNodeSpec,
+  type NodeId,
+  type Result,
+} from "@storyboard/ui/dnd-collections/core";

--- a/packages/timeline-domain/tsconfig.json
+++ b/packages/timeline-domain/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["esnext"],
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@storyboard/ui/*": ["../ui/*"]
+    }
+  },
+  "include": ["index.ts", "src/**/*.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/packages/ui/dnd-collections/core/index.ts
+++ b/packages/ui/dnd-collections/core/index.ts
@@ -1,0 +1,88 @@
+// The framework-free core: a node-safe entry point exposing ONLY the pure
+// graph engine (no React, no dnd-kit, no "use client"). Importing the
+// package barrel (`@storyboard/ui/dnd-collections`) pulls in the React views;
+// non-UI consumers (e.g. a domain layer that reuses the normalized graph as
+// its structural substrate) import `@storyboard/ui/dnd-collections/core`
+// instead and stay dependency-light. Every symbol here is also re-exported
+// from the package barrel — this is a narrower, purer view of the same code,
+// not a second surface.
+
+export {
+  buildGraph,
+  findGraphInvariantViolation,
+  getChildren,
+  getDocumentOrder,
+  isCollection,
+  isSameOrAncestor,
+  isVideoMedia,
+  mediaDurationSeconds,
+  parseCollectionItemNode,
+  parseGraphSpec,
+  videoFrameCount,
+  parseNodeId,
+  validateGraph,
+  EMPTY_GRAPH,
+  MAX_VIDEO_FRAMES,
+  SECONDS_PER_VIDEO_FRAME,
+  type BuildGraphError,
+  type CollectionNode,
+  type CollectionsValidationError,
+  type CollectionsGraph,
+  type CollectionItemNode,
+  type GraphInvariantViolation,
+  type GraphValidationError,
+  type GraphNodeSpec,
+  type ImageMediaNode,
+  type MediaNode,
+  type NodeId,
+  type Result,
+  type VideoMediaNode,
+} from "./graph";
+export {
+  applyCommand,
+  type AddNodesCommand,
+  type ApplyCommandSuccess,
+  type CollectionsCommand,
+  type CommandRejection,
+  type MediaUpdate,
+  type MoveNodesCommand,
+  type UpdateMediaCommand,
+} from "./commands";
+export {
+  applyPatch,
+  invertPatch,
+  type CollectionsPatch,
+  type NodeAdd,
+  type NodeMove,
+  type NodeUpdate,
+} from "./patches";
+export {
+  decodeDropTarget,
+  encodeDropTarget,
+  intentDestination,
+  isIntentInvalid,
+  resolveAddCommandFromIntent,
+  resolveCommandFromIntent,
+  resolveDropIntent,
+  type DropIntent,
+  type DropTarget,
+  type IntentRejection,
+  type PanelChildRect,
+  type RectLike,
+} from "./intents";
+export { createHistory, type CollectionsHistory, type HistoryEntry } from "./history";
+export {
+  resolveGridRowMoveCommand,
+  resolveKeyboardCommand,
+  resolveTrashCommand,
+  resolveTrimCommand,
+  resolveWindowMoveCommand,
+  type GridRowMoveRejection,
+  type KeyboardMoveAction,
+  type KeyboardRejection,
+  type KeyboardTrashRejection,
+  type KeyboardTrimAction,
+  type KeyboardTrimRejection,
+  type KeyboardWindowMoveAction,
+  type KeyboardWindowMoveRejection,
+} from "./keyboard";


### PR DESCRIPTION
…elineDocuments

Phase 2 of docs/storyboard-graph-architecture.md, on the app's actual data:

- packages/ui/dnd-collections/core/index.ts: framework-free core entry point (pure re-exports; node-safe engine seam for domain packages).
- packages/timeline-domain: the storage/hydration adapter between TimelineDocument and the collections graph. buildFocusedGraph hydrates the focused timeline plus one child level (deeper collections stay placeholders); app-only fields ride a side-table keyed by node id; a collection clip IS its child timeline (node id = childTimelineId, legacy clip id preserved for round-trips; duplicate references demote to non-navigable cards). graphChildrenToClips projects back with packTimelineClips packing parity, and collectAffectedCollectionIds maps a committed patch to the exact documents to rewrite. 9 unit tests including round-trips against createInitialTimelineDocuments.
- apps/media-strip-rsc /graph-timeline/[[...timelinePath]]: the proof page. ONE DndCollections owns the focused strip and every inline sub-timeline; the URL is the drill-in focus path (double-click a collection clip or its Focus button); each committed change/undo/redo writes back only the affected documents (visible in the sync panel); edits persist across focus round-trips via hydrate-on-focus.

Verified in-browser: drill-in (root -> scene-a -> scene-a-details, 3-level breadcrumb, placeholder hydration), keyboard reorder + trim with patch-scoped writes, undo/redo re-deriving the write, and persistence across navigation.