### PR TITLE
Trash: folder-with-can icon, a working Empty Trash, no duplicate-key errors

### DIFF
--- a/apps/timeline-gstudio001/app/api/trash/route.ts
+++ b/apps/timeline-gstudio001/app/api/trash/route.ts
@@ -13,8 +13,9 @@ export async function DELETE() {
 
     const trashId = `trash-${user.uid}`;
     const trashDoc = await getFirebaseTimelineDocument(trashId, user.uid);
+    const cleared = trashDoc?.clips.length ?? 0;
 
-    if (trashDoc && trashDoc.clips.length > 0) {
+    if (trashDoc && cleared > 0) {
       for (const clip of trashDoc.clips) {
         const clipSrc = (clip as any).src;
         if (clipSrc && clipSrc.includes("cloudinary.com")) {
@@ -30,11 +31,18 @@ export async function DELETE() {
         }
       }
 
-      trashDoc.clips = [];
-      await saveFirebaseTimelineDocument(trashDoc, user.uid);
+      // `allowEmptying` is what makes this work at all. The save path refuses
+      // an empty write over a non-empty document (a stale client erasing real
+      // work) and, separately, reads `lastNonEmptyDocument` back whenever the
+      // stored clips are empty — so without the opt-in this endpoint threw
+      // 500, and had it not thrown the bin would have re-read full anyway.
+      // A copy, not a mutation of the loaded document.
+      await saveFirebaseTimelineDocument({ ...trashDoc, clips: [] }, user.uid, {
+        allowEmptying: true,
+      });
     }
 
-    return NextResponse.json({ success: true });
+    return NextResponse.json({ success: true, cleared });
   } catch (error) {
     console.error("[TRASH_EMPTY_ERROR]", error);
     return NextResponse.json({ error: "Unable to empty the trash." }, { status: 500 });

--- a/apps/timeline-gstudio001/app/api/trash/trash-empty.test.ts
+++ b/apps/timeline-gstudio001/app/api/trash/trash-empty.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
+
+// Empty-the-bin tests over the REAL DELETE handler and the REAL
+// firebase-timeline-store save path — only the process boundaries are faked
+// (the Firestore SDK, the session cookie, Cloudinary). The endpoint could
+// never work before: the save path refuses an empty write over a non-empty
+// document, and — had it not thrown — the READ path re-hydrates
+// `lastNonEmptyDocument` whenever the stored clips are empty, so the bin
+// would have come straight back. Both are pinned here.
+
+type Stored = Record<string, unknown>;
+
+const DELETE_SENTINEL = "__delete__";
+
+const state = vi.hoisted(() => {
+  const docs = new Map<string, Stored>();
+  const current = {
+    user: { uid: "user-a", email: null as string | null, name: null, picture: null },
+  };
+  const cloudinaryDeletes: { publicId: string; resourceType: string }[] = [];
+
+  const applySet = (id: string, data: Stored, opts?: { merge?: boolean }) => {
+    const existing = docs.get(id);
+    const merged = opts?.merge && existing ? { ...existing, ...data } : { ...data };
+    // Firestore's FieldValue.delete() removes the field on a merge write;
+    // the in-memory double honours it so the read-back path is exercised
+    // exactly as it runs in production.
+    for (const [key, value] of Object.entries(merged)) {
+      if (value === "__delete__") delete merged[key];
+    }
+    docs.set(id, merged);
+  };
+  const snapshot = (id: string) => {
+    const data = docs.get(id);
+    return {
+      id,
+      exists: data !== undefined,
+      data: () => (data ? { ...data } : undefined),
+      get: (field: string) => (data ? data[field] : undefined),
+    };
+  };
+  const docRef = (id: string) => ({
+    id,
+    get: async () => snapshot(id),
+    set: async (data: Stored, opts?: { merge?: boolean }) => applySet(id, data, opts),
+    delete: async () => {
+      docs.delete(id);
+    },
+  });
+  const db = {
+    collection: () => ({
+      doc: docRef,
+      where: () => ({ limit: () => ({ get: async () => ({ docs: [] }) }) }),
+    }),
+  };
+  return { docs, current, db, cloudinaryDeletes };
+});
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/firebase-admin", () => ({ getFirebaseDb: () => state.db }));
+vi.mock("firebase-admin/firestore", () => {
+  class Timestamp {
+    toDate() {
+      return new Date(0);
+    }
+  }
+  return {
+    Timestamp,
+    FieldValue: { serverTimestamp: () => new Timestamp(), delete: () => DELETE_SENTINEL },
+  };
+});
+vi.mock("@/lib/firebase-auth-session", () => ({
+  requireAuthUser: async () => ({ user: state.current.user, response: null }),
+}));
+vi.mock("@/lib/cloudinary-media-store", () => ({
+  listCloudinaryAssets: async () => [],
+  deleteCloudinaryAsset: async (publicId: string, resourceType: string) => {
+    state.cloudinaryDeletes.push({ publicId, resourceType });
+  },
+}));
+
+import { DELETE as emptyTrash } from "./route";
+import { GET as getTimeline } from "../timelines/[id]/route";
+
+const TRASH_ID = "trash-user-a";
+
+function clip(id: string, src: string, kind: "image" | "video" = "image"): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind,
+    src,
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 4,
+    sourceDuration: 4,
+    trimIn: 0,
+    trimOut: 0,
+  } as TimelineClip;
+}
+
+function seedTrash(clips: TimelineClip[], revision = 3) {
+  const document: TimelineDocument = { id: TRASH_ID, title: "Trash Bin", clips };
+  state.docs.set(TRASH_ID, {
+    id: TRASH_ID,
+    title: document.title,
+    document,
+    clips,
+    // Written by every non-empty save — the recovery snapshot that used to
+    // make an emptied bin refill itself on the next read.
+    lastNonEmptyDocument: document,
+    ownerUid: "user-a",
+    revision,
+  });
+}
+
+const readBack = async (): Promise<TimelineDocument> => {
+  const response = await getTimeline(new Request(`http://test.local/api/timelines/${TRASH_ID}`), {
+    params: Promise.resolve({ id: TRASH_ID }),
+  });
+  const body = (await response.json()) as { document: TimelineDocument };
+  return body.document;
+};
+
+beforeEach(() => {
+  state.docs.clear();
+  state.cloudinaryDeletes.length = 0;
+  state.current.user = { uid: "user-a", email: null, name: null, picture: null };
+});
+
+describe("DELETE /api/trash", () => {
+  it("empties the bin", async () => {
+    seedTrash([
+      clip("c1", "https://example.test/a.png"),
+      clip("c2", "https://example.test/b.png"),
+    ]);
+
+    const response = await emptyTrash();
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true, cleared: 2 });
+
+    // Stored: no clips, no recovery snapshot, revision bumped.
+    const stored = state.docs.get(TRASH_ID)!;
+    expect((stored.document as TimelineDocument).clips).toEqual([]);
+    expect(stored.clips).toEqual([]);
+    expect(stored.lastNonEmptyDocument).toBeUndefined();
+    expect(stored.revision).toBe(4);
+    // Ownership is preserved — an empty is still an ordinary owned write.
+    expect(stored.ownerUid).toBe("user-a");
+  });
+
+  it("stays empty on the next read — no refill from the recovery snapshot", async () => {
+    seedTrash([clip("c1", "https://example.test/a.png")]);
+    expect((await emptyTrash()).status).toBe(200);
+
+    // Through the real GET route: `toTimelineDocument` falls back to
+    // `lastNonEmptyDocument` whenever the stored clips are empty, so an empty
+    // that leaves the snapshot behind reads back FULL — the bin would refill
+    // itself and the button would look broken even with the write succeeding.
+    expect((await readBack()).clips).toEqual([]);
+  });
+
+  it("deletes only the Cloudinary-hosted assets, by resource type", async () => {
+    seedTrash([
+      clip("c1", "https://res.cloudinary.com/demo/image/upload/v1/folder/pic.png"),
+      clip("c2", "https://res.cloudinary.com/demo/video/upload/v1/folder/movie.mp4", "video"),
+      clip("c3", "https://example.test/not-cloudinary.png"),
+    ]);
+
+    expect((await emptyTrash()).status).toBe(200);
+    expect(state.cloudinaryDeletes).toEqual([
+      { publicId: "folder/pic", resourceType: "image" },
+      { publicId: "folder/movie", resourceType: "video" },
+    ]);
+  });
+
+  it("is a no-op on an already-empty bin", async () => {
+    state.docs.set(TRASH_ID, {
+      id: TRASH_ID,
+      title: "Trash Bin",
+      document: { id: TRASH_ID, title: "Trash Bin", clips: [] },
+      clips: [],
+      ownerUid: "user-a",
+      revision: 7,
+    });
+
+    const response = await emptyTrash();
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true, cleared: 0 });
+    // No write at all: the revision is untouched.
+    expect(state.docs.get(TRASH_ID)?.revision).toBe(7);
+  });
+
+  it("leaves another user's trash document alone", async () => {
+    seedTrash([clip("c1", "https://example.test/a.png")]);
+    state.current.user = { uid: "user-b", email: null, name: null, picture: null };
+    const before = state.docs.get(TRASH_ID);
+
+    // user-b empties THEIR bin (which doesn't exist) — user-a's is untouched.
+    expect((await emptyTrash()).status).toBe(200);
+    expect(state.docs.get(TRASH_ID)).toEqual(before);
+  });
+});

