### PR TITLE
Item actions: keyboard shortcuts (Ctrl/Cmd+C/X/V/D) + batched multi-Duplicate

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import type { TimelineDocument } from "@storyboard/timeline-model/types";
 import {
   getChildren,
+  isEditableKeyboardTarget,
   parseNodeId,
   useCollectionsSelector,
   useCollectionsStore,
@@ -76,50 +77,56 @@ function captureDocumentTree(rootTimelineId: string): Record<string, TimelineDoc
 }
 
 /**
- * Commit one clone into `parentId` at `toIndex` — the shared tail of Duplicate
- * and Paste. Mirrors the palette insert: park the detail so the persistence
- * bridge claims it on the add patch, dispatch add-nodes, then seed each cloned
- * collection's document (revision-0 create + content write) so a drill-in into
- * the copy never 404s. Returns the new node id, or null if the add was refused.
+ * Commit a batch of clones into `parentId` at `toIndex` as ONE add-nodes
+ * dispatch — the shared tail of Duplicate and Paste, and the reason a
+ * multi-item gesture is a single undo step (the delete-path rule). Mirrors the
+ * palette insert: park each detail so the persistence bridge claims it on the
+ * add patch, dispatch, then seed each cloned collection's document (revision-0
+ * create + content write) so a drill-in into a copy never 404s. Returns the
+ * new node ids — empty when the dispatch was refused (details rolled back).
  */
