### PR TITLE
Restore from trash — and make the drawer's controls clickable at all

### DIFF
--- a/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
+++ b/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
@@ -4,14 +4,22 @@ import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
 import { createPortal } from "react-dom";
 import {
   Trash2,
+  Undo2,
   X,
   Loader2,
   AlertCircle,
 } from "lucide-react";
+import { usePathname } from "next/navigation";
 
 import { Button } from "@/components/core/button";
 import { useAuth } from "@/components/auth/auth-provider";
-import { announceGraphTrashEmptied } from "@/lib/graph-view-events";
+import {
+  GRAPH_RESTORE_RESULT_EVENT,
+  announceGraphTrashEmptied,
+  isGraphViewRoute,
+  requestGraphRestoreItem,
+  type GraphRestoreResultDetail,
+} from "@/lib/graph-view-events";
 import type { TimelineClip } from "@storyboard/ui/timeline/types";
 
 type TrashDrawerProps = {
@@ -85,6 +93,48 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
     };
   }, [isOpen, user, requestTrashClips]);
 
+  // RESTORE puts an item back into the timeline the user is looking at — which
+  // is also how they choose the destination: navigate there, then restore. The
+  // move itself is a graph command, and the graph lives in the route tree, so
+  // the drawer asks across the window-event seam and waits for the answer
+  // before dropping the row. Off-graph there is no graph to restore INTO, so
+  // the control isn't offered at all rather than failing on click.
+  const pathname = usePathname();
+  const canRestore = isGraphViewRoute(pathname);
+  const focusedName = "the open timeline";
+  const [restoringId, setRestoringId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const onResult = (event: Event) => {
+      const detail = (event as CustomEvent<GraphRestoreResultDetail>).detail;
+      if (!detail) return;
+      setRestoringId((current) => (current === detail.clipId ? null : current));
+      if (detail.ok) {
+        // Drop ONE row for that clip id — the bin can hold the same id more
+        // than once and the graph restored exactly one of them. The updater
+        // computes the index itself rather than closing over a "did I remove
+        // one yet" flag: React may invoke an updater more than once, and a
+        // flag that survives between invocations made the second pass remove
+        // nothing, leaving the restored row on screen.
+        setClips((current) => {
+          const index = current.findIndex((clip) => clip.id === detail.clipId);
+          if (index === -1) return current;
+          return [...current.slice(0, index), ...current.slice(index + 1)];
+        });
+      }
+      window.dispatchEvent(
+        new CustomEvent("gstudio-toast", { detail: { message: detail.message } }),
+      );
+    };
+    window.addEventListener(GRAPH_RESTORE_RESULT_EVENT, onResult);
+    return () => window.removeEventListener(GRAPH_RESTORE_RESULT_EVENT, onResult);
+  }, []);
+
+  const handleRestore = (clipId: string) => {
+    setRestoringId(clipId);
+    requestGraphRestoreItem(clipId);
+  };
+
   const handleEmptyTrash = async () => {
     // Says what actually happens: the BIN entries go (with no restore path,
     // so it really is permanent), while the uploads behind them stay in the
@@ -125,7 +175,13 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
   return createPortal(
     <div className="fixed inset-0 z-50 flex flex-col justify-end bg-black/40">
       <div className="fixed inset-0" onClick={onClose} />
-      <div className="asset-library-panel pointer-events-auto ml-[72px] flex max-h-[48vh] flex-col border-t border-zinc-800 bg-zinc-950 text-white shadow-2xl shadow-black/50">
+      {/* `relative` is load-bearing, not cosmetic: the click-to-close backdrop
+          above is POSITIONED and this panel was static, and a positioned
+          sibling paints over a static one whatever the DOM order. The backdrop
+          therefore covered the panel's own controls — every click inside the
+          drawer hit the backdrop and closed it, which is why Empty Trash
+          "did nothing". Positioning the panel puts it back on top. */}
+      <div className="asset-library-panel pointer-events-auto relative ml-[72px] flex max-h-[48vh] flex-col border-t border-zinc-800 bg-zinc-950 text-white shadow-2xl shadow-black/50">
         <header className="flex shrink-0 items-center justify-between gap-3 border-b border-zinc-800 px-5 py-3">
           <div className="min-w-0">
             <h2 className="text-sm font-semibold text-zinc-50 flex items-center gap-2">
@@ -152,6 +208,10 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
               type="button"
               variant="outline"
               size="icon"
+              // An icon-only control needs a name: this one had none, so it
+              // reached assistive tech (and tests) as an anonymous button.
+              aria-label="Close trash"
+              title="Close"
               onClick={onClose}
               className="size-8 border-zinc-800 bg-zinc-900 text-zinc-400 hover:text-zinc-200 cursor-pointer"
             >
@@ -217,10 +277,25 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
                       </div>
                     )}
                   </div>
