### PR TITLE
Fix graph-item-content story (provider + un-hydrated frames)

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -2,9 +2,12 @@ import type { Decorator, Meta, StoryObj } from "@storybook/react";
 import { expect } from "storybook/test";
 
 import type { ClipDetail } from "@storyboard/timeline-domain";
-import type {
-  CollectionItemContentProps,
-  NodeId,
+import {
+  DndCollections,
+  buildGraph,
+  type CollectionItemContentComponent,
+  type CollectionItemContentProps,
+  type NodeId,
 } from "@storyboard/ui/dnd-collections";
 
 import { GRAPH_VIEW_COMPONENTS } from "./graph-item-content";
@@ -21,9 +24,20 @@ import { createGraphDetailsStore } from "@/lib/graph-details-store";
 // "repeated thumbnails" case the repo rules require and pin the fix: both
 // frames must render, with no duplicate-key collision.
 
-const ItemContent = GRAPH_VIEW_COMPONENTS.ItemContent;
+// The registry field is optional in the type; the graph view always registers
+// it, so narrow to the defined component for `Meta`.
+const ItemContent: CollectionItemContentComponent = GRAPH_VIEW_COMPONENTS.ItemContent!;
 
 const COLLECTION_ID = "col-1" as NodeId;
+
+/** A one-node graph so the card's collections-store hooks have a provider.
+ *  Its contents are irrelevant: the card renders un-hydrated here, so its
+ *  preview frames come from the stored `previewItems` below, not the graph. */
+const providerGraph = (() => {
+  const result = buildGraph([{ kind: "collection", id: COLLECTION_ID, name: "A timeline", children: [] }]);
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.value;
+})();
 
 /** A deterministic, fully-offline poster (a solid-colour SVG data URI). */
 function poster(label: string, fill: string): string {
@@ -48,23 +62,29 @@ const ASSET_B: PreviewItem = {
   alt: "Asset B",
 };
 
-/** Wraps the card content in a details store so `useClipDetail` resolves. */
+/** Wraps the card content in a collections store (its preview-derivation hook
+ *  needs one) and a details store (so `useClipDetail` resolves). `hydrated:
+ *  false` keeps the frames coming from the stored `previewItems` here — a
+ *  hydrated card would instead derive them from live graph children, which
+ *  this offline fixture deliberately does not carry. */
 function renderWithDetail(previewItems: PreviewItem[]) {
   const detail: ClipDetail = {
     alt: "A timeline",
     aspect: 16 / 9,
     trackIndex: 0,
-    hydrated: true,
+    hydrated: false,
     itemCount: previewItems.length,
     previewItems,
   };
   const store = createGraphDetailsStore({ [COLLECTION_ID]: detail });
   const decorator: Decorator = (Story) => (
-    <GraphDetailsProvider store={store}>
-      <div className="h-32 w-40 bg-zinc-950 p-2">
-        <Story />
-      </div>
-    </GraphDetailsProvider>
+    <DndCollections initialGraph={providerGraph}>
+      <GraphDetailsProvider store={store}>
+        <div className="h-32 w-40 bg-zinc-950 p-2">
+          <Story />
+        </div>
+      </GraphDetailsProvider>
+    </DndCollections>
   );
   return decorator;
 }


### PR DESCRIPTION
Fixes the pre-existing `CollectionCardContent` story failure surfaced during the round-4 punch-list validation ([#122](https://github.com/josulliv101/storyboard-flow/pull/122)).

### Problem
`components/graph-view/graph-item-content.stories.tsx` rendered `GraphClipContent` without a `<DndCollections>` provider. Its `useHydratedCollectionPreviews` hook (added with the hydrated-previews work) calls `useCollectionsStore()`, which threw *"hooks must be used within `<DndCollections>`"* — failing all 3 stories in the storybook interaction project. The `meta.component` also failed app `tsc` (the registry's `ItemContent` field is optional). CI's required checks don't run the storybook project, so it never gated.

### Fix
- Wrap the fixture in `<DndCollections>` with a one-node graph so the store hook has a provider.
- `detail.hydrated: false` — frames come from the stored `previewItems` the fixture supplies (a hydrated card derives them from live graph children, which this offline fixture deliberately omits). Still exercises the positional-key regression the stories guard.
- Narrow the registry `ItemContent` to the defined component for `Meta` (fixes the `tsc` error).

### Validation
- Story: `graph-item-content.stories.tsx` 3/3 ✅ (was 0/3)
- App `tsc --noEmit` ✅ (error gone) · app lint ✅ (0 errors) · `VirtualStrip.stories.tsx` 42/42 in isolation ✅

Story-only change (no component touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)