### PR TITLE
feat: server-compiled playback manifest for full-depth preview (RSC P…

### DIFF
--- a/apps/timeline-gstudio001/app/api/timelines/[id]/preview-manifest/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/[id]/preview-manifest/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from "next/server";
+
+import { compilePlaybackManifest } from "@storyboard/timeline-domain";
+import { requireAuthUser } from "@/lib/firebase-auth-session";
+import { getFirebaseTimelineEntry } from "@/lib/firebase-timeline-store";
+import { loadTimelineClosure } from "@/lib/load-timeline-closure";
+import { checkUserScopedId, TimelineAccessDeniedError } from "@/lib/timeline-ownership";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function isValidTimelineId(id: string) {
+  return /^[a-zA-Z0-9_-]+$/.test(id);
+}
+
+/**
+ * The playback read model: this timeline's COMPLETE nested closure
+ * flattened into absolute-time media leaves (see
+ * timeline-domain/playback-manifest). Compiled from STORED documents — the
+ * preview no longer depends on how much of the graph the session hydrated,
+ * and duplicated clip ids across documents cannot break it. Unloadable
+ * children degrade that branch to silence and are reported in `missing`.
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { user, response } = await requireAuthUser();
+    if (response || !user) return response || NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const { id } = await params;
+    if (!isValidTimelineId(id)) {
+      return NextResponse.json({ error: "Invalid timeline id." }, { status: 400 });
+    }
+    if (checkUserScopedId(id, user.uid) === false) {
+      return NextResponse.json({ error: "Timeline was not found." }, { status: 404 });
+    }
+
+    const entry = await getFirebaseTimelineEntry(id, user.uid);
+    if (!entry) {
+      return NextResponse.json({ error: "Timeline was not found." }, { status: 404 });
+    }
+
+    const { documents, missing } = await loadTimelineClosure(id, user.uid);
+    // The root just loaded through the entry read; serve that version.
+    documents[id] = entry.document;
+
+    const manifest = compilePlaybackManifest(
+      documents,
+      id,
+      entry.revision,
+      new Date().toISOString(),
+    );
+    return NextResponse.json({ manifest, missing });
+  } catch (error) {
+    // Someone else's document: a plain not-found, so timeline ids can't be
+    // probed for existence.
+    if (error instanceof TimelineAccessDeniedError) {
+      return NextResponse.json({ error: "Timeline was not found." }, { status: 404 });
+    }
+    if (error instanceof Error && error.message.startsWith("Collection cycle detected")) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
+
+    const message =
+      error instanceof Error &&
+      (error.message.startsWith("Firebase Storage is not configured") ||
+        error.message.includes("timed out"))
+        ? error.message
+        : "Unable to compile the preview manifest.";
+
+    console.error("[GSTUDIO_TIMELINE_STORAGE_ERROR]", error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/apps/timeline-gstudio001/app/api/timelines/timelines-preview-manifest.test.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/timelines-preview-manifest.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PlaybackManifest } from "@storyboard/timeline-domain";
+import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
+
+// Preview-manifest tests over the REAL route handler, closure loader, and
+// store against the in-memory fake Firestore: the nested closure flattens
+// into leaves, unloadable branches (missing or another user's) degrade to
+// silence and are reported, foreign roots 404, and stored reference cycles
+// come back as an honest 409.
+
+type Stored = Record<string, unknown>;
+
+const state = vi.hoisted(() => {
+  const docs = new Map<string, Stored>();
+  const current = { user: { uid: "user-a", email: null as string | null, name: null, picture: null } };
+
+  const applySet = (id: string, data: Stored, opts?: { merge?: boolean }) => {
+    const existing = docs.get(id);
+    docs.set(id, opts?.merge && existing ? { ...existing, ...data } : { ...data });
+  };
+  const snapshot = (id: string) => {
+    const data = docs.get(id);
+    return {
+      id,
+      exists: data !== undefined,
+      data: () => (data ? { ...data } : undefined),
+      get: (field: string) => (data ? data[field] : undefined),
+    };
+  };
+  const docRef = (id: string) => ({
+    id,
+    get: async () => snapshot(id),
+    set: async (data: Stored, opts?: { merge?: boolean }) => applySet(id, data, opts),
+    delete: async () => {
+      docs.delete(id);
+    },
+  });
+  const db = {
+    collection: () => ({
+      doc: docRef,
+      where: (field: string, _op: string, value: unknown) => ({
+        limit: () => ({
+          get: async () => ({
+            docs: [...docs.keys()].filter((id) => docs.get(id)?.[field] === value).map(snapshot),
+          }),
+        }),
+      }),
+    }),
+    batch: () => {
+      const ops: (() => void)[] = [];
+      return {
+        set: (ref: { id: string }, data: Stored, opts?: { merge?: boolean }) => {
+          ops.push(() => applySet(ref.id, data, opts));
+        },
+        commit: async () => {
+          for (const op of ops) op();
+        },
+      };
+    },
+  };
+  return { docs, current, db };
+});
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/firebase-admin", () => ({
+  getFirebaseDb: () => state.db,
+}));
+vi.mock("firebase-admin/firestore", () => {
+  class Timestamp {
+    toDate() {
+      return new Date(0);
+    }
+  }
+  return { Timestamp, FieldValue: { serverTimestamp: () => new Timestamp() } };
+});
+vi.mock("@/lib/firebase-auth-session", () => ({
+  requireAuthUser: async () => ({ user: state.current.user, response: null }),
+}));
+vi.mock("@/lib/cloudinary-media-store", () => ({
+  listCloudinaryAssets: async () => [],
+}));
+
+import { GET as getPreviewManifest } from "./[id]/preview-manifest/route";
+
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+
+function image(id: string, startTime: number, duration: number): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "image",
+    src: `https://cdn.test/${id}.jpg`,
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime,
+    duration,
+    sourceDuration: duration,
+    trimIn: 0,
+    trimOut: 0,
+  };
+}
+
+function collectionClip(
+  id: string,
+  childTimelineId: string,
+  startTime: number,
+  duration: number,
+): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "collection",
+    title: id,
+    childTimelineId,
+    itemCount: 0,
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime,
+    duration,
+    sourceDuration: duration,
+    trimIn: 0,
+    trimOut: 0,
+  };
+}
+
+function seed(id: string, ownerUid: string, clips: TimelineClip[], revision = 1) {
+  const document: TimelineDocument = { id, title: id, clips };
+  state.docs.set(id, { id, title: id, document, clips, ownerUid, revision });
+}
+
+beforeEach(() => {
+  state.docs.clear();
+  state.current.user = { uid: "user-a", email: null, name: null, picture: null };
+});
+
+describe("preview manifest route", () => {
+  it("flattens the nested closure into absolute-time leaves with the root revision", async () => {
+    seed("scene", "user-a", [image("a", 0, 2), image("b", 2, 2)]);
+    seed(
+      "root-1",
+      "user-a",
+      [image("intro", 0, 4), collectionClip("scene-ref", "scene", 4, 4)],
+      9,
+    );
+
+    const response = await getPreviewManifest(new Request("http://test.local"), params("root-1"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { manifest: PlaybackManifest; missing: string[] };
+
+    expect(body.missing).toEqual([]);
+    expect(body.manifest.projectRevision).toBe(9);
+    expect(body.manifest.durationSeconds).toBe(8);
+    expect(body.manifest.leaves.map((leaf) => leaf.id)).toEqual(["intro", "a", "b"]);
+    expect(body.manifest.leaves[1].collectionPath).toEqual(["root-1", "scene"]);
+    expect(body.manifest.leaves[1].timelineStart).toBeCloseTo(4, 6);
+  });
+
+  it("degrades unloadable branches to silence and reports them", async () => {
+    // "ghost" doesn't exist; "theirs" belongs to another user — both branches
+    // must fall silent without failing the preview.
+    seed("theirs", "user-b", [image("x", 0, 4)]);
+    seed(
+      "root-1",
+      "user-a",
+      [
+        image("intro", 0, 2),
+        collectionClip("ghost-ref", "ghost", 2, 2),
+        collectionClip("theirs-ref", "theirs", 4, 2),
+      ],
+    );
+
+    const response = await getPreviewManifest(new Request("http://test.local"), params("root-1"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { manifest: PlaybackManifest; missing: string[] };
+
+    expect(body.manifest.leaves.map((leaf) => leaf.id)).toEqual(["intro"]);
+    expect([...body.missing].sort()).toEqual(["ghost", "theirs"]);
+  });
+
+  it("returns 404 for another user's root", async () => {
+    seed("root-b", "user-b", [image("x", 0, 4)]);
+    const response = await getPreviewManifest(new Request("http://test.local"), params("root-b"));
+    expect(response.status).toBe(404);
+  });
+
+  it("reports a stored reference cycle as 409", async () => {
+    seed("loop-a", "user-a", [collectionClip("to-b", "loop-b", 0, 2)]);
+    seed("loop-b", "user-a", [collectionClip("to-a", "loop-a", 0, 2)]);
+
+    const response = await getPreviewManifest(new Request("http://test.local"), params("loop-a"));
+    expect(response.status).toBe(409);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toMatch(/Collection cycle detected/);
+  });
+});

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -16,7 +16,12 @@ import {
   useCollectionsStore,
   type CollectionsGraph,
 } from "@storyboard/ui/dnd-collections";
-import { graphChildrenToClips, type DetailsById } from "@storyboard/timeline-domain";
+import {
+  graphChildrenToClips,
+  manifestToClips,
+  type DetailsById,
+  type PlaybackManifest,
+} from "@storyboard/timeline-domain";
 import { WorkbenchSplitPane } from "@storyboard/ui/timeline/viewport/workbench-display-surface";
 import {
   TimelineDocumentsProvider,
@@ -471,6 +476,67 @@ function GatewayDocumentsBridge() {
   return null;
 }
 
+// The stored manifest goes stale when a commit lands; refetch AFTER the
+// write path has settled it server-side (900ms debounce + batch flight).
+const MANIFEST_REFRESH_DELAY_MS = 2500;
+
+type ManifestClipsState = Readonly<{ clips: TimelineClip[]; forId: string }> | null;
+
+/**
+ * The server-compiled playback read model for the focused timeline: the
+ * COMPLETE nested closure flattened into media leaves (see
+ * timeline-domain/playback-manifest), so preview depth no longer depends on
+ * what the session hydrated. Null until it lands (or when it can't load) —
+ * the caller falls back to the live graph projection, which also covers the
+ * refresh window after local edits.
+ */
+function useManifestClips(enabled: boolean, focusedId: string): TimelineClip[] | null {
+  const store = useCollectionsStore();
+  const [state, setState] = useState<ManifestClipsState>(null);
+  const [staleAt, setStaleAt] = useState(0);
+
+  // Committed changes invalidate the stored manifest — coalesce into one
+  // delayed refetch so a burst of edits refreshes once, after persisting.
+  useEffect(() => {
+    if (!enabled) return;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const unsubscribe = store.subscribeToChanges(() => {
+      if (timer !== null) clearTimeout(timer);
+      timer = setTimeout(() => setStaleAt(Date.now()), MANIFEST_REFRESH_DELAY_MS);
+    });
+    return () => {
+      unsubscribe();
+      if (timer !== null) clearTimeout(timer);
+    };
+  }, [enabled, store]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await fetch(
+          `/api/timelines/${encodeURIComponent(focusedId)}/preview-manifest`,
+          { cache: "no-store" },
+        );
+        if (!response.ok) return; // projection fallback stands
+        const result = (await response.json().catch(() => null)) as {
+          manifest?: PlaybackManifest;
+        } | null;
+        if (cancelled || !result?.manifest) return;
+        setState({ clips: manifestToClips(result.manifest), forId: focusedId });
+      } catch {
+        /* projection fallback stands */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, focusedId, staleAt]);
+
+  return state !== null && state.forId === focusedId ? state.clips : null;
+}
+
 export function PreviewShell({
   enabled,
   focusedId,
@@ -489,10 +555,17 @@ export function PreviewShell({
     detailsStore.read,
     detailsStore.read,
   );
-  const clips = useMemo<TimelineClip[]>(
+  const projectionClips = useMemo<TimelineClip[]>(
     () => (enabled ? graphChildrenToClips(graph, details, focusedId) : []),
     [enabled, graph, details, focusedId],
   );
+  // The pane plays the manifest (full nested depth) once it lands; until
+  // then — and for ~2.5s after an edit while the stored documents catch up
+  // — the live focused-level projection plays. Same clock either way: the
+  // projection's collection-card durations come from read-time summaries,
+  // so both models agree on total time when the store is settled.
+  const manifestClips = useManifestClips(enabled, focusedId);
+  const clips = manifestClips ?? projectionClips;
   const [time, setTime] = useState(0);
 
   useEffect(() => channel.subscribe(() => setTime(channel.get())), [channel]);
@@ -525,6 +598,8 @@ export function PreviewShell({
   return (
     <TimelineDocumentsProvider initialState={initialDocumentsState}>
       <GatewayDocumentsBridge />
+      {/* Test/debug witness for which read model the pane is playing. */}
+      <span data-preview-source={manifestClips !== null ? "manifest" : "projection"} hidden />
       <WorkbenchSplitPane clips={clips} currentTime={time} onCurrentTimeChange={handleTimeChange}>
         {children}
       </WorkbenchSplitPane>

--- a/apps/timeline-gstudio001/lib/load-timeline-closure.ts
+++ b/apps/timeline-gstudio001/lib/load-timeline-closure.ts
@@ -1,0 +1,49 @@
+import "server-only";
+
+import type { TimelineDocument } from "@storyboard/timeline-model/types";
+
+import { getFirebaseTimelineDocument } from "./firebase-timeline-store";
+
+// The nested document closure for a timeline: the root plus every document
+// reachable through collection clips, breadth-first with a visited set (a
+// reference cycle in stored data terminates the WALK here; the manifest
+// compiler still refuses to flatten it). A child that fails to load —
+// missing, or another user's — is substituted with an EMPTY document and
+// reported, so a dangling reference degrades that branch to silence
+// instead of failing the whole preview.
+
+export async function loadTimelineClosure(
+  rootId: string,
+  requesterUid: string,
+): Promise<{ documents: Record<string, TimelineDocument>; missing: string[] }> {
+  const documents: Record<string, TimelineDocument> = {};
+  const missing: string[] = [];
+  const queue: string[] = [rootId];
+  const seen = new Set<string>([rootId]);
+
+  while (queue.length > 0) {
+    const id = queue.shift();
+    if (id === undefined) break;
+    const document = await getFirebaseTimelineDocument(id, requesterUid).catch(() => null);
+    if (!document) {
+      if (id !== rootId) {
+        missing.push(id);
+        documents[id] = { id, title: "", clips: [] };
+        continue;
+      }
+      // A missing ROOT is the caller's 404 to raise, not ours to hide.
+      documents[id] = { id, title: "", clips: [] };
+      missing.push(id);
+      continue;
+    }
+    documents[id] = document;
+    for (const clip of document.clips) {
+      if (clip.kind !== "collection" || !clip.childTimelineId) continue;
+      if (seen.has(clip.childTimelineId)) continue;
+      seen.add(clip.childTimelineId);
+      queue.push(clip.childTimelineId);
+    }
+  }
+
+  return { documents, missing };
+}

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -105,6 +105,56 @@ function buildFixtureDocuments(): Map<string, FixtureDocument> {
   ]);
 }
 
+/** Flatten the fixture closure the way the real preview-manifest route does
+ *  (fixtures are untrimmed, so every leaf plays at rate 1). */
+function compileFixtureManifest(
+  documents: Map<string, FixtureDocument>,
+  rootId: string,
+  revision: number,
+) {
+  const root = documents.get(rootId);
+  if (!root) return null;
+  type Leaf = Record<string, unknown>;
+  const leaves: Leaf[] = [];
+  const walk = (documentId: string, path: string[], offset: number) => {
+    const doc = documents.get(documentId);
+    if (!doc) return;
+    for (const clip of doc.clips) {
+      if (clip.kind === "collection") {
+        const childId = clip.childTimelineId as string;
+        walk(childId, [...path, childId], offset + (clip.startTime as number));
+        continue;
+      }
+      leaves.push({
+        id: clip.id,
+        collectionPath: path,
+        kind: clip.kind,
+        src: clip.src,
+        poster: clip.poster,
+        timelineStart: offset + (clip.startTime as number),
+        timelineDuration: clip.duration,
+        sourceStart: clip.trimIn ?? 0,
+        playbackRate: 1,
+      });
+    }
+  };
+  walk(rootId, [rootId], 0);
+  const durationSeconds = root.clips.reduce(
+    (duration, clip) =>
+      Math.max(duration, (clip.startTime as number) + (clip.duration as number)),
+    0,
+  );
+  return {
+    projectId: rootId,
+    projectRevision: revision,
+    durationSeconds,
+    leaves: leaves.sort(
+      (a, b) => (a.timelineStart as number) - (b.timelineStart as number),
+    ),
+    compiledAt: new Date().toISOString(),
+  };
+}
+
 // ── API mock ────────────────────────────────────────────────────────────────
 
 type RecordedPatch = { id: string; clipIds: string[] };
@@ -165,6 +215,18 @@ async function installGraphApi(
       },
     }),
   );
+
+  // Two-segment path, so the generic single-segment mock below never sees it.
+  await page.route("**/api/timelines/*/preview-manifest", (route) => {
+    const id = decodeURIComponent(
+      new URL(route.request().url()).pathname.split("/").at(-2) ?? "",
+    );
+    const manifest = compileFixtureManifest(documents, id, revisions.get(id) ?? 0);
+    if (!manifest) {
+      return route.fulfill({ status: 404, json: { error: "Timeline was not found." } });
+    }
+    return route.fulfill({ json: { manifest, missing: [] } });
+  });
 
   await page.route("**/api/timelines/*", async (route) => {
     const request = route.request();
@@ -520,6 +582,13 @@ test.describe("graph view E2E", () => {
     await expect.poll(() => stripOrder(page, CHILD_ID), { timeout: 15000 }).toEqual(["c1", "c2"]);
 
     await headerToggle(page, "Preview").click();
+
+    // The pane upgrades to the server-compiled full-depth manifest read
+    // model once it lands (until then the live projection plays).
+    await expect(page.locator("[data-preview-source]")).toHaveAttribute(
+      "data-preview-source",
+      "manifest",
+    );
 
     // Playhead visuals ride the strip's presentational overlay; the triangle
     // cap is a zero-size bordered div (attached, not "visible").

--- a/packages/timeline-domain/index.ts
+++ b/packages/timeline-domain/index.ts
@@ -16,3 +16,9 @@ export {
   type FocusedGraph,
   type HydrationSpecs,
 } from "./src/adapter";
+export {
+  compilePlaybackManifest,
+  manifestToClips,
+  type PlaybackLeaf,
+  type PlaybackManifest,
+} from "./src/playback-manifest";

--- a/packages/timeline-domain/src/playback-manifest.test.ts
+++ b/packages/timeline-domain/src/playback-manifest.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+
+import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
+
+import { compilePlaybackManifest, manifestToClips } from "./playback-manifest";
+
+function image(id: string, startTime: number, duration: number): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "image",
+    src: `https://cdn.test/${id}.jpg`,
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime,
+    duration,
+    sourceDuration: duration,
+    trimIn: 0,
+    trimOut: 0,
+  };
+}
+
+function video(
+  id: string,
+  startTime: number,
+  duration: number,
+  { sourceDuration = duration, trimIn = 0 }: { sourceDuration?: number; trimIn?: number } = {},
+): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "video",
+    src: `https://cdn.test/${id}.mp4`,
+    poster: `https://cdn.test/${id}.jpg`,
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime,
+    duration,
+    sourceDuration,
+    trimIn,
+    trimOut: Math.max(0, sourceDuration - trimIn - duration),
+  };
+}
+
+function collection(
+  id: string,
+  childTimelineId: string,
+  startTime: number,
+  duration: number,
+  { sourceDuration = duration, trimIn = 0 }: { sourceDuration?: number; trimIn?: number } = {},
+): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "collection",
+    title: id,
+    childTimelineId,
+    itemCount: 0,
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime,
+    duration,
+    sourceDuration,
+    trimIn,
+    trimOut: Math.max(0, sourceDuration - trimIn - duration),
+  };
+}
+
+function doc(id: string, clips: TimelineClip[]): TimelineDocument {
+  return { id, title: id, clips };
+}
+
+const AT = "2026-07-18T00:00:00.000Z";
+
+describe("compilePlaybackManifest", () => {
+  it("flattens a nested closure into ordered absolute-time media leaves", () => {
+    // root: [intro image 0-4][scene collection 4-10 -> scene doc][outro video 10-16]
+    // scene: [a image 0-2][b video 2-6]  (natural length 6 = collection span 6)
+    const documents = {
+      root: doc("root", [
+        image("intro", 0, 4),
+        collection("scene-ref", "scene", 4, 6),
+        video("outro", 10, 6),
+      ]),
+      scene: doc("scene", [image("a", 0, 2), video("b", 2, 4)]),
+    };
+
+    const manifest = compilePlaybackManifest(documents, "root", 7, AT);
+
+    expect(manifest.durationSeconds).toBe(16);
+    expect(manifest.projectRevision).toBe(7);
+    expect(manifest.leaves.map((leaf) => leaf.id)).toEqual(["intro", "a", "b", "outro"]);
+    const a = manifest.leaves[1];
+    expect(a.collectionPath).toEqual(["root", "scene"]);
+    expect(a.timelineStart).toBeCloseTo(4, 6); // scene starts at 4 in root time
+    expect(a.timelineDuration).toBeCloseTo(2, 6); // unscaled: span matches source
+    expect(a.playbackRate).toBeCloseTo(1, 6);
+    const b = manifest.leaves[2];
+    expect(b.timelineStart).toBeCloseTo(6, 6);
+    expect(b.sourceStart).toBe(0);
+  });
+
+  it("windows leaves under a trimmed collection clip (model invariant: rate 1)", () => {
+    // Stored clips keep trimIn + duration + trimOut === sourceDuration, so a
+    // trimmed collection shows a WINDOW of its source at rate 1: here the
+    // 8s scene trimmed to [2..4], displayed for 2s of root time.
+    const documents = {
+      root: doc("root", [
+        collection("scene-ref", "scene", 0, 2, { sourceDuration: 8, trimIn: 2 }),
+      ]),
+      scene: doc("scene", [image("a", 0, 4), image("b", 4, 4)]),
+    };
+
+    const manifest = compilePlaybackManifest(documents, "root", 1, AT);
+
+    // Only `a` overlaps the [2..4] window; `b` (4..8) is trimmed away.
+    expect(manifest.leaves.map((leaf) => leaf.id)).toEqual(["a"]);
+    const [a] = manifest.leaves;
+    expect(a.timelineStart).toBeCloseTo(0, 6);
+    expect(a.timelineDuration).toBeCloseTo(2, 6);
+    // `a` starts mid-source: 2s into its own 4s span.
+    expect(a.sourceStart).toBeCloseTo(2, 6);
+    expect(a.playbackRate).toBeCloseTo(1, 6);
+  });
+
+  it("time-scales leaves when a collection clip compresses its source range", () => {
+    // Not expressible through the editor today (the invariant keeps rate 1),
+    // but the stored model permits it — a 6s source window displayed in 2s
+    // must play its content at 3x.
+    const compressed: TimelineClip = {
+      id: "scene-ref",
+      index: 0,
+      kind: "collection",
+      title: "scene-ref",
+      childTimelineId: "scene",
+      itemCount: 0,
+      alt: "scene-ref",
+      aspect: 16 / 9,
+      trackIndex: 0,
+      startTime: 0,
+      duration: 2,
+      sourceDuration: 8,
+      trimIn: 2,
+      trimOut: 0, // window [2..8]: 6s of source in 2s of display
+    };
+    const documents = {
+      root: doc("root", [compressed]),
+      scene: doc("scene", [image("a", 0, 4), image("b", 4, 4)]),
+    };
+
+    const manifest = compilePlaybackManifest(documents, "root", 1, AT);
+
+    expect(manifest.leaves.map((leaf) => leaf.id)).toEqual(["a", "b"]);
+    const [a, b] = manifest.leaves;
+    // Window [2..8]: 2s of `a`, 4s of `b`, compressed 3x onto 2s.
+    expect(a.timelineDuration).toBeCloseTo(2 / 3, 6);
+    expect(b.timelineStart).toBeCloseTo(2 / 3, 6);
+    expect(b.timelineDuration).toBeCloseTo(4 / 3, 6);
+    expect(a.sourceStart).toBeCloseTo(2, 6);
+    expect(a.playbackRate).toBeCloseTo(3, 6);
+  });
+
+  it("fails loudly on a missing nested document", () => {
+    const documents = {
+      root: doc("root", [collection("ref", "ghost", 0, 3)]),
+    };
+    expect(() => compilePlaybackManifest(documents, "root", 1, AT)).toThrow(
+      'Missing nested timeline "ghost".',
+    );
+  });
+
+  it("fails loudly on a reference cycle", () => {
+    const documents = {
+      root: doc("root", [collection("ref-a", "a", 0, 3)]),
+      a: doc("a", [collection("ref-root", "root", 0, 3)]),
+    };
+    expect(() => compilePlaybackManifest(documents, "root", 1, AT)).toThrow(
+      /Collection cycle detected/,
+    );
+  });
+});
+
+describe("manifestToClips", () => {
+  it("maps leaves onto player clips with path-qualified ids and exact source windows", () => {
+    const documents = {
+      root: doc("root", [collection("scene-ref", "scene", 0, 2, { sourceDuration: 8, trimIn: 2 })]),
+      scene: doc("scene", [video("v", 0, 8)]),
+    };
+    const manifest = compilePlaybackManifest(documents, "root", 1, AT);
+    const clips = manifestToClips(manifest);
+
+    expect(clips).toHaveLength(1);
+    const clip = clips[0];
+    expect(clip.id).toBe("root/scene:v");
+    expect(clip.kind).toBe("video");
+    expect(clip.startTime).toBeCloseTo(0, 6);
+    expect(clip.duration).toBeCloseTo(2, 6);
+    // The player resolves source time as trimIn + progress * (sourceDuration
+    // - trimIn - trimOut): with trimOut 0 this must span exactly
+    // duration * playbackRate starting at sourceStart.
+    expect(clip.trimIn).toBeCloseTo(2, 6);
+    expect(clip.sourceDuration - clip.trimIn).toBeCloseTo(
+      manifest.leaves[0].timelineDuration * manifest.leaves[0].playbackRate,
+      6,
+    );
+  });
+});

