### PR TITLE
Graph review: collection drag-ghost images, drop-zone hover feedback, valid tool-drag cursor

### DIFF
--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -203,6 +203,27 @@ html[data-timeline-endpoint-transition="active"]::view-transition-old(.timeline-
   animation: trash-armed-pulse 1.5s ease-in-out infinite;
 }
 
+/* The sidebar trash ICON, while a dragged card hovers the breadcrumb's
+   "Move to trash" zone: a looping wiggle-pop that calls attention to where the
+   item is headed. A continuous twin of the one-shot trash-arrival above. */
+@keyframes trash-hover-attention {
+  0%,
+  100% {
+    transform: scale(1) rotate(0);
+  }
+  30% {
+    transform: scale(1.25) rotate(-8deg);
+    color: rgb(244 244 245);
+  }
+  60% {
+    transform: scale(1.1) rotate(6deg);
+  }
+}
+
+.animate-trash-hover-attention {
+  animation: trash-hover-attention 800ms ease-in-out infinite;
+}
+
 @media (prefers-reduced-motion: reduce) {
   html[data-timeline-route-fade] body {
     animation: none !important;
@@ -217,7 +238,8 @@ html[data-timeline-endpoint-transition="active"]::view-transition-old(.timeline-
   }
 
   .animate-trash-arrival,
-  .animate-trash-armed-pulse {
+  .animate-trash-armed-pulse,
+  .animate-trash-hover-attention {
     animation: none;
   }
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -238,10 +238,35 @@ function GraphAddCollectionButton() {
   const handleDragStart = (event: React.DragEvent) => {
     // Same MIME the sidebar tool used, which NativeDropStrip/Grid accept.
     event.dataTransfer.setData("application/x-gstudio-type", "collection");
-    event.dataTransfer.effectAllowed = "copyMove";
+    event.dataTransfer.effectAllowed = "copy";
     const img = new window.Image();
     img.src = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
     event.dataTransfer.setDragImage(img, 0, 0);
+
+    // The browser shows a "no-drop" cursor wherever a dragover handler doesn't
+    // preventDefault — i.e. everywhere except directly over a strip/grid — so
+    // the cursor flickers to no-drop as the pointer crosses the gaps between
+    // them (and at the very start, up in the header). Claim EVERY dragover at
+    // the document level for the drag's lifetime so the cursor stays a valid
+    // "copy" throughout; the strips/grids still own the drop position and the
+    // actual add. A matching document drop swallows a stray drop that misses
+    // every strip so the browser takes no default action.
+    const onDocDragOver = (e: DragEvent) => {
+      if (!e.dataTransfer?.types.includes("application/x-gstudio-type")) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "copy";
+    };
+    const onDocDrop = (e: DragEvent) => {
+      if (e.dataTransfer?.types.includes("application/x-gstudio-type")) e.preventDefault();
+    };
+    const cleanup = () => {
+      document.removeEventListener("dragover", onDocDragOver);
+      document.removeEventListener("drop", onDocDrop);
+      document.removeEventListener("dragend", cleanup);
+    };
+    document.addEventListener("dragover", onDocDragOver);
+    document.addEventListener("drop", onDocDrop);
+    document.addEventListener("dragend", cleanup, { once: true });
   };
 
   return (

--- a/apps/timeline-gstudio001/components/graph-view/graph-breadcrumb-drop.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-breadcrumb-drop.tsx
@@ -13,7 +13,7 @@ import {
   type NodeId,
 } from "@storyboard/ui/dnd-collections";
 
-import { announceGraphTrashArrival } from "@/lib/graph-view-events";
+import { announceGraphTrashArrival, setGraphTrashDropHover } from "@/lib/graph-view-events";
 
 // The graph's card-drag drop targets live CENTRED IN THE BREADCRUMB ROW now,
 // appearing while a card is being dragged (they were the sidebar tool
@@ -58,6 +58,7 @@ function DropZone({
   label,
   accent,
   dataAttr,
+  onOverChange,
 }: Readonly<{
   targetId: NodeId;
   active: boolean;
@@ -65,11 +66,20 @@ function DropZone({
   label: string;
   accent: ZoneAccent;
   dataAttr: string;
+  /** Notified whenever this zone becomes the hovered drop target (or stops
+   *  being it) — the trash zone uses it to animate the sidebar icon. */
+  onOverChange?: (over: boolean) => void;
 }>) {
   const state = useZoneState(targetId);
   const { setNodeRef } = useDroppable({
     id: encodeDropTarget({ type: "panel", collectionId: targetId }),
   });
+
+  useEffect(() => {
+    onOverChange?.(state === "over");
+  }, [state, onOverChange]);
+  // Belt-and-braces: clear the signal if the zone unmounts mid-hover.
+  useEffect(() => () => onOverChange?.(false), [onOverChange]);
 
   return (
     <div
@@ -179,6 +189,7 @@ export function BreadcrumbDropZones({
           label="Move to trash"
           dataAttr="data-graph-sidebar-trash"
           accent={{ over: "border-zinc-200 bg-zinc-700 text-zinc-50", icon: "text-zinc-100" }}
+          onOverChange={setGraphTrashDropHover}
         />
       )}
     </div>

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -395,10 +395,9 @@ const GraphTrimHandle = memo(function GraphTrimHandle({
   );
 });
 
-/** The image that represents a dragged item: a video's poster frame, an
- *  image clip's own source, or null for a collection (no single frame) or a
- *  poster-less clip — those fall back to a labelled tile. */
-function ghostImageSrc(node: CollectionGhostContentProps["node"]): string | null {
+/** A media clip's own frame: a video's poster, an image's source (null when
+ *  it has neither — the ghost then falls back to a labelled tile). */
+function mediaGhostSrc(node: CollectionGhostContentProps["node"]): string | null {
   if (node.kind !== "media") return null;
   return node.mediaKind === "video" ? (node.posterSrcs?.[0] ?? null) : (node.src ?? null);
 }
@@ -406,23 +405,38 @@ function ghostImageSrc(node: CollectionGhostContentProps["node"]): string | null
 /**
  * The drag ghost: a SQUARE thumbnail of the item being moved (the provider
  * sizes the overlay box square via `dragGhostWidth`/`dragGhostHeight`), so the
- * preview reads as "this picture" rather than a duration-shaped card. Media
- * shows its own frame cover-cropped to the square; a collection (or a clip
- * with no poster) falls back to a labelled tile so the ghost is never an empty
- * or broken box.
+ * preview reads as "this picture" rather than a duration-shaped card. A media
+ * clip shows its own frame; a COLLECTION shows the same child preview frames
+ * its card paints (first/middle/last of its media), derived from the LIVE
+ * graph — which is available inside the drag overlay even though the details
+ * side-table is not. A poster-less clip, or a collection with no media to
+ * show, falls back to a labelled tile so the ghost is never empty or broken.
  */
 const GraphGhost = memo(function GraphGhost({ node, extraCount }: CollectionGhostContentProps) {
-  const imageSrc = ghostImageSrc(node);
+  const isCollection = node.kind === "collection";
+  const collectionPreviews = useHydratedCollectionPreviews(node.id as string, isCollection);
+  const frames: string[] = isCollection
+    ? collectionPreviews.map((preview) => preview.poster ?? preview.src).filter(Boolean)
+    : (() => {
+        const src = mediaGhostSrc(node);
+        return src ? [src] : [];
+      })();
+
   return (
     <span className="relative flex h-full w-full items-center justify-center overflow-hidden rounded-md bg-zinc-900 shadow-2xl ring-2 ring-amber-400">
-      {imageSrc ? (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
-          src={imageSrc}
-          alt=""
-          draggable={false}
-          className="h-full w-full object-cover"
-        />
+      {frames.length > 0 ? (
+        <span className="flex h-full w-full gap-px">
+          {frames.map((src, index) => (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              key={index}
+              src={src}
+              alt=""
+              draggable={false}
+              className="h-full min-w-0 flex-1 object-cover"
+            />
+          ))}
+        </span>
       ) : (
         <span className="flex h-full w-full flex-col items-center justify-center gap-1 p-2 text-center">
           <span className="truncate text-[11px] font-semibold text-zinc-100">{node.name}</span>

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { useSyncExternalStore } from "react";
 
-import { useCollectionsSelector, type NodeId } from "@storyboard/ui/dnd-collections";
+import { parseNodeId, useCollectionsSelector, type NodeId } from "@storyboard/ui/dnd-collections";
 
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
@@ -50,6 +50,29 @@ export function GraphBreadcrumb({
   );
   const focusedTitle = documents[focusedId]?.title ?? focusedNodeName ?? focusedId;
   const rename = useInlineRename(focusedId as NodeId, focusedTitle);
+  // While a card is dragged over the "Move to parent" drop zone, its target is
+  // the focused collection's parent — light up THAT crumb so the user sees
+  // where the item will land. `parentId` is the parent node's id; the crumb
+  // whose id matches it gets the highlight.
+  const parentId = useCollectionsSelector(
+    (snapshot) => snapshot.graph.parentById.get(parseNodeId(focusedId)) ?? null,
+  );
+  const parentDropHovered = useCollectionsSelector((snapshot) => {
+    const intent = snapshot.interaction.dropIntent;
+    const target = snapshot.graph.parentById.get(parseNodeId(focusedId)) ?? null;
+    return (
+      target !== null &&
+      intent?.type === "append-to-collection" &&
+      intent.collectionId === target
+    );
+  });
+  // Just an UNDERLINE (no box/chip): text-decoration is drawn under the glyphs
+  // and never changes the crumb's layout width, so highlighting the parent
+  // never bumps its neighbours.
+  const parentCrumbClass = (crumbId: string) =>
+    parentDropHovered && crumbId === parentId
+      ? " text-sky-200 underline decoration-sky-400 decoration-2 underline-offset-4"
+      : "";
   const parentHref =
     timelinePath.length > 1
       ? `${base}/${timelinePath.slice(0, -1).map(encodeURIComponent).join("/")}`
@@ -76,7 +99,10 @@ export function GraphBreadcrumb({
             renders once, as the current one. */}
         {focusedId !== projectId && (
           <>
-            <Link href={base} className="text-zinc-400 transition-colors hover:text-white">
+            <Link
+              href={base}
+              className={`text-zinc-400 transition-colors hover:text-white${parentCrumbClass(projectId)}`}
+            >
               {documents[projectId]?.title ?? projectId}
             </Link>
             <span>/</span>
@@ -89,7 +115,7 @@ export function GraphBreadcrumb({
                 .slice(0, index + 1)
                 .map(encodeURIComponent)
                 .join("/")}`}
-              className="text-zinc-400 transition-colors hover:text-white"
+              className={`text-zinc-400 transition-colors hover:text-white${parentCrumbClass(segment)}`}
             >
               {documents[segment]?.title ?? segment}
             </Link>

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -21,6 +21,7 @@ import { useAuth } from "@/components/auth/auth-provider";
 import {
   GRAPH_ASSETS_TOGGLE_EVENT,
   GRAPH_TRASH_ARRIVAL_EVENT,
+  GRAPH_TRASH_HOVER_EVENT,
   GRAPH_VIEW_STATE_EVENT,
   isGraphViewRoute,
   requestGraphChildrenToggle,
@@ -216,6 +217,17 @@ export function TimelineSidebar() {
     return () => window.removeEventListener(GRAPH_TRASH_ARRIVAL_EVENT, handleArrival);
   }, []);
 
+  // A dragged card is (or is not) currently over the breadcrumb's trash drop
+  // zone — the icon does an attention wiggle while it is, pointing the user at
+  // where the drop lands.
+  const [trashDropHover, setTrashDropHover] = useState(false);
+  useEffect(() => {
+    const handleHover = (event: Event) =>
+      setTrashDropHover((event as CustomEvent<boolean>).detail === true);
+    window.addEventListener(GRAPH_TRASH_HOVER_EVENT, handleHover);
+    return () => window.removeEventListener(GRAPH_TRASH_HOVER_EVENT, handleHover);
+  }, []);
+
   const onGraphRoute = isGraphViewRoute(pathname);
 
   const handleLogout = async () => {
@@ -406,6 +418,9 @@ export function TimelineSidebar() {
                 key={item.id === "trash" ? trashArrival : undefined}
                 className={cn(
                   "h-4 w-4 transition-colors",
+                  // Continuous wiggle while a card hovers the trash drop zone;
+                  // the one-shot arrival pop takes over on the actual drop.
+                  item.id === "trash" && trashDropHover && "animate-trash-hover-attention",
                   item.id === "trash" && trashArrival > 0 && "animate-trash-arrival",
                 )}
               />

--- a/apps/timeline-gstudio001/lib/graph-view-events.ts
+++ b/apps/timeline-gstudio001/lib/graph-view-events.ts
@@ -100,3 +100,18 @@ export const GRAPH_TRASH_ARRIVAL_EVENT = "graph-view:trash-arrival";
 export function announceGraphTrashArrival(): void {
   window.dispatchEvent(new CustomEvent(GRAPH_TRASH_ARRIVAL_EVENT));
 }
+
+// While a dragged card hovers the breadcrumb's "Move to trash" zone, the
+// sidebar's trash icon plays an attention animation — the drop target lives in
+// the graph tree, the icon is app chrome, so the state crosses the same
+// window-event seam. Detail is the hover on/off boolean.
+
+export const GRAPH_TRASH_HOVER_EVENT = "graph-view:trash-hover";
+
+/** Tell the sidebar's trash icon whether a card is currently over the trash
+ *  drop zone (so it can animate for attention). */
+export function setGraphTrashDropHover(hovering: boolean): void {
+  window.dispatchEvent(
+    new CustomEvent<boolean>(GRAPH_TRASH_HOVER_EVENT, { detail: hovering }),
+  );
+}

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1175,6 +1175,57 @@ test.describe("graph view E2E", () => {
     await expect.poll(() => stripOrder(page, CHILD_ID)).toEqual(["c1", "c2"]);
   });
 
+  test("hovering a drop zone highlights the parent crumb / animates the sidebar trash icon", async ({
+    page,
+  }) => {
+    await installGraphApi(page);
+    // Drill in so the parent zone exists (parent = the project crumb).
+    await page.goto(`${GRAPH_URL}/${encodeURIComponent(CHILD_ID)}?surface=strip`);
+    const c1 = strip(page, CHILD_ID).locator('[data-node-id="c1"]');
+    await c1.waitFor({ state: "visible", timeout: 30000 });
+    await settleMoveAnimations(page);
+
+    const parentZone = page.locator(`[data-graph-parent-drop="${PROJECT_ID}"]`);
+    const trashZone = page.locator(`[data-graph-sidebar-trash="${TRASH_ID}"]`);
+    const parentCrumb = page
+      .getByRole("navigation", { name: "Timeline focus path" })
+      .getByRole("link")
+      .first();
+    const trashIcon = page
+      .getByRole("button", { name: "Trash", exact: true })
+      .locator("svg")
+      .first();
+
+    // Pick c1 up (hold to activate), then hold it — no release — over each zone.
+    const box = (await c1.boundingBox())!;
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.waitForTimeout(400);
+
+    // Over MOVE-TO-PARENT → the parent crumb lights up; trash icon still calm.
+    const pz = (await parentZone.boundingBox())!;
+    await page.mouse.move(pz.x + pz.width / 2, pz.y + pz.height / 2, { steps: 12 });
+    await expect
+      .poll(async () => (await parentCrumb.getAttribute("class")) ?? "")
+      .toContain("decoration-sky-400");
+    await expect(trashIcon).not.toHaveClass(/animate-trash-hover-attention/);
+
+    // Over MOVE-TO-TRASH → the sidebar trash icon animates; crumb highlight clears.
+    const tz = (await trashZone.boundingBox())!;
+    await page.mouse.move(tz.x + tz.width / 2, tz.y + tz.height / 2, { steps: 12 });
+    await expect(trashIcon).toHaveClass(/animate-trash-hover-attention/);
+    await expect
+      .poll(async () => (await parentCrumb.getAttribute("class")) ?? "")
+      .not.toContain("decoration-sky-400");
+
+    // Release back on the source — no move — and the trash animation stops.
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2, { steps: 12 });
+    await page.mouse.up();
+    await page.waitForTimeout(80);
+    await expect(trashIcon).not.toHaveClass(/animate-trash-hover-attention/);
+    expect(await stripOrder(page, CHILD_ID)).toEqual(["c1", "c2"]);
+  });
+
   test("drop into an un-hydrated collection bounces and never writes its document", async ({
     page,
   }) => {


### PR DESCRIPTION
Follow-up graph-view review items (post #144).

## Items
- **Collection drag ghost shows images** — `GraphGhost` fell back to a text tile for any collection. It now paints the collection's child preview frames (first/middle/last of its media), derived from the LIVE graph — which is available inside the drag overlay even though the details side-table is not. Media ghosts are unchanged; a collection with no media (or none loaded) still falls back to the labelled tile.
- **Drop-zone hover feedback** (while a card is dragged over a zone):
  - **Move to parent** → the parent breadcrumb crumb **underlines**. Text-decoration only, so it never changes the crumb's layout width / bumps its neighbours.
  - **Move to trash** → the sidebar trash icon plays a looping attention wiggle (a continuous twin of the one-shot arrival pop), wired from the drop zone to the sidebar chrome over a window event.
- **Valid tool-drag cursor** — the Collection tool drag read as "no-drop" until the pointer was over a strip/grid (the browser only marks those droppable), flickering over the gaps. A document-level `dragover` now claims the cursor as `copy` for the drag's lifetime, so it reads as a valid action throughout; a matching document `drop` swallows a stray drop that misses every strip.

## Coverage
- New hover-feedback e2e: hold a card over each zone (no release) and assert the parent crumb underlines / the sidebar trash icon animates, and that they clear correctly.

## Verification
- app `tsc`: clean
- app lint: 0 errors (4 pre-existing `<img>` warnings)
- app vitest: **197/197**
- graph-item-content stories: **7/7**
- graph-view e2e: **44/44**

## Known follow-up (not in this PR)
Collection previews are built from *direct* media children only (no recursion), so a collection whose direct children are all sub-collections shows no images in either the card or the ghost. Recursing would surface nested media but diverges the live card from the server-side stored summary — deferred pending a product call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)