### PR TITLE
fix(gstudio001): enforce timeline ownership authorization (P0)

### DIFF
--- a/apps/timeline-gstudio001/app/api/timelines/[id]/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/[id]/route.ts
@@ -16,6 +16,7 @@ import {
 } from "@storyboard/ui/timeline/timeline-documents";
 import { listCloudinaryAssets } from "@/lib/cloudinary-media-store";
 import { healTimelineDocument } from "@/lib/heal-timeline-document";
+import { checkUserScopedId, TimelineAccessDeniedError } from "@/lib/timeline-ownership";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -24,7 +25,21 @@ function isValidTimelineId(id: string) {
   return /^[a-zA-Z0-9_-]+$/.test(id);
 }
 
+/** User-scoped ids (trash-<uid>, asset-library-<uid>…) embed their owner:
+ *  a mismatch is rejected before any storage read. Returns null when the id
+ *  is fine (not scoped, or scoped to the requester). */
+function scopedIdMismatch(id: string, uid: string) {
+  return checkUserScopedId(id, uid) === false
+    ? NextResponse.json({ error: "Timeline was not found." }, { status: 404 })
+    : null;
+}
+
 function storageErrorResponse(error: unknown, fallback: string) {
+  // Someone else's document: a plain not-found, so timeline ids can't be
+  // probed for existence.
+  if (error instanceof TimelineAccessDeniedError) {
+    return NextResponse.json({ error: "Timeline was not found." }, { status: 404 });
+  }
   const message =
     error instanceof Error &&
     (error.message.startsWith("Firebase Storage is not configured") ||
@@ -56,8 +71,11 @@ export async function GET(
     if (response || !user) return response || NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
     const { id } = await params;
+    const mismatch = scopedIdMismatch(id, user.uid);
+    if (mismatch) return mismatch;
+
     if (id.startsWith("trash-")) {
-      const firebaseDocument = await getFirebaseTimelineDocument(id);
+      const firebaseDocument = await getFirebaseTimelineDocument(id, user.uid);
       const doc: TimelineDocument = firebaseDocument || {
         id,
         title: "Trash Bin",
@@ -71,7 +89,7 @@ export async function GET(
     }
 
     if (id.startsWith("asset-library-")) {
-      const firebaseDocument = await getFirebaseTimelineDocument(id);
+      const firebaseDocument = await getFirebaseTimelineDocument(id, user.uid);
 
       let title = "Cloudinary Assets";
       if (id.startsWith("asset-library-col-")) {
@@ -226,7 +244,7 @@ export async function GET(
       });
     }
 
-    const firebaseDocument = await getFirebaseTimelineDocument(id);
+    const firebaseDocument = await getFirebaseTimelineDocument(id, user.uid);
     if (firebaseDocument) {
       // Load-time self-heal: re-point moved/renamed Cloudinary assets AND
       // backfill real video durations onto untrimmed clips (see
@@ -238,7 +256,7 @@ export async function GET(
       );
 
       if (changed) {
-        await saveFirebaseTimelineDocument(healedDocument).catch(() => {});
+        await saveFirebaseTimelineDocument(healedDocument, user.uid).catch(() => {});
       }
 
       return NextResponse.json({ document: healedDocument });
@@ -249,7 +267,7 @@ export async function GET(
       return NextResponse.json({ error: "Timeline was not found." }, { status: 404 });
     }
 
-    const savedDocument = await saveFirebaseTimelineDocument(fallbackDocument);
+    const savedDocument = await saveFirebaseTimelineDocument(fallbackDocument, user.uid);
     return NextResponse.json({ document: savedDocument });
   } catch (error) {
     return storageErrorResponse(error, "Unable to load the timeline document.");
@@ -261,13 +279,15 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const { response } = await requireAuthUser();
-    if (response) return response;
+    const { user, response } = await requireAuthUser();
+    if (response || !user) return response || NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
     const { id } = await params;
     if (!isValidTimelineId(id)) {
       return NextResponse.json({ error: "Invalid timeline id." }, { status: 400 });
     }
+    const mismatch = scopedIdMismatch(id, user.uid);
+    if (mismatch) return mismatch;
 
     const body = (await request.json().catch(() => ({}))) as {
       document?: unknown;
@@ -284,7 +304,7 @@ export async function PATCH(
       );
     }
 
-    const savedDocument = await saveFirebaseTimelineDocument(body.document);
+    const savedDocument = await saveFirebaseTimelineDocument(body.document, user.uid);
     return NextResponse.json({ document: savedDocument });
   } catch (error) {
     if (
@@ -303,15 +323,17 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const { response } = await requireAuthUser();
-    if (response) return response;
+    const { user, response } = await requireAuthUser();
+    if (response || !user) return response || NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
     const { id } = await params;
     if (!isValidTimelineId(id)) {
       return NextResponse.json({ error: "Invalid timeline id." }, { status: 400 });
     }
+    const mismatch = scopedIdMismatch(id, user.uid);
+    if (mismatch) return mismatch;
 
-    await deleteFirebaseTimelineDocument(id);
+    await deleteFirebaseTimelineDocument(id, user.uid);
     return NextResponse.json({ success: true });
   } catch (error) {
     return storageErrorResponse(error, "Unable to delete the timeline document.");

--- a/apps/timeline-gstudio001/app/api/timelines/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/route.ts
@@ -23,10 +23,10 @@ function storageErrorResponse(error: unknown, fallback: string) {
 
 export async function GET() {
   try {
-    const { response } = await requireAuthUser();
-    if (response) return response;
+    const { user, response } = await requireAuthUser();
+    if (response || !user) return response || NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-    return NextResponse.json({ projects: await listFirebaseTimelineProjects() });
+    return NextResponse.json({ projects: await listFirebaseTimelineProjects(user.uid) });
   } catch (error) {
     return storageErrorResponse(error, "Unable to load timeline projects.");
   }
@@ -34,12 +34,12 @@ export async function GET() {
 
 export async function POST(request: Request) {
   try {
-    const { response } = await requireAuthUser();
-    if (response) return response;
+    const { user, response } = await requireAuthUser();
+    if (response || !user) return response || NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
     const body = (await request.json().catch(() => ({}))) as { title?: unknown };
     const title = typeof body.title === "string" ? body.title : undefined;
-    const project = await createFirebaseTimelineProject(title);
+    const project = await createFirebaseTimelineProject(user.uid, title);
 
     return NextResponse.json({ project }, { status: 201 });
   } catch (error) {

--- a/apps/timeline-gstudio001/app/api/timelines/timelines-authorization.test.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/timelines-authorization.test.ts
@@ -1,0 +1,243 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TimelineClip, TimelineDocument } from "@storyboard/ui/timeline/types";
+
+// Two-user authorization tests over the REAL route handlers and the REAL
+// firebase-timeline-store enforcement — only the process boundaries are
+// faked: the Firestore SDK (in-memory), the session cookie (switchable
+// current user), and the Cloudinary listing (empty). Covers the review's
+// P0: list scoping, direct GET, PATCH, DELETE, legacy-document claiming,
+// and user-scoped id (trash-<uid>) pre-checks.
+
+type Stored = Record<string, unknown>;
+
+const state = vi.hoisted(() => {
+  const docs = new Map<string, Stored>();
+  const current = { user: { uid: "user-a", email: null as string | null, name: null, picture: null } };
+
+  const applySet = (id: string, data: Stored, opts?: { merge?: boolean }) => {
+    const existing = docs.get(id);
+    docs.set(id, opts?.merge && existing ? { ...existing, ...data } : { ...data });
+  };
+  const snapshot = (id: string) => {
+    const data = docs.get(id);
+    return {
+      id,
+      exists: data !== undefined,
+      data: () => (data ? { ...data } : undefined),
+      get: (field: string) => (data ? data[field] : undefined),
+    };
+  };
+  const docRef = (id: string) => ({
+    id,
+    get: async () => snapshot(id),
+    set: async (data: Stored, opts?: { merge?: boolean }) => applySet(id, data, opts),
+    delete: async () => {
+      docs.delete(id);
+    },
+  });
+  const db = {
+    collection: () => ({
+      doc: docRef,
+      where: (field: string, _op: string, value: unknown) => ({
+        limit: () => ({
+          get: async () => ({
+            docs: [...docs.keys()].filter((id) => docs.get(id)?.[field] === value).map(snapshot),
+          }),
+        }),
+      }),
+    }),
+    batch: () => {
+      const ops: (() => void)[] = [];
+      return {
+        set: (ref: { id: string }, data: Stored, opts?: { merge?: boolean }) => {
+          ops.push(() => applySet(ref.id, data, opts));
+        },
+        commit: async () => {
+          for (const op of ops) op();
+        },
+      };
+    },
+  };
+  return { docs, current, db };
+});
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/firebase-admin", () => ({
+  getFirebaseDb: () => state.db,
+}));
+vi.mock("firebase-admin/firestore", () => {
+  class Timestamp {
+    toDate() {
+      return new Date(0);
+    }
+  }
+  return { Timestamp, FieldValue: { serverTimestamp: () => new Timestamp() } };
+});
+vi.mock("@/lib/firebase-auth-session", () => ({
+  requireAuthUser: async () => ({ user: state.current.user, response: null }),
+}));
+vi.mock("@/lib/cloudinary-media-store", () => ({
+  listCloudinaryAssets: async () => [],
+}));
+
+import { GET as listProjects, POST as createProject } from "./route";
+import { DELETE as deleteTimeline, GET as getTimeline, PATCH as patchTimeline } from "./[id]/route";
+
+const asUser = (uid: string) => {
+  state.current.user = { uid, email: null, name: null, picture: null };
+};
+
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+
+function clip(id: string): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "image",
+    src: "https://example.test/img.jpg",
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 4,
+    sourceDuration: 4,
+    trimIn: 0,
+    trimOut: 0,
+  };
+}
+
+function seedProject(id: string, ownerUid: string | undefined) {
+  const document: TimelineDocument = { id, title: `Project ${id}`, clips: [clip(`${id}-c0`)] };
+  state.docs.set(id, {
+    id,
+    title: document.title,
+    document,
+    clips: document.clips,
+    isProject: true,
+    ...(ownerUid === undefined ? {} : { ownerUid }),
+  });
+}
+
+function patchRequest(document: TimelineDocument) {
+  return new Request("http://test.local/api/timelines/x", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ document }),
+  });
+}
+
+beforeEach(() => {
+  state.docs.clear();
+  asUser("user-a");
+});
+
+describe("timeline authorization", () => {
+  it("stamps ownerUid on newly created projects", async () => {
+    const response = await createProject(
+      new Request("http://test.local/api/timelines", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: "Mine" }),
+      }),
+    );
+    expect(response.status).toBe(201);
+    const { project } = (await response.json()) as { project: TimelineDocument };
+    expect(state.docs.get(project.id)?.ownerUid).toBe("user-a");
+  });
+
+  it("GET returns 404 for another user's document", async () => {
+    seedProject("project-a1", "user-a");
+    asUser("user-b");
+
+    const response = await getTimeline(new Request("http://test.local"), params("project-a1"));
+    expect(response.status).toBe(404);
+  });
+
+  it("PATCH refuses another user's document and leaves it untouched", async () => {
+    seedProject("project-a1", "user-a");
+    const before = state.docs.get("project-a1");
+    asUser("user-b");
+
+    const evil: TimelineDocument = { id: "project-a1", title: "Taken over", clips: [clip("x")] };
+    const response = await patchTimeline(patchRequest(evil), params("project-a1"));
+
+    expect(response.status).toBe(404);
+    expect(state.docs.get("project-a1")).toEqual(before);
+  });
+
+  it("DELETE refuses another user's document and leaves it in place", async () => {
+    seedProject("project-a1", "user-a");
+    asUser("user-b");
+
+    const response = await deleteTimeline(new Request("http://test.local"), params("project-a1"));
+
+    expect(response.status).toBe(404);
+    expect(state.docs.has("project-a1")).toBe(true);
+  });
+
+  it("owner reads and updates their own document", async () => {
+    seedProject("project-a1", "user-a");
+
+    const getResponse = await getTimeline(new Request("http://test.local"), params("project-a1"));
+    expect(getResponse.status).toBe(200);
+
+    const updated: TimelineDocument = {
+      id: "project-a1",
+      title: "Project project-a1",
+      clips: [clip("new")],
+    };
+    const patchResponse = await patchTimeline(patchRequest(updated), params("project-a1"));
+    expect(patchResponse.status).toBe(200);
+    expect((state.docs.get("project-a1")?.document as TimelineDocument).clips[0].id).toBe("new");
+    expect(state.docs.get("project-a1")?.ownerUid).toBe("user-a");
+  });
+
+  it("first authenticated GET claims a legacy unowned document; others are then denied", async () => {
+    seedProject("project-legacy", undefined);
+
+    const response = await getTimeline(new Request("http://test.local"), params("project-legacy"));
+    expect(response.status).toBe(200);
+    expect(state.docs.get("project-legacy")?.ownerUid).toBe("user-a");
+
+    asUser("user-b");
+    const denied = await getTimeline(new Request("http://test.local"), params("project-legacy"));
+    expect(denied.status).toBe(404);
+  });
+
+  it("list returns own and claims legacy projects, never another user's", async () => {
+    seedProject("project-a1", "user-a");
+    seedProject("project-b1", "user-b");
+    seedProject("project-legacy", undefined);
+
+    const response = await listProjects();
+    expect(response.status).toBe(200);
+    const { projects } = (await response.json()) as { projects: { id: string }[] };
+    const ids = projects.map((project) => project.id).sort();
+
+    expect(ids).toEqual(["project-a1", "project-legacy"]);
+    expect(state.docs.get("project-legacy")?.ownerUid).toBe("user-a");
+    expect(state.docs.get("project-b1")?.ownerUid).toBe("user-b");
+  });
+
+  it("rejects another user's trash id before any storage access", async () => {
+    asUser("user-b");
+    const response = await getTimeline(new Request("http://test.local"), params("trash-user-a"));
+    expect(response.status).toBe(404);
+    expect(state.docs.size).toBe(0); // no read, no claim, nothing written
+
+    const patch = await patchTimeline(
+      patchRequest({ id: "trash-user-a", title: "Trash Bin", clips: [clip("x")] }),
+      params("trash-user-a"),
+    );
+    expect(patch.status).toBe(404);
+    expect(state.docs.size).toBe(0);
+  });
+
+  it("serves the requester's own (possibly empty) trash", async () => {
+    const response = await getTimeline(new Request("http://test.local"), params("trash-user-a"));
+    expect(response.status).toBe(200);
+    const { document } = (await response.json()) as { document: TimelineDocument };
+    expect(document.id).toBe("trash-user-a");
+  });
+});

