### PR TITLE
The asset panel no longer hides content the page can't scroll to

### DIFF
--- a/apps/timeline-gstudio001/components/assets/asset-library-drawer.tsx
+++ b/apps/timeline-gstudio001/components/assets/asset-library-drawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useLayoutEffect, useRef, useState, Fragment } from "react";
+import { useCallback, useEffect, useRef, useState, Fragment } from "react";
 import { createPortal } from "react-dom";
 import {
   AlertCircle,
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 
 import { Button } from "@/components/core/button";
+import { useBottomDrawerInset } from "@/components/assets/use-bottom-drawer-inset";
 import { SmoothScrollList } from "@/components/timeline/smooth-scroll-list";
 import { cn } from "@/lib/utils";
 import type { TimelineClip } from "@storyboard/ui/timeline/types";
@@ -148,35 +149,9 @@ export function AssetLibraryDrawer({ isOpen, onClose }: AssetLibraryDrawerProps)
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [isOpen, onClose]);
 
-  useLayoutEffect(() => {
-    const root = document.documentElement;
-
-    if (!isOpen) {
-      root.style.setProperty("--asset-library-height", "0px");
-      return;
-    }
-
-    const panel = panelRef.current;
-    if (!panel) return;
-
-    const publishHeight = () => {
-      root.style.setProperty(
-        "--asset-library-height",
-        `${panel.getBoundingClientRect().height}px`,
-      );
-    };
-
-    publishHeight();
-    const observer = new ResizeObserver(publishHeight);
-    observer.observe(panel);
-    window.addEventListener("resize", publishHeight);
-
-    return () => {
-      observer.disconnect();
-      window.removeEventListener("resize", publishHeight);
-      root.style.setProperty("--asset-library-height", "0px");
-    };
-  }, [isOpen]);
+  // Keeps the page scrollable past this drawer (shared with the graph's asset
+  // palette — see use-bottom-drawer-inset).
+  useBottomDrawerInset(panelRef, isOpen);
 
   if (!isOpen || typeof document === "undefined") return null;
 

--- a/apps/timeline-gstudio001/components/assets/use-bottom-drawer-inset.ts
+++ b/apps/timeline-gstudio001/components/assets/use-bottom-drawer-inset.ts
@@ -1,0 +1,61 @@
+"use client";
+
+import { useLayoutEffect, type RefObject } from "react";
+
+/**
+ * The page's bottom inset, in px, owned by whichever bottom drawer is open.
+ * `app/layout.tsx` pads `<main>` by it, and the workbench preview subtracts it
+ * from the visible viewport when sizing itself.
+ */
+const BOTTOM_INSET_VARIABLE = "--asset-library-height";
+
+/**
+ * Publish an open bottom drawer's height as the page's bottom inset.
+ *
+ * A drawer that is `position: fixed` at the bottom covers page content, and
+ * nothing scrolls it out from under: the page's scroll range ends where its
+ * content ends, so the last rows of a board simply cannot be brought into
+ * view. Padding `<main>` by the drawer's live height extends that range by
+ * exactly the covered amount.
+ *
+ * Shared by every bottom drawer rather than re-implemented per drawer — the
+ * asset library had this and the graph's asset palette did not, which is
+ * precisely how the graph board ended up with unreachable content. The height
+ * is observed, not assumed, so a drawer that grows (content, a resize, a
+ * wrapped toolbar) keeps the inset honest, and unmounting or closing restores
+ * it to zero.
+ */
+export function useBottomDrawerInset(
+  panelRef: RefObject<HTMLElement | null>,
+  open: boolean,
+): void {
+  useLayoutEffect(() => {
+    const root = document.documentElement;
+
+    if (!open) {
+      root.style.setProperty(BOTTOM_INSET_VARIABLE, "0px");
+      return;
+    }
+
+    const panel = panelRef.current;
+    if (!panel) return;
+
+    const publishHeight = () => {
+      root.style.setProperty(
+        BOTTOM_INSET_VARIABLE,
+        `${panel.getBoundingClientRect().height}px`,
+      );
+    };
+
+    publishHeight();
+    const observer = new ResizeObserver(publishHeight);
+    observer.observe(panel);
+    window.addEventListener("resize", publishHeight);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", publishHeight);
+      root.style.setProperty(BOTTOM_INSET_VARIABLE, "0px");
+    };
+  }, [open, panelRef]);
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-asset-palette.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-asset-palette.tsx
@@ -12,6 +12,7 @@ import {
 } from "@storyboard/ui/dnd-collections";
 
 import { Button } from "@/components/core/button";
+import { useBottomDrawerInset } from "@/components/assets/use-bottom-drawer-inset";
 import type { CloudinaryAsset } from "@/lib/cloudinary-media-store";
 
 import { clearPendingDetails, parkPendingDetail } from "./graph-pending-details";
