### PR TITLE
Close the Codex->Claude auto-fix loop on gated PRs

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -37,7 +37,6 @@ jobs:
       (
         (github.event_name == 'issues' && github.event.label.name == 'claude') ||
         (github.event_name == 'issue_comment' &&
-         github.event.issue.pull_request == null &&
          contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review' &&
          github.event.review.state == 'changes_requested')
@@ -69,8 +68,8 @@ jobs:
             --max-turns 80
             --system-prompt "You are the implementation agent for one trusted GitHub issue (or one round of review feedback on your own PR). Follow AGENTS.md and every nested instruction file. Make the smallest complete change, add focused regression coverage, and run the closest relevant validation before finishing. On a changes-requested review, address exactly the reviewer's points on the same branch. Never broaden scope, never file new issues, never merge, and never edit .github/workflows unless the issue explicitly asks for it."
 
-      # Only the issue-triggered runs open a PR; feedback runs push to the
-      # existing branch and stop.
+      # Only issue-origin runs open a PR; a PR-comment (@claude) or review-
+      # feedback run pushes to the existing branch, then re-arms the gate below.
       #
       # Codex-gated by DEFAULT; the SOURCE ISSUE's `chore` label opts out:
       #   * default (bug/feature/anything non-chore) — DON'T arm auto-merge;
@@ -82,7 +81,10 @@ jobs:
       #     discriminately.
       # `hold` still vetoes either lane.
       - name: Open pull request
-        if: github.event_name != 'pull_request_review' && steps.claude.outputs.branch_name != ''
+        if: >-
+          (github.event_name == 'issues' ||
+           (github.event_name == 'issue_comment' && github.event.issue.pull_request == null)) &&
+          steps.claude.outputs.branch_name != ''
         env:
           GH_TOKEN: ${{ secrets.LOOP_PAT }}
           BRANCH: ${{ steps.claude.outputs.branch_name }}
@@ -118,4 +120,24 @@ jobs:
             gh pr edit "$pr" --repo "$repo" --add-label gated
             gh issue comment "$ISSUE" --repo "$repo" --body "Opened PR #${pr} — Codex-gated (auto-merge armed only if Codex approves)."
           fi
+
+      # A PR-comment (@claude, e.g. the Codex gate's auto-fix request) or a
+      # changes-requested review means Claude just pushed a fix to an EXISTING
+      # gated PR. Re-fire the gate (toggle the `gated` label) so it re-reads
+      # Codex's verdict on the new commit. Only gated PRs loop; chore/manual
+      # PRs are left alone.
+      - name: Re-arm Codex gate after a fix
+        if: >-
+          (github.event_name == 'issue_comment' && github.event.issue.pull_request != null) ||
+          github.event_name == 'pull_request_review'
+        env:
+          GH_TOKEN: ${{ secrets.LOOP_PAT }}
+          PR: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          repo="$GITHUB_REPOSITORY"
+          if gh pr view "$PR" --repo "$repo" --json labels --jq '.labels[].name' | grep -qx gated; then
+            gh pr edit "$PR" --repo "$repo" --remove-label gated || true
+            sleep 2
+            gh pr edit "$PR" --repo "$repo" --add-label gated
           fi

--- a/.github/workflows/codex-gate.yml
+++ b/.github/workflows/codex-gate.yml
@@ -1,23 +1,23 @@
 name: Codex gate — gated PRs
 
-# The human-optional review gate. It runs for EVERY PR by default; only the
-# `chore` skip lane bypasses it (those PRs arm auto-merge directly and never
-# get the `gated` label).
+# The review gate + auto-fix loop. Runs for EVERY PR by default; only the
+# `chore` skip lane bypasses it (those arm auto-merge directly and never get
+# the `gated` label).
 #
-# claude-implement.yml labels a non-chore PR `gated` instead of arming
-# auto-merge, and THIS workflow decides the merge:
+# On each `gated` labeling it polls up to 12 min for Codex's verdict on the
+# CURRENT head commit, then:
+#   * approved (👍 reaction or APPROVED review) -> arm auto-merge. Out of the loop.
+#   * findings (CHANGES_REQUESTED review or inline code comments) -> ask Claude
+#     to address them (@claude comment), up to MAX_ROUNDS times. Claude pushes
+#     a fix, re-arms this gate, Codex re-reviews the new commit, repeat.
+#   * MAX_ROUNDS reached without convergence -> add `hold`, ping the owner.
+#   * no verdict in the window -> leave open, ping the owner.
+#   * `hold` label present -> stand down.
 #
-#   * Codex approves (👍 reaction, or a formal APPROVED review) -> arm
-#     auto-merge. It lands on green CI with nobody in the loop.
-#   * Codex leaves findings (a CHANGES_REQUESTED review, or inline code
-#     comments) -> leave the PR open and ping. You address or overrule.
-#   * No verdict within the window -> leave open and ping. Your call.
-#   * `hold` label present -> stand down; you merge manually.
-#
-# Codex's signals are informal (a reaction / review comments), NOT a formal
-# GitHub approval that branch protection could require — so this POLLS for the
-# verdict rather than gating on a required check. The poll runs in one job for
-# up to ~12 min (public repo = free minutes); `timeout-minutes` caps it.
+# Only signals NEWER than the head commit count, so a prior round's findings
+# never re-trigger a fix. Codex's signal is informal (reaction/comments), so
+# this polls rather than gating a branch-protection check. Owner-authored PRs
+# only (the loop's PRs are opened via LOOP_PAT = the owner).
 
 on:
   pull_request:
@@ -30,9 +30,6 @@ concurrency:
 jobs:
   gate:
     name: Codex verdict gate
-    # Only the `gated` label, and only on PRs the owner authored (the loop's
-    # PRs are opened via LOOP_PAT = the owner). A non-owner PR never reaches the
-    # gate, so it cannot be used to arm auto-merge on someone else's branch.
     if: >-
       github.event.label.name == 'gated' &&
       github.event.pull_request.user.login == github.repository_owner
@@ -41,40 +38,43 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
 
     steps:
-      - name: Wait for Codex verdict, then arm auto-merge or hold
+      - name: Wait for Codex verdict, then merge / auto-fix / hold
         env:
           GH_TOKEN: ${{ secrets.LOOP_PAT }}
           PR: ${{ github.event.pull_request.number }}
           BOT: "chatgpt-codex-connector[bot]"
+          MAX_ROUNDS: "5"
         run: |
           set -euo pipefail
           repo="$GITHUB_REPOSITORY"
+          mark="<!-- codex-autofix -->"
           deadline=$(( $(date +%s) + 12 * 60 ))   # give Codex up to 12 minutes
 
           note() { gh pr comment "$PR" --repo "$repo" --body "$1"; }
 
+          # Baseline: only Codex signals at/after the current head commit are
+          # THIS round's verdict. Codex re-reviews on every push, so a prior
+          # round's stale findings must not count.
+          commit_iso="$(gh pr view "$PR" --repo "$repo" --json commits --jq '.commits[-1].committedDate' 2>/dev/null || echo '')"
+          [ -n "$commit_iso" ] || commit_iso="1970-01-01T00:00:00Z"
+
           while :; do
-            # Owner veto always wins, checked every pass so a late `hold` still stops it.
             if gh pr view "$PR" --repo "$repo" --json labels --jq '.labels[].name' | grep -qx hold; then
               note "🔒 \`hold\` present — Codex gate standing down. Merge manually when ready."
               exit 0
             fi
 
-            # Approval: Codex's 👍 reaction, OR a formal APPROVED review.
             up="$(gh api "repos/$repo/issues/$PR/reactions" \
-              --jq "[.[] | select(.user.login==\"$BOT\" and .content==\"+1\")] | length" 2>/dev/null || echo 0)"
+              --jq "[.[] | select(.user.login==\"$BOT\" and .content==\"+1\" and .created_at >= \"$commit_iso\")] | length" 2>/dev/null || echo 0)"
             okrev="$(gh api "repos/$repo/pulls/$PR/reviews" \
-              --jq "[.[] | select(.user.login==\"$BOT\" and .state==\"APPROVED\")] | length" 2>/dev/null || echo 0)"
-
-            # Findings: a changes-requested review, or any inline code comments.
-            # (General summary comments go to the issue thread and are NOT treated
-            # as blocking — only line-anchored review comments are.)
+              --jq "[.[] | select(.user.login==\"$BOT\" and .state==\"APPROVED\" and .submitted_at >= \"$commit_iso\")] | length" 2>/dev/null || echo 0)"
             changes="$(gh api "repos/$repo/pulls/$PR/reviews" \
-              --jq "[.[] | select(.user.login==\"$BOT\" and .state==\"CHANGES_REQUESTED\")] | length" 2>/dev/null || echo 0)"
+              --jq "[.[] | select(.user.login==\"$BOT\" and .state==\"CHANGES_REQUESTED\" and .submitted_at >= \"$commit_iso\")] | length" 2>/dev/null || echo 0)"
             inline="$(gh api "repos/$repo/pulls/$PR/comments" \
-              --jq "[.[] | select(.user.login==\"$BOT\")] | length" 2>/dev/null || echo 0)"
+              --jq "[.[] | select(.user.login==\"$BOT\" and .created_at >= \"$commit_iso\")] | length" 2>/dev/null || echo 0)"
 
             if [ "${up:-0}" != "0" ] || [ "${okrev:-0}" != "0" ]; then
               gh pr merge "$PR" --repo "$repo" --auto --merge
@@ -83,7 +83,17 @@ jobs:
             fi
 
             if [ "${changes:-0}" != "0" ] || [ "${inline:-0}" != "0" ]; then
-              note "⚠️ Codex left review findings — auto-merge **not** armed. Address them (push to this branch) or merge manually if you disagree. Re-apply the \`gated\` label to re-run the gate."
+              # How many auto-fix rounds have we already asked for? (one marker
+              # comment per request.)
+              rounds="$(gh api "repos/$repo/issues/$PR/comments" --paginate \
+                --jq "[.[] | select(.body | contains(\"$mark\"))] | length" 2>/dev/null || echo 0)"
+              if [ "${rounds:-0}" -ge "$MAX_ROUNDS" ]; then
+                gh pr edit "$PR" --repo "$repo" --add-label hold
+                note "🛑 Codex and Claude did not converge after $MAX_ROUNDS auto-fix rounds — added \`hold\`. Over to you: review the thread and merge or close."
+                exit 0
+              fi
+              n=$(( rounds + 1 ))
+              note "$(printf '%s\n\n@claude Codex requested changes on this PR (auto-fix round %s of %s). Read Codex'\''s review comments above and address exactly those points on this branch — add or adjust tests, run the closest validation. Do not broaden scope.' "$mark" "$n" "$MAX_ROUNDS")"
               exit 0
             fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,15 @@ Mechanics the workflows depend on:
     and lands on green CI + merge guard, no Codex gate. For genuinely trivial
     changes (comment, version bump, rename); use it discriminately.
   - `hold` vetoes either lane.
+- Auto-fix loop on a gated PR: when Codex leaves findings (a changes-requested
+  review or inline code comments) instead of approving, `codex-gate.yml` posts
+  an `@claude` request instead of just pinging. That re-triggers
+  `claude-implement.yml` (its `@claude`-on-a-PR path) to address the findings
+  on the same branch and push; the workflow then re-applies the `gated` label,
+  Codex re-reviews the new commit, and the gate re-evaluates. This repeats up
+  to 5 rounds; if Codex and Claude still haven't converged, the gate adds
+  `hold` and pings the owner. The gate only counts Codex signals NEWER than the
+  head commit, so a prior round's findings never re-trigger a fix.
 - There is deliberately no branch-protection-required approval: Codex's signal
   is informal (reaction/comments), so the gate POLLS for it rather than gating
   a required check. The `hold` label is the universal brake.


### PR DESCRIPTION
When Codex flags a gated PR, the gate now hands findings back to Claude automatically (up to 5 rounds) instead of just pinging you; Claude fixes on the branch, the gate re-arms, Codex re-reviews. Bounded, stale-signal-safe, `hold`-vetoable. Also fixes a stray `fi` from #94's chore lane that hadn't executed yet. See AGENTS.md diff.