### PR TITLE
Add a `disabled` flag to the model and a command that sets it

### DIFF
--- a/packages/collections-core/commands.test.ts
+++ b/packages/collections-core/commands.test.ts
@@ -692,3 +692,79 @@ describe("patch inversion round-trips", () => {
     });
   });
 });
+
+describe("set-node-disabled", () => {
+  const nodeOf = (graph: CollectionsGraph, id: string) => graph.nodesById.get(parseNodeId(id))!;
+
+  test("sets the flag on media and on collections, leaving structure alone", () => {
+    for (const target of ["A", "F"]) {
+      const graph = fixture();
+      const result = applyCommand(graph, {
+        type: "set-node-disabled",
+        nodeId: parseNodeId(target),
+        disabled: true,
+      });
+      if (!result.ok) throw new Error(JSON.stringify(result.error));
+      expect(nodeOf(result.value.graph, target).disabled).toBe(true);
+      // Structure untouched — a disabled node keeps its slot and its children.
+      for (const [id] of graph.childrenById) {
+        expect([...getChildren(result.value.graph, id)]).toEqual([...getChildren(graph, id)]);
+      }
+      expect(findGraphInvariantViolation(result.value.graph)).toBeNull();
+    }
+  });
+
+  test("enabling DELETES the key rather than writing false", () => {
+    const disabled = applyCommand(fixture(), {
+      type: "set-node-disabled",
+      nodeId: parseNodeId("A"),
+      disabled: true,
+    });
+    if (!disabled.ok) throw new Error("expected ok");
+
+    const enabled = applyCommand(disabled.value.graph, {
+      type: "set-node-disabled",
+      nodeId: parseNodeId("A"),
+      disabled: false,
+    });
+    if (!enabled.ok) throw new Error("expected ok");
+    // `false` would be truthy-adjacent noise on every clip that ever toggled;
+    // absence is the enabled state everywhere else in the model.
+    expect("disabled" in nodeOf(enabled.value.graph, "A")).toBe(false);
+  });
+
+  test("a no-op change is refused, so it never enters history", () => {
+    const alreadyEnabled = applyCommand(fixture(), {
+      type: "set-node-disabled",
+      nodeId: parseNodeId("A"),
+      disabled: false,
+    });
+    expect(alreadyEnabled.ok).toBe(false);
+    if (!alreadyEnabled.ok) expect(alreadyEnabled.error.reason).toBe("same-position");
+  });
+
+  test("a missing node is refused", () => {
+    const result = applyCommand(fixture(), {
+      type: "set-node-disabled",
+      nodeId: parseNodeId("nope"),
+      disabled: true,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.reason).toBe("missing-node");
+  });
+
+  test("undo restores the previous flag", () => {
+    const graph = fixture();
+    const result = applyCommand(graph, {
+      type: "set-node-disabled",
+      nodeId: parseNodeId("A"),
+      disabled: true,
+    });
+    if (!result.ok) throw new Error("expected ok");
+
+    const undone = applyPatch(result.value.graph, invertPatch(result.value.patch));
+    expect("disabled" in nodeOf(undone, "A")).toBe(false);
+    const redone = applyPatch(undone, result.value.patch);
+    expect(nodeOf(redone, "A").disabled).toBe(true);
+  });
+});

--- a/packages/collections-core/commands.ts
+++ b/packages/collections-core/commands.ts
@@ -59,6 +59,13 @@ export type CollectionsCommand =
       nodeId: NodeId;
       /** Non-blank; callers trim. */
       name: string;
+    }>
+  | Readonly<{
+      type: "set-node-disabled";
+      /** Any node — media or collection. Structure is untouched. */
+      nodeId: NodeId;
+      /** True to skip the node (and its subtree) in playback and totals. */
+      disabled: boolean;
     }>;
 
 export type CommandRejection =
