### PR TITLE
Preview manifest never retries after a failed fetch while preview stays open

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.test.ts
@@ -11,6 +11,7 @@ import {
   MAX_MANIFEST_FETCH_RETRIES,
   mediaSpanKey,
   nextManifestClipsState,
+  nextManifestFailureCount,
   shouldRetryManifestFetch,
   type PreviewCardSpans,
 } from "./graph-playhead-model";
@@ -223,6 +224,31 @@ describe("nextManifestClipsState", () => {
   it("is a no-op on an already-empty cache either way", () => {
     expect(nextManifestClipsState(null, true)).toBeNull();
     expect(nextManifestClipsState(null, false)).toBeNull();
+  });
+});
+
+describe("nextManifestFailureCount", () => {
+  it("keeps the streak while preview stays enabled", () => {
+    expect(nextManifestFailureCount(MAX_MANIFEST_FETCH_RETRIES + 1, true)).toBe(
+      MAX_MANIFEST_FETCH_RETRIES + 1,
+    );
+    expect(nextManifestFailureCount(0, true)).toBe(0);
+  });
+
+  // The regression this guards: a session that reached the retry cap left the
+  // count past MAX_MANIFEST_FETCH_RETRIES. Reopening preview for the SAME
+  // focusedId does not trip the fetch effect's focusedId-change reset, so the
+  // capped count carried over and the first failed fetch after reopening
+  // scheduled no retry. Zeroing on disable means every reopen starts fresh.
+  it("resets the streak the instant preview disables", () => {
+    expect(nextManifestFailureCount(MAX_MANIFEST_FETCH_RETRIES + 1, false)).toBe(0);
+    expect(nextManifestFailureCount(3, false)).toBe(0);
+  });
+
+  // Disabling already zeroed it, so the enable flip only has to leave 0 alone.
+  it("leaves an already-reset streak at zero across a reopen", () => {
+    expect(nextManifestFailureCount(0, false)).toBe(0);
+    expect(nextManifestFailureCount(0, true)).toBe(0);
   });
 });
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.test.ts
@@ -8,8 +8,10 @@ import {
   cardSpansOf,
   childSpans,
   manifestTrailsLedger,
+  MAX_MANIFEST_FETCH_RETRIES,
   mediaSpanKey,
   nextManifestClipsState,
+  shouldRetryManifestFetch,
   type PreviewCardSpans,
 } from "./graph-playhead-model";
 
@@ -221,5 +223,33 @@ describe("nextManifestClipsState", () => {
   it("is a no-op on an already-empty cache either way", () => {
     expect(nextManifestClipsState(null, true)).toBeNull();
     expect(nextManifestClipsState(null, false)).toBeNull();
+  });
+});
+
+describe("shouldRetryManifestFetch", () => {
+  // The regression this guards: a transient 500/network blip left the pane on
+  // the shallow live projection forever because no failure path advanced the
+  // fetch. The caller now retries on failure — but only up to a cap, so a
+  // hard-down endpoint stops polling on an idle session.
+  it("retries every consecutive failure up to the cap", () => {
+    for (let attempt = 1; attempt <= MAX_MANIFEST_FETCH_RETRIES; attempt += 1) {
+      expect(shouldRetryManifestFetch(attempt)).toBe(true);
+    }
+  });
+
+  it("gives up once the failure streak exceeds the cap", () => {
+    expect(shouldRetryManifestFetch(MAX_MANIFEST_FETCH_RETRIES + 1)).toBe(false);
+    expect(shouldRetryManifestFetch(MAX_MANIFEST_FETCH_RETRIES + 5)).toBe(false);
+  });
+
+  // A reset streak (the caller zeroes its count on any good response, and an
+  // aborted fetch never increments) has nothing to retry.
+  it("does not retry with no accrued failures", () => {
+    expect(shouldRetryManifestFetch(0)).toBe(false);
+  });
+
+  it("honors a caller-supplied cap", () => {
+    expect(shouldRetryManifestFetch(2, 2)).toBe(true);
+    expect(shouldRetryManifestFetch(3, 2)).toBe(false);
   });
 });

