### PR TITLE
Two-agent GitHub loop: CI gate, Claude implement, veto-able auto-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+# The validation gate every PR must pass before auto-merge can complete.
+# Kept to the fast, deterministic checks (typecheck + lint + unit); the
+# Playwright e2e suite is intentionally excluded here — it needs a dev server
+# and real browsers, too slow/flaky to gate every merge on. Run it locally or
+# in a separate manual workflow when a change warrants it.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Typecheck, lint, unit
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install
+        run: npm install
+
+      - name: Typecheck UI package
+        working-directory: packages/ui
+        run: npx tsc --noEmit -p tsconfig.json
+
+      - name: Lint app
+        working-directory: apps/timeline-gstudio001
+        run: npm run lint
+
+      - name: Unit tests (pure logic)
+        working-directory: apps/storybook
+        run: npx vitest run --project=unit
+
+      - name: App tests (routes, gateway, model)
+        working-directory: apps/timeline-gstudio001
+        run: npx vitest run

--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -1,0 +1,99 @@
+name: Claude — implement issue
+
+# Claude's half of the two-agent loop: it implements ONE trusted issue and
+# opens a pull request, then addresses review feedback on that PR.
+#
+# Triggers (all owner-gated — a bot cannot start this, per the "no bot triggers
+# a bot automatically" rule; you introduce work by labeling or mentioning):
+#   * an issue gets the `claude` label
+#   * you comment `@claude` on an issue
+#   * a review requests changes on a Claude-authored PR (feedback loop)
+#
+# The PR is opened with LOOP_PAT, NOT github.token, on purpose: a PR created by
+# github.token does not trigger `pull_request` workflows, so the CI gate and
+# merge guard would never report and auto-merge would hang forever. LOOP_PAT
+# creates a real PR that fires those checks.
+
+on:
+  issues:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  implement:
+    name: Implement / address feedback
+    # Owner-authored triggers only. The three shapes: labeled `claude`,
+    # `@claude` comment on an issue (not a PR), or a changes-requested review
+    # on a PR. github.repository_owner is the single source of "is this me".
+    if: >-
+      github.actor == github.repository_owner &&
+      (
+        (github.event_name == 'issues' && github.event.label.name == 'claude') ||
+        (github.event_name == 'issue_comment' &&
+         github.event.issue.pull_request == null &&
+         contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' &&
+         github.event.review.state == 'changes_requested')
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ github.token }}
+          branch_name_template: "claude/issue-{{entityNumber}}-{{timestamp}}"
+          use_commit_signing: true
+          additional_permissions: |
+            actions: read
+          claude_args: |
+            --max-turns 40
+            --system-prompt "You are the implementation agent for one trusted GitHub issue (or one round of review feedback on your own PR). Follow AGENTS.md and every nested instruction file. Make the smallest complete change, add focused regression coverage, and run the closest relevant validation before finishing. On a changes-requested review, address exactly the reviewer's points on the same branch. Never broaden scope, never file new issues, never merge, and never edit .github/workflows unless the issue explicitly asks for it."
+
+      # Only the issue-triggered runs open a PR; feedback runs push to the
+      # existing branch and stop.
+      - name: Open pull request and arm auto-merge
+        if: github.event_name != 'pull_request_review' && steps.claude.outputs.branch_name != ''
+        env:
+          GH_TOKEN: ${{ secrets.LOOP_PAT }}
+          BRANCH: ${{ steps.claude.outputs.branch_name }}
+          BASE: ${{ github.event.repository.default_branch }}
+          ISSUE: ${{ github.event.issue.number }}
+          TITLE: ${{ github.event.issue.title }}
+        run: |
+          set -euo pipefail
+
+          existing="$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$BRANCH" --state open --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            echo "PR #$existing already open for $BRANCH."
+            pr="$existing"
+          else
+            body="$(printf 'Implemented by Claude from #%s. Closes #%s.\n\nAuto-merge is armed: this PR lands on its own once CI is green and the merge guard passes. Add the `hold` label to veto.' "$ISSUE" "$ISSUE")"
+            pr="$(gh pr create --repo "$GITHUB_REPOSITORY" --base "$BASE" --head "$BRANCH" \
+              --title "$TITLE" --body "$body" | grep -oE '[0-9]+$')"
+            gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body "Opened PR #${pr} — auto-merge armed (add \`hold\` to veto)."
+          fi
+
+          # Arm auto-merge. It completes only when every required check is green
+          # (CI + merge guard) and any required approvals are satisfied.
+          gh pr merge "$pr" --repo "$GITHUB_REPOSITORY" --auto --merge || \
+            echo "::warning::Could not arm auto-merge (enable it in repo settings and add required checks)."

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,0 +1,69 @@
+name: Codex — review PR
+
+# PAID TIER — DORMANT until you set repo variable CODEX_ENABLED=true AND secret
+# OPENAI_API_KEY. openai/codex-action is API-key billed; there is no supported
+# ChatGPT-subscription auth for CI (verified 2026-07). Turning this on incurs
+# OpenAI API cost per review.
+#
+# Formal approval matters: only a real GitHub "approve" review satisfies a
+# branch-protection approval requirement, which is what lets auto-merge land a
+# PR unattended. Codex's native GitHub integration leaves advisory comments,
+# NOT formal approvals — so the closed, computer-off loop needs this CI leg.
+#
+# NOTE: submitting the review below assumes Codex emits a verdict this workflow
+# can act on. Validate against a throwaway PR before trusting it to gate merges.
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+concurrency:
+  group: codex-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Review
+    if: >-
+      vars.CODEX_ENABLED == 'true' &&
+      github.event.pull_request.user.login != github.repository_owner
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Codex review
+        id: codex
+        uses: openai/codex-action@main
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          output-file: codex-verdict.md
+          prompt: |
+            You are the reviewer for pull request #${{ github.event.pull_request.number }}.
+            Review the diff of this branch against the base for correctness,
+            architecture fit (see AGENTS.md and nested instruction files),
+            performance, and TypeScript quality. Focus only on the graph and
+            dnd-collections work if the diff touches it.
+
+            End your response with EXACTLY ONE line:
+              VERDICT: APPROVE   — if you would merge as-is
+              VERDICT: REQUEST_CHANGES — if a blocking problem remains
+            Precede it with a concise, itemised review body.
+
+      - name: Submit GitHub review from verdict
+        env:
+          GH_TOKEN: ${{ secrets.LOOP_PAT }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          body="$(sed '/^VERDICT:/d' codex-verdict.md)"
+          if grep -q '^VERDICT: APPROVE' codex-verdict.md; then
+            gh pr review "$PR" --repo "$GITHUB_REPOSITORY" --approve --body "$body"
+          else
+            gh pr review "$PR" --repo "$GITHUB_REPOSITORY" --request-changes --body "$body"
+          fi

--- a/.github/workflows/codex-scout.yml
+++ b/.github/workflows/codex-scout.yml
@@ -1,0 +1,85 @@
+name: Codex — scout for next issue
+
+# PAID TIER — DORMANT until repo variable CODEX_ENABLED=true AND secret
+# OPENAI_API_KEY. API-key billed (same as codex-review).
+#
+# Manual to start (workflow_dispatch): you press "Run workflow" when you want
+# the next piece of work queued. The commented `schedule` block is the later
+# "automate it" switch — uncomment to have the scout run nightly.
+#
+# Governor (non-negotiable for an unattended loop): the scout files AT MOST ONE
+# issue, and ONLY if no open `claude` issue already exists. Without this a
+# self-fuelling loop can file unbounded issues overnight and drain Actions
+# minutes, Claude quota, and OpenAI credits.
+
+on:
+  workflow_dispatch:
+  # schedule:
+  #   - cron: "17 6 * * *"   # ~nightly; uncomment to automate
+
+concurrency:
+  group: codex-scout
+  cancel-in-progress: false
+
+jobs:
+  scout:
+    name: Find and file one issue
+    if: vars.CODEX_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Governor — bail if a claude issue is already open
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          open="$(gh issue list --repo "$GITHUB_REPOSITORY" --label claude --state open --json number --jq 'length')"
+          if [ "$open" -gt 0 ]; then
+            echo "A claude issue is already open — scout stands down."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v4
+        if: steps.gate.outputs.proceed == 'true'
+        with:
+          fetch-depth: 0
+
+      - name: Codex scan
+        if: steps.gate.outputs.proceed == 'true'
+        uses: openai/codex-action@main
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          output-file: codex-finding.md
+          prompt: |
+            Scan this repository for the single highest-value, well-scoped
+            follow-up improvement in the graph / dnd-collections work — a real
+            bug, a missing regression test, a documented invariant not yet
+            enforced, or a concrete simplification. Consolidate related points
+            into one finding. Search existing open AND closed issues first and
+            produce NOTHING if the best finding duplicates one.
+
+            If you find something worth filing, write a complete issue:
+            first line `TITLE: <imperative title>`, then a body with priority,
+            evidence (file:line), acceptance criteria, and the regression test
+            expected. If nothing clears the bar, write exactly `NO_FINDING`.
+
+      - name: File the issue
+        if: steps.gate.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.LOOP_PAT }}
+        run: |
+          set -euo pipefail
+          if grep -q '^NO_FINDING' codex-finding.md; then
+            echo "Scout found nothing worth filing."
+            exit 0
+          fi
+          title="$(grep -m1 '^TITLE:' codex-finding.md | sed 's/^TITLE:[[:space:]]*//')"
+          body="$(sed '/^TITLE:/d' codex-finding.md)"
+          [ -n "$title" ] || { echo "::error::Codex produced no TITLE line."; exit 1; }
+          gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" --body "$body" --label claude

