### PR TITLE
OAuth 2.1 + PKCE for the remote MCP endpoint

### DIFF
--- a/apps/timeline-gstudio001/app/.well-known/oauth-authorization-server/route.ts
+++ b/apps/timeline-gstudio001/app/.well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,22 @@
+import {
+  METADATA_HEADERS,
+  authorizationServerMetadata,
+  originFromRequest,
+} from "@/lib/oauth/metadata";
+
+// RFC 8414 Authorization Server Metadata — where the client discovers the
+// /authorize and /token endpoints and that S256 PKCE is required.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export function GET(request: Request) {
+  const origin = originFromRequest(request);
+  return new Response(JSON.stringify(authorizationServerMetadata(origin), null, 2), {
+    headers: METADATA_HEADERS,
+  });
+}
+
+export function OPTIONS() {
+  return new Response(null, { status: 204, headers: METADATA_HEADERS });
+}

--- a/apps/timeline-gstudio001/app/.well-known/oauth-protected-resource/route.ts
+++ b/apps/timeline-gstudio001/app/.well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,23 @@
+import {
+  METADATA_HEADERS,
+  originFromRequest,
+  protectedResourceMetadata,
+} from "@/lib/oauth/metadata";
+
+// RFC 9728 Protected Resource Metadata. The 401 from /api/mcp points here via
+// its WWW-Authenticate `resource_metadata` parameter; the client fetches this
+// to learn which authorization server to talk to.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export function GET(request: Request) {
+  const origin = originFromRequest(request);
+  return new Response(JSON.stringify(protectedResourceMetadata(origin), null, 2), {
+    headers: METADATA_HEADERS,
+  });
+}
+
+export function OPTIONS() {
+  return new Response(null, { status: 204, headers: METADATA_HEADERS });
+}

--- a/apps/timeline-gstudio001/app/api/mcp/route.ts
+++ b/apps/timeline-gstudio001/app/api/mcp/route.ts
@@ -7,6 +7,8 @@ import {
   getFirebaseTimelineDocument,
   listFirebaseTimelineProjects,
 } from "@/lib/firebase-timeline-store";
+import { MCP_SCOPE, getSigningSecret, verifyAccessToken } from "@/lib/oauth/core";
+import { mcpResourceUrl, originFromRequest } from "@/lib/oauth/metadata";
 import { TimelineAccessDeniedError } from "@/lib/timeline-ownership";
 
 // Remote MCP endpoint — the "give Claude a URL" surface, distinct from the
@@ -14,15 +16,14 @@ import { TimelineAccessDeniedError } from "@/lib/timeline-ownership";
 // browser against the live CollectionsStore; these run server-side against
 // Firestore, so an agent can read the project with no browser open.
 //
-// READ-ONLY on purpose. This is a publicly reachable endpoint over real user
-// data, so the first milestone proves transport + auth without exposing any
-// write path. Mutations wait until the auth story is finished (see below).
+// READ-ONLY on purpose: a publicly reachable endpoint over real user data
+// proves transport + auth before any write path exists.
 //