--- a/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
+++ b/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
@@ -11,6 +11,7 @@ import {
 
 import { Button } from "@/components/core/button";
 import { useAuth } from "@/components/auth/auth-provider";
+import { announceGraphTrashEmptied } from "@/lib/graph-view-events";
 import type { TimelineClip } from "@storyboard/ui/timeline/types";
 
 type TrashDrawerProps = {
@@ -97,6 +98,11 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
 
       setClips([]);
 
+      // A graph view mounted behind this drawer still holds every one of
+      // those items as nodes under its trash root, and would write them back
+      // on the next commit that touches the trash. Tell it to rebuild.
+      announceGraphTrashEmptied();
+
       window.dispatchEvent(
         new CustomEvent("gstudio-toast", {
           detail: { message: "Trash bin emptied successfully" }
@@ -168,9 +174,16 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
             </div>
           ) : (
             <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4 p-5">
-              {clips.map((clip) => (
+              {clips.map((clip, index) => (
                 <div
-                  key={clip.id}
+                  // Keyed by SLOT, not by clip id: the trash document can
+                  // legitimately hold the same id more than once (the legacy
+                  // views mint stable per-asset clip ids, so one asset trashed
+                  // from two timelines arrives twice — the graph's own
+                  // hydration demotes such collisions for the same reason).
+                  // An id key made React log a duplicate-key error per repeat
+                  // and drop cards from the grid.
+                  key={`${index}-${clip.id}`}
                   className="relative group rounded-lg overflow-hidden border border-zinc-900 bg-zinc-900/20 p-2 hover:border-zinc-800 transition-colors"
                 >
                   <div className="aspect-video relative rounded bg-black/60 overflow-hidden flex items-center justify-center border border-zinc-800/40">

--- a/apps/timeline-gstudio001/components/graph-view/boot-session-key.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/boot-session-key.test.ts
@@ -20,6 +20,15 @@ describe("bootSessionKey", () => {
     expect(bootSessionKey(null, "proj-1")).toBe(bootSessionKey(null, "proj-1"));
   });
 
+  it("defaults the generation, so existing two-argument callers are unaffected", () => {
+    expect(bootSessionKey("user-a", "proj-1")).toBe(bootSessionKey("user-a", "proj-1", 0));
+  });
+
+  it("changes when the generation is bumped (a permanent trash empty remounts)", () => {
+    expect(bootSessionKey("user-a", "proj-1", 1)).not.toBe(bootSessionKey("user-a", "proj-1"));
+    expect(bootSessionKey("user-a", "proj-1", 1)).toBe(bootSessionKey("user-a", "proj-1", 1));
+  });
+
   it("does not let a separator inside either value forge a different pairing", () => {
     // Without encoding, ("a:b", "c") and ("a", "b:c") would both stringify to
     // "a:b:c" and collide.

--- a/apps/timeline-gstudio001/components/graph-view/boot-session-key.ts
+++ b/apps/timeline-gstudio001/components/graph-view/boot-session-key.ts
@@ -11,19 +11,29 @@
  * the session identity forces a remount when — and only when — the session
  * changes, recreating the store from the fresh `initialGraph`.
  *
- * The key is intentionally derived only from the signed-in uid and the
- * projectId: it must stay stable across ordinary renders and route drill-in
- * (navigating within the same project/user must NOT remount — that would drop
- * selection and undo history on every drill). This value is stored alongside
- * the built graph in the boot-ready state so the key changes atomically with
- * the graph it describes, never before it.
+ * The key is intentionally derived only from the signed-in uid, the projectId,
+ * and a rebuild counter: it must stay stable across ordinary renders and route
+ * drill-in (navigating within the same project/user must NOT remount — that
+ * would drop selection and undo history on every drill). This value is stored
+ * alongside the built graph in the boot-ready state so the key changes
+ * atomically with the graph it describes, never before it.
+ *
+ * `generation` is the deliberate remount lever, for the rare case where the
+ * mounted store holds nodes that no longer exist server-side and cannot be
+ * removed by any command — today: the trash bin being permanently emptied
+ * from the sidebar drawer, whose items are nodes under this graph's trash
+ * root. Callers bump it; every other input stays untouched.
  */
-export function bootSessionKey(uid: string | null, projectId: string): string {
+export function bootSessionKey(
+  uid: string | null,
+  projectId: string,
+  generation = 0,
+): string {
   // Encode presence explicitly (`0` = signed-out, `1` + encoded uid =
   // signed-in) so a signed-out (null) session never collapses onto a
   // signed-in session whose uid happens to be the empty string. Both parts are
   // encoded unambiguously so no uid/projectId pair can collide with another (a
   // literal separator in either value can't fake a boundary).
   const uidPart = uid === null ? "0" : `1${encodeURIComponent(uid)}`;
-  return `${uidPart}:${encodeURIComponent(projectId)}`;
+  return `${uidPart}:${encodeURIComponent(projectId)}:${generation}`;
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -40,6 +40,7 @@ import {
   GRAPH_PREVIEW_TOGGLE_EVENT,
   GRAPH_RULER_TOGGLE_EVENT,
   GRAPH_SURFACE_EVENT,
+  GRAPH_TRASH_EMPTIED_EVENT,
   broadcastGraphViewState,
   type GraphSurface,
 } from "@/lib/graph-view-events";
@@ -211,6 +212,25 @@ export function GraphTimelineView({
     () => bootstrap !== null && bootstrap !== undefined && bootstrap.length > 0,
   );
 
+  // The sidebar's trash drawer just PERMANENTLY emptied the bin on the
+  // server. Every one of those items is still a node under this graph's trash
+  // root, and the next commit that touches the trash would write the whole
+  // stale list back — resurrecting what the user just destroyed. Drop the
+  // cached documents and re-boot: the counter feeds the boot effect below AND
+  // the session key, so `<DndCollections>` remounts and actually adopts the
+  // rebuilt graph (`initialGraph` is initial-only by design). Undo history
+  // goes with it, which is the honest outcome — a permanent delete is not
+  // undoable, and history entries referencing those nodes could not replay.
+  const [trashGeneration, setTrashGeneration] = useState(0);
+  useEffect(() => {
+    const onEmptied = () => {
+      graphDocumentsGateway.refresh();
+      setTrashGeneration((generation) => generation + 1);
+    };
+    window.addEventListener(GRAPH_TRASH_EMPTIED_EVENT, onEmptied);
+    return () => window.removeEventListener(GRAPH_TRASH_EMPTIED_EVENT, onEmptied);
+  }, []);
+
   useEffect(() => {
     if (trashDocumentId === null) return;
 
@@ -292,14 +312,14 @@ export function GraphTimelineView({
         status: "ready",
         graph: built.value,
         trashRootId,
-        sessionKey: bootSessionKey(uid, projectId),
+        sessionKey: bootSessionKey(uid, projectId, trashGeneration),
       });
     })();
 
     return () => {
       cancelled = true;
     };
-  }, [projectId, trashDocumentId, uid, detailsStore, bootedFromServer]);
+  }, [projectId, trashDocumentId, uid, detailsStore, bootedFromServer, trashGeneration]);
 
   const onSync = useCallback((entry: SyncEntry) => {
     setSyncLog((log) => [entry, ...log].slice(0, 6));

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -5,6 +5,7 @@ import {
   ClipboardPaste,
   Copy,
   CopyPlus,
+  Folder,
   Images,
   Layers,
   FolderTree,
@@ -52,6 +53,38 @@ type UtilityItem = {
   description: string;
   icon: React.ComponentType<{ className?: string }>;
 };
+
+/**
+ * The trash BIN as this app means it: a folder (it holds timeline items, and
+ * they come back) with a trash can sitting in its body. Lucide has no such
+ * glyph, so it is composed — the folder at full size, the can scaled into the
+ * pocket below the tab. Both strokes inherit `currentColor`, so every state
+ * the button paints (idle, pressed, drop-hover) still styles one icon.
+ *
+ * `className` sizes the WRAPPER (the call site passes the same `h-4 w-4` every
+ * other sidebar icon gets) and the parts size off it, so the composition can
+ * never drift from the row.
+ */
+function FolderTrashIcon({ className }: Readonly<{ className?: string }>) {
+  return (
+    <span
+      aria-hidden="true"
+      // The animated element: the sidebar hands its drop-hover / arrival
+      // classes to THIS wrapper (both glyphs move together), so it is also
+      // what the e2e watches.
+      data-sidebar-icon="trash"
+      className={cn("relative inline-block shrink-0", className)}
+    >
+      <Folder className="h-full w-full" />
+      {/* Nudged below the folder's tab so the can reads as sitting INSIDE the
+          pocket; the heavier stroke keeps it legible at 16px. */}
+      <Trash2
+        className="absolute left-1/2 top-[58%] h-[52%] w-[52%] -translate-x-1/2 -translate-y-1/2"
+        strokeWidth={2.75}
+      />
+    </span>
+  );
+}
 
 const SIDEBAR_ICON_BASE =
   "group/sidebar-item relative flex size-11 items-center justify-center rounded-lg border transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400";
@@ -230,7 +263,7 @@ const UTILITY_ITEMS: UtilityItem[] = [
     id: "trash",
     label: "Trash",
     description: "Deleted timeline items",
-    icon: Trash2,
+    icon: FolderTrashIcon,
   },
   {
     id: "settings",

--- a/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
@@ -260,6 +260,19 @@ export async function getFirebaseTimelineDocument(id: string, requesterUid: stri
   return entry?.document ?? null;
 }
 
+export type SaveOptions = Readonly<{
+  isProject?: boolean;
+  /**
+   * Permit a save that leaves the document with NO clips, and clear the
+   * `lastNonEmptyDocument` recovery snapshot with it. Off by default: an empty
+   * write is normally a stale or half-loaded client about to erase real work,
+   * which the guard in `saveFirebaseTimelineEntry` rejects. The one caller
+   * that means it is DELETE /api/trash — emptying the bin is the user asking
+   * for exactly this document to end up empty.
+   */
+  allowEmptying?: boolean;
+}>;
+
 /** The one Firestore payload both write paths (single save, atomic batch)
  *  produce — shared so revision stamping and ownership claiming can't drift
  *  between them. */
@@ -268,7 +281,7 @@ function buildSavePayload(
   existing: TimelineDocumentRecord | undefined,
   requesterUid: string,
   revision: number,
-  options?: { isProject?: boolean },
+  options?: SaveOptions,
 ) {
   return {
     id: normalizedDocument.id,
@@ -278,7 +291,16 @@ function buildSavePayload(
     clips: normalizedDocument.clips,
     ...(normalizedDocument.clips.length > 0
       ? { lastNonEmptyDocument: normalizedDocument }
-      : {}),
+      : // A DELIBERATE empty (`allowEmptying` — the trash bin's Empty Trash)
+        // must drop the recovery snapshot as well. `toTimelineDocument` reads
+        // `lastNonEmptyDocument` back whenever the stored document has no
+        // clips, so leaving it behind would re-hydrate the very clips this
+        // write removed and the empty would never stick. An INCIDENTAL empty
+        // (never reachable through the guard below, but merge-safe anyway)
+        // leaves the snapshot exactly where it was.
+        options?.allowEmptying
+        ? { lastNonEmptyDocument: FieldValue.delete() }
+        : {}),
     isProject: options?.isProject ?? existing?.isProject === true,
     // Ownership: a save CREATES with the requester as owner, CLAIMS a legacy
     // unowned record, and was refused earlier on someone else's. Children
@@ -293,7 +315,7 @@ function buildSavePayload(
 export async function saveFirebaseTimelineEntry(
   document: TimelineDocument,
   requesterUid: string,
-  options?: { isProject?: boolean },
+  options?: SaveOptions,
 ): Promise<TimelineEntry> {
   if (isUnsavedProjectPlaceholder(document)) {
     throw new Error("Refusing to save an unloaded project placeholder.");
@@ -313,6 +335,7 @@ export async function saveFirebaseTimelineEntry(
     : null;
 
   if (
+    !options?.allowEmptying &&
     existingDocument &&
     existingDocument.clips.length > 0 &&
     normalizedDocument.clips.length === 0
@@ -345,7 +368,7 @@ export async function saveFirebaseTimelineEntry(
 export async function saveFirebaseTimelineDocument(
   document: TimelineDocument,
   requesterUid: string,
-  options?: { isProject?: boolean },
+  options?: SaveOptions,
 ) {
   return (await saveFirebaseTimelineEntry(document, requesterUid, options)).document;
 }

--- a/apps/timeline-gstudio001/lib/graph-view-events.ts
+++ b/apps/timeline-gstudio001/lib/graph-view-events.ts
@@ -148,3 +148,16 @@ export function setGraphTrashDropHover(hovering: boolean): void {
     new CustomEvent<boolean>(GRAPH_TRASH_HOVER_EVENT, { detail: hovering }),
   );
 }
+
+// Emptying the bin is the one action that removes items the graph is HOLDING.
+// The drawer is app chrome and talks to the server directly, so a graph view
+// mounted behind it would keep the deleted nodes in its store — and write them
+// straight back on the next commit that touches the trash. The drawer
+// announces the empty here and the graph view rebuilds from the server.
+
+export const GRAPH_TRASH_EMPTIED_EVENT = "graph-view:trash-emptied";
+
+/** Announce that the trash document was permanently emptied on the server. */
+export function announceGraphTrashEmptied(): void {
+  window.dispatchEvent(new CustomEvent(GRAPH_TRASH_EMPTIED_EVENT));
+}

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1232,10 +1232,9 @@ test.describe("graph view E2E", () => {
     const parentZone = page.locator(`[data-graph-ancestor-drop="${PROJECT_ID}"]`);
     const parentCrumb = parentZone.locator("a");
     const trashZone = page.locator(`[data-graph-sidebar-trash="${TRASH_ID}"]`);
-    const trashIcon = page
-      .getByRole("button", { name: "Trash", exact: true })
-      .locator("svg")
-      .first();
+    // The drawer button's icon is a COMPOSED glyph (a folder with a trash can
+    // in it), so the animation rides its wrapper — not an <svg>.
+    const trashIcon = page.locator('[data-sidebar-icon="trash"]');
 
     // Pick c1 up (hold to activate), then hold it — no release — over each zone.
     const box = (await c1.boundingBox())!;


### PR DESCRIPTION
Three fixes to the trash surface.

### 1. The sidebar icon is a folder with a can in it

Lucide has no such glyph, so `FolderTrashIcon` layers `Trash2` inside `Folder`. Both strokes inherit `currentColor`, so idle / pressed / drop-hover still style one icon. The drag animations ride the wrapper (`data-sidebar-icon="trash"`), which is what the e2e watches now — it used to watch the lone `<svg>`.

### 2. Empty Trash could never have worked

Two independent guards stood in front of it:

- `saveFirebaseTimelineEntry` refuses an empty write over a non-empty document (a stale client about to erase real work) → `DELETE /api/trash` threw and answered **500 every time**.
- `toTimelineDocument` reads `lastNonEmptyDocument` back whenever the stored clips are empty → even a successful write would have **re-read full**.

New opt-in `SaveOptions.allowEmptying` (off by default) skips the guard *and* clears the recovery snapshot with `FieldValue.delete()`. The trash route is the one caller — emptying the bin is the user asking for exactly this document to end up empty.

**Client half:** a graph view mounted behind the drawer still holds every one of those items as nodes under its trash root, and would write them back on the next commit that touches the trash. The drawer announces the empty (`GRAPH_TRASH_EMPTIED_EVENT`); the graph view drops its cached documents and re-boots. `bootSessionKey` gained a `generation` component so `<DndCollections>` actually remounts and adopts the rebuilt graph (`initialGraph` is initial-only). Undo history goes with it — a permanent delete is not undoable and those entries could not replay.

### 3. The two console errors on opening the drawer

The grid keyed cards by `clip.id`, and the trash document legitimately holds repeated ids: this app mints stable per-asset clip ids, so one asset trashed from two timelines arrives twice — the graph's own hydration demotes such collisions for the same reason. Keyed by slot now. Live check: 53 clips → 53 cards, no console errors, no dev-overlay issues badge (was "2 Issues").

### Tests

New `app/api/trash/trash-empty.test.ts` drives the REAL handler over the REAL store with an in-memory Firestore (including a `FieldValue.delete()` double): empties, **stays empty on re-read**, deletes only Cloudinary-hosted assets by resource type, no-ops on an empty bin, leaves another user's document alone. Both halves proven fail-first — guard bypass removed → 500; snapshot left behind → refills. `bootSessionKey` pins the new generation argument.

### One thing to know

The route also deletes the Cloudinary asset behind each trashed clip. Because the same asset can be referenced from several timelines, emptying can delete an asset a live timeline still uses. That is pre-existing route behaviour, but it was unreachable while the endpoint 500'd — worth a reference check before anyone leans on it.

Verified: app vitest 222/222 · graph-view e2e 52/52 · app `tsc` clean · lint clean (4 pre-existing `img` warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
