### PR TITLE
Fix seven code-review findings in the graph view

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -10,7 +10,7 @@ import {
 
 import { Button } from "@/components/core/button";
 
-import { NativeDropStrip } from "./graph-native-drop";
+import { NativeDropStrip, SidebarToolInsertBridge } from "./graph-native-drop";
 import { OpenKeyBoundary } from "./graph-navigation";
 import { SyncPanel, type SyncEntry } from "./graph-persistence";
 import {
@@ -91,6 +91,9 @@ export function GraphBoard({
   return (
     <OpenKeyBoundary>
       <PreviewShell enabled={previewOn} focusedId={focusedId} channel={timeChannel}>
+        {/* Outside the surface branch on purpose: the sidebar's tool buttons
+            must insert in grid mode too, where no NativeDropStrip exists. */}
+        <SidebarToolInsertBridge collectionId={focusedId} />
         <div className="flex flex-col gap-5 rounded-xl border border-zinc-800 bg-zinc-950/50 p-4">
           <div className="flex items-center justify-between gap-3">
             <p className="text-xs text-zinc-500">

--- a/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useCallback, useRef, useState, type DragEvent, type ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState, type DragEvent, type ReactNode } from "react";
 
 import {
   getChildren,
   parseNodeId,
+  useCollectionsContainer,
   useCollectionsStore,
   type CollectionItemNode,
 } from "@storyboard/ui/dnd-collections";
@@ -12,9 +13,14 @@ import {
 import type { ClipDetail } from "@storyboard/timeline-domain";
 
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
-import { uploadTimelineMedia } from "@/lib/timeline-media-client";
+import {
+  GRAPH_INSERT_TOOL_EVENT,
+  isGraphInsertTool,
+  type GraphInsertToolDetail,
+} from "@/lib/graph-view-events";
+import { probeVideoFile, uploadTimelineMedia } from "@/lib/timeline-media-client";
 
-import { parkPendingDetail } from "./graph-pending-details";
+import { parkPendingDetail, unparkPendingDetail } from "./graph-pending-details";
 
 // The NATIVE drag-and-drop seam for the graph strips. dnd-kit owns
 // in-graph drags (cards, palette thumbnails); this layer owns what dnd-kit
@@ -27,10 +33,15 @@ import { parkPendingDetail } from "./graph-pending-details";
 //     add one node per file — in a single undoable commit.
 //
 // Both paths land as an ordinary add-nodes dispatch through the store, so
-// undo, the change feed, and the patch-scoped persistence all apply. The
-// PersistenceBridge's bounce policy stays the gate for un-hydrated targets:
-// a bounced add is undone with a rejection flash, and this layer detects
-// the bounce (the node is gone) and skips its follow-up work.
+// undo, the change feed, and the patch-scoped persistence all apply. Drops
+// into un-hydrated collections are refused BEFORE they commit by the store's
+// commandPolicy, so a refused add comes back from `dispatch` itself.
+//
+// The file pipeline is bounded on three axes, all of which were previously
+// unbounded: each video is decoded ONCE (duration and poster frame off the
+// same element, via probeVideoFile), at most MAX_CONCURRENT_MEDIA files are
+// in flight, and every decode and upload carries an AbortSignal that unmount
+// trips.
 
 const TOOL_MIME = "application/x-gstudio-type";
 // The demo clip the legacy views use for placeholder video content.
@@ -47,111 +58,58 @@ function mintId(prefix: string): string {
   return `${prefix}-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
 }
 
-/** Duration probe for dropped video files (images default to 4s). */
-function mediaFileDuration(file: File): Promise<number> {
-  return new Promise((resolve) => {
-    if (!file.type.startsWith("video/")) {
-      resolve(4);
-      return;
+// How many dropped files are decoded/uploaded at once. `Promise.all` over the
+// whole drop meant N video decoders, canvases, blobs, and uploads existing
+// simultaneously — dropping a folder of large videos produced a burst that
+// stalled the main thread. Small enough to bound the peak, big enough that
+// network latency still overlaps.
+const MAX_CONCURRENT_MEDIA = 3;
+
+/** Default timeline seconds for a dropped image. */
+const IMAGE_CLIP_SECONDS = 4;
+
+/** Client-space geometry of one mounted card, measured once per drag. */
+type CardGeometry = Readonly<{ nodeId: string; left: number; right: number; mid: number }>;
+
+type DragGeometry = Readonly<{
+  wrapperLeft: number;
+  /** Mounted cards in DOM order, which mirrors child order. */
+  cards: readonly CardGeometry[];
+}>;
+
+/**
+ * `Promise.all` with a worker pool. Results stay in INPUT order — the drop
+ * adds nodes in file order, so completion order must not leak through.
+ */
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  run: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+  const worker = async () => {
+    for (;;) {
+      const index = cursor++;
+      if (index >= items.length) return;
+      results[index] = await run(items[index]);
     }
-    const video = document.createElement("video");
-    video.preload = "metadata";
-    const sourceUrl = URL.createObjectURL(file);
-    const cleanup = () => {
-      URL.revokeObjectURL(sourceUrl);
-      video.removeAttribute("src");
-      video.load();
-    };
-    video.onloadedmetadata = () => {
-      const duration =
-        Number.isFinite(video.duration) && video.duration > 0 ? video.duration : 5;
-      cleanup();
-      resolve(duration);
-    };
-    video.onerror = () => {
-      cleanup();
-      resolve(5);
-    };
-    video.src = sourceUrl;
-  });
+  };
+  await Promise.all(
+    Array.from({ length: Math.max(1, Math.min(limit, items.length)) }, worker),
+  );
+  return results;
 }
 
 /**
- * Wraps a strip and accepts native drops into the given collection.
- * Insertion position follows the legacy midpoint rule, resolved against the
- * MOUNTED cards (virtualization: DOM order matches child order, but indexes
- * must come from the graph, not the DOM position).
+ * Mint-and-insert for the sidebar's tool palette, shared by the two ways a
+ * tool can arrive: a native DRAG (which carries a pointer-derived index) and
+ * plain ACTIVATION of the sidebar button (which appends). Extracted so the
+ * keyboard path runs exactly the same code as the drop — an accessible route
+ * that quietly diverges from the pointer one is how they drift apart.
  */
-export function NativeDropStrip({
-  collectionId,
-  children,
-}: Readonly<{ collectionId: string; children: ReactNode }>) {
+function useToolInsertion(collectionId: string) {
   const store = useCollectionsStore();
-  const wrapperRef = useRef<HTMLDivElement>(null);
-  const [indicatorX, setIndicatorX] = useState<number | null>(null);
-  const [upload, setUpload] = useState<
-    | Readonly<{ status: "uploading"; count: number }>
-    | Readonly<{ status: "error"; message: string }>
-    | null
-  >(null);
-
-  const acceptsDrag = (event: DragEvent) => {
-    const types = event.dataTransfer.types;
-    return types.includes(TOOL_MIME) || types.includes("Files");
-  };
-
-  /** Graph child index for a drop at clientX, via mounted-card midpoints. */
-  const resolveInsertIndex = useCallback(
-    (clientX: number): number => {
-      const wrapper = wrapperRef.current;
-      const children_ = getChildren(store.getSnapshot().graph, parseNodeId(collectionId));
-      if (!wrapper) return children_.length;
-      const cards = [...wrapper.querySelectorAll<HTMLElement>("[data-node-id]")];
-      for (const card of cards) {
-        const rect = card.getBoundingClientRect();
-        if (clientX < rect.left + rect.width / 2) {
-          const index = children_.indexOf(parseNodeId(card.dataset.nodeId ?? ""));
-          if (index >= 0) return index;
-        }
-      }
-      const last = cards[cards.length - 1];
-      if (last) {
-        const index = children_.indexOf(parseNodeId(last.dataset.nodeId ?? ""));
-        if (index >= 0) return index + 1;
-      }
-      return children_.length;
-    },
-    [store, collectionId],
-  );
-
-  const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
-    if (!acceptsDrag(event)) return;
-    event.preventDefault();
-    event.dataTransfer.dropEffect = "copy";
-    const wrapper = wrapperRef.current;
-    if (!wrapper) return;
-    // Indicator: snap to the resolved insertion edge when a card anchors it,
-    // else follow the pointer (empty strip / trailing whitespace).
-    const rect = wrapper.getBoundingClientRect();
-    const cards = [...wrapper.querySelectorAll<HTMLElement>("[data-node-id]")];
-    let x = event.clientX - rect.left;
-    for (const card of cards) {
-      const cardRect = card.getBoundingClientRect();
-      if (event.clientX < cardRect.left + cardRect.width / 2) {
-        x = cardRect.left - rect.left - 3;
-        break;
-      }
-      x = cardRect.right - rect.left + 3;
-    }
-    setIndicatorX(x);
-  };
-
-  const handleDragLeave = (event: DragEvent<HTMLDivElement>) => {
-    // Only clear when the pointer truly left the wrapper (dragleave fires
-    // for every child boundary crossing).
-    if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
-    setIndicatorX(null);
-  };
 
   const addNodes = useCallback(
     (nodes: readonly CollectionItemNode[], toIndex: number): boolean => {
@@ -161,17 +119,24 @@ export function NativeDropStrip({
         toParentId: parseNodeId(collectionId),
         toIndex,
       });
-      if (!result.ok) return false;
-      // The PersistenceBridge may have BOUNCED the add (un-hydrated target):
-      // it undoes reentrantly, so by now the nodes are gone again.
-      const graph = store.getSnapshot().graph;
-      return nodes.every((node) => graph.nodesById.has(node.id));
+      // Every refusal — including the un-hydrated-target veto — now comes
+      // back from dispatch itself, because the policy runs BEFORE the commit.
+      // Nothing landed in the graph, so there is no post-commit state to
+      // inspect; just release the details parked for nodes that will never
+      // exist.
+      if (!result.ok) {
+        for (const node of nodes) unparkPendingDetail(node.id as string);
+        return false;
+      }
+      return true;
     },
     [store, collectionId],
   );
 
-  const dropTool = useCallback(
-    (tool: SidebarTool, toIndex: number) => {
+  /** Returns whether the tool actually landed, so callers can announce the
+   *  truth rather than assuming success. */
+  const insertTool = useCallback(
+    (tool: SidebarTool, toIndex: number): boolean => {
       if (tool === "collection") {
         const childId = mintId("timeline");
         // hydrated: true — the collection is BRAND-NEW and empty, so drops
@@ -199,7 +164,7 @@ export function NativeDropStrip({
           graphDocumentsGateway.seed({ id: childId, title: "New Timeline", clips: [] });
           graphDocumentsGateway.writeClips(childId, []);
         }
-        return;
+        return added;
       }
 
       const id = mintId(tool);
@@ -213,7 +178,7 @@ export function NativeDropStrip({
           trimIn: 0,
           trimOut: 0,
         });
-        addNodes(
+        return addNodes(
           [
             {
               id: parseNodeId(id),
@@ -226,7 +191,6 @@ export function NativeDropStrip({
           ],
           toIndex,
         );
-        return;
       }
 
       parkPendingDetail(id, {
@@ -235,7 +199,7 @@ export function NativeDropStrip({
         trackIndex: 0,
         poster: placeholder,
       });
-      addNodes(
+      return addNodes(
         [
           {
             id: parseNodeId(id),
@@ -255,6 +219,227 @@ export function NativeDropStrip({
     [addNodes],
   );
 
+  return { addNodes, insertTool };
+}
+
+/** Human label for an inserted tool, for the announcement. */
+const TOOL_LABELS: Readonly<Record<SidebarTool, string>> = {
+  collection: "collection",
+  image: "image clip",
+  video: "video clip",
+};
+
+/**
+ * The KEYBOARD/click path for the sidebar tool palette. The sidebar is app
+ * chrome living outside this provider, so it hands the tool off through a
+ * window event (same pattern as the Assets launcher) and this appends it to
+ * the focused collection.
+ *
+ * Mounted for BOTH surfaces, deliberately: `NativeDropStrip` only wraps the
+ * strip, and an accessible control that silently does nothing in grid mode
+ * would be worse than no control at all.
+ */
+export function SidebarToolInsertBridge({
+  collectionId,
+}: Readonly<{ collectionId: string }>) {
+  const store = useCollectionsStore();
+  const { insertTool } = useToolInsertion(collectionId);
+  const { announce } = useCollectionsContainer();
+
+  useEffect(() => {
+    const handleInsert = (event: Event) => {
+      const tool = (event as CustomEvent<GraphInsertToolDetail>).detail?.tool;
+      if (!tool || !isGraphInsertTool(tool)) return;
+      const parentId = parseNodeId(collectionId);
+      const graph = store.getSnapshot().graph;
+      // Append: with no pointer there is no position to read, and the end of
+      // the timeline is the one spot that needs no explanation.
+      const landed = insertTool(tool, getChildren(graph, parentId).length);
+      const target = graph.nodesById.get(parentId)?.name ?? "the timeline";
+      announce(
+        landed
+          ? `Added a ${TOOL_LABELS[tool]} to the end of "${target}".`
+          : `Could not add a ${TOOL_LABELS[tool]} to "${target}".`,
+      );
+    };
+    window.addEventListener(GRAPH_INSERT_TOOL_EVENT, handleInsert);
+    return () => window.removeEventListener(GRAPH_INSERT_TOOL_EVENT, handleInsert);
+  }, [store, collectionId, insertTool, announce]);
+
+  return null;
+}
+
+/**
+ * Wraps a strip and accepts native drops into the given collection.
+ * Insertion position follows the legacy midpoint rule, resolved against the
+ * MOUNTED cards (virtualization: DOM order matches child order, but indexes
+ * must come from the graph, not the DOM position).
+ */
+export function NativeDropStrip({
+  collectionId,
+  children,
+}: Readonly<{ collectionId: string; children: ReactNode }>) {
+  const store = useCollectionsStore();
+  const { addNodes, insertTool } = useToolInsertion(collectionId);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [indicatorX, setIndicatorX] = useState<number | null>(null);
+  const [upload, setUpload] = useState<
+    | Readonly<{ status: "uploading"; count: number }>
+    | Readonly<{ status: "error"; message: string }>
+    | null
+  >(null);
+
+  // Drag-session geometry (see measureDragGeometry) plus the rAF coalescing
+  // state for the drop indicator. All refs: none of it should drive a render.
+  const dragGeometryRef = useRef<DragGeometry | null>(null);
+  const dragSessionRef = useRef(false);
+  const pointerXRef = useRef(0);
+  const indicatorFrameRef = useRef<number | null>(null);
+  const indicatorXRef = useRef<number | null>(null);
+
+  // Live drops, so unmount (drill-in, route change, surface toggle) can stop
+  // their decodes and uploads instead of leaving media elements and requests
+  // running for a view nobody is looking at. A Set, not one controller: a
+  // second drop while the first is still uploading must not cancel the first.
+  const dropAbortsRef = useRef<Set<AbortController>>(new Set());
+  useEffect(() => {
+    const pending = dropAbortsRef.current;
+    return () => {
+      for (const controller of pending) controller.abort();
+      pending.clear();
+    };
+  }, []);
+
+  const acceptsDrag = (event: DragEvent) => {
+    const types = event.dataTransfer.types;
+    return types.includes(TOOL_MIME) || types.includes("Files");
+  };
+
+  /**
+   * Measure the wrapper and every mounted card ONCE per drag session.
+   *
+   * `dragover` fires continuously, and reading `getBoundingClientRect` per
+   * card per event forces layout on each one. Cards do not move while a
+   * native drag is in progress — nothing commits until drop — so the geometry
+   * is stable, and the only things that invalidate it are scrolling (which
+   * also swaps which cards are virtualized in) and resizing.
+   */
+  const measureDragGeometry = useCallback((): DragGeometry | null => {
+    const wrapper = wrapperRef.current;
+    if (!wrapper) return null;
+    const wrapperLeft = wrapper.getBoundingClientRect().left;
+    const cards = [...wrapper.querySelectorAll<HTMLElement>("[data-node-id]")].map((card) => {
+      const rect = card.getBoundingClientRect();
+      return {
+        nodeId: card.dataset.nodeId ?? "",
+        left: rect.left,
+        right: rect.right,
+        mid: rect.left + rect.width / 2,
+      };
+    });
+    return { wrapperLeft, cards };
+  }, []);
+
+  /** Graph child index for a drop at clientX, via mounted-card midpoints. */
+  const resolveInsertIndex = useCallback(
+    (clientX: number): number => {
+      const children_ = getChildren(store.getSnapshot().graph, parseNodeId(collectionId));
+      // Reuse the drag session's measurements; fall back to measuring for a
+      // drop that arrived without a preceding dragover (programmatic drops).
+      const geometry = dragGeometryRef.current ?? measureDragGeometry();
+      if (!geometry) return children_.length;
+      // An id may be any non-whitespace string, so match by value rather than
+      // reconstructing one — `parseNodeId` throws on an empty attribute.
+      const indexOfCard = (card: CardGeometry) =>
+        children_.findIndex((childId) => (childId as string) === card.nodeId);
+      for (const card of geometry.cards) {
+        if (clientX < card.mid) {
+          const index = indexOfCard(card);
+          if (index >= 0) return index;
+        }
+      }
+      const last = geometry.cards[geometry.cards.length - 1];
+      if (last) {
+        const index = indexOfCard(last);
+        if (index >= 0) return index + 1;
+      }
+      return children_.length;
+    },
+    [store, collectionId, measureDragGeometry],
+  );
+
+  const invalidateDragGeometry = useCallback(() => {
+    dragGeometryRef.current = null;
+  }, []);
+
+  /** Resolve and paint the indicator for the latest pointer x, once a frame. */
+  const flushIndicator = useCallback(() => {
+    indicatorFrameRef.current = null;
+    const geometry = (dragGeometryRef.current ??= measureDragGeometry());
+    if (!geometry) return;
+    const clientX = pointerXRef.current;
+    // Snap to the resolved insertion edge when a card anchors it, else follow
+    // the pointer (empty strip / trailing whitespace).
+    let x = clientX - geometry.wrapperLeft;
+    for (const card of geometry.cards) {
+      if (clientX < card.mid) {
+        x = card.left - geometry.wrapperLeft - 3;
+        break;
+      }
+      x = card.right - geometry.wrapperLeft + 3;
+    }
+    // Most frames of a drag resolve to the SAME edge — re-rendering for them
+    // is pure waste.
+    if (indicatorXRef.current === x) return;
+    indicatorXRef.current = x;
+    setIndicatorX(x);
+  }, [measureDragGeometry]);
+
+  const endDragSession = useCallback(() => {
+    if (!dragSessionRef.current) return;
+    dragSessionRef.current = false;
+    window.removeEventListener("scroll", invalidateDragGeometry, true);
+    window.removeEventListener("resize", invalidateDragGeometry);
+    if (indicatorFrameRef.current !== null) {
+      cancelAnimationFrame(indicatorFrameRef.current);
+      indicatorFrameRef.current = null;
+    }
+    dragGeometryRef.current = null;
+    indicatorXRef.current = null;
+    setIndicatorX(null);
+  }, [invalidateDragGeometry]);
+
+  // A drag can end anywhere (dropped on another target, cancelled with Esc),
+  // and `dragend` fires on the drag SOURCE — which is the sidebar, not us. A
+  // window-level listener is what actually guarantees the session closes.
+  useEffect(() => endDragSession, [endDragSession]);
+
+  const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
+    if (!acceptsDrag(event)) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+
+    if (!dragSessionRef.current) {
+      dragSessionRef.current = true;
+      // Capture phase: the strip scrolls in its own container, not the window.
+      window.addEventListener("scroll", invalidateDragGeometry, true);
+      window.addEventListener("resize", invalidateDragGeometry);
+      window.addEventListener("dragend", endDragSession, { once: true });
+    }
+    // Coalesce to one resolve+paint per frame, no matter the event rate.
+    pointerXRef.current = event.clientX;
+    if (indicatorFrameRef.current === null) {
+      indicatorFrameRef.current = requestAnimationFrame(flushIndicator);
+    }
+  };
+
+  const handleDragLeave = (event: DragEvent<HTMLDivElement>) => {
+    // Only clear when the pointer truly left the wrapper (dragleave fires
+    // for every child boundary crossing).
+    if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
+    endDragSession();
+  };
+
   const dropFiles = useCallback(
     async (files: readonly File[], toIndex: number) => {
       const media = files.filter(
@@ -263,19 +448,31 @@ export function NativeDropStrip({
       if (media.length === 0) return;
       setUpload({ status: "uploading", count: media.length });
 
+      const controller = new AbortController();
+      const signal = controller.signal;
+      dropAbortsRef.current.add(controller);
+
       try {
         type UploadResult = Readonly<{
           node: CollectionItemNode | null;
           detail: ClipDetail | null;
           error: string | null;
         }>;
-        const results: readonly UploadResult[] = await Promise.all(
-          media.map(async (file): Promise<UploadResult> => {
+        const results: readonly UploadResult[] = await mapWithConcurrency(
+          media,
+          MAX_CONCURRENT_MEDIA,
+          async (file): Promise<UploadResult> => {
             const isVideo = file.type.startsWith("video/");
-            const duration = await mediaFileDuration(file);
+            // ONE decode per video: duration and poster frame together. The
+            // probe is handed to the upload so it does not decode again.
+            const probe = isVideo ? await probeVideoFile(file, { signal }) : null;
+            const duration = probe?.durationSeconds ?? IMAGE_CLIP_SECONDS;
             let hosted: Awaited<ReturnType<typeof uploadTimelineMedia>>;
             try {
-              hosted = await uploadTimelineMedia(file.name, file);
+              hosted = await uploadTimelineMedia(file.name, file, undefined, {
+                thumbnail: probe?.thumbnail ?? null,
+                signal,
+              });
             } catch {
               return { node: null, detail: null, error: `"${file.name}" could not be uploaded.` };
             }
@@ -309,17 +506,34 @@ export function NativeDropStrip({
               mediaKind: "image",
               name: file.name,
               src: hosted.url,
-              durationSeconds: 4,
+              durationSeconds: IMAGE_CLIP_SECONDS,
             };
             return {
               node,
-              detail: { alt: file.name, aspect: 16 / 9, trackIndex: 0, sourceDuration: 4, trimIn: 0, trimOut: 0 },
+              detail: {
+                alt: file.name,
+                aspect: 16 / 9,
+                trackIndex: 0,
+                sourceDuration: IMAGE_CLIP_SECONDS,
+                trimIn: 0,
+                trimOut: 0,
+              },
               error: null,
             };
-          }),
+          },
         );
 
-        const failure = results.find((result) => result.error)?.error ?? null;
+        // Navigated away or unmounted mid-drop: the nodes belong to a view
+        // that is gone, so commit nothing and touch no state.
+        if (signal.aborted) return;
+
+        // Report every distinct upload failure, not just the first: a drop of
+        // five files that fails three ways used to surface one message.
+        const uploadErrors = [
+          ...new Set(
+            results.map((result) => result.error).filter((error): error is string => error !== null),
+          ),
+        ];
         const landed = results.filter(
           (result): result is UploadResult & { node: CollectionItemNode; detail: ClipDetail } =>
             result.node !== null && result.detail !== null,
@@ -328,20 +542,35 @@ export function NativeDropStrip({
         // palette drag clears every pending detail at drag start, so
         // parking during the (async) uploads left a window where completed
         // files lost their metadata before the commit could claim it.
+        let commitError: string | null = null;
         if (landed.length > 0) {
           for (const result of landed) {
             parkPendingDetail(result.node.id as string, result.detail);
           }
           // ONE dispatch for the whole file set: a multi-file drop is a
           // single undoable step and a single persisted batch.
-          addNodes(
+          const added = addNodes(
             landed.map((result) => result.node),
             toIndex,
           );
+          // The dispatch can be REFUSED (the un-hydrated-target veto). Ignoring
+          // it left the user with successfully uploaded files, no cards, and
+          // no error — the upload silently went nowhere.
+          if (!added) {
+            commitError =
+              landed.length === 1
+                ? `"${landed[0].node.name}" uploaded but could not be added here.`
+                : `${landed.length} files uploaded but could not be added here.`;
+          }
         }
-        setUpload(failure ? { status: "error", message: failure } : null);
+        // The commit failure dominates: it means NOTHING from this drop landed.
+        const message = commitError ?? (uploadErrors.length > 0 ? uploadErrors.join(" · ") : null);
+        setUpload(message ? { status: "error", message } : null);
       } catch {
+        if (signal.aborted) return;
         setUpload({ status: "error", message: "The dropped files could not be added." });
+      } finally {
+        dropAbortsRef.current.delete(controller);
       }
     },
     [addNodes],
@@ -350,12 +579,15 @@ export function NativeDropStrip({
   const handleDrop = (event: DragEvent<HTMLDivElement>) => {
     if (!acceptsDrag(event)) return;
     event.preventDefault();
-    setIndicatorX(null);
+    // Resolve BEFORE ending the session: the index comes from the same
+    // measurements the indicator was drawn from, so where the user saw the
+    // line is where the node lands.
     const toIndex = resolveInsertIndex(event.clientX);
+    endDragSession();
 
     const tool = event.dataTransfer.getData(TOOL_MIME);
     if (tool && isSidebarTool(tool)) {
-      dropTool(tool, toIndex);
+      insertTool(tool, toIndex);
       return;
     }
     const files = [...event.dataTransfer.files];
@@ -380,21 +612,28 @@ export function NativeDropStrip({
           style={{ transform: `translateX(${indicatorX}px)` }}
         />
       )}
-      {upload !== null && (
-        <p
-          data-native-drop-status
-          className={[
-            "pointer-events-none absolute bottom-1 left-1 z-20 rounded px-2 py-1 text-[10px]",
-            upload.status === "uploading"
+      {/* Always MOUNTED, so it is a live region the moment the page renders:
+          a role="status" element that appears at the same time as its text
+          is unreliably announced. Empty and visually gone while idle. */}
+      <p
+        data-native-drop-status
+        role="status"
+        aria-live="polite"
+        className={[
+          "pointer-events-none absolute bottom-1 left-1 z-20 rounded px-2 py-1 text-[10px]",
+          upload === null
+            ? "sr-only"
+            : upload.status === "uploading"
               ? "bg-zinc-900/90 text-zinc-200"
               : "bg-red-950/90 text-red-200",
-          ].join(" ")}
-        >
-          {upload.status === "uploading"
+        ].join(" ")}
+      >
+        {upload === null
+          ? ""
+          : upload.status === "uploading"
             ? `Uploading ${upload.count} file${upload.count === 1 ? "" : "s"}…`
             : upload.message}
-        </p>
-      )}
+      </p>
     </div>
   );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-pending-details.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-pending-details.ts
@@ -21,6 +21,13 @@ export function clearPendingDetails(): void {
   pendingDetails.clear();
 }
 
+/** Drop one parked entry whose add was REFUSED, so the node it described
+ *  can never exist. Targeted twin of `clearPendingDetails` for the
+ *  imperative paths that park before dispatching. */
+export function unparkPendingDetail(id: string): void {
+  pendingDetails.delete(id);
+}
+
 /** Claim parked metadata for every node an add-nodes patch committed. */
 export function claimPendingPaletteDetails(
   patch: CollectionsPatch,

--- a/apps/timeline-gstudio001/components/graph-view/graph-persistence.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-persistence.tsx
@@ -2,14 +2,9 @@
 
 import { useEffect } from "react";
 
-import {
-  useCollectionsContainer,
-  useCollectionsStore,
-  type CollectionsChange,
-} from "@storyboard/ui/dnd-collections";
+import { useCollectionsStore, type CollectionsChange } from "@storyboard/ui/dnd-collections";
 import {
   collectAffectedCollectionIds,
-  collectUnhydratedDropTargets,
   graphChildrenToClips,
 } from "@storyboard/timeline-domain";
 
@@ -27,7 +22,16 @@ export type SyncEntry = Readonly<{
   bounced?: boolean;
 }>;
 
-/** Persist committed graph patches and bounce drops into unloaded collections. */
+/**
+ * Persist committed graph patches.
+ *
+ * Drops into un-hydrated collections are NOT handled here — they are refused
+ * before they commit, by the `commandPolicy` in graph-timeline-view.tsx.
+ * This bridge used to bounce them post-commit with `store.undo()`, which
+ * looked equivalent but silently destroyed the user's redo branch (the
+ * commit clears it) and left the refused command itself redoable. Anything
+ * reaching this subscriber is a change that is meant to stick.
+ */
 export function PersistenceBridge({
   onSync,
 }: Readonly<{
@@ -35,7 +39,6 @@ export function PersistenceBridge({
 }>) {
   const store = useCollectionsStore();
   const detailsStore = useGraphDetailsStore();
-  const { announce } = useCollectionsContainer();
 
   useEffect(
     () =>
@@ -44,29 +47,6 @@ export function PersistenceBridge({
         if (claimed) detailsStore.merge(claimed);
 
         const current = detailsStore.read();
-        if (change.origin !== "undo") {
-          const blocked = collectUnhydratedDropTargets(change.patch, current);
-          if (blocked.length > 0) {
-            store.undo();
-            const placedIds =
-              change.patch.type === "nodes-moved"
-                ? change.patch.moves.map((move) => move.nodeId)
-                : change.patch.type === "nodes-added"
-                  ? change.patch.adds.map((add) => add.node.id)
-                  : [];
-            if (placedIds.length > 0) store.flashRejection(placedIds);
-            announce("That collection is still loading — drop again once its clips appear.");
-            onSync({
-              at: Date.now(),
-              origin: change.origin,
-              patchType: change.patch.type,
-              collections: blocked,
-              bounced: true,
-            });
-            return;
-          }
-        }
-
         const affected = collectAffectedCollectionIds(change.graph, change.patch).filter(
           (id) => graphDocumentsGateway.peek(id) !== null && current[id]?.hydrated !== false,
         );
@@ -80,7 +60,7 @@ export function PersistenceBridge({
           collections: affected,
         });
       }),
-    [store, detailsStore, announce, onSync],
+    [store, detailsStore, onSync],
   );
 
   return null;

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useContext, useState } from "react";
+import { useContext, useMemo, useState } from "react";
 import { CornerDownRight, Folder, FolderOpen } from "lucide-react";
 
 import {
@@ -30,17 +30,38 @@ import {
   type FocusSurface,
 } from "./graph-view-config";
 
-/** The focused collection's direct collection child ids, as a stable joined
- *  key so a node subscribes only to ITS OWN child-set identity — a selector
- *  returning a fresh array would re-render on every unrelated graph change. */
-function useCollectionChildIds(collectionId: NodeId): NodeId[] {
-  const joined = useCollectionsSelector((snapshot) =>
-    getChildren(snapshot.graph, collectionId)
-      .filter((childId) => snapshot.graph.nodesById.get(childId)?.kind === "collection")
-      .map((childId) => childId as string)
-      .join(","),
+/**
+ * The focused collection's direct COLLECTION child ids.
+ *
+ * The subscription is the raw children array, which the reducer shares
+ * structurally: its identity survives every change that doesn't touch THIS
+ * collection's children, so the selector returns a stable reference (what
+ * `useCollectionsSelector` requires) without allocating.
+ *
+ * This used to subscribe to `ids.join(",")` and rebuild the list with
+ * `split(",")`. That worked only for ids containing no comma — but the core
+ * explicitly allows ANY non-whitespace string as a `NodeId` (see graph.ts),
+ * so an id like `client,a` would have been torn into two ids that address
+ * nothing. Nothing in the app mints such an id today, which is precisely why
+ * it would have failed the first time some other id source did.
+ *
+ * The kind filter reads the store WITHOUT subscribing to it, which is sound
+ * because a node's `kind` is fixed for its lifetime — no command changes it
+ * (`update-media` only rewrites media fields), so this derivation is a pure
+ * function of the children array it is keyed on.
+ */
+function useCollectionChildIds(collectionId: NodeId): readonly NodeId[] {
+  const store = useCollectionsStore();
+  const children = useCollectionsSelector((snapshot) =>
+    getChildren(snapshot.graph, collectionId),
   );
-  return joined === "" ? [] : joined.split(",").map((id) => parseNodeId(id));
+  return useMemo(
+    () =>
+      children.filter(
+        (childId) => store.getSnapshot().graph.nodesById.get(childId)?.kind === "collection",
+      ),
+    [children, store],
+  );
 }
 
 /** One collection row in the sub-graph tree: collapsed by default, expands to

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -14,12 +14,18 @@ import {
 import {
   DndCollections,
   buildGraph,
+  parseNodeId,
   type CollectionItemNode,
   type CollectionsGraph,
+  type CommandPolicy,
   type GraphNodeSpec,
   type NodeId,
 } from "@storyboard/ui/dnd-collections";
-import { buildHydrationSpecs, type ClipDetail } from "@storyboard/timeline-domain";
+import {
+  buildHydrationSpecs,
+  collectUnhydratedDropTargets,
+  type ClipDetail,
+} from "@storyboard/timeline-domain";
 
 import { useAuth } from "@/components/auth/auth-provider";
 import { createGraphDetailsStore } from "@/lib/graph-details-store";
@@ -218,6 +224,42 @@ export function GraphTimelineView({
     setSyncLog((log) => [entry, ...log].slice(0, 6));
   }, []);
 
+  // Gate-until-hydrated, as a PRE-COMMIT veto. A collection whose stored
+  // clips haven't loaded is an empty placeholder: content landing in it would
+  // block its future hydration (the engine only fills an EMPTY collection)
+  // and let the patch-scoped write overwrite the stored document with just
+  // the new content.
+  //
+  // This has to run before the command commits. The previous design let the
+  // drop commit and had the PersistenceBridge undo it back out, which is not
+  // the same thing — committing clears the redo branch, so a bounced drop
+  // silently threw away whatever the user still had to redo and left the
+  // refused drop itself on the redo stack.
+  //
+  // Reads `detailsStore` live (it is a stable external store), so this
+  // closure never goes stale. The onSync call is a deliberate exception to
+  // the "pure predicate" rule — it feeds the SyncPanel's telemetry and fires
+  // at most once per blocked dispatch.
+  const commandPolicy = useCallback<CommandPolicy>(
+    (command) => {
+      const blocked = collectUnhydratedDropTargets(command, detailsStore.read());
+      if (blocked.length === 0) return null;
+      onSync({
+        at: Date.now(),
+        origin: "command",
+        patchType: command.type === "add-nodes" ? "nodes-added" : "nodes-moved",
+        collections: blocked,
+        bounced: true,
+      });
+      return {
+        reason: "blocked-by-policy",
+        blockedIds: blocked.map(parseNodeId),
+        message: "That collection is still loading — drop again once its clips appear.",
+      };
+    },
+    [detailsStore, onSync],
+  );
+
   // Click-to-open (the pointer twin of the O key): the provider's
   // onOpenNode fires on a plain click on an open-target card — after the
   // package's gesture arbitration, so a drag, a hold-grab, or a pan never
@@ -282,6 +324,7 @@ export function GraphTimelineView({
         trimRequiresSelection
         onOpenNode={handleOpenNode}
         openOnClick={openOnClick}
+        commandPolicy={commandPolicy}
       >
         <GraphDetailsProvider store={detailsStore}>
           <PersistenceBridge onSync={onSync} />

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -19,7 +19,12 @@ import { usePathname, useSearchParams } from "next/navigation";
 import { AssetLibraryDrawer } from "@/components/assets/asset-library-drawer";
 import { TrashDrawer } from "@/components/assets/trash-drawer";
 import { useAuth } from "@/components/auth/auth-provider";
-import { GRAPH_ASSETS_TOGGLE_EVENT, isGraphViewRoute } from "@/lib/graph-view-events";
+import {
+  GRAPH_ASSETS_TOGGLE_EVENT,
+  isGraphInsertTool,
+  isGraphViewRoute,
+  requestGraphToolInsert,
+} from "@/lib/graph-view-events";
 import { cn } from "@/lib/utils";
 import type { ProjectViewMode } from "@storyboard/ui/timeline/timeline-view-state";
 
@@ -237,6 +242,24 @@ export function TimelineSidebar() {
     window.dispatchEvent(new CustomEvent("gstudio-drag-end"));
   };
 
+  // Dragging a tool onto a strip is POINTER-only (native HTML5 drag with a
+  // custom DataTransfer), so on the graph route activation appends it to the
+  // open timeline instead — the keyboard, screen-reader, and touch route to
+  // the same result. Drag remains the way to choose a POSITION.
+  const canInsertTools = isGraphViewRoute(pathname);
+
+  const handleToolActivate = (item: DraggableItem) => {
+    if (canInsertTools && isGraphInsertTool(item.type)) {
+      requestGraphToolInsert(item.type);
+      // The graph view announces the authoritative result on its own
+      // aria-live channel (it knows the target and whether it landed); this
+      // is the visible half, for everyone else.
+      setToastMessage(`Added a ${item.label} to the end of the open timeline.`);
+      return;
+    }
+    showDragToast(item.label);
+  };
+
   const showDragToast = (label: string) => {
     setToastMessage(`Drag this "${label}" block onto the workspace to add it!`);
   };
@@ -293,30 +316,32 @@ export function TimelineSidebar() {
               const tooltipId = `sidebar-tooltip-new-${item.type}`;
 
               return (
-                <div
+                <button
                   key={item.type}
-                  role="button"
-                  tabIndex={0}
-                  aria-label={item.label}
+                  type="button"
+                  aria-label={
+                    canInsertTools
+                      ? `Add ${item.label} to the open timeline`
+                      : item.label
+                  }
                   aria-describedby={tooltipId}
                   draggable
                   onDragStart={(e) => handleDragStart(e, item.type)}
                   onDragEnd={handleDragEnd}
-                  onClick={() => showDragToast(item.label)}
-                  onKeyDown={(event) => {
-                    if (event.key !== "Enter" && event.key !== " ") return;
-                    event.preventDefault();
-                    showDragToast(item.label);
-                  }}
+                  onClick={() => handleToolActivate(item)}
                   className="group/sidebar-item relative flex size-11 cursor-grab select-none items-center justify-center rounded-lg border border-zinc-800 bg-zinc-900/40 text-zinc-400 transition-all duration-200 hover:border-sky-500 hover:bg-sky-950/20 hover:text-sky-400 active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
                 >
                   <Icon className="h-4 w-4 transition-colors" />
                   <TooltipLabel
                     id={tooltipId}
                     label={item.label}
-                    description={item.description}
+                    description={
+                      canInsertTools
+                        ? `${item.description} · click to append, drag to place`
+                        : item.description
+                    }
                   />
-                </div>
+                </button>
               );
             })}
           </div>
@@ -488,6 +513,8 @@ export function TimelineSidebar() {
 
       {toastMessage && (
         <div
+          role="status"
+          aria-live="polite"
           style={{
             position: "fixed",
             top: "24px",
@@ -497,7 +524,7 @@ export function TimelineSidebar() {
           }}
           className="timeline-toast-animate flex h-10 items-center gap-2.5 rounded-full border border-sky-500/30 bg-zinc-900/95 px-5 text-xs font-medium text-zinc-100 shadow-2xl backdrop-blur-md select-none"
         >
-          <Layers className="h-3.5 w-3.5 text-sky-400 shrink-0" />
+          <Layers className="h-3.5 w-3.5 text-sky-400 shrink-0" aria-hidden="true" />
           <span className="text-zinc-200">
             {toastMessage}
           </span>

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
@@ -51,6 +51,10 @@ type FetchCall = {
   id: string;
   writes?: BatchWrite[];
   keepalive?: boolean;
+  /** Kept so tests can assert a batch was abandoned (unload takeover). */
+  signal?: AbortSignal;
+  /** Serialized request body length, for keepalive-budget assertions. */
+  bodyBytes?: number;
 };
 
 /** Stubs global fetch; returns the recorded calls for assertions. */
@@ -65,6 +69,9 @@ function installFetch(handler: (call: FetchCall) => Promise<MockResponse> | Mock
           ? (JSON.parse(init.body) as { writes: BatchWrite[] }).writes
           : undefined,
       keepalive: init?.keepalive,
+      signal: init?.signal ?? undefined,
+      bodyBytes:
+        typeof init?.body === "string" ? new TextEncoder().encode(init.body).length : undefined,
     };
     calls.push(call);
     return Promise.resolve(handler(call));
@@ -211,6 +218,130 @@ describe("graph-documents-gateway", () => {
     // The debounce timer was consumed — no duplicate batch later.
     await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
     expect(batchesOf(calls)).toHaveLength(1);
+  });
+
+  // The unload path. A keepalive flush must never wait on a request that
+  // page teardown is about to kill — queuing behind it is how the last edit
+  // was lost.
+  it("an unload flush takes over a running non-keepalive save instead of queuing behind it", async () => {
+    const stuckSave = deferred<MockResponse>(); // never settles: the page is closing
+    let batchCount = 0;
+    const calls = installFetch((call) => {
+      if (call.method !== "POST") {
+        return jsonResponse({ document: doc("a", [clip("a1")]), revision: 1 });
+      }
+      batchCount += 1;
+      return batchCount === 1 ? stuckSave.promise : okResults(call.writes);
+    });
+    const gateway = createGraphDocumentsGateway();
+    await gateway.ensure("a");
+
+    gateway.writeClips("a", [clip("a2")]);
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+    expect(batchesOf(calls)).toHaveLength(1); // in flight, will never settle
+
+    // An edit lands mid-flight, then the tab starts closing.
+    gateway.writeClips("a", [clip("a3")]);
+    gateway.flushPendingWrites({ keepalive: true });
+
+    const batches = batchesOf(calls);
+    expect(batches).toHaveLength(2); // it did NOT wait for the stuck request
+    expect(batches[0].signal?.aborted).toBe(true); // the stuck one was abandoned
+    expect(batches[1].keepalive).toBe(true);
+    // Carries the LATEST cache, and still expects the revision the abandoned
+    // batch expected — no response landed, so the ledger never advanced.
+    expect(clipIds(batches[1].writes?.[0].document)).toEqual(["a3"]);
+    expect(batches[1].writes?.[0].expectedRevision).toBe(1);
+    // Abandoning is not a failure: it must not surface as a save error.
+    expect(gateway.lastError()).toBeNull();
+  });
+
+  it("an unload flush re-sends an in-flight batch even with nothing newly dirty", async () => {
+    const stuckSave = deferred<MockResponse>();
+    let batchCount = 0;
+    const calls = installFetch((call) => {
+      if (call.method !== "POST") {
+        return jsonResponse({ document: doc("a", [clip("a1")]), revision: 1 });
+      }
+      batchCount += 1;
+      return batchCount === 1 ? stuckSave.promise : okResults(call.writes);
+    });
+    const gateway = createGraphDocumentsGateway();
+    await gateway.ensure("a");
+
+    gateway.writeClips("a", [clip("a2")]);
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+    gateway.flushPendingWrites({ keepalive: true });
+
+    // The in-flight batch's own content is what would have been lost.
+    const batches = batchesOf(calls);
+    expect(batches).toHaveLength(2);
+    expect(batches[1].keepalive).toBe(true);
+    expect(clipIds(batches[1].writes?.[0].document)).toEqual(["a2"]);
+  });
+
+  it("a second unload flush leaves an already-keepalive batch alone", async () => {
+    const stuckSave = deferred<MockResponse>();
+    const calls = installFetch((call) =>
+      call.method === "POST"
+        ? stuckSave.promise
+        : jsonResponse({ document: doc("a", [clip("a1")]), revision: 1 }),
+    );
+    const gateway = createGraphDocumentsGateway();
+    await gateway.ensure("a");
+
+    gateway.writeClips("a", [clip("a2")]);
+    gateway.flushPendingWrites({ keepalive: true });
+    expect(batchesOf(calls)).toHaveLength(1);
+
+    // pagehide AND visibilitychange both fire on a real close — the second
+    // must not abandon and re-send a request that is already unload-safe.
+    gateway.flushPendingWrites({ keepalive: true });
+    expect(batchesOf(calls)).toHaveLength(1);
+    expect(batchesOf(calls)[0].signal?.aborted).toBe(false);
+  });
+
+  it("an over-budget unload batch drops keepalive rather than being refused outright", async () => {
+    // Over the 64 KiB keepalive quota the fetch is a NETWORK ERROR, not a
+    // truncation — requesting keepalive here would guarantee the loss.
+    const calls = installFetch((call) =>
+      call.method === "POST"
+        ? okResults(call.writes)
+        : jsonResponse({ document: doc("a", [clip("a1")]), revision: 1 }),
+    );
+    const gateway = createGraphDocumentsGateway();
+    await gateway.ensure("a");
+
+    const huge = { ...clip("a2"), alt: "x".repeat(80_000) };
+    gateway.writeClips("a", [huge]);
+    gateway.flushPendingWrites({ keepalive: true });
+
+    const batches = batchesOf(calls);
+    expect(batches).toHaveLength(1);
+    expect(batches[0].bodyBytes).toBeGreaterThan(64 * 1024);
+    expect(batches[0].keepalive).toBeFalsy(); // sent best-effort instead
+    // The batch still went out INTACT — atomicity is not traded away.
+    expect(clipIds(batches[0].writes?.[0].document)).toEqual(["a2"]);
+    // And the risk is surfaced rather than swallowed.
+    expect(gateway.lastError()).toMatch(/too large/i);
+  });
+
+  it("a body under the keepalive budget still gets keepalive", async () => {
+    const calls = installFetch((call) =>
+      call.method === "POST"
+        ? okResults(call.writes)
+        : jsonResponse({ document: doc("a", [clip("a1")]), revision: 1 }),
+    );
+    const gateway = createGraphDocumentsGateway();
+    await gateway.ensure("a");
+
+    gateway.writeClips("a", [clip("a2")]);
+    gateway.flushPendingWrites({ keepalive: true });
+
+    const batches = batchesOf(calls);
+    expect(batches[0].bodyBytes).toBeLessThan(56 * 1024);
+    expect(batches[0].keepalive).toBe(true);
+    expect(gateway.lastError()).toBeNull();
   });
 
   it("refresh keeps cached content readable but makes ensure refetch it", async () => {

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
@@ -32,6 +32,16 @@ const SAVE_RETRY_MS = 5000;
 // How long an ensure waits for a declared-incoming RSC prime before
 // fetching itself — roughly a streamed payload's round trip.
 const PRIME_WAIT_MS = 1000;
+// The fetch spec caps keepalive at 64 KiB across every in-flight keepalive
+// request on the page, and going over is a hard network error rather than a
+// truncation. Budget under it: headers count toward the quota, and other
+// code on the page (analytics beacons) may hold some of it.
+const KEEPALIVE_BUDGET_BYTES = 56 * 1024;
+
+/** Byte length of a UTF-8 body — `String.length` undercounts non-ASCII
+ *  (clip titles, alt text), which is exactly how a body sneaks over quota. */
+const byteLength = (value: string): number =>
+  typeof TextEncoder === "function" ? new TextEncoder().encode(value).length : value.length;
 
 /** A server-read document + revision, delivered by RSC (layout bootstrap /
  *  focus-path streams) and fed to `prime`. Defined HERE (client-safe) so
@@ -125,6 +135,11 @@ export type GraphDocumentsGateway = Readonly<{
    * Send the pending batch NOW. Called on pagehide/hidden (with keepalive,
    * so the request survives the tab closing) and before a refresh — closing
    * the tab inside the debounce window must not lose the last edit.
+   *
+   * A keepalive flush never QUEUES behind a running save: the running request
+   * was created without keepalive, so teardown would kill it and the queued
+   * batch would never start. It abandons that request instead and re-sends its
+   * documents, plus anything dirtied since, as one unload-safe batch.
    */
   flushPendingWrites: (options?: { keepalive?: boolean }) => void;
   /**
@@ -160,10 +175,15 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
   // in-flight batch could reach the server after a newer one and win.
   let saveInFlight: Promise<void> | null = null;
   let saveQueued = false;
-  // A queued trailing batch remembers whether any flush that requested it
-  // needed keepalive (pagehide) — dropping that bit would send the trailing
-  // batch as an ordinary fetch during page teardown.
-  let saveQueuedKeepalive = false;
+  // Whether the in-flight batch was itself sent with keepalive — i.e. already
+  // survives page teardown, so an unload flush has no reason to displace it.
+  let saveInFlightKeepalive = false;
+  // What the in-flight batch is carrying, so an unload flush that abandons it
+  // can re-dirty those documents and re-send them itself.
+  let saveInFlightIds: readonly string[] = [];
+  // Abandons the in-flight batch: aborts the request AND makes its handlers
+  // no-ops, so a late settle can't clobber the batch that replaced it.
+  let abandonSaveInFlight: (() => void) | null = null;
   // Ids whose cached content predates the current graph session (see
   // `refresh`) or lost a revision conflict: readable, but `ensure`
   // refetches them.
@@ -197,14 +217,21 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
     errors.clear();
     errorBanner = null;
     inflight.clear();
-    dirtyIds.clear();
     if (saveTimer !== null) {
       clearTimeout(saveTimer);
       saveTimer = null;
     }
+    // Abandon BEFORE clearing the dirty set: abandoning re-dirties whatever
+    // the in-flight batch was carrying, and on a reset (a different user is
+    // binding) none of the previous session's documents may survive to be
+    // written into the new one.
+    abandonSaveInFlight?.();
+    abandonSaveInFlight = null;
+    dirtyIds.clear();
     saveInFlight = null;
     saveQueued = false;
-    saveQueuedKeepalive = false;
+    saveInFlightKeepalive = false;
+    saveInFlightIds = [];
     staleIds = new Set();
     expectedPrimes.clear();
     pendingPrimes = [];
@@ -333,13 +360,29 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
   };
 
   const persistBatch = (options?: { keepalive?: boolean }) => {
+    const wantsKeepalive = options?.keepalive === true;
+
     if (saveInFlight !== null) {
-      saveQueued = true;
-      // The trailing batch must keep the strongest delivery requirement any
-      // caller asked for — a pagehide flush queued behind a running save
-      // still needs keepalive or the browser may kill it on teardown.
-      if (options?.keepalive) saveQueuedKeepalive = true;
-      return;
+      if (!wantsKeepalive) {
+        // Ordinary write during a flight: queue ONE trailing batch, which
+        // will re-read the latest cache when the current one settles.
+        saveQueued = true;
+        return;
+      }
+      // Unload flush with a batch already running. Queuing behind it — what
+      // this used to do — is what lost the last edit: the running request was
+      // created WITHOUT keepalive, so page teardown kills it, and the
+      // trailing batch that was waiting on its settle never starts at all.
+      if (saveInFlightKeepalive && dirtyIds.size === 0) {
+        // Already unload-safe and carrying everything: leave it alone.
+        return;
+      }
+      // Abandon it and re-send its documents ourselves, from the latest
+      // cache, in one unload-safe batch. Its `expectedRevision`s are still
+      // valid: no response landed, so the revision ledger never advanced.
+      // (If the server did process it before the abort, our batch loses CAS
+      // and 409s — handled, and strictly better than not sending at all.)
+      abandonSaveInFlight?.();
     }
     if (dirtyIds.size === 0) return;
     const writes: { document: TimelineDocument; expectedRevision?: number }[] = [];
@@ -356,32 +399,72 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
     if (writes.length === 0) return;
 
     const gen = generation;
-    const settle = () => {
-      // A reset (auth rebind) happened mid-flight: this batch belongs to
-      // the previous session — don't touch the new one's state.
-      if (gen !== generation) return;
+    const batchIds = writes.map((write) => write.document.id);
+    let abandoned = false;
+    const controller = typeof AbortController === "function" ? new AbortController() : null;
+    abandonSaveInFlight = () => {
+      abandoned = true;
+      controller?.abort();
+      // Put THIS batch's documents back in the dirty set so whatever replaces
+      // it carries them too — nothing is dropped by abandoning a flight.
+      for (const timelineId of batchIds) dirtyIds.add(timelineId);
       saveInFlight = null;
+      saveInFlightKeepalive = false;
+      saveInFlightIds = [];
+      saveQueued = false;
+      abandonSaveInFlight = null;
+    };
+
+    const settle = () => {
+      // A reset (auth rebind) happened mid-flight, or an unload flush took
+      // this batch over: either way this response belongs to a batch nobody
+      // is waiting on — don't touch the state that replaced it.
+      if (gen !== generation || abandoned) return;
+      saveInFlight = null;
+      saveInFlightKeepalive = false;
+      saveInFlightIds = [];
+      abandonSaveInFlight = null;
       // Trailing batch: edits that landed mid-flight go out now, from the
-      // latest cache — carrying a queued keepalive requirement forward.
+      // latest cache.
       if (saveQueued) {
         saveQueued = false;
-        const keepalive = saveQueuedKeepalive;
-        saveQueuedKeepalive = false;
-        persistBatch(keepalive ? { keepalive: true } : undefined);
+        persistBatch();
       }
     };
 
+    const body = JSON.stringify({ writes });
+    // The keepalive quota is 64 KiB across ALL in-flight keepalive requests,
+    // and a request over it is not merely truncated — the fetch is a network
+    // error, so asking for keepalive on an oversized body GUARANTEES the loss
+    // it was meant to prevent. Splitting isn't an option either: this batch is
+    // all-or-nothing by design. So send it as an ordinary request instead —
+    // best effort, but it still lands whenever the page survives (the
+    // visibilitychange case, most same-tab navigations) — and say so, rather
+    // than failing silently.
+    const overKeepaliveBudget = wantsKeepalive && byteLength(body) > KEEPALIVE_BUDGET_BYTES;
+    if (overKeepaliveBudget) {
+      for (const write of writes) {
+        setError(
+          write.document.id,
+          `"${write.document.title}" is too large to be guaranteed a save while the page closes — keep this tab open until it saves.`,
+        );
+      }
+    }
+
+    saveInFlightIds = batchIds;
+    saveInFlightKeepalive = wantsKeepalive && !overKeepaliveBudget;
     saveInFlight = fetch("/api/timelines/batch", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ writes }),
-      // keepalive lets the request outlive an unloading page (pagehide
-      // flush). Not the default: keepalive bodies are capped (~64KB).
-      ...(options?.keepalive ? { keepalive: true } : {}),
+      body,
+      ...(controller ? { signal: controller.signal } : {}),
+      // keepalive lets the request outlive an unloading page (pagehide flush).
+      // Not the default: it spends the shared 64 KiB quota above.
+      ...(saveInFlightKeepalive ? { keepalive: true } : {}),
     })
       .then(
         async (response) => {
-          if (gen !== generation) return;
+          if (gen !== generation || abandoned) return;
           if (response.ok) {
             const result = (await response.json().catch(() => ({}))) as {
               results?: { id: string; revision: number }[];
@@ -445,7 +528,10 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
           scheduleFlush(SAVE_RETRY_MS);
         },
         (cause: unknown) => {
-          if (gen !== generation) return;
+          // `abandoned` covers the abort we issued ourselves: its documents
+          // are already back in `dirtyIds` and travelling in the replacement
+          // batch, so reporting a failure here would be a lie.
+          if (gen !== generation || abandoned) return;
           // Network failure: same re-queue + slow retry as above.
           for (const write of writes) {
             setError(

--- a/apps/timeline-gstudio001/lib/graph-view-events.ts
+++ b/apps/timeline-gstudio001/lib/graph-view-events.ts
@@ -10,3 +10,28 @@ export const GRAPH_ASSETS_TOGGLE_EVENT = "graph-view:toggle-assets";
 export function isGraphViewRoute(pathname: string): boolean {
   return /^\/timeline\/[^/]+\/graph(\/|$)/.test(pathname);
 }
+
+// The sidebar's tool palette hands off the same way. Dragging a tool onto a
+// strip is a POINTER-only gesture (native HTML5 drag carrying a custom
+// DataTransfer), which left keyboard and assistive-tech users — and touch —
+// with no way to insert anything at all. Activating the tool now appends it
+// to the open timeline through this event; the drag stays as the way to
+// choose a POSITION.
+
+export const GRAPH_INSERT_TOOL_EVENT = "graph-view:insert-tool";
+
+/** The palette tools, mirrored by `isSidebarTool` on the graph side. */
+export type GraphInsertTool = "collection" | "image" | "video";
+
+export type GraphInsertToolDetail = Readonly<{ tool: GraphInsertTool }>;
+
+export function isGraphInsertTool(value: string): value is GraphInsertTool {
+  return value === "collection" || value === "image" || value === "video";
+}
+
+/** Ask the graph view to append a palette tool to the focused collection. */
+export function requestGraphToolInsert(tool: GraphInsertTool): void {
+  window.dispatchEvent(
+    new CustomEvent<GraphInsertToolDetail>(GRAPH_INSERT_TOOL_EVENT, { detail: { tool } }),
+  );
+}

--- a/apps/timeline-gstudio001/lib/timeline-media-client.test.ts
+++ b/apps/timeline-gstudio001/lib/timeline-media-client.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { uploadTimelineMedia } from "./timeline-media-client";
+
+// The upload boundary. `response.json()` is `any`, so the function's
+// `Promise<TimelineMediaUploadResult>` annotation proves nothing about what
+// the network actually returned — these pin the runtime check that does.
+//
+// Image uploads only: the video path calls captureVideoThumbnail, which needs
+// a DOM this node-env suite doesn't have. The parse it feeds is the same.
+
+type MockResponse = {
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+  text: () => Promise<string>;
+};
+
+function response(body: unknown, status = 200): MockResponse {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => (body instanceof Error ? Promise.reject(body) : Promise.resolve(body)),
+    text: () => Promise.resolve(typeof body === "string" ? body : JSON.stringify(body)),
+  };
+}
+
+function stubUpload(result: MockResponse) {
+  vi.stubGlobal("fetch", (() => Promise.resolve(result)) as unknown as typeof fetch);
+}
+
+const png = () => new Blob([new Uint8Array([137, 80, 78, 71])], { type: "image/png" });
+
+describe("uploadTimelineMedia", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the parsed result for a well-formed response", async () => {
+    stubUpload(response({ pathname: "media/a.png", url: "https://cdn.test/a.png" }));
+    await expect(uploadTimelineMedia("a.png", png())).resolves.toEqual({
+      pathname: "media/a.png",
+      url: "https://cdn.test/a.png",
+    });
+  });
+
+  it("keeps optional thumbnail fields when they are present and valid", async () => {
+    stubUpload(
+      response({
+        pathname: "media/a.png",
+        url: "https://cdn.test/a.png",
+        thumbnailPathname: "thumbs/a.jpg",
+        thumbnailUrl: "https://cdn.test/thumbs/a.jpg",
+      }),
+    );
+    await expect(uploadTimelineMedia("a.png", png())).resolves.toMatchObject({
+      thumbnailPathname: "thumbs/a.jpg",
+      thumbnailUrl: "https://cdn.test/thumbs/a.jpg",
+    });
+  });
+
+  // The F4 case: 2xx, parseable JSON, but not a usable upload result. This
+  // used to sail through and build a node with `src: undefined` — which the
+  // reducer ACCEPTS (src is optional), so a sourceless clip committed and
+  // persisted with no error anywhere.
+  it.each([
+    ["missing url", { pathname: "media/a.png" }],
+    ["missing pathname", { url: "https://cdn.test/a.png" }],
+    ["empty url", { pathname: "media/a.png", url: "   " }],
+    ["non-string url", { pathname: "media/a.png", url: 42 }],
+    ["null body", null],
+    ["array body", []],
+    [
+      "present but malformed thumbnail",
+      { pathname: "media/a.png", url: "https://cdn.test/a.png", thumbnailUrl: "" },
+    ],
+  ])("rejects a 2xx response with %s", async (_label, body) => {
+    stubUpload(response(body));
+    await expect(uploadTimelineMedia("a.png", png())).rejects.toThrow(/without a usable url/);
+  });
+
+  it("rejects a 2xx response whose body is not JSON at all", async () => {
+    // A proxy returning an HTML error page with a 200 — .json() itself throws.
+    stubUpload(response(new Error("Unexpected token <")));
+    await expect(uploadTimelineMedia("a.png", png())).rejects.toThrow(/without a usable url/);
+  });
+
+  it("still reports non-2xx responses as upload failures", async () => {
+    stubUpload(response("storage is full", 507));
+    await expect(uploadTimelineMedia("a.png", png())).rejects.toThrow(/Media upload failed/);
+  });
+});
+
+describe("uploadTimelineMedia video thumbnails", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const mp4 = () => new Blob([new Uint8Array([0, 0, 0, 24])], { type: "video/mp4" });
+  const ok = { pathname: "media/a.mp4", url: "https://cdn.test/a.mp4" };
+
+  /** Records the FormData each upload sent. */
+  function stubUploadCapturing(body: unknown = ok) {
+    const bodies: FormData[] = [];
+    vi.stubGlobal("fetch", ((_url: string, init?: RequestInit) => {
+      if (init?.body instanceof FormData) bodies.push(init.body);
+      return Promise.resolve(response(body));
+    }) as unknown as typeof fetch);
+    return bodies;
+  }
+
+  // The F5 property. A supplied thumbnail means the upload must NOT decode
+  // the video itself — the caller already did. This suite runs in a node
+  // environment with no `document`, so an internal decode attempt would
+  // throw: the test passing IS the proof that no second decode happened.
+  it("uses a caller-supplied thumbnail instead of decoding the video again", async () => {
+    const bodies = stubUploadCapturing();
+    const poster = new Blob([new Uint8Array([255, 216])], { type: "image/jpeg" });
+
+    await expect(
+      uploadTimelineMedia("a.mp4", mp4(), undefined, { thumbnail: poster }),
+    ).resolves.toEqual(ok);
+
+    expect(bodies).toHaveLength(1);
+    // FormData re-wraps a Blob as a File, so compare content, not identity.
+    const sent = bodies[0].get("thumbnail");
+    expect(sent).toBeInstanceOf(Blob);
+    expect((sent as Blob).type).toBe("image/jpeg");
+    expect(await (sent as Blob).arrayBuffer()).toEqual(await poster.arrayBuffer());
+    expect(String(bodies[0].get("thumbnailFilename"))).toMatch(/^timeline-thumbnails\/a-thumbnail-/);
+  });
+
+  it("treats a supplied null thumbnail as 'already tried, none available'", async () => {
+    // Present-but-null must still suppress the internal decode — otherwise a
+    // video whose poster capture failed would be decoded a second time here.
+    const bodies = stubUploadCapturing();
+
+    await expect(
+      uploadTimelineMedia("a.mp4", mp4(), undefined, { thumbnail: null }),
+    ).resolves.toEqual(ok);
+
+    expect(bodies[0].get("thumbnail")).toBeNull();
+    expect(bodies[0].get("thumbnailFilename")).toBeNull();
+  });
+
+  it("passes an abort signal through to the request", async () => {
+    const signals: (AbortSignal | undefined)[] = [];
+    vi.stubGlobal("fetch", ((_url: string, init?: RequestInit) => {
+      signals.push(init?.signal ?? undefined);
+      return Promise.resolve(response(ok));
+    }) as unknown as typeof fetch);
+    const controller = new AbortController();
+
+    await uploadTimelineMedia("a.mp4", mp4(), undefined, {
+      thumbnail: null,
+      signal: controller.signal,
+    });
+    expect(signals[0]).toBe(controller.signal);
+  });
+});

--- a/apps/timeline-gstudio001/lib/timeline-media-client.ts
+++ b/apps/timeline-gstudio001/lib/timeline-media-client.ts
@@ -5,6 +5,38 @@ export type TimelineMediaUploadResult = {
   thumbnailUrl?: string;
 };
 
+// A `Promise<TimelineMediaUploadResult>` annotation on a function that returns
+// `response.json()` is a claim, not a check: the value is `any` at runtime and
+// TypeScript is happy. A 2xx response missing `url` used to flow straight into
+// node construction, and because `src` is OPTIONAL on media nodes the add
+// SUCCEEDED — committing and persisting a clip with no source, silently. So
+// the boundary validates.
+
+const nonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0;
+
+/** `null` when the payload isn't a usable upload result. Optional fields must
+ *  be absent or valid — a present-but-malformed thumbnail is a server bug
+ *  worth surfacing, not something to quietly drop. */
+function parseUploadResult(value: unknown): TimelineMediaUploadResult | null {
+  if (typeof value !== "object" || value === null) return null;
+  const candidate = value as Record<string, unknown>;
+  if (!nonEmptyString(candidate.pathname) || !nonEmptyString(candidate.url)) return null;
+  for (const key of ["thumbnailPathname", "thumbnailUrl"] as const) {
+    if (candidate[key] !== undefined && !nonEmptyString(candidate[key])) return null;
+  }
+  return {
+    pathname: candidate.pathname,
+    url: candidate.url,
+    ...(candidate.thumbnailPathname !== undefined
+      ? { thumbnailPathname: candidate.thumbnailPathname as string }
+      : {}),
+    ...(candidate.thumbnailUrl !== undefined
+      ? { thumbnailUrl: candidate.thumbnailUrl as string }
+      : {}),
+  };
+}
+
 function isVideoUpload(filename: string, file: Blob) {
   return file.type.startsWith("video/") || /\.(mp4|webm|mov)$/i.test(filename);
 }
@@ -13,80 +45,164 @@ function sanitizeFilename(value: string) {
   return value.replace(/[^a-zA-Z0-9._-]/g, "-").slice(-120) || `upload-${Date.now()}`;
 }
 
-export async function captureVideoThumbnail(
-  videoBlob: Blob,
-  targetTimeSeconds = 0.35,
-): Promise<Blob | null> {
-  const sourceUrl = URL.createObjectURL(videoBlob);
+// How long ONE media-element step (decode, seek) may hang before we give up.
+// A video element that emits neither its success event nor `error` — a
+// corrupt file, a codec the browser half-supports — otherwise leaves the drop
+// pending forever, with the UI stuck on "Uploading…" and nothing to cancel.
+const VIDEO_PROBE_TIMEOUT_MS = 15_000;
+
+/** Fallback source duration when the element never reports a usable one. */
+const UNKNOWN_VIDEO_SECONDS = 5;
+
+export type VideoProbe = Readonly<{
+  /** Source duration in seconds; `UNKNOWN_VIDEO_SECONDS` when unreadable. */
+  durationSeconds: number;
+  /** Poster frame, or null when it could not be captured. */
+  thumbnail: Blob | null;
+}>;
+
+/**
+ * Settle an event-driven step, but never later than `timeoutMs`, and abandon
+ * it immediately if `signal` aborts. Media element events are the motivating
+ * case: they are not promises and have no built-in way to give up.
+ */
+function settleWithin<T>(
+  executor: (resolve: (value: T) => void, reject: (error: Error) => void) => void,
+  { signal, timeoutMs, label }: { signal?: AbortSignal; timeoutMs: number; label: string },
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const onAbort = () => finish(() => reject(new Error(`${label} was cancelled.`)));
+    const cleanup = () => {
+      if (timer !== undefined) clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+    };
+    function finish(act: () => void) {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      act();
+    }
+
+    if (signal?.aborted) {
+      finish(() => reject(new Error(`${label} was cancelled.`)));
+      return;
+    }
+    signal?.addEventListener("abort", onAbort);
+    timer = setTimeout(
+      () => finish(() => reject(new Error(`${label} timed out after ${timeoutMs}ms.`))),
+      timeoutMs,
+    );
+    executor(
+      (value) => finish(() => resolve(value)),
+      (error) => finish(() => reject(error)),
+    );
+  });
+}
+
+/** Poster frame from an already-decoded, already-seeked video element. */
+async function drawPosterFrame(video: HTMLVideoElement): Promise<Blob | null> {
+  const canvas = document.createElement("canvas");
+  canvas.width = 640;
+  canvas.height = 360;
+  const context = canvas.getContext("2d");
+  if (!context) return null;
+
+  context.fillStyle = "#000";
+  context.fillRect(0, 0, canvas.width, canvas.height);
+
+  const scale = Math.max(
+    canvas.width / Math.max(1, video.videoWidth),
+    canvas.height / Math.max(1, video.videoHeight),
+  );
+  const width = video.videoWidth * scale;
+  const height = video.videoHeight * scale;
+  context.drawImage(video, (canvas.width - width) / 2, (canvas.height - height) / 2, width, height);
+
+  const thumbnail = await new Promise<Blob | null>((resolve) =>
+    canvas.toBlob(resolve, "image/jpeg", 0.78),
+  );
+  return thumbnail && thumbnail.size > 0 ? thumbnail : null;
+}
+
+/**
+ * ONE decode per video: duration AND poster frame come off the same element.
+ *
+ * These used to be two independent loads of the same file — a duration probe
+ * in the drop layer, then a thumbnail capture in here — so every dropped
+ * video was decoded twice, doubling the decoder/blob pressure of a multi-file
+ * drop for no gain.
+ *
+ * Best-effort by design: a video that fails to decode still yields a usable
+ * duration fallback and a null thumbnail, and the caller decides what that
+ * means. The ONE failure it propagates is an abort, because that means the
+ * caller has gone away and should stop.
+ */
+export async function probeVideoFile(
+  file: Blob,
+  options?: { targetTimeSeconds?: number; signal?: AbortSignal },
+): Promise<VideoProbe> {
+  const targetTimeSeconds = options?.targetTimeSeconds ?? 0.35;
+  const signal = options?.signal;
+  const sourceUrl = URL.createObjectURL(file);
   const video = document.createElement("video");
   video.muted = true;
   video.preload = "auto";
   video.playsInline = true;
 
-  const waitForVideoReady = () =>
-    new Promise<void>((resolve, reject) => {
-      if (video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
-        resolve();
-        return;
-      }
-
-      video.addEventListener("loadeddata", () => resolve(), { once: true });
-      video.addEventListener(
-        "error",
-        () => reject(new Error("Could not decode the selected video for thumbnail capture.")),
-        { once: true },
-      );
-    });
-
-  const seekTo = (time: number) =>
-    new Promise<void>((resolve, reject) => {
-      if (
-        Math.abs(video.currentTime - time) < 0.01 &&
-        video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA
-      ) {
-        resolve();
-        return;
-      }
-
-      video.addEventListener("seeked", () => resolve(), { once: true });
-      video.addEventListener(
-        "error",
-        () => reject(new Error("Could not seek the selected video for thumbnail capture.")),
-        { once: true },
-      );
-      video.currentTime = time;
-    });
+  const readDuration = () =>
+    Number.isFinite(video.duration) && video.duration > 0
+      ? video.duration
+      : UNKNOWN_VIDEO_SECONDS;
 
   try {
     video.src = sourceUrl;
-    await waitForVideoReady();
-
-    const duration = Number.isFinite(video.duration) && video.duration > 0 ? video.duration : 1;
-    await seekTo(Math.min(Math.max(0, targetTimeSeconds), Math.max(0, duration - 0.05)));
-
-    const canvas = document.createElement("canvas");
-    canvas.width = 640;
-    canvas.height = 360;
-    const context = canvas.getContext("2d");
-    if (!context) return null;
-
-    context.fillStyle = "#000";
-    context.fillRect(0, 0, canvas.width, canvas.height);
-
-    const scale = Math.max(
-      canvas.width / Math.max(1, video.videoWidth),
-      canvas.height / Math.max(1, video.videoHeight),
+    await settleWithin<void>(
+      (resolve, reject) => {
+        if (video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
+          resolve();
+          return;
+        }
+        video.addEventListener("loadeddata", () => resolve(), { once: true });
+        video.addEventListener(
+          "error",
+          () => reject(new Error("Could not decode the selected video.")),
+          { once: true },
+        );
+      },
+      { signal, timeoutMs: VIDEO_PROBE_TIMEOUT_MS, label: "Video decode" },
     );
-    const width = video.videoWidth * scale;
-    const height = video.videoHeight * scale;
-    context.drawImage(video, (canvas.width - width) / 2, (canvas.height - height) / 2, width, height);
 
-    const thumbnail = await new Promise<Blob | null>((resolve) =>
-      canvas.toBlob(resolve, "image/jpeg", 0.78),
+    const durationSeconds = readDuration();
+    const seekTo = Math.min(
+      Math.max(0, targetTimeSeconds),
+      Math.max(0, durationSeconds - 0.05),
     );
-    return thumbnail && thumbnail.size > 0 ? thumbnail : null;
-  } catch {
-    return null;
+    await settleWithin<void>(
+      (resolve, reject) => {
+        if (
+          Math.abs(video.currentTime - seekTo) < 0.01 &&
+          video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA
+        ) {
+          resolve();
+          return;
+        }
+        video.addEventListener("seeked", () => resolve(), { once: true });
+        video.addEventListener(
+          "error",
+          () => reject(new Error("Could not seek the selected video.")),
+          { once: true },
+        );
+        video.currentTime = seekTo;
+      },
+      { signal, timeoutMs: VIDEO_PROBE_TIMEOUT_MS, label: "Video seek" },
+    );
+
+    return { durationSeconds, thumbnail: await drawPosterFrame(video) };
+  } catch (cause) {
+    if (signal?.aborted) throw cause;
+    return { durationSeconds: readDuration(), thumbnail: null };
   } finally {
     video.removeAttribute("src");
     video.load();
@@ -98,6 +214,17 @@ export async function uploadTimelineMedia(
   filename: string,
   file: Blob,
   folderPath?: string,
+  options?: {
+    /**
+     * A poster frame the caller already captured (via `probeVideoFile`).
+     * When the key is PRESENT — including as `null`, meaning "tried, none
+     * available" — this function does not decode the video itself. That is
+     * what keeps a dropped video to a single decode; callers that omit it
+     * keep the original decode-here behavior.
+     */
+    thumbnail?: Blob | null;
+    signal?: AbortSignal;
+  },
 ): Promise<TimelineMediaUploadResult> {
   const safeFilename = sanitizeFilename(filename);
   const formData = new FormData();
@@ -108,7 +235,10 @@ export async function uploadTimelineMedia(
   }
 
   if (isVideoUpload(safeFilename, file)) {
-    const thumbnail = await captureVideoThumbnail(file);
+    const thumbnail =
+      options && "thumbnail" in options
+        ? (options.thumbnail ?? null)
+        : (await probeVideoFile(file, { signal: options?.signal })).thumbnail;
     if (thumbnail) {
       const baseName = safeFilename.replace(/\.[^/.]+$/, "").slice(0, 90) || "video";
       formData.append("thumbnail", thumbnail);
@@ -122,6 +252,7 @@ export async function uploadTimelineMedia(
   const response = await fetch("/api/timeline-media/upload", {
     method: "POST",
     body: formData,
+    ...(options?.signal ? { signal: options.signal } : {}),
   });
 
   if (!response.ok) {
@@ -129,5 +260,18 @@ export async function uploadTimelineMedia(
     throw new Error(`Media upload failed: ${message}`);
   }
 
-  return response.json();
+  // `.json()` itself rejects on a 2xx body that isn't JSON at all (an HTML
+  // error page from a proxy is the classic one).
+  const payload = await response.json().catch(() => null);
+  const parsed = parseUploadResult(payload);
+  if (!parsed) {
+    // THROWING, not returning a broken result: every caller already wraps
+    // this in a try/catch that turns a failure into a per-file message, and
+    // an upload whose location we can't read has failed in every sense that
+    // matters to them.
+    throw new Error(
+      `Media upload for "${safeFilename}" returned a response without a usable url.`,
+    );
+  }
+  return parsed;
 }

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -316,6 +316,15 @@ async function stripOrder(page: Page, collectionId: string): Promise<string[]> {
     .evaluateAll((els) => els.map((el) => (el as HTMLElement).dataset.nodeId ?? ""));
 }
 
+/** Grid-surface twin of `stripOrder` — the strip locator finds nothing once
+ *  the surface toggle switches to grid. */
+async function gridOrder(page: Page, collectionId: string): Promise<string[]> {
+  return page
+    .locator(`[data-virtual-grid="${collectionId}"]`)
+    .locator("[data-node-id]")
+    .evaluateAll((els) => els.map((el) => (el as HTMLElement).dataset.nodeId ?? ""));
+}
+
 async function openGraph(page: Page): Promise<void> {
   await page.goto(GRAPH_URL);
   await strip(page, PROJECT_ID)
@@ -365,6 +374,7 @@ async function holdDrag(
 }
 
 const undoButton = (page: Page): Locator => page.getByRole("button", { name: /undo/i });
+const redoButton = (page: Page): Locator => page.getByRole("button", { name: /redo/i });
 
 // The sidebar ALSO has an "Assets" button (the drawer-handoff one) — scope
 // to the main region to hit the graph header's own toggles.
@@ -441,6 +451,36 @@ test.describe("graph view E2E", () => {
     await expect
       .poll(() => stripOrder(page, GRANDCHILD_ID), { timeout: 15000 })
       .toEqual(["g1"]);
+  });
+
+  test("a collection id containing a comma is one row, not two broken ones", async ({ page }) => {
+    // The core allows ANY non-whitespace string as a NodeId. The sub-graph
+    // tree used to subscribe to `ids.join(",")` and rebuild the list with
+    // `split(",")`, so an id like this was torn into two ids addressing
+    // nothing — the row would vanish and its strip would never hydrate.
+    const COMMA_ID = "timeline-e2e,comma";
+    const api = await installGraphApi(page);
+    api.documents
+      .get(PROJECT_ID)!
+      .clips.push(collectionClip("clip-comma", COMMA_ID, 3, "Scene Comma", 1));
+    api.documents.set(COMMA_ID, {
+      id: COMMA_ID,
+      title: "Scene Comma",
+      clips: [mediaClip("k1", "image", 0, 4)],
+    });
+
+    await openGraph(page);
+
+    // Exactly one row for it, and it is addressable by its real id.
+    await expect(page.locator('section[aria-label="Sub-timeline: Scene Comma"]')).toHaveCount(1);
+    // The torn ids ("timeline-e2e" / "comma") must not have produced rows.
+    await expect(page.locator('section[aria-label^="Sub-timeline: "]')).toHaveCount(2);
+
+    // And it behaves like any other row: expanding lazy-hydrates its clips.
+    await expandSubGraph(page, "Scene Comma");
+    await expect
+      .poll(() => stripOrder(page, COMMA_ID), { timeout: 15000 })
+      .toEqual(["k1"]);
   });
 
   test("renaming a sub-graph in place persists to the child document title", async ({ page }) => {
@@ -704,8 +744,8 @@ test.describe("graph view E2E", () => {
       "Open to load",
     );
 
-    // Nest alpha into the placeholder (drop dead-center): the persistence
-    // bridge bounces it — undone on the spot with a rejection flash.
+    // Nest alpha into the placeholder (drop dead-center): the commandPolicy
+    // refuses it BEFORE it commits, with a rejection flash.
     await holdDrag(
       page,
       projectStrip.locator('[data-node-id="alpha"]'),
@@ -728,6 +768,65 @@ test.describe("graph view E2E", () => {
     for (const patch of api.patchesFor(PROJECT_ID)) {
       expect(patch.clipIds).toContain("alpha");
     }
+  });
+
+  test("a refused drop leaves the redo branch intact", async ({ page }) => {
+    // The regression behind the pre-commit commandPolicy. The old design let
+    // the drop commit and undid it from the persistence bridge; the commit
+    // cleared the redo branch on its way in, so a refused drop silently ate
+    // the user's redoable work and left ITSELF queued for redo.
+    await installGraphApi(page, { blockChildDocument: true });
+    await openGraph(page);
+    const projectStrip = strip(page, PROJECT_ID);
+
+    // Action A: move alpha to the end, then undo it so A is redoable.
+    await holdDrag(
+      page,
+      projectStrip.locator('[data-node-id="alpha"]'),
+      projectStrip.locator('[data-node-id="charlie"]'),
+      0.85,
+    );
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID))
+      .toEqual(["bravo", CHILD_ID, "charlie", "alpha"]);
+    await undoButton(page).click();
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID))
+      .toEqual(["alpha", "bravo", CHILD_ID, "charlie"]);
+    await expect(redoButton(page)).toBeEnabled();
+
+    // The premise: the child is STILL an un-hydrated placeholder here, after
+    // the drag/undo above. Without this the drop below would be legal and the
+    // test would pass while exercising nothing.
+    await expect(projectStrip.locator(`[data-node-id="${CHILD_ID}"]`)).toContainText(
+      "Open to load",
+    );
+
+    // Now attempt a drop the policy refuses. Must be alpha (index 0, the
+    // same drag the bounce test above proves NESTS) — a node adjacent to the
+    // placeholder resolves dead-center as a same-position no-op instead,
+    // which the reducer rejects for unrelated reasons and would make this
+    // test pass without ever exercising the veto.
+    await holdDrag(
+      page,
+      projectStrip.locator('[data-node-id="alpha"]'),
+      projectStrip.locator(`[data-node-id="${CHILD_ID}"]`),
+      0.5,
+    );
+    // The refusal itself is covered by the bounce test above; here the point
+    // is only that nothing landed (the flash is a 600ms window — too racy to
+    // assert after the extra interactions this test needs).
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID))
+      .toEqual(["alpha", "bravo", CHILD_ID, "charlie"]);
+
+    // A is STILL what redo replays — not the refused drop, and not nothing.
+    await expect(redoButton(page)).toBeEnabled();
+    await redoButton(page).click();
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID))
+      .toEqual(["bravo", CHILD_ID, "charlie", "alpha"]);
+    await expect(redoButton(page)).toBeDisabled();
   });
 
   test("preview mode: playhead with triangle cap, drag-to-scrub, no layout blowout", async ({
@@ -1073,5 +1172,225 @@ test.describe("graph view E2E", () => {
     await expect
       .poll(() => stripOrder(page, PROJECT_ID).then((order) => order.length))
       .toBe(6);
+  });
+
+  test("sidebar tools insert from the KEYBOARD, with no pointer involved", async ({ page }) => {
+    // The palette used to be pointer-only: its tiles were <div role="button">
+    // whose Enter/Space did nothing but show a "drag this" toast, and actual
+    // insertion needed a native drag carrying a custom DataTransfer. Keyboard
+    // and assistive-tech users could not create anything at all.
+    await installGraphApi(page);
+    await openGraph(page);
+
+    const imageTool = page.getByRole("button", { name: /add image clip/i });
+    await expect(imageTool).toBeVisible();
+
+    // Reach it by TABBING — it must be in the focus order, not just clickable.
+    await imageTool.focus();
+    await expect(imageTool).toBeFocused();
+    await page.keyboard.press("Enter");
+
+    // Appended to the end of the focused timeline.
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID))
+      .toEqual(["alpha", "bravo", CHILD_ID, "charlie", expect.stringMatching(/^image-/)]);
+
+    // Space is the other native activation key, and must not be swallowed.
+    await imageTool.focus();
+    await page.keyboard.press(" ");
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID).then((order) => order.length))
+      .toBe(6);
+
+    // It is an ordinary undoable commit, exactly like the drop path.
+    await undoButton(page).click();
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID).then((order) => order.length))
+      .toBe(5);
+
+    // And it persists.
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID).then((order) => order.at(-1)), { timeout: 5000 })
+      .toMatch(/^image-/);
+  });
+
+  test("keyboard insertion works in grid mode, where no drop strip is mounted", async ({
+    page,
+  }) => {
+    // The native-drop wrapper only wraps the STRIP. An accessible control
+    // that silently does nothing on the other surface would be worse than
+    // no control at all, so the insert bridge is mounted for both.
+    await installGraphApi(page);
+    await openGraph(page);
+    await headerToggle(page, "grid").click();
+    await expect(page.locator(`[data-native-drop="${PROJECT_ID}"]`)).toHaveCount(0);
+
+    await page.getByRole("button", { name: /add collection/i }).focus();
+    await page.keyboard.press("Enter");
+
+    await expect
+      .poll(() => gridOrder(page, PROJECT_ID).then((order) => order.at(-1) ?? ""))
+      .toMatch(/^timeline-/);
+  });
+
+  test("a 2xx upload with no usable url adds nothing and says so", async ({ page }) => {
+    // The upload SUCCEEDS as far as HTTP is concerned but the body has no
+    // url. Because `src` is optional on a media node, this used to commit and
+    // persist a sourceless clip with no error shown anywhere.
+    const api = await installGraphApi(page);
+    await page.route("**/api/timeline-media/upload", (route) =>
+      route.fulfill({ json: { pathname: "media/orphan.png" } }),
+    );
+    await openGraph(page);
+    const dropZone = page.locator(`[data-native-drop="${PROJECT_ID}"]`);
+
+    const fileTransfer = await page.evaluateHandle(() => {
+      const transfer = new DataTransfer();
+      transfer.items.add(
+        new File([new Uint8Array([137, 80, 78, 71])], "orphan.png", { type: "image/png" }),
+      );
+      return transfer;
+    });
+    await dropZone.dispatchEvent("drop", { dataTransfer: fileTransfer, clientX: 0 });
+
+    // The failure is surfaced in the drop zone's live region...
+    await expect(page.locator("[data-native-drop-status]")).toContainText(/could not be uploaded/i);
+    // ...and the strip is untouched.
+    expect(await stripOrder(page, PROJECT_ID)).toEqual([
+      "alpha",
+      "bravo",
+      CHILD_ID,
+      "charlie",
+    ]);
+    // Nothing was persisted either.
+    await page.waitForTimeout(1500); // outlast the write debounce
+    expect(api.patchesFor(PROJECT_ID)).toHaveLength(0);
+  });
+
+  test("a drop larger than the concurrency limit keeps file order", async ({ page }) => {
+    // The pipeline no longer runs every file at once — it runs a bounded pool
+    // (MAX_CONCURRENT_MEDIA = 3). Completion order therefore differs from
+    // input order, and the nodes must still be added in FILE order. Staggered
+    // upload latency makes the difference observable: without order-preserving
+    // collection, the slow first file would land last.
+    await installGraphApi(page);
+    let seen = 0;
+    let inFlight = 0;
+    let peakInFlight = 0;
+    await page.route("**/api/timeline-media/upload", async (route) => {
+      const index = seen++;
+      inFlight += 1;
+      peakInFlight = Math.max(peakInFlight, inFlight);
+      // First file is the slowest, so a completion-ordered result would
+      // reverse it to the end.
+      await new Promise((resolve) => setTimeout(resolve, index === 0 ? 400 : 20));
+      inFlight -= 1;
+      return route.fulfill({
+        json: { pathname: `p-${index}.png`, url: `${PIXEL}#file-${index}` },
+      });
+    });
+    await openGraph(page);
+    const dropZone = page.locator(`[data-native-drop="${PROJECT_ID}"]`);
+
+    const fileTransfer = await page.evaluateHandle(() => {
+      const transfer = new DataTransfer();
+      for (const name of ["f0.png", "f1.png", "f2.png", "f3.png", "f4.png"]) {
+        transfer.items.add(
+          new File([new Uint8Array([137, 80, 78, 71])], name, { type: "image/png" }),
+        );
+      }
+      return transfer;
+    });
+    // clientX 0 = insert before the first card, so the batch leads the strip.
+    await dropZone.dispatchEvent("drop", { dataTransfer: fileTransfer, clientX: 0 });
+
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID).then((order) => order.length), { timeout: 15000 })
+      .toBe(9);
+
+    // The five new cards lead the strip, and their names are in file order.
+    const names = await strip(page, PROJECT_ID)
+      .locator("[data-node-id]")
+      .evaluateAll((els) => els.map((el) => el.getAttribute("aria-label") ?? ""));
+    expect(names.slice(0, 5)).toEqual(["f0.png", "f1.png", "f2.png", "f3.png", "f4.png"]);
+
+    // And the pool was actually bounded — this is the half that `Promise.all`
+    // would fail, since it preserves order but starts all five at once.
+    expect(peakInFlight).toBeLessThanOrEqual(3);
+    expect(seen).toBe(5);
+  });
+
+  test("dragover measures once per drag session, not once per event", async ({ page }) => {
+    // Every accepted dragover used to call getBoundingClientRect on the
+    // wrapper AND every mounted card, then setState — forcing layout at the
+    // event rate. Geometry is now measured once per session and the indicator
+    // is resolved at most once per frame.
+    await page.addInitScript(() => {
+      const original = Element.prototype.getBoundingClientRect;
+      (window as unknown as { __rectCalls: number }).__rectCalls = 0;
+      Element.prototype.getBoundingClientRect = function patched() {
+        (window as unknown as { __rectCalls: number }).__rectCalls += 1;
+        return original.call(this);
+      };
+    });
+    await installGraphApi(page);
+    await openGraph(page);
+    const dropZone = page.locator(`[data-native-drop="${PROJECT_ID}"]`);
+    const box = (await dropZone.boundingBox())!;
+
+    const EVENTS = 40;
+    const measured = await page.evaluate(
+      async ({ count, left, width }) => {
+        const zone = document.querySelector("[data-native-drop]");
+        if (!zone) throw new Error("no drop zone");
+        const transfer = new DataTransfer();
+        transfer.setData("application/x-gstudio-type", "image");
+
+        const win = window as unknown as { __rectCalls: number };
+        win.__rectCalls = 0;
+        for (let i = 0; i < count; i++) {
+          zone.dispatchEvent(
+            new DragEvent("dragover", {
+              dataTransfer: transfer,
+              bubbles: true,
+              cancelable: true,
+              clientX: left + (width * i) / count,
+              clientY: 0,
+            }),
+          );
+        }
+        // Let the coalescing frame(s) run.
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+        return win.__rectCalls;
+      },
+      { count: EVENTS, left: box.x, width: box.width },
+    );
+
+    // One pass over a 4-card strip is ~5 reads. The old path did that per
+    // event (~200 for 40 events); anything at or below one-per-event is a
+    // decisive separation while leaving room for unrelated app measurement.
+    expect(measured).toBeLessThan(EVENTS);
+
+    // And it still works: the indicator is showing.
+    await expect(page.locator("[data-native-drop-indicator]")).toHaveCount(1);
+  });
+
+  test("sidebar tools are still drag sources after becoming real buttons", async ({ page }) => {
+    // Adding the keyboard path must not cost the pointer one. Playwright's
+    // synthetic mouse cannot drive a native HTML5 drag, so this asserts the
+    // next best thing: the element is still draggable and its dragstart
+    // still loads the DataTransfer the drop zone reads.
+    await installGraphApi(page);
+    await openGraph(page);
+
+    const imageTool = page.getByRole("button", { name: /add image clip/i });
+    await expect(imageTool).toHaveAttribute("draggable", "true");
+
+    const carried = await imageTool.evaluate((el) => {
+      const transfer = new DataTransfer();
+      el.dispatchEvent(new DragEvent("dragstart", { dataTransfer: transfer, bubbles: true }));
+      return transfer.getData("application/x-gstudio-type");
+    });
+    expect(carried).toBe("image");
   });
 });

