### PR TITLE
Punch list 10: elastic folder-hover call-out

### DIFF
--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -181,27 +181,43 @@ body {
 }
 
 /* A collection CARD, called out while its child-timeline row's folder is
-   hovered: one pass of a sky glow that rises and falls, then the card rests.
-   A one-shot, not a loop — the pointer sits on a folder for as long as the
-   user is reading the tree, and a throb for all of that is noise.
+   hovered (PL10-001, replacing PL9-002's glow): one elastic grow that
+   overshoots and springs back to rest. A one-shot, not a loop — the pointer
+   sits on a folder for as long as the user is reading the tree, and a throb
+   for all of that is noise.
 
-   Glow and ring only. Never the element's opacity (see the trash note above),
-   and nothing that changes the box: these cards sit in a virtualized strip
-   where a size change would shove every neighbour. */
+   TRANSFORM only. Never the element's opacity (see the trash note above),
+   and never a width/height/margin: these cards sit in a virtualized strip
+   where a box-model change would shove every neighbour. A scale composites
+   on its own layer and moves nothing else on the board — which is exactly
+   why this one is allowed where the box change the old comment forbade is
+   not. */
 @keyframes collection-paired-callout {
   0% {
-    box-shadow: 0 0 0 0 rgba(56, 189, 248, 0);
+    transform: scale(1);
   }
-  35% {
-    box-shadow: 0 0 18px 4px rgba(56, 189, 248, 0.55);
+  /* Out fast... */
+  40% {
+    transform: scale(1.06);
+  }
+  /* ...then past rest, and settle. The undershoot is what reads as elastic;
+     without it the card just inflates and deflates. */
+  68% {
+    transform: scale(0.985);
+  }
+  86% {
+    transform: scale(1.012);
   }
   100% {
-    box-shadow: 0 0 0 0 rgba(56, 189, 248, 0);
+    transform: scale(1);
   }
 }
 
 .animate-collection-paired-callout {
-  animation: collection-paired-callout 260ms ease-out;
+  animation: collection-paired-callout 320ms cubic-bezier(0.34, 1.56, 0.64, 1);
+  /* Grow from the card's middle, so a card at either end of the strip pushes
+     out symmetrically instead of sliding off its own origin. */
+  transform-origin: center center;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -212,8 +228,10 @@ body {
     animation: none;
   }
 
-  /* The connection still has to READ without motion: hold the glow steady
-     for as long as the row is hovered instead of playing it. */
+  /* The connection still has to READ without motion: with the scale off,
+     hold a steady glow for as long as the row is hovered instead. This is
+     the old PL9-002 call-out, kept for exactly the users who cannot see the
+     new one. */
   .animate-collection-paired-callout {
     box-shadow: 0 0 16px 3px rgba(56, 189, 248, 0.5);
   }

--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -214,6 +214,9 @@ body {
 }
 
 .animate-collection-paired-callout {
+  /* 320ms is also COLLECTION_CALLOUT_MS in graph-collection-hover.tsx, which
+     holds the class on for exactly this long so a flick across a folder still
+     plays the whole thing. Change one, change the other. */
   animation: collection-paired-callout 320ms cubic-bezier(0.34, 1.56, 0.64, 1);
   /* Grow from the card's middle, so a card at either end of the strip pushes
      out symmetrically instead of sliding off its own origin. */

--- a/apps/timeline-gstudio001/components/graph-view/graph-collection-hover.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-collection-hover.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { createContext, useContext, useMemo, useSyncExternalStore, type ReactNode } from "react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react";
 
 /**
  * With child timelines shown, a collection appears TWICE: as a card in the
@@ -102,15 +110,57 @@ export function useCollectionHoverSource(collectionId: string): Readonly<{
 }
 
 /**
+ * How long the card's call-out animation runs. MUST stay in sync with
+ * `collection-paired-callout` in globals.css — this is the hold below, and a
+ * hold shorter than the keyframes would cut them off again.
+ */
+export const COLLECTION_CALLOUT_MS = 320;
+
+/**
  * The TARGET end, for a collection card: whether its row is being hovered
  * right now. Drives a one-shot call-out on the card (see
  * `graph-item-content`), so what matters is the transition into true.
+ *
+ * It HOLDS past the pointer leaving. The call-out is an animation, and the
+ * card only carries it for as long as this returns true — so a flick across a
+ * folder used to start the elastic scale and then kill it a frame or two in,
+ * leaving a card that twitched and stopped. Once triggered it now plays out,
+ * whether or not the pointer stayed.
+ *
+ * The hold is timed from the FIRST trigger, not extended by later ones: it
+ * tracks the animation that is already running, so re-entering the same folder
+ * mid-play lets that play finish rather than restarting it (a wiggle over one
+ * row shouldn't strobe). Re-entering after it ends drops the class and re-adds
+ * it, which is what restarts the animation.
  */
 export function useCollectionHoverTarget(collectionId: string): boolean {
   const channel = useContext(CollectionHoverContext);
-  return useSyncExternalStore(
+  const hovered = useSyncExternalStore(
     channel ? channel.subscribe : NO_SUBSCRIBE,
     () => (channel ? channel.get() === collectionId : false),
     () => false,
   );
+
+  const [holding, setHolding] = useState(false);
+  const [wasHovered, setWasHovered] = useState(hovered);
+
+  // Latch on the RISING edge, adjusted during render (the repo's
+  // cascading-render-safe pattern — a synchronous setState in an effect trips
+  // the lint). Edge-triggered, not level-triggered: latching on every render
+  // where `hovered` is true would re-arm the timer forever while the pointer
+  // rests on a folder.
+  if (hovered !== wasHovered) {
+    setWasHovered(hovered);
+    if (hovered) setHolding(true);
+  }
+
+  useEffect(() => {
+    if (!holding) return;
+    // Deliberately NOT keyed on `hovered`: the whole point is that the pointer
+    // leaving must not cancel this timer.
+    const timer = window.setTimeout(() => setHolding(false), COLLECTION_CALLOUT_MS);
+    return () => window.clearTimeout(timer);
+  }, [holding]);
+
+  return hovered || holding;
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -968,7 +968,21 @@ const GraphCollectionItem = memo(function GraphCollectionItem({
     <CollectionItem.Root
       id={id}
       rovingTabIndex={rovingTabIndex}
-      className={["h-full w-full", className ?? ""].join(" ")}
+      className={[
+        "h-full w-full",
+        // PL10-003: the call-out's scale pushes the card ~7px past this
+        // wrapper, and a transform that spills counts as SCROLLABLE overflow —
+        // so calling out the last card in a strip or a grid row grew the
+        // scroller and flashed a scrollbar for the length of the animation.
+        //
+        // `clip` (not `hidden`) makes this box swallow that overflow without
+        // becoming a scroll container itself, and the clip margin is what keeps
+        // it from being a cure worse than the disease: the card's own growth
+        // (~7px) stays visible, and so do the drop-indicator bars, which sit
+        // half a gap OUTSIDE the card by design.
+        "overflow-clip [overflow-clip-margin:12px]",
+        className ?? "",
+      ].join(" ")}
     >
       <GraphCollectionItemParts dragActivation={dragActivation} />
     </CollectionItem.Root>

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -813,6 +813,17 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
           // way `data-disabled`'s values do on a media card.
           muted ? "is-disabled-card" : "",
           muted && node.disabled !== true ? "is-parent-disabled-card" : "",
+          // PL10-001: the call-out lives ON the card because it SCALES the
+          // card — a transform on the inset overlay this used to be would
+          // animate nothing anyone can see. Same marker-class trick as the
+          // disabled states above, and for the same reason: a hyphenated
+          // `data-` attribute passed to SelectionSurface is silently dropped.
+          //
+          // Toggling the class is also what restarts the one-shot. Moving
+          // between folders drops it off one card and adds it to the next, so
+          // the animation re-fires without a counter or a manual restart, and
+          // re-entering the same folder replays it.
+          calledOut ? "is-called-out-card animate-collection-paired-callout" : "",
         ].join(" ")}
       >
         {muted && <DisabledChip inherited={node.disabled !== true} />}
@@ -894,24 +905,10 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
         </span>
       </CollectionItem.SelectionSurface>
 
-      {/* The call-out for PL9-002, mounted only while this collection's row is
-          hovered. MOUNTING is what restarts the one-shot: moving between
-          folders unmounts one card's overlay and mounts the next card's, so
-          the animation re-fires without a counter or a manual restart, and
-          re-entering the same folder replays it.
-
-          A SIBLING of the selection surface, not a child: the surface is
-          `overflow-hidden` (its preview frames bleed to the edges), and an
-          outward glow drawn inside it would be clipped away to nothing. Out
-          here it also cannot collide with the selected/rejected ring states
-          the card already carries. */}
-      {calledOut && (
-        <span
-          aria-hidden="true"
-          data-collection-called-out
-          className="animate-collection-paired-callout pointer-events-none absolute inset-0 rounded-md"
-        />
-      )}
+      {/* (PL10-001 moved the call-out itself onto the selection surface above.
+          The overlay span that used to live here painted a glow; a scale has
+          to be on the card, and an element's own `overflow-hidden` clips its
+          children, never its own transform.) */}
 
       {/* The drill affordance — a REAL button now that it composes as a
           SIBLING of the selection surface. Centred over the preview area (the

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -3899,7 +3899,13 @@ test.describe("graph view E2E", () => {
     expect(neighbourDuring.x).toBeCloseTo(neighbourBefore.x, 0);
     expect(neighbourDuring.width).toBeCloseTo(neighbourBefore.width, 0);
 
+    // PL10-002: a flick still plays the whole animation. The pointer is gone
+    // and the call-out is still on the card — without the hold it would be
+    // torn off mid-keyframe, one or two frames in.
     await page.mouse.move(0, 0);
+    expect(await calledOut.count()).toBe(1);
+
+    // ...and then it ends on its own.
     await expect(calledOut).toHaveCount(0);
     // And the card comes back to exactly the box it started in.
     const cardAfter = (await card.boundingBox())!;
@@ -3918,6 +3924,53 @@ test.describe("graph view E2E", () => {
     await page.getByRole("button", { name: "Hide children timelines" }).click();
     await expect(page.locator('section[aria-label^="Sub-timeline"]')).toHaveCount(0);
     await expect(calledOut).toHaveCount(0);
+  });
+
+  test("the call-out's scale never grows a scroll area", async ({ page }) => {
+    // PL10-003. A transform that spills past its box counts as SCROLLABLE
+    // overflow, so the call-out used to grow whichever scroller held the card
+    // and flash a scrollbar for the length of the animation. The card's
+    // wrapper is `overflow: clip` (with a margin wide enough for the growth
+    // and for the drop bars) so nothing above it ever hears about the scale.
+    await installGraphApi(page);
+    await openGraph(page);
+    const rowFolder = page
+      .locator('section[aria-label="Sub-timeline: Scene A"]')
+      .getByRole("button", { name: "Expand" })
+      .first();
+
+    await rowFolder.hover();
+    await expect(page.locator(".is-called-out-card")).toHaveCount(1);
+
+    // Measure every ancestor at rest and at the animation's peak. Pausing the
+    // animation is what makes this deterministic — sampling a 320ms one-shot
+    // from the test side would race it.
+    const changed = await page.evaluate(() => {
+      const card = document.querySelector(".is-called-out-card");
+      if (!card) return ["no call-out"];
+      const animation = card.getAnimations()[0];
+      if (!animation) return ["no animation"];
+      const chain: Element[] = [];
+      // Start ABOVE the clip box itself: a clip container still reports its
+      // own scrollWidth, it just stops handing it upward, and that upward
+      // propagation is the whole bug.
+      for (let n = card.closest("[data-node-wrapper]")?.parentElement; n; n = n.parentElement) {
+        chain.push(n);
+      }
+      const snap = () => chain.map((n) => `${n.scrollWidth}x${n.scrollHeight}`);
+      animation.pause();
+      animation.currentTime = 0;
+      const rest = snap();
+      animation.currentTime = 128; // the 1.06 peak
+      const peak = snap();
+      animation.play();
+      return peak.flatMap((size, i) =>
+        size === rest[i]
+          ? []
+          : [`${chain[i].tagName}.${chain[i].className}: ${rest[i]} -> ${size}`],
+      );
+    });
+    expect(changed).toEqual([]);
   });
 
   test("clicking away anywhere that is not a control clears the selection", async ({

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -3846,7 +3846,9 @@ test.describe("graph view E2E", () => {
 
   test("hovering a child row's folder calls out its collection card", async ({ page }) => {
     // PL9-002, revising PL8-012: ONE direction now, and the card is called out
-    // by an animation rather than its icon changing.
+    // by an animation rather than its icon changing. PL10-001 made that
+    // animation an elastic SCALE on the card itself (the old inset glow
+    // overlay is gone), so the marker moved onto the card.
     await installGraphApi(page);
     await openGraph(page); // children timelines on
     const cardIcon = page.getByRole("button", { name: "Open Scene A" }).first();
@@ -3854,9 +3856,16 @@ test.describe("graph view E2E", () => {
       .locator('section[aria-label="Sub-timeline: Scene A"]')
       .getByRole("button", { name: "Expand" })
       .first();
-    const calledOut = page.locator("[data-collection-called-out]");
+    const calledOut = page.locator(".is-called-out-card");
 
     await expect(calledOut).toHaveCount(0);
+
+    // A NEIGHBOUR card, to prove the call-out moves nothing but itself, and
+    // the called-out card's own resting box to compare against afterwards.
+    const neighbour = strip(page, PROJECT_ID).locator('[data-node-id="alpha"]');
+    const card = strip(page, PROJECT_ID).locator(`[data-node-id="${CHILD_ID}"]`);
+    const neighbourBefore = (await neighbour.boundingBox())!;
+    const cardBefore = (await card.boundingBox())!;
 
     // Row folder → the matching card, and only that one.
     await rowFolder.hover();
@@ -3866,15 +3875,36 @@ test.describe("graph view E2E", () => {
     );
     expect(inCard).toBe(CHILD_ID);
 
-    // The call-out is drawn, not laid out: the card's box is untouched.
-    const cardBefore = (await strip(page, PROJECT_ID)
-      .locator(`[data-node-id="${CHILD_ID}"]`)
-      .boundingBox())!;
+    // The class is not the point — the KEYFRAMES are. Assert the card is
+    // actually running them, and that they scale it (an animation whose name
+    // resolves but whose rule was renamed away would still pass on class
+    // presence alone).
+    const running = await calledOut.evaluate((el) => {
+      const style = getComputedStyle(el);
+      return {
+        name: style.animationName,
+        scales: el.getAnimations().some((animation) =>
+          (animation as CSSAnimation).animationName === "collection-paired-callout",
+        ),
+      };
+    });
+    expect(running.name).toBe("collection-paired-callout");
+    expect(running.scales).toBe(true);
+
+    // It is a TRANSFORM, so it reflows nothing: the neighbour must not budge
+    // while the called-out card is mid-animation. (The called-out card's own
+    // box does change under the scale — that is the effect, and measuring it
+    // mid-flight would only race the keyframes.)
+    const neighbourDuring = (await neighbour.boundingBox())!;
+    expect(neighbourDuring.x).toBeCloseTo(neighbourBefore.x, 0);
+    expect(neighbourDuring.width).toBeCloseTo(neighbourBefore.width, 0);
+
     await page.mouse.move(0, 0);
     await expect(calledOut).toHaveCount(0);
-    const cardAfter = (await strip(page, PROJECT_ID)
-      .locator(`[data-node-id="${CHILD_ID}"]`)
-      .boundingBox())!;
+    // And the card comes back to exactly the box it started in.
+    const cardAfter = (await card.boundingBox())!;
+    const neighbourAfter = (await neighbour.boundingBox())!;
+    expect(neighbourAfter.x).toBeCloseTo(neighbourBefore.x, 0);
     expect(cardAfter.x).toBeCloseTo(cardBefore.x, 0);
     expect(cardAfter.width).toBeCloseTo(cardBefore.width, 0);
 

--- a/punch-list/PUNCH-LIST-10.md
+++ b/punch-list/PUNCH-LIST-10.md
@@ -58,3 +58,63 @@ adding/removing the class is what restarts the one-shot.
 Live-measured at the paused peak: card 219.3×132 → 232.5×139.9 (1.06 both
 axes), and no other `[data-node-id]` box moved. Reduced motion keeps the old
 steady sky glow.
+
+## PL10-002 — A flick over the folder plays the whole animation
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `graph-collection-hover.tsx` (`useCollectionHoverTarget`)
+- Screenshot: Not captured
+
+Passing quickly over a folder and straight back out starts the PL10-001
+animation and then cuts it off — the card twitches and stops. It should play
+in full once triggered, whether or not the pointer stayed.
+
+Acceptance criteria:
+
+- A momentary hover plays the animation to completion after the pointer has
+  left.
+- Dwelling on the folder behaves as before; leaving after the animation has
+  finished ends the call-out immediately.
+- No strobing: wiggling over one folder does not restart it repeatedly.
+
+Built as: the target hook returns `hovered || holding`, where `holding` is a
+320ms latch timed from the FIRST trigger and deliberately NOT cancelled when
+the pointer leaves. Timing it from the first trigger (rather than extending
+it per re-entry) is what makes a wiggle finish the run in progress instead of
+restarting it. `COLLECTION_CALLOUT_MS` must stay in sync with the keyframe
+duration in globals.css — a short hold would cut the animation off again.
+
+Note: a fast sweep DOWN the tree now leaves several cards animating at once,
+one per folder passed. That is the same rule applied to each — say if you
+want a sweep to call out only the folder the pointer settles on.
+
+## PL10-003 — The call-out must not flash a scrollbar
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `graph-item-content.tsx` (`GraphCollectionItem` wrapper)
+- Screenshot: Not captured
+
+Calling out the last card in a row briefly flashes a scrollbar.
+
+Cause: a transform that spills outside its box still counts as SCROLLABLE
+overflow, so the scaled card grew its scroller (measured: the strip's
+`overflow-x-auto` box went 132 → 136 tall at the peak, and the card's own
+container 235 → 242 wide) and the browser showed a bar for the length of the
+animation.
+
+Acceptance criteria:
+
+- No scrollbar appears or flashes on any surface while the call-out plays.
+- The card's growth is still fully visible — not clipped to its box.
+- Drop indicator bars, which sit half a gap outside the card by design, stay
+  visible.
+
+Built as: the collection card's wrapper is `overflow: clip` with
+`overflow-clip-margin: 12px`. `clip` (not `hidden`) swallows the overflow
+without turning the wrapper into a scroll container, and the 12px margin
+clears both the card's ~7px growth and the drop bars' ~4px. E2E pins that no
+ancestor above the wrapper changes scroll size between rest and peak; proven
+to fail without the clip (three ancestors grew, the strip's scroller among
+them).

--- a/punch-list/PUNCH-LIST-10.md
+++ b/punch-list/PUNCH-LIST-10.md
@@ -1,0 +1,60 @@
+# Punch List 10
+
+## PL10-001 — Folder-hover call-out becomes an elastic squash-and-snap
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `graph-item-content.tsx` collection card call-out,
+  `app/globals.css` keyframes (revises PL9-002)
+- Screenshot: Not captured
+
+PL9-002 settled the DIRECTION (hovering a child timeline's folder calls out
+the matching collection card, one way only) and shipped a glow pulse as the
+call-out. Keep the direction and the trigger; replace the glow.
+
+The card should ELASTICALLY grow and snap back to its normal size — a spring
+overshoot rather than a light effect. Still a one-shot on hover-enter, still
+re-firing when the pointer moves between folders.
+
+Assumption to confirm: it scales UP briefly (both axes, ~1.04) and springs
+back past rest with a decaying overshoot, ~300ms. Say if you meant height
+only, or a squash the other way (shrink first, then snap out).
+
+Reference: the call-out today is a SIBLING overlay span
+(`data-collection-called-out`, `.animate-collection-paired-callout`) mounted
+only while the row is hovered — mounting is what restarts the one-shot, and
+that mechanism should survive. But an inset overlay can only paint; scaling
+it is invisible. The transform has to land on the CARD, so this either moves
+the animation onto the selection surface's wrapper or keeps the overlay as
+the mount-trigger and drives the card via a data attribute.
+
+The globals.css note "nothing that changes the box" was about box-model
+size in a virtualized strip. A `transform: scale` composites and does not
+reflow neighbours — that is why this is allowed and a width/height animation
+is not.
+
+Acceptance criteria:
+
+- Hovering a sub-timeline row's folder plays a one-shot elastic scale on the
+  matching collection card, in both strip and grid surfaces.
+- Moving between folders re-fires it on the newly matched card; re-entering
+  the same folder replays it.
+- No glow/ring remains from the old call-out.
+- Neighbouring cards do not shift: the animation must not reflow the strip
+  or grid (transform only, no width/height/margin).
+- The scale is not clipped by the card's `overflow-hidden`, and it does not
+  fight the selected (amber ring) or rejected (red ring) states.
+- Under `prefers-reduced-motion: reduce` the connection still reads without
+  motion — a steady, non-animated call-out held while the row is hovered.
+- The PL9-002 e2e that asserts the one-way call-out is updated, not deleted.
+
+Built as: `scale(1) → 1.06 → 0.985 → 1.012 → 1` over 320ms on a spring
+curve — out fast, past rest, settle. The undershoot is what reads as elastic;
+without it the card only inflates and deflates. The overlay span is deleted;
+the card carries `is-called-out-card animate-collection-paired-callout`
+(marker class, because SelectionSurface drops hyphenated `data-` props), and
+adding/removing the class is what restarts the one-shot.
+
+Live-measured at the paused peak: card 219.3×132 → 232.5×139.9 (1.06 both
+axes), and no other `[data-node-id]` box moved. Reduced motion keeps the old
+steady sky glow.


### PR DESCRIPTION
Punch list 10, items 1-3 — all on the collection card's call-out, the thing that fires when you hover a child timeline's folder.

**PL10-001 — elastic call-out.** PL9-002's sky glow is replaced by a one-shot elastic scale: `1 → 1.06 → 0.985 → 1.012 → 1` over 320ms on a spring curve. The undershoot past rest is what reads as elastic; without it the card only inflates and deflates.

The animation had to move onto the card itself. It used to live on an inset overlay span, which can paint a glow but cannot show a transform, so the marker is now a class on the selection surface (a hyphenated `data-` prop passed to `SelectionSurface` is silently dropped) and toggling that class is what restarts the one-shot.

**PL10-002 — a flick plays the whole animation.** The card carried the animation only while the hover channel named it as the target, so passing quickly over a folder started the scale and killed it a frame or two in. `useCollectionHoverTarget` now holds past the pointer leaving, timed from the first trigger rather than extended per re-entry — a wiggle over one folder finishes the run in progress instead of strobing.

**PL10-003 — no more scrollbar flash.** A transform that spills past its box still counts as *scrollable* overflow, so the scaled card grew its scroller and the browser drew a bar for the length of the animation (measured: the strip's `overflow-x-auto` box 132 → 136 tall at the peak). The card's wrapper is now `overflow: clip` with a 12px clip margin — `clip` rather than `hidden` so it swallows the overflow without becoming a scroll container, and the margin clears both the card's ~7px growth and the drop bars that sit half a gap outside the card by design.

## Verification

- graph-view e2e **87/87** (one new test, two updated).
- Both new assertions proven to fail with their fix reverted — the scroll one listed three growing ancestors, the strip's scroller among them.
- Live-measured in the running app: 1.06 on both axes at the peak with no other card's box moving; after a flick, the card still at 1.061 at 60ms with the pointer gone since 30ms.
- Lint clean (4 pre-existing `<img>` warnings).

Reduced motion keeps the old steady glow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)