### PR TITLE
feat(gstudio001): transactional batch writes with expected revisions …

### DIFF
--- a/apps/timeline-gstudio001/app/api/timelines/[id]/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/[id]/route.ts
@@ -3,7 +3,8 @@ import { NextResponse } from "next/server";
 import type { TimelineDocument, TimelineClip } from "@storyboard/ui/timeline/types";
 import {
   getFirebaseTimelineDocument,
-  saveFirebaseTimelineDocument,
+  getFirebaseTimelineEntry,
+  saveFirebaseTimelineEntry,
   deleteFirebaseTimelineDocument,
 } from "@/lib/firebase-timeline-store";
 import { requireAuthUser } from "@/lib/firebase-auth-session";
@@ -79,13 +80,14 @@ export async function GET(
     if (mismatch) return mismatch;
 
     if (id.startsWith("trash-")) {
-      const firebaseDocument = await getFirebaseTimelineDocument(id, user.uid);
-      const doc: TimelineDocument = firebaseDocument || {
+      const entry = await getFirebaseTimelineEntry(id, user.uid);
+      const doc: TimelineDocument = entry?.document || {
         id,
         title: "Trash Bin",
         clips: [],
       };
-      return NextResponse.json({ document: doc });
+      // revision 0 = not stored yet; a batch write expecting 0 creates it.
+      return NextResponse.json({ document: doc, revision: entry?.revision ?? 0 });
     }
 
     if (!isValidTimelineId(id)) {
@@ -248,19 +250,24 @@ export async function GET(
       });
     }
 
-    const firebaseDocument = await getFirebaseTimelineDocument(id, user.uid);
-    if (firebaseDocument) {
+    const entry = await getFirebaseTimelineEntry(id, user.uid);
+    if (entry) {
       // Load-time self-heal: re-point moved/renamed Cloudinary assets AND
       // backfill real video durations onto untrimmed clips (see
       // healTimelineDocument). Persisted only when something actually changed.
       const cloudinaryAssets = await listCloudinaryAssets(user.uid).catch(() => []);
       const { document: healedDocument, changed } = healTimelineDocument(
-        firebaseDocument,
+        entry.document,
         cloudinaryAssets,
       );
 
+      // The served revision must reflect the heal write (it bumps the
+      // counter) or the client's first expected-revision write would
+      // conflict spuriously.
+      let revision = entry.revision;
       if (changed) {
-        await saveFirebaseTimelineDocument(healedDocument, user.uid).catch(() => {});
+        const saved = await saveFirebaseTimelineEntry(healedDocument, user.uid).catch(() => null);
+        if (saved) revision = saved.revision;
       }
 
       // Collection summaries derive from the CHILD documents at read time
@@ -278,7 +285,7 @@ export async function GET(
       );
       const derived = deriveCollectionSummaries(healedDocument, childDocuments);
 
-      return NextResponse.json({ document: derived.document });
+      return NextResponse.json({ document: derived.document, revision });
     }
 
     const fallbackDocument = getTimelineDocument(id);
@@ -286,8 +293,8 @@ export async function GET(
       return NextResponse.json({ error: "Timeline was not found." }, { status: 404 });
     }
 
-    const savedDocument = await saveFirebaseTimelineDocument(fallbackDocument, user.uid);
-    return NextResponse.json({ document: savedDocument });
+    const saved = await saveFirebaseTimelineEntry(fallbackDocument, user.uid);
+    return NextResponse.json({ document: saved.document, revision: saved.revision });
   } catch (error) {
     return storageErrorResponse(error, "Unable to load the timeline document.");
   }
@@ -323,8 +330,12 @@ export async function PATCH(
       );
     }
 
-    const savedDocument = await saveFirebaseTimelineDocument(body.document, user.uid);
-    return NextResponse.json({ document: savedDocument });
+    // No expected revision on the single-document path: legacy views keep
+    // last-write-wins. The response still carries the stamped revision so
+    // any caller can start carrying expectations (the batch endpoint is the
+    // compare-and-set path).
+    const saved = await saveFirebaseTimelineEntry(body.document, user.uid);
+    return NextResponse.json({ document: saved.document, revision: saved.revision });
   } catch (error) {
     if (
       error instanceof Error &&

--- a/apps/timeline-gstudio001/app/api/timelines/batch/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/batch/route.ts
@@ -1,0 +1,138 @@
+import { NextResponse } from "next/server";
+
+import type { TimelineDocument } from "@storyboard/ui/timeline/types";
+import { isUnsavedProjectPlaceholder } from "@storyboard/ui/timeline/timeline-documents";
+import { requireAuthUser } from "@/lib/firebase-auth-session";
+import {
+  saveFirebaseTimelineDocumentsAtomic,
+  TimelineRevisionConflictError,
+  type TimelineBatchWrite,
+} from "@/lib/firebase-timeline-store";
+import { checkUserScopedId, TimelineAccessDeniedError } from "@/lib/timeline-ownership";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// One graph change can touch a handful of documents (a cross-timeline move
+// touches two, plus a trash drop). Far below Firestore's transaction limit;
+// anything larger than this is a malformed client.
+const MAX_BATCH_WRITES = 25;
+
+function isValidTimelineId(id: string) {
+  return /^[a-zA-Z0-9_-]+$/.test(id);
+}
+
+function isTimelineDocument(value: unknown): value is TimelineDocument {
+  if (!value || typeof value !== "object") return false;
+  const document = value as Partial<TimelineDocument>;
+
+  return (
+    typeof document.id === "string" &&
+    typeof document.title === "string" &&
+    Array.isArray(document.clips)
+  );
+}
+
+/**
+ * ALL-OR-NOTHING multi-document writes: the batch twin of PATCH
+ * /api/timelines/[id], for changes that span documents (cross-timeline
+ * moves, trash drops) where independent PATCHes could persist half a
+ * change. Each write may carry `expectedRevision` (from the GET that read
+ * the document): any mismatch rejects the WHOLE batch with 409 and the
+ * conflicted ids' actual revisions — nothing is written, and a stale
+ * client can't silently overwrite a newer writer. Writes without an
+ * expectation keep last-write-wins (legacy semantics).
+ */
+export async function POST(request: Request) {
+  try {
+    const { user, response } = await requireAuthUser();
+    if (response || !user) return response || NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const body = (await request.json().catch(() => ({}))) as {
+      writes?: { document?: unknown; expectedRevision?: unknown }[];
+    };
+    if (!Array.isArray(body.writes) || body.writes.length === 0) {
+      return NextResponse.json({ error: "A batch requires at least one write." }, { status: 400 });
+    }
+    if (body.writes.length > MAX_BATCH_WRITES) {
+      return NextResponse.json(
+        { error: `A batch is limited to ${MAX_BATCH_WRITES} writes.` },
+        { status: 400 },
+      );
+    }
+
+    const writes: TimelineBatchWrite[] = [];
+    for (const write of body.writes) {
+      if (!isTimelineDocument(write.document)) {
+        return NextResponse.json(
+          { error: "Every batch write needs a valid timeline document." },
+          { status: 400 },
+        );
+      }
+      if (!isValidTimelineId(write.document.id)) {
+        return NextResponse.json({ error: "Invalid timeline id." }, { status: 400 });
+      }
+      // User-scoped ids (trash-<uid>, asset-library-<uid>…) embed their
+      // owner: a mismatch is rejected before any storage read, as a plain
+      // not-found (no existence oracle).
+      if (checkUserScopedId(write.document.id, user.uid) === false) {
+        return NextResponse.json({ error: "Timeline was not found." }, { status: 404 });
+      }
+      if (isUnsavedProjectPlaceholder(write.document)) {
+        return NextResponse.json(
+          { error: "Refusing to save an unloaded project placeholder." },
+          { status: 409 },
+        );
+      }
+      if (
+        write.expectedRevision !== undefined &&
+        (typeof write.expectedRevision !== "number" ||
+          !Number.isInteger(write.expectedRevision) ||
+          write.expectedRevision < 0)
+      ) {
+        return NextResponse.json(
+          { error: "expectedRevision must be a non-negative integer." },
+          { status: 400 },
+        );
+      }
+      writes.push({
+        document: write.document,
+        ...(write.expectedRevision !== undefined
+          ? { expectedRevision: write.expectedRevision }
+          : {}),
+      });
+    }
+
+    const results = await saveFirebaseTimelineDocumentsAtomic(writes, user.uid);
+    return NextResponse.json({ results });
+  } catch (error) {
+    if (error instanceof TimelineRevisionConflictError) {
+      return NextResponse.json(
+        { error: error.message, conflicts: error.conflicts },
+        { status: 409 },
+      );
+    }
+    // Someone else's document: a plain not-found, so timeline ids can't be
+    // probed for existence.
+    if (error instanceof TimelineAccessDeniedError) {
+      return NextResponse.json({ error: "Timeline was not found." }, { status: 404 });
+    }
+    if (
+      error instanceof Error &&
+      (error.message.startsWith("Refusing to save an empty timeline") ||
+        error.message.startsWith("A batch write must not repeat"))
+    ) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
+
+    const message =
+      error instanceof Error &&
+      (error.message.startsWith("Firebase Storage is not configured") ||
+        error.message.includes("timed out"))
+        ? error.message
+        : "Unable to save the timeline documents.";
+
+    console.error("[GSTUDIO_TIMELINE_STORAGE_ERROR]", error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/apps/timeline-gstudio001/app/api/timelines/timelines-batch.test.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/timelines-batch.test.ts
@@ -1,0 +1,298 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TimelineClip, TimelineDocument } from "@storyboard/ui/timeline/types";
+
+// Batch-write tests over the REAL route handler and the REAL
+// firebase-timeline-store transaction — only the process boundaries are
+// faked: the Firestore SDK (in-memory, with an all-or-nothing
+// runTransaction), the session cookie, and the Cloudinary listing. Covers
+// the review's cross-document atomicity finding: several documents commit
+// as a unit, a single revision mismatch rejects everything, and revisions
+// stamp/bump through GET, PATCH, and batch alike.
+
+type Stored = Record<string, unknown>;
+
+const state = vi.hoisted(() => {
+  const docs = new Map<string, Stored>();
+  const current = { user: { uid: "user-a", email: null as string | null, name: null, picture: null } };
+
+  const applySet = (id: string, data: Stored, opts?: { merge?: boolean }) => {
+    const existing = docs.get(id);
+    docs.set(id, opts?.merge && existing ? { ...existing, ...data } : { ...data });
+  };
+  const snapshot = (id: string) => {
+    const data = docs.get(id);
+    return {
+      id,
+      exists: data !== undefined,
+      data: () => (data ? { ...data } : undefined),
+      get: (field: string) => (data ? data[field] : undefined),
+    };
+  };
+  const docRef = (id: string) => ({
+    id,
+    get: async () => snapshot(id),
+    set: async (data: Stored, opts?: { merge?: boolean }) => applySet(id, data, opts),
+    delete: async () => {
+      docs.delete(id);
+    },
+  });
+  type Tx = {
+    get: (ref: { id: string }) => Promise<ReturnType<typeof snapshot>>;
+    set: (ref: { id: string }, data: Stored, opts?: { merge?: boolean }) => void;
+  };
+  const db = {
+    collection: () => ({
+      doc: docRef,
+      where: (field: string, _op: string, value: unknown) => ({
+        limit: () => ({
+          get: async () => ({
+            docs: [...docs.keys()].filter((id) => docs.get(id)?.[field] === value).map(snapshot),
+          }),
+        }),
+      }),
+    }),
+    batch: () => {
+      const ops: (() => void)[] = [];
+      return {
+        set: (ref: { id: string }, data: Stored, opts?: { merge?: boolean }) => {
+          ops.push(() => applySet(ref.id, data, opts));
+        },
+        commit: async () => {
+          for (const op of ops) op();
+        },
+      };
+    },
+    // All-or-nothing like the real thing: staged sets apply only when the
+    // transaction function resolves; a throw discards every staged write.
+    runTransaction: async <T>(fn: (tx: Tx) => Promise<T>): Promise<T> => {
+      const staged: (() => void)[] = [];
+      const tx: Tx = {
+        get: async (ref) => snapshot(ref.id),
+        set: (ref, data, opts) => {
+          staged.push(() => applySet(ref.id, data, opts));
+        },
+      };
+      const result = await fn(tx);
+      for (const op of staged) op();
+      return result;
+    },
+  };
+  return { docs, current, db };
+});
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/firebase-admin", () => ({
+  getFirebaseDb: () => state.db,
+}));
+vi.mock("firebase-admin/firestore", () => {
+  class Timestamp {
+    toDate() {
+      return new Date(0);
+    }
+  }
+  return { Timestamp, FieldValue: { serverTimestamp: () => new Timestamp() } };
+});
+vi.mock("@/lib/firebase-auth-session", () => ({
+  requireAuthUser: async () => ({ user: state.current.user, response: null }),
+}));
+vi.mock("@/lib/cloudinary-media-store", () => ({
+  listCloudinaryAssets: async () => [],
+}));
+
+import { POST as batchWrite } from "./batch/route";
+import { GET as getTimeline, PATCH as patchTimeline } from "./[id]/route";
+
+const asUser = (uid: string) => {
+  state.current.user = { uid, email: null, name: null, picture: null };
+};
+
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+
+function clip(id: string): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "image",
+    src: "https://example.test/img.jpg",
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 4,
+    sourceDuration: 4,
+    trimIn: 0,
+    trimOut: 0,
+  };
+}
+
+function seedTimeline(id: string, ownerUid: string | undefined, revision?: number) {
+  const document: TimelineDocument = { id, title: `Timeline ${id}`, clips: [clip(`${id}-c0`)] };
+  state.docs.set(id, {
+    id,
+    title: document.title,
+    document,
+    clips: document.clips,
+    isProject: true,
+    ...(ownerUid === undefined ? {} : { ownerUid }),
+    ...(revision === undefined ? {} : { revision }),
+  });
+}
+
+function batchRequest(writes: { document: TimelineDocument; expectedRevision?: number }[]) {
+  return new Request("http://test.local/api/timelines/batch", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ writes }),
+  });
+}
+
+function docOf(id: string, clipId: string): TimelineDocument {
+  return { id, title: `Timeline ${id}`, clips: [clip(clipId)] };
+}
+
+beforeEach(() => {
+  state.docs.clear();
+  asUser("user-a");
+});
+
+describe("timeline batch writes", () => {
+  it("writes several documents atomically and stamps bumped revisions", async () => {
+    seedTimeline("doc-1", "user-a", 3);
+    seedTimeline("doc-2", "user-a"); // legacy: no revision field = 0
+
+    const response = await batchWrite(
+      batchRequest([
+        { document: docOf("doc-1", "new-1"), expectedRevision: 3 },
+        { document: docOf("doc-2", "new-2"), expectedRevision: 0 },
+      ]),
+    );
+    expect(response.status).toBe(200);
+    const { results } = (await response.json()) as { results: { id: string; revision: number }[] };
+    expect(results).toEqual([
+      { id: "doc-1", revision: 4 },
+      { id: "doc-2", revision: 1 },
+    ]);
+
+    expect((state.docs.get("doc-1")?.document as TimelineDocument).clips[0].id).toBe("new-1");
+    expect((state.docs.get("doc-2")?.document as TimelineDocument).clips[0].id).toBe("new-2");
+    expect(state.docs.get("doc-1")?.revision).toBe(4);
+    expect(state.docs.get("doc-1")?.ownerUid).toBe("user-a");
+    expect(state.docs.get("doc-1")?.isProject).toBe(true); // preserved, not reset
+  });
+
+  it("a single revision mismatch rejects the WHOLE batch and writes nothing", async () => {
+    seedTimeline("doc-1", "user-a", 3);
+    seedTimeline("doc-2", "user-a", 1);
+    const before1 = state.docs.get("doc-1");
+    const before2 = state.docs.get("doc-2");
+
+    const response = await batchWrite(
+      batchRequest([
+        { document: docOf("doc-1", "stale"), expectedRevision: 2 }, // actual is 3
+        { document: docOf("doc-2", "fine"), expectedRevision: 1 },
+      ]),
+    );
+    expect(response.status).toBe(409);
+    const body = (await response.json()) as {
+      conflicts: { id: string; actualRevision: number }[];
+    };
+    expect(body.conflicts).toEqual([{ id: "doc-1", actualRevision: 3 }]);
+
+    expect(state.docs.get("doc-1")).toEqual(before1);
+    expect(state.docs.get("doc-2")).toEqual(before2); // the matching write rolled back too
+  });
+
+  it("creates a new document with expectation 0 and stamps the owner", async () => {
+    const response = await batchWrite(
+      batchRequest([{ document: docOf("doc-new", "c1"), expectedRevision: 0 }]),
+    );
+    expect(response.status).toBe(200);
+    const { results } = (await response.json()) as { results: { id: string; revision: number }[] };
+    expect(results).toEqual([{ id: "doc-new", revision: 1 }]);
+    expect(state.docs.get("doc-new")?.ownerUid).toBe("user-a");
+  });
+
+  it("expectation-less writes keep last-write-wins semantics", async () => {
+    seedTimeline("doc-1", "user-a", 3);
+
+    const response = await batchWrite(batchRequest([{ document: docOf("doc-1", "lww") }]));
+    expect(response.status).toBe(200);
+    const { results } = (await response.json()) as { results: { id: string; revision: number }[] };
+    expect(results).toEqual([{ id: "doc-1", revision: 4 }]);
+  });
+
+  it("another user's document rejects the whole batch as 404 and writes nothing", async () => {
+    seedTimeline("doc-a", "user-a", 1);
+    seedTimeline("doc-b", "user-b", 1);
+    const beforeA = state.docs.get("doc-a");
+    const beforeB = state.docs.get("doc-b");
+
+    const response = await batchWrite(
+      batchRequest([
+        { document: docOf("doc-a", "mine"), expectedRevision: 1 },
+        { document: docOf("doc-b", "theirs"), expectedRevision: 1 },
+      ]),
+    );
+    expect(response.status).toBe(404);
+    expect(state.docs.get("doc-a")).toEqual(beforeA);
+    expect(state.docs.get("doc-b")).toEqual(beforeB);
+  });
+
+  it("rejects another user's trash id before any storage access", async () => {
+    asUser("user-b");
+    const response = await batchWrite(
+      batchRequest([{ document: { id: "trash-user-a", title: "Trash Bin", clips: [clip("x")] } }]),
+    );
+    expect(response.status).toBe(404);
+    expect(state.docs.size).toBe(0);
+  });
+
+  it("refuses an empty document over an existing non-empty one, batch-wide", async () => {
+    seedTimeline("doc-1", "user-a", 2);
+    const before = state.docs.get("doc-1");
+
+    const response = await batchWrite(
+      batchRequest([
+        { document: { id: "doc-1", title: "Timeline doc-1", clips: [] }, expectedRevision: 2 },
+      ]),
+    );
+    expect(response.status).toBe(409);
+    expect(state.docs.get("doc-1")).toEqual(before);
+  });
+
+  it("rejects a batch that repeats a timeline id", async () => {
+    seedTimeline("doc-1", "user-a", 1);
+    const response = await batchWrite(
+      batchRequest([
+        { document: docOf("doc-1", "first"), expectedRevision: 1 },
+        { document: docOf("doc-1", "second"), expectedRevision: 1 },
+      ]),
+    );
+    expect(response.status).toBe(409);
+  });
+
+  it("GET serves the revision the next expecting write must carry", async () => {
+    seedTimeline("doc-1", "user-a", 3);
+    const response = await getTimeline(new Request("http://test.local"), params("doc-1"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { revision: number };
+    expect(body.revision).toBe(3);
+  });
+
+  it("the single-document PATCH path stamps revisions too", async () => {
+    seedTimeline("doc-1", "user-a", 3);
+    const response = await patchTimeline(
+      new Request("http://test.local/api/timelines/doc-1", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document: docOf("doc-1", "patched") }),
+      }),
+      params("doc-1"),
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { revision: number };
+    expect(body.revision).toBe(4);
+    expect(state.docs.get("doc-1")?.revision).toBe(4);
+  });
+});

