### PR TITLE
Drill-in is instant, and no longer tears down the preview pane

### DIFF
--- a/apps/timeline-gstudio001/app/timeline/[timelineId]/graph/[[...activeTimelinePath]]/page.tsx
+++ b/apps/timeline-gstudio001/app/timeline/[timelineId]/graph/[[...activeTimelinePath]]/page.tsx
@@ -15,10 +15,16 @@ import { loadFocusPathPayloads } from "@/lib/graph-rsc-payloads";
 
 async function FocusPathStream({
   path,
-  uid,
   focusedOnly,
-}: Readonly<{ path: readonly string[]; uid: string; focusedOnly: boolean }>) {
-  const payloads = await loadFocusPathPayloads(path, uid, { focusedOnly });
+}: Readonly<{ path: readonly string[]; focusedOnly: boolean }>) {
+  // Session lookup lives INSIDE the boundary with the document load. Awaited
+  // in the page body it would block the RSC response for this navigation —
+  // and the client is waiting on that response to commit the new pathname.
+  // Everything this component produces is a cache prime the client can also
+  // fetch itself, so all of it belongs behind Suspense.
+  const user = await getAuthUser();
+  if (!user) return null;
+  const payloads = await loadFocusPathPayloads(path, user.uid, { focusedOnly });
   if (payloads.length === 0) return null;
   return <GraphGatewayPrimer payloads={payloads} />;
 }
