### PR TITLE
Record when a clip was trashed, and which timeline it came from

### DIFF
--- a/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
+++ b/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
@@ -12,6 +12,7 @@ import {
 import { usePathname } from "next/navigation";
 
 import { Button } from "@/components/core/button";
+import { trashRowCaption } from "@/lib/trash-provenance";
 import { useAuth } from "@/components/auth/auth-provider";
 import {
   GRAPH_RESTORE_RESULT_EVENT,
@@ -278,9 +279,24 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
                     )}
                   </div>
                   <div className="mt-2 flex min-w-0 items-center gap-2">
-                    <p className="min-w-0 flex-1 truncate text-xs font-semibold text-zinc-200">
-                      {(clip as any).title || clip.alt || "Clip"}
-                    </p>
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-xs font-semibold text-zinc-200">
+                        {(clip as any).title || clip.alt || "Clip"}
+                      </p>
+                      {/* Where it came from and when it went. Two clips can be
+                          identical in every field the drawer paints — same
+                          name, same thumbnail, same duration — because placing
+                          one asset twice is ordinary and duplicating a clip
+                          copies its src verbatim. This caption is the only
+                          thing that tells those rows apart. Absent on clips
+                          trashed before it was recorded, and the row then
+                          simply prints nothing rather than an empty line. */}
+                      {trashRowCaption(clip.trashedFrom, clip.trashedAt) && (
+                        <p className="truncate text-[10px] text-zinc-500">
+                          {trashRowCaption(clip.trashedFrom, clip.trashedAt)}
+                        </p>
+                      )}
+                    </div>
                     {canRestore && (
                       <Button
                         type="button"

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
@@ -322,6 +322,22 @@ export function GraphItemActionsBridge({
         snapshot.interaction.selectedIds,
         focusedId,
       );
+      // Clear the trash stamp BEFORE dispatching, for the same reason the
+      // stamp is WRITTEN before its dispatch: the persistence bridge writes
+      // the affected documents from its `subscribeToChanges` callback, which
+      // runs during the dispatch. Clearing afterwards updates the in-memory
+      // table but misses the write, so the restored clip lands back in its
+      // timeline still carrying "deleted from X, 2h ago" — stale metadata on
+      // a live clip, and a wrong date the next time it IS deleted.
+      const stampedDetail = details.get(nodeId as string);
+      const hadStamp =
+        stampedDetail !== undefined &&
+        (stampedDetail.trashedAt !== undefined || stampedDetail.trashedFrom !== undefined);
+      if (hadStamp && stampedDetail) {
+        const { trashedAt: _at, trashedFrom: _from, ...rest } = stampedDetail;
+        details.merge({ [nodeId as string]: rest });
+      }
+
       const dispatched = store.dispatch({
         type: "move-nodes",
         nodeIds: [nodeId],
@@ -329,8 +345,12 @@ export function GraphItemActionsBridge({
         toIndex,
       });
       // A refusal already speaks through the commandPolicy's own toast; the
-      // drawer only needs to know the row is still trashed.
-      if (!dispatched.ok) return answer(false, "Couldn't restore that item here.");
+      // drawer only needs to know the row is still trashed. Put the stamp
+      // back with it — the clip is still in the bin, so it must still say so.
+      if (!dispatched.ok) {
+        if (hadStamp && stampedDetail) details.merge({ [nodeId as string]: stampedDetail });
+        return answer(false, "Couldn't restore that item here.");
+      }
 
       const name = graph.nodesById.get(nodeId)?.name ?? "Item";
       const target = graph.nodesById.get(parentId)?.name ?? "this timeline";
@@ -441,7 +461,7 @@ export function GraphItemActionsBridge({
       // mid-capture makes moveSelectionToTrash a no-op (returns 0, isDragging),
       // and clearing anyway would leave Cut silently behaving like Copy —
       // clipboard set, nothing trashed, selection gone.
-      const moved = moveSelectionToTrash(store, trashId, selected);
+      const moved = moveSelectionToTrash(store, trashId, selected, details);
       if (moved > 0) store.clearSelection();
     };
 
@@ -485,7 +505,7 @@ export function GraphItemActionsBridge({
           void runExclusive(duplicateSelection);
           break;
         case "delete":
-          moveSelectionToTrash(store, trashId);
+          moveSelectionToTrash(store, trashId, undefined, details);
           store.clearSelection();
           break;
         case "toggle-disabled": {

--- a/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
@@ -16,6 +16,10 @@ import {
 import { toast } from "@/components/core/sonner";
 import { requestGraphRenameItem } from "@/lib/graph-view-events";
 
+import type { ClipDetail } from "@storyboard/timeline-domain";
+
+import type { GraphDetailsStore } from "@/lib/graph-details-store";
+
 import { useGraphDetailsStore } from "./graph-details-context";
 
 type GraphViewNav = Readonly<{
@@ -120,6 +124,11 @@ export function moveSelectionToTrash(
   // selection here would trash whatever the user selected in the meantime,
   // not what they cut). Defaults to the live selection for the keyboard path.
   ids?: readonly NodeId[],
+  // Optional: when supplied, each trashed clip is stamped with WHEN it went to
+  // the bin and WHICH timeline it came from. Optional rather than required so
+  // the trash move works unchanged from any call site that has no details
+  // store — provenance is a nicety, never a precondition for deleting.
+  details?: GraphDetailsStore,
 ): number {
   if (trashId === null || store.getSnapshot().interaction.isDragging) return 0;
   const { graph, interaction } = store.getSnapshot();
@@ -128,6 +137,36 @@ export function moveSelectionToTrash(
   const trash = parseNodeId(trashId);
   const movable = selected.filter((nodeId) => resolveTrashCommand(graph, nodeId, trash).ok);
   if (movable.length === 0) return 0;
+
+  // Stamp BEFORE dispatching: the persistence bridge writes the affected
+  // documents from its `subscribeToChanges` callback, reading the details
+  // table as it stands then — so a stamp applied after the dispatch would
+  // miss the very write it is meant to ride. The parent is read here for the
+  // same reason: after the move it IS the trash.
+  const previousDetails: Record<string, ClipDetail> = {};
+  if (details) {
+    const trashedAt = new Date().toISOString();
+    const stamped: Record<string, ClipDetail> = {};
+    for (const nodeId of movable) {
+      const existing = details.get(nodeId as string);
+      // No detail entry means nothing to merge INTO — every graph node built
+      // from a document has one, so this is the "shouldn't happen" branch
+      // rather than a case worth inventing defaults for.
+      if (!existing) continue;
+      previousDetails[nodeId as string] = existing;
+      const parentId = graph.parentById.get(nodeId) ?? null;
+      const title = parentId === null ? undefined : graph.nodesById.get(parentId)?.name;
+      stamped[nodeId as string] = {
+        ...existing,
+        trashedAt,
+        ...(parentId !== null && title
+          ? { trashedFrom: { timelineId: parentId as string, title } }
+          : {}),
+      };
+    }
+    details.merge(stamped);
+  }
+
   const dispatched = store.dispatch({
     type: "move-nodes",
     nodeIds: movable,
@@ -135,8 +174,12 @@ export function moveSelectionToTrash(
     toIndex: getChildren(graph, trash).length,
   });
   // A refusal (the un-hydrated-target policy, a cycle) already speaks through
-  // the commandPolicy's own toast — announce only what landed.
-  if (!dispatched.ok) return 0;
+  // the commandPolicy's own toast — announce only what landed. Roll the stamp
+  // back with it: nothing was trashed, so nothing may claim to have been.
+  if (!dispatched.ok) {
+    if (details && Object.keys(previousDetails).length > 0) details.merge(previousDetails);
+    return 0;
+  }
   toast(`Moved ${movable.length} item${movable.length === 1 ? "" : "s"} to trash.`, {
     id: "graph-delete-to-trash",
   });
@@ -195,7 +238,7 @@ export function OpenKeyBoundary({
     if (trashId === null || store.getSnapshot().interaction.isDragging) return;
     if (store.getSnapshot().interaction.selectedIds.size === 0) return;
     event.preventDefault();
-    moveSelectionToTrash(store, trashId);
+    moveSelectionToTrash(store, trashId, undefined, detailsStore);
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {

--- a/apps/timeline-gstudio001/lib/trash-provenance.test.ts
+++ b/apps/timeline-gstudio001/lib/trash-provenance.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { formatTrashedAgo, trashRowCaption } from "./trash-provenance";
+
+const NOW = new Date("2026-07-25T12:00:00.000Z");
+const ago = (ms: number) => new Date(NOW.getTime() - ms).toISOString();
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+describe("formatTrashedAgo", () => {
+  it("drops resolution as the age grows", () => {
+    expect(formatTrashedAgo(ago(5 * SECOND), NOW)).toBe("just now");
+    expect(formatTrashedAgo(ago(59 * SECOND), NOW)).toBe("just now");
+    expect(formatTrashedAgo(ago(MINUTE), NOW)).toBe("1m ago");
+    expect(formatTrashedAgo(ago(59 * MINUTE), NOW)).toBe("59m ago");
+    expect(formatTrashedAgo(ago(HOUR), NOW)).toBe("1h ago");
+    expect(formatTrashedAgo(ago(23 * HOUR), NOW)).toBe("23h ago");
+    expect(formatTrashedAgo(ago(DAY), NOW)).toBe("1d ago");
+    expect(formatTrashedAgo(ago(7 * DAY), NOW)).toBe("7d ago");
+  });
+
+  it("switches to a date past a week, rather than making the reader do arithmetic", () => {
+    const old = formatTrashedAgo(ago(23 * DAY), NOW);
+    expect(old).not.toMatch(/ago/);
+    expect(old).toBeTruthy();
+  });
+
+  it("reads a FUTURE stamp as 'just now' instead of negative time", () => {
+    // Clock skew between the client that wrote it and the one reading it is
+    // ordinary; "-3m ago" is not.
+    const future = new Date(NOW.getTime() + 3 * MINUTE).toISOString();
+    expect(formatTrashedAgo(future, NOW)).toBe("just now");
+  });
+
+  it("degrades to null on absent or unparseable input rather than throwing", () => {
+    expect(formatTrashedAgo(undefined, NOW)).toBeNull();
+    expect(formatTrashedAgo("", NOW)).toBeNull();
+    expect(formatTrashedAgo("not a date", NOW)).toBeNull();
+  });
+});
+
+describe("trashRowCaption", () => {
+  it("joins both halves, and prints the separator ONLY between two", () => {
+    expect(trashRowCaption({ title: "Bank Heist" }, ago(2 * HOUR), NOW)).toBe(
+      "from Bank Heist · 2h ago",
+    );
+    expect(trashRowCaption({ title: "Bank Heist" }, undefined, NOW)).toBe("from Bank Heist");
+    expect(trashRowCaption(undefined, ago(2 * HOUR), NOW)).toBe("2h ago");
+  });
+
+  it("is null when neither half is known, so the row prints nothing", () => {
+    // Clips trashed before provenance was recorded land here — the drawer must
+    // show them normally, not with an empty caption line.
+    expect(trashRowCaption(undefined, undefined, NOW)).toBeNull();
+    expect(trashRowCaption({ title: "" }, undefined, NOW)).toBeNull();
+  });
+});

--- a/apps/timeline-gstudio001/lib/trash-provenance.ts
+++ b/apps/timeline-gstudio001/lib/trash-provenance.ts
@@ -1,0 +1,56 @@
+/**
+ * How long ago a clip was trashed, for the trash drawer's row caption.
+ *
+ * Coarse on purpose. The question a person asks in the bin is "was this the
+ * thing I just deleted, or something from last week?" — minutes matter for the
+ * first hour and stop mattering entirely after that, so the resolution drops
+ * as the age grows rather than printing "2 days, 4 hours" precision nobody
+ * acts on. Past a week it switches to a date, because "23d ago" is arithmetic
+ * the reader has to do.
+ *
+ * Pure and total: it runs against stored data, so a missing or unparseable
+ * timestamp returns null and the caller simply prints nothing. A FUTURE
+ * timestamp (clock skew between the writing client and the reading one, which
+ * is a different machine often enough) reads as "just now" rather than
+ * "-3m ago".
+ */
+export function formatTrashedAgo(
+  trashedAt: string | undefined,
+  now: Date = new Date(),
+): string | null {
+  if (!trashedAt) return null;
+  const then = new Date(trashedAt);
+  const thenMs = then.getTime();
+  if (Number.isNaN(thenMs)) return null;
+
+  const seconds = Math.floor((now.getTime() - thenMs) / 1000);
+  if (seconds < 60) return "just now";
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  if (days <= 7) return `${days}d ago`;
+
+  return then.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+/**
+ * The whole caption: where it came from, when it went. Either half may be
+ * missing — clips trashed before this was recorded have neither, and a clip
+ * trashed from a timeline whose name could not be read has only the time — so
+ * the separator is only printed between two halves that both exist.
+ */
+export function trashRowCaption(
+  trashedFrom: { title: string } | undefined,
+  trashedAt: string | undefined,
+  now?: Date,
+): string | null {
+  const when = formatTrashedAgo(trashedAt, now);
+  const where = trashedFrom?.title ? `from ${trashedFrom.title}` : null;
+  if (where && when) return `${where} · ${when}`;
+  return where ?? when;
+}

--- a/packages/timeline-domain/src/adapter.test.ts
+++ b/packages/timeline-domain/src/adapter.test.ts
@@ -343,6 +343,31 @@ describe("graphChildrenToClips (round-trip)", () => {
       controlClips.map((c) => [c.id, c.index, c.startTime, c.duration]),
     );
   });
+
+  it("round-trips trash provenance through the details side-table", () => {
+    // Same seam as sourceAsset: the engine never models "when was this
+    // deleted", so hydration must park it and the write path must put it back
+    // — and must NOT invent it on clips that never had it.
+    const trashedAt = "2026-07-25T12:00:00.000Z";
+    const trashedFrom = { timelineId: "bank-heist", title: "Bank Heist" };
+    const doc: TimelineDocument = {
+      id: "trash-root",
+      title: "Trash",
+      clips: packTimelineClips([
+        { ...image("deleted", 4), trashedAt, trashedFrom },
+        image("never-trashed", 4),
+      ]),
+    };
+    const result = buildFocusedGraph({ "trash-root": doc }, "trash-root");
+    if (!result.ok) throw new Error(result.error);
+    expect(result.value.details["deleted"]?.trashedAt).toBe(trashedAt);
+    expect(result.value.details["deleted"]?.trashedFrom).toEqual(trashedFrom);
+
+    const projected = graphChildrenToClips(result.value.graph, result.value.details, "trash-root");
+    expect(projected[0]).toMatchObject({ id: "deleted", trashedAt, trashedFrom });
+    expect("trashedAt" in projected[1]).toBe(false);
+    expect("trashedFrom" in projected[1]).toBe(false);
+  });
 });
 
 describe("against the app's real initial documents", () => {

--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -35,6 +35,7 @@ import type {
   CollectionTimelineClip,
   TimelineClip,
   TimelineDocument,
+  TrashOrigin,
 } from "@storyboard/timeline-model/types";
 
 import {
@@ -70,6 +71,11 @@ export type ClipDetail = Readonly<{
   /** Which asset-provider file this media clip came from — pure provenance
    *  (the engine never reads it), round-tripped like poster. */
   sourceAsset?: AssetSourceRef;
+  /** When this clip was trashed, and from where. Provenance again: the engine
+   *  never reads it, so it rides the side-table rather than the graph node —
+   *  the same seam `sourceAsset` uses, and for the same reason. */
+  trashedAt?: string;
+  trashedFrom?: TrashOrigin;
   itemCount?: number;
   previewItems?: CollectionTimelineClip["previewItems"];
   /** The collection clip's own display duration in its parent timeline. */
@@ -133,6 +139,8 @@ function mediaDetail(clip: Exclude<TimelineClip, CollectionTimelineClip>): ClipD
     trackIndex: clip.trackIndex,
     ...(clip.poster === undefined ? {} : { poster: clip.poster }),
     ...(clip.sourceAsset === undefined ? {} : { sourceAsset: clip.sourceAsset }),
+    ...(clip.trashedAt === undefined ? {} : { trashedAt: clip.trashedAt }),
+    ...(clip.trashedFrom === undefined ? {} : { trashedFrom: clip.trashedFrom }),
     ...(clip.playbackStartTime === undefined ? {} : { playbackStartTime: clip.playbackStartTime }),
     ...(clip.playbackDuration === undefined ? {} : { playbackDuration: clip.playbackDuration }),
     ...(clip.kind === "image"
@@ -146,6 +154,8 @@ function collectionDetail(clip: CollectionTimelineClip, hydrated: boolean): Clip
     alt: clip.alt,
     aspect: clip.aspect,
     trackIndex: clip.trackIndex,
+    ...(clip.trashedAt === undefined ? {} : { trashedAt: clip.trashedAt }),
+    ...(clip.trashedFrom === undefined ? {} : { trashedFrom: clip.trashedFrom }),
     sourceClipId: clip.id,
     itemCount: clip.itemCount,
     ...(clip.previewItems === undefined ? {} : { previewItems: clip.previewItems }),
@@ -476,6 +486,8 @@ export function graphChildrenToClips(
           ? {}
           : { playbackDuration: detail.playbackDuration }),
         ...(detail?.sourceAsset === undefined ? {} : { sourceAsset: detail.sourceAsset }),
+        ...(detail?.trashedAt === undefined ? {} : { trashedAt: detail.trashedAt }),
+        ...(detail?.trashedFrom === undefined ? {} : { trashedFrom: detail.trashedFrom }),
         // Read from the NODE, not `detail`: disabling goes through a graph
         // command, so the flag rides the patch/undo path like a rename does.
         ...(node.disabled ? { disabled: true } : {}),
@@ -539,6 +551,8 @@ export function graphChildrenToClips(
       trimIn: detail?.trimIn ?? 0,
       trimOut: detail?.trimOut ?? 0,
       ...(node.disabled ? { disabled: true } : {}),
+      ...(detail?.trashedAt === undefined ? {} : { trashedAt: detail.trashedAt }),
+      ...(detail?.trashedFrom === undefined ? {} : { trashedFrom: detail.trashedFrom }),
     };
   });
 }

--- a/packages/timeline-model/types.ts
+++ b/packages/timeline-model/types.ts
@@ -39,6 +39,12 @@ export type TimelineItemBase = {
    * `false`, so documents that never use the feature never grow the field.
    */
   disabled?: boolean;
+  /** ISO instant this clip was moved to trash. Absent on every live clip —
+   *  its presence IS the record that a clip is in the bin, which is why it is
+   *  cleared on restore rather than left as stale metadata. */
+  trashedAt?: string;
+  /** Which timeline this clip was deleted from. See {@link TrashOrigin}. */
+  trashedFrom?: TrashOrigin;
   /** Optional unscaled timeline position used when visual width differs from playback time. */
   playbackStartTime?: number;
   /** Optional unscaled playback duration used when visual width differs from playback time. */
@@ -70,6 +76,20 @@ export type TimelineItemBase = {
 export type AssetSourceRef = {
   providerId: string;
   assetId: string;
+};
+
+/** Where a clip was deleted FROM, and when. Written when a clip moves to
+ *  trash; cleared when it is restored.
+ *
+ *  The title is a SNAPSHOT, not a lookup key: it is what the trash drawer
+ *  prints, and it has to keep printing after the origin timeline is renamed or
+ *  itself deleted — which is exactly when someone is digging through the trash.
+ *  The id rides along for re-linking later (restore-to-origin), the same
+ *  division of labour as `sourceAsset`: the id is what it IS, the snapshot is
+ *  how it READS. */
+export type TrashOrigin = {
+  timelineId: string;
+  title: string;
 };
 
 export type ImageTimelineClip = TimelineItemBase & {

--- a/packages/timeline-model/validate.ts
+++ b/packages/timeline-model/validate.ts
@@ -36,6 +36,21 @@ function isOptionalAssetSourceRef(value: unknown): boolean {
   );
 }
 
+/** Same null leniency as every optional field; when present BOTH halves must
+ *  be non-empty strings — a half-recorded origin prints as "from " in the
+ *  drawer, which is worse than printing nothing. */
+function isOptionalTrashOrigin(value: unknown): boolean {
+  if (value == null) return true;
+  if (typeof value !== "object") return false;
+  const origin = value as Record<string, unknown>;
+  return (
+    typeof origin.timelineId === "string" &&
+    origin.timelineId.length > 0 &&
+    typeof origin.title === "string" &&
+    origin.title.length > 0
+  );
+}
+
 function hasClipBase(clip: Record<string, unknown>): boolean {
   return (
     typeof clip.id === "string" &&
@@ -55,7 +70,9 @@ function hasClipBase(clip: Record<string, unknown>): boolean {
     // truthy non-boolean would be read as "skip this clip" by the playback
     // and summary passes — a stored string "false" would silently drop a
     // clip from the timeline.
-    (clip.disabled === undefined || typeof clip.disabled === "boolean")
+    (clip.disabled === undefined || typeof clip.disabled === "boolean") &&
+    isOptionalString(clip.trashedAt) &&
+    isOptionalTrashOrigin(clip.trashedFrom)
   );
 }
 


### PR DESCRIPTION
## What

The trash couldn't tell two rows apart. Deleting a clip and its duplicate gives two entries **identical in every painted field** — same name, same thumbnail, same duration — because placing one asset twice is ordinary and duplicating a clip copies its `src` verbatim.

Each clip now records `trashedAt` and `trashedFrom` when it goes to the bin, and the drawer prints a caption under the name:

```
South_Asian_woman_in_alley_202606170902-1782651761356
from My Foobar 002 · just now
```

Clips trashed before this existed have neither and print **nothing** — not an empty line.

## Design

**The title is a snapshot, not a lookup key.** It has to keep printing after the origin timeline is renamed or deleted, which is exactly when someone is digging through the trash. The id rides along for a future restore-to-origin — the same division of labour as `sourceAsset`.

**Both fields ride the details side-table**, not the graph node. The engine never reads them, which is precisely the seam `sourceAsset` uses. (Contrast `disabled`, which had to be a graph command because it needed undo.)

## Ordering is the whole trick — and I got it wrong once

The persistence bridge writes affected documents from its `subscribeToChanges` callback, which runs **during** the dispatch. So the stamp must be applied *before* the trash move and cleared *before* the restore move.

My first version cleared it **after** the restore dispatch. The in-memory table updated, but the write had already gone — so a restored clip landed back in its timeline still claiming to have been deleted, and would have shown a stale date the next time it was binned.

I only caught it by inspecting the restored clip in the running app; the code read fine. Both paths now also roll their change back if the dispatch is refused, so nothing claims to have been trashed when nothing was.

## Verified end-to-end on the real project

| step | result |
|---|---|
| delete | `trashedAt 2026-07-26T00:47:33.965Z`, `trashedFrom "My Foobar 002"` |
| drawer | renders `from My Foobar 002 · just now`; the three older rows print nothing |
| restore | both fields cleared, **no `trashed*` keys remain** |

The project is back to its original state — the clip is live again and the trash holds the same 3 items it started with.

## Tests (+7)

The relative-time formatter (coarsening buckets, a **future** stamp reading as "just now" rather than negative time under clock skew, unparseable input degrading to `null`) and an adapter round-trip proving the fields survive the side-table and stay absent on clips that never had them.

One honest gap: the ordering bug above has no regression test. It lives in a React effect wired to the store, and this app's vitest can't parse `.tsx` — so it's covered by the end-to-end check above, not by a unit test.

## Verification

`tsc` clean, app lint 0 errors (4 pre-existing `<img>` warnings), app vitest 352/352, unit 367/367, storybook 153/153. Includes a merge of `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