--- a/apps/timeline-gstudio001/components/graph-view/graph-asset-palette.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-asset-palette.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import {
+  PaletteItem,
+  parseNodeId,
+  useCollectionsStore,
+  usePanWithMomentum,
+  type CollectionItemNode,
+  type CollectionsPatch,
+} from "@storyboard/ui/dnd-collections";
+import type { ClipDetail } from "@storyboard/timeline-domain";
+
+import { Button } from "@/components/core/button";
+import type { CloudinaryAsset } from "@/lib/cloudinary-media-store";
+
+const pendingPaletteDetails = new Map<string, ClipDetail>();
+const DEFAULT_IMAGE_SECONDS = 4;
+const DEFAULT_VIDEO_SECONDS = 8;
+const PALETTE_ASSET_LIMIT = 48;
+
+function assetDisplayName(asset: CloudinaryAsset): string {
+  const path = asset.relativePath ?? asset.pathname;
+  return path.split("/").pop() ?? path;
+}
+
+function createNodeFromAsset(asset: CloudinaryAsset): CollectionItemNode {
+  pendingPaletteDetails.clear();
+  const id = parseNodeId(
+    `asset-${asset.id}-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`,
+  );
+  const name = assetDisplayName(asset);
+  const aspect =
+    asset.width && asset.height && asset.height > 0 ? asset.width / asset.height : 16 / 9;
+
+  pendingPaletteDetails.set(id as string, {
+    alt: name,
+    aspect,
+    trackIndex: 0,
+    poster: asset.thumbnailUrl,
+    ...(asset.resourceType === "image"
+      ? { sourceDuration: DEFAULT_IMAGE_SECONDS, trimIn: 0, trimOut: 0 }
+      : {}),
+  });
+
+  if (asset.resourceType === "video") {
+    return {
+      id,
+      kind: "media",
+      mediaKind: "video",
+      name,
+      src: asset.url,
+      posterSrcs: [asset.thumbnailUrl],
+      fullDurationSeconds: asset.duration ?? DEFAULT_VIDEO_SECONDS,
+      trimInSeconds: 0,
+      trimOutSeconds: 0,
+    };
+  }
+
+  return {
+    id,
+    kind: "media",
+    mediaKind: "image",
+    name,
+    src: asset.url,
+    durationSeconds: DEFAULT_IMAGE_SECONDS,
+  };
+}
+
+/** Claim app-side metadata parked by PaletteItem when an add commits. */
+export function claimPendingPaletteDetails(
+  patch: CollectionsPatch,
+): Record<string, ClipDetail> | null {
+  if (patch.type !== "nodes-added") return null;
+
+  let claimed: Record<string, ClipDetail> | null = null;
+  for (const add of patch.adds) {
+    const id = add.node.id as string;
+    const detail = pendingPaletteDetails.get(id);
+    if (!detail) continue;
+    (claimed ??= {})[id] = detail;
+    pendingPaletteDetails.delete(id);
+  }
+  return claimed;
+}
+
+type AssetPaletteState =
+  | Readonly<{ status: "loading" }>
+  | Readonly<{ status: "error"; message: string }>
+  | Readonly<{ status: "ready"; assets: readonly CloudinaryAsset[]; truncated: boolean }>;
+
+function PaletteRail({ assets }: Readonly<{ assets: readonly CloudinaryAsset[] }>) {
+  const store = useCollectionsStore();
+  const railRef = useRef<HTMLDivElement>(null);
+  const panOptions = useMemo<Parameters<typeof usePanWithMomentum>[2]>(
+    () => ({ isGestureClaimed: () => store.getSnapshot().interaction.isDragging }),
+    [store],
+  );
+  usePanWithMomentum(railRef, "x", panOptions);
+
+  return (
+    <div
+      ref={railRef}
+      data-drag-activation="hold"
+      className="flex cursor-grab gap-2 overflow-x-auto pb-1 select-none active:cursor-grabbing"
+      style={{ touchAction: "pan-y" }}
+    >
+      {assets.map((asset) => (
+        <PaletteItem
+          key={asset.id}
+          paletteId={`asset-${asset.id}`}
+          createNode={() => createNodeFromAsset(asset)}
+          className="relative h-24 w-36 shrink-0 overflow-hidden p-0"
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={asset.thumbnailUrl}
+            alt={assetDisplayName(asset)}
+            draggable={false}
+            loading="lazy"
+            className="h-full w-full object-cover"
+          />
+          {asset.resourceType === "video" && (
+            <span className="absolute bottom-1 left-1 rounded bg-black/75 px-1 py-0.5 text-[9px] font-bold tracking-wide text-zinc-100">
+              VIDEO
+            </span>
+          )}
+        </PaletteItem>
+      ))}
+    </div>
+  );
+}
+
+export function AssetPaletteDrawer({
+  open,
+  onClose,
+}: Readonly<{
+  open: boolean;
+  onClose: () => void;
+}>) {
+  const [state, setState] = useState<AssetPaletteState>({ status: "loading" });
+
+  const handleClose = () => {
+    if (state.status === "error") setState({ status: "loading" });
+    onClose();
+  };
+
+  useEffect(() => {
+    if (!open || state.status !== "loading") return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await fetch("/api/assets", { cache: "no-store" });
+        const result = (await response.json().catch(() => ({}))) as {
+          assets?: CloudinaryAsset[];
+          error?: string;
+        };
+        if (cancelled) return;
+        if (!response.ok || !result.assets) {
+          setState({ status: "error", message: result.error ?? "Could not load assets." });
+          return;
+        }
+        setState({
+          status: "ready",
+          assets: result.assets.slice(0, PALETTE_ASSET_LIMIT),
+          truncated: result.assets.length > PALETTE_ASSET_LIMIT,
+        });
+      } catch (cause) {
+        if (!cancelled) {
+          setState({
+            status: "error",
+            message: cause instanceof Error ? cause.message : "Could not load assets.",
+          });
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, state.status]);
+
+  if (!open || typeof document === "undefined") return null;
+
+  return createPortal(
+    <section
+      aria-label="Asset palette"
+      className="pointer-events-none fixed inset-x-0 bottom-0 z-40"
+    >
+      <aside
+        role="dialog"
+        aria-modal="false"
+        aria-label="Asset palette"
+        className="pointer-events-auto ml-[72px] flex max-h-[38vh] flex-col border-t border-zinc-800 bg-zinc-950 p-3 text-white shadow-2xl shadow-black/50"
+      >
+        <div className="mb-2 flex items-center gap-3">
+          <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">
+            Assets
+          </h3>
+          <span className="text-[10px] text-zinc-600">
+            Drag a thumbnail into any timeline · Enter picks one up for keyboard placement
+          </span>
+          <span className="grow" />
+          <Button type="button" variant="ghost" size="sm" onClick={handleClose}>
+            Close
+          </Button>
+        </div>
+
+        {state.status === "loading" && (
+          <div className="flex gap-2">
+            {Array.from({ length: 6 }).map((_, index) => (
+              <div
+                key={index}
+                className="h-24 w-36 shrink-0 animate-pulse rounded-md bg-zinc-900"
+              />
+            ))}
+          </div>
+        )}
+
+        {state.status === "error" && (
+          <div className="flex items-center gap-3 rounded-md border border-zinc-800 px-3 py-2">
+            <p className="text-xs text-zinc-500">{state.message}</p>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setState({ status: "loading" })}
+            >
+              Retry
+            </Button>
+          </div>
+        )}
+
+        {state.status === "ready" &&
+          (state.assets.length === 0 ? (
+            <p className="rounded-md border border-zinc-800 px-3 py-2 text-xs text-zinc-500">
+              No assets yet — upload some from the asset library on the storyboard view.
+            </p>
+          ) : (
+            <>
+              <PaletteRail assets={state.assets} />
+              {state.truncated && (
+                <p className="mt-1 text-[10px] text-zinc-600">
+                  Showing the newest {PALETTE_ASSET_LIMIT} assets — the full library is on the
+                  storyboard view.
+                </p>
+              )}
+            </>
+          ))}
+      </aside>
+    </section>,
+    document.body,
+  );
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import {
+  TrashTarget,
+  UndoRedoControls,
+  VirtualGrid,
+  VirtualStrip,
+  parseNodeId,
+} from "@storyboard/ui/dnd-collections";
+
+import { Button } from "@/components/core/button";
+
+import { OpenKeyBoundary } from "./graph-navigation";
+import { SyncPanel, type SyncEntry } from "./graph-persistence";
+import {
+  GraphGridPlayhead,
+  GraphGridScrubSurface,
+  GraphPlayhead,
+  PlayheadScrubBand,
+  PreviewShell,
+  type PreviewTimeChannel,
+} from "./graph-preview";
+import { SubTimelines } from "./graph-sub-timelines";
+import {
+  GRID_CELL_HEIGHT,
+  GRID_CELL_WIDTH,
+  GRID_GAP,
+  TIMELINE_PPS,
+} from "./graph-view-config";
+
+export type FocusSurface = "strip" | "grid";
+
+function SurfaceToggle({
+  surface,
+  onChange,
+}: Readonly<{
+  surface: FocusSurface;
+  onChange: (surface: FocusSurface) => void;
+}>) {
+  return (
+    <div
+      role="group"
+      aria-label="Focused timeline layout"
+      className="flex items-center rounded-md border border-zinc-800 p-0.5"
+    >
+      {(["strip", "grid"] as const).map((option) => (
+        <button
+          key={option}
+          type="button"
+          aria-pressed={surface === option}
+          onClick={() => onChange(option)}
+          className={[
+            "rounded px-2 py-1 text-xs capitalize transition-colors",
+            surface === option
+              ? "bg-zinc-800 text-zinc-100"
+              : "text-zinc-500 hover:text-zinc-200",
+          ].join(" ")}
+        >
+          {option}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function GraphBoard({
+  focusedId,
+  surface,
+  onSurfaceChange,
+  previewOn,
+  onTogglePreview,
+  assetsOpen,
+  onToggleAssets,
+  timeChannel,
+  trashRootId,
+  syncEntries,
+}: Readonly<{
+  focusedId: string;
+  surface: FocusSurface;
+  onSurfaceChange: (surface: FocusSurface) => void;
+  previewOn: boolean;
+  onTogglePreview: () => void;
+  assetsOpen: boolean;
+  onToggleAssets: () => void;
+  timeChannel: PreviewTimeChannel;
+  trashRootId: string | null;
+  syncEntries: readonly SyncEntry[];
+}>) {
+  return (
+    <OpenKeyBoundary>
+      <PreviewShell enabled={previewOn} focusedId={focusedId} channel={timeChannel}>
+        <div className="flex flex-col gap-5 rounded-xl border border-zinc-800 bg-zinc-950/50 p-4">
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-xs text-zinc-500">
+              Press-and-hold to drag (cross-timeline included) · amber edges trim · double-click
+              (or O) a dashed clip to focus it · undo survives drill-in.
+            </p>
+            <div className="flex shrink-0 items-center gap-3">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                aria-pressed={previewOn}
+                onClick={onTogglePreview}
+              >
+                Preview
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                aria-pressed={assetsOpen}
+                onClick={onToggleAssets}
+              >
+                Assets
+              </Button>
+              <SurfaceToggle surface={surface} onChange={onSurfaceChange} />
+              <UndoRedoControls />
+            </div>
+          </div>
+
+          {surface === "strip" ? (
+            <div className="relative">
+              <VirtualStrip
+                collectionId={parseNodeId(focusedId)}
+                pixelsPerSecond={TIMELINE_PPS}
+                itemHeight={88}
+                itemDragActivation="hold"
+                overlay={
+                  previewOn ? (
+                    <GraphPlayhead focusedId={focusedId} channel={timeChannel} />
+                  ) : undefined
+                }
+                className="bg-black/25"
+              />
+              {previewOn && (
+                <PlayheadScrubBand focusedId={focusedId} channel={timeChannel} />
+              )}
+            </div>
+          ) : (
+            <div className="relative">
+              <VirtualGrid
+                collectionId={parseNodeId(focusedId)}
+                cellWidth={GRID_CELL_WIDTH}
+                cellHeight={GRID_CELL_HEIGHT}
+                gap={GRID_GAP}
+                height={420}
+                overlay={
+                  previewOn ? (
+                    <GraphGridPlayhead focusedId={focusedId} channel={timeChannel} />
+                  ) : undefined
+                }
+                className="bg-black/25"
+              />
+              {previewOn && (
+                <GraphGridScrubSurface focusedId={focusedId} channel={timeChannel} />
+              )}
+            </div>
+          )}
+
+          <SubTimelines focusedId={focusedId} />
+
+          {trashRootId !== null && (
+            <div className="flex items-end justify-end">
+              <div className="shrink-0">
+                <h3 className="mb-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-zinc-500">
+                  Trash
+                </h3>
+                <TrashTarget trashId={parseNodeId(trashRootId)} />
+              </div>
+            </div>
+          )}
+
+          <SyncPanel entries={syncEntries} />
+        </div>
+      </PreviewShell>
+    </OpenKeyBoundary>
+  );
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-details-context.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-details-context.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { createContext, useContext, useSyncExternalStore } from "react";
+
+import type { ClipDetail } from "@storyboard/timeline-domain";
+
+import type { GraphDetailsStore } from "@/lib/graph-details-store";
+
+const GraphDetailsStoreContext = createContext<GraphDetailsStore | null>(null);
+
+export function GraphDetailsProvider({
+  store,
+  children,
+}: Readonly<{
+  store: GraphDetailsStore;
+  children: React.ReactNode;
+}>) {
+  return (
+    <GraphDetailsStoreContext.Provider value={store}>
+      {children}
+    </GraphDetailsStoreContext.Provider>
+  );
+}
+
+export function useGraphDetailsStore(): GraphDetailsStore {
+  const store = useContext(GraphDetailsStoreContext);
+  if (store === null) {
+    throw new Error("useGraphDetailsStore must be used inside the graph view's provider tree.");
+  }
+  return store;
+}
+
+/** Subscribe to one detail entry so unrelated hydration does not re-render this consumer. */
+export function useClipDetail(id: string): ClipDetail | undefined {
+  const store = useGraphDetailsStore();
+  return useSyncExternalStore(
+    store.subscribe,
+    () => store.get(id),
+    () => store.get(id),
+  );
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-hydration.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-hydration.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useEffect } from "react";
+
+import {
+  getChildren,
+  parseNodeId,
+  useCollectionsStore,
+  type CollectionsStore,
+} from "@storyboard/ui/dnd-collections";
+import { buildHydrationSpecs, type ClipDetail } from "@storyboard/timeline-domain";
+
+import type { GraphDetailsStore } from "@/lib/graph-details-store";
+import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
+
+import { useGraphDetailsStore } from "./graph-details-context";
+import { FALLBACK_DETAIL } from "./graph-view-config";
+
+/** Fetch and hydrate one placeholder timeline, including its app-side detail entries. */
+export async function hydrateTimeline(
+  store: CollectionsStore,
+  detailsStore: GraphDetailsStore,
+  timelineId: string,
+): Promise<void> {
+  if (detailsStore.get(timelineId)?.hydrated === true) return;
+
+  const document = await graphDocumentsGateway.ensure(timelineId);
+  if (!document) return;
+
+  const current = store.getSnapshot().graph;
+  const collectionId = parseNodeId(timelineId);
+  if (!current.nodesById.has(collectionId)) return;
+
+  if (getChildren(current, collectionId).length > 0) {
+    const payload = buildHydrationSpecs(graphDocumentsGateway.read(), timelineId, 0);
+    if (!payload.ok) return;
+
+    const details = detailsStore.read();
+    const merged: Record<string, ClipDetail> = {};
+    for (const [id, detail] of Object.entries(payload.value.details)) {
+      if (details[id] === undefined && current.nodesById.has(parseNodeId(id))) {
+        merged[id] = detail;
+      }
+    }
+    const own = details[timelineId];
+    merged[timelineId] = own ? { ...own, hydrated: true } : { ...FALLBACK_DETAIL, hydrated: true };
+    detailsStore.merge(merged);
+    return;
+  }
+
+  const payload = buildHydrationSpecs(
+    graphDocumentsGateway.read(),
+    timelineId,
+    0,
+    current.nodesById.keys(),
+  );
+  if (!payload.ok) return;
+
+  const applied = store.hydrate(collectionId, payload.value.specs);
+  if (!applied.ok) return;
+
+  const merged: Record<string, ClipDetail> = { ...payload.value.details };
+  const own = detailsStore.get(timelineId);
+  merged[timelineId] = own ? { ...own, hydrated: true } : { ...FALLBACK_DETAIL, hydrated: true };
+  detailsStore.merge(merged);
+}
+
+/** Hydrate the focus path plus the shallow inline timelines rendered below it. */
+export function HydrationController({
+  projectId,
+  segments,
+  onFocusError,
+}: Readonly<{
+  projectId: string;
+  segments: readonly string[];
+  onFocusError: (error: string | null) => void;
+}>) {
+  const store = useCollectionsStore();
+  const detailsStore = useGraphDetailsStore();
+  const pathKey = segments.join("/");
+
+  useEffect(() => {
+    let cancelled = false;
+    const path = pathKey === "" ? [] : pathKey.split("/");
+    const focusedId = path[path.length - 1] ?? projectId;
+
+    void (async () => {
+      const ensure = (timelineId: string) => hydrateTimeline(store, detailsStore, timelineId);
+      let error: string | null = null;
+      let previous: string | null = null;
+
+      for (const segment of [projectId, ...path]) {
+        if (cancelled) return;
+        const graph = store.getSnapshot().graph;
+        const node = graph.nodesById.get(parseNodeId(segment));
+        if (node === undefined || node.kind !== "collection") {
+          error = `This project has no timeline "${segment}".`;
+          break;
+        }
+        if (
+          previous !== null &&
+          graph.parentById.get(parseNodeId(segment)) !== parseNodeId(previous)
+        ) {
+          error = `Timeline "${segment}" is not inside "${previous}".`;
+          break;
+        }
+        await ensure(segment);
+        previous = segment;
+      }
+
+      if (error === null && !cancelled) {
+        const collectionChildrenOf = (id: string) => {
+          const graph = store.getSnapshot().graph;
+          return getChildren(graph, parseNodeId(id))
+            .filter((childId) => graph.nodesById.get(childId)?.kind === "collection")
+            .map((childId) => childId as string);
+        };
+        const children = collectionChildrenOf(focusedId);
+        await Promise.all(children.map(ensure));
+        if (!cancelled) {
+          const grandchildren = children.flatMap(collectionChildrenOf);
+          await Promise.all(grandchildren.map(ensure));
+        }
+      }
+
+      if (!cancelled) onFocusError(error);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [pathKey, projectId, store, detailsStore, onFocusError]);
+
+  return null;
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { memo, useContext } from "react";
+
+import {
+  mediaDurationSeconds,
+  useLiveTrim,
+  videoFrameCount,
+  type CollectionGhostContentProps,
+  type CollectionItemContentProps,
+  type CollectionTrimHandleContentProps,
+  type CollectionsComponents,
+  type MediaNode,
+  type NodeId,
+} from "@storyboard/ui/dnd-collections";
+
+import { useClipDetail } from "./graph-details-context";
+import { GraphViewNavContext } from "./graph-navigation";
+
+/** Leaf subscription: only the clip being trimmed re-renders per pointer move. */
+function LiveDurationPill({ id, node }: { id: NodeId; node: MediaNode }) {
+  const live = useLiveTrim(id);
+  const showing = live ? live.effectiveSeconds : mediaDurationSeconds(node);
+  return (
+    <span className="pointer-events-none absolute right-1 bottom-1 z-10 rounded bg-black/75 px-1.5 py-0.5 font-mono text-[9px] tabular-nums text-zinc-100">
+      {node.mediaKind === "video"
+        ? `${showing.toFixed(2)}s / ${node.fullDurationSeconds.toFixed(2)}s`
+        : `${showing.toFixed(2)}s`}
+    </span>
+  );
+}
+
+const GraphClipContent = memo(function GraphClipContent({
+  id,
+  node,
+  childCount,
+  selected,
+  rejected,
+  isDragSource,
+  trimEnabled,
+}: CollectionItemContentProps) {
+  const nav = useContext(GraphViewNavContext);
+  const detail = useClipDetail(id as string);
+
+  if (node.kind === "collection") {
+    const hydrated = detail?.hydrated === true;
+    const count = hydrated ? childCount : (detail?.itemCount ?? childCount);
+    const previews = detail?.previewItems?.slice(0, 3) ?? [];
+    return (
+      <span
+        title="Double-click (or press O) to open this timeline"
+        onDoubleClick={() => nav?.openTimeline(id)}
+        className={[
+          "relative flex h-full w-full flex-col justify-between overflow-hidden rounded-md border border-dashed border-sky-500/40 bg-sky-500/[0.08] p-1.5",
+          selected ? "ring-2 ring-amber-400" : "",
+          rejected ? "ring-2 ring-red-500 motion-safe:animate-pulse" : "",
+          isDragSource ? "opacity-40" : "",
+        ].join(" ")}
+      >
+        <span className="flex min-h-0 flex-1 gap-0.5 overflow-hidden">
+          {previews.length === 0 ? (
+            <span className="flex flex-1 items-center justify-center text-[9px] text-zinc-500">
+              {hydrated ? "Empty" : "Open to load"}
+            </span>
+          ) : (
+            previews.map((preview) => (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                key={preview.id}
+                src={preview.poster ?? preview.src}
+                alt=""
+                draggable={false}
+                loading="lazy"
+                className="h-full min-w-0 flex-1 rounded-sm object-cover"
+              />
+            ))
+          )}
+        </span>
+        <span className="mt-1 flex items-baseline justify-between gap-1">
+          <span className="truncate text-[10px] font-semibold text-zinc-100">{node.name}</span>
+          <span className="shrink-0 font-mono text-[9px] text-zinc-400">{count}</span>
+        </span>
+      </span>
+    );
+  }
+
+  const isVideo = node.mediaKind === "video";
+  const posters = isVideo ? (node.posterSrcs ?? []) : node.src ? [node.src] : [];
+  const frames = isVideo ? videoFrameCount(mediaDurationSeconds(node), 6) : 1;
+  return (
+    <span
+      className={[
+        "relative flex h-full w-full overflow-hidden rounded-md bg-zinc-900",
+        selected ? "ring-2 ring-amber-400" : "ring-1 ring-white/15",
+        rejected ? "ring-2 ring-red-500 motion-safe:animate-pulse" : "",
+        isDragSource ? "opacity-40" : "",
+      ].join(" ")}
+    >
+      {posters.length === 0 ? (
+        <span className="flex h-full w-full items-center justify-center text-[10px] text-zinc-500">
+          No preview
+        </span>
+      ) : (
+        <span className="flex h-full w-full">
+          {Array.from({ length: frames }).map((_, index) => (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              key={index}
+              src={posters[index % posters.length]}
+              alt=""
+              draggable={false}
+              loading="lazy"
+              className="h-full min-w-0 flex-1 border-r border-black/60 object-cover last:border-r-0"
+            />
+          ))}
+        </span>
+      )}
+      {trimEnabled && <LiveDurationPill id={id} node={node} />}
+    </span>
+  );
+});
+
+const GraphTrimHandle = memo(function GraphTrimHandle({
+  side,
+  selected,
+}: CollectionTrimHandleContentProps) {
+  return (
+    <span
+      className={[
+        "flex h-full w-full items-center justify-center transition-opacity",
+        side === "left" ? "rounded-l-md" : "rounded-r-md",
+        selected ? "bg-amber-400 opacity-95" : "bg-amber-400/50 opacity-0 group-hover:opacity-90",
+      ].join(" ")}
+    >
+      <span className="h-4 w-0.5 rounded bg-black/60" />
+    </span>
+  );
+});
+
+const GraphGhost = memo(function GraphGhost({ node, extraCount }: CollectionGhostContentProps) {
+  return (
+    <span className="relative flex h-full w-full flex-col justify-between rounded-md bg-zinc-900/95 p-2 text-xs shadow-2xl ring-2 ring-amber-400">
+      <span className="truncate font-semibold text-zinc-100">{node.name}</span>
+      <span className="font-mono text-[10px] text-zinc-400">
+        {node.kind === "collection" ? "Timeline" : `${mediaDurationSeconds(node).toFixed(2)}s`}
+      </span>
+      {extraCount > 0 && (
+        <span className="absolute -top-2 -right-2 flex h-6 min-w-6 items-center justify-center rounded-full bg-amber-400 px-1 text-[11px] font-bold text-black shadow">
+          +{extraCount}
+        </span>
+      )}
+    </span>
+  );
+});
+
+export const GRAPH_VIEW_COMPONENTS: CollectionsComponents = {
+  ItemContent: GraphClipContent,
+  TrimHandleContent: GraphTrimHandle,
+  GhostContent: GraphGhost,
+};

--- a/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { createContext, useContext, useMemo } from "react";
+import { useRouter } from "next/navigation";
+
+import {
+  parseNodeId,
+  useCollectionsStore,
+  type NodeId,
+} from "@storyboard/ui/dnd-collections";
+
+import { useGraphDetailsStore } from "./graph-details-context";
+
+type GraphViewNav = Readonly<{
+  openTimeline: (nodeId: NodeId) => void;
+}>;
+
+export const GraphViewNavContext = createContext<GraphViewNav | null>(null);
+
+export function GraphViewNavProvider({
+  projectId,
+  focusedId,
+  children,
+}: Readonly<{
+  projectId: string;
+  focusedId: string;
+  children: React.ReactNode;
+}>) {
+  const router = useRouter();
+  const store = useCollectionsStore();
+  const detailsStore = useGraphDetailsStore();
+
+  const value = useMemo<GraphViewNav>(
+    () => ({
+      openTimeline: (nodeId) => {
+        const timelineId =
+          detailsStore.get(nodeId as string)?.duplicateOfTimelineId ?? (nodeId as string);
+        if (timelineId === focusedId) return;
+
+        const base = `/timeline/${encodeURIComponent(projectId)}/graph`;
+        if (timelineId === projectId) {
+          router.push(base);
+          return;
+        }
+
+        const { graph } = store.getSnapshot();
+        const chain: string[] = [timelineId];
+        let parent = graph.parentById.get(parseNodeId(timelineId)) ?? null;
+        while (parent !== null && (parent as string) !== projectId) {
+          chain.unshift(parent as string);
+          parent = graph.parentById.get(parent) ?? null;
+        }
+        if ((parent as string | null) !== projectId) return;
+        router.push(`${base}/${chain.map(encodeURIComponent).join("/")}`);
+      },
+    }),
+    [detailsStore, focusedId, projectId, router, store],
+  );
+
+  return <GraphViewNavContext.Provider value={value}>{children}</GraphViewNavContext.Provider>;
+}
+
+/** Keyboard drill-in boundary for collection and duplicate-reference cards. */
+export function OpenKeyBoundary({ children }: Readonly<{ children: React.ReactNode }>) {
+  const nav = useContext(GraphViewNavContext);
+  const store = useCollectionsStore();
+  const detailsStore = useGraphDetailsStore();
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "o" && event.key !== "O") return;
+    if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
+    if (store.getSnapshot().interaction.isDragging) return;
+
+    const target = event.target as HTMLElement;
+    if (target.closest("input, textarea, [contenteditable=true]")) return;
+    const id = target.closest<HTMLElement>("[data-node-id]")?.dataset.nodeId;
+    if (!id) return;
+
+    const node = store.getSnapshot().graph.nodesById.get(parseNodeId(id));
+    const opensTimeline =
+      node?.kind === "collection" || detailsStore.get(id)?.duplicateOfTimelineId !== undefined;
+    if (!opensTimeline) return;
+
+    event.preventDefault();
+    nav?.openTimeline(parseNodeId(id));
+  };
+
+  return (
+    <div style={{ display: "contents" }} onKeyDown={handleKeyDown}>
+      {children}
+    </div>
+  );
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-persistence.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-persistence.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useEffect } from "react";
+
+import {
+  useCollectionsContainer,
+  useCollectionsStore,
+  type CollectionsChange,
+} from "@storyboard/ui/dnd-collections";
+import {
+  collectAffectedCollectionIds,
+  collectUnhydratedDropTargets,
+  graphChildrenToClips,
+} from "@storyboard/timeline-domain";
+
+import { collectReachableDetailIds } from "@/lib/graph-details-store";
+import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
+
+import { claimPendingPaletteDetails } from "./graph-asset-palette";
+import { useGraphDetailsStore } from "./graph-details-context";
+
+export type SyncEntry = Readonly<{
+  at: number;
+  origin: CollectionsChange["origin"];
+  patchType: CollectionsChange["patch"]["type"];
+  collections: readonly string[];
+  bounced?: boolean;
+}>;
+
+/** Persist committed graph patches and bounce drops into unloaded collections. */
+export function PersistenceBridge({
+  onSync,
+}: Readonly<{
+  onSync: (entry: SyncEntry) => void;
+}>) {
+  const store = useCollectionsStore();
+  const detailsStore = useGraphDetailsStore();
+  const { announce } = useCollectionsContainer();
+
+  useEffect(
+    () =>
+      store.subscribeToChanges((change) => {
+        const claimed = claimPendingPaletteDetails(change.patch);
+        if (claimed) detailsStore.merge(claimed);
+
+        const current = detailsStore.read();
+        if (change.origin !== "undo") {
+          const blocked = collectUnhydratedDropTargets(change.patch, current);
+          if (blocked.length > 0) {
+            store.undo();
+            const placedIds =
+              change.patch.type === "nodes-moved"
+                ? change.patch.moves.map((move) => move.nodeId)
+                : change.patch.type === "nodes-added"
+                  ? change.patch.adds.map((add) => add.node.id)
+                  : [];
+            if (placedIds.length > 0) store.flashRejection(placedIds);
+            announce("That collection is still loading — drop again once its clips appear.");
+            onSync({
+              at: Date.now(),
+              origin: change.origin,
+              patchType: change.patch.type,
+              collections: blocked,
+              bounced: true,
+            });
+            return;
+          }
+        }
+
+        const affected = collectAffectedCollectionIds(change.graph, change.patch).filter(
+          (id) => graphDocumentsGateway.peek(id) !== null && current[id]?.hydrated !== false,
+        );
+        for (const id of affected) {
+          graphDocumentsGateway.writeClips(id, graphChildrenToClips(change.graph, current, id));
+        }
+        onSync({
+          at: Date.now(),
+          origin: change.origin,
+          patchType: change.patch.type,
+          collections: affected,
+        });
+      }),
+    [store, detailsStore, announce, onSync],
+  );
+
+  return null;
+}
+
+/** Prune detail entries only after they leave both the graph and undo history. */
+export function GraphDetailsJanitor() {
+  const store = useCollectionsStore();
+  const detailsStore = useGraphDetailsStore();
+
+  useEffect(
+    () =>
+      store.subscribeToChanges(() => {
+        const snapshot = store.getSnapshot();
+        if (snapshot.canRedo) return;
+        detailsStore.prune(collectReachableDetailIds(snapshot));
+      }),
+    [store, detailsStore],
+  );
+
+  return null;
+}
+
+export function SyncPanel({ entries }: { entries: readonly SyncEntry[] }) {
+  return (
+    <div className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-3">
+      <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-zinc-500">
+        Patch-scoped document writes
+      </h3>
+      {entries.length === 0 ? (
+        <p className="mt-2 text-xs text-zinc-500">
+          No writes yet — reorder, trim, nest, or undo and watch which timeline documents are
+          queued for persistence. Hydration never appears here because loading data is not a
+          change worth writing back.
+        </p>
+      ) : (
+        <ol className="mt-2 flex flex-col gap-1 font-mono text-[11px] text-zinc-400">
+          {entries.map((entry) => (
+            <li key={entry.at} className="flex flex-wrap items-baseline gap-x-2">
+              <span className="text-zinc-100">{entry.origin}</span>
+              <span>{entry.patchType}</span>
+              <span aria-hidden="true">→</span>
+              {entry.bounced ? (
+                <span className="text-amber-400">
+                  reverted — {entry.collections.join(", ")} still loading
+                </span>
+              ) : (
+                <span className="text-sky-400">
+                  {entry.collections.length === 0
+                    ? "(nothing stored)"
+                    : entry.collections.join(", ")}
+                </span>
+              )}
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -1,0 +1,533 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+
+import {
+  MIN_ITEM_WIDTH,
+  durationToWidth,
+  useCollectionsSelector,
+  useCollectionsStore,
+  type CollectionsGraph,
+} from "@storyboard/ui/dnd-collections";
+import { graphChildrenToClips, type DetailsById } from "@storyboard/timeline-domain";
+import { WorkbenchSplitPane } from "@storyboard/ui/timeline/viewport/workbench-display-surface";
+import {
+  TimelineDocumentsProvider,
+  useTimelineDocuments,
+} from "@storyboard/ui/timeline/timeline-document-store";
+import { createTimelineDocumentsState } from "@storyboard/ui/timeline/timeline-documents";
+import type { TimelineClip, TimelineDocument } from "@storyboard/ui/timeline/types";
+
+import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
+
+import { useGraphDetailsStore } from "./graph-details-context";
+import {
+  GRID_CELL_HEIGHT,
+  GRID_CELL_WIDTH,
+  GRID_GAP,
+  TIMELINE_PPS,
+} from "./graph-view-config";
+
+export type PreviewTimeChannel = Readonly<{
+  get: () => number;
+  set: (time: number) => void;
+  subscribe: (listener: () => void) => () => void;
+}>;
+
+export function createPreviewTimeChannel(): PreviewTimeChannel {
+  let time = 0;
+  const listeners = new Set<() => void>();
+  return {
+    get: () => time,
+    set: (next) => {
+      time = next;
+      for (const listener of listeners) listener();
+    },
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}
+
+type PlayheadMap = Readonly<{
+  xAt: (time: number) => number;
+  timeAt: (x: number) => number;
+  totalDurationSeconds: number;
+}>;
+
+const STRIP_GAP_PX = 8;
+const COLLECTION_CARD_PX = 128;
+
+function buildPlayheadMap(clips: readonly TimelineClip[]): PlayheadMap {
+  const times: number[] = [];
+  const xs: number[] = [];
+  let x = 0;
+  for (const clip of clips) {
+    const width =
+      clip.kind === "collection"
+        ? Math.max(MIN_ITEM_WIDTH, COLLECTION_CARD_PX)
+        : durationToWidth(clip.duration, TIMELINE_PPS);
+    times.push(clip.startTime, clip.startTime + clip.duration);
+    xs.push(x, x + width);
+    x += width + STRIP_GAP_PX;
+  }
+  const count = times.length;
+  const total = count > 0 ? times[count - 1] : 0;
+
+  const interpolate = (value: number, from: number[], to: number[]): number => {
+    if (count === 0) return 0;
+    if (value <= from[0]) return to[0];
+    if (value >= from[count - 1]) return to[count - 1];
+    let low = 0;
+    let high = count - 1;
+    while (low < high - 1) {
+      const middle = (low + high) >> 1;
+      if (from[middle] <= value) low = middle;
+      else high = middle;
+    }
+    const span = from[high] - from[low];
+    const fraction = span > 0 ? (value - from[low]) / span : 0;
+    return to[low] + fraction * (to[high] - to[low]);
+  };
+
+  return {
+    xAt: (time) => interpolate(time, times, xs),
+    timeAt: (offset) => interpolate(offset, xs, times),
+    totalDurationSeconds: total,
+  };
+}
+
+type GridPlayheadMap = Readonly<{
+  posAt: (time: number) => { x: number; y: number };
+  timeAt: (x: number, y: number) => number;
+  totalDurationSeconds: number;
+  rowHeight: number;
+}>;
+
+function buildGridPlayheadMap(clips: readonly TimelineClip[], cols: number): GridPlayheadMap {
+  const columns = Math.max(1, cols);
+  const starts: number[] = [];
+  const ends: number[] = [];
+  for (const clip of clips) {
+    starts.push(clip.startTime);
+    ends.push(clip.startTime + clip.duration);
+  }
+  const count = clips.length;
+  const total = count > 0 ? ends[count - 1] : 0;
+  const cellX = (index: number) => (index % columns) * (GRID_CELL_WIDTH + GRID_GAP);
+  const cellY = (index: number) =>
+    Math.floor(index / columns) * (GRID_CELL_HEIGHT + GRID_GAP);
+  const clamp01 = (value: number) => Math.min(1, Math.max(0, value));
+
+  return {
+    rowHeight: GRID_CELL_HEIGHT,
+    totalDurationSeconds: total,
+    posAt: (time) => {
+      if (count === 0) return { x: 0, y: 0 };
+      let low = 0;
+      if (time >= starts[count - 1]) {
+        low = count - 1;
+      } else if (time > starts[0]) {
+        let high = count - 1;
+        while (low < high - 1) {
+          const middle = (low + high) >> 1;
+          if (starts[middle] <= time) low = middle;
+          else high = middle;
+        }
+      }
+      const span = ends[low] - starts[low];
+      const fraction = span > 0 ? clamp01((time - starts[low]) / span) : 0;
+      return { x: cellX(low) + fraction * GRID_CELL_WIDTH, y: cellY(low) };
+    },
+    timeAt: (x, y) => {
+      if (count === 0) return 0;
+      const row = Math.max(0, Math.floor(y / (GRID_CELL_HEIGHT + GRID_GAP)));
+      const column = Math.max(
+        0,
+        Math.min(columns - 1, Math.floor(x / (GRID_CELL_WIDTH + GRID_GAP))),
+      );
+      const index = Math.max(0, Math.min(count - 1, row * columns + column));
+      const fraction = clamp01((x - cellX(index)) / GRID_CELL_WIDTH);
+      return Math.min(
+        total,
+        Math.max(0, starts[index] + fraction * (ends[index] - starts[index])),
+      );
+    },
+  };
+}
+
+export function GraphPlayhead({
+  focusedId,
+  channel,
+}: Readonly<{
+  focusedId: string;
+  channel: PreviewTimeChannel;
+}>) {
+  const store = useCollectionsStore();
+  const detailsStore = useGraphDetailsStore();
+  const lineRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let lastGraph: CollectionsGraph | null = null;
+    let lastDetails: DetailsById | null = null;
+    let map: PlayheadMap | null = null;
+    const paint = () => {
+      const graph = store.getSnapshot().graph;
+      const details = detailsStore.read();
+      if (graph !== lastGraph || details !== lastDetails) {
+        lastGraph = graph;
+        lastDetails = details;
+        map = buildPlayheadMap(graphChildrenToClips(graph, details, focusedId));
+      }
+      const line = lineRef.current;
+      if (line && map) line.style.transform = `translateX(${map.xAt(channel.get())}px)`;
+    };
+    paint();
+    const unsubscribeTime = channel.subscribe(paint);
+    const unsubscribeStore = store.subscribe(paint);
+    const unsubscribeDetails = detailsStore.subscribe(paint);
+    return () => {
+      unsubscribeTime();
+      unsubscribeStore();
+      unsubscribeDetails();
+    };
+  }, [store, detailsStore, focusedId, channel]);
+
+  return (
+    <div
+      ref={lineRef}
+      data-graph-playhead
+      className="absolute inset-y-0 left-0 w-0.5 bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.9)]"
+    >
+      <div className="absolute -left-[5px] -top-2 h-0 w-0 border-x-[6px] border-t-[8px] border-x-transparent border-t-red-500" />
+    </div>
+  );
+}
+
+export function PlayheadScrubBand({
+  focusedId,
+  channel,
+}: Readonly<{
+  focusedId: string;
+  channel: PreviewTimeChannel;
+}>) {
+  const store = useCollectionsStore();
+  const detailsStore = useGraphDetailsStore();
+  const bandRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const band = bandRef.current;
+    if (!band) return;
+    const scroller = band.parentElement?.querySelector<HTMLElement>(".overflow-x-auto") ?? null;
+    if (!scroller) return;
+
+    let map: PlayheadMap | null = null;
+    let mapGraph: CollectionsGraph | null = null;
+    let mapDetails: DetailsById | null = null;
+    const seek = (event: PointerEvent) => {
+      const graph = store.getSnapshot().graph;
+      const details = detailsStore.read();
+      if (graph !== mapGraph || details !== mapDetails || !map) {
+        mapGraph = graph;
+        mapDetails = details;
+        map = buildPlayheadMap(graphChildrenToClips(graph, details, focusedId));
+      }
+      const rect = scroller.getBoundingClientRect();
+      const styles = getComputedStyle(scroller);
+      const contentX =
+        event.clientX -
+        rect.left -
+        parseFloat(styles.borderLeftWidth) -
+        parseFloat(styles.paddingLeft) +
+        scroller.scrollLeft;
+      channel.set(Math.max(0, Math.min(map.timeAt(contentX), map.totalDurationSeconds)));
+    };
+
+    let pointerId: number | null = null;
+    const handleMove = (event: PointerEvent) => {
+      if (event.pointerId === pointerId) seek(event);
+    };
+    const end = (event: PointerEvent) => {
+      if (event.pointerId !== pointerId) return;
+      pointerId = null;
+      window.removeEventListener("pointermove", handleMove);
+      window.removeEventListener("pointerup", end);
+      window.removeEventListener("pointercancel", end);
+    };
+    const handleDown = (event: PointerEvent) => {
+      if (!event.isPrimary || event.button !== 0) return;
+      pointerId = event.pointerId;
+      try {
+        band.setPointerCapture(event.pointerId);
+      } catch {
+        // Synthetic pointer: window listeners still own the lifecycle.
+      }
+      seek(event);
+      window.addEventListener("pointermove", handleMove);
+      window.addEventListener("pointerup", end);
+      window.addEventListener("pointercancel", end);
+    };
+
+    band.addEventListener("pointerdown", handleDown);
+    return () => {
+      band.removeEventListener("pointerdown", handleDown);
+      window.removeEventListener("pointermove", handleMove);
+      window.removeEventListener("pointerup", end);
+      window.removeEventListener("pointercancel", end);
+    };
+  }, [store, detailsStore, focusedId, channel]);
+
+  return (
+    <div
+      ref={bandRef}
+      data-playhead-scrub
+      aria-hidden="true"
+      className="absolute inset-x-0 top-0 z-10 h-3 cursor-ew-resize"
+    />
+  );
+}
+
+export function GraphGridPlayhead({
+  focusedId,
+  channel,
+}: Readonly<{
+  focusedId: string;
+  channel: PreviewTimeChannel;
+}>) {
+  const store = useCollectionsStore();
+  const detailsStore = useGraphDetailsStore();
+  const lineRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const line = lineRef.current;
+    if (!line) return;
+    const grid = line.closest<HTMLElement>("[data-virtual-grid]");
+    let lastGraph: CollectionsGraph | null = null;
+    let lastDetails: DetailsById | null = null;
+    let lastColumns = 0;
+    let map: GridPlayheadMap | null = null;
+
+    const paint = () => {
+      const graph = store.getSnapshot().graph;
+      const details = detailsStore.read();
+      const columns = Number(grid?.dataset.gridColumns) || 1;
+      if (graph !== lastGraph || details !== lastDetails || columns !== lastColumns) {
+        lastGraph = graph;
+        lastDetails = details;
+        lastColumns = columns;
+        map = buildGridPlayheadMap(graphChildrenToClips(graph, details, focusedId), columns);
+      }
+      if (!map) return;
+      const { x, y } = map.posAt(channel.get());
+      line.style.transform = `translate(${x}px, ${y}px)`;
+      line.style.height = `${map.rowHeight}px`;
+    };
+
+    paint();
+    const unsubscribeTime = channel.subscribe(paint);
+    const unsubscribeStore = store.subscribe(paint);
+    const unsubscribeDetails = detailsStore.subscribe(paint);
+    const observer = grid ? new ResizeObserver(paint) : null;
+    if (grid && observer) observer.observe(grid);
+    return () => {
+      unsubscribeTime();
+      unsubscribeStore();
+      unsubscribeDetails();
+      observer?.disconnect();
+    };
+  }, [store, detailsStore, focusedId, channel]);
+
+  return (
+    <div
+      ref={lineRef}
+      data-graph-grid-playhead
+      className="absolute left-0 top-0 w-0.5 bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.9)]"
+    >
+      <div className="absolute -left-[5px] -top-2 h-0 w-0 border-x-[6px] border-t-[8px] border-x-transparent border-t-red-500" />
+    </div>
+  );
+}
+
+export function GraphGridScrubSurface({
+  focusedId,
+  channel,
+}: Readonly<{
+  focusedId: string;
+  channel: PreviewTimeChannel;
+}>) {
+  const store = useCollectionsStore();
+  const detailsStore = useGraphDetailsStore();
+  const surfaceRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const surface = surfaceRef.current;
+    if (!surface) return;
+    const grid = surface.parentElement?.querySelector<HTMLElement>("[data-virtual-grid]") ?? null;
+    if (!grid) return;
+
+    let map: GridPlayheadMap | null = null;
+    let mapGraph: CollectionsGraph | null = null;
+    let mapDetails: DetailsById | null = null;
+    let mapColumns = 0;
+    const seek = (event: PointerEvent) => {
+      const graph = store.getSnapshot().graph;
+      const details = detailsStore.read();
+      const columns = Number(grid.dataset.gridColumns) || 1;
+      if (graph !== mapGraph || details !== mapDetails || columns !== mapColumns || !map) {
+        mapGraph = graph;
+        mapDetails = details;
+        mapColumns = columns;
+        map = buildGridPlayheadMap(graphChildrenToClips(graph, details, focusedId), columns);
+      }
+      const overlay = grid.querySelector<HTMLElement>("[data-virtual-grid-overlay]");
+      const rect = (overlay ?? grid).getBoundingClientRect();
+      channel.set(map.timeAt(event.clientX - rect.left, event.clientY - rect.top));
+    };
+
+    let pointerId: number | null = null;
+    const handleMove = (event: PointerEvent) => {
+      if (event.pointerId === pointerId) seek(event);
+    };
+    const end = (event: PointerEvent) => {
+      if (event.pointerId !== pointerId) return;
+      pointerId = null;
+      window.removeEventListener("pointermove", handleMove);
+      window.removeEventListener("pointerup", end);
+      window.removeEventListener("pointercancel", end);
+    };
+    const handleDown = (event: PointerEvent) => {
+      if (!event.isPrimary || event.button !== 0) return;
+      pointerId = event.pointerId;
+      try {
+        surface.setPointerCapture(event.pointerId);
+      } catch {
+        // Synthetic pointer: window listeners still own the lifecycle.
+      }
+      seek(event);
+      window.addEventListener("pointermove", handleMove);
+      window.addEventListener("pointerup", end);
+      window.addEventListener("pointercancel", end);
+    };
+    const handleWheel = (event: WheelEvent) => {
+      const scale = event.deltaMode === 1 ? 32 : 1;
+      const before = grid.scrollTop;
+      const maximum = grid.scrollHeight - grid.clientHeight;
+      const next = Math.max(0, Math.min(before + event.deltaY * scale, maximum));
+      if (next !== before) {
+        grid.scrollTop = next;
+        event.preventDefault();
+      }
+    };
+
+    surface.addEventListener("pointerdown", handleDown);
+    surface.addEventListener("wheel", handleWheel, { passive: false });
+    return () => {
+      surface.removeEventListener("pointerdown", handleDown);
+      surface.removeEventListener("wheel", handleWheel);
+      window.removeEventListener("pointermove", handleMove);
+      window.removeEventListener("pointerup", end);
+      window.removeEventListener("pointercancel", end);
+    };
+  }, [store, detailsStore, focusedId, channel]);
+
+  return (
+    <div
+      ref={surfaceRef}
+      data-grid-scrub
+      aria-hidden="true"
+      className="absolute inset-0 z-10 cursor-crosshair"
+    />
+  );
+}
+
+function GatewayDocumentsBridge() {
+  const { registerTimelineDocument } = useTimelineDocuments();
+  const seenRef = useRef<Readonly<Record<string, TimelineDocument>>>({});
+
+  useEffect(() => {
+    const sync = () => {
+      const seen = seenRef.current;
+      const current = graphDocumentsGateway.read();
+      if (current === seen) return;
+      for (const [id, document] of Object.entries(current)) {
+        if (seen[id] !== document) registerTimelineDocument(document, { persist: false });
+      }
+      seenRef.current = current;
+    };
+    sync();
+    return graphDocumentsGateway.subscribe(sync);
+  }, [registerTimelineDocument]);
+
+  return null;
+}
+
+export function PreviewShell({
+  enabled,
+  focusedId,
+  channel,
+  children,
+}: Readonly<{
+  enabled: boolean;
+  focusedId: string;
+  channel: PreviewTimeChannel;
+  children: React.ReactNode;
+}>) {
+  const graph = useCollectionsSelector((snapshot) => snapshot.graph);
+  const detailsStore = useGraphDetailsStore();
+  const details = useSyncExternalStore(
+    detailsStore.subscribe,
+    detailsStore.read,
+    detailsStore.read,
+  );
+  const clips = useMemo<TimelineClip[]>(
+    () => (enabled ? graphChildrenToClips(graph, details, focusedId) : []),
+    [enabled, graph, details, focusedId],
+  );
+  const [time, setTime] = useState(0);
+
+  useEffect(() => channel.subscribe(() => setTime(channel.get())), [channel]);
+  const handleTimeChange = useCallback(
+    (next: number) => {
+      setTime(next);
+      channel.set(next);
+    },
+    [channel],
+  );
+
+  useEffect(() => {
+    channel.set(0);
+  }, [channel, focusedId]);
+
+  const totalDuration =
+    clips.length > 0
+      ? clips[clips.length - 1].startTime + clips[clips.length - 1].duration
+      : 0;
+  useEffect(() => {
+    if (channel.get() > totalDuration) channel.set(totalDuration);
+  }, [channel, totalDuration]);
+
+  const [initialDocumentsState] = useState(() =>
+    createTimelineDocumentsState({ ...graphDocumentsGateway.read() }, {}),
+  );
+
+  if (!enabled) return <>{children}</>;
+
+  return (
+    <TimelineDocumentsProvider initialState={initialDocumentsState}>
+      <GatewayDocumentsBridge />
+      <WorkbenchSplitPane clips={clips} currentTime={time} onCurrentTimeChange={handleTimeChange}>
+        {children}
+      </WorkbenchSplitPane>
+    </TimelineDocumentsProvider>
+  );
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useContext, useState } from "react";
+
+import {
+  VirtualStrip,
+  getChildren,
+  parseNodeId,
+  useCollectionsSelector,
+  useCollectionsStore,
+  type NodeId,
+} from "@storyboard/ui/dnd-collections";
+
+import { Button } from "@/components/core/button";
+
+import { useClipDetail, useGraphDetailsStore } from "./graph-details-context";
+import { hydrateTimeline } from "./graph-hydration";
+import { GraphViewNavContext } from "./graph-navigation";
+import { TIMELINE_PPS } from "./graph-view-config";
+
+function SubTimelineSection({
+  collectionId,
+  name,
+  collapsed,
+  onToggleCollapsed,
+}: Readonly<{
+  collectionId: NodeId;
+  name: string;
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+}>) {
+  const nav = useContext(GraphViewNavContext);
+  const store = useCollectionsStore();
+  const detailsStore = useGraphDetailsStore();
+  const id = collectionId as string;
+  const detail = useClipDetail(id);
+  const hydrated = detail?.hydrated === true;
+  const liveCount = useCollectionsSelector((snapshot) =>
+    getChildren(snapshot.graph, collectionId).length,
+  );
+
+  return (
+    <section aria-label={`Sub-timeline: ${name}`}>
+      <div className="mb-1.5 flex items-center gap-2">
+        <span className="h-3 w-3 rounded-sm border border-dashed border-sky-500/60 bg-sky-500/20" />
+        <h3 className="text-sm font-semibold text-zinc-100">{name}</h3>
+        <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] text-zinc-300">
+          {hydrated ? liveCount : (detail?.itemCount ?? 0)} clips
+        </span>
+        {!hydrated && (
+          <span className="rounded border border-zinc-700 px-1.5 py-0.5 text-[10px] text-zinc-500">
+            loading…
+          </span>
+        )}
+        <span className="grow" />
+        {!hydrated && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              void hydrateTimeline(store, detailsStore, id);
+            }}
+          >
+            Load inline
+          </Button>
+        )}
+        {hydrated && (
+          <Button type="button" variant="ghost" size="sm" onClick={onToggleCollapsed}>
+            {collapsed ? "Expand" : "Collapse"}
+          </Button>
+        )}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => nav?.openTimeline(collectionId)}
+        >
+          Focus
+        </Button>
+      </div>
+
+      {hydrated && !collapsed && (
+        <VirtualStrip
+          collectionId={collectionId}
+          pixelsPerSecond={TIMELINE_PPS}
+          itemHeight={64}
+          itemDragActivation="hold"
+          className="bg-black/20"
+        />
+      )}
+    </section>
+  );
+}
+
+export function SubTimelines({ focusedId }: Readonly<{ focusedId: string }>) {
+  const graph = useCollectionsSelector((snapshot) => snapshot.graph);
+  const [collapsedIds, setCollapsedIds] = useState<ReadonlySet<string>>(new Set());
+
+  const collections = getChildren(graph, parseNodeId(focusedId)).filter(
+    (childId) => graph.nodesById.get(childId)?.kind === "collection",
+  );
+  if (collections.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-3">
+      {collections.map((collectionId) => {
+        const node = graph.nodesById.get(collectionId);
+        if (node?.kind !== "collection") return null;
+        const id = collectionId as string;
+        return (
+          <SubTimelineSection
+            key={id}
+            collectionId={collectionId}
+            name={node.name}
+            collapsed={collapsedIds.has(id)}
+            onToggleCollapsed={() =>
+              setCollapsedIds((current) => {
+                const next = new Set(current);
+                if (next.has(id)) next.delete(id);
+                else next.add(id);
+                return next;
+              })
+            }
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -1,1799 +1,42 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
 import {
-  createContext,
-  memo,
   useCallback,
-  useContext,
   useEffect,
   useMemo,
-  useRef,
   useState,
   useSyncExternalStore,
 } from "react";
-import { createPortal } from "react-dom";
-import { ArrowLeft } from "lucide-react";
 
 import {
   DndCollections,
-  PaletteItem,
-  TrashTarget,
-  UndoRedoControls,
-  VirtualGrid,
-  VirtualStrip,
   buildGraph,
-  getChildren,
-  mediaDurationSeconds,
-  parseNodeId,
-  useCollectionsContainer,
-  useCollectionsSelector,
-  useCollectionsStore,
-  useLiveTrim,
-  usePanWithMomentum,
-  videoFrameCount,
-  type CollectionGhostContentProps,
-  type CollectionItemContentProps,
-  type CollectionItemNode,
-  type CollectionTrimHandleContentProps,
-  type CollectionsChange,
-  type CollectionsComponents,
   type CollectionsGraph,
-  type CollectionsStore,
   type GraphNodeSpec,
-  type MediaNode,
-  type NodeId,
 } from "@storyboard/ui/dnd-collections";
-import {
-  buildHydrationSpecs,
-  collectAffectedCollectionIds,
-  collectUnhydratedDropTargets,
-  graphChildrenToClips,
-  type ClipDetail,
-  type DetailsById,
-} from "@storyboard/timeline-domain";
-import { MIN_ITEM_WIDTH, durationToWidth } from "@storyboard/ui/dnd-collections";
-import { WorkbenchSplitPane } from "@storyboard/ui/timeline/viewport/workbench-display-surface";
-import {
-  TimelineDocumentsProvider,
-  useTimelineDocuments,
-} from "@storyboard/ui/timeline/timeline-document-store";
-import { createTimelineDocumentsState } from "@storyboard/ui/timeline/timeline-documents";
-import type { TimelineClip, TimelineDocument } from "@storyboard/ui/timeline/types";
+import { buildHydrationSpecs, type ClipDetail } from "@storyboard/timeline-domain";
 
 import { useAuth } from "@/components/auth/auth-provider";
-import { Button } from "@/components/core/button";
-import {
-  collectReachableDetailIds,
-  createGraphDetailsStore,
-  type GraphDetailsStore,
-} from "@/lib/graph-details-store";
+import { createGraphDetailsStore } from "@/lib/graph-details-store";
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 import { GRAPH_ASSETS_TOGGLE_EVENT } from "@/lib/graph-view-events";
-import type { CloudinaryAsset } from "@/lib/cloudinary-media-store";
 
-// The graph project view — phase 3 of docs/storyboard-graph-architecture.md,
-// running against the app's REAL persistence (the same auth-gated
-// GET/PATCH /api/timelines contract the storyboard/workbench views use):
-//
-//   - ONE <DndCollections> owns the whole view session. Focus (the URL's
-//     catch-all path) is pure view state read from usePathname(); the
-//     provider mounts once per project (hosted by the route-group layout —
-//     pages remount per param change, layouts persist), so the UNDO STACK
-//     SURVIVES drill-in navigation.
-//   - Documents hydrate on focus through the engine's hydration seam
-//     (`store.hydrate`): navigating to a collection fetches its document
-//     and fills the placeholder in place — async IO, invisible to undo and
-//     the change feed.
-//   - Persistence is patch-scoped: every committed change (command, undo,
-//     redo) is mapped by `collectAffectedCollectionIds` to the documents it
-//     touched, and ONLY those are PATCHed (debounced per timeline) — no
-//     parent-scan resync pass.
-//
-// Deliberately additive: nothing in the storyboard/workbench pipeline is
-// imported or modified. Both view systems speak the same storage contract,
-// which is the whole migration strategy.
-
-const TIMELINE_PPS = 40;
-
-/** How the FOCUSED timeline's children render: duration-mapped strip or a
- *  wrapping grid (better at scale). Per-view state, deliberately outside
- *  the store — the graph doesn't know or care how a view projects it. */
-type FocusSurface = "strip" | "grid";
-
-function SurfaceToggle({
-  surface,
-  onChange,
-}: Readonly<{ surface: FocusSurface; onChange: (surface: FocusSurface) => void }>) {
-  return (
-    <div
-      role="group"
-      aria-label="Focused timeline layout"
-      className="flex items-center rounded-md border border-zinc-800 p-0.5"
-    >
-      {(["strip", "grid"] as const).map((option) => (
-        <button
-          key={option}
-          type="button"
-          aria-pressed={surface === option}
-          onClick={() => onChange(option)}
-          className={[
-            "rounded px-2 py-1 text-xs capitalize transition-colors",
-            surface === option
-              ? "bg-zinc-800 text-zinc-100"
-              : "text-zinc-500 hover:text-zinc-200",
-          ].join(" ")}
-        >
-          {option}
-        </button>
-      ))}
-    </div>
-  );
-}
-
-// ── Details side-table store ────────────────────────────────────────────────
-// The details table lives in an EXTERNAL store (see lib/graph-details-store):
-// components subscribe to exactly the slice they render. The context carries
-// the STORE — a per-view-session constant — so providing it never re-renders
-// a consumer; only each consumer's own subscription does.
-
-const GraphDetailsStoreContext = createContext<GraphDetailsStore | null>(null);
-
-function useGraphDetailsStore(): GraphDetailsStore {
-  const store = useContext(GraphDetailsStoreContext);
-  if (store === null) {
-    throw new Error("useGraphDetailsStore must be used inside the graph view's provider tree.");
-  }
-  return store;
-}
-
-/** ONE node's detail: the card re-renders when its own entry changes
- *  (hydration landing, a palette claim) and never for anyone else's. */
-function useClipDetail(id: string): ClipDetail | undefined {
-  const store = useGraphDetailsStore();
-  return useSyncExternalStore(
-    store.subscribe,
-    () => store.get(id),
-    () => store.get(id),
-  );
-}
-
-// ── Navigation context ──────────────────────────────────────────────────────
-// Content components are module-scope (identity-stable, per the package's
-// registry contract), so drill-in reaches them via context. Deliberately
-// SLIM — just the navigation callback: detail lookups go through the details
-// store, so this value only changes when the focus itself does.
-
-type GraphViewNav = Readonly<{
-  openTimeline: (nodeId: NodeId) => void;
-}>;
-
-const GraphViewNavContext = createContext<GraphViewNav | null>(null);
-
-function GraphViewNavProvider({
-  projectId,
-  focusedId,
-  children,
-}: Readonly<{
-  projectId: string;
-  focusedId: string;
-  children: React.ReactNode;
-}>) {
-  const router = useRouter();
-  const store = useCollectionsStore();
-  const detailsStore = useGraphDetailsStore();
-
-  const value = useMemo<GraphViewNav>(
-    () => ({
-      openTimeline: (nodeId) => {
-        // A duplicate-reference card opens the timeline it points at.
-        const timelineId =
-          detailsStore.get(nodeId as string)?.duplicateOfTimelineId ?? (nodeId as string);
-        if (timelineId === focusedId) return;
-        const base = `/timeline/${encodeURIComponent(projectId)}/graph`;
-        if (timelineId === projectId) {
-          router.push(base);
-          return;
-        }
-        // Focus paths are PROJECT-anchored: walk up the LIVE graph (the node
-        // may have been dragged elsewhere since it appeared) to the root.
-        const { graph } = store.getSnapshot();
-        const chain: string[] = [timelineId];
-        let parent = graph.parentById.get(parseNodeId(timelineId)) ?? null;
-        while (parent !== null && (parent as string) !== projectId) {
-          chain.unshift(parent as string);
-          parent = graph.parentById.get(parent) ?? null;
-        }
-        if ((parent as string | null) !== projectId) return; // detached — no route to it
-        router.push(`${base}/${chain.map(encodeURIComponent).join("/")}`);
-      },
-    }),
-    [detailsStore, focusedId, projectId, router, store],
-  );
-
-  return <GraphViewNavContext.Provider value={value}>{children}</GraphViewNavContext.Provider>;
-}
-
-/**
- * Keyboard path to drill-in: "O" on a focused collection card opens it.
- * Collection cards render their open affordance as a double-click on the
- * card CONTENT, but the focusable element is the card's selection button —
- * an interactive child inside a button would be invalid HTML, so pointer-
- * free users had no way to invoke it. The card's keyboard surface is owned
- * by the package (Enter grabs, arrows rove, Alt+arrows move), so the app
- * claims a free key at a bubble boundary instead of touching the shell.
- *
- * display: contents — a listener boundary only, invisible to layout.
- *
- * NOTE for the upcoming interaction model (click = navigate on collections):
- * this key stays the keyboard twin of whatever pointer gesture navigation
- * settles on; only the hint copy should need to change.
- */
-function OpenKeyBoundary({ children }: Readonly<{ children: React.ReactNode }>) {
-  const nav = useContext(GraphViewNavContext);
-  const store = useCollectionsStore();
-  const detailsStore = useGraphDetailsStore();
-
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== "o" && event.key !== "O") return;
-    if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
-    // A keyboard-grabbed card is mid-drag: navigating away now would strand
-    // the drag session in a view where its source card no longer exists.
-    if (store.getSnapshot().interaction.isDragging) return;
-    const target = event.target as HTMLElement;
-    // Never swallow typing (no editable fields render in the board today,
-    // but a future rename input inside a card must not lose its "o").
-    if (target.closest("input, textarea, [contenteditable=true]")) return;
-    const id = target.closest<HTMLElement>("[data-node-id]")?.dataset.nodeId;
-    if (!id) return;
-    const node = store.getSnapshot().graph.nodesById.get(parseNodeId(id));
-    // Same set double-click navigates: collections, plus duplicate-reference
-    // cards (openTimeline resolves those to the timeline they point at).
-    const opensTimeline =
-      node?.kind === "collection" || detailsStore.get(id)?.duplicateOfTimelineId !== undefined;
-    if (!opensTimeline) return;
-    event.preventDefault();
-    nav?.openTimeline(parseNodeId(id));
-  };
-
-  return (
-    <div style={{ display: "contents" }} onKeyDown={handleKeyDown}>
-      {children}
-    </div>
-  );
-}
-
-// ── Async hydration ─────────────────────────────────────────────────────────
-
-/**
- * Fetch (if needed) and hydrate one placeholder timeline through the
- * engine's hydration seam, committing the side-table entries straight into
- * the details store. Commits are immediate and UNCONDITIONAL — callers'
- * cancellation guards focus-scoped work, but these entries are GRAPH-scoped:
- * `store.hydrate` here mutates the shared graph, which outlives any focus
- * run, and a hydrated node without its aspect/poster/trim metadata would
- * bake fallback values into the next write touching its document. Levels as
- * in `buildHydrationSpecs` — the gateway caches one document per fetch, so
- * hydration is always level 0 (a timeline's own clips; its child collections
- * stay placeholders until focused or expanded).
- */
-async function hydrateTimeline(
-  store: CollectionsStore,
-  detailsStore: GraphDetailsStore,
-  timelineId: string,
-): Promise<void> {
-  if (detailsStore.get(timelineId)?.hydrated === true) return;
-
-  const doc = await graphDocumentsGateway.ensure(timelineId);
-  if (!doc) return;
-
-  // Re-read graph AND details — the await may have raced another hydration
-  // (the store reads synchronously, so post-await reads are always current).
-  const current = store.getSnapshot().graph;
-  if (!current.nodesById.has(parseNodeId(timelineId))) return;
-
-  if (getChildren(current, parseNodeId(timelineId)).length > 0) {
-    // REPAIR path: the graph holds this collection's children but the
-    // side-table never recorded them (a past run hydrated the graph, then
-    // its details were lost — or another hydration raced this one). The
-    // graph can't be re-hydrated (the engine only fills empty collections),
-    // but the details CAN be rebuilt from the cached document. Fill only
-    // entries that are missing — never overwrite committed ones (a child
-    // collection's own `hydrated: true` must survive a parent repair).
-    const payload = buildHydrationSpecs(graphDocumentsGateway.read(), timelineId, 0);
-    if (!payload.ok) return;
-    const details = detailsStore.read();
-    const merged: Record<string, ClipDetail> = {};
-    for (const [id, detail] of Object.entries(payload.value.details)) {
-      if (details[id] === undefined && current.nodesById.has(parseNodeId(id))) {
-        merged[id] = detail;
-      }
-    }
-    const own = details[timelineId];
-    merged[timelineId] = own ? { ...own, hydrated: true } : { ...FALLBACK_DETAIL, hydrated: true };
-    detailsStore.merge(merged);
-    return;
-  }
-
-  const payload = buildHydrationSpecs(
-    graphDocumentsGateway.read(),
-    timelineId,
-    0,
-    current.nodesById.keys(),
-  );
-  if (!payload.ok) return;
-  const applied = store.hydrate(parseNodeId(timelineId), payload.value.specs);
-  if (!applied.ok) return;
-
-  const merged: Record<string, ClipDetail> = { ...payload.value.details };
-  const own = detailsStore.get(timelineId);
-  merged[timelineId] = own ? { ...own, hydrated: true } : { ...FALLBACK_DETAIL, hydrated: true };
-  detailsStore.merge(merged);
-}
-
-/** Detail for a timeline the graph knows only as a root (no source clip). */
-const FALLBACK_DETAIL: ClipDetail = { alt: "", aspect: 16 / 9, trackIndex: 0 };
-
-/**
- * Keeps the graph hydrated for the current focus path: every route segment's
- * document is fetched and loaded (deep links land on a root-only graph),
- * then the focused timeline's child collections load their own clips so the
- * inline sub-timelines render. Renders nothing; runs at navigation cadence,
- * cancellation-safe across route changes.
- */
-function HydrationController({
-  projectId,
-  segments,
-  onFocusError,
-}: Readonly<{
-  projectId: string;
-  segments: readonly string[];
-  onFocusError: (error: string | null) => void;
-}>) {
-  const store = useCollectionsStore();
-  const detailsStore = useGraphDetailsStore();
-  const pathKey = segments.join("/");
-
-  useEffect(() => {
-    let cancelled = false;
-    const path = pathKey === "" ? [] : pathKey.split("/");
-    const focusedId = path[path.length - 1] ?? projectId;
-
-    void (async () => {
-      // hydrateTimeline reads and commits the details store directly — the
-      // synchronous store is what killed this effect's old ref-mirroring and
-      // local-accumulator workarounds, and detail commits no longer cancel
-      // and restart the in-flight traversal (the store reference is stable).
-      const ensure = (timelineId: string) => hydrateTimeline(store, detailsStore, timelineId);
-
-      let error: string | null = null;
-      let previous: string | null = null;
-      for (const segment of [projectId, ...path]) {
-        if (cancelled) return;
-        const graph = store.getSnapshot().graph;
-        const node = graph.nodesById.get(parseNodeId(segment));
-        // Kind check: a media clip's id in the path is not a timeline.
-        if (node === undefined || node.kind !== "collection") {
-          error = `This project has no timeline "${segment}".`;
-          break;
-        }
-        // Chain check: each focus segment must be a CHILD of the previous
-        // one. Existence alone would accept the trash root or any collection
-        // loaded elsewhere in the graph (crafted or stale URLs) — focusing
-        // content the path never led to. Runs after the previous segment's
-        // hydration, so the parent edge is present for legitimate deep
-        // links; a collection that was MOVED since the URL was minted fails
-        // here and lands on the route's unknown-timeline state.
-        if (previous !== null && graph.parentById.get(parseNodeId(segment)) !== parseNodeId(previous)) {
-          error = `Timeline "${segment}" is not inside "${previous}".`;
-          break;
-        }
-        await ensure(segment);
-        previous = segment;
-      }
-      if (error === null && !cancelled) {
-        // The focused timeline's placeholder child collections load their
-        // own clips so their inline strips have content. Fetches run in
-        // parallel; hydration applies as each lands.
-        const collectionChildrenOf = (id: string) => {
-          const graph = store.getSnapshot().graph;
-          return getChildren(graph, parseNodeId(id))
-            .filter((childId) => graph.nodesById.get(childId)?.kind === "collection")
-            .map((childId) => childId as string);
-        };
-        const children = collectionChildrenOf(focusedId);
-        await Promise.all(children.map(ensure));
-        if (!cancelled) {
-          // One more shallow level: grandchild collections are VISIBLE as
-          // cards inside the sub-timeline strips, and every visible
-          // collection is a drop target — hydrating them keeps the
-          // gate-until-hydrated bounce (PersistenceBridge) a rare race
-          // fallback instead of the common path.
-          const grandchildren = children.flatMap(collectionChildrenOf);
-          await Promise.all(grandchildren.map(ensure));
-        }
-      }
-      if (cancelled) return;
-      onFocusError(error);
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [pathKey, projectId, store, detailsStore, onFocusError]);
-
-  return null;
-}
-
-// ── Asset palette ───────────────────────────────────────────────────────────
-// The user's Cloudinary library as external drag sources: PaletteItem's
-// factory runs at drag START (fresh node id per drag), and the drop commits
-// an ordinary add-nodes through the intent pipeline — undoable, persisted
-// patch-scoped like any other change.
-
-/** App-side fields for a node created by a palette drag, keyed by the
- *  freshly minted node id. The factory can't reach React state (it runs
- *  inside dnd-kit's drag start), so it parks the detail here and the
- *  PersistenceBridge claims it when the add COMMITS — before the first
- *  write, so poster/aspect round-trip into the stored clip. */
-const pendingPaletteDetails = new Map<string, ClipDetail>();
-
-const DEFAULT_IMAGE_SECONDS = 4;
-const DEFAULT_VIDEO_SECONDS = 8;
-
-function assetDisplayName(asset: CloudinaryAsset): string {
-  const path = asset.relativePath ?? asset.pathname;
-  return path.split("/").pop() ?? path;
-}
-
-function createNodeFromAsset(asset: CloudinaryAsset): CollectionItemNode {
-  // One drag is in flight at a time, and the bridge deletes the entry on
-  // commit — so anything still in the map here is leftover from a CANCELLED
-  // or rejected drag (its minted id can never be referenced again). Clearing
-  // at the next drag start caps the leak at a single stale entry.
-  pendingPaletteDetails.clear();
-  const id = parseNodeId(
-    `asset-${asset.id}-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`,
-  );
-  const name = assetDisplayName(asset);
-  const aspect =
-    asset.width && asset.height && asset.height > 0 ? asset.width / asset.height : 16 / 9;
-  pendingPaletteDetails.set(id as string, {
-    alt: name,
-    aspect,
-    trackIndex: 0,
-    poster: asset.thumbnailUrl,
-    ...(asset.resourceType === "image"
-      ? { sourceDuration: DEFAULT_IMAGE_SECONDS, trimIn: 0, trimOut: 0 }
-      : {}),
-  });
-  if (asset.resourceType === "video") {
-    return {
-      id,
-      kind: "media",
-      mediaKind: "video",
-      name,
-      src: asset.url,
-      posterSrcs: [asset.thumbnailUrl],
-      // Real duration from the Search-API listing; the default only covers
-      // the degraded duration-less listing path.
-      fullDurationSeconds: asset.duration ?? DEFAULT_VIDEO_SECONDS,
-      trimInSeconds: 0,
-      trimOutSeconds: 0,
-    };
-  }
-  return {
-    id,
-    kind: "media",
-    mediaKind: "image",
-    name,
-    src: asset.url,
-    durationSeconds: DEFAULT_IMAGE_SECONDS,
-  };
-}
-
-type AssetPaletteState =
-  | Readonly<{ status: "loading" }>
-  | Readonly<{ status: "error"; message: string }>
-  | Readonly<{ status: "ready"; assets: readonly CloudinaryAsset[]; truncated: boolean }>;
-
-const PALETTE_ASSET_LIMIT = 48;
-
-/**
- * The graph view's asset surface: the SAME bottom-drawer position and look
- * as the app's legacy asset library, but its thumbnails are PaletteItems —
- * external dnd-collections drag sources. Rendered via a portal FROM INSIDE
- * the provider (portals keep React context, so dnd-kit wiring works across
- * it) because the drawer must float over the whole page. The sidebar's
- * Assets button opens this drawer on graph routes (see
- * lib/graph-view-events.ts); the legacy drawer — whose media-strip drags
- * cannot land on dnd-collections timelines — stays off these routes.
- */
-/**
- * The scrollable thumbnail rail. Its OWN component on purpose:
- * `usePanWithMomentum` attaches listeners in an effect that reads the ref
- * once (its deps never change), so the hook must run in the component that
- * MOUNTS the scroll container — hoisted into the drawer (which renders this
- * rail conditionally), the ref would still be null when the effect ran and
- * grab-to-pan would silently never engage.
- */
-function PaletteRail({ assets }: Readonly<{ assets: readonly CloudinaryAsset[] }>) {
-  const store = useCollectionsStore();
-  const railRef = useRef<HTMLDivElement>(null);
-
-  // Grab-to-pan with momentum, exactly like the timeline strips: the rail's
-  // hold marker (below) makes thumbnail presses press-and-hold to DRAG, so
-  // fast swipes cancel the pending drag and pan instead; the pan stands
-  // down when a still press claims the pointer.
-  const panOptions = useMemo<Parameters<typeof usePanWithMomentum>[2]>(
-    () => ({ isGestureClaimed: () => store.getSnapshot().interaction.isDragging }),
-    [store],
-  );
-  usePanWithMomentum(railRef, "x", panOptions);
-
-  return (
-    // The hold marker routes thumbnail presses through press-and-hold
-    // activation (CollectionsPointerSensor), freeing fast swipes for the
-    // grab-to-pan. pan-y leaves vertical touch scrolling to the page.
-    <div
-      ref={railRef}
-      data-drag-activation="hold"
-      className="flex cursor-grab gap-2 overflow-x-auto pb-1 select-none active:cursor-grabbing"
-      style={{ touchAction: "pan-y" }}
-    >
-      {assets.map((asset) => (
-        <PaletteItem
-          key={asset.id}
-          paletteId={`asset-${asset.id}`}
-          createNode={() => createNodeFromAsset(asset)}
-          className="relative h-24 w-36 shrink-0 overflow-hidden p-0"
-        >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={asset.thumbnailUrl}
-            alt={assetDisplayName(asset)}
-            draggable={false}
-            loading="lazy"
-            className="h-full w-full object-cover"
-          />
-          {asset.resourceType === "video" && (
-            <span className="absolute bottom-1 left-1 rounded bg-black/75 px-1 py-0.5 text-[9px] font-bold tracking-wide text-zinc-100">
-              VIDEO
-            </span>
-          )}
-        </PaletteItem>
-      ))}
-    </div>
-  );
-}
-
-function AssetPaletteDrawer({ open, onClose }: Readonly<{ open: boolean; onClose: () => void }>) {
-  const [state, setState] = useState<AssetPaletteState>({ status: "loading" });
-
-  // Lazy: fetch on first open, keep a SUCCESS for the session. Failures are
-  // never latched (the old fetched-once ref marked the attempt as done
-  // before it ran, so one transient error made the palette unrecoverable
-  // until reload): the error state has its own Retry, and closing an
-  // errored drawer resets it so the next open refetches.
-  const handleClose = () => {
-    if (state.status === "error") setState({ status: "loading" });
-    onClose();
-  };
-
-  useEffect(() => {
-    if (!open || state.status !== "loading") return;
-    let cancelled = false;
-    void (async () => {
-      try {
-        const response = await fetch("/api/assets", { cache: "no-store" });
-        const result = (await response.json().catch(() => ({}))) as {
-          assets?: CloudinaryAsset[];
-          error?: string;
-        };
-        if (cancelled) return;
-        if (!response.ok || !result.assets) {
-          setState({ status: "error", message: result.error ?? "Could not load assets." });
-          return;
-        }
-        setState({
-          status: "ready",
-          assets: result.assets.slice(0, PALETTE_ASSET_LIMIT),
-          truncated: result.assets.length > PALETTE_ASSET_LIMIT,
-        });
-      } catch (cause) {
-        if (!cancelled) {
-          setState({
-            status: "error",
-            message: cause instanceof Error ? cause.message : "Could not load assets.",
-          });
-        }
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [open, state.status]);
-
-  if (!open || typeof document === "undefined") return null;
-
-  return createPortal(
-    // z-40: above the page content (strips top out at z-30) but BELOW
-    // dnd-kit's DragOverlay (z-index 999) — the drag ghost must float over
-    // this drawer, not under it.
-    <section
-      aria-label="Asset palette"
-      className="pointer-events-none fixed inset-x-0 bottom-0 z-40"
-    >
-      <aside
-        role="dialog"
-        aria-modal="false"
-        aria-label="Asset palette"
-        className="pointer-events-auto ml-[72px] flex max-h-[38vh] flex-col border-t border-zinc-800 bg-zinc-950 p-3 text-white shadow-2xl shadow-black/50"
-      >
-        <div className="mb-2 flex items-center gap-3">
-          <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">
-            Assets
-          </h3>
-          <span className="text-[10px] text-zinc-600">
-            Drag a thumbnail into any timeline · Enter picks one up for keyboard placement
-          </span>
-          <span className="grow" />
-          <Button type="button" variant="ghost" size="sm" onClick={handleClose}>
-            Close
-          </Button>
-        </div>
-        {state.status === "loading" && (
-          <div className="flex gap-2">
-            {Array.from({ length: 6 }).map((_, index) => (
-              <div
-                key={index}
-                className="h-24 w-36 shrink-0 animate-pulse rounded-md bg-zinc-900"
-              />
-            ))}
-          </div>
-        )}
-        {state.status === "error" && (
-          <div className="flex items-center gap-3 rounded-md border border-zinc-800 px-3 py-2">
-            <p className="text-xs text-zinc-500">{state.message}</p>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => setState({ status: "loading" })}
-            >
-              Retry
-            </Button>
-          </div>
-        )}
-        {state.status === "ready" &&
-          (state.assets.length === 0 ? (
-            <p className="rounded-md border border-zinc-800 px-3 py-2 text-xs text-zinc-500">
-              No assets yet — upload some from the asset library on the storyboard view.
-            </p>
-          ) : (
-            <>
-              <PaletteRail assets={state.assets} />
-              {state.truncated && (
-                <p className="mt-1 text-[10px] text-zinc-600">
-                  Showing the newest {PALETTE_ASSET_LIMIT} assets — the full library is on the
-                  storyboard view.
-                </p>
-              )}
-            </>
-          ))}
-      </aside>
-    </section>,
-    document.body,
-  );
-}
-
-// ── Playback preview ────────────────────────────────────────────────────────
-// The graph view drives the SAME preview surface the legacy workbench uses
-// (WorkbenchSplitPane: player + transport + draggable divider), fed with the
-// focused timeline's clips projected from the graph at commit cadence. Two
-// render-cost decisions keep playback cheap:
-//
-//   - The board rides through PreviewShell as `children`, so the per-frame
-//     time state inside the shell never re-renders a single card (stable
-//     children identity skips the whole subtree).
-//   - The strip's playhead paints IMPERATIVELY: time ticks travel a
-//     ref-backed channel (never React state), and the line's transform is
-//     written directly — the documented createTimeToOffset pattern.
-
-type PreviewTimeChannel = Readonly<{
-  get: () => number;
-  set: (time: number) => void;
-  subscribe: (listener: () => void) => () => void;
-}>;
-
-function createPreviewTimeChannel(): PreviewTimeChannel {
-  let time = 0;
-  const listeners = new Set<() => void>();
-  return {
-    get: () => time,
-    set: (next) => {
-      time = next;
-      for (const listener of listeners) listener();
-    },
-    subscribe: (listener) => {
-      listeners.add(listener);
-      return () => {
-        listeners.delete(listener);
-      };
-    },
-  };
-}
-
-/**
- * Bidirectional playback-time ↔ content-x map over the SAME clips
- * projection the preview pane plays. This matters: the pane's clock runs
- * over the projected TimelineClips — packing gaps and collection durations
- * included — so the playhead must map that clock, not the engine's
- * media-only contiguous one, or it drifts around collections and gaps.
- * Widths use the strip's own conversions (durationToWidth for media at
- * TIMELINE_PPS, the 128px default card for collections), interpolating
- * linearly inside each clip and across each gap.
- */
-type PlayheadMap = Readonly<{
-  xAt: (time: number) => number;
-  timeAt: (x: number) => number;
-  totalDurationSeconds: number;
-}>;
-
-const STRIP_GAP_PX = 8; // VirtualStrip's default gap
-const COLLECTION_CARD_PX = 128; // VirtualStrip's default itemWidth
-
-function buildPlayheadMap(clips: readonly TimelineClip[]): PlayheadMap {
-  // Piecewise-linear anchors (t, x) at every clip edge; gaps between clips
-  // span their own time (CLIP_GAP_SECONDS) across the strip's gap pixels.
-  const times: number[] = [];
-  const xs: number[] = [];
-  let x = 0;
-  for (const clip of clips) {
-    const width =
-      clip.kind === "collection"
-        ? Math.max(MIN_ITEM_WIDTH, COLLECTION_CARD_PX)
-        : durationToWidth(clip.duration, TIMELINE_PPS);
-    times.push(clip.startTime, clip.startTime + clip.duration);
-    xs.push(x, x + width);
-    x += width + STRIP_GAP_PX;
-  }
-  const count = times.length;
-  const total = count > 0 ? times[count - 1] : 0;
-
-  const lerp = (value: number, from: number[], to: number[]): number => {
-    if (count === 0) return 0;
-    if (value <= from[0]) return to[0];
-    if (value >= from[count - 1]) return to[count - 1];
-    let lo = 0;
-    let hi = count - 1;
-    while (lo < hi - 1) {
-      const mid = (lo + hi) >> 1;
-      if (from[mid] <= value) lo = mid;
-      else hi = mid;
-    }
-    const span = from[hi] - from[lo];
-    const fraction = span > 0 ? (value - from[lo]) / span : 0;
-    return to[lo] + fraction * (to[hi] - to[lo]);
-  };
-
-  return {
-    xAt: (time) => lerp(time, times, xs),
-    timeAt: (offset) => lerp(offset, xs, times),
-    totalDurationSeconds: total,
-  };
-}
-
-// Grid surface cell geometry — must match the <VirtualGrid> props below and
-// its default gap, since the playhead maps time onto that exact layout.
-const GRID_CELL_W = 160;
-const GRID_CELL_H = 96;
-const GRID_GAP = 8;
-
-/**
- * The grid analog of buildPlayheadMap. In the grid every cell is the SAME
- * width regardless of the clip's duration, so time maps onto a cell as a
- * fraction of that constant width, and the playhead advances cell-by-cell,
- * wrapping down a row every `cols` clips. `timeAt` is 2D — column from x AND
- * row from y — so a scrub can move within a row or jump rows.
- */
-type GridPlayheadMap = Readonly<{
-  posAt: (time: number) => { x: number; y: number };
-  timeAt: (x: number, y: number) => number;
-  totalDurationSeconds: number;
-  rowHeight: number;
-}>;
-
-function buildGridPlayheadMap(clips: readonly TimelineClip[], cols: number): GridPlayheadMap {
-  const columns = Math.max(1, cols);
-  const starts: number[] = [];
-  const ends: number[] = [];
-  for (const clip of clips) {
-    starts.push(clip.startTime);
-    ends.push(clip.startTime + clip.duration);
-  }
-  const n = clips.length;
-  const total = n > 0 ? ends[n - 1] : 0;
-  const cellX = (i: number) => (i % columns) * (GRID_CELL_W + GRID_GAP);
-  const cellY = (i: number) => Math.floor(i / columns) * (GRID_CELL_H + GRID_GAP);
-  const clamp01 = (value: number) => Math.min(1, Math.max(0, value));
-
-  return {
-    rowHeight: GRID_CELL_H,
-    totalDurationSeconds: total,
-    posAt: (time) => {
-      if (n === 0) return { x: 0, y: 0 };
-      // Last clip whose start <= time (binary search); time landing in the
-      // gap after a clip clamps to that clip's right edge.
-      let lo = 0;
-      if (time >= starts[n - 1]) {
-        lo = n - 1;
-      } else if (time > starts[0]) {
-        let hi = n - 1;
-        while (lo < hi - 1) {
-          const mid = (lo + hi) >> 1;
-          if (starts[mid] <= time) lo = mid;
-          else hi = mid;
-        }
-      }
-      const span = ends[lo] - starts[lo];
-      const frac = span > 0 ? clamp01((time - starts[lo]) / span) : 0;
-      return { x: cellX(lo) + frac * GRID_CELL_W, y: cellY(lo) };
-    },
-    timeAt: (x, y) => {
-      if (n === 0) return 0;
-      const row = Math.max(0, Math.floor(y / (GRID_CELL_H + GRID_GAP)));
-      const col = Math.max(0, Math.min(columns - 1, Math.floor(x / (GRID_CELL_W + GRID_GAP))));
-      const i = Math.max(0, Math.min(n - 1, row * columns + col));
-      const frac = clamp01((x - cellX(i)) / GRID_CELL_W);
-      return Math.min(total, Math.max(0, starts[i] + frac * (ends[i] - starts[i])));
-    },
-  };
-}
-
-/** The red playhead over the focused strip — a line with a triangle cap,
- *  strictly presentational (the strip overlay layer is aria-hidden and
- *  pointer-events: none; scrubbing lives in PlayheadScrubBand outside the
- *  strip). Rebuilds its map when the graph identity changes (commits AND
- *  hydration), repaints on every channel tick — no React render on either. */
-function GraphPlayhead({
-  focusedId,
-  channel,
-}: Readonly<{ focusedId: string; channel: PreviewTimeChannel }>) {
-  const store = useCollectionsStore();
-  const detailsStore = useGraphDetailsStore();
-  const lineRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    let lastGraph: CollectionsGraph | null = null;
-    let lastDetails: DetailsById | null = null;
-    let map: PlayheadMap | null = null;
-    const paint = () => {
-      const graph = store.getSnapshot().graph;
-      const details = detailsStore.read();
-      if (graph !== lastGraph || details !== lastDetails) {
-        lastGraph = graph;
-        lastDetails = details;
-        map = buildPlayheadMap(graphChildrenToClips(graph, details, focusedId));
-      }
-      const line = lineRef.current;
-      if (line && map) line.style.transform = `translateX(${map.xAt(channel.get())}px)`;
-    };
-    paint();
-    const unsubscribeTime = channel.subscribe(paint);
-    const unsubscribeStore = store.subscribe(paint);
-    const unsubscribeDetails = detailsStore.subscribe(paint);
-    return () => {
-      unsubscribeTime();
-      unsubscribeStore();
-      unsubscribeDetails();
-    };
-  }, [store, detailsStore, focusedId, channel]);
-
-  return (
-    <div
-      ref={lineRef}
-      data-graph-playhead
-      className="absolute inset-y-0 left-0 w-0.5 bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.9)]"
-    >
-      {/* Triangle cap: lifted into the strip's top padding (p-2 = 8px, the
-          triangle's exact height) so it sits ABOVE the items, tip meeting the
-          line at their top edge. Absolute, so it still costs no layout. */}
-      <div
-        className="absolute -left-[5px] -top-2 h-0 w-0 border-x-[6px] border-t-[8px] border-x-transparent border-t-red-500"
-      />
-    </div>
-  );
-}
-
-/**
- * The interactive scrub surface: a thin band overlaying the strip's top
- * edge (absolute — no layout shift). The strip's own overlay layer is
- * contractually non-interactive, so the triangle/line VISUALS ride there
- * while THIS band owns the pointer: press or drag anywhere on it to seek —
- * the drag starts wherever the playhead triangle is, which is what makes
- * the triangle feel draggable.
- */
-function PlayheadScrubBand({
-  focusedId,
-  channel,
-}: Readonly<{ focusedId: string; channel: PreviewTimeChannel }>) {
-  const store = useCollectionsStore();
-  const detailsStore = useGraphDetailsStore();
-  const bandRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const band = bandRef.current;
-    if (!band) return;
-    // The strip's scroll container is the band's next sibling subtree; the
-    // seek math needs its live scrollLeft and content origin per event.
-    const scroller = band.parentElement?.querySelector<HTMLElement>(".overflow-x-auto") ?? null;
-    if (!scroller) return;
-
-    let map: PlayheadMap | null = null;
-    let mapGraph: CollectionsGraph | null = null;
-    let mapDetails: DetailsById | null = null;
-    const seek = (event: PointerEvent) => {
-      const graph = store.getSnapshot().graph;
-      const details = detailsStore.read();
-      if (graph !== mapGraph || details !== mapDetails || !map) {
-        mapGraph = graph;
-        mapDetails = details;
-        map = buildPlayheadMap(graphChildrenToClips(graph, details, focusedId));
-      }
-      const rect = scroller.getBoundingClientRect();
-      const styles = getComputedStyle(scroller);
-      const contentX =
-        event.clientX -
-        rect.left -
-        parseFloat(styles.borderLeftWidth) -
-        parseFloat(styles.paddingLeft) +
-        scroller.scrollLeft;
-      channel.set(Math.max(0, Math.min(map.timeAt(contentX), map.totalDurationSeconds)));
-    };
-
-    let pointerId: number | null = null;
-    const handleMove = (event: PointerEvent) => {
-      if (event.pointerId === pointerId) seek(event);
-    };
-    const end = (event: PointerEvent) => {
-      if (event.pointerId !== pointerId) return;
-      pointerId = null;
-      window.removeEventListener("pointermove", handleMove);
-      window.removeEventListener("pointerup", end);
-      window.removeEventListener("pointercancel", end);
-    };
-    const handleDown = (event: PointerEvent) => {
-      if (!event.isPrimary || event.button !== 0) return;
-      pointerId = event.pointerId;
-      try {
-        band.setPointerCapture(event.pointerId);
-      } catch {
-        /* synthetic pointer — window listeners suffice */
-      }
-      seek(event);
-      window.addEventListener("pointermove", handleMove);
-      window.addEventListener("pointerup", end);
-      window.addEventListener("pointercancel", end);
-    };
-
-    band.addEventListener("pointerdown", handleDown);
-    return () => {
-      band.removeEventListener("pointerdown", handleDown);
-      window.removeEventListener("pointermove", handleMove);
-      window.removeEventListener("pointerup", end);
-      window.removeEventListener("pointercancel", end);
-    };
-  }, [store, detailsStore, focusedId, channel]);
-
-  return (
-    <div
-      ref={bandRef}
-      data-playhead-scrub
-      aria-hidden="true"
-      className="absolute inset-x-0 top-0 z-10 h-3 cursor-ew-resize"
-    />
-  );
-}
-
-/**
- * The grid playhead: a one-row-tall red line inside the grid's content
- * overlay (so it scrolls with the rows and the scroller's overflow clips it
- * when its row is off-screen). It moves through the active cell as time
- * advances and jumps to the next cell/row on clip boundaries. Column count
- * comes from the grid's own `data-grid-columns`, so the map rebuilds when a
- * resize reflows the grid. Painted imperatively — no React render per tick.
- */
-function GraphGridPlayhead({
-  focusedId,
-  channel,
-}: Readonly<{ focusedId: string; channel: PreviewTimeChannel }>) {
-  const store = useCollectionsStore();
-  const detailsStore = useGraphDetailsStore();
-  const lineRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const line = lineRef.current;
-    if (!line) return;
-    const grid = line.closest<HTMLElement>("[data-virtual-grid]");
-
-    let lastGraph: CollectionsGraph | null = null;
-    let lastDetails: DetailsById | null = null;
-    let lastCols = 0;
-    let map: GridPlayheadMap | null = null;
-    const paint = () => {
-      const graph = store.getSnapshot().graph;
-      const details = detailsStore.read();
-      const cols = Number(grid?.dataset.gridColumns) || 1;
-      if (graph !== lastGraph || details !== lastDetails || cols !== lastCols) {
-        lastGraph = graph;
-        lastDetails = details;
-        lastCols = cols;
-        map = buildGridPlayheadMap(graphChildrenToClips(graph, details, focusedId), cols);
-      }
-      if (!map) return;
-      const { x, y } = map.posAt(channel.get());
-      line.style.transform = `translate(${x}px, ${y}px)`;
-      line.style.height = `${map.rowHeight}px`;
-    };
-    paint();
-
-    const unsubscribeTime = channel.subscribe(paint);
-    const unsubscribeStore = store.subscribe(paint);
-    const unsubscribeDetails = detailsStore.subscribe(paint);
-    // Responsive columns can change on resize with no store/graph change.
-    const observer = grid ? new ResizeObserver(paint) : null;
-    if (grid && observer) observer.observe(grid);
-    return () => {
-      unsubscribeTime();
-      unsubscribeStore();
-      unsubscribeDetails();
-      observer?.disconnect();
-    };
-  }, [store, detailsStore, focusedId, channel]);
-
-  return (
-    <div
-      ref={lineRef}
-      data-graph-grid-playhead
-      className="absolute left-0 top-0 w-0.5 bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.9)]"
-    >
-      <div className="absolute -left-[5px] -top-2 h-0 w-0 border-x-[6px] border-t-[8px] border-x-transparent border-t-red-500" />
-    </div>
-  );
-}
-
-/**
- * The grid scrub surface: a full-grid pointer layer (the grid has no per-row
- * top gutter the way the strip does, and the user scrubs BOTH axes — column
- * within a row, row by dragging vertically). It reads content coordinates
- * off the overlay wrapper (same rect as the scrolling spacer, so scroll is
- * already folded in) and seeks through the 2D map. Because it overlays the
- * cards, wheel events are forwarded to the grid so it still scrolls while
- * previewing.
- *
- * Trade-off: covering the cards means item drag/reorder is paused while
- * Preview is on in grid mode — toggle Preview off to rearrange.
- */
-function GraphGridScrubSurface({
-  focusedId,
-  channel,
-}: Readonly<{ focusedId: string; channel: PreviewTimeChannel }>) {
-  const store = useCollectionsStore();
-  const detailsStore = useGraphDetailsStore();
-  const surfaceRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const surface = surfaceRef.current;
-    if (!surface) return;
-    const grid = surface.parentElement?.querySelector<HTMLElement>("[data-virtual-grid]") ?? null;
-    if (!grid) return;
-
-    let map: GridPlayheadMap | null = null;
-    let mapGraph: CollectionsGraph | null = null;
-    let mapDetails: DetailsById | null = null;
-    let mapCols = 0;
-    const seek = (event: PointerEvent) => {
-      const graph = store.getSnapshot().graph;
-      const details = detailsStore.read();
-      const cols = Number(grid.dataset.gridColumns) || 1;
-      if (graph !== mapGraph || details !== mapDetails || cols !== mapCols || !map) {
-        mapGraph = graph;
-        mapDetails = details;
-        mapCols = cols;
-        map = buildGridPlayheadMap(graphChildrenToClips(graph, details, focusedId), cols);
-      }
-      // The overlay wrapper shares the scrolling spacer's rect, so its top/
-      // left already fold in scroll position and container padding.
-      const overlay = grid.querySelector<HTMLElement>("[data-virtual-grid-overlay]");
-      const rect = (overlay ?? grid).getBoundingClientRect();
-      channel.set(map.timeAt(event.clientX - rect.left, event.clientY - rect.top));
-    };
-
-    let pointerId: number | null = null;
-    const handleMove = (event: PointerEvent) => {
-      if (event.pointerId === pointerId) seek(event);
-    };
-    const end = (event: PointerEvent) => {
-      if (event.pointerId !== pointerId) return;
-      pointerId = null;
-      window.removeEventListener("pointermove", handleMove);
-      window.removeEventListener("pointerup", end);
-      window.removeEventListener("pointercancel", end);
-    };
-    const handleDown = (event: PointerEvent) => {
-      if (!event.isPrimary || event.button !== 0) return;
-      pointerId = event.pointerId;
-      try {
-        surface.setPointerCapture(event.pointerId);
-      } catch {
-        /* synthetic pointer — window listeners suffice */
-      }
-      seek(event);
-      window.addEventListener("pointermove", handleMove);
-      window.addEventListener("pointerup", end);
-      window.addEventListener("pointercancel", end);
-    };
-    // Forward wheel to the grid so it still scrolls under the surface. The
-    // grid scroller is a SIBLING subtree, not this surface's scroll ancestor,
-    // so the browser's default action would scroll the page while we scroll
-    // the grid — a double scroll. Non-passive + preventDefault exactly when
-    // the grid consumed the delta; at the grid's boundary the default stands
-    // so the page scrolls naturally.
-    const handleWheel = (event: WheelEvent) => {
-      // deltaMode 1 = lines (e.g. Firefox wheel); normalize to pixels.
-      const scale = event.deltaMode === 1 ? 32 : 1;
-      const before = grid.scrollTop;
-      const max = grid.scrollHeight - grid.clientHeight;
-      const next = Math.max(0, Math.min(before + event.deltaY * scale, max));
-      if (next !== before) {
-        grid.scrollTop = next;
-        event.preventDefault();
-      }
-    };
-
-    surface.addEventListener("pointerdown", handleDown);
-    surface.addEventListener("wheel", handleWheel, { passive: false });
-    return () => {
-      surface.removeEventListener("pointerdown", handleDown);
-      surface.removeEventListener("wheel", handleWheel);
-      window.removeEventListener("pointermove", handleMove);
-      window.removeEventListener("pointerup", end);
-      window.removeEventListener("pointercancel", end);
-    };
-  }, [store, detailsStore, focusedId, channel]);
-
-  return (
-    <div
-      ref={surfaceRef}
-      data-grid-scrub
-      aria-hidden="true"
-      className="absolute inset-0 z-10 cursor-crosshair"
-    />
-  );
-}
-
-/**
- * Keeps the legacy documents context in step with the gateway cache. The
- * preview surface resolves COLLECTION clips' frames through
- * useTimelineDocuments() — without a synced provider it would fall back to
- * the read-only demo store and show the wrong content. Registration only
- * (persist: false): the gateway already owns persistence.
- */
-function GatewayDocumentsBridge() {
-  const { registerTimelineDocument } = useTimelineDocuments();
-  const seenRef = useRef<Readonly<Record<string, TimelineDocument>>>({});
-
-  useEffect(() => {
-    const sync = () => {
-      const seen = seenRef.current;
-      const current = graphDocumentsGateway.read();
-      if (current === seen) return;
-      for (const [id, doc] of Object.entries(current)) {
-        if (seen[id] !== doc) registerTimelineDocument(doc, { persist: false });
-      }
-      seenRef.current = current;
-    };
-    sync();
-    return graphDocumentsGateway.subscribe(sync);
-  }, [registerTimelineDocument]);
-
-  return null;
-}
-
-function PreviewShell({
-  enabled,
-  focusedId,
-  channel,
-  children,
-}: Readonly<{
-  enabled: boolean;
-  focusedId: string;
-  channel: PreviewTimeChannel;
-  children: React.ReactNode;
-}>) {
-  // Commit-cadence projection: graph identity changes only per committed
-  // change/hydration, so this recomputes exactly when the clips could have.
-  // The WHOLE details table is the right subscription here (unlike the
-  // cards): the pane plays a projection over every child's detail. The
-  // stable `children` identity still shields the board subtree.
-  const graph = useCollectionsSelector((s) => s.graph);
-  const detailsStore = useGraphDetailsStore();
-  const details = useSyncExternalStore(
-    detailsStore.subscribe,
-    detailsStore.read,
-    detailsStore.read,
-  );
-  const clips = useMemo<TimelineClip[]>(
-    () => (enabled ? graphChildrenToClips(graph, details, focusedId) : []),
-    [enabled, graph, details, focusedId],
-  );
-
-  // Per-frame time lives HERE (the pane is a controlled player); `children`
-  // keeps its identity across these renders, so the board subtree skips.
-  // The CHANNEL is the time bus both directions converge on: the pane's
-  // transport writes it via handleTimeChange, the scrub band writes it
-  // directly — and this subscription folds either back into the pane's
-  // controlled clock (same-value sets bail, so no feedback loop).
-  const [time, setTime] = useState(0);
-  useEffect(() => channel.subscribe(() => setTime(channel.get())), [channel]);
-  const handleTimeChange = useCallback(
-    (next: number) => {
-      setTime(next);
-      channel.set(next);
-    },
-    [channel],
-  );
-
-  // Time state and the channel outlive drill-in (the provider lives in a
-  // persistent layout), but a DIFFERENT focused timeline is a different
-  // clock: without a reset, drilling from 60s into a 10s timeline parks the
-  // transport at "60 / 10" with the playhead pinned to the end. Both
-  // effects write only the CHANNEL (the external clock) — the local `time`
-  // state follows through the subscription above, which is also what keeps
-  // the playhead and scrub surfaces in step.
-  useEffect(() => {
-    channel.set(0);
-  }, [channel, focusedId]);
-
-  // Edits can also shorten the projection UNDER a parked playhead (trim,
-  // delete, undo) — clamp to the new end rather than pointing past it.
-  const totalDuration =
-    clips.length > 0 ? clips[clips.length - 1].startTime + clips[clips.length - 1].duration : 0;
-  useEffect(() => {
-    if (channel.get() > totalDuration) channel.set(totalDuration);
-  }, [channel, totalDuration]);
-
-  // Created ONCE (lazy useState), never per render: the provider consumes
-  // initialState only on its first render, and this component re-renders on
-  // every playback tick (up to 30Hz) — building it inline JSON-cloned every
-  // cached document per frame just to throw the result away. Documents that
-  // land after this snapshot are covered by GatewayDocumentsBridge, which
-  // sweeps the full gateway cache on every provider mount.
-  const [initialDocumentsState] = useState(() =>
-    createTimelineDocumentsState({ ...graphDocumentsGateway.read() }, {}),
-  );
-
-  if (!enabled) return <>{children}</>;
-
-  return (
-    <TimelineDocumentsProvider initialState={initialDocumentsState}>
-      <GatewayDocumentsBridge />
-      <WorkbenchSplitPane clips={clips} currentTime={time} onCurrentTimeChange={handleTimeChange}>
-        {children}
-      </WorkbenchSplitPane>
-    </TimelineDocumentsProvider>
-  );
-}
-
-// ── Consumer pixels (module scope — identity-stable) ────────────────────────
-
-/** Live-tracking duration readout — a LEAF so only the clip being trimmed
- *  re-renders per pointer move (useLiveTrim re-renders its caller). */
-function LiveDurationPill({ id, node }: { id: NodeId; node: MediaNode }) {
-  const live = useLiveTrim(id);
-  const showing = live ? live.effectiveSeconds : mediaDurationSeconds(node);
-  return (
-    <span className="pointer-events-none absolute right-1 bottom-1 z-10 rounded bg-black/75 px-1.5 py-0.5 font-mono text-[9px] tabular-nums text-zinc-100">
-      {node.mediaKind === "video"
-        ? `${showing.toFixed(2)}s / ${node.fullDurationSeconds.toFixed(2)}s`
-        : `${showing.toFixed(2)}s`}
-    </span>
-  );
-}
-
-const GraphClipContent = memo(function GraphClipContent({
-  id,
-  node,
-  childCount,
-  selected,
-  rejected,
-  isDragSource,
-  trimEnabled,
-}: CollectionItemContentProps) {
-  const nav = useContext(GraphViewNavContext);
-  // Per-entry subscription: THIS card re-renders when its own detail lands
-  // (hydration, a palette claim) — a commit elsewhere touches nobody.
-  const detail = useClipDetail(id as string);
-
-  if (node.kind === "collection") {
-    const hydrated = detail?.hydrated === true;
-    const count = hydrated ? childCount : (detail?.itemCount ?? childCount);
-    const previews = detail?.previewItems?.slice(0, 3) ?? [];
-    return (
-      <span
-        title="Double-click (or press O) to open this timeline"
-        onDoubleClick={() => nav?.openTimeline(id)}
-        className={[
-          "relative flex h-full w-full flex-col justify-between overflow-hidden rounded-md border border-dashed border-sky-500/40 bg-sky-500/[0.08] p-1.5",
-          selected ? "ring-2 ring-amber-400" : "",
-          rejected ? "ring-2 ring-red-500 motion-safe:animate-pulse" : "",
-          isDragSource ? "opacity-40" : "",
-        ].join(" ")}
-      >
-        <span className="flex min-h-0 flex-1 gap-0.5 overflow-hidden">
-          {previews.length === 0 ? (
-            <span className="flex flex-1 items-center justify-center text-[9px] text-zinc-500">
-              {hydrated ? "Empty" : "Open to load"}
-            </span>
-          ) : (
-            previews.map((preview) => (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
-                key={preview.id}
-                src={preview.poster ?? preview.src}
-                alt=""
-                draggable={false}
-                loading="lazy"
-                className="h-full min-w-0 flex-1 rounded-sm object-cover"
-              />
-            ))
-          )}
-        </span>
-        <span className="mt-1 flex items-baseline justify-between gap-1">
-          <span className="truncate text-[10px] font-semibold text-zinc-100">{node.name}</span>
-          <span className="shrink-0 font-mono text-[9px] text-zinc-400">{count}</span>
-        </span>
-      </span>
-    );
-  }
-
-  const isVideo = node.mediaKind === "video";
-  const posters = isVideo ? (node.posterSrcs ?? []) : node.src ? [node.src] : [];
-  const frames = isVideo ? videoFrameCount(mediaDurationSeconds(node), 6) : 1;
-  return (
-    <span
-      className={[
-        "relative flex h-full w-full overflow-hidden rounded-md bg-zinc-900",
-        selected ? "ring-2 ring-amber-400" : "ring-1 ring-white/15",
-        rejected ? "ring-2 ring-red-500 motion-safe:animate-pulse" : "",
-        isDragSource ? "opacity-40" : "",
-      ].join(" ")}
-    >
-      {posters.length === 0 ? (
-        <span className="flex h-full w-full items-center justify-center text-[10px] text-zinc-500">
-          No preview
-        </span>
-      ) : (
-        <span className="flex h-full w-full">
-          {Array.from({ length: frames }).map((_, index) => (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              key={index}
-              src={posters[index % posters.length]}
-              alt=""
-              draggable={false}
-              loading="lazy"
-              className="h-full min-w-0 flex-1 border-r border-black/60 object-cover last:border-r-0"
-            />
-          ))}
-        </span>
-      )}
-      {trimEnabled && <LiveDurationPill id={id} node={node} />}
-    </span>
-  );
-});
-
-const GraphTrimHandle = memo(function GraphTrimHandle({
-  side,
-  selected,
-}: CollectionTrimHandleContentProps) {
-  return (
-    <span
-      className={[
-        "flex h-full w-full items-center justify-center transition-opacity",
-        side === "left" ? "rounded-l-md" : "rounded-r-md",
-        selected ? "bg-amber-400 opacity-95" : "bg-amber-400/50 opacity-0 group-hover:opacity-90",
-      ].join(" ")}
-    >
-      <span className="h-4 w-0.5 rounded bg-black/60" />
-    </span>
-  );
-});
-
-const GraphGhost = memo(function GraphGhost({ node, extraCount }: CollectionGhostContentProps) {
-  return (
-    <span className="relative flex h-full w-full flex-col justify-between rounded-md bg-zinc-900/95 p-2 text-xs shadow-2xl ring-2 ring-amber-400">
-      <span className="truncate font-semibold text-zinc-100">{node.name}</span>
-      <span className="font-mono text-[10px] text-zinc-400">
-        {node.kind === "collection" ? "Timeline" : `${mediaDurationSeconds(node).toFixed(2)}s`}
-      </span>
-      {extraCount > 0 && (
-        <span className="absolute -top-2 -right-2 flex h-6 min-w-6 items-center justify-center rounded-full bg-amber-400 px-1 text-[11px] font-bold text-black shadow">
-          +{extraCount}
-        </span>
-      )}
-    </span>
-  );
-});
-
-const GRAPH_VIEW_COMPONENTS: CollectionsComponents = {
-  ItemContent: GraphClipContent,
-  TrimHandleContent: GraphTrimHandle,
-  GhostContent: GraphGhost,
-};
-
-// ── Inline sub-timelines ────────────────────────────────────────────────────
-
-/** One sub-timeline section, with ITS OWN detail subscription: a hydration
- *  landing for this collection re-renders this section — not its siblings. */
-function SubTimelineSection({
-  collectionId,
-  name,
-  collapsed,
-  onToggleCollapsed,
-}: Readonly<{
-  collectionId: NodeId;
-  name: string;
-  collapsed: boolean;
-  onToggleCollapsed: () => void;
-}>) {
-  const nav = useContext(GraphViewNavContext);
-  const store = useCollectionsStore();
-  const detailsStore = useGraphDetailsStore();
-  const id = collectionId as string;
-  const detail = useClipDetail(id);
-  const hydrated = detail?.hydrated === true;
-  // Primitive selector: re-renders only when THIS collection's child count
-  // changes, not on every graph commit.
-  const liveCount = useCollectionsSelector((s) => getChildren(s.graph, collectionId).length);
-
-  return (
-    <section aria-label={`Sub-timeline: ${name}`}>
-      <div className="mb-1.5 flex items-center gap-2">
-        <span className="h-3 w-3 rounded-sm border border-dashed border-sky-500/60 bg-sky-500/20" />
-        <h3 className="text-sm font-semibold text-zinc-100">{name}</h3>
-        <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] text-zinc-300">
-          {hydrated ? liveCount : (detail?.itemCount ?? 0)} clips
-        </span>
-        {!hydrated && (
-          <span className="rounded border border-zinc-700 px-1.5 py-0.5 text-[10px] text-zinc-500">
-            loading…
-          </span>
-        )}
-        <span className="grow" />
-        {!hydrated && (
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={() => {
-              void hydrateTimeline(store, detailsStore, id);
-            }}
-          >
-            Load inline
-          </Button>
-        )}
-        {hydrated && (
-          <Button type="button" variant="ghost" size="sm" onClick={onToggleCollapsed}>
-            {collapsed ? "Expand" : "Collapse"}
-          </Button>
-        )}
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={() => nav?.openTimeline(collectionId)}
-        >
-          Focus
-        </Button>
-      </div>
-      {hydrated && !collapsed && (
-        <VirtualStrip
-          collectionId={collectionId}
-          pixelsPerSecond={TIMELINE_PPS}
-          itemHeight={64}
-          itemDragActivation="hold"
-          className="bg-black/20"
-        />
-      )}
-    </section>
-  );
-}
-
-function SubTimelines({ focusedId }: Readonly<{ focusedId: string }>) {
-  const graph = useCollectionsSelector((s) => s.graph);
-  const [collapsedIds, setCollapsedIds] = useState<ReadonlySet<string>>(new Set());
-
-  const collections = getChildren(graph, parseNodeId(focusedId)).filter(
-    (childId) => graph.nodesById.get(childId)?.kind === "collection",
-  );
-  if (collections.length === 0) return null;
-
-  return (
-    <div className="flex flex-col gap-3">
-      {collections.map((collectionId) => {
-        const node = graph.nodesById.get(collectionId);
-        if (node?.kind !== "collection") return null;
-        const id = collectionId as string;
-        return (
-          <SubTimelineSection
-            key={id}
-            collectionId={collectionId}
-            name={node.name}
-            collapsed={collapsedIds.has(id)}
-            onToggleCollapsed={() =>
-              setCollapsedIds((current) => {
-                const next = new Set(current);
-                if (next.has(id)) next.delete(id);
-                else next.add(id);
-                return next;
-              })
-            }
-          />
-        );
-      })}
-    </div>
-  );
-}
-
-// ── Persistence bridge ──────────────────────────────────────────────────────
-
-type SyncEntry = Readonly<{
-  at: number;
-  origin: CollectionsChange["origin"];
-  patchType: CollectionsChange["patch"]["type"];
-  collections: readonly string[];
-  /** True when the change was REVERTED (drop into an un-hydrated collection). */
-  bounced?: boolean;
-}>;
-
-/**
- * The write path AND the gate-until-hydrated policy, in one subscriber:
- *
- * - A command (or redo) that places content INTO an un-hydrated placeholder
- *   is BOUNCED — undone on the spot with a rejection flash and an
- *   announcement. Letting it stand would block the collection's hydration
- *   (the engine refuses to fill a non-empty collection) and eventually let
- *   a write clobber the stored document. Eager visible hydration
- *   (HydrationController) makes this a rare fetch-latency race, not the
- *   common path.
- * - Everything else is written patch-scoped: only the touched documents,
- *   and never one whose clips haven't loaded (`hydrated: false`).
- *
- * Lives INSIDE the provider (unlike an `onChange` prop) because bouncing
- * needs the store; `subscribeToChanges` supports reentrant dispatch, so
- * undoing from within the feed is safe and ordered.
- */
-function PersistenceBridge({
-  onSync,
-}: Readonly<{
-  onSync: (entry: SyncEntry) => void;
-}>) {
-  const store = useCollectionsStore();
-  const detailsStore = useGraphDetailsStore();
-  const { announce } = useCollectionsContainer();
-
-  useEffect(
-    () =>
-      store.subscribeToChanges((change) => {
-        // A committed palette add claims its parked detail BEFORE the write
-        // below, so poster/aspect round-trip into the very first PATCH.
-        if (change.patch.type === "nodes-added") {
-          let claimed: Record<string, ClipDetail> | null = null;
-          for (const add of change.patch.adds) {
-            const detail = pendingPaletteDetails.get(add.node.id as string);
-            if (detail) {
-              (claimed ??= {})[add.node.id as string] = detail;
-              pendingPaletteDetails.delete(add.node.id as string);
-            }
-          }
-          if (claimed) detailsStore.merge(claimed);
-        }
-
-        // Synchronous store: this read already sees the claim above.
-        const current = detailsStore.read();
-
-        if (change.origin !== "undo") {
-          const blocked = collectUnhydratedDropTargets(change.patch, current);
-          if (blocked.length > 0) {
-            store.undo();
-            const placedIds =
-              change.patch.type === "nodes-moved"
-                ? change.patch.moves.map((move) => move.nodeId)
-                : change.patch.type === "nodes-added"
-                  ? change.patch.adds.map((add) => add.node.id)
-                  : [];
-            if (placedIds.length > 0) store.flashRejection(placedIds);
-            announce("That collection is still loading — drop again once its clips appear.");
-            onSync({
-              at: Date.now(),
-              origin: change.origin,
-              patchType: change.patch.type,
-              collections: blocked,
-              bounced: true,
-            });
-            return;
-          }
-        }
-
-        const affected = collectAffectedCollectionIds(change.graph, change.patch).filter(
-          (id) => graphDocumentsGateway.peek(id) !== null && current[id]?.hydrated !== false,
-        );
-        for (const id of affected) {
-          graphDocumentsGateway.writeClips(id, graphChildrenToClips(change.graph, current, id));
-        }
-        onSync({
-          at: Date.now(),
-          origin: change.origin,
-          patchType: change.patch.type,
-          collections: affected,
-        });
-      }),
-    [store, detailsStore, announce, onSync],
-  );
-
-  return null;
-}
-
-/**
- * Lifecycle for the details side-table (review finding: unbounded
- * retention). After each commit, entries whose nodes can no longer exist
- * are dropped. "Can no longer exist" is precise, not heuristic: an id is
- * retained while it's in the live graph OR mentioned by any undo-stack
- * patch — undoing a removal resurrects its node, which must get its detail
- * back. The redo stack isn't visible in the snapshot, so the sweep waits
- * while a redo branch is open (an undone add could resurrect a node whose
- * detail was just dropped); the next fresh command clears the branch and
- * the sweep catches up. Without this, a long session accumulates details
- * for every node that ever existed — cancelled palette adds, trashed
- * content aged off the capped history, and so on.
- */
-function GraphDetailsJanitor() {
-  const store = useCollectionsStore();
-  const detailsStore = useGraphDetailsStore();
-
-  useEffect(
-    () =>
-      store.subscribeToChanges(() => {
-        const snapshot = store.getSnapshot();
-        if (snapshot.canRedo) return;
-        detailsStore.prune(collectReachableDetailIds(snapshot));
-      }),
-    [store, detailsStore],
-  );
-
-  return null;
-}
-
-// ── Persistence sync panel ──────────────────────────────────────────────────
-
-function SyncPanel({ entries }: { entries: readonly SyncEntry[] }) {
-  return (
-    <div className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-3">
-      <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-zinc-500">
-        Patch-scoped document writes
-      </h3>
-      {entries.length === 0 ? (
-        <p className="mt-2 text-xs text-zinc-500">
-          No writes yet — reorder, trim, nest, or undo and watch which timeline documents are
-          QUEUED for a PATCH (writes debounce briefly and any failure appears in the banner
-          above). Hydration never appears here: loading data is not a change worth writing back.
-        </p>
-      ) : (
-        <ol className="mt-2 flex flex-col gap-1 font-mono text-[11px] text-zinc-400">
-          {entries.map((entry) => (
-            <li key={entry.at} className="flex flex-wrap items-baseline gap-x-2">
-              <span className="text-zinc-100">{entry.origin}</span>
-              <span>{entry.patchType}</span>
-              <span aria-hidden="true">→</span>
-              {entry.bounced ? (
-                <span className="text-amber-400">
-                  reverted — {entry.collections.join(", ")} still loading
-                </span>
-              ) : (
-                <span className="text-sky-400">
-                  {entry.collections.length === 0
-                    ? "(nothing stored)"
-                    : entry.collections.join(", ")}
-                </span>
-              )}
-            </li>
-          ))}
-        </ol>
-      )}
-    </div>
-  );
-}
-
-// ── Chrome: back arrow + breadcrumbs in the app's own style ─────────────────
-
-function GraphViewChrome({
-  projectId,
-  timelinePath,
-}: Readonly<{ projectId: string; timelinePath: readonly string[] }>) {
-  // Titles arrive as documents land in the gateway cache.
-  const documents = useSyncExternalStore(
-    graphDocumentsGateway.subscribe,
-    graphDocumentsGateway.read,
-    graphDocumentsGateway.read,
-  );
-  const base = `/timeline/${encodeURIComponent(projectId)}/graph`;
-  const focusedId = timelinePath[timelinePath.length - 1] ?? projectId;
-  const parentHref =
-    timelinePath.length > 1
-      ? `${base}/${timelinePath.slice(0, -1).map(encodeURIComponent).join("/")}`
-      : timelinePath.length === 1
-        ? base
-        : "/";
-
-  return (
-    <div className="flex items-center justify-between gap-3 w-full">
-      <div className="flex items-center gap-3 min-w-0">
-        <Link
-          href={parentHref}
-          className="flex h-8 w-8 items-center justify-center rounded-full border border-zinc-800 bg-zinc-950/50 text-zinc-400 hover:border-zinc-700 hover:text-zinc-100 hover:bg-zinc-800 transition-all shrink-0"
-          title={focusedId === projectId ? "Go to Projects" : "Go to parent timeline"}
-        >
-          <ArrowLeft className="h-4 w-4" />
-        </Link>
-        <nav
-          aria-label="Timeline focus path"
-          className="flex items-center gap-2 text-xs text-zinc-400 select-none"
-        >
-          <Link href="/" className="text-zinc-400 hover:text-white transition-colors">
-            Projects
-          </Link>
-          <span>/</span>
-          <Link href={base} className="text-zinc-400 hover:text-white transition-colors">
-            Graph
-          </Link>
-          <span>/</span>
-          {timelinePath.slice(0, -1).map((segment, index) => (
-            <span key={segment} className="flex items-center gap-2">
-              <Link
-                href={`${base}/${timelinePath
-                  .slice(0, index + 1)
-                  .map(encodeURIComponent)
-                  .join("/")}`}
-                className="text-zinc-400 hover:text-white transition-colors"
-              >
-                {documents[segment]?.title ?? segment}
-              </Link>
-              <span>/</span>
-            </span>
-          ))}
-          <span className="text-zinc-100 font-semibold truncate max-w-[250px]">
-            {documents[focusedId]?.title ?? focusedId}
-          </span>
-        </nav>
-      </div>
-      <div className="shrink-0 flex items-center gap-3">
-        <Link
-          href={`/timeline/${encodeURIComponent(projectId)}/storyboard${
-            focusedId === projectId ? "" : `/${encodeURIComponent(focusedId)}`
-          }`}
-          className="text-xs text-zinc-400 hover:text-white transition-colors"
-        >
-          Storyboard view
-        </Link>
-      </div>
-    </div>
-  );
-}
-
-// ── Entry ───────────────────────────────────────────────────────────────────
+import { AssetPaletteDrawer } from "./graph-asset-palette";
+import { GraphBoard, type FocusSurface } from "./graph-board";
+import { GraphDetailsProvider } from "./graph-details-context";
+import { HydrationController } from "./graph-hydration";
+import { GRAPH_VIEW_COMPONENTS } from "./graph-item-content";
+import { GraphViewNavProvider } from "./graph-navigation";
+import {
+  GraphDetailsJanitor,
+  PersistenceBridge,
+  type SyncEntry,
+} from "./graph-persistence";
+import { createPreviewTimeChannel } from "./graph-preview";
+import { FALLBACK_DETAIL } from "./graph-view-config";
+import { GraphViewChrome } from "./graph-view-chrome";
 
 type BootState =
   | Readonly<{ status: "loading" }>
@@ -1801,14 +44,14 @@ type BootState =
   | Readonly<{
       status: "ready";
       graph: CollectionsGraph;
-      /** The trash collection's root id, when its document loaded. */
       trashRootId: string | null;
     }>;
 
+/**
+ * Session orchestration for the graph route. Feature behavior lives in the
+ * sibling graph-* modules; this root owns only boot data and durable view state.
+ */
 export function GraphTimelineView({ projectId }: { projectId: string }) {
-  // Mounted by the route-group LAYOUT (which persists across focus
-  // navigation — pages remount per param change), so the focus path comes
-  // from the pathname, not page props.
   const pathname = usePathname();
   const base = `/timeline/${encodeURIComponent(projectId)}/graph`;
   const timelinePath = useMemo(
@@ -1825,63 +68,46 @@ export function GraphTimelineView({ projectId }: { projectId: string }) {
   const focusedId = timelinePath[timelinePath.length - 1] ?? projectId;
 
   const [boot, setBoot] = useState<BootState>({ status: "loading" });
-  // The details side-table — one store per view session, exactly the
-  // lifetime of the engine store it annotates. Consumers subscribe to their
-  // own slice (see useClipDetail), so commits re-render only who they touch.
   const [detailsStore] = useState(() => createGraphDetailsStore());
   const [focusError, setFocusError] = useState<string | null>(null);
   const [syncLog, setSyncLog] = useState<readonly SyncEntry[]>([]);
-  // Hosted by the persistent layout, so the chosen surface survives
-  // drill-in navigation along with the provider itself.
   const [surface, setSurface] = useState<FocusSurface>("strip");
-  // Playback preview: the workbench split pane above the board, plus the
-  // strip playhead. Per-view state (survives drill-ins with the provider);
-  // the time channel is ref-backed so ticks never render React.
   const [previewOn, setPreviewOn] = useState(false);
   const [timeChannel] = useState(createPreviewTimeChannel);
-  // The asset palette drawer — opened by the board's Assets button OR the
-  // app sidebar's Assets launcher (which hands off via a window event on
-  // graph routes; see lib/graph-view-events.ts).
   const [assetsOpen, setAssetsOpen] = useState(false);
+
   useEffect(() => {
     const toggle = () => setAssetsOpen((current) => !current);
     window.addEventListener(GRAPH_ASSETS_TOGGLE_EVENT, toggle);
     return () => window.removeEventListener(GRAPH_ASSETS_TOGGLE_EVENT, toggle);
   }, []);
+
   const gatewayError = useSyncExternalStore(
     graphDocumentsGateway.subscribe,
     graphDocumentsGateway.lastError,
     graphDocumentsGateway.lastError,
   );
 
-  // Boot: fetch the project's document AND the user's trash document, then
-  // build a TWO-root graph — the project timeline and the trash collection.
-  // Trash is just another stored collection document (`trash-<uid>`), so
-  // drops onto <TrashTarget> are ordinary moves between roots: undoable,
-  // and persisted by the same patch-scoped write path. Referenced child
-  // timelines start as placeholders — fetched on focus/expand.
   const { user } = useAuth();
-  const trashDocId = user ? `trash-${user.uid}` : null;
+  const trashDocumentId = user ? `trash-${user.uid}` : null;
+
   useEffect(() => {
-    if (trashDocId === null) return; // auth still resolving (AuthGate guarantees a user)
-    // Entering the graph view must not trust the session cache: edits made in
-    // the storyboard view (or another tab) since the last graph session would
-    // otherwise be overwritten by full-document PATCHes built from stale
-    // content. `refresh` flushes pending writes and marks every cached id
-    // stale, so the `ensure` calls below (and hydrate-on-focus) refetch.
+    if (trashDocumentId === null) return;
+
     graphDocumentsGateway.refresh();
     let cancelled = false;
     void (async () => {
-      const [projectDoc, trashDoc] = await Promise.all([
+      const [projectDocument, trashDocument] = await Promise.all([
         graphDocumentsGateway.ensure(projectId),
-        graphDocumentsGateway.ensure(trashDocId),
+        graphDocumentsGateway.ensure(trashDocumentId),
       ]);
       if (cancelled) return;
-      if (!projectDoc) {
+      if (!projectDocument) {
         setBoot({
           status: "error",
           message:
-            graphDocumentsGateway.lastError() ?? `Project timeline "${projectId}" did not load.`,
+            graphDocumentsGateway.lastError() ??
+            `Project timeline "${projectId}" did not load.`,
         });
         return;
       }
@@ -1891,47 +117,45 @@ export function GraphTimelineView({ projectId }: { projectId: string }) {
         setBoot({ status: "error", message: projectSpecs.error });
         return;
       }
+
       const projectRoot: GraphNodeSpec = {
         kind: "collection",
         id: projectId,
-        name: projectDoc.title,
+        name: projectDocument.title,
         children: projectSpecs.value.specs,
       };
       let bootDetails: Record<string, ClipDetail> = { ...projectSpecs.value.details };
-
-      // Trash root — hydrated in FULL at boot: patch-scoped writes replace a
-      // document wholesale, so the graph must hold everything the stored
-      // trash holds before a write may touch it.
       let trashRootId: string | null = null;
       let roots: GraphNodeSpec[] = [projectRoot];
-      if (trashDoc) {
-        const trashSpecs = buildHydrationSpecs(graphDocumentsGateway.read(), trashDocId, 0, [
-          projectId,
-          ...Object.keys(bootDetails),
-        ]);
+
+      if (trashDocument) {
+        const trashSpecs = buildHydrationSpecs(
+          graphDocumentsGateway.read(),
+          trashDocumentId,
+          0,
+          [projectId, ...Object.keys(bootDetails)],
+        );
         if (trashSpecs.ok) {
           roots = [
             projectRoot,
             {
               kind: "collection",
-              id: trashDocId,
-              name: trashDoc.title || "Trash Bin",
+              id: trashDocumentId,
+              name: trashDocument.title || "Trash Bin",
               children: trashSpecs.value.specs,
             },
           ];
           bootDetails = {
             ...bootDetails,
             ...trashSpecs.value.details,
-            [trashDocId]: { ...FALLBACK_DETAIL, hydrated: true },
+            [trashDocumentId]: { ...FALLBACK_DETAIL, hydrated: true },
           };
-          trashRootId = trashDocId;
+          trashRootId = trashDocumentId;
         }
       }
 
       let built = buildGraph(roots);
       if (!built.ok && trashRootId !== null) {
-        // Id collision between trash content and the project (stale trash
-        // data): boot WITHOUT trash rather than not at all.
         trashRootId = null;
         built = buildGraph([projectRoot]);
       }
@@ -1939,16 +163,16 @@ export function GraphTimelineView({ projectId }: { projectId: string }) {
         setBoot({ status: "error", message: JSON.stringify(built.error) });
         return;
       }
+
       detailsStore.replaceAll(bootDetails);
       setBoot({ status: "ready", graph: built.value, trashRootId });
     })();
+
     return () => {
       cancelled = true;
     };
-  }, [projectId, trashDocId, detailsStore]);
+  }, [projectId, trashDocumentId, detailsStore]);
 
-  // Persistence (write path + gate-until-hydrated bounce) lives in
-  // <PersistenceBridge> inside the provider — bouncing needs the store.
   const onSync = useCallback((entry: SyncEntry) => {
     setSyncLog((log) => [entry, ...log].slice(0, 6));
   }, []);
@@ -1962,12 +186,16 @@ export function GraphTimelineView({ projectId }: { projectId: string }) {
       </div>
     );
   }
+
   if (boot.status === "error") {
     return (
       <div className="rounded-lg border border-red-500/40 bg-red-500/10 p-4 text-sm text-red-200">
         <p className="font-semibold">Could not load this project&apos;s graph view.</p>
         <p className="mt-1 text-red-300/80">{boot.message}</p>
-        <Link href="/" className="mt-3 inline-block text-xs text-red-200 underline underline-offset-4">
+        <Link
+          href="/"
+          className="mt-3 inline-block text-xs text-red-200 underline underline-offset-4"
+        >
           Back to Projects
         </Link>
       </div>
@@ -1982,136 +210,50 @@ export function GraphTimelineView({ projectId }: { projectId: string }) {
           {gatewayError}
         </p>
       )}
+
       <DndCollections
         initialGraph={boot.graph}
         components={GRAPH_VIEW_COMPONENTS}
-        // The provider lives in a persistent layout (undo survives drill-in),
-        // so an unbounded history would retain every patch — including
-        // removed-node payloads — for the whole session. 200 undo steps is
-        // far beyond practical use while keeping memory flat.
         maxHistoryEntries={200}
       >
-        <GraphDetailsStoreContext.Provider value={detailsStore}>
-        <PersistenceBridge onSync={onSync} />
-        <GraphDetailsJanitor />
-        {/* Portaled to document.body, but rendered HERE so the PaletteItems
-            stay inside the provider's dnd context (portals keep it). */}
-        <AssetPaletteDrawer open={assetsOpen} onClose={() => setAssetsOpen(false)} />
-        <HydrationController
-          projectId={projectId}
-          segments={timelinePath}
-          onFocusError={setFocusError}
-        />
-        <GraphViewNavProvider projectId={projectId} focusedId={focusedId}>
-          {focusError !== null ? (
-            <div className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-4 text-sm text-zinc-300">
-              <p className="font-semibold text-zinc-100">Unknown timeline</p>
-              <p className="mt-1">{focusError}</p>
-              <Link
-                href={base}
-                className="mt-3 inline-block text-xs text-sky-400 underline underline-offset-4"
-              >
-                Back to the project timeline
-              </Link>
-            </div>
-          ) : (
-            <OpenKeyBoundary>
-            <PreviewShell enabled={previewOn} focusedId={focusedId} channel={timeChannel}>
-            <div className="flex flex-col gap-5 rounded-xl border border-zinc-800 bg-zinc-950/50 p-4">
-              <div className="flex items-center justify-between gap-3">
-                <p className="text-xs text-zinc-500">
-                  Press-and-hold to drag (cross-timeline included) · amber edges trim ·
-                  double-click (or O) a dashed clip to focus it · undo survives drill-in.
-                </p>
-                <div className="flex shrink-0 items-center gap-3">
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    aria-pressed={previewOn}
-                    onClick={() => setPreviewOn((current) => !current)}
-                  >
-                    Preview
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    aria-pressed={assetsOpen}
-                    onClick={() => setAssetsOpen((current) => !current)}
-                  >
-                    Assets
-                  </Button>
-                  <SurfaceToggle surface={surface} onChange={setSurface} />
-                  <UndoRedoControls />
-                </div>
+        <GraphDetailsProvider store={detailsStore}>
+          <PersistenceBridge onSync={onSync} />
+          <GraphDetailsJanitor />
+          <AssetPaletteDrawer open={assetsOpen} onClose={() => setAssetsOpen(false)} />
+          <HydrationController
+            projectId={projectId}
+            segments={timelinePath}
+            onFocusError={setFocusError}
+          />
+
+          <GraphViewNavProvider projectId={projectId} focusedId={focusedId}>
+            {focusError !== null ? (
+              <div className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-4 text-sm text-zinc-300">
+                <p className="font-semibold text-zinc-100">Unknown timeline</p>
+                <p className="mt-1">{focusError}</p>
+                <Link
+                  href={base}
+                  className="mt-3 inline-block text-xs text-sky-400 underline underline-offset-4"
+                >
+                  Back to the project timeline
+                </Link>
               </div>
-              {surface === "strip" ? (
-                // relative wrapper: the scrub band overlays the strip's top
-                // edge (absolute — no layout shift). Playhead VISUALS ride
-                // the strip's presentational overlay; the band owns pointers.
-                <div className="relative">
-                  <VirtualStrip
-                    collectionId={parseNodeId(focusedId)}
-                    pixelsPerSecond={TIMELINE_PPS}
-                    itemHeight={88}
-                    itemDragActivation="hold"
-                    overlay={
-                      previewOn ? (
-                        <GraphPlayhead focusedId={focusedId} channel={timeChannel} />
-                      ) : undefined
-                    }
-                    className="bg-black/25"
-                  />
-                  {previewOn && (
-                    <PlayheadScrubBand focusedId={focusedId} channel={timeChannel} />
-                  )}
-                </div>
-              ) : (
-                // Same graph, same provider — dragging between this grid and
-                // the sub-timeline strips below is native. In Preview the
-                // playhead rides the grid's content overlay and the scrub
-                // surface owns pointers (see GraphGridScrubSurface).
-                <div className="relative">
-                  <VirtualGrid
-                    collectionId={parseNodeId(focusedId)}
-                    cellWidth={GRID_CELL_W}
-                    cellHeight={GRID_CELL_H}
-                    gap={GRID_GAP}
-                    height={420}
-                    overlay={
-                      previewOn ? (
-                        <GraphGridPlayhead focusedId={focusedId} channel={timeChannel} />
-                      ) : undefined
-                    }
-                    className="bg-black/25"
-                  />
-                  {previewOn && (
-                    <GraphGridScrubSurface focusedId={focusedId} channel={timeChannel} />
-                  )}
-                </div>
-              )}
-              <SubTimelines focusedId={focusedId} />
-              {boot.trashRootId !== null && (
-                <div className="flex items-end justify-end">
-                  <div className="shrink-0">
-                    <h3 className="mb-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-zinc-500">
-                      Trash
-                    </h3>
-                    {/* Drops here are ordinary moves into the trash-<uid>
-                        document — undoable, persisted patch-scoped. Also
-                        enables Alt+Delete on focused cards. */}
-                    <TrashTarget trashId={parseNodeId(boot.trashRootId)} />
-                  </div>
-                </div>
-              )}
-              <SyncPanel entries={syncLog} />
-            </div>
-            </PreviewShell>
-            </OpenKeyBoundary>
-          )}
-        </GraphViewNavProvider>
-        </GraphDetailsStoreContext.Provider>
+            ) : (
+              <GraphBoard
+                focusedId={focusedId}
+                surface={surface}
+                onSurfaceChange={setSurface}
+                previewOn={previewOn}
+                onTogglePreview={() => setPreviewOn((current) => !current)}
+                assetsOpen={assetsOpen}
+                onToggleAssets={() => setAssetsOpen((current) => !current)}
+                timeChannel={timeChannel}
+                trashRootId={boot.trashRootId}
+                syncEntries={syncLog}
+              />
+            )}
+          </GraphViewNavProvider>
+        </GraphDetailsProvider>
       </DndCollections>
     </div>
   );

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { useSyncExternalStore } from "react";
+
+import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
+
+export function GraphViewChrome({
+  projectId,
+  timelinePath,
+}: Readonly<{
+  projectId: string;
+  timelinePath: readonly string[];
+}>) {
+  const documents = useSyncExternalStore(
+    graphDocumentsGateway.subscribe,
+    graphDocumentsGateway.read,
+    graphDocumentsGateway.read,
+  );
+  const base = `/timeline/${encodeURIComponent(projectId)}/graph`;
+  const focusedId = timelinePath[timelinePath.length - 1] ?? projectId;
+  const parentHref =
+    timelinePath.length > 1
+      ? `${base}/${timelinePath.slice(0, -1).map(encodeURIComponent).join("/")}`
+      : timelinePath.length === 1
+        ? base
+        : "/";
+
+  return (
+    <div className="flex w-full items-center justify-between gap-3">
+      <div className="flex min-w-0 items-center gap-3">
+        <Link
+          href={parentHref}
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-zinc-800 bg-zinc-950/50 text-zinc-400 transition-all hover:border-zinc-700 hover:bg-zinc-800 hover:text-zinc-100"
+          title={focusedId === projectId ? "Go to Projects" : "Go to parent timeline"}
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </Link>
+        <nav
+          aria-label="Timeline focus path"
+          className="flex items-center gap-2 text-xs text-zinc-400 select-none"
+        >
+          <Link href="/" className="text-zinc-400 transition-colors hover:text-white">
+            Projects
+          </Link>
+          <span>/</span>
+          <Link href={base} className="text-zinc-400 transition-colors hover:text-white">
+            Graph
+          </Link>
+          <span>/</span>
+          {timelinePath.slice(0, -1).map((segment, index) => (
+            <span key={segment} className="flex items-center gap-2">
+              <Link
+                href={`${base}/${timelinePath
+                  .slice(0, index + 1)
+                  .map(encodeURIComponent)
+                  .join("/")}`}
+                className="text-zinc-400 transition-colors hover:text-white"
+              >
+                {documents[segment]?.title ?? segment}
+              </Link>
+              <span>/</span>
+            </span>
+          ))}
+          <span className="max-w-[250px] truncate font-semibold text-zinc-100">
+            {documents[focusedId]?.title ?? focusedId}
+          </span>
+        </nav>
+      </div>
+
+      <Link
+        href={`/timeline/${encodeURIComponent(projectId)}/storyboard${
+          focusedId === projectId ? "" : `/${encodeURIComponent(focusedId)}`
+        }`}
+        className="shrink-0 text-xs text-zinc-400 transition-colors hover:text-white"
+      >
+        Storyboard view
+      </Link>
+    </div>
+  );
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-config.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-config.ts
@@ -1,0 +1,14 @@
+import type { ClipDetail } from "@storyboard/timeline-domain";
+
+export const TIMELINE_PPS = 40;
+
+export const GRID_CELL_WIDTH = 160;
+export const GRID_CELL_HEIGHT = 96;
+export const GRID_GAP = 8;
+
+/** Detail for a timeline the graph knows only as a root (no source clip). */
+export const FALLBACK_DETAIL: ClipDetail = {
+  alt: "",
+  aspect: 16 / 9,
+  trackIndex: 0,
+};

--- a/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
@@ -17,9 +17,47 @@ type TimelineDocumentRecord = {
   /** Authorization boundary: absent only on legacy records, which are
    *  claimed by the first authenticated toucher (see lib/timeline-ownership). */
   ownerUid?: string;
+  /** Monotonic save counter, stamped on EVERY write (absent = 0, legacy).
+   *  Clients that carry an expected revision into a batch write get
+   *  compare-and-set semantics; clients that don't (legacy views) keep
+   *  last-write-wins. */
+  revision?: number;
   createdAt?: Timestamp;
   updatedAt?: Timestamp;
 };
+
+/** A document plus the revision that read observed — the token a client
+ *  hands back as `expectedRevision` to detect concurrent writers. */
+export type TimelineEntry = {
+  document: TimelineDocument;
+  revision: number;
+};
+
+export type TimelineBatchWrite = {
+  document: TimelineDocument;
+  /** Omit for last-write-wins (legacy semantics). When present, the write
+   *  only applies if the stored revision still matches. */
+  expectedRevision?: number;
+};
+
+export type TimelineRevisionConflict = {
+  id: string;
+  actualRevision: number;
+};
+
+/** A batch was rejected because at least one expected revision no longer
+ *  matched — NOTHING in the batch was written. */
+export class TimelineRevisionConflictError extends Error {
+  readonly conflicts: readonly TimelineRevisionConflict[];
+
+  constructor(conflicts: readonly TimelineRevisionConflict[]) {
+    super(
+      `Timeline write conflict: ${conflicts.map((conflict) => conflict.id).join(", ")} changed since they were read.`,
+    );
+    this.name = "TimelineRevisionConflictError";
+    this.conflicts = conflicts;
+  }
+}
 
 export type TimelineProjectSummary = {
   id: string;
@@ -200,7 +238,10 @@ export async function listFirebaseTimelineProjects(requesterUid: string) {
     });
 }
 
-export async function getFirebaseTimelineDocument(id: string, requesterUid: string) {
+export async function getFirebaseTimelineEntry(
+  id: string,
+  requesterUid: string,
+): Promise<TimelineEntry | null> {
   const snapshot = await withFirebaseTimeout(
     collection().doc(id).get(),
     "Loading timeline document",
@@ -216,14 +257,52 @@ export async function getFirebaseTimelineDocument(id: string, requesterUid: stri
       "Claiming legacy timeline document",
     );
   }
-  return toTimelineDocument(snapshot.id, data);
+  return {
+    document: toTimelineDocument(snapshot.id, data),
+    revision: data.revision ?? 0,
+  };
 }
 
-export async function saveFirebaseTimelineDocument(
+export async function getFirebaseTimelineDocument(id: string, requesterUid: string) {
+  const entry = await getFirebaseTimelineEntry(id, requesterUid);
+  return entry?.document ?? null;
+}
+
+/** The one Firestore payload both write paths (single save, atomic batch)
+ *  produce — shared so revision stamping and ownership claiming can't drift
+ *  between them. */
+function buildSavePayload(
+  normalizedDocument: TimelineDocument,
+  existing: TimelineDocumentRecord | undefined,
+  requesterUid: string,
+  revision: number,
+  options?: { isProject?: boolean },
+) {
+  return {
+    id: normalizedDocument.id,
+    title: normalizedDocument.title,
+    description: normalizedDocument.description || null,
+    document: normalizedDocument,
+    clips: normalizedDocument.clips,
+    ...(normalizedDocument.clips.length > 0
+      ? { lastNonEmptyDocument: normalizedDocument }
+      : {}),
+    isProject: options?.isProject ?? existing?.isProject === true,
+    // Ownership: a save CREATES with the requester as owner, CLAIMS a legacy
+    // unowned record, and was refused earlier on someone else's. Children
+    // minted implicitly through writes (collection drops) are stamped too.
+    ownerUid: existing?.ownerUid ?? requesterUid,
+    revision,
+    createdAt: existing?.createdAt || FieldValue.serverTimestamp(),
+    updatedAt: FieldValue.serverTimestamp(),
+  };
+}
+
+export async function saveFirebaseTimelineEntry(
   document: TimelineDocument,
   requesterUid: string,
   options?: { isProject?: boolean },
-) {
+): Promise<TimelineEntry> {
   if (isUnsavedProjectPlaceholder(document)) {
     throw new Error("Refusing to save an unloaded project placeholder.");
   }
@@ -231,18 +310,14 @@ export async function saveFirebaseTimelineDocument(
   const normalizedDocument = normalizeDocument(document);
   const ref = collection().doc(normalizedDocument.id);
   const existing = await withFirebaseTimeout(ref.get(), "Loading timeline document");
-  const existingIsProject = existing.exists ? existing.get("isProject") === true : false;
-  // Ownership: a save CREATES with the requester as owner, CLAIMS a legacy
-  // unowned record, and is refused on someone else's. Children minted
-  // implicitly through PATCH (collection drops) are stamped here too.
-  const existingOwnerUid = existing.exists
-    ? (existing.data() as TimelineDocumentRecord).ownerUid
+  const existingData = existing.exists
+    ? (existing.data() as TimelineDocumentRecord)
     : undefined;
-  if (existing.exists && resolveOwnership(existingOwnerUid, requesterUid) === "denied") {
+  if (existingData && resolveOwnership(existingData.ownerUid, requesterUid) === "denied") {
     throw new TimelineAccessDeniedError(normalizedDocument.id);
   }
-  const existingDocument = existing.exists
-    ? toTimelineDocument(existing.id, existing.data() as TimelineDocumentRecord)
+  const existingDocument = existingData
+    ? toTimelineDocument(existing.id, existingData)
     : null;
 
   if (
@@ -255,29 +330,122 @@ export async function saveFirebaseTimelineDocument(
     );
   }
 
+  // No expectation here: the single-save path keeps last-write-wins (legacy
+  // views). It still STAMPS the next revision so batch writers see honest
+  // counters.
+  const revision = (existingData?.revision ?? 0) + 1;
   await withFirebaseTimeout(
     ref.set(
-      {
-        id: normalizedDocument.id,
-        title: normalizedDocument.title,
-        description: normalizedDocument.description || null,
-        document: normalizedDocument,
-        clips: normalizedDocument.clips,
-        ...(normalizedDocument.clips.length > 0
-          ? { lastNonEmptyDocument: normalizedDocument }
-          : {}),
-        isProject: options?.isProject ?? existingIsProject,
-        ownerUid: existingOwnerUid ?? requesterUid,
-        createdAt: existing.exists ? existing.get("createdAt") || FieldValue.serverTimestamp() : FieldValue.serverTimestamp(),
-        updatedAt: FieldValue.serverTimestamp(),
-      },
+      buildSavePayload(normalizedDocument, existingData, requesterUid, revision, options),
       { merge: true },
     ),
     "Saving timeline document",
   );
 
   const snapshot = await withFirebaseTimeout(ref.get(), "Loading timeline document");
-  return toTimelineDocument(snapshot.id, snapshot.data() as TimelineDocumentRecord);
+  const savedData = snapshot.data() as TimelineDocumentRecord;
+  return {
+    document: toTimelineDocument(snapshot.id, savedData),
+    revision: savedData.revision ?? revision,
+  };
+}
+
+export async function saveFirebaseTimelineDocument(
+  document: TimelineDocument,
+  requesterUid: string,
+  options?: { isProject?: boolean },
+) {
+  return (await saveFirebaseTimelineEntry(document, requesterUid, options)).document;
+}
+
+/**
+ * ALL-OR-NOTHING multi-document save in one Firestore transaction — the
+ * write path for changes that span documents (a cross-timeline move touches
+ * two), where independent PATCHes could apply half a change. Per-write
+ * `expectedRevision` gives compare-and-set: any mismatch aborts the WHOLE
+ * batch with a TimelineRevisionConflictError listing every conflicted id
+ * (so a stale client can't silently overwrite a newer writer). Ownership
+ * and the empty-over-nonempty guard match the single-save path exactly.
+ */
+export async function saveFirebaseTimelineDocumentsAtomic(
+  writes: readonly TimelineBatchWrite[],
+  requesterUid: string,
+): Promise<{ id: string; revision: number }[]> {
+  for (const write of writes) {
+    if (isUnsavedProjectPlaceholder(write.document)) {
+      throw new Error("Refusing to save an unloaded project placeholder.");
+    }
+  }
+  const ids = writes.map((write) => write.document.id);
+  if (new Set(ids).size !== ids.length) {
+    throw new Error("A batch write must not repeat a timeline id.");
+  }
+
+  return withFirebaseTimeout(
+    getFirebaseDb().runTransaction(async (tx) => {
+      // Firestore transactions require every read before the first write.
+      const refs = ids.map((id) => collection().doc(id));
+      const snapshots = await Promise.all(refs.map((ref) => tx.get(ref)));
+
+      const conflicts: TimelineRevisionConflict[] = [];
+      const staged: {
+        ref: (typeof refs)[number];
+        id: string;
+        revision: number;
+        payload: ReturnType<typeof buildSavePayload>;
+      }[] = [];
+
+      for (let index = 0; index < writes.length; index += 1) {
+        const normalizedDocument = normalizeDocument(writes[index].document);
+        const snapshot = snapshots[index];
+        const existingData = snapshot.exists
+          ? (snapshot.data() as TimelineDocumentRecord)
+          : undefined;
+
+        if (existingData && resolveOwnership(existingData.ownerUid, requesterUid) === "denied") {
+          throw new TimelineAccessDeniedError(normalizedDocument.id);
+        }
+
+        const actualRevision = existingData?.revision ?? 0;
+        const expected = writes[index].expectedRevision;
+        if (expected !== undefined && expected !== actualRevision) {
+          conflicts.push({ id: normalizedDocument.id, actualRevision });
+          continue;
+        }
+
+        const existingDocument = existingData
+          ? toTimelineDocument(snapshot.id, existingData)
+          : null;
+        if (
+          existingDocument &&
+          existingDocument.clips.length > 0 &&
+          normalizedDocument.clips.length === 0
+        ) {
+          throw new Error(
+            "Refusing to save an empty timeline over an existing non-empty document.",
+          );
+        }
+
+        staged.push({
+          ref: refs[index],
+          id: normalizedDocument.id,
+          revision: actualRevision + 1,
+          payload: buildSavePayload(
+            normalizedDocument,
+            existingData,
+            requesterUid,
+            actualRevision + 1,
+          ),
+        });
+      }
+
+      if (conflicts.length > 0) throw new TimelineRevisionConflictError(conflicts);
+
+      for (const entry of staged) tx.set(entry.ref, entry.payload, { merge: true });
+      return staged.map(({ id, revision }) => ({ id, revision }));
+    }),
+    "Saving timeline documents",
+  );
 }
 
 export async function createFirebaseTimelineProject(requesterUid: string, title?: string) {

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
@@ -43,10 +43,13 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
+type BatchWrite = { document: TimelineDocument; expectedRevision?: number };
+
 type FetchCall = {
   method: string;
+  /** GET: the timeline id from the url. POST: "batch". */
   id: string;
-  body?: TimelineDocument;
+  writes?: BatchWrite[];
   keepalive?: boolean;
 };
 
@@ -57,9 +60,9 @@ function installFetch(handler: (call: FetchCall) => Promise<MockResponse> | Mock
     const call: FetchCall = {
       method: init?.method ?? "GET",
       id: decodeURIComponent(String(input).split("/").pop() ?? ""),
-      body:
+      writes:
         typeof init?.body === "string"
-          ? (JSON.parse(init.body) as { document: TimelineDocument }).document
+          ? (JSON.parse(init.body) as { writes: BatchWrite[] }).writes
           : undefined,
       keepalive: init?.keepalive,
     };
@@ -70,10 +73,19 @@ function installFetch(handler: (call: FetchCall) => Promise<MockResponse> | Mock
   return calls;
 }
 
-const patchesOf = (calls: FetchCall[]) => calls.filter((call) => call.method === "PATCH");
-const getsOf = (calls: FetchCall[]) => calls.filter((call) => call.method === "GET");
+const batchesOf = (calls: FetchCall[]) => calls.filter((call) => call.method === "POST");
+const getsOf = (calls: FetchCall[], id?: string) =>
+  calls.filter((call) => call.method === "GET" && (id === undefined || call.id === id));
 const clipIds = (document: TimelineDocument | null | undefined) =>
   document?.clips.map((entry) => entry.id);
+/** results payload echoing each write's next revision (expected + 1). */
+const okResults = (writes: BatchWrite[] = []) =>
+  jsonResponse({
+    results: writes.map((write) => ({
+      id: write.document.id,
+      revision: (write.expectedRevision ?? 0) + 1,
+    })),
+  });
 
 describe("graph-documents-gateway", () => {
   beforeEach(() => {
@@ -86,7 +98,9 @@ describe("graph-documents-gateway", () => {
   });
 
   it("ensure fetches once, dedupes concurrent calls, and serves the cache afterward", async () => {
-    const calls = installFetch(() => jsonResponse({ document: doc("a", [clip("a1")]) }));
+    const calls = installFetch(() =>
+      jsonResponse({ document: doc("a", [clip("a1")]), revision: 1 }),
+    );
     const gateway = createGraphDocumentsGateway();
 
     const [first, second] = await Promise.all([gateway.ensure("a"), gateway.ensure("a")]);
@@ -108,81 +122,106 @@ describe("graph-documents-gateway", () => {
     expect(calls).toHaveLength(0);
   });
 
-  it("coalesces rapid writes into one debounced PATCH carrying the latest clips", async () => {
+  it("one debounce window: several dirty documents flush as ONE batch carrying their expected revisions", async () => {
+    const revisionOf = new Map([
+      ["a", 3],
+      ["b", 7],
+    ]);
     const calls = installFetch((call) =>
-      call.method === "PATCH"
-        ? jsonResponse({ document: call.body })
-        : jsonResponse({ document: doc("a", [clip("a1")]) }),
+      call.method === "POST"
+        ? okResults(call.writes)
+        : jsonResponse({
+            document: doc(call.id, [clip(`${call.id}-seed`)]),
+            revision: revisionOf.get(call.id) ?? 0,
+          }),
     );
     const gateway = createGraphDocumentsGateway();
     await gateway.ensure("a");
+    await gateway.ensure("b");
 
     gateway.writeClips("a", [clip("a2")]);
-    gateway.writeClips("a", [clip("a3")]);
-    expect(patchesOf(calls)).toHaveLength(0);
+    gateway.writeClips("b", [clip("b2")]);
+    expect(batchesOf(calls)).toHaveLength(0);
 
     await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
-    const patches = patchesOf(calls);
-    expect(patches).toHaveLength(1);
-    expect(clipIds(patches[0].body)).toEqual(["a3"]);
+    const batches = batchesOf(calls);
+    expect(batches).toHaveLength(1);
+    expect(batches[0].writes).toHaveLength(2);
+    const byId = new Map(batches[0].writes?.map((write) => [write.document.id, write]));
+    expect(clipIds(byId.get("a")?.document)).toEqual(["a2"]);
+    expect(byId.get("a")?.expectedRevision).toBe(3);
+    expect(clipIds(byId.get("b")?.document)).toEqual(["b2"]);
+    expect(byId.get("b")?.expectedRevision).toBe(7);
+
+    // The batch result advanced the revision ledger: the next write for "a"
+    // expects 4, not 3.
+    gateway.writeClips("a", [clip("a3")]);
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+    const second = batchesOf(calls)[1];
+    expect(second.writes).toHaveLength(1);
+    expect(second.writes?.[0].expectedRevision).toBe(4);
   });
 
-  it("serializes PATCHes per document: a write during a flight queues one trailing PATCH with the latest cache", async () => {
+  it("serializes batches: writes during a flight queue one trailing batch with the latest cache", async () => {
     const firstSave = deferred<MockResponse>();
-    let patchCount = 0;
+    let batchCount = 0;
     const calls = installFetch((call) => {
-      if (call.method !== "PATCH") return jsonResponse({ document: doc("a", [clip("a1")]) });
-      patchCount += 1;
-      return patchCount === 1 ? firstSave.promise : jsonResponse({ document: call.body });
+      if (call.method !== "POST") {
+        return jsonResponse({ document: doc("a", [clip("a1")]), revision: 1 });
+      }
+      batchCount += 1;
+      return batchCount === 1 ? firstSave.promise : okResults(call.writes);
     });
     const gateway = createGraphDocumentsGateway();
     await gateway.ensure("a");
 
     gateway.writeClips("a", [clip("a2")]);
     await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
-    expect(patchesOf(calls)).toHaveLength(1); // in flight, unresolved
+    expect(batchesOf(calls)).toHaveLength(1); // in flight, unresolved
 
-    // Two more edits land while the first PATCH is still out.
     gateway.writeClips("a", [clip("a3")]);
     gateway.writeClips("a", [clip("a4")]);
     await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
-    expect(patchesOf(calls)).toHaveLength(1); // queued, not raced
+    expect(batchesOf(calls)).toHaveLength(1); // queued, not raced
 
-    firstSave.resolve(jsonResponse({ document: doc("a", [clip("a2")]) }));
+    firstSave.resolve(jsonResponse({ results: [{ id: "a", revision: 2 }] }));
     await vi.advanceTimersByTimeAsync(0);
-    const patches = patchesOf(calls);
-    expect(patches).toHaveLength(2);
-    expect(clipIds(patches[1].body)).toEqual(["a4"]);
+    const batches = batchesOf(calls);
+    expect(batches).toHaveLength(2);
+    expect(clipIds(batches[1].writes?.[0].document)).toEqual(["a4"]);
+    expect(batches[1].writes?.[0].expectedRevision).toBe(2);
   });
 
-  it("flushPendingWrites sends debounce-pending writes immediately, with keepalive", async () => {
+  it("flushPendingWrites sends the pending batch immediately, with keepalive", async () => {
     const calls = installFetch((call) =>
-      call.method === "PATCH"
-        ? jsonResponse({ document: call.body })
-        : jsonResponse({ document: doc("a", [clip("a1")]) }),
+      call.method === "POST"
+        ? okResults(call.writes)
+        : jsonResponse({ document: doc("a", [clip("a1")]), revision: 1 }),
     );
     const gateway = createGraphDocumentsGateway();
     await gateway.ensure("a");
 
     gateway.writeClips("a", [clip("a2")]);
     gateway.flushPendingWrites({ keepalive: true });
-    const patches = patchesOf(calls);
-    expect(patches).toHaveLength(1);
-    expect(patches[0].keepalive).toBe(true);
-    expect(clipIds(patches[0].body)).toEqual(["a2"]);
+    const batches = batchesOf(calls);
+    expect(batches).toHaveLength(1);
+    expect(batches[0].keepalive).toBe(true);
+    expect(clipIds(batches[0].writes?.[0].document)).toEqual(["a2"]);
 
-    // The debounce timer was consumed — no duplicate PATCH later.
+    // The debounce timer was consumed — no duplicate batch later.
     await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
-    expect(patchesOf(calls)).toHaveLength(1);
+    expect(batchesOf(calls)).toHaveLength(1);
   });
 
   it("refresh keeps cached content readable but makes ensure refetch it", async () => {
     const secondLoad = deferred<MockResponse>();
     let gets = 0;
     const calls = installFetch((call) => {
-      if (call.method !== "GET") return jsonResponse({ document: call.body });
+      if (call.method !== "GET") return okResults(call.writes);
       gets += 1;
-      return gets === 1 ? jsonResponse({ document: doc("a", [clip("v1")]) }) : secondLoad.promise;
+      return gets === 1
+        ? jsonResponse({ document: doc("a", [clip("v1")]), revision: 1 })
+        : secondLoad.promise;
     });
     const gateway = createGraphDocumentsGateway();
     await gateway.ensure("a");
@@ -195,66 +234,126 @@ describe("graph-documents-gateway", () => {
     await vi.advanceTimersByTimeAsync(0);
     expect(getsOf(calls)).toHaveLength(2);
 
-    secondLoad.resolve(jsonResponse({ document: doc("a", [clip("v2")]) }));
+    secondLoad.resolve(jsonResponse({ document: doc("a", [clip("v2")]), revision: 6 }));
     await refetch;
     expect(clipIds(gateway.peek("a"))).toEqual(["v2"]);
 
-    // Freshness restored: the next ensure serves the cache again.
+    // Freshness restored: the next ensure serves the cache again, and the
+    // next write expects the refetched revision.
     await gateway.ensure("a");
     expect(getsOf(calls)).toHaveLength(2);
+    gateway.writeClips("a", [clip("v3")]);
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+    expect(batchesOf(calls)[0].writes?.[0].expectedRevision).toBe(6);
   });
 
-  it("a stale ensure waits for the in-flight save to settle before refetching", async () => {
+  it("a stale ensure waits for the in-flight batch to settle before refetching", async () => {
     const save = deferred<MockResponse>();
     let gets = 0;
     const calls = installFetch((call) => {
-      if (call.method === "PATCH") return save.promise;
+      if (call.method === "POST") return save.promise;
       gets += 1;
-      return jsonResponse({ document: doc("a", [clip(gets === 1 ? "v1" : "v2")]) });
+      return jsonResponse({
+        document: doc("a", [clip(gets === 1 ? "v1" : "v2")]),
+        revision: gets,
+      });
     });
     const gateway = createGraphDocumentsGateway();
     await gateway.ensure("a");
     gateway.writeClips("a", [clip("v1b")]);
 
-    gateway.refresh(); // flushes: the PATCH goes out and stays in flight
-    expect(patchesOf(calls)).toHaveLength(1);
+    gateway.refresh(); // flushes: the batch goes out and stays in flight
+    expect(batchesOf(calls)).toHaveLength(1);
 
     const refetch = gateway.ensure("a");
     await vi.advanceTimersByTimeAsync(0);
     // No GET yet — fetching before the save settles would read pre-save state.
     expect(getsOf(calls)).toHaveLength(1);
 
-    save.resolve(jsonResponse({ document: doc("a", [clip("v1b")]) }));
+    save.resolve(jsonResponse({ results: [{ id: "a", revision: 2 }] }));
     const refetched = await refetch;
     expect(getsOf(calls)).toHaveLength(2);
     expect(clipIds(refetched)).toEqual(["v2"]);
   });
 
-  it("keeps per-document errors: one document's success does not clear another's failure", async () => {
-    let badFails = true;
+  it("a revision conflict reloads the conflicted document, surfaces it, and re-queues the rest", async () => {
+    let conflictOnce = true;
+    const serverA = doc("a", [clip("a-server")]);
     const calls = installFetch((call) => {
-      if (call.method !== "PATCH") return jsonResponse({ document: doc(call.id, [clip("seed")]) });
-      if (call.body?.id === "bad" && badFails) return jsonResponse({}, 500);
-      return jsonResponse({ document: call.body });
+      if (call.method === "GET") {
+        // First GETs seed both docs at revision 1; the post-conflict reload
+        // of "a" serves the newer server content at its real revision.
+        return call.id === "a" && getsOf(calls, "a").length > 1
+          ? jsonResponse({ document: serverA, revision: 5 })
+          : jsonResponse({ document: doc(call.id, [clip(`${call.id}-seed`)]), revision: 1 });
+      }
+      if (conflictOnce && call.writes?.some((write) => write.document.id === "a")) {
+        conflictOnce = false;
+        return jsonResponse(
+          { error: "conflict", conflicts: [{ id: "a", actualRevision: 5 }] },
+          409,
+        );
+      }
+      return okResults(call.writes);
     });
     const gateway = createGraphDocumentsGateway();
-    await gateway.ensure("bad");
-    await gateway.ensure("good");
+    await gateway.ensure("a");
+    await gateway.ensure("b");
 
-    gateway.writeClips("bad", [clip("x")]);
-    gateway.writeClips("good", [clip("y")]);
+    gateway.writeClips("a", [clip("a2")]);
+    gateway.writeClips("b", [clip("b2")]);
     await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
-    expect(gateway.lastError()).toContain('Saving "Timeline bad" failed (500).');
+    expect(batchesOf(calls)).toHaveLength(1); // rejected as a whole
+
+    // The conflicted doc reloaded: server content and revision win the
+    // cache; the error names it AFTER the reload so it doesn't flash away.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(clipIds(gateway.peek("a"))).toEqual(["a-server"]);
+    expect(gateway.lastError()).toContain('"Timeline a" changed in another view');
+
+    // The unconflicted write re-queued and goes out on its own.
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+    const second = batchesOf(calls)[1];
+    expect(second.writes?.map((write) => write.document.id)).toEqual(["b"]);
+    expect(second.writes?.[0].expectedRevision).toBe(1);
+
+    // The next edit to "a" writes against the reloaded revision and clears
+    // the conflict message on success.
+    gateway.writeClips("a", [clip("a3")]);
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+    const third = batchesOf(calls)[2];
+    expect(third.writes?.[0].expectedRevision).toBe(5);
+    expect(gateway.lastError()).toBeNull();
+  });
+
+  it("keeps per-document errors: one document's success does not clear another's failure", async () => {
+    let aFails = true;
+    const calls = installFetch((call) => {
+      if (call.method !== "POST") {
+        return jsonResponse({ document: doc(call.id, [clip("seed")]), revision: 1 });
+      }
+      if (aFails && call.writes?.some((write) => write.document.id === "a")) {
+        return jsonResponse({}, 500);
+      }
+      return okResults(call.writes);
+    });
+    const gateway = createGraphDocumentsGateway();
+    await gateway.ensure("a");
+    await gateway.ensure("b");
+
+    gateway.writeClips("a", [clip("x")]);
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+    expect(gateway.lastError()).toContain('Saving "Timeline a" failed (500).');
     expect(calls.length).toBeGreaterThan(0);
 
-    // "good" saving again must not hide "bad"'s standing failure.
-    gateway.writeClips("good", [clip("y2")]);
+    // "b" saving cleanly in a later batch must not hide "a"'s failure.
+    gateway.writeClips("b", [clip("y")]);
     await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
-    expect(gateway.lastError()).toContain("Timeline bad");
+    expect(gateway.lastError()).toContain("Timeline a");
 
-    // Only "bad" itself succeeding clears it.
-    badFails = false;
-    gateway.writeClips("bad", [clip("x2")]);
+    // Only "a" itself succeeding clears it.
+    aFails = false;
+    gateway.writeClips("a", [clip("x2")]);
     await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
     expect(gateway.lastError()).toBeNull();
   });

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
@@ -1,19 +1,29 @@
 import type { TimelineClip, TimelineDocument } from "@storyboard/ui/timeline/types";
 import type { DocumentsById } from "@storyboard/timeline-domain";
 
-// The graph view's ONLY coupling to persistence: the same
-// GET/PATCH /api/timelines/[id] contract the legacy SmoothScrollList views
-// speak (auth-gated, per-user Firebase behind it), fronted by an in-memory
-// session cache. The graph provider replaces the legacy
-// TimelineDocumentsProvider's consistency role wholesale, so this gateway
-// deliberately does NOT touch that store — one storage contract, two
-// independent view systems, which is what lets the graph view ship without
-// modifying storyboard/workbench.
+// The graph view's ONLY coupling to persistence: GET /api/timelines/[id]
+// for reads (the same contract the legacy SmoothScrollList views speak) and
+// POST /api/timelines/batch for writes, fronted by an in-memory session
+// cache. The graph provider replaces the legacy TimelineDocumentsProvider's
+// consistency role wholesale, so this gateway deliberately does NOT touch
+// that store — one storage contract, two independent view systems, which is
+// what lets the graph view ship without modifying storyboard/workbench.
 //
 // Reads are synchronous against the cache (the timeline-domain adapter takes
 // a DocumentsById snapshot); `ensure` is the async fill (hydrate-on-focus
-// IO); `writeClips` is the patch-scoped write path — cache immediately,
-// PATCH debounced per timeline like the legacy autosave.
+// IO); `writeClips` is the write path — cache immediately, then ONE debounce
+// window for ALL dirty documents, flushed as a single ATOMIC batch:
+//
+//   - Atomicity: a change that spans documents (a cross-timeline move
+//     touches two) is written in the same window, so it commits or fails as
+//     a unit — independent per-document PATCHes could persist half a change.
+//   - Revisions: every GET carries the document's revision, every batch
+//     write carries it back as `expectedRevision`. A mismatch (another tab,
+//     the storyboard view) rejects the whole batch with 409 — this session's
+//     stale full-document write can no longer silently overwrite a newer
+//     one. Conflicted documents are reloaded; the local edit stays in the
+//     GRAPH (the session's source of truth), so the user's next change
+//     re-persists their intent against the fresh revision.
 
 const SAVE_DEBOUNCE_MS = 900;
 
@@ -29,9 +39,9 @@ export type GraphDocumentsGateway = Readonly<{
    */
   ensure: (timelineId: string) => Promise<TimelineDocument | null>;
   /**
-   * The patch-scoped write path: update the cached document's clips now,
-   * PATCH the API after a debounce (per timeline — rapid edits coalesce).
-   * No-op for timelines the session hasn't loaded.
+   * The write path: update the cached document's clips now, join the
+   * current debounce window — the whole dirty set goes out as one atomic
+   * batch. No-op for timelines the session hasn't loaded.
    */
   writeClips: (timelineId: string, clips: TimelineClip[]) => void;
   /** Cache-change notifications (documents landing, clips written). */
@@ -40,40 +50,47 @@ export type GraphDocumentsGateway = Readonly<{
    *  document is healthy; multiple failures are all listed. */
   lastError: () => string | null;
   /**
-   * Send every debounce-pending write NOW. Called on pagehide/hidden (with
-   * keepalive, so the requests survive the tab closing) and before a
-   * refresh — closing the tab inside the debounce window must not lose the
-   * last edit.
+   * Send the pending batch NOW. Called on pagehide/hidden (with keepalive,
+   * so the request survives the tab closing) and before a refresh — closing
+   * the tab inside the debounce window must not lose the last edit.
    */
   flushPendingWrites: (options?: { keepalive?: boolean }) => void;
   /**
    * Entering the graph view calls this: every cached document is marked
-   * STALE, so `ensure` refetches it (after any in-flight save settles)
+   * STALE, so `ensure` refetches it (after any in-flight batch settles)
    * instead of trusting the session cache. Without it, edits made in the
    * storyboard view (or another tab) between graph sessions would be
-   * overwritten by the next full-document PATCH built from stale content.
-   * Cached content stays readable until the refetch lands.
+   * overwritten by full-document writes built from stale content. Cached
+   * content stays readable until the refetch lands.
    */
   refresh: () => void;
 }>;
 
 export function createGraphDocumentsGateway(): GraphDocumentsGateway {
   let documents: DocumentsById = {};
+  // The expected-revision ledger: revision observed at GET (or returned by
+  // the last batch), per document. Absent = no expectation (a server that
+  // didn't send one) — that document falls back to last-write-wins.
+  const revisions = new Map<string, number>();
   // Errors are PER DOCUMENT: a successful write of one timeline must never
   // clear (and thereby hide) another timeline's failed save — with a single
   // last-error string, whichever request resolved last won.
   const errors = new Map<string, string>();
   let errorBanner: string | null = null;
   const inflight = new Map<string, Promise<TimelineDocument | null>>();
-  const saveTimers = new Map<string, ReturnType<typeof setTimeout>>();
-  // Writes are SERIALIZED per document: at most one PATCH in flight, and a
-  // write requested meanwhile is queued to run after it — always carrying
-  // the LATEST cached document. Without this, an older in-flight PATCH
-  // could reach the server after a newer one and win.
-  const savesInFlight = new Map<string, Promise<void>>();
-  const saveQueued = new Set<string>();
+  // ONE debounce window for ALL dirty documents (not a timer per doc): a
+  // change that touches several documents writes them in the same window,
+  // so they travel in the SAME atomic batch.
+  const dirtyIds = new Set<string>();
+  let saveTimer: ReturnType<typeof setTimeout> | null = null;
+  // At most one batch in flight; a write requested meanwhile queues one
+  // trailing batch that re-reads the latest cache. Without this, an older
+  // in-flight batch could reach the server after a newer one and win.
+  let saveInFlight: Promise<void> | null = null;
+  let saveQueued = false;
   // Ids whose cached content predates the current graph session (see
-  // `refresh`): readable, but `ensure` refetches them.
+  // `refresh`) or lost a revision conflict: readable, but `ensure`
+  // refetches them.
   let staleIds = new Set<string>();
   const listeners = new Set<() => void>();
 
@@ -107,12 +124,20 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
       }
       const result = (await response.json().catch(() => ({}))) as {
         document?: TimelineDocument;
+        revision?: number;
       };
       if (!result.document || result.document.id !== timelineId) {
         setError(timelineId, `Timeline "${timelineId}" returned an unexpected document.`);
         return null;
       }
       documents = { ...documents, [timelineId]: result.document };
+      if (typeof result.revision === "number") {
+        revisions.set(timelineId, result.revision);
+      } else {
+        // No revision from the server: drop any stale expectation rather
+        // than let it force spurious conflicts.
+        revisions.delete(timelineId);
+      }
       setError(timelineId, null);
       notify();
       return result.document;
@@ -125,52 +150,145 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
     }
   };
 
-  const persist = (timelineId: string, options?: { keepalive?: boolean }) => {
-    if (savesInFlight.has(timelineId)) {
-      saveQueued.add(timelineId);
+  const ensure = (timelineId: string): Promise<TimelineDocument | null> => {
+    const cached = documents[timelineId];
+    if (cached && !staleIds.has(timelineId)) return Promise.resolve(cached);
+    const pending = inflight.get(timelineId);
+    if (pending) return pending;
+    // A stale doc may still have a batch in flight (flushed on refresh) —
+    // fetching before it settles would read the pre-save server state.
+    const settled = saveInFlight ?? Promise.resolve();
+    const request = settled
+      .then(() => fetchDocument(timelineId))
+      .then((document) => {
+        if (document !== null) staleIds.delete(timelineId);
+        return document;
+      })
+      .finally(() => {
+        inflight.delete(timelineId);
+      });
+    inflight.set(timelineId, request);
+    return request;
+  };
+
+  const scheduleFlush = () => {
+    if (saveTimer !== null) clearTimeout(saveTimer);
+    saveTimer = setTimeout(() => {
+      saveTimer = null;
+      persistBatch();
+    }, SAVE_DEBOUNCE_MS);
+  };
+
+  const persistBatch = (options?: { keepalive?: boolean }) => {
+    if (saveInFlight !== null) {
+      saveQueued = true;
       return;
     }
-    const document = documents[timelineId];
-    if (!document) return;
-    const flight = fetch(`/api/timelines/${encodeURIComponent(timelineId)}`, {
-      method: "PATCH",
+    if (dirtyIds.size === 0) return;
+    const writes: { document: TimelineDocument; expectedRevision?: number }[] = [];
+    for (const timelineId of dirtyIds) {
+      const document = documents[timelineId];
+      if (!document) continue;
+      const revision = revisions.get(timelineId);
+      writes.push({
+        document,
+        ...(revision !== undefined ? { expectedRevision: revision } : {}),
+      });
+    }
+    dirtyIds.clear();
+    if (writes.length === 0) return;
+
+    const settle = () => {
+      saveInFlight = null;
+      // Trailing batch: edits that landed mid-flight go out now, from the
+      // latest cache.
+      if (saveQueued) {
+        saveQueued = false;
+        persistBatch();
+      }
+    };
+
+    saveInFlight = fetch("/api/timelines/batch", {
+      method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ document }),
+      body: JSON.stringify({ writes }),
       // keepalive lets the request outlive an unloading page (pagehide
       // flush). Not the default: keepalive bodies are capped (~64KB).
       ...(options?.keepalive ? { keepalive: true } : {}),
-    }).then(
-      (response) => {
-        if (!response.ok) {
-          setError(timelineId, `Saving "${document.title}" failed (${response.status}).`);
-        } else {
-          setError(timelineId, null);
-        }
-      },
-      (cause: unknown) => {
-        setError(
-          timelineId,
-          cause instanceof Error ? cause.message : `Saving "${document.title}" failed.`,
-        );
-      },
-    );
-    savesInFlight.set(
-      timelineId,
-      flight.then(() => {
-        savesInFlight.delete(timelineId);
-        // Trailing write: edits that landed mid-flight go out now, from the
-        // latest cache.
-        if (saveQueued.delete(timelineId)) persist(timelineId);
-      }),
-    );
+    })
+      .then(
+        async (response) => {
+          if (response.ok) {
+            const result = (await response.json().catch(() => ({}))) as {
+              results?: { id: string; revision: number }[];
+            };
+            for (const write of writes) setError(write.document.id, null);
+            for (const entry of result.results ?? []) {
+              if (typeof entry.revision === "number") revisions.set(entry.id, entry.revision);
+            }
+            return;
+          }
+          const result = (await response.json().catch(() => ({}))) as {
+            error?: string;
+            conflicts?: { id: string; actualRevision: number }[];
+          };
+          const conflictIds = new Set((result.conflicts ?? []).map((entry) => entry.id));
+          if (response.status === 409 && conflictIds.size > 0) {
+            // Compare-and-set lost: someone else wrote these documents since
+            // this session read them, and NOTHING in the batch was applied.
+            // Conflicted documents are reloaded (fresh content + revision) —
+            // the stale local write is NOT forced over the newer server
+            // state. The graph still holds the local edit, so the user's
+            // next change re-persists their intent against the fresh
+            // revision. Unconflicted writes from the batch re-queue as-is.
+            for (const write of writes) {
+              const timelineId = write.document.id;
+              if (conflictIds.has(timelineId)) {
+                staleIds.add(timelineId);
+                // The message lands AFTER the reload (a successful fetch
+                // clears that document's error slot — set before, it would
+                // flash and vanish); it then stands until the document next
+                // saves cleanly. A failed reload keeps its own load error.
+                void ensure(timelineId).then((document) => {
+                  if (document !== null) {
+                    setError(
+                      timelineId,
+                      `"${write.document.title}" changed in another view — reloaded it; the last edit here was not saved.`,
+                    );
+                  }
+                });
+              } else {
+                dirtyIds.add(timelineId);
+              }
+            }
+            if (dirtyIds.size > 0) scheduleFlush();
+            return;
+          }
+          for (const write of writes) {
+            setError(
+              write.document.id,
+              result.error ?? `Saving "${write.document.title}" failed (${response.status}).`,
+            );
+          }
+        },
+        (cause: unknown) => {
+          for (const write of writes) {
+            setError(
+              write.document.id,
+              cause instanceof Error ? cause.message : `Saving "${write.document.title}" failed.`,
+            );
+          }
+        },
+      )
+      .then(settle, settle);
   };
 
   const flushPendingWrites = (options?: { keepalive?: boolean }) => {
-    for (const [timelineId, timer] of [...saveTimers]) {
-      clearTimeout(timer);
-      saveTimers.delete(timelineId);
-      persist(timelineId, options);
+    if (saveTimer !== null) {
+      clearTimeout(saveTimer);
+      saveTimer = null;
     }
+    persistBatch(options);
   };
 
   if (typeof window !== "undefined") {
@@ -188,40 +306,14 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
   return {
     read: () => documents,
     peek: (timelineId) => documents[timelineId] ?? null,
-    ensure: (timelineId) => {
-      const cached = documents[timelineId];
-      if (cached && !staleIds.has(timelineId)) return Promise.resolve(cached);
-      const pending = inflight.get(timelineId);
-      if (pending) return pending;
-      // A stale doc may still have a save in flight (flushed on refresh) —
-      // fetching before it settles would read the pre-save server state.
-      const settled = savesInFlight.get(timelineId) ?? Promise.resolve();
-      const request = settled
-        .then(() => fetchDocument(timelineId))
-        .then((document) => {
-          if (document !== null) staleIds.delete(timelineId);
-          return document;
-        })
-        .finally(() => {
-          inflight.delete(timelineId);
-        });
-      inflight.set(timelineId, request);
-      return request;
-    },
+    ensure,
     writeClips: (timelineId, clips) => {
       const document = documents[timelineId];
       if (!document) return;
       documents = { ...documents, [timelineId]: { ...document, clips } };
       notify();
-      const timer = saveTimers.get(timelineId);
-      if (timer !== undefined) clearTimeout(timer);
-      saveTimers.set(
-        timelineId,
-        setTimeout(() => {
-          saveTimers.delete(timelineId);
-          persist(timelineId);
-        }, SAVE_DEBOUNCE_MS),
-      );
+      dirtyIds.add(timelineId);
+      scheduleFlush();
     },
     subscribe: (listener) => {
       listeners.add(listener);

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -2,12 +2,12 @@ import { expect, test, type Locator, type Page } from "@playwright/test";
 
 // E2E for the graph project view (/timeline/[projectId]/graph) — the REAL
 // Next app driven with real mouse input. The server surface the view touches
-// (/api/auth/me, /api/timelines/[id], /api/assets) is mocked per-test with
-// page.route(), so the suite exercises everything the Storybook layers can't:
-// AuthGate, App Router layout persistence (undo across drill-in), the
-// documents gateway with debounced patch-scoped PATCHes, the palette drawer,
-// the trash root, and the preview playhead — without reading or writing any
-// real storage.
+// (/api/auth/me, /api/timelines/[id], /api/timelines/batch, /api/assets) is
+// mocked per-test with page.route(), so the suite exercises everything the
+// Storybook layers can't: AuthGate, App Router layout persistence (undo
+// across drill-in), the documents gateway's debounced ATOMIC batch writes
+// with expected revisions, the palette drawer, the trash root, and the
+// preview playhead — without reading or writing any real storage.
 //
 // Selector contract (documented in packages/ui/dnd-collections/API.md):
 //   [data-node-id] card buttons · [data-virtual-strip="<collectionId>"]
@@ -111,8 +111,12 @@ type RecordedPatch = { id: string; clipIds: string[] };
 
 type GraphApi = {
   documents: Map<string, FixtureDocument>;
+  /** One entry per document write, in arrival order (batch writes fan out). */
   patches: RecordedPatch[];
   patchesFor: (id: string) => RecordedPatch[];
+  /** The document ids each POST /api/timelines/batch carried — the
+   *  atomicity witness: docs written by one change must share a batch. */
+  batches: string[][];
 };
 
 async function installGraphApi(
@@ -121,6 +125,10 @@ async function installGraphApi(
 ): Promise<GraphApi> {
   const documents = buildFixtureDocuments();
   const patches: RecordedPatch[] = [];
+  const batches: string[][] = [];
+  // Served on GET and enforced on batch writes, like the real API: the
+  // gateway must round-trip these as expectedRevision.
+  const revisions = new Map<string, number>([...documents.keys()].map((id) => [id, 1]));
 
   await page.route("**/api/auth/me", (route) =>
     route.fulfill({
@@ -162,6 +170,44 @@ async function installGraphApi(
     const request = route.request();
     const id = decodeURIComponent(new URL(request.url()).pathname.split("/").pop() ?? "");
 
+    // The graph gateway's write path: ONE atomic batch per debounce window,
+    // each write carrying the expectedRevision its GET served. Mirrors the
+    // real endpoint: a conflict rejects the whole batch, success bumps and
+    // returns every revision.
+    if (id === "batch" && request.method() === "POST") {
+      const body = request.postDataJSON() as {
+        writes?: { document?: FixtureDocument; expectedRevision?: number }[];
+      };
+      const writes = (body.writes ?? []).filter(
+        (write): write is { document: FixtureDocument; expectedRevision?: number } =>
+          write.document !== undefined,
+      );
+      const conflicts = writes.flatMap((write) => {
+        const actual = revisions.get(write.document.id) ?? 0;
+        return write.expectedRevision !== undefined && write.expectedRevision !== actual
+          ? [{ id: write.document.id, actualRevision: actual }]
+          : [];
+      });
+      if (conflicts.length > 0) {
+        await route.fulfill({ status: 409, json: { error: "Write conflict.", conflicts } });
+        return;
+      }
+      const results: { id: string; revision: number }[] = [];
+      for (const write of writes) {
+        documents.set(write.document.id, write.document);
+        const next = (revisions.get(write.document.id) ?? 0) + 1;
+        revisions.set(write.document.id, next);
+        patches.push({
+          id: write.document.id,
+          clipIds: write.document.clips.map((clip) => clip.id),
+        });
+        results.push({ id: write.document.id, revision: next });
+      }
+      batches.push(writes.map((write) => write.document.id));
+      await route.fulfill({ json: { results } });
+      return;
+    }
+
     if (options.blockChildDocument && id === CHILD_ID && request.method() === "GET") {
       // Simulate the fetch-latency window the bounce policy exists for: the
       // child document never arrives, so its collection stays un-hydrated.
@@ -175,26 +221,19 @@ async function installGraphApi(
         await route.fulfill({ status: 404, json: { error: "Timeline was not found." } });
         return;
       }
-      await route.fulfill({ json: { document: doc } });
-      return;
-    }
-
-    if (request.method() === "PATCH") {
-      const body = request.postDataJSON() as { document?: FixtureDocument };
-      if (!body.document || body.document.id !== id) {
-        await route.fulfill({ status: 400, json: { error: "Bad document." } });
-        return;
-      }
-      documents.set(id, body.document);
-      patches.push({ id, clipIds: body.document.clips.map((clip) => clip.id) });
-      await route.fulfill({ json: { document: body.document } });
+      await route.fulfill({ json: { document: doc, revision: revisions.get(id) ?? 0 } });
       return;
     }
 
     await route.continue();
   });
 
-  return { documents, patches, patchesFor: (id) => patches.filter((patch) => patch.id === id) };
+  return {
+    documents,
+    patches,
+    patchesFor: (id) => patches.filter((patch) => patch.id === id),
+    batches,
+  };
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -293,7 +332,7 @@ test.describe("graph view E2E", () => {
       .poll(() => stripOrder(page, PROJECT_ID))
       .toEqual(["bravo", CHILD_ID, "charlie", "alpha"]);
 
-    // The gateway debounces ~900ms, then PATCHes the project document with
+    // The gateway debounces ~900ms, then writes the project document with
     // the reordered clips — the collection clip under its ORIGINAL clip id
     // (sourceClipId round-trip) — and touches nothing else.
     await expect
@@ -417,6 +456,13 @@ test.describe("graph view E2E", () => {
     await expect
       .poll(() => api.patchesFor(PROJECT_ID).at(-1)?.clipIds, { timeout: 5000 })
       .toEqual(["alpha", "clip-scene", "charlie"]);
+    // ATOMICITY: both halves of the move traveled in the SAME batch request —
+    // a crash between two independent PATCHes could persist half a move.
+    expect(
+      api.batches.some(
+        (batch) => batch.includes(TRASH_ID) && batch.includes(PROJECT_ID),
+      ),
+    ).toBe(true);
 
     // Trash drops are ordinary undoable moves.
     await undoButton(page).click();


### PR DESCRIPTION
…+ graph-view module split

Review-2 finding #3, the full fix:

- Stored records carry a monotonic `revision` (absent = 0 for legacy), stamped on every save through a shared buildSavePayload so the single-save and batch paths cannot drift. GET and PATCH return it (additive; legacy views keep last-write-wins).
- POST /api/timelines/batch runs all writes in ONE Firestore transaction. Per-write expectedRevision is compare-and-set: any mismatch rejects the whole batch with 409 and the conflicted ids' actual revisions, and nothing is written — a stale client can no longer silently overwrite a newer writer, and a cross-document change can no longer persist by halves. Ownership, the empty-over-nonempty guard, and the no-existence-oracle 404 match the single-document path.
- Gateway: one debounce window for the whole dirty set (was per-document timers), so both documents touched by a cross-timeline move travel in the same atomic batch; one batch in flight with a queued trailing batch; a revision ledger fed by GETs and batch results. On conflict the document is marked stale and reloaded, the banner lands after the reload (earlier, the successful fetch would clear it instantly), unconflicted writes re-queue, and the graph still holds the local edit so the next change re-persists against the fresh revision.
- Also carries the graph-view module split: graph-timeline-view.tsx slimmed to a session orchestrator over ten graph-* modules.

Tests: 10 batch tests over the real handler + real store against a fake Firestore with all-or-nothing runTransaction; 9 reworked gateway tests; e2e mock upgraded to the batch contract with an atomicity witness (trash test asserts both move halves share one batch). Vitest 73/73, e2e 10/10, typecheck + lint clean.