### PR TITLE
Green the graph e2e suite, and fix the F2 rename bug it was hiding

### DIFF
--- a/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
+++ b/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
@@ -302,6 +302,12 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
                 // because copies of one asset share them.
                 const clip = group.clips[0];
                 const busy = group.clips.some((entry) => restoringIds.includes(entry.id));
+                // `title` lives only on a COLLECTION clip, so it needs the
+                // discriminant to reach — media clips fall straight through to
+                // `alt`. Computed once: the visible label and the button's
+                // accessible name must not be able to drift apart.
+                const label =
+                  (clip.kind === "collection" ? clip.title : undefined) || clip.alt || "Clip";
                 return (
                 <div
                   // Keyed by SLOT as well as identity: the trash document can
@@ -318,7 +324,7 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
                     {clip.kind === "video" ? (
                       <>
                         <img
-                          src={(clip as any).poster || (clip as any).src}
+                          src={clip.poster || clip.src}
                           alt={clip.alt}
                           className="w-full h-full object-cover opacity-80"
                         />
@@ -328,7 +334,7 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
                       </>
                     ) : clip.kind === "image" ? (
                       <img
-                        src={(clip as any).src}
+                        src={clip.src}
                         alt={clip.alt}
                         className="w-full h-full object-cover"
                       />
@@ -344,7 +350,7 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
                   <div className="mt-2 flex min-w-0 items-center gap-2">
                     <div className="min-w-0 flex-1">
                       <p className="truncate text-xs font-semibold text-zinc-200">
-                        {(clip as any).title || clip.alt || "Clip"}
+                        {label}
                       </p>
                       {/* Where it came from and when it went. Two clips can be
                           identical in every field the drawer paints — same
@@ -368,7 +374,7 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
                         disabled={busy}
                         onClick={() => handleAddToTimeline(group)}
                         title={`Add to ${focusedName}`}
-                        aria-label={`Add ${(clip as any).title || clip.alt || "clip"} to ${focusedName}`}
+                        aria-label={`Add ${label} to ${focusedName}`}
                         className="h-6 shrink-0 border-zinc-800 px-2 text-[10px] text-zinc-300 hover:border-sky-500/50 hover:text-sky-300 cursor-pointer"
                       >
                         <Undo2 className="mr-1 h-3 w-3" />

--- a/apps/timeline-gstudio001/components/graph-view/graph-inline-rename.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-inline-rename.tsx
@@ -4,7 +4,11 @@ import { useCallback, useEffect, useState } from "react";
 
 import { useCollectionsStore, type NodeId } from "@storyboard/ui/dnd-collections";
 
-import { GRAPH_RENAME_ITEM_EVENT } from "@/lib/graph-view-events";
+import {
+  GRAPH_RENAME_ITEM_EVENT,
+  type GraphRenameRequest,
+  type GraphRenameSite,
+} from "@/lib/graph-view-events";
 
 /**
  * In-place rename LOGIC for a collection node, single-sourced so the card, the
@@ -18,7 +22,13 @@ import { GRAPH_RENAME_ITEM_EVENT } from "@/lib/graph-view-events";
  * or unchanged name is a no-op — the reducer would reject it anyway, but not
  * dispatching keeps a stray empty commit out of history.
  */
-export function useInlineRename(nodeId: NodeId, currentName: string) {
+export function useInlineRename(
+  nodeId: NodeId,
+  currentName: string,
+  /** Which surface this instance IS. A node id names up to three mounted sites
+   *  at once, and only the addressed one may open — see the event's own note. */
+  site: GraphRenameSite,
+) {
   const store = useCollectionsStore();
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
@@ -33,11 +43,12 @@ export function useInlineRename(nodeId: NodeId, currentName: string) {
   // its editor — the keyboard twin of double-clicking the label.
   useEffect(() => {
     const onRename = (event: Event) => {
-      if ((event as CustomEvent<string>).detail === (nodeId as string)) begin();
+      const request = (event as CustomEvent<GraphRenameRequest>).detail;
+      if (request.nodeId === (nodeId as string) && request.site === site) begin();
     };
     window.addEventListener(GRAPH_RENAME_ITEM_EVENT, onRename);
     return () => window.removeEventListener(GRAPH_RENAME_ITEM_EVENT, onRename);
-  }, [nodeId, begin]);
+  }, [nodeId, site, begin]);
 
   const cancel = useCallback(() => setEditing(false), []);
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -595,7 +595,7 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
   const detail = useClipDetail(id as string);
   // Same source of truth as the tree/breadcrumb, so a rename shows here too.
   const title = useTimelineTitle(id as string);
-  const rename = useInlineRename(id, title ?? node.name);
+  const rename = useInlineRename(id, title ?? node.name, "card");
   const nav = useContext(GraphViewNavContext);
   // Hydrated collections derive their preview frames and total duration from
   // live children (like the count), so editing a loaded child refreshes this

--- a/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
@@ -226,7 +226,9 @@ export function OpenKeyBoundary({
     if (!id) return;
     if (store.getSnapshot().graph.nodesById.get(parseNodeId(id))?.kind !== "collection") return;
     event.preventDefault();
-    requestGraphRenameItem(id);
+    // F2 is pressed ON a card, so the card is what should open — the id was
+    // resolved from the focused card's own element above.
+    requestGraphRenameItem(id, "card");
   };
 
   // Plain Delete/Backspace trashes EVERY selected card — the pointer twin of

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -130,7 +130,7 @@ function SubTimelineNode({
     (snapshot) => snapshot.graph.nodesById.get(collectionId)?.name ?? id,
   );
   const name = useTimelineTitle(id) ?? nodeName;
-  const rename = useInlineRename(collectionId, name);
+  const rename = useInlineRename(collectionId, name, "sub-row");
   const detail = useClipDetail(id);
   const hydrated = detail?.hydrated === true;
   // ENABLED children only — this row says what the timeline contributes, so

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
@@ -99,7 +99,7 @@ export function GraphBreadcrumb({
     (snapshot) => snapshot.graph.nodesById.get(focusedId as NodeId)?.name,
   );
   const focusedTitle = documents[focusedId]?.title ?? focusedNodeName ?? focusedId;
-  const rename = useInlineRename(focusedId as NodeId, focusedTitle);
+  const rename = useInlineRename(focusedId as NodeId, focusedTitle, "breadcrumb");
   const parentHref =
     timelinePath.length > 1
       ? `${base}/${timelinePath.slice(0, -1).map(encodeURIComponent).join("/")}`

--- a/apps/timeline-gstudio001/lib/graph-view-events.ts
+++ b/apps/timeline-gstudio001/lib/graph-view-events.ts
@@ -143,12 +143,26 @@ export function requestGraphItemAction(action: GraphItemAction): void {
 // to each rename site (card, breadcrumb, sub-row — all via useInlineRename).
 // This event carries the node id so the matching site opens its editor: the
 // keyboard twin of double-clicking the label.
+//
+// The SITE is part of the address, not decoration. One node id routinely names
+// three mounted sites at once — a collection at the focused level has a card, a
+// sub-timeline row, and (when focused) a breadcrumb. Broadcasting the id alone
+// opened an editor in every one of them, and because each editor focuses itself
+// on mount and commits on blur, they knocked each other out and ALL of them
+// closed: F2 appeared to do nothing at all.
 
 export const GRAPH_RENAME_ITEM_EVENT = "graph-view:rename-item";
 
-/** Ask the rename site for this node id to open its inline editor. */
-export function requestGraphRenameItem(nodeId: string): void {
-  window.dispatchEvent(new CustomEvent<string>(GRAPH_RENAME_ITEM_EVENT, { detail: nodeId }));
+/** Which of the three rename surfaces a request is addressed to. */
+export type GraphRenameSite = "card" | "sub-row" | "breadcrumb";
+
+export type GraphRenameRequest = Readonly<{ nodeId: string; site: GraphRenameSite }>;
+
+/** Ask ONE rename site to open its inline editor. */
+export function requestGraphRenameItem(nodeId: string, site: GraphRenameSite): void {
+  window.dispatchEvent(
+    new CustomEvent<GraphRenameRequest>(GRAPH_RENAME_ITEM_EVENT, { detail: { nodeId, site } }),
+  );
 }
 
 // The reverse hand-off: when a drag drops into the graph's sidebar trash

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -483,11 +483,12 @@ const previewToggle = (page: Page): Locator =>
 const assetsButton = (page: Page): Locator =>
   page.getByRole("button", { name: "Assets", exact: true });
 
-// Each sub-graph row's drill-in control (formerly labelled "Focus").
-const drillButton = (page: Page, sectionName: string): Locator =>
-  page
-    .locator(`section[aria-label="Sub-timeline: ${sectionName}"]`)
-    .getByRole("button", { name: "Drill into timeline" });
+// Drilling in. The sub-timeline ROW no longer offers this — its folder toggle
+// opens the timeline in place, and the second control that navigated away was
+// removed deliberately (see graph-sub-timelines). The collection CARD's own
+// open button is the affordance now, so navigation tests go through it.
+const drillButton = (page: Page, timelineName: string): Locator =>
+  page.getByRole("button", { name: `Open ${timelineName}`, exact: true }).first();
 
 // ── Tests ───────────────────────────────────────────────────────────────────
 
@@ -694,10 +695,20 @@ test.describe("graph view E2E", () => {
     // and is verified with a real keypress (Playwright's Chromium doesn't
     // deliver the F2 function key to the page).
     await page.evaluate(
-      (id) => window.dispatchEvent(new CustomEvent("graph-view:rename-item", { detail: id })),
+      (id) =>
+        window.dispatchEvent(
+          new CustomEvent("graph-view:rename-item", { detail: { nodeId: id, site: "card" } }),
+        ),
       CHILD_ID,
     );
+
+    // EXACTLY one editor. Scene A has a card AND a sub-timeline row mounted for
+    // the same node id, and an unaddressed broadcast opened both: each editor
+    // focuses itself on mount and commits on blur, so they closed each other
+    // and F2 did nothing at all. The count is the regression — `fill` below
+    // would fail on a strict-mode violation, but only by accident.
     const editor = page.getByRole("textbox", { name: "Timeline name" });
+    await expect(editor).toHaveCount(1);
     await editor.fill("Heist Plan");
     await editor.press("Enter");
 
@@ -2176,7 +2187,10 @@ test.describe("graph view E2E", () => {
       .poll(() => api.patchesFor(TRASH_ID).at(-1)?.clipIds, { timeout: 5000 })
       .toEqual(["bravo"]);
     await page.getByRole("button", { name: "Trash", exact: true }).click();
-    const restore = page.getByRole("button", { name: /^Restore bravo/ });
+    // "Add <name> to <timeline>" — the drawer stopped saying "Restore" when it
+    // became one row per image: putting an image back is an insert into the
+    // timeline you are looking at, not an undo of where it came from.
+    const restore = page.getByRole("button", { name: /^Add bravo to/ });
     await expect(restore).toBeVisible();
     await restore.click();
 


### PR DESCRIPTION
Addresses review findings **3** (red suite) and **9** (`any` casts).

Four graph-view e2e tests were failing on `main`. Three were stale tests. The fourth was a **real product bug** that the stale suite had stopped reporting.

## The real bug: F2 rename did nothing

`useInlineRename` is mounted at three sites — the collection card, the sub-timeline row, and the breadcrumb. The rename request carried only a node id, and a collection at the focused level has **all three mounted for that same id**. So F2 opened an editor in every matching site; each editor focuses itself on mount and commits on blur, so they knocked each other out and all of them closed.

Diagnosed by watching the DOM rather than guessing: two inputs added, two removed, none left. The reviewer flagged this as possibly "a test/listener timing race"; it is a genuine multi-site collision, and it affects any collection that has both a card and a sub-row — the common case.

The request now carries the **site** as part of its address (`{ nodeId, site }`), and F2 — which resolves its id from the focused card's own element — addresses the card. The e2e now asserts **exactly one** editor opens, which is the actual regression; `fill` alone would have caught the two-editor case only by accident, via a strict-mode violation.

## The stale tests

- `drillIntoScene` waited on the sub-timeline row's drill-in, which was **removed deliberately** — the row's folder toggle opens the timeline in place, and the second control that navigated away was answering a question the row doesn't ask. Navigation now goes through the collection card's own open button.
- The trash test waited on `/^Restore/`. The drawer stopped saying that in #200 when it became one row per image: putting an image back is an insert into the timeline you're looking at, so it says `Add <name> to <timeline>`.

## Finding 9

Four `(clip as any)` casts removed from `trash-drawer.tsx`. `clip.kind` already discriminates the union; `title` genuinely needs the discriminant since only a collection clip has one, so it's computed once and shared by the visible label and the button's accessible name — they can no longer drift.

## Verification

- **63/63** graph-view e2e pass (was 59/63).
- App: 408 tests, typecheck clean, lint 0 errors.

Generated with [Claude Code](https://claude.com/claude-code)