### PR TITLE
Graph review: session guard, playhead repaint, strip selector

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
@@ -242,6 +242,22 @@ export function GraphItemActionsBridge({
   const [busy, setBusy] = useState(false);
   const busyRef = useRef(false);
 
+  // Session-lifetime guard for the async actions below. This bridge is
+  // remounted with a fresh store whenever the graph's session key changes
+  // (project / user / trash-generation switch), so ONE mount == ONE session:
+  // the ref flips false only on a true unmount, and NEVER on the intra-session
+  // dep changes (focusedId / trashId navigation) that merely re-run the action
+  // effect — those keep the same live store, so an in-flight Duplicate is still
+  // valid across them. An async action consults it before touching the store
+  // or the SINGLETON documents gateway; see `duplicateSelection`.
+  const sessionAliveRef = useRef(true);
+  useEffect(() => {
+    sessionAliveRef.current = true;
+    return () => {
+      sessionAliveRef.current = false;
+    };
+  }, []);
+
   // Graph → sidebar: mirror the live selection size + busy (on mount and every
   // change) — and zero it on unmount, so a later graph session doesn't flash
   // the previous session's stale item-mode cluster before its own first
@@ -343,9 +359,20 @@ export function GraphItemActionsBridge({
       const built: Built[] = [];
       for (const id of selected) {
         const clone = await buildClone(store, details, id);
+        // The session can be torn down (project switch) while a clone's
+        // document tree loads. Bail the moment it is — before loading more.
+        if (!sessionAliveRef.current) return;
         if (clone !== null) built.push({ sourceId: id, clone });
       }
       if (built.length === 0) return;
+
+      // The safety-critical check: everything below dispatches into `store`
+      // and, via `insertClones`, seeds + writes cloned child documents through
+      // the singleton gateway. If the session died during the loads above,
+      // those writes would seed timelines into a project that no longer exists
+      // — orphans with no graph path to reach them. No awaits follow, so this
+      // one guard covers the whole side-effecting section.
+      if (!sessionAliveRef.current) return;
 
       const liveGraph = store.getSnapshot().graph;
       const groups = new Map<NodeId, Built[]>();

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -188,14 +188,22 @@ export function GraphPlayhead({
     let lastGraph: CollectionsGraph | null = null;
     let lastDetails: DetailsById | null = null;
     let map: PlayheadMap | null = null;
-    const paint = () => {
+    // Rebuild the position map only when its geometry inputs (graph/details)
+    // change; returns whether it did, so store-driven callers can skip the DOM
+    // write when nothing the playhead reads actually moved.
+    const rebuildIfNeeded = (): boolean => {
       const graph = store.getSnapshot().graph;
       const details = detailsStore.read();
-      if (graph !== lastGraph || details !== lastDetails) {
-        lastGraph = graph;
-        lastDetails = details;
-        map = buildPlayheadMap(childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond)));
-      }
+      if (graph === lastGraph && details === lastDetails) return false;
+      lastGraph = graph;
+      lastDetails = details;
+      map = buildPlayheadMap(
+        childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond)),
+      );
+      return true;
+    };
+    // Position-only style write, for the current clock time.
+    const paint = () => {
       const line = lineRef.current;
       if (!line || !map) return;
       const time = channel.get();
@@ -206,10 +214,24 @@ export function GraphPlayhead({
       line.style.display = inside ? "" : "none";
       if (inside) line.style.transform = `translateX(${map.xAt(time)}px)`;
     };
-    paint();
-    const unsubscribeTime = channel.subscribe(paint);
-    const unsubscribeStore = store.subscribe(paint);
-    const unsubscribeDetails = detailsStore.subscribe(paint);
+    // The clock moved: always reposition, cheaply picking up any pending
+    // geometry change on the way (the rebuild is a no-op when nothing changed).
+    const tick = () => {
+      rebuildIfNeeded();
+      paint();
+    };
+    // A store/details notification only matters to the playhead when it changed
+    // the geometry. Drag start/end, selection, and every drop-intent tick
+    // during a drag leave the committed graph untouched, so this bails before
+    // any DOM write — otherwise every mounted sub-timeline playhead repainted
+    // on each of those, directly on the drag/INP hot path.
+    const onData = () => {
+      if (rebuildIfNeeded()) paint();
+    };
+    tick();
+    const unsubscribeTime = channel.subscribe(tick);
+    const unsubscribeStore = store.subscribe(onData);
+    const unsubscribeDetails = detailsStore.subscribe(onData);
     return () => {
       unsubscribeTime();
       unsubscribeStore();
@@ -433,7 +455,11 @@ export function GraphGridPlayhead({
     let lastCellWidth = 0;
     let map: GridPlayheadMap | null = null;
 
-    const paint = () => {
+    // Rebuild the position map only when its geometry inputs change — graph or
+    // details, plus the grid's live column count / cell width. Returns whether
+    // it did, so store-driven callers can skip the DOM write when nothing the
+    // playhead reads actually moved.
+    const rebuildIfNeeded = (): boolean => {
       const graph = store.getSnapshot().graph;
       const details = detailsStore.read();
       const columns = Number(grid?.dataset.gridColumns) || 1;
@@ -442,22 +468,28 @@ export function GraphGridPlayhead({
       // is only a target for picking column count, not the rendered size.
       const cellWidth = Number(grid?.dataset.gridCellWidth) || 1;
       if (
-        graph !== lastGraph ||
-        details !== lastDetails ||
-        columns !== lastColumns ||
-        cellWidth !== lastCellWidth
+        graph === lastGraph &&
+        details === lastDetails &&
+        columns === lastColumns &&
+        cellWidth === lastCellWidth
       ) {
-        lastGraph = graph;
-        lastDetails = details;
-        lastColumns = columns;
-        lastCellWidth = cellWidth;
-        map = buildGridPlayheadMap(
-          childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond)),
-          columns,
-          cellWidth,
-          cellHeight,
-        );
+        return false;
       }
+      lastGraph = graph;
+      lastDetails = details;
+      lastColumns = columns;
+      lastCellWidth = cellWidth;
+      map = buildGridPlayheadMap(
+        childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond)),
+        columns,
+        cellWidth,
+        cellHeight,
+      );
+      return true;
+    };
+
+    // Position-only style write, for the current clock time.
+    const paint = () => {
       if (!map) return;
       const time = channel.get();
       const inside =
@@ -471,11 +503,27 @@ export function GraphGridPlayhead({
       line.style.height = `${map.rowHeight + SEEK_RAIL_BAND_INSET_PX}px`;
     };
 
-    paint();
-    const unsubscribeTime = channel.subscribe(paint);
-    const unsubscribeStore = store.subscribe(paint);
-    const unsubscribeDetails = detailsStore.subscribe(paint);
-    const observer = grid ? new ResizeObserver(paint) : null;
+    // The clock moved: always reposition, cheaply picking up any pending
+    // geometry change on the way (the rebuild is a no-op when nothing changed).
+    const tick = () => {
+      rebuildIfNeeded();
+      paint();
+    };
+    // Store / details / resize notifications only matter when they changed the
+    // geometry. Drag start/end, selection, and every drop-intent tick during a
+    // drag leave the committed graph untouched, so this bails before any DOM
+    // write — otherwise every mounted sub-timeline playhead repainted on each
+    // of those, directly on the drag/INP hot path. A resize that alters
+    // columns/cellWidth is caught here too.
+    const onData = () => {
+      if (rebuildIfNeeded()) paint();
+    };
+
+    tick();
+    const unsubscribeTime = channel.subscribe(tick);
+    const unsubscribeStore = store.subscribe(onData);
+    const unsubscribeDetails = detailsStore.subscribe(onData);
+    const observer = grid ? new ResizeObserver(onData) : null;
     if (grid && observer) observer.observe(grid);
     return () => {
       unsubscribeTime();

--- a/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
@@ -249,8 +249,15 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
     const graphGeneration = useCollectionsSelector((s) => s.graphGeneration);
     const nodesById = store.getSnapshot().graph.nodesById;
     // The selected video (if any) drives the TrimOverview band above the row.
+    // Scoped to THIS collection's own children: only the strip that owns the
+    // selected clip can show its trim overview, so a selection anywhere else in
+    // the graph leaves this selector returning null and Object.is bails the
+    // re-render. (Unscoped, it returned the first selected video ANYWHERE, so
+    // every mounted strip received the same node and re-rendered on any video
+    // selection — even though only one strip could ever display it.)
     const selectedVideo = useCollectionsSelector((s) => {
       for (const id of s.interaction.selectedIds) {
+        if (s.graph.parentById.get(id) !== collectionId) continue;
         const n = s.graph.nodesById.get(id);
         if (n && isVideoMedia(n)) return n;
       }


### PR DESCRIPTION
Addresses the three code-defect findings from the DnD/graph review (the remaining #4 is a known env flake, #5 a deliberate type nit).

## Fixes

**#1 — P1 lifecycle: async Duplicate can outlive the project session.**
`duplicateSelection` awaits each collection's document tree, but a project switch remounts the actions bridge with a fresh store while the old promise keeps the old `store` and the singleton documents gateway. On resolve it would seed cloned child documents into a project that no longer exists — orphaned timelines. Added a session-alive ref (flipped only on a true unmount, so intra-session `focusedId`/`trashId` navigation never trips it) checked after each load and immediately before the side-effecting `insertClones`.

**#2 — P2 playhead repaint on every store notification.**
Both strip and grid playheads subscribed one `paint` to the whole store, writing `line.style` on every notify — including each drop-intent tick during a drag. Split into a position-only `paint` (time channel) and a `rebuildIfNeeded`-gated data path (store/details/grid resize). During a drag the committed graph is unchanged, so the store path now bails before any DOM write; time-only movement stays on the time channel.

**#3 — P2 selecting one video re-renders every strip.**
`VirtualStrip`'s `selectedVideo` selector returned the first selected video *anywhere*, so every mounted strip got the same node and re-rendered. Scoped the scan to the strip's own children (`parentById.get(id) === collectionId`); non-owning strips return `null` and `Object.is` bails.

## Verification
- `eslint` + `tsc --noEmit` clean on all touched files (the one project-wide tsc error is pre-existing in `asset-library-route.test.ts`, unrelated).
- graph-view scrub e2e: 3 passed (strip drag-to-scrub, strip auto-pan, grid scrub).
- VirtualStrip story interaction tests: 42 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