-// AUTH IS INTERIM. A single static bearer token identifying ONE owner uid,
-// which is enough to drive from Claude Code / mcp-remote and prove the loop.
-// claude.ai's custom-connector flow expects OAuth 2.1 + PKCE, so connecting
-// there needs that built first — at which point `ownerUid()` stops being a
-// fixed env var and starts being derived per authenticated user.
+// TWO auth paths, both yielding the uid the tools act as:
+//   1. OAuth 2.1 access token (claude.ai custom connector) — uid from `sub`.
+//   2. Static bearer token (Claude Code / mcp-remote) — uid from MCP_OWNER_UID.
+// The static path stays because it's already wired up; it is only active when
+// both its env vars are set, and OAuth is tried first.
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -32,15 +33,8 @@ export const maxDuration = 60;
 function secretsMatch(provided: string, expected: string): boolean {
   const a = Buffer.from(provided);
   const b = Buffer.from(expected);
-  // timingSafeEqual throws on length mismatch, so gate on it — the length of
-  // a rejected token is not itself sensitive.
   if (a.length !== b.length) return false;
   return timingSafeEqual(a, b);
-}
-
-/** The uid every tool reads as. Fixed while auth is a shared bearer token. */
-function ownerUid(): string | undefined {
-  return process.env.MCP_OWNER_UID?.trim() || undefined;
 }
 
 function jsonResult(summary: string, payload: unknown) {
@@ -56,15 +50,26 @@ function errorResult(message: string) {
   return { content: [{ type: "text" as const, text: message }], isError: true };
 }
 
+/**
+ * The uid this call acts as, taken from the verified token — never from tool
+ * arguments, so one authenticated caller can't read another account's data.
+ */
+function uidFrom(extra: { authInfo?: { extra?: Record<string, unknown> } }): string | null {
+  const uid = extra.authInfo?.extra?.uid;
+  return typeof uid === "string" && uid.length > 0 ? uid : null;
+}
+
+const NO_IDENTITY = "Could not determine the account for this token.";
+
 const handler = createMcpHandler(
   (server) => {
     server.tool(
       "list_projects",
       "List the owner's timeline projects: id, title, clip count, and last-updated time. Start here to find a project id for read_timeline.",
       {},
-      async () => {
-        const uid = ownerUid();
-        if (!uid) return errorResult("MCP_OWNER_UID is not configured on the server.");
+      async (_args, extra) => {
+        const uid = uidFrom(extra);
+        if (!uid) return errorResult(NO_IDENTITY);
 
         const projects = await listFirebaseTimelineProjects(uid);
         const summary =
@@ -82,9 +87,9 @@ const handler = createMcpHandler(
       "read_timeline",
       "Read one timeline document by id — its title and full ordered clip list. Ids come from list_projects, or from a collection clip's childTimelineId when drilling into a nested timeline.",
       { timelineId: z.string().min(1).describe("Timeline document id.") },
-      async ({ timelineId }) => {
-        const uid = ownerUid();
-        if (!uid) return errorResult("MCP_OWNER_UID is not configured on the server.");
+      async ({ timelineId }, extra) => {
+        const uid = uidFrom(extra);
+        if (!uid) return errorResult(NO_IDENTITY);
 
         try {
           const document = await getFirebaseTimelineDocument(timelineId, uid);
@@ -116,26 +121,47 @@ const handler = createMcpHandler(
 );
 
 /**
- * Bearer gate. Returning `undefined` denies the request; mcp-handler answers
- * with a 401 carrying the WWW-Authenticate challenge. A server missing either
- * env var denies everything rather than falling open.
+ * Returning `undefined` denies; mcp-handler answers 401 with the
+ * WWW-Authenticate challenge pointing at the protected-resource metadata,
+ * which is how a client discovers the OAuth server. Unconfigured servers deny
+ * rather than falling open.
  */
 const authedHandler = withMcpAuth(
   handler,
-  (_request, bearerToken) => {
-    const expected = process.env.MCP_BEARER_TOKEN?.trim();
-    const uid = ownerUid();
-    if (!expected || !uid) return undefined;
-    if (!bearerToken || !secretsMatch(bearerToken, expected)) return undefined;
+  (request, bearerToken) => {
+    if (!bearerToken) return undefined;
 
-    return {
-      token: bearerToken,
-      clientId: "storyboard-flow-mcp",
-      scopes: ["timelines:read"],
-      extra: { uid },
-    };
+    // 1. OAuth access token. Audience is bound to THIS deployment's MCP URL,
+    //    so a token minted for another resource can't be replayed here.
+    const signingSecret = getSigningSecret();
+    if (signingSecret) {
+      const audience = mcpResourceUrl(originFromRequest(request));
+      const verified = verifyAccessToken(bearerToken, signingSecret, audience);
+      if (verified.ok) {
+        return {
+          token: bearerToken,
+          clientId: verified.claims.client_id,
+          scopes: verified.claims.scope.split(/\s+/).filter(Boolean),
+          extra: { uid: verified.claims.sub },
+        };
+      }
+    }
+
+    // 2. Static bearer fallback (Claude Code / mcp-remote).
+    const staticToken = process.env.MCP_BEARER_TOKEN?.trim();
+    const staticUid = process.env.MCP_OWNER_UID?.trim();
+    if (staticToken && staticUid && secretsMatch(bearerToken, staticToken)) {
+      return {
+        token: bearerToken,
+        clientId: "storyboard-flow-mcp",
+        scopes: [MCP_SCOPE],
+        extra: { uid: staticUid },
+      };
+    }
+
+    return undefined;
   },
-  { required: true, requiredScopes: ["timelines:read"] },
+  { required: true, requiredScopes: [MCP_SCOPE] },
 );
 
 export { authedHandler as GET, authedHandler as POST, authedHandler as DELETE };

--- a/apps/timeline-gstudio001/app/api/oauth/authorize/route.ts
+++ b/apps/timeline-gstudio001/app/api/oauth/authorize/route.ts
@@ -1,0 +1,85 @@
+import { loadClient } from "@/lib/oauth/core";
+import {
+  errorRedirectUrl,
+  successRedirectUrl,
+  validateAuthorizeRequest,
+} from "@/lib/oauth/authorize-request";
+import { mcpResourceUrl, originFromRequest } from "@/lib/oauth/metadata";
+import { issueAuthCode } from "@/lib/oauth/store";
+import { getAuthUser } from "@/lib/firebase-auth-session";
+
+// The consent form POSTs here. Every parameter is re-validated server-side
+// against the registered client — the page's rendering is a UI affordance, not
+// a trust boundary, so nothing from the form is taken on faith.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+  const client = loadClient();
+  if (!client) {
+    return new Response("OAuth is not configured on this server.", { status: 500 });
+  }
+
+  const form = new URLSearchParams(await request.text());
+  const validation = validateAuthorizeRequest(form, client);
+
+  if (!validation.ok) {
+    // Never redirect to an unverified destination.
+    if (!validation.redirectable) {
+      return new Response(validation.description, { status: 400 });
+    }
+    return Response.redirect(
+      errorRedirectUrl(
+        validation.redirectUri,
+        validation.error,
+        validation.description,
+        validation.state,
+      ),
+      303,
+    );
+  }
+
+  // The session cookie is the ONLY source of identity here — a uid submitted
+  // in the form would let anyone mint a code for someone else's account.
+  const user = await getAuthUser();
+  if (!user) {
+    return Response.redirect(
+      errorRedirectUrl(
+        validation.params.redirectUri,
+        "access_denied",
+        "Not signed in.",
+        validation.params.state,
+      ),
+      303,
+    );
+  }
+
+  if (form.get("decision") !== "approve") {
+    return Response.redirect(
+      errorRedirectUrl(
+        validation.params.redirectUri,
+        "access_denied",
+        "The user denied the request.",
+        validation.params.state,
+      ),
+      303,
+    );
+  }
+
+  const origin = originFromRequest(request);
+  const code = await issueAuthCode({
+    clientId: validation.params.clientId,
+    redirectUri: validation.params.redirectUri,
+    codeChallenge: validation.params.codeChallenge,
+    codeChallengeMethod: validation.params.codeChallengeMethod,
+    uid: user.uid,
+    scope: validation.params.scope,
+    resource: mcpResourceUrl(origin),
+  });
+
+  return Response.redirect(
+    successRedirectUrl(validation.params.redirectUri, code, validation.params.state),
+    303,
+  );
+}

--- a/apps/timeline-gstudio001/app/api/oauth/token/route.ts
+++ b/apps/timeline-gstudio001/app/api/oauth/token/route.ts
@@ -1,0 +1,157 @@
+import {
+  ACCESS_TOKEN_TTL_SECONDS,
+  getSigningSecret,
+  loadClient,
+  safeEqual,
+  signAccessToken,
+  verifyPkce,
+} from "@/lib/oauth/core";
+import { mcpResourceUrl, originFromRequest } from "@/lib/oauth/metadata";
+import { consumeAuthCode, issueRefreshToken, rotateRefreshToken } from "@/lib/oauth/store";
+
+// OAuth 2.1 token endpoint: authorization_code (with PKCE) and refresh_token.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/** OAuth errors are a defined JSON shape, not free text (RFC 6749 §5.2). */
+function oauthError(error: string, description: string, status = 400) {
+  return Response.json(
+    { error, error_description: description },
+    { status, headers: { "cache-control": "no-store" } },
+  );
+}
+
+/** Client credentials may arrive as form fields or HTTP Basic. */
+function readClientCredentials(request: Request, form: URLSearchParams) {
+  const basic = request.headers.get("authorization");
+  if (basic?.toLowerCase().startsWith("basic ")) {
+    const decoded = Buffer.from(basic.slice(6), "base64").toString("utf8");
+    const separator = decoded.indexOf(":");
+    if (separator > 0) {
+      return {
+        clientId: decodeURIComponent(decoded.slice(0, separator)),
+        clientSecret: decodeURIComponent(decoded.slice(separator + 1)),
+      };
+    }
+  }
+  return {
+    clientId: form.get("client_id") ?? "",
+    clientSecret: form.get("client_secret") ?? "",
+  };
+}
+
+export async function POST(request: Request) {
+  const client = loadClient();
+  const secret = getSigningSecret();
+  if (!client || !secret) {
+    return oauthError("server_error", "OAuth is not configured on this server.", 500);
+  }
+
+  const form = new URLSearchParams(await request.text());
+  const { clientId, clientSecret } = readClientCredentials(request, form);
+
+  // Authenticate the client before doing anything else with the grant.
+  if (!safeEqual(clientId, client.clientId) || !safeEqual(clientSecret, client.clientSecret)) {
+    return oauthError("invalid_client", "Unknown client or bad secret.", 401);
+  }
+
+  const origin = originFromRequest(request);
+  const resource = mcpResourceUrl(origin);
+  const grantType = form.get("grant_type");
+
+  if (grantType === "authorization_code") {
+    const code = form.get("code");
+    const redirectUri = form.get("redirect_uri");
+    const codeVerifier = form.get("code_verifier");
+    if (!code || !redirectUri || !codeVerifier) {
+      return oauthError("invalid_request", "code, redirect_uri and code_verifier are required.");
+    }
+
+    // Single-use: consuming deletes the code even if validation below fails,
+    // so an intercepted code can never be retried.
+    const grant = await consumeAuthCode(code);
+    if (!grant) return oauthError("invalid_grant", "Code is unknown, already used, or expired.");
+
+    if (grant.clientId !== client.clientId) {
+      return oauthError("invalid_grant", "Code was issued to a different client.");
+    }
+    // The redirect_uri must match the one the code was bound to (RFC 6749 §4.1.3).
+    if (grant.redirectUri !== redirectUri) {
+      return oauthError("invalid_grant", "redirect_uri does not match the authorization request.");
+    }
+    if (!verifyPkce(codeVerifier, grant.codeChallenge, grant.codeChallengeMethod)) {
+      return oauthError("invalid_grant", "PKCE verification failed.");
+    }
+
+    return issueTokens(grant.uid, grant.scope, client.clientId, origin, resource, secret);
+  }
+
+  if (grantType === "refresh_token") {
+    const presented = form.get("refresh_token");
+    if (!presented) return oauthError("invalid_request", "refresh_token is required.");
+
+    const rotated = await rotateRefreshToken(presented);
+    if (!rotated) return oauthError("invalid_grant", "Refresh token is unknown or expired.");
+    if (rotated.grant.clientId !== client.clientId) {
+      return oauthError("invalid_grant", "Refresh token was issued to a different client.");
+    }
+
+    return tokenResponse(
+      signAccessToken(
+        buildClaims(rotated.grant.uid, rotated.grant.scope, client.clientId, origin, resource),
+        secret,
+      ),
+      rotated.nextToken,
+      rotated.grant.scope,
+    );
+  }
+
+  return oauthError("unsupported_grant_type", `Unsupported grant_type: ${grantType ?? "(none)"}`);
+}
+
+function buildClaims(
+  uid: string,
+  scope: string,
+  clientId: string,
+  origin: string,
+  resource: string,
+) {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    sub: uid,
+    iss: origin,
+    aud: resource,
+    client_id: clientId,
+    scope,
+    iat: now,
+    exp: now + ACCESS_TOKEN_TTL_SECONDS,
+  };
+}
+
+async function issueTokens(
+  uid: string,
+  scope: string,
+  clientId: string,
+  origin: string,
+  resource: string,
+  secret: string,
+) {
+  const accessToken = signAccessToken(buildClaims(uid, scope, clientId, origin, resource), secret);
+  const refreshToken = await issueRefreshToken({ clientId, uid, scope, resource });
+  return tokenResponse(accessToken, refreshToken, scope);
+}
+
+function tokenResponse(accessToken: string, refreshToken: string, scope: string) {
+  return Response.json(
+    {
+      access_token: accessToken,
+      token_type: "Bearer",
+      expires_in: ACCESS_TOKEN_TTL_SECONDS,
+      refresh_token: refreshToken,
+      scope,
+    },
+    // Tokens must never be cached by any intermediary.
+    { headers: { "cache-control": "no-store", pragma: "no-cache" } },
+  );
+}

--- a/apps/timeline-gstudio001/app/oauth/authorize/page.tsx
+++ b/apps/timeline-gstudio001/app/oauth/authorize/page.tsx
@@ -1,0 +1,121 @@
+import { redirect } from "next/navigation";
+
+import { getAuthUser } from "@/lib/firebase-auth-session";
+import { errorRedirectUrl, validateAuthorizeRequest } from "@/lib/oauth/authorize-request";
+import { loadClient } from "@/lib/oauth/core";
+
+// OAuth consent screen. A PAGE rather than an API route so it renders inside
+// the root layout — an unauthenticated visitor gets the existing AuthGate
+// sign-in form instead of a bespoke login here.
+//
+// This screen only *presents* the request; /api/oauth/authorize re-validates
+// everything on POST, so nothing here is a trust boundary.
+
+export const dynamic = "force-dynamic";
+
+function Shell({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="mx-auto mt-16 max-w-md rounded-lg border border-zinc-800 bg-zinc-900/40 p-6">
+      <h1 className="text-lg font-semibold text-zinc-100">{title}</h1>
+      <div className="mt-3 text-sm text-zinc-300">{children}</div>
+    </div>
+  );
+}
+
+export default async function AuthorizePage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const client = loadClient();
+  if (!client) {
+    return (
+      <Shell title="Connection unavailable">
+        This server has no OAuth client configured, so it can&apos;t authorize connections yet.
+      </Shell>
+    );
+  }
+
+  const raw = await searchParams;
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(raw)) {
+    if (typeof value === "string") query.set(key, value);
+    else if (Array.isArray(value) && value[0]) query.set(key, value[0]);
+  }
+
+  const validation = validateAuthorizeRequest(query, client);
+
+  if (!validation.ok) {
+    // Untrusted client/redirect: show the problem, never bounce to it.
+    if (!validation.redirectable) {
+      return <Shell title="Invalid request">{validation.description}</Shell>;
+    }
+    redirect(
+      errorRedirectUrl(
+        validation.redirectUri,
+        validation.error,
+        validation.description,
+        validation.state,
+      ),
+    );
+  }
+
+  const user = await getAuthUser();
+  if (!user) {
+    // AuthGate (root layout) renders the sign-in form around this. Signing in
+    // via email link returns to the app root, which drops these parameters —
+    // so tell the user to restart the connection rather than silently failing.
+    return (
+      <Shell title="Sign in to continue">
+        Sign in above, then start the connection again from Claude — signing in returns you to the
+        app and doesn&apos;t preserve this authorization request.
+      </Shell>
+    );
+  }
+
+  const { params } = validation;
+
+  return (
+    <Shell title="Connect to Claude">
+      <p>
+        Claude is asking to read your timeline projects as{" "}
+        <span className="font-medium text-zinc-100">{user.email ?? user.uid}</span>.
+      </p>
+      <ul className="mt-3 list-disc space-y-1 pl-5 text-zinc-400">
+        <li>List your projects</li>
+        <li>Read the clips in a timeline</li>
+      </ul>
+      <p className="mt-3 text-zinc-400">
+        It cannot change or delete anything — this connection is read-only.
+      </p>
+
+      <form method="POST" action="/api/oauth/authorize" className="mt-5 flex gap-2">
+        {/* Echoed back for server-side re-validation, not trusted as-is. */}
+        <input type="hidden" name="client_id" value={params.clientId} />
+        <input type="hidden" name="redirect_uri" value={params.redirectUri} />
+        <input type="hidden" name="response_type" value="code" />
+        <input type="hidden" name="code_challenge" value={params.codeChallenge} />
+        <input type="hidden" name="code_challenge_method" value={params.codeChallengeMethod} />
+        <input type="hidden" name="scope" value={params.scope} />
+        {params.state !== null && <input type="hidden" name="state" value={params.state} />}
+
+        <button
+          type="submit"
+          name="decision"
+          value="approve"
+          className="rounded-md bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-500"
+        >
+          Allow read access
+        </button>
+        <button
+          type="submit"
+          name="decision"
+          value="deny"
+          className="rounded-md border border-zinc-700 px-4 py-2 text-sm text-zinc-300 hover:border-zinc-500"
+        >
+          Deny
+        </button>
+      </form>
+    </Shell>
+  );
+}

--- a/apps/timeline-gstudio001/lib/oauth/authorize-request.test.ts
+++ b/apps/timeline-gstudio001/lib/oauth/authorize-request.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { successRedirectUrl, validateAuthorizeRequest } from "./authorize-request";
+import type { OAuthClient } from "./core";
+
+const CLIENT: OAuthClient = {
+  clientId: "client-abc",
+  clientSecret: "secret",
+  redirectUris: ["https://claude.ai/api/mcp/auth_callback"],
+};
+
+function query(overrides: Record<string, string | null> = {}) {
+  const base: Record<string, string> = {
+    client_id: CLIENT.clientId,
+    redirect_uri: CLIENT.redirectUris[0],
+    response_type: "code",
+    code_challenge: "a".repeat(43),
+    code_challenge_method: "S256",
+    state: "xyz",
+  };
+  const params = new URLSearchParams(base);
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === null) params.delete(key);
+    else params.set(key, value);
+  }
+  return params;
+}
+
+describe("validateAuthorizeRequest", () => {
+  it("accepts a well-formed request and normalizes scope", () => {
+    const result = validateAuthorizeRequest(query(), CLIENT);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.params.scope).toBe("timelines:read");
+      expect(result.params.state).toBe("xyz");
+    }
+  });
+
+  // The core security rule: an untrusted client/redirect must NOT be
+  // redirected to, or the endpoint becomes an open redirector that leaks codes.
+  it("treats an unknown client_id as FATAL (never redirects)", () => {
+    const result = validateAuthorizeRequest(query({ client_id: "someone-else" }), CLIENT);
+    expect(result).toMatchObject({ ok: false, redirectable: false });
+  });
+
+  it("treats an unregistered redirect_uri as FATAL (never redirects)", () => {
+    const result = validateAuthorizeRequest(
+      query({ redirect_uri: "https://evil.test/steal" }),
+      CLIENT,
+    );
+    expect(result).toMatchObject({ ok: false, redirectable: false });
+  });
+
+  it("treats a near-miss redirect_uri as FATAL (no prefix matching)", () => {
+    const result = validateAuthorizeRequest(
+      query({ redirect_uri: `${CLIENT.redirectUris[0]}/extra` }),
+      CLIENT,
+    );
+    expect(result).toMatchObject({ ok: false, redirectable: false });
+  });
+
+  it("reports other failures as redirectable errors, preserving state", () => {
+    for (const [overrides, error] of [
+      [{ response_type: "token" }, "unsupported_response_type"],
+      [{ code_challenge: null }, "invalid_request"],
+      [{ code_challenge_method: "plain" }, "invalid_request"],
+      [{ scope: "timelines:write" }, "invalid_scope"],
+    ] as const) {
+      const result = validateAuthorizeRequest(query(overrides), CLIENT);
+      expect(result).toMatchObject({
+        ok: false,
+        redirectable: true,
+        error,
+        state: "xyz",
+        redirectUri: CLIENT.redirectUris[0],
+      });
+    }
+  });
+
+  it("rejects a missing PKCE challenge rather than allowing a non-PKCE flow", () => {
+    const result = validateAuthorizeRequest(query({ code_challenge: null }), CLIENT);
+    expect(result.ok).toBe(false);
+  });
+
+  it("handles an absent state without inventing one", () => {
+    const result = validateAuthorizeRequest(query({ state: null }), CLIENT);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.params.state).toBeNull();
+  });
+});
+
+describe("successRedirectUrl", () => {
+  it("appends code and state without clobbering existing query params", () => {
+    const url = successRedirectUrl("https://claude.ai/cb?keep=1", "the-code", "xyz");
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get("code")).toBe("the-code");
+    expect(parsed.searchParams.get("state")).toBe("xyz");
+    expect(parsed.searchParams.get("keep")).toBe("1");
+  });
+
+  it("omits state when there was none", () => {
+    const parsed = new URL(successRedirectUrl("https://claude.ai/cb", "the-code", null));
+    expect(parsed.searchParams.has("state")).toBe(false);
+  });
+});

--- a/apps/timeline-gstudio001/lib/oauth/authorize-request.ts
+++ b/apps/timeline-gstudio001/lib/oauth/authorize-request.ts
@@ -1,0 +1,122 @@
+import { MCP_SCOPE, isRegisteredRedirectUri, safeEqual, type OAuthClient } from "./core";
+
+// Validation for the authorization request, shared by the consent page and the
+// POST that issues the code — they must agree exactly, or a request the page
+// showed as safe could be issued under different terms.
+
+export type AuthorizeParams = Readonly<{
+  clientId: string;
+  redirectUri: string;
+  state: string | null;
+  codeChallenge: string;
+  codeChallengeMethod: string;
+  scope: string;
+}>;
+
+export type AuthorizeValidation =
+  /** Safe to show consent for. */
+  | Readonly<{ ok: true; params: AuthorizeParams }>
+  /**
+   * FATAL: the client or redirect_uri itself is untrustworthy, so we must NOT
+   * redirect — bouncing to an unverified redirect_uri is exactly how an open
+   * redirector leaks codes. Render the error to the user instead (RFC 6749 §4.1.2.1).
+   */
+  | Readonly<{ ok: false; redirectable: false; description: string }>
+  /** Recoverable: redirect back to the verified redirect_uri with ?error=. */
+  | Readonly<{
+      ok: false;
+      redirectable: true;
+      redirectUri: string;
+      state: string | null;
+      error: string;
+      description: string;
+    }>;
+
+export function validateAuthorizeRequest(
+  query: URLSearchParams,
+  client: OAuthClient,
+): AuthorizeValidation {
+  const clientId = query.get("client_id") ?? "";
+  const redirectUri = query.get("redirect_uri") ?? "";
+
+  // These two are validated FIRST and are fatal — everything after may safely
+  // report errors by redirecting, because the destination is now trusted.
+  if (!clientId || !safeEqual(clientId, client.clientId)) {
+    return { ok: false, redirectable: false, description: "Unknown client_id." };
+  }
+  if (!redirectUri || !isRegisteredRedirectUri(redirectUri, client.redirectUris)) {
+    return {
+      ok: false,
+      redirectable: false,
+      description: "redirect_uri is not registered for this client.",
+    };
+  }
+
+  const state = query.get("state");
+  const fail = (error: string, description: string): AuthorizeValidation => ({
+    ok: false,
+    redirectable: true,
+    redirectUri,
+    state,
+    error,
+    description,
+  });
+
+  if (query.get("response_type") !== "code") {
+    return fail("unsupported_response_type", "Only response_type=code is supported.");
+  }
+
+  const codeChallenge = query.get("code_challenge") ?? "";
+  const codeChallengeMethod = query.get("code_challenge_method") ?? "";
+  if (!codeChallenge) {
+    // PKCE is mandatory in OAuth 2.1 — a missing challenge is refused rather
+    // than treated as a legacy plain-code request.
+    return fail("invalid_request", "code_challenge is required (PKCE).");
+  }
+  if (codeChallengeMethod !== "S256") {
+    return fail("invalid_request", "code_challenge_method must be S256.");
+  }
+
+  const requested = query.get("scope");
+  if (requested && requested.split(/\s+/).some((s) => s && s !== MCP_SCOPE)) {
+    return fail("invalid_scope", `Only the "${MCP_SCOPE}" scope is available.`);
+  }
+
+  return {
+    ok: true,
+    params: {
+      clientId,
+      redirectUri,
+      state,
+      codeChallenge,
+      codeChallengeMethod,
+      scope: MCP_SCOPE,
+    },
+  };
+}
+
+/** Build the error redirect for a recoverable failure. */
+export function errorRedirectUrl(
+  redirectUri: string,
+  error: string,
+  description: string,
+  state: string | null,
+): string {
+  const url = new URL(redirectUri);
+  url.searchParams.set("error", error);
+  url.searchParams.set("error_description", description);
+  if (state) url.searchParams.set("state", state);
+  return url.toString();
+}
+
+/** Build the success redirect carrying the authorization code. */
+export function successRedirectUrl(
+  redirectUri: string,
+  code: string,
+  state: string | null,
+): string {
+  const url = new URL(redirectUri);
+  url.searchParams.set("code", code);
+  if (state) url.searchParams.set("state", state);
+  return url.toString();
+}

--- a/apps/timeline-gstudio001/lib/oauth/core.test.ts
+++ b/apps/timeline-gstudio001/lib/oauth/core.test.ts
@@ -1,0 +1,166 @@
+import { createHash } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  base64url,
+  getSigningSecret,
+  isRegisteredRedirectUri,
+  loadClient,
+  safeEqual,
+  signAccessToken,
+  verifyAccessToken,
+  verifyPkce,
+  type AccessTokenClaims,
+} from "./core";
+
+const SECRET = "x".repeat(48);
+const AUDIENCE = "https://example.test/api/mcp";
+
+function challengeFor(verifier: string) {
+  return base64url(createHash("sha256").update(verifier).digest());
+}
+
+function claims(overrides: Partial<AccessTokenClaims> = {}): AccessTokenClaims {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    sub: "uid-123",
+    iss: "https://example.test",
+    aud: AUDIENCE,
+    client_id: "client-abc",
+    scope: "timelines:read",
+    iat: now,
+    exp: now + 3600,
+    ...overrides,
+  };
+}
+
+describe("verifyPkce", () => {
+  const verifier = "a".repeat(64);
+  const challenge = challengeFor(verifier);
+
+  it("accepts a correct S256 verifier", () => {
+    expect(verifyPkce(verifier, challenge, "S256")).toBe(true);
+  });
+
+  it("rejects a wrong verifier", () => {
+    expect(verifyPkce("b".repeat(64), challenge, "S256")).toBe(false);
+  });
+
+  it("rejects the `plain` method — OAuth 2.1 forbids it (downgrade attack)", () => {
+    // Even when verifier === challenge, which is what `plain` would accept.
+    expect(verifyPkce(verifier, verifier, "plain")).toBe(false);
+  });
+
+  it("rejects an absent/unknown method rather than defaulting", () => {
+    expect(verifyPkce(verifier, challenge, "")).toBe(false);
+    expect(verifyPkce(verifier, challenge, "S512")).toBe(false);
+  });
+
+  it("enforces RFC 7636 verifier length bounds", () => {
+    const short = "a".repeat(42);
+    expect(verifyPkce(short, challengeFor(short), "S256")).toBe(false);
+    const long = "a".repeat(129);
+    expect(verifyPkce(long, challengeFor(long), "S256")).toBe(false);
+  });
+
+  it("rejects verifiers with characters outside the allowed set", () => {
+    const bad = "a".repeat(60) + "!@#$";
+    expect(verifyPkce(bad, challengeFor(bad), "S256")).toBe(false);
+  });
+});
+
+describe("isRegisteredRedirectUri", () => {
+  const registered = ["https://claude.ai/api/mcp/auth_callback"];
+
+  it("accepts an exact match", () => {
+    expect(isRegisteredRedirectUri("https://claude.ai/api/mcp/auth_callback", registered)).toBe(true);
+  });
+
+  it("rejects prefix / suffix variations (open-redirect vectors)", () => {
+    expect(isRegisteredRedirectUri("https://claude.ai/api/mcp/auth_callback/evil", registered)).toBe(false);
+    expect(isRegisteredRedirectUri("https://claude.ai/api/mcp", registered)).toBe(false);
+    expect(isRegisteredRedirectUri("https://evil.test/api/mcp/auth_callback", registered)).toBe(false);
+    expect(isRegisteredRedirectUri("https://claude.ai.evil.test/api/mcp/auth_callback", registered)).toBe(false);
+  });
+});
+
+describe("access tokens", () => {
+  it("round-trips a signed token", () => {
+    const token = signAccessToken(claims(), SECRET);
+    const result = verifyAccessToken(token, SECRET, AUDIENCE);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.claims.sub).toBe("uid-123");
+  });
+
+  it("rejects a tampered payload", () => {
+    const token = signAccessToken(claims(), SECRET);
+    const [header, , signature] = token.split(".");
+    const forged = base64url(JSON.stringify(claims({ sub: "someone-else" })));
+    const result = verifyAccessToken(`${header}.${forged}.${signature}`, SECRET, AUDIENCE);
+    expect(result).toEqual({ ok: false, reason: "bad-signature" });
+  });
+
+  it("rejects a token signed with a different secret", () => {
+    const token = signAccessToken(claims(), "y".repeat(48));
+    expect(verifyAccessToken(token, SECRET, AUDIENCE)).toEqual({ ok: false, reason: "bad-signature" });
+  });
+
+  it("rejects an expired token", () => {
+    const past = Math.floor(Date.now() / 1000) - 10;
+    const token = signAccessToken(claims({ exp: past }), SECRET);
+    expect(verifyAccessToken(token, SECRET, AUDIENCE)).toEqual({ ok: false, reason: "expired" });
+  });
+
+  it("rejects a token minted for a different audience (no cross-resource replay)", () => {
+    const token = signAccessToken(claims({ aud: "https://other.test/api/mcp" }), SECRET);
+    expect(verifyAccessToken(token, SECRET, AUDIENCE)).toEqual({ ok: false, reason: "wrong-audience" });
+  });
+
+  it("rejects an alg:none token (algorithm confusion)", () => {
+    const header = base64url(JSON.stringify({ alg: "none", typ: "JWT" }));
+    const payload = base64url(JSON.stringify(claims()));
+    // Unsigned, and with an empty signature segment.
+    expect(verifyAccessToken(`${header}.${payload}.`, SECRET, AUDIENCE).ok).toBe(false);
+    expect(verifyAccessToken(`${header}.${payload}`, SECRET, AUDIENCE)).toEqual({
+      ok: false,
+      reason: "malformed",
+    });
+  });
+
+  it("rejects malformed input", () => {
+    expect(verifyAccessToken("not-a-token", SECRET, AUDIENCE)).toEqual({ ok: false, reason: "malformed" });
+  });
+});
+
+describe("safeEqual", () => {
+  it("compares by value and rejects length mismatch without throwing", () => {
+    expect(safeEqual("abc", "abc")).toBe(true);
+    expect(safeEqual("abc", "abd")).toBe(false);
+    expect(safeEqual("abc", "abcd")).toBe(false);
+    expect(safeEqual("", "")).toBe(true);
+  });
+});
+
+describe("config loading", () => {
+  it("returns null unless every client field is present", () => {
+    expect(loadClient({})).toBeNull();
+    expect(
+      loadClient({ MCP_OAUTH_CLIENT_ID: "a", MCP_OAUTH_CLIENT_SECRET: "b" }),
+    ).toBeNull();
+  });
+
+  it("parses a comma-separated redirect list", () => {
+    const client = loadClient({
+      MCP_OAUTH_CLIENT_ID: "a",
+      MCP_OAUTH_CLIENT_SECRET: "b",
+      MCP_OAUTH_REDIRECT_URIS: "https://one.test/cb, https://two.test/cb",
+    });
+    expect(client?.redirectUris).toEqual(["https://one.test/cb", "https://two.test/cb"]);
+  });
+
+  it("refuses a signing secret that is too short to be safe", () => {
+    expect(getSigningSecret({ MCP_OAUTH_SIGNING_SECRET: "short" })).toBeNull();
+    expect(getSigningSecret({ MCP_OAUTH_SIGNING_SECRET: SECRET })).toBe(SECRET);
+  });
+});

