### PR TITLE
Land the first graph-view review pass

### DIFF
--- a/apps/timeline-gstudio001/components/core/sonner.tsx
+++ b/apps/timeline-gstudio001/components/core/sonner.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Toaster as Sonner, toast } from "sonner";
+
+type ToasterProps = React.ComponentProps<typeof Sonner>;
+
+/**
+ * The app's snackbar surface.
+ *
+ * Themed to `dark` outright rather than through `next-themes` (the shadcn
+ * default): this app has no theme provider and renders one dark palette, so
+ * reading a theme context that never changes would only add a dependency.
+ * Classes are the app's own zinc scale for the same reason — the shadcn
+ * `bg-background`/`text-foreground` tokens aren't defined here.
+ */
+const Toaster = ({ ...props }: ToasterProps) => (
+  <Sonner
+    theme="dark"
+    className="toaster group"
+    position="bottom-right"
+    toastOptions={{
+      classNames: {
+        toast:
+          "group toast group-[.toaster]:bg-zinc-900 group-[.toaster]:text-zinc-100 group-[.toaster]:border group-[.toaster]:border-zinc-800 group-[.toaster]:shadow-lg",
+        description: "group-[.toast]:text-zinc-400",
+        actionButton: "group-[.toast]:bg-amber-400 group-[.toast]:text-zinc-950",
+        cancelButton: "group-[.toast]:bg-zinc-800 group-[.toast]:text-zinc-400",
+        error: "group-[.toaster]:border-red-900/60",
+        success: "group-[.toaster]:border-emerald-900/60",
+      },
+    }}
+    {...props}
+  />
+);
+
+export { Toaster, toast };

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Eye } from "lucide-react";
+
 import {
   TrashTarget,
   UndoRedoControls,
@@ -23,14 +25,44 @@ import {
 } from "./graph-preview";
 import { SubTimelines } from "./graph-sub-timelines";
 import {
-  GRID_CELL_HEIGHT,
   GRID_CELL_WIDTH,
   GRID_GAP,
+  ITEM_SIZE_HEIGHTS,
+  ITEM_SIZES,
   TIMELINE_PPS,
   type FocusSurface,
+  type ItemSize,
 } from "./graph-view-config";
 
-export type { FocusSurface };
+export type { FocusSurface, ItemSize };
+
+/** One page-wide control: every strip row and grid cell on the page — the
+ *  focused surface AND every sub-graph row — reads the same step. */
+function SizeSelect({
+  size,
+  onChange,
+}: Readonly<{
+  size: ItemSize;
+  onChange: (size: ItemSize) => void;
+}>) {
+  return (
+    <label className="flex items-center gap-1.5 text-xs text-zinc-500">
+      <span className="sr-only">Item size</span>
+      <select
+        aria-label="Item size"
+        value={size}
+        onChange={(event) => onChange(event.target.value as ItemSize)}
+        className="rounded-md border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs uppercase text-zinc-300 outline-none transition-colors hover:border-zinc-700 focus-visible:border-amber-400"
+      >
+        {ITEM_SIZES.map((option) => (
+          <option key={option} value={option}>
+            {option.toUpperCase()}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
 
 function SurfaceToggle({
   surface,
@@ -69,10 +101,10 @@ export function GraphBoard({
   focusedId,
   surface,
   onSurfaceChange,
+  itemSize,
+  onItemSizeChange,
   previewOn,
   onTogglePreview,
-  assetsOpen,
-  onToggleAssets,
   timeChannel,
   trashRootId,
   syncEntries,
@@ -80,14 +112,16 @@ export function GraphBoard({
   focusedId: string;
   surface: FocusSurface;
   onSurfaceChange: (surface: FocusSurface) => void;
+  itemSize: ItemSize;
+  onItemSizeChange: (size: ItemSize) => void;
   previewOn: boolean;
   onTogglePreview: () => void;
-  assetsOpen: boolean;
-  onToggleAssets: () => void;
   timeChannel: PreviewTimeChannel;
   trashRootId: string | null;
   syncEntries: readonly SyncEntry[];
 }>) {
+  const heights = ITEM_SIZE_HEIGHTS[itemSize];
+
   return (
     <OpenKeyBoundary>
       <PreviewShell enabled={previewOn} focusedId={focusedId} channel={timeChannel}>
@@ -105,21 +139,19 @@ export function GraphBoard({
               <Button
                 type="button"
                 variant="ghost"
-                size="sm"
+                size="icon"
                 aria-pressed={previewOn}
+                aria-label={previewOn ? "Hide preview" : "Show preview"}
+                title={previewOn ? "Hide preview" : "Show preview"}
                 onClick={onTogglePreview}
+                className={[
+                  "h-8 w-8",
+                  previewOn ? "bg-zinc-800 text-zinc-100" : "text-zinc-500",
+                ].join(" ")}
               >
-                Preview
+                <Eye aria-hidden="true" className="h-4 w-4" />
               </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                aria-pressed={assetsOpen}
-                onClick={onToggleAssets}
-              >
-                Assets
-              </Button>
+              <SizeSelect size={itemSize} onChange={onItemSizeChange} />
               <SurfaceToggle surface={surface} onChange={onSurfaceChange} />
               <UndoRedoControls />
             </div>
@@ -130,7 +162,7 @@ export function GraphBoard({
               <VirtualStrip
                 collectionId={parseNodeId(focusedId)}
                 pixelsPerSecond={TIMELINE_PPS}
-                itemHeight={88}
+                itemHeight={heights.strip}
                 itemDragActivation="hold"
                 overlay={
                   previewOn ? (
@@ -148,23 +180,31 @@ export function GraphBoard({
               <VirtualGrid
                 collectionId={parseNodeId(focusedId)}
                 cellWidth={GRID_CELL_WIDTH}
-                cellHeight={GRID_CELL_HEIGHT}
+                cellHeight={heights.gridCell}
                 gap={GRID_GAP}
                 height={420}
                 overlay={
                   previewOn ? (
-                    <GraphGridPlayhead focusedId={focusedId} channel={timeChannel} />
+                    <GraphGridPlayhead
+                      focusedId={focusedId}
+                      channel={timeChannel}
+                      cellHeight={heights.gridCell}
+                    />
                   ) : undefined
                 }
                 className="bg-black/25"
               />
               {previewOn && (
-                <GraphGridScrubSurface focusedId={focusedId} channel={timeChannel} />
+                <GraphGridScrubSurface
+                  focusedId={focusedId}
+                  channel={timeChannel}
+                  cellHeight={heights.gridCell}
+                />
               )}
             </div>
           )}
 
-          <SubTimelines focusedId={focusedId} surface={surface} />
+          <SubTimelines focusedId={focusedId} surface={surface} itemSize={itemSize} />
 
           {trashRootId !== null && (
             <div className="flex items-end justify-end">

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import {
+  createContext,
   useCallback,
+  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -12,6 +14,8 @@ import {
 import {
   MIN_ITEM_WIDTH,
   durationToWidth,
+  getChildren,
+  parseNodeId,
   useCollectionsSelector,
   useCollectionsStore,
   type CollectionsGraph,
@@ -33,7 +37,7 @@ import type { TimelineClip, TimelineDocument } from "@storyboard/ui/timeline/typ
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 
 import { useGraphDetailsStore } from "./graph-details-context";
-import { GRID_CELL_HEIGHT, GRID_GAP, TIMELINE_PPS } from "./graph-view-config";
+import { GRID_GAP, TIMELINE_PPS } from "./graph-view-config";
 
 export type PreviewTimeChannel = Readonly<{
   get: () => number;
@@ -68,18 +72,87 @@ type PlayheadMap = Readonly<{
 const STRIP_GAP_PX = 8;
 const COLLECTION_CARD_PX = 128;
 
-function buildPlayheadMap(clips: readonly TimelineClip[]): PlayheadMap {
-  const times: number[] = [];
-  const xs: number[] = [];
-  let x = 0;
-  for (const clip of clips) {
+/**
+ * Where each focused-level CARD begins and ends in the clock the preview pane
+ * is actually playing, keyed by the child's graph node id.
+ *
+ * The pane plays the server manifest whenever it has one, and the live
+ * projection only in the ~2.5s window after an edit. Those two disagree: the
+ * projection re-derives collection-card durations from read-time summaries,
+ * which drift from the stored document the manifest is compiled off. The
+ * playhead used to map ALWAYS off the projection, so in the steady state it
+ * placed the marker on a 75s clock over a pane playing 72s — far enough in
+ * to sit over the wrong collection entirely.
+ */
+export type PreviewCardSpans = ReadonlyMap<string, Readonly<{ start: number; end: number }>>;
+
+const PreviewCardSpansContext = createContext<PreviewCardSpans | null>(null);
+
+function cardSpansOf(manifest: PlaybackManifest): PreviewCardSpans {
+  const spans = new Map<string, { start: number; end: number }>();
+  for (const leaf of manifest.leaves) {
+    // collectionPath[0] is the focused collection itself; [1] is the child
+    // whose CARD the strip draws. A leaf that is a direct media child of the
+    // focused collection has no [1] — that leaf IS its own card.
+    const key = leaf.collectionPath[1] ?? leaf.id;
+    const end = leaf.timelineStart + leaf.timelineDuration;
+    const current = spans.get(key);
+    spans.set(
+      key,
+      current
+        ? { start: Math.min(current.start, leaf.timelineStart), end: Math.max(current.end, end) }
+        : { start: leaf.timelineStart, end },
+    );
+  }
+  return spans;
+}
+
+type PlayheadCard = Readonly<{ width: number; startTime: number; endTime: number }>;
+
+/**
+ * One card per focused-level child: WIDTH from the projection (that is the
+ * strip's own layout, which the pane has no say in) and TIME from the model
+ * the pane is playing, so the marker can never point at a card the surface
+ * is not showing.
+ *
+ * Zips by INDEX against `getChildren` rather than matching clip ids: a
+ * projection clip reports `detail.sourceClipId` when one exists, which is not
+ * the node id the manifest paths are built from. `graphChildrenToClips` maps
+ * over the same `getChildren` array, so index alignment is guaranteed where
+ * id equality is not.
+ */
+function buildPlayheadCards(
+  graph: CollectionsGraph,
+  details: DetailsById,
+  focusedId: string,
+  spans: PreviewCardSpans | null,
+): PlayheadCard[] {
+  const childIds = getChildren(graph, parseNodeId(focusedId));
+  return graphChildrenToClips(graph, details, focusedId).map((clip, index) => {
     const width =
       clip.kind === "collection"
         ? Math.max(MIN_ITEM_WIDTH, COLLECTION_CARD_PX)
         : durationToWidth(clip.duration, TIMELINE_PPS);
-    times.push(clip.startTime, clip.startTime + clip.duration);
-    xs.push(x, x + width);
-    x += width + STRIP_GAP_PX;
+    // A card with no manifest span is one contributing no playback time (an
+    // empty collection). Its projection span is the only thing left to say,
+    // and it is bounded by the neighbours that DO carry manifest times.
+    const span = spans?.get(childIds[index] as string);
+    return {
+      width,
+      startTime: span ? span.start : clip.startTime,
+      endTime: span ? span.end : clip.startTime + clip.duration,
+    };
+  });
+}
+
+function buildPlayheadMap(cards: readonly PlayheadCard[]): PlayheadMap {
+  const times: number[] = [];
+  const xs: number[] = [];
+  let x = 0;
+  for (const card of cards) {
+    times.push(card.startTime, card.endTime);
+    xs.push(x, x + card.width);
+    x += card.width + STRIP_GAP_PX;
   }
   const count = times.length;
   const total = count > 0 ? times[count - 1] : 0;
@@ -118,6 +191,7 @@ function buildGridPlayheadMap(
   clips: readonly TimelineClip[],
   cols: number,
   cellWidth: number,
+  cellHeight: number,
 ): GridPlayheadMap {
   const columns = Math.max(1, cols);
   const starts: number[] = [];
@@ -130,11 +204,11 @@ function buildGridPlayheadMap(
   const total = count > 0 ? ends[count - 1] : 0;
   const cellX = (index: number) => (index % columns) * (cellWidth + GRID_GAP);
   const cellY = (index: number) =>
-    Math.floor(index / columns) * (GRID_CELL_HEIGHT + GRID_GAP);
+    Math.floor(index / columns) * (cellHeight + GRID_GAP);
   const clamp01 = (value: number) => Math.min(1, Math.max(0, value));
 
   return {
-    rowHeight: GRID_CELL_HEIGHT,
+    rowHeight: cellHeight,
     totalDurationSeconds: total,
     posAt: (time) => {
       if (count === 0) return { x: 0, y: 0 };
@@ -155,7 +229,7 @@ function buildGridPlayheadMap(
     },
     timeAt: (x, y) => {
       if (count === 0) return 0;
-      const row = Math.max(0, Math.floor(y / (GRID_CELL_HEIGHT + GRID_GAP)));
+      const row = Math.max(0, Math.floor(y / (cellHeight + GRID_GAP)));
       const column = Math.max(
         0,
         Math.min(columns - 1, Math.floor(x / (cellWidth + GRID_GAP))),
@@ -179,6 +253,7 @@ export function GraphPlayhead({
 }>) {
   const store = useCollectionsStore();
   const detailsStore = useGraphDetailsStore();
+  const spans = useContext(PreviewCardSpansContext);
   const lineRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -191,7 +266,7 @@ export function GraphPlayhead({
       if (graph !== lastGraph || details !== lastDetails) {
         lastGraph = graph;
         lastDetails = details;
-        map = buildPlayheadMap(graphChildrenToClips(graph, details, focusedId));
+        map = buildPlayheadMap(buildPlayheadCards(graph, details, focusedId, spans));
       }
       const line = lineRef.current;
       if (line && map) line.style.transform = `translateX(${map.xAt(channel.get())}px)`;
@@ -205,7 +280,7 @@ export function GraphPlayhead({
       unsubscribeStore();
       unsubscribeDetails();
     };
-  }, [store, detailsStore, focusedId, channel]);
+  }, [store, detailsStore, focusedId, channel, spans]);
 
   return (
     <div
@@ -227,6 +302,7 @@ export function PlayheadScrubBand({
 }>) {
   const store = useCollectionsStore();
   const detailsStore = useGraphDetailsStore();
+  const spans = useContext(PreviewCardSpansContext);
   const bandRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -244,7 +320,7 @@ export function PlayheadScrubBand({
       if (graph !== mapGraph || details !== mapDetails || !map) {
         mapGraph = graph;
         mapDetails = details;
-        map = buildPlayheadMap(graphChildrenToClips(graph, details, focusedId));
+        map = buildPlayheadMap(buildPlayheadCards(graph, details, focusedId, spans));
       }
       const rect = scroller.getBoundingClientRect();
       const styles = getComputedStyle(scroller);
@@ -289,7 +365,7 @@ export function PlayheadScrubBand({
       window.removeEventListener("pointerup", end);
       window.removeEventListener("pointercancel", end);
     };
-  }, [store, detailsStore, focusedId, channel]);
+  }, [store, detailsStore, focusedId, channel, spans]);
 
   return (
     <div
@@ -304,9 +380,11 @@ export function PlayheadScrubBand({
 export function GraphGridPlayhead({
   focusedId,
   channel,
+  cellHeight,
 }: Readonly<{
   focusedId: string;
   channel: PreviewTimeChannel;
+  cellHeight: number;
 }>) {
   const store = useCollectionsStore();
   const detailsStore = useGraphDetailsStore();
@@ -344,6 +422,7 @@ export function GraphGridPlayhead({
           graphChildrenToClips(graph, details, focusedId),
           columns,
           cellWidth,
+          cellHeight,
         );
       }
       if (!map) return;
@@ -364,7 +443,7 @@ export function GraphGridPlayhead({
       unsubscribeDetails();
       observer?.disconnect();
     };
-  }, [store, detailsStore, focusedId, channel]);
+  }, [store, detailsStore, focusedId, channel, cellHeight]);
 
   return (
     <div
@@ -380,9 +459,11 @@ export function GraphGridPlayhead({
 export function GraphGridScrubSurface({
   focusedId,
   channel,
+  cellHeight,
 }: Readonly<{
   focusedId: string;
   channel: PreviewTimeChannel;
+  cellHeight: number;
 }>) {
   const store = useCollectionsStore();
   const detailsStore = useGraphDetailsStore();
@@ -420,6 +501,7 @@ export function GraphGridScrubSurface({
           graphChildrenToClips(graph, details, focusedId),
           columns,
           cellWidth,
+          cellHeight,
         );
       }
       const overlay = grid.querySelector<HTMLElement>("[data-virtual-grid-overlay]");
@@ -471,7 +553,7 @@ export function GraphGridScrubSurface({
       window.removeEventListener("pointerup", end);
       window.removeEventListener("pointercancel", end);
     };
-  }, [store, detailsStore, focusedId, channel]);
+  }, [store, detailsStore, focusedId, channel, cellHeight]);
 
   return (
     <div
@@ -508,7 +590,11 @@ function GatewayDocumentsBridge() {
 // write path has settled it server-side (900ms debounce + batch flight).
 const MANIFEST_REFRESH_DELAY_MS = 2500;
 
-type ManifestClipsState = Readonly<{ clips: TimelineClip[]; forId: string }> | null;
+type ManifestClipsState = Readonly<{
+  clips: TimelineClip[];
+  spans: PreviewCardSpans;
+  forId: string;
+}> | null;
 
 /**
  * The server-compiled playback read model for the focused timeline: the
@@ -518,7 +604,10 @@ type ManifestClipsState = Readonly<{ clips: TimelineClip[]; forId: string }> | n
  * the caller falls back to the live graph projection, which also covers the
  * refresh window after local edits.
  */
-function useManifestClips(enabled: boolean, focusedId: string): TimelineClip[] | null {
+function useManifestClips(
+  enabled: boolean,
+  focusedId: string,
+): Readonly<{ clips: TimelineClip[]; spans: PreviewCardSpans }> | null {
   const store = useCollectionsStore();
   const [state, setState] = useState<ManifestClipsState>(null);
   const [staleAt, setStaleAt] = useState(0);
@@ -565,7 +654,11 @@ function useManifestClips(enabled: boolean, focusedId: string): TimelineClip[] |
           retryTimer = setTimeout(() => setStaleAt(Date.now()), MANIFEST_REFRESH_DELAY_MS);
           return;
         }
-        setState({ clips: manifestToClips(result.manifest), forId: focusedId });
+        setState({
+          clips: manifestToClips(result.manifest),
+          spans: cardSpansOf(result.manifest),
+          forId: focusedId,
+        });
       } catch {
         /* projection fallback stands */
       }
@@ -576,7 +669,9 @@ function useManifestClips(enabled: boolean, focusedId: string): TimelineClip[] |
     };
   }, [enabled, focusedId, staleAt]);
 
-  return state !== null && state.forId === focusedId ? state.clips : null;
+  return state !== null && state.forId === focusedId
+    ? { clips: state.clips, spans: state.spans }
+    : null;
 }
 
 export function PreviewShell({
@@ -606,8 +701,11 @@ export function PreviewShell({
   // — the live focused-level projection plays. Same clock either way: the
   // projection's collection-card durations come from read-time summaries,
   // so both models agree on total time when the store is settled.
-  const manifestClips = useManifestClips(enabled, focusedId);
-  const clips = manifestClips ?? projectionClips;
+  const manifest = useManifestClips(enabled, focusedId);
+  const clips = manifest?.clips ?? projectionClips;
+  // Null while the pane is on the projection — the playhead's own projection
+  // map is already the same clock then, so there is nothing to reconcile.
+  const cardSpans = manifest?.spans ?? null;
   const [time, setTime] = useState(0);
 
   useEffect(() => channel.subscribe(() => setTime(channel.get())), [channel]);
@@ -651,7 +749,7 @@ export function PreviewShell({
     <TimelineDocumentsProvider initialState={initialDocumentsState}>
       <GatewayDocumentsBridge />
       {/* Test/debug witness for which read model the pane is playing. */}
-      <span data-preview-source={manifestClips !== null ? "manifest" : "projection"} hidden />
+      <span data-preview-source={manifest !== null ? "manifest" : "projection"} hidden />
       <WorkbenchSplitPane
         clips={clips}
         currentTime={time}
@@ -659,7 +757,11 @@ export function PreviewShell({
         getInitialSurfaceHeight={getInitialSurfaceHeight}
         onSurfaceHeightChange={handleSurfaceHeightChange}
       >
-        {children}
+        {/* The playhead and scrub band live in `children`; they read these
+            spans so their time↔x mapping is the pane's clock, not their own. */}
+        <PreviewCardSpansContext.Provider value={cardSpans}>
+          {children}
+        </PreviewCardSpansContext.Provider>
       </WorkbenchSplitPane>
     </TimelineDocumentsProvider>
   );

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useContext, useMemo, useState } from "react";
-import { CornerDownRight, Folder, FolderOpen } from "lucide-react";
+import { ChevronsRight, Folder, FolderOpen } from "lucide-react";
 
 import {
   VirtualGrid,
@@ -20,14 +20,15 @@ import { hydrateTimeline } from "./graph-hydration";
 import { NativeDropStrip } from "./graph-native-drop";
 import { GraphViewNavContext } from "./graph-navigation";
 import {
-  GRID_CELL_HEIGHT,
   GRID_CELL_WIDTH,
   GRID_GAP,
+  ITEM_SIZE_HEIGHTS,
   MAX_SUBTREE_DEPTH,
   SUBTIMELINE_INDENT_PX,
   SUBTIMELINE_GRID_MAX_HEIGHT,
   TIMELINE_PPS,
   type FocusSurface,
+  type ItemSize,
 } from "./graph-view-config";
 
 /**
@@ -71,10 +72,12 @@ function SubTimelineNode({
   collectionId,
   depth,
   surface,
+  itemSize,
 }: Readonly<{
   collectionId: NodeId;
   depth: number;
   surface: FocusSurface;
+  itemSize: ItemSize;
 }>) {
   const nav = useContext(GraphViewNavContext);
   const store = useCollectionsStore();
@@ -173,12 +176,12 @@ function SubTimelineNode({
         <span className="grow" />
         <button
           type="button"
-          aria-label="Focus"
-          title="Focus this timeline"
+          aria-label="Drill into timeline"
+          title="Drill into this timeline"
           onClick={() => nav?.openTimeline(collectionId)}
           className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
         >
-          <CornerDownRight aria-hidden="true" className="h-4 w-4" />
+          <ChevronsRight aria-hidden="true" className="h-4 w-4" />
         </button>
       </div>
 
@@ -198,7 +201,7 @@ function SubTimelineNode({
             <VirtualGrid
               collectionId={collectionId}
               cellWidth={GRID_CELL_WIDTH}
-              cellHeight={GRID_CELL_HEIGHT}
+              cellHeight={ITEM_SIZE_HEIGHTS[itemSize].gridCell}
               gap={GRID_GAP}
               height={SUBTIMELINE_GRID_MAX_HEIGHT}
               className="bg-black/20"
@@ -208,7 +211,7 @@ function SubTimelineNode({
               <VirtualStrip
                 collectionId={collectionId}
                 pixelsPerSecond={TIMELINE_PPS}
-                itemHeight={64}
+                itemHeight={ITEM_SIZE_HEIGHTS[itemSize].strip}
                 itemDragActivation="hold"
                 className="bg-black/20"
               />
@@ -222,6 +225,7 @@ function SubTimelineNode({
                 collectionId={childId}
                 depth={depth + 1}
                 surface={surface}
+                itemSize={itemSize}
               />
             ))}
         </div>
@@ -233,7 +237,8 @@ function SubTimelineNode({
 export function SubTimelines({
   focusedId,
   surface,
-}: Readonly<{ focusedId: string; surface: FocusSurface }>) {
+  itemSize,
+}: Readonly<{ focusedId: string; surface: FocusSurface; itemSize: ItemSize }>) {
   const childIds = useCollectionChildIds(parseNodeId(focusedId));
   if (childIds.length === 0) return null;
 
@@ -245,6 +250,7 @@ export function SubTimelines({
           collectionId={collectionId}
           depth={0}
           surface={surface}
+          itemSize={itemSize}
         />
       ))}
     </div>

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -36,7 +36,9 @@ import {
 import { GRAPH_ASSETS_TOGGLE_EVENT } from "@/lib/graph-view-events";
 
 import { AssetPaletteDrawer } from "./graph-asset-palette";
-import { GraphBoard, type FocusSurface } from "./graph-board";
+import { Toaster, toast } from "@/components/core/sonner";
+
+import { GraphBoard, type FocusSurface, type ItemSize } from "./graph-board";
 import { GraphDetailsProvider } from "./graph-details-context";
 import { HydrationController } from "./graph-hydration";
 import { GRAPH_VIEW_COMPONENTS } from "./graph-item-content";
@@ -48,7 +50,7 @@ import {
 } from "./graph-persistence";
 import { unparkPendingDetail } from "./graph-pending-details";
 import { createPreviewTimeChannel } from "./graph-preview";
-import { FALLBACK_DETAIL } from "./graph-view-config";
+import { DEFAULT_ITEM_SIZE, FALLBACK_DETAIL } from "./graph-view-config";
 import { GraphViewChrome } from "./graph-view-chrome";
 
 type BootState =
@@ -93,6 +95,7 @@ export function GraphTimelineView({
   const [focusError, setFocusError] = useState<string | null>(null);
   const [syncLog, setSyncLog] = useState<readonly SyncEntry[]>([]);
   const [surface, setSurface] = useState<FocusSurface>("strip");
+  const [itemSize, setItemSize] = useState<ItemSize>(DEFAULT_ITEM_SIZE);
   const [previewOn, setPreviewOn] = useState(false);
   const [timeChannel] = useState(createPreviewTimeChannel);
   const [assetsOpen, setAssetsOpen] = useState(false);
@@ -252,10 +255,15 @@ export function GraphTimelineView({
         collections: blocked,
         bounced: true,
       });
+      // The SyncPanel entry above is developer telemetry. This is the part the
+      // USER sees: without it a refused drop just silently snapped back, with
+      // the explanation buried in a debug panel.
+      const message = "That collection is still loading — drop again once its clips appear.";
+      toast.error(message, { id: `blocked-${blocked.join(",")}` });
       return {
         reason: "blocked-by-policy",
         blockedIds: blocked.map(parseNodeId),
-        message: "That collection is still loading — drop again once its clips appear.",
+        message,
       };
     },
     [detailsStore, onSync],
@@ -313,6 +321,10 @@ export function GraphTimelineView({
 
   return (
     <div className="flex flex-col gap-4">
+      {/* Outside <DndCollections> on purpose: a toast must survive the tree
+          that raised it (a rejected drop unmounts nothing, but a focus change
+          remounts the board). */}
+      <Toaster />
       <GraphViewChrome projectId={projectId} timelinePath={timelinePath} />
       {gatewayError !== null && (
         <p className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
@@ -368,10 +380,10 @@ export function GraphTimelineView({
                 focusedId={focusedId}
                 surface={surface}
                 onSurfaceChange={setSurface}
+                itemSize={itemSize}
+                onItemSizeChange={setItemSize}
                 previewOn={previewOn}
                 onTogglePreview={() => setPreviewOn((current) => !current)}
-                assetsOpen={assetsOpen}
-                onToggleAssets={() => setAssetsOpen((current) => !current)}
                 timeChannel={timeChannel}
                 trashRootId={boot.trashRootId}
                 syncEntries={syncLog}

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
@@ -41,14 +41,18 @@ export function GraphViewChrome({
           aria-label="Timeline focus path"
           className="flex items-center gap-2 text-xs text-zinc-400 select-none"
         >
-          <Link href="/" className="text-zinc-400 transition-colors hover:text-white">
-            Projects
-          </Link>
-          <span>/</span>
-          <Link href={base} className="text-zinc-400 transition-colors hover:text-white">
-            Graph
-          </Link>
-          <span>/</span>
+          {/* The project is the ROOT crumb, not a child of a "Projects / Graph"
+              chrome path: the trail reads as the timeline tree the user is
+              standing in. At the root the project IS the focused crumb, so it
+              renders once, as the current one. */}
+          {focusedId !== projectId && (
+            <>
+              <Link href={base} className="text-zinc-400 transition-colors hover:text-white">
+                {documents[projectId]?.title ?? projectId}
+              </Link>
+              <span>/</span>
+            </>
+          )}
           {timelinePath.slice(0, -1).map((segment, index) => (
             <span key={segment} className="flex items-center gap-2">
               <Link

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-config.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-config.ts
@@ -7,8 +7,31 @@ export type FocusSurface = "strip" | "grid";
 export const TIMELINE_PPS = 40;
 
 export const GRID_CELL_WIDTH = 160;
-export const GRID_CELL_HEIGHT = 96;
 export const GRID_GAP = 8;
+
+/** The five steps of the page-wide item size control. */
+export type ItemSize = "xs" | "sm" | "md" | "lg" | "xl";
+
+export const ITEM_SIZES = ["xs", "sm", "md", "lg", "xl"] as const;
+
+/**
+ * Item size scales HEIGHT ONLY — the strip's row height and the grid's cell
+ * height. Widths stay where they were: a strip clip's width is its duration at
+ * TIMELINE_PPS, so the horizontal time scale is identical at every step and a
+ * size change never moves the playhead. The grid keeps GRID_CELL_WIDTH for the
+ * same reason (its column count, and so its time→x mapping, is width-derived).
+ *
+ * `md` reproduces the sizes the page used before the control existed.
+ */
+export const ITEM_SIZE_HEIGHTS = {
+  xs: { strip: 44, gridCell: 56 },
+  sm: { strip: 64, gridCell: 76 },
+  md: { strip: 88, gridCell: 96 },
+  lg: { strip: 120, gridCell: 132 },
+  xl: { strip: 156, gridCell: 172 },
+} as const satisfies Record<ItemSize, { strip: number; gridCell: number }>;
+
+export const DEFAULT_ITEM_SIZE: ItemSize = "md";
 
 /** Max viewport height of a sub-graph row's GRID (it hugs content up to this
  *  cap, then scrolls) — smaller than the focused grid so nested rows stay

--- a/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
@@ -4,6 +4,7 @@ import { FieldValue, Timestamp } from "firebase-admin/firestore";
 
 import type { TimelineDocument, TimelineClip } from "@storyboard/timeline-model/types";
 import { getFirebaseDb } from "./firebase-admin";
+import { firstFrameUrl } from "./project-thumbnail";
 import { resolveOwnership, TimelineAccessDeniedError } from "./timeline-ownership";
 
 type TimelineDocumentRecord = {
@@ -178,15 +179,6 @@ function toIsoDate(value: unknown) {
   return undefined;
 }
 
-function getDocumentThumbnailUrl(document?: TimelineDocument) {
-  const mediaClip = document?.clips.find(
-    (clip) => clip.kind === "image" || clip.kind === "video",
-  );
-
-  if (!mediaClip) return undefined;
-  return mediaClip.kind === "video" ? mediaClip.poster || mediaClip.src : mediaClip.src;
-}
-
 function toProjectSummary(id: string, data: Partial<TimelineDocumentRecord>): TimelineProjectSummary {
   const document = toTimelineDocument(id, data);
 
@@ -195,7 +187,7 @@ function toProjectSummary(id: string, data: Partial<TimelineDocumentRecord>): Ti
     title: document.title,
     description: document.description,
     clipCount: document.clips.length,
-    thumbnailUrl: getDocumentThumbnailUrl(document),
+    thumbnailUrl: firstFrameUrl(document.clips),
     createdAt: toIsoDate(data.createdAt),
     updatedAt: toIsoDate(data.updatedAt),
   };

--- a/apps/timeline-gstudio001/lib/project-thumbnail.test.ts
+++ b/apps/timeline-gstudio001/lib/project-thumbnail.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import type { TimelineClip } from "@storyboard/timeline-model/types";
+
+import { firstFrameUrl } from "./project-thumbnail";
+
+const base = {
+  index: 0,
+  alt: "",
+  aspect: 16 / 9,
+  trackIndex: 0,
+  startTime: 0,
+  duration: 3,
+  sourceDuration: 3,
+  trimIn: 0,
+  trimOut: 0,
+};
+
+function image(id: string, src: string): TimelineClip {
+  return { ...base, id, kind: "image", src };
+}
+
+function video(id: string, src: string, poster?: string): TimelineClip {
+  return { ...base, id, kind: "video", src, poster };
+}
+
+function collection(
+  id: string,
+  previewItems: NonNullable<
+    Extract<TimelineClip, { kind: "collection" }>["previewItems"]
+  >,
+): TimelineClip {
+  return {
+    ...base,
+    id,
+    kind: "collection",
+    title: id,
+    childTimelineId: `child-${id}`,
+    itemCount: previewItems.length,
+    previewItems,
+  };
+}
+
+describe("firstFrameUrl", () => {
+  it("takes the first image clip's src", () => {
+    expect(firstFrameUrl([image("a", "https://cdn.test/a.jpg")])).toBe(
+      "https://cdn.test/a.jpg",
+    );
+  });
+
+  it("prefers a video's poster over its src", () => {
+    expect(
+      firstFrameUrl([video("a", "https://cdn.test/a.mp4", "https://cdn.test/a.jpg")]),
+    ).toBe("https://cdn.test/a.jpg");
+  });
+
+  it("falls back to a video's src when it has no poster", () => {
+    expect(firstFrameUrl([video("a", "https://cdn.test/a.mp4")])).toBe(
+      "https://cdn.test/a.mp4",
+    );
+  });
+
+  // The regression this module exists for: a project organised into scenes
+  // holds ONLY collection clips, so a kind === image|video scan returned
+  // undefined and the card rendered the empty placeholder.
+  it("reads a collection's first preview item when no media clip is present", () => {
+    const clips = [
+      collection("Bank Heist", [
+        { id: "p1", kind: "image", src: "https://cdn.test/heist.jpg", alt: "p1" },
+        { id: "p2", kind: "image", src: "https://cdn.test/other.jpg", alt: "p2" },
+      ]),
+      collection("Car Chase", [
+        { id: "p3", kind: "image", src: "https://cdn.test/chase.jpg", alt: "p3" },
+      ]),
+    ];
+    expect(firstFrameUrl(clips)).toBe("https://cdn.test/heist.jpg");
+  });
+
+  it("uses a collection preview video's poster", () => {
+    const clips = [
+      collection("Scene", [
+        {
+          id: "p1",
+          kind: "video",
+          src: "https://cdn.test/p1.mp4",
+          poster: "https://cdn.test/p1.jpg",
+          alt: "p1",
+        },
+      ]),
+    ];
+    expect(firstFrameUrl(clips)).toBe("https://cdn.test/p1.jpg");
+  });
+
+  it("skips collections that carry no preview items", () => {
+    const clips = [collection("Empty", []), image("a", "https://cdn.test/a.jpg")];
+    expect(firstFrameUrl(clips)).toBe("https://cdn.test/a.jpg");
+  });
+
+  it("returns undefined when nothing can supply a frame", () => {
+    expect(firstFrameUrl([])).toBeUndefined();
+    expect(firstFrameUrl([collection("Empty", [])])).toBeUndefined();
+  });
+});

--- a/apps/timeline-gstudio001/lib/project-thumbnail.ts
+++ b/apps/timeline-gstudio001/lib/project-thumbnail.ts
@@ -1,0 +1,37 @@
+import type { TimelineClip } from "@storyboard/timeline-model/types";
+
+/**
+ * The frame a project card shows: the first one ANY clip in the document can
+ * supply, scanning in timeline order.
+ *
+ * A collection clip contributes its own first preview item. That branch is the
+ * whole point: once a project's top level is organised into scenes it holds no
+ * media clip at all, only collections — so a plain `kind === "image" | "video"`
+ * scan found nothing and the card fell through to the empty placeholder, even
+ * though every collection card in the strip below was rendering thumbnails from
+ * exactly the `previewItems` this now reads.
+ *
+ * Deliberately does NOT descend into child timeline documents: `previewItems`
+ * is the summary the write path already denormalised onto the clip, so this
+ * stays a pure function of one document and adds no reads to the list query.
+ */
+export function firstFrameUrl(clips: readonly TimelineClip[]): string | undefined {
+  for (const clip of clips) {
+    if (clip.kind === "image") {
+      if (clip.src) return clip.src;
+      continue;
+    }
+    if (clip.kind === "video") {
+      const url = clip.poster || clip.src;
+      if (url) return url;
+      continue;
+    }
+    if (clip.kind === "collection") {
+      for (const item of clip.previewItems ?? []) {
+        const url = item.kind === "video" ? item.poster || item.src : item.src;
+        if (url) return url;
+      }
+    }
+  }
+  return undefined;
+}

--- a/apps/timeline-gstudio001/package.json
+++ b/apps/timeline-gstudio001/package.json
@@ -35,6 +35,7 @@
     "postcss": "^8.5.6",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -514,6 +514,7 @@
         "postcss": "^8.5.6",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1"
       },
       "devDependencies": {

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -177,6 +177,13 @@ function clipContainsPlaybackTime(clip: TimelineClip, currentTime: number) {
   return currentTime >= playbackStart && currentTime <= playbackStart + playbackDuration;
 }
 
+/** The clip that literally covers this time — never one held over from
+ *  earlier. Callers deciding whether a time is INSIDE playable material (as
+ *  opposed to what to draw at it) must use this. */
+function getContainingClip(clips: TimelineClip[], currentTime: number) {
+  return clips.find((clip) => clipContainsPlaybackTime(clip, currentTime)) ?? null;
+}
+
 function getActiveClip(
   clips: TimelineClip[],
   currentTime: number,
@@ -190,14 +197,25 @@ function getActiveClip(
     return preferredClip;
   }
 
-  const lastClip = clips[clips.length - 1];
-  if (lastClip && currentTime >= getClipPlaybackStart(lastClip) + getClipPlaybackDuration(lastClip)) {
-    return lastClip;
-  }
+  const containing = getContainingClip(clips, currentTime);
+  if (containing) return containing;
 
-  return clips.find((clip) => {
-    return clipContainsPlaybackTime(clip, currentTime);
-  }) ?? null;
+  // Nothing covers this time: the playhead sits in a GAP between clips, or
+  // past the last one. Hold the clip that most recently started instead of
+  // returning null — null renders the empty surface, so a gap flashed to
+  // black mid-timeline. A gap carries no NEW frame; it is not an instruction
+  // to blank what a real clip last showed. (The old special case for "past
+  // the final clip" was this same rule, applied only at the tail.)
+  //
+  // Scans for the greatest start rather than trusting array order, so it
+  // holds the right frame even for a caller that has not sorted. A leading
+  // gap — before any clip has started — correctly still yields null.
+  let held: TimelineClip | null = null;
+  for (const clip of clips) {
+    if (getClipPlaybackStart(clip) > currentTime) continue;
+    if (!held || getClipPlaybackStart(clip) > getClipPlaybackStart(held)) held = clip;
+  }
+  return held;
 }
 
 function getTimelineDuration(clips: TimelineClip[]) {
@@ -209,7 +227,11 @@ function getTimelineDuration(clips: TimelineClip[]) {
 
 function normalizePlaybackTime(clips: TimelineClip[], time: number, duration: number) {
   const boundedTime = clamp(time, 0, duration);
-  if (getActiveClip(clips, boundedTime)) return boundedTime;
+  // Containment, NOT getActiveClip: this decides whether the time needs
+  // snapping forward to real material, and getActiveClip now answers "what
+  // should the surface draw" — which holds a frame across gaps and would
+  // make every gap look like a legitimate resting place.
+  if (getContainingClip(clips, boundedTime)) return boundedTime;
 
   const nextClip = clips.find((clip) => getClipPlaybackStart(clip) > boundedTime);
   return nextClip ? clamp(getClipPlaybackStart(nextClip), 0, duration) : duration;
@@ -942,7 +964,12 @@ export function WorkbenchSplitPane({
           aria-valuemin={MIN_SURFACE_HEIGHT}
           aria-valuenow={Math.round(surfaceHeight)}
           aria-label="Resize workbench display"
-          className="group flex h-5 w-full cursor-row-resize items-center justify-center bg-transparent focus-visible:outline focus-visible:outline-2 focus-visible:outline-amber-400 focus-visible:outline-offset-2"
+          // The divider's OWN height is the only source of the gap on either
+          // side of the rule: it centres the 1px line, so the space above and
+          // below is h/2 each. Nothing else may add padding against it — the
+          // lower pane used to carry a pt-3 that made the bottom gap 22px
+          // against the top's 10px, which read as a misaligned rule.
+          className="group flex h-6 w-full cursor-row-resize items-center justify-center bg-transparent focus-visible:outline focus-visible:outline-2 focus-visible:outline-amber-400 focus-visible:outline-offset-2"
           onPointerDown={handleDividerPointerDown}
           onPointerMove={handleDividerPointerMove}
           onPointerUp={handleDividerPointerUp}
@@ -951,7 +978,7 @@ export function WorkbenchSplitPane({
           <span className="h-px w-full bg-zinc-800 transition-colors group-hover:bg-amber-400/70 group-active:bg-amber-400" />
         </button>
       </div>
-      <div ref={lowerPaneRef} className="min-h-0 pt-3">
+      <div ref={lowerPaneRef} className="min-h-0">
         {children}
       </div>
     </div>


### PR DESCRIPTION
Ten items from a walkthrough of the dnd-collections graph view.

Two were preview bugs sharing a root cause — the pane and its playhead disagreeing about what time means:

- The pane plays the server manifest, but the playhead always mapped time->x off the client projection. Those clocks drift (the projection re-derives collection durations from read-time summaries), so the marker sat over one collection while the surface showed another. Card WIDTHS still come from the projection — that is the strip's own layout — but card TIMES now come from whichever model the pane is playing, published through PreviewCardSpansContext.
- Clips pack with CLIP_GAP_SECONDS between them, and getActiveClip returned null in those gaps, cutting the surface to black mid- timeline. It now holds the frame of the clip that most recently started. getContainingClip is split out so the seek path keeps strict containment and still snaps past gaps.

The rest:

- Project cards fell through to the empty placeholder whenever a project's top level held only collections. firstFrameUrl now reads a collection's previewItems, the same summary the strip already draws.
- The split-pane divider had 10px above the rule and 22px below; the lower pane's padding is gone and the divider's own height is now the single source of both gaps.
- One page-wide item size control (xs..sm..xl), scaling height only so the horizontal time scale never moves. Every strip row and grid cell reads the same step, which meant threading a live cell height through the grid playhead math that had hardcoded the constant.
- Snackbars via shadcn sonner, wired to the drop-rejection policy whose message previously only reached a debug panel.
- Preview button is an icon toggle; the duplicate Assets button is gone (the sidebar already owns that toggle).
- Breadcrumbs start at the project rather than a "Projects / Graph" chrome path, and the drill-down affordance reads as one.