### PR TITLE
Asset panel phase 3: tags as a browsable pseudo-hierarchy

### DIFF
--- a/apps/timeline-gstudio001/app/api/assets/assets-route.test.ts
+++ b/apps/timeline-gstudio001/app/api/assets/assets-route.test.ts
@@ -84,6 +84,23 @@ describe("GET /api/assets", () => {
     expect(body.assets.map((entry) => entry.id)).toEqual(["a"]);
   });
 
+  it("?mode=tags browses the tag pseudo-hierarchy via ?tag= segment params", async () => {
+    state.vendorAssets = [
+      { ...vendorAsset("plain", "plain.png") },
+      { ...vendorAsset("tagged", "Scenes/t.png"), tags: ["scene/heist"] },
+    ];
+    // Tags root: untagged assets + top-level tag groups (folder placement is
+    // irrelevant in tag space).
+    const root = await listAssets(request("?mode=tags"));
+    const rootBody = (await root.json()) as { assets: { id: string }[]; folders: unknown };
+    expect(rootBody.assets.map((entry) => entry.id)).toEqual(["plain"]);
+    expect(rootBody.folders).toEqual([{ name: "scene", path: ["scene"] }]);
+
+    const heist = await listAssets(request("?mode=tags&tag=scene&tag=heist"));
+    const heistBody = (await heist.json()) as { assets: { id: string }[] };
+    expect(heistBody.assets.map((entry) => entry.id)).toEqual(["tagged"]);
+  });
+
   it("404s an unknown provider by name", async () => {
     const response = await listAssets(request("?provider=nope"));
     expect(response.status).toBe(404);
@@ -106,7 +123,7 @@ describe("GET /api/assets/providers", () => {
       {
         id: "cloudinary",
         label: "Cloudinary",
-        capabilities: { folders: true, tags: false, search: false, upload: false, delete: false },
+        capabilities: { folders: true, tags: true, search: false, upload: false, delete: false },
       },
     ]);
   });

--- a/apps/timeline-gstudio001/app/api/assets/route.ts
+++ b/apps/timeline-gstudio001/app/api/assets/route.ts
@@ -15,7 +15,11 @@ export const dynamic = "force-dynamic";
  *                       segment containing "/" can never fake a boundary.
  *                       `?browse=1` with no folder params means the ROOT
  *                       folder; no browse and no folder params means the
- *                       FLAT listing (every asset — the palette's view).
+ *                       FLAT listing (every asset).
+ *   ?mode=tags          browse the TAG pseudo-hierarchy instead: `?tag=`
+ *                       params (repeatable, per segment) are the path, none
+ *                       = the tags root. `folders` rows are then tag groups
+ *                       — the client renders them identically.
  *   ?limit=<n>
  *
  * Response: { providerId, capabilities, assets, folders, nextCursor? } — the
@@ -37,11 +41,18 @@ export async function GET(request: Request) {
       );
     }
 
