### PR TITLE
Graph view punch list round 4 (#1–#10)

### DIFF
--- a/apps/timeline-gstudio001/app/page.tsx
+++ b/apps/timeline-gstudio001/app/page.tsx
@@ -158,7 +158,7 @@ export default function Home() {
         throw new Error(result.error || "Unable to create project.");
       }
 
-      router.push(`/timeline/${encodeURIComponent(result.project.id)}/storyboard`);
+      router.push(`/timeline/${encodeURIComponent(result.project.id)}/graph`);
     } catch (error) {
       setLoadError(error instanceof Error ? error.message : "Unable to create project.");
     } finally {
@@ -264,7 +264,7 @@ export default function Home() {
               >
                 {/* Link overlay covering the whole card area */}
                 <Link
-                  href={`/timeline/${encodeURIComponent(project.id)}/storyboard`}
+                  href={`/timeline/${encodeURIComponent(project.id)}/graph`}
                   className="absolute inset-0 z-10"
                 />
 

--- a/apps/timeline-gstudio001/app/timeline/[timelineId]/page.tsx
+++ b/apps/timeline-gstudio001/app/timeline/[timelineId]/page.tsx
@@ -56,15 +56,25 @@ export default function TimelineDocumentPage({
 
   const normalizedProjectSearch = normalizedProjectSearchParams.toString();
 
+  // Graph view is the default landing spot for a project. Bare `/timeline/{id}`
+  // only honors an EXPLICIT `?view=storyboard`/`?view=workbench`; anything else
+  // (including no `view` param at all) redirects into the graph view instead of
+  // falling back to `parseProjectViewMode`'s storyboard default.
+  const rawViewParam = Array.isArray(resolvedSearchParams.view)
+    ? resolvedSearchParams.view[0]
+    : resolvedSearchParams.view;
+  const redirectView =
+    rawViewParam === "storyboard" || rawViewParam === "workbench" ? rawViewParam : "graph";
+
   useEffect(() => {
     if (!isProjectTimeline) return;
 
     router.replace(
-      `/timeline/${encodeURIComponent(timelineId)}/${projectView}${
+      `/timeline/${encodeURIComponent(timelineId)}/${redirectView}${
         normalizedProjectSearch ? `?${normalizedProjectSearch}` : ""
       }`,
     );
-  }, [isProjectTimeline, normalizedProjectSearch, projectView, router, timelineId]);
+  }, [isProjectTimeline, normalizedProjectSearch, redirectView, router, timelineId]);
 
   if (isProjectTimeline) {
     return null;

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -1,13 +1,16 @@
 "use client";
 
-import { EllipsisVertical, FolderTree, TvMinimal } from "lucide-react";
+import { useContext } from "react";
+import { EllipsisVertical, FolderTree, Redo2, Ruler, TvMinimal, Undo2 } from "lucide-react";
 
 import {
+  CollectionsContainerContext,
   TrashTarget,
-  UndoRedoControls,
   VirtualGrid,
   VirtualStrip,
   parseNodeId,
+  useCollectionsSelector,
+  useCollectionsStore,
 } from "@storyboard/ui/dnd-collections";
 
 import { Button } from "@/components/core/button";
@@ -28,6 +31,7 @@ import {
   GraphGridPlayhead,
   GraphGridScrubSurface,
   GraphPlayhead,
+  GraphRuler,
   PlayheadScrubBand,
   PreviewShell,
   collectionCardWidth,
@@ -128,6 +132,53 @@ function ScaleSlider({
   );
 }
 
+/**
+ * Undo/redo as ICON buttons, matching the toolbar's other ghost icon controls
+ * (preview, children) rather than the package's generic text-label
+ * `UndoRedoControls`. App-local on purpose: the icon styling is this toolbar's
+ * design, so it stays out of the framework-agnostic package — but the store
+ * wiring (and best-effort announce) is exactly the package control's.
+ */
+function GraphUndoRedo() {
+  const store = useCollectionsStore();
+  const canUndo = useCollectionsSelector((s) => s.canUndo);
+  const canRedo = useCollectionsSelector((s) => s.canRedo);
+  const announce = useContext(CollectionsContainerContext)?.announce;
+
+  return (
+    <div className="flex items-center gap-1">
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        disabled={!canUndo}
+        aria-label="Undo"
+        title="Undo"
+        onClick={() => {
+          if (store.undo()) announce?.("Change undone.");
+        }}
+        className="h-8 w-8 text-zinc-400 hover:text-zinc-100 disabled:opacity-40"
+      >
+        <Undo2 aria-hidden="true" className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        disabled={!canRedo}
+        aria-label="Redo"
+        title="Redo"
+        onClick={() => {
+          if (store.redo()) announce?.("Change redone.");
+        }}
+        className="h-8 w-8 text-zinc-400 hover:text-zinc-100 disabled:opacity-40"
+      >
+        <Redo2 aria-hidden="true" className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}
+
 function SurfaceToggle({
   surface,
   onChange,
@@ -172,6 +223,8 @@ export function GraphBoard({
   onPixelsPerSecondChange,
   previewOn,
   onTogglePreview,
+  rulerOn,
+  onToggleRuler,
   childrenShown,
   onToggleChildren,
   timeChannel,
@@ -190,6 +243,8 @@ export function GraphBoard({
   onPixelsPerSecondChange: (pixelsPerSecond: number) => void;
   previewOn: boolean;
   onTogglePreview: () => void;
+  rulerOn: boolean;
+  onToggleRuler: () => void;
   childrenShown: boolean;
   onToggleChildren: () => void;
   timeChannel: PreviewTimeChannel;
@@ -211,14 +266,21 @@ export function GraphBoard({
               opaque background is load-bearing twice over: it reads as a
               toolbar, and it OCCLUDES the strip/grid scrolling underneath —
               which is what stops a playhead marker from bleeding up into the
-              preview. The negative margins let that background span the card's
-              full width past its p-4 padding. */}
+              breadcrumb row. z-40 to sit ABOVE the strip's z-30 playhead
+              overlay (z-20 was below it, so the marker bled through the
+              header); it matches the sticky preview's z-40. The negative
+              margins let that background span the card's full width past its
+              p-4 padding. */}
           <div
-            className="sticky z-20 -mx-4 -mt-4 flex items-center justify-between gap-3 rounded-t-xl border-b border-zinc-800/70 bg-zinc-950/95 px-4 py-3 backdrop-blur-sm"
+            className="sticky z-40 -mx-4 -mt-4 flex flex-wrap items-center justify-between gap-x-3 gap-y-2 rounded-t-xl border-b border-zinc-800/70 bg-zinc-950/95 px-4 py-3 backdrop-blur-sm"
             style={{ top: "var(--workbench-preview-offset, 0px)" }}
           >
             {breadcrumb}
-            <div className="flex shrink-0 items-center gap-3">
+            {/* flex-wrap + wrap-capable controls so a narrow viewport folds the
+                toolbar onto a second line instead of pushing controls (the
+                Strip/Grid toggle especially) off-screen. No effect when it
+                fits. */}
+            <div className="flex flex-wrap items-center justify-end gap-2">
               <Button
                 type="button"
                 variant="ghost"
@@ -234,6 +296,25 @@ export function GraphBoard({
               >
                 <TvMinimal aria-hidden="true" className="h-4 w-4" />
               </Button>
+              {/* Ruler is a strip-only axis (grid has no single time axis), so
+                  the toggle drops out in grid mode like the scale slider. */}
+              {surface === "strip" ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-pressed={rulerOn}
+                  aria-label={rulerOn ? "Hide time ruler" : "Show time ruler"}
+                  title={rulerOn ? "Hide time ruler" : "Show time ruler"}
+                  onClick={onToggleRuler}
+                  className={[
+                    "h-8 w-8",
+                    rulerOn ? "bg-zinc-800 text-zinc-100" : "text-zinc-500",
+                  ].join(" ")}
+                >
+                  <Ruler aria-hidden="true" className="h-4 w-4" />
+                </Button>
+              ) : null}
               <Button
                 type="button"
                 variant="ghost"
@@ -249,12 +330,18 @@ export function GraphBoard({
               >
                 <FolderTree aria-hidden="true" className="h-4 w-4" />
               </Button>
-              <ScaleSlider
-                pixelsPerSecond={pixelsPerSecond}
-                onChange={onPixelsPerSecondChange}
-              />
+              {/* px/s is a strip-only axis: grid cells are sized by thumbnail
+                  size, and the grid playhead ignores clip width, so the slider
+                  is a no-op in grid mode. Hidden there (state is preserved, so
+                  returning to strip restores the last zoom). */}
+              {surface === "strip" ? (
+                <ScaleSlider
+                  pixelsPerSecond={pixelsPerSecond}
+                  onChange={onPixelsPerSecondChange}
+                />
+              ) : null}
               <SurfaceToggle surface={surface} onChange={onSurfaceChange} />
-              <UndoRedoControls />
+              <GraphUndoRedo />
               <BoardMenu itemSize={itemSize} onItemSizeChange={onItemSizeChange} />
             </div>
           </div>
@@ -268,12 +355,19 @@ export function GraphBoard({
                 itemHeight={dims.strip}
                 itemDragActivation="hold"
                 overlay={
-                  previewOn ? (
-                    <GraphPlayhead
-                      focusedId={focusedId}
-                      channel={timeChannel}
-                      pixelsPerSecond={pixelsPerSecond}
-                    />
+                  previewOn || rulerOn ? (
+                    <>
+                      {rulerOn ? (
+                        <GraphRuler focusedId={focusedId} pixelsPerSecond={pixelsPerSecond} />
+                      ) : null}
+                      {previewOn ? (
+                        <GraphPlayhead
+                          focusedId={focusedId}
+                          channel={timeChannel}
+                          pixelsPerSecond={pixelsPerSecond}
+                        />
+                      ) : null}
+                    </>
                   ) : undefined
                 }
                 className="bg-black/25"
@@ -297,6 +391,11 @@ export function GraphBoard({
                   cellHeight={dims.gridHeight}
                   gap={GRID_GAP}
                   height={GRID_UNCAPPED_HEIGHT}
+                  // Mirror the strip: a quick tap is a CLICK (so the in-card
+                  // drill button works) and a press-and-hold starts the reorder
+                  // drag. "body" (the default) drags instantly, which ate the
+                  // drill click and made drags ambiguous.
+                  itemDragActivation="hold"
                   overlay={
                     previewOn ? (
                       <GraphGridPlayhead

--- a/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
@@ -933,13 +933,34 @@ export function NativeDropGrid({
     }
     const { x: clientX, y: clientY } = pointerRef.current;
     const before = cellBeforeWhichPointerFalls(geometry, clientX, clientY);
-    // Draw at the left edge of the cell the boundary precedes, else at the
-    // right edge of the last cell (append). Spans that cell's row height.
-    const anchorCell = before ?? geometry.cells[geometry.cells.length - 1];
-    const x =
-      (before ? anchorCell.left - 3 : anchorCell.right + 3) - geometry.wrapperLeft;
-    const y = anchorCell.top - geometry.wrapperTop;
-    const height = anchorCell.bottom - anchorCell.top;
+    // Where the bar draws. The boundary before a cell that STARTS a new row is
+    // the same insertion point as "after the previous row's last cell" — so
+    // when the pointer is actually on that previous row (dragged past its right
+    // end), draw at the previous cell's RIGHT edge instead of jumping to the
+    // far left of the next row, which read as the indicator landing in the
+    // wrong place. Otherwise: left edge of the cell the boundary precedes, or
+    // the right edge of the last cell when appending at the very end.
+    const beforeIndex = before ? geometry.cells.indexOf(before) : -1;
+    const previous = beforeIndex > 0 ? geometry.cells[beforeIndex - 1] : null;
+    const boundaryStartsRow = before !== null && previous !== null && previous.top < before.top - 1;
+    const anchorPreviousRowEnd = boundaryStartsRow && previous !== null && clientY <= previous.bottom;
+    let x: number;
+    let y: number;
+    let height: number;
+    if (!before) {
+      const last = geometry.cells[geometry.cells.length - 1];
+      x = last.right + 3 - geometry.wrapperLeft;
+      y = last.top - geometry.wrapperTop;
+      height = last.bottom - last.top;
+    } else if (anchorPreviousRowEnd && previous) {
+      x = previous.right + 3 - geometry.wrapperLeft;
+      y = previous.top - geometry.wrapperTop;
+      height = previous.bottom - previous.top;
+    } else {
+      x = before.left - 3 - geometry.wrapperLeft;
+      y = before.top - geometry.wrapperTop;
+      height = before.bottom - before.top;
+    }
     setIndicator((current) =>
       current && current.x === x && current.y === y && current.height === height
         ? current

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -26,6 +26,7 @@ import {
 } from "@storyboard/timeline-domain";
 
 import {
+  STRIP_GAP_PX,
   buildGridPlayheadMap,
   buildPlayheadMap,
   cardSpansOf,
@@ -183,6 +184,113 @@ export function GraphPlayhead({
       className="absolute inset-y-0 left-0 w-0.5 bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.9)]"
     >
       <div className="absolute -left-[5px] -top-2 h-0 w-0 border-x-[6px] border-t-[8px] border-x-transparent border-t-red-500" />
+    </div>
+  );
+}
+
+const RULER_MIN_TICK_GAP_PX = 46;
+const RULER_NICE_STEPS = [0.5, 1, 2, 5, 10, 15, 30, 60, 120, 300, 600];
+
+/** Nicest second-interval whose on-screen gap clears the minimum, at this zoom. */
+function rulerTickInterval(pixelsPerSecond: number): number {
+  const target = RULER_MIN_TICK_GAP_PX / Math.max(1, pixelsPerSecond);
+  return RULER_NICE_STEPS.find((step) => step >= target) ?? RULER_NICE_STEPS[RULER_NICE_STEPS.length - 1];
+}
+
+function formatRulerTick(seconds: number): string {
+  if (seconds < 60) return Number.isInteger(seconds) ? `${seconds}s` : `${seconds.toFixed(1)}s`;
+  const minutes = Math.floor(seconds / 60);
+  const rest = Math.round(seconds % 60);
+  return `${minutes}:${String(rest).padStart(2, "0")}`;
+}
+
+/**
+ * A second-ruler over the strip. It reads the SAME piecewise time↔x map the
+ * playhead uses (`buildPlayheadMap`), so a tick at t seconds lands exactly
+ * where the playhead sits at t — the strip is NOT a linear time axis (media
+ * width is duration·pps, but the inter-card gutter absorbs the pack gap and a
+ * collection card is a FIXED width holding an arbitrary duration), so a
+ * fixed-pixel-pitch ruler would drift off the cards.
+ *
+ * Media cards are ruled at nice second intervals. A collection card's interior
+ * is left blank — ruling an arbitrary duration across its fixed width would
+ * cram ticks into an unreadable smear — and only its start edge is ticked, so
+ * the card still reads as one bracketed block on the ruler.
+ *
+ * Works with preview OFF too: without a manifest `spans` is null and
+ * `childSpans` falls back to projection times, which is the honest clock then.
+ * Rides the strip overlay (content coordinates), so scroll/auto-scroll and the
+ * live-trim transform all apply for free.
+ */
+export function GraphRuler({
+  focusedId,
+  pixelsPerSecond,
+}: Readonly<{ focusedId: string; pixelsPerSecond: number }>) {
+  const store = useCollectionsStore();
+  const detailsStore = useGraphDetailsStore();
+  const spans = useContext(PreviewCardSpansContext);
+  const graph = useSyncExternalStore(
+    store.subscribe,
+    () => store.getSnapshot().graph,
+    () => store.getSnapshot().graph,
+  );
+  const details = useSyncExternalStore(
+    detailsStore.subscribe,
+    () => detailsStore.read(),
+    () => detailsStore.read(),
+  );
+
+  const ticks = useMemo(() => {
+    const clips = graphChildrenToClips(graph, details, focusedId);
+    const cards = childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond));
+    if (cards.length === 0) return [];
+    const map = buildPlayheadMap(cards);
+    const total = map.totalDurationSeconds;
+    if (total <= 0) return [];
+
+    // Card x-ranges + collection flag, in the SAME cumulative layout the map
+    // walks — so a tick's x can be tested against the collection interiors.
+    // Each card's left is the summed widths+gaps before it (no running
+    // accumulator to mutate — keeps the memo body free of reassignment).
+    const ranges = cards.map((card, index) => {
+      const x0 = cards
+        .slice(0, index)
+        .reduce((sum, previous) => sum + previous.width + STRIP_GAP_PX, 0);
+      return { x0, x1: x0 + card.width, isCollection: clips[index]?.kind === "collection" };
+    });
+    const inCollectionInterior = (cx: number) =>
+      ranges.some((range) => range.isCollection && cx > range.x0 + 1 && cx <= range.x1);
+
+    const interval = rulerTickInterval(pixelsPerSecond);
+    const out: Array<{ x: number; label: string }> = [];
+    for (let t = 0; t <= total + 1e-6; t += interval) {
+      const cx = map.xAt(t);
+      if (inCollectionInterior(cx)) continue;
+      out.push({ x: cx, label: formatRulerTick(Math.round(t * 100) / 100) });
+    }
+    // Unlabeled edge tick bracketing each collection's blank interior.
+    for (const range of ranges) {
+      if (range.isCollection) out.push({ x: range.x0, label: "" });
+    }
+    return out;
+  }, [graph, details, spans, focusedId, pixelsPerSecond]);
+
+  return (
+    <div aria-hidden="true" data-graph-ruler className="pointer-events-none absolute inset-x-0 top-0">
+      {ticks.map((tick, index) => (
+        <div
+          key={index}
+          className="absolute top-0 flex flex-col items-center"
+          style={{ transform: `translateX(${tick.x}px)` }}
+        >
+          <div className="h-2 w-px bg-sky-300/60" />
+          {tick.label ? (
+            <span className="mt-px rounded-sm bg-zinc-950/70 px-0.5 font-mono text-[8px] leading-none text-sky-200/80">
+              {tick.label}
+            </span>
+          ) : null}
+        </div>
+      ))}
     </div>
   );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -112,6 +112,7 @@ export function GraphTimelineView({
   // the FolderTree toggle unmounts them.
   const [childrenShown, setChildrenShown] = useState(true);
   const [previewOn, setPreviewOn] = useState(false);
+  const [rulerOn, setRulerOn] = useState(false);
   const [timeChannel] = useState(createPreviewTimeChannel);
   const [assetsOpen, setAssetsOpen] = useState(false);
 
@@ -422,6 +423,8 @@ export function GraphTimelineView({
                 onPixelsPerSecondChange={setPixelsPerSecond}
                 previewOn={previewOn}
                 onTogglePreview={() => setPreviewOn((current) => !current)}
+                rulerOn={rulerOn}
+                onToggleRuler={() => setRulerOn((current) => !current)}
                 childrenShown={childrenShown}
                 onToggleChildren={() => setChildrenShown((current) => !current)}
                 timeChannel={timeChannel}

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -706,6 +706,39 @@ test.describe("graph view E2E", () => {
     expect(api.patchesFor(TRASH_ID)).toHaveLength(0);
   });
 
+  test("grid mode: hold-drag reorders a cell, parity with the strip", async ({
+    page,
+  }) => {
+    const api = await installGraphApi(page);
+    await openGraph(page);
+    // Switch the surface to grid; the cards become grid cells (same NodeCard,
+    // now with "hold" drag activation so a press-and-hold reorders).
+    await page
+      .getByRole("group", { name: "Timeline layout" })
+      .getByRole("button", { name: "grid" })
+      .click();
+    const projectGrid = page.locator(`[data-virtual-grid="${PROJECT_ID}"]`);
+    await expect(projectGrid).toBeVisible();
+
+    // Hold-drag alpha onto charlie's right half — alpha lands after charlie,
+    // exactly as the strip reorder does.
+    await holdDrag(
+      page,
+      projectGrid.locator('[data-node-id="alpha"]'),
+      projectGrid.locator('[data-node-id="charlie"]'),
+      0.85,
+    );
+    await expect
+      .poll(() => gridOrder(page, PROJECT_ID))
+      .toEqual(["bravo", CHILD_ID, "charlie", "alpha"]);
+
+    // Same patch-scoped write as the strip: only the project document changes.
+    await expect
+      .poll(() => api.patchesFor(PROJECT_ID).length, { timeout: 5000 })
+      .toBeGreaterThan(0);
+    expect(api.patchesFor(CHILD_ID)).toHaveLength(0);
+  });
+
   test("undo history survives drill-in navigation (the layout-persistence invariant)", async ({
     page,
   }) => {

--- a/packages/ui/dnd-collections/VirtualStrip.stories.tsx
+++ b/packages/ui/dnd-collections/VirtualStrip.stories.tsx
@@ -389,6 +389,40 @@ export const WidthCallbackStableDuringDrag: Story = {
   },
 };
 
+export const NoOpBoundaryHidesIndicator: Story = {
+  // Dragging an item to a boundary that leaves it exactly where it is (the gap
+  // on either side of itself) is a no-op — the drop indicator must hide. Any
+  // other boundary is a real move and keeps its indicator.
+  render: () => (
+    <DndCollections initialGraph={variableGraph()}>
+      <div className="w-[640px]">
+        <VirtualStrip collectionId={parseNodeId("strip")} />
+      </div>
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    const m0handle = nodeHandle(canvasElement, "m0");
+    const m0 = nodeCard(canvasElement, "m0");
+    const m1 = nodeCard(canvasElement, "m1");
+    const m2 = nodeCard(canvasElement, "m2");
+    await waitForLayout(m2);
+
+    // Activate on a real boundary (m1|m2) — the indicator shows.
+    await dragHoldAt(m0handle, gapBetween(m1, m2));
+    await waitFor(() => {
+      expect(canvasElement.querySelector('[data-drop-indicator="virtual"]')).not.toBeNull();
+    });
+
+    // Move to the gap right after m0 itself (m0|m1): a no-op — indicator hides.
+    await moveHeldPointer(gapBetween(m0, m1));
+    await waitFor(() => {
+      expect(canvasElement.querySelector('[data-drop-indicator="virtual"]')).toBeNull();
+    });
+
+    await releaseAt(gapBetween(m0, m1));
+  },
+};
+
 /** Media strip with a collection card ("folder", 1 child) at index 5. */
 function mixedGraph() {
   const children: GraphNodeSpec[] = [];

--- a/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
@@ -18,7 +18,10 @@ import {
   nonNegativeIntegerOr,
   positiveIntegerOrUndefined,
 } from "../core/numeric";
-import { type CollectionItemContentComponent } from "../react/collections-components";
+import {
+  type CollectionItemContentComponent,
+  type NodeCardDragActivation,
+} from "../react/collections-components";
 import { useCollectionsSelector, useCollectionsStore } from "../react/collections-store";
 import { NodeCard } from "../react/node-views";
 import { useEdgeAutoScroll } from "../react/use-edge-autoscroll";
@@ -64,6 +67,14 @@ export type VirtualGridProps = Readonly<{
   /** Per-view card pixels — overrides the provider `components` registry.
    *  MUST be identity-stable (module scope). */
   itemContent?: CollectionItemContentComponent;
+  /**
+   * How a cell drag starts. Default "body" — the card body drags instantly,
+   * which makes a plain click ambiguous with a drag (a press that nudges is a
+   * drag, and an in-card affordance's click can be eaten). "hold" mirrors the
+   * strip: a quick press is a CLICK (so in-card controls like a drill button
+   * work), a press-and-hold starts the reorder drag.
+   */
+  itemDragActivation?: NodeCardDragActivation;
   /** Presentational layer painted in CONTENT coordinates (inside the
    *  scrolling spacer), like VirtualStrip's `overlay`: a playhead, region
    *  markers. aria-hidden and pointer-events: none — scroll and the drop
@@ -88,6 +99,7 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
       overscan: overscanOption,
       height: heightOption,
       itemContent,
+      itemDragActivation = "body",
       overlay,
       className,
     },
@@ -156,6 +168,16 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
       estimateSize: () => rowSize,
       overscan,
     });
+
+    // The virtualizer caches each row's size and does NOT re-read estimateSize
+    // when its VALUE changes — only its identity/count. So a changed rowSize
+    // (the item-size control resizing cells) leaves getTotalSize() reporting
+    // the old height: the spacer stays short and the content-height container
+    // clips the now-taller cells. Reset the cache whenever rowSize changes.
+    // Layout effect so the corrected height lands before paint, no reflow flash.
+    useLayoutEffect(() => {
+      virtualizer.measure();
+    }, [virtualizer, rowSize]);
 
     // Pointer -> visible boundary index: row from y (floor — the row under
     // the pointer), column boundary from x (round — nearest gap between
@@ -253,11 +275,30 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
 
     const indicatorIndex = useCollectionsSelector((s) => {
       const intent = s.interaction.dropIntent;
-      return intent?.type === "insert-at-index" &&
-        intent.collectionId === collectionId &&
-        !s.interaction.dropIntentInvalid
-        ? intent.index
-        : null;
+      if (
+        intent?.type !== "insert-at-index" ||
+        intent.collectionId !== collectionId ||
+        s.interaction.dropIntentInvalid
+      ) {
+        return null;
+      }
+      // Hide the indicator on a NO-OP move: dragging items already in this
+      // collection to a boundary that leaves them where they are. Only for a
+      // contiguous run wholly inside this collection (see VirtualStrip).
+      const active = s.interaction.activeIds;
+      if (active.length > 0) {
+        const children = getChildren(s.graph, collectionId);
+        const positions = active.map((id) => children.indexOf(id));
+        if (positions.every((position) => position >= 0)) {
+          const lo = Math.min(...positions);
+          const hi = Math.max(...positions);
+          const contiguous = hi - lo + 1 === positions.length;
+          if (contiguous && intent.index >= lo && intent.index <= hi + 1) {
+            return null;
+          }
+        }
+      }
+      return intent.index;
     });
     // Boundary k -> a vertical line in row floor(k/cols) at column k%cols
     // (k at a row's end renders at the next row's left edge — the same
@@ -356,6 +397,7 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
                         className="h-full w-full"
                         rovingTabIndex={absoluteIndex === rovingIndex ? 0 : -1}
                         itemContent={itemContent}
+                        dragActivation={itemDragActivation}
                       />
                     </div>
                   );

--- a/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
@@ -677,11 +677,33 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
     // collection (positioned in content coordinates, so it scrolls along).
     const indicatorIndex = useCollectionsSelector((s) => {
       const intent = s.interaction.dropIntent;
-      return intent?.type === "insert-at-index" &&
-        intent.collectionId === collectionId &&
-        !s.interaction.dropIntentInvalid
-        ? intent.index
-        : null;
+      if (
+        intent?.type !== "insert-at-index" ||
+        intent.collectionId !== collectionId ||
+        s.interaction.dropIntentInvalid
+      ) {
+        return null;
+      }
+      // Hide the indicator on a NO-OP: dragging items that already live in this
+      // collection to a boundary that leaves them exactly where they are. Only
+      // when they form a contiguous run wholly inside this collection — dropping
+      // at any boundary from the run's start to just past its end is identity.
+      // (A non-contiguous multi-drag reorders the items between them, so it is a
+      // real move and keeps its indicator.)
+      const active = s.interaction.activeIds;
+      if (active.length > 0) {
+        const children = getChildren(s.graph, collectionId);
+        const positions = active.map((id) => children.indexOf(id));
+        if (positions.every((position) => position >= 0)) {
+          const lo = Math.min(...positions);
+          const hi = Math.max(...positions);
+          const contiguous = hi - lo + 1 === positions.length;
+          if (contiguous && intent.index >= lo && intent.index <= hi + 1) {
+            return null;
+          }
+        }
+      }
+      return intent.index;
     });
 
     // Boundary k's line sits in the gap before item k (measured offsets, so

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -954,7 +954,11 @@ export function WorkbenchSplitPane({
       }
     >
       <div
-        className="sticky top-0 z-30 min-w-0 bg-zinc-950"
+        // z-40 (above the strip's z-30 consumer overlay) so a playhead marker
+        // in a timeline scrolling underneath is occluded by the sticky
+        // preview, not painted over it. At z-30 the marker tied the preview
+        // and, being later in the DOM, bled through into the preview area.
+        className="sticky top-0 z-40 min-w-0 bg-zinc-950"
         data-testid="workbench-preview-region"
       >
         <div


### PR DESCRIPTION
Round-4 graph-view punch list — 10 items, each verified in the running app (and via tests where pointer input matters).

**Not Codex-gated** by request: no `gated` label, so the Codex gate / auto-fix / auto-merge loop does not run. Normal CI (typecheck, lint, unit, app tests) still applies.

### Items
1. **Default to graph view** in a project (home links, new-project redirect, bare `/timeline/{id}` → `/graph`; explicit `?view=storyboard|workbench` still honored).
2. **Playhead no longer bleeds** over the sticky preview or the breadcrumb row — preview region + pinned header raised to `z-40`, above the strip's `z-30` overlay.
3. **Time-ruler toggle** (strip-only): ticks built from the same `buildPlayheadMap` as the playhead, so they map to seconds and absorb pack gaps; collection cards left un-ruled (fixed width / arbitrary duration) with only an edge tick.
4. **Drop indicator hides on a no-op move** (strip + grid) — dragging a contiguous run back onto its own boundary.
5. **Grid native-drop indicator** draws at the current row's right edge instead of jumping to the next row's left past a row's end.
6. **Grid cells no longer truncate** at larger thumbnail sizes — VirtualGrid remeasures the virtualizer on cell-size change.
7. **Hide the px/s scale slider** in grid mode (it's a no-op there).
8. **Grid drag-to-reorder** parity with the strip — VirtualGrid gains `itemDragActivation`, set to `"hold"`.
9. **Undo/Redo → icon buttons**; toolbar wraps at narrow widths instead of overflowing.
10. **Grid FolderDown drill-in** works with a real click (fixed by the `"hold"` activation from #8).

### Validation
- `packages/ui` typecheck ✅ · app lint ✅ · unit 515/515 ✅ · app tests 173/173 ✅ · story suite ✅ (new no-op story) · **graph-view e2e 32/32** ✅ (new grid-reorder test)
- New coverage: e2e grid hold-drag reorder; story for the no-op indicator.

### Note (pre-existing, not in this PR's scope)
`components/graph-view/graph-item-content.stories.tsx` fails the storybook interaction project and the app `tsc` — its `useHydratedCollectionPreviews` hook needs a `<DndCollections>` provider the story doesn't supply. It's byte-identical to `main` (introduced with PR #116's hydrated-previews work) and unaffected by this PR; CI's required checks don't run that project, so it doesn't gate here. Happy to fix separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)