### PR TITLE
Graph view keeps the previous session's graph when boot re-runs (no remount key)

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/boot-session-key.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/boot-session-key.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { bootSessionKey } from "./boot-session-key";
+
+describe("bootSessionKey", () => {
+  it("is stable for the same uid + projectId (ordinary renders / drill-in must not remount)", () => {
+    expect(bootSessionKey("user-a", "proj-1")).toBe(bootSessionKey("user-a", "proj-1"));
+  });
+
+  it("changes when the signed-in user changes (soft account switch remounts)", () => {
+    expect(bootSessionKey("user-a", "proj-1")).not.toBe(bootSessionKey("user-b", "proj-1"));
+  });
+
+  it("changes when the project changes", () => {
+    expect(bootSessionKey("user-a", "proj-1")).not.toBe(bootSessionKey("user-a", "proj-2"));
+  });
+
+  it("distinguishes a signed-out (null uid) session from a signed-in one", () => {
+    expect(bootSessionKey(null, "proj-1")).not.toBe(bootSessionKey("", "proj-1"));
+    expect(bootSessionKey(null, "proj-1")).toBe(bootSessionKey(null, "proj-1"));
+  });
+
+  it("does not let a separator inside either value forge a different pairing", () => {
+    // Without encoding, ("a:b", "c") and ("a", "b:c") would both stringify to
+    // "a:b:c" and collide.
+    expect(bootSessionKey("a:b", "c")).not.toBe(bootSessionKey("a", "b:c"));
+  });
+});

--- a/apps/timeline-gstudio001/components/graph-view/boot-session-key.ts
+++ b/apps/timeline-gstudio001/components/graph-view/boot-session-key.ts
@@ -1,0 +1,25 @@
+/**
+ * Identity of a booted graph session, used as the React `key` on
+ * `<DndCollections>`.
+ *
+ * `DndCollections` consumes `initialGraph` initial-ONLY by design (its store
+ * is the source of truth thereafter — see
+ * `packages/ui/dnd-collections/react/DndCollections.tsx`). So a boot re-run
+ * that rebuilds the graph for a DIFFERENT session (a soft user switch:
+ * sign out and into another account without a full navigation) would leave
+ * the mounted store holding the previous user's graph. Keying the provider on
+ * the session identity forces a remount when — and only when — the session
+ * changes, recreating the store from the fresh `initialGraph`.
+ *
+ * The key is intentionally derived only from the signed-in uid and the
+ * projectId: it must stay stable across ordinary renders and route drill-in
+ * (navigating within the same project/user must NOT remount — that would drop
+ * selection and undo history on every drill). This value is stored alongside
+ * the built graph in the boot-ready state so the key changes atomically with
+ * the graph it describes, never before it.
+ */
+export function bootSessionKey(uid: string | null, projectId: string): string {
+  // Encode both parts unambiguously so no uid/projectId pair can collide with
+  // another (a literal separator in either value can't fake a boundary).
+  return `${encodeURIComponent(uid ?? "")}:${encodeURIComponent(projectId)}`;
+}

