### PR TITLE
Add Codex-gated merge lane for feature PRs

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -71,7 +71,14 @@ jobs:
 
       # Only the issue-triggered runs open a PR; feedback runs push to the
       # existing branch and stop.
-      - name: Open pull request and arm auto-merge
+      #
+      # Two lanes, decided by the SOURCE ISSUE's `feature` label:
+      #   * bug/polish (no `feature`) — arm auto-merge here; it lands on green CI.
+      #   * feature (`feature` label)  — DON'T arm; label the PR `feature`, which
+      #     fires codex-gate.yml. That gate waits for Codex's verdict and arms
+      #     auto-merge only on approval, so a feature never merges out from under
+      #     Codex's review. `hold` still vetoes either lane.
+      - name: Open pull request
         if: github.event_name != 'pull_request_review' && steps.claude.outputs.branch_name != ''
         env:
           GH_TOKEN: ${{ secrets.LOOP_PAT }}
@@ -79,21 +86,32 @@ jobs:
           BASE: ${{ github.event.repository.default_branch }}
           ISSUE: ${{ github.event.issue.number }}
           TITLE: ${{ github.event.issue.title }}
+          IS_FEATURE: ${{ contains(github.event.issue.labels.*.name, 'feature') }}
         run: |
           set -euo pipefail
+          repo="$GITHUB_REPOSITORY"
 
-          existing="$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$BRANCH" --state open --json number --jq '.[0].number // empty')"
+          existing="$(gh pr list --repo "$repo" --head "$BRANCH" --state open --json number --jq '.[0].number // empty')"
           if [ -n "$existing" ]; then
             echo "PR #$existing already open for $BRANCH."
             pr="$existing"
           else
-            body="$(printf 'Implemented by Claude from #%s. Closes #%s.\n\nAuto-merge is armed: this PR lands on its own once CI is green and the merge guard passes. Add the `hold` label to veto.' "$ISSUE" "$ISSUE")"
-            pr="$(gh pr create --repo "$GITHUB_REPOSITORY" --base "$BASE" --head "$BRANCH" \
+            if [ "$IS_FEATURE" = "true" ]; then
+              body="$(printf 'Implemented by Claude from #%s. Closes #%s.\n\n**Feature PR — Codex-gated.** Auto-merge is NOT armed yet. The Codex gate waits for a review, then arms auto-merge only if Codex approves (👍). If Codex flags findings or is silent past the window, this stays open for you. Add the `hold` label to force manual merge.' "$ISSUE" "$ISSUE")"
+            else
+              body="$(printf 'Implemented by Claude from #%s. Closes #%s.\n\nAuto-merge is armed: this PR lands on its own once CI is green and the merge guard passes. Add the `hold` label to veto.' "$ISSUE" "$ISSUE")"
+            fi
+            pr="$(gh pr create --repo "$repo" --base "$BASE" --head "$BRANCH" \
               --title "$TITLE" --body "$body" | grep -oE '[0-9]+$')"
-            gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body "Opened PR #${pr} — auto-merge armed (add \`hold\` to veto)."
           fi
 
-          # Arm auto-merge. It completes only when every required check is green
-          # (CI + merge guard) and any required approvals are satisfied.
-          gh pr merge "$pr" --repo "$GITHUB_REPOSITORY" --auto --merge || \
-            echo "::warning::Could not arm auto-merge (enable it in repo settings and add required checks)."
+          if [ "$IS_FEATURE" = "true" ]; then
+            # Hand off to the Codex gate. Adding the label via LOOP_PAT (not
+            # github.token) is what lets codex-gate.yml's pull_request trigger fire.
+            gh pr edit "$pr" --repo "$repo" --add-label feature
+            gh issue comment "$ISSUE" --repo "$repo" --body "Opened PR #${pr} — feature PR, Codex-gated (auto-merge armed only if Codex approves)."
+          else
+            gh issue comment "$ISSUE" --repo "$repo" --body "Opened PR #${pr} — auto-merge armed (add \`hold\` to veto)."
+            gh pr merge "$pr" --repo "$repo" --auto --merge || \
+              echo "::warning::Could not arm auto-merge (enable it in repo settings and add required checks)."
+          fi

