### PR TITLE
feat: interaction model (click/drag/hold grammar) + native drops onto…

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-asset-palette.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-asset-palette.tsx
@@ -9,14 +9,13 @@ import {
   useCollectionsStore,
   usePanWithMomentum,
   type CollectionItemNode,
-  type CollectionsPatch,
 } from "@storyboard/ui/dnd-collections";
-import type { ClipDetail } from "@storyboard/timeline-domain";
 
 import { Button } from "@/components/core/button";
 import type { CloudinaryAsset } from "@/lib/cloudinary-media-store";
 
-const pendingPaletteDetails = new Map<string, ClipDetail>();
+import { clearPendingDetails, parkPendingDetail } from "./graph-pending-details";
+
 const DEFAULT_IMAGE_SECONDS = 4;
 const DEFAULT_VIDEO_SECONDS = 8;
 const PALETTE_ASSET_LIMIT = 48;
@@ -27,7 +26,7 @@ function assetDisplayName(asset: CloudinaryAsset): string {
 }
 
 function createNodeFromAsset(asset: CloudinaryAsset): CollectionItemNode {
-  pendingPaletteDetails.clear();
+  clearPendingDetails();
   const id = parseNodeId(
     `asset-${asset.id}-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`,
   );
@@ -35,7 +34,7 @@ function createNodeFromAsset(asset: CloudinaryAsset): CollectionItemNode {
   const aspect =
     asset.width && asset.height && asset.height > 0 ? asset.width / asset.height : 16 / 9;
 
-  pendingPaletteDetails.set(id as string, {
+  parkPendingDetail(id as string, {
     alt: name,
     aspect,
     trackIndex: 0,
@@ -67,23 +66,6 @@ function createNodeFromAsset(asset: CloudinaryAsset): CollectionItemNode {
     src: asset.url,
     durationSeconds: DEFAULT_IMAGE_SECONDS,
   };
-}
-
-/** Claim app-side metadata parked by PaletteItem when an add commits. */
-export function claimPendingPaletteDetails(
-  patch: CollectionsPatch,
-): Record<string, ClipDetail> | null {
-  if (patch.type !== "nodes-added") return null;
-
-  let claimed: Record<string, ClipDetail> | null = null;
-  for (const add of patch.adds) {
-    const id = add.node.id as string;
-    const detail = pendingPaletteDetails.get(id);
-    if (!detail) continue;
-    (claimed ??= {})[id] = detail;
-    pendingPaletteDetails.delete(id);
-  }
-  return claimed;
 }
 
 type AssetPaletteState =

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -10,6 +10,7 @@ import {
 
 import { Button } from "@/components/core/button";
 
+import { NativeDropStrip } from "./graph-native-drop";
 import { OpenKeyBoundary } from "./graph-navigation";
 import { SyncPanel, type SyncEntry } from "./graph-persistence";
 import {
@@ -92,8 +93,9 @@ export function GraphBoard({
         <div className="flex flex-col gap-5 rounded-xl border border-zinc-800 bg-zinc-950/50 p-4">
           <div className="flex items-center justify-between gap-3">
             <p className="text-xs text-zinc-500">
-              Press-and-hold to drag (cross-timeline included) · amber edges trim · double-click
-              (or O) a dashed clip to focus it · undo survives drill-in.
+              Click a clip to select it (amber edges trim while selected) · click (or O on) a
+              dashed clip to focus it · Ctrl+click multi-selects · press-and-hold to drag
+              (cross-timeline included) · undo survives drill-in.
             </p>
             <div className="flex shrink-0 items-center gap-3">
               <Button
@@ -120,7 +122,7 @@ export function GraphBoard({
           </div>
 
           {surface === "strip" ? (
-            <div className="relative">
+            <NativeDropStrip collectionId={focusedId}>
               <VirtualStrip
                 collectionId={parseNodeId(focusedId)}
                 pixelsPerSecond={TIMELINE_PPS}
@@ -136,7 +138,7 @@ export function GraphBoard({
               {previewOn && (
                 <PlayheadScrubBand focusedId={focusedId} channel={timeChannel} />
               )}
-            </div>
+            </NativeDropStrip>
           ) : (
             <div className="relative">
               <VirtualGrid

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useContext } from "react";
+import { memo } from "react";
 
 import {
   mediaDurationSeconds,
@@ -15,7 +15,6 @@ import {
 } from "@storyboard/ui/dnd-collections";
 
 import { useClipDetail } from "./graph-details-context";
-import { GraphViewNavContext } from "./graph-navigation";
 
 /** Leaf subscription: only the clip being trimmed re-renders per pointer move. */
 function LiveDurationPill({ id, node }: { id: NodeId; node: MediaNode }) {
@@ -39,17 +38,18 @@ const GraphClipContent = memo(function GraphClipContent({
   isDragSource,
   trimEnabled,
 }: CollectionItemContentProps) {
-  const nav = useContext(GraphViewNavContext);
   const detail = useClipDetail(id as string);
 
   if (node.kind === "collection") {
     const hydrated = detail?.hydrated === true;
     const count = hydrated ? childCount : (detail?.itemCount ?? childCount);
     const previews = detail?.previewItems?.slice(0, 3) ?? [];
+    // Opening is the SHELL's job now: a plain click on a collection card
+    // routes through the provider's onOpenNode (see graph-timeline-view) —
+    // no double-click handler here. The title is just the affordance hint.
     return (
       <span
-        title="Double-click (or press O) to open this timeline"
-        onDoubleClick={() => nav?.openTimeline(id)}
+        title="Click (or press O) to open this timeline"
         className={[
           "relative flex h-full w-full flex-col justify-between overflow-hidden rounded-md border border-dashed border-sky-500/40 bg-sky-500/[0.08] p-1.5",
           selected ? "ring-2 ring-amber-400" : "",
@@ -122,14 +122,15 @@ const GraphClipContent = memo(function GraphClipContent({
 
 const GraphTrimHandle = memo(function GraphTrimHandle({
   side,
-  selected,
 }: CollectionTrimHandleContentProps) {
+  // Handles exist only on SELECTED clips (trimRequiresSelection at the
+  // provider), so these pixels are always the active affordance — no
+  // hover-reveal state for unselected cards to style anymore.
   return (
     <span
       className={[
-        "flex h-full w-full items-center justify-center transition-opacity",
+        "flex h-full w-full items-center justify-center bg-amber-400 opacity-95",
         side === "left" ? "rounded-l-md" : "rounded-r-md",
-        selected ? "bg-amber-400 opacity-95" : "bg-amber-400/50 opacity-0 group-hover:opacity-90",
       ].join(" ")}
     >
       <span className="h-4 w-0.5 rounded bg-black/60" />

--- a/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
@@ -1,0 +1,387 @@
+"use client";
+
+import { useCallback, useRef, useState, type DragEvent, type ReactNode } from "react";
+
+import {
+  getChildren,
+  parseNodeId,
+  useCollectionsStore,
+  type CollectionItemNode,
+} from "@storyboard/ui/dnd-collections";
+
+import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
+import { uploadTimelineMedia } from "@/lib/timeline-media-client";
+
+import { parkPendingDetail } from "./graph-pending-details";
+
+// The NATIVE drag-and-drop seam for the graph strips. dnd-kit owns
+// in-graph drags (cards, palette thumbnails); this layer owns what dnd-kit
+// cannot see — HTML5 drags:
+//
+//   - the sidebar tool icons (application/x-gstudio-type: collection /
+//     image / video), which mint a fresh node at the drop position;
+//   - OS FILE drops (images/videos, several at once), which upload through
+//     the same /api/timeline-media pipeline the legacy views use and then
+//     add one node per file — in a single undoable commit.
+//
+// Both paths land as an ordinary add-nodes dispatch through the store, so
+// undo, the change feed, and the patch-scoped persistence all apply. The
+// PersistenceBridge's bounce policy stays the gate for un-hydrated targets:
+// a bounced add is undone with a rejection flash, and this layer detects
+// the bounce (the node is gone) and skips its follow-up work.
+
+const TOOL_MIME = "application/x-gstudio-type";
+// The demo clip the legacy views use for placeholder video content.
+const PLACEHOLDER_VIDEO_SRC = "https://www.w3schools.com/html/mov_bbb.mp4";
+const PLACEHOLDER_VIDEO_SECONDS = 10;
+
+type SidebarTool = "collection" | "image" | "video";
+
+function isSidebarTool(value: string): value is SidebarTool {
+  return value === "collection" || value === "image" || value === "video";
+}
+
+function mintId(prefix: string): string {
+  return `${prefix}-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/** Duration probe for dropped video files (images default to 4s). */
+function mediaFileDuration(file: File): Promise<number> {
+  return new Promise((resolve) => {
+    if (!file.type.startsWith("video/")) {
+      resolve(4);
+      return;
+    }
+    const video = document.createElement("video");
+    video.preload = "metadata";
+    const sourceUrl = URL.createObjectURL(file);
+    const cleanup = () => {
+      URL.revokeObjectURL(sourceUrl);
+      video.removeAttribute("src");
+      video.load();
+    };
+    video.onloadedmetadata = () => {
+      const duration =
+        Number.isFinite(video.duration) && video.duration > 0 ? video.duration : 5;
+      cleanup();
+      resolve(duration);
+    };
+    video.onerror = () => {
+      cleanup();
+      resolve(5);
+    };
+    video.src = sourceUrl;
+  });
+}
+
+/**
+ * Wraps a strip and accepts native drops into the given collection.
+ * Insertion position follows the legacy midpoint rule, resolved against the
+ * MOUNTED cards (virtualization: DOM order matches child order, but indexes
+ * must come from the graph, not the DOM position).
+ */
+export function NativeDropStrip({
+  collectionId,
+  children,
+}: Readonly<{ collectionId: string; children: ReactNode }>) {
+  const store = useCollectionsStore();
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [indicatorX, setIndicatorX] = useState<number | null>(null);
+  const [upload, setUpload] = useState<
+    | Readonly<{ status: "uploading"; count: number }>
+    | Readonly<{ status: "error"; message: string }>
+    | null
+  >(null);
+
+  const acceptsDrag = (event: DragEvent) => {
+    const types = event.dataTransfer.types;
+    return types.includes(TOOL_MIME) || types.includes("Files");
+  };
+
+  /** Graph child index for a drop at clientX, via mounted-card midpoints. */
+  const resolveInsertIndex = useCallback(
+    (clientX: number): number => {
+      const wrapper = wrapperRef.current;
+      const children_ = getChildren(store.getSnapshot().graph, parseNodeId(collectionId));
+      if (!wrapper) return children_.length;
+      const cards = [...wrapper.querySelectorAll<HTMLElement>("[data-node-id]")];
+      for (const card of cards) {
+        const rect = card.getBoundingClientRect();
+        if (clientX < rect.left + rect.width / 2) {
+          const index = children_.indexOf(parseNodeId(card.dataset.nodeId ?? ""));
+          if (index >= 0) return index;
+        }
+      }
+      const last = cards[cards.length - 1];
+      if (last) {
+        const index = children_.indexOf(parseNodeId(last.dataset.nodeId ?? ""));
+        if (index >= 0) return index + 1;
+      }
+      return children_.length;
+    },
+    [store, collectionId],
+  );
+
+  const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
+    if (!acceptsDrag(event)) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+    const wrapper = wrapperRef.current;
+    if (!wrapper) return;
+    // Indicator: snap to the resolved insertion edge when a card anchors it,
+    // else follow the pointer (empty strip / trailing whitespace).
+    const rect = wrapper.getBoundingClientRect();
+    const cards = [...wrapper.querySelectorAll<HTMLElement>("[data-node-id]")];
+    let x = event.clientX - rect.left;
+    for (const card of cards) {
+      const cardRect = card.getBoundingClientRect();
+      if (event.clientX < cardRect.left + cardRect.width / 2) {
+        x = cardRect.left - rect.left - 3;
+        break;
+      }
+      x = cardRect.right - rect.left + 3;
+    }
+    setIndicatorX(x);
+  };
+
+  const handleDragLeave = (event: DragEvent<HTMLDivElement>) => {
+    // Only clear when the pointer truly left the wrapper (dragleave fires
+    // for every child boundary crossing).
+    if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
+    setIndicatorX(null);
+  };
+
+  const addNodes = useCallback(
+    (nodes: readonly CollectionItemNode[], toIndex: number): boolean => {
+      const result = store.dispatch({
+        type: "add-nodes",
+        nodes,
+        toParentId: parseNodeId(collectionId),
+        toIndex,
+      });
+      if (!result.ok) return false;
+      // The PersistenceBridge may have BOUNCED the add (un-hydrated target):
+      // it undoes reentrantly, so by now the nodes are gone again.
+      const graph = store.getSnapshot().graph;
+      return nodes.every((node) => graph.nodesById.has(node.id));
+    },
+    [store, collectionId],
+  );
+
+  const dropTool = useCallback(
+    (tool: SidebarTool, toIndex: number) => {
+      if (tool === "collection") {
+        const childId = mintId("timeline");
+        // hydrated: true — the collection is BRAND-NEW and empty, so drops
+        // into it must not bounce and writes may touch its document.
+        parkPendingDetail(childId, {
+          alt: "New Timeline collection",
+          aspect: 16 / 9,
+          trackIndex: 0,
+          itemCount: 0,
+          duration: 3,
+          sourceDuration: 3,
+          trimIn: 0,
+          trimOut: 0,
+          hydrated: true,
+        });
+        const added = addNodes(
+          [{ id: parseNodeId(childId), kind: "collection", name: "New Timeline" }],
+          toIndex,
+        );
+        if (added) {
+          // Create the child document itself: seed the cache (expected
+          // revision 0 = compare-and-set create) and queue an empty write —
+          // it joins the same atomic batch as the parent's update, so a
+          // drill-in never 404s on a half-created collection.
+          graphDocumentsGateway.seed({ id: childId, title: "New Timeline", clips: [] });
+          graphDocumentsGateway.writeClips(childId, []);
+        }
+        return;
+      }
+
+      const id = mintId(tool);
+      const placeholder = `https://picsum.photos/seed/${id}/640/360`;
+      if (tool === "image") {
+        parkPendingDetail(id, {
+          alt: "New Image",
+          aspect: 16 / 9,
+          trackIndex: 0,
+          sourceDuration: 4,
+          trimIn: 0,
+          trimOut: 0,
+        });
+        addNodes(
+          [
+            {
+              id: parseNodeId(id),
+              kind: "media",
+              mediaKind: "image",
+              name: "New Image",
+              src: placeholder,
+              durationSeconds: 4,
+            },
+          ],
+          toIndex,
+        );
+        return;
+      }
+
+      parkPendingDetail(id, {
+        alt: "New Video",
+        aspect: 16 / 9,
+        trackIndex: 0,
+        poster: placeholder,
+      });
+      addNodes(
+        [
+          {
+            id: parseNodeId(id),
+            kind: "media",
+            mediaKind: "video",
+            name: "New Video",
+            src: PLACEHOLDER_VIDEO_SRC,
+            posterSrcs: [placeholder],
+            fullDurationSeconds: PLACEHOLDER_VIDEO_SECONDS,
+            trimInSeconds: 0,
+            trimOutSeconds: 0,
+          },
+        ],
+        toIndex,
+      );
+    },
+    [addNodes],
+  );
+
+  const dropFiles = useCallback(
+    async (files: readonly File[], toIndex: number) => {
+      const media = files.filter(
+        (file) => file.type.startsWith("image/") || file.type.startsWith("video/"),
+      );
+      if (media.length === 0) return;
+      setUpload({ status: "uploading", count: media.length });
+
+      try {
+        const results: readonly { node: CollectionItemNode | null; error: string | null }[] =
+          await Promise.all(
+            media.map(async (file) => {
+            const isVideo = file.type.startsWith("video/");
+            const duration = await mediaFileDuration(file);
+            let hosted: Awaited<ReturnType<typeof uploadTimelineMedia>>;
+            try {
+              hosted = await uploadTimelineMedia(file.name, file);
+            } catch {
+              return { node: null, error: `"${file.name}" could not be uploaded.` };
+            }
+            if (isVideo && !hosted.thumbnailUrl) {
+              return { node: null, error: `"${file.name}" has no video thumbnail.` };
+            }
+
+            const id = mintId(isVideo ? "video" : "image");
+            if (isVideo) {
+              parkPendingDetail(id, {
+                alt: file.name,
+                aspect: 16 / 9,
+                trackIndex: 0,
+                poster: hosted.thumbnailUrl,
+              });
+              const node: CollectionItemNode = {
+                id: parseNodeId(id),
+                kind: "media",
+                mediaKind: "video",
+                name: file.name,
+                src: hosted.url,
+                posterSrcs: hosted.thumbnailUrl ? [hosted.thumbnailUrl] : undefined,
+                fullDurationSeconds: duration,
+                trimInSeconds: 0,
+                // Match the legacy drop: long videos start showing 12s.
+                trimOutSeconds: Math.max(0, duration - 12),
+              };
+              return { node, error: null };
+            }
+            parkPendingDetail(id, {
+              alt: file.name,
+              aspect: 16 / 9,
+              trackIndex: 0,
+              sourceDuration: 4,
+              trimIn: 0,
+              trimOut: 0,
+            });
+            const node: CollectionItemNode = {
+              id: parseNodeId(id),
+              kind: "media",
+              mediaKind: "image",
+              name: file.name,
+              src: hosted.url,
+              durationSeconds: 4,
+            };
+            return { node, error: null };
+          }),
+        );
+
+        const failure = results.find((result) => result.error)?.error ?? null;
+        const nodes = results
+          .map((result) => result.node)
+          .filter((node): node is CollectionItemNode => node !== null);
+        // ONE dispatch for the whole file set: a multi-file drop is a single
+        // undoable step and a single persisted batch.
+        if (nodes.length > 0) addNodes(nodes, toIndex);
+        setUpload(failure ? { status: "error", message: failure } : null);
+      } catch {
+        setUpload({ status: "error", message: "The dropped files could not be added." });
+      }
+    },
+    [addNodes],
+  );
+
+  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
+    if (!acceptsDrag(event)) return;
+    event.preventDefault();
+    setIndicatorX(null);
+    const toIndex = resolveInsertIndex(event.clientX);
+
+    const tool = event.dataTransfer.getData(TOOL_MIME);
+    if (tool && isSidebarTool(tool)) {
+      dropTool(tool, toIndex);
+      return;
+    }
+    const files = [...event.dataTransfer.files];
+    if (files.length > 0) void dropFiles(files, toIndex);
+  };
+
+  return (
+    <div
+      ref={wrapperRef}
+      data-native-drop={collectionId}
+      className="relative"
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
+      {children}
+      {indicatorX !== null && (
+        <div
+          data-native-drop-indicator
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-y-1 z-20 w-0.5 rounded bg-amber-400 shadow-[0_0_6px_rgba(251,191,36,0.9)]"
+          style={{ transform: `translateX(${indicatorX}px)` }}
+        />
+      )}
+      {upload !== null && (
+        <p
+          data-native-drop-status
+          className={[
+            "pointer-events-none absolute bottom-1 left-1 z-20 rounded px-2 py-1 text-[10px]",
+            upload.status === "uploading"
+              ? "bg-zinc-900/90 text-zinc-200"
+              : "bg-red-950/90 text-red-200",
+          ].join(" ")}
+        >
+          {upload.status === "uploading"
+            ? `Uploading ${upload.count} file${upload.count === 1 ? "" : "s"}…`
+            : upload.message}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useMemo } from "react";
+import { createContext, useContext, useEffect, useMemo, type MutableRefObject } from "react";
 import { useRouter } from "next/navigation";
 
 import {
@@ -20,10 +20,18 @@ export const GraphViewNavContext = createContext<GraphViewNav | null>(null);
 export function GraphViewNavProvider({
   projectId,
   focusedId,
+  openNodeRef,
   children,
 }: Readonly<{
   projectId: string;
   focusedId: string;
+  /**
+   * Written with the latest openTimeline. The provider-level click-to-open
+   * callback (the `onOpenNode` prop on <DndCollections>) is registered ABOVE
+   * the engine provider, where this component's store isn't reachable — the
+   * ref is the seam that hands it the current focus logic.
+   */
+  openNodeRef?: MutableRefObject<(nodeId: NodeId) => void>;
   children: React.ReactNode;
 }>) {
   const router = useRouter();
@@ -56,6 +64,10 @@ export function GraphViewNavProvider({
     }),
     [detailsStore, focusedId, projectId, router, store],
   );
+
+  useEffect(() => {
+    if (openNodeRef) openNodeRef.current = value.openTimeline;
+  }, [openNodeRef, value]);
 
   return <GraphViewNavContext.Provider value={value}>{children}</GraphViewNavContext.Provider>;
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-pending-details.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-pending-details.ts
@@ -1,0 +1,39 @@
+import type { CollectionsPatch } from "@storyboard/ui/dnd-collections";
+import type { ClipDetail } from "@storyboard/timeline-domain";
+
+// App-side details for nodes created OUTSIDE React state — a palette drag's
+// factory (runs inside dnd-kit's drag start) and the native drop layer
+// (sidebar tools, OS file drops) both mint nodes imperatively and park the
+// node's app-only fields here. The PersistenceBridge claims parked entries
+// when the add COMMITS — before the first write, so poster/aspect/hydrated
+// round-trip into the stored clip.
+
+const pendingDetails = new Map<string, ClipDetail>();
+
+/** Park a freshly minted node's detail until its add-nodes commit claims it. */
+export function parkPendingDetail(id: string, detail: ClipDetail): void {
+  pendingDetails.set(id, detail);
+}
+
+/** Drop everything parked — a drag start clears leftovers from a CANCELLED
+ *  or rejected drag (its minted ids can never be referenced again). */
+export function clearPendingDetails(): void {
+  pendingDetails.clear();
+}
+
+/** Claim parked metadata for every node an add-nodes patch committed. */
+export function claimPendingPaletteDetails(
+  patch: CollectionsPatch,
+): Record<string, ClipDetail> | null {
+  if (patch.type !== "nodes-added") return null;
+
+  let claimed: Record<string, ClipDetail> | null = null;
+  for (const add of patch.adds) {
+    const id = add.node.id as string;
+    const detail = pendingDetails.get(id);
+    if (!detail) continue;
+    (claimed ??= {})[id] = detail;
+    pendingDetails.delete(id);
+  }
+  return claimed;
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-persistence.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-persistence.tsx
@@ -16,7 +16,7 @@ import {
 import { collectReachableDetailIds } from "@/lib/graph-details-store";
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 
-import { claimPendingPaletteDetails } from "./graph-asset-palette";
+import { claimPendingPaletteDetails } from "./graph-pending-details";
 import { useGraphDetailsStore } from "./graph-details-context";
 
 export type SyncEntry = Readonly<{

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -15,6 +15,7 @@ import { Button } from "@/components/core/button";
 
 import { useClipDetail, useGraphDetailsStore } from "./graph-details-context";
 import { hydrateTimeline } from "./graph-hydration";
+import { NativeDropStrip } from "./graph-native-drop";
 import { GraphViewNavContext } from "./graph-navigation";
 import { TIMELINE_PPS } from "./graph-view-config";
 
@@ -81,13 +82,15 @@ function SubTimelineSection({
       </div>
 
       {hydrated && !collapsed && (
-        <VirtualStrip
-          collectionId={collectionId}
-          pixelsPerSecond={TIMELINE_PPS}
-          itemHeight={64}
-          itemDragActivation="hold"
-          className="bg-black/20"
-        />
+        <NativeDropStrip collectionId={id}>
+          <VirtualStrip
+            collectionId={collectionId}
+            pixelsPerSecond={TIMELINE_PPS}
+            itemHeight={64}
+            itemDragActivation="hold"
+            className="bg-black/20"
+          />
+        </NativeDropStrip>
       )}
     </section>
   );

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -6,6 +6,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   useSyncExternalStore,
 } from "react";
@@ -13,8 +14,10 @@ import {
 import {
   DndCollections,
   buildGraph,
+  type CollectionItemNode,
   type CollectionsGraph,
   type GraphNodeSpec,
+  type NodeId,
 } from "@storyboard/ui/dnd-collections";
 import { buildHydrationSpecs, type ClipDetail } from "@storyboard/timeline-domain";
 
@@ -177,6 +180,23 @@ export function GraphTimelineView({ projectId }: { projectId: string }) {
     setSyncLog((log) => [entry, ...log].slice(0, 6));
   }, []);
 
+  // Click-to-open (the pointer twin of the O key): the provider's
+  // onOpenNode fires on a plain click on an open-target card — after the
+  // package's gesture arbitration, so a drag, a hold-grab, or a pan never
+  // opens. The actual focus logic lives in GraphViewNavProvider (it needs
+  // the engine store, which only exists INSIDE <DndCollections>), so it
+  // registers itself into this ref.
+  const openNodeRef = useRef<(nodeId: NodeId) => void>(() => {});
+  const handleOpenNode = useCallback((nodeId: NodeId) => openNodeRef.current(nodeId), []);
+  // Collections open — and so do duplicate-reference cards (media cards
+  // standing in for a timeline referenced twice; same set the O key uses).
+  const openOnClick = useCallback(
+    (nodeId: NodeId, node: CollectionItemNode) =>
+      node.kind === "collection" ||
+      detailsStore.get(nodeId as string)?.duplicateOfTimelineId !== undefined,
+    [detailsStore],
+  );
+
   if (boot.status === "loading") {
     return (
       <div className="grid gap-3" aria-label="Loading graph view">
@@ -215,6 +235,15 @@ export function GraphTimelineView({ projectId }: { projectId: string }) {
         initialGraph={boot.graph}
         components={GRAPH_VIEW_COMPONENTS}
         maxHistoryEntries={200}
+        // The interaction model: click toggles a clip's selection (trim
+        // handles exist only while selected), click on a collection or
+        // duplicate-reference card drills in, Ctrl/Cmd+click multi-selects,
+        // press-and-hold drags — the package's arbitration keeps the four
+        // from ever colliding.
+        clickSelection="toggle"
+        trimRequiresSelection
+        onOpenNode={handleOpenNode}
+        openOnClick={openOnClick}
       >
         <GraphDetailsProvider store={detailsStore}>
           <PersistenceBridge onSync={onSync} />
@@ -226,7 +255,11 @@ export function GraphTimelineView({ projectId }: { projectId: string }) {
             onFocusError={setFocusError}
           />
 
-          <GraphViewNavProvider projectId={projectId} focusedId={focusedId}>
+          <GraphViewNavProvider
+            projectId={projectId}
+            focusedId={focusedId}
+            openNodeRef={openNodeRef}
+          >
             {focusError !== null ? (
               <div className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-4 text-sm text-zinc-300">
                 <p className="font-semibold text-zinc-100">Unknown timeline</p>

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -105,12 +105,6 @@ function IconLink({
 
 const ITEMS: DraggableItem[] = [
   {
-    type: "timeline",
-    label: "Timeline",
-    description: "New timeline layer",
-    icon: Layers,
-  },
-  {
     type: "collection",
     label: "Collection",
     description: "Nested timeline beat",

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
@@ -326,6 +326,26 @@ describe("graph-documents-gateway", () => {
     expect(gateway.lastError()).toBeNull();
   });
 
+  it("seed makes a client-minted document writable with a compare-and-set create", async () => {
+    const calls = installFetch((call) =>
+      call.method === "POST" ? okResults(call.writes) : jsonResponse({}, 404),
+    );
+    const gateway = createGraphDocumentsGateway();
+
+    gateway.seed(doc("fresh"));
+    expect(clipIds(gateway.peek("fresh"))).toEqual([]);
+
+    gateway.writeClips("fresh", [clip("f1")]);
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+    const batch = batchesOf(calls)[0];
+    expect(batch.writes?.[0].expectedRevision).toBe(0); // CAS create
+    expect(clipIds(batch.writes?.[0].document)).toEqual(["f1"]);
+
+    // Seeding never clobbers an existing cache entry.
+    gateway.seed({ ...doc("fresh"), title: "Other" });
+    expect(gateway.peek("fresh")?.title).toBe("Timeline fresh");
+  });
+
   it("keeps per-document errors: one document's success does not clear another's failure", async () => {
     let aFails = true;
     const calls = installFetch((call) => {

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
@@ -44,6 +44,13 @@ export type GraphDocumentsGateway = Readonly<{
    * batch. No-op for timelines the session hasn't loaded.
    */
   writeClips: (timelineId: string, clips: TimelineClip[]) => void;
+  /**
+   * Insert a BRAND-NEW document into the cache (a collection minted
+   * client-side, e.g. a sidebar-tool drop) with an expected revision of 0 —
+   * the first write is a compare-and-set CREATE, so it can never clobber a
+   * document that turns out to exist. No-op when the id is already cached.
+   */
+  seed: (document: TimelineDocument) => void;
   /** Cache-change notifications (documents landing, clips written). */
   subscribe: (listener: () => void) => () => void;
   /** Outstanding load/save failures, for a status banner. Null when every
@@ -314,6 +321,15 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
       notify();
       dirtyIds.add(timelineId);
       scheduleFlush();
+    },
+    seed: (document) => {
+      if (documents[document.id]) return;
+      documents = { ...documents, [document.id]: document };
+      // Expectation 0: the batch write that first persists this document is
+      // a compare-and-set CREATE — a same-id document appearing on the
+      // server meanwhile conflicts instead of being overwritten.
+      revisions.set(document.id, 0);
+      notify();
     },
     subscribe: (listener) => {
       listeners.add(listener);

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -559,9 +559,9 @@ test.describe("graph view E2E", () => {
     // Drill-in RESETS the persistent preview clock: the layout (and with it
     // the time channel) survives navigation, but a different focused
     // timeline is a different clock — without the reset the transport would
-    // park at "long-timeline-time / short-timeline-duration".
+    // park at "long-timeline-time / short-timeline-duration". A plain click
+    // on the collection card drills (the interaction model's pointer path).
     await strip(page, PROJECT_ID).locator(`[data-node-id="${CHILD_ID}"]`).click();
-    await page.keyboard.press("o");
     await page.waitForURL(`**${GRAPH_URL}/${CHILD_ID}`);
     await expect.poll(translateX).toBeLessThan(20);
   });
@@ -684,12 +684,146 @@ test.describe("graph view E2E", () => {
     await openGraph(page);
     await expect.poll(() => stripOrder(page, CHILD_ID), { timeout: 15000 }).toEqual(["c1", "c2"]);
 
-    // Click selects and focuses the card (no drag: item drags need a hold);
-    // "O" is the keyboard twin of the double-click open.
-    await strip(page, PROJECT_ID).locator(`[data-node-id="${CHILD_ID}"]`).click();
+    // Keyboard-pure path: FOCUS the card (a click would drill immediately
+    // now — the pointer twin below) and press the open key.
+    await strip(page, PROJECT_ID).locator(`[data-node-id="${CHILD_ID}"]`).focus();
     await page.keyboard.press("o");
 
     await page.waitForURL(`**${GRAPH_URL}/${CHILD_ID}`);
     await expect.poll(() => stripOrder(page, CHILD_ID)).toEqual(["c1", "c2"]);
+  });
+
+  test("interaction model: click toggles selection + trim handles, hold-grab release does neither, collection click drills", async ({
+    page,
+  }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    await expect.poll(() => stripOrder(page, CHILD_ID), { timeout: 15000 }).toEqual(["c1", "c2"]);
+
+    // bravo is an IMAGE: selected images grow exactly ONE handle (the end
+    // edge) — a video would grow two.
+    const bravo = strip(page, PROJECT_ID).locator('[data-node-id="bravo"]');
+    const bravoWrapper = strip(page, PROJECT_ID).locator('[data-node-wrapper="bravo"]');
+
+    // Unselected media: no trim handles — the edges are plain card body.
+    await expect(bravoWrapper.locator("[data-trim-handle]")).toHaveCount(0);
+
+    // A real click toggles selection ON, and the handle grows in. (Retried:
+    // under CI load a press can outlast the 250ms hold threshold, becoming a
+    // hold-grab whose click is — correctly — suppressed.)
+    await expect(async () => {
+      await bravo.click();
+      await expect(bravo).toHaveAttribute("data-selected", "true", { timeout: 700 });
+    }).toPass({ timeout: 10000 });
+    await expect(bravoWrapper.locator("[data-trim-handle]")).toHaveCount(1);
+
+    // Press-and-hold released IN PLACE is a grab, not a click: the trailing
+    // click is suppressed, so the selection (and handles) stay put.
+    const box = (await bravo.boundingBox())!;
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.waitForTimeout(400); // past the 250ms hold activation
+    await page.mouse.up();
+    await expect(bravo).toHaveAttribute("data-selected", "true");
+    await expect(bravoWrapper.locator("[data-trim-handle]")).toHaveCount(1);
+
+    // Click again: toggles OFF, handles gone. (Same accidental-hold retry.)
+    await expect(async () => {
+      await bravo.click();
+      await expect(bravo).not.toHaveAttribute("data-selected", "true", { timeout: 700 });
+    }).toPass({ timeout: 10000 });
+    await expect(bravoWrapper.locator("[data-trim-handle]")).toHaveCount(0);
+
+    // A plain click on a collection card DRILLS IN (the pointer twin of O).
+    await expect(async () => {
+      await strip(page, PROJECT_ID).locator(`[data-node-id="${CHILD_ID}"]`).click();
+      await page.waitForURL(`**${GRAPH_URL}/${CHILD_ID}`, { timeout: 3000 });
+    }).toPass({ timeout: 15000 });
+    await expect.poll(() => stripOrder(page, CHILD_ID)).toEqual(["c1", "c2"]);
+  });
+
+  test("native drops: sidebar tools and OS files land as nodes and persist", async ({
+    page,
+  }) => {
+    const api = await installGraphApi(page);
+    let uploads = 0;
+    await page.route("**/api/timeline-media/upload", (route) => {
+      uploads += 1;
+      return route.fulfill({
+        json: { pathname: `upload-${uploads}.png`, url: PIXEL, thumbnailUrl: PIXEL },
+      });
+    });
+    await openGraph(page);
+    await expect.poll(() => stripOrder(page, CHILD_ID), { timeout: 15000 }).toEqual(["c1", "c2"]);
+
+    const dropZone = page.locator(`[data-native-drop="${PROJECT_ID}"]`);
+
+    // 1) Sidebar IMAGE tool: mints a placeholder image clip at the drop
+    //    position (clientX 0 = before the first card).
+    const toolTransfer = await page.evaluateHandle(() => {
+      const transfer = new DataTransfer();
+      transfer.setData("application/x-gstudio-type", "image");
+      return transfer;
+    });
+    await dropZone.dispatchEvent("drop", { dataTransfer: toolTransfer, clientX: 0 });
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID))
+      .toEqual([
+        expect.stringMatching(/^image-/),
+        "alpha",
+        "bravo",
+        CHILD_ID,
+        "charlie",
+      ]);
+
+    // 2) Sidebar COLLECTION tool: mints a new collection AND creates its
+    //    (empty) child document in the SAME atomic batch as the parent
+    //    update — a drill-in can never 404 on a half-created collection.
+    const collectionTransfer = await page.evaluateHandle(() => {
+      const transfer = new DataTransfer();
+      transfer.setData("application/x-gstudio-type", "collection");
+      return transfer;
+    });
+    await dropZone.dispatchEvent("drop", { dataTransfer: collectionTransfer, clientX: 0 });
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID).then((order) => order[0]))
+      .toMatch(/^timeline-/);
+    await expect
+      .poll(
+        () =>
+          api.patches.find((patch) => /^timeline-/.test(patch.id) && patch.clipIds.length === 0)
+            ?.id ?? null,
+        { timeout: 5000 },
+      )
+      .not.toBeNull();
+    const newChildId = api.patches.find((patch) => /^timeline-/.test(patch.id))!.id;
+    expect(
+      api.batches.some((batch) => batch.includes(newChildId) && batch.includes(PROJECT_ID)),
+    ).toBe(true);
+
+    // 3) OS FILE drop, several at once: both upload and land as ONE commit.
+    const fileTransfer = await page.evaluateHandle(() => {
+      const transfer = new DataTransfer();
+      transfer.items.add(new File([new Uint8Array([137, 80, 78, 71])], "photo-a.png", { type: "image/png" }));
+      transfer.items.add(new File([new Uint8Array([137, 80, 78, 71])], "photo-b.png", { type: "image/png" }));
+      return transfer;
+    });
+    await dropZone.dispatchEvent("drop", { dataTransfer: fileTransfer, clientX: 0 });
+    // 4 fixture clips + image tool + collection tool + 2 files = 8.
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID).then((order) => order.length), { timeout: 10000 })
+      .toBe(8);
+    expect(uploads).toBe(2);
+
+    // Both files persisted into the project document in one write.
+    await expect
+      .poll(() => api.patchesFor(PROJECT_ID).at(-1)?.clipIds.length, { timeout: 5000 })
+      .toBe(8);
+
+    // The whole file drop is ONE undoable step.
+    await undoButton(page).click();
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID).then((order) => order.length))
+      .toBe(6);
   });
 });

--- a/packages/ui/dnd-collections/API.md
+++ b/packages/ui/dnd-collections/API.md
@@ -517,6 +517,22 @@ type DndCollectionsProps = {
   maxHistoryEntries?: number; // cap the undo stack; positive integer, default unbounded
   animateMoves?: boolean;     // post-commit FLIP sweep, default true; one sweep for ALL views
   components?: CollectionsComponents; // consumer pixels: ItemContent / GhostContent (see "Custom item content")
+  // Interaction policy (react/interaction-policy.ts) — what a PLAIN CLICK on
+  // a card means. Clicks only reach the cards after gesture arbitration: an
+  // activated drag or press-and-hold grab suppresses its trailing click
+  // (dnd-kit), a surface pan squashes its own (use-pan-with-momentum).
+  clickSelection?: "replace" | "toggle"; // default "replace" (select only this card);
+                                         // "toggle": click toggles — sole-selected deselects,
+                                         // a multi-selection member collapses to itself
+  onOpenNode?: (id: NodeId) => void;     // when set: a plain POINTER click on an open-target
+                                         // card OPENS it (drill-in) instead of selecting.
+                                         // Ctrl/Cmd+click still selection-toggles it; keyboard
+                                         // Space always selects (the keyboard grammar is untouched)
+  openOnClick?: (id: NodeId, node: CollectionItemNode) => boolean; // which nodes open,
+                                         // default node.kind === "collection"
+  trimRequiresSelection?: boolean;       // default false; true = trim handles (hit zones
+                                         // included) exist only on SELECTED media cards, and
+                                         // content's trimEnabled follows
   children: ReactNode;
 };
 ```
@@ -524,6 +540,15 @@ type DndCollectionsProps = {
 `animateMoves` is owned here at the provider (not per view), so a single FLIP
 sweep animates every card under the instance — panels, virtual, and custom
 views — on each commit (drop/undo/redo). It honors `prefers-reduced-motion`.
+
+The interaction-policy props apply to BOTH card shells (`NodeCard` and the
+`CollectionItem` primitives) through one shared click grammar: Ctrl/Cmd+click
+is always the additive selection toggle (also how open-target nodes join a
+multi-drag); a plain pointer click opens (when configured) or selects (per
+`clickSelection`); keyboard activation always selects. With
+`trimRequiresSelection`, an unselected card's edges are plain card body — a
+press there clicks or drags, never trims. Interaction-test coverage lives in
+`InteractionPolicy.stories.tsx`.
 
 `maxHistoryEntries` is initial-only (like `initialGraph`): the oldest undo
 entries fall off past the cap. Any non-positive-integer value is treated as

--- a/packages/ui/dnd-collections/ARCHITECTURE.md
+++ b/packages/ui/dnd-collections/ARCHITECTURE.md
@@ -372,6 +372,35 @@ Everything semantic happens in `core/`.
   dimmed; the `DragOverlay` ghost carries a "+N" badge. The reducer sorts
   the set into document order and prunes ids whose ancestor is also moving.
 
+## Click arbitration and the interaction policy
+
+A card's `onClick` only ever sees the residue the gesture pipeline leaves
+behind, and three mechanisms guarantee it:
+
+- **An activated drag suppresses its trailing click.** dnd-kit adds a
+  capture-phase document click listener the moment activation constraints
+  are met — including a press-and-hold grab released WITHOUT moving, so
+  "click-and-hold" is cleanly distinct from "click".
+- **A pan squashes its own click** (`use-pan-with-momentum`): after a real
+  pan, a one-shot capture listener eats the click inside the container.
+- **The pan captures the pointer only once the press BECOMES a pan** (past
+  the slop). Capturing at pointerdown retargets pointerup to the container,
+  and the browser then fires the compatibility click at the container
+  instead of the pressed card — which silently ate every stationary card
+  click on pannable surfaces. (This exact bug shipped; the graph view's
+  e2e interaction-model test guards it with trusted input.)
+
+What the surviving click MEANS is the provider-level interaction policy
+(`react/interaction-policy.ts`, configured via `clickSelection` /
+`onOpenNode` / `openOnClick` / `trimRequiresSelection` on
+`<DndCollections>`): replace-or-toggle selection, click-to-open for
+collections (pointer clicks only — keyboard Space always selects, so the
+grammar below is untouched; Ctrl/Cmd+click always selection-toggles, which
+is also how open-targets join a multi-drag), and selection-gated trim
+handles. One shared grammar covers both card shells (`NodeCard` and the
+`CollectionItem` primitives); coverage lives in
+`InteractionPolicy.stories.tsx`.
+
 ## Keyboard: two coexisting systems
 
 - dnd-kit's `KeyboardSensor` is restricted to **Enter** to grab/drop (arrows

--- a/packages/ui/dnd-collections/InteractionPolicy.stories.tsx
+++ b/packages/ui/dnd-collections/InteractionPolicy.stories.tsx
@@ -1,0 +1,215 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, userEvent, waitFor } from "storybook/test";
+
+import { buildGraph, getChildren, parseNodeId, type NodeId } from "./core/graph";
+import { DndCollections } from "./react/DndCollections";
+import { useCollectionsSelector } from "./react/collections-store";
+import { NodeCard } from "./react/node-views";
+import { nodeCard, waitForLayout } from "./stories-helpers";
+
+// The provider-level interaction policy (react/interaction-policy.ts):
+// click-toggle selection, click-to-open collections, and selection-gated
+// trim handles. Everything here rides on the gesture arbitration that
+// already exists — an activated drag or hold-grab suppresses its trailing
+// click (dnd-kit), a pan squashes its own (use-pan-with-momentum) — so
+// these stories exercise the semantics of the clicks that survive.
+
+function mediaGraph() {
+  const result = buildGraph([
+    {
+      kind: "collection",
+      id: "board",
+      name: "Board",
+      children: [
+        { kind: "media", id: "alpha", name: "Alpha", durationSeconds: 4 },
+        { kind: "media", id: "bravo", name: "Bravo", durationSeconds: 4 },
+        { kind: "media", id: "charlie", name: "Charlie", durationSeconds: 4 },
+      ],
+    },
+  ]);
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.value;
+}
+
+function mixedGraph() {
+  const result = buildGraph([
+    {
+      kind: "collection",
+      id: "board",
+      name: "Board",
+      children: [
+        { kind: "media", id: "alpha", name: "Alpha", durationSeconds: 4 },
+        {
+          kind: "collection",
+          id: "scene",
+          name: "Scene",
+          children: [{ kind: "media", id: "nested", name: "Nested", durationSeconds: 4 }],
+        },
+      ],
+    },
+  ]);
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.value;
+}
+
+function BoardCards({ trimPixelsPerSecond }: { trimPixelsPerSecond?: number }) {
+  const childIds = useCollectionsSelector((s) => getChildren(s.graph, parseNodeId("board")));
+  return (
+    <div data-testid="board" className="flex gap-3">
+      {childIds.map((id) => (
+        <NodeCard key={id} id={id} trimPixelsPerSecond={trimPixelsPerSecond} />
+      ))}
+    </div>
+  );
+}
+
+const meta = {
+  title: "UI/DndCollectionsInteractionPolicy",
+  decorators: [
+    (Story) => (
+      <div className="min-h-screen bg-background p-8 text-foreground">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const isSelected = (canvasElement: HTMLElement, id: string) =>
+  nodeCard(canvasElement, id).hasAttribute("data-selected");
+
+export const ClickToggleSelection: Story = {
+  render: () => (
+    <DndCollections initialGraph={mediaGraph()} animateMoves={false} clickSelection="toggle">
+      <BoardCards />
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    await waitForLayout(nodeCard(canvasElement, "alpha"));
+    const user = userEvent.setup();
+
+    // Click toggles ON: the clicked card becomes the sole selection.
+    await user.click(nodeCard(canvasElement, "alpha"));
+    await waitFor(() => expect(isSelected(canvasElement, "alpha")).toBe(true));
+
+    // Click the sole-selected card again: toggles OFF.
+    await user.click(nodeCard(canvasElement, "alpha"));
+    await waitFor(() => expect(isSelected(canvasElement, "alpha")).toBe(false));
+
+    // Clicking another card collapses the selection to it.
+    await user.click(nodeCard(canvasElement, "alpha"));
+    await user.click(nodeCard(canvasElement, "bravo"));
+    await waitFor(() => {
+      expect(isSelected(canvasElement, "alpha")).toBe(false);
+      expect(isSelected(canvasElement, "bravo")).toBe(true);
+    });
+
+    // Ctrl+click stays the additive toggle: builds a multi-selection…
+    await user.keyboard("{Control>}");
+    await user.click(nodeCard(canvasElement, "charlie"));
+    await user.keyboard("{/Control}");
+    await waitFor(() => {
+      expect(isSelected(canvasElement, "bravo")).toBe(true);
+      expect(isSelected(canvasElement, "charlie")).toBe(true);
+    });
+
+    // …and a plain click on a member of a multi-selection collapses to it.
+    await user.click(nodeCard(canvasElement, "charlie"));
+    await waitFor(() => {
+      expect(isSelected(canvasElement, "bravo")).toBe(false);
+      expect(isSelected(canvasElement, "charlie")).toBe(true);
+    });
+  },
+};
+
+function OpenOnClickBoard() {
+  const [opened, setOpened] = useState<string>("none");
+  return (
+    <DndCollections
+      initialGraph={mixedGraph()}
+      animateMoves={false}
+      clickSelection="toggle"
+      onOpenNode={(id: NodeId) => setOpened(id as string)}
+    >
+      <output data-testid="opened">{opened}</output>
+      <BoardCards />
+    </DndCollections>
+  );
+}
+
+export const ClickOpensCollections: Story = {
+  render: () => <OpenOnClickBoard />,
+  play: async ({ canvasElement }) => {
+    await waitForLayout(nodeCard(canvasElement, "scene"));
+    const user = userEvent.setup();
+    const opened = () =>
+      canvasElement.querySelector<HTMLElement>('[data-testid="opened"]')!.textContent;
+
+    // A plain pointer click on a collection card OPENS it — and does not
+    // select it.
+    await user.click(nodeCard(canvasElement, "scene"));
+    await waitFor(() => expect(opened()).toBe("scene"));
+    expect(isSelected(canvasElement, "scene")).toBe(false);
+
+    // A plain click on a media card selects (toggle mode) and never opens.
+    await user.click(nodeCard(canvasElement, "alpha"));
+    await waitFor(() => expect(isSelected(canvasElement, "alpha")).toBe(true));
+    expect(opened()).toBe("scene");
+
+    // Ctrl+click on the collection SELECTS it (how open-targets join a
+    // multi-drag) without opening.
+    await user.keyboard("{Control>}");
+    await user.click(nodeCard(canvasElement, "scene"));
+    await user.keyboard("{/Control}");
+    await waitFor(() => expect(isSelected(canvasElement, "scene")).toBe(true));
+    expect(opened()).toBe("scene");
+
+    // Keyboard activation (Space) keeps SELECTION semantics on a collection
+    // — keyboard users open through their own key, so Space must not drill.
+    await user.click(nodeCard(canvasElement, "alpha")); // reset: collapse to alpha
+    nodeCard(canvasElement, "scene").focus();
+    await user.keyboard(" ");
+    await waitFor(() => expect(isSelected(canvasElement, "scene")).toBe(true));
+    expect(opened()).toBe("scene");
+  },
+};
+
+const trimHandlesOf = (canvasElement: HTMLElement, id: string) =>
+  canvasElement
+    .querySelector(`[data-node-wrapper="${id}"]`)!
+    .querySelectorAll("[data-trim-handle]").length;
+
+export const SelectionGatedTrimHandles: Story = {
+  render: () => (
+    <DndCollections
+      initialGraph={mediaGraph()}
+      animateMoves={false}
+      clickSelection="toggle"
+      trimRequiresSelection
+    >
+      <BoardCards trimPixelsPerSecond={24} />
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    await waitForLayout(nodeCard(canvasElement, "alpha"));
+    const user = userEvent.setup();
+
+    // Unselected media cards have NO trim handles — their edges are plain
+    // card body.
+    expect(trimHandlesOf(canvasElement, "alpha")).toBe(0);
+    expect(trimHandlesOf(canvasElement, "bravo")).toBe(0);
+
+    // Selecting a card grows its handles (image: right edge only) — nobody
+    // else's.
+    await user.click(nodeCard(canvasElement, "alpha"));
+    await waitFor(() => expect(trimHandlesOf(canvasElement, "alpha")).toBe(1));
+    expect(trimHandlesOf(canvasElement, "bravo")).toBe(0);
+
+    // Toggling the selection off removes them again.
+    await user.click(nodeCard(canvasElement, "alpha"));
+    await waitFor(() => expect(trimHandlesOf(canvasElement, "alpha")).toBe(0));
+  },
+};

--- a/packages/ui/dnd-collections/index.ts
+++ b/packages/ui/dnd-collections/index.ts
@@ -100,6 +100,10 @@ export {
 } from "./react/collections-store";
 export { DndCollections, type DndCollectionsProps } from "./react/DndCollections";
 export {
+  type CollectionsClickSelection,
+  type CollectionsInteractionPolicy,
+} from "./react/interaction-policy";
+export {
   CollectionPanel,
   CollectionPanels,
   NodeCard,

--- a/packages/ui/dnd-collections/react/DndCollections.tsx
+++ b/packages/ui/dnd-collections/react/DndCollections.tsx
@@ -52,6 +52,11 @@ import {
   type CollectionsComponents,
 } from "./collections-components";
 import { CollectionsContainerContext } from "./container-context";
+import {
+  CollectionsInteractionPolicyContext,
+  useCollectionsInteractionPolicyValue,
+  type CollectionsClickSelection,
+} from "./interaction-policy";
 import { LiveTrimChannelContext, useCreateLiveTrimChannel } from "./live-trim";
 import { useFlipGraphAnimation } from "./use-flip-graph-animation";
 import { NodeCardGhost } from "./node-views";
@@ -91,6 +96,34 @@ export type DndCollectionsProps = Readonly<{
    * from one place. Components MUST be identity-stable (module scope).
    */
   components?: CollectionsComponents;
+  /**
+   * What a plain click on a card selects (see react/interaction-policy.ts):
+   * "replace" (default) selects only the clicked card; "toggle" toggles it —
+   * an unselected card becomes the sole selection, the sole-selected card
+   * deselects, a card in a multi-selection collapses the selection to
+   * itself. Ctrl/Cmd+click is an additive toggle in both modes.
+   */
+  clickSelection?: CollectionsClickSelection;
+  /**
+   * When set, a plain POINTER click on an open-target card (default:
+   * collections; override with `openOnClick`) OPENS it — drill-in
+   * navigation — instead of selecting. Ctrl/Cmd+click still
+   * selection-toggles it, and keyboard activation (Space) always selects,
+   * so the keyboard grammar is unchanged. Clicks only survive to this
+   * handler when no drag activated and no pan engaged — a press-and-hold
+   * grab released in place, a drag, or a swipe never opens.
+   */
+  onOpenNode?: (id: NodeId) => void;
+  /** Which nodes a plain click opens (only consulted when `onOpenNode` is
+   *  set). Default: `node.kind === "collection"`. */
+  openOnClick?: (id: NodeId, node: CollectionItemNode) => boolean;
+  /**
+   * Render media trim handles only on SELECTED cards, default `false`.
+   * Unselected card edges become plain card body (press = drag/click), and
+   * content's `trimEnabled` follows, so duration readouts gate with the
+   * handles.
+   */
+  trimRequiresSelection?: boolean;
   children: ReactNode;
 }>;
 
@@ -153,9 +186,19 @@ export function DndCollections({
   maxHistoryEntries,
   animateMoves = true,
   components,
+  clickSelection,
+  onOpenNode,
+  openOnClick,
+  trimRequiresSelection,
   children,
 }: DndCollectionsProps) {
   const componentsValue = useCollectionsComponentsValue(components);
+  const interactionPolicy = useCollectionsInteractionPolicyValue({
+    clickSelection,
+    onOpenNode,
+    openOnClick,
+    trimRequiresSelection,
+  });
   // Live trim values ride a ref-backed emitter (never the store): only
   // content that opted in via useLiveTrim re-renders per trim move.
   const liveTrimChannel = useCreateLiveTrimChannel();
@@ -187,9 +230,11 @@ export function DndCollections({
   return (
     <CollectionsStoreProvider value={store}>
       <CollectionsComponentsContext.Provider value={componentsValue}>
-        <LiveTrimChannelContext.Provider value={liveTrimChannel}>
-          <DndCollectionsContext animateMoves={animateMoves}>{children}</DndCollectionsContext>
-        </LiveTrimChannelContext.Provider>
+        <CollectionsInteractionPolicyContext.Provider value={interactionPolicy}>
+          <LiveTrimChannelContext.Provider value={liveTrimChannel}>
+            <DndCollectionsContext animateMoves={animateMoves}>{children}</DndCollectionsContext>
+          </LiveTrimChannelContext.Provider>
+        </CollectionsInteractionPolicyContext.Provider>
       </CollectionsComponentsContext.Provider>
     </CollectionsStoreProvider>
   );

--- a/packages/ui/dnd-collections/react/collection-item.tsx
+++ b/packages/ui/dnd-collections/react/collection-item.tsx
@@ -25,6 +25,10 @@ import { encodeDropTarget } from "../core/intents";
 import { finitePositiveOrUndefined } from "../core/numeric";
 import { useCollectionsSelector, useCollectionsStore } from "./collections-store";
 import { useCollectionsContainer } from "./container-context";
+import {
+  handleSelectionSurfaceClick,
+  useCollectionsInteractionPolicy,
+} from "./interaction-policy";
 import { NodeCardIndicators } from "./node-views";
 import { resolveTrim, useTrimPointerDrag, type TrimSide } from "./trim-gesture";
 
@@ -169,12 +173,21 @@ const Root = memo(function CollectionItemRoot({
     [setDraggableRef, setDroppableRef]
   );
 
+  const interactionPolicy = useCollectionsInteractionPolicy();
   const select = useCallback(
     (event: MouseEvent) => {
-      if (event.ctrlKey || event.metaKey) store.toggleSelected(id);
-      else store.setSelection([id]);
+      // Same click grammar as NodeCard — one policy for both shells.
+      const current = store.getSnapshot().graph.nodesById.get(id);
+      if (!current) return;
+      handleSelectionSurfaceClick({
+        event,
+        id,
+        node: current,
+        store,
+        policy: interactionPolicy,
+      });
     },
-    [store, id]
+    [store, id, interactionPolicy]
   );
 
   const dragSource = isDragging || isDragSource;
@@ -297,6 +310,7 @@ const TrimHandle = memo(function CollectionItemTrimHandle({
   className?: string;
 }) {
   const ctx = useCollectionItemContext("TrimHandle");
+  const interactionPolicy = useCollectionsInteractionPolicy();
   // Hooks run unconditionally; the render below bails for non-trimmable
   // configurations. The cast is safe: beginDrag is only reachable from a
   // rendered handle, which requires a media node.
@@ -317,7 +331,10 @@ const TrimHandle = memo(function CollectionItemTrimHandle({
   if (
     node.kind !== "media" ||
     trimScale === undefined ||
-    (side === "left" && node.mediaKind !== "video")
+    (side === "left" && node.mediaKind !== "video") ||
+    // Selection-gated trims: the handle (hit zone included) exists only on
+    // the selected item — same policy as NodeCard's stock handles.
+    (interactionPolicy.trimRequiresSelection && !ctx.selected)
   ) {
     return null;
   }

--- a/packages/ui/dnd-collections/react/interaction-policy.ts
+++ b/packages/ui/dnd-collections/react/interaction-policy.ts
@@ -1,0 +1,131 @@
+"use client";
+
+import { createContext, useContext, useMemo } from "react";
+
+import type { CollectionItemNode, NodeId } from "../core/graph";
+import type { CollectionsStore } from "./collections-store";
+
+// The plain-click interaction policy — what a REAL click on a card's
+// selection surface means. It exists because a click is only ever the
+// residue the gesture arbitration leaves behind: an activated drag
+// (distance, or a press-and-hold grab — even released without moving)
+// stops the trailing click at the document (dnd-kit's activation click
+// guard), and a surface pan squashes its own (use-pan-with-momentum). What
+// reaches the card's onClick is therefore a deliberate, stationary,
+// short-press CLICK — and this policy decides what it does.
+//
+// Configured at the provider, defaults preserving the classic behavior:
+//
+//   clickSelection "replace" (default): click selects only this card.
+//   clickSelection "toggle": click toggles — an unselected card becomes the
+//     sole selection, the sole-selected card deselects, a card inside a
+//     multi-selection collapses the selection to itself. (The model for
+//     selection-gated trim UIs: click shows the handles, click again hides
+//     them.)
+//
+//   onOpenNode + openOnClick: a plain POINTER click on an open-target
+//     (default: collections) OPENS it — drill-in navigation — instead of
+//     selecting. Ctrl/Cmd+click still selection-toggles it (which is also
+//     how open-target nodes join a multi-drag), and KEYBOARD activation
+//     (Space, event.detail === 0) always selects, so the keyboard grammar
+//     — Space selects, Enter grabs, the app's own key opens — is
+//     untouched.
+//
+//   trimRequiresSelection: trim handles exist ONLY on selected media cards.
+//     Unselected card edges are plain card body (press = drag/click), and
+//     content's `trimEnabled` follows, so readouts gate with the handles.
+
+export type CollectionsClickSelection = "replace" | "toggle";
+
+export type CollectionsInteractionPolicy = Readonly<{
+  clickSelection: CollectionsClickSelection;
+  onOpenNode?: (id: NodeId) => void;
+  openOnClick?: (id: NodeId, node: CollectionItemNode) => boolean;
+  trimRequiresSelection: boolean;
+}>;
+
+const DEFAULT_POLICY: CollectionsInteractionPolicy = {
+  clickSelection: "replace",
+  trimRequiresSelection: false,
+};
+
+export const CollectionsInteractionPolicyContext =
+  createContext<CollectionsInteractionPolicy>(DEFAULT_POLICY);
+
+export function useCollectionsInteractionPolicy(): CollectionsInteractionPolicy {
+  return useContext(CollectionsInteractionPolicyContext);
+}
+
+/** Normalizes the provider's policy props into a context value keyed on the
+ *  fields, so an unchanged policy never invalidates consumers. */
+export function useCollectionsInteractionPolicyValue(props: {
+  clickSelection?: CollectionsClickSelection;
+  onOpenNode?: (id: NodeId) => void;
+  openOnClick?: (id: NodeId, node: CollectionItemNode) => boolean;
+  trimRequiresSelection?: boolean;
+}): CollectionsInteractionPolicy {
+  const { clickSelection, onOpenNode, openOnClick, trimRequiresSelection } = props;
+  return useMemo<CollectionsInteractionPolicy>(() => {
+    if (
+      clickSelection === undefined &&
+      onOpenNode === undefined &&
+      openOnClick === undefined &&
+      trimRequiresSelection === undefined
+    ) {
+      return DEFAULT_POLICY;
+    }
+    return {
+      clickSelection: clickSelection ?? "replace",
+      onOpenNode,
+      openOnClick,
+      trimRequiresSelection: trimRequiresSelection ?? false,
+    };
+  }, [clickSelection, onOpenNode, openOnClick, trimRequiresSelection]);
+}
+
+/**
+ * The one click grammar both card shells share (NodeCard and
+ * CollectionItem.Root):
+ *
+ *   Ctrl/Cmd+click  → additive selection toggle, always.
+ *   pointer click   → open, when the policy marks this node an open target.
+ *   otherwise       → select, per `clickSelection`.
+ */
+export function handleSelectionSurfaceClick(args: {
+  event: Readonly<{ ctrlKey: boolean; metaKey: boolean; detail: number }>;
+  id: NodeId;
+  node: CollectionItemNode;
+  store: CollectionsStore;
+  policy: CollectionsInteractionPolicy;
+}): void {
+  const { event, id, node, store, policy } = args;
+
+  if (event.ctrlKey || event.metaKey) {
+    store.toggleSelected(id);
+    return;
+  }
+
+  // detail === 0 is keyboard activation (Space on the <button>): keyboard
+  // users select here and open through their own key, so only a real
+  // pointer click routes to open.
+  if (
+    event.detail > 0 &&
+    policy.onOpenNode !== undefined &&
+    (policy.openOnClick ? policy.openOnClick(id, node) : node.kind === "collection")
+  ) {
+    policy.onOpenNode(id);
+    return;
+  }
+
+  if (policy.clickSelection === "toggle") {
+    const selected = store.getSnapshot().interaction.selectedIds;
+    if (selected.has(id) && selected.size === 1) {
+      store.clearSelection();
+    } else {
+      store.setSelection([id]);
+    }
+    return;
+  }
+
+  store.setSelection([id]);
+}

--- a/packages/ui/dnd-collections/react/node-views.tsx
+++ b/packages/ui/dnd-collections/react/node-views.tsx
@@ -16,6 +16,10 @@ import {
 import { useCollectionsSelector, useCollectionsStore } from "./collections-store";
 import { useCollectionsContainer } from "./container-context";
 import { DefaultItemContent } from "./default-item-content";
+import {
+  handleSelectionSurfaceClick,
+  useCollectionsInteractionPolicy,
+} from "./interaction-policy";
 import { roundSecondsForDisplay } from "./duration-format";
 import { TrimHandles } from "./trim-handles";
 
@@ -236,17 +240,35 @@ export const NodeCard = memo(function NodeCard({
     [setDraggableRef, setDroppableRef]
   );
 
+  const interactionPolicy = useCollectionsInteractionPolicy();
   const handleClick = useCallback(
     (event: MouseEvent) => {
-      if (event.ctrlKey || event.metaKey) store.toggleSelected(id);
-      else store.setSelection([id]);
+      // The selector above returns null only for a removed node — in which
+      // case this card is unmounting and no click can arrive; the guard is
+      // for the type.
+      const current = store.getSnapshot().graph.nodesById.get(id);
+      if (!current) return;
+      handleSelectionSurfaceClick({
+        event,
+        id,
+        node: current,
+        store,
+        policy: interactionPolicy,
+      });
     },
-    [store, id]
+    [store, id, interactionPolicy]
   );
 
   if (!node) return null;
 
   const isCollection = node.kind === "collection";
+  // Selection-gated trims: with `trimRequiresSelection`, handles (and the
+  // content's trimEnabled flag) exist only on the selected card — an
+  // unselected card's edges are plain card body.
+  const trimActive =
+    trimScale !== undefined &&
+    node.kind === "media" &&
+    (!interactionPolicy.trimRequiresSelection || isSelected);
 
   return (
     <div className={twMerge("group relative", className)} data-node-wrapper={id}>
@@ -300,7 +322,7 @@ export const NodeCard = memo(function NodeCard({
           // activation and onDragStart publishing the store's drag set.
           isDragSource={isDragging || isDragSource}
           dragActivation={dragActivation}
-          trimEnabled={trimScale !== undefined && node.kind === "media"}
+          trimEnabled={trimActive}
         />
       </button>
 
@@ -325,7 +347,7 @@ export const NodeCard = memo(function NodeCard({
         </button>
       )}
 
-      {trimScale !== undefined && node.kind === "media" && (
+      {trimActive && trimScale !== undefined && node.kind === "media" && (
         <TrimHandles node={node} pixelsPerSecond={trimScale} selected={isSelected} />
       )}
 

--- a/packages/ui/dnd-collections/react/use-pan-with-momentum.ts
+++ b/packages/ui/dnd-collections/react/use-pan-with-momentum.ts
@@ -120,6 +120,19 @@ export function usePanWithMomentum(
         }
         if (Math.abs(position - downPosition) < slop) return;
         panning = true; // past the slop: this press is a pan, not a click
+        // Capture ONLY now that the press is a pan. Capturing at pointerdown
+        // retargets pointerup to the container, and the browser then fires
+        // the compatibility click at the container instead of the pressed
+        // card — silently eating every stationary card click on pannable
+        // surfaces. A stationary press must stay an untouched click; a real
+        // pan still gets capture so moves keep delivering outside the
+        // container. (Synthetic pointers can't be captured — listeners on
+        // window cover them.)
+        try {
+          el.setPointerCapture(event.pointerId);
+        } catch {
+          /* untrusted pointer — window listeners suffice */
+        }
       }
       scrollBy(lastPosition - position); // content follows the pointer
       lastPosition = position;
@@ -188,13 +201,8 @@ export function usePanWithMomentum(
       downPosition = pointerAxis(event);
       lastPosition = downPosition;
       samples = [{ t: performance.now(), p: downPosition }];
-      // Capture keeps real pointers delivering outside the container;
-      // synthetic pointers (tests) have no active pointer to capture.
-      try {
-        el.setPointerCapture(event.pointerId);
-      } catch {
-        /* untrusted pointer — window listeners below suffice */
-      }
+      // No capture here — see handleMove: capture waits until the press
+      // commits to panning, so a stationary press stays a real card click.
       window.addEventListener("pointermove", handleMove);
       window.addEventListener("pointerup", endPan);
       window.addEventListener("pointercancel", endPan);


### PR DESCRIPTION
… graph strips

Package (dnd-collections) - provider-level interaction policy (react/interaction-policy.ts), one shared click grammar for both card shells; defaults preserve existing consumer behavior:

- clickSelection "toggle": click toggles a card's selection (sole-selected deselects, a multi-selection member collapses to itself); Ctrl/Cmd+click stays the additive toggle.
- onOpenNode + openOnClick: a plain POINTER click on an open-target card (default collections) OPENS it instead of selecting. Keyboard Space always selects, so the keyboard grammar is untouched; Ctrl/Cmd+click still selects open-targets for multi-drag.
- trimRequiresSelection: trim handles (hit zones included, both shells, content trimEnabled too) exist only on SELECTED media cards.
- Click arbitration was already structural (dnd-kit stops the click after any activated drag, incl. a zero-move hold-grab; a pan squashes its own)
  - but the pan captured the pointer at pointerDOWN, retargeting pointerup to the container so the browser fired every compatibility click AT the container: stationary card clicks on hold-mode strips were silently eaten. The pan now captures only once a press actually becomes a pan.
- New ARCHITECTURE.md section, API.md props, InteractionPolicy.stories.tsx (3 play stories).

App (graph view) - the model wired in (toggle selection, selection-gated trims, click-to-drill incl. duplicate-reference cards via openNodeRef), double-click open removed, copy updated. Plus the native HTML5 drop seam (graph-native-drop.tsx) on the focused strip and every sub-timeline strip:

- Sidebar tool icons (collection / image / video) drop at the pointer position with an insertion indicator; the stale Timeline tool is gone. A dropped collection creates its empty child document in the SAME atomic batch as the parent update (gateway.seed: expected revision 0 = compare-and-set create), so drill-ins never 404 on a fresh collection.
- OS file drops, several at once: upload through the existing /api/timeline-media pipeline, land as ONE undoable commit and one persisted batch, with per-file failure reporting.
- Both paths are ordinary add-nodes dispatches: undo, the change feed, patch-scoped persistence, and the un-hydrated bounce all apply.
- pendingPaletteDetails generalized into graph-pending-details.ts (shared by the palette factory and the drop layer).

Tests: gateway seed unit test; e2e "interaction model" (trusted input: toggle + gated handles, hold-grab release changes nothing, click drills) and "native drops" (tool drops, parent+child atomicity witness, two-file drop as one write and one undo step). Vitest 74/74, graph-view e2e 12/12, dnd-collections stories 100/100, apps/web dnd-collections e2e 24/24, typecheck + lint clean.