### PR TITLE
Stop two per-frame and per-notification hot paths from scaling with views

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -154,6 +154,43 @@ function useHydratedCollectionPreviews(
 }
 
 /**
+ * A collection's ENABLED child count, from its live graph children.
+ *
+ * Memoized on the committed graph's IDENTITY for the same reason the preview
+ * frames are: as a bare `useCollectionsSelector` this scanned the children
+ * array on EVERY store notification — and the store notifies for
+ * interaction-only updates too, so every drop-intent tick during a drag
+ * re-counted the children of every hydrated collection on screen. Primitive
+ * equality stopped the re-RENDER; it never stopped the scan. `snapshot.graph`
+ * keeps its reference until a commit, so this is now a reference check during
+ * a drag and the walk runs once per commit.
+ *
+ * Exported because the sub-timeline ROW shows the same number as the card —
+ * two copies of "enabled children" would drift, and the two sit on screen
+ * together.
+ */
+export function useEnabledChildCount(id: NodeId): number {
+  const store = useCollectionsStore();
+  const [derive] = useState(() =>
+    createDerivedCache({
+      compute: (graph: CollectionsGraph, nodeId: NodeId) => {
+        let total = 0;
+        for (const child of graph.childrenById.get(nodeId) ?? []) {
+          if (graph.nodesById.get(child)?.disabled !== true) total += 1;
+        }
+        return total;
+      },
+      contentKey: (count) => String(count),
+    }),
+  );
+  const getSnapshot = useCallback(
+    () => derive(store.getSnapshot().graph, id),
+    [store, derive, id],
+  );
+  return useSyncExternalStore(store.subscribe, getSnapshot, getSnapshot);
+}
+
+/**
  * The frames a collection PRESENTS: first and last, live once hydrated and the
  * stored summary until then.
  *
@@ -601,15 +638,7 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
   // live children (like the count), so editing a loaded child refreshes this
   // card without a reload; placeholders fall back to their stored summary.
   const hydrated = detail?.hydrated === true;
-  // Primitive return, per the store's selector contract.
-  const enabledChildCount = useCollectionsSelector((s) => {
-    const children = s.graph.childrenById.get(id) ?? [];
-    let total = 0;
-    for (const child of children) {
-      if (s.graph.nodesById.get(child)?.disabled !== true) total += 1;
-    }
-    return total;
-  });
+  const enabledChildCount = useEnabledChildCount(id);
   const liveSeconds = useHydratedCollectionSeconds(id as string, hydrated);
 
   // ENABLED children only, so the card agrees with the time totals and with

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -16,7 +16,7 @@ import {
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 
 import { useClipDetail, useGraphDetailsStore, useTimelineTitle } from "./graph-details-context";
-import { useCollectionPreviewFrames } from "./graph-item-content";
+import { useCollectionPreviewFrames, useEnabledChildCount } from "./graph-item-content";
 import { hydrateTimeline } from "./graph-hydration";
 import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
 import { NativeDropGrid, NativeDropStrip } from "./graph-native-drop";
@@ -136,13 +136,7 @@ function SubTimelineNode({
   // ENABLED children only — this row says what the timeline contributes, so
   // it has to agree with the time totals and the served summary rather than
   // counting clips that are skipped.
-  const liveCount = useCollectionsSelector((snapshot) => {
-    let total = 0;
-    for (const child of getChildren(snapshot.graph, collectionId)) {
-      if (snapshot.graph.nodesById.get(child)?.disabled !== true) total += 1;
-    }
-    return total;
-  });
+  const liveCount = useEnabledChildCount(collectionId);
   // Same pair the card shows; empty until an un-hydrated row loads.
   const previewFrames = useCollectionPreviewFrames(id, hydrated, detail?.previewItems);
   const childIds = useCollectionChildIds(collectionId);

--- a/packages/ui/dnd-collections/react/edge-autoscroll-coordinator.test.ts
+++ b/packages/ui/dnd-collections/react/edge-autoscroll-coordinator.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { scrollCanMoveBox, type ContainmentNode } from "./edge-autoscroll-coordinator";
+
+// A stand-in for the containment tree, so the rule can be exercised in the
+// node-env project (no DOM here). `contains` is the DOM's own semantics:
+// a node contains itself and every descendant.
+function node(name: string, children: FakeNode[] = []): FakeNode {
+  const self: FakeNode = {
+    name,
+    children,
+    contains: (other) =>
+      other === self || children.some((child) => child.contains(other as never)),
+  };
+  return self;
+}
+
+type FakeNode = ContainmentNode & {
+  name: string;
+  children: FakeNode[];
+};
+
+describe("scrollCanMoveBox", () => {
+  // Two independent scroll containers side by side — the shape the recursive
+  // sub-graph tree produces, and the one that made this O(mounted views).
+  const stripA = node("strip-a");
+  const stripB = node("strip-b");
+  const page = node("page", [stripA, stripB]);
+
+  it("does NOT remeasure the scroller itself", () => {
+    // Every frame of our own auto-scroll comes through here. Scrolling a
+    // container moves its content, not its own box.
+    expect(scrollCanMoveBox(stripA, stripA)).toBe(false);
+  });
+
+  it("does NOT remeasure a SIBLING view", () => {
+    // The regression: scrolling one strip used to force a layout on every
+    // other mounted view, every frame.
+    expect(scrollCanMoveBox(stripA, stripB)).toBe(false);
+  });
+
+  it("DOES remeasure a view inside the scroller", () => {
+    // A nested sub-timeline really did travel with its ancestor's scroll.
+    expect(scrollCanMoveBox(page, stripA)).toBe(true);
+    expect(scrollCanMoveBox(page, stripB)).toBe(true);
+  });
+
+  it("remeasures everything on a null scope (resize targets window, not a Node)", () => {
+    expect(scrollCanMoveBox(null, stripA)).toBe(true);
+    expect(scrollCanMoveBox(null, stripB)).toBe(true);
+  });
+
+  it("remeasures everything for a document-level scroll, with no special case", () => {
+    // `document.contains(el)` is true for every mounted element, so the page
+    // scrolling falls out of the same rule.
+    const documentish = node("document", [page]);
+    expect(scrollCanMoveBox(documentish, stripA)).toBe(true);
+    expect(scrollCanMoveBox(documentish, stripB)).toBe(true);
+  });
+
+  it("does not remeasure a view in a DETACHED tree", () => {
+    // Defensive: an entry whose element left the document shares no ancestor
+    // with the scroller, so it is not measured either.
+    expect(scrollCanMoveBox(page, node("orphan"))).toBe(false);
+  });
+});

--- a/packages/ui/dnd-collections/react/edge-autoscroll-coordinator.ts
+++ b/packages/ui/dnd-collections/react/edge-autoscroll-coordinator.ts
@@ -32,6 +32,32 @@ import { type CollectionsStore } from "./collections-store";
 
 export type EdgeAutoScrollOptions = Readonly<{ edge?: number; maxSpeed?: number }>;
 
+/** The one bit of `Node` the containment rule below needs. Structural on
+ *  purpose: it lets the rule be unit-tested in the node-env project, which has
+ *  no DOM. */
+export type ContainmentNode = Readonly<{ contains: (other: never) => boolean }>;
+
+/**
+ * Whether a scroll on `scope` can have moved `el`'s box — the rule that keeps
+ * the frame loop off O(mounted views) forced layouts.
+ *
+ * - The scroller itself: NO. Scrolling a container moves its content, not its
+ *   own box. (This is also every frame of our own auto-scroll.)
+ * - Something inside it: yes, that content travelled.
+ * - Something outside it: NO. A sibling view cannot move because another
+ *   scroller scrolled.
+ * - `scope === null` (a resize, whose target is `window`, not a Node): yes,
+ *   anything may have moved.
+ *
+ * A window/document scroll needs no special case: `document.contains(el)` is
+ * true for every mounted element, so it measures all.
+ */
+export function scrollCanMoveBox(scope: ContainmentNode | null, el: ContainmentNode): boolean {
+  if (scope === null) return true;
+  if (scope === el) return false;
+  return scope.contains(el as never);
+}
+
 type Entry = {
   readonly el: HTMLElement;
   readonly axis: "x" | "y";
@@ -95,10 +121,16 @@ export function createEdgeAutoScrollCoordinator(
     for (const entry of entries) entry.rect = entry.el.getBoundingClientRect();
   };
   const remeasure = (event: Event) => {
-    // A container's OWN scroll (which this loop causes every frame) does not
-    // move its box — skip it; anything else may have.
+    // Scoped by `scrollCanMoveBox`, because this is the hottest path in the
+    // package: the listener is capture-phase on window, so it sees every
+    // scroll in the document — including the ones this very loop causes when
+    // it writes scrollLeft/scrollTop each frame. Measuring every entry there
+    // meant one forced layout per mounted view per frame, and the recursive
+    // sub-graph tree is exactly what multiplies mounted views.
+    const scope = event.target instanceof Node ? (event.target as ContainmentNode) : null;
     for (const entry of entries) {
-      if (event.target !== entry.el) entry.rect = entry.el.getBoundingClientRect();
+      if (!scrollCanMoveBox(scope, entry.el as unknown as ContainmentNode)) continue;
+      entry.rect = entry.el.getBoundingClientRect();
     }
   };
 


### PR DESCRIPTION
Addresses review findings **5** and **6**. Finding 4 is deliberately not in here — see the end.

## 5 — Autoscroll forced a layout per mounted view, per frame

The coordinator's scroll listener is capture-phase on `window`, so it saw **every** scroll in the document — including the ones its own frame loop causes when it writes `scrollLeft`/`scrollTop`. It then called `getBoundingClientRect()` on every registered entry except the scroll target: one forced layout per mounted view per frame, and the recursive sub-graph tree is exactly what multiplies mounted views.

Scoped by **containment**, which is exact rather than heuristic:

- the scroller itself → no (scrolling a container moves its content, not its box — this is also every frame of our own auto-scroll);
- inside it → yes, that content travelled;
- outside it → no, a sibling view cannot move because another scroller scrolled.

Window and document scrolls need no special case: `document.contains(el)` is true for every mounted entry, so they measure all. A **resize** goes through the same handler and targets `window`, which is not a `Node`, so the scope is null and everything is measured — resize can move any box.

The rule is extracted as `scrollCanMoveBox`, a pure predicate typed structurally (`ContainmentNode`) so the node-env project can exercise it without a DOM — there's no jsdom/happy-dom in this repo. Six cases, including the sibling-view regression and the detached-tree edge.

## 6 — Per-card selectors rescanned children on unrelated updates

The card's `enabledChildCount` and the sub-row's `liveCount` filtered the children array on **every** store notification, and the store notifies for interaction too — so every drop-intent tick during a drag re-counted the children of every hydrated collection on screen. Primitive equality stopped the re-*render*; it never stopped the *scan*.

Both now share one `useEnabledChildCount`, memoized on the committed graph's identity via the existing `createDerivedCache` — the same treatment the preview frames and the duration already had, and it also removes a duplicated definition of "enabled children" that sat on screen twice.

## Verification

- Unit: 392 (6 new) · Stories: 156 (incl. `RenderEfficiencyDuringDrag`) · App: 409
- Typecheck (`packages/ui` + app) clean, lint 0 errors
- E2E: **64/64** graph-view

## Finding 4 is NOT here, on purpose

`GRID_UNCAPPED_HEIGHT` makes the grid content-height so the *page* scrolls — a deliberate product decision, and the file already documents the render-all cost. The only correct fix is real window-scroll virtualization (`useWindowVirtualizer` + `scrollMargin`, which this repo's `@tanstack/react-virtual@3.14.5` does support). That is not a review-fix: it moves the grid's scroll source, so edge autoscroll, insert-boundary resolution, the grid playhead and the seek rails all need re-verification, plus the stories and e2e that pin internal-scroll behaviour.

**Related finding while confirming this**, which the review didn't note: because the grid container is content-height, `scrollHeight === clientHeight` — I measured it live — so `useEdgeAutoScroll(scrollRef, "y")` in grid mode is **already a no-op**. Drag-to-edge cannot auto-scroll in grid mode today. Same root cause, and a window-scroll migration would fix both together.

Generated with [Claude Code](https://claude.com/claude-code)