@@ -106,6 +113,9 @@ export function applyCommand(
   // Data mutations — no target parent/index, so handle them first.
   if (command.type === "update-media") {
     return applyMediaUpdate(graph, command.nodeId, command.update);
+  }
+  if (command.type === "set-node-disabled") {
+    return applySetDisabled(graph, command.nodeId, command.disabled);
   }
   if (command.type === "rename-node") {
     return applyRename(graph, command.nodeId, command.name);
@@ -342,6 +352,46 @@ function applyRename(
   if (node.name === name) return { ok: false, error: { reason: "same-position" } };
 
   const after: CollectionItemNode = { ...node, name };
+  const patch: CollectionsPatch = {
+    type: "nodes-updated",
+    updates: [{ nodeId, before: node, after }],
+  };
+  return { ok: true, value: { graph: applyPatch(graph, patch), patch } };
+}
+
+/**
+ * Mark a node skipped (or un-skipped). Like a rename this is pure DATA — no
+ * structure changes, so a disabled node keeps its slot, its order, and its
+ * trim — and it rides the same `nodes-updated` patch, inheriting undo/redo,
+ * the change feed and structural sharing.
+ *
+ * The engine gives `disabled` no meaning beyond storing it. Who skips what is
+ * a DOMAIN decision (see the playback manifest and the collection-summary
+ * derivation, which drop disabled clips and repack around them); teaching the
+ * graph about it would put timing policy inside the reducer.
+ *
+ * Enabling DELETES the key rather than writing `false`, so an untouched
+ * document never grows a field and `before`/`after` stay minimal.
+ */
+function applySetDisabled(
+  graph: CollectionsGraph,
+  nodeId: NodeId,
+  disabled: boolean
+): Result<ApplyCommandSuccess, CommandRejection> {
+  const node = graph.nodesById.get(nodeId);
+  if (!node) return { ok: false, error: { reason: "missing-node", nodeId } };
+  if ((node.disabled ?? false) === disabled) {
+    return { ok: false, error: { reason: "same-position" } };
+  }
+
+  let after: CollectionItemNode;
+  if (disabled) {
+    after = { ...node, disabled: true };
+  } else {
+    const { disabled: _enabled, ...rest } = node;
+    after = rest as CollectionItemNode;
+  }
+
   const patch: CollectionsPatch = {
     type: "nodes-updated",
     updates: [{ nodeId, before: node, after }],

--- a/packages/collections-core/graph.ts
+++ b/packages/collections-core/graph.ts
@@ -48,6 +48,15 @@ export type ImageMediaNode = Readonly<{
   src?: string;
   /** The item's timeline duration. Trimming an image sets this directly. */
   durationSeconds: number;
+  /**
+   * Skipped: excluded from playback and from every count and duration total,
+   * along with its whole subtree when it is a collection. The engine treats a
+   * disabled node exactly like an enabled one — it still occupies its slot,
+   * still moves, still trims — because "skip this" is a DOMAIN fact about the
+   * timeline, not a structural one about the graph. Absent means enabled;
+   * re-enabling removes the key rather than writing `false`.
+   */
+  disabled?: boolean;
 }>;
 
 export type VideoMediaNode = Readonly<{
@@ -70,6 +79,15 @@ export type VideoMediaNode = Readonly<{
   trimInSeconds: number;
   /** Seconds trimmed off the END (right handle). 0 = untrimmed. */
   trimOutSeconds: number;
+  /**
+   * Skipped: excluded from playback and from every count and duration total,
+   * along with its whole subtree when it is a collection. The engine treats a
+   * disabled node exactly like an enabled one — it still occupies its slot,
+   * still moves, still trims — because "skip this" is a DOMAIN fact about the
+   * timeline, not a structural one about the graph. Absent means enabled;
+   * re-enabling removes the key rather than writing `false`.
+   */
+  disabled?: boolean;
 }>;
 
 export type MediaNode = ImageMediaNode | VideoMediaNode;
@@ -78,6 +96,15 @@ export type CollectionNode = Readonly<{
   id: NodeId;
   kind: "collection";
   name: string;
+  /**
+   * Skipped: excluded from playback and from every count and duration total,
+   * along with its whole subtree when it is a collection. The engine treats a
+   * disabled node exactly like an enabled one — it still occupies its slot,
+   * still moves, still trims — because "skip this" is a DOMAIN fact about the
+   * timeline, not a structural one about the graph. Absent means enabled;
+   * re-enabling removes the key rather than writing `false`.
+   */
+  disabled?: boolean;
 }>;
 
 export type CollectionItemNode = MediaNode | CollectionNode;
@@ -143,6 +170,7 @@ export type GraphNodeSpec =
       name: string;
       src?: string;
       durationSeconds?: number; // default 4
+      disabled?: boolean;
     }>
   | Readonly<{
       kind: "media";
@@ -154,8 +182,15 @@ export type GraphNodeSpec =
       fullDurationSeconds: number;
       trimInSeconds?: number; // default 0
       trimOutSeconds?: number; // default 0
+      disabled?: boolean;
     }>
-  | Readonly<{ kind: "collection"; id: string; name: string; children?: readonly GraphNodeSpec[] }>;
+  | Readonly<{
+      kind: "collection";
+      id: string;
+      name: string;
+      children?: readonly GraphNodeSpec[];
+      disabled?: boolean;
+    }>;
 
 export type BuildGraphError =
   | Readonly<{ reason: "duplicate-id"; id: string }>
@@ -225,6 +260,7 @@ export function buildGraph(
               fullDurationSeconds: spec.fullDurationSeconds,
               trimInSeconds: spec.trimInSeconds ?? 0,
               trimOutSeconds: spec.trimOutSeconds ?? 0,
+              ...(spec.disabled ? { disabled: true } : {}),
             }
           : {
               id,
@@ -233,10 +269,16 @@ export function buildGraph(
               name: spec.name,
               src: spec.src,
               durationSeconds: spec.durationSeconds ?? 4,
+              ...(spec.disabled ? { disabled: true } : {}),
             }
       );
     } else {
-      nodesById.set(id, { id, kind: "collection", name: spec.name });
+      nodesById.set(id, {
+        id,
+        kind: "collection",
+        name: spec.name,
+        ...(spec.disabled ? { disabled: true } : {}),
+      });
       const children = spec.children ?? [];
       childrenById.set(id, children.map((child) => child.id as NodeId));
       // Push in reverse so pop() visits children in document order — keeps
@@ -448,6 +490,13 @@ function validateNodeIdentity(
   if (value.kind !== "media" && value.kind !== "collection") {
     return invalidValue(`${path}.kind`, 'Expected "media" or "collection".');
   }
+  // Checked here rather than per-kind: `disabled` is on every node type, and
+  // a truthy non-boolean (the string "false", say) would otherwise be
+  // normalized to `disabled: true` by the parse path's `? :` and silently
+  // skip a clip in playback.
+  if (value.disabled !== undefined && typeof value.disabled !== "boolean") {
+    return invalidType(`${path}.disabled`, "Expected a boolean.");
+  }
   return null;
 }
 
@@ -555,7 +604,10 @@ export function parseCollectionItemNode(
   const id = parseNodeId(value.id as string);
   const name = value.name as string;
   if (value.kind === "collection") {
-    return { ok: true, value: { id, kind: "collection", name } };
+    return {
+      ok: true,
+      value: { id, kind: "collection", name, ...(value.disabled ? { disabled: true } : {}) },
+    };
   }
 
   const mediaError = validateMediaRecord(value, path, true);
@@ -576,6 +628,7 @@ export function parseCollectionItemNode(
         fullDurationSeconds: value.fullDurationSeconds as number,
         trimInSeconds: value.trimInSeconds as number,
         trimOutSeconds: value.trimOutSeconds as number,
+        ...(value.disabled ? { disabled: true } : {}),
       },
     };
   }
@@ -589,6 +642,7 @@ export function parseCollectionItemNode(
       name,
       src: value.src as string | undefined,
       durationSeconds: value.durationSeconds as number,
+      ...(value.disabled ? { disabled: true } : {}),
     },
   };
 }

--- a/packages/timeline-domain/src/adapter.test.ts
+++ b/packages/timeline-domain/src/adapter.test.ts
@@ -301,6 +301,48 @@ describe("graphChildrenToClips (round-trip)", () => {
     expect(projected[0]).toMatchObject({ id: "with-ref", sourceAsset });
     expect("sourceAsset" in projected[1]).toBe(false);
   });
+
+  it("round-trips `disabled` on media and collection clips, and omits it otherwise", () => {
+    // Unlike sourceAsset this rides the GRAPH, not the details side-table —
+    // disabling is a command, so the flag has to survive
+    // clip -> spec -> node -> clip. A disabled clip keeps its slot: same
+    // order, same startTime, same duration as if it were enabled.
+    const doc: TimelineDocument = {
+      id: "dis-root",
+      title: "Disabled",
+      clips: packTimelineClips([
+        { ...image("off-img", 4), disabled: true },
+        image("on-img", 4),
+        { ...collectionClip("off-col", "child", "Child"), disabled: true },
+      ]),
+    };
+    const result = buildFocusedGraph({ "dis-root": doc, child: CHILD_DOC }, "dis-root");
+    if (!result.ok) throw new Error(result.error);
+
+    const projected = graphChildrenToClips(result.value.graph, result.value.details, "dis-root");
+    expect(projected[0]).toMatchObject({ id: "off-img", disabled: true });
+    expect("disabled" in projected[1]).toBe(false);
+    expect(projected[2]).toMatchObject({ disabled: true });
+
+    // Slot preserved: projecting the SAME document with nothing disabled must
+    // produce identical geometry. Compared against an enabled twin rather
+    // than against packTimelineClips, because a hydrated collection derives
+    // its duration from live children — the stored 3 is not what it projects.
+    const enabledDoc: TimelineDocument = {
+      ...doc,
+      clips: doc.clips.map(({ disabled: _skip, ...clip }) => clip as TimelineClip),
+    };
+    const control = buildFocusedGraph({ "dis-root": enabledDoc, child: CHILD_DOC }, "dis-root");
+    if (!control.ok) throw new Error(control.error);
+    const controlClips = graphChildrenToClips(
+      control.value.graph,
+      control.value.details,
+      "dis-root",
+    );
+    expect(projected.map((c) => [c.id, c.index, c.startTime, c.duration])).toEqual(
+      controlClips.map((c) => [c.id, c.index, c.startTime, c.duration]),
+    );
+  });
 });
 
 describe("against the app's real initial documents", () => {

--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -113,6 +113,7 @@ function mediaSpec(clip: Exclude<TimelineClip, CollectionTimelineClip>): GraphNo
       fullDurationSeconds: clip.sourceDuration,
       trimInSeconds: clip.trimIn,
       trimOutSeconds: clip.trimOut,
+      ...(clip.disabled ? { disabled: true } : {}),
     };
   }
   return {
@@ -121,6 +122,7 @@ function mediaSpec(clip: Exclude<TimelineClip, CollectionTimelineClip>): GraphNo
     name: clip.alt,
     src: clip.src,
     durationSeconds: clip.duration,
+    ...(clip.disabled ? { disabled: true } : {}),
   };
 }
 
