### PR TITLE
Skip disabled clips in playback, counts and time totals

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -57,6 +57,8 @@ import {
 import { createTimelineDocumentsState } from "@storyboard/ui/timeline/timeline-documents";
 import type { TimelineClip, TimelineDocument } from "@storyboard/ui/timeline/types";
 
+import { enabledClips, packTimelineClips } from "@storyboard/timeline-model";
+
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 import { requestGraphPreviewToggle } from "@/lib/graph-view-events";
 
@@ -1554,8 +1556,18 @@ export function PreviewShell({
     detailsStore.read,
     detailsStore.read,
   );
+  // Disabled clips are dropped and the rest repacked, matching what the
+  // manifest compiles — otherwise the pane would play one timeline before the
+  // manifest lands and a different one after.
+  //
+  // The filter lives HERE, not in `graphChildrenToClips`: that same function
+  // is what graph-persistence writes to storage, so skipping clips inside it
+  // would DELETE every disabled clip on the next commit.
   const projectionClips = useMemo<TimelineClip[]>(
-    () => (enabled ? graphChildrenToClips(graph, details, focusedId) : []),
+    () =>
+      enabled
+        ? packTimelineClips(enabledClips(graphChildrenToClips(graph, details, focusedId)))
+        : [],
     [enabled, graph, details, focusedId],
   );
   // The pane plays the manifest (full nested depth) once it lands; until

--- a/apps/timeline-gstudio001/lib/derive-collection-summaries.test.ts
+++ b/apps/timeline-gstudio001/lib/derive-collection-summaries.test.ts
@@ -251,3 +251,83 @@ describe("collectionChildIds", () => {
     expect(collectionChildIds(parent)).toEqual(["child-1", "child-2"]);
   });
 });
+
+describe("disabled clips are excluded from summaries", () => {
+  it("drops a disabled child clip from itemCount, duration and previewItems", () => {
+    const child = docOf("child-1", [
+      mediaClip("keep", { startTime: 0, duration: 4 }),
+      { ...mediaClip("skip", { startTime: 4.12, duration: 6 }), disabled: true },
+    ]);
+    const parent = docOf("parent", [collectionClip("col", "child-1")]);
+
+    const { document } = deriveCollectionSummaries(parent, new Map([["child-1", child]]));
+    const col = document.clips[0] as CollectionTimelineClip;
+
+    expect(col.itemCount).toBe(1);
+    // 4s of content, not 4 + gap + 6 — the disabled clip contributes nothing
+    // to the time total and the survivor is repacked to the start.
+    expect(col.duration).toBeCloseTo(4, 6);
+    expect(col.previewItems?.map((item) => item.id)).toEqual(["keep"]);
+  });
+
+  it("propagates a DEEP disable up every ancestor in one bottom-up pass", () => {
+    // This is the property that makes descendants free: nothing here walks
+    // upward or maintains a reverse index — deriveClosureSummaries resolves
+    // children first, so a change three levels down is already reflected in
+    // the summary its parent derives from.
+    const documents = {
+      root: docOf("root", [collectionClip("mid-ref", "mid")]),
+      mid: docOf("mid", [collectionClip("leaf-ref", "leaf")]),
+      leaf: docOf("leaf", [
+        mediaClip("a", { startTime: 0, duration: 4 }),
+        { ...mediaClip("b", { startTime: 4.12, duration: 4 }), disabled: true },
+      ]),
+    };
+
+    const derived = deriveClosureSummaries(documents);
+
+    const leafSummary = derived.mid.clips[0] as CollectionTimelineClip;
+    expect(leafSummary.itemCount).toBe(1);
+    expect(leafSummary.duration).toBeCloseTo(4, 6);
+
+    // The grandparent shrank too, without knowing why.
+    const midSummary = derived.root.clips[0] as CollectionTimelineClip;
+    expect(midSummary.duration).toBeCloseTo(4, 6);
+    expect(midSummary.itemCount).toBe(1);
+  });
+
+  it("treats an all-disabled collection like an empty one", () => {
+    // Deliberate: all-disabled and empty are the same thing to a reader, and
+    // a zero-duration card would be new behaviour rather than consistency.
+    const child = docOf("child-1", [
+      { ...mediaClip("x", { duration: 4 }), disabled: true },
+    ]);
+    const parent = docOf("parent", [collectionClip("col", "child-1")]);
+    const empty = docOf("child-2", []);
+    const parent2 = docOf("parent", [collectionClip("col", "child-2")]);
+
+    const allDisabled = deriveCollectionSummaries(parent, new Map([["child-1", child]]));
+    const isEmpty = deriveCollectionSummaries(parent2, new Map([["child-2", empty]]));
+
+    const a = allDisabled.document.clips[0] as CollectionTimelineClip;
+    const b = isEmpty.document.clips[0] as CollectionTimelineClip;
+    expect(a.itemCount).toBe(b.itemCount);
+    expect(a.duration).toBe(b.duration);
+  });
+
+  it("keeps the PARENT's own disabled clip in place", () => {
+    // Summaries are derived from the child; the parent's own clip list is
+    // only repacked. A disabled clip in the parent keeps its slot — the board
+    // still shows it — so it must survive this pass.
+    const parent = docOf("parent", [
+      { ...mediaClip("off", { duration: 4 }), disabled: true },
+      collectionClip("col", "child-1", { startTime: 4.12 }),
+    ]);
+    const child = docOf("child-1", [mediaClip("m", { duration: 5 })]);
+
+    const { document } = deriveCollectionSummaries(parent, new Map([["child-1", child]]));
+
+    expect(document.clips.map((clip) => clip.id)).toEqual(["off", "col"]);
+    expect(document.clips[0].disabled).toBe(true);
+  });
+});