--- a/.github/workflows/codex-gate.yml
+++ b/.github/workflows/codex-gate.yml
@@ -1,0 +1,95 @@
+name: Codex gate — feature PRs
+
+# The human-optional review gate for FEATURE pull requests.
+#
+# Bug/polish PRs auto-merge in ~90s — faster than Codex can review, so its
+# opinion only ever lands as an after-the-fact record there. Features deserve
+# a real review window, so claude-implement.yml labels a feature PR `feature`
+# instead of arming auto-merge, and THIS workflow decides the merge:
+#
+#   * Codex approves (👍 reaction, or a formal APPROVED review) -> arm
+#     auto-merge. It lands on green CI with nobody in the loop.
+#   * Codex leaves findings (a CHANGES_REQUESTED review, or inline code
+#     comments) -> leave the PR open and ping. You address or overrule.
+#   * No verdict within the window -> leave open and ping. Your call.
+#   * `hold` label present -> stand down; you merge manually.
+#
+# Codex's signals are informal (a reaction / review comments), NOT a formal
+# GitHub approval that branch protection could require — so this POLLS for the
+# verdict rather than gating on a required check. The poll runs in one job for
+# up to ~12 min (public repo = free minutes); `timeout-minutes` caps it.
+
+on:
+  pull_request:
+    types: [labeled]
+
+concurrency:
+  group: codex-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    name: Codex verdict gate
+    # Only the `feature` label, and only on PRs the owner authored (the loop's
+    # PRs are opened via LOOP_PAT = the owner). A non-owner PR never reaches the
+    # gate, so it cannot be used to arm auto-merge on someone else's branch.
+    if: >-
+      github.event.label.name == 'feature' &&
+      github.event.pull_request.user.login == github.repository_owner
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Wait for Codex verdict, then arm auto-merge or hold
+        env:
+          GH_TOKEN: ${{ secrets.LOOP_PAT }}
+          PR: ${{ github.event.pull_request.number }}
+          BOT: "chatgpt-codex-connector[bot]"
+        run: |
+          set -euo pipefail
+          repo="$GITHUB_REPOSITORY"
+          deadline=$(( $(date +%s) + 12 * 60 ))   # give Codex up to 12 minutes
+
+          note() { gh pr comment "$PR" --repo "$repo" --body "$1"; }
+
+          while :; do
+            # Owner veto always wins, checked every pass so a late `hold` still stops it.
+            if gh pr view "$PR" --repo "$repo" --json labels --jq '.labels[].name' | grep -qx hold; then
+              note "🔒 \`hold\` present — Codex gate standing down. Merge manually when ready."
+              exit 0
+            fi
+
+            # Approval: Codex's 👍 reaction, OR a formal APPROVED review.
+            up="$(gh api "repos/$repo/issues/$PR/reactions" \
+              --jq "[.[] | select(.user.login==\"$BOT\" and .content==\"+1\")] | length" 2>/dev/null || echo 0)"
+            okrev="$(gh api "repos/$repo/pulls/$PR/reviews" \
+              --jq "[.[] | select(.user.login==\"$BOT\" and .state==\"APPROVED\")] | length" 2>/dev/null || echo 0)"
+
+            # Findings: a changes-requested review, or any inline code comments.
+            # (General summary comments go to the issue thread and are NOT treated
+            # as blocking — only line-anchored review comments are.)
+            changes="$(gh api "repos/$repo/pulls/$PR/reviews" \
+              --jq "[.[] | select(.user.login==\"$BOT\" and .state==\"CHANGES_REQUESTED\")] | length" 2>/dev/null || echo 0)"
+            inline="$(gh api "repos/$repo/pulls/$PR/comments" \
+              --jq "[.[] | select(.user.login==\"$BOT\")] | length" 2>/dev/null || echo 0)"
+
+            if [ "${up:-0}" != "0" ] || [ "${okrev:-0}" != "0" ]; then
+              gh pr merge "$PR" --repo "$repo" --auto --merge
+              note "✅ Codex approved — auto-merge armed; lands once CI is green."
+              exit 0
+            fi
+
+            if [ "${changes:-0}" != "0" ] || [ "${inline:-0}" != "0" ]; then
+              note "⚠️ Codex left review findings — auto-merge **not** armed. Address them (push to this branch) or merge manually if you disagree. Re-apply the \`feature\` label to re-run the gate."
+              exit 0
+            fi
+
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              note "⌛ No Codex verdict within 12 min — auto-merge **not** armed. Merge manually, or re-apply the \`feature\` label to wait again."
+              exit 0
+            fi
+            sleep 20
+          done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,13 +62,23 @@ Mechanics the workflows depend on:
 - PRs are opened with `LOOP_PAT` (not the default Actions token) so CI and the
   merge guard actually fire — a token-created PR triggers no downstream
   workflow.
-- Auto-merge lands a PR once CI is green and the merge guard passes; `hold`
-  holds it. There is deliberately no required approval: the veto label is the
-  brake, which keeps the loop computer-off on subscriptions alone.
-- Codex review is the NATIVE GitHub integration (chatgpt.com/codex), which
-  runs on the Codex subscription and leaves advisory comments — it informs the
-  next round but does not gate the merge. There is no API-billed Codex in CI:
-  `OPENAI_API_KEY` is never created or stored (hard constraint).
+- Two merge lanes, chosen by the source issue's `feature` label:
+  - **bug/polish** (no `feature`): auto-merge is armed at PR open and lands on
+    green CI + merge guard. Codex's review is a post-hoc record here (the PR
+    merges in ~90s, faster than Codex reviews). `hold` vetoes.
+  - **feature** (`feature` label): claude-implement does NOT arm auto-merge;
+    it labels the PR `feature`, which fires `codex-gate.yml`. That gate waits
+    up to 12 min for Codex's verdict, then arms auto-merge **only** on approval
+    (👍 reaction or a formal APPROVED review). Findings, or silence past the
+    window, leave the PR open and ping you. `hold` stands the gate down. This
+    is the "give Codex time, be out of the loop only when it approves" path.
+- There is deliberately no branch-protection-required approval: Codex's signal
+  is informal (reaction/comments), so the gate POLLS for it rather than gating
+  a required check. The `hold` label is the universal brake.
+- Codex review is the NATIVE GitHub integration (chatgpt.com/codex), on the
+  Codex subscription. "Enable credits use" stays OFF so it can never spill into
+  paid credits. There is no API-billed Codex in CI: `OPENAI_API_KEY` is never
+  created or stored (hard constraint).
 - Filing the next issue (the "scout") stays manual — owner-seeded, or a Codex
   cloud task — because subscription Codex cannot do it in CI and an unattended
   auto-scout is the most likely thing to run away.


### PR DESCRIPTION
Adds a `feature` label lane: those PRs wait for Codex's verdict (up to 12 min) and auto-merge only on approval (👍 or APPROVED review); findings or a timeout hold the PR and ping you. `hold` stands the gate down. Bug/polish PRs are unchanged. See AGENTS.md diff for the documented behavior.