### PR TITLE
Graph drops silently ignore media files without a MIME type

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-dropped-media.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-dropped-media.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyDroppedMedia } from "./graph-dropped-media";
+
+/** A File whose reported MIME type and name are both controlled. */
+function fileWith(name: string, type: string): File {
+  return new File([new Uint8Array([0])], name, { type });
+}
+
+describe("classifyDroppedMedia", () => {
+  it("classifies by MIME prefix when the browser supplies one", () => {
+    expect(classifyDroppedMedia(fileWith("a.png", "image/png"))).toBe("image");
+    expect(classifyDroppedMedia(fileWith("a.mp4", "video/mp4"))).toBe("video");
+    // The name is irrelevant when a usable MIME type is present.
+    expect(classifyDroppedMedia(fileWith("noext", "image/webp"))).toBe("image");
+  });
+
+  it.each([
+    ["frame.png", "image"],
+    ["frame.PNG", "image"],
+    ["photo.jpg", "image"],
+    ["photo.jpeg", "image"],
+    ["art.webp", "image"],
+    ["clip.mp4", "video"],
+    ["clip.webm", "video"],
+    ["clip.mov", "video"],
+  ] as const)("falls back to the %s extension when the MIME type is empty", (name, kind) => {
+    expect(classifyDroppedMedia(fileWith(name, ""))).toBe(kind);
+  });
+
+  it("falls back to the extension for application/octet-stream", () => {
+    expect(classifyDroppedMedia(fileWith("frame.png", "application/octet-stream"))).toBe("image");
+    expect(classifyDroppedMedia(fileWith("clip.mp4", "application/octet-stream"))).toBe("video");
+  });
+
+  it("ignores unrelated file types", () => {
+    // Unrelated MIME type.
+    expect(classifyDroppedMedia(fileWith("notes.txt", "text/plain"))).toBeNull();
+    // Unresolved MIME type with an unsupported extension.
+    expect(classifyDroppedMedia(fileWith("archive.zip", ""))).toBeNull();
+    expect(classifyDroppedMedia(fileWith("doc.pdf", "application/octet-stream"))).toBeNull();
+    // No extension and no usable MIME type.
+    expect(classifyDroppedMedia(fileWith("README", ""))).toBeNull();
+  });
+});

--- a/apps/timeline-gstudio001/components/graph-view/graph-dropped-media.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-dropped-media.ts
@@ -1,0 +1,57 @@
+// Classifying an OS FILE drop for the graph. Kept as a pure `.ts` module —
+// no React/DOM — so it can be unit-tested (the app's Vitest cannot parse the
+// `.tsx` component that consumes it) and so the rule lives in ONE place.
+//
+// The File API lets `File.type` be an empty string when the user agent cannot
+// determine a MIME type (https://www.w3.org/TR/FileAPI/#dfn-type), and some
+// agents report `application/octet-stream` instead. Filtering purely on an
+// `image/` or `video/` MIME prefix therefore silently discarded valid media
+// that the upload boundary (getMediaContentType in firebase-media-store) can
+// already classify from the filename extension. This helper mirrors that same
+// extension fallback so the graph accepts exactly what the pipeline can store.
+
+/** The media kinds a dropped file can become in the graph. */
+export type DroppedMediaKind = "image" | "video";
+
+/**
+ * Image/video extensions the upload pipeline already supports (see
+ * `getMediaContentType`). Kept deliberately in lockstep with it: broadening
+ * one without the other reintroduces the accept-then-reject mismatch this
+ * fixes. Only used when the browser gives no usable MIME type.
+ */
+const EXTENSION_KINDS: Readonly<Record<string, DroppedMediaKind>> = {
+  jpg: "image",
+  jpeg: "image",
+  png: "image",
+  webp: "image",
+  mp4: "video",
+  webm: "video",
+  mov: "video",
+};
+
+/** MIME types the browser could not resolve, so the extension must decide. */
+function isUnresolvedMime(type: string): boolean {
+  return type === "" || type === "application/octet-stream";
+}
+
+/** The supported media kind for a filename extension, or null. */
+function extensionKind(filename: string): DroppedMediaKind | null {
+  const dot = filename.lastIndexOf(".");
+  if (dot < 0) return null;
+  return EXTENSION_KINDS[filename.slice(dot + 1).toLowerCase()] ?? null;
+}
+
+/**
+ * The media kind a dropped file should upload as, or `null` to ignore it.
+ *
+ * Prefers the browser's MIME type (`image/*`, `video/*`). When the agent
+ * supplied no usable type (empty or `application/octet-stream`), falls back to
+ * the filename extension — but ONLY the extensions the upload pipeline already
+ * supports, so the graph never accepts a drop the server would reject.
+ */
+export function classifyDroppedMedia(file: File): DroppedMediaKind | null {
+  if (file.type.startsWith("image/")) return "image";
+  if (file.type.startsWith("video/")) return "video";
+  if (isUnresolvedMime(file.type)) return extensionKind(file.name);
+  return null;
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/lib/graph-view-events";
 import { probeVideoFile, uploadTimelineMedia } from "@/lib/timeline-media-client";
 
+import { classifyDroppedMedia, type DroppedMediaKind } from "./graph-dropped-media";
 import { parkPendingDetail, unparkPendingDetail } from "./graph-pending-details";
 
 // The NATIVE drag-and-drop seam for the graph strips. dnd-kit owns
@@ -451,9 +452,15 @@ function useNativeDrop(collectionId: string) {
 
   const dropFiles = useCallback(
     async (files: readonly File[], anchor: DropAnchor) => {
-      const media = files.filter(
-        (file) => file.type.startsWith("image/") || file.type.startsWith("video/"),
-      );
+      // Classify each file to its media kind (or drop it). The kind is carried
+      // forward so the upload path never re-derives it from the MIME type: a
+      // supported file can arrive with an empty or `application/octet-stream`
+      // type, which would misread a video as an image.
+      type ClassifiedFile = Readonly<{ file: File; kind: DroppedMediaKind }>;
+      const media: readonly ClassifiedFile[] = files.flatMap((file) => {
+        const kind = classifyDroppedMedia(file);
+        return kind ? [{ file, kind }] : [];
+      });
       if (media.length === 0) return;
       const token = ++dropTokenRef.current;
       setDropStatus(token, { status: "uploading", count: media.length });
@@ -471,8 +478,8 @@ function useNativeDrop(collectionId: string) {
         const results: readonly UploadResult[] = await mapWithConcurrency(
           media,
           MAX_CONCURRENT_MEDIA,
-          async (file): Promise<UploadResult> => {
-            const isVideo = file.type.startsWith("video/");
+          async ({ file, kind }): Promise<UploadResult> => {
+            const isVideo = kind === "video";
             // ONE decode per video: duration and poster frame together. The
             // probe is handed to the upload so it does not decode again.
             const probe = isVideo ? await probeVideoFile(file, { signal }) : null;


### PR DESCRIPTION
Implemented by Claude from #108. Closes #108.

**Codex-gated.** Auto-merge is NOT armed yet. The Codex gate waits for a review, then arms auto-merge only if Codex approves (👍). If Codex flags findings or is silent past the window, this stays open for you. Add the `hold` label to force manual merge.