### PR TITLE
WebMCP view + playback tools (controlled player)

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-mcp-tools.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-mcp-tools.tsx
@@ -1,36 +1,86 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
-import { useCollectionsStore } from "@storyboard/ui/dnd-collections";
+import { useCollectionsStore, type NodeId } from "@storyboard/ui/dnd-collections";
 
+import {
+  GRAPH_VIEW_STATE_EVENT,
+  requestGraphPreviewToggle,
+  type GraphViewStateDetail,
+} from "@/lib/graph-view-events";
 import { createGraphTools } from "@/lib/webmcp/tools";
 import { registerWebMcpTools } from "@/lib/webmcp/webmcp-adapter";
 
 import { useGraphDetailsStore } from "./graph-details-context";
+import type { PreviewTimeChannel } from "./graph-preview";
+
+// The graph view broadcasts this on mount and every change; until the first
+// one lands we assume the load defaults (grid, everything off).
+const INITIAL_VIEW_STATE: GraphViewStateDetail = {
+  surface: "grid",
+  rulerOn: false,
+  childrenShown: false,
+  previewOn: false,
+};
 
 /**
  * Registers the WebMCP agent tools for the open graph session.
  *
  * Rendered INSIDE `<DndCollections>` (next to PersistenceBridge) so it can
  * reach the live store and the details side-table. Registration is tied to
- * this mount via `registerWebMcpTools`' AbortController: the bridge remounts
+ * this mount via `registerWebMcpTools`' AbortController — the bridge remounts
  * with a fresh store whenever the graph session key changes, so tools can't
- * outlive their session — the same session-lifetime discipline the async
- * item-action handlers use. `focusedId` re-registers the tools (they default
- * reads and placement to the open collection); the store is stable within a
- * session, so intra-session reads always see current state via getSnapshot.
+ * outlive their session.
+ *
+ * View/session tools need a little more than the store: navigation is a router
+ * push exposed by `onOpenNode` (the same `openTimeline` seam the board uses),
+ * and the preview/view state rides the sidebar's window-event bus — we mirror
+ * the broadcast into a ref so `get_view_state` / `set_preview` read it live.
  */
 export function McpToolsBridge({
+  projectId,
   focusedId,
   trashId,
-}: Readonly<{ focusedId: string; trashId: string | null }>) {
+  onOpenNode,
+  timeChannel,
+}: Readonly<{
+  projectId: string;
+  focusedId: string;
+  trashId: string | null;
+  onOpenNode: (nodeId: NodeId) => void;
+  timeChannel: PreviewTimeChannel;
+}>) {
   const store = useCollectionsStore();
   const details = useGraphDetailsStore();
+  const viewStateRef = useRef<GraphViewStateDetail>(INITIAL_VIEW_STATE);
+
+  useEffect(() => {
+    const onState = (event: Event) => {
+      viewStateRef.current = (event as CustomEvent<GraphViewStateDetail>).detail;
+    };
+    window.addEventListener(GRAPH_VIEW_STATE_EVENT, onState);
+    return () => window.removeEventListener(GRAPH_VIEW_STATE_EVENT, onState);
+  }, []);
 
   useEffect(
-    () => registerWebMcpTools(createGraphTools({ store, details, focusedId, trashId })),
-    [store, details, focusedId, trashId],
+    () =>
+      registerWebMcpTools(
+        createGraphTools({
+          store,
+          details,
+          projectId,
+          focusedId,
+          trashId,
+          openTimeline: onOpenNode,
+          getViewState: () => viewStateRef.current,
+          togglePreview: requestGraphPreviewToggle,
+          seek: (seconds) => timeChannel.set(Math.max(0, seconds)),
+          setPlaying: timeChannel.setPlaying,
+          getPlayback: () => ({ time: timeChannel.get(), isPlaying: timeChannel.isPlaying() }),
+        }),
+      ),
+    [store, details, projectId, focusedId, trashId, onOpenNode, timeChannel],
   );
 
   return null;

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -66,11 +66,19 @@ export type PreviewTimeChannel = Readonly<{
   get: () => number;
   set: (time: number) => void;
   subscribe: (listener: () => void) => () => void;
+  /** Play state, held here (above the preview pane's mount) so it survives the
+   *  pane toggling off/on and can be driven before the pane exists — that's how
+   *  "play turns the preview on and it's already playing" works. */
+  isPlaying: () => boolean;
+  setPlaying: (playing: boolean) => void;
+  subscribePlaying: (listener: () => void) => () => void;
 }>;
 
 export function createPreviewTimeChannel(): PreviewTimeChannel {
   let time = 0;
+  let playing = false;
   const listeners = new Set<() => void>();
+  const playListeners = new Set<() => void>();
   return {
     get: () => time,
     set: (next) => {
@@ -81,6 +89,18 @@ export function createPreviewTimeChannel(): PreviewTimeChannel {
       listeners.add(listener);
       return () => {
         listeners.delete(listener);
+      };
+    },
+    isPlaying: () => playing,
+    setPlaying: (next) => {
+      if (playing === next) return;
+      playing = next;
+      for (const listener of playListeners) listener();
+    },
+    subscribePlaying: (listener) => {
+      playListeners.add(listener);
+      return () => {
+        playListeners.delete(listener);
       };
     },
   };
@@ -1550,6 +1570,15 @@ export function PreviewShell({
   const [time, setTime] = useState(0);
 
   useEffect(() => channel.subscribe(() => setTime(channel.get())), [channel]);
+  // Controlled playback: the channel is the source of truth (so play state
+  // survives the pane toggling and can be set before it mounts). The surface
+  // renders play/pause from `playing` and reports its own button/auto-stop
+  // through `channel.setPlaying`.
+  const playing = useSyncExternalStore(
+    channel.subscribePlaying,
+    channel.isPlaying,
+    channel.isPlaying,
+  );
   const handleTimeChange = useCallback(
     (next: number) => {
       setTime(next);
@@ -1606,6 +1635,8 @@ export function PreviewShell({
         clips={clips}
         currentTime={time}
         onCurrentTimeChange={handleTimeChange}
+        playing={playing}
+        onPlayingChange={channel.setPlaying}
         getInitialSurfaceHeight={getInitialSurfaceHeight}
         onSurfaceHeightChange={handleSurfaceHeightChange}
       >

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -497,7 +497,13 @@ export function GraphTimelineView({
       >
           <PersistenceBridge onSync={onSync} />
           <GraphItemActionsBridge trashId={boot.trashRootId} focusedId={focusedId} />
-          <McpToolsBridge focusedId={focusedId} trashId={boot.trashRootId} />
+          <McpToolsBridge
+            projectId={projectId}
+            focusedId={focusedId}
+            trashId={boot.trashRootId}
+            onOpenNode={handleOpenNode}
+            timeChannel={timeChannel}
+          />
           <GraphDetailsJanitor />
           <AssetPaletteDrawer open={assetsOpen} onClose={() => setAssetsOpen(false)} />
           <HydrationController

--- a/apps/timeline-gstudio001/lib/webmcp/tools.test.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/tools.test.ts
@@ -6,9 +6,11 @@ import {
   getChildren,
   parseNodeId,
   type CollectionsGraph,
+  type NodeId,
 } from "@storyboard/ui/dnd-collections";
 
 import type { GraphDetailsStore } from "@/lib/graph-details-store";
+import type { GraphViewStateDetail } from "@/lib/graph-view-events";
 
 import { createGraphTools } from "./tools";
 
@@ -39,9 +41,54 @@ const fakeDetails = {
   subscribe: () => () => {},
 } as unknown as GraphDetailsStore;
 
+/** Records navigation/preview/playback calls the view tools make, and
+ *  simulates preview + playback so the tools' deterministic logic is testable. */
+function viewSpies() {
+  const opened: string[] = [];
+  const toggles: string[] = [];
+  let view: GraphViewStateDetail = {
+    surface: "grid",
+    rulerOn: false,
+    childrenShown: false,
+    previewOn: false,
+  };
+  let playback = { time: 0, isPlaying: false };
+  return {
+    opened,
+    toggles,
+    getPreview: () => view.previewOn,
+    getPlayback: () => playback,
+    hooks: {
+      openTimeline: (id: NodeId) => {
+        opened.push(String(id));
+      },
+      getViewState: () => view,
+      togglePreview: () => {
+        toggles.push("toggle");
+        view = { ...view, previewOn: !view.previewOn };
+      },
+      seek: (seconds: number) => {
+        playback = { ...playback, time: Math.max(0, seconds) };
+      },
+      setPlaying: (playing: boolean) => {
+        playback = { ...playback, isPlaying: playing };
+      },
+      getPlayback: () => playback,
+    },
+  };
+}
+
 function harness(focusedId = "project") {
   const store = createCollectionsStore(graph());
-  const defs = createGraphTools({ store, details: fakeDetails, focusedId, trashId: null });
+  const spies = viewSpies();
+  const defs = createGraphTools({
+    store,
+    details: fakeDetails,
+    projectId: "project",
+    focusedId,
+    trashId: null,
+    ...spies.hooks,
+  });
   const tool = (name: string) => {
     const found = defs.find((d) => d.name === name);
     if (!found) throw new Error(`missing tool ${name}`);
@@ -49,7 +96,27 @@ function harness(focusedId = "project") {
   };
   const order = (parent: string) =>
     getChildren(store.getSnapshot().graph, parseNodeId(parent)).map(String);
-  return { store, read: tool("read_timeline"), move: tool("move_clip"), order };
+  const selected = () => [...store.getSnapshot().interaction.selectedIds].map(String);
+  return {
+    store,
+    order,
+    selected,
+    opened: spies.opened,
+    toggles: spies.toggles,
+    getPreview: spies.getPreview,
+    getPlayback: spies.getPlayback,
+    read: tool("read_timeline"),
+    move: tool("move_clip"),
+    getViewStateTool: tool("get_view_state"),
+    select: tool("select_items"),
+    clearSelection: tool("clear_selection"),
+    focus: tool("focus"),
+    goUp: tool("go_up"),
+    setPreview: tool("set_preview"),
+    play: tool("play"),
+    pause: tool("pause"),
+    seek: tool("seek"),
+  };
 }
 
 describe("read_timeline tool", () => {
@@ -118,7 +185,14 @@ function mediaGraph(): CollectionsGraph {
 
 function mediaHarness(trashId: string | null = "trash") {
   const store = createCollectionsStore(mediaGraph());
-  const defs = createGraphTools({ store, details: fakeDetails, focusedId: "project", trashId });
+  const defs = createGraphTools({
+    store,
+    details: fakeDetails,
+    projectId: "project",
+    focusedId: "project",
+    trashId,
+    ...viewSpies().hooks,
+  });
   const tool = (name: string) => {
     const found = defs.find((d) => d.name === name);
     if (!found) throw new Error(`missing tool ${name}`);
@@ -191,5 +265,140 @@ describe("remove_clip tool", () => {
   it("errors when the trash isn't loaded", async () => {
     const { remove } = mediaHarness(null);
     expect((await remove.execute({ nodeId: "img" })).isError).toBe(true);
+  });
+});
+
+describe("select_items / clear_selection tools", () => {
+  it("selects known ids and skips unknown ones", async () => {
+    const h = harness();
+    const res = await h.select.execute({ nodeIds: ["a", "scene-a", "ghost"] });
+    expect(res.isError).toBeFalsy();
+    expect(h.selected().sort()).toEqual(["a", "scene-a"]);
+  });
+
+  it("errors when no id is known", async () => {
+    const h = harness();
+    expect((await h.select.execute({ nodeIds: ["ghost"] })).isError).toBe(true);
+  });
+
+  it("clears the selection", async () => {
+    const h = harness();
+    await h.select.execute({ nodeIds: ["a", "b"] });
+    await h.clearSelection.execute({});
+    expect(h.selected()).toEqual([]);
+  });
+});
+
+describe("get_view_state tool", () => {
+  it("reports focus, selection, and preview", async () => {
+    const h = harness();
+    await h.select.execute({ nodeIds: ["a"] });
+    const res = await h.getViewStateTool.execute({});
+    expect(res.structuredContent).toMatchObject({
+      focusedId: "project",
+      isRoot: true,
+      selectedIds: ["a"],
+      previewOn: false,
+    });
+  });
+});
+
+describe("focus / go_up tools", () => {
+  it("focus opens a collection by id", async () => {
+    const h = harness();
+    expect((await h.focus.execute({ nodeId: "scene-a" })).isError).toBeFalsy();
+    expect(h.opened).toEqual(["scene-a"]);
+  });
+
+  it("focus with no id opens the project root", async () => {
+    const h = harness("scene-a");
+    await h.focus.execute({});
+    expect(h.opened).toEqual(["project"]);
+  });
+
+  it("focus on the already-focused node is a no-op", async () => {
+    const h = harness();
+    const res = await h.focus.execute({ nodeId: "project" });
+    expect((res.structuredContent as { changed: boolean }).changed).toBe(false);
+    expect(h.opened).toEqual([]);
+  });
+
+  it("focus rejects a clip", async () => {
+    const h = harness();
+    expect((await h.focus.execute({ nodeId: "a" })).isError).toBe(true);
+  });
+
+  it("go_up focuses the parent", async () => {
+    const h = harness("scene-a");
+    await h.goUp.execute({});
+    expect(h.opened).toEqual(["project"]);
+  });
+
+  it("go_up at the root is a no-op", async () => {
+    const h = harness();
+    const res = await h.goUp.execute({});
+    expect((res.structuredContent as { changed: boolean }).changed).toBe(false);
+    expect(h.opened).toEqual([]);
+  });
+});
+
+describe("set_preview tool", () => {
+  it("toggles only when the requested state differs", async () => {
+    const h = harness();
+    const on = await h.setPreview.execute({ on: true });
+    expect((on.structuredContent as { changed: boolean }).changed).toBe(true);
+    expect(h.getPreview()).toBe(true);
+    expect(h.toggles.length).toBe(1);
+
+    const again = await h.setPreview.execute({ on: true });
+    expect((again.structuredContent as { changed: boolean }).changed).toBe(false);
+    expect(h.toggles.length).toBe(1);
+  });
+});
+
+describe("play / pause / seek tools", () => {
+  it("play turns preview on (when off) and starts playback", async () => {
+    const h = harness();
+    const res = await h.play.execute({});
+    expect(res.isError).toBeFalsy();
+    expect(h.getPreview()).toBe(true);
+    expect(h.getPlayback().isPlaying).toBe(true);
+    expect((res.structuredContent as { openedPreview: boolean }).openedPreview).toBe(true);
+  });
+
+  it("play does not re-open the preview when it's already on", async () => {
+    const h = harness();
+    await h.setPreview.execute({ on: true });
+    const res = await h.play.execute({});
+    expect((res.structuredContent as { openedPreview: boolean }).openedPreview).toBe(false);
+    expect(h.getPlayback().isPlaying).toBe(true);
+  });
+
+  it("pause stops playback", async () => {
+    const h = harness();
+    await h.play.execute({});
+    const res = await h.pause.execute({});
+    expect(h.getPlayback().isPlaying).toBe(false);
+    expect((res.structuredContent as { changed: boolean }).changed).toBe(true);
+  });
+
+  it("seek moves the playhead and clamps negatives to 0", async () => {
+    const h = harness();
+    await h.seek.execute({ seconds: 12.5 });
+    expect(h.getPlayback().time).toBe(12.5);
+    await h.seek.execute({ seconds: -4 });
+    expect(h.getPlayback().time).toBe(0);
+  });
+
+  it("get_view_state reports playback", async () => {
+    const h = harness();
+    await h.seek.execute({ seconds: 3 });
+    await h.play.execute({});
+    const res = await h.getViewStateTool.execute({});
+    expect(res.structuredContent).toMatchObject({
+      isPlaying: true,
+      currentTimeSeconds: 3,
+      previewOn: true,
+    });
   });
 });

--- a/apps/timeline-gstudio001/lib/webmcp/tools.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/tools.ts
@@ -7,6 +7,7 @@ import {
 } from "@storyboard/ui/dnd-collections";
 
 import type { GraphDetailsStore } from "@/lib/graph-details-store";
+import type { GraphViewStateDetail } from "@/lib/graph-view-events";
 
 import { resolveMovePlacement } from "./placement";
 import { describeDispatchRejection, toolError, toolOk } from "./results";
@@ -19,12 +20,27 @@ import type { ToolDef } from "./types";
 export type GraphToolContext = Readonly<{
   store: CollectionsStore;
   details: GraphDetailsStore;
+  /** The project's root timeline id (focus/go_up resolve "root" to this). */
+  projectId: string;
   focusedId: string;
   /** The project's trash root id, or null when it isn't loaded (remove_clip). */
   trashId: string | null;
+  /** Open (drill into / focus) a timeline — the graph view's navigation. */
+  openTimeline: (nodeId: NodeId) => void;
+  /** The live view/session state (preview on, surface), read from the graph
+   *  view's broadcast — for get_view_state and deterministic set_preview. */
+  getViewState: () => GraphViewStateDetail;
+  /** Flip the preview pane (fires the same event the sidebar's toggle does). */
+  togglePreview: () => void;
+  /** Move the preview clock to a time in seconds (clamped ≥ 0). */
+  seek: (seconds: number) => void;
+  /** Start (true) or stop (false) playback. Visible only while preview is on. */
+  setPlaying: (playing: boolean) => void;
+  /** Current playhead time (seconds) and whether playback is running. */
+  getPlayback: () => Readonly<{ time: number; isPlaying: boolean }>;
 }>;
 
-/** The v1 tool surface. Add tools here as they land (see docs). */
+/** The tool surface. Document-edit tools first, then view/session tools. */
 export function createGraphTools(ctx: GraphToolContext): ToolDef[] {
   return [
     readTimelineTool(ctx),
@@ -32,6 +48,15 @@ export function createGraphTools(ctx: GraphToolContext): ToolDef[] {
     trimClipTool(ctx),
     renameItemTool(ctx),
     removeClipTool(ctx),
+    getViewStateTool(ctx),
+    selectItemsTool(ctx),
+    clearSelectionTool(ctx),
+    focusTool(ctx),
+    goUpTool(ctx),
+    setPreviewTool(ctx),
+    playTool(ctx),
+    pauseTool(ctx),
+    seekTool(ctx),
   ];
 }
 
@@ -51,6 +76,11 @@ function readNumber(args: unknown, key: string): number | undefined {
 function readBoolean(args: unknown, key: string): boolean | undefined {
   const value = record(args)[key];
   return typeof value === "boolean" ? value : undefined;
+}
+function readStringArray(args: unknown, key: string): string[] {
+  const value = record(args)[key];
+  if (!Array.isArray(value)) return [];
+  return value.filter((v): v is string => typeof v === "string" && v.trim().length > 0);
 }
 function readPosition(args: unknown): "start" | "end" | undefined {
   const value = readString(args, "position");
@@ -342,6 +372,215 @@ function removeClipTool(ctx: GraphToolContext): ToolDef {
         removedId: nodeIdStr,
         recoverable: true,
       });
+    },
+  };
+}
+
+// ---- view / session tools (ephemeral — no persistence) ---------------------
+
+function getViewStateTool(ctx: GraphToolContext): ToolDef {
+  return {
+    name: "get_view_state",
+    description:
+      "The current view state: which timeline is focused, which items are selected, and whether the preview pane is on. Use this to see where you are before navigating or selecting.",
+    annotations: { readOnlyHint: true },
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+    execute: () => {
+      const snapshot = ctx.store.getSnapshot();
+      const focusNode = snapshot.graph.nodesById.get(parseNodeId(ctx.focusedId));
+      const selectedIds = [...snapshot.interaction.selectedIds].map(String);
+      const selectedNames = selectedIds.map(
+        (id) => snapshot.graph.nodesById.get(parseNodeId(id))?.name ?? id,
+      );
+      const view = ctx.getViewState();
+      const playback = ctx.getPlayback();
+      return toolOk(
+        `Focused: "${focusNode?.name ?? ctx.focusedId}". Selected: ${selectedIds.length}. Preview: ${view.previewOn ? "on" : "off"}${playback.isPlaying ? ", playing" : ""} at ${playback.time.toFixed(1)}s.`,
+        {
+          focusedId: ctx.focusedId,
+          focusedTitle: focusNode?.name ?? null,
+          isRoot: ctx.focusedId === ctx.projectId,
+          selectedIds,
+          selectedNames,
+          previewOn: view.previewOn,
+          surface: view.surface,
+          isPlaying: playback.isPlaying,
+          currentTimeSeconds: playback.time,
+        },
+      );
+    },
+  };
+}
+
+function selectItemsTool(ctx: GraphToolContext): ToolDef {
+  return {
+    name: "select_items",
+    description:
+      "Select one or more clips/collections by id (replaces the current selection). Selecting shows an item's controls and is what some edits act on.",
+    inputSchema: {
+      type: "object",
+      required: ["nodeIds"],
+      properties: { nodeIds: { type: "array", items: { type: "string" }, minItems: 1 } },
+      additionalProperties: false,
+    },
+    execute: (args) => {
+      const idStrs = readStringArray(args, "nodeIds");
+      if (idStrs.length === 0) return toolError("select_items requires a non-empty nodeIds array.");
+      const graph = ctx.store.getSnapshot().graph;
+      const known = idStrs.map(parseNodeId).filter((id) => graph.nodesById.has(id));
+      if (known.length === 0) return toolError("None of those ids are in the current graph.");
+      ctx.store.setSelection(known);
+      const skipped = idStrs.length - known.length;
+      return toolOk(
+        `Selected ${known.length} item${known.length === 1 ? "" : "s"}${skipped > 0 ? ` (${skipped} unknown id${skipped === 1 ? "" : "s"} skipped)` : ""}.`,
+        { selectedIds: known.map(String) },
+      );
+    },
+  };
+}
+
+function clearSelectionTool(ctx: GraphToolContext): ToolDef {
+  return {
+    name: "clear_selection",
+    description: "Clear the current selection (deselect everything).",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+    execute: () => {
+      const had = ctx.store.getSnapshot().interaction.selectedIds.size;
+      ctx.store.clearSelection();
+      return toolOk(
+        had === 0 ? "Nothing was selected." : `Deselected ${had} item${had === 1 ? "" : "s"}.`,
+        { cleared: had },
+      );
+    },
+  };
+}
+
+function focusTool(ctx: GraphToolContext): ToolDef {
+  return {
+    name: "focus",
+    description:
+      "Open (drill into / focus) a timeline or collection by id, so later reads and edits act on it. Omit nodeId, or pass the project id, to return to the top-level project. Navigation is async — the view updates a moment later, so read_timeline to confirm.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        nodeId: { type: "string", description: "Collection/timeline id to open. Omit for the project root." },
+      },
+      additionalProperties: false,
+    },
+    execute: (args) => {
+      const targetStr = readString(args, "nodeId") ?? ctx.projectId;
+      const graph = ctx.store.getSnapshot().graph;
+      const target = parseNodeId(targetStr);
+      const node = graph.nodesById.get(target);
+      if (!node) return toolError(`No node with id "${targetStr}".`);
+      if (node.kind !== "collection") {
+        return toolError(`"${node.name}" is a clip, not a timeline you can open.`);
+      }
+      if (targetStr === ctx.focusedId) {
+        return toolOk(`Already focused on "${node.name}".`, { focusedId: targetStr, changed: false });
+      }
+      ctx.openTimeline(target);
+      return toolOk(`Opening "${node.name}"… (navigation is async — read_timeline to confirm)`, {
+        focusedId: targetStr,
+        changed: true,
+      });
+    },
+  };
+}
+
+function goUpTool(ctx: GraphToolContext): ToolDef {
+  return {
+    name: "go_up",
+    description:
+      "Go up one level — focus the parent of the current timeline. No-op at the project root. Async, like focus.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+    execute: () => {
+      if (ctx.focusedId === ctx.projectId) {
+        return toolOk("Already at the project root.", { focusedId: ctx.projectId, changed: false });
+      }
+      const graph = ctx.store.getSnapshot().graph;
+      const parent = graph.parentById.get(parseNodeId(ctx.focusedId)) ?? null;
+      const targetStr = parent === null ? ctx.projectId : String(parent);
+      ctx.openTimeline(parseNodeId(targetStr));
+      const name = graph.nodesById.get(parseNodeId(targetStr))?.name ?? targetStr;
+      return toolOk(`Going up to "${name}"…`, { focusedId: targetStr, changed: true });
+    },
+  };
+}
+
+function setPreviewTool(ctx: GraphToolContext): ToolDef {
+  return {
+    name: "set_preview",
+    description: "Turn the preview pane on or off. The preview plays the focused timeline.",
+    inputSchema: {
+      type: "object",
+      required: ["on"],
+      properties: { on: { type: "boolean" } },
+      additionalProperties: false,
+    },
+    execute: (args) => {
+      const on = readBoolean(args, "on");
+      if (on === undefined) return toolError("set_preview requires `on` (true or false).");
+      if (ctx.getViewState().previewOn === on) {
+        return toolOk(`Preview is already ${on ? "on" : "off"}.`, { previewOn: on, changed: false });
+      }
+      ctx.togglePreview();
+      return toolOk(`Turned preview ${on ? "on" : "off"}.`, { previewOn: on, changed: true });
+    },
+  };
+}
+
+function playTool(ctx: GraphToolContext): ToolDef {
+  return {
+    name: "play",
+    description:
+      "Start playback of the focused timeline. Turns the preview pane on first if it's off, so you can see it play.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+    execute: () => {
+      const openedPreview = !ctx.getViewState().previewOn;
+      if (openedPreview) ctx.togglePreview();
+      ctx.setPlaying(true);
+      return toolOk(openedPreview ? "Opened the preview and started playing." : "Playing.", {
+        playing: true,
+        openedPreview,
+      });
+    },
+  };
+}
+
+function pauseTool(ctx: GraphToolContext): ToolDef {
+  return {
+    name: "pause",
+    description: "Stop playback of the focused timeline. The playhead stays where it is (seek to move it).",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+    execute: () => {
+      const wasPlaying = ctx.getPlayback().isPlaying;
+      ctx.setPlaying(false);
+      return toolOk(wasPlaying ? "Paused." : "Already paused.", {
+        playing: false,
+        changed: wasPlaying,
+      });
+    },
+  };
+}
+
+function seekTool(ctx: GraphToolContext): ToolDef {
+  return {
+    name: "seek",
+    description:
+      "Move the playhead to a time (in seconds) in the focused timeline. Clamped to ≥ 0 (and to the timeline's end by the player).",
+    inputSchema: {
+      type: "object",
+      required: ["seconds"],
+      properties: { seconds: { type: "number", minimum: 0 } },
+      additionalProperties: false,
+    },
+    execute: (args) => {
+      const seconds = readNumber(args, "seconds");
+      if (seconds === undefined) return toolError("seek requires a numeric `seconds`.");
+      const clamped = Math.max(0, seconds);
+      ctx.seek(clamped);
+      return toolOk(`Moved the playhead to ${clamped.toFixed(1)}s.`, { seconds: clamped });
     },
   };
 }

--- a/docs/webmcp-agent-tools.md
+++ b/docs/webmcp-agent-tools.md
@@ -402,3 +402,38 @@ placement default `after: nodeId`; `insertClones(...)`; `setSelection(newIds)`.
   relocates to trash and errors when trash is absent). Remaining v1 surface:
   `list_assets` + `add_clip` (asset-provider seam), then `duplicate_clip`
   (async → brings in the `sessionAlive` guard).
+
+- **2026-07-24** — Increment 3: **view / session tools** — a new category
+  distinct from the document-edit tools. These are *ephemeral* (no persistence,
+  no undo): `get_view_state` (focus + selection + preview, read-only),
+  `select_items` / `clear_selection` (→ `store.setSelection` / `clearSelection`),
+  `focus` / `go_up` (→ the graph view's `openTimeline` navigation), and
+  `set_preview` (→ the `GRAPH_PREVIEW_TOGGLE_EVENT` window event, made
+  deterministic by reading the `GRAPH_VIEW_STATE_EVENT` broadcast). Motivation:
+  driving the app previously required pixel-clicking for navigation/preview
+  (brittle); these make it first-class. Wiring: selection is pure store; preview
+  rides the sidebar's existing window-event bus (zero threading — the bridge
+  mirrors the view-state broadcast into a ref); navigation is a router push, so
+  `<McpToolsBridge>` gains `projectId` + `onOpenNode` (the `openTimeline` seam,
+  same one the board's click-to-drill uses). Verified: 36 unit tests
+  (handlers over a real store + injected nav/preview spies) and **live** in the
+  real app via chrome-in-browser — `focus`/`go_up` moved the route, `set_preview`
+  flipped the pane and `get_view_state` read it back. Navigation is async (the
+  tool returns before the route commits — read_timeline to confirm).
+
+- **2026-07-24** — Increment 3 (cont.): **playback tools** `play` / `pause` /
+  `seek`, plus `isPlaying` + `currentTimeSeconds` on `get_view_state`. `play`
+  turns the preview on first if it's off (so you see it), then starts. This
+  needed a change to the **shared player**: `WorkbenchDisplaySurface`
+  (`packages/ui/timeline`) gained optional controlled-playback props
+  (`playing` + `onPlayingChange`) — supplied → it renders/reports play state
+  through them; omitted → the previous uncontrolled behavior is unchanged (so
+  every existing consumer is untouched). Play state now lives on the
+  `PreviewTimeChannel` (`isPlaying`/`setPlaying`/`subscribePlaying`), above the
+  pane's mount, so it survives preview toggling and can be set before the pane
+  exists (that's what makes play-auto-shows-preview race-free). `PreviewShell`
+  wires the surface's controlled props to the channel; `<McpToolsBridge>` gains
+  the channel and derives `seek`/`setPlaying`/`getPlayback`. Verified: 41 unit
+  tests, `packages/ui` typecheck + a `ControlledPlayback` story interaction
+  test (the surface reflects the `playing` prop), and **live** — `play` opened
+  the preview and advanced time 0→2.5s, `pause` froze it, `seek` jumped to 20s.

--- a/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
+++ b/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, userEvent, within } from "storybook/test";
 
 import { WorkbenchSplitPane } from "./workbench-display-surface";
 
@@ -51,4 +52,51 @@ type Story = StoryObj<typeof meta>;
  * the timeline sections continue through the document scrollport. */
 export const StickyPreview: Story = {
   render: () => <StickyPreviewFixture />,
+};
+
+function ControlledPlaybackFixture() {
+  const [currentTime, setCurrentTime] = useState(0);
+  const [playing, setPlaying] = useState(false);
+
+  return (
+    <main className="min-h-[900px] bg-zinc-950 p-4 text-zinc-100">
+      <button
+        type="button"
+        data-testid="external-toggle"
+        onClick={() => setPlaying((value) => !value)}
+        className="mb-3 rounded border border-zinc-700 px-3 py-1 text-sm"
+      >
+        External play toggle
+      </button>
+      <WorkbenchSplitPane
+        clips={[]}
+        currentTime={currentTime}
+        onCurrentTimeChange={setCurrentTime}
+        playing={playing}
+        onPlayingChange={setPlaying}
+      >
+        <div className="min-h-24" />
+      </WorkbenchSplitPane>
+    </main>
+  );
+}
+
+/** Controlled playback: when `playing` is supplied, the surface's play/pause
+ *  button REFLECTS that prop rather than owning the state — flipping it from
+ *  outside swaps the button from Play to Pause. */
+export const ControlledPlayback: Story = {
+  render: () => <ControlledPlaybackFixture />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const user = userEvent.setup();
+
+    // Starts paused → the surface offers "Play".
+    expect(canvas.getByRole("button", { name: "Play workbench preview" })).toBeInTheDocument();
+
+    // Flip the controlled prop from OUTSIDE the surface; it re-renders as "Pause".
+    await user.click(canvas.getByTestId("external-toggle"));
+    expect(
+      await canvas.findByRole("button", { name: "Pause workbench preview" }),
+    ).toBeInTheDocument();
+  },
 };

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -41,6 +41,12 @@ type WorkbenchDisplaySurfaceProps = {
   onCurrentTimeChange: (time: number) => void;
   className?: string;
   preferredClipId?: string | null;
+  /** Controlled playback. When supplied, the surface plays iff this is true and
+   *  reports intent through `onPlayingChange` (the play button and the
+   *  end-of-timeline auto-stop call it) instead of holding play state itself.
+   *  Omit for the default uncontrolled behavior (internal play state). */
+  playing?: boolean;
+  onPlayingChange?: (playing: boolean) => void;
 };
 
 const BUFFER_WINDOW_SIZE = 4;
@@ -246,6 +252,8 @@ export function WorkbenchDisplaySurface({
   onCurrentTimeChange,
   className,
   preferredClipId,
+  playing,
+  onPlayingChange,
 }: WorkbenchDisplaySurfaceProps) {
   const { getCollectionClipFramePreview } = useTimelineDocuments();
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -261,7 +269,18 @@ export function WorkbenchDisplaySurface({
   const sortedClipsRef = useRef<TimelineClip[]>([]);
   const durationRef = useRef(0);
   const isPlayingRef = useRef(false);
-  const [isPlaying, setIsPlaying] = useState(false);
+  // Controlled when `playing` is supplied; otherwise the surface owns the state
+  // (the default, preserving every existing consumer's behavior).
+  const isControlledPlayback = playing !== undefined;
+  const [uncontrolledPlaying, setUncontrolledPlaying] = useState(false);
+  const isPlaying = playing ?? uncontrolledPlaying;
+  const setPlaying = useCallback(
+    (next: boolean) => {
+      if (isControlledPlayback) onPlayingChange?.(next);
+      else setUncontrolledPlaying(next);
+    },
+    [isControlledPlayback, onPlayingChange],
+  );
 
   const sortedClips = useMemo(
     () => [...clips].sort((a, b) => getClipPlaybackStart(a) - getClipPlaybackStart(b) || a.index - b.index),
@@ -635,7 +654,7 @@ export function WorkbenchDisplaySurface({
       if (nextTime >= durationRef.current) {
         publishTime(durationRef.current, now, true);
         renderFrameAtTime(durationRef.current, false, true);
-        setIsPlaying(false);
+        setPlaying(false);
         return;
       }
 
@@ -654,7 +673,7 @@ export function WorkbenchDisplaySurface({
       window.removeEventListener("visibilitychange", handleVisibilityChange);
       cancelQueuedFrame();
     };
-  }, [isPlaying, onCurrentTimeChange, renderFrameAtTime]);
+  }, [isPlaying, onCurrentTimeChange, renderFrameAtTime, setPlaying]);
 
   useEffect(() => {
     const mediaCache = cacheRef.current;
@@ -709,7 +728,7 @@ export function WorkbenchDisplaySurface({
           </button>
           <button
             type="button"
-            onClick={() => setIsPlaying((value) => !value)}
+            onClick={() => setPlaying(!isPlaying)}
             disabled={!canPlay}
             className="grid size-9 place-items-center rounded-full border border-zinc-700 bg-zinc-900 text-zinc-100 transition-colors hover:border-amber-400 hover:text-amber-300 disabled:cursor-not-allowed disabled:opacity-40"
             aria-label={isPlaying ? "Pause workbench preview" : "Play workbench preview"}
@@ -742,6 +761,9 @@ type WorkbenchSplitPaneProps = {
   onCurrentTimeChange: (time: number) => void;
   children: ReactNode;
   preferredClipId?: string | null;
+  /** Controlled playback, forwarded to the display surface. See there. */
+  playing?: boolean;
+  onPlayingChange?: (playing: boolean) => void;
   /** Read ONCE at mount for a height carried over from a previous mount (e.g.
    *  the consumer toggled this pane off and back on). Returning a number makes
    *  the pane start there and SKIP the one-time fit — a height the user chose
@@ -760,6 +782,8 @@ export function WorkbenchSplitPane({
   onCurrentTimeChange,
   children,
   preferredClipId,
+  playing,
+  onPlayingChange,
   getInitialSurfaceHeight,
   onSurfaceHeightChange,
 }: WorkbenchSplitPaneProps) {
@@ -1014,6 +1038,8 @@ export function WorkbenchSplitPane({
             currentTime={currentTime}
             onCurrentTimeChange={onCurrentTimeChange}
             preferredClipId={preferredClipId}
+            playing={playing}
+            onPlayingChange={onPlayingChange}
             className="h-full"
           />
         </div>


### PR DESCRIPTION
Adds a **new category of ephemeral view/session tools** plus **playback**, and the shared-player change playback needs. This is what lets an agent drive the app without pixel-clicking.

## Tools

| Tool | Does | Wiring |
|---|---|---|
| `get_view_state` (read-only) | focus + selection + preview + playback | store + view-state broadcast + channel |
| `select_items` / `clear_selection` | select/deselect by id | `store.setSelection` / `clearSelection` |
| `focus` / `go_up` | drill into / focus a timeline; go up | the graph view's `openTimeline` (router push) |
| `set_preview` | preview pane on/off | `GRAPH_PREVIEW_TOGGLE_EVENT` + `GRAPH_VIEW_STATE_EVENT` |
| `play` / `pause` / `seek` | play (auto-opens preview), stop, scrub | the `PreviewTimeChannel` |

## Shared-player change (`packages/ui/timeline`)

Playback state lived *inside* `WorkbenchDisplaySurface`, so I made it **optionally controlled**:

- New `playing` + `onPlayingChange` props. **Supplied** → the surface renders/reports play state through them. **Omitted** → the previous uncontrolled behavior is byte-for-byte unchanged, so **every existing consumer is untouched**.
- Play state now lives on the `PreviewTimeChannel` (`isPlaying`/`setPlaying`/`subscribePlaying`), *above* the pane's mount — so it survives preview toggling and can be set before the pane exists. That's what makes **`play` auto-opening the preview race-free**: set channel playing → turn preview on → the pane mounts already-playing.
- `PreviewShell` wires the surface's controlled props to the channel.

## Blast radius

`<McpToolsBridge>` is still a no-op where `navigator.modelContext` is absent (flag off). The shared-player change is backward-compatible by construction (uncontrolled default). No existing behavior changes.

## Verification

- **41 webmcp unit tests** — handlers over a real store with injected nav/preview/playback spies (select mutates the store; focus/go_up call `openTimeline`; set_preview/play/pause toggle deterministically; seek clamps ≥ 0; get_view_state reports playback).
- **`packages/ui` typecheck** + a **`ControlledPlayback` story interaction test** (the surface reflects the `playing` prop; existing `StickyPreview` still passes).
- App `tsc` + `eslint` clean.
- **Live in the real app**: `focus`/`go_up` moved the route; **`play` opened the preview and advanced time 0→2.5s**; `pause` froze it; `seek` jumped to 20s.

## Next

Resume `list_assets` + `add_clip` (stashed), then `duplicate_clip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
