### PR TITLE
Add read-only remote MCP endpoint at /api/mcp

### DIFF
--- a/apps/timeline-gstudio001/app/api/mcp/route.ts
+++ b/apps/timeline-gstudio001/app/api/mcp/route.ts
@@ -1,0 +1,141 @@
+import { timingSafeEqual } from "node:crypto";
+
+import { createMcpHandler, withMcpAuth } from "mcp-handler";
+import { z } from "zod";
+
+import {
+  getFirebaseTimelineDocument,
+  listFirebaseTimelineProjects,
+} from "@/lib/firebase-timeline-store";
+import { TimelineAccessDeniedError } from "@/lib/timeline-ownership";
+
+// Remote MCP endpoint — the "give Claude a URL" surface, distinct from the
+// in-page WebMCP tools (see docs/webmcp-agent-tools.md). Those run in the
+// browser against the live CollectionsStore; these run server-side against
+// Firestore, so an agent can read the project with no browser open.
+//
+// READ-ONLY on purpose. This is a publicly reachable endpoint over real user
+// data, so the first milestone proves transport + auth without exposing any
+// write path. Mutations wait until the auth story is finished (see below).
+//
+// AUTH IS INTERIM. A single static bearer token identifying ONE owner uid,
+// which is enough to drive from Claude Code / mcp-remote and prove the loop.
+// claude.ai's custom-connector flow expects OAuth 2.1 + PKCE, so connecting
+// there needs that built first — at which point `ownerUid()` stops being a
+// fixed env var and starts being derived per authenticated user.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+/** Constant-time compare that can't leak length via early return. */
+function secretsMatch(provided: string, expected: string): boolean {
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  // timingSafeEqual throws on length mismatch, so gate on it — the length of
+  // a rejected token is not itself sensitive.
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+/** The uid every tool reads as. Fixed while auth is a shared bearer token. */
+function ownerUid(): string | undefined {
+  return process.env.MCP_OWNER_UID?.trim() || undefined;
+}
+
+function jsonResult(summary: string, payload: unknown) {
+  return {
+    content: [
+      { type: "text" as const, text: summary },
+      { type: "text" as const, text: JSON.stringify(payload, null, 2) },
+    ],
+  };
+}
+
+function errorResult(message: string) {
+  return { content: [{ type: "text" as const, text: message }], isError: true };
+}
+
+const handler = createMcpHandler(
+  (server) => {
+    server.tool(
+      "list_projects",
+      "List the owner's timeline projects: id, title, clip count, and last-updated time. Start here to find a project id for read_timeline.",
+      {},
+      async () => {
+        const uid = ownerUid();
+        if (!uid) return errorResult("MCP_OWNER_UID is not configured on the server.");
+
+        const projects = await listFirebaseTimelineProjects(uid);
+        const summary =
+          projects.length === 0
+            ? "No timeline projects."
+            : `${projects.length} project${projects.length === 1 ? "" : "s"}: ${projects
+                .slice(0, 10)
+                .map((p) => `${p.title} (${p.clipCount} clips, id ${p.id})`)
+                .join("; ")}${projects.length > 10 ? "…" : ""}`;
+        return jsonResult(summary, { projects });
+      },
+    );
+
+    server.tool(
+      "read_timeline",
+      "Read one timeline document by id — its title and full ordered clip list. Ids come from list_projects, or from a collection clip's childTimelineId when drilling into a nested timeline.",
+      { timelineId: z.string().min(1).describe("Timeline document id.") },
+      async ({ timelineId }) => {
+        const uid = ownerUid();
+        if (!uid) return errorResult("MCP_OWNER_UID is not configured on the server.");
+
+        try {
+          const document = await getFirebaseTimelineDocument(timelineId, uid);
+          if (!document) return errorResult(`No timeline document with id "${timelineId}".`);
+
+          const clips = document.clips ?? [];
+          const summary = `"${document.title}" — ${clips.length} clip${
+            clips.length === 1 ? "" : "s"
+          }: ${
+            clips
+              .slice(0, 8)
+              .map((clip) => (clip.kind === "collection" ? `${clip.title} (collection)` : clip.kind))
+              .join(", ") || "(empty)"
+          }${clips.length > 8 ? "…" : ""}`;
+          return jsonResult(summary, { timeline: document });
+        } catch (error) {
+          // Ownership is enforced in the store; surface a refusal rather than
+          // leaking whether the id exists under another account.
+          if (error instanceof TimelineAccessDeniedError) {
+            return errorResult(`Not authorized to read timeline "${timelineId}".`);
+          }
+          throw error;
+        }
+      },
+    );
+  },
+  {},
+  { basePath: "/api", maxDuration: 60 },
+);
+
+/**
+ * Bearer gate. Returning `undefined` denies the request; mcp-handler answers
+ * with a 401 carrying the WWW-Authenticate challenge. A server missing either
+ * env var denies everything rather than falling open.
+ */
+const authedHandler = withMcpAuth(
+  handler,
+  (_request, bearerToken) => {
+    const expected = process.env.MCP_BEARER_TOKEN?.trim();
+    const uid = ownerUid();
+    if (!expected || !uid) return undefined;
+    if (!bearerToken || !secretsMatch(bearerToken, expected)) return undefined;
+
+    return {
+      token: bearerToken,
+      clientId: "storyboard-flow-mcp",
+      scopes: ["timelines:read"],
+      extra: { uid },
+    };
+  },
+  { required: true, requiredScopes: ["timelines:read"] },
+);
+
+export { authedHandler as GET, authedHandler as POST, authedHandler as DELETE };

--- a/apps/timeline-gstudio001/package.json
+++ b/apps/timeline-gstudio001/package.json
@@ -23,6 +23,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@google/genai": "^2.4.0",
     "@hookform/resolvers": "^5.2.1",
+    "@modelcontextprotocol/sdk": "^1.26.0",
     "@radix-ui/react-dropdown-menu": "^2.1.21",
     "@radix-ui/react-slider": "^1.4.4",
     "@radix-ui/react-slot": "^1.3.0",
@@ -35,13 +36,15 @@
     "clsx": "^2.1.1",
     "firebase-admin": "^13.10.0",
     "lucide-react": "^0.553.0",
+    "mcp-handler": "^1.1.0",
     "motion": "^12.23.24",
     "next": "^15.4.9",
     "postcss": "^8.5.6",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@playwright/test": "1.60.0",

--- a/docs/webmcp-agent-tools.md
+++ b/docs/webmcp-agent-tools.md
@@ -437,3 +437,26 @@ placement default `after: nodeId`; `insertClones(...)`; `setSelection(newIds)`.
   tests, `packages/ui` typecheck + a `ControlledPlayback` story interaction
   test (the surface reflects the `playing` prop), and **live** — `play` opened
   the preview and advanced time 0→2.5s, `pause` froze it, `seek` jumped to 20s.
+
+- **2026-07-24** — The **server-MCP transport** (the "durable hedge" above) is
+  now real, alongside WebMCP rather than replacing it. `app/api/mcp/route.ts`
+  mounts a remote MCP server via Vercel's `mcp-handler` (streamable HTTP) on the
+  deployed origin, so an agent can reach the project by URL with **no browser
+  open**. Deliberately a different execution path from the WebMCP tools: those
+  mutate the live `CollectionsStore` in the page (real-time), these read
+  Firestore server-side through the existing `firebase-timeline-store`
+  functions. **Read-only** for this milestone — it's a publicly reachable
+  endpoint over real user data, so transport + auth get proven before any write
+  path exists. Tools: `list_projects`, `read_timeline`.
+
+  **Auth is interim**: one static bearer token (`MCP_BEARER_TOKEN`) identifying
+  a single `MCP_OWNER_UID`, gated by `withMcpAuth` — enough to drive from Claude
+  Code / `mcp-remote`. claude.ai's custom-connector flow expects **OAuth 2.1 +
+  PKCE**, so connecting there requires building that; at which point the fixed
+  `ownerUid()` env var becomes a per-user derivation. The 401 already emits the
+  correct `WWW-Authenticate` challenge with `resource_metadata` pointing at
+  `/.well-known/oauth-protected-resource`, which is the discovery hook OAuth
+  will use. Note the real-time property is **not** available on this transport —
+  Firestore reads are one-shot and the browser holds no listeners, so a
+  server-side write would not appear in an open tab without a live-push channel
+  (see the top of this doc).

--- a/package-lock.json
+++ b/package-lock.json
@@ -502,6 +502,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@google/genai": "^2.4.0",
         "@hookform/resolvers": "^5.2.1",
+        "@modelcontextprotocol/sdk": "^1.26.0",
         "@radix-ui/react-dropdown-menu": "^2.1.21",
         "@radix-ui/react-slider": "^1.4.4",
         "@radix-ui/react-slot": "^1.3.0",
@@ -514,13 +515,15 @@
         "clsx": "^2.1.1",
         "firebase-admin": "^13.10.0",
         "lucide-react": "^0.553.0",
+        "mcp-handler": "^1.1.0",
         "motion": "^12.23.24",
         "next": "^15.4.9",
         "postcss": "^8.5.6",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
         "sonner": "^2.0.7",
-        "tailwind-merge": "^3.3.1"
+        "tailwind-merge": "^3.3.1",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@playwright/test": "1.60.0",
@@ -4415,9 +4418,9 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
+      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -6946,6 +6949,71 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.2.tgz",
       "integrity": "sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==",
       "license": "MIT"
+    },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/client/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
     },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.12.0",
