### PR TITLE
Make Cut atomic (review #3): session guard + gate clear on move count

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
@@ -413,11 +413,21 @@ export function GraphItemActionsBridge({
       const selected = [...store.getSnapshot().interaction.selectedIds];
       if (selected.length === 0) return;
       if (!(await captureSelection(store, details, selected))) return;
+      // The capture awaited documents; the session can be torn down (project
+      // switch) meanwhile — the same guard Duplicate uses. Without it the move
+      // below dispatches into a dead store, leaving the clipboard populated
+      // while the originals were never actually removed in the live session.
+      if (!sessionAliveRef.current) return;
       // Remove the originals (recoverable in trash); the clipboard holds an
       // independent snapshot, so Paste still relocates them. Item mode stays
       // alive because the clipboard is now non-empty (Paste remains available).
-      moveSelectionToTrash(store, trashId, selected);
-      store.clearSelection();
+      //
+      // Clear the selection ONLY if the move actually landed: a drag starting
+      // mid-capture makes moveSelectionToTrash a no-op (returns 0, isDragging),
+      // and clearing anyway would leave Cut silently behaving like Copy —
+      // clipboard set, nothing trashed, selection gone.
+      const moved = moveSelectionToTrash(store, trashId, selected);
+      if (moved > 0) store.clearSelection();
     };
 
     const pasteSelection = () => {


### PR DESCRIPTION
Addresses review finding #3. `cutSelection` awaited `captureSelection`, then moved the originals to trash and cleared selection **unconditionally** — ignoring the move result and skipping the session-lifetime check Duplicate uses. Two silent failures:

- **Project switch during capture** → the stale move dispatched into a destroyed store, leaving the clipboard populated but the originals not removed in the live session. **Fix:** recheck `sessionAliveRef` after the await (same guard as Duplicate).
- **Drag starting mid-capture** → `moveSelectionToTrash` returns `0` (`isDragging`), yet Cut cleared selection anyway → silently behaved like Copy. **Fix:** clear selection only when the move landed (`moved > 0`).

Verified: app `tsc` + eslint clean, Cut / Ctrl+X e2e (2) pass. A deterministic test for the race isn't practical here (the `.tsx` isn't unit-testable, and the timing isn't reliably reproducible in e2e); the guards mirror the already-verified Duplicate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)