### PR TITLE
Eagerly hydrate one level of child collections

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-hydration.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-hydration.tsx
@@ -87,7 +87,14 @@ export async function hydrateTimeline(
   reportHydrationIssue(timelineId, null);
 }
 
-/** Hydrate the focus path plus the shallow inline timelines rendered below it. */
+/**
+ * Hydrate the focus path, then eagerly hydrate ONE level of inline child
+ * timelines below the focus. That child level is already cache-warm (the RSC
+ * layer primes it), so its graph hydration costs no extra fetch; it makes the
+ * sub-rows' data present without a drill-in — collapsed rows STAY collapsed
+ * (a row's strip is gated on its own `expanded` state, not on hydration).
+ * Grandchildren and deeper stay lazy, hydrating on their row's first expand.
+ */
 export function HydrationController({
   projectId,
   segments,
@@ -125,14 +132,12 @@ export function HydrationController({
 
     void (async () => {
       const ensure = (timelineId: string) => hydrateTimeline(store, detailsStore, timelineId);
+      const focusChain = [projectId, ...path];
       let error: string | null = null;
       let previous: string | null = null;
 
-      // Only the FOCUS PATH is hydrated up front — the sub-graph tree below
-      // hydrates each row lazily on its first expand. (The RSC layer still
-      // primes one eager child level into the gateway cache, so that first
-      // expand is a warm-cache hit, not a fresh fetch.)
-      for (const segment of [projectId, ...path]) {
+      // The FOCUS PATH is hydrated up front, in order.
+      for (const segment of focusChain) {
         if (cancelled) return;
         const graph = store.getSnapshot().graph;
         const node = graph.nodesById.get(parseNodeId(segment));
@@ -152,6 +157,21 @@ export function HydrationController({
       }
 
       if (!cancelled) onFocusError(error);
+      if (cancelled || error !== null) return;
+
+      // Then eagerly hydrate ONE level below: the focused timeline's direct
+      // child collections. That level is cache-warm (RSC-primed), so each is a
+      // warm hit that just pulls the children into the graph — no drill-in
+      // needed, so sub-rows carry live data and are addressable by tools/moves
+      // straight away. Rows still render collapsed (strip gated on `expanded`);
+      // grandchildren stay lazy. Best-effort per child: a failure reports its
+      // own issue (see hydrateTimeline) and never blocks the focus view.
+      const focusedId = focusChain[focusChain.length - 1];
+      for (const childId of getChildren(store.getSnapshot().graph, parseNodeId(focusedId))) {
+        if (cancelled) return;
+        const child = store.getSnapshot().graph.nodesById.get(childId);
+        if (child?.kind === "collection") await ensure(childId);
+      }
     })();
 
     return () => {

--- a/docs/webmcp-agent-tools.md
+++ b/docs/webmcp-agent-tools.md
@@ -58,7 +58,7 @@ handlers:
 | --- | --- | --- |
 | Agent (Claude) | `chrome-devtools-mcp` with `--categoryExperimentalWebmcp=true` | official Google MCP server over CDP; **primary route** |
 | Manual | DevTools → **Application → WebMCP** panel | invoke tools by hand; appears once a tool is registered (Chrome 149+) |
-| Manual / scripted | console: `navigator.modelContextTesting` | `getTools()` / `executeTool(name, input)` (introspect for exact names) |
+| Manual / scripted | console: `navigator.modelContextTesting` | `listTools()` / `executeTool(name, input)` |
 
 MCP client config for the primary route:
 
@@ -335,9 +335,10 @@ placement default `after: nodeId`; `insertClones(...)`; `setSelection(newIds)`.
   revisit only if a caller needs raw control.
 - **Auto-select on mutate** — default on for single-node `move`/`add`/
   `duplicate` (aids the "watch it" UX); needs a `select:false` escape hatch.
-- **`navigator.modelContextTesting` method names** — `getTools`/`executeTool`
-  vs `listTools`/`executeTool` differ across spec versions; introspect the live
-  object before wiring the console/manual path.
+- ~~`navigator.modelContextTesting` method names~~ — **RESOLVED (Chrome 150):**
+  `listTools()` and `executeTool(name, input)` (it's a `ModelContextTesting`
+  extending `EventTarget`, also exposing `getCrossDocumentScriptToolResult`
+  and an `ontoolchange` event).
 
 ## Decision log
 
@@ -373,3 +374,19 @@ placement default `after: nodeId`; `insertClones(...)`; `setSelection(newIds)`.
   `sessionAlive` guard is needed yet (it returns with `duplicate_clip`/
   `add_clip`). Covered by unit tests in `lib/webmcp/*.test.ts` (pure placement
   + tree projection, and handler-over-a-real-store for read/move).
+
+- **2026-07-24** — Eager one-level hydration (app behavior, decoupled from
+  WebMCP; requested so tools see hydrated data without a drill-in).
+  `HydrationController` (`components/graph-view/graph-hydration.tsx`) now, after
+  the focus path, hydrates the focused timeline's **direct child collections**.
+  That level is cache-warm (RSC-primed), so it costs no extra fetch. Rows still
+  render collapsed — a sub-row's strip is gated on its own `expanded` state,
+  not on hydration (`graph-sub-timelines.tsx`), so the collapse/expand UX is
+  unchanged. Effect on the tools: `read_timeline` now returns the focused
+  timeline's child collections as `hydrated:true` with a real `childCount`, and
+  `move_clip` into them works without drilling in. **The "refused into
+  un-hydrated" behavior now only applies to grandchild+ collections** (still
+  lazy). Verified: full graph-view e2e (61) green — including the collapsed-row
+  and un-hydrated-drop-bounce tests. Console signature confirmed:
+  `navigator.modelContextTesting.listTools()` and
+  `executeTool(name, jsonArgsString)` (args are a JSON **string**).


### PR DESCRIPTION
Eagerly hydrates **one level** of child collections below the focus, so the visible sub-collections carry live data without a drill-in — app behavior, independent of WebMCP, but it's what makes `read_timeline` show them hydrated and `move_clip` into them work.

## Change

`HydrationController` (`graph-hydration.tsx`), after hydrating the focus path, now also hydrates the focused timeline's **direct child collections**. That level is already **cache-warm** (the RSC layer primes it), so hydrating it into the graph costs no extra fetch.

## Why it's safe (collapse ≠ hydrate)

A sub-row renders its strip only when `expanded && hydrated`, and `expanded` is local UI state defaulting to collapsed (`graph-sub-timelines.tsx`). So eager hydration fills the data while **rows stay visually collapsed** — the strip doesn't render until you expand it. Grandchildren and deeper stay lazy (hydrate on their row's first expand), so the un-hydrated-drop bounce still applies below the first level.

## Effect on the WebMCP tools

- `read_timeline` now returns the focused timeline's child collections as `hydrated:true` with a real `childCount` (previously `hydrated:false, childCount:0`).
- `move_clip` into a direct child collection works without drilling in first (the `commandPolicy` no longer refuses it). Deeper un-hydrated targets are still refused, as before.

## Verification

- **Full graph-view e2e: 61 passed** — including "sub-graph rows start collapsed and lazy-hydrate on expand", "sub-graphs nest recursively", and "drop into an un-hydrated collection bounces and never writes its document".
- `tsc --noEmit` + `eslint` clean on the changed file.

Also folds in `docs/webmcp-agent-tools.md` updates: the confirmed console signature (`listTools()` / `executeTool(name, jsonArgsString)`) and a decision-log entry for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
