### PR TITLE
feat(gstudio001): backfill real video durations onto stored clips at …

### DIFF
--- a/apps/timeline-gstudio001/app/api/timelines/[id]/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/[id]/route.ts
@@ -15,6 +15,7 @@ import {
   isUnsavedProjectPlaceholder,
 } from "@storyboard/ui/timeline/timeline-documents";
 import { listCloudinaryAssets } from "@/lib/cloudinary-media-store";
+import { healTimelineDocument } from "@/lib/heal-timeline-document";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -227,44 +228,17 @@ export async function GET(
 
     const firebaseDocument = await getFirebaseTimelineDocument(id);
     if (firebaseDocument) {
-      // Self-healing: Check if any clip has a Cloudinary URL that might have moved/renamed
-      let hasChanges = false;
+      // Load-time self-heal: re-point moved/renamed Cloudinary assets AND
+      // backfill real video durations onto untrimmed clips (see
+      // healTimelineDocument). Persisted only when something actually changed.
       const cloudinaryAssets = await listCloudinaryAssets(user.uid).catch(() => []);
-      let healedDocument = firebaseDocument;
-      if (cloudinaryAssets.length > 0) {
-        const assetMap = new Map<string, typeof cloudinaryAssets[0]>();
-        cloudinaryAssets.forEach((asset) => {
-          const filename = asset.relativePath?.split("/").pop() || asset.pathname?.split("/").pop();
-          if (filename) {
-            assetMap.set(filename, asset);
-          }
-        });
+      const { document: healedDocument, changed } = healTimelineDocument(
+        firebaseDocument,
+        cloudinaryAssets,
+      );
 
-        const healedClips = firebaseDocument.clips.map((clip) => {
-          if (clip.kind === "video" || clip.kind === "image") {
-            const filename = clip.src.split("/").pop()?.split("?")[0]?.replace(/\.[^/.]+$/, "");
-            if (filename) {
-              const matchedAsset = assetMap.get(filename);
-              if (matchedAsset && clip.src !== matchedAsset.url) {
-                hasChanges = true;
-                return {
-                  ...clip,
-                  src: matchedAsset.url,
-                  poster: clip.kind === "video" ? matchedAsset.thumbnailUrl : clip.poster,
-                };
-              }
-            }
-          }
-          return clip;
-        });
-        healedDocument = {
-          ...firebaseDocument,
-          clips: healedClips,
-        };
-
-        if (hasChanges) {
-          await saveFirebaseTimelineDocument(healedDocument).catch(() => {});
-        }
+      if (changed) {
+        await saveFirebaseTimelineDocument(healedDocument).catch(() => {});
       }
 
       return NextResponse.json({ document: healedDocument });

--- a/apps/timeline-gstudio001/lib/heal-timeline-document.test.ts
+++ b/apps/timeline-gstudio001/lib/heal-timeline-document.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+
+import { CLIP_GAP_SECONDS } from "@storyboard/ui/timeline/constants";
+import type { TimelineClip, TimelineDocument } from "@storyboard/ui/timeline/types";
+
+import type { CloudinaryAsset } from "./cloudinary-media-store";
+import { healTimelineDocument } from "./heal-timeline-document";
+
+const CLOUD = "https://res.cloudinary.com/demo/video/upload/v1";
+
+function videoClip(
+  publicId: string,
+  index: number,
+  startTime: number,
+  duration: number,
+  sourceDuration = duration,
+  trimIn = 0,
+  trimOut = 0,
+): TimelineClip {
+  return {
+    id: `clip-${publicId}`,
+    index,
+    kind: "video",
+    src: `${CLOUD}/${publicId}.mp4`,
+    poster: `${CLOUD}/${publicId}.jpg`,
+    alt: publicId,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime,
+    duration,
+    sourceDuration,
+    trimIn,
+    trimOut,
+  };
+}
+
+function imageClip(publicId: string, index: number, startTime: number): TimelineClip {
+  return {
+    id: `clip-${publicId}`,
+    index,
+    kind: "image",
+    src: `${CLOUD}/${publicId}.jpg`,
+    alt: publicId,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime,
+    duration: 4,
+    sourceDuration: 4,
+    trimIn: 0,
+    trimOut: 0,
+  };
+}
+
+function videoAsset(publicId: string, duration: number | undefined, url?: string): CloudinaryAsset {
+  return {
+    id: publicId,
+    pathname: `folder/${publicId}`,
+    relativePath: publicId,
+    url: url ?? `${CLOUD}/${publicId}.mp4`,
+    thumbnailUrl: `${CLOUD}/${publicId}.jpg`,
+    resourceType: "video",
+    duration,
+  };
+}
+
+function doc(clips: TimelineClip[]): TimelineDocument {
+  return { id: "project-1", title: "Doc", clips };
+}
+
+const srcOf = (clip: TimelineClip): string => (clip.kind === "collection" ? "" : clip.src);
+const posterOf = (clip: TimelineClip): string | undefined =>
+  clip.kind === "collection" ? undefined : clip.poster;
+
+describe("healTimelineDocument", () => {
+  it("backfills a real duration onto an untrimmed defaulted video and repacks", () => {
+    const input = doc([
+      videoClip("v-a", 0, 0, 8), // defaulted 8s, untrimmed
+      videoClip("v-b", 1, 8.12, 5),
+    ]);
+
+    const { document, changed } = healTimelineDocument(input, [
+      videoAsset("v-a", 12.4),
+      videoAsset("v-b", 5), // already correct — no change
+    ]);
+
+    expect(changed).toBe(true);
+    const [a, b] = document.clips;
+    expect(a.duration).toBe(12.4);
+    expect(a.sourceDuration).toBe(12.4);
+    // Downstream clip repacked behind the longer first clip.
+    expect(b.startTime).toBeCloseTo(12.4 + CLIP_GAP_SECONDS, 5);
+    expect(b.duration).toBe(5); // untouched
+  });
+
+  it("never rewrites a trimmed clip (a stored trim is a user choice)", () => {
+    // Shows 6s of a source the listing reports as 12.4s, but the user trimmed
+    // it: trimIn+duration+trimOut === sourceDuration must stay intact.
+    const input = doc([videoClip("v-a", 0, 0, 6, 8, 1, 1)]);
+
+    const { document, changed } = healTimelineDocument(input, [videoAsset("v-a", 12.4)]);
+
+    expect(changed).toBe(false);
+    expect(document).toBe(input); // same reference — caller skips the write
+    expect(document.clips[0].sourceDuration).toBe(8);
+  });
+
+  it("leaves an already-correct untrimmed video alone (within epsilon)", () => {
+    const input = doc([videoClip("v-a", 0, 0, 8.33, 8.33)]);
+    const { changed } = healTimelineDocument(input, [videoAsset("v-a", 8.333333)]);
+    expect(changed).toBe(false);
+  });
+
+  it("heals a moved asset's src without repacking when no duration changed", () => {
+    const moved = `${CLOUD}/v-a-moved.mp4`;
+    const input = doc([videoClip("v-a", 0, 0, 5), imageClip("i-b", 1, 5.12)]);
+
+    const { document, changed } = healTimelineDocument(input, [
+      // Same filename key, new url, correct duration → src heal only.
+      videoAsset("v-a", 5, moved),
+    ]);
+
+    expect(changed).toBe(true);
+    expect(srcOf(document.clips[0])).toBe(moved);
+    expect(posterOf(document.clips[0])).toBe(`${CLOUD}/v-a.jpg`);
+    // No duration moved → startTimes preserved, not repacked.
+    expect(document.clips[1].startTime).toBe(5.12);
+  });
+
+  it("does both heals at once and repacks from the duration change", () => {
+    const moved = `${CLOUD}/v-a-moved.mp4`;
+    const input = doc([videoClip("v-a", 0, 0, 8), imageClip("i-b", 1, 8.12)]);
+
+    const { document, changed } = healTimelineDocument(input, [videoAsset("v-a", 3, moved)]);
+
+    expect(changed).toBe(true);
+    expect(srcOf(document.clips[0])).toBe(moved);
+    expect(document.clips[0].duration).toBe(3);
+    expect(document.clips[1].startTime).toBeCloseTo(3 + CLIP_GAP_SECONDS, 5);
+  });
+
+  it("is a no-op with no assets", () => {
+    const input = doc([videoClip("v-a", 0, 0, 8)]);
+    const result = healTimelineDocument(input, []);
+    expect(result.changed).toBe(false);
+    expect(result.document).toBe(input);
+  });
+
+  it("ignores videos with no listed duration (degraded listing)", () => {
+    const input = doc([videoClip("v-a", 0, 0, 8)]);
+    const { changed } = healTimelineDocument(input, [videoAsset("v-a", undefined)]);
+    expect(changed).toBe(false);
+  });
+});

--- a/apps/timeline-gstudio001/lib/heal-timeline-document.ts
+++ b/apps/timeline-gstudio001/lib/heal-timeline-document.ts
@@ -1,0 +1,92 @@
+import { packTimelineClips } from "@storyboard/ui/timeline/timeline-documents";
+import type { TimelineDocument } from "@storyboard/ui/timeline/types";
+
+import type { CloudinaryAsset } from "./cloudinary-media-store";
+
+// Two load-time self-heals for stored timeline documents, in one pass:
+//
+//   1. src/poster — a clip whose Cloudinary asset moved or was re-uploaded
+//      (same filename, new secure_url) is re-pointed at the live URL.
+//   2. duration backfill — before the Search-API listing landed, every
+//      dropped video got a flat default length (6s/8s) because the listing
+//      carried no duration. Now that real durations arrive, an UNTRIMMED
+//      video clip (trimIn === 0 && trimOut === 0) is corrected to its true
+//      length. Trimmed clips are left ALONE — a stored trim is a user choice,
+//      and rewriting sourceDuration under it would break the
+//      trimIn+duration+trimOut === sourceDuration invariant.
+//
+// A duration change shifts every following clip's startTime, so the document
+// is repacked (packTimelineClips — the same packing the app uses) whenever a
+// duration moved. Returns the SAME document reference when nothing changed so
+// the caller can skip the write.
+
+/** Durations within this many seconds are treated as already correct. */
+const DURATION_EPSILON = 0.05;
+
+/** Asset filename as stored (public_id leaf) — the key the src match uses. */
+function assetFilename(asset: CloudinaryAsset): string | undefined {
+  return asset.relativePath?.split("/").pop() || asset.pathname?.split("/").pop() || undefined;
+}
+
+/** A clip's source URL reduced to the same filename key (extension stripped —
+ *  Cloudinary public_ids carry none, but the delivery URL does). */
+function clipAssetKey(src: string): string | undefined {
+  return src.split("/").pop()?.split("?")[0]?.replace(/\.[^/.]+$/, "") || undefined;
+}
+
+export function healTimelineDocument(
+  document: TimelineDocument,
+  assets: readonly CloudinaryAsset[],
+): { document: TimelineDocument; changed: boolean } {
+  if (assets.length === 0) return { document, changed: false };
+
+  const assetMap = new Map<string, CloudinaryAsset>();
+  for (const asset of assets) {
+    const filename = assetFilename(asset);
+    if (filename) assetMap.set(filename, asset);
+  }
+
+  let changed = false;
+  let durationsChanged = false;
+
+  const healed = document.clips.map((clip) => {
+    if (clip.kind !== "video" && clip.kind !== "image") return clip;
+
+    const key = clipAssetKey(clip.src);
+    if (!key) return clip;
+    const asset = assetMap.get(key);
+    if (!asset) return clip;
+
+    let next = clip;
+
+    if (next.src !== asset.url) {
+      next = {
+        ...next,
+        src: asset.url,
+        poster: next.kind === "video" ? asset.thumbnailUrl : next.poster,
+      };
+      changed = true;
+    }
+
+    if (
+      next.kind === "video" &&
+      typeof asset.duration === "number" &&
+      asset.duration > 0 &&
+      next.trimIn === 0 &&
+      next.trimOut === 0 &&
+      Math.abs(next.sourceDuration - asset.duration) > DURATION_EPSILON
+    ) {
+      next = { ...next, duration: asset.duration, sourceDuration: asset.duration };
+      changed = true;
+      durationsChanged = true;
+    }
+
+    return next;
+  });
+
+  if (!changed) return { document, changed: false };
+
+  // Repack only when a duration moved — a bare src swap keeps every startTime.
+  const clips = durationsChanged ? packTimelineClips(healed) : healed;
+  return { document: { ...document, clips }, changed: true };
+}

--- a/apps/timeline-gstudio001/vitest.config.ts
+++ b/apps/timeline-gstudio001/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     environment: "node",
     include: [
       "components/timeline/**/*.test.ts",
+      "lib/**/*.test.ts",
       "../../packages/ui/timeline/**/*.test.ts",
     ],
   },


### PR DESCRIPTION
…load

Extract the GET /api/timelines/[id] inline self-heal into a pure, tested helper and extend it with a duration backfill: stored videos saved before the Cloudinary Search-API listing existed all got a flat default length (6s/8s). On load, an UNTRIMMED video clip is now corrected to its real listed duration.

Trimmed clips are left alone — a stored trim is a user choice, and rewriting sourceDuration under it would break the
trimIn+duration+trimOut === sourceDuration invariant. Start times are repacked (packTimelineClips) only when a duration actually moved; a bare src swap keeps every startTime. Returns the same document reference when nothing changed so the route skips the write.

- lib/heal-timeline-document.ts: pure healTimelineDocument(doc, assets)
- lib/heal-timeline-document.test.ts: 7 unit tests (backfill+repack, trimmed untouched, epsilon, src-only, both-at-once, no-op, no-duration)
- vitest.config.ts: include lib/**/*.test.ts