--- a/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.ts
@@ -132,6 +132,22 @@ export function nextManifestClipsState<T>(state: T | null, enabled: boolean): T 
 export const MAX_MANIFEST_FETCH_RETRIES = 5;
 
 /**
+ * The retry streak must not survive a preview disable — `useManifestClips`
+ * calls this whenever `enabled` flips, alongside dropping the cached manifest.
+ * The failure count caps retries WITHIN one open session; once a hard-down
+ * endpoint reaches the cap the count stays past it until a good response or a
+ * different `focusedId`. Closing and reopening preview for the same timeline
+ * only clears the cache, so a reopened session inherited the capped count and
+ * the first failed fetch after reopening scheduled no retry — the projection
+ * fallback then stood indefinitely. Zeroing on disable resets the streak so
+ * every reopen starts a fresh session (re-enabling keeps 0, since disabling
+ * already cleared it), exactly mirroring `nextManifestClipsState`.
+ */
+export function nextManifestFailureCount(count: number, enabled: boolean): number {
+  return enabled ? count : 0;
+}
+
+/**
  * Whether a failed manifest fetch should schedule another attempt, given how
  * many consecutive failures have now accrued (the current one included). The
  * caller resets its streak to 0 on any good response and passes the

--- a/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.ts
@@ -123,6 +123,31 @@ export function nextManifestClipsState<T>(state: T | null, enabled: boolean): T 
   return enabled ? state : null;
 }
 
+/**
+ * How many consecutive failed manifest fetches to retry before giving up and
+ * letting the projection fallback stand silently. A transient 500 or network
+ * blip recovers within a couple of polls; a hard-down endpoint must not poll
+ * forever on an idle session.
+ */
+export const MAX_MANIFEST_FETCH_RETRIES = 5;
+
+/**
+ * Whether a failed manifest fetch should schedule another attempt, given how
+ * many consecutive failures have now accrued (the current one included). The
+ * caller resets its streak to 0 on any good response and passes the
+ * post-increment count here, so retries run for failures 1..`maxRetries` and
+ * stop once the cap is exceeded.
+ *
+ * Aborts are NOT failures and must be filtered by the caller BEFORE this — an
+ * aborted fetch (unmount/refocus/refetch) never counts and never retries.
+ */
+export function shouldRetryManifestFetch(
+  consecutiveFailures: number,
+  maxRetries: number = MAX_MANIFEST_FETCH_RETRIES,
+): boolean {
+  return consecutiveFailures > 0 && consecutiveFailures <= maxRetries;
+}
+
 export type ChildSpan = Readonly<{ startTime: number; endTime: number; width: number }>;
 
 /**

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -32,6 +32,7 @@ import {
   childSpans,
   manifestTrailsLedger,
   nextManifestClipsState,
+  shouldRetryManifestFetch,
   type GridPlayheadMap,
   type PlayheadMap,
   type PreviewCardSpans,
@@ -512,6 +513,12 @@ function useManifestClips(
   const store = useCollectionsStore();
   const [state, setState] = useState<ManifestClipsState>(null);
   const [staleAt, setStaleAt] = useState(0);
+  // Consecutive failed fetches, so a hard-down endpoint stops polling after
+  // MAX_MANIFEST_FETCH_RETRIES (a good response resets it). A ref, not state:
+  // it must survive the effect re-runs a retry triggers WITHOUT being a
+  // dependency that would itself re-run the fetch.
+  const failureCountRef = useRef(0);
+  const lastFetchedIdRef = useRef(focusedId);
 
   // Disabling preview unsubscribes the effect below, so a commit made while
   // CLOSED would otherwise never clear the cached manifest — see
@@ -550,17 +557,41 @@ function useManifestClips(
     // in-flight json() parse, so the signal check below is the single guard.
     const controller = new AbortController();
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    // Only a retry (staleAt bump) keeps counting — a switch to a different
+    // timeline starts its own streak, so timeline A's failures can't cap
+    // timeline B before it has even tried.
+    if (failureCountRef.current > 0 && lastFetchedIdRef.current !== focusedId) {
+      failureCountRef.current = 0;
+    }
+    lastFetchedIdRef.current = focusedId;
+    // A failed fetch (non-2xx or thrown) schedules the SAME delayed refetch as
+    // the install guard, so a transient 500/network blip recovers on its own
+    // while preview stays open — until the retry cap. An ABORT (our own
+    // cleanup) is not a failure and must not retry, so it is filtered first.
+    const scheduleRetryAfterFailure = () => {
+      if (controller.signal.aborted) return;
+      failureCountRef.current += 1;
+      if (shouldRetryManifestFetch(failureCountRef.current)) {
+        retryTimer = setTimeout(() => setStaleAt(Date.now()), MANIFEST_REFRESH_DELAY_MS);
+      }
+    };
     void (async () => {
       try {
         const response = await fetch(
           `/api/timelines/${encodeURIComponent(focusedId)}/preview-manifest`,
           { cache: "no-store", signal: controller.signal },
         );
-        if (!response.ok) return; // projection fallback stands
+        if (!response.ok) {
+          scheduleRetryAfterFailure(); // projection fallback stands meanwhile
+          return;
+        }
         const result = (await response.json().catch(() => null)) as {
           manifest?: PlaybackManifest;
         } | null;
         if (controller.signal.aborted || !result?.manifest) return;
+        // A good response ends the failure streak, whether it installs now or
+        // waits behind the install guard below.
+        failureCountRef.current = 0;
         // Install guard: a manifest compiled BEFORE this session's latest
         // accepted write to ANY document in the closure is pre-write server
         // state — never install it over the live projection; poll again once
@@ -587,7 +618,8 @@ function useManifestClips(
           forId: focusedId,
         });
       } catch {
-        /* projection fallback stands (including our own abort) */
+        // projection fallback stands; retry unless this was our own abort
+        scheduleRetryAfterFailure();
       }
     })();
     return () => {

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -32,6 +32,7 @@ import {
   childSpans,
   manifestTrailsLedger,
   nextManifestClipsState,
+  nextManifestFailureCount,
   shouldRetryManifestFetch,
   type GridPlayheadMap,
   type PlayheadMap,
@@ -530,6 +531,13 @@ function useManifestClips(
   if (prevEnabled !== enabled) {
     setPrevEnabled(enabled);
     setState((prev) => nextManifestClipsState(prev, enabled));
+    // Reset the retry streak on the same toggle that drops the cache. Without
+    // this a session that hit MAX_MANIFEST_FETCH_RETRIES left the count past
+    // the cap, and reopening preview for the SAME focusedId (which does not
+    // trip the focusedId-change reset in the fetch effect) inherited it — so
+    // the first failed fetch after reopening scheduled no retry and the
+    // projection fallback stood indefinitely.
+    failureCountRef.current = nextManifestFailureCount(failureCountRef.current, enabled);
   }
 
   // A committed change makes the held manifest STALE — discard it

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -531,14 +531,19 @@ function useManifestClips(
   if (prevEnabled !== enabled) {
     setPrevEnabled(enabled);
     setState((prev) => nextManifestClipsState(prev, enabled));
-    // Reset the retry streak on the same toggle that drops the cache. Without
-    // this a session that hit MAX_MANIFEST_FETCH_RETRIES left the count past
-    // the cap, and reopening preview for the SAME focusedId (which does not
-    // trip the focusedId-change reset in the fetch effect) inherited it — so
-    // the first failed fetch after reopening scheduled no retry and the
-    // projection fallback stood indefinitely.
-    failureCountRef.current = nextManifestFailureCount(failureCountRef.current, enabled);
   }
+
+  // Reset the retry streak whenever preview toggles closed. Without this a
+  // session that hit MAX_MANIFEST_FETCH_RETRIES left the count past the cap,
+  // and reopening preview for the SAME focusedId (which does not trip the
+  // focusedId-change reset in the fetch effect) inherited it — so the first
+  // failed fetch after reopening scheduled no retry and the projection
+  // fallback stood indefinitely. Done in an effect, not during render, because
+  // the react-hooks rule forbids touching a ref while rendering; re-enabling
+  // keeps the already-zeroed count so every reopen starts a fresh session.
+  useEffect(() => {
+    failureCountRef.current = nextManifestFailureCount(failureCountRef.current, enabled);
+  }, [enabled]);
 
   // A committed change makes the held manifest STALE — discard it
   // immediately (the live projection is correct the instant the commit


### PR DESCRIPTION
Implemented by Claude from #110. Closes #110.

**Codex-gated.** Auto-merge is NOT armed yet. The Codex gate waits for a review, then arms auto-merge only if Codex approves (👍). If Codex flags findings or is silent past the window, this stays open for you. Add the `hold` label to force manual merge.