@@ -123,6 +124,14 @@ export function AssetPaletteDrawer({
   onClose: () => void;
 }>) {
   const [state, setState] = useState<AssetPaletteState>({ status: "loading" });
+  const panelRef = useRef<HTMLElement | null>(null);
+  // This panel is FIXED to the bottom of the viewport and non-modal — the
+  // board behind it stays live, and you drag out of it onto that board. So
+  // the page has to be able to scroll its own content clear of it; without
+  // this, the last row of cards sat under the panel with no scroll left to
+  // reach them. Publishing the height also lets the preview pane size itself
+  // against the viewport that is actually visible.
+  useBottomDrawerInset(panelRef, open);
 
   const handleClose = () => {
     if (state.status === "error") setState({ status: "loading" });
@@ -171,6 +180,7 @@ export function AssetPaletteDrawer({
       className="pointer-events-none fixed inset-x-0 bottom-0 z-40"
     >
       <aside
+        ref={panelRef}
         role="dialog"
         aria-modal="false"
         aria-label="Asset palette"

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1034,6 +1034,61 @@ test.describe("graph view E2E", () => {
       .toEqual(["alpha", "bravo", "clip-scene", "charlie"]);
   });
 
+  test("the asset palette leaves the page scrollable clear of itself", async ({ page }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    // Short viewport + the children tree = a page taller than the screen, so
+    // the bottom is only reachable by scrolling.
+    await page.setViewportSize({ width: 1280, height: 520 });
+    await expandSubGraph(page, "Scene A");
+
+    await assetsButton(page).click();
+    const drawer = page.getByRole("dialog", { name: "Asset palette" });
+    await expect(drawer).toBeVisible();
+
+    // The panel is fixed to the bottom of the viewport, so the page must gain
+    // exactly its height as scrollable room — otherwise the last content sits
+    // under it with no scroll left to reach it.
+    await expect
+      .poll(async () => {
+        const [pad, panelHeight] = await Promise.all([
+          page.evaluate(
+            () => parseFloat(getComputedStyle(document.querySelector("main")!).paddingBottom) || 0,
+          ),
+          drawer.evaluate((el) => el.getBoundingClientRect().height),
+        ]);
+        return panelHeight > 0 && Math.abs(pad - panelHeight) < 1;
+      })
+      .toBe(true);
+
+    // And it really is reachable: scrolled to the end, the last card clears
+    // the panel's top edge.
+    await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight));
+    await expect
+      .poll(async () =>
+        page.evaluate(() => {
+          const cards = document.querySelectorAll("[data-node-id]");
+          const last = cards[cards.length - 1]?.getBoundingClientRect();
+          const panelTop = document
+            .querySelector('aside[aria-label="Asset palette"]')!
+            .getBoundingClientRect().top;
+          return last !== undefined && last.bottom <= panelTop + 1;
+        }),
+      )
+      .toBe(true);
+
+    // Closing gives the room back.
+    await assetsButton(page).click();
+    await expect(drawer).toHaveCount(0);
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => parseFloat(getComputedStyle(document.querySelector("main")!).paddingBottom) || 0,
+        ),
+      )
+      .toBe(0);
+  });
+
   test("palette drag mints a fresh node from an asset and persists it", async ({ page }) => {
     const api = await installGraphApi(page);
     await openGraph(page);


### PR DESCRIPTION
Punch-list item **7**. The graph's asset palette is `position: fixed` at the bottom and non-modal — the board behind it stays live, and you drag out of it onto that board. But the page's scroll range ends where its content ends, so the rows under the panel had no scroll left to reach them.

The legacy asset library already solved this: it publishes its live height as `--asset-library-height`, and `<main>` pads its bottom by that. The graph's palette — a second, later drawer — never did.

That mechanism is now a shared hook (`useBottomDrawerInset`) rather than a per-drawer effect, and both drawers use it, so the next bottom drawer can't quietly ship without it.

### Measured in the running app

With the children tree open (page 1063px, viewport 871px): opening the palette pads `main` by its live height — 161px, then 180px as the thumbnails loaded, since the `ResizeObserver` keeps it honest — scrolling to the end brings the last sub-timeline row fully clear of the panel, and closing returns the inset to 0.

**Knock-on, free:** the preview pane already subtracts this variable from the visible viewport when sizing itself, so it now sizes correctly with the palette open too.

### Pin

`the asset palette leaves the page scrollable clear of itself` — short viewport plus an expanded sub-graph; asserts `main`'s bottom padding tracks the panel height, that the last card clears the panel's top once scrolled, and that closing gives the room back. Proven fail-first.

graph-view e2e 56/56 · app vitest 222/222 · app `tsc` clean · lint clean (4 pre-existing `img` warnings). One parallel run flaked on two unrelated tests (the known load-dependent pair); both green in isolation and on the re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
