### PR TITLE
Flat media order: the graph twin of the manifest's leaf walk

### DIFF
--- a/packages/timeline-domain/index.ts
+++ b/packages/timeline-domain/index.ts
@@ -26,3 +26,8 @@ export {
   type PlaybackLeaf,
   type PlaybackManifest,
 } from "./src/playback-manifest";
+export {
+  flattenMediaOrder,
+  resolveFlatDropTarget,
+  type FlatItem,
+} from "./src/flat-order";

--- a/packages/timeline-domain/src/flat-order.test.ts
+++ b/packages/timeline-domain/src/flat-order.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from "vitest";
+
+import { packTimelineClips } from "@storyboard/ui/timeline/timeline-documents";
+import type { TimelineClip, TimelineDocument } from "@storyboard/ui/timeline/types";
+
+import { buildFocusedGraph } from "./adapter";
+import { buildGraph, parseNodeId, type CollectionsGraph, type GraphNodeSpec } from "./engine";
+import { flattenMediaOrder, resolveFlatDropTarget } from "./flat-order";
+import { compilePlaybackManifest } from "./playback-manifest";
+
+const base = {
+  index: 0,
+  aspect: 16 / 9,
+  trackIndex: 0,
+  startTime: 0,
+  playbackStartTime: undefined,
+  playbackDuration: undefined,
+} as const;
+
+function image(id: string, duration: number): TimelineClip {
+  return {
+    ...base,
+    id,
+    kind: "image",
+    alt: `${id} alt`,
+    src: `https://example.com/${id}.jpg`,
+    duration,
+    sourceDuration: duration,
+    trimIn: 0,
+    trimOut: 0,
+  };
+}
+
+function collectionClip(id: string, childTimelineId: string, title: string): TimelineClip {
+  return {
+    ...base,
+    id,
+    kind: "collection",
+    title,
+    childTimelineId,
+    itemCount: 2,
+    alt: `${title} collection`,
+    duration: 30,
+    sourceDuration: 30,
+    trimIn: 0,
+    trimOut: 0,
+  };
+}
+
+const media = (id: string, durationSeconds = 4): GraphNodeSpec => ({
+  kind: "media",
+  id,
+  name: id,
+  durationSeconds,
+});
+
+const collection = (
+  id: string,
+  children: readonly GraphNodeSpec[] = [],
+  extra: Partial<GraphNodeSpec> = {},
+): GraphNodeSpec => ({ kind: "collection", id, name: id, children, ...extra });
+
+function graphOf(roots: readonly GraphNodeSpec[]): CollectionsGraph {
+  const result = buildGraph(roots);
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.value;
+}
+
+const idsOf = (graph: CollectionsGraph, focused: string) =>
+  flattenMediaOrder(graph, parseNodeId(focused)).map((item) => String(item.nodeId));
+
+describe("flattenMediaOrder", () => {
+  it("emits media depth-first in child order, walking THROUGH collections", () => {
+    const graph = graphOf([
+      collection("root", [
+        media("a"),
+        collection("scene", [media("s1"), media("s2")]),
+        media("b"),
+      ]),
+    ]);
+
+    // "scene" itself never appears — a flat run has no collections in it.
+    expect(idsOf(graph, "root")).toEqual(["a", "s1", "s2", "b"]);
+  });
+
+  it("descends any depth, and each item carries its parent chain", () => {
+    const graph = graphOf([
+      collection("root", [
+        collection("mid", [collection("deep", [media("d1")]), media("m1")]),
+      ]),
+    ]);
+
+    expect(flattenMediaOrder(graph, parseNodeId("root")).map((item) => ({
+      id: String(item.nodeId),
+      path: item.collectionPath.map(String),
+    }))).toEqual([
+      { id: "d1", path: ["mid", "deep"] },
+      { id: "m1", path: ["mid"] },
+    ]);
+  });
+
+  it("gives a direct child of the focused timeline an EMPTY path", () => {
+    // Nothing sits between it and the view's root, so there is no collection
+    // to name on its card.
+    const graph = graphOf([collection("root", [media("a")])]);
+    expect(flattenMediaOrder(graph, parseNodeId("root"))[0].collectionPath).toEqual([]);
+  });
+
+  it("walks THROUGH a disabled collection rather than skipping it", () => {
+    // Disabling changes what plays, not what the timeline contains — the
+    // children still show, muted, exactly as on the nested board.
+    const graph = graphOf([
+      collection("root", [
+        collection("off", [media("x"), media("y")], { disabled: true }),
+        media("z"),
+      ]),
+    ]);
+    expect(idsOf(graph, "root")).toEqual(["x", "y", "z"]);
+  });
+
+  it("flattens from the FOCUSED collection, not the project root", () => {
+    const graph = graphOf([
+      collection("root", [media("a"), collection("scene", [media("s1")])]),
+    ]);
+    expect(idsOf(graph, "scene")).toEqual(["s1"]);
+  });
+
+  it("is empty for an empty collection", () => {
+    expect(idsOf(graphOf([collection("root", [])]), "root")).toEqual([]);
+  });
+
+  it("stops at maxDepth instead of recursing forever", () => {
+    const graph = graphOf([
+      collection("root", [collection("l1", [collection("l2", [media("deep")])])]),
+    ]);
+    // Depth 1 reaches l1's own media (none) but not l2's.
+    expect(flattenMediaOrder(graph, parseNodeId("root"), 1)).toEqual([]);
+    expect(flattenMediaOrder(graph, parseNodeId("root"), 2).map((i) => String(i.nodeId))).toEqual([
+      "deep",
+    ]);
+  });
+});
+
+describe("manifest parity", () => {
+  // The invariant that keeps the flat strip and the preview telling the same
+  // story about what comes next.
+  function docs(): Record<string, TimelineDocument> {
+    return {
+      root: {
+        id: "root",
+        title: "Root",
+        clips: packTimelineClips([
+          image("a", 4),
+          collectionClip("clip-scene", "scene", "Scene"),
+          image("b", 4),
+        ]),
+      },
+      scene: {
+        id: "scene",
+        title: "Scene",
+        clips: packTimelineClips([image("s1", 4), image("s2", 4)]),
+      },
+    };
+  }
+
+  it("orders media exactly as the manifest orders its leaves", () => {
+    const documents = docs();
+    const focused = buildFocusedGraph(documents, "root");
+    if (!focused.ok) throw new Error(focused.error);
+
+    const manifest = compilePlaybackManifest(documents, "root", 1, "2026-07-26T00:00:00.000Z");
+    const manifestOrder = manifest.leaves.map((leaf) => leaf.id);
+    const flatOrder = idsOf(focused.value.graph, "root");
+
+    expect(flatOrder).toEqual(manifestOrder);
+    expect(flatOrder).toEqual(["a", "s1", "s2", "b"]);
+  });
+
+  it("keeps the manifest a SUBSEQUENCE when a collection is trimmed", () => {
+    // The deliberate membership difference: the manifest windows a trimmed
+    // collection down to what plays, while the flat strip is an editing
+    // surface and must still show what was trimmed away. Order is shared;
+    // membership is not — so the manifest's ids must appear in the flat list
+    // in the same relative order, not equal it.
+    const documents = docs();
+    const sceneClip = documents.root.clips.find((clip) => clip.kind === "collection")!;
+    // Show only the first half of the scene.
+    Object.assign(sceneClip, { sourceDuration: 8, trimIn: 0, trimOut: 4, duration: 4 });
+
+    const focused = buildFocusedGraph(documents, "root");
+    if (!focused.ok) throw new Error(focused.error);
+    const manifest = compilePlaybackManifest(documents, "root", 1, "2026-07-26T00:00:00.000Z");
+
+    const flatOrder = idsOf(focused.value.graph, "root");
+    const manifestOrder = manifest.leaves.map((leaf) => leaf.id);
+
+    // STRICTLY fewer, asserted first: without this the subsequence check
+    // below would pass vacuously if the trim never took effect, and the test
+    // would prove nothing about the difference it exists to describe.
+    expect(manifestOrder).toEqual(["a", "s1", "b"]);
+    expect(flatOrder).toEqual(["a", "s1", "s2", "b"]);
+
+    // Subsequence check: walk the flat list once, consuming manifest ids.
+    let cursor = 0;
+    for (const id of flatOrder) if (id === manifestOrder[cursor]) cursor += 1;
+    expect(cursor).toBe(manifestOrder.length);
+  });
+});
+
+describe("resolveFlatDropTarget", () => {
+  const graph = graphOf([
+    collection("root", [
+      media("a"),
+      collection("scene", [media("s1"), media("s2")]),
+      media("b"),
+    ]),
+  ]);
+  const items = flattenMediaOrder(graph, parseNodeId("root"));
+  const resolve = (boundary: number) => {
+    const target = resolveFlatDropTarget(graph, items, parseNodeId("root"), boundary);
+    return { parent: String(target.parentId), index: target.index };
+  };
+
+  it("sends a drop at the very start to the head of the FOCUSED timeline", () => {
+    // No left neighbour to inherit a collection from.
+    expect(resolve(0)).toEqual({ parent: "root", index: 0 });
+  });
+
+  it("lands in the left neighbour's collection, right after it", () => {
+    // Flat order is [a, s1, s2, b]. After s1 — which lives in "scene", not
+    // root — the drop belongs to scene at index 1.
+    expect(resolve(2)).toEqual({ parent: "scene", index: 1 });
+    // After s2, still scene, now at its end.
+    expect(resolve(3)).toEqual({ parent: "scene", index: 2 });
+  });
+
+  it("uses the FOCUSED timeline when the left neighbour is a direct child", () => {
+    expect(resolve(1)).toEqual({ parent: "root", index: 1 });
+  });
+
+  it("clamps a boundary past the ends", () => {
+    expect(resolve(-5)).toEqual({ parent: "root", index: 0 });
+    // Past the last item: after "b", which is root's third child.
+    expect(resolve(99)).toEqual({ parent: "root", index: 3 });
+  });
+
+  it("appends when the flat list is stale against the graph", () => {
+    const stale = [{ nodeId: parseNodeId("ghost"), collectionPath: [parseNodeId("scene")] }];
+    const target = resolveFlatDropTarget(graph, stale, parseNodeId("root"), 1);
+    expect(String(target.parentId)).toBe("scene");
+    expect(target.index).toBe(2);
+  });
+});