--- a/apps/timeline-gstudio001/app/api/trash/route.ts
+++ b/apps/timeline-gstudio001/app/api/trash/route.ts
@@ -12,7 +12,7 @@ export async function DELETE() {
     if (response || !user) return response || NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
     const trashId = `trash-${user.uid}`;
-    const trashDoc = await getFirebaseTimelineDocument(trashId);
+    const trashDoc = await getFirebaseTimelineDocument(trashId, user.uid);
 
     if (trashDoc && trashDoc.clips.length > 0) {
       for (const clip of trashDoc.clips) {
@@ -31,7 +31,7 @@ export async function DELETE() {
       }
 
       trashDoc.clips = [];
-      await saveFirebaseTimelineDocument(trashDoc);
+      await saveFirebaseTimelineDocument(trashDoc, user.uid);
     }
 
     return NextResponse.json({ success: true });

--- a/apps/timeline-gstudio001/lib/cloudinary-media-store.ts
+++ b/apps/timeline-gstudio001/lib/cloudinary-media-store.ts
@@ -251,7 +251,33 @@ async function searchCloudinaryVideos(
   return assets;
 }
 
+// Per-user TTL cache over the full asset listing. Every timeline GET runs a
+// listing for document healing, and the graph view's eager hydration can GET
+// dozens of timelines in one burst — without this each GET pays multiple
+// paginated Cloudinary API calls (rate-limit and latency risk). Caching the
+// PROMISE also dedupes the burst: concurrent callers share one in-flight
+// listing. Uploads and deletes invalidate, so a fresh listing follows any
+// change a user makes through this app.
+const ASSET_LIST_TTL_MS = 60_000;
+const assetListCache = new Map<string, { at: number; promise: Promise<CloudinaryAsset[]> }>();
+
+function invalidateAssetListCache(userId?: string) {
+  if (userId) assetListCache.delete(userId);
+  else assetListCache.clear();
+}
+
 export async function listCloudinaryAssets(userId: string) {
+  const cached = assetListCache.get(userId);
+  if (cached && Date.now() - cached.at < ASSET_LIST_TTL_MS) return cached.promise;
+
+  const promise = listCloudinaryAssetsUncached(userId);
+  assetListCache.set(userId, { at: Date.now(), promise });
+  // Failures are never cached — the next caller retries immediately.
+  promise.catch(() => assetListCache.delete(userId));
+  return promise;
+}
+
+async function listCloudinaryAssetsUncached(userId: string) {
   const config = getCloudinaryConfig();
   const userFolder = `${config.folder}/${userId}`;
   const [images, videos] = await Promise.all([
@@ -329,6 +355,8 @@ export async function uploadCloudinaryMedia(
       ? cloudinaryVideoThumbnailUrl(config, body.public_id)
       : undefined;
 
+  invalidateAssetListCache(userId);
+
   return {
     pathname: body.public_id,
     url: body.secure_url,
@@ -368,6 +396,10 @@ export async function deleteCloudinaryAsset(publicId: string, resourceType: "ima
     const err = await response.json().catch(() => ({}));
     throw new Error(err.error?.message || "Failed to delete Cloudinary asset.");
   }
+
+  // No uid in this signature; the public_id embeds it but parsing is
+  // brittle. Deletes are rare — clear every user's cached listing.
+  invalidateAssetListCache();
 
   return await response.json();
 }

--- a/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
@@ -4,6 +4,7 @@ import { FieldValue, Timestamp } from "firebase-admin/firestore";
 
 import type { TimelineDocument, TimelineClip } from "@storyboard/ui/timeline/types";
 import { getFirebaseDb } from "./firebase-admin";
+import { resolveOwnership, TimelineAccessDeniedError } from "./timeline-ownership";
 
 type TimelineDocumentRecord = {
   id: string;
@@ -13,6 +14,9 @@ type TimelineDocumentRecord = {
   lastNonEmptyDocument?: TimelineDocument;
   clips?: TimelineClip[];
   isProject?: boolean;
+  /** Authorization boundary: absent only on legacy records, which are
+   *  claimed by the first authenticated toucher (see lib/timeline-ownership). */
+  ownerUid?: string;
   createdAt?: Timestamp;
   updatedAt?: Timestamp;
 };
@@ -159,14 +163,36 @@ function toProjectSummary(id: string, data: Partial<TimelineDocumentRecord>): Ti
   };
 }
 
-export async function listFirebaseTimelineProjects() {
+export async function listFirebaseTimelineProjects(requesterUid: string) {
   const snapshot = await withFirebaseTimeout(
     collection().where("isProject", "==", true).limit(100).get(),
     "Loading timeline projects",
   );
 
-  return snapshot.docs
-    .map((doc) => toProjectSummary(doc.id, doc.data() as TimelineDocumentRecord))
+  // The scan (not an ownerUid where-clause) is deliberate while legacy
+  // records exist: unowned projects must surface here so the first
+  // authenticated visit CLAIMS them — otherwise they'd silently vanish from
+  // the list until a manual migration ran. Other users' projects are
+  // filtered out; claims are stamped before returning.
+  const visible: { id: string; data: TimelineDocumentRecord }[] = [];
+  const toClaim: string[] = [];
+  for (const doc of snapshot.docs) {
+    const data = doc.data() as TimelineDocumentRecord;
+    const decision = resolveOwnership(data.ownerUid, requesterUid);
+    if (decision === "denied") continue;
+    if (decision === "claim") toClaim.push(doc.id);
+    visible.push({ id: doc.id, data });
+  }
+  if (toClaim.length > 0) {
+    const batch = getFirebaseDb().batch();
+    for (const id of toClaim) {
+      batch.set(collection().doc(id), { ownerUid: requesterUid }, { merge: true });
+    }
+    await withFirebaseTimeout(batch.commit(), "Claiming legacy timeline projects");
+  }
+
+  return visible
+    .map(({ id, data }) => toProjectSummary(id, data))
     .sort((a, b) => {
       const aTime = a.updatedAt ? new Date(a.updatedAt).getTime() : 0;
       const bTime = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
@@ -174,18 +200,28 @@ export async function listFirebaseTimelineProjects() {
     });
 }
 
-export async function getFirebaseTimelineDocument(id: string) {
+export async function getFirebaseTimelineDocument(id: string, requesterUid: string) {
   const snapshot = await withFirebaseTimeout(
     collection().doc(id).get(),
     "Loading timeline document",
   );
 
   if (!snapshot.exists) return null;
-  return toTimelineDocument(snapshot.id, snapshot.data() as TimelineDocumentRecord);
+  const data = snapshot.data() as TimelineDocumentRecord;
+  const decision = resolveOwnership(data.ownerUid, requesterUid);
+  if (decision === "denied") throw new TimelineAccessDeniedError(id);
+  if (decision === "claim") {
+    await withFirebaseTimeout(
+      collection().doc(id).set({ ownerUid: requesterUid }, { merge: true }),
+      "Claiming legacy timeline document",
+    );
+  }
+  return toTimelineDocument(snapshot.id, data);
 }
 
 export async function saveFirebaseTimelineDocument(
   document: TimelineDocument,
+  requesterUid: string,
   options?: { isProject?: boolean },
 ) {
   if (isUnsavedProjectPlaceholder(document)) {
@@ -196,6 +232,15 @@ export async function saveFirebaseTimelineDocument(
   const ref = collection().doc(normalizedDocument.id);
   const existing = await withFirebaseTimeout(ref.get(), "Loading timeline document");
   const existingIsProject = existing.exists ? existing.get("isProject") === true : false;
+  // Ownership: a save CREATES with the requester as owner, CLAIMS a legacy
+  // unowned record, and is refused on someone else's. Children minted
+  // implicitly through PATCH (collection drops) are stamped here too.
+  const existingOwnerUid = existing.exists
+    ? (existing.data() as TimelineDocumentRecord).ownerUid
+    : undefined;
+  if (existing.exists && resolveOwnership(existingOwnerUid, requesterUid) === "denied") {
+    throw new TimelineAccessDeniedError(normalizedDocument.id);
+  }
   const existingDocument = existing.exists
     ? toTimelineDocument(existing.id, existing.data() as TimelineDocumentRecord)
     : null;
@@ -222,6 +267,7 @@ export async function saveFirebaseTimelineDocument(
           ? { lastNonEmptyDocument: normalizedDocument }
           : {}),
         isProject: options?.isProject ?? existingIsProject,
+        ownerUid: existingOwnerUid ?? requesterUid,
         createdAt: existing.exists ? existing.get("createdAt") || FieldValue.serverTimestamp() : FieldValue.serverTimestamp(),
         updatedAt: FieldValue.serverTimestamp(),
       },
@@ -234,7 +280,7 @@ export async function saveFirebaseTimelineDocument(
   return toTimelineDocument(snapshot.id, snapshot.data() as TimelineDocumentRecord);
 }
 
-export async function createFirebaseTimelineProject(title?: string) {
+export async function createFirebaseTimelineProject(requesterUid: string, title?: string) {
   const id = `project-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const cleanTitle = title?.trim().slice(0, 80) || "Untitled Project";
   const document: TimelineDocument = {
@@ -243,16 +289,19 @@ export async function createFirebaseTimelineProject(title?: string) {
     description: "Custom timeline project.",
     clips: [],
   };
-  await saveFirebaseTimelineDocument(document, { isProject: true });
+  await saveFirebaseTimelineDocument(document, requesterUid, { isProject: true });
   return document;
 }
 
-export async function deleteFirebaseTimelineDocument(id: string) {
+export async function deleteFirebaseTimelineDocument(id: string, requesterUid: string) {
   const ref = collection().doc(id);
   const docSnap = await withFirebaseTimeout(ref.get(), "Loading timeline document for deletion");
-  
+
   if (docSnap.exists) {
     const data = docSnap.data() as TimelineDocumentRecord;
+    if (resolveOwnership(data.ownerUid, requesterUid) === "denied") {
+      throw new TimelineAccessDeniedError(id);
+    }
     const document = data.document;
     if (document && document.clips) {
       const deleteQueue: string[] = [];
@@ -264,9 +313,16 @@ export async function deleteFirebaseTimelineDocument(id: string) {
         }
       };
       extractChildTimelineIds(document.clips);
-      
+
       for (const childId of deleteQueue) {
-        await deleteFirebaseTimelineDocument(childId);
+        try {
+          await deleteFirebaseTimelineDocument(childId, requesterUid);
+        } catch (error) {
+          // A child owned by someone else (shouldn't happen, but ids are
+          // attacker-suppliable in stored clips) is skipped, not fatal —
+          // the requester's own tree still deletes.
+          if (!(error instanceof TimelineAccessDeniedError)) throw error;
+        }
       }
     }
   }

--- a/apps/timeline-gstudio001/lib/timeline-ownership.test.ts
+++ b/apps/timeline-gstudio001/lib/timeline-ownership.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { checkUserScopedId, resolveOwnership } from "./timeline-ownership";
+
+describe("resolveOwnership", () => {
+  it("owns records stamped with the requester's uid", () => {
+    expect(resolveOwnership("user-a", "user-a")).toBe("owned");
+  });
+
+  it("denies records stamped with another uid", () => {
+    expect(resolveOwnership("user-b", "user-a")).toBe("denied");
+  });
+
+  it("claims legacy records with no owner", () => {
+    expect(resolveOwnership(undefined, "user-a")).toBe("claim");
+    expect(resolveOwnership(null, "user-a")).toBe("claim");
+    expect(resolveOwnership("", "user-a")).toBe("claim");
+  });
+});
+
+describe("checkUserScopedId", () => {
+  it("passes the requester's own trash and asset-library ids", () => {
+    expect(checkUserScopedId("trash-user-a", "user-a")).toBe(true);
+    expect(checkUserScopedId("asset-library-user-a", "user-a")).toBe(true);
+    expect(checkUserScopedId("asset-library-col-user-a-Zm9sZGVy", "user-a")).toBe(true);
+  });
+
+  it("rejects another user's scoped ids", () => {
+    expect(checkUserScopedId("trash-user-b", "user-a")).toBe(false);
+    expect(checkUserScopedId("asset-library-user-b", "user-a")).toBe(false);
+    expect(checkUserScopedId("asset-library-col-user-b-Zm9sZGVy", "user-a")).toBe(false);
+  });
+
+  it("rejects prefix-forged ids (a uid that PREFIXES the requester's)", () => {
+    // trash-user-a is NOT a valid id for a user whose uid is "user-a2".
+    expect(checkUserScopedId("trash-user-a", "user-a2")).toBe(false);
+    expect(checkUserScopedId("asset-library-col-user-a-x", "user-a2")).toBe(false);
+  });
+
+  it("returns null for ids that carry no embedded owner", () => {
+    expect(checkUserScopedId("project-123", "user-a")).toBeNull();
+    expect(checkUserScopedId("timeline-abc", "user-a")).toBeNull();
+  });
+});

--- a/apps/timeline-gstudio001/lib/timeline-ownership.ts
+++ b/apps/timeline-gstudio001/lib/timeline-ownership.ts
@@ -1,0 +1,58 @@
+// Pure ownership rules for timeline documents — no Firebase imports, so the
+// authorization decision itself is unit-testable in isolation. Enforcement
+// lives in lib/firebase-timeline-store.ts (every store function requires the
+// requester's uid); routes additionally pre-check user-scoped ids.
+
+/**
+ * The one access rule:
+ *
+ * - `owned`  — the record belongs to the requester.
+ * - `claim`  — the record predates ownership stamping (no ownerUid). It is
+ *   CLAIMED by the first authenticated user who touches it — a self-executing
+ *   migration for legacy documents, chosen deliberately over treating them as
+ *   public or breaking the existing user's access until a manual script runs.
+ *   The exposure window is deploy-until-the-owner's-next-visit; after that
+ *   every document is stamped and strictly enforced.
+ * - `denied` — the record belongs to someone else.
+ */
+export type OwnershipDecision = "owned" | "claim" | "denied";
+
+export function resolveOwnership(
+  recordOwnerUid: string | null | undefined,
+  requesterUid: string,
+): OwnershipDecision {
+  if (recordOwnerUid === null || recordOwnerUid === undefined || recordOwnerUid === "") {
+    return "claim";
+  }
+  return recordOwnerUid === requesterUid ? "owned" : "denied";
+}
+
+/**
+ * Some timeline ids embed their owner's uid by construction (`trash-<uid>`,
+ * `asset-library-<uid>`, `asset-library-col-<uid>-<folder>`). For those the
+ * check needs no storage read at all.
+ *
+ * Returns `null` when the id is not user-scoped (ownership must come from
+ * the stored record), otherwise whether the embedded uid is the requester's.
+ */
+export function checkUserScopedId(id: string, requesterUid: string): boolean | null {
+  if (id.startsWith("trash-")) {
+    return id === `trash-${requesterUid}`;
+  }
+  if (id.startsWith("asset-library-col-")) {
+    return id.startsWith(`asset-library-col-${requesterUid}-`);
+  }
+  if (id.startsWith("asset-library-")) {
+    return id === `asset-library-${requesterUid}`;
+  }
+  return null;
+}
+
+/** Thrown by the store when a document belongs to a different user. Routes
+ *  map it to 404 — a plain not-found, so ids can't be probed for existence. */
+export class TimelineAccessDeniedError extends Error {
+  constructor(id: string) {
+    super(`Access to timeline "${id}" was denied.`);
+    this.name = "TimelineAccessDeniedError";
+  }
+}

--- a/apps/timeline-gstudio001/vitest.config.ts
+++ b/apps/timeline-gstudio001/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   test: {
     environment: "node",
     include: [
+      "app/**/*.test.ts",
       "components/timeline/**/*.test.ts",
       "lib/**/*.test.ts",
       "../../packages/ui/timeline/**/*.test.ts",


### PR DESCRIPTION
Any authenticated user could previously read, overwrite, or delete any timeline document — requireAuthUser() checked WHO you are but nothing checked WHETHER you owned the document you asked for. The project list returned every document in the collection, making ids discoverable.

lib/timeline-ownership.ts: pure ownership rules, no Firebase imports. resolveOwnership(recordOwnerUid, requesterUid) -> owned | claim | denied. "claim" is deliberate: a legacy document with no ownerUid is stamped to the first authenticated user who touches it — a self-executing migration, chosen over treating pre-existing documents as public or breaking current access until a manual script runs. checkUserScopedId validates trash-<uid>/asset-library-<uid> ids against their embedded owner before any storage read, including prefix-forgery (uid "a" can't reach "trash-a2"). TimelineAccessDeniedError maps to 404 everywhere — not 403 — so ids can't be probed for existence.

lib/firebase-timeline-store.ts: every function now REQUIRES the requester's uid (the compiler forces every caller to thread identity). list scans+claims unowned+filters others; get/save/delete all enforce resolveOwnership; save stamps ownerUid on create (existing ?? requester, covering children minted implicitly through cross-document PATCH); delete's recursive child cleanup skips a denied child instead of failing the whole tree (child ids inside stored clips are attacker-suppliable).

Routes (timelines/route.ts, timelines/[id]/route.ts, trash/route.ts) thread the authenticated uid through every call and pre-check user-scoped ids before touching storage.

Folds in review finding #5 (Cloudinary listing multiplication): a per-user 60s TTL cache in cloudinary-media-store.ts stores the PROMISE, so the graph view's eager-hydration burst of many timeline GETs shares one Cloudinary listing instead of one each. Uploads/deletes invalidate; failures are never cached.

Tests exercise the REAL route handlers and REAL store enforcement against an in-memory fake Firestore (only process boundaries mocked: Firestore SDK, session cookie, Cloudinary) — two-user cases for list, GET, PATCH, DELETE, legacy-claim-then-deny, and scoped-id rejection with zero storage access.