### PR TITLE
Fix quadratic drop-indicator no-op check (review #2)

### DIFF
--- a/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
@@ -26,6 +26,7 @@ import {
 } from "../react/collections-components";
 import { useCollectionsSelector, useCollectionsStore } from "../react/collections-store";
 import { NodeCard } from "../react/node-views";
+import { isContiguousReorderNoOp } from "./insert-noop";
 import { useEdgeAutoScroll } from "../react/use-edge-autoscroll";
 import {
   useFocusNode,
@@ -298,18 +299,8 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
       // Hide the indicator on a NO-OP move: dragging items already in this
       // collection to a boundary that leaves them where they are. Only for a
       // contiguous run wholly inside this collection (see VirtualStrip).
-      const active = s.interaction.activeIds;
-      if (active.length > 0) {
-        const children = getChildren(s.graph, collectionId);
-        const positions = active.map((id) => children.indexOf(id));
-        if (positions.every((position) => position >= 0)) {
-          const lo = Math.min(...positions);
-          const hi = Math.max(...positions);
-          const contiguous = hi - lo + 1 === positions.length;
-          if (contiguous && intent.index >= lo && intent.index <= hi + 1) {
-            return null;
-          }
-        }
+      if (isContiguousReorderNoOp(indexById, s.interaction.activeIds, intent.index)) {
+        return null;
       }
       return intent.index;
     });

--- a/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
@@ -27,6 +27,7 @@ import {
   finitePositiveOrUndefined,
   nonNegativeIntegerOr,
 } from "../core/numeric";
+import { isContiguousReorderNoOp } from "./insert-noop";
 import {
   useCollectionsComponents,
   type CollectionItemContentComponent,
@@ -724,18 +725,8 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
       // at any boundary from the run's start to just past its end is identity.
       // (A non-contiguous multi-drag reorders the items between them, so it is a
       // real move and keeps its indicator.)
-      const active = s.interaction.activeIds;
-      if (active.length > 0) {
-        const children = getChildren(s.graph, collectionId);
-        const positions = active.map((id) => children.indexOf(id));
-        if (positions.every((position) => position >= 0)) {
-          const lo = Math.min(...positions);
-          const hi = Math.max(...positions);
-          const contiguous = hi - lo + 1 === positions.length;
-          if (contiguous && intent.index >= lo && intent.index <= hi + 1) {
-            return null;
-          }
-        }
+      if (isContiguousReorderNoOp(indexById, s.interaction.activeIds, intent.index)) {
+        return null;
       }
       return intent.index;
     });

--- a/packages/ui/dnd-collections/virtual/insert-noop.test.ts
+++ b/packages/ui/dnd-collections/virtual/insert-noop.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { parseNodeId, type NodeId } from "../core/graph";
+
+import { isContiguousReorderNoOp } from "./insert-noop";
+
+function indexMap(ids: readonly string[]): Map<NodeId, number> {
+  return new Map(ids.map((id, index) => [parseNodeId(id), index] as const));
+}
+const ids = (...values: string[]): NodeId[] => values.map(parseNodeId);
+
+describe("isContiguousReorderNoOp", () => {
+  const idx = indexMap(["a", "b", "c", "d", "e"]); // a=0 … e=4
+
+  it("is a no-op for a contiguous run dropped anywhere within its own span", () => {
+    const active = ids("b", "c"); // positions 1,2
+    expect(isContiguousReorderNoOp(idx, active, 1)).toBe(true);
+    expect(isContiguousReorderNoOp(idx, active, 2)).toBe(true);
+    expect(isContiguousReorderNoOp(idx, active, 3)).toBe(true); // just past the end
+  });
+
+  it("is a real move outside the run's span", () => {
+    const active = ids("b", "c"); // 1,2
+    expect(isContiguousReorderNoOp(idx, active, 0)).toBe(false);
+    expect(isContiguousReorderNoOp(idx, active, 4)).toBe(false);
+  });
+
+  it("treats a non-contiguous multi-selection as a real move", () => {
+    expect(isContiguousReorderNoOp(idx, ids("b", "d"), 2)).toBe(false); // gap at c
+  });
+
+  it("is a real move in when any dragged item isn't in this collection", () => {
+    expect(isContiguousReorderNoOp(indexMap(["a", "b", "c"]), ids("b", "z"), 1)).toBe(false);
+  });
+
+  it("empty selection is never a no-op", () => {
+    expect(isContiguousReorderNoOp(idx, [], 0)).toBe(false);
+  });
+
+  it("stays correct with thousands of children and a large contiguous selection", () => {
+    const N = 20000;
+    const all = Array.from({ length: N }, (_, i) => `n${i}`);
+    const big = indexMap(all);
+    const run = all.slice(5000, 15000).map(parseNodeId); // 10k contiguous
+    expect(isContiguousReorderNoOp(big, run, 5000)).toBe(true); // run start
+    expect(isContiguousReorderNoOp(big, run, 15000)).toBe(true); // just past end
+    expect(isContiguousReorderNoOp(big, run, 4999)).toBe(false);
+    expect(isContiguousReorderNoOp(big, run, 15001)).toBe(false);
+  });
+});

--- a/packages/ui/dnd-collections/virtual/insert-noop.ts
+++ b/packages/ui/dnd-collections/virtual/insert-noop.ts
@@ -1,0 +1,37 @@
+import { type NodeId } from "../core/graph";
+
+/**
+ * True when a live insert-at-index into a collection would drop a CONTIGUOUS
+ * run of the dragged items exactly where they already sit — an identity move,
+ * so the drop indicator should hide. Dropping at any boundary from the run's
+ * start to just past its end is a no-op; a non-contiguous multi-drag reorders
+ * the items between them, so it is a real move and keeps its indicator. A
+ * dragged item not in this collection makes it a real move IN.
+ *
+ * `O(active)`, no allocation or spread: positions come from the collection's
+ * precomputed `childIndexById` map (both virtual views already build one), so
+ * this stays cheap on the drag hot path even for thousands of children and a
+ * large selection. It replaces `active.map((id) => children.indexOf(id))` plus
+ * `Math.min(...positions)` / `Math.max(...positions)`, which ran every
+ * drop-intent tick at `O(active × children)` and risked a spread `RangeError`
+ * for a pathologically large selection.
+ */
+export function isContiguousReorderNoOp(
+  childIndexById: ReadonlyMap<NodeId, number>,
+  activeIds: readonly NodeId[],
+  intentIndex: number,
+): boolean {
+  if (activeIds.length === 0) return false;
+
+  let lo = Infinity;
+  let hi = -Infinity;
+  for (const id of activeIds) {
+    const position = childIndexById.get(id);
+    if (position === undefined) return false; // a dragged item lives elsewhere
+    if (position < lo) lo = position;
+    if (position > hi) hi = position;
+  }
+
+  const contiguous = hi - lo + 1 === activeIds.length;
+  return contiguous && intentIndex >= lo && intentIndex <= hi + 1;
+}


### PR DESCRIPTION
Addresses review finding #2. On every drop-intent tick during a drag, both `VirtualStrip` and `VirtualGrid` ran `active.map((id) => children.indexOf(id))` + `Math.min(...positions)` / `Math.max(...positions)` — **O(active × children)** and spread-bounded (a `RangeError` risk for a pathologically large selection).

- Extract the no-op detection into a pure **O(active)** helper `isContiguousReorderNoOp` that reads positions from the collection's precomputed `indexById` map (both views already build one), tracking `lo`/`hi` in a single loop — no allocation, no spread.
- Both views call it, deduplicating the identical block.

Verified: `packages/ui` tsc clean; new unit test (incl. **20k children / 10k contiguous selection**) 6 pass; VirtualStrip + VirtualGrid story interaction suites (**56**) pass — no regression to the no-op indicator behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)