### PR TITLE
Guard the Radix value->ItemSize cast in graph-board

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -41,6 +41,7 @@ import {
   ITEM_SIZES,
   MAX_TIMELINE_PPS,
   MIN_TIMELINE_PPS,
+  isItemSize,
   stepDownItemSize,
   type FocusSurface,
   type ItemSize,
@@ -79,7 +80,9 @@ function BoardMenu({
         <DropdownMenuLabel>Thumbnail size</DropdownMenuLabel>
         <DropdownMenuRadioGroup
           value={itemSize}
-          onValueChange={(value) => onItemSizeChange(value as ItemSize)}
+          onValueChange={(value) => {
+            if (isItemSize(value)) onItemSizeChange(value);
+          }}
         >
           {ITEM_SIZES.map((option) => (
             <DropdownMenuRadioItem key={option} value={option}>

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-config.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-config.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { ITEM_SIZES, isItemSize } from "./graph-view-config";
+
+describe("isItemSize", () => {
+  it.each(ITEM_SIZES)("accepts %s", (size) => {
+    expect(isItemSize(size)).toBe(true);
+  });
+
+  it("rejects a junk string", () => {
+    expect(isItemSize("huge")).toBe(false);
+  });
+});

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-config.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-config.ts
@@ -26,6 +26,12 @@ export type ItemSize = "xs" | "sm" | "md" | "lg" | "xl";
 
 export const ITEM_SIZES = ["xs", "sm", "md", "lg", "xl"] as const;
 
+/** Narrows an arbitrary string (e.g. a Radix radio-group value) to `ItemSize`,
+ *  validating against `ITEM_SIZES` instead of asserting the type. */
+export function isItemSize(value: string): value is ItemSize {
+  return (ITEM_SIZES as readonly string[]).includes(value);
+}
+
 /**
  * Per-size dimensions for the two surfaces.
  *


### PR DESCRIPTION
Implemented by Claude from #89. Closes #89.

Auto-merge is armed: this PR lands on its own once CI is green and the merge guard passes. Add the `hold` label to veto.