### PR TITLE
Asset panel phase 4: S3 adapter + provider picker

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-asset-palette.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-asset-palette.tsx
@@ -73,6 +73,9 @@ type PalettePage = Readonly<{
   truncated: boolean;
 }>;
 
+/** What the picker needs from /api/assets/providers. */
+type ProviderOption = Readonly<{ id: string; label: string }>;
+
 type AssetPaletteState =
   | Readonly<{ status: "loading" }>
   | Readonly<{ status: "error"; message: string }>
@@ -256,16 +259,47 @@ export function AssetPaletteDrawer({
   // UI, per the seam's degradation contract).
   const [mode, setMode] = useState<BrowseMode>("folders");
   const [tagsAvailable, setTagsAvailable] = useState(false);
+  // Which asset provider is selected. `null` = the server's default (the
+  // first-registered); an explicit id is threaded into every request. The
+  // picker only appears when more than one provider is installed, so a
+  // single-provider deployment is unchanged.
+  const [providers, setProviders] = useState<readonly ProviderOption[]>([]);
+  const [providerId, setProviderId] = useState<string | null>(null);
+
+  // The page cache is keyed by ALL THREE axes — provider, mode, path — so no
+  // cached page can leak across a provider or hierarchy switch (a folder path
+  // means nothing in another provider, nor in tag space).
+  const cacheKey = useCallback(
+    (p: string | null, m: BrowseMode, segments: readonly string[]) =>
+      JSON.stringify([p ?? "", m, segments]),
+    [],
+  );
 
   const navigateTo = useCallback(
     (next: readonly string[], nextMode?: BrowseMode) => {
       const targetMode = nextMode ?? mode;
       setMode(targetMode);
       setPath(next);
-      const cached = pageCacheRef.current.get(JSON.stringify([targetMode, next]));
+      const cached = pageCacheRef.current.get(cacheKey(providerId, targetMode, next));
       setState(cached ? { status: "ready", ...cached } : { status: "loading" });
     },
-    [mode],
+    [mode, providerId, cacheKey],
+  );
+
+  // Switching provider is a full reset: back to the FOLDER root, because a
+  // path and even a hierarchy MODE belong to the provider you left (the new
+  // one may not do tags at all — its next response re-derives tagsAvailable).
+  const selectProvider = useCallback(
+    (next: string) => {
+      if (next === (providerId ?? "")) return;
+      const targetId = next === "" ? null : next;
+      setProviderId(targetId);
+      setMode("folders");
+      setPath([]);
+      const cached = pageCacheRef.current.get(cacheKey(targetId, "folders", []));
+      setState(cached ? { status: "ready", ...cached } : { status: "loading" });
+    },
+    [providerId, cacheKey],
   );
   // This panel is FIXED to the bottom of the viewport and non-modal — the
   // board behind it stays live, and you drag out of it onto that board. So
@@ -280,6 +314,28 @@ export function AssetPaletteDrawer({
     onClose();
   };
 
+  // Load the installed providers once the drawer opens — best-effort: a
+  // failure just leaves the picker hidden and the default provider serving,
+  // which is exactly the single-provider experience.
+  useEffect(() => {
+    if (!open || providers.length > 0) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await fetch("/api/assets/providers", { cache: "no-store" });
+        const result = (await response.json().catch(() => ({}))) as {
+          providers?: ProviderOption[];
+        };
+        if (!cancelled && response.ok && result.providers) setProviders(result.providers);
+      } catch {
+        // Ignore — the default provider still serves without a picker.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, providers.length]);
+
   useEffect(() => {
     if (!open || state.status !== "loading") return;
     let cancelled = false;
@@ -293,6 +349,7 @@ export function AssetPaletteDrawer({
           mode === "tags"
             ? new URLSearchParams({ mode: "tags" })
             : new URLSearchParams({ browse: "1" });
+        if (providerId !== null) params.set("provider", providerId);
         for (const segment of path) params.append(mode === "tags" ? "tag" : "folder", segment);
         const response = await fetch(`/api/assets?${params}`, { cache: "no-store" });
         const result = (await response.json().catch(() => ({}))) as {
@@ -311,7 +368,7 @@ export function AssetPaletteDrawer({
           folders: result.folders ?? [],
           truncated: result.assets.length > PALETTE_ASSET_LIMIT,
         };
-        pageCacheRef.current.set(JSON.stringify([mode, path]), page);
+        pageCacheRef.current.set(cacheKey(providerId, mode, path), page);
         setTagsAvailable(result.capabilities?.tags === true);
         setState({ status: "ready", ...page });
       } catch (cause) {
@@ -326,7 +383,7 @@ export function AssetPaletteDrawer({
     return () => {
       cancelled = true;
     };
-  }, [open, state.status, path, mode]);
+  }, [open, state.status, path, mode, providerId, cacheKey]);
 
   if (!open || typeof document === "undefined") return null;
 
@@ -348,6 +405,27 @@ export function AssetPaletteDrawer({
             rootLabel={mode === "tags" ? "Tags" : "Assets"}
             onNavigate={navigateTo}
           />
+          {/* The provider picker appears ONLY with more than one installed —
+              a single-provider deployment (Cloudinary alone, no S3 env) is
+              visually unchanged. A native <select>: the option count is
+              provider-driven, so a fixed toggle wouldn't scale. */}
+          {providers.length > 1 && (
+            <label className="flex shrink-0 items-center gap-1 text-[10px] text-zinc-500">
+              <span className="sr-only">Asset source</span>
+              <select
+                aria-label="Asset source"
+                value={providerId ?? providers[0].id}
+                onChange={(event) => selectProvider(event.target.value)}
+                className="rounded-md border border-zinc-800 bg-zinc-900 px-1.5 py-0.5 text-[10px] font-semibold text-zinc-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+              >
+                {providers.map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
           {tagsAvailable && (
             <div
               role="group"

--- a/apps/timeline-gstudio001/lib/assets/registry.ts
+++ b/apps/timeline-gstudio001/lib/assets/registry.ts
@@ -3,11 +3,18 @@
 // APIs. Registration order is preference order — the first entry is what a
 // request that names no provider gets.
 //
-// Adding a provider = one adapter file + one entry here. The S3 adapter
-// (decided 2026-07-23: the second provider, proving the seam) lands as
-// exactly that pair.
+// Adding a provider = one adapter file + one entry here.
 
 import { cloudinaryAssetProvider } from "./cloudinary-provider";
-import { createAssetProviderRegistry } from "./provider";
+import { createAssetProviderRegistry, type AssetProvider } from "./provider";
+import { createS3AssetProvider } from "./s3-provider";
 
-export const assetProviders = createAssetProviderRegistry([cloudinaryAssetProvider]);
+// Cloudinary is always present (it's env-or-nothing at call time, but the
+// adapter registers unconditionally); S3 only appears when its bucket is
+// configured, so an unconfigured deployment never offers a dead provider in
+// the picker. `createS3AssetProvider` returns null in that case.
+const providers: AssetProvider[] = [cloudinaryAssetProvider];
+const s3Provider = createS3AssetProvider();
+if (s3Provider !== null) providers.push(s3Provider);
+
+export const assetProviders = createAssetProviderRegistry(providers);

--- a/apps/timeline-gstudio001/lib/assets/s3-provider.test.ts
+++ b/apps/timeline-gstudio001/lib/assets/s3-provider.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createS3AssetProvider,
+  readS3Config,
+  S3_PROVIDER_ID,
+  type S3Deps,
+  type S3ObjectSummary,
+} from "./s3-provider";
+
+const ENV = {
+  S3_ASSETS_BUCKET: "media-bucket",
+  S3_ASSETS_REGION: "us-east-1",
+  S3_ASSETS_PREFIX: "media/",
+  S3_ASSETS_PUBLIC_URL: "https://cdn.test",
+} as const;
+
+function deps(objects: readonly S3ObjectSummary[]): S3Deps {
+  return {
+    listObjects: async () => objects,
+    // Public-base style: encoded key appended. The presigned path is exercised
+    // separately below.
+    urlFor: async (key) =>
+      `https://cdn.test/${key.split("/").map(encodeURIComponent).join("/")}`,
+  };
+}
+
+function provider(objects: readonly S3ObjectSummary[], env = ENV) {
+  const created = createS3AssetProvider(env, deps(objects));
+  if (created === null) throw new Error("expected S3 provider to register");
+  return created;
+}
+
+describe("readS3Config", () => {
+  it("returns null unless BOTH bucket and region are set", () => {
+    expect(readS3Config({})).toBeNull();
+    expect(readS3Config({ S3_ASSETS_BUCKET: "b" })).toBeNull();
+    expect(readS3Config({ S3_ASSETS_REGION: "r" })).toBeNull();
+    expect(readS3Config({ S3_ASSETS_BUCKET: "b", S3_ASSETS_REGION: "r" })).not.toBeNull();
+  });
+
+  it("normalizes the prefix to 'seg/seg/' or '' whatever the author typed", () => {
+    const base = { S3_ASSETS_BUCKET: "b", S3_ASSETS_REGION: "r" };
+    expect(readS3Config({ ...base, S3_ASSETS_PREFIX: "media" })?.prefix).toBe("media/");
+    expect(readS3Config({ ...base, S3_ASSETS_PREFIX: "/media/" })?.prefix).toBe("media/");
+    expect(readS3Config({ ...base, S3_ASSETS_PREFIX: "a/b" })?.prefix).toBe("a/b/");
+    expect(readS3Config({ ...base })?.prefix).toBe("");
+  });
+
+  it("strips a trailing slash from the public URL base", () => {
+    const config = readS3Config({ ...ENV, S3_ASSETS_PUBLIC_URL: "https://cdn.test/" });
+    expect(config?.publicUrlBase).toBe("https://cdn.test");
+  });
+});
+
+describe("createS3AssetProvider", () => {
+  it("is null (unregistered) when S3 isn't configured", () => {
+    expect(createS3AssetProvider({})).toBeNull();
+  });
+
+  it("maps object keys to neutral assets, folders from the key path", async () => {
+    const s3 = provider([
+      { key: "media/root.png", size: 10, lastModified: "2026-07-01T00:00:00Z" },
+      { key: "media/Scenes/a.jpg" },
+      { key: "media/Scenes/Heist/b.png" },
+    ]);
+    const flat = await s3.list({ uid: "u" }, {});
+    expect(flat.assets.map((entry) => entry.id)).toEqual([
+      "media/root.png",
+      "media/Scenes/a.jpg",
+      "media/Scenes/Heist/b.png",
+    ]);
+    expect(flat.assets[0]).toMatchObject({
+      providerId: S3_PROVIDER_ID,
+      name: "root.png",
+      kind: "image",
+      src: "https://cdn.test/media/root.png",
+      thumbnailUrl: "https://cdn.test/media/root.png",
+      folderPath: [], // the configured prefix is stripped — user-visible tree
+      bytes: 10,
+      createdAt: "2026-07-01T00:00:00Z",
+    });
+    expect(flat.folders).toEqual([{ name: "Scenes", path: ["Scenes"] }]);
+  });
+
+  it("scopes a folder query exactly like the Cloudinary adapter (shared derivation)", async () => {
+    const s3 = provider([
+      { key: "media/root.png" },
+      { key: "media/Scenes/a.jpg" },
+      { key: "media/Scenes/Heist/b.png" },
+    ]);
+    const scenes = await s3.list({ uid: "u" }, { folder: ["Scenes"] });
+    expect(scenes.assets.map((entry) => entry.id)).toEqual(["media/Scenes/a.jpg"]);
+    expect(scenes.folders).toEqual([{ name: "Heist", path: ["Scenes", "Heist"] }]);
+  });
+
+  it("skips non-media keys instead of surfacing broken tiles", async () => {
+    const s3 = provider([
+      { key: "media/a.png" },
+      { key: "media/notes.txt" },
+      { key: "media/manifest.json" },
+      { key: "media/subdir/" }, // S3 directory marker
+    ]);
+    expect((await s3.list({ uid: "u" }, {})).assets.map((entry) => entry.id)).toEqual([
+      "media/a.png",
+    ]);
+  });
+
+  it("uses a sibling image as a video's poster, and an empty thumb when none", async () => {
+    const s3 = provider([
+      { key: "media/clip.mp4" },
+      { key: "media/clip.jpg" },
+      { key: "media/lonely.mp4" },
+    ]);
+    const assets = (await s3.list({ uid: "u" }, {})).assets;
+    const withPoster = assets.find((entry) => entry.id === "media/clip.mp4");
+    const noPoster = assets.find((entry) => entry.id === "media/lonely.mp4");
+    expect(withPoster?.thumbnailUrl).toBe("https://cdn.test/media/clip.jpg");
+    expect(withPoster?.src).toBe("https://cdn.test/media/clip.mp4");
+    expect(noPoster?.thumbnailUrl).toBe("");
+  });
+
+  it("declares folders on and tags off — its Folders/Tags toggle disappears", async () => {
+    const s3 = provider([]);
+    expect(s3.capabilities).toEqual({
+      folders: true,
+      tags: false,
+      search: false,
+      upload: false,
+      delete: false,
+    });
+    // A stray tagPath is ignored (contract: never throw), served as folders.
+    const page = await s3.list({ uid: "u" }, { tagPath: ["anything"] });
+    expect(page.assets).toEqual([]);
+  });
+
+  it("labels itself by bucket, so the picker distinguishes two S3 buckets", () => {
+    expect(provider([]).label).toBe("S3 (media-bucket)");
+  });
+
+  it("caches the listing within its TTL — one sweep serves several browses", async () => {
+    const listObjects = vi.fn(async () => [{ key: "media/a.png" }] as S3ObjectSummary[]);
+    const created = createS3AssetProvider(ENV, {
+      listObjects,
+      urlFor: async (key) => `https://cdn.test/${key}`,
+    });
+    if (created === null) throw new Error("expected provider");
+    await created.list({ uid: "u" }, {});
+    await created.list({ uid: "u" }, { folder: ["x"] });
+    expect(listObjects).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/timeline-gstudio001/lib/assets/s3-provider.ts
+++ b/apps/timeline-gstudio001/lib/assets/s3-provider.ts
@@ -1,0 +1,261 @@
+// Amazon S3 behind the neutral seam — the seam's second adapter, and the
+// proof it isn't Cloudinary-shaped: an S3 bucket is a flat namespace of
+// path-shaped KEYS, so folder browsing falls out of the same
+// `pageFromFlatListing` derivation, and everything S3 cannot do (tags on a
+// listing, media dimensions, durations) is simply declared off or omitted
+// rather than faked.
+//
+// Env-configured (no per-user OAuth — that is its own future track):
+//   S3_ASSETS_BUCKET       required — registers the provider when present
+//   S3_ASSETS_REGION       required
+//   S3_ASSETS_PREFIX       optional key prefix ("media/"); the browse root
+//   S3_ASSETS_PUBLIC_URL   optional public/CDN base; when absent, URLs are
+//                          presigned GETs (private buckets work untouched)
+// Credentials ride the SDK's default chain (AWS_ACCESS_KEY_ID / role / …).
+//
+// The bucket is APP-level, not per-user (unlike Cloudinary's per-uid
+// folder): listing still requires a session, but every signed-in user sees
+// the same bucket. Fine for a personal deployment; revisit if this app ever
+// becomes multi-tenant.
+
+import { pageFromFlatListing } from "./path-folders";
+import type { AssetProvider } from "./provider";
+import type { Asset, AssetKind } from "./types";
+
+export const S3_PROVIDER_ID = "s3";
+
+/** One listed object, reduced to what the mapping needs — the injection
+ *  point that keeps the adapter unit-testable without the SDK. */
+export type S3ObjectSummary = Readonly<{
+  key: string;
+  size?: number;
+  lastModified?: string;
+}>;
+
+export type S3Deps = Readonly<{
+  listObjects: () => Promise<readonly S3ObjectSummary[]>;
+  /** A browser-usable URL for an object key (public base or presigned). */
+  urlFor: (key: string) => Promise<string>;
+}>;
+
+export type S3Config = Readonly<{
+  bucket: string;
+  region: string;
+  prefix: string;
+  publicUrlBase: string | null;
+}>;
+
+const IMAGE_EXTENSIONS = new Set(["jpg", "jpeg", "png", "gif", "webp", "avif"]);
+const VIDEO_EXTENSIONS = new Set(["mp4", "webm", "mov", "m4v"]);
+/** Sibling-poster convention: `clip.mp4` uses `clip.jpg`/`clip.png`/… from
+ *  the same folder as its thumbnail when one exists. S3 has no transformation
+ *  service, so a poster either sits next to the video or there isn't one. */
+const POSTER_EXTENSIONS = ["jpg", "jpeg", "png", "webp"];
+
+function extensionOf(key: string): string {
+  const name = key.split("/").pop() ?? key;
+  const dot = name.lastIndexOf(".");
+  return dot === -1 ? "" : name.slice(dot + 1).toLowerCase();
+}
+
+function kindOf(key: string): AssetKind | null {
+  const extension = extensionOf(key);
+  if (IMAGE_EXTENSIONS.has(extension)) return "image";
+  if (VIDEO_EXTENSIONS.has(extension)) return "video";
+  return null;
+}
+
+export function readS3Config(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): S3Config | null {
+  const bucket = env.S3_ASSETS_BUCKET;
+  const region = env.S3_ASSETS_REGION;
+  if (!bucket || !region) return null;
+  const rawPrefix = env.S3_ASSETS_PREFIX ?? "";
+  return {
+    bucket,
+    region,
+    // Normalized to "segment/segment/" (or "") so key math never sees a
+    // doubled or missing slash whatever the env author typed.
+    prefix: rawPrefix.replace(/^\/+|\/+$/g, "") + (rawPrefix.trim() ? "/" : ""),
+    publicUrlBase: env.S3_ASSETS_PUBLIC_URL?.replace(/\/+$/, "") ?? null,
+  };
+}
+
+/** 30s listing cache — the palette refetches per folder navigation, and each
+ *  uncached hit is a full paginated ListObjectsV2 sweep. Promise-cached so a
+ *  burst shares one in-flight listing, same pattern as the Cloudinary store. */
+const LISTING_TTL_MS = 30_000;
+
+async function mapObjects(
+  objects: readonly S3ObjectSummary[],
+  config: S3Config,
+  urlFor: (key: string) => Promise<string>,
+): Promise<Asset[]> {
+  // Key set for the sibling-poster lookup, before any filtering: the poster
+  // image is itself a listable asset AND the video's thumbnail — hiding it
+  // from the listing would guess at intent, so it stays visible.
+  const keys = new Set(objects.map((object) => object.key));
+  const assets: Asset[] = [];
+  for (const object of objects) {
+    const kind = kindOf(object.key);
+    // Not renderable media (manifests, sidecar files, "directory" markers) —
+    // skipped rather than surfaced as broken tiles.
+    if (kind === null) continue;
+    if (!object.key.startsWith(config.prefix)) continue;
+    const relative = object.key.slice(config.prefix.length);
+    const segments = relative.split("/").filter((segment) => segment.length > 0);
+    if (segments.length === 0) continue;
+
+    const src = await urlFor(object.key);
+    let thumbnailUrl = kind === "image" ? src : "";
+    if (kind === "video") {
+      const stem = object.key.slice(0, object.key.length - extensionOf(object.key).length - 1);
+      const posterKey = POSTER_EXTENSIONS.map((ext) => `${stem}.${ext}`).find((candidate) =>
+        keys.has(candidate),
+      );
+      if (posterKey !== undefined) thumbnailUrl = await urlFor(posterKey);
+    }
+
+    assets.push({
+      id: object.key,
+      providerId: S3_PROVIDER_ID,
+      name: segments[segments.length - 1],
+      kind,
+      src,
+      // "" when a video has no sibling poster — the palette renders a
+      // labelled tile for that, per the degradation contract.
+      thumbnailUrl,
+      folderPath: segments.slice(0, -1),
+      tags: [],
+      ...(object.size === undefined ? {} : { bytes: object.size }),
+      ...(object.lastModified === undefined ? {} : { createdAt: object.lastModified }),
+    });
+  }
+  return assets;
+}
+
+/** The REAL deps, built on first use: the SDK loads lazily so a deployment
+ *  without S3 configured never pays for it, and everything stays behind the
+ *  `S3Deps` seam the unit tests inject through. */
+function createSdkDeps(config: S3Config): S3Deps {
+  type SdkHandles = {
+    send: (input: { prefix: string; token?: string }) => Promise<{
+      objects: S3ObjectSummary[];
+      nextToken?: string;
+    }>;
+    presign: (key: string) => Promise<string>;
+  };
+  let handlesPromise: Promise<SdkHandles> | null = null;
+  const handles = () =>
+    (handlesPromise ??= (async () => {
+      const [{ S3Client, ListObjectsV2Command, GetObjectCommand }, { getSignedUrl }] =
+        await Promise.all([import("@aws-sdk/client-s3"), import("@aws-sdk/s3-request-presigner")]);
+      const client = new S3Client({ region: config.region });
+      return {
+        send: async ({ prefix, token }) => {
+          const output = await client.send(
+            new ListObjectsV2Command({
+              Bucket: config.bucket,
+              Prefix: prefix,
+              MaxKeys: 1000,
+              ...(token === undefined ? {} : { ContinuationToken: token }),
+            }),
+          );
+          return {
+            objects: (output.Contents ?? []).flatMap((entry) =>
+              entry.Key === undefined
+                ? []
+                : [
+                    {
+                      key: entry.Key,
+                      ...(entry.Size === undefined ? {} : { size: entry.Size }),
+                      ...(entry.LastModified === undefined
+                        ? {}
+                        : { lastModified: entry.LastModified.toISOString() }),
+                    },
+                  ],
+            ),
+            nextToken: output.NextContinuationToken,
+          };
+        },
+        presign: (key) =>
+          getSignedUrl(
+            client,
+            new GetObjectCommand({ Bucket: config.bucket, Key: key }),
+            { expiresIn: 3600 },
+          ),
+      };
+    })());
+
+  return {
+    listObjects: async () => {
+      const sdk = await handles();
+      const objects: S3ObjectSummary[] = [];
+      let token: string | undefined;
+      let pages = 0;
+      do {
+        const page = await sdk.send({ prefix: config.prefix, token });
+        objects.push(...page.objects);
+        token = page.nextToken;
+        pages += 1;
+      } while (token !== undefined && pages < 10);
+      return objects;
+    },
+    urlFor: (key) => {
+      if (config.publicUrlBase !== null) {
+        // Encode per segment; the "/" separators are real path structure.
+        const encoded = key.split("/").map(encodeURIComponent).join("/");
+        return Promise.resolve(`${config.publicUrlBase}/${encoded}`);
+      }
+      return handles().then((sdk) => sdk.presign(key));
+    },
+  };
+}
+
+/**
+ * Null when the env doesn't configure S3 — the registry then simply doesn't
+ * register it, so the picker never offers a dead provider.
+ */
+export function createS3AssetProvider(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+  depsOverride?: S3Deps,
+): AssetProvider | null {
+  const config = readS3Config(env);
+  if (config === null) return null;
+  const deps = depsOverride ?? createSdkDeps(config);
+
+  let cached: { at: number; assets: Promise<Asset[]> } | null = null;
+  const listing = () => {
+    if (cached !== null && Date.now() - cached.at < LISTING_TTL_MS) return cached.assets;
+    const assets = deps.listObjects().then((objects) => mapObjects(objects, config, deps.urlFor));
+    // A failed sweep must not poison the cache window with a rejection.
+    assets.catch(() => {
+      cached = null;
+    });
+    cached = { at: Date.now(), assets };
+    return assets;
+  };
+
+  return {
+    id: S3_PROVIDER_ID,
+    label: `S3 (${config.bucket})`,
+    capabilities: {
+      folders: true,
+      // Object tags need a GetObjectTagging call PER OBJECT — unaffordable
+      // on a listing, so the capability is honestly off and the palette's
+      // Folders/Tags toggle disappears for this provider.
+      tags: false,
+      search: false,
+      upload: false,
+      delete: false,
+    },
+    async list(_ctx, query) {
+      const assets = await listing();
+      // tagPath can arrive despite the capability (the contract: ignore,
+      // never throw) — without tags every asset would sit at the tags root,
+      // which is just the folder-flat view, so serve folders regardless.
+      return pageFromFlatListing(assets, query);
+    },
+  };
+}

--- a/apps/timeline-gstudio001/package.json
+++ b/apps/timeline-gstudio001/package.json
@@ -16,6 +16,8 @@
     "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1094.0",
+    "@aws-sdk/s3-request-presigner": "^3.1094.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1258,6 +1258,101 @@ test.describe("graph view E2E", () => {
     await expect(drawer.locator('[data-palette-folder="b-roll"]')).toHaveCount(0);
   });
 
+  test("provider picker: appears with two providers, switches the source, hidden with one", async ({
+    page,
+  }) => {
+    await installGraphApi(page);
+
+    // Register AFTER installGraphApi so these win: one handler for BOTH the
+    // providers list and the (provider-scoped) asset listing. Two providers
+    // installed — Cloudinary (default) and S3 — with disjoint contents so a
+    // switch is unmistakable.
+    await page.route("**/api/assets/providers**", (route) =>
+      route.fulfill({
+        json: {
+          providers: [
+            {
+              id: "cloudinary",
+              label: "Cloudinary",
+              capabilities: {
+                folders: true,
+                tags: false,
+                search: false,
+                upload: false,
+                delete: false,
+              },
+            },
+            {
+              id: "s3",
+              label: "S3 (media-bucket)",
+              capabilities: {
+                folders: true,
+                tags: false,
+                search: false,
+                upload: false,
+                delete: false,
+              },
+            },
+          ],
+        },
+      }),
+    );
+    await page.route("**/api/assets?**", (route) => {
+      const url = new URL(route.request().url());
+      const provider = url.searchParams.get("provider") ?? "cloudinary";
+      const asset = (id: string) => ({
+        id,
+        providerId: provider,
+        name: `${id}.png`,
+        kind: "image",
+        src: PIXEL,
+        thumbnailUrl: PIXEL,
+        folderPath: [],
+        tags: [],
+      });
+      return route.fulfill({
+        json: {
+          providerId: provider,
+          capabilities: { folders: true, tags: false, search: false, upload: false, delete: false },
+          folders: [],
+          assets: provider === "s3" ? [asset("s3-only")] : [asset("cloud-only")],
+        },
+      });
+    });
+
+    await openGraph(page);
+    await assetsButton(page).click();
+    const drawer = page.getByRole("dialog", { name: "Asset palette" });
+
+    // Cloudinary is the default source, so its content shows first…
+    await expect(drawer.locator('[data-palette-item="asset-cloud-only"]')).toBeVisible();
+    const picker = drawer.getByRole("combobox", { name: "Asset source" });
+    await expect(picker).toBeVisible();
+
+    // …switch to S3: its disjoint content replaces Cloudinary's.
+    await picker.selectOption("s3");
+    await expect(drawer.locator('[data-palette-item="asset-s3-only"]')).toBeVisible();
+    await expect(drawer.locator('[data-palette-item="asset-cloud-only"]')).toHaveCount(0);
+
+    // And back — proving the switch is real navigation, not a one-way trip.
+    await picker.selectOption("cloudinary");
+    await expect(drawer.locator('[data-palette-item="asset-cloud-only"]')).toBeVisible();
+    await expect(drawer.locator('[data-palette-item="asset-s3-only"]')).toHaveCount(0);
+  });
+
+  test("provider picker stays hidden when only one provider is installed", async ({ page }) => {
+    // The DEFAULT installGraphApi mock returns no providers list (its
+    // `**/api/assets**` handler answers the providers URL with an assets
+    // payload that carries no `providers` field), so the picker never
+    // appears — the single-provider deployment is visually unchanged.
+    await installGraphApi(page);
+    await openGraph(page);
+    await assetsButton(page).click();
+    const drawer = page.getByRole("dialog", { name: "Asset palette" });
+    await expect(drawer.locator('[data-palette-item="asset-img-1"]')).toBeVisible();
+    await expect(drawer.getByRole("combobox", { name: "Asset source" })).toHaveCount(0);
+  });
+
   test("trash drop moves across roots, persists BOTH documents, and undoes", async ({
     page,
   }) => {

--- a/docs/asset-providers.md
+++ b/docs/asset-providers.md
@@ -73,10 +73,35 @@ serves both; only the source differs:
    where UNTAGGED assets sit beside the top-level groups), and the palette
    grows a capability-gated Folders/Tags toggle. An asset tagged twice lives
    in both places; folder placement is invisible in tag space.
-4. **S3 adapter** (decided: the second provider) + provider picker; upload/
-   delete through the seam.
+4. ✅ **S3 adapter** + provider picker. `lib/assets/s3-provider.ts` maps
+   object keys to neutral assets (folders from the key path via the same
+   `pageFromFlatListing`), env-configured (`S3_ASSETS_BUCKET` /
+   `S3_ASSETS_REGION`, optional `S3_ASSETS_PREFIX` and `S3_ASSETS_PUBLIC_URL`;
+   URLs are presigned GETs when no public base is set, so private buckets
+   work). The SDK loads lazily and the deps (`listObjects` / `urlFor`) are
+   injectable, so the adapter unit-tests without AWS. The provider registers
+   only when the bucket is configured; the palette's picker `<select>`
+   appears only when more than one provider is installed. Upload/delete
+   through the seam is still ahead (both providers declare them off).
 5. Retire the legacy drawer's bespoke virtual-timeline folder pipeline
    (`/api/timelines/asset-library-*`) onto the seam.
+
+## Enabling S3
+
+Set in the app's environment:
+
+```
+S3_ASSETS_BUCKET=my-media-bucket
+S3_ASSETS_REGION=us-east-1
+S3_ASSETS_PREFIX=media/            # optional — the browse root inside the bucket
+S3_ASSETS_PUBLIC_URL=https://cdn…  # optional — omit for presigned private URLs
+```
+
+Credentials ride the AWS SDK default chain (`AWS_ACCESS_KEY_ID` /
+`AWS_SECRET_ACCESS_KEY`, or an instance role). With the bucket set, the
+provider registers and the palette shows an "Asset source" picker. The
+bucket is app-level (every signed-in user sees the same bucket); per-user
+buckets would be the OAuth track's concern.
 
 Out of scope until its own track: per-user OAuth providers (token storage,
 refresh, connect/disconnect UI). The `AssetContext` parameter is where those

--- a/package-lock.json
+++ b/package-lock.json
@@ -495,6 +495,8 @@
     "apps/timeline-gstudio001": {
       "version": "0.1.0",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.1094.0",
+        "@aws-sdk/s3-request-presigner": "^3.1094.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -711,6 +713,331 @@
         "@babel/runtime": "^7.0.0",
         "bind-event-listener": "^3.0.0",
         "raf-schd": "^4.0.3"
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.19.tgz",
+      "integrity": "sha512-Hc4N100RdkuWshKBnhPzmpdftfi9mCLz+OHFELHM1QIgMH4QRUUWyWgfiebta/YX2Bd62wTcm3EqAP8TeXv0gA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1094.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1094.0.tgz",
+      "integrity": "sha512-Qkz3HXW9bBajTO1Pgvbxkj2THliDnYPFBaJwIF1mDmnPe1E7reV9V/QJxBz14slIvdcU0tiyB+z37Qns0EY9Zg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.19",
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/credential-provider-node": "^3.972.71",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.65",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.976.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.976.0.tgz",
+      "integrity": "sha512-0cjRaEdlVoOrsNb9pP5q1Syyc8pXw5xSj2Np2ryReRTr9FppIIRVSdZK4lbnfmc2Hvgux/xBOUU6baB7z8//uA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.36",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.4",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.60",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.60.tgz",
+      "integrity": "sha512-BAkxdoe7tpDDqCghGpuOeHQRbm/2znVvOQm0AvpQbA2tbfMN46doN4zx65fv85ImP3KADwc2zQPmbrlI9MPfMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.62",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.62.tgz",
+      "integrity": "sha512-g/0fGqKTb9xpKdd9AtpmV5Eo3DFKbnkpA2+w0peISSlu7NfAoWOuYBFxsu+yWBtxU89ka55ezoZBCbFaS8pjYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.5.tgz",
+      "integrity": "sha512-ylubazcRfq2TVus/qXucSXeC42Qdjp5HQxTu68K/BsdMiZlcSLD1zkpoCgApXZX1Y6YJhtGGs7ZHhO/GuIgBlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/credential-provider-env": "^3.972.60",
+        "@aws-sdk/credential-provider-http": "^3.972.62",
+        "@aws-sdk/credential-provider-login": "^3.972.67",
+        "@aws-sdk/credential-provider-process": "^3.972.60",
+        "@aws-sdk/credential-provider-sso": "^3.973.4",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.66",
+        "@aws-sdk/nested-clients": "^3.997.34",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.67.tgz",
+      "integrity": "sha512-CCygIKJ9YbI3n84OClSaSppkgKKHVj2TGT33c6FRORZrYNZQ1POmD+ip0FLYokiJAK7sSdc3YVkOsBm90oxWMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/nested-clients": "^3.997.34",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.71.tgz",
+      "integrity": "sha512-HIg7Q2osBzajQwL+1Vkyh2E7Gim3eTNb9RHIsOxDGjW0eZg4oEKtRs5sioCnc73ilhaOm4gX2lHVF8J7+nt2rg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.60",
+        "@aws-sdk/credential-provider-http": "^3.972.62",
+        "@aws-sdk/credential-provider-ini": "^3.973.5",
+        "@aws-sdk/credential-provider-process": "^3.972.60",
+        "@aws-sdk/credential-provider-sso": "^3.973.4",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.66",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.60",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.60.tgz",
+      "integrity": "sha512-YIo3f99hM43QdYG8hDzwGemnR/pU95b0kramqSJUTleCqaB7+HwKf7YZFHqvOgTqZTPx/mRmNIqoDRr3U0Z3Tw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.4.tgz",
+      "integrity": "sha512-BPdmL8sSBOCv4ngZ+3LHxyc3CNqDCEK37CHioCk7zGrTMY5sUtkH8q+o6qA80nn6w3/fyBPGNE7OIRlmoOxRQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/nested-clients": "^3.997.34",
+        "@aws-sdk/token-providers": "3.1092.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.66.tgz",
+      "integrity": "sha512-kSAziJboOmZmsR9/MTbiNjowl2BPes1bQuJpne4qAZ62ubi8fjfr/aupJSQje6udBoYxXTQbsL0e0kby2la3ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/nested-clients": "^3.997.34",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.65.tgz",
+      "integrity": "sha512-udwNhRfDTfCB98mAHjjgsnKQlxygB4e0X+Obne/XjJpvVsF0YCQC8ZErd/8Z6IPoLQjtiKHzwqEDbZiLrJEnOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.34.tgz",
+      "integrity": "sha512-Y9REVrSwmLM+Qy6sZJ7ofMC2S3Hr3tPP/4CzL5U1olPP7OGoF+6+Px0E49cVQBtSxJtyeLJMf0UaBErfeSahAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1094.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1094.0.tgz",
+      "integrity": "sha512-7kG3C37tPWEpz8TyHslFhi2TrQ10und7ijerO0V/Ljq2uxBWVi4SFcol8yp2gM09HYzMnkWCfOxAKJZ2OZvClw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
+      "integrity": "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1092.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1092.0.tgz",
+      "integrity": "sha512-hBYUAr6iBLNFcsiWTgtBb0stdSw39VOUq4Sp4A5caCNf66BAZplWN4FleKrVpJx5li2YgdnK2DqoFSMWC642FQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/nested-clients": "^3.997.34",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.36.tgz",
+      "integrity": "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -6756,6 +7083,87 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@smithy/core": {
+      "version": "3.29.8",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.8.tgz",
+      "integrity": "sha512-rpCbCV+TimOBi3VLNBMmtTvgfOWcFIEAru3+TFlG87SL2F+te4jOnnNR+cf3uR4eJ5Qf4LnT80fqnBKgPRS6zA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.13.tgz",
+      "integrity": "sha512-X+2HNZhWi5i3rJsCas0LPf6fTQUaKyJ40zd8aTO/bwpRfpU3biYaqLr7C1WMibL7PVKJalpi1PyybjGPNoHC8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.10",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.10.tgz",
+      "integrity": "sha512-5/Yj9mS2JjTsB3B8ZX7euh77mrY9aXW23ag1yAmFykSRmA6vldqBrgqmSeQ50EjY+5SB8+aE4w14B6LKbBVEhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.10",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.10.tgz",
+      "integrity": "sha512-ETQz9v/Z+nTQc6fRWTXxUpxJqwpmzB3Tn3WKAdHwWkeT+m+HE5czs6GNG8vW+4vyxXSls65RVcvOZwk7Q/PS/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.9",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.9.tgz",
+      "integrity": "sha512-g5rnEii/mkT0mjVJmlsaOfyNBtHNTecD9Lo4NP8D5HzMUEnZNpz7/FbvBCjNcV4vteHFAxOGiLUYNxPkDZZAPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@so-ric/colorspace": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
@@ -9873,6 +10281,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/boxen": {
       "version": "5.1.2",


### PR DESCRIPTION
Phase 4 of the asset-panel epic (`docs/asset-providers.md`) — the seam's second provider and its first real multi-provider proof.

### S3 adapter (`lib/assets/s3-provider.ts`)

An S3 bucket is a flat namespace of path-shaped keys, so folder browsing falls out of the **same** `pageFromFlatListing` the Cloudinary adapter uses — the second provider needed no new browsing code, which is the seam doing its job.

- **Env-configured**: `S3_ASSETS_BUCKET` + `S3_ASSETS_REGION` required; `S3_ASSETS_PREFIX` sets the browse root, `S3_ASSETS_PUBLIC_URL` a CDN base. With no public base, URLs are **presigned GETs** — private buckets work untouched.
- Media kind from the key extension; a video's poster is a **sibling image key** when one exists, else an empty thumb (the palette's labelled-tile fallback).
- Tags are honestly **off** (per-object `GetObjectTagging` is unaffordable on a listing), so this provider's Folders/Tags toggle simply never appears.

**Testability + cost**: the AWS SDK loads **lazily** (an unconfigured deployment never pays for it) behind an injectable `S3Deps` seam (`listObjects` / `urlFor`), so the adapter unit-tests fully without AWS — 11 cases (config parsing, key→asset mapping, shared folder scoping, non-media skipping, sibling posters, capabilities, bucket labelling, TTL caching). It registers only when the bucket is configured, so the picker never offers a dead provider.

### Provider picker (`graph-asset-palette`)

A `<select>` in the palette header, shown only when `/api/assets/providers` returns **more than one** — a single-provider deployment is visually unchanged. Switching provider is a full reset to the folder root (a path, and even the hierarchy *mode*, belong to the provider you left; the new one may not do tags). The page cache is now keyed by `[provider, mode, path]` so nothing leaks across a switch, and every request threads `?provider=`.

### Tests

s3-provider unit (11) + two e2e: the picker appears with two providers and switches to disjoint S3 content and back (**proven fail-first** — drop `?provider=` and the switch shows nothing), and stays hidden with one provider. **Live-verified**: with no S3 env only Cloudinary registers, `?provider=s3` 404s, the picker is absent, and the palette is unchanged (4 folders / 21 assets / tags toggle present).

Deps: `@aws-sdk/client-s3` + `@aws-sdk/s3-request-presigner`.

App vitest 263/263 · graph-view e2e 61/61 · app `tsc` clean · lint clean (4 pre-existing `img` warnings).

### To actually enable S3

Set `S3_ASSETS_BUCKET` / `S3_ASSETS_REGION` (+ optional `S3_ASSETS_PREFIX`, `S3_ASSETS_PUBLIC_URL`) and provide AWS credentials via the SDK default chain. Until then it's dormant and nothing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
