### PR TITLE
Graph review: recursive collection previews, ancestor-crumb drop targets, refined drag ghost

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -401,11 +401,12 @@ export function GraphBoard({
               />
             </div>
 
-            {/* Card-drag drop targets (move-to-parent + trash), centred over
-                this header row and shown only while a card is being dragged.
-                Inside the header so its absolute layer positions against it;
-                inside the provider so its droppables join the DndContext. */}
-            <BreadcrumbDropZones focusedId={focusedId} trashId={trashRootId} />
+            {/* The trash drop target (right side), shown only while a card is
+                being dragged. The "move up a level" targets are the ancestor
+                breadcrumb crumbs themselves (see GraphBreadcrumb). Inside the
+                header so its absolute layer positions against it; inside the
+                provider so its droppable joins the DndContext. */}
+            <BreadcrumbDropZones trashId={trashRootId} />
           </div>
 
           {surface === "strip" ? (

--- a/apps/timeline-gstudio001/components/graph-view/graph-breadcrumb-drop.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-breadcrumb-drop.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { useDroppable } from "@dnd-kit/core";
-import { FolderUp, Trash2 } from "lucide-react";
+import { Trash2 } from "lucide-react";
 
 import {
   encodeDropTarget,
@@ -139,22 +139,18 @@ function useTrashArrivalAnnounce(trashId: NodeId) {
 }
 
 /**
- * The two card-drag drop zones, centred over the board header. Renders the
- * parent-level zone (unless the focus is the root) and the trash zone, both
+ * The trash card-drag drop zone, right-aligned over the board header (opposite
+ * the breadcrumb). The "move up a level" targets are the ancestor breadcrumb
+ * crumbs themselves now (see AncestorCrumb) — dropping on a crumb moves the
+ * card to that collection, up to the root — so only trash lives here. Shown
  * only while a card drag is live. Also registers the trash id for the keyboard
  * controller (Alt+Delete), which the old sidebar portal used to own.
  */
 export function BreadcrumbDropZones({
-  focusedId,
   trashId,
-}: Readonly<{ focusedId: string; trashId: string | null }>) {
+}: Readonly<{ trashId: string | null }>) {
   const { trashRef } = useCollectionsContainer();
   const isDragging = useCollectionsSelector((s) => s.interaction.isDragging);
-  // The focused collection's parent, if any — the "up one level" target. Null
-  // at the root, where the parent zone is hidden (nowhere up to go).
-  const parentId = useCollectionsSelector(
-    (s) => s.graph.parentById.get(parseNodeId(focusedId)) ?? null,
-  );
   const trashNodeId = trashId !== null ? parseNodeId(trashId) : null;
 
   // Keep the keyboard trash path (Alt+Delete) working now that the sidebar
@@ -169,29 +165,18 @@ export function BreadcrumbDropZones({
 
   useTrashArrivalAnnounce(trashNodeId ?? parseNodeId("__none__"));
 
+  if (trashNodeId === null) return null;
   return (
-    <div className="pointer-events-none absolute inset-0 z-30 flex items-center justify-center gap-3 px-4">
-      {parentId !== null && (
-        <DropZone
-          targetId={parentId}
-          active={isDragging}
-          icon={FolderUp}
-          label="Move to parent"
-          dataAttr="data-graph-parent-drop"
-          accent={{ over: "border-sky-300 bg-sky-800 text-sky-50", icon: "text-sky-100" }}
-        />
-      )}
-      {trashNodeId !== null && (
-        <DropZone
-          targetId={trashNodeId}
-          active={isDragging}
-          icon={Trash2}
-          label="Move to trash"
-          dataAttr="data-graph-sidebar-trash"
-          accent={{ over: "border-zinc-200 bg-zinc-700 text-zinc-50", icon: "text-zinc-100" }}
-          onOverChange={setGraphTrashDropHover}
-        />
-      )}
+    <div className="pointer-events-none absolute inset-0 z-30 flex items-center justify-end px-4">
+      <DropZone
+        targetId={trashNodeId}
+        active={isDragging}
+        icon={Trash2}
+        label="Move to trash"
+        dataAttr="data-graph-sidebar-trash"
+        accent={{ over: "border-zinc-200 bg-zinc-700 text-zinc-50", icon: "text-zinc-100" }}
+        onOverChange={setGraphTrashDropHover}
+      />
     </div>
   );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -414,9 +414,23 @@ function mediaGhostSrc(node: CollectionGhostContentProps["node"]): string | null
  */
 const GraphGhost = memo(function GraphGhost({ node, extraCount }: CollectionGhostContentProps) {
   const isCollection = node.kind === "collection";
-  const collectionPreviews = useHydratedCollectionPreviews(node.id as string, isCollection);
+  // Mirror the CARD (GraphCollectionItemParts) exactly, so the ghost shows what
+  // the card shows: a HYDRATED collection uses its live recursive preview
+  // frames; a placeholder falls back to the stored summary in the details
+  // side-table — reachable here now that the provider wraps the drag overlay.
+  const detail = useClipDetail(node.id as string);
+  const hydrated = detail?.hydrated === true;
+  const livePreviews = useHydratedCollectionPreviews(node.id as string, isCollection && hydrated);
+  const all: readonly CollectionPreviewFrame[] = isCollection
+    ? hydrated
+      ? livePreviews
+      : (detail?.previewItems ?? [])
+    : [];
+  // FIRST and LAST only (or the single frame) — never three, exactly as the
+  // card picks its two representative frames.
+  const chosen = all.length > 1 ? [all[0], all[all.length - 1]] : all;
   const frames: string[] = isCollection
-    ? collectionPreviews.map((preview) => preview.poster ?? preview.src).filter(Boolean)
+    ? chosen.map((preview) => preview.poster ?? preview.src).filter(Boolean)
     : (() => {
         const src = mediaGhostSrc(node);
         return src ? [src] : [];

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -437,7 +437,9 @@ const GraphGhost = memo(function GraphGhost({ node, extraCount }: CollectionGhos
       })();
 
   return (
-    <span className="relative flex h-full w-full items-center justify-center overflow-hidden rounded-md bg-zinc-900 shadow-2xl ring-2 ring-amber-400">
+    // Slightly transparent so the breadcrumb drop zones read THROUGH the ghost
+    // while dragging over them — the user can see where they're aiming.
+    <span className="relative flex h-full w-full items-center justify-center overflow-hidden rounded-md bg-zinc-900 opacity-80 shadow-2xl ring-2 ring-amber-400">
       {frames.length > 0 ? (
         <span className="flex h-full w-full gap-px">
           {frames.map((src, index) => (

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -433,9 +433,10 @@ export function GraphTimelineView({
         // GraphGhost): width AND height pinned so it shows the clip's own
         // frame at a stable 1:1, centred on the grabbed pixel, instead of a
         // duration-shaped card that (for a long clip) buried the drop target
-        // it was aimed at.
-        dragGhostWidth={112}
-        dragGhostHeight={112}
+        // it was aimed at. Kept SMALL so it doesn't cover the breadcrumb drop
+        // zones the user is aiming the drag at.
+        dragGhostWidth={72}
+        dragGhostHeight={72}
         onOpenNode={handleOpenNode}
         openOnClick={openOnClick}
         commandPolicy={commandPolicy}

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -407,6 +407,11 @@ export function GraphTimelineView({
         </p>
       )}
 
+      {/* GraphDetailsProvider wraps DndCollections (not just its children) so
+          the details store is reachable inside the drag OVERLAY too — the
+          collection drag ghost reads a placeholder's stored preview frames
+          there the same way the card does. */}
+      <GraphDetailsProvider store={detailsStore}>
       <DndCollections
         // initialGraph is initial-only (the store is the source of truth
         // thereafter), so a boot re-run for a new session must remount to
@@ -436,7 +441,6 @@ export function GraphTimelineView({
         commandPolicy={commandPolicy}
         onPaletteDiscard={handlePaletteDiscard}
       >
-        <GraphDetailsProvider store={detailsStore}>
           <PersistenceBridge onSync={onSync} />
           <GraphDetailsJanitor />
           <AssetPaletteDrawer open={assetsOpen} onClose={() => setAssetsOpen(false)} />
@@ -484,8 +488,8 @@ export function GraphTimelineView({
               />
             )}
           </GraphViewNavProvider>
-        </GraphDetailsProvider>
       </DndCollections>
+      </GraphDetailsProvider>
     </div>
   );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
@@ -3,8 +3,14 @@
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { useSyncExternalStore } from "react";
+import { useDroppable } from "@dnd-kit/core";
 
-import { parseNodeId, useCollectionsSelector, type NodeId } from "@storyboard/ui/dnd-collections";
+import {
+  encodeDropTarget,
+  parseNodeId,
+  useCollectionsSelector,
+  type NodeId,
+} from "@storyboard/ui/dnd-collections";
 
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
@@ -25,11 +31,55 @@ function focusedIdOf(projectId: string, timelinePath: readonly string[]) {
   return timelinePath[timelinePath.length - 1] ?? projectId;
 }
 
+type CrumbDropState = "idle" | "droppable" | "hovered";
+
+/**
+ * A breadcrumb crumb that DOUBLES AS a drop target while a card is dragged.
+ * The trail already IS the ancestor chain (root … parent), so dropping a card
+ * on any ancestor crumb moves it to THAT collection — up one level, or several,
+ * all the way to the root, in a single motion. Idle it is a plain nav link;
+ * during a drag every ancestor crumb reads as droppable (a dotted underline),
+ * and the crumb under the pointer shows where the item will land (a solid sky
+ * underline). Text-decoration only, so the crumb's width never changes and
+ * nothing shifts as the states toggle. The focused (current) crumb is NOT one
+ * of these — the item already lives there.
+ */
+function AncestorCrumb({
+  crumbId,
+  href,
+  label,
+}: Readonly<{ crumbId: string; href: string; label: string }>) {
+  const { setNodeRef } = useDroppable({
+    id: encodeDropTarget({ type: "panel", collectionId: parseNodeId(crumbId) }),
+  });
+  const state = useCollectionsSelector((snapshot): CrumbDropState => {
+    if (!snapshot.interaction.isDragging) return "idle";
+    const intent = snapshot.interaction.dropIntent;
+    return intent?.type === "append-to-collection" && String(intent.collectionId) === crumbId
+      ? "hovered"
+      : "droppable";
+  });
+  const className =
+    state === "hovered"
+      ? "text-sky-200 underline decoration-sky-400 decoration-2 underline-offset-4"
+      : state === "droppable"
+        ? "text-zinc-300 underline decoration-dotted decoration-zinc-500 underline-offset-4"
+        : "text-zinc-400 transition-colors hover:text-white";
+  return (
+    <span ref={setNodeRef} data-graph-ancestor-drop={crumbId}>
+      <Link href={href} className={className}>
+        {label}
+      </Link>
+    </span>
+  );
+}
+
 /**
  * Where you ARE and how to go up — the navigation unit, rendered inside the
  * board's own header rather than as page chrome above it. It sits where a
  * paragraph of interaction hints used to: the trail is worth permanent space,
- * a list of things you can try is not.
+ * a list of things you can try is not. During a card drag the ancestor crumbs
+ * become drop targets (see AncestorCrumb).
  */
 export function GraphBreadcrumb({
   projectId,
@@ -50,29 +100,6 @@ export function GraphBreadcrumb({
   );
   const focusedTitle = documents[focusedId]?.title ?? focusedNodeName ?? focusedId;
   const rename = useInlineRename(focusedId as NodeId, focusedTitle);
-  // While a card is dragged over the "Move to parent" drop zone, its target is
-  // the focused collection's parent — light up THAT crumb so the user sees
-  // where the item will land. `parentId` is the parent node's id; the crumb
-  // whose id matches it gets the highlight.
-  const parentId = useCollectionsSelector(
-    (snapshot) => snapshot.graph.parentById.get(parseNodeId(focusedId)) ?? null,
-  );
-  const parentDropHovered = useCollectionsSelector((snapshot) => {
-    const intent = snapshot.interaction.dropIntent;
-    const target = snapshot.graph.parentById.get(parseNodeId(focusedId)) ?? null;
-    return (
-      target !== null &&
-      intent?.type === "append-to-collection" &&
-      intent.collectionId === target
-    );
-  });
-  // Just an UNDERLINE (no box/chip): text-decoration is drawn under the glyphs
-  // and never changes the crumb's layout width, so highlighting the parent
-  // never bumps its neighbours.
-  const parentCrumbClass = (crumbId: string) =>
-    parentDropHovered && crumbId === parentId
-      ? " text-sky-200 underline decoration-sky-400 decoration-2 underline-offset-4"
-      : "";
   const parentHref =
     timelinePath.length > 1
       ? `${base}/${timelinePath.slice(0, -1).map(encodeURIComponent).join("/")}`
@@ -99,26 +126,24 @@ export function GraphBreadcrumb({
             renders once, as the current one. */}
         {focusedId !== projectId && (
           <>
-            <Link
+            <AncestorCrumb
+              crumbId={projectId}
               href={base}
-              className={`text-zinc-400 transition-colors hover:text-white${parentCrumbClass(projectId)}`}
-            >
-              {documents[projectId]?.title ?? projectId}
-            </Link>
+              label={documents[projectId]?.title ?? projectId}
+            />
             <span>/</span>
           </>
         )}
         {timelinePath.slice(0, -1).map((segment, index) => (
           <span key={segment} className="flex items-center gap-2">
-            <Link
+            <AncestorCrumb
+              crumbId={segment}
               href={`${base}/${timelinePath
                 .slice(0, index + 1)
                 .map(encodeURIComponent)
                 .join("/")}`}
-              className={`text-zinc-400 transition-colors hover:text-white${parentCrumbClass(segment)}`}
-            >
-              {documents[segment]?.title ?? segment}
-            </Link>
+              label={documents[segment]?.title ?? segment}
+            />
             <span>/</span>
           </span>
         ))}

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -942,11 +942,11 @@ test.describe("graph view E2E", () => {
     await expect(ghost).toBeVisible();
     const ghostBox = (await ghost.boundingBox())!;
 
-    // Fixed 112px SQUARE regardless of the card: a compact thumbnail of the
+    // Fixed 72px SQUARE regardless of the card: a compact thumbnail of the
     // item, materially narrower than the wide source card — proof the ghost is
     // not sized to the clip's duration.
-    expect(ghostBox.width).toBeGreaterThan(104);
-    expect(ghostBox.width).toBeLessThan(120);
+    expect(ghostBox.width).toBeGreaterThan(64);
+    expect(ghostBox.width).toBeLessThan(80);
     expect(Math.abs(ghostBox.height - ghostBox.width)).toBeLessThan(4);
     expect(alphaBox.width).toBeGreaterThan(ghostBox.width + 40);
 
@@ -1125,33 +1125,32 @@ test.describe("graph view E2E", () => {
       .toEqual([]);
   });
 
-  test("the breadcrumb parent zone moves a card up a level (and hides at the root)", async ({
+  test("dropping a card on an ancestor breadcrumb crumb moves it up a level (no crumb at the root)", async ({
     page,
   }) => {
     const api = await installGraphApi(page);
 
-    // At the ROOT the focused collection has no parent, so the parent zone is
-    // not rendered at all (nowhere up to go).
+    // At the ROOT the focused crumb is the ONLY crumb — there are no ANCESTOR
+    // crumbs to drop on (nowhere up to go).
     await page.goto(`${GRAPH_URL}?surface=strip`);
     await strip(page, PROJECT_ID)
       .locator('[data-node-id="alpha"]')
       .waitFor({ state: "visible", timeout: 30000 });
-    await expect(page.locator("[data-graph-parent-drop]")).toHaveCount(0);
+    await expect(page.locator("[data-graph-ancestor-drop]")).toHaveCount(0);
 
-    // Drill into the child: now the parent zone targets the PROJECT (its
-    // parent). It is invisible until a drag, but laid out so holdDrag reaches
-    // it — exactly like the trash zone beside it.
+    // Drill into the child: the PROJECT crumb (its parent) becomes an ancestor
+    // drop target — the trail itself is the "move up a level" control now.
     await page.goto(`${GRAPH_URL}/${encodeURIComponent(CHILD_ID)}?surface=strip`);
     await strip(page, CHILD_ID)
       .locator('[data-node-id="c1"]')
       .waitFor({ state: "visible", timeout: 30000 });
     expect(await stripOrder(page, CHILD_ID)).toEqual(["c1", "c2"]);
-    const parentZone = page.locator(`[data-graph-parent-drop="${PROJECT_ID}"]`);
-    await expect(parentZone).toHaveCount(1);
+    const projectCrumb = page.locator(`[data-graph-ancestor-drop="${PROJECT_ID}"]`);
+    await expect(projectCrumb).toHaveCount(1);
 
-    // Drag c1 up onto the parent zone → it leaves the focused child and lands
-    // in the parent collection.
-    await holdDrag(page, strip(page, CHILD_ID).locator('[data-node-id="c1"]'), parentZone);
+    // Drag c1 up onto the project (parent) crumb → it leaves the focused child
+    // and lands in the parent collection.
+    await holdDrag(page, strip(page, CHILD_ID).locator('[data-node-id="c1"]'), projectCrumb);
 
     // The focused child now holds only c2…
     await expect.poll(() => stripOrder(page, CHILD_ID)).toEqual(["c2"]);
@@ -1175,22 +1174,61 @@ test.describe("graph view E2E", () => {
     await expect.poll(() => stripOrder(page, CHILD_ID)).toEqual(["c1", "c2"]);
   });
 
+  test("every ancestor is a drop target: a card jumps multiple levels to a grandparent crumb", async ({
+    page,
+  }) => {
+    const api = await installGraphApi(page);
+    // Build PROJECT → Scene A (child) → Scene B (grandchild, holds g1).
+    api.documents
+      .get(CHILD_ID)!
+      .clips.push(collectionClip("clip-nested", GRANDCHILD_ID, 2, "Scene B", 1));
+    api.documents.set(GRANDCHILD_ID, {
+      id: GRANDCHILD_ID,
+      title: "Scene B",
+      clips: [mediaClip("g1", "image", 0, 4)],
+    });
+
+    // Focus TWO levels deep, on Scene B, via a deep link.
+    await page.goto(
+      `${GRAPH_URL}/${encodeURIComponent(CHILD_ID)}/${encodeURIComponent(GRANDCHILD_ID)}?surface=strip`,
+    );
+    await strip(page, GRANDCHILD_ID)
+      .locator('[data-node-id="g1"]')
+      .waitFor({ state: "visible", timeout: 30000 });
+
+    // BOTH ancestors are drop targets — the project (root) and Scene A (parent).
+    await expect(page.locator("[data-graph-ancestor-drop]")).toHaveCount(2);
+    const projectCrumb = page.locator(`[data-graph-ancestor-drop="${PROJECT_ID}"]`);
+    await expect(projectCrumb).toHaveCount(1);
+    await expect(page.locator(`[data-graph-ancestor-drop="${CHILD_ID}"]`)).toHaveCount(1);
+
+    // Drop g1 on the PROJECT crumb → it jumps TWO levels up, from Scene B
+    // straight to the project, in a single motion.
+    await holdDrag(page, strip(page, GRANDCHILD_ID).locator('[data-node-id="g1"]'), projectCrumb);
+    await expect.poll(() => stripOrder(page, GRANDCHILD_ID)).toEqual([]);
+    await expect
+      .poll(() => api.patchesFor(GRANDCHILD_ID).at(-1)?.clipIds, { timeout: 5000 })
+      .toEqual([]);
+    await expect
+      .poll(() => api.patchesFor(PROJECT_ID).at(-1)?.clipIds, { timeout: 5000 })
+      .toEqual(["alpha", "bravo", "clip-scene", "charlie", "g1"]);
+  });
+
   test("hovering a drop zone highlights the parent crumb / animates the sidebar trash icon", async ({
     page,
   }) => {
     await installGraphApi(page);
-    // Drill in so the parent zone exists (parent = the project crumb).
+    // Drill in so an ancestor crumb (the project) exists to drop on.
     await page.goto(`${GRAPH_URL}/${encodeURIComponent(CHILD_ID)}?surface=strip`);
     const c1 = strip(page, CHILD_ID).locator('[data-node-id="c1"]');
     await c1.waitFor({ state: "visible", timeout: 30000 });
     await settleMoveAnimations(page);
 
-    const parentZone = page.locator(`[data-graph-parent-drop="${PROJECT_ID}"]`);
+    // The project (ancestor) crumb IS the "move up" drop target; its link
+    // carries the hover underline.
+    const parentZone = page.locator(`[data-graph-ancestor-drop="${PROJECT_ID}"]`);
+    const parentCrumb = parentZone.locator("a");
     const trashZone = page.locator(`[data-graph-sidebar-trash="${TRASH_ID}"]`);
-    const parentCrumb = page
-      .getByRole("navigation", { name: "Timeline focus path" })
-      .getByRole("link")
-      .first();
     const trashIcon = page
       .getByRole("button", { name: "Trash", exact: true })
       .locator("svg")

--- a/packages/timeline-domain/src/adapter.test.ts
+++ b/packages/timeline-domain/src/adapter.test.ts
@@ -721,4 +721,45 @@ describe("hydratedCollectionPreviews (card frames)", () => {
     // Empty: the card keeps its stored summary for a placeholder.
     expect(hydratedCollectionPreviews(focused.value.graph, "kid")).toEqual([]);
   });
+
+  it("recurses into a hydrated sub-collection to surface its nested images", () => {
+    const documents: Record<string, TimelineDocument> = {
+      kid: {
+        id: "kid",
+        title: "Kid",
+        clips: packTimelineClips([collectionClip("clip-sub", "sub", "Sub")]),
+      },
+      sub: {
+        id: "sub",
+        title: "Sub",
+        clips: packTimelineClips([image("s-a", 3), image("s-b", 3)]),
+      },
+    };
+    const focused = buildFocusedGraph(documents, "kid");
+    if (!focused.ok) throw new Error(focused.error);
+
+    // "kid" has NO direct media — only the "sub" collection. The walk descends
+    // into sub and surfaces its images as kid's preview frames (the first
+    // nested image, and beyond).
+    expect(hydratedCollectionPreviews(focused.value.graph, "kid").map((p) => p.id)).toEqual([
+      "s-a",
+      "s-b",
+    ]);
+  });
+
+  it("stops at a placeholder sub-collection (its nested media aren't loaded)", () => {
+    const documents: Record<string, TimelineDocument> = {
+      kid: {
+        id: "kid",
+        title: "Kid",
+        clips: packTimelineClips([collectionClip("clip-sub", "sub", "Sub")]),
+      },
+      // "sub" has no document: it stays a placeholder with no children in the
+      // graph, so the descent finds nothing to show.
+    };
+    const focused = buildFocusedGraph(documents, "kid");
+    if (!focused.ok) throw new Error(focused.error);
+
+    expect(hydratedCollectionPreviews(focused.value.graph, "kid")).toEqual([]);
+  });
 });

--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -373,22 +373,46 @@ export type CollectionPreviewFrame = Readonly<{ id: string; src: string; poster?
  * thumbnail the card paints — `posterSrcs` for video, `src` for an image —
  * and the same first/middle/last selection `previewItemsFrom` uses keeps the
  * card in step with the persisted preview.
+ *
+ * RECURSES into sub-collections: a collection whose direct children are all
+ * nested collections has no media of its own to show, so the walk descends
+ * depth-first (in child order) to surface the first nested image — and the
+ * rest, from which first/middle/last is picked. A placeholder sub-collection
+ * has no children in the graph, so the descent stops there naturally (its
+ * nested media aren't loaded and can't be shown until it hydrates). This is a
+ * LIVE-card enrichment only; the persisted summary (`hydratedCollectionPreviewItems`
+ * / `previewItemsFrom`) stays direct-media, since it can't resolve documents
+ * it doesn't hold.
  */
 export function hydratedCollectionPreviews(
   graph: CollectionsGraph,
   collectionId: string,
 ): readonly CollectionPreviewFrame[] {
   const media: CollectionPreviewFrame[] = [];
-  for (const childId of getChildren(graph, parseNodeId(collectionId))) {
-    const node = graph.nodesById.get(childId);
-    if (!node || node.kind !== "media") continue;
-    const poster = node.mediaKind === "video" ? node.posterSrcs?.[0] : undefined;
-    media.push({
-      id: node.id as string,
-      src: node.src ?? "",
-      ...(poster === undefined ? {} : { poster }),
-    });
-  }
+  const seen = new Set<string>();
+  const collect = (id: NodeId): void => {
+    for (const childId of getChildren(graph, id)) {
+      const node = graph.nodesById.get(childId);
+      if (!node) continue;
+      if (node.kind === "media") {
+        const poster = node.mediaKind === "video" ? node.posterSrcs?.[0] : undefined;
+        media.push({
+          id: node.id as string,
+          src: node.src ?? "",
+          ...(poster === undefined ? {} : { poster }),
+        });
+      } else if (node.kind === "collection") {
+        // Descend to find nested images. `seen` guards a pathological cycle
+        // (the graph is a tree, so this is belt-and-braces).
+        const key = node.id as string;
+        if (!seen.has(key)) {
+          seen.add(key);
+          collect(childId);
+        }
+      }
+    }
+  };
+  collect(parseNodeId(collectionId));
   if (media.length <= 3) return media;
   return [media[0], media[Math.floor(media.length / 2)], media[media.length - 1]];
 }


### PR DESCRIPTION
Follow-up graph-view review items (post #145).

## Items
- **Collection previews recurse into sub-collections** — `hydratedCollectionPreviews` (the live card/ghost frame derivation) walked only DIRECT media children, so a collection whose direct children are all nested collections showed nothing. It now descends depth-first, in child order, to surface the first nested image (and beyond, for first/last). A placeholder sub-collection has no graph children, so the descent stops there naturally. Live-card enrichment only; the persisted summary stays direct-media.
- **Drag ghost mirrors the card** — shows **first + last** frames (never three), and an un-hydrated collection falls back to its **stored** preview summary. `GraphDetailsProvider` now wraps `DndCollections` (not just its children) so the details side-table is reachable inside the drag overlay, letting the ghost use the same `hydrated ? live : stored` selection the card does.
- **Breadcrumb crumbs are the "move up a level" drop targets** — the trail already IS the ancestor chain, so during a card drag every ancestor crumb becomes a drop target: dropping a card on a crumb moves it to that collection — up one level, or several, straight to the root in one motion. Idle it's a nav link; during a drag it reads as droppable (dotted underline), solid sky underline under the pointer (text-decoration only, no width shift). The separate wide "Move to parent" zone is gone; the trash zone stays, right-aligned opposite the breadcrumb.
- **Drag ghost refined** — 112 → **72px** square and ~**80% opaque**, so it no longer covers the crumbs the drag is aimed at and the drop zones read through it.

## Coverage
- Unit: previews recurse into a hydrated sub-collection; stop at a placeholder.
- E2E: ancestor-crumb drop (parent) + no-crumb-at-root; **multi-level jump to a grandparent crumb** (two levels up in one drop); hover underlines the crumb / animates the trash icon; ghost size assertion → 72.

## Verification
- ui + app `tsc`: clean
- app lint: 0 errors (4 pre-existing `<img>` warnings)
- unit: **43/43**
- graph-item-content stories: **7/7**
- graph-view e2e: **45/45** (767 is a known dev-server transient — passes in isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)