--- a/apps/timeline-gstudio001/lib/oauth/core.ts
+++ b/apps/timeline-gstudio001/lib/oauth/core.ts
@@ -1,0 +1,195 @@
+import { createHash, createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+
+// Pure OAuth 2.1 primitives for the MCP authorization server. No I/O, no
+// Firebase, no Next — so every security-critical rule here unit-tests directly.
+//
+// HS256 is hand-rolled on node:crypto rather than pulling in `jose`: that
+// package is what broke the Vercel deploy (pure-ESM v6 required from CJS), and
+// a symmetric JWT is small enough that owning it beats re-entering that
+// minefield. If this ever needs asymmetric keys for third-party verifiers,
+// revisit — but the only verifier is this same server.
+
+export type AccessTokenClaims = Readonly<{
+  /** Firebase uid the token acts as. */
+  sub: string;
+  /** Issuer — this deployment's origin. */
+  iss: string;
+  /** Audience — the MCP resource URL. Bound so a token minted for one
+   *  resource can't be replayed at another (RFC 8707 resource indicators). */
+  aud: string;
+  /** OAuth client the token was issued to. */
+  client_id: string;
+  scope: string;
+  /** Seconds since epoch. */
+  iat: number;
+  exp: number;
+}>;
+
+const B64URL = { pad: /=+$/, plus: /\+/g, slash: /\//g } as const;
+
+export function base64url(input: Buffer | string): string {
+  return Buffer.from(input)
+    .toString("base64")
+    .replace(B64URL.pad, "")
+    .replace(B64URL.plus, "-")
+    .replace(B64URL.slash, "_");
+}
+
+function base64urlDecode(input: string): Buffer {
+  const padded = input.replace(/-/g, "+").replace(/_/g, "/");
+  return Buffer.from(padded + "=".repeat((4 - (padded.length % 4)) % 4), "base64");
+}
+
+/** Constant-time string compare that doesn't leak length via early return. */
+export function safeEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) return false;
+  return timingSafeEqual(bufA, bufB);
+}
+
+/** Cryptographically random opaque token (codes, refresh tokens, secrets). */
+export function randomToken(bytes = 32): string {
+  return base64url(randomBytes(bytes));
+}
+
+/** Store secrets hashed — a leaked Firestore read must not yield usable tokens. */
+export function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+// --- PKCE ------------------------------------------------------------------
+
+/**
+ * Verify a PKCE code_verifier against the stored challenge.
+ *
+ * **S256 only.** OAuth 2.1 forbids `plain`, so an unknown or absent method is
+ * rejected rather than defaulted — defaulting to `plain` is the classic PKCE
+ * downgrade. The verifier's own charset/length rules (RFC 7636 §4.1) are
+ * enforced too: an over-short verifier would make the challenge guessable.
+ */
+export function verifyPkce(
+  codeVerifier: string,
+  codeChallenge: string,
+  method: string,
+): boolean {
+  if (method !== "S256") return false;
+  if (codeVerifier.length < 43 || codeVerifier.length > 128) return false;
+  if (!/^[A-Za-z0-9\-._~]+$/.test(codeVerifier)) return false;
+  const computed = base64url(createHash("sha256").update(codeVerifier).digest());
+  return safeEqual(computed, codeChallenge);
+}
+
+// --- Redirect URIs ---------------------------------------------------------
+
+/**
+ * OAuth 2.1 requires EXACT redirect-URI matching — no prefix or wildcard
+ * matching, which is how open redirectors turn into token theft.
+ */
+export function isRegisteredRedirectUri(
+  candidate: string,
+  registered: readonly string[],
+): boolean {
+  return registered.some((uri) => uri === candidate);
+}
+
+// --- Access tokens (HS256 JWT) ---------------------------------------------
+
+function signingInput(header: string, payload: string): string {
+  return `${header}.${payload}`;
+}
+
+function hmac(input: string, secret: string): string {
+  return base64url(createHmac("sha256", secret).update(input).digest());
+}
+
+export function signAccessToken(claims: AccessTokenClaims, secret: string): string {
+  const header = base64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const payload = base64url(JSON.stringify(claims));
+  return `${signingInput(header, payload)}.${hmac(signingInput(header, payload), secret)}`;
+}
+
+export type VerifyResult =
+  | Readonly<{ ok: true; claims: AccessTokenClaims }>
+  | Readonly<{ ok: false; reason: "malformed" | "bad-signature" | "expired" | "wrong-audience" }>;
+
+/**
+ * Verify and decode an access token.
+ *
+ * Signature is checked BEFORE any claim is trusted, and `alg` is pinned to
+ * HS256 from our own header rather than read from the token — honouring a
+ * token-supplied `alg` is the `alg: "none"` / algorithm-confusion attack.
+ */
+export function verifyAccessToken(
+  token: string,
+  secret: string,
+  expectedAudience: string,
+  now = Math.floor(Date.now() / 1000),
+): VerifyResult {
+  const parts = token.split(".");
+  if (parts.length !== 3) return { ok: false, reason: "malformed" };
+  const [header, payload, signature] = parts;
+
+  if (!safeEqual(hmac(signingInput(header, payload), secret), signature)) {
+    return { ok: false, reason: "bad-signature" };
+  }
+
+  let claims: AccessTokenClaims;
+  try {
+    claims = JSON.parse(base64urlDecode(payload).toString("utf8")) as AccessTokenClaims;
+  } catch {
+    return { ok: false, reason: "malformed" };
+  }
+  if (typeof claims.exp !== "number" || typeof claims.sub !== "string" || !claims.sub) {
+    return { ok: false, reason: "malformed" };
+  }
+  if (claims.exp <= now) return { ok: false, reason: "expired" };
+  if (claims.aud !== expectedAudience) return { ok: false, reason: "wrong-audience" };
+
+  return { ok: true, claims };
+}
+
+// --- Client registry -------------------------------------------------------
+
+/** Just the string map these readers need — `process.env` satisfies it, and so
+ *  does a test fixture, without demanding the full NodeJS.ProcessEnv shape. */
+export type EnvLike = Readonly<Record<string, string | undefined>>;
+
+export type OAuthClient = Readonly<{
+  clientId: string;
+  /** Hashed comparison only; never logged or echoed. */
+  clientSecret: string;
+  redirectUris: readonly string[];
+}>;
+
+/**
+ * The single registered client, from env. Dynamic Client Registration is
+ * deliberately NOT implemented: Claude also accepts operator-provided
+ * credentials, so a static client avoids exposing an unauthenticated
+ * registration endpoint on a personal deployment.
+ *
+ * `MCP_OAUTH_REDIRECT_URIS` is comma-separated and matched exactly.
+ */
+export function loadClient(env: EnvLike = process.env): OAuthClient | null {
+  const clientId = env.MCP_OAUTH_CLIENT_ID?.trim();
+  const clientSecret = env.MCP_OAUTH_CLIENT_SECRET?.trim();
+  const redirectUris = (env.MCP_OAUTH_REDIRECT_URIS ?? "")
+    .split(",")
+    .map((uri) => uri.trim())
+    .filter(Boolean);
+
+  if (!clientId || !clientSecret || redirectUris.length === 0) return null;
+  return { clientId, clientSecret, redirectUris };
+}
+
+export function getSigningSecret(env: EnvLike = process.env): string | null {
+  const secret = env.MCP_OAUTH_SIGNING_SECRET?.trim();
+  // Short secrets make HS256 brute-forceable; refuse rather than warn.
+  return secret && secret.length >= 32 ? secret : null;
+}
+
+/** Auth codes are single-use and short-lived; 60s is ample for a redirect. */
+export const AUTH_CODE_TTL_SECONDS = 60;
+export const ACCESS_TOKEN_TTL_SECONDS = 60 * 60;
+export const REFRESH_TOKEN_TTL_SECONDS = 60 * 60 * 24 * 30;
+export const MCP_SCOPE = "timelines:read";

