### PR TITLE
feat(dnd-collections): hydrate() — incremental hydration that keeps u…

### DIFF
--- a/apps/media-strip-rsc/app/graph-timeline/[[...timelinePath]]/page.tsx
+++ b/apps/media-strip-rsc/app/graph-timeline/[[...timelinePath]]/page.tsx
@@ -1,55 +1,7 @@
-import Link from "next/link";
-import type { Metadata } from "next";
-
-import { ClientGraphTimeline } from "../../../components/graph-timeline/client-graph-timeline";
-
-export const metadata: Metadata = {
-  title: "Graph Timeline | StoryboardFlow",
-  description:
-    "The app's real TimelineDocuments rendered through the collections graph: one provider, drill-in focus, inline sub-timelines, and patch-scoped persistence.",
-};
-
-type GraphTimelinePageProps = Readonly<{
-  params: Promise<{ timelinePath?: string[] }>;
-}>;
-
-// The phase-2 proof of docs/storyboard-graph-architecture.md: the graph is
-// the structural source of truth, ONE <DndCollections> hosts every view, and
-// the route's catch-all segments are the drill-in focus path (per-view state
-// lives in the route, shared state lives in the store).
-export default async function GraphTimelinePage({ params }: GraphTimelinePageProps) {
-  const { timelinePath } = await params;
-
-  return (
-    <main className="mx-auto flex min-h-dvh w-full max-w-7xl flex-col gap-8 px-5 py-8 md:px-8">
-      <header className="flex flex-col gap-5 border-b border-border pb-6">
-        <nav aria-label="Labs">
-          <Link
-            href="/dnd-collections"
-            className="text-sm font-medium text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
-          >
-            Back to DnD Collections Lab
-          </Link>
-        </nav>
-
-        <div className="max-w-3xl">
-          <p className="text-sm font-medium uppercase tracking-[0.18em] text-primary">
-            StoryboardFlow graph architecture proof
-          </p>
-          <h1 className="mt-3 text-4xl font-semibold leading-tight text-balance md:text-5xl">
-            Graph Timeline
-          </h1>
-          <p className="mt-3 max-w-2xl text-base leading-7 text-muted-foreground text-pretty">
-            The app&apos;s real TimelineDocuments projected through the collections graph. One
-            provider owns the page: the focused timeline, every inline sub-timeline, undo, and
-            cross-timeline drags all share a single graph. Double-click a collection clip (or use a
-            sub-timeline&apos;s Focus button) to drill in — the URL is the focus path, and the
-            document for that timeline hydrates on arrival.
-          </p>
-        </div>
-      </header>
-
-      <ClientGraphTimeline timelinePath={timelinePath ?? []} />
-    </main>
-  );
+// Intentionally empty: this page REMOUNTS on every focus navigation (App
+// Router keys pages by their dynamic params), so nothing stateful can live
+// here. The whole interactive tree — provider, graph, undo history — is
+// mounted once by ../layout.tsx and reads the focus path from usePathname().
+export default function GraphTimelinePage() {
+  return null;
 }

--- a/apps/media-strip-rsc/app/graph-timeline/layout.tsx
+++ b/apps/media-strip-rsc/app/graph-timeline/layout.tsx
@@ -1,0 +1,54 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+import { ClientGraphTimeline } from "../../components/graph-timeline/client-graph-timeline";
+
+export const metadata: Metadata = {
+  title: "Graph Timeline | StoryboardFlow",
+  description:
+    "The app's real TimelineDocuments rendered through the collections graph: one provider, drill-in focus, inline sub-timelines, and patch-scoped persistence.",
+};
+
+// The interactive tree lives in the LAYOUT, not the page: App Router
+// remounts page components when their dynamic params change, but layouts
+// persist — and persistence is the whole point here (one provider, one
+// graph, one undo stack across every focus navigation). The page below is
+// an empty shell; the client component reads the focus path from
+// usePathname().
+export default function GraphTimelineLayout({ children }: { children: ReactNode }) {
+  return (
+    <main className="mx-auto flex min-h-dvh w-full max-w-7xl flex-col gap-8 px-5 py-8 md:px-8">
+      <header className="flex flex-col gap-5 border-b border-border pb-6">
+        <nav aria-label="Labs">
+          <Link
+            href="/dnd-collections"
+            className="text-sm font-medium text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
+          >
+            Back to DnD Collections Lab
+          </Link>
+        </nav>
+
+        <div className="max-w-3xl">
+          <p className="text-sm font-medium uppercase tracking-[0.18em] text-primary">
+            StoryboardFlow graph architecture proof
+          </p>
+          <h1 className="mt-3 text-4xl font-semibold leading-tight text-balance md:text-5xl">
+            Graph Timeline
+          </h1>
+          <p className="mt-3 max-w-2xl text-base leading-7 text-muted-foreground text-pretty">
+            The app&apos;s real TimelineDocuments projected through the collections graph. One
+            provider owns the whole session: the focused timeline, every inline sub-timeline,
+            undo, and cross-timeline drags all share a single graph. Double-click a collection
+            clip (or use a sub-timeline&apos;s Focus button) to drill in — the URL is the focus
+            path, the document hydrates on arrival through the engine&apos;s hydration seam, and
+            the undo stack survives every navigation.
+          </p>
+        </div>
+      </header>
+
+      <ClientGraphTimeline />
+      {children}
+    </main>
+  );
+}

--- a/apps/media-strip-rsc/components/graph-timeline/client-graph-timeline.tsx
+++ b/apps/media-strip-rsc/components/graph-timeline/client-graph-timeline.tsx
@@ -18,6 +18,6 @@ const GraphTimeline = dynamic(
   },
 );
 
