### PR TITLE
Review fixes: ownership claiming is gone, and CI runs the story suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,17 @@
 name: CI
 
-# The validation gate every PR must pass before auto-merge can complete.
-# Kept to the fast, deterministic checks (typecheck + lint + unit); the
-# Playwright e2e suite is intentionally excluded here — it needs a dev server
-# and real browsers, too slow/flaky to gate every merge on. Run it locally or
-# in a separate manual workflow when a change warrants it.
+# The validation gate every PR must pass before auto-merge can complete:
+# typecheck + lint + unit + the Storybook browser suite.
+#
+# The Storybook `play` functions ARE this repo's interaction test suite, so
+# leaving them out meant interaction and visual contracts could drift while CI
+# stayed green — and they did: a badge's type floor moved 9px -> 11px and the
+# assertion demanding 9px went unnoticed because nothing ran it. They need a
+# real Chromium but no dev server, which is what makes them affordable here.
+#
+# The Playwright e2e suite is still intentionally excluded — it needs a running
+# dev server and real trusted mouse input, too slow to gate every merge on. Run
+# it locally or in a separate manual workflow when a change warrants it.
 
 on:
   pull_request:
@@ -50,3 +57,12 @@ jobs:
       - name: App tests (routes, gateway, model)
         working-directory: apps/timeline-gstudio001
         run: npx vitest run
+
+      # Only Chromium — the browser project pins a single chromium instance,
+      # so installing the other engines is pure download time.
+      - name: Install Chromium for browser stories
+        run: npx playwright install --with-deps chromium
+
+      - name: Story interaction tests (headless Chromium)
+        working-directory: apps/storybook
+        run: npx vitest run --project=storybook

--- a/apps/timeline-gstudio001/app/api/timeline-media/route.test.ts
+++ b/apps/timeline-gstudio001/app/api/timeline-media/route.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const state = vi.hoisted(() => ({
   scopedProject: null as string | null,
   metadataReads: 0,
+  cacheControl: "private, no-cache",
 }));
 
 vi.mock("server-only", () => ({}));
