### PR TITLE
The preview opens at its height instead of animating into it

### DIFF
--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1393,6 +1393,40 @@ test.describe("graph view E2E", () => {
     await expect(redoButton(page)).toBeDisabled();
   });
 
+  test("the preview OPENS at its height instead of animating into it", async ({ page }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+
+    // Listen before the toggle: the mount-time sizing pass measures the real
+    // height a frame or two after the placeholder one paints, so a height
+    // transition armed at mount plays as a visible shrink — every first open,
+    // and only the first (a reopen restores the remembered height).
+    await page.evaluate(() => {
+      const runs: string[] = [];
+      (window as unknown as { __heightRuns: string[] }).__heightRuns = runs;
+      document.addEventListener(
+        "transitionrun",
+        (event) => {
+          if ((event as TransitionEvent).propertyName === "height") runs.push("height");
+        },
+        true,
+      );
+    });
+
+    await previewToggle(page).click();
+    await expect(page.locator('[data-testid="workbench-display-canvas"]')).toBeVisible();
+    await page.waitForTimeout(500);
+
+    const runs = await page.evaluate(
+      () => (window as unknown as { __heightRuns: string[] }).__heightRuns,
+    );
+    expect(runs).toEqual([]);
+
+    // The transition is still armed afterwards, for a viewport clamp.
+    const pane = page.locator('[data-testid="workbench-preview-region"] > div').first();
+    await expect(pane).toHaveClass(/transition-\[height\]/);
+  });
+
   test("a dropped card animates out of the ghost, not back to where it started", async ({
     page,
   }) => {

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -769,6 +769,10 @@ export function WorkbenchSplitPane({
     () => restoredSurfaceHeight ?? DEFAULT_SURFACE_HEIGHT,
   );
   const [isDividerDragging, setIsDividerDragging] = useState(false);
+  // False until the opening height has been measured AND painted (see the
+  // double-rAF below), so the pane appears at its size instead of animating
+  // into it.
+  const [heightAnimated, setHeightAnimated] = useState(false);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const dividerRef = useRef<HTMLButtonElement | null>(null);
   const lowerPaneRef = useRef<HTMLDivElement | null>(null);
@@ -871,6 +875,24 @@ export function WorkbenchSplitPane({
     });
   }, [clampToViewport]);
 
+  // Arm the height transition only once the opening size has been painted.
+  // The sizing pass below runs in a layout effect and its inputs (the
+  // divider's box, the viewport boundary, the asset-drawer variable) settle
+  // over the first frames, so the height can land a frame or two after the
+  // first paint — late enough for the browser to have a before-change style
+  // and animate the difference. Two frames is "after the next paint" without
+  // guessing at a duration.
+  useEffect(() => {
+    let second = 0;
+    const first = requestAnimationFrame(() => {
+      second = requestAnimationFrame(() => setHeightAnimated(true));
+    });
+    return () => {
+      cancelAnimationFrame(first);
+      cancelAnimationFrame(second);
+    };
+  }, []);
+
   useLayoutEffect(() => {
     // Size ONCE on mount. After that the height belongs to the user: only a
     // divider drag changes it, and a shrinking viewport may clamp it.
@@ -972,7 +994,14 @@ export function WorkbenchSplitPane({
         <div
           className={cn(
             "min-h-0",
-            !isDividerDragging &&
+            // The transition is for LATER height changes (a shrinking
+            // viewport clamping the pane). It must not run against the
+            // mount-time sizing pass, which starts from a placeholder height
+            // and measures the real one — that played as a visible shrink
+            // every first open, and only the first, since a reopen restores
+            // the remembered height and never re-measures.
+            heightAnimated &&
+              !isDividerDragging &&
               "transition-[height] duration-[260ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none",
           )}
           style={{


### PR DESCRIPTION
Punch-list item **2**. Reproduced in the running app: opening the preview animated the pane **380px → 282px over ~270ms** — a `transitionrun` on `height`, sampled at 380 → 346 → 308 → 299 → … → 282. Only ever on the *first* open, which is what made it read as a glitch rather than a design.

### What met at mount

The pane starts at a placeholder `DEFAULT_SURFACE_HEIGHT`, and a layout-effect sizing pass then measures the real opening height (a third of the visible viewport) — while the wrapper carries a 260ms `transition-[height]` from its very first render. The measured inputs (the divider's box, the viewport boundary, the asset-drawer variable) settle over the first frames, so the height lands late enough for the browser to have a before-change style and animate the difference.

A **reopen** restores the remembered height and never re-measures, which is why it never animated again.

### Fix

The transition is armed only once the opening height has been painted (double rAF — "after the next paint", no guessed duration). It still covers what it was there for: a shrinking viewport clamping the pane.

### Pin

`the preview OPENS at its height instead of animating into it` listens for `transitionrun` on `height` across the toggle and asserts none fired, then asserts the transition **is** armed afterwards. Proven fail-first — arming at mount again fires three.

graph-view e2e 55/55 · app vitest 222/222 · WorkbenchSplitPane story 1/1 · ui `tsc` clean · lint clean (4 pre-existing `img` warnings). One unrelated load-dependent flake appeared on a parallel run (`grid is the bare-URL default`) and was green in isolation and on the full re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
