### PR TITLE
Show the current scale value next to the timeline scale slider

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -109,7 +109,7 @@ function ScaleSlider({
   onChange: (pixelsPerSecond: number) => void;
 }>) {
   return (
-    <div className="flex w-28 shrink-0 items-center gap-2" title="Timeline scale">
+    <div className="flex w-36 shrink-0 items-center gap-2" title="Timeline scale">
       <Slider
         aria-label="Timeline scale"
         min={MIN_TIMELINE_PPS}
@@ -118,6 +118,12 @@ function ScaleSlider({
         value={[pixelsPerSecond]}
         onValueChange={([next]) => onChange(next)}
       />
+      <span
+        aria-hidden="true"
+        className="w-11 shrink-0 font-mono text-[10px] tabular-nums text-zinc-500"
+      >
+        {`${Math.round(pixelsPerSecond)} px/s`}
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
Implemented by Claude from #92. Closes #92.

**Feature PR — Codex-gated.** Auto-merge is NOT armed yet. The Codex gate waits for a review, then arms auto-merge only if Codex approves (👍). If Codex flags findings or is silent past the window, this stays open for you. Add the `hold` label to force manual merge.