### PR TITLE
Item-shell seam + composed collection card (review finding 1)

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-inline-rename.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-inline-rename.tsx
@@ -39,25 +39,23 @@ export function useInlineRename(nodeId: NodeId, currentName: string) {
 }
 
 /**
- * The inline editor, as a `contentEditable` span rather than an `<input>`.
+ * The inline editor: one real `<input>` shared by every rename site — the
+ * collection card, the breadcrumb crumb, and the sub-timeline row heading.
  *
- * A strip/grid card's content renders INSIDE the NodeCard `<button>` shell. An
- * `<input>` there is invalid interactive content and the parser hoists it OUT
- * of the button on hydration; a `<span>` is phrasing content and stays put —
- * which is why this is a contentEditable span. That dodges the hoist, but be
- * honest: a focusable `role="textbox"` inside a `<button>` is still not clean
- * a11y (nested interactive semantics). The correct fix is to render the editor
- * OUTSIDE the button — a sibling of a selection surface — which needs an
- * item-shell override on VirtualStrip/VirtualGrid that the graph does not have
- * yet. Until then this is a pragmatic, edit-only (transient) editor; `role` +
- * `aria-label` keep it testable and named. The text is seeded once via the ref
- * (never bound as React children, which would reset the caret every keystroke)
- * and read back through `onInput`.
+ * It used to be a `contentEditable` span because the card's editor rendered
+ * INSIDE the NodeCard `<button>` shell, where an `<input>` is invalid
+ * interactive content. The graph now renders its collection items through the
+ * package's item-shell seam (see GraphCollectionItem), which composes this
+ * editor as a SIBLING of the selection surface — so a native input is legal
+ * everywhere it appears, with real caret/selection/IME behavior for free.
  *
- * Placed within the card's drag sensor, so a press or click here must not start
- * a drag or toggle selection — hence the stopPropagation. The card's keyboard
- * chords already skip editable targets, so typing is safe; Enter commits (no
- * newline) and Escape cancels.
+ * Uncontrolled on purpose: the value is seeded once (`defaultValue`) and
+ * reported through `onInput`; select-on-focus lets the first keystroke replace
+ * the old name. The card's editor sits inside drag-sensor/pan territory, so
+ * presses must not start a drag, a pan, or toggle selection — hence the
+ * stopPropagation trio. Keyboard chords already skip editable targets
+ * (isEditableKeyboardTarget); the keydown stopPropagation is belt-and-braces.
+ * Enter commits, Escape cancels, blur commits.
  */
 export function InlineNameEditor({
   initialValue,
@@ -72,42 +70,27 @@ export function InlineNameEditor({
   onCancel: () => void;
   className?: string;
 }>) {
-  const setRef = useCallback(
-    (element: HTMLSpanElement | null) => {
-      if (!element) return;
-      element.textContent = initialValue;
-      element.focus();
-      // Select all so the first keystroke replaces the old name.
-      const range = document.createRange();
-      range.selectNodeContents(element);
-      const selection = window.getSelection();
-      selection?.removeAllRanges();
-      selection?.addRange(range);
-    },
-    [initialValue],
-  );
+  const setRef = useCallback((element: HTMLInputElement | null) => {
+    if (!element) return;
+    element.focus();
+    // Select all so the first keystroke replaces the old name.
+    element.select();
+  }, []);
 
   return (
-    <span
+    <input
       ref={setRef}
-      role="textbox"
       aria-label="Timeline name"
-      contentEditable
-      suppressContentEditableWarning
+      defaultValue={initialValue}
       spellCheck={false}
-      onInput={(event) => onInput(event.currentTarget.textContent ?? "")}
+      onChange={(event) => onInput(event.target.value)}
       onPointerDown={(event) => event.stopPropagation()}
       onClick={(event) => event.stopPropagation()}
       onDoubleClick={(event) => event.stopPropagation()}
       onKeyDown={(event) => {
         event.stopPropagation();
-        if (event.key === "Enter") {
-          event.preventDefault(); // commit instead of inserting a newline
-          onCommit();
-        } else if (event.key === "Escape") {
-          event.preventDefault();
-          onCancel();
-        }
+        if (event.key === "Enter") onCommit();
+        else if (event.key === "Escape") onCancel();
       }}
       onBlur={onCommit}
       className={className}

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -1,12 +1,12 @@
 import type { Decorator, Meta, StoryObj } from "@storybook/react";
-import { expect } from "storybook/test";
+import { expect, userEvent, waitFor } from "storybook/test";
 
 import type { ClipDetail } from "@storyboard/timeline-domain";
 import {
   DndCollections,
   buildGraph,
-  type CollectionItemContentComponent,
-  type CollectionItemContentProps,
+  type CollectionItemShellComponent,
+  type CollectionItemShellProps,
   type NodeId,
 } from "@storyboard/ui/dnd-collections";
 
@@ -14,25 +14,24 @@ import { GRAPH_VIEW_COMPONENTS } from "./graph-item-content";
 import { GraphDetailsProvider } from "./graph-details-context";
 import { createGraphDetailsStore } from "@/lib/graph-details-store";
 
-// The collection card's ItemContent renders two preview frames — the child
-// timeline's FIRST and LAST preview items. Stored clip ids are NOT unique
-// across positions (the same asset placed twice mints the same stable id — see
-// the duplicate-media machinery in `packages/timeline-domain/src/adapter.ts`),
-// so a collection whose first and last preview items reference the SAME asset
-// used to render two frames with the same React key. These deterministic,
-// offline stories (data-URI posters, an in-memory details store) cover the
-// "repeated thumbnails" case the repo rules require and pin the fix: both
-// frames must render, with no duplicate-key collision.
+// The COMPOSED collection card, exactly as the graph renders it: the
+// registered ItemShell routes collections through CollectionItem primitives,
+// so the folder drill-in and the rename editor are real interactive elements
+// composed as SIBLINGS of the card's selection <button> — the structure the
+// direct-ItemContent stories could never exercise (review finding 1). These
+// deterministic, offline stories (data-URI posters, an in-memory details
+// store) cover the preview-frame cases the repo rules require AND pin the
+// composed card's DOM validity.
 
 // The registry field is optional in the type; the graph view always registers
 // it, so narrow to the defined component for `Meta`.
-const ItemContent: CollectionItemContentComponent = GRAPH_VIEW_COMPONENTS.ItemContent!;
+const ItemShell: CollectionItemShellComponent = GRAPH_VIEW_COMPONENTS.ItemShell!;
 
 const COLLECTION_ID = "col-1" as NodeId;
 
-/** A one-node graph so the card's collections-store hooks have a provider.
- *  Its contents are irrelevant: the card renders un-hydrated here, so its
- *  preview frames come from the stored `previewItems` below, not the graph. */
+/** A one-node graph: the shell reads the node (kind, name) from the store.
+ *  The card renders un-hydrated here, so its preview frames come from the
+ *  stored `previewItems` below, not from graph children. */
 const providerGraph = (() => {
   const result = buildGraph([{ kind: "collection", id: COLLECTION_ID, name: "A timeline", children: [] }]);
   if (!result.ok) throw new Error(JSON.stringify(result.error));
@@ -62,11 +61,11 @@ const ASSET_B: PreviewItem = {
   alt: "Asset B",
 };
 
-/** Wraps the card content in a collections store (its preview-derivation hook
- *  needs one) and a details store (so `useClipDetail` resolves). `hydrated:
- *  false` keeps the frames coming from the stored `previewItems` here — a
- *  hydrated card would instead derive them from live graph children, which
- *  this offline fixture deliberately does not carry. */
+/** Wraps the composed card in a collections store (the shell and its rename
+ *  dispatch need one) and a details store (so `useClipDetail` resolves).
+ *  `hydrated: false` keeps the frames coming from the stored `previewItems`
+ *  here — a hydrated card would instead derive them from live graph children,
+ *  which this offline fixture deliberately does not carry. */
 function renderWithDetail(previewItems: PreviewItem[]) {
   const detail: ClipDetail = {
     alt: "A timeline",
@@ -95,22 +94,17 @@ function previewImages(root: HTMLElement): HTMLImageElement[] {
   return Array.from(root.querySelectorAll("img"));
 }
 
-const baseArgs: CollectionItemContentProps = {
+const baseArgs: CollectionItemShellProps = {
   id: COLLECTION_ID,
-  node: { id: COLLECTION_ID, kind: "collection", name: "A timeline" },
-  childCount: 2,
-  selected: false,
-  rejected: false,
-  isDragSource: false,
-  dragActivation: "body",
-  trimEnabled: false,
+  className: "h-full w-full",
+  dragActivation: "hold",
 };
 
 const meta = {
   title: "GStudio/GraphView/CollectionCardContent",
-  component: ItemContent,
+  component: ItemShell,
   tags: ["autodocs"],
-} satisfies Meta<typeof ItemContent>;
+} satisfies Meta<typeof ItemShell>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -153,5 +147,50 @@ export const SingleFrame: Story = {
   play: async ({ canvasElement }) => {
     const images = previewImages(canvasElement);
     await expect(images).toHaveLength(1);
+  },
+};
+
+/**
+ * The composed card's STRUCTURE (review finding 1): the selection surface is
+ * a real <button> with zero interactive content inside it, the folder
+ * drill-in is a real <button> sibling, and the rename editor is a real
+ * <input> sibling — and renaming through it updates the graph node (the
+ * surface's accessible name) in place.
+ */
+export const ComposedCardStructure: Story = {
+  args: baseArgs,
+  decorators: [renderWithDetail([ASSET_A, ASSET_B])],
+  play: async ({ canvasElement }) => {
+    const surface = canvasElement.querySelector<HTMLElement>("[data-node-id]");
+    await expect(surface).not.toBeNull();
+    await expect(surface!.tagName).toBe("BUTTON");
+    // No nested interactive semantics inside the surface button.
+    await expect(
+      surface!.querySelectorAll("button, [role='button'], input, textarea, select, a[href], [tabindex]"),
+    ).toHaveLength(0);
+
+    // The folder control is a REAL button OUTSIDE the surface.
+    const folder = canvasElement.querySelector<HTMLElement>('button[aria-label^="Open "]');
+    await expect(folder).not.toBeNull();
+    await expect(surface!.contains(folder)).toBe(false);
+
+    // Double-click the name label → a REAL input opens outside the surface...
+    const label = Array.from(surface!.querySelectorAll("span")).find(
+      (el) => el.textContent === "A timeline",
+    )!;
+    await userEvent.dblClick(label);
+    const editor = canvasElement.querySelector<HTMLInputElement>(
+      'input[aria-label="Timeline name"]',
+    );
+    await expect(editor).not.toBeNull();
+    await expect(surface!.contains(editor)).toBe(false);
+
+    // ...and committing a new name renames the GRAPH node: the surface's
+    // accessible name follows immediately.
+    await userEvent.clear(editor!);
+    await userEvent.type(editor!, "Renamed timeline{Enter}");
+    await waitFor(() =>
+      expect(surface!.getAttribute("aria-label")).toMatch(/^Renamed timeline \(collection/),
+    );
   },
 };

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -4,16 +4,22 @@ import { memo, useCallback, useContext, useRef, useState, useSyncExternalStore }
 import { FolderDown, Image as ImageIcon, Video } from "lucide-react";
 
 import {
+  CollectionItem,
+  NodeCard,
   mediaDurationSeconds,
+  useCollectionItemState,
+  useCollectionsSelector,
   useCollectionsStore,
   useLiveTrim,
   videoFrameCount,
   type CollectionGhostContentProps,
   type CollectionItemContentProps,
+  type CollectionItemShellProps,
   type CollectionTrimHandleContentProps,
   type CollectionsComponents,
   type CollectionsGraph,
   type MediaNode,
+  type NodeCardDragActivation,
   type NodeId,
 } from "@storyboard/ui/dnd-collections";
 import {
@@ -169,143 +175,21 @@ function LiveDurationPill({ id, node }: { id: NodeId; node: MediaNode }) {
 const GraphClipContent = memo(function GraphClipContent({
   id,
   node,
-  childCount,
   selected,
   rejected,
   isDragSource,
   trimEnabled,
 }: CollectionItemContentProps) {
-  const detail = useClipDetail(id as string);
-  // Same source of truth as the tree/breadcrumb, so a rename shows here too.
-  const title = useTimelineTitle(id as string);
-  // In-place rename of the collection name (media cards never edit; the hook
-  // is cheap and called unconditionally to satisfy the rules of hooks).
-  const rename = useInlineRename(id, title ?? node.name);
-  const nav = useContext(GraphViewNavContext);
-  // Hydrated collections derive their preview frames from live children (like
-  // the count below), so editing a loaded child refreshes this card without a
-  // reload; placeholders fall back to their stored summary.
-  const isHydratedCollection = node.kind === "collection" && detail?.hydrated === true;
-  const livePreviews = useHydratedCollectionPreviews(id as string, isHydratedCollection);
-  const liveSeconds = useHydratedCollectionSeconds(id as string, isHydratedCollection);
-  // Card geometry for the video filmstrip's frame count (media branch below).
+  // Card geometry for the video filmstrip's frame count.
   const [cardSizeRef, cardSize] = useElementSize();
 
-  if (node.kind === "collection") {
-    const hydrated = detail?.hydrated === true;
-    const count = hydrated ? childCount : (detail?.itemCount ?? childCount);
-    // Total content duration: live-derived when hydrated (tracks child edits),
-    // else the stored collection-clip duration. Absent only for a placeholder
-    // with no stored duration yet.
-    const totalSeconds = hydrated ? liveSeconds : detail?.duration;
-    // FIRST and LAST only — the card says "a timeline runs from here to
-    // there", which two frames tell and three do not. A single-item
-    // collection has no "last" distinct from its first, so it shows one
-    // frame across the full width rather than the same image twice.
-    const all: readonly CollectionPreviewFrame[] = hydrated
-      ? livePreviews
-      : (detail?.previewItems ?? []);
-    const previews = all.length > 1 ? [all[0], all[all.length - 1]] : all;
-    const displayName = title ?? node.name;
-    // Interaction split: the card BODY selects (like any clip — see
-    // openOnClick in graph-timeline-view no longer opening collections), and
-    // the big folder button is the ONE thing that drills in. Selected cards
-    // can then be trashed with Delete alongside media.
-    return (
-      <span
-        title="Click to select · click the folder to open · press O to open"
-        className={[
-          "relative flex h-full w-full flex-col justify-between overflow-hidden rounded-md border border-dashed border-sky-500/40 bg-sky-500/[0.08] p-1.5",
-          selected ? "ring-2 ring-amber-400" : "",
-          rejected ? "ring-2 ring-red-500 motion-safe:animate-pulse" : "",
-          isDragSource ? "opacity-40" : "",
-        ].join(" ")}
-      >
-        {/* `relative` so the folder button can centre itself over the seam
-            between the two frames rather than sitting in the label strip. */}
-        <span className="relative flex min-h-0 flex-1 gap-0.5 overflow-hidden">
-          {previews.length === 0 ? (
-            <span className="flex flex-1 items-center justify-center text-[9px] text-zinc-500">
-              {/* Previews are direct MEDIA children only, so a collection of
-                  nothing but sub-collections has none — that is not "Empty"
-                  (count > 0). Reserve "Empty" for a truly childless collection. */}
-              {!hydrated ? "Open to load" : count === 0 ? "Empty" : "No media preview"}
-            </span>
-          ) : (
-            previews.map((preview, index) => (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
-                // Positional key: `previews` is a fixed-length, order-stable
-                // first/last pair, and stored clip ids are NOT unique across
-                // positions (the same asset can be both the first and last
-                // preview item), so keying by `preview.id` collides. The slot
-                // is what this is, so key by the slot.
-                key={`${index}-${preview.id}`}
-                src={preview.poster ?? preview.src}
-                alt=""
-                draggable={false}
-                loading="lazy"
-                className="h-full min-w-0 flex-1 rounded-sm object-cover"
-              />
-            ))
-          )}
-          {/* The drill affordance: a large control, sized as a fraction of the
-              card so it stays prominent at every item size. A span with
-              role=button, NOT a <button> — the NodeCard shell is itself a
-              <button>, and nesting one is invalid HTML. stopPropagation on
-              pointerdown keeps a press on it from starting the card's drag or
-              selecting it (the control opens, the body selects); keyboard
-              drill-in stays on the O key (OpenKeyBoundary), so this is a
-              pointer affordance and sits outside the tab order. */}
-          <span
-            role="button"
-            tabIndex={-1}
-            aria-label={`Open ${displayName}`}
-            title="Open this timeline"
-            data-collections-keyboard-ignore
-            onPointerDown={(event) => event.stopPropagation()}
-            onClick={(event) => {
-              event.stopPropagation();
-              nav?.openTimeline(id as NodeId);
-            }}
-            className="absolute left-1/2 top-1/2 flex aspect-square h-[46%] -translate-x-1/2 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full bg-zinc-950/70 text-sky-200 ring-1 ring-sky-400/50 backdrop-blur-[2px] transition-colors hover:bg-zinc-900/85 hover:text-sky-100 hover:ring-sky-300"
-          >
-            <FolderDown className="h-[55%] w-[55%]" />
-          </span>
-        </span>
-        <span className="mt-1 flex items-center justify-between gap-1">
-          {rename.editing ? (
-            <InlineNameEditor
-              initialValue={displayName}
-              onInput={rename.setDraft}
-              onCommit={rename.commit}
-              onCancel={rename.cancel}
-              className="min-w-0 flex-1 truncate rounded-sm bg-zinc-950/80 px-1 text-[10px] font-semibold text-zinc-100 outline-none ring-1 ring-amber-400/70"
-            />
-          ) : (
-            <span
-              onDoubleClick={(event) => {
-                event.stopPropagation();
-                rename.begin();
-              }}
-              title="Double-click to rename"
-              className="min-w-0 flex-1 cursor-text truncate text-[10px] font-semibold text-zinc-100"
-            >
-              {displayName}
-            </span>
-          )}
-          <span className="flex shrink-0 items-center gap-1 font-mono text-[9px] text-zinc-400">
-            {typeof totalSeconds === "number" && totalSeconds > 0 ? (
-              <span className="text-sky-300/90" title="Total duration of contents">
-                {formatCollectionSeconds(totalSeconds)}
-              </span>
-            ) : null}
-            <span>{count}</span>
-          </span>
-        </span>
-      </span>
-    );
-  }
+  // MEDIA pixels only. Collections don't render through this seam anymore:
+  // their card carries interactive controls (folder drill-in, inline rename),
+  // which cannot legally nest inside NodeCard's <button> — so the registered
+  // ItemShell (GraphItemShell below) routes collections to the composed
+  // CollectionItem-based card instead. This guard is defensive: nothing in
+  // the graph view reaches it with a collection node.
+  if (node.kind === "collection") return null;
 
   const isVideo = node.mediaKind === "video";
   // Frame count follows the card's WIDTH (roughly one ~square frame per card
@@ -416,8 +300,184 @@ const GraphGhost = memo(function GraphGhost({ node, extraCount }: CollectionGhos
   );
 });
 
+/**
+ * The composed collection ITEM, rendered through the package's item-shell
+ * seam instead of NodeCard (review finding 1). This card carries INTERACTIVE
+ * controls — the folder drill-in and the inline rename editor — and inside
+ * NodeCard they had to fake their semantics (`role="button"` span, a
+ * contentEditable "textbox") because real ones can't nest in the card
+ * <button>. Here the CollectionItem primitives keep the package behavior
+ * (drag, selection, keyboard grab, drop indicators, FLIP identity) and the
+ * controls compose as SIBLINGS of the selection surface: a real <button> and
+ * a real <input>, legally.
+ */
+const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
+  dragActivation,
+}: {
+  dragActivation: NodeCardDragActivation;
+}) {
+  const { id, node, childCount, selected, rejected, isDragSource } = useCollectionItemState();
+  const detail = useClipDetail(id as string);
+  // Same source of truth as the tree/breadcrumb, so a rename shows here too.
+  const title = useTimelineTitle(id as string);
+  const rename = useInlineRename(id, title ?? node.name);
+  const nav = useContext(GraphViewNavContext);
+  // Hydrated collections derive their preview frames and total duration from
+  // live children (like the count), so editing a loaded child refreshes this
+  // card without a reload; placeholders fall back to their stored summary.
+  const hydrated = detail?.hydrated === true;
+  const livePreviews = useHydratedCollectionPreviews(id as string, hydrated);
+  const liveSeconds = useHydratedCollectionSeconds(id as string, hydrated);
+
+  const count = hydrated ? childCount : (detail?.itemCount ?? childCount);
+  const totalSeconds = hydrated ? liveSeconds : detail?.duration;
+  // FIRST and LAST only — the card says "a timeline runs from here to
+  // there", which two frames tell and three do not. A single-item
+  // collection has no "last" distinct from its first, so it shows one
+  // frame across the full width rather than the same image twice.
+  const all: readonly CollectionPreviewFrame[] = hydrated
+    ? livePreviews
+    : (detail?.previewItems ?? []);
+  const previews = all.length > 1 ? [all[0], all[all.length - 1]] : all;
+  const displayName = title ?? node.name;
+
+  return (
+    <>
+      {/* Interaction split: the surface (card body) SELECTS — like any clip —
+          and drags; only the folder button below drills in. Selected cards
+          can then be trashed with Delete alongside media. */}
+      <CollectionItem.SelectionSurface
+        dragActivation={dragActivation === "hold" ? "hold" : "body"}
+        className={[
+          "flex h-full w-full flex-col justify-between overflow-hidden rounded-md border border-dashed border-sky-500/40 bg-sky-500/[0.08] p-1.5",
+          selected ? "ring-2 ring-amber-400" : "",
+          rejected ? "ring-2 ring-red-500 motion-safe:animate-pulse" : "",
+          isDragSource ? "opacity-40" : "",
+        ].join(" ")}
+      >
+        <span className="flex min-h-0 flex-1 gap-0.5 overflow-hidden">
+          {previews.length === 0 ? (
+            <span className="flex flex-1 items-center justify-center text-[9px] text-zinc-500">
+              {/* Previews are direct MEDIA children only, so a collection of
+                  nothing but sub-collections has none — that is not "Empty"
+                  (count > 0). Reserve "Empty" for a truly childless collection. */}
+              {!hydrated ? "Open to load" : count === 0 ? "Empty" : "No media preview"}
+            </span>
+          ) : (
+            previews.map((preview, index) => (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                // Positional key: `previews` is a fixed-length, order-stable
+                // first/last pair, and stored clip ids are NOT unique across
+                // positions (the same asset can be both the first and last
+                // preview item), so keying by `preview.id` collides. The slot
+                // is what this is, so key by the slot.
+                key={`${index}-${preview.id}`}
+                src={preview.poster ?? preview.src}
+                alt=""
+                draggable={false}
+                loading="lazy"
+                className="h-full min-w-0 flex-1 rounded-sm object-cover"
+              />
+            ))
+          )}
+        </span>
+        <span className="mt-1 flex items-center justify-between gap-1">
+          <span
+            onDoubleClick={(event) => {
+              event.stopPropagation();
+              rename.begin();
+            }}
+            title="Double-click to rename"
+            className="min-w-0 flex-1 cursor-text truncate text-[10px] font-semibold text-zinc-100"
+          >
+            {displayName}
+          </span>
+          <span className="flex shrink-0 items-center gap-1 font-mono text-[9px] text-zinc-400">
+            {typeof totalSeconds === "number" && totalSeconds > 0 ? (
+              <span className="text-sky-300/90" title="Total duration of contents">
+                {formatCollectionSeconds(totalSeconds)}
+              </span>
+            ) : null}
+            <span>{count}</span>
+          </span>
+        </span>
+      </CollectionItem.SelectionSurface>
+
+      {/* The drill affordance — a REAL button now that it composes as a
+          SIBLING of the selection surface. Centred over the preview area (the
+          card minus its label row), sized as a fraction of the card so it
+          stays prominent at every item size. Pointer-only by design:
+          tabIndex -1 keeps roving views at one tab stop per item, and
+          keyboard drill-in stays on the O key (OpenKeyBoundary). The
+          stopPropagation keeps a press from starting a strip pan. */}
+      <button
+        type="button"
+        tabIndex={-1}
+        aria-label={`Open ${displayName}`}
+        title="Open this timeline"
+        data-collections-keyboard-ignore
+        onPointerDown={(event) => event.stopPropagation()}
+        onClick={(event) => {
+          event.stopPropagation();
+          nav?.openTimeline(id);
+        }}
+        className="absolute left-1/2 top-[41%] flex aspect-square h-[34%] -translate-x-1/2 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full bg-zinc-950/70 text-sky-200 ring-1 ring-sky-400/50 backdrop-blur-[2px] transition-colors hover:bg-zinc-900/85 hover:text-sky-100 hover:ring-sky-300"
+      >
+        <FolderDown className="h-[55%] w-[55%]" />
+      </button>
+
+      {/* The rename editor — a REAL input, overlaying the label row while
+          editing. A sibling of the surface, so it nests in no button. */}
+      {rename.editing && (
+        <InlineNameEditor
+          initialValue={displayName}
+          onInput={rename.setDraft}
+          onCommit={rename.commit}
+          onCancel={rename.cancel}
+          className="absolute inset-x-1.5 bottom-1.5 z-20 rounded-sm bg-zinc-950/95 px-1 py-0.5 text-[10px] font-semibold text-zinc-100 outline-none ring-1 ring-amber-400/70"
+        />
+      )}
+
+      <CollectionItem.DropIndicators />
+    </>
+  );
+});
+
+const GraphCollectionItem = memo(function GraphCollectionItem({
+  id,
+  className,
+  dragActivation = "body",
+  rovingTabIndex,
+}: CollectionItemShellProps) {
+  return (
+    <CollectionItem.Root
+      id={id}
+      rovingTabIndex={rovingTabIndex}
+      className={["h-full w-full", className ?? ""].join(" ")}
+    >
+      <GraphCollectionItemParts dragActivation={dragActivation} />
+    </CollectionItem.Root>
+  );
+});
+
+/**
+ * The graph's per-item renderer (registered as the provider `ItemShell`):
+ * media keeps the stock NodeCard shell (its content is presentational, so the
+ * single-button card is exactly right); collections get the composed card
+ * above. The kind subscription is a primitive, so the dispatcher re-renders
+ * only if a node changes kind — which never happens after creation.
+ */
+const GraphItemShell = memo(function GraphItemShell(props: CollectionItemShellProps) {
+  const isCollection = useCollectionsSelector(
+    (s) => s.graph.nodesById.get(props.id)?.kind === "collection",
+  );
+  return isCollection ? <GraphCollectionItem {...props} /> : <NodeCard {...props} />;
+});
+
 export const GRAPH_VIEW_COMPONENTS: CollectionsComponents = {
   ItemContent: GraphClipContent,
+  ItemShell: GraphItemShell,
   TrimHandleContent: GraphTrimHandle,
   GhostContent: GraphGhost,
 };

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -17,7 +17,7 @@ import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 
 import { useClipDetail, useGraphDetailsStore, useTimelineTitle } from "./graph-details-context";
 import { hydrateTimeline } from "./graph-hydration";
-import { useInlineRename } from "./graph-inline-rename";
+import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
 import { NativeDropGrid, NativeDropStrip } from "./graph-native-drop";
 import {
   subTimelineRowStatus,
@@ -177,16 +177,11 @@ function SubTimelineNode({
           )}
         </button>
         {rename.editing ? (
-          <input
-            aria-label="Timeline name"
-            value={rename.draft}
-            autoFocus
-            onChange={(event) => rename.setDraft(event.target.value)}
-            onBlur={rename.commit}
-            onKeyDown={(event) => {
-              if (event.key === "Enter") rename.commit();
-              else if (event.key === "Escape") rename.cancel();
-            }}
+          <InlineNameEditor
+            initialValue={name}
+            onInput={rename.setDraft}
+            onCommit={rename.commit}
+            onCancel={rename.cancel}
             className="min-w-0 flex-1 rounded border border-sky-500/60 bg-zinc-900 px-1.5 py-0.5 text-sm font-semibold text-zinc-100 outline-none"
           />
         ) : (

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -625,14 +625,88 @@ test.describe("graph view E2E", () => {
       .toBe("Heist Plan");
   });
 
+  test("composed collection card: interactive controls are siblings of the surface, never nested", async ({
+    page,
+  }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    const surface = strip(page, PROJECT_ID).locator(`[data-node-id="${CHILD_ID}"]`);
+    const wrapper = strip(page, PROJECT_ID).locator(`[data-node-wrapper="${CHILD_ID}"]`);
+    await surface.waitFor({ state: "visible" });
+
+    // The selection surface is a real <button> with NO interactive content
+    // inside it — nested interactive semantics are invalid HTML and read as
+    // an ambiguous a11y tree (review finding 1). The folder control and the
+    // rename editor compose as SIBLINGS via the package's item-shell seam.
+    await expect(surface).toHaveJSProperty("tagName", "BUTTON");
+    await expect(
+      surface.locator("button, [role='button'], input, textarea, select, a[href], [tabindex]"),
+    ).toHaveCount(0);
+
+    // The drill affordance is a REAL button (not a role="button" span).
+    const folder = wrapper.getByRole("button", { name: /^Open / });
+    await expect(folder).toHaveJSProperty("tagName", "BUTTON");
+
+    // The rename editor is a REAL input, and it never lands inside the surface.
+    await surface.getByText("Scene A", { exact: true }).dblclick();
+    const editor = wrapper.getByRole("textbox", { name: "Timeline name" });
+    await expect(editor).toHaveJSProperty("tagName", "INPUT");
+    await expect(surface.locator("input")).toHaveCount(0);
+    await editor.press("Escape");
+    await expect(editor).toHaveCount(0);
+  });
+
+  test("a collection card hold-drags to reorder, like any clip", async ({ page }) => {
+    // The composed collection item routes its pointer drag through the
+    // selection surface (SelectionSurface dragActivation="hold") instead of
+    // NodeCard's body — this pins that the hold sensor wiring survived the
+    // recomposition end to end, persistence included. Press the LABEL strip
+    // at the bottom of the card, not the centre: the centre is the folder
+    // button, which is click-only territory (its press has never been able
+    // to start a card drag) — the body around it is what drags.
+    const api = await installGraphApi(page);
+    await openGraph(page);
+    const projectStrip = strip(page, PROJECT_ID);
+    const card = projectStrip.locator(`[data-node-id="${CHILD_ID}"]`);
+    const target = projectStrip.locator('[data-node-id="charlie"]');
+    await card.waitFor({ state: "visible" });
+    await settleMoveAnimations(page);
+    const cardBox = (await card.boundingBox())!;
+    const targetBox = (await target.boundingBox())!;
+
+    await page.mouse.move(cardBox.x + cardBox.width / 2, cardBox.y + cardBox.height - 8);
+    await page.mouse.down();
+    await page.waitForTimeout(400); // past the hold-activation delay
+    // Drop on charlie's right half: the collection lands after it.
+    await page.mouse.move(
+      targetBox.x + targetBox.width * 0.85,
+      targetBox.y + targetBox.height / 2,
+      { steps: 12 },
+    );
+    await page.waitForTimeout(150); // dwell: let collision/intent settle
+    await page.mouse.up();
+    await page.waitForTimeout(80); // outlast dnd-kit's click suppressor
+
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID))
+      .toEqual(["alpha", "bravo", "charlie", CHILD_ID]);
+    await expect
+      .poll(() => api.patchesFor(PROJECT_ID).length, { timeout: 5000 })
+      .toBeGreaterThan(0);
+    const patch = api.patchesFor(PROJECT_ID).at(-1);
+    expect(patch?.clipIds).toEqual(["alpha", "bravo", "charlie", "clip-scene"]);
+  });
+
   test("renaming the focused BREADCRUMB crumb in place persists the collection title", async ({
     page,
   }) => {
     const api = await installGraphApi(page);
     await openGraph(page);
     // Drill into the child collection so it is the focused (current) crumb.
+    // The folder button is a SIBLING of the card's selection surface (a real
+    // <button> can't nest in a button), so scope at the item wrapper.
     await strip(page, PROJECT_ID)
-      .locator(`[data-node-id="${CHILD_ID}"]`)
+      .locator(`[data-node-wrapper="${CHILD_ID}"]`)
       .getByRole("button", { name: "Open Scene A" })
       .click();
     const trail = page.getByRole("navigation", { name: "Timeline focus path" });
@@ -1127,7 +1201,7 @@ test.describe("graph view E2E", () => {
     // park at "long-timeline-time / short-timeline-duration". The collection
     // card's folder button drills (the interaction model's pointer path).
     await strip(page, PROJECT_ID)
-      .locator(`[data-node-id="${CHILD_ID}"]`)
+      .locator(`[data-node-wrapper="${CHILD_ID}"]`)
       .getByRole("button", { name: /^Open / })
       .click();
     await page.waitForURL(`**${GRAPH_URL}/${CHILD_ID}`);
@@ -1337,9 +1411,14 @@ test.describe("graph view E2E", () => {
     }).toPass({ timeout: 10000 });
     await expect(page).toHaveURL(new RegExp(`${GRAPH_URL}$`));
 
-    // The folder button is the pointer twin of O: it DRILLS IN.
+    // The folder button is the pointer twin of O: it DRILLS IN. It is a real
+    // <button> SIBLING of the selection surface (nesting one in the card
+    // button would be invalid HTML), so find it via the item wrapper.
+    const collectionWrapper = strip(page, PROJECT_ID).locator(
+      `[data-node-wrapper="${CHILD_ID}"]`,
+    );
     await expect(async () => {
-      await collectionCard.getByRole("button", { name: /^Open / }).click();
+      await collectionWrapper.getByRole("button", { name: /^Open / }).click();
       await page.waitForURL(`**${GRAPH_URL}/${CHILD_ID}`, { timeout: 3000 });
     }).toPass({ timeout: 15000 });
     await expect.poll(() => stripOrder(page, CHILD_ID)).toEqual(["c1", "c2"]);

--- a/packages/ui/dnd-collections/API.md
+++ b/packages/ui/dnd-collections/API.md
@@ -804,13 +804,35 @@ type CollectionTrimOverviewContentProps = Readonly<{
 }>;
 type CollectionTrimOverviewContentComponent = ComponentType<CollectionTrimOverviewContentProps>;
 
+type CollectionItemShellProps = Readonly<{
+  id: NodeId;
+  className?: string;                      // slot sizing — virtual views pass "h-full w-full"
+  dragActivation?: NodeCardDragActivation;
+  rovingTabIndex?: number;
+  trimPixelsPerSecond?: number;
+  itemContent?: CollectionItemContentComponent;
+}>;
+type CollectionItemShellComponent = ComponentType<CollectionItemShellProps>;
+
 type CollectionsComponents = Readonly<{
   ItemContent?: CollectionItemContentComponent;  // every card, all views
+  ItemShell?: CollectionItemShellComponent;      // the whole per-item renderer in the VIRTUAL views (default NodeCard)
   GhostContent?: CollectionGhostContentComponent; // the drag-overlay ghost
   TrimHandleContent?: CollectionTrimHandleContentComponent; // pixels INSIDE the trim hit zones
   OverviewContent?: CollectionTrimOverviewContentComponent; // the overview's filmstrip/label pixels
 }>;
 ```
+
+**The item SHELL** is the seam one level up from `ItemContent`: where
+`ItemContent` swaps the pixels inside NodeCard's `<button>`, an `ItemShell`
+replaces NodeCard itself in the virtual views (`VirtualStrip`/`VirtualGrid`;
+panels keep NodeCard). Its props are exactly NodeCard's, so NodeCard is the
+default and a custom shell can fall back to it per node. This is the only
+way to put LEGALLY interactive controls (a real `<button>`, an `<input>`) on
+a card: compose them with the `CollectionItem` primitives as SIBLINGS of
+`CollectionItem.SelectionSurface` instead of nesting them inside a button
+(see "Compound items" below). Resolution: per-view `itemShell` → provider
+registry → `NodeCard`.
 
 **The source-window overview** splits the same way: `OverviewContent`
 replaces its BACKGROUND pixels (the full-source filmstrip and labels —
@@ -854,8 +876,9 @@ Rules, all load-bearing for the efficiency model:
   stable.
 - **Presentational only**: content renders inside a `<button>` — no
   interactive elements (buttons, links, inputs). Interactivity (selection,
-  drag, trim) is the shell's job; compound primitives for custom interactive
-  placement are a planned escape hatch.
+  drag, trim) is the shell's job; an item that genuinely needs its own
+  interactive controls renders through the `ItemShell` seam and composes
+  them with the compound primitives as siblings of the selection surface.
 - Nothing per-frame ever reaches content: every prop is a rarely-changing
   primitive plus the structurally-shared `node`. Content may subscribe to
   its own stores — that re-renders only the subscribed content, never the
@@ -882,7 +905,7 @@ every pixel AND the DOM shape:
 | Primitive | Owns |
 | --- | --- |
 | `Root` | `id`, `className?`, `trimPixelsPerSecond?`, `rovingTabIndex?`. The draggable node AND droppable (ghost/collision rects = the whole item), the narrow selector subscriptions (same as NodeCard — the efficiency story holds), `data-node-wrapper`/`data-render-count`. Renders null for missing ids. |
-| `SelectionSurface` | The focusable `<button>`: `data-node-id` (FLIP, keyboard delegation, roving focus, and e2e key off it), selection clicks (Ctrl/Cmd toggles), `aria-label`/`aria-pressed`/instructions `describedby`, and the KEYBOARD grab (Enter) — always the tab stop. |
+| `SelectionSurface` | The focusable `<button>`: `data-node-id` (FLIP, keyboard delegation, roving focus, and e2e key off it), selection clicks (Ctrl/Cmd toggles), `aria-label`/`aria-pressed`/instructions `describedby`, and the KEYBOARD grab (Enter) — always the tab stop. `dragActivation?: "none" \| "body" \| "hold"` (default "none") opts the surface in as the POINTER drag activator too — "body" drags instantly, "hold" is press-and-hold with fast movement handed to surface gestures — for items that want NodeCard's whole-body drag without a grip. |
 | `DragHandle` | Pointer-only drag activator (`data-drag-handle`, `touch-action: none`, aria-hidden) — place it anywhere; keyboard drag stays on the SelectionSurface. |
 | `TrimHandle` | `side: "left" \| "right"` + your grip pixels as children. The hit zone (default edge geometry, override via `className`), the pointer gesture, `data-trim-handle` (the strip's pan filter skips it). Renders null for collections, images' left side, or without `Root trimPixelsPerSecond`. |
 | `DropIndicators` | The stock nest overlay + before/after bars. Or draw your own from `useCollectionItemState()` (`{ id, node, childCount, selected, rejected, isDragSource, dropSide, nestState }`). |
@@ -968,6 +991,7 @@ type VirtualStripProps = {
   itemDragActivation?: "handle" | "hold";                // default "handle" (grip bar); "hold" = press-and-hold the body. Ignored when panToScroll is off (bodies drag instantly)
   trimPixelsPerSecond?: number;                          // override the trim conversion; DEFAULTS to pixelsPerSecond. Handles render when either is set; commits update-media on release. LIVE resize follows the strip's OWN width resolution (a synthesized node with the live trims runs through itemWidthFor/pixelsPerSecond) — so consumer floors hold mid-drag, and a fixed-width strip's card keeps its width (data trims, geometry doesn't)
   itemContent?: CollectionItemContentComponent;          // per-view card pixels; overrides the provider registry
+  itemShell?: CollectionItemShellComponent;              // per-view ITEM renderer (default NodeCard; registry ItemShell in between) — see "Custom item content"
   overlay?: ReactNode;                                   // STRICTLY PRESENTATIONAL content-coordinate layer over the strip (playhead, markers): rides scroll + live-trim transform. aria-hidden + pointer-events none — no interactive/focusable children (focusable-inside-aria-hidden is an a11y violation); interactive scrubbers belong in your own layer outside the strip
   className?: string;
 };
@@ -1043,6 +1067,7 @@ type VirtualGridProps = {
   overscan?: number;    // default 2 (rows)
   height?: number;      // default 480 — MAXIMUM viewport height: the grid hugs its content while the rows fit and scrolls past the cap. An empty grid keeps one row's worth of drop area
   itemContent?: CollectionItemContentComponent; // per-view card pixels; overrides the provider registry
+  itemShell?: CollectionItemShellComponent; // per-view ITEM renderer (default NodeCard; registry ItemShell in between) — see "Custom item content"
   overlay?: ReactNode;  // STRICTLY PRESENTATIONAL content-coordinate layer inside the scrolling spacer (playhead, region markers): rides vertical scroll and the drop-spacer height. aria-hidden + pointer-events none — no interactive/focusable children; interactive scrubbers belong in your own layer outside the grid. Position children in content coords: col c → left c*(cellWidth+gap), row r → top r*(cellHeight+gap) — but use the LIVE cellWidth off data-grid-cell-width, not the cellWidth prop (which is only a target, not the rendered size); read the live column count off data-grid-columns
   className?: string;
 };

--- a/packages/ui/dnd-collections/index.ts
+++ b/packages/ui/dnd-collections/index.ts
@@ -132,6 +132,8 @@ export {
   type CollectionGhostContentProps,
   type CollectionItemContentComponent,
   type CollectionItemContentProps,
+  type CollectionItemShellComponent,
+  type CollectionItemShellProps,
   type CollectionTrimHandleContentComponent,
   type CollectionTrimHandleContentProps,
   type CollectionTrimOverviewContentComponent,

--- a/packages/ui/dnd-collections/react/collection-item.tsx
+++ b/packages/ui/dnd-collections/react/collection-item.tsx
@@ -7,6 +7,7 @@ import {
   useContext,
   useMemo,
   useRef,
+  type ButtonHTMLAttributes,
   type KeyboardEventHandler,
   type MouseEvent,
   type PointerEventHandler,
@@ -246,13 +247,34 @@ const Root = memo(function CollectionItemRoot({
 const SelectionSurface = memo(function CollectionItemSelectionSurface({
   children,
   className,
+  dragActivation = "none",
 }: {
   children?: ReactNode;
   className?: string;
+  /**
+   * Opt the surface itself in as the POINTER drag activator: "body" drags
+   * instantly from anywhere on it, "hold" requires the press-and-hold (fast
+   * movement is handed to surface gestures like strip panning) — the same
+   * modes NodeCard's body supports, for compound items that want NodeCard's
+   * whole-body drag without a grip. The default "none" keeps DragHandle as
+   * the only pointer path. The keyboard grab (Enter) lives here in EVERY
+   * mode — the surface is the one guaranteed tab stop.
+   */
+  dragActivation?: "none" | "body" | "hold";
 }) {
   const ctx = useCollectionItemContext("SelectionSurface");
   const { instructionsId } = useCollectionsContainer();
   const isCollection = ctx.node.kind === "collection";
+  const bodyDrag = dragActivation !== "none";
+  // Localized cast, same as DragHandle's: dnd-kit types its listener map as
+  // Record<string, Function>; these are the button's synthetic handlers.
+  const dragListeners = bodyDrag
+    ? (ctx.listeners as ButtonHTMLAttributes<HTMLButtonElement> | undefined)
+    : {
+        onKeyDown: ctx.listeners?.onKeyDown as
+          | KeyboardEventHandler<HTMLButtonElement>
+          | undefined,
+      };
   return (
     <button
       type="button"
@@ -261,15 +283,25 @@ const SelectionSurface = memo(function CollectionItemSelectionSurface({
       {...(ctx.selected ? { "data-selected": "true" } : {})}
       {...(ctx.rejected ? { "data-rejected": "true" } : {})}
       aria-label={`${ctx.node.name}${isCollection ? ` (collection, ${ctx.childCount} items)` : ""}`}
-      aria-pressed={ctx.selected}
-      aria-describedby={joinAriaIds(instructionsId)}
       onClick={ctx.select}
-      // The KEYBOARD grab (Enter) always lives on the selection button — the
-      // one guaranteed tab stop — matching NodeCard's grammar. (Localized
-      // cast: dnd-kit types its listener map as Record<string, Function>.)
-      onKeyDown={ctx.listeners?.onKeyDown as KeyboardEventHandler<HTMLButtonElement> | undefined}
+      // The hold sensor picks press-and-hold activation by this marker on
+      // the pressed target's ancestry (see CollectionsPointerSensor).
+      {...(dragActivation === "hold" ? { "data-drag-activation": "hold" } : {})}
+      {...(bodyDrag ? ctx.attributes : {})}
+      {...dragListeners}
+      // After dnd-kit's attribute spread, mirroring NodeCard: the pressed
+      // semantic is SELECTION, and roving tabindex must win over dnd-kit's.
+      aria-pressed={ctx.selected}
+      aria-describedby={joinAriaIds(
+        bodyDrag ? ctx.attributes["aria-describedby"] : undefined,
+        instructionsId
+      )}
       {...(ctx.rovingTabIndex !== undefined ? { tabIndex: ctx.rovingTabIndex } : {})}
-      className={twMerge("select-none text-left", className)}
+      className={twMerge(
+        "select-none text-left",
+        bodyDrag ? "cursor-grab active:cursor-grabbing" : "",
+        className
+      )}
     >
       {children}
     </button>

--- a/packages/ui/dnd-collections/react/collections-components.tsx
+++ b/packages/ui/dnd-collections/react/collections-components.tsx
@@ -67,6 +67,34 @@ export type CollectionItemContentProps = Readonly<{
  */
 export type CollectionItemContentComponent = ComponentType<CollectionItemContentProps>;
 
+/**
+ * What a virtual view passes to whatever renders each item. The default
+ * renderer is `NodeCard` (these are exactly its props), so a custom shell is
+ * drop-in: same id, same slot-filling `className`, same activation/roving/
+ * trim wiring to forward or reinterpret.
+ */
+export type CollectionItemShellProps = Readonly<{
+  id: NodeId;
+  /** Slot sizing from the view — virtual views pass "h-full w-full". */
+  className?: string;
+  dragActivation?: NodeCardDragActivation;
+  rovingTabIndex?: number;
+  trimPixelsPerSecond?: number;
+  itemContent?: CollectionItemContentComponent;
+}>;
+
+/**
+ * A full ITEM renderer for the virtual views — the shell seam one level up
+ * from `itemContent`. `ItemContent` swaps the pixels inside NodeCard's
+ * <button>; an item SHELL replaces NodeCard itself, which is the only way to
+ * put legally interactive controls (a real <button>, an <input>) on a card:
+ * compose them via the `CollectionItem` primitives as SIBLINGS of
+ * `CollectionItem.SelectionSurface` instead of nesting them in a button.
+ * Identity-stable (module scope), like every registry entry. Views that
+ * don't need it keep the NodeCard default.
+ */
+export type CollectionItemShellComponent = ComponentType<CollectionItemShellProps>;
+
 export type CollectionGhostContentProps = Readonly<{
   /** The primary dragged node (pressed card / palette factory result). */
   node: CollectionItemNode;
@@ -120,6 +148,10 @@ export type CollectionsComponents = Readonly<{
   /** Replaces the card pixels everywhere (panels, virtual views). Per-view
    *  `itemContent` props override this registry entry. */
   ItemContent?: CollectionItemContentComponent;
+  /** Replaces the whole item renderer in the VIRTUAL views (NodeCard by
+   *  default) — see CollectionItemShellComponent. Per-view `itemShell`
+   *  props override this registry entry. Panels keep NodeCard. */
+  ItemShell?: CollectionItemShellComponent;
   /** Replaces the drag-overlay ghost pixels. */
   GhostContent?: CollectionGhostContentComponent;
   /** Replaces the pixels INSIDE the trim-handle hit zones. */
@@ -150,15 +182,16 @@ export function useCollectionsComponentsValue(
   components?: CollectionsComponents
 ): CollectionsComponents {
   const ItemContent = components?.ItemContent;
+  const ItemShell = components?.ItemShell;
   const GhostContent = components?.GhostContent;
   const TrimHandleContent = components?.TrimHandleContent;
   const OverviewContent = components?.OverviewContent;
   const value = useMemo<CollectionsComponents>(
     () =>
-      ItemContent || GhostContent || TrimHandleContent || OverviewContent
-        ? { ItemContent, GhostContent, TrimHandleContent, OverviewContent }
+      ItemContent || ItemShell || GhostContent || TrimHandleContent || OverviewContent
+        ? { ItemContent, ItemShell, GhostContent, TrimHandleContent, OverviewContent }
         : EMPTY_COMPONENTS,
-    [ItemContent, GhostContent, TrimHandleContent, OverviewContent]
+    [ItemContent, ItemShell, GhostContent, TrimHandleContent, OverviewContent]
   );
 
   const previousRef = useRef(value);
@@ -173,9 +206,9 @@ export function useCollectionsComponentsValue(
     warnedRef.current = true;
     console.warn(
       "dnd-collections: a `components` entry changed identity between renders. " +
-        "Define ItemContent/GhostContent/TrimHandleContent/OverviewContent at module " +
-        "scope — a new component type per render remounts every card's content and " +
-        "defeats memoization."
+        "Define ItemContent/ItemShell/GhostContent/TrimHandleContent/OverviewContent " +
+        "at module scope — a new component type per render remounts every card's " +
+        "content and defeats memoization."
     );
   }, [value]);
 

--- a/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
@@ -19,7 +19,9 @@ import {
   positiveIntegerOrUndefined,
 } from "../core/numeric";
 import {
+  useCollectionsComponents,
   type CollectionItemContentComponent,
+  type CollectionItemShellComponent,
   type NodeCardDragActivation,
 } from "../react/collections-components";
 import { useCollectionsSelector, useCollectionsStore } from "../react/collections-store";
@@ -40,7 +42,8 @@ import {
 // WIDTH stretches to fill the container exactly (see `cellWidth` doc) — only
 // height is a fixed constant, so media letterboxes at a width:height ratio
 // that varies slightly with container width, by design (2026-07-19).
-// Cards are the standard NodeCard; the droppable contract is the same
+// Cards render through the item-shell resolution (per-view `itemShell` →
+// registry `ItemShell` → NodeCard); the droppable contract is the same
 // virtualInsert used by VirtualStrip, with 2D boundary math. NOTE: cards
 // moving BETWEEN rows re-parent (rows are keyed by index), so cross-row
 // moves recreate the card's DOM element — FLIP and held focus don't
@@ -67,6 +70,12 @@ export type VirtualGridProps = Readonly<{
   /** Per-view card pixels — overrides the provider `components` registry.
    *  MUST be identity-stable (module scope). */
   itemContent?: CollectionItemContentComponent;
+  /**
+   * Per-view item SHELL — replaces the whole per-cell renderer (NodeCard by
+   * default; registry `ItemShell` sits between). See VirtualStrip's prop of
+   * the same name. MUST be identity-stable (module scope).
+   */
+  itemShell?: CollectionItemShellComponent;
   /**
    * How a cell drag starts. Default "body" — the card body drags instantly,
    * which makes a plain click ambiguous with a drag (a press that nudges is a
@@ -99,12 +108,16 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
       overscan: overscanOption,
       height: heightOption,
       itemContent,
+      itemShell,
       itemDragActivation = "body",
       overlay,
       className,
     },
     ref
   ) {
+    // The per-cell renderer: per-view override → provider registry → NodeCard.
+    const registeredShell = useCollectionsComponents().ItemShell;
+    const ItemShell: CollectionItemShellComponent = itemShell ?? registeredShell ?? NodeCard;
     const cellWidth = finitePositiveOr(cellWidthOption, 128);
     const cellHeight = finitePositiveOr(cellHeightOption, 96);
     const gap = finiteNonNegativeOr(gapOption, 8);
@@ -392,7 +405,7 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
                       onFocus={() => onItemFocus(id)}
                       style={{ width: fillCellWidth, height: cellHeight }}
                     >
-                      <NodeCard
+                      <ItemShell
                         id={id}
                         className="h-full w-full"
                         rovingTabIndex={absoluteIndex === rovingIndex ? 0 : -1}

--- a/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
@@ -27,7 +27,11 @@ import {
   finitePositiveOrUndefined,
   nonNegativeIntegerOr,
 } from "../core/numeric";
-import { type CollectionItemContentComponent } from "../react/collections-components";
+import {
+  useCollectionsComponents,
+  type CollectionItemContentComponent,
+  type CollectionItemShellComponent,
+} from "../react/collections-components";
 import { useCollectionsSelector, useCollectionsStore } from "../react/collections-store";
 import { findNodeElement } from "../react/node-dom";
 import { NodeCard, type NodeCardDragActivation } from "../react/node-views";
@@ -72,7 +76,8 @@ function resolveStripIndex(key: string, current: number, count: number): number 
 }
 
 // Horizontal virtualized strip: renders only visible cards + overscan out
-// of arbitrarily large collections. Cards ARE the standard NodeCard —
+// of arbitrarily large collections. Cards render through the item-shell
+// resolution (per-view `itemShell` → registry `ItemShell` → NodeCard) —
 // virtualization changes WHICH ids mount, never how a card works — so
 // selection, drag-source dimming, and store subscriptions come along
 // unchanged. DnD over gaps and unmounted regions resolves through the
@@ -145,6 +150,14 @@ export type VirtualStripProps = Readonly<{
    *  MUST be identity-stable (module scope). */
   itemContent?: CollectionItemContentComponent;
   /**
+   * Per-view item SHELL — replaces the whole per-item renderer (NodeCard by
+   * default; registry `ItemShell` sits between). The seam for items that
+   * need legally interactive controls: compose them with the CollectionItem
+   * primitives as SIBLINGS of the selection surface. MUST be identity-stable
+   * (module scope). Receives exactly NodeCard's props.
+   */
+  itemShell?: CollectionItemShellComponent;
+  /**
    * STRICTLY PRESENTATIONAL content rendered in CONTENT coordinates over the
    * whole strip (inside an `aria-hidden`, `pointer-events: none` layer above
    * the cards), so it rides scrolling, auto-scroll, and the live-trim
@@ -182,6 +195,7 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
       itemDragActivation = "handle",
       trimPixelsPerSecond: trimPixelsPerSecondOption,
       itemContent,
+      itemShell,
       overlay,
       className,
     },
@@ -198,6 +212,9 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
       finitePositiveOrUndefined(trimPixelsPerSecondOption) ?? pixelsPerSecond;
     const store = useCollectionsStore();
     const cardActivation: NodeCardDragActivation = panToScroll ? itemDragActivation : "body";
+    // The per-item renderer: per-view override → provider registry → NodeCard.
+    const registeredShell = useCollectionsComponents().ItemShell;
+    const ItemShell: CollectionItemShellComponent = itemShell ?? registeredShell ?? NodeCard;
 
     // Stable array reference between commits — the virtualizer's item keys
     // and index math stay coherent across drags for free.
@@ -810,10 +827,10 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
                     transform: `translateX(${item.start}px)`,
                   }}
                 >
-                  {/* Explicit sizing: the card fills its (possibly variable) slot.
+                  {/* Explicit sizing: the item fills its (possibly variable) slot.
                       With panToScroll, item drags move to the grip bar or behind
                       a press-and-hold so the body is free to pan the strip. */}
-                  <NodeCard
+                  <ItemShell
                     id={childIds[item.index]}
                     className="h-full w-full"
                     dragActivation={cardActivation}


### PR DESCRIPTION
The full fix for review finding 1: interactive controls were nested inside the card's `<button>` — the folder drill-in as a `role="button"` span and the rename editor as a `contentEditable` "textbox" — because the virtual views hardcoded `NodeCard` and the compound-primitive escape hatch was unreachable from them.

## Package: a typed item-shell seam
- **`CollectionItemShellComponent`** — a full per-item renderer whose props are exactly `NodeCard`'s. Registered on the provider `components` registry as `ItemShell`, or per view via `itemShell`; `VirtualStrip`/`VirtualGrid` resolve per-view → registry → `NodeCard`, so every existing consumer is byte-for-byte unchanged.
- **`CollectionItem.SelectionSurface`** gains `dragActivation?: "none" | "body" | "hold"` so a compound item can carry NodeCard's whole-body pointer drag (hold marker + dnd-kit listeners on the surface) instead of requiring a grip bar.
- Exports through the curated index; API.md documents the seam and retires the stale "compound primitives are a planned escape hatch" note.

## App: the composed collection card
`GraphItemShell` (registered `ItemShell`) routes media to `NodeCard` unchanged and collections to a composed `CollectionItem` card where the folder drill-in is a **real `<button>`** and the rename editor is a **real `<input>`**, both **siblings** of the selection surface — zero nested interactive semantics. `InlineNameEditor` is now a native input (contentEditable dropped entirely), shared by the card, the breadcrumb, and the sub-timeline row.

## Coverage
- New `ComposedCardStructure` story: the surface button has zero interactive descendants, folder/editor live outside it, and committing a rename updates the surface's accessible name (the reviewer's requested composed-card a11y test).
- New e2e ×2: the same structural assertions in the real app, and a collection-card **hold-drag reorder** pinning the surface's drag wiring end to end (pressing the label strip — the card centre is the folder, which is click-only territory exactly as it was before).
- Three folder-button e2e locators re-scoped to `[data-node-wrapper]`, matching how trim handles are already located.

## Verification
Full graph-view e2e **38/38**; package stories 79 (DndCollections/VirtualStrip/VirtualGrid) + app stories 4; unit 515; app vitest 187; package + app typecheck and lint clean. Live-app DOM check confirms: surface `BUTTON` with 0 interactive descendants, folder `BUTTON` outside it, hold marker present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)