### PR TITLE
Close two async races, and fix the selection duration readout

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-asset-palette.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-asset-palette.tsx
@@ -361,10 +361,24 @@ export function AssetPaletteDrawer({
   // were reaching for. Its own flag rather than the shared `loading` status,
   // which swaps the whole rail for skeletons — that would be a worse answer
   // to "show me more" than showing nothing at all.
+  // The identity of the page the rail is showing right now. Held in a ref as
+  // well as computed, because an async completion needs the CURRENT value, not
+  // the one its closure captured — that is precisely the comparison.
+  const pageKey = cacheKey(providerId, mode, path, searchTerm);
+  const pageKeyRef = useRef(pageKey);
+  useEffect(() => {
+    pageKeyRef.current = pageKey;
+  }, [pageKey]);
+
   const [loadingMore, setLoadingMore] = useState(false);
   const loadMore = useCallback(async () => {
     const cursor = state.status === "ready" ? state.nextCursor : undefined;
     if (cursor === undefined || loadingMore) return;
+    // The page this request belongs to, by full identity. Unlike the browse
+    // effect — whose `cancelled` flag is scoped to the effect, so navigating
+    // away tears it down — nothing cancels this callback, so it has to
+    // recognise its own page on the way back.
+    const requestKey = pageKey;
     setLoadingMore(true);
     try {
       const response = await fetch(`/api/assets?${requestParams(cursor)}`, { cache: "no-store" });
@@ -373,17 +387,25 @@ export function AssetPaletteDrawer({
         nextCursor?: string;
       };
       if (!response.ok || !result.assets) return;
+      // The page the user was on may have been replaced while this was in
+      // flight (they searched, navigated, switched provider). Appending then
+      // would splice one folder's assets onto another's, and the user could
+      // drag an asset from a place they are not looking at.
+      //
+      // The CURSOR alone cannot detect that: cursors are plain offsets
+      // (`String(end)` in path-folders), so every folder paging at the same
+      // size produces the very same "48", and two different folders collide on
+      // every page rather than rarely. Identity is the whole key.
+      if (pageKeyRef.current !== requestKey) return;
       setState((current) => {
-        // The page the user was on may have been replaced while this was in
-        // flight (they searched, navigated, switched provider). Appending
-        // then would splice one folder's assets onto another's.
         if (current.status !== "ready" || current.nextCursor !== cursor) return current;
         const merged: PalettePage = {
           assets: [...current.assets, ...result.assets!],
           folders: current.folders,
           ...(result.nextCursor === undefined ? {} : { nextCursor: result.nextCursor }),
         };
-        pageCacheRef.current.set(cacheKey(providerId, mode, path, searchTerm), merged);
+        // Cached under the key the request was ISSUED for, never the live one.
+        pageCacheRef.current.set(requestKey, merged);
         return { status: "ready", ...merged };
       });
     } catch {
@@ -393,7 +415,7 @@ export function AssetPaletteDrawer({
     } finally {
       setLoadingMore(false);
     }
-  }, [state, loadingMore, requestParams, cacheKey, providerId, mode, path, searchTerm]);
+  }, [state, loadingMore, requestParams, pageKey]);
 
   const navigateTo = useCallback(
     (next: readonly string[], nextMode?: BrowseMode) => {

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -22,7 +22,7 @@ import {
 } from "@storyboard/ui/dnd-collections";
 import {
   graphChildrenToClips,
-  hydratedCollectionDuration,
+  hydratedCollectionPlayableDuration,
   manifestToClips,
   type DetailsById,
   type PlaybackManifest,
@@ -1580,8 +1580,20 @@ export function useSelectionAggregate(): Readonly<{ count: number; seconds: numb
       const node = graph.nodesById.get(id);
       if (!node) continue;
       if (node.kind === "collection") {
-        const hydrated = hydratedCollectionDuration(graph, details, id);
-        total += hydrated > 0 ? hydrated : (details[id as string]?.duration ?? 0);
+        const detail = details[id as string];
+        // Pick on HYDRATION, not on `duration > 0`. Zero is a legitimate live
+        // answer — every child deleted, or every child disabled — and treating
+        // it as "no live value yet" fell back to the stored summary, so the
+        // header kept quoting the old nonzero total for a collection that now
+        // plays nothing.
+        //
+        // And the PLAYABLE walk, not the layout one: this is a readout, so it
+        // has to agree with the number the collection's own card shows. The
+        // layout twin counts disabled children (it feeds the card's slot on
+        // the board) and would report more seconds here than the card claims.
+        total += detail?.hydrated
+          ? hydratedCollectionPlayableDuration(graph, details, id)
+          : (detail?.playableDuration ?? detail?.duration ?? 0);
       } else {
         total += mediaDurationSeconds(node);
       }

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
@@ -199,6 +199,59 @@ describe("graph-documents-gateway", () => {
     expect(batches[1].writes?.[0].expectedRevision).toBe(2);
   });
 
+  // The refresh/save race. Awaiting only the batch that happened to be in
+  // flight resolves the moment IT lands — while the trailing batch, carrying
+  // the edit that arrived mid-flight, is still on the wire. The read then
+  // returns pre-save content AND a revision, so the stale version installs as
+  // current and a later whole-document write can overwrite the queued edit for
+  // good.
+  it("a refresh waits out the TRAILING batch too, not just the one in flight", async () => {
+    const firstSave = deferred<MockResponse>();
+    const secondSave = deferred<MockResponse>();
+    let batchCount = 0;
+    const calls = installFetch((call) => {
+      if (call.method !== "POST") {
+        return jsonResponse({ document: doc("a", [clip("from-server")]), revision: 9 });
+      }
+      batchCount += 1;
+      if (batchCount === 1) return firstSave.promise;
+      if (batchCount === 2) return secondSave.promise;
+      return okResults(call.writes);
+    });
+    const gateway = createGraphDocumentsGateway();
+    await gateway.ensure("a");
+    expect(getsOf(calls, "a")).toHaveLength(1);
+
+    // Save A goes out…
+    gateway.writeClips("a", [clip("a2")]);
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+    expect(batchesOf(calls)).toHaveLength(1);
+
+    // …an edit lands WHILE it is in flight, so a trailing batch is queued…
+    gateway.writeClips("a", [clip("a3")]);
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+    expect(batchesOf(calls)).toHaveLength(1);
+
+    // …and the view refreshes, which marks everything stale and re-reads.
+    gateway.refresh();
+    const refreshed = gateway.ensure("a");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(getsOf(calls, "a")).toHaveLength(1);
+
+    // Save A lands and the TRAILING batch starts. THIS is the moment the old
+    // code fetched: its awaited promise had resolved, so the GET raced batch B.
+    firstSave.resolve(jsonResponse({ results: [{ id: "a", revision: 2 }] }));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(batchesOf(calls)).toHaveLength(2);
+    expect(getsOf(calls, "a")).toHaveLength(1);
+
+    // Only once the pipeline is genuinely idle does the read go out.
+    secondSave.resolve(jsonResponse({ results: [{ id: "a", revision: 3 }] }));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(getsOf(calls, "a")).toHaveLength(2);
+    expect(clipIds(await refreshed)).toEqual(["from-server"]);
+  });
+
   it("flushPendingWrites sends the pending batch immediately, with keepalive", async () => {
     const calls = installFetch((call) =>
       call.method === "POST"

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
@@ -32,6 +32,10 @@ const SAVE_RETRY_MS = 5000;
 // How long an ensure waits for a declared-incoming RSC prime before
 // fetching itself — roughly a streamed payload's round trip.
 const PRIME_WAIT_MS = 1000;
+// How many trailing save batches a refresh will wait out before fetching
+// anyway (see whenSavesSettled). Each round is a full round-trip, so this is
+// generous for any real burst of edits while still bounding the wait.
+const MAX_SAVE_DRAIN_ROUNDS = 10;
 // The fetch spec caps keepalive at 64 KiB across every in-flight keepalive
 // request on the page, and going over is a hard network error rather than a
 // truncation. Budget under it: headers count toward the quota, and other
@@ -352,15 +356,41 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
     });
   };
 
+  /**
+   * Resolves when the save pipeline is idle — nothing in flight AND nothing
+   * queued behind it.
+   *
+   * A LOOP, not a single await, and that is the whole point. `settle()` starts
+   * a TRAILING batch for edits that arrived mid-flight, and that batch is a
+   * NEW promise: awaiting only the one that existed when we started resolves
+   * the moment the FIRST batch lands, while the trailing POST is still on the
+   * wire. A refresh that raced it read pre-save server state and — because the
+   * response also carries a revision — installed that stale content as
+   * current, so the queued edit could later be overwritten for good.
+   *
+   * Bounded rather than unbounded: each round costs a real network round-trip,
+   * and a session editing continuously could otherwise keep a reader waiting
+   * forever. On exhaustion we fall through and fetch anyway, which is no worse
+   * than the behaviour this replaced.
+   */
+  const whenSavesSettled = async (): Promise<void> => {
+    for (let round = 0; round < MAX_SAVE_DRAIN_ROUNDS; round += 1) {
+      const inFlight = saveInFlight;
+      if (inFlight === null) return;
+      // The batch promise absorbs its own failures (see the handlers on it),
+      // so this only ever waits — it never rethrows into the caller's chain.
+      await inFlight.catch(() => undefined);
+    }
+  };
+
   const ensure = (timelineId: string): Promise<TimelineDocument | null> => {
     const cached = documents[timelineId];
     if (cached && !staleIds.has(timelineId)) return Promise.resolve(cached);
     const pending = inflight.get(timelineId);
     if (pending) return pending;
-    // A stale doc may still have a batch in flight (flushed on refresh) —
-    // fetching before it settles would read the pre-save server state.
-    const settled = saveInFlight ?? Promise.resolve();
-    const request = settled
+    // A stale doc may still have writes in flight or queued (flushed on
+    // refresh) — fetching before they ALL settle would read pre-save state.
+    const request = whenSavesSettled()
       // An expected RSC prime gets a grace window to land before the
       // fallback fetch — the server is already streaming this document.
       .then(() => awaitExpectedPrime(timelineId))

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1169,6 +1169,95 @@ test.describe("graph view E2E", () => {
       .toBe(0);
   });
 
+  // Pagination is per-PLACE, and a slow page must never land somewhere else.
+  // The two folders here deliberately hand out the SAME cursor ("1") — real
+  // cursors are plain offsets (`String(end)`), so folders paging at the same
+  // size collide on every page, not rarely. A cursor-only guard passes here;
+  // only the page's full identity catches it.
+  test("a slow 'load more' from one folder never lands in another", async ({ page }) => {
+    await installGraphApi(page);
+    let releaseLatePage!: () => void;
+    const latePageHeld = new Promise<void>((resolve) => {
+      releaseLatePage = resolve;
+    });
+
+    const asset = (id: string) => ({
+      id,
+      providerId: "cloudinary",
+      name: id,
+      kind: "image" as const,
+      src: `https://cdn.test/${id}.jpg`,
+      thumbnailUrl: `https://cdn.test/${id}.jpg`,
+      width: 16,
+      height: 9,
+      tags: [] as string[],
+    });
+
+    // Registered AFTER installGraphApi, so it takes precedence.
+    await page.route("**/api/assets?*", async (route) => {
+      const url = new URL(route.request().url());
+      const folder = url.searchParams.getAll("folder");
+      const cursor = url.searchParams.get("cursor");
+      const body = (payload: Record<string, unknown>) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ providerId: "cloudinary", capabilities: {}, ...payload }),
+        });
+
+      if (folder.length === 0) {
+        return body({
+          assets: [],
+          folders: [
+            { name: "alpha", path: ["alpha"] },
+            { name: "beta", path: ["beta"] },
+          ],
+        });
+      }
+      if (folder[0] === "alpha" && cursor === null) {
+        return body({ assets: [asset("alpha-1")], folders: [], nextCursor: "1" });
+      }
+      if (folder[0] === "alpha") {
+        await latePageHeld; // the slow page, released after we have navigated away
+        return body({ assets: [asset("alpha-late")], folders: [] });
+      }
+      // beta hands out the SAME cursor value alpha did.
+      return body({ assets: [asset("beta-1")], folders: [], nextCursor: "1" });
+    });
+
+    await openGraph(page);
+    await assetsButton(page).click();
+    const drawer = page.getByRole("dialog", { name: "Asset palette" });
+    await expect(drawer).toBeVisible();
+
+    // Into alpha, and ask for its second page…
+    await drawer.locator('[data-palette-folder="alpha"]').click();
+    await expect(drawer.locator('[data-palette-item="asset-alpha-1"]')).toBeVisible();
+    await drawer.getByRole("button", { name: "Load more" }).click();
+
+    // …then leave for beta while that request is still out.
+    await drawer.getByRole("button", { name: "ASSETS" }).click();
+    await drawer.locator('[data-palette-folder="beta"]').click();
+    await expect(drawer.locator('[data-palette-item="asset-beta-1"]')).toBeVisible();
+
+    // Wait for the late page to actually REACH the client before asserting —
+    // otherwise "alpha-late is absent" would pass simply by checking too early,
+    // and the test would prove nothing.
+    const latePageDelivered = page.waitForResponse(
+      (response) =>
+        response.url().includes("folder=alpha") && response.url().includes("cursor="),
+    );
+    releaseLatePage();
+    await latePageDelivered;
+
+    // Beta's rail keeps exactly beta's asset. Without the identity guard
+    // alpha-late appends here, and the user could then drag an asset out of a
+    // folder they are not looking at.
+    await expect(drawer.locator("[data-palette-item]")).toHaveCount(1);
+    await expect(drawer.locator('[data-palette-item="asset-alpha-late"]')).toHaveCount(0);
+    await expect(drawer.locator('[data-palette-item="asset-beta-1"]')).toBeVisible();
+  });
+
   test("palette drag mints a fresh node from an asset and persists it", async ({ page }) => {
     const api = await installGraphApi(page);
     await openGraph(page);

--- a/packages/timeline-domain/src/adapter.test.ts
+++ b/packages/timeline-domain/src/adapter.test.ts
@@ -12,6 +12,8 @@ import {
   collectAffectedCollectionIds,
   collectUnhydratedDropTargets,
   graphChildrenToClips,
+  hydratedCollectionDuration,
+  hydratedCollectionPlayableDuration,
   hydratedCollectionPreviews,
 } from "./adapter";
 import {
@@ -662,6 +664,71 @@ describe("hydrated collection durations", () => {
     // mid is hydrated: derived = 2 + gap + deep's SUMMARY 50 (deep is a
     // placeholder — its stored word is all anyone has).
     expect(clips[0].duration).toBeCloseTo(2 + 0.12 + 50, 5);
+  });
+});
+
+describe("hydratedCollectionPlayableDuration", () => {
+  // The READOUT twin of hydratedCollectionDuration. The two must diverge
+  // exactly where something is disabled: geometry keeps the slot (the playhead
+  // jumps it), the readout says what a viewer would sit through.
+  function docsWithDisabledChild(): Record<string, TimelineDocument> {
+    return {
+      root: {
+        id: "root",
+        title: "Root",
+        clips: [collectionClip("clip-kid", "kid", "Kid")],
+      },
+      kid: {
+        id: "kid",
+        title: "Kid",
+        clips: packTimelineClips([image("k-a", 4), { ...image("k-b", 5), disabled: true }]),
+      },
+    };
+  }
+
+  it("excludes a disabled child's seconds AND its gap, where the layout walk keeps them", () => {
+    const focused = buildFocusedGraph(docsWithDisabledChild(), "root");
+    if (!focused.ok) throw new Error(focused.error);
+    const { graph, details } = focused.value;
+    const kid = parseNodeId("kid");
+
+    expect(hydratedCollectionDuration(graph, details, kid)).toBeCloseTo(9.12, 5);
+    expect(hydratedCollectionPlayableDuration(graph, details, kid)).toBeCloseTo(4, 5);
+  });
+
+  it("returns ZERO when every child is disabled — a real answer, not 'unknown'", () => {
+    // This is what made the header's old `duration > 0 ? live : stored` test
+    // wrong: zero is a legitimate live value, so falling back on it re-quoted
+    // a stale nonzero summary for a collection that now plays nothing.
+    const documents = docsWithDisabledChild();
+    documents.kid.clips = packTimelineClips([
+      { ...image("k-a", 4), disabled: true },
+      { ...image("k-b", 5), disabled: true },
+    ]);
+    const focused = buildFocusedGraph(documents, "root");
+    if (!focused.ok) throw new Error(focused.error);
+
+    expect(
+      hydratedCollectionPlayableDuration(focused.value.graph, focused.value.details, parseNodeId("kid")),
+    ).toBe(0);
+  });
+
+  it("agrees with the layout walk when nothing is disabled", () => {
+    const focused = buildFocusedGraph(
+      {
+        root: { id: "root", title: "Root", clips: [collectionClip("clip-kid", "kid", "Kid")] },
+        kid: { id: "kid", title: "Kid", clips: packTimelineClips([image("k-a", 4), image("k-b", 5)]) },
+      },
+      "root",
+    );
+    if (!focused.ok) throw new Error(focused.error);
+    const { graph, details } = focused.value;
+    const kid = parseNodeId("kid");
+
+    expect(hydratedCollectionPlayableDuration(graph, details, kid)).toBeCloseTo(
+      hydratedCollectionDuration(graph, details, kid),
+      5,
+    );
   });
 });
 


### PR DESCRIPTION
Addresses review findings **1** and **2** (both P1) and **8**.

## 1 — Refresh can race a queued save and install stale content

`ensure()` awaited only the save promise that existed when it started. But `settle()` launches a **trailing batch** for edits that arrived mid-flight, and that is a *new* promise nobody was waiting on — so the refresh resolved the moment the first batch landed, and its GET raced the second. The response carried pre-save content **and** a revision, so the stale version installed as current and a later whole-document write could overwrite the queued edit permanently.

`whenSavesSettled()` now drains in a loop until nothing is in flight. Bounded (`MAX_SAVE_DRAIN_ROUNDS`) rather than unbounded: each round is a real round-trip, and a session editing continuously shouldn't be able to strand a reader forever — on exhaustion it fetches anyway, which is no worse than the behaviour it replaces.

**Regression:** save A → edit during A → refresh → save B, asserting no GET is issued until *both* batches settle. Verified failing against the old single-await (2 GETs instead of 1).

## 2 — Asset pagination can append one folder's results into another

The guard compared only `nextCursor`. Cursors are plain offsets — `String(end)` in `path-folders.ts` — so two folders paging at the same size produce the identical `"48"` and collide on **every** page, not occasionally. A slow page from folder A appended to folder B's visible rail, and the user could then drag an asset out of a folder they weren't looking at.

The guard is now the page's full identity — provider, mode, path, query — which `cacheKey` already computed for the page cache. The merged page is also cached under the key it was *requested* for rather than the live one. (The browse effect was already safe: its `cancelled` flag is scoped to the effect, so navigating away tears it down. `loadMore` is a callback, so nothing cancelled it.)

**Regression (e2e):** two folders that deliberately hand out the **same** cursor; page 2 of `alpha` is held until after navigating into `beta`, then released. Verified failing without the guard (2 palette items instead of 1). The test waits on the actual response delivery first, so it can't pass by checking too early — an earlier draft of it did exactly that.

## 8 — Stale aggregate duration

Two bugs in one line:

- It picked the live value on `duration > 0`. Zero is a legitimate live answer — every child deleted, or every child disabled — so it fell back to the stored summary and the header kept quoting the old nonzero total. Picks on `detail.hydrated` now.
- It still called the **layout** walk, which counts disabled children. That's my own inconsistency from #201: the card badge moved to the playable walk and this didn't, so a selected collection reported more seconds than its own card displayed. The review predates #201 and couldn't have seen it.

**Coverage:** new `hydratedCollectionPlayableDuration` cases — diverges from the layout walk exactly where something is disabled, returns a real `0` for an all-disabled collection, and agrees with the layout walk when nothing is.

## Verification

- App: 409 tests, typecheck clean, lint 0 errors
- Shared unit: 381 tests
- E2E: **64/64** graph-view

Generated with [Claude Code](https://claude.com/claude-code)