### PR TITLE
One row per image in the trash, and Add takes every copy

### DIFF
--- a/apps/timeline-gstudio001/app/api/trash/route.ts
+++ b/apps/timeline-gstudio001/app/api/trash/route.ts
@@ -46,3 +46,62 @@ export async function DELETE() {
     return NextResponse.json({ error: "Unable to empty the trash." }, { status: 500 });
   }
 }
+
+/**
+ * Discard SPECIFIC entries from the bin, without restoring them.
+ *
+ * The trash holds one row per IMAGE, not per clip: deleting a clip and its
+ * duplicate puts two identical entries in the bin, and adding that image back
+ * takes one of them. The others have to go, or the row would linger holding
+ * copies of something the user has already taken back.
+ *
+ * Same shape as emptying, and the same two constraints. `allowEmptying` is
+ * needed because discarding the last entries leaves the document empty, and
+ * the save path otherwise refuses an empty write over a non-empty document.
+ * And like emptying, the caller MUST tell the graph to rebuild afterwards —
+ * a mounted graph view holds these clips as nodes under its trash root and
+ * would write them straight back on the next commit that touches the trash.
+ *
+ * Uploaded files are untouched, exactly as for emptying: one upload can back
+ * several clips, and discarding a bin entry is not deleting a file.
+ */
+export async function POST(request: Request) {
+  try {
+    const { user, response } = await requireAuthUser();
+    if (response || !user) return response || NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const body = (await request.json().catch(() => ({}))) as { clipIds?: unknown };
+    const clipIds = Array.isArray(body.clipIds)
+      ? body.clipIds.filter((id): id is string => typeof id === "string" && id.length > 0)
+      : [];
+    if (clipIds.length === 0) {
+      return NextResponse.json({ error: "clipIds is required." }, { status: 400 });
+    }
+
+    const trashId = `trash-${user.uid}`;
+    const trashDoc = await getFirebaseTimelineDocument(trashId, user.uid);
+    if (!trashDoc) return NextResponse.json({ success: true, discarded: 0 });
+
+    // Drop ONE entry per requested id, not every clip sharing it: the bin can
+    // legitimately hold the same id twice (stable per-asset ids mean one file
+    // trashed from two timelines arrives twice), and a caller asking to
+    // discard one of them must not lose the other.
+    const remaining = [...trashDoc.clips];
+    let discarded = 0;
+    for (const clipId of clipIds) {
+      const index = remaining.findIndex((clip) => clip.id === clipId);
+      if (index === -1) continue;
+      remaining.splice(index, 1);
+      discarded += 1;
+    }
+    if (discarded === 0) return NextResponse.json({ success: true, discarded: 0 });
+
+    await saveFirebaseTimelineDocument({ ...trashDoc, clips: remaining }, user.uid, {
+      allowEmptying: true,
+    });
+    return NextResponse.json({ success: true, discarded });
+  } catch (error) {
+    console.error("[TRASH_DISCARD_ERROR]", error);
+    return NextResponse.json({ error: "Unable to update the trash." }, { status: 500 });
+  }
+}

--- a/apps/timeline-gstudio001/app/api/trash/trash-empty.test.ts
+++ b/apps/timeline-gstudio001/app/api/trash/trash-empty.test.ts
@@ -2,7 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
 
-// Empty-the-bin tests over the REAL DELETE handler and the REAL
+// Bin-removal tests — DELETE (empty everything) and POST (discard specific
+// entries) — over the REAL handlers and the REAL
 // firebase-timeline-store save path — only the process boundaries are faked
 // (the Firestore SDK, the session cookie, Cloudinary). The endpoint could
 // never work before: the save path refuses an empty write over a non-empty
@@ -85,7 +86,7 @@ vi.mock("@/lib/cloudinary-media-store", () => ({
   },
 }));
 
-import { DELETE as emptyTrash } from "./route";
+import { DELETE as emptyTrash, POST as discardTrash } from "./route";
 import { GET as getTimeline } from "../timelines/[id]/route";
 
 const TRASH_ID = "trash-user-a";