-export function ClientGraphTimeline({ timelinePath }: { timelinePath: string[] }) {
-  return <GraphTimeline timelinePath={timelinePath} />;
+export function ClientGraphTimeline() {
+  return <GraphTimeline />;
 }

--- a/apps/media-strip-rsc/components/graph-timeline/graph-timeline.tsx
+++ b/apps/media-strip-rsc/components/graph-timeline/graph-timeline.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import {
   createContext,
   memo,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useState,
 } from "react";
@@ -37,16 +38,18 @@ import {
   type CollectionTrimHandleContentProps,
   type CollectionsChange,
   type CollectionsComponents,
+  type CollectionsStore,
   type MediaNode,
   type NodeId,
 } from "@storyboard/ui/dnd-collections";
 import {
   buildFocusedGraph,
+  buildHydrationSpecs,
   collectAffectedCollectionIds,
   graphChildrenToClips,
+  type ClipDetail,
   type DetailsById,
   type DocumentsById,
-  type FocusedGraph,
 } from "@storyboard/timeline-domain";
 import { createInitialTimelineDocuments } from "@storyboard/ui/timeline/timeline-documents";
 import type { TimelineClip } from "@storyboard/ui/timeline/types";
@@ -54,30 +57,28 @@ import type { TimelineClip } from "@storyboard/ui/timeline/types";
 // The phase-2 proof of docs/storyboard-graph-architecture.md, on the app's
 // REAL data (`createInitialTimelineDocuments`):
 //
-//   - ONE <DndCollections> owns the page. The focused timeline and every
-//     inline sub-timeline are projections of the same graph, so dragging a
-//     clip between timelines, nesting it into a collection card, and undoing
-//     all of it are one store's business — no cross-provider choreography.
-//   - The URL is the focus path (per-view state lives in the route). Double-
-//     clicking a collection clip or pressing a sub-timeline's Focus button
-//     pushes its timeline id onto the path; landing there hydrates that
-//     document into a fresh graph (hydrate-on-focus).
+//   - ONE <DndCollections> owns the whole SESSION. The provider mounts once
+//     with the root timeline; focus (the URL's catch-all path) is pure view
+//     state, and drilling in never remounts anything — which is why the
+//     UNDO STACK SURVIVES navigation. Cross-timeline drags, nesting, and
+//     undo are all one store's business.
+//   - Documents hydrate on focus through the engine's hydration seam
+//     (`store.hydrate` — IO landing, invisible to undo and the change
+//     feed): navigating to a placeholder timeline fills it in place, and a
+//     placeholder sub-timeline can also be loaded inline without leaving
+//     the current focus.
 //   - Persistence is patch-scoped: every committed change (command, undo,
 //     redo) is mapped by `collectAffectedCollectionIds` to the documents it
 //     touched, and ONLY those are rewritten via `graphChildrenToClips` — the
 //     write path the sync panel makes visible.
-//
-// Known, deliberate trade-off: drilling in remounts the provider, so the
-// undo stack is scoped to a focus session (hydration stays out-of-band from
-// undo; see the architecture doc's open questions).
 
 const ROOT_TIMELINE_ID = "root";
 const TIMELINE_PPS = 40;
 
 // ── Session document store ──────────────────────────────────────────────────
 // Module scope stands in for the persistence layer: committed edits survive
-// drill-in navigation (which remounts the provider), so what a focus session
-// hydrates is what previous sessions wrote — a true storage round-trip.
+// full page remounts, so what a session hydrates is what previous sessions
+// wrote — a true storage round-trip.
 
 let sessionDocuments: DocumentsById = createInitialTimelineDocuments();
 
@@ -89,6 +90,100 @@ function writeDocumentClips(timelineId: string, clips: TimelineClip[]) {
   const doc = sessionDocuments[timelineId];
   if (!doc) return;
   sessionDocuments = { ...sessionDocuments, [timelineId]: { ...doc, clips } };
+}
+
+// ── Hydration ───────────────────────────────────────────────────────────────
+
+/**
+ * Fill one placeholder timeline through the engine's hydration seam and
+ * return the side-table entries to merge (or null when there was nothing to
+ * do). `levels` as in `buildHydrationSpecs`: 0 loads the timeline's own
+ * clips, 1 also loads each child collection's clips.
+ */
+function hydrateTimeline(
+  store: CollectionsStore,
+  details: Readonly<Record<string, ClipDetail>>,
+  timelineId: string,
+  levels: number,
+): Record<string, ClipDetail> | null {
+  const graph = store.getSnapshot().graph;
+  const doc = readDocuments()[timelineId];
+  if (!doc) return null;
+  const alreadyHydrated = details[timelineId]?.hydrated === true;
+  if (alreadyHydrated || getChildren(graph, parseNodeId(timelineId)).length > 0) return null;
+
+  const payload = buildHydrationSpecs(readDocuments(), timelineId, levels, graph.nodesById.keys());
+  if (!payload.ok) return null;
+  const applied = store.hydrate(parseNodeId(timelineId), payload.value.specs);
+  if (!applied.ok) return null;
+
+  const merged: Record<string, ClipDetail> = { ...payload.value.details };
+  const own = details[timelineId];
+  if (own) merged[timelineId] = { ...own, hydrated: true };
+  return merged;
+}
+
+/**
+ * Keeps the graph hydrated for the current focus path: every route segment's
+ * document is loaded (deep links land on a root-only graph), and the focused
+ * timeline's child collections load their own clips so the inline
+ * sub-timelines render. Renders nothing; runs at navigation cadence.
+ */
+function HydrationController({
+  segments,
+  focusedId,
+  details,
+  onDetails,
+  onFocusError,
+}: Readonly<{
+  segments: readonly string[];
+  focusedId: string;
+  details: DetailsById;
+  onDetails: (merged: Readonly<Record<string, ClipDetail>>) => void;
+  onFocusError: (error: string | null) => void;
+}>) {
+  const store = useCollectionsStore();
+  const pathKey = segments.join("/");
+
+  useEffect(() => {
+    const path = pathKey === "" ? [] : pathKey.split("/");
+    const merged: Record<string, ClipDetail> = {};
+    const detailOf = (id: string) => merged[id] ?? details[id];
+    const ensure = (timelineId: string, levels: number) => {
+      const hydrated = hydrateTimeline(
+        store,
+        { ...details, ...merged },
+        timelineId,
+        levels,
+      );
+      if (hydrated) Object.assign(merged, hydrated);
+    };
+
+    let error: string | null = null;
+    for (const segment of [ROOT_TIMELINE_ID, ...path]) {
+      if (!store.getSnapshot().graph.nodesById.has(parseNodeId(segment))) {
+        error = `Unknown timeline "${segment}".`;
+        break;
+      }
+      ensure(segment, 1);
+    }
+    if (error === null) {
+      // The focused timeline's placeholder child collections load their own
+      // clips (one level) so their inline strips have content.
+      const graph = store.getSnapshot().graph;
+      for (const childId of getChildren(graph, parseNodeId(focusedId))) {
+        const node = graph.nodesById.get(childId);
+        if (node?.kind === "collection" && detailOf(childId as string)?.hydrated === false) {
+          ensure(childId as string, 0);
+        }
+      }
+    }
+
+    onFocusError(error);
+    if (Object.keys(merged).length > 0) onDetails(merged);
+  }, [pathKey, focusedId, details, store, onDetails, onFocusError]);
+
+  return null;
 }
 
 // ── Navigation context ──────────────────────────────────────────────────────
@@ -105,12 +200,10 @@ const GraphTimelineNavContext = createContext<GraphTimelineNav | null>(null);
 function GraphTimelineNavProvider({
   details,
   focusedId,
-  timelinePath,
   children,
 }: Readonly<{
   details: DetailsById;
   focusedId: string;
-  timelinePath: readonly string[];
   children: React.ReactNode;
 }>) {
   const router = useRouter();
@@ -123,21 +216,24 @@ function GraphTimelineNavProvider({
         // A duplicate-reference card opens the timeline it points at.
         const timelineId = details[nodeId as string]?.duplicateOfTimelineId ?? (nodeId as string);
         if (timelineId === focusedId) return;
-        // Build the URL chain by walking up the LIVE graph to the focused
-        // root — the node may have been dragged under a different collection
-        // since mount, and the path must reflect where it lives now.
+        if (timelineId === ROOT_TIMELINE_ID) {
+          router.push("/graph-timeline");
+          return;
+        }
+        // Focus paths are ROOT-anchored: walk up the LIVE graph (the node
+        // may have been dragged elsewhere since it appeared) to the root.
         const { graph } = store.getSnapshot();
         const chain: string[] = [timelineId];
         let parent = graph.parentById.get(parseNodeId(timelineId)) ?? null;
-        while (parent !== null && (parent as string) !== focusedId) {
+        while (parent !== null && (parent as string) !== ROOT_TIMELINE_ID) {
           chain.unshift(parent as string);
           parent = graph.parentById.get(parent) ?? null;
         }
-        if ((parent as string | null) !== focusedId) return; // detached — no route to it
-        router.push(`/graph-timeline/${[...timelinePath, ...chain].join("/")}`);
+        if ((parent as string | null) !== ROOT_TIMELINE_ID) return; // detached — no route to it
+        router.push(`/graph-timeline/${chain.join("/")}`);
       },
     }),
-    [details, focusedId, timelinePath, router, store],
+    [details, focusedId, router, store],
   );
 
   return (
@@ -295,10 +391,19 @@ const GRAPH_TIMELINE_COMPONENTS: CollectionsComponents = {
 // the parent — a second projection of the same graph in the same provider,
 // which is exactly what makes cross-timeline drags native.
 
-function SubTimelines({ focusedId, details }: { focusedId: string; details: DetailsById }) {
+function SubTimelines({
+  focusedId,
+  details,
+  onDetails,
+}: Readonly<{
+  focusedId: string;
+  details: DetailsById;
+  onDetails: (merged: Readonly<Record<string, ClipDetail>>) => void;
+}>) {
   const nav = useContext(GraphTimelineNavContext);
-  // Graph identity changes only per committed change — this section re-
-  // renders at commit cadence (cheap), never per drag move.
+  const store = useCollectionsStore();
+  // Graph identity changes only per committed change/hydration — this
+  // section re-renders at commit cadence (cheap), never per drag move.
   const graph = useCollectionsSelector((s) => s.graph);
   const [collapsedIds, setCollapsedIds] = useState<ReadonlySet<string>>(new Set());
 
@@ -332,6 +437,19 @@ function SubTimelines({ focusedId, details }: { focusedId: string; details: Deta
                 </Badge>
               )}
               <span className="grow" />
+              {!hydrated && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    const merged = hydrateTimeline(store, details, id, 0);
+                    if (merged) onDetails(merged);
+                  }}
+                >
+                  Load inline
+                </Button>
+              )}
               {hydrated && (
                 <Button
                   type="button"
@@ -369,8 +487,8 @@ function SubTimelines({ focusedId, details }: { focusedId: string; details: Deta
             )}
             {!hydrated && (
               <p className="rounded-md border border-dashed border-border px-3 py-2 text-xs text-muted-foreground">
-                This timeline&apos;s document loads when focused — press Focus (or double-click its
-                clip above).
+                This timeline&apos;s document hasn&apos;t loaded — Load inline hydrates it right
+                here (undo history is untouched), Focus navigates to it.
               </p>
             )}
           </section>
@@ -398,6 +516,7 @@ function SyncPanel({ entries }: { entries: readonly SyncEntry[] }) {
       {entries.length === 0 ? (
         <p className="mt-2 text-xs text-muted-foreground">
           No writes yet — reorder, trim, nest, or undo and watch which documents get rewritten.
+          Hydration never appears here: loading data is not a change worth writing back.
         </p>
       ) : (
         <ol className="mt-2 flex flex-col gap-1 font-mono text-[11px] text-muted-foreground">
@@ -417,92 +536,53 @@ function SyncPanel({ entries }: { entries: readonly SyncEntry[] }) {
   );
 }
 
-// ── The board (one provider per focus session) ──────────────────────────────
+// ── The focused board (a PROJECTION — the provider lives above it) ──────────
 
 function GraphTimelineBoard({
   focusedId,
-  timelinePath,
-  focusedGraph,
+  details,
+  onDetails,
+  syncLog,
 }: Readonly<{
   focusedId: string;
-  timelinePath: readonly string[];
-  focusedGraph: FocusedGraph;
+  details: DetailsById;
+  onDetails: (merged: Readonly<Record<string, ClipDetail>>) => void;
+  syncLog: readonly SyncEntry[];
 }>) {
-  const { graph: initialGraph, details, missingDocuments } = focusedGraph;
-  const [syncLog, setSyncLog] = useState<readonly SyncEntry[]>([]);
   const focusedDoc = readDocuments()[focusedId];
 
-  // The persistence write path: map the committed patch to the documents it
-  // touched, rewrite only those. `change.graph` is post-commit, so the
-  // projection reads the truth the engine just established.
-  const handleChange = useCallback(
-    (change: CollectionsChange) => {
-      const affected = collectAffectedCollectionIds(change.graph, change.patch).filter(
-        (id) => readDocuments()[id] !== undefined,
-      );
-      for (const id of affected) {
-        writeDocumentClips(id, graphChildrenToClips(change.graph, details, id));
-      }
-      setSyncLog((log) =>
-        [
-          {
-            at: Date.now(),
-            origin: change.origin,
-            patchType: change.patch.type,
-            collections: affected,
-          },
-          ...log,
-        ].slice(0, 6),
-      );
-    },
-    [details],
-  );
-
   return (
-    <DndCollections
-      initialGraph={initialGraph}
-      components={GRAPH_TIMELINE_COMPONENTS}
-      onChange={handleChange}
-    >
-      <GraphTimelineNavProvider details={details} focusedId={focusedId} timelinePath={timelinePath}>
-        <Card>
-          <CardHeader>
-            <CardTitle>
-              <h2>{focusedDoc?.title ?? focusedId}</h2>
-            </CardTitle>
-            {focusedDoc?.description && (
-              <CardDescription>{focusedDoc.description}</CardDescription>
-            )}
-            <CardAction>
-              <UndoRedoControls />
-            </CardAction>
-          </CardHeader>
-          <CardContent className="flex flex-col gap-5">
-            {missingDocuments.length > 0 && (
-              <p className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
-                Referenced timelines without documents: {missingDocuments.join(", ")} (left as
-                placeholders).
-              </p>
-            )}
-            <VirtualStrip
-              collectionId={parseNodeId(focusedId)}
-              pixelsPerSecond={TIMELINE_PPS}
-              itemHeight={88}
-              itemDragActivation="hold"
-              className="bg-black/25"
-            />
-            <SubTimelines focusedId={focusedId} details={details} />
-            <SyncPanel entries={syncLog} />
-            <ul className="flex flex-wrap gap-x-6 gap-y-2 text-xs text-muted-foreground">
-              <li>Press-and-hold a clip to drag — including between the timelines above.</li>
-              <li>Drag a clip&apos;s amber edges to trim; drop a clip ON a dashed card to nest it.</li>
-              <li>Double-click a dashed collection clip to focus its timeline (the URL follows).</li>
-              <li>Undo/redo covers all of it — one history, because it&apos;s one graph.</li>
-            </ul>
-          </CardContent>
-        </Card>
-      </GraphTimelineNavProvider>
-    </DndCollections>
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          <h2>{focusedDoc?.title ?? focusedId}</h2>
+        </CardTitle>
+        {focusedDoc?.description && <CardDescription>{focusedDoc.description}</CardDescription>}
+        <CardAction>
+          <UndoRedoControls />
+        </CardAction>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-5">
+        <VirtualStrip
+          collectionId={parseNodeId(focusedId)}
+          pixelsPerSecond={TIMELINE_PPS}
+          itemHeight={88}
+          itemDragActivation="hold"
+          className="bg-black/25"
+        />
+        <SubTimelines focusedId={focusedId} details={details} onDetails={onDetails} />
+        <SyncPanel entries={syncLog} />
+        <ul className="flex flex-wrap gap-x-6 gap-y-2 text-xs text-muted-foreground">
+          <li>Press-and-hold a clip to drag — including between the timelines above.</li>
+          <li>Drag a clip&apos;s amber edges to trim; drop a clip ON a dashed card to nest it.</li>
+          <li>Double-click a dashed collection clip to focus its timeline (the URL follows).</li>
+          <li>
+            Undo/redo covers all of it AND survives drill-in — one provider, one graph, one
+            history for the whole session.
+          </li>
+        </ul>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -553,27 +633,73 @@ function Breadcrumbs({ timelinePath }: { timelinePath: readonly string[] }) {
 
 // ── Entry ───────────────────────────────────────────────────────────────────
 
-export function GraphTimeline({ timelinePath }: { timelinePath: string[] }) {
+export function GraphTimeline() {
+  // Mounted by the route-group LAYOUT (which persists across focus
+  // navigation — pages remount per param change), so the focus path comes
+  // from the pathname, not page props.
+  const pathname = usePathname();
+  const timelinePath = useMemo(
+    () =>
+      pathname
+        .replace(/^\/graph-timeline\/?/, "")
+        .split("/")
+        .filter(Boolean)
+        .map(decodeURIComponent),
+    [pathname],
+  );
   const focusedId = timelinePath[timelinePath.length - 1] ?? ROOT_TIMELINE_ID;
-  // Hydrate-on-focus: every focus change re-reads the session documents —
-  // which carry all previously committed writes — and builds a fresh graph
-  // for the focused timeline plus one level of child collections.
-  const built = useMemo(() => buildFocusedGraph(readDocuments(), focusedId), [focusedId]);
+  // The provider's graph mounts ONCE, rooted at the root timeline with one
+  // child level; everything deeper hydrates on focus (HydrationController)
+  // or inline (SubTimelines). Session documents carry all committed writes,
+  // so a full reload rebuilds from what was persisted.
+  const [initial] = useState(() => buildFocusedGraph(readDocuments(), ROOT_TIMELINE_ID));
+  const [details, setDetails] = useState<DetailsById>(() =>
+    initial.ok ? initial.value.details : {},
+  );
+  const [focusError, setFocusError] = useState<string | null>(null);
+  const [syncLog, setSyncLog] = useState<readonly SyncEntry[]>([]);
 
-  if (!built.ok) {
+  const onDetails = useCallback(
+    (merged: Readonly<Record<string, ClipDetail>>) =>
+      setDetails((current) => ({ ...current, ...merged })),
+    [],
+  );
+
+  // The persistence write path: map the committed patch to the documents it
+  // touched, rewrite only those. `change.graph` is post-commit, so the
+  // projection reads the truth the engine just established.
+  const handleChange = useCallback(
+    (change: CollectionsChange) => {
+      const affected = collectAffectedCollectionIds(change.graph, change.patch).filter(
+        (id) => readDocuments()[id] !== undefined,
+      );
+      for (const id of affected) {
+        writeDocumentClips(id, graphChildrenToClips(change.graph, details, id));
+      }
+      setSyncLog((log) =>
+        [
+          {
+            at: Date.now(),
+            origin: change.origin,
+            patchType: change.patch.type,
+            collections: affected,
+          },
+          ...log,
+        ].slice(0, 6),
+      );
+    },
+    [details],
+  );
+
+  if (!initial.ok) {
     return (
       <Card>
         <CardHeader>
           <CardTitle>
-            <h2>Unknown timeline</h2>
+            <h2>Could not load the root timeline</h2>
           </CardTitle>
-          <CardDescription>{built.error}</CardDescription>
+          <CardDescription>{initial.error}</CardDescription>
         </CardHeader>
-        <CardContent>
-          <Link href="/graph-timeline" className="text-sm text-primary underline underline-offset-4">
-            Back to the root timeline
-          </Link>
-        </CardContent>
       </Card>
     );
   }
@@ -581,13 +707,46 @@ export function GraphTimeline({ timelinePath }: { timelinePath: string[] }) {
   return (
     <div className="flex flex-col gap-4">
       <Breadcrumbs timelinePath={timelinePath} />
-      {/* Keyed remount per focus: a focus session is a hydration boundary. */}
-      <GraphTimelineBoard
-        key={focusedId}
-        focusedId={focusedId}
-        timelinePath={timelinePath}
-        focusedGraph={built.value}
-      />
+      <DndCollections
+        initialGraph={initial.value.graph}
+        components={GRAPH_TIMELINE_COMPONENTS}
+        onChange={handleChange}
+      >
+        <HydrationController
+          segments={timelinePath}
+          focusedId={focusedId}
+          details={details}
+          onDetails={onDetails}
+          onFocusError={setFocusError}
+        />
+        <GraphTimelineNavProvider details={details} focusedId={focusedId}>
+          {focusError !== null ? (
+            <Card>
+              <CardHeader>
+                <CardTitle>
+                  <h2>Unknown timeline</h2>
+                </CardTitle>
+                <CardDescription>{focusError}</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Link
+                  href="/graph-timeline"
+                  className="text-sm text-primary underline underline-offset-4"
+                >
+                  Back to the root timeline
+                </Link>
+              </CardContent>
+            </Card>
+          ) : (
+            <GraphTimelineBoard
+              focusedId={focusedId}
+              details={details}
+              onDetails={onDetails}
+              syncLog={syncLog}
+            />
+          )}
+        </GraphTimelineNavProvider>
+      </DndCollections>
     </div>
   );
 }

--- a/docs/storyboard-graph-architecture.md
+++ b/docs/storyboard-graph-architecture.md
@@ -144,6 +144,13 @@ adapter under the graph:
 - **Hydration is out-of-band:** it never enters the undo stack. User undo
   replays user commands only. A drop into an un-hydrated collection hydrates
   first (or is gated until expanded).
+  *Implemented:* the engine now ships this as `store.hydrate(collectionId,
+  specs)` / core `hydrateCollection` — fills an empty placeholder, pushes no
+  history entry, emits nothing on the change feed, and (because it only adds
+  nodes under a childless collection) leaves every history patch replayable,
+  so one provider and one undo stack live across all focus navigation. The
+  domain payload comes from `@storyboard/timeline-domain`'s
+  `buildHydrationSpecs`.
 - Writes flow from the store's `onChange`/`subscribeToChanges` feed: a commit
   names exactly the affected collections (patch-scoped), so persistence
   writes only the documents that changed.
@@ -219,9 +226,10 @@ replacement, never by big-bang rewrite.
 1. **Single-parent confirmation:** a collection lives under exactly one
    parent (containment). If the product ever needs the *same* collection
    instanced under multiple parents, that is a different model — flag now.
-2. **Hydration ↔ undo policy details:** gating drops into un-hydrated
-   collections vs. hydrate-on-drop; whether undo history survives focus
-   navigation across un-hydrated boundaries.
+2. **Hydration ↔ undo policy details:** ~~whether undo history survives focus
+   navigation across un-hydrated boundaries~~ — settled: it does, via
+   `store.hydrate` (see § 4). Remaining: gating drops into un-hydrated
+   collections vs. hydrate-on-drop.
 3. **Eviction:** whether far-from-focus subtrees are ever de-hydrated, or
    memory is allowed to grow monotonically per session (likely fine at
    storyboard scale; decide explicitly).

--- a/packages/timeline-domain/index.ts
+++ b/packages/timeline-domain/index.ts
@@ -4,11 +4,14 @@
 
 export {
   buildFocusedGraph,
+  buildHydrationSpecs,
   collectAffectedCollectionIds,
   graphChildrenToClips,
   type BuildFocusedGraphResult,
+  type BuildHydrationSpecsResult,
   type ClipDetail,
   type DetailsById,
   type DocumentsById,
   type FocusedGraph,
+  type HydrationSpecs,
 } from "./src/adapter";

--- a/packages/timeline-domain/src/adapter.test.ts
+++ b/packages/timeline-domain/src/adapter.test.ts
@@ -8,10 +8,16 @@ import type { TimelineClip, TimelineDocument } from "@storyboard/ui/timeline/typ
 
 import {
   buildFocusedGraph,
+  buildHydrationSpecs,
   collectAffectedCollectionIds,
   graphChildrenToClips,
 } from "./adapter";
-import { findGraphInvariantViolation, getChildren, parseNodeId } from "./engine";
+import {
+  findGraphInvariantViolation,
+  getChildren,
+  hydrateCollection,
+  parseNodeId,
+} from "./engine";
 
 // The adapter is the storage/hydration seam of the graph architecture: real
 // TimelineDocuments in, a valid focused graph + side-table out, and clips
@@ -173,6 +179,71 @@ describe("buildFocusedGraph", () => {
 
   it("rejects an unknown focus target", () => {
     expect(buildFocusedGraph(DOCUMENTS, "nope")).toMatchObject({ ok: false });
+  });
+});
+
+describe("buildHydrationSpecs", () => {
+  it("hydrates a placeholder mid-session to the same shape a fresh focused build gives", () => {
+    // Focused build leaves the grandchild as a placeholder…
+    const focused = buildFocusedGraph(DOCUMENTS, "focus-root");
+    if (!focused.ok) throw new Error(focused.error);
+    expect(getChildren(focused.value.graph, parseNodeId("grandchild"))).toEqual([]);
+
+    // …then the incremental payload fills it through the engine's hydrate.
+    const payload = buildHydrationSpecs(
+      DOCUMENTS,
+      "grandchild",
+      1,
+      focused.value.graph.nodesById.keys(),
+    );
+    expect(payload.ok).toBe(true);
+    if (!payload.ok) return;
+    const hydrated = hydrateCollection(
+      focused.value.graph,
+      parseNodeId("grandchild"),
+      payload.value.specs,
+    );
+    expect(hydrated.ok).toBe(true);
+    if (!hydrated.ok) return;
+
+    expect(findGraphInvariantViolation(hydrated.value)).toBeNull();
+    expect(getChildren(hydrated.value, parseNodeId("grandchild"))).toEqual(["g-img"]);
+    expect(payload.value.details["g-img"]).toMatchObject({ alt: "g-img alt" });
+  });
+
+  it("demotes children already present in the live graph via usedIds", () => {
+    // A doc whose collection clip references a timeline the live graph
+    // already contains elsewhere ("child" is in the focused build).
+    const docs = {
+      ...DOCUMENTS,
+      grandchild: {
+        ...GRANDCHILD_DOC,
+        clips: packTimelineClips([
+          image("g-img", 1),
+          collectionClip("g-ref-clip", "child", "Child again"),
+        ]),
+      },
+    };
+    const focused = buildFocusedGraph(docs, "focus-root");
+    if (!focused.ok) throw new Error(focused.error);
+
+    const payload = buildHydrationSpecs(docs, "grandchild", 1, focused.value.graph.nodesById.keys());
+    if (!payload.ok) throw new Error(payload.error);
+    // The duplicate reference became a card keyed by the CLIP id, so the
+    // engine accepts the specs without an id collision.
+    const hydrated = hydrateCollection(
+      focused.value.graph,
+      parseNodeId("grandchild"),
+      payload.value.specs,
+    );
+    expect(hydrated.ok).toBe(true);
+    if (!hydrated.ok) return;
+    expect(getChildren(hydrated.value, parseNodeId("grandchild"))).toEqual(["g-img", "g-ref-clip"]);
+    expect(payload.value.details["g-ref-clip"]).toMatchObject({ duplicateOfTimelineId: "child" });
+  });
+
+  it("rejects an unknown timeline", () => {
+    expect(buildHydrationSpecs(DOCUMENTS, "nope")).toMatchObject({ ok: false });
   });
 });
 

--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -188,6 +188,50 @@ function clipSpecs(
   });
 }
 
+export type HydrationSpecs = Readonly<{
+  /** Child specs for the timeline — feed them to `store.hydrate(timelineId, specs)`. */
+  specs: readonly GraphNodeSpec[];
+  /** Side-table entries for every spec'd node — merge into the app's details map. */
+  details: DetailsById;
+  missingDocuments: readonly string[];
+}>;
+
+export type BuildHydrationSpecsResult =
+  | Readonly<{ ok: true; value: HydrationSpecs }>
+  | Readonly<{ ok: false; error: string }>;
+
+/**
+ * Build the child specs for ONE timeline document — the incremental
+ * hydration payload for `store.hydrate` when a placeholder collection gets
+ * focused or expanded mid-session. `hydrateChildLevels` behaves as in
+ * `buildFocusedGraph`. Pass the LIVE graph's node ids as `usedIds` so a
+ * child referenced elsewhere in the graph demotes to a reference card
+ * instead of colliding.
+ */
+export function buildHydrationSpecs(
+  documents: DocumentsById,
+  timelineId: string,
+  hydrateChildLevels = 1,
+  usedIds?: Iterable<string>,
+): BuildHydrationSpecsResult {
+  const doc = documents[timelineId];
+  if (!doc) {
+    return { ok: false, error: `Unknown timeline document "${timelineId}".` };
+  }
+  const ctx: BuildContext = {
+    documents,
+    details: {},
+    missing: [],
+    used: new Set(usedIds),
+  };
+  ctx.used.add(timelineId);
+  const specs = clipSpecs(ctx, doc, hydrateChildLevels);
+  return {
+    ok: true,
+    value: { specs, details: ctx.details, missingDocuments: ctx.missing },
+  };
+}
+
 /**
  * Build the graph for a focused timeline (drill-in navigation target).
  * `hydrateChildLevels` controls how many collection levels below the focused
@@ -205,17 +249,13 @@ export function buildFocusedGraph(
     return { ok: false, error: `Unknown timeline document "${focusedId}".` };
   }
 
-  const ctx: BuildContext = {
-    documents,
-    details: {},
-    missing: [],
-    used: new Set([focusedId]),
-  };
+  const children = buildHydrationSpecs(documents, focusedId, hydrateChildLevels);
+  if (!children.ok) return children;
   const rootSpec: GraphNodeSpec = {
     kind: "collection",
     id: focusedId,
     name: focusedDoc.title,
-    children: clipSpecs(ctx, focusedDoc, hydrateChildLevels),
+    children: children.value.specs,
   };
 
   const built = buildGraph([rootSpec]);
@@ -224,7 +264,11 @@ export function buildFocusedGraph(
   }
   return {
     ok: true,
-    value: { graph: built.value, details: ctx.details, missingDocuments: ctx.missing },
+    value: {
+      graph: built.value,
+      details: children.value.details,
+      missingDocuments: children.value.missingDocuments,
+    },
   };
 }
 

--- a/packages/timeline-domain/src/engine.ts
+++ b/packages/timeline-domain/src/engine.ts
@@ -8,6 +8,7 @@ export {
   buildGraph,
   findGraphInvariantViolation,
   getChildren,
+  hydrateCollection,
   mediaDurationSeconds,
   parseNodeId,
   type CollectionItemNode,

--- a/packages/ui/dnd-collections/API.md
+++ b/packages/ui/dnd-collections/API.md
@@ -286,6 +286,38 @@ validate — apply patches only to the graph state they were produced against
 
 ---
 
+## Core: hydrate (`core/hydrate.ts`)
+
+### `hydrateCollection(graph, collectionId, children): Result<CollectionsGraph, HydrateRejection>`
+
+Fill an EMPTY collection (a lazy-loaded placeholder) with a denormalized
+`GraphNodeSpec` subtree — the incremental middle between `initialGraph`
+(initial-only) and `replaceGraph` (wholesale swap). Because hydration only
+ADDS nodes under a childless collection, every existing history patch stays
+replayable — this is what lets a store keep one graph and one undo stack
+alive across drill-in navigation while documents load on focus.
+
+Pure and structurally sharing: the input graph is untouched, untouched
+nodes/children arrays keep their identities, and an empty spec list returns
+the SAME graph reference. Specs are validated with the same walker as
+`buildGraph` (wrapped in the target), so intra-subtree duplicate ids,
+media-with-children, and malformed fields are all caught; ids colliding with
+the HOST graph are rejected before anything merges.
+
+```ts
+type HydrateRejection =
+  | { reason: "missing-collection"; collectionId: NodeId }
+  | { reason: "not-a-collection"; collectionId: NodeId }
+  | { reason: "collection-not-empty"; collectionId: NodeId } // fills placeholders only — merge policy is the caller's
+  | { reason: "duplicate-id"; id: string } // collides with the host graph, or repeats within the specs
+  | { reason: "invalid-spec"; error: BuildGraphError };
+```
+
+Hydration is IO landing, not user intent — see `store.hydrate` for how the
+store keeps it invisible to undo/redo and the change feed.
+
+---
+
 ## Core: intents (`core/intents.ts`)
 
 Geometry → semantics, separate from legality (the reducer's job).
@@ -573,10 +605,11 @@ type CollectionsChange = {
 | --- | --- | --- |
 | `getSnapshot` | `() => CollectionsSnapshot` | Snapshot identity changes per notify; FIELD identities change only when the field did. |
 | `subscribe` | `(listener: () => void) => () => void` | Returns unsubscribe. |
-| `subscribeToChanges` | `(listener: (change: CollectionsChange) => void) => () => void` | The committed-change feed as a multi-listener seam — same events and ordering as the `onChange` option. For consumers that need the PATCH of a commit (e.g. `VirtualStrip` resizes exactly the slots a `nodes-updated` patch touched). Fires for dispatch/undo/redo; `replaceGraph` emits nothing. |
+| `subscribeToChanges` | `(listener: (change: CollectionsChange) => void) => () => void` | The committed-change feed as a multi-listener seam — same events and ordering as the `onChange` option. For consumers that need the PATCH of a commit (e.g. `VirtualStrip` resizes exactly the slots a `nodes-updated` patch touched). Fires for dispatch/undo/redo; `replaceGraph` and `hydrate` emit nothing. |
 | `dispatch` | `(command) => Result<CollectionsPatch, CommandRejection>` | Reduce + push history + notify + `onChange`. |
 | `undo` / `redo` | `() => boolean` | False when the respective stack is empty. |
 | `replaceGraph` | `(graph: CollectionsGraph) => Result<void, GraphValidationError>` | Runtime-validates then swaps the committed graph wholesale — the escape hatch for async/server-loaded data (`initialGraph` is initial-only). Invalid input is rejected without changing or notifying the store. A successful swap clears undo/redo history (old patches can't replay on a new graph) and any in-progress drag/preview, prunes the selection to surviving ids, and — deliberately — does NOT fire `onChange` (the caller supplied this state; echoing it risks feedback loops). |
+| `hydrate` | `(collectionId: NodeId, children: readonly GraphNodeSpec[]) => Result<void, HydrateRejection>` | `replaceGraph`'s incremental sibling for hydrate-on-focus: fills an EMPTY collection via `hydrateCollection`. Undo/redo SURVIVES (only adds, under a childless collection — every history patch stays replayable), interaction state is untouched, and — like `replaceGraph` — nothing is emitted on `onChange`/`subscribeToChanges` (IO landing, not user intent). Snapshot subscribers are notified; data-sized `VirtualStrip`s detect the feed-less graph change and re-measure on their own. Rejections return without notifying. |
 | `setSelection` | `(ids: readonly NodeId[]) => void` | No-op (no notify) when the set is unchanged. |
 | `toggleSelected` | `(id: NodeId) => void` | |
 | `clearSelection` | `() => void` | No-op when already empty. |

--- a/packages/ui/dnd-collections/ARCHITECTURE.md
+++ b/packages/ui/dnd-collections/ARCHITECTURE.md
@@ -272,6 +272,31 @@ Roots are structural anchors: `rootIds` is not part of the patch model, and
 `applyCommand` rejects any attempt to move a root (`cannot-move-root`)
 rather than half-supporting it.
 
+### Hydration: IO landing, outside the mutation path
+
+Lazy-loaded data enters the graph through exactly one seam that is
+deliberately NOT a command: `store.hydrate(collectionId, specs)` (pure core:
+`hydrateCollection`) fills an EMPTY collection — a placeholder standing in
+for a document that hadn't loaded yet — with a denormalized subtree. It sits
+between `initialGraph` (initial-only) and `replaceGraph` (wholesale swap
+that must clear history):
+
+- **Undo/redo survives.** Hydration only ADDS nodes under a childless
+  collection, so every history patch still references nodes that exist, in
+  children arrays hydration never rewrites — the stack replays fine. This is
+  what lets an app keep ONE provider (one graph, one undo stack) alive
+  across drill-in navigation while documents hydrate on focus.
+- **Invisible to history and the change feed.** No history entry (undoing
+  "the data loaded" is nonsense) and no `onChange`/`subscribeToChanges`
+  event (the data came FROM storage; echoing it back invites write loops —
+  same reasoning as `replaceGraph`). Snapshot subscribers are notified so
+  views re-render; data-sized virtual views detect the feed-less graph
+  change through their `replaceGraph` path and re-measure.
+- **Placeholders only.** A non-empty target is rejected
+  (`collection-not-empty`) — merging into populated collections is app
+  policy the engine refuses to guess at. Id collisions with the host graph
+  are rejected before anything merges.
+
 ## The efficiency story
 
 The target workload is a huge graph where a drag is a per-frame event

--- a/packages/ui/dnd-collections/core/hydrate.test.ts
+++ b/packages/ui/dnd-collections/core/hydrate.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildGraph,
+  findGraphInvariantViolation,
+  getChildren,
+  parseNodeId,
+  type CollectionsGraph,
+  type GraphNodeSpec,
+} from "./graph";
+import { hydrateCollection } from "./hydrate";
+
+function hostGraph(): CollectionsGraph {
+  const result = buildGraph([
+    {
+      kind: "collection",
+      id: "root",
+      name: "Root",
+      children: [
+        { kind: "media", id: "m1", name: "Clip 1", durationSeconds: 3 },
+        { kind: "collection", id: "placeholder", name: "Lazy", children: [] },
+        {
+          kind: "collection",
+          id: "populated",
+          name: "Populated",
+          children: [{ kind: "media", id: "m2", name: "Clip 2", durationSeconds: 2 }],
+        },
+      ],
+    },
+  ]);
+  if (!result.ok) throw new Error("host graph invalid");
+  return result.value;
+}
+
+const SPECS: readonly GraphNodeSpec[] = [
+  { kind: "media", id: "h1", name: "Hydrated 1", durationSeconds: 4 },
+  {
+    kind: "collection",
+    id: "h-nested",
+    name: "Nested",
+    children: [{ kind: "media", id: "h2", name: "Hydrated 2", durationSeconds: 1 }],
+  },
+];
+
+describe("hydrateCollection", () => {
+  it("fills an empty collection and keeps every index coherent", () => {
+    const graph = hostGraph();
+    const result = hydrateCollection(graph, parseNodeId("placeholder"), SPECS);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const next = result.value;
+
+    expect(findGraphInvariantViolation(next)).toBeNull();
+    expect(getChildren(next, parseNodeId("placeholder"))).toEqual(["h1", "h-nested"]);
+    expect(getChildren(next, parseNodeId("h-nested"))).toEqual(["h2"]);
+    expect(next.parentById.get(parseNodeId("h1"))).toBe("placeholder");
+    expect(next.parentById.get(parseNodeId("h2"))).toBe("h-nested");
+    // The target keeps its own node value and real parent.
+    expect(next.nodesById.get(parseNodeId("placeholder"))).toBe(
+      graph.nodesById.get(parseNodeId("placeholder")),
+    );
+    expect(next.parentById.get(parseNodeId("placeholder"))).toBe("root");
+    expect(next.rootIds).toBe(graph.rootIds);
+  });
+
+  it("is pure and structurally shares everything it didn't touch", () => {
+    const graph = hostGraph();
+    const result = hydrateCollection(graph, parseNodeId("placeholder"), SPECS);
+    if (!result.ok) throw new Error("hydrate failed");
+    const next = result.value;
+
+    // Input untouched.
+    expect(getChildren(graph, parseNodeId("placeholder"))).toEqual([]);
+    expect(graph.nodesById.has(parseNodeId("h1"))).toBe(false);
+    // Untouched values keep their identities.
+    expect(next.nodesById.get(parseNodeId("m1"))).toBe(graph.nodesById.get(parseNodeId("m1")));
+    expect(next.childrenById.get(parseNodeId("root"))).toBe(
+      graph.childrenById.get(parseNodeId("root")),
+    );
+    expect(next.childrenById.get(parseNodeId("populated"))).toBe(
+      graph.childrenById.get(parseNodeId("populated")),
+    );
+  });
+
+  it("returns the SAME graph for an empty spec list", () => {
+    const graph = hostGraph();
+    const result = hydrateCollection(graph, parseNodeId("placeholder"), []);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toBe(graph);
+  });
+
+  it("rejects missing, non-collection, and non-empty targets", () => {
+    const graph = hostGraph();
+    expect(hydrateCollection(graph, parseNodeId("nope"), SPECS)).toMatchObject({
+      ok: false,
+      error: { reason: "missing-collection" },
+    });
+    expect(hydrateCollection(graph, parseNodeId("m1"), SPECS)).toMatchObject({
+      ok: false,
+      error: { reason: "not-a-collection" },
+    });
+    expect(hydrateCollection(graph, parseNodeId("populated"), SPECS)).toMatchObject({
+      ok: false,
+      error: { reason: "collection-not-empty" },
+    });
+  });
+
+  it("rejects spec ids that collide with the host graph", () => {
+    const graph = hostGraph();
+    const result = hydrateCollection(graph, parseNodeId("placeholder"), [
+      { kind: "media", id: "m2", name: "Collides", durationSeconds: 1 },
+    ]);
+    expect(result).toMatchObject({ ok: false, error: { reason: "duplicate-id", id: "m2" } });
+  });
+
+  it("rejects duplicate ids WITHIN the specs", () => {
+    const graph = hostGraph();
+    const result = hydrateCollection(graph, parseNodeId("placeholder"), [
+      { kind: "media", id: "dup", name: "A", durationSeconds: 1 },
+      { kind: "media", id: "dup", name: "B", durationSeconds: 1 },
+    ]);
+    expect(result).toMatchObject({ ok: false, error: { reason: "duplicate-id", id: "dup" } });
+  });
+
+  it("rejects a spec reusing the target's own id", () => {
+    const graph = hostGraph();
+    const result = hydrateCollection(graph, parseNodeId("placeholder"), [
+      { kind: "media", id: "placeholder", name: "Self", durationSeconds: 1 },
+    ]);
+    expect(result).toMatchObject({ ok: false, error: { reason: "duplicate-id", id: "placeholder" } });
+  });
+
+  it("rejects malformed specs (media with children) as invalid-spec", () => {
+    const graph = hostGraph();
+    const badSpec = {
+      kind: "media",
+      id: "bad",
+      name: "Bad",
+      durationSeconds: 1,
+      children: [],
+    } as unknown as GraphNodeSpec;
+    const result = hydrateCollection(graph, parseNodeId("placeholder"), [badSpec]);
+    expect(result).toMatchObject({ ok: false, error: { reason: "invalid-spec" } });
+  });
+});

--- a/packages/ui/dnd-collections/core/hydrate.ts
+++ b/packages/ui/dnd-collections/core/hydrate.ts
@@ -1,0 +1,99 @@
+// Incremental hydration: fill an EMPTY collection (a lazy-loaded
+// placeholder) with a denormalized subtree, without touching anything else.
+//
+// This is the missing middle between `initialGraph` (initial-only) and
+// `replaceGraph` (wholesale swap that must clear undo history): hydration
+// only ADDS nodes under a collection that had none, so every existing patch
+// in the history — built against nodes that all still exist, in children
+// arrays hydration never rewrites — remains replayable. That is what lets a
+// store keep one graph (and one undo stack) alive across drill-in
+// navigation while documents load on focus.
+//
+// Hydration is deliberately NOT a command and produces NO patch: it is IO
+// landing (state that already exists in storage), not user intent, so it
+// must be invisible to undo/redo and to the persistence change feed —
+// undoing "the data loaded" or writing it back to where it came from would
+// both be nonsense. See ARCHITECTURE.md § Hydration.
+
+import {
+  buildGraph,
+  type BuildGraphError,
+  type CollectionsGraph,
+  type GraphNodeSpec,
+  type NodeId,
+  type Result,
+} from "./graph";
+
+export type HydrateRejection =
+  | Readonly<{ reason: "missing-collection"; collectionId: NodeId }>
+  | Readonly<{ reason: "not-a-collection"; collectionId: NodeId }>
+  /** Hydration fills placeholders; merging into populated collections is a
+   *  policy decision the engine refuses to guess at. */
+  | Readonly<{ reason: "collection-not-empty"; collectionId: NodeId }>
+  /** A spec id collides with an existing node, or repeats within the specs. */
+  | Readonly<{ reason: "duplicate-id"; id: string }>
+  | Readonly<{ reason: "invalid-spec"; error: BuildGraphError }>;
+
+/**
+ * Return a new graph with `children` denormalized under the (empty)
+ * collection `collectionId`. Pure: the input graph is untouched, untouched
+ * nodes and children arrays keep their identities. Hydrating with an empty
+ * spec list is a no-op and returns the SAME graph reference.
+ */
+export function hydrateCollection(
+  graph: CollectionsGraph,
+  collectionId: NodeId,
+  children: readonly GraphNodeSpec[]
+): Result<CollectionsGraph, HydrateRejection> {
+  const target = graph.nodesById.get(collectionId);
+  if (!target) {
+    return { ok: false, error: { reason: "missing-collection", collectionId } };
+  }
+  if (target.kind !== "collection") {
+    return { ok: false, error: { reason: "not-a-collection", collectionId } };
+  }
+  if ((graph.childrenById.get(collectionId) ?? []).length > 0) {
+    return { ok: false, error: { reason: "collection-not-empty", collectionId } };
+  }
+  if (children.length === 0) return { ok: true, value: graph };
+
+  // Denormalize + validate the subtree by wrapping the specs in the target
+  // itself and reusing buildGraph — one spec walker, one validation story.
+  // Intra-subtree duplicate ids surface here.
+  const built = buildGraph([
+    { kind: "collection", id: collectionId, name: target.name, children },
+  ]);
+  if (!built.ok) {
+    return built.error.reason === "duplicate-id"
+      ? { ok: false, error: { reason: "duplicate-id", id: built.error.id } }
+      : { ok: false, error: { reason: "invalid-spec", error: built.error } };
+  }
+  const subtree = built.value;
+
+  // Ids are the graph's addressing scheme — a collision with the HOST graph
+  // would corrupt every index, so reject before merging anything.
+  for (const id of subtree.nodesById.keys()) {
+    if (id !== collectionId && graph.nodesById.has(id)) {
+      return { ok: false, error: { reason: "duplicate-id", id } };
+    }
+  }
+
+  const nodesById = new Map(graph.nodesById);
+  const childrenById = new Map(graph.childrenById);
+  const parentById = new Map(graph.parentById);
+  for (const [id, node] of subtree.nodesById) {
+    // The target keeps the HOST's node, children entry (overwritten below),
+    // and real parent — the subtree wrapper only existed to reuse buildGraph.
+    if (id === collectionId) continue;
+    nodesById.set(id, node);
+    parentById.set(id, subtree.parentById.get(id) ?? null);
+  }
+  for (const [id, childIds] of subtree.childrenById) {
+    childrenById.set(id, childIds);
+  }
+
+  return {
+    ok: true,
+    value: { nodesById, childrenById, parentById, rootIds: graph.rootIds },
+  };
+}

--- a/packages/ui/dnd-collections/core/index.ts
+++ b/packages/ui/dnd-collections/core/index.ts
@@ -48,6 +48,7 @@ export {
   type MoveNodesCommand,
   type UpdateMediaCommand,
 } from "./commands";
+export { hydrateCollection, type HydrateRejection } from "./hydrate";
 export {
   applyPatch,
   invertPatch,

--- a/packages/ui/dnd-collections/index.ts
+++ b/packages/ui/dnd-collections/index.ts
@@ -46,6 +46,7 @@ export {
   type MoveNodesCommand,
   type UpdateMediaCommand,
 } from "./core/commands";
+export { hydrateCollection, type HydrateRejection } from "./core/hydrate";
 export {
   applyPatch,
   invertPatch,

--- a/packages/ui/dnd-collections/react/collections-store.test.ts
+++ b/packages/ui/dnd-collections/react/collections-store.test.ts
@@ -462,4 +462,85 @@ describe("createCollectionsStore", () => {
     store.destroy();
     expect(store.getSnapshot().interaction.rejectedIdSet.size).toBe(0);
   });
+
+  // Hydration is IO landing, not user intent: it must reach snapshot
+  // subscribers (views re-render) while staying invisible to undo/redo and
+  // the persistence change feed — and, unlike replaceGraph, it must leave
+  // the history replayable.
+  describe("hydrate", () => {
+    const hydrationSpecs: readonly GraphNodeSpec[] = [
+      media("h1"),
+      { kind: "collection", id: "h-nested", name: "Nested", children: [media("h2")] },
+    ];
+
+    test("fills the placeholder and notifies snapshot subscribers only", () => {
+      const changes: CollectionsChange[] = [];
+      const store = createCollectionsStore(graphFixture(), { onChange: (c) => changes.push(c) });
+      const feed = vi.fn();
+      store.subscribeToChanges(feed);
+      const listener = vi.fn();
+      store.subscribe(listener);
+
+      const result = store.hydrate(id("root-b"), hydrationSpecs);
+      expect(result.ok).toBe(true);
+      const { graph, canUndo, historyEntries } = store.getSnapshot();
+      expect([...(graph.childrenById.get(id("root-b")) ?? [])]).toEqual(["h1", "h-nested"]);
+      expect(listener).toHaveBeenCalledTimes(1);
+      // No history entry, no change-feed event, no onChange.
+      expect(canUndo).toBe(false);
+      expect(historyEntries).toHaveLength(0);
+      expect(feed).not.toHaveBeenCalled();
+      expect(changes).toHaveLength(0);
+    });
+
+    test("undo history SURVIVES hydration and still replays", () => {
+      const store = createCollectionsStore(graphFixture());
+      // Commit BEFORE hydration: move x into root-b, then undo it so the
+      // placeholder is empty again when hydration lands.
+      expect(store.dispatch(moveX).ok).toBe(true);
+      expect(store.undo()).toBe(true);
+
+      expect(store.hydrate(id("root-b"), hydrationSpecs).ok).toBe(true);
+      // Redo replays the pre-hydration patch onto the hydrated graph.
+      expect(store.redo()).toBe(true);
+      const children = [...(store.getSnapshot().graph.childrenById.get(id("root-b")) ?? [])];
+      expect(children).toEqual(["x", "h1", "h-nested"]);
+      // …and undoing it again leaves the hydrated nodes untouched.
+      expect(store.undo()).toBe(true);
+      expect([...(store.getSnapshot().graph.childrenById.get(id("root-b")) ?? [])]).toEqual([
+        "h1",
+        "h-nested",
+      ]);
+    });
+
+    test("rejections return without notifying anyone", () => {
+      const store = createCollectionsStore(graphFixture());
+      const listener = vi.fn();
+      store.subscribe(listener);
+      const before = store.getSnapshot();
+
+      expect(store.hydrate(id("root-a"), hydrationSpecs)).toMatchObject({
+        ok: false,
+        error: { reason: "collection-not-empty" },
+      });
+      expect(store.hydrate(id("root-b"), [media("x")])).toMatchObject({
+        ok: false,
+        error: { reason: "duplicate-id", id: "x" },
+      });
+      expect(listener).not.toHaveBeenCalled();
+      expect(store.getSnapshot()).toBe(before);
+    });
+
+    test("an empty spec list is a silent no-op", () => {
+      const store = createCollectionsStore(graphFixture());
+      const listener = vi.fn();
+      store.subscribe(listener);
+      const before = store.getSnapshot();
+
+      expect(store.hydrate(id("root-b"), []).ok).toBe(true);
+      expect(listener).not.toHaveBeenCalled();
+      expect(store.getSnapshot()).toBe(before);
+      expect(store.getSnapshot().graph).toBe(before.graph);
+    });
+  });
 });

--- a/packages/ui/dnd-collections/react/collections-store.ts
+++ b/packages/ui/dnd-collections/react/collections-store.ts
@@ -3,11 +3,13 @@
 import { createContext, useContext, useSyncExternalStore } from "react";
 import {
   type CollectionsGraph,
+  type GraphNodeSpec,
   type GraphValidationError,
   type NodeId,
   type Result,
   validateGraph,
 } from "../core/graph";
+import { hydrateCollection, type HydrateRejection } from "../core/hydrate";
 import {
   applyCommand,
   type CollectionsCommand,
@@ -100,6 +102,22 @@ export type CollectionsStore = Readonly<{
    * loops — this is a reset, not a recorded mutation.
    */
   replaceGraph: (graph: CollectionsGraph) => Result<void, GraphValidationError>;
+  /**
+   * Fill an EMPTY collection (a lazy-loaded placeholder) with a denormalized
+   * subtree — `replaceGraph`'s incremental sibling for hydrate-on-focus.
+   * Because hydration only ADDS nodes under a childless collection, every
+   * history patch stays replayable, so — unlike `replaceGraph` — undo/redo
+   * SURVIVES. Hydration is IO landing, not user intent: it pushes no history
+   * entry and emits nothing on `onChange`/`subscribeToChanges` (undoing "the
+   * data loaded", or writing it back to the storage it came from, would both
+   * be nonsense). Snapshot subscribers are notified so views re-render.
+   * Consumers keeping geometry caches keyed to `subscribeToChanges` should
+   * also rebuild after a hydrate they issued.
+   */
+  hydrate: (
+    collectionId: NodeId,
+    children: readonly GraphNodeSpec[]
+  ) => Result<void, HydrateRejection>;
 
   /** Replace selection with the supplied ids that exist in the current graph. */
   setSelection: (ids: readonly NodeId[]) => void;
@@ -302,6 +320,23 @@ export function createCollectionsStore(
     return { ok: true, value: undefined };
   }
 
+  function hydrate(
+    collectionId: NodeId,
+    children: readonly GraphNodeSpec[]
+  ): Result<void, HydrateRejection> {
+    const result = hydrateCollection(graph, collectionId, children);
+    if (!result.ok) return result;
+    // Empty spec list: hydrateCollection returned the same graph — nothing
+    // to notify anyone about.
+    if (result.value === graph) return { ok: true, value: undefined };
+    graph = result.value;
+    // Nothing was removed and nothing moved: history, selection, and any
+    // live drag/preview all remain valid — notify with no change payload
+    // (no history entry, no change-feed event; see the type's doc comment).
+    notify();
+    return { ok: true, value: undefined };
+  }
+
   return {
     getSnapshot: () => snapshot,
     subscribe: (listener) => {
@@ -321,6 +356,7 @@ export function createCollectionsStore(
     undo,
     redo,
     replaceGraph,
+    hydrate,
 
     setSelection: (ids) => {
       const next = new Set<NodeId>();


### PR DESCRIPTION
…ndo alive

Closes the graph architecture's biggest open question (hydration <-> undo, docs/storyboard-graph-architecture.md section 9.2): drilling into a lazily loaded timeline no longer costs the undo stack.

Engine:
- core/hydrate.ts: hydrateCollection(graph, collectionId, specs) fills an EMPTY placeholder collection with a denormalized subtree — pure, structurally sharing, validated by the same walker as buildGraph (wrapped in the target). Rejects non-empty targets (merge policy is the caller's) and id collisions with the host graph. Because it only ADDS nodes under a childless collection, every history patch stays replayable.
- store.hydrate: replaceGraph's incremental sibling. No history entry, no onChange/subscribeToChanges event (IO landing, not user intent — echoing it back to storage would loop); snapshot subscribers notified. Data-sized VirtualStrips already re-measure via their feed-less-graph-change path.
- 8 core tests + 4 store tests (history replay across hydration included); API.md + ARCHITECTURE.md sections.

Domain:
- timeline-domain buildHydrationSpecs(documents, timelineId, levels, usedIds): the incremental payload for store.hydrate, sharing the buildFocusedGraph machinery; usedIds demotes cross-graph duplicate references to reference cards. 3 new tests incl. an engine round-trip.

Proof page:
- ONE provider for the whole SESSION: moved the interactive tree into the route-group layout (App Router remounts pages per dynamic-param change; layouts persist) with focus derived from usePathname(). A HydrationController hydrates the route's segment chain on navigation and the focused timeline's child collections; placeholder sub-timelines get a "Load inline" button (hydrate without navigating).

Verified in-browser: undo enabled after drill-in and correctly rewriting the root document from a child focus; un-nesting a placeholder writing both touched documents; inline hydration adding 12 cards with undo untouched and no sync-feed echo; undo returning the hydrated collection with children; cold deep link 2 levels down hydrating the full chain. 467 unit tests pass; ui, timeline-domain, and media-strip-rsc typechecks clean.