### PR TITLE
Flat mode gets its rail, ruler, playhead and header back

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -39,6 +39,7 @@ import {
   GraphPlayhead,
   GraphRuler,
   GraphSeekRails,
+  FlatItemsProvider,
   GraphStripSeekRail,
   PreviewShell,
   collectionCardWidth,
@@ -374,18 +375,23 @@ export function GraphBoard({
   // strip mid-drag. `undefined` when flat is off, which is what makes the
   // strip fall back to the focused collection's own children.
   const graph = useCollectionsSelector((s) => s.graph);
-  const flatItemIds = useMemo(
+  // The ITEMS, not just their ids: the strip needs the ids, and every time
+  // overlay needs each item's parent chain to look up its manifest span.
+  const flatItems = useMemo(
     () =>
-      flatOn
-        ? flattenMediaOrder(graph, parseNodeId(focusedId), MAX_SUBTREE_DEPTH).map(
-            (item) => item.nodeId,
-          )
-        : undefined,
+      flatOn ? flattenMediaOrder(graph, parseNodeId(focusedId), MAX_SUBTREE_DEPTH) : null,
     [flatOn, graph, focusedId],
+  );
+  const flatItemIds = useMemo(
+    () => flatItems?.map((item) => item.nodeId),
+    [flatItems],
   );
 
   return (
     <OpenKeyBoundary trashId={trashRootId}>
+      {/* Published ABOVE the preview shell so the header aggregate and every
+          time overlay inside it measure the run actually on screen. */}
+      <FlatItemsProvider items={flatItems}>
       <PreviewShell enabled={previewOn} focusedId={focusedId} channel={timeChannel}>
         {/* Outside the surface branch on purpose: the sidebar's tool buttons
             must insert in grid mode too, where no NativeDropStrip exists. */}
@@ -474,14 +480,7 @@ export function GraphBoard({
                 itemHeight={dims.strip}
                 itemDragActivation="hold"
                 overlay={
-                  // FLAT mode carries no time overlays yet. The ruler, the
-                  // playhead and the rail below all position through
-                  // `childSpans`, which maps the focused collection's DIRECT
-                  // children — in a flat run those are the wrong cards, so the
-                  // marks would land on items they do not describe. Showing
-                  // nothing is the honest state until the flat span model
-                  // lands; the preview pane itself still plays.
-                  !flatOn && (previewOn || rulerOn) ? (
+                  previewOn || rulerOn ? (
                     <>
                       {rulerOn ? (
                         <GraphRuler
@@ -508,7 +507,7 @@ export function GraphBoard({
                   with the content; a drag held at the scroller's edge
                   auto-pans to reveal more items mid-scrub. Replaces the old
                   invisible PlayheadScrubBand. */}
-              {previewOn && !flatOn && (
+              {previewOn && (
                 <GraphStripSeekRail
                   focusedId={focusedId}
                   channel={timeChannel}
@@ -589,6 +588,7 @@ export function GraphBoard({
           {devPanelsOn && <SyncPanel entries={syncEntries} />}
         </div>
       </PreviewShell>
+      </FlatItemsProvider>
     </OpenKeyBoundary>
   );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildGraph, type GraphNodeSpec } from "@storyboard/collections-core";
+import { buildGraph, parseNodeId, type GraphNodeSpec } from "@storyboard/collections-core";
 import type { PlaybackLeaf, PlaybackManifest } from "@storyboard/timeline-domain";
 
 import {
@@ -10,6 +10,7 @@ import {
   buildStripOverlay,
   cardSpansOf,
   childSpans,
+  flatCardSpans,
   isDisabledByAncestor,
   manifestTrailsLedger,
   MAX_MANIFEST_FETCH_RETRIES,
@@ -219,6 +220,117 @@ describe("playableSpanSeconds", () => {
 
   it("is zero when every card is disabled", () => {
     expect(playableSpanSeconds([card(0, 4, true), card(4.12, 8.12, true)])).toBe(0);
+  });
+});
+
+describe("flatCardSpans", () => {
+  const nested = () =>
+    graphOf([
+      collection("root", [
+        media("a", 4),
+        {
+          kind: "collection",
+          id: "scene",
+          name: "scene",
+          children: [media("s1", 4), media("s2", 4)],
+        },
+        media("b", 4),
+      ]),
+    ]);
+  const items = (graph: ReturnType<typeof graphOf>) => [
+    { nodeId: parseNodeId("a"), collectionPath: [] },
+    { nodeId: parseNodeId("s1"), collectionPath: [parseNodeId("scene")] },
+    { nodeId: parseNodeId("s2"), collectionPath: [parseNodeId("scene")] },
+    { nodeId: parseNodeId("b"), collectionPath: [] },
+  ];
+  const width = (seconds: number) => seconds * 10;
+
+  it("packs the run itself when no manifest has landed", () => {
+    const graph = nested();
+    const cards = flatCardSpans(graph, items(graph), "root", null, width);
+
+    expect(cards).toHaveLength(4);
+    // Leading padding, each duration, one gap between — the run's own packing,
+    // because items from different documents share no single projection.
+    // Rounded: the cumulative gap arithmetic lands a float ulp off exact.
+    const round = (value: number) => Math.round(value * 100) / 100;
+    expect(cards.map((card) => [round(card.startTime), round(card.endTime)])).toEqual([
+      [0, 4],
+      [4.12, 8.12],
+      [8.24, 12.24],
+      [12.36, 16.36],
+    ]);
+    expect(cards.map((card) => card.width)).toEqual([40, 40, 40, 40]);
+  });
+
+  it("reads each card's window from the manifest, keyed by its OWN parent", () => {
+    // The point of carrying the parent chain: s1/s2 are keyed under "scene",
+    // not under the focused root, so a flat strip lands on the same clock the
+    // preview plays.
+    const graph = nested();
+    const spans: PreviewCardSpans = new Map([
+      [mediaSpanKey("root", "a"), { start: 0, end: 4 }],
+      [mediaSpanKey("scene", "s1"), { start: 5, end: 9 }],
+      [mediaSpanKey("scene", "s2"), { start: 9, end: 13 }],
+      [mediaSpanKey("root", "b"), { start: 13, end: 17 }],
+    ]);
+
+    const cards = flatCardSpans(graph, items(graph), "root", spans, width);
+    expect(cards.map((card) => [card.startTime, card.endTime])).toEqual([
+      [0, 4],
+      [5, 9],
+      [9, 13],
+      [13, 17],
+    ]);
+  });
+
+  it("counts EVERY card as enabled when nothing is disabled", () => {
+    // Guards the header readout against an off-by-one: N items in, N counted.
+    const graph = nested();
+    const cards = flatCardSpans(graph, items(graph), "root", null, width);
+    expect(cards.filter((card) => card.disabled !== true)).toHaveLength(4);
+  });
+
+  it("marks a card disabled by an ANCESTOR that is off-screen in a flat run", () => {
+    // The whole reason inheritance is resolved here: in a flat run the
+    // disabled collection is not on screen to explain itself.
+    const graph = graphOf([
+      collection("root", [
+        {
+          kind: "collection",
+          id: "off",
+          name: "off",
+          disabled: true,
+          children: [media("x", 4)],
+        },
+        media("b", 4),
+      ]),
+    ]);
+    const cards = flatCardSpans(
+      graph,
+      [
+        { nodeId: parseNodeId("x"), collectionPath: [parseNodeId("off")] },
+        { nodeId: parseNodeId("b"), collectionPath: [] },
+      ],
+      "root",
+      null,
+      width,
+    );
+    expect(cards.map((card) => card.disabled)).toEqual([true, undefined]);
+  });
+
+  it("clamps monotonic when manifest-timed and packed cards mix", () => {
+    // Same invariant childSpans holds: the playhead map binary-searches the
+    // times array and returns garbage on an unsorted one.
+    const graph = nested();
+    const spans: PreviewCardSpans = new Map([
+      [mediaSpanKey("scene", "s2"), { start: 1, end: 2 }],
+    ]);
+    const times = flatCardSpans(graph, items(graph), "root", spans, width).flatMap((card) => [
+      card.startTime,
+      card.endTime,
+    ]);
+    expect([...times].sort((left, right) => left - right)).toEqual(times);
   });
 });
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.ts
@@ -1,7 +1,13 @@
-import { getChildren, parseNodeId, type CollectionsGraph } from "@storyboard/collections-core";
+import {
+  getChildren,
+  mediaDurationSeconds,
+  parseNodeId,
+  type CollectionsGraph,
+} from "@storyboard/collections-core";
 import {
   graphChildrenToClips,
   type DetailsById,
+  type FlatItem,
   type PlaybackManifest,
 } from "@storyboard/timeline-domain";
 import {
@@ -275,6 +281,61 @@ export function childSpans(
  * Card lengths come from `childSpans`, so a collection contributes the
  * manifest's full-depth window rather than a stored summary guess.
  */
+/**
+ * `childSpans` for a FLAT run — the same card windows, for a list that spans
+ * many parents instead of one collection's children.
+ *
+ * The manifest keys each media leaf by `mediaSpanKey(parent, id)`, and a flat
+ * item carries its parent chain, so the lookup is exact per card: a flat strip
+ * reads the SAME clock the preview plays, card for card, without the caller
+ * having to know which collection any of them came from.
+ *
+ * The fallback (no manifest yet) packs the run itself — leading padding, each
+ * duration, one gap between — because there is no single projection to borrow
+ * from when the items come from different documents. Same monotonic clamp as
+ * `childSpans`, and for the same reason: mixing manifest-timed and
+ * fallback-timed cards can otherwise produce an unsorted times array, and the
+ * playhead map's binary search silently returns garbage on one.
+ */
+export function flatCardSpans(
+  graph: CollectionsGraph,
+  items: readonly FlatItem[],
+  focusedId: string,
+  spans: PreviewCardSpans | null,
+  widthForSeconds: (seconds: number) => number,
+): ChildSpan[] {
+  let previousEnd = 0;
+  let cursor = TIMELINE_LEADING_PADDING_SECONDS;
+
+  return items.map((item) => {
+    const node = graph.nodesById.get(item.nodeId);
+    const seconds = node && node.kind === "media" ? mediaDurationSeconds(node) : 0;
+    const parentId =
+      (item.collectionPath[item.collectionPath.length - 1] as string | undefined) ?? focusedId;
+    const span = spans?.get(mediaSpanKey(parentId, item.nodeId as string));
+
+    const fallbackStart = cursor;
+    cursor += seconds + CLIP_GAP_SECONDS;
+
+    const startTime = Math.max(span ? span.start : fallbackStart, previousEnd);
+    const endTime = Math.max(span ? span.end : fallbackStart + seconds, startTime);
+    previousEnd = endTime;
+
+    // A flat card is disabled by its OWN flag or by any collection above it —
+    // and in a flat run those ancestors are off-screen, which is exactly why
+    // the inherited case has to be resolved here rather than assumed away.
+    const disabled =
+      node?.disabled === true || isDisabledByAncestor(graph, item.nodeId as string);
+
+    return {
+      width: widthForSeconds(seconds),
+      startTime,
+      endTime,
+      ...(disabled ? { disabled: true } : {}),
+    };
+  });
+}
+
 export type StripSegment = Readonly<{ x: number; width: number }>;
 
 export type StripOverlay = Readonly<{

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -25,6 +25,7 @@ import {
   hydratedCollectionPlayableDuration,
   manifestToClips,
   type DetailsById,
+  type FlatItem,
   type PlaybackManifest,
 } from "@storyboard/timeline-domain";
 
@@ -36,6 +37,7 @@ import {
   buildStripOverlay,
   cardSpansOf,
   childSpans,
+  flatCardSpans,
   formatRulerTick,
   manifestTrailsLedger,
   nextManifestClipsState,
@@ -146,6 +148,46 @@ function clipWidthAt(pixelsPerSecond: number): (clip: TimelineClip) => number {
 // wrong cards (the round-1 #6 bug).
 const PreviewCardSpansContext = createContext<PreviewCardSpans | null>(null);
 
+/**
+ * The FLAT run the strip is showing, or null in the ordinary nested reading.
+ *
+ * Every time overlay — ruler, playhead, seek rail — and the header aggregate
+ * derive their card windows from the focused collection's DIRECT children. In
+ * a flat run those are the wrong cards, so each of them reads this instead and
+ * measures the run actually on screen. Published by the board, which already
+ * computes the list for the strip itself, so the marks and the cards can never
+ * disagree about what they are describing.
+ */
+const FlatItemsContext = createContext<readonly FlatItem[] | null>(null);
+
+export function FlatItemsProvider({
+  items,
+  children,
+}: Readonly<{ items: readonly FlatItem[] | null; children: React.ReactNode }>) {
+  return <FlatItemsContext.Provider value={items}>{children}</FlatItemsContext.Provider>;
+}
+
+/**
+ * The cards a time overlay should measure: the flat run when one is showing,
+ * this collection's own children otherwise. One resolution, called from every
+ * overlay — including the ones that rebuild inside an effect rather than a
+ * memo, which is why it is a plain function and not a hook.
+ */
+function cardsFor(
+  graph: CollectionsGraph,
+  details: DetailsById,
+  focusedId: string,
+  spans: PreviewCardSpans | null,
+  pixelsPerSecond: number,
+  flatItems: readonly FlatItem[] | null,
+): ChildSpan[] {
+  return flatItems
+    ? flatCardSpans(graph, flatItems, focusedId, spans, (seconds) =>
+        durationToWidth(seconds, pixelsPerSecond),
+      )
+    : childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond));
+}
+
 /** The global-clock windows the pane is playing, or null when it is on the
  *  live projection (no manifest yet). Sub-rows use it both to gate their
  *  playhead — only shown when a manifest exists, since only then do their
@@ -177,8 +219,9 @@ export function useFocusedTimelineAggregate(
     () => detailsStore.read(),
     () => detailsStore.read(),
   );
+  const flatItems = useContext(FlatItemsContext);
   return useMemo(() => {
-    const cards = childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond));
+    const cards = cardsFor(graph, details, focusedId, spans, pixelsPerSecond, flatItems);
     // Enabled-only, both numbers: this readout says what a viewer would sit
     // through, which is NOT how far the playhead travels now that disabled
     // cards keep their span. The two disagree by design — the ruler runs
@@ -187,7 +230,7 @@ export function useFocusedTimelineAggregate(
       count: cards.filter((card) => card.disabled !== true).length,
       seconds: playableSpanSeconds(cards),
     };
-  }, [graph, details, focusedId, spans, pixelsPerSecond]);
+  }, [graph, details, focusedId, spans, pixelsPerSecond, flatItems]);
 }
 
 
@@ -209,6 +252,7 @@ export function GraphPlayhead({
   const store = useCollectionsStore();
   const detailsStore = useGraphDetailsStore();
   const spans = useContext(PreviewCardSpansContext);
+  const flatItems = useContext(FlatItemsContext);
   const lineRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -225,7 +269,7 @@ export function GraphPlayhead({
       lastGraph = graph;
       lastDetails = details;
       map = buildPlayheadMap(
-        childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond)),
+        cardsFor(graph, details, focusedId, spans, pixelsPerSecond, flatItems),
       );
       return true;
     };
@@ -264,7 +308,7 @@ export function GraphPlayhead({
       unsubscribeStore();
       unsubscribeDetails();
     };
-  }, [store, detailsStore, focusedId, channel, spans, pixelsPerSecond, activeWindow]);
+  }, [store, detailsStore, focusedId, channel, spans, pixelsPerSecond, activeWindow, flatItems]);
 
   // No cap on the line: the seek rail's circular thumb above IS the
   // playhead's head now — the old triangle poked up over it. The stem
@@ -389,6 +433,7 @@ export function GraphRuler({
     [],
   );
   const tickWindow = useScrollerTickWindow(scroller);
+  const flatItems = useContext(FlatItemsContext);
   const graph = useSyncExternalStore(
     store.subscribe,
     () => store.getSnapshot().graph,
@@ -406,9 +451,14 @@ export function GraphRuler({
   // tick count follows the VIEWPORT, not the duration. Scrolling recomputes
   // only on chunk crossings (tickWindow identity is stable between them).
   const { ticks, collectionSpans, skips } = useMemo(() => {
-    const clips = graphChildrenToClips(graph, details, focusedId);
-    const cards = childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond));
-    const isCollection = clips.map((clip) => clip.kind === "collection");
+    const cards = cardsFor(graph, details, focusedId, spans, pixelsPerSecond, flatItems);
+    // A flat run holds no collections at all, so every card is ruled — the
+    // blank-interior rule exists only for collection cards.
+    const isCollection = flatItems
+      ? cards.map(() => false)
+      : graphChildrenToClips(graph, details, focusedId).map(
+          (clip) => clip.kind === "collection",
+        );
     return {
       ticks: buildRulerTicks(cards, isCollection, pixelsPerSecond, tickWindow),
       // A collection's interior gets no ticks (its width is not a time axis)
@@ -420,7 +470,7 @@ export function GraphRuler({
       // range as the ticks beside them.
       skips: buildStripOverlay(cards, tickWindow).skips,
     };
-  }, [graph, details, spans, focusedId, pixelsPerSecond, tickWindow]);
+  }, [graph, details, spans, focusedId, pixelsPerSecond, tickWindow, flatItems]);
 
   return (
     <div
@@ -1032,6 +1082,7 @@ export function GraphStripSeekRail({
   const store = useCollectionsStore();
   const detailsStore = useGraphDetailsStore();
   const spans = useContext(PreviewCardSpansContext);
+  const flatItems = useContext(FlatItemsContext);
   const outerRef = useRef<HTMLDivElement>(null);
   const innerRef = useRef<HTMLDivElement>(null);
   const fillRef = useRef<HTMLDivElement>(null);
@@ -1051,8 +1102,8 @@ export function GraphStripSeekRail({
     () => detailsStore.read(),
   );
   const cards = useMemo(
-    () => childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond)),
-    [graph, details, spans, focusedId, pixelsPerSecond],
+    () => cardsFor(graph, details, focusedId, spans, pixelsPerSecond, flatItems),
+    [graph, details, spans, focusedId, pixelsPerSecond, flatItems],
   );
   const map = useMemo(() => buildPlayheadMap(cards), [cards]);
   const start = cards.length > 0 ? cards[0].startTime : 0;

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -3437,13 +3437,12 @@ test.describe("graph view E2E", () => {
       .poll(() => stripOrder(page, PROJECT_ID), { timeout: 15000 })
       .toEqual(["alpha", "bravo", "c1", "c2", "charlie"]);
 
-    // The time overlays stay off: they position through the focused
-    // collection's DIRECT children, so in a flat run they would mark the wrong
-    // cards. Showing nothing is deliberate until the flat span model lands.
+    // The time overlays now measure the FLAT run rather than the focused
+    // collection's direct children, so the ruler rules the cards on screen.
     await page.getByRole("button", { name: /show time ruler/i }).click();
-    await expect(page.locator("[data-graph-ruler]")).toHaveCount(0);
+    await expect(page.locator("[data-graph-ruler]")).toHaveCount(1);
 
-    // Leaving flat mode restores the nested reading — and the ruler with it.
+    // Leaving flat mode restores the nested reading.
     await page.getByRole("button", { name: "Show collections" }).click();
     await expect
       .poll(() => stripOrder(page, PROJECT_ID))


### PR DESCRIPTION
The last visible gap in flat mode. #209 suppressed every time overlay because they all derive card windows from `childSpans` — the focused collection's **direct children** — and in a flat run those are the wrong cards, so each mark would sit on an item it doesn't describe. This builds the span model they were waiting for.

## `flatCardSpans`

`childSpans`' twin for a run spanning many parents:

- **With a manifest**, the lookup is exact per card. The manifest keys each leaf by `mediaSpanKey(parent, id)`, and a flat item carries its parent chain — so a flat strip reads the *same clock the preview plays*, card for card, without the caller knowing which collection anything came from. This is what the parent chain in #207 was for.
- **Without one**, it packs the run itself (leading padding, each duration, one gap between), because items from different documents share no single projection to borrow from.
- **Same monotonic clamp** as `childSpans`, for the same reason: mixing manifest-timed and packed cards can produce an unsorted times array, and the playhead map's binary search returns garbage on one. Pinned by a test.
- **Inheritance resolved here**, which matters more in a flat run than anywhere else — the disabled collection explaining why a card is dimmed is off-screen entirely.

The run reaches the overlays through a context the board publishes: it already computes the list for the strip, so the marks and the cards can't disagree about what they're describing. One resolver (`cardsFor`) serves all four consumers, including the playhead, which rebuilds inside an *effect* rather than a memo — which is why it's a plain function, not a hook.

## Verification

Driven in the app: the header goes from **"7 clips · 3m 18s"** (the nested reading, while the strip showed 41 items) to **"40 clips · 3m 13s"**, with the rail's windowed ticks and the playhead back.

That 41-vs-40 is the enabled-only readout working — one item in the run is disabled. I didn't assume that: "40 of 41" is exactly the shape of an off-by-one, so there's now a test asserting N items in → N counted when nothing is disabled, which distinguishes the two decisively.

- App **420** tests (5 new) · unit 406 · typecheck clean · lint 0 errors · e2e 68 green (the retried flat-drop drag flaked once and passed on retry — the retry doing its job).
- One e2e assertion inverted on purpose: it asserted the ruler was *absent* in flat mode, which was #209's honest placeholder. It now asserts the ruler renders.

## What's left on the epic

Only the open question from step 1: whether flat mode should show items trimmed out of playback. It currently does — the flat walk deliberately reports what the timeline *contains* rather than what plays, since it's an editing surface. Now that the overlays are live you can see both readings side by side and judge it.

Generated with [Claude Code](https://claude.com/claude-code)