--- a/apps/timeline-gstudio001/lib/oauth/metadata.ts
+++ b/apps/timeline-gstudio001/lib/oauth/metadata.ts
@@ -1,0 +1,59 @@
+import { MCP_SCOPE } from "./core";
+
+// Shared shape for the two discovery documents. Origin is derived from the
+// REQUEST rather than an env var so the same code serves localhost, preview
+// deployments, and production without configuration drift — a metadata
+// document advertising the wrong origin breaks the flow in confusing ways.
+
+export function originFromRequest(request: Request): string {
+  // x-forwarded-* is what Vercel sets in front of the function; fall back to
+  // the request URL for local dev.
+  const headers = request.headers;
+  const forwardedHost = headers.get("x-forwarded-host") ?? headers.get("host");
+  const forwardedProto = headers.get("x-forwarded-proto") ?? "https";
+  if (forwardedHost) return `${forwardedProto}://${forwardedHost}`;
+  return new URL(request.url).origin;
+}
+
+export function mcpResourceUrl(origin: string): string {
+  return `${origin}/api/mcp`;
+}
+
+/** RFC 9728 — tells the client which authorization server guards this resource. */
+export function protectedResourceMetadata(origin: string) {
+  return {
+    resource: mcpResourceUrl(origin),
+    authorization_servers: [origin],
+    scopes_supported: [MCP_SCOPE],
+    bearer_methods_supported: ["header"],
+  };
+}
+
+/** RFC 8414 — the authorization server's own capabilities. */
+export function authorizationServerMetadata(origin: string) {
+  return {
+    issuer: origin,
+    // A PAGE, not an API route: it renders under the root layout, so the
+    // existing AuthGate handles sign-in for an unauthenticated visitor and the
+    // consent screen can reuse app chrome.
+    authorization_endpoint: `${origin}/oauth/authorize`,
+    token_endpoint: `${origin}/api/oauth/token`,
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    // S256 ONLY — advertising `plain` would invite the downgrade OAuth 2.1 bans.
+    code_challenge_methods_supported: ["S256"],
+    token_endpoint_auth_methods_supported: ["client_secret_post", "client_secret_basic"],
+    scopes_supported: [MCP_SCOPE],
+    // No registration_endpoint: Dynamic Client Registration is intentionally
+    // not offered, so clients use operator-provided credentials instead.
+  };
+}
+
+/** Discovery documents are public and fetched cross-origin by the client. */
+export const METADATA_HEADERS = {
+  "content-type": "application/json",
+  "cache-control": "public, max-age=300",
+  "access-control-allow-origin": "*",
+  "access-control-allow-methods": "GET, OPTIONS",
+  "access-control-allow-headers": "*",
+} as const;

