### PR TITLE
Graph drag: 16:9 ghost, destination readout, faded chrome

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -29,7 +29,7 @@ import {
 import { Slider } from "@/components/core/slider";
 
 import { NativeDropGrid, NativeDropStrip, SidebarToolInsertBridge } from "./graph-native-drop";
-import { BreadcrumbDropZones } from "./graph-breadcrumb-drop";
+import { BreadcrumbDropZones, DragChromeFade } from "./graph-breadcrumb-drop";
 import { OpenKeyBoundary } from "./graph-navigation";
 import { SyncPanel, type SyncEntry } from "./graph-persistence";
 import {
@@ -367,14 +367,19 @@ export function GraphBoard({
                 (under the transport's play cluster). min-w-0 lets a long
                 breadcrumb truncate inside its wing. */}
             <div className="flex min-w-0 flex-1 items-center">{breadcrumb}</div>
-            <FocusedAggregate
-              focusedId={focusedId}
-              pixelsPerSecond={deferredPixelsPerSecond}
-            />
+            {/* Middle summary and the right-hand controls fade out under the
+                drag readout that overlays this row, and fade back on drop. The
+                breadcrumb stays — it IS the drop target. */}
+            <DragChromeFade className="flex items-center">
+              <FocusedAggregate
+                focusedId={focusedId}
+                pixelsPerSecond={deferredPixelsPerSecond}
+              />
+            </DragChromeFade>
             {/* flex-wrap + wrap-capable controls so a narrow viewport folds the
                 toolbar onto a second line instead of pushing controls
                 off-screen. No effect when it fits. */}
-            <div className="flex flex-1 flex-wrap items-center justify-end gap-2">
+            <DragChromeFade className="flex flex-1 flex-wrap items-center justify-end gap-2">
               {/* The Collection tool (moved here from the icon sidebar): the
                   view's one "add structure" action leads the cluster, fenced
                   off from the surface/history controls to its right. */}
@@ -399,7 +404,7 @@ export function GraphBoard({
                 onItemSizeChange={onItemSizeChange}
                 storyboardHref={storyboardHref}
               />
-            </div>
+            </DragChromeFade>
 
             {/* The trash drop target (right side), shown only while a card is
                 being dragged. The "move up a level" targets are the ancestor

--- a/apps/timeline-gstudio001/components/graph-view/graph-breadcrumb-drop.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-breadcrumb-drop.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useSyncExternalStore, type ReactNode } from "react";
 import { useDroppable } from "@dnd-kit/core";
-import { Trash2 } from "lucide-react";
+import { FolderInput, Trash2 } from "lucide-react";
 
 import {
   encodeDropTarget,
@@ -13,6 +13,7 @@ import {
   type NodeId,
 } from "@storyboard/ui/dnd-collections";
 
+import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 import { announceGraphTrashArrival, setGraphTrashDropHover } from "@/lib/graph-view-events";
 
 // The graph's card-drag drop targets live CENTRED IN THE BREADCRUMB ROW now,
@@ -42,6 +43,71 @@ function useZoneState(targetId: NodeId): ZoneState {
   });
 }
 
+/** The collection the current drag would drop INTO, named for display. Live
+ *  only while a card drag points at an append-to-collection target (a
+ *  breadcrumb crumb, a collection card, or the trash) — null otherwise. The
+ *  ghost sits on the cursor and hides whatever the pointer is over, so this
+ *  feeds a readout ELSEWHERE (the trash slot) that says where the drop lands.
+ *  Each selector returns a primitive so no per-call allocation reaches the
+ *  store's snapshot comparison. */
+type DropDestination = Readonly<{ id: string; name: string; invalid: boolean }>;
+
+function useDropDestination(): DropDestination | null {
+  const documents = useSyncExternalStore(
+    graphDocumentsGateway.subscribe,
+    graphDocumentsGateway.read,
+    graphDocumentsGateway.read,
+  );
+  const id = useCollectionsSelector((s) => {
+    const intent = s.interaction.dropIntent;
+    return intent?.type === "append-to-collection" ? String(intent.collectionId) : null;
+  });
+  const graphName = useCollectionsSelector((s) =>
+    id !== null ? (s.graph.nodesById.get(id as NodeId)?.name ?? null) : null,
+  );
+  const invalid = useCollectionsSelector((s) =>
+    id !== null ? s.interaction.dropIntentInvalid : false,
+  );
+  if (id === null) return null;
+  // Prefer the document title (what the crumb itself shows) so the readout
+  // matches the label the user is aiming at; fall back to the graph node name.
+  return { id, name: documents[id]?.title ?? graphName ?? "here", invalid };
+}
+
+/**
+ * Fades its children OUT while a card drag is live and back IN on drop. The
+ * trash/destination readout takes over the header's right side during a drag,
+ * so the toolbar icons and the centre summary underneath it would show through;
+ * fading them keeps that surface clean and returns them when the drag ends.
+ *
+ * It subscribes to `isDragging` itself so the (large) board header need not —
+ * only this wrapper re-renders on the drag edges, and `children` keep their
+ * identity across that, so the controls inside never re-render. Opacity, not
+ * unmount, so nothing reflows: the breadcrumb keeps its position and the wings
+ * stay balanced. Left click-through (`pointer-events-none`) while hidden so a
+ * faded control can't be hit under the readout.
+ */
+export function DragChromeFade({
+  className,
+  children,
+}: Readonly<{ className?: string; children: ReactNode }>) {
+  const isDragging = useCollectionsSelector((s) => s.interaction.isDragging);
+  return (
+    <div
+      aria-hidden={isDragging || undefined}
+      data-drag-chrome-fade=""
+      data-faded={isDragging ? "true" : "false"}
+      className={[
+        className ?? "",
+        "transition-opacity duration-200 motion-reduce:transition-none",
+        isDragging ? "pointer-events-none opacity-0" : "opacity-100",
+      ].join(" ")}
+    >
+      {children}
+    </div>
+  );
+}
+
 const ZONE_BASE =
   "flex h-10 min-w-[150px] items-center justify-center gap-2 rounded-md border text-xs font-medium transition-all duration-200";
 
@@ -59,6 +125,7 @@ function DropZone({
   accent,
   dataAttr,
   onOverChange,
+  destinationHint,
 }: Readonly<{
   targetId: NodeId;
   active: boolean;
@@ -69,6 +136,11 @@ function DropZone({
   /** Notified whenever this zone becomes the hovered drop target (or stops
    *  being it) — the trash zone uses it to animate the sidebar icon. */
   onOverChange?: (over: boolean) => void;
+  /** When the drag points at some OTHER collection (a breadcrumb crumb or a
+   *  card) rather than this zone, borrow the zone's pixels to name that
+   *  destination — the ghost is covering it, so this is where the user reads
+   *  where the drop will land. Ignored while this zone is itself the target. */
+  destinationHint?: DropDestination | null;
 }>) {
   const state = useZoneState(targetId);
   const { setNodeRef } = useDroppable({
@@ -81,25 +153,50 @@ function DropZone({
   // Belt-and-braces: clear the signal if the zone unmounts mid-hover.
   useEffect(() => () => onOverChange?.(false), [onOverChange]);
 
+  // Borrow the zone for the destination readout only when it is NOT itself the
+  // target ("over"/"invalid" mean the pointer is here — show its own affordance
+  // then). The droppable ref stays mounted either way, so the hit rect is never
+  // lost while the label morphs.
+  const hint = active && state === "idle" ? (destinationHint ?? null) : null;
+
   return (
     <div
       ref={setNodeRef}
       role="group"
       aria-hidden={!active}
       {...{ [dataAttr]: targetId as string }}
-      data-drop-state={state}
+      data-drop-state={hint ? "hint" : state}
       className={[
         ZONE_BASE,
         active ? "pointer-events-auto scale-100 opacity-100" : "pointer-events-none scale-95 opacity-0",
-        state === "over"
-          ? accent.over
-          : state === "invalid"
-            ? "border-zinc-700 bg-zinc-900/90 text-zinc-600"
-            : "border-dashed border-zinc-600 bg-zinc-950/85 text-zinc-300 backdrop-blur-sm",
+        hint
+          ? hint.invalid
+            ? "border-zinc-700 bg-zinc-900/90 text-zinc-500"
+            : "border-sky-400 bg-sky-950/80 text-sky-100"
+          : state === "over"
+            ? accent.over
+            : state === "invalid"
+              ? "border-zinc-700 bg-zinc-900/90 text-zinc-600"
+              : "border-dashed border-zinc-600 bg-zinc-950/85 text-zinc-300 backdrop-blur-sm",
       ].join(" ")}
     >
-      <Icon aria-hidden="true" className={["h-4 w-4", state === "over" ? accent.icon : ""].join(" ")} />
-      {label}
+      {hint ? (
+        <>
+          <FolderInput aria-hidden="true" className="h-4 w-4 shrink-0" />
+          {/* One line that GROWS the box to fit — the readout must always be the
+              right size for the name. The generous cap only engages for an
+              absurdly long name, so it can never overflow the header. */}
+          <span className="max-w-[min(70vw,420px)] truncate whitespace-nowrap">
+            {hint.invalid ? "Can’t drop into " : "Drop into "}
+            <span className="font-semibold">{hint.name}</span>
+          </span>
+        </>
+      ) : (
+        <>
+          <Icon aria-hidden="true" className={["h-4 w-4", state === "over" ? accent.icon : ""].join(" ")} />
+          {label}
+        </>
+      )}
     </div>
   );
 }
@@ -151,7 +248,11 @@ export function BreadcrumbDropZones({
 }: Readonly<{ trashId: string | null }>) {
   const { trashRef } = useCollectionsContainer();
   const isDragging = useCollectionsSelector((s) => s.interaction.isDragging);
+  const destination = useDropDestination();
   const trashNodeId = trashId !== null ? parseNodeId(trashId) : null;
+  // Feed the readout only when the drop lands somewhere OTHER than trash — the
+  // trash keeps its own affordance when it is the target.
+  const destinationHint = destination !== null && destination.id !== trashId ? destination : null;
 
   // Keep the keyboard trash path (Alt+Delete) working now that the sidebar
   // portal that used to register this is gone.
@@ -176,6 +277,7 @@ export function BreadcrumbDropZones({
         dataAttr="data-graph-sidebar-trash"
         accent={{ over: "border-zinc-200 bg-zinc-700 text-zinc-50", icon: "text-zinc-100" }}
         onOverChange={setGraphTrashDropHover}
+        destinationHint={destinationHint}
       />
     </div>
   );

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -429,14 +429,14 @@ export function GraphTimelineView({
         // from ever colliding.
         clickSelection="toggle"
         trimRequiresSelection
-        // The drag ghost is a fixed SQUARE thumbnail of the item (see
+        // The drag ghost is a fixed 16:9 thumbnail of the item (see
         // GraphGhost): width AND height pinned so it shows the clip's own
-        // frame at a stable 1:1, centred on the grabbed pixel, instead of a
-        // duration-shaped card that (for a long clip) buried the drop target
-        // it was aimed at. Kept SMALL so it doesn't cover the breadcrumb drop
-        // zones the user is aiming the drag at.
+        // frame at a stable landscape ratio, centred on the grabbed pixel,
+        // instead of a duration-shaped card that (for a long clip) buried the
+        // drop target it was aimed at. Kept SMALL so it doesn't cover the
+        // breadcrumb drop zones the user is aiming the drag at.
         dragGhostWidth={72}
-        dragGhostHeight={72}
+        dragGhostHeight={40}
         onOpenNode={handleOpenNode}
         openOnClick={openOnClick}
         commandPolicy={commandPolicy}

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -911,7 +911,7 @@ test.describe("graph view E2E", () => {
     expect(api.patchesFor(TRASH_ID)).toHaveLength(0);
   });
 
-  test("the drag ghost is a fixed compact square, not the card's duration-relative width", async ({
+  test("the drag ghost is a fixed compact 16:9 thumbnail, not the card's duration-relative width", async ({
     page,
   }) => {
     await installGraphApi(page);
@@ -942,12 +942,15 @@ test.describe("graph view E2E", () => {
     await expect(ghost).toBeVisible();
     const ghostBox = (await ghost.boundingBox())!;
 
-    // Fixed 72px SQUARE regardless of the card: a compact thumbnail of the
-    // item, materially narrower than the wide source card — proof the ghost is
-    // not sized to the clip's duration.
+    // Fixed 72×40 (16:9) regardless of the card: a compact landscape thumbnail
+    // of the item, materially narrower than the wide source card — proof the
+    // ghost is not sized to the clip's duration. The ratio also excludes the
+    // old square (1:1) shape.
     expect(ghostBox.width).toBeGreaterThan(64);
     expect(ghostBox.width).toBeLessThan(80);
-    expect(Math.abs(ghostBox.height - ghostBox.width)).toBeLessThan(4);
+    const ghostRatio = ghostBox.width / ghostBox.height;
+    expect(ghostRatio).toBeGreaterThan(1.6);
+    expect(ghostRatio).toBeLessThan(2.0);
     expect(alphaBox.width).toBeGreaterThan(ghostBox.width + 40);
 
     // And it rides under the cursor: its centre tracks the pointer on BOTH
@@ -1240,6 +1243,14 @@ test.describe("graph view E2E", () => {
     await page.mouse.down();
     await page.waitForTimeout(400);
 
+    // The middle summary + right toolbar fade out under the drag readout (both
+    // DragChromeFade wrappers); the breadcrumb, the drop target, stays.
+    const chromeFades = page.locator("[data-drag-chrome-fade]");
+    await expect(chromeFades).toHaveCount(2);
+    for (const fade of await chromeFades.all()) {
+      await expect(fade).toHaveAttribute("data-faded", "true");
+    }
+
     // Over MOVE-TO-PARENT → the parent crumb lights up; trash icon still calm.
     const pz = (await parentZone.boundingBox())!;
     await page.mouse.move(pz.x + pz.width / 2, pz.y + pz.height / 2, { steps: 12 });
@@ -1247,6 +1258,13 @@ test.describe("graph view E2E", () => {
       .poll(async () => (await parentCrumb.getAttribute("class")) ?? "")
       .toContain("decoration-sky-400");
     await expect(trashIcon).not.toHaveClass(/animate-trash-hover-attention/);
+
+    // The ghost covers the crumb, so the trash slot borrows its pixels to name
+    // the destination: "Drop into {crumb title}".
+    const crumbLabel = (await parentCrumb.innerText()).trim();
+    await expect(trashZone).toHaveAttribute("data-drop-state", "hint");
+    await expect(trashZone).toContainText("Drop into");
+    await expect(trashZone).toContainText(crumbLabel);
 
     // Over MOVE-TO-TRASH → the sidebar trash icon animates; crumb highlight clears.
     const tz = (await trashZone.boundingBox())!;
@@ -1256,11 +1274,20 @@ test.describe("graph view E2E", () => {
       .poll(async () => (await parentCrumb.getAttribute("class")) ?? "")
       .not.toContain("decoration-sky-400");
 
+    // The trash IS the target now, so the slot is the trash again — not a
+    // destination hint.
+    await expect(trashZone).toHaveAttribute("data-drop-state", "over");
+    await expect(trashZone).toContainText("Move to trash");
+
     // Release back on the source — no move — and the trash animation stops.
     await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2, { steps: 12 });
     await page.mouse.up();
     await page.waitForTimeout(80);
     await expect(trashIcon).not.toHaveClass(/animate-trash-hover-attention/);
+    // Chrome returns once the drag ends.
+    for (const fade of await chromeFades.all()) {
+      await expect(fade).toHaveAttribute("data-faded", "false");
+    }
     expect(await stripOrder(page, CHILD_ID)).toEqual(["c1", "c2"]);
   });
 


### PR DESCRIPTION
Four tweaks to the graph-view drag experience.

## Changes
- **16:9 drag ghost** — the ghost is now a compact 72×40 landscape thumbnail instead of a 72px square (`dragGhostHeight` 72→40). Same small footprint, reads as a frame. Images use `object-cover`, so they crop rather than distort.
- **"Drop into {name}" readout** — while dragging, the ghost sits on the cursor and hides whatever the pointer is over. The trash slot now borrows its pixels to name the live destination (`Drop into {crumb/collection title}`) whenever the target is a breadcrumb crumb or a collection card. It reverts to `Move to trash` when the trash itself is the target, and to idle otherwise. The trash droppable stays mounted the whole time, so its hit rect is never lost — only the label morphs.
- **Faded header chrome during drag** — new `DragChromeFade` wrapper fades the middle summary and the right-hand toolbar out while a drag is live (so they don't show through the readout) and back on drop. The breadcrumb stays — it *is* the drop target. Self-subscribing wrapper, so the board doesn't re-render on drag; children keep their identity.
- **Readout box fits its text** — the destination name is no longer capped/truncated at 180px; the box grows to fit the full name on one line, with a generous `min(70vw,420px)` safety cap so a pathological name can't overflow the header.

## Tests
- Updated the ghost e2e to the 16:9 contract (asserts a landscape ratio, excludes the old square).
- Added assertions to the hover-drag test: readout shows `Drop into {title}` with `data-drop-state="hint"`, reverts to `Move to trash`, and the two `DragChromeFade` wrappers toggle `data-faded`.
- `graph-view` Playwright suite: **45/45**. `tsc` + `eslint` clean.