--- a/apps/timeline-gstudio001/components/graph-view/boot-session-key.ts
+++ b/apps/timeline-gstudio001/components/graph-view/boot-session-key.ts
@@ -19,7 +19,11 @@
  * the graph it describes, never before it.
  */
 export function bootSessionKey(uid: string | null, projectId: string): string {
-  // Encode both parts unambiguously so no uid/projectId pair can collide with
-  // another (a literal separator in either value can't fake a boundary).
-  return `${encodeURIComponent(uid ?? "")}:${encodeURIComponent(projectId)}`;
+  // Encode presence explicitly (`0` = signed-out, `1` + encoded uid =
+  // signed-in) so a signed-out (null) session never collapses onto a
+  // signed-in session whose uid happens to be the empty string. Both parts are
+  // encoded unambiguously so no uid/projectId pair can collide with another (a
+  // literal separator in either value can't fake a boundary).
+  const uidPart = uid === null ? "0" : `1${encodeURIComponent(uid)}`;
+  return `${uidPart}:${encodeURIComponent(projectId)}`;
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -39,6 +39,7 @@ import { AssetPaletteDrawer } from "./graph-asset-palette";
 import { toast } from "@/components/core/sonner";
 
 import { bootSessionKey } from "./boot-session-key";
+import { trashDocumentId as deriveTrashDocumentId } from "./trash-document-id";
 
 import { GraphBoard, type FocusSurface, type ItemSize } from "./graph-board";
 import { GraphDetailsProvider } from "./graph-details-context";
@@ -128,7 +129,11 @@ export function GraphTimelineView({
 
   const { user } = useAuth();
   const uid = user ? user.uid : null;
-  const trashDocumentId = uid ? `trash-${uid}` : null;
+  // Gate on presence (null = signed out), NOT truthiness: a signed-in user
+  // with an empty-string uid still owns a trash document, and the boot effect
+  // returns early when this is null — a truthiness check would strand that
+  // user on the loading screen.
+  const trashDocumentId = deriveTrashDocumentId(uid);
 
   // AUTH BINDING first: the gateway is a module singleton that outlives
   // soft logout/login, so a different signed-in user must reset it before

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -38,6 +38,8 @@ import { GRAPH_ASSETS_TOGGLE_EVENT } from "@/lib/graph-view-events";
 import { AssetPaletteDrawer } from "./graph-asset-palette";
 import { toast } from "@/components/core/sonner";
 
+import { bootSessionKey } from "./boot-session-key";
+
 import { GraphBoard, type FocusSurface, type ItemSize } from "./graph-board";
 import { GraphDetailsProvider } from "./graph-details-context";
 import { HydrationController } from "./graph-hydration";
@@ -64,6 +66,10 @@ type BootState =
       status: "ready";
       graph: CollectionsGraph;
       trashRootId: string | null;
+      // Identity of the session this graph belongs to. Rides along with the
+      // graph so the <DndCollections> remount key changes atomically with the
+      // graph it consumes (initialGraph is initial-only), never before it.
+      sessionKey: string;
     }>;
 
 /**
@@ -121,7 +127,8 @@ export function GraphTimelineView({
   );
 
   const { user } = useAuth();
-  const trashDocumentId = user ? `trash-${user.uid}` : null;
+  const uid = user ? user.uid : null;
+  const trashDocumentId = uid ? `trash-${uid}` : null;
 
   // AUTH BINDING first: the gateway is a module singleton that outlives
   // soft logout/login, so a different signed-in user must reset it before
@@ -224,13 +231,18 @@ export function GraphTimelineView({
       }
 
       detailsStore.replaceAll(bootDetails);
-      setBoot({ status: "ready", graph: built.value, trashRootId });
+      setBoot({
+        status: "ready",
+        graph: built.value,
+        trashRootId,
+        sessionKey: bootSessionKey(uid, projectId),
+      });
     })();
 
     return () => {
       cancelled = true;
     };
-  }, [projectId, trashDocumentId, detailsStore, bootedFromServer]);
+  }, [projectId, trashDocumentId, uid, detailsStore, bootedFromServer]);
 
   const onSync = useCallback((entry: SyncEntry) => {
     setSyncLog((log) => [entry, ...log].slice(0, 6));
@@ -340,6 +352,12 @@ export function GraphTimelineView({
       )}
 
       <DndCollections
+        // initialGraph is initial-only (the store is the source of truth
+        // thereafter), so a boot re-run for a new session must remount to
+        // adopt the freshly built graph. The key is stable across ordinary
+        // renders and route drill-in — only a different uid/project changes
+        // it — so undo history and selection survive navigation.
+        key={boot.sessionKey}
         initialGraph={boot.graph}
         components={GRAPH_VIEW_COMPONENTS}
         maxHistoryEntries={200}

--- a/apps/timeline-gstudio001/components/graph-view/trash-document-id.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/trash-document-id.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { trashDocumentId } from "./trash-document-id";
+
+describe("trashDocumentId", () => {
+  it("derives the trash id for a signed-in uid", () => {
+    expect(trashDocumentId("user-a")).toBe("trash-user-a");
+  });
+
+  it("is null only when signed out (null uid)", () => {
+    expect(trashDocumentId(null)).toBeNull();
+  });
+
+  it("keeps an empty-string uid signed in (not collapsed onto signed-out)", () => {
+    // Regression: a truthiness check turned uid === "" into null, so the boot
+    // effect returned early and the graph never left loading for that user.
+    expect(trashDocumentId("")).toBe("trash-");
+    expect(trashDocumentId("")).not.toBeNull();
+  });
+});

--- a/apps/timeline-gstudio001/components/graph-view/trash-document-id.ts
+++ b/apps/timeline-gstudio001/components/graph-view/trash-document-id.ts
@@ -1,0 +1,14 @@
+/**
+ * Trash-bin document id for a graph session, or `null` when there is no
+ * session to own one.
+ *
+ * The distinction that matters: a signed-in user with an empty-string uid is
+ * still signed in — only a `null` uid means signed out. A truthiness check
+ * (`uid ? ... : null`) would collapse an empty-string uid onto the signed-out
+ * case, and the boot effect returns early when the trash id is `null`, so the
+ * graph would never leave its loading state for such a user. Gate on `null`
+ * explicitly, mirroring `bootSessionKey`'s null-vs-empty handling.
+ */
+export function trashDocumentId(uid: string | null): string | null {
+  return uid === null ? null : `trash-${uid}`;
+}


### PR DESCRIPTION
Implemented by Claude from #113. Closes #113.

**Codex-gated.** Auto-merge is NOT armed yet. The Codex gate waits for a review, then arms auto-merge only if Codex approves (👍). If Codex flags findings or is silent past the window, this stays open for you. Add the `hold` label to force manual merge.