### PR TITLE
Graph view punch list round 5 (items 1, 2, 4, 5)

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -5,7 +5,6 @@ import { EllipsisVertical, FolderTree, Redo2, Ruler, TvMinimal, Undo2 } from "lu
 
 import {
   CollectionsContainerContext,
-  TrashTarget,
   VirtualGrid,
   VirtualStrip,
   parseNodeId,
@@ -25,6 +24,7 @@ import {
 import { Slider } from "@/components/core/slider";
 
 import { NativeDropGrid, NativeDropStrip, SidebarToolInsertBridge } from "./graph-native-drop";
+import { SidebarGraphTrashPortal } from "./graph-sidebar-trash";
 import { OpenKeyBoundary } from "./graph-navigation";
 import { SyncPanel, type SyncEntry } from "./graph-persistence";
 import {
@@ -435,16 +435,11 @@ export function GraphBoard({
             />
           )}
 
-          {trashRootId !== null && (
-            <div className="flex items-end justify-end">
-              <div className="shrink-0">
-                <h3 className="mb-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-zinc-500">
-                  Trash
-                </h3>
-                <TrashTarget trashId={parseNodeId(trashRootId)} />
-              </div>
-            </div>
-          )}
+          {/* Trash is now the sidebar tool palette, which morphs into a drop
+              target while a card is being dragged (R5 #1) — the old fixed
+              bottom-right panel is gone (R5 #5). This portals into the sidebar
+              from inside the provider, so its droppable joins the DndContext. */}
+          <SidebarGraphTrashPortal trashId={trashRootId} />
 
           <SyncPanel entries={syncEntries} />
         </div>

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -276,16 +276,27 @@ export function GraphRuler({
   }, [graph, details, spans, focusedId, pixelsPerSecond]);
 
   return (
-    <div aria-hidden="true" data-graph-ruler className="pointer-events-none absolute inset-x-0 top-0">
+    <div
+      aria-hidden="true"
+      data-graph-ruler
+      className="pointer-events-none absolute inset-x-0 top-0 z-10 h-[18px]"
+    >
+      {/* Opaque band: the ticks used to be thin translucent lines painted over
+          the thumbnails and washed out against bright frames. A solid dark
+          strip with a bright baseline keeps the whole ruler legible over ANY
+          clip, at every zoom. */}
+      <div className="absolute inset-x-0 top-0 h-[18px] border-b border-sky-400/50 bg-zinc-950/90" />
       {ticks.map((tick, index) => (
-        <div
-          key={index}
-          className="absolute top-0 flex flex-col items-center"
-          style={{ transform: `translateX(${tick.x}px)` }}
-        >
-          <div className="h-2 w-px bg-sky-300/60" />
+        <div key={index} className="absolute top-0" style={{ transform: `translateX(${tick.x}px)` }}>
+          {/* Labeled ticks (media seconds) run the full band and are bright;
+              unlabeled collection-edge ticks are short and dim. */}
+          <div
+            className={
+              tick.label ? "h-[18px] w-px bg-sky-300" : "h-[9px] w-px bg-sky-400/60"
+            }
+          />
           {tick.label ? (
-            <span className="mt-px rounded-sm bg-zinc-950/70 px-0.5 font-mono text-[8px] leading-none text-sky-200/80">
+            <span className="absolute left-[3px] top-[2px] whitespace-nowrap font-mono text-[9px] font-medium leading-none text-sky-100">
               {tick.label}
             </span>
           ) : null}

--- a/apps/timeline-gstudio001/components/graph-view/graph-sidebar-trash.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sidebar-trash.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { useDroppable } from "@dnd-kit/core";
+import { Trash2 } from "lucide-react";
+
+import {
+  encodeDropTarget,
+  getChildren,
+  parseNodeId,
+  useCollectionsContainer,
+  useCollectionsSelector,
+  type NodeId,
+} from "@storyboard/ui/dnd-collections";
+
+// The graph's trash drop target lives in the SIDEBAR now, taking the tool
+// palette's place while a card is being dragged (the "add" tools are useless
+// mid-drag). It is:
+//   - defined inside the board's <DndCollections> so its useDroppable joins the
+//     same DndContext (and the shared @dnd-kit/core instance) as every card;
+//   - PORTALED into a slot the global sidebar renders, which sits outside the
+//     collections provider entirely.
+// The dropTarget id is the SAME `panel`/trashId the old bottom-right target
+// used, so DndCollections' drag-end resolves it to the identical move-to-trash
+// command — undo restores, nothing is deleted.
+
+/** Id of the sidebar DOM node the board portals the trash target into. */
+export const SIDEBAR_TRASH_SLOT_ID = "graph-sidebar-trash-slot";
+
+function SidebarGraphTrashTarget({ trashId }: Readonly<{ trashId: NodeId }>) {
+  const isDragging = useCollectionsSelector((s) => s.interaction.isDragging);
+  const isCollection = useCollectionsSelector(
+    (s) => s.graph.nodesById.get(trashId)?.kind === "collection",
+  );
+  const count = useCollectionsSelector((s) =>
+    s.graph.nodesById.get(trashId)?.kind === "collection"
+      ? getChildren(s.graph, trashId).length
+      : 0,
+  );
+  const state = useCollectionsSelector((s) => {
+    const intent = s.interaction.dropIntent;
+    if (intent?.type !== "append-to-collection" || intent.collectionId !== trashId) return "idle";
+    return s.interaction.dropIntentInvalid ? "invalid" : "over";
+  });
+
+  const { setNodeRef } = useDroppable({
+    id: encodeDropTarget({ type: "panel", collectionId: trashId }),
+    disabled: !isCollection,
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      role="group"
+      // A pointer affordance shown only mid-drag; the keyboard trash path is
+      // Alt+Delete / Delete, wired separately.
+      aria-hidden={!isDragging}
+      data-graph-sidebar-trash={trashId}
+      data-trash-state={state}
+      className={[
+        "absolute inset-0 flex flex-col items-center justify-center gap-1 rounded-lg border border-dashed text-[10px] font-semibold uppercase tracking-wide",
+        // The morph: idle it is invisible and lets tool clicks through; a drag
+        // fades + scales it in over the tools. transition covers both ways.
+        "transition-all duration-200 ease-out",
+        isDragging ? "scale-100 opacity-100" : "pointer-events-none scale-90 opacity-0",
+        state === "over"
+          ? "border-red-400 bg-red-500/20 text-red-200"
+          : state === "invalid"
+            ? "border-red-500 bg-red-500/30 text-red-200"
+            : "border-red-500/40 bg-zinc-950/90 text-zinc-400",
+      ].join(" ")}
+    >
+      <Trash2
+        className={[
+          "h-5 w-5 transition-transform duration-200",
+          state === "over" ? "scale-110 text-red-200" : "",
+        ].join(" ")}
+      />
+      <span>Trash{count > 0 ? ` ${count}` : ""}</span>
+    </div>
+  );
+}
+
+/**
+ * Mounted inside the board. Registers the trash id for the keyboard controller
+ * (so Alt+Delete keeps working after the old bottom-right target is gone), then
+ * portals the drop target into the sidebar slot once that slot exists. The
+ * target is always rendered while the slot is present, so dnd-kit measures it
+ * at drag start even though it is invisible until a drag begins.
+ */
+export function SidebarGraphTrashPortal({ trashId }: Readonly<{ trashId: string | null }>) {
+  const { trashRef } = useCollectionsContainer();
+  const [slot, setSlot] = useState<HTMLElement | null>(null);
+
+  const trashNodeId = trashId !== null ? parseNodeId(trashId) : null;
+
+  useEffect(() => {
+    if (trashNodeId === null) return;
+    trashRef.current = trashNodeId;
+    return () => {
+      if (trashRef.current === trashNodeId) trashRef.current = null;
+    };
+  }, [trashRef, trashNodeId]);
+
+  useEffect(() => {
+    // The sidebar (global chrome, outside this provider) renders the slot. Find
+    // it on the next frame — deferred through rAF, never a synchronous setState
+    // in the effect — retrying a few frames to cover the mount-order race.
+    let raf = 0;
+    let tries = 0;
+    const find = () => {
+      const el = document.getElementById(SIDEBAR_TRASH_SLOT_ID);
+      if (el) {
+        setSlot(el);
+        return;
+      }
+      if (tries++ < 120) raf = requestAnimationFrame(find);
+    };
+    raf = requestAnimationFrame(find);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  if (trashNodeId === null || slot === null) return null;
+  return createPortal(<SidebarGraphTrashTarget trashId={trashNodeId} />, slot);
+}

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -257,12 +257,18 @@ export function TimelineSidebar() {
         <>
           <div className="h-px w-10 shrink-0 bg-zinc-800/80" />
 
-          <SidebarToolPalette
-            canInsert={canInsertTools}
-            onActivate={handleToolActivate}
-            onDragStart={handleDragStart}
-            onDragEnd={handleDragEnd}
-          />
+          {/* `relative` so the graph board can portal its trash drop target
+              into the slot below, filling the palette's exact footprint and
+              morphing over the tools during a drag (see graph-sidebar-trash). */}
+          <div className="relative">
+            <SidebarToolPalette
+              canInsert={canInsertTools}
+              onActivate={handleToolActivate}
+              onDragStart={handleDragStart}
+              onDragEnd={handleDragEnd}
+            />
+            <div id="graph-sidebar-trash-slot" className="absolute inset-0" />
+          </div>
         </>
       )}
 

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -635,6 +635,12 @@ test.describe("graph view E2E", () => {
   }) => {
     await installGraphApi(page);
     await openGraph(page);
+    // A short viewport so the board content reliably overflows and the page can
+    // scroll PAST the preview (the sticky-pin assertion below needs that). The
+    // preview's own height is a fixed model value, independent of viewport, so
+    // the height-persistence checks are unaffected. (The old always-present
+    // bottom trash panel used to guarantee this height; it's gone now — R5 #5.)
+    await page.setViewportSize({ width: 1280, height: 560 });
     await previewToggle(page).click();
 
     const divider = page.getByRole("separator", { name: "Resize workbench display" });
@@ -828,7 +834,10 @@ test.describe("graph view E2E", () => {
   }) => {
     const api = await installGraphApi(page);
     await openGraph(page);
-    const trash = page.locator(`[data-trash-target="${TRASH_ID}"]`);
+    // Trash is the sidebar tool palette now (R5 #1): invisible until a drag
+    // starts, then it morphs in over the tools. It is still laid out (opacity
+    // 0), so holdDrag can target it, and the drag activates it before the drop.
+    const trash = page.locator(`[data-graph-sidebar-trash="${TRASH_ID}"]`);
     await holdDrag(page, strip(page, PROJECT_ID).locator('[data-node-id="bravo"]'), trash);
 
     await expect
@@ -1165,8 +1174,10 @@ test.describe("graph view E2E", () => {
 
     await page.keyboard.press("Delete");
     await expect.poll(() => stripOrder(page, PROJECT_ID)).toEqual([CHILD_ID, "charlie"]);
+    // The toast is the trash confirmation now — the always-visible bottom-right
+    // count panel was removed (R5 #5); trash lives in the sidebar and only
+    // surfaces during a drag.
     await expect(page.getByText("Moved 2 items to trash.").first()).toBeVisible();
-    await expect(page.getByRole("group", { name: /^Trash, 2 items/ })).toBeVisible();
 
     // ONE undo restores the whole selection — the delete was a single
     // command, not one history entry per card.
@@ -1174,8 +1185,6 @@ test.describe("graph view E2E", () => {
     await expect
       .poll(() => stripOrder(page, PROJECT_ID))
       .toEqual(["alpha", "bravo", CHILD_ID, "charlie"]);
-    // Empty again: the target's label drops the count entirely at zero.
-    await expect(page.getByRole("group", { name: /^Trash\. Drop items/ })).toBeVisible();
     await expect(undoButton(page)).toBeDisabled();
   });
 

--- a/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
@@ -729,8 +729,12 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
               ref={overlayRef}
               // Floats above the strip; positioned horizontally by
               // positionOverlay (transform set imperatively). An overlay, so
-              // it never displaces the clip row.
-              className="absolute left-0 z-30"
+              // it never displaces the clip row. z-50 so it floats above any
+              // sticky chrome a consumer pins over the strip (e.g. the graph
+              // board's z-40 header) rather than being clipped by it — unlike
+              // the playhead/consumer overlay (z-30), which is MEANT to scroll
+              // under that chrome.
+              className="absolute left-0 z-50"
               style={{ bottom: `calc(100% + ${OVERVIEW_GAP}px)` }}
             >
               <TrimOverviewStrip


### PR DESCRIPTION
Round-5 punch list. Items 1, 2, 4, 5 here; **item 3 (live trim-frame preview) is a larger standalone feature** and is proposed as a focused follow-up (see below).

**Not Codex-gated** (no `gated` label). Normal CI applies.

### Items
1. **Sidebar trash morph.** While a card is dragged, the sidebar tool palette morphs into a trash drop target filling its exact footprint (fade + scale in/out). Dropping a card there runs the standard move-to-trash command. Implemented as a droppable defined inside the board's `DndCollections` (so it joins the DndContext + the shared, hoisted `@dnd-kit/core`) and **portaled** into a slot the global sidebar renders — no package change.
5. **Removed the bottom-right trash panel** (redundant now).
2. **Overview no longer truncates.** The selected clip's floating full-sequence overview was tied with the sticky header at z-30 and got clipped by it after round 4's z-40 header; raised the overview to z-50 (the playhead/consumer overlay stays z-30, still correctly occluded).
4. **Legible ruler.** Opaque band + bright baseline, clearer major/minor ticks, larger labels — the round-4 thin translucent lines washed out over thumbnails.

### Validation
- graph-view **e2e 32/32** ✅ (trash test retargeted to the sidebar target; Delete test asserts via toast now that the always-visible count panel is gone; preview-pin test uses a short viewport so content still overflows)
- app `tsc` ✅ · `packages/ui` `tsc` ✅ · lint ✅ (0 errors) · unit 515/515 ✅ · app tests 173/173 ✅ · VirtualStrip stories 42/42 ✅

### Item 3 — deferred (needs its own PR)
"Live trim-frame preview while dragging a trim handle" is a substantial sub-feature: it needs the package to expose the live-trim signal (VirtualStrip only consumes it internally today), video-frame seeking at *uncommitted* live-trim times, a preview-area override that leaves the playhead untouched, and a fallback floating overlay when the preview is closed. Worth doing carefully on its own branch rather than bolted onto this batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)