### PR TITLE
Punch list 11: rail polish, and the details trigger on the card

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -2,7 +2,7 @@
 
 import { useContext, useDeferredValue, useMemo } from "react";
 import { useSearchParams } from "next/navigation";
-import { FolderPlus, Maximize2, Redo2, Settings, Undo2 } from "lucide-react";
+import { FolderPlus, Redo2, Settings, Undo2 } from "lucide-react";
 
 import {
   CollectionsContainerContext,
@@ -48,7 +48,7 @@ import {
 } from "./graph-preview";
 import { AddCollectionSlot } from "./graph-add-collection-slot";
 import { CollectionHoverProvider } from "./graph-collection-hover";
-import { ItemDetailsProvider, useItemDetails } from "./graph-item-details-context";
+import { ItemDetailsProvider } from "./graph-item-details-context";
 import { GraphItemDetailsModal } from "./graph-item-details-modal";
 import { SubTimelines } from "./graph-sub-timelines";
 import {
@@ -244,51 +244,6 @@ function GraphUndoRedo() {
         <Redo2 aria-hidden="true" className="h-4 w-4" />
       </Button>
     </div>
-  );
-}
-
-/**
- * Opens the ITEM DETAILS view (PL10-004 → PL10-012). It lives in the toolbar
- * rather than on the card because a media card is NodeCard's single `<button>`
- * shell, where a nested button would be invalid HTML (the same constraint that
- * made the collection rename a contentEditable span). Disabled with no media
- * item selected, since there would be nothing to open.
- *
- * Both surfaces: a grid card has no trim handles, but details are not a
- * trimming idea — a grid item has a name, a duration, and (soon) tags like any
- * other. Discovery doesn't rest on finding this either: in the strip, dragging
- * a card's own trim handle still previews the edge in place.
- */
-function GraphItemDetailsToggle() {
-  const { open, setOpen } = useItemDetails();
-  const hasMedia = useCollectionsSelector((s) => {
-    for (const id of s.interaction.selectedIds) {
-      if (s.graph.nodesById.get(id)?.kind === "media") return true;
-    }
-    return false;
-  });
-
-  return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon"
-      disabled={!hasMedia}
-      aria-pressed={open}
-      aria-label={open ? "Close item details" : "Open item details"}
-      title={
-        hasMedia
-          ? "Item details — open the item on its own, with its name, duration and trim"
-          : "Item details — select a media item first"
-      }
-      onClick={() => setOpen(!open)}
-      className={[
-        "h-8 w-8 disabled:opacity-40",
-        open ? "text-amber-300 hover:text-amber-200" : "text-zinc-400 hover:text-zinc-100",
-      ].join(" ")}
-    >
-      <Maximize2 aria-hidden="true" className="h-4 w-4" />
-    </Button>
   );
 }
 
@@ -518,7 +473,6 @@ export function GraphBoard({
                   <div aria-hidden="true" className="h-5 w-px shrink-0 bg-zinc-700" />
                 </>
               ) : null}
-              <GraphItemDetailsToggle />
               <GraphUndoRedo />
               <BoardMenu
                 itemSize={itemSize}

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -12,7 +12,7 @@ import {
   useSyncExternalStore,
   type ReactNode,
 } from "react";
