### PR TITLE
feat(gstudio001): playhead works in grid mode — advance, scrub 2D

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -634,6 +634,73 @@ function buildPlayheadMap(clips: readonly TimelineClip[]): PlayheadMap {
   };
 }
 
+// Grid surface cell geometry — must match the <VirtualGrid> props below and
+// its default gap, since the playhead maps time onto that exact layout.
+const GRID_CELL_W = 160;
+const GRID_CELL_H = 96;
+const GRID_GAP = 8;
+
+/**
+ * The grid analog of buildPlayheadMap. In the grid every cell is the SAME
+ * width regardless of the clip's duration, so time maps onto a cell as a
+ * fraction of that constant width, and the playhead advances cell-by-cell,
+ * wrapping down a row every `cols` clips. `timeAt` is 2D — column from x AND
+ * row from y — so a scrub can move within a row or jump rows.
+ */
+type GridPlayheadMap = Readonly<{
+  posAt: (time: number) => { x: number; y: number };
+  timeAt: (x: number, y: number) => number;
+  totalDurationSeconds: number;
+  rowHeight: number;
+}>;
+
+function buildGridPlayheadMap(clips: readonly TimelineClip[], cols: number): GridPlayheadMap {
+  const columns = Math.max(1, cols);
+  const starts: number[] = [];
+  const ends: number[] = [];
+  for (const clip of clips) {
+    starts.push(clip.startTime);
+    ends.push(clip.startTime + clip.duration);
+  }
+  const n = clips.length;
+  const total = n > 0 ? ends[n - 1] : 0;
+  const cellX = (i: number) => (i % columns) * (GRID_CELL_W + GRID_GAP);
+  const cellY = (i: number) => Math.floor(i / columns) * (GRID_CELL_H + GRID_GAP);
+  const clamp01 = (value: number) => Math.min(1, Math.max(0, value));
+
+  return {
+    rowHeight: GRID_CELL_H,
+    totalDurationSeconds: total,
+    posAt: (time) => {
+      if (n === 0) return { x: 0, y: 0 };
+      // Last clip whose start <= time (binary search); time landing in the
+      // gap after a clip clamps to that clip's right edge.
+      let lo = 0;
+      if (time >= starts[n - 1]) {
+        lo = n - 1;
+      } else if (time > starts[0]) {
+        let hi = n - 1;
+        while (lo < hi - 1) {
+          const mid = (lo + hi) >> 1;
+          if (starts[mid] <= time) lo = mid;
+          else hi = mid;
+        }
+      }
+      const span = ends[lo] - starts[lo];
+      const frac = span > 0 ? clamp01((time - starts[lo]) / span) : 0;
+      return { x: cellX(lo) + frac * GRID_CELL_W, y: cellY(lo) };
+    },
+    timeAt: (x, y) => {
+      if (n === 0) return 0;
+      const row = Math.max(0, Math.floor(y / (GRID_CELL_H + GRID_GAP)));
+      const col = Math.max(0, Math.min(columns - 1, Math.floor(x / (GRID_CELL_W + GRID_GAP))));
+      const i = Math.max(0, Math.min(n - 1, row * columns + col));
+      const frac = clamp01((x - cellX(i)) / GRID_CELL_W);
+      return Math.min(total, Math.max(0, starts[i] + frac * (ends[i] - starts[i])));
+    },
+  };
+}
+
 /** The red playhead over the focused strip — a line with a triangle cap,
  *  strictly presentational (the strip overlay layer is aria-hidden and
  *  pointer-events: none; scrubbing lives in PlayheadScrubBand outside the
@@ -767,6 +834,163 @@ function PlayheadScrubBand({
       data-playhead-scrub
       aria-hidden="true"
       className="absolute inset-x-0 top-0 z-10 h-3 cursor-ew-resize"
+    />
+  );
+}
+
+/**
+ * The grid playhead: a one-row-tall red line inside the grid's content
+ * overlay (so it scrolls with the rows and the scroller's overflow clips it
+ * when its row is off-screen). It moves through the active cell as time
+ * advances and jumps to the next cell/row on clip boundaries. Column count
+ * comes from the grid's own `data-grid-columns`, so the map rebuilds when a
+ * resize reflows the grid. Painted imperatively — no React render per tick.
+ */
+function GraphGridPlayhead({
+  focusedId,
+  details,
+  channel,
+}: Readonly<{ focusedId: string; details: DetailsById; channel: PreviewTimeChannel }>) {
+  const store = useCollectionsStore();
+  const lineRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const line = lineRef.current;
+    if (!line) return;
+    const grid = line.closest<HTMLElement>("[data-virtual-grid]");
+
+    let lastGraph: CollectionsGraph | null = null;
+    let lastCols = 0;
+    let map: GridPlayheadMap | null = null;
+    const paint = () => {
+      const graph = store.getSnapshot().graph;
+      const cols = Number(grid?.dataset.gridColumns) || 1;
+      if (graph !== lastGraph || cols !== lastCols) {
+        lastGraph = graph;
+        lastCols = cols;
+        map = buildGridPlayheadMap(graphChildrenToClips(graph, details, focusedId), cols);
+      }
+      if (!map) return;
+      const { x, y } = map.posAt(channel.get());
+      line.style.transform = `translate(${x}px, ${y}px)`;
+      line.style.height = `${map.rowHeight}px`;
+    };
+    paint();
+
+    const unsubscribeTime = channel.subscribe(paint);
+    const unsubscribeStore = store.subscribe(paint);
+    // Responsive columns can change on resize with no store/graph change.
+    const observer = grid ? new ResizeObserver(paint) : null;
+    if (grid && observer) observer.observe(grid);
+    return () => {
+      unsubscribeTime();
+      unsubscribeStore();
+      observer?.disconnect();
+    };
+  }, [store, focusedId, details, channel]);
+
+  return (
+    <div
+      ref={lineRef}
+      data-graph-grid-playhead
+      className="absolute left-0 top-0 w-0.5 bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.9)]"
+    >
+      <div className="absolute -left-[5px] -top-2 h-0 w-0 border-x-[6px] border-t-[8px] border-x-transparent border-t-red-500" />
+    </div>
+  );
+}
+
+/**
+ * The grid scrub surface: a full-grid pointer layer (the grid has no per-row
+ * top gutter the way the strip does, and the user scrubs BOTH axes — column
+ * within a row, row by dragging vertically). It reads content coordinates
+ * off the overlay wrapper (same rect as the scrolling spacer, so scroll is
+ * already folded in) and seeks through the 2D map. Because it overlays the
+ * cards, wheel events are forwarded to the grid so it still scrolls while
+ * previewing.
+ *
+ * Trade-off: covering the cards means item drag/reorder is paused while
+ * Preview is on in grid mode — toggle Preview off to rearrange.
+ */
+function GraphGridScrubSurface({
+  focusedId,
+  details,
+  channel,
+}: Readonly<{ focusedId: string; details: DetailsById; channel: PreviewTimeChannel }>) {
+  const store = useCollectionsStore();
+  const surfaceRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const surface = surfaceRef.current;
+    if (!surface) return;
+    const grid = surface.parentElement?.querySelector<HTMLElement>("[data-virtual-grid]") ?? null;
+    if (!grid) return;
+
+    let map: GridPlayheadMap | null = null;
+    let mapGraph: CollectionsGraph | null = null;
+    let mapCols = 0;
+    const seek = (event: PointerEvent) => {
+      const graph = store.getSnapshot().graph;
+      const cols = Number(grid.dataset.gridColumns) || 1;
+      if (graph !== mapGraph || cols !== mapCols || !map) {
+        mapGraph = graph;
+        mapCols = cols;
+        map = buildGridPlayheadMap(graphChildrenToClips(graph, details, focusedId), cols);
+      }
+      // The overlay wrapper shares the scrolling spacer's rect, so its top/
+      // left already fold in scroll position and container padding.
+      const overlay = grid.querySelector<HTMLElement>("[data-virtual-grid-overlay]");
+      const rect = (overlay ?? grid).getBoundingClientRect();
+      channel.set(map.timeAt(event.clientX - rect.left, event.clientY - rect.top));
+    };
+
+    let pointerId: number | null = null;
+    const handleMove = (event: PointerEvent) => {
+      if (event.pointerId === pointerId) seek(event);
+    };
+    const end = (event: PointerEvent) => {
+      if (event.pointerId !== pointerId) return;
+      pointerId = null;
+      window.removeEventListener("pointermove", handleMove);
+      window.removeEventListener("pointerup", end);
+      window.removeEventListener("pointercancel", end);
+    };
+    const handleDown = (event: PointerEvent) => {
+      if (!event.isPrimary || event.button !== 0) return;
+      pointerId = event.pointerId;
+      try {
+        surface.setPointerCapture(event.pointerId);
+      } catch {
+        /* synthetic pointer — window listeners suffice */
+      }
+      seek(event);
+      window.addEventListener("pointermove", handleMove);
+      window.addEventListener("pointerup", end);
+      window.addEventListener("pointercancel", end);
+    };
+    // Forward wheel to the grid so it still scrolls under the surface.
+    const handleWheel = (event: WheelEvent) => {
+      grid.scrollTop += event.deltaY;
+      grid.scrollLeft += event.deltaX;
+    };
+
+    surface.addEventListener("pointerdown", handleDown);
+    surface.addEventListener("wheel", handleWheel, { passive: true });
+    return () => {
+      surface.removeEventListener("pointerdown", handleDown);
+      surface.removeEventListener("wheel", handleWheel);
+      window.removeEventListener("pointermove", handleMove);
+      window.removeEventListener("pointerup", end);
+      window.removeEventListener("pointercancel", end);
+    };
+  }, [store, focusedId, details, channel]);
+
+  return (
+    <div
+      ref={surfaceRef}
+      data-grid-scrub
+      aria-hidden="true"
+      className="absolute inset-0 z-10 cursor-crosshair"
     />
   );
 }
