### PR TITLE
Disabled items keep their slot; the player skips them instead

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -9,6 +9,7 @@ import {
   type CollectionItemShellComponent,
   type CollectionItemShellProps,
   type CollectionTrimOverviewContentComponent,
+  type CollectionsGraph,
   type NodeId,
   type VideoMediaNode,
 } from "@storyboard/ui/dnd-collections";
@@ -212,6 +213,106 @@ export const ComposedCardStructure: Story = {
     await waitFor(() =>
       expect(surface!.getAttribute("aria-label")).toMatch(/^Renamed timeline \(collection/),
     );
+  },
+};
+
+// ── Disabled, and disabled-by-parent ────────────────────────────────────────
+
+/** Builds a details store + provider around an arbitrary graph, so the
+ *  disabled cases can nest the card inside a parent collection. */
+function renderWithGraph(graph: CollectionsGraph) {
+  const detail: ClipDetail = {
+    alt: "A timeline",
+    aspect: 16 / 9,
+    trackIndex: 0,
+    hydrated: false,
+    itemCount: 2,
+    previewItems: [ASSET_A, ASSET_B],
+  };
+  const store = createGraphDetailsStore({ [COLLECTION_ID]: detail });
+  const decorator: Decorator = (Story) => (
+    <DndCollections initialGraph={graph}>
+      <GraphDetailsProvider store={store}>
+        <div className="h-32 w-40 bg-zinc-950 p-2">
+          <Story />
+        </div>
+      </GraphDetailsProvider>
+    </DndCollections>
+  );
+  return decorator;
+}
+
+const graphWithNodeDisabled = (() => {
+  const result = buildGraph([
+    { kind: "collection", id: COLLECTION_ID, name: "A timeline", children: [], disabled: true },
+  ]);
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.value;
+})();
+
+const graphWithParentDisabled = (() => {
+  const result = buildGraph([
+    {
+      kind: "collection",
+      id: "parent" as NodeId,
+      name: "Off parent",
+      disabled: true,
+      children: [{ kind: "collection", id: COLLECTION_ID, name: "A timeline", children: [] }],
+    },
+  ]);
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.value;
+})();
+
+/**
+ * A card disabled on ITSELF: muted, and badged with the word that names why.
+ * The badge is what distinguishes it from the inherited case below — the two
+ * look identical otherwise, on purpose, because a viewer sees neither.
+ */
+export const DisabledCard: Story = {
+  args: baseArgs,
+  decorators: [renderWithGraph(graphWithNodeDisabled)],
+  play: async ({ canvasElement }) => {
+    const surface = canvasElement.querySelector<HTMLElement>("[data-node-id]")!;
+    // Marker CLASS, not data-disabled: SelectionSurface has an explicit prop
+    // list with no rest spread, so a hyphenated attribute would be dropped.
+    await expect(surface.classList.contains("is-disabled-card")).toBe(true);
+    await expect(surface.classList.contains("is-parent-disabled-card")).toBe(false);
+
+    const chip = canvasElement.querySelector<HTMLElement>("[data-disabled-chip]")!;
+    await expect(chip).not.toBeNull();
+    await expect(chip.dataset.disabledChip).toBe("self");
+    await expect(chip.textContent).toBe("DISABLED");
+  },
+};
+
+/**
+ * A card that is off only because a collection ABOVE it is. It carries the
+ * same muted treatment but its own flag is clear, so re-enabling it here would
+ * do nothing — the chip says where to go instead.
+ */
+export const DisabledByParentCard: Story = {
+  args: baseArgs,
+  decorators: [renderWithGraph(graphWithParentDisabled)],
+  play: async ({ canvasElement }) => {
+    const surface = canvasElement.querySelector<HTMLElement>("[data-node-id]")!;
+    await expect(surface.classList.contains("is-disabled-card")).toBe(true);
+    await expect(surface.classList.contains("is-parent-disabled-card")).toBe(true);
+
+    const chip = canvasElement.querySelector<HTMLElement>("[data-disabled-chip]")!;
+    await expect(chip.dataset.disabledChip).toBe("inherited");
+    await expect(chip.textContent).toBe("PARENT OFF");
+  },
+};
+
+/** The ordinary case carries no chip at all. */
+export const NoDisabledChipWhenEnabled: Story = {
+  args: baseArgs,
+  decorators: [renderWithDetail([ASSET_A, ASSET_B])],
+  play: async ({ canvasElement }) => {
+    const surface = canvasElement.querySelector<HTMLElement>("[data-node-id]")!;
+    await expect(surface.classList.contains("is-disabled-card")).toBe(false);
+    await expect(canvasElement.querySelector("[data-disabled-chip]")).toBeNull();
   },
 };
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -33,13 +33,14 @@ import {
   type NodeId,
 } from "@storyboard/ui/dnd-collections";
 import {
-  hydratedCollectionDuration,
+  hydratedCollectionPlayableDuration,
   hydratedCollectionPreviews,
   type CollectionPreviewFrame,
   type DetailsById,
 } from "@storyboard/timeline-domain";
 
 import { useClipDetail, useGraphDetailsStore, useTimelineTitle } from "./graph-details-context";
+import { isDisabledByAncestor } from "./graph-playhead-model";
 import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
 import { GraphViewNavContext } from "./graph-navigation";
 import { TrimFramePreview } from "./graph-trim-frame-preview";
@@ -196,8 +197,12 @@ function useHydratedCollectionSeconds(id: string, enabled: boolean): number | nu
   const detailsStore = useGraphDetailsStore();
   const [derive] = useState(() =>
     createDerivedCache({
+      // PLAYABLE seconds, not the layout span: this is the card's readout, and
+      // it should say what a viewer would sit through. The layout twin
+      // (`hydratedCollectionDuration`) still drives the clip's duration in the
+      // projection, where the disabled slot has to survive.
       compute: (graph: CollectionsGraph, details: DetailsById, nodeId: NodeId) =>
-        hydratedCollectionDuration(graph, details, nodeId),
+        hydratedCollectionPlayableDuration(graph, details, nodeId),
       contentKey: (seconds) => String(Math.round(seconds * 1000)),
     }),
   );
@@ -240,6 +245,47 @@ function LiveDurationPill({ id, node }: { id: NodeId; node: MediaNode }) {
   );
 }
 
