### PR TITLE
Fix sidebar tool-drag regression (R6 #9)

### DIFF
--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -279,7 +279,16 @@ export function TimelineSidebar() {
               onDragStart={handleDragStart}
               onDragEnd={handleDragEnd}
             />
-            <div id="graph-sidebar-trash-slot" className="absolute inset-0" />
+            {/* pointer-events-none so the slot never covers the tool buttons'
+                own drag/click — it only hosts the portaled trash target, which
+                re-enables its OWN pointer-events while a card drag is live (a
+                child overriding a none parent), and whose dnd-kit drop is
+                rect-based regardless. Without this the slot ate the tools'
+                dragstart and sidebar tool-drag stopped working. */}
+            <div
+              id="graph-sidebar-trash-slot"
+              className="pointer-events-none absolute inset-0"
+            />
           </div>
         </>
       )}

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1769,5 +1769,25 @@ test.describe("graph view E2E", () => {
       return transfer.getData("application/x-gstudio-type");
     });
     expect(carried).toBe("image");
+
+    // ...and the button must actually RECEIVE that dragstart under a real
+    // pointer. dispatchEvent above bypasses hit-testing, so it can't catch the
+    // regression where the graph's trash slot (an absolute overlay covering
+    // the palette footprint) sits ON TOP of the tools and eats their gesture.
+    // Assert hit-testing: the element at each tool's own centre is that tool,
+    // not the slot. (The slot must stay pointer-events-none — R6 #9.)
+    for (const name of [/add collection/i, /add image clip/i, /add video clip/i]) {
+      const tool = page.getByRole("button", { name });
+      const hit = await tool.evaluate((el) => {
+        const r = el.getBoundingClientRect();
+        const top = document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2);
+        return {
+          onThisTool: el.contains(top),
+          coveredBySlot: top?.closest("#graph-sidebar-trash-slot") != null,
+        };
+      });
+      expect(hit.coveredBySlot).toBe(false);
+      expect(hit.onThisTool).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
**Regression fix.** Not Codex-gated.

R5's sidebar trash morph ([#124](https://github.com/josulliv101/storyboard-flow/pull/124)) added an `absolute inset-0` slot div over the tool palette to host the portaled trash target. With default `pointer-events` it covered the **Add Collection / Image / Video** buttons and swallowed their `dragstart` — native tool-drag onto a strip silently broke.

**Fix:** one line — `pointer-events-none` on the slot. Events fall through to the tool buttons; the portaled trash target re-enables its *own* pointer-events during a card drag (a child overriding the `none` parent) and its dnd-kit drop is rect-based anyway, so the trash morph + drop are unchanged.

**Test (R6 #9 asked for one):** the existing "still drag sources" test dispatched `dragstart` directly on the element — which bypasses hit-testing, so it stayed green through the regression. Extended it to assert hit-testing (`elementFromPoint` at each tool's centre is that tool, not the slot). **Proven**: fails on the pre-fix markup (`coveredBySlot: true`), passes after.

Verified: tool-drag guard ✅, trash-drop ✅, native-drops ✅, lint ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)