### PR TITLE
Quiet the preview divider, and give the pane a corner close button

### DIFF
--- a/apps/timeline-gstudio001/.env.example
+++ b/apps/timeline-gstudio001/.env.example
@@ -31,3 +31,36 @@ FIREBASE_STORAGE_BUCKET="MY_FIREBASE_STORAGE_BUCKET"
 # Option B: omit the service-account values above and set GOOGLE_APPLICATION_CREDENTIALS
 # to a service-account JSON file path in the host environment.
 # FIREBASE_STORAGE_BUCKET is only required if CLOUDINARY_URL is not set.
+
+# --- Remote MCP endpoint (/api/mcp) -----------------------------------------
+# None of these are needed for local development: with no signing secret the
+# OAuth path is simply inactive, and the endpoint denies rather than falling
+# open. They are set per-environment on the host (Production and Preview are
+# separate values — updating one does not update the other).
+#
+# MCP_OAUTH_SIGNING_SECRET signs AND verifies access tokens.
+# MUST BE AT LEAST 32 CHARACTERS. Below that, getSigningSecret() returns null,
+# the OAuth branch is skipped entirely, and every request 401s with no other
+# symptom — see lib/oauth/core.ts. Generate one with:
+#   node -e "console.log(require('crypto').randomBytes(48).toString('base64url'))"
+#
+# ROTATING IT invalidates every existing access token, so the connector must be
+# re-authorized afterwards. Refresh tokens survive (they are opaque strings
+# stored under an unkeyed SHA-256 hash, so the secret does not affect lookup).
+# Host env changes only reach running functions after a REDEPLOY.
+MCP_OAUTH_SIGNING_SECRET="MY_32_PLUS_CHARACTER_RANDOM_SECRET"
+
+# The connector's own credentials. Rotating MCP_OAUTH_CLIENT_SECRET additionally
+# requires updating the stored secret in the client (e.g. the claude.ai
+# connector), or the token exchange fails before verification is ever reached.
+MCP_OAUTH_CLIENT_ID="MY_MCP_OAUTH_CLIENT_ID"
+MCP_OAUTH_CLIENT_SECRET="MY_MCP_OAUTH_CLIENT_SECRET"
+
+# Comma-separated, and matched EXACTLY — a stray trailing slash fails the
+# callback.
+MCP_OAUTH_REDIRECT_URIS="https://claude.ai/api/mcp/auth_callback"
+
+# Static bearer fallback (Claude Code / mcp-remote), tried after OAuth. Only
+# active when BOTH are set; either one alone silently disables the path.
+MCP_BEARER_TOKEN="MY_STATIC_BEARER_TOKEN"
+MCP_OWNER_UID="MY_FIREBASE_UID"

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -58,6 +58,7 @@ import { createTimelineDocumentsState } from "@storyboard/ui/timeline/timeline-d
 import type { TimelineClip, TimelineDocument } from "@storyboard/ui/timeline/types";
 
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
+import { requestGraphPreviewToggle } from "@/lib/graph-view-events";
 
 import { useGraphDetailsStore } from "./graph-details-context";
 import { GRID_GAP, TIMELINE_PPS } from "./graph-view-config";
@@ -1618,6 +1619,11 @@ export function PreviewShell({
     surfaceHeightRef.current = height;
   }, []);
 