+/**
+ * Whether a COLLECTION above this card is disabled. Primitive return, per the
+ * store's selector contract — the walk itself is
+ * `isDisabledByAncestor` in graph-playhead-model, shared with the seek rail so
+ * the card and the rail can never disagree about what is off.
+ */
+function useDisabledByAncestor(id: NodeId): boolean {
+  return useCollectionsSelector((snapshot) => isDisabledByAncestor(snapshot.graph, id as string));
+}
+
+/**
+ * The card's "this will not play" badge, top-right.
+ *
+ * Two causes, two words, because the fix differs: a card disabled OUTRIGHT is
+ * re-enabled on itself, while one that is off because an ancestor collection
+ * is off cannot be re-enabled here at all — you have to go up and turn the
+ * collection back on. Muting them identically but labelling them the same
+ * would strand someone clicking a toggle that cannot help them.
+ */
+function DisabledChip({ inherited }: { inherited: boolean }) {
+  return (
+    <span
+      aria-hidden="true"
+      data-disabled-chip={inherited ? "inherited" : "self"}
+      title={
+        inherited
+          ? "Skipped — a collection above this one is disabled"
+          : "Skipped during playback"
+      }
+      className={[
+        "pointer-events-none absolute right-1 top-1 z-10 rounded px-1 py-0.5 font-mono text-[8px] leading-none font-semibold tracking-[0.08em]",
+        inherited
+          ? "bg-black/75 text-zinc-300 ring-1 ring-zinc-500/40"
+          : "bg-black/80 text-amber-300 ring-1 ring-amber-400/40",
+      ].join(" ")}
+    >
+      {inherited ? "PARENT OFF" : "DISABLED"}
+    </span>
+  );
+}
+
 const GraphClipContent = memo(function GraphClipContent({
   id,
   node,
@@ -257,6 +303,8 @@ const GraphClipContent = memo(function GraphClipContent({
   const measuredFrames =
     cardSize.height > 0 ? Math.round(cardSize.width / cardSize.height) : 0;
   const settledFrames = useSettledFrameCount(measuredFrames);
+  // Above the collection early-return below — hooks may not be conditional.
+  const inheritedDisabled = useDisabledByAncestor(id);
 
   // MEDIA pixels only. Collections don't render through this seam anymore:
   // their card carries interactive controls (folder drill-in, inline rename),
@@ -304,9 +352,14 @@ const GraphClipContent = memo(function GraphClipContent({
         // and its full width (its duration still shapes the board), it just
         // stops looking like content that plays. Grayscale + reduced opacity
         // survives on top of any artwork, where a tint would not.
-        node.disabled ? "opacity-45 grayscale" : "",
+        //
+        // Inherited disabling looks IDENTICAL — a viewer sees neither — and
+        // only the chip distinguishes them.
+        node.disabled || inheritedDisabled ? "opacity-45 grayscale" : "",
       ].join(" ")}
-      data-disabled={node.disabled ? "true" : undefined}
+      // Distinct VALUES so e2e can assert which cause is in play; both are
+      // truthy for "this card is muted".
+      data-disabled={node.disabled ? "true" : inheritedDisabled ? "inherited" : undefined}
     >
       {frameSrcs.length === 0 ? (
         <span className="flex h-full w-full items-center justify-center text-[10px] text-zinc-500">
@@ -340,6 +393,9 @@ const GraphClipContent = memo(function GraphClipContent({
       >
         {isVideo ? "VIDEO" : "IMAGE"}
       </span>
+      {(node.disabled || inheritedDisabled) && (
+        <DisabledChip inherited={node.disabled !== true} />
+      )}
       {trimEnabled && <LiveDurationPill id={id} node={node} />}
       {/* Floating frame-at-the-edge panel during a trim drag (video only) —
           rides the same per-node live-trim channel as the pill. */}
@@ -560,9 +616,14 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
   // the served summary (which derives itemCount from the effective document).
   // `childCount` from the primitive counts every child, disabled included.
   const count = hydrated ? enabledChildCount : (detail?.itemCount ?? enabledChildCount);
-  const totalSeconds = hydrated ? liveSeconds : detail?.duration;
+  // Playable seconds both ways: live for a hydrated collection, and for a
+  // placeholder the stored `playableDuration` summary — falling back to
+  // `duration` for documents saved before the split, where the two are equal.
+  const totalSeconds = hydrated ? liveSeconds : (detail?.playableDuration ?? detail?.duration);
   const previews = useCollectionPreviewFrames(id as string, hydrated, detail?.previewItems);
   const displayName = title ?? node.name;
+  const inheritedDisabled = useDisabledByAncestor(id);
+  const muted = node.disabled === true || inheritedDisabled;
 
   return (
     <>
@@ -577,18 +638,24 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
         // displaying "9" until its clips load.
         ariaLabel={`${displayName} (collection, ${count} items)`}
         className={[
-          "flex h-full w-full flex-col justify-between overflow-hidden rounded-md border border-dashed border-sky-500/40 bg-sky-500/[0.08] p-1.5",
+          // `relative` so the disabled chip below can pin to this card's own
+          // top-right corner rather than some ancestor's.
+          "relative flex h-full w-full flex-col justify-between overflow-hidden rounded-md border border-dashed border-sky-500/40 bg-sky-500/[0.08] p-1.5",
           selected ? "ring-2 ring-amber-400" : "",
           rejected ? "ring-2 ring-red-500 motion-safe:animate-pulse" : "",
           isDragSource ? "opacity-40" : "",
           // No `data-disabled` twin here: SelectionSurface takes an explicit
           // prop list with no rest spread, so a hyphenated attribute passed to
           // it is silently dropped — and TS does not flag it, because excess
-          // property checks skip hyphenated JSX names. The marker class below
-          // is what tests and e2e can query on a collection card.
-          node.disabled ? "opacity-45 grayscale is-disabled-card" : "",
+          // property checks skip hyphenated JSX names. The marker classes below
+          // are what tests and e2e can query on a collection card; the
+          // inherited one gets its own so the two causes stay separable, the
+          // way `data-disabled`'s values do on a media card.
+          muted ? "opacity-45 grayscale is-disabled-card" : "",
+          muted && node.disabled !== true ? "is-parent-disabled-card" : "",
         ].join(" ")}
       >
+        {muted && <DisabledChip inherited={node.disabled !== true} />}
         <span className="flex min-h-0 flex-1 gap-0.5 overflow-hidden">
           {previews.length === 0 ? (
             <span className="flex flex-1 items-center justify-center text-[9px] text-zinc-500">

--- a/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.test.ts
@@ -9,11 +9,14 @@ import {
   buildRulerTicks,
   cardSpansOf,
   childSpans,
+  disabledCardSegments,
+  isDisabledByAncestor,
   manifestTrailsLedger,
   MAX_MANIFEST_FETCH_RETRIES,
   mediaSpanKey,
   nextManifestClipsState,
   nextManifestFailureCount,
+  playableSpanSeconds,
   rulerMajorSpacing,
   rulerSubtierCount,
   shouldRetryManifestFetch,
@@ -132,6 +135,111 @@ describe("childSpans", () => {
       expect(x).toBeGreaterThanOrEqual(previousX);
       previousX = x;
     }
+  });
+});
+
+describe("disabled cards", () => {
+  const disabledMedia = (id: string, durationSeconds: number): GraphNodeSpec => ({
+    kind: "media",
+    id,
+    name: id,
+    durationSeconds,
+    disabled: true,
+  });
+
+  it("marks a card whose own node is disabled", () => {
+    const graph = graphOf([
+      collection("root", [media("a", 4), disabledMedia("b", 4), media("c", 4)]),
+    ]);
+
+    const cards = childSpans(graph, {}, "root", null, flatWidth);
+
+    expect(cards.map((card) => card.disabled)).toEqual([undefined, true, undefined]);
+  });
+
+  it("marks EVERY card when the focused collection itself is disabled", () => {
+    // Drilled into a disabled collection: none of these children carry the
+    // flag, but nothing here plays, so the rail must dim the whole level.
+    const graph = graphOf([
+      collection("root", [
+        { kind: "collection", id: "off", name: "off", disabled: true, children: [media("x", 4), media("y", 4)] },
+      ]),
+    ]);
+
+    const cards = childSpans(graph, {}, "off", null, flatWidth);
+
+    expect(cards.map((card) => card.disabled)).toEqual([true, true]);
+  });
+
+  it("marks cards nested any depth below a disabled collection", () => {
+    const graph = graphOf([
+      collection("root", [
+        {
+          kind: "collection",
+          id: "off",
+          name: "off",
+          disabled: true,
+          children: [collection("inner", [media("deep", 4)])],
+        },
+      ]),
+    ]);
+
+    expect(isDisabledByAncestor(graph, "inner")).toBe(true);
+    expect(isDisabledByAncestor(graph, "deep")).toBe(true);
+    expect(childSpans(graph, {}, "inner", null, flatWidth)[0].disabled).toBe(true);
+  });
+
+  it("does not report a node's OWN flag as inherited", () => {
+    // The card needs to tell the two apart — they show different chips, and
+    // only one of them can be fixed on the card itself.
+    const graph = graphOf([collection("root", [disabledMedia("b", 4)])]);
+
+    expect(isDisabledByAncestor(graph, "b")).toBe(false);
+  });
+});
+
+describe("playableSpanSeconds", () => {
+  const card = (startTime: number, endTime: number, disabled = false): ChildSpan => ({
+    startTime,
+    endTime,
+    width: 100,
+    ...(disabled ? { disabled: true } : {}),
+  });
+
+  it("equals the last card's end when nothing is disabled", () => {
+    // The number this replaced, so an untouched timeline reads identically.
+    const cards = [card(0, 4), card(4.12, 8.12), card(8.24, 12.24)];
+    expect(playableSpanSeconds(cards)).toBeCloseTo(12.24, 6);
+  });
+
+  it("drops a disabled card's span AND its gap", () => {
+    const cards = [card(0, 4), card(4.12, 8.12, true), card(8.24, 12.24)];
+    expect(playableSpanSeconds(cards)).toBeCloseTo(8.12, 6);
+  });
+
+  it("is zero when every card is disabled", () => {
+    expect(playableSpanSeconds([card(0, 4, true), card(4.12, 8.12, true)])).toBe(0);
+  });
+});
+
+describe("disabledCardSegments", () => {
+  it("places a segment under each disabled card, in strip coordinates", () => {
+    const cards: ChildSpan[] = [
+      { startTime: 0, endTime: 4, width: 100 },
+      { startTime: 4, endTime: 8, width: 60, disabled: true },
+      { startTime: 8, endTime: 12, width: 40, disabled: true },
+    ];
+
+    expect(disabledCardSegments(cards)).toEqual([
+      { x: 100 + STRIP_GAP_PX, width: 60 },
+      { x: 100 + 60 + STRIP_GAP_PX * 2, width: 40 },
+    ]);
+  });
+
+  it("returns nothing when every card plays", () => {
+    expect(
+      disabledCardSegments([{ startTime: 0, endTime: 4, width: 100 }]),
+    ).toEqual([]);
   });
 });
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.ts
@@ -4,6 +4,10 @@ import {
   type DetailsById,
   type PlaybackManifest,
 } from "@storyboard/timeline-domain";
+import {
+  CLIP_GAP_SECONDS,
+  TIMELINE_LEADING_PADDING_SECONDS,
+} from "@storyboard/timeline-model/constants";
 import type { TimelineClip } from "@storyboard/timeline-model/types";
 
 import { GRID_GAP } from "./graph-view-config";
@@ -164,7 +168,16 @@ export function shouldRetryManifestFetch(
   return consecutiveFailures > 0 && consecutiveFailures <= maxRetries;
 }
 
-export type ChildSpan = Readonly<{ startTime: number; endTime: number; width: number }>;
+export type ChildSpan = Readonly<{
+  startTime: number;
+  endTime: number;
+  width: number;
+  /** Won't play — the seek rail dims this stretch and the player jumps it.
+   *  True for a clip disabled outright AND for one whose collection ancestor
+   *  is (see `isDisabledByAncestor`); the rail draws no distinction, because
+   *  either way nothing here reaches the viewer. */
+  disabled?: boolean;
+}>;
 
 /**
  * Each direct child of `collectionId`, with its time window in the clock the
@@ -190,6 +203,29 @@ export type ChildSpan = Readonly<{ startTime: number; endTime: number; width: nu
  * manifest paths are built from, but `graphChildrenToClips` maps over the
  * same `getChildren` array, so index alignment holds.
  */
+/**
+ * Whether any COLLECTION above this node is disabled — the inherited state.
+ * Disabling a collection disables everything inside it, at any depth, and a
+ * descendant cannot opt back in.
+ *
+ * The node's own flag is deliberately NOT consulted: callers need to tell "off
+ * because I said so" from "off because my parent is", and they show different
+ * chips. Ask this and the node's own `disabled` separately.
+ *
+ * Cycle-guarded with a seen set — `parentById` is a tree in practice, but this
+ * runs on the render path and a malformed graph must not hang it.
+ */
+export function isDisabledByAncestor(graph: CollectionsGraph, nodeId: string): boolean {
+  const seen = new Set<string>();
+  let parent = graph.parentById.get(nodeId as never) ?? null;
+  while (parent !== null && !seen.has(parent as string)) {
+    if (graph.nodesById.get(parent)?.disabled === true) return true;
+    seen.add(parent as string);
+    parent = graph.parentById.get(parent) ?? null;
+  }
+  return false;
+}
+
 export function childSpans(
   graph: CollectionsGraph,
   details: DetailsById,
@@ -198,6 +234,13 @@ export function childSpans(
   widthForClip: (clip: TimelineClip) => number,
 ): ChildSpan[] {
   const childIds = getChildren(graph, parseNodeId(collectionId));
+  // Drilled INTO a disabled collection: none of these children carry the flag
+  // themselves, but nothing here plays, so every card counts as disabled for
+  // the rail. Resolved once for the whole level — it cannot vary between
+  // siblings.
+  const focusDisabled =
+    graph.nodesById.get(parseNodeId(collectionId))?.disabled === true ||
+    isDisabledByAncestor(graph, collectionId);
   let previousEnd = 0;
   return graphChildrenToClips(graph, details, collectionId).map((clip, index) => {
     const childId = childIds[index] as string;
@@ -209,8 +252,56 @@ export function childSpans(
     const startTime = Math.max(span ? span.start : clip.startTime, previousEnd);
     const endTime = Math.max(span ? span.end : clip.startTime + clip.duration, startTime);
     previousEnd = endTime;
-    return { width: widthForClip(clip), startTime, endTime };
+    return {
+      width: widthForClip(clip),
+      startTime,
+      endTime,
+      ...(focusDisabled || clip.disabled === true ? { disabled: true } : {}),
+    };
   });
+}
+
+/**
+ * Seconds of these cards that will actually PLAY — the readout number, as
+ * opposed to the layout span the playhead sweeps.
+ *
+ * The two are the same until something is disabled, and this reduces to the
+ * old `last.endTime` exactly when nothing is: leading padding, plus each
+ * enabled card's own length, plus one gap between neighbours. Disabled cards
+ * contribute neither their span nor a gap, which is what keeps the header
+ * total describing what a viewer would sit through rather than how far the
+ * playhead can travel.
+ *
+ * Card lengths come from `childSpans`, so a collection contributes the
+ * manifest's full-depth window rather than a stored summary guess.
+ */
+/**
+ * Content-space x ranges of the cards that will NOT play, in the strip's own
+ * layout (widths plus the inter-card gutter — the same accumulation
+ * `buildPlayheadMap` walks, so a segment lands exactly under its card).
+ *
+ * Shared by the strip's seek rail and the ruler band so the two mark the same
+ * stretches; a disabled item reads as one continuous dimmed run across both.
+ */
+export function disabledCardSegments(
+  cards: readonly ChildSpan[],
+): Array<Readonly<{ x: number; width: number }>> {
+  const segments: Array<Readonly<{ x: number; width: number }>> = [];
+  let cursor = 0;
+  for (const card of cards) {
+    if (card.disabled === true) segments.push({ x: cursor, width: card.width });
+    cursor += card.width + STRIP_GAP_PX;
+  }
+  return segments;
+}
+
+export function playableSpanSeconds(cards: readonly ChildSpan[]): number {
+  const enabled = cards.filter((card) => card.disabled !== true);
+  if (enabled.length === 0) return 0;
+  const content = enabled.reduce((total, card) => total + (card.endTime - card.startTime), 0);
+  return (
+    TIMELINE_LEADING_PADDING_SECONDS + content + CLIP_GAP_SECONDS * (enabled.length - 1)
+  );
 }
 
 export type PlayheadMap = Readonly<{

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -35,10 +35,12 @@ import {
   buildRulerTicks,
   cardSpansOf,
   childSpans,
+  disabledCardSegments,
   formatRulerTick,
   manifestTrailsLedger,
   nextManifestClipsState,
   nextManifestFailureCount,
+  playableSpanSeconds,
   shouldRetryManifestFetch,
   STRIP_GAP_PX,
   type ChildSpan,
@@ -56,8 +58,6 @@ import {
 } from "@storyboard/ui/timeline/timeline-document-store";
 import { createTimelineDocumentsState } from "@storyboard/ui/timeline/timeline-documents";
 import type { TimelineClip, TimelineDocument } from "@storyboard/ui/timeline/types";
-
-import { enabledClips, packTimelineClips } from "@storyboard/timeline-model";
 
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 import { requestGraphPreviewToggle } from "@/lib/graph-view-events";
@@ -179,9 +179,13 @@ export function useFocusedTimelineAggregate(
   );
   return useMemo(() => {
     const cards = childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond));
+    // Enabled-only, both numbers: this readout says what a viewer would sit
+    // through, which is NOT how far the playhead travels now that disabled
+    // cards keep their span. The two disagree by design — the ruler runs
+    // longer than the total claimed here whenever something is disabled.
     return {
-      count: cards.length,
-      seconds: cards.length > 0 ? cards[cards.length - 1].endTime : 0,
+      count: cards.filter((card) => card.disabled !== true).length,
+      seconds: playableSpanSeconds(cards),
     };
   }, [graph, details, focusedId, spans, pixelsPerSecond]);
 }
@@ -385,7 +389,7 @@ export function GraphRuler({
   // zoom no longer mints thousands of offscreen tick elements per commit —
   // tick count follows the VIEWPORT, not the duration. Scrolling recomputes
   // only on chunk crossings (tickWindow identity is stable between them).
-  const { ticks, collectionSpans } = useMemo(() => {
+  const { ticks, collectionSpans, skips } = useMemo(() => {
     const clips = graphChildrenToClips(graph, details, focusedId);
     const cards = childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond));
     const isCollection = clips.map((clip) => clip.kind === "collection");
@@ -395,6 +399,9 @@ export function GraphRuler({
       // — fill its stretch of the band with the content duration instead
       // (R7 #4), same live-derived total the card badge shows.
       collectionSpans: buildRulerCollectionSpans(cards, isCollection, tickWindow),
+      // Same segments the seek rail dims, so a skipped stretch reads as one
+      // run down through the ruler and the scrubber.
+      skips: disabledCardSegments(cards),
     };
   }, [graph, details, spans, focusedId, pixelsPerSecond, tickWindow]);
 
@@ -410,6 +417,17 @@ export function GraphRuler({
           strip with a bright baseline keeps the whole ruler legible over ANY
           clip, at every zoom. */}
       <div className="absolute inset-x-0 top-0 h-[18px] border-b border-sky-400/50 bg-zinc-950/90" />
+      {/* Skipped stretches, under the ticks: the band goes flat and gray where
+          playback will not travel, so the ruler reads as measuring a timeline
+          with holes in it rather than one continuous run. */}
+      {skips.map((segment, index) => (
+        <div
+          key={`skip-${index}`}
+          data-ruler-skip
+          className="absolute top-0 h-[18px] bg-zinc-700/50"
+          style={{ transform: `translateX(${segment.x}px)`, width: segment.width }}
+        />
+      ))}
       {ticks.map((tick, index) => (
         <div key={index} className="absolute top-0" style={{ transform: `translateX(${tick.x}px)` }}>
           {/* Tier drives height + brightness: labeled majors run the full band
@@ -769,6 +787,23 @@ function SeekRailRow({
         aria-hidden="true"
         className="absolute inset-y-0 left-0 rounded-full bg-sky-300/80"
       />
+      {/* SKIP marks: the cells playback will jump over. One per disabled card
+          in THIS row, laid on the row's own cell pitch — a grid cell is a
+          fixed width, so the mark is the cell, not a time range. */}
+      {rowCards.map((card, index) =>
+        card.disabled === true ? (
+          <span
+            key={`skip-${index}`}
+            data-rail-skip
+            aria-hidden="true"
+            className="absolute inset-y-0 bg-zinc-600/70"
+            style={{
+              left: `${((index * pitch) / extent) * 100}%`,
+              width: `${(cellWidth / extent) * 100}%`,
+            }}
+          />
+        ) : null,
+      )}
       {rowCards.slice(1).map((_, index) => (
         <span
           key={index}
@@ -1008,14 +1043,18 @@ export function GraphStripSeekRail({
   // The rail's content width ends at the LAST item's right edge, and the
   // interior ticks sit at the gap centres between cards — the strip twin of
   // the grid rails' cell-edge ticks.
-  const { extent, ticks } = useMemo(() => {
+  const { extent, ticks, skips } = useMemo(() => {
     let cursor = 0;
     const tickXs: number[] = [];
     cards.forEach((card, index) => {
       if (index > 0) tickXs.push(cursor - STRIP_GAP_PX / 2);
       cursor += card.width + STRIP_GAP_PX;
     });
-    return { extent: Math.max(1, cursor - STRIP_GAP_PX), ticks: tickXs };
+    return {
+      extent: Math.max(1, cursor - STRIP_GAP_PX),
+      ticks: tickXs,
+      skips: disabledCardSegments(cards),
+    };
   }, [cards]);
 
   // Window geometry over the scroller's padding band, measured like the
@@ -1285,6 +1324,19 @@ export function GraphStripSeekRail({
             aria-hidden="true"
             className="absolute inset-y-0 left-0 rounded-full bg-sky-300/80"
           />
+          {/* SKIP marks, over the fill: the stretches playback will jump. A
+              neutral scrim rather than a colour of its own — the point is
+              that this part of the rail is dead, and a dead stretch should
+              look drained next to the live fill, not decorated. */}
+          {skips.map((segment, index) => (
+            <span
+              key={`skip-${index}`}
+              data-rail-skip
+              aria-hidden="true"
+              className="absolute inset-y-0 bg-zinc-600/70"
+              style={{ left: segment.x, width: segment.width }}
+            />
+          ))}
           {ticks.map((x, index) => (
             <span
               key={index}
@@ -1556,18 +1608,14 @@ export function PreviewShell({
     detailsStore.read,
     detailsStore.read,
   );
-  // Disabled clips are dropped and the rest repacked, matching what the
-  // manifest compiles — otherwise the pane would play one timeline before the
-  // manifest lands and a different one after.
-  //
-  // The filter lives HERE, not in `graphChildrenToClips`: that same function
-  // is what graph-persistence writes to storage, so skipping clips inside it
-  // would DELETE every disabled clip on the next commit.
+  // Disabled clips ride through UNFILTERED and unrepacked, matching what the
+  // manifest now compiles — otherwise the pane would play one timeline before
+  // the manifest lands and a different one after. They already carry
+  // `disabled` off the graph node (see graphChildrenToClips), and the display
+  // surface is what acts on it: jump the span while playing, gray it while
+  // scrubbing.
   const projectionClips = useMemo<TimelineClip[]>(
-    () =>
-      enabled
-        ? packTimelineClips(enabledClips(graphChildrenToClips(graph, details, focusedId)))
-        : [],
+    () => (enabled ? graphChildrenToClips(graph, details, focusedId) : []),
     [enabled, graph, details, focusedId],
   );
   // The pane plays the manifest (full nested depth) once it lands; until

--- a/apps/timeline-gstudio001/lib/derive-collection-summaries.test.ts
+++ b/apps/timeline-gstudio001/lib/derive-collection-summaries.test.ts
@@ -252,8 +252,8 @@ describe("collectionChildIds", () => {
   });
 });
 
-describe("disabled clips are excluded from summaries", () => {
-  it("drops a disabled child clip from itemCount, duration and previewItems", () => {
+describe("disabled clips split geometry from the readouts", () => {
+  it("keeps a disabled child in `duration` but out of the readouts", () => {
     const child = docOf("child-1", [
       mediaClip("keep", { startTime: 0, duration: 4 }),
       { ...mediaClip("skip", { startTime: 4.12, duration: 6 }), disabled: true },
@@ -263,10 +263,13 @@ describe("disabled clips are excluded from summaries", () => {
     const { document } = deriveCollectionSummaries(parent, new Map([["child-1", child]]));
     const col = document.clips[0] as CollectionTimelineClip;
 
+    // LAYOUT: the full 4 + gap + 6 span. The collection's slot has to cover
+    // its disabled child, or the manifest's window math would squeeze the
+    // child's real content into a shorter parent span and play it fast.
+    expect(col.duration).toBeCloseTo(10.12, 6);
+    // READOUTS: what a viewer would actually see.
+    expect(col.playableDuration).toBeCloseTo(4, 6);
     expect(col.itemCount).toBe(1);
-    // 4s of content, not 4 + gap + 6 — the disabled clip contributes nothing
-    // to the time total and the survivor is repacked to the start.
-    expect(col.duration).toBeCloseTo(4, 6);
     expect(col.previewItems?.map((item) => item.id)).toEqual(["keep"]);
   });
 
@@ -288,17 +291,50 @@ describe("disabled clips are excluded from summaries", () => {
 
     const leafSummary = derived.mid.clips[0] as CollectionTimelineClip;
     expect(leafSummary.itemCount).toBe(1);
-    expect(leafSummary.duration).toBeCloseTo(4, 6);
+    expect(leafSummary.duration).toBeCloseTo(8.12, 6);
+    expect(leafSummary.playableDuration).toBeCloseTo(4, 6);
 
-    // The grandparent shrank too, without knowing why.
+    // The grandparent's PLAYABLE time shrank too, without knowing why — while
+    // its layout span still covers everything below it. This is the assertion
+    // that pins the propagation THROUGH a collection child: mid's playable
+    // time has to read leaf-ref's playableDuration (4), not its layout
+    // duration (8.12), or a deep disable would stop one level up.
     const midSummary = derived.root.clips[0] as CollectionTimelineClip;
-    expect(midSummary.duration).toBeCloseTo(4, 6);
     expect(midSummary.itemCount).toBe(1);
+    expect(midSummary.playableDuration).toBeCloseTo(4, 6);
+    expect(midSummary.duration).toBeCloseTo(8.12, 6);
   });
 
-  it("treats an all-disabled collection like an empty one", () => {
-    // Deliberate: all-disabled and empty are the same thing to a reader, and
-    // a zero-duration card would be new behaviour rather than consistency.
+  it("omits playableDuration entirely when nothing is disabled", () => {
+    // The field must not appear on documents that never use the feature —
+    // same convention as `disabled` itself.
+    const child = docOf("child-1", [mediaClip("a", { startTime: 0, duration: 4 })]);
+    const parent = docOf("parent", [collectionClip("col", "child-1")]);
+
+    const { document } = deriveCollectionSummaries(parent, new Map([["child-1", child]]));
+    const col = document.clips[0] as CollectionTimelineClip;
+
+    expect("playableDuration" in col).toBe(false);
+  });
+
+  it("clears a stale playableDuration once the child is re-enabled", () => {
+    // The derivation spreads the previous clip, so re-enabling must DELETE the
+    // key rather than leave the old playable time sitting there.
+    const child = docOf("child-1", [mediaClip("a", { startTime: 0, duration: 4 })]);
+    const parent = docOf("parent", [
+      { ...collectionClip("col", "child-1"), playableDuration: 2 },
+    ]);
+
+    const { document } = deriveCollectionSummaries(parent, new Map([["child-1", child]]));
+    const col = document.clips[0] as CollectionTimelineClip;
+
+    expect(col.playableDuration).toBeUndefined();
+  });
+
+  it("gives an all-disabled collection the same PLAYABLE time as an empty one", () => {
+    // Deliberate: all-disabled and empty are the same thing to a reader. Their
+    // layout spans differ, though — the all-disabled one still has a child
+    // occupying room on the board.
     const child = docOf("child-1", [
       { ...mediaClip("x", { duration: 4 }), disabled: true },
     ]);
@@ -312,7 +348,8 @@ describe("disabled clips are excluded from summaries", () => {
     const a = allDisabled.document.clips[0] as CollectionTimelineClip;
     const b = isEmpty.document.clips[0] as CollectionTimelineClip;
     expect(a.itemCount).toBe(b.itemCount);
-    expect(a.duration).toBe(b.duration);
+    expect(a.playableDuration ?? a.duration).toBe(b.duration);
+    expect(a.duration).toBeGreaterThan(b.duration);
   });
 
   it("keeps the PARENT's own disabled clip in place", () => {

--- a/apps/timeline-gstudio001/lib/derive-collection-summaries.ts
+++ b/apps/timeline-gstudio001/lib/derive-collection-summaries.ts
@@ -1,10 +1,18 @@
-import { TIMELINE_LEADING_PADDING_SECONDS } from "@storyboard/timeline-model/constants";
 import {
+  CLIP_GAP_SECONDS,
+  TIMELINE_LEADING_PADDING_SECONDS,
+} from "@storyboard/timeline-model/constants";
+import {
+  collectionSpanSeconds,
   effectiveDocument,
+  enabledClips,
   packTimelineClips,
   previewItemsFrom,
 } from "@storyboard/timeline-model";
-import type { TimelineDocument } from "@storyboard/timeline-model/types";
+import type {
+  CollectionTimelineClip,
+  TimelineDocument,
+} from "@storyboard/timeline-model/types";
 
 // Read-time derivation of collection-clip summaries (review finding: stale
 // parents). A collection clip stores DENORMALIZED child facts — title,
@@ -23,6 +31,31 @@ import type { TimelineDocument } from "@storyboard/timeline-model/types";
 // Served, not persisted: writing back on every GET would add load and
 // races for a value the next GET rederives anyway.
 
+/**
+ * The playable span of a document — leading padding, each enabled clip's
+ * playable length, one gap between neighbours.
+ *
+ * Not simply `collectionSpanSeconds(enabledClips(...))`: a nested COLLECTION
+ * child is enabled yet may itself contain disabled descendants, and its
+ * `duration` is the layout span that counts them. Reading its own
+ * `playableDuration` is what carries a deep disable up through every ancestor
+ * — `deriveClosureSummaries` derives children first, so by the time a parent
+ * is summarized its collection children already carry the right number.
+ */
+function playableSpanOf(document: TimelineDocument): number {
+  const enabled = enabledClips(document.clips);
+  if (enabled.length === 0) return 3;
+  const content = enabled.reduce(
+    (total, clip) =>
+      total +
+      (clip.kind === "collection" ? (clip.playableDuration ?? clip.duration) : clip.duration),
+    0,
+  );
+  return (
+    TIMELINE_LEADING_PADDING_SECONDS + content + CLIP_GAP_SECONDS * (enabled.length - 1)
+  );
+}
+
 export function deriveCollectionSummaries(
   document: TimelineDocument,
   childDocuments: ReadonlyMap<string, TimelineDocument | null>,
@@ -37,37 +70,43 @@ export function deriveCollectionSummaries(
     if (!child) return clip;
 
     const title = child.title || clip.title;
-    // Summaries describe what the collection CONTRIBUTES, so they are derived
-    // from the child's ENABLED clips, repacked. That is what makes a disabled
-    // clip vanish from counts and time totals — and because
-    // `deriveClosureSummaries` runs bottom-up, disabling something three
-    // levels down shrinks every ancestor automatically, with no reverse index.
+    // GEOMETRY vs READOUT — the one distinction this derivation carries.
     //
-    // A collection whose children are ALL disabled falls to the same
-    // `duration = 3` an empty collection already gets: all-disabled and empty
-    // are the same thing to a reader, and inventing a zero-width case here
-    // would be new behaviour, not consistency.
+    // `duration` is the collection's LAYOUT span, so it counts every child
+    // including disabled ones. It has to: the manifest maps a parent's output
+    // span onto the child's local time range, so a duration that excluded a
+    // disabled grandchild would window the child's full content into a
+    // too-short span and play it fast. It is also the card's slot on the
+    // board, which is what the playhead jumps over.
+    //
+    // The READOUTS — itemCount, previewItems, playableDuration — describe what
+    // actually plays, so they come from the ENABLED projection. Because
+    // `deriveClosureSummaries` runs bottom-up, disabling something three levels
+    // down shrinks every ancestor's playable time automatically, with no
+    // reverse index.
     const effectiveChild = effectiveDocument(child);
     const itemCount = effectiveChild.clips.length;
     const previewItems = previewItemsFrom(effectiveChild.clips);
-    let duration = 3;
-    if (effectiveChild.clips.length > 0) {
-      const last = effectiveChild.clips[effectiveChild.clips.length - 1];
-      duration = last.startTime + last.duration + TIMELINE_LEADING_PADDING_SECONDS;
-    }
+    const duration = collectionSpanSeconds(child.clips);
+    const playable = playableSpanOf(child);
+    // Omitted when nothing under the collection is disabled — `duration` is
+    // already the playable time then, and documents that never use the feature
+    // never grow the field (same convention as `disabled` itself).
+    const playableDuration = playable === duration ? undefined : playable;
 
     if (
       clip.title === title &&
       clip.itemCount === itemCount &&
       clip.duration === duration &&
       clip.sourceDuration === duration &&
+      clip.playableDuration === playableDuration &&
       JSON.stringify(clip.previewItems ?? []) === JSON.stringify(previewItems)
     ) {
       return clip;
     }
 
     changed = true;
-    return {
+    const next: CollectionTimelineClip = {
       ...clip,
       title,
       alt: `${title} collection`,
@@ -76,6 +115,12 @@ export function deriveCollectionSummaries(
       duration,
       sourceDuration: duration,
     };
+    // Assign-or-DELETE, not a spread of `undefined`: a collection that had a
+    // disabled child and no longer does must lose the key outright, or the
+    // spread above would carry the stale playable time forward.
+    if (playableDuration === undefined) delete next.playableDuration;
+    else next.playableDuration = playableDuration;
+    return next;
   });
 
   if (!changed) return { document, changed: false };

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -2269,6 +2269,70 @@ test.describe("graph view E2E", () => {
     await expect(undoButton(page)).toBeDisabled();
   });
 
+  test("a disabled clip keeps its slot: the rail marks it, scrubbing lands in it grayed, and play jumps it", async ({
+    page,
+  }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    const bravo = strip(page, PROJECT_ID).locator('[data-node-id="bravo"]');
+
+    // Disable the middle clip through the sidebar action.
+    await expect(async () => {
+      await bravo.click();
+      await expect(bravo).toHaveAttribute("data-selected", "true", { timeout: 700 });
+    }).toPass({ timeout: 10000 });
+    await page.getByRole("button", { name: "Disable", exact: true }).click();
+
+    // The card stays exactly where it was, muted and badged — never removed.
+    // `data-disabled` rides the CONTENT span inside the dnd button, not the
+    // button itself (which carries dnd-kit's own aria-disabled).
+    await expect(bravo.locator('[data-disabled="true"]')).toBeVisible();
+    await expect(bravo.locator('[data-disabled-chip="self"]')).toHaveText("DISABLED");
+    await expect.poll(() => stripOrder(page, PROJECT_ID)).toEqual([
+      "alpha",
+      "bravo",
+      CHILD_ID,
+      "charlie",
+    ]);
+
+    // Deselect: a live selection swaps the sidebar's layout controls (the
+    // preview toggle among them) for the item-action cluster.
+    // (Deselecting REMOVES data-selected rather than setting it false, so the
+    // aria state is what to wait on.)
+    await expect(async () => {
+      await bravo.click();
+      await expect(bravo).toHaveAttribute("aria-pressed", "false", { timeout: 700 });
+    }).toPass({ timeout: 10000 });
+
+    await previewToggle(page).click();
+    const rail = page.locator("[data-graph-seek-rail]").first();
+    await expect(rail).toBeVisible();
+    // The skip is visible in the scrubber before anything is played.
+    await expect(page.locator("[data-rail-skip]").first()).toBeVisible();
+
+    // SCRUB into the disabled clip: allowed, and the frame reads as excluded.
+    // Its span is the second card's, so a press around 40% of the rail lands
+    // inside it; nudge along the rail until the badge shows.
+    const badge = page.getByTestId("workbench-display-disabled");
+    const box = (await rail.boundingBox())!;
+    await expect(async () => {
+      for (const fraction of [0.3, 0.35, 0.4, 0.45, 0.5]) {
+        await page.mouse.move(box.x + box.width * fraction, box.y + box.height / 2);
+        await page.mouse.down();
+        await page.mouse.up();
+        if (await badge.isVisible()) return;
+      }
+      throw new Error("never scrubbed into the disabled clip");
+    }).toPass({ timeout: 10000 });
+
+    // PLAY from inside it: the playhead must leave the span immediately rather
+    // than sit through the clip's full duration showing a held frame. The
+    // badge clearing IS the jump — it only shows while the clock is inside a
+    // disabled clip.
+    await page.getByRole("button", { name: "Play workbench preview" }).click();
+    await expect(badge).toBeHidden({ timeout: 2000 });
+  });
+
   test("selecting a clip switches the rail to item actions; Duplicate clones it after itself; Delete returns to normal", async ({
     page,
   }) => {

--- a/packages/timeline-domain/index.ts
+++ b/packages/timeline-domain/index.ts
@@ -9,6 +9,7 @@ export {
   collectUnhydratedDropTargets,
   graphChildrenToClips,
   hydratedCollectionDuration,
+  hydratedCollectionPlayableDuration,
   hydratedCollectionPreviews,
   type BuildFocusedGraphResult,
   type BuildHydrationSpecsResult,

--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -78,8 +78,12 @@ export type ClipDetail = Readonly<{
   trashedFrom?: TrashOrigin;
   itemCount?: number;
   previewItems?: CollectionTimelineClip["previewItems"];
-  /** The collection clip's own display duration in its parent timeline. */
+  /** The collection clip's own display duration in its parent timeline — its
+   *  LAYOUT span, disabled descendants included. */
   duration?: number;
+  /** Of that span, the seconds that actually play. Absent when nothing under
+   *  the collection is disabled (then `duration` already is it). */
+  playableDuration?: number;
   /** False for placeholder collections awaiting hydration. */
   hydrated?: boolean;
   /** Set on a duplicate-reference card (see module comment). */
@@ -160,6 +164,9 @@ function collectionDetail(clip: CollectionTimelineClip, hydrated: boolean): Clip
     itemCount: clip.itemCount,
     ...(clip.previewItems === undefined ? {} : { previewItems: clip.previewItems }),
     duration: clip.duration,
+    ...(clip.playableDuration === undefined
+      ? {}
+      : { playableDuration: clip.playableDuration }),
     sourceDuration: clip.sourceDuration,
     trimIn: clip.trimIn,
     trimOut: clip.trimOut,
@@ -362,6 +369,46 @@ export function hydratedCollectionDuration(
 }
 
 /**
+ * The same walk, restricted to what actually PLAYS: disabled children (and
+ * everything under them) contribute neither their seconds nor their gap.
+ *
+ * The twin of `hydratedCollectionDuration`, and the split matters —that one
+ * is GEOMETRY, feeding the collection clip's `duration` in the projection, so
+ * it has to keep counting disabled children or the card would lose the slot
+ * the playhead jumps over. This one is a READOUT, for the card's badge and the
+ * selection total, where the honest number is what a viewer would sit through.
+ *
+ * Falls back to the stored `playableDuration` summary for an unhydrated child
+ * (see deriveCollectionSummaries), then to `duration` for documents written
+ * before the field existed — where nothing is disabled the two are equal
+ * anyway, so the fallback is exact rather than approximate.
+ */
+export function hydratedCollectionPlayableDuration(
+  graph: CollectionsGraph,
+  details: DetailsById,
+  collectionId: NodeId,
+): number {
+  let total = TIMELINE_LEADING_PADDING_SECONDS;
+  let first = true;
+  for (const childId of getChildren(graph, collectionId)) {
+    const node = graph.nodesById.get(childId);
+    if (!node) continue;
+    if (node.disabled === true) continue;
+    if (!first) total += CLIP_GAP_SECONDS;
+    first = false;
+    if (node.kind === "media") {
+      total += mediaDurationSeconds(node);
+      continue;
+    }
+    const detail = details[childId as string];
+    total += detail?.hydrated
+      ? hydratedCollectionPlayableDuration(graph, details, childId)
+      : (detail?.playableDuration ?? detail?.duration ?? 3);
+  }
+  return total;
+}
+
+/**
  * Preview frames of a HYDRATED collection, derived from its live children with
  * the SAME `previewItemsFrom` the read-time summary derivation uses — so the
  * projection and the served document agree byte-for-byte.
@@ -528,6 +575,13 @@ export function graphChildrenToClips(
     const previewItems = detail?.hydrated
       ? hydratedCollectionPreviewItems(graph, details, node.id)
       : detail?.previewItems;
+    // The playable READOUT beside the layout duration above, derived live for
+    // the same self-healing reason. Omitted when it equals the layout span, so
+    // a closure with nothing disabled never grows the field.
+    const playable = detail?.hydrated
+      ? hydratedCollectionPlayableDuration(graph, details, node.id)
+      : detail?.playableDuration;
+    const playableDuration = playable === duration ? undefined : playable;
     nextStartTime += duration + CLIP_GAP_SECONDS;
     return {
       id: detail?.sourceClipId ?? (node.id as string),
@@ -542,6 +596,7 @@ export function graphChildrenToClips(
         ? getChildren(graph, node.id).length
         : (detail?.itemCount ?? getChildren(graph, node.id).length),
       ...(previewItems === undefined ? {} : { previewItems }),
+      ...(playableDuration === undefined ? {} : { playableDuration }),
       alt: detail?.alt ?? `${node.name} collection`,
       aspect: detail?.aspect ?? 16 / 9,
       trackIndex: detail?.trackIndex ?? 0,

--- a/packages/timeline-domain/src/playback-manifest.test.ts
+++ b/packages/timeline-domain/src/playback-manifest.test.ts
@@ -211,11 +211,11 @@ describe("manifestToClips", () => {
 });
 
 describe("disabled clips", () => {
-  it("skips a disabled clip and CLOSES the gap it leaves", () => {
-    // The closing is the point. Dropping "b" without repacking would leave
-    // 0-4 and 8-12 occupied and 4-8 empty — and the player holds the last
-    // drawn frame across an empty span, so "a" would freeze on screen for
-    // four seconds instead of "b" being skipped.
+  it("KEEPS a disabled clip's span and marks it, leaving neighbours in place", () => {
+    // The span is the point. The compiler used to drop "b" and repack, which
+    // left the player nothing to jump over and no way to scrub into it. Now
+    // "b" holds 4-8 exactly as stored, "c" does not move up, and the player
+    // decides what to do about it.
     const documents = {
       root: doc("root", [
         image("a", 0, 4),
@@ -226,21 +226,22 @@ describe("disabled clips", () => {
 
     const manifest = compilePlaybackManifest(documents, "root", 1, AT);
 
-    expect(manifest.leaves.map((leaf) => leaf.id)).toEqual(["a", "c"]);
-    // "c" moved up into "b"'s span, and the total lost b's four seconds.
-    // Expressed via CLIP_GAP_SECONDS because the survivors are REPACKED, so
-    // they sit at the model's canonical spacing, not the fixture's literals.
-    expect(manifest.leaves[1].timelineStart).toBeCloseTo(4 + CLIP_GAP_SECONDS, 6);
-    expect(manifest.durationSeconds).toBeCloseTo(8 + CLIP_GAP_SECONDS, 6);
-    // No hole beyond the standard inter-clip gap — which is what would make
-    // the player freeze-frame rather than skip.
-    const gap =
-      manifest.leaves[1].timelineStart -
-      (manifest.leaves[0].timelineStart + manifest.leaves[0].timelineDuration);
-    expect(gap).toBeCloseTo(CLIP_GAP_SECONDS, 6);
+    expect(manifest.leaves.map((leaf) => leaf.id)).toEqual(["a", "b", "c"]);
+    expect(manifest.leaves.map((leaf) => leaf.disabled)).toEqual([
+      undefined,
+      true,
+      undefined,
+    ]);
+    // Stored coordinates, untouched — no repack.
+    expect(manifest.leaves[1].timelineStart).toBeCloseTo(4, 6);
+    expect(manifest.leaves[2].timelineStart).toBeCloseTo(8, 6);
+    expect(manifest.durationSeconds).toBeCloseTo(12, 6);
   });
 
-  it("skips a disabled collection's ENTIRE subtree", () => {
+  it("marks a disabled collection's ENTIRE subtree, and keeps its span", () => {
+    // Walked into rather than pruned: the subtree's leaves all exist, all
+    // carry the flag, and the collection still occupies 4-10 so the playhead
+    // has something to leap.
     const documents = {
       root: doc("root", [
         image("intro", 0, 4),
@@ -252,39 +253,62 @@ describe("disabled clips", () => {
 
     const manifest = compilePlaybackManifest(documents, "root", 1, AT);
 
-    expect(manifest.leaves.map((leaf) => leaf.id)).toEqual(["intro", "outro"]);
-    expect(manifest.durationSeconds).toBeCloseTo(8 + CLIP_GAP_SECONDS, 6);
+    expect(manifest.leaves.map((leaf) => leaf.id)).toEqual([
+      "intro",
+      "deep-a",
+      "deep-b",
+      "outro",
+    ]);
+    expect(manifest.leaves.map((leaf) => leaf.disabled)).toEqual([
+      undefined,
+      true,
+      true,
+      undefined,
+    ]);
+    expect(manifest.durationSeconds).toBeCloseTo(14, 6);
   });
 
-  it("skips a disabled clip nested inside a collection, and re-times the parent", () => {
-    // The child shrinks from 6s to 2s, so the parent's collection clip has to
-    // be re-timed too — otherwise its 6s span would window the child's 2s of
-    // content and stretch or truncate it.
+  it("marks a disabled clip nested inside an ENABLED collection", () => {
+    // Inheritance is one-way: the parent is playable, so only the clip that
+    // was actually disabled is marked. The child's timing is untouched —
+    // nothing shrinks, so the parent's window still maps 1:1.
     const documents = {
-      root: doc("root", [collection("scene-ref", "scene", 0, 2)]),
+      root: doc("root", [collection("scene-ref", "scene", 0, 6)]),
       scene: doc("scene", [
         image("keep", 0, 2),
-        { ...image("drop", 2, 4), disabled: true },
+        { ...image("skip", 2, 4), disabled: true },
       ]),
     };
 
     const manifest = compilePlaybackManifest(documents, "root", 1, AT);
 
-    expect(manifest.leaves.map((leaf) => leaf.id)).toEqual(["keep"]);
+    expect(manifest.leaves.map((leaf) => leaf.id)).toEqual(["keep", "skip"]);
+    expect(manifest.leaves.map((leaf) => leaf.disabled)).toEqual([undefined, true]);
     expect(manifest.leaves[0].playbackRate).toBeCloseTo(1, 6);
-    expect(manifest.leaves[0].timelineDuration).toBeCloseTo(2, 6);
+    expect(manifest.leaves[1].timelineDuration).toBeCloseTo(4, 6);
   });
 
-  it("leaves an all-enabled closure byte-identical", () => {
-    // The pass must be a no-op when nothing is disabled — it runs on every
-    // compile, including for every document that never uses the feature.
+  it("does not mark anything in an all-enabled closure", () => {
+    // The flag must never appear on a document that does not use the feature —
+    // an always-present `disabled: false` would churn every stored manifest.
     const documents = {
       root: doc("root", [image("a", 0, 4), collection("s", "scene", 4, 4)]),
       scene: doc("scene", [image("x", 0, 4)]),
     };
-    const before = JSON.stringify(compilePlaybackManifest(documents, "root", 1, AT));
-    const after = JSON.stringify(compilePlaybackManifest(documents, "root", 1, AT));
-    expect(after).toBe(before);
-    expect(JSON.parse(before).leaves.map((l: { id: string }) => l.id)).toEqual(["a", "x"]);
+
+    const manifest = compilePlaybackManifest(documents, "root", 1, AT);
+
+    expect(manifest.leaves.map((leaf) => leaf.id)).toEqual(["a", "x"]);
+    expect(manifest.leaves.every((leaf) => !("disabled" in leaf))).toBe(true);
+  });
+
+  it("carries the flag onto the player's clips", () => {
+    const documents = {
+      root: doc("root", [image("a", 0, 4), { ...image("b", 4, 4), disabled: true }]),
+    };
+
+    const clips = manifestToClips(compilePlaybackManifest(documents, "root", 1, AT));
+
+    expect(clips.map((clip) => clip.disabled)).toEqual([undefined, true]);
   });
 });

--- a/packages/timeline-domain/src/playback-manifest.ts
+++ b/packages/timeline-domain/src/playback-manifest.ts
@@ -12,8 +12,12 @@
 // maps it onto the parent's output span, accumulating `playbackRate` so a
 // leaf knows both WHERE it plays (timelineStart/Duration in root time) and
 // WHAT it plays (sourceStart, advancing at playbackRate).
+//
+// DISABLED clips are compiled in, marked rather than dropped, so this clock
+// matches the board's layout exactly. Skipping them is the player's job —
+// only it knows whether the user is playing (jump the span) or scrubbing
+// (draw it grayed).
 
-import { effectiveDocuments } from "@storyboard/timeline-model";
 import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
 
 export type PlaybackLeaf = Readonly<{
@@ -26,6 +30,12 @@ export type PlaybackLeaf = Readonly<{
   timelineDuration: number;
   sourceStart: number;
   playbackRate: number;
+  /** Skipped by the PLAYER, not by this compiler. A disabled leaf keeps its
+   *  full span on the timeline — that span is what the playhead jumps over
+   *  while playing and what a scrub can land inside. Set when the leaf's own
+   *  clip is disabled OR any collection clip above it on the path was.
+   *  Absent means playable. */
+  disabled?: boolean;
 }>;
 
 export type PlaybackManifest = Readonly<{
@@ -67,6 +77,7 @@ function addMediaLeaf(
   window: TimeWindow,
   overlapStart: number,
   overlapEnd: number,
+  disabled: boolean,
 ): void {
   const localSpan = Math.max(0.001, window.localEnd - window.localStart);
   const outputScale = window.outputDuration / localSpan;
@@ -83,6 +94,7 @@ function addMediaLeaf(
     timelineDuration: (overlapEnd - overlapStart) * outputScale,
     sourceStart: clip.trimIn + clipProgress * sourceRange,
     playbackRate: (sourceRange / Math.max(0.001, clip.duration)) / outputScale,
+    ...(disabled ? { disabled: true } : {}),
   });
 }
 
@@ -93,6 +105,11 @@ function flattenDocument(
   window: TimeWindow,
   visited: ReadonlySet<string>,
   leaves: PlaybackLeaf[],
+  /** True once any collection clip ABOVE this document was disabled. Disabling
+   *  a collection disables everything under it, and there is no way back on
+   *  the way down — an enabled child of a disabled parent still does not play.
+   */
+  inheritedDisabled: boolean,
 ): void {
   if (visited.has(documentId)) throw new Error(`Collection cycle detected at "${documentId}".`);
   const document = documents[documentId];
@@ -107,8 +124,14 @@ function flattenDocument(
     const overlapEnd = Math.min(clipEnd, window.localEnd);
     if (overlapEnd <= overlapStart) continue;
 
+    // Disabled rides DOWN the walk instead of pruning it: the subtree still
+    // compiles, so a disabled collection keeps its span and every leaf under
+    // it is marked. That span is what the player jumps over and what a scrub
+    // can land inside.
+    const clipDisabled = inheritedDisabled || clip.disabled === true;
+
     if (clip.kind !== "collection") {
-      addMediaLeaf(leaves, clip, path, window, overlapStart, overlapEnd);
+      addMediaLeaf(leaves, clip, path, window, overlapStart, overlapEnd, clipDisabled);
       continue;
     }
 
@@ -134,6 +157,7 @@ function flattenDocument(
       },
       nextVisited,
       leaves,
+      clipDisabled,
     );
   }
 }
@@ -146,23 +170,23 @@ export function compilePlaybackManifest(
   documentRevisions?: Readonly<Record<string, number>>,
 ): PlaybackManifest {
   if (!documents[projectId]) throw new Error(`Unknown project timeline "${projectId}".`);
-  // Compile from the EFFECTIVE closure: disabled clips dropped, survivors
-  // repacked. Doing it here rather than inside `flattenDocument` is what
-  // makes the window math below work unchanged — it maps a parent's output
-  // span onto the child's LOCAL time range, so the child's coordinates have
-  // to already be closed up. Filtering during the walk would instead leave
-  // the disabled clip's span empty, and the player holds the last frame
-  // across a gap: a freeze-frame, not a skip.
+  // Compiled from the STORED closure, disabled clips and all. They keep their
+  // stored positions, so the manifest's clock IS the board's layout: the
+  // playhead maps onto the same cards, a disabled item has a real span to be
+  // jumped over, and a scrub can come to rest inside one.
   //
-  // Dropping a disabled COLLECTION clip removes its whole subtree here,
-  // without walking into it.
-  const effective = effectiveDocuments(documents);
-  const root = effective[projectId];
+  // This is the inverse of the original design, which dropped disabled clips
+  // and repacked the survivors here. That closed the gap (necessary, because
+  // the player HOLDS the last frame across an empty span — a freeze-frame,
+  // not a skip) but left nothing to jump over or scrub into. The skip now
+  // happens in the player instead, which can tell playing from scrubbing;
+  // this compiler cannot.
+  const root = documents[projectId];
   const durationSeconds = documentDuration(root);
   const leaves: PlaybackLeaf[] = [];
 
   flattenDocument(
-    effective,
+    documents,
     projectId,
     [projectId],
     {
@@ -173,6 +197,7 @@ export function compilePlaybackManifest(
     },
     new Set(),
     leaves,
+    false,
   );
 
   return {
@@ -208,6 +233,9 @@ export function manifestToClips(manifest: PlaybackManifest): TimelineClip[] {
       sourceDuration: leaf.sourceStart + sourceRange,
       trimIn: leaf.sourceStart,
       trimOut: 0,
+      // The player reads this to decide whether to skip the span (playing) or
+      // draw it grayed (scrubbing).
+      ...(leaf.disabled ? { disabled: true } : {}),
     };
     if (leaf.kind === "video") {
       return {

--- a/packages/timeline-model/documents.ts
+++ b/packages/timeline-model/documents.ts
@@ -58,6 +58,26 @@ export function enabledClips(clips: readonly TimelineClip[]): TimelineClip[] {
 }
 
 /**
+ * The span a document of these clips occupies — the number a referring
+ * collection clip carries as its own duration. Trailing padding mirrors the
+ * leading padding `packTimelineClips` adds.
+ *
+ * An EMPTY list is 3 seconds, not zero: a zero-width collection card cannot be
+ * seen or clicked, and a collection whose children are all disabled reaches
+ * this same floor through the enabled-only projection — all-disabled and empty
+ * are the same thing to a reader.
+ *
+ * One definition, two callers, and they must not drift: the summary derivation
+ * feeds it ALL clips for the layout span and the enabled ones for the playable
+ * span.
+ */
+export function collectionSpanSeconds(clips: readonly TimelineClip[]): number {
+  if (clips.length === 0) return 3;
+  const last = clips[clips.length - 1];
+  return last.startTime + last.duration + TIMELINE_LEADING_PADDING_SECONDS;
+}
+
+/**
  * A document as the READ models should see it: disabled clips dropped, and
  * the survivors repacked so the gap they left closes.
  *

--- a/packages/timeline-model/types.ts
+++ b/packages/timeline-model/types.ts
@@ -113,6 +113,19 @@ export type CollectionTimelineClip = TimelineItemBase & {
   title: string;
   childTimelineId: string;
   itemCount: number;
+  /**
+   * Seconds of this collection that actually PLAY — its child's enabled clips
+   * only. The twin of `duration`, which is the collection's LAYOUT span and
+   * counts disabled children so the board, the ruler and the playback clock
+   * agree on where every card sits.
+   *
+   * The two differ exactly when a descendant is disabled, and the split is
+   * deliberate: geometry has to include a disabled clip (the playhead jumps
+   * over its span, a scrub can land in it) while the readouts on the card
+   * describe what a viewer would actually see. Absent when nothing under the
+   * collection is disabled — then `duration` already is the playable time.
+   */
+  playableDuration?: number;
   previewItems?: Array<{
     id: string;
     kind: MediaKind;

--- a/packages/ui/timeline/viewport/playback-skip.test.ts
+++ b/packages/ui/timeline/viewport/playback-skip.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import type { TimelineClip } from "../types";
+import { getContainingClip, getTimelineDuration, nextPlayableTime } from "./playback-skip";
+
+function image(
+  id: string,
+  startTime: number,
+  duration: number,
+  disabled = false,
+): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "image",
+    src: `https://cdn.test/${id}.jpg`,
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime,
+    duration,
+    sourceDuration: duration,
+    trimIn: 0,
+    trimOut: 0,
+    ...(disabled ? { disabled: true } : {}),
+  };
+}
+
+/** a: 0-4, b: 4-8 (DISABLED), c: 8-12 — the shape every skip case needs. */
+const clips = [image("a", 0, 4), image("b", 4, 4, true), image("c", 8, 4)];
+const duration = getTimelineDuration(clips);
+
+describe("nextPlayableTime", () => {
+  it("leaves a time inside an enabled clip alone", () => {
+    expect(nextPlayableTime(clips, 2, duration)).toBeCloseTo(2, 6);
+    expect(nextPlayableTime(clips, 9.5, duration)).toBeCloseTo(9.5, 6);
+  });
+
+  it("jumps the WHOLE disabled item, not one frame of it", () => {
+    // Anywhere inside it lands on the same place: the next enabled clip.
+    // Advancing gradually would play the span out at normal speed showing a
+    // held frame, which is the freeze the whole design exists to avoid.
+    expect(nextPlayableTime(clips, 4.01, duration)).toBeCloseTo(8, 6);
+    expect(nextPlayableTime(clips, 6, duration)).toBeCloseTo(8, 6);
+    expect(nextPlayableTime(clips, 7.99, duration)).toBeCloseTo(8, 6);
+  });
+
+  it("holds at a shared boundary, which still belongs to the enabled clip", () => {
+    // Spans are inclusive at both ends, so t=4 is the last instant of "a" as
+    // much as the first of "b" — and `getContainingClip` resolves ties to the
+    // earlier clip. Staying is right: there is still an enabled frame to draw.
+    // The very next tick is strictly inside "b" and jumps.
+    expect(getContainingClip(clips, 4)?.id).toBe("a");
+    expect(nextPlayableTime(clips, 4, duration)).toBeCloseTo(4, 6);
+    // Only reachable with ABUTTING clips; the real packing always leaves
+    // CLIP_GAP_SECONDS between them, and a time in that gap skips cleanly.
+    const packed = [image("a", 0, 4), image("b", 4.5, 4, true), image("c", 9, 4)];
+    expect(nextPlayableTime(packed, 4.2, getTimelineDuration(packed))).toBeCloseTo(9, 6);
+  });
+
+  it("jumps a RUN of disabled clips in one hop", () => {
+    // The scan is over every enabled clip, not the immediate neighbour, so
+    // consecutive disabled items need no special case.
+    const run = [
+      image("a", 0, 4),
+      image("b", 4, 4, true),
+      image("c", 8, 4, true),
+      image("d", 12, 4),
+    ];
+    expect(nextPlayableTime(run, 5, getTimelineDuration(run))).toBeCloseTo(12, 6);
+  });
+
+  it("runs to the timeline end when nothing playable follows", () => {
+    const trailing = [image("a", 0, 4), image("b", 4, 4, true)];
+    const total = getTimelineDuration(trailing);
+    expect(nextPlayableTime(trailing, 5, total)).toBeCloseTo(total, 6);
+  });
+
+  it("returns the end for an all-disabled timeline", () => {
+    const none = [image("a", 0, 4, true), image("b", 4, 4, true)];
+    const total = getTimelineDuration(none);
+    expect(nextPlayableTime(none, 0, total)).toBeCloseTo(total, 6);
+  });
+
+  it("still snaps forward over a plain GAP", () => {
+    // Predates disabling and must survive it: an empty span is not silence,
+    // because the surface holds the last drawn frame across it.
+    const gapped = [image("a", 0, 4), image("c", 8, 4)];
+    expect(nextPlayableTime(gapped, 6, getTimelineDuration(gapped))).toBeCloseTo(8, 6);
+  });
+
+  it("clamps out-of-range times into the timeline", () => {
+    expect(nextPlayableTime(clips, -5, duration)).toBeCloseTo(0, 6);
+    expect(nextPlayableTime(clips, 99, duration)).toBeCloseTo(duration, 6);
+  });
+
+  it("resumes mid-clip when an enabled clip OVERLAPS the skipped one", () => {
+    // A long enabled bed under a disabled overlay: skipping the overlay must
+    // not skip the bed along with it, so playback resumes inside the bed at
+    // the point the overlay ended.
+    const overlapping = [image("bed", 0, 12), image("over", 4, 4, true)];
+    // getContainingClip finds "bed" first here, so the skip only engages once
+    // the disabled clip is what covers the time — force that by asking from
+    // inside the overlay with the overlay listed first.
+    const overlayFirst = [image("over", 4, 4, true), image("bed", 0, 12)];
+    expect(getContainingClip(overlapping, 6)?.id).toBe("bed");
+    expect(nextPlayableTime(overlayFirst, 6, getTimelineDuration(overlayFirst))).toBeCloseTo(
+      8,
+      6,
+    );
+  });
+
+  it("is unchanged for a timeline with nothing disabled", () => {
+    const plain = [image("a", 0, 4), image("b", 4, 4), image("c", 8, 4)];
+    const total = getTimelineDuration(plain);
+    for (const time of [0, 1.5, 4, 6, 11.9, total]) {
+      expect(nextPlayableTime(plain, time, total)).toBeCloseTo(time, 6);
+    }
+  });
+});

--- a/packages/ui/timeline/viewport/playback-skip.ts
+++ b/packages/ui/timeline/viewport/playback-skip.ts
@@ -1,0 +1,99 @@
+// Where the playhead is allowed to REST while playing — the pure half of the
+// display surface's clock. No React, no DOM: the surface imports these and
+// the unit suite exercises them directly.
+//
+// Disabled clips reach the player intact, occupying their full span (see
+// timeline-domain/playback-manifest). That is deliberate — the span is what
+// the board draws, what the ruler measures, and what a scrub can land inside.
+// Skipping them is a PLAY-TIME decision, made here, because only the player
+// knows the difference between playing (jump the span) and scrubbing (draw it
+// grayed). Compiling them away instead would leave nothing to jump over.
+
+import type { TimelineClip } from "../types";
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function getClipPlaybackStart(clip: TimelineClip) {
+  return clip.playbackStartTime ?? clip.startTime;
+}
+
+export function getClipPlaybackDuration(clip: TimelineClip) {
+  return Math.max(0.001, clip.playbackDuration ?? clip.duration);
+}
+
+export function clipContainsPlaybackTime(clip: TimelineClip, currentTime: number) {
+  const playbackStart = getClipPlaybackStart(clip);
+  const playbackDuration = getClipPlaybackDuration(clip);
+  return currentTime >= playbackStart && currentTime <= playbackStart + playbackDuration;
+}
+
+/** The clip that literally covers this time — never one held over from
+ *  earlier. Callers deciding whether a time is INSIDE material (as opposed to
+ *  what to draw at it) must use this. */
+export function getContainingClip(clips: readonly TimelineClip[], currentTime: number) {
+  return clips.find((clip) => clipContainsPlaybackTime(clip, currentTime)) ?? null;
+}
+
+export function getTimelineDuration(clips: readonly TimelineClip[]) {
+  return clips.reduce(
+    (duration, clip) =>
+      Math.max(duration, getClipPlaybackStart(clip) + getClipPlaybackDuration(clip)),
+    0,
+  );
+}
+
+/**
+ * The time playback should actually run at, given where the clock has reached.
+ *
+ * Three cases collapse into one rule — resume at the earliest moment from here
+ * on that sits inside an ENABLED clip:
+ *
+ * - inside an enabled clip: stay put, the common case;
+ * - inside a DISABLED clip: jump the whole item, landing on the next enabled
+ *   clip rather than crawling through a span that will not be drawn;
+ * - in a gap, or past the last clip: snap forward to the next enabled clip,
+ *   or to the timeline's end when nothing playable follows.
+ *
+ * The gap rule predates disabling and is load-bearing: an empty span is not
+ * silence, because the surface HOLDS the last drawn frame across it, so
+ * dwelling in a gap freeze-frames instead of advancing.
+ *
+ * Consecutive disabled clips need no special handling — the scan is over every
+ * enabled clip, not the immediate neighbour, so a run of them is one jump.
+ *
+ * PLAY PATH ONLY. Scrubbing deliberately does not call this: the user can put
+ * the playhead anywhere, including inside a disabled clip, and the surface
+ * draws that frame grayed.
+ */
+export function nextPlayableTime(
+  clips: readonly TimelineClip[],
+  time: number,
+  duration: number,
+): number {
+  const bounded = clamp(time, 0, duration);
+  const containing = getContainingClip(clips, bounded);
+  if (containing && containing.disabled !== true) return bounded;
+
+  // Past the end of a disabled clip we are skipping, or from here if the time
+  // was in a gap to begin with.
+  const from = containing
+    ? getClipPlaybackStart(containing) + getClipPlaybackDuration(containing)
+    : bounded;
+
+  let earliest: number | null = null;
+  for (const clip of clips) {
+    if (clip.disabled === true) continue;
+    const start = getClipPlaybackStart(clip);
+    const end = start + getClipPlaybackDuration(clip);
+    // Still ahead of us, or already under way and running past `from` — an
+    // enabled clip that merely OVERLAPS the skipped one resumes mid-clip
+    // rather than being jumped along with it.
+    if (end < from) continue;
+    const candidate = Math.max(start, from);
+    if (earliest === null || candidate < earliest) earliest = candidate;
+  }
+
+  return earliest === null ? duration : clamp(earliest, 0, duration);
+}

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -18,6 +18,14 @@ import { useTimelineDocuments } from "../timeline-document-store";
 
 import type { CollectionTimelineClip, TimelineClip } from "../types";
 import { formatSeconds } from "../utils";
+import {
+  clipContainsPlaybackTime,
+  getClipPlaybackDuration,
+  getClipPlaybackStart,
+  getContainingClip,
+  getTimelineDuration,
+  nextPlayableTime,
+} from "./playback-skip";
 
 type DisplayMedia = {
   key: string;
@@ -74,13 +82,9 @@ function getClipPlaybackRate(clip: TimelineClip) {
   return clamp(sourceRange / getClipPlaybackDuration(clip), 0.0625, 16);
 }
 
-function getClipPlaybackStart(clip: TimelineClip) {
-  return clip.playbackStartTime ?? clip.startTime;
-}
-
-function getClipPlaybackDuration(clip: TimelineClip) {
-  return Math.max(0.001, clip.playbackDuration ?? clip.duration);
-}
+// getClipPlaybackStart / getClipPlaybackDuration / clipContainsPlaybackTime /
+// getContainingClip / getTimelineDuration now live in ./playback-skip, beside
+// the skip rule that reads them — pure, and unit-tested without React.
 
 function getClipPlaybackProgress(clip: TimelineClip, timelineTime: number) {
   const playbackStart = getClipPlaybackStart(clip);
@@ -184,19 +188,6 @@ function resolveClipMedia(
   };
 }
 
-function clipContainsPlaybackTime(clip: TimelineClip, currentTime: number) {
-  const playbackStart = getClipPlaybackStart(clip);
-  const playbackDuration = getClipPlaybackDuration(clip);
-  return currentTime >= playbackStart && currentTime <= playbackStart + playbackDuration;
-}
-
-/** The clip that literally covers this time — never one held over from
- *  earlier. Callers deciding whether a time is INSIDE playable material (as
- *  opposed to what to draw at it) must use this. */
-function getContainingClip(clips: TimelineClip[], currentTime: number) {
-  return clips.find((clip) => clipContainsPlaybackTime(clip, currentTime)) ?? null;
-}
-
 function getActiveClip(
   clips: TimelineClip[],
   currentTime: number,
@@ -231,24 +222,11 @@ function getActiveClip(
   return held;
 }
 
-function getTimelineDuration(clips: TimelineClip[]) {
-  return clips.reduce(
-    (duration, clip) => Math.max(duration, getClipPlaybackStart(clip) + getClipPlaybackDuration(clip)),
-    0,
-  );
-}
-
-function normalizePlaybackTime(clips: TimelineClip[], time: number, duration: number) {
-  const boundedTime = clamp(time, 0, duration);
-  // Containment, NOT getActiveClip: this decides whether the time needs
-  // snapping forward to real material, and getActiveClip now answers "what
-  // should the surface draw" — which holds a frame across gaps and would
-  // make every gap look like a legitimate resting place.
-  if (getContainingClip(clips, boundedTime)) return boundedTime;
-
-  const nextClip = clips.find((clip) => getClipPlaybackStart(clip) > boundedTime);
-  return nextClip ? clamp(getClipPlaybackStart(nextClip), 0, duration) : duration;
-}
+// normalizePlaybackTime is `nextPlayableTime` (./playback-skip): it decides
+// whether the clock needs snapping forward to material that will actually be
+// drawn — over a gap, or over a DISABLED clip's whole span. Deliberately not
+// getActiveClip, which answers "what should the surface draw" and holds a
+// frame across gaps, making every gap look like a legitimate resting place.
 
 export function WorkbenchDisplaySurface({
   clips,
@@ -264,6 +242,7 @@ export function WorkbenchDisplaySurface({
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const cacheRef = useRef(new Map<string, CachedMedia>());
   const activeMediaRef = useRef<DisplayMedia | null>(null);
+  const activeClipDisabledRef = useRef(false);
   const animationFrameRef = useRef<number | null>(null);
   const timeoutFrameRef = useRef<number | null>(null);
   const pendingSeekDrawCleanupRef = useRef<(() => void) | null>(null);
@@ -394,7 +373,14 @@ export function WorkbenchDisplaySurface({
     context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
     context.fillStyle = "#050505";
     context.fillRect(0, 0, cssWidth, cssHeight);
+    // A disabled clip is reachable only by scrubbing, and it draws GRAYED so
+    // the frame reads as "here, but not in the cut" — the same grayscale the
+    // card wears on the board, on the same content. Filter is set around the
+    // one drawImage and reset immediately: the backdrop fill above must stay
+    // its true black, and a leaked filter would tint the next frame drawn.
+    if (activeClipDisabledRef.current) context.filter = "grayscale(1) opacity(0.45)";
     context.drawImage(drawable, (cssWidth - width) / 2, (cssHeight - height) / 2, width, height);
+    context.filter = "none";
   }, []);
 
   const drawEmptyFrame = useCallback(() => {
@@ -507,6 +493,15 @@ export function WorkbenchDisplaySurface({
 
     activeMediaRef.current = media;
     lastRenderedMediaKeyRef.current = media?.key ?? null;
+    // A REF, not a draw argument: `drawDrawable` is reached from half a dozen
+    // async listeners (image load, video seeked/loadeddata) that have no idea
+    // which clip they belong to. Setting it here — the one place the active
+    // clip is resolved — makes every one of those redraws inherit the right
+    // treatment.
+    //
+    // Only reachable while SCRUBBING: playing snaps the clock out of a
+    // disabled span before anything is drawn (see nextPlayableTime).
+    activeClipDisabledRef.current = active?.disabled === true;
 
     if (!media) {
       pauseInactiveVideos(null);
@@ -609,7 +604,7 @@ export function WorkbenchDisplaySurface({
     }
 
     const clipsRef = sortedClipsRef;
-    const startTime = normalizePlaybackTime(clipsRef.current, currentTimeRef.current, durationRef.current);
+    const startTime = nextPlayableTime(clipsRef.current, currentTimeRef.current, durationRef.current);
     currentTimeRef.current = startTime;
     playbackAnchorRef.current = {
       timelineTime: startTime,
@@ -647,7 +642,7 @@ export function WorkbenchDisplaySurface({
         startedAtMs: now,
       };
       const rawTime = anchor.timelineTime + (now - anchor.startedAtMs) / 1000;
-      const nextTime = normalizePlaybackTime(clipsRef.current, rawTime, durationRef.current);
+      const nextTime = nextPlayableTime(clipsRef.current, rawTime, durationRef.current);
       if (Math.abs(nextTime - rawTime) > 0.001) {
         resetAnchor(nextTime, now);
       }
@@ -718,6 +713,17 @@ export function WorkbenchDisplaySurface({
           aria-label={activeMedia ? `${activeMedia.clipTitle} preview` : "Empty workbench preview"}
           data-testid="workbench-display-canvas"
         />
+        {/* Names what the grayed frame means. Only ever visible while
+            SCRUBBING — playing jumps the span, so the clock never rests here.
+            Top-LEFT: the close button owns the right corner. */}
+        {activeClip?.disabled === true && (
+          <span
+            className="absolute left-2 top-2 z-10 rounded bg-black/80 px-1.5 py-0.5 font-mono text-[10px] leading-none font-semibold tracking-[0.08em] text-amber-300 ring-1 ring-amber-400/40"
+            data-testid="workbench-display-disabled"
+          >
+            DISABLED
+          </span>
+        )}
         {/* Second way out of the preview, next to the sidebar's toggle. Pinned
             to the canvas's far-right corner, which is LETTERBOX: the frame is
             drawn centred at `min` scale, so this sits in the black gutter


### PR DESCRIPTION
Reworks the `disabled` feature (shipped in #190–193) so a disabled item is skipped at **play time** rather than at **compile time**.

## Why

`effectiveDocument` dropped disabled clips and repacked the survivors, so the playback clock never contained them. That made three of the requested behaviours impossible: the playhead had no span to jump over, a scrub had nothing to land in, and a disabled collection's descendants had no representation at all (the whole subtree was pruned at the parent clip).

## What changed

- **The manifest compiles disabled clips in, marked rather than dropped** (`playback-manifest.ts`), so its clock matches the board's layout. A disabled collection is now *walked into*, which is what preserves its span and gives descendant inheritance for free — every leaf beneath it is marked on the way down.
- **`nextPlayableTime`** — a new pure, unit-tested module (`packages/ui/timeline/viewport/playback-skip.ts`) — jumps the whole disabled span while playing. This has to live in the player: only it can tell playing from scrubbing. Scrubbing into a disabled clip is allowed and draws the frame grayed, with a DISABLED badge over the canvas.
- **Cards carry a chip top-right**: `DISABLED` when the node itself is off, `PARENT OFF` when a collection above it is. Identical muting, different labels — re-enabling on the card only helps in the first case.
- **The seek rail and ruler dim** the stretches playback will jump.

## The one distinction to hold onto

| Concern | Counts disabled? | Read by |
| --- | --- | --- |
| Geometry / layout clock | yes | cards, ruler, rails, playhead map, manifest spans |
| Playability | flag only | the player |
| Readouts | no | header aggregate, collection badge + item count |

Readouts staying enabled-only was a deliberate call, so geometry and readouts now disagree on purpose — the ruler runs longer than the header's total whenever something is disabled. That split is why a collection clip gains `playableDuration` beside `duration`: the layout span **must** count disabled children or the manifest's window math would squeeze a child's real content into a too-short parent span and play it fast, while the card's badge should say what a viewer would actually sit through.

## Tests

- Rewrote the `disabled clips` block in `playback-manifest.test.ts` — all three cases asserted the old drop-and-repack semantics.
- New `playback-skip.test.ts`: whole-item jumps, runs of disabled clips, the pre-existing gap rule, the shared-boundary edge, and an overlap case.
- New coverage for the geometry/readout split in `derive-collection-summaries.test.ts`, including that a deep disable propagates through a *collection* child (the case that would silently stop one level up).
- New `graph-playhead-model` cases for inherited disabling and the rail segments.
- Stories for both chips; e2e in `graph-view.spec.ts` covering rail mark → scrub-in-grayed → play-jumps. **Verified failing first** by removing the skip: the e2e fails on exactly the jump assertion.

## Verification

App: 408 tests, typecheck clean, lint 0 errors. Shared: 378 unit + 156 story tests. E2E: 59 passed; 4 pre-existing failures confirmed identical on a clean tree (stashed and re-ran).

Also driven in the real app: disabled a collection, drilled in to see `PARENT OFF` on descendants, scrubbed into the span (grayed + badge), pressed play and watched the clock jump 111.6s → 119.1s onto the next enabled card.

## Not included

`packages/timeline-widget` has its own disabled styling and ships a built artifact, so the agent-facing strip keeps today's look. Say the word if it should follow.

Generated with [Claude Code](https://claude.com/claude-code)