### PR TITLE
Ship punch list 08

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -46,6 +46,7 @@ import {
   useSelectionAggregate,
   type PreviewTimeChannel,
 } from "./graph-preview";
+import { CollectionHoverProvider } from "./graph-collection-hover";
 import { SubTimelines } from "./graph-sub-timelines";
 import {
   GRID_GAP,
@@ -382,6 +383,11 @@ export function GraphBoard({
 
   return (
     <OpenKeyBoundary trashId={trashRootId}>
+      {/* Spans the surfaces AND the child rows below them, because the pairing
+          it carries joins the two: a collection's card up here and its row
+          down there light each other up on hover. Inert unless the children
+          tree is actually shown — with it off there is no row to pair with. */}
+      <CollectionHoverProvider enabled={childrenShown}>
       {/* Published ABOVE the preview shell so the header aggregate and every
           time overlay inside it measure the run actually on screen. */}
       <FlatItemsProvider items={flatItems}>
@@ -618,6 +624,7 @@ export function GraphBoard({
         </div>
       </PreviewShell>
       </FlatItemsProvider>
+      </CollectionHoverProvider>
     </OpenKeyBoundary>
   );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-breadcrumb-drop.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-breadcrumb-drop.tsx
@@ -170,9 +170,14 @@ function DropZone({
         ZONE_BASE,
         active ? "pointer-events-auto scale-100 opacity-100" : "pointer-events-none scale-95 opacity-0",
         hint
-          ? hint.invalid
-            ? "border-transparent bg-zinc-900/70 text-zinc-500"
-            : "border-transparent bg-zinc-800/75 text-zinc-200 shadow-sm"
+          ? // No fill: this is a READOUT borrowing the zone's pixels to name
+            // where the drop will land, not a target of its own — a panel
+            // behind it read as a second droppable. Valid vs invalid is
+            // carried by text color alone. The zone's own states below keep
+            // their backgrounds; only this branch goes bare.
+            hint.invalid
+            ? "border-transparent bg-transparent text-zinc-500"
+            : "border-transparent bg-transparent text-zinc-200"
           : state === "over"
             ? accent.over
             : state === "invalid"

--- a/apps/timeline-gstudio001/components/graph-view/graph-collection-hover.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-collection-hover.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { createContext, useContext, useMemo, useSyncExternalStore, type ReactNode } from "react";
+
+/**
+ * With child timelines shown, a collection appears TWICE: as a card in the
+ * surface and as its own row below. Hovering either one highlights the other,
+ * so the pairing is visible instead of something the user has to infer from
+ * two identical names.
+ *
+ * A subscribable channel rather than context state: every collection card on
+ * screen consumes this, and putting the hovered id in a context value would
+ * re-render all of them (and their subtrees) on every pointer move between
+ * cards. Each consumer subscribes with its own id and re-renders only when ITS
+ * answer flips, so a hover repaints exactly the two elements that changed.
+ */
+type HoverListener = () => void;
+
+type CollectionHoverChannel = Readonly<{
+  get: () => string | null;
+  set: (next: string | null) => void;
+  subscribe: (listener: HoverListener) => () => void;
+}>;
+
+function createCollectionHoverChannel(): CollectionHoverChannel {
+  let hovered: string | null = null;
+  const listeners = new Set<HoverListener>();
+  return {
+    get: () => hovered,
+    set: (next) => {
+      if (hovered === next) return;
+      hovered = next;
+      for (const listener of listeners) listener();
+    },
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}
+
+const CollectionHoverContext = createContext<CollectionHoverChannel | null>(null);
+
+/** Stable no-op subscribe for the provider-less case — `useSyncExternalStore`
+ *  resubscribes whenever this argument's identity changes. */
+const NO_SUBSCRIBE = () => () => {};
+
+/**
+ * `enabled` is the children toggle. With it off there is no row for a card to
+ * pair WITH, so the provider hands down nothing and the hook degrades to a
+ * no-op — a card that highlighted itself with no counterpart would just be an
+ * unexplained flicker.
+ */
+export function CollectionHoverProvider({
+  enabled,
+  children,
+}: Readonly<{ enabled: boolean; children: ReactNode }>) {
+  const channel = useMemo(() => createCollectionHoverChannel(), []);
+  return (
+    <CollectionHoverContext.Provider value={enabled ? channel : null}>
+      {children}
+    </CollectionHoverContext.Provider>
+  );
+}
+
+const NO_PAIR = {
+  paired: false,
+  onPointerEnter: undefined,
+  onPointerLeave: undefined,
+} as const;
+
+/**
+ * Whether `collectionId`'s twin is currently hovered, plus the handlers that
+ * announce this element as the hovered one. Undefined handlers when there is
+ * no provider (or children are off) so the props simply don't attach.
+ */
+export function useCollectionHoverPair(collectionId: string): Readonly<{
+  paired: boolean;
+  onPointerEnter?: () => void;
+  onPointerLeave?: () => void;
+}> {
+  const channel = useContext(CollectionHoverContext);
+  const paired = useSyncExternalStore(
+    channel ? channel.subscribe : NO_SUBSCRIBE,
+    () => (channel ? channel.get() === collectionId : false),
+    () => false,
+  );
+  return useMemo(
+    () =>
+      channel
+        ? {
+            paired,
+            onPointerEnter: () => channel.set(collectionId),
+            // Clear only if we are still the hovered one: pointer events can
+            // arrive out of order when moving directly between the card and
+            // its row, and a late leave would otherwise wipe the enter that
+            // already landed.
+            onPointerLeave: () => {
+              if (channel.get() === collectionId) channel.set(null);
+            },
+          }
+        : NO_PAIR,
+    [channel, collectionId, paired],
+  );
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -44,6 +44,7 @@ import {
 import { useClipDetail, useGraphDetailsStore, useTimelineTitle } from "./graph-details-context";
 import { isDisabledByAncestor } from "./graph-playhead-model";
 import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
+import { useCollectionHoverPair } from "./graph-collection-hover";
 import { GraphViewNavContext } from "./graph-navigation";
 import { TrimFramePreview } from "./graph-trim-frame-preview";
 import { createDerivedCache } from "@/lib/derived-cache";
@@ -764,6 +765,7 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
   const title = useTimelineTitle(id as string);
   const rename = useInlineRename(id, title ?? node.name, "card");
   const nav = useContext(GraphViewNavContext);
+  const hoverPair = useCollectionHoverPair(id as string);
   // Hydrated collections derive their preview frames and total duration from
   // live children (like the count), so editing a loaded child refreshes this
   // card without a reload; placeholders fall back to their stored summary.
@@ -908,17 +910,28 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
         aria-label={`Open ${displayName}`}
         title="Open this timeline"
         data-collections-keyboard-ignore
+        // Same collection, two places on screen once the children tree is
+        // shown. Hovering here lights up this collection's ROW, and hovering
+        // that row lights this up (`paired`) — see graph-collection-hover.
+        data-collection-paired={hoverPair.paired ? "true" : undefined}
+        onPointerEnter={hoverPair.onPointerEnter}
+        onPointerLeave={hoverPair.onPointerLeave}
         onClick={(event) => {
           event.stopPropagation();
           nav?.openTimeline(id);
         }}
-        className="absolute left-1/2 top-[41%] flex aspect-square h-[34%] -translate-x-1/2 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full bg-zinc-950/70 text-sky-200 ring-1 ring-sky-400/50 backdrop-blur-[2px] transition-colors hover:bg-zinc-900/85 hover:text-sky-100 hover:ring-sky-300"
+        className={[
+          "absolute left-1/2 top-[41%] flex aspect-square h-[34%] -translate-x-1/2 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full bg-zinc-950/70 text-sky-200 ring-1 backdrop-blur-[2px] transition-colors hover:bg-zinc-900/85 hover:text-sky-100 hover:ring-sky-300",
+          hoverPair.paired ? "bg-zinc-900/85 text-sky-100 ring-sky-300" : "ring-sky-400/50",
+        ].join(" ")}
       >
         {/* CornerRightDown — turn and descend, the verb this control performs:
             NAVIGATE into the timeline. The sidebar's FolderTree toggles whether
             the children tree is shown, which is a different verb and does not
             share this icon. */}
-        <CollectionFolderGlyph className="h-[55%] w-[55%]" />
+        {/* 45%, not 55%: the mark crowded the ring it sits in. The circle's
+            own size is unchanged — only the glyph inside it shrank. */}
+        <CollectionFolderGlyph className="h-[45%] w-[45%]" />
       </button>
 
       {/* The rename editor — a REAL input, overlaying the label row while

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useRef, useState } from "react";
-import { Folder, FolderOpen } from "lucide-react";
+import { Folder, FolderOpen, ListTree } from "lucide-react";
 
 import {
   VirtualGrid,
@@ -15,6 +15,7 @@ import {
 
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 
+import { useCollectionHoverPair } from "./graph-collection-hover";
 import { useClipDetail, useGraphDetailsStore, useTimelineTitle } from "./graph-details-context";
 import {
   VideoFrameLookAhead,
@@ -139,6 +140,7 @@ function SubTimelineNode({
   );
   const name = useTimelineTitle(id) ?? nodeName;
   const rename = useInlineRename(collectionId, name, "sub-row");
+  const hoverPair = useCollectionHoverPair(collectionId as string);
   const detail = useClipDetail(id);
   const hydrated = detail?.hydrated === true;
   // ENABLED children only — this row says what the timeline contributes, so
@@ -185,7 +187,16 @@ function SubTimelineNode({
           aria-label={expanded ? "Collapse" : "Expand"}
           aria-expanded={expanded}
           onClick={toggle}
-          className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-sky-400 transition-colors hover:bg-zinc-800 hover:text-sky-300"
+          // The other half of the card↔row pairing: hovering this folder
+          // lights up the same collection's card icon in the surface above,
+          // and `paired` is this end lighting up when the card is hovered.
+          data-collection-paired={hoverPair.paired ? "true" : undefined}
+          onPointerEnter={hoverPair.onPointerEnter}
+          onPointerLeave={hoverPair.onPointerLeave}
+          className={[
+            "flex h-5 w-5 shrink-0 items-center justify-center rounded transition-colors hover:bg-zinc-800 hover:text-sky-300",
+            hoverPair.paired ? "bg-zinc-800 text-sky-300" : "text-sky-400",
+          ].join(" ")}
         >
           {expanded ? (
             <FolderOpen aria-hidden="true" className="h-4 w-4" />
@@ -417,13 +428,12 @@ export function SubTimelines({
     return (
       <div
         data-subtimelines-empty
-        className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 px-3 py-4 text-center"
+        className="flex items-center gap-2 rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 px-3 py-3"
       >
+        {/* The same mark the sub-timeline rows would be hanging off, so the
+            empty state reads as the tree itself rather than a notice. */}
+        <ListTree aria-hidden="true" className="h-4 w-4 shrink-0 text-zinc-500" />
         <p className="text-sm font-medium text-zinc-300">No child timelines</p>
-        <p className="mt-0.5 text-xs text-zinc-500">
-          Child timelines are shown. Add a collection to this timeline and it appears here as
-          its own row.
-        </p>
       </div>
     );
   }

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -12,6 +12,7 @@ import {
 } from "react";
 
 import {
+  ClearSelectionOnOutsideClick,
   DndCollections,
   buildGraph,
   parseNodeId,
@@ -594,6 +595,11 @@ export function GraphTimelineView({
         itemInstructions="Press O to open the focused collection, or F2 to rename it."
       >
           <PersistenceBridge onSync={onSync} />
+          {/* The whole graph route is the collection's screen, so clicking
+              away ANYWHERE that is not a control deselects — not just inside a
+              strip or grid box, which was the only place that worked and made
+              "get back to nothing selected" a hunt for the right pixel. */}
+          <ClearSelectionOnOutsideClick />
           <GraphItemActionsBridge trashId={boot.trashRootId} focusedId={focusedId} />
           <McpToolsBridge
             projectId={projectId}

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
@@ -12,6 +12,12 @@ import {
   type NodeId,
 } from "@storyboard/ui/dnd-collections";
 
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/core/dropdown-menu";
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 import { cn } from "@/lib/utils";
 import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
@@ -128,6 +134,49 @@ function AncestorCrumb({
   );
 }
 
+/** How many ancestors the trail shows before it starts folding, and how many
+ *  it keeps visible when it does. Counting rather than measuring: a
+ *  width-driven collapse has to observe the header, re-measure on every rename
+ *  and resize, and still picks a threshold — this picks one honestly, and the
+ *  crumbs it does show already truncate at 180px each. */
+const MAX_VISIBLE_ANCESTORS = 2;
+const VISIBLE_TRAILING_ANCESTORS = 1;
+
+type CrumbEntry = Readonly<{ id: string; href: string; label: string }>;
+
+/**
+ * The folded ancestors, behind one "…" control. A real menu, not an ellipsis
+ * glyph: the whole point is that the hidden levels stay REACHABLE, so every
+ * one of them is a link you can navigate to.
+ *
+ * These crumbs stop being drop targets while folded — a target you cannot see
+ * is not one you can aim a card at. The visible crumbs keep theirs.
+ */
+function CollapsedCrumbs({ crumbs }: Readonly<{ crumbs: readonly CrumbEntry[] }>) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          data-graph-crumb-overflow
+          aria-label={`Show ${crumbs.length} hidden ${crumbs.length === 1 ? "timeline" : "timelines"}`}
+          title="Hidden timelines"
+          className="shrink-0 rounded-md px-1.5 py-1 text-zinc-400 transition-colors hover:bg-zinc-800/60 hover:text-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70"
+        >
+          …
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        {crumbs.map((crumb) => (
+          <DropdownMenuItem key={crumb.id} asChild>
+            <Link href={crumb.href}>{crumb.label}</Link>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 /**
  * Where you ARE and how to go up — the navigation unit, rendered inside the
  * board's own header rather than as page chrome above it. It sits where a
@@ -153,6 +202,27 @@ export function GraphBreadcrumb({
     (snapshot) => snapshot.graph.nodesById.get(focusedId as NodeId)?.name,
   );
   const focusedTitle = documents[focusedId]?.title ?? focusedNodeName ?? focusedId;
+  // Every ancestor between the root crumb and the focused one, resolved once
+  // so the overflow menu and the visible crumbs render the same thing.
+  const ancestors = timelinePath.slice(0, -1).map((segment, index) => ({
+    id: segment,
+    href: `${base}/${timelinePath
+      .slice(0, index + 1)
+      .map(encodeURIComponent)
+      .join("/")}`,
+    label: documents[segment]?.title ?? segment,
+  }));
+  // Deep paths crowd the header out. Past the threshold the EARLIEST ancestors
+  // fold into one "…" — the immediate parent stays put, because that is the
+  // one the eye actually uses, and the root and focused crumbs are never
+  // eligible (they are rendered outside this list).
+  const collapse = ancestors.length > MAX_VISIBLE_ANCESTORS;
+  const collapsedAncestors = collapse
+    ? ancestors.slice(0, ancestors.length - VISIBLE_TRAILING_ANCESTORS)
+    : [];
+  const visibleAncestors = collapse
+    ? ancestors.slice(ancestors.length - VISIBLE_TRAILING_ANCESTORS)
+    : ancestors;
   const parentHref =
     timelinePath.length > 1
       ? `${base}/${timelinePath.slice(0, -1).map(encodeURIComponent).join("/")}`
@@ -187,16 +257,15 @@ export function GraphBreadcrumb({
             <span aria-hidden="true" className="shrink-0">/</span>
           </>
         )}
-        {timelinePath.slice(0, -1).map((segment, index) => (
-          <span key={segment} className="flex min-w-0 shrink-[2] items-center gap-2">
-            <AncestorCrumb
-              crumbId={segment}
-              href={`${base}/${timelinePath
-                .slice(0, index + 1)
-                .map(encodeURIComponent)
-                .join("/")}`}
-              label={documents[segment]?.title ?? segment}
-            />
+        {collapsedAncestors.length > 0 && (
+          <span className="flex shrink-0 items-center gap-2">
+            <CollapsedCrumbs crumbs={collapsedAncestors} />
+            <span aria-hidden="true" className="shrink-0">/</span>
+          </span>
+        )}
+        {visibleAncestors.map((ancestor) => (
+          <span key={ancestor.id} className="flex min-w-0 shrink-[2] items-center gap-2">
+            <AncestorCrumb crumbId={ancestor.id} href={ancestor.href} label={ancestor.label} />
             <span aria-hidden="true" className="shrink-0">/</span>
           </span>
         ))}

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -76,7 +76,7 @@ function TrashAreaIcon({ className }: Readonly<{ className?: string }>) {
       className={cn("relative inline-flex shrink-0 overflow-visible", className)}
     >
       <Folder className="h-full w-full" strokeWidth={2.1} />
-      <span className="absolute -top-1 -right-1 flex size-3.5 items-center justify-center rounded-full bg-zinc-950 ring-1 ring-zinc-600">
+      <span className="absolute -bottom-1 -right-1 flex size-3.5 items-center justify-center rounded-full bg-zinc-950 ring-1 ring-zinc-600">
         <Trash2 className="size-2.5" strokeWidth={2.7} />
       </span>
     </span>
@@ -92,7 +92,7 @@ function MediaFolderIcon({ className }: Readonly<{ className?: string }>) {
       className={cn("relative inline-flex shrink-0 overflow-visible", className)}
     >
       <Folder className="h-full w-full" strokeWidth={2.1} />
-      <span className="absolute -top-1 -right-1 flex size-3.5 items-center justify-center rounded-full bg-zinc-950 ring-1 ring-zinc-600">
+      <span className="absolute -bottom-1 -right-1 flex size-3.5 items-center justify-center rounded-full bg-zinc-950 ring-1 ring-zinc-600">
         <ImageIcon className="size-2.5" strokeWidth={2.5} />
       </span>
     </span>

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1006,9 +1006,9 @@ test.describe("graph view E2E", () => {
     await expect.poll(heightOf).toBeGreaterThan(0);
     const initial = await heightOf();
 
-    // The divider is a compact 16px box — 4px of breathing room under the
-    // preview plus the 12px visible band, which is also its drag track — even
-    // though its centered transport overhangs it.
+    // The 16px box is the DRAG TARGET and never changes; the visible band is
+    // smaller and centred inside it (8px at desktop, 12 where it has to hold
+    // the grip), so the space above it reads as clearance under the preview.
     expect(
       await divider.evaluate((el) => Math.round(el.getBoundingClientRect().height)),
     ).toBe(16);
@@ -1016,7 +1016,7 @@ test.describe("graph view E2E", () => {
       await divider
         .locator("[data-divider-line]")
         .evaluate((el) => Math.round(el.getBoundingClientRect().height)),
-    ).toBe(12);
+    ).toBe(8);
     // The grip is for coarse pointers only: present in the DOM, not painted
     // at desktop width.
     await expect(divider.locator("[data-divider-grip]")).toBeHidden();
@@ -2214,15 +2214,17 @@ test.describe("graph view E2E", () => {
     // Grip marks are the coarse-pointer affordance; this runs at desktop
     // width, where the hover brighten does the job and the grip stays unpainted.
     await expect(divider.locator("[data-divider-grip]")).toBeHidden();
+    // RESTING (nothing hovered): background-free. The ACTIVE invert to a white
+    // disc is covered by the WorkbenchSplitPane story, which can hover the
+    // preview deterministically.
     expect(
       await primaryControl.evaluate(
         (element) => getComputedStyle(element).backgroundColor,
       ),
     ).toBe("rgba(0, 0, 0, 0)");
 
-    // All three 44px hit targets remain centered on the divider's 12px BAND
-    // (the box is 16 — 4px of padding holds the band off the preview), while
-    // their visible chrome stays deliberately compact.
+    // All three 44px hit targets remain centered on the divider's visible
+    // band, while their own chrome stays deliberately compact.
     const [surfaceBox, canvasBox, groupBox, dividerBox, dividerLineBox, timeBox] =
       await Promise.all([
         surface.boundingBox(),
@@ -2238,15 +2240,16 @@ test.describe("graph view E2E", () => {
     expect(dividerBox).not.toBeNull();
     expect(dividerLineBox).not.toBeNull();
     expect(timeBox).not.toBeNull();
+    // The BOX is the hit target and never changes; the visible band is
+    // smaller and centred on one fixed mid-line, so its height can differ by
+    // breakpoint (8 here at desktop, 12 where it hosts the grip) with nothing
+    // else moving.
     expect(dividerBox!.height).toBe(16);
-    expect(dividerLineBox!.height).toBe(12);
-    expect(dividerLineBox!.y + dividerLineBox!.height).toBeCloseTo(
-      dividerBox!.y + dividerBox!.height,
-      0,
-    );
+    expect(dividerLineBox!.height).toBe(8);
+    expect(dividerLineBox!.y + dividerLineBox!.height / 2).toBeCloseTo(dividerBox!.y + 10, 0);
     expect(groupBox!.width).toBe(132);
     expect(groupBox!.height).toBe(44);
-    // Centered on the BAND, not on the padded box.
+    // Centered on the BAND, not on the box.
     expect(dividerLineBox!.y + dividerLineBox!.height / 2).toBeCloseTo(
       groupBox!.y + groupBox!.height / 2,
       0,
@@ -3584,6 +3587,144 @@ test.describe("graph view E2E", () => {
       .poll(() => gridOrder(page, PROJECT_ID))
       .toEqual(["alpha", expect.stringMatching(/^timeline-/), "bravo", CHILD_ID, "charlie"]);
     await expect(indicator).toHaveCount(0);
+  });
+
+  test("a deep breadcrumb folds its middle crumbs behind a reachable ellipsis", async ({
+    page,
+  }) => {
+    // PL8-002. Every ancestor used to render, so a deep path crowded the
+    // header out. The root and the focused crumb are never folded, and the
+    // immediate parent stays visible — the folded ones stay REACHABLE.
+    const api = await installGraphApi(page);
+    const DEPTH_IDS = ["timeline-d1", "timeline-d2", "timeline-d3", "timeline-d4"];
+    const TITLES = ["Depth One", "Depth Two", "Depth Three", "Depth Four"];
+    // project → d1 → d2 → d3 → d4
+    api.documents.get(PROJECT_ID)!.clips.push(
+      collectionClip("clip-d1", DEPTH_IDS[0], 9, TITLES[0], 1),
+    );
+    DEPTH_IDS.forEach((id, index) => {
+      const child = DEPTH_IDS[index + 1];
+      api.documents.set(id, {
+        id,
+        title: TITLES[index],
+        clips: child
+          ? [collectionClip(`clip-${child}`, child, 0, TITLES[index + 1], 1)]
+          : [mediaClip("deep-leaf", "image", 0, 4)],
+      });
+    });
+
+    await page.goto(`${GRAPH_URL}/${DEPTH_IDS.join("/")}?surface=strip`);
+    await expect(strip(page, DEPTH_IDS[3])).toBeVisible({ timeout: 30000 });
+
+    const trail = page.getByRole("navigation", { name: "Timeline focus path" });
+    const overflow = trail.locator("[data-graph-crumb-overflow]");
+
+    // Three ancestors (d1, d2, d3) is past the threshold: the first two fold.
+    await expect(overflow).toBeVisible();
+    await expect(overflow).toHaveAttribute("aria-label", /2 hidden timelines/i);
+    await expect(trail.getByRole("link", { name: TITLES[0] })).toHaveCount(0);
+    await expect(trail.getByRole("link", { name: TITLES[1] })).toHaveCount(0);
+    // Kept: the root crumb, the immediate parent, and the focused crumb.
+    await expect(trail.getByRole("link", { name: "E2E Project" })).toBeVisible();
+    await expect(trail.getByRole("link", { name: TITLES[2] })).toBeVisible();
+    await expect(trail).toContainText(TITLES[3]);
+
+    // The folded levels are reachable: open the menu and navigate to one.
+    await overflow.click();
+    const hidden = page.getByRole("menuitem", { name: TITLES[1] });
+    await expect(hidden).toBeVisible();
+    await hidden.click();
+    await page.waitForURL(`**${GRAPH_URL}/${DEPTH_IDS[0]}/${DEPTH_IDS[1]}`);
+
+    // Two ancestors left — under the threshold, so nothing folds now.
+    await expect(trail.locator("[data-graph-crumb-overflow]")).toHaveCount(0);
+    await expect(trail.getByRole("link", { name: TITLES[0] })).toBeVisible();
+  });
+
+  test("a collection's card icon and its child-timeline row highlight together", async ({
+    page,
+  }) => {
+    // PL8-012. With the tree shown a collection is on screen twice, and
+    // nothing said the two were the same thing.
+    await installGraphApi(page);
+    await openGraph(page); // children timelines on
+    // The drill button is a SIBLING of the card's selection surface, not a
+    // child of it — `[data-node-id]` is the surface itself, so scoping to the
+    // card finds nothing.
+    const cardIcon = page.getByRole("button", { name: "Open Scene A" }).first();
+    const rowFolder = page
+      .locator('section[aria-label="Sub-timeline: Scene A"]')
+      .getByRole("button", { name: "Expand" })
+      .first();
+    const paired = page.locator('[data-collection-paired="true"]');
+
+    await expect(paired).toHaveCount(0);
+
+    // Card → row.
+    await cardIcon.hover();
+    await expect(rowFolder).toHaveAttribute("data-collection-paired", "true");
+    // Exactly the pair: the hovered element and its twin, nothing else.
+    await expect(paired).toHaveCount(2);
+
+    await page.mouse.move(0, 0);
+    await expect(paired).toHaveCount(0);
+
+    // Row → card.
+    await rowFolder.hover();
+    await expect(cardIcon).toHaveAttribute("data-collection-paired", "true");
+    await expect(paired).toHaveCount(2);
+
+    await page.mouse.move(0, 0);
+    await expect(paired).toHaveCount(0);
+
+    // With the tree hidden there is no row to pair with, so hovering the card
+    // highlights nothing.
+    await page.getByRole("button", { name: "Hide children timelines" }).click();
+    await expect(page.locator('section[aria-label^="Sub-timeline"]')).toHaveCount(0);
+    await cardIcon.hover();
+    await expect(paired).toHaveCount(0);
+  });
+
+  test("clicking away anywhere that is not a control clears the selection", async ({
+    page,
+  }) => {
+    // PL8-001. The surfaces already cleared on their own empty space; this is
+    // the rest of the screen — the board's padding, the header, the space
+    // beside the strip — which left "nothing selected" unreachable unless the
+    // user found the right pixel inside a strip.
+    await installGraphApi(page);
+    await openGraph(page);
+    const alpha = strip(page, PROJECT_ID).locator('[data-node-id="alpha"]');
+    const header = page.getByRole("navigation", { name: "Timeline focus path" });
+
+    const select = async () => {
+      await alpha.click();
+      await expect(alpha).toHaveAttribute("data-selected", "true");
+    };
+
+    // A CONTROL is an action, not a click-away. The sidebar's Copy button
+    // only exists WHILE something is selected, which makes it the sharpest
+    // case available: if the click cleared, the button it was on would vanish.
+    await select();
+    await page.getByRole("button", { name: "Copy", exact: true }).click();
+    await expect(alpha).toHaveAttribute("data-selected", "true");
+
+    // A card click still replaces rather than clears.
+    const bravo = strip(page, PROJECT_ID).locator('[data-node-id="bravo"]');
+    await bravo.click();
+    await expect(bravo).toHaveAttribute("data-selected", "true");
+    await expect(alpha).not.toHaveAttribute("data-selected", "true");
+
+    // The breadcrumb row's own empty space — chrome, but not a control.
+    const headerBox = (await header.boundingBox())!;
+    await page.mouse.click(headerBox.x + headerBox.width - 4, headerBox.y + headerBox.height / 2);
+    await expect(bravo).not.toHaveAttribute("data-selected", "true");
+
+    // And well outside any surface: the page margin below the board.
+    await select();
+    const viewport = page.viewportSize()!;
+    await page.mouse.click(viewport.width - 8, viewport.height - 8);
+    await expect(alpha).not.toHaveAttribute("data-selected", "true");
   });
 
   test("the children toggle says so when the timeline has no child timelines", async ({

--- a/packages/ui/dnd-collections/VirtualStrip.stories.tsx
+++ b/packages/ui/dnd-collections/VirtualStrip.stories.tsx
@@ -2271,3 +2271,45 @@ export const BackgroundClickClearsSelection: Story = {
     );
   },
 };
+
+export const DropIndicatorCentersInGap: Story = {
+  // PL8-005: the bar must sit in the MIDDLE of the gap it marks. The card's
+  // own before/after bars back out by half a gap to do that, and the first
+  // card used to zero BOTH sides — so the boundary between card 0 and card 1,
+  // a perfectly ordinary gap, drew its bar jammed against card 0's edge.
+  render: () => (
+    <DndCollections initialGraph={variableGraph()}>
+      <div className="w-[640px]">
+        <VirtualStrip collectionId={parseNodeId("strip")} />
+      </div>
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    const dragged = nodeHandle(canvasElement, "m2");
+    const m0 = nodeCard(canvasElement, "m0");
+    const m1 = nodeCard(canvasElement, "m1");
+    await waitForLayout(m1);
+
+    const barCenter = () => {
+      const bar = canvasElement.querySelector<HTMLElement>("[data-drop-indicator]");
+      if (!bar) return null;
+      const box = bar.getBoundingClientRect();
+      return box.left + box.width / 2;
+    };
+
+    // Aim INSIDE m0's right half, so the bar is drawn by the FIRST card's own
+    // trailing side. Releasing in the gap instead lets m1 win the collision
+    // and draw its leading bar, which never had the bug.
+    const m0Box = m0.getBoundingClientRect();
+    const m1Box = m1.getBoundingClientRect();
+    const insideM0Right = { x: m0Box.right - 4, y: m0Box.top + m0Box.height / 2 };
+    await dragHoldAt(dragged, insideM0Right);
+    await waitFor(() => expect(barCenter()).not.toBeNull());
+    expect(
+      canvasElement.querySelector("[data-drop-indicator]")!.getAttribute("data-drop-indicator"),
+    ).toBe("after");
+    expect(barCenter()!).toBeCloseTo((m0Box.right + m1Box.left) / 2, 0);
+
+    await releaseAt(insideM0Right);
+  },
+};

--- a/packages/ui/dnd-collections/index.ts
+++ b/packages/ui/dnd-collections/index.ts
@@ -116,6 +116,10 @@ export {
   type CollectionsClickSelection,
   type CollectionsInteractionPolicy,
 } from "./react/interaction-policy";
+// Empty space clears the selection. The virtual surfaces do this for their own
+// box already; mount this inside the provider to widen it to the whole screen
+// the collection owns — the package cannot know where that ends.
+export { ClearSelectionOnOutsideClick } from "./react/use-background-clear";
 export {
   CollectionPanel,
   CollectionPanels,

--- a/packages/ui/dnd-collections/react/node-views.tsx
+++ b/packages/ui/dnd-collections/react/node-views.tsx
@@ -390,14 +390,24 @@ export function NodeCardIndicators({
         </div>
       )}
 
-      {/* Before/after drop indicator bars. */}
+      {/* Before/after drop indicator bars.
+
+          Each bar backs out by half a gap so it lands in the MIDDLE of the gap
+          it marks. The two sides read their own variable because a card's two
+          gaps are not always the same: the first card in a strip (and the first
+          in every grid row) has no space to its left to centre in, and pulling
+          the bar out there would put it under the container's padding, where
+          the scroll box clips it. That edge case belongs to the BEFORE side
+          only — zeroing both, as one shared variable forced, left the bar
+          jammed against the card on the side that did have a gap. Both fall
+          back to the old single variable, then to half of the default gap. */}
       {dropSide === "before" && (
         <div
           aria-hidden="true"
           data-drop-indicator="before"
           className="pointer-events-none absolute inset-y-0 z-20 w-1 -translate-x-1/2 rounded-full bg-primary"
           style={{
-            left: "calc(-1 * var(--dnd-drop-indicator-half-gap, 4px))",
+            left: "calc(-1 * var(--dnd-drop-indicator-half-gap-before, var(--dnd-drop-indicator-half-gap, 4px)))",
           }}
         />
       )}
@@ -407,7 +417,7 @@ export function NodeCardIndicators({
           data-drop-indicator="after"
           className="pointer-events-none absolute inset-y-0 z-20 w-1 translate-x-1/2 rounded-full bg-primary"
           style={{
-            right: "calc(-1 * var(--dnd-drop-indicator-half-gap, 4px))",
+            right: "calc(-1 * var(--dnd-drop-indicator-half-gap-after, var(--dnd-drop-indicator-half-gap, 4px)))",
           }}
         />
       )}

--- a/packages/ui/dnd-collections/react/use-background-clear.ts
+++ b/packages/ui/dnd-collections/react/use-background-clear.ts
@@ -1,8 +1,8 @@
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from "react";
 
 import { isEditableKeyboardTarget } from "./node-dom";
-import type { CollectionsStore } from "./collections-store";
+import { useCollectionsStore, type CollectionsStore } from "./collections-store";
 
 /**
  * How far the pointer may travel between press and release and still count as
@@ -13,23 +13,95 @@ import type { CollectionsStore } from "./collections-store";
 const BACKGROUND_CLICK_SLOP_PX = 4;
 
 /**
- * Targets inside a surface that own their own press even though they are not
- * cards: the trim affordances, and anything a consumer marked as its own
- * gesture. Cards are excluded separately by `[data-node-id]`.
+ * What counts as an ACTION rather than background. Anything a click here would
+ * already do something with — a control, a card, a gesture affordance — leaves
+ * the selection alone; everything else is "clicking away".
+ *
+ * Roles are matched as well as tags because a control is often neither: the
+ * app's menus, toggles, and tabs are divs with a role, and a click that opens
+ * a menu must not also clear behind it.
  */
-const NON_BACKGROUND_SELECTOR =
-  "[data-node-id], [data-drag-handle], [data-trim-handle], [data-trim-overview], button, a, input, textarea, select, [role='slider']";
+const NON_BACKGROUND_SELECTOR = [
+  "[data-node-id]",
+  "[data-drag-handle]",
+  "[data-trim-handle]",
+  "[data-trim-overview]",
+  "button",
+  "a",
+  "input",
+  "textarea",
+  "select",
+  "label",
+  "summary",
+  "[role='button']",
+  "[role='link']",
+  "[role='slider']",
+  "[role='menuitem']",
+  "[role='menuitemradio']",
+  "[role='menuitemcheckbox']",
+  "[role='option']",
+  "[role='tab']",
+  "[role='checkbox']",
+  "[role='radio']",
+  "[role='switch']",
+  "[role='separator']",
+].join(", ");
 
 /**
- * Clicking empty space in a surface clears the selection — the counterpart to
+ * Layers that own the whole screen while they are open. A click anywhere with
+ * one of these up is DISMISSING it — an action, and the only thing that click
+ * does. Menus and dialogs also mount an invisible full-screen dismiss layer,
+ * so the click's target is that layer rather than anything meaningful; without
+ * this the first click that closed a menu also silently cleared the selection
+ * behind it, which unmounted the very controls the menu belonged to.
+ */
+const DISMISSABLE_LAYER_SELECTOR =
+  "[role='menu'], [role='dialog'], [role='alertdialog'], [role='listbox']";
+
+/** True when a click on `target` is an action, not a click on the background. */
+function isActionTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return true;
+  if (target.closest(NON_BACKGROUND_SELECTOR)) return true;
+  if (target.ownerDocument.querySelector(DISMISSABLE_LAYER_SELECTOR)) return true;
+  return isEditableKeyboardTarget(target);
+}
+
+/**
+ * The shared decision, for both the container-scoped hook and the page-wide
+ * component below: does this click mean "deselect"?
+ *
+ * The press position is remembered so a PAN or a drag cannot be mistaken for a
+ * click — both end with a `click` event too, and only the one that stayed put
+ * means "I clicked the background". A double-click's second click is ignored
+ * for the same reason the card grammar ignores it: the gesture is already
+ * committed to something else.
+ */
+function shouldClear(
+  store: CollectionsStore,
+  target: EventTarget | null,
+  detail: number,
+  clientX: number,
+  clientY: number,
+  origin: { x: number; y: number } | null,
+): boolean {
+  if (detail > 1) return false;
+  if (isActionTarget(target)) return false;
+  // Keyboard activation reports 0/0 and no preceding pointerdown; a real
+  // background click always has one.
+  if (!origin) return false;
+  if (
+    Math.abs(clientX - origin.x) > BACKGROUND_CLICK_SLOP_PX ||
+    Math.abs(clientY - origin.y) > BACKGROUND_CLICK_SLOP_PX
+  ) {
+    return false;
+  }
+  return store.getSnapshot().interaction.selectedIds.size > 0;
+}
+
+/**
+ * Clicking empty space in a SURFACE clears the selection — the counterpart to
  * the card grammar in `interaction-policy`, and the only way to reach "nothing
  * selected" with the mouse.
- *
- * The press position is remembered so a PAN cannot be mistaken for a click:
- * both end with a `click` event on the scroll container, and only the one that
- * stayed put means "I clicked the background". A double-click's second click
- * is ignored for the same reason the card grammar ignores it — the gesture is
- * already committed to something else.
  */
 export function useBackgroundSelectionClear(store: CollectionsStore): Readonly<{
   onPointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
@@ -45,29 +117,63 @@ export function useBackgroundSelectionClear(store: CollectionsStore): Readonly<{
     (event: ReactMouseEvent<HTMLElement>) => {
       const origin = originRef.current;
       originRef.current = null;
-
-      if (event.detail > 1) return;
-
-      const target = event.target;
-      if (!(target instanceof Element)) return;
-      if (target.closest(NON_BACKGROUND_SELECTOR)) return;
-      if (isEditableKeyboardTarget(target)) return;
-
-      // Keyboard activation reports 0/0 and no preceding pointerdown; a real
-      // background click always has one.
-      if (!origin) return;
       if (
-        Math.abs(event.clientX - origin.x) > BACKGROUND_CLICK_SLOP_PX ||
-        Math.abs(event.clientY - origin.y) > BACKGROUND_CLICK_SLOP_PX
+        shouldClear(store, event.target, event.detail, event.clientX, event.clientY, origin)
       ) {
-        return;
+        store.clearSelection();
       }
-
-      if (store.getSnapshot().interaction.selectedIds.size === 0) return;
-      store.clearSelection();
     },
     [store],
   );
 
   return { onPointerDown, onClick };
+}
+
+/**
+ * The same rule, widened to the whole PAGE: any click that is not an action
+ * clears the selection, wherever it lands — the board's padding, the header,
+ * the space beside the surfaces, another panel entirely.
+ *
+ * Mounted by the CONSUMER rather than by the provider, because "the page" is
+ * the consumer's idea, not the package's: an app embedding a small collections
+ * widget in a larger screen would not want clicks elsewhere reaching into it.
+ * Render it inside the provider on the screen the collection owns.
+ *
+ * The click is read in the BUBBLE phase, deliberately. A click that something
+ * else has already claimed is not a click-away, and the claim shows up as
+ * stopped propagation — most importantly dnd-kit's, which eats the trailing
+ * click after a drag or a hold-grab from a capture-phase listener on this same
+ * document. Listening in capture ran BEFORE that suppressor (listeners fire in
+ * registration order, and this one mounts first), so releasing a hold-grab in
+ * place cleared the selection the grab was holding.
+ */
+export function ClearSelectionOnOutsideClick(): null {
+  const store = useCollectionsStore();
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    let origin: { x: number; y: number } | null = null;
+
+    const onPointerDown = (event: PointerEvent) => {
+      origin = { x: event.clientX, y: event.clientY };
+    };
+    const onClick = (event: MouseEvent) => {
+      const pressed = origin;
+      origin = null;
+      if (
+        shouldClear(store, event.target, event.detail, event.clientX, event.clientY, pressed)
+      ) {
+        store.clearSelection();
+      }
+    };
+
+    document.addEventListener("pointerdown", onPointerDown, true);
+    document.addEventListener("click", onClick);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      document.removeEventListener("click", onClick);
+    };
+  }, [store]);
+
+  return null;
 }

--- a/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
@@ -414,11 +414,20 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
                         {
                           width: fillCellWidth,
                           height: cellHeight,
-                          // A row-start boundary is the grid's left edge, not
-                          // the centre of a fictional gap outside the scroller.
-                          // Match the virtual indicator's clamped coordinate so
-                          // the two rendering paths can never alternate.
-                          "--dnd-drop-indicator-half-gap": colInRow === 0 ? "0px" : `${gap / 2}px`,
+                          // A row-EDGE boundary is the grid's own edge, not the
+                          // centre of a fictional gap outside the scroller, so
+                          // those bars sit flush; matching the virtual
+                          // indicator's clamped coordinate keeps the two
+                          // rendering paths from alternating. The sides are
+                          // separate because only ONE of a cell's two gaps is
+                          // ever the row edge — with a single shared value the
+                          // first cell in every row also lost the offset on its
+                          // interior side, and the bar sat against the card
+                          // instead of in the middle of a real gap.
+                          "--dnd-drop-indicator-half-gap-before":
+                            colInRow === 0 ? "0px" : `${gap / 2}px`,
+                          "--dnd-drop-indicator-half-gap-after":
+                            colInRow === cols - 1 ? "0px" : `${gap / 2}px`,
                         } as CSSProperties
                       }
                     >

--- a/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
@@ -890,8 +890,17 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
                       width: item.size - gap,
                       height: itemHeight,
                       transform: `translateX(${item.start}px)`,
-                      "--dnd-drop-indicator-half-gap":
+                      // Only the FIRST card's leading side is special: there
+                      // is no gap before it, and the scroll box clips anything
+                      // pulled out into the container's padding. Its trailing
+                      // side has an ordinary gap and gets the ordinary offset.
+                      // Only the FIRST card's leading side is special: there
+                      // is no gap before it, and the scroll box clips anything
+                      // pulled out into the container's padding. Its trailing
+                      // side has an ordinary gap and gets the ordinary offset.
+                      "--dnd-drop-indicator-half-gap-before":
                         item.index === 0 ? "0px" : `${gap / 2}px`,
+                      "--dnd-drop-indicator-half-gap-after": `${gap / 2}px`,
                     } as CSSProperties
                   }
                 >

--- a/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
+++ b/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import { expect, userEvent, within } from "storybook/test";
+import { expect, userEvent, waitFor, within } from "storybook/test";
 
 import type { TimelineClip } from "../types";
 
@@ -96,11 +96,12 @@ export const StickyPreview: Story = {
     // only at tablet width and below (md:hidden), so presence is what this
     // story can assert without pinning the canvas width.
     expect(divider.querySelector("[data-divider-grip]")).not.toBeNull();
-    // 4px of padding above a 12px band: the box is 16 and the band is
-    // BOTTOM-aligned in it, so the gap lands under the preview surface.
+    // The box is the hit target and stays 16 at every breakpoint. The visible
+    // band is smaller and CENTERED on one fixed mid-line, so its height can
+    // change (8 desktop / 12 coarse-pointer) without moving anything.
     expect(dividerBox.height).toBe(16);
-    expect(dividerLineBox.height).toBe(12);
-    expect(dividerLineBox.bottom).toBeCloseTo(dividerBox.bottom, 0);
+    expect(dividerLineBox.height).toBeLessThan(dividerBox.height);
+    expect(dividerLineBox.y + dividerLineBox.height / 2).toBeCloseTo(dividerBox.y + 10, 0);
     // The transport centers on the BAND, not on the padded box.
     expect(dividerLineBox.y + dividerLineBox.height / 2).toBeCloseTo(
       buttonGroupBox.y + buttonGroupBox.height / 2,
@@ -248,6 +249,10 @@ export const ControlledPlayback: Story = {
     expect(canvas.getByRole("button", { name: "Next workbench clip" })).toBeVisible();
     expect(previewCanvas).not.toHaveAttribute("tabindex");
 
+    // RESTING: background-free, so the mark reads straight off the divider.
+    expect(getComputedStyle(primaryControl!).backgroundColor).toBe("rgba(0, 0, 0, 0)");
+    const restingColor = getComputedStyle(primaryControl!).color;
+
     const previewBounds = previewCanvas.getBoundingClientRect();
     await user.pointer({
       target: previewCanvas,
@@ -257,8 +262,20 @@ export const ControlledPlayback: Story = {
       },
     });
     expect(getComputedStyle(previewCanvas).cursor).toBe("pointer");
-    expect(primaryControl).toHaveClass("text-white");
-    expect(getComputedStyle(primaryControl!).backgroundColor).toBe("rgba(0, 0, 0, 0)");
+    // ACTIVE: the control INVERTS — solid white disc, mark punched black out
+    // of it — rather than just brightening the glyph.
+    // POLLED, not read once: the control carries `transition-colors`, so an
+    // immediate getComputedStyle returns a value part-way through the fade —
+    // which read as "still transparent" and looked exactly like the class not
+    // applying at all.
+    await waitFor(() =>
+      expect(getComputedStyle(primaryControl!).backgroundColor).toBe("rgb(255, 255, 255)"),
+    );
+    // The glyph color is not pinned to a literal: the token serializes as
+    // oklch, and which color space a browser reports is not what this story is
+    // about. What matters is that it left the resting zinc for the dark mark
+    // the new white disc needs.
+    expect(getComputedStyle(primaryControl!).color).not.toBe(restingColor);
     expect(controls).toHaveAttribute("data-transport-layout", "static");
     await user.unhover(previewCanvas);
 

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Pause, Play, SkipBack, SkipForward, X } from "lucide-react";
+import { GripHorizontal, Pause, Play, SkipBack, SkipForward, X } from "lucide-react";
 import {
   useCallback,
   useEffect,
@@ -78,19 +78,17 @@ const BUFFER_WINDOW_SIZE = 4;
 const DEFAULT_SURFACE_HEIGHT = 380;
 const MIN_SURFACE_HEIGHT = 120;
 const MIN_TIMELINE_SPACE = 260;
-/** The visible divider BAND, which is also its drag track (Tailwind h-3). */
-const DIVIDER_BAND_HEIGHT_PX = 12;
-/** Breathing room between the preview surface and the band. Part of the
- *  divider button's own box, not a margin, so the measured element and the
- *  published offset below cannot disagree. */
-const DIVIDER_TOP_PADDING_PX = 4;
-/** The divider element's full height — padding + band. Feeds
- *  `--workbench-preview-offset`, so it MUST stay equal to what the button
- *  actually renders (`pt-1` + `h-3`). */
-const DIVIDER_HEIGHT_PX = DIVIDER_TOP_PADDING_PX + DIVIDER_BAND_HEIGHT_PX;
-/** Where the band's mid-line falls inside that box. The transport is centered
- *  on it and may overhang it without changing layout. */
-const DIVIDER_BAND_CENTER_PX = DIVIDER_TOP_PADDING_PX + DIVIDER_BAND_HEIGHT_PX / 2;
+/** The divider button's full height — the DRAG HIT TARGET, and what
+ *  `--workbench-preview-offset` is built from. Constant at every breakpoint
+ *  (Tailwind h-4), so the band inside it can change height without moving the
+ *  preview, the transport, or anything sticking below. */
+const DIVIDER_HEIGHT_PX = 16;
+/** Where the visible band's mid-line falls inside that box. The band is
+ *  CENTERED on this line at every breakpoint rather than sized from the top,
+ *  which is what lets it be 8px on desktop and 12px on coarse-pointer widths
+ *  (where it hosts the grip) without the transport shifting. The transport is
+ *  centered on the same line and may overhang the band freely. */
+const DIVIDER_BAND_CENTER_PX = 10;
 
 type WorkbenchDividerTransportProps = {
   currentTime: number;
@@ -156,10 +154,15 @@ function WorkbenchDividerTransport({
           aria-label={isPlaying ? "Pause workbench preview" : "Play workbench preview"}
           title={isPlaying ? "Pause" : "Play"}
         >
+          {/* ACTIVE = the highlighted state (the preview is hovered, or this
+              button is), the same condition that used to only whiten the
+              glyph. It now INVERTS: a solid white disc with the mark punched
+              black out of it. Resting stays background-free, and the disc is
+              the well's own size, so nothing shifts as it lights up. */}
           <span
             className={cn(
-              "grid size-5 place-items-center rounded-full transition-colors group-hover/play:text-white group-focus-visible/play:ring-2 group-focus-visible/play:ring-sky-400 group-focus-visible/play:ring-offset-2 group-focus-visible/play:ring-offset-zinc-950",
-              previewHovered && "text-white",
+              "grid size-5 place-items-center rounded-full transition-colors group-hover/play:bg-white group-hover/play:text-zinc-950 group-focus-visible/play:ring-2 group-focus-visible/play:ring-sky-400 group-focus-visible/play:ring-offset-2 group-focus-visible/play:ring-offset-zinc-950",
+              previewHovered && "bg-white text-zinc-950",
             )}
             data-transport-primary-control
           >
@@ -907,7 +910,7 @@ export function WorkbenchDisplaySurface({
           <button
             type="button"
             onClick={onClose}
-            className="absolute right-2 top-2 z-10 grid size-7 place-items-center rounded-full border border-zinc-800 bg-zinc-900/80 text-zinc-400 backdrop-blur-sm transition-colors hover:border-zinc-600 hover:text-zinc-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-400 focus-visible:outline-offset-2"
+            className="absolute right-4 top-4 z-10 grid size-7 place-items-center rounded-full border border-zinc-800 bg-zinc-900/80 text-zinc-400 backdrop-blur-sm transition-colors hover:border-zinc-600 hover:text-zinc-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-400 focus-visible:outline-offset-2"
             aria-label="Close preview"
             title="Close preview"
             data-testid="workbench-preview-close"
@@ -1239,10 +1242,11 @@ export function WorkbenchSplitPane({
           aria-valuemin={MIN_SURFACE_HEIGHT}
           aria-valuenow={Math.round(surfaceHeight)}
           aria-label="Resize workbench display"
-          // pt-1 + h-3 = DIVIDER_HEIGHT_PX. The padding is the gap under the
-          // preview; the band below it is both the visible divider and the
-          // drag track, and the transport rides centered on that band.
-          className="group relative block w-full cursor-row-resize bg-transparent pt-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-400 focus-visible:outline-offset-2"
+          // h-4 = DIVIDER_HEIGHT_PX: the whole box is the drag target, and it
+          // stays this height at every breakpoint. The visible band inside is
+          // smaller and centered, so the space above it reads as the gap under
+          // the preview without being separate padding.
+          className="group relative block h-4 w-full cursor-row-resize bg-transparent focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-400 focus-visible:outline-offset-2"
           data-workbench-divider
           onPointerDown={handleDividerPointerDown}
           onPointerMove={handleDividerPointerMove}
@@ -1250,27 +1254,31 @@ export function WorkbenchSplitPane({
           onPointerCancel={handleDividerPointerUp}
         >
           {/* The band fades out across the 132px transport group so no divider
-              color shows behind its background-free icons — the same window
-              the one-pixel centerline used, now filling the full band. */}
+              color shows behind its background-free icons.
+
+              CENTERED on DIVIDER_BAND_CENTER_PX rather than sized from the
+              box's top: 8px at desktop, and 12px below `md`, where it has to
+              stay tall enough to hold the grip icon. Because both heights
+              share one mid-line, the transport that rides on it never moves. */}
           <span
             aria-hidden="true"
-            className="pointer-events-none block h-3 rounded-sm bg-[linear-gradient(to_right,currentColor_0,currentColor_calc(50%_-_6.125rem),transparent_calc(50%_-_4.125rem),transparent_calc(50%_+_4.125rem),currentColor_calc(50%_+_6.125rem),currentColor_100%)] text-zinc-800 transition-colors group-hover:text-zinc-700 group-active:text-zinc-600"
+            className="pointer-events-none absolute inset-x-0 h-3 rounded-sm bg-[linear-gradient(to_right,currentColor_0,currentColor_calc(50%_-_6.125rem),transparent_calc(50%_-_4.125rem),transparent_calc(50%_+_4.125rem),currentColor_calc(50%_+_6.125rem),currentColor_100%)] text-zinc-800 transition-colors group-hover:text-zinc-700 group-active:text-zinc-600 md:h-2"
+            style={{ top: DIVIDER_BAND_CENTER_PX, transform: "translateY(-50%)" }}
             data-divider-line
           />
           {/* Coarse-pointer devices never see the hover brighten, so at tablet
-              width and below the band carries a standing grip mark instead.
-              ONE mark, at 7rem left of centre: the centre belongs to the
-              transport (solid band resumes past ±6.125rem) and the band's
-              right end belongs to the time readout, whose opaque pill is up
-              to half the width — a mirrored mark over there is simply painted
-              over. Left of the transport is the only place on a phone-width
-              band that is reliably empty. */}
+              width and below the band carries a standing grip instead. At the
+              band's far LEFT: the centre belongs to the transport and the right
+              end to the time readout, whose opaque pill can span half the
+              width — anything placed there is simply painted over. */}
           <span
             aria-hidden="true"
             data-divider-grip
-            className="pointer-events-none absolute left-[calc(50%_-_7rem)] h-0.5 w-5 rounded-full bg-zinc-500 md:hidden"
+            className="pointer-events-none absolute left-2 text-zinc-500 md:hidden"
             style={{ top: DIVIDER_BAND_CENTER_PX, transform: "translateY(-50%)" }}
-          />
+          >
+            <GripHorizontal className="h-3 w-3" strokeWidth={2.5} />
+          </span>
         </button>
         </div>
       ) : null}

--- a/punch-list/PUNCH-LIST-08.md
+++ b/punch-list/PUNCH-LIST-08.md
@@ -1,0 +1,290 @@
+# Punch List 08
+
+## PL8-001 — Click-away deselects from anywhere, not just the surface
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: Graph view — selection clearing (extends PL7-001)
+- Screenshot: Not captured
+
+PL7-001 clears the selection on an empty-space click, but only inside a
+strip or grid container. Any click that is not itself an action should
+count as clicking away: page background, the board's padding, the header
+row, the area beside the surfaces. Clicking a control that does something —
+a button, a link, a toggle, a card — is an action and must not deselect.
+
+Reference: `useBackgroundSelectionClear` in
+`packages/ui/dnd-collections/react/use-background-clear.ts`, wired to the
+`VirtualStrip` / `VirtualGrid` containers. The rule needs to move up to a
+page-level listener while keeping the same non-action test.
+
+Acceptance criteria:
+
+- With a selection active, a click anywhere that does not trigger an action
+  clears it — including outside any strip or grid.
+- Clicks on buttons, links, inputs, cards, drag handles, trim handles, the
+  seek rail, the divider, and sidebar controls do NOT clear the selection.
+- A click that ends a drag, a pan, or a trim does not clear it (the
+  press-position guard still applies).
+- A double-click's second click does not clear it.
+- Ctrl/Cmd+click toggle and plain card-click replace still behave as now.
+- Clearing does not move the playhead, change focus, or scroll the page.
+
+## PL8-002 — Collapse a long breadcrumb behind a clickable "…"
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `graph-view-chrome.tsx` — `GraphBreadcrumb`
+- Screenshot: Not captured
+
+A deep timeline path renders every ancestor crumb, so the trail crowds the
+header. Omit the middle crumbs behind a "…" that can be clicked to reach
+any of them.
+
+Reference: `GraphBreadcrumb` maps `timelinePath.slice(0, -1)` into
+`AncestorCrumb`s. Crumbs are also DROP TARGETS during a card drag
+(`graph-breadcrumb-drop.tsx`), which the overflow has to keep in mind.
+
+Acceptance criteria:
+
+- When the trail is too long for the header, middle crumbs collapse into a
+  single "…" indicator.
+- The "…" is a real control: activating it lists every omitted crumb and
+  navigating to one works.
+- The root crumb and the current (focused, renamable) crumb are never
+  collapsed.
+- Short trails render exactly as they do now, with no "…".
+- The overflow control is keyboard reachable and screen-reader labelled.
+- The header does not overflow horizontally at any width.
+- Crumb drop targets still work for the crumbs that remain visible;
+  collapsing must not break the drag/drop path.
+
+## PL8-003 — Collection card glyph slightly smaller inside its circle
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: Collection card drill affordance (`graph-item-content.tsx`)
+- Screenshot: Not captured
+
+The circular drill button on a collection card is the right size, but the
+`CornerRightDown` glyph inside it is too large for the circle.
+
+Today: the button is `aspect-square h-[34%]` and the glyph is
+`h-[55%] w-[55%]` of it.
+
+Acceptance criteria:
+
+- The circle keeps its current diameter.
+- The glyph is visibly smaller inside it, with more breathing room.
+- It stays centred and crisp at every item size, strip and grid.
+- The empty-collection ghost glyph (the one on a card with no preview) is
+  reviewed for the same proportion.
+
+## PL8-004 — Divider grip becomes a GripHorizontal at the far left
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `workbench-display-surface.tsx` — divider grip (revises PL7-005d)
+- Screenshot: Not captured
+
+PL7-005 added a plain pill mark left of the transport at `md` and below.
+Replace it with the lucide `GripHorizontal` icon, positioned at the far
+LEFT end of the divider rather than near the centre.
+
+Acceptance criteria:
+
+- The grip renders as `GripHorizontal`, at the divider's left end.
+- Still shown at `md` and below only; unchanged above it.
+- It does not collide with the transport controls or the time readout at
+  any width down to 320px.
+- It stays decorative (`aria-hidden`) and never intercepts the resize drag.
+
+## PL8-005 — Reorder drop indicator is not centred in the gap
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: Strip/grid reorder indicator (`virtual-strip-geometry.ts`,
+  `VirtualStrip`, `VirtualGrid`)
+- Screenshot: Not captured
+
+Dragging an item to a new position draws a blue vertical bar at the
+boundary. It does not always land centred in the gap between the two
+neighbouring cards.
+
+Reference: `indicatorLeftOffset(edgeStart, gap)` returns
+`max(0, edgeStart - gap / 2)`, and the bar is `w-1 -translate-x-1/2`. The
+`max(0, …)` clamp is one suspect at the leading boundary; the rendered gap
+disagreeing with the `gap` prop, and the first-item trim gutter, are
+others. Diagnose before changing the formula.
+
+Acceptance criteria:
+
+- The bar is centred in the gap at every boundary, including the first
+  (before the first card) and the last (after the last card).
+- Correct in both strip and grid, at every item size and zoom.
+- Still correct while a trim gutter is in effect on the first card.
+- The boundary the bar marks is still the boundary the drop commits to.
+
+## PL8-006 — Divider visible height slightly less
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `workbench-display-surface.tsx` — `data-divider-line` (revises
+  PL7-005a)
+- Screenshot: Not captured
+
+PL7-005 made the visible band 12px. Trim it a little. The hit target stays
+where it is.
+
+If the band must remain 12px at tablet width and below to host the PL8-004
+grip icon, that is acceptable — the reduction can be desktop-only.
+
+Acceptance criteria:
+
+- The visible band is shorter than 12px at desktop width.
+- The drag hit target keeps its current height.
+- `DIVIDER_HEIGHT_PX` and the rendered box stay in sync — the constant
+  feeds `--workbench-preview-offset` and the sticky preview offset.
+- The transport stays centred on the band and legible against it.
+- Existing divider e2e and story expectations are re-synced.
+
+## PL8-007 — Preview close button needs more inset from the corner
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `workbench-display-surface.tsx` — preview close button
+- Screenshot: Not captured
+
+The close button in the preview's top-right corner sits too close to the
+edges. Today: `absolute right-2 top-2`.
+
+Acceptance criteria:
+
+- The button has visibly more space from the top and right edges.
+- It stays inside the preview surface and clear of the letterboxed frame.
+- Hit target and focus ring are unchanged.
+- It does not overlap the scrub readout or any other preview overlay.
+
+## PL8-008 — Breadcrumb drop hint loses its background
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `graph-breadcrumb-drop.tsx` — `DropZone` hint branch
+- Screenshot: Not captured
+
+While dragging a card over a breadcrumb crumb, the right-hand zone borrows
+its pixels to read out "Drop into <name>". That readout should have no
+background fill.
+
+Today the hint branch applies `bg-zinc-800/75` (or `bg-zinc-900/70` when
+invalid) plus `shadow-sm`.
+
+Acceptance criteria:
+
+- The hint readout renders with no background fill and no drop shadow.
+- Its icon and text stay legible over whatever is behind it.
+- The TRASH drop zone's own appearance is untouched — its idle, `over`, and
+  `invalid` states keep their current backgrounds.
+- The zone's droppable hit rect is unchanged (it stays mounted either way).
+- The invalid variant is still visually distinct from the valid one.
+
+## PL8-009 — Sidebar folder badges move to the bottom-right
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `timeline-sidebar.tsx` — `MediaFolderIcon` and the trash folder icon
+- Screenshot: Not captured
+
+Both bottom-of-rail folder icons carry a small badge (an image glyph for
+assets, a trash glyph for the trash). Move the badge from the folder's
+top-right corner to its bottom-right.
+
+Today both use `absolute -top-1 -right-1`.
+
+Acceptance criteria:
+
+- Both badges sit at the folder's bottom-right corner.
+- The badge keeps its size, ring, and background treatment.
+- Neither icon's overall footprint changes, and the rail's spacing and
+  alignment are unaffected.
+- The trash icon's drop-hover and arrival animations still work.
+
+## PL8-010 — Trim the "No child timelines" empty state
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `graph-sub-timelines.tsx` — `SubTimelines` empty state (revises
+  PL7-004)
+- Screenshot: Not captured
+
+The empty state added in PL7-004 carries a second explanatory line and is
+centred. Reduce it to the heading alone, left aligned, with an icon that
+reads as a tree node.
+
+Acceptance criteria:
+
+- The panel shows "No child timelines" and nothing else.
+- Content is left aligned, not centred.
+- A tree-node icon precedes the text and reads as part of the tree.
+- Still top-level only, still only when the children toggle is on.
+- Still reachable to assistive tech and still replaced by the real row as
+  soon as a child timeline exists.
+
+## PL8-011 — Active play/pause is a black glyph in a white circle
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `workbench-display-surface.tsx` — transport primary control
+- Screenshot: Not captured
+
+In its active state the play/pause button should invert: a white filled
+circle with the glyph drawn black inside it.
+
+Today the control is background-free — a `size-5` `rounded-full` span
+(`data-transport-primary-control`) that only changes text color, going
+`text-zinc-400` → white when the preview is hovered or on button hover.
+
+Read as: "active" is that highlighted state (preview hovered / hover), the
+same condition that whitens the glyph today. Say if you meant the pressed
+`:active` state instead — the work is different.
+
+Acceptance criteria:
+
+- In the active state the control paints a solid white circle with a black
+  glyph; play and pause both.
+- The resting state is unchanged — still background-free, still zinc.
+- The circle keeps the control's current diameter, so nothing shifts as it
+  activates, and the 44px hit target is untouched.
+- Contrast holds against the divider band behind it.
+- The focus ring stays visible against the white fill.
+- The e2e that asserts `data-transport-primary-control` has a transparent
+  background is scoped to the RESTING state, or updated.
+
+## PL8-012 — Card icon and its sub-timeline row highlight together
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: Collection card drill icon ↔ `SubTimelineNode` folder row
+- Screenshot: Not captured
+
+With child timelines enabled, a collection appears twice: as a card in the
+surface and as its own row below. Hovering one should highlight the other,
+in both directions, so the pairing is visible.
+
+The two are matched by the collection's node id — the card's `data-node-id`
+and the row's collection id are the same value.
+
+Acceptance criteria:
+
+- Hovering a collection card's icon highlights that collection's
+  sub-timeline row.
+- Hovering that row's folder highlights the card's icon.
+- The highlight only appears while child timelines are enabled — with the
+  toggle off there is no row to pair with.
+- Only the matching pair highlights; sibling collections are unaffected,
+  including when several rows are expanded and nested.
+- The highlight clears on pointer-out, and on the row unmounting mid-hover.
+- Nothing about layout, selection, drag, or the drill/expand actions
+  changes — this is a hover affordance only.
+- The pairing survives scrolling and virtualization: an unmounted card or a
+  collapsed row simply has nothing to highlight, and must not error.


### PR DESCRIPTION
Twelve graph-view items from a UI review round, tracked in [punch-list/PUNCH-LIST-08.md](punch-list/PUNCH-LIST-08.md).

| Item | Change |
| --- | --- |
| PL8-001 | Click-away deselects from anywhere non-actionable |
| PL8-002 | Deep breadcrumb folds middle crumbs behind a clickable "…" |
| PL8-003 | Collection glyph smaller inside its circle |
| PL8-004 / PL8-006 | `GripHorizontal` at the band's left; visible band 8px at desktop |
| PL8-005 | Reorder bar centred in the gap |
| PL8-007 | Preview close button inset from the corner |
| PL8-008 | Breadcrumb drop hint loses its fill |
| PL8-009 | Sidebar folder badges → bottom-right |
| PL8-010 | "No child timelines" trimmed to one line + tree icon |
| PL8-011 | Active play/pause inverts to black-on-white |
| PL8-012 | Card icon ↔ child-row pair highlight |

### The three worth reading

**PL8-001 — two ways a page-wide click listener bites.** Both found by breaking existing tests, not by reasoning:

- The click is read in the **bubble** phase. A click something else already claimed is not a click-away, and the claim shows up as stopped propagation — most importantly dnd-kit's, which eats the trailing click of a hold-grab from a capture listener on the same document. Reading in capture ran *first* (listeners fire in registration order, and this one mounts earlier) and cleared the very selection the grab was holding.
- An open menu or dialog mounts a full-screen dismiss layer, so the click that closes one targets *that layer*. Without a guard, dismissing the item-actions menu cleared the selection and unmounted the menu's own trigger.

**PL8-005 — the bar was off by exactly `gap/2`, but only sometimes.** A card's two drop bars shared one `--dnd-drop-indicator-half-gap`, and the first card in a strip (and the first in every grid **row**) zeroed it so the leading bar wouldn't be pulled into the scroll box's clipped padding. That also zeroed the side with a perfectly ordinary gap. Split per side. Proven fail-first in a story: bar centre at 169 instead of 173.

**PL8-004 + PL8-006 interact,** as flagged when the items were logged. The divider box is now a constant 16px — the drag target, and what `--workbench-preview-offset` is built from — with the visible band smaller and **centred on one fixed mid-line**: 8px at desktop, 12px below `md` where it hosts the grip. Sharing a mid-line is what lets the band change height without the transport moving.

### Verification

- graph-view e2e **82/82**, app vitest 442/442, unit 408/408, stories 165/165
- app + `packages/ui` tsc clean; lint clean (4 pre-existing `img` warnings)
- PL8-003/009/012 also measured live in the running app — glyph 20px in a 45px circle, both badges anchored bottom-right, and a card-icon hover pairing exactly two elements (its own button and the matching row's folder), clearing on leave

🤖 Generated with [Claude Code](https://claude.com/claude-code)