--- a/packages/timeline-domain/src/playback-manifest.ts
+++ b/packages/timeline-domain/src/playback-manifest.ts
@@ -1,0 +1,205 @@
+// The playback read model: a timeline's COMPLETE nested document closure
+// flattened into absolute-time media leaves — what a full-depth preview
+// plays. Compiled from STORED documents (typically server-side, where the
+// closure is cheap to load), so playback depth no longer depends on how
+// much of the graph a session happens to have hydrated, and duplicated
+// clip ids across documents are a non-issue: leaves key on their
+// collection path, nothing enters the graph.
+//
+// The window math handles nested collection clips that are TRIMMED or
+// time-scaled in their parent: each recursion narrows the child's local
+// time window (trimIn + displayed progress across the source range) and
+// maps it onto the parent's output span, accumulating `playbackRate` so a
+// leaf knows both WHERE it plays (timelineStart/Duration in root time) and
+// WHAT it plays (sourceStart, advancing at playbackRate).
+
+import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
+
+export type PlaybackLeaf = Readonly<{
+  id: string;
+  collectionPath: readonly string[];
+  kind: "image" | "video";
+  src: string;
+  poster?: string;
+  timelineStart: number;
+  timelineDuration: number;
+  sourceStart: number;
+  playbackRate: number;
+}>;
+
+export type PlaybackManifest = Readonly<{
+  projectId: string;
+  projectRevision: number;
+  durationSeconds: number;
+  leaves: readonly PlaybackLeaf[];
+  compiledAt: string;
+}>;
+
+type DocumentMap = Readonly<Record<string, TimelineDocument>>;
+
+type TimeWindow = Readonly<{
+  localStart: number;
+  localEnd: number;
+  outputStart: number;
+  outputDuration: number;
+}>;
+
+function documentDuration(document: TimelineDocument): number {
+  return document.clips.reduce(
+    (duration, clip) => Math.max(duration, clip.startTime + clip.duration),
+    0,
+  );
+}
+
+function addMediaLeaf(
+  leaves: PlaybackLeaf[],
+  clip: Exclude<TimelineClip, { kind: "collection" }>,
+  path: readonly string[],
+  window: TimeWindow,
+  overlapStart: number,
+  overlapEnd: number,
+): void {
+  const localSpan = Math.max(0.001, window.localEnd - window.localStart);
+  const outputScale = window.outputDuration / localSpan;
+  const sourceRange = Math.max(0.001, clip.sourceDuration - clip.trimIn - clip.trimOut);
+  const clipProgress = clip.duration > 0 ? (overlapStart - clip.startTime) / clip.duration : 0;
+
+  leaves.push({
+    id: clip.id,
+    collectionPath: path,
+    kind: clip.kind,
+    src: clip.src,
+    ...(clip.poster === undefined ? {} : { poster: clip.poster }),
+    timelineStart: window.outputStart + (overlapStart - window.localStart) * outputScale,
+    timelineDuration: (overlapEnd - overlapStart) * outputScale,
+    sourceStart: clip.trimIn + clipProgress * sourceRange,
+    playbackRate: (sourceRange / Math.max(0.001, clip.duration)) / outputScale,
+  });
+}
+
+function flattenDocument(
+  documents: DocumentMap,
+  documentId: string,
+  path: readonly string[],
+  window: TimeWindow,
+  visited: ReadonlySet<string>,
+  leaves: PlaybackLeaf[],
+): void {
+  if (visited.has(documentId)) throw new Error(`Collection cycle detected at "${documentId}".`);
+  const document = documents[documentId];
+  if (!document) throw new Error(`Missing nested timeline "${documentId}".`);
+
+  const nextVisited = new Set(visited);
+  nextVisited.add(documentId);
+
+  for (const clip of document.clips) {
+    const clipEnd = clip.startTime + clip.duration;
+    const overlapStart = Math.max(clip.startTime, window.localStart);
+    const overlapEnd = Math.min(clipEnd, window.localEnd);
+    if (overlapEnd <= overlapStart) continue;
+
+    if (clip.kind !== "collection") {
+      addMediaLeaf(leaves, clip, path, window, overlapStart, overlapEnd);
+      continue;
+    }
+
+    const sourceRange = Math.max(0.001, clip.sourceDuration - clip.trimIn - clip.trimOut);
+    const displayedStartProgress =
+      clip.duration > 0 ? (overlapStart - clip.startTime) / clip.duration : 0;
+    const displayedEndProgress =
+      clip.duration > 0 ? (overlapEnd - clip.startTime) / clip.duration : 1;
+    const childStart = clip.trimIn + displayedStartProgress * sourceRange;
+    const childEnd = clip.trimIn + displayedEndProgress * sourceRange;
+    const parentScale =
+      window.outputDuration / Math.max(0.001, window.localEnd - window.localStart);
+
+    flattenDocument(
+      documents,
+      clip.childTimelineId,
+      [...path, clip.childTimelineId],
+      {
+        localStart: childStart,
+        localEnd: childEnd,
+        outputStart: window.outputStart + (overlapStart - window.localStart) * parentScale,
+        outputDuration: (overlapEnd - overlapStart) * parentScale,
+      },
+      nextVisited,
+      leaves,
+    );
+  }
+}
+
+export function compilePlaybackManifest(
+  documents: DocumentMap,
+  projectId: string,
+  projectRevision: number,
+  compiledAt: string,
+): PlaybackManifest {
+  const root = documents[projectId];
+  if (!root) throw new Error(`Unknown project timeline "${projectId}".`);
+  const durationSeconds = documentDuration(root);
+  const leaves: PlaybackLeaf[] = [];
+
+  flattenDocument(
+    documents,
+    projectId,
+    [projectId],
+    {
+      localStart: 0,
+      localEnd: Math.max(0.001, durationSeconds),
+      outputStart: 0,
+      outputDuration: durationSeconds,
+    },
+    new Set(),
+    leaves,
+  );
+
+  return {
+    projectId,
+    projectRevision,
+    durationSeconds,
+    leaves: leaves.sort((a, b) => a.timelineStart - b.timelineStart),
+    compiledAt,
+  };
+}
+
+/**
+ * Manifest leaves as synthetic TimelineClips for the workbench player. The
+ * player resolves a video's source time as
+ * `trimIn + progress * (sourceDuration - trimIn - trimOut)`, so a leaf maps
+ * losslessly: trimIn = sourceStart, trimOut = 0, and sourceDuration set so
+ * the remaining range spans exactly `timelineDuration * playbackRate`. Leaf
+ * ids can repeat across documents (duplicated references), so the clip id
+ * is path-qualified.
+ */
+export function manifestToClips(manifest: PlaybackManifest): TimelineClip[] {
+  return manifest.leaves.map((leaf, index) => {
+    const sourceRange = Math.max(0.001, leaf.timelineDuration * leaf.playbackRate);
+    const base = {
+      id: `${leaf.collectionPath.join("/")}:${leaf.id}`,
+      index,
+      alt: leaf.id,
+      aspect: 16 / 9,
+      trackIndex: 0,
+      startTime: leaf.timelineStart,
+      duration: leaf.timelineDuration,
+      sourceDuration: leaf.sourceStart + sourceRange,
+      trimIn: leaf.sourceStart,
+      trimOut: 0,
+    };
+    if (leaf.kind === "video") {
+      return {
+        ...base,
+        kind: "video",
+        src: leaf.src,
+        ...(leaf.poster === undefined ? {} : { poster: leaf.poster }),
+      };
+    }
+    return {
+      ...base,
+      kind: "image",
+      src: leaf.src,
+      ...(leaf.poster === undefined ? {} : { poster: leaf.poster }),
+    };
+  });
+}