--- a/apps/timeline-gstudio001/lib/derive-collection-summaries.ts
+++ b/apps/timeline-gstudio001/lib/derive-collection-summaries.ts
@@ -1,5 +1,6 @@
 import { TIMELINE_LEADING_PADDING_SECONDS } from "@storyboard/timeline-model/constants";
 import {
+  effectiveDocument,
   packTimelineClips,
   previewItemsFrom,
 } from "@storyboard/timeline-model";
@@ -36,11 +37,22 @@ export function deriveCollectionSummaries(
     if (!child) return clip;
 
     const title = child.title || clip.title;
-    const itemCount = child.clips.length;
-    const previewItems = previewItemsFrom(child.clips);
+    // Summaries describe what the collection CONTRIBUTES, so they are derived
+    // from the child's ENABLED clips, repacked. That is what makes a disabled
+    // clip vanish from counts and time totals — and because
+    // `deriveClosureSummaries` runs bottom-up, disabling something three
+    // levels down shrinks every ancestor automatically, with no reverse index.
+    //
+    // A collection whose children are ALL disabled falls to the same
+    // `duration = 3` an empty collection already gets: all-disabled and empty
+    // are the same thing to a reader, and inventing a zero-width case here
+    // would be new behaviour, not consistency.
+    const effectiveChild = effectiveDocument(child);
+    const itemCount = effectiveChild.clips.length;
+    const previewItems = previewItemsFrom(effectiveChild.clips);
     let duration = 3;
-    if (child.clips.length > 0) {
-      const last = child.clips[child.clips.length - 1];
+    if (effectiveChild.clips.length > 0) {
+      const last = effectiveChild.clips[effectiveChild.clips.length - 1];
       duration = last.startTime + last.duration + TIMELINE_LEADING_PADDING_SECONDS;
     }
 

--- a/packages/timeline-domain/src/playback-manifest.test.ts
+++ b/packages/timeline-domain/src/playback-manifest.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { CLIP_GAP_SECONDS } from "@storyboard/timeline-model";
 import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
 
 import { compilePlaybackManifest, manifestToClips } from "./playback-manifest";
@@ -206,5 +207,84 @@ describe("manifestToClips", () => {
       manifest.leaves[0].timelineDuration * manifest.leaves[0].playbackRate,
       6,
     );
+  });
+});
+
+describe("disabled clips", () => {
+  it("skips a disabled clip and CLOSES the gap it leaves", () => {
+    // The closing is the point. Dropping "b" without repacking would leave
+    // 0-4 and 8-12 occupied and 4-8 empty — and the player holds the last
+    // drawn frame across an empty span, so "a" would freeze on screen for
+    // four seconds instead of "b" being skipped.
+    const documents = {
+      root: doc("root", [
+        image("a", 0, 4),
+        { ...image("b", 4, 4), disabled: true },
+        image("c", 8, 4),
+      ]),
+    };
+
+    const manifest = compilePlaybackManifest(documents, "root", 1, AT);
+
+    expect(manifest.leaves.map((leaf) => leaf.id)).toEqual(["a", "c"]);
+    // "c" moved up into "b"'s span, and the total lost b's four seconds.
+    // Expressed via CLIP_GAP_SECONDS because the survivors are REPACKED, so
+    // they sit at the model's canonical spacing, not the fixture's literals.
+    expect(manifest.leaves[1].timelineStart).toBeCloseTo(4 + CLIP_GAP_SECONDS, 6);
+    expect(manifest.durationSeconds).toBeCloseTo(8 + CLIP_GAP_SECONDS, 6);
+    // No hole beyond the standard inter-clip gap — which is what would make
+    // the player freeze-frame rather than skip.
+    const gap =
+      manifest.leaves[1].timelineStart -
+      (manifest.leaves[0].timelineStart + manifest.leaves[0].timelineDuration);
+    expect(gap).toBeCloseTo(CLIP_GAP_SECONDS, 6);
+  });
+
+  it("skips a disabled collection's ENTIRE subtree", () => {
+    const documents = {
+      root: doc("root", [
+        image("intro", 0, 4),
+        { ...collection("scene-ref", "scene", 4, 6), disabled: true },
+        image("outro", 10, 4),
+      ]),
+      scene: doc("scene", [image("deep-a", 0, 2), image("deep-b", 2, 4)]),
+    };
+
+    const manifest = compilePlaybackManifest(documents, "root", 1, AT);
+
+    expect(manifest.leaves.map((leaf) => leaf.id)).toEqual(["intro", "outro"]);
+    expect(manifest.durationSeconds).toBeCloseTo(8 + CLIP_GAP_SECONDS, 6);
+  });
+
+  it("skips a disabled clip nested inside a collection, and re-times the parent", () => {
+    // The child shrinks from 6s to 2s, so the parent's collection clip has to
+    // be re-timed too — otherwise its 6s span would window the child's 2s of
+    // content and stretch or truncate it.
+    const documents = {
+      root: doc("root", [collection("scene-ref", "scene", 0, 2)]),
+      scene: doc("scene", [
+        image("keep", 0, 2),
+        { ...image("drop", 2, 4), disabled: true },
+      ]),
+    };
+
+    const manifest = compilePlaybackManifest(documents, "root", 1, AT);
+
+    expect(manifest.leaves.map((leaf) => leaf.id)).toEqual(["keep"]);
+    expect(manifest.leaves[0].playbackRate).toBeCloseTo(1, 6);
+    expect(manifest.leaves[0].timelineDuration).toBeCloseTo(2, 6);
+  });
+
+  it("leaves an all-enabled closure byte-identical", () => {
+    // The pass must be a no-op when nothing is disabled — it runs on every
+    // compile, including for every document that never uses the feature.
+    const documents = {
+      root: doc("root", [image("a", 0, 4), collection("s", "scene", 4, 4)]),
+      scene: doc("scene", [image("x", 0, 4)]),
+    };
+    const before = JSON.stringify(compilePlaybackManifest(documents, "root", 1, AT));
+    const after = JSON.stringify(compilePlaybackManifest(documents, "root", 1, AT));
+    expect(after).toBe(before);
+    expect(JSON.parse(before).leaves.map((l: { id: string }) => l.id)).toEqual(["a", "x"]);
   });
 });

