### PR TITLE
Add the disable/enable control, and mute disabled cards

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
@@ -236,6 +236,18 @@ export function GraphItemActionsBridge({
   const store = useCollectionsStore();
   const details = useGraphDetailsStore();
   const selectionSize = useCollectionsSelector((s) => s.interaction.selectedIds.size);
+  // Returns a PRIMITIVE, per the store's selector contract — allocating here
+  // (an array of the selected nodes, say) would re-render on every snapshot.
+  // A mixed selection is false, so the toggle's next press disables the rest
+  // rather than flipping each item independently.
+  const allDisabled = useCollectionsSelector((s) => {
+    const selected = s.interaction.selectedIds;
+    if (selected.size === 0) return false;
+    for (const id of selected) {
+      if (s.graph.nodesById.get(id)?.disabled !== true) return false;
+    }
+    return true;
+  });
   // True while an async action (copy/cut/duplicate loading documents) runs.
   // State so the broadcast below re-fires; the REF is what the (stable) event
   // listener consults, so the guard needs no effect re-subscription.
@@ -263,9 +275,12 @@ export function GraphItemActionsBridge({
   // the previous session's stale item-mode cluster before its own first
   // broadcast lands.
   useEffect(() => {
-    broadcastGraphSelection({ count: selectionSize, busy });
-  }, [selectionSize, busy]);
-  useEffect(() => () => broadcastGraphSelection({ count: 0, busy: false }), []);
+    broadcastGraphSelection({ count: selectionSize, busy, allDisabled });
+  }, [selectionSize, busy, allDisabled]);
+  useEffect(
+    () => () => broadcastGraphSelection({ count: 0, busy: false, allDisabled: false }),
+    [],
+  );
 
   // Trash drawer → graph: put a deleted item back into the OPEN timeline.
   //
@@ -473,6 +488,35 @@ export function GraphItemActionsBridge({
           moveSelectionToTrash(store, trashId);
           store.clearSelection();
           break;
+        case "toggle-disabled": {
+          const selected = [...store.getSnapshot().interaction.selectedIds];
+          if (selected.length === 0) break;
+          // One command per node, but ONE decision for the whole selection:
+          // every node goes to the same state, so a mixed selection resolves
+          // instead of each item flipping its own way. Re-read `disabled`
+          // from the live graph rather than trusting the sidebar's broadcast,
+          // which is a frame behind.
+          const graph = store.getSnapshot().graph;
+          const nextDisabled = selected.some(
+            (id) => graph.nodesById.get(id)?.disabled !== true,
+          );
+          let changed = 0;
+          for (const nodeId of selected) {
+            // A node already in the target state is refused as `same-position`
+            // and never enters history — so this loop cannot pad undo with
+            // no-ops when only part of the selection needs changing.
+            if (store.dispatch({ type: "set-node-disabled", nodeId, disabled: nextDisabled }).ok) {
+              changed += 1;
+            }
+          }
+          if (changed > 0) {
+            toast(
+              `${nextDisabled ? "Disabled" : "Enabled"} ${changed} item${changed === 1 ? "" : "s"}.`,
+              { id: "graph-item-disable" },
+            );
+          }
+          break;
+        }
         case "cancel":
           graphClipboard.clear();
           store.clearSelection();

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -362,3 +362,54 @@ export const TrimOverviewSamplesDistinctFrames: Story = {
     expect(canvasElement.textContent).not.toContain("full clip");
   },
 };
+
+/**
+ * A DISABLED collection: skipped in playback, counts and time totals, but it
+ * keeps its slot and its full width — its duration still shapes the board.
+ * So it must read as muted, never as missing or as an error. Grayscale plus
+ * reduced opacity is what survives on top of arbitrary artwork, where a tint
+ * would not.
+ */
+export const DisabledCollection: Story = {
+  args: baseArgs,
+  decorators: [
+    (Story) => {
+      const graph = buildGraph([
+        {
+          kind: "collection",
+          id: COLLECTION_ID,
+          name: "A timeline",
+          children: [],
+          disabled: true,
+        },
+      ]);
+      if (!graph.ok) throw new Error(JSON.stringify(graph.error));
+      const store = createGraphDetailsStore({
+        [COLLECTION_ID]: {
+          alt: "A timeline",
+          aspect: 16 / 9,
+          trackIndex: 0,
+          hydrated: false,
+          itemCount: 2,
+          previewItems: [ASSET_A, ASSET_B],
+        },
+      });
+      return (
+        <DndCollections initialGraph={graph.value}>
+          <GraphDetailsProvider store={store}>
+            <div className="h-32 w-40 bg-zinc-950 p-2">
+              <Story />
+            </div>
+          </GraphDetailsProvider>
+        </DndCollections>
+      );
+    },
+  ],
+  play: async ({ canvasElement }) => {
+    const card = canvasElement.querySelector(".is-disabled-card");
+    await expect(card).not.toBeNull();
+    await expect(getComputedStyle(card as Element).filter).toBe("grayscale(1)");
+    // The frames still render — a disabled card shows its content, muted.
+    await expect(previewImages(canvasElement)).toHaveLength(2);
+  },
+};

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -267,7 +267,13 @@ const GraphClipContent = memo(function GraphClipContent({
         selected ? "ring-2 ring-amber-400" : "ring-1 ring-white/15",
         rejected ? "ring-2 ring-red-500 motion-safe:animate-pulse" : "",
         isDragSource ? "opacity-40" : "",
+        // Disabled reads as MUTED, never as missing: the card keeps its slot
+        // and its full width (its duration still shapes the board), it just
+        // stops looking like content that plays. Grayscale + reduced opacity
+        // survives on top of any artwork, where a tint would not.
+        node.disabled ? "opacity-45 grayscale" : "",
       ].join(" ")}
+      data-disabled={node.disabled ? "true" : undefined}
     >
       {frameSrcs.length === 0 ? (
         <span className="flex h-full w-full items-center justify-center text-[10px] text-zinc-500">
@@ -506,10 +512,22 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
   // live children (like the count), so editing a loaded child refreshes this
   // card without a reload; placeholders fall back to their stored summary.
   const hydrated = detail?.hydrated === true;
+  // Primitive return, per the store's selector contract.
+  const enabledChildCount = useCollectionsSelector((s) => {
+    const children = s.graph.childrenById.get(id) ?? [];
+    let total = 0;
+    for (const child of children) {
+      if (s.graph.nodesById.get(child)?.disabled !== true) total += 1;
+    }
+    return total;
+  });
   const livePreviews = useHydratedCollectionPreviews(id as string, hydrated);
   const liveSeconds = useHydratedCollectionSeconds(id as string, hydrated);
 
-  const count = hydrated ? childCount : (detail?.itemCount ?? childCount);
+  // ENABLED children only, so the card agrees with the time totals and with
+  // the served summary (which derives itemCount from the effective document).
+  // `childCount` from the primitive counts every child, disabled included.
+  const count = hydrated ? enabledChildCount : (detail?.itemCount ?? enabledChildCount);
   const totalSeconds = hydrated ? liveSeconds : detail?.duration;
   // FIRST and LAST only — the card says "a timeline runs from here to
   // there", which two frames tell and three do not. A single-item
@@ -538,6 +556,12 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
           selected ? "ring-2 ring-amber-400" : "",
           rejected ? "ring-2 ring-red-500 motion-safe:animate-pulse" : "",
           isDragSource ? "opacity-40" : "",
+          // No `data-disabled` twin here: SelectionSurface takes an explicit
+          // prop list with no rest spread, so a hyphenated attribute passed to
+          // it is silently dropped — and TS does not flag it, because excess
+          // property checks skip hyphenated JSX names. The marker class below
+          // is what tests and e2e can query on a collection card.
+          node.disabled ? "opacity-45 grayscale is-disabled-card" : "",
         ].join(" ")}
       >
         <span className="flex min-h-0 flex-1 gap-0.5 overflow-hidden">

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -133,9 +133,16 @@ function SubTimelineNode({
   const rename = useInlineRename(collectionId, name);
   const detail = useClipDetail(id);
   const hydrated = detail?.hydrated === true;
-  const liveCount = useCollectionsSelector((snapshot) =>
-    getChildren(snapshot.graph, collectionId).length,
-  );
+  // ENABLED children only — this row says what the timeline contributes, so
+  // it has to agree with the time totals and the served summary rather than
+  // counting clips that are skipped.
+  const liveCount = useCollectionsSelector((snapshot) => {
+    let total = 0;
+    for (const child of getChildren(snapshot.graph, collectionId)) {
+      if (snapshot.graph.nodesById.get(child)?.disabled !== true) total += 1;
+    }
+    return total;
+  });
   const childIds = useCollectionChildIds(collectionId);
   const status = subTimelineRowStatus({ expanded, hydrated, failed });
 

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -2,6 +2,8 @@
 
 import React, { useState, useEffect, useRef, useSyncExternalStore } from "react";
 import {
+  Ban,
+  CircleCheck,
   ClipboardPaste,
   Copy,
   CopyPlus,
@@ -222,7 +224,14 @@ function ItemActionsCluster({
   hasSelection,
   canPaste,
   busy,
-}: Readonly<{ hasSelection: boolean; canPaste: boolean; busy: boolean }>) {
+  allDisabled,
+}: Readonly<{
+  hasSelection: boolean;
+  canPaste: boolean;
+  busy: boolean;
+  /** Every selected item is already skipped — flips the toggle to "Enable". */
+  allDisabled: boolean;
+}>) {
   return (
     <div className="flex flex-col items-center gap-2">
       {/* Only the five actions that touch the SELECTION sit inside the amber
@@ -267,6 +276,20 @@ function ItemActionsCluster({
           icon={Trash2}
           label="Delete"
           description="Move the selected item to trash"
+          disabled={busy || !hasSelection}
+        />
+        {/* The button shows the icon of the ACTION it performs, so it reads
+            Ban ("disable this") until everything selected is already
+            disabled, then offers the way back. */}
+        <ItemActionButton
+          action="toggle-disabled"
+          icon={allDisabled ? CircleCheck : Ban}
+          label={allDisabled ? "Enable" : "Disable"}
+          description={
+            allDisabled
+              ? "Play this item again, and count it in the totals"
+              : "Skip this item in playback, counts and time totals"
+          }
           disabled={busy || !hasSelection}
         />
       </div>
@@ -410,12 +433,14 @@ export function TimelineSidebar() {
   // selection (copy here, drill into another timeline, paste there).
   const [selectionCount, setSelectionCount] = useState(0);
   const [actionBusy, setActionBusy] = useState(false);
+  const [selectionAllDisabled, setSelectionAllDisabled] = useState(false);
   useEffect(() => {
     const onSelection = (event: Event) => {
       const detail = (event as CustomEvent<GraphSelectionDetail>).detail;
       if (detail) {
         setSelectionCount(detail.count);
         setActionBusy(detail.busy);
+        setSelectionAllDisabled(detail.allDisabled);
       }
     };
     window.addEventListener(GRAPH_SELECTION_EVENT, onSelection);
@@ -480,6 +505,7 @@ export function TimelineSidebar() {
           hasSelection={selectionCount > 0}
           canPaste={canPaste}
           busy={actionBusy}
+          allDisabled={selectionAllDisabled}
         />
       )}
 

--- a/apps/timeline-gstudio001/lib/graph-view-events.ts
+++ b/apps/timeline-gstudio001/lib/graph-view-events.ts
@@ -101,10 +101,26 @@ export const GRAPH_ITEM_ACTION_EVENT = "graph-view:item-action";
 /** Graph → sidebar: how many items are currently selected, and whether an
  *  async item action (copy/cut/duplicate loading documents) is in flight —
  *  the sidebar disables the cluster while busy so actions can't double-fire. */
-export type GraphSelectionDetail = Readonly<{ count: number; busy: boolean }>;
+export type GraphSelectionDetail = Readonly<{
+  count: number;
+  busy: boolean;
+  /** True when EVERY selected item is already disabled, which is what flips
+   *  the toggle's label from "Disable" to "Enable". A mixed selection reads
+   *  as false: the toggle then disables the rest, so one press always leaves
+   *  the selection in a single, predictable state. */
+  allDisabled: boolean;
+}>;
 
 /** The per-item actions the sidebar's item-mode cluster can request. */
-export type GraphItemAction = "copy" | "cut" | "paste" | "duplicate" | "delete" | "cancel";
+export type GraphItemAction =
+  | "copy"
+  | "cut"
+  | "paste"
+  | "duplicate"
+  | "delete"
+  | "cancel"
+  /** Skip (or un-skip) the selection in playback, counts and time totals. */
+  | "toggle-disabled";
 
 /** Graph → sidebar: the live selection size, so the sidebar can enter/exit
  *  item-actions mode and enable/disable the selection-dependent buttons. */


### PR DESCRIPTION
## What

PR 3 of 4 — the feature becomes usable. Select an item, press Disable.

## The control

One toggle, not two actions. The button shows the icon and label of what it will **do**: `Disable` (Ban) until everything selected is already disabled, then `Enable` (CircleCheck).

A **mixed selection disables the rest** rather than flipping each item its own way, so one press always leaves the selection in a single predictable state. The handler re-reads `disabled` from the live graph rather than trusting the sidebar's broadcast, which is a frame behind. Nodes already in the target state are refused as `same-position` and never enter history, so the loop can't pad undo with no-ops.

`GraphSelectionDetail` gains `allDisabled`, computed in a selector that returns a **primitive** — the store's selector contract forbids per-call allocations, which would re-render on every snapshot.

## The cards

Disabled reads as **muted, never as missing**: the card keeps its slot and full width (its duration still shapes the board) at 45% opacity and grayscale — which survives on top of arbitrary artwork where a tint would not.

Both live counts now count **enabled children only** — the collection card badge and the sub-timeline row — so they agree with the time totals and with the served summary.

## A silent prop drop, caught by the story

The collection card carries a marker **class**, not a data attribute. `CollectionItem.SelectionSurface` takes an explicit prop list with no rest spread, so `data-disabled` passed to it is **silently dropped** — and TypeScript doesn't flag it, because excess-property checks skip hyphenated JSX names. `className` *is* forwarded, so the muting itself always worked; only my test marker vanished. The media card keeps `data-disabled` (a real DOM element).

## Verified end-to-end on the real project

Disabling one clip in the running app:

| | before | after |
|---|---|---|
| manifest leaves | 40 | **39** |
| manifest duration | 206.35s | **201.23s** |
| ancestor `itemCount` | 2 | **1** |
| ancestor duration | 9.12s | **4.0s** |
| card | normal | **opacity 0.45, grayscale(1)** |

The ancestor shrank with no reverse index — the bottom-up derivation doing its job on real data. Re-enabling restored every number exactly and **deleted** the key rather than storing `false`. **The project is back to its original state.**

One note: an earlier attempt showed the flag persisting but being ignored, then vanishing. That was a stale dev server — it had been started before PR 1 and 2 existed, so it served an adapter that dropped `disabled` on write. Restarting it resolved it completely; no code defect.

## Verification

| check | result |
|---|---|
| `tsc --noEmit` app | clean |
| app lint | 0 errors (4 pre-existing `<img>` warnings) |
| app vitest | 341/341 |
| vitest `unit` | 366/366 |
| vitest `storybook` | 152/152 (+1 `DisabledCollection` story) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