@@ -1598,14 +1822,35 @@ export function GraphTimelineView({ projectId }: { projectId: string }) {
                 </div>
               ) : (
                 // Same graph, same provider — dragging between this grid and
-                // the sub-timeline strips below is native.
-                <VirtualGrid
-                  collectionId={parseNodeId(focusedId)}
-                  cellWidth={160}
-                  cellHeight={96}
-                  height={420}
-                  className="bg-black/25"
-                />
+                // the sub-timeline strips below is native. In Preview the
+                // playhead rides the grid's content overlay and the scrub
+                // surface owns pointers (see GraphGridScrubSurface).
+                <div className="relative">
+                  <VirtualGrid
+                    collectionId={parseNodeId(focusedId)}
+                    cellWidth={GRID_CELL_W}
+                    cellHeight={GRID_CELL_H}
+                    gap={GRID_GAP}
+                    height={420}
+                    overlay={
+                      previewOn ? (
+                        <GraphGridPlayhead
+                          focusedId={focusedId}
+                          details={details}
+                          channel={timeChannel}
+                        />
+                      ) : undefined
+                    }
+                    className="bg-black/25"
+                  />
+                  {previewOn && (
+                    <GraphGridScrubSurface
+                      focusedId={focusedId}
+                      details={details}
+                      channel={timeChannel}
+                    />
+                  )}
+                </div>
               )}
               <SubTimelines focusedId={focusedId} details={details} onDetails={onDetails} />
               {boot.trashRootId !== null && (

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -510,4 +510,64 @@ test.describe("graph view E2E", () => {
 
     await expect.poll(translateX).toBeGreaterThan(before + 100);
   });
+
+  test("grid mode: playhead rides cells, scrubs horizontally and jumps rows", async ({
+    page,
+  }) => {
+    // Narrow viewport → few responsive columns, so the 4 project clips wrap
+    // onto at least two rows (needed to exercise the vertical row scrub).
+    await page.setViewportSize({ width: 420, height: 900 });
+    await installGraphApi(page);
+    await openGraph(page);
+    await expect.poll(() => stripOrder(page, CHILD_ID), { timeout: 15000 }).toEqual(["c1", "c2"]);
+
+    // Switch the focused surface to grid, then turn Preview on.
+    await page
+      .getByRole("group", { name: "Focused timeline layout" })
+      .getByRole("button", { name: "grid" })
+      .click();
+    await headerToggle(page, "Preview").click();
+
+    const playhead = page.locator("[data-graph-grid-playhead]");
+    await expect(playhead).toBeVisible();
+
+    const grid = page.locator("[data-virtual-grid]");
+    // Fewer than 4 columns guarantees a second row for the 4 project clips.
+    const cols = Number(await grid.getAttribute("data-grid-columns"));
+    expect(cols).toBeGreaterThanOrEqual(1);
+    expect(cols).toBeLessThan(4);
+
+    const translate = () =>
+      playhead.evaluate((el) => {
+        const m = /translate\(([-\d.]+)px,\s*([-\d.]+)px\)/.exec((el as HTMLElement).style.transform);
+        return m ? { x: Number(m[1]), y: Number(m[2]) } : { x: 0, y: 0 };
+      });
+
+    // Positions are taken RELATIVE TO THE SCRUB SURFACE, which overlays the
+    // grid exactly — so its interior offsets are layout-independent (the
+    // preview pane above settles asynchronously and shifts absolute page
+    // coords). scrub.hover() also waits for a stable box before pressing.
+    // Content geometry: 9px border+padding, cell 160×96, 8px gap → row pitch
+    // 104, a cell's vertical center ≈ 9 + 48 = 57 below the scrub top.
+    const scrub = page.locator("[data-grid-scrub]");
+    const ROW0_Y = 57;
+    const ROW1_Y = 57 + 104;
+
+    // Horizontal scrub across row 0 → x advances, still on row 0.
+    await scrub.hover({ position: { x: 30, y: ROW0_Y } });
+    await page.mouse.down();
+    const sb = (await scrub.boundingBox())!;
+    await page.mouse.move(sb.x + 150, sb.y + ROW0_Y, { steps: 8 });
+    await page.mouse.up();
+    await expect.poll(async () => (await translate()).x).toBeGreaterThan(100);
+    expect((await translate()).y).toBeLessThan(52); // still the first row
+
+    // Vertical scrub: press into the SECOND row → the playhead jumps a row
+    // down (time lands on a later clip). This is the grid-only affordance.
+    await scrub.hover({ position: { x: 89, y: ROW1_Y } });
+    await page.mouse.down();
+    await page.mouse.move(sb.x + 93, sb.y + ROW1_Y, { steps: 4 });
+    await page.mouse.up();
+    await expect.poll(async () => (await translate()).y).toBeGreaterThan(80);
+  });
 });