@@ -30,9 +36,6 @@ export default async function GraphViewPage({
 }) {
   const { activeTimelinePath = [] } = await params;
   if (activeTimelinePath.length === 0) return null;
-
-  const user = await getAuthUser();
-  if (!user) return null;
 
   // Soft navigations arrive as RSC flight requests (the `RSC` header): the
   // client already holds the ancestors from boot and earlier navigations,
@@ -52,7 +55,7 @@ export default async function GraphViewPage({
           CLIENT twin in graph-timeline-view.tsx does decode, correctly:
           `usePathname()` returns the raw encoded pathname. Different sources,
           different rules. */}
-      <FocusPathStream path={activeTimelinePath} uid={user.uid} focusedOnly={softNavigation} />
+      <FocusPathStream path={activeTimelinePath} focusedOnly={softNavigation} />
     </Suspense>
   );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
@@ -27,6 +27,7 @@ export function GraphViewNavProvider({
   projectId,
   focusedId,
   openNodeRef,
+  onNavigateStart,
   children,
 }: Readonly<{
   projectId: string;
@@ -38,6 +39,15 @@ export function GraphViewNavProvider({
    * ref is the seam that hands it the current focus logic.
    */
   openNodeRef?: MutableRefObject<(nodeId: NodeId) => void>;
+  /**
+   * The focus path this navigation is heading to, published BEFORE the
+   * router push. `router.push` doesn't commit the new pathname until the
+   * server answers that segment's RSC request, and the view derives its focus
+   * from the pathname — so without this the whole board waits on a round trip
+   * it needs nothing from. The consumer renders the pending path immediately
+   * and drops it when the URL catches up.
+   */
+  onNavigateStart?: (path: readonly string[]) => void;
   children: React.ReactNode;
 }>) {
   const router = useRouter();
@@ -53,6 +63,7 @@ export function GraphViewNavProvider({
 
         const base = `/timeline/${encodeURIComponent(projectId)}/graph`;
         if (timelineId === projectId) {
+          onNavigateStart?.([]);
           router.push(base);
           return;
         }
@@ -69,10 +80,14 @@ export function GraphViewNavProvider({
           parent = graph.parentById.get(parent) ?? null;
         }
         if (parent !== projectNodeId) return;
+        // The pending path is exactly what the URL will decode to (the push
+        // below encodes these same segments), so the optimistic render and
+        // the committed one can't disagree.
+        onNavigateStart?.(chain);
         router.push(`${base}/${chain.map(encodeURIComponent).join("/")}`);
       },
     }),
-    [detailsStore, focusedId, projectId, router, store],
+    [detailsStore, focusedId, onNavigateStart, projectId, router, store],
   );
 
   useEffect(() => {

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -1549,10 +1549,12 @@ export function PreviewShell({
       {/* Test/debug witness for which read model the pane is playing. */}
       <span data-preview-source={manifest !== null ? "manifest" : "projection"} hidden />
       <WorkbenchSplitPane
-        // Remount on drill so the player shows the newly-focused collection's
-        // first frame instead of holding the previous one. The chosen height
-        // survives — getInitialSurfaceHeight restores it from the ref at mount.
-        key={focusedId}
+        // NOT keyed by focusedId any more. That remount existed only to force
+        // the player off the previous collection's frame; the surface now
+        // repaints when its clip list changes, so a drill-in keeps the canvas,
+        // the decoded media cache and the chosen height instead of tearing the
+        // pane down and flashing black — the most visible part of "clicking
+        // into a collection updates the whole screen".
         clips={clips}
         currentTime={time}
         onCurrentTimeChange={handleTimeChange}

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -99,7 +99,7 @@ export function GraphTimelineView({
 }) {
   const pathname = usePathname();
   const base = `/timeline/${encodeURIComponent(projectId)}/graph`;
-  const timelinePath = useMemo(
+  const urlPath = useMemo(
     () =>
       pathname.startsWith(base)
         ? pathname
@@ -110,6 +110,31 @@ export function GraphTimelineView({
         : [],
     [pathname, base],
   );
+  // OPTIMISTIC FOCUS. A drill-in is `router.push`, and the App Router does not
+  // commit the new pathname until the server answers the RSC request for that
+  // segment — measured at ~270ms locally, which is exactly the "clicking into
+  // a collection takes a beat" complaint. Nothing about the focus change
+  // actually needs the server: the graph is already in memory, and the page
+  // segment only PRIMES documents the client can fetch itself. So the
+  // navigation callback publishes the path it is heading to, the view moves
+  // on the next frame, and the URL catches up behind it.
+  //
+  // The URL stays the source of truth: this clears whenever the real path
+  // changes (the push landing, Back/Forward, a deep link), and the two agree
+  // by construction because the pending value IS what was pushed.
+  const [pendingPath, setPendingPath] = useState<readonly string[] | null>(null);
+  // Dropped DURING the render that sees a new URL (the documented
+  // adjust-state-on-change pattern, as in the trash drawer) rather than in an
+  // effect: an effect would render the pending path once more before clearing
+  // it, and set-state-in-an-effect is a lint error here for exactly that
+  // cascade. `urlPath` is memoized on the pathname, so this compares
+  // identities and fires only on a real navigation.
+  const [urlPathSeen, setUrlPathSeen] = useState(urlPath);
+  if (urlPath !== urlPathSeen) {
+    setUrlPathSeen(urlPath);
+    setPendingPath(null);
+  }
+  const timelinePath = pendingPath ?? urlPath;
   const focusedId = timelinePath[timelinePath.length - 1] ?? projectId;
 
   const [boot, setBoot] = useState<BootState>({ status: "loading" });
@@ -484,6 +509,7 @@ export function GraphTimelineView({
             projectId={projectId}
             focusedId={focusedId}
             openNodeRef={openNodeRef}
+            onNavigateStart={setPendingPath}
           >
             {focusError !== null ? (
               <div className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-4 text-sm text-zinc-300">

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1393,6 +1393,50 @@ test.describe("graph view E2E", () => {
     await expect(redoButton(page)).toBeDisabled();
   });
 
+  test("drilling in doesn't wait for the server, and keeps the preview pane alive", async ({
+    page,
+  }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    await previewToggle(page).click();
+    await expect(page.locator('[data-testid="workbench-display-canvas"]')).toBeVisible();
+
+    // Tag the live canvas. A remounted pane mints a fresh one, so the tag
+    // surviving the drill IS the "no teardown" assertion.
+    await page.evaluate(() => {
+      document
+        .querySelector('[data-testid="workbench-display-canvas"]')
+        ?.setAttribute("data-alive", "1");
+    });
+
+    // Hold the App Router's RSC request for this navigation. The focus change
+    // needs nothing from it (the graph is in memory; the route only primes
+    // documents), so the board must move well before it answers.
+    await page.route("**/graph/**", async (route) => {
+      if (!route.request().url().includes("_rsc=")) return route.continue();
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await route.continue();
+    });
+
+    await page.getByRole("button", { name: "Open Scene A" }).first().click();
+    // Well inside the 2s the server response is held for.
+    await expect(page.getByText("Scene A", { exact: true }).first()).toBeVisible({
+      timeout: 900,
+    });
+    await expect(strip(page, PROJECT_ID)).toHaveCount(0, { timeout: 900 });
+
+    // Same canvas element as before the drill: no black flash, no re-decode,
+    // and the height the user chose survives.
+    await expect(page.locator('[data-testid="workbench-display-canvas"]')).toHaveAttribute(
+      "data-alive",
+      "1",
+    );
+    // The URL still lands once the held response arrives.
+    await expect
+      .poll(() => new URL(page.url()).pathname, { timeout: 8000 })
+      .toBe(`/timeline/${PROJECT_ID}/graph/${CHILD_ID}`);
+  });
+
   test("preview mode: capless playhead line, drag-to-scrub, no layout blowout", async ({
     page,
   }) => {

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -530,11 +530,19 @@ export function WorkbenchDisplaySurface({
     });
   }, [bufferedMedia, drawActiveFrame, ensureCachedMedia]);
 
+  // Repaint on a new CLIP LIST as well as a new time. `renderFrameAtTime`
+  // reads the clips through a ref (so playback doesn't re-create it every
+  // frame), which means a caller that swaps the whole list — the graph view
+  // drilling into another collection — left the canvas showing the previous
+  // list's frame whenever the time didn't also change (it resets to 0, and
+  // 0 → 0 is not a change). Consumers worked around that by remounting the
+  // pane, throwing away the canvas, the media cache and the chosen height.
+  // Depending on the sorted list makes the swap repaint itself.
   useEffect(() => {
     if (isPlayingRef.current) return;
     currentTimeRef.current = currentTime;
     renderFrameAtTime(currentTime, false, true);
-  }, [currentTime, renderFrameAtTime]);
+  }, [currentTime, renderFrameAtTime, sortedClips]);
 
   const seekToClip = useCallback(
     (direction: -1 | 1) => {


### PR DESCRIPTION
Punch-list items **10** (drill-in delay) and **8** (whole-screen update). Measured in the running app: click → breadcrumb **267ms before, 15–21ms after**.

### Why it was slow

The focused timeline is derived from `usePathname()`, and a drill-in is `router.push`. The App Router doesn't commit the new pathname until the server answers that segment's RSC request — so the whole board waited on a round trip it needs nothing from: the graph is already in memory, and the page segment only *primes* documents the client can fetch itself.

- `GraphViewNavProvider` now publishes the path it's navigating to (`onNavigateStart`) before pushing. The view renders it immediately and drops it when the URL catches up. The pending value **is** what was pushed, so optimistic and committed renders can't disagree, and Back/Forward/deep links still drive focus from the URL. Cleared during render (adjust-state-on-change), not in an effect — an effect renders the stale path one extra time, and set-state-in-an-effect is a lint error here for exactly that cascade.
- The page's `getAuthUser()` moved **inside** the Suspense boundary. Awaited in the page body it blocked the very RSC response the client was waiting on; everything that component produces is a cache prime, so all of it belongs behind the boundary.

### Why the whole screen flashed

`<WorkbenchSplitPane key={focusedId}>` remounted the player on every drill — new canvas, dropped media cache, re-measured height, a beat of black.

That key existed only because the surface would otherwise keep painting the previous collection's frame: it reads clips through a **ref**, so a new list alone never triggered a repaint (time resets to 0, and 0 → 0 is not a change). The paint effect now depends on the sorted clips, so the swap repaints itself — and the key is gone. The pane, its decoded media, and the user's chosen height all survive a drill.

### Pin

`drilling in doesn't wait for the server, and keeps the preview pane alive` holds the RSC response for 2s and asserts the board moves inside 900ms, plus a tag on the canvas element that only survives if the pane was never remounted. Both halves proven fail-first — optimistic path off → breadcrumb assertion fails; key restored → canvas tag fails.

App vitest 222/222 · graph-view e2e 53/53 · WorkbenchSplitPane story 1/1 · ui + app `tsc` clean · lint clean (4 pre-existing `img` warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