--- a/.github/workflows/merge-guard.yml
+++ b/.github/workflows/merge-guard.yml
@@ -1,0 +1,30 @@
+name: Merge guard
+
+# The veto brake for auto-merge. GitHub's auto-merge waits on required status
+# checks but has no native "block on a label" — so this publishes a check that
+# is GREEN normally and RED whenever a `hold` label is on the PR. Make
+# `Merge guard / guard` a required check on main and auto-merge will pause the
+# moment you slap `hold` on a PR, and resume when you take it off.
+#
+# Runs on label changes AND on sync/open so the check is always freshly
+# reported for the current label set.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+jobs:
+  guard:
+    name: guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Fail while the PR is held
+        env:
+          HELD: ${{ contains(github.event.pull_request.labels.*.name, 'hold') }}
+        run: |
+          if [ "$HELD" = "true" ]; then
+            echo "::error::This PR carries the 'hold' label — auto-merge is vetoed. Remove 'hold' to release."
+            exit 1
+          fi
+          echo "No hold label — merge permitted."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,3 +36,35 @@ Use the closest relevant package scripts for typecheck, lint, tests, and Storybo
 
 - never opt out of typing by using any
 
+## Cloud agent collaboration
+
+A two-agent loop runs on GitHub Actions (see `.github/workflows/`). Roles:
+
+- **Codex owns review and issue tracking.** A review that finds an actionable
+  problem outside the PR's scope searches open AND closed issues for
+  duplicates, then files ONE consolidated GitHub issue with priority,
+  evidence (`file:line`), acceptance criteria, and the expected regression
+  test. Related findings from the same subsystem consolidate into one issue
+  unless they need independent ownership or release timing.
+- **Claude owns implementation.** It picks up one labeled issue, makes the
+  smallest complete change with focused regression coverage, and opens a PR.
+  One implementation issue per PR unless the issue defines an atomic
+  multi-part change.
+- **No bot triggers another bot automatically.** Work enters the loop only
+  through an owner-authored `claude` label or `@claude` mention; PR creation
+  is the handoff to review. This owner gate is deliberate — it is the manual
+  brake while the loop is young.
+
+Mechanics the workflows depend on:
+
+- The `claude` label (or `@claude`) starts implementation; the `hold` label
+  vetoes a PR's auto-merge at any time.
+- PRs are opened with `LOOP_PAT` (not the default Actions token) so CI and the
+  merge guard actually fire — a token-created PR triggers no downstream
+  workflow.
+- Auto-merge lands a PR once CI is green and the merge guard passes; `hold`
+  holds it. Adding a required approval (Codex's) is the later, closed-loop
+  upgrade and needs a reviewer identity distinct from the PR author.
+- The Codex review and scout workflows are the PAID tier — dormant until
+  `CODEX_ENABLED=true` and `OPENAI_API_KEY` exist, because `openai/codex-action`
+  is API-billed (no ChatGPT-subscription auth in CI).


### PR DESCRIPTION
Sets up the Codex-reviews / Claude-implements loop as GitHub Actions, split into a **free tier** that runs today and a **paid tier** that stays dormant until you opt in.

## Free tier (live once you add secrets)
- **`ci.yml`** — typecheck + lint + unit + app tests. The gate that makes auto-merge safe.
- **`claude-implement.yml`** — you label an issue `claude` (or comment `@claude`); Claude implements one issue, opens the PR via `LOOP_PAT` so CI and the merge guard actually fire, and arms auto-merge. Re-triggers on a changes-requested review to address feedback.
- **`merge-guard.yml`** — a required check that goes red while a PR has the `hold` label. Your veto brake.

## Paid tier (dormant until `CODEX_ENABLED=true` + `OPENAI_API_KEY`)
- **`codex-review.yml`** — formal approve / request-changes per PR (what branch protection needs to let auto-merge land unattended; native Codex only comments).
- **`codex-scout.yml`** — manual scan that files **one** issue, only when none is open.

`openai/codex-action` is API-key billed — no ChatGPT-subscription auth exists for CI (verified 2026-07), so the Codex legs cost money and are opt-in.

## To activate (your part — all credentials)
1. Install the **Claude GitHub App** on this repo; run `claude setup-token` locally → secret `CLAUDE_CODE_OAUTH_TOKEN`.
2. Create a fine-grained PAT (issues + PRs read/write) → secret `LOOP_PAT`.
3. Branch protection on `main`: require checks `validate` (CI) + `guard` (merge guard).

Labels `claude`/`hold` and repo auto-merge are already set. Paid tier stays off until you set `CODEX_ENABLED` + `OPENAI_API_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)