### PR TITLE
Punch list 11: one duration vocabulary, a type floor, and touch reachability

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-add-collection-slot.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-add-collection-slot.tsx
@@ -39,7 +39,7 @@ export function AddCollectionSlot({
       className="flex h-full w-full flex-col items-center justify-center gap-1 rounded-md border border-dashed border-zinc-700 bg-zinc-900/30 text-zinc-500 transition-colors hover:border-sky-500/60 hover:bg-sky-500/[0.06] hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70"
     >
       <FolderPlus aria-hidden="true" className="h-4 w-4" />
-      <span className="text-[10px] font-medium">Add timeline</span>
+      <span className="text-[11px] font-medium">Add timeline</span>
     </button>
   );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-asset-palette.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-asset-palette.tsx
@@ -124,7 +124,7 @@ function FolderTile({
       className="flex h-24 w-36 shrink-0 flex-col items-center justify-center gap-1.5 rounded-md border border-zinc-800 bg-zinc-900/60 px-2 text-zinc-400 transition-colors hover:border-sky-500/50 hover:bg-zinc-900 hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
     >
       <Icon aria-hidden="true" className="h-6 w-6" />
-      <span className="w-full truncate text-center text-[10px] font-semibold text-zinc-300">
+      <span className="w-full truncate text-center text-[11px] font-semibold text-zinc-300">
         {folder.name}
       </span>
     </button>
@@ -238,7 +238,7 @@ function PaletteRail({
             className="h-full w-full object-cover"
           />
           {asset.kind === "video" && (
-            <span className="absolute bottom-1 left-1 rounded bg-black/75 px-1 py-0.5 text-[9px] font-bold tracking-wide text-zinc-100">
+            <span className="absolute bottom-1 left-1 rounded bg-black/75 px-1 py-0.5 text-[11px] font-bold tracking-wide text-zinc-100">
               VIDEO
             </span>
           )}
@@ -562,13 +562,13 @@ export function AssetPaletteDrawer({
               visually unchanged. A native <select>: the option count is
               provider-driven, so a fixed toggle wouldn't scale. */}
           {providers.length > 1 && (
-            <label className="flex shrink-0 items-center gap-1 text-[10px] text-zinc-500">
+            <label className="flex shrink-0 items-center gap-1 text-[11px] text-zinc-500">
               <span className="sr-only">Asset source</span>
               <select
                 aria-label="Asset source"
                 value={providerId ?? providers[0].id}
                 onChange={(event) => selectProvider(event.target.value)}
-                className="rounded-md border border-zinc-800 bg-zinc-900 px-1.5 py-0.5 text-[10px] font-semibold text-zinc-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+                className="rounded-md border border-zinc-800 bg-zinc-900 px-1.5 py-0.5 text-[11px] font-semibold text-zinc-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
               >
                 {providers.map((option) => (
                   <option key={option.id} value={option.id}>
@@ -596,8 +596,8 @@ export function AssetPaletteDrawer({
                   }}
                   className={
                     mode === option
-                      ? "bg-zinc-800 px-2 py-0.5 text-[10px] font-semibold text-zinc-100"
-                      : "px-2 py-0.5 text-[10px] font-semibold text-zinc-500 hover:text-zinc-200"
+                      ? "bg-zinc-800 px-2 py-0.5 text-[11px] font-semibold text-zinc-100"
+                      : "px-2 py-0.5 text-[11px] font-semibold text-zinc-500 hover:text-zinc-200"
                   }
                 >
                   {option === "folders" ? "Folders" : "Tags"}
@@ -606,7 +606,7 @@ export function AssetPaletteDrawer({
             </div>
           )}
           {searchAvailable && (
-            <label className="flex shrink-0 items-center gap-1.5 text-[10px] text-zinc-500">
+            <label className="flex shrink-0 items-center gap-1.5 text-[11px] text-zinc-500">
               <span className="sr-only">Search assets</span>
               <input
                 type="search"
@@ -626,7 +626,7 @@ export function AssetPaletteDrawer({
               />
             </label>
           )}
-          <span className="shrink-0 text-[10px] text-zinc-600">
+          <span className="shrink-0 text-[11px] text-zinc-600">
             {searchTerm
               ? "Results span the whole library · clear the box to browse"
               : "Drag a thumbnail into any timeline · Enter picks one up for keyboard placement"}
@@ -699,11 +699,11 @@ export function AssetPaletteDrawer({
                     size="sm"
                     disabled={loadingMore}
                     onClick={() => void loadMore()}
-                    className="h-6 px-2 text-[10px]"
+                    className="h-6 px-2 text-[11px]"
                   >
                     {loadingMore ? "Loading…" : "Load more"}
                   </Button>
-                  <span className="text-[10px] text-zinc-600">
+                  <span className="text-[11px] text-zinc-600">
                     {state.assets.length} shown
                     {searchTerm ? " · narrow the search to get there faster" : ""}
                   </span>

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -15,6 +15,7 @@ import {
 
 import { flattenMediaOrder } from "@storyboard/timeline-domain";
 
+import { formatDuration } from "@/lib/format-duration";
 import { requestGraphToolInsert } from "@/lib/graph-view-events";
 import { Button } from "@/components/core/button";
 import {
@@ -125,13 +126,6 @@ function BoardMenu({
   );
 }
 
-/** "8 clips · 3m 00s" — matches the collection cards' badge idiom. */
-function formatAggregateSeconds(seconds: number): string {
-  if (seconds < 60) return `${seconds.toFixed(1)}s`;
-  const minutes = Math.floor(seconds / 60);
-  return `${minutes}m ${String(Math.round(seconds % 60)).padStart(2, "0")}s`;
-}
-
 /**
  * The centre readout of the header row: normally the focused timeline's
  * aggregate, and — while anything is selected — what the SELECTION adds up
@@ -160,7 +154,7 @@ function FocusedAggregate({
         className="hidden shrink-0 px-3 text-center font-mono text-[11px] tabular-nums text-amber-300/90 sm:block"
         title="Selected items"
       >
-        {selection.count} selected · {formatAggregateSeconds(selection.seconds)}
+        {selection.count} selected · {formatDuration(selection.seconds)}
       </span>
     );
   }
@@ -171,7 +165,7 @@ function FocusedAggregate({
       className="hidden shrink-0 px-3 text-center font-mono text-[11px] tabular-nums text-zinc-400 sm:block"
       title="Focused timeline total"
     >
-      {count} {count === 1 ? "clip" : "clips"} · {formatAggregateSeconds(seconds)}
+      {count} {count === 1 ? "clip" : "clips"} · {formatDuration(seconds)}
     </span>
   );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -49,6 +49,7 @@ import { useItemDetails } from "./graph-item-details-context";
 import { GraphViewNavContext } from "./graph-navigation";
 import { TrimPanel } from "./graph-trim-panel";
 import { createDerivedCache } from "@/lib/derived-cache";
+import { formatDuration, formatSeconds } from "@/lib/format-duration";
 import {
   collectionPreviewFrameUrl,
   videoFrameUrls,
@@ -287,23 +288,15 @@ function useHydratedCollectionSeconds(id: string, enabled: boolean): number | nu
   return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }
 
-/** Compact clock-ish duration label for a collection card ("12.4s", "1:23"). */
-function formatCollectionSeconds(seconds: number): string {
-  if (seconds < 60) return `${seconds.toFixed(1)}s`;
-  const minutes = Math.floor(seconds / 60);
-  const rest = Math.round(seconds % 60);
-  return `${minutes}:${String(rest).padStart(2, "0")}`;
-}
-
 /** Leaf subscription: only the clip being trimmed re-renders per pointer move. */
 function LiveDurationPill({ id, node }: { id: NodeId; node: MediaNode }) {
   const live = useLiveTrim(id);
   const showing = live ? live.effectiveSeconds : mediaDurationSeconds(node);
   return (
-    <span className="pointer-events-none absolute right-1 bottom-1 z-10 rounded bg-black/75 px-1.5 py-0.5 font-mono text-[9px] tabular-nums text-zinc-100">
+    <span className="pointer-events-none absolute right-1 bottom-1 z-10 rounded bg-black/75 px-1.5 py-0.5 font-mono text-[11px] tabular-nums text-zinc-100">
       {node.mediaKind === "video"
-        ? `${showing.toFixed(2)}s / ${node.fullDurationSeconds.toFixed(2)}s`
-        : `${showing.toFixed(2)}s`}
+        ? `${formatSeconds(showing)} / ${formatSeconds(node.fullDurationSeconds)}`
+        : formatSeconds(showing)}
     </span>
   );
 }
@@ -521,7 +514,7 @@ const GraphClipContent = memo(function GraphClipContent({
         ].join(" ")}
       >
       {frameSrcs.length === 0 ? (
-        <span className="flex h-full w-full items-center justify-center text-[10px] text-zinc-500">
+        <span className="flex h-full w-full items-center justify-center text-[11px] text-zinc-500">
           No preview
         </span>
       ) : (
@@ -554,7 +547,7 @@ const GraphClipContent = memo(function GraphClipContent({
       <span
         aria-hidden="true"
         data-media-kind={isVideo ? "video" : "image"}
-        className="pointer-events-none absolute bottom-2 left-2 z-10 rounded bg-black/75 px-1.5 py-0.5 font-mono text-[9px] leading-none font-semibold tracking-[0.08em] text-zinc-100"
+        className="pointer-events-none absolute bottom-2 left-2 z-10 rounded bg-black/75 px-1.5 py-0.5 font-mono text-[11px] leading-none font-semibold tracking-[0.08em] text-zinc-100"
       >
         {isVideo ? "VIDEO" : "IMAGE"}
       </span>
@@ -629,7 +622,7 @@ const GraphTrimOverviewContent = memo(
     return (
       <div className="flex h-full w-full">
         {frameSrcs.length === 0 ? (
-          <span className="flex h-full w-full items-center justify-center bg-muted text-[10px] text-muted-foreground select-none">
+          <span className="flex h-full w-full items-center justify-center bg-muted text-[11px] text-muted-foreground select-none">
             No preview frames
           </span>
         ) : (
@@ -752,8 +745,8 @@ const GraphGhost = memo(function GraphGhost({ node, extraCount }: CollectionGhos
       ) : (
         <span className="flex h-full w-full flex-col items-center justify-center gap-1 p-2 text-center">
           <span className="truncate text-[11px] font-semibold text-zinc-100">{node.name}</span>
-          <span className="font-mono text-[9px] text-zinc-400">
-            {mediaDurationSeconds(node).toFixed(2)}s
+          <span className="font-mono text-[11px] text-zinc-400">
+            {formatSeconds(mediaDurationSeconds(node))}
           </span>
         </span>
       )}
@@ -914,7 +907,7 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
             {typeof totalSeconds === "number" && totalSeconds > 0 ? (
               <>
                 <span className="text-sky-300/90" title="Total duration of contents">
-                  {formatCollectionSeconds(totalSeconds)}
+                  {formatDuration(totalSeconds)}
                 </span>
                 <span aria-hidden="true" className="text-zinc-500">
                   /
@@ -1062,7 +1055,13 @@ const ItemDetailsTrigger = memo(function ItemDetailsTrigger({
         // Hidden until the card is hovered or something inside it has focus —
         // including this button, which is why `focus-within` is on the group
         // rather than `focus-visible` here alone.
-        "opacity-0 transition-opacity duration-150",
+        //
+        // The HIDING is gated on hover existing at all (PL11-011). A touch
+        // device never hovers, so an unconditional `opacity-0` made this the
+        // only way to open the details view AND made it unreachable there.
+        // Visible by default, hidden only where a pointer can reveal it: busy
+        // beats unreachable.
+        "transition-opacity duration-150 [@media(hover:hover)]:opacity-0",
         "group-hover/media-item:opacity-100 group-focus-within/media-item:opacity-100",
         "focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300",
       ].join(" ")}

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -17,6 +17,7 @@ import {
   type VideoMediaNode,
 } from "@storyboard/ui/dnd-collections";
 
+import { formatSeconds } from "@/lib/format-duration";
 import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
 import { useItemDetails } from "./graph-item-details-context";
 
@@ -231,7 +232,7 @@ function TrimNumbers({
         →
       </span>
       <SecondsField label="out" value={outPoint} disabled={disabled} onCommit={(raw) => commit("out", raw)} />
-      <span className="text-zinc-600">of {full.toFixed(2)}s</span>
+      <span className="text-zinc-600">of {formatSeconds(full)}</span>
     </div>
   );
 }
@@ -371,7 +372,7 @@ function ModalBody({ node, onClose }: Readonly<{ node: MediaNode; onClose: () =>
           )}
           <div className="flex items-center gap-3">
             <span className="font-mono text-[11px] tabular-nums text-zinc-400">
-              {video ? `${showing.toFixed(2)}s of ${fullDuration.toFixed(2)}s` : `${showing.toFixed(2)}s`}
+              {video ? `${formatSeconds(showing)} of ${formatSeconds(fullDuration)}` : formatSeconds(showing)}
             </span>
             {/* Scoped to this clip's own trims — see useScopedHistory. Each
                 release is one commit, so these step through the adjustments
@@ -445,8 +446,8 @@ function ModalBody({ node, onClose }: Readonly<{ node: MediaNode; onClose: () =>
             />
           )}
           {video && (
-            <span className="absolute right-2 bottom-2 rounded bg-black/80 px-1.5 py-0.5 font-mono text-[10px] tabular-nums text-amber-200">
-              {rawTime.toFixed(2)}s
+            <span className="absolute right-2 bottom-2 rounded bg-black/80 px-1.5 py-0.5 font-mono text-[11px] tabular-nums text-amber-200">
+              {formatSeconds(rawTime)}
             </span>
           )}
         </div>
@@ -477,13 +478,13 @@ function ModalBody({ node, onClose }: Readonly<{ node: MediaNode; onClose: () =>
               trimOut={trimOut}
               disabled={live !== null}
             />
-            <div className="text-right font-mono text-[10px] text-zinc-500">
+            <div className="text-right font-mono text-[11px] text-zinc-500">
               drag the amber edges to trim, the film to move the window
             </div>
           </>
         ) : (
-          <div className="flex items-center justify-between font-mono text-[10px] text-zinc-500">
-            <span className="text-amber-200/90">still · {showing.toFixed(2)}s on screen</span>
+          <div className="flex items-center justify-between font-mono text-[11px] text-zinc-500">
+            <span className="text-amber-200/90">still · {formatSeconds(showing)} on screen</span>
             <span>drag the card&apos;s edge on the strip to change how long it holds</span>
           </div>
         )}

--- a/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
@@ -734,7 +734,7 @@ function NativeDropStatus({ upload }: Readonly<{ upload: DropSummary | null }>) 
       role="status"
       aria-live="polite"
       className={[
-        "pointer-events-none absolute bottom-1 left-1 z-20 rounded px-2 py-1 text-[10px]",
+        "pointer-events-none absolute bottom-1 left-1 z-20 rounded px-2 py-1 text-[11px]",
         upload === null
           ? "sr-only"
           : upload.tone === "progress"

--- a/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.ts
@@ -15,6 +15,7 @@ import {
   TIMELINE_LEADING_PADDING_SECONDS,
 } from "@storyboard/timeline-model/constants";
 import type { TimelineClip } from "@storyboard/timeline-model/types";
+import { formatTick } from "@/lib/format-duration";
 
 import { GRID_GAP } from "./graph-view-config";
 
@@ -492,10 +493,7 @@ export function rulerTickLevel(index: number, maxTier: number): number {
 }
 
 export function formatRulerTick(seconds: number): string {
-  if (seconds < 60) return Number.isInteger(seconds) ? `${seconds}s` : `${seconds.toFixed(1)}s`;
-  const minutes = Math.floor(seconds / 60);
-  const rest = Math.round(seconds % 60);
-  return `${minutes}:${String(rest).padStart(2, "0")}`;
+  return formatTick(seconds);
 }
 
 export type RulerTick = Readonly<{ x: number; level: number; label: string }>;

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -594,7 +594,7 @@ export function GraphRuler({
             style={{ height: RULER_TIER_HEIGHT_PX[tick.level] ?? RULER_TIER_HEIGHT_PX[3] }}
           />
           {tick.label ? (
-            <span className="absolute left-[3px] top-[2px] whitespace-nowrap font-mono text-[9px] font-medium leading-none text-sky-100">
+            <span className="absolute left-[3px] top-[2px] whitespace-nowrap font-mono text-[11px] font-medium leading-none text-sky-100">
               {tick.label}
             </span>
           ) : null}
@@ -608,7 +608,7 @@ export function GraphRuler({
           <span
             key={`collection-${index}`}
             data-ruler-collection-duration
-            className="absolute top-[2px] -translate-x-1/2 whitespace-nowrap font-mono text-[9px] font-medium leading-none text-sky-200/90"
+            className="absolute top-[2px] -translate-x-1/2 whitespace-nowrap font-mono text-[11px] font-medium leading-none text-sky-200/90"
             style={{ left: span.x + span.width / 2 }}
           >
             {formatRulerTick(Math.round(span.seconds * 10) / 10)}
@@ -1040,7 +1040,7 @@ function SeekRailRow({
           // sticky breadcrumb header, and there is nothing overhead to draw
           // into — the readout was simply cut off (PL9-007). Downward it
           // overlays the cards, which are its own surface and beneath it.
-          className="pointer-events-none absolute top-full z-50 mt-1.5 -translate-x-1/2 whitespace-nowrap rounded bg-zinc-900/95 px-1.5 py-0.5 font-mono text-[10px] text-zinc-100 shadow-sm ring-1 ring-zinc-700"
+          className="pointer-events-none absolute top-full z-50 mt-1.5 -translate-x-1/2 whitespace-nowrap rounded bg-zinc-900/95 px-1.5 py-0.5 font-mono text-[11px] text-zinc-100 shadow-sm ring-1 ring-zinc-700"
         />
       )}
     </div>
@@ -1634,7 +1634,7 @@ export function GraphStripSeekRail({
           // sticky breadcrumb header, and there is nothing overhead to draw
           // into — the readout was simply cut off (PL9-007). Downward it
           // overlays the cards, which are its own surface and beneath it.
-          className="pointer-events-none absolute top-full z-50 mt-1.5 -translate-x-1/2 whitespace-nowrap rounded bg-zinc-900/95 px-1.5 py-0.5 font-mono text-[10px] text-zinc-100 shadow-sm ring-1 ring-zinc-700"
+          className="pointer-events-none absolute top-full z-50 mt-1.5 -translate-x-1/2 whitespace-nowrap rounded bg-zinc-900/95 px-1.5 py-0.5 font-mono text-[11px] text-zinc-100 shadow-sm ring-1 ring-zinc-700"
         />
       )}
     </div>

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -230,15 +230,15 @@ function SubTimelineNode({
             {name}
           </h3>
         )}
-        <span className="shrink-0 rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] text-zinc-300">
+        <span className="shrink-0 rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[11px] text-zinc-300">
           {hydrated ? liveCount : (detail?.itemCount ?? 0)} clips
         </span>
         {status !== "idle" && (
           <span
             className={
               status === "failed"
-                ? "shrink-0 rounded border border-red-700/60 px-1.5 py-0.5 text-[10px] text-red-400"
-                : "shrink-0 rounded border border-zinc-700 px-1.5 py-0.5 text-[10px] text-zinc-500"
+                ? "shrink-0 rounded border border-red-700/60 px-1.5 py-0.5 text-[11px] text-red-400"
+                : "shrink-0 rounded border border-zinc-700 px-1.5 py-0.5 text-[11px] text-zinc-500"
             }
           >
             {subTimelineRowStatusLabel(status)}

--- a/apps/timeline-gstudio001/components/graph-view/graph-trim-panel.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-trim-panel.tsx
@@ -3,6 +3,8 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
+import { formatSeconds } from "@/lib/format-duration";
+
 import {
   useLiveTrim,
   type LiveTrim,
@@ -170,8 +172,8 @@ function LiveEdgeFrame({
           activeEdge === "right" ? "right-0" : "left-0",
         ].join(" ")}
       />
-      <span className="absolute right-0 bottom-0 bg-zinc-950/85 px-1 font-mono text-[9px] leading-tight tabular-nums text-amber-200">
-        {time.toFixed(2)}s
+      <span className="absolute right-0 bottom-0 bg-zinc-950/85 px-1 font-mono text-[11px] leading-tight tabular-nums text-amber-200">
+        {formatSeconds(time)}
       </span>
     </div>,
     document.body,

--- a/apps/timeline-gstudio001/lib/format-duration.ts
+++ b/apps/timeline-gstudio001/lib/format-duration.ts
@@ -1,0 +1,52 @@
+// ONE duration vocabulary for the graph view (PL11-009).
+//
+// There were four near-copies of the same rule — the board's aggregate, the
+// collection card's badge, the ruler's tick labels, and a scatter of raw
+// `toFixed(2)` — so the same timeline could read "52.9s" in one place, "6:32"
+// in another and "1m 24s" in a third within one glance. Numbers that change
+// shape between neighbouring pixels stop feeling like measurements.
+//
+// Two registers, and the split is deliberate rather than an oversight:
+//
+//   READING  — "how long is this?" Rounded, clock-like past a minute, and
+//              never more precision than the eye can use.
+//   EDITING  — "what exactly am I setting?" Hundredths, always in seconds,
+//              because an in-point of 1:02 is not something you can type back.
+//
+// Anything a user can EDIT gets the editing form; anything they merely read
+// gets the reading form.
+
+/** Reading: "12.4s", "1:23", "1:02:03". */
+export function formatDuration(seconds: number): string {
+  const safe = Number.isFinite(seconds) && seconds > 0 ? seconds : 0;
+  if (safe < 60) return `${safe.toFixed(1)}s`;
+  const hours = Math.floor(safe / 3600);
+  const minutes = Math.floor((safe % 3600) / 60);
+  const rest = Math.round(safe % 60);
+  // Rounding 59.6s up must not print ":60".
+  const carried = rest === 60;
+  const shownRest = carried ? 0 : rest;
+  const shownMinutes = carried ? minutes + 1 : minutes;
+  if (hours > 0) {
+    return `${hours}:${String(shownMinutes).padStart(2, "0")}:${String(shownRest).padStart(2, "0")}`;
+  }
+  return `${shownMinutes}:${String(shownRest).padStart(2, "0")}`;
+}
+
+/** Editing: "12.40s" — hundredths, always seconds, never clock notation. */
+export function formatSeconds(seconds: number): string {
+  const safe = Number.isFinite(seconds) ? seconds : 0;
+  return `${safe.toFixed(2)}s`;
+}
+
+/**
+ * Ruler ticks: the reading form, minus the trailing ".0" on whole seconds.
+ * A tick every second reading "1.0s 2.0s 3.0s" is a column of noise; the
+ * fractional tiers (½s, ¼s) still need their decimal.
+ */
+export function formatTick(seconds: number): string {
+  if (seconds < 60) {
+    return Number.isInteger(seconds) ? `${seconds}s` : `${seconds.toFixed(1)}s`;
+  }
+  return formatDuration(seconds);
+}

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -4283,6 +4283,40 @@ test.describe("graph view E2E", () => {
     }).toBe("0.00");
   });
 
+  test("without hover, the details trigger stays visible", async ({ browser }) => {
+    // PL11-011. The trigger hides itself until the card is hovered — which on
+    // a touch device means it hides forever, and it is the only way into the
+    // details view. The HIDING is therefore gated on hover existing at all.
+    //
+    // A real touch CONTEXT, not `Emulation.setEmulatedMedia`: that API leaves
+    // `(hover: hover)` matching in this Chromium, so it would have proved
+    // nothing. `hasTouch` drives the same device emulation a phone gets, and
+    // the media query answers accordingly.
+    const context = await browser.newContext({ hasTouch: true, isMobile: true });
+    const page = await context.newPage();
+    try {
+      await installGraphApi(page);
+      await openGraph(page);
+
+      expect(
+        await page.evaluate(() => window.matchMedia("(hover: none)").matches),
+      ).toBe(true);
+
+      const trigger = page.locator('[data-item-details-trigger="alpha"]');
+      await expect(trigger).toHaveCount(1);
+      // Nothing hovered, nothing focused: hover-capable would read "0".
+      await expect
+        .poll(() => trigger.evaluate((el) => getComputedStyle(el).opacity))
+        .toBe("1");
+
+      // And it still opens from there.
+      await trigger.tap();
+      await expect(page.getByRole("dialog")).toHaveCount(1);
+    } finally {
+      await context.close();
+    }
+  });
+
   test("the header says whether the work is saved", async ({ page }) => {
     // PL11-003. The app autosaves on a 900ms debounce and used to say nothing
     // about it — and undo history dies on reload, so "did that save?" is a

--- a/punch-list/PUNCH-LIST-11.md
+++ b/punch-list/PUNCH-LIST-11.md
@@ -1,5 +1,68 @@
 # Punch List 11
 
+## PL11-009 — One duration vocabulary
+
+- Status: Complete
+- Area: `lib/format-duration.ts` (new), board, cards, ruler, details view
+- Screenshot: Not captured
+
+The same timeline read "52.9s" on a card, "1m 24s" in the header and "6:32" on
+its parent, because four near-copies of one rule had drifted apart. Numbers
+that change shape between neighbouring pixels stop feeling like measurements.
+
+One module, two registers, and the split is deliberate rather than an
+oversight:
+
+- READING — `formatDuration`: "12.4s" under a minute, "1:23" / "1:02:03" past
+  it. Rounded, and never more precision than the eye can use.
+- EDITING — `formatSeconds`: "12.40s", always seconds, because an in-point of
+  "1:02" is not something you can type back into a field.
+
+Anything editable takes the editing form; everything else reads. The ruler
+keeps its own entry point (`formatTick`) because whole-second ticks drop the
+".0" — a column reading "1.0s 2.0s 3.0s" is noise.
+
+Live after the change: header `2 clips · 7:31`, cards `52.9s` and `6:38`,
+details view `29.47s of 52.77s`.
+
+## PL11-010 — A floor under the type
+
+- Status: Complete
+- Area: the graph view's labels (28 occurrences across 8 files)
+- Screenshot: Not captured
+
+The rail had just gone to 28px glyphs while the board still ran 9px and 10px
+labels on near-black — two extremes with no middle register. Everything below
+11px came up to it; the view now renders at 11px and 12px only, and nothing
+overflowed its pill (checked by measuring `scrollWidth` against `clientWidth`
+for every leaf label on the board).
+
+11px is a floor for GLANCEABLE metadata, not a target: the readouts that
+matter (names, aggregates) already sit at 12px and up.
+
+## PL11-011 — Hover-only affordances on touch
+
+- Status: Complete
+- Area: `graph-item-content.tsx`
+- Screenshot: Not captured
+
+The details trigger hid itself until its card was hovered — which on a touch
+device means it hides forever, and it is the only way into the details view.
+The HIDING is now gated on hover existing at all
+(`[@media(hover:hover)]:opacity-0`): visible by default, hidden only where a
+pointer can reveal it. Busy beats unreachable.
+
+Audited the rest rather than assuming: the breadcrumb drop zones are
+drag-state-driven, the sidebar's tooltip labels are supplementary to buttons
+that are always visible and tappable, and the collection call-out is a
+hover-triggered flourish that simply never fires without a pointer. The
+trigger was the only control a touch user could not reach.
+
+TEST NOTE: `Emulation.setEmulatedMedia` with a `hover: none` feature leaves
+`(hover: hover)` matching in this Chromium — it would have proved nothing.
+The test opens a real `hasTouch` context instead, asserts
+`matchMedia("(hover: none)")` first, and taps the trigger.
+
 ## PL11-005 — F2 renames a media card in place
 
 - Status: Complete


### PR DESCRIPTION
The three remaining presentation items from the UX review.

## PL11-009 — one duration vocabulary

The same timeline read `52.9s` on a card, `1m 24s` in the header and `6:32` on its parent, because four near-copies of one rule had drifted apart. Numbers that change shape between neighbouring pixels stop feeling like measurements.

One module, two registers, and the split is deliberate rather than an oversight:

- **Reading** — `formatDuration`: `12.4s` under a minute, `1:23` / `1:02:03` past it. Rounded, never more precision than the eye can use.
- **Editing** — `formatSeconds`: `12.40s`, always seconds, because an in-point of `1:02` is not something you can type back into a field.

Anything editable takes the editing form; everything else reads. The ruler keeps its own entry point (`formatTick`) because whole-second ticks drop the `.0` — a column reading `1.0s 2.0s 3.0s` is noise.

Live after the change: header `2 clips · 7:31`, cards `52.9s` and `6:38`, details view `29.47s of 52.77s`.

## PL11-010 — a floor under the type

The rail had just gone to 28px glyphs while the board still ran 9px and 10px labels on near-black — two extremes with no middle register. Everything below 11px came up to it (28 occurrences across 8 files). The view now renders at 11px and 12px only, and nothing overflowed its pill — checked by measuring `scrollWidth` against `clientWidth` for every leaf label on the board.

11px is a floor for glanceable metadata, not a target: names and aggregates already sit at 12px and up.

## PL11-011 — hover-only affordances on touch

The details trigger hid itself until its card was hovered — which on a touch device means it hides forever, and it is the only way into the details view. The **hiding** is now gated on hover existing at all (`[@media(hover:hover)]:opacity-0`): visible by default, hidden only where a pointer can reveal it. Busy beats unreachable.

Audited the rest rather than sweeping: the breadcrumb drop zones are drag-state-driven, the sidebar's tooltip labels are supplementary to buttons that are always visible and tappable, and the collection call-out is a hover-triggered flourish that simply never fires without a pointer. The trigger was the only control a touch user could not reach.

**Test note worth keeping:** `Emulation.setEmulatedMedia` with a `hover: none` feature leaves `(hover: hover)` matching in this Chromium, so the first version of that test proved nothing. It opens a real `hasTouch` context instead, asserts `matchMedia("(hover: none)")` before anything else, and taps the trigger.

## Verification

- graph-view e2e **97/99**. Both failures are 28–30s timeouts under full parallelism (`crafted focus URLs`, `interaction model`), green in isolation, and flaky before this branch.
- app vitest **442/442**, typecheck and lint clean.

Separately worth addressing: the suite is at 99 tests against a dev server that compiles routes on demand, and 1–4 tests now time out per full run. "Green in isolation" is becoming a routine caveat rather than a rare one — worth fixing the cause (worker count, or making the heavy navigation tests serial) rather than annotating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