### PR DESCRIPTION
…OC fold-in 1/4)

Ports the RSC POC's strongest piece into the main app: the preview now plays a server-compiled read model of the focused timeline's COMPLETE nested document closure, independent of what the session has hydrated.

- @storyboard/timeline-domain gains compilePlaybackManifest (recursive time-window flattening: trimmed collection clips narrow the child's source window onto the parent span, accumulating playbackRate; the stored model's trim invariant keeps editor content at rate 1, and the compression case is representable and tested) and manifestToClips, which maps leaves losslessly onto what the workbench player already consumes (trimIn = sourceStart, sourceDuration spans exactly duration * rate; ids path-qualified since leaves may repeat across documents).
- GET /api/timelines/[id]/preview-manifest: ownership-checked, built on a breadth-first closure loader where an unloadable child (missing, or another user's) degrades that branch to silence and is reported in `missing` instead of failing the preview; a stored reference cycle comes back as an honest 409.
- PreviewShell plays manifestClips when they land, falling back to the live focused-level projection immediately and for ~2.5s after each edit while the write settles (refetch coalesced off the store's change feed). A hidden data-preview-source marker witnesses which model is playing. Side effect: duplicate-clip-id hydration failures can no longer blank the preview - leaves never enter the graph.

Tests: 6 domain tests (windows, compression, missing-doc/cycle failures, player mapping), 4 route tests on the fake-Firestore harness, e2e preview test asserts the manifest upgrade against a fixture-flattening mock. App vitest 78/78, unit project 475/475, graph-view e2e 12/12, typecheck + lint clean.