@@ -227,6 +228,101 @@ describe("DELETE /api/trash", () => {
 
     // user-b empties THEIR bin (which doesn't exist) — user-a's is untouched.
     expect((await emptyTrash()).status).toBe(200);
+    expect(state.docs.get(TRASH_ID)).toEqual(before);
+  });
+});
+
+const discard = (clipIds: unknown) =>
+  discardTrash(
+    new Request("http://test.local/api/trash", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ clipIds }),
+    }),
+  );
+
+// POST removes SPECIFIC entries, which is what taking an image back out of the
+// bin needs: the drawer shows one row per image, the graph moves one copy into
+// the open timeline, and the copies that never moved have to go too — or the
+// row returns holding duplicates of something already taken back.
+describe("POST /api/trash", () => {
+  it("discards the named entries and leaves the rest", async () => {
+    seedTrash([
+      clip("c1", "https://example.test/a.png"),
+      clip("c2", "https://example.test/b.png"),
+      clip("c3", "https://example.test/c.png"),
+    ]);
+
+    const response = await discard(["c1", "c3"]);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true, discarded: 2 });
+
+    expect(state.docs.get(TRASH_ID)?.clips).toEqual([
+      expect.objectContaining({ id: "c2" }),
+    ]);
+    expect((await readBack()).clips.map((entry) => entry.id)).toEqual(["c2"]);
+  });
+
+  it("drops ONE entry per id, not every clip sharing it", async () => {
+    // The bin legitimately holds the same id twice: stable per-asset clip ids
+    // mean one file trashed from two timelines arrives under one id. A caller
+    // discarding one copy must not lose the other.
+    seedTrash([
+      clip("dup", "https://example.test/a.png"),
+      clip("dup", "https://example.test/a.png"),
+      clip("c2", "https://example.test/b.png"),
+    ]);
+
+    expect(await (await discard(["dup"])).json()).toEqual({ success: true, discarded: 1 });
+    expect(state.docs.get(TRASH_ID)?.clips).toEqual([
+      expect.objectContaining({ id: "dup" }),
+      expect.objectContaining({ id: "c2" }),
+    ]);
+  });
+
+  it("discarding the LAST entries empties the document and it stays empty", async () => {
+    // `allowEmptying` is what makes this work: the save path refuses an empty
+    // write over a non-empty document, and the read path otherwise re-hydrates
+    // `lastNonEmptyDocument` whenever the stored clips are empty.
+    seedTrash([clip("c1", "https://example.test/a.png")]);
+
+    expect(await (await discard(["c1"])).json()).toEqual({ success: true, discarded: 1 });
+    expect(state.docs.get(TRASH_ID)?.clips).toEqual([]);
+    expect((await readBack()).clips).toEqual([]);
+  });
+
+  it("never deletes the uploaded file behind a discarded entry", async () => {
+    seedTrash([clip("c1", "https://res.cloudinary.com/demo/image/upload/v1/f/orphan.png")]);
+    await discard(["c1"]);
+    expect(state.cloudinaryDeletes).toEqual([]);
+  });
+
+  it("ignores ids that aren't in the bin, without writing", async () => {
+    seedTrash([clip("c1", "https://example.test/a.png")], 5);
+
+    expect(await (await discard(["nope"])).json()).toEqual({ success: true, discarded: 0 });
+    expect(state.docs.get(TRASH_ID)?.revision).toBe(5);
+    expect(state.docs.get(TRASH_ID)?.clips).toHaveLength(1);
+  });
+
+  it("rejects a request with no usable ids", async () => {
+    seedTrash([clip("c1", "https://example.test/a.png")]);
+
+    for (const body of [[], ["", "  ".trim()], "c1", undefined]) {
+      const response = await discard(body);
+      expect(response.status).toBe(400);
+    }
+    expect(state.docs.get(TRASH_ID)?.clips).toHaveLength(1);
+  });
+
+  it("leaves another user's trash document alone", async () => {
+    seedTrash([clip("c1", "https://example.test/a.png")]);
+    state.current.user = { uid: "user-b", email: null, name: null, picture: null };
+    const before = state.docs.get(TRASH_ID);
+
+    // The id exists — in SOMEONE ELSE'S bin. The handler only ever reads the
+    // caller's own `trash-<uid>` document, so there is nothing to remove.
+    expect(await (await discard(["c1"])).json()).toEqual({ success: true, discarded: 0 });
     expect(state.docs.get(TRASH_ID)).toEqual(before);
   });
 });

--- a/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
+++ b/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
@@ -14,6 +14,7 @@ import { usePathname } from "next/navigation";
 import { Button } from "@/components/core/button";
 import { toast } from "@/components/core/sonner";
 import { trashRowCaption } from "@/lib/trash-provenance";
