### PR TITLE
Rename SubTimelineNode's window local so it stops shadowing the global

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -102,8 +102,8 @@ function SubTimelineNode({
   // present) AND the clock actually visits this collection (it has a window).
   // On the projection fallback a sub-row's local times don't line up with the
   // global clock, so the marker would lie — better absent for that ~2.5s.
-  const window = spans?.get(id);
-  const showPlayhead = previewOn && window !== undefined;
+  const clockWindow = spans?.get(id);
+  const showPlayhead = previewOn && clockWindow !== undefined;
   const dims = ITEM_SIZE_DIMENSIONS[itemSize];
 
   const [expanded, setExpanded] = useState(false);
@@ -235,7 +235,7 @@ function SubTimelineNode({
                         channel={timeChannel}
                         cellHeight={dims.gridHeight}
                         pixelsPerSecond={pixelsPerSecond}
-                        activeWindow={window}
+                        activeWindow={clockWindow}
                       />
                     ) : undefined
                   }
@@ -265,7 +265,7 @@ function SubTimelineNode({
                       focusedId={id}
                       channel={timeChannel}
                       pixelsPerSecond={pixelsPerSecond}
-                      activeWindow={window}
+                      activeWindow={clockWindow}
                     />
                   ) : undefined
                 }


### PR DESCRIPTION
Review finding 12 (polish tier): `const window = spans?.get(id)` in `SubTimelineNode` shadowed the `window` global for the whole component body, so any future use of the real global (resize listeners, `matchMedia`) would silently read the manifest span instead. Renamed to `clockWindow` at the declaration and its three use sites; no behavior change.

Verified: app lint 0 errors, sub-timeline rows render normally in the live app.

Also the first PR through the fully automated create-and-merge loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)