### PR TITLE
Punch list 11: a details view for collections, and the scrub readout above the playhead

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-collection-details.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-collection-details.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useContext, useEffect } from "react";
+import { createPortal } from "react-dom";
+import { Redo2, Undo2, X } from "lucide-react";
+
+import {
+  isEditableKeyboardTarget,
+  type CollectionItemNode,
+} from "@storyboard/ui/dnd-collections";
+
+import { formatDuration } from "@/lib/format-duration";
+import { collectionPreviewFrameUrl } from "@/lib/video-frame-url";
+
+import { useClipDetail, useTimelineTitle } from "./graph-details-context";
+import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
+import {
+  useCollectionPreviewFrames,
+  useEnabledChildCount,
+  useHydratedCollectionSeconds,
+} from "./graph-item-content";
+import { GraphViewNavContext } from "./graph-navigation";
+
+// A COLLECTION's details (PL11-012).
+//
+// Drilling in already answers "what is in here", so this deliberately is not a
+// second timeline view. It answers what you would otherwise have to drill in
+// and come back out to learn — how much is inside, how long it runs, whether
+// it is even loaded — and lets the name be fixed on the spot.
+//
+// The hero is its contents, because a timeline's identity is its footage: the
+// card morphs into a larger version of the frames it was already showing.
+
+export function CollectionDetailsBody({
+  node,
+  hero,
+  history,
+  onClose,
+}: Readonly<{
+  node: CollectionItemNode;
+  /** The shared view-transition name the card hands over. */
+  hero: string;
+  history: Readonly<{
+    undoableHere: boolean;
+    redoableHere: boolean;
+    undo: () => void;
+    redo: () => void;
+  }>;
+  onClose: () => void;
+}>) {
+  const nav = useContext(GraphViewNavContext);
+  // The gateway is the source of truth for a collection's title (the card and
+  // the breadcrumb read it too), so a rename made anywhere shows up here.
+  const title = useTimelineTitle(node.id as string);
+  const displayName = title ?? node.name;
+  const rename = useInlineRename(node.id, displayName, "item-details");
+
+  const detail = useClipDetail(node.id as string);
+  const hydrated = detail?.hydrated === true;
+  const liveCount = useEnabledChildCount(node.id);
+  const liveSeconds = useHydratedCollectionSeconds(node.id as string, hydrated);
+  // Live numbers once loaded; the stored summary for a placeholder — the same
+  // rule the card follows, so the two never disagree.
+  const count = hydrated ? liveCount : (detail?.itemCount ?? liveCount);
+  const seconds =
+    (hydrated ? liveSeconds : (detail?.playableDuration ?? detail?.duration)) ?? 0;
+  const previews = useCollectionPreviewFrames(node.id as string, hydrated, detail?.previewItems);
+
+  const beginRename = rename.begin;
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      // Capture phase, so the editable guard is what keeps Escape from
+      // closing the whole view mid-rename.
+      if (isEditableKeyboardTarget(event.target)) return;
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        onClose();
+        return;
+      }
+      if (event.key === "F2") {
+        event.preventDefault();
+        event.stopPropagation();
+        beginRename();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => document.removeEventListener("keydown", onKeyDown, true);
+  }, [onClose, beginRename]);
+
+  return createPortal(
+    <div
+      data-item-details={node.id}
+      data-item-details-kind="collection"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Details for ${displayName}`}
+      className="fixed inset-0 z-[80] flex items-center justify-center bg-black/80 p-6 backdrop-blur-sm"
+      onPointerDown={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div
+        className="flex w-full max-w-3xl flex-col gap-3 rounded-lg border border-zinc-700 bg-zinc-950 p-4 shadow-2xl shadow-black/60"
+        onPointerDown={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center justify-between gap-3">
+          {rename.editing ? (
+            <InlineNameEditor
+              initialValue={displayName}
+              onInput={rename.setDraft}
+              onCommit={rename.commit}
+              onCancel={rename.cancel}
+              ariaLabel="Timeline name"
+              className="min-w-0 flex-1 rounded-sm bg-zinc-900 px-1 py-0.5 text-sm font-semibold text-zinc-100 outline-none ring-1 ring-amber-400/70"
+            />
+          ) : (
+            <span
+              onDoubleClick={rename.begin}
+              title="Double-click or press F2 to rename"
+              className="min-w-0 flex-1 cursor-text truncate text-sm font-semibold text-zinc-100"
+            >
+              {displayName}
+            </span>
+          )}
+          <div className="flex items-center gap-3">
+            <span className="font-mono text-[11px] tabular-nums text-zinc-400">
+              {count} {count === 1 ? "item" : "items"} · {formatDuration(seconds)}
+            </span>
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                data-item-details-undo
+                disabled={!history.undoableHere}
+                onClick={history.undo}
+                aria-label="Undo the last change"
+                title="Undo the last change to this timeline"
+                className="rounded p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100 disabled:pointer-events-none disabled:opacity-30"
+              >
+                <Undo2 aria-hidden="true" className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                data-item-details-redo
+                disabled={!history.redoableHere}
+                onClick={history.redo}
+                aria-label="Redo the last change"
+                title="Redo the last change to this timeline"
+                className="rounded p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100 disabled:pointer-events-none disabled:opacity-30"
+              >
+                <Redo2 aria-hidden="true" className="h-4 w-4" />
+              </button>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close the details view"
+              className="rounded p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
+            >
+              <X aria-hidden="true" className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+
+        <div
+          data-item-details-frame
+          style={{ viewTransitionName: hero }}
+          className="flex min-h-32 gap-1 overflow-hidden rounded-md border border-dashed border-sky-500/40 bg-sky-500/[0.06] p-2"
+        >
+          {previews.length === 0 ? (
+            <span className="flex w-full items-center justify-center font-mono text-[11px] text-zinc-500">
+              {hydrated ? "This timeline is empty." : "Not loaded yet — open it to see inside."}
+            </span>
+          ) : (
+            previews.map((preview, index) => (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                // Keyed by SLOT, not content: the frames are a fixed-length,
+                // order-stable pair, and keying by id both collides and
+                // remounts on every child edit (the card learned this).
+                key={index}
+                src={collectionPreviewFrameUrl(preview)}
+                alt=""
+                draggable={false}
+                className="h-32 min-w-0 flex-1 rounded-sm object-cover"
+              />
+            ))
+          )}
+        </div>
+
+        <div className="flex items-center justify-between font-mono text-[11px] text-zinc-500">
+          <span className="text-sky-200/90">
+            {hydrated ? "loaded" : "summary only"}
+          </span>
+          <button
+            type="button"
+            data-item-details-open
+            onClick={() => {
+              onClose();
+              nav?.openTimeline(node.id);
+            }}
+            className="rounded px-2 py-1 text-[11px] font-semibold text-sky-200 hover:bg-sky-500/10 hover:text-sky-100"
+          >
+            Open this timeline
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -256,7 +256,7 @@ export function useCollectionPreviewFrames(
  * derivation used to re-walk the subtree per drag notification). The rounded
  * content key keeps sub-millisecond recompute jitter from churning the value.
  */
-function useHydratedCollectionSeconds(id: string, enabled: boolean): number | null {
+export function useHydratedCollectionSeconds(id: string, enabled: boolean): number | null {
   const store = useCollectionsStore();
   const detailsStore = useGraphDetailsStore();
   const [derive] = useState(() =>
@@ -969,6 +969,11 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
         />
       )}
 
+      {/* Same control the media card carries (PL11-012): a timeline has
+          details worth reading — what is inside it, how long it runs, whether
+          it is loaded — without drilling in to find out. */}
+      <ItemDetailsTrigger id={id} rovingTabIndex={undefined} />
+
       <CollectionItem.DropIndicators />
     </>
   );
@@ -985,7 +990,7 @@ const GraphCollectionItem = memo(function GraphCollectionItem({
       id={id}
       rovingTabIndex={rovingTabIndex}
       className={[
-        "h-full w-full",
+        "group/collection-item h-full w-full",
         // PL10-003: the call-out's scale pushes the card ~7px past this
         // wrapper, and a transform that spills counts as SCROLLABLE overflow —
         // so calling out the last card in a strip or a grid row grew the
@@ -1006,9 +1011,9 @@ const GraphCollectionItem = memo(function GraphCollectionItem({
 });
 
 /**
- * The details trigger on a media card (PL11-002): top-right, revealed on
- * hover or keyboard focus, and a real tab stop when its card is the roving
- * one.
+ * The details trigger (PL11-002, both card kinds since PL11-012): top-right,
+ * revealed on hover or keyboard focus, and a real tab stop when its card is
+ * the roving one.
  *
  * It is a SIBLING of NodeCard, not a child. NodeCard's shell is a single
  * `<button>`, and a button inside a button is invalid HTML — the same
@@ -1027,13 +1032,19 @@ const ItemDetailsTrigger = memo(function ItemDetailsTrigger({
 }: Readonly<{ id: NodeId; rovingTabIndex: number | undefined }>) {
   const store = useCollectionsStore();
   const { setOpenId } = useItemDetails();
+  // NAME the item: a board shows dozens of these, and "Open item details"
+  // spoken twenty times says nothing about which one. It also kept the label
+  // out of the way of the collection card's own "Open <name>" drill button —
+  // one card carrying two buttons whose names both began "Open" made every
+  // by-role locator ambiguous, which is how this was found.
+  const name = useCollectionsSelector((s) => s.graph.nodesById.get(id)?.name ?? "item");
 
   return (
     <button
       type="button"
       data-item-details-trigger={id}
-      aria-label="Open item details"
-      title="Open item details"
+      aria-label={`Details for ${name}`}
+      title="Details"
       {...(rovingTabIndex !== undefined ? { tabIndex: rovingTabIndex } : {})}
       onPointerDown={(event) => {
         // Keep the press off the surface gestures underneath — the strip's
@@ -1063,6 +1074,7 @@ const ItemDetailsTrigger = memo(function ItemDetailsTrigger({
         // beats unreachable.
         "transition-opacity duration-150 [@media(hover:hover)]:opacity-0",
         "group-hover/media-item:opacity-100 group-focus-within/media-item:opacity-100",
+        "group-hover/collection-item:opacity-100 group-focus-within/collection-item:opacity-100",
         "focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300",
       ].join(" ")}
     >

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -13,12 +13,14 @@ import {
   useCollectionsSelector,
   useCollectionsStore,
   useLiveTrim,
+  type CollectionItemNode,
   type MediaNode,
   type VideoMediaNode,
 } from "@storyboard/ui/dnd-collections";
 
 import { formatSeconds } from "@/lib/format-duration";
 import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
+import { CollectionDetailsBody } from "./graph-collection-details";
 import { useItemDetails } from "./graph-item-details-context";
 
 // The trim MODAL (PL10-008, an experiment replacing the docked map).
@@ -148,7 +150,19 @@ function useScopedHistory(nodeId: string) {
   const undoableHere = useCollectionsSelector((s) => {
     if (!s.canUndo) return false;
     const last = s.historyEntries[s.historyEntries.length - 1];
-    return last?.command.type === "update-media" && last.command.nodeId === nodeId;
+    if (!last) return false;
+    // Whatever this ITEM can do to itself: trim (media), rename (either), or
+    // a disable toggle. Structural commands name a parent and a set of moved
+    // nodes rather than "this item", so they stay out of reach here — which
+    // is the point of scoping.
+    const command = last.command;
+    if (command.type === "update-media" || command.type === "rename-node") {
+      return command.nodeId === nodeId;
+    }
+    if (command.type === "set-node-disabled") {
+      return command.nodeIds.length === 1 && command.nodeIds[0] === nodeId;
+    }
+    return false;
   });
   const [undoneHere, setUndoneHere] = useState(0);
   const redoableHere = canRedo && undoneHere > 0;
@@ -281,6 +295,21 @@ function SecondsField({
       />
       <span className="text-zinc-600">s</span>
     </label>
+  );
+}
+
+/**
+ * The collection half of the view. Split into its own module because the
+ * two bodies share only their frame — the header, the hero and the facts
+ * below it answer different questions for a timeline than for a clip.
+ */
+function CollectionDetails({
+  node,
+  onClose,
+}: Readonly<{ node: CollectionItemNode; onClose: () => void }>) {
+  const history = useScopedHistory(node.id);
+  return (
+    <CollectionDetailsBody node={node} hero={HERO} history={history} onClose={onClose} />
   );
 }
 
@@ -508,8 +537,7 @@ export function GraphItemDetailsModal() {
   // the source strip, a still gets its image and its duration (PL10-012).
   const node = useCollectionsSelector((s) => {
     if (openId === null) return null;
-    const found = s.graph.nodesById.get(parseNodeId(openId));
-    return found?.kind === "media" ? found : null;
+    return s.graph.nodesById.get(parseNodeId(openId)) ?? null;
   });
   const [mounted, setMounted] = useState(false);
   const openIdRef = useRef<string | null>(null);
@@ -517,7 +545,9 @@ export function GraphItemDetailsModal() {
   // Opening and closing are driven by the context flag so the toolbar button,
   // Escape, the close button and the scrim all go through one path.
   useEffect(() => {
-    const wanted = openId !== null && node !== null && !!node.src;
+    // A collection has no `src` and needs none — its hero is its contents.
+    const wanted =
+      openId !== null && node !== null && (node.kind === "collection" || !!node.src);
     if (wanted === mounted) return;
 
     if (wanted && node) {
@@ -543,6 +573,10 @@ export function GraphItemDetailsModal() {
     });
   }, [openId, node, mounted]);
 
-  if (!mounted || node === null || !node.src) return null;
+  if (!mounted || node === null) return null;
+  if (node.kind === "collection") {
+    return <CollectionDetails node={node} onClose={() => setOpenId(null)} />;
+  }
+  if (!node.src) return null;
   return <ModalBody node={node} onClose={() => setOpenId(null)} />;
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -10,6 +10,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
+import { createPortal } from "react-dom";
 
 import {
   MIN_ITEM_WIDTH,
@@ -870,10 +871,16 @@ function SeekRailRow({
       if (label) {
         label.textContent = formatSeconds(clamped);
         label.style.visibility = active ? "" : "hidden";
-        // Clamped into the rail so the readout stays legible at both ends.
+        // VIEWPORT coordinates, because the label is portaled to the body —
+        // read off the thumb it rides so it needs no knowledge of where the
+        // rail sits. Clamped to the viewport (not the rail) for the same
+        // reason it used to be clamped to the rail: it must stay legible at
+        // both ends rather than hanging off the edge.
+        const thumbRect = thumb.getBoundingClientRect();
         const half = label.offsetWidth / 2;
-        const x = fraction * rail.clientWidth;
-        label.style.left = `${Math.min(rail.clientWidth - half, Math.max(half, x))}px`;
+        const centre = thumbRect.left + thumbRect.width / 2;
+        label.style.left = `${Math.min(window.innerWidth - half - 4, Math.max(half + 4, centre))}px`;
+        label.style.top = `${thumbRect.top - 6}px`;
       }
       rail.setAttribute("aria-valuenow", (clamped - rowStart).toFixed(1));
       rail.setAttribute(
@@ -1031,18 +1038,24 @@ function SeekRailRow({
           clock is up in the preview chrome, too far to read mid-drag. Only
           during a drag: on hover it would follow a playhead nobody is moving.
           pointer-events-none so it can never take the drag's own pointer. */}
-      {scrubbing && (
-        <span
-          ref={timeRef}
-          data-rail-time
-          aria-hidden="true"
-          // BELOW the rail, not above: the surfaces sit hard against the
-          // sticky breadcrumb header, and there is nothing overhead to draw
-          // into — the readout was simply cut off (PL9-007). Downward it
-          // overlays the cards, which are its own surface and beneath it.
-          className="pointer-events-none absolute top-full z-50 mt-1.5 -translate-x-1/2 whitespace-nowrap rounded bg-zinc-900/95 px-1.5 py-0.5 font-mono text-[11px] text-zinc-100 shadow-sm ring-1 ring-zinc-700"
-        />
-      )}
+      {scrubbing &&
+        createPortal(
+          <span
+            ref={timeRef}
+            data-rail-time
+            aria-hidden="true"
+            // ABOVE the thumb (PL11-013), which is where the eye already is:
+            // the pointer is on the rail, and a label under it sits behind
+            // the hand. It could not live above while it was a CHILD of the
+            // rail — the surfaces clip vertically and sit hard against the
+            // sticky header, which is what put it below in PL9-007. Portaled
+            // and FIXED, nothing clips it; the paint above positions it in
+            // viewport coordinates. z-[70] clears the header it may overlap,
+            // and pointer-events-none keeps it out of the drag's way.
+            className="pointer-events-none fixed z-[70] -translate-x-1/2 -translate-y-full whitespace-nowrap rounded bg-zinc-900/95 px-1.5 py-0.5 font-mono text-[11px] text-zinc-100 shadow-sm ring-1 ring-zinc-700"
+          />,
+          document.body,
+        )}
     </div>
   );
 }
@@ -1371,12 +1384,19 @@ export function GraphStripSeekRail({
         windowX >= -overhang &&
         windowX <= outer.clientWidth + overhang;
       thumb.style.visibility = visible ? "" : "hidden";
-      // The scrub readout rides the thumb. Clamped into the rail so it stays
-      // legible at both ends instead of hanging off the timeline.
+      // The scrub readout rides the thumb, ABOVE it, in viewport coordinates
+      // (PL11-013) — it is portaled to the body, so rail-local pixels would
+      // mean nothing. Clamped to the viewport so it stays legible at both
+      // ends instead of hanging off the timeline, and hidden whenever the
+      // thumb is: a time label with no thumb under it points at nothing.
       const label = timeRef.current;
       if (label) {
+        label.style.visibility = visible ? "" : "hidden";
+        const thumbRect = thumb.getBoundingClientRect();
         const half = label.offsetWidth / 2;
-        label.style.left = `${Math.min(outer.clientWidth - half, Math.max(half, windowX))}px`;
+        const centre = thumbRect.left + thumbRect.width / 2;
+        label.style.left = `${Math.min(window.innerWidth - half - 4, Math.max(half + 4, centre))}px`;
+        label.style.top = `${thumbRect.top - 6}px`;
       }
     };
     const syncScroll = () => {
@@ -1625,18 +1645,24 @@ export function GraphStripSeekRail({
       />
       {/* The scrub readout, twin of the strip rail's — see there for why it
           exists and why it is drag-only. */}
-      {scrubbing && (
-        <span
-          ref={timeRef}
-          data-rail-time
-          aria-hidden="true"
-          // BELOW the rail, not above: the surfaces sit hard against the
-          // sticky breadcrumb header, and there is nothing overhead to draw
-          // into — the readout was simply cut off (PL9-007). Downward it
-          // overlays the cards, which are its own surface and beneath it.
-          className="pointer-events-none absolute top-full z-50 mt-1.5 -translate-x-1/2 whitespace-nowrap rounded bg-zinc-900/95 px-1.5 py-0.5 font-mono text-[11px] text-zinc-100 shadow-sm ring-1 ring-zinc-700"
-        />
-      )}
+      {scrubbing &&
+        createPortal(
+          <span
+            ref={timeRef}
+            data-rail-time
+            aria-hidden="true"
+            // ABOVE the thumb (PL11-013), which is where the eye already is:
+            // the pointer is on the rail, and a label under it sits behind
+            // the hand. It could not live above while it was a CHILD of the
+            // rail — the surfaces clip vertically and sit hard against the
+            // sticky header, which is what put it below in PL9-007. Portaled
+            // and FIXED, nothing clips it; the paint above positions it in
+            // viewport coordinates. z-[70] clears the header it may overlap,
+            // and pointer-events-none keeps it out of the drag's way.
+            className="pointer-events-none fixed z-[70] -translate-x-1/2 -translate-y-full whitespace-nowrap rounded bg-zinc-900/95 px-1.5 py-0.5 font-mono text-[11px] text-zinc-100 shadow-sm ring-1 ring-zinc-700"
+          />,
+          document.body,
+        )}
     </div>
   );
 }

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -3879,6 +3879,10 @@ test.describe("graph view E2E", () => {
     const readoutBox = (await readout.boundingBox())!;
     expect(Math.abs(readoutBox.x + readoutBox.width / 2 - (thumbBox.x + thumbBox.width / 2)))
       .toBeLessThan(40);
+    // ABOVE the thumb (PL11-013), not below it: the pointer is on the rail,
+    // so a label underneath sits behind the user's own hand. It clears the
+    // thumb entirely rather than merely being higher-centred.
+    expect(readoutBox.y + readoutBox.height).toBeLessThanOrEqual(thumbBox.y + 1);
 
     // Gone on release.
     await page.mouse.up();
@@ -4315,6 +4319,41 @@ test.describe("graph view E2E", () => {
     } finally {
       await context.close();
     }
+  });
+
+  test("a collection opens its own details view", async ({ page }) => {
+    // PL11-012. Drilling in already answers "what is in here", so this answers
+    // what you would otherwise drill in and back out to learn: how much is
+    // inside, how long it runs, whether it is loaded — plus a rename.
+    const api = await installGraphApi(page);
+    await openGraph(page);
+
+    const details = page.locator("[data-item-details]");
+    await expect(details).toHaveCount(0);
+
+    await openItemDetails(page, CHILD_ID);
+    await expect(details).toHaveCount(1);
+    await expect(details).toHaveAttribute("data-item-details-kind", "collection");
+    await expect(details).toContainText("Scene A");
+    // Its facts, not a clip's: no trim fields anywhere in here.
+    await expect(page.locator("[data-trim-field]")).toHaveCount(0);
+    await expect(details).toContainText("items");
+
+    // Rename lands the same way it does from the card — through the child
+    // document's title, which is the source of truth for a collection's name.
+    await details.locator("text=Scene A").first().dblclick();
+    const editor = page.getByRole("textbox", { name: "Timeline name" });
+    await editor.fill("Opening beat");
+    await editor.press("Enter");
+    await expect(details).toContainText("Opening beat");
+    await expect
+      .poll(() => api.documents.get(CHILD_ID)?.title, { timeout: 5000 })
+      .toBe("Opening beat");
+
+    // And it can hand off to the thing it describes.
+    await page.locator("[data-item-details-open]").click();
+    await expect(details).toHaveCount(0);
+    await page.waitForURL(`**${GRAPH_URL}/${CHILD_ID}`);
   });
 
   test("the header says whether the work is saved", async ({ page }) => {

--- a/punch-list/PUNCH-LIST-11.md
+++ b/punch-list/PUNCH-LIST-11.md
@@ -1,5 +1,57 @@
 # Punch List 11
 
+## PL11-012 — Collections get a details view too
+
+- Status: Complete
+- Area: `graph-collection-details.tsx` (new), `graph-item-details-modal.tsx`,
+  `graph-item-content.tsx`
+- Screenshot: Not captured
+
+The trigger and the view now serve both card kinds. What a collection's view
+is NOT: a second timeline view — drilling in already answers "what is in
+here". What it IS: the questions you would otherwise drill in and come back
+out to ask — how much is inside, how long it runs, whether it is even loaded
+— plus a rename, and a button to go in.
+
+The hero is its contents, because a timeline's identity is its footage: the
+card morphs into a larger version of the frames it was already showing. Live
+numbers once hydrated, the stored summary for a placeholder — the same rule
+the card follows, so the two can never disagree.
+
+Scoped undo widened with it: a collection's undoable acts are renames and
+disable toggles, not trims, so the gate now matches `update-media`,
+`rename-node` and a single-node `set-node-disabled` against this item.
+Structural commands name a parent and a set of moved nodes rather than "this
+item", so they stay out of reach — which is the point of scoping.
+
+REGRESSION CAUGHT BY THE SUITE, worth remembering: the trigger's
+`aria-label="Open item details"` collided with the collection card's own
+`Open <name>` drill button under the tests' `/^Open /` matcher — seven tests
+failed with strict-mode violations, not timeouts. Two buttons on one card
+whose names both began "Open" was a labelling problem before it was a test
+problem: the trigger now reads `Details for <name>`, which also stops a board
+full of them all announcing the same thing.
+
+## PL11-013 — The scrub readout moves above the playhead
+
+- Status: Complete
+- Area: `graph-preview.tsx`
+- Screenshot: Not captured
+
+The timestamp sat below the thumb, which is where the user's own hand is
+during a drag. It reads above now.
+
+PL9-007 had put it below for a real reason — the rails sit hard against the
+sticky header and the surfaces clip vertically, so an upward label inside the
+rail was simply cut off. The fix is therefore not a CSS flip: the readout is
+portaled to the body and positioned `fixed` in VIEWPORT coordinates, read off
+the thumb's rect each paint. Nothing clips it, and z-[70] lets it overlap the
+header it may reach into.
+
+Both rails (strip and grid) share the change. Proven fail-first: moving the
+same label back below the thumb fails the new geometric assertion (readout
+bottom must clear the thumb's top).
+
 ## PL11-009 — One duration vocabulary
 
 - Status: Complete


### PR DESCRIPTION
## PL11-012 — collections get a details view too

The trigger and the details view now serve both card kinds.

What a collection's view is **not**: a second timeline view — drilling in already answers "what is in here". What it **is**: the questions you would otherwise drill in and come back out to ask — how much is inside, how long it runs, whether it is even loaded — plus a rename and a way in.

The hero is its contents, because a timeline's identity is its footage: the card morphs into a larger version of the frames it was already showing. Live numbers once hydrated, the stored summary for a placeholder — the rule the card already follows, so the two can never disagree.

Scoped undo widened with it: a collection's undoable acts are renames and disable toggles rather than trims, so the gate matches `update-media`, `rename-node` and a single-node `set-node-disabled` against this item. Structural commands name a parent and a set of moved nodes rather than "this item", so they stay out of reach — which is the point of scoping.

**A regression the suite caught, worth remembering.** The trigger's `aria-label="Open item details"` collided with the collection card's own `Open <name>` drill button under the tests' `/^Open /` matcher: seven tests failed with strict-mode violations rather than timeouts. Two buttons on one card whose names both began "Open" was a labelling problem before it was a test problem — a board full of triggers all announced the same words. The trigger now reads `Details for <name>`.

## PL11-013 — the scrub readout moves above the playhead

The timestamp sat below the thumb, which is exactly where the user's hand is during a drag.

This is not a CSS flip. PL9-007 had put it below for a real reason: the rails sit hard against the sticky header and the surfaces clip vertically, so an upward label inside the rail was simply cut off. The readout is now portaled to the body and positioned `fixed` in **viewport** coordinates, read off the thumb's rect on each paint — nothing clips it, and `z-[70]` lets it overlap the header it may reach into. Both rails (strip and grid) share the change.

## Verification

- graph-view e2e **99/100**. The one failure is `crafted focus URLs`, which has flaked under parallel load since before this branch and passes in isolation.
- Typecheck and lint clean.
- Placement proven fail-first: putting the same label back below the thumb fails the new geometric assertion (readout bottom must clear the thumb's top).
- Collection view driven live on *Mugshots*: `3 items · 18.3s`, `loaded`, two content frames as the hero, an "Open this timeline" hand-off, and no trim fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
