### PR TITLE
Empty Trash: keep assets other timelines still reference

### DIFF
--- a/apps/timeline-gstudio001/app/api/trash/route.ts
+++ b/apps/timeline-gstudio001/app/api/trash/route.ts
@@ -1,11 +1,34 @@
 import { NextResponse } from "next/server";
 import { requireAuthUser } from "@/lib/firebase-auth-session";
-import { getFirebaseTimelineDocument, saveFirebaseTimelineDocument } from "@/lib/firebase-timeline-store";
+import {
+  collectMediaReferences,
+  getFirebaseTimelineDocument,
+  saveFirebaseTimelineDocument,
+} from "@/lib/firebase-timeline-store";
 import { deleteCloudinaryAsset } from "@/lib/cloudinary-media-store";
+import {
+  isStillReferenced,
+  mediaMatchKeys,
+  referenceIndex,
+  type MediaMatchKeys,
+} from "@/lib/media-references";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+/**
+ * Empty the signed-in user's trash bin: clear the document, and permanently
+ * delete the uploaded assets behind its clips.
+ *
+ * The asset half is REFERENCE-CHECKED. The same upload can be referenced from
+ * several timelines (this app mints stable per-asset clip ids, so placing one
+ * asset twice makes two clips of one asset), which means "this clip is in the
+ * bin" does not mean "nobody is using this file". Anything another document
+ * still points at is kept; only assets no live document references are
+ * destroyed. The check fails SAFE in every direction — a scan that errors, or
+ * that hit its document cap and so can't prove absence, keeps every asset and
+ * still empties the bin, which is the part the user actually asked for.
+ */
 export async function DELETE() {
   try {
     const { user, response } = await requireAuthUser();
@@ -14,20 +37,43 @@ export async function DELETE() {
     const trashId = `trash-${user.uid}`;
     const trashDoc = await getFirebaseTimelineDocument(trashId, user.uid);
     const cleared = trashDoc?.clips.length ?? 0;
+    let assetsDeleted = 0;
+    let assetsKept = 0;
 
     if (trashDoc && cleared > 0) {
+      // Everything the rest of the library still points at. The bin itself is
+      // excluded — its own clips are what we are about to delete, so counting
+      // them would keep every asset forever.
+      const scan = await collectMediaReferences([trashId]).catch((error: unknown) => {
+        console.warn("[TRASH_EMPTY] media reference scan failed; keeping assets", error);
+        return { urls: new Set<string>(), complete: false };
+      });
+      const referenced = referenceIndex(scan.urls);
+
+      // De-duplicated by asset: the bin can hold several clips of one upload
+      // (that is exactly the case this check exists for), and the second
+      // delete of the same public id would 404 against Cloudinary.
+      const seen = new Set<string>();
       for (const clip of trashDoc.clips) {
-        const clipSrc = (clip as any).src;
-        if (clipSrc && clipSrc.includes("cloudinary.com")) {
-          const publicId = extractCloudinaryPublicId(clipSrc);
-          if (publicId) {
-            const resourceType = clip.kind === "video" ? "video" : "image";
-            try {
-              await deleteCloudinaryAsset(publicId, resourceType);
-            } catch (err) {
-              console.warn(`Failed to delete Cloudinary asset ${publicId}:`, err);
-            }
-          }
+        const clipSrc = (clip as { src?: unknown }).src;
+        if (typeof clipSrc !== "string") continue;
+        const keys: MediaMatchKeys | null = mediaMatchKeys(clipSrc);
+        if (keys === null) continue;
+        if (seen.has(keys.publicId)) continue;
+        seen.add(keys.publicId);
+
+        // Incomplete scan = no evidence either way, so the asset stays.
+        if (!scan.complete || isStillReferenced(referenced, keys)) {
+          assetsKept += 1;
+          continue;
+        }
+
+        const resourceType = clip.kind === "video" ? "video" : "image";
+        try {
+          await deleteCloudinaryAsset(keys.publicId, resourceType);
+          assetsDeleted += 1;
+        } catch (err) {
+          console.warn(`Failed to delete Cloudinary asset ${keys.publicId}:`, err);
         }
       }
 
@@ -42,19 +88,9 @@ export async function DELETE() {
       });
     }
 
-    return NextResponse.json({ success: true, cleared });
+    return NextResponse.json({ success: true, cleared, assetsDeleted, assetsKept });
   } catch (error) {
     console.error("[TRASH_EMPTY_ERROR]", error);
     return NextResponse.json({ error: "Unable to empty the trash." }, { status: 500 });
   }
-}
-
-function extractCloudinaryPublicId(url: string): string | null {
-  try {
-    const match = url.match(/\/upload\/(?:v\d+\/)?(.+)$/);
-    if (match && match[1]) {
-      return match[1].replace(/\.[^/.]+$/, "");
-    }
-  } catch {}
-  return null;
 }

--- a/apps/timeline-gstudio001/app/api/trash/trash-empty.test.ts
+++ b/apps/timeline-gstudio001/app/api/trash/trash-empty.test.ts
@@ -49,13 +49,22 @@ const state = vi.hoisted(() => {
       docs.delete(id);
     },
   });
