### PR TITLE
Fix auto-fix loop: re-request Codex review + widen approval detection

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -123,10 +123,13 @@ jobs:
 
       # A PR-comment (@claude, e.g. the Codex gate's auto-fix request) or a
       # changes-requested review means Claude just pushed a fix to an EXISTING
-      # gated PR. Re-fire the gate (toggle the `gated` label) so it re-reads
-      # Codex's verdict on the new commit. Only gated PRs loop; chore/manual
-      # PRs are left alone.
-      - name: Re-arm Codex gate after a fix
+      # gated PR. Two things must happen for the loop to continue:
+      #   1. Explicitly ask Codex to re-review — its auto-review fires on OWNER
+      #      pushes but NOT on this bot's fix push, so relying on "on every push"
+      #      stalls the loop. `@codex review` forces it.
+      #   2. Re-fire the gate (toggle `gated`) so it polls for the new verdict.
+      # Only gated PRs loop; chore/manual PRs are left alone.
+      - name: Re-request Codex review and re-arm the gate after a fix
         if: >-
           (github.event_name == 'issue_comment' && github.event.issue.pull_request != null) ||
           github.event_name == 'pull_request_review'
@@ -137,6 +140,7 @@ jobs:
           set -euo pipefail
           repo="$GITHUB_REPOSITORY"
           if gh pr view "$PR" --repo "$repo" --json labels --jq '.labels[].name' | grep -qx gated; then
+            gh pr comment "$PR" --repo "$repo" --body "@codex review"
             gh pr edit "$PR" --repo "$repo" --remove-label gated || true
             sleep 2
             gh pr edit "$PR" --repo "$repo" --add-label gated

--- a/.github/workflows/codex-gate.yml
+++ b/.github/workflows/codex-gate.yml
@@ -75,13 +75,15 @@ jobs:
               --jq "[.[] | select(.user.login==\"$BOT\" and .state==\"CHANGES_REQUESTED\" and .submitted_at >= \"$commit_iso\")] | length" 2>/dev/null || echo 0)"
             inline="$(gh api "repos/$repo/pulls/$PR/comments" \
               --jq "[.[] | select(.user.login==\"$BOT\" and .created_at >= \"$commit_iso\")] | length" 2>/dev/null || echo 0)"
+            # ANY Codex review of the current commit. Codex posts COMMENTED
+            # reviews (never APPROVED), so a review of this commit with no inline
+            # findings is the "nothing to flag" signal.
+            reviewed="$(gh api "repos/$repo/pulls/$PR/reviews" \
+              --jq "[.[] | select(.user.login==\"$BOT\" and .submitted_at >= \"$commit_iso\")] | length" 2>/dev/null || echo 0)"
 
-            if [ "${up:-0}" != "0" ] || [ "${okrev:-0}" != "0" ]; then
-              gh pr merge "$PR" --repo "$repo" --auto --merge
-              note "✅ Codex approved — auto-merge armed; lands once CI is green."
-              exit 0
-            fi
-
+            # Findings FIRST — a changes-requested review or any inline comment on
+            # this commit — so a review that flagged something is never mistaken
+            # for a clean pass.
             if [ "${changes:-0}" != "0" ] || [ "${inline:-0}" != "0" ]; then
               # How many auto-fix rounds have we already asked for? (one marker
               # comment per request.)
@@ -94,6 +96,15 @@ jobs:
               fi
               n=$(( rounds + 1 ))
               note "$(printf '%s\n\n@claude Codex requested changes on this PR (auto-fix round %s of %s). Read Codex'\''s review comments above and address exactly those points on this branch — add or adjust tests, run the closest validation. Do not broaden scope.' "$mark" "$n" "$MAX_ROUNDS")"
+              exit 0
+            fi
+
+            # Approval: an explicit 👍, a formal APPROVED review, OR a Codex
+            # review of this commit that left no inline findings (the clean
+            # COMMENTED-review case, since Codex never emits APPROVED).
+            if [ "${up:-0}" != "0" ] || [ "${okrev:-0}" != "0" ] || [ "${reviewed:-0}" != "0" ]; then
+              gh pr merge "$PR" --repo "$repo" --auto --merge
+              note "✅ Codex reviewed with no blocking findings — auto-merge armed; lands once CI is green."
               exit 0
             fi
 


### PR DESCRIPTION
First live auto-fix run stalled: Codex doesn't auto-re-review the bot's fix push, and it never emits APPROVED. Now the workflow explicitly `@codex review`s after a fix, and the gate accepts a clean (finding-free) Codex review as approval. See #97.