### PR TITLE
Punch list 11: rename in place, typed trims, a shortcuts sheet, durable undo

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -21,6 +21,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuGroup,
+  DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
@@ -50,6 +51,7 @@ import { AddCollectionSlot } from "./graph-add-collection-slot";
 import { CollectionHoverProvider } from "./graph-collection-hover";
 import { ItemDetailsProvider } from "./graph-item-details-context";
 import { GraphSaveStatus } from "./graph-save-status";
+import { GraphShortcuts, requestGraphShortcuts } from "./graph-shortcuts";
 import { GraphItemDetailsModal } from "./graph-item-details-modal";
 import { SubTimelines } from "./graph-sub-timelines";
 import {
@@ -97,6 +99,12 @@ function BoardMenu({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
+        <DropdownMenuGroup>
+          <DropdownMenuItem onSelect={() => requestGraphShortcuts()}>
+            Keyboard shortcuts
+            <span className="ml-auto pl-6 font-mono text-[11px] text-zinc-500">?</span>
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
         <DropdownMenuGroup>
           <DropdownMenuLabel>Thumbnail size</DropdownMenuLabel>
           <DropdownMenuRadioGroup
@@ -408,6 +416,9 @@ export function GraphBoard({
             portals to the body, so where it mounts only decides which
             providers it can see. */}
         <GraphItemDetailsModal />
+        {/* The "?" sheet. Every gesture in this view is invisible otherwise —
+            hold-to-drag, O, F2, the whole Alt layer (PL11-007). */}
+        <GraphShortcuts />
         <div className="flex flex-col gap-2">
           {/* Pinned so the controls stay reachable while scrolling the
               surfaces. It sticks just BELOW the sticky preview via the offset

--- a/apps/timeline-gstudio001/components/graph-view/graph-history-persistence.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-history-persistence.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { useCollectionsStore, type HistoryEntry } from "@storyboard/ui/dnd-collections";
+
+// Undo that survives a reload (PL11-008).
+//
+// The app autosaves, and history lived only in memory — so a refresh made
+// every committed mistake permanent, with the trash covering deletes and
+// nothing covering trims, renames or moves. Patches are serializable by
+// design ("this log doubles as a persistence journal", says the history
+// module), so the stack can simply be written down.
+//
+// sessionStorage, not localStorage: a reload is the case this exists for, and
+// a stack from days ago — built against a graph the server has since changed
+// under other sessions — is a liability rather than a safety net. Same tab,
+// same sitting.
+//
+// Restoring is SAFE without validation here: `undo` verifies each entry
+// against the live graph before applying it and drops the unreachable side,
+// so a stale entry is refused when reached instead of corrupting anything.
+
+/** Bounded on purpose: sessionStorage is a few MB per origin, and a
+ *  `nodes-added` patch carries whole node specs. Fifty steps back is far more
+ *  than anyone walks, and the oldest are the least valuable. */
+const MAX_ENTRIES = 50;
+/** A ceiling in case fifty entries are unusually fat (a big multi-select
+ *  move). Writing is best-effort — a full quota must never break editing. */
+const MAX_BYTES = 512_000;
+
+const storageKey = (sessionKey: string) => `graph-history:${sessionKey}`;
+
+/** Structural check at the trust boundary — this came from storage, which the
+ *  user (or an older build) can have written anything into. */
+function parseEntries(raw: string): readonly HistoryEntry[] {
+  const parsed: unknown = JSON.parse(raw);
+  if (!Array.isArray(parsed)) return [];
+  const entries: HistoryEntry[] = [];
+  for (const candidate of parsed) {
+    if (typeof candidate !== "object" || candidate === null) continue;
+    const entry = candidate as Partial<HistoryEntry>;
+    if (typeof entry.command !== "object" || entry.command === null) continue;
+    if (typeof entry.patch !== "object" || entry.patch === null) continue;
+    if (typeof entry.at !== "number") continue;
+    entries.push(entry as HistoryEntry);
+  }
+  return entries;
+}
+
+/**
+ * Mount inside the collections provider, keyed to the boot session. Restores
+ * once on mount, then mirrors every committed change back to storage.
+ */
+export function HistoryPersistenceBridge({
+  sessionKey,
+}: Readonly<{ sessionKey: string }>) {
+  const store = useCollectionsStore();
+  // Restore exactly once per session, and never re-restore from our own
+  // writes: the effect below fires on every commit.
+  const restoredRef = useRef(false);
+
+  useEffect(() => {
+    if (restoredRef.current) return;
+    restoredRef.current = true;
+    if (typeof window === "undefined") return;
+    try {
+      const raw = window.sessionStorage.getItem(storageKey(sessionKey));
+      if (!raw) return;
+      const entries = parseEntries(raw);
+      if (entries.length > 0) store.restoreHistory(entries);
+    } catch {
+      // Unreadable or unparseable: an absent undo stack is the same outcome
+      // the user had before this existed, so there is nothing to report.
+    }
+  }, [store, sessionKey]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    return store.subscribeToChanges(() => {
+      const entries = store.getSnapshot().historyEntries;
+      const recent = entries.slice(-MAX_ENTRIES);
+      try {
+        const payload = JSON.stringify(recent);
+        if (payload.length > MAX_BYTES) {
+          // Too fat to keep whole — keep the newest half rather than nothing.
+          const half = recent.slice(Math.floor(recent.length / 2));
+          window.sessionStorage.setItem(storageKey(sessionKey), JSON.stringify(half));
+          return;
+        }
+        window.sessionStorage.setItem(storageKey(sessionKey), payload);
+      } catch {
+        // Quota or private-mode failure: editing continues, undo just goes
+        // back to being session-only.
+      }
+    });
+  }, [store, sessionKey]);
+
+  return null;
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -1073,18 +1073,40 @@ const ItemDetailsTrigger = memo(function ItemDetailsTrigger({
 });
 
 /**
- * The media card: the stock NodeCard, wrapped so a details trigger can sit
- * beside it. The wrapper carries the surface's sizing className and the hover
- * group; NodeCard fills it.
+ * The media card: the stock NodeCard, wrapped so a details trigger and a
+ * rename editor can sit BESIDE it. The wrapper carries the surface's sizing
+ * className and the hover group; NodeCard fills it.
+ *
+ * The editor is a sibling for the reason everything else here is: NodeCard's
+ * shell is a `<button>`, and an `<input>` inside it is invalid interactive
+ * content. Naming a run of similar clips is arrow → F2 → type → Enter →
+ * arrow, with no modal in the loop (PL11-005) — the same grammar the
+ * collection card, breadcrumb and sub-timeline row already share.
  */
 const GraphMediaItem = memo(function GraphMediaItem({
   className,
   ...props
 }: CollectionItemShellProps) {
+  const node = useCollectionsSelector((s) => s.graph.nodesById.get(props.id) ?? null);
+  const detail = useClipDetail(props.id as string);
+  // Seeded with the AUTHORED title when there is one, so re-naming edits what
+  // the user wrote rather than making them delete a filename first.
+  const rename = useInlineRename(props.id, detail?.title ?? "", "card");
+
   return (
     <div className={["group/media-item relative", className ?? ""].join(" ")}>
       <NodeCard {...props} className="h-full w-full" />
       <ItemDetailsTrigger id={props.id} rovingTabIndex={props.rovingTabIndex} />
+      {rename.editing && node?.kind === "media" && (
+        <InlineNameEditor
+          initialValue={detail?.title ?? ""}
+          onInput={rename.setDraft}
+          onCommit={rename.commit}
+          onCancel={rename.cancel}
+          ariaLabel="Clip name"
+          className="absolute inset-x-1 top-1 z-30 rounded-sm bg-zinc-950/95 px-1 py-0.5 text-[11px] font-semibold text-zinc-100 outline-none ring-1 ring-amber-400/70"
+        />
+      )}
     </div>
   );
 });

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -169,6 +169,120 @@ function useScopedHistory(nodeId: string) {
   };
 }
 
+/** Two decimals, and never NaN — a half-typed field must not dispatch. */
+function parseSeconds(raw: string): number | null {
+  const value = Number.parseFloat(raw);
+  if (!Number.isFinite(value)) return null;
+  return Math.round(value * 100) / 100;
+}
+
+/**
+ * Typed in/out points for a video (PL11-006).
+ *
+ * Each field commits on blur or Enter, as ONE `update-media` — the same
+ * command the grips dispatch, so this is a second input method for one
+ * behaviour rather than a second path into the model. Escape reverts the
+ * field to the committed value.
+ *
+ * Clamping is deliberate rather than validating-and-refusing: an out point
+ * before the in point (or past the source) is a typo, and snapping to the
+ * nearest legal value is faster to correct than an error message. The 0.05s
+ * floor keeps a clip from being trimmed to nothing by a stray keystroke.
+ */
+function TrimNumbers({
+  node,
+  trimIn,
+  trimOut,
+  disabled,
+}: Readonly<{ node: VideoMediaNode; trimIn: number; trimOut: number; disabled: boolean }>) {
+  const store = useCollectionsStore();
+  const full = node.fullDurationSeconds;
+  const inPoint = trimIn;
+  const outPoint = full - trimOut;
+
+  const commit = (side: "in" | "out", raw: string) => {
+    const typed = parseSeconds(raw);
+    if (typed === null) return;
+    const next =
+      side === "in"
+        ? {
+            trimInSeconds: Math.min(Math.max(0, typed), Math.max(0, outPoint - MIN_SHOWING_SECONDS)),
+            trimOutSeconds: trimOut,
+          }
+        : {
+            trimInSeconds: trimIn,
+            trimOutSeconds: Math.min(
+              Math.max(0, full - typed),
+              Math.max(0, full - inPoint - MIN_SHOWING_SECONDS),
+            ),
+          };
+    if (next.trimInSeconds === trimIn && next.trimOutSeconds === trimOut) return;
+    store.dispatch({
+      type: "update-media",
+      nodeId: node.id,
+      update: { mediaKind: "video", ...next },
+    });
+  };
+
+  return (
+    <div className="flex items-center gap-3 font-mono text-[11px] text-zinc-400">
+      <SecondsField label="in" value={inPoint} disabled={disabled} onCommit={(raw) => commit("in", raw)} />
+      <span aria-hidden="true" className="text-zinc-600">
+        →
+      </span>
+      <SecondsField label="out" value={outPoint} disabled={disabled} onCommit={(raw) => commit("out", raw)} />
+      <span className="text-zinc-600">of {full.toFixed(2)}s</span>
+    </div>
+  );
+}
+
+/** The smallest clip a typed edge may leave behind. */
+const MIN_SHOWING_SECONDS = 0.05;
+
+function SecondsField({
+  label,
+  value,
+  disabled,
+  onCommit,
+}: Readonly<{
+  label: string;
+  value: number;
+  disabled: boolean;
+  onCommit: (raw: string) => void;
+}>) {
+  // Uncontrolled between commits, keyed by the committed value: a controlled
+  // input would fight the caret while typing "1" on the way to "12.5", and
+  // the key makes it re-seed whenever the value changes underneath (a grip
+  // drag, an undo).
+  return (
+    <label className="flex items-center gap-1.5">
+      <span className="text-zinc-500">{label}</span>
+      <input
+        key={value}
+        type="text"
+        inputMode="decimal"
+        aria-label={`${label} point, seconds`}
+        data-trim-field={label}
+        defaultValue={value.toFixed(2)}
+        disabled={disabled}
+        onKeyDown={(event) => {
+          event.stopPropagation();
+          if (event.key === "Enter") {
+            onCommit((event.target as HTMLInputElement).value);
+            (event.target as HTMLInputElement).blur();
+          } else if (event.key === "Escape") {
+            (event.target as HTMLInputElement).value = value.toFixed(2);
+            (event.target as HTMLInputElement).blur();
+          }
+        }}
+        onBlur={(event) => onCommit(event.target.value)}
+        className="w-16 rounded-sm bg-zinc-900 px-1.5 py-0.5 text-right tabular-nums text-amber-200/90 outline-none ring-1 ring-zinc-700 focus:ring-amber-400/70 disabled:opacity-40"
+      />
+      <span className="text-zinc-600">s</span>
+    </label>
+  );
+}
+
 function ModalBody({ node, onClose }: Readonly<{ node: MediaNode; onClose: () => void }>) {
   const live = useLiveTrim(node.id);
   const history = useScopedHistory(node.id);
@@ -352,11 +466,19 @@ function ModalBody({ node, onClose }: Readonly<{ node: MediaNode; onClose: () =>
               ) : null}
             </div>
 
-            <div className="flex items-center justify-between font-mono text-[10px] text-zinc-500">
-              <span className="text-amber-200/90">
-                in {trimIn.toFixed(2)}s → out {(trimIn + showing).toFixed(2)}s
-              </span>
-              <span>drag the amber edges to trim, the film to move the window</span>
+            {/* TYPED in/out (PL11-006). Dragging resolves to whatever a pixel
+                is worth — ~0.11s here, and coarser on the board — so an exact
+                edge was simply unreachable by pointer. These are the same
+                `update-media` command the grips dispatch, so undo, the live
+                channel and the write path all behave identically. */}
+            <TrimNumbers
+              node={video}
+              trimIn={trimIn}
+              trimOut={trimOut}
+              disabled={live !== null}
+            />
+            <div className="text-right font-mono text-[10px] text-zinc-500">
+              drag the amber edges to trim, the film to move the window
             </div>
           </>
         ) : (

--- a/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
@@ -233,16 +233,18 @@ export function OpenKeyBoundary({
     nav?.openTimeline(parentId);
   };
 
-  // F2 opens the focused collection's inline rename editor — the keyboard twin
-  // of double-clicking its label, so rename isn't pointer-only. Only
-  // collections carry a rename editor (media has no name field), so the key is
-  // claimed only when it will actually act.
+  // F2 opens the focused card's inline rename editor — the keyboard twin of
+  // double-clicking its label, so rename isn't pointer-only. Collections AND
+  // media both carry one now (PL11-005): a media clip's name is its `title`,
+  // and naming a handful of similar-looking clips should not mean a modal
+  // round-trip each time.
   const renameFromKey = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (store.getSnapshot().interaction.isDragging) return;
     const target = event.target as HTMLElement;
     const id = target.closest<HTMLElement>("[data-node-id]")?.dataset.nodeId;
     if (!id) return;
-    if (store.getSnapshot().graph.nodesById.get(parseNodeId(id))?.kind !== "collection") return;
+    const node = store.getSnapshot().graph.nodesById.get(parseNodeId(id));
+    if (node?.kind !== "collection" && node?.kind !== "media") return;
     event.preventDefault();
     // F2 is pressed ON a card, so the card is what should open — the id was
     // resolved from the focused card's own element above.

--- a/apps/timeline-gstudio001/components/graph-view/graph-shortcuts.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-shortcuts.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { X } from "lucide-react";
+
+import { isEditableKeyboardTarget } from "@storyboard/ui/dnd-collections";
+
+// The shortcuts sheet (PL11-007).
+//
+// Nearly every gesture in this view is invisible: press-and-hold to drag, O to
+// drill in, F2 to rename, the whole Alt-key layer, and — until recently — no
+// keyboard undo at all. None of it was written down anywhere a user could
+// reach. This is that page.
+//
+// Every row below was verified against the handler that implements it rather
+// than written from memory: the app-level keys in `graph-item-actions`, the
+// board keys in `OpenKeyBoundary`, and the card grammar in the package's
+// `use-keyboard-controller`. A shortcut sheet that lies is worse than none.
+
+export const GRAPH_SHORTCUTS_EVENT = "graph-view:show-shortcuts";
+
+/** Ask the graph view to open the shortcuts sheet (the board menu does). */
+export function requestGraphShortcuts(): void {
+  window.dispatchEvent(new Event(GRAPH_SHORTCUTS_EVENT));
+}
+
+type Row = Readonly<{ keys: string; what: string }>;
+type Section = Readonly<{ title: string; note?: string; rows: readonly Row[] }>;
+
+const SECTIONS: readonly Section[] = [
+  {
+    title: "Anywhere in the view",
+    rows: [
+      { keys: "Ctrl/⌘ Z", what: "Undo" },
+      { keys: "Ctrl/⌘ ⇧ Z  ·  Ctrl Y", what: "Redo" },
+      { keys: "Ctrl/⌘ C", what: "Copy the selection" },
+      { keys: "Ctrl/⌘ X", what: "Cut — paste to move it" },
+      { keys: "Ctrl/⌘ V", what: "Paste" },
+      { keys: "Ctrl/⌘ D", what: "Duplicate in place" },
+      { keys: "?", what: "This sheet" },
+    ],
+  },
+  {
+    title: "On a focused card",
+    note: "Tab reaches one card per surface; arrows move between them.",
+    rows: [
+      { keys: "Space", what: "Select this card" },
+      { keys: "Ctrl/⌘ Space", what: "Add or remove it from a multi-selection" },
+      { keys: "Enter", what: "Grab it — arrows move, Enter drops, Escape cancels" },
+      { keys: "O", what: "Open a timeline card (drill in)" },
+      { keys: "F2", what: "Rename in place" },
+      { keys: "Delete  ·  Backspace", what: "Move the selection to trash" },
+    ],
+  },
+  {
+    title: "Reordering (Alt)",
+    rows: [
+      { keys: "Alt ←  ·  Alt →", what: "Move one place earlier / later" },
+      { keys: "Alt Home  ·  Alt End", what: "Move to the start / end" },
+      { keys: "Alt ↓", what: "Nest into the neighbouring timeline" },
+      { keys: "Alt ↑", what: "Move out to the parent timeline" },
+      { keys: "Alt Delete", what: "Move just this card to trash" },
+    ],
+  },
+  {
+    title: "Trimming (Alt + Shift)",
+    note: "One second per press. The details view takes exact numbers.",
+    rows: [
+      { keys: "Alt ⇧ →  ·  Alt ⇧ ←", what: "End edge later / earlier" },
+      { keys: "Alt ⇧ ↑  ·  Alt ⇧ ↓", what: "Video start edge in / out" },
+      { keys: "Alt ⇧ Home  ·  Alt ⇧ End", what: "Slide the source window, same duration" },
+    ],
+  },
+  {
+    title: "Playhead",
+    note: "With a seek rail focused.",
+    rows: [
+      { keys: "←  ·  →", what: "Step one second" },
+      { keys: "Home  ·  End", what: "Jump to the start / end of that row" },
+    ],
+  },
+];
+
+export function GraphShortcuts() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const onRequest = () => setOpen(true);
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      if (event.key === "Escape" && open) {
+        setOpen(false);
+        return;
+      }
+      // "?" is Shift+/ on most layouts, so match the CHARACTER rather than the
+      // physical key — and never while typing.
+      if (event.key !== "?" || event.ctrlKey || event.metaKey || event.altKey) return;
+      if (isEditableKeyboardTarget(event.target)) return;
+      event.preventDefault();
+      setOpen((previous) => !previous);
+    };
+    window.addEventListener(GRAPH_SHORTCUTS_EVENT, onRequest);
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener(GRAPH_SHORTCUTS_EVENT, onRequest);
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return createPortal(
+    <div
+      data-graph-shortcuts
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard shortcuts"
+      onPointerDown={(event) => {
+        if (event.target === event.currentTarget) setOpen(false);
+      }}
+      className="fixed inset-0 z-[90] flex items-center justify-center bg-black/80 p-6 backdrop-blur-sm"
+    >
+      <div className="max-h-[80vh] w-full max-w-2xl overflow-y-auto rounded-lg border border-zinc-700 bg-zinc-950 p-5 shadow-2xl shadow-black/60">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-zinc-100">Keyboard shortcuts</h2>
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            aria-label="Close the shortcuts sheet"
+            className="rounded p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
+          >
+            <X aria-hidden="true" className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="grid gap-5 sm:grid-cols-2">
+          {SECTIONS.map((section) => (
+            <section key={section.title}>
+              <h3 className="text-[11px] font-semibold tracking-wide text-amber-200/80 uppercase">
+                {section.title}
+              </h3>
+              {section.note && (
+                <p className="mt-0.5 text-[11px] text-zinc-500">{section.note}</p>
+              )}
+              <dl className="mt-2 space-y-1.5">
+                {section.rows.map((row) => (
+                  <div key={row.keys} className="flex items-baseline justify-between gap-3">
+                    <dt className="shrink-0 font-mono text-[11px] text-zinc-300">{row.keys}</dt>
+                    <dd className="min-w-0 text-right text-[12px] text-zinc-400">{row.what}</dd>
+                  </div>
+                ))}
+              </dl>
+            </section>
+          ))}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -71,6 +71,7 @@ import {
   PersistenceBridge,
   type SyncEntry,
 } from "./graph-persistence";
+import { HistoryPersistenceBridge } from "./graph-history-persistence";
 import { unparkPendingDetail } from "./graph-pending-details";
 import { createPreviewTimeChannel } from "./graph-preview";
 import {
@@ -595,6 +596,10 @@ export function GraphTimelineView({
         itemInstructions="Press O to open the focused collection, or F2 to rename it."
       >
           <PersistenceBridge onSync={onSync} />
+          {/* Undo that survives a refresh (PL11-008). Keyed to the same boot
+              session as the graph itself, so a different project or user
+              never inherits a stack built against another graph. */}
+          <HistoryPersistenceBridge sessionKey={boot.sessionKey} />
           {/* The whole graph route is the collection's screen, so clicking
               away ANYWHERE that is not a control deselects — not just inside a
               strip or grid box, which was the only place that worked and made

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -4107,6 +4107,182 @@ test.describe("graph view E2E", () => {
     await expect(page.getByRole("dialog")).toHaveCount(1);
   });
 
+  test("F2 renames a media card in place", async ({ page }) => {
+    // PL11-005. Naming a run of similar-looking clips should be arrow → F2 →
+    // type → Enter → arrow. The editor is a SIBLING of NodeCard, because that
+    // shell is a <button> and an <input> inside it is invalid content.
+    const api = await installGraphApi(page);
+    await openGraph(page);
+
+    const alpha = strip(page, PROJECT_ID).locator('[data-node-id="alpha"]');
+    await expect(async () => {
+      await alpha.click();
+      await expect(alpha).toHaveAttribute("data-selected", "true", { timeout: 700 });
+    }).toPass({ timeout: 10000 });
+
+    // No label yet: nobody has named it.
+    await expect(strip(page, PROJECT_ID).locator('[data-node-id="alpha"] [data-clip-title]'))
+      .toHaveCount(0);
+
+    await alpha.focus();
+    await page.keyboard.press("F2");
+    const editor = page.getByRole("textbox", { name: "Clip name" });
+    await expect(editor).toBeFocused();
+    await editor.fill("Jake looks up");
+    await editor.press("Enter");
+
+    // The card carries it, and so does the stored document — as `title`.
+    await expect(
+      strip(page, PROJECT_ID).locator('[data-node-wrapper="alpha"] [data-clip-title]'),
+    ).toHaveText("Jake looks up");
+    await expect
+      .poll(
+        () => api.documents.get(PROJECT_ID)?.clips.find((clip) => clip.id === "alpha")?.title,
+        { timeout: 5000 },
+      )
+      .toBe("Jake looks up");
+
+    // Escape abandons an edit rather than committing it.
+    await alpha.focus();
+    await page.keyboard.press("F2");
+    const second = page.getByRole("textbox", { name: "Clip name" });
+    await second.fill("Discarded");
+    await second.press("Escape");
+    await expect(
+      strip(page, PROJECT_ID).locator('[data-node-wrapper="alpha"] [data-clip-title]'),
+    ).toHaveText("Jake looks up");
+  });
+
+  test("typed in/out points trim exactly", async ({ page }) => {
+    // PL11-006. A pixel is worth ~0.11s in the details view and more on the
+    // board, so an exact edge was unreachable by pointer. Typed fields
+    // dispatch the SAME update-media the grips do.
+    const api = await installGraphApi(page);
+    await openGraph(page);
+
+    // alpha: 6s showing of an 8s source, so in 0.00 → out 6.00.
+    const alpha = strip(page, PROJECT_ID).locator('[data-node-id="alpha"]');
+    await expect(async () => {
+      await alpha.click();
+      await expect(alpha).toHaveAttribute("data-selected", "true", { timeout: 700 });
+    }).toPass({ timeout: 10000 });
+    await openItemDetails(page, "alpha");
+
+    const inField = page.locator('[data-trim-field="in"]');
+    const outField = page.locator('[data-trim-field="out"]');
+    await expect(inField).toHaveValue("0.00");
+    await expect(outField).toHaveValue("6.00");
+
+    await inField.fill("1.37");
+    await inField.press("Enter");
+    await expect.poll(
+      () => api.documents.get(PROJECT_ID)?.clips.find((c) => c.id === "alpha")?.trimIn,
+      { timeout: 5000 },
+    ).toBeCloseTo(1.37, 2);
+
+    await outField.fill("4.2");
+    await outField.press("Enter");
+    await expect.poll(
+      () => api.documents.get(PROJECT_ID)?.clips.find((c) => c.id === "alpha")?.trimOut,
+      { timeout: 5000 },
+    ).toBeCloseTo(3.8, 2);
+    // 4.2 − 1.37, exactly — the point of typing it.
+    await expect.poll(
+      () => api.documents.get(PROJECT_ID)?.clips.find((c) => c.id === "alpha")?.duration,
+      { timeout: 5000 },
+    ).toBeCloseTo(2.83, 2);
+
+    // Nonsense is CLAMPED, not refused: an out point before the in point is a
+    // typo, and snapping is faster to correct than an error message.
+    await outField.fill("0.1");
+    await outField.press("Enter");
+    await expect.poll(async () => Number(await outField.inputValue())).toBeGreaterThan(1.37);
+
+    // Escape abandons an edit rather than committing it.
+    const committed = await inField.inputValue();
+    await inField.fill("9.99");
+    await inField.press("Escape");
+    await expect(inField).toHaveValue(committed);
+  });
+
+  test("? opens the shortcuts sheet, and typing never does", async ({ page }) => {
+    // PL11-007. Hold-to-drag, O, F2 and the whole Alt layer are invisible
+    // without this.
+    await installGraphApi(page);
+    await openGraph(page);
+
+    const sheet = page.locator("[data-graph-shortcuts]");
+    await expect(sheet).toHaveCount(0);
+
+    await page.keyboard.press("?");
+    await expect(sheet).toHaveCount(1);
+    // A sample of rows, each of which corresponds to a real handler.
+    await expect(sheet).toContainText("Undo");
+    await expect(sheet).toContainText("Rename in place");
+    await expect(sheet).toContainText("Slide the source window, same duration");
+
+    await page.keyboard.press("Escape");
+    await expect(sheet).toHaveCount(0);
+
+    // Not while typing: a "?" in the rename field is a question mark.
+    const alpha = strip(page, PROJECT_ID).locator('[data-node-id="alpha"]');
+    await expect(async () => {
+      await alpha.click();
+      await expect(alpha).toHaveAttribute("data-selected", "true", { timeout: 700 });
+    }).toPass({ timeout: 10000 });
+    await alpha.focus();
+    await page.keyboard.press("F2");
+    const editor = page.getByRole("textbox", { name: "Clip name" });
+    await editor.fill("What?");
+    await expect(sheet).toHaveCount(0);
+    await expect(editor).toHaveValue("What?");
+    await editor.press("Escape");
+  });
+
+  test("undo survives a reload", async ({ page }) => {
+    // PL11-008. The app autosaves and history lived only in memory, so a
+    // refresh made every committed mistake permanent. The stack is written to
+    // sessionStorage and restored on boot; `undo` still verifies each entry
+    // against the live graph, so a stale one is refused rather than applied.
+    await installGraphApi(page);
+    await openGraph(page);
+
+    const alpha = strip(page, PROJECT_ID).locator('[data-node-id="alpha"]');
+    await expect(async () => {
+      await alpha.click();
+      await expect(alpha).toHaveAttribute("data-selected", "true", { timeout: 700 });
+    }).toPass({ timeout: 10000 });
+    await openItemDetails(page, "alpha");
+
+    // A typed trim is the cleanest edit to assert on: exact, and one commit.
+    const inField = page.locator('[data-trim-field="in"]');
+    await inField.fill("2.00");
+    await inField.press("Enter");
+    await expect
+      .poll(() => page.locator('[data-trim-field="in"]').inputValue(), { timeout: 5000 })
+      .toBe("2.00");
+    await page.keyboard.press("Escape");
+
+    // Reload: in memory this stack would be gone.
+    await page.reload();
+    await strip(page, PROJECT_ID)
+      .locator('[data-node-id="alpha"]')
+      .waitFor({ state: "visible", timeout: 30000 });
+
+    await page.keyboard.press("Control+z");
+
+    // Back to where it started, in the graph AND on the way to the server.
+    await expect(async () => {
+      await strip(page, PROJECT_ID).locator('[data-node-id="alpha"]').click();
+      await expect(strip(page, PROJECT_ID).locator('[data-node-id="alpha"]'))
+        .toHaveAttribute("data-selected", "true", { timeout: 700 });
+    }).toPass({ timeout: 10000 });
+    await openItemDetails(page, "alpha");
+    await expect.poll(() => page.locator('[data-trim-field="in"]').inputValue(), {
+      timeout: 5000,
+    }).toBe("0.00");
+  });
+
   test("the header says whether the work is saved", async ({ page }) => {
     // PL11-003. The app autosaves on a 900ms debounce and used to say nothing
     // about it — and undo history dies on reload, so "did that save?" is a

--- a/packages/ui/dnd-collections/react/collections-store.ts
+++ b/packages/ui/dnd-collections/react/collections-store.ts
@@ -152,6 +152,21 @@ export type CollectionsStore = Readonly<{
   undo: () => boolean;
   redo: () => boolean;
   /**
+   * Reinstate an undo stack recorded earlier — the seam a consumer needs to
+   * make undo survive a page reload (patches are serializable by design, and
+   * this log doubles as a persistence journal).
+   *
+   * Entries are pushed oldest-first, so the last one becomes the next undo.
+   * Nothing is verified here: `undo` already checks each entry against the
+   * live graph before applying it and drops the unreachable side, which is
+   * exactly the guard a restored stack needs — an entry that no longer fits
+   * the graph is refused when reached rather than corrupting it.
+   *
+   * The REDO branch is deliberately not restorable: redo means "put back what
+   * I just took away", and after a reload there is no "just".
+   */
+  restoreHistory: (entries: readonly HistoryEntry[]) => void;
+  /**
    * Swap in a new committed graph wholesale — the escape hatch for
    * async/server-loaded data that `initialGraph` (initial-only) can't handle.
    * Clears undo/redo history (patches were built against the old graph and
@@ -385,6 +400,13 @@ export function createCollectionsStore(
     return true;
   }
 
+  function restoreHistory(entries: readonly HistoryEntry[]): void {
+    if (entries.length === 0) return;
+    for (const entry of entries) history.push(entry);
+    refreshHistoryEntries();
+    notify();
+  }
+
   function redo(): boolean {
     const patch = history.peekRedo();
     if (!patch) return false;
@@ -482,6 +504,7 @@ export function createCollectionsStore(
     dispatch,
     undo,
     redo,
+    restoreHistory,
     replaceGraph,
     hydrate,
 

--- a/punch-list/PUNCH-LIST-11.md
+++ b/punch-list/PUNCH-LIST-11.md
@@ -1,5 +1,90 @@
 # Punch List 11
 
+## PL11-005 — F2 renames a media card in place
+
+- Status: Complete
+- Area: `graph-item-content.tsx`, `graph-navigation.tsx`
+- Screenshot: Not captured
+
+Naming a run of similar clips should be arrow → F2 → type → Enter → arrow, not
+a modal round-trip each time. `OpenKeyBoundary`'s F2 now claims media as well
+as collections, and the media card renders the same `InlineNameEditor` the
+collection card, breadcrumb and sub-row share — as a SIBLING of NodeCard,
+because that shell is a `<button>` and an `<input>` inside it is invalid
+content. The wrapper added in PL11-002 is what makes the sibling possible.
+
+Seeded with the authored `title` (not the filename), so re-naming edits what
+the user wrote instead of making them clear a machine name first.
+
+Known gap: an empty value is a no-op, so a title cannot be UNSET once given.
+
+## PL11-006 — Typed in/out points
+
+- Status: Complete
+- Area: `graph-item-details-modal.tsx`
+- Screenshot: Not captured
+
+A pixel is worth ~0.11s in the details view and more on the board, so exact
+edges were unreachable by pointer — restoring a clip to a known duration took
+me a dozen attempts and never landed closer than 0.04s. The details view now
+takes numbers.
+
+Each field commits on blur or Enter as one `update-media` — the same command
+the grips dispatch, so undo, the live channel and the write path behave
+identically. Escape reverts the field. Out-of-range values are CLAMPED rather
+than refused: an out point before the in point is a typo, and snapping is
+faster to correct than an error message. A 0.05s floor stops a stray keystroke
+trimming a clip to nothing.
+
+## PL11-007 — The shortcuts sheet
+
+- Status: Complete
+- Area: `graph-shortcuts.tsx` (new), `graph-board.tsx`
+- Screenshot: Not captured
+
+Hold-to-drag, O, F2, the whole Alt layer, and (until PL11-003) no keyboard
+undo at all — none of it was written down anywhere a user could reach. `?`
+opens a sheet; the board menu has an entry for anyone who never tries the key.
+
+Every row was verified against the handler that implements it — the app keys
+in `graph-item-actions`, the board keys in `OpenKeyBoundary`, the card grammar
+in the package's `use-keyboard-controller` — rather than written from memory.
+A shortcuts sheet that lies is worse than none.
+
+`?` is matched as a CHARACTER (it is Shift+/ on most layouts) and never fires
+while typing.
+
+## PL11-008 — Undo survives a reload
+
+- Status: Complete
+- Area: `packages/ui/dnd-collections/react/collections-store.ts`,
+  `graph-history-persistence.tsx` (new), `graph-timeline-view.tsx`
+- Screenshot: Not captured
+
+The app autosaves and history lived only in memory, so a refresh made every
+committed mistake permanent — the trash covered deletes, nothing covered
+trims, renames or moves. I hit this myself repeatedly while restoring demo
+data, before the demo project turned out to be scratch.
+
+Patches are serializable by design ("this log doubles as a persistence
+journal"), so the stack is simply written down: the store gained
+`restoreHistory(entries)`, and an app-side bridge mirrors `historyEntries` to
+sessionStorage keyed by the boot session, restoring once on mount.
+
+Three decisions worth keeping:
+
+- **sessionStorage, not local**: a reload is the case this exists for. A stack
+  from days ago, built against a graph other sessions have since changed, is a
+  liability rather than a safety net.
+- **Undo only, never redo**: redo means "put back what I just took away", and
+  after a reload there is no "just".
+- **No validation on restore**: `undo` already verifies each entry against the
+  live graph and drops the unreachable side, so a stale entry is refused when
+  reached instead of corrupting anything. Bounded at 50 entries / 512KB.
+
+Proven fail-first: with the bridge unmounted, a trim survives the reload and
+Ctrl+Z does nothing — the field still reads 2.00 where it should read 0.00.
+
 ## PL11-003 — The header says whether the work is saved
 
 - Status: Complete


### PR DESCRIPTION
The four remaining items from the UX review, smallest first.

## PL11-005 — F2 renames a media card in place

Naming a run of similar clips should be arrow → F2 → type → Enter → arrow, not a modal round-trip each time. `OpenKeyBoundary`'s F2 now claims media as well as collections, and the card renders the same `InlineNameEditor` every other rename site shares — as a **sibling** of NodeCard, because that shell is a `<button>` and an `<input>` inside it is invalid content. The wrapper PL11-002 added is what makes the sibling possible.

Seeded with the authored `title` rather than the filename, so re-naming edits what the user wrote instead of making them clear a machine name first.

*Known gap:* an empty value is a no-op, so a title can't be unset once given.

## PL11-006 — typed in/out points

A pixel is worth ~0.11s in the details view and more on the board, so exact edges were unreachable by pointer. Each field commits on blur or Enter as one `update-media` — the same command the grips dispatch, so undo, the live channel and the write path behave identically. Escape reverts the field.

Out-of-range values are **clamped, not refused**: an out point before the in point is a typo, and snapping to the nearest legal value is faster to correct than an error message. A 0.05s floor stops a stray keystroke trimming a clip to nothing.

## PL11-007 — the shortcuts sheet

Hold-to-drag, `O`, `F2`, the whole Alt layer, and (until PL11-003) no keyboard undo at all — none of it was written down anywhere a user could reach. `?` opens a sheet; the board menu has an entry for anyone who never tries the key.

Every row was **verified against the handler that implements it** — the app keys in `graph-item-actions`, the board keys in `OpenKeyBoundary`, the card grammar in the package's `use-keyboard-controller` — rather than written from memory. A shortcuts sheet that lies is worse than none. `?` is matched as a character (Shift+/ on most layouts) and never fires while typing.

## PL11-008 — undo survives a reload

The app autosaves and history lived only in memory, so a refresh made every committed mistake permanent: the trash covered deletes, nothing covered trims, renames or moves.

Patches are serializable by design ("this log doubles as a persistence journal"), so the stack is written down. The store gains `restoreHistory(entries)`; an app-side bridge mirrors `historyEntries` to sessionStorage keyed by the boot session and restores once on mount.

Three decisions worth keeping:

- **sessionStorage, not local.** A reload is the case this exists for. A stack from days ago, built against a graph other sessions have since changed, is a liability rather than a safety net.
- **Undo only, never redo.** Redo means "put back what I just took away", and after a reload there is no "just".
- **No validation on restore.** `undo` already verifies each entry against the live graph and drops the unreachable side, so a stale entry is refused when reached instead of corrupting anything. Bounded at 50 entries / 512KB, best-effort on quota failure.

## Verification

- graph-view e2e **97/98** with four new tests. The one failure is `crafted focus URLs are rejected` — three navigations and a 15s poll, which already flaked under parallel load before this branch and passes in isolation.
- app vitest **442/442**, package unit **408/408**, DndCollections + CompoundItem stories **28/28**, both typechecks and lint clean.
- Durable undo proven fail-first: with the bridge unmounted, the trim survives the reload and Ctrl+Z does nothing — the field reads `2.00` where it should read `0.00`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