--- a/apps/timeline-gstudio001/lib/oauth/store.ts
+++ b/apps/timeline-gstudio001/lib/oauth/store.ts
@@ -1,0 +1,110 @@
+import "server-only";
+
+import { Timestamp } from "firebase-admin/firestore";
+
+import { getFirebaseDb } from "@/lib/firebase-admin";
+
+import {
+  AUTH_CODE_TTL_SECONDS,
+  REFRESH_TOKEN_TTL_SECONDS,
+  hashToken,
+  randomToken,
+} from "./core";
+
+// Firestore persistence for the OAuth authorization server.
+//
+// Codes and refresh tokens are stored HASHED and looked up by hash: a leaked
+// database read yields nothing replayable. Consumption runs in a transaction
+// so a code can only ever be redeemed once even under concurrent requests —
+// replaying an intercepted code is the attack this closes, and a
+// read-then-delete would leave a window open.
+
+const CODES = "mcpOAuthCodes";
+const REFRESH = "mcpOAuthRefreshTokens";
+
+export type AuthCodeGrant = Readonly<{
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  codeChallengeMethod: string;
+  uid: string;
+  scope: string;
+  resource: string;
+}>;
+
+type StoredCode = AuthCodeGrant & { expiresAt: Timestamp };
+
+/** Mint a single-use authorization code. Returns the plaintext code (only
+ *  ever held by the client); Firestore keeps its hash. */
+export async function issueAuthCode(grant: AuthCodeGrant): Promise<string> {
+  const code = randomToken(32);
+  await getFirebaseDb()
+    .collection(CODES)
+    .doc(hashToken(code))
+    .set({
+      ...grant,
+      expiresAt: Timestamp.fromMillis(Date.now() + AUTH_CODE_TTL_SECONDS * 1000),
+    } satisfies StoredCode);
+  return code;
+}
+
+/**
+ * Atomically redeem a code. Returns the grant and deletes it in the same
+ * transaction, so a second redemption of the same code always fails. Expired
+ * codes are deleted and refused.
+ */
+export async function consumeAuthCode(code: string): Promise<AuthCodeGrant | null> {
+  const ref = getFirebaseDb().collection(CODES).doc(hashToken(code));
+  return getFirebaseDb().runTransaction(async (tx) => {
+    const snapshot = await tx.get(ref);
+    if (!snapshot.exists) return null;
+    const data = snapshot.data() as StoredCode;
+    tx.delete(ref); // single-use, whether or not it turns out to be expired
+    if (data.expiresAt.toMillis() <= Date.now()) return null;
+    const { expiresAt: _expiresAt, ...grant } = data;
+    return grant;
+  });
+}
+
+export type RefreshGrant = Readonly<{
+  clientId: string;
+  uid: string;
+  scope: string;
+  resource: string;
+}>;
+
+type StoredRefresh = RefreshGrant & { expiresAt: Timestamp };
+
+export async function issueRefreshToken(grant: RefreshGrant): Promise<string> {
+  const token = randomToken(32);
+  await getFirebaseDb()
+    .collection(REFRESH)
+    .doc(hashToken(token))
+    .set({
+      ...grant,
+      expiresAt: Timestamp.fromMillis(Date.now() + REFRESH_TOKEN_TTL_SECONDS * 1000),
+    } satisfies StoredRefresh);
+  return token;
+}
+
+/**
+ * Redeem and ROTATE a refresh token: the presented token is consumed and a new
+ * one issued in its place. Rotation is what makes theft detectable — a stolen
+ * token stops working as soon as the legitimate client refreshes.
+ */
+export async function rotateRefreshToken(
+  token: string,
+): Promise<Readonly<{ grant: RefreshGrant; nextToken: string }> | null> {
+  const ref = getFirebaseDb().collection(REFRESH).doc(hashToken(token));
+  const grant = await getFirebaseDb().runTransaction(async (tx) => {
+    const snapshot = await tx.get(ref);
+    if (!snapshot.exists) return null;
+    const data = snapshot.data() as StoredRefresh;
+    tx.delete(ref);
+    if (data.expiresAt.toMillis() <= Date.now()) return null;
+    const { expiresAt: _expiresAt, ...rest } = data;
+    return rest;
+  });
+  if (!grant) return null;
+  return { grant, nextToken: await issueRefreshToken(grant) };
+}

