### PR TITLE
Smoke test: confirm Codex auto-review posts on new PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,3 +72,5 @@ Mechanics the workflows depend on:
 - Filing the next issue (the "scout") stays manual — owner-seeded, or a Codex
   cloud task — because subscription Codex cannot do it in CI and an unattended
   auto-scout is the most likely thing to run away.
+
+<!-- Codex auto-review enabled on this repo (native GitHub integration, advisory). -->


### PR DESCRIPTION
Tiny doc-only change to verify the native Codex GitHub integration reviews new PRs. Not auto-merged — leaving it open so the Codex review comment can land. Safe to close after.