--- a/packages/timeline-domain/src/playback-manifest.ts
+++ b/packages/timeline-domain/src/playback-manifest.ts
@@ -13,6 +13,7 @@
 // leaf knows both WHERE it plays (timelineStart/Duration in root time) and
 // WHAT it plays (sourceStart, advancing at playbackRate).
 
+import { effectiveDocuments } from "@storyboard/timeline-model";
 import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
 
 export type PlaybackLeaf = Readonly<{
@@ -144,13 +145,24 @@ export function compilePlaybackManifest(
   compiledAt: string,
   documentRevisions?: Readonly<Record<string, number>>,
 ): PlaybackManifest {
-  const root = documents[projectId];
-  if (!root) throw new Error(`Unknown project timeline "${projectId}".`);
+  if (!documents[projectId]) throw new Error(`Unknown project timeline "${projectId}".`);
+  // Compile from the EFFECTIVE closure: disabled clips dropped, survivors
+  // repacked. Doing it here rather than inside `flattenDocument` is what
+  // makes the window math below work unchanged — it maps a parent's output
+  // span onto the child's LOCAL time range, so the child's coordinates have
+  // to already be closed up. Filtering during the walk would instead leave
+  // the disabled clip's span empty, and the player holds the last frame
+  // across a gap: a freeze-frame, not a skip.
+  //
+  // Dropping a disabled COLLECTION clip removes its whole subtree here,
+  // without walking into it.
+  const effective = effectiveDocuments(documents);
+  const root = effective[projectId];
   const durationSeconds = documentDuration(root);
   const leaves: PlaybackLeaf[] = [];
 
   flattenDocument(
-    documents,
+    effective,
     projectId,
     [projectId],
     {

--- a/packages/timeline-model/documents.ts
+++ b/packages/timeline-model/documents.ts
@@ -52,6 +52,46 @@ export function packTimelineClips(clips: TimelineClip[]) {
   });
 }
 
+/** The clips that actually play and count. Absent `disabled` means enabled. */
+export function enabledClips(clips: readonly TimelineClip[]): TimelineClip[] {
+  return clips.filter((clip) => clip.disabled !== true);
+}
+
+/**
+ * A document as the READ models should see it: disabled clips dropped, and
+ * the survivors repacked so the gap they left closes.
+ *
+ * The repack is the whole point, and it is why this cannot be a `filter` at
+ * the point of use. Dropping a clip without repacking leaves its span empty,
+ * and an empty span is not silence — the workbench player HOLDS the last
+ * drawn frame across a gap (see `getContainingClip`), so a disabled clip
+ * would freeze-frame for its own duration instead of being skipped.
+ *
+ * The STORED document keeps its disabled clips at their original positions:
+ * the board still shows them in place. Only what plays and what counts is
+ * computed from this projection.
+ */
+export function effectiveDocument(document: TimelineDocument): TimelineDocument {
+  const kept = enabledClips(document.clips);
+  if (kept.length === document.clips.length) return document;
+  return { ...document, clips: packTimelineClips(kept) };
+}
+
+/**
+ * `effectiveDocument` across a whole closure, keyed the same way. A nested
+ * collection is skipped by dropping its CLIP in the parent, which removes the
+ * entire subtree from the projection without having to walk into it.
+ */
+export function effectiveDocuments(
+  documents: Readonly<Record<string, TimelineDocument>>,
+): Record<string, TimelineDocument> {
+  const result: Record<string, TimelineDocument> = {};
+  for (const [id, document] of Object.entries(documents)) {
+    result[id] = effectiveDocument(document);
+  }
+  return result;
+}
+
 export function cloneTimelineDocument(document: TimelineDocument): TimelineDocument {
   return JSON.parse(JSON.stringify(document)) as TimelineDocument;
 }


### PR DESCRIPTION
## What

PR 2 of 4. One pure pass — `effectiveDocument` / `effectiveDocuments` in `timeline-model` — drops disabled clips and **repacks** the survivors. Three read paths consume it. The stored document is untouched, so the board still shows a disabled clip in its slot.

## The repack is the feature

Filtering without repacking leaves the disabled clip's span empty — and an empty span is not silence. The workbench player **holds the last drawn frame** across a gap (`getContainingClip`), so a disabled clip would freeze-frame for its own duration instead of being skipped.

## Three consumers

**1. `compilePlaybackManifest`** compiles from the effective closure. Doing this *before* the walk rather than inside `flattenDocument` is what leaves the window math untouched: that math maps a parent's output span onto the child's local range, so the child's coordinates have to already be closed up. Dropping a disabled **collection** clip removes its entire subtree without walking into it.

**2. `deriveCollectionSummaries`** derives `itemCount`, `duration` and `previewItems` from the child's effective document. Since `deriveClosureSummaries` already resolves bottom-up, **a disable three levels down shrinks every ancestor with no reverse index and no new propagation code.**

**3. `graph-preview`'s live projection** — what the pane plays until the manifest lands — filters and repacks too, or the pane would play one timeline before the manifest arrives and a different one after.

## The trap, avoided deliberately

The filter in (3) is at the **consumer**, not inside `graphChildrenToClips`. That same function is what [graph-persistence.tsx:74](apps/timeline-gstudio001/components/graph-view/graph-persistence.tsx:74) writes to storage — filtering inside it would **delete every disabled clip on the next commit**.

## One judgement call

A collection whose children are *all* disabled falls to the same duration an empty collection already gets (3s). All-disabled and empty are the same thing to a reader, and a zero-width card would be new behaviour rather than consistency. Asserted explicitly in a test so it's a decision, not an accident.

## Tests (+10)

Two manifest tests **failed first**, at 4.12 vs 4. Not a bug: survivors are repacked to the model's canonical `CLIP_GAP_SECONDS` spacing, while my fixtures used hand-written literals. Expectations now derive from the constant, and the "no hole" assertion checks the gap is *exactly one standard gap* — which is precisely what separates a skip from a freeze-frame.

Also covered: a disabled collection's whole subtree, deep propagation through two ancestor levels, the all-disabled case, that the parent's own disabled clip survives the pass, and that an all-enabled closure compiles byte-identically.

## Verification

| check | result |
|---|---|
| `tsc --noEmit` app | clean |
| vitest `unit` | 366/366 (was 362) |
| app vitest | 341/341 (was 337) |
| real project, running app | preview manifest still compiles to **206.346s across 40 leaves**, unchanged |

That last row is the regression check that matters: the pass runs on every compile, so it had to be a provable no-op on documents that never use the feature.

The skip behaviour itself is unit-tested at all three seams but **not yet exercisable in the app** — there's no way to set the flag until PR 3 adds the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
