### PR TITLE
Move the trash drawer's messages onto sonner

### DIFF
--- a/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
+++ b/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
@@ -12,6 +12,7 @@ import {
 import { usePathname } from "next/navigation";
 
 import { Button } from "@/components/core/button";
+import { toast } from "@/components/core/sonner";
 import { trashRowCaption } from "@/lib/trash-provenance";
 import { useAuth } from "@/components/auth/auth-provider";
 import {
@@ -123,9 +124,13 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
           return [...current.slice(0, index), ...current.slice(index + 1)];
         });
       }
-      window.dispatchEvent(
-        new CustomEvent("gstudio-toast", { detail: { message: detail.message } }),
-      );
+      // Sonner, like every other surface in the app. This used to dispatch a
+      // bespoke `gstudio-toast` event that the sidebar rendered as its own
+      // fixed pill — see the commit that removed it: the sidebar has
+      // `backdrop-filter`, which makes it a containing block for `position:
+      // fixed`, so that pill resolved `left: 50%` against a 72px rail and
+      // hung half off the left edge of the screen.
+      toast(detail.message, { id: `trash-restore-${detail.clipId}` });
     };
     window.addEventListener(GRAPH_RESTORE_RESULT_EVENT, onResult);
     return () => window.removeEventListener(GRAPH_RESTORE_RESULT_EVENT, onResult);
@@ -158,11 +163,7 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
       // on the next commit that touches the trash. Tell it to rebuild.
       announceGraphTrashEmptied();
 
-      window.dispatchEvent(
-        new CustomEvent("gstudio-toast", {
-          detail: { message: "Trash bin emptied successfully" }
-        })
-      );
+      toast("Trash bin emptied.", { id: "trash-emptied" });
     } catch (err) {
       console.error(err);
       setError("Unable to empty trash.");

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -357,7 +357,6 @@ export function TimelineSidebar() {
       document.removeEventListener("touchstart", handleClickOutside);
     };
   }, [isProfileOpen]);
-  const [toastMessage, setToastMessage] = useState<string | null>(null);
   const pathSegments = pathname.split("/").filter(Boolean);
   const activeProjectId =
     pathSegments[0] === "timeline" && pathSegments[1]?.startsWith("project-")
@@ -384,24 +383,6 @@ export function TimelineSidebar() {
     };
     window.addEventListener(GRAPH_VIEW_STATE_EVENT, onState);
     return () => window.removeEventListener(GRAPH_VIEW_STATE_EVENT, onState);
-  }, []);
-
-  useEffect(() => {
-    if (!toastMessage) return;
-    const timer = setTimeout(() => {
-      setToastMessage(null);
-    }, 4000);
-    return () => clearTimeout(timer);
-  }, [toastMessage]);
-
-  useEffect(() => {
-    const handleToastEvent = (e: any) => {
-      if (e.detail?.message) {
-        setToastMessage(e.detail.message);
-      }
-    };
-    window.addEventListener("gstudio-toast" as any, handleToastEvent);
-    return () => window.removeEventListener("gstudio-toast" as any, handleToastEvent);
   }, []);
 
   // A drag just dropped items into the graph's sidebar trash target — play
@@ -475,9 +456,9 @@ export function TimelineSidebar() {
   const handleLogout = async () => {
     try {
       await logout();
-      setToastMessage("Signed out.");
+      toast("Signed out.", { id: "auth-signed-out" });
     } catch {
-      setToastMessage("Unable to sign out.");
+      toast("Unable to sign out.", { id: "auth-signed-out" });
     }
   };
 
@@ -641,9 +622,7 @@ export function TimelineSidebar() {
                 }
               : item.id === "trash"
                 ? () => setIsTrashOpen(!isTrashOpen)
-                : // Placeholder until real settings exist — and the app's
-                  // first sonner-driven surface, next to the legacy
-                  // `gstudio-toast` pill the trash drawer still uses.
+                : // Placeholder until real settings exist.
                   () =>
                     toast("Settings", {
                       description: "App-wide settings aren’t wired up yet.",
@@ -762,19 +741,6 @@ export function TimelineSidebar() {
       />
 
       <style>{`
-        @keyframes slideDown {
-          from {
-            transform: translate(-50%, -20px);
-            opacity: 0;
-          }
-          to {
-            transform: translate(-50%, 0);
-            opacity: 1;
-          }
-        }
-        .timeline-toast-animate {
-          animation: slideDown 0.35s cubic-bezier(0.16, 1, 0.3, 1) forwards;
-        }
         @keyframes slideInLeft {
           from {
             transform: translateX(-8px);
@@ -790,25 +756,6 @@ export function TimelineSidebar() {
         }
       `}</style>
 
-      {toastMessage && (
-        <div
-          role="status"
-          aria-live="polite"
-          style={{
-            position: "fixed",
-            top: "24px",
-            left: "50%",
-            transform: "translateX(-50%)",
-            zIndex: 10000,
-          }}
-          className="timeline-toast-animate flex h-10 items-center gap-2.5 rounded-full border border-sky-500/30 bg-zinc-900/95 px-5 text-xs font-medium text-zinc-100 shadow-2xl backdrop-blur-md select-none"
-        >
-          <Layers className="h-3.5 w-3.5 text-sky-400 shrink-0" aria-hidden="true" />
-          <span className="text-zinc-200">
-            {toastMessage}
-          </span>
-        </div>
-      )}
     </aside>
   );
 }


### PR DESCRIPTION
## The bug

Restoring from the trash showed its message **half off the left edge of the screen**.

It was written to be top-centre:

```
position: fixed; top: 24px; left: 50%; transform: translateX(-50%);
```

But it rendered inside the sidebar `<aside>`, which has `backdrop-filter: blur(12px)` — and **a backdrop-filter makes an element a containing block for `position: fixed` descendants**. So `left: 50%` resolved against a 72px rail instead of the viewport:

```
36px (half the rail) − 56.5px (half the pill) = −20.5px
```

Measured at **x = −21** in a 1361px viewport.

## And no, it wasn't sonner

Every other surface in the app already used sonner. This was the one holdout — the code called it "the legacy `gstudio-toast` pill" itself.

It's gone entirely: the custom event, the sidebar's listener, its state, its 4-second dismissal timer, the `slideDown` keyframes, and the markup. The drawer calls `toast()` directly, as does the sign-out path that turned out to be the pill's only other caller. Toast ids are set per message so a double restore replaces rather than stacks.

## Verification

Fired the `graph-view:restore-result` event the graph actually sends after a restore:

| | before | after |
|---|---|---|
| position | x = **−21**, y = 24 | x = 981, y = 847 |
| where that is | half off the left edge | bottom-right, with every other toast |
| legacy pills rendered | 1 | **0** |

`tsc` clean, app lint 0 errors (4 pre-existing `<img>` warnings), app vitest 352/352, storybook 153/153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