--- a/packages/ui/dnd-collections/API.md
+++ b/packages/ui/dnd-collections/API.md
@@ -935,6 +935,7 @@ type VirtualGridProps = {
   overscan?: number;    // default 2 (rows)
   height?: number;      // default 480 — scroll viewport height
   itemContent?: CollectionItemContentComponent; // per-view card pixels; overrides the provider registry
+  overlay?: ReactNode;  // STRICTLY PRESENTATIONAL content-coordinate layer inside the scrolling spacer (playhead, region markers): rides vertical scroll and the drop-spacer height. aria-hidden + pointer-events none — no interactive/focusable children; interactive scrubbers belong in your own layer outside the grid. Position children in content coords: col c → left c*(cellWidth+gap), row r → top r*(cellHeight+gap); read the live column count off data-grid-columns
   className?: string;
 };
 type VirtualGridHandle = {
@@ -962,7 +963,7 @@ keep durable state in the collection store.
 | Attribute | Element | Meaning |
 | --- | --- | --- |
 | `data-virtual-strip` / `data-virtual-grid` | scroll container | Collection identity. |
-| `data-virtual-overlay` | overlay layer (strip) | The consumer `overlay` slot's content-coordinate wrapper (aria-hidden, pointer-events none). |
+| `data-virtual-overlay` / `data-virtual-grid-overlay` | overlay layer (strip / grid) | The consumer `overlay` slot's content-coordinate wrapper (aria-hidden, pointer-events none). |
 | `data-grid-columns` | grid container | Live column count (keyboard row-move scope). |
 | `data-virtual-index` / `data-virtual-row` | slot / row wrapper | Virtualizer index. |
 | `data-drop-indicator="virtual"` / `"virtual-grid"` | indicator line | The resolved insert boundary, in content coordinates. |

--- a/packages/ui/dnd-collections/VirtualGrid.stories.tsx
+++ b/packages/ui/dnd-collections/VirtualGrid.stories.tsx
@@ -111,6 +111,64 @@ export const ThousandItemGrid: Story = {
   },
 };
 
