### PR TITLE
Asset panel phase 1: provider seam, neutral API, clip provenance

### DIFF
--- a/apps/timeline-gstudio001/app/api/assets/assets-route.test.ts
+++ b/apps/timeline-gstudio001/app/api/assets/assets-route.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CloudinaryAsset } from "@/lib/cloudinary-media-store";
+
+// The REAL route handler over the REAL registry and Cloudinary adapter —
+// only the process boundaries are faked (session, vendor listing).
+
+const state = vi.hoisted(() => ({
+  vendorAssets: [] as CloudinaryAsset[],
+  user: { uid: "user-a", email: null as string | null, name: null, picture: null } as {
+    uid: string;
+  } | null,
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/firebase-auth-session", () => ({
+  requireAuthUser: async () =>
+    state.user
+      ? { user: state.user, response: null }
+      : { user: null, response: new Response(null, { status: 401 }) },
+}));
+vi.mock("@/lib/cloudinary-media-store", () => ({
+  listCloudinaryAssets: async () => state.vendorAssets,
+}));
+
+import { GET as listAssets } from "./route";
+import { GET as listProviders } from "./providers/route";
+
+function vendorAsset(id: string, relativePath: string): CloudinaryAsset {
+  return {
+    id,
+    pathname: `gstudio/user-a/${relativePath}`,
+    url: `https://cdn.test/${id}`,
+    thumbnailUrl: `https://cdn.test/${id}.thumb`,
+    resourceType: "image",
+    relativePath,
+  };
+}
+
+const request = (query = "") => new Request(`http://test.local/api/assets${query}`);
+
+beforeEach(() => {
+  state.vendorAssets = [
+    vendorAsset("a", "root-a.png"),
+    vendorAsset("b", "Scenes/b.png"),
+    vendorAsset("c", "Scenes/Heist/c.png"),
+  ];
+  state.user = { uid: "user-a" };
+});
+
+describe("GET /api/assets", () => {
+  it("serves the NEUTRAL shape from the default provider", async () => {
+    const response = await listAssets(request());
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.providerId).toBe("cloudinary");
+    expect(body.capabilities).toMatchObject({ folders: true });
+    const assets = body.assets as { id: string; providerId: string; src: string; kind: string }[];
+    // Flat listing: everything, regardless of folder.
+    expect(assets.map((entry) => entry.id)).toEqual(["a", "b", "c"]);
+    expect(assets[0]).toMatchObject({
+      providerId: "cloudinary",
+      kind: "image",
+      src: "https://cdn.test/a",
+    });
+    expect(body.folders).toEqual([{ name: "Scenes", path: ["Scenes"] }]);
+  });
+
+  it("scopes to a folder via repeated ?folder= segment params", async () => {
+    const response = await listAssets(request("?folder=Scenes"));
+    const body = (await response.json()) as { assets: { id: string }[]; folders: unknown };
+    expect(body.assets.map((entry) => entry.id)).toEqual(["b"]);
+    expect(body.folders).toEqual([{ name: "Heist", path: ["Scenes", "Heist"] }]);
+
+    const deep = await listAssets(request("?folder=Scenes&folder=Heist"));
+    expect(((await deep.json()) as { assets: { id: string }[] }).assets.map((e) => e.id)).toEqual([
+      "c",
+    ]);
+  });
+
+  it("?browse=1 with no folder params is the ROOT folder, distinct from flat", async () => {
+    const response = await listAssets(request("?browse=1"));
+    const body = (await response.json()) as { assets: { id: string }[] };
+    expect(body.assets.map((entry) => entry.id)).toEqual(["a"]);
+  });
+
+  it("404s an unknown provider by name", async () => {
+    const response = await listAssets(request("?provider=nope"));
+    expect(response.status).toBe(404);
+    expect(((await response.json()) as { error: string }).error).toContain('"nope"');
+  });
+
+  it("requires a session", async () => {
+    state.user = null;
+    expect((await listAssets(request())).status).toBe(401);
+  });
+});
+
+describe("GET /api/assets/providers", () => {
+  it("lists installed providers with capabilities for the picker", async () => {
+    const response = await listProviders();
+    const body = (await response.json()) as {
+      providers: { id: string; label: string; capabilities: { folders: boolean } }[];
+    };
+    expect(body.providers).toEqual([
+      {
+        id: "cloudinary",
+        label: "Cloudinary",
+        capabilities: { folders: true, tags: false, search: false, upload: false, delete: false },
+      },
+    ]);
+  });
+});

--- a/apps/timeline-gstudio001/app/api/assets/providers/route.ts
+++ b/apps/timeline-gstudio001/app/api/assets/providers/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+
+import { assetProviders } from "@/lib/assets/registry";
+import { requireAuthUser } from "@/lib/firebase-auth-session";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/** The installed asset providers, with their capabilities — what the panel's
+ *  provider picker renders, and how it knows which controls (folders, tags,
+ *  search, upload) each provider can honour. */
+export async function GET() {
+  const { user, response } = await requireAuthUser();
+  if (response || !user) return response || NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  return NextResponse.json({ providers: assetProviders.describeAll() });
+}

--- a/apps/timeline-gstudio001/app/api/assets/route.ts
+++ b/apps/timeline-gstudio001/app/api/assets/route.ts
@@ -1,21 +1,59 @@
 import { NextResponse } from "next/server";
 
