### PR TITLE
Green npm run lint (13 errors -> 0)

### DIFF
--- a/apps/timeline-gstudio001/app/page.tsx
+++ b/apps/timeline-gstudio001/app/page.tsx
@@ -48,32 +48,61 @@ export default function Home() {
   const [isCreating, setIsCreating] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
 
-  const loadProjects = useCallback(async () => {
-    setIsLoading(true);
-    setLoadError(null);
+  // Pure request: resolves to the project list or throws — it never touches
+  // state, so the mount effect can consume it through promise CALLBACKS
+  // (state changes only when the external request answers) and Refresh can
+  // wrap it with its own synchronous loading reset.
+  const requestProjects = useCallback(async (): Promise<TimelineProjectSummary[]> => {
+    const response = await fetch("/api/timelines", { cache: "no-store" });
+    const result = (await response.json().catch(() => ({}))) as {
+      projects?: TimelineProjectSummary[];
+      error?: string;
+    };
 
-    try {
-      const response = await fetch("/api/timelines", { cache: "no-store" });
-      const result = (await response.json().catch(() => ({}))) as {
-        projects?: TimelineProjectSummary[];
-        error?: string;
-      };
-
-      if (!response.ok) {
-        throw new Error(result.error || "Unable to load projects.");
-      }
-
-      setProjects(result.projects || []);
-    } catch (error) {
-      setLoadError(error instanceof Error ? error.message : "Unable to load projects.");
-    } finally {
-      setIsLoading(false);
+    if (!response.ok) {
+      throw new Error(result.error || "Unable to load projects.");
     }
+
+    return result.projects || [];
   }, []);
 
   useEffect(() => {
-    void loadProjects();
-  }, [loadProjects]);
+    // Mount needs no sync loading reset — isLoading INITIALIZES true. The
+    // cancelled flag keeps a slow answer from writing into an unmounted tree.
+    let cancelled = false;
+    requestProjects()
+      .then((next) => {
+        if (cancelled) return;
+        setProjects(next);
+        setLoadError(null);
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        setLoadError(error instanceof Error ? error.message : "Unable to load projects.");
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [requestProjects]);
+
+  // Refresh (an event handler) re-raises the loading flag before refetching.
+  const reloadProjects = useCallback(() => {
+    setIsLoading(true);
+    setLoadError(null);
+    requestProjects()
+      .then((next) => {
+        setProjects(next);
+      })
+      .catch((error: unknown) => {
+        setLoadError(error instanceof Error ? error.message : "Unable to load projects.");
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, [requestProjects]);
 
   const handleDeleteProject = async (e: React.MouseEvent, id: string) => {
     e.stopPropagation();
@@ -192,7 +221,7 @@ export default function Home() {
             variant="outline"
             size="sm"
             className="gap-2 border-zinc-800 bg-zinc-950 text-zinc-300 hover:bg-zinc-900"
-            onClick={() => void loadProjects()}
+            onClick={reloadProjects}
             disabled={isLoading}
           >
             <RefreshCw className={cn("h-3.5 w-3.5", isLoading && "animate-spin")} />

--- a/apps/timeline-gstudio001/app/workbench/page.tsx
+++ b/apps/timeline-gstudio001/app/workbench/page.tsx
@@ -53,6 +53,20 @@ function WorkbenchPageContent() {
     };
   }, [timelineId]);
 
+  // Above the early return: hooks must run on EVERY render, and this
+  // component can bail before rendering when the document is missing.
+  const handlePreviewTimeChange = useCallback((
+    time: number,
+    clips?: TimelineClip[],
+    activeClipId?: string,
+  ) => {
+    setPreviewTime(time);
+    if (clips) {
+      setPreviewClips(clips);
+    }
+    setPreviewClipId(activeClipId ?? null);
+  }, []);
+
   if (!document) return null;
 
   const path = getTimelinePath(timelineId);
@@ -72,18 +86,6 @@ function WorkbenchPageContent() {
   const handleOpenCollection = (nextId: string) => {
     router.push(`${pathname}?timelineId=${nextId}`);
   };
-
-  const handlePreviewTimeChange = useCallback((
-    time: number,
-    clips?: TimelineClip[],
-    activeClipId?: string,
-  ) => {
-    setPreviewTime(time);
-    if (clips) {
-      setPreviewClips(clips);
-    }
-    setPreviewClipId(activeClipId ?? null);
-  }, []);
 
   const timelineChrome = (
     <div className="flex items-center justify-between gap-3">

--- a/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
+++ b/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
 import { createPortal } from "react-dom";
 import {
   Trash2,
@@ -18,45 +18,71 @@ type TrashDrawerProps = {
   onClose: () => void;
 };
 
+// "Am I on the client?" as an external-store read: the server snapshot says
+// no, the client snapshot says yes, and nothing ever notifies — React swaps
+// the value at hydration. Replaces the setIsMounted(true)-in-an-effect flag,
+// which cost an extra post-mount render.
+const emptySubscribe = () => () => {};
+const useIsMounted = () =>
+  useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false,
+  );
+
 export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
   const { user } = useAuth();
   const [clips, setClips] = useState<TimelineClip[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [isMounted, setIsMounted] = useState(false);
+  const isMounted = useIsMounted();
 
-  const loadTrash = useCallback(async () => {
-    if (!user) return;
-    setIsLoading(true);
-    setError(null);
-    try {
-      const trashId = `trash-${user.uid}`;
-      const response = await fetch(`/api/timelines/${encodeURIComponent(trashId)}`, {
-        cache: "no-store",
-      });
-      if (response.ok) {
-        const result = await response.json();
-        setClips(result.document?.clips || []);
-      } else {
-        setClips([]);
-      }
-    } catch (err) {
-      console.error(err);
-      setError("Failed to load trash items.");
-    } finally {
-      setIsLoading(false);
+  // Opening resets the loading/error surface DURING the render that opens
+  // (the documented adjust-state-on-prop-change pattern), so the spinner is
+  // up before the fetch below even starts — the effect itself then only
+  // touches state from the request's own callbacks.
+  const [prevOpen, setPrevOpen] = useState(isOpen);
+  if (isOpen !== prevOpen) {
+    setPrevOpen(isOpen);
+    if (isOpen && user) {
+      setIsLoading(true);
+      setError(null);
     }
-  }, [user]);
+  }
 
-  useEffect(() => {
-    setIsMounted(true);
+  // Pure request: resolves to the trash clips and never touches state, so
+  // the open effect can consume it through promise CALLBACKS — state changes
+  // only when the request answers, never synchronously in the effect body.
+  const requestTrashClips = useCallback(async (uid: string): Promise<TimelineClip[]> => {
+    const trashId = `trash-${uid}`;
+    const response = await fetch(`/api/timelines/${encodeURIComponent(trashId)}`, {
+      cache: "no-store",
+    });
+    if (!response.ok) return [];
+    const result = await response.json();
+    return result.document?.clips || [];
   }, []);
 
   useEffect(() => {
-    if (isOpen) {
-      loadTrash();
-    }
-  }, [isOpen, loadTrash]);
+    if (!isOpen || !user) return;
+    let cancelled = false;
+    requestTrashClips(user.uid)
+      .then((next) => {
+        if (cancelled) return;
+        setClips(next);
+        setError(null);
+      })
+      .catch((err: unknown) => {
+        console.error(err);
+        if (!cancelled) setError("Failed to load trash items.");
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, user, requestTrashClips]);
 
   const handleEmptyTrash = async () => {
     const confirmed = window.confirm(

--- a/apps/timeline-gstudio001/components/auth/auth-gate.tsx
+++ b/apps/timeline-gstudio001/components/auth/auth-gate.tsx
@@ -20,6 +20,13 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const didHandleEmailLink = useRef(false);
 
+  // A one-shot URL handshake: Firebase's email link lands with ?oobCode, and
+  // the code plus the locally stored email exist only in window (URL +
+  // localStorage), so SSR forces this read into an effect. Deriving the
+  // initial state instead would need useSearchParams, whose Suspense
+  // envelope would have to wrap the entire app (AuthGate mounts in the root
+  // layout) — a bigger render-boundary change than this one-shot deserves.
+  /* eslint-disable react-hooks/set-state-in-effect -- see above: SSR-constrained one-shot URL/localStorage read */
   useEffect(() => {
     if (didHandleEmailLink.current || user) return;
 
@@ -53,6 +60,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
         setIsSubmitting(false);
       });
   }, [completeSignInLink, user]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   if (isLoading) {
     return (

--- a/apps/timeline-gstudio001/components/auth/auth-provider.tsx
+++ b/apps/timeline-gstudio001/components/auth/auth-provider.tsx
@@ -43,25 +43,47 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<AuthUser | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
+  // Pure request: resolves to the session user (or null) and never touches
+  // state — so the mount effect can consume it through promise CALLBACKS
+  // (state changes only when the external request answers), and refreshUser
+  // wraps it for event-handler callers who want the loading flag re-raised.
+  const requestUser = useCallback(async (): Promise<AuthUser | null> => {
+    const response = await fetch("/api/auth/me", { cache: "no-store" });
+    const result = (await response.json().catch(() => ({}))) as {
+      user?: AuthUser | null;
+    };
+    return result.user ?? null;
+  }, []);
+
   const refreshUser = useCallback(async () => {
     setIsLoading(true);
-
     try {
-      const response = await fetch("/api/auth/me", { cache: "no-store" });
-      const result = (await response.json().catch(() => ({}))) as {
-        user?: AuthUser | null;
-      };
-      setUser(result.user ?? null);
+      setUser(await requestUser());
     } catch {
       setUser(null);
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [requestUser]);
 
   useEffect(() => {
-    void refreshUser();
-  }, [refreshUser]);
+    // Mount needs no sync loading reset — isLoading INITIALIZES true. The
+    // cancelled flag keeps a slow answer from writing into an unmounted tree.
+    let cancelled = false;
+    requestUser()
+      .then((next) => {
+        if (!cancelled) setUser(next);
+      })
+      .catch(() => {
+        if (!cancelled) setUser(null);
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [requestUser]);
 
   const sendSignInLink = useCallback(async ({ email }: AuthCredentials) => {
     const response = await fetch("/api/auth/login", {

--- a/apps/timeline-gstudio001/eslint.config.mjs
+++ b/apps/timeline-gstudio001/eslint.config.mjs
@@ -8,7 +8,17 @@ const __dirname = path.dirname(__filename);
 
 export default defineConfig([
     {
-        ignores: ["storybook-static/**", "test-results/**", "playwright-report/**", "coverage/**"],
+        // .next-dev is this app's DEV distDir (see next.config) — generated
+        // webpack output, never lintable. .next is covered by the Next preset,
+        // but the custom name is not.
+        ignores: [
+            ".next-dev/**",
+            ".next/**",
+            "storybook-static/**",
+            "test-results/**",
+            "playwright-report/**",
+            "coverage/**",
+        ],
     },
     {
         extends: [...next],


### PR DESCRIPTION
Lint has been red since before the review rounds, so it gated nothing. Three kinds of error, three kinds of fix:

- Seven were the DEV build output linting itself: next.config points the dev server at a custom .next-dev distDir, which the Next preset's .next ignore never covered. Both are ignored now.

- One was real: workbench/page.tsx called useCallback BELOW its early return, so the hook count changed between renders. Hoisted.

- Five were react-hooks/set-state-in-effect on fetch-on-mount loaders. The rule's analysis doesn't follow await boundaries into a callee, so the loaders are refactored to its canonical shape — a PURE request function (returns data, never touches state) consumed through promise callbacks directly in the effect. This is a genuine improvement, not appeasement: mount no longer pays the loaders' synchronous setLoading(true) no-op render (loading state already initializes true), and every mount fetch now carries a cancelled flag, so a slow response can't write into an unmounted tree. Event-handler paths (Refresh, refreshUser) keep their synchronous loading reset, where it's allowed and wanted.
  - app/page.tsx: requestProjects + effect/reloadProjects split.
  - auth-provider: requestUser + effect/refreshUser split.
  - trash-drawer: requestTrashClips(uid); the open-reset moved to the documented adjust-state-during-render pattern, and the setIsMounted-in-an-effect flag became a useSyncExternalStore read (server false, client true) — one less post-mount render.
  - auth-gate keeps its effect under a scoped, justified disable: the Firebase email-link handshake reads window (URL + localStorage), so SSR forces the read into an effect, and deriving initial state via useSearchParams would demand a Suspense envelope around the whole app for a one-shot flow.

Remaining warnings are the four deliberate <img> usages.

Verified: lint 0 errors, tsc clean, app vitest 117, graph-view e2e 29/30 (the one failure, "a refused drop leaves the redo branch intact", is a pre-existing drag-timing flake — it fails ~1 in 2 on a fresh server with and without these changes, which touch nothing in the graph path; logged separately). Browser-checked: Home loads + Refresh spins, trash drawer loads and settles, workbench renders.