@@ -36,7 +37,7 @@ vi.mock("@/lib/firebase-media-store", () => ({
     return {
       size: 100,
       contentType: "video/mp4",
-      cacheControl: "private, no-cache",
+      cacheControl: state.cacheControl,
       bucketName: "bucket",
     };
   },
@@ -45,7 +46,7 @@ vi.mock("@/lib/firebase-media-store", () => ({
     pathname?.startsWith("timeline-thumbnails/") === true,
 }));
 
-import { HEAD } from "./route";
+import { GET, HEAD } from "./route";
 
 function request(pathname: string) {
   return new Request(
@@ -54,9 +55,19 @@ function request(pathname: string) {
   );
 }
 
+const OWNED = "timeline-videos/projects/user-a/project-a/large.mp4";
+
+function rangeRequest(range: string | null) {
+  return new Request(
+    `http://test.local/api/timeline-media?pathname=${encodeURIComponent(OWNED)}`,
+    { method: "GET", headers: range ? { range } : undefined },
+  );
+}
+
 beforeEach(() => {
   state.scopedProject = null;
   state.metadataReads = 0;
+  state.cacheControl = "private, no-cache";
 });
 
 describe("project-scoped Firebase media reads", () => {
@@ -78,5 +89,87 @@ describe("project-scoped Firebase media reads", () => {
     expect(response.status).toBe(404);
     expect(state.scopedProject).toBeNull();
     expect(state.metadataReads).toBe(0);
+  });
+});
+
+describe("range responses", () => {
+  it("serves an explicit range as 206", async () => {
+    const response = await GET(rangeRequest("bytes=10-20"));
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("content-range")).toBe("bytes 10-20/100");
+    expect(response.headers.get("content-length")).toBe("11");
+  });
+
+  // The regression: this used to answer `bytes 0-500/100` worth of intent —
+  // the FIRST bytes rather than the last 30.
+  it("serves a suffix range from the end of the resource", async () => {
+    const response = await GET(rangeRequest("bytes=-30"));
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("content-range")).toBe("bytes 70-99/100");
+    expect(response.headers.get("content-length")).toBe("30");
+  });
+
+  it("runs an open-ended range to the final byte", async () => {
+    const response = await GET(rangeRequest("bytes=90-"));
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("content-range")).toBe("bytes 90-99/100");
+  });
+
+  it("answers 416 for a range past the end of the resource", async () => {
+    const response = await GET(rangeRequest("bytes=100-200"));
+
+    expect(response.status).toBe(416);
+    expect(response.headers.get("content-range")).toBe("bytes */100");
+  });
+
+  it("serves the full body when there is no range", async () => {
+    const response = await GET(rangeRequest(null));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-length")).toBe("100");
+    expect(response.headers.get("accept-ranges")).toBe("bytes");
+  });
+
+  // Valid but unimplemented — serving only its first part would hand the
+  // client bytes it did not ask for under a 206 that claims otherwise.
+  it("serves the full body for an unsupported multi-range request", async () => {
+    const response = await GET(rangeRequest("bytes=0-1,5-6"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-length")).toBe("100");
+  });
+});
+
+describe("cache headers", () => {
+  it("never lets an authenticated response be stored in a shared cache", async () => {
+    // What thumbnails are actually written to storage with.
+    state.cacheControl = "public, max-age=31536000, immutable";
+
+    const response = await GET(rangeRequest(null));
+    const cacheControl = response.headers.get("cache-control") ?? "";
+
+    expect(cacheControl).toContain("private");
+    expect(cacheControl).not.toContain("public");
+    // The freshness lifetime itself is still worth keeping — only the
+    // shared-cache permission had to go.
+    expect(cacheControl).toContain("max-age=31536000");
+  });
+
+  it("keeps an already-private directive intact", async () => {
+    const response = await GET(rangeRequest(null));
+
+    expect(response.headers.get("cache-control")).toBe("private, no-cache");
+  });
+
+  it("applies the same policy to 206 responses", async () => {
+    state.cacheControl = "public, max-age=31536000, immutable";
+
+    const response = await GET(rangeRequest("bytes=0-9"));
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("cache-control")).not.toContain("public");
   });
 });

--- a/apps/timeline-gstudio001/app/api/timeline-media/route.ts
+++ b/apps/timeline-gstudio001/app/api/timeline-media/route.ts
@@ -6,6 +6,7 @@ import {
   isAllowedMediaPathname,
 } from "@/lib/firebase-media-store";
 import { requireAuthUser } from "@/lib/firebase-auth-session";
+import { parseRangeHeader } from "@/lib/http-range";
 import {
   ProjectAssetScopeError,
   requireProjectAssetScope,
@@ -13,6 +14,31 @@ import {
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+
+/**
+ * Every byte this route serves passed an auth check, so no response from it may
+ * be stored in a SHARED cache: a CDN or corporate proxy keys on URL alone and
+ * would hand one user's media to the next requester without re-running that
+ * check. Thumbnails are written to storage with
+ * `public, max-age=31536000, immutable` (fine for the object, wrong for this
+ * response), so the stored directive is overridden here rather than merely
+ * fixed at upload time — that way EXISTING objects are covered too, not just
+ * ones uploaded after this deploy.
+ */
+function toPrivateCacheControl(stored: string | undefined) {
+  if (!stored) return "private, no-cache";
+  // Drop any existing cacheability directive — `public` because it is wrong
+  // here, `private` so re-asserting it below cannot double it up — and keep
+  // every freshness directive (max-age, immutable, no-cache…) as stored.
+  const preserved = stored
+    .split(",")
+    .map((directive) => directive.trim())
+    .filter((directive) => {
+      const normalized = directive.toLowerCase();
+      return normalized !== "public" && normalized !== "private";
+    });
+  return ["private", ...preserved].join(", ");
+}
 
 function projectScopeFromMediaPathname(pathname: string) {
   const match =
@@ -45,13 +71,12 @@ async function handleMediaRequest(request: Request, includeBody: boolean) {
       return new NextResponse("Media not found.", { status: 404 });
     }
 
-    const range = request.headers.get("range");
-    if (range && media.contentType.startsWith("video/")) {
-      const match = range.match(/bytes=(\d*)-(\d*)/);
-      const start = match?.[1] ? Number(match[1]) : 0;
-      const end = match?.[2] ? Number(match[2]) : media.size - 1;
+    const cacheControl = toPrivateCacheControl(media.cacheControl);
 
-      if (Number.isNaN(start) || Number.isNaN(end) || start > end || start >= media.size) {
+    if (media.contentType.startsWith("video/")) {
+      const range = parseRangeHeader(request.headers.get("range"), media.size);
+
+      if (range.type === "unsatisfiable") {
         return new NextResponse(null, {
           status: 416,
           headers: {
@@ -60,28 +85,32 @@ async function handleMediaRequest(request: Request, includeBody: boolean) {
         });
       }
 
-      const chunkEnd = Math.min(end, media.size - 1);
-      const chunkSize = chunkEnd - start + 1;
+      if (range.type === "satisfiable") {
+        const chunkSize = range.end - range.start + 1;
 
-      return new NextResponse(
-        includeBody ? createMediaReadStream(pathname, { start, end: chunkEnd }, media.bucketName) : null,
-        {
-          status: 206,
-          headers: {
-            "Accept-Ranges": "bytes",
-            "Cache-Control": media.cacheControl,
-            "Content-Length": String(chunkSize),
-            "Content-Range": `bytes ${start}-${chunkEnd}/${media.size}`,
-            "Content-Type": media.contentType,
+        return new NextResponse(
+          includeBody
+            ? createMediaReadStream(pathname, { start: range.start, end: range.end }, media.bucketName)
+            : null,
+          {
+            status: 206,
+            headers: {
+              "Accept-Ranges": "bytes",
+              "Cache-Control": cacheControl,
+              "Content-Length": String(chunkSize),
+              "Content-Range": `bytes ${range.start}-${range.end}/${media.size}`,
+              "Content-Type": media.contentType,
+            },
           },
-        },
-      );
+        );
+      }
+      // "ignore" falls through to the full 200 representation below.
     }
 
     return new NextResponse(includeBody ? createMediaReadStream(pathname, undefined, media.bucketName) : null, {
       headers: {
         "Accept-Ranges": media.contentType.startsWith("video/") ? "bytes" : "none",
-        "Cache-Control": media.cacheControl,
+        "Cache-Control": cacheControl,
         "Content-Length": String(media.size),
         "Content-Type": media.contentType,
       },

--- a/apps/timeline-gstudio001/app/api/timelines/timelines-authorization.test.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/timelines-authorization.test.ts
@@ -6,7 +6,7 @@ import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/
 // firebase-timeline-store enforcement — only the process boundaries are
 // faked: the Firestore SDK (in-memory), the session cookie (switchable
 // current user), and the Cloudinary listing (empty). Covers the review's
-// P0: list scoping, direct GET, PATCH, DELETE, legacy-document claiming,
+// P0: list scoping, direct GET, PATCH, DELETE, unowned-document refusal,
 // and user-scoped id (trash-<uid>) pre-checks.
 
 type Stored = Record<string, unknown>;
@@ -193,19 +193,19 @@ describe("timeline authorization", () => {
     expect(state.docs.get("project-a1")?.ownerUid).toBe("user-a");
   });
 
-  it("first authenticated GET claims a legacy unowned document; others are then denied", async () => {
+  // Both of these used to assert the opposite: a GET or a list CLAIMED an
+  // unowned record for whoever arrived first. The legacy records that justified
+  // that are migrated, so knowing an id is no longer a claim to it.
+  it("GET denies an unowned document and writes nothing", async () => {
     seedProject("project-legacy", undefined);
 
     const response = await getTimeline(new Request("http://test.local"), params("project-legacy"));
-    expect(response.status).toBe(200);
-    expect(state.docs.get("project-legacy")?.ownerUid).toBe("user-a");
 
-    asUser("user-b");
-    const denied = await getTimeline(new Request("http://test.local"), params("project-legacy"));
-    expect(denied.status).toBe(404);
+    expect(response.status).toBe(404);
+    expect(state.docs.get("project-legacy")?.ownerUid).toBeUndefined();
   });
 
-  it("list returns own and claims legacy projects, never another user's", async () => {
+  it("list returns only the requester's own projects and claims nothing", async () => {
     seedProject("project-a1", "user-a");
     seedProject("project-b1", "user-b");
     seedProject("project-legacy", undefined);
@@ -215,9 +215,24 @@ describe("timeline authorization", () => {
     const { projects } = (await response.json()) as { projects: { id: string }[] };
     const ids = projects.map((project) => project.id).sort();
 
-    expect(ids).toEqual(["project-a1", "project-legacy"]);
-    expect(state.docs.get("project-legacy")?.ownerUid).toBe("user-a");
+    expect(ids).toEqual(["project-a1"]);
+    // Listing is read-only now — no ownership was stamped on the way past.
+    expect(state.docs.get("project-legacy")?.ownerUid).toBeUndefined();
     expect(state.docs.get("project-b1")?.ownerUid).toBe("user-b");
+  });
+
+  it("refuses to overwrite or delete an unowned document", async () => {
+    seedProject("project-legacy", undefined);
+
+    const patch = await patchTimeline(
+      patchRequest({ id: "project-legacy", title: "Taken", clips: [clip("x")] }),
+      params("project-legacy"),
+    );
+    expect(patch.status).toBe(404);
+
+    const removed = await deleteTimeline(new Request("http://test.local"), params("project-legacy"));
+    expect(removed.status).toBe(404);
+    expect(state.docs.has("project-legacy")).toBe(true);
   });
 
   it("rejects another user's trash id before any storage access", async () => {

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -441,7 +441,12 @@ export const FilmstripResampleSettles: Story = {
     const kind = canvasElement.querySelector<HTMLElement>('[data-media-kind="video"]')!;
     const card = kind.parentElement?.parentElement;
     expect(card).not.toBeNull();
-    expect(getComputedStyle(kind).fontSize).toBe("9px");
+    // A FLOOR, not an exact size. The badge was raised 9px -> 11px when the
+    // type floor landed, and this assertion kept demanding 9px — it went
+    // unnoticed because the browser story project was not in CI. Asserting the
+    // minimum keeps the accessibility guarantee without breaking on the next
+    // deliberate type change.
+    expect(Number.parseFloat(getComputedStyle(kind).fontSize)).toBeGreaterThanOrEqual(11);
     const kindRect = kind.getBoundingClientRect();
     const cardRect = card!.getBoundingClientRect();
     expect(kindRect.left - cardRect.left).toBeGreaterThanOrEqual(7);

--- a/apps/timeline-gstudio001/lib/firebase-media-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-media-store.ts
@@ -93,8 +93,16 @@ export async function uploadMedia(
         resumable: false,
         metadata: {
           contentType: normalizedContentType,
+          // Thumbnails are content-addressed by a unique upload name, so the
+          // long immutable lifetime is right — but `private`, not `public`:
+          // these objects are only ever reachable through the authenticated
+          // /api/timeline-media route, and `public` would authorize a shared
+          // cache to serve one user's thumbnail to another on URL match alone.
+          // The route re-asserts this on every response (see
+          // `toPrivateCacheControl`) so objects predating this change are
+          // covered too.
           cacheControl: pathname.startsWith("timeline-thumbnails/")
-            ? "public, max-age=31536000, immutable"
+            ? "private, max-age=31536000, immutable"
             : "private, no-cache",
         },
       });

--- a/apps/timeline-gstudio001/lib/firebase-timeline-cascade-delete.test.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-cascade-delete.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
+
+// Cascade-deletion tests over the REAL store against an in-memory Firestore.
+// The subject is the TRAVERSAL: `childTimelineId` values come from stored
+// clips, nothing in the write path forbids a cycle or a shared child, and the
+// previous recursive walk had neither a visited set nor a bound.
+
+type Stored = Record<string, unknown>;
+
+const state = vi.hoisted(() => {
+  const docs = new Map<string, Stored>();
+  const reads: string[] = [];
+
+  const snapshot = (id: string) => {
+    const data = docs.get(id);
+    return {
+      id,
+      exists: data !== undefined,
+      data: () => (data ? { ...data } : undefined),
+    };
+  };
+  const db = {
+    collection: () => ({
+      doc: (id: string) => ({
+        id,
+        get: async () => {
+          reads.push(id);
+          return snapshot(id);
+        },
+        delete: async () => {
+          docs.delete(id);
+        },
+      }),
+    }),
+  };
+  return { docs, reads, db };
+});
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/firebase-admin", () => ({ getFirebaseDb: () => state.db }));
+vi.mock("./firebase-admin", () => ({ getFirebaseDb: () => state.db }));
+vi.mock("firebase-admin/firestore", () => {
+  class Timestamp {
+    toDate() {
+      return new Date(0);
+    }
+  }
+  return { Timestamp, FieldValue: { serverTimestamp: () => new Timestamp() } };
+});
+
+import {
+  deleteFirebaseTimelineDocument,
+  TimelineCascadeTooLargeError,
+} from "./firebase-timeline-store";
+import { TimelineAccessDeniedError } from "./timeline-ownership";
+
+function collectionClip(id: string, childTimelineId: string): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "collection",
+    childTimelineId,
+    title: childTimelineId,
+    alt: `${childTimelineId} collection`,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 4,
+    sourceDuration: 4,
+    trimIn: 0,
+    trimOut: 0,
+  } as TimelineClip;
+}
+
+/** Seed a document whose collection clips point at `childIds`. */
+function seed(id: string, ownerUid: string | undefined, childIds: string[] = []) {
+  const document: TimelineDocument = {
+    id,
+    title: `Doc ${id}`,
+    clips: childIds.map((childId, index) => ({
+      ...collectionClip(`${id}-c${index}`, childId),
+      index,
+    })),
+  };
+  state.docs.set(id, {
+    id,
+    title: document.title,
+    document,
+    clips: document.clips,
+    ...(ownerUid === undefined ? {} : { ownerUid }),
+  });
+}
+
+beforeEach(() => {
+  state.docs.clear();
+  state.reads.length = 0;
+});
+
+describe("cascade deletion", () => {
+  it("deletes a document and its nested collection children", async () => {
+    seed("root", "user-a", ["child-a", "child-b"]);
+    seed("child-a", "user-a", ["grandchild"]);
+    seed("child-b", "user-a");
+    seed("grandchild", "user-a");
+    seed("unrelated", "user-a");
+
+    await deleteFirebaseTimelineDocument("root", "user-a");
+
+    expect([...state.docs.keys()]).toEqual(["unrelated"]);
+  });
+
+  // The regression: this recursed A -> B -> A until the stack gave out, because
+  // the parent was deleted only AFTER recursing, so the cycle never broke.
+  it("terminates on a cycle instead of recursing forever", async () => {
+    seed("a", "user-a", ["b"]);
+    seed("b", "user-a", ["a"]);
+
+    await deleteFirebaseTimelineDocument("a", "user-a");
+
+    expect(state.docs.size).toBe(0);
+    // Each document is READ once, not once per inbound edge.
+    expect(state.reads).toEqual(["a", "b"]);
+  });
+
+  it("terminates on a self-referencing document", async () => {
+    seed("loop", "user-a", ["loop"]);
+
+    await deleteFirebaseTimelineDocument("loop", "user-a");
+
+    expect(state.docs.size).toBe(0);
+    expect(state.reads).toEqual(["loop"]);
+  });
+
+  it("visits a diamond-shared child once", async () => {
+    seed("root", "user-a", ["left", "right"]);
+    seed("left", "user-a", ["shared"]);
+    seed("right", "user-a", ["shared"]);
+    seed("shared", "user-a");
+
+    await deleteFirebaseTimelineDocument("root", "user-a");
+
+    expect(state.docs.size).toBe(0);
+    expect(state.reads.filter((id) => id === "shared")).toHaveLength(1);
+  });
+
+  it("refuses at the root when the document belongs to someone else", async () => {
+    seed("root", "user-b", ["child"]);
+    seed("child", "user-b");
+
+    await expect(deleteFirebaseTimelineDocument("root", "user-a")).rejects.toBeInstanceOf(
+      TimelineAccessDeniedError,
+    );
+    // Nothing removed — the refusal precedes every write.
+    expect(state.docs.size).toBe(2);
+  });
+
+  it("skips a child owned by someone else but still deletes the rest", async () => {
+    seed("root", "user-a", ["mine", "theirs"]);
+    seed("mine", "user-a");
+    seed("theirs", "user-b");
+
+    await deleteFirebaseTimelineDocument("root", "user-a");
+
+    expect([...state.docs.keys()]).toEqual(["theirs"]);
+  });
+
+  it("tolerates a dangling child reference", async () => {
+    seed("root", "user-a", ["missing"]);
+
+    await deleteFirebaseTimelineDocument("root", "user-a");
+
+    expect(state.docs.size).toBe(0);
+  });
+
+  it("deletes a root that no longer exists without error", async () => {
+    await expect(deleteFirebaseTimelineDocument("gone", "user-a")).resolves.toBeUndefined();
+  });
+
+  it("refuses an oversized tree before deleting anything", async () => {
+    // A chain longer than the cascade ceiling.
+    const length = 600;
+    for (let i = 0; i < length; i += 1) {
+      seed(`n${i}`, "user-a", i + 1 < length ? [`n${i + 1}`] : []);
+    }
+
+    await expect(deleteFirebaseTimelineDocument("n0", "user-a")).rejects.toBeInstanceOf(
+      TimelineCascadeTooLargeError,
+    );
+    expect(state.docs.size).toBe(length);
+  });
+
+  it("deletes the deepest documents before the root", async () => {
+    seed("root", "user-a", ["child"]);
+    seed("child", "user-a", ["grandchild"]);
+    seed("grandchild", "user-a");
+
+    const deleteOrder: string[] = [];
+    const original = state.db.collection;
+    state.db.collection = () => {
+      const inner = original();
+      return {
+        doc: (id: string) => {
+          const ref = inner.doc(id);
+          return {
+            ...ref,
+            delete: async () => {
+              deleteOrder.push(id);
+              await ref.delete();
+            },
+          };
+        },
+      };
+    };
+
+    try {
+      await deleteFirebaseTimelineDocument("root", "user-a");
+    } finally {
+      state.db.collection = original;
+    }
+
+    expect(deleteOrder).toEqual(["grandchild", "child", "root"]);
+  });
+});

--- a/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
@@ -15,8 +15,9 @@ type TimelineDocumentRecord = {
   lastNonEmptyDocument?: TimelineDocument;
   clips?: TimelineClip[];
   isProject?: boolean;
-  /** Authorization boundary: absent only on legacy records, which are
-   *  claimed by the first authenticated toucher (see lib/timeline-ownership). */
+  /** Authorization boundary. Optional only because Firestore documents are
+   *  untyped at rest — every live record carries one, and a record without an
+   *  owner is unreachable rather than up for grabs (see lib/timeline-ownership). */
   ownerUid?: string;
   /** Monotonic save counter, stamped on EVERY write (absent = 0, legacy).
    *  Clients that carry an expected revision into a batch write get
@@ -199,26 +200,22 @@ export async function listFirebaseTimelineProjects(requesterUid: string) {
     "Loading timeline projects",
   );
 
-  // The scan (not an ownerUid where-clause) is deliberate while legacy
-  // records exist: unowned projects must surface here so the first
-  // authenticated visit CLAIMS them — otherwise they'd silently vanish from
-  // the list until a manual migration ran. Other users' projects are
-  // filtered out; claims are stamped before returning.
+  // Listing is now READ ONLY. It used to stamp `ownerUid` onto every ownerless
+  // project in the result set — one batch write per list, granting ownership to
+  // whoever happened to look first. The legacy records that justified it have
+  // been migrated (see lib/timeline-ownership), so unowned projects are simply
+  // not visible to anyone.
+  //
+  // The `.limit(100)` still precedes the ownership filter, so this reads other
+  // users' rows and can miss a user's own projects once the collection exceeds
+  // 100 documents across all users. Fixing that needs a
+  // `.where("ownerUid", "==", requesterUid)` with a composite index deployed
+  // alongside it.
   const visible: { id: string; data: TimelineDocumentRecord }[] = [];
-  const toClaim: string[] = [];
   for (const doc of snapshot.docs) {
     const data = doc.data() as TimelineDocumentRecord;
-    const decision = resolveOwnership(data.ownerUid, requesterUid);
-    if (decision === "denied") continue;
-    if (decision === "claim") toClaim.push(doc.id);
+    if (resolveOwnership(data.ownerUid, requesterUid) !== "owned") continue;
     visible.push({ id: doc.id, data });
-  }
-  if (toClaim.length > 0) {
-    const batch = getFirebaseDb().batch();
-    for (const id of toClaim) {
-      batch.set(collection().doc(id), { ownerUid: requesterUid }, { merge: true });
-    }
-    await withFirebaseTimeout(batch.commit(), "Claiming legacy timeline projects");
   }
 
   return visible
@@ -241,13 +238,10 @@ export async function getFirebaseTimelineEntry(
 
   if (!snapshot.exists) return null;
   const data = snapshot.data() as TimelineDocumentRecord;
-  const decision = resolveOwnership(data.ownerUid, requesterUid);
-  if (decision === "denied") throw new TimelineAccessDeniedError(id);
-  if (decision === "claim") {
-    await withFirebaseTimeout(
-      collection().doc(id).set({ ownerUid: requesterUid }, { merge: true }),
-      "Claiming legacy timeline document",
-    );
+  // Reads no longer write. An ownerless record is denied like any other record
+  // the requester does not own — knowing its id is not a claim to it.
+  if (resolveOwnership(data.ownerUid, requesterUid) !== "owned") {
+    throw new TimelineAccessDeniedError(id);
   }
   return {
     document: toTimelineDocument(snapshot.id, data),
@@ -274,7 +268,7 @@ export type SaveOptions = Readonly<{
 }>;
 
 /** The one Firestore payload both write paths (single save, atomic batch)
- *  produce — shared so revision stamping and ownership claiming can't drift
+ *  produce — shared so revision and ownership stamping can't drift
  *  between them. */
 function buildSavePayload(
   normalizedDocument: TimelineDocument,
@@ -476,39 +470,93 @@ export async function createFirebaseTimelineProject(requesterUid: string, title?
   return document;
 }
 
+/**
+ * Ceiling on how many documents one cascade may touch. Real collection trees
+ * are a handful of documents a few levels deep, so hitting this means the
+ * structure is pathological — and a pathological tree must fail LOUDLY before
+ * anything is deleted rather than half-delete and leave unreachable orphans
+ * the user can no longer see or retry from.
+ */
+const MAX_CASCADE_DOCUMENTS = 500;
+
+export class TimelineCascadeTooLargeError extends Error {
+  constructor(id: string) {
+    super(
+      `Deleting timeline "${id}" would touch more than ${MAX_CASCADE_DOCUMENTS} documents.`,
+    );
+    this.name = "TimelineCascadeTooLargeError";
+  }
+}
+
+/**
+ * Delete a document and the collection sub-timelines beneath it.
+ *
+ * The traversal is breadth-first with a VISITED SET, which is what keeps a
+ * malformed graph from taking the process down: `childTimelineId` values live
+ * in stored clips and are attacker-suppliable, nothing in the write path
+ * forbids a cycle, and the previous recursive walk re-entered A → B → A until
+ * the stack gave out (it deleted the parent only AFTER recursing, so the cycle
+ * never broke itself). A diamond — two clips pointing at one child — likewise
+ * used to enqueue that child twice.
+ *
+ * Reads and writes are separated: the whole id set is collected first, so a
+ * refusal (foreign owner at the root, oversized tree) happens before any
+ * document is removed.
+ *
+ * NOT addressed here, deliberately: a child referenced by a DIFFERENT project
+ * is still deleted along with this one. Fixing that needs inbound-reference
+ * counting or explicit per-document parentage in the stored model, which is a
+ * schema decision rather than a traversal fix.
+ */
 export async function deleteFirebaseTimelineDocument(id: string, requesterUid: string) {
-  const ref = collection().doc(id);
-  const docSnap = await withFirebaseTimeout(ref.get(), "Loading timeline document for deletion");
+  const visited = new Set<string>([id]);
+  const queue: string[] = [id];
+  // Root-first, so reversing it deletes the deepest documents first and the
+  // root last — a failure part-way leaves a visibly broken parent the user can
+  // retry from, rather than invisible orphans under a vanished root.
+  const toDelete: string[] = [];
 
-  if (docSnap.exists) {
-    const data = docSnap.data() as TimelineDocumentRecord;
-    if (resolveOwnership(data.ownerUid, requesterUid) === "denied") {
-      throw new TimelineAccessDeniedError(id);
+  while (queue.length > 0) {
+    const currentId = queue.shift() as string;
+    const snapshot = await withFirebaseTimeout(
+      collection().doc(currentId).get(),
+      "Loading timeline document for deletion",
+    );
+
+    if (!snapshot.exists) {
+      // A dangling child reference is nothing to delete. The ROOT still gets a
+      // (no-op) delete so callers see the same success as before.
+      if (currentId === id) toDelete.push(currentId);
+      continue;
     }
-    const document = data.document;
-    if (document && document.clips) {
-      const deleteQueue: string[] = [];
-      const extractChildTimelineIds = (clips: TimelineClip[]) => {
-        for (const clip of clips) {
-          if (clip.kind === "collection" && clip.childTimelineId) {
-            deleteQueue.push(clip.childTimelineId);
-          }
-        }
-      };
-      extractChildTimelineIds(document.clips);
 
-      for (const childId of deleteQueue) {
-        try {
-          await deleteFirebaseTimelineDocument(childId, requesterUid);
-        } catch (error) {
-          // A child owned by someone else (shouldn't happen, but ids are
-          // attacker-suppliable in stored clips) is skipped, not fatal —
-          // the requester's own tree still deletes.
-          if (!(error instanceof TimelineAccessDeniedError)) throw error;
-        }
+    const data = snapshot.data() as TimelineDocumentRecord;
+    if (resolveOwnership(data.ownerUid, requesterUid) === "denied") {
+      // At the root this is the authorization answer. Deeper it means a stored
+      // clip pointed at someone else's document: skip it, and keep deleting
+      // the requester's own tree.
+      if (currentId === id) throw new TimelineAccessDeniedError(id);
+      continue;
+    }
+
+    toDelete.push(currentId);
+
+    for (const clip of data.document?.clips ?? []) {
+      if (clip.kind !== "collection" || !clip.childTimelineId) continue;
+      // Already queued or already deleted — a cycle or a diamond.
+      if (visited.has(clip.childTimelineId)) continue;
+      if (visited.size >= MAX_CASCADE_DOCUMENTS) {
+        throw new TimelineCascadeTooLargeError(id);
       }
+      visited.add(clip.childTimelineId);
+      queue.push(clip.childTimelineId);
     }
   }
 
-  await withFirebaseTimeout(ref.delete(), "Deleting timeline document");
+  for (const documentId of toDelete.reverse()) {
+    await withFirebaseTimeout(
+      collection().doc(documentId).delete(),
+      "Deleting timeline document",
+    );
+  }
 }

--- a/apps/timeline-gstudio001/lib/http-range.test.ts
+++ b/apps/timeline-gstudio001/lib/http-range.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import { parseRangeHeader } from "./http-range";
+
+const SIZE = 1000;
+
+describe("parseRangeHeader", () => {
+  it("reads an explicit first and last byte position, inclusive", () => {
+    expect(parseRangeHeader("bytes=10-20", SIZE)).toEqual({
+      type: "satisfiable",
+      start: 10,
+      end: 20,
+    });
+  });
+
+  it("runs an open-ended range to the final byte", () => {
+    expect(parseRangeHeader("bytes=0-", SIZE)).toEqual({
+      type: "satisfiable",
+      start: 0,
+      end: 999,
+    });
+  });
+
+  // The regression the old unanchored regex got backwards: it read the `500`
+  // as an END position and served the FIRST 501 bytes.
+  it("reads a suffix range as the LAST n bytes", () => {
+    expect(parseRangeHeader("bytes=-500", SIZE)).toEqual({
+      type: "satisfiable",
+      start: 500,
+      end: 999,
+    });
+  });
+
+  it("clamps a suffix longer than the resource to the whole resource", () => {
+    expect(parseRangeHeader("bytes=-5000", SIZE)).toEqual({
+      type: "satisfiable",
+      start: 0,
+      end: 999,
+    });
+  });
+
+  it("clamps a last position past the end to the final byte", () => {
+    expect(parseRangeHeader("bytes=900-99999", SIZE)).toEqual({
+      type: "satisfiable",
+      start: 900,
+      end: 999,
+    });
+  });
+
+  it("serves the single final byte", () => {
+    expect(parseRangeHeader("bytes=999-", SIZE)).toEqual({
+      type: "satisfiable",
+      start: 999,
+      end: 999,
+    });
+  });
+
+  it("tolerates whitespace and a capitalized unit", () => {
+    expect(parseRangeHeader("  Bytes = 10-20 ", SIZE)).toEqual({
+      type: "satisfiable",
+      start: 10,
+      end: 20,
+    });
+  });
+
+  describe("unsatisfiable", () => {
+    it("rejects a start at or past the end of the resource", () => {
+      expect(parseRangeHeader("bytes=1000-", SIZE)).toEqual({ type: "unsatisfiable" });
+      expect(parseRangeHeader("bytes=5000-6000", SIZE)).toEqual({ type: "unsatisfiable" });
+    });
+
+    it("rejects a last position before the first", () => {
+      expect(parseRangeHeader("bytes=20-10", SIZE)).toEqual({ type: "unsatisfiable" });
+    });
+
+    it("rejects a zero-length suffix", () => {
+      expect(parseRangeHeader("bytes=-0", SIZE)).toEqual({ type: "unsatisfiable" });
+    });
+
+    it("rejects any range against an empty resource", () => {
+      expect(parseRangeHeader("bytes=0-", 0)).toEqual({ type: "unsatisfiable" });
+      expect(parseRangeHeader("bytes=-500", 0)).toEqual({ type: "unsatisfiable" });
+    });
+  });
+
+  describe("ignored — the caller serves the full body as 200", () => {
+    it("ignores an absent header", () => {
+      expect(parseRangeHeader(null, SIZE)).toEqual({ type: "ignore" });
+    });
+
+    // Valid per spec, but unimplemented. Answering 416 would claim the request
+    // cannot be satisfied at all, which is false; ignoring it is allowed.
+    it("ignores a multi-range request instead of serving only its first part", () => {
+      expect(parseRangeHeader("bytes=0-1,5-6", SIZE)).toEqual({ type: "ignore" });
+    });
+
+    it("ignores a unit this server does not implement", () => {
+      expect(parseRangeHeader("items=0-10", SIZE)).toEqual({ type: "ignore" });
+    });
+
+    it("ignores malformed specs", () => {
+      expect(parseRangeHeader("bytes=abc", SIZE)).toEqual({ type: "ignore" });
+      expect(parseRangeHeader("bytes=", SIZE)).toEqual({ type: "ignore" });
+      expect(parseRangeHeader("bytes=-", SIZE)).toEqual({ type: "ignore" });
+      expect(parseRangeHeader("bytes=1.5-2", SIZE)).toEqual({ type: "ignore" });
+      expect(parseRangeHeader("bytes=-10-20", SIZE)).toEqual({ type: "ignore" });
+    });
+  });
+});

--- a/apps/timeline-gstudio001/lib/http-range.ts
+++ b/apps/timeline-gstudio001/lib/http-range.ts
@@ -1,0 +1,76 @@
+// Pure HTTP Range parsing (RFC 7233 §2.1/§3.1) — no Firebase, no request
+// object, so every branch is unit-testable in isolation. The media route is
+// the only caller.
+
+export type ParsedRange =
+  /** A byte range the caller should serve as 206. `end` is INCLUSIVE. */
+  | { readonly type: "satisfiable"; readonly start: number; readonly end: number }
+  /** Well-formed but outside the resource — the caller must answer 416. */
+  | { readonly type: "unsatisfiable" }
+  /**
+   * No range, malformed, or a form this server does not implement (multiple
+   * ranges). The caller serves the FULL representation as 200, which is always
+   * allowed: "A server MAY ignore the Range header field" (RFC 7233 §3.1).
+   * 416 would be wrong here — a multi-range request is perfectly satisfiable,
+   * just not by us, and 416 means "cannot be satisfied at all".
+   */
+  | { readonly type: "ignore" };
+
+const IGNORE: ParsedRange = { type: "ignore" };
+const UNSATISFIABLE: ParsedRange = { type: "unsatisfiable" };
+
+/**
+ * Parse a single `bytes=` range against a known resource size.
+ *
+ * The three forms, all of which were previously collapsed into one unanchored
+ * regex that read `bytes=-500` as "the first 501 bytes" instead of "the last
+ * 500":
+ *
+ * - `bytes=10-20` — explicit first and last byte position.
+ * - `bytes=10-`   — from 10 to the end of the resource.
+ * - `bytes=-500`  — SUFFIX: the final 500 bytes, not a start position.
+ */
+export function parseRangeHeader(header: string | null, size: number): ParsedRange {
+  if (!header) return IGNORE;
+
+  // The unit is case-insensitive; anything other than `bytes` must be ignored.
+  const match = /^\s*bytes\s*=\s*(.*)$/i.exec(header);
+  if (!match) return IGNORE;
+
+  const spec = match[1].trim();
+  // Multiple ranges (`bytes=0-1,5-6`) are valid but unimplemented — serve the
+  // whole body rather than pretending the first part was the whole request,
+  // which is what the old unanchored regex silently did.
+  if (spec.includes(",")) return IGNORE;
+
+  const parts = /^(\d*)-(\d*)$/.exec(spec);
+  if (!parts) return IGNORE;
+
+  const [, firstPos, lastPos] = parts;
+  // `bytes=-` carries no positions at all: malformed, not a suffix of length 0.
+  if (firstPos === "" && lastPos === "") return IGNORE;
+
+  // A zero-length resource cannot satisfy any byte range.
+  if (size <= 0) return UNSATISFIABLE;
+
+  if (firstPos === "") {
+    // Suffix form. `bytes=-0` asks for the last zero bytes — unsatisfiable.
+    const suffixLength = Number(lastPos);
+    if (suffixLength <= 0) return UNSATISFIABLE;
+    return {
+      type: "satisfiable",
+      start: Math.max(0, size - suffixLength),
+      end: size - 1,
+    };
+  }
+
+  const start = Number(firstPos);
+  if (start >= size) return UNSATISFIABLE;
+
+  // An absent or past-the-end last position is clamped to the final byte, so
+  // `bytes=0-` and an over-long `bytes=0-99999` both mean "to the end".
+  const end = lastPos === "" ? size - 1 : Math.min(Number(lastPos), size - 1);
+  if (end < start) return UNSATISFIABLE;
+
+  return { type: "satisfiable", start, end };
+}

--- a/apps/timeline-gstudio001/lib/timeline-ownership.test.ts
+++ b/apps/timeline-gstudio001/lib/timeline-ownership.test.ts
@@ -11,10 +11,13 @@ describe("resolveOwnership", () => {
     expect(resolveOwnership("user-b", "user-a")).toBe("denied");
   });
 
-  it("claims legacy records with no owner", () => {
-    expect(resolveOwnership(undefined, "user-a")).toBe("claim");
-    expect(resolveOwnership(null, "user-a")).toBe("claim");
-    expect(resolveOwnership("", "user-a")).toBe("claim");
+  // This used to answer "claim" — the first authenticated toucher became the
+  // owner. The legacy records that justified it are migrated, and an ownerless
+  // record is now simply unreachable.
+  it("denies records with no owner instead of granting them", () => {
+    expect(resolveOwnership(undefined, "user-a")).toBe("denied");
+    expect(resolveOwnership(null, "user-a")).toBe("denied");
+    expect(resolveOwnership("", "user-a")).toBe("denied");
   });
 });
 

--- a/apps/timeline-gstudio001/lib/timeline-ownership.ts
+++ b/apps/timeline-gstudio001/lib/timeline-ownership.ts
@@ -7,22 +7,32 @@
  * The one access rule:
  *
  * - `owned`  — the record belongs to the requester.
- * - `claim`  — the record predates ownership stamping (no ownerUid). It is
- *   CLAIMED by the first authenticated user who touches it — a self-executing
- *   migration for legacy documents, chosen deliberately over treating them as
- *   public or breaking the existing user's access until a manual script runs.
- *   The exposure window is deploy-until-the-owner's-next-visit; after that
- *   every document is stamped and strictly enforced.
- * - `denied` — the record belongs to someone else.
+ * - `denied` — anything else: another user's record, OR a record with no
+ *   owner at all.
+ *
+ * An UNOWNED record is denied, not granted. There used to be a third answer,
+ * `claim`, which handed an ownerless record to the first authenticated user
+ * who touched it — a self-executing migration for documents predating
+ * ownership stamping. It worked, but its exposure window only closed once no
+ * ownerless records remained, and nothing measured that: listing projects
+ * batch-stamped every ownerless project it saw, and knowing a bare id was
+ * enough to take or delete the document behind it.
+ *
+ * The migration is done — `npm run audit:ownership` reported 0 ownerless
+ * records across all 144 documents after
+ * `scripts/stamp-ownerless-timelines.mjs` ran — so the window is shut for
+ * good. Re-run that audit before assuming a new ownerless record cannot
+ * appear; the answer here is now deliberately unforgiving, and a record that
+ * somehow loses its owner becomes unreachable rather than up for grabs.
  */
-export type OwnershipDecision = "owned" | "claim" | "denied";
+export type OwnershipDecision = "owned" | "denied";
 
 export function resolveOwnership(
   recordOwnerUid: string | null | undefined,
   requesterUid: string,
 ): OwnershipDecision {
   if (recordOwnerUid === null || recordOwnerUid === undefined || recordOwnerUid === "") {
-    return "claim";
+    return "denied";
   }
   return recordOwnerUid === requesterUid ? "owned" : "denied";
 }

--- a/apps/timeline-gstudio001/package.json
+++ b/apps/timeline-gstudio001/package.json
@@ -13,7 +13,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui"
+    "test:e2e:ui": "playwright test --ui",
+    "audit:ownership": "node --env-file=.env scripts/audit-ownerless-timelines.mjs",
+    "stamp:ownership": "node --env-file=.env scripts/stamp-ownerless-timelines.mjs"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1094.0",

--- a/apps/timeline-gstudio001/scripts/audit-ownerless-timelines.mjs
+++ b/apps/timeline-gstudio001/scripts/audit-ownerless-timelines.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+// Ownership audit for the timelines collection.
+//
+// `lib/timeline-ownership.ts` classifies a record with no `ownerUid` as
+// "claim": the first authenticated user who lists projects or opens the id
+// becomes its owner. That was a deliberate self-executing migration for
+// records predating ownership stamping, with an exposure window of
+// "deploy until the real owner's next visit" — but the window only closes
+// once no ownerless records remain, and nothing measures that.
+//
+// This measures it. READ ONLY: it never writes, claims, or deletes.
+//
+// Lives in this workspace because firebase-admin is installed here, not at the
+// repo root — a root-level script cannot resolve it.
+//
+//   npm run audit:ownership --workspace=apps/timeline-gstudio001
+//   npm run audit:ownership --workspace=apps/timeline-gstudio001 -- --list
+//
+// Reads FIREBASE_PROJECT_ID / FIREBASE_CLIENT_EMAIL / FIREBASE_PRIVATE_KEY,
+// falling back to application-default credentials — the same inputs as
+// lib/firebase-admin.ts.
+//
+// What the result means:
+//
+//   0 ownerless    The migration is complete. The `claim` branch is now dead
+//                  code that can only ever misfire; delete it and deny
+//                  ownerless records outright.
+//   > 0 ownerless  Every one is claimable by whoever reaches it first. Assign
+//                  owners from evidence a script cannot infer (who created it,
+//                  who has been editing it) BEFORE removing the claim path,
+//                  or those documents become unreachable.
+
+import { cert, applicationDefault, initializeApp } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+
+// Must track TIMELINE_COLLECTION in lib/firebase-timeline-store.ts.
+const COLLECTION = "gstudioTimelineDocuments";
+const listAll = process.argv.includes("--list");
+
+function credential() {
+  const projectId = process.env.FIREBASE_PROJECT_ID;
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n");
+
+  if (clientEmail && privateKey) {
+    return { credential: cert({ projectId, clientEmail, privateKey }), projectId };
+  }
+  return { credential: applicationDefault(), projectId };
+}
+
+function isOwnerless(data) {
+  // Exactly `resolveOwnership`'s "claim" test — missing, null, or empty.
+  const ownerUid = data.ownerUid;
+  return ownerUid === undefined || ownerUid === null || ownerUid === "";
+}
+
+function toIso(value) {
+  if (!value) return "unknown";
+  if (typeof value.toDate === "function") return value.toDate().toISOString();
+  return String(value);
+}
+
+async function main() {
+  initializeApp(credential());
+  const db = getFirestore();
+
+  // The full collection, not the app's `.limit(100)` — the point is the total.
+  const snapshot = await db.collection(COLLECTION).get();
+
+  const ownerless = [];
+  const ownerCounts = new Map();
+
+  snapshot.forEach((doc) => {
+    const data = doc.data();
+    if (isOwnerless(data)) {
+      ownerless.push({
+        id: doc.id,
+        title: data.title ?? "(untitled)",
+        isProject: data.isProject === true,
+        clips: Array.isArray(data.clips) ? data.clips.length : 0,
+        updatedAt: toIso(data.updatedAt),
+      });
+      return;
+    }
+    ownerCounts.set(data.ownerUid, (ownerCounts.get(data.ownerUid) ?? 0) + 1);
+  });
+
+  const projects = ownerless.filter((entry) => entry.isProject);
+
+  console.log(`collection:        ${COLLECTION}`);
+  console.log(`documents:         ${snapshot.size}`);
+  console.log(`distinct owners:   ${ownerCounts.size}`);
+  console.log(`ownerless:         ${ownerless.length}`);
+  console.log(`  of which projects: ${projects.length}`);
+  console.log("");
+
+  if (ownerless.length === 0) {
+    console.log("No ownerless documents. The claim path in");
+    console.log("lib/timeline-ownership.ts can be removed and ownerless records");
+    console.log("denied in every runtime read, write, and delete.");
+    return;
+  }
+
+  console.log(`${ownerless.length} document(s) are claimable by the first`);
+  console.log("authenticated user who lists projects or opens the id.");
+  console.log("");
+  console.log("Projects are the urgent ones: listing alone stamps every");
+  console.log("ownerless project in the first 100 results at once.");
+  console.log("");
+
+  const shown = listAll ? ownerless : ownerless.slice(0, 20);
+  for (const entry of shown) {
+    const kind = entry.isProject ? "project" : "document";
+    console.log(
+      `  ${entry.id}  [${kind}, ${entry.clips} clips, updated ${entry.updatedAt}]  ${entry.title}`,
+    );
+  }
+  if (!listAll && ownerless.length > shown.length) {
+    console.log(`  ... and ${ownerless.length - shown.length} more (--list to see all)`);
+  }
+
+  // Non-zero exit so this can gate a release check.
+  process.exitCode = 1;
+}
+
+main().catch((error) => {
+  console.error("Audit failed:", error.message);
+  process.exitCode = 2;
+});

--- a/apps/timeline-gstudio001/scripts/stamp-ownerless-timelines.mjs
+++ b/apps/timeline-gstudio001/scripts/stamp-ownerless-timelines.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+// One-shot migration: stamp `ownerUid` onto records that predate ownership
+// stamping, so the runtime "claim" path can be deleted.
+//
+// Ordering matters. Removing the claim path FIRST would make every ownerless
+// record permanently unreachable — `resolveOwnership` would answer "denied"
+// for a document with no owner to compare against. Stamp, verify zero
+// remaining, then remove.
+//
+//   npm run stamp:ownership --workspace=apps/timeline-gstudio001            # dry run
+//   npm run stamp:ownership --workspace=apps/timeline-gstudio001 -- --apply # write
+//
+// SAFETY: refuses to write when the collection has more than one distinct
+// owner. With a single owner the assignment is unambiguous; with several,
+// "who owned this legacy record" needs human evidence this script cannot see,
+// and guessing would hand one user another's work.
+
+import { cert, applicationDefault, initializeApp } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+
+// Must track TIMELINE_COLLECTION in lib/firebase-timeline-store.ts.
+const COLLECTION = "gstudioTimelineDocuments";
+const BATCH_SIZE = 400; // Firestore caps a batch at 500 writes.
+
+const apply = process.argv.includes("--apply");
+
+function credential() {
+  const projectId = process.env.FIREBASE_PROJECT_ID;
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n");
+
+  if (clientEmail && privateKey) {
+    return { credential: cert({ projectId, clientEmail, privateKey }), projectId };
+  }
+  return { credential: applicationDefault(), projectId };
+}
+
+function isOwnerless(data) {
+  const ownerUid = data.ownerUid;
+  return ownerUid === undefined || ownerUid === null || ownerUid === "";
+}
+
+async function main() {
+  initializeApp(credential());
+  const db = getFirestore();
+  const snapshot = await db.collection(COLLECTION).get();
+
+  const ownerless = [];
+  const owners = new Map();
+
+  snapshot.forEach((doc) => {
+    const data = doc.data();
+    if (isOwnerless(data)) {
+      ownerless.push({ id: doc.id, title: data.title ?? "(untitled)" });
+      return;
+    }
+    owners.set(data.ownerUid, (owners.get(data.ownerUid) ?? 0) + 1);
+  });
+
+  console.log(`documents:   ${snapshot.size}`);
+  console.log(`ownerless:   ${ownerless.length}`);
+  console.log(`owners:      ${owners.size}`);
+  for (const [uid, count] of owners) console.log(`  ${uid}  (${count} docs)`);
+  console.log("");
+
+  if (ownerless.length === 0) {
+    console.log("Nothing to stamp.");
+    return;
+  }
+
+  if (owners.size !== 1) {
+    console.error(
+      `Refusing to stamp: ${owners.size} distinct owners. Assignment needs`,
+    );
+    console.error("evidence of who created each record, which this script cannot infer.");
+    process.exitCode = 2;
+    return;
+  }
+
+  const [ownerUid] = [...owners.keys()];
+  console.log(`${apply ? "Stamping" : "Would stamp"} ${ownerless.length} document(s) with ${ownerUid}:`);
+  for (const entry of ownerless) console.log(`  ${entry.id}  ${entry.title}`);
+  console.log("");
+
+  if (!apply) {
+    console.log("Dry run. Re-run with --apply to write.");
+    return;
+  }
+
+  let written = 0;
+  for (let index = 0; index < ownerless.length; index += BATCH_SIZE) {
+    const chunk = ownerless.slice(index, index + BATCH_SIZE);
+    const batch = db.batch();
+    for (const entry of chunk) {
+      // merge — stamp ownership without touching the document body.
+      batch.set(db.collection(COLLECTION).doc(entry.id), { ownerUid }, { merge: true });
+    }
+    await batch.commit();
+    written += chunk.length;
+    console.log(`  committed ${written}/${ownerless.length}`);
+  }
+
+  console.log("");
+  console.log(`Stamped ${written} document(s). Re-run the audit to confirm zero remain.`);
+}
+
+main().catch((error) => {
+  console.error("Stamping failed:", error.message);
+  process.exitCode = 2;
+});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "storybook": "npm run storybook --workspace=apps/storybook",
     "build-storybook": "npm run build-storybook --workspace=apps/storybook",
     "dev:frontend": "npm run dev --workspace=apps/timeline-gstudio001",
-    "audit:ui": "node scripts/find-unreachable-ui.mjs"
+    "audit:ui": "node scripts/find-unreachable-ui.mjs",
+    "audit:ownership": "npm run audit:ownership --workspace=apps/timeline-gstudio001"
   },
   "devDependencies": {
     "cross-env": "^10.1.0",

--- a/packages/ui/timeline/timeline-documents.ts
+++ b/packages/ui/timeline/timeline-documents.ts
@@ -430,19 +430,6 @@ export function getTimelinePathFromState(
   return path;
 }
 
-export function syncParentCollections(
-  collectionTimelineId: string,
-  childClips: any[],
-  newTimelineId?: string,
-) {
-  return syncParentCollectionsInState(
-    defaultTimelineDocumentsState,
-    collectionTimelineId,
-    childClips,
-    newTimelineId,
-  );
-}
-
 export function syncParentCollectionsInState(
   state: TimelineDocumentsState,
   collectionTimelineId: string,
@@ -494,14 +481,6 @@ export function syncParentCollectionsInState(
     ...state,
     documents: nextDocuments,
   };
-}
-
-export function addClipToCollection(collectionTimelineId: string, clip: any) {
-  const newClip = {
-    ...clip,
-    id: `${collectionTimelineId}-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
-  };
-  return newClip;
 }
 
 export function addClipToCollectionInState(
@@ -778,17 +757,20 @@ export function getCollectionFramePreviewFromState(
       };
     }
 
-    const sourceDuration = (c as any).sourceDuration || c.duration || 1;
+    // The collection branch above returns, so `c` is a MediaTimelineClip here
+    // and every field below is on the type — the casts these lines used to
+    // carry predated the discriminated union and were hiding that.
+    const sourceDuration = c.sourceDuration || c.duration || 1;
     const previewTime =
       c.kind === "video"
-        ? clamp((c as any).trimIn + relativeOffset, 0, Math.max(0, sourceDuration - 0.001))
+        ? clamp(c.trimIn + relativeOffset, 0, Math.max(0, sourceDuration - 0.001))
         : 0;
 
     return {
       id: c.id,
       kind: c.kind,
-      src: (c as any).src,
-      poster: (c as any).poster,
+      src: c.src,
+      poster: c.poster,
       alt: c.alt,
       previewTime,
       sourceDuration,


### PR DESCRIPTION
Acts on an external review of the app. Every specific claim was checked against the code before anything was changed — the facts held up (accurate line numbers throughout), the severity ranking did not. These are ordered by what the data showed rather than by the review's grades.

## Ownership — the claim path is gone

`resolveOwnership` had a third answer, `claim`: a record with no `ownerUid` went to the first authenticated user who touched it, and `listFirebaseTimelineProjects` batch-stamped every ownerless project in its result set. It was a deliberate self-executing migration, but its exposure window only closed once zero ownerless records remained, and nothing measured that.

Measured it:

```
before:  144 documents, 34 ownerless, 1 distinct owner, 0 ownerless *projects*
after:   144 documents,  0 ownerless
```

Zero ownerless projects means the mass-claim-on-list vector had touched nothing. Of the 34: 7 `asset-library-*` (already protected by `checkUserScopedId` regardless of owner), 23 `timeline-<ts>-<rand>` (unguessable), and 4 with short guessable ids — `archive`, `promo`, `root`, `storyboard`, holding 72/36/15/0 clips. That is the real exposure, and only to a *second* account; there is exactly one owner in the database.

All 34 are stamped and the claim path is deleted:

- `OwnershipDecision` is now `"owned" | "denied"` — ownerless is **denied**, not granted
- listing is read-only (the per-list ownership batch write is gone)
- `getFirebaseTimelineEntry` no longer writes on read
- the save/delete sites already tested `=== "denied"`, so they tightened automatically

Two scripts in `apps/timeline-gstudio001/scripts/` (they live in that workspace because firebase-admin is not hoisted to the root):

```bash
npm run audit:ownership --workspace=apps/timeline-gstudio001
```

`stamp:ownership` is dry-run by default and **refuses to write when the collection has more than one distinct owner** — assignment then needs evidence a script cannot infer, and guessing would hand one user another's work.

## HTTP suffix ranges returned the wrong bytes

`bytes=-500` returned the **first 501 bytes**. The unanchored regex read the suffix length as an end position. Parsing moved to `lib/http-range.ts` covering all three forms, with multi-range serving the full body as 200 rather than 416 — a range we do not *implement* is not a range that cannot be *satisfied*.

## Cascade deletion could not survive a cycle

`childTimelineId` values live in stored clips and nothing in the write path forbids a cycle. The recursive walk had no visited set and deleted the parent only *after* recursing, so `A -> B -> A` never broke itself. Against the old code the new cycle test **kills the vitest worker after 22s** — not a catchable assertion failure.

Now breadth-first with a visited set, a 500-document ceiling, and reads fully separated from writes so a refusal precedes any deletion. Deepest-first ordering preserved.

**Still open:** a child referenced by a *different* project is deleted along with this one. That needs inbound-reference counting or explicit parentage — a schema decision, not a traversal fix — so it is documented in the code rather than guessed at.

## Authenticated media was publicly cacheable

Thumbnails are written to storage with `public, max-age=31536000, immutable` and the route echoed it onto an authenticated response, which permits a shared cache to serve one user's media to the next on URL match alone. The route now strips `public` from every response, so objects predating this change are covered too — not just future uploads. Upload metadata fixed as well.

## CI never ran the interaction suite

CLAUDE.md says the story `play` functions **are** the interaction test suite, and CI ran only unit + app tests. Contracts drifted silently as a result: `FilmstripResampleSettles` asserted `9px` while the component declared `text-[11px]`.

Git history settled which side was wrong — commit `4adda9c` ("…**a type floor**…") deliberately raised it as an accessibility minimum. So the component was right and the assertion was stale. It now asserts the floor (`>= 11`) rather than a magic number, so it cannot drift the same way.

`--project=storybook` joins the gate. The job's `name:` is **deliberately unchanged** — it is the required-check context, and renaming it would block every PR.

## `any` removal

The two `any` wrappers in `timeline-documents.ts` were dead. They looked live to grep because the store defines its *own* same-named `syncParentCollections`/`addClipToCollection` callbacks and imports only the `*InState` variants. The remaining three casts were unnecessary once `c` narrows to `MediaTimelineClip`.

## Deliberately not in this PR

- **Trash mutations** are still read-modify-write over a last-write-wins save
- **Uploads** are still unbounded (no body/file/quota limit, MIME trusted)
- **`.limit(100)` still precedes the ownership filter** — the fix needs a composite index deployed, so it is not a code-only change; the constraint is now named in a comment
- **Storybook standalone typecheck** is still broken (three separate causes)

## Verification

| Suite | Result |
| --- | --- |
| App tests | **477** passed (was 442) |
| Unit | 408 passed |
| Stories (headless Chromium) | **165/165**, 3 consecutive clean runs |
| Typecheck (app + packages/ui) | clean |
| Lint | clean (4 pre-existing `<img>` warnings) |

Against the **real** database under the new stricter rule: `isProject` rows in the first 100 = 2, visible to the owner = 2, hidden = 0 — the tightened policy costs the existing user nothing.

No browser verification: the changed paths are server-side and behind authentication, so the in-app browser would only reach the login gate. The real-data query above exercises the new rule against actual data instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
