### PR TITLE
feat(gstudio001): persistence hardening — write serialization, pagehi…

### DIFF
--- a/apps/timeline-gstudio001/app/api/timelines/[id]/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/[id]/route.ts
@@ -15,6 +15,10 @@ import {
   isUnsavedProjectPlaceholder,
 } from "@storyboard/ui/timeline/timeline-documents";
 import { listCloudinaryAssets } from "@/lib/cloudinary-media-store";
+import {
+  collectionChildIds,
+  deriveCollectionSummaries,
+} from "@/lib/derive-collection-summaries";
 import { healTimelineDocument } from "@/lib/heal-timeline-document";
 import { checkUserScopedId, TimelineAccessDeniedError } from "@/lib/timeline-ownership";
 
@@ -259,7 +263,22 @@ export async function GET(
         await saveFirebaseTimelineDocument(healedDocument, user.uid).catch(() => {});
       }
 
-      return NextResponse.json({ document: healedDocument });
+      // Collection summaries derive from the CHILD documents at read time
+      // (see deriveCollectionSummaries) — served fresh, never persisted. A
+      // child that fails to load (missing, or not this user's) keeps the
+      // stored summary.
+      const childIds = collectionChildIds(healedDocument);
+      const childDocuments = new Map(
+        await Promise.all(
+          childIds.map(async (childId) => {
+            const child = await getFirebaseTimelineDocument(childId, user.uid).catch(() => null);
+            return [childId, child] as const;
+          }),
+        ),
+      );
+      const derived = deriveCollectionSummaries(healedDocument, childDocuments);
+
+      return NextResponse.json({ document: derived.document });
     }
 
     const fallbackDocument = getTimelineDocument(id);

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -1787,6 +1787,12 @@ export function GraphTimelineView({ projectId }: { projectId: string }) {
   const trashDocId = user ? `trash-${user.uid}` : null;
   useEffect(() => {
     if (trashDocId === null) return; // auth still resolving (AuthGate guarantees a user)
+    // Entering the graph view must not trust the session cache: edits made in
+    // the storyboard view (or another tab) since the last graph session would
+    // otherwise be overwritten by full-document PATCHes built from stale
+    // content. `refresh` flushes pending writes and marks every cached id
+    // stale, so the `ensure` calls below (and hydrate-on-focus) refetch.
+    graphDocumentsGateway.refresh();
     let cancelled = false;
     void (async () => {
       const [projectDoc, trashDoc] = await Promise.all([

--- a/apps/timeline-gstudio001/lib/derive-collection-summaries.test.ts
+++ b/apps/timeline-gstudio001/lib/derive-collection-summaries.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  CollectionTimelineClip,
+  TimelineClip,
+  TimelineDocument,
+} from "@storyboard/ui/timeline/types";
+
+import { collectionChildIds, deriveCollectionSummaries } from "./derive-collection-summaries";
+
+function mediaClip(
+  id: string,
+  { startTime = 0, duration = 4 }: { startTime?: number; duration?: number } = {},
+): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "image",
+    src: `https://cdn.test/${id}.jpg`,
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime,
+    duration,
+    sourceDuration: duration,
+    trimIn: 0,
+    trimOut: 0,
+  };
+}
+
+function collectionClip(
+  id: string,
+  childTimelineId: string,
+  overrides: Partial<CollectionTimelineClip> = {},
+): CollectionTimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "collection",
+    title: "Stored Title",
+    childTimelineId,
+    itemCount: 0,
+    alt: "Stored Title collection",
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 3,
+    sourceDuration: 3,
+    trimIn: 0,
+    trimOut: 0,
+    ...overrides,
+  };
+}
+
+function docOf(id: string, clips: TimelineClip[], title = `Timeline ${id}`): TimelineDocument {
+  return { id, title, clips };
+}
+
+describe("deriveCollectionSummaries", () => {
+  it("derives title, itemCount, previewItems, and duration from the loaded child", () => {
+    const child = docOf(
+      "child-1",
+      [mediaClip("m1", { startTime: 0, duration: 4 }), mediaClip("m2", { startTime: 5, duration: 6 })],
+      "Fresh Child Title",
+    );
+    const parent = docOf("parent", [collectionClip("col", "child-1")]);
+
+    const { document, changed } = deriveCollectionSummaries(
+      parent,
+      new Map([["child-1", child]]),
+    );
+
+    expect(changed).toBe(true);
+    const summary = document.clips[0] as CollectionTimelineClip;
+    expect(summary.title).toBe("Fresh Child Title");
+    expect(summary.alt).toBe("Fresh Child Title collection");
+    expect(summary.itemCount).toBe(2);
+    // last.startTime + last.duration + leading padding (0)
+    expect(summary.duration).toBe(11);
+    expect(summary.sourceDuration).toBe(11);
+    expect(summary.previewItems).toEqual([
+      { id: "m1", kind: "image", src: "https://cdn.test/m1.jpg", poster: undefined, alt: "m1" },
+      { id: "m2", kind: "image", src: "https://cdn.test/m2.jpg", poster: undefined, alt: "m2" },
+    ]);
+  });
+
+  it("uses first/middle/last media when the child holds more than three clips", () => {
+    const child = docOf("child-1", [
+      mediaClip("m1"),
+      mediaClip("m2"),
+      mediaClip("m3"),
+      mediaClip("m4"),
+      mediaClip("m5"),
+    ]);
+    const parent = docOf("parent", [collectionClip("col", "child-1")]);
+
+    const { document } = deriveCollectionSummaries(parent, new Map([["child-1", child]]));
+    const summary = document.clips[0] as CollectionTimelineClip;
+    expect(summary.previewItems?.map((item) => item.id)).toEqual(["m1", "m3", "m5"]);
+  });
+
+  it("summarizes an empty child as duration 3 with no preview items", () => {
+    const child = docOf("child-1", []);
+    const parent = docOf("parent", [
+      collectionClip("col", "child-1", { itemCount: 5, duration: 20, sourceDuration: 20 }),
+    ]);
+
+    const { document, changed } = deriveCollectionSummaries(parent, new Map([["child-1", child]]));
+    expect(changed).toBe(true);
+    const summary = document.clips[0] as CollectionTimelineClip;
+    expect(summary.itemCount).toBe(0);
+    expect(summary.duration).toBe(3);
+    expect(summary.previewItems).toEqual([]);
+  });
+
+  it("keeps the stored title when the child's title is empty", () => {
+    const child = docOf("child-1", [], "");
+    const parent = docOf("parent", [collectionClip("col", "child-1", { itemCount: 1 })]);
+
+    const { document } = deriveCollectionSummaries(parent, new Map([["child-1", child]]));
+    expect((document.clips[0] as CollectionTimelineClip).title).toBe("Stored Title");
+  });
+
+  it("returns the same document unchanged when every summary is already in sync", () => {
+    const child = docOf("child-1", [mediaClip("m1", { startTime: 0, duration: 5 })], "Synced");
+    const parent = docOf("parent", [
+      collectionClip("col", "child-1", {
+        title: "Synced",
+        itemCount: 1,
+        duration: 5,
+        sourceDuration: 5,
+        previewItems: [
+          { id: "m1", kind: "image", src: "https://cdn.test/m1.jpg", poster: undefined, alt: "m1" },
+        ],
+      }),
+    ]);
+
+    const result = deriveCollectionSummaries(parent, new Map([["child-1", child]]));
+    expect(result.changed).toBe(false);
+    expect(result.document).toBe(parent);
+  });
+
+  it("leaves the stored summary for missing or unloadable children — stale beats blank", () => {
+    const parent = docOf("parent", [
+      collectionClip("col-a", "child-absent", { itemCount: 4, duration: 12, sourceDuration: 12 }),
+      collectionClip("col-b", "child-null", { itemCount: 2, duration: 7, sourceDuration: 7 }),
+    ]);
+
+    const result = deriveCollectionSummaries(parent, new Map([["child-null", null]]));
+    expect(result.changed).toBe(false);
+    expect(result.document).toBe(parent);
+  });
+
+  it("repacks the document when a derived duration moves the following clips", () => {
+    const child = docOf("child-1", [mediaClip("m1", { startTime: 0, duration: 11 })], "Grown");
+    const parent = docOf("parent", [
+      collectionClip("col", "child-1", { startTime: 0, duration: 3, sourceDuration: 3 }),
+      mediaClip("after", { startTime: 3.12, duration: 4 }),
+    ]);
+
+    const { document, changed } = deriveCollectionSummaries(parent, new Map([["child-1", child]]));
+    expect(changed).toBe(true);
+    expect(document.clips[0].duration).toBe(11);
+    expect(document.clips[0].startTime).toBe(0);
+    // duration + CLIP_GAP_SECONDS
+    expect(document.clips[1].startTime).toBeCloseTo(11.12, 10);
+    expect(document.clips.map((entry) => entry.index)).toEqual([0, 1]);
+  });
+});
+
+describe("collectionChildIds", () => {
+  it("collects unique child ids from collection clips only", () => {
+    const parent = docOf("parent", [
+      collectionClip("col-a", "child-1"),
+      mediaClip("m1"),
+      collectionClip("col-b", "child-2"),
+      collectionClip("col-c", "child-1"),
+    ]);
+
+    expect(collectionChildIds(parent)).toEqual(["child-1", "child-2"]);
+  });
+});

--- a/apps/timeline-gstudio001/lib/derive-collection-summaries.ts
+++ b/apps/timeline-gstudio001/lib/derive-collection-summaries.ts
@@ -1,0 +1,82 @@
+import { TIMELINE_LEADING_PADDING_SECONDS } from "@storyboard/ui/timeline/constants";
+import {
+  packTimelineClips,
+  previewItemsFrom,
+} from "@storyboard/ui/timeline/timeline-documents";
+import type { TimelineDocument } from "@storyboard/ui/timeline/types";
+
+// Read-time derivation of collection-clip summaries (review finding: stale
+// parents). A collection clip stores DENORMALIZED child facts — title,
+// itemCount, previewItems, duration — and the graph view's patch-scoped
+// writes only touch the directly edited document, so a child edit leaves
+// every referring parent's stored summary stale. Rather than maintaining a
+// reverse-reference index and widening every write, the summaries are
+// recomputed when a document is SERVED: every view loads through the same
+// GET route, so no reader ever sees a stale summary, and the stored fields
+// become a cache that regenerates on read.
+//
+// The recompute mirrors the legacy store's own
+// `syncParentCollectionsInState` exactly (same previewItemsFrom, same
+// duration formula, same repack) so the two write paths can't drift apart.
+//
+// Served, not persisted: writing back on every GET would add load and
+// races for a value the next GET rederives anyway.
+
+export function deriveCollectionSummaries(
+  document: TimelineDocument,
+  childDocuments: ReadonlyMap<string, TimelineDocument | null>,
+): { document: TimelineDocument; changed: boolean } {
+  let changed = false;
+
+  const clips = document.clips.map((clip) => {
+    if (clip.kind !== "collection") return clip;
+    const child = childDocuments.get(clip.childTimelineId);
+    // Unknown child (not fetched, missing, or someone else's): leave the
+    // stored summary — stale beats blank.
+    if (!child) return clip;
+
+    const title = child.title || clip.title;
+    const itemCount = child.clips.length;
+    const previewItems = previewItemsFrom(child.clips);
+    let duration = 3;
+    if (child.clips.length > 0) {
+      const last = child.clips[child.clips.length - 1];
+      duration = last.startTime + last.duration + TIMELINE_LEADING_PADDING_SECONDS;
+    }
+
+    if (
+      clip.title === title &&
+      clip.itemCount === itemCount &&
+      clip.duration === duration &&
+      clip.sourceDuration === duration &&
+      JSON.stringify(clip.previewItems ?? []) === JSON.stringify(previewItems)
+    ) {
+      return clip;
+    }
+
+    changed = true;
+    return {
+      ...clip,
+      title,
+      alt: `${title} collection`,
+      itemCount,
+      previewItems,
+      duration,
+      sourceDuration: duration,
+    };
+  });
+
+  if (!changed) return { document, changed: false };
+  // A duration change moves every following clip — repack, exactly as the
+  // legacy sync does.
+  return { document: { ...document, clips: packTimelineClips(clips) }, changed: true };
+}
+
+/** The child ids a derivation pass for this document would want loaded. */
+export function collectionChildIds(document: TimelineDocument): string[] {
+  const ids = new Set<string>();
+  for (const clip of document.clips) {
+    if (clip.kind === "collection" && clip.childTimelineId) ids.add(clip.childTimelineId);
+  }
+  return [...ids];
+}

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TimelineClip, TimelineDocument } from "@storyboard/ui/timeline/types";
+
+import { createGraphDocumentsGateway } from "./graph-documents-gateway";
+
+const SAVE_DEBOUNCE_MS = 900;
+
+function clip(id: string, startTime = 0): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "video",
+    src: `https://cdn.test/${id}.mp4`,
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime,
+    duration: 4,
+    sourceDuration: 4,
+    trimIn: 0,
+    trimOut: 0,
+  };
+}
+
+function doc(id: string, clips: TimelineClip[] = []): TimelineDocument {
+  return { id, title: `Timeline ${id}`, clips };
+}
+
+type MockResponse = { ok: boolean; status: number; json: () => Promise<unknown> };
+
+function jsonResponse(body: unknown, status = 200): MockResponse {
+  return { ok: status >= 200 && status < 300, status, json: () => Promise.resolve(body) };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+type FetchCall = {
+  method: string;
+  id: string;
+  body?: TimelineDocument;
+  keepalive?: boolean;
+};
+
+/** Stubs global fetch; returns the recorded calls for assertions. */
+function installFetch(handler: (call: FetchCall) => Promise<MockResponse> | MockResponse) {
+  const calls: FetchCall[] = [];
+  const impl = (input: RequestInfo | URL, init?: RequestInit) => {
+    const call: FetchCall = {
+      method: init?.method ?? "GET",
+      id: decodeURIComponent(String(input).split("/").pop() ?? ""),
+      body:
+        typeof init?.body === "string"
+          ? (JSON.parse(init.body) as { document: TimelineDocument }).document
+          : undefined,
+      keepalive: init?.keepalive,
+    };
+    calls.push(call);
+    return Promise.resolve(handler(call));
+  };
+  vi.stubGlobal("fetch", impl as unknown as typeof fetch);
+  return calls;
+}
+
+const patchesOf = (calls: FetchCall[]) => calls.filter((call) => call.method === "PATCH");
+const getsOf = (calls: FetchCall[]) => calls.filter((call) => call.method === "GET");
+const clipIds = (document: TimelineDocument | null | undefined) =>
+  document?.clips.map((entry) => entry.id);
+
+describe("graph-documents-gateway", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("ensure fetches once, dedupes concurrent calls, and serves the cache afterward", async () => {
+    const calls = installFetch(() => jsonResponse({ document: doc("a", [clip("a1")]) }));
+    const gateway = createGraphDocumentsGateway();
+
+    const [first, second] = await Promise.all([gateway.ensure("a"), gateway.ensure("a")]);
+    expect(first).not.toBeNull();
+    expect(first).toBe(second);
+    expect(getsOf(calls)).toHaveLength(1);
+
+    await gateway.ensure("a");
+    expect(getsOf(calls)).toHaveLength(1);
+    expect(clipIds(gateway.peek("a"))).toEqual(["a1"]);
+  });
+
+  it("writeClips is a no-op for documents the session has not loaded", async () => {
+    const calls = installFetch(() => jsonResponse({}));
+    const gateway = createGraphDocumentsGateway();
+
+    gateway.writeClips("ghost", [clip("g1")]);
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("coalesces rapid writes into one debounced PATCH carrying the latest clips", async () => {
+    const calls = installFetch((call) =>
+      call.method === "PATCH"
+        ? jsonResponse({ document: call.body })
+        : jsonResponse({ document: doc("a", [clip("a1")]) }),
+    );
+    const gateway = createGraphDocumentsGateway();
+    await gateway.ensure("a");
+
+    gateway.writeClips("a", [clip("a2")]);
+    gateway.writeClips("a", [clip("a3")]);
+    expect(patchesOf(calls)).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+    const patches = patchesOf(calls);
+    expect(patches).toHaveLength(1);
+    expect(clipIds(patches[0].body)).toEqual(["a3"]);
+  });
+
+  it("serializes PATCHes per document: a write during a flight queues one trailing PATCH with the latest cache", async () => {
+    const firstSave = deferred<MockResponse>();
+    let patchCount = 0;
+    const calls = installFetch((call) => {
+      if (call.method !== "PATCH") return jsonResponse({ document: doc("a", [clip("a1")]) });
+      patchCount += 1;
+      return patchCount === 1 ? firstSave.promise : jsonResponse({ document: call.body });
+    });
+    const gateway = createGraphDocumentsGateway();
+    await gateway.ensure("a");
+
+    gateway.writeClips("a", [clip("a2")]);
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+    expect(patchesOf(calls)).toHaveLength(1); // in flight, unresolved
+
+    // Two more edits land while the first PATCH is still out.
+    gateway.writeClips("a", [clip("a3")]);
+    gateway.writeClips("a", [clip("a4")]);
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+    expect(patchesOf(calls)).toHaveLength(1); // queued, not raced
+
+    firstSave.resolve(jsonResponse({ document: doc("a", [clip("a2")]) }));
+    await vi.advanceTimersByTimeAsync(0);
+    const patches = patchesOf(calls);
+    expect(patches).toHaveLength(2);
+    expect(clipIds(patches[1].body)).toEqual(["a4"]);
+  });
+
+  it("flushPendingWrites sends debounce-pending writes immediately, with keepalive", async () => {
+    const calls = installFetch((call) =>
+      call.method === "PATCH"
+        ? jsonResponse({ document: call.body })
+        : jsonResponse({ document: doc("a", [clip("a1")]) }),
+    );
+    const gateway = createGraphDocumentsGateway();
+    await gateway.ensure("a");
+
+    gateway.writeClips("a", [clip("a2")]);
+    gateway.flushPendingWrites({ keepalive: true });
+    const patches = patchesOf(calls);
+    expect(patches).toHaveLength(1);
+    expect(patches[0].keepalive).toBe(true);
+    expect(clipIds(patches[0].body)).toEqual(["a2"]);
+
+    // The debounce timer was consumed — no duplicate PATCH later.
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+    expect(patchesOf(calls)).toHaveLength(1);
+  });
+
+  it("refresh keeps cached content readable but makes ensure refetch it", async () => {
+    const secondLoad = deferred<MockResponse>();
+    let gets = 0;
+    const calls = installFetch((call) => {
+      if (call.method !== "GET") return jsonResponse({ document: call.body });
+      gets += 1;
+      return gets === 1 ? jsonResponse({ document: doc("a", [clip("v1")]) }) : secondLoad.promise;
+    });
+    const gateway = createGraphDocumentsGateway();
+    await gateway.ensure("a");
+    expect(getsOf(calls)).toHaveLength(1);
+
+    gateway.refresh();
+    const refetch = gateway.ensure("a");
+    // Stale content stays synchronously readable while the refetch runs.
+    expect(clipIds(gateway.peek("a"))).toEqual(["v1"]);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(getsOf(calls)).toHaveLength(2);
+
+    secondLoad.resolve(jsonResponse({ document: doc("a", [clip("v2")]) }));
+    await refetch;
+    expect(clipIds(gateway.peek("a"))).toEqual(["v2"]);
+
+    // Freshness restored: the next ensure serves the cache again.
+    await gateway.ensure("a");
+    expect(getsOf(calls)).toHaveLength(2);
+  });
+
+  it("a stale ensure waits for the in-flight save to settle before refetching", async () => {
+    const save = deferred<MockResponse>();
+    let gets = 0;
+    const calls = installFetch((call) => {
+      if (call.method === "PATCH") return save.promise;
+      gets += 1;
+      return jsonResponse({ document: doc("a", [clip(gets === 1 ? "v1" : "v2")]) });
+    });
+    const gateway = createGraphDocumentsGateway();
+    await gateway.ensure("a");
+    gateway.writeClips("a", [clip("v1b")]);
+
+    gateway.refresh(); // flushes: the PATCH goes out and stays in flight
+    expect(patchesOf(calls)).toHaveLength(1);
+
+    const refetch = gateway.ensure("a");
+    await vi.advanceTimersByTimeAsync(0);
+    // No GET yet — fetching before the save settles would read pre-save state.
+    expect(getsOf(calls)).toHaveLength(1);
+
+    save.resolve(jsonResponse({ document: doc("a", [clip("v1b")]) }));
+    const refetched = await refetch;
+    expect(getsOf(calls)).toHaveLength(2);
+    expect(clipIds(refetched)).toEqual(["v2"]);
+  });
+
+  it("keeps per-document errors: one document's success does not clear another's failure", async () => {
+    let badFails = true;
+    const calls = installFetch((call) => {
+      if (call.method !== "PATCH") return jsonResponse({ document: doc(call.id, [clip("seed")]) });
+      if (call.body?.id === "bad" && badFails) return jsonResponse({}, 500);
+      return jsonResponse({ document: call.body });
+    });
+    const gateway = createGraphDocumentsGateway();
+    await gateway.ensure("bad");
+    await gateway.ensure("good");
+
+    gateway.writeClips("bad", [clip("x")]);
+    gateway.writeClips("good", [clip("y")]);
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+    expect(gateway.lastError()).toContain('Saving "Timeline bad" failed (500).');
+    expect(calls.length).toBeGreaterThan(0);
+
+    // "good" saving again must not hide "bad"'s standing failure.
+    gateway.writeClips("good", [clip("y2")]);
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+    expect(gateway.lastError()).toContain("Timeline bad");
+
+    // Only "bad" itself succeeding clears it.
+    badFails = false;
+    gateway.writeClips("bad", [clip("x2")]);
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+    expect(gateway.lastError()).toBeNull();
+  });
+});

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
@@ -39,6 +39,22 @@ export type GraphDocumentsGateway = Readonly<{
   /** Outstanding load/save failures, for a status banner. Null when every
    *  document is healthy; multiple failures are all listed. */
   lastError: () => string | null;
+  /**
+   * Send every debounce-pending write NOW. Called on pagehide/hidden (with
+   * keepalive, so the requests survive the tab closing) and before a
+   * refresh — closing the tab inside the debounce window must not lose the
+   * last edit.
+   */
+  flushPendingWrites: (options?: { keepalive?: boolean }) => void;
+  /**
+   * Entering the graph view calls this: every cached document is marked
+   * STALE, so `ensure` refetches it (after any in-flight save settles)
+   * instead of trusting the session cache. Without it, edits made in the
+   * storyboard view (or another tab) between graph sessions would be
+   * overwritten by the next full-document PATCH built from stale content.
+   * Cached content stays readable until the refetch lands.
+   */
+  refresh: () => void;
 }>;
 
 export function createGraphDocumentsGateway(): GraphDocumentsGateway {
@@ -50,6 +66,15 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
   let errorBanner: string | null = null;
   const inflight = new Map<string, Promise<TimelineDocument | null>>();
   const saveTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  // Writes are SERIALIZED per document: at most one PATCH in flight, and a
+  // write requested meanwhile is queued to run after it — always carrying
+  // the LATEST cached document. Without this, an older in-flight PATCH
+  // could reach the server after a newer one and win.
+  const savesInFlight = new Map<string, Promise<void>>();
+  const saveQueued = new Set<string>();
+  // Ids whose cached content predates the current graph session (see
+  // `refresh`): readable, but `ensure` refetches them.
+  let staleIds = new Set<string>();
   const listeners = new Set<() => void>();
 
   const notify = () => {
@@ -100,13 +125,20 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
     }
   };
 
-  const persist = (timelineId: string) => {
+  const persist = (timelineId: string, options?: { keepalive?: boolean }) => {
+    if (savesInFlight.has(timelineId)) {
+      saveQueued.add(timelineId);
+      return;
+    }
     const document = documents[timelineId];
     if (!document) return;
-    void fetch(`/api/timelines/${encodeURIComponent(timelineId)}`, {
+    const flight = fetch(`/api/timelines/${encodeURIComponent(timelineId)}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ document }),
+      // keepalive lets the request outlive an unloading page (pagehide
+      // flush). Not the default: keepalive bodies are capped (~64KB).
+      ...(options?.keepalive ? { keepalive: true } : {}),
     }).then(
       (response) => {
         if (!response.ok) {
@@ -122,19 +154,57 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
         );
       },
     );
+    savesInFlight.set(
+      timelineId,
+      flight.then(() => {
+        savesInFlight.delete(timelineId);
+        // Trailing write: edits that landed mid-flight go out now, from the
+        // latest cache.
+        if (saveQueued.delete(timelineId)) persist(timelineId);
+      }),
+    );
   };
+
+  const flushPendingWrites = (options?: { keepalive?: boolean }) => {
+    for (const [timelineId, timer] of [...saveTimers]) {
+      clearTimeout(timer);
+      saveTimers.delete(timelineId);
+      persist(timelineId, options);
+    }
+  };
+
+  if (typeof window !== "undefined") {
+    // Closing or backgrounding the tab inside the debounce window must not
+    // lose the last edit. pagehide is the unload signal; hidden visibility
+    // additionally covers mobile tab kills (and an early flush is harmless).
+    window.addEventListener("pagehide", () => flushPendingWrites({ keepalive: true }));
+    window.addEventListener("visibilitychange", () => {
+      if (window.document.visibilityState === "hidden") {
+        flushPendingWrites({ keepalive: true });
+      }
+    });
+  }
 
   return {
     read: () => documents,
     peek: (timelineId) => documents[timelineId] ?? null,
     ensure: (timelineId) => {
       const cached = documents[timelineId];
-      if (cached) return Promise.resolve(cached);
+      if (cached && !staleIds.has(timelineId)) return Promise.resolve(cached);
       const pending = inflight.get(timelineId);
       if (pending) return pending;
-      const request = fetchDocument(timelineId).finally(() => {
-        inflight.delete(timelineId);
-      });
+      // A stale doc may still have a save in flight (flushed on refresh) —
+      // fetching before it settles would read the pre-save server state.
+      const settled = savesInFlight.get(timelineId) ?? Promise.resolve();
+      const request = settled
+        .then(() => fetchDocument(timelineId))
+        .then((document) => {
+          if (document !== null) staleIds.delete(timelineId);
+          return document;
+        })
+        .finally(() => {
+          inflight.delete(timelineId);
+        });
       inflight.set(timelineId, request);
       return request;
     },
@@ -160,6 +230,11 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
       };
     },
     lastError: () => errorBanner,
+    flushPendingWrites,
+    refresh: () => {
+      flushPendingWrites();
+      staleIds = new Set(Object.keys(documents));
+    },
   };
 }
 

--- a/packages/ui/timeline/timeline-documents.ts
+++ b/packages/ui/timeline/timeline-documents.ts
@@ -92,7 +92,9 @@ function createCollectionClip({
   };
 }
 
-function previewItemsFrom(clips: TimelineClip[]) {
+// Exported: server-side summary derivation (gstudio's timeline GET) must
+// produce byte-identical previews to this store's own recompute.
+export function previewItemsFrom(clips: TimelineClip[]) {
   const mediaClips = clips.filter(
     (clip) => clip.kind === "image" || clip.kind === "video",
   );


### PR DESCRIPTION
…de flush, refresh-on-entry, read-time summaries

Review-2 findings #2, #3 (client half), #4:

- Gateway serializes PATCHes per document: at most one in flight, an edit landing mid-flight queues one trailing PATCH re-read from the latest cache, so an older request can never land after a newer one and win.
- flushPendingWrites({keepalive}) drains debounce timers immediately; wired to pagehide + visibilitychange-hidden so closing the tab inside the debounce window no longer loses the last edit.
- refresh() flushes and marks every cached id stale; the graph-view boot effect calls it, so entering the view refetches instead of trusting the session cache (storyboard/other-tab edits would otherwise be clobbered by full-document PATCHes built from stale content). A stale ensure waits for that id's in-flight save before refetching.
- Collection-clip summaries (title/itemCount/previewItems/duration) are recomputed from child documents when a document is SERVED (GET), mirroring the legacy syncParentCollectionsInState exactly via the now-exported previewItemsFrom. Served fresh, never persisted; a child that fails to load keeps its stored summary.

Tests: 15 new unit tests (gateway behavior under fake timers + stubbed fetch; summary derivation incl. repack and no-op cases). Full vitest 54/54, graph-view e2e 10/10, typecheck + lint clean.