### PR TITLE
Grid seek rails: per-row scrub with playhead lockstep

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -41,6 +41,7 @@ import {
   GraphGridPlayhead,
   GraphPlayhead,
   GraphRuler,
+  GraphSeekRail,
   PlayheadScrubBand,
   PreviewShell,
   collectionCardWidth,
@@ -416,34 +417,47 @@ export function GraphBoard({
               )}
             </NativeDropStrip>
           ) : (
-            // No scrub surface sibling anymore: grid scrubbing is DRAG THE
-            // PLAYHEAD (inside the overlay slot) — the old full-cover surface
-            // ate every card pointerdown while preview was on (R7 #5/#6/#7).
-            <NativeDropGrid collectionId={focusedId}>
-              <VirtualGrid
-                collectionId={parseNodeId(focusedId)}
-                cellWidth={dims.gridWidth}
-                cellHeight={dims.gridHeight}
-                gap={GRID_GAP}
-                height={GRID_UNCAPPED_HEIGHT}
-                // Mirror the strip: a quick tap is a CLICK (so the in-card
-                // drill button works) and a press-and-hold starts the reorder
-                // drag. "body" (the default) drags instantly, which ate the
-                // drill click and made drags ambiguous.
-                itemDragActivation="hold"
-                overlay={
-                  previewOn ? (
-                    <GraphGridPlayhead
-                      focusedId={focusedId}
-                      channel={timeChannel}
-                      cellHeight={dims.gridHeight}
-                      pixelsPerSecond={deferredPixelsPerSecond}
-                    />
-                  ) : undefined
-                }
-                className="bg-black/25"
-              />
-            </NativeDropGrid>
+            // Grid scrubbing is the SEEK RAIL above the grid — one slim,
+            // always-visible slider (the video-player idiom), so cards keep
+            // every pointerdown (the old full-cover surface ate them all —
+            // R7 #5/#6/#7) and the in-grid playhead line stays a passive
+            // indicator. The rail sits OUTSIDE NativeDropGrid: its drop
+            // math measures its own wrapper, and the rail is not a drop
+            // surface.
+            <div className="flex flex-col gap-1.5">
+              {previewOn && (
+                <GraphSeekRail
+                  focusedId={focusedId}
+                  channel={timeChannel}
+                  pixelsPerSecond={deferredPixelsPerSecond}
+                />
+              )}
+              <NativeDropGrid collectionId={focusedId}>
+                <VirtualGrid
+                  collectionId={parseNodeId(focusedId)}
+                  cellWidth={dims.gridWidth}
+                  cellHeight={dims.gridHeight}
+                  gap={GRID_GAP}
+                  height={GRID_UNCAPPED_HEIGHT}
+                  // Mirror the strip: a quick tap is a CLICK (so the in-card
+                  // drill button works) and a press-and-hold starts the reorder
+                  // drag. "body" (the default) drags instantly, which ate the
+                  // drill click and made drags ambiguous.
+                  itemDragActivation="hold"
+                  overlay={
+                    previewOn ? (
+                      <GraphGridPlayhead
+                        focusedId={focusedId}
+                        channel={timeChannel}
+                        cellHeight={dims.gridHeight}
+                        pixelsPerSecond={deferredPixelsPerSecond}
+                      />
+                    ) : undefined
+                  }
+                  className="bg-black/25"
+                />
+              </NativeDropGrid>
+            </div>
           )}
 
           {/* Children render one size step below the focused timeline (flat —

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -41,7 +41,7 @@ import {
   GraphGridPlayhead,
   GraphPlayhead,
   GraphRuler,
-  GraphSeekRail,
+  GraphSeekRails,
   PlayheadScrubBand,
   PreviewShell,
   collectionCardWidth,
@@ -417,21 +417,15 @@ export function GraphBoard({
               )}
             </NativeDropStrip>
           ) : (
-            // Grid scrubbing is the SEEK RAIL above the grid — one slim,
-            // always-visible slider (the video-player idiom), so cards keep
+            // Grid scrubbing is the per-row SEEK RAILS layer — one slim
+            // slider in the gap above each row (the video-player idiom, in
+            // lockstep with the playhead line on every row), so cards keep
             // every pointerdown (the old full-cover surface ate them all —
             // R7 #5/#6/#7) and the in-grid playhead line stays a passive
-            // indicator. The rail sits OUTSIDE NativeDropGrid: its drop
-            // math measures its own wrapper, and the rail is not a drop
-            // surface.
-            <div className="flex flex-col gap-1.5">
-              {previewOn && (
-                <GraphSeekRail
-                  focusedId={focusedId}
-                  channel={timeChannel}
-                  pixelsPerSecond={deferredPixelsPerSecond}
-                />
-              )}
+            // indicator. The layer overlays the grid as a SIBLING (outside
+            // NativeDropGrid, whose drop math measures its own wrapper, and
+            // outside the aria-hidden overlay — rails are focusable).
+            <div className="relative">
               <NativeDropGrid collectionId={focusedId}>
                 <VirtualGrid
                   collectionId={parseNodeId(focusedId)}
@@ -457,6 +451,14 @@ export function GraphBoard({
                   className="bg-black/25"
                 />
               </NativeDropGrid>
+              {previewOn && (
+                <GraphSeekRails
+                  focusedId={focusedId}
+                  channel={timeChannel}
+                  cellHeight={dims.gridHeight}
+                  pixelsPerSecond={deferredPixelsPerSecond}
+                />
+              )}
             </div>
           )}
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -258,6 +258,12 @@ const GraphClipContent = memo(function GraphClipContent({
       ref={cardSizeRef}
       className={[
         "relative flex h-full w-full overflow-hidden rounded-md bg-zinc-900",
+        // GRID cells only: inset the artwork like the collection card does
+        // (its p-1.5 frame + label row keep its pixels off the cell edges),
+        // so media and collections read as the SAME height and the artwork
+        // stays clear of the seek rail riding the gap above. The strip
+        // keeps its full-bleed filmstrip (width there IS duration).
+        "[[data-virtual-grid]_&]:p-1.5",
         selected ? "ring-2 ring-amber-400" : "ring-1 ring-white/15",
         rejected ? "ring-2 ring-red-500 motion-safe:animate-pulse" : "",
         isDragSource ? "opacity-40" : "",
@@ -268,7 +274,7 @@ const GraphClipContent = memo(function GraphClipContent({
           No preview
         </span>
       ) : (
-        <span className="flex h-full w-full">
+        <span className="flex h-full w-full [[data-virtual-grid]_&]:overflow-hidden [[data-virtual-grid]_&]:rounded-sm">
           {frameSrcs.map((src, index) => (
             // eslint-disable-next-line @next/next/no-img-element
             <img

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -483,7 +483,7 @@ export function GraphGridPlayhead({
     let lastCellWidth = 0;
     let map: GridPlayheadMap | null = null;
 
-    const ensureMap = (): GridPlayheadMap | null => {
+    const paint = () => {
       const graph = store.getSnapshot().graph;
       const details = detailsStore.read();
       const columns = Number(grid?.dataset.gridColumns) || 1;
@@ -508,67 +508,17 @@ export function GraphGridPlayhead({
           cellHeight,
         );
       }
-      return map;
-    };
-
-    const paint = () => {
-      const current = ensureMap();
-      if (!current) return;
+      if (!map) return;
       const time = channel.get();
       const inside =
         !activeWindow || (time >= activeWindow.start - 0.04 && time <= activeWindow.end + 0.04);
       line.style.display = inside ? "" : "none";
       if (!inside) return;
-      const { x, y } = current.posAt(time);
+      const { x, y } = map.posAt(time);
       line.style.transform = `translate(${x}px, ${y}px)`;
-      line.style.height = `${current.rowHeight}px`;
+      line.style.height = `${map.rowHeight}px`;
     };
 
-    // Scrub = DRAG THE PLAYHEAD (R7 #5/#6/#7). The full-cover scrub surface
-    // this grid used to carry ate every card pointerdown while preview was
-    // on — no select, no drill, no hold-drag. Now the cards own their
-    // pixels again and the playhead itself is the only scrub affordance:
-    // its (enlarged) handle captures the pointer and maps x/y through the
-    // same grid time map the old surface used, so cross-row scrubs still
-    // work — drag the handle onto another row and it jumps there.
-    const seek = (event: PointerEvent) => {
-      const current = ensureMap();
-      if (!current || !grid) return;
-      const overlay = grid.querySelector<HTMLElement>("[data-virtual-grid-overlay]");
-      const rect = (overlay ?? grid).getBoundingClientRect();
-      channel.set(current.timeAt(event.clientX - rect.left, event.clientY - rect.top));
-    };
-
-    let pointerId: number | null = null;
-    const handleMove = (event: PointerEvent) => {
-      if (event.pointerId === pointerId) seek(event);
-    };
-    const end = (event: PointerEvent) => {
-      if (event.pointerId !== pointerId) return;
-      pointerId = null;
-      window.removeEventListener("pointermove", handleMove);
-      window.removeEventListener("pointerup", end);
-      window.removeEventListener("pointercancel", end);
-    };
-    const handleDown = (event: PointerEvent) => {
-      if (!event.isPrimary || event.button !== 0) return;
-      // The handle sits inside the aria-hidden overlay layer; nothing else
-      // must see this press (a card behind it would treat it as a select).
-      event.stopPropagation();
-      event.preventDefault();
-      pointerId = event.pointerId;
-      try {
-        line.setPointerCapture(event.pointerId);
-      } catch {
-        // Synthetic pointer: window listeners still own the lifecycle.
-      }
-      seek(event);
-      window.addEventListener("pointermove", handleMove);
-      window.addEventListener("pointerup", end);
-      window.addEventListener("pointercancel", end);
-    };
-
-    line.addEventListener("pointerdown", handleDown);
     paint();
     const unsubscribeTime = channel.subscribe(paint);
     const unsubscribeStore = store.subscribe(paint);
@@ -576,10 +526,6 @@ export function GraphGridPlayhead({
     const observer = grid ? new ResizeObserver(paint) : null;
     if (grid && observer) observer.observe(grid);
     return () => {
-      line.removeEventListener("pointerdown", handleDown);
-      window.removeEventListener("pointermove", handleMove);
-      window.removeEventListener("pointerup", end);
-      window.removeEventListener("pointercancel", end);
       unsubscribeTime();
       unsubscribeStore();
       unsubscribeDetails();
@@ -587,20 +533,186 @@ export function GraphGridPlayhead({
     };
   }, [store, detailsStore, focusedId, channel, cellHeight, spans, pixelsPerSecond, activeWindow]);
 
+  // PASSIVE indicator: all scrubbing lives on the GraphSeekRail above the
+  // grid (one obvious control), so the line paints position and takes no
+  // pointer — cards keep every gesture underneath it.
   return (
-    // pointer-events re-enabled DELIBERATELY: the overlay wrapper is
-    // pointer-events-none so cards stay interactive; only this handle takes
-    // the pointer back. It stays pointer-only and unfocusable (the wrapper
-    // is aria-hidden — a focusable child there would be a keyboard trap).
     <div
       ref={lineRef}
       data-graph-grid-playhead
-      className="pointer-events-auto absolute left-0 top-0 w-0.5 cursor-ew-resize bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.9)]"
+      className="absolute left-0 top-0 w-0.5 bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.9)]"
     >
       <div className="absolute -left-[5px] -top-2 h-0 w-0 border-x-[6px] border-t-[8px] border-x-transparent border-t-red-500" />
-      {/* Invisible enlarged grab zone: the 2px line alone is unhittable.
-          Spans the cap and the full line height, ~17px wide. */}
-      <div data-graph-grid-playhead-handle className="absolute -inset-x-2 -top-2 bottom-0" />
+    </div>
+  );
+}
+
+/** Keyboard step for the seek rail: one nudge per arrow press. */
+const SEEK_RAIL_STEP_SECONDS = 1;
+
+/**
+ * The grid's one scrub control: a slim seek bar above the grid — the
+ * universal video-player idiom, so it needs no explanation. Pointer: press
+ * or drag anywhere on the rail (pointer capture keeps the drag smooth past
+ * its edges). Keyboard: it is a real `role="slider"` — Tab reaches it,
+ * arrows nudge by a second, Home/End jump to the ends. Clip boundaries show
+ * as faint ticks.
+ *
+ * The rail maps its width LINEARLY over the timeline's clock window
+ * ([first card start, last card end] of `childSpans` — the focused grid
+ * starts at 0; a sub-timeline's window sits inside the shared global clock,
+ * so its rail both summons the playhead into that row and scrubs it). The
+ * in-grid line (`GraphGridPlayhead`) is a passive twin reading the same
+ * channel. Cards are untouched: click selects, hold drags, the folder
+ * button drills.
+ *
+ * Renders as a normal sibling ABOVE the grid — not in the aria-hidden
+ * overlay (it is focusable) and not covering any card pixels.
+ */
+export function GraphSeekRail({
+  focusedId,
+  channel,
+  pixelsPerSecond,
+  ariaLabel = "Seek preview",
+}: Readonly<{
+  focusedId: string;
+  channel: PreviewTimeChannel;
+  pixelsPerSecond: number;
+  ariaLabel?: string;
+}>) {
+  const store = useCollectionsStore();
+  const detailsStore = useGraphDetailsStore();
+  const spans = useContext(PreviewCardSpansContext);
+  const railRef = useRef<HTMLDivElement>(null);
+  const fillRef = useRef<HTMLDivElement>(null);
+  const thumbRef = useRef<HTMLDivElement>(null);
+  const pointerIdRef = useRef<number | null>(null);
+
+  const graph = useSyncExternalStore(
+    store.subscribe,
+    () => store.getSnapshot().graph,
+    () => store.getSnapshot().graph,
+  );
+  const details = useSyncExternalStore(
+    detailsStore.subscribe,
+    () => detailsStore.read(),
+    () => detailsStore.read(),
+  );
+  const { start, end, boundaries } = useMemo(() => {
+    const cards = childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond));
+    if (cards.length === 0) return { start: 0, end: 0, boundaries: [] as number[] };
+    const first = cards[0].startTime;
+    const last = cards[cards.length - 1].endTime;
+    const span = Math.max(last - first, 1e-6);
+    // Interior clip boundaries as fractions of the rail (the outer edges ARE
+    // the rail's ends).
+    return {
+      start: first,
+      end: last,
+      boundaries: cards.slice(1).map((card) => (card.startTime - first) / span),
+    };
+  }, [graph, details, spans, focusedId, pixelsPerSecond]);
+
+  // Thumb/fill/aria track the channel imperatively — time moves at pointer
+  // rate during a scrub, which is no reason to re-render the rail.
+  useEffect(() => {
+    const rail = railRef.current;
+    const fill = fillRef.current;
+    const thumb = thumbRef.current;
+    if (!rail || !fill || !thumb) return;
+    const paint = () => {
+      const span = Math.max(end - start, 1e-6);
+      const fraction = Math.min(1, Math.max(0, (channel.get() - start) / span));
+      fill.style.width = `${fraction * 100}%`;
+      thumb.style.left = `${fraction * 100}%`;
+      rail.setAttribute("aria-valuenow", (fraction * (end - start)).toFixed(1));
+      rail.setAttribute(
+        "aria-valuetext",
+        `${(fraction * (end - start)).toFixed(1)} of ${(end - start).toFixed(1)} seconds`,
+      );
+    };
+    paint();
+    return channel.subscribe(paint);
+  }, [channel, start, end]);
+
+  const seekToPointer = (event: React.PointerEvent<HTMLDivElement>) => {
+    const rail = railRef.current;
+    if (!rail) return;
+    const rect = rail.getBoundingClientRect();
+    const fraction = Math.min(1, Math.max(0, (event.clientX - rect.left) / Math.max(1, rect.width)));
+    channel.set(start + fraction * (end - start));
+  };
+
+  return (
+    <div
+      ref={railRef}
+      data-graph-seek-rail
+      role="slider"
+      tabIndex={0}
+      aria-label={ariaLabel}
+      aria-orientation="horizontal"
+      aria-valuemin={0}
+      aria-valuemax={Number((end - start).toFixed(1))}
+      aria-valuenow={0}
+      title="Drag to preview"
+      onPointerDown={(event) => {
+        if (!event.isPrimary || event.button !== 0) return;
+        event.preventDefault();
+        pointerIdRef.current = event.pointerId;
+        try {
+          event.currentTarget.setPointerCapture(event.pointerId);
+        } catch {
+          // Synthetic pointer without capture support: moves still arrive
+          // while the pointer stays over the rail, which tests rely on.
+        }
+        seekToPointer(event);
+      }}
+      onPointerMove={(event) => {
+        if (event.pointerId === pointerIdRef.current) seekToPointer(event);
+      }}
+      onPointerUp={(event) => {
+        if (event.pointerId === pointerIdRef.current) pointerIdRef.current = null;
+      }}
+      onPointerCancel={(event) => {
+        if (event.pointerId === pointerIdRef.current) pointerIdRef.current = null;
+      }}
+      onKeyDown={(event) => {
+        if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
+        const current = channel.get();
+        if (event.key === "ArrowLeft" || event.key === "ArrowDown") {
+          channel.set(Math.max(start, current - SEEK_RAIL_STEP_SECONDS));
+        } else if (event.key === "ArrowRight" || event.key === "ArrowUp") {
+          channel.set(Math.min(end, current + SEEK_RAIL_STEP_SECONDS));
+        } else if (event.key === "Home") {
+          channel.set(start);
+        } else if (event.key === "End") {
+          channel.set(end);
+        } else {
+          return;
+        }
+        event.preventDefault();
+      }}
+      className="group relative h-2.5 w-full cursor-ew-resize touch-none rounded-full bg-zinc-800/80 ring-1 ring-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+    >
+      {/* Elapsed fill, then boundary ticks, then the thumb on top. */}
+      <div
+        ref={fillRef}
+        aria-hidden="true"
+        className="absolute inset-y-0 left-0 rounded-full bg-red-500/25"
+      />
+      {boundaries.map((fraction, index) => (
+        <span
+          key={index}
+          aria-hidden="true"
+          className="absolute inset-y-0 w-px bg-white/25"
+          style={{ left: `${fraction * 100}%` }}
+        />
+      ))}
+      <div
+        ref={thumbRef}
+        aria-hidden="true"
+        className="absolute top-1/2 h-3.5 w-3.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.7)] ring-2 ring-zinc-950 transition-transform group-hover:scale-110"
+      />
     </div>
   );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -37,6 +37,7 @@ import {
   nextManifestClipsState,
   nextManifestFailureCount,
   shouldRetryManifestFetch,
+  type ChildSpan,
   type GridPlayheadMap,
   type PlayheadMap,
   type PreviewCardSpans,
@@ -560,19 +561,27 @@ type SeekRailGeometry = Readonly<{
 
 /**
  * One row's seek rail: a slim slider lying in the gap directly above its
- * row of cells, mapping EXACTLY that row's cell geometry — so the thumb
+ * row of cells, spanning EXACTLY that row's cell geometry — so the thumb
  * rides in lockstep above the in-grid playhead line whenever the time is
  * inside this row, and the boundary ticks sit on the real cell edges
- * below. Rows other than the one containing the current time render an
- * empty track (no thumb/fill); pressing one summons the playhead into it.
+ * below. The rails together read as ONE segmented progress bar: rows the
+ * playhead has passed show a full fill, rows ahead sit empty, and only
+ * the row containing the current time carries the thumb. Pressing any
+ * rail summons the playhead into that row.
  *
- * Pointer: press/drag anywhere (pointer capture keeps the drag smooth).
+ * Pointer: press/drag anywhere (pointer capture keeps the drag smooth) —
+ * and the drag CONTINUES past the rail's ends: seeking goes through the
+ * whole timeline's unwrapped map at this row's offset, so overshooting
+ * the row's tail scrubs on into the next row's clips (and dragging left
+ * past its head backs into the previous row) at the same pixel rate.
  * Keyboard: a real `role="slider"` scoped to this row's time window —
  * arrows nudge by a second, Home/End jump to the row's ends.
  */
 function SeekRailRow({
   rowCards,
   isLastRow,
+  map,
+  offsetX,
   cellWidth,
   x,
   y,
@@ -582,6 +591,10 @@ function SeekRailRow({
 }: Readonly<{
   rowCards: readonly ChildSpan[];
   isLastRow: boolean;
+  /** The WHOLE timeline's unwrapped cell map (all cards in one line). */
+  map: GridPlayheadMap;
+  /** This row's left edge inside that unwrapped line, in px. */
+  offsetX: number;
   cellWidth: number;
   x: number;
   y: number;
@@ -599,12 +612,6 @@ function SeekRailRow({
   const extent = Math.max(1, cells * pitch - GRID_GAP);
   const rowStart = rowCards[0].startTime;
   const rowEnd = rowCards[cells - 1].endTime;
-  // The row's own piecewise map: its cells laid in one line — which they
-  // already are — so fraction·extent IS the in-grid x of the line.
-  const map = useMemo(
-    () => buildGridPlayheadMap(rowCards, cells, cellWidth, 1),
-    [rowCards, cells, cellWidth],
-  );
 
   // Thumb/fill/aria track the channel imperatively — time moves at pointer
   // rate during a scrub, no reason to re-render. Deps cover everything the
@@ -619,10 +626,13 @@ function SeekRailRow({
       // A time exactly on a row boundary belongs to the NEXT row (its
       // cell's start), except the very end of the last row.
       const active = time >= rowStart && (isLastRow ? time <= rowEnd : time < rowEnd);
-      fill.style.visibility = active ? "" : "hidden";
       thumb.style.visibility = active ? "" : "hidden";
+      // Cumulative fill: clamping into the row's window paints a PASSED row
+      // full (clamped = rowEnd → fraction 1) and a not-yet-reached row
+      // empty (clamped = rowStart → fraction 0), so the stack of rails
+      // reads as one continuous progress bar.
       const clamped = Math.min(rowEnd, Math.max(rowStart, time));
-      const fraction = Math.min(1, Math.max(0, map.posAt(clamped).x / extent));
+      const fraction = Math.min(1, Math.max(0, (map.posAt(clamped).x - offsetX) / extent));
       fill.style.width = `${fraction * 100}%`;
       thumb.style.left = `${fraction * 100}%`;
       rail.setAttribute("aria-valuenow", (clamped - rowStart).toFixed(1));
@@ -633,17 +643,17 @@ function SeekRailRow({
     };
     paint();
     return channel.subscribe(paint);
-  }, [channel, map, extent, rowStart, rowEnd, isLastRow]);
+  }, [channel, map, offsetX, extent, rowStart, rowEnd, isLastRow]);
 
   const seekToPointer = (event: React.PointerEvent<HTMLDivElement>) => {
     const rail = railRef.current;
     if (!rail) return;
     const rect = rail.getBoundingClientRect();
-    const fraction = Math.min(
-      1,
-      Math.max(0, (event.clientX - rect.left) / Math.max(1, rect.width)),
-    );
-    channel.set(map.timeAt(fraction * extent, 0));
+    // Deliberately UNCLAMPED to this rail: the pointer's x rides the whole
+    // timeline's unwrapped line at this row's offset, so a drag that
+    // overshoots either end keeps scrubbing into the neighbouring rows
+    // (timeAt clamps to the timeline's own bounds).
+    channel.set(map.timeAt(offsetX + (event.clientX - rect.left), 0));
   };
 
   return (
@@ -696,27 +706,34 @@ function SeekRailRow({
         }
         event.preventDefault();
       }}
-      className="group pointer-events-auto absolute cursor-ew-resize touch-none rounded-full bg-zinc-800/80 ring-1 ring-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+      // Solid track, not a translucency: the rail sits over the grid's own
+      // dark backdrop, where a see-through zinc melted away entirely — the
+      // user read row 1 as having "no rail" (R7 follow-up).
+      className="group pointer-events-auto absolute cursor-ew-resize touch-none rounded-full bg-zinc-700 shadow-[inset_0_1px_2px_rgba(0,0,0,0.6)] ring-1 ring-white/25 transition-shadow hover:ring-white/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
       style={{ left: x, top: y, width: extent, height: GRID_GAP }}
     >
       {/* Elapsed fill, then boundary ticks, then the thumb on top. */}
       <div
         ref={fillRef}
         aria-hidden="true"
-        className="absolute inset-y-0 left-0 rounded-full bg-red-500/25"
+        className="absolute inset-y-0 left-0 rounded-full bg-red-500/40"
       />
       {rowCards.slice(1).map((_, index) => (
         <span
           key={index}
           aria-hidden="true"
-          className="absolute inset-y-0 w-px bg-white/25"
+          className="absolute inset-y-0 w-px bg-white/30"
           style={{ left: `${(((index + 1) * pitch - GRID_GAP / 2) / extent) * 100}%` }}
         />
       ))}
+      {/* h-2.5, not larger: the rail lives in the 8px row gap, and a taller
+          thumb overhangs onto the cards below — the "item overlaps rail"
+          complaint. 1px of kiss is invisible; the whole rail is the hit
+          target anyway. */}
       <div
         ref={thumbRef}
         aria-hidden="true"
-        className="absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.7)] ring-2 ring-zinc-950 transition-transform group-hover:scale-110"
+        className="absolute top-1/2 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.7)] ring-2 ring-zinc-950 transition-transform group-hover:scale-110"
       />
     </div>
   );
@@ -834,7 +851,18 @@ export function GraphSeekRails({
     return out;
   }, [cards, cardCount, geometry]);
 
-  if (!geometry || rows.length === 0) {
+  // ONE unwrapped map for the whole timeline (every card in a single line):
+  // each row's rail paints and seeks through it at its own offset, which is
+  // what lets a drag run PAST a rail's ends into the neighbouring rows.
+  const fullMap = useMemo(
+    () =>
+      geometry && cardCount > 0
+        ? buildGridPlayheadMap(cards, cardCount, geometry.cellWidth, 1)
+        : null,
+    [cards, cardCount, geometry],
+  );
+
+  if (!geometry || !fullMap || rows.length === 0) {
     // Pre-measure (or empty timeline): nothing to place yet — the observer
     // pass lands within a frame of the grid reporting its layout.
     return <div ref={rootRef} className="pointer-events-none absolute inset-0" />;
@@ -847,6 +875,8 @@ export function GraphSeekRails({
           key={row}
           rowCards={rowCards}
           isLastRow={row === rows.length - 1}
+          map={fullMap}
+          offsetX={row * geometry.columns * (geometry.cellWidth + GRID_GAP)}
           cellWidth={geometry.cellWidth}
           x={geometry.left}
           y={geometry.top + row * (cellHeight + GRID_GAP) - GRID_GAP}

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -547,112 +547,116 @@ export function GraphGridPlayhead({
   );
 }
 
-/** Keyboard step for the seek rail: one nudge per arrow press. */
+/** Keyboard step for the seek rails: one nudge per arrow press. */
 const SEEK_RAIL_STEP_SECONDS = 1;
 
+type SeekRailGeometry = Readonly<{
+  columns: number;
+  cellWidth: number;
+  /** The grid CONTENT origin relative to the rails' own root. */
+  left: number;
+  top: number;
+}>;
+
 /**
- * The grid's one scrub control: a slim seek bar above the grid — the
- * universal video-player idiom, so it needs no explanation. Pointer: press
- * or drag anywhere on the rail (pointer capture keeps the drag smooth past
- * its edges). Keyboard: it is a real `role="slider"` — Tab reaches it,
- * arrows nudge by a second, Home/End jump to the ends. Clip boundaries show
- * as faint ticks.
+ * One row's seek rail: a slim slider lying in the gap directly above its
+ * row of cells, mapping EXACTLY that row's cell geometry — so the thumb
+ * rides in lockstep above the in-grid playhead line whenever the time is
+ * inside this row, and the boundary ticks sit on the real cell edges
+ * below. Rows other than the one containing the current time render an
+ * empty track (no thumb/fill); pressing one summons the playhead into it.
  *
- * The rail maps its width LINEARLY over the timeline's clock window
- * ([first card start, last card end] of `childSpans` — the focused grid
- * starts at 0; a sub-timeline's window sits inside the shared global clock,
- * so its rail both summons the playhead into that row and scrubs it). The
- * in-grid line (`GraphGridPlayhead`) is a passive twin reading the same
- * channel. Cards are untouched: click selects, hold drags, the folder
- * button drills.
- *
- * Renders as a normal sibling ABOVE the grid — not in the aria-hidden
- * overlay (it is focusable) and not covering any card pixels.
+ * Pointer: press/drag anywhere (pointer capture keeps the drag smooth).
+ * Keyboard: a real `role="slider"` scoped to this row's time window —
+ * arrows nudge by a second, Home/End jump to the row's ends.
  */
-export function GraphSeekRail({
-  focusedId,
+function SeekRailRow({
+  rowCards,
+  isLastRow,
+  cellWidth,
+  x,
+  y,
   channel,
-  pixelsPerSecond,
-  ariaLabel = "Seek preview",
+  ariaLabel,
+  rowIndex,
 }: Readonly<{
-  focusedId: string;
+  rowCards: readonly ChildSpan[];
+  isLastRow: boolean;
+  cellWidth: number;
+  x: number;
+  y: number;
   channel: PreviewTimeChannel;
-  pixelsPerSecond: number;
-  ariaLabel?: string;
+  ariaLabel: string;
+  rowIndex: number;
 }>) {
-  const store = useCollectionsStore();
-  const detailsStore = useGraphDetailsStore();
-  const spans = useContext(PreviewCardSpansContext);
   const railRef = useRef<HTMLDivElement>(null);
   const fillRef = useRef<HTMLDivElement>(null);
   const thumbRef = useRef<HTMLDivElement>(null);
   const pointerIdRef = useRef<number | null>(null);
 
-  const graph = useSyncExternalStore(
-    store.subscribe,
-    () => store.getSnapshot().graph,
-    () => store.getSnapshot().graph,
+  const cells = rowCards.length;
+  const pitch = cellWidth + GRID_GAP;
+  const extent = Math.max(1, cells * pitch - GRID_GAP);
+  const rowStart = rowCards[0].startTime;
+  const rowEnd = rowCards[cells - 1].endTime;
+  // The row's own piecewise map: its cells laid in one line — which they
+  // already are — so fraction·extent IS the in-grid x of the line.
+  const map = useMemo(
+    () => buildGridPlayheadMap(rowCards, cells, cellWidth, 1),
+    [rowCards, cells, cellWidth],
   );
-  const details = useSyncExternalStore(
-    detailsStore.subscribe,
-    () => detailsStore.read(),
-    () => detailsStore.read(),
-  );
-  const { start, end, boundaries } = useMemo(() => {
-    const cards = childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond));
-    if (cards.length === 0) return { start: 0, end: 0, boundaries: [] as number[] };
-    const first = cards[0].startTime;
-    const last = cards[cards.length - 1].endTime;
-    const span = Math.max(last - first, 1e-6);
-    // Interior clip boundaries as fractions of the rail (the outer edges ARE
-    // the rail's ends).
-    return {
-      start: first,
-      end: last,
-      boundaries: cards.slice(1).map((card) => (card.startTime - first) / span),
-    };
-  }, [graph, details, spans, focusedId, pixelsPerSecond]);
 
   // Thumb/fill/aria track the channel imperatively — time moves at pointer
-  // rate during a scrub, which is no reason to re-render the rail.
+  // rate during a scrub, no reason to re-render. Deps cover everything the
+  // closure reads, so map/window changes re-subscribe fresh.
   useEffect(() => {
     const rail = railRef.current;
     const fill = fillRef.current;
     const thumb = thumbRef.current;
     if (!rail || !fill || !thumb) return;
     const paint = () => {
-      const span = Math.max(end - start, 1e-6);
-      const fraction = Math.min(1, Math.max(0, (channel.get() - start) / span));
+      const time = channel.get();
+      // A time exactly on a row boundary belongs to the NEXT row (its
+      // cell's start), except the very end of the last row.
+      const active = time >= rowStart && (isLastRow ? time <= rowEnd : time < rowEnd);
+      fill.style.visibility = active ? "" : "hidden";
+      thumb.style.visibility = active ? "" : "hidden";
+      const clamped = Math.min(rowEnd, Math.max(rowStart, time));
+      const fraction = Math.min(1, Math.max(0, map.posAt(clamped).x / extent));
       fill.style.width = `${fraction * 100}%`;
       thumb.style.left = `${fraction * 100}%`;
-      rail.setAttribute("aria-valuenow", (fraction * (end - start)).toFixed(1));
+      rail.setAttribute("aria-valuenow", (clamped - rowStart).toFixed(1));
       rail.setAttribute(
         "aria-valuetext",
-        `${(fraction * (end - start)).toFixed(1)} of ${(end - start).toFixed(1)} seconds`,
+        `${(clamped - rowStart).toFixed(1)} of ${(rowEnd - rowStart).toFixed(1)} seconds`,
       );
     };
     paint();
     return channel.subscribe(paint);
-  }, [channel, start, end]);
+  }, [channel, map, extent, rowStart, rowEnd, isLastRow]);
 
   const seekToPointer = (event: React.PointerEvent<HTMLDivElement>) => {
     const rail = railRef.current;
     if (!rail) return;
     const rect = rail.getBoundingClientRect();
-    const fraction = Math.min(1, Math.max(0, (event.clientX - rect.left) / Math.max(1, rect.width)));
-    channel.set(start + fraction * (end - start));
+    const fraction = Math.min(
+      1,
+      Math.max(0, (event.clientX - rect.left) / Math.max(1, rect.width)),
+    );
+    channel.set(map.timeAt(fraction * extent, 0));
   };
 
   return (
     <div
       ref={railRef}
       data-graph-seek-rail
+      data-row={rowIndex}
       role="slider"
       tabIndex={0}
       aria-label={ariaLabel}
       aria-orientation="horizontal"
       aria-valuemin={0}
-      aria-valuemax={Number((end - start).toFixed(1))}
+      aria-valuemax={Number((rowEnd - rowStart).toFixed(1))}
       aria-valuenow={0}
       title="Drag to preview"
       onPointerDown={(event) => {
@@ -678,21 +682,22 @@ export function GraphSeekRail({
       }}
       onKeyDown={(event) => {
         if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
-        const current = channel.get();
+        const base = Math.min(rowEnd, Math.max(rowStart, channel.get()));
         if (event.key === "ArrowLeft" || event.key === "ArrowDown") {
-          channel.set(Math.max(start, current - SEEK_RAIL_STEP_SECONDS));
+          channel.set(Math.max(rowStart, base - SEEK_RAIL_STEP_SECONDS));
         } else if (event.key === "ArrowRight" || event.key === "ArrowUp") {
-          channel.set(Math.min(end, current + SEEK_RAIL_STEP_SECONDS));
+          channel.set(Math.min(rowEnd, base + SEEK_RAIL_STEP_SECONDS));
         } else if (event.key === "Home") {
-          channel.set(start);
+          channel.set(rowStart);
         } else if (event.key === "End") {
-          channel.set(end);
+          channel.set(rowEnd);
         } else {
           return;
         }
         event.preventDefault();
       }}
-      className="group relative h-2.5 w-full cursor-ew-resize touch-none rounded-full bg-zinc-800/80 ring-1 ring-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+      className="group pointer-events-auto absolute cursor-ew-resize touch-none rounded-full bg-zinc-800/80 ring-1 ring-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+      style={{ left: x, top: y, width: extent, height: GRID_GAP }}
     >
       {/* Elapsed fill, then boundary ticks, then the thumb on top. */}
       <div
@@ -700,19 +705,156 @@ export function GraphSeekRail({
         aria-hidden="true"
         className="absolute inset-y-0 left-0 rounded-full bg-red-500/25"
       />
-      {boundaries.map((fraction, index) => (
+      {rowCards.slice(1).map((_, index) => (
         <span
           key={index}
           aria-hidden="true"
           className="absolute inset-y-0 w-px bg-white/25"
-          style={{ left: `${fraction * 100}%` }}
+          style={{ left: `${(((index + 1) * pitch - GRID_GAP / 2) / extent) * 100}%` }}
         />
       ))}
       <div
         ref={thumbRef}
         aria-hidden="true"
-        className="absolute top-1/2 h-3.5 w-3.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.7)] ring-2 ring-zinc-950 transition-transform group-hover:scale-110"
+        className="absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.7)] ring-2 ring-zinc-950 transition-transform group-hover:scale-110"
       />
+    </div>
+  );
+}
+
+/**
+ * The grid's scrub control: one slim seek rail PER ROW (the video-player
+ * idiom, one lane at a time), each lying in the 8px gap above its row —
+ * row 0's rides the grid's own top padding, so nothing shifts when the
+ * preview toggles. Per-row rails are what keep the thumb positionally in
+ * lockstep with the in-grid playhead line on EVERY row of a multi-row
+ * grid; a single bar over the grid could only ever align with row 0.
+ *
+ * Renders as an absolutely-positioned layer over the grid (a sibling, NOT
+ * inside the aria-hidden overlay — rails are focusable) with pointer
+ * events off everywhere except the rails themselves, so cards keep every
+ * gesture: click selects, hold drags, the folder button drills.
+ *
+ * Geometry comes from the sibling grid's dataset (live column count and
+ * exact rendered cell width) plus its border+padding, observed by BOTH a
+ * ResizeObserver and a MutationObserver — resize alone settles one layout
+ * stale, because it fires before VirtualGrid commits the fresh dataset
+ * (React renders a frame later).
+ */
+export function GraphSeekRails({
+  focusedId,
+  channel,
+  cellHeight,
+  pixelsPerSecond,
+  ariaLabel = "Seek preview",
+}: Readonly<{
+  focusedId: string;
+  channel: PreviewTimeChannel;
+  cellHeight: number;
+  pixelsPerSecond: number;
+  ariaLabel?: string;
+}>) {
+  const store = useCollectionsStore();
+  const detailsStore = useGraphDetailsStore();
+  const spans = useContext(PreviewCardSpansContext);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  const graph = useSyncExternalStore(
+    store.subscribe,
+    () => store.getSnapshot().graph,
+    () => store.getSnapshot().graph,
+  );
+  const details = useSyncExternalStore(
+    detailsStore.subscribe,
+    () => detailsStore.read(),
+    () => detailsStore.read(),
+  );
+  const cards = useMemo(
+    () => childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond)),
+    [graph, details, spans, focusedId, pixelsPerSecond],
+  );
+  const cardCount = cards.length;
+
+  const [geometry, setGeometry] = useState<SeekRailGeometry | null>(null);
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    const grid = root.parentElement?.querySelector<HTMLElement>("[data-virtual-grid]");
+    if (!grid) return;
+    const update = () => {
+      const columns = Number(grid.dataset.gridColumns) || 0;
+      const cellWidth = Number(grid.dataset.gridCellWidth) || 0;
+      if (columns <= 0 || cellWidth <= 0) {
+        setGeometry(null);
+        return;
+      }
+      const styles = getComputedStyle(grid);
+      const rootRect = root.getBoundingClientRect();
+      const gridRect = grid.getBoundingClientRect();
+      const left =
+        gridRect.left -
+        rootRect.left +
+        parseFloat(styles.borderLeftWidth) +
+        parseFloat(styles.paddingLeft);
+      const top =
+        gridRect.top -
+        rootRect.top +
+        parseFloat(styles.borderTopWidth) +
+        parseFloat(styles.paddingTop);
+      setGeometry((previous) =>
+        previous &&
+        previous.columns === columns &&
+        previous.cellWidth === cellWidth &&
+        previous.left === left &&
+        previous.top === top
+          ? previous
+          : { columns, cellWidth, left, top },
+      );
+    };
+    update();
+    const resizes = new ResizeObserver(update);
+    resizes.observe(grid);
+    const mutations = new MutationObserver(update);
+    mutations.observe(grid, {
+      attributes: true,
+      attributeFilter: ["data-grid-cell-width", "data-grid-columns"],
+    });
+    return () => {
+      resizes.disconnect();
+      mutations.disconnect();
+    };
+  }, [cardCount]);
+
+  const rows = useMemo(() => {
+    if (!geometry || cardCount === 0) return [] as (readonly ChildSpan[])[];
+    const out: (readonly ChildSpan[])[] = [];
+    for (let index = 0; index < cardCount; index += geometry.columns) {
+      out.push(cards.slice(index, index + geometry.columns));
+    }
+    return out;
+  }, [cards, cardCount, geometry]);
+
+  if (!geometry || rows.length === 0) {
+    // Pre-measure (or empty timeline): nothing to place yet — the observer
+    // pass lands within a frame of the grid reporting its layout.
+    return <div ref={rootRef} className="pointer-events-none absolute inset-0" />;
+  }
+
+  return (
+    <div ref={rootRef} data-graph-seek-rails className="pointer-events-none absolute inset-0 z-20">
+      {rows.map((rowCards, row) => (
+        <SeekRailRow
+          key={row}
+          rowCards={rowCards}
+          isLastRow={row === rows.length - 1}
+          cellWidth={geometry.cellWidth}
+          x={geometry.left}
+          y={geometry.top + row * (cellHeight + GRID_GAP) - GRID_GAP}
+          channel={channel}
+          rowIndex={row}
+          ariaLabel={rows.length > 1 ? `${ariaLabel}, row ${row + 1}` : ariaLabel}
+        />
+      ))}
     </div>
   );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -28,6 +28,7 @@ import {
   GraphGridPlayhead,
   GraphPlayhead,
   GraphRuler,
+  GraphSeekRail,
   PlayheadScrubBand,
   collectionCardWidth,
   usePreviewCardSpans,
@@ -229,30 +230,41 @@ function SubTimelineNode({
         >
           {surface === "grid" ? (
             // Grid mode now accepts native drops too (a NativeDropGrid),
-            // matching the strip. Scrubbing is drag-the-playhead (R7 #5-#7),
-            // so there is no scrub-surface sibling — cards keep their
-            // pointerdowns even with the preview on.
-            <NativeDropGrid collectionId={id}>
-              <VirtualGrid
-                collectionId={collectionId}
-                cellWidth={dims.gridWidth}
-                cellHeight={dims.gridHeight}
-                gap={GRID_GAP}
-                height={GRID_UNCAPPED_HEIGHT}
-                overlay={
-                  showPlayhead ? (
-                    <GraphGridPlayhead
-                      focusedId={id}
-                      channel={timeChannel}
-                      cellHeight={dims.gridHeight}
-                      pixelsPerSecond={pixelsPerSecond}
-                      activeWindow={clockWindow}
-                    />
-                  ) : undefined
-                }
-                className="bg-black/20"
-              />
-            </NativeDropGrid>
+            // matching the strip. Scrubbing is this row's SEEK RAIL — its
+            // window sits inside the shared clock, so pressing it SUMMONS
+            // the playhead into this timeline; cards keep every pointerdown
+            // and the in-grid line is a passive indicator.
+            <div className="flex min-w-0 flex-col gap-1.5">
+              {showPlayhead && (
+                <GraphSeekRail
+                  focusedId={id}
+                  channel={timeChannel}
+                  pixelsPerSecond={pixelsPerSecond}
+                  ariaLabel={`Seek preview in ${name}`}
+                />
+              )}
+              <NativeDropGrid collectionId={id}>
+                <VirtualGrid
+                  collectionId={collectionId}
+                  cellWidth={dims.gridWidth}
+                  cellHeight={dims.gridHeight}
+                  gap={GRID_GAP}
+                  height={GRID_UNCAPPED_HEIGHT}
+                  overlay={
+                    showPlayhead ? (
+                      <GraphGridPlayhead
+                        focusedId={id}
+                        channel={timeChannel}
+                        cellHeight={dims.gridHeight}
+                        pixelsPerSecond={pixelsPerSecond}
+                        activeWindow={clockWindow}
+                      />
+                    ) : undefined
+                  }
+                  className="bg-black/20"
+                />
+              </NativeDropGrid>
+            </div>
           ) : (
             <NativeDropStrip collectionId={id}>
               <VirtualStrip

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -28,7 +28,7 @@ import {
   GraphGridPlayhead,
   GraphPlayhead,
   GraphRuler,
-  GraphSeekRail,
+  GraphSeekRails,
   PlayheadScrubBand,
   collectionCardWidth,
   usePreviewCardSpans,
@@ -230,19 +230,12 @@ function SubTimelineNode({
         >
           {surface === "grid" ? (
             // Grid mode now accepts native drops too (a NativeDropGrid),
-            // matching the strip. Scrubbing is this row's SEEK RAIL — its
-            // window sits inside the shared clock, so pressing it SUMMONS
-            // the playhead into this timeline; cards keep every pointerdown
-            // and the in-grid line is a passive indicator.
-            <div className="flex min-w-0 flex-col gap-1.5">
-              {showPlayhead && (
-                <GraphSeekRail
-                  focusedId={id}
-                  channel={timeChannel}
-                  pixelsPerSecond={pixelsPerSecond}
-                  ariaLabel={`Seek preview in ${name}`}
-                />
-              )}
+            // matching the strip. Scrubbing is this timeline's per-row SEEK
+            // RAILS layer — its windows sit inside the shared clock, so
+            // pressing a rail SUMMONS the playhead into this timeline;
+            // cards keep every pointerdown and the in-grid line is a
+            // passive indicator.
+            <div className="relative min-w-0">
               <NativeDropGrid collectionId={id}>
                 <VirtualGrid
                   collectionId={collectionId}
@@ -264,6 +257,15 @@ function SubTimelineNode({
                   className="bg-black/20"
                 />
               </NativeDropGrid>
+              {showPlayhead && (
+                <GraphSeekRails
+                  focusedId={id}
+                  channel={timeChannel}
+                  cellHeight={dims.gridHeight}
+                  pixelsPerSecond={pixelsPerSecond}
+                  ariaLabel={`Seek preview in ${name}`}
+                />
+              )}
             </div>
           ) : (
             <NativeDropStrip collectionId={id}>

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1248,42 +1248,80 @@ test.describe("graph view E2E", () => {
         return m ? { x: Number(m[1]), y: Number(m[2]) } : { x: 0, y: 0 };
       });
 
-    // ONE scrub control: the seek rail above the grid — a real slider with
-    // clip-boundary ticks. Cards own all their pixels (the old full-cover
-    // surface ate every pointerdown — R7 #5/#6/#7); the in-grid line is a
-    // passive indicator of the rail's position.
-    const rail = page.getByRole("slider", { name: "Seek preview" });
-    await expect(rail).toBeVisible();
-    await expect(rail.locator("span")).toHaveCount(3); // 4 clips → 3 boundary ticks
+    // The scrub control: one seek rail PER ROW, each in the gap above its
+    // row, mapping exactly that row's cells — so the thumb rides in
+    // lockstep above the playhead line on EVERY row of a multi-row grid.
+    // Cards own all their pixels (the old full-cover surface ate every
+    // pointerdown — R7 #5/#6/#7); the line is a passive indicator.
+    const rows = Math.ceil(4 / cols);
+    expect(rows).toBeGreaterThanOrEqual(2); // multi-row is the case under test
+    const rails = page.locator("[data-graph-seek-rail]");
+    await expect(rails).toHaveCount(rows);
+    const rail0 = page.getByRole("slider", { name: "Seek preview, row 1" });
+    const lastRail = page.getByRole("slider", { name: `Seek preview, row ${rows}` });
+    await expect(rail0).toBeVisible();
 
-    // Press near the rail's start → the line lands on row 0; drag along the
-    // rail toward the end → time crosses into the later clips and the LINE
-    // CHANGES ROWS, no gesture on the grid itself.
-    await rail.hover({ position: { x: 30, y: 5 } });
+    // Each rail spans exactly ITS row's cells: row 0 is full (cols cells),
+    // the LAST row holds the remainder. Measure lands async
+    // (ResizeObserver + MutationObserver), hence polls.
+    const cellW = Number(await grid.getAttribute("data-grid-cell-width"));
+    const lastRowCells = 4 - cols * (rows - 1);
+    await expect
+      .poll(async () => (await rail0.boundingBox())!.width)
+      .toBeCloseTo(cols * (cellW + 8) - 8, 0);
+    await expect
+      .poll(async () => (await lastRail.boundingBox())!.width)
+      .toBeCloseTo(lastRowCells * (cellW + 8) - 8, 0);
+
+    // Press row 0's rail → the line lands on row 0, thumb IN LOCKSTEP
+    // directly above it (same content x — the whole point of per-row
+    // rails); the last row's rail shows no thumb (time is not inside it).
+    await rail0.hover({ position: { x: 30, y: 4 } });
     await page.mouse.down();
-    await expect.poll(async () => (await translate()).y).toBeLessThan(52); // row 0
-    const railBox = (await rail.boundingBox())!;
-    await page.mouse.move(railBox.x + railBox.width * 0.9, railBox.y + 5, { steps: 8 });
     await page.mouse.up();
-    await expect.poll(async () => (await translate()).y).toBeGreaterThan(80); // a later row
+    await expect.poll(async () => (await translate()).y).toBeLessThan(52); // row 0
+    const thumbOf = (rail: Locator) => rail.locator("div").last();
+    const lockstep = async () => {
+      const thumb = (await thumbOf(rail0).boundingBox())!;
+      const line = (await playhead.boundingBox())!;
+      return Math.abs(thumb.x + thumb.width / 2 - (line.x + 1));
+    };
+    await expect.poll(lockstep).toBeLessThanOrEqual(2);
+    await expect(thumbOf(lastRail)).not.toBeVisible(); // parked rows sit empty
 
-    // The rail owns the whole gesture: nothing on the grid got selected.
+    // Press the LAST row's rail → the playhead SUMMONS into that row and
+    // the thumbs swap; still nothing on the grid got selected.
+    const lastBox = (await lastRail.boundingBox())!;
+    await page.mouse.click(lastBox.x + lastBox.width / 2, lastBox.y + 4);
+    await expect.poll(async () => (await translate()).y).toBeGreaterThan(80);
+    await expect(thumbOf(lastRail)).toBeVisible();
+    await expect(thumbOf(rail0)).not.toBeVisible();
     await expect(grid.locator('[data-selected="true"]')).toHaveCount(0);
 
-    // KEYBOARD: the rail is a slider — Home rewinds, arrows nudge by a
-    // second, End jumps to the tail. aria-valuenow tracks the clock.
-    const valueNow = () => rail.evaluate((el) => Number(el.getAttribute("aria-valuenow")));
-    await rail.focus();
+    // Ticks sit on REAL cell edges: pressing row 0's first tick parks the
+    // line exactly at the second clip's cell origin, whatever that clip's
+    // duration. (Float coordinates on purpose: an integer-rounded press can
+    // slip off the 8px gap the tick centres on.) Row 0 has interior ticks
+    // only when it holds more than one cell.
+    if (cols > 1) {
+      const tickBox = (await rail0.locator("span").first().boundingBox())!;
+      await page.mouse.click(tickBox.x + tickBox.width / 2, tickBox.y + 3);
+      await expect.poll(async () => (await translate()).x).toBeCloseTo(cellW + 8, 0);
+      expect((await translate()).y).toBeCloseTo(0, 0);
+    }
+
+    // KEYBOARD: each rail is a slider over ITS row's time window — Home
+    // rewinds the row, arrows nudge by a second, End jumps to the row's
+    // tail. aria-valuenow tracks the clock, row-relative.
+    const valueNow = () => rail0.evaluate((el) => Number(el.getAttribute("aria-valuenow")));
+    await rail0.focus();
     await page.keyboard.press("Home");
     await expect.poll(valueNow).toBe(0);
     await expect.poll(async () => (await translate()).x).toBeLessThan(5); // line rewound too
+    const max = await rail0.evaluate((el) => Number(el.getAttribute("aria-valuemax")));
     await page.keyboard.press("ArrowRight");
-    await page.keyboard.press("ArrowRight");
-    await expect.poll(valueNow).toBe(2);
-    await page.keyboard.press("ArrowLeft");
-    await expect.poll(valueNow).toBe(1);
+    await expect.poll(valueNow).toBe(Math.min(1, max));
     await page.keyboard.press("End");
-    const max = await rail.evaluate((el) => Number(el.getAttribute("aria-valuemax")));
     await expect.poll(valueNow).toBe(max);
 
     // Grids are CONTENT-HEIGHT (the `height` prop is only a max): every row

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1298,6 +1298,32 @@ test.describe("graph view E2E", () => {
     await expect(thumbOf(rail0)).not.toBeVisible();
     await expect(grid.locator('[data-selected="true"]')).toHaveCount(0);
 
+    // CUMULATIVE fill: with the playhead on the last row, every EARLIER
+    // row's rail reads fully scrubbed-through — the rails stack up into one
+    // segmented progress bar. (The fill is the rail's first div child.)
+    const fillOf = (rail: Locator) => rail.locator("div").first();
+    const rail0Box = (await rail0.boundingBox())!;
+    await expect
+      .poll(async () => (await fillOf(rail0).boundingBox())!.width)
+      .toBeCloseTo(rail0Box.width, 0);
+
+    // CONTINUATION: a drag is not caged by its rail. Dragging the LAST
+    // rail left PAST its head backs the scrub into earlier rows' clips…
+    await lastRail.hover({ position: { x: 10, y: 4 } });
+    await page.mouse.down();
+    await page.mouse.move(lastBox.x - cellW, lastBox.y + 4, { steps: 6 });
+    await expect
+      .poll(async () => (await translate()).y)
+      .toBeLessThan((rows - 1) * 108 - 20); // strictly above the last row
+    await page.mouse.up();
+
+    // …and overshooting row 0's tail runs forward into the next row.
+    await rail0.hover({ position: { x: 30, y: 4 } });
+    await page.mouse.down();
+    await page.mouse.move(rail0Box.x + rail0Box.width + 60, rail0Box.y + 4, { steps: 6 });
+    await expect.poll(async () => (await translate()).y).toBeGreaterThan(80);
+    await page.mouse.up();
+
     // Ticks sit on REAL cell edges: pressing row 0's first tick parks the
     // line exactly at the second clip's cell origin, whatever that clip's
     // duration. (Float coordinates on purpose: an integer-rounded press can
@@ -1350,10 +1376,17 @@ test.describe("graph view E2E", () => {
 
     // With the surface gone the cards OWN their pixels again, preview on:
 
+    // Media cards in the GRID inset their artwork like collection cards do
+    // (~6px frame), so both card kinds read as the same height and the
+    // artwork stays clear of the rail above. (The strip keeps full-bleed.)
+    const alpha = grid.locator('[data-node-id="alpha"]');
+    const alphaImgBox = (await alpha.locator("img").first().boundingBox())!;
+    const alphaBox = (await alpha.boundingBox())!;
+    expect(alphaImgBox.y - alphaBox.y).toBeGreaterThanOrEqual(5);
+
     // SELECT (R7 #7): a plain click toggles selection. (Retried: under load
     // a press can outlast the 250ms hold threshold and become a grab, whose
     // click is — correctly — suppressed.)
-    const alpha = grid.locator('[data-node-id="alpha"]');
     await expect(async () => {
       await alpha.click();
       await expect(alpha).toHaveAttribute("data-selected", "true", { timeout: 700 });

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1218,11 +1218,11 @@ test.describe("graph view E2E", () => {
     await expect.poll(translateX).toBeLessThan(20);
   });
 
-  test("grid mode with preview: scrub = drag the playhead; cards keep select, drill and hold-drag", async ({
+  test("grid mode with preview: seek rail scrubs (pointer + keyboard); cards keep select, drill and hold-drag", async ({
     page,
   }) => {
     // Narrow viewport → few responsive columns, so the 4 project clips wrap
-    // onto at least two rows (needed to exercise the cross-row scrub).
+    // onto at least two rows (needed to see the line change rows on seek).
     await page.setViewportSize({ width: 420, height: 900 });
     await installGraphApi(page);
     await openGraph(page);
@@ -1248,32 +1248,43 @@ test.describe("graph view E2E", () => {
         return m ? { x: Number(m[1]), y: Number(m[2]) } : { x: 0, y: 0 };
       });
 
-    // The full-cover scrub surface is GONE (it ate every card pointerdown —
-    // R7 #5/#6/#7): the playhead itself is the scrub affordance now. Its
-    // enlarged handle spans the marker line; grab it and drag. hover() waits
-    // for a stable box first (the pane above settles asynchronously).
-    const handle = playhead.locator("[data-graph-grid-playhead-handle]");
-    // Content geometry at the default MD size: cell 160×100, 8px gap → row
-    // pitch 108.
-    const ROW_PITCH = 108;
+    // ONE scrub control: the seek rail above the grid — a real slider with
+    // clip-boundary ticks. Cards own all their pixels (the old full-cover
+    // surface ate every pointerdown — R7 #5/#6/#7); the in-grid line is a
+    // passive indicator of the rail's position.
+    const rail = page.getByRole("slider", { name: "Seek preview" });
+    await expect(rail).toBeVisible();
+    await expect(rail.locator("span")).toHaveCount(3); // 4 clips → 3 boundary ticks
 
-    // Horizontal scrub across row 0 → x advances, still on row 0.
-    await handle.hover();
+    // Press near the rail's start → the line lands on row 0; drag along the
+    // rail toward the end → time crosses into the later clips and the LINE
+    // CHANGES ROWS, no gesture on the grid itself.
+    await rail.hover({ position: { x: 30, y: 5 } });
     await page.mouse.down();
-    const start = (await playhead.boundingBox())!;
-    await page.mouse.move(start.x + 150, start.y + 50, { steps: 8 });
+    await expect.poll(async () => (await translate()).y).toBeLessThan(52); // row 0
+    const railBox = (await rail.boundingBox())!;
+    await page.mouse.move(railBox.x + railBox.width * 0.9, railBox.y + 5, { steps: 8 });
     await page.mouse.up();
-    await expect.poll(async () => (await translate()).x).toBeGreaterThan(100);
-    expect((await translate()).y).toBeLessThan(52); // still the first row
+    await expect.poll(async () => (await translate()).y).toBeGreaterThan(80); // a later row
 
-    // Cross-row scrub: drag the handle INTO the second row → the playhead
-    // jumps a row down (time lands on a later clip).
-    await handle.hover();
-    await page.mouse.down();
-    const mid = (await playhead.boundingBox())!;
-    await page.mouse.move(mid.x + 4, mid.y + 50 + ROW_PITCH, { steps: 4 });
-    await page.mouse.up();
-    await expect.poll(async () => (await translate()).y).toBeGreaterThan(80);
+    // The rail owns the whole gesture: nothing on the grid got selected.
+    await expect(grid.locator('[data-selected="true"]')).toHaveCount(0);
+
+    // KEYBOARD: the rail is a slider — Home rewinds, arrows nudge by a
+    // second, End jumps to the tail. aria-valuenow tracks the clock.
+    const valueNow = () => rail.evaluate((el) => Number(el.getAttribute("aria-valuenow")));
+    await rail.focus();
+    await page.keyboard.press("Home");
+    await expect.poll(valueNow).toBe(0);
+    await expect.poll(async () => (await translate()).x).toBeLessThan(5); // line rewound too
+    await page.keyboard.press("ArrowRight");
+    await page.keyboard.press("ArrowRight");
+    await expect.poll(valueNow).toBe(2);
+    await page.keyboard.press("ArrowLeft");
+    await expect.poll(valueNow).toBe(1);
+    await page.keyboard.press("End");
+    const max = await rail.evaluate((el) => Number(el.getAttribute("aria-valuemax")));
+    await expect.poll(valueNow).toBe(max);
 
     // Grids are CONTENT-HEIGHT (the `height` prop is only a max): every row
     // gets room and the PAGE owns vertical scroll. Nothing may consume the


### PR DESCRIPTION
## Summary

Replaces grid-mode scrubbing (round 7's drag-the-playhead) with **per-row seek rails** — the video-player idiom, one slim slider in the gap above each grid row:

- **Lockstep**: each rail maps exactly its row's cell geometry, so the thumb rides directly above the in-grid playhead line on every row (e2e-pinned ≤2px). Ticks sit on real cell edges.
- **Summon**: pressing any rail (including a sub-timeline's, via the shared clock) moves the playhead there — a timeline with a hidden playhead is one press away. Plain click stays selection.
- **Segmented progress**: passed rows paint a full fill, rows ahead sit empty; the stack reads as one progress bar.
- **Continuation**: drags aren't caged by their rail — overshooting an end keeps scrubbing into the neighbouring row at the same pixel rate.
- **Keyboard**: every rail is a real `role="slider"` (Tab, arrows ±1s, Home/End, row-relative aria values).
- **Cards untouched**: the in-grid line is a passive indicator again; select / hold-drag / drill all work with preview on. Grid media cards get the collection card's ~6px inset frame so both kinds read the same height and clear the rail (strip stays full-bleed).

## Verification

- graph-view e2e 39/39 — grid test rewritten around the rails: per-row counts/widths, lockstep pin, parked-thumb swap on cross-row summon, tick press → exact cell origin, both continuation directions, cumulative fill, artwork inset, select/hold-drag/drill with preview on
- app vitest 197/197, stories 7/7, lint + tsc clean
- Live-verified in the running app at each step (screenshots in session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)