### PR TITLE
Sub-timeline row shows 'loading…' forever when hydration fails

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timeline-status.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timeline-status.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  subTimelineRowStatus,
+  subTimelineRowStatusLabel,
+} from "./graph-sub-timeline-status";
+
+describe("subTimelineRowStatus", () => {
+  it("is idle while collapsed, regardless of hydrated/failed", () => {
+    expect(subTimelineRowStatus({ expanded: false, hydrated: false, failed: false })).toBe("idle");
+    expect(subTimelineRowStatus({ expanded: false, hydrated: true, failed: false })).toBe("idle");
+    expect(subTimelineRowStatus({ expanded: false, hydrated: false, failed: true })).toBe("idle");
+  });
+
+  it("is idle once expanded and hydrated (successful path shows no badge)", () => {
+    expect(subTimelineRowStatus({ expanded: true, hydrated: true, failed: false })).toBe("idle");
+    // A stale `failed` flag never overrides a real hydration.
+    expect(subTimelineRowStatus({ expanded: true, hydrated: true, failed: true })).toBe("idle");
+  });
+
+  it("is loading while expanded and genuinely in flight", () => {
+    expect(subTimelineRowStatus({ expanded: true, hydrated: false, failed: false })).toBe("loading");
+  });
+
+  it("is failed when an expanded row's attempt finished without hydrating", () => {
+    expect(subTimelineRowStatus({ expanded: true, hydrated: false, failed: true })).toBe("failed");
+  });
+});
+
+describe("subTimelineRowStatusLabel", () => {
+  it("renders the in-flight copy for loading", () => {
+    expect(subTimelineRowStatusLabel("loading")).toBe("loading…");
+  });
+
+  it("renders a distinct, retry-hinting copy for failed", () => {
+    const label = subTimelineRowStatusLabel("failed");
+    expect(label).not.toBe("loading…");
+    expect(label).toMatch(/retry/i);
+  });
+});

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timeline-status.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timeline-status.ts
@@ -1,0 +1,28 @@
+/**
+ * Pure status derivation for a sub-timeline row's pending badge.
+ *
+ * Split out of `graph-sub-timelines.tsx` (a `.tsx` the app's vitest cannot
+ * parse) so the three-way label logic is unit-testable in isolation.
+ *
+ * A row lazily hydrates its clips on first expand. Three outcomes matter:
+ *   - `idle`    — collapsed, or expanded and already hydrated: no badge.
+ *   - `loading` — expanded, genuinely in flight (attempt not yet failed).
+ *   - `failed`  — expanded, an attempt finished without hydrating. Without
+ *                 this the row claimed "loading…" forever on a document that
+ *                 could never load (see graph-hydration's failure paths).
+ */
+export type SubTimelineRowStatus = "idle" | "loading" | "failed";
+
+export function subTimelineRowStatus(
+  input: Readonly<{ expanded: boolean; hydrated: boolean; failed: boolean }>,
+): SubTimelineRowStatus {
+  if (!input.expanded || input.hydrated) return "idle";
+  return input.failed ? "failed" : "loading";
+}
+
+/** The badge copy for each non-idle status (`idle` renders no badge). */
+export function subTimelineRowStatusLabel(
+  status: Exclude<SubTimelineRowStatus, "idle">,
+): string {
+  return status === "failed" ? "couldn't load — collapse and expand to retry" : "loading…";
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useContext, useMemo, useState } from "react";
+import { useContext, useMemo, useRef, useState } from "react";
 import { FolderDown, Folder, FolderOpen } from "lucide-react";
 
 import {
@@ -18,6 +18,10 @@ import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 import { useClipDetail, useGraphDetailsStore, useTimelineTitle } from "./graph-details-context";
 import { hydrateTimeline } from "./graph-hydration";
 import { NativeDropGrid, NativeDropStrip } from "./graph-native-drop";
+import {
+  subTimelineRowStatus,
+  subTimelineRowStatusLabel,
+} from "./graph-sub-timeline-status";
 import { GraphViewNavContext } from "./graph-navigation";
 import {
   GraphGridPlayhead,
@@ -109,6 +113,13 @@ function SubTimelineNode({
   const [expanded, setExpanded] = useState(false);
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
+  // "Attempted and failed" flag: hydration has several paths that leave the
+  // details store un-hydrated permanently (document fetch failed, spec build
+  // refused, store rejected). Those report to the global banner but left THIS
+  // row stuck on "loading…". `attemptRef` fences stale resolutions so a slow
+  // failed attempt can't flip a newer, still-in-flight expand back to failed.
+  const [failed, setFailed] = useState(false);
+  const attemptRef = useRef(0);
 
   // Primitive subscriptions only (see useCollectionChildIds). The display
   // name is the gateway document title (source of truth), with the graph node
@@ -123,12 +134,25 @@ function SubTimelineNode({
     getChildren(snapshot.graph, collectionId).length,
   );
   const childIds = useCollectionChildIds(collectionId);
+  const status = subTimelineRowStatus({ expanded, hydrated, failed });
 
   const toggle = () => {
     if (!expanded && !hydrated) {
-      // Fire-and-forget: the store subscription re-renders this node once the
-      // children land, and the body is gated on `hydrated` until then.
-      void hydrateTimeline(store, detailsStore, id);
+      // Clear any prior failure for this fresh attempt, then hydrate. The store
+      // subscription re-renders this node once the children land; the body is
+      // gated on `hydrated` until then. If the attempt finishes WITHOUT
+      // hydrating (see graph-hydration's failure paths), flip the row to a
+      // "failed" badge instead of leaving it on "loading…" forever. Setting
+      // state from the resolved promise (not an effect) keeps clear of the
+      // repo's react-hooks/set-state-in-effect rule.
+      setFailed(false);
+      const attempt = ++attemptRef.current;
+      void hydrateTimeline(store, detailsStore, id)
+        .catch(() => undefined)
+        .then(() => {
+          if (attempt !== attemptRef.current) return; // superseded by a newer expand
+          if (detailsStore.get(id)?.hydrated !== true) setFailed(true);
+        });
     }
     setExpanded((current) => !current);
   };
@@ -190,9 +214,15 @@ function SubTimelineNode({
         <span className="shrink-0 rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] text-zinc-300">
           {hydrated ? liveCount : (detail?.itemCount ?? 0)} clips
         </span>
-        {expanded && !hydrated && (
-          <span className="shrink-0 rounded border border-zinc-700 px-1.5 py-0.5 text-[10px] text-zinc-500">
-            loading…
+        {status !== "idle" && (
+          <span
+            className={
+              status === "failed"
+                ? "shrink-0 rounded border border-red-700/60 px-1.5 py-0.5 text-[10px] text-red-400"
+                : "shrink-0 rounded border border-zinc-700 px-1.5 py-0.5 text-[10px] text-zinc-500"
+            }
+          >
+            {subTimelineRowStatusLabel(status)}
           </span>
         )}
         <span className="grow" />


### PR DESCRIPTION
Implemented by Claude from #111. Closes #111.

**Codex-gated.** Auto-merge is NOT armed yet. The Codex gate waits for a review, then arms auto-merge only if Codex approves (👍). If Codex flags findings or is silent past the window, this stays open for you. Add the `hold` label to force manual merge.