-function insertClone(
+function insertClones(
   store: CollectionsStore,
-  clone: CloneForInsert,
+  clones: readonly CloneForInsert[],
   parentId: NodeId,
   toIndex: number,
-): NodeId | null {
-  if (clone.detail) parkPendingDetail(clone.node.id as string, clone.detail);
+): readonly NodeId[] {
+  if (clones.length === 0) return [];
+  for (const clone of clones) {
+    if (clone.detail) parkPendingDetail(clone.node.id as string, clone.detail);
+  }
   const dispatched = store.dispatch({
     type: "add-nodes",
-    nodes: [clone.node],
+    nodes: clones.map((clone) => clone.node),
     toParentId: parentId,
     toIndex,
   });
   if (!dispatched.ok) {
-    unparkPendingDetail(clone.node.id as string);
-    return null;
+    for (const clone of clones) unparkPendingDetail(clone.node.id as string);
+    return [];
   }
-  for (const document of clone.newDocuments) {
-    graphDocumentsGateway.seed(document);
-    graphDocumentsGateway.writeClips(document.id, document.clips);
+  for (const clone of clones) {
+    for (const document of clone.newDocuments) {
+      graphDocumentsGateway.seed(document);
+      graphDocumentsGateway.writeClips(document.id, document.clips);
+    }
   }
-  return clone.node.id;
+  return clones.map((clone) => clone.node.id);
 }
 
 /**
- * Duplicate one source node right AFTER it in its own parent. A collection
- * deep-clones its document tree first (ensuring its subtree is loaded). Returns
- * the new node's id, or null if nothing landed.
+ * Build (but don't insert) the clone of one source node — the async half of
+ * Duplicate: a collection ensures its whole document subtree first. Null when
+ * the source vanished or its tree couldn't load (toasted).
  */
-async function duplicateOne(
+async function buildClone(
   store: CollectionsStore,
   details: GraphDetailsStore,
   sourceId: NodeId,
-): Promise<NodeId | null> {
+): Promise<CloneForInsert | null> {
   const node = store.getSnapshot().graph.nodesById.get(sourceId);
   if (!node) return null;
   const detail = details.get(sourceId as string);
-
   if (node.kind === "collection") {
     const rootTimelineId = detail?.duplicateOfTimelineId ?? (sourceId as string);
     if (!(await ensureDocumentTree(rootTimelineId))) {
@@ -127,23 +134,10 @@ async function duplicateOne(
       return null;
     }
   }
-
-  const clone = cloneNodeForInsert(node, detail, {
+  return cloneNodeForInsert(node, detail, {
     readDocument: (timelineId) => graphDocumentsGateway.peek(timelineId),
     mintId,
   });
-
-  // Re-read the live graph: an earlier duplicate in this batch may have shifted
-  // the source's parent's children.
-  const liveGraph = store.getSnapshot().graph;
-  const parentId = liveGraph.parentById.get(sourceId);
-  // A root has a null parent and can't take a sibling — skip it (roots aren't
-  // duplicable anyway).
-  if (parentId === undefined || parentId === null) return null;
-  const siblings = getChildren(liveGraph, parentId);
-  const at = siblings.indexOf(sourceId);
-  const toIndex = at >= 0 ? at + 1 : siblings.length;
-  return insertClone(store, clone, parentId, toIndex);
 }
 
 /**
@@ -199,26 +193,12 @@ function pasteIntoFocused(store: CollectionsStore, focusedId: string): readonly 
       mintId,
     }),
   );
-  for (const clone of clones) {
-    if (clone.detail) parkPendingDetail(clone.node.id as string, clone.detail);
-  }
-  const dispatched = store.dispatch({
-    type: "add-nodes",
-    nodes: clones.map((clone) => clone.node),
-    toParentId: focusedParent,
-    toIndex: getChildren(store.getSnapshot().graph, focusedParent).length,
-  });
-  if (!dispatched.ok) {
-    for (const clone of clones) unparkPendingDetail(clone.node.id as string);
-    return [];
-  }
-  for (const clone of clones) {
-    for (const document of clone.newDocuments) {
-      graphDocumentsGateway.seed(document);
-      graphDocumentsGateway.writeClips(document.id, document.clips);
-    }
-  }
-  return clones.map((clone) => clone.node.id);
+  return insertClones(
+    store,
+    clones,
+    focusedParent,
+    getChildren(store.getSnapshot().graph, focusedParent).length,
+  );
 }
 
 /**
@@ -280,11 +260,52 @@ export function GraphItemActionsBridge({
     const duplicateSelection = async () => {
       const selected = [...store.getSnapshot().interaction.selectedIds];
       if (selected.length === 0) return;
-      const newIds: NodeId[] = [];
+      // Build every clone FIRST (the async ensure), then insert with ONE
+      // add-nodes per parent — a multi-duplicate inside one parent is a single
+      // undo step (the delete-path rule; the old per-source loop left N
+      // entries behind one gesture). One command inserts contiguously, so the
+      // block lands right after the LAST selected source in that parent, with
+      // the copies keeping the sources' relative order; the common single-item
+      // case keeps its exact after-the-source placement. Sources in DIFFERENT
+      // parents still cost one entry per parent — a single cross-parent
+      // command doesn't exist in the engine.
+      type Built = Readonly<{ sourceId: NodeId; clone: CloneForInsert }>;
+      const built: Built[] = [];
       for (const id of selected) {
-        const newId = await duplicateOne(store, details, id);
-        if (newId !== null) newIds.push(newId);
+        const clone = await buildClone(store, details, id);
+        if (clone !== null) built.push({ sourceId: id, clone });
       }
+      if (built.length === 0) return;
+
+      const liveGraph = store.getSnapshot().graph;
+      const groups = new Map<NodeId, Built[]>();
+      for (const item of built) {
+        const parentId = liveGraph.parentById.get(item.sourceId);
+        // A root has no parent and can't take a sibling — skip (roots aren't
+        // duplicable anyway); likewise a source deleted during the loads.
+        if (parentId === undefined || parentId === null) continue;
+        const group = groups.get(parentId);
+        if (group) group.push(item);
+        else groups.set(parentId, [item]);
+      }
+
+      const newIds: NodeId[] = [];
+      for (const [parentId, group] of groups) {
+        const siblings = getChildren(store.getSnapshot().graph, parentId);
+        const at = (item: Built) => siblings.indexOf(item.sourceId);
+        group.sort((a, b) => at(a) - at(b));
+        const lastAt = at(group[group.length - 1]);
+        const toIndex = lastAt >= 0 ? lastAt + 1 : siblings.length;
+        newIds.push(
+          ...insertClones(
+            store,
+            group.map((item) => item.clone),
+            parentId,
+            toIndex,
+          ),
+        );
+      }
+      // Select the copies, so the user sees what they made and can act again.
       if (newIds.length > 0) store.setSelection(newIds);
     };
 
@@ -312,17 +333,24 @@ export function GraphItemActionsBridge({
       store.clearSelection();
     };
 
-    const onAction = (event: Event) => {
-      const action = (event as CustomEvent<GraphItemAction>).detail;
+    // The ONE funnel every trigger goes through — the sidebar's buttons (via
+    // the window event) and the keyboard shortcuts below — so the busy guard,
+    // clipboard rules, and undo shapes can never differ by input method.
+    const perform = (action: GraphItemAction) => {
       // Sync actions honour the same one-at-a-time rule: a paste or delete
       // landing mid-cut would race the capture's trash move.
       if (busyRef.current) return;
       switch (action) {
         case "copy":
           void runExclusive(async () => {
-            await captureSelection(store, details, [
-              ...store.getSnapshot().interaction.selectedIds,
-            ]);
+            const selected = [...store.getSnapshot().interaction.selectedIds];
+            if (await captureSelection(store, details, selected)) {
+              // Copy changes nothing visible on the board — say it landed
+              // (both entry points; the keyboard one especially needs it).
+              toast(`Copied ${selected.length} item${selected.length === 1 ? "" : "s"}.`, {
+                id: "graph-item-copy",
+              });
+            }
           });
           break;
         case "cut":
@@ -346,8 +374,52 @@ export function GraphItemActionsBridge({
           break;
       }
     };
+
+    const onAction = (event: Event) => {
+      perform((event as CustomEvent<GraphItemAction>).detail);
+    };
+
+    // Keyboard: Ctrl/Cmd+C, X, V, D — window-level (not a React boundary on
+    // the board) because paste's moment of need is right AFTER a drill-in,
+    // when the navigation dropped focus to <body> and a subtree listener
+    // would never hear the key. Every guard fails OPEN to the browser: the
+    // shortcut is claimed (preventDefault — Ctrl+D would bookmark) only when
+    // it will actually act on the graph.
+    const KEY_TO_ACTION: Readonly<Record<string, GraphItemAction>> = {
+      c: "copy",
+      x: "cut",
+      v: "paste",
+      d: "duplicate",
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!(event.ctrlKey || event.metaKey) || event.altKey || event.shiftKey) return;
+      const action = KEY_TO_ACTION[event.key.toLowerCase()];
+      if (action === undefined) return;
+      if (event.repeat || event.defaultPrevented) return;
+      // Inputs and the rename editor own their clipboard keys (the package's
+      // shared keyboard policy).
+      if (isEditableKeyboardTarget(event.target)) return;
+      const snapshot = store.getSnapshot();
+      if (snapshot.interaction.isDragging) return;
+      // A real TEXT selection means the user wants the browser's copy/cut.
+      if (
+        (action === "copy" || action === "cut") &&
+        (window.getSelection()?.toString() ?? "") !== ""
+      ) {
+        return;
+      }
+      const hasSelection = snapshot.interaction.selectedIds.size > 0;
+      if (action === "paste" ? graphClipboard.isEmpty() : !hasSelection) return;
+      event.preventDefault();
+      perform(action);
+    };
+
     window.addEventListener(GRAPH_ITEM_ACTION_EVENT, onAction);
-    return () => window.removeEventListener(GRAPH_ITEM_ACTION_EVENT, onAction);
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener(GRAPH_ITEM_ACTION_EVENT, onAction);
+      window.removeEventListener("keydown", onKeyDown);
+    };
   }, [store, details, trashId, focusedId]);
 
   return null;

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1886,6 +1886,99 @@ test.describe("graph view E2E", () => {
     await expect(page.getByRole("button", { name: "Grid layout" })).toBeVisible();
   });
 
+  test("keyboard: Ctrl+C copies and Ctrl+V pastes after a drill-in (focus on <body>)", async ({
+    page,
+  }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    const alpha = strip(page, PROJECT_ID).locator('[data-node-id="alpha"]');
+
+    await expect(async () => {
+      await alpha.click();
+      await expect(alpha).toHaveAttribute("data-selected", "true", { timeout: 700 });
+    }).toPass({ timeout: 10000 });
+
+    // Ctrl+C — the copy toast is the only visible change, plus Paste arming.
+    await page.keyboard.press("Control+c");
+    await expect(page.getByText("Copied 1 item.").first()).toBeVisible();
+    await expect(page.getByRole("button", { name: "Paste", exact: true })).toBeEnabled();
+
+    // Drill in — focus drops to <body> here, which is exactly why the
+    // shortcut listener is window-level and not a board-subtree boundary.
+    await page.getByRole("button", { name: "Open Scene A" }).first().click();
+    await strip(page, CHILD_ID)
+      .locator('[data-node-id="c1"]')
+      .waitFor({ state: "visible", timeout: 30000 });
+
+    await page.keyboard.press("Control+v");
+    await expect.poll(() => stripOrder(page, CHILD_ID)).toHaveLength(3);
+    await expect(
+      strip(page, CHILD_ID).getByRole("button", { name: "alpha", exact: true }),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Grid layout" })).toBeVisible();
+  });
+
+  test("keyboard: Ctrl+D duplicates in place, Ctrl+X cuts the copy back out", async ({
+    page,
+  }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    const bravo = strip(page, PROJECT_ID).locator('[data-node-id="bravo"]');
+
+    await expect(async () => {
+      await bravo.click();
+      await expect(bravo).toHaveAttribute("data-selected", "true", { timeout: 700 });
+    }).toPass({ timeout: 10000 });
+
+    // Ctrl+D → the clone lands right after bravo and becomes the selection.
+    await page.keyboard.press("Control+d");
+    await expect.poll(() => stripOrder(page, PROJECT_ID)).toHaveLength(5);
+    const order = await stripOrder(page, PROJECT_ID);
+    expect(order[1]).toBe("bravo");
+    expect(order[3]).toBe(CHILD_ID);
+
+    // Ctrl+X cuts the selected clone: gone from the strip, Paste armed.
+    await page.keyboard.press("Control+x");
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID))
+      .toEqual(["alpha", "bravo", CHILD_ID, "charlie"]);
+    await expect(page.getByRole("button", { name: "Paste", exact: true })).toBeEnabled();
+  });
+
+  test("multi-select Duplicate in one parent is ONE undoable step", async ({ page }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    const projectStrip = strip(page, PROJECT_ID);
+    const alpha = projectStrip.locator('[data-node-id="alpha"]');
+    const bravo = projectStrip.locator('[data-node-id="bravo"]');
+
+    await expect(async () => {
+      await alpha.click();
+      await expect(alpha).toHaveAttribute("data-selected", "true", { timeout: 700 });
+    }).toPass({ timeout: 10000 });
+    await expect(async () => {
+      await bravo.click({ modifiers: ["Control"] });
+      await expect(bravo).toHaveAttribute("data-selected", "true", { timeout: 700 });
+    }).toPass({ timeout: 10000 });
+
+    // Both copies land as one contiguous block after the LAST source (bravo),
+    // keeping the sources' relative order.
+    await page.getByRole("button", { name: "Duplicate", exact: true }).click();
+    await expect.poll(() => stripOrder(page, PROJECT_ID)).toHaveLength(6);
+    const order = await stripOrder(page, PROJECT_ID);
+    expect(order.slice(0, 2)).toEqual(["alpha", "bravo"]);
+    expect(order.slice(4)).toEqual([CHILD_ID, "charlie"]);
+    expect(order[2]).not.toBe(order[3]);
+
+    // ONE undo reverses the whole duplicate — one gesture, one history entry
+    // (per parent; both sources share the project here).
+    await undoButton(page).click();
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID))
+      .toEqual(["alpha", "bravo", CHILD_ID, "charlie"]);
+    await expect(undoButton(page)).toBeDisabled();
+  });
+
   test("interaction model: click toggles selection + trim handles, hold-grab release does neither, collection body selects and its folder button drills", async ({
     page,
   }) => {


### PR DESCRIPTION
Follow-up to #148, closing the two items from its review that were worth doing now.

## Keyboard shortcuts
Ctrl/Cmd+**C**opy, **X** (cut), **V** (paste), **D**uplicate drive the same actions as the sidebar cluster. Design points:

- **Window-level listener**, not a board-subtree boundary: paste's moment of need is right after a drill-in, when navigation has dropped focus to `<body>` — a subtree listener would never hear the key. (The new e2e pins exactly this case.)
- **Every guard fails open to the browser**: editable targets (the package's shared keyboard policy), live drags, key repeat, already-claimed events, a real text selection for copy/cut, and empty selection/clipboard all pass through untouched. `preventDefault` fires only when the shortcut will actually act — so Ctrl+D never eats the bookmark shortcut unless an item is selected.
- **One funnel**: both the sidebar's window event and the keyboard call the same `perform(action)`, so the busy guard, clipboard rules, and undo shapes cannot differ by input method.
- Copy now **toasts** ("Copied N items") — it changes nothing visible on the board, and the keyboard path especially needs the acknowledgement.

## Batched multi-Duplicate
Duplicating a multi-selection previously looped one `add-nodes` per item — N history entries for one gesture, violating the repo's own one-gesture-one-undo rule (documented on the delete path). Now: build every clone first (async ensures), then **one dispatch per parent** via a shared `insertClones` (paste uses it too). The block lands after the last selected source in its parent with source order preserved; single-item duplicate keeps its exact after-the-source placement. Cross-parent selections still cost one entry per parent — a single cross-parent add doesn't exist in the engine.

## Tests
3 new e2e: Ctrl+C → drill → Ctrl+V (focus-on-body), Ctrl+D + Ctrl+X, multi-duplicate ONE-undo. Full suite **51/51**, unit **205/205**, `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)