### PR TITLE
Punch list 09 (4 of 6 items, plus the strip half of a 5th)

### DIFF
--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -180,11 +180,42 @@ body {
   animation: trash-hover-attention 800ms ease-in-out infinite;
 }
 
+/* A collection CARD, called out while its child-timeline row's folder is
+   hovered: one pass of a sky glow that rises and falls, then the card rests.
+   A one-shot, not a loop — the pointer sits on a folder for as long as the
+   user is reading the tree, and a throb for all of that is noise.
+
+   Glow and ring only. Never the element's opacity (see the trash note above),
+   and nothing that changes the box: these cards sit in a virtualized strip
+   where a size change would shove every neighbour. */
+@keyframes collection-paired-callout {
+  0% {
+    box-shadow: 0 0 0 0 rgba(56, 189, 248, 0);
+  }
+  35% {
+    box-shadow: 0 0 18px 4px rgba(56, 189, 248, 0.55);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(56, 189, 248, 0);
+  }
+}
+
+.animate-collection-paired-callout {
+  animation: collection-paired-callout 260ms ease-out;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .animate-trash-arrival,
   .animate-trash-armed-pulse,
-  .animate-trash-hover-attention {
+  .animate-trash-hover-attention,
+  .animate-collection-paired-callout {
     animation: none;
+  }
+
+  /* The connection still has to READ without motion: hold the glow steady
+     for as long as the row is hovered instead of playing it. */
+  .animate-collection-paired-callout {
+    box-shadow: 0 0 16px 3px rgba(56, 189, 248, 0.5);
   }
 }
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-collection-hover.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-collection-hover.tsx
@@ -4,15 +4,19 @@ import { createContext, useContext, useMemo, useSyncExternalStore, type ReactNod
 
 /**
  * With child timelines shown, a collection appears TWICE: as a card in the
- * surface and as its own row below. Hovering either one highlights the other,
- * so the pairing is visible instead of something the user has to infer from
- * two identical names.
+ * surface and as its own row below. Hovering the ROW's folder calls out the
+ * matching card, so the pairing is visible instead of something the user has
+ * to infer from two identical names.
+ *
+ * ONE DIRECTION. The card does not call out the row: the tree is a place you
+ * go looking for a card, not the other way round, and lighting both ends made
+ * every pass of the pointer across the surface twitch something below.
  *
  * A subscribable channel rather than context state: every collection card on
  * screen consumes this, and putting the hovered id in a context value would
  * re-render all of them (and their subtrees) on every pointer move between
- * cards. Each consumer subscribes with its own id and re-renders only when ITS
- * answer flips, so a hover repaints exactly the two elements that changed.
+ * rows. Each consumer subscribes with its own id and re-renders only when ITS
+ * answer flips, so a hover repaints exactly the card that changed.
  */
 type HoverListener = () => void;
 
@@ -65,43 +69,48 @@ export function CollectionHoverProvider({
   );
 }
 
-const NO_PAIR = {
-  paired: false,
+const NO_HANDLERS = {
   onPointerEnter: undefined,
   onPointerLeave: undefined,
 } as const;
 
 /**
- * Whether `collectionId`'s twin is currently hovered, plus the handlers that
- * announce this element as the hovered one. Undefined handlers when there is
- * no provider (or children are off) so the props simply don't attach.
+ * The SOURCE end, for a child timeline row's folder: the handlers that announce
+ * this collection as the hovered one. Undefined when there is no provider (or
+ * children are off), so the props simply don't attach.
  */
-export function useCollectionHoverPair(collectionId: string): Readonly<{
-  paired: boolean;
+export function useCollectionHoverSource(collectionId: string): Readonly<{
   onPointerEnter?: () => void;
   onPointerLeave?: () => void;
 }> {
   const channel = useContext(CollectionHoverContext);
-  const paired = useSyncExternalStore(
-    channel ? channel.subscribe : NO_SUBSCRIBE,
-    () => (channel ? channel.get() === collectionId : false),
-    () => false,
-  );
   return useMemo(
     () =>
       channel
         ? {
-            paired,
             onPointerEnter: () => channel.set(collectionId),
             // Clear only if we are still the hovered one: pointer events can
-            // arrive out of order when moving directly between the card and
-            // its row, and a late leave would otherwise wipe the enter that
-            // already landed.
+            // arrive out of order when moving between adjacent rows, and a
+            // late leave would otherwise wipe the enter that already landed.
             onPointerLeave: () => {
               if (channel.get() === collectionId) channel.set(null);
             },
           }
-        : NO_PAIR,
-    [channel, collectionId, paired],
+        : NO_HANDLERS,
+    [channel, collectionId],
+  );
+}
+
+/**
+ * The TARGET end, for a collection card: whether its row is being hovered
+ * right now. Drives a one-shot call-out on the card (see
+ * `graph-item-content`), so what matters is the transition into true.
+ */
+export function useCollectionHoverTarget(collectionId: string): boolean {
+  const channel = useContext(CollectionHoverContext);
+  return useSyncExternalStore(
+    channel ? channel.subscribe : NO_SUBSCRIBE,
+    () => (channel ? channel.get() === collectionId : false),
+    () => false,
   );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -44,7 +44,7 @@ import {
 import { useClipDetail, useGraphDetailsStore, useTimelineTitle } from "./graph-details-context";
 import { isDisabledByAncestor } from "./graph-playhead-model";
 import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
-import { useCollectionHoverPair } from "./graph-collection-hover";
+import { useCollectionHoverTarget } from "./graph-collection-hover";
 import { GraphViewNavContext } from "./graph-navigation";
 import { TrimFramePreview } from "./graph-trim-frame-preview";
 import { createDerivedCache } from "@/lib/derived-cache";
@@ -765,7 +765,7 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
   const title = useTimelineTitle(id as string);
   const rename = useInlineRename(id, title ?? node.name, "card");
   const nav = useContext(GraphViewNavContext);
-  const hoverPair = useCollectionHoverPair(id as string);
+  const calledOut = useCollectionHoverTarget(id as string);
   // Hydrated collections derive their preview frames and total duration from
   // live children (like the count), so editing a loaded child refreshes this
   // card without a reload; placeholders fall back to their stored summary.
@@ -894,6 +894,25 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
         </span>
       </CollectionItem.SelectionSurface>
 
+      {/* The call-out for PL9-002, mounted only while this collection's row is
+          hovered. MOUNTING is what restarts the one-shot: moving between
+          folders unmounts one card's overlay and mounts the next card's, so
+          the animation re-fires without a counter or a manual restart, and
+          re-entering the same folder replays it.
+
+          A SIBLING of the selection surface, not a child: the surface is
+          `overflow-hidden` (its preview frames bleed to the edges), and an
+          outward glow drawn inside it would be clipped away to nothing. Out
+          here it also cannot collide with the selected/rejected ring states
+          the card already carries. */}
+      {calledOut && (
+        <span
+          aria-hidden="true"
+          data-collection-called-out
+          className="animate-collection-paired-callout pointer-events-none absolute inset-0 rounded-md"
+        />
+      )}
+
       {/* The drill affordance — a REAL button now that it composes as a
           SIBLING of the selection surface. Centred over the preview area (the
           card minus its label row), sized as a fraction of the card so it
@@ -910,20 +929,11 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
         aria-label={`Open ${displayName}`}
         title="Open this timeline"
         data-collections-keyboard-ignore
-        // Same collection, two places on screen once the children tree is
-        // shown. Hovering here lights up this collection's ROW, and hovering
-        // that row lights this up (`paired`) — see graph-collection-hover.
-        data-collection-paired={hoverPair.paired ? "true" : undefined}
-        onPointerEnter={hoverPair.onPointerEnter}
-        onPointerLeave={hoverPair.onPointerLeave}
         onClick={(event) => {
           event.stopPropagation();
           nav?.openTimeline(id);
         }}
-        className={[
-          "absolute left-1/2 top-[41%] flex aspect-square h-[34%] -translate-x-1/2 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full bg-zinc-950/70 text-sky-200 ring-1 backdrop-blur-[2px] transition-colors hover:bg-zinc-900/85 hover:text-sky-100 hover:ring-sky-300",
-          hoverPair.paired ? "bg-zinc-900/85 text-sky-100 ring-sky-300" : "ring-sky-400/50",
-        ].join(" ")}
+        className="absolute left-1/2 top-[41%] flex aspect-square h-[34%] -translate-x-1/2 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full bg-zinc-950/70 text-sky-200 ring-1 ring-sky-400/50 backdrop-blur-[2px] transition-colors hover:bg-zinc-900/85 hover:text-sky-100 hover:ring-sky-300"
       >
         {/* CornerRightDown — turn and descend, the verb this control performs:
             NAVIGATE into the timeline. The sidebar's FolderTree toggles whether

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -62,6 +62,7 @@ import {
   useTimelineDocuments,
 } from "@storyboard/ui/timeline/timeline-document-store";
 import { createTimelineDocumentsState } from "@storyboard/ui/timeline/timeline-documents";
+import { formatSeconds } from "@storyboard/ui/timeline/utils";
 import type { TimelineClip, TimelineDocument } from "@storyboard/ui/timeline/types";
 
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
@@ -774,6 +775,10 @@ function SeekRailRow({
   const fillRef = useRef<HTMLDivElement>(null);
   const thumbRef = useRef<HTMLDivElement>(null);
   const pointerIdRef = useRef<number | null>(null);
+  const timeRef = useRef<HTMLSpanElement>(null);
+  // Mounted only during a scrub (PL9-003); `scrubbing` is a paint dep so the
+  // imperative writer below picks up the freshly mounted node.
+  const [scrubbing, setScrubbing] = useState(false);
 
   const cells = rowCards.length;
   const pitch = cellWidth + GRID_GAP;
@@ -803,6 +808,15 @@ function SeekRailRow({
       const fraction = Math.min(1, Math.max(0, (map.posAt(clamped).x - offsetX) / extent));
       fill.style.width = `${fraction * 100}%`;
       thumb.style.left = `${fraction * 100}%`;
+      const label = timeRef.current;
+      if (label) {
+        label.textContent = formatSeconds(clamped);
+        label.style.visibility = active ? "" : "hidden";
+        // Clamped into the rail so the readout stays legible at both ends.
+        const half = label.offsetWidth / 2;
+        const x = fraction * rail.clientWidth;
+        label.style.left = `${Math.min(rail.clientWidth - half, Math.max(half, x))}px`;
+      }
       rail.setAttribute("aria-valuenow", (clamped - rowStart).toFixed(1));
       rail.setAttribute(
         "aria-valuetext",
@@ -811,7 +825,7 @@ function SeekRailRow({
     };
     paint();
     return channel.subscribe(paint);
-  }, [channel, map, offsetX, extent, rowStart, rowEnd, isLastRow]);
+  }, [channel, map, offsetX, extent, rowStart, rowEnd, isLastRow, scrubbing]);
 
   const seekToPointer = (event: React.PointerEvent<HTMLDivElement>) => {
     const rail = railRef.current;
@@ -847,16 +861,21 @@ function SeekRailRow({
           // Synthetic pointer without capture support: moves still arrive
           // while the pointer stays over the rail, which tests rely on.
         }
+        setScrubbing(true);
         seekToPointer(event);
       }}
       onPointerMove={(event) => {
         if (event.pointerId === pointerIdRef.current) seekToPointer(event);
       }}
       onPointerUp={(event) => {
-        if (event.pointerId === pointerIdRef.current) pointerIdRef.current = null;
+        if (event.pointerId !== pointerIdRef.current) return;
+        pointerIdRef.current = null;
+        setScrubbing(false);
       }}
       onPointerCancel={(event) => {
-        if (event.pointerId === pointerIdRef.current) pointerIdRef.current = null;
+        if (event.pointerId !== pointerIdRef.current) return;
+        pointerIdRef.current = null;
+        setScrubbing(false);
       }}
       onKeyDown={(event) => {
         if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
@@ -936,6 +955,18 @@ function SeekRailRow({
         aria-hidden="true"
         className="absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.7)] ring-2 ring-zinc-950 transition-transform group-hover:scale-110"
       />
+      {/* Where the playhead is HEADING, at the pointer — the transport's own
+          clock is up in the preview chrome, too far to read mid-drag. Only
+          during a drag: on hover it would follow a playhead nobody is moving.
+          pointer-events-none so it can never take the drag's own pointer. */}
+      {scrubbing && (
+        <span
+          ref={timeRef}
+          data-rail-time
+          aria-hidden="true"
+          className="pointer-events-none absolute bottom-full z-50 mb-1.5 -translate-x-1/2 whitespace-nowrap rounded bg-zinc-900/95 px-1.5 py-0.5 font-mono text-[10px] text-zinc-100 shadow-sm ring-1 ring-zinc-700"
+        />
+      )}
     </div>
   );
 }
@@ -1143,6 +1174,12 @@ export function GraphStripSeekRail({
   const pointerIdRef = useRef<number | null>(null);
   const lastClientXRef = useRef(0);
   const panFrameRef = useRef<number | null>(null);
+  const timeRef = useRef<HTMLSpanElement>(null);
+  // Rendered ONLY while a scrub drag is live (PL9-003). State, not a style
+  // toggle, so the label does not exist to be measured or read the rest of
+  // the time; the paint effect below lists it as a dep so the imperative
+  // writer picks up the freshly mounted node.
+  const [scrubbing, setScrubbing] = useState(false);
 
   const graph = useSyncExternalStore(
     store.subscribe,
@@ -1255,6 +1292,13 @@ export function GraphStripSeekRail({
         windowX >= -overhang &&
         windowX <= outer.clientWidth + overhang;
       thumb.style.visibility = visible ? "" : "hidden";
+      // The scrub readout rides the thumb. Clamped into the rail so it stays
+      // legible at both ends instead of hanging off the timeline.
+      const label = timeRef.current;
+      if (label) {
+        const half = label.offsetWidth / 2;
+        label.style.left = `${Math.min(outer.clientWidth - half, Math.max(half, windowX))}px`;
+      }
     };
     const syncScroll = () => {
       inner.style.transform = `translateX(${-scroller.scrollLeft}px)`;
@@ -1266,6 +1310,7 @@ export function GraphStripSeekRail({
       const clamped = Math.min(end, Math.max(start, time));
       contentX = map.xAt(clamped);
       fill.style.width = `${contentX}px`;
+      if (timeRef.current) timeRef.current.textContent = formatSeconds(clamped);
       placeThumb();
       outer.setAttribute("aria-valuenow", (clamped - start).toFixed(1));
       outer.setAttribute(
@@ -1281,7 +1326,7 @@ export function GraphStripSeekRail({
       unsubscribe();
       scroller.removeEventListener("scroll", syncScroll);
     };
-  }, [channel, map, start, end]);
+  }, [channel, map, start, end, scrubbing]);
 
   const scrollerOf = (): HTMLElement | null =>
     outerRef.current?.parentElement?.querySelector<HTMLElement>("[data-virtual-strip]") ?? null;
@@ -1369,6 +1414,7 @@ export function GraphStripSeekRail({
           // Synthetic pointer without capture support: moves still arrive
           // while the pointer stays over the rail, which tests rely on.
         }
+        setScrubbing(true);
         seekAtClientX(event.clientX);
         startPanLoop();
       }}
@@ -1380,11 +1426,13 @@ export function GraphStripSeekRail({
       onPointerUp={(event) => {
         if (event.pointerId !== pointerIdRef.current) return;
         pointerIdRef.current = null;
+        setScrubbing(false);
         stopPanLoop();
       }}
       onPointerCancel={(event) => {
         if (event.pointerId !== pointerIdRef.current) return;
         pointerIdRef.current = null;
+        setScrubbing(false);
         stopPanLoop();
       }}
       onKeyDown={(event) => {
@@ -1484,6 +1532,16 @@ export function GraphStripSeekRail({
         aria-hidden="true"
         className="absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.7)] ring-2 ring-zinc-950 transition-transform group-hover:scale-110"
       />
+      {/* The scrub readout, twin of the strip rail's — see there for why it
+          exists and why it is drag-only. */}
+      {scrubbing && (
+        <span
+          ref={timeRef}
+          data-rail-time
+          aria-hidden="true"
+          className="pointer-events-none absolute bottom-full z-50 mb-1.5 -translate-x-1/2 whitespace-nowrap rounded bg-zinc-900/95 px-1.5 py-0.5 font-mono text-[10px] text-zinc-100 shadow-sm ring-1 ring-zinc-700"
+        />
+      )}
     </div>
   );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -71,10 +71,32 @@ import { requestGraphPreviewToggle } from "@/lib/graph-view-events";
 import { useGraphDetailsStore } from "./graph-details-context";
 import { GRID_GAP, TIMELINE_PPS } from "./graph-view-config";
 
+/**
+ * Where a live scrub's POINTER is, in the dragged surface's own content
+ * coordinates — published alongside the time, and only while a drag is live.
+ *
+ * It exists because time alone cannot answer "where is the pointer". A
+ * collection with no items occupies width on screen but contributes NO time,
+ * so the whole of that card maps to one instant: `timeAt` returns the same
+ * value across it, and `xAt` of that value can only come back to one edge.
+ * Driven by time, the playhead jumps to the far side while the pointer is
+ * still crossing — right for playback, where there is nothing to play, and
+ * wrong for a drag, where the user is steering a position on screen.
+ *
+ * Scoped by `surfaceId` so only the surface being dragged follows the
+ * pointer; every other playhead (sub-rows, the other layout) stays on the
+ * clock, which is what keeps them in agreement with each other.
+ */
+export type PreviewScrubPosition = Readonly<{ surfaceId: string; x: number }>;
+
 export type PreviewTimeChannel = Readonly<{
   get: () => number;
   set: (time: number) => void;
   subscribe: (listener: () => void) => () => void;
+  /** The live scrub's pointer position, or null when nothing is being
+   *  dragged. Changing it notifies the same listeners `set` does. */
+  getScrub: () => PreviewScrubPosition | null;
+  setScrub: (scrub: PreviewScrubPosition | null) => void;
   /** Play state, held here (above the preview pane's mount) so it survives the
    *  pane toggling off/on and can be driven before the pane exists — that's how
    *  "play turns the preview on and it's already playing" works. */
@@ -86,12 +108,18 @@ export type PreviewTimeChannel = Readonly<{
 export function createPreviewTimeChannel(): PreviewTimeChannel {
   let time = 0;
   let playing = false;
+  let scrub: PreviewScrubPosition | null = null;
   const listeners = new Set<() => void>();
   const playListeners = new Set<() => void>();
   return {
     get: () => time,
     set: (next) => {
       time = next;
+      for (const listener of listeners) listener();
+    },
+    getScrub: () => scrub,
+    setScrub: (next) => {
+      scrub = next;
       for (const listener of listeners) listener();
     },
     subscribe: (listener) => {
@@ -301,17 +329,22 @@ export function GraphPlayhead({
       );
       return true;
     };
-    // Position-only style write, for the current clock time.
+    // Position-only style write, for the current clock time — or, while this
+    // surface is being scrubbed, for the POINTER (see PreviewScrubPosition:
+    // an empty collection is width with no time, so time alone cannot say
+    // where the pointer is inside it).
     const paint = () => {
       const line = lineRef.current;
       if (!line || !map) return;
+      const scrub = channel.getScrub();
+      const scrubX = scrub && scrub.surfaceId === focusedId ? scrub.x : null;
       const time = channel.get();
       // 40ms of slack so the marker doesn't blink off at the exact seam
       // between two adjacent collections.
       const inside =
         !activeWindow || (time >= activeWindow.start - 0.04 && time <= activeWindow.end + 0.04);
       line.style.display = inside ? "" : "none";
-      if (inside) line.style.transform = `translateX(${map.xAt(time)}px)`;
+      if (inside) line.style.transform = `translateX(${scrubX ?? map.xAt(time)}px)`;
     };
     // The clock moved: always reposition, cheaply picking up any pending
     // geometry change on the way (the rebuild is a no-op when nothing changed).
@@ -1308,7 +1341,12 @@ export function GraphStripSeekRail({
       const time = channel.get();
       thumb.dataset.active = String(time >= start && time <= end);
       const clamped = Math.min(end, Math.max(start, time));
-      contentX = map.xAt(clamped);
+      // Same rule as the playhead line: while THIS surface is being scrubbed
+      // the head rides the pointer, so thumb, line and cursor stay together
+      // across a collection that has width but no time.
+      const scrub = channel.getScrub();
+      contentX =
+        scrub && scrub.surfaceId === focusedId ? scrub.x : map.xAt(clamped);
       fill.style.width = `${contentX}px`;
       if (timeRef.current) timeRef.current.textContent = formatSeconds(clamped);
       placeThumb();
@@ -1326,7 +1364,7 @@ export function GraphStripSeekRail({
       unsubscribe();
       scroller.removeEventListener("scroll", syncScroll);
     };
-  }, [channel, map, start, end, scrubbing]);
+  }, [channel, map, start, end, scrubbing, focusedId]);
 
   const scrollerOf = (): HTMLElement | null =>
     outerRef.current?.parentElement?.querySelector<HTMLElement>("[data-virtual-strip]") ?? null;
@@ -1336,7 +1374,12 @@ export function GraphStripSeekRail({
     if (!scroller || !geometry) return;
     const rect = scroller.getBoundingClientRect();
     const contentX = clientX - rect.left - geometry.padLeft + scroller.scrollLeft;
-    channel.set(map.timeAt(Math.min(extent, Math.max(0, contentX))));
+    const clamped = Math.min(extent, Math.max(0, contentX));
+    // Position FIRST, then time: both notify the same listeners, and a
+    // playhead that read the new time against a stale scrub x would paint one
+    // frame in the wrong place at the start of every drag.
+    channel.setScrub({ surfaceId: focusedId, x: clamped });
+    channel.set(map.timeAt(clamped));
   };
 
   const stopPanLoop = () => {
@@ -1427,12 +1470,14 @@ export function GraphStripSeekRail({
         if (event.pointerId !== pointerIdRef.current) return;
         pointerIdRef.current = null;
         setScrubbing(false);
+        channel.setScrub(null);
         stopPanLoop();
       }}
       onPointerCancel={(event) => {
         if (event.pointerId !== pointerIdRef.current) return;
         pointerIdRef.current = null;
         setScrubbing(false);
+        channel.setScrub(null);
         stopPanLoop();
       }}
       onKeyDown={(event) => {

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -15,7 +15,7 @@ import {
 
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 
-import { useCollectionHoverPair } from "./graph-collection-hover";
+import { useCollectionHoverSource } from "./graph-collection-hover";
 import { useClipDetail, useGraphDetailsStore, useTimelineTitle } from "./graph-details-context";
 import {
   VideoFrameLookAhead,
@@ -140,7 +140,7 @@ function SubTimelineNode({
   );
   const name = useTimelineTitle(id) ?? nodeName;
   const rename = useInlineRename(collectionId, name, "sub-row");
-  const hoverPair = useCollectionHoverPair(collectionId as string);
+  const hoverSource = useCollectionHoverSource(collectionId as string);
   const detail = useClipDetail(id);
   const hydrated = detail?.hydrated === true;
   // ENABLED children only — this row says what the timeline contributes, so
@@ -182,21 +182,29 @@ function SubTimelineNode({
       className="min-w-0 rounded-lg border border-zinc-800/70 bg-zinc-900/40 p-3"
     >
       <div className="mb-1.5 flex items-center gap-2">
+        {/* Tree elbow. Nesting is otherwise carried only by the panels'
+            indentation, which reads as "inset boxes" rather than "branches";
+            the corner in front of the folder names the relationship. Drawn
+            with borders on an empty box rather than as a glyph so it lines up
+            with the folder's optical centre at any font size, and given a
+            fixed width so the header's other columns — name, badges, and the
+            preview frames' shared right-hand column — do not move. */}
+        <span
+          aria-hidden="true"
+          data-subtimeline-elbow
+          className="-mr-0.5 -mt-2 h-2.5 w-2 shrink-0 rounded-bl-[3px] border-b border-l border-zinc-700"
+        />
         <button
           type="button"
           aria-label={expanded ? "Collapse" : "Expand"}
           aria-expanded={expanded}
           onClick={toggle}
-          // The other half of the card↔row pairing: hovering this folder
-          // lights up the same collection's card icon in the surface above,
-          // and `paired` is this end lighting up when the card is hovered.
-          data-collection-paired={hoverPair.paired ? "true" : undefined}
-          onPointerEnter={hoverPair.onPointerEnter}
-          onPointerLeave={hoverPair.onPointerLeave}
-          className={[
-            "flex h-5 w-5 shrink-0 items-center justify-center rounded transition-colors hover:bg-zinc-800 hover:text-sky-300",
-            hoverPair.paired ? "bg-zinc-800 text-sky-300" : "text-sky-400",
-          ].join(" ")}
+          // Hovering this folder calls out the same collection's CARD in the
+          // surface above (graph-collection-hover). One direction only: the
+          // card does not reach back down here.
+          onPointerEnter={hoverSource.onPointerEnter}
+          onPointerLeave={hoverSource.onPointerLeave}
+          className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-sky-400 transition-colors hover:bg-zinc-800 hover:text-sky-300"
         >
           {expanded ? (
             <FolderOpen aria-hidden="true" className="h-4 w-4" />

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-config.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-config.ts
@@ -101,10 +101,13 @@ export function stepDownItemSize(size: ItemSize): ItemSize {
  */
 export const GRID_UNCAPPED_HEIGHT = 100_000;
 /** Sub-graph tree: left indent of a row's body (strip + nested rows) so the
- *  strip lines up with the LABEL, past the folder icon. Matches the header's
- *  folder button (h-5 = 20px) + gap-2 (8px). Applied structurally per level,
- *  so nesting accumulates it. */
-export const SUBTIMELINE_INDENT_PX = 28;
+ *  strip lines up with the LABEL, past everything before it in the header.
+ *  Sums the header's own leading run: the tree elbow (w-2 = 8px, pulled 2px
+ *  closer by -mr-0.5) + gap-2 (8px) + the folder button (h-5 = 20px) + gap-2
+ *  (8px) = 42. Applied structurally per level, so nesting accumulates it.
+ *  KEEP IN STEP with that row header — an e2e pins the strip's left edge to
+ *  the label's, which is what catches it when they drift. */
+export const SUBTIMELINE_INDENT_PX = 42;
 /** Stop RECURSING past this depth (render the row, omit its nested children) —
  *  defensive insurance against pathological data; the graph is otherwise a
  *  single-parent tree for navigable collections. */

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -3656,6 +3656,64 @@ test.describe("graph view E2E", () => {
     await expect(trail.getByRole("link", { name: TITLES[0] })).toBeVisible();
   });
 
+  test("scrubbing across an empty collection keeps the playhead under the pointer", async ({
+    page,
+  }) => {
+    // PL9-005. An empty collection is WIDTH with no TIME, so every x across it
+    // maps to one instant — and a playhead driven by that instant can only
+    // paint at one edge while the pointer crosses the rest.
+    const api = await installGraphApi(page);
+    const EMPTY_ID = "timeline-e2e-empty";
+    api.documents.get(PROJECT_ID)!.clips.push(
+      collectionClip("clip-empty", EMPTY_ID, 9, "Nothing Here", 0),
+      // Trailing content so the empty card is not the LAST thing in the
+      // strip: parked at the timeline's end it sits in the rail's edge
+      // auto-pan zone, and the content sliding under a stationary pointer
+      // moves the line's viewport x backwards — the pan working correctly,
+      // but indistinguishable here from the bug under test.
+      mediaClip("tail-1", "image", 10, 4),
+      mediaClip("tail-2", "image", 11, 4),
+    );
+    api.documents.set(EMPTY_ID, { id: EMPTY_ID, title: "Nothing Here", clips: [] });
+    await openGraph(page);
+    await previewToggle(page).click();
+
+    const emptyCard = strip(page, PROJECT_ID).locator(`[data-node-id="${EMPTY_ID}"]`);
+    await emptyCard.scrollIntoViewIfNeeded();
+    await expect(emptyCard).toBeVisible();
+    // Centre it, so neither end of the crossing lands in the pan zone.
+    await strip(page, PROJECT_ID).evaluate((el, id) => {
+      const card = el.querySelector(`[data-node-id="${id}"]`) as HTMLElement | null;
+      if (card) el.scrollLeft += card.getBoundingClientRect().left
+        - el.getBoundingClientRect().left
+        - (el.clientWidth - card.getBoundingClientRect().width) / 2;
+    }, EMPTY_ID);
+    const card = (await emptyCard.boundingBox())!;
+    const rail = page.getByRole("slider", { name: "Seek preview" }).first();
+    const railBox = (await rail.boundingBox())!;
+    const line = page.locator("[data-graph-playhead]").first();
+    const y = railBox.y + railBox.height / 2;
+
+    // Press at the empty card's left edge, then walk across it.
+    await page.mouse.move(card.x + 2, y);
+    await page.mouse.down();
+    const samples: number[] = [];
+    for (const fraction of [0.25, 0.5, 0.75, 0.95]) {
+      await page.mouse.move(card.x + card.width * fraction, y, { steps: 4 });
+      const lineBox = (await line.boundingBox())!;
+      samples.push(lineBox.x);
+    }
+    await page.mouse.up();
+
+    // The line tracked the pointer across the card instead of pinning to one
+    // edge: each sample is further right than the last, and the last one is
+    // near the card's far side rather than back at its start.
+    for (let i = 1; i < samples.length; i++) {
+      expect(samples[i]).toBeGreaterThan(samples[i - 1]);
+    }
+    expect(samples[samples.length - 1]).toBeGreaterThan(card.x + card.width * 0.6);
+  });
+
   test("a scrub drag shows the timestamp at the playhead, and only then", async ({ page }) => {
     // PL9-003. The transport's clock is up in the preview chrome; mid-drag the
     // number has to be where the pointer is.

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -577,6 +577,21 @@ test.describe("graph view E2E", () => {
     await expect
       .poll(() => stripOrder(page, GRANDCHILD_ID), { timeout: 15000 })
       .toEqual(["g1"]);
+
+    // PL9-006: every row leads with a tree elbow, at every depth — and it
+    // takes width, so the thing to guard is that the preview frames still
+    // land on ONE vertical line across depths (the column the nested panels'
+    // negative right inset exists to keep straight).
+    for (const label of ["Scene A", "Scene B"]) {
+      await expect(
+        page.locator(`section[aria-label="Sub-timeline: ${label}"] [data-subtimeline-elbow]`).first(),
+      ).toBeVisible();
+    }
+    const thumbRights = await page
+      .locator("[data-subtimeline-thumbs]")
+      .evaluateAll((els) => els.map((el) => Math.round(el.getBoundingClientRect().right)));
+    expect(thumbRights.length).toBeGreaterThan(1);
+    expect(new Set(thumbRights).size).toBe(1);
   });
 
   test("a collection id containing a comma is one row, not two broken ones", async ({ page }) => {
@@ -3641,48 +3656,88 @@ test.describe("graph view E2E", () => {
     await expect(trail.getByRole("link", { name: TITLES[0] })).toBeVisible();
   });
 
-  test("a collection's card icon and its child-timeline row highlight together", async ({
-    page,
-  }) => {
-    // PL8-012. With the tree shown a collection is on screen twice, and
-    // nothing said the two were the same thing.
+  test("a scrub drag shows the timestamp at the playhead, and only then", async ({ page }) => {
+    // PL9-003. The transport's clock is up in the preview chrome; mid-drag the
+    // number has to be where the pointer is.
+    await installGraphApi(page);
+    await openGraph(page);
+    await previewToggle(page).click();
+    const rail = page.getByRole("slider", { name: "Seek preview" }).first();
+    await expect(rail).toBeVisible();
+    const readout = page.locator("[data-rail-time]");
+
+    // Not on hover, and not while parked.
+    await rail.hover();
+    await expect(readout).toHaveCount(0);
+
+    const box = (await rail.boundingBox())!;
+    await page.mouse.move(box.x + box.width * 0.25, box.y + box.height / 2);
+    await page.mouse.down();
+    await expect(readout).toHaveCount(1);
+    const atQuarter = await readout.textContent();
+    expect(atQuarter).toMatch(/^\d+(\.\d+)?s$/);
+
+    // It tracks the drag: further along the rail reads a later time.
+    await page.mouse.move(box.x + box.width * 0.75, box.y + box.height / 2, { steps: 8 });
+    await expect
+      .poll(async () => Number.parseFloat((await readout.textContent()) ?? "0"))
+      .toBeGreaterThan(Number.parseFloat(atQuarter ?? "0"));
+
+    // It rides WITH the thumb rather than sitting in a fixed corner.
+    const thumbBox = (await page.locator("[data-rail-thumb]").first().boundingBox())!;
+    const readoutBox = (await readout.boundingBox())!;
+    expect(Math.abs(readoutBox.x + readoutBox.width / 2 - (thumbBox.x + thumbBox.width / 2)))
+      .toBeLessThan(40);
+
+    // Gone on release.
+    await page.mouse.up();
+    await expect(readout).toHaveCount(0);
+  });
+
+  test("hovering a child row's folder calls out its collection card", async ({ page }) => {
+    // PL9-002, revising PL8-012: ONE direction now, and the card is called out
+    // by an animation rather than its icon changing.
     await installGraphApi(page);
     await openGraph(page); // children timelines on
-    // The drill button is a SIBLING of the card's selection surface, not a
-    // child of it — `[data-node-id]` is the surface itself, so scoping to the
-    // card finds nothing.
     const cardIcon = page.getByRole("button", { name: "Open Scene A" }).first();
     const rowFolder = page
       .locator('section[aria-label="Sub-timeline: Scene A"]')
       .getByRole("button", { name: "Expand" })
       .first();
-    const paired = page.locator('[data-collection-paired="true"]');
+    const calledOut = page.locator("[data-collection-called-out]");
 
-    await expect(paired).toHaveCount(0);
+    await expect(calledOut).toHaveCount(0);
 
-    // Card → row.
-    await cardIcon.hover();
-    await expect(rowFolder).toHaveAttribute("data-collection-paired", "true");
-    // Exactly the pair: the hovered element and its twin, nothing else.
-    await expect(paired).toHaveCount(2);
-
-    await page.mouse.move(0, 0);
-    await expect(paired).toHaveCount(0);
-
-    // Row → card.
+    // Row folder → the matching card, and only that one.
     await rowFolder.hover();
-    await expect(cardIcon).toHaveAttribute("data-collection-paired", "true");
-    await expect(paired).toHaveCount(2);
+    await expect(calledOut).toHaveCount(1);
+    const inCard = await calledOut.evaluate((el) =>
+      el.closest("[data-node-wrapper]")?.querySelector("[data-node-id]")?.getAttribute("data-node-id"),
+    );
+    expect(inCard).toBe(CHILD_ID);
 
+    // The call-out is drawn, not laid out: the card's box is untouched.
+    const cardBefore = (await strip(page, PROJECT_ID)
+      .locator(`[data-node-id="${CHILD_ID}"]`)
+      .boundingBox())!;
     await page.mouse.move(0, 0);
-    await expect(paired).toHaveCount(0);
+    await expect(calledOut).toHaveCount(0);
+    const cardAfter = (await strip(page, PROJECT_ID)
+      .locator(`[data-node-id="${CHILD_ID}"]`)
+      .boundingBox())!;
+    expect(cardAfter.x).toBeCloseTo(cardBefore.x, 0);
+    expect(cardAfter.width).toBeCloseTo(cardBefore.width, 0);
 
-    // With the tree hidden there is no row to pair with, so hovering the card
-    // highlights nothing.
+    // The reverse direction is GONE: hovering the card touches nothing.
+    await cardIcon.hover();
+    await expect(calledOut).toHaveCount(0);
+    await expect(rowFolder).not.toHaveAttribute("data-collection-paired", "true");
+
+    // And with the tree hidden there is no row to hover from at all.
+    await page.mouse.move(0, 0);
     await page.getByRole("button", { name: "Hide children timelines" }).click();
     await expect(page.locator('section[aria-label^="Sub-timeline"]')).toHaveCount(0);
-    await cardIcon.hover();
-    await expect(paired).toHaveCount(0);
+    await expect(calledOut).toHaveCount(0);
   });
 
   test("clicking away anywhere that is not a control clears the selection", async ({

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -858,8 +858,14 @@ export function WorkbenchDisplaySurface({
   return (
     <section
       aria-label="Workbench display surface"
+      // BORDERLESS. The rounded corners, the near-black fill, and the shadow
+      // already separate the preview from the page; the outline on top read as
+      // a frame around a frame. Nothing else may move as it goes: the section's
+      // own box is what the split pane sizes and what
+      // `--workbench-preview-offset` is built from, so dropping the border
+      // only gives the canvas inside its 1px back.
       className={cn(
-        "relative flex min-h-0 flex-col overflow-visible rounded-lg border border-zinc-800 bg-zinc-950 shadow-2xl",
+        "relative flex min-h-0 flex-col overflow-visible rounded-lg bg-zinc-950 shadow-2xl",
         className,
       )}
       data-testid="workbench-display-surface"
@@ -910,7 +916,7 @@ export function WorkbenchDisplaySurface({
           <button
             type="button"
             onClick={onClose}
-            className="absolute right-4 top-4 z-10 grid size-7 place-items-center rounded-full border border-zinc-800 bg-zinc-900/80 text-zinc-400 backdrop-blur-sm transition-colors hover:border-zinc-600 hover:text-zinc-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-400 focus-visible:outline-offset-2"
+            className="absolute right-4 top-2 z-10 grid size-7 place-items-center rounded-full border border-zinc-800 bg-zinc-900/80 text-zinc-400 backdrop-blur-sm transition-colors hover:border-zinc-600 hover:text-zinc-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-400 focus-visible:outline-offset-2"
             aria-label="Close preview"
             title="Close preview"
             data-testid="workbench-preview-close"

--- a/punch-list/PUNCH-LIST-09.md
+++ b/punch-list/PUNCH-LIST-09.md
@@ -163,7 +163,7 @@ Acceptance criteria:
 
 ## PL9-005 — Scrubbing across an empty collection loses the cursor
 
-- Status: Open
+- Status: STRIP done; GRID rails still to do
 - URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
 - Area: Seek rails and playhead (`graph-playhead-model.ts`,
   `graph-preview.tsx`)
@@ -184,6 +184,17 @@ pointer is. While a scrub drag is live the line wants to follow the POINTER
 directly, emitting whatever time that x maps to, and hand back to the
 time-driven position on release. Confirm the empty-collection span really is
 zero-width in time before building on that.
+
+DONE (strip): the channel now carries a scrub POSITION beside the time —
+`PreviewScrubPosition`, scoped by surface id — and the strip's playhead line
+and rail thumb both ride it while that surface is being dragged. Proven
+fail-first: without it the line does not move AT ALL across an empty card
+(824.33 → 824.33 over the whole crossing).
+
+NOT DONE (grid): `buildGridPlayheadMap.posAt` collapses a zero-duration cell
+the same way, so the grid's rails need the same treatment. It needs a `y` on
+the scrub payload (a grid position is a row as well as an offset) and the
+grid rail computing both in grid content coordinates.
 
 Acceptance criteria:
 

--- a/punch-list/PUNCH-LIST-09.md
+++ b/punch-list/PUNCH-LIST-09.md
@@ -1,0 +1,244 @@
+# Punch List 09
+
+## PL9-001 — Trailing "add a collection" placeholder in every strip and grid
+
+- Status: Open
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: Strip and grid surfaces — trailing add affordance
+- Screenshot: Not captured
+
+Adding a nested timeline today means reaching for the sidebar's collection
+tool. Every strip and grid should end with a placeholder slot that adds one
+in place, at the end of that surface.
+
+Read as a new COLLECTION (nested timeline) — the same thing the sidebar's
+collection tool mints, which is the only insert tool there is. Say if you
+meant a generic "any item" slot.
+
+Reference: `requestGraphToolInsert("collection")` →
+`SidebarToolInsertBridge` / `useToolInsertion` is the existing mint-and-
+insert path; the sidebar routes through `resolveInsertPlacement`, which is
+selection-aware. A trailing placeholder means "append HERE" and should not
+inherit that placement rule.
+
+Acceptance criteria:
+
+- Every strip and every grid ends with a placeholder slot, after the last
+  card — the focused surface and each rendered sub-timeline surface alike.
+- Activating it appends a new collection to THAT surface's collection,
+  regardless of what is selected elsewhere.
+- The new timeline lands as an ordinary undoable commit, and persists like
+  any other insert.
+- The placeholder is not an item: it must not be counted by the strip/grid
+  boundary math, the playhead or ruler models, the header aggregate,
+  keyboard roving, or selection.
+- Dropping a card or a file at the end of the surface still lands after the
+  last real card — the placeholder must not absorb or displace the drop.
+- It is keyboard reachable and labelled, and reads as an affordance rather
+  than as a card.
+- An EMPTY collection shows it alongside (or in place of) the existing
+  "Drop items here" hint, without the two fighting for the same pixels.
+- It scrolls with the content — in a virtualized strip that means it sits
+  after the last card at the true content end, not pinned to the viewport.
+
+## PL9-002 — Pair highlight becomes one-way, onto the card's border
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `graph-collection-hover.tsx`, collection card, sub-timeline row
+  (revises PL8-012)
+- Screenshot: Not captured
+
+PL8-012 made the pairing bidirectional and lit the card's drill ICON. Narrow
+it to one direction and move the highlight:
+
+- Hovering a child timeline's FOLDER calls out the matching collection card
+  with a brief ANIMATION, not a static border or icon change.
+- Hovering the collection card no longer highlights the child's folder. That
+  direction goes away entirely.
+
+Proposed animation (confirm or redirect): a one-shot attention pulse on
+hover-enter — a glow that rises and falls over ~250ms — then the card rests.
+A one-shot says "this one" and gets out of the way; a looped pulse would sit
+there throbbing for as long as the pointer rests on a folder, which in a tree
+of many rows is most of the time.
+
+Reference: `useCollectionHoverPair` currently drives `data-collection-paired`
+on both the card's drill button (`graph-item-content.tsx`) and the row's
+folder toggle (`graph-sub-timelines.tsx`). The e2e "a collection's card icon
+and its child-timeline row highlight together" asserts the old two-way
+behaviour and needs rewriting, not deleting.
+
+Acceptance criteria:
+
+- Hovering a sub-timeline row's folder animates that collection's card; the
+  card's icon is unchanged.
+- Hovering a collection card (icon or body) does nothing to the tree.
+- Only the matching card animates — siblings, nested rows, and other
+  expanded rows are unaffected.
+- Moving between folders re-fires cleanly: the previous card's animation
+  ends and the new one plays, with no pile-up when moving quickly.
+- Nothing is left mid-animation if the card unmounts, scrolls out of a
+  virtualized surface, or the row collapses mid-hover.
+- Still only while child timelines are enabled.
+- No layout shift and no disturbance to neighbours: the effect is drawn
+  outside the box (glow/ring/shadow), not by changing size or spacing.
+- Reduced motion is respected — the connection still reads without the
+  animation. NOTE: `motion-safe:` cannot prefix a hand-rolled keyframe
+  class; use a `prefers-reduced-motion` media block, as the sidebar trash
+  pulse had to.
+- Element OPACITY is not the vehicle: it made the sidebar trash target
+  translucent and let what was behind it bleed through. Animate the glow.
+- It stays a hover affordance: selection, drag, drill and expand are all
+  untouched, and the card's selected/rejected states still read clearly
+  while it plays.
+
+## PL9-003 — Timestamp tooltip while the playhead is being dragged
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: Seek rails / playhead (`graph-preview.tsx`)
+- Screenshot: Not captured
+
+Dragging the playhead gives no readout of where it is going. Show the
+timestamp in a tooltip that follows it, only for the duration of the drag.
+
+Note on what "the playhead" means here: the red line is PASSIVE — R7 settled
+that scrubbing is done by dragging the seek rail's thumb, which is what moves
+the line. So this is the rail drag: `GraphStripSeekRail` in the strip and
+`GraphSeekRails` in the grid. The divider transport already shows the current
+time, but it is up in the preview chrome, far from the pointer.
+
+Assumed pointer-only, per "actively being dragged" — keyboard seeking (the
+rail is a `role="slider"` with arrow/Home/End) does not raise it. Its
+`aria-valuenow` already speaks the position. Say if you want it there too.
+
+Acceptance criteria:
+
+- Pressing and dragging a seek rail shows a tooltip with the timestamp at
+  the playhead, updating live as it moves.
+- It appears on drag start and disappears on release, on cancel, and if the
+  pointer leaves the window mid-drag — never left behind.
+- It does not show on hover alone, on a parked rail, or during playback.
+- The format matches the transport's existing readout, so one clock is not
+  spelled two ways.
+- It tracks the thumb through the strip's edge auto-pan, and stays legible
+  and on-screen at both ends of the timeline rather than clipping.
+- Both surfaces: the strip's rail and the grid's per-row rails, including
+  a drag that crosses from one grid row into the next.
+- Purely presentational — it must not intercept pointer events, disturb the
+  drag, or change the scrub math.
+- It does not shift layout or reflow the strip as it appears.
+
+## PL9-004 — Drop the preview's border, raise its close button
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `workbench-display-surface.tsx` — preview surface and close button
+  (revises PL8-007)
+- Screenshot: Not captured
+
+Two tweaks to the preview:
+
+(a) Remove the border around the preview area. Today the surface carries
+`border border-zinc-800` alongside `rounded-lg bg-zinc-950 shadow-2xl`.
+
+(b) The close button sits slightly too low. PL8-007 moved it to
+`right-4 top-4`; raise it, keeping the right inset.
+
+Acceptance criteria:
+
+- No border is drawn around the preview surface.
+- Removing it changes no geometry: the border is 1px on each side, so the
+  canvas must not grow into it or the preview height, the divider's box, and
+  `--workbench-preview-offset` all shift by a pixel or two.
+- The rounded corners and the surface's own background still read as a
+  distinct area against the page.
+- The close button is visibly higher, still clear of the top edge and of the
+  letterboxed frame beneath it.
+- Its hit target, focus ring, and hover treatment are unchanged.
+- The e2e that asserts the surface's `borderBottomWidth` is `0px` (it checks
+  the divider sits flush) still holds, and any story or e2e that reads the
+  surface's border is re-synced.
+
+## PL9-005 — Scrubbing across an empty collection loses the cursor
+
+- Status: Open
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: Seek rails and playhead (`graph-playhead-model.ts`,
+  `graph-preview.tsx`)
+- Screenshot: Not captured
+
+An empty collection occupies WIDTH on screen but contributes no TIME, so
+dragging the playhead across it makes the line jump ahead to the next card
+while the pointer is still crossing the empty one. Pointer and playhead come
+apart, and the drag stops feeling connected to anything.
+
+Skipping is right during PLAYBACK — there is nothing there to play. It is
+wrong while scrubbing, where the user is steering a position on screen.
+
+Likely shape: `buildPlayheadMap` is a piecewise time↔x map, and the playhead
+paints from `xAt(time)`. A zero-duration span means many x values share one
+time, so the round trip x → `timeAt` → `xAt` cannot come back to where the
+pointer is. While a scrub drag is live the line wants to follow the POINTER
+directly, emitting whatever time that x maps to, and hand back to the
+time-driven position on release. Confirm the empty-collection span really is
+zero-width in time before building on that.
+
+Acceptance criteria:
+
+- While dragging, the playhead stays under the pointer for the whole width
+  of an empty collection — it slides across rather than jumping past it.
+- The time it reports while crossing is still the honest one (the empty
+  collection adds no playable time); only the LINE's position is pointer-led.
+- On release the playhead sits where the pointer left it, and the normal
+  time-driven position takes over again without a visible snap.
+- PLAYBACK is unchanged: an empty collection is still skipped as it plays.
+- Several empty collections in a row, and an empty collection at the very
+  start or end of a timeline, all behave the same way.
+- A collection that is merely un-hydrated is not treated as empty — it has
+  a stored duration and must keep it.
+- Strip and grid rails alike, including a grid drag crossing rows.
+- The ruler, the rail's fill and thumb, and the playhead line stay in
+  agreement throughout the drag.
+
+## PL9-006 — Tree-node mark to the left of each child row's folder
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `graph-sub-timelines.tsx` — `SubTimelineNode` row header
+- Screenshot: Not captured
+
+Child timeline rows lead with a folder icon. Keep it, and add a small
+decorative mark to its LEFT so the row reads as a node in a tree rather than
+as a free-standing panel.
+
+Proposed (confirm or redirect): a single elbow connector — the `└─` corner —
+sized to the row header and drawn in a muted zinc, immediately before the
+folder button. The bigger alternative is a full tree spine: vertical rules
+running down through each ancestor level, with the elbow branching off the
+last one. That reads more like a real tree, but it has to know whether each
+row is its parent's LAST child and has to line up across panel borders, so
+it is a different-sized job. Starting with the elbow.
+
+Reference: rows nest recursively through `SubTimelineNode` (`depth` prop),
+and nesting is currently expressed by panel indentation
+(`SUBTIMELINE_INDENT_PX` / `SUBTIMELINE_PANEL_RIGHT_INSET_PX`), not by any
+connector. The row header is a flex line: folder button, name, clip count,
+status badge, spacer, preview frames.
+
+Acceptance criteria:
+
+- Every child timeline row shows the mark immediately left of its folder
+  icon, at every nesting depth.
+- The folder icon itself is unchanged — same glyph, same open/closed states,
+  same expand/collapse behaviour and hit target.
+- The mark is decorative: `aria-hidden`, not focusable, and it does not
+  become part of the row's accessible name.
+- It does not disturb the header's layout — the name, badges, and the
+  preview frames keep their positions and the frames stay aligned in their
+  column across depths.
+- It is muted enough to read as structure, not as another control competing
+  with the folder.
+- It shares its visual language with the "No child timelines" empty state's
+  tree icon (PL8-010), so the two do not look like different systems.


### PR DESCRIPTION
Tracked in [punch-list/PUNCH-LIST-09.md](punch-list/PUNCH-LIST-09.md).

| Item | Status |
| --- | --- |
| PL9-002 Pair call-out becomes one-way, as an animation | Done |
| PL9-003 Timestamp readout during a scrub drag | Done |
| PL9-004 Preview border off, close button raised | Done |
| PL9-006 Tree elbow before each child row's folder | Done |
| PL9-005 Playhead under the pointer over an empty collection | **Strip done, grid not** |
| PL9-001 Trailing add-collection placeholder | **Not started** |

### PL9-005 — the diagnosis held up

`buildPlayheadMap` records `startTime === endTime` for an empty collection, so `timeAt` returns one value across the card's whole width and `xAt` of that value can only come back to one edge. The channel now carries a scrub **position** beside the time, scoped by surface id, and the strip's line and thumb ride it while that surface is dragged.

Proven fail-first: without it the line does not move **at all** across the card — 824.33 → 824.33 over the whole crossing.

**The grid half is not done.** `buildGridPlayheadMap.posAt` collapses a zero-duration cell the same way; fixing it needs a `y` on the scrub payload, since a grid position is a row as well as an offset.

### PL9-002 — what made the one-shot work

**Mounting** the overlay is what restarts the animation: moving between folders unmounts one card's and mounts the next's, so it re-fires with no counter and no manual restart. The overlay is a **sibling** of the selection surface — that surface is `overflow-hidden` for its preview frames, and an outward glow drawn inside it would be clipped to nothing.

### PL9-006 — the knock-on worth knowing

The elbow takes 14px of the row header's leading run, and `SUBTIMELINE_INDENT_PX` exists to line each row's strip up with its label. Resynced 28 → 42, with the constant now spelling out the run it sums. The e2e pinning strip-left to label-left is what caught it.

### Verification

- graph-view e2e 83/84 — the one failure passes in isolation, and a different test failed on each full run: the suite's documented load flake
- app vitest 442/442, unit 408/408, stories 165/165
- tsc clean both packages; lint clean (4 pre-existing `img` warnings)
- PL9-002 also confirmed live: leaving unmounts the overlay, re-entering re-fires (`running @100ms`), and mid-flight the glow is a real unclipped sky shadow

🤖 Generated with [Claude Code](https://claude.com/claude-code)