### PR TITLE
fix(gstudio001): graph-view small fixes — preview clock, palette retr…

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -205,6 +205,9 @@ function OpenKeyBoundary({ children }: Readonly<{ children: React.ReactNode }>) 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key !== "o" && event.key !== "O") return;
     if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
+    // A keyboard-grabbed card is mid-drag: navigating away now would strand
+    // the drag session in a view where its source card no longer exists.
+    if (store.getSnapshot().interaction.isDragging) return;
     const target = event.target as HTMLElement;
     // Never swallow typing (no editable fields render in the board today,
     // but a future rename input inside a card must not lose its "o").
@@ -476,7 +479,7 @@ function createNodeFromAsset(asset: CloudinaryAsset): CollectionItemNode {
 type AssetPaletteState =
   | Readonly<{ status: "loading" }>
   | Readonly<{ status: "error"; message: string }>
-  | Readonly<{ status: "ready"; assets: readonly CloudinaryAsset[] }>;
+  | Readonly<{ status: "ready"; assets: readonly CloudinaryAsset[]; truncated: boolean }>;
 
 const PALETTE_ASSET_LIMIT = 48;
 
@@ -551,11 +554,18 @@ function PaletteRail({ assets }: Readonly<{ assets: readonly CloudinaryAsset[] }
 function AssetPaletteDrawer({ open, onClose }: Readonly<{ open: boolean; onClose: () => void }>) {
   const [state, setState] = useState<AssetPaletteState>({ status: "loading" });
 
-  // Lazy: fetch on first open, keep for the session.
-  const fetchedRef = useRef(false);
+  // Lazy: fetch on first open, keep a SUCCESS for the session. Failures are
+  // never latched (the old fetched-once ref marked the attempt as done
+  // before it ran, so one transient error made the palette unrecoverable
+  // until reload): the error state has its own Retry, and closing an
+  // errored drawer resets it so the next open refetches.
+  const handleClose = () => {
+    if (state.status === "error") setState({ status: "loading" });
+    onClose();
+  };
+
   useEffect(() => {
-    if (!open || fetchedRef.current) return;
-    fetchedRef.current = true;
+    if (!open || state.status !== "loading") return;
     let cancelled = false;
     void (async () => {
       try {
@@ -569,7 +579,11 @@ function AssetPaletteDrawer({ open, onClose }: Readonly<{ open: boolean; onClose
           setState({ status: "error", message: result.error ?? "Could not load assets." });
           return;
         }
-        setState({ status: "ready", assets: result.assets.slice(0, PALETTE_ASSET_LIMIT) });
+        setState({
+          status: "ready",
+          assets: result.assets.slice(0, PALETTE_ASSET_LIMIT),
+          truncated: result.assets.length > PALETTE_ASSET_LIMIT,
+        });
       } catch (cause) {
         if (!cancelled) {
           setState({
@@ -582,7 +596,7 @@ function AssetPaletteDrawer({ open, onClose }: Readonly<{ open: boolean; onClose
     return () => {
       cancelled = true;
     };
-  }, [open]);
+  }, [open, state.status]);
 
   if (!open || typeof document === "undefined") return null;
 
@@ -608,7 +622,7 @@ function AssetPaletteDrawer({ open, onClose }: Readonly<{ open: boolean; onClose
             Drag a thumbnail into any timeline · Enter picks one up for keyboard placement
           </span>
           <span className="grow" />
-          <Button type="button" variant="ghost" size="sm" onClick={onClose}>
+          <Button type="button" variant="ghost" size="sm" onClick={handleClose}>
             Close
           </Button>
         </div>
@@ -623,9 +637,17 @@ function AssetPaletteDrawer({ open, onClose }: Readonly<{ open: boolean; onClose
           </div>
         )}
         {state.status === "error" && (
-          <p className="rounded-md border border-zinc-800 px-3 py-2 text-xs text-zinc-500">
-            {state.message}
-          </p>
+          <div className="flex items-center gap-3 rounded-md border border-zinc-800 px-3 py-2">
+            <p className="text-xs text-zinc-500">{state.message}</p>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setState({ status: "loading" })}
+            >
+              Retry
+            </Button>
+          </div>
         )}
         {state.status === "ready" &&
           (state.assets.length === 0 ? (
@@ -633,7 +655,15 @@ function AssetPaletteDrawer({ open, onClose }: Readonly<{ open: boolean; onClose
               No assets yet — upload some from the asset library on the storyboard view.
             </p>
           ) : (
-            <PaletteRail assets={state.assets} />
+            <>
+              <PaletteRail assets={state.assets} />
+              {state.truncated && (
+                <p className="mt-1 text-[10px] text-zinc-600">
+                  Showing the newest {PALETTE_ASSET_LIMIT} assets — the full library is on the
+                  storyboard view.
+                </p>
+              )}
+            </>
           ))}
       </aside>
     </section>,
@@ -1176,6 +1206,25 @@ function PreviewShell({
     [channel],
   );
 
+  // Time state and the channel outlive drill-in (the provider lives in a
+  // persistent layout), but a DIFFERENT focused timeline is a different
+  // clock: without a reset, drilling from 60s into a 10s timeline parks the
+  // transport at "60 / 10" with the playhead pinned to the end. Both
+  // effects write only the CHANNEL (the external clock) — the local `time`
+  // state follows through the subscription above, which is also what keeps
+  // the playhead and scrub surfaces in step.
+  useEffect(() => {
+    channel.set(0);
+  }, [channel, focusedId]);
+
+  // Edits can also shorten the projection UNDER a parked playhead (trim,
+  // delete, undo) — clamp to the new end rather than pointing past it.
+  const totalDuration =
+    clips.length > 0 ? clips[clips.length - 1].startTime + clips[clips.length - 1].duration : 0;
+  useEffect(() => {
+    if (channel.get() > totalDuration) channel.set(totalDuration);
+  }, [channel, totalDuration]);
+
   // Created ONCE (lazy useState), never per render: the provider consumes
   // initialState only on its first render, and this component re-renders on
   // every playback tick (up to 30Hz) — building it inline JSON-cloned every
@@ -1559,12 +1608,13 @@ function SyncPanel({ entries }: { entries: readonly SyncEntry[] }) {
   return (
     <div className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-3">
       <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-zinc-500">
-        Patch-scoped document saves
+        Patch-scoped document writes
       </h3>
       {entries.length === 0 ? (
         <p className="mt-2 text-xs text-zinc-500">
-          No saves yet — reorder, trim, nest, or undo and watch which timeline documents get
-          PATCHed. Hydration never appears here: loading data is not a change worth writing back.
+          No writes yet — reorder, trim, nest, or undo and watch which timeline documents are
+          QUEUED for a PATCH (writes debounce briefly and any failure appears in the banner
+          above). Hydration never appears here: loading data is not a change worth writing back.
         </p>
       ) : (
         <ol className="mt-2 flex flex-col gap-1 font-mono text-[11px] text-zinc-400">

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
@@ -36,13 +36,18 @@ export type GraphDocumentsGateway = Readonly<{
   writeClips: (timelineId: string, clips: TimelineClip[]) => void;
   /** Cache-change notifications (documents landing, clips written). */
   subscribe: (listener: () => void) => () => void;
-  /** Most recent load/save failure, for a status banner. Cleared on success. */
+  /** Outstanding load/save failures, for a status banner. Null when every
+   *  document is healthy; multiple failures are all listed. */
   lastError: () => string | null;
 }>;
 
 export function createGraphDocumentsGateway(): GraphDocumentsGateway {
   let documents: DocumentsById = {};
-  let error: string | null = null;
+  // Errors are PER DOCUMENT: a successful write of one timeline must never
+  // clear (and thereby hide) another timeline's failed save — with a single
+  // last-error string, whichever request resolved last won.
+  const errors = new Map<string, string>();
+  let errorBanner: string | null = null;
   const inflight = new Map<string, Promise<TimelineDocument | null>>();
   const saveTimers = new Map<string, ReturnType<typeof setTimeout>>();
   const listeners = new Set<() => void>();
@@ -51,9 +56,14 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
     for (const listener of listeners) listener();
   };
 
-  const setError = (next: string | null) => {
-    if (error === next) return;
-    error = next;
+  const setError = (timelineId: string, next: string | null) => {
+    if (next === null) {
+      if (!errors.delete(timelineId)) return;
+    } else {
+      if (errors.get(timelineId) === next) return;
+      errors.set(timelineId, next);
+    }
+    errorBanner = errors.size === 0 ? null : [...errors.values()].join(" · ");
     notify();
   };
 
@@ -64,22 +74,28 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
       });
       if (!response.ok) {
         const result = (await response.json().catch(() => ({}))) as { error?: string };
-        setError(result.error || `Timeline "${timelineId}" failed to load (${response.status}).`);
+        setError(
+          timelineId,
+          result.error || `Timeline "${timelineId}" failed to load (${response.status}).`,
+        );
         return null;
       }
       const result = (await response.json().catch(() => ({}))) as {
         document?: TimelineDocument;
       };
       if (!result.document || result.document.id !== timelineId) {
-        setError(`Timeline "${timelineId}" returned an unexpected document.`);
+        setError(timelineId, `Timeline "${timelineId}" returned an unexpected document.`);
         return null;
       }
       documents = { ...documents, [timelineId]: result.document };
-      setError(null);
+      setError(timelineId, null);
       notify();
       return result.document;
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : `Timeline "${timelineId}" failed to load.`);
+      setError(
+        timelineId,
+        cause instanceof Error ? cause.message : `Timeline "${timelineId}" failed to load.`,
+      );
       return null;
     }
   };
@@ -94,13 +110,14 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
     }).then(
       (response) => {
         if (!response.ok) {
-          setError(`Saving "${document.title}" failed (${response.status}).`);
+          setError(timelineId, `Saving "${document.title}" failed (${response.status}).`);
         } else {
-          setError(null);
+          setError(timelineId, null);
         }
       },
       (cause: unknown) => {
         setError(
+          timelineId,
           cause instanceof Error ? cause.message : `Saving "${document.title}" failed.`,
         );
       },
@@ -142,7 +159,7 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
         listeners.delete(listener);
       };
     },
-    lastError: () => error,
+    lastError: () => errorBanner,
   };
 }
 

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -509,6 +509,15 @@ test.describe("graph view E2E", () => {
     await page.mouse.up();
 
     await expect.poll(translateX).toBeGreaterThan(before + 100);
+
+    // Drill-in RESETS the persistent preview clock: the layout (and with it
+    // the time channel) survives navigation, but a different focused
+    // timeline is a different clock — without the reset the transport would
+    // park at "long-timeline-time / short-timeline-duration".
+    await strip(page, PROJECT_ID).locator(`[data-node-id="${CHILD_ID}"]`).click();
+    await page.keyboard.press("o");
+    await page.waitForURL(`**${GRAPH_URL}/${CHILD_ID}`);
+    await expect.poll(translateX).toBeLessThan(20);
   });
 
   test("grid mode: playhead rides cells, scrubs horizontally and jumps rows", async ({


### PR DESCRIPTION
…y, O-key guard, honest errors

Four fixes from the second external review:

- Preview clock resets on drill-in and clamps when the projection shortens. The time channel outlives navigation (persistent layout), so drilling from a 60s timeline into a 10s one parked the transport at "60 / 10" with the playhead pinned to the end. Both effects write only the CHANNEL; local time state follows through the existing subscription — every playhead surface converges on the channel, and the react-hooks/set-state-in-effect rule forbids the sync-setState shape anyway.

- Palette failures are never latched: the old fetched-once ref marked the attempt done BEFORE the request ran, so one transient error made the palette unrecoverable until reload. Fetching is now keyed on status === "loading"; the error state has a Retry button; closing an errored drawer resets it so the next open refetches; and a truncation note appears when the 48-asset cap drops results.

- "O to open" is ignored while a keyboard drag is active — navigating mid-drag would strand the drag session in a view where its source card no longer exists.

- Gateway errors are per-document: with a single last-error string, whichever request resolved last won, so one timeline's successful save could clear and hide another timeline's failed save. The banner now joins every outstanding failure and a success clears only its own document's entry. SyncPanel wording no longer claims documents were saved when writes were only queued behind the debounce.

e2e: preview test extended — scrub far, drill in via O, assert the playhead reset near zero.