### PR TITLE
Extract the sidebar tool palette and give it Storybook coverage

### DIFF
--- a/apps/timeline-gstudio001/components/timeline/sidebar-tool-palette.stories.tsx
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-tool-palette.stories.tsx
@@ -1,0 +1,117 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { SidebarToolPalette } from "./sidebar-tool-palette";
+
+// The palette is the sidebar's insertion surface. It used to be pointer-only:
+// `div[role="button"]` tiles whose Enter/Space showed a "drag this" hint while
+// real insertion required a native HTML5 drag carrying a custom DataTransfer,
+// so keyboard, screen-reader, and touch users could not create anything.
+//
+// These stories cover the ACTIVATION half. The drag half needs real trusted
+// input and lives in the Playwright suite (per the storybook rules), which is
+// also where the graph-side effect of an insert is asserted.
+
+const meta = {
+  title: "GStudio/Timeline/SidebarToolPalette",
+  component: SidebarToolPalette,
+  tags: ["autodocs"],
+  // The sidebar is a dark, narrow rail; give the tooltips room to sit beside
+  // the tiles rather than clipping at the canvas edge.
+  decorators: [
+    (Story) => (
+      <div className="flex w-[280px] justify-start bg-zinc-900/50 p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    canInsert: {
+      control: { type: "boolean" },
+      description:
+        "Whether activating a tool INSERTS it. False off the graph route, where nothing listens for the handoff — the accessible name then promises only what a drag can deliver.",
+    },
+    onActivate: { description: "Click, Enter, or Space on a tool." },
+  },
+  args: {
+    canInsert: true,
+    onActivate: fn(),
+    onDragStart: fn(),
+    onDragEnd: fn(),
+  },
+} satisfies Meta<typeof SidebarToolPalette>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ---------------------------------------------------------------------------
+// States
+// ---------------------------------------------------------------------------
+
+/** On the graph route: activation appends to the open timeline. */
+export const CanInsert: Story = {};
+
+/**
+ * Off the graph route (storyboard/workbench), nothing is listening for the
+ * handoff. The accessible name drops the "Add …" promise rather than offering
+ * an action that would do nothing.
+ */
+export const DragOnly: Story = {
+  args: { canInsert: false },
+};
+
+// ---------------------------------------------------------------------------
+// Behavior
+// ---------------------------------------------------------------------------
+
+/** The tiles are real buttons, so they are reachable and named as actions. */
+export const AccessibleNames: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const tools = canvas.getAllByRole("button");
+    await expect(tools).toHaveLength(3);
+    await expect(
+      canvas.getByRole("button", { name: "Add Image Clip to the open timeline" }),
+    ).toBeInTheDocument();
+    // Drag survives the switch to <button> — it is the position affordance.
+    await expect(tools[0]).toHaveAttribute("draggable", "true");
+  },
+};
+
+/** A click reports the activated tool. */
+export const ClickActivates: Story = {
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Add Collection to the open timeline" }),
+    );
+    await expect(args.onActivate).toHaveBeenCalledTimes(1);
+    await expect(args.onActivate).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "collection" }),
+    );
+  },
+};
+
+/**
+ * The regression this component exists for: Enter and Space must activate.
+ * The old `div[role="button"]` hand-rolled these keys and did nothing useful
+ * with them; a real <button> gets both from the platform.
+ */
+export const KeyboardActivates: Story = {
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const video = canvas.getByRole("button", { name: "Add Video Clip to the open timeline" });
+
+    video.focus();
+    await expect(video).toHaveFocus();
+
+    await userEvent.keyboard("{Enter}");
+    await expect(args.onActivate).toHaveBeenCalledTimes(1);
+
+    await userEvent.keyboard(" ");
+    await expect(args.onActivate).toHaveBeenCalledTimes(2);
+    await expect(args.onActivate).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: "video" }),
+    );
+  },
+};

