### PR TITLE
Flat cards name their collection, and reveal it

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -293,6 +293,40 @@ function useDisabledByAncestor(id: NodeId): boolean {
 }
 
 /**
+ * Where a card's item actually LIVES, when that is not the timeline you are
+ * looking at — the flat strip's answer to the context it gives up.
+ *
+ * Returns null in the ordinary nested strip, and it needs no mode flag to do
+ * so: there, every card's parent IS the focused collection, so the comparison
+ * is false by construction. In a flat run the cards drawn from nested
+ * collections differ, and exactly those get a label. Direct children of the
+ * focused timeline stay unlabelled in both readings, which is right — their
+ * collection is the one on screen.
+ */
+function useCardProvenance(
+  id: NodeId,
+): Readonly<{ parentId: NodeId; name: string }> | null {
+  const nav = useContext(GraphViewNavContext);
+  const focusedId = nav?.focusedId ?? null;
+  // Primitive returns, per the store's selector contract.
+  const parentId = useCollectionsSelector(
+    (snapshot) => snapshot.graph.parentById.get(id) ?? null,
+  );
+  const nodeName = useCollectionsSelector((snapshot) => {
+    const parent = snapshot.graph.parentById.get(id);
+    return parent ? (snapshot.graph.nodesById.get(parent)?.name ?? null) : null;
+  });
+  // The document title is the source of truth for a collection's name (the
+  // graph node is the optimistic fallback until it loads) — same resolution
+  // the collection card and the breadcrumb use, so a rename shows here too.
+  const title = useTimelineTitle((parentId ?? "") as string);
+
+  if (parentId === null || focusedId === null) return null;
+  if ((parentId as string) === focusedId) return null;
+  return { parentId, name: title ?? nodeName ?? (parentId as string) };
+}
+
+/**
  * The card's "this will not play" badge, top-right.
  *
  * Two causes, two words, because the fix differs: a card disabled OUTRIGHT is
@@ -323,6 +357,47 @@ function DisabledChip({ inherited }: { inherited: boolean }) {
   );
 }
 
+/**
+ * Which collection this card's item lives in, drawn along the card's bottom
+ * edge — the flat strip's orientation, and what makes the drop rule ("lands in
+ * the left neighbour's collection") readable BEFORE you release.
+ *
+ * A SPAN, not a button, deliberately. This renders inside NodeCard's selection
+ * `<button>`, and nesting interactive semantics is invalid HTML and an
+ * ambiguous a11y tree — the package makes that an invariant and a story
+ * asserts it. So the reveal rides a double-click, which needs no role, and the
+ * O key covers the same action from the keyboard (see OpenKeyBoundary).
+ *
+ * KNOWN GAP: `aria-hidden`, matching the card's other chips, so the collection
+ * name is not announced. Fixing that means composing it into the card's
+ * accessible name, which lives in the package's NodeCard — a change worth
+ * making deliberately rather than smuggling in here.
+ */
+function ProvenanceLabel({
+  parentId,
+  name,
+}: Readonly<{ parentId: NodeId; name: string }>) {
+  const nav = useContext(GraphViewNavContext);
+  return (
+    <span
+      aria-hidden="true"
+      data-provenance={parentId as string}
+      title={`In "${name}" — double-click to open it (or press O)`}
+      onDoubleClick={(event) => {
+        event.stopPropagation();
+        nav?.openTimeline(parentId);
+      }}
+      // TOP-LEFT: the bottom band is already three-deep (kind tag left,
+      // duration pill right, and the label spanning both would sit under
+      // them), and the top-right belongs to the disabled chip. Capped width so
+      // a long collection name truncates instead of running into that chip.
+      className="pointer-events-auto absolute left-1 top-1 z-10 max-w-[70%] cursor-pointer truncate rounded bg-sky-950/85 px-1 py-0.5 text-[8px] leading-none font-semibold text-sky-200 ring-1 ring-sky-400/30 hover:bg-sky-900/90 hover:text-sky-100"
+    >
+      {name}
+    </span>
+  );
+}
+
 const GraphClipContent = memo(function GraphClipContent({
   id,
   node,
@@ -342,6 +417,7 @@ const GraphClipContent = memo(function GraphClipContent({
   const settledFrames = useSettledFrameCount(measuredFrames);
   // Above the collection early-return below — hooks may not be conditional.
   const inheritedDisabled = useDisabledByAncestor(id);
+  const provenance = useCardProvenance(id);
 
   // MEDIA pixels only. Collections don't render through this seam anymore:
   // their card carries interactive controls (folder drill-in, inline rename),
@@ -433,6 +509,7 @@ const GraphClipContent = memo(function GraphClipContent({
       {(node.disabled || inheritedDisabled) && (
         <DisabledChip inherited={node.disabled !== true} />
       )}
+      {provenance && <ProvenanceLabel parentId={provenance.parentId} name={provenance.name} />}
       {trimEnabled && <LiveDurationPill id={id} node={node} />}
       {/* Floating frame-at-the-edge panel during a trim drag (video only) —
           rides the same per-node live-trim channel as the pill. */}

--- a/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
@@ -24,6 +24,10 @@ import { useGraphDetailsStore } from "./graph-details-context";
 
 type GraphViewNav = Readonly<{
   openTimeline: (nodeId: NodeId) => void;
+  /** The timeline currently in focus. Cards read it to tell whether they are
+   *  being shown OUTSIDE their own collection — which is exactly the flat
+   *  strip, and what makes a provenance label worth drawing. */
+  focusedId: string;
 }>;
 
 export const GraphViewNavContext = createContext<GraphViewNav | null>(null);
@@ -61,6 +65,7 @@ export function GraphViewNavProvider({
 
   const value = useMemo<GraphViewNav>(
     () => ({
+      focusedId,
       openTimeline: (nodeId) => {
         const id = nodeId as string;
         const timelineId = detailsStore.get(id)?.duplicateOfTimelineId ?? id;
@@ -205,14 +210,27 @@ export function OpenKeyBoundary({
     const id = target.closest<HTMLElement>("[data-node-id]")?.dataset.nodeId;
     if (!id) return;
 
+    const graph = store.getSnapshot().graph;
     const nodeId = parseNodeId(id);
-    const node = store.getSnapshot().graph.nodesById.get(nodeId);
+    const node = graph.nodesById.get(nodeId);
     const opensTimeline =
       node?.kind === "collection" || detailsStore.get(id)?.duplicateOfTimelineId !== undefined;
-    if (!opensTimeline) return;
+    if (opensTimeline) {
+      event.preventDefault();
+      nav?.openTimeline(nodeId);
+      return;
+    }
 
+    // A card shown OUTSIDE its own collection — the flat strip — opens the
+    // collection it lives in. Same verb ("take me to where this is"), and the
+    // keyboard twin of double-clicking its provenance label, which cannot be a
+    // button because it renders inside the card's selection button.
+    // Null as well as undefined: a ROOT has an explicit null parent, and it is
+    // the one node with nowhere to reveal.
+    const parentId = graph.parentById.get(nodeId);
+    if (parentId == null || (parentId as string) === nav?.focusedId) return;
     event.preventDefault();
-    nav?.openTimeline(nodeId);
+    nav?.openTimeline(parentId);
   };
 
   // F2 opens the focused collection's inline rename editor — the keyboard twin

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -3451,6 +3451,36 @@ test.describe("graph view E2E", () => {
     await expect(page.locator("[data-graph-ruler]")).toHaveCount(1);
   });
 
+  test("flat cards name their collection, and reveal it", async ({ page }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+
+    // Nested: every card's parent IS the focused timeline, so nothing is
+    // labelled — the mode needs no flag to stay quiet here.
+    await expect(page.locator("[data-provenance]")).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Show all items in order" }).click();
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID), { timeout: 15000 })
+      .toEqual(["alpha", "bravo", "c1", "c2", "charlie"]);
+
+    // Only the cards drawn from a NESTED collection carry a label: c1/c2 live
+    // in Scene A, while alpha/bravo/charlie are the focused timeline's own.
+    const labels = page.locator("[data-provenance]");
+    await expect(labels).toHaveCount(2);
+    await expect(labels.first()).toHaveText("Scene A");
+    await expect(
+      strip(page, PROJECT_ID).locator('[data-node-id="alpha"] [data-provenance]'),
+    ).toHaveCount(0);
+
+    // Double-click reveals — a span, not a button, because it renders inside
+    // the card's selection button and nesting interactive semantics is
+    // invalid. (The O key is its keyboard twin; see OpenKeyBoundary.)
+    await labels.first().dblclick();
+    await page.waitForURL(`**${GRAPH_URL}/${CHILD_ID}`);
+    await expect.poll(() => stripOrder(page, CHILD_ID)).toEqual(["c1", "c2"]);
+  });
+
   // The seek rail's marks are PER ITEM — one boundary tick between every pair
   // of cards — so unwindowed they scale with clip count, which is precisely
   // the cost the strip's card virtualizer exists to avoid. It matters most for


### PR DESCRIPTION
**Step 5**, taken before step 4 deliberately: the drop rule you chose — a drop lands in the **left neighbour's** collection — is only legible if the card says which collection that is. Building drops first would have shipped an invisible rule.

## The label needs no mode flag

It draws when a card's parent isn't the focused timeline. In the ordinary nested strip that's false by construction (every card's parent *is* the focus), and in a flat run it's true for exactly the cards pulled in from elsewhere. Direct children stay unlabelled in both readings — their collection is the one on screen.

The name resolves document title first, graph node second, the same way the collection card and breadcrumb do, so a rename shows here too.

## A span, not a button

It renders inside `NodeCard`'s selection `<button>`, and nesting interactive semantics is invalid HTML and an ambiguous a11y tree — the package makes that an invariant and a story asserts it. Rather than route flat media cards through a composed shell (a much larger change), the reveal rides a **double-click**, which needs no role, and the **O key** is its keyboard twin: on a card shown outside its own collection, `OpenKeyBoundary` now opens the collection it lives in. Same verb as drilling into a collection card, so it needed no new key.

## Two things found by looking rather than reasoning

- **Placement.** I first put the label along the bottom edge. Screenshotting it showed the bottom band already holds the kind tag (left) and duration pill (right), with the label sitting under both. Moved to top-left, capped width; the top-right belongs to the disabled chip.
- **A false alarm worth naming.** Mid-verification the labels didn't appear at all — because navigating to the app root had left me on the projects list, not a graph route. Worth stating so it isn't re-diagnosed later.

## Known gap, deliberate

The label is `aria-hidden`, matching the card's other chips, so the collection name isn't announced. Fixing that means composing it into the card's accessible name, which lives in the package's `NodeCard` — worth doing deliberately rather than smuggling into this PR. The O key means the *action* is keyboard-reachable today; it's the *name* that isn't.

## Verification

- New e2e: nothing labelled nested; exactly the two Scene A cards labelled flat; `alpha` unlabelled; double-click navigates into Scene A.
- App 415 · typecheck clean · lint 0 errors · e2e **67/67**, no flakes this run.
- Driven in the real app: 41-item run, every mounted card labelled, double-click on "Test 002" navigating into it.

## Next

**4.** drop translation (lifts the add veto — now legible) · the flat span model for the overlays and header aggregate · and the still-open question of whether flat mode should show items trimmed out of playback.

Generated with [Claude Code](https://claude.com/claude-code)