--- a/packages/timeline-domain/src/flat-order.ts
+++ b/packages/timeline-domain/src/flat-order.ts
@@ -1,0 +1,115 @@
+// The FLAT reading of a timeline: every media item in the focused closure, in
+// playback order, with collections walked THROUGH rather than shown. What the
+// strip's "show all items in order" mode renders.
+//
+// The graph twin of `compilePlaybackManifest`'s walk — same depth-first order,
+// same child order — but over the live GRAPH rather than stored documents, and
+// with one deliberate difference in MEMBERSHIP (see below). Keeping the two
+// orders identical is what stops the flat strip and the preview disagreeing
+// about what comes next.
+//
+// MEMBERSHIP DIFFERS, ON PURPOSE. The manifest emits what PLAYS, so it windows
+// a trimmed collection clip down to the leaves overlapping its trim range and
+// drops the rest. This emits what the timeline CONTAINS, because the flat strip
+// is an editing surface: an item trimmed out of playback still exists, is still
+// selectable, and still has to be reachable. So the manifest's leaves are a
+// SUBSEQUENCE of this walk, not an equal set — the invariant its parity test
+// asserts.
+
+import { getChildren, type CollectionsGraph, type NodeId } from "./engine";
+
+export type FlatItem = Readonly<{
+  nodeId: NodeId;
+  /**
+   * The collection ids from the focused root down to this item's own parent —
+   * last entry IS the parent. Empty for a direct child of the focused
+   * timeline, which has no collection above it inside this view.
+   *
+   * Carried because the flat strip needs it twice over: to name the item's
+   * collection on the card (a flat run loses that context, which is why
+   * reordering is disabled in it), and to resolve a palette drop, which lands
+   * in the LEFT neighbour's parent.
+   */
+  collectionPath: readonly NodeId[];
+}>;
+
+/**
+ * Every media node under `focusedId`, depth-first in child order.
+ *
+ * Collections are descended into and never emitted — including DISABLED ones.
+ * A disabled collection's children still exist and still show (muted, as
+ * "PARENT OFF"), exactly as they do on the nested board; disabling changes
+ * what plays, not what the timeline contains.
+ *
+ * `maxDepth` caps recursion as defensive insurance against pathological data,
+ * matching the board's own MAX_SUBTREE_DEPTH. The path-scoped `seen` set is
+ * the same kind of insurance: the graph is a single-parent tree by
+ * construction, so a cycle cannot occur in a valid one — but this runs on the
+ * render path, where hanging is a far worse failure than truncating. Unlike
+ * the manifest compiler, which throws on a cycle because it runs server-side
+ * and can afford to fail loudly, this simply stops descending.
+ */
+export function flattenMediaOrder(
+  graph: CollectionsGraph,
+  focusedId: NodeId,
+  maxDepth = 12,
+): FlatItem[] {
+  const items: FlatItem[] = [];
+
+  const walk = (
+    collectionId: NodeId,
+    path: readonly NodeId[],
+    depth: number,
+    seen: ReadonlySet<NodeId>,
+  ): void => {
+    if (depth > maxDepth || seen.has(collectionId)) return;
+    const nextSeen = new Set(seen);
+    nextSeen.add(collectionId);
+
+    for (const childId of getChildren(graph, collectionId)) {
+      const node = graph.nodesById.get(childId);
+      if (!node) continue;
+      if (node.kind === "media") {
+        items.push({ nodeId: childId, collectionPath: path });
+        continue;
+      }
+      walk(childId, [...path, childId], depth + 1, nextSeen);
+    }
+  };
+
+  walk(focusedId, [], 0, new Set());
+  return items;
+}
+
+/**
+ * The item immediately LEFT of a flat boundary, and where a palette drop there
+ * belongs: that neighbour's own collection, right after it.
+ *
+ * A flat run spans many parents, so a drop position cannot name a parent by
+ * itself — this is the rule that gives it one. At the very start (boundary 0)
+ * there is no left neighbour, so the drop goes to the head of the focused
+ * timeline.
+ *
+ * `boundary` is the gap index in the FLAT list: 0 is before the first item,
+ * `items.length` is after the last.
+ */
+export function resolveFlatDropTarget(
+  graph: CollectionsGraph,
+  items: readonly FlatItem[],
+  focusedId: NodeId,
+  boundary: number,
+): Readonly<{ parentId: NodeId; index: number }> {
+  const clamped = Math.max(0, Math.min(items.length, Math.trunc(boundary)));
+  if (clamped === 0) return { parentId: focusedId, index: 0 };
+
+  const left = items[clamped - 1];
+  const parentId = left.collectionPath[left.collectionPath.length - 1] ?? focusedId;
+  const siblings = getChildren(graph, parentId);
+  const leftIndex = siblings.indexOf(left.nodeId);
+  // A left neighbour that is somehow not among its parent's children means the
+  // flat list is stale against the graph; appending is the safe reading.
+  return {
+    parentId,
+    index: leftIndex < 0 ? siblings.length : leftIndex + 1,
+  };
+}