--- a/apps/timeline-gstudio001/components/timeline/sidebar-tool-palette.tsx
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-tool-palette.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import React from "react";
+import { FolderPlus, Image, Video } from "lucide-react";
+
+import { SidebarTooltipLabel } from "./sidebar-tooltip-label";
+
+// The sidebar's "new thing" palette, split out of TimelineSidebar as a PURE
+// presentational component: no router, no auth, no drawers. The sidebar as a
+// whole can't be rendered in isolation (its AuthProvider fetches /api/auth/me
+// on mount, which stories are not allowed to do), and this palette is the part
+// whose behavior actually needs covering — a tool can be inserted two ways and
+// they must not drift apart.
+//
+// Two ways in, deliberately:
+//   - ACTIVATION (click, Enter, Space) appends to the open timeline. This is
+//     the only route available to keyboard, screen-reader, and touch users;
+//     these were `div[role="button"]`s whose keys did nothing but show a
+//     "drag this" hint, so insertion was pointer-only.
+//   - DRAG carries the tool over a strip and picks a POSITION. It stays as the
+//     precision affordance, not the only one.
+
+export type SidebarToolType = "collection" | "image" | "video";
+
+export type SidebarToolItem = Readonly<{
+  type: SidebarToolType;
+  label: string;
+  description: string;
+  icon: React.ComponentType<{ className?: string }>;
+}>;
+
+export const SIDEBAR_TOOL_ITEMS: readonly SidebarToolItem[] = [
+  {
+    type: "collection",
+    label: "Collection",
+    description: "Nested timeline beat",
+    icon: FolderPlus,
+  },
+  { type: "image", label: "Image Clip", description: "Image timeline clip", icon: Image },
+  { type: "video", label: "Video Clip", description: "Video timeline clip", icon: Video },
+];
+
+export function SidebarToolPalette({
+  items = SIDEBAR_TOOL_ITEMS,
+  /**
+   * Whether activating a tool INSERTS it. False off the graph route, where
+   * nothing is listening for the handoff — the label and tooltip then promise
+   * only what a drag can deliver, rather than an action that won't happen.
+   */
+  canInsert,
+  onActivate,
+  onDragStart,
+  onDragEnd,
+}: Readonly<{
+  items?: readonly SidebarToolItem[];
+  canInsert: boolean;
+  onActivate: (item: SidebarToolItem) => void;
+  onDragStart?: (event: React.DragEvent, type: SidebarToolType) => void;
+  onDragEnd?: () => void;
+}>) {
+  return (
+    <div className="flex flex-col items-center gap-2">
+      {items.map((item) => {
+        const Icon = item.icon;
+        const tooltipId = `sidebar-tooltip-new-${item.type}`;
+
+        return (
+          <button
+            key={item.type}
+            type="button"
+            aria-label={canInsert ? `Add ${item.label} to the open timeline` : item.label}
+            aria-describedby={tooltipId}
+            draggable
+            onDragStart={(event) => onDragStart?.(event, item.type)}
+            onDragEnd={onDragEnd}
+            onClick={() => onActivate(item)}
+            className="group/sidebar-item relative flex size-11 cursor-grab select-none items-center justify-center rounded-lg border border-zinc-800 bg-zinc-900/40 text-zinc-400 transition-all duration-200 hover:border-sky-500 hover:bg-sky-950/20 hover:text-sky-400 active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+          >
+            <Icon className="h-4 w-4 transition-colors" />
+            <SidebarTooltipLabel
+              id={tooltipId}
+              label={item.label}
+              description={
+                canInsert
+                  ? `${item.description} · click to append, drag to place`
+                  : item.description
+              }
+            />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/timeline-gstudio001/components/timeline/sidebar-tooltip-label.tsx
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-tooltip-label.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+/**
+ * The sidebar's hover/focus tooltip. Shared by every sidebar affordance —
+ * nav links, the tool palette, and the utility row — so the three cannot
+ * drift apart visually. Referenced by `aria-describedby`, which is why it
+ * carries an id and `role="tooltip"` rather than being decorative.
+ */
+export function SidebarTooltipLabel({
+  id,
+  label,
+  description,
+}: Readonly<{ id: string; label: string; description?: string }>) {
+  return (
+    <span
+      id={id}
+      role="tooltip"
+      className="pointer-events-none absolute left-full top-1/2 z-50 ml-3 min-w-max -translate-y-1/2 rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-left opacity-0 shadow-xl shadow-black/30 transition-opacity duration-150 group-hover/sidebar-item:opacity-100 group-focus-visible/sidebar-item:opacity-100"
+    >
+      <span className="block whitespace-nowrap text-xs font-semibold text-zinc-100">{label}</span>
+      {description ? (
+        <span className="mt-0.5 block whitespace-nowrap text-[10px] font-medium text-zinc-500">
+          {description}
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -26,14 +26,10 @@ import {
   requestGraphToolInsert,
 } from "@/lib/graph-view-events";
 import { cn } from "@/lib/utils";
-import type { ProjectViewMode } from "@storyboard/ui/timeline/timeline-view-state";
 
-type DraggableItem = {
-  type: "timeline" | "collection" | "image" | "video";
-  label: string;
-  description: string;
-  icon: React.ComponentType<{ className?: string }>;
-};
+import { SidebarToolPalette, type SidebarToolItem } from "./sidebar-tool-palette";
+import { SidebarTooltipLabel } from "./sidebar-tooltip-label";
+import type { ProjectViewMode } from "@storyboard/ui/timeline/timeline-view-state";
 
 type UtilityItem = {
   id: "assets" | "trash" | "settings";
@@ -41,31 +37,6 @@ type UtilityItem = {
   description: string;
   icon: React.ComponentType<{ className?: string }>;
 };
-
-type TooltipLabelProps = {
-  id: string;
-  label: string;
-  description?: string;
-};
-
-function TooltipLabel({ id, label, description }: TooltipLabelProps) {
-  return (
-    <span
-      id={id}
-      role="tooltip"
-      className="pointer-events-none absolute left-full top-1/2 z-50 ml-3 min-w-max -translate-y-1/2 rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-left opacity-0 shadow-xl shadow-black/30 transition-opacity duration-150 group-hover/sidebar-item:opacity-100 group-focus-visible/sidebar-item:opacity-100"
-    >
-      <span className="block whitespace-nowrap text-xs font-semibold text-zinc-100">
-        {label}
-      </span>
-      {description ? (
-        <span className="mt-0.5 block whitespace-nowrap text-[10px] font-medium text-zinc-500">
-          {description}
-        </span>
-      ) : null}
-    </span>
-  );
-}
 
 const SIDEBAR_ICON_BASE =
   "group/sidebar-item relative flex size-11 items-center justify-center rounded-lg border transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400";
@@ -103,31 +74,10 @@ function IconLink({
       )}
     >
       <Icon className="h-4 w-4 transition-colors" />
-      <TooltipLabel id={tooltipId} label={label} description={description} />
+      <SidebarTooltipLabel id={tooltipId} label={label} description={description} />
     </Link>
   );
 }
-
-const ITEMS: DraggableItem[] = [
-  {
-    type: "collection",
-    label: "Collection",
-    description: "Nested timeline beat",
-    icon: FolderPlus,
-  },
-  {
-    type: "image",
-    label: "Image Clip",
-    description: "Image timeline clip",
-    icon: Image,
-  },
-  {
-    type: "video",
-    label: "Video Clip",
-    description: "Video timeline clip",
-    icon: Video,
-  },
-];
 
 const UTILITY_ITEMS: UtilityItem[] = [
   {
@@ -248,7 +198,7 @@ export function TimelineSidebar() {
   // the same result. Drag remains the way to choose a POSITION.
   const canInsertTools = isGraphViewRoute(pathname);
 
-  const handleToolActivate = (item: DraggableItem) => {
+  const handleToolActivate = (item: SidebarToolItem) => {
     if (canInsertTools && isGraphInsertTool(item.type)) {
       requestGraphToolInsert(item.type);
       // The graph view announces the authoritative result on its own
@@ -310,41 +260,12 @@ export function TimelineSidebar() {
         <>
           <div className="h-px w-10 shrink-0 bg-zinc-800/80" />
 
-          <div className="flex flex-col items-center gap-2">
-            {ITEMS.map((item) => {
-              const Icon = item.icon;
-              const tooltipId = `sidebar-tooltip-new-${item.type}`;
-
-              return (
-                <button
-                  key={item.type}
-                  type="button"
-                  aria-label={
-                    canInsertTools
-                      ? `Add ${item.label} to the open timeline`
-                      : item.label
-                  }
-                  aria-describedby={tooltipId}
-                  draggable
-                  onDragStart={(e) => handleDragStart(e, item.type)}
-                  onDragEnd={handleDragEnd}
-                  onClick={() => handleToolActivate(item)}
-                  className="group/sidebar-item relative flex size-11 cursor-grab select-none items-center justify-center rounded-lg border border-zinc-800 bg-zinc-900/40 text-zinc-400 transition-all duration-200 hover:border-sky-500 hover:bg-sky-950/20 hover:text-sky-400 active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
-                >
-                  <Icon className="h-4 w-4 transition-colors" />
-                  <TooltipLabel
-                    id={tooltipId}
-                    label={item.label}
-                    description={
-                      canInsertTools
-                        ? `${item.description} · click to append, drag to place`
-                        : item.description
-                    }
-                  />
-                </button>
-              );
-            })}
-          </div>
+          <SidebarToolPalette
+            canInsert={canInsertTools}
+            onActivate={handleToolActivate}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+          />
         </>
       )}
 
@@ -390,7 +311,7 @@ export function TimelineSidebar() {
               )}
             >
               <Icon className="h-4 w-4 transition-colors" />
-              <TooltipLabel
+              <SidebarTooltipLabel
                 id={tooltipId}
                 label={item.label}
                 description={item.description}
@@ -422,7 +343,7 @@ export function TimelineSidebar() {
               {user?.name ? user.name[0].toUpperCase() : (user?.email ? user.email[0].toUpperCase() : "U")}
             </div>
           )}
-          <TooltipLabel
+          <SidebarTooltipLabel
             id="sidebar-tooltip-utility-account"
             label="Account"
             description={user?.email ? `Signed in as ${user.email}` : "Signed in"}


### PR DESCRIPTION
Follow-up to the F3 accessibility fix, which changed the sidebar's tool tiles from div[role=button] to real buttons with an activation path but added no story — the repo rule is that UI changes update Storybook coverage.

TimelineSidebar can't be rendered in a story at all: its AuthProvider fetches /api/auth/me on mount and the context isn't injectable, and stories are forbidden from calling live APIs. Rather than export the auth context for tests, split the palette out as a pure presentational component with no router, auth, or drawer dependencies — which is also the composition the repo's own rules ask for.

- SidebarToolPalette: items, canInsert, onActivate, onDragStart/End.
- SidebarTooltipLabel: the tooltip was about to be duplicated between the palette and the sidebar's nav/utility rows, so it moves to its own module and all three now share one implementation.
- Drops the unused "timeline" member from the tool type union; ITEMS never contained one.

Stories cover the activation half: accessible names, click, and — the regression the fix was for — Enter and Space. The drag half stays in the Playwright suite per the storybook rules, since it needs trusted input. Note these stories document the extracted component; the proof that the old tiles were keyboard-inoperable is the e2e added with the original fix.