### PR TITLE
Graph ruler tick windowing + filmstrip resample settling (P3)

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useContext } from "react";
+import { useContext, useDeferredValue } from "react";
 import {
   EllipsisVertical,
   FolderTree,
@@ -268,6 +268,15 @@ export function GraphBoard({
   syncEntries: readonly SyncEntry[];
 }>) {
   const dims = ITEM_SIZE_DIMENSIONS[itemSize];
+  // Zoom splits urgency (round-4 polish item 8): the slider thumb must track
+  // the pointer, so its value stays URGENT — while the expensive work a zoom
+  // step triggers (strip relayout, ruler rebuild, per-card resize fan-out)
+  // renders at this DEFERRED value, interruptible by the next slider step.
+  // (Not startTransition on the onChange: that would defer the controlled
+  // thumb itself, making the handle lag the pointer.) Every time→x consumer
+  // below — strip, ruler, playheads, scrub bands, sub-rows — shares this ONE
+  // deferred value, so their geometry can never disagree mid-drag.
+  const deferredPixelsPerSecond = useDeferredValue(pixelsPerSecond);
 
   return (
     <OpenKeyBoundary trashId={trashRootId}>
@@ -366,21 +375,24 @@ export function GraphBoard({
             <NativeDropStrip collectionId={focusedId}>
               <VirtualStrip
                 collectionId={parseNodeId(focusedId)}
-                pixelsPerSecond={pixelsPerSecond}
-                itemWidth={collectionCardWidth(pixelsPerSecond)}
+                pixelsPerSecond={deferredPixelsPerSecond}
+                itemWidth={collectionCardWidth(deferredPixelsPerSecond)}
                 itemHeight={dims.strip}
                 itemDragActivation="hold"
                 overlay={
                   previewOn || rulerOn ? (
                     <>
                       {rulerOn ? (
-                        <GraphRuler focusedId={focusedId} pixelsPerSecond={pixelsPerSecond} />
+                        <GraphRuler
+                          focusedId={focusedId}
+                          pixelsPerSecond={deferredPixelsPerSecond}
+                        />
                       ) : null}
                       {previewOn ? (
                         <GraphPlayhead
                           focusedId={focusedId}
                           channel={timeChannel}
-                          pixelsPerSecond={pixelsPerSecond}
+                          pixelsPerSecond={deferredPixelsPerSecond}
                         />
                       ) : null}
                     </>
@@ -392,7 +404,7 @@ export function GraphBoard({
                 <PlayheadScrubBand
                   focusedId={focusedId}
                   channel={timeChannel}
-                  pixelsPerSecond={pixelsPerSecond}
+                  pixelsPerSecond={deferredPixelsPerSecond}
                 />
               )}
             </NativeDropStrip>
@@ -418,7 +430,7 @@ export function GraphBoard({
                         focusedId={focusedId}
                         channel={timeChannel}
                         cellHeight={dims.gridHeight}
-                        pixelsPerSecond={pixelsPerSecond}
+                        pixelsPerSecond={deferredPixelsPerSecond}
                       />
                     ) : undefined
                   }
@@ -429,7 +441,7 @@ export function GraphBoard({
                     focusedId={focusedId}
                     channel={timeChannel}
                     cellHeight={dims.gridHeight}
-                    pixelsPerSecond={pixelsPerSecond}
+                    pixelsPerSecond={deferredPixelsPerSecond}
                   />
                 )}
               </div>
@@ -445,7 +457,7 @@ export function GraphBoard({
               focusedId={focusedId}
               surface={surface}
               itemSize={stepDownItemSize(itemSize)}
-              pixelsPerSecond={pixelsPerSecond}
+              pixelsPerSecond={deferredPixelsPerSecond}
               previewOn={previewOn}
               rulerOn={rulerOn}
               timeChannel={timeChannel}

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { Decorator, Meta, StoryObj } from "@storybook/react";
 import { expect, userEvent, waitFor } from "storybook/test";
 
@@ -209,5 +210,80 @@ export const ComposedCardStructure: Story = {
     await waitFor(() =>
       expect(surface!.getAttribute("aria-label")).toMatch(/^Renamed timeline \(collection/),
     );
+  },
+};
+
+// ── Filmstrip resample settling (P3) ────────────────────────────────────────
+
+const VIDEO_ID = "vid-1" as NodeId;
+
+const videoGraph = (() => {
+  const result = buildGraph([
+    {
+      kind: "collection",
+      id: "root-video",
+      name: "Root",
+      children: [
+        {
+          kind: "media",
+          id: VIDEO_ID as string,
+          mediaKind: "video",
+          name: "A video",
+          src: poster("V", "#334155"),
+          posterSrcs: [poster("V", "#334155")],
+          fullDurationSeconds: 8,
+        },
+      ],
+    },
+  ]);
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.value;
+})();
+
+/** A VIDEO card at a controllable size. Media routes through NodeCard, which
+ *  reads its pixels from the provider `components` registry — so this
+ *  renders the registered GraphClipContent, filmstrip and all. */
+function FilmstripSettleHarness() {
+  const [store] = useState(() => createGraphDetailsStore({}));
+  return (
+    <DndCollections initialGraph={videoGraph} components={GRAPH_VIEW_COMPONENTS}>
+      <GraphDetailsProvider store={store}>
+        <div data-resize-host style={{ width: 192, height: 96 }}>
+          <ItemShell id={VIDEO_ID} className="h-full w-full" />
+        </div>
+      </GraphDetailsProvider>
+    </DndCollections>
+  );
+}
+
+/**
+ * The filmstrip's frame count SETTLES instead of chasing every size change
+ * (P3): a zoom drag sweeps a card's width→count ratio through several
+ * integers, and adopting each crossing re-timed every frame slot — swapping
+ * every `<img>` src per crossing, per video card. The first measurement
+ * adopts immediately (a virtualization remount must not show a blank card),
+ * but a CHANGED measurement must hold for the settle delay before one
+ * resample lands on the final count.
+ */
+export const FilmstripResampleSettles: Story = {
+  args: { id: VIDEO_ID, className: "h-full w-full" },
+  render: () => <FilmstripSettleHarness />,
+  play: async ({ canvasElement }) => {
+    const host = canvasElement.querySelector<HTMLElement>("[data-resize-host]")!;
+    // First measurement adopts immediately: 192×96 → 2 frames.
+    await waitFor(() => expect(previewImages(canvasElement)).toHaveLength(2));
+
+    // Grow the card as a zoom drag would. The filmstrip must NOT adopt the
+    // new count as soon as the resize lands (80ms is plenty for the
+    // ResizeObserver + re-render, and well inside the settle delay)…
+    host.style.width = "480px";
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(previewImages(canvasElement).length).toBeLessThan(5);
+
+    // …and once the size holds still past the delay, ONE resample lands on
+    // the final count (480 / 96 = 5 frames).
+    await waitFor(() => expect(previewImages(canvasElement)).toHaveLength(5), {
+      timeout: 2000,
+    });
   },
 };

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useCallback, useContext, useRef, useState, useSyncExternalStore } from "react";
+import { memo, useCallback, useContext, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { FolderDown, Image as ImageIcon, Video } from "lucide-react";
 
 import {
@@ -65,6 +65,40 @@ function useElementSize(): [(element: HTMLElement | null) => void, { width: numb
     observerRef.current = observer;
   }, []);
   return [ref, size];
+}
+
+/**
+ * How long a CHANGED frame-count measurement must hold before the filmstrip
+ * re-samples. A continuous px/s drag sweeps a card's width→count ratio
+ * through several integers, and adopting each crossing re-times every frame
+ * slot — swapping every `<img>` src on the card (a fresh CDN URL per slot)
+ * several times per drag, per video card. Generous on purpose: the drag's
+ * layout already tracks live (widths are CSS), only the frame REFINEMENT
+ * waits for the size to hold still.
+ */
+const FRAME_COUNT_SETTLE_MS = 400;
+
+/**
+ * The measured frame count, SETTLED: the first real measurement is adopted
+ * immediately — a freshly (re)mounted card, virtualization remounts included,
+ * must not wait out the delay to show its filmstrip — while later changes
+ * must hold for FRAME_COUNT_SETTLE_MS before they re-sample. The first
+ * adoption happens during render (the repo's cascading-render-safe pattern;
+ * a synchronous setState in the effect would trip the lint), so this pass
+ * already returns the measured value; changes adopt from the timer, which is
+ * async by nature.
+ */
+function useSettledFrameCount(measured: number): number {
+  const [settled, setSettled] = useState(measured);
+  if (settled === 0 && measured !== 0) setSettled(measured);
+  useEffect(() => {
+    // settled === 0 means the render-time first adoption is already in
+    // flight — nothing to debounce yet.
+    if (measured === settled || settled === 0) return;
+    const timer = setTimeout(() => setSettled(measured), FRAME_COUNT_SETTLE_MS);
+    return () => clearTimeout(timer);
+  }, [measured, settled]);
+  return settled === 0 ? measured : settled;
 }
 
 const NO_PREVIEWS: readonly CollectionPreviewFrame[] = [];
@@ -180,8 +214,15 @@ const GraphClipContent = memo(function GraphClipContent({
   isDragSource,
   trimEnabled,
 }: CollectionItemContentProps) {
-  // Card geometry for the video filmstrip's frame count.
+  // Card geometry for the video filmstrip's frame count. Frame count follows
+  // the card's WIDTH (roughly one ~square frame per card height), SETTLED so
+  // a continuous zoom drag doesn't re-sample the whole filmstrip at every
+  // integer-ratio crossing — computed above the early return because the
+  // settle hook must run unconditionally.
   const [cardSizeRef, cardSize] = useElementSize();
+  const measuredFrames =
+    cardSize.height > 0 ? Math.round(cardSize.width / cardSize.height) : 0;
+  const settledFrames = useSettledFrameCount(measuredFrames);
 
   // MEDIA pixels only. Collections don't render through this seam anymore:
   // their card carries interactive controls (folder drill-in, inline rename),
@@ -192,15 +233,12 @@ const GraphClipContent = memo(function GraphClipContent({
   if (node.kind === "collection") return null;
 
   const isVideo = node.mediaKind === "video";
-  // Frame count follows the card's WIDTH (roughly one ~square frame per card
-  // height), so a wider clip shows MORE distinct frames rather than the same
-  // still tiled — falling back to a duration-based count until first measured.
-  const measuredFrames =
-    cardSize.height > 0 ? Math.round(cardSize.width / cardSize.height) : 0;
+  // A wider clip shows MORE distinct frames rather than the same still tiled
+  // — falling back to a duration-based count until first measured.
   const frames = isVideo
     ? Math.max(
         1,
-        Math.min(measuredFrames || videoFrameCount(mediaDurationSeconds(node), 6), VIDEO_FRAME_CAP),
+        Math.min(settledFrames || videoFrameCount(mediaDurationSeconds(node), 6), VIDEO_FRAME_CAP),
       )
     : 1;
   // Each video frame is sampled at its own time across the visible clip (R6

--- a/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.test.ts
@@ -5,6 +5,7 @@ import type { PlaybackLeaf, PlaybackManifest } from "@storyboard/timeline-domain
 
 import {
   buildPlayheadMap,
+  buildRulerTicks,
   cardSpansOf,
   childSpans,
   manifestTrailsLedger,
@@ -12,8 +13,13 @@ import {
   mediaSpanKey,
   nextManifestClipsState,
   nextManifestFailureCount,
+  rulerMajorSpacing,
+  rulerSubtierCount,
   shouldRetryManifestFetch,
+  STRIP_GAP_PX,
+  type ChildSpan,
   type PreviewCardSpans,
+  type RulerTick,
 } from "./graph-playhead-model";
 
 const media = (id: string, durationSeconds: number): GraphNodeSpec => ({
@@ -249,6 +255,140 @@ describe("nextManifestFailureCount", () => {
   it("leaves an already-reset streak at zero across a reopen", () => {
     expect(nextManifestFailureCount(0, false)).toBe(0);
     expect(nextManifestFailureCount(0, true)).toBe(0);
+  });
+});
+
+describe("buildRulerTicks", () => {
+  const PPS = 40;
+  // At 40 px/s: major = 2s (first nice step ≥ 46/40), all three subtiers
+  // clear the 6px minor gap (2/8 · 40 = 10px), so finest = 0.25s.
+  const MAJOR = rulerMajorSpacing(PPS);
+  const FINEST = MAJOR / 2 ** rulerSubtierCount(MAJOR, PPS);
+
+  /** `count` back-to-back media cards of `seconds` each, laid out at PPS —
+   *  times start at 0 and are gapless, so t maps linearly onto x within a
+   *  card and the fixtures stay hand-checkable. */
+  function mediaCards(count: number, seconds: number): ChildSpan[] {
+    const cards: ChildSpan[] = [];
+    for (let index = 0; index < count; index += 1) {
+      cards.push({
+        startTime: index * seconds,
+        endTime: (index + 1) * seconds,
+        width: seconds * PPS,
+      });
+    }
+    return cards;
+  }
+
+  const noCollections = (cards: readonly ChildSpan[]) => cards.map(() => false);
+  const FULL_WINDOW = { startX: 0, endX: Number.MAX_SAFE_INTEGER };
+  const serialize = (tick: RulerTick) => `${tick.x.toFixed(3)}|${tick.level}|${tick.label}`;
+
+  it("builds the exact tier ladder on a small strip (full window)", () => {
+    const cards = mediaCards(1, 4);
+    const ticks = buildRulerTicks(cards, noCollections(cards), PPS, FULL_WINDOW);
+
+    // 4s at finest 0.25s = 17 ticks, t=n·0.25 at x=t·40.
+    expect(ticks).toHaveLength(17);
+    expect(ticks[0]).toEqual({ x: 0, level: 0, label: "0s" });
+    expect(ticks[8]).toEqual({ x: 80, level: 0, label: "2s" }); // major (2s grid)
+    expect(ticks[4]).toEqual({ x: 40, level: 1, label: "" }); // half-major
+    expect(ticks[2]).toEqual({ x: 20, level: 2, label: "" }); // quarter
+    expect(ticks[1]).toEqual({ x: 10, level: 3, label: "" }); // eighth
+  });
+
+  // The windowing contract: for ANY window, the output is exactly the full
+  // build filtered to that window — plus at most one tick of slack per side
+  // from the floor/ceil index widening. Nothing visible is ever missing.
+  it("windowed output equals the full build filtered to the window", () => {
+    const cards = mediaCards(500, 4); // 2000s ≈ 80,000px of content
+    const flags = noCollections(cards);
+    const windowRange = { startX: 8400, endX: 9424 };
+    const full = buildRulerTicks(cards, flags, PPS, FULL_WINDOW);
+    const windowed = buildRulerTicks(cards, flags, PPS, windowRange);
+
+    // Completeness: every full-build tick inside the window is present.
+    const windowedSet = new Set(windowed.map(serialize));
+    const fullInWindow = full.filter(
+      (tick) => tick.x >= windowRange.startX && tick.x <= windowRange.endX,
+    );
+    expect(fullInWindow.length).toBeGreaterThan(50); // non-vacuous window
+    for (const tick of fullInWindow) {
+      expect(windowedSet.has(serialize(tick))).toBe(true);
+    }
+
+    // Tightness: nothing further out than one finest-step of slack.
+    const slackPx = FINEST * PPS + STRIP_GAP_PX;
+    for (const tick of windowed) {
+      expect(tick.x).toBeGreaterThanOrEqual(windowRange.startX - slackPx);
+      expect(tick.x).toBeLessThanOrEqual(windowRange.endX + slackPx);
+    }
+
+    // And every windowed tick is byte-identical to its full-build twin
+    // (tiers keyed on the ABSOLUTE step index — windowing shifts nothing).
+    const fullSet = new Set(full.map(serialize));
+    for (const tick of windowed) {
+      expect(fullSet.has(serialize(tick))).toBe(true);
+    }
+  });
+
+  it("bounds tick count by the window, not the timeline duration", () => {
+    const cards = mediaCards(2000, 4); // 8000s — ~32,000 ticks unwindowed
+    const windowed = buildRulerTicks(cards, noCollections(cards), PPS, {
+      startX: 100_000,
+      endX: 101_024,
+    });
+
+    // ~1024px of window at ≥10px per finest tick, plus slack: two orders of
+    // magnitude under the unwindowed count.
+    expect(windowed.length).toBeGreaterThan(50);
+    expect(windowed.length).toBeLessThan(300);
+  });
+
+  // Every time at or before the first card's startTime clamps to x = 0 —
+  // including the "0s" origin label. `timeAt(0)` returns that startTime, so a
+  // naive floor from it would drop the pre-content pile; the startX <= 0
+  // branch keeps it whenever the window reaches the content origin.
+  it("keeps the t=0 origin tick when the window includes the content start", () => {
+    const cards: ChildSpan[] = [{ startTime: 1, endTime: 5, width: 160 }];
+    const ticks = buildRulerTicks(cards, [false], PPS, { startX: 0, endX: 1024 });
+
+    expect(ticks.some((tick) => tick.label === "0s" && tick.x === 0)).toBe(true);
+  });
+
+  it("skips collection interiors and windows their edge ticks like any other", () => {
+    // media(4s/160px) · gap · collection(128px holding 100s) · gap · media —
+    // then a second collection far to the right, outside the window.
+    const cards: ChildSpan[] = [
+      { startTime: 0, endTime: 4, width: 160 },
+      { startTime: 4, endTime: 104, width: 128 },
+      { startTime: 104, endTime: 108, width: 160 },
+      { startTime: 108, endTime: 208, width: 128 },
+    ];
+    const flags = [false, true, false, true];
+    const windowRange = { startX: 0, endX: 300 }; // covers the FIRST collection only
+    const ticks = buildRulerTicks(cards, flags, PPS, windowRange);
+
+    // No numbered tick lands strictly inside the first collection's card
+    // (x in (169, 296]); its edge tick at x0=168 is present.
+    const collectionX0 = 160 + STRIP_GAP_PX;
+    const collectionX1 = collectionX0 + 128;
+    const interior = ticks.filter(
+      (tick) => tick.x > collectionX0 + 1 && tick.x <= collectionX1,
+    );
+    expect(interior).toEqual([]);
+    expect(ticks.filter((tick) => tick.x === collectionX0 && tick.level === 1)).toHaveLength(1);
+
+    // The second collection sits beyond the window: no edge tick for it.
+    const secondX0 = collectionX1 + STRIP_GAP_PX + 160 + STRIP_GAP_PX;
+    expect(ticks.some((tick) => tick.x === secondX0)).toBe(false);
+  });
+
+  it("returns nothing for an empty or zero-duration strip", () => {
+    expect(buildRulerTicks([], [], PPS, FULL_WINDOW)).toEqual([]);
+    expect(
+      buildRulerTicks([{ startTime: 0, endTime: 0, width: 100 }], [false], PPS, FULL_WINDOW),
+    ).toEqual([]);
   });
 });
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.ts
@@ -254,6 +254,171 @@ export function buildPlayheadMap(cards: readonly ChildSpan[]): PlayheadMap {
   };
 }
 
+// ── Ruler ticks ─────────────────────────────────────────────────────────────
+
+const RULER_LABEL_MIN_GAP_PX = 46;
+const RULER_MINOR_MIN_GAP_PX = 6;
+const RULER_NICE_SECONDS = [1, 2, 5, 10, 15, 30, 60, 120, 300, 600];
+const RULER_MAX_SUBTIER = 3;
+
+/** The labeled (major) tick interval — the nicest whole-second count whose
+ *  on-screen gap clears the label minimum at this zoom. */
+export function rulerMajorSpacing(pixelsPerSecond: number): number {
+  const target = RULER_LABEL_MIN_GAP_PX / Math.max(1, pixelsPerSecond);
+  return (
+    RULER_NICE_SECONDS.find((step) => step >= target) ??
+    RULER_NICE_SECONDS[RULER_NICE_SECONDS.length - 1]
+  );
+}
+
+/** How many binary subdivisions of the major fit as MINOR ticks — major/2,
+ *  /4, /8 (half, quarter, eighth of the major; at a 1s major these are the
+ *  half/quarter/eighth SECOND ticks). Each tier is added only while its gap
+ *  still clears the minor minimum, so zooming out drops the finest tiers. */
+export function rulerSubtierCount(majorSpacing: number, pixelsPerSecond: number): number {
+  let tiers = 0;
+  while (
+    tiers < RULER_MAX_SUBTIER &&
+    (majorSpacing / 2 ** (tiers + 1)) * pixelsPerSecond >= RULER_MINOR_MIN_GAP_PX
+  ) {
+    tiers += 1;
+  }
+  return tiers;
+}
+
+/** The tier a tick at finest-step index `n` belongs to: the COARSEST whose
+ *  spacing divides it (more trailing power-of-two factors = coarser tier).
+ *  0 is the labeled major. */
+export function rulerTickLevel(index: number, maxTier: number): number {
+  if (index === 0) return 0;
+  let trailing = 0;
+  let value = index;
+  while (trailing < maxTier && value % 2 === 0) {
+    value /= 2;
+    trailing += 1;
+  }
+  return maxTier - trailing;
+}
+
+export function formatRulerTick(seconds: number): string {
+  if (seconds < 60) return Number.isInteger(seconds) ? `${seconds}s` : `${seconds.toFixed(1)}s`;
+  const minutes = Math.floor(seconds / 60);
+  const rest = Math.round(seconds % 60);
+  return `${minutes}:${String(rest).padStart(2, "0")}`;
+}
+
+export type RulerTick = Readonly<{ x: number; level: number; label: string }>;
+
+/** The content-x range ticks should exist for (overscan already applied by
+ *  the caller). The ruler is NOT windowed by CSS clipping — ticks outside
+ *  this range are simply never built, which is the whole point. */
+export type RulerWindow = Readonly<{ startX: number; endX: number }>;
+
+/**
+ * The ruler's ticks for one strip, WINDOWED to a content-x range.
+ *
+ * Unwindowed, tick count scales with total DURATION at the finest tier —
+ * a long timeline at high zoom is thousands of ticks, each an absolutely
+ * positioned element, rebuilt per commit, almost all outside the viewport.
+ * Ticks are indexed on a regular time grid, and `timeAt` (the map's inverse,
+ * monotonic because card x-edges strictly increase) turns the window's pixel
+ * bounds into a tick-INDEX range — so generation itself is O(visible), not
+ * O(duration) merely filtered.
+ *
+ * Two exactness notes, both pinned by tests:
+ * - A window whose `startX` reaches the content origin keeps the whole
+ *   pre-content tick pile (every t at or before the first card's startTime
+ *   clamps to x = 0 — the "0s" origin label lives there): `timeAt(0)` returns
+ *   the first card's start TIME, and flooring from there would drop them.
+ * - The index range is widened by the floor/ceil to one tick of slack per
+ *   side, so a window never loses an edge tick to interpolation rounding —
+ *   for any window, the output equals the full build filtered to it (± that
+ *   slack), never less.
+ *
+ * Media cards are ruled; a collection card's fixed width holds an arbitrary
+ * duration, so its INTERIOR is skipped (a smear of ticks says nothing) and a
+ * single minor edge tick brackets it instead. The interior test binary-
+ * searches the (sorted, disjoint) card ranges — with thousands of cards the
+ * old linear `some` per tick was the other hidden O(n) in here.
+ */
+export function buildRulerTicks(
+  cards: readonly ChildSpan[],
+  isCollectionCard: readonly boolean[],
+  pixelsPerSecond: number,
+  windowRange: RulerWindow,
+): RulerTick[] {
+  if (cards.length === 0) return [];
+  const map = buildPlayheadMap(cards);
+  const total = map.totalDurationSeconds;
+  if (total <= 0) return [];
+
+  // Card x-ranges + collection flag, in the SAME cumulative layout the map
+  // walks — one pass carrying the running left edge.
+  const ranges: Array<{ x0: number; x1: number; isCollection: boolean }> = [];
+  let cursorX = 0;
+  for (let index = 0; index < cards.length; index += 1) {
+    ranges.push({
+      x0: cursorX,
+      x1: cursorX + cards[index].width,
+      isCollection: isCollectionCard[index] === true,
+    });
+    cursorX += cards[index].width + STRIP_GAP_PX;
+  }
+
+  // Ranges are sorted and disjoint (widths are positive, the gap separates
+  // them), so at most ONE range can contain a given x: the last whose left
+  // edge lies before it. Binary search for that candidate, then apply the
+  // exact interior predicate to it alone.
+  const inCollectionInterior = (cx: number): boolean => {
+    if (ranges[0].x0 >= cx) return false;
+    let low = 0;
+    let high = ranges.length - 1;
+    while (low < high) {
+      const middle = (low + high + 1) >> 1;
+      if (ranges[middle].x0 < cx) low = middle;
+      else high = middle - 1;
+    }
+    const range = ranges[low];
+    return range.isCollection && cx > range.x0 + 1 && cx <= range.x1;
+  };
+
+  // Tiered ticks: a labeled MAJOR every `major` seconds, plus half / quarter
+  // / eighth minors between them — as many tiers as clear the minor gap at
+  // this zoom. Stepping by the FINEST spacing and assigning each step its
+  // coarsest tier keeps every tier aligned to the major grid; the step index
+  // is ABSOLUTE (n = t / finest), so windowing never shifts a tick's tier.
+  const major = rulerMajorSpacing(pixelsPerSecond);
+  const maxTier = rulerSubtierCount(major, pixelsPerSecond);
+  const finest = major / 2 ** maxTier;
+  const steps = Math.floor((total + 1e-6) / finest);
+  const firstStep =
+    windowRange.startX <= 0
+      ? 0
+      : Math.max(0, Math.floor(map.timeAt(windowRange.startX) / finest));
+  const lastStep = Math.min(steps, Math.ceil(map.timeAt(windowRange.endX) / finest));
+
+  const out: RulerTick[] = [];
+  for (let n = firstStep; n <= lastStep; n += 1) {
+    const t = n * finest;
+    const cx = map.xAt(t);
+    if (inCollectionInterior(cx)) continue;
+    const level = rulerTickLevel(n, maxTier);
+    out.push({
+      x: cx,
+      level,
+      label: level === 0 ? formatRulerTick(Math.round(t * 1000) / 1000) : "",
+    });
+  }
+  // A minor edge tick bracketing each collection's blank interior — windowed
+  // like every other tick.
+  for (const range of ranges) {
+    if (range.isCollection && range.x0 >= windowRange.startX && range.x0 <= windowRange.endX) {
+      out.push({ x: range.x0, level: 1, label: "" });
+    }
+  }
+  return out;
+}
+
 export type GridPlayheadMap = Readonly<{
   posAt: (time: number) => { x: number; y: number };
   timeAt: (x: number, y: number) => number;

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -26,9 +26,9 @@ import {
 } from "@storyboard/timeline-domain";
 
 import {
-  STRIP_GAP_PX,
   buildGridPlayheadMap,
   buildPlayheadMap,
+  buildRulerTicks,
   cardSpansOf,
   childSpans,
   manifestTrailsLedger,
@@ -38,6 +38,7 @@ import {
   type GridPlayheadMap,
   type PlayheadMap,
   type PreviewCardSpans,
+  type RulerWindow,
 } from "./graph-playhead-model";
 
 export type { PreviewCardSpans } from "./graph-playhead-model";
@@ -188,58 +189,60 @@ export function GraphPlayhead({
   );
 }
 
-const RULER_LABEL_MIN_GAP_PX = 46;
-const RULER_MINOR_MIN_GAP_PX = 6;
-const RULER_NICE_SECONDS = [1, 2, 5, 10, 15, 30, 60, 120, 300, 600];
-const RULER_MAX_SUBTIER = 3;
 /** Tick height per tier: 0 = labeled major (full band), then progressively
  *  shorter minors (half / quarter / eighth). Index by `level`. */
 const RULER_TIER_HEIGHT_PX = [18, 11, 8, 5];
 
-/** The labeled (major) tick interval — the nicest whole-second count whose
- *  on-screen gap clears the label minimum at this zoom. */
-function rulerMajorSpacing(pixelsPerSecond: number): number {
-  const target = RULER_LABEL_MIN_GAP_PX / Math.max(1, pixelsPerSecond);
-  return (
-    RULER_NICE_SECONDS.find((step) => step >= target) ??
-    RULER_NICE_SECONDS[RULER_NICE_SECONDS.length - 1]
-  );
-}
+/** Window quantum for ruler ticks. Coarse on purpose: the window only
+ *  changes when scrolling crosses a chunk boundary, so the per-scroll-event
+ *  work is a compare-and-bail, and each re-render is amortized over ~512px
+ *  of travel. One chunk of overscan each side keeps ticks present under the
+ *  pointer during the between-chunks glide. */
+const RULER_WINDOW_CHUNK_PX = 512;
 
-/** How many binary subdivisions of the major fit as MINOR ticks — major/2,
- *  /4, /8 (half, quarter, eighth of the major; at a 1s major these are the
- *  half/quarter/eighth SECOND ticks). Each tier is added only while its gap
- *  still clears the minor minimum, so zooming out drops the finest tiers. */
-function rulerSubtierCount(majorSpacing: number, pixelsPerSecond: number): number {
-  let tiers = 0;
-  while (
-    tiers < RULER_MAX_SUBTIER &&
-    (majorSpacing / 2 ** (tiers + 1)) * pixelsPerSecond >= RULER_MINOR_MIN_GAP_PX
-  ) {
-    tiers += 1;
-  }
-  return tiers;
-}
+/** Pre-measure fallback: covers any plausible first paint from scroll 0 so
+ *  the ruler is never blank while the ResizeObserver's initial (async)
+ *  delivery is in flight; the first real measure then tightens it. */
+const INITIAL_RULER_WINDOW: RulerWindow = { startX: 0, endX: RULER_WINDOW_CHUNK_PX * 8 };
 
-/** The tier a tick at finest-step index `n` belongs to: the COARSEST whose
- *  spacing divides it (more trailing power-of-two factors = coarser tier).
- *  0 is the labeled major. */
-function rulerTickLevel(index: number, maxTier: number): number {
-  if (index === 0) return 0;
-  let trailing = 0;
-  let value = index;
-  while (trailing < maxTier && value % 2 === 0) {
-    value /= 2;
-    trailing += 1;
-  }
-  return maxTier - trailing;
-}
+/**
+ * The chunk-quantized visible content-x range of the strip this element
+ * renders inside — the ruler's tick window. Reads the scroll container via
+ * the package's documented `[data-virtual-strip]` selector contract (the
+ * ruler rides the strip's own overlay layer, so `closest` finds it). Updates
+ * ride the scroller's scroll event and a ResizeObserver — both async, so no
+ * synchronous setState-in-effect; the observer's initial delivery IS the
+ * first measurement.
+ */
+function useStripTickWindow(rulerEl: HTMLElement | null): RulerWindow {
+  const [tickWindow, setTickWindow] = useState<RulerWindow>(INITIAL_RULER_WINDOW);
 
-function formatRulerTick(seconds: number): string {
-  if (seconds < 60) return Number.isInteger(seconds) ? `${seconds}s` : `${seconds.toFixed(1)}s`;
-  const minutes = Math.floor(seconds / 60);
-  const rest = Math.round(seconds % 60);
-  return `${minutes}:${String(rest).padStart(2, "0")}`;
+  useEffect(() => {
+    if (!rulerEl) return;
+    const scroller = rulerEl.closest<HTMLElement>("[data-virtual-strip]");
+    // Not inside a strip (defensive): the initial window stands, degrading to
+    // the unwindowed behavior for the first few thousand pixels.
+    if (!scroller) return;
+    const update = () => {
+      const chunk = RULER_WINDOW_CHUNK_PX;
+      const startX = Math.max(0, (Math.floor(scroller.scrollLeft / chunk) - 1) * chunk);
+      const endX = (Math.ceil((scroller.scrollLeft + scroller.clientWidth) / chunk) + 1) * chunk;
+      setTickWindow((previous) =>
+        previous.startX === startX && previous.endX === endX
+          ? previous
+          : { startX, endX },
+      );
+    };
+    scroller.addEventListener("scroll", update, { passive: true });
+    const observer = new ResizeObserver(update);
+    observer.observe(scroller);
+    return () => {
+      scroller.removeEventListener("scroll", update);
+      observer.disconnect();
+    };
+  }, [rulerEl]);
+
+  return tickWindow;
 }
 
 /**
@@ -259,6 +262,11 @@ function formatRulerTick(seconds: number): string {
  * `childSpans` falls back to projection times, which is the honest clock then.
  * Rides the strip overlay (content coordinates), so scroll/auto-scroll and the
  * live-trim transform all apply for free.
+ *
+ * Ticks are WINDOWED to the strip's visible scroll range (chunk-quantized,
+ * one chunk of overscan each side — see useStripTickWindow): tick count
+ * follows the viewport, never the timeline's duration, so a thousands-of-
+ * clips strip at high zoom stops minting thousands of offscreen tick divs.
  */
 export function GraphRuler({
   focusedId,
@@ -267,6 +275,10 @@ export function GraphRuler({
   const store = useCollectionsStore();
   const detailsStore = useGraphDetailsStore();
   const spans = useContext(PreviewCardSpansContext);
+  // State, not a ref: the tick-window hook needs the element on the render
+  // pass after mount, and render-time ref reads are illegal.
+  const [rulerEl, setRulerEl] = useState<HTMLElement | null>(null);
+  const tickWindow = useStripTickWindow(rulerEl);
   const graph = useSyncExternalStore(
     store.subscribe,
     () => store.getSnapshot().graph,
@@ -278,59 +290,25 @@ export function GraphRuler({
     () => detailsStore.read(),
   );
 
+  // Tick building is windowed AND pure (graph-playhead-model): only the
+  // ticks inside the visible chunk range exist, so a long timeline at high
+  // zoom no longer mints thousands of offscreen tick elements per commit —
+  // tick count follows the VIEWPORT, not the duration. Scrolling recomputes
+  // only on chunk crossings (tickWindow identity is stable between them).
   const ticks = useMemo(() => {
     const clips = graphChildrenToClips(graph, details, focusedId);
     const cards = childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond));
-    if (cards.length === 0) return [];
-    const map = buildPlayheadMap(cards);
-    const total = map.totalDurationSeconds;
-    if (total <= 0) return [];
-
-    // Card x-ranges + collection flag, in the SAME cumulative layout the map
-    // walks — so a tick's x can be tested against the collection interiors.
-    // ONE pass carrying a running left edge: each card starts where the
-    // previous one ended plus the pack gap. (The prior version re-summed all
-    // preceding widths per card with slice+reduce — O(n²) over the strip, and
-    // rebuilt on every commit; the accumulator is a local `let`, still pure.)
-    const ranges: Array<{ x0: number; x1: number; isCollection: boolean }> = [];
-    let cursorX = 0;
-    for (let index = 0; index < cards.length; index += 1) {
-      const card = cards[index];
-      ranges.push({
-        x0: cursorX,
-        x1: cursorX + card.width,
-        isCollection: clips[index]?.kind === "collection",
-      });
-      cursorX += card.width + STRIP_GAP_PX;
-    }
-    const inCollectionInterior = (cx: number) =>
-      ranges.some((range) => range.isCollection && cx > range.x0 + 1 && cx <= range.x1);
-
-    // Tiered ticks: a labeled MAJOR every `major` seconds, plus half / quarter
-    // / eighth minors between them — as many tiers as clear the minor gap at
-    // this zoom (item R6 #2). Stepping by the FINEST spacing and assigning each
-    // step its coarsest tier keeps every tier aligned to the major grid.
-    const major = rulerMajorSpacing(pixelsPerSecond);
-    const maxTier = rulerSubtierCount(major, pixelsPerSecond);
-    const finest = major / 2 ** maxTier;
-    const steps = Math.floor((total + 1e-6) / finest);
-    const out: Array<{ x: number; level: number; label: string }> = [];
-    for (let n = 0; n <= steps; n += 1) {
-      const t = n * finest;
-      const cx = map.xAt(t);
-      if (inCollectionInterior(cx)) continue;
-      const level = rulerTickLevel(n, maxTier);
-      out.push({ x: cx, level, label: level === 0 ? formatRulerTick(Math.round(t * 1000) / 1000) : "" });
-    }
-    // A minor edge tick bracketing each collection's blank interior.
-    for (const range of ranges) {
-      if (range.isCollection) out.push({ x: range.x0, level: 1, label: "" });
-    }
-    return out;
-  }, [graph, details, spans, focusedId, pixelsPerSecond]);
+    return buildRulerTicks(
+      cards,
+      clips.map((clip) => clip.kind === "collection"),
+      pixelsPerSecond,
+      tickWindow,
+    );
+  }, [graph, details, spans, focusedId, pixelsPerSecond, tickWindow]);
 
   return (
     <div
+      ref={setRulerEl}
       aria-hidden="true"
       data-graph-ruler
       className="pointer-events-none absolute inset-x-0 top-0 z-10 h-[18px]"

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1977,4 +1977,51 @@ test.describe("graph view E2E", () => {
     await expect.poll(() => stripOrder(page, CHILD_ID)).toEqual(["c1", "c2"]);
     await expect.poll(() => page.locator("[data-graph-ruler]").count()).toBeGreaterThanOrEqual(2);
   });
+
+  test("ruler ticks are windowed to the visible strip, not the whole timeline", async ({
+    page,
+  }) => {
+    const api = await installGraphApi(page);
+    // A LONG project: 300 clips ≈ 1,200s ≈ 50,000px of strip at the default
+    // zoom. Unwindowed, the ruler minted one div per finest step across the
+    // whole duration (~4,800 ticks); windowed, tick count follows the
+    // viewport. `alpha` stays first so openGraph's readiness wait holds.
+    const project = api.documents.get(PROJECT_ID)!;
+    project.clips = [
+      mediaClip("alpha", "video", 0, 6, 8),
+      ...Array.from({ length: 299 }, (_, i) => mediaClip(`long-${i}`, "image", i + 1, 4)),
+    ];
+    await openGraph(page);
+    await page.getByRole("button", { name: /show time ruler/i }).click();
+    const ruler = page.locator("[data-graph-ruler]");
+    await expect(ruler).toHaveCount(1);
+
+    // Ticks translate within the strip's content coordinates; read each
+    // tick's x off its transform.
+    const tickXsInRange = (fromX: number, toX: number) =>
+      ruler.locator("> div").evaluateAll(
+        (els, range) =>
+          els.filter((el) => {
+            const match = /translateX\(([\d.]+)px\)/.exec((el as HTMLElement).style.transform);
+            return match !== null && +match[1] >= range.fromX && +match[1] <= range.toX;
+          }).length,
+        { fromX, toX },
+      );
+
+    // Near the origin: ticks exist. Far to the right (x ≈ 30,000, ~750s in):
+    // NONE exist yet — the unwindowed ruler had them all.
+    await expect.poll(() => tickXsInRange(0, 600)).toBeGreaterThan(5);
+    await expect.poll(() => tickXsInRange(30_000, 32_000)).toBe(0);
+    const beforeScroll = await ruler.locator("> div").count();
+    expect(beforeScroll).toBeLessThan(800);
+
+    // Scroll the strip deep into the timeline: the window follows and ticks
+    // materialize under the new viewport — still bounded, never the full set.
+    await strip(page, PROJECT_ID).evaluate((el) => {
+      el.scrollLeft = 30_000;
+    });
+    await expect.poll(() => tickXsInRange(30_000, 32_000)).toBeGreaterThan(5);
+    const afterScroll = await ruler.locator("> div").count();
+    expect(afterScroll).toBeLessThan(800);
+  });
 });


### PR DESCRIPTION
The performance half of the graph-view dnd-collections review (P3), completing the punch-list.

## Ruler tick windowing
The strip's second-ruler minted one absolutely-positioned tick div per finest-tier step across the **whole timeline duration**, rebuilt on every commit — thousands of mostly-offscreen elements on a long timeline at high zoom.

- Tick math extracted into pure, unit-testable `buildRulerTicks(cards, isCollectionCard, pps, window)` in `graph-playhead-model.ts`. Generation is **O(visible), not O(duration)**: the window's pixel bounds invert through `map.timeAt` (a monotonic inverse) to a tick-*index* range, so offscreen steps are never visited. The collection-interior test binary-searches the sorted, disjoint card ranges instead of scanning linearly per tick.
- `GraphRuler` tracks the strip's visible content-x range via `useStripTickWindow` — chunk-quantized (512px, one chunk of overscan each side), updated on scroll + resize with no set-state-in-effect. Tick count follows the viewport.

One design subtlety pinned by a test: `timeAt(0)` returns the *first card's* start time (leading padding), so a naive floor would drop the pre-content ticks clamped at x=0 — including the "0s" origin label. A `startX <= 0` branch keeps them, so full-strip output stays byte-identical to the old builder.

## Filmstrip resample settling + zoom responsiveness
- `useSettledFrameCount` debounces *changed* frame-count measurements (the first adopts immediately, so a virtualization remount is never blank). A continuous zoom drag no longer re-times every frame slot at each integer width/height-ratio crossing — which was swapping every `<img>` src (a fresh CDN URL per slot) several times per drag, per video card.
- `GraphBoard` feeds `useDeferredValue(pixelsPerSecond)` to every time→x consumer (strip, `itemWidth`, ruler, both playheads, scrub bands, sub-rows). The slider thumb stays urgent; the expensive relayout renders at the deferred value, interruptible by the next step. Deliberately not `startTransition` on the slider's `onChange` — that would defer the controlled thumb itself and make the handle lag the pointer. Settles the round-4 slider-responsiveness item.

## Tests
Four pins proven fail-first (three windowing, one filmstrip): the `buildRulerTicks` unit suite (tier ladder, windowed-equals-full-filtered with slack bound, bounded count on a 2,000-card strip, origin-tick preservation, windowed collection interiors/edges, empty cases), e2e `ruler ticks are windowed to the visible strip` (300-clip project, far ticks absent until scroll, count bounded both sides), and the `FilmstripResampleSettles` story.

Verified: app unit 193/193, storybook stories green, lint clean, graph-view e2e 39/39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