@@ -191,7 +193,13 @@ function clipSpecs(
         ...collectionDetail(clip, false),
         duplicateOfTimelineId: childId,
       };
-      return { kind: "collection", id: clip.id, name: clip.title, children: [] };
+      return {
+        kind: "collection",
+        id: clip.id,
+        name: clip.title,
+        children: [],
+        ...(clip.disabled ? { disabled: true } : {}),
+      };
     }
     ctx.used.add(childId);
 
@@ -203,12 +211,19 @@ function clipSpecs(
         id: childId,
         name: clip.title,
         children: clipSpecs(ctx, childDoc, hydrateLevels - 1),
+        ...(clip.disabled ? { disabled: true } : {}),
       };
     }
 
     if (!childDoc) ctx.missing.push(childId);
     ctx.details[childId] = collectionDetail(clip, false);
-    return { kind: "collection", id: childId, name: clip.title, children: [] };
+    return {
+      kind: "collection",
+      id: childId,
+      name: clip.title,
+      children: [],
+      ...(clip.disabled ? { disabled: true } : {}),
+    };
   });
 }
 
@@ -461,6 +476,9 @@ export function graphChildrenToClips(
           ? {}
           : { playbackDuration: detail.playbackDuration }),
         ...(detail?.sourceAsset === undefined ? {} : { sourceAsset: detail.sourceAsset }),
