### PR TITLE
fix: review-3 hardening - auth-bound gateway, full API validation, du…

### DIFF
--- a/apps/timeline-gstudio001/app/api/timelines/[id]/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/[id]/route.ts
@@ -11,6 +11,7 @@ import {
   decodeFolderPath,
   encodeFolderPath,
   getFolderPathFromTimelineId,
+  isStoredTimelineDocument,
   isUnsavedProjectPlaceholder,
 } from "@storyboard/timeline-model";
 // Demo-content seed for the GET fallback — deliberately still the UI
@@ -51,17 +52,6 @@ function storageErrorResponse(error: unknown, fallback: string) {
 
   console.error("[GSTUDIO_TIMELINE_STORAGE_ERROR]", error);
   return NextResponse.json({ error: message }, { status: 500 });
-}
-
-function isTimelineDocument(value: unknown): value is TimelineDocument {
-  if (!value || typeof value !== "object") return false;
-  const document = value as Partial<TimelineDocument>;
-
-  return (
-    typeof document.id === "string" &&
-    typeof document.title === "string" &&
-    Array.isArray(document.clips)
-  );
 }
 
 export async function GET(
@@ -279,7 +269,10 @@ export async function PATCH(
       document?: unknown;
     };
 
-    if (!isTimelineDocument(body.document) || body.document.id !== id) {
+    // Full runtime validation (every clip, discriminated by kind) — the
+    // same guard the batch endpoint uses; a malformed payload must never
+    // persist under a TimelineClip assertion.
+    if (!isStoredTimelineDocument(body.document) || body.document.id !== id) {
       return NextResponse.json({ error: "A valid timeline document is required." }, { status: 400 });
     }
 

--- a/apps/timeline-gstudio001/app/api/timelines/batch/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/batch/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 
-import type { TimelineDocument } from "@storyboard/timeline-model/types";
-import { isUnsavedProjectPlaceholder } from "@storyboard/timeline-model";
+import { isStoredTimelineDocument, isUnsavedProjectPlaceholder } from "@storyboard/timeline-model";
 import { requireAuthUser } from "@/lib/firebase-auth-session";
 import {
   saveFirebaseTimelineDocumentsAtomic,
@@ -20,17 +19,6 @@ const MAX_BATCH_WRITES = 25;
 
 function isValidTimelineId(id: string) {
   return /^[a-zA-Z0-9_-]+$/.test(id);
-}
-
-function isTimelineDocument(value: unknown): value is TimelineDocument {
-  if (!value || typeof value !== "object") return false;
-  const document = value as Partial<TimelineDocument>;
-
-  return (
-    typeof document.id === "string" &&
-    typeof document.title === "string" &&
-    Array.isArray(document.clips)
-  );
 }
 
 /**
@@ -63,7 +51,10 @@ export async function POST(request: Request) {
 
     const writes: TimelineBatchWrite[] = [];
     for (const write of body.writes) {
-      if (!isTimelineDocument(write.document)) {
+      // Full runtime validation (every clip, discriminated by kind): a
+      // malformed client payload must never persist under a TimelineClip
+      // assertion — it would break hydration and packing at read time.
+      if (!isStoredTimelineDocument(write.document)) {
         return NextResponse.json(
           { error: "Every batch write needs a valid timeline document." },
           { status: 400 },

--- a/apps/timeline-gstudio001/components/auth/auth-provider.tsx
+++ b/apps/timeline-gstudio001/components/auth/auth-provider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 
 export type AuthUser = {
   uid: string;
@@ -38,6 +39,7 @@ async function readAuthResponse(response: Response) {
 }
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
   const [user, setUser] = useState<AuthUser | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -80,12 +82,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       body: JSON.stringify({ email, oobCode }),
     });
     setUser(await readAuthResponse(response));
-  }, []);
+    // The RSC router cache was rendered with the PREVIOUS session (or none):
+    // server components must re-run with the new cookie, or stale payloads
+    // (another user's bootstrap) linger in the cache.
+    router.refresh();
+  }, [router]);
 
   const logout = useCallback(async () => {
     await fetch("/api/auth/logout", { method: "POST" });
     setUser(null);
-  }, []);
+    // Same reasoning as login: drop RSC output rendered under the old
+    // session so nothing authenticated survives in the router cache.
+    router.refresh();
+  }, [router]);
 
   const value = useMemo(
     () => ({ user, isLoading, sendSignInLink, completeSignInLink, logout, refreshUser }),

--- a/apps/timeline-gstudio001/components/graph-view/graph-gateway-primer.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-gateway-primer.tsx
@@ -21,7 +21,7 @@ export function GraphGatewayPrimer({
 }: Readonly<{ payloads: readonly GraphServerPayload[] }>) {
   useEffect(() => {
     for (const payload of payloads) {
-      graphDocumentsGateway.prime(payload.document, payload.revision);
+      graphDocumentsGateway.prime(payload.document, payload.revision, payload.forUid);
     }
   }, [payloads]);
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
@@ -9,6 +9,8 @@ import {
   type CollectionItemNode,
 } from "@storyboard/ui/dnd-collections";
 
+import type { ClipDetail } from "@storyboard/timeline-domain";
+
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 import { uploadTimelineMedia } from "@/lib/timeline-media-client";
 
@@ -262,29 +264,27 @@ export function NativeDropStrip({
       setUpload({ status: "uploading", count: media.length });
 
       try {
-        const results: readonly { node: CollectionItemNode | null; error: string | null }[] =
-          await Promise.all(
-            media.map(async (file) => {
+        type UploadResult = Readonly<{
+          node: CollectionItemNode | null;
+          detail: ClipDetail | null;
+          error: string | null;
+        }>;
+        const results: readonly UploadResult[] = await Promise.all(
+          media.map(async (file): Promise<UploadResult> => {
             const isVideo = file.type.startsWith("video/");
             const duration = await mediaFileDuration(file);
             let hosted: Awaited<ReturnType<typeof uploadTimelineMedia>>;
             try {
               hosted = await uploadTimelineMedia(file.name, file);
             } catch {
-              return { node: null, error: `"${file.name}" could not be uploaded.` };
+              return { node: null, detail: null, error: `"${file.name}" could not be uploaded.` };
             }
             if (isVideo && !hosted.thumbnailUrl) {
-              return { node: null, error: `"${file.name}" has no video thumbnail.` };
+              return { node: null, detail: null, error: `"${file.name}" has no video thumbnail.` };
             }
 
             const id = mintId(isVideo ? "video" : "image");
             if (isVideo) {
-              parkPendingDetail(id, {
-                alt: file.name,
-                aspect: 16 / 9,
-                trackIndex: 0,
-                poster: hosted.thumbnailUrl,
-              });
               const node: CollectionItemNode = {
                 id: parseNodeId(id),
                 kind: "media",
@@ -297,16 +297,12 @@ export function NativeDropStrip({
                 // Match the legacy drop: long videos start showing 12s.
                 trimOutSeconds: Math.max(0, duration - 12),
               };
-              return { node, error: null };
+              return {
+                node,
+                detail: { alt: file.name, aspect: 16 / 9, trackIndex: 0, poster: hosted.thumbnailUrl },
+                error: null,
+              };
             }
-            parkPendingDetail(id, {
-              alt: file.name,
-              aspect: 16 / 9,
-              trackIndex: 0,
-              sourceDuration: 4,
-              trimIn: 0,
-              trimOut: 0,
-            });
             const node: CollectionItemNode = {
               id: parseNodeId(id),
               kind: "media",
@@ -315,17 +311,34 @@ export function NativeDropStrip({
               src: hosted.url,
               durationSeconds: 4,
             };
-            return { node, error: null };
+            return {
+              node,
+              detail: { alt: file.name, aspect: 16 / 9, trackIndex: 0, sourceDuration: 4, trimIn: 0, trimOut: 0 },
+              error: null,
+            };
           }),
         );
 
         const failure = results.find((result) => result.error)?.error ?? null;
-        const nodes = results
-          .map((result) => result.node)
-          .filter((node): node is CollectionItemNode => node !== null);
-        // ONE dispatch for the whole file set: a multi-file drop is a single
-        // undoable step and a single persisted batch.
-        if (nodes.length > 0) addNodes(nodes, toIndex);
+        const landed = results.filter(
+          (result): result is UploadResult & { node: CollectionItemNode; detail: ClipDetail } =>
+            result.node !== null && result.detail !== null,
+        );
+        // Park and dispatch in the SAME synchronous tick: a concurrent
+        // palette drag clears every pending detail at drag start, so
+        // parking during the (async) uploads left a window where completed
+        // files lost their metadata before the commit could claim it.
+        if (landed.length > 0) {
+          for (const result of landed) {
+            parkPendingDetail(result.node.id as string, result.detail);
+          }
+          // ONE dispatch for the whole file set: a multi-file drop is a
+          // single undoable step and a single persisted batch.
+          addNodes(
+            landed.map((result) => result.node),
+            toIndex,
+          );
+        }
         setUpload(failure ? { status: "error", message: failure } : null);
       } catch {
         setUpload({ status: "error", message: "The dropped files could not be added." });

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -495,12 +495,15 @@ function useManifestClips(enabled: boolean, focusedId: string): TimelineClip[] |
   const [state, setState] = useState<ManifestClipsState>(null);
   const [staleAt, setStaleAt] = useState(0);
 
-  // Committed changes invalidate the stored manifest — coalesce into one
-  // delayed refetch so a burst of edits refreshes once, after persisting.
+  // A committed change makes the held manifest STALE — discard it
+  // immediately (the live projection is correct the instant the commit
+  // lands and takes over), then refetch once the writes have settled. A
+  // burst of edits coalesces into one delayed refetch.
   useEffect(() => {
     if (!enabled) return;
     let timer: ReturnType<typeof setTimeout> | null = null;
     const unsubscribe = store.subscribeToChanges(() => {
+      setState(null);
       if (timer !== null) clearTimeout(timer);
       timer = setTimeout(() => setStaleAt(Date.now()), MANIFEST_REFRESH_DELAY_MS);
     });
@@ -513,6 +516,7 @@ function useManifestClips(enabled: boolean, focusedId: string): TimelineClip[] |
   useEffect(() => {
     if (!enabled) return;
     let cancelled = false;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
     void (async () => {
       try {
         const response = await fetch(
@@ -524,6 +528,15 @@ function useManifestClips(enabled: boolean, focusedId: string): TimelineClip[] |
           manifest?: PlaybackManifest;
         } | null;
         if (cancelled || !result?.manifest) return;
+        // Install guard: a manifest compiled BEFORE this session's latest
+        // accepted write (its revision trails the compare-and-set ledger)
+        // is pre-write server state — never install it over the live
+        // projection; poll again once the write has landed server-side.
+        const ledger = graphDocumentsGateway.revisionOf(focusedId);
+        if (ledger !== undefined && result.manifest.projectRevision < ledger) {
+          retryTimer = setTimeout(() => setStaleAt(Date.now()), MANIFEST_REFRESH_DELAY_MS);
+          return;
+        }
         setState({ clips: manifestToClips(result.manifest), forId: focusedId });
       } catch {
         /* projection fallback stands */
@@ -531,6 +544,7 @@ function useManifestClips(enabled: boolean, focusedId: string): TimelineClip[] |
     })();
     return () => {
       cancelled = true;
+      if (retryTimer !== null) clearTimeout(retryTimer);
     };
   }, [enabled, focusedId, staleAt]);
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -105,16 +105,23 @@ export function GraphTimelineView({
   const { user } = useAuth();
   const trashDocumentId = user ? `trash-${user.uid}` : null;
 
-  // RSC payloads prime the gateway on EVERY layout render (each navigation
-  // re-serves fresh boot documents server-side — a free freshness signal).
-  // Priming is guarded inside the gateway: never over local edits, never
-  // regressing the revision ledger. Declared BEFORE the boot effect so a
-  // first-render bootstrap is in the cache when boot runs.
+  // AUTH BINDING first: the gateway is a module singleton that outlives
+  // soft logout/login, so a different signed-in user must reset it before
+  // anything reads or primes. Declared before the prime and boot effects
+  // so mount-order runs bind → prime → boot.
+  useEffect(() => {
+    if (user) graphDocumentsGateway.bindUser(user.uid);
+  }, [user]);
+
+  // RSC payloads prime the gateway (guarded inside it: only for the bound
+  // user, never over local edits, never regressing the revision ledger).
+  // `user` is a dep so payloads that arrived before the client-side auth
+  // resolved get re-applied once the binding exists.
   useEffect(() => {
     for (const payload of bootstrap ?? []) {
-      graphDocumentsGateway.prime(payload.document, payload.revision);
+      graphDocumentsGateway.prime(payload.document, payload.revision, payload.forUid);
     }
-  }, [bootstrap]);
+  }, [bootstrap, user]);
   // Whether THIS mount booted from server payloads — captured once: the
   // boot effect must not re-run when later layout renders replace the
   // bootstrap array's identity.

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
@@ -366,8 +366,9 @@ describe("graph-documents-gateway", () => {
       call.method === "POST" ? okResults(call.writes) : jsonResponse({}, 500),
     );
     const gateway = createGraphDocumentsGateway();
+    gateway.bindUser("user-a");
 
-    gateway.prime(doc("a", [clip("server-1")]), 7);
+    gateway.prime(doc("a", [clip("server-1")]), 7, "user-a");
     // Served straight from cache — no GET.
     expect(clipIds(await gateway.ensure("a"))).toEqual(["server-1"]);
     expect(getsOf(calls)).toHaveLength(0);
@@ -384,16 +385,17 @@ describe("graph-documents-gateway", () => {
         : jsonResponse({ document: doc("a", [clip("a1")]), revision: 5 }),
     );
     const gateway = createGraphDocumentsGateway();
+    gateway.bindUser("user-a");
     await gateway.ensure("a");
 
     // Older server read: the ledger (5) wins.
-    gateway.prime(doc("a", [clip("older")]), 3);
+    gateway.prime(doc("a", [clip("older")]), 3, "user-a");
     expect(clipIds(gateway.peek("a"))).toEqual(["a1"]);
 
     // A dirty document is a local edit in flight to the server — a fresh
     // server read must not clobber it.
     gateway.writeClips("a", [clip("local")]);
-    gateway.prime(doc("a", [clip("newer")]), 9);
+    gateway.prime(doc("a", [clip("newer")]), 9, "user-a");
     expect(clipIds(gateway.peek("a"))).toEqual(["local"]);
 
     // Same-revision confirm on a clean cache: the cached content (which IS
@@ -401,9 +403,14 @@ describe("graph-documents-gateway", () => {
     // clears, and no refetch happens.
     await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS); // flush the write → revision 6
     gateway.refresh(); // marks stale
-    gateway.prime(doc("a", [clip("server-echo")]), 6);
+    gateway.prime(doc("a", [clip("server-echo")]), 6, "user-a");
     expect(clipIds(await gateway.ensure("a"))).toEqual(["local"]);
     expect(getsOf(calls)).toHaveLength(1); // only the original seed GET
+
+    // A payload served for ANYONE ELSE is refused outright.
+    gateway.refresh();
+    gateway.prime(doc("a", [clip("foreign")]), 20, "user-b");
+    expect(clipIds(gateway.peek("a"))).toEqual(["local"]);
   });
 
   it("ensure waits for a declared-incoming prime instead of fetching", async () => {
@@ -413,13 +420,14 @@ describe("graph-documents-gateway", () => {
         : jsonResponse({ document: doc("a", [clip("fetched")]), revision: 1 }),
     );
     const gateway = createGraphDocumentsGateway();
+    gateway.bindUser("user-a");
 
     gateway.expectPrimes(["a"]);
     const pending = gateway.ensure("a");
     await vi.advanceTimersByTimeAsync(0);
     expect(getsOf(calls)).toHaveLength(0); // waiting, not fetching
 
-    gateway.prime(doc("a", [clip("primed")]), 4);
+    gateway.prime(doc("a", [clip("primed")]), 4, "user-a");
     expect(clipIds(await pending)).toEqual(["primed"]);
     expect(getsOf(calls)).toHaveLength(0); // the prime won — no fetch at all
 

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
@@ -26,16 +26,23 @@ import type { DocumentsById } from "@storyboard/timeline-domain";
 //     re-persists their intent against the fresh revision.
 
 const SAVE_DEBOUNCE_MS = 900;
+// Retry cadence for writes that failed for non-conflict reasons — slower
+// than the edit debounce so a struggling server isn't hammered.
+const SAVE_RETRY_MS = 5000;
 // How long an ensure waits for a declared-incoming RSC prime before
 // fetching itself — roughly a streamed payload's round trip.
 const PRIME_WAIT_MS = 1000;
 
 /** A server-read document + revision, delivered by RSC (layout bootstrap /
  *  focus-path streams) and fed to `prime`. Defined HERE (client-safe) so
- *  the server-only loader module and the client share one shape. */
+ *  the server-only loader module and the client share one shape. `forUid`
+ *  stamps WHO the server read it for: `prime` refuses payloads for anyone
+ *  but the bound user, so a stale RSC prop (router cache across an auth
+ *  transition) can never seed another user's session. */
 export type GraphServerPayload = Readonly<{
   document: TimelineDocument;
   revision: number;
+  forUid: string;
 }>;
 
 export type GraphDocumentsGateway = Readonly<{
@@ -70,7 +77,7 @@ export type GraphDocumentsGateway = Readonly<{
    * flight) and never regressing the revision ledger; a skipped prime just
    * leaves the existing fetch paths to do their job.
    */
-  prime: (document: TimelineDocument, revision: number) => void;
+  prime: (document: TimelineDocument, revision: number, forUid: string) => void;
   /**
    * Declare that primes for these ids are INCOMING (the server is streaming
    * this navigation's payloads): an `ensure` for a missing/stale id waits a
@@ -81,6 +88,17 @@ export type GraphDocumentsGateway = Readonly<{
    * KNOWN to be server-primed, or every miss pays the window for nothing.
    */
   expectPrimes: (ids: readonly string[], windowMs?: number) => void;
+  /**
+   * Bind this cache to an authenticated user. The FIRST bind (or a re-bind
+   * to the same uid) is free; binding a DIFFERENT uid resets everything —
+   * documents, revisions, dirty state, errors, in-flight work — because the
+   * module singleton outlives soft logout/login, and the next user must
+   * never read the previous user's documents from memory. Call before any
+   * prime/ensure in an authenticated session.
+   */
+  bindUser: (uid: string) => void;
+  /** The compare-and-set ledger's revision for a document, if known. */
+  revisionOf: (timelineId: string) => number | undefined;
   /** Cache-change notifications (documents landing, clips written). */
   subscribe: (listener: () => void) => () => void;
   /** Outstanding load/save failures, for a status banner. Null when every
@@ -134,14 +152,48 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
   // in-flight batch could reach the server after a newer one and win.
   let saveInFlight: Promise<void> | null = null;
   let saveQueued = false;
+  // A queued trailing batch remembers whether any flush that requested it
+  // needed keepalive (pagehide) — dropping that bit would send the trailing
+  // batch as an ordinary fetch during page teardown.
+  let saveQueuedKeepalive = false;
   // Ids whose cached content predates the current graph session (see
   // `refresh`) or lost a revision conflict: readable, but `ensure`
   // refetches them.
   let staleIds = new Set<string>();
   const listeners = new Set<() => void>();
 
+  // The AUTH BOUNDARY: which user's documents this cache holds. The module
+  // singleton outlives soft logout/login, so binding a DIFFERENT uid must
+  // reset everything — otherwise the next user reads the previous user's
+  // documents straight from memory, bypassing every server-side ownership
+  // check. `generation` invalidates async work that started before a
+  // reset: a late fetch or batch response from the previous user's session
+  // must not repopulate the new one.
+  let boundUid: string | null = null;
+  let generation = 0;
+
   const notify = () => {
     for (const listener of listeners) listener();
+  };
+
+  const reset = () => {
+    generation += 1;
+    documents = {};
+    revisions.clear();
+    errors.clear();
+    errorBanner = null;
+    inflight.clear();
+    dirtyIds.clear();
+    if (saveTimer !== null) {
+      clearTimeout(saveTimer);
+      saveTimer = null;
+    }
+    saveInFlight = null;
+    saveQueued = false;
+    saveQueuedKeepalive = false;
+    staleIds = new Set();
+    expectedPrimes.clear();
+    notify();
   };
 
   const setError = (timelineId: string, next: string | null) => {
@@ -156,12 +208,17 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
   };
 
   const fetchDocument = async (timelineId: string): Promise<TimelineDocument | null> => {
+    const gen = generation;
     try {
       const response = await fetch(`/api/timelines/${encodeURIComponent(timelineId)}`, {
         cache: "no-store",
       });
+      // A reset (auth rebind) happened while this was in flight: the
+      // response belongs to the previous session and must not land.
+      if (gen !== generation) return null;
       if (!response.ok) {
         const result = (await response.json().catch(() => ({}))) as { error?: string };
+        if (gen !== generation) return null;
         setError(
           timelineId,
           result.error || `Timeline "${timelineId}" failed to load (${response.status}).`,
@@ -172,6 +229,7 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
         document?: TimelineDocument;
         revision?: number;
       };
+      if (gen !== generation) return null;
       if (!result.document || result.document.id !== timelineId) {
         setError(timelineId, `Timeline "${timelineId}" returned an unexpected document.`);
         return null;
@@ -188,6 +246,7 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
       notify();
       return result.document;
     } catch (cause) {
+      if (gen !== generation) return null;
       setError(
         timelineId,
         cause instanceof Error ? cause.message : `Timeline "${timelineId}" failed to load.`,
@@ -250,17 +309,21 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
     return request;
   };
 
-  const scheduleFlush = () => {
+  const scheduleFlush = (delayMs: number = SAVE_DEBOUNCE_MS) => {
     if (saveTimer !== null) clearTimeout(saveTimer);
     saveTimer = setTimeout(() => {
       saveTimer = null;
       persistBatch();
-    }, SAVE_DEBOUNCE_MS);
+    }, delayMs);
   };
 
   const persistBatch = (options?: { keepalive?: boolean }) => {
     if (saveInFlight !== null) {
       saveQueued = true;
+      // The trailing batch must keep the strongest delivery requirement any
+      // caller asked for — a pagehide flush queued behind a running save
+      // still needs keepalive or the browser may kill it on teardown.
+      if (options?.keepalive) saveQueuedKeepalive = true;
       return;
     }
     if (dirtyIds.size === 0) return;
@@ -277,13 +340,19 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
     dirtyIds.clear();
     if (writes.length === 0) return;
 
+    const gen = generation;
     const settle = () => {
+      // A reset (auth rebind) happened mid-flight: this batch belongs to
+      // the previous session — don't touch the new one's state.
+      if (gen !== generation) return;
       saveInFlight = null;
       // Trailing batch: edits that landed mid-flight go out now, from the
-      // latest cache.
+      // latest cache — carrying a queued keepalive requirement forward.
       if (saveQueued) {
         saveQueued = false;
-        persistBatch();
+        const keepalive = saveQueuedKeepalive;
+        saveQueuedKeepalive = false;
+        persistBatch(keepalive ? { keepalive: true } : undefined);
       }
     };
 
@@ -297,10 +366,12 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
     })
       .then(
         async (response) => {
+          if (gen !== generation) return;
           if (response.ok) {
             const result = (await response.json().catch(() => ({}))) as {
               results?: { id: string; revision: number }[];
             };
+            if (gen !== generation) return;
             for (const write of writes) setError(write.document.id, null);
             for (const entry of result.results ?? []) {
               if (typeof entry.revision === "number") revisions.set(entry.id, entry.revision);
@@ -311,6 +382,7 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
             error?: string;
             conflicts?: { id: string; actualRevision: number }[];
           };
+          if (gen !== generation) return;
           const conflictIds = new Set((result.conflicts ?? []).map((entry) => entry.id));
           if (response.status === 409 && conflictIds.size > 0) {
             // Compare-and-set lost: someone else wrote these documents since
@@ -343,20 +415,31 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
             if (dirtyIds.size > 0) scheduleFlush();
             return;
           }
+          // Non-conflict failure (5xx, 400…): surface it AND re-queue —
+          // clearing dirtyIds before the request must not permanently drop
+          // the change when the server balks. The slower retry cadence
+          // keeps a struggling server from being hammered, and re-dirtied
+          // ids ride any later unload flush.
           for (const write of writes) {
             setError(
               write.document.id,
               result.error ?? `Saving "${write.document.title}" failed (${response.status}).`,
             );
+            dirtyIds.add(write.document.id);
           }
+          scheduleFlush(SAVE_RETRY_MS);
         },
         (cause: unknown) => {
+          if (gen !== generation) return;
+          // Network failure: same re-queue + slow retry as above.
           for (const write of writes) {
             setError(
               write.document.id,
               cause instanceof Error ? cause.message : `Saving "${write.document.title}" failed.`,
             );
+            dirtyIds.add(write.document.id);
           }
+          scheduleFlush(SAVE_RETRY_MS);
         },
       )
       .then(settle, settle);
@@ -403,8 +486,13 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
       revisions.set(document.id, 0);
       notify();
     },
-    prime: (document, revision) => {
+    prime: (document, revision, forUid) => {
       const timelineId = document.id;
+      // Auth guard: a payload served for anyone but the BOUND user is
+      // refused — a stale RSC prop surviving an auth transition (router
+      // cache) must never seed another user's session. Unbound = refuse
+      // too; the caller re-primes after binding.
+      if (boundUid === null || forUid !== boundUid) return;
       // Local edits win: a dirty document (or any batch mid-flight, whose
       // write set isn't inspectable here) must not be replaced by a server
       // read that predates it.
@@ -430,6 +518,13 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
         expectedPrimes.set(id, deadline);
       }
     },
+    bindUser: (uid) => {
+      if (boundUid === uid) return;
+      const hadUser = boundUid !== null;
+      boundUid = uid;
+      if (hadUser) reset();
+    },
+    revisionOf: (timelineId) => revisions.get(timelineId),
     subscribe: (listener) => {
       listeners.add(listener);
       return () => {

--- a/apps/timeline-gstudio001/lib/graph-rsc-payloads.ts
+++ b/apps/timeline-gstudio001/lib/graph-rsc-payloads.ts
@@ -32,7 +32,12 @@ export async function loadGraphBootstrapPayloads(
     const project = await serveTimelineDocument(projectId, requesterUid);
     if (!project) return null;
     const trash = await serveTrashDocument(`trash-${requesterUid}`, requesterUid);
-    return [project, trash];
+    // forUid lets the client's prime refuse payloads that survive an auth
+    // transition in the router cache.
+    return [
+      { ...project, forUid: requesterUid },
+      { ...trash, forUid: requesterUid },
+    ];
   } catch {
     return null;
   }
@@ -63,8 +68,10 @@ export async function loadFocusPathPayloads(
     seen.add(id);
     try {
       const served = await serveTimelineDocument(id, requesterUid);
-      if (served) payloads.push(served);
-      return served;
+      if (!served) return null;
+      const payload: GraphServerPayload = { ...served, forUid: requesterUid };
+      payloads.push(payload);
+      return payload;
     } catch {
       return null;
     }

--- a/packages/timeline-model/index.ts
+++ b/packages/timeline-model/index.ts
@@ -1,3 +1,4 @@
 export * from "./types";
 export * from "./constants";
 export * from "./documents";
+export * from "./validate";

--- a/packages/timeline-model/validate.test.ts
+++ b/packages/timeline-model/validate.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import { isStoredTimelineDocument, isTimelineClip } from "./validate";
+
+const image = {
+  id: "img-1",
+  index: 0,
+  kind: "image",
+  src: "https://cdn.test/img.jpg",
+  alt: "img",
+  aspect: 16 / 9,
+  trackIndex: 0,
+  startTime: 0,
+  duration: 4,
+  sourceDuration: 4,
+  trimIn: 0,
+  trimOut: 0,
+};
+
+const video = {
+  ...image,
+  id: "vid-1",
+  kind: "video",
+  src: "https://cdn.test/vid.mp4",
+  poster: "https://cdn.test/vid.jpg",
+  sourceDuration: 10,
+  trimOut: 6,
+};
+
+const collection = {
+  id: "col-1",
+  index: 1,
+  kind: "collection",
+  title: "Scene",
+  childTimelineId: "timeline-1",
+  itemCount: 3,
+  previewItems: [
+    { id: "p1", kind: "image", src: "https://cdn.test/p1.jpg", alt: "p1" },
+  ],
+  alt: "Scene collection",
+  aspect: 16 / 9,
+  trackIndex: 0,
+  startTime: 4.12,
+  duration: 3,
+  sourceDuration: 3,
+  trimIn: 0,
+  trimOut: 0,
+};
+
+describe("isTimelineClip", () => {
+  it("accepts every stored clip kind", () => {
+    expect(isTimelineClip(image)).toBe(true);
+    expect(isTimelineClip(video)).toBe(true);
+    expect(isTimelineClip(collection)).toBe(true);
+  });
+
+  it("tolerates null optionals (Firestore round-trips produce them)", () => {
+    expect(isTimelineClip({ ...video, poster: null })).toBe(true);
+    expect(isTimelineClip({ ...collection, previewItems: null })).toBe(true);
+    expect(isTimelineClip({ ...image, playbackStartTime: null })).toBe(true);
+  });
+
+  it("rejects the shapes the shallow guard let through", () => {
+    expect(isTimelineClip({ ...image, kind: "gif" })).toBe(false); // unknown kind
+    expect(isTimelineClip({ ...image, src: undefined })).toBe(false); // media without src
+    expect(isTimelineClip({ ...image, duration: Number.NaN })).toBe(false); // NaN poisons packing
+    expect(isTimelineClip({ ...image, startTime: Number.POSITIVE_INFINITY })).toBe(false);
+    expect(isTimelineClip({ ...image, id: "" })).toBe(false);
+    expect(isTimelineClip({ ...collection, childTimelineId: "" })).toBe(false);
+    expect(isTimelineClip({ ...collection, itemCount: "3" })).toBe(false);
+    expect(isTimelineClip({ ...collection, previewItems: [{ id: 1 }] })).toBe(false);
+    expect(isTimelineClip("not a clip")).toBe(false);
+    expect(isTimelineClip(null)).toBe(false);
+  });
+});
+
+describe("isStoredTimelineDocument", () => {
+  it("accepts a document whose every clip validates", () => {
+    expect(
+      isStoredTimelineDocument({ id: "doc", title: "Doc", clips: [image, video, collection] }),
+    ).toBe(true);
+    expect(isStoredTimelineDocument({ id: "doc", title: "", clips: [] })).toBe(true);
+    expect(
+      isStoredTimelineDocument({ id: "doc", title: "Doc", description: null, clips: [] }),
+    ).toBe(true);
+  });
+
+  it("rejects a document containing ONE malformed clip", () => {
+    expect(
+      isStoredTimelineDocument({
+        id: "doc",
+        title: "Doc",
+        clips: [image, { ...video, duration: "6" }],
+      }),
+    ).toBe(false);
+    expect(isStoredTimelineDocument({ id: "doc", title: "Doc", clips: "nope" })).toBe(false);
+    expect(isStoredTimelineDocument({ id: "", title: "Doc", clips: [] })).toBe(false);
+  });
+});

--- a/packages/timeline-model/validate.ts
+++ b/packages/timeline-model/validate.ts
@@ -1,0 +1,87 @@
+// Runtime validation of the stored model at API boundaries. The shallow
+// checks the routes used before (id/title strings, clips is SOME array)
+// let a malformed client persist arbitrary values under a TimelineClip
+// assertion — which then broke graph hydration and packing math at read
+// time. These guards mirror the types exactly, with one deliberate
+// leniency: OPTIONAL fields tolerate null as well as undefined (Firestore
+// round-trips and legacy writers produce nulls), while every REQUIRED
+// numeric must be a finite number (NaN/Infinity poison packing).
+
+import type { TimelineClip, TimelineDocument } from "./types";
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isOptionalString(value: unknown): boolean {
+  return value == null || typeof value === "string";
+}
+
+function isOptionalFiniteNumber(value: unknown): boolean {
+  return value == null || isFiniteNumber(value);
+}
+
+function hasClipBase(clip: Record<string, unknown>): boolean {
+  return (
+    typeof clip.id === "string" &&
+    clip.id.length > 0 &&
+    isFiniteNumber(clip.index) &&
+    typeof clip.alt === "string" &&
+    isFiniteNumber(clip.aspect) &&
+    isFiniteNumber(clip.trackIndex) &&
+    isFiniteNumber(clip.startTime) &&
+    isFiniteNumber(clip.duration) &&
+    isFiniteNumber(clip.sourceDuration) &&
+    isFiniteNumber(clip.trimIn) &&
+    isFiniteNumber(clip.trimOut) &&
+    isOptionalFiniteNumber(clip.playbackStartTime) &&
+    isOptionalFiniteNumber(clip.playbackDuration)
+  );
+}
+
+export function isTimelineClip(value: unknown): value is TimelineClip {
+  if (!value || typeof value !== "object") return false;
+  const clip = value as Record<string, unknown>;
+  if (!hasClipBase(clip)) return false;
+
+  if (clip.kind === "image" || clip.kind === "video") {
+    return typeof clip.src === "string" && isOptionalString(clip.poster);
+  }
+
+  if (clip.kind === "collection") {
+    if (typeof clip.title !== "string") return false;
+    if (typeof clip.childTimelineId !== "string" || clip.childTimelineId.length === 0) {
+      return false;
+    }
+    if (!isFiniteNumber(clip.itemCount)) return false;
+    if (clip.previewItems == null) return true;
+    if (!Array.isArray(clip.previewItems)) return false;
+    return clip.previewItems.every((item) => {
+      if (!item || typeof item !== "object") return false;
+      const preview = item as Record<string, unknown>;
+      return (
+        typeof preview.id === "string" &&
+        (preview.kind === "image" || preview.kind === "video") &&
+        typeof preview.src === "string" &&
+        typeof preview.alt === "string" &&
+        isOptionalString(preview.poster)
+      );
+    });
+  }
+
+  return false;
+}
+
+/** The API-boundary document guard: shape AND every clip validated. */
+export function isStoredTimelineDocument(value: unknown): value is TimelineDocument {
+  if (!value || typeof value !== "object") return false;
+  const document = value as Record<string, unknown>;
+  return (
+    typeof document.id === "string" &&
+    document.id.length > 0 &&
+    typeof document.title === "string" &&
+    isOptionalString(document.description) &&
+    Array.isArray(document.clips) &&
+    document.clips.every(isTimelineClip)
+  );
+}


### PR DESCRIPTION
…rable saves

- @storyboard/timeline-model gains validate.ts: full runtime guards for TimelineClip (discriminated by kind, finite-number checks) and TimelineDocument; PATCH and batch routes now use it instead of their shallow local checks, so malformed payloads can't persist.
- graph-documents-gateway: bindUser() auth boundary resets the module singleton across auth transitions; a generation counter invalidates in-flight fetches/batches from the previous session; prime() refuses payloads not stamped for the bound user (forUid on GraphServerPayload).
- Failed saves (5xx/network) re-dirty their ids and retry on a slower cadence instead of silently dropping the change; a queued trailing batch preserves any keepalive requirement from a pagehide flush.
- AuthProvider calls router.refresh() on login/logout so RSC router-cache output from the previous session is dropped.
- Native file drops park pending details in the same tick as the dispatch, closing the window where a concurrent drag cleared them mid-upload.
- Manifest preview discards a stale manifest immediately on local commits and refuses to install a manifest whose revision trails the CAS ledger.