### PR TITLE
Flat strip: the toggle, the closure hydration, and the run itself

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useContext, useDeferredValue } from "react";
+import { useContext, useDeferredValue, useMemo } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { EllipsisVertical, FolderPlus, Redo2, Undo2 } from "lucide-react";
@@ -13,6 +13,8 @@ import {
   useCollectionsSelector,
   useCollectionsStore,
 } from "@storyboard/ui/dnd-collections";
+
+import { flattenMediaOrder } from "@storyboard/timeline-domain";
 
 import { requestGraphToolInsert } from "@/lib/graph-view-events";
 import { Button } from "@/components/core/button";
@@ -50,6 +52,7 @@ import {
   GRID_UNCAPPED_HEIGHT,
   ITEM_SIZE_DIMENSIONS,
   ITEM_SIZES,
+  MAX_SUBTREE_DEPTH,
   MAX_TIMELINE_PPS,
   MIN_TIMELINE_PPS,
   isItemSize,
@@ -314,6 +317,7 @@ export function GraphBoard({
   onPixelsPerSecondChange,
   previewOn,
   rulerOn,
+  flatOn,
   storyboardHref,
   childrenShown,
   timeChannel,
@@ -334,6 +338,9 @@ export function GraphBoard({
   previewOn: boolean;
   /** Toggled from the SIDEBAR's ruler icon (strip mode only). */
   rulerOn: boolean;
+  /** Strip's flat mode: render the whole closure in order, not this
+   *  collection's direct children. */
+  flatOn: boolean;
   /** For the overflow menu's "Storyboard view" item — routing stays the
    *  caller's business, like the breadcrumb slot. */
   storyboardHref: string;
@@ -360,6 +367,22 @@ export function GraphBoard({
   // below — strip, ruler, playheads, scrub bands, sub-rows — shares this ONE
   // deferred value, so their geometry can never disagree mid-drag.
   const deferredPixelsPerSecond = useDeferredValue(pixelsPerSecond);
+  // FLAT mode's item source: every media node in the focused closure, in
+  // playback order. Memoized on the committed graph's IDENTITY — the store
+  // notifies for interaction too, and VirtualStrip keys its measurements off
+  // this array, so a fresh one per notification would re-measure the whole
+  // strip mid-drag. `undefined` when flat is off, which is what makes the
+  // strip fall back to the focused collection's own children.
+  const graph = useCollectionsSelector((s) => s.graph);
+  const flatItemIds = useMemo(
+    () =>
+      flatOn
+        ? flattenMediaOrder(graph, parseNodeId(focusedId), MAX_SUBTREE_DEPTH).map(
+            (item) => item.nodeId,
+          )
+        : undefined,
+    [flatOn, graph, focusedId],
+  );
 
   return (
     <OpenKeyBoundary trashId={trashRootId}>
@@ -445,12 +468,20 @@ export function GraphBoard({
               <NativeDropStrip collectionId={focusedId}>
               <VirtualStrip
                 collectionId={parseNodeId(focusedId)}
+                itemIds={flatItemIds}
                 pixelsPerSecond={deferredPixelsPerSecond}
                 itemWidth={collectionCardWidth(deferredPixelsPerSecond)}
                 itemHeight={dims.strip}
                 itemDragActivation="hold"
                 overlay={
-                  previewOn || rulerOn ? (
+                  // FLAT mode carries no time overlays yet. The ruler, the
+                  // playhead and the rail below all position through
+                  // `childSpans`, which maps the focused collection's DIRECT
+                  // children — in a flat run those are the wrong cards, so the
+                  // marks would land on items they do not describe. Showing
+                  // nothing is the honest state until the flat span model
+                  // lands; the preview pane itself still plays.
+                  !flatOn && (previewOn || rulerOn) ? (
                     <>
                       {rulerOn ? (
                         <GraphRuler
@@ -477,7 +508,7 @@ export function GraphBoard({
                   with the content; a drag held at the scroller's edge
                   auto-pans to reveal more items mid-scrub. Replaces the old
                   invisible PlayheadScrubBand. */}
-              {previewOn && (
+              {previewOn && !flatOn && (
                 <GraphStripSeekRail
                   focusedId={focusedId}
                   channel={timeChannel}

--- a/apps/timeline-gstudio001/components/graph-view/graph-hydration.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-hydration.tsx
@@ -181,3 +181,111 @@ export function HydrationController({
 
   return null;
 }
+
+/**
+ * Hydrate the WHOLE closure under `rootId` — every nested collection, to any
+ * depth — and resolve once nothing is left unhydrated.
+ *
+ * Flat mode needs this and the nested board does not: a strip showing one
+ * collection's children only ever needs that collection loaded, but a flat run
+ * IS the closure, so an unhydrated branch is not a collapsed row the user can
+ * open — it is items silently missing from a list that claims to be complete.
+ *
+ * A LOOP rather than one pass, because hydrating a level is what reveals the
+ * next: a placeholder's children only exist after its own document lands. Each
+ * round hydrates every placeholder it can currently see, then re-reads the
+ * graph and looks again; it ends when a round finds none.
+ *
+ * Rounds are bounded. Hydration can legitimately fail (a missing document, or
+ * another user's) — `hydrateTimeline` reports that and returns, leaving the
+ * collection unhydrated forever, so an unbounded loop would spin on it. The
+ * cap also covers a graph deeper than any real timeline.
+ *
+ * `onProgress` fires after each round so a caller can show what has landed so
+ * far; the gateway dedupes concurrent `ensure`s for the same id, so hydrating a
+ * level in parallel costs one request per document, not one per reference.
+ */
+export async function hydrateClosure(
+  store: CollectionsStore,
+  detailsStore: GraphDetailsStore,
+  rootId: string,
+  { maxRounds = 16, onProgress }: Readonly<{
+    maxRounds?: number;
+    onProgress?: () => void;
+  }> = {},
+): Promise<void> {
+  for (let round = 0; round < maxRounds; round += 1) {
+    const graph = store.getSnapshot().graph;
+    const details = detailsStore.read();
+    const pending: string[] = [];
+
+    // Collect every unhydrated collection under the root, this round.
+    const seen = new Set<string>();
+    const visit = (id: string) => {
+      if (seen.has(id)) return;
+      seen.add(id);
+      for (const childId of getChildren(graph, parseNodeId(id))) {
+        const node = graph.nodesById.get(childId);
+        if (!node || node.kind !== "collection") continue;
+        const childKey = childId as string;
+        if (details[childKey]?.hydrated === true) visit(childKey);
+        else pending.push(childKey);
+      }
+    };
+    visit(rootId);
+
+    if (pending.length === 0) return;
+    // Parallel within a round: these are independent documents, and the
+    // gateway collapses duplicate ids for us.
+    await Promise.all(pending.map((id) => hydrateTimeline(store, detailsStore, id)));
+    onProgress?.();
+
+    // A round that hydrated nothing NEW would loop forever — every id in
+    // `pending` failed to load and will keep failing. Stop and let their
+    // reported errors stand.
+    const after = detailsStore.read();
+    if (!pending.some((id) => after[id]?.hydrated === true)) return;
+  }
+}
+
+/**
+ * Loads the whole closure while FLAT mode is on.
+ *
+ * Mounted inside the provider (the collections store lives only there) and
+ * reports its pending state up, because the flag itself belongs to the view
+ * state the sidebar mirrors.
+ *
+ * Re-runs on focus change as well as on entry: drilling into a different
+ * collection while flat is on makes a different closure the subject.
+ */
+export function FlatClosureHydrator({
+  enabled,
+  focusedId,
+  onLoadingChange,
+}: Readonly<{
+  enabled: boolean;
+  focusedId: string;
+  onLoadingChange: (loading: boolean) => void;
+}>) {
+  const store = useCollectionsStore();
+  const detailsStore = useGraphDetailsStore();
+
+  useEffect(() => {
+    if (!enabled) {
+      onLoadingChange(false);
+      return;
+    }
+    let cancelled = false;
+    onLoadingChange(true);
+    void hydrateClosure(store, detailsStore, focusedId).finally(() => {
+      // A focus change or a flat-mode exit already superseded this run; its
+      // "finished" would clear a flag the NEXT run had just raised.
+      if (!cancelled) onLoadingChange(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, focusedId, store, detailsStore, onLoadingChange]);
+
+  return null;
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-mcp-tools.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-mcp-tools.tsx
@@ -22,6 +22,8 @@ const INITIAL_VIEW_STATE: GraphViewStateDetail = {
   rulerOn: false,
   childrenShown: false,
   previewOn: false,
+    flatOn: false,
+    flatLoading: false,
 };
 
 /**

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -38,6 +38,7 @@ import {
   GRAPH_ASSETS_TOGGLE_EVENT,
   GRAPH_CHILDREN_TOGGLE_EVENT,
   GRAPH_PREVIEW_TOGGLE_EVENT,
+  GRAPH_FLAT_TOGGLE_EVENT,
   GRAPH_RULER_TOGGLE_EVENT,
   GRAPH_SURFACE_EVENT,
   GRAPH_TRASH_EMPTIED_EVENT,
@@ -53,7 +54,7 @@ import { trashDocumentId as deriveTrashDocumentId } from "./trash-document-id";
 
 import { GraphBoard, type FocusSurface, type ItemSize } from "./graph-board";
 import { GraphDetailsProvider } from "./graph-details-context";
-import { HydrationController } from "./graph-hydration";
+import { FlatClosureHydrator, HydrationController } from "./graph-hydration";
 import { GraphItemActionsBridge } from "./graph-item-actions";
 import { McpToolsBridge } from "./graph-mcp-tools";
 import { GRAPH_VIEW_COMPONENTS } from "./graph-item-content";
@@ -158,6 +159,10 @@ export function GraphTimelineView({
   const [childrenShown, setChildrenShown] = useState(false);
   const [previewOn, setPreviewOn] = useState(false);
   const [rulerOn, setRulerOn] = useState(false);
+  // Flat mode: every item in the focused closure, in order, no nesting.
+  // Strip-only — grid has no equivalent, and leaving grid turns it off below.
+  const [flatOn, setFlatOn] = useState(false);
+  const [flatLoading, setFlatLoading] = useState(false);
   const [timeChannel] = useState(createPreviewTimeChannel);
   const [assetsOpen, setAssetsOpen] = useState(false);
 
@@ -175,14 +180,17 @@ export function GraphTimelineView({
       if (detail === "strip" || detail === "grid") setSurface(detail);
     };
     const onRulerToggle = () => setRulerOn((current) => !current);
+    const onFlatToggle = () => setFlatOn((current) => !current);
     const onChildrenToggle = () => setChildrenShown((current) => !current);
     const onPreviewToggle = () => setPreviewOn((current) => !current);
     window.addEventListener(GRAPH_SURFACE_EVENT, onSurface);
+    window.addEventListener(GRAPH_FLAT_TOGGLE_EVENT, onFlatToggle);
     window.addEventListener(GRAPH_RULER_TOGGLE_EVENT, onRulerToggle);
     window.addEventListener(GRAPH_CHILDREN_TOGGLE_EVENT, onChildrenToggle);
     window.addEventListener(GRAPH_PREVIEW_TOGGLE_EVENT, onPreviewToggle);
     return () => {
       window.removeEventListener(GRAPH_SURFACE_EVENT, onSurface);
+      window.removeEventListener(GRAPH_FLAT_TOGGLE_EVENT, onFlatToggle);
       window.removeEventListener(GRAPH_RULER_TOGGLE_EVENT, onRulerToggle);
       window.removeEventListener(GRAPH_CHILDREN_TOGGLE_EVENT, onChildrenToggle);
       window.removeEventListener(GRAPH_PREVIEW_TOGGLE_EVENT, onPreviewToggle);
@@ -192,8 +200,24 @@ export function GraphTimelineView({
   // …and this broadcast (on mount and every change) is what lets its
   // controls show the current surface, ruler, children, and preview state.
   useEffect(() => {
-    broadcastGraphViewState({ surface, rulerOn, childrenShown, previewOn });
-  }, [surface, rulerOn, childrenShown, previewOn]);
+    broadcastGraphViewState({ surface, rulerOn, childrenShown, previewOn, flatOn, flatLoading });
+  }, [surface, rulerOn, childrenShown, previewOn, flatOn, flatLoading]);
+
+  // Flat mode is a STRIP reading. Leaving strip drops it rather than letting it
+  // sit armed and re-apply invisibly on the way back — the grid never showed a
+  // flat run, so returning to a flat strip the user did not ask for would be a
+  // surprise. Adjusted during render (the repo's cascading-render-safe pattern)
+  // rather than in an effect, which the set-state-in-effect lint forbids.
+  const [prevSurface, setPrevSurface] = useState(surface);
+  if (prevSurface !== surface) {
+    setPrevSurface(surface);
+    if (surface !== "strip" && flatOn) setFlatOn(false);
+  }
+
+  // The closure hydration flat mode needs runs in `FlatClosureHydrator`, which
+  // is mounted INSIDE the provider below — the collections store only exists
+  // there. This component owns the flag and the pending state; the hydrator
+  // reports back through `setFlatLoading`.
 
   const gatewayError = useSyncExternalStore(
     graphDocumentsGateway.subscribe,
@@ -367,8 +391,37 @@ export function GraphTimelineView({
   // closure never goes stale. The onSync call is a deliberate exception to
   // the "pure predicate" rule — it feeds the SyncPanel's telemetry and fires
   // at most once per blocked dispatch.
+  // Read live rather than closed over: the policy closure is handed to the
+  // provider once, and a stale `flatOn` would let a reorder through the moment
+  // the user toggled flat on.
+  const flatOnRef = useRef(flatOn);
+  useEffect(() => {
+    flatOnRef.current = flatOn;
+  }, [flatOn]);
+
   const commandPolicy = useCallback<CommandPolicy>(
     (command) => {
+      // FLAT MODE refuses POSITION-based commands.
+      //
+      // Reordering: the owner's call, and the reason is the UI's — which
+      // collection an item belongs to stops being visible in a flat run, so a
+      // drag whose whole meaning is "put it here, among these" has no honest
+      // reading.
+      //
+      // Adding: a correctness bar, not a design one, and it lifts once the
+      // translation lands. The strip publishes boundaries into the FLAT list
+      // while the drop intent still names the focused collection, so a drop
+      // committed today would insert at a flat index inside the wrong parent.
+      // `resolveFlatDropTarget` is the rule that fixes it; until it is wired,
+      // refusing beats landing items somewhere nobody chose.
+      if (flatOnRef.current && (command.type === "move-nodes" || command.type === "add-nodes")) {
+        const message =
+          command.type === "move-nodes"
+            ? "Reordering is off while every item is shown — open the collection to reorder inside it."
+            : "Adding is off while every item is shown — open a collection to add to it.";
+        toast.error(message, { id: "flat-mode-blocked" });
+        return { reason: "blocked-by-policy", blockedIds: [], message };
+      }
       const blocked = collectUnhydratedDropTargets(command, detailsStore.read());
       if (blocked.length === 0) return null;
       onSync({
@@ -513,6 +566,14 @@ export function GraphTimelineView({
             serverPrimed={bootedFromServer}
             onFocusError={setFocusError}
           />
+          {/* Flat mode needs the WHOLE closure loaded, not just the focus
+              chain — mounted here because the collections store lives only
+              inside the provider. */}
+          <FlatClosureHydrator
+            enabled={flatOn}
+            focusedId={focusedId}
+            onLoadingChange={setFlatLoading}
+          />
 
           <GraphViewNavProvider
             projectId={projectId}
@@ -544,6 +605,7 @@ export function GraphTimelineView({
                 onPixelsPerSecondChange={setPixelsPerSecond}
                 previewOn={previewOn}
                 rulerOn={rulerOn}
+                flatOn={flatOn}
                 storyboardHref={storyboardHref}
                 childrenShown={childrenShown}
                 timeChannel={timeChannel}

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -1,26 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useRef, useSyncExternalStore } from "react";
-import {
-  Ban,
-  CircleCheck,
-  ClipboardPaste,
-  Copy,
-  CopyPlus,
-  Folder,
-  Images,
-  Layers,
-  FolderTree,
-  GalleryHorizontalEnd,
-  LayoutGrid,
-  Ruler,
-  Scissors,
-  Settings,
-  TvMinimal,
-  LogOut,
-  Trash2,
-  X,
-} from "lucide-react";
+import { Ban, CircleCheck, ClipboardPaste, Copy, CopyPlus, Folder, FolderTree, GalleryHorizontalEnd, Images, Layers, LayoutGrid, ListOrdered, LogOut, Ruler, Scissors, Settings, Trash2, TvMinimal, X } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { TrashDrawer } from "@/components/assets/trash-drawer";
@@ -35,6 +16,7 @@ import {
   requestGraphChildrenToggle,
   requestGraphItemAction,
   requestGraphPreviewToggle,
+  requestGraphFlatToggle,
   requestGraphRulerToggle,
   requestGraphSurface,
   type GraphItemAction,
@@ -375,6 +357,8 @@ export function TimelineSidebar() {
     rulerOn: false,
     childrenShown: false,
     previewOn: false,
+    flatOn: false,
+    flatLoading: false,
   });
   useEffect(() => {
     const onState = (event: Event) => {
@@ -593,6 +577,42 @@ export function TimelineSidebar() {
                   id="sidebar-tooltip-ruler"
                   label="Time ruler"
                   description="Tick marks over every strip"
+                />
+              </button>
+            )}
+
+            {/* Flat mode — strip only, like the ruler. Grid keeps its nesting,
+                so there is nothing to flatten there. */}
+            {onGraphRoute && graphView.surface === "strip" && (
+              <button
+                type="button"
+                aria-pressed={graphView.flatOn}
+                aria-label={graphView.flatOn ? "Show collections" : "Show all items in order"}
+                aria-describedby="sidebar-tooltip-flat"
+                aria-busy={graphView.flatLoading}
+                onClick={requestGraphFlatToggle}
+                className={cn(
+                  SIDEBAR_ICON_BASE,
+                  graphView.flatOn ? SIDEBAR_ICON_PRESSED : SIDEBAR_ICON_IDLE,
+                )}
+              >
+                <ListOrdered
+                  className={cn(
+                    "h-4 w-4 transition-colors",
+                    // Loading the closure can take a moment on a deep project,
+                    // and a half-built run would otherwise look like the real
+                    // answer.
+                    graphView.flatLoading ? "motion-safe:animate-pulse" : "",
+                  )}
+                />
+                <SidebarTooltipLabel
+                  id="sidebar-tooltip-flat"
+                  label="All items in order"
+                  description={
+                    graphView.flatLoading
+                      ? "Loading every collection…"
+                      : "One flat run — no collections. Reordering is off."
+                  }
                 />
               </button>
             )}

--- a/apps/timeline-gstudio001/lib/graph-view-events.ts
+++ b/apps/timeline-gstudio001/lib/graph-view-events.ts
@@ -46,6 +46,9 @@ export function requestGraphToolInsert(tool: GraphInsertTool): void {
 
 export const GRAPH_SURFACE_EVENT = "graph-view:set-surface";
 export const GRAPH_RULER_TOGGLE_EVENT = "graph-view:toggle-ruler";
+/** Strip only: show every item in the focused closure in playback order, with
+ *  no collections and no nesting. */
+export const GRAPH_FLAT_TOGGLE_EVENT = "graph-view:toggle-flat";
 export const GRAPH_CHILDREN_TOGGLE_EVENT = "graph-view:toggle-children";
 export const GRAPH_PREVIEW_TOGGLE_EVENT = "graph-view:toggle-preview";
 export const GRAPH_VIEW_STATE_EVENT = "graph-view:view-state";
@@ -58,6 +61,12 @@ export type GraphViewStateDetail = Readonly<{
   rulerOn: boolean;
   childrenShown: boolean;
   previewOn: boolean;
+  /** Strip's flat mode. Strip-only, like the ruler — grid has no equivalent. */
+  flatOn: boolean;
+  /** True while flat mode is loading the closure it needs (every nested
+   *  collection has to be hydrated before the flat run is complete). The
+   *  sidebar shows it as a pending state rather than a silently short list. */
+  flatLoading: boolean;
 }>;
 
 /** Ask the graph view to switch its layout surface. */
@@ -70,6 +79,11 @@ export function requestGraphSurface(surface: GraphSurface): void {
 /** Ask the graph view to toggle the strip's time ruler. */
 export function requestGraphRulerToggle(): void {
   window.dispatchEvent(new Event(GRAPH_RULER_TOGGLE_EVENT));
+}
+
+/** Ask the strip to toggle flat mode (all items in order, no nesting). */
+export function requestGraphFlatToggle(): void {
+  window.dispatchEvent(new Event(GRAPH_FLAT_TOGGLE_EVENT));
 }
 
 /** Ask the graph view to toggle the children-timelines tree. */

--- a/apps/timeline-gstudio001/lib/webmcp/tools.test.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/tools.test.ts
@@ -51,6 +51,8 @@ function viewSpies() {
     rulerOn: false,
     childrenShown: false,
     previewOn: false,
+    flatOn: false,
+    flatLoading: false,
   };
   let playback = { time: 0, isPlaying: false };
   return {

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -3414,6 +3414,43 @@ test.describe("graph view E2E", () => {
     expect(afterScroll).toBeLessThan(800);
   });
 
+  test("flat mode shows the whole closure in order, with no collections", async ({ page }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+
+    // Nested reading: the project's four direct children, one of them a
+    // collection card.
+    expect(await stripOrder(page, PROJECT_ID)).toEqual([
+      "alpha",
+      "bravo",
+      CHILD_ID,
+      "charlie",
+    ]);
+
+    const flat = page.getByRole("button", { name: "Show all items in order" });
+    await expect(flat).toBeVisible();
+    await flat.click();
+
+    // Flat reading: Scene A is walked THROUGH — its clips take its place, in
+    // order, and the collection card itself is gone.
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID), { timeout: 15000 })
+      .toEqual(["alpha", "bravo", "c1", "c2", "charlie"]);
+
+    // The time overlays stay off: they position through the focused
+    // collection's DIRECT children, so in a flat run they would mark the wrong
+    // cards. Showing nothing is deliberate until the flat span model lands.
+    await page.getByRole("button", { name: /show time ruler/i }).click();
+    await expect(page.locator("[data-graph-ruler]")).toHaveCount(0);
+
+    // Leaving flat mode restores the nested reading — and the ruler with it.
+    await page.getByRole("button", { name: "Show collections" }).click();
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID))
+      .toEqual(["alpha", "bravo", CHILD_ID, "charlie"]);
+    await expect(page.locator("[data-graph-ruler]")).toHaveCount(1);
+  });
+
   // The seek rail's marks are PER ITEM — one boundary tick between every pair
   // of cards — so unwindowed they scale with clip count, which is precisely
   // the cost the strip's card virtualizer exists to avoid. It matters most for

--- a/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
@@ -288,8 +288,14 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
       [itemIds],
     );
     // The item source as the change-feed subscriber sees it (see its own note).
+    // Written in an EFFECT, not during render — a render-time ref write is a
+    // lint error in this repo. One commit of lag is harmless here: the
+    // subscriber only uses it for `nodes-updated`, whose membership and order
+    // are identical in the previous list by definition.
     const shownIdsRef = useRef<readonly NodeId[] | null>(null);
-    shownIdsRef.current = itemIds ?? null;
+    useEffect(() => {
+      shownIdsRef.current = itemIds ?? null;
+    }, [itemIds]);
     const selectedVideo = useCollectionsSelector((s) => {
       for (const id of s.interaction.selectedIds) {
         if (shownIds ? !shownIds.has(id) : s.graph.parentById.get(id) !== collectionId) continue;


### PR DESCRIPTION
**Step 3.** Strip view can now show every item in the focused closure in playback order — no collections, no nesting. This is the first increment you can actually see.

Verified in the real app: **6 direct children become a 41-item run, 14 mounted** (virtualization holding), **zero collection cards**.

## Closure hydration

A flat run *is* the closure, so an unhydrated branch isn't a collapsed row the user can open — it's items silently missing from a list claiming to be complete. `hydrateClosure` loops rather than doing one pass, because hydrating a level is what reveals the next. Bounded, because hydration can legitimately fail (a missing document, or another user's) and an unbounded loop would spin on it forever.

It runs in `FlatClosureHydrator`, mounted **inside** the provider — the collections store lives only there — and reports pending state up to the sidebar, which shows it rather than letting a half-built run look like the final answer.

Flat mode is strip-only and drops when the surface leaves strip: the grid never showed a flat run, so coming back to a flat strip nobody asked for would be a surprise.

## Two things deliberately switched OFF, for different reasons

**Position-based commands are refused.** Reordering is your call and the UI's reason — which collection an item belongs to stops being visible, so a drag meaning "put it here, among these" has no honest reading. **Adding** is refused on a *correctness* bar instead, and only until step 4: the strip publishes boundaries into the flat list while the drop intent still names the focused collection, so a drop committed today would insert at a flat index inside the **wrong parent**. `resolveFlatDropTarget` (shipped in #207) is the fix; refusing beats landing items somewhere nobody chose.

**Time overlays are off in flat mode** — same class of reason, found while verifying. The ruler, playhead and seek rail all position through `childSpans`, which maps the focused collection's *direct* children. In a flat run those are the wrong cards, so every mark would sit on an item it doesn't describe. Showing nothing is the honest state until the flat span model lands. The preview pane itself still plays.

The header aggregate has the same limitation (it still reports the nested reading) and is the other half of that follow-up.

## Verification

- New e2e: nested `[alpha, bravo, Scene A, charlie]` → flat `[alpha, bravo, c1, c2, charlie]`, the collection card gone, the ruler suppressed, and toggling back restoring both.
- App 415 · unit 406 · typecheck (app + `packages/ui`) clean · lint 0 errors · e2e **65/65** (two known parallel-load flakes, both green in isolation).

One diagnostic worth recording: mid-verification the toggle appeared stuck on. It was Fast Refresh preserving state while my new `useState` shifted the hook order — a genuine fresh load behaved correctly. Not a bug, but it looked exactly like one.

## Next

**4.** drop translation (lifts the add veto) · **5.** provenance label + click-to-reveal · plus the flat span model for the overlays and header.

Generated with [Claude Code](https://claude.com/claude-code)