### PR TITLE
fix(graph-view): gate drops into un-hydrated collections; hydrate all…

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -12,6 +12,12 @@
       "runtimeExecutable": "npm",
       "runtimeArgs": ["--prefix", "apps/timeline-gstudio001", "run", "dev"],
       "port": 3000
+    },
+    {
+      "name": "media-strip-rsc-3001",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["--prefix", "apps/media-strip-rsc", "run", "dev", "--", "-p", "3001"],
+      "port": 3001
     }
   ]
 }

--- a/apps/media-strip-rsc/components/graph-timeline/graph-timeline.tsx
+++ b/apps/media-strip-rsc/components/graph-timeline/graph-timeline.tsx
@@ -9,6 +9,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 
@@ -29,6 +30,7 @@ import {
   getChildren,
   mediaDurationSeconds,
   parseNodeId,
+  useCollectionsContainer,
   useCollectionsSelector,
   useCollectionsStore,
   useLiveTrim,
@@ -46,6 +48,7 @@ import {
   buildFocusedGraph,
   buildHydrationSpecs,
   collectAffectedCollectionIds,
+  collectUnhydratedDropTargets,
   graphChildrenToClips,
   type ClipDetail,
   type DetailsById,
@@ -169,13 +172,23 @@ function HydrationController({
     }
     if (error === null) {
       // The focused timeline's placeholder child collections load their own
-      // clips (one level) so their inline strips have content.
-      const graph = store.getSnapshot().graph;
-      for (const childId of getChildren(graph, parseNodeId(focusedId))) {
-        const node = graph.nodesById.get(childId);
-        if (node?.kind === "collection" && detailOf(childId as string)?.hydrated === false) {
-          ensure(childId as string, 0);
-        }
+      // clips (one level) so their inline strips have content — and then one
+      // more shallow level: grandchild collections are VISIBLE as cards
+      // inside those strips, and every visible collection is a drop target,
+      // so hydrating them keeps the gate-until-hydrated bounce
+      // (PersistenceBridge) a rare race fallback instead of the common path.
+      const collectionChildrenOf = (id: string) => {
+        const graph = store.getSnapshot().graph;
+        return getChildren(graph, parseNodeId(id))
+          .filter((childId) => graph.nodesById.get(childId)?.kind === "collection")
+          .map((childId) => childId as string);
+      };
+      const children = collectionChildrenOf(focusedId);
+      for (const childId of children) {
+        if (detailOf(childId)?.hydrated === false) ensure(childId, 0);
+      }
+      for (const grandchildId of children.flatMap(collectionChildrenOf)) {
+        if (detailOf(grandchildId)?.hydrated === false) ensure(grandchildId, 0);
       }
     }
 
@@ -498,14 +511,87 @@ function SubTimelines({
   );
 }
 
-// ── Persistence sync panel ──────────────────────────────────────────────────
+// ── Persistence bridge ──────────────────────────────────────────────────────
 
 type SyncEntry = Readonly<{
   at: number;
   origin: CollectionsChange["origin"];
   patchType: CollectionsChange["patch"]["type"];
   collections: readonly string[];
+  /** True when the change was REVERTED (drop into an un-hydrated collection). */
+  bounced?: boolean;
 }>;
+
+/**
+ * The write path AND the gate-until-hydrated policy, in one subscriber: a
+ * command (or redo) placing content INTO an un-hydrated placeholder is
+ * BOUNCED — undone on the spot with a rejection flash — because letting it
+ * stand would block the collection's hydration (the engine refuses to fill
+ * a non-empty collection) and let a write clobber the stored document.
+ * Everything else writes patch-scoped, never touching a document whose
+ * clips haven't loaded. Lives INSIDE the provider (unlike an `onChange`
+ * prop) because bouncing needs the store; `subscribeToChanges` supports
+ * reentrant dispatch, so undoing from within the feed is safe and ordered.
+ */
+function PersistenceBridge({
+  details,
+  onSync,
+}: Readonly<{ details: DetailsById; onSync: (entry: SyncEntry) => void }>) {
+  const store = useCollectionsStore();
+  const { announce } = useCollectionsContainer();
+  const detailsRef = useRef(details);
+  useEffect(() => {
+    detailsRef.current = details;
+  });
+
+  useEffect(
+    () =>
+      store.subscribeToChanges((change) => {
+        const current = detailsRef.current;
+
+        if (change.origin !== "undo") {
+          const blocked = collectUnhydratedDropTargets(change.patch, current);
+          if (blocked.length > 0) {
+            store.undo();
+            const placedIds =
+              change.patch.type === "nodes-moved"
+                ? change.patch.moves.map((move) => move.nodeId)
+                : change.patch.type === "nodes-added"
+                  ? change.patch.adds.map((add) => add.node.id)
+                  : [];
+            if (placedIds.length > 0) store.flashRejection(placedIds);
+            announce("That collection is still loading — drop again once its clips appear.");
+            onSync({
+              at: Date.now(),
+              origin: change.origin,
+              patchType: change.patch.type,
+              collections: blocked,
+              bounced: true,
+            });
+            return;
+          }
+        }
+
+        const affected = collectAffectedCollectionIds(change.graph, change.patch).filter(
+          (id) => readDocuments()[id] !== undefined && current[id]?.hydrated !== false,
+        );
+        for (const id of affected) {
+          writeDocumentClips(id, graphChildrenToClips(change.graph, current, id));
+        }
+        onSync({
+          at: Date.now(),
+          origin: change.origin,
+          patchType: change.patch.type,
+          collections: affected,
+        });
+      }),
+    [store, announce, onSync],
+  );
+
+  return null;
+}
+
+// ── Persistence sync panel ──────────────────────────────────────────────────
 
 function SyncPanel({ entries }: { entries: readonly SyncEntry[] }) {
   return (
@@ -525,9 +611,17 @@ function SyncPanel({ entries }: { entries: readonly SyncEntry[] }) {
               <span className="text-foreground">{entry.origin}</span>
               <span>{entry.patchType}</span>
               <span aria-hidden="true">→</span>
-              <span className="text-primary">
-                {entry.collections.length === 0 ? "(no stored documents)" : entry.collections.join(", ")}
-              </span>
+              {entry.bounced ? (
+                <span className="text-amber-400">
+                  reverted — {entry.collections.join(", ")} still loading
+                </span>
+              ) : (
+                <span className="text-primary">
+                  {entry.collections.length === 0
+                    ? "(no stored documents)"
+                    : entry.collections.join(", ")}
+                </span>
+              )}
             </li>
           ))}
         </ol>
@@ -665,31 +759,11 @@ export function GraphTimeline() {
     [],
   );
 
-  // The persistence write path: map the committed patch to the documents it
-  // touched, rewrite only those. `change.graph` is post-commit, so the
-  // projection reads the truth the engine just established.
-  const handleChange = useCallback(
-    (change: CollectionsChange) => {
-      const affected = collectAffectedCollectionIds(change.graph, change.patch).filter(
-        (id) => readDocuments()[id] !== undefined,
-      );
-      for (const id of affected) {
-        writeDocumentClips(id, graphChildrenToClips(change.graph, details, id));
-      }
-      setSyncLog((log) =>
-        [
-          {
-            at: Date.now(),
-            origin: change.origin,
-            patchType: change.patch.type,
-            collections: affected,
-          },
-          ...log,
-        ].slice(0, 6),
-      );
-    },
-    [details],
-  );
+  // Persistence (write path + gate-until-hydrated bounce) lives in
+  // <PersistenceBridge> inside the provider — bouncing needs the store.
+  const onSync = useCallback((entry: SyncEntry) => {
+    setSyncLog((log) => [entry, ...log].slice(0, 6));
+  }, []);
 
   if (!initial.ok) {
     return (
@@ -707,11 +781,8 @@ export function GraphTimeline() {
   return (
     <div className="flex flex-col gap-4">
       <Breadcrumbs timelinePath={timelinePath} />
-      <DndCollections
-        initialGraph={initial.value.graph}
-        components={GRAPH_TIMELINE_COMPONENTS}
-        onChange={handleChange}
-      >
+      <DndCollections initialGraph={initial.value.graph} components={GRAPH_TIMELINE_COMPONENTS}>
+        <PersistenceBridge details={details} onSync={onSync} />
         <HydrationController
           segments={timelinePath}
           focusedId={focusedId}

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -9,6 +9,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
   useSyncExternalStore,
 } from "react";
@@ -22,6 +23,7 @@ import {
   getChildren,
   mediaDurationSeconds,
   parseNodeId,
+  useCollectionsContainer,
   useCollectionsSelector,
   useCollectionsStore,
   useLiveTrim,
@@ -40,6 +42,7 @@ import {
   buildFocusedGraph,
   buildHydrationSpecs,
   collectAffectedCollectionIds,
+  collectUnhydratedDropTargets,
   graphChildrenToClips,
   type ClipDetail,
   type DetailsById,
@@ -256,11 +259,23 @@ function HydrationController({
         // The focused timeline's placeholder child collections load their
         // own clips so their inline strips have content. Fetches run in
         // parallel; hydration applies as each lands.
-        const graph = store.getSnapshot().graph;
-        const collectionChildren = getChildren(graph, parseNodeId(focusedId)).filter(
-          (childId) => graph.nodesById.get(childId)?.kind === "collection",
-        );
-        await Promise.all(collectionChildren.map((childId) => ensure(childId as string)));
+        const collectionChildrenOf = (id: string) => {
+          const graph = store.getSnapshot().graph;
+          return getChildren(graph, parseNodeId(id))
+            .filter((childId) => graph.nodesById.get(childId)?.kind === "collection")
+            .map((childId) => childId as string);
+        };
+        const children = collectionChildrenOf(focusedId);
+        await Promise.all(children.map(ensure));
+        if (!cancelled) {
+          // One more shallow level: grandchild collections are VISIBLE as
+          // cards inside the sub-timeline strips, and every visible
+          // collection is a drop target — hydrating them keeps the
+          // gate-until-hydrated bounce (PersistenceBridge) a rare race
+          // fallback instead of the common path.
+          const grandchildren = children.flatMap(collectionChildrenOf);
+          await Promise.all(grandchildren.map(ensure));
+        }
       }
       if (cancelled) return;
       onFocusError(error);
@@ -522,14 +537,93 @@ function SubTimelines({
   );
 }
 
-// ── Persistence sync panel ──────────────────────────────────────────────────
+// ── Persistence bridge ──────────────────────────────────────────────────────
 
 type SyncEntry = Readonly<{
   at: number;
   origin: CollectionsChange["origin"];
   patchType: CollectionsChange["patch"]["type"];
   collections: readonly string[];
+  /** True when the change was REVERTED (drop into an un-hydrated collection). */
+  bounced?: boolean;
 }>;
+
+/**
+ * The write path AND the gate-until-hydrated policy, in one subscriber:
+ *
+ * - A command (or redo) that places content INTO an un-hydrated placeholder
+ *   is BOUNCED — undone on the spot with a rejection flash and an
+ *   announcement. Letting it stand would block the collection's hydration
+ *   (the engine refuses to fill a non-empty collection) and eventually let
+ *   a write clobber the stored document. Eager visible hydration
+ *   (HydrationController) makes this a rare fetch-latency race, not the
+ *   common path.
+ * - Everything else is written patch-scoped: only the touched documents,
+ *   and never one whose clips haven't loaded (`hydrated: false`).
+ *
+ * Lives INSIDE the provider (unlike an `onChange` prop) because bouncing
+ * needs the store; `subscribeToChanges` supports reentrant dispatch, so
+ * undoing from within the feed is safe and ordered.
+ */
+function PersistenceBridge({
+  details,
+  onSync,
+}: Readonly<{ details: DetailsById; onSync: (entry: SyncEntry) => void }>) {
+  const store = useCollectionsStore();
+  const { announce } = useCollectionsContainer();
+  const detailsRef = useRef(details);
+  useEffect(() => {
+    detailsRef.current = details;
+  });
+
+  useEffect(
+    () =>
+      store.subscribeToChanges((change) => {
+        const current = detailsRef.current;
+
+        if (change.origin !== "undo") {
+          const blocked = collectUnhydratedDropTargets(change.patch, current);
+          if (blocked.length > 0) {
+            store.undo();
+            const placedIds =
+              change.patch.type === "nodes-moved"
+                ? change.patch.moves.map((move) => move.nodeId)
+                : change.patch.type === "nodes-added"
+                  ? change.patch.adds.map((add) => add.node.id)
+                  : [];
+            if (placedIds.length > 0) store.flashRejection(placedIds);
+            announce("That collection is still loading — drop again once its clips appear.");
+            onSync({
+              at: Date.now(),
+              origin: change.origin,
+              patchType: change.patch.type,
+              collections: blocked,
+              bounced: true,
+            });
+            return;
+          }
+        }
+
+        const affected = collectAffectedCollectionIds(change.graph, change.patch).filter(
+          (id) => graphDocumentsGateway.peek(id) !== null && current[id]?.hydrated !== false,
+        );
+        for (const id of affected) {
+          graphDocumentsGateway.writeClips(id, graphChildrenToClips(change.graph, current, id));
+        }
+        onSync({
+          at: Date.now(),
+          origin: change.origin,
+          patchType: change.patch.type,
+          collections: affected,
+        });
+      }),
+    [store, announce, onSync],
+  );
+
+  return null;
+}
+
+// ── Persistence sync panel ──────────────────────────────────────────────────
 
 function SyncPanel({ entries }: { entries: readonly SyncEntry[] }) {
   return (
@@ -549,9 +643,17 @@ function SyncPanel({ entries }: { entries: readonly SyncEntry[] }) {
               <span className="text-zinc-100">{entry.origin}</span>
               <span>{entry.patchType}</span>
               <span aria-hidden="true">→</span>
-              <span className="text-sky-400">
-                {entry.collections.length === 0 ? "(nothing stored)" : entry.collections.join(", ")}
-              </span>
+              {entry.bounced ? (
+                <span className="text-amber-400">
+                  reverted — {entry.collections.join(", ")} still loading
+                </span>
+              ) : (
+                <span className="text-sky-400">
+                  {entry.collections.length === 0
+                    ? "(nothing stored)"
+                    : entry.collections.join(", ")}
+                </span>
+              )}
             </li>
           ))}
         </ol>
@@ -709,30 +811,11 @@ export function GraphTimelineView({ projectId }: { projectId: string }) {
     [],
   );
 
-  // The persistence write path: map the committed patch to the documents it
-  // touched, rewrite ONLY those through the gateway (debounced PATCH each).
-  const handleChange = useCallback(
-    (change: CollectionsChange) => {
-      const affected = collectAffectedCollectionIds(change.graph, change.patch).filter(
-        (id) => graphDocumentsGateway.peek(id) !== null,
-      );
-      for (const id of affected) {
-        graphDocumentsGateway.writeClips(id, graphChildrenToClips(change.graph, details, id));
-      }
-      setSyncLog((log) =>
-        [
-          {
-            at: Date.now(),
-            origin: change.origin,
-            patchType: change.patch.type,
-            collections: affected,
-          },
-          ...log,
-        ].slice(0, 6),
-      );
-    },
-    [details],
-  );
+  // Persistence (write path + gate-until-hydrated bounce) lives in
+  // <PersistenceBridge> inside the provider — bouncing needs the store.
+  const onSync = useCallback((entry: SyncEntry) => {
+    setSyncLog((log) => [entry, ...log].slice(0, 6));
+  }, []);
 
   if (boot.status === "loading") {
     return (
@@ -763,11 +846,8 @@ export function GraphTimelineView({ projectId }: { projectId: string }) {
           {gatewayError}
         </p>
       )}
-      <DndCollections
-        initialGraph={boot.graph}
-        components={GRAPH_VIEW_COMPONENTS}
-        onChange={handleChange}
-      >
+      <DndCollections initialGraph={boot.graph} components={GRAPH_VIEW_COMPONENTS}>
+        <PersistenceBridge details={details} onSync={onSync} />
         <HydrationController
           projectId={projectId}
           segments={timelinePath}

--- a/docs/storyboard-graph-architecture.md
+++ b/docs/storyboard-graph-architecture.md
@@ -226,10 +226,16 @@ replacement, never by big-bang rewrite.
 1. **Single-parent confirmation:** a collection lives under exactly one
    parent (containment). If the product ever needs the *same* collection
    instanced under multiple parents, that is a different model — flag now.
-2. **Hydration ↔ undo policy details:** ~~whether undo history survives focus
-   navigation across un-hydrated boundaries~~ — settled: it does, via
-   `store.hydrate` (see § 4). Remaining: gating drops into un-hydrated
-   collections vs. hydrate-on-drop.
+2. **Hydration ↔ undo policy details:** settled in full. Undo history
+   survives focus navigation via `store.hydrate` (see § 4). Drops into
+   un-hydrated collections are handled by two cooperating layers: every
+   VISIBLE placeholder collection hydrates eagerly (the focused timeline's
+   children plus the grandchild cards inside their strips — the working set
+   stays view-bounded), and the persistence bridge BOUNCES the residual
+   race (`collectUnhydratedDropTargets` → `store.undo()` + rejection flash
+   + announcement) so content can never land in, or overwrite, a document
+   whose clips haven't loaded. Writes additionally refuse any collection
+   with `hydrated: false`.
 3. **Eviction:** whether far-from-focus subtrees are ever de-hydrated, or
    memory is allowed to grow monotonically per session (likely fine at
    storyboard scale; decide explicitly).

--- a/packages/timeline-domain/index.ts
+++ b/packages/timeline-domain/index.ts
@@ -6,6 +6,7 @@ export {
   buildFocusedGraph,
   buildHydrationSpecs,
   collectAffectedCollectionIds,
+  collectUnhydratedDropTargets,
   graphChildrenToClips,
   type BuildFocusedGraphResult,
   type BuildHydrationSpecsResult,

--- a/packages/timeline-domain/src/adapter.test.ts
+++ b/packages/timeline-domain/src/adapter.test.ts
@@ -10,6 +10,7 @@ import {
   buildFocusedGraph,
   buildHydrationSpecs,
   collectAffectedCollectionIds,
+  collectUnhydratedDropTargets,
   graphChildrenToClips,
 } from "./adapter";
 import {
@@ -294,6 +295,97 @@ describe("against the app's real initial documents", () => {
     if (!result.ok) throw new Error(result.error);
     const projected = graphChildrenToClips(result.value.graph, result.value.details, "scene-a");
     expect(projected.map((c) => c.id)).toEqual(documents["scene-a"].clips.map((c) => c.id));
+  });
+});
+
+describe("collectUnhydratedDropTargets", () => {
+  it("flags moves and adds whose destination is an un-hydrated placeholder", () => {
+    const result = buildFocusedGraph(DOCUMENTS, "focus-root");
+    if (!result.ok) throw new Error(result.error);
+    const { details } = result.value; // "grandchild" is a placeholder (hydrated: false)
+
+    expect(
+      collectUnhydratedDropTargets(
+        {
+          type: "nodes-moved",
+          moves: [
+            {
+              nodeId: parseNodeId("img-1"),
+              fromParentId: parseNodeId("focus-root"),
+              fromIndex: 0,
+              toParentId: parseNodeId("grandchild"),
+              toIndex: 0,
+            },
+          ],
+        },
+        details,
+      ),
+    ).toEqual(["grandchild"]);
+
+    expect(
+      collectUnhydratedDropTargets(
+        {
+          type: "nodes-added",
+          adds: [
+            {
+              parentId: parseNodeId("grandchild"),
+              index: 0,
+              node: { id: parseNodeId("new-1"), kind: "media", name: "New", durationSeconds: 2 },
+            },
+          ],
+        },
+        details,
+      ),
+    ).toEqual(["grandchild"]);
+  });
+
+  it("passes hydrated destinations, roots without details, and non-placing patches", () => {
+    const result = buildFocusedGraph(DOCUMENTS, "focus-root");
+    if (!result.ok) throw new Error(result.error);
+    const { graph, details } = result.value;
+
+    // "child" is hydrated: true; "focus-root" has no detail entry at all —
+    // both are legitimate destinations.
+    expect(
+      collectUnhydratedDropTargets(
+        {
+          type: "nodes-moved",
+          moves: [
+            {
+              nodeId: parseNodeId("img-1"),
+              fromParentId: parseNodeId("focus-root"),
+              fromIndex: 0,
+              toParentId: parseNodeId("child"),
+              toIndex: 0,
+            },
+            {
+              nodeId: parseNodeId("c-img"),
+              fromParentId: parseNodeId("child"),
+              fromIndex: 0,
+              toParentId: parseNodeId("focus-root"),
+              toIndex: 0,
+            },
+          ],
+        },
+        details,
+      ),
+    ).toEqual([]);
+
+    expect(
+      collectUnhydratedDropTargets(
+        {
+          type: "nodes-updated",
+          updates: [
+            {
+              nodeId: parseNodeId("vid-1"),
+              before: graph.nodesById.get(parseNodeId("vid-1"))!,
+              after: graph.nodesById.get(parseNodeId("vid-1"))!,
+            },
+          ],
+        },
+        details,
+      ),
+    ).toEqual([]);
   });
 });
 

--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -361,6 +361,39 @@ export function graphChildrenToClips(
 }
 
 /**
+ * The destination collections of a committed patch that are still
+ * UN-hydrated placeholders — their stored clips haven't loaded, so letting
+ * content land in them both blocks their future hydration (the engine
+ * refuses to fill a non-empty collection) and, worse, would let the
+ * patch-scoped write overwrite the stored document with only the new
+ * content. Apps use this to enforce the gate-until-hydrated policy: revert
+ * (undo) a command whose destination appears here.
+ */
+export function collectUnhydratedDropTargets(
+  patch: CollectionsPatch,
+  details: DetailsById,
+): readonly string[] {
+  const unhydrated = (id: NodeId) => details[id as string]?.hydrated === false;
+  const ids = new Set<string>();
+  switch (patch.type) {
+    case "nodes-moved":
+      for (const move of patch.moves) {
+        if (unhydrated(move.toParentId)) ids.add(move.toParentId as string);
+      }
+      break;
+    case "nodes-added":
+      for (const add of patch.adds) {
+        if (unhydrated(add.parentId)) ids.add(add.parentId as string);
+      }
+      break;
+    // nodes-removed / nodes-updated place nothing anywhere.
+    default:
+      break;
+  }
+  return [...ids];
+}
+
+/**
  * The collections whose stored documents a committed change touches — the
  * patch-scoped persistence write set.
  */


### PR DESCRIPTION
… visible placeholders

Closes the architecture doc's last hydration open question (section 9.2) and a real data hazard in both graph views: a clip dropped INTO an un-hydrated placeholder collection would block that collection's hydration (the engine refuses to fill a non-empty collection), strand the dropped clip, and let the patch-scoped write overwrite the stored document with only the new content. Two cooperating layers:

- Eager visible hydration: the HydrationController now hydrates one more shallow level — grandchild collections, which are VISIBLE as cards inside the sub-timeline strips and therefore drop targets. Every visible collection is hydrated (sync app: before paint; async app: fetches in parallel on navigation), so the working set stays view-bounded and the gate below is a rare fetch-latency race, not the common path.
- Gate-until-hydrated bounce: persistence moved from the onChange prop into a PersistenceBridge INSIDE the provider (bouncing needs the store). A command or redo whose patch places nodes into an un-hydrated collection (new timeline-domain helper collectUnhydratedDropTargets, unit-tested) is undone on the spot with a rejection flash, an aria announcement, and an amber "reverted" sync-panel entry. subscribeToChanges supports reentrant dispatch, so undoing from within the feed is safe and ordered. Writes additionally refuse any collection with hydrated: false.

Applied to both consumers (timeline-gstudio001 graph view and the media-strip-rsc proof page); architecture doc question 9.2 marked settled.

Verified in-browser (proof page): focusing collection-board eagerly hydrates all three act-* sub-timelines (12/15/14 cards, none left un-hydrated), keyboard moves write patch-scoped through the new bridge, no console errors. 469 unit tests pass; both app typechecks clean.