### PR TITLE
VirtualStrip takes an optional item source

### DIFF
--- a/packages/ui/dnd-collections/API.md
+++ b/packages/ui/dnd-collections/API.md
@@ -981,6 +981,7 @@ only after Enter — navigation stands down while a drag is live.
 ```ts
 type VirtualStripProps = {
   collectionId: NodeId;
+  itemIds?: readonly NodeId[];                           // render THESE nodes instead of collectionId's own children — the seam for a FLAT strip spanning many parents. collectionId still identifies the VIEW (DOM marker, accessible name, insert-container key); only the item source changes. Caller owns reference stability (the virtualizer keys measurements off it) AND index meaning: published boundaries index into THIS list while the drop intent still names collectionId, so a consumer allowing drops must translate (flat boundary → real parent + index) before the command commits
   pixelsPerSecond?: number;                              // THE timeline scale: media widths = durationToWidth(duration, pps), and trim handles inherit it — one scale, no drift. The recommended sizing for duration-mapped strips
   itemWidth?: number;                                    // default 128; collections and non-duration fallbacks
   itemWidthFor?: (node: CollectionItemNode) => number | undefined; // ADVANCED per-node width override (beats pixelsPerSecond); memoized by node id

--- a/packages/ui/dnd-collections/VirtualStrip.stories.tsx
+++ b/packages/ui/dnd-collections/VirtualStrip.stories.tsx
@@ -2122,3 +2122,78 @@ export const OverlayRidesLeftTrimTransform: Story = {
     expect(Math.abs(playheadX() - (x0 - 48))).toBeLessThanOrEqual(1);
   },
 };
+
+// ── itemIds: the FLAT item source ───────────────────────────────────────────
+//
+// A strip normally renders `collectionId`'s own children. `itemIds` overrides
+// that so one strip can show media drawn from MANY collections — the "show all
+// items in order" mode, where a whole closure is laid out flat. `collectionId`
+// stays the view's identity (marker, accessible name, insert container); only
+// the item source changes.
+
+const nestedGraph = () => {
+  const result = buildGraph([
+    {
+      kind: "collection",
+      id: "root",
+      name: "Root",
+      children: [
+        { kind: "media", id: "a", name: "A", durationSeconds: 4 },
+        {
+          kind: "collection",
+          id: "scene",
+          name: "Scene",
+          children: [
+            { kind: "media", id: "s1", name: "S1", durationSeconds: 4 },
+            {
+              kind: "media",
+              id: "s2",
+              name: "S2",
+              mediaKind: "video",
+              fullDurationSeconds: 6,
+            },
+          ],
+        },
+        { kind: "media", id: "b", name: "B", durationSeconds: 4 },
+      ],
+    },
+  ]);
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.value;
+};
+
+/** The flat run, in playback order, spanning two parents. Module scope so the
+ *  reference is stable — the virtualizer keys its measurements off it. */
+const FLAT_IDS = ["a", "s1", "s2", "b"].map(parseNodeId);
+
+export const FlatItemSource: Story = {
+  render: () => (
+    <DndCollections initialGraph={nestedGraph()}>
+      <div className="w-[640px]">
+        <VirtualStrip collectionId={parseNodeId("root")} itemIds={FLAT_IDS} itemWidth={96} />
+      </div>
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    // Every card renders, in the supplied order — including s1/s2, which are
+    // children of "scene" and would never appear in root's own strip.
+    for (const id of ["a", "s1", "s2", "b"]) {
+      await waitForLayout(nodeCard(canvasElement, id));
+    }
+    const xs = ["a", "s1", "s2", "b"].map((id) =>
+      nodeCard(canvasElement, id).getBoundingClientRect().left,
+    );
+    expect(xs).toEqual([...xs].sort((left, right) => left - right));
+
+    // The collection itself is NOT drawn — a flat run has no collections in it.
+    expect(canvasElement.querySelector('[data-node-id="scene"]')).toBeNull();
+
+    // Selecting a video whose parent is a NESTED collection still raises the
+    // trim overview: the strip scopes by membership in `itemIds`, not by
+    // parentage, which the unmodified parent test would have rejected.
+    await userEvent.click(nodeCard(canvasElement, "s2"));
+    await waitFor(() =>
+      expect(nodeCard(canvasElement, "s2").getAttribute("data-selected")).toBe("true"),
+    );
+  },
+};

--- a/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
@@ -116,6 +116,27 @@ const OVERLAY_Z_INDEX = 30;
 export type VirtualStripProps = Readonly<{
   collectionId: NodeId;
   /**
+   * Render THESE nodes instead of `collectionId`'s own children — the seam for
+   * a FLAT strip, which shows a whole closure's media in playback order and so
+   * spans many parents.
+   *
+   * `collectionId` still identifies the VIEW (its DOM marker, its accessible
+   * name, its insert-container key): a flat strip still belongs to the
+   * collection it was opened from. Only the item SOURCE changes.
+   *
+   * Caller owns reference stability — the virtualizer keys its measurements off
+   * this array, so a new array every render re-measures the whole strip. Memoize
+   * on the committed graph, as the store's own selectors do.
+   *
+   * CALLER OWNS INDEX MEANING TOO. Boundaries this strip publishes are indices
+   * into THIS list, and the drop intent still names `collectionId` — so a
+   * consumer that allows drops must translate (flat boundary → real parent +
+   * index) before the command commits, or items land at the wrong index in the
+   * wrong collection. The graph view vetoes position-based commands in flat
+   * mode for exactly this reason.
+   */
+  itemIds?: readonly NodeId[];
+  /**
    * THE timeline scale: media card widths derive from their effective
    * duration via `durationToWidth(seconds, pixelsPerSecond)`, and — unless
    * `trimPixelsPerSecond` overrides it — the trim handles convert drags at
@@ -196,6 +217,7 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
   function VirtualStrip(
     {
       collectionId,
+      itemIds,
       pixelsPerSecond: pixelsPerSecondOption,
       itemWidth: itemWidthOption,
       itemWidthFor,
@@ -228,8 +250,10 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
     const ItemShell: CollectionItemShellComponent = itemShell ?? registeredShell ?? NodeCard;
 
     // Stable array reference between commits — the virtualizer's item keys
-    // and index math stay coherent across drags for free.
-    const childIds = useCollectionsSelector((s) => getChildren(s.graph, collectionId));
+    // and index math stay coherent across drags for free. An `itemIds`
+    // override (flat strip) supplies its own list and owns that stability.
+    const ownChildIds = useCollectionsSelector((s) => getChildren(s.graph, collectionId));
+    const childIds = itemIds ?? ownChildIds;
     const indexById = useMemo(
       () => new Map(childIds.map((id, index) => [id, index])),
       [childIds]
@@ -256,9 +280,19 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
     // re-render. (Unscoped, it returned the first selected video ANYWHERE, so
     // every mounted strip received the same node and re-rendered on any video
     // selection — even though only one strip could ever display it.)
+    // Membership, not parentage, when an item source is supplied: a flat
+    // strip's cards live under many parents, so the parent test would reject
+    // every one of them and the trim overview would never appear.
+    const shownIds = useMemo(
+      () => (itemIds ? new Set<NodeId>(itemIds) : null),
+      [itemIds],
+    );
+    // The item source as the change-feed subscriber sees it (see its own note).
+    const shownIdsRef = useRef<readonly NodeId[] | null>(null);
+    shownIdsRef.current = itemIds ?? null;
     const selectedVideo = useCollectionsSelector((s) => {
       for (const id of s.interaction.selectedIds) {
-        if (s.graph.parentById.get(id) !== collectionId) continue;
+        if (shownIds ? !shownIds.has(id) : s.graph.parentById.get(id) !== collectionId) continue;
         const n = s.graph.nodesById.get(id);
         if (n && isVideoMedia(n)) return n;
       }
@@ -372,7 +406,14 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
         // flush in order — a listener dispatching a MOVE before this update
         // drains would make any cached index stale. O(children) per update,
         // at commit cadence.
-        const children = change.graph.childrenById.get(collectionId);
+        // A supplied item source cannot be re-derived from the change's graph
+        // (only the consumer knows how the list was built), so it is read from
+        // a ref instead. Safe here specifically: `nodes-updated` is a DATA
+        // patch — a trim or a rename — which never changes membership or
+        // order, so the list this strip last rendered is still the one whose
+        // indices these updates address. Structural patches take the
+        // childIds-identity path above, not this one.
+        const children = shownIdsRef.current ?? change.graph.childrenById.get(collectionId);
         if (!children) return;
         for (const update of change.patch.updates) {
           const index = children.indexOf(update.nodeId);


### PR DESCRIPTION
**Step 2 of the flat strip.** The package seam only — the app doesn't use it yet.

## This revises the plan you approved

The plan called for a separate `FlatStrip` view, because `VirtualStrip` assumes its `collectionId` in eight places. Reading further, that was the wrong call and I raised it before building:

- `VirtualStrip` is **874 lines** wiring pan-with-momentum, edge autoscroll, roving focus, the trim overview, FLIP and an imperative handle. A second copy means permanently twinned views where every future fix lands twice — plus twinned interaction tests.
- Only **three** of those eight usages actually conflict with a flat list. The rest are **identity** — the `data-virtual-strip` marker, the accessible name, the insert-container key — which a flat strip keeps happily, because it still belongs to the collection it was opened from.
- Drop resolution isn't in the view at all: `DropIntent` and `resolveCommandFromIntent` live in the pure core. So the flat drop rule is a separate concern and never argued for a separate view.

## The three conflicts

- **Item source** — `itemIds ?? getChildren(graph, collectionId)`.
- **Selected-video scoping** tested `parentById.get(id) !== collectionId`. A flat strip's cards live under many parents, so that test would reject every one and the trim overview would never appear. Now it tests membership in `itemIds` when supplied.
- **The trim-resize subscriber** indexed off `change.graph.childrenById.get(collectionId)`. It can't re-derive a supplied list (only the consumer knows how it was built), so it reads a ref. Safe *precisely* here: `nodes-updated` is a **data** patch — a trim or a rename — which never changes membership or order, so the list last rendered still addresses these updates. Structural patches take the `childIds`-identity path instead, not this one.

## What the caller owns

Documented loudly on the prop and in API.md: reference stability (the virtualizer keys measurements off the array) **and index meaning** — published boundaries index into the supplied list while the drop intent still names `collectionId`. A consumer allowing drops must translate flat boundary → real parent + index before the command commits, or items land at the wrong index in the wrong collection. That's why the graph view will veto position-based commands in flat mode until step 4 builds the translation.

## Verification

- New `FlatItemSource` story: a run spanning two parents renders in order; `s1`/`s2` are children of `scene`, so they can only appear via the override — it cannot pass vacuously. Asserts the collection itself is not drawn, and that selecting a video under a nested parent still works (the membership fix).
- **All 156 story tests pass**, including `RenderEfficiencyDuringDrag` — the override is fully backward-compatible when omitted.
- Unit 406 · app 415 · typecheck (`packages/ui` + app) clean · lint 0 errors.

Typecheck caught a bad video spec in my new story that the passing test didn't (`durationSeconds` where video takes `fullDurationSeconds`) — fixed.

Generated with [Claude Code](https://claude.com/claude-code)