### PR TITLE
Move graph layout controls into the sidebar; Collection is the only tool

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -8,6 +8,11 @@
       "port": 3000
     },
     {
+      "name": "timeline-gstudio001-attach",
+      "url": "http://localhost:3000",
+      "port": 3000
+    },
+    {
       "name": "storybook",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["--prefix", "apps/storybook", "run", "storybook"],

--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -221,3 +221,14 @@ html[data-timeline-endpoint-transition="active"]::view-transition-old(.timeline-
     animation: none;
   }
 }
+
+/* The page (document scroller) must never scroll-anchor: opening the
+   preview pane mounts ~150px of content at the top of <main>, and Chrome's
+   anchoring "helpfully" scrolled the page down to keep the board still —
+   which pinned the fresh pane and made its restore-clamp shrink the height
+   the user had chosen. The pane's own sticky logic owns that relationship.
+   On <html> because the exclusion-subtree form (overflow-anchor on <main>)
+   did not suppress it in Chromium. */
+html {
+  overflow-anchor: none;
+}

--- a/apps/timeline-gstudio001/app/layout.tsx
+++ b/apps/timeline-gstudio001/app/layout.tsx
@@ -26,6 +26,9 @@ export default function RootLayout({children}: {children: React.ReactNode}) {
               <Suspense fallback={null}>
                 <TimelineSidebar />
               </Suspense>
+              {/* Scroll anchoring is disabled page-wide (see globals.css):
+                  the preview pane mounting at main's top must not scroll
+                  the page out from under its own sticky logic. */}
               <main
                 className="min-w-0 flex-1 px-8 pt-6"
                 style={{

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -1,17 +1,9 @@
 "use client";
 
 import { useContext, useDeferredValue } from "react";
+import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import {
-  EllipsisVertical,
-  FolderTree,
-  GalleryHorizontalEnd,
-  LayoutGrid,
-  Redo2,
-  Ruler,
-  TvMinimal,
-  Undo2,
-} from "lucide-react";
+import { EllipsisVertical, Redo2, Undo2 } from "lucide-react";
 
 import {
   CollectionsContainerContext,
@@ -26,9 +18,11 @@ import { Button } from "@/components/core/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/core/dropdown-menu";
 import { Slider } from "@/components/core/slider";
@@ -45,6 +39,7 @@ import {
   GraphStripSeekRail,
   PreviewShell,
   collectionCardWidth,
+  useFocusedTimelineAggregate,
   type PreviewTimeChannel,
 } from "./graph-preview";
 import { SubTimelines } from "./graph-sub-timelines";
@@ -72,9 +67,11 @@ export type { FocusSurface, ItemSize };
 function BoardMenu({
   itemSize,
   onItemSizeChange,
+  storyboardHref,
 }: Readonly<{
   itemSize: ItemSize;
   onItemSizeChange: (size: ItemSize) => void;
+  storyboardHref: string;
 }>) {
   return (
     <DropdownMenu>
@@ -91,6 +88,13 @@ function BoardMenu({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
+        <DropdownMenuLabel>View</DropdownMenuLabel>
+        {/* Children visibility moved to the icon SIDEBAR (under the
+            Collection tool) — only the leave-the-graph link lives here. */}
+        <DropdownMenuItem asChild>
+          <Link href={storyboardHref}>Storyboard view</Link>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
         <DropdownMenuLabel>Thumbnail size</DropdownMenuLabel>
         <DropdownMenuRadioGroup
           value={itemSize}
@@ -109,6 +113,38 @@ function BoardMenu({
   );
 }
 
+/** "8 clips · 3m 00s" — matches the collection cards' badge idiom. */
+function formatAggregateSeconds(seconds: number): string {
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}m ${String(Math.round(seconds % 60)).padStart(2, "0")}s`;
+}
+
+/**
+ * The focused timeline's aggregate, at the row's TRUE centre — directly
+ * under the preview transport's centred play cluster. The header's two
+ * wings (breadcrumb / controls) carry equal `flex-1`, so this piece sits
+ * dead-centre and stays there; a long breadcrumb truncates inside its own
+ * wing instead of pushing the centre around. Passive DATA on purpose (the
+ * per-card badges show the same numbers), so hiding it on small screens
+ * costs nothing.
+ */
+function FocusedAggregate({
+  focusedId,
+  pixelsPerSecond,
+}: Readonly<{ focusedId: string; pixelsPerSecond: number }>) {
+  const { count, seconds } = useFocusedTimelineAggregate(focusedId, pixelsPerSecond);
+  if (count === 0) return null;
+  return (
+    <span
+      className="hidden shrink-0 px-3 text-center font-mono text-[11px] tabular-nums text-zinc-500 sm:block"
+      title="Focused timeline total"
+    >
+      {count} {count === 1 ? "clip" : "clips"} · {formatAggregateSeconds(seconds)}
+    </span>
+  );
+}
+
 /**
  * Horizontal zoom. Lives in the header rather than the overflow menu because
  * it is an exploration tool, not a setting — you reach for it WHILE reading
@@ -123,7 +159,13 @@ function ScaleSlider({
   onChange: (pixelsPerSecond: number) => void;
 }>) {
   return (
-    <div className="flex w-36 shrink-0 items-center gap-2" title="Timeline scale">
+    // Compact, label-less: the tooltip carries what it does AND the live
+    // value (the slider's own aria-valuenow has it too) — the header row
+    // earns back the label's width.
+    <div
+      className="flex w-24 shrink-0 items-center"
+      title={`Timeline zoom — stretch or squeeze the strip's time scale (${Math.round(pixelsPerSecond)} px/s)`}
+    >
       <Slider
         aria-label="Timeline scale"
         min={MIN_TIMELINE_PPS}
@@ -132,12 +174,6 @@ function ScaleSlider({
         value={[pixelsPerSecond]}
         onValueChange={([next]) => onChange(next)}
       />
-      <span
-        aria-hidden="true"
-        className="w-11 shrink-0 font-mono text-[10px] tabular-nums text-zinc-500"
-      >
-        {`${Math.round(pixelsPerSecond)} px/s`}
-      </span>
     </div>
   );
 }
@@ -189,61 +225,18 @@ function GraphUndoRedo() {
   );
 }
 
-function SurfaceToggle({
-  surface,
-  onChange,
-}: Readonly<{
-  surface: FocusSurface;
-  onChange: (surface: FocusSurface) => void;
-}>) {
-  return (
-    <div
-      role="group"
-      aria-label="Timeline layout"
-      className="flex items-center rounded-md border border-zinc-800 p-0.5"
-    >
-      {(["strip", "grid"] as const).map((option) => {
-        const Icon = option === "strip" ? GalleryHorizontalEnd : LayoutGrid;
-        return (
-          <button
-            key={option}
-            type="button"
-            // Keep the accessible name the visible label used to carry, so the
-            // control (and its tests) still resolve by "strip"/"grid".
-            aria-label={option}
-            title={option === "strip" ? "Strip layout" : "Grid layout"}
-            aria-pressed={surface === option}
-            onClick={() => onChange(option)}
-            className={[
-              "flex items-center justify-center rounded px-2 py-1 transition-colors",
-              surface === option
-                ? "bg-zinc-800 text-zinc-100"
-                : "text-zinc-500 hover:text-zinc-200",
-            ].join(" ")}
-          >
-            <Icon aria-hidden="true" className="h-4 w-4" />
-          </button>
-        );
-      })}
-    </div>
-  );
-}
-
 export function GraphBoard({
   focusedId,
   breadcrumb,
   surface,
-  onSurfaceChange,
   itemSize,
   onItemSizeChange,
   pixelsPerSecond,
   onPixelsPerSecondChange,
   previewOn,
-  onTogglePreview,
   rulerOn,
-  onToggleRuler,
+  storyboardHref,
   childrenShown,
-  onToggleChildren,
   timeChannel,
   trashRootId,
   syncEntries,
@@ -252,18 +245,21 @@ export function GraphBoard({
   /** Slot, not routing props: the board renders where you are without
    *  knowing how a route is shaped. */
   breadcrumb: React.ReactNode;
+  /** Chosen in the SIDEBAR now (its grid/strip icons), not in this header. */
   surface: FocusSurface;
-  onSurfaceChange: (surface: FocusSurface) => void;
   itemSize: ItemSize;
   onItemSizeChange: (size: ItemSize) => void;
   pixelsPerSecond: number;
   onPixelsPerSecondChange: (pixelsPerSecond: number) => void;
+  /** Toggled from the SIDEBAR's preview icon; the board only renders it. */
   previewOn: boolean;
-  onTogglePreview: () => void;
+  /** Toggled from the SIDEBAR's ruler icon (strip mode only). */
   rulerOn: boolean;
-  onToggleRuler: () => void;
+  /** For the overflow menu's "Storyboard view" item — routing stays the
+   *  caller's business, like the breadcrumb slot. */
+  storyboardHref: string;
+  /** Toggled from the SIDEBAR's children icon; the board only renders it. */
   childrenShown: boolean;
-  onToggleChildren: () => void;
   timeChannel: PreviewTimeChannel;
   trashRootId: string | null;
   syncEntries: readonly SyncEntry[];
@@ -308,79 +304,49 @@ export function GraphBoard({
             className="sticky z-40 -mx-4 -mt-4 flex flex-wrap items-center justify-between gap-x-3 gap-y-2 rounded-t-xl border-b border-zinc-800/70 bg-zinc-950/95 px-4 py-3 backdrop-blur-sm"
             style={{ top: "var(--workbench-preview-offset, 0px)" }}
           >
-            {breadcrumb}
+            {/* Equal-flex wings keep the aggregate at the row's true centre
+                (under the transport's play cluster). min-w-0 lets a long
+                breadcrumb truncate inside its wing. */}
+            <div className="flex min-w-0 flex-1 items-center">{breadcrumb}</div>
+            <FocusedAggregate
+              focusedId={focusedId}
+              pixelsPerSecond={deferredPixelsPerSecond}
+            />
             {/* flex-wrap + wrap-capable controls so a narrow viewport folds the
-                toolbar onto a second line instead of pushing controls (the
-                Strip/Grid toggle especially) off-screen. No effect when it
-                fits. */}
-            <div className="flex flex-wrap items-center justify-end gap-2">
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                aria-pressed={previewOn}
-                aria-label={previewOn ? "Hide preview" : "Show preview"}
-                title={previewOn ? "Hide preview" : "Show preview"}
-                onClick={onTogglePreview}
-                className={[
-                  "h-8 w-8",
-                  previewOn ? "bg-zinc-800 text-zinc-100" : "text-zinc-500",
-                ].join(" ")}
-              >
-                <TvMinimal aria-hidden="true" className="h-4 w-4" />
-              </Button>
-              {/* Ruler is a strip-only axis (grid has no single time axis), so
-                  the toggle drops out in grid mode like the scale slider. */}
-              {surface === "strip" ? (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  aria-pressed={rulerOn}
-                  aria-label={rulerOn ? "Hide time ruler" : "Show time ruler"}
-                  title={rulerOn ? "Hide time ruler" : "Show time ruler"}
-                  onClick={onToggleRuler}
-                  className={[
-                    "h-8 w-8",
-                    rulerOn ? "bg-zinc-800 text-zinc-100" : "text-zinc-500",
-                  ].join(" ")}
-                >
-                  <Ruler aria-hidden="true" className="h-4 w-4" />
-                </Button>
-              ) : null}
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                aria-pressed={childrenShown}
-                aria-label={childrenShown ? "Hide children timelines" : "Show children timelines"}
-                title={childrenShown ? "Hide children timelines" : "Show children timelines"}
-                onClick={onToggleChildren}
-                className={[
-                  "h-8 w-8",
-                  childrenShown ? "bg-zinc-800 text-zinc-100" : "text-zinc-500",
-                ].join(" ")}
-              >
-                <FolderTree aria-hidden="true" className="h-4 w-4" />
-              </Button>
+                toolbar onto a second line instead of pushing controls
+                off-screen. No effect when it fits. */}
+            <div className="flex flex-1 flex-wrap items-center justify-end gap-2">
               {/* px/s is a strip-only axis: grid cells are sized by thumbnail
                   size, and the grid playhead ignores clip width, so the slider
                   is a no-op in grid mode. Hidden there (state is preserved, so
-                  returning to strip restores the last zoom). */}
+                  returning to strip restores the last zoom). It LEADS the
+                  cluster, fenced off by a rule: zoom reshapes the surface,
+                  everything right of the line is a toggle or an action. */}
               {surface === "strip" ? (
-                <ScaleSlider
-                  pixelsPerSecond={pixelsPerSecond}
-                  onChange={onPixelsPerSecondChange}
-                />
+                <>
+                  <ScaleSlider
+                    pixelsPerSecond={pixelsPerSecond}
+                    onChange={onPixelsPerSecondChange}
+                  />
+                  <div aria-hidden="true" className="h-5 w-px shrink-0 bg-zinc-700" />
+                </>
               ) : null}
-              <SurfaceToggle surface={surface} onChange={onSurfaceChange} />
               <GraphUndoRedo />
-              <BoardMenu itemSize={itemSize} onItemSizeChange={onItemSizeChange} />
+              <BoardMenu
+                itemSize={itemSize}
+                onItemSizeChange={onItemSizeChange}
+                storyboardHref={storyboardHref}
+              />
             </div>
           </div>
 
           {surface === "strip" ? (
-            <NativeDropStrip collectionId={focusedId}>
+            // The focused surface gets the same distinct gray panel as each
+            // sub-timeline row (the storyboard idiom). Padding lives on THIS
+            // wrapper, never on NativeDropStrip: its drop math is
+            // clientX-vs-own-rect, and padding there drifts the indicator.
+            <div className="rounded-lg border border-zinc-800/70 bg-zinc-900/40 p-3">
+              <NativeDropStrip collectionId={focusedId}>
               <VirtualStrip
                 collectionId={parseNodeId(focusedId)}
                 pixelsPerSecond={deferredPixelsPerSecond}
@@ -406,7 +372,9 @@ export function GraphBoard({
                     </>
                   ) : undefined
                 }
-                className="bg-black/25"
+                // pt-4: the 16px top band the seek rail centres in — same
+                // clearance system as the grid's GRID_GAP row bands.
+                className="bg-black/25 pt-4"
               />
               {/* The strip's scrub control — the same rail treatment as the
                   grid's, riding the strip's top padding band and scrolling
@@ -420,7 +388,8 @@ export function GraphBoard({
                   pixelsPerSecond={deferredPixelsPerSecond}
                 />
               )}
-            </NativeDropStrip>
+              </NativeDropStrip>
+            </div>
           ) : (
             // Grid scrubbing is the per-row SEEK RAILS layer — one slim
             // slider in the gap above each row (the video-player idiom, in
@@ -429,8 +398,11 @@ export function GraphBoard({
             // R7 #5/#6/#7) and the in-grid playhead line stays a passive
             // indicator. The layer overlays the grid as a SIBLING (outside
             // NativeDropGrid, whose drop math measures its own wrapper, and
-            // outside the aria-hidden overlay — rails are focusable).
-            <div className="relative">
+            // outside the aria-hidden overlay — rails are focusable). Same
+            // gray panel as the strip branch; the rails' geometry is
+            // measured live from the grid's own rect, so the padding is
+            // accounted for automatically.
+            <div className="relative rounded-lg border border-zinc-800/70 bg-zinc-900/40 p-3">
               <NativeDropGrid collectionId={focusedId}>
                 <VirtualGrid
                   collectionId={parseNodeId(focusedId)}
@@ -453,7 +425,8 @@ export function GraphBoard({
                       />
                     ) : undefined
                   }
-                  className="bg-black/25"
+                  // pt-4 = GRID_GAP: row 0's rail band matches the row gaps.
+                  className="bg-black/25 pt-4"
                 />
               </NativeDropGrid>
               {previewOn && (

--- a/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
@@ -36,8 +36,8 @@ import { parkPendingDetail, unparkPendingDetail } from "./graph-pending-details"
 // in-graph drags (cards, palette thumbnails); this layer owns what dnd-kit
 // cannot see — HTML5 drags:
 //
-//   - the sidebar tool icons (application/x-gstudio-type: collection /
-//     image / video), which mint a fresh node at the drop position;
+//   - the sidebar COLLECTION tool (application/x-gstudio-type), which
+//     mints a fresh nested timeline at the drop position;
 //   - OS FILE drops (images/videos, several at once), which upload through
 //     the same /api/timeline-media pipeline the legacy views use and then
 //     add one node per file — in a single undoable commit.
@@ -54,14 +54,14 @@ import { parkPendingDetail, unparkPendingDetail } from "./graph-pending-details"
 // trips.
 
 const TOOL_MIME = "application/x-gstudio-type";
-// The demo clip the legacy views use for placeholder video content.
-const PLACEHOLDER_VIDEO_SRC = "https://www.w3schools.com/html/mov_bbb.mp4";
-const PLACEHOLDER_VIDEO_SECONDS = 10;
 
-type SidebarTool = "collection" | "image" | "video";
+// Collection is the only sidebar tool now: the old image/video tools minted
+// demo-content placeholders nobody used — real media arrives as FILES (OS
+// drop / Assets drawer), handled by the upload path below.
+type SidebarTool = "collection";
 
 function isSidebarTool(value: string): value is SidebarTool {
-  return value === "collection" || value === "image" || value === "video";
+  return value === "collection";
 }
 
 function mintId(prefix: string): string {
@@ -197,11 +197,17 @@ function useToolInsertion(collectionId: string) {
   const store = useCollectionsStore();
 
   const addNodes = useCallback(
-    (nodes: readonly CollectionItemNode[], toIndex: number): boolean => {
+    (
+      nodes: readonly CollectionItemNode[],
+      toIndex: number,
+      // Default: the hook's own collection (every drop path). The insert
+      // bridge overrides it to land next to a selection in ANOTHER strip.
+      toParentId: NodeId = parseNodeId(collectionId),
+    ): boolean => {
       const result = store.dispatch({
         type: "add-nodes",
         nodes,
-        toParentId: parseNodeId(collectionId),
+        toParentId,
         toIndex,
       });
       // Every refusal — including the un-hydrated-target veto — now comes
@@ -221,85 +227,35 @@ function useToolInsertion(collectionId: string) {
   /** Returns whether the tool actually landed, so callers can announce the
    *  truth rather than assuming success. */
   const insertTool = useCallback(
-    (tool: SidebarTool, toIndex: number): boolean => {
-      if (tool === "collection") {
-        const childId = mintId("timeline");
-        // hydrated: true — the collection is BRAND-NEW and empty, so drops
-        // into it must not bounce and writes may touch its document.
-        parkPendingDetail(childId, {
-          alt: "New Timeline collection",
-          aspect: 16 / 9,
-          trackIndex: 0,
-          itemCount: 0,
-          duration: 3,
-          sourceDuration: 3,
-          trimIn: 0,
-          trimOut: 0,
-          hydrated: true,
-        });
-        const added = addNodes(
-          [{ id: parseNodeId(childId), kind: "collection", name: "New Timeline" }],
-          toIndex,
-        );
-        if (added) {
-          // Create the child document itself: seed the cache (expected
-          // revision 0 = compare-and-set create) and queue an empty write —
-          // it joins the same atomic batch as the parent's update, so a
-          // drill-in never 404s on a half-created collection.
-          graphDocumentsGateway.seed({ id: childId, title: "New Timeline", clips: [] });
-          graphDocumentsGateway.writeClips(childId, []);
-        }
-        return added;
-      }
-
-      const id = mintId(tool);
-      const placeholder = `https://picsum.photos/seed/${id}/640/360`;
-      if (tool === "image") {
-        parkPendingDetail(id, {
-          alt: "New Image",
-          aspect: 16 / 9,
-          trackIndex: 0,
-          sourceDuration: 4,
-          trimIn: 0,
-          trimOut: 0,
-        });
-        return addNodes(
-          [
-            {
-              id: parseNodeId(id),
-              kind: "media",
-              mediaKind: "image",
-              name: "New Image",
-              src: placeholder,
-              durationSeconds: 4,
-            },
-          ],
-          toIndex,
-        );
-      }
-
-      parkPendingDetail(id, {
-        alt: "New Video",
+    (_tool: SidebarTool, toIndex: number, toParentId?: NodeId): boolean => {
+      const childId = mintId("timeline");
+      // hydrated: true — the collection is BRAND-NEW and empty, so drops
+      // into it must not bounce and writes may touch its document.
+      parkPendingDetail(childId, {
+        alt: "New Timeline collection",
         aspect: 16 / 9,
         trackIndex: 0,
-        poster: placeholder,
+        itemCount: 0,
+        duration: 3,
+        sourceDuration: 3,
+        trimIn: 0,
+        trimOut: 0,
+        hydrated: true,
       });
-      return addNodes(
-        [
-          {
-            id: parseNodeId(id),
-            kind: "media",
-            mediaKind: "video",
-            name: "New Video",
-            src: PLACEHOLDER_VIDEO_SRC,
-            posterSrcs: [placeholder],
-            fullDurationSeconds: PLACEHOLDER_VIDEO_SECONDS,
-            trimInSeconds: 0,
-            trimOutSeconds: 0,
-          },
-        ],
+      const added = addNodes(
+        [{ id: parseNodeId(childId), kind: "collection", name: "New Timeline" }],
         toIndex,
+        toParentId,
       );
+      if (added) {
+        // Create the child document itself: seed the cache (expected
+        // revision 0 = compare-and-set create) and queue an empty write —
+        // it joins the same atomic batch as the parent's update, so a
+        // drill-in never 404s on a half-created collection.
+        graphDocumentsGateway.seed({ id: childId, title: "New Timeline", clips: [] });
+        graphDocumentsGateway.writeClips(childId, []);
+      }
+      return added;
     },
     [addNodes],
   );
@@ -310,15 +266,18 @@ function useToolInsertion(collectionId: string) {
 /** Human label for an inserted tool, for the announcement. */
 const TOOL_LABELS: Readonly<Record<SidebarTool, string>> = {
   collection: "collection",
-  image: "image clip",
-  video: "video clip",
 };
 
 /**
  * The KEYBOARD/click path for the sidebar tool palette. The sidebar is app
  * chrome living outside this provider, so it hands the tool off through a
- * window event (same pattern as the Assets launcher) and this appends it to
- * the focused collection.
+ * window event (same pattern as the Assets launcher). SELECTION-AWARE: the
+ * tool lands right after the most recently selected card, inside THAT
+ * card's own timeline (any strip, not just the focused one — clicking the
+ * sidebar never clears selection, so this works for mouse and keyboard
+ * alike). With nothing selected it appends to the focused collection, the
+ * one spot that needs no explanation. Dragging the tool remains the
+ * pointer-precision path either way.
  *
  * Mounted for BOTH surfaces, deliberately: `NativeDropStrip` only wraps the
  * strip, and an accessible control that silently does nothing in grid mode
@@ -335,15 +294,34 @@ export function SidebarToolInsertBridge({
     const handleInsert = (event: Event) => {
       const tool = (event as CustomEvent<GraphInsertToolDetail>).detail?.tool;
       if (!tool || !isGraphInsertTool(tool)) return;
-      const parentId = parseNodeId(collectionId);
-      const graph = store.getSnapshot().graph;
-      // Append: with no pointer there is no position to read, and the end of
-      // the timeline is the one spot that needs no explanation.
-      const landed = insertTool(tool, getChildren(graph, parentId).length);
+      const snapshot = store.getSnapshot();
+      const graph = snapshot.graph;
+      // Sets iterate in insertion order, so `.at(-1)` is the most recent
+      // selection — the card a multi-select last touched.
+      const selectedId = [...snapshot.interaction.selectedIds].at(-1);
+      const selectedParentId =
+        selectedId !== undefined ? (graph.parentById.get(selectedId) ?? null) : null;
+      const parentId = selectedParentId ?? parseNodeId(collectionId);
+      const siblings = getChildren(graph, parentId);
+      const selectedAt =
+        selectedId !== undefined && selectedParentId !== null
+          ? siblings.indexOf(selectedId)
+          : -1;
+      const landed = insertTool(
+        tool,
+        selectedAt >= 0 ? selectedAt + 1 : siblings.length,
+        parentId,
+      );
       const target = graph.nodesById.get(parentId)?.name ?? "the timeline";
+      const afterName =
+        selectedAt >= 0 && selectedId !== undefined
+          ? (graph.nodesById.get(selectedId)?.name ?? "the selected clip")
+          : null;
       announce(
         landed
-          ? `Added a ${TOOL_LABELS[tool]} to the end of "${target}".`
+          ? afterName !== null
+            ? `Added a ${TOOL_LABELS[tool]} after "${afterName}" in "${target}".`
+            : `Added a ${TOOL_LABELS[tool]} to the end of "${target}".`
           : `Could not add a ${TOOL_LABELS[tool]} to "${target}".`,
       );
     };

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -128,6 +128,38 @@ export function usePreviewCardSpans(): PreviewCardSpans | null {
   return useContext(PreviewCardSpansContext);
 }
 
+/**
+ * Clip count and total seconds of the focused timeline — the board header's
+ * centred aggregate readout. Same plumbing as the playheads (graph + details
+ * + manifest spans through `childSpans`), so its total always agrees with
+ * where the playhead can actually reach.
+ */
+export function useFocusedTimelineAggregate(
+  focusedId: string,
+  pixelsPerSecond: number,
+): Readonly<{ count: number; seconds: number }> {
+  const store = useCollectionsStore();
+  const detailsStore = useGraphDetailsStore();
+  const spans = useContext(PreviewCardSpansContext);
+  const graph = useSyncExternalStore(
+    store.subscribe,
+    () => store.getSnapshot().graph,
+    () => store.getSnapshot().graph,
+  );
+  const details = useSyncExternalStore(
+    detailsStore.subscribe,
+    () => detailsStore.read(),
+    () => detailsStore.read(),
+  );
+  return useMemo(() => {
+    const cards = childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond));
+    return {
+      count: cards.length,
+      seconds: cards.length > 0 ? cards[cards.length - 1].endTime : 0,
+    };
+  }, [graph, details, focusedId, spans, pixelsPerSecond]);
+}
+
 
 export function GraphPlayhead({
   focusedId,
@@ -183,12 +215,14 @@ export function GraphPlayhead({
   }, [store, detailsStore, focusedId, channel, spans, pixelsPerSecond, activeWindow]);
 
   // No cap on the line: the seek rail's circular thumb above IS the
-  // playhead's head now — the old triangle poked up over it.
+  // playhead's head now — the old triangle poked up over it. The stem
+  // reaches up through the band's clearance (-top-1 = the 4px inset) so it
+  // meets the track's underside instead of floating below it.
   return (
     <div
       ref={lineRef}
       data-graph-playhead
-      className="absolute inset-y-0 left-0 w-0.5 bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.9)]"
+      className="absolute -top-1 bottom-0 left-0 w-0.5 bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.9)]"
     />
   );
 }
@@ -428,8 +462,10 @@ export function GraphGridPlayhead({
       line.style.display = inside ? "" : "none";
       if (!inside) return;
       const { x, y } = map.posAt(time);
-      line.style.transform = `translate(${x}px, ${y}px)`;
-      line.style.height = `${map.rowHeight}px`;
+      // Reach up through the band's clearance so the stem meets its row
+      // rail's underside (the strip line does the same via -top-1).
+      line.style.transform = `translate(${x}px, ${y - SEEK_RAIL_BAND_INSET_PX}px)`;
+      line.style.height = `${map.rowHeight + SEEK_RAIL_BAND_INSET_PX}px`;
     };
 
     paint();
@@ -461,6 +497,15 @@ export function GraphGridPlayhead({
 
 /** Keyboard step for the seek rails: one nudge per arrow press. */
 const SEEK_RAIL_STEP_SECONDS = 1;
+
+/** The rail's slim track vs the BAND it rides (the grid's row gap; the
+ *  strip's `pt-4` top padding). The track centres in the band, so the
+ *  clearance on each side keeps the track and its thumb clear of the cards
+ *  — rail and items never overlap, and a selected card's ring stays fully
+ *  visible (the old design filled the band edge-to-edge and sat flush on
+ *  the card tops). */
+const SEEK_RAIL_TRACK_PX = 8;
+const SEEK_RAIL_BAND_INSET_PX = (GRID_GAP - SEEK_RAIL_TRACK_PX) / 2;
 
 type SeekRailGeometry = Readonly<{
   columns: number;
@@ -621,7 +666,12 @@ function SeekRailRow({
       // dark backdrop, where a see-through zinc melted away entirely — the
       // user read row 1 as having "no rail" (R7 follow-up).
       className="group pointer-events-auto absolute cursor-ew-resize touch-none rounded-full bg-zinc-700 shadow-[inset_0_1px_2px_rgba(0,0,0,0.6)] ring-1 ring-white/25 transition-shadow hover:ring-white/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
-      style={{ left: x, top: y, width: extent, height: GRID_GAP }}
+      style={{
+        left: x,
+        top: y + SEEK_RAIL_BAND_INSET_PX,
+        width: extent,
+        height: SEEK_RAIL_TRACK_PX,
+      }}
     >
       {/* Elapsed fill, then boundary ticks, then the thumb on top. */}
       <div
@@ -638,15 +688,15 @@ function SeekRailRow({
           style={{ left: `${(((index + 1) * pitch - GRID_GAP / 2) / extent) * 100}%` }}
         />
       ))}
-      {/* h-2.5, not larger: the rail lives in the 8px row gap, and a taller
-          thumb overhangs onto the cards below — the "item overlaps rail"
-          complaint. 1px of kiss is invisible; the whole rail is the hit
+      {/* h-3: the head is visibly bigger than the slim track (2px past it
+          each side), and the band's inset keeps even that overhang clear of
+          the cards — thumb and items never touch. The whole rail is the hit
           target anyway. */}
       <div
         ref={thumbRef}
         data-rail-thumb
         aria-hidden="true"
-        className="absolute top-1/2 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.7)] ring-2 ring-zinc-950 transition-transform group-hover:scale-110"
+        className="absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.7)] ring-2 ring-zinc-950 transition-transform group-hover:scale-110"
       />
     </div>
   );
@@ -901,8 +951,13 @@ export function GraphStripSeekRail({
       const scrollerRect = scroller.getBoundingClientRect();
       const wrapperRect = wrapper.getBoundingClientRect();
       const left = scrollerRect.left - wrapperRect.left + padLeft;
+      // Centre the slim track in the scroller's top padding band (falls
+      // back to flush-at-top if the padding is no taller than the track).
       const top =
-        scrollerRect.top - wrapperRect.top + parseFloat(styles.borderTopWidth);
+        scrollerRect.top -
+        wrapperRect.top +
+        parseFloat(styles.borderTopWidth) +
+        Math.max(0, (parseFloat(styles.paddingTop) - SEEK_RAIL_TRACK_PX) / 2);
       const width = Math.max(0, scroller.clientWidth - padLeft - padRight + 1);
       setGeometry((previous) =>
         previous &&
@@ -932,17 +987,33 @@ export function GraphStripSeekRail({
     const scroller = outer.parentElement?.querySelector<HTMLElement>("[data-virtual-strip]");
     if (!scroller) return;
 
+    // The thumb lives OUTSIDE the pill's clip in window coordinates
+    // (content x − scrollLeft), so the circle stays whole at the timeline's
+    // ends. It hides once fully past the window's edge (a detached head
+    // floating beside the pill would read as a bug); `contentX` carries the
+    // last painted position into scroll-only frames.
+    let contentX = 0;
+    const placeThumb = () => {
+      const windowX = contentX - scroller.scrollLeft;
+      thumb.style.left = `${windowX}px`;
+      const overhang = thumb.offsetWidth / 2;
+      const visible =
+        thumb.dataset.active !== "false" &&
+        windowX >= -overhang &&
+        windowX <= outer.clientWidth + overhang;
+      thumb.style.visibility = visible ? "" : "hidden";
+    };
     const syncScroll = () => {
       inner.style.transform = `translateX(${-scroller.scrollLeft}px)`;
+      placeThumb();
     };
     const paint = () => {
       const time = channel.get();
-      const active = time >= start && time <= end;
-      thumb.style.visibility = active ? "" : "hidden";
+      thumb.dataset.active = String(time >= start && time <= end);
       const clamped = Math.min(end, Math.max(start, time));
-      const x = map.xAt(clamped);
-      fill.style.width = `${x}px`;
-      thumb.style.left = `${x}px`;
+      contentX = map.xAt(clamped);
+      fill.style.width = `${contentX}px`;
+      placeThumb();
       outer.setAttribute("aria-valuenow", (clamped - start).toFixed(1));
       outer.setAttribute(
         "aria-valuetext",
@@ -1082,50 +1153,59 @@ export function GraphStripSeekRail({
         revealTime(next);
         event.preventDefault();
       }}
-      // The OUTER element wears the grid rail's exact chrome (rounded pill,
-      // solid track, groove, ring) so both surfaces read as one control —
-      // the window IS the visible track, and it ends at the LAST item when
-      // the timeline fits (min with the extent, exactly like a grid rail).
-      // When the timeline overflows, the pill spans the viewport and the
-      // content layer slides inside it.
-      className="group absolute z-20 cursor-ew-resize touch-none overflow-hidden rounded-full bg-zinc-700 shadow-[inset_0_1px_2px_rgba(0,0,0,0.6)] ring-1 ring-white/25 transition-shadow hover:ring-white/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+      // The pill wears the grid rail's exact chrome (rounded, solid track,
+      // groove, ring) so both surfaces read as one control — the window IS
+      // the visible track, and it ends at the LAST item when the timeline
+      // fits (min with the extent, exactly like a grid rail). When the
+      // timeline overflows, the pill spans the viewport and the content
+      // layer slides inside it. The chrome lives on an INNER clip layer:
+      // only fill and ticks clip to the pill, while the thumb rides the
+      // unclipped outer in window coordinates — the circle stays whole at
+      // the timeline's ends instead of being cut by the pill's corner.
+      className="group absolute z-20 cursor-ew-resize touch-none rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
       style={
         geometry
           ? {
               left: geometry.left,
               top: geometry.top,
               width: Math.min(extent, geometry.width),
-              height: 8,
+              height: SEEK_RAIL_TRACK_PX,
             }
-          : { left: 9, top: 1, right: 9, height: 8 }
+          : { left: 9, top: 1 + SEEK_RAIL_BAND_INSET_PX, right: 9, height: SEEK_RAIL_TRACK_PX }
       }
     >
-      {/* Content-space layer: as wide as the timeline, translated against
-          the scroller so fill, ticks and thumb stay glued to their cards. */}
-      <div ref={innerRef} className="relative h-full" style={{ width: extent }}>
-        <div
-          ref={fillRef}
-          data-rail-fill
-          aria-hidden="true"
-          className="absolute inset-y-0 left-0 rounded-full bg-sky-400/40"
-        />
-        {ticks.map((x, index) => (
-          <span
-            key={index}
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 overflow-hidden rounded-full bg-zinc-700 shadow-[inset_0_1px_2px_rgba(0,0,0,0.6)] ring-1 ring-white/25 transition-shadow group-hover:ring-white/40"
+      >
+        {/* Content-space layer: as wide as the timeline, translated against
+            the scroller so fill and ticks stay glued to their cards. */}
+        <div ref={innerRef} className="relative h-full" style={{ width: extent }}>
+          <div
+            ref={fillRef}
+            data-rail-fill
             aria-hidden="true"
-            className="absolute inset-y-0 w-px bg-white/30"
-            style={{ left: x }}
+            className="absolute inset-y-0 left-0 rounded-full bg-sky-400/40"
           />
-        ))}
-        {/* h-2.5 like the grid rails: 1px of kiss past the 8px band, no
-            overhang onto the cards. */}
-        <div
-          ref={thumbRef}
-          data-rail-thumb
-          aria-hidden="true"
-          className="absolute top-1/2 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.7)] ring-2 ring-zinc-950 transition-transform group-hover:scale-110"
-        />
+          {ticks.map((x, index) => (
+            <span
+              key={index}
+              aria-hidden="true"
+              className="absolute inset-y-0 w-px bg-white/30"
+              style={{ left: x }}
+            />
+          ))}
+        </div>
       </div>
+      {/* h-3 like the grid rails: the head is visibly bigger than the slim
+          track, and the band's inset keeps it clear of the cards. Window
+          coordinates (painted as content x − scrollLeft), unclipped. */}
+      <div
+        ref={thumbRef}
+        data-rail-thumb
+        aria-hidden="true"
+        className="absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.7)] ring-2 ring-zinc-950 transition-transform group-hover:scale-110"
+      />
     </div>
   );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -161,7 +161,13 @@ function SubTimelineNode({
   };
 
   return (
-    <section aria-label={`Sub-timeline: ${name}`} className="min-w-0">
+    // Each timeline is its OWN gray panel (header + surface in one box) —
+    // the storyboard view's idiom, adopted so every strip reads as one
+    // distinct area; nested rows nest panels, echoing the hierarchy.
+    <section
+      aria-label={`Sub-timeline: ${name}`}
+      className="min-w-0 rounded-lg border border-zinc-800/70 bg-zinc-900/40 p-3"
+    >
       <div className="mb-1.5 flex items-center gap-2">
         <button
           type="button"
@@ -254,7 +260,8 @@ function SubTimelineNode({
                       />
                     ) : undefined
                   }
-                  className="bg-black/20"
+                  // pt-4 = GRID_GAP: row 0's rail band matches the row gaps.
+                  className="bg-black/20 pt-4"
                 />
               </NativeDropGrid>
               {showPlayhead && (
@@ -292,7 +299,8 @@ function SubTimelineNode({
                     </>
                   ) : undefined
                 }
-                className="bg-black/20"
+                // pt-4: the 16px top band the seek rail centres in.
+                className="bg-black/20 pt-4"
               />
               {showPlayhead && (
                 <GraphStripSeekRail

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import {
   useCallback,
   useEffect,
@@ -33,7 +33,15 @@ import {
   graphDocumentsGateway,
   type GraphServerPayload,
 } from "@/lib/graph-documents-gateway";
-import { GRAPH_ASSETS_TOGGLE_EVENT } from "@/lib/graph-view-events";
+import {
+  GRAPH_ASSETS_TOGGLE_EVENT,
+  GRAPH_CHILDREN_TOGGLE_EVENT,
+  GRAPH_PREVIEW_TOGGLE_EVENT,
+  GRAPH_RULER_TOGGLE_EVENT,
+  GRAPH_SURFACE_EVENT,
+  broadcastGraphViewState,
+  type GraphSurface,
+} from "@/lib/graph-view-events";
 
 import { AssetPaletteDrawer } from "./graph-asset-palette";
 import { toast } from "@/components/core/sonner";
@@ -58,7 +66,7 @@ import {
   DEFAULT_TIMELINE_PPS,
   FALLBACK_DETAIL,
 } from "./graph-view-config";
-import { GraphBreadcrumb, GraphViewChrome } from "./graph-view-chrome";
+import { GraphBreadcrumb } from "./graph-view-chrome";
 
 type BootState =
   | Readonly<{ status: "loading" }>
@@ -105,12 +113,20 @@ export function GraphTimelineView({
   const [detailsStore] = useState(() => createGraphDetailsStore());
   const [focusError, setFocusError] = useState<string | null>(null);
   const [syncLog, setSyncLog] = useState<readonly SyncEntry[]>([]);
-  const [surface, setSurface] = useState<FocusSurface>("strip");
+  // GRID is the load default (the sidebar's first icon); `?surface=strip`
+  // lets a link land directly in strip mode. The graph tree mounts
+  // client-only (`ssr: false` in client-graph-view), so useSearchParams has
+  // no prerender/Suspense implications.
+  const initialSurface = useSearchParams().get("surface");
+  const [surface, setSurface] = useState<FocusSurface>(
+    initialSurface === "strip" ? "strip" : "grid",
+  );
   const [itemSize, setItemSize] = useState<ItemSize>(DEFAULT_ITEM_SIZE);
   const [pixelsPerSecond, setPixelsPerSecond] = useState(DEFAULT_TIMELINE_PPS);
-  // Children timelines render by default (their absence would hide the tree);
-  // the FolderTree toggle unmounts them.
-  const [childrenShown, setChildrenShown] = useState(true);
+  // Children timelines are OFF by default (the focused timeline is the
+  // page's subject; the tree is opt-in) — the sidebar's children icon
+  // mounts them.
+  const [childrenShown, setChildrenShown] = useState(false);
   const [previewOn, setPreviewOn] = useState(false);
   const [rulerOn, setRulerOn] = useState(false);
   const [timeChannel] = useState(createPreviewTimeChannel);
@@ -121,6 +137,34 @@ export function GraphTimelineView({
     window.addEventListener(GRAPH_ASSETS_TOGGLE_EVENT, toggle);
     return () => window.removeEventListener(GRAPH_ASSETS_TOGGLE_EVENT, toggle);
   }, []);
+
+  // The sidebar owns the layout switch and the ruler toggle (its top icons /
+  // tool cluster); it drives this state through request events…
+  useEffect(() => {
+    const onSurface = (event: Event) => {
+      const detail = (event as CustomEvent<GraphSurface>).detail;
+      if (detail === "strip" || detail === "grid") setSurface(detail);
+    };
+    const onRulerToggle = () => setRulerOn((current) => !current);
+    const onChildrenToggle = () => setChildrenShown((current) => !current);
+    const onPreviewToggle = () => setPreviewOn((current) => !current);
+    window.addEventListener(GRAPH_SURFACE_EVENT, onSurface);
+    window.addEventListener(GRAPH_RULER_TOGGLE_EVENT, onRulerToggle);
+    window.addEventListener(GRAPH_CHILDREN_TOGGLE_EVENT, onChildrenToggle);
+    window.addEventListener(GRAPH_PREVIEW_TOGGLE_EVENT, onPreviewToggle);
+    return () => {
+      window.removeEventListener(GRAPH_SURFACE_EVENT, onSurface);
+      window.removeEventListener(GRAPH_RULER_TOGGLE_EVENT, onRulerToggle);
+      window.removeEventListener(GRAPH_CHILDREN_TOGGLE_EVENT, onChildrenToggle);
+      window.removeEventListener(GRAPH_PREVIEW_TOGGLE_EVENT, onPreviewToggle);
+    };
+  }, []);
+
+  // …and this broadcast (on mount and every change) is what lets its
+  // controls show the current surface, ruler, children, and preview state.
+  useEffect(() => {
+    broadcastGraphViewState({ surface, rulerOn, childrenShown, previewOn });
+  }, [surface, rulerOn, childrenShown, previewOn]);
 
   const gatewayError = useSyncExternalStore(
     graphDocumentsGateway.subscribe,
@@ -348,9 +392,15 @@ export function GraphTimelineView({
     );
   }
 
+  // The old "Storyboard view" chrome row above the preview is gone — the
+  // link lives in the board's overflow menu now, so the page starts at the
+  // preview itself.
+  const storyboardHref = `/timeline/${encodeURIComponent(projectId)}/storyboard${
+    focusedId === projectId ? "" : `/${encodeURIComponent(focusedId)}`
+  }`;
+
   return (
     <div className="flex flex-col gap-4">
-      <GraphViewChrome projectId={projectId} timelinePath={timelinePath} />
       {gatewayError !== null && (
         <p className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
           {gatewayError}
@@ -418,17 +468,14 @@ export function GraphTimelineView({
                   <GraphBreadcrumb projectId={projectId} timelinePath={timelinePath} />
                 }
                 surface={surface}
-                onSurfaceChange={setSurface}
                 itemSize={itemSize}
                 onItemSizeChange={setItemSize}
                 pixelsPerSecond={pixelsPerSecond}
                 onPixelsPerSecondChange={setPixelsPerSecond}
                 previewOn={previewOn}
-                onTogglePreview={() => setPreviewOn((current) => !current)}
                 rulerOn={rulerOn}
-                onToggleRuler={() => setRulerOn((current) => !current)}
+                storyboardHref={storyboardHref}
                 childrenShown={childrenShown}
-                onToggleChildren={() => setChildrenShown((current) => !current)}
                 timeChannel={timeChannel}
                 trashRootId={boot.trashRootId}
                 syncEntries={syncLog}

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
@@ -118,27 +118,6 @@ export function GraphBreadcrumb({
   );
 }
 
-/** The view switcher, which stays page chrome: it leaves the graph entirely,
- *  so it does not belong among the board's own controls. */
-export function GraphViewChrome({
-  projectId,
-  timelinePath,
-}: Readonly<{
-  projectId: string;
-  timelinePath: readonly string[];
-}>) {
-  const focusedId = focusedIdOf(projectId, timelinePath);
-
-  return (
-    <div className="flex w-full items-center justify-end gap-3">
-      <Link
-        href={`/timeline/${encodeURIComponent(projectId)}/storyboard${
-          focusedId === projectId ? "" : `/${encodeURIComponent(focusedId)}`
-        }`}
-        className="shrink-0 text-xs text-zinc-400 transition-colors hover:text-white"
-      >
-        Storyboard view
-      </Link>
-    </div>
-  );
-}
+// (The old GraphViewChrome row — a full-width strip holding only the
+// "Storyboard view" link — is gone: the link lives in the board's overflow
+// menu now, so the page starts at the preview itself.)

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-config.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-config.ts
@@ -17,9 +17,14 @@ export const TIMELINE_PPS = 40;
  */
 export const MIN_TIMELINE_PPS = 6;
 export const MAX_TIMELINE_PPS = 200;
-export const DEFAULT_TIMELINE_PPS = TIMELINE_PPS;
+/** Opens a notch wider than the packing constant's 40 so clips breathe. */
+export const DEFAULT_TIMELINE_PPS = 50;
 
-export const GRID_GAP = 8;
+/** Gap between grid cells — sized as the seek-rail BAND: the slim track
+ *  centres inside it with clear space on both sides, so the rail (and its
+ *  thumb) never touches the cards above or below. The strips reserve the
+ *  same 16px as top padding (`pt-4`) for their rail. */
+export const GRID_GAP = 16;
 
 /** The five steps of the page-wide item size control. */
 export type ItemSize = "xs" | "sm" | "md" | "lg" | "xl";
@@ -59,7 +64,7 @@ export const ITEM_SIZE_DIMENSIONS = {
   { strip: number; gridWidth: number; gridHeight: number }
 >;
 
-export const DEFAULT_ITEM_SIZE: ItemSize = "md";
+export const DEFAULT_ITEM_SIZE: ItemSize = "lg";
 
 /**
  * The size one step SMALLER, clamped at the floor. Children timelines render a

--- a/apps/timeline-gstudio001/components/timeline/sidebar-tool-palette.stories.tsx
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-tool-palette.stories.tsx
@@ -64,14 +64,16 @@ export const DragOnly: Story = {
 // Behavior
 // ---------------------------------------------------------------------------
 
-/** The tiles are real buttons, so they are reachable and named as actions. */
+/** The tile is a real button, so it is reachable and named as an action.
+ *  (Collection is the only tool: the image/video placeholder tools were
+ *  removed — media arrives via the Assets drawer or OS file drops.) */
 export const AccessibleNames: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const tools = canvas.getAllByRole("button");
-    await expect(tools).toHaveLength(3);
+    await expect(tools).toHaveLength(1);
     await expect(
-      canvas.getByRole("button", { name: "Add Image Clip to the open timeline" }),
+      canvas.getByRole("button", { name: "Add Collection to the open timeline" }),
     ).toBeInTheDocument();
     // Drag survives the switch to <button> — it is the position affordance.
     await expect(tools[0]).toHaveAttribute("draggable", "true");
@@ -100,10 +102,10 @@ export const ClickActivates: Story = {
 export const KeyboardActivates: Story = {
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
-    const video = canvas.getByRole("button", { name: "Add Video Clip to the open timeline" });
+    const tool = canvas.getByRole("button", { name: "Add Collection to the open timeline" });
 
-    video.focus();
-    await expect(video).toHaveFocus();
+    tool.focus();
+    await expect(tool).toHaveFocus();
 
     await userEvent.keyboard("{Enter}");
     await expect(args.onActivate).toHaveBeenCalledTimes(1);
@@ -111,7 +113,7 @@ export const KeyboardActivates: Story = {
     await userEvent.keyboard(" ");
     await expect(args.onActivate).toHaveBeenCalledTimes(2);
     await expect(args.onActivate).toHaveBeenLastCalledWith(
-      expect.objectContaining({ type: "video" }),
+      expect.objectContaining({ type: "collection" }),
     );
   },
 };

--- a/apps/timeline-gstudio001/components/timeline/sidebar-tool-palette.tsx
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-tool-palette.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { FolderPlus, Image, Video } from "lucide-react";
+import { FolderPlus } from "lucide-react";
 
 import { SidebarTooltipLabel } from "./sidebar-tooltip-label";
 
@@ -20,7 +20,11 @@ import { SidebarTooltipLabel } from "./sidebar-tooltip-label";
 //   - DRAG carries the tool over a strip and picks a POSITION. It stays as the
 //     precision affordance, not the only one.
 
-export type SidebarToolType = "collection" | "image" | "video";
+// Collection is the ONLY tool: it mints structure, which nothing else can.
+// The old image/video tools minted demo-content placeholder clips (picsum /
+// stock mp4) that no real workflow used — media enters through the Assets
+// drawer or an OS file drop, both of which carry actual files.
+export type SidebarToolType = "collection";
 
 export type SidebarToolItem = Readonly<{
   type: SidebarToolType;
@@ -36,8 +40,6 @@ export const SIDEBAR_TOOL_ITEMS: readonly SidebarToolItem[] = [
     description: "Nested timeline beat",
     icon: FolderPlus,
   },
-  { type: "image", label: "Image Clip", description: "Image timeline clip", icon: Image },
-  { type: "video", label: "Video Clip", description: "Video timeline clip", icon: Video },
 ];
 
 export function SidebarToolPalette({

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -5,33 +5,40 @@ import {
   Images,
   Layers,
   FolderPlus,
-  Image,
-  Video,
-  Film,
-  Hammer,
+  FolderTree,
+  GalleryHorizontalEnd,
+  LayoutGrid,
+  Ruler,
   Settings,
+  TvMinimal,
   UserCircle,
   LogOut,
   Trash2,
 } from "lucide-react";
 import Link from "next/link";
-import { usePathname, useSearchParams } from "next/navigation";
+import { usePathname } from "next/navigation";
 import { AssetLibraryDrawer } from "@/components/assets/asset-library-drawer";
 import { TrashDrawer } from "@/components/assets/trash-drawer";
 import { useAuth } from "@/components/auth/auth-provider";
 import {
   GRAPH_ASSETS_TOGGLE_EVENT,
   GRAPH_TRASH_ARRIVAL_EVENT,
+  GRAPH_VIEW_STATE_EVENT,
   isGraphInsertTool,
   isGraphViewRoute,
+  requestGraphChildrenToggle,
+  requestGraphPreviewToggle,
+  requestGraphRulerToggle,
+  requestGraphSurface,
   requestGraphToolInsert,
+  type GraphSurface,
+  type GraphViewStateDetail,
 } from "@/lib/graph-view-events";
 import { toast } from "@/components/core/sonner";
 import { cn } from "@/lib/utils";
 
 import { SidebarToolPalette, type SidebarToolItem } from "./sidebar-tool-palette";
 import { SidebarTooltipLabel } from "./sidebar-tooltip-label";
-import type { ProjectViewMode } from "@storyboard/ui/timeline/timeline-view-state";
 
 type UtilityItem = {
   id: "assets" | "trash" | "settings";
@@ -47,7 +54,12 @@ const SIDEBAR_ICON_IDLE =
 const SIDEBAR_ICON_PRESSED =
   "translate-y-px border-zinc-600 bg-zinc-800 text-zinc-100 shadow-inner shadow-black/50 ring-1 ring-inset ring-zinc-700/70";
 
-type IconLinkProps = {
+type SurfaceIconControlProps = {
+  surface: GraphSurface;
+  /** On a graph route the control is a BUTTON that switches the live view's
+   *  layout through the event bridge; elsewhere it is a LINK that lands on
+   *  the graph route already in that layout. */
+  onGraphRoute: boolean;
   href: string;
   icon: React.ComponentType<{ className?: string }>;
   isActive: boolean;
@@ -55,28 +67,46 @@ type IconLinkProps = {
   description: string;
 };
 
-function IconLink({
+function SurfaceIconControl({
+  surface,
+  onGraphRoute,
   href,
   icon: Icon,
   isActive,
   label,
   description,
-}: IconLinkProps) {
+}: SurfaceIconControlProps) {
   const tooltipId = `sidebar-tooltip-${label.toLowerCase().replace(/\s+/g, "-")}`;
+  const className = cn(
+    SIDEBAR_ICON_BASE,
+    isActive ? SIDEBAR_ICON_PRESSED : SIDEBAR_ICON_IDLE,
+  );
+  const content = (
+    <>
+      <Icon className="h-4 w-4 transition-colors" />
+      <SidebarTooltipLabel id={tooltipId} label={label} description={description} />
+    </>
+  );
 
-  return (
+  return onGraphRoute ? (
+    <button
+      type="button"
+      aria-label={label}
+      aria-describedby={tooltipId}
+      aria-pressed={isActive}
+      onClick={() => requestGraphSurface(surface)}
+      className={className}
+    >
+      {content}
+    </button>
+  ) : (
     <Link
       href={href}
       aria-label={label}
       aria-describedby={tooltipId}
-      aria-current={isActive ? "page" : undefined}
-      className={cn(
-        SIDEBAR_ICON_BASE,
-        isActive ? SIDEBAR_ICON_PRESSED : SIDEBAR_ICON_IDLE,
-      )}
+      className={className}
     >
-      <Icon className="h-4 w-4 transition-colors" />
-      <SidebarTooltipLabel id={tooltipId} label={label} description={description} />
+      {content}
     </Link>
   );
 }
@@ -104,7 +134,6 @@ const UTILITY_ITEMS: UtilityItem[] = [
 
 export function TimelineSidebar() {
   const pathname = usePathname();
-  const searchParams = useSearchParams();
   const { user, logout } = useAuth();
   const [isAssetLibraryOpen, setIsAssetLibraryOpen] = useState(false);
   const [isTrashOpen, setIsTrashOpen] = useState(false);
@@ -140,22 +169,28 @@ export function TimelineSidebar() {
     pathSegments[0] === "timeline" && pathSegments[1]?.startsWith("project-")
       ? pathSegments[1]
       : undefined;
-  const projectView: ProjectViewMode | null = activeProjectId
-    ? pathSegments[2] === "workbench"
-      ? "workbench"
-      : "storyboard"
-    : null;
-  const activeTimelinePath = activeProjectId ? pathSegments.slice(3).join("/") : "";
 
-  const getProjectViewHref = (mode: ProjectViewMode) => {
-    if (!activeProjectId) return mode === "storyboard" ? "/storyboard" : "/workbench";
+  const graphHref = activeProjectId
+    ? `/timeline/${encodeURIComponent(activeProjectId)}/graph`
+    : "/";
 
-    const search = searchParams.toString();
-    const childPath = activeTimelinePath ? `/${activeTimelinePath}` : "";
-    return `/timeline/${encodeURIComponent(activeProjectId)}/${mode}${childPath}${
-      search ? `?${search}` : ""
-    }`;
-  };
+  // The graph view broadcasts its surface + ruler state (on mount and every
+  // change); the sidebar's layout icons and ruler toggle reflect it. Grid is
+  // the graph's load default, so it is the resting state here too.
+  const [graphView, setGraphView] = useState<GraphViewStateDetail>({
+    surface: "grid",
+    rulerOn: false,
+    childrenShown: false,
+    previewOn: false,
+  });
+  useEffect(() => {
+    const onState = (event: Event) => {
+      const detail = (event as CustomEvent<GraphViewStateDetail>).detail;
+      if (detail) setGraphView(detail);
+    };
+    window.addEventListener(GRAPH_VIEW_STATE_EVENT, onState);
+    return () => window.removeEventListener(GRAPH_VIEW_STATE_EVENT, onState);
+  }, []);
 
   useEffect(() => {
     if (!toastMessage) return;
@@ -205,19 +240,21 @@ export function TimelineSidebar() {
     window.dispatchEvent(new CustomEvent("gstudio-drag-end"));
   };
 
+  const onGraphRoute = isGraphViewRoute(pathname);
   // Dragging a tool onto a strip is POINTER-only (native HTML5 drag with a
   // custom DataTransfer), so on the graph route activation appends it to the
   // open timeline instead — the keyboard, screen-reader, and touch route to
   // the same result. Drag remains the way to choose a POSITION.
-  const canInsertTools = isGraphViewRoute(pathname);
+  const canInsertTools = onGraphRoute;
 
   const handleToolActivate = (item: SidebarToolItem) => {
     if (canInsertTools && isGraphInsertTool(item.type)) {
       requestGraphToolInsert(item.type);
       // The graph view announces the authoritative result on its own
-      // aria-live channel (it knows the target and whether it landed); this
-      // is the visible half, for everyone else.
-      setToastMessage(`Added a ${item.label} to the end of the open timeline.`);
+      // aria-live channel (it knows the target and whether it landed —
+      // after the selected card, or appended); this is the visible half,
+      // deliberately position-agnostic.
+      setToastMessage(`Added a ${item.label}.`);
       return;
     }
     showDragToast(item.label);
@@ -254,47 +291,132 @@ export function TimelineSidebar() {
 
       {activeProjectId && (
         <div className="flex flex-col items-center gap-2">
-          <IconLink
-            href={getProjectViewHref("storyboard")}
-            icon={Film}
-            isActive={projectView === "storyboard"}
-            label="Storyboard"
-            description="Project storyboard"
+          {/* The graph's layout switch (was the breadcrumb row's strip/grid
+              toggle). Grid first: it is the initial-load default. */}
+          <SurfaceIconControl
+            surface="grid"
+            onGraphRoute={onGraphRoute}
+            href={graphHref}
+            icon={LayoutGrid}
+            isActive={onGraphRoute && graphView.surface === "grid"}
+            label="Grid layout"
+            description="Graph timelines as grids"
           />
-          <IconLink
-            href={getProjectViewHref("workbench")}
-            icon={Hammer}
-            isActive={projectView === "workbench"}
-            label="Workbench"
-            description="Project workbench"
+          <SurfaceIconControl
+            surface="strip"
+            onGraphRoute={onGraphRoute}
+            href={`${graphHref}?surface=strip`}
+            icon={GalleryHorizontalEnd}
+            isActive={onGraphRoute && graphView.surface === "strip"}
+            label="Strip layout"
+            description="Graph timelines as strips"
           />
         </div>
       )}
 
       {activeProjectId && (
         <>
-          <div className="h-px w-10 shrink-0 bg-zinc-800/80" />
+          {/* zinc-500: the old zinc-800/80 vanished against the rail. */}
+          <div className="h-px w-10 shrink-0 bg-zinc-500" />
 
-          {/* `relative` so the graph board can portal its trash drop target
-              into the slot below, filling the palette's exact footprint and
-              morphing over the tools during a drag (see graph-sidebar-trash). */}
-          <div className="relative">
-            <SidebarToolPalette
-              canInsert={canInsertTools}
-              onActivate={handleToolActivate}
-              onDragStart={handleDragStart}
-              onDragEnd={handleDragEnd}
-            />
-            {/* pointer-events-none so the slot never covers the tool buttons'
-                own drag/click — it only hosts the portaled trash target, which
-                re-enables its OWN pointer-events while a card drag is live (a
-                child overriding a none parent), and whose dnd-kit drop is
-                rect-based regardless. Without this the slot ate the tools'
-                dragstart and sidebar tool-drag stopped working. */}
-            <div
-              id="graph-sidebar-trash-slot"
-              className="pointer-events-none absolute inset-0"
-            />
+          <div className="flex flex-col items-center gap-2">
+            {/* The preview-pane toggle leads the cluster (was the breadcrumb
+                row's TV icon). */}
+            {onGraphRoute && (
+              <button
+                type="button"
+                aria-pressed={graphView.previewOn}
+                aria-label={graphView.previewOn ? "Hide preview" : "Show preview"}
+                aria-describedby="sidebar-tooltip-preview"
+                onClick={requestGraphPreviewToggle}
+                className={cn(
+                  SIDEBAR_ICON_BASE,
+                  graphView.previewOn ? SIDEBAR_ICON_PRESSED : SIDEBAR_ICON_IDLE,
+                )}
+              >
+                <TvMinimal className="h-4 w-4 transition-colors" />
+                <SidebarTooltipLabel
+                  id="sidebar-tooltip-preview"
+                  label="Preview"
+                  description="Play the focused timeline"
+                />
+              </button>
+            )}
+
+            {/* `relative` so the graph board can portal its trash drop target
+                into the slot below, filling the palette's exact footprint and
+                morphing over the tools during a drag (see graph-sidebar-trash). */}
+            <div className="relative">
+              <SidebarToolPalette
+                canInsert={canInsertTools}
+                onActivate={handleToolActivate}
+                onDragStart={handleDragStart}
+                onDragEnd={handleDragEnd}
+              />
+              {/* pointer-events-none so the slot never covers the tool buttons'
+                  own drag/click — it only hosts the portaled trash target, which
+                  re-enables its OWN pointer-events while a card drag is live (a
+                  child overriding a none parent), and whose dnd-kit drop is
+                  rect-based regardless. Without this the slot ate the tools'
+                  dragstart and sidebar tool-drag stopped working. */}
+              <div
+                id="graph-sidebar-trash-slot"
+                className="pointer-events-none absolute inset-0"
+              />
+            </div>
+
+            {/* The children-timelines toggle, under the Collection tool: the
+                two are a pair (Collection MAKES a nested timeline, this shows
+                or hides the tree of them). */}
+            {onGraphRoute && (
+              <button
+                type="button"
+                aria-pressed={graphView.childrenShown}
+                aria-label={
+                  graphView.childrenShown
+                    ? "Hide children timelines"
+                    : "Show children timelines"
+                }
+                aria-describedby="sidebar-tooltip-children"
+                onClick={requestGraphChildrenToggle}
+                className={cn(
+                  SIDEBAR_ICON_BASE,
+                  graphView.childrenShown ? SIDEBAR_ICON_PRESSED : SIDEBAR_ICON_IDLE,
+                )}
+              >
+                <FolderTree className="h-4 w-4 transition-colors" />
+                <SidebarTooltipLabel
+                  id="sidebar-tooltip-children"
+                  label="Children timelines"
+                  description="Show the nested timeline tree"
+                />
+              </button>
+            )}
+
+            {/* The strip's time-ruler toggle (was in the breadcrumb row). It
+                rides under the children toggle and only exists in strip
+                layout — the grid has no single time axis for a ruler to
+                mark. */}
+            {onGraphRoute && graphView.surface === "strip" && (
+              <button
+                type="button"
+                aria-pressed={graphView.rulerOn}
+                aria-label={graphView.rulerOn ? "Hide time ruler" : "Show time ruler"}
+                aria-describedby="sidebar-tooltip-ruler"
+                onClick={requestGraphRulerToggle}
+                className={cn(
+                  SIDEBAR_ICON_BASE,
+                  graphView.rulerOn ? SIDEBAR_ICON_PRESSED : SIDEBAR_ICON_IDLE,
+                )}
+              >
+                <Ruler className="h-4 w-4 transition-colors" />
+                <SidebarTooltipLabel
+                  id="sidebar-tooltip-ruler"
+                  label="Time ruler"
+                  description="Tick marks over every strip"
+                />
+              </button>
+            )}
           </div>
         </>
       )}

--- a/apps/timeline-gstudio001/lib/graph-view-events.ts
+++ b/apps/timeline-gstudio001/lib/graph-view-events.ts
@@ -20,19 +20,72 @@ export function isGraphViewRoute(pathname: string): boolean {
 
 export const GRAPH_INSERT_TOOL_EVENT = "graph-view:insert-tool";
 
-/** The palette tools, mirrored by `isSidebarTool` on the graph side. */
-export type GraphInsertTool = "collection" | "image" | "video";
+/** The palette tools, mirrored by `isSidebarTool` on the graph side.
+ *  Collection only: the old image/video placeholder tools were removed —
+ *  media enters through the Assets drawer or OS file drops. */
+export type GraphInsertTool = "collection";
 
 export type GraphInsertToolDetail = Readonly<{ tool: GraphInsertTool }>;
 
 export function isGraphInsertTool(value: string): value is GraphInsertTool {
-  return value === "collection" || value === "image" || value === "video";
+  return value === "collection";
 }
 
 /** Ask the graph view to append a palette tool to the focused collection. */
 export function requestGraphToolInsert(tool: GraphInsertTool): void {
   window.dispatchEvent(
     new CustomEvent<GraphInsertToolDetail>(GRAPH_INSERT_TOOL_EVENT, { detail: { tool } }),
+  );
+}
+
+// The sidebar's top two icons ARE the graph's layout switch (grid first —
+// the initial-load default — then strip), and the ruler toggle lives under
+// the tool palette in strip mode. Same seam as the tools: the sidebar sets
+// state through request events, and the graph view broadcasts its state back
+// (on mount and on every change) so the sidebar controls can reflect it.
+
+export const GRAPH_SURFACE_EVENT = "graph-view:set-surface";
+export const GRAPH_RULER_TOGGLE_EVENT = "graph-view:toggle-ruler";
+export const GRAPH_CHILDREN_TOGGLE_EVENT = "graph-view:toggle-children";
+export const GRAPH_PREVIEW_TOGGLE_EVENT = "graph-view:toggle-preview";
+export const GRAPH_VIEW_STATE_EVENT = "graph-view:view-state";
+
+/** Mirrors `FocusSurface` in graph-view-config (grid is the load default). */
+export type GraphSurface = "strip" | "grid";
+
+export type GraphViewStateDetail = Readonly<{
+  surface: GraphSurface;
+  rulerOn: boolean;
+  childrenShown: boolean;
+  previewOn: boolean;
+}>;
+
+/** Ask the graph view to switch its layout surface. */
+export function requestGraphSurface(surface: GraphSurface): void {
+  window.dispatchEvent(
+    new CustomEvent<GraphSurface>(GRAPH_SURFACE_EVENT, { detail: surface }),
+  );
+}
+
+/** Ask the graph view to toggle the strip's time ruler. */
+export function requestGraphRulerToggle(): void {
+  window.dispatchEvent(new Event(GRAPH_RULER_TOGGLE_EVENT));
+}
+
+/** Ask the graph view to toggle the children-timelines tree. */
+export function requestGraphChildrenToggle(): void {
+  window.dispatchEvent(new Event(GRAPH_CHILDREN_TOGGLE_EVENT));
+}
+
+/** Ask the graph view to toggle the preview pane. */
+export function requestGraphPreviewToggle(): void {
+  window.dispatchEvent(new Event(GRAPH_PREVIEW_TOGGLE_EVENT));
+}
+
+/** Graph → sidebar: the current view state, for control highlighting. */
+export function broadcastGraphViewState(detail: GraphViewStateDetail): void {
+  window.dispatchEvent(
+    new CustomEvent<GraphViewStateDetail>(GRAPH_VIEW_STATE_EVENT, { detail }),
   );
 }
 

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -330,10 +330,17 @@ async function gridOrder(page: Page, collectionId: string): Promise<string[]> {
 }
 
 async function openGraph(page: Page): Promise<void> {
-  await page.goto(GRAPH_URL);
+  // GRID is the bare-URL load default; this suite's tests are written
+  // against strips, so land directly in strip layout via the deep-link
+  // param (the same one the sidebar's Strip icon uses off-graph).
+  await page.goto(`${GRAPH_URL}?surface=strip`);
   await strip(page, PROJECT_ID)
     .locator('[data-node-id="alpha"]')
     .waitFor({ state: "visible", timeout: 30000 });
+  // Children timelines are OFF by default now; this suite predates that
+  // and reads the tree throughout, so reveal it through the real control
+  // (the sidebar's children icon).
+  await page.getByRole("button", { name: "Show children timelines" }).click();
 }
 
 /** Sub-graph rows start COLLAPSED — expand one to reveal its (lazy-hydrated)
@@ -415,14 +422,20 @@ async function holdDrag(
 const undoButton = (page: Page): Locator => page.getByRole("button", { name: /undo/i });
 const redoButton = (page: Page): Locator => page.getByRole("button", { name: /redo/i });
 
-// Scope header toggles to the main region so sidebar buttons never match.
-const headerToggle = (page: Page, label: string): Locator =>
-  page.getByRole("main").getByRole("button", { name: label, exact: true });
+// The layout switch lives in the SIDEBAR now (its top icons drive the graph
+// surface through the event bridge); the breadcrumb row has no toggle.
+const surfaceButton = (page: Page, surface: "strip" | "grid"): Locator =>
+  page.getByRole("button", {
+    name: surface === "grid" ? "Grid layout" : "Strip layout",
+    exact: true,
+  });
 
 // The preview toggle is an ICON button whose accessible name flips with
-// state ("Show preview" / "Hide preview") — a fixed exact label can't find it.
+// state ("Show preview" / "Hide preview") — a fixed exact label can't find
+// it. It lives in the SIDEBAR now (first icon under the separator), so no
+// main-region scoping.
 const previewToggle = (page: Page): Locator =>
-  page.getByRole("main").getByRole("button", { name: /(show|hide) preview/i });
+  page.getByRole("button", { name: /(show|hide) preview/i });
 
 // The board's own "Assets" button is gone — the SIDEBAR button is the one
 // affordance, and on graph routes it hands off to the palette drawer.
@@ -732,23 +745,60 @@ test.describe("graph view E2E", () => {
       .poll(() => stripOrder(page, CHILD_ID), { timeout: 15000 })
       .toEqual(["c1", "c2"]);
 
-    const layout = page.getByRole("group", { name: "Timeline layout" });
     const childStrip = page.locator(`[data-virtual-strip="${CHILD_ID}"]`);
     const childGrid = page.locator(`[data-virtual-grid="${CHILD_ID}"]`);
 
-    // Default strip mode: the child row is a strip.
+    // openGraph lands in strip mode: the child row is a strip.
     await expect(childStrip).toBeVisible();
     await expect(childGrid).toHaveCount(0);
 
-    // Toggle grid → the child follows the page-wide surface, not just the focus.
-    await layout.getByRole("button", { name: "grid" }).click();
+    // Sidebar Grid icon → the child follows the page-wide surface, not just
+    // the focus.
+    await surfaceButton(page, "grid").click();
     await expect(childGrid).toBeVisible();
     await expect(childStrip).toHaveCount(0);
 
     // Back to strip → the child follows again.
-    await layout.getByRole("button", { name: "strip" }).click();
+    await surfaceButton(page, "strip").click();
     await expect(childStrip).toBeVisible();
     await expect(childGrid).toHaveCount(0);
+  });
+
+  test("grid is the bare-URL default; the sidebar owns layout and the strip-only ruler toggle", async ({
+    page,
+  }) => {
+    await installGraphApi(page);
+    // No ?surface param: the graph must land in GRID layout, with the
+    // sidebar's Grid icon pressed and no ruler toggle (grid has no time
+    // axis; the breadcrumb row hosts neither control anymore).
+    await page.goto(GRAPH_URL);
+    await expect(page.locator(`[data-virtual-grid="${PROJECT_ID}"]`)).toBeVisible();
+    await expect(surfaceButton(page, "grid")).toHaveAttribute("aria-pressed", "true");
+    await expect(surfaceButton(page, "strip")).toHaveAttribute("aria-pressed", "false");
+    await expect(page.getByRole("button", { name: /show time ruler/i })).toHaveCount(0);
+
+    // Children timelines are opt-in: OFF by default, mounted by the
+    // sidebar's children icon.
+    await expect(
+      page.getByRole("button", { name: "Show children timelines" }),
+    ).toHaveAttribute("aria-pressed", "false");
+    await expect(page.locator('section[aria-label^="Sub-timeline"]')).toHaveCount(0);
+
+    // Strip icon → strip layout, and the ruler toggle appears in the
+    // sidebar under the tool cluster.
+    await surfaceButton(page, "strip").click();
+    await expect(strip(page, PROJECT_ID)).toBeVisible();
+    await expect(surfaceButton(page, "strip")).toHaveAttribute("aria-pressed", "true");
+    const rulerToggle = page.getByRole("button", { name: /show time ruler/i });
+    await expect(rulerToggle).toBeVisible();
+
+    // It toggles the real ruler and reads back pressed.
+    await rulerToggle.click();
+    await expect(page.getByRole("button", { name: /hide time ruler/i })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await expect(page.locator("[data-graph-ruler]").first()).toBeVisible();
   });
 
   test("preview height is the user's: tree growth never steals it, and a toggle restores it", async ({
@@ -818,9 +868,15 @@ test.describe("graph view E2E", () => {
     // clamp against the pinned layout, which is a different question than
     // height persistence.
     await page.evaluate(() => window.scrollTo({ top: 0, behavior: "instant" }));
-    await previewToggle(page).click();
+    // KEYBOARD activation for the off/on cycle: a mouse click here made the
+    // runner scroll the page mid-toggle (the fresh pane then mounted pinned
+    // and clamped the restored height — a different question than height
+    // persistence, which is this test's subject).
+    await previewToggle(page).focus();
+    await page.keyboard.press("Enter");
     await expect(divider).toHaveCount(0);
-    await previewToggle(page).click();
+    await previewToggle(page).focus();
+    await page.keyboard.press("Enter");
     await expect(divider).toBeVisible();
     await expect.poll(heightOf).toBe(initial);
   });
@@ -907,10 +963,7 @@ test.describe("graph view E2E", () => {
     await openGraph(page);
     // Switch the surface to grid; the cards become grid cells (same NodeCard,
     // now with "hold" drag activation so a press-and-hold reorders).
-    await page
-      .getByRole("group", { name: "Timeline layout" })
-      .getByRole("button", { name: "grid" })
-      .click();
+    await surfaceButton(page, "grid").click();
     const projectGrid = page.locator(`[data-virtual-grid="${PROJECT_ID}"]`);
     await expect(projectGrid).toBeVisible();
 
@@ -961,7 +1014,8 @@ test.describe("graph view E2E", () => {
     await undoButton(page).click();
 
     await page.goBack();
-    await page.waitForURL(`**${GRAPH_URL}`);
+    // `*` tail: openGraph lands with ?surface=strip, and BACK returns to it.
+    await page.waitForURL(`**${GRAPH_URL}*`);
     await expect
       .poll(() => stripOrder(page, PROJECT_ID))
       .toEqual(["alpha", "bravo", CHILD_ID, "charlie"]);
@@ -1300,10 +1354,7 @@ test.describe("graph view E2E", () => {
     await installGraphApi(page);
     await openGraph(page);
     // Switch the surface to grid, then turn Preview on.
-    await page
-      .getByRole("group", { name: "Timeline layout" })
-      .getByRole("button", { name: "grid" })
-      .click();
+    await surfaceButton(page, "grid").click();
     await previewToggle(page).click();
 
     const playhead = page.locator("[data-graph-grid-playhead]");
@@ -1495,7 +1546,7 @@ test.describe("graph view E2E", () => {
     // A skipped level breaks the chain: the child's clips are not children
     // of the project directly... but a LEGITIMATE deep link to the child
     // itself passes every edge and hydrates on boot.
-    await page.goto(`${GRAPH_URL}/${CHILD_ID}`);
+    await page.goto(`${GRAPH_URL}/${CHILD_ID}?surface=strip`);
     await expect
       .poll(() => stripOrder(page, CHILD_ID), { timeout: 15000 })
       .toEqual(["c1", "c2"]);
@@ -1598,7 +1649,8 @@ test.describe("graph view E2E", () => {
       await collectionCard.click({ position: { x: cardBox.width / 2, y: cardBox.height - 4 } });
       await expect(collectionCard).toHaveAttribute("data-selected", "true", { timeout: 700 });
     }).toPass({ timeout: 10000 });
-    await expect(page).toHaveURL(new RegExp(`${GRAPH_URL}$`));
+    // Query-tolerant: openGraph lands with ?surface=strip on the same path.
+    await expect(page).toHaveURL(new RegExp(`${GRAPH_URL}(\\?.*)?$`));
 
     // The folder button is the pointer twin of O: it DRILLS IN. It is a real
     // <button> SIBLING of the selection surface (nesting one in the card
@@ -1660,27 +1712,11 @@ test.describe("graph view E2E", () => {
     await openGraph(page);
     const dropZone = page.locator(`[data-native-drop="${PROJECT_ID}"]`);
 
-    // 1) Sidebar IMAGE tool: mints a placeholder image clip at the drop
-    //    position (clientX 0 = before the first card).
-    const toolTransfer = await page.evaluateHandle(() => {
-      const transfer = new DataTransfer();
-      transfer.setData("application/x-gstudio-type", "image");
-      return transfer;
-    });
-    await dropZone.dispatchEvent("drop", { dataTransfer: toolTransfer, clientX: 0 });
-    await expect
-      .poll(() => stripOrder(page, PROJECT_ID))
-      .toEqual([
-        expect.stringMatching(/^image-/),
-        "alpha",
-        "bravo",
-        CHILD_ID,
-        "charlie",
-      ]);
-
-    // 2) Sidebar COLLECTION tool: mints a new collection AND creates its
-    //    (empty) child document in the SAME atomic batch as the parent
-    //    update — a drill-in can never 404 on a half-created collection.
+    // 1) Sidebar COLLECTION tool (the only palette tool): mints a new
+    //    collection at the drop position (clientX 0 = before the first
+    //    card) AND creates its (empty) child document in the SAME atomic
+    //    batch as the parent update — a drill-in can never 404 on a
+    //    half-created collection.
     const collectionTransfer = await page.evaluateHandle(() => {
       const transfer = new DataTransfer();
       transfer.setData("application/x-gstudio-type", "collection");
@@ -1703,7 +1739,7 @@ test.describe("graph view E2E", () => {
       api.batches.some((batch) => batch.includes(newChildId) && batch.includes(PROJECT_ID)),
     ).toBe(true);
 
-    // 3) OS FILE drop, several at once: both upload and land as ONE commit.
+    // 2) OS FILE drop, several at once: both upload and land as ONE commit.
     const fileTransfer = await page.evaluateHandle(() => {
       const transfer = new DataTransfer();
       transfer.items.add(new File([new Uint8Array([137, 80, 78, 71])], "photo-a.png", { type: "image/png" }));
@@ -1711,22 +1747,22 @@ test.describe("graph view E2E", () => {
       return transfer;
     });
     await dropZone.dispatchEvent("drop", { dataTransfer: fileTransfer, clientX: 0 });
-    // 4 fixture clips + image tool + collection tool + 2 files = 8.
+    // 4 fixture clips + collection tool + 2 files = 7.
     await expect
       .poll(() => stripOrder(page, PROJECT_ID).then((order) => order.length), { timeout: 10000 })
-      .toBe(8);
+      .toBe(7);
     expect(uploads).toBe(2);
 
     // Both files persisted into the project document in one write.
     await expect
       .poll(() => api.patchesFor(PROJECT_ID).at(-1)?.clipIds.length, { timeout: 5000 })
-      .toBe(8);
+      .toBe(7);
 
     // The whole file drop is ONE undoable step.
     await undoButton(page).click();
     await expect
       .poll(() => stripOrder(page, PROJECT_ID).then((order) => order.length))
-      .toBe(6);
+      .toBe(5);
   });
 
   test("sidebar tools insert from the KEYBOARD, with no pointer involved", async ({ page }) => {
@@ -1737,21 +1773,21 @@ test.describe("graph view E2E", () => {
     await installGraphApi(page);
     await openGraph(page);
 
-    const imageTool = page.getByRole("button", { name: /add image clip/i });
-    await expect(imageTool).toBeVisible();
+    const collectionTool = page.getByRole("button", { name: /add collection/i });
+    await expect(collectionTool).toBeVisible();
 
     // Reach it by TABBING — it must be in the focus order, not just clickable.
-    await imageTool.focus();
-    await expect(imageTool).toBeFocused();
+    await collectionTool.focus();
+    await expect(collectionTool).toBeFocused();
     await page.keyboard.press("Enter");
 
     // Appended to the end of the focused timeline.
     await expect
       .poll(() => stripOrder(page, PROJECT_ID))
-      .toEqual(["alpha", "bravo", CHILD_ID, "charlie", expect.stringMatching(/^image-/)]);
+      .toEqual(["alpha", "bravo", CHILD_ID, "charlie", expect.stringMatching(/^timeline-/)]);
 
     // Space is the other native activation key, and must not be swallowed.
-    await imageTool.focus();
+    await collectionTool.focus();
     await page.keyboard.press(" ");
     await expect
       .poll(() => stripOrder(page, PROJECT_ID).then((order) => order.length))
@@ -1766,7 +1802,52 @@ test.describe("graph view E2E", () => {
     // And it persists.
     await expect
       .poll(() => stripOrder(page, PROJECT_ID).then((order) => order.at(-1)), { timeout: 5000 })
-      .toMatch(/^image-/);
+      .toMatch(/^timeline-/);
+  });
+
+  test("the collection tool lands AFTER the selected card, in that card's own strip", async ({
+    page,
+  }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+
+    // Select bravo (a media clip: click toggles selection, no drill)…
+    await strip(page, PROJECT_ID).locator('[data-node-id="bravo"]').click();
+    await expect(strip(page, PROJECT_ID).locator('[data-node-id="bravo"]')).toHaveAttribute(
+      "data-selected",
+      "true",
+    );
+
+    // …then CLICK the sidebar tool: sidebar clicks never clear selection,
+    // so the new collection lands right after bravo, not at the end.
+    const collectionTool = page.getByRole("button", { name: /add collection/i });
+    await collectionTool.click();
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID))
+      .toEqual([
+        "alpha",
+        "bravo",
+        expect.stringMatching(/^timeline-/),
+        CHILD_ID,
+        "charlie",
+      ]);
+
+    // The selected card may live in ANY strip: select c1 in the CHILD
+    // timeline — the insert follows the selection there, not the focus.
+    await expandSubGraph(page, "Scene A");
+    await expect
+      .poll(() => stripOrder(page, CHILD_ID), { timeout: 15000 })
+      .toEqual(["c1", "c2"]);
+    await strip(page, CHILD_ID).locator('[data-node-id="c1"]').click();
+    await collectionTool.click();
+    await expect
+      .poll(() => stripOrder(page, CHILD_ID))
+      .toEqual(["c1", expect.stringMatching(/^timeline-/), "c2"]);
+
+    // The focused root gained exactly the ONE insert from before.
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID).then((order) => order.length))
+      .toBe(5);
   });
 
   test("keyboard insertion works in grid mode too", async ({ page }) => {
@@ -1775,7 +1856,7 @@ test.describe("graph view E2E", () => {
     // insert bridge is mounted for both surfaces either way.
     await installGraphApi(page);
     await openGraph(page);
-    await headerToggle(page, "grid").click();
+    await surfaceButton(page, "grid").click();
     await expect(page.locator(`[data-native-drop="${PROJECT_ID}"]`)).toHaveCount(1);
 
     await page.getByRole("button", { name: /add collection/i }).focus();
@@ -1897,7 +1978,7 @@ test.describe("graph view E2E", () => {
         const zone = document.querySelector("[data-native-drop]");
         if (!zone) throw new Error("no drop zone");
         const transfer = new DataTransfer();
-        transfer.setData("application/x-gstudio-type", "image");
+        transfer.setData("application/x-gstudio-type", "collection");
 
         const win = window as unknown as { __rectCalls: number };
         win.__rectCalls = 0;
@@ -2120,35 +2201,32 @@ test.describe("graph view E2E", () => {
     await installGraphApi(page);
     await openGraph(page);
 
-    const imageTool = page.getByRole("button", { name: /add image clip/i });
-    await expect(imageTool).toHaveAttribute("draggable", "true");
+    const collectionTool = page.getByRole("button", { name: /add collection/i });
+    await expect(collectionTool).toHaveAttribute("draggable", "true");
 
-    const carried = await imageTool.evaluate((el) => {
+    const carried = await collectionTool.evaluate((el) => {
       const transfer = new DataTransfer();
       el.dispatchEvent(new DragEvent("dragstart", { dataTransfer: transfer, bubbles: true }));
       return transfer.getData("application/x-gstudio-type");
     });
-    expect(carried).toBe("image");
+    expect(carried).toBe("collection");
 
     // ...and the button must actually RECEIVE that dragstart under a real
     // pointer. dispatchEvent above bypasses hit-testing, so it can't catch the
     // regression where the graph's trash slot (an absolute overlay covering
     // the palette footprint) sits ON TOP of the tools and eats their gesture.
-    // Assert hit-testing: the element at each tool's own centre is that tool,
+    // Assert hit-testing: the element at the tool's own centre is that tool,
     // not the slot. (The slot must stay pointer-events-none — R6 #9.)
-    for (const name of [/add collection/i, /add image clip/i, /add video clip/i]) {
-      const tool = page.getByRole("button", { name });
-      const hit = await tool.evaluate((el) => {
-        const r = el.getBoundingClientRect();
-        const top = document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2);
-        return {
-          onThisTool: el.contains(top),
-          coveredBySlot: top?.closest("#graph-sidebar-trash-slot") != null,
-        };
-      });
-      expect(hit.coveredBySlot).toBe(false);
-      expect(hit.onThisTool).toBe(true);
-    }
+    const hit = await collectionTool.evaluate((el) => {
+      const r = el.getBoundingClientRect();
+      const top = document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2);
+      return {
+        onThisTool: el.contains(top),
+        coveredBySlot: top?.closest("#graph-sidebar-trash-slot") != null,
+      };
+    });
+    expect(hit.coveredBySlot).toBe(false);
+    expect(hit.onThisTool).toBe(true);
   });
 
   test("the ruler renders on EVERY displayed strip, not just the focused one", async ({


### PR DESCRIPTION
## What

Relocates the graph view's layout controls out of the breadcrumb chrome and into the timeline sidebar, and trims the sidebar tool palette to **Collection only**.

### Controls moved to the sidebar
- **Grid / Strip layout switch**, **preview toggle**, **ruler toggle**, and **children-tree toggle** now live in the sidebar.
- Wired through the `graph-view-events` bridge: the sidebar sets state via request events (`requestGraphSurface` / `requestGraphRulerToggle` / `requestGraphChildrenToggle` / `requestGraphPreviewToggle`); the graph view calls `broadcastGraphViewState` on mount and on every change, so the sidebar controls highlight in lockstep.
- Grid stays the load default, so it's the sidebar's resting state too.
- The old `GraphViewChrome` "Storyboard view" strip is removed — that link lives in the board's overflow menu now, so the page starts at the preview itself.

### Sidebar tools → Collection only
- Removed the image/video placeholder tools. They minted demo placeholder clips (picsum / stock mp4) no real workflow used; media enters through the Assets drawer or an OS file drop, both of which carry actual files.
- `SidebarToolType`, `GraphInsertTool`, and their guards narrow to `"collection"`.

### Defaults tuned to match the seek-rail work
- `DEFAULT_TIMELINE_PPS` 40 → 50 (clips breathe)
- `GRID_GAP` 8 → 16 (sized as the seek-rail band, so the rail never touches the cards)
- `DEFAULT_ITEM_SIZE` md → lg

### Scroll-anchoring fix
- `overflow-anchor: none` on `<html>`: opening the preview pane mounts content at `main`'s top, and Chrome's scroll anchoring pushed the page down to keep the board still — pinning the fresh pane and shrinking the height the user chose. The pane's own sticky logic owns that relationship.

## Verification
- app `tsc`: clean
- app lint: 0 errors (4 pre-existing `<img>` warnings)
- app vitest: **197/197**
- sidebar-tool-palette stories: **5/5**
- graph-view e2e (Playwright): **42/42** — incl. new tests for sidebar-owned layout, page-wide surface toggle, and preview-height ownership

🤖 Generated with [Claude Code](https://claude.com/claude-code)