### PR TITLE
Make Codex review the default; add chore skip lane

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -72,12 +72,15 @@ jobs:
       # Only the issue-triggered runs open a PR; feedback runs push to the
       # existing branch and stop.
       #
-      # Two lanes, decided by the SOURCE ISSUE's `feature` label:
-      #   * bug/polish (no `feature`) — arm auto-merge here; it lands on green CI.
-      #   * feature (`feature` label)  — DON'T arm; label the PR `feature`, which
-      #     fires codex-gate.yml. That gate waits for Codex's verdict and arms
-      #     auto-merge only on approval, so a feature never merges out from under
-      #     Codex's review. `hold` still vetoes either lane.
+      # Codex-gated by DEFAULT; the SOURCE ISSUE's `chore` label opts out:
+      #   * default (bug/feature/anything non-chore) — DON'T arm auto-merge;
+      #     label the PR `gated`, which fires codex-gate.yml. That gate waits
+      #     for Codex's verdict and arms auto-merge only on approval, so nothing
+      #     merges out from under Codex's review.
+      #   * chore (`chore` label) — the skip lane: arm auto-merge here so a
+      #     trivial change lands on green CI without waiting on Codex. Use it
+      #     discriminately.
+      # `hold` still vetoes either lane.
       - name: Open pull request
         if: github.event_name != 'pull_request_review' && steps.claude.outputs.branch_name != ''
         env:
@@ -86,7 +89,7 @@ jobs:
           BASE: ${{ github.event.repository.default_branch }}
           ISSUE: ${{ github.event.issue.number }}
           TITLE: ${{ github.event.issue.title }}
-          IS_FEATURE: ${{ contains(github.event.issue.labels.*.name, 'feature') }}
+          IS_CHORE: ${{ contains(github.event.issue.labels.*.name, 'chore') }}
         run: |
           set -euo pipefail
           repo="$GITHUB_REPOSITORY"
@@ -96,22 +99,23 @@ jobs:
             echo "PR #$existing already open for $BRANCH."
             pr="$existing"
           else
-            if [ "$IS_FEATURE" = "true" ]; then
-              body="$(printf 'Implemented by Claude from #%s. Closes #%s.\n\n**Feature PR — Codex-gated.** Auto-merge is NOT armed yet. The Codex gate waits for a review, then arms auto-merge only if Codex approves (👍). If Codex flags findings or is silent past the window, this stays open for you. Add the `hold` label to force manual merge.' "$ISSUE" "$ISSUE")"
+            if [ "$IS_CHORE" = "true" ]; then
+              body="$(printf 'Implemented by Claude from #%s. Closes #%s.\n\n**Chore — skip lane.** Auto-merge is armed: this lands on its own once CI is green and the merge guard passes (no Codex gate). Add the `hold` label to veto.' "$ISSUE" "$ISSUE")"
             else
-              body="$(printf 'Implemented by Claude from #%s. Closes #%s.\n\nAuto-merge is armed: this PR lands on its own once CI is green and the merge guard passes. Add the `hold` label to veto.' "$ISSUE" "$ISSUE")"
+              body="$(printf 'Implemented by Claude from #%s. Closes #%s.\n\n**Codex-gated.** Auto-merge is NOT armed yet. The Codex gate waits for a review, then arms auto-merge only if Codex approves (👍). If Codex flags findings or is silent past the window, this stays open for you. Add the `hold` label to force manual merge.' "$ISSUE" "$ISSUE")"
             fi
             pr="$(gh pr create --repo "$repo" --base "$BASE" --head "$BRANCH" \
               --title "$TITLE" --body "$body" | grep -oE '[0-9]+$')"
           fi
 
-          if [ "$IS_FEATURE" = "true" ]; then
-            # Hand off to the Codex gate. Adding the label via LOOP_PAT (not
-            # github.token) is what lets codex-gate.yml's pull_request trigger fire.
-            gh pr edit "$pr" --repo "$repo" --add-label feature
-            gh issue comment "$ISSUE" --repo "$repo" --body "Opened PR #${pr} — feature PR, Codex-gated (auto-merge armed only if Codex approves)."
-          else
-            gh issue comment "$ISSUE" --repo "$repo" --body "Opened PR #${pr} — auto-merge armed (add \`hold\` to veto)."
+          if [ "$IS_CHORE" = "true" ]; then
+            gh issue comment "$ISSUE" --repo "$repo" --body "Opened PR #${pr} — chore, auto-merge armed, Codex gate skipped (add \`hold\` to veto)."
             gh pr merge "$pr" --repo "$repo" --auto --merge || \
               echo "::warning::Could not arm auto-merge (enable it in repo settings and add required checks)."
+          else
+            # Hand off to the Codex gate. Adding the label via LOOP_PAT (not
+            # github.token) is what lets codex-gate.yml's pull_request trigger fire.
+            gh pr edit "$pr" --repo "$repo" --add-label gated
+            gh issue comment "$ISSUE" --repo "$repo" --body "Opened PR #${pr} — Codex-gated (auto-merge armed only if Codex approves)."
+          fi
           fi