-                  <div className="mt-2 min-w-0">
-                    <p className="truncate text-xs font-semibold text-zinc-200">
+                  <div className="mt-2 flex min-w-0 items-center gap-2">
+                    <p className="min-w-0 flex-1 truncate text-xs font-semibold text-zinc-200">
                       {(clip as any).title || clip.alt || "Clip"}
                     </p>
+                    {canRestore && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={restoringId === clip.id}
+                        onClick={() => handleRestore(clip.id)}
+                        title={`Restore into ${focusedName}`}
+                        aria-label={`Restore ${(clip as any).title || clip.alt || "clip"}`}
+                        className="h-6 shrink-0 border-zinc-800 px-2 text-[10px] text-zinc-300 hover:border-sky-500/50 hover:text-sky-300 cursor-pointer"
+                      >
+                        <Undo2 className="mr-1 h-3 w-3" />
+                        Restore
+                      </Button>
+                    )}
                   </div>
                 </div>
               ))}

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
@@ -6,6 +6,7 @@ import type { TimelineDocument } from "@storyboard/timeline-model/types";
 import {
   getChildren,
   isEditableKeyboardTarget,
+  parseNodeId,
   useCollectionsSelector,
   useCollectionsStore,
   type CollectionsStore,
@@ -20,6 +21,8 @@ import { resolveInsertPlacement } from "@/lib/graph-insert-placement";
 import { cloneNodeForInsert, type CloneForInsert } from "@/lib/graph-node-clone";
 import {
   GRAPH_ITEM_ACTION_EVENT,
+  GRAPH_RESTORE_ITEM_EVENT,
+  broadcastGraphRestoreResult,
   broadcastGraphSelection,
   type GraphItemAction,
 } from "@/lib/graph-view-events";
@@ -247,6 +250,65 @@ export function GraphItemActionsBridge({
     broadcastGraphSelection({ count: selectionSize, busy });
   }, [selectionSize, busy]);
   useEffect(() => () => broadcastGraphSelection({ count: 0, busy: false }), []);
+
+  // Trash drawer → graph: put a deleted item back into the OPEN timeline.
+  //
+  // Restoring is the delete command run backwards — one `move-nodes` out of
+  // the trash root — so it undoes, persists, and animates like any other move.
+  // The destination is wherever the user is now, which is also how they choose
+  // it: navigate to the timeline you want it in, then restore. It shares the
+  // Paste/Collection-tool placement rule, so a selected card in the focused
+  // subtree puts it right after that card instead of at the end.
+  //
+  // The drawer knows items by their stored CLIP id. The graph may hold the
+  // same item under a different node id — a collection is keyed by its child
+  // timeline, and a duplicate media id is demoted to a synthetic one — so the
+  // node is resolved against the trash root's children by id OR by the
+  // detail's `sourceClipId`, which is exactly what the hydration path records
+  // for both of those cases.
+  useEffect(() => {
+    const onRestore = (event: Event) => {
+      const clipId = (event as CustomEvent<string>).detail;
+      if (typeof clipId !== "string" || clipId.length === 0) return;
+      const answer = (ok: boolean, message: string) =>
+        broadcastGraphRestoreResult({ clipId, ok, message });
+
+      if (trashId === null) return answer(false, "The trash isn't loaded in this project.");
+      const snapshot = store.getSnapshot();
+      if (snapshot.interaction.isDragging) return answer(false, "Finish the drag first.");
+
+      const graph = snapshot.graph;
+      const trashNode = parseNodeId(trashId);
+      const nodeId = getChildren(graph, trashNode).find(
+        (id) => (id as string) === clipId || details.get(id as string)?.sourceClipId === clipId,
+      );
+      if (nodeId === undefined) {
+        return answer(false, "That item is no longer in this project's trash.");
+      }
+
+      const { parentId, toIndex } = resolveInsertPlacement(
+        graph,
+        snapshot.interaction.selectedIds,
+        focusedId,
+      );
+      const dispatched = store.dispatch({
+        type: "move-nodes",
+        nodeIds: [nodeId],
+        toParentId: parentId,
+        toIndex,
+      });
+      // A refusal already speaks through the commandPolicy's own toast; the
+      // drawer only needs to know the row is still trashed.
+      if (!dispatched.ok) return answer(false, "Couldn't restore that item here.");
+
+      const name = graph.nodesById.get(nodeId)?.name ?? "Item";
+      const target = graph.nodesById.get(parentId)?.name ?? "this timeline";
+      answer(true, `Restored "${name}" to "${target}".`);
+    };
+
+    window.addEventListener(GRAPH_RESTORE_ITEM_EVENT, onRestore);
+    return () => window.removeEventListener(GRAPH_RESTORE_ITEM_EVENT, onRestore);
+  }, [store, details, trashId, focusedId]);
 
   // Sidebar → graph: run the requested action against the current selection.
   useEffect(() => {

--- a/apps/timeline-gstudio001/lib/graph-view-events.ts
+++ b/apps/timeline-gstudio001/lib/graph-view-events.ts
@@ -149,6 +149,37 @@ export function setGraphTrashDropHover(hovering: boolean): void {
   );
 }
 
+// Restore: the trash DRAWER lists what was deleted, but putting an item back
+// is a graph move (trash root → the open collection), and the graph lives in
+// the route tree. The drawer asks; the bridge inside the provider performs it
+// and answers, so the drawer can drop the row it just restored — or say why
+// it couldn't.
+
+export const GRAPH_RESTORE_ITEM_EVENT = "graph-view:restore-item";
+export const GRAPH_RESTORE_RESULT_EVENT = "graph-view:restore-result";
+
+/** Identifies a trashed item by its stored CLIP id — what the drawer has.
+ *  The graph may know it under a different node id (a collection is keyed by
+ *  its child timeline; a duplicate media id is demoted), so the bridge
+ *  resolves it against the trash root's children. */
+export type GraphRestoreResultDetail = Readonly<{
+  clipId: string;
+  ok: boolean;
+  message: string;
+}>;
+
+/** Drawer → graph: put this trashed item back into the open timeline. */
+export function requestGraphRestoreItem(clipId: string): void {
+  window.dispatchEvent(new CustomEvent<string>(GRAPH_RESTORE_ITEM_EVENT, { detail: clipId }));
+}
+
+/** Graph → drawer: what happened. */
+export function broadcastGraphRestoreResult(detail: GraphRestoreResultDetail): void {
+  window.dispatchEvent(
+    new CustomEvent<GraphRestoreResultDetail>(GRAPH_RESTORE_RESULT_EVENT, { detail }),
+  );
+}
+
 // Emptying the bin is the one action that removes items the graph is HOLDING.
 // The drawer is app chrome and talks to the server directly, so a graph view
 // mounted behind it would keep the deleted nodes in its store — and write them

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1902,6 +1902,56 @@ test.describe("graph view E2E", () => {
     }).toPass({ timeout: 15000 });
   });
 
