### PR TITLE
Use a folder-with-arrow icon for drilling into a timeline

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { memo, useCallback, useContext, useEffect, useRef, useState, useSyncExternalStore } from "react";
-import { FolderTree } from "lucide-react";
+import { FolderInput } from "lucide-react";
 
 import {
   CollectionItem,
@@ -614,9 +614,11 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
         }}
         className="absolute left-1/2 top-[41%] flex aspect-square h-[34%] -translate-x-1/2 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full bg-zinc-950/70 text-sky-200 ring-1 ring-sky-400/50 backdrop-blur-[2px] transition-colors hover:bg-zinc-900/85 hover:text-sky-100 hover:ring-sky-300"
       >
-        {/* FolderTree, matching the sidebar's children-timelines toggle — one
-            icon for "this has child timelines" everywhere. */}
-        <FolderTree className="h-[55%] w-[55%]" />
+        {/* FolderInput — a folder with an arrow going INTO it, matching the
+            sub-timeline row's drill button. Both NAVIGATE; the sidebar's
+            FolderTree toggles whether the children tree is shown, which is a
+            different verb and no longer shares this icon. */}
+        <FolderInput className="h-[55%] w-[55%]" />
       </button>
 
       {/* The rename editor — a REAL input, overlaying the label row while

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useContext, useMemo, useRef, useState } from "react";
-import { FolderTree, Folder, FolderOpen } from "lucide-react";
+import { FolderInput, Folder, FolderOpen } from "lucide-react";
 
 import {
   VirtualGrid,
@@ -221,9 +221,12 @@ function SubTimelineNode({
           onClick={() => nav?.openTimeline(collectionId)}
           className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
         >
-          {/* FolderTree, matching the sidebar's children-timelines toggle and
-              the collection card's drill button — one icon for the concept. */}
-          <FolderTree aria-hidden="true" className="h-4 w-4" />
+          {/* FolderInput — a folder with an arrow going INTO it. This button
+              NAVIGATES; the sidebar's FolderTree toggles whether the children
+              tree is shown. Those are different verbs and no longer share an
+              icon. The collection card's drill button is the same verb as
+              this one and uses the same icon. */}
+          <FolderInput aria-hidden="true" className="h-4 w-4" />
         </button>
       </div>
 


### PR DESCRIPTION
## What

The "Drill into timeline" button used `FolderTree`. It now uses `FolderInput` — a folder with an arrow pointing right, into it.

## Why it also changed the collection card

`FolderTree` had three usages, and the code comments justified them as "one icon for the concept". They're two concepts:

| where | action | icon now |
|---|---|---|
| sub-timeline row | `nav.openTimeline(collectionId)` | `FolderInput` |
| collection card centre button | `nav.openTimeline(id)` — identical | `FolderInput` |
| sidebar toggle | `requestGraphChildrenToggle()` | `FolderTree` (unchanged) |

The first two navigate; the third only controls whether the children tree renders. Changing just the row would have left two buttons doing the same thing with different icons, so both navigation affordances moved and the sidebar toggle kept `FolderTree`. That's a sharper icon language than before, not just a swap.

`FolderInput` is the right glyph over the near neighbours: its arrowhead path `m9 16 3-3-3-3` points **right** along a horizontal line into the folder. `FolderOutput`'s points left; `FolderSymlink`'s curves out of the folder.

## Verification

Live in the running app: all 6 drill buttons render `lucide-folder-input`, the card button renders `lucide-folder-input`, the sidebar toggle still renders `lucide-folder-tree`.

`tsc` clean, app lint 0 errors, `graph-item-content` stories 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