+  // The pane's own close button goes through the SAME window event as the
+  // sidebar's toggle, so `previewOn` in graph-timeline-view stays the one
+  // owner of the state. Only reachable while open, so toggle IS close.
+  const handleClose = useCallback(() => requestGraphPreviewToggle(), []);
+
   if (!enabled) return <>{children}</>;
 
   return (
@@ -1639,6 +1645,7 @@ export function PreviewShell({
         onPlayingChange={channel.setPlaying}
         getInitialSurfaceHeight={getInitialSurfaceHeight}
         onSurfaceHeightChange={handleSurfaceHeightChange}
+        onClose={handleClose}
       >
         {/* The playhead and scrub band live in `children`; they read these
             spans so their time↔x mapping is the pane's clock, not their own. */}

--- a/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
+++ b/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
@@ -100,3 +100,39 @@ export const ControlledPlayback: Story = {
     ).toBeInTheDocument();
   },
 };
+
+function ClosablePreviewFixture() {
+  const [currentTime, setCurrentTime] = useState(0);
+  const [open, setOpen] = useState(true);
+
+  return (
+    <main className="min-h-[900px] bg-zinc-950 p-4 text-zinc-100">
+      {open ? (
+        <WorkbenchSplitPane
+          clips={[]}
+          currentTime={currentTime}
+          onCurrentTimeChange={setCurrentTime}
+          onClose={() => setOpen(false)}
+        >
+          <div className="min-h-24" />
+        </WorkbenchSplitPane>
+      ) : (
+        <p data-testid="preview-closed">Preview closed</p>
+      )}
+    </main>
+  );
+}
+
+/** `onClose` adds the corner close button — a second way out of the preview
+ *  beside whatever toggle the consumer owns. Without the prop no button is
+ *  drawn (see the other stories: none of them have one). */
+export const ClosablePreview: Story = {
+  render: () => <ClosablePreviewFixture />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const user = userEvent.setup();
+
+    await user.click(canvas.getByRole("button", { name: "Close preview" }));
+    expect(await canvas.findByTestId("preview-closed")).toBeInTheDocument();
+  },
+};

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Pause, Play, SkipBack, SkipForward } from "lucide-react";
+import { Pause, Play, SkipBack, SkipForward, X } from "lucide-react";
 import {
   useCallback,
   useEffect,
@@ -47,6 +47,10 @@ type WorkbenchDisplaySurfaceProps = {
    *  Omit for the default uncontrolled behavior (internal play state). */
   playing?: boolean;
   onPlayingChange?: (playing: boolean) => void;
+  /** When supplied, the surface renders a close affordance in its top-right
+   *  corner. Omit and no button is drawn — a consumer that has no way to hide
+   *  the preview must not show one. */
+  onClose?: () => void;
 };
 
 const BUFFER_WINDOW_SIZE = 4;
@@ -254,6 +258,7 @@ export function WorkbenchDisplaySurface({
   preferredClipId,
   playing,
   onPlayingChange,
+  onClose,
 }: WorkbenchDisplaySurfaceProps) {
   const { getCollectionClipFramePreview } = useTimelineDocuments();
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -705,7 +710,7 @@ export function WorkbenchDisplaySurface({
       data-testid="workbench-display-surface"
       data-buffered-media-count={bufferedMedia.length}
     >
-      <div className="min-h-0 flex-1 bg-black">
+      <div className="relative min-h-0 flex-1 bg-black">
         <canvas
           ref={canvasRef}
           className="block h-full w-full bg-black"
@@ -713,6 +718,22 @@ export function WorkbenchDisplaySurface({
           aria-label={activeMedia ? `${activeMedia.clipTitle} preview` : "Empty workbench preview"}
           data-testid="workbench-display-canvas"
         />
+        {/* Second way out of the preview, next to the sidebar's toggle. Pinned
+            to the canvas's far-right corner, which is LETTERBOX: the frame is
+            drawn centred at `min` scale, so this sits in the black gutter
+            rather than over the picture. */}
+        {onClose && (
+          <button
+            type="button"
+            onClick={onClose}
+            className="absolute right-2 top-2 z-10 grid size-7 place-items-center rounded-full border border-zinc-800 bg-zinc-900/80 text-zinc-400 backdrop-blur-sm transition-colors hover:border-zinc-600 hover:text-zinc-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-400 focus-visible:outline-offset-2"
+            aria-label="Close preview"
+            title="Close preview"
+            data-testid="workbench-preview-close"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        )}
       </div>
       <div className="relative flex shrink-0 items-center justify-center border-t border-zinc-800 bg-zinc-950 px-4 py-2 text-xs text-zinc-200">
         <div className="flex items-center gap-2">
@@ -774,6 +795,8 @@ type WorkbenchSplitPaneProps = {
    *  across unmounts. Store it in a ref: this fires per pointer move during a
    *  divider drag. */
   onSurfaceHeightChange?: (height: number) => void;
+  /** Forwarded to the display surface's close button. See there. */
+  onClose?: () => void;
 };
 
 export function WorkbenchSplitPane({
@@ -786,6 +809,7 @@ export function WorkbenchSplitPane({
   onPlayingChange,
   getInitialSurfaceHeight,
   onSurfaceHeightChange,
+  onClose,
 }: WorkbenchSplitPaneProps) {
   // Read once, at mount. `undefined` means nothing to restore → fit instead.
   const [restoredSurfaceHeight] = useState(() => getInitialSurfaceHeight?.());
@@ -1040,6 +1064,7 @@ export function WorkbenchSplitPane({
             preferredClipId={preferredClipId}
             playing={playing}
             onPlayingChange={onPlayingChange}
+            onClose={onClose}
             className="h-full"
           />
         </div>
@@ -1052,14 +1077,15 @@ export function WorkbenchSplitPane({
           aria-valuenow={Math.round(surfaceHeight)}
           aria-label="Resize workbench display"
           // The divider's OWN height is the only source of the gap on either
-          // side of the rule: it centres the 1px line, so the space above and
-          // below is h/2 each (h-3 — kept in sync with DIVIDER_HEIGHT_PX).
+          // side: it centres the grip, so the space above and below is h/2
+          // each (h-3 — kept in sync with DIVIDER_HEIGHT_PX).
           // Nothing else may add padding against it — the lower pane used to
           // carry a pt-3 that made the bottom gap 22px against the top's
-          // 10px, which read as a misaligned rule. Affordance: a centred
-          // grip pill says "draggable" at rest, and hovering tints the whole
-          // band gray (the old amber line highlight is gone; focus ring is
-          // sky, matching the seek rails).
+          // 10px, which read as misaligned. Affordance: a centred grip pill
+          // says "draggable" at rest (half-opacity so it stays quiet), and
+          // hovering brings it to full strength and tints the whole band gray
+          // — no full-width rule (the old amber line highlight is gone too;
+          // focus ring is sky, matching the seek rails).
           className="group relative flex h-3 w-full cursor-row-resize items-center justify-center bg-transparent transition-colors hover:bg-zinc-800/70 active:bg-zinc-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-400 focus-visible:outline-offset-2"
           onPointerDown={handleDividerPointerDown}
           onPointerMove={handleDividerPointerMove}
@@ -1068,12 +1094,8 @@ export function WorkbenchSplitPane({
         >
           <span
             aria-hidden="true"
-            className="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-zinc-800"
-          />
-          <span
-            aria-hidden="true"
             data-divider-grip
-            className="relative h-1 w-10 rounded-full bg-zinc-600 transition-colors group-hover:bg-zinc-400 group-active:bg-zinc-300"
+            className="relative h-1 w-10 rounded-full bg-zinc-600 opacity-50 transition-[color,background-color,opacity] group-hover:bg-zinc-400 group-hover:opacity-100 group-active:bg-zinc-300 group-active:opacity-100"
           />
         </button>
       </div>


### PR DESCRIPTION
## What

Two small preview-pane changes, plus a docs-only `.env.example` addition that was already sitting in the tree.

**Divider.** It drew a full-width 1px rule that ran through the grip handle. The rule is gone — the grip alone carries the affordance — and the grip now rests at 50% opacity, reaching full strength on hover alongside the existing band tint.

**Close button.** `WorkbenchDisplaySurface` / `WorkbenchSplitPane` take an optional `onClose`. Supplied, a close button renders in the canvas's top-right. Omitted, no button is drawn, so `app/workbench` and the legacy timeline page — neither of which has a preview toggle — are untouched. The graph view wires it to `requestGraphPreviewToggle()`, the same window event the sidebar's TV icon dispatches, so `previewOn` in `graph-timeline-view` stays the single owner of the state.

## Placement note

The button sits in the letterbox, not over the picture: the canvas fills the pane width and the frame is drawn centred at `min` scale, so at a 1142×177 canvas a 16:9 frame ends at x≈833 while the button starts at x=1211. The gutter shrinks as the pane grows — past roughly 600px of canvas height a 16:9 frame would reach the corner, where the button's translucent `zinc-900/80` + backdrop blur is the fallback. Making overlap structurally impossible would mean moving it outside the canvas into a right-edge chrome strip, which costs picture width at every size.

## Verification

- Measured live in the running app: grip 0.5 → 1.0 opacity on hover, band transparent → `zinc-800/70`, no wide ≤2px element straddling the divider midline (a DOM sweep, so the rule is gone rather than hidden). Close button measures 28×28 at 8px inset; clicking it unmounted the surface and flipped the sidebar toggle back to "Show preview" / `aria-pressed="false"`.
- New `ClosablePreview` story clicks the button and asserts the pane unmounts — `npx vitest run --project=storybook WorkbenchSplitPane.stories.tsx`, 3/3 pass.
- `tsc --noEmit` clean in both `packages/ui` and `apps/timeline-gstudio001`.
- The existing e2e assertions in `graph-view.spec.ts` (12px band, one `[data-divider-grip]`, hover changes band background) still describe the divider correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
