### PR TITLE
Consolidate NodeId<->string round-trip casts in graph-view

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
@@ -16,6 +16,7 @@ import {
   useCollectionsContainer,
   useCollectionsStore,
   type CollectionItemNode,
+  type NodeId,
 } from "@storyboard/ui/dnd-collections";
 
 import type { ClipDetail } from "@storyboard/timeline-domain";
@@ -101,6 +102,28 @@ type DropAnchor = Readonly<{
   /** Index at drop time — the last-resort fallback if neither survives. */
   index: number;
 }>;
+
+/**
+ * Index of the child whose id equals `nodeId`. Matches by VALUE rather than
+ * reconstructing a `NodeId` — an id may be any non-whitespace string, and
+ * `NodeId` is structurally a string, so no cast is needed either side of the
+ * comparison. Shared by every anchor resolver below instead of each closing
+ * over its own copy.
+ */
+function indexOfChildId(children: readonly NodeId[], nodeId: string): number {
+  return children.findIndex((childId) => childId === nodeId);
+}
+
+/** The `DropAnchor` neighbour ids that bracket `index` within `children`. */
+function neighborsAt(
+  children: readonly NodeId[],
+  index: number,
+): Pick<DropAnchor, "beforeId" | "afterId"> {
+  return {
+    beforeId: index > 0 ? children[index - 1] : null,
+    afterId: index < children.length ? children[index] : null,
+  };
+}
 
 /** One live drop's contribution to the status line. */
 type DropStatus =
@@ -409,16 +432,14 @@ function useNativeDrop(collectionId: string) {
   const resolveAnchoredIndex = useCallback(
     (anchor: DropAnchor): number => {
       const children = getChildren(store.getSnapshot().graph, parseNodeId(collectionId));
-      const indexOf = (nodeId: string) =>
-        children.findIndex((childId) => (childId as string) === nodeId);
       // Prefer the successor: "before whatever followed the gap" survives the
       // predecessor being removed, which is the commoner edit.
       if (anchor.afterId !== null) {
-        const at = indexOf(anchor.afterId);
+        const at = indexOfChildId(children, anchor.afterId);
         if (at >= 0) return at;
       }
       if (anchor.beforeId !== null) {
-        const at = indexOf(anchor.beforeId);
+        const at = indexOfChildId(children, anchor.beforeId);
         if (at >= 0) return at + 1;
       }
       // Both neighbors are gone (or there were none): fall back to the
@@ -666,10 +687,7 @@ export function NativeDropStrip({
       // Reuse the drag session's measurements; fall back to measuring for a
       // drop that arrived without a preceding dragover (programmatic drops).
       const geometry = dragGeometryRef.current ?? measureDragGeometry();
-      // An id may be any non-whitespace string, so match by value rather than
-      // reconstructing one — `parseNodeId` throws on an empty attribute.
-      const indexOfCard = (card: CardGeometry) =>
-        children.findIndex((childId) => (childId as string) === card.nodeId);
+      const indexOfCard = (card: CardGeometry) => indexOfChildId(children, card.nodeId);
 
       let index = children.length;
       if (geometry) {
@@ -691,11 +709,7 @@ export function NativeDropStrip({
         if (resolved >= 0) index = resolved;
       }
 
-      return {
-        index,
-        beforeId: index > 0 ? (children[index - 1] as string) : null,
-        afterId: index < children.length ? (children[index] as string) : null,
-      };
+      return { index, ...neighborsAt(children, index) };
     },
     [store, collectionId, measureDragGeometry],
   );
@@ -885,22 +899,16 @@ export function NativeDropGrid({
     (clientX: number, clientY: number): DropAnchor => {
       const children = getChildren(store.getSnapshot().graph, parseNodeId(collectionId));
       const geometry = dragGeometryRef.current ?? measureDragGeometry();
-      const indexOfId = (nodeId: string) =>
-        children.findIndex((childId) => (childId as string) === nodeId);
 
       let index = children.length;
       if (geometry) {
         const before = cellBeforeWhichPointerFalls(geometry, clientX, clientY);
         if (before) {
-          const at = indexOfId(before.nodeId);
+          const at = indexOfChildId(children, before.nodeId);
           if (at >= 0) index = at;
         }
       }
-      return {
-        index,
-        beforeId: index > 0 ? (children[index - 1] as string) : null,
-        afterId: index < children.length ? (children[index] as string) : null,
-      };
+      return { index, ...neighborsAt(children, index) };
     },
     [store, collectionId, measureDragGeometry, cellBeforeWhichPointerFalls],
   );

--- a/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
@@ -46,8 +46,8 @@ export function GraphViewNavProvider({
   const value = useMemo<GraphViewNav>(
     () => ({
       openTimeline: (nodeId) => {
-        const timelineId =
-          detailsStore.get(nodeId as string)?.duplicateOfTimelineId ?? (nodeId as string);
+        const id = nodeId as string;
+        const timelineId = detailsStore.get(id)?.duplicateOfTimelineId ?? id;
         if (timelineId === focusedId) return;
 
         const base = `/timeline/${encodeURIComponent(projectId)}/graph`;
@@ -58,12 +58,16 @@ export function GraphViewNavProvider({
 
         const { graph } = store.getSnapshot();
         const chain: string[] = [timelineId];
+        // Parse `projectId` to `NodeId` ONCE and compare `parent` against it
+        // directly, rather than casting `parent` back to `string` at every
+        // step of the walk.
+        const projectNodeId = parseNodeId(projectId);
         let parent = graph.parentById.get(parseNodeId(timelineId)) ?? null;
-        while (parent !== null && (parent as string) !== projectId) {
-          chain.unshift(parent as string);
+        while (parent !== null && parent !== projectNodeId) {
+          chain.unshift(parent);
           parent = graph.parentById.get(parent) ?? null;
         }
-        if ((parent as string | null) !== projectId) return;
+        if (parent !== projectNodeId) return;
         router.push(`${base}/${chain.map(encodeURIComponent).join("/")}`);
       },
     }),
@@ -96,13 +100,14 @@ export function OpenKeyBoundary({
     const id = target.closest<HTMLElement>("[data-node-id]")?.dataset.nodeId;
     if (!id) return;
 
-    const node = store.getSnapshot().graph.nodesById.get(parseNodeId(id));
+    const nodeId = parseNodeId(id);
+    const node = store.getSnapshot().graph.nodesById.get(nodeId);
     const opensTimeline =
       node?.kind === "collection" || detailsStore.get(id)?.duplicateOfTimelineId !== undefined;
     if (!opensTimeline) return;
 
     event.preventDefault();
-    nav?.openTimeline(parseNodeId(id));
+    nav?.openTimeline(nodeId);
   };
 
   // Plain Delete/Backspace trashes EVERY selected card — the pointer twin of


### PR DESCRIPTION
Implemented by Claude from #85. Closes #85.

Auto-merge is armed: this PR lands on its own once CI is green and the merge guard passes. Add the `hold` label to veto.