### PR TITLE
Make `dark:` mean this app, not the reader's operating system

### DIFF
--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -4,6 +4,21 @@
 @source "../components";
 @source "../../../packages/ui";
 
+/* This app is dark-ONLY: `color-scheme: dark` below, `html { background:
+   #09090b }`, and every surface hardcoded on the zinc-950 scale. But Tailwind
+   v4's stock `dark:` variant is `@media (prefers-color-scheme: dark)`, so the
+   shadcn primitives copied into components/core (their light values are the
+   BASE, their dark values behind `dark:`) followed the reader's OS instead of
+   the app. On a light-mode machine the trash drawer's Restore buttons painted
+   pure white on a near-black panel, with zinc-300 text on top — invisible.
+   Nobody on a dark-mode machine could see it.
+
+   Rebinding the variant to a class, and putting that class on <html>, makes
+   `dark:` mean "this app" rather than "this operating system" — so every
+   primitive here and every one copied in later resolves to its dark branch
+   deterministically. */
+@custom-variant dark (&:where(.dark, .dark *));
+
 /* Design tokens for the dnd-collections package's own pixels (drop
    indicator, focus rings, ghost chrome — bg-primary, border-border, …).
    Registered `inline` so utilities reference the --gv-* custom properties

--- a/apps/timeline-gstudio001/app/layout.tsx
+++ b/apps/timeline-gstudio001/app/layout.tsx
@@ -12,8 +12,11 @@ export const metadata: Metadata = {
 };
 
 export default function RootLayout({children}: {children: React.ReactNode}) {
+  // `dark` is what switches on every `dark:` utility — the variant is rebound
+  // to this class in globals.css, precisely so the app stops following the
+  // reader's OS theme.
   return (
-    <html lang="en">
+    <html lang="en" className="dark">
       <body suppressHydrationWarning>
         {/* App-wide: the sidebar renders on every route, so anything it
             toasts needs a surface here rather than inside one view. */}


### PR DESCRIPTION
## The bug

The trash drawer's buttons render **pure white on a near-black panel** for anyone whose OS is in light mode.

| | |
|---|---|
| drawer background | `oklch(0.141…)` (zinc-950) |
| Restore button background | `rgb(255, 255, 255)` |
| Restore text | zinc-300 on white — close to unreadable |

## Why it survived

The app is dark-**only**: `color-scheme: dark`, `html { background: #09090b }`, every surface hardcoded on the zinc scale. But Tailwind v4's stock `dark:` variant is `@media (prefers-color-scheme: dark)`, and the shadcn primitives copied into `components/core` carry their **light** values as the base with dark behind `dark:`:

```
border bg-white shadow-sm … dark:border-zinc-800 dark:bg-zinc-950
```

So the primitives followed the *reader's OS* while everything around them followed the *app*. It's invisible to anyone on a dark-mode machine — which is precisely why it went unnoticed.

## The fix

Rebind the variant to a class and put that class on `<html>`:

```css
@custom-variant dark (&:where(.dark, .dark *));
```

Now `dark:` means "this app" rather than "this operating system", so every primitive — present and future — resolves to its dark branch deterministically.

## Verification

Measured in a browser reporting `prefers-color-scheme: light`, i.e. the condition that caused it:

| | before | after |
|---|---|---|
| `html` class | (none) | `dark` |
| Restore bg | `rgb(255,255,255)` | `oklch(0.141 0.005 285.823)` |
| Empty Trash bg | `rgb(255,255,255)` | `oklch(0.141 0.005 285.823)` |

The buttons now match the panel exactly. **Dark-mode readers see no change** — `dark:` was already winning for them.

Blast radius is small and checked: exactly one component uses `dark:` today (`components/core/button.tsx`, 17 occurrences) and nothing set a `.dark` class anywhere.

`tsc` clean, app lint 0 errors, app vitest 346/346, card stories 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