+import { groupTrashClips } from "@/lib/trash-groups";
 import { useAuth } from "@/components/auth/auth-provider";
 import {
   GRAPH_RESTORE_RESULT_EVENT,
@@ -104,13 +105,15 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
   const pathname = usePathname();
   const canRestore = isGraphViewRoute(pathname);
   const focusedName = "the open timeline";
-  const [restoringId, setRestoringId] = useState<string | null>(null);
+  // A SET, not one id: "Restore all" puts several in flight at once, and a
+  // single slot would leave every button but the last looking idle.
+  const [restoringIds, setRestoringIds] = useState<readonly string[]>([]);
 
   useEffect(() => {
     const onResult = (event: Event) => {
       const detail = (event as CustomEvent<GraphRestoreResultDetail>).detail;
       if (!detail) return;
-      setRestoringId((current) => (current === detail.clipId ? null : current));
+      setRestoringIds((current) => current.filter((id) => id !== detail.clipId));
       if (detail.ok) {
         // Drop ONE row for that clip id — the bin can hold the same id more
         // than once and the graph restored exactly one of them. The updater
@@ -137,8 +140,25 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
   }, []);
 
   const handleRestore = (clipId: string) => {
-    setRestoringId(clipId);
+    setRestoringIds((current) => [...current, clipId]);
     requestGraphRestoreItem(clipId);
+  };
+
+  /**
+   * Take ONE copy out of the bin and add it to whatever timeline is open.
+   *
+   * This was never "put it back where it came from" — the graph inserts at
+   * `resolveInsertPlacement`, i.e. into the FOCUSED timeline — but calling it
+   * Restore implied otherwise. The bin is a place you take images from; where
+   * they land is wherever you are.
+   *
+   * One click takes one copy, so a row holding two still has one to give and
+   * stays, with its count down by one. That is why nothing needs a "discard
+   * from bin" primitive the graph would fight: every entry leaves the bin the
+   * same way, by being added somewhere.
+   */
+  const handleAddToTimeline = (clipId: string) => {
+    handleRestore(clipId);
   };
 
   const handleEmptyTrash = async () => {
@@ -240,16 +260,22 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
             </div>
           ) : (
             <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4 p-5">
-              {clips.map((clip, index) => (
+              {groupTrashClips(clips).map((group, index) => {
+                // The row stands for the IMAGE, not one clip: every field it
+                // paints comes from the first copy, which is safe precisely
+                // because copies of one asset share them.
+                const clip = group.clips[0];
+                const busy = group.clips.some((entry) => restoringIds.includes(entry.id));
+                return (
                 <div
-                  // Keyed by SLOT, not by clip id: the trash document can
+                  // Keyed by SLOT as well as identity: the trash document can
                   // legitimately hold the same id more than once (the legacy
                   // views mint stable per-asset clip ids, so one asset trashed
                   // from two timelines arrives twice — the graph's own
                   // hydration demotes such collisions for the same reason).
                   // An id key made React log a duplicate-key error per repeat
                   // and drop cards from the grid.
-                  key={`${index}-${clip.id}`}
+                  key={`${index}-${group.key}`}
                   className="relative group rounded-lg overflow-hidden border border-zinc-900 bg-zinc-900/20 p-2 hover:border-zinc-800 transition-colors"
                 >
                   <div className="aspect-video relative rounded bg-black/60 overflow-hidden flex items-center justify-center border border-zinc-800/40">
@@ -278,6 +304,18 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
                         </span>
                       </div>
                     )}
+                    {group.clips.length > 1 && (
+                      // Not "pick one of these" — they are identical. It is
+                      // how many times this row can still be added before it
+                      // is spent, so the row staying after a click reads as
+                      // correct rather than broken.
+                      <span
+                        className="absolute left-1 top-1 rounded-full bg-black/85 px-1.5 py-0.5 text-[9px] font-semibold text-zinc-100 ring-1 ring-white/15"
+                        title={`${group.clips.length} copies in the bin`}
+                      >
+                        ×{group.clips.length}
+                      </span>
+                    )}
                   </div>
                   <div className="mt-2 flex min-w-0 items-center gap-2">
                     <div className="min-w-0 flex-1">
@@ -303,19 +341,20 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
                         type="button"
                         variant="outline"
                         size="sm"
-                        disabled={restoringId === clip.id}
-                        onClick={() => handleRestore(clip.id)}
-                        title={`Restore into ${focusedName}`}
-                        aria-label={`Restore ${(clip as any).title || clip.alt || "clip"}`}
+                        disabled={busy}
+                        onClick={() => handleAddToTimeline(clip.id)}
+                        title={`Add to ${focusedName}`}
+                        aria-label={`Add ${(clip as any).title || clip.alt || "clip"} to ${focusedName}`}
                         className="h-6 shrink-0 border-zinc-800 px-2 text-[10px] text-zinc-300 hover:border-sky-500/50 hover:text-sky-300 cursor-pointer"
                       >
                         <Undo2 className="mr-1 h-3 w-3" />
-                        Restore
+                        Add
                       </Button>
                     )}
                   </div>
                 </div>
-              ))}
+                );
+              })}
             </div>
           )}
         </main>

