### PR TITLE
Ship punch list 07

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -487,7 +487,7 @@ export function GraphBoard({
                 itemIds={flatItemIds}
                 pixelsPerSecond={deferredPixelsPerSecond}
                 overscan={GRAPH_STRIP_OVERSCAN_ITEMS}
-                itemWidth={collectionCardWidth(deferredPixelsPerSecond)}
+                itemWidth={collectionCardWidth(deferredPixelsPerSecond, dims.strip)}
                 itemHeight={dims.strip}
                 itemDragActivation="hold"
                 overlay={
@@ -497,6 +497,7 @@ export function GraphBoard({
                         <GraphRuler
                           focusedId={focusedId}
                           pixelsPerSecond={deferredPixelsPerSecond}
+                          cardHeight={dims.strip}
                         />
                       ) : null}
                       {previewOn ? (
@@ -504,6 +505,7 @@ export function GraphBoard({
                           focusedId={focusedId}
                           channel={timeChannel}
                           pixelsPerSecond={deferredPixelsPerSecond}
+                          cardHeight={dims.strip}
                         />
                       ) : null}
                     </>
@@ -526,6 +528,7 @@ export function GraphBoard({
                   focusedId={focusedId}
                   channel={timeChannel}
                   pixelsPerSecond={deferredPixelsPerSecond}
+                  cardHeight={dims.strip}
                 />
               )}
                 </NativeDropStrip>

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -12,7 +12,7 @@ import {
   useSyncExternalStore,
   type ReactNode,
 } from "react";
-import { FolderInput } from "lucide-react";
+import { CornerRightDown } from "lucide-react";
 
 import {
   CollectionItem,
@@ -382,10 +382,11 @@ function DisabledChip({ inherited }: { inherited: boolean }) {
 }
 
 /** Shared collection glyph for both the card affordance and an empty drag
- * ghost. The lighter stroke keeps the compound folder/arrow mark readable at
- * small sizes without looking heavier than the surrounding icon system. */
+ * ghost. A single-stroke turn-and-descend mark reads at small sizes where the
+ * old compound folder/arrow went muddy, and it says the verb the control
+ * actually performs: go DOWN into this timeline. */
 function CollectionFolderGlyph({ className }: Readonly<{ className?: string }>) {
-  return <FolderInput aria-hidden="true" className={className} strokeWidth={1.5} />;
+  return <CornerRightDown aria-hidden="true" className={className} strokeWidth={1.5} />;
 }
 
 /**
@@ -906,10 +907,10 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
         }}
         className="absolute left-1/2 top-[41%] flex aspect-square h-[34%] -translate-x-1/2 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full bg-zinc-950/70 text-sky-200 ring-1 ring-sky-400/50 backdrop-blur-[2px] transition-colors hover:bg-zinc-900/85 hover:text-sky-100 hover:ring-sky-300"
       >
-        {/* FolderInput — a folder with an arrow going INTO it, matching the
-            sub-timeline row's drill button. Both NAVIGATE; the sidebar's
-            FolderTree toggles whether the children tree is shown, which is a
-            different verb and no longer shares this icon. */}
+        {/* CornerRightDown — turn and descend, the verb this control performs:
+            NAVIGATE into the timeline. The sidebar's FolderTree toggles whether
+            the children tree is shown, which is a different verb and does not
+            share this icon. */}
         <CollectionFolderGlyph className="h-[55%] w-[55%]" />
       </button>
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
@@ -6,6 +6,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
   type DragEvent,
   type ReactNode,
 } from "react";
@@ -323,9 +324,111 @@ export function SidebarToolInsertBridge({
   return null;
 }
 
-function acceptsNativeDrag(event: DragEvent<HTMLElement>): boolean {
-  const types = event.dataTransfer.types;
+function acceptsDragTypes(types: readonly string[] | undefined): boolean {
+  if (!types) return false;
   return types.includes(TOOL_MIME) || types.includes("Files");
+}
+
+function acceptsNativeDrag(event: DragEvent<HTMLElement>): boolean {
+  return acceptsDragTypes(event.dataTransfer.types);
+}
+
+/**
+ * "A droppable drag is somewhere over the page right now" — the signal every
+ * drop zone lights up on, so the targets announce themselves BEFORE the
+ * pointer finds one. Kept module-level and reference-counted because the
+ * answer is global while the subscribers are many (the focused surface plus
+ * every rendered sub-timeline); one window listener serves all of them.
+ *
+ * Armed by `dragover` rather than tracked with dragenter/dragleave pairs:
+ * those fire in a well-known flickering interleave as the pointer crosses
+ * child elements, and every counter-based fix leaks a stuck state on some
+ * path (drag out of the window, drop on another app, ESC). `dragover` fires
+ * continuously while a drag is over the page, so a short expiry that each
+ * event refreshes is self-healing — nothing can leave it stuck on.
+ *
+ * dnd-kit card drags are POINTER drags and emit no HTML5 drag events at all,
+ * so they never arm this.
+ */
+const NATIVE_DRAG_IDLE_MS = 200;
+
+const nativeDragSignal = {
+  active: false,
+  listeners: new Set<() => void>(),
+  timer: null as ReturnType<typeof setTimeout> | null,
+  detach: null as (() => void) | null,
+};
+
+function setNativeDragActive(next: boolean): void {
+  if (nativeDragSignal.active === next) return;
+  nativeDragSignal.active = next;
+  for (const listener of nativeDragSignal.listeners) listener();
+}
+
+function clearNativeDragTimer(): void {
+  if (nativeDragSignal.timer !== null) {
+    clearTimeout(nativeDragSignal.timer);
+    nativeDragSignal.timer = null;
+  }
+}
+
+function subscribeNativeDrag(listener: () => void): () => void {
+  nativeDragSignal.listeners.add(listener);
+  if (nativeDragSignal.detach === null && typeof window !== "undefined") {
+    const onDragOver = (event: globalThis.DragEvent) => {
+      if (!acceptsDragTypes(event.dataTransfer?.types)) return;
+      setNativeDragActive(true);
+      clearNativeDragTimer();
+      nativeDragSignal.timer = setTimeout(() => {
+        nativeDragSignal.timer = null;
+        setNativeDragActive(false);
+      }, NATIVE_DRAG_IDLE_MS);
+    };
+    const onEnd = () => {
+      clearNativeDragTimer();
+      setNativeDragActive(false);
+    };
+    window.addEventListener("dragover", onDragOver, true);
+    window.addEventListener("drop", onEnd, true);
+    window.addEventListener("dragend", onEnd, true);
+    nativeDragSignal.detach = () => {
+      window.removeEventListener("dragover", onDragOver, true);
+      window.removeEventListener("drop", onEnd, true);
+      window.removeEventListener("dragend", onEnd, true);
+    };
+  }
+  return () => {
+    nativeDragSignal.listeners.delete(listener);
+    if (nativeDragSignal.listeners.size === 0) {
+      nativeDragSignal.detach?.();
+      nativeDragSignal.detach = null;
+      clearNativeDragTimer();
+      nativeDragSignal.active = false;
+    }
+  };
+}
+
+/** True while a droppable native drag is over the page. */
+function useNativeDragArmed(): boolean {
+  return useSyncExternalStore(
+    subscribeNativeDrag,
+    () => nativeDragSignal.active,
+    () => false,
+  );
+}
+
+/**
+ * The drop-zone affordance: every eligible target outlines itself for the
+ * duration of the drag, and the one under the pointer is filled in. Ring and
+ * background only — nothing here may change the box, or arming the affordance
+ * would reflow the strips mid-drag and move the very gaps being aimed at.
+ */
+function dropZoneClassName(armed: boolean, hovered: boolean): string {
+  if (!armed) return "relative rounded-lg";
+  return [
+    "relative rounded-lg ring-1 transition-colors duration-150 motion-reduce:transition-none",
+    hovered ? "bg-sky-400/10 ring-2 ring-sky-400" : "bg-sky-400/[0.03] ring-sky-400/40",
+  ].join(" ");
 }
 
 /**
@@ -643,6 +746,10 @@ export function NativeDropStrip({
   const { commitDrop, upload } = useNativeDrop(collectionId, projectId);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const [indicatorX, setIndicatorX] = useState<number | null>(null);
+  const armed = useNativeDragArmed();
+  // "The pointer is over THIS zone" — separate from the indicator, which an
+  // empty strip has nothing to draw.
+  const [dragSessionActive, setDragSessionActive] = useState(false);
 
   // Drag-session geometry (see measureDragGeometry) plus the rAF coalescing
   // state for the drop indicator. All refs: none of it should drive a render.
@@ -750,6 +857,7 @@ export function NativeDropStrip({
     dragGeometryRef.current = null;
     indicatorXRef.current = null;
     setIndicatorX(null);
+    setDragSessionActive(false);
   }, [invalidateDragGeometry]);
 
   // A drag can end anywhere (dropped on another target, cancelled with Esc),
@@ -764,6 +872,7 @@ export function NativeDropStrip({
 
     if (!dragSessionRef.current) {
       dragSessionRef.current = true;
+      setDragSessionActive(true);
       // Capture phase: the strip scrolls in its own container, not the window.
       window.addEventListener("scroll", invalidateDragGeometry, true);
       window.addEventListener("resize", invalidateDragGeometry);
@@ -798,7 +907,9 @@ export function NativeDropStrip({
     <div
       ref={wrapperRef}
       data-native-drop={collectionId}
-      className="relative"
+      data-native-drop-armed={armed || undefined}
+      data-native-drop-hovered={armed && dragSessionActive ? true : undefined}
+      className={dropZoneClassName(armed, dragSessionActive)}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
@@ -808,7 +919,10 @@ export function NativeDropStrip({
         <div
           data-native-drop-indicator
           aria-hidden="true"
-          className="pointer-events-none absolute inset-y-1 z-20 w-0.5 rounded bg-amber-400 shadow-[0_0_6px_rgba(251,191,36,0.9)]"
+          // left-0 for the same reason the grid's indicator needs it: the
+          // translate is measured from the wrapper's origin, so the element
+          // must be anchored there rather than left at its static position.
+          className="pointer-events-none absolute inset-y-1 left-0 z-30 w-0.5 rounded bg-amber-400 shadow-[0_0_6px_rgba(251,191,36,0.9)]"
           style={{ transform: `translateX(${indicatorX}px)` }}
         />
       )}
@@ -854,6 +968,10 @@ export function NativeDropGrid({
   const { commitDrop, upload } = useNativeDrop(collectionId, projectId);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const [indicator, setIndicator] = useState<GridIndicator | null>(null);
+  const armed = useNativeDragArmed();
+  // "The pointer is over THIS zone" — separate from the indicator, which an
+  // empty grid has nothing to draw.
+  const [dragSessionActive, setDragSessionActive] = useState(false);
 
   const dragGeometryRef = useRef<GridDragGeometry | null>(null);
   const dragSessionRef = useRef(false);
@@ -978,6 +1096,7 @@ export function NativeDropGrid({
     }
     dragGeometryRef.current = null;
     setIndicator(null);
+    setDragSessionActive(false);
   }, [invalidateDragGeometry]);
 
   useEffect(() => endDragSession, [endDragSession]);
@@ -989,6 +1108,7 @@ export function NativeDropGrid({
 
     if (!dragSessionRef.current) {
       dragSessionRef.current = true;
+      setDragSessionActive(true);
       window.addEventListener("scroll", invalidateDragGeometry, true);
       window.addEventListener("resize", invalidateDragGeometry);
       window.addEventListener("dragend", endDragSession, { once: true });
@@ -1016,7 +1136,9 @@ export function NativeDropGrid({
     <div
       ref={wrapperRef}
       data-native-drop={collectionId}
-      className="relative"
+      data-native-drop-armed={armed || undefined}
+      data-native-drop-hovered={armed && dragSessionActive ? true : undefined}
+      className={dropZoneClassName(armed, dragSessionActive)}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
@@ -1026,7 +1148,14 @@ export function NativeDropGrid({
         <div
           data-native-drop-indicator
           aria-hidden="true"
-          className="pointer-events-none absolute z-20 w-0.5 rounded bg-amber-400 shadow-[0_0_6px_rgba(251,191,36,0.9)]"
+          // left-0/top-0 are LOAD-BEARING. `absolute` with neither offset
+          // resolves to the element's STATIC position — and this div is the
+          // wrapper's last child, so that position is directly BELOW the
+          // grid. The transform below is measured from the wrapper's origin
+          // (`wrapperLeft`/`wrapperTop`), so without the anchor the line drew
+          // a whole grid's height too low. z-30 clears the grid's own
+          // overlay tier as well as its cards.
+          className="pointer-events-none absolute left-0 top-0 z-30 w-0.5 rounded bg-amber-400 shadow-[0_0_6px_rgba(251,191,36,0.9)]"
           style={{
             transform: `translate(${indicator.x}px, ${indicator.y}px)`,
             height: `${indicator.height}px`,

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -126,19 +126,34 @@ export function createPreviewTimeChannel(): PreviewTimeChannel {
  * read the SAME number — the two must agree or the marker drifts off the cards.
  */
 const COLLECTION_CARD_BASE_PX = 128;
-export function collectionCardWidth(pixelsPerSecond: number): number {
-  return Math.max(MIN_ITEM_WIDTH, COLLECTION_CARD_BASE_PX * (pixelsPerSecond / TIMELINE_PPS));
+/** Collections never render narrower than a 16:9 box against the card height
+ *  they are drawn at. Zooming out used to squeeze them into slivers no one
+ *  could read or hit; the aspect floor keeps the poster frame intact and
+ *  scales with item size, so `xs` rows and `xl` rows each get a proportionate
+ *  minimum instead of one flat pixel count. */
+const COLLECTION_MIN_ASPECT = 16 / 9;
+export function collectionCardWidth(pixelsPerSecond: number, cardHeight: number): number {
+  return Math.max(
+    MIN_ITEM_WIDTH,
+    cardHeight * COLLECTION_MIN_ASPECT,
+    COLLECTION_CARD_BASE_PX * (pixelsPerSecond / TIMELINE_PPS),
+  );
 }
 
 /**
  * The strip's width resolution at a given zoom, injected into the pure
  * playhead model so its cards use EXACTLY the widths the strip renders —
- * collections at the shared fixed-per-zoom width, media by duration.
+ * collections at the shared per-zoom width (with its aspect floor), media by
+ * duration. `cardHeight` is the strip's own `itemHeight`, which the floor
+ * needs; pass 0 where widths are not read (see `cardsFor` callers).
  */
-function clipWidthAt(pixelsPerSecond: number): (clip: TimelineClip) => number {
+function clipWidthAt(
+  pixelsPerSecond: number,
+  cardHeight: number,
+): (clip: TimelineClip) => number {
   return (clip) =>
     clip.kind === "collection"
-      ? collectionCardWidth(pixelsPerSecond)
+      ? collectionCardWidth(pixelsPerSecond, cardHeight)
       : durationToWidth(clip.duration, pixelsPerSecond);
 }
 
@@ -182,13 +197,16 @@ function cardsFor(
   focusedId: string,
   spans: PreviewCardSpans | null,
   pixelsPerSecond: number,
+  /** The strip's `itemHeight` — only the collection aspect floor reads it.
+   *  Callers that consume times and counts rather than geometry pass 0. */
+  cardHeight: number,
   flatItems: readonly FlatItem[] | null,
 ): ChildSpan[] {
   return flatItems
     ? flatCardSpans(graph, flatItems, focusedId, spans, (seconds) =>
         durationToWidth(seconds, pixelsPerSecond),
       )
-    : childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond));
+    : childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond, cardHeight));
 }
 
 /** The global-clock windows the pane is playing, or null when it is on the
@@ -224,7 +242,9 @@ export function useFocusedTimelineAggregate(
   );
   const flatItems = useContext(FlatItemsContext);
   return useMemo(() => {
-    const cards = cardsFor(graph, details, focusedId, spans, pixelsPerSecond, flatItems);
+    // 0 card height: this readout is counts and seconds, never geometry, so
+    // the collection aspect floor has nothing to act on here.
+    const cards = cardsFor(graph, details, focusedId, spans, pixelsPerSecond, 0, flatItems);
     // Enabled-only, both numbers: this readout says what a viewer would sit
     // through, which is NOT how far the playhead travels now that disabled
     // cards keep their span. The two disagree by design — the ruler runs
@@ -241,11 +261,15 @@ export function GraphPlayhead({
   focusedId,
   channel,
   pixelsPerSecond,
+  cardHeight,
   activeWindow,
 }: Readonly<{
   focusedId: string;
   channel: PreviewTimeChannel;
   pixelsPerSecond: number;
+  /** The strip's `itemHeight`. Feeds the collection aspect floor, so this
+   *  marker lands on the same card edges the strip actually draws. */
+  cardHeight: number;
   /** When set (sub-rows), the marker is hidden while the global clock is
    *  outside this collection's window — only the row the clock is currently
    *  inside shows it, so one clock appears to sweep through the tree. The
@@ -272,7 +296,7 @@ export function GraphPlayhead({
       lastGraph = graph;
       lastDetails = details;
       map = buildPlayheadMap(
-        cardsFor(graph, details, focusedId, spans, pixelsPerSecond, flatItems),
+        cardsFor(graph, details, focusedId, spans, pixelsPerSecond, cardHeight, flatItems),
       );
       return true;
     };
@@ -311,7 +335,17 @@ export function GraphPlayhead({
       unsubscribeStore();
       unsubscribeDetails();
     };
-  }, [store, detailsStore, focusedId, channel, spans, pixelsPerSecond, activeWindow, flatItems]);
+  }, [
+    store,
+    detailsStore,
+    focusedId,
+    channel,
+    spans,
+    pixelsPerSecond,
+    cardHeight,
+    activeWindow,
+    flatItems,
+  ]);
 
   // No cap on the line: the seek rail's circular thumb above IS the
   // playhead's head now — the old triangle poked up over it. The stem
@@ -423,7 +457,14 @@ const stripScrollerBeside = (element: HTMLElement): HTMLElement | null =>
 export function GraphRuler({
   focusedId,
   pixelsPerSecond,
-}: Readonly<{ focusedId: string; pixelsPerSecond: number }>) {
+  cardHeight,
+}: Readonly<{
+  focusedId: string;
+  pixelsPerSecond: number;
+  /** The strip's `itemHeight` — feeds the collection aspect floor so ticks
+   *  and collection stretches land on the widths the strip draws. */
+  cardHeight: number;
+}>) {
   const store = useCollectionsStore();
   const detailsStore = useGraphDetailsStore();
   const spans = useContext(PreviewCardSpansContext);
@@ -454,7 +495,7 @@ export function GraphRuler({
   // tick count follows the VIEWPORT, not the duration. Scrolling recomputes
   // only on chunk crossings (tickWindow identity is stable between them).
   const { ticks, collectionSpans, skips } = useMemo(() => {
-    const cards = cardsFor(graph, details, focusedId, spans, pixelsPerSecond, flatItems);
+    const cards = cardsFor(graph, details, focusedId, spans, pixelsPerSecond, cardHeight, flatItems);
     // A flat run holds no collections at all, so every card is ruled — the
     // blank-interior rule exists only for collection cards.
     const isCollection = flatItems
@@ -473,7 +514,7 @@ export function GraphRuler({
       // range as the ticks beside them.
       skips: buildStripOverlay(cards, tickWindow).skips,
     };
-  }, [graph, details, spans, focusedId, pixelsPerSecond, tickWindow, flatItems]);
+  }, [graph, details, spans, focusedId, pixelsPerSecond, cardHeight, tickWindow, flatItems]);
 
   return (
     <div
@@ -591,7 +632,10 @@ export function GraphGridPlayhead({
       lastColumns = columns;
       lastCellWidth = cellWidth;
       map = buildGridPlayheadMap(
-        childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond)),
+        // 0 card height: grid cells are uniform and this map lays out by
+        // `cellWidth`, never by the per-clip width, so the strip's collection
+        // aspect floor has nothing to act on here.
+        childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond, 0)),
         columns,
         cellWidth,
         cellHeight,
@@ -944,7 +988,9 @@ export function GraphSeekRails({
     () => detailsStore.read(),
   );
   const cards = useMemo(
-    () => childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond)),
+    // 0 card height, as in GraphGridPlayhead: the grid rails measure their
+    // row from `cellWidth`, so per-clip widths never reach the geometry.
+    () => childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond, 0)),
     [graph, details, spans, focusedId, pixelsPerSecond],
   );
   const cardCount = cards.length;
@@ -1075,11 +1121,15 @@ export function GraphStripSeekRail({
   focusedId,
   channel,
   pixelsPerSecond,
+  cardHeight,
   ariaLabel = "Seek preview",
 }: Readonly<{
   focusedId: string;
   channel: PreviewTimeChannel;
   pixelsPerSecond: number;
+  /** The strip's `itemHeight` — feeds the collection aspect floor, keeping
+   *  the rail's thumb in lockstep with the playhead line below it. */
+  cardHeight: number;
   ariaLabel?: string;
 }>) {
   const store = useCollectionsStore();
@@ -1105,8 +1155,8 @@ export function GraphStripSeekRail({
     () => detailsStore.read(),
   );
   const cards = useMemo(
-    () => cardsFor(graph, details, focusedId, spans, pixelsPerSecond, flatItems),
-    [graph, details, spans, focusedId, pixelsPerSecond, flatItems],
+    () => cardsFor(graph, details, focusedId, spans, pixelsPerSecond, cardHeight, flatItems),
+    [graph, details, spans, focusedId, pixelsPerSecond, cardHeight, flatItems],
   );
   const map = useMemo(() => buildPlayheadMap(cards), [cards]);
   const start = cards.length > 0 ? cards[0].startTime : 0;

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -326,20 +326,25 @@ function SubTimelineNode({
                 collectionId={collectionId}
                 pixelsPerSecond={pixelsPerSecond}
                 overscan={GRAPH_STRIP_OVERSCAN_ITEMS}
-                itemWidth={collectionCardWidth(pixelsPerSecond)}
+                itemWidth={collectionCardWidth(pixelsPerSecond, dims.strip)}
                 itemHeight={dims.strip}
                 itemDragActivation="hold"
                 overlay={
                   showPlayhead || rulerOn ? (
                     <>
                       {rulerOn ? (
-                        <GraphRuler focusedId={id} pixelsPerSecond={pixelsPerSecond} />
+                        <GraphRuler
+                          focusedId={id}
+                          pixelsPerSecond={pixelsPerSecond}
+                          cardHeight={dims.strip}
+                        />
                       ) : null}
                       {showPlayhead ? (
                         <GraphPlayhead
                           focusedId={id}
                           channel={timeChannel}
                           pixelsPerSecond={pixelsPerSecond}
+                          cardHeight={dims.strip}
                           activeWindow={clockWindow}
                         />
                       ) : null}
@@ -354,6 +359,7 @@ function SubTimelineNode({
                   focusedId={id}
                   channel={timeChannel}
                   pixelsPerSecond={pixelsPerSecond}
+                  cardHeight={dims.strip}
                   ariaLabel={`Seek preview in ${name}`}
                 />
               )}
@@ -402,7 +408,25 @@ export function SubTimelines({
   timeChannel: PreviewTimeChannel;
 }>) {
   const childIds = useCollectionChildIds(parseNodeId(focusedId));
-  if (childIds.length === 0) return null;
+  // Rendering nothing here made the sidebar's children toggle look broken:
+  // "the feature is on and this timeline has none" was indistinguishable from
+  // "the button did nothing". Only the TOP-LEVEL surface says so — repeating
+  // it under every childless nested row would be noise, and nested rows go
+  // through SubTimelineNode, which never reaches this branch.
+  if (childIds.length === 0) {
+    return (
+      <div
+        data-subtimelines-empty
+        className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 px-3 py-4 text-center"
+      >
+        <p className="text-sm font-medium text-zinc-300">No child timelines</p>
+        <p className="mt-0.5 text-xs text-zinc-500">
+          Child timelines are shown. Add a collection to this timeline and it appears here as
+          its own row.
+        </p>
+      </div>
+    );
+  }
 
   return (
     <div className="flex min-w-0 flex-col gap-3">

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -220,6 +220,17 @@ export function GraphTimelineView({
     if (surface !== "strip" && flatOn) setFlatOn(false);
   }
 
+  // The ruler is scoped to flat mode (its toggle only mounts there), so flat
+  // going off has to take the ruler with it — otherwise the control vanishes
+  // while the ruler it armed stays painted on every strip, with no way back.
+  // Watched on flatOn rather than folded into the toggle handler because the
+  // block above turns flat off too; one watcher catches both paths.
+  const [prevFlatOn, setPrevFlatOn] = useState(flatOn);
+  if (prevFlatOn !== flatOn) {
+    setPrevFlatOn(flatOn);
+    if (!flatOn && rulerOn) setRulerOn(false);
+  }
+
   // The closure hydration flat mode needs runs in `FlatClosureHydrator`, which
   // is mounted INSIDE the provider below — the collections store only exists
   // there. This component owns the flag and the pending state; the hydrator

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -637,33 +637,8 @@ export function TimelineSidebar() {
               </button>
             )}
 
-            {/* The strip's time-ruler toggle (was in the breadcrumb row). It
-                rides under the children toggle and only exists in strip
-                layout — the grid has no single time axis for a ruler to
-                mark. */}
-            {onGraphRoute && graphView.surface === "strip" && (
-              <button
-                type="button"
-                aria-pressed={graphView.rulerOn}
-                aria-label={graphView.rulerOn ? "Hide time ruler" : "Show time ruler"}
-                aria-describedby="sidebar-tooltip-ruler"
-                onClick={requestGraphRulerToggle}
-                className={cn(
-                  SIDEBAR_ICON_BASE,
-                  graphView.rulerOn ? SIDEBAR_ICON_PRESSED : SIDEBAR_ICON_IDLE,
-                )}
-              >
-                <Ruler className="h-4 w-4 transition-colors" />
-                <SidebarTooltipLabel
-                  id="sidebar-tooltip-ruler"
-                  label="Time ruler"
-                  description="Tick marks over every strip"
-                />
-              </button>
-            )}
-
-            {/* Flat mode — strip only, like the ruler. Grid keeps its nesting,
-                so there is nothing to flatten there. */}
+            {/* Flat mode — strip only. Grid keeps its nesting, so there is
+                nothing to flatten there. */}
             {onGraphRoute && graphView.surface === "strip" && (
               <button
                 type="button"
@@ -694,6 +669,35 @@ export function TimelineSidebar() {
                       ? "Loading every collection…"
                       : "One flat run — no collections. Reordering is off."
                   }
+                />
+              </button>
+            )}
+
+            {/* The strip's time-ruler toggle, BELOW flat mode and scoped to
+                it: a ruler is a single continuous time axis, which only the
+                flat run actually is. In the nested strip a collection card
+                holds an arbitrary duration in a fixed width, so the ticks
+                beside it measure nothing the user can act on. Grid has no
+                time axis at all. Flat turning off also turns the ruler off
+                (see graph-timeline-view) — otherwise this control vanishes
+                while its ruler stays painted. */}
+            {onGraphRoute && graphView.surface === "strip" && graphView.flatOn && (
+              <button
+                type="button"
+                aria-pressed={graphView.rulerOn}
+                aria-label={graphView.rulerOn ? "Hide time ruler" : "Show time ruler"}
+                aria-describedby="sidebar-tooltip-ruler"
+                onClick={requestGraphRulerToggle}
+                className={cn(
+                  SIDEBAR_ICON_BASE,
+                  graphView.rulerOn ? SIDEBAR_ICON_PRESSED : SIDEBAR_ICON_IDLE,
+                )}
+              >
+                <Ruler className="h-4 w-4 transition-colors" />
+                <SidebarTooltipLabel
+                  id="sidebar-tooltip-ruler"
+                  label="Time ruler"
+                  description="Tick marks over every strip"
                 />
               </button>
             )}

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -384,6 +384,13 @@ async function openGraph(page: Page): Promise<void> {
   await page.getByRole("button", { name: "Show children timelines" }).click();
 }
 
+/** The ruler toggle only mounts in FLAT mode (a ruler is one continuous time
+ *  axis, which only the flat run is), so every ruler test enters flat first. */
+async function enableRuler(page: Page): Promise<void> {
+  await page.getByRole("button", { name: "Show all items in order" }).click();
+  await page.getByRole("button", { name: /show time ruler/i }).click();
+}
+
 /** Sub-graph rows start COLLAPSED — expand one to reveal its (lazy-hydrated)
  *  strip and its own nested rows. `.first()` guards against nested rows once
  *  children exist under the same section name. */
@@ -938,11 +945,17 @@ test.describe("graph view E2E", () => {
     ).toHaveAttribute("aria-pressed", "false");
     await expect(page.locator('section[aria-label^="Sub-timeline"]')).toHaveCount(0);
 
-    // Strip icon → strip layout, and the ruler toggle appears in the
-    // sidebar under the tool cluster.
+    // Strip icon → strip layout. The ruler toggle is scoped to FLAT mode, so
+    // a plain strip still shows no ruler control.
     await surfaceButton(page, "strip").click();
     await expect(strip(page, PROJECT_ID)).toBeVisible();
     await expect(surfaceButton(page, "strip")).toHaveAttribute("aria-pressed", "true");
+    await expect(page.getByRole("button", { name: /show time ruler/i })).toHaveCount(0);
+
+    // Flat mode is what mints a single continuous time axis, and only then
+    // does the ruler toggle appear — below the flat icon in the rail.
+    const flatToggle = page.getByRole("button", { name: "Show all items in order" });
+    await flatToggle.click();
     const rulerToggle = page.getByRole("button", { name: /show time ruler/i });
     await expect(rulerToggle).toBeVisible();
 
@@ -953,6 +966,13 @@ test.describe("graph view E2E", () => {
       "true",
     );
     await expect(page.locator("[data-graph-ruler]").first()).toBeVisible();
+
+    // Leaving flat mode takes the ruler with it: the control unmounts and the
+    // ruler it armed stops painting, so no strip is left ruled with no way
+    // back.
+    await page.getByRole("button", { name: "Show collections" }).click();
+    await expect(page.getByRole("button", { name: /time ruler/i })).toHaveCount(0);
+    await expect(page.locator("[data-graph-ruler]")).toHaveCount(0);
   });
 
   test("preview height is the user's: tree growth never steals it, and a toggle restores it", async ({
@@ -976,12 +996,20 @@ test.describe("graph view E2E", () => {
     await expect.poll(heightOf).toBeGreaterThan(0);
     const initial = await heightOf();
 
-    // The divider remains a compact 12px track even though its centered
-    // transport overhangs it.
+    // The divider is a compact 16px box — 4px of breathing room under the
+    // preview plus the 12px visible band, which is also its drag track — even
+    // though its centered transport overhangs it.
     expect(
       await divider.evaluate((el) => Math.round(el.getBoundingClientRect().height)),
+    ).toBe(16);
+    expect(
+      await divider
+        .locator("[data-divider-line]")
+        .evaluate((el) => Math.round(el.getBoundingClientRect().height)),
     ).toBe(12);
-    await expect(divider.locator("[data-divider-grip]")).toHaveCount(0);
+    // The grip is for coarse pointers only: present in the DOM, not painted
+    // at desktop width.
+    await expect(divider.locator("[data-divider-grip]")).toBeHidden();
     const splitPane = page.getByTestId("workbench-split-pane");
     const displaySurface = page.getByTestId("workbench-display-surface");
     expect(
@@ -998,10 +1026,15 @@ test.describe("graph view E2E", () => {
     expect(
       await dividerLine.evaluate((element) => getComputedStyle(element).backgroundImage),
     ).toContain("linear-gradient");
+    // The band is painted by a gradient built from `currentColor`, so COLOR
+    // is what hover changes. (This read used to be `backgroundColor`, which
+    // is transparent on a gradient-backed element in both states — the
+    // assertion could not fail and, once the gradient landed, could not pass
+    // either.)
     const dividerLineColor = () =>
-      dividerLine.evaluate((el) => getComputedStyle(el).backgroundColor);
+      dividerLine.evaluate((el) => getComputedStyle(el).color);
     const restLineColor = await dividerLineColor();
-    await divider.hover({ position: { x: 20, y: 6 } });
+    await divider.hover({ position: { x: 20, y: 10 } });
     await expect.poll(dividerLineColor).not.toBe(restLineColor);
     await page.mouse.move(0, 0); // unhover before the resize steps below
 
@@ -2162,15 +2195,18 @@ test.describe("graph view E2E", () => {
     await expect(page.getByRole("button", { name: "Next workbench clip" })).toBeVisible();
     await expect(time).toContainText("/");
     await expect(controls.locator("[data-transport-capsule]")).toHaveCount(0);
-    await expect(divider.locator("[data-divider-grip]")).toHaveCount(0);
+    // Grip marks are the coarse-pointer affordance; this runs at desktop
+    // width, where the hover brighten does the job and the grip stays unpainted.
+    await expect(divider.locator("[data-divider-grip]")).toBeHidden();
     expect(
       await primaryControl.evaluate(
         (element) => getComputedStyle(element).backgroundColor,
       ),
     ).toBe("rgba(0, 0, 0, 0)");
 
-    // All three 44px hit targets remain centered on the fixed 12px divider,
-    // while their visible chrome stays deliberately compact.
+    // All three 44px hit targets remain centered on the divider's 12px BAND
+    // (the box is 16 — 4px of padding holds the band off the preview), while
+    // their visible chrome stays deliberately compact.
     const [surfaceBox, canvasBox, groupBox, dividerBox, dividerLineBox, timeBox] =
       await Promise.all([
         surface.boundingBox(),
@@ -2186,13 +2222,15 @@ test.describe("graph view E2E", () => {
     expect(dividerBox).not.toBeNull();
     expect(dividerLineBox).not.toBeNull();
     expect(timeBox).not.toBeNull();
-    expect(dividerBox!.height).toBe(12);
-    expect(groupBox!.width).toBe(132);
-    expect(groupBox!.height).toBe(44);
-    expect(groupBox!.y + groupBox!.height / 2).toBeCloseTo(
-      dividerBox!.y + dividerBox!.height / 2,
+    expect(dividerBox!.height).toBe(16);
+    expect(dividerLineBox!.height).toBe(12);
+    expect(dividerLineBox!.y + dividerLineBox!.height).toBeCloseTo(
+      dividerBox!.y + dividerBox!.height,
       0,
     );
+    expect(groupBox!.width).toBe(132);
+    expect(groupBox!.height).toBe(44);
+    // Centered on the BAND, not on the padded box.
     expect(dividerLineBox!.y + dividerLineBox!.height / 2).toBeCloseTo(
       groupBox!.y + groupBox!.height / 2,
       0,
@@ -3490,6 +3528,30 @@ test.describe("graph view E2E", () => {
     await expect(indicator).toBeVisible();
     const indicatorBox = (await indicator.boundingBox())!;
     expect(indicatorBox.x + indicatorBox.width / 2).toBeCloseTo(point.x, 0);
+    // …and it must sit ON the row it marks. The line is positioned by a
+    // transform measured from the wrapper's origin, so an unanchored
+    // `absolute` resolved to its static position — the wrapper's LAST child,
+    // i.e. below the whole grid — and the line drew a grid's height too low
+    // while still passing the x check above.
+    expect(indicatorBox.y).toBeCloseTo(bravoBox.y, 0);
+    expect(indicatorBox.height).toBeCloseTo(bravoBox.height, 0);
+    // It also has to paint ABOVE the grid. elementFromPoint can't confirm
+    // that (the line is pointer-events-none, so hit-testing looks straight
+    // through it), so pin the stacking instead: a positive z-index on a
+    // later sibling of a z-auto grid puts the line in the positive layer.
+    const stacking = await indicator.evaluate((line) => {
+      const zone = line.closest("[data-native-drop]")!;
+      const grid = zone.querySelector("[data-virtual-grid]")!;
+      return {
+        lineZ: Number(getComputedStyle(line).zIndex),
+        gridZ: getComputedStyle(grid).zIndex,
+        lineIsLaterSibling:
+          Boolean(grid.compareDocumentPosition(line) & Node.DOCUMENT_POSITION_FOLLOWING),
+      };
+    });
+    expect(stacking.lineZ).toBeGreaterThan(0);
+    expect(stacking.gridZ).toBe("auto");
+    expect(stacking.lineIsLaterSibling).toBe(true);
 
     const transfer = await page.evaluateHandle(() => {
       const value = new DataTransfer();
@@ -3506,6 +3568,102 @@ test.describe("graph view E2E", () => {
       .poll(() => gridOrder(page, PROJECT_ID))
       .toEqual(["alpha", expect.stringMatching(/^timeline-/), "bravo", CHILD_ID, "charlie"]);
     await expect(indicator).toHaveCount(0);
+  });
+
+  test("the children toggle says so when the timeline has no child timelines", async ({
+    page,
+  }) => {
+    // PL7-004: with the toggle on and nothing to show, the board used to
+    // render nothing at all, so the control read as broken.
+    const api = await installGraphApi(page);
+    const project = api.documents.get(PROJECT_ID)!;
+    // Media only — no collections, so the tree has no rows to draw.
+    project.clips = [mediaClip("alpha", "video", 0, 6, 8), mediaClip("bravo", "image", 1, 4)];
+    await page.goto(`${GRAPH_URL}?surface=strip`);
+    await strip(page, PROJECT_ID)
+      .locator('[data-node-id="alpha"]')
+      .waitFor({ state: "visible", timeout: 30000 });
+
+    const empty = page.locator("[data-subtimelines-empty]");
+    const childrenToggle = page.getByRole("button", { name: "Show children timelines" });
+    // OFF: nothing renders — the empty state belongs to the ON state only.
+    await expect(empty).toHaveCount(0);
+
+    await childrenToggle.click();
+    await expect(empty).toBeVisible();
+    await expect(empty).toContainText(/no child timelines/i);
+
+    // Adding a collection replaces it with the real row, no reload.
+    await page.getByRole("button", { name: /add collection/i }).click();
+    await expect(empty).toHaveCount(0);
+    await expect(page.locator('section[aria-label^="Sub-timeline"]')).toHaveCount(1);
+
+    // Turning the toggle back off leaves neither.
+    await page.getByRole("button", { name: "Hide children timelines" }).click();
+    await expect(empty).toHaveCount(0);
+    await expect(page.locator('section[aria-label^="Sub-timeline"]')).toHaveCount(0);
+  });
+
+  test("every drop zone announces itself for the whole native drag", async ({ page }) => {
+    // PL7-003: before this, the only feedback was the insertion line, which
+    // appears after the pointer has already found a target. Now a droppable
+    // drag anywhere on the page outlines every zone, and the one under the
+    // pointer is filled in.
+    await installGraphApi(page);
+    await openGraph(page);
+    await expandSubGraph(page, "Scene A");
+    await expect.poll(() => stripOrder(page, CHILD_ID), { timeout: 15000 }).toEqual(["c1", "c2"]);
+
+    const zones = page.locator("[data-native-drop]");
+    await expect.poll(() => zones.count()).toBeGreaterThan(1);
+    const armed = page.locator("[data-native-drop-armed]");
+    const hovered = page.locator("[data-native-drop-hovered]");
+    await expect(armed).toHaveCount(0);
+
+    // A drag that is over the PAGE but not over any zone: every zone arms,
+    // none is hovered. The header is a safe "not a drop zone" target.
+    const dragOverPage = () =>
+      page.evaluate(() => {
+        const transfer = new DataTransfer();
+        transfer.setData("application/x-gstudio-type", "collection");
+        document.body.dispatchEvent(
+          new DragEvent("dragover", { bubbles: true, cancelable: true, dataTransfer: transfer }),
+        );
+      });
+    await dragOverPage();
+    const zoneCount = await zones.count();
+    await expect(armed).toHaveCount(zoneCount);
+    await expect(hovered).toHaveCount(0);
+
+    // Layout must not move as the affordance comes and goes — the ring and
+    // tint are drawn outside the box, so the cards keep their coordinates.
+    const box = (await page.locator(`[data-native-drop="${PROJECT_ID}"]`).boundingBox())!;
+
+    // Now over one zone specifically: it alone reads hovered.
+    await page.locator(`[data-native-drop="${PROJECT_ID}"]`).evaluate((zone, point) => {
+      const transfer = new DataTransfer();
+      transfer.setData("application/x-gstudio-type", "collection");
+      zone.dispatchEvent(
+        new DragEvent("dragover", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: transfer,
+          clientX: point.x,
+          clientY: point.y,
+        }),
+      );
+    }, { x: box.x + box.width / 2, y: box.y + box.height / 2 });
+    await expect(hovered).toHaveCount(1);
+    await expect(armed).toHaveCount(zoneCount);
+    const armedBox = (await page.locator(`[data-native-drop="${PROJECT_ID}"]`).boundingBox())!;
+    expect(armedBox.x).toBeCloseTo(box.x, 0);
+    expect(armedBox.y).toBeCloseTo(box.y, 0);
+    expect(armedBox.width).toBeCloseTo(box.width, 0);
+
+    // The drag ending anywhere disarms everything — no residue.
+    await page.evaluate(() => window.dispatchEvent(new DragEvent("dragend")));
+    await expect(armed).toHaveCount(0);
+    await expect(hovered).toHaveCount(0);
   });
 
   test("a 2xx upload with no usable url adds nothing and says so", async ({ page }) => {
@@ -3872,8 +4030,8 @@ test.describe("graph view E2E", () => {
   }) => {
     await installGraphApi(page);
     await openGraph(page);
-    // Ruler is strip-only and off by default; turn it on.
-    await page.getByRole("button", { name: /show time ruler/i }).click();
+    // Ruler lives in flat mode and is off by default; turn both on.
+    await enableRuler(page);
     await expect(page.locator("[data-graph-ruler]")).toHaveCount(1);
 
     // Expand a sub-collection — its strip must get its OWN ruler (R6 #1), so a
@@ -3897,7 +4055,7 @@ test.describe("graph view E2E", () => {
       ...Array.from({ length: 299 }, (_, i) => mediaClip(`long-${i}`, "image", i + 1, 4)),
     ];
     await openGraph(page);
-    await page.getByRole("button", { name: /show time ruler/i }).click();
+    await enableRuler(page);
     const ruler = page.locator("[data-graph-ruler]");
     await expect(ruler).toHaveCount(1);
 
@@ -3958,12 +4116,13 @@ test.describe("graph view E2E", () => {
     await page.getByRole("button", { name: /show time ruler/i }).click();
     await expect(page.locator("[data-graph-ruler]")).toHaveCount(1);
 
-    // Leaving flat mode restores the nested reading.
+    // Leaving flat mode restores the nested reading — and takes the ruler
+    // with it, since the ruler is scoped to the flat run.
     await page.getByRole("button", { name: "Show collections" }).click();
     await expect
       .poll(() => stripOrder(page, PROJECT_ID))
       .toEqual(["alpha", "bravo", CHILD_ID, "charlie"]);
-    await expect(page.locator("[data-graph-ruler]")).toHaveCount(1);
+    await expect(page.locator("[data-graph-ruler]")).toHaveCount(0);
   });
 
   test("flat mode keeps expanded child playheads synchronized with preview", async ({

--- a/packages/ui/dnd-collections/VirtualGrid.stories.tsx
+++ b/packages/ui/dnd-collections/VirtualGrid.stories.tsx
@@ -8,6 +8,7 @@ import { PaletteItem } from "./react/palette";
 import { VirtualGrid } from "./virtual/VirtualGrid";
 import { VirtualStrip } from "./virtual/VirtualStrip";
 import {
+  dispatchPointerSequence,
   dragHoldAt,
   dragToPoint,
   gapBetween,
@@ -704,5 +705,83 @@ export const KeyboardRovingNavigation: Story = {
       expect(first).not.toBeNull();
       expect(first!.ownerDocument.activeElement).toBe(first);
     });
+  },
+};
+
+/** Three cards in a four-column grid: the fourth slot and everything below
+ *  the first row are real background — the deselect target. */
+function shortGridGraph() {
+  const result = buildGraph([
+    {
+      kind: "collection",
+      id: "grid",
+      name: "Grid",
+      children: [
+        { kind: "media", id: "m0", name: "M0", durationSeconds: 4 },
+        { kind: "media", id: "m1", name: "M1", durationSeconds: 4 },
+        { kind: "media", id: "m2", name: "M2", durationSeconds: 4 },
+      ],
+    },
+  ]);
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.value;
+}
+
+export const BackgroundDragKeepsSelection: Story = {
+  // PL7-001's guard, pinned where it carries weight. The grid has no pan hook
+  // to squash a trailing click, so a press that TRAVELS across the background
+  // and releases delivers a plain click to the container — indistinguishable
+  // from a deliberate background click except by where the press started.
+  // Without the press-position check, dragging across empty space silently
+  // dropped the selection.
+  render: () => (
+    <DndCollections initialGraph={shortGridGraph()}>
+      <div className="w-[600px]">
+        <VirtualGrid collectionId={parseNodeId("grid")} columns={COLUMNS} />
+      </div>
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    const grid = canvasElement.querySelector<HTMLElement>('[data-virtual-grid="grid"]')!;
+    const m1 = nodeCard(canvasElement, "m1");
+    await waitForLayout(m1);
+
+    await userEvent.click(m1);
+    await waitFor(() => expect(nodeCard(canvasElement, "m1")).toHaveAttribute("data-selected", "true"));
+
+    // Background: below the only row, inside the container.
+    const rowBottom = nodeCard(canvasElement, "m0").getBoundingClientRect().bottom;
+    const gridBox = grid.getBoundingClientRect();
+    const emptyY = (rowBottom + gridBox.bottom) / 2;
+    const emptyX = gridBox.left + gridBox.width / 2;
+    expect(emptyY).toBeGreaterThan(rowBottom);
+
+    const click = (x: number, y: number) =>
+      grid.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true, detail: 1, clientX: x, clientY: y }),
+      );
+
+    // Press, travel well past the slop, release: the selection survives.
+    await dispatchPointerSequence([
+      { element: grid, type: "pointerdown", clientX: emptyX, clientY: emptyY },
+      { element: grid, type: "pointermove", clientX: emptyX - 80, clientY: emptyY, delayAfterMs: 16 },
+      { element: grid, type: "pointerup", clientX: emptyX - 80, clientY: emptyY },
+    ]);
+    click(emptyX - 80, emptyY);
+    // Settle first: a clear would land on a later render, so asserting
+    // synchronously here would pass even when the guard is gone.
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(nodeCard(canvasElement, "m1")).toHaveAttribute("data-selected", "true");
+
+    // A stationary press on the same spot DOES clear — so the assertion above
+    // is about the movement, not about background clicks being inert here.
+    await dispatchPointerSequence([
+      { element: grid, type: "pointerdown", clientX: emptyX, clientY: emptyY },
+      { element: grid, type: "pointerup", clientX: emptyX, clientY: emptyY },
+    ]);
+    click(emptyX, emptyY);
+    await waitFor(() =>
+      expect(nodeCard(canvasElement, "m1")).not.toHaveAttribute("data-selected", "true"),
+    );
   },
 };

--- a/packages/ui/dnd-collections/VirtualStrip.stories.tsx
+++ b/packages/ui/dnd-collections/VirtualStrip.stories.tsx
@@ -2197,3 +2197,77 @@ export const FlatItemSource: Story = {
     );
   },
 };
+
+/** A handful of cards in a wide strip, so there is real empty space to the
+ *  right of the last one — the "click away to deselect" target. */
+const shortGraph = () => {
+  const result = buildGraph([
+    {
+      kind: "collection",
+      id: "strip",
+      name: "Strip",
+      children: [
+        { kind: "media", id: "m0", name: "M0", durationSeconds: 4 },
+        { kind: "media", id: "m1", name: "M1", durationSeconds: 4 },
+        { kind: "media", id: "m2", name: "M2", durationSeconds: 4 },
+      ],
+    },
+  ]);
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.value;
+};
+
+export const BackgroundClickClearsSelection: Story = {
+  // PL7-001: a click on empty strip space is the only mouse route back to
+  // "nothing selected" — cards themselves only ever replace or toggle.
+  //
+  // A pan across that same empty space must NOT clear, but on a strip the pan
+  // hook already squashes its own trailing click, so asserting it here would
+  // pass with or without the press-position guard. The guard is pinned where
+  // it is actually load-bearing — VirtualGrid, which has no pan hook — in
+  // `BackgroundDragKeepsSelection`.
+  render: () => (
+    <DndCollections initialGraph={shortGraph()}>
+      <div className="w-[640px]">
+        <VirtualStrip collectionId={parseNodeId("strip")} itemWidth={96} />
+      </div>
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    const strip = canvasElement.querySelector<HTMLElement>('[data-virtual-strip="strip"]')!;
+    const m1 = nodeCard(canvasElement, "m1");
+    await waitForLayout(m1);
+
+    await userEvent.click(m1);
+    await waitFor(() => expect(nodeCard(canvasElement, "m1")).toHaveAttribute("data-selected", "true"));
+
+    // Empty space: past the last card's right edge, still inside the strip.
+    const last = nodeCard(canvasElement, "m2").getBoundingClientRect();
+    const stripBox = strip.getBoundingClientRect();
+    const emptyX = (last.right + stripBox.right) / 2;
+    const emptyY = stripBox.top + stripBox.height / 2;
+    expect(emptyX).toBeGreaterThan(last.right);
+
+    const pressBackground = (x: number, y: number) =>
+      dispatchPointerSequence([
+        { element: strip, type: "pointerdown", clientX: x, clientY: y },
+      ]);
+    const releaseBackground = (x: number, y: number) =>
+      dispatchPointerSequence([{ element: strip, type: "pointerup", clientX: x, clientY: y }]);
+    const clickBackground = (x: number, y: number) => {
+      strip.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true, detail: 1, clientX: x, clientY: y }),
+      );
+    };
+
+    // A stationary click on empty space clears it.
+    await pressBackground(emptyX, emptyY);
+    await releaseBackground(emptyX, emptyY);
+    clickBackground(emptyX, emptyY);
+    // Unselected cards carry no data-selected at all, so absence is the
+    // assertion — not the string "false".
+    await waitFor(() =>
+      expect(nodeCard(canvasElement, "m1")).not.toHaveAttribute("data-selected", "true"),
+    );
+  },
+};

--- a/packages/ui/dnd-collections/react/use-background-clear.ts
+++ b/packages/ui/dnd-collections/react/use-background-clear.ts
@@ -1,0 +1,73 @@
+import { useCallback, useRef } from "react";
+import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from "react";
+
+import { isEditableKeyboardTarget } from "./node-dom";
+import type { CollectionsStore } from "./collections-store";
+
+/**
+ * How far the pointer may travel between press and release and still count as
+ * a CLICK on the background. Past it the gesture was a pan (or the tail of a
+ * card drag that ended over empty space), and a pan must not silently drop the
+ * user's selection.
+ */
+const BACKGROUND_CLICK_SLOP_PX = 4;
+
+/**
+ * Targets inside a surface that own their own press even though they are not
+ * cards: the trim affordances, and anything a consumer marked as its own
+ * gesture. Cards are excluded separately by `[data-node-id]`.
+ */
+const NON_BACKGROUND_SELECTOR =
+  "[data-node-id], [data-drag-handle], [data-trim-handle], [data-trim-overview], button, a, input, textarea, select, [role='slider']";
+
+/**
+ * Clicking empty space in a surface clears the selection — the counterpart to
+ * the card grammar in `interaction-policy`, and the only way to reach "nothing
+ * selected" with the mouse.
+ *
+ * The press position is remembered so a PAN cannot be mistaken for a click:
+ * both end with a `click` event on the scroll container, and only the one that
+ * stayed put means "I clicked the background". A double-click's second click
+ * is ignored for the same reason the card grammar ignores it — the gesture is
+ * already committed to something else.
+ */
+export function useBackgroundSelectionClear(store: CollectionsStore): Readonly<{
+  onPointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
+  onClick: (event: ReactMouseEvent<HTMLElement>) => void;
+}> {
+  const originRef = useRef<{ x: number; y: number } | null>(null);
+
+  const onPointerDown = useCallback((event: ReactPointerEvent<HTMLElement>) => {
+    originRef.current = { x: event.clientX, y: event.clientY };
+  }, []);
+
+  const onClick = useCallback(
+    (event: ReactMouseEvent<HTMLElement>) => {
+      const origin = originRef.current;
+      originRef.current = null;
+
+      if (event.detail > 1) return;
+
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      if (target.closest(NON_BACKGROUND_SELECTOR)) return;
+      if (isEditableKeyboardTarget(target)) return;
+
+      // Keyboard activation reports 0/0 and no preceding pointerdown; a real
+      // background click always has one.
+      if (!origin) return;
+      if (
+        Math.abs(event.clientX - origin.x) > BACKGROUND_CLICK_SLOP_PX ||
+        Math.abs(event.clientY - origin.y) > BACKGROUND_CLICK_SLOP_PX
+      ) {
+        return;
+      }
+
+      if (store.getSnapshot().interaction.selectedIds.size === 0) return;
+      store.clearSelection();
+    },
+    [store],
+  );
+
+  return { onPointerDown, onClick };
+}

--- a/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
@@ -29,6 +29,7 @@ import {
 import { useCollectionsSelector, useCollectionsStore } from "../react/collections-store";
 import { NodeCard } from "../react/node-views";
 import { isContiguousReorderNoOp } from "./insert-noop";
+import { useBackgroundSelectionClear } from "../react/use-background-clear";
 import { useEdgeAutoScroll } from "../react/use-edge-autoscroll";
 import {
   useFocusNode,
@@ -235,6 +236,7 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
     // row, ±cols between rows), scrolling offscreen rows into view. Alt+arrows
     // stay item MOVES (handled by the keyboard controller via data-grid-columns).
     const store = useCollectionsStore();
+    const backgroundClear = useBackgroundSelectionClear(store);
     const name = useCollectionsSelector(
       (s) => s.graph.nodesById.get(collectionId)?.name ?? String(collectionId)
     );
@@ -346,6 +348,11 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
         aria-rowcount={rowCount}
         aria-colcount={cols}
         onKeyDown={onKeyDown}
+        // Empty space is the "deselect" target; the pointerdown half records
+        // the press position so a drag that ends over the background is not
+        // mistaken for a click. (See useBackgroundSelectionClear.)
+        onPointerDown={backgroundClear.onPointerDown}
+        onClick={backgroundClear.onClick}
         className={twMerge(
           "relative overflow-y-auto rounded-md border border-dashed border-border p-2",
           className,

--- a/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
@@ -40,6 +40,7 @@ import { findNodeElement, isEditableKeyboardTarget } from "../react/node-dom";
 import { NodeCard, type NodeCardDragActivation } from "../react/node-views";
 import { TrimOverviewStrip } from "../react/trim-overview";
 import { TrimPreviewContext, type LiveTrim, type TrimPreview } from "../react/trim-preview-context";
+import { useBackgroundSelectionClear } from "../react/use-background-clear";
 import { useEdgeAutoScroll } from "../react/use-edge-autoscroll";
 import {
   usePanWithMomentum,
@@ -620,6 +621,7 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
       [panToScroll, store]
     );
     usePanWithMomentum(scrollRef, "x", panOptions);
+    const backgroundClear = useBackgroundSelectionClear(store);
 
     const scrollToNode = useCallback(
       (id: NodeId): boolean => {
@@ -832,6 +834,11 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
             aria-rowcount={childIds.length === 0 ? 0 : 1}
             aria-colcount={childIds.length}
             onKeyDown={onKeyDown}
+            // Empty space is the "deselect" target. The pointerdown half only
+            // records where the press started, so a PAN (which also ends in a
+            // click here) can be told apart from a real background click.
+            onPointerDown={backgroundClear.onPointerDown}
+            onClick={backgroundClear.onClick}
             className={twMerge(
               "relative overflow-x-auto rounded-md border border-dashed border-border p-2",
               className,

--- a/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
+++ b/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
@@ -92,12 +92,16 @@ export const StickyPreview: Story = {
     expect(buttonGroupBox.width).toBe(132);
     expect(buttonGroupBox.height).toBe(44);
     expect(controls.querySelector("[data-transport-capsule]")).toBeNull();
-    expect(divider.querySelector("[data-divider-grip]")).toBeNull();
-    expect(dividerBox.height).toBe(12);
-    expect(buttonGroupBox.y + buttonGroupBox.height / 2).toBeCloseTo(
-      dividerBox.y + dividerBox.height / 2,
-      0,
-    );
+    // The grip is the coarse-pointer affordance — always in the DOM, painted
+    // only at tablet width and below (md:hidden), so presence is what this
+    // story can assert without pinning the canvas width.
+    expect(divider.querySelector("[data-divider-grip]")).not.toBeNull();
+    // 4px of padding above a 12px band: the box is 16 and the band is
+    // BOTTOM-aligned in it, so the gap lands under the preview surface.
+    expect(dividerBox.height).toBe(16);
+    expect(dividerLineBox.height).toBe(12);
+    expect(dividerLineBox.bottom).toBeCloseTo(dividerBox.bottom, 0);
+    // The transport centers on the BAND, not on the padded box.
     expect(dividerLineBox.y + dividerLineBox.height / 2).toBeCloseTo(
       buttonGroupBox.y + buttonGroupBox.height / 2,
       0,

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -78,9 +78,19 @@ const BUFFER_WINDOW_SIZE = 4;
 const DEFAULT_SURFACE_HEIGHT = 380;
 const MIN_SURFACE_HEIGHT = 120;
 const MIN_TIMELINE_SPACE = 260;
-/** The resize divider's own height (Tailwind h-3). The transport is centered
- *  on this stable track and may overhang it without changing layout. */
-const DIVIDER_HEIGHT_PX = 12;
+/** The visible divider BAND, which is also its drag track (Tailwind h-3). */
+const DIVIDER_BAND_HEIGHT_PX = 12;
+/** Breathing room between the preview surface and the band. Part of the
+ *  divider button's own box, not a margin, so the measured element and the
+ *  published offset below cannot disagree. */
+const DIVIDER_TOP_PADDING_PX = 4;
+/** The divider element's full height — padding + band. Feeds
+ *  `--workbench-preview-offset`, so it MUST stay equal to what the button
+ *  actually renders (`pt-1` + `h-3`). */
+const DIVIDER_HEIGHT_PX = DIVIDER_TOP_PADDING_PX + DIVIDER_BAND_HEIGHT_PX;
+/** Where the band's mid-line falls inside that box. The transport is centered
+ *  on it and may overhang it without changing layout. */
+const DIVIDER_BAND_CENTER_PX = DIVIDER_TOP_PADDING_PX + DIVIDER_BAND_HEIGHT_PX / 2;
 
 type WorkbenchDividerTransportProps = {
   currentTime: number;
@@ -118,7 +128,7 @@ function WorkbenchDividerTransport({
       <div
         className="pointer-events-auto absolute left-1/2 flex h-11 w-[8.25rem] items-center justify-center"
         data-transport-button-group
-        style={{ top: DIVIDER_HEIGHT_PX / 2, transform: "translate(-50%, -50%)" }}
+        style={{ top: DIVIDER_BAND_CENTER_PX, transform: "translate(-50%, -50%)" }}
         onPointerDown={(event) => {
           // The transport visually occupies the divider, but remains its own
           // interaction island. A transport press must never begin a resize.
@@ -134,7 +144,7 @@ function WorkbenchDividerTransport({
           title="Previous clip"
         >
           <span className="grid size-5 translate-x-2 place-items-center rounded-full transition-colors group-focus-visible/previous:ring-2 group-focus-visible/previous:ring-sky-400 group-focus-visible/previous:ring-offset-2 group-focus-visible/previous:ring-offset-zinc-950">
-            <SkipBack className="size-3 fill-current" />
+            <SkipBack className="size-3.5 fill-current" />
           </span>
         </button>
 
@@ -154,9 +164,9 @@ function WorkbenchDividerTransport({
             data-transport-primary-control
           >
             {isPlaying ? (
-              <Pause className="size-2.5 fill-current" />
+              <Pause className="size-3 fill-current" />
             ) : (
-              <Play className="ml-0.5 size-2.5 fill-current" />
+              <Play className="ml-0.5 size-3 fill-current" />
             )}
           </span>
         </button>
@@ -170,7 +180,7 @@ function WorkbenchDividerTransport({
           title="Next clip"
         >
           <span className="grid size-5 -translate-x-2 place-items-center rounded-full transition-colors group-focus-visible/next:ring-2 group-focus-visible/next:ring-sky-400 group-focus-visible/next:ring-offset-2 group-focus-visible/next:ring-offset-zinc-950">
-            <SkipForward className="size-3 fill-current" />
+            <SkipForward className="size-3.5 fill-current" />
           </span>
         </button>
       </div>
@@ -179,7 +189,7 @@ function WorkbenchDividerTransport({
         className="absolute right-3 max-w-[calc(50%_-_5rem)] overflow-hidden text-ellipsis whitespace-nowrap rounded-full bg-zinc-900/90 px-2 py-0.5 font-mono text-[10px] text-zinc-400 shadow-sm"
         aria-label={`Preview time ${formatSeconds(currentTime)} of ${formatSeconds(duration)}`}
         data-testid="workbench-preview-time"
-        style={{ top: DIVIDER_HEIGHT_PX / 2, transform: "translateY(-50%)" }}
+        style={{ top: DIVIDER_BAND_CENTER_PX, transform: "translateY(-50%)" }}
       >
         <span className="sm:hidden">{formatSeconds(currentTime)}</span>
         <span className="hidden sm:inline">
@@ -1229,21 +1239,37 @@ export function WorkbenchSplitPane({
           aria-valuemin={MIN_SURFACE_HEIGHT}
           aria-valuenow={Math.round(surfaceHeight)}
           aria-label="Resize workbench display"
-          // The divider keeps a 12px interaction track while its one-pixel
-          // centerline runs directly through the transport controls. The line
-          // fades across the 132px transport group so no divider color shows
-          // behind its background-free icons.
-          className="group relative block h-3 w-full cursor-row-resize bg-transparent focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-400 focus-visible:outline-offset-2"
+          // pt-1 + h-3 = DIVIDER_HEIGHT_PX. The padding is the gap under the
+          // preview; the band below it is both the visible divider and the
+          // drag track, and the transport rides centered on that band.
+          className="group relative block w-full cursor-row-resize bg-transparent pt-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-400 focus-visible:outline-offset-2"
           data-workbench-divider
           onPointerDown={handleDividerPointerDown}
           onPointerMove={handleDividerPointerMove}
           onPointerUp={handleDividerPointerUp}
           onPointerCancel={handleDividerPointerUp}
         >
+          {/* The band fades out across the 132px transport group so no divider
+              color shows behind its background-free icons — the same window
+              the one-pixel centerline used, now filling the full band. */}
           <span
             aria-hidden="true"
-            className="pointer-events-none absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-[linear-gradient(to_right,currentColor_0,currentColor_calc(50%_-_6.125rem),transparent_calc(50%_-_4.125rem),transparent_calc(50%_+_4.125rem),currentColor_calc(50%_+_6.125rem),currentColor_100%)] text-zinc-800 transition-colors group-hover:text-zinc-600 group-active:text-zinc-500"
+            className="pointer-events-none block h-3 rounded-sm bg-[linear-gradient(to_right,currentColor_0,currentColor_calc(50%_-_6.125rem),transparent_calc(50%_-_4.125rem),transparent_calc(50%_+_4.125rem),currentColor_calc(50%_+_6.125rem),currentColor_100%)] text-zinc-800 transition-colors group-hover:text-zinc-700 group-active:text-zinc-600"
             data-divider-line
+          />
+          {/* Coarse-pointer devices never see the hover brighten, so at tablet
+              width and below the band carries a standing grip mark instead.
+              ONE mark, at 7rem left of centre: the centre belongs to the
+              transport (solid band resumes past ±6.125rem) and the band's
+              right end belongs to the time readout, whose opaque pill is up
+              to half the width — a mirrored mark over there is simply painted
+              over. Left of the transport is the only place on a phone-width
+              band that is reliably empty. */}
+          <span
+            aria-hidden="true"
+            data-divider-grip
+            className="pointer-events-none absolute left-[calc(50%_-_7rem)] h-0.5 w-5 rounded-full bg-zinc-500 md:hidden"
+            style={{ top: DIVIDER_BAND_CENTER_PX, transform: "translateY(-50%)" }}
           />
         </button>
         </div>

--- a/punch-list/PUNCH-LIST-02.md
+++ b/punch-list/PUNCH-LIST-02.md
@@ -1,0 +1,248 @@
+# Punch List 02
+
+## PL2-001 — Refine collection metadata separation and name spacing
+
+- Status: Completed
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Grid view — collection item UI
+- Screenshot: Not captured
+
+The collection item’s duration and item count should be visually separated by
+a slash. The collection name also needs more surrounding space because it
+currently sits too close to the card borders and the preview image above it.
+
+Acceptance criteria:
+
+- Duration and item count are separated by a slash, for example
+  `8.7s / 2 items`.
+- Singular and plural item labels remain grammatically correct.
+- The collection name has more horizontal padding from the card borders.
+- The collection name has more vertical space between it and the preview
+  image.
+- The added spacing remains balanced and readable at every supported item
+  size without clipping or unwanted wrapping.
+
+## PL2-002 — Make the sidebar Trash-area icon unmistakable
+
+- Status: Completed
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Sidebar icon bar — Trash area above Settings
+- Screenshot: Not captured
+
+Replace the current Trash-area icon with a clearer folder-and-trash
+composition. The preferred direction is either a large folder with a
+prominent trash symbol centered or positioned at its upper-right, or a large
+trash symbol with a smaller folder badge at its upper-right. Choose the
+composition that remains clearest at the sidebar’s rendered size.
+
+Acceptance criteria:
+
+- The icon visibly combines the concepts of a folder or storage area and
+  trash.
+- The trash symbol is large and clear enough to recognize immediately at the
+  sidebar’s default size.
+- The composition remains legible in its default, hover, focused, active, and
+  drag-feedback states.
+- It remains visually distinguishable from the ordinary trash-bucket icon
+  used to delete a selected item.
+- The icon stays in the existing Trash-area position directly above Settings.
+
+## PL2-003 — Show Paste only when clipboard content is available
+
+- Status: Completed
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Sidebar icon bar — selected-item action context
+- Screenshot: Not captured
+
+When an item is selected and the context-aware sidebar actions appear, hide
+the Paste icon if there is nothing available to paste. Show the action only
+when the graph clipboard contains an item that can be pasted.
+
+Acceptance criteria:
+
+- Paste is absent from the selected-item sidebar when the graph clipboard is
+  empty.
+- Paste appears as soon as pasteable clipboard content is available.
+- The visible Paste action retains its existing behavior and availability
+  rules.
+- Copying or cutting an item updates the sidebar without requiring a page
+  reload or reselection.
+- Clearing the clipboard hides Paste again and preserves the ordering and
+  spacing of the remaining actions.
+
+## PL2-004 — Combine folder and media concepts in the Assets icon
+
+- Status: Completed
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Sidebar icon bar — Assets
+- Screenshot: Not captured
+
+Update the Assets icon so it communicates both a media library and a folder or
+stored collection. The result should read as the place where project media is
+organized, rather than as a generic image-only action.
+
+Acceptance criteria:
+
+- The icon visibly combines a folder or library concept with recognizable
+  media imagery.
+- It remains clear and legible at the sidebar’s default rendered size.
+- The visual is distinct from the Trash-area folder-and-trash icon and the
+  Collection tool.
+- The icon remains recognizable in its default, hover, focused, active, and
+  drawer-open states.
+- The Assets icon’s existing position and behavior remain unchanged.
+
+## PL2-005 — Subdue the selected-item amber treatment
+
+- Status: Completed
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Grid items and sidebar — selected-item context
+- Screenshot: Not captured
+
+The selected item’s amber border and the matching amber treatment on its
+context-aware sidebar actions currently stand out too strongly. Preserve a
+visible relationship between the selected item and its available actions, but
+make the shared color treatment quieter and less dominant.
+
+Acceptance criteria:
+
+- A selected item remains clearly identifiable without an overly bright or
+  visually dominant border.
+- The contextual sidebar actions retain a subtle visual relationship to the
+  selected item.
+- The amber hue, opacity, border weight, background tint, or a combination of
+  these is reduced to create a more subdued result.
+- Selection and action states remain distinguishable from hover, focus,
+  disabled, drag, and error states.
+- Text and icons continue to meet readable contrast requirements in the
+  subdued treatment.
+
+## PL2-006 — Make every breadcrumb item editable with one click
+
+- Status: Completed
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph/timeline-mrw5pjun10npp2
+- Area: Graph header — timeline breadcrumb
+- Screenshot: Not captured
+
+Every timeline breadcrumb item should support inline renaming. Replace the
+current behavior, where only the last item is editable by double-clicking, with
+a consistent interaction across the entire breadcrumb: a subtle hover state
+indicates editability, and a single click enters inline-edit mode.
+
+Acceptance criteria:
+
+- Every breadcrumb item, including ancestors and the current timeline, can be
+  edited in place.
+- Hovering an editable breadcrumb item applies a subtle background or
+  equivalent visual treatment that indicates interactivity.
+- A single click on any breadcrumb item replaces its label with a focused
+  inline text editor.
+- Pressing Enter commits the edited name.
+- Clicking or moving focus outside the editor commits the edited name.
+- The updated name is reflected consistently anywhere that timeline name is
+  shown.
+- The interaction remains keyboard accessible, with a visible focus state and
+  no layout jump when entering or leaving edit mode.
+- Editing one breadcrumb item does not accidentally rename or activate another
+  item.
+
+## PL2-007 — Replace the Projects-page loading indicator with skeletons
+
+- Status: Completed
+- URL: http://localhost:3000/
+- Area: Timeline Projects — initial project-list loading state
+- Screenshot: Not captured
+
+When the Projects page is loading its saved projects, show a skeleton layout
+instead of the current generic loading indicator. The placeholders should
+closely represent the project cards that will replace them.
+
+Acceptance criteria:
+
+- The current loading indicator is removed from the saved-project loading
+  state.
+- The page displays project-card skeletons while project data is loading.
+- Skeleton dimensions and spacing closely match the loaded project-card
+  layout to minimize layout shift.
+- Stable page content, such as the page heading and new-project controls,
+  remains available while the saved-project list loads.
+- Skeletons are replaced cleanly by loaded projects, the empty state, or an
+  error state when the request finishes.
+- The loading region exposes an appropriate accessible busy or loading state.
+
+## PL2-008 — Improve the breadcrumb-row aggregate text contrast
+
+- Status: Completed
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Graph header — centered clip-count and duration summary
+- Screenshot: Not captured
+
+The centered aggregate text in the breadcrumb row, such as
+“5 clips · 24.0s,” blends too closely into the header background. Make it
+slightly more visible and easier to read without allowing it to compete with
+the breadcrumb or primary controls.
+
+Acceptance criteria:
+
+- The centered clip-count and duration summary has moderately stronger
+  contrast against the header background.
+- The text remains visually secondary to the breadcrumb and primary actions.
+- The updated treatment remains readable in normal, selected-item, and
+  drag-feedback states.
+- Clip-count and duration values, formatting, position, and behavior remain
+  unchanged.
+- The text continues to meet accessible contrast expectations for supporting
+  interface information.
+
+## PL2-009 — Make “Drop to nest” larger and easier to read
+
+- Status: Completed
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Collection item — nested-drop feedback
+- Screenshot: Not captured
+
+When an item is dragged over a collection and nesting is available, make the
+“Drop to nest” label larger and more prominent. The collection preview image,
+name, and metadata currently compete with the label, so apply a stronger
+lightened or opaque veil over the underlying collection content while the nest
+target is active.
+
+Acceptance criteria:
+
+- The “Drop to nest” label uses a noticeably larger, more readable type size.
+- The label remains positioned at the bottom center of the collection item.
+- An active nest target visually suppresses the underlying preview image,
+  collection name, and metadata with a lightened or more opaque overlay.
+- The label has strong contrast against both light and dark collection
+  imagery.
+- The valid-nest treatment remains clearly distinct from the invalid or
+  cycle-prevention state.
+- The stronger feedback does not change the collection’s drop-target geometry
+  or interfere with completing the drop.
+
+## PL2-010 — Stabilize the blue drop indicator at grid-row starts
+
+- Status: Completed
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Grid view — first-position and row-start drop boundaries
+- Screenshot: Not captured
+
+The blue vertical drop indicator is now centered correctly for most gaps, but
+the boundary before the first item still has two alternate visual positions.
+The problem occurs at the very beginning of the grid and may also affect a
+drop boundary at the start of a wrapped grid row. These row-start boundaries
+should resolve to one stable indicator position.
+
+Acceptance criteria:
+
+- Dropping before the first item in the grid shows the blue indicator in one
+  consistent position.
+- A drop boundary at the start of any wrapped grid row also uses one stable
+  position.
+- The indicator does not jump between alternate left or right placements
+  while the pointer remains over the same row-start boundary.
+- The row-start indicator is centered in the intended leading gap using the
+  same spacing logic as ordinary between-item boundaries.
+- The item is inserted at the exact position represented by the indicator.
+- Behavior remains stable across responsive column-count and item-size
+  changes.

--- a/punch-list/PUNCH-LIST-03.md
+++ b/punch-list/PUNCH-LIST-03.md
@@ -1,0 +1,277 @@
+# Punch List 03
+
+## PL3-001 — Limit breadcrumb inline editing to the current item
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph/timeline-mrqmm7d1jocgec/timeline-mrupwdw45u6lld
+- Area: Graph header — timeline breadcrumb
+- Screenshot: Not captured
+
+Keep inline editing for the last breadcrumb item, which represents the
+currently open timeline. Every earlier breadcrumb item should instead be a
+navigation link that opens the corresponding ancestor timeline view.
+
+Acceptance criteria:
+
+- Only the last breadcrumb item can enter inline-edit mode.
+- The last item retains its current single-click edit behavior.
+- Pressing Enter or moving focus outside the editor commits the last item's
+  updated name.
+- Every earlier breadcrumb item renders as a link rather than an inline-edit
+  control.
+- Selecting an earlier breadcrumb item navigates to that item's correct
+  timeline view.
+- Each ancestor link uses the correct path depth and preserves encoded
+  timeline identifiers.
+- Ancestor links retain clear hover and keyboard-focus feedback.
+- Clicking an ancestor never opens the rename editor or renames that item.
+
+## PL3-002 — Match the selected-action separator to the selection border
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph/timeline-mrqmm7d1jocgec/timeline-mrupwdw45u6lld
+- Area: Sidebar icon bar — selected-item action context
+- Screenshot: Not captured
+
+When an item is selected, the context-aware sidebar includes a separator
+directly above the bottom close or Done action. Change this separator from its
+current neutral color to the same subdued yellow or amber used for the selected
+item's border.
+
+Acceptance criteria:
+
+- The separator above the close or Done icon uses the same color as the
+  selected item's border.
+- The separator remains visually subdued and does not appear brighter or more
+  saturated than the selection border.
+- The matching color reinforces the relationship between the selected item
+  and its context-aware actions.
+- The separator's size, position, spacing, and behavior remain unchanged.
+- The separator remains legible against the sidebar background without
+  competing with the action icons.
+
+## PL3-003 — Subdue the active “Drop to nest” background veil
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph/timeline-mrqmm7d1jocgec
+- Area: Collection item — nested-drop feedback
+- Screenshot: Not captured
+
+When a dragged item is held over a collection, the active “Drop to nest”
+treatment currently uses a bright, translucent whitish blur over the
+collection content. Replace that bright veil with a more subdued,
+semi-transparent gray treatment.
+
+Acceptance criteria:
+
+- The active nesting veil uses a muted gray rather than a bright white tint.
+- The gray treatment remains translucent so the underlying collection is
+  still recognizable.
+- The veil continues to suppress the underlying preview, name, and metadata
+  enough for the “Drop to nest” label to remain easy to read.
+- The label's size, bottom-center position, and contrast remain unchanged.
+- The background blur may remain, but it should no longer create a bright or
+  washed-out appearance.
+- Valid nesting feedback remains clearly distinguishable from the invalid or
+  cycle-prevention state.
+
+## PL3-004 — Enlarge and inset image/video type labels
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph/timeline-mrqmm7d1jocgec
+- Area: Grid items — image and video type labels
+- Screenshot: Not captured
+
+Image and video items display a small type label in the lower-left corner.
+Make this label slightly larger and give it more breathing room from the
+item's left and bottom edges.
+
+Acceptance criteria:
+
+- Both IMAGE and VIDEO labels use a slightly larger, more readable type size.
+- The label is inset farther from the item's left edge.
+- The label is inset farther from the item's bottom edge.
+- Internal label padding remains balanced around the text.
+- The updated label stays compact and does not obscure important preview
+  content.
+- The treatment remains consistent across supported grid item sizes and
+  selected, disabled, hover, and drag states.
+
+## PL3-005 — Use the collection folder glyph for empty drag previews
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Collection item — drag preview
+- Screenshot: Not captured
+
+An empty collection has no preview images to display in its drag element.
+When such a collection is dragged, show the same folder-with-right-pointing
+arrow glyph currently used in the center of collection items as the drag
+preview's primary visual.
+
+Acceptance criteria:
+
+- Dragging an empty collection displays the folder-with-right-pointing-arrow
+  glyph instead of an empty or missing image area.
+- The drag preview reuses the existing collection-item glyph rather than
+  introducing a visually different icon.
+- The glyph is centered and sized clearly within the drag preview.
+- The collection name and any other existing drag-preview information remain
+  available where applicable.
+- Non-empty collections continue to use their existing image-based drag
+  previews.
+- The empty-collection preview remains recognizable across supported item
+  sizes and while crossing different drop targets.
+
+## PL3-006 — Remove unnecessary outer padding from grid and strip views
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Graph board — grid and strip surface containers
+- Screenshot: Not captured
+
+Both the grid view and strip view have unnecessary padding around the outside
+of their item surfaces. Remove that extra spacing on all four sides so the
+views use the available board area more efficiently.
+
+Acceptance criteria:
+
+- The unnecessary top, right, bottom, and left outer padding is removed from
+  the grid view.
+- The same unnecessary outer padding is removed from the strip view.
+- Item-to-item gaps and intentional spacing inside each surface remain
+  consistent.
+- Cards, drop indicators, drag targets, and selection borders are not clipped
+  at the surface edges.
+- Empty states, scrollbars, and time-ruler alignment remain correctly
+  positioned after the padding change.
+- The result remains consistent across supported viewport widths and item
+  sizes.
+
+## PL3-007 — Reduce the collection folder-arrow icon stroke weight
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Collection item — center open-folder icon
+- Screenshot: Not captured
+
+The folder-with-right-pointing-arrow icon shown on collection items currently
+has a stroke that appears too heavy. Reduce its stroke weight so the glyph
+looks lighter and better balanced with the surrounding card UI.
+
+Acceptance criteria:
+
+- The collection folder-arrow icon uses a visibly lighter stroke weight.
+- The folder and arrow remain clearly recognizable at every supported item
+  size.
+- The icon remains legible over both preview imagery and empty collection
+  backgrounds.
+- Its dimensions, center position, hit area, and open-collection behavior
+  remain unchanged.
+- Any reuse of this glyph in the empty-collection drag preview follows the
+  same lighter visual treatment.
+
+## PL3-008 — Replace Copy and Cut with Paste while the clipboard is armed
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph/timeline-mrqmm7d1jocgec
+- Area: Sidebar icon bar — selected-item action context
+- Screenshot: Not captured
+
+When an item is selected, Copy and Cut are initially available. After either
+operation places content on the graph clipboard and makes Paste visible, hide
+both Copy and Cut. Restore them after the paste completes or the clipboard is
+cleared.
+
+Acceptance criteria:
+
+- Copy and Cut are visible while an item is selected and the graph clipboard
+  is empty.
+- Completing Copy or Cut makes Paste visible immediately.
+- Whenever Paste is visible because clipboard content is available, Copy and
+  Cut are hidden.
+- After a successful paste consumes or clears the clipboard, Paste hides and
+  Copy and Cut return when a selection is available.
+- Explicitly clearing or canceling the clipboard produces the same reset.
+- The transition does not require a page reload or reselection.
+- Remaining actions preserve a clear and intentional order without empty
+  spacing where Copy and Cut were removed.
+- Keyboard copy, cut, paste, and cancel behavior remains consistent with the
+  visible sidebar state.
+
+## PL3-009 — Keep the Disabled status label fully visible
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Grid and strip items — disabled state
+- Screenshot: Not captured
+
+Disabled items correctly mute and gray out their background content, but the
+Disabled label in the upper-right is currently affected by the same opacity
+and grayscale treatment. Keep the label at normal opacity and color so it
+remains clear and noticeable.
+
+Acceptance criteria:
+
+- The underlying content of a disabled item retains its existing muted,
+  grayscale appearance.
+- The Disabled label is excluded from the item's opacity and grayscale
+  treatment.
+- The label renders at full opacity with a clear, intentional color and
+  readable contrast.
+- The label remains positioned in the item's upper-right corner.
+- The label stays noticeable across image, video, and collection items in both
+  grid and strip views.
+- Selected, inherited-disabled, hover, and drag states do not unintentionally
+  dim or obscure the status label.
+
+## PL3-010 — Preserve the full selection border on disabled items
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph/timeline-mrqmm7d1jocgec
+- Area: Grid and strip items — disabled selection state
+- Screenshot: Not captured
+
+When a disabled item is selected, its highlight border currently becomes
+muted or faded along with the disabled content. The selection border should
+look exactly the same as it does around an enabled selected item.
+
+Acceptance criteria:
+
+- A selected disabled item uses the same border color as a selected enabled
+  item.
+- Border opacity, saturation, thickness, and visibility are identical in both
+  states.
+- The disabled item's background content remains muted while the selection
+  border stays unaffected.
+- The behavior is consistent for image, video, and collection items.
+- The matching selection treatment works in both grid and strip views.
+- Hover, focus, drag, error, and inherited-disabled states do not weaken or
+  obscure the active selection border.
+
+## PL3-011 — Keep disabled collection metadata at normal visibility
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph/timeline-mrqmm7d1jocgec
+- Area: Collection items — disabled state metadata
+- Screenshot: Not captured
+
+When a collection item is disabled, its preview content may remain muted, but
+the collection name, duration, and item count should retain their normal
+appearance rather than becoming faded or grayscale.
+
+Acceptance criteria:
+
+- A disabled collection's name uses the same opacity and color treatment as
+  an enabled collection's name.
+- The duration remains fully visible and preserves its normal color.
+- The item count and singular or plural label remain fully visible and
+  preserve their normal color.
+- The slash separating duration and item count remains clearly visible.
+- Preview imagery or other background content may retain the existing muted
+  disabled treatment.
+- The metadata remains unaffected by direct and inherited disabled states.
+- Selected, hover, focus, and drag states do not reduce the metadata's normal
+  readability.
+- The behavior remains consistent in grid and strip views at all supported
+  item sizes.

--- a/punch-list/PUNCH-LIST-04.md
+++ b/punch-list/PUNCH-LIST-04.md
@@ -1,0 +1,292 @@
+# Punch List 04
+
+## PL4-001 — Make grid and strip surfaces flush with the breadcrumb row
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Graph board — grid and strip surface layout
+- Screenshot: Not captured
+
+The grid and strip currently appear nested inside an additional content
+container, one visual level deeper than the breadcrumb row. Remove that nested
+panel treatment so both item surfaces align with and span the same full width
+as the breadcrumb row. As part of the same cleanup, reduce the vertical space
+between the breadcrumb row and the item surface below it to a small,
+intentional gap.
+
+Acceptance criteria:
+
+- Grid items extend flush to the same left and right boundaries as the
+  breadcrumb row.
+- Strip items extend flush to the same left and right boundaries as the
+  breadcrumb row.
+- No extra horizontal or vertical padding surrounds either item surface.
+- The grid does not render an outer border, dashed outline, rounded panel
+  frame, or other container chrome around its items.
+- The strip does not render an outer border, dashed outline, rounded panel
+  frame, or other container chrome around its items.
+- The grid and strip no longer read as a nested content area.
+- The vertical gap between the breadcrumb row and the grid is small and
+  visually intentional.
+- The vertical gap between the breadcrumb row and the strip is the same small
+  amount.
+- Switching between grid and strip does not change that breadcrumb-to-content
+  spacing.
+- Intentional spacing between individual items remains unchanged.
+- Selection rings, drag targets, drop indicators, empty states, rulers,
+  scrollbars, and playhead controls are not clipped by the full-width layout.
+- The alignment remains consistent across supported viewport widths and
+  while switching between grid and strip modes.
+
+## PL4-002 — Move the settings icon to the board size menu
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Graph board toolbar and sidebar icon bar
+- Screenshot: Not captured
+
+Replace the vertical-three-dots icon next to Undo and Redo in the main graph
+toolbar with a settings icon. This control should keep opening the same menu
+and retain its current size-selection behavior. Remove the separate settings
+icon from the bottom of the sidebar because it is redundant.
+
+Acceptance criteria:
+
+- The control next to Undo and Redo uses a recognizable settings icon instead
+  of the vertical-three-dots icon.
+- Its position, hit area, tooltip, enabled state, and keyboard accessibility
+  remain intact.
+- Clicking the new settings icon opens the same menu that the
+  vertical-three-dots control previously opened.
+- All existing grid and strip size options remain available and continue to
+  work.
+- The settings icon at the bottom of the sidebar is removed.
+- Removing the sidebar control leaves no empty slot, divider, or excess gap.
+- Assets, Trash, Account, and the other sidebar controls retain their current
+  order and spacing.
+- There is only one settings icon in this graph-page context.
+
+## PL4-003 — Show only the folder glyph in an empty collection drag preview
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Collection item — empty drag preview
+- Screenshot: Not captured
+
+When a collection containing no items is dragged, its drag preview should show
+only the folder-with-right-arrow glyph. Remove the collection name, caption,
+placeholder, or other light-colored content currently appearing beneath the
+glyph.
+
+Acceptance criteria:
+
+- An empty collection drag preview contains only the folder-with-right-arrow
+  glyph.
+- No collection name, “Timeline” caption, placeholder text, white strip, or
+  other content appears beneath the glyph.
+- The glyph remains centered horizontally and vertically within the drag
+  preview.
+- The glyph retains the same lighter stroke treatment used on collection
+  cards.
+- The drag preview remains clearly visible over both light and dark content.
+- Non-empty collections continue to use their image-based drag previews.
+- Multi-item drag count badges continue to appear when applicable without
+  introducing other content into the empty-collection preview.
+
+## PL4-004 — Constrain and pad breadcrumb destination hints during drag
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph/timeline-ms3dcxh3uufsc9/timeline-ms3jkgcpvk8gis
+- Area: Graph header — drag destination and trash drop target
+- Screenshot: Not captured
+
+While an item is dragged, the top-right header area normally becomes the trash
+drop target. Hovering an ancestor breadcrumb changes that area into a
+destination hint naming the breadcrumb collection. Long destination names
+currently grow too wide, and the name does not have the balanced left and
+right padding used by the trash label.
+
+Acceptance criteria:
+
+- The breadcrumb destination name has a defined maximum width.
+- Names that exceed the available width truncate with an ellipsis rather than
+  expanding or overflowing the drop target.
+- The destination name has balanced left and right padding.
+- Its horizontal padding visually matches the trash drop-area label.
+- Short breadcrumb names remain centered and are not unnecessarily truncated.
+- The drop target keeps a stable height and does not shift surrounding header
+  controls when switching between Trash and breadcrumb-destination states.
+- The full breadcrumb destination remains available through an accessible
+  name, tooltip, or equivalent non-visual text.
+- Trash and breadcrumb destination states remain visually distinct and retain
+  their existing drop behavior.
+
+## PL4-005 — Prevent long breadcrumbs from overlapping the timeline summary
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph/timeline-ms3dcxh3uufsc9/timeline-ms3jkgcpvk8gis
+- Area: Graph header — breadcrumb and clip-count/duration summary
+- Screenshot: [Current breadcrumb overlap](screenshots/PL4-005-breadcrumb-overlap.png)
+
+A long breadcrumb trail can expand into the centered clip-count and duration
+summary. The breadcrumb must yield to the other header content, use only the
+space available to it, and truncate long names before either area overlaps.
+
+Acceptance criteria:
+
+- The breadcrumb trail never overlaps the clip-count and duration summary.
+- The clip-count and duration summary remains fully visible and readable.
+- The breadcrumb region is constrained to the space remaining beside the
+  summary and toolbar controls.
+- Long breadcrumb names truncate with an ellipsis before reaching the summary.
+- Truncation favors preserving the current timeline name while still keeping
+  the overall trail within its available width.
+- Breadcrumb separators remain visible and correctly spaced where practical.
+- Ancestor links and the current editable crumb retain their existing
+  navigation and rename behavior.
+- The full name of every truncated crumb remains available through a tooltip,
+  accessible name, or equivalent non-visual text.
+- Entering inline-edit mode does not cause the editor to overlap the summary.
+- The layout remains collision-free at supported desktop widths and while
+  resizing the browser.
+
+## PL4-006 — Standardize and shorten sidebar separators
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Sidebar icon bar — normal and selected-item contexts
+- Screenshot: Not captured
+
+The normal sidebar and the context-aware sidebar shown for selected items both
+contain horizontal separators. Make those separators exactly the same length,
+and reduce that shared length because both currently appear too wide.
+
+Acceptance criteria:
+
+- The normal sidebar separator and selected-item context separator use the
+  same width.
+- Both separators are visibly shorter than their current width.
+- A single shared size or styling rule controls their width so the two modes
+  cannot drift apart.
+- Each separator remains horizontally centered in the sidebar.
+- Existing separator colors remain appropriate to their context, including
+  the amber relationship to a selected item where applicable.
+- Separator thickness, vertical spacing, and surrounding action order remain
+  unchanged unless a minor adjustment is needed to preserve centering.
+- Switching between normal and selected-item sidebar modes does not produce a
+  horizontal size jump.
+
+## PL4-007 — Remove the yellow border from the Disabled label
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph/timeline-mrw5phknx4l9cc
+- Area: Grid and strip items — disabled status label
+- Screenshot: Not captured
+
+The Disabled label in the upper-right corner of a disabled item currently has
+a yellow border. Remove that yellow outline so the status label does not
+compete with or resemble the selected-item border.
+
+Acceptance criteria:
+
+- The Disabled label no longer renders a yellow border, ring, or outline.
+- The label remains fully opaque and clearly readable.
+- Its background and text retain sufficient contrast over image, video, and
+  collection previews.
+- The label remains in the upper-right corner with its existing size and
+  padding.
+- The selected-item border remains unchanged and visually distinct from the
+  Disabled label.
+- Directly disabled and inherited-disabled states use intentional,
+  non-selection border treatments.
+- The result remains consistent in grid and strip views, including selected,
+  hover, focus, and drag states.
+
+## PL4-008 — Center every blue insertion indicator in its item gap
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Grid and strip drag-and-drop — insertion position indicator
+- Screenshot: Not captured
+
+The blue vertical insertion bar that previews a dragged item's drop position
+is not always centered in the gap between adjacent items. Use one consistent
+positioning calculation so the bar's center aligns exactly with the geometric
+center of the gap.
+
+Acceptance criteria:
+
+- The center of the blue insertion bar matches the exact center of the
+  adjacent-item gap.
+- The indicator never uses alternate left-offset, center, or right-offset
+  positions for the same insertion boundary.
+- Centering is based on the rendered item rectangles and actual gap, including
+  the indicator's own width.
+- The behavior is consistent between grid and strip views.
+- First-item, last-item, row-start, row-end, and full-last-row insertion
+  positions use the same centering rule where a gap exists.
+- Different card sizes, responsive grid columns, zoom levels, and strip
+  duration widths do not introduce an offset.
+- Scrolling, virtualization, and drag auto-scroll do not change the
+  indicator's horizontal alignment.
+- The displayed insertion position continues to match the committed drop
+  order.
+
+## PL4-009 — Make the breadcrumb destination message look like a hint
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph/timeline-mrqmm4xxyqc9p6
+- Area: Graph header — breadcrumb drag destination feedback
+- Screenshot: Not captured
+
+When a dragged item hovers over an ancestor breadcrumb, the right side of the
+header displays text naming the destination. Its current styling resembles a
+separate drop target even though the breadcrumb itself is the active target.
+Restyle that message as passive, explanatory help text. Do not change the
+trash drop area shown during drag.
+
+Acceptance criteria:
+
+- The breadcrumb destination message reads visually as a hint or status
+  message rather than an interactive drop zone.
+- It does not use the border, dashed outline, filled target surface, or other
+  affordances that make the trash area read as droppable.
+- The text clearly communicates which breadcrumb destination will receive the
+  item.
+- The hint remains legible, compact, and visually subordinate to the actual
+  breadcrumb drop target.
+- The truncation and horizontal-padding requirements from PL4-004 continue to
+  apply.
+- The trash drop area retains its existing appearance, dimensions, hover
+  feedback, and drop behavior.
+- Switching between trash-target and breadcrumb-hint states does not shift
+  surrounding header controls.
+- The breadcrumb remains the only interactive drop target for this move and
+  retains its existing drop behavior.
+
+## PL4-010 — Use 16:9 cards in the initial grid and strip skeleton
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Graph page — initial loading skeleton
+- Screenshot: Not captured
+
+Before the main graph content becomes visible, the loading skeleton represents
+the upcoming grid or strip items. Those placeholder cards are currently too
+tall. Render them at a 16:9 aspect ratio so the loading state better reflects
+the final media-card proportions.
+
+Acceptance criteria:
+
+- Grid skeleton item placeholders use a 16:9 width-to-height ratio.
+- Strip skeleton item placeholders use the same 16:9 ratio.
+- Placeholder heights are visibly reduced from the current loading state.
+- Skeleton widths continue to respond appropriately to the available
+  viewport and selected surface layout.
+- The skeleton preserves the expected number, spacing, and general placement
+  of upcoming items.
+- The transition from skeleton to loaded content minimizes vertical layout
+  shift.
+- Rounded corners, shimmer or pulse treatment, and existing loading
+  accessibility behavior remain intact.
+- The 16:9 treatment remains consistent across supported desktop widths.

--- a/punch-list/PUNCH-LIST-05.md
+++ b/punch-list/PUNCH-LIST-05.md
@@ -1,0 +1,155 @@
+# Punch List 05
+
+## PL5-001 — Keep selected-item borders visible at grid edges
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Graph grid — selected item border
+- Screenshot: [Selected border clipped at the left edge](screenshots/PL5-001-selected-edge-border-clipping.png)
+
+When a selected item sits against the left edge of the grid, the grid’s
+scrolling boundary clips the outside half of its yellow selection border. The
+same problem can occur at the right edge. Keep the complete selection border
+visible on every side of edge-positioned cards.
+
+Acceptance criteria:
+
+- The complete yellow selection border remains visible on a card in the
+  leftmost grid column.
+- The complete yellow selection border remains visible on a card in the
+  rightmost grid column.
+- Top and bottom selection borders remain fully visible as well.
+- The treatment is consistent for collection, image, and video items.
+- Disabled items use the same complete selected border.
+- Changing grid size, responsive column count, or viewport width does not
+  reintroduce clipping.
+- Grid item alignment and the flush, padding-free board layout remain
+  unchanged.
+- Strip-view selection remains visually consistent and is not regressed.
+
+## PL5-002 — Reduce the empty-collection drag-preview icon
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Collection item — empty drag preview
+- Screenshot: Not captured
+
+An empty collection uses the folder-with-right-arrow glyph as its drag
+preview. Reduce that glyph’s size within the drag element without changing the
+corresponding icon on collection cards.
+
+Acceptance criteria:
+
+- The folder-with-right-arrow glyph is visibly smaller in the empty
+  collection drag preview.
+- The glyph remains centered horizontally and vertically.
+- Its lighter stroke treatment remains unchanged.
+- The collection-card icon retains its current size.
+- Non-empty collection drag previews remain image-based and unchanged.
+- Multi-item drag count badges remain unaffected.
+
+## PL5-003 — Reposition disabled badges and preserve media-type labels
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Grid and strip items — disabled status and media-type labels
+- Screenshot: Not captured
+
+Move the Disabled status badge from the upper-right corner to the lower-right
+corner with clear inset spacing. Keep the Image or Video label in the
+lower-left fully opaque and readable when the underlying item artwork is
+disabled and muted.
+
+Acceptance criteria:
+
+- Direct and inherited disabled badges appear at the bottom-right.
+- The disabled badge has balanced space from the right and bottom card edges.
+- The badge remains fully opaque and readable.
+- Image and Video labels remain fully opaque and are not grayscale when their
+  item is disabled.
+- The underlying artwork retains its disabled opacity and grayscale treatment.
+- The lower-left media label and lower-right disabled badge do not overlap.
+- Disabled collection metadata reserves room for the badge and remains
+  readable.
+- Selected, grid, and strip states use the same positioning.
+
+## PL5-004 — Restore the projects-page header row and top spacing
+
+- Status: Complete
+- URL: http://localhost:3000/
+- Area: Timeline Projects page — page header and New Project form
+- Screenshot: Not captured
+
+The New Project form has fallen onto its own full-width row, and the projects
+page content sits too close to the top edge. Restore the form beside the
+Timeline Projects title and supporting copy at the normal desktop/tablet
+layout, and add page-local breathing room above the header.
+
+Acceptance criteria:
+
+- Timeline Projects, its blurb, and the New Project form share one header row
+  at supported desktop and tablet widths.
+- The New Project form has a bounded width rather than stretching across the
+  page.
+- The header can stack cleanly on genuinely narrow screens without horizontal
+  overflow.
+- The projects page has visible breathing room above the header.
+- The page-local spacing does not change graph-page breadcrumb alignment.
+- The Saved Projects section and project-card grid retain their current width
+  and spacing.
+
+## PL5-005 — Clean up the preview divider and contain the playhead
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Preview transport, resize divider, and graph playhead
+- Screenshot: [Preview border and playhead overflow](screenshots/PL5-005-preview-playhead-overflow.png)
+
+The preview transport has a bottom border immediately above the resize grip,
+which makes the divider look visually doubled. At the start of the timeline,
+the seek thumb is centered on the grid's left edge and its outer half can
+remain visible beside the sticky preview or breadcrumb row. That overhang must
+be hidden only while it passes behind either sticky region—not when the
+timeline is normally visible.
+
+Acceptance criteria:
+
+- The preview transport has no bottom border competing with the resize grip.
+- The resize grip retains its existing height, centered position, and hover
+  treatment.
+- Timeline playheads and seek thumbs cannot peek around the left or right edge
+  of the sticky preview or breadcrumb row while passing behind them.
+- The complete seek thumb remains visible when its timeline row is below the
+  preview.
+- The preview-only masking does not create a new scrolling container or
+  disturb the sticky preview and breadcrumb row.
+- Timeline scrolling, scrubbing, and the playhead's in-grid position remain
+  unchanged.
+
+## PL5-006 — Isolate assets by project
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Asset palette, media uploads, and provider storage
+- Screenshot: Not captured
+
+Each root project owns its own asset library. Asset requests must carry the
+current root project ID, pass project ownership checks, and expose only media
+assigned to that project. New Cloudinary uploads use a project folder beneath
+the existing app and user folders.
+
+Acceptance criteria:
+
+- Opening the asset palette in one project cannot list assets from another.
+- Search, folders, tags, pagination, and provider switching retain the project
+  scope.
+- OS file drops upload into the current root project's asset scope, including
+  when dropped into a nested collection.
+- Cloudinary stores new media under `<app>/<user>/<project>/...`.
+- The Firebase Storage fallback and optional S3 provider use equivalent
+  user/project boundaries.
+- Asset list and upload routes reject missing, invalid, inaccessible, or
+  unknown project IDs.
+- Existing unassigned assets are not silently shared into new projects.
+- The provider-neutral asset model represents project membership as an array,
+  while current assets belong to exactly one project.

--- a/punch-list/PUNCH-LIST-06.md
+++ b/punch-list/PUNCH-LIST-06.md
@@ -1,0 +1,103 @@
+# Punch List 06
+
+## PL6-001 — Remove text behind the collection folder icon
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: Graph grid — collection card preview
+- Screenshot: [Text visible behind the middle collection icon](screenshots/PL6-001-collection-text-behind-folder-icon.png)
+
+The middle collection card displays faint fallback text behind its centered
+folder-with-arrow icon. Remove that text so the preview area contains only the
+collection icon when no usable preview image is shown.
+
+Acceptance criteria:
+
+- No fallback, empty-state, or image-alt text is visible behind the collection
+  folder icon.
+- The folder-with-arrow icon remains centered and fully visible.
+- Empty collections and collections with unavailable previews use the same
+  clean icon-only fallback.
+- Collection name, duration, and item-count metadata remain unchanged.
+- Image and video item previews are unaffected.
+
+## PL6-002 — Oversized original storage
+
+- Status: Excluded at user request
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: Native file drop — Cloudinary upload pipeline
+- Screenshot: Not captured
+
+Do not add a second storage provider or an oversized-original overflow
+destination. Cloudinary remains the configured asset provider. Its existing
+chunked upload and explicit 413 error handling remain unchanged.
+
+## PL6-003 — Resolve collection previews through nested containers
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph/timeline-ms3mv1s8quqihc
+- Area: Graph grid — nested collection preview
+- Screenshot: [Nested video does not provide a clear collection preview](screenshots/PL6-003-nested-video-missing-collection-preview.png)
+
+The second collection contains a video, but its collection card does not show
+that video's poster as a clear preview. Preview selection appears to stop at a
+container boundary instead of resolving usable media from nested descendants.
+
+Acceptance criteria:
+
+- A collection with directly contained video media uses that video's poster as
+  its preview.
+- A collection whose first usable media is inside another nested collection
+  resolves that descendant recursively.
+- The preview is clearly visible and is not obscured by fallback text or the
+  empty-collection treatment.
+- The folder-with-arrow overlay remains available as the collection affordance
+  without replacing a valid media preview.
+- Empty collections retain the icon-only fallback.
+- Missing or invalid media URLs fall through to the next usable descendant
+  without causing an infinite traversal.
+- Grid and strip views use the same preview-selection result.
+
+## PL6-004 — Respect a video clip's front trim in collection previews
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: Collection cards and nested collection preview thumbnails
+- Screenshot: Not captured
+
+When a video clip supplies the representative image for a collection, use the
+frame at the beginning of its visible trimmed range rather than the source
+video's first frame.
+
+Acceptance criteria:
+
+- A video with a positive front trim uses the frame at `trimIn` as its
+  collection preview.
+- Untrimmed videos retain their existing poster URL.
+- Image previews are unchanged.
+- The trim offset survives stored collection summaries and nested collection
+  preview propagation.
+- Providers that cannot address a frame by timestamp retain the existing
+  poster as a safe fallback.
+- Collection cards, drag previews, and sub-timeline thumbnails use the same
+  resolved frame.
+
+## PL6-005 — Preload video frames ahead of horizontal scrolling
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph/timeline-ms3mv1s8quqihc
+- Area: Virtualized strip video thumbnails
+- Screenshot: Not captured
+
+Long timelines can extend far beyond the viewport. When a user pans forward,
+video frame images should already be available instead of appearing after the
+new cards enter view.
+
+Acceptance criteria:
+
+- Graph strips keep a bounded eight-card look-ahead beyond each viewport edge.
+- Video frames inside that mounted look-ahead begin loading immediately.
+- Frame decoding remains asynchronous so completed images do not stall
+  scrolling.
+- The full timeline is not mounted or preloaded at once.
+- Focused and nested timeline strips use the same preload policy.

--- a/punch-list/PUNCH-LIST-07.md
+++ b/punch-list/PUNCH-LIST-07.md
@@ -1,0 +1,277 @@
+# Punch List 07
+
+## PL7-001 — Clicking empty space clears the selection
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: Graph board — selection surface (strip and grid)
+- Screenshot: Not captured
+
+With one or more items selected, clicking empty space away from any card
+leaves the selection intact. Selection can currently only be changed by
+clicking another card, so there is no way to get back to "nothing selected"
+with the mouse.
+
+Assumed scope (correct me if wrong): an empty-space click inside the board's
+own content area clears the selection; clicks on surrounding chrome
+(toolbar, breadcrumb, sidebar, preview pane, ruler/seek rail) do not.
+
+Acceptance criteria:
+
+- Clicking empty space inside a strip or grid, with a selection active,
+  clears the selection.
+- Clicking a card still selects it (replace semantics), and Ctrl/Cmd+click
+  still toggles — neither path regresses.
+- A click that ends a drag, a pan, or a trim does not clear the selection.
+- A double-click's second click does not clear the selection (the existing
+  `event.detail > 1` guard stays honored).
+- Clicking chrome outside the board content area leaves the selection alone.
+- Clearing the selection does not move the playhead or change focus/scroll.
+
+## PL7-002 — Native-drop indicator in grid renders behind cards and off-target
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: Grid view — `NativeDropGrid` drop indicator
+- Screenshot: Not captured
+
+Dragging a file in from the OS file manager onto the grid draws a vertical
+amber insertion line, but it paints underneath the grid cards and the
+boundary it marks does not match where the file actually lands.
+
+Reference: the indicator element and its 2-D boundary math are in
+`graph-native-drop.tsx` (`NativeDropGrid`, `flushIndicator` /
+`cellBeforeWhichPointerFalls`), drawn at `z-20` inside the drop wrapper.
+
+Acceptance criteria:
+
+- The insertion line paints above grid cards, their artwork, and the
+  playhead/seek-rail overlays for the whole drag.
+- The line's position marks the boundary the drop actually commits to —
+  advertised index and committed index agree at every pointer position,
+  including the last cell of a row, the first cell of a row, and past the
+  final card (append).
+- The line stays correct while the pointer moves within a row, between rows,
+  and after the grid scrolls or resizes mid-drag.
+- Dropping commits the file at the marked boundary.
+- The line clears on drag leave, drop, and cancel.
+- Strip-view native drop is unaffected.
+
+## PL7-003 — Show drop-zone affordance during a native file drag
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: Graph board and sub-timelines — native file drop targets
+- Screenshot: Not captured
+
+While a file is dragged in from the OS, nothing on the page indicates which
+regions will accept it. The only feedback is the insertion line, which
+appears after the pointer is already over a target. The drop targets should
+announce themselves for the duration of the drag.
+
+Every `NativeDropStrip` / `NativeDropGrid` is a target: the focused
+timeline's strip or grid, plus each rendered sub-timeline's strip or grid.
+
+Acceptance criteria:
+
+- As soon as a native file drag enters the page, every drop target takes a
+  visible style change that reads as "droppable here".
+- The target under the pointer is distinguished from the other, merely
+  eligible, targets.
+- The affordance ends on drop, drag leave, and drag cancel, leaving no
+  residual styling.
+- The affordance appears only for drags that carry files — an internal card
+  drag does not trigger it.
+- The styling does not shift layout (no reflow of cards, strip scroll
+  position, or preview height) as it appears or clears.
+- It coexists with the PL7-002 insertion line without obscuring it.
+- It respects reduced-motion preferences if it animates.
+
+## PL7-004 — Empty state when child timelines are shown but there are none
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: Graph board — FolderTree "show child timelines" toggle / `SubTimelines`
+- Screenshot: Not captured
+
+With the child-timelines toggle on, a focused timeline that contains no
+child timelines renders nothing below the focused surface. The toggle reads
+as broken — there is no way to tell "the feature is on and there is nothing
+to show" from "the toggle did nothing".
+
+Reference: `childrenShown` gates the `SubTimelines` mount in
+`graph-board.tsx`; with no child collections it produces no rows.
+
+Acceptance criteria:
+
+- With the toggle on and no child timelines present, a short empty-state
+  indicator appears where the child rows would render.
+- The indicator makes clear the feature is enabled and the timeline simply
+  has no children.
+- With the toggle off, nothing renders — no empty state.
+- As soon as a child timeline is added, the empty state is replaced by the
+  real row without a reload.
+- The indicator is reachable to assistive tech (not `aria-hidden`) and does
+  not disturb the preview height, playhead, or page scroll.
+- Scope is the top-level (focused) timeline ONLY, and only when it has no
+  child timelines. Childless sub-timeline rows never render the empty state.
+
+## PL7-005 — Divider height, transport icon size, top padding, touch grip
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `workbench-display-surface.tsx` — resize divider and preview transport
+- Screenshot: Not captured
+
+Four changes to the preview/timeline divider band:
+
+(a) Make the VISIBLE divider a 12px band rather than the current 1px
+centerline (confirmed with the user). The interaction track is already 12px
+(`DIVIDER_HEIGHT_PX = 12`, the `h-3` button), so this is a restyle of the
+`data-divider-line` span, not a geometry change.
+
+(b) Play/pause and skip icons slightly larger. Today: `Play`/`Pause` are
+`size-2.5` (10px), `SkipBack`/`SkipForward` are `size-3` (12px), inside
+`size-5` wells in `size-11` buttons.
+
+(c) Small padding above the divider, between the preview surface's bottom
+edge and the divider band.
+
+(d) At tablet width and below, show a persistent indicator that the divider
+is draggable (a grip). Breakpoint: `md` (≤768px), confirmed with the user.
+Coarse-pointer devices have no hover, so the hover-only line-brighten is
+invisible to them.
+
+Acceptance criteria:
+
+- The visible divider reads as a 12px band; the transport controls stay
+  centered on it and remain legible against it.
+- `DIVIDER_HEIGHT_PX` and the divider's rendered height stay in sync — it
+  feeds `--workbench-preview-offset` and the sticky preview offset math.
+- Transport icons are visibly larger while staying inside their wells; hit
+  targets stay at least 44px.
+- A small gap separates the preview surface from the divider; no other
+  vertical rhythm shifts.
+- At ≤ tablet width the grip is visible without hover; above it, current
+  behavior is unchanged.
+- Resize drag, keyboard resize, and the transport's pointer-down isolation
+  (a transport press must not start a resize) all still work.
+- Existing preview-height e2e expectations are re-synced if the total
+  preview region height changes.
+
+## PL7-006 — Sidebar collection-tool drag shows the same broken grid indicator
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: Grid view — sidebar tool drag into `NativeDropGrid`
+- Screenshot: Not captured
+
+Dragging a new collection item from the sidebar tool palette into grid view
+draws the amber insertion line in the wrong place and under the grid.
+
+SAME ROOT CAUSE AS PL7-002. `acceptsNativeDrag` admits both the sidebar
+tool MIME and OS `Files`, and both drag sources then share one indicator and
+one `flushIndicator` boundary calculation. Fix once; verify twice.
+
+Acceptance criteria:
+
+- All PL7-002 criteria hold for a sidebar tool drag as well as an OS file
+  drag.
+- Both drag sources are covered by the verification, in grid and in strip.
+- The new collection lands at the boundary the line marked.
+
+## PL7-007 — Collection cards in strip view need a 16:9 minimum width
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: Strip view — collection card width (`collectionCardWidth`)
+- Screenshot: Not captured
+
+Collection cards in the strip may grow wider with the zoom slider, but they
+must never get narrower than a 16:9 box against the card's rendered height.
+
+Today `collectionCardWidth(pixelsPerSecond)` returns
+`max(MIN_ITEM_WIDTH, 128 * pps / TIMELINE_PPS)` — a flat pixel floor with no
+relationship to card height, so zooming out squeezes collections to a narrow
+sliver. The new floor is `height * 16 / 9`.
+
+Note this widens collections at default zoom too: at the MD strip height
+(100px) the floor is ~178px against today's 128px base.
+
+Reference: `graph-preview.tsx` (`collectionCardWidth`, `clipWidthAt`),
+consumed by `graph-board.tsx` and `graph-sub-timelines.tsx` as the strip's
+`itemWidth`. The function currently takes only `pixelsPerSecond` and will
+need the card height.
+
+Acceptance criteria:
+
+- A strip collection card is never narrower than `height * 16 / 9`.
+- Above that floor it still scales with the zoom slider as it does now.
+- The floor tracks the rendered card height, so it differs per item size and
+  for the one-step-smaller sub-timeline rows.
+- The strip's `itemWidth`, the playhead model's `clipWidthAt`, the ruler's
+  collection spans, and the strip seek rail all read the SAME width — the
+  playhead must not drift off the cards at any zoom.
+- Media clip widths stay duration-proportional and unchanged.
+- Grid view is unaffected (its cells are already fixed-size).
+- Ruler collection-duration labels still fit or still hide by the existing
+  minimum-width rule.
+
+## PL7-008 — Ruler toggle only in flat view, and below the flat-view icon
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: Sidebar rail — ruler and flat-view toggles (`timeline-sidebar.tsx`)
+- Screenshot: Not captured
+
+Today both toggles render whenever the surface is a strip, with the ruler
+ABOVE flat mode. The ruler should be gated on flat view being enabled, and
+should sit BELOW the flat-view icon.
+
+Reference: `timeline-sidebar.tsx` — the ruler button is gated on
+`onGraphRoute && graphView.surface === "strip"` and is rendered before the
+flat button; swap the order and add the `flatOn` condition.
+
+Acceptance criteria:
+
+- The ruler toggle is hidden unless flat view is on; the flat toggle keeps
+  its current strip-only gate.
+- In the rail, the ruler icon renders below the flat-view icon.
+- Turning flat view off also turns the ruler off, so no strip is left with a
+  ruler and no visible control to dismiss it. (Assumption — say if the ruler
+  state should instead persist for the next time flat is enabled.)
+- Grid view shows neither toggle, unchanged.
+- Tooltip, `aria-pressed`, and `aria-label` wiring stay correct for both
+  buttons after the reorder.
+- Any e2e that finds these buttons by position or by enabling the ruler
+  without flat mode is updated.
+
+## PL7-009 — Replace the collection glyph with CornerRightDown
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: Collection cards — `CollectionFolderGlyph` (`graph-item-content.tsx`)
+- Screenshot: Not captured
+
+Swap the collection icon from lucide `FolderInput` (folder-with-arrow) to
+`CornerRightDown`.
+
+`CollectionFolderGlyph` is one component used in two places, so replacing it
+covers both: the empty/no-preview collection ghost centred on the card, and
+the circular drill ("Open <name>") button overlaid on collection cards.
+
+There is a THIRD `FolderInput` in `graph-breadcrumb-drop.tsx` — the
+move-to-parent breadcrumb drop zone. Assumed OUT OF SCOPE: that is a
+different verb (move into) from the collection identity/drill icon. Say if
+it should change too.
+
+Acceptance criteria:
+
+- Both `CollectionFolderGlyph` sites render `CornerRightDown`.
+- The glyph stays centred and fully visible in the card ghost and inside the
+  circular drill button at every item size, with the current stroke weight
+  and color treatment.
+- No stray `FolderInput` import is left behind in `graph-item-content.tsx`.
+- Accessible names ("Open <name>", the card's collection label) are
+  unchanged — this is a glyph swap only.
+- Any story or e2e that asserts on the old icon is updated.

--- a/punch-list/PUNCH-LIST.md
+++ b/punch-list/PUNCH-LIST.md
@@ -1,0 +1,203 @@
+# Punch List
+
+## PL-001 — Hide the Trash icon on the Timeline Projects page
+
+- Status: Completed
+- URL: http://localhost:3000/
+- Area: Timeline Projects — side icon bar
+- Screenshot: Not captured
+
+The side icon bar should not display the Trash icon on the Timeline Projects
+page. The Trash icon should remain visible on other regular application pages.
+
+Acceptance criteria:
+
+- The side icon bar omits the Trash icon on the Timeline Projects page.
+- The Trash icon remains available in the side icon bar on other regular pages.
+
+## PL-002 — Show immediate feedback while opening a project
+
+- Status: Completed
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Project selection and timeline-page navigation
+- Screenshot: Not captured
+
+Selecting a project currently has a noticeable delay with no indication that
+navigation or loading is in progress. The application should transition to the
+selected project's page immediately and display skeleton placeholders there
+until the real page content is ready.
+
+Acceptance criteria:
+
+- Selecting a project produces immediate visual feedback.
+- The application transitions to the selected project's destination page
+  without leaving the projects page looking unresponsive.
+- The destination page displays skeletons that represent its loading layout.
+- The skeletons are replaced by the real project content when loading
+  completes.
+
+## PL-003 — Correct collection drag-and-drop feedback in grid view
+
+- Status: Completed
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Grid view — dragging a new collection
+- Screenshot: Not captured
+
+Dragging a new collection onto the grid sometimes shows the browser's
+“no drop” cursor even though the grid is a valid drop target. A vertical yellow
+insertion line also appears at the bottom of the grid instead of at the
+collection's actual intended insertion point. The visual indicator and the
+resulting drop location are not aligned.
+
+Acceptance criteria:
+
+- A valid new-collection drag over the grid never displays the “no drop”
+  cursor.
+- The yellow insertion indicator appears at the location represented by the
+  current pointer position.
+- Dropping the collection inserts it at the location shown by the indicator.
+- The indicator updates as the pointer moves and disappears when the drag ends
+  or leaves the valid drop area.
+
+## PL-004 — Remove the legacy Storyboard View menu item
+
+- Status: Completed
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Vertical three-dot overflow menu
+- Screenshot: Not captured
+
+The overflow menu currently includes a legacy item labeled “Storyboard View.”
+This obsolete link should no longer appear in the menu.
+
+Acceptance criteria:
+
+- “Storyboard View” is removed from the vertical three-dot overflow menu.
+- The remaining menu items continue to appear and function normally.
+
+## PL-005 — Center the grid-item drop indicator within the gap
+
+- Status: Completed
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Grid view — reordering items
+- Screenshot: Not captured
+
+While a grid item is being dragged, the blue vertical insertion line appears
+inside the gap between two items. Its horizontal position is inconsistent: it
+can appear at the left edge, center, or right edge of the same gap. The line
+should always be centered within the gap.
+
+Acceptance criteria:
+
+- The blue insertion line is horizontally centered in the gap between the two
+  items surrounding the proposed drop position.
+- The line does not shift between left-, center-, and right-aligned variants
+  for the same gap.
+- The centered indicator remains aligned with the actual resulting insertion
+  position.
+
+## PL-006 — Improve collection labels and metadata readability
+
+- Status: Completed
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Collection item UI
+- Screenshot: Not captured
+
+Collection items display their duration and item count, but the count is shown
+as an unlabeled number, such as “2,” which does not clearly communicate what it
+represents. The metadata is also too small, and the collection name needs
+greater visual prominence and readability.
+
+Acceptance criteria:
+
+- The collection count includes a clear label, such as “2 items.”
+- Singular and plural labels are grammatically correct, such as “1 item” and
+  “2 items.”
+- The duration and item-count text is larger and easier to read.
+- The collection name is larger and easier to read.
+- The updated typography preserves a clear hierarchy between the collection
+  name and its supporting metadata.
+
+## PL-007 — Move the “Drop to Nest” label below the drag preview
+
+- Status: Completed
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Collection item — nested-drop feedback
+- Screenshot: Not captured
+
+When an item is dragged over a collection, the “Drop to Nest” label appears in
+the center of the collection item. The dragged element usually occupies that
+same area and obscures the label. Position the label at the bottom center of
+the collection item instead.
+
+Acceptance criteria:
+
+- The “Drop to Nest” label is horizontally centered near the bottom of the
+  collection item.
+- The label remains visible and readable while the dragged element is over the
+  collection.
+- The label does not cover important collection content or interfere with the
+  drop target.
+
+## PL-008 — Improve the sidebar Trash-area icon
+
+- Status: Completed
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Sidebar icon bar — Trash area
+- Screenshot: Not captured
+
+The current Trash-area icon combines a folder with a small trash symbol, but
+the trash symbol is difficult to recognize at sidebar size. Replace it with a
+clearer visual representation of the Trash area while keeping it distinct from
+the standard trash-bucket icon used for other actions.
+
+Acceptance criteria:
+
+- The icon clearly communicates that it opens the Trash area at its rendered
+  sidebar size.
+- The visual remains distinguishable from the regular trash-bucket action
+  icon used elsewhere.
+- The icon is legible and recognizable in the sidebar's default, hover,
+  focused, and active states.
+
+## PL-009 — Add an overflow menu to selected-item sidebar actions
+
+- Status: Completed
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Sidebar icon bar — selected-item action context
+- Screenshot: Not captured
+
+The contextual sidebar action list shown when an item is selected is becoming
+too long. Add a vertical three-dot overflow icon above the separator and move
+the less-frequent Duplicate and Disable actions into its menu.
+
+Acceptance criteria:
+
+- A vertical three-dot overflow button appears above the separator in the
+  selected-item sidebar context.
+- Activating the overflow button opens a menu containing Duplicate and
+  Disable.
+- Duplicate and Disable are removed from the primary sidebar icon list.
+- Both actions retain their existing behavior when invoked from the overflow
+  menu.
+- The remaining selected-item actions preserve their current ordering and
+  behavior.
+
+## PL-010 — Align the breadcrumb row with the SW logo
+
+- Status: Completed
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: Main content layout — breadcrumb row
+- Screenshot: Not captured
+
+The main breadcrumb row does not align with the SW logo on the same horizontal
+plane because of padding in the main content area. The SW logo should remain in
+its current position; correct the alignment by adjusting the main-area
+padding.
+
+Acceptance criteria:
+
+- The main breadcrumb row aligns horizontally with the SW logo.
+- The SW logo's position and sidebar spacing remain unchanged.
+- The alignment correction is made through the main content area's padding.
+- Other main-page content maintains intentional and consistent spacing after
+  the adjustment.


### PR DESCRIPTION
Nine graph-view items from a UI review round, tracked in [punch-list/PUNCH-LIST-07.md](punch-list/PUNCH-LIST-07.md).

| Item | Change |
| --- | --- |
| PL7-001 | Clicking empty space in a strip or grid clears the selection |
| PL7-002 / PL7-006 | Grid native-drop line drew below the grid and behind the cards |
| PL7-003 | Drop targets announce themselves for the whole native drag |
| PL7-004 | Empty state when the children toggle is on and there are none |
| PL7-005 | 12px divider band, larger transport icons, padding above, coarse-pointer grip |
| PL7-007 | Strip collection cards floor at 16:9 against their height |
| PL7-008 | Ruler toggle only in flat mode, below the flat icon |
| PL7-009 | Collection glyph → `CornerRightDown` |

### Notes worth a look

**PL7-002 root cause.** `absolute` with neither `left` nor `top` resolves to the element's *static* position — for the wrapper's last child that is directly below the grid — while the transform was measured from the wrapper's origin. The line drew a whole grid's height too low. Anchored and raised to `z-30`; the strip's twin got the same anchor. One `acceptsNativeDrag` path serves both OS file drags and sidebar tool drags, so PL7-006 is the same fix.

**PL7-001 guard.** A pan also ends in a `click` on the scroll container, so the press position is remembered and a moved press is not treated as a background click. Pinned in VirtualGrid rather than VirtualStrip: the strip's pan hook already squashes its own trailing click, so the assertion would pass there with or without the guard.

**PL7-003 arming.** One reference-counted window `dragover` watcher with a short self-healing expiry, rather than dragenter/dragleave pairs — those flicker across child boundaries and every counter-based fix leaks a stuck state on some path. dnd-kit card drags emit no HTML5 drag events, so they never arm it.

**PL7-008 coupling.** Leaving flat mode turns the ruler off too, or the control unmounts while the ruler it armed stays painted with no way back.

**Drive-by fix.** The divider hover assertion read `backgroundColor` on a gradient-backed element — transparent in both states, so it could neither pass nor fail once the gradient landed in #214. Reads `color` now, which is what drives the gradient's `currentColor`.

### Verification

- app vitest 442/442, unit 408/408, stories 164/164
- `packages/ui` and app `tsc` clean; app lint clean (4 pre-existing `img` warnings)
- graph-view e2e: 75 passed. Three failures remain and were each confirmed pre-existing on `main` by stashing this branch: the two un-hydrated/refused-drop tests and the flat palette drop.
- PL7-005 and PL7-007 also measured live in the running app: divider box 16 / band 12, `--workbench-preview-offset` consistent, collection card ratio exactly 1.778, grip hidden at desktop and clear of both transport and time readout at 375px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)