### PR TITLE
Deflake "a refused drop leaves the redo branch intact" (10/10 green)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,8 @@ Hard-won traps, all previously lost time:
 - Simulated `PointerEvent`s must set `isPrimary: true` or dnd-kit's PointerSensor silently ignores the whole sequence.
 - Playwright e2e must target **play-less** stories: Storybook auto-runs `play()` on iframe load, and its synthetic `pointerup` kills a concurrently running real-mouse drag.
 - A held modifier across multiple `userEvent` clicks requires one `userEvent.setup()` session (the static API resets keyboard state per call).
+- dnd-kit keeps a document-capture click SUPPRESSOR armed for **50ms after a drop** (`AbstractPointerSensor.detach` defers its listener removal). A button clicked inside that window is silently eaten — its click passes `window` but never reaches React. Wait ~80ms after `mouse.up` before clicking anything (the e2e `holdDrag` helper does).
+- Never measure card geometry mid-FLIP: commits (drop/undo/redo) animate displaced cards for 180ms and `getBoundingClientRect` includes the transform, so a drag measured then releases at a stale coordinate and resolves the wrong intent. Settle move animations first (see `settleMoveAnimations` in the e2e spec).
 
 ## Rules (from AGENTS.md files — follow these)
 

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -347,6 +347,33 @@ async function expandSubGraph(page: Page, name: string): Promise<void> {
     .click();
 }
 
+/**
+ * Wait for FLIP move animations to finish before measuring card geometry.
+ *
+ * Commits (drop, undo, redo) animate every displaced card for 180ms via
+ * element.animate — and getBoundingClientRect INCLUDES the transform, so a
+ * drag measured mid-FLIP reads boxes up to a full slot away from where the
+ * cards land. That was a real ~1-in-2 flake: a drop aimed at a card's
+ * dead-center released at a stale coordinate and resolved to a different
+ * intent entirely. CSS animations/transitions are excluded — spinners and
+ * pulses are infinite and would never settle.
+ */
+async function settleMoveAnimations(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () =>
+      !document
+        .getAnimations()
+        .some(
+          (animation) =>
+            !(animation instanceof CSSAnimation) &&
+            !(animation instanceof CSSTransition) &&
+            animation.playState === "running",
+        ),
+    undefined,
+    { timeout: 3000 },
+  );
+}
+
 /** Press-and-hold drag: hold past the 250ms activation delay, travel, dwell,
  *  release. Used for strip cards AND palette thumbnails (both hold-marked). */
 async function holdDrag(
@@ -357,6 +384,7 @@ async function holdDrag(
 ): Promise<void> {
   await source.waitFor({ state: "visible" });
   await target.waitFor({ state: "visible" });
+  await settleMoveAnimations(page);
   const sourceBox = await source.boundingBox();
   const targetBox = await target.boundingBox();
   expect(sourceBox).not.toBeNull();
@@ -375,6 +403,13 @@ async function holdDrag(
   );
   await page.waitForTimeout(150); // dwell: let collision/intent settle
   await page.mouse.up();
+  // dnd-kit's pointer sensor keeps a document-capture click SUPPRESSOR armed
+  // for 50ms after release (AbstractPointerSensor.detach defers
+  // documentListeners.removeAll) so the drag's own trailing click cannot
+  // select/open. Any button clicked inside that window is silently eaten —
+  // its click propagates past window but is stopped before React's root
+  // handler. Outlast the window before handing control back.
+  await page.waitForTimeout(80);
 }
 
 const undoButton = (page: Page): Locator => page.getByRole("button", { name: /undo/i });
@@ -874,6 +909,12 @@ test.describe("graph view E2E", () => {
       projectStrip.locator(`[data-node-id="${CHILD_ID}"]`),
       0.5,
     );
+    // Pin the premise: the VETO fired (its message reaches both the live
+    // region and the toast — .first() tolerates either), not some other
+    // rejection that would leave redo intact for the wrong reason.
+    await expect(
+      page.getByText(/drop again once its clips appear/i).first(),
+    ).toBeVisible();
     // The refusal itself is covered by the bounce test above; here the point
     // is only that nothing landed (the flash is a 600ms window — too racy to
     // assert after the extra interactions this test needs).


### PR DESCRIPTION
The test failed ~1-in-2. Instrumentation (announcement + window-capture hit logging) found TWO independent races, both environmental:

1. The second drag measured card geometry MID-FLIP. The test drags immediately after clicking Undo, and commits animate every displaced card for 180ms — getBoundingClientRect includes the transform, so the "dead-center of the placeholder" release coordinate was captured from rects up to a slot away from where the cards land. Failing runs resolved the drop as over the project container / a same-position move ("Dropped in place.") instead of the nest the veto needs.

2. The Redo click was swallowed by dnd-kit itself. Its pointer sensor arms a document-capture stopPropagation click listener at activation and — by design — defers removing it for 50ms AFTER release (AbstractPointerSensor.detach), so the drag's own trailing click can't select or open. When the test's two intermediate polls resolved fast, the Redo click landed inside that window: the hit log shows pointerdown/up/click all arriving ON the Redo button at window capture, yet React's handler never ran — no "Change redone.", no replay, button still enabled. One observed run took the same "Dropped in place" path and PASSED because its polls happened to outlast the 50ms — proving the store itself was never at fault.

Fixes, both in the shared holdDrag helper so every drag test benefits:
- settleMoveAnimations() waits for WAAPI move animations to finish before measuring (CSS animations/transitions excluded — spinners and pulses are infinite and would never settle).
- an 80ms post-release wait outlasts the click suppressor.

The test also now PINS its premise: after the drop it asserts the veto message is visible, so a drop that resolves to any other rejection can never pass vacuously again.

Both traps are recorded in CLAUDE.md's hard-won list.

Verified: target test 10/10 (--repeat-each=10), full graph-view suite 30/30 — and faster (27.5s vs ~37s; fewer internal retries).