### PR TITLE
Heal the 2.8s duration drift: derive summaries, close the write set o…

### DIFF
--- a/apps/timeline-gstudio001/app/api/timelines/[id]/preview-manifest/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/[id]/preview-manifest/route.ts
@@ -42,15 +42,17 @@ export async function GET(
       return NextResponse.json({ error: "Timeline was not found." }, { status: 404 });
     }
 
-    const { documents, missing } = await loadTimelineClosure(id, user.uid);
+    const { documents, missing, revisions } = await loadTimelineClosure(id, user.uid);
     // The root just loaded through the entry read; serve that version.
     documents[id] = entry.document;
+    revisions[id] = entry.revision;
 
     const manifest = compilePlaybackManifest(
       documents,
       id,
       entry.revision,
       new Date().toISOString(),
+      revisions,
     );
     return NextResponse.json({ manifest, missing });
   } catch (error) {

--- a/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.test.ts
@@ -7,6 +7,7 @@ import {
   buildPlayheadMap,
   cardSpansOf,
   childSpans,
+  manifestTrailsLedger,
   mediaSpanKey,
   type PreviewCardSpans,
 } from "./graph-playhead-model";
@@ -159,5 +160,43 @@ describe("cardSpansOf", () => {
     // sceneA's card gets ITS occurrence's window, not the 0..14 union.
     const cards = childSpans(graph, {}, "sceneA", spans, flatWidth);
     expect(cards.map((card) => [card.startTime, card.endTime])).toEqual([[0, 4]]);
+  });
+});
+
+describe("manifestTrailsLedger", () => {
+  const revisionOf = (ledger: Record<string, number>) => (id: string) => ledger[id];
+
+  it("flags a manifest whose CHILD compile predates the session's write", () => {
+    // The root's revision is current — only per-document checking catches it.
+    const manifest = { projectRevision: 5, documentRevisions: { root: 5, kid: 2 } };
+    expect(manifestTrailsLedger(manifest, "root", revisionOf({ root: 5, kid: 3 }))).toBe(true);
+  });
+
+  it("accepts a manifest at or ahead of every known revision", () => {
+    const manifest = { projectRevision: 5, documentRevisions: { root: 5, kid: 3 } };
+    expect(manifestTrailsLedger(manifest, "root", revisionOf({ root: 5, kid: 3 }))).toBe(false);
+    expect(manifestTrailsLedger(manifest, "root", revisionOf({}))).toBe(false);
+  });
+
+  it("falls back to the root-only check when documentRevisions is absent", () => {
+    expect(manifestTrailsLedger({ projectRevision: 4 }, "root", revisionOf({ root: 5 }))).toBe(true);
+    expect(manifestTrailsLedger({ projectRevision: 5 }, "root", revisionOf({ root: 5 }))).toBe(false);
+  });
+
+  // The race the revision comparison alone cannot see: a write still in the
+  // debounce window (or in a batch whose response hasn't landed) has not
+  // bumped the ledger, so a manifest compiled server-side BEFORE the write
+  // carries revisions that look current. A pending write on any document the
+  // compile read must veto the install until the write settles.
+  it("rejects a revision-current manifest while a read-set document has a pending write", () => {
+    const manifest = { projectRevision: 5, documentRevisions: { root: 5, kid: 3 } };
+    const ledger = revisionOf({ root: 5, kid: 3 });
+    expect(manifestTrailsLedger(manifest, "root", ledger, (id) => id === "kid")).toBe(true);
+    expect(manifestTrailsLedger(manifest, "root", ledger, () => false)).toBe(false);
+  });
+
+  it("waits on a pending ROOT write even without documentRevisions", () => {
+    const manifest = { projectRevision: 5 };
+    expect(manifestTrailsLedger(manifest, "root", revisionOf({ root: 5 }), (id) => id === "root")).toBe(true);
   });
 });

--- a/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.ts
@@ -67,6 +67,45 @@ export function cardSpansOf(manifest: PlaybackManifest): PreviewCardSpans {
   return spans;
 }
 