+function GridOverlayExample() {
+  // Row 2, column 1 in content coordinates (cellHeight 96 + gap 8 = 104).
+  const CELL = 128 + 8;
+  const ROW = 96 + 8;
+  return (
+    <DndCollections initialGraph={gridGraph()}>
+      <div className="w-[600px]">
+        <VirtualGrid
+          collectionId={parseNodeId("grid")}
+          columns={COLUMNS}
+          height={300}
+          overlay={
+            <div
+              data-grid-playhead
+              style={{
+                position: "absolute",
+                left: 1 * CELL,
+                top: 2 * ROW,
+                width: 2,
+                height: 96,
+                background: "red",
+              }}
+            />
+          }
+        />
+      </div>
+    </DndCollections>
+  );
+}
+
+export const GridOverlay: Story = {
+  // The grid overlay renders in CONTENT coordinates inside the scrolling
+  // spacer: a marker placed at (col*cellPitch, row*rowPitch) sits at that
+  // exact content point and rides vertical scroll — viewport position shifts
+  // by exactly the scroll while the content-relative offset never changes.
+  render: () => <GridOverlayExample />,
+  play: async ({ canvasElement }) => {
+    await waitForLayout(nodeCard(canvasElement, "m0"));
+    const grid = canvasElement.querySelector<HTMLElement>('[data-virtual-grid="grid"]')!;
+    const marker = () => canvasElement.querySelector<HTMLElement>("[data-grid-playhead]")!;
+    const spacer = marker().closest("[data-virtual-grid-overlay]")!.parentElement as HTMLElement;
+    const contentTop = () =>
+      marker().getBoundingClientRect().top - spacer.getBoundingClientRect().top;
+
+    expect(Math.round(contentTop())).toBe(2 * (96 + 8)); // row 2
+
+    const viewportBefore = marker().getBoundingClientRect().top;
+    grid.scrollTop = 50;
+    await waitFor(() => {
+      expect(Math.round(marker().getBoundingClientRect().top)).toBe(
+        Math.round(viewportBefore - 50)
+      );
+    });
+    // Content-relative offset unchanged — it rode the scroll.
+    expect(Math.round(contentTop())).toBe(2 * (96 + 8));
+  },
+};
+
 const gridOrder = (canvasElement: HTMLElement, id: string) =>
   [
     ...canvasElement

--- a/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
@@ -7,6 +7,7 @@ import {
   useLayoutEffect,
   useMemo,
   useState,
+  type ReactNode,
 } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 
@@ -53,6 +54,11 @@ export type VirtualGridProps = Readonly<{
   /** Per-view card pixels — overrides the provider `components` registry.
    *  MUST be identity-stable (module scope). */
   itemContent?: CollectionItemContentComponent;
+  /** Presentational layer painted in CONTENT coordinates (inside the
+   *  scrolling spacer), like VirtualStrip's `overlay`: a playhead, region
+   *  markers. aria-hidden and pointer-events: none — scroll and the drop
+   *  spacer height apply for free, and gestures pass through to the cards. */
+  overlay?: ReactNode;
   className?: string;
 }>;
 
@@ -72,6 +78,7 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
       overscan: overscanOption,
       height: heightOption,
       itemContent,
+      overlay,
       className,
     },
     ref