-import { listCloudinaryAssets } from "@/lib/cloudinary-media-store";
+import { assetProviders } from "@/lib/assets/registry";
+import type { AssetQuery } from "@/lib/assets/types";
 import { requireAuthUser } from "@/lib/firebase-auth-session";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-export async function GET() {
+/**
+ * List assets through the provider seam.
+ *
+ *   ?provider=<id>      which provider (default: the registry's first)
+ *   ?folder=<segment>   repeatable — one param per PATH SEGMENT, so a
+ *                       segment containing "/" can never fake a boundary.
+ *                       `?browse=1` with no folder params means the ROOT
+ *                       folder; no browse and no folder params means the
+ *                       FLAT listing (every asset — the palette's view).
+ *   ?limit=<n>
+ *
+ * Response: { providerId, capabilities, assets, folders, nextCursor? } — the
+ * neutral shapes from lib/assets/types, whoever the provider is.
+ */
+export async function GET(request: Request) {
   try {
     const { user, response } = await requireAuthUser();
     if (response || !user) return response || NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-    return NextResponse.json({ assets: await listCloudinaryAssets(user.uid) });
+    const url = new URL(request.url);
+    const providerId = url.searchParams.get("provider");
+    const provider =
+      providerId === null ? assetProviders.defaultProvider() : assetProviders.get(providerId);
+    if (!provider) {
+      return NextResponse.json(
+        { error: `Unknown asset provider "${providerId}".` },
+        { status: 404 },
+      );
+    }
+
+    const folderSegments = url.searchParams.getAll("folder");
+    const browsing = url.searchParams.get("browse") !== null || folderSegments.length > 0;
+    const limitParam = Number(url.searchParams.get("limit"));
+    const query: AssetQuery = {
+      ...(browsing ? { folder: folderSegments } : {}),
+      ...(Number.isFinite(limitParam) && limitParam > 0 ? { limit: limitParam } : {}),
+    };
+
+    const page = await provider.list({ uid: user.uid }, query);
+    return NextResponse.json({
+      providerId: provider.id,
+      capabilities: provider.capabilities,
+      ...page,
+    });
   } catch (error) {
     console.error("[GSTUDIO_ASSETS_LIST_ERROR]", error);
-    const message =
-      error instanceof Error ? error.message : "Unable to load Cloudinary assets.";
+    const message = error instanceof Error ? error.message : "Unable to load assets.";
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/apps/timeline-gstudio001/app/api/timelines/[id]/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/[id]/route.ts
@@ -17,6 +17,7 @@ import {
 // Demo-content seed for the GET fallback — deliberately still the UI
 // package's fixture set, not model logic.
 import { getTimelineDocument } from "@storyboard/ui/timeline/timeline-documents";
+import { CLOUDINARY_PROVIDER_ID } from "@/lib/assets/cloudinary-provider";
 import { listCloudinaryAssets } from "@/lib/cloudinary-media-store";
 import { serveTimelineDocument, serveTrashDocument } from "@/lib/serve-timeline";
 import { checkUserScopedId, TimelineAccessDeniedError } from "@/lib/timeline-ownership";
@@ -175,6 +176,10 @@ export async function GET(
           const duration = asset.resourceType === "video" ? (asset.duration ?? 6) : 4;
           const stableId = `asset-${asset.id.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
 
+          // Provenance travels with the clip from the moment it is minted
+          // (`sourceAsset` on the stored model): `src` is how it renders,
+          // this is which provider file it IS.
+          const sourceAsset = { providerId: CLOUDINARY_PROVIDER_ID, assetId: asset.id };
           const newClip: TimelineClip =
             asset.resourceType === "video"
               ? {
@@ -191,6 +196,7 @@ export async function GET(
                   sourceDuration: duration,
                   trimIn: 0,
                   trimOut: 0,
+                  sourceAsset,
                 }
               : {
                   id: stableId,
@@ -205,6 +211,7 @@ export async function GET(
                   sourceDuration: duration,
                   trimIn: 0,
                   trimOut: 0,
+                  sourceAsset,
                 };
 
           merged.push(newClip);

--- a/apps/timeline-gstudio001/components/assets/asset-library-drawer.tsx
+++ b/apps/timeline-gstudio001/components/assets/asset-library-drawer.tsx
@@ -13,75 +13,19 @@ import { Button } from "@/components/core/button";
 import { useBottomDrawerInset } from "@/components/assets/use-bottom-drawer-inset";
 import { SmoothScrollList } from "@/components/timeline/smooth-scroll-list";
 import { cn } from "@/lib/utils";
-import type { TimelineClip } from "@storyboard/ui/timeline/types";
 import { useAuth } from "@/components/auth/auth-provider";
 import { getTimelinePath, getTimelineDocument } from "@storyboard/ui/timeline/timeline-documents";
 
-type CloudinaryAsset = {
-  id: string;
-  pathname: string;
-  url: string;
-  thumbnailUrl: string;
-  resourceType: "image" | "video";
-  format?: string;
-  width?: number;
-  height?: number;
-  size?: number;
-  createdAt?: string;
-  duration?: number;
-};
+// No local Cloudinary shape any more: this drawer never consumed the /api/
+// assets payload (its clips are minted SERVER-side by the asset-library
+// virtual-timeline route) — the fetch below is a refresh trigger and error
+// surface, so it reads only `error`. The dead vendor type and unused
+// clip-minting helper it carried went with the provider seam.
 
 type AssetLibraryDrawerProps = {
   isOpen: boolean;
   onClose: () => void;
 };
-
-function getAssetName(pathname: string) {
-  return pathname.split("/").pop() || pathname;
-}
-
-function createAssetClip(asset: CloudinaryAsset, index: number, startTime: number): TimelineClip {
-  const name = getAssetName(asset.pathname);
-  const aspect =
-    asset.width && asset.height && asset.height > 0
-      ? asset.width / asset.height
-      : 16 / 9;
-  const duration = asset.resourceType === "video" ? (asset.duration ?? 6) : 4;
-  const stableId = `asset-${asset.id.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
-
-  if (asset.resourceType === "video") {
-    return {
-      id: stableId,
-      index,
-      kind: "video",
-      src: asset.url,
-      poster: asset.thumbnailUrl,
-      alt: name,
-      aspect,
-      trackIndex: 0,
-      startTime,
-      duration,
-      sourceDuration: duration,
-      trimIn: 0,
-      trimOut: 0,
-    };
-  }
-
-  return {
-    id: stableId,
-    index,
-    kind: "image",
-    src: asset.url,
-    alt: name,
-    aspect,
-    trackIndex: 0,
-    startTime,
-    duration,
-    sourceDuration: duration,
-    trimIn: 0,
-    trimOut: 0,
-  };
-}
 
 export function AssetLibraryDrawer({ isOpen, onClose }: AssetLibraryDrawerProps) {
   const { user } = useAuth();
@@ -106,13 +50,10 @@ export function AssetLibraryDrawer({ isOpen, onClose }: AssetLibraryDrawerProps)
 
     try {
       const response = await fetch("/api/assets", { cache: "no-store" });
-      const result = (await response.json().catch(() => ({}))) as {
-        assets?: CloudinaryAsset[];
-        error?: string;
-      };
+      const result = (await response.json().catch(() => ({}))) as { error?: string };
 
       if (!response.ok) {
-        throw new Error(result.error || "Unable to load Cloudinary assets.");
+        throw new Error(result.error || "Unable to load assets.");
       }
 
       setAssetsVersion((v) => v + 1);

--- a/apps/timeline-gstudio001/components/graph-view/graph-asset-palette.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-asset-palette.tsx
@@ -13,7 +13,7 @@ import {
 
 import { Button } from "@/components/core/button";
 import { useBottomDrawerInset } from "@/components/assets/use-bottom-drawer-inset";
-import type { CloudinaryAsset } from "@/lib/cloudinary-media-store";
+import type { Asset } from "@/lib/assets/types";
 
 import { clearPendingDetails, parkPendingDetail } from "./graph-pending-details";
 
@@ -21,39 +21,36 @@ const DEFAULT_IMAGE_SECONDS = 4;
 const DEFAULT_VIDEO_SECONDS = 8;
 const PALETTE_ASSET_LIMIT = 48;
 
-function assetDisplayName(asset: CloudinaryAsset): string {
-  const path = asset.relativePath ?? asset.pathname;
-  return path.split("/").pop() ?? path;
-}
-
-function createNodeFromAsset(asset: CloudinaryAsset): CollectionItemNode {
+function createNodeFromAsset(asset: Asset): CollectionItemNode {
   clearPendingDetails();
   const id = parseNodeId(
     `asset-${asset.id}-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`,
   );
-  const name = assetDisplayName(asset);
   const aspect =
     asset.width && asset.height && asset.height > 0 ? asset.width / asset.height : 16 / 9;
 
   parkPendingDetail(id as string, {
-    alt: name,
+    alt: asset.name,
     aspect,
     trackIndex: 0,
     poster: asset.thumbnailUrl,
-    ...(asset.resourceType === "image"
+    // Provenance: the persisted clip records which provider file it came
+    // from, not just the URL it renders by (the model's `sourceAsset`).
+    sourceAsset: { providerId: asset.providerId, assetId: asset.id },
+    ...(asset.kind === "image"
       ? { sourceDuration: DEFAULT_IMAGE_SECONDS, trimIn: 0, trimOut: 0 }
       : {}),
   });
 
-  if (asset.resourceType === "video") {
+  if (asset.kind === "video") {
     return {
       id,
       kind: "media",
       mediaKind: "video",
-      name,
-      src: asset.url,
+      name: asset.name,
+      src: asset.src,
       posterSrcs: [asset.thumbnailUrl],
-      fullDurationSeconds: asset.duration ?? DEFAULT_VIDEO_SECONDS,
+      fullDurationSeconds: asset.durationSeconds ?? DEFAULT_VIDEO_SECONDS,
       trimInSeconds: 0,
       trimOutSeconds: 0,
     };
@@ -63,8 +60,8 @@ function createNodeFromAsset(asset: CloudinaryAsset): CollectionItemNode {
     id,
     kind: "media",
     mediaKind: "image",
-    name,
-    src: asset.url,
+    name: asset.name,
+    src: asset.src,
     durationSeconds: DEFAULT_IMAGE_SECONDS,
   };
 }
@@ -72,9 +69,9 @@ function createNodeFromAsset(asset: CloudinaryAsset): CollectionItemNode {
 type AssetPaletteState =
   | Readonly<{ status: "loading" }>
   | Readonly<{ status: "error"; message: string }>
-  | Readonly<{ status: "ready"; assets: readonly CloudinaryAsset[]; truncated: boolean }>;
+  | Readonly<{ status: "ready"; assets: readonly Asset[]; truncated: boolean }>;
 
-function PaletteRail({ assets }: Readonly<{ assets: readonly CloudinaryAsset[] }>) {
+function PaletteRail({ assets }: Readonly<{ assets: readonly Asset[] }>) {
   const store = useCollectionsStore();
   const railRef = useRef<HTMLDivElement>(null);
   const panOptions = useMemo<Parameters<typeof usePanWithMomentum>[2]>(
@@ -100,12 +97,12 @@ function PaletteRail({ assets }: Readonly<{ assets: readonly CloudinaryAsset[] }
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={asset.thumbnailUrl}
-            alt={assetDisplayName(asset)}
+            alt={asset.name}
             draggable={false}
             loading="lazy"
             className="h-full w-full object-cover"
           />
-          {asset.resourceType === "video" && (
+          {asset.kind === "video" && (
             <span className="absolute bottom-1 left-1 rounded bg-black/75 px-1 py-0.5 text-[9px] font-bold tracking-wide text-zinc-100">
               VIDEO
             </span>
@@ -145,7 +142,7 @@ export function AssetPaletteDrawer({
       try {
         const response = await fetch("/api/assets", { cache: "no-store" });
         const result = (await response.json().catch(() => ({}))) as {
-          assets?: CloudinaryAsset[];
+          assets?: Asset[];
           error?: string;
         };
         if (cancelled) return;

--- a/apps/timeline-gstudio001/lib/assets/cloudinary-provider.test.ts
+++ b/apps/timeline-gstudio001/lib/assets/cloudinary-provider.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CloudinaryAsset } from "@/lib/cloudinary-media-store";
+
+// The adapter under its process boundary: the vendor store is faked, the
+// mapping and the provider's list() run for real.
+const state = vi.hoisted(() => ({
+  vendorAssets: [] as CloudinaryAsset[],
+  listedForUid: null as string | null,
+}));
+
+vi.mock("@/lib/cloudinary-media-store", () => ({
+  listCloudinaryAssets: async (uid: string) => {
+    state.listedForUid = uid;
+    return state.vendorAssets;
+  },
+}));
+
+import {
+  CLOUDINARY_PROVIDER_ID,
+  cloudinaryAssetProvider,
+  cloudinaryAssetToAsset,
+} from "./cloudinary-provider";
+
+function vendorAsset(overrides: Partial<CloudinaryAsset>): CloudinaryAsset {
+  return {
+    id: "gstudio/user-1/pic-123",
+    pathname: "gstudio/user-1/pic-123",
+    url: "https://res.cloudinary.test/image/upload/gstudio/user-1/pic-123.png",
+    thumbnailUrl: "https://res.cloudinary.test/thumb/pic-123.jpg",
+    resourceType: "image",
+    relativePath: "pic-123",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  state.vendorAssets = [];
+  state.listedForUid = null;
+});
+
+describe("cloudinaryAssetToAsset", () => {
+  it("maps a vendor row to the neutral shape, folders from relativePath", () => {
+    const mapped = cloudinaryAssetToAsset(
+      vendorAsset({
+        relativePath: "Foobar 001/Scenes/beach-178.png",
+        width: 1600,
+        height: 900,
+        size: 12345,
+        createdAt: "2026-07-01T00:00:00Z",
+      }),
+    );
+    expect(mapped).toEqual({
+      id: "gstudio/user-1/pic-123",
+      providerId: CLOUDINARY_PROVIDER_ID,
+      name: "beach-178.png",
+      kind: "image",
+      src: "https://res.cloudinary.test/image/upload/gstudio/user-1/pic-123.png",
+      thumbnailUrl: "https://res.cloudinary.test/thumb/pic-123.jpg",
+      folderPath: ["Foobar 001", "Scenes"],
+      tags: [],
+      width: 1600,
+      height: 900,
+      bytes: 12345,
+      createdAt: "2026-07-01T00:00:00Z",
+    });
+  });
+
+  it("keeps the vendor id verbatim — it IS what sourceAsset.assetId records", () => {
+    const mapped = cloudinaryAssetToAsset(vendorAsset({ id: "gstudio/u/deep/path/name-1" }));
+    expect(mapped.id).toBe("gstudio/u/deep/path/name-1");
+  });
+
+  it("maps a video's duration to durationSeconds", () => {
+    const mapped = cloudinaryAssetToAsset(
+      vendorAsset({ resourceType: "video", duration: 12.4, relativePath: "clip.mp4" }),
+    );
+    expect(mapped.kind).toBe("video");
+    expect(mapped.durationSeconds).toBe(12.4);
+    expect(mapped.folderPath).toEqual([]);
+  });
+
+  it("falls back to the pathname when relativePath is absent", () => {
+    const mapped = cloudinaryAssetToAsset(
+      vendorAsset({ relativePath: undefined, pathname: "gstudio/user-1/pic-123" }),
+    );
+    expect(mapped.name).toBe("pic-123");
+  });
+});
+
+describe("cloudinaryAssetProvider.list", () => {
+  it("lists for the CALLER's uid and scopes by the queried folder", async () => {
+    state.vendorAssets = [
+      vendorAsset({ id: "a", relativePath: "root-a.png" }),
+      vendorAsset({ id: "b", relativePath: "Scenes/b.png" }),
+      vendorAsset({ id: "c", relativePath: "Scenes/Heist/c.png" }),
+    ];
+    const flat = await cloudinaryAssetProvider.list({ uid: "user-1" }, {});
+    expect(state.listedForUid).toBe("user-1");
+    expect(flat.assets.map((entry) => entry.id)).toEqual(["a", "b", "c"]);
+    expect(flat.folders.map((folder) => folder.name)).toEqual(["Scenes"]);
+
+    const scenes = await cloudinaryAssetProvider.list({ uid: "user-1" }, { folder: ["Scenes"] });
+    expect(scenes.assets.map((entry) => entry.id)).toEqual(["b"]);
+    expect(scenes.folders).toEqual([{ name: "Heist", path: ["Scenes", "Heist"] }]);
+  });
+
+  it("declares folders on and the not-yet-served capabilities off", () => {
+    expect(cloudinaryAssetProvider.capabilities).toEqual({
+      folders: true,
+      tags: false,
+      search: false,
+      upload: false,
+      delete: false,
+    });
+  });
+});

--- a/apps/timeline-gstudio001/lib/assets/cloudinary-provider.ts
+++ b/apps/timeline-gstudio001/lib/assets/cloudinary-provider.ts
@@ -1,0 +1,64 @@
+// Cloudinary behind the neutral seam. The vendor store (cloudinary-media-store)
+// stays exactly what it was — the upload route and document healing still use
+// it directly; this adapter only translates its LISTING into the neutral
+// `Asset` shape for the panel/API surface.
+
+import { listCloudinaryAssets, type CloudinaryAsset } from "@/lib/cloudinary-media-store";
+
+import { pageFromFlatListing } from "./path-folders";
+import type { AssetContext, AssetProvider } from "./provider";
+import type { Asset } from "./types";
+
+export const CLOUDINARY_PROVIDER_ID = "cloudinary";
+
+/**
+ * One vendor row → one neutral asset. `id` stays the Cloudinary public id
+ * (path-shaped, may contain "/") — it is the durable name deletion and
+ * re-resolution use, and exactly what a clip's `sourceAsset.assetId` records.
+ * The folder path comes from `relativePath` (the public id with the app/user
+ * root prefix stripped by the store), so folders are the folders the USER
+ * sees, not the storage-internal `<root>/<uid>/` plumbing.
+ */
+export function cloudinaryAssetToAsset(vendorAsset: CloudinaryAsset): Asset {
+  const relative = vendorAsset.relativePath ?? vendorAsset.pathname;
+  const segments = relative.split("/").filter((segment) => segment.length > 0);
+  return {
+    id: vendorAsset.id,
+    providerId: CLOUDINARY_PROVIDER_ID,
+    name: segments[segments.length - 1] ?? relative,
+    kind: vendorAsset.resourceType,
+    src: vendorAsset.url,
+    thumbnailUrl: vendorAsset.thumbnailUrl,
+    folderPath: segments.slice(0, -1),
+    // Phase 3 (tags browse) teaches the store's listing to carry tags; until
+    // then Cloudinary reports none and declares the capability off.
+    tags: [],
+    ...(vendorAsset.width === undefined ? {} : { width: vendorAsset.width }),
+    ...(vendorAsset.height === undefined ? {} : { height: vendorAsset.height }),
+    ...(vendorAsset.duration === undefined ? {} : { durationSeconds: vendorAsset.duration }),
+    ...(vendorAsset.size === undefined ? {} : { bytes: vendorAsset.size }),
+    ...(vendorAsset.createdAt === undefined ? {} : { createdAt: vendorAsset.createdAt }),
+  };
+}
+
+export const cloudinaryAssetProvider: AssetProvider = {
+  id: CLOUDINARY_PROVIDER_ID,
+  label: "Cloudinary",
+  capabilities: {
+    folders: true,
+    // Declared OFF until the adapter actually serves them — the UI offers
+    // only what list() honours today.
+    tags: false,
+    search: false,
+    upload: false,
+    delete: false,
+  },
+  async list(ctx: AssetContext, query) {
+    // The store's listing is already user-scoped and paginated at the vendor
+    // boundary; folder scoping is derived from it in memory (the documented
+    // fallback in path-folders — a native `prefix` query is the upgrade path
+    // if libraries outgrow it).
+    const vendorAssets = await listCloudinaryAssets(ctx.uid);
+    return pageFromFlatListing(vendorAssets.map(cloudinaryAssetToAsset), query);
+  },
+};

--- a/apps/timeline-gstudio001/lib/assets/path-folders.test.ts
+++ b/apps/timeline-gstudio001/lib/assets/path-folders.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { pageFromFlatListing } from "./path-folders";
+import type { Asset } from "./types";
+
+function asset(id: string, folderPath: string[]): Asset {
+  return {
+    id,
+    providerId: "test",
+    name: id,
+    kind: "image",
+    src: `https://cdn.test/${id}`,
+    thumbnailUrl: `https://cdn.test/${id}.thumb`,
+    folderPath,
+    tags: [],
+  };
+}
+
+const LISTING = [
+  asset("root-a", []),
+  asset("root-b", []),
+  asset("scenes-1", ["Scenes"]),
+  asset("scenes-2", ["Scenes"]),
+  asset("heist-1", ["Scenes", "Heist"]),
+  asset("props-1", ["Props"]),
+];
+
+describe("pageFromFlatListing", () => {
+  it("flat query (folder undefined) returns EVERY asset plus top-level folder rows", () => {
+    const page = pageFromFlatListing(LISTING, {});
+    expect(page.assets.map((entry) => entry.id)).toEqual([
+      "root-a",
+      "root-b",
+      "scenes-1",
+      "scenes-2",
+      "heist-1",
+      "props-1",
+    ]);
+    expect(page.folders).toEqual([
+      { name: "Props", path: ["Props"] },
+      { name: "Scenes", path: ["Scenes"] },
+    ]);
+  });
+
+  it("root browse ([]) returns only root-level assets — flat and root are distinct", () => {
+    const page = pageFromFlatListing(LISTING, { folder: [] });
+    expect(page.assets.map((entry) => entry.id)).toEqual(["root-a", "root-b"]);
+    expect(page.folders.map((folder) => folder.name)).toEqual(["Props", "Scenes"]);
+  });
+
+  it("a folder lists its DIRECT assets and direct subfolders only", () => {
+    const page = pageFromFlatListing(LISTING, { folder: ["Scenes"] });
+    // heist-1 is deeper — it appears through its subfolder row, which is what
+    // makes drill-in mean something.
+    expect(page.assets.map((entry) => entry.id)).toEqual(["scenes-1", "scenes-2"]);
+    expect(page.folders).toEqual([{ name: "Heist", path: ["Scenes", "Heist"] }]);
+  });
+
+  it("a leaf folder lists assets and no subfolders", () => {
+    const page = pageFromFlatListing(LISTING, { folder: ["Scenes", "Heist"] });
+    expect(page.assets.map((entry) => entry.id)).toEqual(["heist-1"]);
+    expect(page.folders).toEqual([]);
+  });
+
+  it("an unknown folder is empty, not an error", () => {
+    const page = pageFromFlatListing(LISTING, { folder: ["Nope"] });
+    expect(page.assets).toEqual([]);
+    expect(page.folders).toEqual([]);
+  });
+
+  it("limit caps assets but never hides folder rows", () => {
+    const page = pageFromFlatListing(LISTING, { limit: 1 });
+    expect(page.assets.map((entry) => entry.id)).toEqual(["root-a"]);
+    expect(page.folders.length).toBe(2);
+  });
+
+  it("a same-named folder at two depths stays two folders", () => {
+    const listing = [asset("a", ["X"]), asset("b", ["Y", "X"])];
+    expect(pageFromFlatListing(listing, {}).folders.map((folder) => folder.path)).toEqual([
+      ["X"],
+      ["Y"],
+    ]);
+    expect(pageFromFlatListing(listing, { folder: ["Y"] }).folders).toEqual([
+      { name: "X", path: ["Y", "X"] },
+    ]);
+  });
+});

--- a/apps/timeline-gstudio001/lib/assets/path-folders.ts
+++ b/apps/timeline-gstudio001/lib/assets/path-folders.ts
@@ -1,0 +1,53 @@
+// Folder browsing derived from asset PATHS — shared by every provider whose
+// backend is really a flat namespace with path-shaped keys (Cloudinary public
+// ids, S3 object keys). Such backends have no folder API to ask; the tree IS
+// the set of key prefixes, so one derivation serves them all and a new
+// path-based adapter gets browsing for free.
+
+import type { Asset, AssetFolder, AssetPage, AssetQuery } from "./types";
+
+function sameFolder(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((segment, i) => segment === b[i]);
+}
+
+function isUnder(path: readonly string[], folder: readonly string[]): boolean {
+  return path.length > folder.length && folder.every((segment, i) => segment === path[i]);
+}
+
+/**
+ * Resolve a query against a fully-mapped flat listing.
+ *
+ * `folder` undefined → every asset (the flat view) plus the top-level folder
+ * rows; `folder` set → that folder's DIRECT assets plus its direct subfolder
+ * rows. Assets deeper than the queried folder appear only through their
+ * subfolder row, which is what makes drill-in mean something.
+ *
+ * In-memory on purpose, and marked as the seam to push down: a provider with
+ * a native prefix/tag query (S3 `Delimiter`, Cloudinary `prefix`) should
+ * translate `query` into it and skip this — the fallback exists so a minimal
+ * adapter is a mapping function and nothing more.
+ */
+export function pageFromFlatListing(assets: readonly Asset[], query: AssetQuery): AssetPage {
+  const folder = query.folder;
+
+  const matching =
+    folder === undefined
+      ? assets
+      : assets.filter((asset) => sameFolder(asset.folderPath, folder));
+
+  const base = folder ?? [];
+  const seen = new Set<string>();
+  const folders: AssetFolder[] = [];
+  for (const asset of assets) {
+    if (!isUnder(asset.folderPath, base)) continue;
+    const name = asset.folderPath[base.length];
+    if (seen.has(name)) continue;
+    seen.add(name);
+    folders.push({ name, path: [...base, name] });
+  }
+  folders.sort((a, b) => a.name.localeCompare(b.name));
+
+  const limited =
+    query.limit !== undefined && query.limit >= 0 ? matching.slice(0, query.limit) : matching;
+  return { assets: limited, folders };
+}

--- a/apps/timeline-gstudio001/lib/assets/provider.test.ts
+++ b/apps/timeline-gstudio001/lib/assets/provider.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { LIST_ONLY_CAPABILITIES, createAssetProviderRegistry, type AssetProvider } from "./provider";
+
+function fakeProvider(id: string): AssetProvider {
+  return {
+    id,
+    label: id.toUpperCase(),
+    capabilities: { ...LIST_ONLY_CAPABILITIES, folders: id === "with-folders" },
+    list: async () => ({ assets: [], folders: [] }),
+  };
+}
+
+describe("createAssetProviderRegistry", () => {
+  it("resolves providers by id and answers unknown ids with undefined", () => {
+    const registry = createAssetProviderRegistry([fakeProvider("one"), fakeProvider("two")]);
+    expect(registry.get("two")?.id).toBe("two");
+    expect(registry.get("nope")).toBeUndefined();
+  });
+
+  it("defaults to the FIRST registered provider (registration order is preference)", () => {
+    const registry = createAssetProviderRegistry([fakeProvider("first"), fakeProvider("second")]);
+    expect(registry.defaultProvider().id).toBe("first");
+  });
+
+  it("describeAll carries each provider's own capabilities", () => {
+    const registry = createAssetProviderRegistry([
+      fakeProvider("with-folders"),
+      fakeProvider("flat"),
+    ]);
+    expect(registry.describeAll()).toEqual([
+      {
+        id: "with-folders",
+        label: "WITH-FOLDERS",
+        capabilities: { ...LIST_ONLY_CAPABILITIES, folders: true },
+      },
+      { id: "flat", label: "FLAT", capabilities: LIST_ONLY_CAPABILITIES },
+    ]);
+  });
+
+  it("rejects a duplicate provider id at construction, not at request time", () => {
+    expect(() =>
+      createAssetProviderRegistry([fakeProvider("dup"), fakeProvider("dup")]),
+    ).toThrow(/Duplicate asset provider id "dup"/);
+  });
+
+  it("rejects an empty registry", () => {
+    expect(() => createAssetProviderRegistry([])).toThrow(/at least one provider/);
+  });
+});

--- a/apps/timeline-gstudio001/lib/assets/provider.ts
+++ b/apps/timeline-gstudio001/lib/assets/provider.ts
@@ -1,0 +1,66 @@
+// The provider interface and its registry — pure module (no server imports),
+// so registry behaviour unit-tests with in-memory fakes. The INSTANCE the
+// routes use lives in ./registry.ts, which is server-only because the real
+// adapters are.
+
+import type {
+  AssetPage,
+  AssetProviderCapabilities,
+  AssetProviderDescriptor,
+  AssetQuery,
+} from "./types";
+
+/** Per-request context. Today just the signed-in user; per-user OAuth
+ *  credentials (Drive/Dropbox) will arrive here when that track lands, which
+ *  is why every provider method takes it rather than reading globals. */
+export type AssetContext = Readonly<{ uid: string }>;
+
+export type AssetProvider = AssetProviderDescriptor &
+  Readonly<{
+    /** List assets/folders for a query. A provider MUST tolerate query fields
+     *  outside its capabilities by ignoring them (never throwing): the
+     *  capabilities gate the UI, not the wire. */
+    list: (ctx: AssetContext, query: AssetQuery) => Promise<AssetPage>;
+  }>;
+
+export type AssetProviderRegistry = Readonly<{
+  get: (id: string) => AssetProvider | undefined;
+  /** Descriptors only — what /api/assets/providers serves the picker. */
+  describeAll: () => readonly AssetProviderDescriptor[];
+  /** The provider used when a request names none. Always the first
+   *  registered — registration order is the app's preference order. */
+  defaultProvider: () => AssetProvider;
+}>;
+
+export function createAssetProviderRegistry(
+  providers: readonly AssetProvider[],
+): AssetProviderRegistry {
+  if (providers.length === 0) {
+    throw new Error("An asset provider registry needs at least one provider.");
+  }
+  const byId = new Map<string, AssetProvider>();
+  for (const provider of providers) {
+    if (byId.has(provider.id)) {
+      // Fail at construction, not at request time: a duplicate id would make
+      // `?provider=` ambiguous and asset refs unresolvable.
+      throw new Error(`Duplicate asset provider id "${provider.id}".`);
+    }
+    byId.set(provider.id, provider);
+  }
+  return {
+    get: (id) => byId.get(id),
+    describeAll: () =>
+      providers.map(({ id, label, capabilities }) => ({ id, label, capabilities })),
+    defaultProvider: () => providers[0],
+  };
+}
+
+/** Capability set for a provider that only lists — the common starting point
+ *  for a new adapter; spread and override what the backend really supports. */
+export const LIST_ONLY_CAPABILITIES: AssetProviderCapabilities = {
+  folders: false,
+  tags: false,
+  search: false,
+  upload: false,
+  delete: false,
+};

--- a/apps/timeline-gstudio001/lib/assets/registry.ts
+++ b/apps/timeline-gstudio001/lib/assets/registry.ts
@@ -1,0 +1,13 @@
+// THE registry instance the API routes resolve providers from. Server-only by
+// composition: the adapters registered here read env config and call vendor
+// APIs. Registration order is preference order — the first entry is what a
+// request that names no provider gets.
+//
+// Adding a provider = one adapter file + one entry here. The S3 adapter
+// (decided 2026-07-23: the second provider, proving the seam) lands as
+// exactly that pair.
+
+import { cloudinaryAssetProvider } from "./cloudinary-provider";
+import { createAssetProviderRegistry } from "./provider";
+
+export const assetProviders = createAssetProviderRegistry([cloudinaryAssetProvider]);

--- a/apps/timeline-gstudio001/lib/assets/types.ts
+++ b/apps/timeline-gstudio001/lib/assets/types.ts
@@ -1,0 +1,95 @@
+// The provider-NEUTRAL asset model — what the asset panel, the palette, and
+// the /api/assets surface speak. Nothing above this seam names Cloudinary,
+// S3, or any other backend; a provider adapter's whole job is to translate
+// its vendor's listing into these shapes (see ./provider.ts).
+//
+// Isomorphic on purpose: client components render `Asset`s, so this module
+// must import nothing server-only.
+
+export type AssetKind = "image" | "video";
+
+/** A source-of-truth reference to an asset in its provider's own terms —
+ *  ALSO recorded on clips minted from an asset (`sourceAsset` on the stored
+ *  model), so a clip can always say where its media came from even after
+ *  URLs change or the provider is re-configured. */
+export type AssetSourceRef = Readonly<{
+  /** Registry id of the provider ("cloudinary", "s3", …). */
+  providerId: string;
+  /** The provider's own id for the asset (public id, object key, …). */
+  assetId: string;
+}>;
+
+export type Asset = Readonly<{
+  /** The provider's own id — unique within that provider only. Pair with
+   *  `providerId` (an `AssetSourceRef`) anywhere two providers can meet. */
+  id: string;
+  providerId: string;
+  /** Display name — the basename, not a path. */
+  name: string;
+  kind: AssetKind;
+  /** Directly usable media URL. */
+  src: string;
+  /** Small preview image URL (a poster frame for videos). */
+  thumbnailUrl: string;
+  /** REAL containment hierarchy, root = []. Providers without folders always
+   *  report []. */
+  folderPath: readonly string[];
+  /** Flat labels; a "/" inside a tag is the pseudo-hierarchy separator the
+   *  tags browse mode nests on. Providers without tags report []. */
+  tags: readonly string[];
+  width?: number;
+  height?: number;
+  /** Videos only. */
+  durationSeconds?: number;
+  bytes?: number;
+  createdAt?: string;
+}>;
+
+export type AssetFolder = Readonly<{
+  /** Display name of this folder (its last path segment). */
+  name: string;
+  /** Full path from the root, ending in `name`. */
+  path: readonly string[];
+}>;
+
+export type AssetQuery = Readonly<{
+  /**
+   * Folder to browse. `undefined` = the FLAT listing (every asset, no
+   * folder scoping — today's palette behaviour); `[]` = the root folder's
+   * direct children; deeper arrays scope to that folder. Distinct on
+   * purpose: flat is a view, root is a place.
+   */
+  folder?: readonly string[];
+  /** Require every listed tag (capability-gated). */
+  tags?: readonly string[];
+  /** Free-text filter (capability-gated). */
+  search?: string;
+  cursor?: string;
+  limit?: number;
+}>;
+
+export type AssetPage = Readonly<{
+  assets: readonly Asset[];
+  /** Direct subfolders of the queried folder (or the top-level folders for
+   *  the flat/root listing) — the rows a browse UI renders above assets. */
+  folders: readonly AssetFolder[];
+  nextCursor?: string;
+}>;
+
+/** What a provider can actually do — the UI renders only what's true here,
+ *  so "any third party" degrades gracefully instead of breaking: a provider
+ *  without folders gets a flat panel, one without upload gets no drop zone. */
+export type AssetProviderCapabilities = Readonly<{
+  folders: boolean;
+  tags: boolean;
+  search: boolean;
+  upload: boolean;
+  delete: boolean;
+}>;
+
+export type AssetProviderDescriptor = Readonly<{
+  id: string;
+  /** Human label for the provider picker ("Cloudinary", "S3 — media bucket"). */
+  label: string;
+  capabilities: AssetProviderCapabilities;
+}>;

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -196,30 +196,41 @@ async function installGraphApi(
     }),
   );
 
+  // The provider-NEUTRAL /api/assets shape (lib/assets/types) — the palette
+  // reads `name`/`kind`/`src`/`durationSeconds`, never a vendor field.
   await page.route("**/api/assets**", (route) =>
     route.fulfill({
       json: {
+        providerId: "cloudinary",
+        capabilities: { folders: true, tags: false, search: false, upload: false, delete: false },
+        folders: [],
         assets: [
           {
             id: "img-1",
-            pathname: "fixtures/sunset.jpg",
-            url: PIXEL,
+            providerId: "cloudinary",
+            name: "sunset.jpg",
+            kind: "image",
+            src: PIXEL,
             thumbnailUrl: PIXEL,
-            resourceType: "image",
+            folderPath: ["fixtures"],
+            tags: [],
             width: 1600,
             height: 900,
           },
           {
             id: "vid-1",
-            pathname: "fixtures/clip.mp4",
-            url: PIXEL,
+            providerId: "cloudinary",
+            name: "clip.mp4",
+            kind: "video",
+            src: PIXEL,
             thumbnailUrl: PIXEL,
-            resourceType: "video",
+            folderPath: ["fixtures"],
+            tags: [],
             width: 1920,
             height: 1080,
-            // Real duration from the Cloudinary Search API listing — a
-            // dropped video must land at this length, not the 8s default.
-            duration: 12.4,
+            // Real duration from the provider listing — a dropped video must
+            // land at this length, not the 8s default.
+            durationSeconds: 12.4,
           },
         ],
       },
@@ -1114,6 +1125,13 @@ test.describe("graph view E2E", () => {
     expect(persisted).toBeDefined();
     expect(persisted?.kind).toBe("image");
     expect(persisted?.src).toBe(PIXEL);
+    // …and the PROVENANCE: which provider file this clip is, not just the
+    // URL it renders by — the whole chain (palette detail → parked → add
+    // patch → persisted write) has to carry it for it to appear here.
+    expect((persisted as { sourceAsset?: unknown }).sourceAsset).toEqual({
+      providerId: "cloudinary",
+      assetId: "img-1",
+    });
 
     // A VIDEO asset lands at its REAL listed duration, not the default.
     await holdDrag(

--- a/docs/asset-providers.md
+++ b/docs/asset-providers.md
@@ -1,0 +1,76 @@
+# Asset providers
+
+The asset panel is provider-agnostic. Everything above the seam —
+`/api/assets`, the graph palette, the (future) panel UI — speaks the neutral
+shapes in `apps/timeline-gstudio001/lib/assets/types.ts`; a backend joins by
+implementing one interface and registering one line.
+
+## The seam
+
+- **`Asset` / `AssetFolder` / `AssetPage` / `AssetQuery`** (`lib/assets/types.ts`)
+  — the neutral model. Isomorphic: client components render these.
+- **`AssetProvider`** (`lib/assets/provider.ts`) — `descriptor + list(ctx, query)`.
+  `ctx` carries the signed-in uid today; per-user OAuth credentials
+  (Drive/Dropbox) arrive there when that track lands.
+- **`assetProviders`** (`lib/assets/registry.ts`) — the server-only instance.
+  Registration order is preference order; the first entry answers requests
+  that name no provider. Adding a provider = one adapter file + one entry.
+
+**Capabilities are the degradation contract.** Each provider declares
+`{ folders, tags, search, upload, delete }` and the UI renders only what is
+true — a provider without folders gets a flat panel, one without upload gets
+no drop zone. Declare a capability only when `list()` (etc.) actually honours
+it. Providers must *ignore* query fields outside their capabilities, never
+throw: capabilities gate the UI, not the wire.
+
+**Identity.** `Asset.id` is the provider's own durable id (Cloudinary public
+id, S3 object key). Anywhere two providers can meet, pair it with
+`providerId` — that pair is `AssetSourceRef`, and it is **recorded on every
+clip minted from an asset** (`sourceAsset` on the stored model, round-tripped
+through the graph's details side-table like `poster`). `src` is how a clip
+renders; `sourceAsset` is what it is — the hook for re-linking, usage
+queries, and safe deletion later.
+
+## Wire protocol
+
+`GET /api/assets?provider=<id>&folder=<seg>&folder=<seg>&browse=1&limit=<n>`
+
+- `folder` repeats one param per **path segment**, so a segment containing
+  `/` can never fake a boundary (NodeId lesson: assume ids contain your
+  delimiter).
+- No `folder`/`browse` → the **flat** listing (every asset — today's palette
+  view). `browse=1` alone → the **root** folder. Flat is a view; root is a
+  place.
+- Response: `{ providerId, capabilities, assets, folders, nextCursor? }`.
+
+`GET /api/assets/providers` → `{ providers: AssetProviderDescriptor[] }` for
+the picker.
+
+## Hierarchy and tags
+
+Both browse modes reduce to a path of segments, so one breadcrumb/list UI
+serves both; only the source differs:
+
+- **Folders** — real containment (`Asset.folderPath`). Path-based backends
+  (Cloudinary public ids, S3 keys) derive browsing from key prefixes via the
+  shared `pageFromFlatListing` (`lib/assets/path-folders.ts`); a provider
+  with a native prefix/delimiter query should translate `AssetQuery` into it
+  and skip the in-memory fallback.
+- **Tags** — flat labels on `Asset.tags`; a `/` inside a tag is the
+  pseudo-hierarchy separator the tags browse mode nests on (`scene/heist`).
+
+## Phasing
+
+1. ✅ Seam + Cloudinary adapter + neutral API + `sourceAsset` provenance
+   (this document's landing change).
+2. Folder browsing UI (breadcrumb + folder rows + drill-in in the palette).
+3. Tags mode (Cloudinary listing gains tags; Folders/Tags toggle,
+   capability-gated).
+4. **S3 adapter** (decided: the second provider) + provider picker; upload/
+   delete through the seam.
+5. Retire the legacy drawer's bespoke virtual-timeline folder pipeline
+   (`/api/timelines/asset-library-*`) onto the seam.
+
+Out of scope until its own track: per-user OAuth providers (token storage,
+refresh, connect/disconnect UI). The `AssetContext` parameter is where those
+credentials will arrive; nothing above the seam changes.

--- a/packages/timeline-domain/src/adapter.test.ts
+++ b/packages/timeline-domain/src/adapter.test.ts
@@ -278,6 +278,29 @@ describe("graphChildrenToClips (round-trip)", () => {
       expect(col.itemCount).toBe(2);
     }
   });
+
+  it("round-trips a media clip's sourceAsset provenance through the side-table", () => {
+    // The asset panel records which provider file a clip came from; the
+    // engine never models it, so hydration must park it in the details
+    // side-table and the write path must put it back — like poster, and
+    // like poster it must NOT appear on clips that never had it.
+    const sourceAsset = { providerId: "cloudinary", assetId: "gstudio/u/pic-1" };
+    const doc = {
+      id: "prov-root",
+      title: "Provenance",
+      clips: [
+        { ...image("with-ref", 4), sourceAsset },
+        image("without-ref", 4),
+      ],
+    };
+    const result = buildFocusedGraph({ "prov-root": doc }, "prov-root");
+    if (!result.ok) throw new Error(result.error);
+    expect(result.value.details["with-ref"]?.sourceAsset).toEqual(sourceAsset);
+
+    const projected = graphChildrenToClips(result.value.graph, result.value.details, "prov-root");
+    expect(projected[0]).toMatchObject({ id: "with-ref", sourceAsset });
+    expect("sourceAsset" in projected[1]).toBe(false);
+  });
 });
 
 describe("against the app's real initial documents", () => {

--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -31,6 +31,7 @@ import {
 } from "@storyboard/timeline-model/constants";
 import { previewItemsFrom } from "@storyboard/timeline-model/documents";
 import type {
+  AssetSourceRef,
   CollectionTimelineClip,
   TimelineClip,
   TimelineDocument,
@@ -66,6 +67,9 @@ export type ClipDetail = Readonly<{
    *  collection clip (node id = childTimelineId), and any DEMOTED duplicate
    *  media clip. The write path round-trips it. */
   sourceClipId?: string;
+  /** Which asset-provider file this media clip came from — pure provenance
+   *  (the engine never reads it), round-tripped like poster. */
+  sourceAsset?: AssetSourceRef;
   itemCount?: number;
   previewItems?: CollectionTimelineClip["previewItems"];
   /** The collection clip's own display duration in its parent timeline. */
@@ -126,6 +130,7 @@ function mediaDetail(clip: Exclude<TimelineClip, CollectionTimelineClip>): ClipD
     aspect: clip.aspect,
     trackIndex: clip.trackIndex,
     ...(clip.poster === undefined ? {} : { poster: clip.poster }),
+    ...(clip.sourceAsset === undefined ? {} : { sourceAsset: clip.sourceAsset }),
     ...(clip.playbackStartTime === undefined ? {} : { playbackStartTime: clip.playbackStartTime }),
     ...(clip.playbackDuration === undefined ? {} : { playbackDuration: clip.playbackDuration }),
     ...(clip.kind === "image"
@@ -455,6 +460,7 @@ export function graphChildrenToClips(
         ...(detail?.playbackDuration === undefined
           ? {}
           : { playbackDuration: detail.playbackDuration }),
+        ...(detail?.sourceAsset === undefined ? {} : { sourceAsset: detail.sourceAsset }),
       };
       if (node.mediaKind === "video") {
         return {

--- a/packages/timeline-model/types.ts
+++ b/packages/timeline-model/types.ts
@@ -49,16 +49,29 @@ export type TimelineItemBase = {
   viewCollectionAccentIndex?: number;
 };
 
+/** Where a media clip's file came from: the asset provider that owns it and
+ *  that provider's own id for it. Recorded when a clip is minted from the
+ *  asset panel so the file stays identifiable across URL changes, provider
+ *  re-configuration, and future re-linking — `src` is how the clip RENDERS,
+ *  this is what the clip IS. Absent on clips that predate it and on media
+ *  that never came through a provider (direct OS drops). */
+export type AssetSourceRef = {
+  providerId: string;
+  assetId: string;
+};
+
 export type ImageTimelineClip = TimelineItemBase & {
   kind: "image";
   src: string;
   poster?: string;
+  sourceAsset?: AssetSourceRef;
 };
 
 export type VideoTimelineClip = TimelineItemBase & {
   kind: "video";
   src: string;
   poster?: string;
+  sourceAsset?: AssetSourceRef;
 };
 
 export type MediaTimelineClip = ImageTimelineClip | VideoTimelineClip;

--- a/packages/timeline-model/validate.test.ts
+++ b/packages/timeline-model/validate.test.ts
@@ -58,6 +58,19 @@ describe("isTimelineClip", () => {
     expect(isTimelineClip({ ...video, poster: null })).toBe(true);
     expect(isTimelineClip({ ...collection, previewItems: null })).toBe(true);
     expect(isTimelineClip({ ...image, playbackStartTime: null })).toBe(true);
+    expect(isTimelineClip({ ...image, sourceAsset: null })).toBe(true);
+  });
+
+  it("accepts a whole sourceAsset ref and rejects a half-recorded one", () => {
+    const ref = { providerId: "cloudinary", assetId: "gstudio/u/pic-1" };
+    expect(isTimelineClip({ ...image, sourceAsset: ref })).toBe(true);
+    expect(isTimelineClip({ ...video, sourceAsset: ref })).toBe(true);
+    // Half a ref would send re-resolution to the wrong provider — worse
+    // than none, so it fails the clip.
+    expect(isTimelineClip({ ...image, sourceAsset: { providerId: "cloudinary" } })).toBe(false);
+    expect(isTimelineClip({ ...image, sourceAsset: { providerId: "", assetId: "x" } })).toBe(false);
+    expect(isTimelineClip({ ...image, sourceAsset: { providerId: "p", assetId: "" } })).toBe(false);
+    expect(isTimelineClip({ ...image, sourceAsset: "cloudinary:pic-1" })).toBe(false);
   });
 
   it("rejects the shapes the shallow guard let through", () => {

--- a/packages/timeline-model/validate.ts
+++ b/packages/timeline-model/validate.ts
@@ -21,6 +21,21 @@ function isOptionalFiniteNumber(value: unknown): boolean {
   return value == null || isFiniteNumber(value);
 }
 
+/** Same null leniency as every optional field; when present, BOTH halves of
+ *  the ref must be non-empty strings — a half-recorded source is worse than
+ *  none, since re-resolution would query the wrong provider. */
+function isOptionalAssetSourceRef(value: unknown): boolean {
+  if (value == null) return true;
+  if (typeof value !== "object") return false;
+  const ref = value as Record<string, unknown>;
+  return (
+    typeof ref.providerId === "string" &&
+    ref.providerId.length > 0 &&
+    typeof ref.assetId === "string" &&
+    ref.assetId.length > 0
+  );
+}
+
 function hasClipBase(clip: Record<string, unknown>): boolean {
   return (
     typeof clip.id === "string" &&
@@ -45,7 +60,11 @@ export function isTimelineClip(value: unknown): value is TimelineClip {
   if (!hasClipBase(clip)) return false;
 
   if (clip.kind === "image" || clip.kind === "video") {
-    return typeof clip.src === "string" && isOptionalString(clip.poster);
+    return (
+      typeof clip.src === "string" &&
+      isOptionalString(clip.poster) &&
+      isOptionalAssetSourceRef(clip.sourceAsset)
+    );
   }
 
   if (clip.kind === "collection") {


### PR DESCRIPTION
Punch-list item **4**, first slice of the epic. Design doc: `docs/asset-providers.md`. Decisions baked in: **S3 is the second provider** (phase 4), and **clips record `providerId` + `assetId`** from day one.

### The seam (`lib/assets/`)

Provider-neutral `Asset` / `AssetFolder` / `AssetPage` / `AssetQuery` types (isomorphic — client components render them), an `AssetProvider` interface (`descriptor + list(ctx, query)`), and a registry whose registration order is preference order.

**Capabilities are the degradation contract**: each provider declares `{folders, tags, search, upload, delete}` and the UI renders only what's true — an arbitrary third party degrades to what it can do instead of breaking. `AssetContext` carries the uid today and is where per-user OAuth credentials (Drive/Dropbox) arrive when that track lands.

### Cloudinary behind it

Maps the vendor listing to the neutral shape — folders from `relativePath`, so the tree is what the **user** sees, not the `<root>/<uid>/` storage plumbing. Folder scoping + folder-row derivation live in a shared `pageFromFlatListing` that any path-keyed backend (S3 keys) reuses; a native prefix query is the documented upgrade path. Declares only what it honours today: folders on, everything else off.

### The API

`/api/assets`: `?provider=` (default = first registered), `?folder=` repeated **per segment** (a segment containing `/` can never fake a boundary — the NodeId lesson), `?browse=1` = the root folder, absence = the flat listing. *Flat is a view; root is a place.* Unknown provider → 404. New `/api/assets/providers` serves descriptors for the picker.

### Provenance

Media clips minted from an asset record `sourceAsset: {providerId, assetId}` — `src` is how a clip renders, this is what it **is** (the hook for re-linking, usage queries, safe deletion). Round-tripped through the graph's details side-table like `poster`; validated at the API boundary (a *half*-recorded ref fails the clip — it would send re-resolution to the wrong provider); recorded by **both** mint paths (graph palette + the legacy virtual-timeline route). The legacy drawer's local Cloudinary type and clip-minting helper turned out to be dead code — deleted.

### Tests

path-folders (flat/root/deep, direct-children-only, same-name-two-depths), registry, Cloudinary mapping + scoping, the real route handler (shape, folder params, browse, 404, 401), adapter round-trip (**proven fail-first**), model validation, and the palette e2e now pins `sourceAsset` on the *persisted* clip — the whole palette → parked detail → add patch → write chain.

**Live-verified against the real account**: 38 assets flat / 21 at root with real folders derived ("Foobar 001", "Winterhill Gang", …), palette renders all 38, legacy drawer loads, freshly-minted library clips carry `sourceAsset`.

App vitest 246/246 · unit 519/519 · app+ui `tsc` clean · lint clean (4 pre-existing `img` warnings) · e2e 56 passed + the known load-dependent flake green in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
