### PR TITLE
Preview reopens with a stale manifest after editing while closed

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.test.ts
@@ -9,6 +9,7 @@ import {
   childSpans,
   manifestTrailsLedger,
   mediaSpanKey,
+  nextManifestClipsState,
   type PreviewCardSpans,
 } from "./graph-playhead-model";
 
@@ -198,5 +199,27 @@ describe("manifestTrailsLedger", () => {
   it("waits on a pending ROOT write even without documentRevisions", () => {
     const manifest = { projectRevision: 5 };
     expect(manifestTrailsLedger(manifest, "root", revisionOf({ root: 5 }), (id) => id === "root")).toBe(true);
+  });
+});
+
+describe("nextManifestClipsState", () => {
+  const cached = { forId: "timeline-1" };
+
+  it("keeps the cached manifest while preview stays enabled", () => {
+    expect(nextManifestClipsState(cached, true)).toBe(cached);
+  });
+
+  // The regression this guards: an edit made while preview is CLOSED never
+  // clears `state` (the commit-driven discard effect only subscribes while
+  // enabled), so re-enabling used to hand back a manifest compiled before
+  // that edit. Disabling must drop the cache so re-enabling always starts
+  // from the live projection.
+  it("drops the cached manifest the instant preview disables", () => {
+    expect(nextManifestClipsState(cached, false)).toBeNull();
+  });
+
+  it("is a no-op on an already-empty cache either way", () => {
+    expect(nextManifestClipsState(null, true)).toBeNull();
+    expect(nextManifestClipsState(null, false)).toBeNull();
   });
 });

--- a/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.ts
@@ -106,6 +106,23 @@ export function manifestTrailsLedger(
   return rootLedger !== undefined && manifest.projectRevision < rootLedger;
 }
 
+/**
+ * The cached manifest must not survive a preview disable — `useManifestClips`
+ * calls this whenever `enabled` flips. The commit-driven discard effect in
+ * graph-preview.tsx (which clears the cache the instant a change lands and
+ * schedules a refetch) only runs while `enabled` is true, so a graph edit
+ * made while preview is CLOSED leaves the pre-edit manifest cached with
+ * nothing to clear it. Re-enabling would otherwise immediately return that
+ * stale manifest (its `forId` still matches) until a fresh fetch installs —
+ * which can fail (`!response.ok`) or sit behind the install guard
+ * (`manifestTrailsLedger`) for a while. Dropping the cache here on every
+ * disable means re-enabling always starts from the live projection and
+ * refetches fresh, never showing an earlier graph generation.
+ */
+export function nextManifestClipsState<T>(state: T | null, enabled: boolean): T | null {
+  return enabled ? state : null;
+}
+
 export type ChildSpan = Readonly<{ startTime: number; endTime: number; width: number }>;
 
 /**

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -516,9 +516,14 @@ function useManifestClips(
   // Disabling preview unsubscribes the effect below, so a commit made while
   // CLOSED would otherwise never clear the cached manifest — see
   // nextManifestClipsState's doc comment for why re-enabling must drop it.
-  useEffect(() => {
+  // Adjust during render when `enabled` flips (the repo's cascading-render-safe
+  // pattern) rather than in an effect, which react-hooks/set-state-in-effect
+  // forbids.
+  const [prevEnabled, setPrevEnabled] = useState(enabled);
+  if (prevEnabled !== enabled) {
+    setPrevEnabled(enabled);
     setState((prev) => nextManifestClipsState(prev, enabled));
-  }, [enabled]);
+  }
 
   // A committed change makes the held manifest STALE — discard it
   // immediately (the live projection is correct the instant the commit

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -31,6 +31,7 @@ import {
   cardSpansOf,
   childSpans,
   manifestTrailsLedger,
+  nextManifestClipsState,
   type GridPlayheadMap,
   type PlayheadMap,
   type PreviewCardSpans,
@@ -511,6 +512,13 @@ function useManifestClips(
   const store = useCollectionsStore();
   const [state, setState] = useState<ManifestClipsState>(null);
   const [staleAt, setStaleAt] = useState(0);
+
+  // Disabling preview unsubscribes the effect below, so a commit made while
+  // CLOSED would otherwise never clear the cached manifest — see
+  // nextManifestClipsState's doc comment for why re-enabling must drop it.
+  useEffect(() => {
+    setState((prev) => nextManifestClipsState(prev, enabled));
+  }, [enabled]);
 
   // A committed change makes the held manifest STALE — discard it
   // immediately (the live projection is correct the instant the commit


### PR DESCRIPTION
Implemented by Claude from #102. Closes #102.

**Codex-gated.** Auto-merge is NOT armed yet. The Codex gate waits for a review, then arms auto-merge only if Codex approves (👍). If Codex flags findings or is silent past the window, this stays open for you. Add the `hold` label to force manual merge.