--- a/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
+++ b/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { createPortal } from "react-dom";
 import {
   Trash2,
@@ -15,6 +15,8 @@ import { Button } from "@/components/core/button";
 import { toast } from "@/components/core/sonner";
 import { trashRowCaption } from "@/lib/trash-provenance";
 import { groupTrashClips } from "@/lib/trash-groups";
+import { discardTrashClips } from "@/lib/graph-trash-discard";
+import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 import { useAuth } from "@/components/auth/auth-provider";
 import {
   GRAPH_RESTORE_RESULT_EVENT,
@@ -109,6 +111,7 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
   // single slot would leave every button but the last looking idle.
   const [restoringIds, setRestoringIds] = useState<readonly string[]>([]);
 
+  const uid = user?.uid;
   useEffect(() => {
     const onResult = (event: Event) => {
       const detail = (event as CustomEvent<GraphRestoreResultDetail>).detail;
@@ -121,11 +124,32 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
         // one yet" flag: React may invoke an updater more than once, and a
         // flag that survives between invocations made the second pass remove
         // nothing, leaving the restored row on screen.
+        const duplicates = addedGroupRef.current.get(detail.clipId) ?? [];
+        addedGroupRef.current.delete(detail.clipId);
         setClips((current) => {
-          const index = current.findIndex((clip) => clip.id === detail.clipId);
-          if (index === -1) return current;
-          return [...current.slice(0, index), ...current.slice(index + 1)];
+          // Drop the clip that was added, plus the duplicates that came with
+          // its row — the row stood for one image and that image is now taken.
+          const doomed = new Set([detail.clipId, ...duplicates]);
+          const kept: TimelineClip[] = [];
+          const removedOnce = new Set<string>();
+          for (const clip of current) {
+            // One removal per id: the bin can hold the same id twice, and only
+            // as many as this row accounted for may go.
+            if (doomed.has(clip.id) && !removedOnce.has(clip.id)) {
+              removedOnce.add(clip.id);
+              continue;
+            }
+            kept.push(clip);
+          }
+          return kept;
         });
+        // The add moved ONE clip out of the bin through the graph; these never
+        // move anywhere, so they need a real discard — which has to wait for
+        // the graph's own (debounced) trash write to land first, or it gets
+        // overwritten by it. See lib/graph-trash-discard.ts.
+        if (duplicates.length > 0 && uid) {
+          void discardTrashClips(duplicates, `trash-${uid}`, graphDocumentsGateway);
+        }
       }
       // Sonner, like every other surface in the app. This used to dispatch a
       // bespoke `gstudio-toast` event that the sidebar rendered as its own
@@ -137,7 +161,7 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
     };
     window.addEventListener(GRAPH_RESTORE_RESULT_EVENT, onResult);
     return () => window.removeEventListener(GRAPH_RESTORE_RESULT_EVENT, onResult);
-  }, []);
+  }, [uid]);
 
   const handleRestore = (clipId: string) => {
     setRestoringIds((current) => [...current, clipId]);
@@ -145,20 +169,32 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
   };
 
   /**
-   * Take ONE copy out of the bin and add it to whatever timeline is open.
+   * Add the row's image to whatever timeline is open, and clear it from the
+   * bin entirely.
    *
    * This was never "put it back where it came from" — the graph inserts at
    * `resolveInsertPlacement`, i.e. into the FOCUSED timeline — but calling it
    * Restore implied otherwise. The bin is a place you take images from; where
    * they land is wherever you are.
    *
-   * One click takes one copy, so a row holding two still has one to give and
-   * stays, with its count down by one. That is why nothing needs a "discard
-   * from bin" primitive the graph would fight: every entry leaves the bin the
-   * same way, by being added somewhere.
+   * The bin holds one row per IMAGE. How many clips happen to back that row
+   * is bookkeeping the user never asked about, so taking the image takes ALL
+   * of them: one copy is added, and any duplicates are discarded rather than
+   * left behind as a row that looks unchanged after you just used it.
+   *
+   * The discard is deliberately AFTER the add succeeds. If the add is refused
+   * (no graph, an un-hydrated target), nothing has been taken and nothing may
+   * be thrown away.
    */
-  const handleAddToTimeline = (clipId: string) => {
-    handleRestore(clipId);
+  const addedGroupRef = useRef(new Map<string, readonly string[]>());
+  const handleAddToTimeline = (group: { key: string; clips: readonly TimelineClip[] }) => {
+    const [first, ...duplicates] = group.clips;
+    if (!first) return;
+    addedGroupRef.current.set(
+      first.id,
+      duplicates.map((clip) => clip.id),
+    );
+    handleRestore(first.id);
   };
 
   const handleEmptyTrash = async () => {
@@ -304,18 +340,6 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
                         </span>
                       </div>
                     )}
