### PR TITLE
Punch list 11: the breadcrumb stops waiting for the server, and the e2e flake was oversubscription

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
@@ -23,7 +23,14 @@ import type { GraphDetailsStore } from "@/lib/graph-details-store";
 import { useGraphDetailsStore } from "./graph-details-context";
 
 type GraphViewNav = Readonly<{
-  openTimeline: (nodeId: NodeId) => void;
+  /**
+   * Focus a timeline, optimistically. Returns whether it took the navigation:
+   * FALSE means the node's parent chain does not reach this project, so the
+   * caller still owns the click. Only the breadcrumb reads it — a crumb is a
+   * real <a href>, and one that resolves to nothing must fall back to letting
+   * the browser follow it rather than silently eating the click.
+   */
+  openTimeline: (nodeId: NodeId) => boolean;
   /** The timeline currently in focus. Cards read it to tell whether they are
    *  being shown OUTSIDE their own collection — which is exactly the flat
    *  strip, and what makes a provenance label worth drawing. */
@@ -69,13 +76,14 @@ export function GraphViewNavProvider({
       openTimeline: (nodeId) => {
         const id = nodeId as string;
         const timelineId = detailsStore.get(id)?.duplicateOfTimelineId ?? id;
-        if (timelineId === focusedId) return;
+        // Already here: handled, in the sense the caller must not also act.
+        if (timelineId === focusedId) return true;
 
         const base = `/timeline/${encodeURIComponent(projectId)}/graph`;
         if (timelineId === projectId) {
           onNavigateStart?.([]);
           router.push(base);
-          return;
+          return true;
         }
 
         const { graph } = store.getSnapshot();
@@ -89,12 +97,13 @@ export function GraphViewNavProvider({
           chain.unshift(parent);
           parent = graph.parentById.get(parent) ?? null;
         }
-        if (parent !== projectNodeId) return;
+        if (parent !== projectNodeId) return false;
         // The pending path is exactly what the URL will decode to (the push
         // below encodes these same segments), so the optimistic render and
         // the committed one can't disagree.
         onNavigateStart?.(chain);
         router.push(`${base}/${chain.map(encodeURIComponent).join("/")}`);
+        return true;
       },
     }),
     [detailsStore, focusedId, onNavigateStart, projectId, router, store],

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
-import { useSyncExternalStore } from "react";
+import { useContext, useSyncExternalStore } from "react";
 import { useDroppable } from "@dnd-kit/core";
 
 import {
@@ -21,6 +21,40 @@ import {
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 import { cn } from "@/lib/utils";
 import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
+import { GraphViewNavContext } from "./graph-navigation";
+
+/**
+ * Navigate a crumb the way every OTHER focus change in this app already does.
+ *
+ * The trail was the last navigation still relying on a bare `next/link`, and a
+ * Link cannot repaint the board until the App Router commits the new pathname
+ * — which waits on an RSC request the board needs nothing from, since the
+ * graph is already in memory. Measured in dev, where that round trip is local
+ * and therefore as cheap as it will ever be: drilling INTO a collection
+ * acknowledged the click in ~20ms, while a crumb sat silent for ~83ms and its
+ * content change landed on the same millisecond as the URL, every time. In
+ * production that round trip is a network hop, and a control that does
+ * nothing at all for that long reads as broken rather than slow.
+ *
+ * `openTimeline` publishes the destination BEFORE it pushes, so the board
+ * moves on the next frame and the URL catches up behind it.
+ *
+ * The `href` stays real, and this claims only the plain left click. Modified
+ * and middle clicks still open a tab or a window — the reason these are
+ * anchors and not buttons — and a false return (a crumb whose chain does not
+ * reach this project) hands the click back to the browser rather than eating
+ * it.
+ */
+function useCrumbNavigation(crumbId: string) {
+  const nav = useContext(GraphViewNavContext);
+  return (event: React.MouseEvent<HTMLAnchorElement>) => {
+    if (nav === null || event.defaultPrevented) return;
+    if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+      return;
+    }
+    if (nav.openTimeline(parseNodeId(crumbId))) event.preventDefault();
+  };
+}
 
 function useGraphPathTitles() {
   return useSyncExternalStore(
@@ -103,6 +137,7 @@ function AncestorCrumb({
   const { setNodeRef } = useDroppable({
     id: encodeDropTarget({ type: "panel", collectionId: parseNodeId(crumbId) }),
   });
+  const navigate = useCrumbNavigation(crumbId);
   const state = useCollectionsSelector((snapshot): CrumbDropState => {
     if (!snapshot.interaction.isDragging) return "idle";
     const intent = snapshot.interaction.dropIntent;
@@ -118,6 +153,7 @@ function AncestorCrumb({
     >
       <Link
         href={href}
+        onClick={navigate}
         className={cn(
           "block min-w-0 max-w-[180px] truncate rounded-md px-1.5 py-1 transition-colors",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70",
@@ -152,6 +188,19 @@ type CrumbEntry = Readonly<{ id: string; href: string; label: string }>;
  * These crumbs stop being drop targets while folded — a target you cannot see
  * is not one you can aim a card at. The visible crumbs keep theirs.
  */
+/** One folded crumb. Its own component because the optimistic-navigation hook
+ *  cannot be called from inside the map that renders these. */
+function CollapsedCrumbLink({ crumb }: Readonly<{ crumb: CrumbEntry }>) {
+  const navigate = useCrumbNavigation(crumb.id);
+  return (
+    <DropdownMenuItem asChild>
+      <Link href={crumb.href} onClick={navigate}>
+        {crumb.label}
+      </Link>
+    </DropdownMenuItem>
+  );
+}
+
 function CollapsedCrumbs({ crumbs }: Readonly<{ crumbs: readonly CrumbEntry[] }>) {
   return (
     <DropdownMenu>
@@ -168,12 +217,37 @@ function CollapsedCrumbs({ crumbs }: Readonly<{ crumbs: readonly CrumbEntry[] }>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start">
         {crumbs.map((crumb) => (
-          <DropdownMenuItem key={crumb.id} asChild>
-            <Link href={crumb.href}>{crumb.label}</Link>
-          </DropdownMenuItem>
+          <CollapsedCrumbLink key={crumb.id} crumb={crumb} />
         ))}
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+/**
+ * The up-one-level control. Inside the graph it is a crumb by another name and
+ * navigates the same optimistic way; at the ROOT it leaves for the projects
+ * page, which is a genuine document load with nothing to be optimistic about,
+ * so it stays an ordinary link.
+ */
+function ParentLink({
+  href,
+  parentId,
+  title,
+}: Readonly<{ href: string; parentId: string | null; title: string }>) {
+  // Called unconditionally, as a hook must be; the id it closes over is read
+  // only when the handler runs, and the handler is only attached when there is
+  // a parent timeline to go to.
+  const navigate = useCrumbNavigation(parentId ?? "");
+  return (
+    <Link
+      href={href}
+      onClick={parentId === null ? undefined : navigate}
+      className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-zinc-800 bg-zinc-950/50 text-zinc-400 transition-all hover:border-zinc-700 hover:bg-zinc-800 hover:text-zinc-100"
+      title={title}
+    >
+      <ArrowLeft className="h-3.5 w-3.5" />
+    </Link>
   );
 }
 
@@ -229,16 +303,23 @@ export function GraphBreadcrumb({
       : timelinePath.length === 1
         ? base
         : "/";
+  // The node the back arrow lands on, or null when it leaves the graph
+  // entirely (at the root, "up" is the projects page). Mirrors parentHref
+  // exactly — same three cases, so the two cannot point at different places.
+  const parentCrumbId =
+    timelinePath.length > 1
+      ? timelinePath[timelinePath.length - 2]
+      : timelinePath.length === 1
+        ? projectId
+        : null;
 
   return (
     <div className="flex min-w-0 flex-1 items-center gap-3 overflow-hidden">
-      <Link
+      <ParentLink
         href={parentHref}
-        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-zinc-800 bg-zinc-950/50 text-zinc-400 transition-all hover:border-zinc-700 hover:bg-zinc-800 hover:text-zinc-100"
+        parentId={parentCrumbId}
         title={focusedId === projectId ? "Go to Projects" : "Go to parent timeline"}
-      >
-        <ArrowLeft className="h-3.5 w-3.5" />
-      </Link>
+      />
       <nav
         aria-label="Timeline focus path"
         className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden text-xs text-zinc-400 select-none"

--- a/apps/timeline-gstudio001/playwright.config.ts
+++ b/apps/timeline-gstudio001/playwright.config.ts
@@ -3,6 +3,21 @@ import { defineConfig, devices } from "@playwright/test";
 export default defineConfig({
   testDir: "./tests/e2e",
   fullyParallel: true,
+  // CAPPED, and deliberately not scaled to the core count. Every test in both
+  // projects loads pages from ONE dev server process, so the bottleneck is
+  // that server, not this machine's CPUs — and Playwright's default (half the
+  // cores: 14 here) oversubscribes it badly enough to be self-defeating.
+  //
+  // Measured over the graph-view suite, 101 tests:
+  //   14 workers — median test 15.3s, slowest 35.1s, 2 timeouts, 136s wall
+  //    6 workers — median test  5.8s, slowest 13.0s, 0 timeouts, 102s wall
+  //
+  // Fewer workers is faster in wall clock AND stops the failures: past the
+  // server's capacity the extra workers only queue on it. That queueing is
+  // the whole story behind the suite's "1-4 tests time out per run, all green
+  // in isolation" reputation — tests were dying on the 30s budget with a
+  // median of 15s, so anything heavier than typical lost the race.
+  workers: 6,
   reporter: [["list"], ["html", { open: "never" }]],
   use: {
     baseURL: "http://127.0.0.1:6006",
@@ -43,12 +58,21 @@ export default defineConfig({
     {
       name: "graph-view",
       testMatch: /graph-view/,
+      // The per-test budget has to EXCEED navigationTimeout or that allowance
+      // is unreachable: it was 60s against the default 30s test timeout, so a
+      // navigation was always killed by the test long before its own limit,
+      // and the intent below never actually applied. 60/45 keeps the same
+      // shape with room left for the assertions that follow a cold load.
+      // Not a way to let slow tests pass — with the worker cap above, the
+      // slowest test in the suite is 13s, so this ceiling only ever catches a
+      // genuine hang.
+      timeout: 60000,
       use: {
         ...devices["Desktop Chrome"],
         baseURL: "http://127.0.0.1:3000",
         // Dev-mode Next compiles routes on first hit; give cold navigations
         // room before the suite's own (tight) assertions take over.
-        navigationTimeout: 60000,
+        navigationTimeout: 45000,
       },
     },
   ],

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1835,6 +1835,46 @@ test.describe("graph view E2E", () => {
       .toEqual(["alpha", "bravo", "clip-scene", "charlie", "g1"]);
   });
 
+  test("a breadcrumb moves the board without waiting for the server", async ({ page }) => {
+    const api = await installGraphApi(page);
+    api.documents
+      .get(CHILD_ID)!
+      .clips.push(collectionClip("clip-nested", GRANDCHILD_ID, 2, "Scene B", 1));
+    api.documents.set(GRANDCHILD_ID, {
+      id: GRANDCHILD_ID,
+      title: "Scene B",
+      clips: [mediaClip("g1", "image", 0, 4)],
+    });
+
+    await page.goto(
+      `${GRAPH_URL}/${encodeURIComponent(CHILD_ID)}/${encodeURIComponent(GRANDCHILD_ID)}?surface=strip`,
+    );
+    await strip(page, GRANDCHILD_ID)
+      .locator('[data-node-id="g1"]')
+      .waitFor({ state: "visible", timeout: 30000 });
+
+    // STALL every RSC navigation request. A focus change needs NOTHING from
+    // the server — the graph is already in memory and the page segment only
+    // primes documents the client can fetch itself — so the board must move
+    // regardless. This is precisely what a plain <Link> crumb could not do:
+    // it cannot repaint until the App Router commits the new pathname, and
+    // that commit waits on this very request. Asserting the mechanism rather
+    // than a stopwatch, because a timing budget would be flaky and would not
+    // fail at all on a fast local server.
+    await page.route(/_rsc=/, async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+      await route.abort().catch(() => {});
+    });
+
+    await page.locator(`[data-graph-ancestor-drop="${CHILD_ID}"] a`).click();
+
+    // Scene A's own clips are on screen well inside the stall.
+    await expect(strip(page, CHILD_ID).locator('[data-node-id="c1"]')).toBeVisible({
+      timeout: 1500,
+    });
+    await page.unroute(/_rsc=/);
+  });
+
   test("hovering a drop zone highlights the parent crumb / animates the sidebar trash icon", async ({
     page,
   }) => {

--- a/punch-list/PUNCH-LIST-11.md
+++ b/punch-list/PUNCH-LIST-11.md
@@ -421,3 +421,58 @@ be flaky and would not fail on a fast local server. Proven fail-first, but
 only on the SECOND attempt: removing `preventDefault` left the test passing,
 because `openTimeline` still ran and the optimism survived. The honest revert
 is removing the `onClick` altogether, and that fails.
+
+## PL11-015 — The e2e "load flake" was oversubscription
+
+- Status: Complete
+- Area: `playwright.config.ts`
+- Screenshot: Not captured
+
+The graph-view suite had a long-standing reputation: 1-4 tests time out per
+full run, always green in isolation, so the failures got waved through as
+"flakes under parallel load". They were not random. They were the predictable
+result of a budget that had quietly run out.
+
+Diagnosis, from the JSON reporter rather than the summary line: every failure
+was a TEST TIMEOUT at 30000ms — never an assertion — and they landed mid-run
+(+49s, +93s of a 136s run), not at the start, so this was steady-state
+contention and not first-hit compilation. The number that explained it: the
+MEDIAN test took 15.3s against that 30s budget. The suite was running at a
+2x margin on the median, so any test heavier than typical lost the race. Which
+tests drew the short straw varied per run; that is what made it look like luck.
+
+The cause is that Playwright defaults `workers` to half the core count — 14 on
+this machine — while every test in both projects loads pages from ONE dev
+server process. The bottleneck was never the CPU, so those extra workers
+bought queueing rather than parallelism.
+
+Measured over 101 tests:
+
+| workers | failures | p50 | p90 | slowest | wall |
+| --- | --- | --- | --- | --- | --- |
+| 14 (default) | 2 | 15.3s | 19.1s | 35.1s | 136.2s |
+| 6 | 0 | 5.8s | 8.4s | 13.0s | 101.8s |
+
+Fewer workers is faster in wall clock AND removes the failures — no tradeoff
+to weigh, the oversubscription was costing time as well as reliability. The
+cap is a fixed 6 rather than a fraction of the cores on purpose: the shared
+resource it is protecting does not scale with this machine.
+
+A second, quieter bug surfaced while reading the config. `navigationTimeout`
+was 60s against the default 30s per-test timeout, so a navigation was always
+killed by the test budget long before reaching its own limit — the "give cold
+navigations room" comment described an intent that had never been in effect.
+Now 60s per test with a 45s navigation allowance inside it. That is not a way
+to let slow tests pass: with the worker cap the slowest test is 13s, so the
+ceiling only ever catches a genuine hang.
+
+No retries were added. Retries would have hidden this rather than fixed it.
+
+Acceptance criteria:
+
+- A full graph-view run passes without per-test annotation or re-runs.
+- Wall clock does not regress.
+
+Verified: three consecutive full runs, zero failures (p50 5.8/6.1/7.0s, max
+13.0/13.6/22.7s, wall 101.8/110.4/122.5s) against the previous run's 2
+timeouts at 136.2s.

--- a/punch-list/PUNCH-LIST-11.md
+++ b/punch-list/PUNCH-LIST-11.md
@@ -356,3 +356,68 @@ Verified live: `getComputedStyle(svg).strokeWidth` is 1.5px on the rail's
 lucide glyphs (their `stroke-width` ATTRIBUTE is still 2 — the CSS wins),
 1.5px on the folders, 1.9px on the badges, and the logo computes to
 rgb(255, 255, 255).
+
+## PL11-014 — The breadcrumb stops waiting for the server
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `graph-view-chrome.tsx`, `graph-navigation.tsx`
+- Screenshot: Not captured
+
+Reported as "a big delay before the new content shows" when clicking a crumb —
+about a second and a half.
+
+The trail was the last navigation in the app still relying on a bare
+`next/link`. A Link cannot repaint the board until the App Router commits the
+new pathname, and that commit waits on an RSC request the board needs nothing
+from: the graph is already in memory, and the page segment only PRIMES
+documents the client can fetch itself. Every other way to change focus — a
+folder card, "Open this timeline", the O key — goes through `openTimeline`,
+which publishes the destination before it pushes. The crumbs never got it.
+
+Measured in dev, where that round trip is local and so as cheap as it will
+ever be:
+
+| Cold navigation | First feedback | Fully settled |
+| --- | --- | --- |
+| Drill in | 20ms | 530ms |
+| Breadcrumb up (before) | 83ms | 878ms |
+| Breadcrumb up (after) | 20ms | — |
+
+The signature was that the crumb's content change and its URL change landed on
+the SAME millisecond, four times out of four (53.6, 67.2, 94.8, 105.1) — the
+view was not working, it was waiting. The hydration tail is shared by both
+directions and is not what this fixes; the dead window at the front is. In
+production that window is a network hop, and a control that does nothing at
+all for a few hundred milliseconds reads as broken rather than slow.
+
+All three link kinds route through `openTimeline` now: the ancestor crumbs,
+the folded ones in the overflow menu, and the back arrow — except at the root,
+where "up" leaves for the projects page, a genuine document load with nothing
+to be optimistic about.
+
+They stay real anchors. The handler claims ONLY the plain left click, so
+modified and middle clicks still open a tab or a window, and `openTimeline`
+now returns whether it took the navigation: a crumb whose parent chain does
+not reach this project hands the click back to the browser instead of eating
+it.
+
+Acceptance criteria:
+
+- A crumb click repaints the board without a server round trip.
+- Ctrl/Cmd/Shift click still opens a new tab or window.
+- Back/Forward still reconcile the board with the URL.
+
+Verified live: the cold crumb hop repaints at 20.5ms (was 82.8ms), with the
+URL committing behind it and the board agreeing once it lands. Dispatched
+clicks confirm `defaultPrevented` is true for a plain click and false for
+ctrl/meta/shift. Back returns to the previous focus with URL, crumb and card
+count in agreement.
+
+Covered by "a breadcrumb moves the board without waiting for the server",
+which stalls every `_rsc=` request and requires the board to move anyway —
+asserting the mechanism rather than a stopwatch, since a timing budget would
+be flaky and would not fail on a fast local server. Proven fail-first, but
+only on the SECOND attempt: removing `preventDefault` left the test passing,
+because `openTimeline` still ran and the optimism survived. The honest revert
+is removing the `onClick` altogether, and that fails.


### PR DESCRIPTION
Two fixes, both from the same complaint: "there's a big delay before the new content shows."

## PL11-014 — the breadcrumb stops waiting for the server

The trail was the last navigation in the app still on a bare `next/link`. A Link cannot repaint the board until the App Router commits the new pathname, and that commit waits on an RSC request the board needs nothing from — the graph is already in memory, and the page segment only *primes* documents the client can fetch itself.

Every other way to change focus (a folder card, "Open this timeline", the `O` key) goes through `openTimeline`, which publishes the destination *before* it pushes. The crumbs never got it.

Measured cold, in dev, where that round trip is local and so as cheap as it will ever be:

| Cold navigation | First feedback | Fully settled |
| --- | --- | --- |
| Drill in | 20ms | 530ms |
| Breadcrumb up — before | 83ms | 878ms |
| Breadcrumb up — after | **20ms** | — |

The signature was that a crumb's content change and its URL change landed on the **same millisecond**, four times out of four (53.6, 67.2, 94.8, 105.1). The view was not working, it was waiting.

The ~880ms hydration tail is shared by both directions and is **not** what this fixes — drilling in has it too, you just don't notice, because the board acknowledges you at 20ms and fills in visibly. The dead window at the front is the bug. In production it is a network hop, and a control that does nothing at all for a few hundred milliseconds reads as broken rather than slow.

All three link kinds route through `openTimeline` now: ancestor crumbs, the folded ones in the overflow menu, and the back arrow — except at the root, where "up" leaves for the projects page, a real document load with nothing to be optimistic about.

They stay real anchors. The handler claims **only** the plain left click, so modified and middle clicks still open a tab or a window, and `openTimeline` now reports whether it took the navigation: a crumb whose parent chain does not reach this project hands the click back to the browser rather than eating it.

Covered by a test that stalls every `_rsc=` request and requires the board to move anyway — the mechanism rather than a stopwatch, since a timing budget would be flaky and would not fail on a fast local server. Proven fail-first on the **second** attempt: removing `preventDefault` left it passing, because `openTimeline` still ran and the optimism survived. The honest revert is removing the `onClick`, and that fails.

## PL11-015 — the e2e "load flake" was oversubscription

This suite had a reputation: 1–4 tests time out per full run, always green in isolation, so the failures got waved through as flakes under parallel load — including by me, in the last several PR descriptions. They were not random.

From the JSON reporter rather than the summary line: every failure was a **test timeout at 30000ms**, never an assertion, and they landed mid-run (+49s, +93s of a 136s run) rather than at the start — steady-state contention, not first-hit compilation. The number that explained it: **the median test took 15.3s against that 30s budget.** The suite ran at a 2× margin on the median, so anything heavier than typical lost the race, and which test drew the short straw varied per run. That is what made it look like luck.

Playwright defaults `workers` to half the core count — 14 here — while every test in both projects loads pages from **one** dev server process. The bottleneck was never the CPU, so the extra workers bought queueing, not parallelism.

| workers | failures | p50 | p90 | slowest | wall |
| --- | --- | --- | --- | --- | --- |
| 14 (default) | 2 | 15.3s | 19.1s | 35.1s | 136.2s |
| 6 | **0** | **5.8s** | 8.4s | 13.0s | **101.8s** |

Fewer workers is faster in wall clock **and** removes the failures — no tradeoff to weigh. The cap is a fixed 6 rather than a fraction of the cores on purpose: the shared resource it protects does not scale with the machine.

A second, quieter bug surfaced while reading the config. `navigationTimeout` was 60s against the default 30s per-test timeout, so a navigation was always killed by the test budget before reaching its own limit — the "give cold navigations room" comment described an intent that had **never been in effect**. Now 60s per test with a 45s navigation allowance inside it. Not a way to let slow tests pass: with the cap the slowest test is 13s, so the ceiling only catches a genuine hang.

No retries were added. Retries would have hidden this rather than fixed it.

## Verification

- **Three consecutive full graph-view runs, zero failures** (p50 5.8/6.1/7.0s, max 13.0/13.6/22.7s, wall 101.8/110.4/122.5s) against the previous run's 2 timeouts at 136.2s. This is the first PR in a while whose test status needs no asterisk.
- Typecheck and lint clean (4 pre-existing `<img>` warnings).
- Breadcrumb verified live: the cold crumb hop repaints at 20.5ms (was 82.8ms), the URL commits behind it, and the board agrees once it lands. Dispatched clicks confirm `defaultPrevented` is true for a plain click and false for ctrl/meta/shift. Back returns to the previous focus with URL, crumb and card count in agreement.

## Not addressed

The ~880ms hydration tail after a focus change, now the slowest thing left in a navigation. It affects drilling in and crumbing up equally and is a separate piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
