### PR TITLE
Repair stale collection summaries in the preview-manifest route

### DIFF
--- a/apps/timeline-gstudio001/app/api/timelines/[id]/preview-manifest/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/[id]/preview-manifest/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { compilePlaybackManifest } from "@storyboard/timeline-domain";
+import { deriveClosureSummaries } from "@/lib/derive-collection-summaries";
 import { requireAuthUser } from "@/lib/firebase-auth-session";
 import { getFirebaseTimelineEntry } from "@/lib/firebase-timeline-store";
 import { loadTimelineClosure } from "@/lib/load-timeline-closure";
@@ -47,8 +48,17 @@ export async function GET(
     documents[id] = entry.document;
     revisions[id] = entry.revision;
 
+    // Stored collection summaries go stale by design: the graph view's
+    // writes are patch-scoped, so editing a child never rewrites the
+    // parents that reference it. Every other read path repairs that at read
+    // time (serveTimelineDocument); compiling from the raw closure made this
+    // route the one reader that did not, so the preview both reported a
+    // different total than the board and windowed a grown child's newest
+    // clips out of playback entirely.
+    const summarized = deriveClosureSummaries(documents, new Set(missing));
+
     const manifest = compilePlaybackManifest(
-      documents,
+      summarized,
       id,
       entry.revision,
       new Date().toISOString(),

--- a/apps/timeline-gstudio001/app/api/timelines/timelines-preview-manifest.test.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/timelines-preview-manifest.test.ts
@@ -82,6 +82,7 @@ vi.mock("@/lib/cloudinary-media-store", () => ({
 }));
 
 import { GET as getPreviewManifest } from "./[id]/preview-manifest/route";
+import { serveTimelineDocument } from "@/lib/serve-timeline";
 
 const params = (id: string) => ({ params: Promise.resolve({ id }) });
 
@@ -152,10 +153,14 @@ describe("preview manifest route", () => {
 
     expect(body.missing).toEqual([]);
     expect(body.manifest.projectRevision).toBe(9);
-    expect(body.manifest.durationSeconds).toBe(8);
+    // Read-time summary derivation repacks, so the collection clip sits one
+    // CLIP_GAP_SECONDS after "intro" rather than at the un-gapped startTime
+    // this fixture stores — the same normalization the GET route already
+    // applies, which is the point: both read models report one timeline.
+    expect(body.manifest.durationSeconds).toBeCloseTo(8.12, 6);
     expect(body.manifest.leaves.map((leaf) => leaf.id)).toEqual(["intro", "a", "b"]);
     expect(body.manifest.leaves[1].collectionPath).toEqual(["root-1", "scene"]);
-    expect(body.manifest.leaves[1].timelineStart).toBeCloseTo(4, 6);
+    expect(body.manifest.leaves[1].timelineStart).toBeCloseTo(4.12, 6);
   });
 
   it("degrades unloadable branches to silence and reports them", async () => {
@@ -184,6 +189,32 @@ describe("preview manifest route", () => {
     seed("root-b", "user-b", [image("x", 0, 4)]);
     const response = await getPreviewManifest(new Request("http://test.local"), params("root-b"));
     expect(response.status).toBe(404);
+  });
+
+  it("summarizes stale parents from the child, matching what the GET route serves", async () => {
+    // The graph view's writes are patch-scoped: nesting a clip into "scene"
+    // rewrites ONLY "scene", leaving every referring parent's denormalized
+    // summary short. Every other read path repairs that at read time
+    // (serveTimelineDocument); the manifest must agree, or the preview plays
+    // a different timeline than the board shows.
+    seed("scene", "user-a", [image("a", 0, 2), image("b", 2.12, 2), image("c", 4.24, 2.65)]);
+    seed("root-1", "user-a", [
+      image("intro", 0, 4),
+      // Stale: written when "scene" was still two clips long.
+      collectionClip("scene-ref", "scene", 4.12, 4),
+    ]);
+
+    const served = await serveTimelineDocument("root-1", "user-a");
+    const servedClips = served?.document.clips ?? [];
+    const last = servedClips[servedClips.length - 1];
+    const servedDuration = last.startTime + last.duration;
+
+    const response = await getPreviewManifest(new Request("http://test.local"), params("root-1"));
+    const body = (await response.json()) as { manifest: PlaybackManifest; missing: string[] };
+
+    expect(body.manifest.durationSeconds).toBeCloseTo(servedDuration, 6);
+    // The stale span also windowed the child's newest clip out of playback.
+    expect(body.manifest.leaves.map((leaf) => leaf.id)).toEqual(["intro", "a", "b", "c"]);
   });
 
   it("reports a stored reference cycle as 409", async () => {

--- a/apps/timeline-gstudio001/lib/derive-collection-summaries.test.ts
+++ b/apps/timeline-gstudio001/lib/derive-collection-summaries.test.ts
@@ -6,7 +6,11 @@ import type {
   TimelineDocument,
 } from "@storyboard/timeline-model/types";
 
-import { collectionChildIds, deriveCollectionSummaries } from "./derive-collection-summaries";
+import {
+  collectionChildIds,
+  deriveClosureSummaries,
+  deriveCollectionSummaries,
+} from "./derive-collection-summaries";
 
 function mediaClip(
   id: string,
@@ -165,6 +169,73 @@ describe("deriveCollectionSummaries", () => {
     // duration + CLIP_GAP_SECONDS
     expect(document.clips[1].startTime).toBeCloseTo(11.12, 10);
     expect(document.clips.map((entry) => entry.index)).toEqual([0, 1]);
+  });
+});
+
+describe("deriveClosureSummaries", () => {
+  const closureOf = (...docs: TimelineDocument[]) =>
+    Object.fromEntries(docs.map((doc) => [doc.id, doc]));
+
+  it("propagates a deep child's growth up EVERY level in one pass", () => {
+    // The case one-level derivation cannot reach: "grandchild" grew, so
+    // "child"'s stored summary of it is short, so "root"'s summary of
+    // "child" — derived from that stored child — is short too.
+    const grandchild = docOf("grandchild", [mediaClip("g1", { startTime: 0, duration: 10 })]);
+    const child = docOf("child", [
+      collectionClip("gc-ref", "grandchild", { duration: 4, sourceDuration: 4 }),
+    ]);
+    const root = docOf("root", [collectionClip("c-ref", "child", { duration: 4, sourceDuration: 4 })]);
+
+    const closure = deriveClosureSummaries(closureOf(root, child, grandchild));
+
+    expect(closure.child.clips[0].duration).toBe(10);
+    expect(closure.root.clips[0].duration).toBe(10);
+  });
+
+  it("keeps the stored summary for ids the loader could not resolve", () => {
+    // The closure loader substitutes an unloadable branch with an EMPTY
+    // document so it falls silent; deriving from that would overwrite a real
+    // stored summary with "empty collection".
+    const ghost = docOf("ghost", [], "");
+    const root = docOf("root", [
+      collectionClip("ghost-ref", "ghost", { itemCount: 6, duration: 18, sourceDuration: 18 }),
+    ]);
+
+    const closure = deriveClosureSummaries(closureOf(root, ghost), new Set(["ghost"]));
+
+    const summary = closure.root.clips[0] as CollectionTimelineClip;
+    expect(summary.duration).toBe(18);
+    expect(summary.itemCount).toBe(6);
+    expect(closure.root).toBe(root);
+  });
+
+  it("resolves a reference cycle to the stored documents instead of looping", () => {
+    const a = docOf("a", [collectionClip("to-b", "b")]);
+    const b = docOf("b", [collectionClip("to-a", "a")]);
+
+    const closure = deriveClosureSummaries(closureOf(a, b));
+
+    expect(Object.keys(closure).sort()).toEqual(["a", "b"]);
+  });
+
+  it("leaves a closure whose summaries are already in sync untouched", () => {
+    const child = docOf("child", [mediaClip("m1", { startTime: 0, duration: 5 })], "Synced");
+    const root = docOf("root", [
+      collectionClip("c-ref", "child", {
+        title: "Synced",
+        itemCount: 1,
+        duration: 5,
+        sourceDuration: 5,
+        previewItems: [
+          { id: "m1", kind: "image", src: "https://cdn.test/m1.jpg", poster: undefined, alt: "m1" },
+        ],
+      }),
+    ]);
+
+    const closure = deriveClosureSummaries(closureOf(root, child));
+
+    expect(closure.root).toBe(root);
+    expect(closure.child).toBe(child);
   });
 });
 

--- a/apps/timeline-gstudio001/lib/derive-collection-summaries.ts
+++ b/apps/timeline-gstudio001/lib/derive-collection-summaries.ts
@@ -72,6 +72,58 @@ export function deriveCollectionSummaries(
   return { document: { ...document, clips: packTimelineClips(clips) }, changed: true };
 }
 
+/**
+ * Derive summaries across a whole loaded closure, BOTTOM-UP: a document is
+ * summarized from its already-derived children, so a change deep in the
+ * tree propagates up every level in one pass. `deriveCollectionSummaries`
+ * on its own is one level deep — it reads STORED children — which is enough
+ * for the single-document serve path but not for a reader that flattens the
+ * whole closure (the playback manifest): there, a stale grandchild would
+ * still window its parent's content out of the timeline.
+ *
+ * `unresolved` are the ids the loader could not actually read (missing, or
+ * another user's). They are typically substituted with EMPTY documents so a
+ * dangling branch falls silent — deriving from those would rewrite a real
+ * stored summary to "empty collection", so they are treated as absent and
+ * the stored summary stands ("stale beats blank").
+ *
+ * A reference CYCLE resolves to the stored document rather than looping;
+ * detecting it stays the manifest compiler's job, which reports it honestly
+ * instead of serving a half-derived closure.
+ */
+export function deriveClosureSummaries(
+  documents: Readonly<Record<string, TimelineDocument>>,
+  unresolved: ReadonlySet<string> = new Set(),
+): Record<string, TimelineDocument> {
+  const derived: Record<string, TimelineDocument> = {};
+  const visiting = new Set<string>();
+
+  const resolve = (id: string): TimelineDocument | null => {
+    const stored = documents[id];
+    if (!stored || unresolved.has(id)) return null;
+    const settled = derived[id];
+    if (settled) return settled;
+    if (visiting.has(id)) return stored;
+
+    visiting.add(id);
+    const children = new Map<string, TimelineDocument | null>(
+      collectionChildIds(stored).map((childId) => [childId, resolve(childId)]),
+    );
+    visiting.delete(id);
+
+    const result = deriveCollectionSummaries(stored, children).document;
+    derived[id] = result;
+    return result;
+  };
+
+  const closure: Record<string, TimelineDocument> = { ...documents };
+  for (const id of Object.keys(documents)) {
+    const result = resolve(id);
+    if (result) closure[id] = result;
+  }
+  return closure;
+}
+
 /** The child ids a derivation pass for this document would want loaded. */
 export function collectionChildIds(document: TimelineDocument): string[] {
   const ids = new Set<string>();


### PR DESCRIPTION
Recovered from an abandoned Claude worktree and reapplied onto current `main`.

The graph view writes patch-scoped, so editing a child never rewrites the parent clips that summarize it. Every other read path repairs that at read time (`serveTimelineDocument`), but the preview-manifest route compiled straight from the raw closure — so the preview reported a different total than the board and windowed a grown child's newest clips out of playback entirely.

Adds `deriveClosureSummaries()`: a bottom-up pass that re-summarizes a whole loaded closure so a change deep in the tree propagates up every level in one pass. Unresolved branches keep their stored summary ("stale beats blank"), reference cycles resolve to stored docs, and an already-synced closure returns reference-stable docs. The route runs the closure through it before `compilePlaybackManifest`.

17 tests pass (4 new `deriveClosureSummaries` unit tests + a new route integration test asserting the manifest matches `serveTimelineDocument`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)