--- a/docs/storyboard-graph-architecture.md
+++ b/docs/storyboard-graph-architecture.md
@@ -231,11 +231,20 @@ replacement, never by big-bang rewrite.
    un-hydrated collections are handled by two cooperating layers: every
    VISIBLE placeholder collection hydrates eagerly (the focused timeline's
    children plus the grandchild cards inside their strips — the working set
-   stays view-bounded), and the persistence bridge BOUNCES the residual
-   race (`collectUnhydratedDropTargets` → `store.undo()` + rejection flash
-   + announcement) so content can never land in, or overwrite, a document
-   whose clips haven't loaded. Writes additionally refuse any collection
-   with `hydrated: false`.
+   stays view-bounded), and the residual race is REFUSED BEFORE IT COMMITS
+   by the store's `commandPolicy`
+   (`collectUnhydratedDropTargets(command, details)` → `blocked-by-policy`
+   + rejection flash + announcement) so content can never land in, or
+   overwrite, a document whose clips haven't loaded. Writes additionally
+   refuse any collection with `hydrated: false`.
+
+   The veto is deliberately PRE-commit. An earlier design let the drop
+   commit and had the persistence bridge undo it back out; that reverts the
+   graph but not the history, because pushing a command clears the redo
+   branch. A bounced drop therefore discarded whatever the user still had
+   to redo and left the refused command itself sitting on the redo stack.
+   Any future application-level gate belongs in the same policy seam, not
+   in a post-commit subscriber.
 3. **Eviction:** whether far-from-focus subtrees are ever de-hydrated, or
    memory is allowed to grow monotonically per session (likely fine at
    storyboard scale; decide explicitly).