@@ -316,6 +323,20 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
                 })}
             </div>
           ))}
+          {/* Consumer overlay (playhead, region markers) in CONTENT
+              coordinates: inside the spacer, so scroll and the drop-spacer
+              height apply for free. pointer-events: none so drag/select pass
+              through; aria-hidden keeps the grid tree valid (a focusable
+              child under aria-hidden would be a keyboard trap). */}
+          {overlay != null && (
+            <div
+              aria-hidden="true"
+              data-virtual-grid-overlay
+              style={{ position: "absolute", inset: 0, pointerEvents: "none", zIndex: 30 }}
+            >
+              {overlay}
+            </div>
+          )}
         </div>
       </div>
     );


### PR DESCRIPTION
Previously the playhead only rendered in the strip surface; switching the focused timeline to Grid made it disappear entirely because a single vertical line has no meaningful position once clips wrap across rows.

Give VirtualGrid an `overlay` slot (packages/ui/dnd-collections), mirroring VirtualStrip's: presentational content painted inside the scrolling spacer so it rides vertical scroll, aria-hidden and pointer-events:none. Documented in API.md with a GridOverlay story proving the scroll-follow behavior.

On the app side: buildGridPlayheadMap maps time onto CONSTANT-width cells (grid cells don't scale with clip duration the way strip widths do) and advances cell-by-cell, wrapping rows every `cols` clips. GraphGridPlayhead paints the line + triangle cap into the overlay, tracking live column count via data-grid-columns (ResizeObserver for responsive reflow). GraphGridScrubSurface is a full-grid pointer layer so scrubbing works on both axes — horizontal within a row, vertical to jump rows — forwarding wheel events so the grid still scrolls under it.

Trade-off: the scrub surface covers the cards, so item drag/reorder is paused while Preview is on in grid mode.

New e2e: "grid mode: playhead rides cells, scrubs horizontally and jumps rows" in graph-view.spec.ts.