### PR TITLE
Label cap-exhausted PRs with needs-human

### DIFF
--- a/.github/workflows/ci-autofix.yml
+++ b/.github/workflows/ci-autofix.yml
@@ -72,8 +72,8 @@ jobs:
           rounds="$(gh api "repos/$repo/issues/$pr/comments" --paginate \
             --jq '[.[] | select(.body | contains("autofix"))] | length' 2>/dev/null || echo 0)"
           if [ "${rounds:-0}" -ge "$MAX_ROUNDS" ]; then
-            gh pr edit "$pr" --repo "$repo" --add-label hold
-            gh pr comment "$pr" --repo "$repo" --body "🛑 Auto-fix cap ($MAX_ROUNDS rounds) reached with CI still red — added \`hold\`. Over to you: read the failing check and fix or close."
+            gh pr edit "$pr" --repo "$repo" --add-label hold --add-label needs-human
+            gh pr comment "$pr" --repo "$repo" --body "🛑 Auto-fix cap ($MAX_ROUNDS rounds) reached with CI still red — added \`hold\` + \`needs-human\`. Over to you: read the failing check and fix or close."
             exit 0
           fi
 

--- a/.github/workflows/codex-gate.yml
+++ b/.github/workflows/codex-gate.yml
@@ -91,8 +91,8 @@ jobs:
               rounds="$(gh api "repos/$repo/issues/$PR/comments" --paginate \
                 --jq '[.[] | select(.body | contains("autofix"))] | length' 2>/dev/null || echo 0)"
               if [ "${rounds:-0}" -ge "$MAX_ROUNDS" ]; then
-                gh pr edit "$PR" --repo "$repo" --add-label hold
-                note "🛑 Codex and Claude did not converge after $MAX_ROUNDS auto-fix rounds — added \`hold\`. Over to you: review the thread and merge or close."
+                gh pr edit "$PR" --repo "$repo" --add-label hold --add-label needs-human
+                note "🛑 Codex and Claude did not converge after $MAX_ROUNDS auto-fix rounds — added \`hold\` + \`needs-human\`. Over to you: review the thread and merge or close."
                 exit 0
               fi
               n=$(( rounds + 1 ))

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,8 +87,10 @@ Mechanics the workflows depend on:
     suite), which would otherwise strand a Codex-approved PR on a red required
     check.
   - Both share ONE 5-round cap (every request comment contains "autofix"); at
-    the cap the responsible workflow adds `hold` and pings the owner. `hold`
-    breaks the loop anytime.
+    the cap the responsible workflow adds `hold` (stops the merge) AND
+    `needs-human` (a filterable "the loop gave up" marker, distinct from a
+    manually-vetoed `hold`) and pings the owner. `hold` breaks the loop
+    anytime.
 - There is deliberately no branch-protection-required approval: Codex's signal
   is informal (reaction/comments), so the gate POLLS for it rather than gating
   a required check. The `hold` label is the universal brake.


### PR DESCRIPTION
At the 5-round auto-fix cap, the gate/ci-autofix now add `needs-human` (a filterable 'loop gave up' marker) alongside `hold`, so escalated PRs are distinguishable from manually-held ones.