+        // Read from the NODE, not `detail`: disabling goes through a graph
+        // command, so the flag rides the patch/undo path like a rename does.
+        ...(node.disabled ? { disabled: true } : {}),
       };
       if (node.mediaKind === "video") {
         return {
@@ -520,6 +538,7 @@ export function graphChildrenToClips(
       sourceDuration: detail?.sourceDuration ?? duration,
       trimIn: detail?.trimIn ?? 0,
       trimOut: detail?.trimOut ?? 0,
+      ...(node.disabled ? { disabled: true } : {}),
     };
   });
 }

--- a/packages/timeline-model/types.ts
+++ b/packages/timeline-model/types.ts
@@ -27,6 +27,18 @@ export type TimelineItemBase = {
   trimIn: number;
   /** Amount trimmed from the source end. */
   trimOut: number;
+  /**
+   * Skipped: excluded from playback and from every count and duration total,
+   * along with its whole subtree when this is a collection clip. It KEEPS its
+   * slot in the stored document — same index, same startTime, same duration —
+   * because disabling is not deleting: the board still shows the clip in
+   * place, and only the read models (the playback manifest and the
+   * collection-summary derivation) drop it and repack around it.
+   *
+   * Absent means enabled; enabling removes the key rather than writing
+   * `false`, so documents that never use the feature never grow the field.
+   */
+  disabled?: boolean;
   /** Optional unscaled timeline position used when visual width differs from playback time. */
   playbackStartTime?: number;
   /** Optional unscaled playback duration used when visual width differs from playback time. */

--- a/packages/timeline-model/validate.test.ts
+++ b/packages/timeline-model/validate.test.ts
@@ -98,6 +98,18 @@ describe("isStoredTimelineDocument", () => {
     ).toBe(true);
   });
 
