### PR TITLE
WebMCP agent tools: registry + read_timeline + move_clip

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-mcp-tools.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-mcp-tools.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { useCollectionsStore } from "@storyboard/ui/dnd-collections";
+
+import { createGraphTools } from "@/lib/webmcp/tools";
+import { registerWebMcpTools } from "@/lib/webmcp/webmcp-adapter";
+
+import { useGraphDetailsStore } from "./graph-details-context";
+
+/**
+ * Registers the WebMCP agent tools for the open graph session.
+ *
+ * Rendered INSIDE `<DndCollections>` (next to PersistenceBridge) so it can
+ * reach the live store and the details side-table. Registration is tied to
+ * this mount via `registerWebMcpTools`' AbortController: the bridge remounts
+ * with a fresh store whenever the graph session key changes, so tools can't
+ * outlive their session — the same session-lifetime discipline the async
+ * item-action handlers use. `focusedId` re-registers the tools (they default
+ * reads and placement to the open collection); the store is stable within a
+ * session, so intra-session reads always see current state via getSnapshot.
+ */
+export function McpToolsBridge({ focusedId }: Readonly<{ focusedId: string }>) {
+  const store = useCollectionsStore();
+  const details = useGraphDetailsStore();
+
+  useEffect(
+    () => registerWebMcpTools(createGraphTools({ store, details, focusedId })),
+    [store, details, focusedId],
+  );
+
+  return null;
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -55,6 +55,7 @@ import { GraphBoard, type FocusSurface, type ItemSize } from "./graph-board";
 import { GraphDetailsProvider } from "./graph-details-context";
 import { HydrationController } from "./graph-hydration";
 import { GraphItemActionsBridge } from "./graph-item-actions";
+import { McpToolsBridge } from "./graph-mcp-tools";
 import { GRAPH_VIEW_COMPONENTS } from "./graph-item-content";
 import { GraphViewNavProvider } from "./graph-navigation";
 import {
@@ -496,6 +497,7 @@ export function GraphTimelineView({
       >
           <PersistenceBridge onSync={onSync} />
           <GraphItemActionsBridge trashId={boot.trashRootId} focusedId={focusedId} />
+          <McpToolsBridge focusedId={focusedId} />
           <GraphDetailsJanitor />
           <AssetPaletteDrawer open={assetsOpen} onClose={() => setAssetsOpen(false)} />
           <HydrationController

--- a/apps/timeline-gstudio001/lib/webmcp/placement.test.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/placement.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import { buildGraph, parseNodeId, type CollectionsGraph } from "@storyboard/ui/dnd-collections";
+
+import { resolveMovePlacement } from "./placement";
+
+/** project ─ a, b, scene-a[ c1, c2 ] */
+function fixture(): CollectionsGraph {
+  const built = buildGraph([
+    {
+      kind: "collection",
+      id: "project",
+      name: "Project",
+      children: [
+        { kind: "media", id: "a", name: "a" },
+        { kind: "media", id: "b", name: "b" },
+        {
+          kind: "collection",
+          id: "scene-a",
+          name: "Scene A",
+          children: [
+            { kind: "media", id: "c1", name: "c1" },
+            { kind: "media", id: "c2", name: "c2" },
+          ],
+        },
+      ],
+    },
+  ]);
+  if (!built.ok) throw new Error(`fixture invalid: ${JSON.stringify(built.error)}`);
+  return built.value;
+}
+
+const id = parseNodeId;
+
+describe("resolveMovePlacement", () => {
+  const graph = fixture();
+
+  it("reorders within the same parent, adjusting for the post-removal shift", () => {
+    // Move `a` after `b`: pre-removal insert index is 2, but removing `a`
+    // (index 0, before the target) shifts it down to 1.
+    expect(resolveMovePlacement(graph, { nodeId: id("a"), targetId: id("project"), after: id("b") })).toEqual(
+      { ok: true, toParentId: id("project"), toIndex: 1 },
+    );
+  });
+
+  it("does not adjust when the node sits after the insertion point", () => {
+    // Move `scene-a` (index 2) to the start: nothing before it is removed.
+    expect(
+      resolveMovePlacement(graph, { nodeId: id("scene-a"), targetId: id("project"), position: "start" }),
+    ).toEqual({ ok: true, toParentId: id("project"), toIndex: 0 });
+  });
+
+  it("places at the end of the same parent (post-removal length)", () => {
+    expect(resolveMovePlacement(graph, { nodeId: id("a"), targetId: id("project"), position: "end" })).toEqual(
+      { ok: true, toParentId: id("project"), toIndex: 2 },
+    );
+  });
+
+  it("moves into another collection without a post-removal adjustment", () => {
+    expect(resolveMovePlacement(graph, { nodeId: id("a"), targetId: id("scene-a"), before: id("c1") })).toEqual(
+      { ok: true, toParentId: id("scene-a"), toIndex: 0 },
+    );
+    expect(resolveMovePlacement(graph, { nodeId: id("a"), targetId: id("scene-a"), position: "end" })).toEqual(
+      { ok: true, toParentId: id("scene-a"), toIndex: 2 },
+    );
+  });
+
+  it("defaults to end when no anchor is given", () => {
+    expect(resolveMovePlacement(graph, { nodeId: id("c1"), targetId: id("scene-a") })).toEqual({
+      ok: true,
+      toParentId: id("scene-a"),
+      toIndex: 1, // [c1, c2] → removing c1 → end is index 1
+    });
+  });
+
+  it("rejects an unknown anchor", () => {
+    expect(resolveMovePlacement(graph, { nodeId: id("a"), targetId: id("project"), after: id("nope") })).toEqual(
+      { ok: false, error: { reason: "unknown-anchor", anchor: id("nope") } },
+    );
+  });
+
+  it("rejects conflicting anchors", () => {
+    expect(
+      resolveMovePlacement(graph, {
+        nodeId: id("a"),
+        targetId: id("project"),
+        before: id("b"),
+        position: "end",
+      }),
+    ).toEqual({ ok: false, error: { reason: "conflicting-anchors" } });
+  });
+});

--- a/apps/timeline-gstudio001/lib/webmcp/placement.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/placement.ts
@@ -1,0 +1,62 @@
+import { getChildren, type CollectionsGraph, type NodeId } from "@storyboard/ui/dnd-collections";
+
+// Pure placement math for move_clip: turn a SEMANTIC anchor (before/after a
+// sibling, or start/end of a collection) into the reducer's `toIndex`. The
+// agent never computes indexes — this does, including the reducer's
+// post-removal convention (`toIndex` is the target's children index AFTER the
+// moved node is removed, so a same-parent reorder past the node shifts down).
+
+export type MovePlacementInput = Readonly<{
+  /** The node being moved. */
+  nodeId: NodeId;
+  /** The collection it should end up in (already resolved from `into` or the current parent). */
+  targetId: NodeId;
+  before?: NodeId;
+  after?: NodeId;
+  position?: "start" | "end";
+}>;
+
+export type PlacementError =
+  | Readonly<{ reason: "conflicting-anchors" }>
+  | Readonly<{ reason: "unknown-anchor"; anchor: NodeId }>;
+
+export type PlacementOutcome =
+  | Readonly<{ ok: true; toParentId: NodeId; toIndex: number }>
+  | Readonly<{ ok: false; error: PlacementError }>;
+
+export function resolveMovePlacement(
+  graph: CollectionsGraph,
+  input: MovePlacementInput,
+): PlacementOutcome {
+  const anchorCount =
+    (input.before !== undefined ? 1 : 0) +
+    (input.after !== undefined ? 1 : 0) +
+    (input.position !== undefined ? 1 : 0);
+  if (anchorCount > 1) return { ok: false, error: { reason: "conflicting-anchors" } };
+
+  const siblings = getChildren(graph, input.targetId);
+
+  // Pre-removal insertion index within the current sibling order.
+  let pre: number;
+  if (input.before !== undefined) {
+    const at = siblings.indexOf(input.before);
+    if (at < 0) return { ok: false, error: { reason: "unknown-anchor", anchor: input.before } };
+    pre = at;
+  } else if (input.after !== undefined) {
+    const at = siblings.indexOf(input.after);
+    if (at < 0) return { ok: false, error: { reason: "unknown-anchor", anchor: input.after } };
+    pre = at + 1;
+  } else if (input.position === "start") {
+    pre = 0;
+  } else {
+    pre = siblings.length;
+  }
+
+  // Post-removal adjustment: only when reordering WITHIN the same collection
+  // does removing the node shift the target index down by one.
+  const currentIndex =
+    graph.parentById.get(input.nodeId) === input.targetId ? siblings.indexOf(input.nodeId) : -1;
+  const toIndex = currentIndex >= 0 && currentIndex < pre ? pre - 1 : pre;
+
+  return { ok: true, toParentId: input.targetId, toIndex };
+}

--- a/apps/timeline-gstudio001/lib/webmcp/results.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/results.ts
@@ -1,0 +1,46 @@
+import type { DispatchRejection } from "@storyboard/ui/dnd-collections";
+
+import type { ToolResult } from "./types";
+
+/** A successful tool result: a human summary plus the machine payload. */
+export function toolOk(text: string, structuredContent?: unknown): ToolResult {
+  return structuredContent === undefined
+    ? { content: [{ type: "text", text }] }
+    : { content: [{ type: "text", text }], structuredContent };
+}
+
+/** A tool-level error the agent should see and can act on. */
+export function toolError(text: string): ToolResult {
+  return { content: [{ type: "text", text }], isError: true };
+}
+
+/**
+ * Turn a `store.dispatch` rejection into an agent-facing sentence. Every
+ * reducer/policy rejection reason maps to something the agent can correct; the
+ * `blocked-by-policy` case is the app's un-hydrated-collection veto.
+ */
+export function describeDispatchRejection(error: DispatchRejection): string {
+  switch (error.reason) {
+    case "missing-node":
+      return `No node with id "${error.nodeId}".`;
+    case "target-not-collection":
+      return `Target "${error.nodeId}" is a clip, not a collection — items can only go inside a collection.`;
+    case "would-create-cycle":
+      return `That move would nest "${error.nodeId}" inside itself.`;
+    case "cannot-move-root":
+      return `"${error.nodeId}" is a top-level timeline and can't be moved.`;
+    case "duplicate-node-id":
+      return `A node with id "${error.nodeId}" already exists.`;
+    case "invalid-node-id":
+      return "That node id is empty or blank.";
+    case "invalid-node":
+      return "The node failed validation.";
+    case "blocked-by-policy":
+      return (
+        error.message ??
+        `The target collection hasn't loaded yet (${error.blockedIds.join(", ")}). Open it first, then retry.`
+      );
+    default:
+      return "The edit was refused.";
+  }
+}

--- a/apps/timeline-gstudio001/lib/webmcp/timeline-tree.test.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/timeline-tree.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { buildGraph, parseNodeId, type CollectionsGraph } from "@storyboard/ui/dnd-collections";
+
+import { buildTimelineTree } from "./timeline-tree";
+
+/** project ─ img1 (image 3s), vid1 (video full 10, trim 1/2 → 7s), scene-a[ c1, c2 ] */
+function fixture(): CollectionsGraph {
+  const built = buildGraph([
+    {
+      kind: "collection",
+      id: "project",
+      name: "Project",
+      children: [
+        { kind: "media", id: "img1", name: "img1", durationSeconds: 3 },
+        {
+          kind: "media",
+          mediaKind: "video",
+          id: "vid1",
+          name: "vid1",
+          fullDurationSeconds: 10,
+          trimInSeconds: 1,
+          trimOutSeconds: 2,
+        },
+        {
+          kind: "collection",
+          id: "scene-a",
+          name: "Scene A",
+          children: [
+            { kind: "media", id: "c1", name: "c1" },
+            { kind: "media", id: "c2", name: "c2" },
+          ],
+        },
+      ],
+    },
+  ]);
+  if (!built.ok) throw new Error(`fixture invalid: ${JSON.stringify(built.error)}`);
+  return built.value;
+}
+
+const project = parseNodeId("project");
+const allHydrated = () => true;
+
+describe("buildTimelineTree", () => {
+  const graph = fixture();
+
+  it("projects media fields and reports focus", () => {
+    const tree = buildTimelineTree(graph, project, "project", 1, allHydrated);
+    expect(tree.timeline).toEqual({ id: "project", title: "Project", focused: true });
+    expect(tree.nodes[0]).toMatchObject({ id: "img1", kind: "media", mediaKind: "image", durationSeconds: 3 });
+    expect(tree.nodes[1]).toMatchObject({
+      id: "vid1",
+      kind: "media",
+      mediaKind: "video",
+      durationSeconds: 7,
+      trimInSeconds: 1,
+      trimOutSeconds: 2,
+      fullDurationSeconds: 10,
+    });
+  });
+
+  it("summarizes a nested collection at depth 1 (no children)", () => {
+    const tree = buildTimelineTree(graph, project, "project", 1, allHydrated);
+    const collection = tree.nodes[2];
+    expect(collection).toMatchObject({ id: "scene-a", kind: "collection", hydrated: true, childCount: 2 });
+    expect(collection.children).toBeUndefined();
+  });
+
+  it("expands a hydrated collection at depth 2", () => {
+    const tree = buildTimelineTree(graph, project, "project", 2, allHydrated);
+    expect(tree.nodes[2].children?.map((c) => c.id)).toEqual(["c1", "c2"]);
+  });
+
+  it("never expands an un-hydrated placeholder, even within depth", () => {
+    const isHydrated = (id: string) => id !== "scene-a";
+    const tree = buildTimelineTree(graph, project, "project", 2, isHydrated);
+    expect(tree.nodes[2]).toMatchObject({ id: "scene-a", hydrated: false });
+    expect(tree.nodes[2].children).toBeUndefined();
+  });
+
+  it("reports focused:false when reading a non-focused collection", () => {
+    const tree = buildTimelineTree(graph, parseNodeId("scene-a"), "project", 1, allHydrated);
+    expect(tree.timeline).toEqual({ id: "scene-a", title: "Scene A", focused: false });
+  });
+});

--- a/apps/timeline-gstudio001/lib/webmcp/timeline-tree.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/timeline-tree.ts
@@ -1,0 +1,126 @@
+import {
+  getChildren,
+  mediaDurationSeconds,
+  type CollectionsGraph,
+  type MediaNode,
+  type NodeId,
+} from "@storyboard/ui/dnd-collections";
+
+// Pure graph → structured-tree projection for read_timeline. No store, no
+// details store — hydration is injected as a predicate so this unit-tests
+// directly. Ids are treated as OPAQUE strings (never split/parsed).
+
+export type TimelineTreeNode = Readonly<{
+  id: string;
+  kind: "media" | "collection";
+  name: string;
+  // media:
+  mediaKind?: "image" | "video";
+  src?: string;
+  durationSeconds?: number;
+  trimInSeconds?: number;
+  trimOutSeconds?: number;
+  fullDurationSeconds?: number;
+  // collection:
+  hydrated?: boolean;
+  childCount?: number;
+  children?: readonly TimelineTreeNode[];
+}>;
+
+export type TimelineTree = Readonly<{
+  timeline: Readonly<{ id: string; title: string; focused: boolean }>;
+  nodes: readonly TimelineTreeNode[];
+}>;
+
+/** `false` for an un-hydrated collection placeholder (a read on its id would
+ *  otherwise need to lazy-load). Unknown ids default to hydrated. */
+export type IsHydrated = (collectionId: string) => boolean;
+
+export function buildTimelineTree(
+  graph: CollectionsGraph,
+  rootId: NodeId,
+  focusedId: string,
+  depth: number,
+  isHydrated: IsHydrated,
+): TimelineTree {
+  const root = graph.nodesById.get(rootId);
+  return {
+    timeline: {
+      id: String(rootId),
+      title: root?.name ?? String(rootId),
+      focused: String(rootId) === focusedId,
+    },
+    nodes: walk(graph, rootId, depth, isHydrated, new Set()),
+  };
+}
+
+function walk(
+  graph: CollectionsGraph,
+  parentId: NodeId,
+  depth: number,
+  isHydrated: IsHydrated,
+  ancestors: ReadonlySet<string>,
+): TimelineTreeNode[] {
+  const out: TimelineTreeNode[] = [];
+  for (const id of getChildren(graph, parentId)) {
+    const node = graph.nodesById.get(id);
+    if (!node) continue;
+    if (node.kind === "media") {
+      out.push(mediaTreeNode(node));
+    } else {
+      out.push(collectionTreeNode(graph, id, node.name, depth, isHydrated, ancestors));
+    }
+  }
+  return out;
+}
+
+function mediaTreeNode(node: MediaNode): TimelineTreeNode {
+  if (node.mediaKind === "video") {
+    return {
+      id: String(node.id),
+      kind: "media",
+      name: node.name,
+      mediaKind: "video",
+      src: node.src,
+      durationSeconds: mediaDurationSeconds(node),
+      trimInSeconds: node.trimInSeconds,
+      trimOutSeconds: node.trimOutSeconds,
+      fullDurationSeconds: node.fullDurationSeconds,
+    };
+  }
+  return {
+    id: String(node.id),
+    kind: "media",
+    name: node.name,
+    mediaKind: "image",
+    src: node.src,
+    durationSeconds: mediaDurationSeconds(node),
+  };
+}
+
+function collectionTreeNode(
+  graph: CollectionsGraph,
+  id: NodeId,
+  name: string,
+  depth: number,
+  isHydrated: IsHydrated,
+  ancestors: ReadonlySet<string>,
+): TimelineTreeNode {
+  const idStr = String(id);
+  const hydrated = isHydrated(idStr);
+  const base: TimelineTreeNode = {
+    id: idStr,
+    kind: "collection",
+    name,
+    hydrated,
+    childCount: getChildren(graph, id).length,
+  };
+  // Expand only within depth, only hydrated collections, and never revisit an
+  // ancestor id (guards a reference-shared / malformed cyclic graph).
+  if (depth > 1 && hydrated && !ancestors.has(idStr)) {
+    const nextAncestors = new Set(ancestors);
+    nextAncestors.add(idStr);
+    return { ...base, children: walk(graph, id, depth - 1, isHydrated, nextAncestors) };
+  }
+  return base;
+}

--- a/apps/timeline-gstudio001/lib/webmcp/tools.test.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/tools.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildGraph,
+  createCollectionsStore,
+  getChildren,
+  parseNodeId,
+  type CollectionsGraph,
+} from "@storyboard/ui/dnd-collections";
+
+import type { GraphDetailsStore } from "@/lib/graph-details-store";
+
+import { createGraphTools } from "./tools";
+
+/** project ─ a, b, scene-a[ c1 ] */
+function graph(): CollectionsGraph {
+  const built = buildGraph([
+    {
+      kind: "collection",
+      id: "project",
+      name: "Project",
+      children: [
+        { kind: "media", id: "a", name: "a" },
+        { kind: "media", id: "b", name: "b" },
+        { kind: "collection", id: "scene-a", name: "Scene A", children: [{ kind: "media", id: "c1", name: "c1" }] },
+      ],
+    },
+  ]);
+  if (!built.ok) throw new Error(`fixture invalid: ${JSON.stringify(built.error)}`);
+  return built.value;
+}
+
+// The tools only read `details.get`; a no-op store is enough for these paths.
+const fakeDetails = {
+  read: () => ({}),
+  get: () => undefined,
+  merge: () => {},
+  prune: () => {},
+  subscribe: () => () => {},
+} as unknown as GraphDetailsStore;
+
+function harness(focusedId = "project") {
+  const store = createCollectionsStore(graph());
+  const defs = createGraphTools({ store, details: fakeDetails, focusedId });
+  const tool = (name: string) => {
+    const found = defs.find((d) => d.name === name);
+    if (!found) throw new Error(`missing tool ${name}`);
+    return found;
+  };
+  const order = (parent: string) =>
+    getChildren(store.getSnapshot().graph, parseNodeId(parent)).map(String);
+  return { store, read: tool("read_timeline"), move: tool("move_clip"), order };
+}
+
+describe("read_timeline tool", () => {
+  it("returns the focused timeline as a structured tree", async () => {
+    const { read } = harness();
+    const res = await read.execute({});
+    expect(res.isError).toBeFalsy();
+    const tree = res.structuredContent as { timeline: { id: string }; nodes: { id: string }[] };
+    expect(tree.timeline.id).toBe("project");
+    expect(tree.nodes.map((n) => n.id)).toEqual(["a", "b", "scene-a"]);
+  });
+
+  it("errors on an unknown id", async () => {
+    const { read } = harness();
+    expect((await read.execute({ collectionId: "nope" })).isError).toBe(true);
+  });
+});
+
+describe("move_clip tool", () => {
+  it("reorders within the parent and actually mutates the store", async () => {
+    const { move, order } = harness();
+    const res = await move.execute({ nodeId: "a", after: "b" });
+    expect(res.isError).toBeFalsy();
+    expect(order("project")).toEqual(["b", "a", "scene-a"]);
+  });
+
+  it("moves into another collection, updating both parents", async () => {
+    const { move, order } = harness();
+    const res = await move.execute({ nodeId: "a", into: "scene-a", position: "end" });
+    expect(res.isError).toBeFalsy();
+    expect(order("scene-a")).toEqual(["c1", "a"]);
+    expect(order("project")).toEqual(["b", "scene-a"]);
+  });
+
+  it("surfaces the reducer rejection when the target is a clip", async () => {
+    const { move } = harness();
+    expect((await move.execute({ nodeId: "a", into: "b" })).isError).toBe(true);
+  });
+});

--- a/apps/timeline-gstudio001/lib/webmcp/tools.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/tools.ts
@@ -1,0 +1,187 @@
+import {
+  getChildren,
+  parseNodeId,
+  type CollectionsStore,
+  type NodeId,
+} from "@storyboard/ui/dnd-collections";
+
+import type { GraphDetailsStore } from "@/lib/graph-details-store";
+
+import { resolveMovePlacement } from "./placement";
+import { describeDispatchRejection, toolError, toolOk } from "./results";
+import { buildTimelineTree, type TimelineTree } from "./timeline-tree";
+import type { ToolDef } from "./types";
+
+// The live session the tools act on. Injected once by <McpToolsBridge>; the
+// handlers read `store.getSnapshot()` at call time so they always see current
+// state. Only `focusedId` is captured — the bridge re-registers on change.
+export type GraphToolContext = Readonly<{
+  store: CollectionsStore;
+  details: GraphDetailsStore;
+  focusedId: string;
+}>;
+
+/** The v1 tool surface. Add tools here as they land (see docs). */
+export function createGraphTools(ctx: GraphToolContext): ToolDef[] {
+  return [readTimelineTool(ctx), moveClipTool(ctx)];
+}
+
+// ---- arg readers: agent input is `unknown`, never trusted ------------------
+
+function record(args: unknown): Record<string, unknown> {
+  return typeof args === "object" && args !== null ? (args as Record<string, unknown>) : {};
+}
+function readString(args: unknown, key: string): string | undefined {
+  const value = record(args)[key];
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+function readNumber(args: unknown, key: string): number | undefined {
+  const value = record(args)[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+function readBoolean(args: unknown, key: string): boolean | undefined {
+  const value = record(args)[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+function readPosition(args: unknown): "start" | "end" | undefined {
+  const value = readString(args, "position");
+  return value === "start" || value === "end" ? value : undefined;
+}
+function optNodeId(value: string | undefined): NodeId | undefined {
+  return value === undefined ? undefined : parseNodeId(value);
+}
+
+// ---- read_timeline ---------------------------------------------------------
+
+function readTimelineTool(ctx: GraphToolContext): ToolDef {
+  return {
+    name: "read_timeline",
+    description:
+      "Read the open timeline (or a given collection) as a structured, id-addressable tree of clips and nested collections. This is how you see what you can act on before editing.",
+    annotations: { readOnlyHint: true },
+    inputSchema: {
+      type: "object",
+      properties: {
+        collectionId: {
+          type: "string",
+          description: "Collection node id to read. Omit for the currently focused timeline.",
+        },
+        depth: {
+          type: "integer",
+          minimum: 1,
+          default: 1,
+          description:
+            "Levels of nested collections to expand. Deeper (or un-hydrated) collections appear as summaries with hydrated:false.",
+        },
+      },
+      additionalProperties: false,
+    },
+    execute: (args) => {
+      const graph = ctx.store.getSnapshot().graph;
+      const idStr = readString(args, "collectionId") ?? ctx.focusedId;
+      const id = parseNodeId(idStr);
+      const node = graph.nodesById.get(id);
+      if (!node) return toolError(`No node with id "${idStr}".`);
+      if (node.kind !== "collection") {
+        return toolError(`"${idStr}" is a clip, not a collection — nothing to read into.`);
+      }
+      const depth = Math.max(1, Math.floor(readNumber(args, "depth") ?? 1));
+      const tree = buildTimelineTree(
+        graph,
+        id,
+        ctx.focusedId,
+        depth,
+        (collectionId) => ctx.details.get(collectionId)?.hydrated !== false,
+      );
+      return toolOk(summarize(tree), tree);
+    },
+  };
+}
+
+function summarize(tree: TimelineTree): string {
+  const head = `${tree.timeline.title} — ${tree.nodes.length} item${tree.nodes.length === 1 ? "" : "s"}`;
+  if (tree.nodes.length === 0) return `${head} (empty).`;
+  const parts = tree.nodes.slice(0, 6).map((n) =>
+    n.kind === "collection"
+      ? `${n.name} (collection, ${n.childCount ?? 0})`
+      : `${n.name} (${(n.durationSeconds ?? 0).toFixed(1)}s)`,
+  );
+  return `${head}: ${parts.join(", ")}${tree.nodes.length > 6 ? "…" : ""}`;
+}
+
+// ---- move_clip -------------------------------------------------------------
+
+function moveClipTool(ctx: GraphToolContext): ToolDef {
+  return {
+    name: "move_clip",
+    description:
+      "Move or reorder a clip or collection. Give the node id and where it should land: into a collection (omit to reorder within its current parent) and one of before/after a sibling, or position start/end.",
+    inputSchema: {
+      type: "object",
+      required: ["nodeId"],
+      properties: {
+        nodeId: { type: "string" },
+        into: {
+          type: "string",
+          description: "Target collection id. Omit to reorder within the current parent.",
+        },
+        after: { type: "string", description: "Place immediately after this sibling id." },
+        before: { type: "string", description: "Place immediately before this sibling id." },
+        position: { type: "string", enum: ["start", "end"] },
+        select: {
+          type: "boolean",
+          description: "Select the moved node afterward so it's visible. Default true.",
+        },
+      },
+      additionalProperties: false,
+    },
+    execute: (args) => {
+      const nodeIdStr = readString(args, "nodeId");
+      if (!nodeIdStr) return toolError("move_clip requires a nodeId.");
+      const graph = ctx.store.getSnapshot().graph;
+      const nodeId = parseNodeId(nodeIdStr);
+      const node = graph.nodesById.get(nodeId);
+      if (!node) return toolError(`No node with id "${nodeIdStr}".`);
+
+      const intoStr = readString(args, "into");
+      const parent = graph.parentById.get(nodeId) ?? null;
+      const targetStr = intoStr ?? (parent !== null ? String(parent) : undefined);
+      if (targetStr === undefined) {
+        return toolError(`"${nodeIdStr}" is a top-level timeline and can't be moved.`);
+      }
+      const targetId = parseNodeId(targetStr);
+
+      const placement = resolveMovePlacement(graph, {
+        nodeId,
+        targetId,
+        before: optNodeId(readString(args, "before")),
+        after: optNodeId(readString(args, "after")),
+        position: readPosition(args),
+      });
+      if (!placement.ok) {
+        return toolError(
+          placement.error.reason === "conflicting-anchors"
+            ? "Give only one of before / after / position."
+            : `No sibling "${placement.error.anchor}" in the target collection.`,
+        );
+      }
+
+      const result = ctx.store.dispatch({
+        type: "move-nodes",
+        nodeIds: [nodeId],
+        toParentId: targetId,
+        toIndex: placement.toIndex,
+      });
+      if (!result.ok) return toolError(describeDispatchRejection(result.error));
+
+      if (readBoolean(args, "select") !== false) ctx.store.setSelection([nodeId]);
+      const newOrder = getChildren(ctx.store.getSnapshot().graph, targetId).map(String);
+      return toolOk(`Moved "${node.name}" into "${targetStr}" at index ${placement.toIndex}.`, {
+        movedId: nodeIdStr,
+        toParentId: targetStr,
+        toIndex: placement.toIndex,
+        newOrder,
+      });
+    },
+  };
+}

--- a/apps/timeline-gstudio001/lib/webmcp/types.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/types.ts
@@ -1,0 +1,37 @@
+// Transport-agnostic tool layer for the WebMCP agent tools. Nothing in this
+// directory imports React or `navigator` except `webmcp-adapter.ts` — the
+// handlers are pure functions over the live CollectionsStore so they unit-test
+// without a browser, and a future server-MCP transport can wrap the same defs.
+// See docs/webmcp-agent-tools.md.
+
+/** MCP tool-result content block. Only text is used today. */
+export type ToolContentBlock = Readonly<{ type: "text"; text: string }>;
+
+/** MCP tool result. `structuredContent` is the machine-readable payload; the
+ *  text block is the human/agent-readable summary. */
+export type ToolResult = Readonly<{
+  content: readonly ToolContentBlock[];
+  isError?: boolean;
+  structuredContent?: unknown;
+}>;
+
+/** Optional hints the agent may use to reason about a tool (MCP annotations). */
+export type ToolAnnotations = Readonly<{
+  readOnlyHint?: boolean;
+  idempotentHint?: boolean;
+  destructiveHint?: boolean;
+}>;
+
+/**
+ * One tool. `inputSchema` is an opaque JSON Schema object (validated by the
+ * WebMCP layer / documented for the agent); `execute` receives the
+ * agent-supplied args as `unknown` and MUST narrow them itself — never trust
+ * the shape.
+ */
+export type ToolDef = Readonly<{
+  name: string;
+  description: string;
+  inputSchema: unknown;
+  annotations?: ToolAnnotations;
+  execute: (args: unknown) => Promise<ToolResult> | ToolResult;
+}>;

--- a/apps/timeline-gstudio001/lib/webmcp/webmcp-adapter.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/webmcp-adapter.ts
@@ -1,0 +1,51 @@
+import type { ToolDef, ToolResult } from "./types";
+
+// The ONE place the experimental WebMCP browser API is touched, so its churn
+// can't leak into the tool logic. WebMCP ships no TypeScript types yet, so we
+// declare the minimal surface we call: `navigator.modelContext.registerTool`
+// with an AbortSignal to unregister. See docs/webmcp-agent-tools.md.
+
+type WebMcpToolRegistration = Readonly<{
+  name: string;
+  description: string;
+  inputSchema: unknown;
+  annotations?: ToolDef["annotations"];
+  execute: (args: unknown) => Promise<ToolResult> | ToolResult;
+}>;
+
+type ModelContext = Readonly<{
+  registerTool: (tool: WebMcpToolRegistration, options?: { signal?: AbortSignal }) => void;
+}>;
+
+declare global {
+  interface Navigator {
+    readonly modelContext?: ModelContext;
+  }
+}
+
+/**
+ * Register every tool with the page's WebMCP provider, tying their lifetime to
+ * one AbortController. Returns an unregister function (abort). A no-op when the
+ * browser has no `navigator.modelContext` (flag off / unsupported), so callers
+ * can register unconditionally.
+ */
+export function registerWebMcpTools(tools: readonly ToolDef[]): () => void {
+  const modelContext =
+    typeof navigator !== "undefined" ? navigator.modelContext : undefined;
+  if (!modelContext?.registerTool) return () => {};
+
+  const controller = new AbortController();
+  for (const tool of tools) {
+    modelContext.registerTool(
+      {
+        name: tool.name,
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+        annotations: tool.annotations,
+        execute: (args) => tool.execute(args),
+      },
+      { signal: controller.signal },
+    );
+  }
+  return () => controller.abort();
+}

--- a/docs/webmcp-agent-tools.md
+++ b/docs/webmcp-agent-tools.md
@@ -1,0 +1,375 @@
+# WebMCP agent tools
+
+**Status: design / planning — no code yet.** This is the agreed shape for
+letting an AI agent (Claude, or any MCP client) edit the timeline while the
+app is open side-by-side and updates in real time. Keep it current as
+decisions land — see the decision log at the bottom.
+
+## Goal
+
+A **two-writer loop**: you edit in the browser, an agent edits through tools,
+both hit the same timeline documents, and both views stay honest.
+
+```
+You    ─▶ Browser editor ─┐
+                          ├─▶ CollectionsStore command ─▶ PersistenceBridge ─▶ Firestore (revision/CAS)
+Agent  ─▶ WebMCP tools ───┘                                      │
+   ▲                                                             │
+   └──────────────── live re-render (same store) ◀──────────────┘
+```
+
+The headline requirement — *see changes in real time, side by side* — is why
+WebMCP wins here over a server-side MCP: a WebMCP tool runs **in the page**
+and mutates the **live in-memory graph** the UI already renders from, so the
+open editor animates the change and `PersistenceBridge` writes it to
+Firestore, both for free.
+
+## Why the codebase is ready for this
+
+- **The domain engine is headless.** `@storyboard/collections-core` (reducer,
+  patches, graph) and `@storyboard/timeline-domain` (document ⇄ graph adapter)
+  have no React/DOM deps, so a tool can run the *actual* command path and
+  invariants — not a re-implementation.
+- **One mutation path already exists.** Every edit is a `CollectionsCommand`
+  through `store.dispatch`. A tool is a thin translator onto those commands.
+- **Persistence + concurrency are already built.** `PersistenceBridge`
+  (`components/graph-view/graph-persistence.tsx`) subscribes to committed
+  patches and writes affected collections; `lib/firebase-timeline-store.ts`
+  gives revision counters, `expectedRevision` compare-and-set, and atomic
+  multi-document transactions. A second writer inherits all of it.
+
+## The one shaping fact
+
+Firestore access is **server-only and one-shot** (`lib/firebase-timeline-store.ts`
+is `server-only`, Admin SDK, `.get()` — never `onSnapshot`). The client
+`graphDocumentsGateway` is an in-memory cache. Consequence: a write that
+bypasses the live client store would **not** show up in the open app — there
+are no client listeners. WebMCP sidesteps this entirely by mutating the live
+store, which is the whole reason to prefer it. (A future server-MCP transport
+would need a live push — SSE — added; see "Durable transport".)
+
+## Route: how the agent reaches the tools
+
+Tools are registered **once** in the page via `navigator.modelContext.registerTool()`.
+That single registry is reachable by three consumers, all hitting the same
+handlers:
+
+| Consumer | Route | Notes |
+| --- | --- | --- |
+| Agent (Claude) | `chrome-devtools-mcp` with `--categoryExperimentalWebmcp=true` | official Google MCP server over CDP; **primary route** |
+| Manual | DevTools → **Application → WebMCP** panel | invoke tools by hand; appears once a tool is registered (Chrome 149+) |
+| Manual / scripted | console: `navigator.modelContextTesting` | `getTools()` / `executeTool(name, input)` (introspect for exact names) |
+
+MCP client config for the primary route:
+
+```jsonc
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": [
+        "chrome-devtools-mcp@latest",
+        "--categoryExperimentalWebmcp=true"
+      ]
+    }
+  }
+}
+```
+
+Point `chrome-devtools-mcp` at the **visible** Chrome you're watching (its
+browser-URL / CDP-endpoint option), not a spawned headless instance, or the
+agent will edit a browser you can't see.
+
+### Browser prerequisites
+
+- Flags: `chrome://flags/#enable-webmcp-testing` (the API) **and**
+  `chrome://flags/#devtools-webmcp-support` (the DevTools panel). Search
+  "webmcp" in `chrome://flags` and enable all; relaunch.
+- **Secure context required.** `localhost` / `127.0.0.1` / `::1` are exempt and
+  work over plain `http`; a LAN IP (`192.168.x.x`) is **not** a secure context.
+  Verify with `window.isSecureContext === true`. Production is HTTPS → secure
+  automatically.
+- Chrome ≥ 149 for the DevTools panel (the API predates it).
+
+### Production reality
+
+- Works against the deployed HTTPS origin exactly like localhost; it's an
+  operator-side setup pointed at the deployed app.
+- For **flag-on users**, no origin-trial token is needed. To reach users
+  *without* the flag, register the WebMCP Chrome Origin Trial and ship the
+  token — unnecessary once WebMCP is on-by-default (projected late 2026).
+- The DevTools/console manual paths need **no** bridge or MCP client at all.
+
+### Durable transport (later)
+
+Keep tool handlers **transport-agnostic**. If headless/automation/multi-user is
+ever needed, add a server-MCP front-end onto the *same* handlers (running the
+same headless engine) plus an SSE push to re-hydrate open browsers. WebMCP
+stays the interactive surface; the server transport is the durable hedge
+against the experimental API shifting.
+
+## Registry design
+
+```ts
+type ToolDef = {
+  name: string;
+  description: string;
+  inputSchema: JSONSchema;            // agent-facing arg contract
+  annotations?: { readOnlyHint?: boolean };
+  execute(input, client): Promise<ToolResult>;
+};
+
+// Injected once, via closure — the live session handles:
+type ToolCtx = {
+  store;            // useCollectionsStore() — the live graph
+  details;          // useGraphDetailsStore()
+  gateway;          // graphDocumentsGateway (ensure / peek / seed)
+  projectId; focusedId; trashId;
+  mintId;
+  parkPendingDetail; unparkPendingDetail;   // graph-pending-details
+  ensureDocumentTree;                        // async subtree load
+  sessionAlive;     // the ref from the async-Duplicate fix
+};
+```
+
+**`<McpToolsBridge>`** renders **inside `<DndCollections>`**, next to
+`PersistenceBridge`/`GraphItemActionsBridge` (that is where the live store is).
+On mount: feature-detect `navigator.modelContext`, then `registerTool(def, { signal })`
+per tool with an `AbortController` tied to the effect; cleanup aborts →
+unregisters. This ties tool lifetime to the store's mount, so a tool closure
+can't outlive its session and dispatch into a dead store — the **same
+session-lifetime discipline** as the async-Duplicate fix in
+`graph-item-actions.tsx`.
+
+Three shared helpers every tool uses:
+
+- **`resolvePlacement(graph, { into?, before?, after?, position? }) → { toParentId, toIndex }`**
+  — extend `resolveInsertPlacement` so the agent expresses placement
+  *semantically* and the handler does the **post-removal** `toIndex` math
+  (`toIndex` is the target's children index *after* the moved nodes are
+  removed — the reducer's convention; never reinvent it elsewhere).
+- **`ensureTarget(collectionId)`** — `ensureDocumentTree` before any structural
+  op into a nested collection, or the `commandPolicy` refuses a drop into an
+  un-hydrated placeholder. Re-check `sessionAlive` after this await.
+- **`toToolResult(Result)`** — map `store.dispatch`'s `Result` to MCP output:
+  ok → summary + `structuredContent`; `!ok` → `isError` with the rejection
+  `reason`.
+
+### Rules every tool inherits
+
+- **Address by `NodeId`** (the ids `read_timeline` returns). Treat ids as
+  **opaque** — never split/parse them (the `NodeId is any string` rule);
+  only look them up in `graph.nodesById` / `graph.parentById`.
+- **Mutations dispatch to the live store** → UI animates (FLIP) and
+  `PersistenceBridge` persists. No separate write path.
+- **Read-only tools carry `readOnlyHint: true`.**
+- **Any tool with an `await` re-checks `sessionAlive` before dispatch.**
+
+## Command surface (what tools translate into)
+
+From `packages/collections-core/commands.ts`:
+
+```
+move-nodes    { nodeIds, toParentId, toIndex }   ← reorder / move / nest / multi
+add-nodes     { nodes, toParentId, toIndex }     ← brand-new nodes (empty collections OK)
+update-media  { nodeId, update }                 ← trim (video) / duration (image)
+rename-node   { nodeId, name }                   ← media or collection
+```
+
+`MediaUpdate` is `{ mediaKind:"image", durationSeconds }` or
+`{ mediaKind:"video", trimInSeconds?, trimOutSeconds? }` (omitted trim keeps the
+current end). There is **no delete command**: delete = `move-nodes` into the
+trash root (recoverable). Rejections are typed (`missing-node`,
+`target-not-collection`, `would-create-cycle`, `cannot-move-root`,
+`duplicate-node-id`, `invalid-node-id`, `invalid-node`) and become the agent's
+error feedback.
+
+## Tool contracts (v1 surface)
+
+Two read tools (graph + assets) and six mutations.
+
+### `read_timeline` — the agent's eyes (build first)
+
+```jsonc
+// input
+{ "type": "object", "properties": {
+  "collectionId": { "type": "string", "description": "Collection node id. Omit for the focused timeline." },
+  "depth": { "type": "integer", "minimum": 1, "default": 1 },
+  "hydrate": { "type": "boolean", "default": false,
+    "description": "Lazy-load placeholders within depth; else report hydrated:false." }
+}, "additionalProperties": false }
+```
+`readOnlyHint: true`. **Output:** `{ timeline:{id,title,focused}, nodes:[ {id, kind, name,
+mediaKind?, src?, durationSeconds?, trimInSeconds?, trimOutSeconds?, hydrated?, childCount?,
+children?} ] }` + a compact text summary.
+**Handler:** resolve id (default `focusedId`) → walk `getChildren` to `depth`;
+collections read `details[id].hydrated` (summary if placeholder + `hydrate:false`);
+if `hydrate:true`, `ensureTarget` placeholders, re-check `sessionAlive`, re-read
+snapshot. **Guards:** opaque ids; dedupe by id per branch (shared references);
+`missing-node` / not-a-collection.
+
+### `list_assets` — eyes on the palette (companion to `add_clip`)
+
+```jsonc
+// input
+{ "type": "object", "properties": {
+  "folder": { "type": "string" }, "tags": { "type": "array", "items": { "type": "string" } },
+  "query": { "type": "string" }, "limit": { "type": "integer", "default": 30 }
+}, "additionalProperties": false }
+```
+`readOnlyHint: true`. Maps to the asset-provider seam (`lib/assets/*`,
+`docs/asset-providers.md`). **Output:** `{ assets: [ {id, name, mediaKind, src, poster?,
+durationSeconds?, folder, tags} ] }` — the shape `add_clip` consumes. Ignores
+query fields outside the active provider's capabilities.
+
+### `move_clip` → `move-nodes`
+
+```jsonc
+// input
+{ "type": "object", "required": ["nodeId"], "properties": {
+  "nodeId": { "type": "string" },
+  "into": { "type": "string", "description": "Target collection; omit to reorder within current parent." },
+  "after": { "type": "string" }, "before": { "type": "string" },
+  "position": { "type": "string", "enum": ["start", "end"] }
+}, "additionalProperties": false }
+```
+At most one of `after`/`before`/`position` (default `end`). **Handler:** validate
+node (`missing-node`, `cannot-move-root`); `targetId = into ?? parentById.get(nodeId)`
+(must be a collection); `ensureTarget`; `resolvePlacement` with post-removal
+adjustment; `dispatch(move-nodes)`; optionally `setSelection([nodeId])` so the
+move is visible. **Output:** `{ movedId, toParentId, toIndex, newOrder }`.
+**Free:** cross-collection move persists both documents in one atomic
+transaction with revision/CAS.
+
+### `trim_clip` → `update-media`
+
+```jsonc
+// input
+{ "type": "object", "required": ["nodeId"], "properties": {
+  "nodeId": { "type": "string" },
+  "trimInSeconds": { "type": "number", "minimum": 0 },
+  "trimOutSeconds": { "type": "number", "minimum": 0 },
+  "durationSeconds": { "type": "number", "exclusiveMinimum": 0 }
+}, "additionalProperties": false }
+```
+**Handler:** discriminate on the node's own `mediaKind` (video → trims, image →
+duration); reject the wrong field for the kind; validate `trimIn < trimOut` and
+source bounds (reject out-of-range with the bounds in the message, don't
+silently clamp); `dispatch(update-media)`. **Output:**
+`{ nodeId, mediaKind, effectiveDurationSeconds }`.
+
+### `rename_item` → `rename-node`
+
+```jsonc
+// input
+{ "type": "object", "required": ["nodeId", "name"], "properties": {
+  "nodeId": { "type": "string" }, "name": { "type": "string", "minLength": 1 }
+}, "additionalProperties": false }
+```
+Trim `name`, reject blank; `dispatch(rename-node)`. **Free:** a collection rename
+persists the child-document title via `PersistenceBridge` (`renameTimeline`),
+so graph and stored title can't diverge (including through undo/redo).
+
+### `add_clip` → `add-nodes`
+
+```jsonc
+// input
+{ "type": "object", "required": ["asset", "into"], "properties": {
+  "asset": { "type": "object", "required": ["src", "mediaKind", "name"], "properties": {
+    "id": { "type": "string" }, "src": { "type": "string" },
+    "mediaKind": { "type": "string", "enum": ["image", "video"] }, "name": { "type": "string" },
+    "poster": { "type": "string" }, "durationSeconds": { "type": "number" },
+    "trimInSeconds": { "type": "number" }, "trimOutSeconds": { "type": "number" } } },
+  "into": { "type": "string" }, "after": { "type": "string" },
+  "before": { "type": "string" }, "position": { "type": "string", "enum": ["start", "end"] }
+}, "additionalProperties": false }
+```
+**Handler:** `ensureTarget(into)` (must be a collection); `mintId(mediaKind)` →
+fresh media `CollectionItemNode`; **park** the `ClipDetail` (`sourceClipId =
+asset.id`, `poster`, provenance) *before* dispatch; `resolvePlacement` (default
+`end`); `dispatch(add-nodes)`; **on refusal, unpark** and return the reason;
+`setSelection([newId])`. **Output:** `{ nodeId, into, toIndex }`.
+
+### `remove_clip` → `move-nodes` (trash root)
+
+```jsonc
+// input
+{ "type": "object", "required": ["nodeId"], "properties": { "nodeId": { "type": "string" } },
+  "additionalProperties": false }
+```
+Reject if `trashId` is null; reject a root (`cannot-move-root`);
+`moveSelectionToTrash(store, trashId, [nodeId])`. **Output:** `{ removedId,
+recoverable: true }`. Recoverable by design — no hard delete exposed to the
+agent.
+
+### `duplicate_clip` → `buildClone` + `insertClones` (async, build last)
+
+```jsonc
+// input
+{ "type": "object", "required": ["nodeId"], "properties": {
+  "nodeId": { "type": "string" }, "after": { "type": "string" },
+  "before": { "type": "string" }, "position": { "type": "string", "enum": ["start", "end"] }
+}, "additionalProperties": false }
+```
+**Handler:** `built = await buildClone(...)` (collections `ensureDocumentTree`
+and deep-clone the subtree into independent documents); **re-check
+`sessionAlive`** (this is the async-Duplicate guard path — do not bypass);
+placement default `after: nodeId`; `insertClones(...)`; `setSelection(newIds)`.
+**Output:** `{ sourceId, newIds }`.
+
+> Sibling for later: **`create_collection`** — `add-nodes` with one empty
+> collection node whose id is a fresh timeline id, plus `gateway.seed(emptyDoc)`.
+
+## Build order
+
+1. **`read_timeline`** — proves the route end-to-end, zero mutation risk.
+2. **`move_clip`** — first mutation; proves live render + persistence + CAS
+   through one tool ("Claude moves a clip, you watch it slide into place").
+3. **`trim_clip` / `rename_item` / `add_clip` / `list_assets` / `remove_clip`**.
+4. **`duplicate_clip`** last — the only tool that spans documents *and* awaits.
+
+## Open decisions
+
+- **Placement API** — semantic anchors (`after`/`before`/`position`, chosen
+  here) vs raw indices. Semantic keeps the agent from doing post-removal math;
+  revisit only if a caller needs raw control.
+- **Auto-select on mutate** — default on for single-node `move`/`add`/
+  `duplicate` (aids the "watch it" UX); needs a `select:false` escape hatch.
+- **`navigator.modelContextTesting` method names** — `getTools`/`executeTool`
+  vs `listTools`/`executeTool` differ across spec versions; introspect the live
+  object before wiring the console/manual path.
+
+## Decision log
+
+- **2026-07-24** — Initial design. Chose WebMCP (in-page `registerTool`) over
+  server-side MCP for v1 because tools mutate the live store, making real-time
+  side-by-side the default and eliminating the external-write reconciliation
+  problem. Primary agent route: `chrome-devtools-mcp
+  --categoryExperimentalWebmcp=true`; manual routes via the DevTools WebMCP
+  panel and `navigator.modelContextTesting`. Accepted the experimental,
+  flag-on-per-user constraint. Tool handlers to stay transport-agnostic so a
+  server-MCP + SSE transport can back them later. v1 surface = `read_timeline`,
+  `list_assets`, `move_clip`, `trim_clip`, `rename_item`, `add_clip`,
+  `remove_clip`, `duplicate_clip`.
+
+- **2026-07-24** — Increment 1 built: the registry + `read_timeline` +
+  `move_clip`, the minimal proving loop. Code lives in
+  `apps/timeline-gstudio001/lib/webmcp/` (`types`, `results`, `placement`,
+  `timeline-tree`, `tools`, `webmcp-adapter`) with
+  `components/graph-view/graph-mcp-tools.tsx` (`<McpToolsBridge>`) wired next
+  to `PersistenceBridge`. Verified API facts, now relied on: commands are
+  `move-nodes` / `add-nodes` / `update-media` / `rename-node`
+  (`packages/collections-core/commands.ts`); `store.dispatch` returns
+  `Result<CollectionsPatch, DispatchRejection>` where `DispatchRejection =
+  CommandRejection | CommandPolicyRejection` and the policy rejection is
+  `{ reason: "blocked-by-policy", blockedIds, message? }`; a collection's
+  hydration is `details.get(id)?.hydrated !== false`; `registerTool(tool,
+  { signal })` on `navigator.modelContext`, abort to unregister.
+  **v1 deferrals** (revisit as later tools land): no programmatic
+  `ensureTarget` — a move into an un-hydrated collection is left to the
+  `commandPolicy` to refuse, and the rejection is surfaced to the agent;
+  `read_timeline`'s `hydrate` option is dropped (placeholders reported as
+  `hydrated:false`, no lazy-load); both v1 tools are synchronous, so no
+  `sessionAlive` guard is needed yet (it returns with `duplicate_clip`/
+  `add_clip`). Covered by unit tests in `lib/webmcp/*.test.ts` (pure placement
+  + tree projection, and handler-over-a-real-store for read/move).


### PR DESCRIPTION
First increment of the **WebMCP agent tools** feature — the minimal proving loop from [docs/webmcp-agent-tools.md](../blob/webmcp-agent-tools/docs/webmcp-agent-tools.md): the tool registry + `read_timeline` + `move_clip`. It also lands the design doc itself.

## What this does

Registers agent-callable tools in the page via `navigator.modelContext.registerTool`. Because a tool mutates the **live `CollectionsStore`**, the open graph re-renders (FLIP) and `PersistenceBridge` writes to Firestore automatically — no separate live-push or persistence path. Reachable three ways, all one registry: `chrome-devtools-mcp --categoryExperimentalWebmcp=true` (agent), the DevTools **Application → WebMCP** panel (manual), or `navigator.modelContextTesting` (console).

## What's in this slice

- **`lib/webmcp/`** (transport-agnostic, unit-tested — no React/`navigator` except the adapter):
  - `placement.ts` — semantic anchor (`before`/`after`/`position`) → the reducer's post-removal `toIndex`.
  - `timeline-tree.ts` — pure graph → structured, id-addressable tree with hydration flags.
  - `tools.ts` — `read_timeline` (read-only) + `move_clip` (→ `move-nodes`).
  - `results.ts` — maps typed dispatch rejections to agent-facing messages.
  - `webmcp-adapter.ts` — the **only** `navigator.modelContext` touch; feature-detected, `AbortSignal`-scoped, no-op when the flag is off.
- **`components/graph-view/graph-mcp-tools.tsx`** — `<McpToolsBridge>`, rendered inside `<DndCollections>` next to `PersistenceBridge`. Registration is tied to the store mount (tools can't outlive their session — the same discipline as the async item-action fix).

## Safety / blast radius

`<McpToolsBridge>` renders `null` and registers nothing when `navigator.modelContext` is absent (flag off), which is every existing user. So this changes **no existing behavior** — it's purely additive and gated on the experimental browser API.

## v1 deferrals (tracked in the doc's decision log)

- No programmatic hydration: a move into an un-hydrated collection is refused by the existing `commandPolicy`, and that rejection is surfaced to the agent.
- `read_timeline` reports placeholders as `hydrated:false` (no lazy-load yet).
- Both tools are synchronous, so no `sessionAlive` guard yet (returns with `duplicate_clip`/`add_clip`).

## Verification

- `lib/webmcp/*.test.ts`: **17 passing** — pure placement + tree projection, and the handlers driven over a **real store** (asserting `move_clip` actually reorders `childrenById`).
- `tsc --noEmit` and `eslint` clean on the new files.
- End-to-end agent invocation is exercised in a flag-enabled Chrome via chrome-devtools-mcp (operator setup, not CI).

## Next

`trim_clip` / `rename_item` / `add_clip` (+ `list_assets`) / `remove_clip`, then `duplicate_clip` — each a thin translator onto an existing command, per the doc's build order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
