### PR TITLE
Asset panel phase 5: retire the legacy virtual-timeline pipeline onto the seam

### DIFF
--- a/apps/timeline-gstudio001/app/api/timelines/[id]/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/[id]/route.ts
@@ -8,8 +8,6 @@ import {
 } from "@/lib/firebase-timeline-store";
 import { requireAuthUser } from "@/lib/firebase-auth-session";
 import {
-  decodeFolderPath,
-  encodeFolderPath,
   getFolderPathFromTimelineId,
   isStoredTimelineDocument,
   isUnsavedProjectPlaceholder,
@@ -18,7 +16,8 @@ import {
 // package's fixture set, not model logic.
 import { getTimelineDocument } from "@storyboard/ui/timeline/timeline-documents";
 import { CLOUDINARY_PROVIDER_ID } from "@/lib/assets/cloudinary-provider";
-import { listCloudinaryAssets } from "@/lib/cloudinary-media-store";
+import { buildAssetLibraryClips } from "@/lib/assets/asset-library-timeline";
+import { assetProviders } from "@/lib/assets/registry";
 import { serveTimelineDocument, serveTrashDocument } from "@/lib/serve-timeline";
 import { checkUserScopedId, TimelineAccessDeniedError } from "@/lib/timeline-ownership";
 
@@ -79,161 +78,28 @@ export async function GET(
     if (id.startsWith("asset-library-")) {
       const firebaseDocument = await getFirebaseTimelineDocument(id, user.uid);
 
-      let title = "Cloudinary Assets";
-      if (id.startsWith("asset-library-col-")) {
-        title = "New Collection";
-      }
+      const title = id.startsWith("asset-library-col-") ? "New Collection" : "Cloudinary Assets";
+      const doc: TimelineDocument = firebaseDocument || { id, title, clips: [] };
 
-      const doc: TimelineDocument = firebaseDocument || {
-        id,
-        title,
-        clips: [],
-      };
-
-      // 1. Fetch Cloudinary assets
-      const cloudinaryAssets = await listCloudinaryAssets(user.uid);
+      // The bespoke Cloudinary listing + hand-rolled folder detection this
+      // branch used to do now lives behind the provider seam (phase 5): ask
+      // the Cloudinary provider for this folder's page — the SAME
+      // folder-scoping the graph palette uses — and shape it into the
+      // media-strip's synthetic-timeline clips. Pinned to Cloudinary because
+      // the asset-library ids embed Cloudinary folder paths; the drawer is
+      // Cloudinary's, not a generic provider surface.
       const folderPath = getFolderPathFromTimelineId(id, user.uid);
-
-      // Detect subfolders under the current folderPath
-      const detectedSubfolders = new Set<string>();
-      cloudinaryAssets.forEach((asset) => {
-        const path = asset.relativePath || asset.pathname;
-        const parts = path.split("/").filter(Boolean);
-        parts.pop(); // remove file name
-        const assetFolder = parts.join("/");
-
-        if (folderPath === "") {
-          if (parts.length > 0) {
-            detectedSubfolders.add(parts[0]);
-          }
-        } else {
-          if (
-            assetFolder.startsWith(folderPath + "/") &&
-            parts.length > folderPath.split("/").length
-          ) {
-            const childPath = parts.slice(0, folderPath.split("/").length + 1).join("/");
-            detectedSubfolders.add(childPath);
-          }
-        }
-      });
-
-      // 2. Filter Cloudinary assets in this folder
-      const assetsInFolder = cloudinaryAssets.filter((asset) => {
-        const path = asset.relativePath || asset.pathname;
-        const parts = path.split("/").filter(Boolean);
-        parts.pop(); // remove file name
-        const assetFolder = parts.join("/");
-        return assetFolder === folderPath;
-      });
-
-      const allActiveUrls = new Set(cloudinaryAssets.map((a) => a.url));
-
-      // 3. Keep existing collections and valid media clips
-      let merged = doc.clips.filter((clip) => {
-        if (clip.kind === "collection") return true;
-        return allActiveUrls.has(clip.src);
-      });
-
-      // Inject dynamically detected Cloudinary subfolders as collections
-      detectedSubfolders.forEach((subfolderPath) => {
-        const childId = `asset-library-col-${user.uid}-${encodeFolderPath(subfolderPath)}`;
-        const exists = merged.some(
-          (clip) => clip.kind === "collection" && clip.childTimelineId === childId
-        );
-        if (!exists) {
-          const folderName = subfolderPath.split("/").pop() || "Folder";
-          const uniqueId = `dynamic-col-${encodeFolderPath(subfolderPath)}`;
-          merged.push({
-            id: uniqueId,
-            index: merged.length,
-            kind: "collection",
-            title: folderName,
-            childTimelineId: childId,
-            itemCount: 0,
-            duration: 3,
-            sourceDuration: 3,
-            trimIn: 0,
-            trimOut: 0,
-            alt: folderName,
-            aspect: 16 / 9,
-            trackIndex: 0,
-            startTime: 0,
-          });
-        }
-      });
-
-      // 4. Add new assets
-      assetsInFolder.forEach((asset) => {
-        const exists = merged.some(
-          (clip) => clip.kind !== "collection" && clip.src === asset.url
-        );
-        if (!exists) {
-          const name = asset.relativePath?.split("/").pop()?.replace(/\.[^/.]+$/, "") || "Asset";
-          const aspect =
-            asset.width && asset.height && asset.height > 0
-              ? asset.width / asset.height
-              : 16 / 9;
-          const duration = asset.resourceType === "video" ? (asset.duration ?? 6) : 4;
-          const stableId = `asset-${asset.id.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
-
-          // Provenance travels with the clip from the moment it is minted
-          // (`sourceAsset` on the stored model): `src` is how it renders,
-          // this is which provider file it IS.
-          const sourceAsset = { providerId: CLOUDINARY_PROVIDER_ID, assetId: asset.id };
-          const newClip: TimelineClip =
-            asset.resourceType === "video"
-              ? {
-                  id: stableId,
-                  index: merged.length,
-                  kind: "video",
-                  src: asset.url,
-                  poster: asset.thumbnailUrl,
-                  alt: name,
-                  aspect,
-                  trackIndex: 0,
-                  startTime: 0,
-                  duration,
-                  sourceDuration: duration,
-                  trimIn: 0,
-                  trimOut: 0,
-                  sourceAsset,
-                }
-              : {
-                  id: stableId,
-                  index: merged.length,
-                  kind: "image",
-                  src: asset.url,
-                  alt: name,
-                  aspect,
-                  trackIndex: 0,
-                  startTime: 0,
-                  duration,
-                  sourceDuration: duration,
-                  trimIn: 0,
-                  trimOut: 0,
-                  sourceAsset,
-                };
-
-          merged.push(newClip);
-        }
-      });
-
-      // 5. Reindex and pack clips
-      let nextStartTime = 1;
-      const packedClips = merged.map((clip, index) => {
-        const packed = {
-          ...clip,
-          index,
-          startTime: nextStartTime,
-        };
-        nextStartTime += packed.duration + 1;
-        return packed;
-      });
+      const folderSegments = folderPath === "" ? [] : folderPath.split("/");
+      const provider = assetProviders.get(CLOUDINARY_PROVIDER_ID);
+      if (!provider) {
+        return NextResponse.json({ error: "Asset provider unavailable." }, { status: 500 });
+      }
+      const page = await provider.list({ uid: user.uid }, { folder: folderSegments });
 
       return NextResponse.json({
         document: {
           ...doc,
-          clips: packedClips,
+          clips: buildAssetLibraryClips(page, user.uid, doc.clips),
         },
       });
     }

--- a/apps/timeline-gstudio001/app/api/timelines/asset-library-route.test.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/asset-library-route.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { encodeFolderPath } from "@storyboard/timeline-model";
+import type {
+  CollectionTimelineClip,
+  TimelineClip,
+  TimelineDocument,
+} from "@storyboard/timeline-model/types";
+import type { CloudinaryAsset } from "@/lib/cloudinary-media-store";
+
+// The REAL asset-library GET branch over the REAL provider seam and Cloudinary
+// adapter — only the process boundaries are faked (session, the persisted
+// firebase doc, the vendor listing). Proves phase 5: the synthetic
+// asset-library timeline is now built FROM the seam, not a bespoke Cloudinary
+// pipeline.
+
+const state = vi.hoisted(() => ({
+  vendorAssets: [] as CloudinaryAsset[],
+  persisted: null as TimelineDocument | null,
+  user: { uid: "user-a" } as { uid: string } | null,
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/firebase-auth-session", () => ({
+  requireAuthUser: async () =>
+    state.user
+      ? { user: state.user, response: null }
+      : { user: null, response: new Response(null, { status: 401 }) },
+}));
+vi.mock("@/lib/cloudinary-media-store", () => ({
+  listCloudinaryAssets: async () => state.vendorAssets,
+}));
+vi.mock("@/lib/firebase-timeline-store", () => ({
+  getFirebaseTimelineDocument: async () => state.persisted,
+  saveFirebaseTimelineEntry: async () => ({ document: null, revision: 0 }),
+  deleteFirebaseTimelineDocument: async () => undefined,
+}));
+// serve-timeline imports from the (mocked) store; the asset-library branch
+// returns before reaching it, so a no-op stub is enough.
+vi.mock("@/lib/serve-timeline", () => ({
+  serveTimelineDocument: async () => null,
+  serveTrashDocument: async () => null,
+}));
+
+import { GET as getTimeline } from "./[id]/route";
+
+function vendorAsset(id: string, relativePath: string, over: Partial<CloudinaryAsset> = {}): CloudinaryAsset {
+  return {
+    id,
+    pathname: `gstudio/user-a/${relativePath}`,
+    url: `https://cdn.test/${id}`,
+    thumbnailUrl: `https://cdn.test/${id}.thumb`,
+    resourceType: "image",
+    relativePath,
+    ...over,
+  };
+}
+
+async function getDoc(id: string): Promise<TimelineDocument> {
+  const response = await getTimeline(new Request(`http://test.local/api/timelines/${id}`), {
+    params: Promise.resolve({ id }),
+  });
+  expect(response.status).toBe(200);
+  return ((await response.json()) as { document: TimelineDocument }).document;
+}
+
+beforeEach(() => {
+  state.vendorAssets = [
+    vendorAsset("root-a", "root-a.png"),
+    vendorAsset("scenes-1", "Scenes/s1.png"),
+    vendorAsset("heist-1", "Scenes/Heist/h1.png"),
+  ];
+  state.persisted = null;
+  state.user = { uid: "user-a" };
+});
+
+describe("GET /api/timelines/asset-library-<uid> (seam-backed)", () => {
+  it("synthesizes the ROOT folder: its asset plus a subfolder collection", async () => {
+    const doc = await getDoc("asset-library-user-a");
+    // Folders first, then root-level assets — the deeper assets appear only
+    // through the subfolder collection.
+    expect(doc.clips.map((clip) => clip.kind)).toEqual(["collection", "image"]);
+
+    const collection = doc.clips[0] as CollectionTimelineClip;
+    expect(collection.title).toBe("Scenes");
+    expect(collection.childTimelineId).toBe(
+      `asset-library-col-user-a-${encodeFolderPath("Scenes")}`,
+    );
+
+    const media = doc.clips[1] as TimelineClip & { sourceAsset?: unknown };
+    expect(media).toMatchObject({
+      kind: "image",
+      src: "https://cdn.test/root-a",
+      sourceAsset: { providerId: "cloudinary", assetId: "root-a" },
+    });
+  });
+
+  it("scopes a subfolder timeline id to that folder's contents", async () => {
+    const doc = await getDoc(`asset-library-col-user-a-${encodeFolderPath("Scenes")}`);
+    // Scenes: its direct asset (scenes-1) + its Heist subfolder collection.
+    expect(doc.clips.map((clip) => clip.kind)).toEqual(["collection", "image"]);
+    expect((doc.clips[0] as CollectionTimelineClip).childTimelineId).toBe(
+      `asset-library-col-user-a-${encodeFolderPath("Scenes/Heist")}`,
+    );
+    const media = doc.clips[1] as TimelineClip;
+    expect(media.src).toBe("https://cdn.test/scenes-1");
+  });
+
+  it("returns an empty timeline for an empty library, not an error", async () => {
+    state.vendorAssets = [];
+    const doc = await getDoc("asset-library-user-a");
+    expect(doc.clips).toEqual([]);
+  });
+});

--- a/apps/timeline-gstudio001/lib/assets/asset-library-timeline.test.ts
+++ b/apps/timeline-gstudio001/lib/assets/asset-library-timeline.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import { encodeFolderPath } from "@storyboard/timeline-model";
+import type { CollectionTimelineClip, TimelineClip } from "@storyboard/timeline-model/types";
+
+import { buildAssetLibraryClips } from "./asset-library-timeline";
+import type { Asset, AssetFolder, AssetPage } from "./types";
+
+const UID = "user-1";
+
+function asset(id: string, over: Partial<Asset> = {}): Asset {
+  return {
+    id,
+    providerId: "cloudinary",
+    name: `${id}.png`,
+    kind: "image",
+    src: `https://cdn.test/${id}`,
+    thumbnailUrl: `https://cdn.test/${id}.thumb`,
+    folderPath: [],
+    tags: [],
+    ...over,
+  };
+}
+
+function folder(...path: string[]): AssetFolder {
+  return { name: path[path.length - 1], path };
+}
+
+function page(over: Partial<AssetPage> = {}): AssetPage {
+  return { assets: [], folders: [], ...over };
+}
+
+const childId = (segments: string[]) =>
+  `asset-library-col-${UID}-${encodeFolderPath(segments.join("/"))}`;
+
+describe("buildAssetLibraryClips", () => {
+  it("maps subfolders to navigable collections and assets to media, folders first", () => {
+    const clips = buildAssetLibraryClips(
+      page({
+        folders: [folder("Scenes")],
+        assets: [asset("pic-1"), asset("clip-1", { kind: "video", durationSeconds: 12 })],
+      }),
+      UID,
+    );
+    expect(clips.map((clip) => clip.kind)).toEqual(["collection", "image", "video"]);
+
+    const collection = clips[0] as CollectionTimelineClip;
+    expect(collection.title).toBe("Scenes");
+    expect(collection.childTimelineId).toBe(childId(["Scenes"]));
+    expect(collection.id).toBe(`dynamic-col-${encodeFolderPath("Scenes")}`);
+
+    // A nested subfolder's child id embeds its FULL path.
+    const nested = buildAssetLibraryClips(page({ folders: [folder("Scenes", "Heist")] }), UID);
+    expect((nested[0] as CollectionTimelineClip).childTimelineId).toBe(childId(["Scenes", "Heist"]));
+  });
+
+  it("records sourceAsset provenance and strips the extension from the name", () => {
+    // asset("beach") -> name "beach.png"; stripExtension -> "beach".
+    const [image] = buildAssetLibraryClips(page({ assets: [asset("beach")] }), UID);
+    expect(image).toMatchObject({
+      kind: "image",
+      alt: "beach", // extension stripped from the .png name
+      src: "https://cdn.test/beach",
+      sourceAsset: { providerId: "cloudinary", assetId: "beach" },
+    });
+  });
+
+  it("uses the asset's real duration for video, default 4s for image", () => {
+    const clips = buildAssetLibraryClips(
+      page({
+        assets: [asset("v", { kind: "video", durationSeconds: 9.5 }), asset("i")],
+      }),
+      UID,
+    );
+    expect(clips[0].duration).toBe(9.5);
+    expect(clips[1].duration).toBe(4);
+  });
+
+  it("packs with a 1s leading pad and 1s gaps, reindexed", () => {
+    const clips = buildAssetLibraryClips(
+      page({ assets: [asset("a"), asset("b")] }),
+      UID,
+    );
+    // image duration 4, gap 1 -> starts at 1, then 1+4+1 = 6
+    expect(clips.map((clip) => [clip.index, clip.startTime])).toEqual([
+      [0, 1],
+      [1, 6],
+    ]);
+  });
+
+  it("keeps a persisted clip's order and drops stale ones on refresh", () => {
+    const persisted: TimelineClip[] = [
+      // still-live asset, out of listing order — its position must survive
+      { ...(buildAssetLibraryClips(page({ assets: [asset("b")] }), UID)[0]) },
+      // stale media (asset deleted) — must be dropped
+      { ...(buildAssetLibraryClips(page({ assets: [asset("gone")] }), UID)[0]) },
+    ];
+    const clips = buildAssetLibraryClips(
+      page({ assets: [asset("a"), asset("b")] }),
+      UID,
+      persisted,
+    );
+    // b (persisted, kept first) then a (newly appended); "gone" dropped.
+    expect(clips.map((clip) => clip.id)).toEqual([
+      `asset-${"b"}`,
+      `asset-${"a"}`,
+    ]);
+  });
+
+  it("drops a persisted collection whose folder no longer exists", () => {
+    const persisted = buildAssetLibraryClips(page({ folders: [folder("Old")] }), UID);
+    // The live page has a different folder — the stale collection must not
+    // survive, and the live one is appended.
+    const clips = buildAssetLibraryClips(page({ folders: [folder("New")] }), UID, persisted);
+    expect(clips.map((clip) => (clip as CollectionTimelineClip).childTimelineId)).toEqual([
+      childId(["New"]),
+    ]);
+  });
+
+  it("is empty for an empty page", () => {
+    expect(buildAssetLibraryClips(page(), UID)).toEqual([]);
+  });
+});

--- a/apps/timeline-gstudio001/lib/assets/asset-library-timeline.ts
+++ b/apps/timeline-gstudio001/lib/assets/asset-library-timeline.ts
@@ -1,0 +1,135 @@
+// Builds the legacy asset-library VIRTUAL TIMELINE from a neutral asset page.
+//
+// The legacy storyboard/workbench asset drawer (components/assets/
+// asset-library-drawer) browses folders by loading synthetic TimelineDocuments
+// from `/api/timelines/asset-library-<uid>[-col-<folder>]`, rendering them
+// through the media-strip. Before phase 5 the route SYNTHESIZED those
+// documents by calling Cloudinary directly and hand-rolling folder detection —
+// a second, parallel copy of what the provider seam already does.
+//
+// This module is that synthesis rebuilt ON the seam: the route now asks the
+// provider for a folder page (assets + subfolders, the same
+// `pageFromFlatListing` the graph palette uses) and this pure function shapes
+// it into the media-strip's clip model. The drawer is unchanged; the bespoke
+// Cloudinary pipeline is gone, so the seam is the single asset-listing path.
+
+import { encodeFolderPath } from "@storyboard/timeline-model";
+import type { TimelineClip } from "@storyboard/timeline-model/types";
+
+import type { AssetPage } from "./types";
+
+/** A media clip's stable id, matching the pre-seam scheme so a persisted
+ *  asset-library document (rare, but possible) still reconciles by id. */
+function assetClipId(assetId: string): string {
+  return `asset-${assetId.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+}
+
+function stripExtension(name: string): string {
+  return name.replace(/\.[^/.]+$/, "");
+}
+
+/**
+ * Shape a folder page into the asset-library timeline's clips: each subfolder
+ * becomes a navigable collection clip pointing at its own
+ * `asset-library-col-<uid>-<encoded>` timeline, each asset a media clip
+ * carrying its `sourceAsset` provenance. Ordered folders-first (the drawer's
+ * long-standing layout), then packed with the leading-pad + 1s-gap spacing the
+ * old route used, so the media-strip renders identically.
+ *
+ * `persistedClips` is the stored document's clips when one exists — kept only
+ * where they still correspond to a live folder/asset, so a user's manual order
+ * survives a refresh without resurrecting deleted media. Everything not
+ * already present is appended.
+ */
+export function buildAssetLibraryClips(
+  page: AssetPage,
+  uid: string,
+  persistedClips: readonly TimelineClip[] = [],
+): TimelineClip[] {
+  const liveChildIds = new Set(
+    page.folders.map(
+      (folder) => `asset-library-col-${uid}-${encodeFolderPath(folder.path.join("/"))}`,
+    ),
+  );
+  const liveAssetClipIds = new Set(page.assets.map((asset) => assetClipId(asset.id)));
+
+  // Keep persisted clips that still exist in this folder, in their stored
+  // order; drop stale ones (a collection whose folder vanished, media whose
+  // asset was deleted). Tracks what survived so the append step skips dupes.
+  const kept: TimelineClip[] = [];
+  const seenChildIds = new Set<string>();
+  const seenAssetClipIds = new Set<string>();
+  for (const clip of persistedClips) {
+    if (clip.kind === "collection") {
+      if (!liveChildIds.has(clip.childTimelineId) || seenChildIds.has(clip.childTimelineId)) {
+        continue;
+      }
+      seenChildIds.add(clip.childTimelineId);
+      kept.push(clip);
+    } else {
+      if (!liveAssetClipIds.has(clip.id) || seenAssetClipIds.has(clip.id)) continue;
+      seenAssetClipIds.add(clip.id);
+      kept.push(clip);
+    }
+  }
+
+  const folderClips: TimelineClip[] = page.folders
+    .filter((folder) => {
+      const childId = `asset-library-col-${uid}-${encodeFolderPath(folder.path.join("/"))}`;
+      return !seenChildIds.has(childId);
+    })
+    .map((folder) => {
+      const childId = `asset-library-col-${uid}-${encodeFolderPath(folder.path.join("/"))}`;
+      return {
+        id: `dynamic-col-${encodeFolderPath(folder.path.join("/"))}`,
+        index: 0,
+        kind: "collection",
+        title: folder.name,
+        childTimelineId: childId,
+        itemCount: 0,
+        duration: 3,
+        sourceDuration: 3,
+        trimIn: 0,
+        trimOut: 0,
+        alt: folder.name,
+        aspect: 16 / 9,
+        trackIndex: 0,
+        startTime: 0,
+      } satisfies TimelineClip;
+    });
+
+  const assetClips: TimelineClip[] = page.assets
+    .filter((asset) => !seenAssetClipIds.has(assetClipId(asset.id)))
+    .map((asset) => {
+      const duration = asset.kind === "video" ? (asset.durationSeconds ?? 6) : 4;
+      const aspect =
+        asset.width && asset.height && asset.height > 0 ? asset.width / asset.height : 16 / 9;
+      const base = {
+        id: assetClipId(asset.id),
+        index: 0,
+        alt: stripExtension(asset.name),
+        aspect,
+        trackIndex: 0,
+        startTime: 0,
+        duration,
+        sourceDuration: duration,
+        trimIn: 0,
+        trimOut: 0,
+        // Provenance travels with the clip — `src` renders it, this says
+        // which provider file it IS (the model's `sourceAsset`).
+        sourceAsset: { providerId: asset.providerId, assetId: asset.id },
+      };
+      return asset.kind === "video"
+        ? { ...base, kind: "video", src: asset.src, poster: asset.thumbnailUrl }
+        : { ...base, kind: "image", src: asset.src };
+    });
+
+  // Pack: reindex and lay out with the old spacing (1s leading pad, 1s gaps),
+  // preserving kept clips' relative order ahead of freshly-appended ones.
+  let nextStartTime = 1;
+  return [...kept, ...folderClips, ...assetClips].map((clip, index) => {
+    const packed = { ...clip, index, startTime: nextStartTime };
+    nextStartTime += packed.duration + 1;
+    return packed;
+  });
+}

--- a/docs/asset-providers.md
+++ b/docs/asset-providers.md
@@ -83,8 +83,23 @@ serves both; only the source differs:
    only when the bucket is configured; the palette's picker `<select>`
    appears only when more than one provider is installed. Upload/delete
    through the seam is still ahead (both providers declare them off).
-5. Retire the legacy drawer's bespoke virtual-timeline folder pipeline
-   (`/api/timelines/asset-library-*`) onto the seam.
+5. ✅ Retire the legacy virtual-timeline pipeline onto the seam. The
+   `/api/timelines/asset-library-*` GET branch no longer lists Cloudinary
+   directly or hand-rolls folder detection: it asks the Cloudinary provider
+   for the folder's page (the same `pageFromFlatListing` the palette uses) and
+   `lib/assets/asset-library-timeline.ts` shapes it into the media-strip's
+   synthetic-timeline clips (folders → navigable collections, assets → media
+   with `sourceAsset`). The legacy storyboard/workbench drawer is UNCHANGED —
+   it still browses those synthetic timelines through the media-strip — but
+   the seam is now the single asset-listing path. (Minor behavior improvement:
+   a persisted folder-collection whose Cloudinary folder no longer exists is
+   dropped rather than shown stale.)
+
+The seam is now the only asset-BROWSING path in the app. `listCloudinaryAssets`
+survives in exactly two places: the Cloudinary provider adapter (its data
+source), and `serve-timeline`'s document HEALING (validating a stored clip's
+media still exists) — a different concern from browsing, left as-is. No route
+lists assets to browse them except through a provider.
 
 ## Enabling S3
 


### PR DESCRIPTION
The final phase (`docs/asset-providers.md`) — the seam becomes the single asset-**browsing** path.

### What changed

The `/api/timelines/asset-library-*` GET branch — the legacy storyboard/workbench asset drawer's data source — no longer lists Cloudinary directly or hand-rolls folder detection. It asks the Cloudinary provider for the folder's page (the **same** `pageFromFlatListing` the graph palette uses) and a pure builder shapes it into the media-strip's synthetic timeline.

### Why this shape

The legacy drawer renders through the **media-strip** DnD system — a subsystem deliberately left untouched here — and browses by loading synthetic `TimelineDocument`s per folder. So "retire onto the seam" is done **server-side**: the bespoke Cloudinary listing + folder detection (~130 lines) becomes a provider `list({ folder })` call + `buildAssetLibraryClips`. **The drawer is unchanged** — same media-strip, same UX — but the parallel copy of folder logic is gone.

- **`lib/assets/asset-library-timeline.ts`** (new, pure): `AssetPage` → the drawer's clips. Folders → navigable `asset-library-col-<uid>-<encoded>` collections, assets → media clips with `sourceAsset`, folders-first, packed with the old spacing so the strip renders identically. A persisted document reconciles: kept in stored order where still live (preserving a user's folder **renames** and manual order), stale entries dropped. Pinned to Cloudinary — the asset-library ids embed Cloudinary folder paths.
- **route**: the ~130-line branch collapses to folder-resolve + provider call + builder; dead imports removed.

### Behavior

Identical to the old route, with one improvement it makes explicit: a persisted folder-collection whose Cloudinary folder no longer exists is now **dropped** rather than shown as a stale tile opening to nothing (unit-tested).

`listCloudinaryAssets` now survives in exactly two places: the provider adapter (its data source) and `serve-timeline`'s document **healing** (validating a stored clip's media still exists — a different concern from browsing, left as-is).

### Tests

Builder unit (7) + a route test over the **real** branch + real seam + Cloudinary adapter (root synthesis, subfolder scoping, empty library). **Live-verified** against the real account: the storyboard drawer renders the seam-backed library (4 folder-collections + media, provenance intact), drill-in works, the graph palette is unaffected.

App vitest 273/273 · graph-view e2e 61/61 (two known load-dependent flakes green in isolation) · app `tsc` clean · lint clean (4 pre-existing `img` warnings).

**Epic complete** — phases 1–5 all shipped (PRs #160–#164).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