@@ -11245,6 +11313,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/cmdk": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
@@ -14452,6 +14529,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -17197,6 +17283,55 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mcp-handler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mcp-handler/-/mcp-handler-1.1.0.tgz",
+      "integrity": "sha512-MVCES7g18gcoZy+R/3v5nadkUMzMAWdos8jRl6DyljOKvd2/ZKDmwlCjL6zp4vo+7FeCXOYL1uWinHWlkKAAUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^11.1.0",
+        "redis": "^4.6.0"
+      },
+      "bin": {
+        "create-mcp-route": "dist/cli/index.js",
+        "mcp-adapter": "dist/cli/index.js",
+        "mcp-handler": "dist/cli/index.js"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "1.26.0",
+        "next": ">=13.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": false
+        },
+        "next": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mcp-handler/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/mcp-handler/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -19823,6 +19958,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
       }
     },
     "node_modules/redux": {
@@ -24571,9 +24723,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"


### PR DESCRIPTION
The "give Claude a URL" surface, alongside (not replacing) the in-page WebMCP tools. Those mutate the live CollectionsStore in the browser; this reads Firestore server-side via the existing firebase-timeline-store functions, so an agent can read the project with no browser open.

- app/api/mcp/route.ts via Vercel's mcp-handler (streamable HTTP, no Redis).
- Tools: list_projects, read_timeline -- both read-only. This is a publicly reachable endpoint over real user data, so transport + auth are proven before any write path exists.
- Auth via withMcpAuth: a single static bearer token (MCP_BEARER_TOKEN) for one MCP_OWNER_UID, compared in constant time. Missing env vars deny rather than fall open. Ownership is still enforced in the store, and a TimelineAccessDeniedError is surfaced as a refusal rather than leaking whether the id exists under another account.

Auth is INTERIM: claude.ai's custom-connector flow expects OAuth 2.1 + PKCE, so connecting there needs that built -- at which point ownerUid() stops being a fixed env var and becomes a per-user derivation. The 401 already emits the correct WWW-Authenticate challenge with resource_metadata pointing at /.well-known/oauth-protected-resource, which is the discovery hook OAuth uses.

Verified: app tsc clean, production build lists /api/mcp, and an unauthenticated POST returns 401 with the proper Bearer challenge.