### PR TITLE
Header centre shows the selection; media badges say IMAGE / VIDEO

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -41,6 +41,7 @@ import {
   PreviewShell,
   collectionCardWidth,
   useFocusedTimelineAggregate,
+  useSelectionAggregate,
   type PreviewTimeChannel,
 } from "./graph-preview";
 import { SubTimelines } from "./graph-sub-timelines";
@@ -122,22 +123,41 @@ function formatAggregateSeconds(seconds: number): string {
 }
 
 /**
- * The focused timeline's aggregate, at the row's TRUE centre — directly
- * under the preview transport's centred play cluster. The header's two
- * wings (breadcrumb / controls) carry equal `flex-1`, so this piece sits
- * dead-centre and stays there; a long breadcrumb truncates inside its own
- * wing instead of pushing the centre around. Passive DATA on purpose (the
- * per-card badges show the same numbers), so hiding it on small screens
- * costs nothing.
+ * The centre readout of the header row: normally the focused timeline's
+ * aggregate, and — while anything is selected — what the SELECTION adds up
+ * to instead. One slot, two answers: the selection is the more specific fact
+ * about the same timeline, so it takes the same pixels rather than opening a
+ * second readout the eye has to choose between. Clearing the selection puts
+ * the timeline total straight back.
+ *
+ * The header's two wings (breadcrumb / controls) carry equal `flex-1`, so
+ * this piece sits dead-centre and stays there; a long breadcrumb truncates
+ * inside its own wing instead of pushing the centre around. Passive DATA on
+ * purpose (the per-card badges show the same numbers), so hiding it on small
+ * screens costs nothing.
  */
 function FocusedAggregate({
   focusedId,
   pixelsPerSecond,
 }: Readonly<{ focusedId: string; pixelsPerSecond: number }>) {
+  const selection = useSelectionAggregate();
   const { count, seconds } = useFocusedTimelineAggregate(focusedId, pixelsPerSecond);
+
+  if (selection.count > 0) {
+    return (
+      <span
+        data-selection-summary
+        className="hidden shrink-0 px-3 text-center font-mono text-[11px] tabular-nums text-amber-300/90 sm:block"
+        title="Selected items"
+      >
+        {selection.count} selected · {formatAggregateSeconds(selection.seconds)}
+      </span>
+    );
+  }
   if (count === 0) return null;
   return (
     <span
+      data-focused-aggregate
       className="hidden shrink-0 px-3 text-center font-mono text-[11px] tabular-nums text-zinc-500 sm:block"
       title="Focused timeline total"
     >

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { memo, useCallback, useContext, useEffect, useRef, useState, useSyncExternalStore } from "react";
-import { FolderTree, Image as ImageIcon, Video } from "lucide-react";
+import { FolderTree } from "lucide-react";
 
 import {
   CollectionItem,
@@ -288,20 +288,18 @@ const GraphClipContent = memo(function GraphClipContent({
           ))}
         </span>
       )}
-      {/* Kind tag (R6 #7): a corner badge so video vs image reads at a glance,
-          at every item size. Decorative for AT (the card's own label names the
-          clip); the title gives a pointer tooltip. */}
+      {/* Kind tag (R6 #7): a WORD, bottom-left. The glyph version (a 4px film
+          or picture icon in the top corner) was ambiguous at small item sizes
+          — the two lucide marks read as the same smudge — so it says which it
+          is. Bottom-left pairs it with the duration pill on the right without
+          either covering the artwork's centre. Decorative for AT (the card's
+          own label names the clip). */}
       <span
         aria-hidden="true"
         data-media-kind={isVideo ? "video" : "image"}
-        title={isVideo ? "Video" : "Image"}
-        className="pointer-events-none absolute left-1 top-1 flex h-4 w-4 items-center justify-center rounded bg-zinc-950/75 text-zinc-100 ring-1 ring-white/15 backdrop-blur-[1px]"
+        className="pointer-events-none absolute bottom-1 left-1 z-10 rounded bg-black/75 px-1 py-0.5 font-mono text-[8px] leading-none font-semibold tracking-[0.08em] text-zinc-100"
       >
-        {isVideo ? (
-          <Video aria-hidden="true" className="h-2.5 w-2.5" />
-        ) : (
-          <ImageIcon aria-hidden="true" className="h-2.5 w-2.5" />
-        )}
+        {isVideo ? "VIDEO" : "IMAGE"}
       </span>
       {trimEnabled && <LiveDurationPill id={id} node={node} />}
       {/* Floating frame-at-the-edge panel during a trim drag (video only) —

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -14,12 +14,15 @@ import {
 import {
   MIN_ITEM_WIDTH,
   durationToWidth,
+  mediaDurationSeconds,
   useCollectionsSelector,
   useCollectionsStore,
   type CollectionsGraph,
+  type NodeId,
 } from "@storyboard/ui/dnd-collections";
 import {
   graphChildrenToClips,
+  hydratedCollectionDuration,
   manifestToClips,
   type DetailsById,
   type PlaybackManifest,
@@ -1410,6 +1413,58 @@ function useManifestClips(
   return state !== null && state.forId === focusedId
     ? { clips: state.clips, spans: state.spans }
     : null;
+}
+
+/**
+ * What the current selection adds up to — the numbers the board header shows
+ * in place of the focused-timeline total while anything is selected.
+ *
+ * Duration comes from the SAME model the cards and the playhead use: a media
+ * node's effective (trimmed) length, and for a collection the live hydrated
+ * total when its subtree is loaded, falling back to the stored summary for a
+ * placeholder — so a selected collection contributes what its card claims,
+ * not zero. Descendants of another selected node are skipped: selecting a
+ * collection and a clip inside it is one collection's worth of time, not
+ * that time counted twice.
+ */
+export function useSelectionAggregate(): Readonly<{ count: number; seconds: number }> {
+  const graph = useCollectionsSelector((snapshot) => snapshot.graph);
+  const selectedIds = useCollectionsSelector((snapshot) => snapshot.interaction.selectedIds);
+  const detailsStore = useGraphDetailsStore();
+  const details = useSyncExternalStore(
+    detailsStore.subscribe,
+    detailsStore.read,
+    detailsStore.read,
+  );
+
+  return useMemo(() => {
+    const picked = [...selectedIds].filter((id) => graph.nodesById.has(id));
+    // Drop anything already inside another selected node (the reducer prunes
+    // the same way on a multi-node move).
+    const selectedSet = new Set(picked);
+    const roots = picked.filter((id) => {
+      const seen = new Set<NodeId>();
+      let parent = graph.parentById.get(id) ?? null;
+      while (parent !== null && !seen.has(parent)) {
+        if (selectedSet.has(parent)) return false;
+        seen.add(parent);
+        parent = graph.parentById.get(parent) ?? null;
+      }
+      return true;
+    });
+    let total = 0;
+    for (const id of roots) {
+      const node = graph.nodesById.get(id);
+      if (!node) continue;
+      if (node.kind === "collection") {
+        const hydrated = hydratedCollectionDuration(graph, details, id);
+        total += hydrated > 0 ? hydrated : (details[id as string]?.duration ?? 0);
+      } else {
+        total += mediaDurationSeconds(node);
+      }
+    }
+    return { count: roots.length, seconds: total };
+  }, [graph, selectedIds, details]);
 }
 
 export function PreviewShell({


### PR DESCRIPTION
Punch-list items **1** and **9**.

### 1. Selected items summary

The header row's centre readout — the focused timeline's `5 clips · 1m 40s` — is replaced by `2 selected · 8.8s` while anything is selected, and returns when the selection clears. One slot, two answers: the selection is the more specific fact about the same timeline, so it takes the same pixels rather than opening a second readout the eye has to choose between.

`useSelectionAggregate` reads duration from the same model as the cards and the playhead: a media node's effective (trimmed) length, and for a collection the live hydrated total, falling back to the stored summary for an un-hydrated placeholder — so a selected collection contributes what its card claims, not zero. Descendants of another selected node are skipped, the way the reducer prunes a multi-node move, so selecting a collection *and* a clip inside it counts that time once.

### 9. IMAGE / VIDEO badges

The 4px lucide film/picture glyphs in the top-left corner read as the same smudge at small item sizes. They're now a word — `IMAGE` or `VIDEO` — in a small mono badge at the bottom-left, pairing with the duration pill on the right so neither covers the artwork's centre. `data-media-kind` is unchanged.

Verified live in the app, both states: the centre swaps on select and swaps back on Done.

App vitest 222/222 · graph-view e2e 52/52 · app `tsc` clean · lint clean (4 pre-existing `img` warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
