### PR TITLE
WebMCP tools: trim_clip, rename_item, remove_clip

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-mcp-tools.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-mcp-tools.tsx
@@ -21,13 +21,16 @@ import { useGraphDetailsStore } from "./graph-details-context";
  * reads and placement to the open collection); the store is stable within a
  * session, so intra-session reads always see current state via getSnapshot.
  */
-export function McpToolsBridge({ focusedId }: Readonly<{ focusedId: string }>) {
+export function McpToolsBridge({
+  focusedId,
+  trashId,
+}: Readonly<{ focusedId: string; trashId: string | null }>) {
   const store = useCollectionsStore();
   const details = useGraphDetailsStore();
 
   useEffect(
-    () => registerWebMcpTools(createGraphTools({ store, details, focusedId })),
-    [store, details, focusedId],
+    () => registerWebMcpTools(createGraphTools({ store, details, focusedId, trashId })),
+    [store, details, focusedId, trashId],
   );
 
   return null;

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -497,7 +497,7 @@ export function GraphTimelineView({
       >
           <PersistenceBridge onSync={onSync} />
           <GraphItemActionsBridge trashId={boot.trashRootId} focusedId={focusedId} />
-          <McpToolsBridge focusedId={focusedId} />
+          <McpToolsBridge focusedId={focusedId} trashId={boot.trashRootId} />
           <GraphDetailsJanitor />
           <AssetPaletteDrawer open={assetsOpen} onClose={() => setAssetsOpen(false)} />
           <HydrationController

--- a/apps/timeline-gstudio001/lib/webmcp/tools.test.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/tools.test.ts
@@ -41,7 +41,7 @@ const fakeDetails = {
 
 function harness(focusedId = "project") {
   const store = createCollectionsStore(graph());
-  const defs = createGraphTools({ store, details: fakeDetails, focusedId });
+  const defs = createGraphTools({ store, details: fakeDetails, focusedId, trashId: null });
   const tool = (name: string) => {
     const found = defs.find((d) => d.name === name);
     if (!found) throw new Error(`missing tool ${name}`);
@@ -87,5 +87,109 @@ describe("move_clip tool", () => {
   it("surfaces the reducer rejection when the target is a clip", async () => {
     const { move } = harness();
     expect((await move.execute({ nodeId: "a", into: "b" })).isError).toBe(true);
+  });
+});
+
+/** project ─ img (image 4s), vid (video full 10, trim 1/1) ; trash (empty root) */
+function mediaGraph(): CollectionsGraph {
+  const built = buildGraph([
+    {
+      kind: "collection",
+      id: "project",
+      name: "Project",
+      children: [
+        { kind: "media", id: "img", name: "img", durationSeconds: 4 },
+        {
+          kind: "media",
+          mediaKind: "video",
+          id: "vid",
+          name: "vid",
+          fullDurationSeconds: 10,
+          trimInSeconds: 1,
+          trimOutSeconds: 1,
+        },
+      ],
+    },
+    { kind: "collection", id: "trash", name: "Trash", children: [] },
+  ]);
+  if (!built.ok) throw new Error(`fixture invalid: ${JSON.stringify(built.error)}`);
+  return built.value;
+}
+
+function mediaHarness(trashId: string | null = "trash") {
+  const store = createCollectionsStore(mediaGraph());
+  const defs = createGraphTools({ store, details: fakeDetails, focusedId: "project", trashId });
+  const tool = (name: string) => {
+    const found = defs.find((d) => d.name === name);
+    if (!found) throw new Error(`missing tool ${name}`);
+    return found;
+  };
+  const node = (id: string) => store.getSnapshot().graph.nodesById.get(parseNodeId(id));
+  const order = (parent: string) =>
+    getChildren(store.getSnapshot().graph, parseNodeId(parent)).map(String);
+  return {
+    store,
+    node,
+    order,
+    trim: tool("trim_clip"),
+    rename: tool("rename_item"),
+    remove: tool("remove_clip"),
+  };
+}
+
+describe("trim_clip tool", () => {
+  it("re-trims a video and mutates the node", async () => {
+    const { trim, node } = mediaHarness();
+    const res = await trim.execute({ nodeId: "vid", trimInSeconds: 2, trimOutSeconds: 3 });
+    expect(res.isError).toBeFalsy();
+    expect(node("vid")).toMatchObject({ trimInSeconds: 2, trimOutSeconds: 3 });
+    expect(res.structuredContent).toMatchObject({ effectiveDurationSeconds: 5 });
+  });
+
+  it("sets an image duration", async () => {
+    const { trim, node } = mediaHarness();
+    const res = await trim.execute({ nodeId: "img", durationSeconds: 8 });
+    expect(res.isError).toBeFalsy();
+    expect(node("img")).toMatchObject({ durationSeconds: 8 });
+  });
+
+  it("rejects a trim that exceeds the source length", async () => {
+    const { trim } = mediaHarness();
+    expect((await trim.execute({ nodeId: "vid", trimInSeconds: 6, trimOutSeconds: 6 })).isError).toBe(true);
+  });
+
+  it("rejects the wrong field for the media kind", async () => {
+    const { trim } = mediaHarness();
+    expect((await trim.execute({ nodeId: "vid", durationSeconds: 3 })).isError).toBe(true);
+    expect((await trim.execute({ nodeId: "img", trimInSeconds: 1 })).isError).toBe(true);
+  });
+});
+
+describe("rename_item tool", () => {
+  it("renames a clip and trims whitespace", async () => {
+    const { rename, node } = mediaHarness();
+    const res = await rename.execute({ nodeId: "img", name: "  Hero shot  " });
+    expect(res.isError).toBeFalsy();
+    expect(node("img")).toMatchObject({ name: "Hero shot" });
+  });
+
+  it("rejects a blank name", async () => {
+    const { rename } = mediaHarness();
+    expect((await rename.execute({ nodeId: "img", name: "   " })).isError).toBe(true);
+  });
+});
+
+describe("remove_clip tool", () => {
+  it("moves a clip into the trash root", async () => {
+    const { remove, order } = mediaHarness();
+    const res = await remove.execute({ nodeId: "img" });
+    expect(res.isError).toBeFalsy();
+    expect(order("project")).toEqual(["vid"]);
+    expect(order("trash")).toEqual(["img"]);
+  });
+
+  it("errors when the trash isn't loaded", async () => {
+    const { remove } = mediaHarness(null);
+    expect((await remove.execute({ nodeId: "img" })).isError).toBe(true);
   });
 });

--- a/apps/timeline-gstudio001/lib/webmcp/tools.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/tools.ts
@@ -1,5 +1,6 @@
 import {
   getChildren,
+  isVideoMedia,
   parseNodeId,
   type CollectionsStore,
   type NodeId,
@@ -19,11 +20,19 @@ export type GraphToolContext = Readonly<{
   store: CollectionsStore;
   details: GraphDetailsStore;
   focusedId: string;
+  /** The project's trash root id, or null when it isn't loaded (remove_clip). */
+  trashId: string | null;
 }>;
 
 /** The v1 tool surface. Add tools here as they land (see docs). */
 export function createGraphTools(ctx: GraphToolContext): ToolDef[] {
-  return [readTimelineTool(ctx), moveClipTool(ctx)];
+  return [
+    readTimelineTool(ctx),
+    moveClipTool(ctx),
+    trimClipTool(ctx),
+    renameItemTool(ctx),
+    removeClipTool(ctx),
+  ];
 }
 
 // ---- arg readers: agent input is `unknown`, never trusted ------------------
@@ -181,6 +190,157 @@ function moveClipTool(ctx: GraphToolContext): ToolDef {
         toParentId: targetStr,
         toIndex: placement.toIndex,
         newOrder,
+      });
+    },
+  };
+}
+
+// ---- trim_clip -------------------------------------------------------------
+
+function trimClipTool(ctx: GraphToolContext): ToolDef {
+  return {
+    name: "trim_clip",
+    description:
+      "Set a media clip's trim or duration. Video: trimInSeconds / trimOutSeconds (omitted ones keep their current value). Image: durationSeconds.",
+    inputSchema: {
+      type: "object",
+      required: ["nodeId"],
+      properties: {
+        nodeId: { type: "string" },
+        trimInSeconds: { type: "number", minimum: 0, description: "Video only." },
+        trimOutSeconds: { type: "number", minimum: 0, description: "Video only." },
+        durationSeconds: { type: "number", exclusiveMinimum: 0, description: "Image only." },
+      },
+      additionalProperties: false,
+    },
+    execute: (args) => {
+      const nodeIdStr = readString(args, "nodeId");
+      if (!nodeIdStr) return toolError("trim_clip requires a nodeId.");
+      const graph = ctx.store.getSnapshot().graph;
+      const nodeId = parseNodeId(nodeIdStr);
+      const node = graph.nodesById.get(nodeId);
+      if (!node) return toolError(`No node with id "${nodeIdStr}".`);
+      if (node.kind !== "media") {
+        return toolError(`"${node.name}" is a collection, not a clip — only clips can be trimmed.`);
+      }
+
+      const trimIn = readNumber(args, "trimInSeconds");
+      const trimOut = readNumber(args, "trimOutSeconds");
+      const duration = readNumber(args, "durationSeconds");
+
+      if (isVideoMedia(node)) {
+        if (duration !== undefined) {
+          return toolError(
+            "Video clips are trimmed with trimInSeconds / trimOutSeconds, not durationSeconds.",
+          );
+        }
+        const nextIn = trimIn ?? node.trimInSeconds;
+        const nextOut = trimOut ?? node.trimOutSeconds;
+        if (nextIn < 0 || nextOut < 0 || nextIn + nextOut >= node.fullDurationSeconds) {
+          return toolError(
+            `Trim out of range: the source is ${node.fullDurationSeconds}s, so trimIn + trimOut must be under that (got ${nextIn} + ${nextOut}).`,
+          );
+        }
+        const result = ctx.store.dispatch({
+          type: "update-media",
+          nodeId,
+          update: { mediaKind: "video", trimInSeconds: nextIn, trimOutSeconds: nextOut },
+        });
+        if (!result.ok) return toolError(describeDispatchRejection(result.error));
+        const effective = Math.max(0, node.fullDurationSeconds - nextIn - nextOut);
+        return toolOk(`Trimmed "${node.name}" to ${effective.toFixed(2)}s (in ${nextIn}s, out ${nextOut}s).`, {
+          nodeId: nodeIdStr,
+          mediaKind: "video",
+          trimInSeconds: nextIn,
+          trimOutSeconds: nextOut,
+          effectiveDurationSeconds: effective,
+        });
+      }
+
+      // Image.
+      if (trimIn !== undefined || trimOut !== undefined) {
+        return toolError("Image clips take a durationSeconds, not trimInSeconds / trimOutSeconds.");
+      }
+      if (duration === undefined) return toolError("trim_clip on an image needs a durationSeconds.");
+      if (duration <= 0) return toolError("durationSeconds must be greater than 0.");
+      const result = ctx.store.dispatch({
+        type: "update-media",
+        nodeId,
+        update: { mediaKind: "image", durationSeconds: duration },
+      });
+      if (!result.ok) return toolError(describeDispatchRejection(result.error));
+      return toolOk(`Set "${node.name}" duration to ${duration}s.`, {
+        nodeId: nodeIdStr,
+        mediaKind: "image",
+        effectiveDurationSeconds: duration,
+      });
+    },
+  };
+}
+
+// ---- rename_item -----------------------------------------------------------
+
+function renameItemTool(ctx: GraphToolContext): ToolDef {
+  return {
+    name: "rename_item",
+    description:
+      "Rename a clip or collection. Renaming a collection also updates its child document's title.",
+    inputSchema: {
+      type: "object",
+      required: ["nodeId", "name"],
+      properties: {
+        nodeId: { type: "string" },
+        name: { type: "string", minLength: 1 },
+      },
+      additionalProperties: false,
+    },
+    execute: (args) => {
+      const nodeIdStr = readString(args, "nodeId");
+      if (!nodeIdStr) return toolError("rename_item requires a nodeId.");
+      const rawName = readString(args, "name");
+      if (!rawName) return toolError("rename_item requires a non-blank name.");
+      const name = rawName.trim();
+      const graph = ctx.store.getSnapshot().graph;
+      const nodeId = parseNodeId(nodeIdStr);
+      if (!graph.nodesById.get(nodeId)) return toolError(`No node with id "${nodeIdStr}".`);
+      const result = ctx.store.dispatch({ type: "rename-node", nodeId, name });
+      if (!result.ok) return toolError(describeDispatchRejection(result.error));
+      return toolOk(`Renamed to "${name}".`, { nodeId: nodeIdStr, name });
+    },
+  };
+}
+
+// ---- remove_clip -----------------------------------------------------------
+
+function removeClipTool(ctx: GraphToolContext): ToolDef {
+  return {
+    name: "remove_clip",
+    description: "Move a clip or collection to the trash. Recoverable — not a hard delete.",
+    inputSchema: {
+      type: "object",
+      required: ["nodeId"],
+      properties: { nodeId: { type: "string" } },
+      additionalProperties: false,
+    },
+    execute: (args) => {
+      const nodeIdStr = readString(args, "nodeId");
+      if (!nodeIdStr) return toolError("remove_clip requires a nodeId.");
+      if (ctx.trashId === null) return toolError("The trash isn't loaded in this project.");
+      const graph = ctx.store.getSnapshot().graph;
+      const nodeId = parseNodeId(nodeIdStr);
+      const node = graph.nodesById.get(nodeId);
+      if (!node) return toolError(`No node with id "${nodeIdStr}".`);
+      const trashRoot = parseNodeId(ctx.trashId);
+      const result = ctx.store.dispatch({
+        type: "move-nodes",
+        nodeIds: [nodeId],
+        toParentId: trashRoot,
+        toIndex: getChildren(graph, trashRoot).length,
+      });
+      if (!result.ok) return toolError(describeDispatchRejection(result.error));
+      return toolOk(`Moved "${node.name}" to the trash (recoverable).`, {
+        removedId: nodeIdStr,
+        recoverable: true,
       });
     },
   };

--- a/docs/webmcp-agent-tools.md
+++ b/docs/webmcp-agent-tools.md
@@ -390,3 +390,15 @@ placement default `after: nodeId`; `insertClones(...)`; `setSelection(newIds)`.
   and un-hydrated-drop-bounce tests. Console signature confirmed:
   `navigator.modelContextTesting.listTools()` and
   `executeTool(name, jsonArgsString)` (args are a JSON **string**).
+
+- **2026-07-24** — Increment 2: the synchronous mutation trio `trim_clip`
+  (`update-media` — video trims / image duration, validated against the source
+  length), `rename_item` (`rename-node`), and `remove_clip` (`move-nodes` into
+  the trash root, recoverable). All are direct command translators — no
+  async/ensure. `ToolCtx` gained `trashId` (threaded from `boot.trashRootId`
+  through `<McpToolsBridge>`) for `remove_clip`. Covered by
+  handler-over-a-real-store tests in `tools.test.ts` (trim mutates the node,
+  wrong-field/out-of-range rejected; rename trims + rejects blank; remove
+  relocates to trash and errors when trash is absent). Remaining v1 surface:
+  `list_assets` + `add_clip` (asset-provider seam), then `duplicate_clip`
+  (async → brings in the `sessionAlive` guard).


### PR DESCRIPTION
Increment 2 of the WebMCP agent tools ([docs](../blob/webmcp-mutation-trio/docs/webmcp-agent-tools.md)): the three **synchronous mutation tools**, each a thin translator onto an existing `CollectionsCommand`. Additive, behind the same WebMCP feature-detect no-op — no change to existing behavior.

## Tools

- **`trim_clip`** → `update-media`. Video: `trimInSeconds` / `trimOutSeconds` (omitted keeps current); image: `durationSeconds`. Discriminates on the node's own `mediaKind`, validates against the source length, and rejects the wrong field for the kind or an out-of-range trim with a clear message.
- **`rename_item`** → `rename-node`. Trims the name, rejects blank. A collection rename persists the child document title via `PersistenceBridge` (free).
- **`remove_clip`** → `move-nodes` into the trash root. Recoverable — no hard delete exposed to the agent. `ToolCtx` gains `trashId`, threaded from `boot.trashRootId` through `<McpToolsBridge>`.

## Verification

- **25 webmcp unit tests** (was 17) — the new ones drive each handler over a **real store**: `trim_clip` mutates the node and rejects wrong-field/out-of-range; `rename_item` trims + rejects blank; `remove_clip` relocates to trash and errors when trash is absent.
- `tsc --noEmit` + `eslint` clean on the changed files.

## Next

`list_assets` + `add_clip` (asset-provider seam), then `duplicate_clip` (async → brings in the `sessionAlive` guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
