### PR TITLE
Item actions: selection-aware Paste placement, subtree-guarded

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
@@ -6,7 +6,6 @@ import type { TimelineDocument } from "@storyboard/timeline-model/types";
 import {
   getChildren,
   isEditableKeyboardTarget,
-  parseNodeId,
   useCollectionsSelector,
   useCollectionsStore,
   type CollectionsStore,
@@ -17,6 +16,7 @@ import { toast } from "@/components/core/sonner";
 import { graphClipboard, type ClipboardEntry } from "@/lib/graph-clipboard";
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 import type { GraphDetailsStore } from "@/lib/graph-details-store";
+import { resolveInsertPlacement } from "@/lib/graph-insert-placement";
 import { cloneNodeForInsert, type CloneForInsert } from "@/lib/graph-node-clone";
 import {
   GRAPH_ITEM_ACTION_EVENT,
@@ -176,29 +176,37 @@ async function captureSelection(
 }
 
 /**
- * Paste the clipboard into the focused collection, appended — ONE `add-nodes`
- * dispatch for every entry, so a multi-item paste is a single undoable step
- * and a single persisted batch (the same rule the delete path documents, and
- * the same shape as the multi-file drop commit). Documents seed only after
- * the dispatch commits; a refusal rolls back the parked details and returns
- * [] with the clipboard untouched, so the user can retry.
+ * Paste the clipboard — ONE `add-nodes` dispatch for every entry, so a
+ * multi-item paste is a single undoable step and a single persisted batch (the
+ * same rule the delete path documents, and the same shape as the multi-file
+ * drop commit). Documents seed only after the dispatch commits; a refusal
+ * rolls back the parked details and returns [] with the clipboard untouched,
+ * so the user can retry.
+ *
+ * WHERE it lands is `resolveInsertPlacement` — shared with the Collection
+ * tool, so the view's two pointerless inserts obey one rule: after the
+ * selected card when that card is on the board under the focused collection,
+ * appended to the focused collection otherwise. The subtree half matters most
+ * here: the copy → drill-in → Paste flow keeps the source SELECTED across the
+ * navigation, and a bare "after the selection" would fire the paste back into
+ * the timeline the user just left.
  */
-function pasteIntoFocused(store: CollectionsStore, focusedId: string): readonly NodeId[] {
+function pasteFromClipboard(store: CollectionsStore, focusedId: string): readonly NodeId[] {
   const entries = graphClipboard.read();
   if (entries.length === 0) return [];
-  const focusedParent = parseNodeId(focusedId);
+  const snapshot = store.getSnapshot();
+  const { parentId, toIndex } = resolveInsertPlacement(
+    snapshot.graph,
+    snapshot.interaction.selectedIds,
+    focusedId,
+  );
   const clones = entries.map((entry) =>
     cloneNodeForInsert(entry.node, entry.detail, {
       readDocument: (timelineId) => entry.documents[timelineId] ?? null,
       mintId,
     }),
   );
-  return insertClones(
-    store,
-    clones,
-    focusedParent,
-    getChildren(store.getSnapshot().graph, focusedParent).length,
-  );
+  return insertClones(store, clones, parentId, toIndex);
 }
 
 /**
@@ -212,8 +220,8 @@ function pasteIntoFocused(store: CollectionsStore, focusedId: string): readonly 
  *   - Copy  → snapshot the selection to the clipboard (stays in item mode).
  *   - Cut   → snapshot, then trash the originals; the clipboard keeps an
  *             independent copy, so Paste still relocates them (a move).
- *   - Paste → clone the clipboard into the focused collection, then clear the
- *             clipboard + selection (back to normal).
+ *   - Paste → clone the clipboard in after the selected card (or append to the
+ *             focused collection), then clear the clipboard + selection.
  *   - Duplicate → clone each selection in place (after its source).
  *   - Delete → `moveSelectionToTrash` (shared with the keyboard Delete).
  *   - Cancel → clear the selection AND the clipboard (back to normal).
@@ -324,7 +332,7 @@ export function GraphItemActionsBridge({
     };
 
     const pasteSelection = () => {
-      const pasted = pasteIntoFocused(store, focusedId);
+      const pasted = pasteFromClipboard(store, focusedId);
       // Nothing landed (refused dispatch): keep the clipboard so the user can
       // paste somewhere valid instead of silently losing what they copied.
       if (pasted.length === 0) return;

--- a/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
@@ -22,6 +22,7 @@ import {
 import type { ClipDetail } from "@storyboard/timeline-domain";
 
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
+import { resolveInsertPlacement } from "@/lib/graph-insert-placement";
 import {
   GRAPH_INSERT_TOOL_EVENT,
   isGraphInsertTool,
@@ -271,13 +272,15 @@ const TOOL_LABELS: Readonly<Record<SidebarTool, string>> = {
 /**
  * The KEYBOARD/click path for the sidebar tool palette. The sidebar is app
  * chrome living outside this provider, so it hands the tool off through a
- * window event (same pattern as the Assets launcher). SELECTION-AWARE: the
- * tool lands right after the most recently selected card, inside THAT
- * card's own timeline (any strip, not just the focused one — clicking the
- * sidebar never clears selection, so this works for mouse and keyboard
- * alike). With nothing selected it appends to the focused collection, the
- * one spot that needs no explanation. Dragging the tool remains the
- * pointer-precision path either way.
+ * window event (same pattern as the Assets launcher). SELECTION-AWARE via the
+ * shared `resolveInsertPlacement`: the tool lands right after the most
+ * recently selected card, inside THAT card's own timeline (any strip the
+ * board is showing under the focused collection — clicking the tool never
+ * clears selection, so this works for mouse and keyboard alike). With nothing
+ * selected — or with a selection left BEHIND by a drill-in, which survives the
+ * navigation and would otherwise plant the collection in the timeline the user
+ * just left — it appends to the focused collection, the one spot that needs no
+ * explanation. Dragging the tool remains the pointer-precision path either way.
  *
  * Mounted for BOTH surfaces, deliberately: `NativeDropStrip` only wraps the
  * strip, and an accessible control that silently does nothing in grid mode
@@ -296,27 +299,15 @@ export function SidebarToolInsertBridge({
       if (!tool || !isGraphInsertTool(tool)) return;
       const snapshot = store.getSnapshot();
       const graph = snapshot.graph;
-      // Sets iterate in insertion order, so `.at(-1)` is the most recent
-      // selection — the card a multi-select last touched.
-      const selectedId = [...snapshot.interaction.selectedIds].at(-1);
-      const selectedParentId =
-        selectedId !== undefined ? (graph.parentById.get(selectedId) ?? null) : null;
-      const parentId = selectedParentId ?? parseNodeId(collectionId);
-      const siblings = getChildren(graph, parentId);
-      const selectedAt =
-        selectedId !== undefined && selectedParentId !== null
-          ? siblings.indexOf(selectedId)
-          : -1;
-      const landed = insertTool(
-        tool,
-        selectedAt >= 0 ? selectedAt + 1 : siblings.length,
-        parentId,
+      const { parentId, toIndex, afterId } = resolveInsertPlacement(
+        graph,
+        snapshot.interaction.selectedIds,
+        collectionId,
       );
+      const landed = insertTool(tool, toIndex, parentId);
       const target = graph.nodesById.get(parentId)?.name ?? "the timeline";
       const afterName =
-        selectedAt >= 0 && selectedId !== undefined
-          ? (graph.nodesById.get(selectedId)?.name ?? "the selected clip")
-          : null;
+        afterId !== null ? (graph.nodesById.get(afterId)?.name ?? "the selected clip") : null;
       announce(
         landed
           ? afterName !== null

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -117,8 +117,14 @@ function SurfaceIconControl({
   );
 }
 
+// Recessed, not invisible. This used to dim TWICE — a zinc-600 glyph and then
+// `opacity-50` over it — which on the near-black rail left the Paste icon
+// (item mode's resting state, disabled until something is copied) barely
+// legible. One dimming step is enough: a solid zinc-500 glyph reads as
+// available-but-not-now, and the flat border plus the missing hover response
+// carry "disabled" on their own.
 const SIDEBAR_ICON_DISABLED =
-  "cursor-not-allowed border-zinc-800/50 bg-zinc-900/20 text-zinc-600 opacity-50";
+  "cursor-not-allowed border-zinc-800/70 bg-zinc-900/20 text-zinc-500";
 
 /** One button in the item-actions cluster — dispatches its action across the
  *  window-event seam for the graph provider to perform on the selection. */

--- a/apps/timeline-gstudio001/lib/graph-insert-placement.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-insert-placement.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+
+import { buildGraph, parseNodeId, type CollectionsGraph, type NodeId } from "@storyboard/ui/dnd-collections";
+
+import { resolveInsertPlacement } from "./graph-insert-placement";
+
+/**
+ * project ─ alpha, bravo, scene-a[ c1, c2, scene-b[ d1 ] ], charlie
+ * trash   ─ t1
+ *
+ * `trash` is a SEPARATE root, exactly as the app builds it — a selected card
+ * there must never pull an insert out of the focused project.
+ */
+function fixture(): CollectionsGraph {
+  const built = buildGraph([
+    {
+      kind: "collection",
+      id: "project",
+      name: "Project",
+      children: [
+        { kind: "media", id: "alpha", name: "alpha" },
+        { kind: "media", id: "bravo", name: "bravo" },
+        {
+          kind: "collection",
+          id: "scene-a",
+          name: "Scene A",
+          children: [
+            { kind: "media", id: "c1", name: "c1" },
+            { kind: "media", id: "c2", name: "c2" },
+            {
+              kind: "collection",
+              id: "scene-b",
+              name: "Scene B",
+              children: [{ kind: "media", id: "d1", name: "d1" }],
+            },
+          ],
+        },
+        { kind: "media", id: "charlie", name: "charlie" },
+      ],
+    },
+    {
+      kind: "collection",
+      id: "trash",
+      name: "Trash",
+      children: [{ kind: "media", id: "t1", name: "t1" }],
+    },
+  ]);
+  if (!built.ok) throw new Error(`fixture graph invalid: ${JSON.stringify(built.error)}`);
+  return built.value;
+}
+
+const ids = (...values: string[]): NodeId[] => values.map(parseNodeId);
+
+describe("resolveInsertPlacement", () => {
+  const graph = fixture();
+
+  it("appends to the focused collection when nothing is selected", () => {
+    expect(resolveInsertPlacement(graph, [], "project")).toEqual({
+      parentId: parseNodeId("project"),
+      toIndex: 4,
+      afterId: null,
+    });
+  });
+
+  it("lands right after a card selected in the focused collection", () => {
+    expect(resolveInsertPlacement(graph, ids("bravo"), "project")).toEqual({
+      parentId: parseNodeId("project"),
+      toIndex: 2,
+      afterId: parseNodeId("bravo"),
+    });
+  });
+
+  it("follows the selection into a DESCENDANT strip the board is showing", () => {
+    // Sub-timeline rows are on screen under the focused one, so a card
+    // selected there is a legitimate anchor — the insert goes to ITS strip.
+    expect(resolveInsertPlacement(graph, ids("c1"), "project")).toEqual({
+      parentId: parseNodeId("scene-a"),
+      toIndex: 1,
+      afterId: parseNodeId("c1"),
+    });
+    // Any depth, not just one level down.
+    expect(resolveInsertPlacement(graph, ids("d1"), "project")).toEqual({
+      parentId: parseNodeId("scene-b"),
+      toIndex: 1,
+      afterId: parseNodeId("d1"),
+    });
+  });
+
+  it("uses the LAST selected card of a multi-selection", () => {
+    expect(resolveInsertPlacement(graph, ids("charlie", "alpha"), "project")).toEqual({
+      parentId: parseNodeId("project"),
+      toIndex: 1,
+      afterId: parseNodeId("alpha"),
+    });
+  });
+
+  it("ignores a selection ABOVE the focused collection (the drill-in wrinkle)", () => {
+    // Copy alpha in the project, drill into Scene A, Paste: the selection
+    // survived the navigation but its strip is gone. Appending into the
+    // focused collection is the only placement the user can see happen.
+    expect(resolveInsertPlacement(graph, ids("alpha"), "scene-a")).toEqual({
+      parentId: parseNodeId("scene-a"),
+      toIndex: 3,
+      afterId: null,
+    });
+    // The focused collection's OWN card is a selection above it too.
+    expect(resolveInsertPlacement(graph, ids("scene-a"), "scene-a")).toEqual({
+      parentId: parseNodeId("scene-a"),
+      toIndex: 3,
+      afterId: null,
+    });
+  });
+
+  it("ignores a selection in a sibling branch of the focused collection", () => {
+    // Focused on Scene B; c1 lives in Scene A's strip, which is neither the
+    // focused collection nor inside it.
+    expect(resolveInsertPlacement(graph, ids("c1"), "scene-b")).toEqual({
+      parentId: parseNodeId("scene-b"),
+      toIndex: 1,
+      afterId: null,
+    });
+  });
+
+  it("ignores a selection under a different root (the trash)", () => {
+    expect(resolveInsertPlacement(graph, ids("t1"), "project")).toEqual({
+      parentId: parseNodeId("project"),
+      toIndex: 4,
+      afterId: null,
+    });
+  });
+
+  it("ignores a root selection (a root has no parent to take a sibling)", () => {
+    expect(resolveInsertPlacement(graph, ids("project"), "project")).toEqual({
+      parentId: parseNodeId("project"),
+      toIndex: 4,
+      afterId: null,
+    });
+  });
+
+  it("ignores a selected id that is no longer in the graph", () => {
+    expect(resolveInsertPlacement(graph, ids("deleted"), "project")).toEqual({
+      parentId: parseNodeId("project"),
+      toIndex: 4,
+      afterId: null,
+    });
+  });
+
+  it("appends at 0 when the focused collection is not in the graph yet", () => {
+    // Un-hydrated focus: the dispatch itself will refuse, but the placement
+    // must stay defined rather than throw on a missing children list.
+    expect(resolveInsertPlacement(graph, ids("alpha"), "not-loaded")).toEqual({
+      parentId: parseNodeId("not-loaded"),
+      toIndex: 0,
+      afterId: null,
+    });
+  });
+});

--- a/apps/timeline-gstudio001/lib/graph-insert-placement.ts
+++ b/apps/timeline-gstudio001/lib/graph-insert-placement.ts
@@ -1,0 +1,72 @@
+import {
+  getChildren,
+  isSameOrAncestor,
+  parseNodeId,
+  type CollectionsGraph,
+  type NodeId,
+} from "@storyboard/ui/dnd-collections";
+
+// Where a NEW card lands when the gesture carries no pointer position — the
+// Collection tool's click/keyboard path and the item rail's Paste. Both used
+// to answer this question themselves and drifted; this is the one rule.
+
+export type InsertPlacement = Readonly<{
+  /** The collection the new nodes join. */
+  parentId: NodeId;
+  /** Index within that collection's children. */
+  toIndex: number;
+  /** The card the insert follows, or null when it appended. For announcements. */
+  afterId: NodeId | null;
+}>;
+
+/**
+ * Resolve a selection-aware insert position.
+ *
+ * The rule: land right AFTER the most recently selected card, inside THAT
+ * card's own timeline — which may be any strip on the board, not just the
+ * focused one (clicking the rail or the tool never clears the selection, so
+ * this works for mouse and keyboard alike). With nothing selected, append to
+ * the focused collection: the one spot that needs no explanation.
+ *
+ * The selection only counts when its parent lies INSIDE the focused
+ * collection's subtree (the focused collection itself or a descendant —
+ * i.e. a strip the board is actually showing). Selection survives drill-in
+ * navigation in this app, so without that guard the copy → drill-in → Paste
+ * flow would fire the paste back into the timeline the user just left, at a
+ * card that is no longer on screen. Same for the tool: after a drill-in the
+ * stale selection would plant the new collection a level up.
+ *
+ * Pure graph math — no store, no React — so both call sites share it and it
+ * unit-tests directly.
+ */
+export function resolveInsertPlacement(
+  graph: CollectionsGraph,
+  /** The live selection, in selection order (a Set iterates insertion-first). */
+  selectedIds: Iterable<NodeId>,
+  /** The open collection's id (a timeline id, which is also its node id). */
+  focusedId: string,
+): InsertPlacement {
+  const focusedNodeId = parseNodeId(focusedId);
+  // The LAST entry is the most recent pick — the card a multi-select last
+  // touched, and the one the user is looking at.
+  let selectedId: NodeId | undefined;
+  for (const id of selectedIds) selectedId = id;
+
+  if (selectedId !== undefined) {
+    const selectedParentId = graph.parentById.get(selectedId) ?? null;
+    // A root has no parent and can't take a sibling. `isSameOrAncestor` is
+    // cycle-guarded, so a corrupt parent chain degrades to the append below
+    // instead of hanging.
+    if (selectedParentId !== null && isSameOrAncestor(graph, focusedNodeId, selectedParentId)) {
+      const siblings = getChildren(graph, selectedParentId);
+      const at = siblings.indexOf(selectedId);
+      if (at >= 0) return { parentId: selectedParentId, toIndex: at + 1, afterId: selectedId };
+    }
+  }
+
+  return {
+    parentId: focusedNodeId,
+    toIndex: getChildren(graph, focusedNodeId).length,
+    afterId: null,
+  };
+}

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1834,7 +1834,9 @@ test.describe("graph view E2E", () => {
 
     // Drill into the child collection. The clipboard is a module singleton, so
     // it survives the client-side navigation: the rail stays in item mode with
-    // Paste available even though the selection is now out of view.
+    // Paste available even though the selection is now out of view. The
+    // SELECTION survives the navigation too — see the placement test below for
+    // why the paste must ignore it here and append into the focused child.
     await page.getByRole("button", { name: "Open Scene A" }).first().click();
     await strip(page, CHILD_ID)
       .locator('[data-node-id="c1"]')
@@ -1848,6 +1850,70 @@ test.describe("graph view E2E", () => {
     expect((await stripOrder(page, CHILD_ID)).slice(0, 2)).toEqual(["c1", "c2"]);
     await expect.poll(() => api.patchesFor(CHILD_ID).at(-1)?.clipIds.length).toBe(3);
     await expect(page.getByRole("button", { name: "Grid layout" })).toBeVisible();
+  });
+
+  test("Paste lands AFTER the selected card, and a selection left above the focus never hijacks it", async ({
+    page,
+  }) => {
+    // Paste follows the same placement rule as the Collection tool: after the
+    // most recently selected card, in THAT card's strip — but only while that
+    // strip sits inside the focused collection's subtree (i.e. is on the
+    // board). It used to always append to the focused collection.
+    const api = await installGraphApi(page);
+    await openGraph(page);
+    const projectStrip = strip(page, PROJECT_ID);
+    const alpha = projectStrip.locator('[data-node-id="alpha"]');
+
+    await expect(async () => {
+      await alpha.click();
+      await expect(alpha).toHaveAttribute("data-selected", "true", { timeout: 700 });
+    }).toPass({ timeout: 10000 });
+    await page.getByRole("button", { name: "Copy", exact: true }).click();
+    await expect(page.getByRole("button", { name: "Paste", exact: true })).toBeEnabled();
+
+    // alpha is still selected and still on screen → its clone lands at index 1,
+    // not at the end of the strip.
+    await page.getByRole("button", { name: "Paste", exact: true }).click();
+    await expect.poll(() => stripOrder(page, PROJECT_ID)).toHaveLength(5);
+    const order = await stripOrder(page, PROJECT_ID);
+    expect(order[0]).toBe("alpha");
+    expect(order[1]).not.toBe("alpha");
+    expect(order.slice(2)).toEqual(["bravo", CHILD_ID, "charlie"]);
+    // And it IS alpha's clone sitting there, not some other entry.
+    await expect(projectStrip.getByRole("button", { name: "alpha", exact: true })).toHaveCount(2);
+
+    // Now the drill-in wrinkle: selection SURVIVES navigation in this app, so
+    // a naive "after the selection" would fire this paste back into the
+    // project, at a card the user can no longer see.
+    const charlie = projectStrip.locator('[data-node-id="charlie"]');
+    await expect(async () => {
+      await charlie.click();
+      await expect(charlie).toHaveAttribute("data-selected", "true", { timeout: 700 });
+    }).toPass({ timeout: 10000 });
+    await page.getByRole("button", { name: "Copy", exact: true }).click();
+
+    await page.getByRole("button", { name: "Open Scene A" }).first().click();
+    // The route change itself, not a CHILD card appearing — a sub-row strip
+    // can be on screen before any navigation happens.
+    await expect(strip(page, PROJECT_ID)).toHaveCount(0);
+    await strip(page, CHILD_ID)
+      .locator('[data-node-id="c1"]')
+      .waitFor({ state: "visible", timeout: 30000 });
+    await page.getByRole("button", { name: "Paste", exact: true }).click();
+
+    // Appended into the FOCUSED child, after its own cards…
+    await expect.poll(() => stripOrder(page, CHILD_ID)).toHaveLength(3);
+    expect((await stripOrder(page, CHILD_ID)).slice(0, 2)).toEqual(["c1", "c2"]);
+    await expect(
+      strip(page, CHILD_ID).getByRole("button", { name: "charlie", exact: true }),
+    ).toBeVisible();
+    // …and the project never grew a sixth clip. Checked on the WRITES because
+    // the project strip is off-screen now; the child's write lands in the same
+    // debounced batch, so by the time it is recorded a hijacked project write
+    // would have been too. (Ancestor summary re-writes are expected — a
+    // project patch is fine as long as it still carries five clips.)
+    await expect.poll(() => api.patchesFor(CHILD_ID).at(-1)?.clipIds.length).toBe(3);
+    expect(api.patchesFor(PROJECT_ID).some((patch) => patch.clipIds.length > 5)).toBe(false);
   });
 
   test("Cut removes the clip but keeps it on the clipboard; Paste relocates it", async ({
@@ -2226,6 +2292,27 @@ test.describe("graph view E2E", () => {
     await expect
       .poll(() => stripOrder(page, PROJECT_ID).then((order) => order.length))
       .toBe(5);
+
+    // …but only strips INSIDE the focused subtree count. Select charlie in the
+    // project, then drill into Scene A: the selection survives the navigation,
+    // and the tool must append into the collection now open rather than plant
+    // the new timeline back where the user came from (same rule as Paste).
+    await strip(page, PROJECT_ID).locator('[data-node-id="charlie"]').click();
+    await page.getByRole("button", { name: "Open Scene A" }).first().click();
+    // Wait on the PROJECT strip leaving, not on a CHILD card appearing: the
+    // Scene A sub-row is expanded above, so its strip is already on the page
+    // and that wait would pass without the route having changed at all —
+    // letting the tool click race the navigation (it did, first run).
+    await expect(strip(page, PROJECT_ID)).toHaveCount(0);
+    await collectionTool.click();
+    await expect
+      .poll(() => stripOrder(page, CHILD_ID))
+      .toEqual([
+        "c1",
+        expect.stringMatching(/^timeline-/),
+        "c2",
+        expect.stringMatching(/^timeline-/),
+      ]);
   });
 
   test("keyboard insertion works in grid mode too", async ({ page }) => {


### PR DESCRIPTION
Punch-list #4. Paste used to always append to the focused collection; it now follows the same rule the Collection tool does — land right after the most recently selected card, in **that card's own strip** — with one guard both paths share.

**The guard.** The selection only counts when its parent lies inside the *focused* collection's subtree. Selection survives drill-in navigation in this app, so a bare "after the selection" would send the copy → drill-in → Paste flow back into the timeline the user just left, at a card no longer on screen. The tool's click/keyboard path had the same latent hijack; it goes away with the shared helper.

### Changes

- **`lib/graph-insert-placement.ts`** (new) — pure `resolveInsertPlacement(graph, selectedIds, focusedId) → {parentId, toIndex, afterId}`, cycle-guarded via the core's `isSameOrAncestor`. 10 unit tests: descendant strips at any depth, sibling branch, trash root, root/missing selection, un-hydrated focus.
- **`graph-item-actions.tsx`** — `pasteIntoFocused` → `pasteFromClipboard`, placed by the helper. Still ONE `add-nodes` dispatch, so a multi-item paste stays a single undo step and a single persisted batch.
- **`graph-native-drop.tsx`** — `SidebarToolInsertBridge` drops its own placement math for the helper (net −20 lines) and gains the subtree guard.
- **Sidebar disabled style** — it dimmed twice (a `zinc-600` glyph under `opacity-50`), leaving Paste (item mode's resting state) at **1.47:1** against the near-black rail. One dimming step now: solid `zinc-500`, **4.12:1** — enabled siblings are 7.76:1 — with `cursor-not-allowed` and the missing hover response carrying "disabled".

### Tests

New e2e `Paste lands AFTER the selected card, and a selection left above the focus never hijacks it`, both halves proven fail-first (append-to-focused probe fails the index-1 assertion; guard-removed probe fails the drill-in half, the tool test, and 4 unit tests). A drill-in phase added to the tool test caught a **vacuous wait**: an expanded sub-row's strip is on screen *before* any navigation, so waiting on a child card let the click race the route change — both sites now wait on the project strip leaving.

Verified: app vitest 215/215 · graph-view e2e 52/52 · app `tsc` clean · lint clean (4 pre-existing `img` warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
