### PR TITLE
Preview chrome restyle: slim divider, pale-blue played fill, circle-headed playhead

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -182,14 +182,14 @@ export function GraphPlayhead({
     };
   }, [store, detailsStore, focusedId, channel, spans, pixelsPerSecond, activeWindow]);
 
+  // No cap on the line: the seek rail's circular thumb above IS the
+  // playhead's head now — the old triangle poked up over it.
   return (
     <div
       ref={lineRef}
       data-graph-playhead
       className="absolute inset-y-0 left-0 w-0.5 bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.9)]"
-    >
-      <div className="absolute -left-[5px] -top-2 h-0 w-0 border-x-[6px] border-t-[8px] border-x-transparent border-t-red-500" />
-    </div>
+    />
   );
 }
 
@@ -448,15 +448,14 @@ export function GraphGridPlayhead({
 
   // PASSIVE indicator: all scrubbing lives on the GraphSeekRail above the
   // grid (one obvious control), so the line paints position and takes no
-  // pointer — cards keep every gesture underneath it.
+  // pointer — cards keep every gesture underneath it. No cap on the line:
+  // the row rail's circular thumb above IS the head (same as the strip's).
   return (
     <div
       ref={lineRef}
       data-graph-grid-playhead
       className="absolute left-0 top-0 w-0.5 bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.9)]"
-    >
-      <div className="absolute -left-[5px] -top-2 h-0 w-0 border-x-[6px] border-t-[8px] border-x-transparent border-t-red-500" />
-    </div>
+    />
   );
 }
 
@@ -629,7 +628,7 @@ function SeekRailRow({
         ref={fillRef}
         data-rail-fill
         aria-hidden="true"
-        className="absolute inset-y-0 left-0 rounded-full bg-red-500/40"
+        className="absolute inset-y-0 left-0 rounded-full bg-sky-400/40"
       />
       {rowCards.slice(1).map((_, index) => (
         <span
@@ -1108,7 +1107,7 @@ export function GraphStripSeekRail({
           ref={fillRef}
           data-rail-fill
           aria-hidden="true"
-          className="absolute inset-y-0 left-0 rounded-full bg-red-500/40"
+          className="absolute inset-y-0 left-0 rounded-full bg-sky-400/40"
         />
         {ticks.map((x, index) => (
           <span

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1168,7 +1168,7 @@ test.describe("graph view E2E", () => {
     await expect(redoButton(page)).toBeDisabled();
   });
 
-  test("preview mode: playhead with triangle cap, drag-to-scrub, no layout blowout", async ({
+  test("preview mode: capless playhead line, drag-to-scrub, no layout blowout", async ({
     page,
   }) => {
     await installGraphApi(page);
@@ -1182,11 +1182,12 @@ test.describe("graph view E2E", () => {
       "manifest",
     );
 
-    // Playhead visuals ride the strip's presentational overlay; the triangle
-    // cap is a zero-size bordered div (attached, not "visible").
+    // Playhead visuals ride the strip's presentational overlay. The line is
+    // a bare stem — no cap children: the seek rail's circular thumb above
+    // is the playhead's head.
     const playhead = page.locator("[data-graph-playhead]");
     await expect(playhead).toBeVisible();
-    await expect(playhead.locator("div")).toHaveCount(1);
+    await expect(playhead.locator("div")).toHaveCount(0);
 
     // The preview pane must not blow the page out horizontally (the
     // minmax(0,1fr) grid-track regression).

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -772,6 +772,18 @@ test.describe("graph view E2E", () => {
     await expect.poll(heightOf).toBeGreaterThan(0);
     const initial = await heightOf();
 
+    // Divider restyle: a slim 12px band with a centred grip pill; hovering
+    // tints the WHOLE band gray (the old amber line highlight is gone).
+    expect(
+      await divider.evaluate((el) => Math.round(el.getBoundingClientRect().height)),
+    ).toBe(12);
+    await expect(divider.locator("[data-divider-grip]")).toHaveCount(1);
+    const dividerBg = () => divider.evaluate((el) => getComputedStyle(el).backgroundColor);
+    const restBg = await dividerBg();
+    await divider.hover();
+    await expect.poll(dividerBg).not.toBe(restBg);
+    await page.mouse.move(0, 0); // unhover before the resize steps below
+
     // Expanding a sub-graph grows the content BELOW the preview. The preview
     // used to be fitted to whatever the lower pane left over, so it shrank —
     // its height must now be untouched by content changes.

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -47,9 +47,9 @@ const BUFFER_WINDOW_SIZE = 4;
 const DEFAULT_SURFACE_HEIGHT = 380;
 const MIN_SURFACE_HEIGHT = 120;
 const MIN_TIMELINE_SPACE = 260;
-/** The resize divider's own height (Tailwind h-6). Part of the sticky preview
+/** The resize divider's own height (Tailwind h-3). Part of the sticky preview
  *  region, so the published sticky offset must include it. */
-const DIVIDER_HEIGHT_PX = 24;
+const DIVIDER_HEIGHT_PX = 12;
 
 function clamp(value: number, min: number, max: number) {
   return Math.max(min, Math.min(max, value));
@@ -990,16 +990,28 @@ export function WorkbenchSplitPane({
           aria-label="Resize workbench display"
           // The divider's OWN height is the only source of the gap on either
           // side of the rule: it centres the 1px line, so the space above and
-          // below is h/2 each. Nothing else may add padding against it — the
-          // lower pane used to carry a pt-3 that made the bottom gap 22px
-          // against the top's 10px, which read as a misaligned rule.
-          className="group flex h-6 w-full cursor-row-resize items-center justify-center bg-transparent focus-visible:outline focus-visible:outline-2 focus-visible:outline-amber-400 focus-visible:outline-offset-2"
+          // below is h/2 each (h-3 — kept in sync with DIVIDER_HEIGHT_PX).
+          // Nothing else may add padding against it — the lower pane used to
+          // carry a pt-3 that made the bottom gap 22px against the top's
+          // 10px, which read as a misaligned rule. Affordance: a centred
+          // grip pill says "draggable" at rest, and hovering tints the whole
+          // band gray (the old amber line highlight is gone; focus ring is
+          // sky, matching the seek rails).
+          className="group relative flex h-3 w-full cursor-row-resize items-center justify-center bg-transparent transition-colors hover:bg-zinc-800/70 active:bg-zinc-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-400 focus-visible:outline-offset-2"
           onPointerDown={handleDividerPointerDown}
           onPointerMove={handleDividerPointerMove}
           onPointerUp={handleDividerPointerUp}
           onPointerCancel={handleDividerPointerUp}
         >
-          <span className="h-px w-full bg-zinc-800 transition-colors group-hover:bg-amber-400/70 group-active:bg-amber-400" />
+          <span
+            aria-hidden="true"
+            className="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-zinc-800"
+          />
+          <span
+            aria-hidden="true"
+            data-divider-grip
+            className="relative h-1 w-10 rounded-full bg-zinc-600 transition-colors group-hover:bg-zinc-400 group-active:bg-zinc-300"
+          />
         </button>
       </div>
       <div ref={lowerPaneRef} className="min-h-0">


### PR DESCRIPTION
Two rounds of preview-chrome polish on one branch:

**Divider** (4268751): half height (12px), gray hover band instead of the amber recolor, centred grip pill; sticky-offset constant kept in sync; focus ring amber → sky.

**Seek rails + playhead** (8811703): the rails' played-state fill goes red → pale sky blue (`sky-400/40`, the accent the focus rings already wear), and both playhead lines (strip + grid) lose their triangle caps — the rail's red circular thumb is the playhead's head now, riding a clean stem, and it finally reads as a circle against the blue fill instead of vanishing red-on-red.

Verified: graph-view e2e 40/40 (incl. the divider geometry/hover tests and the retargeted capless-playhead assertion), visual check of strip + grid modes in the live app, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)