+  test("a trashed item restores into the timeline you are looking at", async ({ page }) => {
+    const api = await installGraphApi(page);
+    await openGraph(page);
+
+    // Delete bravo from the project…
+    const bravo = strip(page, PROJECT_ID).locator('[data-node-id="bravo"]');
+    await expect(async () => {
+      await bravo.click();
+      await expect(bravo).toHaveAttribute("data-selected", "true", { timeout: 700 });
+    }).toPass({ timeout: 10000 });
+    await page.getByRole("button", { name: "Delete", exact: true }).click();
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID))
+      .toEqual(["alpha", CHILD_ID, "charlie"]);
+
+    // …drill into the child, so "where it came from" and "where I am" differ…
+    await page.getByRole("button", { name: "Open Scene A" }).first().click();
+    await expect(strip(page, PROJECT_ID)).toHaveCount(0);
+    await expect.poll(() => stripOrder(page, CHILD_ID)).toEqual(["c1", "c2"]);
+
+    // …and restore it from the trash drawer. The drawer reads the trash
+    // document from the server when it opens, so wait for the debounced write
+    // rather than racing it.
+    await expect
+      .poll(() => api.patchesFor(TRASH_ID).at(-1)?.clipIds, { timeout: 5000 })
+      .toEqual(["bravo"]);
+    await page.getByRole("button", { name: "Trash", exact: true }).click();
+    const restore = page.getByRole("button", { name: /^Restore bravo/ });
+    await expect(restore).toBeVisible();
+    await restore.click();
+
+    // It lands in the collection now open — not back where it was deleted
+    // from — and the row leaves the drawer.
+    await expect.poll(() => stripOrder(page, CHILD_ID)).toEqual(["c1", "c2", "bravo"]);
+    await expect(restore).toHaveCount(0);
+
+    // Both documents persist the move, and it is an ordinary undoable step.
+    await expect.poll(() => api.patchesFor(CHILD_ID).at(-1)?.clipIds, { timeout: 5000 }).toEqual([
+      "c1",
+      "c2",
+      "bravo",
+    ]);
+    await expect.poll(() => api.patchesFor(TRASH_ID).at(-1)?.clipIds, { timeout: 5000 }).toEqual([]);
+    // Close the drawer first — its backdrop covers the whole page, sidebar
+    // included, so nothing behind it is clickable.
+    await page.getByRole("button", { name: "Close trash" }).click();
+    await undoButton(page).click();
+    await expect.poll(() => stripOrder(page, CHILD_ID)).toEqual(["c1", "c2"]);
+  });
+
   test("crafted focus URLs are rejected; valid deep links still work", async ({ page }) => {
     await installGraphApi(page);
 


### PR DESCRIPTION
Punch-list item **6**, plus a bug it uncovered.

### Restore

Each row in the trash drawer gets a **Restore** button that puts the item back into the timeline you're currently looking at — which is also how you choose the destination: navigate there, then restore. It's the delete command run backwards (one `move-nodes` out of the trash root), so it persists, undoes, and animates like any other move, and it shares the Paste / Collection-tool placement rule: a selected card in the focused subtree puts it right after that card instead of at the end.

The drawer is app chrome outside the graph provider, so it asks across the window-event seam and waits for the answer before dropping the row. Off-graph there's no graph to restore *into*, so the button isn't offered rather than failing on click. The drawer knows items by stored **clip** id while the graph may hold the same item under a different **node** id (a collection is keyed by its child timeline; a duplicate media id is demoted), so the bridge resolves against the trash root's children by id **or** the detail's `sourceClipId` — exactly what hydration records for both cases.

### The bug underneath

The drawer's click-to-close backdrop is `position: fixed` and the panel was `static` — and a positioned sibling paints over a static one whatever the DOM order. **The backdrop covered the panel's own controls**: every click inside the drawer hit the backdrop and closed it. Verified live — `elementFromPoint` at the centre of the Close button returned the backdrop.

That's the other half of *"the empty trash button doesn't work"*. #151 fixed the server (which was also broken, twice over), but the click had never reached the button. Positioning the panel puts it back on top; all its controls are now reachable, verified the same way.

Also: the drawer's close button had no accessible name — added.

### Pin

`a trashed item restores into the timeline you are looking at` deletes bravo from the project, drills into the child so origin and destination differ, restores from the drawer, and asserts it lands in the **child**, leaves the drawer, persists to both documents, and undoes. Proven fail-first — with the panel static again the test can't even click the drawer.

graph-view e2e 57/57 (the known load-dependent flake needed a retry) · app vitest 222/222 · app `tsc` clean · lint clean (4 pre-existing `img` warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
