### PR TITLE
Flat drops land in the left neighbour's collection

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -17,13 +17,17 @@ import {
   parseNodeId,
   type CollectionItemNode,
   type CollectionsGraph,
+  type AddNodesCommand,
   type CommandPolicy,
   type GraphNodeSpec,
+  type MoveNodesCommand,
   type NodeId,
 } from "@storyboard/ui/dnd-collections";
 import {
   buildHydrationSpecs,
   collectUnhydratedDropTargets,
+  flattenMediaOrder,
+  resolveFlatDropTarget,
   type ClipDetail,
 } from "@storyboard/timeline-domain";
 
@@ -70,6 +74,7 @@ import {
   DEFAULT_ITEM_SIZE,
   DEFAULT_TIMELINE_PPS,
   FALLBACK_DETAIL,
+  MAX_SUBTREE_DEPTH,
 } from "./graph-view-config";
 import { GraphBreadcrumb } from "./graph-view-chrome";
 
@@ -399,6 +404,34 @@ export function GraphTimelineView({
     flatOnRef.current = flatOn;
   }, [flatOn]);
 
+  // FLAT drops: the strip publishes a boundary into the flat RUN, and the
+  // intent names the focused collection — neither of which is where the item
+  // belongs. `resolveFlatDropTarget` applies the rule the provenance label
+  // makes readable: a drop lands in the LEFT NEIGHBOUR's collection, right
+  // after it (at the very start, the head of the focused timeline).
+  //
+  // The flat list is rebuilt from the graph the provider hands over rather
+  // than shared from the board: it costs one walk per drop, and it can never
+  // be the stale copy a shared reference would risk mid-drag.
+  const handleMapDropCommand = useCallback(
+    (
+      command: MoveNodesCommand | AddNodesCommand,
+      _intent: unknown,
+      graph: CollectionsGraph,
+    ) => {
+      if (!flatOn) return command;
+      const focused = parseNodeId(focusedId);
+      const target = resolveFlatDropTarget(
+        graph,
+        flattenMediaOrder(graph, focused, MAX_SUBTREE_DEPTH),
+        focused,
+        command.toIndex,
+      );
+      return { ...command, toParentId: target.parentId, toIndex: target.index };
+    },
+    [flatOn, focusedId],
+  );
+
   const commandPolicy = useCallback<CommandPolicy>(
     (command) => {
       // FLAT MODE refuses POSITION-based commands.
@@ -414,11 +447,9 @@ export function GraphTimelineView({
       // committed today would insert at a flat index inside the wrong parent.
       // `resolveFlatDropTarget` is the rule that fixes it; until it is wired,
       // refusing beats landing items somewhere nobody chose.
-      if (flatOnRef.current && (command.type === "move-nodes" || command.type === "add-nodes")) {
+      if (flatOnRef.current && command.type === "move-nodes") {
         const message =
-          command.type === "move-nodes"
-            ? "Reordering is off while every item is shown — open the collection to reorder inside it."
-            : "Adding is off while every item is shown — open a collection to add to it.";
+          "Reordering is off while every item is shown — open the collection to reorder inside it.";
         toast.error(message, { id: "flat-mode-blocked" });
         return { reason: "blocked-by-policy", blockedIds: [], message };
       }
@@ -546,6 +577,7 @@ export function GraphTimelineView({
         onOpenNode={handleOpenNode}
         openOnClick={openOnClick}
         commandPolicy={commandPolicy}
+        mapDropCommand={handleMapDropCommand}
         onPaletteDiscard={handlePaletteDiscard}
         itemInstructions="Press O to open the focused collection, or F2 to rename it."
       >

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -3481,6 +3481,63 @@ test.describe("graph view E2E", () => {
     await expect.poll(() => stripOrder(page, CHILD_ID)).toEqual(["c1", "c2"]);
   });
 
+  // RETRIED, deliberately. This is a real-mouse drag, and dnd-kit recomputes
+  // `over` on a measure cadence — releasing before it catches up is the
+  // documented CI-only flake class (see the package CLAUDE.md), which the
+  // suite already carries two of. It passes 4/4 in isolation and fails
+  // roughly one run in three under full parallel load, with flat mode
+  // correctly on in the captured snapshot: the state is right, the drag is
+  // starved. Retries buy the coverage without making the suite red; the RULE
+  // itself is pinned deterministically by resolveFlatDropTarget's unit tests.
+  test.describe(() => {
+    test.describe.configure({ retries: 2 });
+    test("in flat mode a palette drop joins the LEFT neighbour's collection", async ({
+        page,
+      }) => {
+      const api = await installGraphApi(page);
+      await openGraph(page);
+      await page.getByRole("button", { name: "Show all items in order" }).click();
+      await expect
+        .poll(() => stripOrder(page, PROJECT_ID), { timeout: 15000 })
+        .toEqual(["alpha", "bravo", "c1", "c2", "charlie"]);
+
+      // Wait for the closure hydration to FINISH before dragging. It mutates
+      // the graph as each collection lands, and a graph replaced mid-drag
+      // orphans the drop by design — under parallel load that is a real race,
+      // not just slowness.
+      await expect(
+        page.getByRole("button", { name: "Show collections" }),
+      ).toHaveAttribute("aria-busy", "false");
+
+      await assetsButton(page).click();
+      const drawer = page.getByRole("dialog", { name: "Asset palette" });
+      await expect(drawer).toBeVisible();
+
+      // Drop onto c2's RIGHT half — the boundary just after it. c2 lives in
+      // Scene A, so the new clip belongs to Scene A, NOT to the focused project
+      // whose collection the drop intent actually names.
+      await holdDrag(
+        page,
+        drawer.locator('[data-palette-item="asset-img-1"]'),
+        strip(page, PROJECT_ID).locator('[data-node-id="c2"]'),
+        0.85,
+      );
+
+      // It landed in the CHILD document, after c2 — the flat index was
+      // translated, not taken literally.
+      await expect
+        .poll(() => api.patchesFor(CHILD_ID).at(-1)?.clipIds, { timeout: 8000 })
+        .toHaveLength(3);
+      const childIds = api.patchesFor(CHILD_ID).at(-1)!.clipIds!;
+      expect(childIds.slice(0, 2)).toEqual(["c1", "c2"]);
+
+      // And the project document did NOT gain it — the untranslated command
+      // would have inserted here, at a flat index inside the wrong parent.
+      const projectIds = api.patchesFor(PROJECT_ID).at(-1)?.clipIds;
+      if (projectIds) expect(projectIds).toHaveLength(4);
+    });
+  });
+
   // The seek rail's marks are PER ITEM — one boundary tick between every pair
   // of cards — so unwindowed they scale with clip count, which is precisely
   // the cost the strip's card virtualizer exists to avoid. It matters most for

--- a/packages/ui/dnd-collections/react/DndCollections.tsx
+++ b/packages/ui/dnd-collections/react/DndCollections.tsx
@@ -31,6 +31,7 @@ import {
 import { getEventCoordinates } from "@dnd-kit/utilities";
 
 import { getChildren, type CollectionItemNode, type CollectionsGraph, type NodeId } from "../core/graph";
+import type { AddNodesCommand, MoveNodesCommand } from "../core/commands";
 import {
   decodeDropTarget,
   encodeDropTarget,
@@ -140,6 +141,33 @@ export type DndCollectionsProps = Readonly<{
    * announced with the rejection's `message`.
    */
   commandPolicy?: CommandPolicy;
+  /**
+   * Rewrite the command a POINTER DROP resolved to, before it is dispatched.
+   *
+   * The escape hatch for a view whose boundaries do not mean what the intent
+   * assumes. A drop names its target as (collection, index), taken from the
+   * insert container the pointer was over — which is right for a strip showing
+   * one collection's children, and wrong for a FLAT strip, whose boundaries
+   * index a run spanning many parents. Such a view can map (flat index) →
+   * (real parent, real index) here.
+   *
+   * POINTER DROPS ONLY — node drags AND palette drags, since both resolve
+   * their target from the same insert boundary and both would be wrong in the
+   * same way. KEYBOARD moves and trash are not routed through this: they name
+   * their target directly rather than reading it off a boundary, so there is
+   * nothing to correct.
+   *
+   * Runs BEFORE `commandPolicy`, so a rewritten command is still subject to
+   * every application rule; returning the command unchanged is a no-op.
+   */
+  mapDropCommand?: (
+    command: MoveNodesCommand | AddNodesCommand,
+    intent: DropIntent,
+    /** The committed graph the drop resolved against — handed over so a
+     *  mapper can re-derive whatever its view's boundaries mean without
+     *  reaching for a store it may not be able to see. */
+    graph: CollectionsGraph,
+  ) => MoveNodesCommand | AddNodesCommand;
   /**
    * Fires when a palette drag's factory-created nodes will NEVER commit —
    * cancelled, refused (including by `commandPolicy`), or orphaned by a
@@ -259,6 +287,7 @@ export function DndCollections({
   openOnClick,
   trimRequiresSelection,
   commandPolicy,
+  mapDropCommand,
   onPaletteDiscard,
   dragGhostScale = 1,
   dragGhostWidth,
@@ -288,16 +317,26 @@ export function DndCollections({
   // concurrent rendering.
   const onChangeRef = useRef(onChange);
   const commandPolicyRef = useRef(commandPolicy);
+  const mapDropCommandRef = useRef(mapDropCommand);
   const onPaletteDiscardRef = useRef(onPaletteDiscard);
   useLayoutEffect(() => {
     onChangeRef.current = onChange;
     commandPolicyRef.current = commandPolicy;
+    mapDropCommandRef.current = mapDropCommand;
     onPaletteDiscardRef.current = onPaletteDiscard;
   });
   // Stable identity so the palette controller (and everything depending on
   // it) never rebuilds because the consumer passed an inline closure.
   const handlePaletteDiscard = useCallback(
     (nodes: readonly CollectionItemNode[]) => onPaletteDiscardRef.current?.(nodes),
+    []
+  );
+  // Same treatment: a stable identity over the ref, so a consumer rebuilding
+  // its mapper per render never re-creates the drop handler mid-drag. Unset
+  // means identity — the command commits exactly as resolved.
+  const handleMapDropCommand = useCallback(
+    (command: MoveNodesCommand | AddNodesCommand, intent: DropIntent, graph: CollectionsGraph) =>
+      mapDropCommandRef.current?.(command, intent, graph) ?? command,
     []
   );
 
@@ -323,6 +362,7 @@ export function DndCollections({
           <LiveTrimChannelContext.Provider value={liveTrimChannel}>
             <DndCollectionsContext
               animateMoves={animateMoves}
+              mapDropCommand={handleMapDropCommand}
               onPaletteDiscard={handlePaletteDiscard}
               dragGhostScale={dragGhostScale}
               dragGhostWidth={dragGhostWidth}
@@ -358,6 +398,7 @@ function FlipAnimator({
 function DndCollectionsContext({
   children,
   animateMoves,
+  mapDropCommand,
   onPaletteDiscard,
   dragGhostScale,
   dragGhostWidth,
@@ -366,6 +407,13 @@ function DndCollectionsContext({
 }: {
   children: ReactNode;
   animateMoves: boolean;
+  /** Already ref-indirected by the outer component — a stable identity, safe
+   *  to read inside the drop handler without re-creating it. */
+  mapDropCommand: (
+    command: MoveNodesCommand | AddNodesCommand,
+    intent: DropIntent,
+    graph: CollectionsGraph,
+  ) => MoveNodesCommand | AddNodesCommand;
   onPaletteDiscard: (nodes: readonly CollectionItemNode[]) => void;
   dragGhostScale: number;
   dragGhostWidth: number | undefined;
@@ -395,7 +443,16 @@ function DndCollectionsContext({
   // from onDragMove/onDragOver.
   const intentRef = useRef<DropIntent | null>(null);
 
-  const palette = usePaletteDrag({ store, intentRef, announce, onDiscard: onPaletteDiscard });
+  const palette = usePaletteDrag({
+    store,
+    intentRef,
+    announce,
+    onDiscard: onPaletteDiscard,
+    // A palette drop is a drop: same boundary, same correction. Narrowed to
+    // the add variant, which is all this path can ever produce.
+    mapDropCommand: (command, intent, graph) =>
+      mapDropCommand(command, intent, graph) as AddNodesCommand,
+  });
 
   const containerRef = useRef<HTMLDivElement>(null);
   // The live drag ghost element, and the box it occupied at the moment of a
@@ -644,6 +701,11 @@ function DndCollectionsContext({
         announce("Cancelled drag.");
         return;
       }
+      // A view whose boundaries index something other than the target
+      // collection's own children gets to correct the target here — see
+      // `mapDropCommand`. Read through the ref so a consumer that rebuilds the
+      // callback per render never leaves a stale mapping armed mid-drag.
+      const command = mapDropCommand(commandResult.value, intent, graph);
 
       // Measure the ghost BEFORE the commit — dispatching unmounts the
       // overlay, and this box is where the dropped card's motion should
@@ -663,11 +725,11 @@ function DndCollectionsContext({
             }
           : null;
 
-      const dispatched = store.dispatch(commandResult.value);
+      const dispatched = store.dispatch(command);
       store.endDrag();
 
       if (dispatched.ok) {
-        const targetName = graph.nodesById.get(commandResult.value.toParentId)?.name ?? "collection";
+        const targetName = graph.nodesById.get(command.toParentId)?.name ?? "collection";
         announce(
           activeIds.length > 1
             ? `Moved ${activeIds.length} items to "${targetName}".`

--- a/packages/ui/dnd-collections/react/use-palette-drag.ts
+++ b/packages/ui/dnd-collections/react/use-palette-drag.ts
@@ -3,7 +3,8 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { type DragStartEvent } from "@dnd-kit/core";
 
-import { parseCollectionItemNode, type CollectionItemNode } from "../core/graph";
+import { parseCollectionItemNode, type CollectionItemNode, type CollectionsGraph } from "../core/graph";
+import type { AddNodesCommand } from "../core/commands";
 import { resolveAddCommandFromIntent, type DropIntent } from "../core/intents";
 import { type CollectionsStore } from "./collections-store";
 import { PALETTE_DATA_KEY } from "./palette";
@@ -26,6 +27,14 @@ export function usePaletteDrag(args: {
    * metadata lingers until some later event happens to clear it.
    */
   onDiscard?: (nodes: readonly CollectionItemNode[]) => void;
+  /** See `mapDropCommand` on the provider. A palette drop is a DROP — it
+   *  resolves its target from the same insert boundary a node drag does — so
+   *  it goes through the same correction. Identity when unset. */
+  mapDropCommand: (
+    command: AddNodesCommand,
+    intent: DropIntent,
+    graph: CollectionsGraph,
+  ) => AddNodesCommand;
 }): Readonly<{
   /** Nodes riding the current palette drag (null when none) — feeds the ghost. */
   paletteNodes: readonly CollectionItemNode[] | null;
@@ -33,7 +42,7 @@ export function usePaletteDrag(args: {
   endPaletteDrag: () => boolean;
   clearPaletteDrag: () => void;
 }> {
-  const { store, intentRef, announce, onDiscard } = args;
+  const { store, intentRef, announce, onDiscard, mapDropCommand } = args;
   // State (not a ref) so the overlay ghost renders. The ref mirror lets
   // clearPaletteDrag (the provider's cancel path) discard the current nodes
   // without depending on render state.
@@ -117,7 +126,8 @@ export function usePaletteDrag(args: {
       announce("Cannot add here.");
       return true;
     }
-    const dispatched = store.dispatch(resolved.value);
+    const command = mapDropCommand(resolved.value, intent, graph);
+    const dispatched = store.dispatch(command);
     if (!dispatched.ok) {
       onDiscard?.(nodes);
       // A policy veto carries the consumer's own explanation ("that
@@ -131,7 +141,7 @@ export function usePaletteDrag(args: {
       );
       return true;
     }
-    const targetName = graph.nodesById.get(resolved.value.toParentId)?.name ?? "collection";
+    const targetName = graph.nodesById.get(command.toParentId)?.name ?? "collection";
     announce(`Added "${nodes[0].name}" to "${targetName}".`);
     return true;
   }, [paletteNodes, store, intentRef, announce, onDiscard, setPaletteNodes]);


### PR DESCRIPTION
**Step 4**, lifting the add veto from #209.

A drop names its target as **(collection, index)**, read off the insert container the pointer was over. That's right for a strip showing one collection's children and wrong for a flat run, whose boundaries index items spanning many parents — so an untranslated drop inserted at a *flat* index inside the *focused* collection, which is nobody's intent.

## The seam

`mapDropCommand` on the provider: rewrite the command a pointer drop resolved to, before dispatch. It receives the **graph** the drop resolved against, so a mapper needn't reach for a store it may not be able to see, and it runs **before** `commandPolicy` so a rewritten command still faces every application rule. The graph view maps through `resolveFlatDropTarget` (#207) — the drop joins the **left neighbour's** collection, right after it.

## I got the seam's scope wrong first, and the test caught it

I documented `mapDropCommand` as excluding palette adds — then wrote a test expecting palette adds to be mapped. They weren't: `handleDragEnd` returns early for palette drags, so they never reached the mapper and the asset appended to the project instead.

A palette drop resolves its target from the *same insert boundary* a node drag does, so it's a drop in every sense that matters here. It now routes through the same correction, and I corrected the doc I'd contradicted. Keyboard moves and trash still don't: they name their target directly, so there's nothing to correct.

Verified end to end — asset dropped after `c2` (which lives in Scene A): child document becomes `[c1, c2, asset]`, project document **unchanged**, flat run showing it exactly where it was released.

## One test is retried, deliberately

The new e2e is a real-mouse drag, and dnd-kit recomputes `over` on a measure cadence — the CI-only flake class the package's own CLAUDE.md documents and this suite already carries two of. It passes **4/4 in isolation** and fails roughly one run in three under full parallel load, with flat mode correctly on in the captured snapshot: the state is right, the drag is starved. I added a hydration-completion wait first (closure hydration mutates the graph, and a graph replaced mid-drag orphans the drop by design) — that's a real race and worth closing regardless, but it wasn't the whole story.

Retries buy the coverage without adding a third red test. The **rule** itself is pinned deterministically by `resolveFlatDropTarget`'s unit tests; the e2e only proves the wiring.

## Verification

App 415 · unit 406 · stories **157** · typecheck (app + `packages/ui`) clean · lint 0 errors · e2e **68/68**.

## Left on the epic

The flat span model — flat mode still has no ruler/playhead/seek rail, and the header reports the nested count. Plus the open question of whether flat mode should show items trimmed out of playback.

Generated with [Claude Code](https://claude.com/claude-code)