### PR TITLE
Disable a whole selection in one command, not one per node

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
@@ -511,25 +511,30 @@ export function GraphItemActionsBridge({
         case "toggle-disabled": {
           const selected = [...store.getSnapshot().interaction.selectedIds];
           if (selected.length === 0) break;
-          // One command per node, but ONE decision for the whole selection:
-          // every node goes to the same state, so a mixed selection resolves
-          // instead of each item flipping its own way. Re-read `disabled`
-          // from the live graph rather than trusting the sidebar's broadcast,
-          // which is a frame behind.
+          // ONE command for the whole selection — one history entry, one
+          // reducer pass, one persistence notification. Dispatching per node
+          // made undo give the items back one at a time, which is not what the
+          // user did. Nodes already in the target state are skipped inside the
+          // reducer, so a partly-disabled selection still resolves in one go.
+          //
+          // Re-read `disabled` from the live graph rather than trusting the
+          // sidebar's broadcast, which is a frame behind.
           const graph = store.getSnapshot().graph;
           const nextDisabled = selected.some(
             (id) => graph.nodesById.get(id)?.disabled !== true,
           );
-          let changed = 0;
-          for (const nodeId of selected) {
-            // A node already in the target state is refused as `same-position`
-            // and never enters history — so this loop cannot pad undo with
-            // no-ops when only part of the selection needs changing.
-            if (store.dispatch({ type: "set-node-disabled", nodeId, disabled: nextDisabled }).ok) {
-              changed += 1;
-            }
-          }
-          if (changed > 0) {
+          const result = store.dispatch({
+            type: "set-node-disabled",
+            nodeIds: selected,
+            disabled: nextDisabled,
+          });
+          if (result.ok) {
+            // What actually CHANGED, which is what the patch carries — not the
+            // selection size, since part of it may already have been there.
+            const changed =
+              result.value.type === "nodes-updated"
+                ? result.value.updates.length
+                : selected.length;
             toast(
               `${nextDisabled ? "Disabled" : "Enabled"} ${changed} item${changed === 1 ? "" : "s"}.`,
               { id: "graph-item-disable" },

--- a/packages/collections-core/commands.test.ts
+++ b/packages/collections-core/commands.test.ts
@@ -701,7 +701,7 @@ describe("set-node-disabled", () => {
       const graph = fixture();
       const result = applyCommand(graph, {
         type: "set-node-disabled",
-        nodeId: parseNodeId(target),
+        nodeIds: [parseNodeId(target)],
         disabled: true,
       });
       if (!result.ok) throw new Error(JSON.stringify(result.error));
@@ -717,14 +717,14 @@ describe("set-node-disabled", () => {
   test("enabling DELETES the key rather than writing false", () => {
     const disabled = applyCommand(fixture(), {
       type: "set-node-disabled",
-      nodeId: parseNodeId("A"),
+      nodeIds: [parseNodeId("A")],
       disabled: true,
     });
     if (!disabled.ok) throw new Error("expected ok");
 
     const enabled = applyCommand(disabled.value.graph, {
       type: "set-node-disabled",
-      nodeId: parseNodeId("A"),
+      nodeIds: [parseNodeId("A")],
       disabled: false,
     });
     if (!enabled.ok) throw new Error("expected ok");
@@ -736,7 +736,7 @@ describe("set-node-disabled", () => {
   test("a no-op change is refused, so it never enters history", () => {
     const alreadyEnabled = applyCommand(fixture(), {
       type: "set-node-disabled",
-      nodeId: parseNodeId("A"),
+      nodeIds: [parseNodeId("A")],
       disabled: false,
     });
     expect(alreadyEnabled.ok).toBe(false);
@@ -746,7 +746,7 @@ describe("set-node-disabled", () => {
   test("a missing node is refused", () => {
     const result = applyCommand(fixture(), {
       type: "set-node-disabled",
-      nodeId: parseNodeId("nope"),
+      nodeIds: [parseNodeId("nope")],
       disabled: true,
     });
     expect(result.ok).toBe(false);
@@ -757,7 +757,7 @@ describe("set-node-disabled", () => {
     const graph = fixture();
     const result = applyCommand(graph, {
       type: "set-node-disabled",
-      nodeId: parseNodeId("A"),
+      nodeIds: [parseNodeId("A")],
       disabled: true,
     });
     if (!result.ok) throw new Error("expected ok");
@@ -766,5 +766,89 @@ describe("set-node-disabled", () => {
     expect("disabled" in nodeOf(undone, "A")).toBe(false);
     const redone = applyPatch(undone, result.value.patch);
     expect(nodeOf(redone, "A").disabled).toBe(true);
+  });
+
+  // Disabling a multi-selection is ONE user action. Per-node dispatch made it
+  // N history entries, so undo gave the items back one at a time.
+  test("a whole selection goes disabled in ONE patch, and comes back in one undo", () => {
+    const graph = fixture();
+    const result = applyCommand(graph, {
+      type: "set-node-disabled",
+      nodeIds: ids(["A", "B", "F"]),
+      disabled: true,
+    });
+    if (!result.ok) throw new Error(JSON.stringify(result.error));
+
+    expect(result.value.patch.type).toBe("nodes-updated");
+    if (result.value.patch.type === "nodes-updated") {
+      expect(result.value.patch.updates).toHaveLength(3);
+    }
+    for (const id of ["A", "B", "F"]) {
+      expect(nodeOf(result.value.graph, id).disabled).toBe(true);
+    }
+    expect(findGraphInvariantViolation(result.value.graph)).toBeNull();
+
+    // ONE inversion restores all three — not one item per undo.
+    const undone = applyPatch(result.value.graph, invertPatch(result.value.patch));
+    for (const id of ["A", "B", "F"]) {
+      expect("disabled" in nodeOf(undone, id)).toBe(false);
+    }
+  });
+
+  test("a partly-disabled selection resolves to one state, skipping what is already there", () => {
+    const first = applyCommand(fixture(), {
+      type: "set-node-disabled",
+      nodeIds: [parseNodeId("A")],
+      disabled: true,
+    });
+    if (!first.ok) throw new Error("expected ok");
+
+    // A is already disabled; B is not. The batch must still apply, carrying
+    // only the node that actually changes — otherwise a mixed selection would
+    // be refused outright.
+    const result = applyCommand(first.value.graph, {
+      type: "set-node-disabled",
+      nodeIds: ids(["A", "B"]),
+      disabled: true,
+    });
+    if (!result.ok) throw new Error(JSON.stringify(result.error));
+    if (result.value.patch.type === "nodes-updated") {
+      expect(result.value.patch.updates.map((update) => String(update.nodeId))).toEqual(["B"]);
+    }
+  });
+
+  test("a batch where EVERY node is already in the target state is refused", () => {
+    const result = applyCommand(fixture(), {
+      type: "set-node-disabled",
+      nodeIds: ids(["A", "B"]),
+      disabled: false,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.reason).toBe("same-position");
+  });
+
+  test("a repeated id contributes ONE update, so the patch stays invertible", () => {
+    // Two updates for one node would leave the second's `before` equal to the
+    // first's `after`, and inverting that could not restore the original.
+    const result = applyCommand(fixture(), {
+      type: "set-node-disabled",
+      nodeIds: ids(["A", "A"]),
+      disabled: true,
+    });
+    if (!result.ok) throw new Error(JSON.stringify(result.error));
+    if (result.value.patch.type === "nodes-updated") {
+      expect(result.value.patch.updates).toHaveLength(1);
+    }
+    const undone = applyPatch(result.value.graph, invertPatch(result.value.patch));
+    expect("disabled" in nodeOf(undone, "A")).toBe(false);
+  });
+
+  test("an empty batch is refused", () => {
+    const result = applyCommand(fixture(), {
+      type: "set-node-disabled",
+      nodeIds: [],
+      disabled: true,
+    });
+    expect(result.ok).toBe(false);
   });
 });

--- a/packages/collections-core/commands.ts
+++ b/packages/collections-core/commands.ts
@@ -62,9 +62,19 @@ export type CollectionsCommand =
     }>
   | Readonly<{
       type: "set-node-disabled";
-      /** Any node — media or collection. Structure is untouched. */
-      nodeId: NodeId;
-      /** True to skip the node (and its subtree) in playback and totals. */
+      /**
+       * Any nodes — media or collection. Structure is untouched.
+       *
+       * A LIST, because disabling a multi-selection is ONE user action and has
+       * to be one command: dispatching per node produced N history entries (so
+       * undo restored one item at a time), N reducer passes, and N persistence
+       * notifications. The `nodes-updated` patch already carried an array of
+       * updates, so the batch costs nothing structurally.
+       */
+      nodeIds: readonly NodeId[];
+      /** True to skip the nodes (and their subtrees) in playback and totals.
+       *  One decision for the whole batch — a mixed selection resolves to a
+       *  single target state rather than each item flipping its own way. */
       disabled: boolean;
     }>;
 
@@ -115,7 +125,7 @@ export function applyCommand(
     return applyMediaUpdate(graph, command.nodeId, command.update);
   }
   if (command.type === "set-node-disabled") {
-    return applySetDisabled(graph, command.nodeId, command.disabled);
+    return applySetDisabled(graph, command.nodeIds, command.disabled);
   }
   if (command.type === "rename-node") {
     return applyRename(graph, command.nodeId, command.name);
@@ -375,27 +385,40 @@ function applyRename(
  */
 function applySetDisabled(
   graph: CollectionsGraph,
-  nodeId: NodeId,
+  nodeIds: readonly NodeId[],
   disabled: boolean
 ): Result<ApplyCommandSuccess, CommandRejection> {
-  const node = graph.nodesById.get(nodeId);
-  if (!node) return { ok: false, error: { reason: "missing-node", nodeId } };
-  if ((node.disabled ?? false) === disabled) {
-    return { ok: false, error: { reason: "same-position" } };
+  if (nodeIds.length === 0) return { ok: false, error: { reason: "nothing-to-add" } };
+
+  const updates: { nodeId: NodeId; before: CollectionItemNode; after: CollectionItemNode }[] = [];
+  const seen = new Set<NodeId>();
+  for (const nodeId of nodeIds) {
+    // A repeated id would emit two updates for one node, and the second's
+    // `before` would already be the first's `after` — an unreversible patch.
+    if (seen.has(nodeId)) continue;
+    seen.add(nodeId);
+    const node = graph.nodesById.get(nodeId);
+    // A MISSING node is still an error: the caller named something that does
+    // not exist, and silently skipping it would hide a real bug.
+    if (!node) return { ok: false, error: { reason: "missing-node", nodeId } };
+    // A node already in the target state contributes nothing. Skipped rather
+    // than rejected, so disabling a partly-disabled selection still works —
+    // the whole batch is only a no-op when EVERY node is already there.
+    if ((node.disabled ?? false) === disabled) continue;
+
+    let after: CollectionItemNode;
+    if (disabled) {
+      after = { ...node, disabled: true };
+    } else {
+      const { disabled: _enabled, ...rest } = node;
+      after = rest as CollectionItemNode;
+    }
+    updates.push({ nodeId, before: node, after });
   }
 
-  let after: CollectionItemNode;
-  if (disabled) {
-    after = { ...node, disabled: true };
-  } else {
-    const { disabled: _enabled, ...rest } = node;
-    after = rest as CollectionItemNode;
-  }
+  if (updates.length === 0) return { ok: false, error: { reason: "same-position" } };
 
-  const patch: CollectionsPatch = {
-    type: "nodes-updated",
-    updates: [{ nodeId, before: node, after }],
-  };
+  const patch: CollectionsPatch = { type: "nodes-updated", updates };
   return { ok: true, value: { graph: applyPatch(graph, patch), patch } };
 }
 

--- a/packages/ui/dnd-collections/react/history-views.tsx
+++ b/packages/ui/dnd-collections/react/history-views.tsx
@@ -22,7 +22,7 @@ function describeCommand(command: CollectionsCommand): string {
     case "rename-node":
       return `rename ${command.nodeId} → "${command.name}"`;
     case "set-node-disabled":
-      return `${command.disabled ? "disable" : "enable"} ${command.nodeId}`;
+      return `${command.disabled ? "disable" : "enable"} [${command.nodeIds.join(", ")}]`;
   }
 }
 


### PR DESCRIPTION
Addresses review finding **7**.

`toggle-disabled` dispatched `set-node-disabled` once per selected node. One user action became **N history entries** — so undo gave the items back one at a time, which is not what the user did — plus N reducer passes and N persistence notifications.

## The change

`set-node-disabled` now takes `nodeIds: readonly NodeId[]`. The `nodes-updated` patch already carried an **array** of updates, so the batch costs nothing structurally: one command, one patch, one history entry, and undo returns the whole selection.

Widened the existing command rather than adding a second one — two ways to disable a node would be a seam nobody needs, and the call sites are few (the sidebar action, the history label, the core tests).

## Two details worth stating

- **Already-in-state nodes are skipped inside the reducer, not rejected.** A partly-disabled selection has to resolve in one go; the batch is refused as `same-position` only when *every* node is already there. The old code got this for free because each node was its own command.
- **A repeated id contributes one update.** Two updates for one node would leave the second's `before` equal to the first's `after` — inverting that could not restore the original, so the patch would not be reversible.

A missing node is still a hard `missing-node` error: the caller named something that doesn't exist, and silently skipping it would hide a real bug.

The toast now reports what actually **changed** (read off the patch) rather than the selection size, since part of the selection may already have been disabled.

## Verification

- New core tests: one patch for a whole selection with one undo restoring all of it; partly-disabled resolution; all-already-there refusal; repeated id; empty batch.
- Shared unit: 386 tests. App: 409. Stories: 156. Typecheck (app + `packages/ui`) clean, lint 0 errors.
- E2E: 64/64 (one unrelated known load-flake on the full parallel run, green in isolation).
- Driven in the real app: two cards selected → Disable → **one** undo brings both back.

Generated with [Claude Code](https://claude.com/claude-code)