--- a/.github/workflows/codex-gate.yml
+++ b/.github/workflows/codex-gate.yml
@@ -1,11 +1,11 @@
-name: Codex gate — feature PRs
+name: Codex gate — gated PRs
 
-# The human-optional review gate for FEATURE pull requests.
+# The human-optional review gate. It runs for EVERY PR by default; only the
+# `chore` skip lane bypasses it (those PRs arm auto-merge directly and never
+# get the `gated` label).
 #
-# Bug/polish PRs auto-merge in ~90s — faster than Codex can review, so its
-# opinion only ever lands as an after-the-fact record there. Features deserve
-# a real review window, so claude-implement.yml labels a feature PR `feature`
-# instead of arming auto-merge, and THIS workflow decides the merge:
+# claude-implement.yml labels a non-chore PR `gated` instead of arming
+# auto-merge, and THIS workflow decides the merge:
 #
 #   * Codex approves (👍 reaction, or a formal APPROVED review) -> arm
 #     auto-merge. It lands on green CI with nobody in the loop.
@@ -30,11 +30,11 @@ concurrency:
 jobs:
   gate:
     name: Codex verdict gate
-    # Only the `feature` label, and only on PRs the owner authored (the loop's
+    # Only the `gated` label, and only on PRs the owner authored (the loop's
     # PRs are opened via LOOP_PAT = the owner). A non-owner PR never reaches the
     # gate, so it cannot be used to arm auto-merge on someone else's branch.
     if: >-
-      github.event.label.name == 'feature' &&
+      github.event.label.name == 'gated' &&
       github.event.pull_request.user.login == github.repository_owner
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -83,12 +83,12 @@ jobs:
             fi
 
             if [ "${changes:-0}" != "0" ] || [ "${inline:-0}" != "0" ]; then
-              note "⚠️ Codex left review findings — auto-merge **not** armed. Address them (push to this branch) or merge manually if you disagree. Re-apply the \`feature\` label to re-run the gate."
+              note "⚠️ Codex left review findings — auto-merge **not** armed. Address them (push to this branch) or merge manually if you disagree. Re-apply the \`gated\` label to re-run the gate."
               exit 0
             fi
 
             if [ "$(date +%s)" -ge "$deadline" ]; then
-              note "⌛ No Codex verdict within 12 min — auto-merge **not** armed. Merge manually, or re-apply the \`feature\` label to wait again."
+              note "⌛ No Codex verdict within 12 min — auto-merge **not** armed. Merge manually, or re-apply the \`gated\` label to wait again."
               exit 0
             fi
             sleep 20

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,16 +62,18 @@ Mechanics the workflows depend on:
 - PRs are opened with `LOOP_PAT` (not the default Actions token) so CI and the
   merge guard actually fire — a token-created PR triggers no downstream
   workflow.
-- Two merge lanes, chosen by the source issue's `feature` label:
-  - **bug/polish** (no `feature`): auto-merge is armed at PR open and lands on
-    green CI + merge guard. Codex's review is a post-hoc record here (the PR
-    merges in ~90s, faster than Codex reviews). `hold` vetoes.
-  - **feature** (`feature` label): claude-implement does NOT arm auto-merge;
-    it labels the PR `feature`, which fires `codex-gate.yml`. That gate waits
-    up to 12 min for Codex's verdict, then arms auto-merge **only** on approval
-    (👍 reaction or a formal APPROVED review). Findings, or silence past the
-    window, leave the PR open and ping you. `hold` stands the gate down. This
-    is the "give Codex time, be out of the loop only when it approves" path.
+- Codex-gated by DEFAULT; the source issue's `chore` label is the skip lane:
+  - **default** (bug, feature, anything non-`chore`): claude-implement does NOT
+    arm auto-merge; it labels the PR `gated`, which fires `codex-gate.yml`.
+    That gate waits up to 12 min for Codex's verdict, then arms auto-merge
+    **only** on approval (👍 reaction or a formal APPROVED review). Findings, or
+    silence past the window, leave the PR open and ping you. This is the "give
+    Codex time, be out of the loop only when it approves" path — a bug worth
+    filing is worth a review.
+  - **chore** (`chore` label): the skip lane — auto-merge is armed at PR open
+    and lands on green CI + merge guard, no Codex gate. For genuinely trivial
+    changes (comment, version bump, rename); use it discriminately.
+  - `hold` vetoes either lane.
 - There is deliberately no branch-protection-required approval: Codex's signal
   is informal (reaction/comments), so the gate POLLS for it rather than gating
   a required check. The `hold` label is the universal brake.


### PR DESCRIPTION
Inverts the merge default: **every PR is Codex-gated** now (a bug worth filing is worth a review), and the new `chore` label is the skip lane for trivial changes (auto-merge on green CI, no gate). `feature` label retired; gate now triggers on the internal `gated` label. `hold` still vetoes. See AGENTS.md diff.