### PR TITLE
Punch list 11: a save indicator, and clip titles that only show when authored

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -49,6 +49,7 @@ import {
 import { AddCollectionSlot } from "./graph-add-collection-slot";
 import { CollectionHoverProvider } from "./graph-collection-hover";
 import { ItemDetailsProvider } from "./graph-item-details-context";
+import { GraphSaveStatus } from "./graph-save-status";
 import { GraphItemDetailsModal } from "./graph-item-details-modal";
 import { SubTimelines } from "./graph-sub-timelines";
 import {
@@ -446,10 +447,16 @@ export function GraphBoard({
                 drag readout that overlays this row, and fade back on drop. The
                 breadcrumb stays — it IS the drop target. */}
             <DragChromeFade className="flex items-center">
-              <FocusedAggregate
-                focusedId={focusedId}
-                pixelsPerSecond={deferredPixelsPerSecond}
-              />
+              {/* One centre slot, two possible occupants. The save state takes
+                  it while it has something to say and hands it back after —
+                  the clip/duration total is a fact you can re-read at any
+                  time, "not saved yet" is not. */}
+              <GraphSaveStatus>
+                <FocusedAggregate
+                  focusedId={focusedId}
+                  pixelsPerSecond={deferredPixelsPerSecond}
+                />
+              </GraphSaveStatus>
             </DragChromeFade>
             {/* flex-wrap + wrap-capable controls so a narrow viewport folds the
                 toolbar onto a second line instead of pushing controls

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -453,6 +453,10 @@ const GraphClipContent = memo(function GraphClipContent({
   const inheritedDisabled = useDisabledByAncestor(id);
   const provenance = useCardProvenance(id);
   const frameLoading = useContext(VideoFrameLoadingContext);
+  // The AUTHORED name, read straight from the side table rather than from
+  // `node.name`: the node's name falls back to the derived alt, so it can't
+  // tell "named by someone" from "named by the file system".
+  const detail = useClipDetail(id as string);
 
   // MEDIA pixels only. Collections don't render through this seam anymore:
   // their card carries interactive controls (folder drill-in, inline rename),
@@ -554,6 +558,22 @@ const GraphClipContent = memo(function GraphClipContent({
       >
         {isVideo ? "VIDEO" : "IMAGE"}
       </span>
+      {/* The clip's NAME, shown only when someone gave it one (PL11-004).
+          Every clip has an `alt` — a filename, usually — so a card that
+          rendered "the name" would render something on all of them, and a
+          library of two thousand machine-named clips reads as a rename
+          backlog. `detail.title` is absent until authored, so an unnamed card
+          simply has no label rather than an empty-looking slot.
+          Decorative for AT: the card's own aria-label already names it. */}
+      {detail?.title && !muted && (
+        <span
+          aria-hidden="true"
+          data-clip-title
+          className="pointer-events-none absolute inset-x-2 top-2 z-10 truncate rounded bg-black/75 px-1.5 py-0.5 text-[11px] leading-tight font-semibold text-zinc-100"
+        >
+          {detail.title}
+        </span>
+      )}
       {muted && (
         <DisabledChip inherited={node.disabled !== true} />
       )}

--- a/apps/timeline-gstudio001/components/graph-view/graph-persistence.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-persistence.tsx
@@ -59,16 +59,19 @@ export function PersistenceBridge({
               void graphDocumentsGateway.renameTimeline(update.nodeId as string, update.after.name);
               continue;
             }
-            // A MEDIA rename has to land in the side table, because that is
-            // what the write path reads: `graphChildrenToClips` emits
-            // `alt: detail?.alt ?? node.name`, and every clip loaded from a
-            // document has `detail.alt` set — so a rename that only touched
-            // the graph would look right, then be overwritten by the stored
-            // alt on the next write and revert on reload. Same patch shape on
-            // undo/redo, so the round-trip reverses for free.
+            // A MEDIA rename lands in the side table, because that is what the
+            // write path reads — a rename that only touched the graph would
+            // look right and then be overwritten on the next write.
+            //
+            // It writes `title`, NOT `alt` (PL11-004): `alt` is the derived
+            // accessibility description and must survive naming, and absence
+            // of `title` is what tells the card this clip is unnamed. Same
+            // patch shape on undo/redo, so the round-trip reverses for free.
             const detail = detailsStore.get(update.nodeId as string);
             if (!detail) continue;
-            detailsStore.merge({ [update.nodeId as string]: { ...detail, alt: update.after.name } });
+            detailsStore.merge({
+              [update.nodeId as string]: { ...detail, title: update.after.name },
+            });
           }
         }
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-save-status.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-save-status.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useState, useSyncExternalStore, type ReactNode } from "react";
+import { CircleAlert, Cloud, CloudUpload } from "lucide-react";
+
+import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
+
+// The save indicator (PL11-003).
+//
+// The app autosaves on a 900ms debounce and, until now, said nothing about it
+// at all — the only readout was a dev-gated panel behind `?dev`. That is a
+// gap with teeth: undo history lives in memory, so a reload ends it, and an
+// autosaved mistake the user never saw commit has no path back. "Is my work
+// safe" deserves an answer on screen.
+//
+// Three states, and no more: something is on its way, everything landed, or
+// something failed. The failure case is the only one that shouts.
+//
+// It lives in the header's CENTRE slot and TAKES IT OVER while it has
+// something to say, handing it back to the clip/duration readout when it does
+// not. One slot, and whichever fact matters more at that moment: a total you
+// can re-read any time loses to "your last edit is not on the server yet".
+
+/** How long "Saved" stays up after a batch lands, before it settles into the
+ *  quiet resting state. Long enough to be noticed, short enough that it isn't
+ *  claiming freshness it no longer has. */
+const SAVED_FLASH_MS = 2600;
+
+function useSaveState() {
+  return useSyncExternalStore(
+    graphDocumentsGateway.subscribe,
+    graphDocumentsGateway.saveState,
+    // Server render: nothing has been written yet.
+    () => ({ pending: 0, inFlight: 0, lastSavedAt: null, error: null }),
+  );
+}
+
+export function GraphSaveStatus({ children }: Readonly<{ children?: ReactNode }>) {
+  const { pending, inFlight, lastSavedAt, error } = useSaveState();
+  const busy = pending > 0 || inFlight > 0;
+
+  // "Saved" is time-based, so it needs a tick of its own: the gateway has
+  // nothing further to notify about once the batch has landed, and without
+  // this the flash would hang around until the next unrelated notification.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (busy || lastSavedAt === null) return;
+    const timer = setTimeout(() => setNow(Date.now()), SAVED_FLASH_MS);
+    return () => clearTimeout(timer);
+  }, [busy, lastSavedAt]);
+
+  const justSaved = !busy && lastSavedAt !== null && now - lastSavedAt < SAVED_FLASH_MS;
+
+  if (error !== null) {
+    return (
+      <span
+        data-save-status="error"
+        title={error}
+        className="flex shrink-0 items-center gap-1.5 px-3 font-mono text-[11px] text-amber-300"
+      >
+        <CircleAlert aria-hidden="true" className="h-3.5 w-3.5" />
+        Not saved
+      </span>
+    );
+  }
+
+  if (busy) {
+    return (
+      <span
+        data-save-status="saving"
+        title="Writing your changes"
+        className="flex shrink-0 items-center gap-1.5 px-3 font-mono text-[11px] text-zinc-400"
+      >
+        <CloudUpload aria-hidden="true" className="h-3.5 w-3.5" />
+        Saving…
+      </span>
+    );
+  }
+
+  // The brief confirmation, then the slot goes back to its usual occupant.
+  // A permanent "Saved" would be chrome that never says anything new.
+  if (justSaved) {
+    return (
+      <span
+        data-save-status="saved"
+        title="Every change is on the server"
+        className="flex shrink-0 items-center gap-1.5 px-3 font-mono text-[11px] text-zinc-300"
+      >
+        <Cloud aria-hidden="true" className="h-3.5 w-3.5" />
+        Saved
+      </span>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
@@ -139,6 +139,22 @@ export type GraphDocumentsGateway = Readonly<{
   isConflicted: (timelineId: string) => boolean;
   /** Cache-change notifications (documents landing, clips written). */
   subscribe: (listener: () => void) => () => void;
+  /**
+   * Where the write path currently stands, for a save indicator. The app
+   * autosaves on a debounce, so without this the user has no way to know
+   * whether an edit is committed — and undo history does not survive a
+   * reload, which makes "did that save?" a question with consequences.
+   *
+   * `pending` counts documents waiting out the debounce window, `inFlight`
+   * those in the batch being sent. Both zero with a `lastSavedAt` means
+   * everything is on the server.
+   */
+  saveState: () => Readonly<{
+    pending: number;
+    inFlight: number;
+    lastSavedAt: number | null;
+    error: string | null;
+  }>;
   /** Outstanding load/save failures, for a status banner. Null when every
    *  document is healthy; multiple failures are all listed. */
   lastError: () => string | null;
@@ -233,6 +249,32 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
   // `boundUid` is still null — dropping them there left every child doc
   // un-warmed. Held here and replayed on bind (foreign uids discarded then).
   let pendingPrimes: { document: TimelineDocument; revision: number; forUid: string }[] = [];
+
+  // When the last batch settled OK — the "Saved" half of the indicator.
+  let lastSavedAt: number | null = null;
+  // CACHED, and re-allocated only when a field actually changes.
+  // `useSyncExternalStore` compares snapshots by identity: a getter that
+  // builds a fresh object per call re-renders forever and React tears the
+  // tree down. (It did — the board stopped rendering entirely.)
+  let saveStateSnapshot: {
+    pending: number;
+    inFlight: number;
+    lastSavedAt: number | null;
+    error: string | null;
+  } = { pending: 0, inFlight: 0, lastSavedAt: null, error: null };
+  const readSaveState = () => {
+    const pending = dirtyIds.size;
+    const inFlight = saveInFlightIds.length;
+    if (
+      saveStateSnapshot.pending !== pending ||
+      saveStateSnapshot.inFlight !== inFlight ||
+      saveStateSnapshot.lastSavedAt !== lastSavedAt ||
+      saveStateSnapshot.error !== errorBanner
+    ) {
+      saveStateSnapshot = { pending, inFlight, lastSavedAt, error: errorBanner };
+    }
+    return saveStateSnapshot;
+  };
 
   const notify = () => {
     for (const listener of listeners) listener();
@@ -479,6 +521,7 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
       saveInFlightKeepalive = false;
       saveInFlightIds = [];
       abandonSaveInFlight = null;
+      notify();
       // Trailing batch: edits that landed mid-flight go out now, from the
       // latest cache.
       if (saveQueued) {
@@ -508,6 +551,9 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
 
     saveInFlightIds = batchIds;
     saveInFlightKeepalive = wantsKeepalive && !overKeepaliveBudget;
+    // The dirty set just moved into a flight: same total work, different
+    // state, and the indicator distinguishes them.
+    notify();
     saveInFlight = fetch("/api/timelines/batch", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -525,6 +571,7 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
               results?: { id: string; revision: number }[];
             };
             if (gen !== generation) return;
+            lastSavedAt = Date.now();
             for (const write of writes) setError(write.document.id, null);
             for (const entry of result.results ?? []) {
               if (typeof entry.revision === "number") revisions.set(entry.id, entry.revision);
@@ -730,6 +777,7 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
     hasPendingWrite: (timelineId) =>
       dirtyIds.has(timelineId) || saveInFlightIds.includes(timelineId),
     isConflicted: (timelineId) => conflictedIds.has(timelineId),
+    saveState: readSaveState,
     subscribe: (listener) => {
       listeners.add(listener);
       return () => {

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -4107,6 +4107,48 @@ test.describe("graph view E2E", () => {
     await expect(page.getByRole("dialog")).toHaveCount(1);
   });
 
+  test("the header says whether the work is saved", async ({ page }) => {
+    // PL11-003. The app autosaves on a 900ms debounce and used to say nothing
+    // about it — and undo history dies on reload, so "did that save?" is a
+    // question with consequences.
+    await installGraphApi(page);
+    await openGraph(page);
+
+    const status = page.locator("[data-save-status]");
+    // Nothing written yet: no claim either way.
+    await expect(status).toHaveCount(0);
+
+    // Any edit puts it into flight. A trim commits on release.
+    const alpha = strip(page, PROJECT_ID).locator('[data-node-id="alpha"]');
+    const wrapper = strip(page, PROJECT_ID).locator('[data-node-wrapper="alpha"]');
+    await expect(async () => {
+      await alpha.click();
+      await expect(alpha).toHaveAttribute("data-selected", "true", { timeout: 700 });
+    }).toPass({ timeout: 10000 });
+    const handle = wrapper.locator("[data-trim-handle]").last();
+    const handleBox = (await handle.boundingBox())!;
+    await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(handleBox.x - 30, handleBox.y + handleBox.height / 2, { steps: 6 });
+    await page.mouse.up();
+
+    // "Saving…" covers both halves of the write path — the debounce window and
+    // the batch in flight — so the poll is on the STATE, not on catching a
+    // particular instant of it.
+    await expect.poll(() => status.getAttribute("data-save-status"), { timeout: 3000 })
+      .toBe("saving");
+    await expect.poll(() => status.getAttribute("data-save-status"), { timeout: 8000 })
+      .toBe("saved");
+    await expect(status).toContainText("Saved");
+
+    // It OWNS the centre slot while it speaks: the clip/duration readout is
+    // displaced, not pushed aside, and comes back when the flash ends.
+    await expect(page.locator("[data-focused-aggregate], [data-selection-summary]"))
+      .toHaveCount(0);
+    await expect(status).toHaveCount(0, { timeout: 6000 });
+    await expect(page.locator("[data-selection-summary]")).toHaveCount(1);
+  });
+
   test("ctrl+z undoes and ctrl+shift+z redoes from the keyboard", async ({ page }) => {
     // PL10-009. Undo/redo had NO keyboard binding — only the toolbar buttons,
     // which is fine until something covers them (the trim modal) or the page
@@ -4228,9 +4270,11 @@ test.describe("graph view E2E", () => {
     }).toPass({ timeout: 10000 });
     await openItemDetails(page, "alpha");
 
-    const storedAlt = () =>
-      api.documents.get(PROJECT_ID)?.clips.find((clip) => clip.id === "alpha")?.alt;
-    expect(storedAlt()).toBe("alpha");
+    const storedClip = () =>
+      api.documents.get(PROJECT_ID)?.clips.find((clip) => clip.id === "alpha");
+    const storedTitle = () => storedClip()?.title;
+    expect(storedTitle()).toBeUndefined();
+    expect(storedClip()?.alt).toBe("alpha");
 
     // Double-click the name, type, Enter.
     await page.locator("[data-item-details] >> text=alpha").first().dblclick();
@@ -4241,8 +4285,22 @@ test.describe("graph view E2E", () => {
 
     // The graph took it...
     await expect(page.locator("[data-item-details]")).toContainText("Belushi close-up");
-    // ...and so did the write, once the gateway's debounce flushes.
-    await expect.poll(storedAlt, { timeout: 5000 }).toBe("Belushi close-up");
+    // ...and so did the write, once the gateway's debounce flushes — as
+    // `title`, with `alt` untouched. Renaming a clip must not rewrite the
+    // accessibility description derived from its source (PL11-004).
+    await expect.poll(storedTitle, { timeout: 5000 }).toBe("Belushi close-up");
+    expect(storedClip()?.alt).toBe("alpha");
+
+    // And the card now shows it, because someone chose it. Unnamed cards
+    // stay bare — that is what keeps a two-thousand-clip library from
+    // reading as a rename backlog.
+    await page.keyboard.press("Escape");
+    await expect(page.locator("[data-item-details]")).toHaveCount(0);
+    await expect(strip(page, PROJECT_ID).locator('[data-node-id="alpha"] [data-clip-title]'))
+      .toHaveText("Belushi close-up");
+    await expect(strip(page, PROJECT_ID).locator('[data-node-id="bravo"] [data-clip-title]'))
+      .toHaveCount(0);
+    await openItemDetails(page, "alpha");
 
     // Escape cancels an edit instead of closing the modal — the capture-phase
     // key handler has to yield to the editor.
@@ -4252,7 +4310,7 @@ test.describe("graph view E2E", () => {
     await reopened.press("Escape");
     await expect(page.getByRole("dialog")).toHaveCount(1);
     await expect(page.locator("[data-item-details]")).toContainText("Belushi close-up");
-    expect(storedAlt()).toBe("Belushi close-up");
+    expect(storedTitle()).toBe("Belushi close-up");
   });
 
   test("a trim drag floats the edge frame above the clip", async ({ page }) => {

--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -54,6 +54,10 @@ export type DocumentsById = Readonly<Record<string, TimelineDocument>>;
 /** App-level clip detail the graph deliberately doesn't model. */
 export type ClipDetail = Readonly<{
   alt: string;
+  /** The user's own name for this clip, when they gave it one. Absent means
+   *  unnamed — which is what the card reads to decide whether to show a name
+   *  at all, so "" and undefined are not interchangeable here. */
+  title?: string;
   aspect: number;
   trackIndex: number;
   poster?: string;
@@ -116,7 +120,7 @@ function mediaSpec(clip: Exclude<TimelineClip, CollectionTimelineClip>): GraphNo
       kind: "media",
       mediaKind: "video",
       id: clip.id,
-      name: clip.alt,
+      name: clip.title ?? clip.alt,
       src: clip.src,
       posterSrcs: clip.poster === undefined ? undefined : [clip.poster],
       fullDurationSeconds: clip.sourceDuration,
@@ -128,7 +132,7 @@ function mediaSpec(clip: Exclude<TimelineClip, CollectionTimelineClip>): GraphNo
   return {
     kind: "media",
     id: clip.id,
-    name: clip.alt,
+    name: clip.title ?? clip.alt,
     src: clip.src,
     durationSeconds: clip.duration,
     ...(clip.disabled ? { disabled: true } : {}),
@@ -138,6 +142,7 @@ function mediaSpec(clip: Exclude<TimelineClip, CollectionTimelineClip>): GraphNo
 function mediaDetail(clip: Exclude<TimelineClip, CollectionTimelineClip>): ClipDetail {
   return {
     alt: clip.alt,
+    ...(clip.title === undefined ? {} : { title: clip.title }),
     aspect: clip.aspect,
     trackIndex: clip.trackIndex,
     ...(clip.poster === undefined ? {} : { poster: clip.poster }),
@@ -530,7 +535,12 @@ export function graphChildrenToClips(
         // A demoted duplicate (see clipSpecs) writes back its STORED id.
         id: detail?.sourceClipId ?? (node.id as string),
         index,
+        // `alt` stays the DERIVED description: a rename writes `title` (see
+        // the persistence bridge), so accessibility text survives naming.
+        // The `?? node.name` fallback is for nodes minted in-session, which
+        // have no detail entry yet.
         alt: detail?.alt ?? node.name,
+        ...(detail?.title === undefined ? {} : { title: detail.title }),
         aspect: detail?.aspect ?? 16 / 9,
         trackIndex: detail?.trackIndex ?? 0,
         startTime,

--- a/packages/timeline-model/types.ts
+++ b/packages/timeline-model/types.ts
@@ -13,7 +13,27 @@ export type CollectionEndpoint = "first" | "last";
 export type TimelineItemBase = {
   id: string;
   index: number;
+  /**
+   * What this clip IS, for assistive tech and image fallbacks — derived from
+   * the source when a clip is created, never authored. Distinct from `title`
+   * on purpose: renaming a clip must not rewrite its accessibility text.
+   */
   alt: string;
+  /**
+   * A NAME the user chose, absent until they choose one.
+   *
+   * Absence is the point. Every clip has an `alt` (a filename, usually), so a
+   * card that displayed "the name" would display something for all of them —
+   * and a library of two thousand machine-named clips reads as a rename
+   * backlog rather than a set of finished items. Only authored titles are
+   * shown, so a named clip looks deliberate and an unnamed one looks neutral.
+   *
+   * The job it does: similar-looking clips (ten close-ups of one actor, cut
+   * from ten different takes) are indistinguishable by thumbnail and carry no
+   * mechanical discriminator at all. A title is the only thing that can say
+   * which moment this is.
+   */
+  title?: string;
   aspect: number;
   trackIndex: number;
 

--- a/punch-list/PUNCH-LIST-11.md
+++ b/punch-list/PUNCH-LIST-11.md
@@ -1,5 +1,85 @@
 # Punch List 11
 
+## PL11-003 — The header says whether the work is saved
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `lib/graph-documents-gateway.ts`, `graph-save-status.tsx` (new),
+  `graph-board.tsx`
+- Screenshot: Not captured
+
+The app autosaves on a 900ms debounce and said nothing about it — the only
+readout was a dev-gated panel behind `?dev`. That gap has teeth: undo history
+lives in memory, so a reload ends it, and an autosaved mistake the user never
+saw commit has no path back.
+
+The gateway now exposes `saveState()` — pending (waiting out the debounce),
+inFlight (in the batch being sent), lastSavedAt, error — and notifies when a
+batch starts and settles, which it did not do before. Three states and no
+more: `Saving…`, `Saved` (~2.6s), and `Not saved` with the error on its
+tooltip.
+
+It lives in the header's CENTRE slot and takes it over while it has something
+to say, handing it back to the clip/duration readout when it doesn't — one
+slot, whichever fact matters more at that moment. A total you can re-read at
+any time loses to "your last edit isn't on the server yet". Nothing shows
+before the session's first write, and there is no permanent resting "Saved":
+chrome that never changes says nothing.
+
+TRAP: `saveState()` first returned a fresh object per call, and
+`useSyncExternalStore` compares snapshots by IDENTITY — so it re-rendered
+forever and React tore the tree down. The board stopped rendering entirely and
+every e2e using it timed out waiting for a card. The getter now caches its
+snapshot and re-allocates only when a field actually changes.
+
+Acceptance criteria:
+
+- No indicator before the first write of a session.
+- An edit shows `Saving…`, then `Saved` once the batch lands, then the centre
+  slot returns to the clip/duration readout.
+- A failure says so, carries the reason, and holds the slot.
+
+## PL11-004 — A clip's name is `title`, and only shows when authored
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `packages/timeline-model/types.ts`,
+  `packages/timeline-domain/src/adapter.ts`, `graph-persistence.tsx`,
+  `graph-item-content.tsx`
+- Screenshot: Not captured
+
+PL10-010 wrote renames into `alt`, which was two problems in one: it rewrote
+the accessibility description, and it left no way to tell a name a person
+chose from a filename the import supplied.
+
+`title` is now its own optional field on the clip, absent until someone types
+one. `alt` goes back to being the derived description and survives renaming.
+The node's `name` reads `title ?? alt`, so aria labels, drag ghosts and
+announcements show the best available name; the CARD reads `detail.title`
+directly, so it shows a label only when one was authored.
+
+That absence is the point. Every clip has an `alt`, so a card rendering "the
+name" renders something for all of them — and two thousand machine-named
+clips read as a rename backlog. Unnamed cards stay bare; named ones look
+deliberate.
+
+What names are FOR here, from the user: similar-looking clips (ten close-ups
+of one actor, cut from ten different takes) are indistinguishable by
+thumbnail and carry no mechanical discriminator — each is 0→N of its own
+source, so in/out says nothing. A title is the only thing that can say which
+moment it is.
+
+Acceptance criteria:
+
+- Renaming writes `title` and leaves `alt` untouched.
+- A card shows a name only when `title` is set.
+- The details view still shows the best name, and renaming round-trips
+  through a reload.
+
+Rejected on the way: positional suffixes for naming a run ("Jake reacts 1…4").
+Reorder is free in this app, so the numbers would start lying the moment
+anyone moved a clip — a name that lies is worse than no name.
+
 ## PL11-002 — The details trigger moves onto the item
 
 - Status: Complete


### PR DESCRIPTION
Two items, both from the UX review: the app never said whether it had saved, and renaming a clip overwrote its accessibility text.

## PL11-003 — the header says whether the work is saved

The app autosaves on a 900ms debounce and said nothing about it; the only readout was a dev-gated panel behind `?dev`. That gap has teeth — undo history lives in memory, so a reload ends it, and an autosaved mistake the user never saw commit has no path back.

`graphDocumentsGateway` now exposes `saveState()` (pending / inFlight / lastSavedAt / error) and notifies when a batch **starts** and when it **settles**, neither of which it did before.

The indicator takes over the header's **centre slot** while it has something to say and hands it back to the clip/duration readout when it doesn't — one slot, whichever fact matters more at that moment. Three states and no more: `Saving…`, `Saved` (~2.6s), `Not saved` with the reason on its tooltip. Nothing before the session's first write, and no permanent resting "Saved": chrome that never changes says nothing. The error state holds the slot, because "not saved" outranks a duration total for as long as it's true.

**Trap, now commented:** `saveState()` first returned a fresh object per call, and `useSyncExternalStore` compares snapshots by identity — so it re-rendered forever and React tore the tree down. The board stopped rendering entirely and every e2e using it timed out waiting for a card. The getter caches its snapshot and re-allocates only when a field changes.

## PL11-004 — a clip's name is `title`, and only shows when authored

PL10-010 wrote renames into `alt`, which was two problems in one: it rewrote the accessibility description, and it left no way to tell a name a person chose from a filename the import supplied.

`title` is now its own optional field, absent until someone types one. `alt` goes back to being the derived description and survives renaming. The node's `name` reads `title ?? alt` so aria labels, drag ghosts and announcements show the best available name; the **card** reads `detail.title` directly, so it labels only what a person named.

The absence is the design. Every clip has an `alt`, so a card rendering "the name" renders something for all of them — and two thousand machine-named clips read as a rename backlog rather than a finished library. Unnamed cards stay bare; named ones look deliberate.

What a name is *for* here: ten close-ups of one actor, cut from ten different takes, are indistinguishable by thumbnail and carry no mechanical discriminator at all — each is 0→N of its own source, so in/out says nothing. A title is the only thing that can say which moment it is.

**Rejected on the way:** positional suffixes for naming a run (`Jake reacts 1…4`). Reorder is free in this app, so the numbers would start lying the moment anyone moved a clip.

## Verification

- graph-view e2e **94/94**, app vitest **442/442**, typecheck and lint clean.
- The save e2e pins the takeover *and* the hand-back: while the status is up, `[data-focused-aggregate]` and `[data-selection-summary]` are both absent; once it clears, the readout returns.
- The rename e2e now asserts `title` becomes the new name **and** `alt` stays `"alpha"`, so the a11y text can't be silently overwritten again.
- Driven live: `1 selected · 22.7s` → `Saving…` → `Saved` → back to the readout; one of five cards carries a label, the rest are bare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
