### PR TITLE
Window the strip's seek-rail and ruler marks, not just the ruler ticks

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.test.ts
@@ -7,9 +7,9 @@ import {
   buildPlayheadMap,
   buildRulerCollectionSpans,
   buildRulerTicks,
+  buildStripOverlay,
   cardSpansOf,
   childSpans,
-  disabledCardSegments,
   isDisabledByAncestor,
   manifestTrailsLedger,
   MAX_MANIFEST_FETCH_RETRIES,
@@ -222,24 +222,78 @@ describe("playableSpanSeconds", () => {
   });
 });
 
-describe("disabledCardSegments", () => {
-  it("places a segment under each disabled card, in strip coordinates", () => {
-    const cards: ChildSpan[] = [
-      { startTime: 0, endTime: 4, width: 100 },
-      { startTime: 4, endTime: 8, width: 60, disabled: true },
-      { startTime: 8, endTime: 12, width: 40, disabled: true },
-    ];
+describe("buildStripOverlay", () => {
+  const cards: ChildSpan[] = [
+    { startTime: 0, endTime: 4, width: 100 },
+    { startTime: 4, endTime: 8, width: 60, disabled: true },
+    { startTime: 8, endTime: 12, width: 40, disabled: true },
+  ];
 
-    expect(disabledCardSegments(cards)).toEqual([
+  it("places a segment under each disabled card, in strip coordinates", () => {
+    expect(buildStripOverlay(cards).skips).toEqual([
       { x: 100 + STRIP_GAP_PX, width: 60 },
       { x: 100 + 60 + STRIP_GAP_PX * 2, width: 40 },
     ]);
   });
 
+  it("puts a boundary tick at each gap centre, and none before the first card", () => {
+    expect(buildStripOverlay(cards).boundaryTicks).toEqual([
+      100 + STRIP_GAP_PX / 2,
+      100 + 60 + STRIP_GAP_PX * 2 - STRIP_GAP_PX / 2,
+    ]);
+  });
+
+  it("reports the full extent, ending at the LAST card's right edge", () => {
+    expect(buildStripOverlay(cards).extent).toBe(100 + 60 + 40 + STRIP_GAP_PX * 2);
+  });
+
   it("returns nothing when every card plays", () => {
-    expect(
-      disabledCardSegments([{ startTime: 0, endTime: 4, width: 100 }]),
-    ).toEqual([]);
+    expect(buildStripOverlay([{ startTime: 0, endTime: 4, width: 100 }]).skips).toEqual([]);
+  });
+
+  // The reason this is windowed at all: one tick per card boundary plus one
+  // mark per disabled card is a DOM node PER ITEM, which is what the strip's
+  // virtualizer exists to avoid — and a flattened all-items strip is a whole
+  // project's worth of cards, not one collection's.
+  describe("windowed to the visible range", () => {
+    it("emits only the marks inside the window", () => {
+      // Window covers the FIRST boundary (x=104) but not the second (x=272).
+      const overlay = buildStripOverlay(cards, { startX: 0, endX: 150 });
+      expect(overlay.boundaryTicks).toEqual([100 + STRIP_GAP_PX / 2]);
+      expect(overlay.skips).toEqual([{ x: 108, width: 60 }]);
+    });
+
+    it("keeps the EXTENT unwindowed — it sizes the layer, not the marks", () => {
+      expect(buildStripOverlay(cards, { startX: 0, endX: 10 }).extent).toBe(
+        buildStripOverlay(cards).extent,
+      );
+    });
+
+    it("keeps a segment that spans the whole window", () => {
+      // Overlap, not containment: a disabled card wider than the viewport is
+      // still under the user, and dropping it would blank the mark they are
+      // standing on.
+      const wide: ChildSpan[] = [{ startTime: 0, endTime: 9, width: 5000, disabled: true }];
+      expect(buildStripOverlay(wide, { startX: 2000, endX: 2500 }).skips).toEqual([
+        { x: 0, width: 5000 },
+      ]);
+    });
+
+    it("adjacent windows together cover everything the full build has", () => {
+      const all = buildStripOverlay(cards);
+      const left = buildStripOverlay(cards, { startX: 0, endX: 150 });
+      const right = buildStripOverlay(cards, { startX: 150, endX: 10_000 });
+
+      // Ticks are points, so they partition cleanly.
+      expect([...left.boundaryTicks, ...right.boundaryTicks]).toEqual(all.boundaryTicks);
+
+      // Segments have WIDTH, so one straddling the seam belongs to both
+      // windows — that is the overlap rule, and the alternative (dropping it
+      // from one side) would blank the mark the user is standing on as they
+      // scroll across. Compare as a set.
+      const union = [...new Set([...left.skips, ...right.skips].map((s) => s.x))];
+      expect(union.sort((a, b) => a - b)).toEqual(all.skips.map((s) => s.x));
+    });
   });
 });
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.ts
@@ -275,24 +275,63 @@ export function childSpans(
  * Card lengths come from `childSpans`, so a collection contributes the
  * manifest's full-depth window rather than a stored summary guess.
  */
+export type StripSegment = Readonly<{ x: number; width: number }>;
+
+export type StripOverlay = Readonly<{
+  /** Full content width of the strip — always the total, never windowed: it
+   *  is the size of the layer everything else is positioned inside. */
+  extent: number;
+  /** Gap-centre x between adjacent cards — the rail's cell boundaries. */
+  boundaryTicks: readonly number[];
+  /** x ranges of the cards that will NOT play. */
+  skips: readonly StripSegment[];
+}>;
+
 /**
- * Content-space x ranges of the cards that will NOT play, in the strip's own
- * layout (widths plus the inter-card gutter — the same accumulation
- * `buildPlayheadMap` walks, so a segment lands exactly under its card).
+ * The strip's overlay geometry in ONE walk: the rail's cell-boundary ticks,
+ * the skipped (disabled) stretches, and the total extent — laid out in the
+ * strip's own coordinates (widths plus the inter-card gutter, the same
+ * accumulation `buildPlayheadMap` does, so every mark lands under its card).
  *
- * Shared by the strip's seek rail and the ruler band so the two mark the same
+ * Shared by the seek rail and the ruler band so the two mark the same
  * stretches; a disabled item reads as one continuous dimmed run across both.
+ *
+ * WINDOWED emission, like the ruler's ticks. Unwindowed this minted one
+ * absolutely-positioned element per card boundary plus one per disabled card,
+ * for EVERY card in the timeline — the exact per-item DOM cost the strip's
+ * virtualizer exists to avoid, and it would land hardest on a flattened
+ * all-items strip, where card count is a whole project's rather than one
+ * collection's.
+ *
+ * The WALK stays O(cards): a card's x depends on every width before it, so
+ * the cursor cannot skip ahead (unlike the ruler's ticks, which sit on a
+ * regular time grid and really are generated O(visible)). What is bounded
+ * here is the DOM, which is what actually costs.
  */
-export function disabledCardSegments(
+export function buildStripOverlay(
   cards: readonly ChildSpan[],
-): Array<Readonly<{ x: number; width: number }>> {
-  const segments: Array<Readonly<{ x: number; width: number }>> = [];
+  windowRange?: RulerWindow,
+): StripOverlay {
+  const boundaryTicks: number[] = [];
+  const skips: StripSegment[] = [];
+  const startX = windowRange?.startX ?? Number.NEGATIVE_INFINITY;
+  const endX = windowRange?.endX ?? Number.POSITIVE_INFINITY;
   let cursor = 0;
-  for (const card of cards) {
-    if (card.disabled === true) segments.push({ x: cursor, width: card.width });
+
+  cards.forEach((card, index) => {
+    if (index > 0) {
+      const tickX = cursor - STRIP_GAP_PX / 2;
+      if (tickX >= startX && tickX <= endX) boundaryTicks.push(tickX);
+    }
+    // Overlap, not containment: a segment wider than the viewport still has to
+    // be drawn while the user is inside it.
+    if (card.disabled === true && cursor + card.width >= startX && cursor <= endX) {
+      skips.push({ x: cursor, width: card.width });
+    }
     cursor += card.width + STRIP_GAP_PX;
-  }
-  return segments;
+  });
+
+  return { extent: Math.max(1, cursor - STRIP_GAP_PX), boundaryTicks, skips };
 }
 
 export function playableSpanSeconds(cards: readonly ChildSpan[]): number {

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -33,9 +33,9 @@ import {
   buildPlayheadMap,
   buildRulerCollectionSpans,
   buildRulerTicks,
+  buildStripOverlay,
   cardSpansOf,
   childSpans,
-  disabledCardSegments,
   formatRulerTick,
   manifestTrailsLedger,
   nextManifestClipsState,
@@ -300,22 +300,24 @@ const RULER_WINDOW_CHUNK_PX = 512;
 const INITIAL_RULER_WINDOW: RulerWindow = { startX: 0, endX: RULER_WINDOW_CHUNK_PX * 8 };
 
 /**
- * The chunk-quantized visible content-x range of the strip this element
- * renders inside — the ruler's tick window. Reads the scroll container via
- * the package's documented `[data-virtual-strip]` selector contract (the
- * ruler rides the strip's own overlay layer, so `closest` finds it). Updates
- * ride the scroller's scroll event and a ResizeObserver — both async, so no
- * synchronous setState-in-effect; the observer's initial delivery IS the
+ * The chunk-quantized visible content-x range of a strip scroller — the window
+ * every overlay on that strip builds against.
+ *
+ * Takes the SCROLLER rather than finding it, because its two callers reach it
+ * differently: the ruler rides the strip's own overlay layer (so it climbs
+ * with `closest`), while the seek rail is a SIBLING of the strip and has to
+ * query across. Both hand the same element here.
+ *
+ * Updates ride the scroller's scroll event and a ResizeObserver — both async,
+ * so no synchronous setState-in-effect; the observer's initial delivery IS the
  * first measurement.
  */
-function useStripTickWindow(rulerEl: HTMLElement | null): RulerWindow {
+function useScrollerTickWindow(scroller: HTMLElement | null): RulerWindow {
   const [tickWindow, setTickWindow] = useState<RulerWindow>(INITIAL_RULER_WINDOW);
 
   useEffect(() => {
-    if (!rulerEl) return;
-    const scroller = rulerEl.closest<HTMLElement>("[data-virtual-strip]");
-    // Not inside a strip (defensive): the initial window stands, degrading to
-    // the unwindowed behavior for the first few thousand pixels.
+    // No scroller yet (or not inside a strip): the initial window stands,
+    // degrading to the unwindowed behavior for the first few thousand pixels.
     if (!scroller) return;
     const update = () => {
       const chunk = RULER_WINDOW_CHUNK_PX;
@@ -334,10 +336,19 @@ function useStripTickWindow(rulerEl: HTMLElement | null): RulerWindow {
       scroller.removeEventListener("scroll", update);
       observer.disconnect();
     };
-  }, [rulerEl]);
+  }, [scroller]);
 
   return tickWindow;
 }
+
+/** The strip scroller for an element that rides the strip's own overlay layer
+ *  (the ruler climbs to it) or sits beside it (the rail queries across).
+ *  Resolved in a REF CALLBACK rather than an effect — the repo's lint forbids
+ *  the synchronous setState-in-effect this would otherwise be. */
+const stripScrollerAbove = (element: HTMLElement): HTMLElement | null =>
+  element.closest<HTMLElement>("[data-virtual-strip]");
+const stripScrollerBeside = (element: HTMLElement): HTMLElement | null =>
+  element.parentElement?.querySelector<HTMLElement>("[data-virtual-strip]") ?? null;
 
 /**
  * A second-ruler over the strip. It reads the SAME piecewise time↔x map the
@@ -369,10 +380,15 @@ export function GraphRuler({
   const store = useCollectionsStore();
   const detailsStore = useGraphDetailsStore();
   const spans = useContext(PreviewCardSpansContext);
-  // State, not a ref: the tick-window hook needs the element on the render
+  // State, not a ref: the tick-window hook needs the scroller on the render
   // pass after mount, and render-time ref reads are illegal.
-  const [rulerEl, setRulerEl] = useState<HTMLElement | null>(null);
-  const tickWindow = useStripTickWindow(rulerEl);
+  const [scroller, setScroller] = useState<HTMLElement | null>(null);
+  const rulerRef = useCallback(
+    (element: HTMLElement | null) =>
+      setScroller(element ? stripScrollerAbove(element) : null),
+    [],
+  );
+  const tickWindow = useScrollerTickWindow(scroller);
   const graph = useSyncExternalStore(
     store.subscribe,
     () => store.getSnapshot().graph,
@@ -400,14 +416,15 @@ export function GraphRuler({
       // (R7 #4), same live-derived total the card badge shows.
       collectionSpans: buildRulerCollectionSpans(cards, isCollection, tickWindow),
       // Same segments the seek rail dims, so a skipped stretch reads as one
-      // run down through the ruler and the scrubber.
-      skips: disabledCardSegments(cards),
+      // run down through the ruler and the scrubber — and windowed to the same
+      // range as the ticks beside them.
+      skips: buildStripOverlay(cards, tickWindow).skips,
     };
   }, [graph, details, spans, focusedId, pixelsPerSecond, tickWindow]);
 
   return (
     <div
-      ref={setRulerEl}
+      ref={rulerRef}
       aria-hidden="true"
       data-graph-ruler
       className="pointer-events-none absolute inset-x-0 top-0 z-10 h-[18px]"
@@ -420,9 +437,9 @@ export function GraphRuler({
       {/* Skipped stretches, under the ticks: the band goes flat and gray where
           playback will not travel, so the ruler reads as measuring a timeline
           with holes in it rather than one continuous run. */}
-      {skips.map((segment, index) => (
+      {skips.map((segment) => (
         <div
-          key={`skip-${index}`}
+          key={`skip-${segment.x}`}
           data-ruler-skip
           className="absolute top-0 h-[18px] bg-zinc-700/50"
           style={{ transform: `translateX(${segment.x}px)`, width: segment.width }}
@@ -1040,22 +1057,26 @@ export function GraphStripSeekRail({
   const map = useMemo(() => buildPlayheadMap(cards), [cards]);
   const start = cards.length > 0 ? cards[0].startTime : 0;
   const end = cards.length > 0 ? cards[cards.length - 1].endTime : 0;
+  // The rail is a SIBLING of the strip, so it queries across for the scroller
+  // rather than climbing to it like the ruler does — same window, two routes.
+  const [scroller, setScroller] = useState<HTMLElement | null>(null);
+  const setOuterRef = useCallback((element: HTMLDivElement | null) => {
+    outerRef.current = element;
+    setScroller(element ? stripScrollerBeside(element) : null);
+  }, []);
+  const tickWindow = useScrollerTickWindow(scroller);
   // The rail's content width ends at the LAST item's right edge, and the
   // interior ticks sit at the gap centres between cards — the strip twin of
   // the grid rails' cell-edge ticks.
-  const { extent, ticks, skips } = useMemo(() => {
-    let cursor = 0;
-    const tickXs: number[] = [];
-    cards.forEach((card, index) => {
-      if (index > 0) tickXs.push(cursor - STRIP_GAP_PX / 2);
-      cursor += card.width + STRIP_GAP_PX;
-    });
-    return {
-      extent: Math.max(1, cursor - STRIP_GAP_PX),
-      ticks: tickXs,
-      skips: disabledCardSegments(cards),
-    };
-  }, [cards]);
+  //
+  // WINDOWED to the visible scroll range, like the ruler's ticks above it:
+  // one tick per card boundary plus one mark per disabled card is a DOM node
+  // PER ITEM, which is exactly what the strip's virtualizer exists to avoid.
+  // `extent` stays the full width — it sizes the layer the marks live in.
+  const { extent, boundaryTicks: ticks, skips } = useMemo(
+    () => buildStripOverlay(cards, tickWindow),
+    [cards, tickWindow],
+  );
 
   // Window geometry over the scroller's padding band, measured like the
   // grid rails' (ResizeObserver; the strip has no dataset race — the map is
@@ -1221,7 +1242,7 @@ export function GraphStripSeekRail({
 
   return (
     <div
-      ref={outerRef}
+      ref={setOuterRef}
       data-graph-seek-rail
       data-strip-rail
       role="slider"
@@ -1328,18 +1349,21 @@ export function GraphStripSeekRail({
               neutral scrim rather than a colour of its own — the point is
               that this part of the rail is dead, and a dead stretch should
               look drained next to the live fill, not decorated. */}
-          {skips.map((segment, index) => (
+          {/* Keyed by POSITION, not index: the list is windowed, so indices
+              shift as the strip scrolls and index keys would remount every
+              mark on each chunk crossing. */}
+          {skips.map((segment) => (
             <span
-              key={`skip-${index}`}
+              key={`skip-${segment.x}`}
               data-rail-skip
               aria-hidden="true"
               className="absolute inset-y-0 bg-zinc-600/70"
               style={{ left: segment.x, width: segment.width }}
             />
           ))}
-          {ticks.map((x, index) => (
+          {ticks.map((x) => (
             <span
-              key={index}
+              key={x}
               aria-hidden="true"
               className="absolute inset-y-0 w-px bg-white/30"
               style={{ left: x }}

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -3413,4 +3413,42 @@ test.describe("graph view E2E", () => {
     const afterScroll = await ruler.locator("> div").count();
     expect(afterScroll).toBeLessThan(800);
   });
+
+  // The seek rail's marks are PER ITEM — one boundary tick between every pair
+  // of cards — so unwindowed they scale with clip count, which is precisely
+  // the cost the strip's card virtualizer exists to avoid. It matters most for
+  // a flattened all-items strip, where the count is a whole project's rather
+  // than one collection's.
+  test("seek rail marks are windowed to the visible strip, not the whole timeline", async ({
+    page,
+  }) => {
+    const api = await installGraphApi(page);
+    const project = api.documents.get(PROJECT_ID)!;
+    project.clips = [
+      mediaClip("alpha", "video", 0, 6, 8),
+      ...Array.from({ length: 299 }, (_, i) => mediaClip(`long-${i}`, "image", i + 1, 4)),
+    ];
+    await openGraph(page);
+    // The rail is the PREVIEW's scrubber — it only mounts with the pane open.
+    await previewToggle(page).click();
+
+    const rail = page.locator("[data-graph-seek-rail][data-strip-rail]");
+    await expect(rail).toHaveCount(1);
+    // The rail's content layer holds the boundary ticks; each is absolutely
+    // positioned at a content x.
+    const markCount = () => rail.locator("span[aria-hidden='true']").count();
+
+    // 300 cards would be 299 boundary ticks unwindowed. Windowed, the count
+    // follows the viewport — generously bounded so this pins the ORDER of
+    // magnitude rather than an exact layout.
+    await expect.poll(markCount).toBeLessThan(120);
+    await expect.poll(markCount).toBeGreaterThan(0);
+
+    // Scrolling deep into the timeline keeps it bounded — the window moves,
+    // it does not accumulate.
+    await strip(page, PROJECT_ID).evaluate((el) => {
+      el.scrollLeft = 30_000;
+    });
+    await expect.poll(markCount).toBeLessThan(120);
+  });
 });


### PR DESCRIPTION
Groundwork for the planned **"show all items in order"** strip option (flattened, no collections, no nesting), where a strip holds a whole project's clips rather than one collection's.

## The gap

The strip's **cards** are already properly virtualized — real scroll container, horizontal `useVirtualizer`, and a 1,000-item story proving <50 mounted nodes. The **overlays above them** were not:

| Overlay | Was windowed? | Nodes at N items |
| --- | --- | --- |
| Ruler ticks | ✅ yes | viewport-bounded |
| Ruler skip marks | ❌ no | one per disabled card |
| Rail boundary ticks | ❌ no | N−1 |
| Rail skip marks | ❌ no | one per disabled card |

That's a DOM node **per item** — precisely the cost the card virtualizer exists to avoid. The boundary ticks are long-standing; the skip marks are mine, from #201, where I windowed nothing because collection-sized strips didn't need it.

Measured on a 300-clip strip: **299** rail marks before, **under 120** after.

## The change

`buildStripOverlay` replaces `disabledCardSegments` and the rail's inline loop — one walk, three outputs (extent, boundary ticks, skips), windowed emission. Honest about what it does and doesn't fix: the **walk** stays O(cards), because a card's x depends on every width before it, so the cursor can't skip ahead the way the ruler's regular-time-grid ticks genuinely can. What's bounded is the DOM, which is what costs.

`useStripTickWindow` → `useScrollerTickWindow`, taking the scroller rather than finding it: the ruler rides the strip's own overlay layer and climbs with `closest`, while the rail is a **sibling** and queries across. Both resolve it in a ref callback, not an effect — the repo's lint forbids the synchronous setState-in-effect that would otherwise be.

Marks are keyed by **position** now: with a windowed list, index keys would remount every mark on each chunk crossing.

`extent` stays unwindowed on purpose — it sizes the layer the marks live inside.

## Verification

- New unit cases incl. the seam behaviour: a segment straddling two windows appears in **both** (overlap, not containment — dropping it from one side would blank the mark the user is scrolling across).
- New e2e mirroring the existing ruler-windowing test. **Verified failing unwindowed**: 299 marks vs the <120 bound.
- App 415 · unit 392 · stories 156 · e2e **65/65** · typecheck + lint clean.
- Driven in the real app: rail and ruler each show exactly one skip for one disabled card, and the marks still land under their cards.

## Note on the grid (review finding 4)

Deprioritized rather than done. Grid mode has no flatten option, so its ceiling is the sum across open child collections — higher than one collection when nested children are shown, but well below a flattened strip. Still worth doing eventually, and it would also fix grid-mode edge autoscroll, which is currently dead (`scrollHeight === clientHeight`, so the container cannot scroll).

Generated with [Claude Code](https://claude.com/claude-code)