### PR TITLE
Finish punch list 09

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-add-collection-slot.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-add-collection-slot.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { FolderPlus } from "lucide-react";
+
+import { getChildren, parseNodeId, useCollectionsSelector } from "@storyboard/ui/dnd-collections";
+
+import { useAppendCollection } from "./graph-native-drop";
+
+/**
+ * The trailing "add a timeline here" slot, at the end of a strip or grid.
+ *
+ * Adding a nested timeline used to mean reaching for the sidebar's collection
+ * tool, which lands next to the SELECTION — fine when you are working on a
+ * card, wrong when what you want is "one more, at the end of this timeline".
+ * This appends to the surface it sits in, whatever is selected elsewhere.
+ *
+ * Deliberately not a card: dashed, muted, and no drag, selection or trim
+ * behaviour. The surfaces render it past their own content extent, so it is
+ * not an item to any of the index math either (see `trailingSlot`).
+ */
+export function AddCollectionSlot({
+  collectionId,
+}: Readonly<{ collectionId: string }>) {
+  const append = useAppendCollection(collectionId);
+  // Append means "after the last child", and the count is the index. Read
+  // live so a drop or an undo elsewhere cannot leave this pointing at a
+  // stale position.
+  const childCount = useCollectionsSelector(
+    (snapshot) => getChildren(snapshot.graph, parseNodeId(collectionId)).length,
+  );
+
+  return (
+    <button
+      type="button"
+      data-add-collection-slot={collectionId}
+      aria-label="Add a timeline to the end"
+      title="Add a timeline here"
+      onClick={() => append(childCount)}
+      className="flex h-full w-full flex-col items-center justify-center gap-1 rounded-md border border-dashed border-zinc-700 bg-zinc-900/30 text-zinc-500 transition-colors hover:border-sky-500/60 hover:bg-sky-500/[0.06] hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70"
+    >
+      <FolderPlus aria-hidden="true" className="h-4 w-4" />
+      <span className="text-[10px] font-medium">Add timeline</span>
+    </button>
+  );
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -46,6 +46,7 @@ import {
   useSelectionAggregate,
   type PreviewTimeChannel,
 } from "./graph-preview";
+import { AddCollectionSlot } from "./graph-add-collection-slot";
 import { CollectionHoverProvider } from "./graph-collection-hover";
 import { SubTimelines } from "./graph-sub-timelines";
 import {
@@ -495,6 +496,10 @@ export function GraphBoard({
                 overscan={GRAPH_STRIP_OVERSCAN_ITEMS}
                 itemWidth={collectionCardWidth(deferredPixelsPerSecond, dims.strip)}
                 itemHeight={dims.strip}
+                // "One more, at the end of THIS timeline" — the sidebar tool
+                // lands next to the selection, which is a different intent.
+                // Flat mode has no single parent to append to, so no slot.
+                trailingSlot={flatOn ? undefined : <AddCollectionSlot collectionId={focusedId} />}
                 itemDragActivation="hold"
                 overlay={
                   previewOn || rulerOn ? (
@@ -566,6 +571,7 @@ export function GraphBoard({
                   // drag. "body" (the default) drags instantly, which ate the
                   // drill click and made drags ambiguous.
                   itemDragActivation="hold"
+                  trailingSlot={<AddCollectionSlot collectionId={focusedId} />}
                   overlay={
                     previewOn ? (
                       <GraphGridPlayhead

--- a/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
@@ -265,6 +265,22 @@ function useToolInsertion(collectionId: string) {
   return { addNodes, insertTool };
 }
 
+/**
+ * Append a fresh nested timeline to `collectionId`, at the index the caller
+ * names. The trailing add slot's route in — the same mint-and-insert the
+ * sidebar tool and the native tool drop use, so a timeline added this way is
+ * indistinguishable from one added any other way (undo, persistence, the
+ * pending-detail bookkeeping all come along).
+ *
+ * Deliberately NOT routed through `resolveInsertPlacement` like the sidebar
+ * button: that rule lands next to the SELECTION, and a control sitting at the
+ * end of one particular surface plainly means "here".
+ */
+export function useAppendCollection(collectionId: string): (toIndex: number) => boolean {
+  const { insertTool } = useToolInsertion(collectionId);
+  return useCallback((toIndex: number) => insertTool("collection", toIndex), [insertTool]);
+}
+
 /** Human label for an inserted tool, for the announcement. */
 const TOOL_LABELS: Readonly<Record<SidebarTool, string>> = {
   collection: "collection",

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -87,7 +87,13 @@ import { GRID_GAP, TIMELINE_PPS } from "./graph-view-config";
  * pointer; every other playhead (sub-rows, the other layout) stays on the
  * clock, which is what keeps them in agreement with each other.
  */
-export type PreviewScrubPosition = Readonly<{ surfaceId: string; x: number }>;
+export type PreviewScrubPosition = Readonly<{
+  surfaceId: string;
+  x: number;
+  /** Grid only: a position there is a ROW as well as an offset. Absent for
+   *  the strip, which is one line. */
+  y?: number;
+}>;
 
 export type PreviewTimeChannel = Readonly<{
   get: () => number;
@@ -685,7 +691,16 @@ export function GraphGridPlayhead({
         !activeWindow || (time >= activeWindow.start - 0.04 && time <= activeWindow.end + 0.04);
       line.style.display = inside ? "" : "none";
       if (!inside) return;
-      const { x, y } = map.posAt(time);
+      // While THIS grid is being scrubbed the line rides the pointer rather
+      // than the clock: a collection with no items is a full cell of width
+      // holding no time, so `posAt` of that instant can only ever return the
+      // cell's left edge (see PreviewScrubPosition).
+      const scrub = channel.getScrub();
+      const pos = map.posAt(time);
+      const { x, y } =
+        scrub && scrub.surfaceId === focusedId && scrub.y !== undefined
+          ? { x: scrub.x, y: scrub.y }
+          : pos;
       // Reach up through the band's clearance so the stem meets its row
       // rail's underside (the strip line does the same via -top-1).
       line.style.transform = `translate(${x}px, ${y - SEEK_RAIL_BAND_INSET_PX}px)`;
@@ -790,6 +805,9 @@ function SeekRailRow({
   channel,
   ariaLabel,
   rowIndex,
+  columns,
+  rowPitchY,
+  surfaceId,
 }: Readonly<{
   rowCards: readonly ChildSpan[];
   isLastRow: boolean;
@@ -803,6 +821,13 @@ function SeekRailRow({
   channel: PreviewTimeChannel;
   ariaLabel: string;
   rowIndex: number;
+  /** Columns and row pitch, so a pointer offset can be wrapped back into the
+   *  grid's own {x, y} for the scrub position — the rail seeks along an
+   *  UNWRAPPED line, the playhead paints on the wrapped grid. */
+  columns: number;
+  rowPitchY: number;
+  /** The surface this rail scrubs, so its playhead (and no other) follows. */
+  surfaceId: string;
 }>) {
   const railRef = useRef<HTMLDivElement>(null);
   const fillRef = useRef<HTMLDivElement>(null);
@@ -868,7 +893,19 @@ function SeekRailRow({
     // timeline's unwrapped line at this row's offset, so a drag that
     // overshoots either end keeps scrubbing into the neighbouring rows
     // (timeAt clamps to the timeline's own bounds).
-    channel.set(map.timeAt(offsetX + (event.clientX - rect.left), 0));
+    const unwrapped = Math.max(0, offsetX + (event.clientX - rect.left));
+    // Wrap that back onto the grid the playhead actually paints on. Position
+    // FIRST, then time — both notify the same listeners, and the other order
+    // paints one frame from the new time against a stale position.
+    const pitch = cellWidth + GRID_GAP;
+    const cell = Math.floor(unwrapped / pitch);
+    const within = Math.min(cellWidth, unwrapped - cell * pitch);
+    channel.setScrub({
+      surfaceId,
+      x: (cell % columns) * pitch + within,
+      y: Math.floor(cell / columns) * rowPitchY,
+    });
+    channel.set(map.timeAt(unwrapped, 0));
   };
 
   return (
@@ -904,11 +941,13 @@ function SeekRailRow({
         if (event.pointerId !== pointerIdRef.current) return;
         pointerIdRef.current = null;
         setScrubbing(false);
+        channel.setScrub(null);
       }}
       onPointerCancel={(event) => {
         if (event.pointerId !== pointerIdRef.current) return;
         pointerIdRef.current = null;
         setScrubbing(false);
+        channel.setScrub(null);
       }}
       onKeyDown={(event) => {
         if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
@@ -997,7 +1036,11 @@ function SeekRailRow({
           ref={timeRef}
           data-rail-time
           aria-hidden="true"
-          className="pointer-events-none absolute bottom-full z-50 mb-1.5 -translate-x-1/2 whitespace-nowrap rounded bg-zinc-900/95 px-1.5 py-0.5 font-mono text-[10px] text-zinc-100 shadow-sm ring-1 ring-zinc-700"
+          // BELOW the rail, not above: the surfaces sit hard against the
+          // sticky breadcrumb header, and there is nothing overhead to draw
+          // into — the readout was simply cut off (PL9-007). Downward it
+          // overlays the cards, which are its own surface and beneath it.
+          className="pointer-events-none absolute top-full z-50 mt-1.5 -translate-x-1/2 whitespace-nowrap rounded bg-zinc-900/95 px-1.5 py-0.5 font-mono text-[10px] text-zinc-100 shadow-sm ring-1 ring-zinc-700"
         />
       )}
     </div>
@@ -1149,6 +1192,9 @@ export function GraphSeekRails({
           y={geometry.top + row * (cellHeight + GRID_GAP) - GRID_GAP}
           channel={channel}
           rowIndex={row}
+          columns={geometry.columns}
+          rowPitchY={cellHeight + GRID_GAP}
+          surfaceId={focusedId}
           ariaLabel={rows.length > 1 ? `${ariaLabel}, row ${row + 1}` : ariaLabel}
         />
       ))}
@@ -1584,7 +1630,11 @@ export function GraphStripSeekRail({
           ref={timeRef}
           data-rail-time
           aria-hidden="true"
-          className="pointer-events-none absolute bottom-full z-50 mb-1.5 -translate-x-1/2 whitespace-nowrap rounded bg-zinc-900/95 px-1.5 py-0.5 font-mono text-[10px] text-zinc-100 shadow-sm ring-1 ring-zinc-700"
+          // BELOW the rail, not above: the surfaces sit hard against the
+          // sticky breadcrumb header, and there is nothing overhead to draw
+          // into — the readout was simply cut off (PL9-007). Downward it
+          // overlays the cards, which are its own surface and beneath it.
+          className="pointer-events-none absolute top-full z-50 mt-1.5 -translate-x-1/2 whitespace-nowrap rounded bg-zinc-900/95 px-1.5 py-0.5 font-mono text-[10px] text-zinc-100 shadow-sm ring-1 ring-zinc-700"
         />
       )}
     </div>

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -15,6 +15,7 @@ import {
 
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 
+import { AddCollectionSlot } from "./graph-add-collection-slot";
 import { useCollectionHoverSource } from "./graph-collection-hover";
 import { useClipDetail, useGraphDetailsStore, useTimelineTitle } from "./graph-details-context";
 import {
@@ -313,6 +314,7 @@ function SubTimelineNode({
                   cellHeight={dims.gridHeight}
                   gap={GRID_GAP}
                   height={GRID_UNCAPPED_HEIGHT}
+                  trailingSlot={<AddCollectionSlot collectionId={id} />}
                   overlay={
                     showPlayhead ? (
                       <GraphGridPlayhead
@@ -347,6 +349,7 @@ function SubTimelineNode({
                 overscan={GRAPH_STRIP_OVERSCAN_ITEMS}
                 itemWidth={collectionCardWidth(pixelsPerSecond, dims.strip)}
                 itemHeight={dims.strip}
+                trailingSlot={<AddCollectionSlot collectionId={id} />}
                 itemDragActivation="hold"
                 overlay={
                   showPlayhead || rulerOn ? (

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -3714,6 +3714,98 @@ test.describe("graph view E2E", () => {
     expect(samples[samples.length - 1]).toBeGreaterThan(card.x + card.width * 0.6);
   });
 
+  test("the GRID playhead also stays under the pointer over an empty collection", async ({
+    page,
+  }) => {
+    // PL9-005's other half: `buildGridPlayheadMap.posAt` collapses a
+    // zero-duration CELL exactly as the strip map collapses a zero-width span.
+    const api = await installGraphApi(page);
+    const EMPTY_ID = "timeline-e2e-empty-grid";
+    api.documents.get(PROJECT_ID)!.clips.push(
+      collectionClip("clip-empty-grid", EMPTY_ID, 9, "Nothing Here", 0),
+    );
+    api.documents.set(EMPTY_ID, { id: EMPTY_ID, title: "Nothing Here", clips: [] });
+    await page.goto(GRAPH_URL);
+    await expect(page.locator(`[data-virtual-grid="${PROJECT_ID}"]`)).toBeVisible();
+    await previewToggle(page).click();
+
+    const emptyCell = page
+      .locator(`[data-virtual-grid="${PROJECT_ID}"] [data-node-id="${EMPTY_ID}"]`);
+    await expect(emptyCell).toBeVisible();
+    const cell = (await emptyCell.boundingBox())!;
+    // The rail for the row the empty cell is in.
+    const rails = page.locator("[data-graph-seek-rail]");
+    const railCount = await rails.count();
+    let rail = rails.first();
+    for (let i = 0; i < railCount; i++) {
+      const box = (await rails.nth(i).boundingBox())!;
+      if (box.y < cell.y && box.y > cell.y - 60) rail = rails.nth(i);
+    }
+    const railBox = (await rail.boundingBox())!;
+    // The grid's marker is its own element — the strip's [data-graph-playhead]
+    // does not exist here.
+    const line = page.locator("[data-graph-grid-playhead]").first();
+    const y = railBox.y + railBox.height / 2;
+
+    await page.mouse.move(cell.x + 2, y);
+    await page.mouse.down();
+    const samples: number[] = [];
+    for (const fraction of [0.3, 0.6, 0.9]) {
+      await page.mouse.move(cell.x + cell.width * fraction, y, { steps: 4 });
+      samples.push((await line.boundingBox())!.x);
+    }
+    await page.mouse.up();
+
+    for (let i = 1; i < samples.length; i++) {
+      expect(samples[i]).toBeGreaterThan(samples[i - 1]);
+    }
+    expect(samples[samples.length - 1]).toBeGreaterThan(cell.x + cell.width * 0.5);
+  });
+
+  test("every surface ends with an add-timeline slot that appends there", async ({ page }) => {
+    // PL9-001. The sidebar tool lands next to the SELECTION; this appends to
+    // the surface it sits in, which is what "one more, at the end" means.
+    const api = await installGraphApi(page);
+    await openGraph(page);
+    await expandSubGraph(page, "Scene A");
+    await expect.poll(() => stripOrder(page, CHILD_ID), { timeout: 15000 }).toEqual(["c1", "c2"]);
+
+    // One per surface: the focused strip and the expanded child's strip.
+    await expect(page.locator("[data-add-collection-slot]")).toHaveCount(2);
+
+    // It is NOT an item — the surfaces still report only their real cards.
+    expect(await stripOrder(page, PROJECT_ID)).toEqual(["alpha", "bravo", CHILD_ID, "charlie"]);
+
+    // Selecting a card elsewhere must not steer where it lands.
+    await strip(page, PROJECT_ID).locator('[data-node-id="alpha"]').click();
+    await expect(strip(page, PROJECT_ID).locator('[data-node-id="alpha"]')).toHaveAttribute(
+      "data-selected",
+      "true",
+    );
+
+    // Append into the CHILD's strip: it lands last there, and the project is
+    // untouched.
+    await page
+      .locator(`[data-add-collection-slot="${CHILD_ID}"]`)
+      .click();
+    await expect
+      .poll(() => stripOrder(page, CHILD_ID), { timeout: 10000 })
+      .toEqual(["c1", "c2", expect.stringMatching(/^timeline-/)]);
+    expect(await stripOrder(page, PROJECT_ID)).toEqual([
+      "alpha",
+      "bravo",
+      CHILD_ID,
+      "charlie",
+    ]);
+
+    // It persists like any other insert, and undo takes it back.
+    await expect
+      .poll(() => api.patchesFor(CHILD_ID).at(-1)?.clipIds?.length, { timeout: 10000 })
+      .toBe(3);
+    await undoButton(page).click();
+    await expect.poll(() => stripOrder(page, CHILD_ID)).toEqual(["c1", "c2"]);
+  });
+
   test("a scrub drag shows the timestamp at the playhead, and only then", async ({ page }) => {
     // PL9-003. The transport's clock is up in the preview chrome; mid-drag the
     // number has to be where the pointer is.

--- a/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
@@ -93,6 +93,13 @@ export type VirtualGridProps = Readonly<{
    *  markers. aria-hidden and pointer-events: none — scroll and the drop
    *  spacer height apply for free, and gestures pass through to the cards. */
   overlay?: ReactNode;
+  /**
+   * Rendered in the cell AFTER the last card — the seam for an "add one here"
+   * affordance. NOT AN ITEM: `childIds.length` still drives every index,
+   * boundary, and roving calculation, so the slot cannot shift a drop or take
+   * a tab stop; it only lengthens the row spacer when it starts a new row.
+   */
+  trailingSlot?: ReactNode;
   className?: string;
 }>;
 
@@ -115,6 +122,7 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
       itemShell,
       itemDragActivation = "body",
       overlay,
+      trailingSlot,
       className,
     },
     ref
@@ -176,7 +184,11 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
         ? Math.max(1, (measuredWidth - (cols - 1) * gap) / cols)
         : cellWidth;
 
-    const rowCount = Math.ceil(childIds.length / cols);
+    // The trailing slot occupies the cell position AFTER the last card, so
+    // it can start a new row. Counted for the SPACER's height only — every
+    // index, boundary and roving calculation still reads `childIds.length`,
+    // so the slot cannot shift a drop or take a tab stop.
+    const rowCount = Math.ceil((childIds.length + (trailingSlot ? 1 : 0)) / cols);
     const rowSize = cellHeight + gap;
 
     const virtualizer = useVirtualizer({
@@ -400,6 +412,19 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
                 transform: `translateY(${row.start}px)`,
               }}
             >
+              {trailingSlot &&
+                Math.floor(childIds.length / cols) === row.index && (
+                  <div
+                    data-virtual-trailing-slot
+                    style={{
+                      order: childIds.length % cols,
+                      width: fillCellWidth,
+                      height: cellHeight,
+                    }}
+                  >
+                    {trailingSlot}
+                  </div>
+                )}
               {childIds
                 .slice(row.index * cols, Math.min(childIds.length, (row.index + 1) * cols))
                 .map((id, colInRow) => {

--- a/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
@@ -163,6 +163,17 @@ export type VirtualStripProps = Readonly<{
    */
   itemWidthFor?: (node: CollectionItemNode) => number | undefined;
   itemHeight?: number;
+  /**
+   * Rendered in a slot AFTER the last card, at the content's true end, so it
+   * scrolls with the strip rather than hovering over it. The seam for an
+   * "add one here" affordance without the surface having to know what
+   * adding means.
+   *
+   * NOT AN ITEM. It sits past `getTotalSize()`, which is what every
+   * boundary, model, and roving-focus calculation is built on, so nothing
+   * counts it and a drop at the end still lands after the last real card.
+   */
+  trailingSlot?: ReactNode;
   gap?: number;
   /** Extra items rendered on each side of the viewport. */
   overscan?: number;
@@ -225,6 +236,7 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
       itemWidth: itemWidthOption,
       itemWidthFor,
       itemHeight: itemHeightOption,
+      trailingSlot,
       gap: gapOption,
       overscan: overscanOption,
       panToScroll = true,
@@ -855,7 +867,11 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
               ref={contentRef}
               {...(childIds.length > 0 ? { role: "row", "aria-rowindex": 1 } : {})}
               style={{
-                width: virtualizer.getTotalSize(),
+                // The slot's width is ADDED here and nowhere else: every
+                // boundary and model reads `getTotalSize()`, which stays the
+                // cards' own extent, so the slot cannot shift an index.
+                width:
+                  virtualizer.getTotalSize() + (trailingSlot ? itemWidth + gap : 0),
                 height: itemHeight,
                 position: "relative",
                 // The left-handle "grows left" anchor (0 unless a left trim is
@@ -917,6 +933,20 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
                   />
                 </div>
               ))}
+              {trailingSlot && (
+                <div
+                  data-virtual-trailing-slot
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    left: virtualizer.getTotalSize(),
+                    width: itemWidth,
+                    height: itemHeight,
+                  }}
+                >
+                  {trailingSlot}
+                </div>
+              )}
               {/* Consumer overlay (playhead, region markers) in CONTENT
                   coordinates: living inside the spacer means scroll,
                   auto-scroll, and the live-trim anchor transform all apply

--- a/punch-list/PUNCH-LIST-09.md
+++ b/punch-list/PUNCH-LIST-09.md
@@ -2,7 +2,7 @@
 
 ## PL9-001 — Trailing "add a collection" placeholder in every strip and grid
 
-- Status: Open
+- Status: Complete
 - URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
 - Area: Strip and grid surfaces — trailing add affordance
 - Screenshot: Not captured
@@ -163,7 +163,7 @@ Acceptance criteria:
 
 ## PL9-005 — Scrubbing across an empty collection loses the cursor
 
-- Status: STRIP done; GRID rails still to do
+- Status: Complete
 - URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
 - Area: Seek rails and playhead (`graph-playhead-model.ts`,
   `graph-preview.tsx`)
@@ -185,16 +185,13 @@ directly, emitting whatever time that x maps to, and hand back to the
 time-driven position on release. Confirm the empty-collection span really is
 zero-width in time before building on that.
 
-DONE (strip): the channel now carries a scrub POSITION beside the time —
-`PreviewScrubPosition`, scoped by surface id — and the strip's playhead line
-and rail thumb both ride it while that surface is being dragged. Proven
-fail-first: without it the line does not move AT ALL across an empty card
-(824.33 → 824.33 over the whole crossing).
-
-NOT DONE (grid): `buildGridPlayheadMap.posAt` collapses a zero-duration cell
-the same way, so the grid's rails need the same treatment. It needs a `y` on
-the scrub payload (a grid position is a row as well as an offset) and the
-grid rail computing both in grid content coordinates.
+The channel carries a scrub POSITION beside the time
+(`PreviewScrubPosition`, scoped by surface id) and the line, the strip's rail
+thumb, and the grid's playhead all ride it while that surface is dragged. The
+grid payload adds a `y` — a grid position is a row as well as an offset — and
+its rail wraps its UNWRAPPED seek offset back onto the grid the playhead
+paints on. Proven fail-first on both: strip 824.33 → 824.33, grid 1032 →
+1032, i.e. no movement at all across the empty card.
 
 Acceptance criteria:
 
@@ -253,3 +250,23 @@ Acceptance criteria:
   with the folder.
 - It shares its visual language with the "No child timelines" empty state's
   tree icon (PL8-010), so the two do not look like different systems.
+
+## PL9-007 — Scrub readout is clipped under the breadcrumb row
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `graph-preview.tsx` — seek-rail scrub readout (follows PL9-003)
+- Screenshot: Not captured
+
+The timestamp readout added in PL9-003 draws ABOVE its rail (`bottom-full`).
+When the surface sits directly under the sticky breadcrumb header there is no
+room there, and the readout is cut off.
+
+Acceptance criteria:
+
+- The readout is fully visible while scrubbing, wherever the surface sits —
+  including hard against the header.
+- It stays attached to the playhead rather than jumping to a fixed corner.
+- It is not occluded by the sticky header, the preview region, or a card.
+- Both the strip rail and the grid's per-row rails.
+- Still drag-only, still pointer-events-none, still no layout shift.


### PR DESCRIPTION
The two items [#218](https://github.com/josulliv101/storyboard-flow/pull/218) left open, plus one new one found while testing.

| Item | |
| --- | --- |
| PL9-001 Trailing add-timeline slot | done |
| PL9-005 grid half — playhead under the pointer over an empty collection | done |
| PL9-007 Scrub readout clipped under the breadcrumb row | done (new) |

## PL9-001 — the slot is not an item

That is the whole difficulty. `trailingSlot` is a new seam on both virtual surfaces, and each keeps its index math untouched:

- **Strip** — the slot's width is added to the *content div* only. `getTotalSize()`, which every boundary, model and roving calculation reads, stays the cards' own extent, so a drop past the last card still appends rather than landing on the slot.
- **Grid** — counted for the row *spacer* only, so it can start a new row without `childIds.length` moving.

It also bypasses `resolveInsertPlacement` deliberately: that rule lands next to the **selection**, and a control at the end of one particular surface plainly means "here". The e2e pins that — a card is selected in the project strip, and clicking the child strip's slot still appends to the child.

Flat mode gets no slot: a flat run has no single parent to append to.

## PL9-005 — the grid half

`buildGridPlayheadMap.posAt` collapses a zero-duration **cell** exactly as the strip map collapsed a zero-width span. The scrub payload gains a `y` — a grid position is a row as well as an offset — and the rail wraps its *unwrapped* seek offset back onto the wrapped grid the playhead paints on.

Proven fail-first on both halves, and the numbers are unambiguous: without the fix the line does not move **at all** across the empty card — strip `824.33 → 824.33`, grid `1032 → 1032`.

## PL9-007 — found while testing PL9-003

The readout drew *above* its rail, and the surfaces sit hard against the sticky breadcrumb header, so there was nothing overhead to draw into. Flipped below, where it overlays the cards — its own surface, beneath it.

## Verification

- graph-view e2e 84/86 — both failures pass in isolation, and a different pair failed on each full run: the suite's documented load flake
- app vitest 442/442, unit 408/408, stories 165/165
- tsc clean both packages; lint clean (4 pre-existing `img` warnings)
- measured live: the readout renders below its rail and clear of the header (`398 ≥ 355`), and the slot reads as an affordance at the end of the strip

🤖 Generated with [Claude Code](https://claude.com/claude-code)