### PR TITLE
Contextual sidebar: copy / cut / paste / duplicate / delete item actions

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import type { TimelineDocument } from "@storyboard/timeline-model/types";
 import {
@@ -149,14 +149,17 @@ async function duplicateOne(
 /**
  * Snapshot the selection onto the clipboard (Copy / Cut). Each collection's
  * whole document tree is ensured then deep-copied, so the clipboard is
- * independent of the source thereafter. Returns false (and toasts) if a
- * collection's tree can't be loaded.
+ * independent of the source thereafter. The write is guarded by the clipboard
+ * GENERATION observed before the (async) loads: if the clipboard was rebound
+ * to a different user mid-capture, the stale write is refused. Returns false
+ * (and toasts, for load failures) if nothing landed.
  */
 async function captureSelection(
   store: CollectionsStore,
   details: GraphDetailsStore,
   selected: readonly NodeId[],
 ): Promise<boolean> {
+  const atGeneration = graphClipboard.generation();
   const graph = store.getSnapshot().graph;
   const entries: ClipboardEntry[] = [];
   for (const id of selected) {
@@ -175,29 +178,47 @@ async function captureSelection(
     entries.push({ node, detail, documents });
   }
   if (entries.length === 0) return false;
-  graphClipboard.set(entries);
-  return true;
+  return graphClipboard.set(entries, atGeneration);
 }
 
 /**
- * Paste the clipboard into the focused collection, appended. Clones fresh ids
- * from the copy-time snapshot each time. Returns the new node ids.
+ * Paste the clipboard into the focused collection, appended — ONE `add-nodes`
+ * dispatch for every entry, so a multi-item paste is a single undoable step
+ * and a single persisted batch (the same rule the delete path documents, and
+ * the same shape as the multi-file drop commit). Documents seed only after
+ * the dispatch commits; a refusal rolls back the parked details and returns
+ * [] with the clipboard untouched, so the user can retry.
  */
-function pasteIntoFocused(store: CollectionsStore, focusedId: string): NodeId[] {
+function pasteIntoFocused(store: CollectionsStore, focusedId: string): readonly NodeId[] {
   const entries = graphClipboard.read();
   if (entries.length === 0) return [];
   const focusedParent = parseNodeId(focusedId);
-  const newIds: NodeId[] = [];
-  for (const entry of entries) {
-    const clone = cloneNodeForInsert(entry.node, entry.detail, {
+  const clones = entries.map((entry) =>
+    cloneNodeForInsert(entry.node, entry.detail, {
       readDocument: (timelineId) => entry.documents[timelineId] ?? null,
       mintId,
-    });
-    const toIndex = getChildren(store.getSnapshot().graph, focusedParent).length;
-    const newId = insertClone(store, clone, focusedParent, toIndex);
-    if (newId !== null) newIds.push(newId);
+    }),
+  );
+  for (const clone of clones) {
+    if (clone.detail) parkPendingDetail(clone.node.id as string, clone.detail);
   }
-  return newIds;
+  const dispatched = store.dispatch({
+    type: "add-nodes",
+    nodes: clones.map((clone) => clone.node),
+    toParentId: focusedParent,
+    toIndex: getChildren(store.getSnapshot().graph, focusedParent).length,
+  });
+  if (!dispatched.ok) {
+    for (const clone of clones) unparkPendingDetail(clone.node.id as string);
+    return [];
+  }
+  for (const clone of clones) {
+    for (const document of clone.newDocuments) {
+      graphDocumentsGateway.seed(document);
+      graphDocumentsGateway.writeClips(document.id, document.clips);
+    }
+  }
+  return clones.map((clone) => clone.node.id);
 }
 
 /**
@@ -224,14 +245,38 @@ export function GraphItemActionsBridge({
   const store = useCollectionsStore();
   const details = useGraphDetailsStore();
   const selectionSize = useCollectionsSelector((s) => s.interaction.selectedIds.size);
+  // True while an async action (copy/cut/duplicate loading documents) runs.
+  // State so the broadcast below re-fires; the REF is what the (stable) event
+  // listener consults, so the guard needs no effect re-subscription.
+  const [busy, setBusy] = useState(false);
+  const busyRef = useRef(false);
 
-  // Graph → sidebar: mirror the live selection size (on mount and every change).
+  // Graph → sidebar: mirror the live selection size + busy (on mount and every
+  // change) — and zero it on unmount, so a later graph session doesn't flash
+  // the previous session's stale item-mode cluster before its own first
+  // broadcast lands.
   useEffect(() => {
-    broadcastGraphSelection({ count: selectionSize });
-  }, [selectionSize]);
+    broadcastGraphSelection({ count: selectionSize, busy });
+  }, [selectionSize, busy]);
+  useEffect(() => () => broadcastGraphSelection({ count: 0, busy: false }), []);
 
   // Sidebar → graph: run the requested action against the current selection.
   useEffect(() => {
+    // ONE action at a time: the sidebar disables its buttons while busy, but
+    // the guard here is what actually prevents a double-fire (a second click
+    // landing before the broadcast round-trips, or any stray event).
+    const runExclusive = async (action: () => Promise<void>) => {
+      if (busyRef.current) return;
+      busyRef.current = true;
+      setBusy(true);
+      try {
+        await action();
+      } finally {
+        busyRef.current = false;
+        setBusy(false);
+      }
+    };
+
     const duplicateSelection = async () => {
       const selected = [...store.getSnapshot().interaction.selectedIds];
       if (selected.length === 0) return;
@@ -244,18 +289,24 @@ export function GraphItemActionsBridge({
     };
 
     const cutSelection = async () => {
+      // Snapshot the ids BEFORE the async capture: the user can change the
+      // selection while documents load, and the trash move below must remove
+      // exactly what was captured — not whatever is selected by then.
       const selected = [...store.getSnapshot().interaction.selectedIds];
       if (selected.length === 0) return;
       if (!(await captureSelection(store, details, selected))) return;
       // Remove the originals (recoverable in trash); the clipboard holds an
       // independent snapshot, so Paste still relocates them. Item mode stays
       // alive because the clipboard is now non-empty (Paste remains available).
-      moveSelectionToTrash(store, trashId);
+      moveSelectionToTrash(store, trashId, selected);
       store.clearSelection();
     };
 
     const pasteSelection = () => {
-      pasteIntoFocused(store, focusedId);
+      const pasted = pasteIntoFocused(store, focusedId);
+      // Nothing landed (refused dispatch): keep the clipboard so the user can
+      // paste somewhere valid instead of silently losing what they copied.
+      if (pasted.length === 0) return;
       // Paste returns to the normal controls: drop the clipboard and selection.
       graphClipboard.clear();
       store.clearSelection();
@@ -263,18 +314,25 @@ export function GraphItemActionsBridge({
 
     const onAction = (event: Event) => {
       const action = (event as CustomEvent<GraphItemAction>).detail;
+      // Sync actions honour the same one-at-a-time rule: a paste or delete
+      // landing mid-cut would race the capture's trash move.
+      if (busyRef.current) return;
       switch (action) {
         case "copy":
-          void captureSelection(store, details, [...store.getSnapshot().interaction.selectedIds]);
+          void runExclusive(async () => {
+            await captureSelection(store, details, [
+              ...store.getSnapshot().interaction.selectedIds,
+            ]);
+          });
           break;
         case "cut":
-          void cutSelection();
+          void runExclusive(cutSelection);
           break;
         case "paste":
           pasteSelection();
           break;
         case "duplicate":
-          void duplicateSelection();
+          void runExclusive(duplicateSelection);
           break;
         case "delete":
           moveSelectionToTrash(store, trashId);

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import { useEffect } from "react";
+
+import type { TimelineDocument } from "@storyboard/timeline-model/types";
+import {
+  getChildren,
+  parseNodeId,
+  useCollectionsSelector,
+  useCollectionsStore,
+  type CollectionsStore,
+  type NodeId,
+} from "@storyboard/ui/dnd-collections";
+
+import { toast } from "@/components/core/sonner";
+import { graphClipboard, type ClipboardEntry } from "@/lib/graph-clipboard";
+import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
+import type { GraphDetailsStore } from "@/lib/graph-details-store";
+import { cloneNodeForInsert, type CloneForInsert } from "@/lib/graph-node-clone";
+import {
+  GRAPH_ITEM_ACTION_EVENT,
+  broadcastGraphSelection,
+  type GraphItemAction,
+} from "@/lib/graph-view-events";
+
+import { moveSelectionToTrash } from "./graph-navigation";
+import { parkPendingDetail, unparkPendingDetail } from "./graph-pending-details";
+import { useGraphDetailsStore } from "./graph-details-context";
+
+/** A fresh, graph-unique id — the same shape the native-drop/tool paths mint. */
+function mintId(prefix: string): string {
+  return `${prefix}-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Ensure a collection's WHOLE document subtree is cached before a clone reads
+ * it — a placeholder collection's document (and its nested ones) may not be
+ * loaded, since a card's summary comes from its PARENT's clip, not from
+ * loading the child. Returns false if any document fails to load (network),
+ * so the caller can abort rather than clone half a tree.
+ */
+async function ensureDocumentTree(rootTimelineId: string): Promise<boolean> {
+  const seen = new Set<string>();
+  const walk = async (timelineId: string): Promise<boolean> => {
+    if (seen.has(timelineId)) return true;
+    seen.add(timelineId);
+    const doc = await graphDocumentsGateway.ensure(timelineId);
+    if (doc === null) return false;
+    for (const clip of doc.clips) {
+      if (clip.kind === "collection" && !(await walk(clip.childTimelineId))) return false;
+    }
+    return true;
+  };
+  return walk(rootTimelineId);
+}
+
+/**
+ * Deep-copy a collection's document tree out of the cache, keyed by original
+ * id — the copy-time snapshot the clipboard holds. `structuredClone` so a
+ * later edit to the source (or a Cut that trashes it) can't change what Paste
+ * later produces. Caller must `ensureDocumentTree` first.
+ */
+function captureDocumentTree(rootTimelineId: string): Record<string, TimelineDocument> {
+  const out: Record<string, TimelineDocument> = {};
+  const walk = (timelineId: string) => {
+    if (out[timelineId] !== undefined) return;
+    const doc = graphDocumentsGateway.peek(timelineId);
+    if (doc === null) return;
+    out[timelineId] = structuredClone(doc);
+    for (const clip of doc.clips) {
+      if (clip.kind === "collection") walk(clip.childTimelineId);
+    }
+  };
+  walk(rootTimelineId);
+  return out;
+}
+
+/**
+ * Commit one clone into `parentId` at `toIndex` — the shared tail of Duplicate
+ * and Paste. Mirrors the palette insert: park the detail so the persistence
+ * bridge claims it on the add patch, dispatch add-nodes, then seed each cloned
+ * collection's document (revision-0 create + content write) so a drill-in into
+ * the copy never 404s. Returns the new node id, or null if the add was refused.
+ */
+function insertClone(
+  store: CollectionsStore,
+  clone: CloneForInsert,
+  parentId: NodeId,
+  toIndex: number,
+): NodeId | null {
+  if (clone.detail) parkPendingDetail(clone.node.id as string, clone.detail);
+  const dispatched = store.dispatch({
+    type: "add-nodes",
+    nodes: [clone.node],
+    toParentId: parentId,
+    toIndex,
+  });
+  if (!dispatched.ok) {
+    unparkPendingDetail(clone.node.id as string);
+    return null;
+  }
+  for (const document of clone.newDocuments) {
+    graphDocumentsGateway.seed(document);
+    graphDocumentsGateway.writeClips(document.id, document.clips);
+  }
+  return clone.node.id;
+}
+
+/**
+ * Duplicate one source node right AFTER it in its own parent. A collection
+ * deep-clones its document tree first (ensuring its subtree is loaded). Returns
+ * the new node's id, or null if nothing landed.
+ */
+async function duplicateOne(
+  store: CollectionsStore,
+  details: GraphDetailsStore,
+  sourceId: NodeId,
+): Promise<NodeId | null> {
+  const node = store.getSnapshot().graph.nodesById.get(sourceId);
+  if (!node) return null;
+  const detail = details.get(sourceId as string);
+
+  if (node.kind === "collection") {
+    const rootTimelineId = detail?.duplicateOfTimelineId ?? (sourceId as string);
+    if (!(await ensureDocumentTree(rootTimelineId))) {
+      toast("Couldn't load the timeline to duplicate.", { id: "graph-duplicate-load" });
+      return null;
+    }
+  }
+
+  const clone = cloneNodeForInsert(node, detail, {
+    readDocument: (timelineId) => graphDocumentsGateway.peek(timelineId),
+    mintId,
+  });
+
+  // Re-read the live graph: an earlier duplicate in this batch may have shifted
+  // the source's parent's children.
+  const liveGraph = store.getSnapshot().graph;
+  const parentId = liveGraph.parentById.get(sourceId);
+  // A root has a null parent and can't take a sibling — skip it (roots aren't
+  // duplicable anyway).
+  if (parentId === undefined || parentId === null) return null;
+  const siblings = getChildren(liveGraph, parentId);
+  const at = siblings.indexOf(sourceId);
+  const toIndex = at >= 0 ? at + 1 : siblings.length;
+  return insertClone(store, clone, parentId, toIndex);
+}
+
+/**
+ * Snapshot the selection onto the clipboard (Copy / Cut). Each collection's
+ * whole document tree is ensured then deep-copied, so the clipboard is
+ * independent of the source thereafter. Returns false (and toasts) if a
+ * collection's tree can't be loaded.
+ */
+async function captureSelection(
+  store: CollectionsStore,
+  details: GraphDetailsStore,
+  selected: readonly NodeId[],
+): Promise<boolean> {
+  const graph = store.getSnapshot().graph;
+  const entries: ClipboardEntry[] = [];
+  for (const id of selected) {
+    const node = graph.nodesById.get(id);
+    if (!node) continue;
+    const detail = details.get(id as string);
+    let documents: Record<string, TimelineDocument> = {};
+    if (node.kind === "collection") {
+      const rootTimelineId = detail?.duplicateOfTimelineId ?? (id as string);
+      if (!(await ensureDocumentTree(rootTimelineId))) {
+        toast("Couldn't load the timeline to copy.", { id: "graph-copy-load" });
+        return false;
+      }
+      documents = captureDocumentTree(rootTimelineId);
+    }
+    entries.push({ node, detail, documents });
+  }
+  if (entries.length === 0) return false;
+  graphClipboard.set(entries);
+  return true;
+}
+
+/**
+ * Paste the clipboard into the focused collection, appended. Clones fresh ids
+ * from the copy-time snapshot each time. Returns the new node ids.
+ */
+function pasteIntoFocused(store: CollectionsStore, focusedId: string): NodeId[] {
+  const entries = graphClipboard.read();
+  if (entries.length === 0) return [];
+  const focusedParent = parseNodeId(focusedId);
+  const newIds: NodeId[] = [];
+  for (const entry of entries) {
+    const clone = cloneNodeForInsert(entry.node, entry.detail, {
+      readDocument: (timelineId) => entry.documents[timelineId] ?? null,
+      mintId,
+    });
+    const toIndex = getChildren(store.getSnapshot().graph, focusedParent).length;
+    const newId = insertClone(store, clone, focusedParent, toIndex);
+    if (newId !== null) newIds.push(newId);
+  }
+  return newIds;
+}
+
+/**
+ * Bridges the sidebar's item-actions cluster to the live selection. The
+ * sidebar is app chrome living OUTSIDE this provider, so — like the tool
+ * palette and the view-state controls — it talks through a window event.
+ * Rendered INSIDE `<DndCollections>` (next to PersistenceBridge) so it can
+ * reach the engine store and the details side-table, this bridge broadcasts
+ * the selection size and performs the picked action:
+ *
+ *   - Copy  → snapshot the selection to the clipboard (stays in item mode).
+ *   - Cut   → snapshot, then trash the originals; the clipboard keeps an
+ *             independent copy, so Paste still relocates them (a move).
+ *   - Paste → clone the clipboard into the focused collection, then clear the
+ *             clipboard + selection (back to normal).
+ *   - Duplicate → clone each selection in place (after its source).
+ *   - Delete → `moveSelectionToTrash` (shared with the keyboard Delete).
+ *   - Cancel → clear the selection AND the clipboard (back to normal).
+ */
+export function GraphItemActionsBridge({
+  trashId,
+  focusedId,
+}: Readonly<{ trashId: string | null; focusedId: string }>) {
+  const store = useCollectionsStore();
+  const details = useGraphDetailsStore();
+  const selectionSize = useCollectionsSelector((s) => s.interaction.selectedIds.size);
+
+  // Graph → sidebar: mirror the live selection size (on mount and every change).
+  useEffect(() => {
+    broadcastGraphSelection({ count: selectionSize });
+  }, [selectionSize]);
+
+  // Sidebar → graph: run the requested action against the current selection.
+  useEffect(() => {
+    const duplicateSelection = async () => {
+      const selected = [...store.getSnapshot().interaction.selectedIds];
+      if (selected.length === 0) return;
+      const newIds: NodeId[] = [];
+      for (const id of selected) {
+        const newId = await duplicateOne(store, details, id);
+        if (newId !== null) newIds.push(newId);
+      }
+      if (newIds.length > 0) store.setSelection(newIds);
+    };
+
+    const cutSelection = async () => {
+      const selected = [...store.getSnapshot().interaction.selectedIds];
+      if (selected.length === 0) return;
+      if (!(await captureSelection(store, details, selected))) return;
+      // Remove the originals (recoverable in trash); the clipboard holds an
+      // independent snapshot, so Paste still relocates them. Item mode stays
+      // alive because the clipboard is now non-empty (Paste remains available).
+      moveSelectionToTrash(store, trashId);
+      store.clearSelection();
+    };
+
+    const pasteSelection = () => {
+      pasteIntoFocused(store, focusedId);
+      // Paste returns to the normal controls: drop the clipboard and selection.
+      graphClipboard.clear();
+      store.clearSelection();
+    };
+
+    const onAction = (event: Event) => {
+      const action = (event as CustomEvent<GraphItemAction>).detail;
+      switch (action) {
+        case "copy":
+          void captureSelection(store, details, [...store.getSnapshot().interaction.selectedIds]);
+          break;
+        case "cut":
+          void cutSelection();
+          break;
+        case "paste":
+          pasteSelection();
+          break;
+        case "duplicate":
+          void duplicateSelection();
+          break;
+        case "delete":
+          moveSelectionToTrash(store, trashId);
+          store.clearSelection();
+          break;
+        case "cancel":
+          graphClipboard.clear();
+          store.clearSelection();
+          break;
+        default:
+          break;
+      }
+    };
+    window.addEventListener(GRAPH_ITEM_ACTION_EVENT, onAction);
+    return () => window.removeEventListener(GRAPH_ITEM_ACTION_EVENT, onAction);
+  }, [store, details, trashId, focusedId]);
+
+  return null;
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { memo, useCallback, useContext, useEffect, useRef, useState, useSyncExternalStore } from "react";
-import { FolderDown, Image as ImageIcon, Video } from "lucide-react";
+import { FolderTree, Image as ImageIcon, Video } from "lucide-react";
 
 import {
   CollectionItem,
@@ -603,7 +603,9 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
         }}
         className="absolute left-1/2 top-[41%] flex aspect-square h-[34%] -translate-x-1/2 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full bg-zinc-950/70 text-sky-200 ring-1 ring-sky-400/50 backdrop-blur-[2px] transition-colors hover:bg-zinc-900/85 hover:text-sky-100 hover:ring-sky-300"
       >
-        <FolderDown className="h-[55%] w-[55%]" />
+        {/* FolderTree, matching the sidebar's children-timelines toggle — one
+            icon for "this has child timelines" everywhere. */}
+        <FolderTree className="h-[55%] w-[55%]" />
       </button>
 
       {/* The rename editor — a REAL input, overlaying the label row while

--- a/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
@@ -96,10 +96,18 @@ export function GraphViewNavProvider({
  * inside a selected collection travels with its parent) and re-sorts into
  * graph order.
  */
-export function moveSelectionToTrash(store: CollectionsStore, trashId: string | null): number {
+export function moveSelectionToTrash(
+  store: CollectionsStore,
+  trashId: string | null,
+  // Explicit ids for callers that snapshotted the selection BEFORE async work
+  // (the sidebar Cut awaits document loads first — re-reading the live
+  // selection here would trash whatever the user selected in the meantime,
+  // not what they cut). Defaults to the live selection for the keyboard path.
+  ids?: readonly NodeId[],
+): number {
   if (trashId === null || store.getSnapshot().interaction.isDragging) return 0;
   const { graph, interaction } = store.getSnapshot();
-  const selected = [...interaction.selectedIds];
+  const selected = ids ?? [...interaction.selectedIds];
   if (selected.length === 0) return 0;
   const trash = parseNodeId(trashId);
   const movable = selected.filter((nodeId) => resolveTrashCommand(graph, nodeId, trash).ok);

--- a/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
@@ -9,6 +9,7 @@ import {
   parseNodeId,
   resolveTrashCommand,
   useCollectionsStore,
+  type CollectionsStore,
   type NodeId,
 } from "@storyboard/ui/dnd-collections";
 
@@ -82,6 +83,43 @@ export function GraphViewNavProvider({
 }
 
 /**
+ * Move the current selection to the trash root as ONE undoable command — the
+ * shared core of the keyboard Delete/Backspace and the sidebar's Delete
+ * action, so the two can never diverge. Reads the selection from the store,
+ * drops invalid picks (missing, root, already trashed) per-node via
+ * resolveTrashCommand, and returns how many actually moved (0 = nothing
+ * dispatched). No-op mid-drag or with no trash root.
+ *
+ * ONE command for the whole selection, not a per-node loop: parity with the
+ * drag path means one UNDO reverses the whole delete, and the reducer's
+ * multi-node handling prunes descendants of other moved nodes (a selected clip
+ * inside a selected collection travels with its parent) and re-sorts into
+ * graph order.
+ */
+export function moveSelectionToTrash(store: CollectionsStore, trashId: string | null): number {
+  if (trashId === null || store.getSnapshot().interaction.isDragging) return 0;
+  const { graph, interaction } = store.getSnapshot();
+  const selected = [...interaction.selectedIds];
+  if (selected.length === 0) return 0;
+  const trash = parseNodeId(trashId);
+  const movable = selected.filter((nodeId) => resolveTrashCommand(graph, nodeId, trash).ok);
+  if (movable.length === 0) return 0;
+  const dispatched = store.dispatch({
+    type: "move-nodes",
+    nodeIds: movable,
+    toParentId: trash,
+    toIndex: getChildren(graph, trash).length,
+  });
+  // A refusal (the un-hydrated-target policy, a cycle) already speaks through
+  // the commandPolicy's own toast — announce only what landed.
+  if (!dispatched.ok) return 0;
+  toast(`Moved ${movable.length} item${movable.length === 1 ? "" : "s"} to trash.`, {
+    id: "graph-delete-to-trash",
+  });
+  return movable.length;
+}
+
+/**
  * Keyboard boundary for the board: the O key drills into a collection or
  * duplicate-reference card, and plain Delete/Backspace moves the whole current
  * selection to trash.
@@ -113,38 +151,13 @@ export function OpenKeyBoundary({
   // Plain Delete/Backspace trashes EVERY selected card — the pointer twin of
   // dragging a multi-selection onto the trash target, and the unmodified
   // sibling of the package's Alt+Delete (which trashes only the focused card).
-  //
-  // ONE command for the whole selection, not a per-node loop: parity with the
-  // drag path means one UNDO reverses the whole delete (a loop left N entries
-  // behind one keypress), and the reducer's own multi-node handling prunes
-  // descendants of other moved nodes (a selected clip inside a selected
-  // collection travels with its parent instead of being yanked to the trash
-  // root separately) and re-sorts into graph order.
+  // The command itself is `moveSelectionToTrash` (shared with the sidebar's
+  // Delete action); here we only gate the keypress and claim it.
   const trashSelection = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (trashId === null || store.getSnapshot().interaction.isDragging) return;
-    const { graph, interaction } = store.getSnapshot();
-    const selected = [...interaction.selectedIds];
-    if (selected.length === 0) return;
-
+    if (store.getSnapshot().interaction.selectedIds.size === 0) return;
     event.preventDefault();
-    const trash = parseNodeId(trashId);
-    // Per-node validation (missing, root, already-in-trash) keeps the loop's
-    // semantics: invalid picks drop out silently, the rest still move.
-    const movable = selected.filter((nodeId) => resolveTrashCommand(graph, nodeId, trash).ok);
-    if (movable.length === 0) return;
-
-    const dispatched = store.dispatch({
-      type: "move-nodes",
-      nodeIds: movable,
-      toParentId: trash,
-      toIndex: getChildren(graph, trash).length,
-    });
-    // A refusal (the un-hydrated-target policy, a cycle) already speaks
-    // through the commandPolicy's own toast — announce only what landed.
-    if (!dispatched.ok) return;
-    toast(`Moved ${movable.length} item${movable.length === 1 ? "" : "s"} to trash.`, {
-      id: "graph-delete-to-trash",
-    });
+    moveSelectionToTrash(store, trashId);
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useContext, useMemo, useRef, useState } from "react";
-import { FolderDown, Folder, FolderOpen } from "lucide-react";
+import { FolderTree, Folder, FolderOpen } from "lucide-react";
 
 import {
   VirtualGrid,
@@ -221,7 +221,9 @@ function SubTimelineNode({
           onClick={() => nav?.openTimeline(collectionId)}
           className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
         >
-          <FolderDown aria-hidden="true" className="h-4 w-4" />
+          {/* FolderTree, matching the sidebar's children-timelines toggle and
+              the collection card's drill button — one icon for the concept. */}
+          <FolderTree aria-hidden="true" className="h-4 w-4" />
         </button>
       </div>
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -52,6 +52,7 @@ import { trashDocumentId as deriveTrashDocumentId } from "./trash-document-id";
 import { GraphBoard, type FocusSurface, type ItemSize } from "./graph-board";
 import { GraphDetailsProvider } from "./graph-details-context";
 import { HydrationController } from "./graph-hydration";
+import { GraphItemActionsBridge } from "./graph-item-actions";
 import { GRAPH_VIEW_COMPONENTS } from "./graph-item-content";
 import { GraphViewNavProvider } from "./graph-navigation";
 import {
@@ -443,6 +444,7 @@ export function GraphTimelineView({
         onPaletteDiscard={handlePaletteDiscard}
       >
           <PersistenceBridge onSync={onSync} />
+          <GraphItemActionsBridge trashId={boot.trashRootId} focusedId={focusedId} />
           <GraphDetailsJanitor />
           <AssetPaletteDrawer open={assetsOpen} onClose={() => setAssetsOpen(false)} />
           <HydrationController

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -28,6 +28,7 @@ import {
 } from "@storyboard/timeline-domain";
 
 import { useAuth } from "@/components/auth/auth-provider";
+import { graphClipboard } from "@/lib/graph-clipboard";
 import { createGraphDetailsStore } from "@/lib/graph-details-store";
 import {
   graphDocumentsGateway,
@@ -184,9 +185,14 @@ export function GraphTimelineView({
   // AUTH BINDING first: the gateway is a module singleton that outlives
   // soft logout/login, so a different signed-in user must reset it before
   // anything reads or primes. Declared before the prime and boot effects
-  // so mount-order runs bind → prime → boot.
+  // so mount-order runs bind → prime → boot. The clipboard singleton holds
+  // copied document snapshots and follows the same rule — a different user
+  // must never paste the previous user's timelines.
   useEffect(() => {
-    if (user) graphDocumentsGateway.bindUser(user.uid);
+    if (user) {
+      graphDocumentsGateway.bindUser(user.uid);
+      graphClipboard.bindUser(user.uid);
+    }
   }, [user]);
 
   // RSC payloads prime the gateway (guarded inside it: only for the bound

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -1,17 +1,22 @@
 "use client";
 
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useSyncExternalStore } from "react";
 import {
+  ClipboardPaste,
+  Copy,
+  CopyPlus,
   Images,
   Layers,
   FolderTree,
   GalleryHorizontalEnd,
   LayoutGrid,
   Ruler,
+  Scissors,
   Settings,
   TvMinimal,
   LogOut,
   Trash2,
+  X,
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -20,17 +25,22 @@ import { TrashDrawer } from "@/components/assets/trash-drawer";
 import { useAuth } from "@/components/auth/auth-provider";
 import {
   GRAPH_ASSETS_TOGGLE_EVENT,
+  GRAPH_SELECTION_EVENT,
   GRAPH_TRASH_ARRIVAL_EVENT,
   GRAPH_TRASH_HOVER_EVENT,
   GRAPH_VIEW_STATE_EVENT,
   isGraphViewRoute,
   requestGraphChildrenToggle,
+  requestGraphItemAction,
   requestGraphPreviewToggle,
   requestGraphRulerToggle,
   requestGraphSurface,
+  type GraphItemAction,
+  type GraphSelectionDetail,
   type GraphSurface,
   type GraphViewStateDetail,
 } from "@/lib/graph-view-events";
+import { graphClipboard } from "@/lib/graph-clipboard";
 import { toast } from "@/components/core/sonner";
 import { cn } from "@/lib/utils";
 
@@ -104,6 +114,93 @@ function SurfaceIconControl({
     >
       {content}
     </Link>
+  );
+}
+
+const SIDEBAR_ICON_DISABLED =
+  "cursor-not-allowed border-zinc-800/50 bg-zinc-900/20 text-zinc-600 opacity-50";
+
+/** One button in the item-actions cluster — dispatches its action across the
+ *  window-event seam for the graph provider to perform on the selection. */
+function ItemActionButton({
+  action,
+  icon: Icon,
+  label,
+  description,
+  disabled = false,
+}: Readonly<{
+  action: GraphItemAction;
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  description: string;
+  disabled?: boolean;
+}>) {
+  const tooltipId = `sidebar-tooltip-item-${action}`;
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-describedby={tooltipId}
+      disabled={disabled}
+      onClick={() => requestGraphItemAction(action)}
+      className={cn(SIDEBAR_ICON_BASE, disabled ? SIDEBAR_ICON_DISABLED : SIDEBAR_ICON_IDLE)}
+    >
+      <Icon className="h-4 w-4 transition-colors" />
+      <SidebarTooltipLabel id={tooltipId} label={label} description={description} />
+    </button>
+  );
+}
+
+/**
+ * The contextual cluster shown while an item is selected (or something is on
+ * the clipboard). Replaces the layout/toggle controls with actions on the
+ * selected item. Copy/Duplicate/Delete need a live selection; Paste needs a
+ * non-empty clipboard; Cancel always exits back to the normal controls.
+ */
+function ItemActionsCluster({
+  hasSelection,
+  canPaste,
+}: Readonly<{ hasSelection: boolean; canPaste: boolean }>) {
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <ItemActionButton
+        action="copy"
+        icon={Copy}
+        label="Copy"
+        description="Copy the selected item"
+        disabled={!hasSelection}
+      />
+      <ItemActionButton
+        action="cut"
+        icon={Scissors}
+        label="Cut"
+        description="Cut the selected item — paste to move it"
+        disabled={!hasSelection}
+      />
+      <ItemActionButton
+        action="paste"
+        icon={ClipboardPaste}
+        label="Paste"
+        description="Paste into this timeline"
+        disabled={!canPaste}
+      />
+      <ItemActionButton
+        action="duplicate"
+        icon={CopyPlus}
+        label="Duplicate"
+        description="Duplicate the selected item in place"
+        disabled={!hasSelection}
+      />
+      <ItemActionButton
+        action="delete"
+        icon={Trash2}
+        label="Delete"
+        description="Move the selected item to trash"
+        disabled={!hasSelection}
+      />
+      <div className="h-px w-10 shrink-0 bg-zinc-700" />
+      <ItemActionButton action="cancel" icon={X} label="Done" description="Exit item actions" />
+    </div>
   );
 }
 
@@ -228,7 +325,28 @@ export function TimelineSidebar() {
     return () => window.removeEventListener(GRAPH_TRASH_HOVER_EVENT, handleHover);
   }, []);
 
+  // The graph broadcasts how many items are selected; while something is
+  // selected — OR the clipboard holds a copy/cut — the contextual controls
+  // switch to item actions (copy, cut, paste, duplicate, delete, cancel). The
+  // clipboard condition is what keeps Paste reachable after Copy clears the
+  // selection (copy here, drill into another timeline, paste there).
+  const [selectionCount, setSelectionCount] = useState(0);
+  useEffect(() => {
+    const onSelection = (event: Event) => {
+      const detail = (event as CustomEvent<GraphSelectionDetail>).detail;
+      if (detail) setSelectionCount(detail.count);
+    };
+    window.addEventListener(GRAPH_SELECTION_EVENT, onSelection);
+    return () => window.removeEventListener(GRAPH_SELECTION_EVENT, onSelection);
+  }, []);
+  const canPaste = useSyncExternalStore(
+    graphClipboard.subscribe,
+    () => !graphClipboard.isEmpty(),
+    () => false,
+  );
+
   const onGraphRoute = isGraphViewRoute(pathname);
+  const itemMode = onGraphRoute && (selectionCount > 0 || canPaste);
 
   const handleLogout = async () => {
     try {
@@ -255,7 +373,11 @@ export function TimelineSidebar() {
         SW
       </Link>
 
-      {activeProjectId && (
+      {activeProjectId && itemMode && (
+        <ItemActionsCluster hasSelection={selectionCount > 0} canPaste={canPaste} />
+      )}
+
+      {activeProjectId && !itemMode && (
         <div className="flex flex-col items-center gap-2">
           {/* The graph's layout switch (was the breadcrumb row's strip/grid
               toggle). Grid first: it is the initial-load default. */}
@@ -280,7 +402,7 @@ export function TimelineSidebar() {
         </div>
       )}
 
-      {activeProjectId && (
+      {activeProjectId && !itemMode && (
         <>
           {/* zinc-500: the old zinc-800/80 vanished against the rail. */}
           <div className="h-px w-10 shrink-0 bg-zinc-500" />

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -154,13 +154,16 @@ function ItemActionButton({
 /**
  * The contextual cluster shown while an item is selected (or something is on
  * the clipboard). Replaces the layout/toggle controls with actions on the
- * selected item. Copy/Duplicate/Delete need a live selection; Paste needs a
- * non-empty clipboard; Cancel always exits back to the normal controls.
+ * selected item. Copy/Cut/Duplicate/Delete need a live selection; Paste needs
+ * a non-empty clipboard; Done exits back to the normal controls (clearing the
+ * clipboard — with contents kept, item mode couldn't close). While an async
+ * action is in flight (`busy`) every button disables, so nothing double-fires.
  */
 function ItemActionsCluster({
   hasSelection,
   canPaste,
-}: Readonly<{ hasSelection: boolean; canPaste: boolean }>) {
+  busy,
+}: Readonly<{ hasSelection: boolean; canPaste: boolean; busy: boolean }>) {
   return (
     <div className="flex flex-col items-center gap-2">
       <ItemActionButton
@@ -168,38 +171,44 @@ function ItemActionsCluster({
         icon={Copy}
         label="Copy"
         description="Copy the selected item"
-        disabled={!hasSelection}
+        disabled={busy || !hasSelection}
       />
       <ItemActionButton
         action="cut"
         icon={Scissors}
         label="Cut"
         description="Cut the selected item — paste to move it"
-        disabled={!hasSelection}
+        disabled={busy || !hasSelection}
       />
       <ItemActionButton
         action="paste"
         icon={ClipboardPaste}
         label="Paste"
         description="Paste into this timeline"
-        disabled={!canPaste}
+        disabled={busy || !canPaste}
       />
       <ItemActionButton
         action="duplicate"
         icon={CopyPlus}
         label="Duplicate"
         description="Duplicate the selected item in place"
-        disabled={!hasSelection}
+        disabled={busy || !hasSelection}
       />
       <ItemActionButton
         action="delete"
         icon={Trash2}
         label="Delete"
         description="Move the selected item to trash"
-        disabled={!hasSelection}
+        disabled={busy || !hasSelection}
       />
       <div className="h-px w-10 shrink-0 bg-zinc-700" />
-      <ItemActionButton action="cancel" icon={X} label="Done" description="Exit item actions" />
+      <ItemActionButton
+        action="cancel"
+        icon={X}
+        label="Done"
+        description="Exit item actions and clear the clipboard"
+        disabled={busy}
+      />
     </div>
   );
 }
@@ -331,10 +340,14 @@ export function TimelineSidebar() {
   // clipboard condition is what keeps Paste reachable after Copy clears the
   // selection (copy here, drill into another timeline, paste there).
   const [selectionCount, setSelectionCount] = useState(0);
+  const [actionBusy, setActionBusy] = useState(false);
   useEffect(() => {
     const onSelection = (event: Event) => {
       const detail = (event as CustomEvent<GraphSelectionDetail>).detail;
-      if (detail) setSelectionCount(detail.count);
+      if (detail) {
+        setSelectionCount(detail.count);
+        setActionBusy(detail.busy);
+      }
     };
     window.addEventListener(GRAPH_SELECTION_EVENT, onSelection);
     return () => window.removeEventListener(GRAPH_SELECTION_EVENT, onSelection);
@@ -347,6 +360,23 @@ export function TimelineSidebar() {
 
   const onGraphRoute = isGraphViewRoute(pathname);
   const itemMode = onGraphRoute && (selectionCount > 0 || canPaste);
+
+  // Swapping clusters unmounts the control that held keyboard focus (e.g. the
+  // Delete button the user just activated), dumping focus to <body>. Restore
+  // it to the rail's first enabled control — but ONLY on a real mode
+  // TRANSITION (not mount: focus starts on <body> on every page load, and
+  // grabbing it then would steal focus from the document), and ONLY when the
+  // swap actually orphaned focus: a mouse click on a card also flips
+  // itemMode, and focus is on the card then, which must not be stolen.
+  const railRef = useRef<HTMLElement>(null);
+  const prevItemModeRef = useRef<boolean | null>(null);
+  useEffect(() => {
+    const previous = prevItemModeRef.current;
+    prevItemModeRef.current = itemMode;
+    if (previous === null || previous === itemMode) return;
+    if (document.activeElement !== document.body && document.activeElement !== null) return;
+    railRef.current?.querySelector<HTMLButtonElement>("button:not([disabled])")?.focus();
+  }, [itemMode]);
 
   const handleLogout = async () => {
     try {
@@ -364,7 +394,10 @@ export function TimelineSidebar() {
   // outrank them (R7 #8). Nothing overlaps the 72px rail itself, so raising
   // it hides nothing.
   return (
-    <aside className="sticky top-0 z-50 flex h-screen w-[72px] shrink-0 flex-col items-center gap-5 overflow-visible border-r border-zinc-800 bg-zinc-900/50 px-3 py-5 backdrop-blur-md">
+    <aside
+      ref={railRef}
+      className="sticky top-0 z-50 flex h-screen w-[72px] shrink-0 flex-col items-center gap-5 overflow-visible border-r border-zinc-800 bg-zinc-900/50 px-3 py-5 backdrop-blur-md"
+    >
       <Link
         href="/"
         aria-label="Storyboard Workbench home"
@@ -374,7 +407,11 @@ export function TimelineSidebar() {
       </Link>
 
       {activeProjectId && itemMode && (
-        <ItemActionsCluster hasSelection={selectionCount > 0} canPaste={canPaste} />
+        <ItemActionsCluster
+          hasSelection={selectionCount > 0}
+          canPaste={canPaste}
+          busy={actionBusy}
+        />
       )}
 
       {activeProjectId && !itemMode && (

--- a/apps/timeline-gstudio001/lib/graph-clipboard.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-clipboard.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { parseNodeId, type CollectionItemNode } from "@storyboard/ui/dnd-collections";
+
+import type { ClipboardEntry } from "./graph-clipboard";
+
+// The singleton is module state; import the factory indirectly by re-importing
+// a fresh module instance per test so tests can't leak into each other.
+async function freshClipboard() {
+  vi.resetModules();
+  const { graphClipboard } = await import("./graph-clipboard");
+  return graphClipboard;
+}
+
+const node: CollectionItemNode = {
+  id: parseNodeId("m1"),
+  kind: "media",
+  mediaKind: "image",
+  name: "Pic",
+  src: "a.png",
+  durationSeconds: 4,
+};
+const entry: ClipboardEntry = { node, detail: undefined, documents: {} };
+
+describe("graphClipboard", () => {
+  it("set / read / clear / isEmpty round-trip, with change notifications", async () => {
+    const clipboard = await freshClipboard();
+    const seen: boolean[] = [];
+    const unsubscribe = clipboard.subscribe(() => seen.push(clipboard.isEmpty()));
+
+    expect(clipboard.isEmpty()).toBe(true);
+    expect(clipboard.set([entry])).toBe(true);
+    expect(clipboard.read()).toEqual([entry]);
+    expect(clipboard.isEmpty()).toBe(false);
+    clipboard.clear();
+    expect(clipboard.isEmpty()).toBe(true);
+    // One notify per real change; clearing an empty clipboard notifies nobody.
+    clipboard.clear();
+    expect(seen).toEqual([false, true]);
+    unsubscribe();
+  });
+
+  it("binding a DIFFERENT user wipes the contents; same user keeps them", async () => {
+    const clipboard = await freshClipboard();
+    clipboard.bindUser("user-a");
+    clipboard.set([entry]);
+
+    clipboard.bindUser("user-a"); // re-bind, same uid — contents survive
+    expect(clipboard.isEmpty()).toBe(false);
+
+    clipboard.bindUser("user-b"); // another user — never their data to paste
+    expect(clipboard.isEmpty()).toBe(true);
+  });
+
+  it("refuses a stale write from a capture that straddled a user switch", async () => {
+    const clipboard = await freshClipboard();
+    clipboard.bindUser("user-a");
+    const atGeneration = clipboard.generation();
+
+    // The async capture is mid-flight when another user signs in…
+    clipboard.bindUser("user-b");
+
+    // …so the capture's set must NOT land user A's data in B's session.
+    expect(clipboard.set([entry], atGeneration)).toBe(false);
+    expect(clipboard.isEmpty()).toBe(true);
+  });
+});

--- a/apps/timeline-gstudio001/lib/graph-clipboard.ts
+++ b/apps/timeline-gstudio001/lib/graph-clipboard.ts
@@ -1,0 +1,63 @@
+import type { TimelineDocument } from "@storyboard/timeline-model/types";
+import type { CollectionItemNode } from "@storyboard/ui/dnd-collections";
+import type { ClipDetail } from "@storyboard/timeline-domain";
+
+// The graph view's copy/cut clipboard: a module singleton, like
+// `graphDocumentsGateway`, so BOTH React trees reach the same instance — the
+// graph provider writes it (Copy/Cut) and reads it (Paste), while the sidebar
+// (app chrome, a different tree) subscribes just for the "can paste" boolean
+// that keeps its item-actions cluster available after the selection is gone.
+//
+// A clipboard entry is an id-agnostic SNAPSHOT taken at copy time: the source
+// node + its detail, plus — for a collection — a deep copy of its whole
+// document tree keyed by original id. Paste re-mints fresh ids from that
+// snapshot each time (via the clone engine), so the copied item is independent
+// of the source even if the source later changes or is deleted (Cut).
+
+export type ClipboardEntry = Readonly<{
+  /** The source node (kind, media props, name). */
+  node: CollectionItemNode;
+  /** The source's side-table entry, cloned onto the paste. */
+  detail: ClipDetail | undefined;
+  /** Deep-copied source document tree, keyed by ORIGINAL timeline id. Empty
+   *  for a media clip (media has no document). */
+  documents: Readonly<Record<string, TimelineDocument>>;
+}>;
+
+export type GraphClipboard = Readonly<{
+  read: () => readonly ClipboardEntry[];
+  set: (entries: readonly ClipboardEntry[]) => void;
+  clear: () => void;
+  isEmpty: () => boolean;
+  /** Change notifications, for the sidebar's `can paste` subscription. */
+  subscribe: (listener: () => void) => () => void;
+}>;
+
+function createGraphClipboard(): GraphClipboard {
+  let entries: readonly ClipboardEntry[] = [];
+  const listeners = new Set<() => void>();
+  const emit = () => {
+    for (const listener of listeners) listener();
+  };
+  return {
+    read: () => entries,
+    set: (next) => {
+      entries = next;
+      emit();
+    },
+    clear: () => {
+      if (entries.length === 0) return;
+      entries = [];
+      emit();
+    },
+    isEmpty: () => entries.length === 0,
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}
+
+export const graphClipboard = createGraphClipboard();

--- a/apps/timeline-gstudio001/lib/graph-clipboard.ts
+++ b/apps/timeline-gstudio001/lib/graph-clipboard.ts
@@ -26,24 +26,45 @@ export type ClipboardEntry = Readonly<{
 
 export type GraphClipboard = Readonly<{
   read: () => readonly ClipboardEntry[];
-  set: (entries: readonly ClipboardEntry[]) => void;
+  /**
+   * Install new contents. Pass the `generation()` observed BEFORE any async
+   * capture work: if the clipboard was rebound to a different user (or
+   * otherwise reset) while the capture ran, the stale write is refused and
+   * `set` returns false — an in-flight Copy must never land another user's
+   * data into the new session.
+   */
+  set: (entries: readonly ClipboardEntry[], atGeneration?: number) => boolean;
   clear: () => void;
   isEmpty: () => boolean;
+  /** Monotonic reset counter — snapshot before async capture, hand to `set`. */
+  generation: () => number;
+  /**
+   * Bind to an authenticated user. Same contract as the documents gateway's
+   * `bindUser`: the module singleton outlives soft logout/login, so binding a
+   * DIFFERENT uid wipes the contents — the next user must never paste the
+   * previous user's timelines. First bind (or re-bind to the same uid) keeps
+   * the contents; every wipe bumps the generation so stale captures die.
+   */
+  bindUser: (uid: string) => void;
   /** Change notifications, for the sidebar's `can paste` subscription. */
   subscribe: (listener: () => void) => () => void;
 }>;
 
 function createGraphClipboard(): GraphClipboard {
   let entries: readonly ClipboardEntry[] = [];
+  let boundUid: string | null = null;
+  let generation = 0;
   const listeners = new Set<() => void>();
   const emit = () => {
     for (const listener of listeners) listener();
   };
   return {
     read: () => entries,
-    set: (next) => {
+    set: (next, atGeneration) => {
+      if (atGeneration !== undefined && atGeneration !== generation) return false;
       entries = next;
       emit();
+      return true;
     },
     clear: () => {
       if (entries.length === 0) return;
@@ -51,6 +72,15 @@ function createGraphClipboard(): GraphClipboard {
       emit();
     },
     isEmpty: () => entries.length === 0,
+    generation: () => generation,
+    bindUser: (uid) => {
+      if (boundUid === uid) return;
+      const hadEntries = entries.length > 0;
+      boundUid = uid;
+      generation += 1;
+      entries = [];
+      if (hadEntries) emit();
+    },
     subscribe: (listener) => {
       listeners.add(listener);
       return () => {

--- a/apps/timeline-gstudio001/lib/graph-node-clone.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-node-clone.test.ts
@@ -149,6 +149,57 @@ describe("cloneNodeForInsert: collection deep clone", () => {
     expect(result.detail).not.toHaveProperty("duplicateOfTimelineId");
   });
 
+  it("preserves sharing topology: a child referenced twice clones ONCE, both refs pointing at it", () => {
+    const sharedDocs: Record<string, TimelineDocument> = {
+      S: {
+        id: "S",
+        title: "Root",
+        clips: [collectionClip("c1", "SUB", "Sub once"), collectionClip("c2", "SUB", "Sub twice")],
+      },
+      SUB: { id: "SUB", title: "Sub", clips: [imageClip("c3", "b.png")] },
+    };
+
+    const result = cloneNodeForInsert(node, detail, {
+      readDocument: readerFor(sharedDocs),
+      mintId: counterMint(),
+    });
+
+    // ONE clone of SUB, not two — the source's sharing must survive the copy.
+    expect(result.newDocuments).toHaveLength(2);
+    const root = result.newDocuments.find((doc) => doc.id === result.node.id)!;
+    const refs = root.clips.flatMap((clip) =>
+      clip.kind === "collection" ? [clip.childTimelineId] : [],
+    );
+    expect(refs).toHaveLength(2);
+    expect(refs[0]).toBe(refs[1]);
+    expect(refs[0]).not.toBe("SUB");
+  });
+
+  it("a cycle resolves to the IN-FLIGHT clone id, never back to the source", () => {
+    // Corrupt-data shape: A contains B, B contains A.
+    const cyclicDocs: Record<string, TimelineDocument> = {
+      A: { id: "A", title: "A", clips: [collectionClip("ab", "B", "To B")] },
+      B: { id: "B", title: "B", clips: [collectionClip("ba", "A", "Back to A")] },
+    };
+
+    const result = cloneNodeForInsert(
+      { id: parseNodeId("A"), kind: "collection", name: "A" },
+      undefined,
+      { readDocument: readerFor(cyclicDocs), mintId: counterMint() },
+    );
+
+    expect(result.newDocuments).toHaveLength(2);
+    const cloneA = result.newDocuments.find((doc) => doc.id === result.node.id)!;
+    const cloneB = result.newDocuments.find((doc) => doc.id !== result.node.id)!;
+    const aRef = cloneA.clips[0];
+    const bRef = cloneB.clips[0];
+    if (aRef.kind !== "collection" || bRef.kind !== "collection") throw new Error("fixture");
+    // A' → B' and B' → A' — the clone is a closed, independent cycle. A back
+    // reference to the SOURCE "A" would wire the copy to the original.
+    expect(aRef.childTimelineId).toBe(cloneB.id);
+    expect(bRef.childTimelineId).toBe(cloneA.id);
+  });
+
   it("clones the REFERENCED timeline when the source is a duplicate-reference", () => {
     const refNode: CollectionItemNode = { id: parseNodeId("ref-card"), kind: "collection", name: "Ref" };
     const refDetail: ClipDetail = {

--- a/apps/timeline-gstudio001/lib/graph-node-clone.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-node-clone.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+
+import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
+import { parseNodeId, type CollectionItemNode } from "@storyboard/ui/dnd-collections";
+import type { ClipDetail } from "@storyboard/timeline-domain";
+
+import { cloneNodeForInsert, type CloneDeps } from "./graph-node-clone";
+
+/** A deterministic minter so ids are predictable and collision-free in tests. */
+function counterMint(): CloneDeps["mintId"] {
+  let n = 0;
+  return (prefix) => `${prefix}-${++n}`;
+}
+
+function imageClip(id: string, src: string): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "image",
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 4,
+    sourceDuration: 4,
+    trimIn: 0,
+    trimOut: 0,
+    src,
+  };
+}
+
+function collectionClip(id: string, childTimelineId: string, title: string): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "collection",
+    title,
+    childTimelineId,
+    itemCount: 1,
+    alt: title,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 4,
+    sourceDuration: 4,
+    trimIn: 0,
+    trimOut: 0,
+  };
+}
+
+/** Every id that exists in the SOURCE — none may appear in the clone. */
+const SOURCE_IDS = ["S", "SUB", "c1", "c2", "c3", "clip-in-parent"];
+
+function readerFor(docs: Record<string, TimelineDocument>): CloneDeps["readDocument"] {
+  return (id) => docs[id] ?? null;
+}
+
+function allIds(doc: TimelineDocument): string[] {
+  return [doc.id, ...doc.clips.map((clip) => clip.id)];
+}
+
+describe("cloneNodeForInsert: media", () => {
+  it("mints a fresh id, copies the props, and needs no new document", () => {
+    const node: CollectionItemNode = {
+      id: parseNodeId("m1"),
+      kind: "media",
+      mediaKind: "image",
+      name: "Pic",
+      src: "https://cdn/pic.png",
+      durationSeconds: 4,
+    };
+    const detail: ClipDetail = {
+      alt: "Pic",
+      aspect: 16 / 9,
+      trackIndex: 0,
+      // Must be dropped: reusing it would collide with the source clip.
+      sourceClipId: "m1",
+    };
+
+    const result = cloneNodeForInsert(node, detail, {
+      readDocument: () => null,
+      mintId: counterMint(),
+    });
+
+    expect(result.node.id).not.toBe("m1");
+    expect(result.node.kind).toBe("media");
+    expect(result.node).toMatchObject({ mediaKind: "image", src: "https://cdn/pic.png", name: "Pic" });
+    expect(result.newDocuments).toEqual([]);
+    expect(result.detail).toBeDefined();
+    expect(result.detail).not.toHaveProperty("sourceClipId");
+  });
+});
+
+describe("cloneNodeForInsert: collection deep clone", () => {
+  const docs: Record<string, TimelineDocument> = {
+    S: { id: "S", title: "Root", clips: [imageClip("c1", "a.png"), collectionClip("c2", "SUB", "Sub")] },
+    SUB: { id: "SUB", title: "Sub", clips: [imageClip("c3", "b.png")] },
+  };
+  const node: CollectionItemNode = { id: parseNodeId("S"), kind: "collection", name: "Root" };
+  const detail: ClipDetail = {
+    alt: "Root",
+    aspect: 16 / 9,
+    trackIndex: 0,
+    itemCount: 2,
+    duration: 10,
+    hydrated: false,
+    sourceClipId: "clip-in-parent",
+  };
+
+  it("remaps every id, emits one new document per collection, and rewires child refs", () => {
+    const result = cloneNodeForInsert(node, detail, {
+      readDocument: readerFor(docs),
+      mintId: counterMint(),
+    });
+
+    // One new document per cloned collection (root + nested).
+    expect(result.newDocuments).toHaveLength(2);
+    const root = result.newDocuments.find((doc) => doc.clips.length === 2)!;
+    const sub = result.newDocuments.find((doc) => doc.clips.length === 1)!;
+    expect(root).toBeDefined();
+    expect(sub).toBeDefined();
+
+    // The inserted node IS the fresh root timeline.
+    expect(result.node.id).toBe(root.id);
+    expect(result.node).toMatchObject({ kind: "collection", name: "Root" });
+
+    // The root's collection clip points at the NEW nested id, not the old one.
+    const nestedClip = root.clips.find((clip) => clip.kind === "collection")!;
+    expect(nestedClip.kind).toBe("collection");
+    if (nestedClip.kind === "collection") {
+      expect(nestedClip.childTimelineId).toBe(sub.id);
+    }
+
+    // Media content is preserved through the clone.
+    const rootImage = root.clips.find((clip) => clip.kind === "image");
+    expect(rootImage && rootImage.kind === "image" ? rootImage.src : null).toBe("a.png");
+    const subImage = sub.clips[0];
+    expect(subImage.kind === "image" ? subImage.src : null).toBe("b.png");
+
+    // NOTHING from the source survives as an id anywhere in the clone.
+    const cloneIds = new Set([result.node.id, ...result.newDocuments.flatMap(allIds)]);
+    for (const sourceId of SOURCE_IDS) {
+      expect(cloneIds.has(sourceId)).toBe(false);
+    }
+
+    // The clone is an independent, un-hydrated placeholder.
+    expect(result.detail?.hydrated).toBe(false);
+    expect(result.detail).not.toHaveProperty("sourceClipId");
+    expect(result.detail).not.toHaveProperty("duplicateOfTimelineId");
+  });
+
+  it("clones the REFERENCED timeline when the source is a duplicate-reference", () => {
+    const refNode: CollectionItemNode = { id: parseNodeId("ref-card"), kind: "collection", name: "Ref" };
+    const refDetail: ClipDetail = {
+      alt: "Ref",
+      aspect: 16 / 9,
+      trackIndex: 0,
+      hydrated: false,
+      duplicateOfTimelineId: "S",
+    };
+
+    const result = cloneNodeForInsert(refNode, refDetail, {
+      readDocument: readerFor(docs),
+      mintId: counterMint(),
+    });
+
+    // It followed the reference to S and deep-cloned that tree (2 documents),
+    // not the empty "ref-card" node.
+    expect(result.newDocuments).toHaveLength(2);
+    const cloneIds = new Set([result.node.id, ...result.newDocuments.flatMap(allIds)]);
+    expect(cloneIds.has("S")).toBe(false);
+    expect(cloneIds.has("ref-card")).toBe(false);
+    expect(result.detail).not.toHaveProperty("duplicateOfTimelineId");
+  });
+});

--- a/apps/timeline-gstudio001/lib/graph-node-clone.ts
+++ b/apps/timeline-gstudio001/lib/graph-node-clone.ts
@@ -54,25 +54,32 @@ function stripCloneOnlyFields(detail: ClipDetail): ClipDetail {
  * fresh id for each document and each clip. Returns the new ROOT id and every
  * new document (nested first). A missing source document (should not happen —
  * the caller ensures the subtree) clones as an empty timeline so a drill-in
- * never 404s; a cycle (only possible in a corrupt graph) keeps the original
- * reference rather than recurse forever.
+ * never 404s.
+ *
+ * The memo preserves the source's SHARING TOPOLOGY: the clone id is allocated
+ * and recorded BEFORE descending, so a child referenced twice resolves to ONE
+ * cloned document both times (rather than silently forking into two), and a
+ * cycle (only possible in corrupt data) resolves to the in-flight clone id —
+ * never to the source id, which would wire a live reference to the original
+ * into an allegedly independent copy.
  */
 function cloneDocumentTree(
   rootId: string,
   deps: CloneDeps,
 ): { newId: string; documents: TimelineDocument[] } {
   const documents: TimelineDocument[] = [];
-  const inProgress = new Set<string>();
+  const cloneIdBySource = new Map<string, string>();
 
   function clone(srcId: string): string {
-    if (inProgress.has(srcId)) return srcId;
+    const existing = cloneIdBySource.get(srcId);
+    if (existing !== undefined) return existing;
     const newId = deps.mintId("timeline");
+    cloneIdBySource.set(srcId, newId);
     const src = deps.readDocument(srcId);
     if (src === null) {
       documents.push({ id: newId, title: "Timeline", clips: [] });
       return newId;
     }
-    inProgress.add(srcId);
     const clips: TimelineClip[] = src.clips.map((clip) => {
       if (clip.kind !== "collection") {
         return { ...clip, id: deps.mintId(clip.kind) };
@@ -80,7 +87,6 @@ function cloneDocumentTree(
       const childNewId = clone(clip.childTimelineId);
       return { ...clip, id: deps.mintId("clip"), childTimelineId: childNewId };
     });
-    inProgress.delete(srcId);
     documents.push({ ...src, id: newId, clips });
     return newId;
   }

--- a/apps/timeline-gstudio001/lib/graph-node-clone.ts
+++ b/apps/timeline-gstudio001/lib/graph-node-clone.ts
@@ -1,0 +1,121 @@
+import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
+import { parseNodeId, type CollectionItemNode } from "@storyboard/ui/dnd-collections";
+import type { ClipDetail } from "@storyboard/timeline-domain";
+
+// The pure clone engine behind Duplicate / Copy-Paste.
+//
+// A media clip clones from the live graph node alone: a fresh id and a copy of
+// its props (src, trims, poster). A collection is an INDEPENDENT deep clone —
+// it maps to a timeline DOCUMENT, so cloning it means walking the document
+// tree (`readDocument`), remapping every timeline id and clip id, and emitting
+// one new document per cloned collection. The top-level clone re-enters the
+// graph as an empty placeholder node whose id IS the fresh root timeline id;
+// its seeded document supplies the children on drill-in. See the id
+// conventions in `@storyboard/timeline-domain` adapter (`buildHydrationSpecs` /
+// `graphChildrenToClips`): a collection node's id doubles as its clip id and
+// its `childTimelineId`, and a media node's id is its clip id.
+//
+// Pure and deterministic given `readDocument` + `mintId`, so it unit-tests
+// without the gateway; the async fill of an un-hydrated subtree (`ensure`)
+// happens in the caller BEFORE this runs, so `readDocument` is a cache read.
+
+export type CloneForInsert = Readonly<{
+  /** The fresh node to `add-nodes` into the target collection. */
+  node: CollectionItemNode;
+  /** Detail to park for the new node before the add commits (undefined when
+   *  the source had none). */
+  detail: ClipDetail | undefined;
+  /** New timeline documents to `seed()` + `writeClips` — one per cloned
+   *  collection, deepest first. Empty for a media clone. */
+  newDocuments: readonly TimelineDocument[];
+}>;
+
+export type CloneDeps = Readonly<{
+  /** Cached read of a timeline document. The caller ensures the whole subtree
+   *  is loaded first, so this never needs to fetch. */
+  readDocument: (timelineId: string) => TimelineDocument | null;
+  /** A fresh, graph-unique id for the given prefix. */
+  mintId: (prefix: string) => string;
+}>;
+
+/**
+ * Fields that must NOT survive a clone: `sourceClipId` pins the clip's stored
+ * id (reusing it would collide with the source clip in a shared parent), and
+ * `duplicateOfTimelineId` marks a reference to another timeline (the clone is
+ * independent — it points at its own fresh document instead).
+ */
+function stripCloneOnlyFields(detail: ClipDetail): ClipDetail {
+  const { sourceClipId: _sourceClipId, duplicateOfTimelineId: _dup, ...rest } = detail;
+  return rest;
+}
+
+/**
+ * Deep-clone a timeline document and every collection it contains, minting a
+ * fresh id for each document and each clip. Returns the new ROOT id and every
+ * new document (nested first). A missing source document (should not happen —
+ * the caller ensures the subtree) clones as an empty timeline so a drill-in
+ * never 404s; a cycle (only possible in a corrupt graph) keeps the original
+ * reference rather than recurse forever.
+ */
+function cloneDocumentTree(
+  rootId: string,
+  deps: CloneDeps,
+): { newId: string; documents: TimelineDocument[] } {
+  const documents: TimelineDocument[] = [];
+  const inProgress = new Set<string>();
+
+  function clone(srcId: string): string {
+    if (inProgress.has(srcId)) return srcId;
+    const newId = deps.mintId("timeline");
+    const src = deps.readDocument(srcId);
+    if (src === null) {
+      documents.push({ id: newId, title: "Timeline", clips: [] });
+      return newId;
+    }
+    inProgress.add(srcId);
+    const clips: TimelineClip[] = src.clips.map((clip) => {
+      if (clip.kind !== "collection") {
+        return { ...clip, id: deps.mintId(clip.kind) };
+      }
+      const childNewId = clone(clip.childTimelineId);
+      return { ...clip, id: deps.mintId("clip"), childTimelineId: childNewId };
+    });
+    inProgress.delete(srcId);
+    documents.push({ ...src, id: newId, clips });
+    return newId;
+  }
+
+  return { newId: clone(rootId), documents };
+}
+
+/**
+ * Build the fresh node (+ detail + any new documents) for inserting a copy of
+ * `node` — the shared core of Duplicate and Paste. `detail` is the source
+ * node's side-table entry, cloned onto the new node so the copy renders
+ * identically; a collection additionally clones its whole document tree.
+ */
+export function cloneNodeForInsert(
+  node: CollectionItemNode,
+  detail: ClipDetail | undefined,
+  deps: CloneDeps,
+): CloneForInsert {
+  if (node.kind === "media") {
+    const id = parseNodeId(deps.mintId(node.mediaKind ?? "media"));
+    const detailClone = detail === undefined ? undefined : stripCloneOnlyFields(detail);
+    return { node: { ...node, id }, detail: detailClone, newDocuments: [] };
+  }
+
+  // A duplicate-reference points at another timeline; clone THAT document tree
+  // so the copy is genuinely independent rather than a second reference.
+  const sourceTimelineId = detail?.duplicateOfTimelineId ?? (node.id as string);
+  const { newId, documents } = cloneDocumentTree(sourceTimelineId, deps);
+  const clonedNode: CollectionItemNode = {
+    id: parseNodeId(newId),
+    kind: "collection",
+    name: node.name,
+  };
+  // Placeholder: the seeded document holds the children, loaded on drill-in.
+  const clonedDetail =
+    detail === undefined ? undefined : { ...stripCloneOnlyFields(detail), hydrated: false };
+  return { node: clonedNode, detail: clonedDetail, newDocuments: documents };
+}

--- a/apps/timeline-gstudio001/lib/graph-view-events.ts
+++ b/apps/timeline-gstudio001/lib/graph-view-events.ts
@@ -89,6 +89,37 @@ export function broadcastGraphViewState(detail: GraphViewStateDetail): void {
   );
 }
 
+// Selection ↔ item actions. The engine's selection lives in the graph
+// provider's tree; the sidebar is app chrome. Same seam again: the graph
+// broadcasts how many items are selected (so the sidebar can switch its
+// contextual cluster to item actions), and the sidebar dispatches the action
+// the user picked back for the graph to perform on the live selection.
+
+export const GRAPH_SELECTION_EVENT = "graph-view:selection";
+export const GRAPH_ITEM_ACTION_EVENT = "graph-view:item-action";
+
+/** Graph → sidebar: how many items are currently selected. */
+export type GraphSelectionDetail = Readonly<{ count: number }>;
+
+/** The per-item actions the sidebar's item-mode cluster can request. */
+export type GraphItemAction = "copy" | "cut" | "paste" | "duplicate" | "delete" | "cancel";
+
+/** Graph → sidebar: the live selection size, so the sidebar can enter/exit
+ *  item-actions mode and enable/disable the selection-dependent buttons. */
+export function broadcastGraphSelection(detail: GraphSelectionDetail): void {
+  window.dispatchEvent(
+    new CustomEvent<GraphSelectionDetail>(GRAPH_SELECTION_EVENT, { detail }),
+  );
+}
+
+/** Sidebar → graph: perform an item action on the current selection (or, for
+ *  paste, on the clipboard). */
+export function requestGraphItemAction(action: GraphItemAction): void {
+  window.dispatchEvent(
+    new CustomEvent<GraphItemAction>(GRAPH_ITEM_ACTION_EVENT, { detail: action }),
+  );
+}
+
 // The reverse hand-off: when a drag drops into the graph's sidebar trash
 // target (which lives in the graph provider's tree), the sidebar's own trash
 // DRAWER button — plain app chrome — plays an arrival animation. Same

--- a/apps/timeline-gstudio001/lib/graph-view-events.ts
+++ b/apps/timeline-gstudio001/lib/graph-view-events.ts
@@ -98,8 +98,10 @@ export function broadcastGraphViewState(detail: GraphViewStateDetail): void {
 export const GRAPH_SELECTION_EVENT = "graph-view:selection";
 export const GRAPH_ITEM_ACTION_EVENT = "graph-view:item-action";
 
-/** Graph → sidebar: how many items are currently selected. */
-export type GraphSelectionDetail = Readonly<{ count: number }>;
+/** Graph → sidebar: how many items are currently selected, and whether an
+ *  async item action (copy/cut/duplicate loading documents) is in flight —
+ *  the sidebar disables the cluster while busy so actions can't double-fire. */
+export type GraphSelectionDetail = Readonly<{ count: number; busy: boolean }>;
 
 /** The per-item actions the sidebar's item-mode cluster can request. */
 export type GraphItemAction = "copy" | "cut" | "paste" | "duplicate" | "delete" | "cancel";

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1877,6 +1877,12 @@ test.describe("graph view E2E", () => {
       .waitFor({ state: "visible", timeout: 30000 });
     await page.getByRole("button", { name: "Paste", exact: true }).click();
     await expect.poll(() => stripOrder(page, CHILD_ID)).toHaveLength(3);
+    // The pasted card IS bravo's clone (same name, fresh id) — not just "some
+    // third child": a paste inserting the wrong entry would still pass a bare
+    // length check.
+    const pasted = strip(page, CHILD_ID).getByRole("button", { name: "bravo", exact: true });
+    await expect(pasted).toBeVisible();
+    await expect(pasted).not.toHaveAttribute("data-node-id", "bravo");
     await expect(page.getByRole("button", { name: "Grid layout" })).toBeVisible();
   });
 

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1776,6 +1776,110 @@ test.describe("graph view E2E", () => {
     await expect(undoButton(page)).toBeDisabled();
   });
 
+  test("selecting a clip switches the rail to item actions; Duplicate clones it after itself; Delete returns to normal", async ({
+    page,
+  }) => {
+    const api = await installGraphApi(page);
+    await openGraph(page);
+    const alpha = strip(page, PROJECT_ID).locator('[data-node-id="alpha"]');
+
+    // Normal rail: layout controls present, no item actions.
+    await expect(page.getByRole("button", { name: "Grid layout" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Duplicate", exact: true })).toHaveCount(0);
+
+    // Select alpha → the contextual cluster switches to item actions, the
+    // layout controls give way, and Paste is disabled (clipboard empty).
+    await expect(async () => {
+      await alpha.click();
+      await expect(alpha).toHaveAttribute("data-selected", "true", { timeout: 700 });
+    }).toPass({ timeout: 10000 });
+    await expect(page.getByRole("button", { name: "Duplicate", exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Grid layout" })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Paste", exact: true })).toBeDisabled();
+
+    // Duplicate → the clone lands right AFTER alpha (index 1), and the focused
+    // document persists the add (one write, five clips).
+    await page.getByRole("button", { name: "Duplicate", exact: true }).click();
+    await expect.poll(() => stripOrder(page, PROJECT_ID)).toHaveLength(5);
+    const order = await stripOrder(page, PROJECT_ID);
+    expect(order[0]).toBe("alpha");
+    expect(order[1]).not.toBe("alpha");
+    expect(order[2]).toBe("bravo");
+    await expect.poll(() => api.patchesFor(PROJECT_ID).at(-1)?.clipIds.length).toBe(5);
+
+    // Delete removes the (now-selected) clone and returns to the normal rail.
+    await page.getByRole("button", { name: "Delete", exact: true }).click();
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID))
+      .toEqual(["alpha", "bravo", CHILD_ID, "charlie"]);
+    await expect(page.getByRole("button", { name: "Grid layout" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Duplicate", exact: true })).toHaveCount(0);
+  });
+
+  test("Copy a clip, drill into a collection, and Paste it there — the rail stays available across the drill-in", async ({
+    page,
+  }) => {
+    const api = await installGraphApi(page);
+    await openGraph(page);
+    const alpha = strip(page, PROJECT_ID).locator('[data-node-id="alpha"]');
+
+    await expect(async () => {
+      await alpha.click();
+      await expect(alpha).toHaveAttribute("data-selected", "true", { timeout: 700 });
+    }).toPass({ timeout: 10000 });
+
+    // Copy → Paste becomes enabled.
+    await page.getByRole("button", { name: "Copy", exact: true }).click();
+    await expect(page.getByRole("button", { name: "Paste", exact: true })).toBeEnabled();
+
+    // Drill into the child collection. The clipboard is a module singleton, so
+    // it survives the client-side navigation: the rail stays in item mode with
+    // Paste available even though the selection is now out of view.
+    await page.getByRole("button", { name: "Open Scene A" }).first().click();
+    await strip(page, CHILD_ID)
+      .locator('[data-node-id="c1"]')
+      .waitFor({ state: "visible", timeout: 30000 });
+    await expect(page.getByRole("button", { name: "Paste", exact: true })).toBeEnabled();
+
+    // Paste → alpha's clone appends into the child (after c1/c2), the child
+    // document gets a write, and the rail returns to normal.
+    await page.getByRole("button", { name: "Paste", exact: true }).click();
+    await expect.poll(() => stripOrder(page, CHILD_ID)).toHaveLength(3);
+    expect((await stripOrder(page, CHILD_ID)).slice(0, 2)).toEqual(["c1", "c2"]);
+    await expect.poll(() => api.patchesFor(CHILD_ID).at(-1)?.clipIds.length).toBe(3);
+    await expect(page.getByRole("button", { name: "Grid layout" })).toBeVisible();
+  });
+
+  test("Cut removes the clip but keeps it on the clipboard; Paste relocates it", async ({
+    page,
+  }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    const bravo = strip(page, PROJECT_ID).locator('[data-node-id="bravo"]');
+
+    await expect(async () => {
+      await bravo.click();
+      await expect(bravo).toHaveAttribute("data-selected", "true", { timeout: 700 });
+    }).toPass({ timeout: 10000 });
+
+    // Cut → bravo leaves the project strip (moved to trash), but the clipboard
+    // keeps an independent copy, so the rail stays in item mode with Paste on.
+    await page.getByRole("button", { name: "Cut", exact: true }).click();
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID))
+      .toEqual(["alpha", CHILD_ID, "charlie"]);
+    await expect(page.getByRole("button", { name: "Paste", exact: true })).toBeEnabled();
+
+    // Paste into the child collection → the cut clip lands there (a move).
+    await page.getByRole("button", { name: "Open Scene A" }).first().click();
+    await strip(page, CHILD_ID)
+      .locator('[data-node-id="c1"]')
+      .waitFor({ state: "visible", timeout: 30000 });
+    await page.getByRole("button", { name: "Paste", exact: true }).click();
+    await expect.poll(() => stripOrder(page, CHILD_ID)).toHaveLength(3);
+    await expect(page.getByRole("button", { name: "Grid layout" })).toBeVisible();
+  });
+
   test("interaction model: click toggles selection + trim handles, hold-grab release does neither, collection body selects and its folder button drills", async ({
     page,
   }) => {


### PR DESCRIPTION
When an item is selected in the graph view (media clip or collection, strip or grid), the sidebar's contextual cluster switches to **item actions**; Delete/Paste/Done return it to the normal controls.

## Actions
- **Copy** — snapshots the selection to a clipboard singleton (stays in item mode; Paste lights up)
- **Cut** — snapshots then trashes the originals (recoverable); the clipboard keeps an independent copy, so Paste relocates them
- **Paste** — clones the clipboard into the focused timeline as **one** `add-nodes` dispatch (one undo step, one persisted batch); disabled until something is copied; the clipboard survives a refused paste for retry
- **Duplicate** — clones each selected item in place (right after its source) and selects the copies
- **Delete** — moves the selection to trash via the same shared command the keyboard Delete runs
- **Done** — clears selection + clipboard, back to normal

The cluster stays available while the clipboard is non-empty even with nothing selected, so *copy here → drill into another timeline → paste there* works across client-side navigation (clipboard is a module singleton reachable from both React trees).

## Architecture
- Sidebar ⇄ graph over the existing window-event bridge: the graph broadcasts `{count, busy}`, the sidebar requests actions back. Bridge component (`GraphItemActionsBridge`) lives inside the provider next to `PersistenceBridge`.
- **Collections are independent deep clones**: a pure engine (`lib/graph-node-clone.ts`) walks the source document tree, remaps every timeline/clip id (memoized so sharing topology survives and cycles close onto the clone, never the source), and emits one new document per cloned collection, seeded via the gateway's revision-0 create. Media clips clone from the live graph node.
- **Clipboard is auth-bound** like the documents gateway: binding a different uid wipes it, and a generation counter kills captures that straddle a user switch.
- Cut passes its pre-capture ids into the trash move (no TOCTOU), and a busy guard runs one action at a time with the sidebar cluster disabled while in flight.
- Bonus tweak: the timeline-children icon is now `FolderTree` in all three places (sidebar toggle, collection card drill button, sub-timeline row drill button).

## Tests
- Unit: clone engine (fresh ids, deep clone, duplicate-reference, shared-child topology, cycle closure) + clipboard contract (round-trip, bindUser wipe, stale-generation refusal) — **205/205**
- E2E: 4 new tests — item-mode switch + Duplicate persistence + Delete-to-normal + Paste-disabled; Copy→drill→Paste; Cut→Paste relocation (asserting the pasted card IS the cut clip's clone) — **48/48**
- `tsc` (app + packages/ui) and `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)