### PR DESCRIPTION
**Step 1 of 5** for the flat strip ("show all items in order"). Pure functions and tests only — no UI, nothing wired up yet.

## What it does

`flattenMediaOrder(graph, focusedId, maxDepth?)` walks the focused closure depth-first in child order, emitting media nodes and walking **through** collections without emitting them. Each item carries its **parent chain**, which the strip needs twice over: to name the item's collection on the card (a flat run loses that context — which is why reordering is disabled in it), and to resolve a palette drop.

Disabled collections are walked through, not skipped: disabling changes what *plays*, not what a timeline *contains*, so their children still appear — muted, exactly as on the nested board.

## The subtle part: membership differs from the manifest, on purpose

The plan called for matching `compilePlaybackManifest`'s order. Matching its **order** is right; matching its **membership** is not, and the difference is worth stating because it would otherwise look like a bug:

- The manifest emits what **plays**, so it windows a trimmed collection clip down to the leaves overlapping its trim range and drops the rest.
- This emits what the timeline **contains**, because the flat strip is an *editing* surface — an item trimmed out of playback still exists, is still selectable, and must stay reachable.

So the manifest's leaves are a **subsequence** of this walk, not an equal set. Both cases are pinned:

- Untrimmed: the two sequences are asserted **equal** (`[a, s1, s2, b]`).
- Trimmed: asserted **explicitly** as `[a, s1, b]` vs `[a, s1, s2, b]` *before* the subsequence check — otherwise the subsequence assertion would pass vacuously if the trim ever stopped taking effect, and the test would prove nothing about the very difference it exists to describe.

## Drop resolution

`resolveFlatDropTarget` is the rule from the design discussion: a boundary lands in the **left neighbour's collection**, right after it; at boundary 0, the head of the focused timeline. Boundaries are clamped, and a left neighbour missing from its parent's children (a flat list stale against the graph) appends rather than guessing.

## Robustness

Cycle-guarded (path-scoped) and depth-capped. Unlike the manifest compiler — which throws on a cycle because it runs server-side and can afford to fail loudly — this **stops descending**: it runs on the render path, where hanging is a far worse failure than truncating.

## Verification

14 new tests. Unit 406 · app 415 · typecheck (`packages/ui` + app) clean · lint 0 errors.

## Next

2. Full-closure hydration + loading state · 3. `FlatStrip` view + toggle · 4. reorder veto + drop wiring · 5. provenance label + click-to-reveal.

Generated with [Claude Code](https://claude.com/claude-code)