-import { CornerRightDown } from "lucide-react";
+import { CornerRightDown, Maximize2 } from "lucide-react";
 
 import {
   CollectionItem,
@@ -45,6 +45,7 @@ import { useClipDetail, useGraphDetailsStore, useTimelineTitle } from "./graph-d
 import { isDisabledByAncestor } from "./graph-playhead-model";
 import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
 import { useCollectionHoverTarget } from "./graph-collection-hover";
+import { useItemDetails } from "./graph-item-details-context";
 import { GraphViewNavContext } from "./graph-navigation";
 import { TrimPanel } from "./graph-trim-panel";
 import { createDerivedCache } from "@/lib/derived-cache";
@@ -992,17 +993,95 @@ const GraphCollectionItem = memo(function GraphCollectionItem({
 });
 
 /**
+ * The details trigger on a media card (PL11-002): top-right, revealed on
+ * hover or keyboard focus, and a real tab stop when its card is the roving
+ * one.
+ *
+ * It is a SIBLING of NodeCard, not a child. NodeCard's shell is a single
+ * `<button>`, and a button inside a button is invalid HTML — the same
+ * constraint that put this control in the toolbar to begin with, and that
+ * made the collection rename a contentEditable span. Living outside that
+ * button also means a press here never reaches the card's drag wiring.
+ *
+ * `tabIndex` follows the surface's ROVING value rather than being a flat 0:
+ * a virtualized strip mounts dozens of cards, and a fixed tab stop per card
+ * would put dozens of them in the tab order. Roving keeps the surface at one
+ * stop; this adds exactly one more, on the card the user is actually on.
+ */
+const ItemDetailsTrigger = memo(function ItemDetailsTrigger({
+  id,
+  rovingTabIndex,
+}: Readonly<{ id: NodeId; rovingTabIndex: number | undefined }>) {
+  const store = useCollectionsStore();
+  const { setOpenId } = useItemDetails();
+
+  return (
+    <button
+      type="button"
+      data-item-details-trigger={id}
+      aria-label="Open item details"
+      title="Open item details"
+      {...(rovingTabIndex !== undefined ? { tabIndex: rovingTabIndex } : {})}
+      onPointerDown={(event) => {
+        // Keep the press off the surface gestures underneath — the strip's
+        // pan and (in grid) the hold-drag both start on pointerdown.
+        event.stopPropagation();
+      }}
+      onClick={(event) => {
+        event.stopPropagation();
+        // Open it AND select it: the details view is about one item, and
+        // leaving the selection on some other card makes every selection-scoped
+        // readout in the board disagree with what the modal is showing.
+        store.setSelection([id]);
+        setOpenId(id as string);
+      }}
+      className={[
+        "absolute top-1 right-1 z-20 flex size-6 items-center justify-center rounded",
+        "bg-zinc-950/80 text-zinc-300 shadow-sm shadow-black/40 backdrop-blur-[1px]",
+        "hover:bg-zinc-900 hover:text-zinc-50",
+        // Hidden until the card is hovered or something inside it has focus —
+        // including this button, which is why `focus-within` is on the group
+        // rather than `focus-visible` here alone.
+        "opacity-0 transition-opacity duration-150",
+        "group-hover/media-item:opacity-100 group-focus-within/media-item:opacity-100",
+        "focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300",
+      ].join(" ")}
+    >
+      <Maximize2 aria-hidden="true" className="h-3.5 w-3.5" />
+    </button>
+  );
+});
+
+/**
+ * The media card: the stock NodeCard, wrapped so a details trigger can sit
+ * beside it. The wrapper carries the surface's sizing className and the hover
+ * group; NodeCard fills it.
+ */
+const GraphMediaItem = memo(function GraphMediaItem({
+  className,
+  ...props
+}: CollectionItemShellProps) {
+  return (
+    <div className={["group/media-item relative", className ?? ""].join(" ")}>
+      <NodeCard {...props} className="h-full w-full" />
+      <ItemDetailsTrigger id={props.id} rovingTabIndex={props.rovingTabIndex} />
+    </div>
+  );
+});
+
+/**
  * The graph's per-item renderer (registered as the provider `ItemShell`):
  * media keeps the stock NodeCard shell (its content is presentational, so the
- * single-button card is exactly right); collections get the composed card
- * above. The kind subscription is a primitive, so the dispatcher re-renders
- * only if a node changes kind — which never happens after creation.
+ * single-button card is exactly right) with the details trigger beside it;
+ * collections get the composed card above. The kind subscription is a
+ * primitive, so the dispatcher re-renders only if a node changes kind — which
+ * never happens after creation.
  */
 const GraphItemShell = memo(function GraphItemShell(props: CollectionItemShellProps) {
   const isCollection = useCollectionsSelector(
     (s) => s.graph.nodesById.get(props.id)?.kind === "collection",
   );
-  return isCollection ? <GraphCollectionItem {...props} /> : <NodeCard {...props} />;
+  return isCollection ? <GraphCollectionItem {...props} /> : <GraphMediaItem {...props} />;
 });
 
 export const GRAPH_VIEW_COMPONENTS: CollectionsComponents = {

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-context.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-context.tsx
@@ -3,27 +3,29 @@
 import { createContext, useContext, useMemo, useState, type ReactNode } from "react";
 
 /**
- * Whether the item-details view is open (PL10-004, generalized by PL10-012).
+ * WHICH item has its details open (PL10-004 → PL11-002).
  *
- * A MODE, not a per-item flag: details work is done in passes, so opening it
- * once keeps it open as the selection moves from item to item. The view itself
- * decides what to draw for whatever is selected — and for a video it also
- * appears unpinned for the length of a trim drag, so the gesture that needs it
- * summons it whether or not the mode is on.
+ * It used to be a boolean mode paired with "whatever is selected", because the
+ * only trigger was a toolbar button. The trigger now lives on the card itself,
+ * and a card can be pressed without being the selection — so the open item is
+ * named here rather than inferred. `null` is closed.
  *
  * Session-scoped on purpose (state, not storage): the view costs a video
  * element and a filmstrip, and having it survive a reload would mean paying
- * that on every page load for a mode the user may have opened once, days ago.
+ * that on every page load for something the user opened once, days ago.
  */
-type ItemDetailsValue = Readonly<{ open: boolean; setOpen: (next: boolean) => void }>;
+type ItemDetailsValue = Readonly<{
+  openId: string | null;
+  setOpenId: (next: string | null) => void;
+}>;
 
 const ItemDetailsContext = createContext<ItemDetailsValue | null>(null);
 
-const CLOSED: ItemDetailsValue = { open: false, setOpen: () => {} };
+const CLOSED: ItemDetailsValue = { openId: null, setOpenId: () => {} };
 
 export function ItemDetailsProvider({ children }: Readonly<{ children: ReactNode }>) {
-  const [open, setOpen] = useState(false);
-  const value = useMemo(() => ({ open, setOpen }), [open]);
+  const [openId, setOpenId] = useState<string | null>(null);
+  const value = useMemo(() => ({ openId, setOpenId }), [openId]);
   return <ItemDetailsContext.Provider value={value}>{children}</ItemDetailsContext.Provider>;
 }
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -9,6 +9,7 @@ import {
   TrimOverviewStrip,
   isEditableKeyboardTarget,
   mediaDurationSeconds,
+  parseNodeId,
   useCollectionsSelector,
   useCollectionsStore,
   useLiveTrim,
@@ -377,16 +378,15 @@ function ModalBody({ node, onClose }: Readonly<{ node: MediaNode; onClose: () =>
  * card INSIDE the closing callback rather than after it.
  */
 export function GraphItemDetailsModal() {
-  const { open, setOpen } = useItemDetails();
-  // ANY selected media item, not just a video: the view is where an item's
-  // details live, and a still has details too (PL10-012). Videos get the
-  // frame + source strip; images get the still and their duration.
+  const { openId, setOpenId } = useItemDetails();
+  // The item the TRIGGER named (PL11-002), not whatever happens to be
+  // selected: the trigger lives on a card, and a card can be pressed without
+  // being the selection. Any media item qualifies — a video gets the frame and
+  // the source strip, a still gets its image and its duration (PL10-012).
   const node = useCollectionsSelector((s) => {
-    for (const id of s.interaction.selectedIds) {
-      const found = s.graph.nodesById.get(id);
-      if (found?.kind === "media") return found;
-    }
-    return null;
+    if (openId === null) return null;
+    const found = s.graph.nodesById.get(parseNodeId(openId));
+    return found?.kind === "media" ? found : null;
   });
   const [mounted, setMounted] = useState(false);
   const openIdRef = useRef<string | null>(null);
@@ -394,7 +394,7 @@ export function GraphItemDetailsModal() {
   // Opening and closing are driven by the context flag so the toolbar button,
   // Escape, the close button and the scrim all go through one path.
   useEffect(() => {
-    const wanted = open && node !== null && !!node.src;
+    const wanted = openId !== null && node !== null && !!node.src;
     if (wanted === mounted) return;
 
     if (wanted && node) {
@@ -418,8 +418,8 @@ export function GraphItemDetailsModal() {
       card?.style.removeProperty("view-transition-name");
       openIdRef.current = null;
     });
-  }, [open, node, mounted]);
+  }, [openId, node, mounted]);
 
   if (!mounted || node === null || !node.src) return null;
-  return <ModalBody node={node} onClose={() => setOpen(false)} />;
+  return <ModalBody node={node} onClose={() => setOpenId(null)} />;
 }

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -75,9 +75,9 @@ function TrashAreaIcon({ className }: Readonly<{ className?: string }>) {
       data-sidebar-icon="trash"
       className={cn("relative inline-flex shrink-0 overflow-visible", className)}
     >
-      <Folder className="h-full w-full" strokeWidth={2.1} />
+      <Folder className="h-full w-full" strokeWidth={1.5} />
       <span className="absolute -bottom-1.5 -right-1.5 flex size-6 items-center justify-center rounded-full bg-zinc-950 ring-1 ring-zinc-600">
-        <Trash2 className="size-4" strokeWidth={2.7} />
+        <Trash2 className="size-4" strokeWidth={1.9} />
       </span>
     </span>
   );
@@ -91,9 +91,9 @@ function MediaFolderIcon({ className }: Readonly<{ className?: string }>) {
       aria-hidden="true"
       className={cn("relative inline-flex shrink-0 overflow-visible", className)}
     >
-      <Folder className="h-full w-full" strokeWidth={2.1} />
+      <Folder className="h-full w-full" strokeWidth={1.5} />
       <span className="absolute -bottom-1.5 -right-1.5 flex size-6 items-center justify-center rounded-full bg-zinc-950 ring-1 ring-zinc-600">
-        <ImageIcon className="size-4" strokeWidth={2.5} />
+        <ImageIcon className="size-4" strokeWidth={1.9} />
       </span>
     </span>
   );
@@ -107,7 +107,7 @@ const SIDEBAR_ICON_BASE =
   "group/sidebar-item relative flex w-full aspect-square items-center justify-center transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-zinc-400";
 /** The glyph inside a tile. Larger than the old h-4: legibility is the point
  *  of the bigger tiles, and a 16px icon in a 72px square reads as a dot. */
-const SIDEBAR_GLYPH = "h-7 w-7 transition-colors";
+const SIDEBAR_GLYPH = "h-7 w-7 [stroke-width:1.5] transition-colors";
 const SIDEBAR_ICON_IDLE =
   "bg-zinc-900/40 text-zinc-400 hover:bg-zinc-800/80 hover:text-zinc-100";
 // No `translate-y-px` any more: with the tiles flush against each other, a
@@ -556,7 +556,7 @@ export function TimelineSidebar() {
       <Link
         href="/"
         aria-label="Storyboard Workbench home"
-        className="flex w-full aspect-square items-center justify-center text-lg font-black text-zinc-400 transition-colors hover:text-zinc-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-zinc-500"
+        className="flex w-full aspect-square items-center justify-center text-lg font-black text-white transition-colors hover:text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-zinc-500"
       >
         SW
       </Link>

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -440,6 +440,18 @@ async function settleMoveAnimations(page: Page): Promise<void> {
 }
 
 /**
+ * Opens an item's details the way a user does now (PL11-002): the trigger
+ * lives on the card, hidden until hover or focus. Playwright's click hovers
+ * first, so the reveal is implicit — but the click is FORCED past the
+ * opacity-0 idle state, which is a visibility rule rather than a hit-testing
+ * one.
+ */
+async function openItemDetails(page: Page, nodeId: string): Promise<void> {
+  await page.locator(`[data-item-details-trigger="${nodeId}"]`).click();
+  await settleViewTransition(page);
+}
+
+/**
  * Waits out a CSS view transition. While one runs, the browser paints a
  * SNAPSHOT of the page over the real DOM — and a snapshot is an image, so
  * every real pointer event during it lands on `<html>` instead of on whatever
@@ -3981,7 +3993,7 @@ test.describe("graph view E2E", () => {
       );
     expect(await heroCount()).toBe(0);
 
-    await page.getByRole("button", { name: "Open item details" }).click();
+    await openItemDetails(page, "alpha");
     const modal = page.getByRole("dialog");
     await expect(modal).toHaveCount(1);
     // Only the modal's frame holds the name while it is open — the card gave
@@ -4027,7 +4039,7 @@ test.describe("graph view E2E", () => {
     await expect.poll(heroCount).toBe(0);
 
     // And it reopens, which is what a stranded name would have broken.
-    await page.getByRole("button", { name: "Open item details" }).click();
+    await openItemDetails(page, "alpha");
     await expect(page.getByRole("dialog")).toHaveCount(1);
     expect(await heroCount()).toBe(1);
   });
@@ -4043,15 +4055,27 @@ test.describe("graph view E2E", () => {
     // bravo is an IMAGE, and we are in the grid — the two things the old
     // trim-only toggle refused.
     const bravo = page.locator('[data-node-id="bravo"]');
-    await expect(async () => {
-      await bravo.click();
-      await expect(bravo).toHaveAttribute("data-selected", "true", { timeout: 700 });
-    }).toPass({ timeout: 10000 });
+    const trigger = page.locator('[data-item-details-trigger="bravo"]');
+    await expect(trigger).toHaveCount(1);
 
-    const toggle = page.getByRole("button", { name: "Open item details" });
-    await expect(toggle).toBeEnabled();
-    await toggle.click();
-    await settleViewTransition(page);
+    // Hidden until the card is hovered or focused. Asserted BEFORE anything is
+    // clicked: clicking a card focuses it, and focus legitimately reveals the
+    // trigger, so a click first would make the idle state untestable. (Real
+    // hover only — the reveal is a CSS `:hover` rule, which synthetic mouse
+    // events cannot produce.)
+    const opacity = () => trigger.evaluate((el) => getComputedStyle(el).opacity);
+    await expect.poll(opacity).toBe("0");
+    await bravo.hover();
+    await expect.poll(opacity).toBe("1");
+    await page.mouse.move(0, 0);
+    await expect.poll(opacity).toBe("0");
+    await trigger.focus();
+    await expect.poll(opacity).toBe("1");
+
+    // Pressing it selects the card as well, so the board's selection-scoped
+    // readouts agree with what the view is showing.
+    await openItemDetails(page, "bravo");
+    await expect(bravo).toHaveAttribute("data-selected", "true");
 
     const details = page.getByRole("dialog");
     await expect(details).toHaveCount(1);
@@ -4070,6 +4094,17 @@ test.describe("graph view E2E", () => {
 
     await page.keyboard.press("Escape");
     await expect(page.locator("[data-item-details]")).toHaveCount(0);
+
+    // Keyboard reachable: the card is the surface's one roving tab stop, and
+    // its trigger is the next one — so Tab from the card lands on it and
+    // Enter opens the view. A flat tabIndex would have put every mounted
+    // card's trigger in the order instead.
+    await bravo.focus();
+    await page.keyboard.press("Tab");
+    await expect(page.locator('[data-item-details-trigger="bravo"]')).toBeFocused();
+    await page.keyboard.press("Enter");
+    await settleViewTransition(page);
+    await expect(page.getByRole("dialog")).toHaveCount(1);
   });
 
   test("ctrl+z undoes and ctrl+shift+z redoes from the keyboard", async ({ page }) => {
@@ -4141,8 +4176,7 @@ test.describe("graph view E2E", () => {
       await alpha.click();
       await expect(alpha).toHaveAttribute("data-selected", "true", { timeout: 700 });
     }).toPass({ timeout: 10000 });
-    await page.getByRole("button", { name: "Open item details" }).click();
-    await settleViewTransition(page);
+    await openItemDetails(page, "alpha");
 
     const undo = page.locator("[data-item-details-undo]");
     const redo = page.locator("[data-item-details-redo]");
@@ -4192,8 +4226,7 @@ test.describe("graph view E2E", () => {
       await alpha.click();
       await expect(alpha).toHaveAttribute("data-selected", "true", { timeout: 700 });
     }).toPass({ timeout: 10000 });
-    await page.getByRole("button", { name: "Open item details" }).click();
-    await settleViewTransition(page);
+    await openItemDetails(page, "alpha");
 
     const storedAlt = () =>
       api.documents.get(PROJECT_ID)?.clips.find((clip) => clip.id === "alpha")?.alt;

--- a/punch-list/PUNCH-LIST-11.md
+++ b/punch-list/PUNCH-LIST-11.md
@@ -1,5 +1,50 @@
 # Punch List 11
 
+## PL11-002 — The details trigger moves onto the item
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `graph-item-content.tsx`, `graph-item-details-context.tsx`,
+  `graph-item-details-modal.tsx`, `graph-board.tsx`
+- Screenshot: Not captured
+
+The toolbar was the wrong home for a per-item control. The trigger now sits in
+the top-right of the media card itself: hidden at rest, revealed on hover or
+on keyboard focus, and a real tab stop.
+
+Where it lives matters: NodeCard's shell IS a `<button>`, and a button inside
+a button is invalid HTML — the constraint that put this control in the toolbar
+originally. So media items now render through a small wrapper (`GraphMediaItem`)
+that carries the sizing and the hover group, with NodeCard filling it and the
+trigger as a SIBLING. Being outside that button also means a press here never
+reaches the card's drag wiring.
+
+`tabIndex` follows the surface's ROVING value rather than a flat 0: a
+virtualized strip mounts dozens of cards, and a fixed tab stop each would put
+dozens in the tab order. Roving keeps the surface at one stop and this adds
+exactly one more, on the card the user is actually on — so Tab from the card
+lands on its trigger, and Enter opens the view.
+
+The open state changed shape with it: the context named a boolean mode paired
+with "whatever is selected", which only worked because the single trigger was
+global. It now names WHICH item is open (`openId`), because a card can be
+pressed without being the selection. Pressing the trigger also selects the
+card, so the board's selection-scoped readouts agree with the view.
+
+Acceptance criteria:
+
+- Hidden at rest; revealed by hovering the card or focusing anything in it.
+- Reachable by keyboard, one extra tab stop, on the roving card only.
+- Opens the details view for THAT item, and selects it.
+- The toolbar button is gone.
+
+E2E covers idle → hover → away → focus opacity, the Tab-then-Enter path, and
+that pressing it selects. The hover assertions must run BEFORE any click:
+clicking a card focuses it, and focus legitimately reveals the trigger, so a
+click first makes the idle state untestable. (The Browser pane cannot prove
+this one — its synthetic mouse doesn't drive CSS `:hover`; Playwright's real
+input does.)
+
 ## PL11-001 — Lighter icon strokes, white logo
 
 - Status: Complete

--- a/punch-list/PUNCH-LIST-11.md
+++ b/punch-list/PUNCH-LIST-11.md
@@ -1,0 +1,33 @@
+# Punch List 11
+
+## PL11-001 — Lighter icon strokes, white logo
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `timeline-sidebar.tsx`
+- Screenshot: Not captured
+
+At 28px the rail's glyphs carried too much stroke — lucide's default 2 reads
+heavy once the icon is that big. Every rail glyph is now 1.5.
+
+Set in CSS (`[stroke-width:1.5]` on the shared glyph class) rather than as a
+prop on each icon: `stroke-width` is an INHERITED SVG property, so one class
+covers every lucide icon the rail renders. The two composed folder icons keep
+their own explicit widths — a presentation attribute on an element beats an
+inherited value — so those were lightened by hand: the folder to 1.5, and
+their corner badges to 1.9 (a little heavier, because at 16px inside a 24px
+badge 1.5 disappears).
+
+The logo's "SW" is white rather than zinc-400, with the hover a step down
+instead of up.
+
+Acceptance criteria:
+
+- Every rail glyph computes to 1.5px stroke.
+- The badge marks stay legible at their size.
+- The logo renders pure white.
+
+Verified live: `getComputedStyle(svg).strokeWidth` is 1.5px on the rail's
+lucide glyphs (their `stroke-width` ATTRIBUTE is still 2 — the CSS wins),
+1.5px on the folders, 1.9px on the badges, and the logo computes to
+rgb(255, 255, 255).


### PR DESCRIPTION
Punch list 11, first two items.

## PL11-001 — lighter icon strokes, white logo

At 28px the rail's glyphs carried too much stroke; lucide's default 2 reads heavy once an icon is that big. Every rail glyph is now 1.5.

Set in CSS (`[stroke-width:1.5]` on the shared glyph class) rather than as a prop per icon, because `stroke-width` is an inherited SVG property — one class covers every icon the rail renders, present and future. The two composed folder icons keep their own explicit widths (a presentation attribute beats an inherited value), so those were lightened by hand: folder to 1.5, corner badges to 1.9 — heavier on purpose, since at 16px inside a 24px badge a 1.5 stroke disappears.

The logo's "SW" is white rather than zinc-400.

## PL11-002 — the details trigger moves onto the item

The toolbar was the wrong home for a per-item control. The trigger now sits in the media card's top-right: hidden at rest, revealed on hover or keyboard focus, and a real tab stop.

**Placement drove the design.** `NodeCard`'s shell IS a `<button>`, and a button inside a button is invalid HTML — the constraint that put this control in the toolbar originally. Media items now render through a wrapper (`GraphMediaItem`) carrying the sizing and the hover group, with NodeCard filling it and the trigger as a sibling. Outside that button, a press here also never reaches the card's drag wiring.

**Tab order.** `tabIndex` follows the surface's ROVING value rather than a flat 0: a virtualized strip mounts dozens of cards, and a fixed tab stop each would put dozens in the tab order. Roving keeps the surface at one stop and this adds exactly one more, on the card the user is on — Tab from the card lands on its trigger, Enter opens the view.

**The open state changed shape.** The context held a boolean mode paired with "whatever is selected", which only worked while the single trigger was global. It now names WHICH item is open, since a card can be pressed without being the selection; pressing the trigger also selects the card, so the board's selection-scoped readouts agree with the view.

## Verification

- graph-view e2e **93/93**, typecheck and lint clean.
- The trigger's e2e pins idle → hover → away → focus opacity, the Tab-then-Enter path, and that pressing it selects. Those hover assertions must run BEFORE any click: clicking a card focuses it, and focus legitimately reveals the trigger, so a click first makes the idle state untestable.
- Strokes measured live: `getComputedStyle(svg).strokeWidth` is 1.5px on the rail's lucide glyphs (their `stroke-width` attribute is still 2 — the CSS wins), 1.9px on the badges; the logo computes to `rgb(255, 255, 255)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
