### PR TITLE
Sub-timeline rows: decorative timeline preview, no drill-in control

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import { memo, useCallback, useContext, useEffect, useRef, useState, useSyncExternalStore } from "react";
+import {
+  memo,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import { FolderInput } from "lucide-react";
 
 import {
@@ -141,6 +150,30 @@ function useHydratedCollectionPreviews(
     return derive(store.getSnapshot().graph, id);
   }, [store, derive, id, enabled]);
   return useSyncExternalStore(store.subscribe, getSnapshot, getSnapshot);
+}
+
+/**
+ * The frames a collection PRESENTS: first and last, live once hydrated and the
+ * stored summary until then.
+ *
+ * First and last only — "a timeline runs from here to there" is what two
+ * frames tell and three do not. A single-item collection has no "last"
+ * distinct from its first, so it yields one frame rather than the same image
+ * twice.
+ *
+ * Exported because the sub-timeline ROW shows the same frames as the card.
+ * Two copies of this rule would drift the moment either changed, and the two
+ * sit on screen together — the row is the tree view of the very cards beside
+ * it, so a disagreement would be visible rather than theoretical.
+ */
+export function useCollectionPreviewFrames(
+  id: string,
+  hydrated: boolean,
+  stored: readonly CollectionPreviewFrame[] | undefined,
+): readonly CollectionPreviewFrame[] {
+  const live = useHydratedCollectionPreviews(id, hydrated);
+  const all = hydrated ? live : (stored ?? NO_PREVIEWS);
+  return useMemo(() => (all.length > 1 ? [all[0], all[all.length - 1]] : all), [all]);
 }
 
 /**
@@ -521,7 +554,6 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
     }
     return total;
   });
-  const livePreviews = useHydratedCollectionPreviews(id as string, hydrated);
   const liveSeconds = useHydratedCollectionSeconds(id as string, hydrated);
 
   // ENABLED children only, so the card agrees with the time totals and with
@@ -529,14 +561,7 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
   // `childCount` from the primitive counts every child, disabled included.
   const count = hydrated ? enabledChildCount : (detail?.itemCount ?? enabledChildCount);
   const totalSeconds = hydrated ? liveSeconds : detail?.duration;
-  // FIRST and LAST only — the card says "a timeline runs from here to
-  // there", which two frames tell and three do not. A single-item
-  // collection has no "last" distinct from its first, so it shows one
-  // frame across the full width rather than the same image twice.
-  const all: readonly CollectionPreviewFrame[] = hydrated
-    ? livePreviews
-    : (detail?.previewItems ?? []);
-  const previews = all.length > 1 ? [all[0], all[all.length - 1]] : all;
+  const previews = useCollectionPreviewFrames(id as string, hydrated, detail?.previewItems);
   const displayName = title ?? node.name;
 
   return (

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -16,6 +16,7 @@ import {
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 
 import { useClipDetail, useGraphDetailsStore, useTimelineTitle } from "./graph-details-context";
+import { useCollectionPreviewFrames } from "./graph-item-content";
 import { hydrateTimeline } from "./graph-hydration";
 import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
 import { NativeDropGrid, NativeDropStrip } from "./graph-native-drop";
@@ -141,6 +142,8 @@ function SubTimelineNode({
     }
     return total;
   });
+  // Same pair the card shows; empty until an un-hydrated row loads.
+  const previewFrames = useCollectionPreviewFrames(id, hydrated, detail?.previewItems);
   const childIds = useCollectionChildIds(collectionId);
   const status = subTimelineRowStatus({ expanded, hydrated, failed });
 
@@ -218,12 +221,43 @@ function SubTimelineNode({
             {subTimelineRowStatusLabel(status)}
           </span>
         )}
-        {/* No drill-in control here. This row already has the affordance that
-            matters — the folder toggle opens the timeline IN PLACE, which is
-            what the children tree is for — so a second control that navigated
-            AWAY from it was answering a question the row does not ask. The
-            collection CARD keeps its drill button; that is where "go to this
-            timeline" belongs. */}
+        <span className="grow" />
+        {/* DECORATIVE only — no drill-in. This row's affordance is the folder
+            toggle, which opens the timeline in place; a second control that
+            navigated away was answering a question the row does not ask. These
+            frames just say WHICH timeline the row is, which a name alone does
+            not when you are scanning a nested tree.
+            
+            aria-hidden and not focusable, so the row's accessible surface is
+            still exactly its toggle and its name.
+
+            The frames butt directly together and fill the box — no gap, no
+            backing colour showing through as a gutter — and the box is sized
+            to the row's full header height rather than sitting inside it.
+
+            Same first/last pair the card shows, from one shared hook: the row
+            is the tree view of the very cards beside it, so two derivations of
+            "what this timeline looks like" would drift in plain sight. */}
+        <span
+          aria-hidden="true"
+          data-subtimeline-thumbs
+          className="flex h-10 w-[72px] shrink-0 overflow-hidden rounded-sm bg-zinc-950/60"
+        >
+          {previewFrames.map((frame, index) => (
+            // Keyed by SLOT, not content: the pair is order-stable and the
+            // same asset can be both first and last, so a content key would
+            // collide AND remount an already-loaded frame on every child edit.
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              key={index}
+              src={frame.poster ?? frame.src}
+              alt=""
+              draggable={false}
+              loading="lazy"
+              className="h-full min-w-0 flex-1 object-cover"
+            />
+          ))}
+        </span>
       </div>
 
       {expanded && hydrated && (

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useContext, useMemo, useRef, useState } from "react";
-import { FolderInput, Folder, FolderOpen } from "lucide-react";
+import { useMemo, useRef, useState } from "react";
+import { Folder, FolderOpen } from "lucide-react";
 
 import {
   VirtualGrid,
@@ -23,7 +23,6 @@ import {
   subTimelineRowStatus,
   subTimelineRowStatusLabel,
 } from "./graph-sub-timeline-status";
-import { GraphViewNavContext } from "./graph-navigation";
 import {
   GraphGridPlayhead,
   GraphPlayhead,
@@ -100,7 +99,6 @@ function SubTimelineNode({
   rulerOn: boolean;
   timeChannel: PreviewTimeChannel;
 }>) {
-  const nav = useContext(GraphViewNavContext);
   const store = useCollectionsStore();
   const detailsStore = useGraphDetailsStore();
   const spans = usePreviewCardSpans();
@@ -220,21 +218,12 @@ function SubTimelineNode({
             {subTimelineRowStatusLabel(status)}
           </span>
         )}
-        <span className="grow" />
-        <button
-          type="button"
-          aria-label="Drill into timeline"
-          title="Drill into this timeline"
-          onClick={() => nav?.openTimeline(collectionId)}
-          className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
-        >
-          {/* FolderInput — a folder with an arrow going INTO it. This button
-              NAVIGATES; the sidebar's FolderTree toggles whether the children
-              tree is shown. Those are different verbs and no longer share an
-              icon. The collection card's drill button is the same verb as
-              this one and uses the same icon. */}
-          <FolderInput aria-hidden="true" className="h-4 w-4" />
-        </button>
+        {/* No drill-in control here. This row already has the affordance that
+            matters — the folder toggle opens the timeline IN PLACE, which is
+            what the children tree is for — so a second control that navigated
+            AWAY from it was answering a question the row does not ask. The
+            collection CARD keeps its drill button; that is where "go to this
+            timeline" belongs. */}
       </div>
 
       {expanded && hydrated && (

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -40,6 +40,7 @@ import {
   ITEM_SIZE_DIMENSIONS,
   MAX_SUBTREE_DEPTH,
   SUBTIMELINE_INDENT_PX,
+  SUBTIMELINE_PANEL_RIGHT_INSET_PX,
   type FocusSurface,
   type ItemSize,
 } from "./graph-view-config";
@@ -242,6 +243,13 @@ function SubTimelineNode({
           aria-hidden="true"
           data-subtimeline-thumbs
           className="flex h-10 w-[72px] shrink-0 overflow-hidden rounded-sm bg-zinc-950/60"
+          // Cancel the right inset this row's ANCESTOR panels impose, so every
+          // preview in the tree lands on one vertical line however deeply the
+          // row is nested. Without it each level shifted the frames 13px left
+          // and the column read as ragged. The frames deliberately overhang
+          // the nested panels' right edges to get there — that is the point:
+          // they belong to the column, not to the panel they sit in.
+          style={{ marginRight: -(depth * SUBTIMELINE_PANEL_RIGHT_INSET_PX) }}
         >
           {previewFrames.map((frame, index) => (
             // Keyed by SLOT, not content: the pair is order-stable and the

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-config.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-config.ts
@@ -107,3 +107,18 @@ export const FALLBACK_DETAIL: ClipDetail = {
   aspect: 16 / 9,
   trackIndex: 0,
 };
+
+/**
+ * How far each nesting level pushes a sub-timeline row's RIGHT edge inward:
+ * the panel's own `p-3` (12px) plus its 1px border. The left indent
+ * (SUBTIMELINE_INDENT_PX) is what makes the hierarchy readable and is
+ * deliberately NOT cancelled — but the right side accumulating the same way
+ * staggered the rows' preview frames, so a depth-3 row's frames sat 39px left
+ * of a depth-0 row's and the column read as ragged.
+ *
+ * COUPLED to the row panel's `p-3 border` classes in graph-sub-timelines.tsx:
+ * change the padding or border there and this must change with it. It is a
+ * literal because Tailwind needs literal class names, so the two cannot be
+ * derived from one source.
+ */
+export const SUBTIMELINE_PANEL_RIGHT_INSET_PX = 13;


### PR DESCRIPTION
## What

Two changes to the children-timelines tree rows:

1. **Removed** the "Drill into timeline" button.
2. **Added** the collection's first/last frame pair on the right, purely decorative.

The collection **card** is untouched — it keeps both its frames and its drill button.

## Why the drill control goes

The tree exists to open a timeline **in place** — that's what its folder toggle does. A second control that navigated *away* from the tree was answering a question the row doesn't ask, sitting inches from the toggle that does the opposite thing. `nav`, `GraphViewNavContext` and the `FolderInput` import went with it.

## Why the frames are decorative

They answer "which timeline is this?", which a name alone doesn't when you're scanning a nested tree. They are `aria-hidden`, not focusable, not clickable — so the row's accessible surface stays exactly its toggle and its name.

An earlier iteration made them a button with the drill icon centred on top. That was wrong twice over: it put an **action** on an **identity** element (the pictures looked clickable while only the 20px disc was, so the natural click did nothing), and a 20px disc over a 48×28 pair covers about a third of it. The card can carry a centred overlay because a card is big enough for the artwork to survive one; a row is not.

## Sizing

72×40, filling the header's full height, with the two frames butted directly together — no gap, so no backing colour shows through as a gutter and nothing pads the image away from its box.

## One shared derivation

`useCollectionPreviewFrames` now owns "first and last, live once hydrated and the stored summary until then", and both the card and the row call it. These two sit on screen together — the row is the tree view of the very cards beside it — so two copies would drift **visibly**, not theoretically.

Frames are keyed by **slot**, not content: the pair is order-stable and the same asset can be both first and last, so a content key would collide *and* remount an already-loaded frame on every child edit.

## Verification

Live in the running app with the tree expanded: 6 rows, 12 frames all loaded, every slot 72×40 with two 36×40 frames (exactly filling it), all rows sharing one right edge, **0** drill buttons on rows, and all 6 card Open buttons still present. The folder toggle still expands a row and renders its nested children.

`tsc` clean, app lint 0 errors (4 pre-existing `<img>` warnings), app vitest 346/346, card stories 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
