### PR TITLE
Drop lands where you dropped it; the collection ghost can't blank mid-drag

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -427,12 +427,24 @@ const GraphGhost = memo(function GraphGhost({ node, extraCount }: CollectionGhos
   // FIRST and LAST only (or the single frame) — never three, exactly as the
   // card picks its two representative frames.
   const chosen = all.length > 1 ? [all[0], all[all.length - 1]] : all;
-  const frames: string[] = isCollection
+  const derivedFrames: string[] = isCollection
     ? chosen.map((preview) => preview.poster ?? preview.src).filter(Boolean)
     : (() => {
         const src = mediaGhostSrc(node);
         return src ? [src] : [];
       })();
+  // STICKY for the life of the ghost. A collection's frames are derived from
+  // the LIVE graph plus the details table, and both move under us mid-drag:
+  // dragging over an un-hydrated collection hydrates it, which re-runs this
+  // derivation. Any moment where it yields fewer frames (or none) swapped the
+  // thumbnail for the grey fallback tile and back — the flicker into a
+  // "disabled-looking" ghost. The ghost is a transient, read-only picture of
+  // what is being dragged, so it may only ever GAIN detail, never lose it.
+  // (State adjusted during render, not a ref: reading or writing a ref while
+  // rendering is a lint error here, and this is the documented pattern.)
+  const [bestFrames, setBestFrames] = useState(derivedFrames);
+  if (derivedFrames.length > bestFrames.length) setBestFrames(derivedFrames);
+  const frames = derivedFrames.length >= bestFrames.length ? derivedFrames : bestFrames;
 
   return (
     // Slightly transparent so the breadcrumb drop zones read THROUGH the ghost

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1393,6 +1393,70 @@ test.describe("graph view E2E", () => {
     await expect(redoButton(page)).toBeDisabled();
   });
 
+  test("a dropped card animates out of the ghost, not back to where it started", async ({
+    page,
+  }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    const projectStrip = strip(page, PROJECT_ID);
+    const alpha = projectStrip.locator('[data-node-id="alpha"]');
+    const charlie = projectStrip.locator('[data-node-id="charlie"]');
+    await settleMoveAnimations(page);
+
+    // Record every Web Animation started during the drop instead of racing a
+    // 180ms window with getAnimations().
+    await page.evaluate(() => {
+      const recorded: { duration: unknown; transforms: string[] }[] = [];
+      (window as unknown as { __drops: typeof recorded }).__drops = recorded;
+      const original = Element.prototype.animate;
+      Element.prototype.animate = function (keyframes, options) {
+        const frames = Array.isArray(keyframes) ? keyframes : [];
+        recorded.push({
+          duration:
+            typeof options === "number" ? options : (options as KeyframeAnimationOptions)?.duration,
+          transforms: frames
+            .map((frame) => (frame as Keyframe)?.transform)
+            .filter((value): value is string => typeof value === "string"),
+        });
+        return original.call(this, keyframes, options);
+      };
+    });
+
+    const from = (await alpha.boundingBox())!;
+    const to = (await charlie.boundingBox())!;
+    await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2);
+    await page.mouse.down();
+    await page.waitForTimeout(400);
+    await page.mouse.move(to.x + to.width * 0.8, to.y + to.height / 2, { steps: 12 });
+    await page.waitForTimeout(150);
+    await page.mouse.up();
+    await page.waitForTimeout(120);
+
+    const drops = await page.evaluate(
+      () => (window as unknown as { __drops: { duration: unknown; transforms: string[] }[] }).__drops,
+    );
+    const moves = drops.filter((entry) => entry.transforms.some((t) => t.includes("translate")));
+    expect(moves.length).toBeGreaterThan(0);
+
+    // dnd-kit's default drop animation (250ms) would fly the ghost BACK to
+    // the drag's origin while the card FLIPs forward — two motions crossing.
+    // It is switched off, so nothing runs at that duration.
+    expect(moves.some((entry) => entry.duration === 250)).toBe(false);
+
+    // The dropped card starts from the ghost's box: a fractional scale (the
+    // ghost is 72px wide, the card is not). Displaced siblings animate at
+    // scale(1, 1), so this is exactly the dropped card's signature.
+    const grewFromGhost = moves.some((entry) =>
+      entry.transforms.some((t) => /scale\(0?\.\d+/.test(t)),
+    );
+    expect(grewFromGhost).toBe(true);
+
+    // And the move itself still committed.
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID))
+      .toEqual(["bravo", CHILD_ID, "charlie", "alpha"]);
+  });
+
   test("drilling in doesn't wait for the server, and keeps the preview pane alive", async ({
     page,
   }) => {

--- a/packages/ui/dnd-collections/react/DndCollections.tsx
+++ b/packages/ui/dnd-collections/react/DndCollections.tsx
@@ -8,6 +8,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type MutableRefObject,
   type ReactNode,
   type RefObject,
 } from "react";
@@ -61,7 +62,10 @@ import {
   type CollectionsClickSelection,
 } from "./interaction-policy";
 import { LiveTrimChannelContext, useCreateLiveTrimChannel } from "./live-trim";
-import { useFlipGraphAnimation } from "./use-flip-graph-animation";
+import {
+  useFlipGraphAnimation,
+  type FlipDropOrigin,
+} from "./use-flip-graph-animation";
 import { NodeCardGhost } from "./node-views";
 import { CollectionsPointerSensor } from "./pointer-sensors";
 import { LiveAnnouncementRegion, useAnnounceChannel } from "./use-announcements";
@@ -330,8 +334,14 @@ export function DndCollections({
 // A dedicated child so its graph subscription re-renders ONLY this null
 // component per commit, never the provider subtree (which would re-render
 // every view and defeat the efficiency model).
-function FlipAnimator({ containerRef }: { containerRef: RefObject<HTMLElement | null> }) {
-  useFlipGraphAnimation(containerRef);
+function FlipAnimator({
+  containerRef,
+  dropOriginRef,
+}: {
+  containerRef: RefObject<HTMLElement | null>;
+  dropOriginRef: RefObject<FlipDropOrigin | null>;
+}) {
+  useFlipGraphAnimation(containerRef, dropOriginRef);
   return null;
 }
 
@@ -376,6 +386,11 @@ function DndCollectionsContext({
   const palette = usePaletteDrag({ store, intentRef, announce, onDiscard: onPaletteDiscard });
 
   const containerRef = useRef<HTMLDivElement>(null);
+  // The live drag ghost element, and the box it occupied at the moment of a
+  // drop — the FLIP sweep animates the dropped card out of that box instead
+  // of out of the slot it used to sit in (see FlipDropOrigin).
+  const ghostRef = useRef<HTMLElement | null>(null);
+  const dropOriginRef = useRef<FlipDropOrigin | null>(null);
   // A mounted <TrashTarget> registers its collection id here (see
   // container-context) so Alt+Delete can move the focused card to trash.
   const trashRef = useRef<NodeId | null>(null);
@@ -618,6 +633,24 @@ function DndCollectionsContext({
         return;
       }
 
+      // Measure the ghost BEFORE the commit — dispatching unmounts the
+      // overlay, and this box is where the dropped card's motion should
+      // start. Only the primary dragged node gets it; the rest of a
+      // multi-select FLIPs from their own previous slots.
+      const ghostBox = ghostRef.current?.getBoundingClientRect() ?? null;
+      dropOriginRef.current =
+        ghostBox && ghostBox.width > 0 && ghostBox.height > 0
+          ? {
+              nodeId: activeIds[0] as string,
+              box: {
+                x: ghostBox.left,
+                y: ghostBox.top,
+                width: ghostBox.width,
+                height: ghostBox.height,
+              },
+            }
+          : null;
+
       const dispatched = store.dispatch(commandResult.value);
       store.endDrag();
 
@@ -685,7 +718,9 @@ function DndCollectionsContext({
         </div>
       </CollectionsContainerContext.Provider>
       {/* Instance-wide FLIP sweep (opt out with animateMoves={false}). */}
-      {animateMoves && <FlipAnimator containerRef={containerRef} />}
+      {animateMoves && (
+        <FlipAnimator containerRef={containerRef} dropOriginRef={dropOriginRef} />
+      )}
       {/* The single keyboard-usage description, referenced by cards via
           aria-describedby (dnd-kit's own instructions are blanked above). It
           must match the real grammar EXACTLY — every chord here is verified
@@ -716,6 +751,7 @@ function DndCollectionsContext({
         ghostScale={dragGhostScale}
         ghostWidth={dragGhostWidth ?? null}
         ghostHeight={dragGhostHeight ?? null}
+        ghostRef={ghostRef}
       />
       <LiveAnnouncementRegion channel={announceChannel} />
     </DndContext>
@@ -727,11 +763,14 @@ function CollectionsDragOverlay({
   ghostScale,
   ghostWidth,
   ghostHeight,
+  ghostRef,
 }: {
   paletteNodes: readonly CollectionItemNode[] | null;
   ghostScale: number;
   ghostWidth: number | null;
   ghostHeight: number | null;
+  /** Receives the ghost's outer element, so a drop can measure where it was. */
+  ghostRef: MutableRefObject<HTMLElement | null>;
 }) {
   const activeIds = useCollectionsSelector((s) => s.interaction.activeIds);
   const primaryId = activeIds[0] ?? null;
@@ -750,16 +789,30 @@ function CollectionsDragOverlay({
   // remedy for the "long clip → giant ghost" problem, so honour it first.
   const wrapped =
     ghostWidth !== null ? (
-      <FixedWidthGhost width={ghostWidth} height={ghostHeight}>
+      <FixedWidthGhost width={ghostWidth} height={ghostHeight} elementRef={ghostRef}>
         {ghost}
       </FixedWidthGhost>
     ) : ghostScale < 1 ? (
-      <ScaledGhost scale={ghostScale}>{ghost}</ScaledGhost>
+      <ScaledGhost scale={ghostScale} elementRef={ghostRef}>
+        {ghost}
+      </ScaledGhost>
     ) : (
-      ghost
+      // Unwrapped, the ghost is consumer pixels with no element of ours to
+      // measure — a plain box that fills dnd-kit's overlay (which is sized to
+      // the source card) gives the drop the same handle in every variant.
+      <div ref={ghostRef as MutableRefObject<HTMLDivElement | null>} className="h-full w-full">
+        {ghost}
+      </div>
     );
 
-  return <DragOverlay>{wrapped}</DragOverlay>;
+  // `dropAnimation={null}`: dnd-kit's default flies the overlay from the
+  // release point BACK to where the drag started (250ms, translate3d), which
+  // on a successful drop is the wrong direction entirely — the user watched
+  // the ghost travel to a new slot, and it then retreated to the old one
+  // while the real card FLIPped forward past it. The two motions crossed.
+  // The ghost now simply hands off: it disappears at release and the dropped
+  // card animates out of the box it left behind (see FlipDropOrigin).
+  return <DragOverlay dropAnimation={null}>{wrapped}</DragOverlay>;
 }
 
 /**
@@ -773,7 +826,15 @@ function CollectionsDragOverlay({
  * the shrink a motion, not a snap; reduced-motion users get the end state
  * with no animation.
  */
-function ScaledGhost({ scale, children }: { scale: number; children: ReactNode }) {
+function ScaledGhost({
+  scale,
+  elementRef,
+  children,
+}: {
+  scale: number;
+  elementRef: MutableRefObject<HTMLElement | null>;
+  children: ReactNode;
+}) {
   const { activatorEvent, activeNodeRect } = useDndContext();
   const [engaged, setEngaged] = useState(false);
 
@@ -793,6 +854,7 @@ function ScaledGhost({ scale, children }: { scale: number; children: ReactNode }
 
   return (
     <div
+      ref={elementRef as MutableRefObject<HTMLDivElement | null>}
       data-drag-ghost-scale={scale}
       style={{
         transformOrigin: origin,
@@ -822,10 +884,12 @@ function ScaledGhost({ scale, children }: { scale: number; children: ReactNode }
 function FixedWidthGhost({
   width,
   height,
+  elementRef,
   children,
 }: {
   width: number;
   height: number | null;
+  elementRef: MutableRefObject<HTMLElement | null>;
   children: ReactNode;
 }) {
   const { activatorEvent, activeNodeRect } = useDndContext();
@@ -855,6 +919,7 @@ function FixedWidthGhost({
 
   return (
     <div
+      ref={elementRef as MutableRefObject<HTMLDivElement | null>}
       data-drag-ghost-width={width}
       data-drag-ghost-height={height ?? undefined}
       style={{

--- a/packages/ui/dnd-collections/react/use-flip-graph-animation.ts
+++ b/packages/ui/dnd-collections/react/use-flip-graph-animation.ts
@@ -11,7 +11,20 @@ const FLIP_DURATION_MS = 180;
 const FLIP_EASING = "cubic-bezier(0.2, 0, 0, 1)";
 
 type Point = Readonly<{ x: number; y: number }>;
-type CardRect = Readonly<{ card: HTMLElement; nodeId: string; point: Point }>;
+type Box = Readonly<{ x: number; y: number; width: number; height: number }>;
+type CardRect = Readonly<{ card: HTMLElement; nodeId: string; point: Point; box: Box }>;
+
+/**
+ * Where the dragged card should APPEAR to come from on a drop: the box the
+ * drag ghost occupied at release. Published by the provider's drag-end
+ * handler (see DndCollections) and consumed by the next sweep.
+ *
+ * Without it the dropped card FLIPs from the slot it used to occupy — so the
+ * motion starts wherever the item WAS, often most of the board away from the
+ * pointer, while the ghost the user was watching vanishes on the spot. The
+ * eye follows the ghost; the animation should continue from there.
+ */
+export type FlipDropOrigin = Readonly<{ nodeId: string; box: Box }>;
 
 function measureCards(container: HTMLElement): CardRect[] {
   const rects: CardRect[] = [];
@@ -28,7 +41,12 @@ function measureCards(container: HTMLElement): CardRect[] {
     // itself, preserving the documented contract.
     const card = idElement.closest<HTMLElement>("[data-node-wrapper]") ?? idElement;
     const rect = card.getBoundingClientRect();
-    rects.push({ card, nodeId, point: { x: rect.left, y: rect.top } });
+    rects.push({
+      card,
+      nodeId,
+      point: { x: rect.left, y: rect.top },
+      box: { x: rect.left, y: rect.top, width: rect.width, height: rect.height },
+    });
   }
   return rects;
 }
@@ -83,7 +101,12 @@ function cancelAnimations(animations: Set<Animation>): void {
   animations.clear();
 }
 
-export function useFlipGraphAnimation(containerRef: RefObject<HTMLElement | null>): void {
+export function useFlipGraphAnimation(
+  containerRef: RefObject<HTMLElement | null>,
+  /** Set by the drop that is about to commit; read (and cleared) by the sweep
+   *  it triggers, so it can only ever affect that one commit. */
+  dropOriginRef?: RefObject<FlipDropOrigin | null>,
+): void {
   const store = useCollectionsStore();
   const graph = useCollectionsSelector((state) => state.graph);
   const firstRects = useRef<readonly CardRect[] | null>(null);
@@ -124,18 +147,34 @@ export function useFlipGraphAnimation(containerRef: RefObject<HTMLElement | null
       window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
     if (reduceMotion) return;
 
+    const dropOrigin = dropOriginRef?.current ?? null;
+    if (dropOriginRef) dropOriginRef.current = null;
+
     const after = measureCards(container);
     const matches = matchBeforeRects(first, after);
-    for (const { card, point } of after) {
-      const before = matches.get(card);
+    for (const { card, nodeId, point, box } of after) {
+      // The DROPPED card starts from the ghost the user just released — same
+      // place their eye already is — scaling up from the ghost's footprint
+      // into the slot. Every other card keeps the plain positional FLIP from
+      // where it used to sit.
+      const isDropped = dropOrigin !== null && dropOrigin.nodeId === nodeId;
+      const before = isDropped ? dropOrigin.box : matches.get(card);
       if (!before) continue;
 
       const dx = before.x - point.x;
       const dy = before.y - point.y;
-      if (dx === 0 && dy === 0) continue;
+      const sx = isDropped && box.width > 0 ? dropOrigin.box.width / box.width : 1;
+      const sy = isDropped && box.height > 0 ? dropOrigin.box.height / box.height : 1;
+      if (dx === 0 && dy === 0 && sx === 1 && sy === 1) continue;
 
       const animation = card.animate(
-        [{ transform: `translate(${dx}px, ${dy}px)` }, { transform: "translate(0, 0)" }],
+        [
+          {
+            transformOrigin: "top left",
+            transform: `translate(${dx}px, ${dy}px) scale(${sx}, ${sy})`,
+          },
+          { transformOrigin: "top left", transform: "translate(0, 0) scale(1, 1)" },
+        ],
         { duration: FLIP_DURATION_MS, easing: FLIP_EASING, composite: "replace" }
       );
       animationsRef.current.add(animation);


### PR DESCRIPTION
Punch-list items **5** (drop animation) and **3** (ghost flicker).

### 5. The drop animation was two motions crossing

Recording `element.animate` calls in the running app showed it plainly: dnd-kit's default `DragOverlay` drop animation flew the ghost from the release point **back to where the drag started** (250ms, `translate3d`), while the FLIP sweep slid the real card **forward** from its old slot into its new one. The eye follows the ghost, so the item appeared to retreat and then something else arrived somewhere else.

- `dropAnimation={null}` — the ghost simply hands off instead of retreating.
- The FLIP now animates the **dropped** card out of the box the ghost occupied at release (`FlipDropOrigin`, measured in the drag-end handler before the dispatch unmounts the overlay), scaling up from that footprint into its slot. Displaced siblings are untouched — they still FLIP from their own previous positions.

One motion, continuing from where the user was already looking.

### 3. The ghost could blank mid-drag

A collection's ghost frames come from the live graph plus the details table, and both move under it during a drag — dragging over an un-hydrated collection hydrates it, re-running that derivation. Any pass yielding fewer frames swapped the thumbnail for the grey fallback tile and back: a flicker into something that reads as disabled. The ghost is a transient, read-only picture of what's being dragged, so it may now only ever *gain* detail, never lose it.

**Honest caveat:** I could not reproduce the flicker with synthetic pointer events — the ghost held two loaded frames across 24 samples, at constant opacity, with no rejected state and no cursor change. So this is the structural fix for the whole class rather than a confirmed single cause: after it, no mid-drag recompute can empty the ghost. If you still see it, the next suspect is the OS cursor rather than the ghost's pixels, and I'd want to know whether the flicker is the *thumbnail* changing or a "no entry" badge appearing.

### Pin

`a dropped card animates out of the ghost, not back to where it started` records every `element.animate` call across a real drag-drop and asserts (a) nothing runs at dnd-kit's 250ms and (b) the dropped card's keyframes carry a fractional scale — the ghost-origin signature, since siblings animate at `scale(1, 1)`. Both halves proven fail-first.

Storybook 344/344 · unit 517/517 · app vitest 222/222 · graph-view e2e 54/54 · ui + app `tsc` clean · lint clean (4 pre-existing `img` warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
