### PR TITLE
Externalize firebase-admin so serverless routes load on Vercel

### DIFF
--- a/apps/timeline-gstudio001/next.config.ts
+++ b/apps/timeline-gstudio001/next.config.ts
@@ -22,6 +22,15 @@ const nextConfig: NextConfig = {
     ],
   },
   output: 'standalone',
+  // firebase-admin must NOT be bundled into the serverless function. Its
+  // transitive `jwks-rsa` does a CommonJS `require("jose")`, and when the
+  // bundler resolves jose it picks the ESM build — Node then refuses the
+  // require with ERR_REQUIRE_ESM and the whole function 500s at module load
+  // (every route that touches auth/Firestore, not just login). Marking it
+  // external defers resolution to Node at runtime, which picks jose's CJS
+  // export condition and loads fine. Only shows up in a bundled deploy —
+  // `next dev` doesn't bundle node_modules, so it passes locally.
+  serverExternalPackages: ['firebase-admin'],
   transpilePackages: ['motion', '@storyboard/ui', '@storyboard/timeline-domain', '@storyboard/timeline-model', '@storyboard/collections-core'],
   webpack: (config, { dev }) => {
     // HMR is disabled in AI Studio via DISABLE_HMR env var.


### PR DESCRIPTION
The deployed app 500s on every route touching auth/Firestore.

**Root cause** — Vercel's function bundle resolves `jose` to its ESM build, but firebase-admin's transitive `jwks-rsa` does a CommonJS `require()` of it:

```
ERR_REQUIRE_ESM: require() of ES Module jose/dist/webapi/index.js
from jwks-rsa/src/utils.js   (page: /api/auth/login)
```

The throw happens at **module load — outside the route's try/catch** — so the client receives Vercel's generic HTML 500 instead of the route's JSON error, surfacing as a bare "Authentication failed." in the UI.

**Fix** — `serverExternalPackages: ['firebase-admin']` stops Next bundling it; Node resolves the subtree and picks jose's CJS export condition.

Invisible locally: `next dev` doesn't bundle `node_modules`, so only a deployed (bundled) build hits it.

Verified: production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)