--- a/docs/webmcp-agent-tools.md
+++ b/docs/webmcp-agent-tools.md
@@ -1,9 +1,11 @@
 # WebMCP agent tools
 
-**Status: design / planning — no code yet.** This is the agreed shape for
-letting an AI agent (Claude, or any MCP client) edit the timeline while the
-app is open side-by-side and updates in real time. Keep it current as
-decisions land — see the decision log at the bottom.
+**Status: shipped, and still growing.** Two surfaces are live — the in-page
+**WebMCP** tools (11 tools; real-time, mutate the live store) and a **remote
+MCP** endpoint at `/api/mcp` (read-only, OAuth 2.1 + PKCE, reachable by URL
+with no browser open). The design below is what they were built from; the
+decision log at the bottom is the running record of what actually shipped and
+why. Keep it current as decisions land.
 
 ## Goal
 
@@ -460,3 +462,37 @@ placement default `after: nodeId`; `insertClones(...)`; `setSelection(newIds)`.
   Firestore reads are one-shot and the browser holds no listeners, so a
   server-side write would not appear in an open tab without a live-push channel
   (see the top of this doc).
+
+- **2026-07-24** — **OAuth 2.1 + PKCE** on the remote MCP endpoint, so
+  claude.ai's custom-connector flow can attach. Built ON Firebase rather than
+  adopting an auth vendor: `/oauth/authorize` is a PAGE (so the root layout's
+  `AuthGate` handles sign-in) that validates the request and shows consent;
+  `POST /api/oauth/authorize` re-validates server-side and issues a single-use
+  code; `POST /api/oauth/token` verifies PKCE + client credentials and returns
+  an HS256 access token plus a rotating refresh token. Discovery lives at
+  `/.well-known/oauth-authorization-server` (RFC 8414) and
+  `/.well-known/oauth-protected-resource` (RFC 9728), both deriving their
+  origin from the request so localhost/preview/production need no config.
+
+  **Security decisions worth keeping:** S256 only (a `plain` or absent method is
+  refused, never defaulted — that's the PKCE downgrade); exact redirect-URI
+  matching; an unknown `client_id`/`redirect_uri` is FATAL and renders an error
+  rather than redirecting (redirecting to an unverified URI is how codes leak);
+  codes are single-use via a Firestore transaction and stored hashed; `alg` is
+  pinned to HS256 from our own header, never read from the token; access tokens
+  are audience-bound to this deployment's MCP URL. `jose` is deliberately NOT
+  used — HS256 is hand-rolled on `node:crypto` because jose@6's pure-ESM
+  packaging is what broke the Vercel deploy (see vercel-production-deploy).
+
+  **Dynamic Client Registration is intentionally omitted** — Claude also accepts
+  operator-provided credentials, so a personal deployment avoids exposing an
+  unauthenticated registration endpoint. New env: `MCP_OAUTH_CLIENT_ID`,
+  `MCP_OAUTH_CLIENT_SECRET`, `MCP_OAUTH_REDIRECT_URIS`,
+  `MCP_OAUTH_SIGNING_SECRET`. The static `MCP_BEARER_TOKEN` path remains for
+  Claude Code / mcp-remote; OAuth is tried first and the uid now comes from the
+  token's `sub` instead of a fixed env var.
+
+  **Known gap:** signing in mid-flow returns to the app root and drops the
+  authorization parameters, so an unauthenticated user must sign in and then
+  restart the connection from Claude. Covered by 28 unit tests over the
+  security-critical rules.


### PR DESCRIPTION
Lets claude.ai's custom-connector flow attach to /api/mcp. Built ON Firebase rather than adopting an auth vendor, so identity stays single-sourced.

## Flow
- `/oauth/authorize` — a PAGE, so the root layout's AuthGate handles sign-in. Validates and renders consent.
- `POST /api/oauth/authorize` — re-validates server-side (the page is a UI affordance, not a trust boundary), takes the uid from the session cookie ONLY, issues a single-use code.
- `POST /api/oauth/token` — authorization_code (PKCE) + refresh_token grants; HS256 access token + rotating refresh token.
- Discovery at `/.well-known/oauth-authorization-server` (RFC 8414) and `/.well-known/oauth-protected-resource` (RFC 9728), origin derived from the request so localhost/preview/prod need no config.

## Security decisions (each covered by tests)
- **S256 only** — `plain` or absent is refused, never defaulted (the PKCE downgrade). Verifier charset/length per RFC 7636.
- **Exact redirect-URI matching**, and an unknown client_id/redirect_uri is **FATAL** — renders an error rather than redirecting. Redirecting to an unverified URI is how codes leak.
- **Codes single-use** via a Firestore transaction, stored hashed; refresh tokens hashed and rotated.
- **`alg` pinned** to HS256 from our own header, never read from the token (algorithm confusion); signature verified before any claim is trusted.
- **Audience-bound** access tokens (no cross-resource replay).

`jose` is deliberately NOT used — HS256 is hand-rolled on `node:crypto`, because jose@6's pure-ESM packaging is exactly what broke the Vercel deploy earlier today. **DCR intentionally omitted**: Claude accepts operator-provided credentials, so a personal deployment avoids an unauthenticated registration endpoint.

`/api/mcp` now derives uid from the token's `sub`; the static `MCP_BEARER_TOKEN` path remains for Claude Code and is tried second.

## New env vars
`MCP_OAUTH_CLIENT_ID`, `MCP_OAUTH_CLIENT_SECRET`, `MCP_OAUTH_REDIRECT_URIS`, `MCP_OAUTH_SIGNING_SECRET`

## Known gap
Signing in mid-flow returns to the app root and drops the authorization parameters, so an unauthenticated user must sign in and then restart the connection from Claude.

## Verified
342 app tests pass (28 new OAuth security tests), tsc clean, production build lists all six routes.