-                    {group.clips.length > 1 && (
-                      // Not "pick one of these" — they are identical. It is
-                      // how many times this row can still be added before it
-                      // is spent, so the row staying after a click reads as
-                      // correct rather than broken.
-                      <span
-                        className="absolute left-1 top-1 rounded-full bg-black/85 px-1.5 py-0.5 text-[9px] font-semibold text-zinc-100 ring-1 ring-white/15"
-                        title={`${group.clips.length} copies in the bin`}
-                      >
-                        ×{group.clips.length}
-                      </span>
-                    )}
                   </div>
                   <div className="mt-2 flex min-w-0 items-center gap-2">
                     <div className="min-w-0 flex-1">
@@ -342,7 +366,7 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
                         variant="outline"
                         size="sm"
                         disabled={busy}
-                        onClick={() => handleAddToTimeline(clip.id)}
+                        onClick={() => handleAddToTimeline(group)}
                         title={`Add to ${focusedName}`}
                         aria-label={`Add ${(clip as any).title || clip.alt || "clip"} to ${focusedName}`}
                         className="h-6 shrink-0 border-zinc-800 px-2 text-[10px] text-zinc-300 hover:border-sky-500/50 hover:text-sky-300 cursor-pointer"

--- a/apps/timeline-gstudio001/lib/graph-trash-discard.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-trash-discard.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { discardTrashClips, settlePendingWrites } from "./graph-trash-discard";
+
+/** A gateway whose pending-write flag flips after a given number of checks —
+ *  standing in for a debounced batch landing some time after the flush. */
+function gatewayPendingFor(checks: number) {
+  const calls = { flushes: 0, checks: 0 };
+  return {
+    calls,
+    gateway: {
+      hasPendingWrite: () => {
+        calls.checks += 1;
+        return calls.checks <= checks;
+      },
+      flushPendingWrites: () => {
+        calls.flushes += 1;
+      },
+    },
+  };
+}
+
+const noSleep = async () => {};
+
+/** These tests run in the node environment, so `window` is stubbed down to the
+ *  one method the announce needs. Returns the event types it saw. */
+function captureAnnouncements(): string[] {
+  const types: string[] = [];
+  vi.stubGlobal("window", {
+    dispatchEvent: (event: Event) => {
+      types.push(event.type);
+      return true;
+    },
+  });
+  return types;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("settlePendingWrites", () => {
+  it("returns without flushing when nothing is pending", async () => {
+    const { calls, gateway } = gatewayPendingFor(0);
+    await settlePendingWrites("trash-u1", gateway, noSleep);
+    expect(calls.flushes).toBe(0);
+  });
+
+  it("flushes once and waits for the write to land", async () => {
+    const { calls, gateway } = gatewayPendingFor(3);
+    await settlePendingWrites("trash-u1", gateway, noSleep);
+    expect(calls.flushes).toBe(1);
+    // One check to decide to flush, then polls until it reads false.
+    expect(calls.checks).toBe(4);
+  });
+
+  it("gives up rather than hanging on a write that never settles", async () => {
+    const gateway = {
+      hasPendingWrite: () => true,
+      flushPendingWrites: () => {},
+    };
+    // Resolves at all — that is the assertion. A wedged write must not block
+    // the discard forever; losing the race is recoverable, hanging is not.
+    await expect(settlePendingWrites("trash-u1", gateway, noSleep)).resolves.toBeUndefined();
+  });
+});
+
+describe("discardTrashClips", () => {
+  it("does nothing for an empty id list", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { gateway } = gatewayPendingFor(0);
+
+    await expect(discardTrashClips([], "trash-u1", gateway)).resolves.toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("waits for the graph's own trash write BEFORE posting", async () => {
+    const order: string[] = [];
+    const gateway = {
+      hasPendingWrite: () => order.length === 0,
+      flushPendingWrites: () => order.push("flush"),
+    };
+    const fetchMock = vi.fn(async () => {
+      order.push("post");
+      return { ok: true } as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await discardTrashClips(["image-a"], "trash-u1", gateway);
+
+    // The whole point: a discard sent before the graph's debounced write lands
+    // is overwritten by it, and the entry comes back on the next load.
+    expect(order).toEqual(["flush", "post"]);
+  });
+
+  it("posts the ids and announces the rebuild", async () => {
+    const events = captureAnnouncements();
+    const fetchMock = vi.fn(async () => ({ ok: true }) as Response);
+    vi.stubGlobal("fetch", fetchMock);
+    const { gateway } = gatewayPendingFor(0);
+
+    await expect(discardTrashClips(["image-a", "image-b"], "trash-u1", gateway)).resolves.toBe(
+      true,
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/trash", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ clipIds: ["image-a", "image-b"] }),
+    });
+    // Without this the mounted graph view writes the discarded clips straight
+    // back on its next commit that touches the trash.
+    expect(events).toEqual(["graph-view:trash-emptied"]);
+  });
+
+  it("does not announce a rebuild the server refused", async () => {
+    const events = captureAnnouncements();
+    vi.stubGlobal("fetch", async () => ({ ok: false }) as Response);
+    const { gateway } = gatewayPendingFor(0);
+
+    await expect(discardTrashClips(["image-a"], "trash-u1", gateway)).resolves.toBe(false);
+    expect(events).toEqual([]);
+  });
+
+  it("survives a network failure", async () => {
+    vi.stubGlobal("fetch", async () => {
+      throw new Error("offline");
+    });
+    const { gateway } = gatewayPendingFor(0);
+    await expect(discardTrashClips(["image-a"], "trash-u1", gateway)).resolves.toBe(false);
+  });
+});

--- a/apps/timeline-gstudio001/lib/graph-trash-discard.ts
+++ b/apps/timeline-gstudio001/lib/graph-trash-discard.ts
@@ -1,0 +1,85 @@
+// Discarding bin entries has to cooperate with the graph's own writer, or it
+// loses to it.
+//
+// Both are FULL-DOCUMENT writers of the trash document: the graph derives it
+// from its trash root's children, and `POST /api/trash` rewrites it from the
+// stored copy. The graph's writer is debounced (`SAVE_DEBOUNCE_MS`), so a
+// discard sent the instant a restore succeeds reads the document, drops the
+// duplicate, saves — and is then overwritten ~900ms later by a batch built
+// from a cache that still contains it. The duplicate reappears on the next
+// load, which is exactly the bug this exists to prevent.
+//
+// So: flush the graph's pending write and wait for it to SETTLE, then discard,
+// then tell the graph to rebuild. Ordering is the whole fix — with the graph's
+// write already on the server, the discard reads the current document and
+// nothing is queued behind it to clobber the result.
+
+import { announceGraphTrashEmptied } from "@/lib/graph-view-events";
+
+/** The slice of the documents gateway this needs. Named structurally so tests
+ *  can drive the ordering without the real gateway (and its IO). */
+export type PendingWriteGateway = Readonly<{
+  hasPendingWrite: (timelineId: string) => boolean;
+  flushPendingWrites: (options?: { keepalive?: boolean }) => void;
+}>;
+
+/** How often to re-check, and how long to wait before giving up and issuing
+ *  the discard anyway. Losing the race is recoverable (the entry comes back and
+ *  can be discarded again); hanging on a wedged write is not. */
+const SETTLE_POLL_MS = 100;
+const SETTLE_TIMEOUT_MS = 5000;
+
+/**
+ * Resolve once no write for `timelineId` is outstanding.
+ *
+ * Polls rather than subscribing: the gateway's `subscribe` reports CACHE
+ * changes, and a batch settling without changing the cache would never wake a
+ * subscriber — a wait that can miss its own wake-up is worse than a cheap
+ * 100ms tick over a window this short.
+ */
+export async function settlePendingWrites(
+  timelineId: string,
+  gateway: PendingWriteGateway,
+  sleep: (ms: number) => Promise<void> = (ms) =>
+    new Promise((resolve) => setTimeout(resolve, ms)),
+): Promise<void> {
+  if (!gateway.hasPendingWrite(timelineId)) return;
+  // Don't wait out the debounce window — the batch is ready, send it now.
+  gateway.flushPendingWrites();
+  for (let waited = 0; waited < SETTLE_TIMEOUT_MS; waited += SETTLE_POLL_MS) {
+    if (!gateway.hasPendingWrite(timelineId)) return;
+    await sleep(SETTLE_POLL_MS);
+  }
+}
+
+/**
+ * Drop specific entries from the bin without restoring them, safely.
+ *
+ * Returns whether the server took them. The announce is not optional and is
+ * the reason this is one function rather than a bare fetch: a mounted graph
+ * view still holds those clips as nodes under its trash root, and would write
+ * them straight back on the next commit that touches the trash.
+ */
+export async function discardTrashClips(
+  clipIds: readonly string[],
+  trashId: string,
+  gateway: PendingWriteGateway,
+): Promise<boolean> {
+  if (clipIds.length === 0) return false;
+  await settlePendingWrites(trashId, gateway);
+  try {
+    const response = await fetch("/api/trash", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ clipIds }),
+    });
+    if (!response.ok) return false;
+    announceGraphTrashEmptied();
+    return true;
+  } catch {
+    // The row is already gone from the drawer's own list; the entries simply
+    // stay in the bin and can be discarded again. Nothing to say here that the
+    // next open of the drawer won't show.
+    return false;
+  }
+}

