### PR TITLE
Add CI-failure auto-fix so red builds self-heal

### DIFF
--- a/.github/workflows/ci-autofix.yml
+++ b/.github/workflows/ci-autofix.yml
@@ -1,0 +1,88 @@
+name: CI auto-fix — loop PRs
+
+# The second half of the auto-fix loop. codex-gate.yml handles Codex's
+# findings (correctness/design); THIS handles CI failures (the repo's hard
+# gates — types, lint, unit tests) that Codex structurally can't catch because
+# it doesn't run the suite. Without it, a PR that passes Codex but fails CI
+# dead-ends: auto-merge is armed but blocked on a red required check forever.
+#
+# On a failing CI run for a loop PR it asks Claude to fix it (@claude, which
+# fires claude-implement's PR path), then Claude pushes, CI re-runs, and — for
+# gated PRs — Codex re-reviews. Shared 5-round cap with the Codex auto-fixes
+# (both post a comment containing "autofix"), so CI-fail -> fix -> CI-fail
+# cannot loop forever; at the cap it adds `hold` and pings the owner.
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+concurrency:
+  group: ci-autofix-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  autofix:
+    name: Ask Claude to fix CI
+    # Only a FAILED CI run, for a pull request, on a loop branch. The PR's
+    # owner/hold/cap checks that need an API lookup happen in the step.
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      startsWith(github.event.workflow_run.head_branch, 'claude/issue-')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      actions: read
+
+    steps:
+      - name: Hand the CI failure to Claude
+        env:
+          # LOOP_PAT posts the @claude comment — a github.token comment would
+          # not trigger claude-implement (bot events don't start workflows).
+          GH_TOKEN: ${{ secrets.LOOP_PAT }}
+          # The workflow token can read the failed run's logs (actions: read);
+          # LOOP_PAT is not scoped to Actions.
+          RO_TOKEN: ${{ github.token }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          MAX_ROUNDS: "5"
+        run: |
+          set -euo pipefail
+          repo="$GITHUB_REPOSITORY"
+
+          pr="$(gh pr list --repo "$repo" --head "$BRANCH" --state open --json number --jq '.[0].number // empty')"
+          [ -n "$pr" ] || { echo "No open PR for $BRANCH — nothing to fix."; exit 0; }
+
+          # Owner-authored loop PR only (the loop opens PRs via LOOP_PAT = owner).
+          author="$(gh pr view "$pr" --repo "$repo" --json author --jq '.author.login')"
+          owner="$(gh api "repos/$repo" --jq '.owner.login')"
+          [ "$author" = "$owner" ] || { echo "PR #$pr not owner-authored — standing down."; exit 0; }
+
+          # `hold` vetoes.
+          if gh pr view "$pr" --repo "$repo" --json labels --jq '.labels[].name' | grep -qx hold; then
+            echo "hold present on #$pr — standing down."; exit 0
+          fi
+
+          # Shared cap across Codex + CI auto-fixes: any prior request comment
+          # (Codex or CI) contains "autofix".
+          rounds="$(gh api "repos/$repo/issues/$pr/comments" --paginate \
+            --jq '[.[] | select(.body | contains("autofix"))] | length' 2>/dev/null || echo 0)"
+          if [ "${rounds:-0}" -ge "$MAX_ROUNDS" ]; then
+            gh pr edit "$pr" --repo "$repo" --add-label hold
+            gh pr comment "$pr" --repo "$repo" --body "🛑 Auto-fix cap ($MAX_ROUNDS rounds) reached with CI still red — added \`hold\`. Over to you: read the failing check and fix or close."
+            exit 0
+          fi
+
+          # Concrete errors from the failed job, read with the workflow token.
+          errs="$(GH_TOKEN="$RO_TOKEN" gh run view "$RUN_ID" --repo "$repo" --log-failed 2>/dev/null \
+            | grep -iE 'error|failed|cannot find|type error|✕|✗|assert' \
+            | grep -viE 'no error|0 error' | head -20 || true)"
+          [ -n "$errs" ] || errs="(could not extract specific lines — read the failing 'Typecheck, lint, unit' job)"
+
+          n=$(( rounds + 1 ))
+          gh pr comment "$pr" --repo "$repo" --body "$(printf '<!-- ci-autofix -->\n\n@claude The required CI check **Typecheck, lint, unit** failed on this PR (auto-fix round %s of %s). Fix the errors on this branch — types, lint, or unit tests — then run the relevant checks to confirm clean. Do not broaden scope.\n\nFailing output:\n```\n%s\n```' "$n" "$MAX_ROUNDS" "$errs")"
+          echo "Asked Claude to fix CI on #$pr (round $n)."

--- a/.github/workflows/codex-gate.yml
+++ b/.github/workflows/codex-gate.yml
@@ -85,10 +85,11 @@ jobs:
             # this commit — so a review that flagged something is never mistaken
             # for a clean pass.
             if [ "${changes:-0}" != "0" ] || [ "${inline:-0}" != "0" ]; then
-              # How many auto-fix rounds have we already asked for? (one marker
-              # comment per request.)
+              # How many auto-fix rounds already, across BOTH Codex and CI
+              # (every request comment — `codex-autofix` or `ci-autofix` —
+              # contains "autofix"), so the cap is shared and can't be doubled.
               rounds="$(gh api "repos/$repo/issues/$PR/comments" --paginate \
-                --jq "[.[] | select(.body | contains(\"$mark\"))] | length" 2>/dev/null || echo 0)"
+                --jq '[.[] | select(.body | contains("autofix"))] | length' 2>/dev/null || echo 0)"
               if [ "${rounds:-0}" -ge "$MAX_ROUNDS" ]; then
                 gh pr edit "$PR" --repo "$repo" --add-label hold
                 note "🛑 Codex and Claude did not converge after $MAX_ROUNDS auto-fix rounds — added \`hold\`. Over to you: review the thread and merge or close."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,15 +74,21 @@ Mechanics the workflows depend on:
     and lands on green CI + merge guard, no Codex gate. For genuinely trivial
     changes (comment, version bump, rename); use it discriminately.
   - `hold` vetoes either lane.
-- Auto-fix loop on a gated PR: when Codex leaves findings (a changes-requested
-  review or inline code comments) instead of approving, `codex-gate.yml` posts
-  an `@claude` request instead of just pinging. That re-triggers
-  `claude-implement.yml` (its `@claude`-on-a-PR path) to address the findings
-  on the same branch and push; the workflow then re-applies the `gated` label,
-  Codex re-reviews the new commit, and the gate re-evaluates. This repeats up
-  to 5 rounds; if Codex and Claude still haven't converged, the gate adds
-  `hold` and pings the owner. The gate only counts Codex signals NEWER than the
-  head commit, so a prior round's findings never re-trigger a fix.
+- Auto-fix loop, from BOTH reviewers:
+  - **Codex findings** (`codex-gate.yml`): a changes-requested review or inline
+    comments → posts an `@claude` request → `claude-implement.yml`'s `@claude`-
+    on-a-PR path fixes on the branch and pushes → the workflow re-applies
+    `gated` and `@codex review`s → the gate re-evaluates the new commit. The
+    gate only counts Codex signals NEWER than the head commit, so a prior
+    round's findings never re-trigger.
+  - **CI failures** (`ci-autofix.yml`): a failing `CI` run on a loop PR →
+    posts an `@claude` request with the failing output → same fix path. This
+    catches types/lint/tests that Codex structurally can't (it doesn't run the
+    suite), which would otherwise strand a Codex-approved PR on a red required
+    check.
+  - Both share ONE 5-round cap (every request comment contains "autofix"); at
+    the cap the responsible workflow adds `hold` and pings the owner. `hold`
+    breaks the loop anytime.
 - There is deliberately no branch-protection-required approval: Codex's signal
   is informal (reaction/comments), so the gate POLLS for it rather than gating
   a required check. The `hold` label is the universal brake.


### PR DESCRIPTION
Codex can't catch CI failures (it doesn't run the suite), so a Codex-approved PR that fails lint/types/tests would strand forever — as #104 did. ci-autofix.yml hands a failing CI run to Claude via the existing @claude fix path, sharing one 5-round cap with the Codex auto-fixes. See AGENTS.md diff.