### PR TITLE
Graph round 7: dev-gated sync panel, sampled trim overview, ruler collection durations, grid card interactivity

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useContext, useDeferredValue } from "react";
+import { useSearchParams } from "next/navigation";
 import {
   EllipsisVertical,
   FolderTree,
@@ -38,7 +39,6 @@ import { OpenKeyBoundary } from "./graph-navigation";
 import { SyncPanel, type SyncEntry } from "./graph-persistence";
 import {
   GraphGridPlayhead,
-  GraphGridScrubSurface,
   GraphPlayhead,
   GraphRuler,
   PlayheadScrubBand,
@@ -268,6 +268,13 @@ export function GraphBoard({
   syncEntries: readonly SyncEntry[];
 }>) {
   const dims = ITEM_SIZE_DIMENSIONS[itemSize];
+  // Developer telemetry (the SyncPanel below) is opt-in via a truthy `dev`
+  // query param — `?dev=1`, `?dev=true`, … — so regular use never shows it
+  // (R7 #1). Read here, not threaded from the page: the graph tree mounts
+  // client-only (`ssr: false` in client-graph-view), so useSearchParams has
+  // no prerender/Suspense implications.
+  const devParam = useSearchParams().get("dev");
+  const devPanelsOn = devParam !== null && !["", "0", "false"].includes(devParam);
   // Zoom splits urgency (round-4 polish item 8): the slider thumb must track
   // the pointer, so its value stays URGENT — while the expensive work a zoom
   // step triggers (strip relayout, ruler rebuild, per-card resize fan-out)
@@ -409,42 +416,33 @@ export function GraphBoard({
               )}
             </NativeDropStrip>
           ) : (
-            // NativeDropGrid wraps the scrub surface too, so a native drag over
-            // the (preview-only) scrub overlay still bubbles to the drop target.
+            // No scrub surface sibling anymore: grid scrubbing is DRAG THE
+            // PLAYHEAD (inside the overlay slot) — the old full-cover surface
+            // ate every card pointerdown while preview was on (R7 #5/#6/#7).
             <NativeDropGrid collectionId={focusedId}>
-              <div className="relative">
-                <VirtualGrid
-                  collectionId={parseNodeId(focusedId)}
-                  cellWidth={dims.gridWidth}
-                  cellHeight={dims.gridHeight}
-                  gap={GRID_GAP}
-                  height={GRID_UNCAPPED_HEIGHT}
-                  // Mirror the strip: a quick tap is a CLICK (so the in-card
-                  // drill button works) and a press-and-hold starts the reorder
-                  // drag. "body" (the default) drags instantly, which ate the
-                  // drill click and made drags ambiguous.
-                  itemDragActivation="hold"
-                  overlay={
-                    previewOn ? (
-                      <GraphGridPlayhead
-                        focusedId={focusedId}
-                        channel={timeChannel}
-                        cellHeight={dims.gridHeight}
-                        pixelsPerSecond={deferredPixelsPerSecond}
-                      />
-                    ) : undefined
-                  }
-                  className="bg-black/25"
-                />
-                {previewOn && (
-                  <GraphGridScrubSurface
-                    focusedId={focusedId}
-                    channel={timeChannel}
-                    cellHeight={dims.gridHeight}
-                    pixelsPerSecond={deferredPixelsPerSecond}
-                  />
-                )}
-              </div>
+              <VirtualGrid
+                collectionId={parseNodeId(focusedId)}
+                cellWidth={dims.gridWidth}
+                cellHeight={dims.gridHeight}
+                gap={GRID_GAP}
+                height={GRID_UNCAPPED_HEIGHT}
+                // Mirror the strip: a quick tap is a CLICK (so the in-card
+                // drill button works) and a press-and-hold starts the reorder
+                // drag. "body" (the default) drags instantly, which ate the
+                // drill click and made drags ambiguous.
+                itemDragActivation="hold"
+                overlay={
+                  previewOn ? (
+                    <GraphGridPlayhead
+                      focusedId={focusedId}
+                      channel={timeChannel}
+                      cellHeight={dims.gridHeight}
+                      pixelsPerSecond={deferredPixelsPerSecond}
+                    />
+                  ) : undefined
+                }
+                className="bg-black/25"
+              />
             </NativeDropGrid>
           )}
 
@@ -470,7 +468,7 @@ export function GraphBoard({
               from inside the provider, so its droppable joins the DndContext. */}
           <SidebarGraphTrashPortal trashId={trashRootId} />
 
-          <SyncPanel entries={syncEntries} />
+          {devPanelsOn && <SyncPanel entries={syncEntries} />}
         </div>
       </PreviewShell>
     </OpenKeyBoundary>

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -8,7 +8,9 @@ import {
   buildGraph,
   type CollectionItemShellComponent,
   type CollectionItemShellProps,
+  type CollectionTrimOverviewContentComponent,
   type NodeId,
+  type VideoMediaNode,
 } from "@storyboard/ui/dnd-collections";
 
 import { GRAPH_VIEW_COMPONENTS } from "./graph-item-content";
@@ -285,5 +287,77 @@ export const FilmstripResampleSettles: Story = {
     await waitFor(() => expect(previewImages(canvasElement)).toHaveLength(5), {
       timeout: 2000,
     });
+  },
+};
+
+// ── Trim overview sampling (R7 #2/#3) ───────────────────────────────────────
+
+/** A frame-addressable source URL: `.invalid` is an IETF-reserved TLD that
+ *  can never resolve, so nothing is fetched — while the `/video/upload/`
+ *  path shape lets the Cloudinary builder rewrite per-frame `so_` offsets,
+ *  which is exactly what this story asserts on. */
+const OVERVIEW_POSTER = "https://cdn.invalid/video/upload/so_0.35,f_jpg/scene.jpg";
+
+const OVERVIEW_NODE: VideoMediaNode = {
+  id: "vid-overview" as NodeId,
+  kind: "media",
+  mediaKind: "video",
+  name: "A video",
+  posterSrcs: [OVERVIEW_POSTER],
+  fullDurationSeconds: 10,
+  trimInSeconds: 1,
+  trimOutSeconds: 2,
+};
+
+/**
+ * The registered OverviewContent (the "sequence above" a selected video)
+ * SAMPLES its frames — the package default tiles the 1–2 stored posters by
+ * modulo, so a one-poster clip painted the same still into every slot (R7
+ * #2). Each slot must carry its own source time, the last one pinned to the
+ * source's end (R7 #3), and the default's "full clip x.xs" readout must be
+ * gone (R7 #3).
+ */
+export const TrimOverviewSamplesDistinctFrames: Story = {
+  args: baseArgs,
+  render: () => {
+    const Overview =
+      GRAPH_VIEW_COMPONENTS.OverviewContent as CollectionTrimOverviewContentComponent;
+    return (
+      <div className="relative h-11 w-[440px] overflow-hidden bg-zinc-950">
+        <Overview
+          node={OVERVIEW_NODE}
+          pixelsPerSecond={44}
+          trimInSeconds={1}
+          trimOutSeconds={2}
+          fullWidth={440}
+        />
+      </div>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    // 440px of strip at 44px square frames → 10 slots.
+    const images = previewImages(canvasElement);
+    await expect(images).toHaveLength(10);
+
+    // Every slot samples its OWN time: all so_ offsets distinct, ascending.
+    const offsets = images.map((img) => {
+      const match = /[/,]so_([\d.]+)/.exec(img.getAttribute("src") ?? "");
+      return match ? Number(match[1]) : NaN;
+    });
+    expect(new Set(offsets).size).toBe(offsets.length);
+    for (let i = 1; i < offsets.length; i += 1) {
+      expect(offsets[i]).toBeGreaterThan(offsets[i - 1]);
+    }
+
+    // The last slot is pinned to the source's end (10s − 0.05 back-off) —
+    // not its slot centre (9.5s).
+    expect(offsets[offsets.length - 1]).toBeCloseTo(9.95);
+
+    // The overview covers the FULL source, not the trimmed window: the
+    // first slot's centre lives in the leading trimmed-away region.
+    expect(offsets[0]).toBeLessThan(1);
+
+    // The stock "full clip x.xs" readout is dropped (R7 #3).
+    expect(canvasElement.textContent).not.toContain("full clip");
   },
 };

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -16,6 +16,7 @@ import {
   type CollectionItemContentProps,
   type CollectionItemShellProps,
   type CollectionTrimHandleContentProps,
+  type CollectionTrimOverviewContentProps,
   type CollectionsComponents,
   type CollectionsGraph,
   type MediaNode,
@@ -304,6 +305,72 @@ const GraphClipContent = memo(function GraphClipContent({
   );
 });
 
+/** Square overview frames — the strip is h-11 (44px), matching the package
+ *  default so only the SAMPLING differs. */
+const OVERVIEW_FRAME_SIZE = 44;
+const OVERVIEW_FRAME_CAP = 40;
+
+/**
+ * The trim overview's background (the "sequence above" a selected video),
+ * replacing the package default via the `OverviewContent` registry slot. The
+ * default TILES the 1–2 stored posters by modulo — with one poster every
+ * frame is the same still, which reads as broken (R7 #2). This samples each
+ * slot at its own time across the FULL SOURCE through the same
+ * `videoFrameUrls` seam the card filmstrip uses, so the two strips show the
+ * same kind of sequence — including the last-slot end-frame pin (R7 #3).
+ * The default's "full clip x.xs" readout is dropped on request (R7 #3); the
+ * trim readouts around the window already carry the numbers.
+ *
+ * Memo comparator (mirrors the package default's): the contract carries live
+ * trimIn/trimOut that change per pointer move during a drag, but this
+ * renderer reads only `node` and `fullWidth` — shallow memo would reconcile
+ * up to 40 <img> elements per move for nothing.
+ */
+const GraphTrimOverviewContent = memo(
+  function GraphTrimOverviewContent({ node, fullWidth }: CollectionTrimOverviewContentProps) {
+    const posters = node.posterSrcs ?? [];
+    // Enough square frames to cover the strip width (ceil so the row fills;
+    // the container clips the overflow), capped so a long source stays
+    // bounded.
+    const frameCount = Math.max(
+      1,
+      Math.min(OVERVIEW_FRAME_CAP, Math.ceil(fullWidth / OVERVIEW_FRAME_SIZE)),
+    );
+    // The overview shows the FULL source (the amber window marks the visible
+    // part), so the sample range is [0, fullDurationSeconds] — not the
+    // trimmed range the card uses.
+    const frameSrcs = videoFrameUrls(posters, frameCount, {
+      trimInSeconds: 0,
+      effectiveSeconds: Math.max(0, node.fullDurationSeconds),
+    });
+    return (
+      <div className="flex h-full w-full">
+        {frameSrcs.length === 0 ? (
+          <span className="flex h-full w-full items-center justify-center bg-muted text-[10px] text-muted-foreground select-none">
+            No preview frames
+          </span>
+        ) : (
+          frameSrcs.map((src, index) => (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              key={index}
+              src={src}
+              alt=""
+              draggable={false}
+              style={{ width: OVERVIEW_FRAME_SIZE }}
+              className="h-full shrink-0 border-r border-black/60 object-cover last:border-r-0"
+            />
+          ))
+        )}
+      </div>
+    );
+  },
+  (prev, next) =>
+    prev.node === next.node &&
+    prev.pixelsPerSecond === next.pixelsPerSecond &&
+    prev.fullWidth === next.fullWidth,
+);
+
 const GraphTrimHandle = memo(function GraphTrimHandle({
   side,
 }: CollectionTrimHandleContentProps) {
@@ -526,5 +593,6 @@ export const GRAPH_VIEW_COMPONENTS: CollectionsComponents = {
   ItemContent: GraphClipContent,
   ItemShell: GraphItemShell,
   TrimHandleContent: GraphTrimHandle,
+  OverviewContent: GraphTrimOverviewContent,
   GhostContent: GraphGhost,
 };

--- a/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.test.ts
@@ -5,6 +5,7 @@ import type { PlaybackLeaf, PlaybackManifest } from "@storyboard/timeline-domain
 
 import {
   buildPlayheadMap,
+  buildRulerCollectionSpans,
   buildRulerTicks,
   cardSpansOf,
   childSpans,
@@ -389,6 +390,43 @@ describe("buildRulerTicks", () => {
     expect(
       buildRulerTicks([{ startTime: 0, endTime: 0, width: 100 }], [false], PPS, FULL_WINDOW),
     ).toEqual([]);
+  });
+});
+
+describe("buildRulerCollectionSpans", () => {
+  // Same fixture shape as the tick tests: media · collection · media ·
+  // collection, so x-ranges are hand-checkable against the tick walk.
+  const cards: ChildSpan[] = [
+    { startTime: 0, endTime: 4, width: 160 },
+    { startTime: 4, endTime: 104, width: 128 }, // 100s of content in 128px
+    { startTime: 104, endTime: 108, width: 160 },
+    { startTime: 108, endTime: 208, width: 128 },
+  ];
+  const flags = [false, true, false, true];
+  const FULL_WINDOW = { startX: 0, endX: Number.MAX_SAFE_INTEGER };
+  const collection1X = 160 + STRIP_GAP_PX;
+  const collection2X = collection1X + 128 + STRIP_GAP_PX + 160 + STRIP_GAP_PX;
+
+  it("yields each collection's x-range and content duration on the tick layout", () => {
+    const spans = buildRulerCollectionSpans(cards, flags, FULL_WINDOW);
+    expect(spans).toEqual([
+      { x: collection1X, width: 128, seconds: 100 },
+      { x: collection2X, width: 128, seconds: 100 },
+    ]);
+  });
+
+  it("windows spans by INTERSECTION so a partially visible collection keeps its label", () => {
+    // Window ends inside the first collection's card — it still reports.
+    const spans = buildRulerCollectionSpans(cards, flags, {
+      startX: 0,
+      endX: collection1X + 10,
+    });
+    expect(spans).toEqual([{ x: collection1X, width: 128, seconds: 100 }]);
+  });
+
+  it("skips collections wholly outside the window and media everywhere", () => {
+    expect(buildRulerCollectionSpans(cards, flags, { startX: 0, endX: 100 })).toEqual([]);
+    expect(buildRulerCollectionSpans(cards, cards.map(() => false), FULL_WINDOW)).toEqual([]);
   });
 });
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.ts
@@ -419,6 +419,40 @@ export function buildRulerTicks(
   return out;
 }
 
+export type RulerCollectionSpan = Readonly<{ x: number; width: number; seconds: number }>;
+
+/**
+ * Each collection card's x-range and content duration, for the ruler band to
+ * FILL with a duration label (R7 #4): `buildRulerTicks` deliberately skips a
+ * collection's interior (its fixed width holds an arbitrary duration, so
+ * ticks there would lie), which left the same opaque band as media cards
+ * with nothing in it — reading as a rendering gap rather than a decision.
+ * Windowed like the ticks: only spans INTERSECTING the visible range exist.
+ * Same cumulative layout walk as the tick ranges, so the two can never
+ * disagree about where a collection sits.
+ */
+export function buildRulerCollectionSpans(
+  cards: readonly ChildSpan[],
+  isCollectionCard: readonly boolean[],
+  windowRange: RulerWindow,
+): RulerCollectionSpan[] {
+  const out: RulerCollectionSpan[] = [];
+  let cursorX = 0;
+  for (let index = 0; index < cards.length; index += 1) {
+    const card = cards[index];
+    const x1 = cursorX + card.width;
+    if (
+      isCollectionCard[index] === true &&
+      x1 >= windowRange.startX &&
+      cursorX <= windowRange.endX
+    ) {
+      out.push({ x: cursorX, width: card.width, seconds: card.endTime - card.startTime });
+    }
+    cursorX = x1 + STRIP_GAP_PX;
+  }
+  return out;
+}
+
 export type GridPlayheadMap = Readonly<{
   posAt: (time: number) => { x: number; y: number };
   timeAt: (x: number, y: number) => number;

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -28,9 +28,11 @@ import {
 import {
   buildGridPlayheadMap,
   buildPlayheadMap,
+  buildRulerCollectionSpans,
   buildRulerTicks,
   cardSpansOf,
   childSpans,
+  formatRulerTick,
   manifestTrailsLedger,
   nextManifestClipsState,
   nextManifestFailureCount,
@@ -193,6 +195,10 @@ export function GraphPlayhead({
  *  shorter minors (half / quarter / eighth). Index by `level`. */
 const RULER_TIER_HEIGHT_PX = [18, 11, 8, 5];
 
+/** Narrowest collection card that still fits its centred duration label —
+ *  below this the band stays empty rather than overflowing the neighbours. */
+const RULER_COLLECTION_LABEL_MIN_WIDTH_PX = 34;
+
 /** Window quantum for ruler ticks. Coarse on purpose: the window only
  *  changes when scrolling crosses a chunk boundary, so the per-scroll-event
  *  work is a compare-and-bail, and each re-render is amortized over ~512px
@@ -295,15 +301,17 @@ export function GraphRuler({
   // zoom no longer mints thousands of offscreen tick elements per commit —
   // tick count follows the VIEWPORT, not the duration. Scrolling recomputes
   // only on chunk crossings (tickWindow identity is stable between them).
-  const ticks = useMemo(() => {
+  const { ticks, collectionSpans } = useMemo(() => {
     const clips = graphChildrenToClips(graph, details, focusedId);
     const cards = childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond));
-    return buildRulerTicks(
-      cards,
-      clips.map((clip) => clip.kind === "collection"),
-      pixelsPerSecond,
-      tickWindow,
-    );
+    const isCollection = clips.map((clip) => clip.kind === "collection");
+    return {
+      ticks: buildRulerTicks(cards, isCollection, pixelsPerSecond, tickWindow),
+      // A collection's interior gets no ticks (its width is not a time axis)
+      // — fill its stretch of the band with the content duration instead
+      // (R7 #4), same live-derived total the card badge shows.
+      collectionSpans: buildRulerCollectionSpans(cards, isCollection, tickWindow),
+    };
   }, [graph, details, spans, focusedId, pixelsPerSecond, tickWindow]);
 
   return (
@@ -339,6 +347,21 @@ export function GraphRuler({
           ) : null}
         </div>
       ))}
+      {/* Collections carry no ticks, so their stretch of the band shows the
+          content duration instead of sitting empty (R7 #4). Centred in the
+          card's range; skipped when the card is too narrow for the label. */}
+      {collectionSpans.map((span, index) =>
+        span.width >= RULER_COLLECTION_LABEL_MIN_WIDTH_PX ? (
+          <span
+            key={`collection-${index}`}
+            data-ruler-collection-duration
+            className="absolute top-[2px] -translate-x-1/2 whitespace-nowrap font-mono text-[9px] font-medium leading-none text-sky-200/90"
+            style={{ left: span.x + span.width / 2 }}
+          >
+            {formatRulerTick(Math.round(span.seconds * 10) / 10)}
+          </span>
+        ) : null,
+      )}
     </div>
   );
 }
@@ -460,7 +483,7 @@ export function GraphGridPlayhead({
     let lastCellWidth = 0;
     let map: GridPlayheadMap | null = null;
 
-    const paint = () => {
+    const ensureMap = (): GridPlayheadMap | null => {
       const graph = store.getSnapshot().graph;
       const details = detailsStore.read();
       const columns = Number(grid?.dataset.gridColumns) || 1;
@@ -485,96 +508,35 @@ export function GraphGridPlayhead({
           cellHeight,
         );
       }
-      if (!map) return;
+      return map;
+    };
+
+    const paint = () => {
+      const current = ensureMap();
+      if (!current) return;
       const time = channel.get();
       const inside =
         !activeWindow || (time >= activeWindow.start - 0.04 && time <= activeWindow.end + 0.04);
       line.style.display = inside ? "" : "none";
       if (!inside) return;
-      const { x, y } = map.posAt(time);
+      const { x, y } = current.posAt(time);
       line.style.transform = `translate(${x}px, ${y}px)`;
-      line.style.height = `${map.rowHeight}px`;
+      line.style.height = `${current.rowHeight}px`;
     };
 
-    paint();
-    const unsubscribeTime = channel.subscribe(paint);
-    const unsubscribeStore = store.subscribe(paint);
-    const unsubscribeDetails = detailsStore.subscribe(paint);
-    const observer = grid ? new ResizeObserver(paint) : null;
-    if (grid && observer) observer.observe(grid);
-    return () => {
-      unsubscribeTime();
-      unsubscribeStore();
-      unsubscribeDetails();
-      observer?.disconnect();
-    };
-  }, [store, detailsStore, focusedId, channel, cellHeight, spans, pixelsPerSecond, activeWindow]);
-
-  return (
-    <div
-      ref={lineRef}
-      data-graph-grid-playhead
-      className="absolute left-0 top-0 w-0.5 bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.9)]"
-    >
-      <div className="absolute -left-[5px] -top-2 h-0 w-0 border-x-[6px] border-t-[8px] border-x-transparent border-t-red-500" />
-    </div>
-  );
-}
-
-export function GraphGridScrubSurface({
-  focusedId,
-  channel,
-  cellHeight,
-  pixelsPerSecond,
-}: Readonly<{
-  focusedId: string;
-  channel: PreviewTimeChannel;
-  cellHeight: number;
-  pixelsPerSecond: number;
-}>) {
-  const store = useCollectionsStore();
-  const detailsStore = useGraphDetailsStore();
-  const spans = useContext(PreviewCardSpansContext);
-  const surfaceRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const surface = surfaceRef.current;
-    if (!surface) return;
-    const grid = surface.parentElement?.querySelector<HTMLElement>("[data-virtual-grid]") ?? null;
-    if (!grid) return;
-
-    let map: GridPlayheadMap | null = null;
-    let mapGraph: CollectionsGraph | null = null;
-    let mapDetails: DetailsById | null = null;
-    let mapColumns = 0;
-    let mapCellWidth = 0;
+    // Scrub = DRAG THE PLAYHEAD (R7 #5/#6/#7). The full-cover scrub surface
+    // this grid used to carry ate every card pointerdown while preview was
+    // on — no select, no drill, no hold-drag. Now the cards own their
+    // pixels again and the playhead itself is the only scrub affordance:
+    // its (enlarged) handle captures the pointer and maps x/y through the
+    // same grid time map the old surface used, so cross-row scrubs still
+    // work — drag the handle onto another row and it jumps there.
     const seek = (event: PointerEvent) => {
-      const graph = store.getSnapshot().graph;
-      const details = detailsStore.read();
-      const columns = Number(grid.dataset.gridColumns) || 1;
-      // Live rendered cell width (post fill-stretch) — see GraphGridPlayhead.
-      const cellWidth = Number(grid.dataset.gridCellWidth) || 1;
-      if (
-        graph !== mapGraph ||
-        details !== mapDetails ||
-        columns !== mapColumns ||
-        cellWidth !== mapCellWidth ||
-        !map
-      ) {
-        mapGraph = graph;
-        mapDetails = details;
-        mapColumns = columns;
-        mapCellWidth = cellWidth;
-        map = buildGridPlayheadMap(
-          childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond)),
-          columns,
-          cellWidth,
-          cellHeight,
-        );
-      }
+      const current = ensureMap();
+      if (!current || !grid) return;
       const overlay = grid.querySelector<HTMLElement>("[data-virtual-grid-overlay]");
       const rect = (overlay ?? grid).getBoundingClientRect();
-      channel.set(map.timeAt(event.clientX - rect.left, event.clientY - rect.top));
+      channel.set(current.timeAt(event.clientX - rect.left, event.clientY - rect.top));
     };
 
     let pointerId: number | null = null;
@@ -590,9 +552,13 @@ export function GraphGridScrubSurface({
     };
     const handleDown = (event: PointerEvent) => {
       if (!event.isPrimary || event.button !== 0) return;
+      // The handle sits inside the aria-hidden overlay layer; nothing else
+      // must see this press (a card behind it would treat it as a select).
+      event.stopPropagation();
+      event.preventDefault();
       pointerId = event.pointerId;
       try {
-        surface.setPointerCapture(event.pointerId);
+        line.setPointerCapture(event.pointerId);
       } catch {
         // Synthetic pointer: window listeners still own the lifecycle.
       }
@@ -601,26 +567,41 @@ export function GraphGridScrubSurface({
       window.addEventListener("pointerup", end);
       window.addEventListener("pointercancel", end);
     };
-    // No wheel handler: grids are content-height (GRID_UNCAPPED_HEIGHT), so
-    // there is no internal scroll to feed — the wheel keeps its default and
-    // the PAGE scrolls, which the e2e suite pins. The forwarding handler this
-    // surface used to carry could only ever no-op.
-    surface.addEventListener("pointerdown", handleDown);
+
+    line.addEventListener("pointerdown", handleDown);
+    paint();
+    const unsubscribeTime = channel.subscribe(paint);
+    const unsubscribeStore = store.subscribe(paint);
+    const unsubscribeDetails = detailsStore.subscribe(paint);
+    const observer = grid ? new ResizeObserver(paint) : null;
+    if (grid && observer) observer.observe(grid);
     return () => {
-      surface.removeEventListener("pointerdown", handleDown);
+      line.removeEventListener("pointerdown", handleDown);
       window.removeEventListener("pointermove", handleMove);
       window.removeEventListener("pointerup", end);
       window.removeEventListener("pointercancel", end);
+      unsubscribeTime();
+      unsubscribeStore();
+      unsubscribeDetails();
+      observer?.disconnect();
     };
-  }, [store, detailsStore, focusedId, channel, cellHeight, spans, pixelsPerSecond]);
+  }, [store, detailsStore, focusedId, channel, cellHeight, spans, pixelsPerSecond, activeWindow]);
 
   return (
+    // pointer-events re-enabled DELIBERATELY: the overlay wrapper is
+    // pointer-events-none so cards stay interactive; only this handle takes
+    // the pointer back. It stays pointer-only and unfocusable (the wrapper
+    // is aria-hidden — a focusable child there would be a keyboard trap).
     <div
-      ref={surfaceRef}
-      data-grid-scrub
-      aria-hidden="true"
-      className="absolute inset-0 z-10 cursor-crosshair"
-    />
+      ref={lineRef}
+      data-graph-grid-playhead
+      className="pointer-events-auto absolute left-0 top-0 w-0.5 cursor-ew-resize bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.9)]"
+    >
+      <div className="absolute -left-[5px] -top-2 h-0 w-0 border-x-[6px] border-t-[8px] border-x-transparent border-t-red-500" />
+      {/* Invisible enlarged grab zone: the 2px line alone is unhittable.
+          Spans the cap and the full line height, ~17px wide. */}
+      <div data-graph-grid-playhead-handle className="absolute -inset-x-2 -top-2 bottom-0" />
+    </div>
   );
 }
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -26,7 +26,6 @@ import {
 import { GraphViewNavContext } from "./graph-navigation";
 import {
   GraphGridPlayhead,
-  GraphGridScrubSurface,
   GraphPlayhead,
   GraphRuler,
   PlayheadScrubBand,
@@ -229,39 +228,30 @@ function SubTimelineNode({
           style={{ paddingLeft: SUBTIMELINE_INDENT_PX }}
         >
           {surface === "grid" ? (
-            // Grid mode now accepts native drops too (a NativeDropGrid), matching
-            // the strip. It wraps the scrub surface so a drag over that overlay
-            // still bubbles to the drop target.
+            // Grid mode now accepts native drops too (a NativeDropGrid),
+            // matching the strip. Scrubbing is drag-the-playhead (R7 #5-#7),
+            // so there is no scrub-surface sibling — cards keep their
+            // pointerdowns even with the preview on.
             <NativeDropGrid collectionId={id}>
-              <div className="relative">
-                <VirtualGrid
-                  collectionId={collectionId}
-                  cellWidth={dims.gridWidth}
-                  cellHeight={dims.gridHeight}
-                  gap={GRID_GAP}
-                  height={GRID_UNCAPPED_HEIGHT}
-                  overlay={
-                    showPlayhead ? (
-                      <GraphGridPlayhead
-                        focusedId={id}
-                        channel={timeChannel}
-                        cellHeight={dims.gridHeight}
-                        pixelsPerSecond={pixelsPerSecond}
-                        activeWindow={clockWindow}
-                      />
-                    ) : undefined
-                  }
-                  className="bg-black/20"
-                />
-                {showPlayhead && (
-                  <GraphGridScrubSurface
-                    focusedId={id}
-                    channel={timeChannel}
-                    cellHeight={dims.gridHeight}
-                    pixelsPerSecond={pixelsPerSecond}
-                  />
-                )}
-              </div>
+              <VirtualGrid
+                collectionId={collectionId}
+                cellWidth={dims.gridWidth}
+                cellHeight={dims.gridHeight}
+                gap={GRID_GAP}
+                height={GRID_UNCAPPED_HEIGHT}
+                overlay={
+                  showPlayhead ? (
+                    <GraphGridPlayhead
+                      focusedId={id}
+                      channel={timeChannel}
+                      cellHeight={dims.gridHeight}
+                      pixelsPerSecond={pixelsPerSecond}
+                      activeWindow={clockWindow}
+                    />
+                  ) : undefined
+                }
+                className="bg-black/20"
+              />
             </NativeDropGrid>
           ) : (
             <NativeDropStrip collectionId={id}>

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -236,8 +236,14 @@ export function TimelineSidebar() {
     }
   };
 
+  // z-50, not z-40: the aside is sticky, so it IS a stacking context and
+  // every child z-index (the fly-out tooltips' z-50 included) is trapped
+  // inside it. The preview region + graph header sit at z-40 later in the
+  // DOM, which painted over the tooltips at equal z — the whole column must
+  // outrank them (R7 #8). Nothing overlaps the 72px rail itself, so raising
+  // it hides nothing.
   return (
-    <aside className="sticky top-0 z-40 flex h-screen w-[72px] shrink-0 flex-col items-center gap-5 overflow-visible border-r border-zinc-800 bg-zinc-900/50 px-3 py-5 backdrop-blur-md">
+    <aside className="sticky top-0 z-50 flex h-screen w-[72px] shrink-0 flex-col items-center gap-5 overflow-visible border-r border-zinc-800 bg-zinc-900/50 px-3 py-5 backdrop-blur-md">
       <Link
         href="/"
         aria-label="Storyboard Workbench home"

--- a/apps/timeline-gstudio001/lib/video-frame-url.test.ts
+++ b/apps/timeline-gstudio001/lib/video-frame-url.test.ts
@@ -47,7 +47,7 @@ describe("cloudinaryVideoFrameUrl", () => {
 });
 
 describe("videoFrameUrls", () => {
-  it("samples `count` frames at slot centres across the visible range", () => {
+  it("samples interior frames at slot centres and pins the LAST to the range end", () => {
     // A recording builder just captures the times it was asked for.
     const times: number[] = [];
     const record: VideoFrameUrlBuilder = (url, t) => {
@@ -56,8 +56,10 @@ describe("videoFrameUrls", () => {
     };
     const urls = videoFrameUrls(["poster"], 4, { trimInSeconds: 0, effectiveSeconds: 8 }, record);
     expect(urls).toHaveLength(4);
-    // (i + 0.5)/4 * 8 = 1, 3, 5, 7 — centres, never the exact 0 or 8 edge.
-    expect(times).toEqual([1, 3, 5, 7]);
+    // Interior: (i + 0.5)/4 * 8 = 1, 3, 5 — centres, never the exact 0 edge.
+    // Last: the end of the range minus the 0.05s back-off (R7 #3), so the
+    // strip finishes on the clip's final frame instead of slot centre 7.
+    expect(times).toEqual([1, 3, 5, 7.95]);
   });
 
   it("offsets sample times by the trim-in so it reads the VISIBLE window", () => {
@@ -67,8 +69,21 @@ describe("videoFrameUrls", () => {
       return "x";
     };
     videoFrameUrls(["poster"], 2, { trimInSeconds: 10, effectiveSeconds: 4 }, record);
-    // (0.5/2)*4 + 10 = 11 ; (1.5/2)*4 + 10 = 13
-    expect(times).toEqual([11, 13]);
+    // First at centre (0.5/2)*4 + 10 = 11 ; last pinned to 10 + (4 - 0.05).
+    expect(times).toEqual([11, 13.95]);
+  });
+
+  it("never pins the last slot below the range midpoint on tiny clips", () => {
+    const times: number[] = [];
+    const record: VideoFrameUrlBuilder = (_url, t) => {
+      times.push(t);
+      return "x";
+    };
+    // effective 0.06s: end - 0.05 = 0.01 would land BEFORE the first slot's
+    // centre — the midpoint floor keeps the pair ordered.
+    videoFrameUrls(["poster"], 2, { trimInSeconds: 0, effectiveSeconds: 0.06 }, record);
+    expect(times[1]).toBeGreaterThanOrEqual(times[0]);
+    expect(times[1]).toBeCloseTo(0.03);
   });
 
   it("returns nothing without a poster or with a non-positive count", () => {

--- a/apps/timeline-gstudio001/lib/video-frame-url.ts
+++ b/apps/timeline-gstudio001/lib/video-frame-url.ts
@@ -43,12 +43,19 @@ export const cloudinaryVideoFrameUrl: VideoFrameUrlBuilder = (frameUrl, timeSeco
  *  another provider — nothing above the seam names Cloudinary. */
 export const defaultVideoFrameUrlBuilder: VideoFrameUrlBuilder = cloudinaryVideoFrameUrl;
 
+/** How far short of the range's exact end the LAST slot samples. The very
+ *  final frame of an encode is often black or a fade-out remnant; a beat
+ *  before it is the frame a person means by "the end of the clip". */
+const LAST_FRAME_BACKOFF_SECONDS = 0.05;
+
 /**
  * `count` frame URLs sampled at even times across the clip's VISIBLE range
- * — [trimInSeconds, trimInSeconds + effectiveSeconds]. Frames are read at slot
- * CENTERS ((i + 0.5) / count) so the first isn't the exact in-cut and the last
- * isn't the very tail (both often black). Falls back to the base poster when
- * there is no usable frame URL to transform.
+ * — [trimInSeconds, trimInSeconds + effectiveSeconds]. Interior frames are
+ * read at slot CENTERS ((i + 0.5) / count) so the first isn't the exact
+ * in-cut (often black); the LAST slot is pinned to the range's end (minus a
+ * small back-off) so the strip always finishes on the clip's final frame
+ * (R7 #3). Falls back to the base poster when there is no usable frame URL
+ * to transform.
  */
 export function videoFrameUrls(
   posters: readonly string[],
@@ -62,7 +69,12 @@ export function videoFrameUrls(
   const effective = Math.max(0, range.effectiveSeconds);
   const urls: string[] = [];
   for (let index = 0; index < slots; index += 1) {
-    const time = range.trimInSeconds + ((index + 0.5) / slots) * effective;
+    // Single-slot strips keep the center sample — pinning them to the end
+    // would represent a whole clip by its final frame.
+    const time =
+      index === slots - 1 && slots > 1
+        ? range.trimInSeconds + Math.max(effective / 2, effective - LAST_FRAME_BACKOFF_SECONDS)
+        : range.trimInSeconds + ((index + 0.5) / slots) * effective;
     urls.push(build(base, time));
   }
   return urls;

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -760,8 +760,10 @@ test.describe("graph view E2E", () => {
     // scroll PAST the preview (the sticky-pin assertion below needs that). The
     // preview's own height is a fixed model value, independent of viewport, so
     // the height-persistence checks are unaffected. (The old always-present
-    // bottom trash panel used to guarantee this height; it's gone now — R5 #5.)
-    await page.setViewportSize({ width: 1280, height: 560 });
+    // bottom trash panel used to guarantee this height — gone in R5 #5 — and
+    // the dev-only SyncPanel stopped shortening the page further in R7 #1,
+    // hence 480, not 560: the page must out-scroll the preview by 40px.)
+    await page.setViewportSize({ width: 1280, height: 480 });
     await previewToggle(page).click();
 
     const divider = page.getByRole("separator", { name: "Resize workbench display" });
@@ -783,6 +785,10 @@ test.describe("graph view E2E", () => {
     // pinned to the viewport instead of disappearing with the graph below.
     const previewRegion = page.getByTestId("workbench-preview-region");
     const main = page.getByRole("main");
+    // The expand click above may have auto-scrolled its button into view
+    // (the shorter viewport makes that likely) — measure the preview's
+    // NATURAL top from an unscrolled page.
+    await page.evaluate(() => window.scrollTo({ top: 0, behavior: "instant" }));
     const naturalTop = await previewRegion.evaluate(
       (element) => element.getBoundingClientRect().top,
     );
@@ -795,7 +801,11 @@ test.describe("graph view E2E", () => {
     expect(await main.evaluate((element) => getComputedStyle(element).overflowY)).toBe("visible");
     expect(await main.evaluate((element) => element.scrollTop)).toBe(0);
 
-    // Closing and reopening the preview restores the same height.
+    // Closing and reopening the preview restores the same height. From the
+    // top of the page again: reopening while scroll-pinned lets the pane
+    // clamp against the pinned layout, which is a different question than
+    // height persistence.
+    await page.evaluate(() => window.scrollTo({ top: 0, behavior: "instant" }));
     await previewToggle(page).click();
     await expect(divider).toHaveCount(0);
     await previewToggle(page).click();
@@ -1208,11 +1218,11 @@ test.describe("graph view E2E", () => {
     await expect.poll(translateX).toBeLessThan(20);
   });
 
-  test("grid mode: playhead rides cells, scrubs horizontally and jumps rows", async ({
+  test("grid mode with preview: scrub = drag the playhead; cards keep select, drill and hold-drag", async ({
     page,
   }) => {
     // Narrow viewport → few responsive columns, so the 4 project clips wrap
-    // onto at least two rows (needed to exercise the vertical row scrub).
+    // onto at least two rows (needed to exercise the cross-row scrub).
     await page.setViewportSize({ width: 420, height: 900 });
     await installGraphApi(page);
     await openGraph(page);
@@ -1238,39 +1248,36 @@ test.describe("graph view E2E", () => {
         return m ? { x: Number(m[1]), y: Number(m[2]) } : { x: 0, y: 0 };
       });
 
-    // Positions are taken RELATIVE TO THE SCRUB SURFACE, which overlays the
-    // grid exactly — so its interior offsets are layout-independent (the
-    // preview pane above settles asynchronously and shifts absolute page
-    // coords). scrub.hover() also waits for a stable box before pressing.
-    // Content geometry at the default MD size: 9px border+padding, cell
-    // 160×100, 8px gap → row pitch 108, a cell's vertical center ≈ 9 + 50 =
-    // 59 below the scrub top.
-    const scrub = page.locator("[data-grid-scrub]");
-    const ROW0_Y = 59;
-    const ROW1_Y = 59 + 108;
+    // The full-cover scrub surface is GONE (it ate every card pointerdown —
+    // R7 #5/#6/#7): the playhead itself is the scrub affordance now. Its
+    // enlarged handle spans the marker line; grab it and drag. hover() waits
+    // for a stable box first (the pane above settles asynchronously).
+    const handle = playhead.locator("[data-graph-grid-playhead-handle]");
+    // Content geometry at the default MD size: cell 160×100, 8px gap → row
+    // pitch 108.
+    const ROW_PITCH = 108;
 
     // Horizontal scrub across row 0 → x advances, still on row 0.
-    await scrub.hover({ position: { x: 30, y: ROW0_Y } });
+    await handle.hover();
     await page.mouse.down();
-    const sb = (await scrub.boundingBox())!;
-    await page.mouse.move(sb.x + 150, sb.y + ROW0_Y, { steps: 8 });
+    const start = (await playhead.boundingBox())!;
+    await page.mouse.move(start.x + 150, start.y + 50, { steps: 8 });
     await page.mouse.up();
     await expect.poll(async () => (await translate()).x).toBeGreaterThan(100);
     expect((await translate()).y).toBeLessThan(52); // still the first row
 
-    // Vertical scrub: press into the SECOND row → the playhead jumps a row
-    // down (time lands on a later clip). This is the grid-only affordance.
-    await scrub.hover({ position: { x: 89, y: ROW1_Y } });
+    // Cross-row scrub: drag the handle INTO the second row → the playhead
+    // jumps a row down (time lands on a later clip).
+    await handle.hover();
     await page.mouse.down();
-    await page.mouse.move(sb.x + 93, sb.y + ROW1_Y, { steps: 4 });
+    const mid = (await playhead.boundingBox())!;
+    await page.mouse.move(mid.x + 4, mid.y + 50 + ROW_PITCH, { steps: 4 });
     await page.mouse.up();
     await expect.poll(async () => (await translate()).y).toBeGreaterThan(80);
 
-    // Grids are CONTENT-HEIGHT now (the `height` prop is only a max): every
-    // row gets room and the PAGE owns vertical scroll, so there is no
-    // internal scroll for the scrub surface's wheel handler to feed. It must
-    // stand down — a consumed wheel here would scroll nothing and dead-zone
-    // the page. Asserted via defaultPrevented observed at window.
+    // Grids are CONTENT-HEIGHT (the `height` prop is only a max): every row
+    // gets room and the PAGE owns vertical scroll. Nothing may consume the
+    // wheel — asserted via defaultPrevented observed at window.
     expect(await grid.evaluate((el) => el.scrollHeight - el.clientHeight)).toBeLessThanOrEqual(1);
 
     await page.evaluate(() => {
@@ -1283,12 +1290,39 @@ test.describe("graph view E2E", () => {
     const wheelLog = () =>
       page.evaluate(() => (window as unknown as { __wheelLog: boolean[] }).__wheelLog);
 
-    await scrub.hover({ position: { x: 89, y: ROW0_Y } });
+    await grid.hover({ position: { x: 89, y: 59 } });
     await page.mouse.wheel(0, 100);
     // NOT consumed: the event keeps its default (the page scroll), and the
     // grid itself never moved.
     await expect.poll(async () => (await wheelLog()).includes(false)).toBe(true);
     expect(await grid.evaluate((el) => el.scrollTop)).toBe(0);
+    // Rewind the page scroll the wheel just caused before measuring cards.
+    await page.evaluate(() => window.scrollTo(0, 0));
+
+    // With the surface gone the cards OWN their pixels again, preview on:
+
+    // SELECT (R7 #7): a plain click toggles selection. (Retried: under load
+    // a press can outlast the 250ms hold threshold and become a grab, whose
+    // click is — correctly — suppressed.)
+    const alpha = grid.locator('[data-node-id="alpha"]');
+    await expect(async () => {
+      await alpha.click();
+      await expect(alpha).toHaveAttribute("data-selected", "true", { timeout: 700 });
+    }).toPass({ timeout: 10000 });
+
+    // HOLD-DRAG (R7 #6): press-and-hold alpha, travel past bravo → reorder.
+    const bravo = grid.locator('[data-node-id="bravo"]');
+    await holdDrag(page, alpha, bravo, 0.9);
+    await expect
+      .poll(() => gridOrder(page, PROJECT_ID))
+      .toEqual(["bravo", "alpha", CHILD_ID, "charlie"]);
+
+    // DRILL (R7 #5): the collection card's folder button navigates.
+    const collectionWrapper = grid.locator(`[data-node-wrapper="${CHILD_ID}"]`);
+    await expect(async () => {
+      await collectionWrapper.getByRole("button", { name: /^Open / }).click();
+      await page.waitForURL(`**${GRAPH_URL}/${CHILD_ID}`, { timeout: 3000 });
+    }).toPass({ timeout: 15000 });
   });
 
   test("crafted focus URLs are rejected; valid deep links still work", async ({ page }) => {


### PR DESCRIPTION
Item 1: the "Patch-scoped document writes" SyncPanel renders only with a
truthy ?dev query param (read via useSearchParams; the graph tree is
client-only so no Suspense implications).

Items 2/3: app-registered OverviewContent for the trim overview samples
each slot at its own source time via the videoFrameUrls seam (the package
default tiled 1-2 posters by modulo — every frame identical with one
poster), drops the "full clip x.xs" readout, and videoFrameUrls pins the
LAST slot to the range end minus a 0.05s back-off so both the card
filmstrip and the overview finish on the clip's final frame.

Item 4: the ruler band fills each collection card's tick-less stretch with
its content duration (new pure buildRulerCollectionSpans, windowed like the
ticks), instead of leaving the opaque band empty.

Items 5/6/7: grid scrubbing is DRAG THE PLAYHEAD — the full-cover
GraphGridScrubSurface (which ate every card pointerdown while preview was
on: no select, no drill, no hold-drag) is removed from the board and
sub-timeline rows; GraphGridPlayhead gained an enlarged pointer-events-auto
grab handle wired to the same grid time map, so cross-row scrubs still work.

Item 8: the sidebar aside is z-50 (sticky = own stacking context, so its
tooltips' z-50 was trapped under the preview's later-in-DOM z-40).

Tests: videoFrameUrls last-pin unit tests + buildRulerCollectionSpans unit
tests (fail-first proven), TrimOverviewSamplesDistinctFrames story
(fail-first proven vs modulo tiling), grid e2e rewritten for the new model
(playhead drag, select, hold-drag reorder, drill — all with preview on),
preview-height e2e adapted to the shorter dev-gated page.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