--- a/apps/timeline-gstudio001/lib/trash-groups.test.ts
+++ b/apps/timeline-gstudio001/lib/trash-groups.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import type { TimelineClip } from "@storyboard/timeline-model/types";
+
+import { groupTrashClips } from "./trash-groups";
+
+function image(id: string, overrides: Partial<TimelineClip> = {}): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "image",
+    src: `https://cdn.test/${id}.jpg`,
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 4,
+    sourceDuration: 4,
+    trimIn: 0,
+    trimOut: 0,
+    ...overrides,
+  } as TimelineClip;
+}
+
+const CLOUDINARY = { providerId: "cloudinary", assetId: "gstudio/u/pic-1" };
+
+describe("groupTrashClips", () => {
+  it("groups by sourceAsset, even when the ids differ", () => {
+    // The real case: a duplicated clip gets a fresh id but keeps the
+    // provenance of the file it points at.
+    const groups = groupTrashClips([
+      image("a", { sourceAsset: CLOUDINARY }),
+      image("b", { sourceAsset: CLOUDINARY }),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].clips.map((c) => c.id)).toEqual(["a", "b"]);
+  });
+
+  it("falls back to src for clips minted before provenance was tracked", () => {
+    const groups = groupTrashClips([
+      image("old-1", { src: "https://cdn.test/same.jpg" }),
+      image("old-2", { src: "https://cdn.test/same.jpg" }),
+      image("other", { src: "https://cdn.test/different.jpg" }),
+    ]);
+    expect(groups.map((g) => g.clips.length)).toEqual([2, 1]);
+  });
+
+  it("does NOT group two clips that merely lack a src", () => {
+    // A collection has no src. Grouping on its absence would collapse every
+    // unrelated collection in the bin into one row.
+    const groups = groupTrashClips([
+      { ...image("col-1"), kind: "collection", src: undefined } as unknown as TimelineClip,
+      { ...image("col-2"), kind: "collection", src: undefined } as unknown as TimelineClip,
+    ]);
+    expect(groups).toHaveLength(2);
+  });
+
+  it("prefers sourceAsset over src, so a re-hosted file still groups", () => {
+    const groups = groupTrashClips([
+      image("a", { sourceAsset: CLOUDINARY, src: "https://cdn.test/v1.jpg" }),
+      image("b", { sourceAsset: CLOUDINARY, src: "https://cdn.test/v2.jpg" }),
+    ]);
+    expect(groups).toHaveLength(1);
+  });
+
+  it("keeps first-appearance order, so the bin still reads chronologically", () => {
+    const groups = groupTrashClips([
+      image("first", { src: "https://cdn.test/1.jpg" }),
+      image("second", { src: "https://cdn.test/2.jpg" }),
+      image("first-again", { src: "https://cdn.test/1.jpg" }),
+    ]);
+    expect(groups.map((g) => g.clips[0].id)).toEqual(["first", "second"]);
+    expect(groups[0].clips).toHaveLength(2);
+  });
+
+  it("keeps EVERY copy in the group — restoring the row restores them all", () => {
+    // The grouping is display-only. Dropping the extras here would be the
+    // data loss that deduplicating the document would be.
+    const groups = groupTrashClips([
+      image("a", { sourceAsset: CLOUDINARY }),
+      image("b", { sourceAsset: CLOUDINARY }),
+      image("c", { sourceAsset: CLOUDINARY }),
+    ]);
+    expect(groups[0].clips.map((c) => c.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("leaves a single clip as a group of one, and an empty bin as nothing", () => {
+    expect(groupTrashClips([image("solo")])[0].clips).toHaveLength(1);
+    expect(groupTrashClips([])).toEqual([]);
+  });
+});

--- a/apps/timeline-gstudio001/lib/trash-groups.ts
+++ b/apps/timeline-gstudio001/lib/trash-groups.ts
@@ -1,0 +1,55 @@
+import type { TimelineClip } from "@storyboard/timeline-model/types";
+
+export type TrashGroup = Readonly<{
+  /** Stable identity for the group — a React key and nothing more. */
+  key: string;
+  /** Every trashed clip that is the same underlying asset, in bin order. */
+  clips: readonly TimelineClip[];
+}>;
+
+/**
+ * What makes two trashed clips "the same image".
+ *
+ * `sourceAsset` first, because that is the provenance the asset panel records
+ * and it survives a URL changing — it is what the clip IS. `src` is the
+ * fallback for clips minted before that was tracked, and for media that never
+ * came through a provider (a direct OS drop). Everything else falls back to
+ * the clip's own id, which groups nothing: a collection is not a duplicate of
+ * another collection just because neither has a src.
+ */
+function assetIdentity(clip: TimelineClip): string {
+  // Narrowed rather than cast: `sourceAsset` and `src` live on the MEDIA
+  // variants, and a collection clip has neither.
+  const ref = clip.kind === "collection" ? undefined : clip.sourceAsset;
+  if (ref) return `asset:${ref.providerId}:${ref.assetId}`;
+  const src = clip.kind === "collection" ? undefined : clip.src;
+  if (src) return `src:${src}`;
+  return `clip:${clip.id}`;
+}
+
+/**
+ * Collapse repeats of one asset into a single row.
+ *
+ * Placing the same image twice is ordinary, and duplicating a clip copies its
+ * `src` verbatim — so deleting a clip and its copy puts two entries in the bin
+ * that are identical in every field the drawer paints. Two indistinguishable
+ * rows with two identical Restore buttons is a worse answer than one row and
+ * one button.
+ *
+ * Grouping is for DISPLAY only — the document still holds every entry, and
+ * restoring the row restores all of them. That is what keeps this from being
+ * the data loss that actually deduplicating would be: a bin gives back what
+ * you put in.
+ *
+ * First-appearance order is preserved, so the bin still reads chronologically.
+ */
+export function groupTrashClips(clips: readonly TimelineClip[]): readonly TrashGroup[] {
+  const byIdentity = new Map<string, TimelineClip[]>();
+  for (const clip of clips) {
+    const key = assetIdentity(clip);
+    const existing = byIdentity.get(key);
+    if (existing) existing.push(clip);
+    else byIdentity.set(key, [clip]);
+  }
+  return [...byIdentity].map(([key, group]) => ({ key, clips: group }));
+}


### PR DESCRIPTION
The bin listed one row per CLIP, so an image deleted twice appeared twice — two identical thumbnails, two identical captions, two identical buttons. There was nothing to choose between them.

Now there is one row per IMAGE, and taking it back takes all of it.

## What changed

**Grouping** (`lib/trash-groups.ts`) — repeats of one asset collapse into a single row, keyed on `sourceAsset` first (the provenance the asset panel records, which survives a URL changing) and `src` as the fallback for clips minted before that was tracked. Collections group only with themselves. First-appearance order is preserved, so the bin still reads chronologically. No count badge: how many clips back a row is bookkeeping the user never asked about.

**"Restore" is now "Add"** — the graph has always inserted at `resolveInsertPlacement`, i.e. into the FOCUSED timeline, never "back where it came from". The bin is a place you take images from; where they land is wherever you are. The label now says so.

**Taking the row takes every copy** — one clip moves into the open timeline through the graph, and the copies that never moved are discarded via a new `POST /api/trash`. Uploaded files are untouched, exactly as for emptying: one upload can back several clips.

## The race, and why there is a new module for it

Both the graph and the API are full-document writers of the trash document, and the persistence gateway debounces its batch by `SAVE_DEBOUNCE_MS` (900ms). A discard sent the instant the restore succeeded read the document, dropped the duplicate, saved — and was then overwritten by the graph's batch, built from a cache that still contained it. The duplicate reappeared on the next load.

`lib/graph-trash-discard.ts` fixes the ordering: flush the graph's pending trash write, wait for it to settle, then discard, then announce the rebuild (a mounted graph view still holds those clips as nodes under its trash root). It takes the gateway as a parameter, so the ordering is testable without IO, and gives up rather than hanging on a wedged write — losing the race is recoverable, hanging is not.

## Tests

- `lib/graph-trash-discard.test.ts` — 8 tests, including that the flush strictly precedes the POST, and that a refused write never announces a rebuild.
- `app/api/trash/trash-empty.test.ts` — 7 new tests for `POST` over the real handler and the real save path: discards the named entries, drops ONE entry per id (the bin can hold the same id twice), empties the document without the recovery snapshot refilling it, never deletes an uploaded file, ignores unknown ids without writing, rejects a request with no usable ids, and leaves another user's bin alone.
- Full app suite: 387 passing.

## Verified on the real project

Duplicated a clip, deleted both copies, opened the bin: 3 clips → 2 rows. Clicking Add put one copy into the open timeline, removed the row, and took the bin to 1 item — and it was still 1 item after a full reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)