### PR TITLE
Fix app type error + gate app typecheck in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
         working-directory: packages/ui
         run: npx tsc --noEmit -p tsconfig.json
 
+      - name: Typecheck app
+        working-directory: apps/timeline-gstudio001
+        run: npx tsc --noEmit
+
       - name: Lint app
         working-directory: apps/timeline-gstudio001
         run: npm run lint

--- a/apps/timeline-gstudio001/app/api/timelines/asset-library-route.test.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/asset-library-route.test.ts
@@ -102,7 +102,9 @@ describe("GET /api/timelines/asset-library-<uid> (seam-backed)", () => {
     expect((doc.clips[0] as CollectionTimelineClip).childTimelineId).toBe(
       `asset-library-col-user-a-${encodeFolderPath("Scenes/Heist")}`,
     );
-    const media = doc.clips[1] as TimelineClip;
+    const media = doc.clips[1];
+    // Narrow off the collection variant (no `src`) before reading `src`.
+    if (media.kind === "collection") throw new Error("expected the image clip at index 1");
     expect(media.src).toBe("https://cdn.test/scenes-1");
   });
 


### PR DESCRIPTION
Addresses review finding #1. The app failed `tsc` — `asset-library-route.test.ts` cast `doc.clips[1]` to the `TimelineClip` union (collections have no `src`) then read `.src` → TS2339 — and CI only typechecked `packages/ui`, so it merged green repeatedly.

- **Fix:** narrow off the collection variant before reading `src` (discriminant check).
- **Gate:** add an app `tsc --noEmit` step to the CI `validate` job so this class of error fails every PR from now on. Job name is unchanged, so branch-protection contexts still match.

Verified: app `tsc` clean (was 1 error), `asset-library-route` test (3) passes, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)