### PR TITLE
Asset panel phase 2: folder browsing in the palette

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-asset-palette.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-asset-palette.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { Folder as FolderIcon } from "lucide-react";
 
 import {
   PaletteItem,
@@ -13,7 +14,7 @@ import {
 
 import { Button } from "@/components/core/button";
 import { useBottomDrawerInset } from "@/components/assets/use-bottom-drawer-inset";
-import type { Asset } from "@/lib/assets/types";
+import type { Asset, AssetFolder } from "@/lib/assets/types";
 
 import { clearPendingDetails, parkPendingDetail } from "./graph-pending-details";
 
@@ -66,12 +67,104 @@ function createNodeFromAsset(asset: Asset): CollectionItemNode {
   };
 }
 
+type PalettePage = Readonly<{
+  assets: readonly Asset[];
+  folders: readonly AssetFolder[];
+  truncated: boolean;
+}>;
+
 type AssetPaletteState =
   | Readonly<{ status: "loading" }>
   | Readonly<{ status: "error"; message: string }>
-  | Readonly<{ status: "ready"; assets: readonly Asset[]; truncated: boolean }>;
+  | (Readonly<{ status: "ready" }> & PalettePage);
 
-function PaletteRail({ assets }: Readonly<{ assets: readonly Asset[] }>) {
+/**
+ * A folder tile in the rail — same footprint as an asset thumbnail so the
+ * rail scans as one row, but a plain BUTTON, not a PaletteItem: folders are
+ * navigation, not draggable media, and making them drag sources would hand
+ * dnd-kit a node factory with nothing to mint.
+ */
+function FolderTile({
+  folder,
+  onOpen,
+}: Readonly<{ folder: AssetFolder; onOpen: (path: readonly string[]) => void }>) {
+  return (
+    <button
+      type="button"
+      data-palette-folder={folder.name}
+      aria-label={`Open folder ${folder.name}`}
+      onClick={() => onOpen(folder.path)}
+      className="flex h-24 w-36 shrink-0 flex-col items-center justify-center gap-1.5 rounded-md border border-zinc-800 bg-zinc-900/60 px-2 text-zinc-400 transition-colors hover:border-sky-500/50 hover:bg-zinc-900 hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+    >
+      <FolderIcon aria-hidden="true" className="h-6 w-6" />
+      <span className="w-full truncate text-center text-[10px] font-semibold text-zinc-300">
+        {folder.name}
+      </span>
+    </button>
+  );
+}
+
+/**
+ * Where you are, and the way back up: Assets / segment / segment. Every
+ * ancestor is a button; the CURRENT folder is text (there is nowhere to go
+ * by clicking where you already are). At the root this renders as the plain
+ * heading it always was — a provider without folders never grows crumbs, so
+ * the degradation contract costs nothing here.
+ */
+function FolderBreadcrumb({
+  path,
+  onNavigate,
+}: Readonly<{ path: readonly string[]; onNavigate: (path: readonly string[]) => void }>) {
+  if (path.length === 0) {
+    return (
+      <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">Assets</h3>
+    );
+  }
+  return (
+    <nav aria-label="Asset folders" className="flex min-w-0 items-center gap-1 text-xs">
+      <button
+        type="button"
+        onClick={() => onNavigate([])}
+        className="shrink-0 font-semibold uppercase tracking-[0.14em] text-zinc-400 hover:text-sky-300"
+      >
+        Assets
+      </button>
+      {path.map((segment, index) => {
+        const isCurrent = index === path.length - 1;
+        return (
+          <span key={index} className="flex min-w-0 items-center gap-1">
+            <span aria-hidden="true" className="shrink-0 text-zinc-700">
+              /
+            </span>
+            {isCurrent ? (
+              <span aria-current="page" className="truncate font-semibold text-zinc-200">
+                {segment}
+              </span>
+            ) : (
+              <button
+                type="button"
+                onClick={() => onNavigate(path.slice(0, index + 1))}
+                className="truncate text-zinc-400 hover:text-sky-300"
+              >
+                {segment}
+              </button>
+            )}
+          </span>
+        );
+      })}
+    </nav>
+  );
+}
+
+function PaletteRail({
+  assets,
+  folders,
+  onOpenFolder,
+}: Readonly<{
+  assets: readonly Asset[];
+  folders: readonly AssetFolder[];
+  onOpenFolder: (path: readonly string[]) => void;
+}>) {
   const store = useCollectionsStore();
   const railRef = useRef<HTMLDivElement>(null);
   const panOptions = useMemo<Parameters<typeof usePanWithMomentum>[2]>(
@@ -87,6 +180,12 @@ function PaletteRail({ assets }: Readonly<{ assets: readonly Asset[] }>) {
       className="flex cursor-grab gap-2 overflow-x-auto pb-1 select-none active:cursor-grabbing"
       style={{ touchAction: "pan-y" }}
     >
+      {/* Folders lead the rail — places before things, the file-browser
+          convention — and they come from the same listing response, so a
+          provider without folders simply contributes none. */}
+      {folders.map((folder) => (
+        <FolderTile key={folder.name} folder={folder} onOpen={onOpenFolder} />
+      ))}
       {assets.map((asset) => (
         <PaletteItem
           key={asset.id}
@@ -121,7 +220,23 @@ export function AssetPaletteDrawer({
   onClose: () => void;
 }>) {
   const [state, setState] = useState<AssetPaletteState>({ status: "loading" });
+  // The folder being browsed. [] is the ROOT, not the flat listing — the
+  // drawer always browses (`?browse=1`): a provider with folders opens
+  // organized instead of jumbled, and one without simply reports no folders
+  // and the same view IS its flat listing. Survives close/reopen (this
+  // component stays mounted), like the preview pane's height.
+  const [path, setPath] = useState<readonly string[]>([]);
+  // Visited folders answer instantly on the way back up; a provider fetch
+  // per crumb-click would make the breadcrumb feel broken. Retry bypasses it
+  // (the effect always network-fetches when loading), so a stale entry heals.
+  const pageCacheRef = useRef(new Map<string, PalettePage>());
   const panelRef = useRef<HTMLElement | null>(null);
+
+  const navigateTo = useCallback((next: readonly string[]) => {
+    setPath(next);
+    const cached = pageCacheRef.current.get(JSON.stringify(next));
+    setState(cached ? { status: "ready", ...cached } : { status: "loading" });
+  }, []);
   // This panel is FIXED to the bottom of the viewport and non-modal — the
   // board behind it stays live, and you drag out of it onto that board. So
   // the page has to be able to scroll its own content clear of it; without
@@ -140,9 +255,15 @@ export function AssetPaletteDrawer({
     let cancelled = false;
     void (async () => {
       try {
-        const response = await fetch("/api/assets", { cache: "no-store" });
+        // browse=1 names the ROOT when the path is empty; one `folder` param
+        // per segment (never a joined string — a segment containing "/" must
+        // not fake a boundary).
+        const params = new URLSearchParams({ browse: "1" });
+        for (const segment of path) params.append("folder", segment);
+        const response = await fetch(`/api/assets?${params}`, { cache: "no-store" });
         const result = (await response.json().catch(() => ({}))) as {
           assets?: Asset[];
+          folders?: AssetFolder[];
           error?: string;
         };
         if (cancelled) return;
@@ -150,11 +271,13 @@ export function AssetPaletteDrawer({
           setState({ status: "error", message: result.error ?? "Could not load assets." });
           return;
         }
-        setState({
-          status: "ready",
+        const page: PalettePage = {
           assets: result.assets.slice(0, PALETTE_ASSET_LIMIT),
+          folders: result.folders ?? [],
           truncated: result.assets.length > PALETTE_ASSET_LIMIT,
-        });
+        };
+        pageCacheRef.current.set(JSON.stringify(path), page);
+        setState({ status: "ready", ...page });
       } catch (cause) {
         if (!cancelled) {
           setState({
@@ -167,7 +290,7 @@ export function AssetPaletteDrawer({
     return () => {
       cancelled = true;
     };
-  }, [open, state.status]);
+  }, [open, state.status, path]);
 
   if (!open || typeof document === "undefined") return null;
 
@@ -184,10 +307,8 @@ export function AssetPaletteDrawer({
         className="pointer-events-auto ml-[72px] flex max-h-[38vh] flex-col border-t border-zinc-800 bg-zinc-950 p-3 text-white shadow-2xl shadow-black/50"
       >
         <div className="mb-2 flex items-center gap-3">
-          <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">
-            Assets
-          </h3>
-          <span className="text-[10px] text-zinc-600">
+          <FolderBreadcrumb path={path} onNavigate={navigateTo} />
+          <span className="shrink-0 text-[10px] text-zinc-600">
             Drag a thumbnail into any timeline · Enter picks one up for keyboard placement
           </span>
           <span className="grow" />
@@ -222,13 +343,19 @@ export function AssetPaletteDrawer({
         )}
 
         {state.status === "ready" &&
-          (state.assets.length === 0 ? (
+          (state.assets.length === 0 && state.folders.length === 0 ? (
             <p className="rounded-md border border-zinc-800 px-3 py-2 text-xs text-zinc-500">
-              No assets yet — upload some from the asset library on the storyboard view.
+              {path.length === 0
+                ? "No assets yet — upload some from the asset library on the storyboard view."
+                : "This folder is empty."}
             </p>
           ) : (
             <>
-              <PaletteRail assets={state.assets} />
+              <PaletteRail
+                assets={state.assets}
+                folders={state.folders}
+                onOpenFolder={navigateTo}
+              />
               {state.truncated && (
                 <p className="mt-1 text-[10px] text-zinc-600">
                   Showing the newest {PALETTE_ASSET_LIMIT} assets — the full library is on the

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -197,45 +197,62 @@ async function installGraphApi(
   );
 
   // The provider-NEUTRAL /api/assets shape (lib/assets/types) — the palette
-  // reads `name`/`kind`/`src`/`durationSeconds`, never a vendor field.
-  await page.route("**/api/assets**", (route) =>
-    route.fulfill({
+  // reads `name`/`kind`/`src`/`durationSeconds`, never a vendor field. The
+  // mock SCOPES by the request's folder params exactly like the server's
+  // pageFromFlatListing, so the palette's browse UI is exercised against
+  // coherent pages: img-1 lives at the ROOT, vid-1 inside "fixtures".
+  const paletteAssets = [
+    {
+      id: "img-1",
+      providerId: "cloudinary",
+      name: "sunset.jpg",
+      kind: "image",
+      src: PIXEL,
+      thumbnailUrl: PIXEL,
+      folderPath: [] as string[],
+      tags: [],
+      width: 1600,
+      height: 900,
+    },
+    {
+      id: "vid-1",
+      providerId: "cloudinary",
+      name: "clip.mp4",
+      kind: "video",
+      src: PIXEL,
+      thumbnailUrl: PIXEL,
+      folderPath: ["fixtures"],
+      tags: [],
+      width: 1920,
+      height: 1080,
+      // Real duration from the provider listing — a dropped video must
+      // land at this length, not the 8s default.
+      durationSeconds: 12.4,
+    },
+  ];
+  await page.route("**/api/assets**", (route) => {
+    const url = new URL(route.request().url());
+    const folder = url.searchParams.getAll("folder");
+    const inFolder = (path: string[]) =>
+      path.length === folder.length && folder.every((seg, i) => path[i] === seg);
+    const subfolderNames = new Set(
+      paletteAssets
+        .filter(
+          (asset) =>
+            asset.folderPath.length > folder.length &&
+            folder.every((seg, i) => asset.folderPath[i] === seg),
+        )
+        .map((asset) => asset.folderPath[folder.length]),
+    );
+    return route.fulfill({
       json: {
         providerId: "cloudinary",
         capabilities: { folders: true, tags: false, search: false, upload: false, delete: false },
-        folders: [],
-        assets: [
-          {
-            id: "img-1",
-            providerId: "cloudinary",
-            name: "sunset.jpg",
-            kind: "image",
-            src: PIXEL,
-            thumbnailUrl: PIXEL,
-            folderPath: ["fixtures"],
-            tags: [],
-            width: 1600,
-            height: 900,
-          },
-          {
-            id: "vid-1",
-            providerId: "cloudinary",
-            name: "clip.mp4",
-            kind: "video",
-            src: PIXEL,
-            thumbnailUrl: PIXEL,
-            folderPath: ["fixtures"],
-            tags: [],
-            width: 1920,
-            height: 1080,
-            // Real duration from the provider listing — a dropped video must
-            // land at this length, not the 8s default.
-            durationSeconds: 12.4,
-          },
-        ],
+        folders: [...subfolderNames].map((name) => ({ name, path: [...folder, name] })),
+        assets: paletteAssets.filter((asset) => inFolder(asset.folderPath)),
       },
-    }),
-  );
+    });
+  });
 
   // Two-segment path, so the generic single-segment mock below never sees it.
   await page.route("**/api/timelines/*/preview-manifest", (route) => {
@@ -1133,7 +1150,10 @@ test.describe("graph view E2E", () => {
       assetId: "img-1",
     });
 
-    // A VIDEO asset lands at its REAL listed duration, not the default.
+    // A VIDEO asset lands at its REAL listed duration, not the default. It
+    // lives inside a folder now — drill in through the real tile first.
+    await drawer.locator('[data-palette-folder="fixtures"]').click();
+    await expect(drawer.locator('[data-palette-item="asset-vid-1"]')).toBeVisible();
     await holdDrag(
       page,
       drawer.locator('[data-palette-item="asset-vid-1"]'),
@@ -1150,6 +1170,39 @@ test.describe("graph view E2E", () => {
     expect(video?.kind).toBe("video");
     expect(video?.sourceDuration).toBe(12.4);
     expect(video?.duration).toBe(12.4); // untrimmed: full source length
+  });
+
+  test("palette folders: root shows tiles, drill-in scopes, the breadcrumb climbs back", async ({
+    page,
+  }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    await assetsButton(page).click();
+    const drawer = page.getByRole("dialog", { name: "Asset palette" });
+
+    // ROOT: the root asset and the folder tile — never the folder's contents
+    // (an asset deeper than the browsed folder appears only through its
+    // folder row; that is what makes drill-in mean something).
+    await expect(drawer.locator('[data-palette-item="asset-img-1"]')).toBeVisible();
+    await expect(drawer.locator('[data-palette-folder="fixtures"]')).toBeVisible();
+    await expect(drawer.locator('[data-palette-item="asset-vid-1"]')).toHaveCount(0);
+
+    // DRILL IN: the folder's assets replace the root's, and the breadcrumb
+    // grows a crumb — the current folder as text, the root as a button.
+    await drawer.locator('[data-palette-folder="fixtures"]').click();
+    await expect(drawer.locator('[data-palette-item="asset-vid-1"]')).toBeVisible();
+    await expect(drawer.locator('[data-palette-item="asset-img-1"]')).toHaveCount(0);
+    const breadcrumb = drawer.getByRole("navigation", { name: "Asset folders" });
+    await expect(breadcrumb.getByText("fixtures")).toBeVisible();
+
+    // CLIMB BACK via the root crumb: the root page returns (from the cache —
+    // no spinner state to wait through, but the assertion is on content, so
+    // either path passes only if the page is RIGHT).
+    await breadcrumb.getByRole("button", { name: "Assets" }).click();
+    await expect(drawer.locator('[data-palette-item="asset-img-1"]')).toBeVisible();
+    await expect(drawer.locator('[data-palette-item="asset-vid-1"]')).toHaveCount(0);
+    // At the root the header is the plain heading again — no navigation.
+    await expect(drawer.getByRole("navigation", { name: "Asset folders" })).toHaveCount(0);
   });
 
   test("trash drop moves across roots, persists BOTH documents, and undoes", async ({

--- a/docs/asset-providers.md
+++ b/docs/asset-providers.md
@@ -63,7 +63,10 @@ serves both; only the source differs:
 
 1. ✅ Seam + Cloudinary adapter + neutral API + `sourceAsset` provenance
    (this document's landing change).
-2. Folder browsing UI (breadcrumb + folder rows + drill-in in the palette).
+2. ✅ Folder browsing UI — the palette always browses (root on open; flat is
+   no longer a palette view), folder tiles lead the rail, the breadcrumb
+   climbs back, and visited pages answer from an in-drawer cache. A provider
+   without folders reports none and the same view IS its flat listing.
 3. Tags mode (Cloudinary listing gains tags; Folders/Tags toggle,
    capability-gated).
 4. **S3 adapter** (decided: the second provider) + provider picker; upload/


### PR DESCRIPTION
Phase 2 of the asset-panel epic (`docs/asset-providers.md`).

### What changed

The palette now **browses**: it opens at the provider's root folder, folder tiles lead the rail (places before things — the file-browser convention), clicking one drills in, and a breadcrumb (`Assets / segment / segment`) climbs back — every ancestor a button, the current folder text. Visited pages answer from an in-drawer cache so the way back up is instant instead of a provider round-trip per crumb; Retry bypasses the cache, so a stale entry heals.

**Flat is no longer a palette view** — the root is the opening page. For a provider without folders nothing changes shape: it reports no folder rows, so its root *is* its flat listing — the degradation contract costs no special casing (the breadcrumb never grows crumbs, the rail never shows tiles).

Folder tiles are plain buttons, not `PaletteItem`s: folders are navigation, not draggable media — a folder drag source would hand dnd-kit a node factory with nothing to mint. Requests send one `folder` param per **segment**, per the wire contract.

### Tests

The `installGraphApi` assets mock now scopes by the request's folder params exactly like the server's `pageFromFlatListing`, so fixture pages stay coherent (img-1 at root, vid-1 inside "fixtures"). New e2e pins root scoping (a nested asset appears only through its folder row), drill-in, breadcrumb climb, and the header reverting to a plain heading at root — **proven fail-first** (palette not sending folder params → drill-in shows nothing). The mint test now drills into a folder for its video half, so drag-from-inside-a-folder is covered where it already lived.

### Live-verified against the real account

Root = 21 assets + 4 folder tiles ("Foobar 001", "Winterhill Gang", …) · drill into Foobar 001 = 12 assets + `Assets / Foobar 001` breadcrumb · climb back restores the root from cache with the plain heading.

App vitest 246/246 · graph-view e2e 58/58 · app `tsc` clean · lint clean (4 pre-existing `img` warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