+    const tagsMode = url.searchParams.get("mode") === "tags";
     const folderSegments = url.searchParams.getAll("folder");
     const browsing = url.searchParams.get("browse") !== null || folderSegments.length > 0;
     const limitParam = Number(url.searchParams.get("limit"));
     const query: AssetQuery = {
-      ...(browsing ? { folder: folderSegments } : {}),
+      // Tags mode is ALWAYS a browse (no tag params = the tags root); the
+      // folder/flat distinction only exists in folders mode.
+      ...(tagsMode
+        ? { tagPath: url.searchParams.getAll("tag") }
+        : browsing
+          ? { folder: folderSegments }
+          : {}),
       ...(Number.isFinite(limitParam) && limitParam > 0 ? { limit: limitParam } : {}),
     };
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-asset-palette.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-asset-palette.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { Folder as FolderIcon } from "lucide-react";
+import { Folder as FolderIcon, Tag as TagIcon } from "lucide-react";
 
 import {
   PaletteItem,
@@ -78,25 +78,35 @@ type AssetPaletteState =
   | Readonly<{ status: "error"; message: string }>
   | (Readonly<{ status: "ready" }> & PalettePage);
 
+/** Which pseudo-hierarchy the drawer is browsing. Folders are the default;
+ *  tags appear as a toggle only when the provider declares the capability. */
+type BrowseMode = "folders" | "tags";
+
 /**
- * A folder tile in the rail — same footprint as an asset thumbnail so the
- * rail scans as one row, but a plain BUTTON, not a PaletteItem: folders are
- * navigation, not draggable media, and making them drag sources would hand
- * dnd-kit a node factory with nothing to mint.
+ * A folder (or tag-group) tile in the rail — same footprint as an asset
+ * thumbnail so the rail scans as one row, but a plain BUTTON, not a
+ * PaletteItem: these are navigation, not draggable media, and making them
+ * drag sources would hand dnd-kit a node factory with nothing to mint.
  */
 function FolderTile({
   folder,
+  mode,
   onOpen,
-}: Readonly<{ folder: AssetFolder; onOpen: (path: readonly string[]) => void }>) {
+}: Readonly<{
+  folder: AssetFolder;
+  mode: BrowseMode;
+  onOpen: (path: readonly string[]) => void;
+}>) {
+  const Icon = mode === "tags" ? TagIcon : FolderIcon;
   return (
     <button
       type="button"
       data-palette-folder={folder.name}
-      aria-label={`Open folder ${folder.name}`}
+      aria-label={`Open ${mode === "tags" ? "tag" : "folder"} ${folder.name}`}
       onClick={() => onOpen(folder.path)}
       className="flex h-24 w-36 shrink-0 flex-col items-center justify-center gap-1.5 rounded-md border border-zinc-800 bg-zinc-900/60 px-2 text-zinc-400 transition-colors hover:border-sky-500/50 hover:bg-zinc-900 hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
     >
-      <FolderIcon aria-hidden="true" className="h-6 w-6" />
+      <Icon aria-hidden="true" className="h-6 w-6" />
       <span className="w-full truncate text-center text-[10px] font-semibold text-zinc-300">
         {folder.name}
       </span>
@@ -113,11 +123,18 @@ function FolderTile({
  */
 function FolderBreadcrumb({
   path,
+  rootLabel,
   onNavigate,
-}: Readonly<{ path: readonly string[]; onNavigate: (path: readonly string[]) => void }>) {
+}: Readonly<{
+  path: readonly string[];
+  rootLabel: string;
+  onNavigate: (path: readonly string[]) => void;
+}>) {
   if (path.length === 0) {
     return (
-      <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">Assets</h3>
+      <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">
+        {rootLabel}
+      </h3>
     );
   }
   return (
@@ -127,7 +144,7 @@ function FolderBreadcrumb({
         onClick={() => onNavigate([])}
         className="shrink-0 font-semibold uppercase tracking-[0.14em] text-zinc-400 hover:text-sky-300"
       >
-        Assets
+        {rootLabel}
       </button>
       {path.map((segment, index) => {
         const isCurrent = index === path.length - 1;
@@ -159,10 +176,12 @@ function FolderBreadcrumb({
 function PaletteRail({
   assets,
   folders,
+  mode,
   onOpenFolder,
 }: Readonly<{
   assets: readonly Asset[];
   folders: readonly AssetFolder[];
+  mode: BrowseMode;
   onOpenFolder: (path: readonly string[]) => void;
 }>) {
   const store = useCollectionsStore();
@@ -184,7 +203,7 @@ function PaletteRail({
           convention — and they come from the same listing response, so a
           provider without folders simply contributes none. */}
       {folders.map((folder) => (
-        <FolderTile key={folder.name} folder={folder} onOpen={onOpenFolder} />
+        <FolderTile key={folder.name} folder={folder} mode={mode} onOpen={onOpenFolder} />
       ))}
       {assets.map((asset) => (
         <PaletteItem
@@ -231,12 +250,23 @@ export function AssetPaletteDrawer({
   // (the effect always network-fetches when loading), so a stale entry heals.
   const pageCacheRef = useRef(new Map<string, PalettePage>());
   const panelRef = useRef<HTMLElement | null>(null);
+  // Folders or tags — the SAME breadcrumb/tile machinery browses either;
+  // only the wire params and the tile icon differ. The toggle renders only
+  // once a response has declared the provider can do tags (capability-gated
+  // UI, per the seam's degradation contract).
+  const [mode, setMode] = useState<BrowseMode>("folders");
+  const [tagsAvailable, setTagsAvailable] = useState(false);
 
-  const navigateTo = useCallback((next: readonly string[]) => {
-    setPath(next);
-    const cached = pageCacheRef.current.get(JSON.stringify(next));
-    setState(cached ? { status: "ready", ...cached } : { status: "loading" });
-  }, []);
+  const navigateTo = useCallback(
+    (next: readonly string[], nextMode?: BrowseMode) => {
+      const targetMode = nextMode ?? mode;
+      setMode(targetMode);
+      setPath(next);
+      const cached = pageCacheRef.current.get(JSON.stringify([targetMode, next]));
+      setState(cached ? { status: "ready", ...cached } : { status: "loading" });
+    },
+    [mode],
+  );
   // This panel is FIXED to the bottom of the viewport and non-modal — the
   // board behind it stays live, and you drag out of it onto that board. So
   // the page has to be able to scroll its own content clear of it; without
@@ -255,15 +285,20 @@ export function AssetPaletteDrawer({
     let cancelled = false;
     void (async () => {
       try {
-        // browse=1 names the ROOT when the path is empty; one `folder` param
-        // per segment (never a joined string — a segment containing "/" must
-        // not fake a boundary).
-        const params = new URLSearchParams({ browse: "1" });
-        for (const segment of path) params.append("folder", segment);
+        // browse=1 names the ROOT when the path is empty; one param per
+        // segment (never a joined string — a segment containing "/" must
+        // not fake a boundary). Tags mode swaps the param family, nothing
+        // else: the response shape is identical.
+        const params =
+          mode === "tags"
+            ? new URLSearchParams({ mode: "tags" })
+            : new URLSearchParams({ browse: "1" });
+        for (const segment of path) params.append(mode === "tags" ? "tag" : "folder", segment);
         const response = await fetch(`/api/assets?${params}`, { cache: "no-store" });
         const result = (await response.json().catch(() => ({}))) as {
           assets?: Asset[];
           folders?: AssetFolder[];
+          capabilities?: { tags?: boolean };
           error?: string;
         };
         if (cancelled) return;
@@ -276,7 +311,8 @@ export function AssetPaletteDrawer({
           folders: result.folders ?? [],
           truncated: result.assets.length > PALETTE_ASSET_LIMIT,
         };
-        pageCacheRef.current.set(JSON.stringify(path), page);
+        pageCacheRef.current.set(JSON.stringify([mode, path]), page);
+        setTagsAvailable(result.capabilities?.tags === true);
         setState({ status: "ready", ...page });
       } catch (cause) {
         if (!cancelled) {
@@ -290,7 +326,7 @@ export function AssetPaletteDrawer({
     return () => {
       cancelled = true;
     };
-  }, [open, state.status, path]);
+  }, [open, state.status, path, mode]);
 
   if (!open || typeof document === "undefined") return null;
 
@@ -307,7 +343,38 @@ export function AssetPaletteDrawer({
         className="pointer-events-auto ml-[72px] flex max-h-[38vh] flex-col border-t border-zinc-800 bg-zinc-950 p-3 text-white shadow-2xl shadow-black/50"
       >
         <div className="mb-2 flex items-center gap-3">
-          <FolderBreadcrumb path={path} onNavigate={navigateTo} />
+          <FolderBreadcrumb
+            path={path}
+            rootLabel={mode === "tags" ? "Tags" : "Assets"}
+            onNavigate={navigateTo}
+          />
+          {tagsAvailable && (
+            <div
+              role="group"
+              aria-label="Browse assets by"
+              className="flex shrink-0 overflow-hidden rounded-md border border-zinc-800"
+            >
+              {(["folders", "tags"] as const).map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  aria-pressed={mode === option}
+                  onClick={() => {
+                    // Switching hierarchies starts at the new one's root —
+                    // a folder path means nothing in tag space.
+                    if (mode !== option) navigateTo([], option);
+                  }}
+                  className={
+                    mode === option
+                      ? "bg-zinc-800 px-2 py-0.5 text-[10px] font-semibold text-zinc-100"
+                      : "px-2 py-0.5 text-[10px] font-semibold text-zinc-500 hover:text-zinc-200"
+                  }
+                >
+                  {option === "folders" ? "Folders" : "Tags"}
+                </button>
+              ))}
+            </div>
+          )}
           <span className="shrink-0 text-[10px] text-zinc-600">
             Drag a thumbnail into any timeline · Enter picks one up for keyboard placement
           </span>
@@ -346,14 +413,19 @@ export function AssetPaletteDrawer({
           (state.assets.length === 0 && state.folders.length === 0 ? (
             <p className="rounded-md border border-zinc-800 px-3 py-2 text-xs text-zinc-500">
               {path.length === 0
-                ? "No assets yet — upload some from the asset library on the storyboard view."
-                : "This folder is empty."}
+                ? mode === "tags"
+                  ? "No tagged or untagged assets to show."
+                  : "No assets yet — upload some from the asset library on the storyboard view."
+                : mode === "tags"
+                  ? "No assets carry exactly this tag."
+                  : "This folder is empty."}
             </p>
           ) : (
             <>
               <PaletteRail
                 assets={state.assets}
                 folders={state.folders}
+                mode={mode}
                 onOpenFolder={navigateTo}
               />
               {state.truncated && (

--- a/apps/timeline-gstudio001/lib/assets/cloudinary-provider.test.ts
+++ b/apps/timeline-gstudio001/lib/assets/cloudinary-provider.test.ts
@@ -58,7 +58,7 @@ describe("cloudinaryAssetToAsset", () => {
       src: "https://res.cloudinary.test/image/upload/gstudio/user-1/pic-123.png",
       thumbnailUrl: "https://res.cloudinary.test/thumb/pic-123.jpg",
       folderPath: ["Foobar 001", "Scenes"],
-      tags: [],
+      tags: [],  // absent upstream -> none, not undefined
       width: 1600,
       height: 900,
       bytes: 12345,
@@ -105,13 +105,32 @@ describe("cloudinaryAssetProvider.list", () => {
     expect(scenes.folders).toEqual([{ name: "Heist", path: ["Scenes", "Heist"] }]);
   });
 
-  it("declares folders on and the not-yet-served capabilities off", () => {
+  it("declares folders and tags on, the not-yet-served capabilities off", () => {
     expect(cloudinaryAssetProvider.capabilities).toEqual({
       folders: true,
-      tags: false,
+      tags: true,
       search: false,
       upload: false,
       delete: false,
     });
+  });
+
+  it("carries vendor tags through and serves a tagPath query as a TAG page", async () => {
+    state.vendorAssets = [
+      vendorAsset({ id: "plain", relativePath: "plain.png" }),
+      vendorAsset({ id: "tagged", relativePath: "Scenes/t.png", tags: ["scene/heist"] }),
+    ];
+    const root = await cloudinaryAssetProvider.list({ uid: "user-1" }, { tagPath: [] });
+    // Tag space ignores folders entirely: the untagged asset sits at the tags
+    // root even though it also sits at the folder root, and the tagged one is
+    // reachable only through its tag group.
+    expect(root.assets.map((entry) => entry.id)).toEqual(["plain"]);
+    expect(root.folders).toEqual([{ name: "scene", path: ["scene"] }]);
+
+    const heist = await cloudinaryAssetProvider.list(
+      { uid: "user-1" },
+      { tagPath: ["scene", "heist"] },
+    );
+    expect(heist.assets.map((entry) => entry.id)).toEqual(["tagged"]);
   });
 });

--- a/apps/timeline-gstudio001/lib/assets/cloudinary-provider.ts
+++ b/apps/timeline-gstudio001/lib/assets/cloudinary-provider.ts
@@ -5,7 +5,7 @@
 
 import { listCloudinaryAssets, type CloudinaryAsset } from "@/lib/cloudinary-media-store";
 
-import { pageFromFlatListing } from "./path-folders";
+import { pageFromFlatListing, pageFromTagListing } from "./path-folders";
 import type { AssetContext, AssetProvider } from "./provider";
 import type { Asset } from "./types";
 
@@ -30,9 +30,7 @@ export function cloudinaryAssetToAsset(vendorAsset: CloudinaryAsset): Asset {
     src: vendorAsset.url,
     thumbnailUrl: vendorAsset.thumbnailUrl,
     folderPath: segments.slice(0, -1),
-    // Phase 3 (tags browse) teaches the store's listing to carry tags; until
-    // then Cloudinary reports none and declares the capability off.
-    tags: [],
+    tags: vendorAsset.tags ?? [],
     ...(vendorAsset.width === undefined ? {} : { width: vendorAsset.width }),
     ...(vendorAsset.height === undefined ? {} : { height: vendorAsset.height }),
     ...(vendorAsset.duration === undefined ? {} : { durationSeconds: vendorAsset.duration }),
@@ -46,19 +44,21 @@ export const cloudinaryAssetProvider: AssetProvider = {
   label: "Cloudinary",
   capabilities: {
     folders: true,
+    tags: true,
     // Declared OFF until the adapter actually serves them — the UI offers
     // only what list() honours today.
-    tags: false,
     search: false,
     upload: false,
     delete: false,
   },
   async list(ctx: AssetContext, query) {
     // The store's listing is already user-scoped and paginated at the vendor
-    // boundary; folder scoping is derived from it in memory (the documented
-    // fallback in path-folders — a native `prefix` query is the upgrade path
-    // if libraries outgrow it).
-    const vendorAssets = await listCloudinaryAssets(ctx.uid);
-    return pageFromFlatListing(vendorAssets.map(cloudinaryAssetToAsset), query);
+    // boundary; folder/tag scoping is derived from it in memory (the
+    // documented fallback in path-folders — a native `prefix`/tag query is
+    // the upgrade path if libraries outgrow it).
+    const assets = (await listCloudinaryAssets(ctx.uid)).map(cloudinaryAssetToAsset);
+    return query.tagPath !== undefined
+      ? pageFromTagListing(assets, query)
+      : pageFromFlatListing(assets, query);
   },
 };

--- a/apps/timeline-gstudio001/lib/assets/path-folders.test.ts
+++ b/apps/timeline-gstudio001/lib/assets/path-folders.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { pageFromFlatListing } from "./path-folders";
+import { pageFromFlatListing, pageFromTagListing } from "./path-folders";
 import type { Asset } from "./types";
 
-function asset(id: string, folderPath: string[]): Asset {
+function asset(id: string, folderPath: string[], tags: string[] = []): Asset {
   return {
     id,
     providerId: "test",
@@ -12,7 +12,7 @@ function asset(id: string, folderPath: string[]): Asset {
     src: `https://cdn.test/${id}`,
     thumbnailUrl: `https://cdn.test/${id}.thumb`,
     folderPath,
-    tags: [],
+    tags,
   };
 }
 
@@ -83,5 +83,49 @@ describe("pageFromFlatListing", () => {
     expect(pageFromFlatListing(listing, { folder: ["Y"] }).folders).toEqual([
       { name: "X", path: ["Y", "X"] },
     ]);
+  });
+});
+
+describe("pageFromTagListing", () => {
+  // Folders play no part in tag space: every asset here lives at folder root
+  // so any grouping observed comes from tags alone.
+  const TAGGED = [
+    asset("untagged", []),
+    asset("hero", [], ["hero"]),
+    asset("heist-1", [], ["scene/heist"]),
+    asset("heist-hero", [], ["scene/heist", "hero"]),
+    asset("chase-1", [], ["scene/chase"]),
+  ];
+
+  it("the tags root shows UNTAGGED assets beside the top-level tag groups", () => {
+    const page = pageFromTagListing(TAGGED, { tagPath: [] });
+    expect(page.assets.map((entry) => entry.id)).toEqual(["untagged"]);
+    expect(page.folders).toEqual([
+      { name: "hero", path: ["hero"] },
+      { name: "scene", path: ["scene"] },
+    ]);
+  });
+
+  it("a tag path matches assets carrying EXACTLY that tag, with subgroups below", () => {
+    // "scene" itself tags nothing here — its page is pure navigation.
+    const scene = pageFromTagListing(TAGGED, { tagPath: ["scene"] });
+    expect(scene.assets).toEqual([]);
+    expect(scene.folders.map((folder) => folder.name)).toEqual(["chase", "heist"]);
+
+    const heist = pageFromTagListing(TAGGED, { tagPath: ["scene", "heist"] });
+    expect(heist.assets.map((entry) => entry.id)).toEqual(["heist-1", "heist-hero"]);
+    expect(heist.folders).toEqual([]);
+  });
+
+  it("an asset tagged twice lives in BOTH places — the difference from folders", () => {
+    const hero = pageFromTagListing(TAGGED, { tagPath: ["hero"] });
+    expect(hero.assets.map((entry) => entry.id)).toEqual(["hero", "heist-hero"]);
+  });
+
+  it("defaults a missing tagPath to the root and honours limit", () => {
+    const page = pageFromTagListing(TAGGED, {});
+    expect(page.assets.map((entry) => entry.id)).toEqual(["untagged"]);
+    const limited = pageFromTagListing(TAGGED, { tagPath: ["scene", "heist"], limit: 1 });
+    expect(limited.assets.map((entry) => entry.id)).toEqual(["heist-1"]);
   });
 });

--- a/apps/timeline-gstudio001/lib/assets/path-folders.ts
+++ b/apps/timeline-gstudio001/lib/assets/path-folders.ts
@@ -3,19 +3,56 @@
 // ids, S3 object keys). Such backends have no folder API to ask; the tree IS
 // the set of key prefixes, so one derivation serves them all and a new
 // path-based adapter gets browsing for free.
+//
+// The same derivation also serves the TAG pseudo-hierarchy: a tag is a path
+// ("scene/heist" nests under "scene"), the only difference being that an
+// asset has exactly ONE folder location but may carry MANY tags — so the
+// core works on a list of locations per asset and the two entry points
+// differ only in how they read them.
 
 import type { Asset, AssetFolder, AssetPage, AssetQuery } from "./types";
 
-function sameFolder(a: readonly string[], b: readonly string[]): boolean {
+type Location = readonly string[];
+
+function sameLocation(a: Location, b: Location): boolean {
   return a.length === b.length && a.every((segment, i) => segment === b[i]);
 }
 
-function isUnder(path: readonly string[], folder: readonly string[]): boolean {
-  return path.length > folder.length && folder.every((segment, i) => segment === path[i]);
+function isUnder(path: Location, base: Location): boolean {
+  return path.length > base.length && base.every((segment, i) => segment === path[i]);
+}
+
+function pageFromLocations(
+  assets: readonly Asset[],
+  locationsOf: (asset: Asset) => readonly Location[],
+  base: Location | undefined,
+  limit: number | undefined,
+): AssetPage {
+  const matching =
+    base === undefined
+      ? assets
+      : assets.filter((asset) => locationsOf(asset).some((loc) => sameLocation(loc, base)));
+
+  const groupBase = base ?? [];
+  const seen = new Set<string>();
+  const folders: AssetFolder[] = [];
+  for (const asset of assets) {
+    for (const location of locationsOf(asset)) {
+      if (!isUnder(location, groupBase)) continue;
+      const name = location[groupBase.length];
+      if (seen.has(name)) continue;
+      seen.add(name);
+      folders.push({ name, path: [...groupBase, name] });
+    }
+  }
+  folders.sort((a, b) => a.name.localeCompare(b.name));
+
+  const limited = limit !== undefined && limit >= 0 ? matching.slice(0, limit) : matching;
+  return { assets: limited, folders };
 }
 
 /**
- * Resolve a query against a fully-mapped flat listing.
+ * Resolve a FOLDER query against a fully-mapped flat listing.
  *
  * `folder` undefined → every asset (the flat view) plus the top-level folder
  * rows; `folder` set → that folder's DIRECT assets plus its direct subfolder
@@ -28,26 +65,24 @@ function isUnder(path: readonly string[], folder: readonly string[]): boolean {
  * adapter is a mapping function and nothing more.
  */
 export function pageFromFlatListing(assets: readonly Asset[], query: AssetQuery): AssetPage {
-  const folder = query.folder;
+  return pageFromLocations(assets, (asset) => [asset.folderPath], query.folder, query.limit);
+}
 
-  const matching =
-    folder === undefined
-      ? assets
-      : assets.filter((asset) => sameFolder(asset.folderPath, folder));
+/** How a tag nests: "scene/heist" is the path ["scene", "heist"]. */
+function tagSegments(tag: string): Location {
+  return tag.split("/").filter((segment) => segment.length > 0);
+}
 
-  const base = folder ?? [];
-  const seen = new Set<string>();
-  const folders: AssetFolder[] = [];
-  for (const asset of assets) {
-    if (!isUnder(asset.folderPath, base)) continue;
-    const name = asset.folderPath[base.length];
-    if (seen.has(name)) continue;
-    seen.add(name);
-    folders.push({ name, path: [...base, name] });
-  }
-  folders.sort((a, b) => a.name.localeCompare(b.name));
-
-  const limited =
-    query.limit !== undefined && query.limit >= 0 ? matching.slice(0, query.limit) : matching;
-  return { assets: limited, folders };
+/**
+ * Resolve a TAGS-mode browse against the same flat listing. Identical
+ * folder semantics over tag paths, with the two differences tags force:
+ * an asset tagged twice lives in BOTH places, and an asset with NO tags
+ * lives at the tags ROOT (the file-browser convention — root files sit
+ * beside the folders). `tagPath` [] is that root; deeper paths scope to
+ * assets carrying exactly that tag.
+ */
+export function pageFromTagListing(assets: readonly Asset[], query: AssetQuery): AssetPage {
+  const locationsOf = (asset: Asset): readonly Location[] =>
+    asset.tags.length === 0 ? [[]] : asset.tags.map(tagSegments);
+  return pageFromLocations(assets, locationsOf, query.tagPath ?? [], query.limit);
 }

--- a/apps/timeline-gstudio001/lib/assets/types.ts
+++ b/apps/timeline-gstudio001/lib/assets/types.ts
@@ -55,12 +55,20 @@ export type AssetFolder = Readonly<{
 export type AssetQuery = Readonly<{
   /**
    * Folder to browse. `undefined` = the FLAT listing (every asset, no
-   * folder scoping — today's palette behaviour); `[]` = the root folder's
-   * direct children; deeper arrays scope to that folder. Distinct on
-   * purpose: flat is a view, root is a place.
+   * folder scoping); `[]` = the root folder's direct children; deeper
+   * arrays scope to that folder. Distinct on purpose: flat is a view, root
+   * is a place.
    */
   folder?: readonly string[];
-  /** Require every listed tag (capability-gated). */
+  /**
+   * TAG pseudo-hierarchy to browse instead (capability-gated; wins over
+   * `folder` when both are present). Same segment semantics — a tag
+   * "scene/heist" is the path ["scene", "heist"] — with the two differences
+   * tags force: an asset tagged twice lives in both places, and an UNTAGGED
+   * asset lives at the tags root. `[]` = that root.
+   */
+  tagPath?: readonly string[];
+  /** Require every listed tag (an AND filter, capability-gated). */
   tags?: readonly string[];
   /** Free-text filter (capability-gated). */
   search?: string;

--- a/apps/timeline-gstudio001/lib/cloudinary-media-store.ts
+++ b/apps/timeline-gstudio001/lib/cloudinary-media-store.ts
@@ -28,6 +28,8 @@ export type CloudinaryAsset = {
   /** Real media duration in seconds — videos only, from the Search API
    *  listing (the Admin API list endpoint doesn't return it). */
   duration?: number;
+  /** Cloudinary tags — the asset panel's tag pseudo-hierarchy browses them. */
+  tags?: string[];
 };
 
 type CloudinaryConfig = {
@@ -54,6 +56,7 @@ type CloudinaryResource = {
   public_id: string;
   resource_type: "image" | "video" | "raw";
   secure_url: string;
+  tags?: string[];
   width?: number;
 };
 
@@ -150,6 +153,7 @@ function toAsset(
     createdAt: resource.created_at,
     relativePath,
     duration: resource.resource_type === "video" ? resource.duration : undefined,
+    tags: resource.tags ?? [],
   };
 }
 
@@ -168,6 +172,9 @@ async function listCloudinaryResources(
       prefix: `${folderPrefix}/`,
       max_results: "100",
       direction: "desc",
+      // Include each resource's tag list — the asset panel's tags browse
+      // mode groups on them.
+      tags: "true",
     });
 
     if (nextCursor) {
@@ -228,6 +235,9 @@ async function searchCloudinaryVideos(
         body: JSON.stringify({
           expression: `public_id:${folderPrefix}/* AND resource_type:video`,
           max_results: 100,
+          // Tag lists ride along like duration does — see the function
+          // comment for why videos use Search in the first place.
+          with_field: "tags",
           ...(nextCursor ? { next_cursor: nextCursor } : {}),
         }),
         cache: "no-store",

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -210,7 +210,7 @@ async function installGraphApi(
       src: PIXEL,
       thumbnailUrl: PIXEL,
       folderPath: [] as string[],
-      tags: [],
+      tags: [] as string[],
       width: 1600,
       height: 900,
     },
@@ -222,7 +222,10 @@ async function installGraphApi(
       src: PIXEL,
       thumbnailUrl: PIXEL,
       folderPath: ["fixtures"],
-      tags: [],
+      // A nested tag, deliberately DISJOINT from the folder tree: tag space
+      // must group this under b-roll/night even though it lives in the
+      // "fixtures" folder.
+      tags: ["b-roll/night"],
       width: 1920,
       height: 1080,
       // Real duration from the provider listing — a dropped video must
@@ -232,24 +235,34 @@ async function installGraphApi(
   ];
   await page.route("**/api/assets**", (route) => {
     const url = new URL(route.request().url());
-    const folder = url.searchParams.getAll("folder");
-    const inFolder = (path: string[]) =>
-      path.length === folder.length && folder.every((seg, i) => path[i] === seg);
-    const subfolderNames = new Set(
-      paletteAssets
-        .filter(
-          (asset) =>
-            asset.folderPath.length > folder.length &&
-            folder.every((seg, i) => asset.folderPath[i] === seg),
-        )
-        .map((asset) => asset.folderPath[folder.length]),
+    // In tags mode an asset's LOCATIONS are its tags split on "/" (or the
+    // root when untagged); in folders mode its one location is folderPath —
+    // the same shapes the server's path-folders module derives.
+    const tagsMode = url.searchParams.get("mode") === "tags";
+    const base = url.searchParams.getAll(tagsMode ? "tag" : "folder");
+    const locationsOf = (asset: (typeof paletteAssets)[number]): string[][] =>
+      tagsMode
+        ? asset.tags.length === 0
+          ? [[]]
+          : asset.tags.map((tag) => tag.split("/"))
+        : [asset.folderPath];
+    const atBase = (path: string[]) =>
+      path.length === base.length && base.every((seg, i) => path[i] === seg);
+    const groupNames = new Set(
+      paletteAssets.flatMap((asset) =>
+        locationsOf(asset)
+          .filter(
+            (path) => path.length > base.length && base.every((seg, i) => path[i] === seg),
+          )
+          .map((path) => path[base.length]),
+      ),
     );
     return route.fulfill({
       json: {
         providerId: "cloudinary",
-        capabilities: { folders: true, tags: false, search: false, upload: false, delete: false },
-        folders: [...subfolderNames].map((name) => ({ name, path: [...folder, name] })),
-        assets: paletteAssets.filter((asset) => inFolder(asset.folderPath)),
+        capabilities: { folders: true, tags: true, search: false, upload: false, delete: false },
+        folders: [...groupNames].map((name) => ({ name, path: [...base, name] })),
+        assets: paletteAssets.filter((asset) => locationsOf(asset).some(atBase)),
       },
     });
   });
@@ -1203,6 +1216,46 @@ test.describe("graph view E2E", () => {
     await expect(drawer.locator('[data-palette-item="asset-vid-1"]')).toHaveCount(0);
     // At the root the header is the plain heading again — no navigation.
     await expect(drawer.getByRole("navigation", { name: "Asset folders" })).toHaveCount(0);
+  });
+
+  test("palette tags mode: toggle, pseudo-hierarchy drill-in, and back to folders", async ({
+    page,
+  }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    await assetsButton(page).click();
+    const drawer = page.getByRole("dialog", { name: "Asset palette" });
+    await expect(drawer.locator('[data-palette-item="asset-img-1"]')).toBeVisible();
+
+    // The toggle exists because the MOCK declares the capability — a
+    // provider that can't do tags never grows this control.
+    const toggle = drawer.getByRole("group", { name: "Browse assets by" });
+    await toggle.getByRole("button", { name: "Tags" }).click();
+
+    // Tags root: the untagged asset beside the top-level tag group. vid-1
+    // lives in the "fixtures" FOLDER but tag space doesn't care — it is
+    // reachable only through b-roll/night.
+    await expect(drawer.locator('[data-palette-item="asset-img-1"]')).toBeVisible();
+    await expect(drawer.locator('[data-palette-folder="b-roll"]')).toBeVisible();
+    await expect(drawer.locator('[data-palette-folder="fixtures"]')).toHaveCount(0);
+    await expect(drawer.locator('[data-palette-item="asset-vid-1"]')).toHaveCount(0);
+
+    // Drill the nested tag: b-roll -> night -> the tagged asset.
+    await drawer.locator('[data-palette-folder="b-roll"]').click();
+    await expect(drawer.locator('[data-palette-folder="night"]')).toBeVisible();
+    await drawer.locator('[data-palette-folder="night"]').click();
+    await expect(drawer.locator('[data-palette-item="asset-vid-1"]')).toBeVisible();
+    await expect(drawer.locator('[data-palette-item="asset-img-1"]')).toHaveCount(0);
+    // The breadcrumb roots at "Tags" in this mode.
+    const breadcrumb = drawer.getByRole("navigation", { name: "Asset folders" });
+    await expect(breadcrumb.getByRole("button", { name: "Tags" })).toBeVisible();
+
+    // Back to Folders: the toggle resets to the FOLDER root (a tag path
+    // means nothing in folder space).
+    await toggle.getByRole("button", { name: "Folders" }).click();
+    await expect(drawer.locator('[data-palette-folder="fixtures"]')).toBeVisible();
+    await expect(drawer.locator('[data-palette-item="asset-img-1"]')).toBeVisible();
+    await expect(drawer.locator('[data-palette-folder="b-roll"]')).toHaveCount(0);
   });
 
   test("trash drop moves across roots, persists BOTH documents, and undoes", async ({

--- a/docs/asset-providers.md
+++ b/docs/asset-providers.md
@@ -67,8 +67,12 @@ serves both; only the source differs:
    no longer a palette view), folder tiles lead the rail, the breadcrumb
    climbs back, and visited pages answer from an in-drawer cache. A provider
    without folders reports none and the same view IS its flat listing.
-3. Tags mode (Cloudinary listing gains tags; Folders/Tags toggle,
-   capability-gated).
+3. ✅ Tags mode — the Cloudinary listing carries tags (Admin API `tags=true`,
+   Search API `with_field: "tags"`), `AssetQuery.tagPath` browses the
+   pseudo-hierarchy (`?mode=tags&tag=<seg>&tag=<seg>`; none = the tags root,
+   where UNTAGGED assets sit beside the top-level groups), and the palette
+   grows a capability-gated Folders/Tags toggle. An asset tagged twice lives
+   in both places; folder placement is invisible in tag space.
 4. **S3 adapter** (decided: the second provider) + provider picker; upload/
    delete through the seam.
 5. Retire the legacy drawer's bespoke virtual-timeline folder pipeline


### PR DESCRIPTION
Phase 3 of the asset-panel epic (`docs/asset-providers.md`).

### What changed

A capability-gated **Folders / Tags** toggle in the palette. Tag paths browse through the *same* breadcrumb/tile machinery folders use — a tag `scene/heist` is the path `["scene", "heist"]`; only the wire param family and the tile icon differ.

Where tags genuinely differ from folders, the semantics say so:

- an asset tagged twice lives in **both** places;
- an **untagged** asset lives at the tags root, beside the top-level groups (root files sit next to the folders);
- folder placement is invisible in tag space — pinned by a fixture clip that lives in the `fixtures` *folder* but is reachable only through its `b-roll/night` *tag*.

### Mechanics

- **cloudinary-media-store** — both listings now carry tags (Admin API `tags=true`; the video Search API `with_field: "tags"`, riding the request that already exists for duration).
- **path-folders** — the folder derivation generalized over *locations* (one `folderPath` vs many tags). `pageFromFlatListing` keeps its exact signature and tests; `pageFromTagListing` is the multi-location twin.
- **`AssetQuery.tagPath`** (wins over `folder`; `[]` = the tags root — tags mode is always a browse). Wire: `?mode=tags&tag=<seg>&tag=<seg>`, one param per segment as ever.
- Cloudinary declares `tags: true`; the palette renders the toggle only when a response says so, mode switches reset to the new root (a folder path means nothing in tag space), and the page cache is keyed by `[mode, path]` so the two hierarchies never cross.

### Tests

Tag-listing derivation (root/untagged, exact-tag matching, multi-tag dual residency, nesting, limit) · provider (vendor tags carried; `tagPath` routes to the tag page) · route (`?mode=tags` root + tag segments) · new e2e driving the real toggle: tags root, nested drill (`b-roll` → `night`), breadcrumb rooted at "Tags", back to Folders. **Fail-first**: `tagPath` ignored server-side → 4 unit tests fail (the e2e mocks the API; the client half is covered by phase 2's params probe).

### Live against the real account

Listing params accepted, toggle renders, and the tags root truthfully shows all 38 assets as untagged with no groups — nothing in that library carries tags yet.

App vitest 252/252 · graph-view e2e 59/59 · app `tsc` clean · lint clean (4 pre-existing `img` warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