+/**
+ * Whether a fetched manifest is STALE against this session's own writes — it
+ * was compiled from a document version older than one the session has already
+ * saved. Installing it would play pre-edit content and, because refetches are
+ * commit-driven, it would STICK until the next unrelated edit.
+ *
+ * Checks every document the compile read (`documentRevisions`), not just the
+ * root: a child edit bumps only the CHILD's revision, so the root check alone
+ * let a pre-edit compile through. Manifests without the field (hand-built
+ * fixtures, older servers) fall back to the root-only check.
+ *
+ * The revision comparison alone still loses one race: a write UNSETTLED when
+ * the compile ran (debounced, or batch response not yet landed) hasn't bumped
+ * the ledger, so a pre-write compile passes `revisionOf` and installs anyway.
+ * `hasPendingWrite` closes it — any document in the read set with an
+ * unsettled write makes the manifest untrusted, and the caller's retry simply
+ * waits the write out. Conservative on purpose: a compile that in fact read
+ * post-write content is also deferred one cycle, which only delays install,
+ * never wrongs it.
+ */
+export function manifestTrailsLedger(
+  manifest: Pick<PlaybackManifest, "projectRevision" | "documentRevisions">,
+  projectId: string,
+  revisionOf: (id: string) => number | undefined,
+  hasPendingWrite?: (id: string) => boolean,
+): boolean {
+  const revisions = manifest.documentRevisions;
+  if (revisions !== undefined) {
+    for (const [id, compiled] of Object.entries(revisions)) {
+      if (hasPendingWrite?.(id)) return true;
+      const ledger = revisionOf(id);
+      if (ledger !== undefined && compiled < ledger) return true;
+    }
+  }
+  if (hasPendingWrite?.(projectId)) return true;
+  const rootLedger = revisionOf(projectId);
+  return rootLedger !== undefined && manifest.projectRevision < rootLedger;
+}
+
 export type ChildSpan = Readonly<{ startTime: number; endTime: number; width: number }>;
 
 /**

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -30,6 +30,7 @@ import {
   buildPlayheadMap,
   cardSpansOf,
   childSpans,
+  manifestTrailsLedger,
   type GridPlayheadMap,
   type PlayheadMap,
   type PreviewCardSpans,
@@ -548,11 +549,22 @@ function useManifestClips(
         } | null;
         if (controller.signal.aborted || !result?.manifest) return;
         // Install guard: a manifest compiled BEFORE this session's latest
-        // accepted write (its revision trails the compare-and-set ledger)
-        // is pre-write server state — never install it over the live
-        // projection; poll again once the write has landed server-side.
-        const ledger = graphDocumentsGateway.revisionOf(focusedId);
-        if (ledger !== undefined && result.manifest.projectRevision < ledger) {
+        // accepted write to ANY document in the closure is pre-write server
+        // state — never install it over the live projection; poll again once
+        // the write has landed server-side. Per-document, not just the root:
+        // a child edit bumps only the child's revision, and a stale compile
+        // that installed here used to STICK until the next unrelated commit.
+        // Pending writes count too: until the batch response lands, the
+        // ledger can't name the revision the write will produce, so a compile
+        // racing the write would pass the pure comparison — wait it out.
+        if (
+          manifestTrailsLedger(
+            result.manifest,
+            focusedId,
+            (id) => graphDocumentsGateway.revisionOf(id),
+            (id) => graphDocumentsGateway.hasPendingWrite(id),
+          )
+        ) {
           retryTimer = setTimeout(() => setStaleAt(Date.now()), MANIFEST_REFRESH_DELAY_MS);
           return;
         }

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
@@ -118,6 +118,15 @@ export type GraphDocumentsGateway = Readonly<{
   /** The compare-and-set ledger's revision for a document, if known. */
   revisionOf: (timelineId: string) => number | undefined;
   /**
+   * True while a write for this document is UNSETTLED — still in the debounce
+   * window or in a batch whose response hasn't landed. During that window the
+   * ledger cannot yet name the revision the write will produce, so a manifest
+   * compiled server-side in the gap passes a pure `revisionOf` comparison even
+   * when it read pre-write content. Install guards check this alongside the
+   * ledger and simply wait the write out.
+   */
+  hasPendingWrite: (timelineId: string) => boolean;
+  /**
    * True when this document lost a revision conflict and the live graph has
    * not been reconciled with the reloaded content. `writeClips` refuses these
    * ids outright; callers can read this to avoid reporting a write they did
@@ -688,6 +697,8 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
       for (const payload of held) installPrime(payload.document, payload.revision, payload.forUid);
     },
     revisionOf: (timelineId) => revisions.get(timelineId),
+    hasPendingWrite: (timelineId) =>
+      dirtyIds.has(timelineId) || saveInFlightIds.includes(timelineId),
     isConflicted: (timelineId) => conflictedIds.has(timelineId),
     subscribe: (listener) => {
       listeners.add(listener);

--- a/apps/timeline-gstudio001/lib/load-timeline-closure.ts
+++ b/apps/timeline-gstudio001/lib/load-timeline-closure.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import type { TimelineDocument } from "@storyboard/timeline-model/types";
 
-import { getFirebaseTimelineDocument } from "./firebase-timeline-store";
+import { getFirebaseTimelineEntry } from "./firebase-timeline-store";
 
 // The nested document closure for a timeline: the root plus every document
 // reachable through collection clips, breadth-first with a visited set (a
@@ -15,8 +15,16 @@ import { getFirebaseTimelineDocument } from "./firebase-timeline-store";
 export async function loadTimelineClosure(
   rootId: string,
   requesterUid: string,
-): Promise<{ documents: Record<string, TimelineDocument>; missing: string[] }> {
+): Promise<{
+  documents: Record<string, TimelineDocument>;
+  missing: string[];
+  /** Per-document save revisions at compile time — the manifest carries them
+   *  so the client can refuse a compile that predates its own writes to ANY
+   *  document in the closure, not just the root. */
+  revisions: Record<string, number>;
+}> {
   const documents: Record<string, TimelineDocument> = {};
+  const revisions: Record<string, number> = {};
   const missing: string[] = [];
   const queue: string[] = [rootId];
   const seen = new Set<string>([rootId]);
@@ -24,8 +32,8 @@ export async function loadTimelineClosure(
   while (queue.length > 0) {
     const id = queue.shift();
     if (id === undefined) break;
-    const document = await getFirebaseTimelineDocument(id, requesterUid).catch(() => null);
-    if (!document) {
+    const entry = await getFirebaseTimelineEntry(id, requesterUid).catch(() => null);
+    if (!entry) {
       if (id !== rootId) {
         missing.push(id);
         documents[id] = { id, title: "", clips: [] };
@@ -36,8 +44,9 @@ export async function loadTimelineClosure(
       missing.push(id);
       continue;
     }
-    documents[id] = document;
-    for (const clip of document.clips) {
+    documents[id] = entry.document;
+    revisions[id] = entry.revision;
+    for (const clip of entry.document.clips) {
       if (clip.kind !== "collection" || !clip.childTimelineId) continue;
       if (seen.has(clip.childTimelineId)) continue;
       seen.add(clip.childTimelineId);
@@ -45,5 +54,5 @@ export async function loadTimelineClosure(
     }
   }
 
-  return { documents, missing };
+  return { documents, missing, revisions };
 }

--- a/packages/timeline-domain/src/adapter.test.ts
+++ b/packages/timeline-domain/src/adapter.test.ts
@@ -105,7 +105,11 @@ const ROOT_DOC: TimelineDocument = {
   clips: packTimelineClips([
     image("img-1", 4),
     video("vid-1", 10, 2, 3),
-    collectionClip("col-clip-1", "child", "Child timeline"),
+    // duration matches the child's actual content (c-img 2 + gap 0.12 +
+    // grandchild summary 3): hydrated collections DERIVE their duration from
+    // live children, so byte-for-byte round-trip parity holds only for a
+    // FRESH summary. The stale-summary cases have their own suite below.
+    { ...collectionClip("col-clip-1", "child", "Child timeline"), duration: 5.12 },
   ]),
 };
 
@@ -408,6 +412,51 @@ describe("collectAffectedCollectionIds", () => {
       }),
     ).toEqual(["focus-root"]);
   });
+
+  // The write path derives a hydrated collection's summary from its live
+  // children, so an edit INSIDE a nested collection changes the projected
+  // clips of every ancestor document too. Without the ancestor closure, a
+  // child-only trim never rewrote the parent — the stored summary stayed
+  // stale, and the server manifest (compiled from stored parent spans) kept
+  // playing the pre-edit total no matter how fresh its compile was.
+  it("closes the write set over ancestors of every touched collection", () => {
+    const result = buildFocusedGraph(DOCUMENTS, "focus-root");
+    if (!result.ok) throw new Error(result.error);
+    const { graph } = result.value;
+
+    // A trim on "c-img" (inside "child", inside the root) rewrites BOTH.
+    expect(
+      collectAffectedCollectionIds(graph, {
+        type: "nodes-updated",
+        updates: [
+          {
+            nodeId: parseNodeId("c-img"),
+            before: graph.nodesById.get(parseNodeId("c-img"))!,
+            after: graph.nodesById.get(parseNodeId("c-img"))!,
+          },
+        ],
+      }),
+    ).toEqual(["child", "focus-root"]);
+
+    // A reorder WITHIN "child" also propagates: itemCount is unchanged but
+    // the parent's projected clip content is the child's summary, and the
+    // closure is deliberately unconditional — writes are debounced into one
+    // batch, so the extra document costs nothing.
+    expect(
+      collectAffectedCollectionIds(graph, {
+        type: "nodes-moved",
+        moves: [
+          {
+            nodeId: parseNodeId("c-img"),
+            fromParentId: parseNodeId("child"),
+            fromIndex: 0,
+            toParentId: parseNodeId("child"),
+            toIndex: 1,
+          },
+        ],
+      }),
+    ).toEqual(["child", "focus-root"]);
+  });
 });
 
 describe("duplicate media-id demotion", () => {
@@ -451,5 +500,76 @@ describe("duplicate media-id demotion", () => {
     // reference keeps its own sourceClipId round-trip.
     expect(clips.map((clip) => clip.id)).toEqual(["c-img", "c-nested-clip"]);
     expect(clips[0].src).toBe("https://example.com/c-img.jpg");
+  });
+});
+
+describe("hydrated collection durations", () => {
+  // A stored summary goes stale the moment the CHILD document is edited —
+  // writes are patch-scoped, so the parent's collection clip keeps the old
+  // duration until the parent itself is rewritten. The projection must
+  // therefore DERIVE a hydrated collection's duration from live children
+  // (like itemCount already does) instead of parroting the summary, or the
+  // preview clock drifts off the manifest AND the parent's next write
+  // re-persists the stale number.
+  function docsWithStaleSummary(): Record<string, TimelineDocument> {
+    return {
+      "stale-root": {
+        id: "stale-root",
+        title: "Stale root",
+        clips: [{ ...collectionClip("clip-kid", "kid", "Kid"), duration: 999 }],
+      },
+      kid: {
+        id: "kid",
+        title: "Kid",
+        clips: packTimelineClips([image("k-a", 4), image("k-b", 5)]),
+      },
+    };
+  }
+
+  it("derives a hydrated collection's duration from live children, not the stale summary", () => {
+    const focused = buildFocusedGraph(docsWithStaleSummary(), "stale-root");
+    if (!focused.ok) throw new Error(focused.error);
+
+    const clips = graphChildrenToClips(focused.value.graph, focused.value.details, "stale-root");
+    // 4 + gap(0.12) + 5 — the child's actual content, not the stored 999.
+    expect(clips[0].kind).toBe("collection");
+    expect(clips[0].duration).toBeCloseTo(9.12, 5);
+  });
+
+  it("keeps the stored summary for an UNHYDRATED placeholder", () => {
+    const documents = docsWithStaleSummary();
+    delete documents.kid; // the child document never loads
+    const focused = buildFocusedGraph(documents, "stale-root");
+    if (!focused.ok) throw new Error(focused.error);
+
+    const clips = graphChildrenToClips(focused.value.graph, focused.value.details, "stale-root");
+    // All anyone knows about a placeholder is its summary.
+    expect(clips[0].duration).toBe(999);
+  });
+
+  it("recurses through hydrated nesting and stops at placeholders", () => {
+    const documents: Record<string, TimelineDocument> = {
+      "nest-root": {
+        id: "nest-root",
+        title: "Nest root",
+        clips: [{ ...collectionClip("clip-mid", "mid", "Mid"), duration: 999 }],
+      },
+      mid: {
+        id: "mid",
+        title: "Mid",
+        clips: packTimelineClips([
+          image("m-a", 2),
+          { ...collectionClip("clip-deep", "deep", "Deep"), duration: 50 },
+        ]),
+      },
+      // "deep" has no document: it stays a placeholder inside mid.
+    };
+    const focused = buildFocusedGraph(documents, "nest-root");
+    if (!focused.ok) throw new Error(focused.error);
+
+    const clips = graphChildrenToClips(focused.value.graph, focused.value.details, "nest-root");
+    // mid is hydrated: derived = 2 + gap + deep's SUMMARY 50 (deep is a
+    // placeholder — its stored word is all anyone has).
+    expect(clips[0].duration).toBeCloseTo(2 + 0.12 + 50, 5);
   });
 });

--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -291,6 +291,46 @@ export function buildFocusedGraph(
 }
 
 /**
+ * Content length of a HYDRATED collection, derived from its live children
+ * with the projection's own packing (leading padding, fixed gaps) — media by
+ * the engine's trims, nested collections recursively when hydrated, else by
+ * their stored summary.
+ *
+ * This exists because a stored summary goes stale the moment the CHILD
+ * document is edited: writes are patch-scoped, so editing inside a child
+ * never rewrites the parent, and the parent's collection clip keeps the old
+ * `duration` indefinitely. Parroting it did two kinds of damage — the
+ * preview clock drifted off the manifest (which derives from child content),
+ * and, because the write path persists documents THROUGH this projection,
+ * the parent's next unrelated write RE-PERSISTED the stale number. Deriving
+ * from the live graph makes the projection agree with the manifest wherever
+ * the session has real knowledge, and writes become self-healing.
+ */
+function hydratedCollectionDuration(
+  graph: CollectionsGraph,
+  details: DetailsById,
+  collectionId: NodeId,
+): number {
+  let total = TIMELINE_LEADING_PADDING_SECONDS;
+  let first = true;
+  for (const childId of getChildren(graph, collectionId)) {
+    const node = graph.nodesById.get(childId);
+    if (!node) continue;
+    if (!first) total += CLIP_GAP_SECONDS;
+    first = false;
+    if (node.kind === "media") {
+      total += mediaDurationSeconds(node);
+      continue;
+    }
+    const detail = details[childId as string];
+    total += detail?.hydrated
+      ? hydratedCollectionDuration(graph, details, childId)
+      : (detail?.duration ?? 3);
+  }
+  return total;
+}
+
+/**
  * Project a collection's children back to TimelineClip[] — the persistence
  * write path. `startTime`/`index` are DERIVED with the same packing math as
  * `packTimelineClips` (leading padding, fixed gap); durations come from the
@@ -352,7 +392,13 @@ export function graphChildrenToClips(
     }
 
     // Collection node → collection clip referencing it as the child timeline.
-    const duration = detail?.duration ?? 3;
+    // Hydrated collections DERIVE their duration from live children (see
+    // hydratedCollectionDuration) — the same stale-summary rule itemCount
+    // below already follows; placeholders keep the stored summary, it is all
+    // anyone knows about them.
+    const duration = detail?.hydrated
+      ? hydratedCollectionDuration(graph, details, node.id)
+      : (detail?.duration ?? 3);
     nextStartTime += duration + CLIP_GAP_SECONDS;
     return {
       id: detail?.sourceClipId ?? (node.id as string),
@@ -412,29 +458,41 @@ export function collectUnhydratedDropTargets(
 /**
  * The collections whose stored documents a committed change touches — the
  * patch-scoped persistence write set.
+ *
+ * Includes every ANCESTOR of a directly-touched collection, because the
+ * write path derives a hydrated collection's summary (duration, itemCount)
+ * from its live children: an edit inside C changes the projected clips of
+ * C's parent, and transitively every document up to the focused root. Before
+ * this closure, a child-only trim never rewrote the parent, so the stored
+ * summary stayed stale and the server manifest — compiled from stored parent
+ * spans — kept playing the pre-edit total no matter how fresh its compile.
  */
 export function collectAffectedCollectionIds(
   graph: CollectionsGraph,
   patch: CollectionsPatch,
 ): readonly string[] {
   const ids = new Set<string>();
-  const parentOf = (nodeId: NodeId) => {
-    const parent = graph.parentById.get(nodeId);
-    if (parent !== undefined && parent !== null) ids.add(parent as string);
+  const addWithAncestors = (nodeId: NodeId | null | undefined) => {
+    let current = nodeId;
+    while (current !== undefined && current !== null && !ids.has(current as string)) {
+      ids.add(current as string);
+      current = graph.parentById.get(current);
+    }
   };
+  const parentOf = (nodeId: NodeId) => addWithAncestors(graph.parentById.get(nodeId));
 
   switch (patch.type) {
     case "nodes-moved":
       for (const move of patch.moves) {
-        ids.add(move.fromParentId as string);
-        ids.add(move.toParentId as string);
+        addWithAncestors(move.fromParentId);
+        addWithAncestors(move.toParentId);
       }
       break;
     case "nodes-added":
-      for (const add of patch.adds) ids.add(add.parentId as string);
+      for (const add of patch.adds) addWithAncestors(add.parentId);
       break;
     case "nodes-removed":
-      for (const removal of patch.removals) ids.add(removal.parentId as string);
+      for (const removal of patch.removals) addWithAncestors(removal.parentId);
       break;
     case "nodes-updated":
       for (const update of patch.updates) parentOf(update.nodeId);

--- a/packages/timeline-domain/src/playback-manifest.ts
+++ b/packages/timeline-domain/src/playback-manifest.ts
@@ -33,6 +33,14 @@ export type PlaybackManifest = Readonly<{
   durationSeconds: number;
   leaves: readonly PlaybackLeaf[];
   compiledAt: string;
+  /** Save revision of EVERY document the compile read, keyed by id. The
+   *  client's install guard compares each against its own write ledger:
+   *  `projectRevision` alone could only catch a stale ROOT, so a manifest
+   *  compiled before a CHILD edit landed installed fine and stuck — playing
+   *  pre-edit content until the next unrelated commit. Optional so
+   *  hand-built fixtures and older payloads keep working (absent = only the
+   *  root check applies). */
+  documentRevisions?: Readonly<Record<string, number>>;
 }>;
 
 type DocumentMap = Readonly<Record<string, TimelineDocument>>;
@@ -134,6 +142,7 @@ export function compilePlaybackManifest(
   projectId: string,
   projectRevision: number,
   compiledAt: string,
+  documentRevisions?: Readonly<Record<string, number>>,
 ): PlaybackManifest {
   const root = documents[projectId];
   if (!root) throw new Error(`Unknown project timeline "${projectId}".`);
@@ -160,6 +169,7 @@ export function compilePlaybackManifest(
     durationSeconds,
     leaves: leaves.sort((a, b) => a.timelineStart - b.timelineStart),
     compiledAt,
+    ...(documentRevisions === undefined ? {} : { documentRevisions }),
   };
 }
 


### PR DESCRIPTION
…ver ancestors

The graph projection and the server manifest disagreed on a project's duration (68.6s vs 65.8s flavors of the same 2.8s drift) whenever a child timeline was edited. Three layered causes, three fixes:

1. Projection parroted stale stored summaries. A hydrated collection now DERIVES its duration from live children (same packing math as the write path), the rule itemCount already followed. Placeholders keep the stored summary - it is all anyone knows about them.

2. The manifest install guard was child-revision-blind, and blind to in-flight writes. The compile now reports the save revision of EVERY document it read (documentRevisions), the closure loader surfaces per-doc revisions, and manifestTrailsLedger checks each against the session ledger PLUS the gateway's pending-write state - a manifest compiled mid-write can no longer install and stick.

3. The persistence write set stopped at the directly-touched document, so a child-only trim never rewrote the parent whose stored summary the manifest compiles from - the server total stayed pre-edit no matter how fresh the compile. collectAffectedCollectionIds now closes over ancestors: editing inside C rewrites C, its parent, and up to the root, so stored summaries heal on every commit.

Live-proven: 4 trims inside a hydrated sub-collection move the projection readout instantly, the server manifest converges to the same total on the next compile (root doc revision bumps from the ancestor write), and 4 undos restore both sides exactly.