+  // The reference scan reads the whole collection with a cap; `scanFails`
+  // stands in for a Firestore error on that read.
+  const control = { scanFails: false };
   const db = {
     collection: () => ({
       doc: docRef,
       where: () => ({ limit: () => ({ get: async () => ({ docs: [] }) }) }),
+      limit: (max: number) => ({
+        get: async () => {
+          if (control.scanFails) throw new Error("scan exploded");
+          return { docs: [...docs.keys()].slice(0, max).map(snapshot) };
+        },
+      }),
     }),
   };
-  return { docs, current, db, cloudinaryDeletes };
+  return { docs, current, db, cloudinaryDeletes, control };
 });
 
 vi.mock("server-only", () => ({}));
@@ -83,6 +92,7 @@ vi.mock("@/lib/cloudinary-media-store", () => ({
 
 import { DELETE as emptyTrash } from "./route";
 import { GET as getTimeline } from "../timelines/[id]/route";
+import { MEDIA_SCAN_LIMIT } from "@/lib/firebase-timeline-store";
 
 const TRASH_ID = "trash-user-a";
 
@@ -118,6 +128,19 @@ function seedTrash(clips: TimelineClip[], revision = 3) {
   });
 }
 
+/** A LIVE (non-trash) document that still points at `srcs`. */
+function seedLiveTimeline(id: string, srcs: string[]) {
+  const clips = srcs.map((src, index) => clip(`${id}-c${index}`, src));
+  state.docs.set(id, {
+    id,
+    title: id,
+    document: { id, title: id, clips },
+    clips,
+    ownerUid: "user-a",
+    revision: 1,
+  });
+}
+
 const readBack = async (): Promise<TimelineDocument> => {
   const response = await getTimeline(new Request(`http://test.local/api/timelines/${TRASH_ID}`), {
     params: Promise.resolve({ id: TRASH_ID }),
@@ -129,6 +152,7 @@ const readBack = async (): Promise<TimelineDocument> => {
 beforeEach(() => {
   state.docs.clear();
   state.cloudinaryDeletes.length = 0;
+  state.control.scanFails = false;
   state.current.user = { uid: "user-a", email: null, name: null, picture: null };
 });
 
@@ -141,7 +165,12 @@ describe("DELETE /api/trash", () => {
 
     const response = await emptyTrash();
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ success: true, cleared: 2 });
+    expect(await response.json()).toEqual({
+      success: true,
+      cleared: 2,
+      assetsDeleted: 0,
+      assetsKept: 0,
+    });
 
     // Stored: no clips, no recovery snapshot, revision bumped.
     const stored = state.docs.get(TRASH_ID)!;
@@ -178,6 +207,83 @@ describe("DELETE /api/trash", () => {
     ]);
   });
 
+  it("KEEPS an asset another timeline still points at", async () => {
+    // The clip is in the bin, but the same upload is placed in a live
+    // timeline — deleting the file would break a timeline the user can see.
+    const shared = "https://res.cloudinary.com/demo/image/upload/v1/folder/shared.png";
+    const orphan = "https://res.cloudinary.com/demo/image/upload/v1/folder/orphan.png";
+    seedTrash([clip("c1", shared), clip("c2", orphan)]);
+    seedLiveTimeline("project-live", [shared]);
+
+    const response = await emptyTrash();
+    expect(await response.json()).toEqual({
+      success: true,
+      cleared: 2,
+      assetsDeleted: 1,
+      assetsKept: 1,
+    });
+    expect(state.cloudinaryDeletes).toEqual([
+      { publicId: "folder/orphan", resourceType: "image" },
+    ]);
+  });
+
+  it("matches across URL SHAPES — a live poster protects the source file", async () => {
+    // The live document kept only a generated poster (transform chain, .jpg);
+    // the bin holds the plain source (.mp4). Same asset, and a naive string
+    // compare would have deleted it.
+    seedTrash([
+      clip("c1", "https://res.cloudinary.com/demo/video/upload/v1712/folder/clip.mp4", "video"),
+    ]);
+    seedLiveTimeline("project-live", [
+      "https://res.cloudinary.com/demo/video/upload/so_0.35,w_640,c_fill/folder/clip.jpg",
+    ]);
+
+    expect((await emptyTrash()).status).toBe(200);
+    expect(state.cloudinaryDeletes).toEqual([]);
+  });
+
+  it("deletes an asset only ONCE, however many trashed clips share it", async () => {
+    const shared = "https://res.cloudinary.com/demo/image/upload/v1/folder/twice.png";
+    seedTrash([clip("c1", shared), clip("c2", shared)]);
+
+    expect((await emptyTrash()).status).toBe(200);
+    expect(state.cloudinaryDeletes).toEqual([
+      { publicId: "folder/twice", resourceType: "image" },
+    ]);
+  });
+
+  it("keeps every asset when the collection is bigger than the scan cap", async () => {
+    // Past the cap the scan has only seen SOME documents, so "no reference
+    // found" stops being evidence of "unreferenced" — and a permanent delete
+    // needs evidence.
+    seedTrash([clip("c1", "https://res.cloudinary.com/demo/image/upload/v1/folder/pic.png")]);
+    for (let i = 0; i < MEDIA_SCAN_LIMIT; i += 1) {
+      state.docs.set(`filler-${i}`, { id: `filler-${i}`, title: "f", clips: [] });
+    }
+
+    const response = await emptyTrash();
+    expect(await response.json()).toMatchObject({ assetsDeleted: 0, assetsKept: 1 });
+    expect(state.cloudinaryDeletes).toEqual([]);
+    expect(state.docs.get(TRASH_ID)?.clips).toEqual([]);
+  });
+
+  it("keeps every asset when the reference scan fails — and still empties the bin", async () => {
+    seedTrash([clip("c1", "https://res.cloudinary.com/demo/image/upload/v1/folder/pic.png")]);
+    state.control.scanFails = true;
+
+    const response = await emptyTrash();
+    expect(await response.json()).toEqual({
+      success: true,
+      cleared: 1,
+      assetsDeleted: 0,
+      assetsKept: 1,
+    });
+    // No evidence either way = no permanent delete. The document still
+    // emptied: that is the part the user asked for.
+    expect(state.cloudinaryDeletes).toEqual([]);
+    expect(state.docs.get(TRASH_ID)?.clips).toEqual([]);
+  });
+
   it("is a no-op on an already-empty bin", async () => {
     state.docs.set(TRASH_ID, {
       id: TRASH_ID,
@@ -190,7 +296,12 @@ describe("DELETE /api/trash", () => {
 
     const response = await emptyTrash();
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ success: true, cleared: 0 });
+    expect(await response.json()).toEqual({
+      success: true,
+      cleared: 0,
+      assetsDeleted: 0,
+      assetsKept: 0,
+    });
     // No write at all: the revision is untouched.
     expect(state.docs.get(TRASH_ID)?.revision).toBe(7);
   });

--- a/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
@@ -4,6 +4,7 @@ import { FieldValue, Timestamp } from "firebase-admin/firestore";
 
 import type { TimelineDocument, TimelineClip } from "@storyboard/timeline-model/types";
 import { getFirebaseDb } from "./firebase-admin";
+import { collectCloudinaryUrls } from "./media-references";
 import { firstFrameUrl } from "./project-thumbnail";
 import { resolveOwnership, TimelineAccessDeniedError } from "./timeline-ownership";
 
@@ -228,6 +229,52 @@ export async function listFirebaseTimelineProjects(requesterUid: string) {
       const bTime = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
       return bTime - aTime;
     });
+}
+
+/** What a media-reference scan saw. `complete` is false when the collection
+ *  was larger than the cap — the caller then knows it CANNOT conclude that an
+ *  asset is unreferenced, only that it didn't happen to see a reference. */
+export type MediaReferenceScan = Readonly<{
+  urls: ReadonlySet<string>;
+  complete: boolean;
+}>;
+
+/** How many documents one scan will read. Generous relative to a real
+ *  library, and bounded so a runaway collection can't turn one endpoint into
+ *  an unbounded read. Exported so a test can sit exactly on the cap rather
+ *  than hard-coding a number that would drift. */
+export const MEDIA_SCAN_LIMIT = 2000;
+
+/**
+ * Every media URL still referenced by a stored document, excluding the ones
+ * named in `excludeDocumentIds`.
+ *
+ * Used before permanently deleting assets (emptying the trash): an asset is
+ * only safe to destroy when nothing outside the bin points at it, and in this
+ * app the same asset routinely appears in several timelines. The scan reads
+ * the WHOLE collection rather than one owner's documents on purpose — this
+ * result only ever suppresses a delete, so casting the widest net is the
+ * conservative choice, and legacy records carry no ownerUid to filter on
+ * anyway. `lastNonEmptyDocument` is scanned along with the live document:
+ * a recovery snapshot that outlives the asset it names would restore a
+ * timeline full of broken images.
+ */
+export async function collectMediaReferences(
+  excludeDocumentIds: readonly string[] = [],
+): Promise<MediaReferenceScan> {
+  const excluded = new Set(excludeDocumentIds);
+  // One over the cap, so a full page is distinguishable from a truncated one.
+  const snapshot = await withFirebaseTimeout(
+    collection().limit(MEDIA_SCAN_LIMIT + 1).get(),
+    "Scanning timelines for media references",
+  );
+  const complete = snapshot.docs.length <= MEDIA_SCAN_LIMIT;
+  const urls = new Set<string>();
+  for (const doc of snapshot.docs.slice(0, MEDIA_SCAN_LIMIT)) {
+    if (excluded.has(doc.id)) continue;
+    collectCloudinaryUrls(doc.data(), urls);
+  }
+  return { urls, complete };
 }
 
 export async function getFirebaseTimelineEntry(

--- a/apps/timeline-gstudio001/lib/media-references.test.ts
+++ b/apps/timeline-gstudio001/lib/media-references.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  cloudinaryPublicId,
+  collectCloudinaryUrls,
+  isCloudinaryUrl,
+  isStillReferenced,
+  mediaMatchKeys,
+  referenceIndex,
+} from "./media-references";
+
+const CDN = "https://res.cloudinary.com/demo";
+
+describe("cloudinaryPublicId", () => {
+  it("reads a plain upload URL", () => {
+    expect(cloudinaryPublicId(`${CDN}/image/upload/v1712/gstudio/user-a/beach-178.png`)).toBe(
+      "gstudio/user-a/beach-178",
+    );
+  });
+
+  it("reads one with no version stamp", () => {
+    expect(cloudinaryPublicId(`${CDN}/image/upload/gstudio/beach-178.png`)).toBe(
+      "gstudio/beach-178",
+    );
+  });
+
+  it("strips a transform chain — the shape this app STORES as a poster", () => {
+    // cloudinaryVideoThumbnailUrl / cloudinaryImageThumbnailUrl both emit a
+    // chain, so a document's poster and its src name the same asset in two
+    // different shapes. They must resolve to the same id or the reference
+    // check would clear an asset that is still in use.
+    const poster = `${CDN}/video/upload/so_0.35,w_640,h_360,c_fill,q_auto,f_jpg/gstudio/clip-178.jpg`;
+    const source = `${CDN}/video/upload/v1712/gstudio/clip-178.mp4`;
+    expect(cloudinaryPublicId(poster)).toBe("gstudio/clip-178");
+    expect(cloudinaryPublicId(poster)).toBe(cloudinaryPublicId(source));
+  });
+
+  it("strips a lone transform, and a transform followed by a version", () => {
+    expect(cloudinaryPublicId(`${CDN}/image/upload/w_300/a/b.jpg`)).toBe("a/b");
+    expect(cloudinaryPublicId(`${CDN}/video/upload/so_2.5/v9/a/b.mp4`)).toBe("a/b");
+  });
+
+  it("keeps interior dots in the name and only drops the extension", () => {
+    expect(cloudinaryPublicId(`${CDN}/image/upload/v1/a/name.with.dots.png`)).toBe(
+      "a/name.with.dots",
+    );
+  });
+
+  it("never eats the id itself, even when it looks like a transform", () => {
+    // A one-segment id after `/upload/` is the id, whatever its shape.
+    expect(cloudinaryPublicId(`${CDN}/image/upload/w_300.png`)).toBe("w_300");
+  });
+
+  it("ignores a query string", () => {
+    expect(cloudinaryPublicId(`${CDN}/image/upload/v1/a/b.png?_a=cache`)).toBe("a/b");
+  });
+
+  it("returns null for anything that isn't a Cloudinary delivery URL", () => {
+    expect(cloudinaryPublicId("https://example.test/a/b.png")).toBeNull();
+    expect(cloudinaryPublicId("data:image/gif;base64,AAAA")).toBeNull();
+    expect(cloudinaryPublicId("")).toBeNull();
+    expect(isCloudinaryUrl("https://res.cloudinary.com/demo/image/list/foo.json")).toBe(false);
+  });
+});
+
+describe("collectCloudinaryUrls", () => {
+  it("finds URLs at any depth, not just known fields", () => {
+    const document = {
+      id: "t1",
+      title: "T",
+      clips: [
+        { id: "c1", kind: "image", src: `${CDN}/image/upload/v1/a/one.png` },
+        {
+          id: "c2",
+          kind: "video",
+          src: `${CDN}/video/upload/v1/a/two.mp4`,
+          poster: `${CDN}/video/upload/so_0.35,w_640/a/two.jpg`,
+        },
+        {
+          id: "c3",
+          kind: "collection",
+          previewItems: [{ src: `${CDN}/image/upload/v1/a/three.png` }],
+        },
+        { id: "c4", kind: "image", src: "https://example.test/local.png" },
+      ],
+    };
+    expect([...collectCloudinaryUrls(document)].sort()).toEqual(
+      [
+        `${CDN}/image/upload/v1/a/one.png`,
+        `${CDN}/image/upload/v1/a/three.png`,
+        `${CDN}/video/upload/so_0.35,w_640/a/two.jpg`,
+        `${CDN}/video/upload/v1/a/two.mp4`,
+      ].sort(),
+    );
+  });
+
+  it("survives a cyclic record instead of hanging", () => {
+    const node: Record<string, unknown> = { src: `${CDN}/image/upload/v1/a/one.png` };
+    node.self = node;
+    expect([...collectCloudinaryUrls(node)]).toEqual([`${CDN}/image/upload/v1/a/one.png`]);
+  });
+});
+
+describe("the reference check", () => {
+  const live = [
+    `${CDN}/image/upload/v1/gstudio/keep-1.png`,
+    `${CDN}/video/upload/so_0.35,w_640/gstudio/keep-2.jpg`,
+  ];
+
+  it("keeps an asset a live document still points at — in EITHER URL shape", () => {
+    const index = referenceIndex(live);
+    // Same asset, different shape: the trashed clip holds the plain source
+    // while the live document only kept a transformed poster.
+    expect(
+      isStillReferenced(index, mediaMatchKeys(`${CDN}/video/upload/v1/gstudio/keep-2.mp4`)!),
+    ).toBe(true);
+    expect(
+      isStillReferenced(index, mediaMatchKeys(`${CDN}/image/upload/v1/gstudio/keep-1.png`)!),
+    ).toBe(true);
+  });
+
+  it("keeps an asset whose folder moved but whose basename is the same", () => {
+    // The loose half of the match: a re-foldered copy still counts as a
+    // reference, because a wrong DELETE is unrecoverable and a wrong keep
+    // is not.
+    const index = referenceIndex(live);
+    expect(
+      isStillReferenced(index, mediaMatchKeys(`${CDN}/image/upload/v1/other/keep-1.png`)!),
+    ).toBe(true);
+  });
+
+  it("clears an asset nothing points at", () => {
+    const index = referenceIndex(live);
+    expect(
+      isStillReferenced(index, mediaMatchKeys(`${CDN}/image/upload/v1/gstudio/gone-9.png`)!),
+    ).toBe(false);
+  });
+
+  it("skips non-Cloudinary URLs when indexing", () => {
+    const index = referenceIndex(["https://example.test/a.png", ...live]);
+    expect(index.publicIds.size).toBe(2);
+  });
+});

--- a/apps/timeline-gstudio001/lib/media-references.ts
+++ b/apps/timeline-gstudio001/lib/media-references.ts
@@ -1,0 +1,124 @@
+// Which stored media a document still POINTS AT — the reference check that
+// stands between "Empty Trash" and a permanently deleted asset.
+//
+// The same uploaded asset can be referenced from several timelines (this app
+// mints stable per-asset clip ids, so one asset placed twice is one asset with
+// two clips). Deleting the asset behind a trashed clip is therefore only safe
+// when nothing OUTSIDE the trash points at it any more. These helpers are pure
+// string/JSON work so they can be unit-tested away from Firestore and
+// Cloudinary; the scan that feeds them lives in firebase-timeline-store.
+
+/** True for a URL this module can reason about (a Cloudinary delivery URL). */
+export function isCloudinaryUrl(value: string): boolean {
+  return value.includes("cloudinary.com") && value.includes("/upload/");
+}
+
+/** A transformation segment: comma-joined `key_value` pairs, e.g.
+ *  `so_0.35,w_640,h_360,c_fill,q_auto,f_jpg` or a lone `w_300`. */
+function isTransformSegment(segment: string): boolean {
+  return segment
+    .split(",")
+    .every((part) => /^[a-z]{1,3}_[^,/]+$/.test(part));
+}
+
+/** A delivery version stamp: `v1712345678`. */
+function isVersionSegment(segment: string): boolean {
+  return /^v\d+$/.test(segment);
+}
+
+/**
+ * The Cloudinary public id a delivery URL resolves to, or null.
+ *
+ * Everything between `/upload/` and the id can be transformations and a
+ * version stamp, and the app stores BOTH shapes: an upload result is plain
+ * (`/upload/v1712/folder/pic.png`) while a generated poster carries a
+ * transform chain (`/upload/so_0.35,w_640,c_fill/folder/pic.jpg`). Comparing
+ * the raw tails would call those two different assets — which, on this path,
+ * would mean deleting one that is still in use. Strip the chain and the
+ * version, drop the extension, and both collapse onto `folder/pic`.
+ */
+export function cloudinaryPublicId(url: string): string | null {
+  if (!isCloudinaryUrl(url)) return null;
+  const afterUpload = url.split("/upload/")[1];
+  if (afterUpload === undefined) return null;
+  // Delivery URLs carry no query/hash in this app, but a stray one would
+  // otherwise become part of the id.
+  const path = afterUpload.split(/[?#]/)[0];
+  const segments = path.split("/").filter((segment) => segment.length > 0);
+  let start = 0;
+  while (
+    start < segments.length - 1 &&
+    (isTransformSegment(segments[start]) || isVersionSegment(segments[start]))
+  ) {
+    start += 1;
+  }
+  const id = segments.slice(start).join("/").replace(/\.[^/.]+$/, "");
+  return id.length > 0 ? id : null;
+}
+
+/**
+ * The keys an asset is matched on. `publicId` is the precise one; `basename`
+ * (its last path segment) is a deliberately LOOSE fallback, because the two
+ * failure directions are not symmetric: keeping an asset nobody references
+ * wastes storage, while deleting one that is still referenced breaks a
+ * timeline the user can still see. A basename in this app carries an upload
+ * timestamp (`beach-1782573064814`), so the looseness costs almost nothing.
+ */
+export type MediaMatchKeys = Readonly<{ publicId: string; basename: string }>;
+
+export function mediaMatchKeys(url: string): MediaMatchKeys | null {
+  const publicId = cloudinaryPublicId(url);
+  if (publicId === null) return null;
+  return { publicId, basename: publicId.split("/").pop() ?? publicId };
+}
+
+/**
+ * Every Cloudinary URL anywhere inside `value` — a deep walk, not a read of
+ * known fields. A reference can hide in a clip's `src`, a video `poster`, a
+ * collection's stored `previewItems`, or whatever a future clip shape adds;
+ * missing one of those is what would make this check delete a live asset. The
+ * walk is cycle-guarded so a self-referencing record can't hang the request.
+ */
+export function collectCloudinaryUrls(value: unknown, into = new Set<string>()): Set<string> {
+  const seen = new WeakSet<object>();
+  const walk = (node: unknown) => {
+    if (typeof node === "string") {
+      if (isCloudinaryUrl(node)) into.add(node);
+      return;
+    }
+    if (node === null || typeof node !== "object") return;
+    if (seen.has(node)) return;
+    seen.add(node);
+    if (Array.isArray(node)) {
+      for (const item of node) walk(item);
+      return;
+    }
+    for (const item of Object.values(node)) walk(item);
+  };
+  walk(value);
+  return into;
+}
+
+/** The match keys for a set of URLs, as the two lookup sets the check uses. */
+export function referenceIndex(urls: Iterable<string>): Readonly<{
+  publicIds: ReadonlySet<string>;
+  basenames: ReadonlySet<string>;
+}> {
+  const publicIds = new Set<string>();
+  const basenames = new Set<string>();
+  for (const url of urls) {
+    const keys = mediaMatchKeys(url);
+    if (keys === null) continue;
+    publicIds.add(keys.publicId);
+    basenames.add(keys.basename);
+  }
+  return { publicIds, basenames };
+}
+
+/** True when something in the index still points at this asset. */
+export function isStillReferenced(
+  index: ReturnType<typeof referenceIndex>,
+  keys: MediaMatchKeys,
+): boolean {
+  return index.publicIds.has(keys.publicId) || index.basenames.has(keys.basename);
+}


### PR DESCRIPTION
Emptying the bin permanently deleted the Cloudinary asset behind every trashed clip. The same upload can be referenced from several timelines — this app mints stable per-asset clip ids, so placing one asset twice makes two clips of one file — so "this clip is in the bin" never implied "nobody is using this file". Emptying could take out a photo a live timeline still displayed. (Latent until #151: the endpoint 500'd.)

The asset half is now reference-checked. The document still empties either way; only genuinely unreferenced files are destroyed.

### Changes

- **`lib/media-references.ts`** (new, pure) — deep-walks a stored record for Cloudinary URLs (`src`, a video `poster`, a collection's `previewItems`, or whatever a future clip shape adds — missing one is what would make this check delete a live asset) and resolves each to a public id.

  **Transform-aware, and that is load-bearing:** this app stores *both* shapes of the same asset — an upload result is plain (`/upload/v1712/folder/pic.png`) while a generated poster carries a chain (`/upload/so_0.35,w_640,c_fill/folder/pic.jpg`). The old route-local extractor read the whole chain as part of the id, so it would have called those two different files. Matching is deliberately loose (public id **or** basename): a wrong keep wastes storage, a wrong delete is unrecoverable.

- **`firebase-timeline-store`** — `collectMediaReferences(excludeIds)` scans the collection (capped, one-over to detect truncation) and harvests every referenced URL, `lastNonEmptyDocument` included: a recovery snapshot that outlives the asset it names would restore a timeline of broken images.

- **The route** keeps an asset when anything still references it, when the scan was truncated, or when the scan threw — no evidence is not evidence of absence, and a permanent delete needs evidence. Deletes are de-duplicated by public id (the bin can hold several clips of one upload, the very case this exists for). Response now reports `{cleared, assetsDeleted, assetsKept}`.

### Tests

14 unit (transform chains, versions, dotted names, cyclic records, both halves of the match) + 5 route cases over the real handler: a shared asset kept while the orphan goes, **a live poster protecting a trashed source**, one delete per shared asset, truncated scan keeps everything, failed scan keeps everything and still empties. Reference check removed → 4 fail.

Verified: app vitest 241/241 · graph-view e2e 52/52 · app `tsc` clean · lint clean (4 pre-existing `img` warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
