### PR TITLE
Fade divider beneath preview controls

### DIFF
--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -995,6 +995,9 @@ test.describe("graph view E2E", () => {
     ).toBe("0px");
     const dividerLine = divider.locator("[data-divider-line]");
     await expect(dividerLine).toHaveCount(1);
+    expect(
+      await dividerLine.evaluate((element) => getComputedStyle(element).backgroundImage),
+    ).toContain("linear-gradient");
     const dividerLineColor = () =>
       dividerLine.evaluate((el) => getComputedStyle(el).backgroundColor);
     const restLineColor = await dividerLineColor();

--- a/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
+++ b/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
@@ -88,6 +88,7 @@ export const StickyPreview: Story = {
     const buttonGroupBox = buttonGroup!.getBoundingClientRect();
     const dividerBox = divider.getBoundingClientRect();
     const dividerLineBox = dividerLine!.getBoundingClientRect();
+    expect(getComputedStyle(dividerLine!).backgroundImage).toContain("linear-gradient");
     expect(buttonGroupBox.width).toBe(132);
     expect(buttonGroupBox.height).toBe(44);
     expect(controls.querySelector("[data-transport-capsule]")).toBeNull();
@@ -264,7 +265,9 @@ export const ControlledPlayback: Story = {
     expect(
       await canvas.findByRole("button", { name: "Pause workbench preview" }),
     ).toBeInTheDocument();
-    expect(canvas.getByTestId("workbench-preview-time")).toHaveTextContent("0s / 30.0s");
+    expect(canvas.getByTestId("workbench-preview-time")).toHaveTextContent(
+      /0(?:\.\d+)?s \/ 30\.0s/,
+    );
 
     await user.tab();
     expect(controls.contains(document.activeElement)).toBe(true);

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -1230,7 +1230,9 @@ export function WorkbenchSplitPane({
           aria-valuenow={Math.round(surfaceHeight)}
           aria-label="Resize workbench display"
           // The divider keeps a 12px interaction track while its one-pixel
-          // centerline runs directly through the transport controls.
+          // centerline runs directly through the transport controls. The line
+          // fades across the 132px transport group so no divider color shows
+          // behind its background-free icons.
           className="group relative block h-3 w-full cursor-row-resize bg-transparent focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-400 focus-visible:outline-offset-2"
           data-workbench-divider
           onPointerDown={handleDividerPointerDown}
@@ -1240,7 +1242,7 @@ export function WorkbenchSplitPane({
         >
           <span
             aria-hidden="true"
-            className="pointer-events-none absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-zinc-800 transition-colors group-hover:bg-zinc-600 group-active:bg-zinc-500"
+            className="pointer-events-none absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-[linear-gradient(to_right,currentColor_0,currentColor_calc(50%_-_6.125rem),transparent_calc(50%_-_4.125rem),transparent_calc(50%_+_4.125rem),currentColor_calc(50%_+_6.125rem),currentColor_100%)] text-zinc-800 transition-colors group-hover:text-zinc-600 group-active:text-zinc-500"
             data-divider-line
           />
         </button>


### PR DESCRIPTION
Updates the preview resize divider from a solid line to a symmetric gray-to-transparent gradient around the transport controls. The fully clear center matches the 132px control group, with a gradual 32px fade on each side, while preserving the 12px resize target and existing interaction colors. Adds Storybook and Playwright assertions for the gradient and makes the controlled-playback time assertion tolerant of normal sub-second progress. Validation: UI and app TypeScript checks, four WorkbenchSplitPane Storybook tests, focused Playwright divider test, and diff check.