--- a/packages/timeline-domain/src/adapter.test.ts
+++ b/packages/timeline-domain/src/adapter.test.ts
@@ -308,16 +308,10 @@ describe("collectUnhydratedDropTargets", () => {
     expect(
       collectUnhydratedDropTargets(
         {
-          type: "nodes-moved",
-          moves: [
-            {
-              nodeId: parseNodeId("img-1"),
-              fromParentId: parseNodeId("focus-root"),
-              fromIndex: 0,
-              toParentId: parseNodeId("grandchild"),
-              toIndex: 0,
-            },
-          ],
+          type: "move-nodes",
+          nodeIds: [parseNodeId("img-1")],
+          toParentId: parseNodeId("grandchild"),
+          toIndex: 0,
         },
         details,
       ),
@@ -326,47 +320,30 @@ describe("collectUnhydratedDropTargets", () => {
     expect(
       collectUnhydratedDropTargets(
         {
-          type: "nodes-added",
-          adds: [
-            {
-              parentId: parseNodeId("grandchild"),
-              index: 0,
-              node: { id: parseNodeId("new-1"), kind: "media", name: "New", durationSeconds: 2 },
-            },
-          ],
+          type: "add-nodes",
+          nodes: [{ id: parseNodeId("new-1"), kind: "media", name: "New", durationSeconds: 2 }],
+          toParentId: parseNodeId("grandchild"),
+          toIndex: 0,
         },
         details,
       ),
     ).toEqual(["grandchild"]);
   });
 
-  it("passes hydrated destinations, roots without details, and non-placing patches", () => {
+  it("passes hydrated destinations, roots without details, and non-placing commands", () => {
     const result = buildFocusedGraph(DOCUMENTS, "focus-root");
     if (!result.ok) throw new Error(result.error);
-    const { graph, details } = result.value;
+    const { details } = result.value;
 
     // "child" is hydrated: true; "focus-root" has no detail entry at all —
     // both are legitimate destinations.
     expect(
       collectUnhydratedDropTargets(
         {
-          type: "nodes-moved",
-          moves: [
-            {
-              nodeId: parseNodeId("img-1"),
-              fromParentId: parseNodeId("focus-root"),
-              fromIndex: 0,
-              toParentId: parseNodeId("child"),
-              toIndex: 0,
-            },
-            {
-              nodeId: parseNodeId("c-img"),
-              fromParentId: parseNodeId("child"),
-              fromIndex: 0,
-              toParentId: parseNodeId("focus-root"),
-              toIndex: 0,
-            },
-          ],
+          type: "move-nodes",
+          nodeIds: [parseNodeId("img-1")],
+          toParentId: parseNodeId("child"),
+          toIndex: 0,
         },
         details,
       ),
@@ -375,14 +352,21 @@ describe("collectUnhydratedDropTargets", () => {
     expect(
       collectUnhydratedDropTargets(
         {
-          type: "nodes-updated",
-          updates: [
-            {
-              nodeId: parseNodeId("vid-1"),
-              before: graph.nodesById.get(parseNodeId("vid-1"))!,
-              after: graph.nodesById.get(parseNodeId("vid-1"))!,
-            },
-          ],
+          type: "move-nodes",
+          nodeIds: [parseNodeId("c-img")],
+          toParentId: parseNodeId("focus-root"),
+          toIndex: 0,
+        },
+        details,
+      ),
+    ).toEqual([]);
+
+    expect(
+      collectUnhydratedDropTargets(
+        {
+          type: "update-media",
+          nodeId: parseNodeId("vid-1"),
+          update: { mediaKind: "video", trimInSeconds: 1 },
         },
         details,
       ),

--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -40,6 +40,7 @@ import {
   getChildren,
   mediaDurationSeconds,
   parseNodeId,
+  type CollectionsCommand,
   type CollectionsGraph,
   type CollectionsPatch,
   type GraphNodeSpec,
@@ -379,36 +380,30 @@ export function graphChildrenToClips(
 }
 
 /**
- * The destination collections of a committed patch that are still
+ * The destination collections of a PROPOSED command that are still
  * UN-hydrated placeholders — their stored clips haven't loaded, so letting
  * content land in them both blocks their future hydration (the engine
  * refuses to fill a non-empty collection) and, worse, would let the
  * patch-scoped write overwrite the stored document with only the new
- * content. Apps use this to enforce the gate-until-hydrated policy: revert
- * (undo) a command whose destination appears here.
+ * content.
+ *
+ * This reads the COMMAND, not the resulting patch, because the gate has to
+ * be a pre-commit veto (`commandPolicy`). Reverting after the fact by
+ * undoing is not equivalent: the commit has already discarded the redo
+ * branch by then. A command carries a single `toParentId`, so this is also
+ * strictly simpler than the patch it would have produced.
+ *
+ * Unknown ids are ALLOWED — only an explicit `hydrated: false` blocks. A
+ * collection nobody has recorded details for is not a known placeholder.
  */
 export function collectUnhydratedDropTargets(
-  patch: CollectionsPatch,
+  command: CollectionsCommand,
   details: DetailsById,
 ): readonly string[] {
-  const unhydrated = (id: NodeId) => details[id as string]?.hydrated === false;
-  const ids = new Set<string>();
-  switch (patch.type) {
-    case "nodes-moved":
-      for (const move of patch.moves) {
-        if (unhydrated(move.toParentId)) ids.add(move.toParentId as string);
-      }
-      break;
-    case "nodes-added":
-      for (const add of patch.adds) {
-        if (unhydrated(add.parentId)) ids.add(add.parentId as string);
-      }
-      break;
-    // nodes-removed / nodes-updated place nothing anywhere.
-    default:
-      break;
-  }
-  return [...ids];
+  // update-media places nothing anywhere; it only re-trims in place.
+  if (command.type === "update-media") return [];
+  const target = command.toParentId as string;
+  return details[target]?.hydrated === false ? [target] : [];
 }
 
 /**

--- a/packages/timeline-domain/src/engine.ts
+++ b/packages/timeline-domain/src/engine.ts
@@ -13,6 +13,7 @@ export {
   mediaDurationSeconds,
   parseNodeId,
   type CollectionItemNode,
+  type CollectionsCommand,
   type CollectionsGraph,
   type CollectionsPatch,
   type GraphNodeSpec,

--- a/packages/ui/dnd-collections/API.md
+++ b/packages/ui/dnd-collections/API.md
@@ -237,6 +237,9 @@ Rejections (`CommandRejection.reason`):
 | `invalid-media-update` | (update-media) The payload's `mediaKind` doesn't match the node, or it carries non-finite values. |
 | `nothing-to-add` | `add-nodes` with an empty `nodes` array. |
 | `invalid-index` | `toIndex` is not an integer (NaN/±Infinity splice at 0; a fraction desyncs forward apply from patch replay). |
+
+`store.dispatch` can additionally refuse with `blocked-by-policy`, which the
+reducer never produces — see `commandPolicy` below.
 | `would-create-cycle` | A node would move into itself or its own descendant. |
 | `nothing-to-move` | Every dragged id was pruned (all descendants of other dragged ids). |
 | `same-position` | The command would leave the graph identical (a move that lands where it started, or a trim to the current value) — a no-op, nothing pushed to history. |
@@ -533,7 +536,20 @@ type DndCollectionsProps = {
   trimRequiresSelection?: boolean;       // default false; true = trim handles (hit zones
                                          // included) exist only on SELECTED media cards, and
                                          // content's trimEnabled follows
+  commandPolicy?: CommandPolicy;         // pre-commit application veto, consulted on EVERY
+                                         // dispatch (drop, keyboard move, trash, palette add)
   children: ReactNode;
+};
+
+type CommandPolicy = (
+  command: CollectionsCommand,
+  graph: CollectionsGraph          // the CURRENT committed graph
+) => CommandPolicyRejection | null; // null = allow
+
+type CommandPolicyRejection = {
+  reason: "blocked-by-policy";
+  blockedIds: readonly NodeId[];   // what the policy blames, for cues/telemetry
+  message?: string;                // announced on the package's aria-live channel
 };
 ```
 
@@ -553,6 +569,21 @@ press there clicks or drags, never trims. Interaction-test coverage lives in
 `maxHistoryEntries` is initial-only (like `initialGraph`): the oldest undo
 entries fall off past the cap. Any non-positive-integer value is treated as
 unbounded.
+
+`commandPolicy` is the seam for rules the pure reducer can't express —
+application state it has no access to, such as "this collection's contents
+haven't loaded yet, so don't accept drops into it." It runs inside `dispatch`
+BEFORE the reducer, so a refused command mutates nothing, pushes no history
+entry, and emits nothing on the change feed; `dispatch` returns the rejection
+and the package flashes the involved cards and announces `message`. Undo and
+redo bypass it (they replay commands the policy already accepted).
+
+Do **not** implement such a gate by letting the command commit and undoing it
+from an `onChange`/`subscribeToChanges` subscriber. That reverts the graph but
+corrupts history: pushing a command clears the redo branch, so the bounce
+discards the user's redoable work and leaves the refused command itself on the
+redo stack. Read the policy's live source at call time rather than closing over
+render-time state.
 
 Creates one store per component lifetime and wires the full dnd-kit stack:
 PointerSensor (4px activation distance) + KeyboardSensor, pointer-priority
@@ -631,7 +662,7 @@ type CollectionsChange = {
 | `getSnapshot` | `() => CollectionsSnapshot` | Snapshot identity changes per notify; FIELD identities change only when the field did. |
 | `subscribe` | `(listener: () => void) => () => void` | Returns unsubscribe. |
 | `subscribeToChanges` | `(listener: (change: CollectionsChange) => void) => () => void` | The committed-change feed as a multi-listener seam — same events and ordering as the `onChange` option. For consumers that need the PATCH of a commit (e.g. `VirtualStrip` resizes exactly the slots a `nodes-updated` patch touched). Fires for dispatch/undo/redo; `replaceGraph` and `hydrate` emit nothing. |
-| `dispatch` | `(command) => Result<CollectionsPatch, CommandRejection>` | Reduce + push history + notify + `onChange`. |
+| `dispatch` | `(command) => Result<CollectionsPatch, DispatchRejection>` | Consult `commandPolicy` → reduce + push history + notify + `onChange`. A policy veto returns `{ reason: "blocked-by-policy", blockedIds, message? }` and short-circuits BEFORE the reducer: no graph change, no history entry, no change event. |
 | `undo` / `redo` | `() => boolean` | False when the respective stack is empty. |
 | `replaceGraph` | `(graph: CollectionsGraph) => Result<void, GraphValidationError>` | Runtime-validates then swaps the committed graph wholesale — the escape hatch for async/server-loaded data (`initialGraph` is initial-only). Invalid input is rejected without changing or notifying the store. A successful swap clears undo/redo history (old patches can't replay on a new graph) and any in-progress drag/preview, prunes the selection to surviving ids, and — deliberately — does NOT fire `onChange` (the caller supplied this state; echoing it risks feedback loops). |
 | `hydrate` | `(collectionId: NodeId, children: readonly GraphNodeSpec[]) => Result<void, HydrateRejection>` | `replaceGraph`'s incremental sibling for hydrate-on-focus: fills an EMPTY collection via `hydrateCollection`. Undo/redo SURVIVES (only adds, under a childless collection — every history patch stays replayable), interaction state is untouched, and — like `replaceGraph` — nothing is emitted on `onChange`/`subscribeToChanges` (IO landing, not user intent). Snapshot subscribers are notified; data-sized `VirtualStrip`s detect the feed-less graph change and re-measure on their own. Rejections return without notifying. |

--- a/packages/ui/dnd-collections/ARCHITECTURE.md
+++ b/packages/ui/dnd-collections/ARCHITECTURE.md
@@ -116,6 +116,9 @@ resolveCommandFromIntent ──────────────────�
       ▼
 CollectionsCommand ("move-nodes")
       │
+      ├──► commandPolicy(command, graph)  ← optional consumer veto, PRE-commit
+      │      returns a rejection ⇒ stop here: no graph change, no history
+      │      entry, no change event (see "Application policy" below)
       ▼
 applyCommand (core/commands.ts)          ← the ONLY reducer
       │  validates: missing-node, duplicate-node-id, cannot-move-root,
@@ -296,6 +299,26 @@ that must clear history):
   (`collection-not-empty`) — merging into populated collections is app
   policy the engine refuses to guess at. Id collisions with the host graph
   are rejected before anything merges.
+
+### Application policy: vetoes belong BEFORE the commit
+
+The reducer validates graph-level truths (does the node exist, would this
+create a cycle). It cannot see application state — most importantly whether a
+placeholder collection's document has actually loaded. That gate is the
+optional `commandPolicy` the provider forwards to the store: it runs inside
+`dispatch`, before `applyCommand`, and a rejection stops the pipeline dead.
+The consumer gets a typed `blocked-by-policy` rejection back and the package
+flashes the involved cards and announces the policy's message.
+
+It has to be pre-commit, and the reason is not stylistic. The obvious
+alternative — let the command commit, inspect the resulting patch in an
+`onChange` subscriber, call `store.undo()` if it violates policy — restores
+the graph but silently corrupts history. `history.push` clears the redo
+branch, so by the time the subscriber runs, whatever the user had left to
+redo is already gone; the undo then pushes the REFUSED command onto the redo
+stack, where redoing it replays the very move that was just rejected. The
+graph looks right and the history is wrong, which is the worst shape a bug
+can take. If a new rule needs to refuse a command, it goes in the policy.
 
 ## The efficiency story
 

--- a/packages/ui/dnd-collections/CLAUDE.md
+++ b/packages/ui/dnd-collections/CLAUDE.md
@@ -34,6 +34,11 @@ Repo-wide rules live in the root CLAUDE.md and `packages/ui/AGENTS.md`.
   `resolveKeyboardCommand` do that math; don't reimplement it elsewhere.
 - **Roots are unmovable** (`cannot-move-root`); `rootIds` is not part of the
   patch model.
+- **A refused command never enters history.** Application gates go through
+  the store's pre-commit `commandPolicy`, never through "commit, inspect in
+  an `onChange` subscriber, `store.undo()` it back out" — that reverts the
+  graph but clears the user's redo branch and leaves the refused command
+  itself redoable. See ARCHITECTURE.md § "Application policy".
 - **Snapshot-field identity is a contract.** Store snapshot fields keep
   their reference unless they actually changed (see the cached
   `historyEntries` — `history.entries()` allocates per call and must not run

--- a/packages/ui/dnd-collections/index.ts
+++ b/packages/ui/dnd-collections/index.ts
@@ -97,6 +97,9 @@ export {
   type CollectionsInteraction,
   type CollectionsSnapshot,
   type CollectionsStore,
+  type CommandPolicy,
+  type CommandPolicyRejection,
+  type DispatchRejection,
 } from "./react/collections-store";
 export { DndCollections, type DndCollectionsProps } from "./react/DndCollections";
 export {

--- a/packages/ui/dnd-collections/react/DndCollections.tsx
+++ b/packages/ui/dnd-collections/react/DndCollections.tsx
@@ -44,6 +44,7 @@ import {
   useCollectionsStore,
   type CollectionsChange,
   type CollectionsStore,
+  type CommandPolicy,
 } from "./collections-store";
 import {
   CollectionsComponentsContext,
@@ -124,6 +125,14 @@ export type DndCollectionsProps = Readonly<{
    * handles.
    */
   trimRequiresSelection?: boolean;
+  /**
+   * Pre-commit application veto (see `CommandPolicy`). Consulted on EVERY
+   * dispatch — pointer drop, keyboard move, trash, palette add — so a rule
+   * the pure reducer cannot express ("that collection is still loading") is
+   * enforced in one place, before anything commits. Blocked commands are
+   * announced with the rejection's `message`.
+   */
+  commandPolicy?: CommandPolicy;
   children: ReactNode;
 }>;
 
@@ -190,6 +199,7 @@ export function DndCollections({
   onOpenNode,
   openOnClick,
   trimRequiresSelection,
+  commandPolicy,
   children,
 }: DndCollectionsProps) {
   const componentsValue = useCollectionsComponentsValue(components);
@@ -213,16 +223,23 @@ export function DndCollections({
   // alternative is a render-phase ref write, which is unsound under
   // concurrent rendering.
   const onChangeRef = useRef(onChange);
+  const commandPolicyRef = useRef(commandPolicy);
   useLayoutEffect(() => {
     onChangeRef.current = onChange;
+    commandPolicyRef.current = commandPolicy;
   });
 
   // One store per component lifetime; the graph prop and history cap are
   // intentionally initial-only (the store is the source of truth thereafter).
+  // `commandPolicy` rides the same ref indirection as `onChange` (and inherits
+  // its documented staleness limit) — a policy should read its live source at
+  // call time rather than closing over render-time state, which makes the
+  // closure's identity irrelevant.
   const [store] = useState<CollectionsStore>(() =>
     createCollectionsStore(initialGraph, {
       onChange: (change) => onChangeRef.current?.(change),
       maxHistoryEntries,
+      commandPolicy: (command, graph) => commandPolicyRef.current?.(command, graph) ?? null,
     })
   );
   useEffect(() => () => store.destroy(), [store]);
@@ -528,6 +545,13 @@ function DndCollectionsContext({
       if (dispatched.error.reason === "would-create-cycle") {
         store.flashRejection(activeIds);
         announce("Cannot move a collection into itself or one of its nested collections.");
+        return;
+      }
+      if (dispatched.error.reason === "blocked-by-policy") {
+        // Refused before it committed, so the cards never moved — the flash
+        // is the whole visible feedback.
+        store.flashRejection(activeIds);
+        if (dispatched.error.message) announce(dispatched.error.message);
         return;
       }
       if (dispatched.error.reason === "same-position") {

--- a/packages/ui/dnd-collections/react/collections-store.test.ts
+++ b/packages/ui/dnd-collections/react/collections-store.test.ts
@@ -320,6 +320,136 @@ describe("createCollectionsStore", () => {
     expect(store.undo()).toBe(false); // stack exhausted
   });
 
+  // The commandPolicy contract. These pin WHY the guard is pre-commit: the
+  // "just undo it back out" alternative passes a naive graph assertion but
+  // corrupts history, which is exactly the bug this seam replaced.
+  test("a policy-blocked command never reaches the graph, history, or the change feed", () => {
+    const changes: CollectionsChange[] = [];
+    const store = createCollectionsStore(graphFixture(), {
+      onChange: (c) => changes.push(c),
+      commandPolicy: (command) =>
+        command.type === "move-nodes" && command.toParentId === id("root-b")
+          ? { reason: "blocked-by-policy", blockedIds: [id("root-b")], message: "Still loading." }
+          : null,
+    });
+
+    const result = store.dispatch(moveX);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected the policy to block the move");
+    expect(result.error.reason).toBe("blocked-by-policy");
+    if (result.error.reason !== "blocked-by-policy") throw new Error("narrowing");
+    expect(result.error.message).toBe("Still loading.");
+    expect(result.error.blockedIds).toEqual([id("root-b")]);
+
+    const snapshot = store.getSnapshot();
+    expect([...(snapshot.graph.childrenById.get(id("root-a")) ?? [])]).toEqual(["x", "y", "z"]);
+    expect([...(snapshot.graph.childrenById.get(id("root-b")) ?? [])]).toEqual([]);
+    expect(snapshot.canUndo).toBe(false);
+    expect(snapshot.historyEntries).toHaveLength(0);
+    expect(changes).toHaveLength(0);
+  });
+
+  test("the post-commit bounce this replaced DOES corrupt history (why the policy is pre-commit)", () => {
+    // Not a feature — an executable record of the hazard. If someone
+    // reintroduces "commit, inspect in a subscriber, undo it back out",
+    // this is what they get.
+    const store = createCollectionsStore(graphFixture());
+    let bouncing = false;
+    const unsubscribe = store.subscribeToChanges((change) => {
+      if (bouncing && change.origin === "command") store.undo();
+    });
+
+    store.dispatch(moveX); // action A
+    store.undo(); // A is now redoable
+    expect(store.getSnapshot().canRedo).toBe(true);
+
+    bouncing = true;
+    store.dispatch({
+      type: "move-nodes",
+      nodeIds: [id("y")],
+      toParentId: id("root-b"),
+      toIndex: 0,
+    });
+
+    // The graph looks correct — y bounced straight back out...
+    expect([...(store.getSnapshot().graph.childrenById.get(id("root-b")) ?? [])]).toEqual([]);
+    // ...but redo now replays the REFUSED move, not A. That is the bug.
+    bouncing = false;
+    expect(store.getSnapshot().canRedo).toBe(true);
+    store.redo();
+    expect([...(store.getSnapshot().graph.childrenById.get(id("root-b")) ?? [])]).toEqual(["y"]);
+    unsubscribe();
+  });
+
+  test("a policy-blocked command preserves an existing redo branch", () => {
+    // The regression: perform A, undo it (A is now redoable), then attempt a
+    // blocked drop. Committing-then-undoing would clear the redo branch and
+    // leave the REFUSED command redoable in A's place.
+    let blocking = false;
+    const store = createCollectionsStore(graphFixture(), {
+      commandPolicy: () =>
+        blocking ? { reason: "blocked-by-policy", blockedIds: [id("root-b")] } : null,
+    });
+
+    store.dispatch(moveX); // action A
+    expect(store.undo()).toBe(true);
+    expect(store.getSnapshot().canRedo).toBe(true);
+
+    blocking = true;
+    const blocked = store.dispatch({
+      type: "move-nodes",
+      nodeIds: [id("y")],
+      toParentId: id("root-b"),
+      toIndex: 0,
+    });
+    expect(blocked.ok).toBe(false);
+
+    // A is still the redoable entry, and redoing it replays A — not the
+    // move that was just refused.
+    expect(store.getSnapshot().canRedo).toBe(true);
+    blocking = false;
+    expect(store.redo()).toBe(true);
+    expect([...(store.getSnapshot().graph.childrenById.get(id("root-b")) ?? [])]).toEqual(["x"]);
+    expect(store.getSnapshot().canRedo).toBe(false);
+  });
+
+  test("the policy sees the current committed graph and can allow selectively", () => {
+    const seen: string[] = [];
+    const store = createCollectionsStore(graphFixture(), {
+      commandPolicy: (command, graph) => {
+        seen.push([...(graph.childrenById.get(id("root-b")) ?? [])].join("|"));
+        return null;
+      },
+    });
+
+    expect(store.dispatch(moveX).ok).toBe(true);
+    expect(
+      store.dispatch({
+        type: "move-nodes",
+        nodeIds: [id("y")],
+        toParentId: id("root-b"),
+        toIndex: 1,
+      }).ok
+    ).toBe(true);
+    // Second call observed the graph AFTER the first commit — the policy is
+    // handed live state, not the graph the store was created with.
+    expect(seen).toEqual(["", "x"]);
+  });
+
+  test("undo and redo bypass the policy — they replay already-accepted commands", () => {
+    let blocking = false;
+    const store = createCollectionsStore(graphFixture(), {
+      commandPolicy: () =>
+        blocking ? { reason: "blocked-by-policy", blockedIds: [id("root-b")] } : null,
+    });
+    store.dispatch(moveX);
+
+    blocking = true;
+    expect(store.undo()).toBe(true);
+    expect(store.redo()).toBe(true);
+    expect([...(store.getSnapshot().graph.childrenById.get(id("root-b")) ?? [])]).toEqual(["x"]);
+  });
+
   test("replaceGraph swaps the graph, clears history, prunes selection, resets drag, and is silent", () => {
     const changes: CollectionsChange[] = [];
     const store = createCollectionsStore(graphFixture(), { onChange: (c) => changes.push(c) });

--- a/packages/ui/dnd-collections/react/collections-store.ts
+++ b/packages/ui/dnd-collections/react/collections-store.ts
@@ -61,6 +61,43 @@ export type CollectionsChange = Readonly<{
   origin: "command" | "undo" | "redo";
 }>;
 
+/**
+ * Rejection produced by a `commandPolicy` — kept OUT of the core's
+ * `CommandRejection` union because the reducer never produces it: it is an
+ * application veto, not a graph-validity failure.
+ */
+export type CommandPolicyRejection = Readonly<{
+  reason: "blocked-by-policy";
+  /** Ids the policy blames (e.g. the collections that refused the drop). */
+  blockedIds: readonly NodeId[];
+  /** Consumer-authored explanation, suitable for announcing to assistive tech. */
+  message?: string;
+}>;
+
+/**
+ * A consumer veto consulted BEFORE the reducer runs — the seam for
+ * APPLICATION policy the pure command layer cannot know about ("this
+ * collection's clips haven't loaded yet, so don't accept drops into it").
+ * Return `null` to allow the command, or a rejection to block it.
+ *
+ * Must be a pure predicate over the command and the CURRENT committed graph;
+ * it runs inside `dispatch`, so it must not dispatch reentrantly.
+ *
+ * This exists instead of the obvious "commit, inspect, undo if invalid"
+ * because that sequence is NOT a no-op. `history.push` discards the redo
+ * branch, so bouncing a drop that way destroys whatever the user had left to
+ * redo AND leaves the refused command itself sitting on the redo stack,
+ * ready to replay the very move that was just rejected. A refused command
+ * must never reach history — which means it must never reach the reducer.
+ */
+export type CommandPolicy = (
+  command: CollectionsCommand,
+  graph: CollectionsGraph
+) => CommandPolicyRejection | null;
+
+/** Everything `dispatch` can refuse with: reducer rejections plus a policy veto. */
+export type DispatchRejection = CommandRejection | CommandPolicyRejection;
+
 /** Thrown when store construction receives a malformed normalized graph. */
 export class InvalidInitialGraphError extends Error {
   readonly validationError: GraphValidationError;
@@ -89,7 +126,7 @@ export type CollectionsStore = Readonly<{
    */
   subscribeToChanges: (listener: (change: CollectionsChange) => void) => () => void;
 
-  dispatch: (command: CollectionsCommand) => Result<CollectionsPatch, CommandRejection>;
+  dispatch: (command: CollectionsCommand) => Result<CollectionsPatch, DispatchRejection>;
   undo: () => boolean;
   redo: () => boolean;
   /**
@@ -147,6 +184,8 @@ export function createCollectionsStore(
     onChange?: (change: CollectionsChange) => void;
     /** Cap the undo stack (oldest entries fall off). Positive integer; default unbounded. */
     maxHistoryEntries?: number;
+    /** Pre-commit application veto — see `CommandPolicy`. */
+    commandPolicy?: CommandPolicy;
   }>
 ): CollectionsStore {
   const initialValidation = validateGraph(initialGraph);
@@ -167,6 +206,7 @@ export function createCollectionsStore(
   const listeners = new Set<() => void>();
   const changeListeners = new Set<(change: CollectionsChange) => void>();
   const onChange = options?.onChange;
+  const commandPolicy = options?.commandPolicy;
   const pendingChanges: CollectionsChange[] = [];
   let notificationDepth = 0;
   let emittingChanges = false;
@@ -252,7 +292,13 @@ export function createCollectionsStore(
 
   function dispatch(
     command: CollectionsCommand
-  ): Result<CollectionsPatch, CommandRejection> {
+  ): Result<CollectionsPatch, DispatchRejection> {
+    // Pre-commit veto, BEFORE the reducer: a refused command must leave no
+    // trace — no graph mutation, no history entry, and above all no cleared
+    // redo branch (see `CommandPolicy`).
+    const vetoed = commandPolicy?.(command, graph);
+    if (vetoed) return { ok: false, error: vetoed };
+
     const result = applyCommand(graph, command);
     if (!result.ok) return { ok: false, error: result.error };
 

--- a/packages/ui/dnd-collections/react/use-keyboard-controller.ts
+++ b/packages/ui/dnd-collections/react/use-keyboard-controller.ts
@@ -295,6 +295,10 @@ export function useCollectionsKeyboard(args: {
           store.flashRejection([nodeId]);
           announce("Cannot move a collection into itself or one of its nested collections.");
         }
+        if (dispatched.error.reason === "blocked-by-policy") {
+          store.flashRejection([nodeId]);
+          if (dispatched.error.message) announce(dispatched.error.message);
+        }
         return;
       }
       announce(`Moved "${name}" to trash.`);
@@ -409,6 +413,10 @@ export function useCollectionsKeyboard(args: {
         if (dispatched.error.reason === "would-create-cycle") {
           store.flashRejection([nodeId]);
           announce("Cannot move a collection into itself or one of its nested collections.");
+        }
+        if (dispatched.error.reason === "blocked-by-policy") {
+          store.flashRejection([nodeId]);
+          if (dispatched.error.message) announce(dispatched.error.message);
         }
         return;
       }


### PR DESCRIPTION
Addresses a review of the graph view spanning correctness, persistence, accessibility, and rendering cost. Each fix carries a regression test that was verified to FAIL against the code it replaces.

Correctness
- Un-hydrated drop targets are now refused by a pre-commit `commandPolicy` on the collections store, replacing a post-commit "dispatch, observe, undo it back out" bounce in the persistence bridge. That bounce restored the graph but corrupted history: pushing a command clears the redo branch, so a refused drop discarded the user's redoable work and left the refused command itself on the redo stack, ready to replay the rejected move. A refused command must never reach history, which means it must never reach the reducer.
- `useCollectionChildIds` no longer serializes ids through `join(",")` / `split(",")`. The core allows ANY non-whitespace string as a NodeId, so an id containing a comma made its sub-graph row disappear entirely along with its subtree. It now subscribes to the structurally shared children array and memoizes the collection-only derivation.

Persistence
- An unload flush no longer queues behind a running save. The in-flight request was created without keepalive, so page teardown killed it and the trailing batch waiting on its settle never started. It now abandons that request and re-sends its documents, plus anything dirtied since, as one unload-safe batch.
- The keepalive payload budget is measured. Over the shared 64 KiB quota a keepalive fetch is a network error, not a truncation, so requesting it on an oversized body guaranteed the loss it existed to prevent; the batch is now sent intact without keepalive and the risk is surfaced.

Accessibility
- Sidebar tool tiles are real <button>s and their activation inserts into the open timeline, instead of div[role=button]s whose Enter/Space only showed a "drag this" toast while real insertion required a pointer-only HTML5 drag. Pointer drag remains, as the way to choose a position.
- Drop-zone upload status and the sidebar toast are live regions.

Robustness and cost
- The media upload boundary validates its response. `response.json()` is `any`, so a 2xx body missing `url` reached node construction — and since `src` is optional on media nodes, the add SUCCEEDED, committing and persisting a sourceless clip with no error anywhere.
- The file-drop pipeline is bounded: one decode per video (duration and poster frame off the same element, previously two separate loads), MAX_CONCURRENT_MEDIA in flight instead of Promise.all over the whole drop, and an AbortSignal that unmount trips. A refused commit is now reported rather than silently dropping successfully uploaded files.
- dragover measures geometry once per drag session and resolves the drop indicator at most once per frame, instead of calling getBoundingClientRect on the wrapper and every card per event. Measured: 164 layout reads for 40 events before, under 40 after.

Also fixes a latent throw in the drop handler (`parseNodeId` on a possibly empty dataset attribute) and an ordering bug where a gateway reset would have left the previous user's documents dirty.

Docs: ARCHITECTURE.md gains an "Application policy" section on why vetoes must be pre-commit; API.md documents `commandPolicy`; the package CLAUDE.md carries it as an invariant.

Not covered by tests: the sidebar's native drag from a real browser (Playwright cannot drive HTML5 drag-and-drop) and probeVideoFile's decode/seek/canvas path (needs a real video asset).