### PR TITLE
Fix the flat-drop translator and resync two stale drop-policy tests

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -851,6 +851,13 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
         </span>
         <span
           data-collection-metadata
+          // Whether this card's numbers come from LIVE children or from the
+          // stored summary. The two look identical now that the placeholder's
+          // "Open to load" text is gone (PL6-001 made the empty preview
+          // icon-only), and hydration decides whether a drop into this
+          // collection is legal at all — so the state needs to stay
+          // observable to the drop-policy e2e that asserts on it.
+          data-collection-hydrated={hydrated ? "true" : "false"}
           className={[
             "mt-1.5 flex items-center justify-between gap-1.5 pl-1 pb-0.5",
             muted ? "pr-[4.75rem]" : "pr-1",

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -19,6 +19,7 @@ import {
   type CollectionsGraph,
   type AddNodesCommand,
   type CommandPolicy,
+  type DropIntent,
   type GraphNodeSpec,
   type MoveNodesCommand,
   type NodeId,
@@ -416,11 +417,21 @@ export function GraphTimelineView({
     flatOnRef.current = flatOn;
   }, [flatOn]);
 
-  // FLAT drops: the strip publishes a boundary into the flat RUN, and the
-  // intent names the focused collection — neither of which is where the item
-  // belongs. `resolveFlatDropTarget` applies the rule the provenance label
-  // makes readable: a drop lands in the LEFT NEIGHBOUR's collection, right
-  // after it (at the very start, the head of the focused timeline).
+  // FLAT drops: the flat STRIP publishes a boundary into the flat RUN, and
+  // the intent names the focused collection — neither of which is where the
+  // item belongs. `resolveFlatDropTarget` applies the rule the provenance
+  // label makes readable: a drop lands in the LEFT NEIGHBOUR's collection,
+  // right after it (at the very start, the head of the focused timeline).
+  //
+  // ONLY that container-level boundary is translated. A drop resolved
+  // against a CARD is already parent-relative and already correct: dnd-kit's
+  // collision pass deliberately prefers a node hit over its container ("a
+  // node card always beats a container"), and `resolveDropIntent` reads that
+  // card's real parent out of the graph — so dropping onto c2 in the flat run
+  // resolves to Scene A directly, which IS the left-neighbour rule. Running
+  // that command through the translator too treats a parent-relative index as
+  // a flat-run boundary and lands the item in a different collection
+  // entirely (it put a drop meant for Scene A into the project instead).
   //
   // The flat list is rebuilt from the graph the provider hands over rather
   // than shared from the board: it costs one walk per drop, and it can never
@@ -428,11 +439,13 @@ export function GraphTimelineView({
   const handleMapDropCommand = useCallback(
     (
       command: MoveNodesCommand | AddNodesCommand,
-      _intent: unknown,
+      intent: DropIntent,
       graph: CollectionsGraph,
     ) => {
       if (!flatOn) return command;
       const focused = parseNodeId(focusedId);
+      // The flat strip's own boundary, and nothing else.
+      if (intent.type !== "insert-at-index" || intent.collectionId !== focused) return command;
       const target = resolveFlatDropTarget(
         graph,
         flattenMediaOrder(graph, focused, MAX_SUBTREE_DEPTH),

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -384,6 +384,16 @@ async function openGraph(page: Page): Promise<void> {
   await page.getByRole("button", { name: "Show children timelines" }).click();
 }
 
+/** A collection card's metadata row in the project strip, which carries
+ *  `data-collection-hydrated` — whether its numbers come from live children
+ *  or from the stored summary. Hydration decides whether a drop into the
+ *  collection is legal, and nothing else on the card shows it. */
+function placeholderCard(page: Page, collectionId: string) {
+  return strip(page, PROJECT_ID)
+    .locator(`[data-node-id="${collectionId}"]`)
+    .locator("[data-collection-metadata]");
+}
+
 /** The ruler toggle only mounts in FLAT mode (a ruler is one continuous time
  *  axis, which only the flat run is), so every ruler test enters flat first. */
 async function enableRuler(page: Page): Promise<void> {
@@ -1850,8 +1860,13 @@ test.describe("graph view E2E", () => {
     const projectStrip = strip(page, PROJECT_ID);
 
     // The child document never loads: the collection stays a placeholder.
-    await expect(projectStrip.locator(`[data-node-id="${CHILD_ID}"]`)).toContainText(
-      "Open to load",
+    // (Read off `data-collection-hydrated`. This used to assert the card's
+    // "Open to load" text, which PL6-001 deleted when it made the empty
+    // collection preview icon-only — a placeholder and a loaded collection
+    // now look the same, so the attribute is the signal.)
+    await expect(placeholderCard(page, CHILD_ID)).toHaveAttribute(
+      "data-collection-hydrated",
+      "false",
     );
 
     // Nest alpha into the placeholder (drop dead-center): the commandPolicy
@@ -1908,8 +1923,9 @@ test.describe("graph view E2E", () => {
     // The premise: the child is STILL an un-hydrated placeholder here, after
     // the drag/undo above. Without this the drop below would be legal and the
     // test would pass while exercising nothing.
-    await expect(projectStrip.locator(`[data-node-id="${CHILD_ID}"]`)).toContainText(
-      "Open to load",
+    await expect(placeholderCard(page, CHILD_ID)).toHaveAttribute(
+      "data-collection-hydrated",
+      "false",
     );
 
     // Now attempt a drop the policy refuses. Must be alpha (index 0, the
@@ -4217,14 +4233,20 @@ test.describe("graph view E2E", () => {
     await expect.poll(() => stripOrder(page, CHILD_ID)).toEqual(["c1", "c2"]);
   });
 
-  // RETRIED, deliberately. This is a real-mouse drag, and dnd-kit recomputes
+  // RETRIED, deliberately. These are real-mouse drags, and dnd-kit recomputes
   // `over` on a measure cadence — releasing before it catches up is the
   // documented CI-only flake class (see the package CLAUDE.md), which the
-  // suite already carries two of. It passes 4/4 in isolation and fails
-  // roughly one run in three under full parallel load, with flat mode
-  // correctly on in the captured snapshot: the state is right, the drag is
-  // starved. Retries buy the coverage without making the suite red; the RULE
-  // itself is pinned deterministically by resolveFlatDropTarget's unit tests.
+  // suite already carries two of. Retries buy the coverage without making the
+  // suite red; the RULE itself is pinned deterministically by
+  // resolveFlatDropTarget's unit tests.
+  //
+  // HISTORY, so the flake note is not read as covering everything: these were
+  // failing DETERMINISTICALLY, not flaking, because the flat translator ran on
+  // every drop command — including the card-relative ones that were already
+  // correct — and re-read a parent-relative index as a flat-run boundary. The
+  // two tests below are the two halves that must stay apart: a drop resolved
+  // against a CARD passes through, a drop resolved against the STRIP is
+  // translated.
   test.describe(() => {
     test.describe.configure({ retries: 2 });
     test("in flat mode a palette drop joins the LEFT neighbour's collection", async ({
@@ -4271,6 +4293,55 @@ test.describe("graph view E2E", () => {
       // would have inserted here, at a flat index inside the wrong parent.
       const projectIds = api.patchesFor(PROJECT_ID).at(-1)?.clipIds;
       if (projectIds) expect(projectIds).toHaveLength(4);
+    });
+
+    test("in flat mode a drop in the GAP is still translated off the flat run", async ({
+      page,
+    }) => {
+      // The other half of the card-vs-strip split. With the pointer over no
+      // card, the flat STRIP wins the collision and publishes a boundary into
+      // the flat run — which does need translating. Guarding the translator
+      // too broadly (skipping it altogether) lands this in the project at a
+      // flat index instead of in Scene A.
+      const api = await installGraphApi(page);
+      await openGraph(page);
+      await page.getByRole("button", { name: "Show all items in order" }).click();
+      await expect
+        .poll(() => stripOrder(page, PROJECT_ID), { timeout: 15000 })
+        .toEqual(["alpha", "bravo", "c1", "c2", "charlie"]);
+      await expect(
+        page.getByRole("button", { name: "Show collections" }),
+      ).toHaveAttribute("aria-busy", "false");
+
+      await assetsButton(page).click();
+      const drawer = page.getByRole("dialog", { name: "Asset palette" });
+      await expect(drawer).toBeVisible();
+
+      // The gutter between c1 and c2 — boundary 3 of the flat run. Translated,
+      // its left neighbour is c1, so the clip joins Scene A after c1.
+      const c1Box = (await strip(page, PROJECT_ID).locator('[data-node-id="c1"]').boundingBox())!;
+      const c2Box = (await strip(page, PROJECT_ID).locator('[data-node-id="c2"]').boundingBox())!;
+      const gapX = (c1Box.x + c1Box.width + c2Box.x) / 2;
+      expect(gapX).toBeGreaterThan(c1Box.x + c1Box.width);
+      expect(gapX).toBeLessThan(c2Box.x);
+
+      const source = drawer.locator('[data-palette-item="asset-img-1"]');
+      const sourceBox = (await source.boundingBox())!;
+      await page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2);
+      await page.mouse.down();
+      await page.waitForTimeout(400); // past the hold delay
+      await page.mouse.move(gapX, c1Box.y + c1Box.height / 2, { steps: 12 });
+      await page.waitForTimeout(150); // dwell: let collision/intent settle
+      await page.mouse.up();
+      await page.waitForTimeout(80); // dnd-kit's post-drop click suppressor
+
+      // Scene A gained it, between c1 and c2.
+      await expect
+        .poll(() => api.patchesFor(CHILD_ID).at(-1)?.clipIds, { timeout: 8000 })
+        .toHaveLength(3);
+      const childIds = api.patchesFor(CHILD_ID).at(-1)!.clipIds!;
+      expect(childIds[0]).toBe("c1");
+      expect(childIds[2]).toBe("c2");
     });
   });
 


### PR DESCRIPTION
The three graph-view e2e failures that predate [#215](https://github.com/josulliv101/storyboard-flow/pull/215). One was a real product bug; two were assertions left behind by an earlier UI change.

## Flat drops landed in the wrong collection

`handleMapDropCommand` treated every drop command's `toIndex` as a boundary into the flat **run** and rewrote its parent accordingly. That is only true for the flat strip's own container-level boundary.

dnd-kit's collision pass deliberately prefers a node hit over its container — *"a node card always beats a container"* — so a drop onto a card resolves through `resolveDropIntent`, which reads that card's real parent out of the graph. It is already parent-relative, already correct, and already *is* the left-neighbour rule. Re-translating it read a parent-relative index as a flat boundary:

```
palette drop aimed at c2 (in Scene A)
  intent        → node:c2, pointer 1041
  command       → { toParentId: timeline-e2e-child, toIndex: 2 }   ← correct
  after mapper  → { toParentId: project-e2e-1,      toIndex: 2 }   ← wrong parent
```

Now only an `insert-at-index` intent naming the **focused** collection is translated; everything else passes through.

Measured rather than guessed: the strip's `resolveBoundary` was never called for this drop, and the mapper's own before/after produced the rewrite above.

### The "flake" was not a flake

The test carried `retries: 2` and a comment attributing it to the real-mouse drag flake class. It failed 3/3 in isolation and on a clean `main`. The retries stay — real-mouse drags do starve under parallel load — but the comment no longer claims the flake covers this, and a **second test pins the other half**: a drop in the *gap* still resolves through the strip and still gets translated. Proven fail-first by disabling the translator.

## Stale placeholder assertions

Two drop-policy tests checked their premise — *"this collection is still un-hydrated"* — by looking for the card's `"Open to load"` text. PL6-001 deleted that text when it made the empty collection preview icon-only (529f8a3), and nothing replaced it: a placeholder and a loaded collection now render identically.

The premise is load-bearing — both tests are vacuous without it — so the card publishes `data-collection-hydrated` and the tests read that. Verified it reads `"true"` for hydrated collections in the running app, so the check is live in both directions.

## Verification

- **graph-view e2e 79/79** — no known failures left in the suite
- app vitest 442/442, graph-item-content stories 13/13
- app + `packages/ui` tsc clean; lint clean (4 pre-existing `img` warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)