+  it("accepts `disabled` only as a boolean", () => {
+    // The write gate is the last place a bad value can be stopped: the
+    // playback and summary passes read this flag as "skip this clip", so a
+    // stored string would silently drop a clip from the timeline.
+    expect(isTimelineClip({ ...image, disabled: true })).toBe(true);
+    expect(isTimelineClip({ ...image, disabled: false })).toBe(true);
+    expect(isTimelineClip(image)).toBe(true);
+    expect(isTimelineClip({ ...image, disabled: "false" })).toBe(false);
+    expect(isTimelineClip({ ...image, disabled: 1 })).toBe(false);
+    expect(isTimelineClip({ ...image, disabled: null })).toBe(false);
+  });
+
   it("rejects a document containing ONE malformed clip", () => {
     expect(
       isStoredTimelineDocument({

--- a/packages/timeline-model/validate.ts
+++ b/packages/timeline-model/validate.ts
@@ -50,7 +50,12 @@ function hasClipBase(clip: Record<string, unknown>): boolean {
     isFiniteNumber(clip.trimIn) &&
     isFiniteNumber(clip.trimOut) &&
     isOptionalFiniteNumber(clip.playbackStartTime) &&
-    isOptionalFiniteNumber(clip.playbackDuration)
+    isOptionalFiniteNumber(clip.playbackDuration) &&
+    // Strictly boolean-or-absent. This gate guards the WRITE path, and a
+    // truthy non-boolean would be read as "skip this clip" by the playback
+    // and summary passes — a stored string "false" would silently drop a
+    // clip from the timeline.
+    (clip.disabled === undefined || typeof clip.disabled === "boolean")
   );
 }
 

--- a/packages/ui/dnd-collections/react/history-views.tsx
+++ b/packages/ui/dnd-collections/react/history-views.tsx
@@ -21,6 +21,8 @@ function describeCommand(command: CollectionsCommand): string {
       return `trim ${command.nodeId} (${command.update.mediaKind})`;
     case "rename-node":
       return `rename ${command.nodeId} → "${command.name}"`;
+    case "set-node-disabled":
+      return `${command.disabled ? "disable" : "enable"} ${command.nodeId}`;
   }
 }
 


### PR DESCRIPTION
## What

PR 1 of 4 for "disable an item". This makes the flag **exist, persist and undo**. Nothing reads it yet — playback and totals are unchanged.

## The load-bearing decision: it rides the graph, not the details side-table

`sourceAsset` and `poster` live in the details side-table, so that was the obvious home for `disabled`. It would not have worked.

Persistence is driven **exclusively** by graph patches — [graph-persistence.tsx:45](apps/timeline-gstudio001/components/graph-view/graph-persistence.tsx:45) subscribes to store changes and writes the affected documents; nothing else writes. A details-only edit produces no patch, so disabling would never save and never enter undo history.

Putting it on the node and mutating it through a command means it inherits undo/redo, the change feed and structural sharing for free.

## `set-node-disabled`

Modelled directly on `rename-node`: any node, media or collection, structure untouched, same `nodes-updated` patch. `update-media` could not be stretched — it's media-only by design ("the one DATA mutation"), and a collection has to be disable-able for the subtree case.

The engine gives the flag **no meaning** beyond storing it. Which clips get skipped is a domain decision belonging to the read models (PR 2), not the reducer — timing policy inside `applyCommand` would be the wrong seam.

Enabling **deletes** the key rather than writing `false`, so a document that never uses the feature never grows the field.

## Validation

Strictly boolean-or-absent on **both** untrusted paths — the model's write gate and the graph's node parser. The read models will treat this as "skip this clip", so a truthy non-boolean (a stored string `"false"`) would silently drop a clip from the timeline. I removed the model guard and confirmed the test fails before restoring it.

## Tests (+7)

- 5 on the command: media and collection, key deletion on enable, no-op refusal (`same-position`, so it never enters history), missing node, undo/redo.
- 1 adapter round-trip: the flag survives `clip → spec → node → clip`, is absent on clips that never had it, and a disabled clip keeps its **exact slot**.
- 1 validator.

The slot assertion compares against an identical **enabled** document rather than `packTimelineClips`. My first version compared to the stored duration of 3 and failed at 5.12 — because a hydrated collection derives its duration from live children. The test caught my wrong expectation, not a bug in the code, and the rewrite tests the property I actually care about: disabling changes nothing about geometry.

A `switch` exhaustiveness error in `history-views.tsx` also caught the new command immediately, which is the type system doing its job.

## Verification

| check | result |
|---|---|
| `tsc --noEmit` packages/ui | clean |
| `tsc --noEmit` app | clean |
| vitest `unit` | 362/362 (was 355) |
| vitest `storybook` | 151/151 |
| app vitest | 337/337 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
