### PR TITLE
Rail parity: strip matches the grid's rail chrome; artwork inset on both surfaces

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -280,11 +280,12 @@ export const FilmstripResampleSettles: Story = {
     // ResizeObserver + re-render, and well inside the settle delay)…
     host.style.width = "480px";
     await new Promise((resolve) => setTimeout(resolve, 80));
-    expect(previewImages(canvasElement).length).toBeLessThan(5);
+    expect(previewImages(canvasElement).length).toBeLessThan(6);
 
     // …and once the size holds still past the delay, ONE resample lands on
-    // the final count (480 / 96 = 5 frames).
-    await waitFor(() => expect(previewImages(canvasElement)).toHaveLength(5), {
+    // the final count. The measured contentRect excludes the card's p-1.5
+    // artwork frame: (480 − 12) / (96 − 12) ≈ 5.6 → 6 frames.
+    await waitFor(() => expect(previewImages(canvasElement)).toHaveLength(6), {
       timeout: 2000,
     });
   },

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -257,13 +257,13 @@ const GraphClipContent = memo(function GraphClipContent({
     <span
       ref={cardSizeRef}
       className={[
-        "relative flex h-full w-full overflow-hidden rounded-md bg-zinc-900",
-        // GRID cells only: inset the artwork like the collection card does
-        // (its p-1.5 frame + label row keep its pixels off the cell edges),
+        // p-1.5 on BOTH surfaces: the artwork is inset like the collection
+        // card's (its frame + label row keep its pixels off the card edges),
         // so media and collections read as the SAME height and the artwork
-        // stays clear of the seek rail riding the gap above. The strip
-        // keeps its full-bleed filmstrip (width there IS duration).
-        "[[data-virtual-grid]_&]:p-1.5",
+        // stays clear of the seek rail riding above — the strip's rail has
+        // the identical adjacency, so full-bleed pressed into it there too.
+        // The card's outer box (and so width = duration) is unchanged.
+        "relative flex h-full w-full overflow-hidden rounded-md bg-zinc-900 p-1.5",
         selected ? "ring-2 ring-amber-400" : "ring-1 ring-white/15",
         rejected ? "ring-2 ring-red-500 motion-safe:animate-pulse" : "",
         isDragSource ? "opacity-40" : "",
@@ -274,7 +274,7 @@ const GraphClipContent = memo(function GraphClipContent({
           No preview
         </span>
       ) : (
-        <span className="flex h-full w-full [[data-virtual-grid]_&]:overflow-hidden [[data-virtual-grid]_&]:rounded-sm">
+        <span className="flex h-full w-full overflow-hidden rounded-sm">
           {frameSrcs.map((src, index) => (
             // eslint-disable-next-line @next/next/no-img-element
             <img

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -1083,20 +1083,27 @@ export function GraphStripSeekRail({
         revealTime(next);
         event.preventDefault();
       }}
-      className="group absolute z-20 cursor-ew-resize touch-none overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+      // The OUTER element wears the grid rail's exact chrome (rounded pill,
+      // solid track, groove, ring) so both surfaces read as one control —
+      // the window IS the visible track, and it ends at the LAST item when
+      // the timeline fits (min with the extent, exactly like a grid rail).
+      // When the timeline overflows, the pill spans the viewport and the
+      // content layer slides inside it.
+      className="group absolute z-20 cursor-ew-resize touch-none overflow-hidden rounded-full bg-zinc-700 shadow-[inset_0_1px_2px_rgba(0,0,0,0.6)] ring-1 ring-white/25 transition-shadow hover:ring-white/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
       style={
         geometry
-          ? { left: geometry.left, top: geometry.top, width: geometry.width, height: 8 }
+          ? {
+              left: geometry.left,
+              top: geometry.top,
+              width: Math.min(extent, geometry.width),
+              height: 8,
+            }
           : { left: 9, top: 1, right: 9, height: 8 }
       }
     >
-      {/* Content-space strip: as wide as the timeline, translated against
-          the scroller so everything stays glued to its card. */}
-      <div
-        ref={innerRef}
-        className="relative h-full rounded-full bg-zinc-700 shadow-[inset_0_1px_2px_rgba(0,0,0,0.6)] ring-1 ring-white/25 transition-shadow group-hover:ring-white/40"
-        style={{ width: extent }}
-      >
+      {/* Content-space layer: as wide as the timeline, translated against
+          the scroller so fill, ticks and thumb stay glued to their cards. */}
+      <div ref={innerRef} className="relative h-full" style={{ width: extent }}>
         <div
           ref={fillRef}
           data-rail-fill

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1214,6 +1214,13 @@ test.describe("graph view E2E", () => {
       Math.abs(stripThumbBox.x + stripThumbBox.width / 2 - (lineBox.x + 1)),
     ).toBeLessThanOrEqual(2);
 
+    // And STRIP media cards inset their artwork like the grid's (~6px
+    // frame) — full-bleed pressed the pixels into the rail here too.
+    const stripMedia = strip(page, PROJECT_ID).locator('[data-node-id="alpha"]');
+    const stripImgBox = (await stripMedia.locator("img").first().boundingBox())!;
+    const stripCardBox = (await stripMedia.boundingBox())!;
+    expect(stripImgBox.y - stripCardBox.y).toBeGreaterThanOrEqual(5);
+
     // Drill-in RESETS the persistent preview clock: the layout (and with it
     // the time channel) survives navigation, but a different focused
     // timeline is a different clock — without the reset the transport would
@@ -1429,9 +1436,9 @@ test.describe("graph view E2E", () => {
 
     // With the surface gone the cards OWN their pixels again, preview on:
 
-    // Media cards in the GRID inset their artwork like collection cards do
-    // (~6px frame), so both card kinds read as the same height and the
-    // artwork stays clear of the rail above. (The strip keeps full-bleed.)
+    // Media cards inset their artwork like collection cards do (~6px
+    // frame, BOTH surfaces), so both card kinds read as the same height
+    // and the artwork stays clear of the rail above.
     const alpha = grid.locator('[data-node-id="alpha"]');
     const alphaImgBox = (await alpha.locator("img").first().boundingBox())!;
     const alphaBox = (await alpha.boundingBox())!;


### PR DESCRIPTION
## Summary

The grid rail's look is the reference — this brings the strip to exact parity:

- **Rail chrome**: the strip rail's outer window now wears the grid track's exact classes (rounded pill, solid zinc-700, inset groove, ring, hover/focus states) and sizes to `min(extent, viewport)` — ending at the last item when the timeline fits, spanning the viewport with the content layer sliding inside when it overflows. Previously the chrome sat on the scroll-synced inner layer, giving clipped square ends and a rectangular focus ring.
- **Artwork inset**: the p-1.5 media-card frame is unconditional now (was grid-scoped) — strip media cards stop pressing into the rail, both surfaces share one card anatomy, card widths (duration) unchanged.
- Knock-on: `FilmstripResampleSettles` expects 6 frames at 480×96 (measured contentRect excludes the frame).

## Verification

- graph-view e2e 40/40 (adds a strip artwork-inset pin alongside the grid's)
- app vitest 197/197, stories 7/7, lint + tsc clean; live-verified strip inset 6px and pill chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)