### PR TITLE
Paginate the asset palette instead of stopping at 48

### DIFF
--- a/apps/timeline-gstudio001/app/api/assets/route.ts
+++ b/apps/timeline-gstudio001/app/api/assets/route.ts
@@ -63,6 +63,10 @@ export async function GET(request: Request) {
             ? { folder: folderSegments }
             : {}),
       ...(Number.isFinite(limitParam) && limitParam > 0 ? { limit: limitParam } : {}),
+      // Opaque to this route on purpose: only the provider knows what its own
+      // cursor means (an offset for the path-derived ones, a backend token
+      // for anything that pushes paging down).
+      ...(url.searchParams.get("cursor") ? { cursor: url.searchParams.get("cursor")! } : {}),
     };
 
     const page = await provider.list({ uid: user.uid }, query);

--- a/apps/timeline-gstudio001/components/graph-view/graph-asset-palette.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-asset-palette.tsx
@@ -20,7 +20,18 @@ import { clearPendingDetails, parkPendingDetail } from "./graph-pending-details"
 
 const DEFAULT_IMAGE_SECONDS = 4;
 const DEFAULT_VIDEO_SECONDS = 8;
-const PALETTE_ASSET_LIMIT = 48;
+/**
+ * How many assets one request fetches — a PAGE SIZE now, not the cap it used
+ * to be. The old 48 was the whole story: the rail showed 48 and said the rest
+ * was elsewhere. With a cursor there is no "rest", so the number is free to
+ * be small.
+ *
+ * Small on purpose. The first page is what the user waits for, and a dozen
+ * tiles already fill a horizontal rail past its scroll edge — fetching four
+ * times that to satisfy a scroll most people never make costs everyone the
+ * wait. "Load more" is one click for the minority who go looking.
+ */
+const PALETTE_PAGE_SIZE = 12;
 
 function createNodeFromAsset(asset: Asset): CollectionItemNode {
   clearPendingDetails();
@@ -70,7 +81,10 @@ function createNodeFromAsset(asset: Asset): CollectionItemNode {
 type PalettePage = Readonly<{
   assets: readonly Asset[];
   folders: readonly AssetFolder[];
-  truncated: boolean;
+  /** The provider's cursor for the NEXT page, absent when this is the last.
+   *  Replaces the old `truncated` boolean, which could only announce that
+   *  there was more and never reach it. */
+  nextCursor?: string;
 }>;
 
 /** What the picker needs from /api/assets/providers. */
@@ -321,6 +335,66 @@ export function AssetPaletteDrawer({
     [],
   );
 
+  // Both the first fetch and every "load more" go through this, so the
+  // search-vs-browse param rules cannot drift between them — that divergence
+  // would be invisible until a paged search silently started browsing.
+  const requestParams = useCallback(
+    (cursor?: string) => {
+      const params = searchTerm
+        ? new URLSearchParams({ q: searchTerm })
+        : mode === "tags"
+          ? new URLSearchParams({ mode: "tags" })
+          : new URLSearchParams({ browse: "1" });
+      params.set("limit", String(PALETTE_PAGE_SIZE));
+      if (providerId !== null) params.set("provider", providerId);
+      if (!searchTerm) {
+        for (const segment of path) params.append(mode === "tags" ? "tag" : "folder", segment);
+      }
+      if (cursor !== undefined) params.set("cursor", cursor);
+      return params;
+    },
+    [searchTerm, mode, providerId, path],
+  );
+
+  // Appending, not replacing: the rail keeps everything already loaded so a
+  // second page never costs the user their scroll position or the tile they
+  // were reaching for. Its own flag rather than the shared `loading` status,
+  // which swaps the whole rail for skeletons — that would be a worse answer
+  // to "show me more" than showing nothing at all.
+  const [loadingMore, setLoadingMore] = useState(false);
+  const loadMore = useCallback(async () => {
+    const cursor = state.status === "ready" ? state.nextCursor : undefined;
+    if (cursor === undefined || loadingMore) return;
+    setLoadingMore(true);
+    try {
+      const response = await fetch(`/api/assets?${requestParams(cursor)}`, { cache: "no-store" });
+      const result = (await response.json().catch(() => ({}))) as {
+        assets?: Asset[];
+        nextCursor?: string;
+      };
+      if (!response.ok || !result.assets) return;
+      setState((current) => {
+        // The page the user was on may have been replaced while this was in
+        // flight (they searched, navigated, switched provider). Appending
+        // then would splice one folder's assets onto another's.
+        if (current.status !== "ready" || current.nextCursor !== cursor) return current;
+        const merged: PalettePage = {
+          assets: [...current.assets, ...result.assets!],
+          folders: current.folders,
+          ...(result.nextCursor === undefined ? {} : { nextCursor: result.nextCursor }),
+        };
+        pageCacheRef.current.set(cacheKey(providerId, mode, path, searchTerm), merged);
+        return { status: "ready", ...merged };
+      });
+    } catch {
+      // Silent: the rail still shows every asset already loaded, and the
+      // button stays for a retry. An error banner would replace content the
+      // user can still use.
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [state, loadingMore, requestParams, cacheKey, providerId, mode, path, searchTerm]);
+
   const navigateTo = useCallback(
     (next: readonly string[], nextMode?: BrowseMode) => {
       const targetMode = nextMode ?? mode;
@@ -399,20 +473,12 @@ export function AssetPaletteDrawer({
         // A search is library-wide and carries no place: no browse, no
         // folder/tag params. The route treats a blank `q` as "not searching",
         // so clearing the box returns to exactly the browse that was showing.
-        const params = searchTerm
-          ? new URLSearchParams({ q: searchTerm })
-          : mode === "tags"
-            ? new URLSearchParams({ mode: "tags" })
-            : new URLSearchParams({ browse: "1" });
-        if (providerId !== null) params.set("provider", providerId);
-        if (!searchTerm) {
-          for (const segment of path) params.append(mode === "tags" ? "tag" : "folder", segment);
-        }
-        const response = await fetch(`/api/assets?${params}`, { cache: "no-store" });
+        const response = await fetch(`/api/assets?${requestParams()}`, { cache: "no-store" });
         const result = (await response.json().catch(() => ({}))) as {
           assets?: Asset[];
           folders?: AssetFolder[];
           capabilities?: { tags?: boolean; search?: boolean };
+          nextCursor?: string;
           error?: string;
         };
         if (cancelled) return;
@@ -421,9 +487,12 @@ export function AssetPaletteDrawer({
           return;
         }
         const page: PalettePage = {
-          assets: result.assets.slice(0, PALETTE_ASSET_LIMIT),
+          // No client-side slice: the provider honours `limit`, so trimming
+          // here again would drop assets we had already fetched AND lie about
+          // where the next page starts.
+          assets: result.assets,
           folders: result.folders ?? [],
-          truncated: result.assets.length > PALETTE_ASSET_LIMIT,
+          ...(result.nextCursor === undefined ? {} : { nextCursor: result.nextCursor }),
         };
         pageCacheRef.current.set(cacheKey(providerId, mode, path, searchTerm), page);
         setTagsAvailable(result.capabilities?.tags === true);
@@ -441,7 +510,7 @@ export function AssetPaletteDrawer({
     return () => {
       cancelled = true;
     };
-  }, [open, state.status, path, mode, providerId, searchTerm, cacheKey]);
+  }, [open, state.status, path, mode, providerId, searchTerm, cacheKey, requestParams]);
 
   if (!open || typeof document === "undefined") return null;
 
@@ -594,15 +663,26 @@ export function AssetPaletteDrawer({
                 mode={mode}
                 onOpenFolder={navigateTo}
               />
-              {state.truncated && (
-                <p className="mt-1 text-[10px] text-zinc-600">
-                  {/* This used to point at "the storyboard view" — a route
-                      deleted in #184, so the advice led nowhere. Search is the
-                      way through a library bigger than a page until the
-                      palette paginates. */}
-                  Showing the first {PALETTE_ASSET_LIMIT}
-                  {searchTerm ? " matches" : " assets"} — narrow it with search.
-                </p>
+              {state.nextCursor !== undefined && (
+                // This used to be a dead end: a line saying "showing the first
+                // 48" and pointing at the storyboard view, a route deleted in
+                // #184. There is now a way to actually reach the rest.
+                <div className="mt-1 flex items-center gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={loadingMore}
+                    onClick={() => void loadMore()}
+                    className="h-6 px-2 text-[10px]"
+                  >
+                    {loadingMore ? "Loading…" : "Load more"}
+                  </Button>
+                  <span className="text-[10px] text-zinc-600">
+                    {state.assets.length} shown
+                    {searchTerm ? " · narrow the search to get there faster" : ""}
+                  </span>
+                </div>
               )}
             </>
           ))}

--- a/apps/timeline-gstudio001/lib/assets/path-folders.test.ts
+++ b/apps/timeline-gstudio001/lib/assets/path-folders.test.ts
@@ -179,3 +179,81 @@ describe("pageFromSearch", () => {
     ).toEqual([]);
   });
 });
+
+describe("pagination", () => {
+  const many = Array.from({ length: 25 }, (_, i) =>
+    asset(`a${String(i).padStart(2, "0")}`, ["Bulk"]),
+  );
+
+  it("tiles the listing exactly — no gaps, no repeats", () => {
+    const walked: string[] = [];
+    let cursor: string | undefined;
+    let pages = 0;
+    do {
+      const page = pageFromFlatListing(many, {
+        folderPath: [],
+        folder: ["Bulk"],
+        limit: 10,
+        ...(cursor === undefined ? {} : { cursor }),
+      } as never);
+      walked.push(...page.assets.map((a) => a.id));
+      cursor = page.nextCursor;
+      pages += 1;
+    } while (cursor !== undefined && pages < 10);
+
+    expect(pages).toBe(3);
+    expect(walked).toEqual(many.map((a) => a.id));
+    expect(new Set(walked).size).toBe(walked.length);
+  });
+
+  it("omits nextCursor on the LAST page, so paging terminates", () => {
+    const last = pageFromFlatListing(many, {
+      folderPath: [],
+      folder: ["Bulk"],
+      limit: 10,
+      cursor: "20",
+    } as never);
+    expect(last.assets).toHaveLength(5);
+    expect(last.nextCursor).toBeUndefined();
+  });
+
+  it("returns folders on the FIRST page only", () => {
+    const first = pageFromFlatListing(many, { folderPath: [], limit: 10 } as never);
+    const second = pageFromFlatListing(many, {
+      folderPath: [],
+      limit: 10,
+      cursor: "10",
+    } as never);
+    expect(first.folders.length).toBeGreaterThan(0);
+    // The place does not change because the user asked for more of its
+    // contents; redrawing the folder row under every page would.
+    expect(second.folders).toEqual([]);
+  });
+
+  it("treats an unparseable cursor as the first page rather than throwing", () => {
+    const page = pageFromFlatListing(many, {
+      folderPath: [],
+      folder: ["Bulk"],
+      limit: 10,
+      cursor: "not-a-number",
+    } as never);
+    expect(page.assets.map((a) => a.id)).toEqual(many.slice(0, 10).map((a) => a.id));
+  });
+
+  it("returns an empty terminal page for a cursor past the end", () => {
+    const page = pageFromFlatListing(many, {
+      folderPath: [],
+      folder: ["Bulk"],
+      limit: 10,
+      cursor: "9999",
+    } as never);
+    expect(page.assets).toEqual([]);
+    expect(page.nextCursor).toBeUndefined();
+  });
+
+  it("paginates SEARCH results too", () => {
+    const first = pageFromSearch(many, { folderPath: [], search: "a0", limit: 4 } as never);
+    expect(first.assets).toHaveLength(4);
+    expect(first.nextCursor).toBe("4");
+  });
+});

--- a/apps/timeline-gstudio001/lib/assets/path-folders.ts
+++ b/apps/timeline-gstudio001/lib/assets/path-folders.ts
@@ -22,11 +22,46 @@ function isUnder(path: Location, base: Location): boolean {
   return path.length > base.length && base.every((segment, i) => segment === path[i]);
 }
 
+/**
+ * The cursor for these path-derived providers is simply an OFFSET into the
+ * listing, encoded as a decimal string.
+ *
+ * That is honest for what this is: the whole listing is already in memory and
+ * ordered, so there is nothing to keyset against that an index does not
+ * already give. The tradeoff is the usual one — if the underlying library
+ * changes between two page requests, an offset can repeat or skip an item.
+ * In practice the listing is TTL-cached for the whole paging session, so the
+ * window a user pages through is fixed; a provider that pushes paging down to
+ * a native query (see below) should emit that backend's own cursor instead
+ * and this becomes irrelevant.
+ *
+ * Anything unparseable reads as 0 rather than throwing: a bad cursor should
+ * show the first page, not an error.
+ */
+function offsetFromCursor(cursor: string | undefined): number {
+  if (cursor === undefined) return 0;
+  const parsed = Number.parseInt(cursor, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
+/** Slice one page out of the matches, and say whether more remain. */
+function paginate(matching: readonly Asset[], query: AssetQuery) {
+  const offset = offsetFromCursor(query.cursor);
+  if (query.limit === undefined || query.limit < 0) {
+    return { assets: matching.slice(offset), nextCursor: undefined };
+  }
+  const end = offset + query.limit;
+  return {
+    assets: matching.slice(offset, end),
+    nextCursor: end < matching.length ? String(end) : undefined,
+  };
+}
+
 function pageFromLocations(
   assets: readonly Asset[],
   locationsOf: (asset: Asset) => readonly Location[],
   base: Location | undefined,
-  limit: number | undefined,
+  query: AssetQuery,
 ): AssetPage {
   const matching =
     base === undefined
@@ -47,8 +82,15 @@ function pageFromLocations(
   }
   folders.sort((a, b) => a.name.localeCompare(b.name));
 
-  const limited = limit !== undefined && limit >= 0 ? matching.slice(0, limit) : matching;
-  return { assets: limited, folders };
+  const { assets: limited, nextCursor } = paginate(matching, query);
+  return {
+    assets: limited,
+    // Folders belong to the FIRST page only. They are the place, not the
+    // contents — repeating them under every page would redraw the whole
+    // folder row each time the user asked for more files.
+    folders: offsetFromCursor(query.cursor) === 0 ? folders : [],
+    ...(nextCursor === undefined ? {} : { nextCursor }),
+  };
 }
 
 /**
@@ -65,7 +107,7 @@ function pageFromLocations(
  * adapter is a mapping function and nothing more.
  */
 export function pageFromFlatListing(assets: readonly Asset[], query: AssetQuery): AssetPage {
-  return pageFromLocations(assets, (asset) => [asset.folderPath], query.folder, query.limit);
+  return pageFromLocations(assets, (asset) => [asset.folderPath], query.folder, query);
 }
 
 /** How a tag nests: "scene/heist" is the path ["scene", "heist"]. */
@@ -84,7 +126,7 @@ function tagSegments(tag: string): Location {
 export function pageFromTagListing(assets: readonly Asset[], query: AssetQuery): AssetPage {
   const locationsOf = (asset: Asset): readonly Location[] =>
     asset.tags.length === 0 ? [[]] : asset.tags.map(tagSegments);
-  return pageFromLocations(assets, locationsOf, query.tagPath ?? [], query.limit);
+  return pageFromLocations(assets, locationsOf, query.tagPath ?? [], query);
 }
 
 /**
@@ -115,6 +157,6 @@ export function pageFromSearch(assets: readonly Asset[], query: AssetQuery): Ass
     return asset.tags.some((tag) => tag.toLowerCase().includes(needle));
   });
 
-  const limited = query.limit === undefined ? matches : matches.slice(0, query.limit);
-  return { assets: limited, folders: [] };
+  const { assets: page, nextCursor } = paginate(matches, query);
+  return { assets: page, folders: [], ...(nextCursor === undefined ? {} : { nextCursor }) };
 }

--- a/docs/asset-providers.md
+++ b/docs/asset-providers.md
@@ -47,6 +47,17 @@ queries, and safe deletion later.
 
 `GET /api/assets?provider=<id>&folder=<seg>&folder=<seg>&browse=1&limit=<n>`
 `GET /api/assets?q=<term>` — a library-wide search; carries no folder/tag/browse.
+`&cursor=<opaque>` — the next page, from the previous response's `nextCursor`.
+
+**Paging is per-provider and OPAQUE above the seam.** The route forwards
+`cursor` without reading it. For the path-derived providers it is an offset
+into the in-memory listing (see `offsetFromCursor`), which is honest because
+the whole listing is already loaded and ordered; a provider that pushes paging
+down to a native query should emit that backend's own token instead and
+nothing above changes. Folders ride the FIRST page only — they are the place,
+not the contents, and repeating them under every page would redraw the folder
+row each time the user asked for more files. A missing `nextCursor` means
+that was the last page.
 
 - `folder` repeats one param per **path segment**, so a segment containing
   `/` can never fake a boundary (NodeId lesson: assume ids contain your


### PR DESCRIPTION
## What

The palette fetched a page, rendered it, and told you the rest of your library was *"on the storyboard view"* — a route deleted in #184. **In a folder of a thousand assets you could reach forty-eight of them.**

`AssetQuery.cursor` and `AssetPage.nextCursor` already existed on the seam and nothing read them. Now they work.

## Design

**The cursor is opaque above the seam.** The route forwards it without interpreting it — only a provider knows what its own cursor means. The path-derived providers answer with an offset into their listing, which is honest for what they are: the listing is already loaded and ordered, so there's nothing to keyset against that an index doesn't already give. A provider that pushes paging down to a native query emits that backend's token instead and nothing above changes.

**Folders ride the first page only.** They're the place, not the contents; redrawing the folder row under every page answers a question the user didn't ask again.

**Loading a page appends.** The rail keeps everything already there, so a second page never costs you your scroll position or the tile you were reaching for. The append is refused if the underlying page changed while the request was in flight (searched, navigated, switched provider) — without that guard it would splice one folder's assets onto another's.

**One param builder** serves both the first fetch and every later page, so the search-vs-browse rules can't drift between them. That divergence would be invisible until a paged search silently started browsing.

## Page size is 12, and renamed

`PALETTE_ASSET_LIMIT` → `PALETTE_PAGE_SIZE`, because that's what it now is — the old name described a cap that no longer exists.

Small on purpose: the first page is what you wait for, and a dozen tiles already fill a horizontal rail past its scroll edge. Fetching four times that to satisfy a scroll most people never make costs everyone the wait; "Load more" is one click for the minority who go looking.

## Verified against the real library

Walking it 10 at a time:

| | |
|---|---|
| pages | 4 |
| cursors | `10 → 20 → 30 → null` |
| assets walked | 38 of 38 |
| duplicates | none |
| order | identical to a single-page fetch |

A malformed cursor serves the first page rather than throwing; a cursor past the end returns an empty terminal page.

In the palette at page size 12:

| | thumbnails | folders | button |
|---|---|---|---|
| browse page 1 | 12 | 4 | yes |
| after Load more | 21 (all) | 4 | gone |
| search page 1 | 12 | 0 | yes |
| search after more | 24 | 0 | yes |

`tsc` clean, app lint 0 errors (4 pre-existing `<img>` warnings), app vitest 365/365 (+6), storybook 153/153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
