### PR TITLE
Complete graph workbench punch-list polish

### DIFF
--- a/apps/timeline-gstudio001/app/api/assets/assets-route.test.ts
+++ b/apps/timeline-gstudio001/app/api/assets/assets-route.test.ts
@@ -7,6 +7,7 @@ import type { CloudinaryAsset } from "@/lib/cloudinary-media-store";
 
 const state = vi.hoisted(() => ({
   vendorAssets: [] as CloudinaryAsset[],
+  listedFor: null as { uid: string; projectId: string } | null,
   user: { uid: "user-a", email: null as string | null, name: null, picture: null } as {
     uid: string;
   } | null,
@@ -20,8 +21,30 @@ vi.mock("@/lib/firebase-auth-session", () => ({
       : { user: null, response: new Response(null, { status: 401 }) },
 }));
 vi.mock("@/lib/cloudinary-media-store", () => ({
-  listCloudinaryAssets: async () => state.vendorAssets,
+  listCloudinaryAssets: async (uid: string, projectId: string) => {
+    state.listedFor = { uid, projectId };
+    return state.vendorAssets;
+  },
 }));
+vi.mock("@/lib/project-asset-scope", () => {
+  class ProjectAssetScopeError extends Error {
+    constructor(
+      message: string,
+      readonly status: number,
+    ) {
+      super(message);
+    }
+  }
+  return {
+    ProjectAssetScopeError,
+    requireProjectAssetScope: async (value: unknown) => {
+      if (typeof value !== "string" || !value.startsWith("project-")) {
+        throw new ProjectAssetScopeError("A valid projectId is required.", 400);
+      }
+      return value;
+    },
+  };
+});
 
 import { GET as listAssets } from "./route";
 import { GET as listProviders } from "./providers/route";
@@ -37,7 +60,13 @@ function vendorAsset(id: string, relativePath: string): CloudinaryAsset {
   };
 }
 
-const request = (query = "") => new Request(`http://test.local/api/assets${query}`);
+const request = (query = "") => {
+  const url = new URL("http://test.local/api/assets");
+  url.searchParams.set("projectId", "project-a");
+  const supplied = new URLSearchParams(query.replace(/^\?/, ""));
+  supplied.forEach((value, key) => url.searchParams.append(key, value));
+  return new Request(url);
+};
 
 beforeEach(() => {
   state.vendorAssets = [
@@ -46,6 +75,7 @@ beforeEach(() => {
     vendorAsset("c", "Scenes/Heist/c.png"),
   ];
   state.user = { uid: "user-a" };
+  state.listedFor = null;
 });
 
 describe("GET /api/assets", () => {
@@ -54,12 +84,14 @@ describe("GET /api/assets", () => {
     expect(response.status).toBe(200);
     const body = (await response.json()) as Record<string, unknown>;
     expect(body.providerId).toBe("cloudinary");
+    expect(state.listedFor).toEqual({ uid: "user-a", projectId: "project-a" });
     expect(body.capabilities).toMatchObject({ folders: true });
     const assets = body.assets as { id: string; providerId: string; src: string; kind: string }[];
     // Flat listing: everything, regardless of folder.
     expect(assets.map((entry) => entry.id)).toEqual(["a", "b", "c"]);
     expect(assets[0]).toMatchObject({
       providerId: "cloudinary",
+      projectIds: ["project-a"],
       kind: "image",
       src: "https://cdn.test/a",
     });
@@ -110,6 +142,11 @@ describe("GET /api/assets", () => {
   it("requires a session", async () => {
     state.user = null;
     expect((await listAssets(request())).status).toBe(401);
+  });
+
+  it("requires a project scope", async () => {
+    const response = await listAssets(new Request("http://test.local/api/assets"));
+    expect(response.status).toBe(400);
   });
 });
 

--- a/apps/timeline-gstudio001/app/api/assets/route.ts
+++ b/apps/timeline-gstudio001/app/api/assets/route.ts
@@ -3,6 +3,10 @@ import { NextResponse } from "next/server";
 import { assetProviders } from "@/lib/assets/registry";
 import type { AssetQuery } from "@/lib/assets/types";
 import { requireAuthUser } from "@/lib/firebase-auth-session";
+import {
+  ProjectAssetScopeError,
+  requireProjectAssetScope,
+} from "@/lib/project-asset-scope";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -10,6 +14,7 @@ export const dynamic = "force-dynamic";
 /**
  * List assets through the provider seam.
  *
+ *   ?projectId=<id>     required root project asset scope
  *   ?provider=<id>      which provider (default: the registry's first)
  *   ?folder=<segment>   repeatable — one param per PATH SEGMENT, so a
  *                       segment containing "/" can never fake a boundary.
@@ -31,6 +36,10 @@ export async function GET(request: Request) {
     if (response || !user) return response || NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
     const url = new URL(request.url);
+    const projectId = await requireProjectAssetScope(
+      url.searchParams.get("projectId"),
+      user.uid,
+    );
     const providerId = url.searchParams.get("provider");
     const provider =
       providerId === null ? assetProviders.defaultProvider() : assetProviders.get(providerId);
@@ -69,13 +78,16 @@ export async function GET(request: Request) {
       ...(url.searchParams.get("cursor") ? { cursor: url.searchParams.get("cursor")! } : {}),
     };
 
-    const page = await provider.list({ uid: user.uid }, query);
+    const page = await provider.list({ uid: user.uid, projectId }, query);
     return NextResponse.json({
       providerId: provider.id,
       capabilities: provider.capabilities,
       ...page,
     });
   } catch (error) {
+    if (error instanceof ProjectAssetScopeError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
     console.error("[GSTUDIO_ASSETS_LIST_ERROR]", error);
     const message = error instanceof Error ? error.message : "Unable to load assets.";
     return NextResponse.json({ error: message }, { status: 500 });

--- a/apps/timeline-gstudio001/app/api/timeline-media/route.test.ts
+++ b/apps/timeline-gstudio001/app/api/timeline-media/route.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  scopedProject: null as string | null,
+  metadataReads: 0,
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/firebase-auth-session", () => ({
+  requireAuthUser: async () => ({
+    user: { uid: "user-a" },
+    response: null,
+  }),
+}));
+vi.mock("@/lib/project-asset-scope", () => {
+  class ProjectAssetScopeError extends Error {
+    constructor(
+      message: string,
+      readonly status: number,
+    ) {
+      super(message);
+    }
+  }
+  return {
+    ProjectAssetScopeError,
+    requireProjectAssetScope: async (projectId: string) => {
+      state.scopedProject = projectId;
+      return projectId;
+    },
+  };
+});
+vi.mock("@/lib/firebase-media-store", () => ({
+  createMediaReadStream: () => null,
+  getMediaMetadata: async () => {
+    state.metadataReads += 1;
+    return {
+      size: 100,
+      contentType: "video/mp4",
+      cacheControl: "private, no-cache",
+      bucketName: "bucket",
+    };
+  },
+  isAllowedMediaPathname: (pathname: string | null) =>
+    pathname?.startsWith("timeline-videos/") === true ||
+    pathname?.startsWith("timeline-thumbnails/") === true,
+}));
+
+import { HEAD } from "./route";
+
+function request(pathname: string) {
+  return new Request(
+    `http://test.local/api/timeline-media?pathname=${encodeURIComponent(pathname)}`,
+    { method: "HEAD" },
+  );
+}
+
+beforeEach(() => {
+  state.scopedProject = null;
+  state.metadataReads = 0;
+});
+
+describe("project-scoped Firebase media reads", () => {
+  it("authorizes the project embedded in an owned media pathname", async () => {
+    const response = await HEAD(
+      request("timeline-videos/projects/user-a/project-a/large.mp4"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(state.scopedProject).toBe("project-a");
+    expect(state.metadataReads).toBe(1);
+  });
+
+  it("hides another user's media before reading storage", async () => {
+    const response = await HEAD(
+      request("timeline-videos/projects/user-b/project-a/large.mp4"),
+    );
+
+    expect(response.status).toBe(404);
+    expect(state.scopedProject).toBeNull();
+    expect(state.metadataReads).toBe(0);
+  });
+});

--- a/apps/timeline-gstudio001/app/api/timeline-media/route.ts
+++ b/apps/timeline-gstudio001/app/api/timeline-media/route.ts
@@ -6,9 +6,21 @@ import {
   isAllowedMediaPathname,
 } from "@/lib/firebase-media-store";
 import { requireAuthUser } from "@/lib/firebase-auth-session";
+import {
+  ProjectAssetScopeError,
+  requireProjectAssetScope,
+} from "@/lib/project-asset-scope";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+
+function projectScopeFromMediaPathname(pathname: string) {
+  const match =
+    /^(?:timeline-videos|timeline-thumbnails)\/projects\/([^/]+)\/([^/]+)\//.exec(
+      pathname,
+    );
+  return match ? { uid: match[1], projectId: match[2] } : null;
+}
 
 async function handleMediaRequest(request: Request, includeBody: boolean) {
   const pathname = new URL(request.url).searchParams.get("pathname");
@@ -18,8 +30,15 @@ async function handleMediaRequest(request: Request, includeBody: boolean) {
   }
 
   try {
-    const { response } = await requireAuthUser();
-    if (response) return response;
+    const { user, response } = await requireAuthUser();
+    if (response || !user) {
+      return response || NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const scope = projectScopeFromMediaPathname(pathname);
+    if (scope && scope.uid !== user.uid) {
+      return new NextResponse("Media not found.", { status: 404 });
+    }
+    if (scope) await requireProjectAssetScope(scope.projectId, user.uid);
 
     const media = await getMediaMetadata(pathname);
     if (!media) {
@@ -68,6 +87,9 @@ async function handleMediaRequest(request: Request, includeBody: boolean) {
       },
     });
   } catch (error) {
+    if (error instanceof ProjectAssetScopeError) {
+      return new NextResponse("Media not found.", { status: 404 });
+    }
     console.error("[GSTUDIO_FIREBASE_MEDIA_READ_ERROR]", error);
     return new NextResponse("Unable to load hosted media.", { status: 500 });
   }

--- a/apps/timeline-gstudio001/app/api/timeline-media/upload/route.test.ts
+++ b/apps/timeline-gstudio001/app/api/timeline-media/upload/route.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  firebaseUploads: [] as Array<{
+    pathname: string;
+    contentType: string | undefined;
+    options: unknown;
+  }>,
+  uploadError: null as Error | null,
+  uploadArgs: null as
+    | {
+        filename: string;
+        contentType: string | undefined;
+        userId: string | undefined;
+        projectId: string | undefined;
+        folderPath: string | undefined;
+      }
+    | null,
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/firebase-auth-session", () => ({
+  requireAuthUser: async () => ({
+    user: { uid: "user-a" },
+    response: null,
+  }),
+}));
+vi.mock("@/lib/project-asset-scope", () => {
+  class ProjectAssetScopeError extends Error {
+    constructor(
+      message: string,
+      readonly status: number,
+    ) {
+      super(message);
+    }
+  }
+  return {
+    ProjectAssetScopeError,
+    requireProjectAssetScope: async (value: unknown) => {
+      if (typeof value !== "string" || !value.startsWith("project-")) {
+        throw new ProjectAssetScopeError("A valid projectId is required.", 400);
+      }
+      return value;
+    },
+  };
+});
+vi.mock("@/lib/cloudinary-media-store", () => {
+  class CloudinaryUploadError extends Error {
+    constructor(
+      message: string,
+      readonly status: number,
+    ) {
+      super(message);
+    }
+  }
+  return {
+    CloudinaryUploadError,
+    hasCloudinaryConfig: () => true,
+    uploadCloudinaryMedia: async (
+      filename: string,
+      _data: Buffer,
+      contentType?: string,
+      userId?: string,
+      projectId?: string,
+      folderPath?: string,
+    ) => {
+      if (state.uploadError) throw state.uploadError;
+      state.uploadArgs = { filename, contentType, userId, projectId, folderPath };
+      return {
+        pathname: `timeline/${userId}/${projectId}/${filename}`,
+        url: `https://cdn.test/${filename}`,
+      };
+    },
+  };
+});
+vi.mock("@/lib/firebase-media-store", () => ({
+  createThumbnailPathname: (pathname: string) =>
+    `timeline-thumbnails/${pathname.split("/").pop() ?? "video"}-thumbnail.jpg`,
+  getMediaContentType: (_filename: string, explicit?: string) =>
+    explicit || "application/octet-stream",
+  sanitizeStoragePathname: (filename: string, prefix = "timeline-videos") =>
+    filename.startsWith("timeline-") ? filename : `${prefix}/${filename}`,
+  toMediaUrl: (pathname: string) =>
+    `/api/timeline-media?pathname=${encodeURIComponent(pathname)}`,
+  uploadMedia: async (
+    pathname: string,
+    _data: Buffer,
+    contentType?: string,
+    options?: unknown,
+  ) => {
+    state.firebaseUploads.push({ pathname, contentType, options });
+    return { pathname, url: `/api/timeline-media?pathname=${encodeURIComponent(pathname)}` };
+  },
+}));
+vi.mock("@/lib/assets/cloudinary-provider", () => ({
+  CLOUDINARY_PROVIDER_ID: "cloudinary",
+}));
+
+import { POST as uploadAsset } from "./route";
+import { CloudinaryUploadError } from "@/lib/cloudinary-media-store";
+
+function request(projectId?: string) {
+  const form = new FormData();
+  form.append("file", new Blob([new Uint8Array([1, 2, 3])], { type: "image/png" }));
+  form.append("filename", "frame.png");
+  if (projectId !== undefined) form.append("projectId", projectId);
+  form.append("folderPath", "Scenes/Opening");
+  return new Request("http://test.local/api/timeline-media/upload", {
+    method: "POST",
+    body: form,
+  });
+}
+
+beforeEach(() => {
+  state.firebaseUploads = [];
+  state.uploadError = null;
+  state.uploadArgs = null;
+});
+
+describe("POST /api/timeline-media/upload project scope", () => {
+  it("threads the authorized project into the provider folder boundary", async () => {
+    const response = await uploadAsset(request("project-a"));
+    expect(response.status).toBe(200);
+    expect(state.uploadArgs).toEqual({
+      filename: "frame.png",
+      contentType: "image/png",
+      userId: "user-a",
+      projectId: "project-a",
+      folderPath: "Scenes/Opening",
+    });
+  });
+
+  it("rejects an upload with no project membership", async () => {
+    const response = await uploadAsset(request());
+    expect(response.status).toBe(400);
+    expect(state.uploadArgs).toBeNull();
+  });
+
+  it("returns a Cloudinary 413 without storing an overflow original", async () => {
+    state.uploadError = new CloudinaryUploadError(
+      "Cloudinary rejected the file because it exceeds this account's upload-size limit.",
+      413,
+    );
+
+    const response = await uploadAsset(request("project-a"));
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toMatchObject({
+      error:
+        "Cloudinary rejected the file because it exceeds this account's upload-size limit.",
+    });
+    expect(state.firebaseUploads).toHaveLength(0);
+  });
+});

--- a/apps/timeline-gstudio001/app/api/timeline-media/upload/route.ts
+++ b/apps/timeline-gstudio001/app/api/timeline-media/upload/route.ts
@@ -1,9 +1,13 @@
+import { randomUUID } from "node:crypto";
+
 import { NextResponse } from "next/server";
 
 import {
+  CloudinaryUploadError,
   hasCloudinaryConfig,
   uploadCloudinaryMedia,
 } from "@/lib/cloudinary-media-store";
+import { CLOUDINARY_PROVIDER_ID } from "@/lib/assets/cloudinary-provider";
 import {
   createThumbnailPathname,
   getMediaContentType,
@@ -12,6 +16,10 @@ import {
   uploadMedia,
 } from "@/lib/firebase-media-store";
 import { requireAuthUser } from "@/lib/firebase-auth-session";
+import {
+  ProjectAssetScopeError,
+  requireProjectAssetScope,
+} from "@/lib/project-asset-scope";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -37,6 +45,45 @@ function getUploadPathname(filename: string, contentType: string) {
   return `timeline-thumbnails/${basename}`;
 }
 
+function storageFolderSegments(folderPath: string | null) {
+  const segments = (folderPath ?? "")
+    .replace(/\\/g, "/")
+    .split("/")
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+  if (segments.some((segment) => segment === "." || segment === "..")) {
+    throw new Error("Asset folder paths cannot contain relative segments.");
+  }
+  return segments.map((segment) => segment.replace(/[^a-zA-Z0-9_.,@-]/g, "-"));
+}
+
+function scopeStoragePathname(
+  pathname: string,
+  uid: string,
+  projectId: string,
+  folderPath: string | null = null,
+) {
+  const [prefix, ...segments] = pathname.split("/");
+  return [
+    prefix,
+    "projects",
+    uid,
+    projectId,
+    ...storageFolderSegments(folderPath),
+    ...segments,
+  ].join("/");
+}
+
+function uniqueStoragePathname(pathname: string) {
+  const slash = pathname.lastIndexOf("/");
+  const prefix = slash === -1 ? "" : pathname.slice(0, slash + 1);
+  const filename = slash === -1 ? pathname : pathname.slice(slash + 1);
+  const dot = filename.lastIndexOf(".");
+  const stem = dot > 0 ? filename.slice(0, dot) : filename;
+  const extension = dot > 0 ? filename.slice(dot) : "";
+  return `${prefix}${stem}-${Date.now()}-${randomUUID().slice(0, 8)}${extension}`;
+}
+
 export async function POST(request: Request) {
   try {
     const { user, response } = await requireAuthUser();
@@ -47,6 +94,7 @@ export async function POST(request: Request) {
     const filename = formData.get("filename") as string | null;
     const thumbnailFile = formData.get("thumbnail") as Blob | null;
     const thumbnailFilename = formData.get("thumbnailFilename") as string | null;
+    const projectId = await requireProjectAssetScope(formData.get("projectId"), user.uid);
 
     if (!file || !filename) {
       return NextResponse.json({ error: "Missing file or filename." }, { status: 400 });
@@ -54,14 +102,14 @@ export async function POST(request: Request) {
 
     const contentType = getMediaContentType(filename, file.type);
     const mediaBuffer = Buffer.from(await file.arrayBuffer());
-
+    const folderPath = formData.get("folderPath") as string | null;
     if (hasCloudinaryConfig()) {
-      const folderPath = formData.get("folderPath") as string | null;
       const storedMedia = await uploadCloudinaryMedia(
         filename,
         mediaBuffer,
         contentType,
         user.uid,
+        projectId,
         folderPath || undefined,
       );
 
@@ -70,10 +118,17 @@ export async function POST(request: Request) {
         url: storedMedia.url,
         thumbnailPathname: storedMedia.thumbnailPathname,
         thumbnailUrl: storedMedia.thumbnailUrl,
+        providerId: CLOUDINARY_PROVIDER_ID,
+        assetId: storedMedia.pathname,
       });
     }
 
-    const pathname = getUploadPathname(filename, contentType);
+    const pathname = scopeStoragePathname(
+      uniqueStoragePathname(getUploadPathname(filename, contentType)),
+      user.uid,
+      projectId,
+      folderPath,
+    );
     const requiresThumbnail = isVideoUpload(pathname, contentType);
 
     if (requiresThumbnail && !thumbnailFile) {
@@ -83,19 +138,25 @@ export async function POST(request: Request) {
       );
     }
 
-    const storedMedia = await uploadMedia(
-      pathname,
-      mediaBuffer,
-      contentType,
-    );
-
     let thumbnailPathname: string | undefined;
     let thumbnailUrl: string | undefined;
 
     if (thumbnailFile && requiresThumbnail) {
       thumbnailPathname = thumbnailFilename
-        ? sanitizeStoragePathname(thumbnailFilename, "timeline-thumbnails")
-        : createThumbnailPathname(pathname);
+        ? scopeStoragePathname(
+            uniqueStoragePathname(
+              sanitizeStoragePathname(thumbnailFilename, "timeline-thumbnails"),
+            ),
+            user.uid,
+            projectId,
+            folderPath,
+          )
+        : scopeStoragePathname(
+            uniqueStoragePathname(createThumbnailPathname(pathname)),
+            user.uid,
+            projectId,
+            folderPath,
+          );
       await uploadMedia(
         thumbnailPathname,
         Buffer.from(await thumbnailFile.arrayBuffer()),
@@ -104,6 +165,12 @@ export async function POST(request: Request) {
       thumbnailUrl = toMediaUrl(thumbnailPathname);
     }
 
+    const storedMedia = await uploadMedia(
+      pathname,
+      mediaBuffer,
+      contentType,
+    );
+
     return NextResponse.json({
       pathname: storedMedia.pathname,
       url: storedMedia.url,
@@ -111,6 +178,16 @@ export async function POST(request: Request) {
       thumbnailUrl,
     });
   } catch (error) {
+    if (error instanceof ProjectAssetScopeError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+    if (error instanceof CloudinaryUploadError) {
+      console.error("[GSTUDIO_CLOUDINARY_UPLOAD_ERROR]", error);
+      return NextResponse.json(
+        { error: error.message },
+        { status: error.status === 413 ? 413 : 502 },
+      );
+    }
     console.error("[GSTUDIO_MEDIA_UPLOAD_ERROR]", error);
     const message =
       error instanceof Error ? error.message : "Unable to upload file to hosted media storage.";

--- a/apps/timeline-gstudio001/app/layout.tsx
+++ b/apps/timeline-gstudio001/app/layout.tsx
@@ -31,7 +31,7 @@ export default function RootLayout({children}: {children: React.ReactNode}) {
                   the preview pane mounting at main's top must not scroll
                   the page out from under its own sticky logic. */}
               <main
-                className="min-w-0 flex-1 px-8 pt-6"
+                className="min-w-0 flex-1 px-8 pt-[13px]"
                 style={{
                   paddingBottom: "var(--asset-library-height, 0px)",
                 }}

--- a/apps/timeline-gstudio001/app/page.tsx
+++ b/apps/timeline-gstudio001/app/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 
 import { Button } from "@/components/core/button";
+import { Skeleton } from "@/components/core/skeleton";
 import { cn } from "@/lib/utils";
 
 type TimelineProjectSummary = {
@@ -38,6 +39,28 @@ function formatUpdatedAt(value?: string) {
   } catch {
     return "No save timestamp";
   }
+}
+
+function ProjectCardSkeleton() {
+  return (
+    <div
+      aria-hidden="true"
+      data-project-card-skeleton
+      className="overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900/55"
+    >
+      <Skeleton className="aspect-video w-full rounded-none border-b border-zinc-800" />
+      <div className="grid gap-3 p-4">
+        <div className="grid gap-2">
+          <Skeleton className="h-4 w-3/5" />
+          <Skeleton className="h-3 w-4/5" />
+        </div>
+        <div className="flex items-center justify-between gap-3">
+          <Skeleton className="h-3 w-14" />
+          <Skeleton className="h-3 w-28" />
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export default function Home() {
@@ -166,10 +189,12 @@ export default function Home() {
     }
   };
 
+  const initialLoading = isLoading && projects.length === 0;
+
   return (
-    <div className="mx-auto grid w-full max-w-[1400px] gap-6 animate-fade-in">
-      <header className="flex flex-col gap-4 border-b border-zinc-800 pb-5 lg:flex-row lg:items-end lg:justify-between">
-        <div className="grid gap-2">
+    <div className="mx-auto grid w-full max-w-[1400px] gap-6 pt-7 animate-fade-in">
+      <header className="flex flex-col gap-4 border-b border-zinc-800 pb-5 md:flex-row md:items-end md:justify-between">
+        <div className="grid min-w-0 flex-1 gap-2">
           <div className="flex items-center gap-2 text-[10px] font-black uppercase tracking-[0.24em] text-amber-300">
             <FolderOpen className="h-4 w-4" />
             Projects
@@ -182,7 +207,7 @@ export default function Home() {
 
         <form
           onSubmit={handleCreateProject}
-          className="flex w-full flex-col gap-2 rounded-lg border border-zinc-800 bg-zinc-900/55 p-3 sm:w-auto sm:min-w-[420px] sm:flex-row"
+          className="flex w-full flex-col gap-2 rounded-lg border border-zinc-800 bg-zinc-900/55 p-3 sm:flex-row md:w-[420px] md:shrink-0"
         >
           <label htmlFor="project-title" className="sr-only">
             Project title
@@ -206,14 +231,23 @@ export default function Home() {
         </form>
       </header>
 
-      <section className="grid gap-4">
+      <section
+        aria-busy={initialLoading}
+        aria-labelledby="saved-projects-heading"
+        className="grid gap-4"
+      >
         <div className="flex items-center justify-between gap-3">
           <div>
-            <h2 className="text-xs font-bold uppercase tracking-widest text-zinc-400">
+            <h2
+              id="saved-projects-heading"
+              className="text-xs font-bold uppercase tracking-widest text-zinc-400"
+            >
               Saved Projects
             </h2>
             <p className="mt-1 text-[10px] font-mono uppercase tracking-widest text-zinc-600">
-              {isLoading ? "Loading" : `${projects.length} ${projects.length === 1 ? "project" : "projects"}`}
+              {initialLoading
+                ? "Project library"
+                : `${projects.length} ${projects.length === 1 ? "project" : "projects"}`}
             </p>
           </div>
           <Button
@@ -236,10 +270,12 @@ export default function Home() {
           </div>
         ) : null}
 
-        {isLoading && projects.length === 0 ? (
-          <div className="flex h-40 items-center justify-center gap-2 rounded-lg border border-zinc-800 bg-zinc-900/35 text-sm text-zinc-500">
-            <Loader2 className="h-4 w-4 animate-spin" />
-            Loading projects
+        {initialLoading ? (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <span className="sr-only">Loading projects</span>
+            {Array.from({ length: 3 }, (_, index) => (
+              <ProjectCardSkeleton key={index} />
+            ))}
           </div>
         ) : projects.length === 0 ? (
           <div className="grid min-h-56 place-items-center rounded-lg border border-dashed border-zinc-800 bg-zinc-900/25 p-6 text-center">

--- a/apps/timeline-gstudio001/app/timeline/[timelineId]/loading.tsx
+++ b/apps/timeline-gstudio001/app/timeline/[timelineId]/loading.tsx
@@ -1,0 +1,41 @@
+import { Skeleton } from "@/components/core/skeleton";
+
+export default function TimelineLoading() {
+  return (
+    <div
+      aria-busy="true"
+      aria-label="Loading project"
+      className="mx-auto grid w-full max-w-[1400px] gap-4"
+    >
+      <section className="overflow-hidden rounded-xl border border-zinc-800 bg-zinc-950/50">
+        <div className="flex min-h-14 items-center justify-between gap-4 border-b border-zinc-800/70 px-4 py-3">
+          <div className="flex min-w-0 items-center gap-2">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-4 w-4 rounded-full" />
+            <Skeleton className="h-4 w-36" />
+          </div>
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-8 w-8" />
+            <Skeleton className="h-8 w-24" />
+            <Skeleton className="h-8 w-8" />
+          </div>
+        </div>
+
+        <div className="grid gap-4 p-4">
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+            {Array.from({ length: 8 }, (_, index) => (
+              <div
+                key={index}
+                className="grid gap-2 rounded-lg border border-zinc-800/80 bg-zinc-950/70 p-2"
+              >
+                <Skeleton className="aspect-video w-full" />
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-3 w-1/2" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/timeline-gstudio001/components/core/skeleton.tsx
+++ b/apps/timeline-gstudio001/components/core/skeleton.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-zinc-800/70", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/apps/timeline-gstudio001/components/graph-view/client-graph-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/client-graph-view.tsx
@@ -3,18 +3,13 @@
 import dynamic from "next/dynamic";
 
 import type { GraphServerPayload } from "@/lib/graph-documents-gateway";
+import { GraphViewLoadingSkeleton } from "./graph-view-loading";
 
 const GraphTimelineView = dynamic(
   () => import("./graph-timeline-view").then((module) => module.GraphTimelineView),
   {
     ssr: false,
-    loading: () => (
-      <div className="grid gap-3" aria-label="Loading graph view">
-        <div className="h-8 w-1/2 animate-pulse rounded-lg bg-zinc-900" />
-        <div className="h-28 w-full animate-pulse rounded-lg bg-zinc-900" />
-        <div className="h-20 w-full animate-pulse rounded-lg bg-zinc-900/60" />
-      </div>
-    ),
+    loading: () => <GraphViewLoadingSkeleton />,
   },
 );
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-asset-palette.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-asset-palette.tsx
@@ -249,9 +249,11 @@ function PaletteRail({
 }
 
 export function AssetPaletteDrawer({
+  projectId,
   open,
   onClose,
 }: Readonly<{
+  projectId: string;
   open: boolean;
   onClose: () => void;
 }>) {
@@ -296,8 +298,8 @@ export function AssetPaletteDrawer({
       // Search is a FOURTH axis, not a variant of the path: a result set for
       // "alley" has nothing to do with the folder the user was standing in,
       // and caching them under one key would serve one for the other.
-      JSON.stringify([p ?? "", m, segments, q]),
-    [],
+      JSON.stringify([projectId, p ?? "", m, segments, q]),
+    [projectId],
   );
 
   // The debounce lives in the CHANGE HANDLER, not an effect: the repo's
@@ -346,6 +348,7 @@ export function AssetPaletteDrawer({
           ? new URLSearchParams({ mode: "tags" })
           : new URLSearchParams({ browse: "1" });
       params.set("limit", String(PALETTE_PAGE_SIZE));
+      params.set("projectId", projectId);
       if (providerId !== null) params.set("provider", providerId);
       if (!searchTerm) {
         for (const segment of path) params.append(mode === "tags" ? "tag" : "folder", segment);
@@ -353,7 +356,7 @@ export function AssetPaletteDrawer({
       if (cursor !== undefined) params.set("cursor", cursor);
       return params;
     },
-    [searchTerm, mode, providerId, path],
+    [searchTerm, mode, providerId, path, projectId],
   );
 
   // Appending, not replacing: the rail keeps everything already loaded so a

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useContext, useDeferredValue, useMemo } from "react";
-import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { EllipsisVertical, FolderPlus, Redo2, Undo2 } from "lucide-react";
+import { FolderPlus, Redo2, Settings, Undo2 } from "lucide-react";
 
 import {
   CollectionsContainerContext,
@@ -21,16 +20,16 @@ import { Button } from "@/components/core/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
+  DropdownMenuGroup,
   DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/core/dropdown-menu";
 import { Slider } from "@/components/core/slider";
 
 import { NativeDropGrid, NativeDropStrip, SidebarToolInsertBridge } from "./graph-native-drop";
+import { VideoFrameLookAhead } from "./graph-item-content";
 import { BreadcrumbDropZones, DragChromeFade } from "./graph-breadcrumb-drop";
 import { OpenKeyBoundary } from "./graph-navigation";
 import { SyncPanel, type SyncEntry } from "./graph-persistence";
@@ -51,6 +50,7 @@ import { SubTimelines } from "./graph-sub-timelines";
 import {
   GRID_GAP,
   GRID_UNCAPPED_HEIGHT,
+  GRAPH_STRIP_OVERSCAN_ITEMS,
   ITEM_SIZE_DIMENSIONS,
   ITEM_SIZES,
   MAX_SUBTREE_DEPTH,
@@ -73,11 +73,9 @@ export type { FocusSurface, ItemSize };
 function BoardMenu({
   itemSize,
   onItemSizeChange,
-  storyboardHref,
 }: Readonly<{
   itemSize: ItemSize;
   onItemSizeChange: (size: ItemSize) => void;
-  storyboardHref: string;
 }>) {
   return (
     <DropdownMenu>
@@ -90,30 +88,25 @@ function BoardMenu({
           title="Board options"
           className="h-8 w-8 text-zinc-500 hover:text-zinc-200"
         >
-          <EllipsisVertical aria-hidden="true" className="h-4 w-4" />
+          <Settings aria-hidden="true" className="h-4 w-4" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuLabel>View</DropdownMenuLabel>
-        {/* Children visibility moved to the icon SIDEBAR (under the
-            Collection tool) — only the leave-the-graph link lives here. */}
-        <DropdownMenuItem asChild>
-          <Link href={storyboardHref}>Storyboard view</Link>
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuLabel>Thumbnail size</DropdownMenuLabel>
-        <DropdownMenuRadioGroup
-          value={itemSize}
-          onValueChange={(value) => {
-            if (isItemSize(value)) onItemSizeChange(value);
-          }}
-        >
-          {ITEM_SIZES.map((option) => (
-            <DropdownMenuRadioItem key={option} value={option}>
-              {option.toUpperCase()}
-            </DropdownMenuRadioItem>
-          ))}
-        </DropdownMenuRadioGroup>
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>Thumbnail size</DropdownMenuLabel>
+          <DropdownMenuRadioGroup
+            value={itemSize}
+            onValueChange={(value) => {
+              if (isItemSize(value)) onItemSizeChange(value);
+            }}
+          >
+            {ITEM_SIZES.map((option) => (
+              <DropdownMenuRadioItem key={option} value={option}>
+                {option.toUpperCase()}
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>
   );
@@ -162,7 +155,7 @@ function FocusedAggregate({
   return (
     <span
       data-focused-aggregate
-      className="hidden shrink-0 px-3 text-center font-mono text-[11px] tabular-nums text-zinc-500 sm:block"
+      className="hidden shrink-0 px-3 text-center font-mono text-[11px] tabular-nums text-zinc-400 sm:block"
       title="Focused timeline total"
     >
       {count} {count === 1 ? "clip" : "clips"} · {formatAggregateSeconds(seconds)}
@@ -276,20 +269,22 @@ function GraphAddCollectionButton() {
     // actual add. A matching document drop swallows a stray drop that misses
     // every strip so the browser takes no default action.
     const onDocDragOver = (e: DragEvent) => {
-      if (!e.dataTransfer?.types.includes("application/x-gstudio-type")) return;
       e.preventDefault();
-      e.dataTransfer.dropEffect = "copy";
+      if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
     };
     const onDocDrop = (e: DragEvent) => {
-      if (e.dataTransfer?.types.includes("application/x-gstudio-type")) e.preventDefault();
+      e.preventDefault();
     };
     const cleanup = () => {
-      document.removeEventListener("dragover", onDocDragOver);
-      document.removeEventListener("drop", onDocDrop);
+      document.removeEventListener("dragover", onDocDragOver, true);
+      document.removeEventListener("drop", onDocDrop, true);
       document.removeEventListener("dragend", cleanup);
     };
-    document.addEventListener("dragover", onDocDragOver);
-    document.addEventListener("drop", onDocDrop);
+    // Capture before nested surfaces. Chromium can briefly expose an empty
+    // `types` list while crossing DOM boundaries, so the drag-lifetime guard
+    // must not depend on reading our MIME type back from each event.
+    document.addEventListener("dragover", onDocDragOver, true);
+    document.addEventListener("drop", onDocDrop, true);
     document.addEventListener("dragend", cleanup, { once: true });
   };
 
@@ -309,6 +304,7 @@ function GraphAddCollectionButton() {
 }
 
 export function GraphBoard({
+  projectId,
   focusedId,
   breadcrumb,
   surface,
@@ -319,12 +315,12 @@ export function GraphBoard({
   previewOn,
   rulerOn,
   flatOn,
-  storyboardHref,
   childrenShown,
   timeChannel,
   trashRootId,
   syncEntries,
 }: Readonly<{
+  projectId: string;
   focusedId: string;
   /** Slot, not routing props: the board renders where you are without
    *  knowing how a route is shaped. */
@@ -342,9 +338,6 @@ export function GraphBoard({
   /** Strip's flat mode: render the whole closure in order, not this
    *  collection's direct children. */
   flatOn: boolean;
-  /** For the overflow menu's "Storyboard view" item — routing stays the
-   *  caller's business, like the breadcrumb slot. */
-  storyboardHref: string;
   /** Toggled from the SIDEBAR's children icon; the board only renders it. */
   childrenShown: boolean;
   timeChannel: PreviewTimeChannel;
@@ -396,7 +389,7 @@ export function GraphBoard({
         {/* Outside the surface branch on purpose: the sidebar's tool buttons
             must insert in grid mode too, where no NativeDropStrip exists. */}
         <SidebarToolInsertBridge collectionId={focusedId} />
-        <div className="flex flex-col gap-5 rounded-xl border border-zinc-800 bg-zinc-950/50 p-4">
+        <div className="flex flex-col gap-2">
           {/* Pinned so the controls stay reachable while scrolling the
               surfaces. It sticks just BELOW the sticky preview via the offset
               the split pane publishes (0 when the preview is closed). The
@@ -409,9 +402,24 @@ export function GraphBoard({
               margins let that background span the card's full width past its
               p-4 padding. */}
           <div
-            className="sticky z-40 -mx-4 -mt-4 flex flex-wrap items-center justify-between gap-x-3 gap-y-2 rounded-t-xl border-b border-zinc-800/70 bg-zinc-950/95 px-4 py-3 backdrop-blur-sm"
+            data-graph-board-header=""
+            className="sticky z-40 grid min-w-0 grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-x-3 border-b border-zinc-800/70 bg-zinc-950/95 py-3 backdrop-blur-sm"
             style={{ top: "var(--workbench-preview-offset, 0px)" }}
           >
+            {/* Seek thumbs are centered on the timeline edge and intentionally
+                extend six pixels beyond it. Mask that overhang only while it
+                passes behind this sticky row; clipping the board would also
+                truncate the thumb once it is normally visible below. */}
+            <span
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-y-0 right-full w-2 bg-zinc-950"
+              data-board-header-edge-occluder="start"
+            />
+            <span
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-y-0 left-full w-2 bg-zinc-950"
+              data-board-header-edge-occluder="end"
+            />
             {/* Equal-flex wings keep the aggregate at the row's true centre
                 (under the transport's play cluster). min-w-0 lets a long
                 breadcrumb truncate inside its wing. */}
@@ -428,7 +436,7 @@ export function GraphBoard({
             {/* flex-wrap + wrap-capable controls so a narrow viewport folds the
                 toolbar onto a second line instead of pushing controls
                 off-screen. No effect when it fits. */}
-            <DragChromeFade className="flex flex-1 flex-wrap items-center justify-end gap-2">
+            <DragChromeFade className="flex min-w-0 items-center justify-end gap-2">
               {/* The Collection tool (moved here from the icon sidebar): the
                   view's one "add structure" action leads the cluster, fenced
                   off from the surface/history controls to its right. */}
@@ -451,7 +459,6 @@ export function GraphBoard({
               <BoardMenu
                 itemSize={itemSize}
                 onItemSizeChange={onItemSizeChange}
-                storyboardHref={storyboardHref}
               />
             </DragChromeFade>
 
@@ -467,15 +474,19 @@ export function GraphBoard({
             // The focused surface spans the card's FULL width (-mx-4 cancels
             // the card's p-4), so its edges line up with the full-bleed
             // breadcrumb bar above instead of sitting inset like a panel
-            // nested under it. Padding lives on THIS wrapper, never on
-            // NativeDropStrip: its drop math is clientX-vs-own-rect, and
-            // padding there drifts the indicator.
-            <div className="-mx-4 border-y border-zinc-800/70 bg-zinc-900/40 p-3">
-              <NativeDropStrip collectionId={focusedId}>
+            // nested under it. The focused surface is intentionally
+            // edge-to-edge; padding here adds dead space around every side.
+            <div
+              data-focused-surface-shell="strip"
+              className=""
+            >
+              <VideoFrameLookAhead>
+                <NativeDropStrip collectionId={focusedId} projectId={projectId}>
               <VirtualStrip
                 collectionId={parseNodeId(focusedId)}
                 itemIds={flatItemIds}
                 pixelsPerSecond={deferredPixelsPerSecond}
+                overscan={GRAPH_STRIP_OVERSCAN_ITEMS}
                 itemWidth={collectionCardWidth(deferredPixelsPerSecond)}
                 itemHeight={dims.strip}
                 itemDragActivation="hold"
@@ -500,7 +511,10 @@ export function GraphBoard({
                 }
                 // pt-4: the 16px top band the seek rail centres in — same
                 // clearance system as the grid's GRID_GAP row bands.
-                className="bg-black/25 pt-4"
+                className={[
+                  "rounded-none border-0 bg-transparent p-0",
+                  previewOn || rulerOn ? "pt-4" : "",
+                ].join(" ")}
               />
               {/* The strip's scrub control — the same rail treatment as the
                   grid's, riding the strip's top padding band and scrolling
@@ -514,7 +528,8 @@ export function GraphBoard({
                   pixelsPerSecond={deferredPixelsPerSecond}
                 />
               )}
-              </NativeDropStrip>
+                </NativeDropStrip>
+              </VideoFrameLookAhead>
             </div>
           ) : (
             // Grid scrubbing is the per-row SEEK RAILS layer — one slim
@@ -525,11 +540,12 @@ export function GraphBoard({
             // indicator. The layer overlays the grid as a SIBLING (outside
             // NativeDropGrid, whose drop math measures its own wrapper, and
             // outside the aria-hidden overlay — rails are focusable). Same
-            // gray panel as the strip branch; the rails' geometry is
-            // measured live from the grid's own rect, so the padding is
-            // accounted for automatically.
-            <div className="relative -mx-4 border-y border-zinc-800/70 bg-zinc-900/40 p-3">
-              <NativeDropGrid collectionId={focusedId}>
+            // gray panel as the strip branch, with no extra shell padding.
+            <div
+              data-focused-surface-shell="grid"
+              className="relative"
+            >
+              <NativeDropGrid collectionId={focusedId} projectId={projectId}>
                 <VirtualGrid
                   collectionId={parseNodeId(focusedId)}
                   cellWidth={dims.gridWidth}
@@ -552,7 +568,10 @@ export function GraphBoard({
                     ) : undefined
                   }
                   // pt-4 = GRID_GAP: row 0's rail band matches the row gaps.
-                  className="bg-black/25 pt-4"
+                  className={[
+                    "rounded-none border-0 bg-transparent p-0",
+                    previewOn ? "pt-4" : "",
+                  ].join(" ")}
                 />
               </NativeDropGrid>
               {previewOn && (
@@ -569,17 +588,24 @@ export function GraphBoard({
           {/* Children render one size step below the focused timeline (flat —
               every descendant is this one size, see stepDownItemSize). The
               FolderTree toggle unmounts them entirely rather than hiding with
-              CSS, so their strips/grids and sub-row playheads leave the DOM. */}
+              CSS, so their strips/grids and sub-row playheads leave the DOM.
+              Flat mode belongs only to the FOCUSED surface above: child rows
+              remain structured and must map their own cards onto the shared
+              preview clock. Reset the outer flat run here so its item list
+              cannot leak into every nested rail/playhead. */}
           {childrenShown && (
-            <SubTimelines
-              focusedId={focusedId}
-              surface={surface}
-              itemSize={stepDownItemSize(itemSize)}
-              pixelsPerSecond={deferredPixelsPerSecond}
-              previewOn={previewOn}
-              rulerOn={rulerOn}
-              timeChannel={timeChannel}
-            />
+            <FlatItemsProvider items={null}>
+              <SubTimelines
+                projectId={projectId}
+                focusedId={focusedId}
+                surface={surface}
+                itemSize={stepDownItemSize(itemSize)}
+                pixelsPerSecond={deferredPixelsPerSecond}
+                previewOn={previewOn}
+                rulerOn={rulerOn}
+                timeChannel={timeChannel}
+              />
+            </FlatItemsProvider>
           )}
 
           {/* Card-drag drop targets (trash + move-to-parent) live in the

--- a/apps/timeline-gstudio001/components/graph-view/graph-breadcrumb-drop.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-breadcrumb-drop.tsx
@@ -109,7 +109,7 @@ export function DragChromeFade({
 }
 
 const ZONE_BASE =
-  "flex h-10 min-w-[150px] items-center justify-center gap-2 rounded-md border text-xs font-medium transition-all duration-200";
+  "flex h-10 min-w-[150px] items-center justify-center gap-2 rounded-md border px-4 text-xs font-medium transition-all duration-200";
 
 type ZoneAccent = Readonly<{ over: string; icon: string }>;
 
@@ -171,8 +171,8 @@ function DropZone({
         active ? "pointer-events-auto scale-100 opacity-100" : "pointer-events-none scale-95 opacity-0",
         hint
           ? hint.invalid
-            ? "border-zinc-700 bg-zinc-900/90 text-zinc-500"
-            : "border-sky-400 bg-sky-950/80 text-sky-100"
+            ? "border-transparent bg-zinc-900/70 text-zinc-500"
+            : "border-transparent bg-zinc-800/75 text-zinc-200 shadow-sm"
           : state === "over"
             ? accent.over
             : state === "invalid"
@@ -186,7 +186,7 @@ function DropZone({
           {/* One line that GROWS the box to fit — the readout must always be the
               right size for the name. The generous cap only engages for an
               absurdly long name, so it can never overflow the header. */}
-          <span className="max-w-[min(70vw,420px)] truncate whitespace-nowrap">
+          <span className="max-w-[min(38vw,320px)] truncate whitespace-nowrap">
             {hint.invalid ? "Can’t drop into " : "Drop into "}
             <span className="font-semibold">{hint.name}</span>
           </span>

--- a/apps/timeline-gstudio001/components/graph-view/graph-inline-rename.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-inline-rename.tsx
@@ -94,12 +94,14 @@ export function InlineNameEditor({
   onCommit,
   onCancel,
   className,
+  ariaLabel = "Timeline name",
 }: Readonly<{
   initialValue: string;
   onInput: (value: string) => void;
   onCommit: () => void;
   onCancel: () => void;
   className?: string;
+  ariaLabel?: string;
 }>) {
   const setRef = useCallback((element: HTMLInputElement | null) => {
     if (!element) return;
@@ -111,7 +113,7 @@ export function InlineNameEditor({
   return (
     <input
       ref={setRef}
-      aria-label="Timeline name"
+      aria-label={ariaLabel}
       defaultValue={initialValue}
       spellCheck={false}
       onChange={(event) => onInput(event.target.value)}

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -6,6 +6,7 @@ import type { ClipDetail } from "@storyboard/timeline-domain";
 import {
   DndCollections,
   buildGraph,
+  type CollectionGhostContentComponent,
   type CollectionItemShellComponent,
   type CollectionItemShellProps,
   type CollectionTrimOverviewContentComponent,
@@ -14,7 +15,10 @@ import {
   type VideoMediaNode,
 } from "@storyboard/ui/dnd-collections";
 
-import { GRAPH_VIEW_COMPONENTS } from "./graph-item-content";
+import {
+  GRAPH_VIEW_COMPONENTS,
+  VideoFrameLookAhead,
+} from "./graph-item-content";
 import { GraphDetailsProvider } from "./graph-details-context";
 import { createGraphDetailsStore } from "@/lib/graph-details-store";
 
@@ -30,8 +34,10 @@ import { createGraphDetailsStore } from "@/lib/graph-details-store";
 // The registry field is optional in the type; the graph view always registers
 // it, so narrow to the defined component for `Meta`.
 const ItemShell: CollectionItemShellComponent = GRAPH_VIEW_COMPONENTS.ItemShell!;
+const GhostContent: CollectionGhostContentComponent = GRAPH_VIEW_COMPONENTS.GhostContent!;
 
 const COLLECTION_ID = "col-1" as NodeId;
+const EMPTY_COLLECTION_ID = "empty-col" as NodeId;
 
 /** A one-node graph: the shell reads the node (kind, name) from the store.
  *  The card renders un-hydrated here, so its preview frames come from the
@@ -41,6 +47,19 @@ const providerGraph = (() => {
   if (!result.ok) throw new Error(JSON.stringify(result.error));
   return result.value;
 })();
+
+const emptyCollectionGraph = (() => {
+  const result = buildGraph([
+    { kind: "collection", id: EMPTY_COLLECTION_ID, name: "Empty timeline", children: [] },
+  ]);
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.value;
+})();
+
+const emptyCollectionNode = emptyCollectionGraph.nodesById.get(EMPTY_COLLECTION_ID);
+if (emptyCollectionNode?.kind !== "collection") {
+  throw new Error("Empty collection ghost fixture did not build.");
+}
 
 /** A deterministic, fully-offline poster (a solid-colour SVG data URI). */
 function poster(label: string, fill: string): string {
@@ -77,6 +96,7 @@ function renderWithDetail(previewItems: PreviewItem[]) {
     trackIndex: 0,
     hydrated: false,
     itemCount: previewItems.length,
+    duration: previewItems.length * 4,
     previewItems,
   };
   const store = createGraphDetailsStore({ [COLLECTION_ID]: detail });
@@ -151,6 +171,7 @@ export const SingleFrame: Story = {
   play: async ({ canvasElement }) => {
     const images = previewImages(canvasElement);
     await expect(images).toHaveLength(1);
+    await expect(canvasElement).toHaveTextContent(/4\.0s\s*\/\s*1 item/);
   },
 };
 
@@ -168,6 +189,35 @@ export const PlaceholderAriaCountMatchesBadge: Story = {
     const surface = canvasElement.querySelector<HTMLElement>("[data-node-id]")!;
     // The stored summary (itemCount 2), not the live childCount (0).
     await expect(surface.getAttribute("aria-label")).toBe("A timeline (collection, 2 items)");
+    await expect(canvasElement).toHaveTextContent(/8\.0s\s*\/\s*2 items/);
+
+    const name = canvasElement.querySelector<HTMLElement>(
+      '[title="Double-click or press F2 to rename"]',
+    )!;
+    const surfaceRect = surface.getBoundingClientRect();
+    const nameRect = name.getBoundingClientRect();
+    await expect(nameRect.left - surfaceRect.left).toBeGreaterThanOrEqual(9);
+    await expect(surfaceRect.right - nameRect.right).toBeGreaterThanOrEqual(9);
+    await expect(surfaceRect.bottom - nameRect.bottom).toBeGreaterThanOrEqual(7);
+  },
+};
+
+/** An empty or unresolved collection shows only the collection affordance;
+ * no fallback copy is allowed to bleed through behind the folder glyph. */
+export const EmptyCardUsesCleanIconFallback: Story = {
+  args: baseArgs,
+  decorators: [renderWithDetail([])],
+  play: async ({ canvasElement }) => {
+    const fallback = canvasElement.querySelector<HTMLElement>(
+      "[data-empty-collection-preview]",
+    );
+    await expect(fallback).not.toBeNull();
+    await expect(fallback!.textContent).toBe("");
+    await expect(previewImages(canvasElement)).toHaveLength(0);
+    await expect(canvasElement).not.toHaveTextContent(/open to load|empty|no media preview/i);
+
+    const folder = canvasElement.querySelector<HTMLElement>('button[aria-label^="Open "]');
+    await expect(folder).not.toBeNull();
   },
 };
 
@@ -283,6 +333,10 @@ export const DisabledCard: Story = {
     await expect(chip).not.toBeNull();
     await expect(chip.dataset.disabledChip).toBe("self");
     await expect(chip.textContent).toBe("DISABLED");
+    await expect(getComputedStyle(surface).opacity).toBe("1");
+    await expect(getComputedStyle(surface).filter).toBe("none");
+    await expect(getComputedStyle(chip).opacity).toBe("1");
+    await expect(getComputedStyle(chip).filter).toBe("none");
   },
 };
 
@@ -302,6 +356,10 @@ export const DisabledByParentCard: Story = {
     const chip = canvasElement.querySelector<HTMLElement>("[data-disabled-chip]")!;
     await expect(chip.dataset.disabledChip).toBe("inherited");
     await expect(chip.textContent).toBe("PARENT OFF");
+    await expect(getComputedStyle(surface).opacity).toBe("1");
+    await expect(getComputedStyle(surface).filter).toBe("none");
+    await expect(getComputedStyle(chip).opacity).toBe("1");
+    await expect(getComputedStyle(chip).filter).toBe("none");
   },
 };
 
@@ -351,9 +409,11 @@ function FilmstripSettleHarness() {
   return (
     <DndCollections initialGraph={videoGraph} components={GRAPH_VIEW_COMPONENTS}>
       <GraphDetailsProvider store={store}>
-        <div data-resize-host style={{ width: 192, height: 96 }}>
-          <ItemShell id={VIDEO_ID} className="h-full w-full" />
-        </div>
+        <VideoFrameLookAhead>
+          <div data-resize-host style={{ width: 192, height: 96 }}>
+            <ItemShell id={VIDEO_ID} className="h-full w-full" />
+          </div>
+        </VideoFrameLookAhead>
       </GraphDetailsProvider>
     </DndCollections>
   );
@@ -375,6 +435,17 @@ export const FilmstripResampleSettles: Story = {
     const host = canvasElement.querySelector<HTMLElement>("[data-resize-host]")!;
     // First measurement adopts immediately: 192×96 → 2 frames.
     await waitFor(() => expect(previewImages(canvasElement)).toHaveLength(2));
+    // Mounted video cards are already inside the virtual strip's bounded
+    // look-ahead window, so their frames must be discovered immediately.
+    expect(previewImages(canvasElement).every((image) => image.loading === "eager")).toBe(true);
+    const kind = canvasElement.querySelector<HTMLElement>('[data-media-kind="video"]')!;
+    const card = kind.parentElement?.parentElement;
+    expect(card).not.toBeNull();
+    expect(getComputedStyle(kind).fontSize).toBe("9px");
+    const kindRect = kind.getBoundingClientRect();
+    const cardRect = card!.getBoundingClientRect();
+    expect(kindRect.left - cardRect.left).toBeGreaterThanOrEqual(7);
+    expect(cardRect.bottom - kindRect.bottom).toBeGreaterThanOrEqual(7);
 
     // Grow the card as a zoom drag would. The filmstrip must NOT adopt the
     // new count as soon as the resize lands (80ms is plenty for the
@@ -464,6 +535,33 @@ export const TrimOverviewSamplesDistinctFrames: Story = {
   },
 };
 
+/** An empty collection has no preview frame to paint, so its drag ghost uses
+ * the exact same light-stroke folder/arrow glyph as the collection card. */
+export const EmptyCollectionGhostUsesFolderGlyph: Story = {
+  args: baseArgs,
+  render: () => {
+    const store = createGraphDetailsStore({});
+    return (
+      <DndCollections initialGraph={emptyCollectionGraph}>
+        <GraphDetailsProvider store={store}>
+          <div className="h-24 w-24">
+            <GhostContent node={emptyCollectionNode} extraCount={0} />
+          </div>
+        </GraphDetailsProvider>
+      </DndCollections>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const ghost = canvasElement.querySelector<HTMLElement>("[data-empty-collection-ghost]")!;
+    await expect(ghost).not.toBeNull();
+    await expect(ghost.textContent).toBe("");
+    const glyph = ghost.querySelector<SVGElement>("svg")!;
+    await expect(glyph.getAttribute("stroke-width")).toBe("1.5");
+    await expect(glyph.classList.contains("h-7")).toBe(true);
+    await expect(glyph.classList.contains("w-7")).toBe(true);
+  },
+};
+
 /**
  * A DISABLED collection: skipped in playback, counts and time totals, but it
  * keeps its slot and its full width — its duration still shapes the board.
@@ -492,6 +590,7 @@ export const DisabledCollection: Story = {
           trackIndex: 0,
           hydrated: false,
           itemCount: 2,
+          duration: 8,
           previewItems: [ASSET_A, ASSET_B],
         },
       });
@@ -509,7 +608,29 @@ export const DisabledCollection: Story = {
   play: async ({ canvasElement }) => {
     const card = canvasElement.querySelector(".is-disabled-card");
     await expect(card).not.toBeNull();
-    await expect(getComputedStyle(card as Element).filter).toBe("grayscale(1)");
+    await expect(getComputedStyle(card as Element).filter).toBe("none");
+    await expect(getComputedStyle(card as Element).opacity).toBe("1");
+    const visuals = canvasElement.querySelector<HTMLElement>("[data-disabled-visuals]")!;
+    await expect(getComputedStyle(visuals).filter).toBe("grayscale(1)");
+    await expect(Number(getComputedStyle(visuals).opacity)).toBeLessThan(1);
+    const chip = canvasElement.querySelector<HTMLElement>("[data-disabled-chip]")!;
+    await expect(getComputedStyle(chip).filter).toBe("none");
+    await expect(getComputedStyle(chip).opacity).toBe("1");
+    await expect(chip.classList.contains("right-2")).toBe(true);
+    await expect(chip.classList.contains("bottom-2")).toBe(true);
+    const metadata = canvasElement.querySelector<HTMLElement>("[data-collection-metadata]")!;
+    await expect(getComputedStyle(metadata).filter).toBe("none");
+    await expect(getComputedStyle(metadata).opacity).toBe("1");
+    await expect(metadata.textContent).toContain("A timeline");
+    await expect(metadata.textContent).toContain("8.0s");
+    await expect(metadata.textContent).toContain("2 items");
+    const folderGlyph = canvasElement.querySelector<SVGElement>(
+      'button[aria-label="Open A timeline"] svg',
+    )!;
+    await expect(folderGlyph.getAttribute("stroke-width")).toBe("1.5");
+    await userEvent.click(card as HTMLElement);
+    await expect((card as HTMLElement).className).toContain("ring-amber-300/65");
+    await expect((card as HTMLElement).className).toContain("ring-inset");
     // The frames still render — a disabled card shows its content, muted.
     await expect(previewImages(canvasElement)).toHaveLength(2);
   },

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  createContext,
   memo,
   useCallback,
   useContext,
@@ -9,6 +10,7 @@ import {
   useRef,
   useState,
   useSyncExternalStore,
+  type ReactNode,
 } from "react";
 import { FolderInput } from "lucide-react";
 
@@ -45,10 +47,30 @@ import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
 import { GraphViewNavContext } from "./graph-navigation";
 import { TrimFramePreview } from "./graph-trim-frame-preview";
 import { createDerivedCache } from "@/lib/derived-cache";
-import { videoFrameUrls } from "@/lib/video-frame-url";
+import {
+  collectionPreviewFrameUrl,
+  videoFrameUrls,
+} from "@/lib/video-frame-url";
 
 /** Never sample more than this many frames for one card, however wide. */
 const VIDEO_FRAME_CAP = 16;
+
+/**
+ * Marks the bounded virtual-strip window as safe to load eagerly. The same
+ * card renderer is used in grid view, where eager loading would request every
+ * video at once, so lazy remains the default outside this boundary.
+ */
+const VideoFrameLoadingContext = createContext<"lazy" | "eager">("lazy");
+
+export function VideoFrameLookAhead({
+  children,
+}: Readonly<{ children: ReactNode }>) {
+  return (
+    <VideoFrameLoadingContext.Provider value="eager">
+      {children}
+    </VideoFrameLoadingContext.Provider>
+  );
+}
 
 /** Live width/height of a card, via ResizeObserver — drives how many frames a
  *  video filmstrip shows, so it stays a sensible sequence at every zoom (R6
@@ -143,7 +165,9 @@ function useHydratedCollectionPreviews(
       compute: (graph: CollectionsGraph, nodeId: string) =>
         hydratedCollectionPreviews(graph, nodeId),
       contentKey: (previews) =>
-        previews.map((p) => `${p.id}\0${p.poster ?? p.src}`).join("\x01"),
+        previews
+          .map((p) => `${p.id}\0${p.poster ?? p.src}\0${p.trimIn ?? 0}`)
+          .join("\x01"),
     }),
   );
   const getSnapshot = useCallback(() => {
@@ -346,15 +370,22 @@ function DisabledChip({ inherited }: { inherited: boolean }) {
           : "Skipped during playback"
       }
       className={[
-        "pointer-events-none absolute right-1 top-1 z-10 rounded px-1 py-0.5 font-mono text-[8px] leading-none font-semibold tracking-[0.08em]",
+        "pointer-events-none absolute right-2 bottom-2 z-20 rounded px-1 py-0.5 font-mono text-[8px] leading-none font-semibold tracking-[0.08em]",
         inherited
-          ? "bg-black/75 text-zinc-300 ring-1 ring-zinc-500/40"
-          : "bg-black/80 text-amber-300 ring-1 ring-amber-400/40",
+          ? "bg-zinc-950/95 text-zinc-100 ring-1 ring-zinc-400/70"
+          : "bg-zinc-950/95 text-amber-200",
       ].join(" ")}
     >
       {inherited ? "PARENT OFF" : "DISABLED"}
     </span>
   );
+}
+
+/** Shared collection glyph for both the card affordance and an empty drag
+ * ghost. The lighter stroke keeps the compound folder/arrow mark readable at
+ * small sizes without looking heavier than the surrounding icon system. */
+function CollectionFolderGlyph({ className }: Readonly<{ className?: string }>) {
+  return <FolderInput aria-hidden="true" className={className} strokeWidth={1.5} />;
 }
 
 /**
@@ -418,6 +449,7 @@ const GraphClipContent = memo(function GraphClipContent({
   // Above the collection early-return below — hooks may not be conditional.
   const inheritedDisabled = useDisabledByAncestor(id);
   const provenance = useCardProvenance(id);
+  const frameLoading = useContext(VideoFrameLoadingContext);
 
   // MEDIA pixels only. Collections don't render through this seam anymore:
   // their card carries interactive controls (folder drill-in, inline rename),
@@ -428,6 +460,7 @@ const GraphClipContent = memo(function GraphClipContent({
   if (node.kind === "collection") return null;
 
   const isVideo = node.mediaKind === "video";
+  const muted = node.disabled === true || inheritedDisabled;
   // A wider clip shows MORE distinct frames rather than the same still tiled
   // — falling back to a duration-based count until first measured.
   const frames = isVideo
@@ -458,9 +491,8 @@ const GraphClipContent = memo(function GraphClipContent({
         // the identical adjacency, so full-bleed pressed into it there too.
         // The card's outer box (and so width = duration) is unchanged.
         "relative flex h-full w-full overflow-hidden rounded-md bg-zinc-900 p-1.5",
-        selected ? "ring-2 ring-amber-400" : "ring-1 ring-white/15",
+        selected ? "ring-1 ring-inset ring-amber-300/65" : "ring-1 ring-white/15",
         rejected ? "ring-2 ring-red-500 motion-safe:animate-pulse" : "",
-        isDragSource ? "opacity-40" : "",
         // Disabled reads as MUTED, never as missing: the card keeps its slot
         // and its full width (its duration still shapes the board), it just
         // stops looking like content that plays. Grayscale + reduced opacity
@@ -468,12 +500,19 @@ const GraphClipContent = memo(function GraphClipContent({
         //
         // Inherited disabling looks IDENTICAL — a viewer sees neither — and
         // only the chip distinguishes them.
-        node.disabled || inheritedDisabled ? "opacity-45 grayscale" : "",
       ].join(" ")}
       // Distinct VALUES so e2e can assert which cause is in play; both are
       // truthy for "this card is muted".
       data-disabled={node.disabled ? "true" : inheritedDisabled ? "inherited" : undefined}
     >
+      <span
+        data-disabled-visuals={muted ? "true" : undefined}
+        className={[
+          "relative flex h-full w-full overflow-hidden rounded-sm",
+          isDragSource ? "opacity-40" : muted ? "opacity-45" : "",
+          muted ? "grayscale" : "",
+        ].join(" ")}
+      >
       {frameSrcs.length === 0 ? (
         <span className="flex h-full w-full items-center justify-center text-[10px] text-zinc-500">
           No preview
@@ -487,12 +526,18 @@ const GraphClipContent = memo(function GraphClipContent({
               src={src}
               alt=""
               draggable={false}
-              loading="lazy"
+              // The virtual strip itself is the loading boundary: only the
+              // visible cards plus its bounded look-ahead are mounted. Start
+              // those frames immediately so a fast horizontal pan cannot
+              // outrun the browser's native lazy-load distance.
+              loading={frameLoading}
+              decoding="async"
               className="h-full min-w-0 flex-1 border-r border-black/60 object-cover last:border-r-0"
             />
           ))}
         </span>
       )}
+      </span>
       {/* Kind tag (R6 #7): a WORD, bottom-left. The glyph version (a 4px film
           or picture icon in the top corner) was ambiguous at small item sizes
           — the two lucide marks read as the same smudge — so it says which it
@@ -502,15 +547,15 @@ const GraphClipContent = memo(function GraphClipContent({
       <span
         aria-hidden="true"
         data-media-kind={isVideo ? "video" : "image"}
-        className="pointer-events-none absolute bottom-1 left-1 z-10 rounded bg-black/75 px-1 py-0.5 font-mono text-[8px] leading-none font-semibold tracking-[0.08em] text-zinc-100"
+        className="pointer-events-none absolute bottom-2 left-2 z-10 rounded bg-black/75 px-1.5 py-0.5 font-mono text-[9px] leading-none font-semibold tracking-[0.08em] text-zinc-100"
       >
         {isVideo ? "VIDEO" : "IMAGE"}
       </span>
-      {(node.disabled || inheritedDisabled) && (
+      {muted && (
         <DisabledChip inherited={node.disabled !== true} />
       )}
       {provenance && <ProvenanceLabel parentId={provenance.parentId} name={provenance.name} />}
-      {trimEnabled && <LiveDurationPill id={id} node={node} />}
+      {trimEnabled && !muted && <LiveDurationPill id={id} node={node} />}
       {/* Floating frame-at-the-edge panel during a trim drag (video only) —
           rides the same per-node live-trim channel as the pill. */}
       {trimEnabled && <TrimFramePreview id={id} node={node} />}
@@ -637,7 +682,7 @@ const GraphGhost = memo(function GraphGhost({ node, extraCount }: CollectionGhos
   // card picks its two representative frames.
   const chosen = all.length > 1 ? [all[0], all[all.length - 1]] : all;
   const derivedFrames: string[] = isCollection
-    ? chosen.map((preview) => preview.poster ?? preview.src).filter(Boolean)
+    ? chosen.map((preview) => collectionPreviewFrameUrl(preview)).filter(Boolean)
     : (() => {
         const src = mediaGhostSrc(node);
         return src ? [src] : [];
@@ -672,11 +717,18 @@ const GraphGhost = memo(function GraphGhost({ node, extraCount }: CollectionGhos
             />
           ))}
         </span>
+      ) : isCollection ? (
+        <span
+          data-empty-collection-ghost
+          className="flex h-full w-full items-center justify-center"
+        >
+          <CollectionFolderGlyph className="h-7 w-7 text-sky-200" />
+        </span>
       ) : (
         <span className="flex h-full w-full flex-col items-center justify-center gap-1 p-2 text-center">
           <span className="truncate text-[11px] font-semibold text-zinc-100">{node.name}</span>
           <span className="font-mono text-[9px] text-zinc-400">
-            {node.kind === "collection" ? "Timeline" : `${mediaDurationSeconds(node).toFixed(2)}s`}
+            {mediaDurationSeconds(node).toFixed(2)}s
           </span>
         </span>
       )}
@@ -742,14 +794,13 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
         // placeholder, the live children once hydrated. The primitive's default
         // reads live childCount alone, which speaks "0 items" over a card
         // displaying "9" until its clips load.
-        ariaLabel={`${displayName} (collection, ${count} items)`}
+        ariaLabel={`${displayName} (collection, ${count} ${count === 1 ? "item" : "items"})`}
         className={[
           // `relative` so the disabled chip below can pin to this card's own
           // top-right corner rather than some ancestor's.
           "relative flex h-full w-full flex-col justify-between overflow-hidden rounded-md border border-dashed border-sky-500/40 bg-sky-500/[0.08] p-1.5",
-          selected ? "ring-2 ring-amber-400" : "",
+          selected ? "ring-1 ring-inset ring-amber-300/65" : "",
           rejected ? "ring-2 ring-red-500 motion-safe:animate-pulse" : "",
-          isDragSource ? "opacity-40" : "",
           // No `data-disabled` twin here: SelectionSurface takes an explicit
           // prop list with no rest spread, so a hyphenated attribute passed to
           // it is silently dropped — and TS does not flag it, because excess
@@ -757,19 +808,25 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
           // are what tests and e2e can query on a collection card; the
           // inherited one gets its own so the two causes stay separable, the
           // way `data-disabled`'s values do on a media card.
-          muted ? "opacity-45 grayscale is-disabled-card" : "",
+          muted ? "is-disabled-card" : "",
           muted && node.disabled !== true ? "is-parent-disabled-card" : "",
         ].join(" ")}
       >
         {muted && <DisabledChip inherited={node.disabled !== true} />}
-        <span className="flex min-h-0 flex-1 gap-0.5 overflow-hidden">
+        <span
+          data-disabled-visuals={muted ? "true" : undefined}
+          className={[
+            "flex min-h-0 flex-1 gap-0.5 overflow-hidden",
+            isDragSource ? "opacity-40" : muted ? "opacity-45" : "",
+            muted ? "grayscale" : "",
+          ].join(" ")}
+        >
           {previews.length === 0 ? (
-            <span className="flex flex-1 items-center justify-center text-[9px] text-zinc-500">
-              {/* Previews are direct MEDIA children only, so a collection of
-                  nothing but sub-collections has none — that is not "Empty"
-                  (count > 0). Reserve "Empty" for a truly childless collection. */}
-              {!hydrated ? "Open to load" : count === 0 ? "Empty" : "No media preview"}
-            </span>
+            <span
+              data-empty-collection-preview
+              aria-hidden="true"
+              className="flex flex-1 items-center justify-center"
+            />
           ) : (
             previews.map((preview, index) => (
               // eslint-disable-next-line @next/next/no-img-element
@@ -782,7 +839,7 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
                 // already-loaded frame. The slot is the stable identity, so the
                 // element persists and only its `src` swaps.
                 key={index}
-                src={preview.poster ?? preview.src}
+                src={collectionPreviewFrameUrl(preview)}
                 alt=""
                 draggable={false}
                 loading="lazy"
@@ -791,7 +848,13 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
             ))
           )}
         </span>
-        <span className="mt-1 flex items-center justify-between gap-1">
+        <span
+          data-collection-metadata
+          className={[
+            "mt-1.5 flex items-center justify-between gap-1.5 pl-1 pb-0.5",
+            muted ? "pr-[4.75rem]" : "pr-1",
+          ].join(" ")}
+        >
           <span
             onDoubleClick={(event) => {
               event.stopPropagation();
@@ -799,17 +862,24 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
               // (keyboard: F2 on the focused card — see OpenKeyBoundary)
             }}
             title="Double-click or press F2 to rename"
-            className="min-w-0 flex-1 cursor-text truncate text-[10px] font-semibold text-zinc-100"
+            className="min-w-0 flex-1 cursor-text truncate text-xs font-semibold text-zinc-100"
           >
             {displayName}
           </span>
-          <span className="flex shrink-0 items-center gap-1 font-mono text-[9px] text-zinc-400">
+          <span className="flex shrink-0 items-center gap-1 font-mono text-[11px] font-medium text-zinc-300">
             {typeof totalSeconds === "number" && totalSeconds > 0 ? (
-              <span className="text-sky-300/90" title="Total duration of contents">
-                {formatCollectionSeconds(totalSeconds)}
-              </span>
+              <>
+                <span className="text-sky-300/90" title="Total duration of contents">
+                  {formatCollectionSeconds(totalSeconds)}
+                </span>
+                <span aria-hidden="true" className="text-zinc-500">
+                  /
+                </span>
+              </>
             ) : null}
-            <span>{count}</span>
+            <span>
+              {count} {count === 1 ? "item" : "items"}
+            </span>
           </span>
         </span>
       </CollectionItem.SelectionSurface>
@@ -840,7 +910,7 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
             sub-timeline row's drill button. Both NAVIGATE; the sidebar's
             FolderTree toggles whether the children tree is shown, which is a
             different verb and no longer shares this icon. */}
-        <FolderInput className="h-[55%] w-[55%]" />
+        <CollectionFolderGlyph className="h-[55%] w-[55%]" />
       </button>
 
       {/* The rename editor — a REAL input, overlaying the label row while
@@ -851,7 +921,7 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
           onInput={rename.setDraft}
           onCommit={rename.commit}
           onCancel={rename.cancel}
-          className="absolute inset-x-1.5 bottom-1.5 z-20 rounded-sm bg-zinc-950/95 px-1 py-0.5 text-[10px] font-semibold text-zinc-100 outline-none ring-1 ring-amber-400/70"
+          className="absolute inset-x-2.5 bottom-2 z-20 rounded-sm bg-zinc-950/95 px-1 py-0.5 text-xs font-semibold text-zinc-100 outline-none ring-1 ring-amber-400/70"
         />
       )}
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
@@ -340,7 +340,7 @@ function acceptsNativeDrag(event: DragEvent<HTMLElement>): boolean {
  * they are shared unchanged: only turning a POINTER into an anchor (1-D for a
  * strip, 2-D for a grid) and drawing the indicator are surface-specific.
  */
-function useNativeDrop(collectionId: string) {
+function useNativeDrop(collectionId: string, projectId: string) {
   const store = useCollectionsStore();
   const { addNodes, insertTool } = useToolInsertion(collectionId);
   // Keyed BY DROP, not one shared slot. Several drops can be live at once
@@ -455,18 +455,31 @@ function useNativeDrop(collectionId: string) {
             const duration = probe?.durationSeconds ?? IMAGE_CLIP_SECONDS;
             let hosted: Awaited<ReturnType<typeof uploadTimelineMedia>>;
             try {
-              hosted = await uploadTimelineMedia(file.name, file, undefined, {
+              hosted = await uploadTimelineMedia(file.name, file, projectId, undefined, {
                 thumbnail: probe?.thumbnail ?? null,
                 signal,
               });
-            } catch {
-              return { node: null, detail: null, error: `"${file.name}" could not be uploaded.` };
+            } catch (error) {
+              const reason =
+                error instanceof Error
+                  ? error.message.replace(/^Media upload failed:\s*/i, "").trim()
+                  : "";
+              const detail = reason ? ` ${reason.slice(0, 220)}` : "";
+              return {
+                node: null,
+                detail: null,
+                error: `"${file.name}" could not be uploaded.${detail}`,
+              };
             }
             if (isVideo && !hosted.thumbnailUrl) {
               return { node: null, detail: null, error: `"${file.name}" has no video thumbnail.` };
             }
 
             const id = mintId(isVideo ? "video" : "image");
+            const sourceAsset =
+              hosted.providerId && hosted.assetId
+                ? { providerId: hosted.providerId, assetId: hosted.assetId }
+                : undefined;
             if (isVideo) {
               const node: CollectionItemNode = {
                 id: parseNodeId(id),
@@ -482,7 +495,13 @@ function useNativeDrop(collectionId: string) {
               };
               return {
                 node,
-                detail: { alt: file.name, aspect: 16 / 9, trackIndex: 0, poster: hosted.thumbnailUrl },
+                detail: {
+                  alt: file.name,
+                  aspect: 16 / 9,
+                  trackIndex: 0,
+                  poster: hosted.thumbnailUrl,
+                  ...(sourceAsset === undefined ? {} : { sourceAsset }),
+                },
                 error: null,
               };
             }
@@ -503,6 +522,7 @@ function useNativeDrop(collectionId: string) {
                 sourceDuration: IMAGE_CLIP_SECONDS,
                 trimIn: 0,
                 trimOut: 0,
+                ...(sourceAsset === undefined ? {} : { sourceAsset }),
               },
               error: null,
             };
@@ -565,7 +585,7 @@ function useNativeDrop(collectionId: string) {
         dropAbortsRef.current.delete(controller);
       }
     },
-    [addNodes, resolveAnchoredIndex, setDropStatus],
+    [addNodes, resolveAnchoredIndex, setDropStatus, projectId],
   );
 
   /** Commit a drop whose insert boundary the surface already resolved. Tools
@@ -616,10 +636,11 @@ function NativeDropStatus({ upload }: Readonly<{ upload: DropSummary | null }>) 
  */
 export function NativeDropStrip({
   collectionId,
+  projectId,
   children,
-}: Readonly<{ collectionId: string; children: ReactNode }>) {
+}: Readonly<{ collectionId: string; projectId: string; children: ReactNode }>) {
   const store = useCollectionsStore();
-  const { commitDrop, upload } = useNativeDrop(collectionId);
+  const { commitDrop, upload } = useNativeDrop(collectionId, projectId);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const [indicatorX, setIndicatorX] = useState<number | null>(null);
 
@@ -809,6 +830,7 @@ type GridCellGeometry = Readonly<{
 type GridDragGeometry = Readonly<{
   wrapperLeft: number;
   wrapperTop: number;
+  gap: number;
   cells: readonly GridCellGeometry[];
 }>;
 
@@ -825,10 +847,11 @@ type GridIndicator = Readonly<{ x: number; y: number; height: number }>;
  */
 export function NativeDropGrid({
   collectionId,
+  projectId,
   children,
-}: Readonly<{ collectionId: string; children: ReactNode }>) {
+}: Readonly<{ collectionId: string; projectId: string; children: ReactNode }>) {
   const store = useCollectionsStore();
-  const { commitDrop, upload } = useNativeDrop(collectionId);
+  const { commitDrop, upload } = useNativeDrop(collectionId, projectId);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const [indicator, setIndicator] = useState<GridIndicator | null>(null);
 
@@ -841,6 +864,11 @@ export function NativeDropGrid({
     const wrapper = wrapperRef.current;
     if (!wrapper) return null;
     const wrapperRect = wrapper.getBoundingClientRect();
+    const virtualRow = wrapper.querySelector<HTMLElement>("[data-virtual-row]");
+    const measuredGap = virtualRow
+      ? Number.parseFloat(window.getComputedStyle(virtualRow).columnGap)
+      : 0;
+    const gap = Number.isFinite(measuredGap) ? measuredGap : 0;
     const cells = [...wrapper.querySelectorAll<HTMLElement>("[data-node-id]")].map((cell) => {
       const rect = cell.getBoundingClientRect();
       return {
@@ -852,7 +880,7 @@ export function NativeDropGrid({
         midX: rect.left + rect.width / 2,
       };
     });
-    return { wrapperLeft: wrapperRect.left, wrapperTop: wrapperRect.top, cells };
+    return { wrapperLeft: wrapperRect.left, wrapperTop: wrapperRect.top, gap, cells };
   }, []);
 
   /** The mounted cell the insertion boundary sits BEFORE, or null to append. */
@@ -902,31 +930,33 @@ export function NativeDropGrid({
     }
     const { x: clientX, y: clientY } = pointerRef.current;
     const before = cellBeforeWhichPointerFalls(geometry, clientX, clientY);
-    // Where the bar draws. The boundary before a cell that STARTS a new row is
-    // the same insertion point as "after the previous row's last cell" — so
-    // when the pointer is actually on that previous row (dragged past its right
-    // end), draw at the previous cell's RIGHT edge instead of jumping to the
-    // far left of the next row, which read as the indicator landing in the
-    // wrong place. Otherwise: left edge of the cell the boundary precedes, or
-    // the right edge of the last cell when appending at the very end.
+    // Draw at the CENTER of the visual gap represented by the resolved
+    // boundary. The same `before` cell resolves the actual DropAnchor below,
+    // so the line cannot advertise one insertion point and commit another.
     const beforeIndex = before ? geometry.cells.indexOf(before) : -1;
     const previous = beforeIndex > 0 ? geometry.cells[beforeIndex - 1] : null;
     const boundaryStartsRow = before !== null && previous !== null && previous.top < before.top - 1;
     const anchorPreviousRowEnd = boundaryStartsRow && previous !== null && clientY <= previous.bottom;
+    const halfGap = geometry.gap / 2;
+    const halfIndicator = 1;
     let x: number;
     let y: number;
     let height: number;
     if (!before) {
       const last = geometry.cells[geometry.cells.length - 1];
-      x = last.right + 3 - geometry.wrapperLeft;
+      x = last.right + halfGap - halfIndicator - geometry.wrapperLeft;
       y = last.top - geometry.wrapperTop;
       height = last.bottom - last.top;
     } else if (anchorPreviousRowEnd && previous) {
-      x = previous.right + 3 - geometry.wrapperLeft;
+      x = previous.right + halfGap - halfIndicator - geometry.wrapperLeft;
       y = previous.top - geometry.wrapperTop;
       height = previous.bottom - previous.top;
+    } else if (previous && !boundaryStartsRow) {
+      x = (previous.right + before.left) / 2 - halfIndicator - geometry.wrapperLeft;
+      y = before.top - geometry.wrapperTop;
+      height = before.bottom - before.top;
     } else {
-      x = before.left - 3 - geometry.wrapperLeft;
+      x = before.left - halfGap - halfIndicator - geometry.wrapperLeft;
       y = before.top - geometry.wrapperTop;
       height = before.bottom - before.top;
     }

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -53,7 +53,10 @@ import {
 } from "./graph-playhead-model";
 
 export type { PreviewCardSpans } from "./graph-playhead-model";
-import { WorkbenchSplitPane } from "@storyboard/ui/timeline/viewport/workbench-display-surface";
+import {
+  WorkbenchDisplaySurface,
+  WorkbenchSplitPane,
+} from "@storyboard/ui/timeline/viewport/workbench-display-surface";
 import {
   TimelineDocumentsProvider,
   useTimelineDocuments,
@@ -1756,43 +1759,35 @@ export function PreviewShell({
     createTimelineDocumentsState({ ...graphDocumentsGateway.read() }, {}),
   );
 
-  // Toggling the preview off UNMOUNTS the split pane, losing its height. Held
-  // here (this component stays mounted) so reopening restores the height the
-  // user last chose. A ref, not state — restoring only needs it at mount, and
-  // the pane reports on every drag frame.
-  const surfaceHeightRef = useRef<number | undefined>(undefined);
-  const getInitialSurfaceHeight = useCallback(() => surfaceHeightRef.current, []);
-  const handleSurfaceHeightChange = useCallback((height: number) => {
-    surfaceHeightRef.current = height;
-  }, []);
-
   // The pane's own close button goes through the SAME window event as the
   // sidebar's toggle, so `previewOn` in graph-timeline-view stays the one
   // owner of the state. Only reachable while open, so toggle IS close.
   const handleClose = useCallback(() => requestGraphPreviewToggle(), []);
 
-  if (!enabled) return <>{children}</>;
-
   return (
     <TimelineDocumentsProvider initialState={initialDocumentsState}>
-      <GatewayDocumentsBridge />
+      {enabled ? <GatewayDocumentsBridge /> : null}
       {/* Test/debug witness for which read model the pane is playing. */}
-      <span data-preview-source={manifest !== null ? "manifest" : "projection"} hidden />
+      {enabled ? (
+        <span data-preview-source={manifest !== null ? "manifest" : "projection"} hidden />
+      ) : null}
       <WorkbenchSplitPane
-        // NOT keyed by focusedId any more. That remount existed only to force
-        // the player off the previous collection's frame; the surface now
-        // repaints when its clip list changes, so a drill-in keeps the canvas,
-        // the decoded media cache and the chosen height instead of tearing the
-        // pane down and flashing black — the most visible part of "clicking
-        // into a collection updates the whole screen".
-        clips={clips}
-        currentTime={time}
-        onCurrentTimeChange={handleTimeChange}
-        playing={playing}
-        onPlayingChange={channel.setPlaying}
-        getInitialSurfaceHeight={getInitialSurfaceHeight}
-        onSurfaceHeightChange={handleSurfaceHeightChange}
-        onClose={handleClose}
+        // The shell and lower pane stay mounted whether the surface is open or
+        // closed. That keeps the virtual strip DOM node—and therefore its
+        // horizontal scroll position—alive through the preview toggle.
+        surface={
+          enabled ? (
+            <WorkbenchDisplaySurface
+              clips={clips}
+              currentTime={time}
+              onCurrentTimeChange={handleTimeChange}
+              playing={playing}
+              onPlayingChange={channel.setPlaying}
+              onClose={handleClose}
+              className="h-full rounded-b-none border-b-0"
+            />
+          ) : null
+        }
       >
         {/* The playhead and scrub band live in `children`; they read these
             spans so their time↔x mapping is the pane's clock, not their own. */}

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -16,7 +16,12 @@ import {
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 
 import { useClipDetail, useGraphDetailsStore, useTimelineTitle } from "./graph-details-context";
-import { useCollectionPreviewFrames, useEnabledChildCount } from "./graph-item-content";
+import {
+  VideoFrameLookAhead,
+  useCollectionPreviewFrames,
+  useEnabledChildCount,
+} from "./graph-item-content";
+import { collectionPreviewFrameUrl } from "@/lib/video-frame-url";
 import { hydrateTimeline } from "./graph-hydration";
 import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
 import { NativeDropGrid, NativeDropStrip } from "./graph-native-drop";
@@ -37,6 +42,7 @@ import {
 import {
   GRID_GAP,
   GRID_UNCAPPED_HEIGHT,
+  GRAPH_STRIP_OVERSCAN_ITEMS,
   ITEM_SIZE_DIMENSIONS,
   MAX_SUBTREE_DEPTH,
   SUBTIMELINE_INDENT_PX,
@@ -83,6 +89,7 @@ function useCollectionChildIds(collectionId: NodeId): readonly NodeId[] {
  *  lazy-hydrate its clips then reveal its strip AND its own collection children
  *  as further-indented rows (recursively). */
 function SubTimelineNode({
+  projectId,
   collectionId,
   depth,
   surface,
@@ -92,6 +99,7 @@ function SubTimelineNode({
   rulerOn,
   timeChannel,
 }: Readonly<{
+  projectId: string;
   collectionId: NodeId;
   depth: number;
   surface: FocusSurface;
@@ -252,7 +260,7 @@ function SubTimelineNode({
             // eslint-disable-next-line @next/next/no-img-element
             <img
               key={index}
-              src={frame.poster ?? frame.src}
+              src={collectionPreviewFrameUrl(frame)}
               alt=""
               draggable={false}
               loading="lazy"
@@ -279,7 +287,7 @@ function SubTimelineNode({
             // cards keep every pointerdown and the in-grid line is a
             // passive indicator.
             <div className="relative min-w-0">
-              <NativeDropGrid collectionId={id}>
+              <NativeDropGrid collectionId={id} projectId={projectId}>
                 <VirtualGrid
                   collectionId={collectionId}
                   cellWidth={dims.gridWidth}
@@ -312,10 +320,12 @@ function SubTimelineNode({
               )}
             </div>
           ) : (
-            <NativeDropStrip collectionId={id}>
+            <VideoFrameLookAhead>
+              <NativeDropStrip collectionId={id} projectId={projectId}>
               <VirtualStrip
                 collectionId={collectionId}
                 pixelsPerSecond={pixelsPerSecond}
+                overscan={GRAPH_STRIP_OVERSCAN_ITEMS}
                 itemWidth={collectionCardWidth(pixelsPerSecond)}
                 itemHeight={dims.strip}
                 itemDragActivation="hold"
@@ -347,12 +357,14 @@ function SubTimelineNode({
                   ariaLabel={`Seek preview in ${name}`}
                 />
               )}
-            </NativeDropStrip>
+              </NativeDropStrip>
+            </VideoFrameLookAhead>
           )}
 
           {depth + 1 < MAX_SUBTREE_DEPTH &&
             childIds.map((childId) => (
               <SubTimelineNode
+                projectId={projectId}
                 key={childId as string}
                 collectionId={childId}
                 depth={depth + 1}
@@ -371,6 +383,7 @@ function SubTimelineNode({
 }
 
 export function SubTimelines({
+  projectId,
   focusedId,
   surface,
   itemSize,
@@ -379,6 +392,7 @@ export function SubTimelines({
   rulerOn,
   timeChannel,
 }: Readonly<{
+  projectId: string;
   focusedId: string;
   surface: FocusSurface;
   itemSize: ItemSize;
@@ -394,6 +408,7 @@ export function SubTimelines({
     <div className="flex min-w-0 flex-col gap-3">
       {childIds.map((collectionId) => (
         <SubTimelineNode
+          projectId={projectId}
           key={collectionId as string}
           collectionId={collectionId}
           depth={0}

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -57,6 +57,7 @@ import { bootSessionKey } from "./boot-session-key";
 import { trashDocumentId as deriveTrashDocumentId } from "./trash-document-id";
 
 import { GraphBoard, type FocusSurface, type ItemSize } from "./graph-board";
+import { GraphViewLoadingSkeleton } from "./graph-view-loading";
 import { GraphDetailsProvider } from "./graph-details-context";
 import { FlatClosureHydrator, HydrationController } from "./graph-hydration";
 import { GraphItemActionsBridge } from "./graph-item-actions";
@@ -505,13 +506,7 @@ export function GraphTimelineView({
   );
 
   if (boot.status === "loading") {
-    return (
-      <div className="grid gap-3" aria-label="Loading graph view">
-        <div className="h-8 w-1/2 animate-pulse rounded-lg bg-zinc-900" />
-        <div className="h-28 w-full animate-pulse rounded-lg bg-zinc-900" />
-        <div className="h-20 w-full animate-pulse rounded-lg bg-zinc-900/60" />
-      </div>
-    );
+    return <GraphViewLoadingSkeleton />;
   }
 
   if (boot.status === "error") {
@@ -528,13 +523,6 @@ export function GraphTimelineView({
       </div>
     );
   }
-
-  // The old "Storyboard view" chrome row above the preview is gone — the
-  // link lives in the board's overflow menu now, so the page starts at the
-  // preview itself.
-  const storyboardHref = `/timeline/${encodeURIComponent(projectId)}/storyboard${
-    focusedId === projectId ? "" : `/${encodeURIComponent(focusedId)}`
-  }`;
 
   return (
     <div className="flex flex-col gap-4">
@@ -591,7 +579,12 @@ export function GraphTimelineView({
             timeChannel={timeChannel}
           />
           <GraphDetailsJanitor />
-          <AssetPaletteDrawer open={assetsOpen} onClose={() => setAssetsOpen(false)} />
+          <AssetPaletteDrawer
+            key={projectId}
+            projectId={projectId}
+            open={assetsOpen}
+            onClose={() => setAssetsOpen(false)}
+          />
           <HydrationController
             projectId={projectId}
             segments={timelinePath}
@@ -626,6 +619,7 @@ export function GraphTimelineView({
               </div>
             ) : (
               <GraphBoard
+                projectId={projectId}
                 focusedId={focusedId}
                 breadcrumb={
                   <GraphBreadcrumb projectId={projectId} timelinePath={timelinePath} />
@@ -638,7 +632,6 @@ export function GraphTimelineView({
                 previewOn={previewOn}
                 rulerOn={rulerOn}
                 flatOn={flatOn}
-                storyboardHref={storyboardHref}
                 childrenShown={childrenShown}
                 timeChannel={timeChannel}
                 trashRootId={boot.trashRootId}

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
@@ -13,6 +13,7 @@ import {
 } from "@storyboard/ui/dnd-collections";
 
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
+import { cn } from "@/lib/utils";
 import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
 
 function useGraphPathTitles() {
@@ -32,6 +33,50 @@ function focusedIdOf(projectId: string, timelinePath: readonly string[]) {
 }
 
 type CrumbDropState = "idle" | "droppable" | "hovered";
+
+function EditableCrumbName({
+  crumbId,
+  label,
+}: Readonly<{
+  crumbId: string;
+  label: string;
+}>) {
+  const nodeName = useCollectionsSelector(
+    (snapshot) => snapshot.graph.nodesById.get(crumbId as NodeId)?.name,
+  );
+  const displayName = nodeName ?? label;
+  const rename = useInlineRename(crumbId as NodeId, displayName, "breadcrumb");
+
+  if (rename.editing) {
+    return (
+      <InlineNameEditor
+        initialValue={displayName}
+        ariaLabel={`Rename ${displayName}`}
+        onInput={rename.setDraft}
+        onCommit={rename.commit}
+        onCancel={rename.cancel}
+        className="h-7 min-w-0 w-full max-w-[250px] truncate rounded-md bg-zinc-800 px-1.5 font-semibold text-zinc-100 outline-none ring-1 ring-sky-500/60"
+      />
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      aria-label={`Rename ${displayName}`}
+      aria-current="page"
+      title={`Rename ${displayName}`}
+      onClick={rename.begin}
+      className={cn(
+        "min-w-0 max-w-[250px] shrink cursor-text truncate rounded-md px-1.5 py-1 text-left transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70",
+        "font-semibold text-zinc-100 hover:bg-zinc-800/70",
+      )}
+    >
+      {displayName}
+    </button>
+  );
+}
 
 /**
  * A breadcrumb crumb that DOUBLES AS a drop target while a card is dragged.
@@ -59,15 +104,24 @@ function AncestorCrumb({
       ? "hovered"
       : "droppable";
   });
-  const className =
-    state === "hovered"
-      ? "text-sky-200 underline decoration-sky-400 decoration-2 underline-offset-4"
-      : state === "droppable"
-        ? "text-zinc-300 underline decoration-dotted decoration-zinc-500 underline-offset-4"
-        : "text-zinc-400 transition-colors hover:text-white";
   return (
-    <span ref={setNodeRef} data-graph-ancestor-drop={crumbId}>
-      <Link href={href} className={className}>
+    <span
+      ref={setNodeRef}
+      data-graph-ancestor-drop={crumbId}
+      className="flex min-w-0 shrink-[2]"
+    >
+      <Link
+        href={href}
+        className={cn(
+          "block min-w-0 max-w-[180px] truncate rounded-md px-1.5 py-1 transition-colors",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70",
+          state === "hovered"
+            ? "text-sky-200 underline decoration-sky-400 decoration-2 underline-offset-4"
+            : state === "droppable"
+              ? "text-zinc-300 underline decoration-dotted decoration-zinc-500 underline-offset-4"
+              : "text-zinc-400 hover:bg-zinc-800/60 hover:text-zinc-100",
+        )}
+      >
         {label}
       </Link>
     </span>
@@ -99,7 +153,6 @@ export function GraphBreadcrumb({
     (snapshot) => snapshot.graph.nodesById.get(focusedId as NodeId)?.name,
   );
   const focusedTitle = documents[focusedId]?.title ?? focusedNodeName ?? focusedId;
-  const rename = useInlineRename(focusedId as NodeId, focusedTitle, "breadcrumb");
   const parentHref =
     timelinePath.length > 1
       ? `${base}/${timelinePath.slice(0, -1).map(encodeURIComponent).join("/")}`
@@ -108,7 +161,7 @@ export function GraphBreadcrumb({
         : "/";
 
   return (
-    <div className="flex min-w-0 items-center gap-3">
+    <div className="flex min-w-0 flex-1 items-center gap-3 overflow-hidden">
       <Link
         href={parentHref}
         className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-zinc-800 bg-zinc-950/50 text-zinc-400 transition-all hover:border-zinc-700 hover:bg-zinc-800 hover:text-zinc-100"
@@ -118,7 +171,7 @@ export function GraphBreadcrumb({
       </Link>
       <nav
         aria-label="Timeline focus path"
-        className="flex min-w-0 items-center gap-2 text-xs text-zinc-400 select-none"
+        className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden text-xs text-zinc-400 select-none"
       >
         {/* The project is the ROOT crumb, not a child of a "Projects / Graph"
             chrome path: the trail reads as the timeline tree the user is
@@ -131,11 +184,11 @@ export function GraphBreadcrumb({
               href={base}
               label={documents[projectId]?.title ?? projectId}
             />
-            <span>/</span>
+            <span aria-hidden="true" className="shrink-0">/</span>
           </>
         )}
         {timelinePath.slice(0, -1).map((segment, index) => (
-          <span key={segment} className="flex items-center gap-2">
+          <span key={segment} className="flex min-w-0 shrink-[2] items-center gap-2">
             <AncestorCrumb
               crumbId={segment}
               href={`${base}/${timelinePath
@@ -144,26 +197,10 @@ export function GraphBreadcrumb({
                 .join("/")}`}
               label={documents[segment]?.title ?? segment}
             />
-            <span>/</span>
+            <span aria-hidden="true" className="shrink-0">/</span>
           </span>
         ))}
-        {rename.editing ? (
-          <InlineNameEditor
-            initialValue={focusedTitle}
-            onInput={rename.setDraft}
-            onCommit={rename.commit}
-            onCancel={rename.cancel}
-            className="max-w-[250px] truncate rounded-sm bg-zinc-800 px-1 font-semibold text-zinc-100 outline-none ring-1 ring-sky-500/60"
-          />
-        ) : (
-          <span
-            onDoubleClick={rename.begin}
-            title="Double-click to rename"
-            className="max-w-[250px] cursor-text truncate font-semibold text-zinc-100"
-          >
-            {focusedTitle}
-          </span>
-        )}
+        <EditableCrumbName crumbId={focusedId} label={focusedTitle} />
       </nav>
     </div>
   );

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-config.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-config.ts
@@ -20,6 +20,15 @@ export const MAX_TIMELINE_PPS = 200;
 /** Opens a notch wider than the packing constant's 40 so clips breathe. */
 export const DEFAULT_TIMELINE_PPS = 50;
 
+/**
+ * Cards kept mounted beyond each horizontal edge of a graph strip.
+ *
+ * Video filmstrips discover their frame URLs only when their card mounts.
+ * Eight cards gives fast pans roughly a viewport of look-ahead at ordinary
+ * clip widths while keeping large timelines bounded by virtualization.
+ */
+export const GRAPH_STRIP_OVERSCAN_ITEMS = 8;
+
 /** Gap between grid cells — sized as the seek-rail BAND: the slim track
  *  centres inside it with clear space on both sides, so the rail (and its
  *  thumb) never touches the cards above or below. The strips reserve the

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-loading.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-loading.tsx
@@ -1,0 +1,27 @@
+import { Skeleton } from "@/components/core/skeleton";
+
+export function GraphViewLoadingSkeleton() {
+  return (
+    <div
+      aria-busy="true"
+      aria-label="Loading graph view"
+      className="grid gap-2"
+      data-graph-loading-skeleton=""
+    >
+      <div className="flex h-12 items-center justify-between gap-4 border-b border-zinc-800/70 py-3">
+        <Skeleton className="h-4 w-1/3 max-w-64" />
+        <Skeleton className="h-4 w-28" />
+        <Skeleton className="h-8 w-44" />
+      </div>
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+        {Array.from({ length: 8 }, (_, index) => (
+          <Skeleton
+            key={index}
+            data-graph-loading-card=""
+            className="aspect-video w-full rounded-lg"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -1,7 +1,27 @@
 "use client";
 
 import React, { useState, useEffect, useRef, useSyncExternalStore } from "react";
-import { Ban, CircleCheck, ClipboardPaste, Copy, CopyPlus, Folder, FolderTree, GalleryHorizontalEnd, Images, Layers, LayoutGrid, ListOrdered, LogOut, Ruler, Scissors, Settings, Trash2, TvMinimal, X } from "lucide-react";
+import {
+  Ban,
+  CircleCheck,
+  ClipboardPaste,
+  Copy,
+  CopyPlus,
+  EllipsisVertical,
+  Folder,
+  FolderTree,
+  GalleryHorizontalEnd,
+  Image as ImageIcon,
+  Layers,
+  LayoutGrid,
+  ListOrdered,
+  LogOut,
+  Ruler,
+  Scissors,
+  Trash2,
+  TvMinimal,
+  X,
+} from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { TrashDrawer } from "@/components/assets/trash-drawer";
@@ -27,44 +47,54 @@ import {
 import { graphClipboard } from "@/lib/graph-clipboard";
 import { toast } from "@/components/core/sonner";
 import { cn } from "@/lib/utils";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/core/dropdown-menu";
 
 import { SidebarTooltipLabel } from "./sidebar-tooltip-label";
 
 type UtilityItem = {
-  id: "assets" | "trash" | "settings";
+  id: "assets" | "trash";
   label: string;
   description: string;
   icon: React.ComponentType<{ className?: string }>;
 };
 
-/**
- * The trash BIN as this app means it: a folder (it holds timeline items, and
- * they come back) with a trash can sitting in its body. Lucide has no such
- * glyph, so it is composed — the folder at full size, the can scaled into the
- * pocket below the tab. Both strokes inherit `currentColor`, so every state
- * the button paints (idle, pressed, drop-hover) still styles one icon.
- *
- * `className` sizes the WRAPPER (the call site passes the same `h-4 w-4` every
- * other sidebar icon gets) and the parts size off it, so the composition can
- * never drift from the row.
- */
-function FolderTrashIcon({ className }: Readonly<{ className?: string }>) {
+/** A folder establishes this as an AREA, while the prominent inset trash
+ * glyph keeps it distinct from both an ordinary folder and the delete action. */
+function TrashAreaIcon({ className }: Readonly<{ className?: string }>) {
   return (
     <span
       aria-hidden="true"
-      // The animated element: the sidebar hands its drop-hover / arrival
-      // classes to THIS wrapper (both glyphs move together), so it is also
-      // what the e2e watches.
+      // The sidebar hands its drop-hover / arrival classes to this wrapper,
+      // which is also what the e2e watches.
       data-sidebar-icon="trash"
-      className={cn("relative inline-block shrink-0", className)}
+      className={cn("relative inline-flex shrink-0 overflow-visible", className)}
     >
-      <Folder className="h-full w-full" />
-      {/* Nudged below the folder's tab so the can reads as sitting INSIDE the
-          pocket; the heavier stroke keeps it legible at 16px. */}
-      <Trash2
-        className="absolute left-1/2 top-[58%] h-[52%] w-[52%] -translate-x-1/2 -translate-y-1/2"
-        strokeWidth={2.75}
-      />
+      <Folder className="h-full w-full" strokeWidth={2.1} />
+      <span className="absolute -top-1 -right-1 flex size-3.5 items-center justify-center rounded-full bg-zinc-950 ring-1 ring-zinc-600">
+        <Trash2 className="size-2.5" strokeWidth={2.7} />
+      </span>
+    </span>
+  );
+}
+
+/** Media lives in a folder, but its image badge prevents the destination from
+ * reading like the collection/tree controls elsewhere in the rail. */
+function MediaFolderIcon({ className }: Readonly<{ className?: string }>) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn("relative inline-flex shrink-0 overflow-visible", className)}
+    >
+      <Folder className="h-full w-full" strokeWidth={2.1} />
+      <span className="absolute -top-1 -right-1 flex size-3.5 items-center justify-center rounded-full bg-zinc-950 ring-1 ring-zinc-600">
+        <ImageIcon className="size-2.5" strokeWidth={2.5} />
+      </span>
     </span>
   );
 }
@@ -75,6 +105,20 @@ const SIDEBAR_ICON_IDLE =
   "border-zinc-800 bg-zinc-900/40 text-zinc-400 hover:border-zinc-600 hover:bg-zinc-800/80 hover:text-zinc-100";
 const SIDEBAR_ICON_PRESSED =
   "translate-y-px border-zinc-600 bg-zinc-800 text-zinc-100 shadow-inner shadow-black/50 ring-1 ring-inset ring-zinc-700/70";
+const SIDEBAR_SEPARATOR_CLASS = "h-px w-7 shrink-0";
+
+function SidebarSeparator({ selected = false }: Readonly<{ selected?: boolean }>) {
+  return (
+    <div
+      aria-hidden="true"
+      data-sidebar-separator={selected ? "selected" : "normal"}
+      className={cn(
+        SIDEBAR_SEPARATOR_CLASS,
+        selected ? "bg-amber-300/65" : "bg-zinc-500",
+      )}
+    />
+  );
+}
 
 type SurfaceIconControlProps = {
   surface: GraphSurface;
@@ -133,23 +177,16 @@ function SurfaceIconControl({
   );
 }
 
-// Recessed, not invisible. This used to dim TWICE — a zinc-600 glyph and then
-// `opacity-50` over it — which on the near-black rail left the Paste icon
-// (item mode's resting state, disabled until something is copied) barely
-// legible. One dimming step is enough: a solid zinc-500 glyph reads as
-// available-but-not-now, and the flat border plus the missing hover response
-// carry "disabled" on their own.
+// Recessed, not invisible. One dimming step is enough: a solid zinc-500 glyph
+// reads as available-but-not-now, and the flat border plus the missing hover
+// response carry "disabled" on their own.
 const SIDEBAR_ICON_DISABLED =
   "cursor-not-allowed border-zinc-800/70 bg-zinc-900/20 text-zinc-500";
 
-// Item mode borrows the SELECTION colour. A selected card is ring-2
-// ring-amber-400 (graph-item-content), and these buttons act on that card, so
-// they carry the same amber — but only in the FILL. Bordering them in amber
-// too was too loud next to the card it is meant to refer to; the tint alone
-// carries the connection. Disabled buttons stay ZINC: an amber-tinted
-// disabled button reads as available, and Paste is disabled most of the time.
+// Item mode borrows a restrained trace of the selection colour. These actions
+// relate to the selected card, but should remain secondary to the content.
 const SIDEBAR_ICON_ITEM_IDLE =
-  "border-zinc-800 bg-amber-400/10 text-amber-200/80 hover:border-zinc-600 hover:bg-amber-400/20 hover:text-amber-100";
+  "border-zinc-800 bg-amber-200/[0.035] text-amber-100/60 hover:border-zinc-600 hover:bg-amber-200/[0.075] hover:text-amber-100/85";
 
 /** One button in the item-actions cluster — dispatches its action across the
  *  window-event seam for the graph provider to perform on the selection. */
@@ -194,12 +231,72 @@ function ItemActionButton({
   );
 }
 
+function ItemActionsOverflow({
+  hasSelection,
+  busy,
+  allDisabled,
+}: Readonly<{
+  hasSelection: boolean;
+  busy: boolean;
+  allDisabled: boolean;
+}>) {
+  const disabled = busy || !hasSelection;
+  const tooltipId = "sidebar-tooltip-item-more";
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label="More item actions"
+          aria-describedby={tooltipId}
+          disabled={disabled}
+          className={cn(
+            SIDEBAR_ICON_BASE,
+            disabled ? SIDEBAR_ICON_DISABLED : SIDEBAR_ICON_ITEM_IDLE,
+          )}
+        >
+          <EllipsisVertical className="h-4 w-4 transition-colors" />
+          <SidebarTooltipLabel
+            id={tooltipId}
+            label="More"
+            description="More actions for the selected item"
+          />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent side="right" align="start">
+        <DropdownMenuGroup>
+          <DropdownMenuItem
+            disabled={disabled}
+            onSelect={() => requestGraphItemAction("duplicate")}
+          >
+            <CopyPlus className="mr-2 h-4 w-4" />
+            Duplicate
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            disabled={disabled}
+            onSelect={() => requestGraphItemAction("toggle-disabled")}
+          >
+            {allDisabled ? (
+              <CircleCheck className="mr-2 h-4 w-4" />
+            ) : (
+              <Ban className="mr-2 h-4 w-4" />
+            )}
+            {allDisabled ? "Enable" : "Disable"}
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 /**
  * The contextual cluster shown while an item is selected (or something is on
  * the clipboard). Replaces the layout/toggle controls with actions on the
- * selected item. Copy/Cut/Duplicate/Delete need a live selection; Paste needs
- * a non-empty clipboard; Done exits back to the normal controls (clearing the
- * clipboard — with contents kept, item mode couldn't close). While an async
+ * selected item. Copy/Cut are replaced by Paste while the clipboard is armed;
+ * Duplicate/Delete need a live selection. Done exits back to the normal
+ * controls (clearing the clipboard — with contents kept, item mode couldn't
+ * close). While an async
  * action is in flight (`busy`) every button disables, so nothing double-fires.
  */
 function ItemActionsCluster({
@@ -216,43 +313,42 @@ function ItemActionsCluster({
 }>) {
   return (
     <div className="flex flex-col items-center gap-2">
-      {/* Only the five actions that touch the SELECTION sit inside the amber
+      {/* Only actions that operate on the selection or clipboard sit inside the amber
           block — a wash, no border, so the group reads as one thing tied to
           the selected card without drawing a box around itself. Done is
           deliberately outside it: it exits the mode, it does nothing to the
           card, and it keeps the sidebar's ordinary zinc. */}
       <div
         data-item-actions-cluster
-        className="flex flex-col items-center gap-2 rounded-xl bg-amber-400/[0.07] px-1.5 py-2"
+        className="flex flex-col items-center gap-2 rounded-xl bg-amber-200/[0.025] px-1.5 py-2"
       >
-        <ItemActionButton
-          action="copy"
-          icon={Copy}
-          label="Copy"
-          description="Copy the selected item"
-          disabled={busy || !hasSelection}
-        />
-        <ItemActionButton
-          action="cut"
-          icon={Scissors}
-          label="Cut"
-          description="Cut the selected item — paste to move it"
-          disabled={busy || !hasSelection}
-        />
-        <ItemActionButton
-          action="paste"
-          icon={ClipboardPaste}
-          label="Paste"
-          description="Paste into this timeline"
-          disabled={busy || !canPaste}
-        />
-        <ItemActionButton
-          action="duplicate"
-          icon={CopyPlus}
-          label="Duplicate"
-          description="Duplicate the selected item in place"
-          disabled={busy || !hasSelection}
-        />
+        {!canPaste ? (
+          <>
+            <ItemActionButton
+              action="copy"
+              icon={Copy}
+              label="Copy"
+              description="Copy the selected item"
+              disabled={busy || !hasSelection}
+            />
+            <ItemActionButton
+              action="cut"
+              icon={Scissors}
+              label="Cut"
+              description="Cut the selected item — paste to move it"
+              disabled={busy || !hasSelection}
+            />
+          </>
+        ) : null}
+        {canPaste ? (
+          <ItemActionButton
+            action="paste"
+            icon={ClipboardPaste}
+            label="Paste"
+            description="Paste into this timeline"
+            disabled={busy}
+          />
+        ) : null}
         <ItemActionButton
           action="delete"
           icon={Trash2}
@@ -260,22 +356,13 @@ function ItemActionsCluster({
           description="Move the selected item to trash"
           disabled={busy || !hasSelection}
         />
-        {/* The button shows the icon of the ACTION it performs, so it reads
-            Ban ("disable this") until everything selected is already
-            disabled, then offers the way back. */}
-        <ItemActionButton
-          action="toggle-disabled"
-          icon={allDisabled ? CircleCheck : Ban}
-          label={allDisabled ? "Enable" : "Disable"}
-          description={
-            allDisabled
-              ? "Play this item again, and count it in the totals"
-              : "Skip this item in playback, counts and time totals"
-          }
-          disabled={busy || !hasSelection}
+        <ItemActionsOverflow
+          hasSelection={hasSelection}
+          busy={busy}
+          allDisabled={allDisabled}
         />
       </div>
-      <div className="h-px w-8 shrink-0 bg-zinc-700" />
+      <SidebarSeparator selected />
       <ItemActionButton
         action="cancel"
         icon={X}
@@ -293,19 +380,13 @@ const UTILITY_ITEMS: UtilityItem[] = [
     id: "assets",
     label: "Assets",
     description: "Media and project assets",
-    icon: Images,
+    icon: MediaFolderIcon,
   },
   {
     id: "trash",
     label: "Trash",
     description: "Deleted timeline items",
-    icon: FolderTrashIcon,
-  },
-  {
-    id: "settings",
-    label: "Settings",
-    description: "App-wide settings",
-    icon: Settings,
+    icon: TrashAreaIcon,
   },
 ];
 
@@ -502,7 +583,7 @@ export function TimelineSidebar() {
       {activeProjectId && !itemMode && (
         <>
           {/* zinc-500: the old zinc-800/80 vanished against the rail. */}
-          <div className="h-px w-10 shrink-0 bg-zinc-500" />
+          <SidebarSeparator />
 
           <div className="flex flex-col items-center gap-2">
             {/* The preview-pane toggle leads the cluster (was the breadcrumb
@@ -628,6 +709,7 @@ export function TimelineSidebar() {
           // asset into — it could browse and do nothing. Rather than leave a
           // button that opens nothing, it is hidden off the graph.
           if (item.id === "assets" && !onGraphRoute) return null;
+          if (item.id === "trash" && pathname === "/") return null;
 
           const Icon = item.icon;
           const tooltipId = `sidebar-tooltip-utility-${item.id}`;
@@ -640,13 +722,7 @@ export function TimelineSidebar() {
                   window.dispatchEvent(new CustomEvent(GRAPH_ASSETS_TOGGLE_EVENT));
                   setIsTrashOpen(false);
                 }
-              : item.id === "trash"
-                ? () => setIsTrashOpen(!isTrashOpen)
-                : // Placeholder until real settings exist.
-                  () =>
-                    toast("Settings", {
-                      description: "App-wide settings aren’t wired up yet.",
-                    });
+              : () => setIsTrashOpen(!isTrashOpen);
 
           return (
             <button
@@ -654,7 +730,7 @@ export function TimelineSidebar() {
               type="button"
               aria-label={item.label}
               aria-describedby={tooltipId}
-              aria-pressed={item.id === "settings" ? undefined : isPressed}
+              aria-pressed={isPressed}
               onClick={handleClick}
               className={cn(
                 SIDEBAR_ICON_BASE,

--- a/apps/timeline-gstudio001/lib/assets/cloudinary-provider.test.ts
+++ b/apps/timeline-gstudio001/lib/assets/cloudinary-provider.test.ts
@@ -7,11 +7,13 @@ import type { CloudinaryAsset } from "@/lib/cloudinary-media-store";
 const state = vi.hoisted(() => ({
   vendorAssets: [] as CloudinaryAsset[],
   listedForUid: null as string | null,
+  listedForProject: null as string | null,
 }));
 
 vi.mock("@/lib/cloudinary-media-store", () => ({
-  listCloudinaryAssets: async (uid: string) => {
+  listCloudinaryAssets: async (uid: string, projectId: string) => {
     state.listedForUid = uid;
+    state.listedForProject = projectId;
     return state.vendorAssets;
   },
 }));
@@ -37,6 +39,7 @@ function vendorAsset(overrides: Partial<CloudinaryAsset>): CloudinaryAsset {
 beforeEach(() => {
   state.vendorAssets = [];
   state.listedForUid = null;
+  state.listedForProject = null;
 });
 
 describe("cloudinaryAssetToAsset", () => {
@@ -49,10 +52,12 @@ describe("cloudinaryAssetToAsset", () => {
         size: 12345,
         createdAt: "2026-07-01T00:00:00Z",
       }),
+      "project-a",
     );
     expect(mapped).toEqual({
       id: "gstudio/user-1/pic-123",
       providerId: CLOUDINARY_PROVIDER_ID,
+      projectIds: ["project-a"],
       name: "beach-178.png",
       kind: "image",
       src: "https://res.cloudinary.test/image/upload/gstudio/user-1/pic-123.png",
@@ -67,13 +72,17 @@ describe("cloudinaryAssetToAsset", () => {
   });
 
   it("keeps the vendor id verbatim — it IS what sourceAsset.assetId records", () => {
-    const mapped = cloudinaryAssetToAsset(vendorAsset({ id: "gstudio/u/deep/path/name-1" }));
+    const mapped = cloudinaryAssetToAsset(
+      vendorAsset({ id: "gstudio/u/deep/path/name-1" }),
+      "project-a",
+    );
     expect(mapped.id).toBe("gstudio/u/deep/path/name-1");
   });
 
   it("maps a video's duration to durationSeconds", () => {
     const mapped = cloudinaryAssetToAsset(
       vendorAsset({ resourceType: "video", duration: 12.4, relativePath: "clip.mp4" }),
+      "project-a",
     );
     expect(mapped.kind).toBe("video");
     expect(mapped.durationSeconds).toBe(12.4);
@@ -83,6 +92,7 @@ describe("cloudinaryAssetToAsset", () => {
   it("falls back to the pathname when relativePath is absent", () => {
     const mapped = cloudinaryAssetToAsset(
       vendorAsset({ relativePath: undefined, pathname: "gstudio/user-1/pic-123" }),
+      "project-a",
     );
     expect(mapped.name).toBe("pic-123");
   });
@@ -95,12 +105,20 @@ describe("cloudinaryAssetProvider.list", () => {
       vendorAsset({ id: "b", relativePath: "Scenes/b.png" }),
       vendorAsset({ id: "c", relativePath: "Scenes/Heist/c.png" }),
     ];
-    const flat = await cloudinaryAssetProvider.list({ uid: "user-1" }, {});
+    const flat = await cloudinaryAssetProvider.list(
+      { uid: "user-1", projectId: "project-a" },
+      {},
+    );
     expect(state.listedForUid).toBe("user-1");
+    expect(state.listedForProject).toBe("project-a");
+    expect(flat.assets.every((entry) => entry.projectIds[0] === "project-a")).toBe(true);
     expect(flat.assets.map((entry) => entry.id)).toEqual(["a", "b", "c"]);
     expect(flat.folders.map((folder) => folder.name)).toEqual(["Scenes"]);
 
-    const scenes = await cloudinaryAssetProvider.list({ uid: "user-1" }, { folder: ["Scenes"] });
+    const scenes = await cloudinaryAssetProvider.list(
+      { uid: "user-1", projectId: "project-a" },
+      { folder: ["Scenes"] },
+    );
     expect(scenes.assets.map((entry) => entry.id)).toEqual(["b"]);
     expect(scenes.folders).toEqual([{ name: "Heist", path: ["Scenes", "Heist"] }]);
   });
@@ -122,7 +140,10 @@ describe("cloudinaryAssetProvider.list", () => {
       vendorAsset({ id: "plain", relativePath: "plain.png" }),
       vendorAsset({ id: "tagged", relativePath: "Scenes/t.png", tags: ["scene/heist"] }),
     ];
-    const root = await cloudinaryAssetProvider.list({ uid: "user-1" }, { tagPath: [] });
+    const root = await cloudinaryAssetProvider.list(
+      { uid: "user-1", projectId: "project-a" },
+      { tagPath: [] },
+    );
     // Tag space ignores folders entirely: the untagged asset sits at the tags
     // root even though it also sits at the folder root, and the tagged one is
     // reachable only through its tag group.
@@ -130,7 +151,7 @@ describe("cloudinaryAssetProvider.list", () => {
     expect(root.folders).toEqual([{ name: "scene", path: ["scene"] }]);
 
     const heist = await cloudinaryAssetProvider.list(
-      { uid: "user-1" },
+      { uid: "user-1", projectId: "project-a" },
       { tagPath: ["scene", "heist"] },
     );
     expect(heist.assets.map((entry) => entry.id)).toEqual(["tagged"]);

--- a/apps/timeline-gstudio001/lib/assets/cloudinary-provider.ts
+++ b/apps/timeline-gstudio001/lib/assets/cloudinary-provider.ts
@@ -19,12 +19,16 @@ export const CLOUDINARY_PROVIDER_ID = "cloudinary";
  * root prefix stripped by the store), so folders are the folders the USER
  * sees, not the storage-internal `<root>/<uid>/` plumbing.
  */
-export function cloudinaryAssetToAsset(vendorAsset: CloudinaryAsset): Asset {
+export function cloudinaryAssetToAsset(
+  vendorAsset: CloudinaryAsset,
+  projectId: string,
+): Asset {
   const relative = vendorAsset.relativePath ?? vendorAsset.pathname;
   const segments = relative.split("/").filter((segment) => segment.length > 0);
   return {
     id: vendorAsset.id,
     providerId: CLOUDINARY_PROVIDER_ID,
+    projectIds: [projectId],
     name: segments[segments.length - 1] ?? relative,
     kind: vendorAsset.resourceType,
     src: vendorAsset.url,
@@ -37,6 +41,14 @@ export function cloudinaryAssetToAsset(vendorAsset: CloudinaryAsset): Asset {
     ...(vendorAsset.size === undefined ? {} : { bytes: vendorAsset.size }),
     ...(vendorAsset.createdAt === undefined ? {} : { createdAt: vendorAsset.createdAt }),
   };
+}
+
+export async function listCloudinaryProjectAssets(
+  ctx: AssetContext,
+): Promise<readonly Asset[]> {
+  return (await listCloudinaryAssets(ctx.uid, ctx.projectId)).map((asset) =>
+    cloudinaryAssetToAsset(asset, ctx.projectId),
+  );
 }
 
 export const cloudinaryAssetProvider: AssetProvider = {
@@ -55,11 +67,11 @@ export const cloudinaryAssetProvider: AssetProvider = {
     delete: false,
   },
   async list(ctx: AssetContext, query) {
-    // The store's listing is already user-scoped and paginated at the vendor
+    // The store's listing is already user/project-scoped and paginated at the vendor
     // boundary; folder/tag scoping is derived from it in memory (the
     // documented fallback in path-folders — a native `prefix`/tag query is
     // the upgrade path if libraries outgrow it).
-    const assets = (await listCloudinaryAssets(ctx.uid)).map(cloudinaryAssetToAsset);
+    const assets = await listCloudinaryProjectAssets(ctx);
     // Search wins over both browse modes: a query spans the whole library, so
     // scoping it to the folder or tag the user happened to be standing in
     // would hide the results they asked for.

--- a/apps/timeline-gstudio001/lib/assets/path-folders.test.ts
+++ b/apps/timeline-gstudio001/lib/assets/path-folders.test.ts
@@ -7,6 +7,7 @@ function asset(id: string, folderPath: string[], tags: string[] = []): Asset {
   return {
     id,
     providerId: "test",
+    projectIds: ["project-test"],
     name: id,
     kind: "image",
     src: `https://cdn.test/${id}`,

--- a/apps/timeline-gstudio001/lib/assets/provider.ts
+++ b/apps/timeline-gstudio001/lib/assets/provider.ts
@@ -13,7 +13,7 @@ import type {
 /** Per-request context. Today just the signed-in user; per-user OAuth
  *  credentials (Drive/Dropbox) will arrive here when that track lands, which
  *  is why every provider method takes it rather than reading globals. */
-export type AssetContext = Readonly<{ uid: string }>;
+export type AssetContext = Readonly<{ uid: string; projectId: string }>;
 
 export type AssetProvider = AssetProviderDescriptor &
   Readonly<{

--- a/apps/timeline-gstudio001/lib/assets/s3-provider.test.ts
+++ b/apps/timeline-gstudio001/lib/assets/s3-provider.test.ts
@@ -60,22 +60,28 @@ describe("createS3AssetProvider", () => {
 
   it("maps object keys to neutral assets, folders from the key path", async () => {
     const s3 = provider([
-      { key: "media/root.png", size: 10, lastModified: "2026-07-01T00:00:00Z" },
-      { key: "media/Scenes/a.jpg" },
-      { key: "media/Scenes/Heist/b.png" },
+      {
+        key: "media/u/project-a/root.png",
+        size: 10,
+        lastModified: "2026-07-01T00:00:00Z",
+      },
+      { key: "media/u/project-a/Scenes/a.jpg" },
+      { key: "media/u/project-a/Scenes/Heist/b.png" },
+      { key: "media/u/project-b/other.png" },
     ]);
-    const flat = await s3.list({ uid: "u" }, {});
+    const flat = await s3.list({ uid: "u", projectId: "project-a" }, {});
     expect(flat.assets.map((entry) => entry.id)).toEqual([
-      "media/root.png",
-      "media/Scenes/a.jpg",
-      "media/Scenes/Heist/b.png",
+      "media/u/project-a/root.png",
+      "media/u/project-a/Scenes/a.jpg",
+      "media/u/project-a/Scenes/Heist/b.png",
     ]);
     expect(flat.assets[0]).toMatchObject({
       providerId: S3_PROVIDER_ID,
+      projectIds: ["project-a"],
       name: "root.png",
       kind: "image",
-      src: "https://cdn.test/media/root.png",
-      thumbnailUrl: "https://cdn.test/media/root.png",
+      src: "https://cdn.test/media/u/project-a/root.png",
+      thumbnailUrl: "https://cdn.test/media/u/project-a/root.png",
       folderPath: [], // the configured prefix is stripped — user-visible tree
       bytes: 10,
       createdAt: "2026-07-01T00:00:00Z",
@@ -85,38 +91,51 @@ describe("createS3AssetProvider", () => {
 
   it("scopes a folder query exactly like the Cloudinary adapter (shared derivation)", async () => {
     const s3 = provider([
-      { key: "media/root.png" },
-      { key: "media/Scenes/a.jpg" },
-      { key: "media/Scenes/Heist/b.png" },
+      { key: "media/u/project-a/root.png" },
+      { key: "media/u/project-a/Scenes/a.jpg" },
+      { key: "media/u/project-a/Scenes/Heist/b.png" },
     ]);
-    const scenes = await s3.list({ uid: "u" }, { folder: ["Scenes"] });
-    expect(scenes.assets.map((entry) => entry.id)).toEqual(["media/Scenes/a.jpg"]);
+    const scenes = await s3.list(
+      { uid: "u", projectId: "project-a" },
+      { folder: ["Scenes"] },
+    );
+    expect(scenes.assets.map((entry) => entry.id)).toEqual([
+      "media/u/project-a/Scenes/a.jpg",
+    ]);
     expect(scenes.folders).toEqual([{ name: "Heist", path: ["Scenes", "Heist"] }]);
   });
 
   it("skips non-media keys instead of surfacing broken tiles", async () => {
     const s3 = provider([
-      { key: "media/a.png" },
-      { key: "media/notes.txt" },
-      { key: "media/manifest.json" },
-      { key: "media/subdir/" }, // S3 directory marker
+      { key: "media/u/project-a/a.png" },
+      { key: "media/u/project-a/notes.txt" },
+      { key: "media/u/project-a/manifest.json" },
+      { key: "media/u/project-a/subdir/" }, // S3 directory marker
     ]);
-    expect((await s3.list({ uid: "u" }, {})).assets.map((entry) => entry.id)).toEqual([
-      "media/a.png",
-    ]);
+    expect(
+      (
+        await s3.list({ uid: "u", projectId: "project-a" }, {})
+      ).assets.map((entry) => entry.id),
+    ).toEqual(["media/u/project-a/a.png"]);
   });
 
   it("uses a sibling image as a video's poster, and an empty thumb when none", async () => {
     const s3 = provider([
-      { key: "media/clip.mp4" },
-      { key: "media/clip.jpg" },
-      { key: "media/lonely.mp4" },
+      { key: "media/u/project-a/clip.mp4" },
+      { key: "media/u/project-a/clip.jpg" },
+      { key: "media/u/project-a/lonely.mp4" },
     ]);
-    const assets = (await s3.list({ uid: "u" }, {})).assets;
-    const withPoster = assets.find((entry) => entry.id === "media/clip.mp4");
-    const noPoster = assets.find((entry) => entry.id === "media/lonely.mp4");
-    expect(withPoster?.thumbnailUrl).toBe("https://cdn.test/media/clip.jpg");
-    expect(withPoster?.src).toBe("https://cdn.test/media/clip.mp4");
+    const assets = (await s3.list({ uid: "u", projectId: "project-a" }, {})).assets;
+    const withPoster = assets.find(
+      (entry) => entry.id === "media/u/project-a/clip.mp4",
+    );
+    const noPoster = assets.find(
+      (entry) => entry.id === "media/u/project-a/lonely.mp4",
+    );
+    expect(withPoster?.thumbnailUrl).toBe(
+      "https://cdn.test/media/u/project-a/clip.jpg",
+    );
+    expect(withPoster?.src).toBe("https://cdn.test/media/u/project-a/clip.mp4");
     expect(noPoster?.thumbnailUrl).toBe("");
   });
 
@@ -132,7 +151,10 @@ describe("createS3AssetProvider", () => {
       delete: false,
     });
     // A stray tagPath is ignored (contract: never throw), served as folders.
-    const page = await s3.list({ uid: "u" }, { tagPath: ["anything"] });
+    const page = await s3.list(
+      { uid: "u", projectId: "project-a" },
+      { tagPath: ["anything"] },
+    );
     expect(page.assets).toEqual([]);
   });
 
@@ -141,14 +163,20 @@ describe("createS3AssetProvider", () => {
   });
 
   it("caches the listing within its TTL — one sweep serves several browses", async () => {
-    const listObjects = vi.fn(async () => [{ key: "media/a.png" }] as S3ObjectSummary[]);
+    const listObjects = vi.fn(
+      async () =>
+        [
+          { key: "media/u/project-a/a.png" },
+          { key: "media/u/project-b/b.png" },
+        ] as S3ObjectSummary[],
+    );
     const created = createS3AssetProvider(ENV, {
       listObjects,
       urlFor: async (key) => `https://cdn.test/${key}`,
     });
     if (created === null) throw new Error("expected provider");
-    await created.list({ uid: "u" }, {});
-    await created.list({ uid: "u" }, { folder: ["x"] });
+    await created.list({ uid: "u", projectId: "project-a" }, {});
+    await created.list({ uid: "u", projectId: "project-b" }, { folder: ["x"] });
     expect(listObjects).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/timeline-gstudio001/lib/assets/s3-provider.ts
+++ b/apps/timeline-gstudio001/lib/assets/s3-provider.ts
@@ -13,10 +13,8 @@
 //                          presigned GETs (private buckets work untouched)
 // Credentials ride the SDK's default chain (AWS_ACCESS_KEY_ID / role / …).
 //
-// The bucket is APP-level, not per-user (unlike Cloudinary's per-uid
-// folder): listing still requires a session, but every signed-in user sees
-// the same bucket. Fine for a personal deployment; revisit if this app ever
-// becomes multi-tenant.
+// Objects are listed from the configured bucket but exposed only beneath
+// `<prefix>/<uid>/<projectId>/`, matching the Cloudinary ownership boundary.
 
 import { pageFromFlatListing, pageFromSearch } from "./path-folders";
 import type { AssetProvider } from "./provider";
@@ -89,7 +87,8 @@ const LISTING_TTL_MS = 30_000;
 
 async function mapObjects(
   objects: readonly S3ObjectSummary[],
-  config: S3Config,
+  scopePrefix: string,
+  projectId: string,
   urlFor: (key: string) => Promise<string>,
 ): Promise<Asset[]> {
   // Key set for the sibling-poster lookup, before any filtering: the poster
@@ -102,8 +101,8 @@ async function mapObjects(
     // Not renderable media (manifests, sidecar files, "directory" markers) —
     // skipped rather than surfaced as broken tiles.
     if (kind === null) continue;
-    if (!object.key.startsWith(config.prefix)) continue;
-    const relative = object.key.slice(config.prefix.length);
+    if (!object.key.startsWith(scopePrefix)) continue;
+    const relative = object.key.slice(scopePrefix.length);
     const segments = relative.split("/").filter((segment) => segment.length > 0);
     if (segments.length === 0) continue;
 
@@ -120,6 +119,7 @@ async function mapObjects(
     assets.push({
       id: object.key,
       providerId: S3_PROVIDER_ID,
+      projectIds: [projectId],
       name: segments[segments.length - 1],
       kind,
       src,
@@ -225,16 +225,16 @@ export function createS3AssetProvider(
   if (config === null) return null;
   const deps = depsOverride ?? createSdkDeps(config);
 
-  let cached: { at: number; assets: Promise<Asset[]> } | null = null;
+  let cached: { at: number; objects: Promise<readonly S3ObjectSummary[]> } | null = null;
   const listing = () => {
-    if (cached !== null && Date.now() - cached.at < LISTING_TTL_MS) return cached.assets;
-    const assets = deps.listObjects().then((objects) => mapObjects(objects, config, deps.urlFor));
+    if (cached !== null && Date.now() - cached.at < LISTING_TTL_MS) return cached.objects;
+    const objects = deps.listObjects();
     // A failed sweep must not poison the cache window with a rejection.
-    assets.catch(() => {
+    objects.catch(() => {
       cached = null;
     });
-    cached = { at: Date.now(), assets };
-    return assets;
+    cached = { at: Date.now(), objects };
+    return objects;
   };
 
   return {
@@ -253,8 +253,15 @@ export function createS3AssetProvider(
       upload: false,
       delete: false,
     },
-    async list(_ctx, query) {
-      const assets = await listing();
+    async list(ctx, query) {
+      const objects = await listing();
+      const scopePrefix = `${config.prefix}${ctx.uid}/${ctx.projectId}/`;
+      const assets = await mapObjects(
+        objects,
+        scopePrefix,
+        ctx.projectId,
+        deps.urlFor,
+      );
       // Search outranks browsing: a query spans the whole library, so scoping
       // it to the folder the user was standing in would hide the hits.
       if (query.search !== undefined && query.search.trim().length > 0) {

--- a/apps/timeline-gstudio001/lib/assets/types.ts
+++ b/apps/timeline-gstudio001/lib/assets/types.ts
@@ -24,6 +24,11 @@ export type Asset = Readonly<{
    *  `providerId` (an `AssetSourceRef`) anywhere two providers can meet. */
   id: string;
   providerId: string;
+  /**
+   * Project memberships for this asset. Today this contains exactly one id;
+   * the array leaves the model ready for explicitly shared assets later.
+   */
+  projectIds: readonly string[];
   /** Display name — the basename, not a path. */
   name: string;
   kind: AssetKind;

--- a/apps/timeline-gstudio001/lib/cloudinary-media-store.test.ts
+++ b/apps/timeline-gstudio001/lib/cloudinary-media-store.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  listCloudinaryAssets,
+  uploadCloudinaryMedia,
+} from "./cloudinary-media-store";
+
+const CLOUDINARY_URL = "cloudinary://key:secret@demo";
+
+beforeEach(() => {
+  process.env.CLOUDINARY_URL = CLOUDINARY_URL;
+  delete process.env.CLOUDINARY_FOLDER;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.CLOUDINARY_URL;
+  delete process.env.CLOUDINARY_FOLDER;
+});
+
+describe("Cloudinary project folders", () => {
+  it("lists only the requested user/project prefix and strips it from browse paths", async () => {
+    const requests: { url: string; init?: RequestInit }[] = [];
+    vi.stubGlobal(
+      "fetch",
+      (async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        requests.push({ url, init });
+        if (url.endsWith("/resources/search")) {
+          return Response.json({ resources: [] });
+        }
+        return Response.json({
+          resources: [
+            {
+              public_id:
+                "timeline-gstudio001/user-project-list/project-a/Scenes/frame-1",
+              resource_type: "image",
+              secure_url: "https://cdn.test/frame-1.png",
+            },
+          ],
+        });
+      }) as typeof fetch,
+    );
+
+    const assets = await listCloudinaryAssets("user-project-list", "project-a");
+    expect(assets).toHaveLength(1);
+    expect(assets[0].relativePath).toBe("Scenes/frame-1");
+
+    const imageRequest = new URL(
+      requests.find((request) => request.url.includes("/resources/image/upload"))!.url,
+    );
+    expect(imageRequest.searchParams.get("prefix")).toBe(
+      "timeline-gstudio001/user-project-list/project-a/",
+    );
+    const searchRequest = requests.find((request) =>
+      request.url.endsWith("/resources/search"),
+    );
+    expect(JSON.parse(String(searchRequest?.init?.body))).toMatchObject({
+      expression:
+        "public_id:timeline-gstudio001/user-project-list/project-a/* AND resource_type:video",
+    });
+  });
+
+  it("uploads into the user/project folder before optional subfolders", async () => {
+    const sent: FormData[] = [];
+    vi.stubGlobal(
+      "fetch",
+      (async (_input: string | URL | Request, init?: RequestInit) => {
+        if (init?.body instanceof FormData) sent.push(init.body);
+        return Response.json({
+          public_id:
+            "timeline-gstudio001/user-upload/project-a/Scenes/frame-1",
+          resource_type: "image",
+          secure_url: "https://cdn.test/frame-1.png",
+        });
+      }) as typeof fetch,
+    );
+
+    await uploadCloudinaryMedia(
+      "frame.png",
+      Buffer.from([1, 2, 3]),
+      "image/png",
+      "user-upload",
+      "project-a",
+      "Scenes",
+    );
+
+    expect(sent[0]?.get("folder")).toBe(
+      "timeline-gstudio001/user-upload/project-a/Scenes",
+    );
+  });
+
+  it("uploads large media in Cloudinary-compatible chunks", async () => {
+    const requests: RequestInit[] = [];
+    vi.stubGlobal(
+      "fetch",
+      (async (_input: string | URL | Request, init?: RequestInit) => {
+        requests.push(init ?? {});
+        const isFinal = requests.length === 2;
+        return Response.json(
+          isFinal
+            ? {
+                done: true,
+                bytes: 20 * 1024 * 1024 + 1,
+                public_id: "timeline-gstudio001/user-upload/project-a/large-video",
+                resource_type: "video",
+                secure_url: "https://cdn.test/large-video.mp4",
+              }
+            : {
+                done: false,
+                public_id: "timeline-gstudio001/user-upload/project-a/large-video",
+                resource_type: "video",
+              },
+        );
+      }) as typeof fetch,
+    );
+
+    await expect(
+      uploadCloudinaryMedia(
+        "large-video.mp4",
+        Buffer.alloc(20 * 1024 * 1024 + 1),
+        "video/mp4",
+        "user-upload",
+        "project-a",
+      ),
+    ).resolves.toMatchObject({
+      pathname: "timeline-gstudio001/user-upload/project-a/large-video",
+      url: "https://cdn.test/large-video.mp4",
+    });
+
+    expect(requests).toHaveLength(2);
+    const firstHeaders = new Headers(requests[0].headers);
+    const secondHeaders = new Headers(requests[1].headers);
+    expect(firstHeaders.get("Content-Range")).toBe(
+      `bytes 0-${20 * 1024 * 1024 - 1}/${20 * 1024 * 1024 + 1}`,
+    );
+    expect(secondHeaders.get("Content-Range")).toBe(
+      `bytes ${20 * 1024 * 1024}-${20 * 1024 * 1024}/${20 * 1024 * 1024 + 1}`,
+    );
+    expect(firstHeaders.get("X-Unique-Upload-Id")).toBeTruthy();
+    expect(secondHeaders.get("X-Unique-Upload-Id")).toBe(
+      firstHeaders.get("X-Unique-Upload-Id"),
+    );
+    expect(((requests[0].body as FormData).get("file") as Blob).size).toBe(
+      20 * 1024 * 1024,
+    );
+    expect(((requests[1].body as FormData).get("file") as Blob).size).toBe(1);
+  });
+});

--- a/apps/timeline-gstudio001/lib/cloudinary-media-store.ts
+++ b/apps/timeline-gstudio001/lib/cloudinary-media-store.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 import { encodePublicIdPath } from "./cloudinary-public-id";
 
@@ -14,6 +14,16 @@ export type CloudinaryMediaUpload = {
   contentType?: string;
   size?: number;
 };
+
+export class CloudinaryUploadError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "CloudinaryUploadError";
+  }
+}
 
 export type CloudinaryAsset = {
   id: string;
@@ -43,11 +53,21 @@ type CloudinaryConfig = {
 
 type CloudinaryUploadResponse = {
   bytes?: number;
+  done?: boolean;
   format?: string;
   public_id: string;
   resource_type: "image" | "video" | "raw";
   secure_url: string;
 };
+
+type CloudinaryUploadApiResponse = Partial<CloudinaryUploadResponse> & {
+  error?: { message?: string };
+};
+
+// Cloudinary requires chunked uploads above 100 MB. Starting at one 20 MB
+// chunk also makes medium/large video uploads more tolerant of transient
+// network failures without adding requests for ordinary images and clips.
+const CLOUDINARY_UPLOAD_CHUNK_BYTES = 20 * 1024 * 1024;
 
 type CloudinaryResource = {
   bytes?: number;
@@ -130,11 +150,11 @@ function cloudinaryImageThumbnailUrl(config: CloudinaryConfig, publicId: string)
 function toAsset(
   config: CloudinaryConfig,
   resource: CloudinaryResource,
-  userId?: string,
+  scopePrefix?: string,
 ): CloudinaryAsset | null {
   if (resource.resource_type !== "image" && resource.resource_type !== "video") return null;
 
-  const prefix = userId ? `${config.folder}/${userId}/` : `${config.folder}/`;
+  const prefix = scopePrefix ? `${scopePrefix}/` : `${config.folder}/`;
   const relativePath = resource.public_id.startsWith(prefix)
     ? resource.public_id.slice(prefix.length)
     : resource.public_id;
@@ -163,7 +183,7 @@ async function listCloudinaryResources(
   config: CloudinaryConfig,
   resourceType: "image" | "video",
   folderPrefix: string,
-  userId: string,
+  relativePrefix: string,
 ) {
   const assets: CloudinaryAsset[] = [];
   let nextCursor: string | undefined;
@@ -200,7 +220,7 @@ async function listCloudinaryResources(
 
     assets.push(
       ...(body.resources || [])
-        .map((resource) => toAsset(config, resource, userId))
+        .map((resource) => toAsset(config, resource, relativePrefix))
         .filter((asset): asset is CloudinaryAsset => !!asset),
     );
     nextCursor = body.next_cursor;
@@ -219,7 +239,7 @@ async function listCloudinaryResources(
 async function searchCloudinaryVideos(
   config: CloudinaryConfig,
   folderPrefix: string,
-  userId: string,
+  relativePrefix: string,
 ) {
   const assets: CloudinaryAsset[] = [];
   let nextCursor: string | undefined;
@@ -253,7 +273,7 @@ async function searchCloudinaryVideos(
 
     assets.push(
       ...(body.resources || [])
-        .map((resource) => toAsset(config, resource, userId))
+        .map((resource) => toAsset(config, resource, relativePrefix))
         .filter((asset): asset is CloudinaryAsset => !!asset),
     );
     nextCursor = body.next_cursor;
@@ -263,8 +283,10 @@ async function searchCloudinaryVideos(
   return assets;
 }
 
-// Per-user TTL cache over the full asset listing. Every timeline GET runs a
-// listing for document healing, and the graph view's eager hydration can GET
+// Per-user/project TTL cache over the requested asset listing. Timeline
+// healing can still request the user's full legacy listing by omitting a
+// project id, but the asset API always supplies one. The graph view's eager
+// hydration can GET
 // dozens of timelines in one burst — without this each GET pays multiple
 // paginated Cloudinary API calls (rate-limit and latency risk). Caching the
 // PROMISE also dedupes the burst: concurrent callers share one in-flight
@@ -273,32 +295,42 @@ async function searchCloudinaryVideos(
 const ASSET_LIST_TTL_MS = 60_000;
 const assetListCache = new Map<string, { at: number; promise: Promise<CloudinaryAsset[]> }>();
 
+const assetListCacheKey = (userId: string, projectId?: string) =>
+  `${userId}\u0000${projectId ?? ""}`;
+
 function invalidateAssetListCache(userId?: string) {
-  if (userId) assetListCache.delete(userId);
-  else assetListCache.clear();
+  if (!userId) {
+    assetListCache.clear();
+    return;
+  }
+  const prefix = `${userId}\u0000`;
+  for (const key of assetListCache.keys()) {
+    if (key.startsWith(prefix)) assetListCache.delete(key);
+  }
 }
 
-export async function listCloudinaryAssets(userId: string) {
-  const cached = assetListCache.get(userId);
+export async function listCloudinaryAssets(userId: string, projectId?: string) {
+  const key = assetListCacheKey(userId, projectId);
+  const cached = assetListCache.get(key);
   if (cached && Date.now() - cached.at < ASSET_LIST_TTL_MS) return cached.promise;
 
-  const promise = listCloudinaryAssetsUncached(userId);
-  assetListCache.set(userId, { at: Date.now(), promise });
+  const promise = listCloudinaryAssetsUncached(userId, projectId);
+  assetListCache.set(key, { at: Date.now(), promise });
   // Failures are never cached — the next caller retries immediately.
-  promise.catch(() => assetListCache.delete(userId));
+  promise.catch(() => assetListCache.delete(key));
   return promise;
 }
 
-async function listCloudinaryAssetsUncached(userId: string) {
+async function listCloudinaryAssetsUncached(userId: string, projectId?: string) {
   const config = getCloudinaryConfig();
-  const userFolder = `${config.folder}/${userId}`;
+  const scopeFolder = [config.folder, userId, projectId].filter(Boolean).join("/");
   const [images, videos] = await Promise.all([
-    listCloudinaryResources(config, "image", userFolder, userId),
+    listCloudinaryResources(config, "image", scopeFolder, scopeFolder),
     // Degrade to the duration-less Admin list if search is unavailable —
     // consumers fall back to default durations, nothing else changes.
-    searchCloudinaryVideos(config, userFolder, userId).catch((error) => {
+    searchCloudinaryVideos(config, scopeFolder, scopeFolder).catch((error) => {
       console.warn("[GSTUDIO_CLOUDINARY_SEARCH_FALLBACK]", error);
-      return listCloudinaryResources(config, "video", userFolder, userId);
+      return listCloudinaryResources(config, "video", scopeFolder, scopeFolder);
     }),
   ]);
 
@@ -314,6 +346,7 @@ export async function uploadCloudinaryMedia(
   data: Buffer,
   explicitContentType?: string,
   userId?: string,
+  projectId?: string,
   folderPath?: string,
 ): Promise<CloudinaryMediaUpload> {
   const config = getCloudinaryConfig();
@@ -325,8 +358,19 @@ export async function uploadCloudinaryMedia(
   let folder = config.folder;
   if (userId) {
     folder = `${config.folder}/${userId}`;
+    if (projectId) {
+      folder = `${folder}/${projectId}`;
+    }
     if (folderPath) {
-      folder = `${folder}/${folderPath}`;
+      const segments = folderPath
+        .replace(/\\/g, "/")
+        .split("/")
+        .map((segment) => segment.trim())
+        .filter((segment) => segment.length > 0);
+      if (segments.some((segment) => segment === "." || segment === "..")) {
+        throw new Error("Asset folder paths cannot contain relative segments.");
+      }
+      if (segments.length > 0) folder = `${folder}/${segments.join("/")}`;
     }
   }
 
@@ -336,30 +380,57 @@ export async function uploadCloudinaryMedia(
     timestamp,
   };
   const signature = signCloudinaryParams(params, config.apiSecret);
-  const uploadForm = new FormData();
-  const uploadBlob = new Blob([new Uint8Array(data)], { type: contentType });
+  const uploadUrl =
+    `https://api.cloudinary.com/v1_1/${config.cloudName}/${resourceType}/upload`;
+  const uploadId = randomUUID();
+  let body: CloudinaryUploadApiResponse | null = null;
 
-  uploadForm.append("file", uploadBlob, filename);
-  uploadForm.append("api_key", config.apiKey);
-  uploadForm.append("folder", params.folder);
-  uploadForm.append("public_id", params.public_id);
-  uploadForm.append("timestamp", String(params.timestamp));
-  uploadForm.append("signature", signature);
+  for (let start = 0; start < data.byteLength; start += CLOUDINARY_UPLOAD_CHUNK_BYTES) {
+    const endExclusive = Math.min(start + CLOUDINARY_UPLOAD_CHUNK_BYTES, data.byteLength);
+    const isChunked = data.byteLength > CLOUDINARY_UPLOAD_CHUNK_BYTES;
+    const uploadForm = new FormData();
+    const uploadBlob = new Blob(
+      [new Uint8Array(data.subarray(start, endExclusive))],
+      { type: contentType },
+    );
 
-  const response = await fetch(
-    `https://api.cloudinary.com/v1_1/${config.cloudName}/${resourceType}/upload`,
-    {
+    uploadForm.append("file", uploadBlob, filename);
+    uploadForm.append("api_key", config.apiKey);
+    uploadForm.append("folder", params.folder);
+    uploadForm.append("public_id", params.public_id);
+    uploadForm.append("timestamp", String(params.timestamp));
+    uploadForm.append("signature", signature);
+
+    const response = await fetch(uploadUrl, {
       method: "POST",
       body: uploadForm,
-    },
-  );
+      headers: isChunked
+        ? {
+            "Content-Range": `bytes ${start}-${endExclusive - 1}/${data.byteLength}`,
+            "X-Unique-Upload-Id": uploadId,
+          }
+        : undefined,
+    });
 
-  const body = (await response.json().catch(() => null)) as
-    | (CloudinaryUploadResponse & { error?: { message?: string } })
-    | null;
+    body = (await response.json().catch(() => null)) as
+      | CloudinaryUploadApiResponse
+      | null;
 
-  if (!response.ok || !body?.secure_url) {
-    throw new Error(body?.error?.message || `Cloudinary upload failed with ${response.status}.`);
+    if (!response.ok) {
+      const fallback =
+        response.status === 413
+          ? "Cloudinary rejected the file because it exceeds this account's upload-size limit."
+          : `Cloudinary upload failed with ${response.status}.`;
+      throw new CloudinaryUploadError(body?.error?.message || fallback, response.status);
+    }
+
+    if (endExclusive < data.byteLength && body?.done !== false) {
+      throw new Error("Cloudinary ended a chunked upload before the complete file was sent.");
+    }
+  }
+
+  if (!body?.secure_url || !body.public_id || !body.resource_type) {
+    throw new Error("Cloudinary completed the upload without returning a usable media URL.");
   }
 
   const thumbnailUrl =

--- a/apps/timeline-gstudio001/lib/derive-collection-summaries.test.ts
+++ b/apps/timeline-gstudio001/lib/derive-collection-summaries.test.ts
@@ -192,6 +192,36 @@ describe("deriveClosureSummaries", () => {
     expect(closure.root.clips[0].duration).toBe(10);
   });
 
+  it("bubbles a nested media preview through collection-only ancestors", () => {
+    const videoLeaf: TimelineClip = {
+      ...mediaClip("nested-video", { duration: 12 }),
+      kind: "video",
+      src: "https://cdn.test/nested-video.mp4",
+      poster: "https://cdn.test/nested-video.jpg",
+      sourceDuration: 15,
+      trimIn: 3,
+    };
+    const leaf = docOf("leaf", [videoLeaf]);
+    const middle = docOf("middle", [collectionClip("leaf-ref", "leaf")]);
+    const root = docOf("root", [collectionClip("middle-ref", "middle")]);
+
+    const closure = deriveClosureSummaries(closureOf(root, middle, leaf));
+    const middlePreview = (closure.middle.clips[0] as CollectionTimelineClip).previewItems;
+    const rootPreview = (closure.root.clips[0] as CollectionTimelineClip).previewItems;
+
+    expect(middlePreview).toEqual([
+      {
+        id: "nested-video",
+        kind: "video",
+        src: "https://cdn.test/nested-video.mp4",
+        poster: "https://cdn.test/nested-video.jpg",
+        trimIn: 3,
+        alt: "nested-video",
+      },
+    ]);
+    expect(rootPreview).toEqual(middlePreview);
+  });
+
   it("keeps the stored summary for ids the loader could not resolve", () => {
     // The closure loader substitutes an unloadable branch with an EMPTY
     // document so it falls silent; deriving from that would overwrite a real

--- a/apps/timeline-gstudio001/lib/derive-collection-summaries.ts
+++ b/apps/timeline-gstudio001/lib/derive-collection-summaries.ts
@@ -56,6 +56,26 @@ function playableSpanOf(document: TimelineDocument): number {
   );
 }
 
+/**
+ * Preview media in playback order, including summaries carried by nested
+ * collection clips. The closure pass derives children before parents, so a
+ * grandchild video poster can bubble all the way to the root without loading
+ * that branch again when the root card is later rendered.
+ */
+function nestedPreviewItemsFrom(clips: readonly TimelineDocument["clips"][number][]) {
+  const nested = clips.flatMap((clip) =>
+    clip.kind === "collection"
+      ? (clip.previewItems ?? [])
+      : previewItemsFrom([clip]),
+  );
+  if (nested.length <= 3) return nested;
+  return [
+    nested[0],
+    nested[Math.floor(nested.length / 2)],
+    nested[nested.length - 1],
+  ];
+}
+
 export function deriveCollectionSummaries(
   document: TimelineDocument,
   childDocuments: ReadonlyMap<string, TimelineDocument | null>,
@@ -86,7 +106,7 @@ export function deriveCollectionSummaries(
     // reverse index.
     const effectiveChild = effectiveDocument(child);
     const itemCount = effectiveChild.clips.length;
-    const previewItems = previewItemsFrom(effectiveChild.clips);
+    const previewItems = nestedPreviewItemsFrom(effectiveChild.clips);
     const duration = collectionSpanSeconds(child.clips);
     const playable = playableSpanOf(child);
     // Omitted when nothing under the collection is disabled — `duration` is

--- a/apps/timeline-gstudio001/lib/project-asset-scope.test.ts
+++ b/apps/timeline-gstudio001/lib/project-asset-scope.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  result: { id: "project-a" } as { id: string } | null,
+  denied: false,
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("./firebase-timeline-store", async () => {
+  const { TimelineAccessDeniedError } =
+    await vi.importActual<typeof import("./timeline-ownership")>("./timeline-ownership");
+  return {
+    getFirebaseTimelineDocument: async (id: string) => {
+      if (state.denied) throw new TimelineAccessDeniedError(id);
+      return state.result;
+    },
+  };
+});
+
+import {
+  ProjectAssetScopeError,
+  requireProjectAssetScope,
+} from "./project-asset-scope";
+
+beforeEach(() => {
+  state.result = { id: "project-a" };
+  state.denied = false;
+});
+
+describe("requireProjectAssetScope", () => {
+  it("accepts an owned root project", async () => {
+    await expect(requireProjectAssetScope("project-a", "user-a")).resolves.toBe(
+      "project-a",
+    );
+  });
+
+  it.each([null, "", "timeline-child", "project-a/../project-b"])(
+    "rejects an invalid project boundary (%s)",
+    async (value) => {
+      await expect(requireProjectAssetScope(value, "user-a")).rejects.toMatchObject({
+        status: 400,
+      } satisfies Partial<ProjectAssetScopeError>);
+    },
+  );
+
+  it("rejects a missing project", async () => {
+    state.result = null;
+    await expect(
+      requireProjectAssetScope("project-missing", "user-a"),
+    ).rejects.toMatchObject({ status: 404 } satisfies Partial<ProjectAssetScopeError>);
+  });
+
+  it("does not expose a project owned by someone else", async () => {
+    state.denied = true;
+    await expect(
+      requireProjectAssetScope("project-b", "user-a"),
+    ).rejects.toMatchObject({ status: 404 } satisfies Partial<ProjectAssetScopeError>);
+  });
+});

--- a/apps/timeline-gstudio001/lib/project-asset-scope.ts
+++ b/apps/timeline-gstudio001/lib/project-asset-scope.ts
@@ -1,0 +1,46 @@
+import "server-only";
+
+import { getFirebaseTimelineDocument } from "./firebase-timeline-store";
+import { TimelineAccessDeniedError } from "./timeline-ownership";
+
+const PROJECT_ID_PATTERN = /^project-[a-zA-Z0-9_-]{1,160}$/;
+
+export class ProjectAssetScopeError extends Error {
+  constructor(
+    message: string,
+    readonly status: 400 | 404,
+  ) {
+    super(message);
+    this.name = "ProjectAssetScopeError";
+  }
+}
+
+/**
+ * Resolve and authorize the root project that owns an asset request.
+ *
+ * The ownership read prevents a caller from using another project id as an
+ * escape hatch into a different asset folder.
+ */
+export async function requireProjectAssetScope(
+  value: unknown,
+  uid: string,
+): Promise<string> {
+  if (typeof value !== "string" || !PROJECT_ID_PATTERN.test(value)) {
+    throw new ProjectAssetScopeError("A valid projectId is required.", 400);
+  }
+
+  try {
+    const project = await getFirebaseTimelineDocument(value, uid);
+    if (project === null) {
+      throw new ProjectAssetScopeError(`Project "${value}" was not found.`, 404);
+    }
+  } catch (error) {
+    if (error instanceof ProjectAssetScopeError) throw error;
+    if (error instanceof TimelineAccessDeniedError) {
+      throw new ProjectAssetScopeError(`Project "${value}" was not found.`, 404);
+    }
+    throw error;
+  }
+
+  return value;
+}

--- a/apps/timeline-gstudio001/lib/timeline-media-client.test.ts
+++ b/apps/timeline-gstudio001/lib/timeline-media-client.test.ts
@@ -38,7 +38,7 @@ describe("uploadTimelineMedia", () => {
 
   it("returns the parsed result for a well-formed response", async () => {
     stubUpload(response({ pathname: "media/a.png", url: "https://cdn.test/a.png" }));
-    await expect(uploadTimelineMedia("a.png", png())).resolves.toEqual({
+    await expect(uploadTimelineMedia("a.png", png(), "project-a")).resolves.toEqual({
       pathname: "media/a.png",
       url: "https://cdn.test/a.png",
     });
@@ -53,9 +53,24 @@ describe("uploadTimelineMedia", () => {
         thumbnailUrl: "https://cdn.test/thumbs/a.jpg",
       }),
     );
-    await expect(uploadTimelineMedia("a.png", png())).resolves.toMatchObject({
+    await expect(uploadTimelineMedia("a.png", png(), "project-a")).resolves.toMatchObject({
       thumbnailPathname: "thumbs/a.jpg",
       thumbnailUrl: "https://cdn.test/thumbs/a.jpg",
+    });
+  });
+
+  it("keeps provider provenance returned by the upload route", async () => {
+    stubUpload(
+      response({
+        pathname: "media/a.png",
+        url: "https://cdn.test/a.png",
+        providerId: "firebase",
+        assetId: "media/a.png",
+      }),
+    );
+    await expect(uploadTimelineMedia("a.png", png(), "project-a")).resolves.toMatchObject({
+      providerId: "firebase",
+      assetId: "media/a.png",
     });
   });
 
@@ -76,18 +91,41 @@ describe("uploadTimelineMedia", () => {
     ],
   ])("rejects a 2xx response with %s", async (_label, body) => {
     stubUpload(response(body));
-    await expect(uploadTimelineMedia("a.png", png())).rejects.toThrow(/without a usable url/);
+    await expect(
+      uploadTimelineMedia("a.png", png(), "project-a"),
+    ).rejects.toThrow(/without a usable url/);
   });
 
   it("rejects a 2xx response whose body is not JSON at all", async () => {
     // A proxy returning an HTML error page with a 200 — .json() itself throws.
     stubUpload(response(new Error("Unexpected token <")));
-    await expect(uploadTimelineMedia("a.png", png())).rejects.toThrow(/without a usable url/);
+    await expect(
+      uploadTimelineMedia("a.png", png(), "project-a"),
+    ).rejects.toThrow(/without a usable url/);
   });
 
   it("still reports non-2xx responses as upload failures", async () => {
     stubUpload(response("storage is full", 507));
-    await expect(uploadTimelineMedia("a.png", png())).rejects.toThrow(/Media upload failed/);
+    await expect(
+      uploadTimelineMedia("a.png", png(), "project-a"),
+    ).rejects.toThrow(/Media upload failed/);
+  });
+
+  it("extracts the server error from a failed JSON upload response", async () => {
+    stubUpload(
+      response(
+        {
+          error:
+            "Cloudinary rejected the file because it exceeds this account's upload-size limit.",
+        },
+        413,
+      ),
+    );
+    await expect(
+      uploadTimelineMedia("a.png", png(), "project-a"),
+    ).rejects.toThrow(
+      "Media upload failed: Cloudinary rejected the file because it exceeds this account's upload-size limit.",
+    );
   });
 });
 
@@ -118,10 +156,13 @@ describe("uploadTimelineMedia video thumbnails", () => {
     const poster = new Blob([new Uint8Array([255, 216])], { type: "image/jpeg" });
 
     await expect(
-      uploadTimelineMedia("a.mp4", mp4(), undefined, { thumbnail: poster }),
+      uploadTimelineMedia("a.mp4", mp4(), "project-a", undefined, {
+        thumbnail: poster,
+      }),
     ).resolves.toEqual(ok);
 
     expect(bodies).toHaveLength(1);
+    expect(bodies[0].get("projectId")).toBe("project-a");
     // FormData re-wraps a Blob as a File, so compare content, not identity.
     const sent = bodies[0].get("thumbnail");
     expect(sent).toBeInstanceOf(Blob);
@@ -136,7 +177,9 @@ describe("uploadTimelineMedia video thumbnails", () => {
     const bodies = stubUploadCapturing();
 
     await expect(
-      uploadTimelineMedia("a.mp4", mp4(), undefined, { thumbnail: null }),
+      uploadTimelineMedia("a.mp4", mp4(), "project-a", undefined, {
+        thumbnail: null,
+      }),
     ).resolves.toEqual(ok);
 
     expect(bodies[0].get("thumbnail")).toBeNull();
@@ -151,7 +194,7 @@ describe("uploadTimelineMedia video thumbnails", () => {
     }) as unknown as typeof fetch);
     const controller = new AbortController();
 
-    await uploadTimelineMedia("a.mp4", mp4(), undefined, {
+    await uploadTimelineMedia("a.mp4", mp4(), "project-a", undefined, {
       thumbnail: null,
       signal: controller.signal,
     });

--- a/apps/timeline-gstudio001/lib/timeline-media-client.ts
+++ b/apps/timeline-gstudio001/lib/timeline-media-client.ts
@@ -3,6 +3,8 @@ export type TimelineMediaUploadResult = {
   url: string;
   thumbnailPathname?: string;
   thumbnailUrl?: string;
+  providerId?: string;
+  assetId?: string;
 };
 
 // A `Promise<TimelineMediaUploadResult>` annotation on a function that returns
@@ -22,7 +24,7 @@ function parseUploadResult(value: unknown): TimelineMediaUploadResult | null {
   if (typeof value !== "object" || value === null) return null;
   const candidate = value as Record<string, unknown>;
   if (!nonEmptyString(candidate.pathname) || !nonEmptyString(candidate.url)) return null;
-  for (const key of ["thumbnailPathname", "thumbnailUrl"] as const) {
+  for (const key of ["thumbnailPathname", "thumbnailUrl", "providerId", "assetId"] as const) {
     if (candidate[key] !== undefined && !nonEmptyString(candidate[key])) return null;
   }
   return {
@@ -34,6 +36,10 @@ function parseUploadResult(value: unknown): TimelineMediaUploadResult | null {
     ...(candidate.thumbnailUrl !== undefined
       ? { thumbnailUrl: candidate.thumbnailUrl as string }
       : {}),
+    ...(candidate.providerId !== undefined
+      ? { providerId: candidate.providerId as string }
+      : {}),
+    ...(candidate.assetId !== undefined ? { assetId: candidate.assetId as string } : {}),
   };
 }
 
@@ -213,6 +219,7 @@ export async function probeVideoFile(
 export async function uploadTimelineMedia(
   filename: string,
   file: Blob,
+  projectId: string,
   folderPath?: string,
   options?: {
     /**
@@ -230,10 +237,10 @@ export async function uploadTimelineMedia(
   const formData = new FormData();
   formData.append("file", file);
   formData.append("filename", safeFilename);
+  formData.append("projectId", projectId);
   if (folderPath) {
     formData.append("folderPath", folderPath);
   }
-
   if (isVideoUpload(safeFilename, file)) {
     const thumbnail =
       options && "thumbnail" in options
@@ -256,8 +263,24 @@ export async function uploadTimelineMedia(
   });
 
   if (!response.ok) {
-    const message = await response.text();
-    throw new Error(`Media upload failed: ${message}`);
+    const responseText = await response.text();
+    let message = responseText.trim();
+    try {
+      const payload: unknown = JSON.parse(responseText);
+      if (
+        typeof payload === "object" &&
+        payload !== null &&
+        "error" in payload &&
+        typeof payload.error === "string"
+      ) {
+        message = payload.error.trim();
+      }
+    } catch {
+      // Plain-text and proxy responses remain useful as-is.
+    }
+    throw new Error(
+      `Media upload failed: ${message || `the server returned ${response.status}`}`,
+    );
   }
 
   // `.json()` itself rejects on a 2xx body that isn't JSON at all (an HTML

--- a/apps/timeline-gstudio001/lib/video-frame-url.test.ts
+++ b/apps/timeline-gstudio001/lib/video-frame-url.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   cloudinaryVideoFrameUrl,
+  collectionPreviewFrameUrl,
   videoFrameUrls,
   type VideoFrameUrlBuilder,
 } from "./video-frame-url";
@@ -43,6 +44,43 @@ describe("cloudinaryVideoFrameUrl", () => {
     expect(cloudinaryVideoFrameUrl("https://example.com/frame.jpg", 3)).toBe(
       "https://example.com/frame.jpg",
     );
+  });
+});
+
+describe("collectionPreviewFrameUrl", () => {
+  it("uses the exact front-trim time for a video collection preview", () => {
+    expect(
+      collectionPreviewFrameUrl({
+        kind: "video",
+        src: "https://res.cloudinary.com/demo/video/upload/folder/clip.mp4",
+        poster: CLOUDINARY_FRAME,
+        trimIn: 6.25,
+      }),
+    ).toContain("/so_6.25,");
+  });
+
+  it("keeps image and untrimmed video previews unchanged", () => {
+    const image = "https://cdn.test/image.jpg";
+    expect(collectionPreviewFrameUrl({ kind: "image", src: image })).toBe(image);
+    expect(
+      collectionPreviewFrameUrl({
+        kind: "video",
+        src: "https://cdn.test/video.mp4",
+        poster: CLOUDINARY_FRAME,
+      }),
+    ).toBe(CLOUDINARY_FRAME);
+  });
+
+  it("degrades to the existing poster when a provider cannot address frames", () => {
+    const poster = "https://cdn.test/video-poster.jpg";
+    expect(
+      collectionPreviewFrameUrl({
+        kind: "video",
+        src: "https://cdn.test/video.mp4",
+        poster,
+        trimIn: 4,
+      }),
+    ).toBe(poster);
   });
 });
 

--- a/apps/timeline-gstudio001/lib/video-frame-url.ts
+++ b/apps/timeline-gstudio001/lib/video-frame-url.ts
@@ -43,6 +43,30 @@ export const cloudinaryVideoFrameUrl: VideoFrameUrlBuilder = (frameUrl, timeSeco
  *  another provider — nothing above the seam names Cloudinary. */
 export const defaultVideoFrameUrlBuilder: VideoFrameUrlBuilder = cloudinaryVideoFrameUrl;
 
+/**
+ * Resolve the still shown when a media item represents a collection.
+ *
+ * Images keep their source unchanged. A video with a front trim asks the
+ * provider seam for the frame at that exact source time, so the collection
+ * represents the first usable frame rather than the discarded beginning.
+ * Providers that cannot address frames return the existing poster unchanged.
+ */
+export function collectionPreviewFrameUrl(
+  preview: Readonly<{
+    kind: "image" | "video";
+    src: string;
+    poster?: string;
+    trimIn?: number;
+  }>,
+  build: VideoFrameUrlBuilder = defaultVideoFrameUrlBuilder,
+): string {
+  const base = preview.poster ?? preview.src;
+  if (preview.kind !== "video" || !preview.poster || (preview.trimIn ?? 0) <= 0) {
+    return base;
+  }
+  return build(base, preview.trimIn ?? 0);
+}
+
 /** How far short of the range's exact end the LAST slot samples. The very
  *  final frame of an encode is often black or a fade-out remnant; a beat
  *  before it is the frame a person means by "the end of the clip". */

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -790,7 +790,7 @@ test.describe("graph view E2E", () => {
     expect(patch?.clipIds).toEqual(["alpha", "bravo", "charlie", "clip-scene"]);
   });
 
-  test("renaming the focused BREADCRUMB crumb in place persists the collection title", async ({
+  test("only the current BREADCRUMB edits in place; every ancestor links to its view", async ({
     page,
   }) => {
     const api = await installGraphApi(page);
@@ -805,9 +805,9 @@ test.describe("graph view E2E", () => {
     const trail = page.getByRole("navigation", { name: "Timeline focus path" });
     await expect(trail).toContainText("Scene A");
 
-    // Double-click the current crumb → inline editor; commit with Enter.
-    await trail.getByText("Scene A", { exact: true }).dblclick();
-    const editor = page.getByRole("textbox", { name: "Timeline name" });
+    // One click edits the current crumb; Enter commits.
+    await trail.getByRole("button", { name: "Rename Scene A" }).click();
+    const editor = page.getByRole("textbox", { name: "Rename Scene A" });
     await editor.fill("Getaway");
     await editor.press("Enter");
 
@@ -815,6 +815,80 @@ test.describe("graph view E2E", () => {
     await expect
       .poll(() => api.documents.get(CHILD_ID)?.title, { timeout: 5000 })
       .toBe("Getaway");
+
+    // Ancestors are navigation links, not rename controls.
+    const rootCrumb = trail.getByRole("link", { name: "E2E Project" });
+    await expect(rootCrumb).toHaveAttribute("href", `/timeline/${PROJECT_ID}/graph`);
+    await expect(trail.getByRole("button", { name: "Rename E2E Project" })).toHaveCount(0);
+    await rootCrumb.click();
+    await expect(page).toHaveURL(new RegExp(`/timeline/${PROJECT_ID}/graph$`));
+    await expect(
+      page
+        .getByRole("navigation", { name: "Timeline focus path" })
+        .getByRole("button", { name: "Rename E2E Project" }),
+    ).toBeVisible();
+  });
+
+  test("focused strip and grid surfaces have no outer shell padding", async ({ page }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+
+    await expect(page.getByRole("button", { name: "Board options" }).locator("svg"))
+      .toHaveClass(/lucide-settings/);
+    await expect(page.locator("aside").getByRole("button", { name: "Settings" })).toHaveCount(0);
+
+    const boxStyles = (selector: string) =>
+      page.locator(selector).evaluate((element) => {
+        const style = getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return {
+          padding: [style.paddingTop, style.paddingRight, style.paddingBottom, style.paddingLeft],
+          border: [
+            style.borderTopWidth,
+            style.borderRightWidth,
+            style.borderBottomWidth,
+            style.borderLeftWidth,
+          ],
+          left: rect.left,
+          right: rect.right,
+        };
+      });
+
+    const headerBox = await boxStyles("[data-graph-board-header]");
+    await expect(page.locator("[data-board-header-edge-occluder]")).toHaveCount(2);
+    const stripBox = await boxStyles(`[data-virtual-strip="${PROJECT_ID}"]`);
+    expect(stripBox.padding).toEqual(["0px", "0px", "0px", "0px"]);
+    expect(stripBox.border).toEqual(["0px", "0px", "0px", "0px"]);
+    expect(stripBox.left).toBeCloseTo(headerBox.left, 1);
+    expect(stripBox.right).toBeCloseTo(headerBox.right, 1);
+
+    await surfaceButton(page, "grid").click();
+    await expect(page.locator('[data-focused-surface-shell="grid"]')).toBeVisible();
+    const gridBox = await boxStyles(`[data-virtual-grid="${PROJECT_ID}"]`);
+    expect(gridBox.padding).toEqual(["0px", "0px", "0px", "0px"]);
+    expect(gridBox.border).toEqual(["0px", "0px", "0px", "0px"]);
+    expect(gridBox.left).toBeCloseTo(headerBox.left, 1);
+    expect(gridBox.right).toBeCloseTo(headerBox.right, 1);
+  });
+
+  test("selected borders stay inside left and right grid edges", async ({ page }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    await surfaceButton(page, "grid").click();
+
+    const grid = page.locator(`[data-virtual-grid="${PROJECT_ID}"]`);
+    const leftCard = grid.locator('[data-node-id="alpha"]');
+    const rightCard = grid.locator('[data-node-id="charlie"]');
+    const collectionCard = grid.locator(`[data-node-id="${CHILD_ID}"]`);
+
+    await leftCard.click();
+    await expect(leftCard.locator(".ring-inset")).toHaveCount(1);
+
+    await rightCard.click();
+    await expect(rightCard.locator(".ring-inset")).toHaveCount(1);
+
+    await collectionCard.click({ position: { x: 10, y: 10 } });
+    await expect(collectionCard).toHaveClass(/ring-inset/);
   });
 
   test("surface toggle is page-wide: sub-graph rows follow grid/strip mode", async ({ page }) => {
@@ -902,16 +976,30 @@ test.describe("graph view E2E", () => {
     await expect.poll(heightOf).toBeGreaterThan(0);
     const initial = await heightOf();
 
-    // Divider restyle: a slim 12px band with a centred grip pill; hovering
-    // tints the WHOLE band gray (the old amber line highlight is gone).
+    // The divider remains a compact 12px track even though its centered
+    // transport overhangs it.
     expect(
       await divider.evaluate((el) => Math.round(el.getBoundingClientRect().height)),
     ).toBe(12);
-    await expect(divider.locator("[data-divider-grip]")).toHaveCount(1);
-    const dividerBg = () => divider.evaluate((el) => getComputedStyle(el).backgroundColor);
-    const restBg = await dividerBg();
-    await divider.hover();
-    await expect.poll(dividerBg).not.toBe(restBg);
+    await expect(divider.locator("[data-divider-grip]")).toHaveCount(0);
+    const splitPane = page.getByTestId("workbench-split-pane");
+    const displaySurface = page.getByTestId("workbench-display-surface");
+    expect(
+      await splitPane.evaluate((element) => getComputedStyle(element).overflowX),
+    ).toBe("visible");
+    await expect(page.locator("[data-preview-edge-occluder]")).toHaveCount(2);
+    expect(
+      await displaySurface.evaluate(
+        (element) => getComputedStyle(element).borderBottomWidth,
+      ),
+    ).toBe("0px");
+    const dividerLine = divider.locator("[data-divider-line]");
+    await expect(dividerLine).toHaveCount(1);
+    const dividerLineColor = () =>
+      dividerLine.evaluate((el) => getComputedStyle(el).backgroundColor);
+    const restLineColor = await dividerLineColor();
+    await divider.hover({ position: { x: 20, y: 6 } });
+    await expect.poll(dividerLineColor).not.toBe(restLineColor);
     await page.mouse.move(0, 0); // unhover before the resize steps below
 
     // Expanding a sub-graph grows the content BELOW the preview. The preview
@@ -959,6 +1047,32 @@ test.describe("graph view E2E", () => {
     await page.keyboard.press("Enter");
     await expect(divider).toBeVisible();
     await expect.poll(heightOf).toBe(initial);
+  });
+
+  test("opening preview preserves a long strip's horizontal scroll position", async ({
+    page,
+  }) => {
+    await installGraphApi(page);
+    await page.setViewportSize({ width: 640, height: 800 });
+    await openGraph(page);
+
+    const projectStrip = strip(page, PROJECT_ID);
+    const before = await projectStrip.evaluate((element) => {
+      const maxScroll = element.scrollWidth - element.clientWidth;
+      if (maxScroll <= 0) throw new Error("Fixture strip does not overflow horizontally.");
+      element.scrollLeft = Math.round(maxScroll * 0.7);
+      element.dataset.scrollIdentityWitness = "same-node";
+      return element.scrollLeft;
+    });
+    expect(before).toBeGreaterThan(0);
+
+    await previewToggle(page).click();
+    await expect(page.getByTestId("workbench-display-surface")).toBeVisible();
+
+    await expect(projectStrip).toHaveAttribute("data-scroll-identity-witness", "same-node");
+    await expect
+      .poll(() => projectStrip.evaluate((element) => element.scrollLeft))
+      .toBe(before);
   });
 
   test("hold-drag reorder persists a patch-scoped write to only the touched document", async ({
@@ -2016,6 +2130,308 @@ test.describe("graph view E2E", () => {
     await expect.poll(translateX).toBeLessThan(20);
   });
 
+  test("preview transport stays static in the divider with time aligned right", async ({
+    page,
+  }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    await previewToggle(page).click();
+
+    const surface = page.getByTestId("workbench-display-surface");
+    const canvas = page.getByTestId("workbench-display-canvas");
+    const controls = page.getByTestId("workbench-preview-controls");
+    const buttonGroup = controls.locator("[data-transport-button-group]");
+    const primaryControl = controls.locator("[data-transport-primary-control]");
+    const time = page.getByTestId("workbench-preview-time");
+    const divider = page.getByRole("separator", {
+      name: "Resize workbench display",
+    });
+    const dividerLine = divider.locator("[data-divider-line]");
+    const playButton = page.getByRole("button", {
+      name: "Play workbench preview",
+    });
+
+    expect(await controls.evaluate((element) => getComputedStyle(element).position)).toBe(
+      "absolute",
+    );
+    await expect(controls).toHaveAttribute("data-transport-layout", "static");
+    await expect(page.getByRole("button", { name: "Previous workbench clip" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Next workbench clip" })).toBeVisible();
+    await expect(time).toContainText("/");
+    await expect(controls.locator("[data-transport-capsule]")).toHaveCount(0);
+    await expect(divider.locator("[data-divider-grip]")).toHaveCount(0);
+    expect(
+      await primaryControl.evaluate(
+        (element) => getComputedStyle(element).backgroundColor,
+      ),
+    ).toBe("rgba(0, 0, 0, 0)");
+
+    // All three 44px hit targets remain centered on the fixed 12px divider,
+    // while their visible chrome stays deliberately compact.
+    const [surfaceBox, canvasBox, groupBox, dividerBox, dividerLineBox, timeBox] =
+      await Promise.all([
+        surface.boundingBox(),
+        canvas.boundingBox(),
+        buttonGroup.boundingBox(),
+        divider.boundingBox(),
+        dividerLine.boundingBox(),
+        time.boundingBox(),
+      ]);
+    expect(surfaceBox).not.toBeNull();
+    expect(canvasBox).not.toBeNull();
+    expect(groupBox).not.toBeNull();
+    expect(dividerBox).not.toBeNull();
+    expect(dividerLineBox).not.toBeNull();
+    expect(timeBox).not.toBeNull();
+    expect(dividerBox!.height).toBe(12);
+    expect(groupBox!.width).toBe(132);
+    expect(groupBox!.height).toBe(44);
+    expect(groupBox!.y + groupBox!.height / 2).toBeCloseTo(
+      dividerBox!.y + dividerBox!.height / 2,
+      0,
+    );
+    expect(dividerLineBox!.y + dividerLineBox!.height / 2).toBeCloseTo(
+      groupBox!.y + groupBox!.height / 2,
+      0,
+    );
+    expect(canvasBox!.y + canvasBox!.height).toBeCloseTo(dividerBox!.y, 0);
+    expect(
+      Math.abs(timeBox!.x + timeBox!.width - (surfaceBox!.x + surfaceBox!.width - 12)),
+    ).toBeLessThanOrEqual(1);
+
+    const [previousVisualBox, playVisualBox, nextVisualBox] = await Promise.all([
+      page
+        .getByRole("button", { name: "Previous workbench clip" })
+        .locator("span")
+        .boundingBox(),
+      page
+        .getByRole("button", { name: "Play workbench preview" })
+        .locator("span")
+        .boundingBox(),
+      page
+        .getByRole("button", { name: "Next workbench clip" })
+        .locator("span")
+        .boundingBox(),
+    ]);
+    expect(previousVisualBox).not.toBeNull();
+    expect(playVisualBox).not.toBeNull();
+    expect(nextVisualBox).not.toBeNull();
+    expect(
+      playVisualBox!.x +
+        playVisualBox!.width / 2 -
+        (previousVisualBox!.x + previousVisualBox!.width / 2),
+    ).toBeCloseTo(36, 0);
+    expect(
+      nextVisualBox!.x +
+        nextVisualBox!.width / 2 -
+        (playVisualBox!.x + playVisualBox!.width / 2),
+    ).toBeCloseTo(36, 0);
+
+    // Divider hover does not resize or move the transport.
+    await divider.hover({ position: { x: 20, y: 6 } });
+    const groupAfterHover = await buttonGroup.boundingBox();
+    expect(groupAfterHover).not.toBeNull();
+    expect(groupAfterHover!.x).toBeCloseTo(groupBox!.x, 0);
+    expect(groupAfterHover!.y).toBeCloseTo(groupBox!.y, 0);
+    expect(groupAfterHover!.width).toBe(groupBox!.width);
+    expect(groupAfterHover!.height).toBe(groupBox!.height);
+
+    const overhangPaintsAboveLowerContent = await playButton.evaluate((element) => {
+      const buttonBox = element.getBoundingClientRect();
+      const controls = element.closest("[data-testid='workbench-preview-controls']");
+      const hit = document.elementFromPoint(
+        buttonBox.left + buttonBox.width / 2,
+        buttonBox.bottom - 2,
+      );
+      return controls === hit || controls?.contains(hit) === true;
+    });
+    expect(overhangPaintsAboveLowerContent).toBe(true);
+
+    // Keyboard focus follows the visible previous/play/next DOM order without
+    // changing the transport's dimensions.
+    const stripButton = page.getByRole("button", {
+      name: "Strip layout",
+      exact: true,
+    });
+    await stripButton.focus();
+    let playHasFocus = false;
+    for (let step = 0; step < 16 && !playHasFocus; step += 1) {
+      await page.keyboard.press("Tab");
+      playHasFocus = await playButton.evaluate(
+        (element) => document.activeElement === element,
+      );
+    }
+    expect(playHasFocus).toBe(true);
+    expect(await playButton.evaluate((element) => element.matches(":focus-visible"))).toBe(
+      true,
+    );
+    await expect(controls).toHaveAttribute("data-transport-layout", "static");
+    const groupAfterFocus = await buttonGroup.boundingBox();
+    expect(groupAfterFocus).not.toBeNull();
+    expect(groupAfterFocus!.width).toBe(groupBox!.width);
+    expect(groupAfterFocus!.height).toBe(groupBox!.height);
+
+    // Clicking the transport must not engage the divider's resize gesture.
+    const surfaceHeightBeforePlay = await divider.getAttribute("aria-valuenow");
+    await playButton.click();
+    await expect(surface).toHaveAttribute("data-preview-playing", "true");
+    await expect(divider).toHaveAttribute("aria-valuenow", surfaceHeightBeforePlay!);
+
+    // The rest of the divider remains a resize target.
+    const dividerBoxAfterPlay = await divider.boundingBox();
+    expect(dividerBoxAfterPlay).not.toBeNull();
+    await page.mouse.move(
+      dividerBoxAfterPlay!.x + 20,
+      dividerBoxAfterPlay!.y + dividerBoxAfterPlay!.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      dividerBoxAfterPlay!.x + 20,
+      dividerBoxAfterPlay!.y + dividerBoxAfterPlay!.height / 2 + 24,
+    );
+    await page.mouse.up();
+    await expect
+      .poll(() => divider.getAttribute("aria-valuenow"))
+      .not.toBe(surfaceHeightBeforePlay);
+  });
+
+  test("preview surface is a pointer shortcut that activates the compact control", async ({
+    page,
+  }) => {
+    const api = await installGraphApi(page);
+    // The fixture's video src is intentionally a tiny image data URI. Use the
+    // same first clip as an image here so the canvas can draw a real rectangle
+    // without reaching the network.
+    api.documents.get(PROJECT_ID)!.clips[0]!.kind = "image";
+    api.documents.get(PROJECT_ID)!.clips[0]!.startTime = 0;
+    await openGraph(page);
+    await previewToggle(page).click();
+
+    const surface = page.getByTestId("workbench-display-surface");
+    const canvas = page.getByTestId("workbench-display-canvas");
+    const controls = page.getByTestId("workbench-preview-controls");
+    const primaryControl = controls.locator("[data-transport-primary-control]");
+    const primaryColor = () =>
+      primaryControl.evaluate((element) => getComputedStyle(element).color);
+    const restingColor = await primaryColor();
+
+    await expect(canvas).toHaveAttribute("data-preview-playback-surface-ready", "true");
+
+    const canvasBox = await canvas.boundingBox();
+    expect(canvasBox).not.toBeNull();
+    const playbackCenter = {
+      x: canvasBox!.width / 2,
+      y: canvasBox!.height / 2,
+    };
+    const emptyGutter = {
+      x: 2,
+      y: canvasBox!.height / 2,
+    };
+
+    await expect(canvas).toHaveAttribute("data-preview-playback-shortcut", "true");
+    await expect(canvas).not.toHaveAttribute("tabindex");
+
+    // Letterbox space is deliberately inert.
+    await canvas.hover({ position: emptyGutter });
+    expect(await canvas.evaluate((element) => getComputedStyle(element).cursor)).toBe(
+      "default",
+    );
+    await expect.poll(primaryColor).toBe(restingColor);
+    await canvas.click({ position: emptyGutter });
+    await expect(surface).toHaveAttribute("data-preview-playing", "false");
+
+    // The shortcut begins only inside the centered rendered-media rectangle.
+    await canvas.hover({ position: playbackCenter });
+    expect(await canvas.evaluate((element) => getComputedStyle(element).cursor)).toBe(
+      "pointer",
+    );
+    await expect(controls).toHaveAttribute("data-transport-layout", "static");
+    await expect.poll(primaryColor).not.toBe(restingColor);
+
+    await canvas.click({ position: playbackCenter });
+    await expect(surface).toHaveAttribute("data-preview-playing", "true");
+    await expect(
+      page.getByRole("button", { name: "Pause workbench preview" }),
+    ).toBeVisible();
+    await expect(controls).toHaveAttribute("data-transport-layout", "static");
+
+    await canvas.click({ position: playbackCenter });
+    await expect(surface).toHaveAttribute("data-preview-playing", "false");
+    await expect(
+      page.getByRole("button", { name: "Play workbench preview" }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Strip layout", exact: true }).hover();
+    await expect.poll(primaryColor).toBe(restingColor);
+  });
+
+  test("preview divider transport keeps all controls visible for touch", async ({
+    page,
+  }) => {
+    const devtools = await page.context().newCDPSession(page);
+    await devtools.send("Emulation.setTouchEmulationEnabled", {
+      enabled: true,
+      maxTouchPoints: 5,
+    });
+    const api = await installGraphApi(page);
+    api.documents.get(PROJECT_ID)!.clips[0]!.kind = "image";
+    api.documents.get(PROJECT_ID)!.clips[0]!.startTime = 0;
+    await openGraph(page);
+    await previewToggle(page).click();
+
+    expect(
+      await page.evaluate(
+        () => window.matchMedia("(hover: hover) and (pointer: fine)").matches,
+      ),
+    ).toBe(false);
+
+    const controls = page.getByTestId("workbench-preview-controls");
+    const buttonGroup = controls.locator("[data-transport-button-group]");
+    await expect(controls).toHaveAttribute("data-transport-layout", "static");
+    await expect
+      .poll(() =>
+        buttonGroup.evaluate((element) => Math.round(element.getBoundingClientRect().width)),
+      )
+      .toBe(132);
+    await expect(page.getByRole("button", { name: "Previous workbench clip" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Next workbench clip" })).toBeVisible();
+    await expect(page.getByTestId("workbench-preview-time")).toBeVisible();
+
+    const canvas = page.getByTestId("workbench-display-canvas");
+    await expect(canvas).toHaveAttribute("data-preview-playback-surface-ready", "true");
+    const canvasBox = await canvas.boundingBox();
+    expect(canvasBox).not.toBeNull();
+    const playbackCenter = {
+      x: canvasBox!.width / 2,
+      y: canvasBox!.height / 2,
+    };
+    await canvas.click({ position: playbackCenter });
+    await expect(page.getByTestId("workbench-display-surface")).toHaveAttribute(
+      "data-preview-playing",
+      "true",
+    );
+    await expect(controls).toHaveAttribute("data-transport-layout", "static");
+    await canvas.click({ position: playbackCenter });
+    await expect(page.getByTestId("workbench-display-surface")).toHaveAttribute(
+      "data-preview-playing",
+      "false",
+    );
+
+    await page.getByRole("button", { name: "Play workbench preview" }).click();
+    await expect
+      .poll(() =>
+        buttonGroup.evaluate((element) => Math.round(element.getBoundingClientRect().width)),
+      )
+      .toBe(132);
+    await expect(page.getByRole("button", { name: "Previous workbench clip" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Next workbench clip" })).toBeVisible();
+
+    await page.getByTestId("workbench-display-canvas").click({
+      position: playbackCenter,
+    });
+    await expect(controls).toHaveAttribute("data-transport-layout", "static");
+  });
+
   test("strip seek rail auto-pans at the scroller's edge while scrubbing", async ({
     page,
   }) => {
@@ -2384,13 +2800,48 @@ test.describe("graph view E2E", () => {
       await bravo.click();
       await expect(bravo).toHaveAttribute("data-selected", "true", { timeout: 700 });
     }).toPass({ timeout: 10000 });
-    await page.getByRole("button", { name: "Disable", exact: true }).click();
+    await page.getByRole("button", { name: "More item actions" }).click();
+    await page.getByRole("menuitem", { name: "Disable", exact: true }).click();
 
     // The card stays exactly where it was, muted and badged — never removed.
     // `data-disabled` rides the CONTENT span inside the dnd button, not the
     // button itself (which carries dnd-kit's own aria-disabled).
     await expect(bravo.locator('[data-disabled="true"]')).toBeVisible();
     await expect(bravo.locator('[data-disabled-chip="self"]')).toHaveText("DISABLED");
+    const disabledContent = bravo.locator('[data-disabled="true"]');
+    await expect(disabledContent).toHaveClass(/ring-amber-300\/65/);
+    const disabledVisuals = disabledContent.locator('[data-disabled-visuals="true"]');
+    await expect
+      .poll(() => disabledVisuals.evaluate((element) => getComputedStyle(element).filter))
+      .toContain("grayscale");
+    await expect
+      .poll(() =>
+        disabledVisuals.evaluate((element) => Number(getComputedStyle(element).opacity)),
+      )
+      .toBeLessThan(1);
+    const disabledChip = disabledContent.locator('[data-disabled-chip="self"]');
+    await expect
+      .poll(() => disabledChip.evaluate((element) => getComputedStyle(element).opacity))
+      .toBe("1");
+    await expect
+      .poll(() => disabledChip.evaluate((element) => getComputedStyle(element).filter))
+      .toBe("none");
+    await expect
+      .poll(() =>
+        disabledChip.evaluate((element) => {
+          const style = getComputedStyle(element);
+          return [style.right, style.bottom];
+        }),
+      )
+      .toEqual(["8px", "8px"]);
+    const mediaKind = disabledContent.locator("[data-media-kind]");
+    await expect(mediaKind).toHaveText("IMAGE");
+    await expect
+      .poll(() => mediaKind.evaluate((element) => getComputedStyle(element).opacity))
+      .toBe("1");
+    await expect
+      .poll(() => mediaKind.evaluate((element) => getComputedStyle(element).filter))
+      .toBe("none");
     await expect.poll(() => stripOrder(page, PROJECT_ID)).toEqual([
       "alpha",
       "bravo",
@@ -2448,18 +2899,25 @@ test.describe("graph view E2E", () => {
     await expect(page.getByRole("button", { name: "Duplicate", exact: true })).toHaveCount(0);
 
     // Select alpha → the contextual cluster switches to item actions, the
-    // layout controls give way, and Paste is disabled (clipboard empty).
+    // layout controls give way, and Paste is absent while the clipboard is empty.
     await expect(async () => {
       await alpha.click();
       await expect(alpha).toHaveAttribute("data-selected", "true", { timeout: 700 });
     }).toPass({ timeout: 10000 });
-    await expect(page.getByRole("button", { name: "Duplicate", exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: "More item actions" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Duplicate", exact: true })).toHaveCount(0);
     await expect(page.getByRole("button", { name: "Grid layout" })).toHaveCount(0);
-    await expect(page.getByRole("button", { name: "Paste", exact: true })).toBeDisabled();
+    await expect(page.getByRole("button", { name: "Paste", exact: true })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Copy", exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Cut", exact: true })).toBeVisible();
+    await expect(page.locator("[data-item-actions-cluster] + div")).toHaveClass(
+      /bg-amber-300\/65/,
+    );
 
     // Duplicate → the clone lands right AFTER alpha (index 1), and the focused
     // document persists the add (one write, five clips).
-    await page.getByRole("button", { name: "Duplicate", exact: true }).click();
+    await page.getByRole("button", { name: "More item actions" }).click();
+    await page.getByRole("menuitem", { name: "Duplicate", exact: true }).click();
     await expect.poll(() => stripOrder(page, PROJECT_ID)).toHaveLength(5);
     const order = await stripOrder(page, PROJECT_ID);
     expect(order[0]).toBe("alpha");
@@ -2491,6 +2949,8 @@ test.describe("graph view E2E", () => {
     // Copy → Paste becomes enabled.
     await page.getByRole("button", { name: "Copy", exact: true }).click();
     await expect(page.getByRole("button", { name: "Paste", exact: true })).toBeEnabled();
+    await expect(page.getByRole("button", { name: "Copy", exact: true })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Cut", exact: true })).toHaveCount(0);
 
     // Drill into the child collection. The clipboard is a module singleton, so
     // it survives the client-side navigation: the rail stays in item mode with
@@ -2689,7 +3149,8 @@ test.describe("graph view E2E", () => {
 
     // Both copies land as one contiguous block after the LAST source (bravo),
     // keeping the sources' relative order.
-    await page.getByRole("button", { name: "Duplicate", exact: true }).click();
+    await page.getByRole("button", { name: "More item actions" }).click();
+    await page.getByRole("menuitem", { name: "Duplicate", exact: true }).click();
     await expect.poll(() => stripOrder(page, PROJECT_ID)).toHaveLength(6);
     const order = await stripOrder(page, PROJECT_ID);
     expect(order.slice(0, 2)).toEqual(["alpha", "bravo"]);
@@ -2990,6 +3451,58 @@ test.describe("graph view E2E", () => {
     await expect
       .poll(() => gridOrder(page, PROJECT_ID).then((order) => order.at(-1) ?? ""))
       .toMatch(/^timeline-/);
+  });
+
+  test("native grid collection drop centers its indicator in the chosen gap and inserts there", async ({
+    page,
+  }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    await surfaceButton(page, "grid").click();
+
+    const dropZone = page.locator(`[data-native-drop="${PROJECT_ID}"]`);
+    const grid = page.locator(`[data-virtual-grid="${PROJECT_ID}"]`);
+    const alphaBox = (await grid.locator('[data-node-id="alpha"]').boundingBox())!;
+    const bravoBox = (await grid.locator('[data-node-id="bravo"]').boundingBox())!;
+    const point = {
+      x: (alphaBox.x + alphaBox.width + bravoBox.x) / 2,
+      y: bravoBox.y + bravoBox.height / 2,
+    };
+
+    const accepted = await dropZone.evaluate((element, position) => {
+      const transfer = new DataTransfer();
+      transfer.setData("application/x-gstudio-type", "collection");
+      const event = new DragEvent("dragover", {
+        bubbles: true,
+        cancelable: true,
+        clientX: position.x,
+        clientY: position.y,
+        dataTransfer: transfer,
+      });
+      return !element.dispatchEvent(event);
+    }, point);
+    expect(accepted).toBe(true);
+
+    const indicator = dropZone.locator("[data-native-drop-indicator]");
+    await expect(indicator).toBeVisible();
+    const indicatorBox = (await indicator.boundingBox())!;
+    expect(indicatorBox.x + indicatorBox.width / 2).toBeCloseTo(point.x, 0);
+
+    const transfer = await page.evaluateHandle(() => {
+      const value = new DataTransfer();
+      value.setData("application/x-gstudio-type", "collection");
+      return value;
+    });
+    await dropZone.dispatchEvent("drop", {
+      dataTransfer: transfer,
+      clientX: point.x,
+      clientY: point.y,
+    });
+
+    await expect
+      .poll(() => gridOrder(page, PROJECT_ID))
+      .toEqual(["alpha", expect.stringMatching(/^timeline-/), "bravo", CHILD_ID, "charlie"]);
+    await expect(indicator).toHaveCount(0);
   });
 
   test("a 2xx upload with no usable url adds nothing and says so", async ({ page }) => {
@@ -3448,6 +3961,68 @@ test.describe("graph view E2E", () => {
       .poll(() => stripOrder(page, PROJECT_ID))
       .toEqual(["alpha", "bravo", CHILD_ID, "charlie"]);
     await expect(page.locator("[data-graph-ruler]")).toHaveCount(1);
+  });
+
+  test("flat mode keeps expanded child playheads synchronized with preview", async ({
+    page,
+  }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    await expandSubGraph(page, "Scene A");
+    await expect.poll(() => stripOrder(page, CHILD_ID)).toEqual(["c1", "c2"]);
+
+    await previewToggle(page).click();
+    await expect(page.locator("[data-preview-source]")).toHaveAttribute(
+      "data-preview-source",
+      "manifest",
+    );
+    await page.getByRole("button", { name: "Show all items in order" }).click();
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID), { timeout: 15000 })
+      .toEqual(["alpha", "bravo", "c1", "c2", "charlie"]);
+
+    const focusedRail = page.getByRole("slider", {
+      name: "Seek preview",
+      exact: true,
+    });
+    const childRail = page.getByRole("slider", {
+      name: "Seek preview in Scene A",
+      exact: true,
+    });
+    const maxOf = (rail: Locator) =>
+      rail.evaluate((element) => Number(element.getAttribute("aria-valuemax")));
+
+    // The focused rail measures the flat closure. The expanded child remains
+    // structured, so its rail must cover only Scene A instead of inheriting
+    // the focused run's full timing map.
+    const focusedMax = await maxOf(focusedRail);
+    const childMax = await maxOf(childRail);
+    expect(childMax).toBeGreaterThan(0);
+    expect(childMax).toBeLessThan(focusedMax);
+
+    // Seeking the child to its start uses Scene A's GLOBAL manifest window:
+    // its own playhead lands at x=0 while Preview draws that first child clip.
+    await childRail.focus();
+    await page.keyboard.press("Home");
+    await expect(childRail).toHaveAttribute("aria-valuenow", "0.0");
+
+    const childSection = page.locator(`section[aria-label="Sub-timeline: Scene A"]`);
+    const childPlayhead = childSection.locator("[data-graph-playhead]");
+    await expect(childPlayhead).toBeVisible();
+    await expect
+      .poll(() =>
+        childPlayhead.evaluate((element) => {
+          const match = /translateX\(([-\d.]+)px\)/.exec(
+            (element as HTMLElement).style.transform,
+          );
+          return match ? Number(match[1]) : Number.POSITIVE_INFINITY;
+        }),
+      )
+      .toBeLessThan(5);
+    await expect(page.getByTestId("workbench-display-canvas")).toHaveAttribute(
+      "aria-label",
+      "c1 preview",
+    );
   });
 
   test("flat cards name their collection, and reveal it", async ({ page }) => {

--- a/packages/timeline-domain/src/adapter.test.ts
+++ b/packages/timeline-domain/src/adapter.test.ts
@@ -827,7 +827,12 @@ describe("hydratedCollectionPreviews (card frames)", () => {
     const previews = hydratedCollectionPreviews(focused.value.graph, "kid");
     // The stored summary was a single "p1" frame; live children are k-a, k-b.
     expect(previews.map((p) => p.id)).toEqual(["k-a", "k-b"]);
-    expect(previews[0]).toEqual({ id: "k-a", src: "https://example.com/k-a.jpg" });
+    expect(previews[0]).toEqual({
+      id: "k-a",
+      kind: "image",
+      src: "https://example.com/k-a.jpg",
+      alt: "k-a alt",
+    });
   });
 
   it("reflects a front-insertion into the live child", () => {
@@ -850,7 +855,7 @@ describe("hydratedCollectionPreviews (card frames)", () => {
       docs([
         image("k-a", 1),
         image("k-b", 1),
-        video("k-vid", 6, 0, 0),
+        video("k-vid", 8, 2, 0),
         image("k-d", 1),
         image("k-e", 1),
       ]),
@@ -864,8 +869,11 @@ describe("hydratedCollectionPreviews (card frames)", () => {
     // The video frame paints its poster, not the source url.
     expect(previews[1]).toEqual({
       id: "k-vid",
+      kind: "video",
       src: "https://example.com/k-vid.mp4",
       poster: "https://example.com/k-vid-poster.jpg",
+      trimIn: 2,
+      alt: "k-vid alt",
     });
   });
 
@@ -918,5 +926,48 @@ describe("hydratedCollectionPreviews (card frames)", () => {
     if (!focused.ok) throw new Error(focused.error);
 
     expect(hydratedCollectionPreviews(focused.value.graph, "kid")).toEqual([]);
+  });
+
+  it("skips unusable media and continues to the next nested preview", () => {
+    const graphResult = buildGraph([
+      {
+        kind: "collection",
+        id: "kid",
+        name: "Kid",
+        children: [
+          {
+            kind: "media",
+            mediaKind: "video",
+            id: "posterless",
+            name: "Posterless",
+            src: "https://example.com/posterless.mp4",
+            fullDurationSeconds: 10,
+          },
+          {
+            kind: "media",
+            mediaKind: "image",
+            id: "missing-image",
+            name: "Missing image",
+          },
+          {
+            kind: "media",
+            mediaKind: "image",
+            id: "usable",
+            name: "Usable",
+            src: "https://example.com/usable.jpg",
+          },
+        ],
+      },
+    ]);
+    if (!graphResult.ok) throw new Error(JSON.stringify(graphResult.error));
+
+    expect(hydratedCollectionPreviews(graphResult.value, "kid")).toEqual([
+      {
+        id: "usable",
+        kind: "image",
+        src: "https://example.com/usable.jpg",
+        alt: "Usable",
+      },
+    ]);
   });
 });

--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -29,7 +29,6 @@ import {
   CLIP_GAP_SECONDS,
   TIMELINE_LEADING_PADDING_SECONDS,
 } from "@storyboard/timeline-model/constants";
-import { previewItemsFrom } from "@storyboard/timeline-model/documents";
 import type {
   AssetSourceRef,
   CollectionTimelineClip,
@@ -409,29 +408,28 @@ export function hydratedCollectionPlayableDuration(
 }
 
 /**
- * Preview frames of a HYDRATED collection, derived from its live children with
- * the SAME `previewItemsFrom` the read-time summary derivation uses — so the
- * projection and the served document agree byte-for-byte.
- *
- * This exists for the same reason `hydratedCollectionDuration` does: a stored
- * summary's `previewItems` goes stale the moment the CHILD document is edited
- * (add to the front, delete the first clip, reorder), and because the write
- * path persists documents THROUGH this projection, an unrelated parent write
- * RE-PERSISTED the stale frames — baking the wrong preview into storage.
- * Deriving from the live children makes the UI's collection card and the
- * stored document agree, and writes self-healing. Placeholders keep their
- * stored summary — it is all anyone knows about them.
+ * Preview frames of a hydrated collection, derived recursively from its live
+ * descendants. Persisting the same result makes collection-only ancestors
+ * self-healing after edits instead of baking a stale or blank summary back
+ * into storage.
  */
 function hydratedCollectionPreviewItems(
   graph: CollectionsGraph,
   details: DetailsById,
   collectionId: NodeId,
 ): CollectionTimelineClip["previewItems"] {
-  return previewItemsFrom(graphChildrenToClips(graph, details, collectionId as string));
+  return [...hydratedCollectionPreviews(graph, collectionId as string, details)];
 }
 
 /** A collection card's preview frame: exactly the fields the card paints. */
-export type CollectionPreviewFrame = Readonly<{ id: string; src: string; poster?: string }>;
+export type CollectionPreviewFrame = Readonly<{
+  id: string;
+  kind: "image" | "video";
+  src: string;
+  poster?: string;
+  trimIn?: number;
+  alt: string;
+}>;
 
 /**
  * Preview frames for a HYDRATED collection CARD, derived from its LIVE media
@@ -446,37 +444,48 @@ export type CollectionPreviewFrame = Readonly<{ id: string; src: string; poster?
  * `itemCount` once hydrated. Placeholders have no live children, so callers
  * keep their stored summary.
  *
- * Graph-only (no side-table needed): a media node already carries the
- * thumbnail the card paints — `posterSrcs` for video, `src` for an image —
- * and the same first/middle/last selection `previewItemsFrom` uses keeps the
- * card in step with the persisted preview.
+ * Media source URLs live on graph nodes. The optional details table adds the
+ * image poster and display alt text when this helper is used for persistence.
  *
  * RECURSES into sub-collections: a collection whose direct children are all
  * nested collections has no media of its own to show, so the walk descends
  * depth-first (in child order) to surface the first nested image — and the
  * rest, from which first/middle/last is picked. A placeholder sub-collection
  * has no children in the graph, so the descent stops there naturally (its
- * nested media aren't loaded and can't be shown until it hydrates). This is a
- * LIVE-card enrichment only; the persisted summary (`hydratedCollectionPreviewItems`
- * / `previewItemsFrom`) stays direct-media, since it can't resolve documents
- * it doesn't hold.
+ * nested media aren't loaded and can't be shown until it hydrates). The
+ * persisted recursive summary then lets higher, unhydrated ancestors reuse
+ * the resolved descendant frame.
  */
 export function hydratedCollectionPreviews(
   graph: CollectionsGraph,
   collectionId: string,
+  details?: DetailsById,
 ): readonly CollectionPreviewFrame[] {
   const media: CollectionPreviewFrame[] = [];
-  const seen = new Set<string>();
+  const seen = new Set<string>([collectionId]);
   const collect = (id: NodeId): void => {
     for (const childId of getChildren(graph, id)) {
       const node = graph.nodesById.get(childId);
       if (!node) continue;
       if (node.kind === "media") {
-        const poster = node.mediaKind === "video" ? node.posterSrcs?.[0] : undefined;
+        const detail = details?.[node.id as string];
+        const src = node.src?.trim() ?? "";
+        const poster =
+          node.mediaKind === "video"
+            ? node.posterSrcs?.find((candidate) => candidate.trim().length > 0)
+            : detail?.poster;
+        if (node.mediaKind === "video" ? poster === undefined : src.length === 0) {
+          continue;
+        }
         media.push({
           id: node.id as string,
-          src: node.src ?? "",
+          kind: node.mediaKind === "video" ? "video" : "image",
+          src,
           ...(poster === undefined ? {} : { poster }),
+          ...(node.mediaKind === "video" && node.trimInSeconds > 0
+            ? { trimIn: node.trimInSeconds }
+            : {}),
+          alt: detail?.alt ?? node.name,
         });
       } else if (node.kind === "collection") {
         // Descend to find nested images. `seen` guards a pathological cycle

--- a/packages/timeline-model/documents.ts
+++ b/packages/timeline-model/documents.ts
@@ -31,6 +31,7 @@ export function previewItemsFrom(clips: TimelineClip[]) {
     kind: clip.kind,
     src: clip.src,
     poster: clip.poster,
+    ...(clip.kind === "video" && clip.trimIn > 0 ? { trimIn: clip.trimIn } : {}),
     alt: clip.alt,
   }));
 }

--- a/packages/timeline-model/types.ts
+++ b/packages/timeline-model/types.ts
@@ -131,6 +131,8 @@ export type CollectionTimelineClip = TimelineItemBase & {
     kind: MediaKind;
     src: string;
     poster?: string;
+    /** Source-time offset represented by a video preview. Absent means 0. */
+    trimIn?: number;
     alt: string;
   }>;
 };

--- a/packages/timeline-model/validate.test.ts
+++ b/packages/timeline-model/validate.test.ts
@@ -61,6 +61,28 @@ describe("isTimelineClip", () => {
     expect(isTimelineClip({ ...image, sourceAsset: null })).toBe(true);
   });
 
+  it("accepts a finite preview trim and rejects malformed preview trims", () => {
+    const preview = collection.previewItems[0];
+    expect(
+      isTimelineClip({
+        ...collection,
+        previewItems: [{ ...preview, kind: "video", trimIn: 2.5 }],
+      }),
+    ).toBe(true);
+    expect(
+      isTimelineClip({
+        ...collection,
+        previewItems: [{ ...preview, kind: "video", trimIn: "2.5" }],
+      }),
+    ).toBe(false);
+    expect(
+      isTimelineClip({
+        ...collection,
+        previewItems: [{ ...preview, kind: "video", trimIn: Number.NaN }],
+      }),
+    ).toBe(false);
+  });
+
   it("accepts a whole sourceAsset ref and rejects a half-recorded one", () => {
     const ref = { providerId: "cloudinary", assetId: "gstudio/u/pic-1" };
     expect(isTimelineClip({ ...image, sourceAsset: ref })).toBe(true);

--- a/packages/timeline-model/validate.ts
+++ b/packages/timeline-model/validate.ts
@@ -105,7 +105,8 @@ export function isTimelineClip(value: unknown): value is TimelineClip {
         (preview.kind === "image" || preview.kind === "video") &&
         typeof preview.src === "string" &&
         typeof preview.alt === "string" &&
-        isOptionalString(preview.poster)
+        isOptionalString(preview.poster) &&
+        isOptionalFiniteNumber(preview.trimIn)
       );
     });
   }

--- a/packages/ui/dnd-collections/VirtualGrid.stories.tsx
+++ b/packages/ui/dnd-collections/VirtualGrid.stories.tsx
@@ -436,11 +436,30 @@ export const PaletteIntoGridAndNestIntoCollection: Story = {
       expect(gridOrder(canvasElement, "grid")[1]).toMatch(/^vid-/);
     });
 
-    // Palette collection onto the folder card's center: nest-add inside.
+    // Palette collection onto the folder card's center: the label remains
+    // visible at the bottom-center while the drag ghost occupies the middle.
     const collectionButton = canvasElement.querySelector<HTMLElement>(
       '[data-palette-item="new-collection"]'
     )!;
-    await dragToPoint(collectionButton, rectCenter(nodeCard(canvasElement, "folder")));
+    const folderPoint = rectCenter(nodeCard(canvasElement, "folder"));
+    await dragHoldAt(collectionButton, folderPoint);
+    await waitFor(() => {
+      const overlay = canvasElement.querySelector<HTMLElement>('[data-nest-state="valid"]');
+      expect(overlay).not.toBeNull();
+      const label = overlay!.querySelector<HTMLElement>("span");
+      expect(label).not.toBeNull();
+      const overlayRect = overlay!.getBoundingClientRect();
+      const labelRect = label!.getBoundingClientRect();
+      expect(labelRect.top).toBeGreaterThan(overlayRect.top + overlayRect.height / 2);
+      expect(labelRect.left + labelRect.width / 2).toBeCloseTo(
+        overlayRect.left + overlayRect.width / 2,
+        0,
+      );
+      expect(getComputedStyle(label!).fontSize).toBe("12px");
+      expect(getComputedStyle(overlay!).backdropFilter).toContain("blur");
+      expect(overlay!.className).toContain("bg-muted/70");
+    });
+    await releaseAt(folderPoint);
     await waitFor(() => {
       expect(nodeCard(canvasElement, "folder").getAttribute("aria-label")).toMatch(
         /collection, 2 items/i
@@ -507,6 +526,64 @@ export const GridGapDropInsertsAtBoundary: Story = {
       );
       expect(ids.slice(0, 7)).toEqual(["m1", "m2", "m3", "m4", "m5", "m0", "m6"]);
     });
+  },
+};
+
+export const CardBoundaryIndicatorStaysCenteredInGap: Story = {
+  render: () => <GridHarness />,
+  play: async ({ canvasElement }) => {
+    const m0 = nodeCard(canvasElement, "m0");
+    const m5 = nodeCard(canvasElement, "m5");
+    const m6 = nodeCard(canvasElement, "m6");
+    await waitForLayout(m6);
+    const m5Rect = m5.getBoundingClientRect();
+    const m6Rect = m6.getBoundingClientRect();
+    const target = {
+      x: m6Rect.left + 2,
+      y: m6Rect.top + m6Rect.height / 2,
+    };
+
+    await dragHoldAt(m0, target);
+    await waitFor(() => {
+      const indicator = canvasElement.querySelector<HTMLElement>(
+        '[data-drop-indicator="before"]',
+      );
+      expect(indicator).not.toBeNull();
+      const indicatorRect = indicator!.getBoundingClientRect();
+      const indicatorCenter = indicatorRect.left + indicatorRect.width / 2;
+      const gapCenter = (m5Rect.right + m6Rect.left) / 2;
+      expect(indicatorCenter).toBeCloseTo(gapCenter, 0);
+    });
+    await releaseAt(target);
+  },
+};
+
+export const RowStartIndicatorsShareOnePosition: Story = {
+  render: () => <GridHarness />,
+  play: async ({ canvasElement }) => {
+    const m4 = nodeCard(canvasElement, "m4");
+    const m7 = nodeCard(canvasElement, "m7");
+    await waitForLayout(m7);
+    const m4Rect = m4.getBoundingClientRect();
+    const target = {
+      x: m4Rect.left + 2,
+      y: m4Rect.top + m4Rect.height / 2,
+    };
+
+    await dragHoldAt(m7, target);
+    await waitFor(() => {
+      const indicators = [
+        ...canvasElement.querySelectorAll<HTMLElement>(
+          '[data-drop-indicator="before"], [data-drop-indicator="virtual-grid"]',
+        ),
+      ];
+      expect(indicators.length).toBeGreaterThan(0);
+      for (const indicator of indicators) {
+        const rect = indicator.getBoundingClientRect();
+        expect(rect.left + rect.width / 2).toBeCloseTo(m4Rect.left, 0);
+      }
+    });
+    await releaseAt(target);
   },
 };
 

--- a/packages/ui/dnd-collections/react/node-views.tsx
+++ b/packages/ui/dnd-collections/react/node-views.tsx
@@ -373,13 +373,18 @@ export function NodeCardIndicators({
         <div
           data-nest-state={nestState}
           className={[
-            "pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-md border-2 text-[10px] font-bold",
+            "pointer-events-none absolute inset-0 z-10 flex items-end justify-center rounded-md border-2 px-2 pb-2 text-xs font-bold",
             nestState === "valid"
-              ? "border-primary bg-primary/15 text-primary"
-              : "border-destructive bg-destructive/15 text-destructive",
+              ? "border-primary bg-muted/70 text-foreground backdrop-blur-[2px]"
+              : "border-destructive bg-destructive/20 text-destructive backdrop-blur-[1px]",
           ].join(" ")}
         >
-          <span className="rounded bg-background/95 px-1.5 py-0.5 shadow">
+          <span
+            className={[
+              "rounded-md bg-background/95 px-2 py-1 shadow-lg ring-1",
+              nestState === "valid" ? "ring-primary/60" : "ring-destructive/50",
+            ].join(" ")}
+          >
             {nestState === "valid" ? "Drop to nest" : "Cannot drop (cycle)"}
           </span>
         </div>
@@ -390,14 +395,20 @@ export function NodeCardIndicators({
         <div
           aria-hidden="true"
           data-drop-indicator="before"
-          className="pointer-events-none absolute inset-y-0 -left-1.5 z-20 w-1 rounded-full bg-primary"
+          className="pointer-events-none absolute inset-y-0 z-20 w-1 -translate-x-1/2 rounded-full bg-primary"
+          style={{
+            left: "calc(-1 * var(--dnd-drop-indicator-half-gap, 4px))",
+          }}
         />
       )}
       {dropSide === "after" && (
         <div
           aria-hidden="true"
           data-drop-indicator="after"
-          className="pointer-events-none absolute inset-y-0 -right-1.5 z-20 w-1 rounded-full bg-primary"
+          className="pointer-events-none absolute inset-y-0 z-20 w-1 translate-x-1/2 rounded-full bg-primary"
+          style={{
+            right: "calc(-1 * var(--dnd-drop-indicator-half-gap, 4px))",
+          }}
         />
       )}
     </>

--- a/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
@@ -8,8 +8,10 @@ import {
   useMemo,
   useState,
   type ReactNode,
+  type CSSProperties,
 } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
+import { twMerge } from "tailwind-merge";
 
 import { getChildren, type NodeId } from "../core/graph";
 import {
@@ -319,7 +321,9 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
         : Math.floor(indicatorIndex / cols);
       const col = appendAfterFullRow ? cols : indicatorIndex % cols;
       return {
-        left: Math.max(0, col * (fillCellWidth + gap) - gap / 2 - 2),
+        // Match the leading-gap center used by a card's "before" indicator.
+        // Clamping created a second position at the first item in every row.
+        left: Math.max(0, col * (fillCellWidth + gap) - gap / 2),
         top: row * rowSize,
       };
     })();
@@ -342,11 +346,16 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
         aria-rowcount={rowCount}
         aria-colcount={cols}
         onKeyDown={onKeyDown}
-        className={[
+        className={twMerge(
           "relative overflow-y-auto rounded-md border border-dashed border-border p-2",
-          className ?? "",
-        ].join(" ")}
-        style={{ maxHeight: height }}
+          className,
+        )}
+        style={
+          {
+            maxHeight: height,
+            "--dnd-drop-indicator-half-gap": `${gap / 2}px`,
+          } as CSSProperties
+        }
       >
         <VirtualEmptyHint visible={childIds.length === 0} />
         <div
@@ -364,7 +373,7 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
             <div
               aria-hidden="true"
               data-drop-indicator="virtual-grid"
-              className="pointer-events-none absolute z-20 w-1 rounded-full bg-primary"
+              className="pointer-events-none absolute z-20 w-1 -translate-x-1/2 rounded-full bg-primary"
               style={{ left: indicator.left, top: indicator.top, height: cellHeight }}
             />
           )}
@@ -394,7 +403,17 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
                       role="gridcell"
                       aria-colindex={colInRow + 1}
                       onFocus={() => onItemFocus(id)}
-                      style={{ width: fillCellWidth, height: cellHeight }}
+                      style={
+                        {
+                          width: fillCellWidth,
+                          height: cellHeight,
+                          // A row-start boundary is the grid's left edge, not
+                          // the centre of a fictional gap outside the scroller.
+                          // Match the virtual indicator's clamped coordinate so
+                          // the two rendering paths can never alternate.
+                          "--dnd-drop-indicator-half-gap": colInRow === 0 ? "0px" : `${gap / 2}px`,
+                        } as CSSProperties
+                      }
                     >
                       <ItemShell
                         id={id}

--- a/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
@@ -9,9 +9,11 @@ import {
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
   type ReactNode,
 } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
+import { twMerge } from "tailwind-merge";
 
 import {
   getChildren,
@@ -830,10 +832,10 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
             aria-rowcount={childIds.length === 0 ? 0 : 1}
             aria-colcount={childIds.length}
             onKeyDown={onKeyDown}
-            className={[
+            className={twMerge(
               "relative overflow-x-auto rounded-md border border-dashed border-border p-2",
-              className ?? "",
-            ].join(" ")}
+              className,
+            )}
             // When WE own horizontal scrolling (pan hook), reserve horizontal
             // touch gestures for it and leave vertical native ("pan-y"). With
             // panToScroll off there is no pan hook, so the browser must keep
@@ -860,7 +862,7 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
                 <div
                   aria-hidden="true"
                   data-drop-indicator="virtual"
-                  className="pointer-events-none absolute inset-y-0 z-20 w-1 rounded-full bg-primary"
+                  className="pointer-events-none absolute inset-y-0 z-20 w-1 -translate-x-1/2 rounded-full bg-primary"
                   style={{ left: indicatorLeft }}
                 />
               )}
@@ -873,14 +875,18 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
                   // Sync the roving index to whatever card actually gains focus
                   // (click, programmatic focus), not just keyboard navigation.
                   onFocus={() => onItemFocus(childIds[item.index])}
-                  style={{
-                    position: "absolute",
-                    top: 0,
-                    left: 0,
-                    width: item.size - gap,
-                    height: itemHeight,
-                    transform: `translateX(${item.start}px)`,
-                  }}
+                  style={
+                    {
+                      position: "absolute",
+                      top: 0,
+                      left: 0,
+                      width: item.size - gap,
+                      height: itemHeight,
+                      transform: `translateX(${item.start}px)`,
+                      "--dnd-drop-indicator-half-gap":
+                        item.index === 0 ? "0px" : `${gap / 2}px`,
+                    } as CSSProperties
+                  }
                 >
                   {/* Explicit sizing: the item fills its (possibly variable) slot.
                       With panToScroll, item drags move to the grip bar or behind

--- a/packages/ui/dnd-collections/virtual/virtual-strip-geometry.test.ts
+++ b/packages/ui/dnd-collections/virtual/virtual-strip-geometry.test.ts
@@ -40,8 +40,8 @@ describe("resolveBoundaryIndex", () => {
 });
 
 describe("indicatorLeftOffset", () => {
-  it("insets half a gap plus the indicator half-width", () => {
-    expect(indicatorLeftOffset(120, 8)).toBe(114); // 120 - 4 - 2
+  it("returns the geometric center of the preceding gap", () => {
+    expect(indicatorLeftOffset(120, 8)).toBe(116);
   });
 
   it("never goes negative", () => {
@@ -50,7 +50,7 @@ describe("indicatorLeftOffset", () => {
   });
 
   it("handles a zero gap", () => {
-    expect(indicatorLeftOffset(50, 0)).toBe(48);
+    expect(indicatorLeftOffset(50, 0)).toBe(50);
   });
 });
 

--- a/packages/ui/dnd-collections/virtual/virtual-strip-geometry.ts
+++ b/packages/ui/dnd-collections/virtual/virtual-strip-geometry.ts
@@ -10,9 +10,6 @@ import {
   type NodeId,
 } from "../core/graph";
 
-/** Half the drop-indicator line's width (px) — used to center it in a gap. */
-const INDICATOR_HALF_WIDTH = 2;
-
 /**
  * A fully trimmed clip can derive a 0px width from its duration. The slot
  * still needs to be visible and clickable: NodeCard's `w-full` fills the slot
@@ -46,12 +43,12 @@ export function resolveBoundaryIndex(
 
 /**
  * Left offset (content coords) for the drop indicator at a boundary whose gap
- * begins at `edgeStart` — half a gap back, centered on the indicator line, and
+ * begins at `edgeStart` — half a gap back at the line's geometric centre, and
  * never negative. `edgeStart` is the following item's `start`, or the strip's
  * total size when appending at the far end.
  */
 export function indicatorLeftOffset(edgeStart: number, gap: number): number {
-  return Math.max(0, edgeStart - gap / 2 - INDICATOR_HALF_WIDTH);
+  return Math.max(0, edgeStart - gap / 2);
 }
 
 /**

--- a/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
+++ b/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
@@ -5,7 +5,10 @@ import { expect, userEvent, within } from "storybook/test";
 
 import type { TimelineClip } from "../types";
 
-import { WorkbenchSplitPane } from "./workbench-display-surface";
+import {
+  WorkbenchDisplaySurface,
+  WorkbenchSplitPane,
+} from "./workbench-display-surface";
 
 function StickyPreviewFixture() {
   const [currentTime, setCurrentTime] = useState(0);
@@ -13,9 +16,14 @@ function StickyPreviewFixture() {
   return (
     <main className="min-h-[1600px] bg-zinc-950 p-4 text-zinc-100">
       <WorkbenchSplitPane
-        clips={[]}
-        currentTime={currentTime}
-        onCurrentTimeChange={setCurrentTime}
+        surface={
+          <WorkbenchDisplaySurface
+            clips={[]}
+            currentTime={currentTime}
+            onCurrentTimeChange={setCurrentTime}
+            className="h-full rounded-b-none border-b-0"
+          />
+        }
       >
         <div className="grid gap-3">
           {Array.from({ length: 18 }, (_, index) => (
@@ -39,9 +47,7 @@ const meta = {
     layout: "fullscreen",
   },
   args: {
-    clips: [],
-    currentTime: 0,
-    onCurrentTimeChange: () => undefined,
+    surface: null,
     children: null,
   },
 } satisfies Meta<typeof WorkbenchSplitPane>;
@@ -54,6 +60,107 @@ type Story = StoryObj<typeof meta>;
  * the timeline sections continue through the document scrollport. */
 export const StickyPreview: Story = {
   render: () => <StickyPreviewFixture />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const splitPane = canvas.getByTestId("workbench-split-pane");
+    const displaySurface = canvas.getByTestId("workbench-display-surface");
+    const previewCanvas = canvas.getByTestId("workbench-display-canvas");
+    const controls = canvas.getByTestId("workbench-preview-controls");
+    const divider = canvas.getByRole("separator", {
+      name: "Resize workbench display",
+    });
+    const lowerPane = canvas.getByTestId("workbench-lower-pane");
+
+    // Timeline overlays can deliberately center a thumb on the content edge.
+    // Keep that overhang visible below the preview, while narrow masks on the
+    // sticky region prevent it from peeking around the preview itself.
+    expect(getComputedStyle(splitPane).overflowX).toBe("visible");
+    expect(
+      canvasElement.querySelectorAll("[data-preview-edge-occluder]"),
+    ).toHaveLength(2);
+    expect(getComputedStyle(displaySurface).borderBottomWidth).toBe("0px");
+    expect(getComputedStyle(controls).position).toBe("absolute");
+    expect(controls.parentElement).toBe(displaySurface);
+    const buttonGroup = controls.querySelector<HTMLElement>("[data-transport-button-group]");
+    const dividerLine = divider.querySelector<HTMLElement>("[data-divider-line]");
+    expect(buttonGroup).not.toBeNull();
+    expect(dividerLine).not.toBeNull();
+    const buttonGroupBox = buttonGroup!.getBoundingClientRect();
+    const dividerBox = divider.getBoundingClientRect();
+    const dividerLineBox = dividerLine!.getBoundingClientRect();
+    expect(buttonGroupBox.width).toBe(132);
+    expect(buttonGroupBox.height).toBe(44);
+    expect(controls.querySelector("[data-transport-capsule]")).toBeNull();
+    expect(divider.querySelector("[data-divider-grip]")).toBeNull();
+    expect(dividerBox.height).toBe(12);
+    expect(buttonGroupBox.y + buttonGroupBox.height / 2).toBeCloseTo(
+      dividerBox.y + dividerBox.height / 2,
+      0,
+    );
+    expect(dividerLineBox.y + dividerLineBox.height / 2).toBeCloseTo(
+      buttonGroupBox.y + buttonGroupBox.height / 2,
+      0,
+    );
+    expect(controls).toHaveAttribute("data-transport-layout", "static");
+    expect(
+      canvas.getByRole("button", { name: "Previous workbench clip" }),
+    ).toBeVisible();
+    expect(canvas.getByRole("button", { name: "Next workbench clip" })).toBeVisible();
+    expect(canvas.getByTestId("workbench-preview-time")).toHaveTextContent("0s / 0s");
+    expect(previewCanvas.getBoundingClientRect().bottom).toBeCloseTo(dividerBox.y, 0);
+    expect(getComputedStyle(lowerPane).zIndex).toBe("0");
+  },
+};
+
+function PersistentLowerPaneFixture() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <main className="bg-zinc-950 p-4 text-zinc-100">
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        className="mb-3 rounded border border-zinc-700 px-3 py-1 text-sm"
+      >
+        Toggle surface
+      </button>
+      <WorkbenchSplitPane
+        surface={
+          open ? (
+            <div className="grid h-full place-items-center bg-zinc-900">Preview surface</div>
+          ) : null
+        }
+      >
+        <div
+          data-testid="persistent-lower-scroller"
+          className="w-full overflow-x-auto"
+        >
+          <div className="h-24 w-[1600px] bg-zinc-800" />
+        </div>
+      </WorkbenchSplitPane>
+    </main>
+  );
+}
+
+/** Opening the optional surface must not replace the lower-pane DOM node or
+ * reset state owned by it, including a virtual timeline's horizontal scroll. */
+export const PersistentLowerPane: Story = {
+  render: () => <PersistentLowerPaneFixture />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const user = userEvent.setup();
+    const scroller = canvas.getByTestId("persistent-lower-scroller");
+
+    scroller.scrollLeft = 480;
+    const scrollBeforeToggle = scroller.scrollLeft;
+    expect(scrollBeforeToggle).toBeGreaterThan(0);
+    scroller.dataset.identityWitness = "same-node";
+    await user.click(canvas.getByRole("button", { name: "Toggle surface" }));
+
+    expect(canvas.getByTestId("workbench-preview-region")).toBeVisible();
+    expect(scroller).toHaveAttribute("data-identity-witness", "same-node");
+    expect(scroller.scrollLeft).toBe(scrollBeforeToggle);
+  },
 };
 
 // A playable clip is REQUIRED for the controlled-playback story, and the
@@ -95,11 +202,16 @@ function ControlledPlaybackFixture() {
         External play toggle
       </button>
       <WorkbenchSplitPane
-        clips={[PLAYABLE_CLIP]}
-        currentTime={currentTime}
-        onCurrentTimeChange={setCurrentTime}
-        playing={playing}
-        onPlayingChange={setPlaying}
+        surface={
+          <WorkbenchDisplaySurface
+            clips={[PLAYABLE_CLIP]}
+            currentTime={currentTime}
+            onCurrentTimeChange={setCurrentTime}
+            playing={playing}
+            onPlayingChange={setPlaying}
+            className="h-full rounded-b-none border-b-0"
+          />
+        }
       >
         <div className="min-h-24" />
       </WorkbenchSplitPane>
@@ -115,9 +227,35 @@ export const ControlledPlayback: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const user = userEvent.setup();
+    const controls = canvas.getByTestId("workbench-preview-controls");
+    const previewCanvas = canvas.getByTestId("workbench-display-canvas");
+    const primaryControl = controls.querySelector<HTMLElement>(
+      "[data-transport-primary-control]",
+    );
+    expect(primaryControl).not.toBeNull();
 
     // Starts paused → the surface offers "Play".
     expect(canvas.getByRole("button", { name: "Play workbench preview" })).toBeInTheDocument();
+    expect(controls).toHaveAttribute("data-transport-layout", "static");
+    expect(
+      canvas.getByRole("button", { name: "Previous workbench clip" }),
+    ).toBeVisible();
+    expect(canvas.getByRole("button", { name: "Next workbench clip" })).toBeVisible();
+    expect(previewCanvas).not.toHaveAttribute("tabindex");
+
+    const previewBounds = previewCanvas.getBoundingClientRect();
+    await user.pointer({
+      target: previewCanvas,
+      coords: {
+        clientX: previewBounds.left + previewBounds.width / 2,
+        clientY: previewBounds.top + previewBounds.height / 2,
+      },
+    });
+    expect(getComputedStyle(previewCanvas).cursor).toBe("pointer");
+    expect(primaryControl).toHaveClass("text-white");
+    expect(getComputedStyle(primaryControl!).backgroundColor).toBe("rgba(0, 0, 0, 0)");
+    expect(controls).toHaveAttribute("data-transport-layout", "static");
+    await user.unhover(previewCanvas);
 
     // Flip the controlled prop from OUTSIDE the surface; it re-renders as
     // "Pause" and STAYS there — the fixture clip is 30s, so nothing stops
@@ -126,6 +264,11 @@ export const ControlledPlayback: Story = {
     expect(
       await canvas.findByRole("button", { name: "Pause workbench preview" }),
     ).toBeInTheDocument();
+    expect(canvas.getByTestId("workbench-preview-time")).toHaveTextContent("0s / 30.0s");
+
+    await user.tab();
+    expect(controls.contains(document.activeElement)).toBe(true);
+    expect(controls).toHaveAttribute("data-transport-layout", "static");
   },
 };
 
@@ -137,10 +280,15 @@ function ClosablePreviewFixture() {
     <main className="min-h-[900px] bg-zinc-950 p-4 text-zinc-100">
       {open ? (
         <WorkbenchSplitPane
-          clips={[]}
-          currentTime={currentTime}
-          onCurrentTimeChange={setCurrentTime}
-          onClose={() => setOpen(false)}
+          surface={
+            <WorkbenchDisplaySurface
+              clips={[]}
+              currentTime={currentTime}
+              onCurrentTimeChange={setCurrentTime}
+              onClose={() => setOpen(false)}
+              className="h-full rounded-b-none border-b-0"
+            />
+          }
         >
           <div className="min-h-24" />
         </WorkbenchSplitPane>

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -43,6 +43,19 @@ type CachedMedia =
   | { kind: "image"; element: HTMLImageElement }
   | { kind: "video"; element: HTMLVideoElement };
 
+type PlaybackSurfaceRect = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+type CanvasPointEvent = {
+  clientX: number;
+  clientY: number;
+  currentTarget: HTMLCanvasElement;
+};
+
 type WorkbenchDisplaySurfaceProps = {
   clips: TimelineClip[];
   currentTime: number;
@@ -65,9 +78,117 @@ const BUFFER_WINDOW_SIZE = 4;
 const DEFAULT_SURFACE_HEIGHT = 380;
 const MIN_SURFACE_HEIGHT = 120;
 const MIN_TIMELINE_SPACE = 260;
-/** The resize divider's own height (Tailwind h-3). Part of the sticky preview
- *  region, so the published sticky offset must include it. */
+/** The resize divider's own height (Tailwind h-3). The transport is centered
+ *  on this stable track and may overhang it without changing layout. */
 const DIVIDER_HEIGHT_PX = 12;
+
+type WorkbenchDividerTransportProps = {
+  currentTime: number;
+  duration: number;
+  isPlaying: boolean;
+  canPlay: boolean;
+  canSeekPrevious: boolean;
+  canSeekNext: boolean;
+  previewHovered: boolean;
+  onTogglePlaying: () => void;
+  onSeekPrevious: () => void;
+  onSeekNext: () => void;
+};
+
+function WorkbenchDividerTransport({
+  currentTime,
+  duration,
+  isPlaying,
+  canPlay,
+  canSeekPrevious,
+  canSeekNext,
+  previewHovered,
+  onTogglePlaying,
+  onSeekPrevious,
+  onSeekNext,
+}: WorkbenchDividerTransportProps) {
+  return (
+    <div
+      role="group"
+      aria-label="Preview transport"
+      className="pointer-events-none absolute inset-x-0 top-full z-50 h-0"
+      data-testid="workbench-preview-controls"
+      data-transport-layout="static"
+    >
+      <div
+        className="pointer-events-auto absolute left-1/2 flex h-11 w-[8.25rem] items-center justify-center"
+        data-transport-button-group
+        style={{ top: DIVIDER_HEIGHT_PX / 2, transform: "translate(-50%, -50%)" }}
+        onPointerDown={(event) => {
+          // The transport visually occupies the divider, but remains its own
+          // interaction island. A transport press must never begin a resize.
+          event.stopPropagation();
+        }}
+      >
+        <button
+          type="button"
+          onClick={onSeekPrevious}
+          disabled={!canSeekPrevious}
+          className="group/previous relative z-10 grid size-11 shrink-0 place-items-center text-zinc-400 transition-colors hover:text-white focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-30"
+          aria-label="Previous workbench clip"
+          title="Previous clip"
+        >
+          <span className="grid size-5 translate-x-2 place-items-center rounded-full transition-colors group-focus-visible/previous:ring-2 group-focus-visible/previous:ring-sky-400 group-focus-visible/previous:ring-offset-2 group-focus-visible/previous:ring-offset-zinc-950">
+            <SkipBack className="size-3 fill-current" />
+          </span>
+        </button>
+
+        <button
+          type="button"
+          onClick={onTogglePlaying}
+          disabled={!canPlay}
+          className="group/play relative z-10 grid size-11 shrink-0 place-items-center text-zinc-400 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40"
+          aria-label={isPlaying ? "Pause workbench preview" : "Play workbench preview"}
+          title={isPlaying ? "Pause" : "Play"}
+        >
+          <span
+            className={cn(
+              "grid size-5 place-items-center rounded-full transition-colors group-hover/play:text-white group-focus-visible/play:ring-2 group-focus-visible/play:ring-sky-400 group-focus-visible/play:ring-offset-2 group-focus-visible/play:ring-offset-zinc-950",
+              previewHovered && "text-white",
+            )}
+            data-transport-primary-control
+          >
+            {isPlaying ? (
+              <Pause className="size-2.5 fill-current" />
+            ) : (
+              <Play className="ml-0.5 size-2.5 fill-current" />
+            )}
+          </span>
+        </button>
+
+        <button
+          type="button"
+          onClick={onSeekNext}
+          disabled={!canSeekNext}
+          className="group/next relative z-10 grid size-11 shrink-0 place-items-center text-zinc-400 transition-colors hover:text-white focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-30"
+          aria-label="Next workbench clip"
+          title="Next clip"
+        >
+          <span className="grid size-5 -translate-x-2 place-items-center rounded-full transition-colors group-focus-visible/next:ring-2 group-focus-visible/next:ring-sky-400 group-focus-visible/next:ring-offset-2 group-focus-visible/next:ring-offset-zinc-950">
+            <SkipForward className="size-3 fill-current" />
+          </span>
+        </button>
+      </div>
+
+      <span
+        className="absolute right-3 max-w-[calc(50%_-_5rem)] overflow-hidden text-ellipsis whitespace-nowrap rounded-full bg-zinc-900/90 px-2 py-0.5 font-mono text-[10px] text-zinc-400 shadow-sm"
+        aria-label={`Preview time ${formatSeconds(currentTime)} of ${formatSeconds(duration)}`}
+        data-testid="workbench-preview-time"
+        style={{ top: DIVIDER_HEIGHT_PX / 2, transform: "translateY(-50%)" }}
+      >
+        <span className="sm:hidden">{formatSeconds(currentTime)}</span>
+        <span className="hidden sm:inline">
+          {formatSeconds(currentTime)} / {formatSeconds(duration)}
+        </span>
+      </span>
+    </div>
+  );
+}
 
 function clamp(value: number, min: number, max: number) {
   return Math.max(min, Math.min(max, value));
@@ -240,6 +361,7 @@ export function WorkbenchDisplaySurface({
 }: WorkbenchDisplaySurfaceProps) {
   const { getCollectionClipFramePreview } = useTimelineDocuments();
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const playbackSurfaceRectRef = useRef<PlaybackSurfaceRect | null>(null);
   const cacheRef = useRef(new Map<string, CachedMedia>());
   const activeMediaRef = useRef<DisplayMedia | null>(null);
   const activeClipDisabledRef = useRef(false);
@@ -257,6 +379,7 @@ export function WorkbenchDisplaySurface({
   // (the default, preserving every existing consumer's behavior).
   const isControlledPlayback = playing !== undefined;
   const [uncontrolledPlaying, setUncontrolledPlaying] = useState(false);
+  const [previewHovered, setPreviewHovered] = useState(false);
   const isPlaying = playing ?? uncontrolledPlaying;
   const setPlaying = useCallback(
     (next: boolean) => {
@@ -369,6 +492,10 @@ export function WorkbenchDisplaySurface({
     const scale = Math.min(cssWidth / sourceWidth, cssHeight / sourceHeight);
     const width = sourceWidth * scale;
     const height = sourceHeight * scale;
+    const left = (cssWidth - width) / 2;
+    const top = (cssHeight - height) / 2;
+    playbackSurfaceRectRef.current = { left, top, width, height };
+    canvas.dataset.previewPlaybackSurfaceReady = "true";
 
     context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
     context.fillStyle = "#050505";
@@ -379,7 +506,7 @@ export function WorkbenchDisplaySurface({
     // one drawImage and reset immediately: the backdrop fill above must stay
     // its true black, and a leaked filter would tint the next frame drawn.
     if (activeClipDisabledRef.current) context.filter = "grayscale(1) opacity(0.45)";
-    context.drawImage(drawable, (cssWidth - width) / 2, (cssHeight - height) / 2, width, height);
+    context.drawImage(drawable, left, top, width, height);
     context.filter = "none";
   }, []);
 
@@ -399,6 +526,8 @@ export function WorkbenchDisplaySurface({
 
     const context = canvas.getContext("2d", { alpha: false });
     if (!context) return;
+    playbackSurfaceRectRef.current = null;
+    canvas.dataset.previewPlaybackSurfaceReady = "false";
     context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
     context.fillStyle = "#050505";
     context.fillRect(0, 0, cssWidth, cssHeight);
@@ -695,30 +824,66 @@ export function WorkbenchDisplaySurface({
   const canSeekPrevious = sortedClips.length > 0 && currentTime > 0;
   const canSeekNext = sortedClips.length > 0 && activeClipIndex < sortedClips.length - 1;
 
+  const isPointerOverPlaybackSurface = useCallback(
+    (event: CanvasPointEvent) => {
+      const playbackSurface = playbackSurfaceRectRef.current;
+      if (!canPlay || !playbackSurface) return false;
+
+      const canvasBounds = event.currentTarget.getBoundingClientRect();
+      const pointerX = event.clientX - canvasBounds.left;
+      const pointerY = event.clientY - canvasBounds.top;
+      return (
+        pointerX >= playbackSurface.left &&
+        pointerX <= playbackSurface.left + playbackSurface.width &&
+        pointerY >= playbackSurface.top &&
+        pointerY <= playbackSurface.top + playbackSurface.height
+      );
+    },
+    [canPlay],
+  );
+
   return (
     <section
       aria-label="Workbench display surface"
       className={cn(
-        "flex min-h-0 flex-col overflow-hidden rounded-lg border border-zinc-800 bg-zinc-950 shadow-2xl",
+        "relative flex min-h-0 flex-col overflow-visible rounded-lg border border-zinc-800 bg-zinc-950 shadow-2xl",
         className,
       )}
       data-testid="workbench-display-surface"
       data-buffered-media-count={bufferedMedia.length}
+      data-preview-playing={isPlaying}
     >
-      <div className="relative min-h-0 flex-1 bg-black">
+      <div className="relative min-h-0 flex-1 overflow-hidden rounded-[inherit] bg-black">
         <canvas
           ref={canvasRef}
-          className="block h-full w-full bg-black"
+          className={cn(
+            "block h-full w-full bg-black",
+            previewHovered ? "cursor-pointer" : "cursor-default",
+          )}
           role="img"
           aria-label={activeMedia ? `${activeMedia.clipTitle} preview` : "Empty workbench preview"}
           data-testid="workbench-display-canvas"
+          data-preview-playback-shortcut={canPlay}
+          onPointerEnter={(event) => {
+            setPreviewHovered(isPointerOverPlaybackSurface(event));
+          }}
+          onPointerMove={(event) => {
+            const nextHovered = isPointerOverPlaybackSurface(event);
+            setPreviewHovered((wasHovered) =>
+              wasHovered === nextHovered ? wasHovered : nextHovered,
+            );
+          }}
+          onPointerLeave={() => setPreviewHovered(false)}
+          onClick={(event) => {
+            if (isPointerOverPlaybackSurface(event)) setPlaying(!isPlaying);
+          }}
         />
         {/* Names what the grayed frame means. Only ever visible while
             SCRUBBING — playing jumps the span, so the clock never rests here.
             Top-LEFT: the close button owns the right corner. */}
         {activeClip?.disabled === true && (
           <span
-            className="absolute left-2 top-2 z-10 rounded bg-black/80 px-1.5 py-0.5 font-mono text-[10px] leading-none font-semibold tracking-[0.08em] text-amber-300 ring-1 ring-amber-400/40"
+            className="pointer-events-none absolute left-2 top-2 z-10 rounded bg-black/80 px-1.5 py-0.5 font-mono text-[10px] leading-none font-semibold tracking-[0.08em] text-amber-300 ring-1 ring-amber-400/40"
             data-testid="workbench-display-disabled"
           >
             DISABLED
@@ -741,56 +906,29 @@ export function WorkbenchDisplaySurface({
           </button>
         )}
       </div>
-      <div className="relative flex shrink-0 items-center justify-center border-t border-zinc-800 bg-zinc-950 px-4 py-2 text-xs text-zinc-200">
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={() => seekToClip(-1)}
-            disabled={!canSeekPrevious}
-            className="grid size-8 place-items-center rounded-full border border-zinc-800 bg-zinc-900 text-zinc-400 transition-colors hover:border-zinc-600 hover:text-zinc-100 disabled:cursor-not-allowed disabled:opacity-35"
-            aria-label="Previous workbench clip"
-            title="Previous clip"
-          >
-            <SkipBack className="h-3.5 w-3.5 fill-current" />
-          </button>
-          <button
-            type="button"
-            onClick={() => setPlaying(!isPlaying)}
-            disabled={!canPlay}
-            className="grid size-9 place-items-center rounded-full border border-zinc-700 bg-zinc-900 text-zinc-100 transition-colors hover:border-amber-400 hover:text-amber-300 disabled:cursor-not-allowed disabled:opacity-40"
-            aria-label={isPlaying ? "Pause workbench preview" : "Play workbench preview"}
-            title={isPlaying ? "Pause" : "Play"}
-          >
-            {isPlaying ? <Pause className="h-3.5 w-3.5 fill-current" /> : <Play className="ml-0.5 h-3.5 w-3.5 fill-current" />}
-          </button>
-          <button
-            type="button"
-            onClick={() => seekToClip(1)}
-            disabled={!canSeekNext}
-            className="grid size-8 place-items-center rounded-full border border-zinc-800 bg-zinc-900 text-zinc-400 transition-colors hover:border-zinc-600 hover:text-zinc-100 disabled:cursor-not-allowed disabled:opacity-35"
-            aria-label="Next workbench clip"
-            title="Next clip"
-          >
-            <SkipForward className="h-3.5 w-3.5 fill-current" />
-          </button>
-        </div>
-        <div className="absolute right-4 shrink-0 font-mono text-[11px] text-zinc-300">
-          {formatSeconds(currentTime)} / {formatSeconds(duration)}
-        </div>
-      </div>
+      <WorkbenchDividerTransport
+        currentTime={currentTime}
+        duration={duration}
+        isPlaying={isPlaying}
+        canPlay={canPlay}
+        canSeekPrevious={canSeekPrevious}
+        canSeekNext={canSeekNext}
+        previewHovered={canPlay && previewHovered}
+        onTogglePlaying={() => setPlaying(!isPlaying)}
+        onSeekPrevious={() => seekToClip(-1)}
+        onSeekNext={() => seekToClip(1)}
+      />
     </section>
   );
 }
 
 type WorkbenchSplitPaneProps = {
-  clips: TimelineClip[];
-  currentTime: number;
-  onCurrentTimeChange: (time: number) => void;
+  /**
+   * Upper-pane content. Pass `null` to close it while keeping the lower pane
+   * mounted, preserving stateful content such as a virtual strip's scroll.
+   */
+  surface: ReactNode | null;
   children: ReactNode;
-  preferredClipId?: string | null;
-  /** Controlled playback, forwarded to the display surface. See there. */
-  playing?: boolean;
-  onPlayingChange?: (playing: boolean) => void;
   /** Read ONCE at mount for a height carried over from a previous mount (e.g.
    *  the consumer toggled this pane off and back on). Returning a number makes
    *  the pane start there and SKIP the one-time fit — a height the user chose
@@ -801,22 +939,15 @@ type WorkbenchSplitPaneProps = {
    *  across unmounts. Store it in a ref: this fires per pointer move during a
    *  divider drag. */
   onSurfaceHeightChange?: (height: number) => void;
-  /** Forwarded to the display surface's close button. See there. */
-  onClose?: () => void;
 };
 
 export function WorkbenchSplitPane({
-  clips,
-  currentTime,
-  onCurrentTimeChange,
+  surface,
   children,
-  preferredClipId,
-  playing,
-  onPlayingChange,
   getInitialSurfaceHeight,
   onSurfaceHeightChange,
-  onClose,
 }: WorkbenchSplitPaneProps) {
+  const hasSurface = surface !== null;
   // Read once, at mount. `undefined` means nothing to restore → fit instead.
   const [restoredSurfaceHeight] = useState(() => getInitialSurfaceHeight?.());
   const [surfaceHeight, setSurfaceHeight] = useState(
@@ -937,6 +1068,7 @@ export function WorkbenchSplitPane({
   // and animate the difference. Two frames is "after the next paint" without
   // guessing at a duration.
   useEffect(() => {
+    if (!hasSurface) return;
     let second = 0;
     const first = requestAnimationFrame(() => {
       second = requestAnimationFrame(() => setHeightAnimated(true));
@@ -945,12 +1077,13 @@ export function WorkbenchSplitPane({
       cancelAnimationFrame(first);
       cancelAnimationFrame(second);
     };
-  }, []);
+  }, [hasSurface]);
 
   useLayoutEffect(() => {
-    // Size ONCE on mount. After that the height belongs to the user: only a
-    // divider drag changes it, and a shrinking viewport may clamp it.
-    if (!didInitialSizeRef.current) {
+    // Size ONCE, when the surface first opens. The split pane itself may have
+    // mounted earlier with only its lower pane so that the lower content keeps
+    // its DOM identity and scroll position across this toggle.
+    if (hasSurface && !didInitialSizeRef.current) {
       didInitialSizeRef.current = true;
       if (restoredSurfaceHeight !== undefined) clampToViewport();
       else initialSurfaceHeight();
@@ -977,7 +1110,13 @@ export function WorkbenchSplitPane({
         clampFrameRef.current = null;
       }
     };
-  }, [initialSurfaceHeight, clampToViewport, scheduleClamp, restoredSurfaceHeight]);
+  }, [
+    initialSurfaceHeight,
+    clampToViewport,
+    scheduleClamp,
+    restoredSurfaceHeight,
+    hasSurface,
+  ]);
 
   // Report the height so a consumer can restore it after an unmount.
   useEffect(() => {
@@ -1028,23 +1167,40 @@ export function WorkbenchSplitPane({
       data-testid="workbench-split-pane"
       // The sticky preview region's height (surface + divider), published so a
       // descendant that wants to pin BELOW it — e.g. a sticky board header —
-      // has a live offset to stick to as the divider resizes. Absent when the
-      // preview is closed (this component isn't mounted then), so consumers
-      // fall back to 0.
+      // has a live offset to stick to as the divider resizes. The split pane
+      // remains mounted while closed, so publish an explicit zero then.
       style={
         {
-          "--workbench-preview-offset": `${surfaceHeight + DIVIDER_HEIGHT_PX}px`,
+          "--workbench-preview-offset": hasSurface
+            ? `${surfaceHeight + DIVIDER_HEIGHT_PX}px`
+            : "0px",
         } as React.CSSProperties
       }
     >
-      <div
+      {hasSurface ? (
+        <div
         // z-40 (above the strip's z-30 consumer overlay) so a playhead marker
         // in a timeline scrolling underneath is occluded by the sticky
         // preview, not painted over it. At z-30 the marker tied the preview
         // and, being later in the DOM, bled through into the preview area.
-        className="sticky top-0 z-40 min-w-0 bg-zinc-950"
+        className="sticky top-0 z-40 min-w-0 overflow-visible bg-zinc-950"
         data-testid="workbench-preview-region"
       >
+        {/* A seek thumb is intentionally centered on the timeline edge, so
+            half of it sits outside the split pane. These narrow side masks
+            hide that overhang only while it passes BEHIND the sticky preview.
+            Clipping the split pane itself also cut the thumb off after it
+            scrolled below the preview, where it should be fully visible. */}
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-y-0 right-full w-2 bg-zinc-950"
+          data-preview-edge-occluder="start"
+        />
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-y-0 left-full w-2 bg-zinc-950"
+          data-preview-edge-occluder="end"
+        />
         <div
           className={cn(
             "min-h-0",
@@ -1062,18 +1218,9 @@ export function WorkbenchSplitPane({
             height: `${surfaceHeight}px`,
             minHeight: `${MIN_SURFACE_HEIGHT}px`,
           }}
-        >
-          <WorkbenchDisplaySurface
-            clips={clips}
-            currentTime={currentTime}
-            onCurrentTimeChange={onCurrentTimeChange}
-            preferredClipId={preferredClipId}
-            playing={playing}
-            onPlayingChange={onPlayingChange}
-            onClose={onClose}
-            className="h-full"
-          />
-        </div>
+          >
+            {surface}
+          </div>
         <button
           ref={dividerRef}
           type="button"
@@ -1082,17 +1229,10 @@ export function WorkbenchSplitPane({
           aria-valuemin={MIN_SURFACE_HEIGHT}
           aria-valuenow={Math.round(surfaceHeight)}
           aria-label="Resize workbench display"
-          // The divider's OWN height is the only source of the gap on either
-          // side: it centres the grip, so the space above and below is h/2
-          // each (h-3 — kept in sync with DIVIDER_HEIGHT_PX).
-          // Nothing else may add padding against it — the lower pane used to
-          // carry a pt-3 that made the bottom gap 22px against the top's
-          // 10px, which read as misaligned. Affordance: a centred grip pill
-          // says "draggable" at rest (half-opacity so it stays quiet), and
-          // hovering brings it to full strength and tints the whole band gray
-          // — no full-width rule (the old amber line highlight is gone too;
-          // focus ring is sky, matching the seek rails).
-          className="group relative flex h-3 w-full cursor-row-resize items-center justify-center bg-transparent transition-colors hover:bg-zinc-800/70 active:bg-zinc-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-400 focus-visible:outline-offset-2"
+          // The divider keeps a 12px interaction track while its one-pixel
+          // centerline runs directly through the transport controls.
+          className="group relative block h-3 w-full cursor-row-resize bg-transparent focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-400 focus-visible:outline-offset-2"
+          data-workbench-divider
           onPointerDown={handleDividerPointerDown}
           onPointerMove={handleDividerPointerMove}
           onPointerUp={handleDividerPointerUp}
@@ -1100,12 +1240,21 @@ export function WorkbenchSplitPane({
         >
           <span
             aria-hidden="true"
-            data-divider-grip
-            className="relative h-1 w-10 rounded-full bg-zinc-600 opacity-50 transition-[color,background-color,opacity] group-hover:bg-zinc-400 group-hover:opacity-100 group-active:bg-zinc-300 group-active:opacity-100"
+            className="pointer-events-none absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-zinc-800 transition-colors group-hover:bg-zinc-600 group-active:bg-zinc-500"
+            data-divider-line
           />
         </button>
-      </div>
-      <div ref={lowerPaneRef} className="min-h-0">
+        </div>
+      ) : null}
+      {/* Keep every lower-pane layer in one z-0 stacking context. Virtual
+          strips intentionally use z-50 for local overlays; without this
+          boundary those later layers could cover the transport where it
+          grows below the divider. */}
+      <div
+        ref={lowerPaneRef}
+        className="relative z-0 min-h-0 isolate"
+        data-testid="workbench-lower-pane"
+      >
         {children}
       </div>
     </div>


### PR DESCRIPTION
Completes the accumulated graph-workbench punch list: refines grid and strip interactions, loading and preview behavior, project-scoped assets and media uploads, collection previews, and the compact divider transport. Adds focused unit, story, and end-to-end regression coverage. Validation: production build; TypeScript checks; 442 app tests; 66 domain/model/geometry tests; 33 Storybook tests; 3 focused Playwright tests; lint with no errors.