### PR TITLE
[loop test] Add a naive average() helper

### DIFF
--- a/apps/timeline-gstudio001/lib/demo-average.test.ts
+++ b/apps/timeline-gstudio001/lib/demo-average.test.ts
@@ -6,4 +6,8 @@ describe("average", () => {
   it("returns the arithmetic mean of the values", () => {
     expect(average([1, 2, 3])).toBe(2);
   });
+
+  it("throws for an empty array instead of returning NaN", () => {
+    expect(() => average([])).toThrow(/non-empty array/);
+  });
 });

--- a/apps/timeline-gstudio001/lib/demo-average.test.ts
+++ b/apps/timeline-gstudio001/lib/demo-average.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { average } from "./demo-average";
+
+describe("average", () => {
+  it("returns the arithmetic mean of the values", () => {
+    expect(average([1, 2, 3])).toBe(2);
+  });
+});

--- a/apps/timeline-gstudio001/lib/demo-average.ts
+++ b/apps/timeline-gstudio001/lib/demo-average.ts
@@ -1,0 +1,4 @@
+/** Demo helper for exercising the review loop. Safe to delete. */
+export function average(values: number[]): number {
+  return values.reduce((sum, n) => sum + n, 0) / values.length;
+}

--- a/apps/timeline-gstudio001/lib/demo-average.ts
+++ b/apps/timeline-gstudio001/lib/demo-average.ts
@@ -1,4 +1,7 @@
 /** Demo helper for exercising the review loop. Safe to delete. */
 export function average(values: number[]): number {
+  if (values.length === 0) {
+    throw new Error("average: values must be a non-empty array");
+  }
   return values.reduce((sum, n) => sum + n, 0) / values.length;
 }


### PR DESCRIPTION
Implemented by Claude from #96. Closes #96.

**Codex-gated.** Auto-merge is NOT armed yet. The Codex gate waits for a review, then arms auto-merge only if Codex approves (👍). If Codex flags findings or is silent past the window, this stays open for you. Add the `hold` label to force manual merge.