### PR TITLE
Review fixes: the project library was hiding people's own projects

### DIFF
--- a/apps/timeline-gstudio001/app/api/auth/login/complete/route.ts
+++ b/apps/timeline-gstudio001/app/api/auth/login/complete/route.ts
@@ -2,16 +2,14 @@ import { NextResponse } from "next/server";
 
 import { completeFirebaseEmailSignInLink } from "@/lib/firebase-auth-rest";
 import { createSessionCookie, setSessionCookie } from "@/lib/firebase-auth-session";
+import { readJsonObject } from "@/lib/read-json-body";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function POST(request: Request) {
   try {
-    const body = (await request.json().catch(() => ({}))) as {
-      email?: unknown;
-      oobCode?: unknown;
-    };
+    const body = await readJsonObject(request);
     const email = typeof body.email === "string" ? body.email.trim() : "";
     const oobCode = typeof body.oobCode === "string" ? body.oobCode : "";
 

--- a/apps/timeline-gstudio001/app/api/auth/login/route.ts
+++ b/apps/timeline-gstudio001/app/api/auth/login/route.ts
@@ -1,28 +1,89 @@
+import { createHash } from "node:crypto";
+
 import { NextResponse } from "next/server";
+import { z } from "zod";
 
 import { sendFirebaseEmailSignInLink } from "@/lib/firebase-auth-rest";
+import { clientAddress, createRateLimiter } from "@/lib/rate-limit";
+import { readJsonObject } from "@/lib/read-json-body";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+// Being unauthenticated is correct for a login endpoint. What was not: it
+// accepted unlimited requests, validated only "is a non-empty string", and
+// returned Firebase's (and its own configuration's) error text verbatim.
+//
+// So it could be driven to exhaust the project's email quota — locking out
+// every legitimate sign-in — or used to send repeated sign-in mail to arbitrary
+// addresses from this project's sender. And `getReadableAuthError` maps
+// `EMAIL_NOT_FOUND` to "No Firebase account exists for that email", which made
+// the response an account-enumeration oracle, while a misconfigured deployment
+// leaked "Add FIREBASE_WEB_API_KEY or NEXT_PUBLIC_FIREBASE_API_KEY" to anyone
+// who asked.
+//
+// Now: a shape-validated address, two rate-limit buckets, one generic answer
+// whatever happens, and the detail kept server-side in the log.
+
+const LoginBody = z.object({
+  // Not a full RFC 5322 parse — just enough that obvious garbage never costs a
+  // provider call. The length cap is the real bound.
+  email: z.string().trim().min(3).max(254).email(),
+});
+
+/** Per-ADDRESS: the anti-harassment bucket — how often one mailbox can be
+ *  mailed, regardless of who asks. */
+const perAddress = createRateLimiter({ limit: 3, windowMs: 15 * 60_000 });
+/** Per-CALLER: the anti-quota-exhaustion bucket — how many addresses one
+ *  source can enumerate. */
+const perSource = createRateLimiter({ limit: 10, windowMs: 15 * 60_000 });
+
+/** Addresses are personal data and these maps outlive the request; a bucket
+ *  only needs a stable key, not the value. */
+const bucketKey = (value: string) =>
+  createHash("sha256").update(value.toLowerCase()).digest("hex").slice(0, 32);
+
+/**
+ * ONE answer for every outcome — sent, address rate-limited, unknown account,
+ * provider hiccup. Anything that varies by whether the address exists is an
+ * enumeration oracle.
+ */
+function acceptedResponse() {
+  return NextResponse.json({
+    success: true,
+    message: "If that address has an account, a sign-in link is on its way.",
+  });
+}
+
 export async function POST(request: Request) {
+  const parsed = LoginBody.safeParse(await readJsonObject(request));
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Enter a valid email address." }, { status: 400 });
+  }
+  const email = parsed.data.email;
+
+  const source = perSource.check(bucketKey(clientAddress(request)));
+  if (!source.allowed) {
+    return NextResponse.json(
+      { error: "Too many sign-in requests. Try again shortly." },
+      { status: 429, headers: { "Retry-After": String(source.retryAfterSeconds) } },
+    );
+  }
+
+  // An address over its own limit gets the SAME success shape as a delivered
+  // link: answering "that one is rate-limited" would confirm the address is
+  // worth hammering.
+  if (!perAddress.check(bucketKey(email)).allowed) {
+    return acceptedResponse();
+  }
+
   try {
-    const body = (await request.json().catch(() => ({}))) as {
-      email?: unknown;
-    };
-    const email = typeof body.email === "string" ? body.email.trim() : "";
-
-    if (!email) {
-      return NextResponse.json({ error: "Email is required." }, { status: 400 });
-    }
-
     const { origin } = new URL(request.url);
     await sendFirebaseEmailSignInLink(email, origin);
-
-    return NextResponse.json({ success: true, email });
   } catch (error) {
+    // Detail stays here. The caller gets the same answer either way.
     console.error("[GSTUDIO_AUTH_LOGIN_ERROR]", error);
-    const message = error instanceof Error ? error.message : "Unable to send sign-in link.";
-    return NextResponse.json({ error: message }, { status: 401 });
   }
+
+  return acceptedResponse();
 }

--- a/apps/timeline-gstudio001/app/api/timeline-media/route.test.ts
+++ b/apps/timeline-gstudio001/app/api/timeline-media/route.test.ts
@@ -90,6 +90,31 @@ describe("project-scoped Firebase media reads", () => {
     expect(state.scopedProject).toBeNull();
     expect(state.metadataReads).toBe(0);
   });
+
+  // The regression: a path that does not carry `projects/<uid>/<projectId>/`
+  // used to skip BOTH checks — the uid comparison and the project-scope read
+  // were each guarded on the scope parsing successfully — so any signed-in
+  // caller could stream any legacy or manually-uploaded object under the two
+  // allowed prefixes. Only the name's entropy stood in the way, which is not
+  // an authorization decision.
+  it.each([
+    "timeline-thumbnails/legacy-thumb.jpg",
+    "timeline-videos/legacy.mp4",
+    "timeline-videos/projects/user-a/large.mp4", // scoped prefix, missing projectId
+    "timeline-thumbnails/projects/shot.jpg",
+  ])("denies the unscoped path %s before reading storage", async (pathname) => {
+    const response = await HEAD(request(pathname));
+
+    expect(response.status).toBe(404);
+    expect(state.scopedProject).toBeNull();
+    expect(state.metadataReads).toBe(0);
+  });
+
+  it("marks media responses nosniff", async () => {
+    const response = await HEAD(request(OWNED));
+
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+  });
 });
 
 describe("range responses", () => {

--- a/apps/timeline-gstudio001/app/api/timeline-media/route.ts
+++ b/apps/timeline-gstudio001/app/api/timeline-media/route.ts
@@ -40,6 +40,18 @@ function toPrivateCacheControl(stored: string | undefined) {
   return ["private", ...preserved].join(", ");
 }
 
+/**
+ * The owner and project a stored object belongs to, read out of its path.
+ *
+ * Every object this app writes is scoped (`scopeStoragePathname` in the upload
+ * route puts `projects/<uid>/<projectId>/` after the prefix), so a path that
+ * does NOT parse is one no upload path here produces — a legacy object, a
+ * manual upload, a migration. Those used to be served to any signed-in caller:
+ * both checks below were conditional on `scope`, so an unparseable path
+ * skipped authorization entirely and the only remaining gate was
+ * `isAllowedMediaPathname`, a prefix test. Guessing the name was the whole
+ * difficulty, which is obscurity, not authorization. Null now DENIES.
+ */
 function projectScopeFromMediaPathname(pathname: string) {
   const match =
     /^(?:timeline-videos|timeline-thumbnails)\/projects\/([^/]+)\/([^/]+)\//.exec(
@@ -60,11 +72,12 @@ async function handleMediaRequest(request: Request, includeBody: boolean) {
     if (response || !user) {
       return response || NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
+    // Deny by default: an unparseable path is not an authorized path.
     const scope = projectScopeFromMediaPathname(pathname);
-    if (scope && scope.uid !== user.uid) {
+    if (!scope || scope.uid !== user.uid) {
       return new NextResponse("Media not found.", { status: 404 });
     }
-    if (scope) await requireProjectAssetScope(scope.projectId, user.uid);
+    await requireProjectAssetScope(scope.projectId, user.uid);
 
     const media = await getMediaMetadata(pathname);
     if (!media) {
@@ -100,6 +113,10 @@ async function handleMediaRequest(request: Request, includeBody: boolean) {
               "Content-Length": String(chunkSize),
               "Content-Range": `bytes ${range.start}-${range.end}/${media.size}`,
               "Content-Type": media.contentType,
+              // The stored contentType came from the uploader. Even with the
+              // upload route's allowlist, this response must never be sniffed
+              // into something executable on our own origin.
+              "X-Content-Type-Options": "nosniff",
             },
           },
         );
@@ -113,6 +130,7 @@ async function handleMediaRequest(request: Request, includeBody: boolean) {
         "Cache-Control": cacheControl,
         "Content-Length": String(media.size),
         "Content-Type": media.contentType,
+        "X-Content-Type-Options": "nosniff",
       },
     });
   } catch (error) {

--- a/apps/timeline-gstudio001/app/api/timeline-media/upload/route.ts
+++ b/apps/timeline-gstudio001/app/api/timeline-media/upload/route.ts
@@ -24,6 +24,54 @@ import {
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+/**
+ * Hard ceiling on one uploaded part. The whole file is read into a Buffer, so
+ * without this a single request could size the function's memory. Platform
+ * body limits usually bite first; this makes the bound explicit and the
+ * failure a 413 the client can explain rather than an OOM.
+ */
+const MAX_UPLOAD_BYTES = 200 * 1024 * 1024;
+/** Thumbnails are generated client-side from a single frame. */
+const MAX_THUMBNAIL_BYTES = 8 * 1024 * 1024;
+
+/**
+ * The only content types this route will store, by EXTENSION.
+ *
+ * The stored object's `Content-Type` used to come from `file.type` — the
+ * client's declaration — which `/api/timeline-media` then replays on a
+ * same-origin response. With no `nosniff` that was a stored-XSS shape; with
+ * nosniff it is still a lie the app has no reason to repeat. The extension is
+ * what the storage path is built from and what the allowlist can be checked
+ * against, so it decides.
+ */
+const UPLOAD_CONTENT_TYPES: ReadonlyMap<string, string> = new Map([
+  ["jpg", "image/jpeg"],
+  ["jpeg", "image/jpeg"],
+  ["png", "image/png"],
+  ["webp", "image/webp"],
+  ["mp4", "video/mp4"],
+  ["webm", "video/webm"],
+  ["mov", "video/quicktime"],
+]);
+
+function allowedContentType(filename: string): string | null {
+  const extension = filename.split(".").pop()?.toLowerCase() ?? "";
+  return UPLOAD_CONTENT_TYPES.get(extension) ?? null;
+}
+
+/** `FormDataEntryValue` is `File | string`. Reading one as a Blob without
+ *  checking turned a client that sent a text field into a 500 from
+ *  `file.arrayBuffer()` rather than the 400 it is. */
+function readBlob(form: FormData, key: string): Blob | null {
+  const value = form.get(key);
+  return value instanceof Blob ? value : null;
+}
+
+function readText(form: FormData, key: string): string | null {
+  const value = form.get(key);
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
 function isImagePathname(pathname: string) {
   return /\.(jpe?g|png|webp)$/i.test(pathname);
 }
@@ -90,19 +138,36 @@ export async function POST(request: Request) {
     if (response || !user) return response || NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
     const formData = await request.formData();
-    const file = formData.get("file") as Blob | null;
-    const filename = formData.get("filename") as string | null;
-    const thumbnailFile = formData.get("thumbnail") as Blob | null;
-    const thumbnailFilename = formData.get("thumbnailFilename") as string | null;
+    const file = readBlob(formData, "file");
+    const filename = readText(formData, "filename");
+    const thumbnailFile = readBlob(formData, "thumbnail");
+    const thumbnailFilename = readText(formData, "thumbnailFilename");
     const projectId = await requireProjectAssetScope(formData.get("projectId"), user.uid);
 
     if (!file || !filename) {
       return NextResponse.json({ error: "Missing file or filename." }, { status: 400 });
     }
+    if (file.size > MAX_UPLOAD_BYTES) {
+      return NextResponse.json(
+        { error: `Files are limited to ${Math.floor(MAX_UPLOAD_BYTES / (1024 * 1024))} MB.` },
+        { status: 413 },
+      );
+    }
+    if (thumbnailFile && thumbnailFile.size > MAX_THUMBNAIL_BYTES) {
+      return NextResponse.json({ error: "Generated thumbnail is too large." }, { status: 413 });
+    }
 
-    const contentType = getMediaContentType(filename, file.type);
+    // Derived from the extension and checked against the allowlist, NOT taken
+    // from the client's `file.type`.
+    const contentType = allowedContentType(filename);
+    if (contentType === null) {
+      return NextResponse.json(
+        { error: `Unsupported file type: ${filename.split(".").pop() ?? filename}.` },
+        { status: 415 },
+      );
+    }
     const mediaBuffer = Buffer.from(await file.arrayBuffer());
-    const folderPath = formData.get("folderPath") as string | null;
+    const folderPath = readText(formData, "folderPath");
     if (hasCloudinaryConfig()) {
       const storedMedia = await uploadCloudinaryMedia(
         filename,
@@ -160,7 +225,10 @@ export async function POST(request: Request) {
       await uploadMedia(
         thumbnailPathname,
         Buffer.from(await thumbnailFile.arrayBuffer()),
-        thumbnailFile.type || "image/jpeg",
+        // Same rule as the media part: the extension decides, never the
+        // client's declaration. Thumbnails are always JPEG unless the
+        // filename says otherwise and the allowlist agrees.
+        (thumbnailFilename && allowedContentType(thumbnailFilename)) || "image/jpeg",
       );
       thumbnailUrl = toMediaUrl(thumbnailPathname);
     }

--- a/apps/timeline-gstudio001/app/api/timelines/[id]/preview-manifest/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/[id]/preview-manifest/route.ts
@@ -4,7 +4,10 @@ import { compilePlaybackManifest } from "@storyboard/timeline-domain";
 import { deriveClosureSummaries } from "@/lib/derive-collection-summaries";
 import { requireAuthUser } from "@/lib/firebase-auth-session";
 import { getFirebaseTimelineEntry } from "@/lib/firebase-timeline-store";
-import { loadTimelineClosure } from "@/lib/load-timeline-closure";
+import {
+  loadTimelineClosure,
+  TimelineClosureTooLargeError,
+} from "@/lib/load-timeline-closure";
 import { checkUserScopedId, TimelineAccessDeniedError } from "@/lib/timeline-ownership";
 
 export const runtime = "nodejs";
@@ -43,10 +46,12 @@ export async function GET(
       return NextResponse.json({ error: "Timeline was not found." }, { status: 404 });
     }
 
-    const { documents, missing, revisions } = await loadTimelineClosure(id, user.uid);
-    // The root just loaded through the entry read; serve that version.
-    documents[id] = entry.document;
-    revisions[id] = entry.revision;
+    // The root was just read above (that read IS this route's 404 check), so
+    // hand it straight to the walker rather than making it fetch the same
+    // document again and then overwriting the result.
+    const { documents, missing, revisions } = await loadTimelineClosure(id, user.uid, {
+      rootEntry: entry,
+    });
 
     // Stored collection summaries go stale by design: the graph view's
     // writes are patch-scoped, so editing a child never rewrites the
@@ -72,6 +77,11 @@ export async function GET(
       return NextResponse.json({ error: "Timeline was not found." }, { status: 404 });
     }
     if (error instanceof Error && error.message.startsWith("Collection cycle detected")) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
+    // Too many documents to compile. 409 like the cycle case: the request is
+    // fine, the stored structure is not, and retrying changes nothing.
+    if (error instanceof TimelineClosureTooLargeError) {
       return NextResponse.json({ error: error.message }, { status: 409 });
     }
 

--- a/apps/timeline-gstudio001/app/api/timelines/[id]/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/[id]/route.ts
@@ -6,6 +6,7 @@ import {
   deleteFirebaseTimelineDocument,
 } from "@/lib/firebase-timeline-store";
 import { requireAuthUser } from "@/lib/firebase-auth-session";
+import { readJsonObject } from "@/lib/read-json-body";
 import {
   isStoredTimelineDocument,
   isUnsavedProjectPlaceholder,
@@ -111,9 +112,7 @@ export async function PATCH(
     const mismatch = scopedIdMismatch(id, user.uid);
     if (mismatch) return mismatch;
 
-    const body = (await request.json().catch(() => ({}))) as {
-      document?: unknown;
-    };
+    const body = await readJsonObject(request);
 
     // Full runtime validation (every clip, discriminated by kind) — the
     // same guard the batch endpoint uses; a malformed payload must never

--- a/apps/timeline-gstudio001/app/api/timelines/batch/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/batch/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 
 import { isStoredTimelineDocument, isUnsavedProjectPlaceholder } from "@storyboard/timeline-model";
 import { requireAuthUser } from "@/lib/firebase-auth-session";
+import { readJsonObject } from "@/lib/read-json-body";
 import {
   saveFirebaseTimelineDocumentsAtomic,
   TimelineRevisionConflictError,
@@ -36,13 +37,12 @@ export async function POST(request: Request) {
     const { user, response } = await requireAuthUser();
     if (response || !user) return response || NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-    const body = (await request.json().catch(() => ({}))) as {
-      writes?: { document?: unknown; expectedRevision?: unknown }[];
-    };
-    if (!Array.isArray(body.writes) || body.writes.length === 0) {
+    const body = await readJsonObject(request);
+    const requested = body.writes;
+    if (!Array.isArray(requested) || requested.length === 0) {
       return NextResponse.json({ error: "A batch requires at least one write." }, { status: 400 });
     }
-    if (body.writes.length > MAX_BATCH_WRITES) {
+    if (requested.length > MAX_BATCH_WRITES) {
       return NextResponse.json(
         { error: `A batch is limited to ${MAX_BATCH_WRITES} writes.` },
         { status: 400 },
@@ -50,7 +50,13 @@ export async function POST(request: Request) {
     }
 
     const writes: TimelineBatchWrite[] = [];
-    for (const write of body.writes) {
+    for (const entry of requested) {
+      // Each element is untrusted too — an array of nulls used to throw on the
+      // first property read, the same 500-for-a-400 as the body itself.
+      const write = (typeof entry === "object" && entry !== null ? entry : {}) as {
+        document?: unknown;
+        expectedRevision?: unknown;
+      };
       // Full runtime validation (every clip, discriminated by kind): a
       // malformed client payload must never persist under a TimelineClip
       // assertion — it would break hydration and packing at read time.

--- a/apps/timeline-gstudio001/app/api/timelines/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+import { readJsonObject } from "@/lib/read-json-body";
+
 import {
   createFirebaseTimelineProject,
   listFirebaseTimelineProjects,
@@ -37,7 +39,7 @@ export async function POST(request: Request) {
     const { user, response } = await requireAuthUser();
     if (response || !user) return response || NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-    const body = (await request.json().catch(() => ({}))) as { title?: unknown };
+    const body = await readJsonObject(request);
     const title = typeof body.title === "string" ? body.title : undefined;
     const project = await createFirebaseTimelineProject(user.uid, title);
 

--- a/apps/timeline-gstudio001/app/api/timelines/timelines-authorization.test.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/timelines-authorization.test.ts
@@ -36,16 +36,28 @@ const state = vi.hoisted(() => {
       docs.delete(id);
     },
   });
+  // Query filters ACCUMULATE, and `limit` applies AFTER all of them — the
+  // real Firestore semantics, and the whole point of the regression below:
+  // a mock whose limit ran before the filters would pass either way.
+  type Filter = { field: string; value: unknown };
+  const query = (filters: readonly Filter[], cap: number | null) => {
+    const run = () =>
+      [...docs.keys()]
+        .filter((id) => filters.every((f) => docs.get(id)?.[f.field] === f.value))
+        .slice(0, cap ?? Infinity)
+        .map(snapshot);
+    return {
+      where: (field: string, _op: string, value: unknown) =>
+        query([...filters, { field, value }], cap),
+      limit: (next: number) => query(filters, next),
+      get: async () => ({ docs: run() }),
+    };
+  };
   const db = {
     collection: () => ({
       doc: docRef,
-      where: (field: string, _op: string, value: unknown) => ({
-        limit: () => ({
-          get: async () => ({
-            docs: [...docs.keys()].filter((id) => docs.get(id)?.[field] === value).map(snapshot),
-          }),
-        }),
-      }),
+      where: (field: string, _op: string, value: unknown) =>
+        query([{ field, value }], null),
     }),
     batch: () => {
       const ops: (() => void)[] = [];
@@ -219,6 +231,28 @@ describe("timeline authorization", () => {
     // Listing is read-only now — no ownership was stamped on the way past.
     expect(state.docs.get("project-legacy")?.ownerUid).toBeUndefined();
     expect(state.docs.get("project-b1")?.ownerUid).toBe("user-b");
+  });
+
+  it("finds the requester's project behind a page-full of other users' rows", async () => {
+    // The bug this pins: `.limit(...)` used to select from EVERY user's rows
+    // before ownership was considered, and with no orderBy Firestore returns
+    // them in `__name__` order — which, for `project-${Date.now()}-…` ids, is
+    // oldest first. So a user's newly created project fell outside the window
+    // the moment the collection held a page of older documents, and their
+    // library rendered empty while the project existed.
+    //
+    // Seeded FIRST so they occupy the whole window under the old query; the
+    // mock preserves insertion order, standing in for that id ordering.
+    for (let index = 0; index < 250; index += 1) {
+      seedProject(`project-old-${String(index).padStart(4, "0")}`, "user-b");
+    }
+    seedProject("project-newest", "user-a");
+
+    const response = await listProjects();
+    expect(response.status).toBe(200);
+    const { projects } = (await response.json()) as { projects: { id: string }[] };
+
+    expect(projects.map((project) => project.id)).toEqual(["project-newest"]);
   });
 
   it("refuses to overwrite or delete an unowned document", async () => {

--- a/apps/timeline-gstudio001/app/api/timelines/timelines-preview-manifest.test.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/timelines-preview-manifest.test.ts
@@ -13,6 +13,9 @@ type Stored = Record<string, unknown>;
 
 const state = vi.hoisted(() => {
   const docs = new Map<string, Stored>();
+  /** Per-id read counter — the closure walk must not fetch a document the
+   *  caller already handed it. */
+  const reads = new Map<string, number>();
   const current = { user: { uid: "user-a", email: null as string | null, name: null, picture: null } };
 
   const applySet = (id: string, data: Stored, opts?: { merge?: boolean }) => {
@@ -30,7 +33,10 @@ const state = vi.hoisted(() => {
   };
   const docRef = (id: string) => ({
     id,
-    get: async () => snapshot(id),
+    get: async () => {
+      reads.set(id, (reads.get(id) ?? 0) + 1);
+      return snapshot(id);
+    },
     set: async (data: Stored, opts?: { merge?: boolean }) => applySet(id, data, opts),
     delete: async () => {
       docs.delete(id);
@@ -59,7 +65,7 @@ const state = vi.hoisted(() => {
       };
     },
   };
-  return { docs, current, db };
+  return { docs, reads, current, db };
 });
 
 vi.mock("server-only", () => ({}));
@@ -134,6 +140,7 @@ function seed(id: string, ownerUid: string, clips: TimelineClip[], revision = 1)
 
 beforeEach(() => {
   state.docs.clear();
+  state.reads.clear();
   state.current.user = { uid: "user-a", email: null, name: null, picture: null };
 });
 
@@ -161,6 +168,34 @@ describe("preview manifest route", () => {
     expect(body.manifest.leaves.map((leaf) => leaf.id)).toEqual(["intro", "a", "b"]);
     expect(body.manifest.leaves[1].collectionPath).toEqual(["root-1", "scene"]);
     expect(body.manifest.leaves[1].timelineStart).toBeCloseTo(4.12, 6);
+  });
+
+  it("reads the root exactly once", async () => {
+    seed("scene", "user-a", [image("a", 0, 2)]);
+    seed("root-1", "user-a", [collectionClip("scene-ref", "scene", 0, 2)]);
+    state.reads.clear();
+
+    await getPreviewManifest(new Request("http://test.local"), params("root-1"));
+
+    // The route's own read IS the 404 check; the closure walker used to fetch
+    // the same document again and have its result overwritten.
+    expect(state.reads.get("root-1")).toBe(1);
+  });
+
+  it("refuses a closure larger than the document ceiling", async () => {
+    // A chain longer than MAX_CLOSURE_DOCUMENTS. Unbounded, this walked every
+    // link serially until the platform killed the function.
+    const length = 520;
+    for (let index = 0; index < length; index += 1) {
+      const next = index + 1 < length ? [collectionClip(`c${index}`, `t${index + 1}`, 0, 2)] : [];
+      seed(`t${index}`, "user-a", next);
+    }
+
+    const response = await getPreviewManifest(new Request("http://test.local"), params("t0"));
+
+    expect(response.status).toBe(409);
+    const { error } = (await response.json()) as { error: string };
+    expect(error).toMatch(/more than 500 documents/);
   });
 
   it("degrades unloadable branches to silence and reports them", async () => {

--- a/apps/timeline-gstudio001/app/api/trash/route.ts
+++ b/apps/timeline-gstudio001/app/api/trash/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from "next/server";
+
+import { readJsonObject } from "@/lib/read-json-body";
 import { requireAuthUser } from "@/lib/firebase-auth-session";
 import {
   getFirebaseTimelineDocument,
@@ -70,7 +72,7 @@ export async function POST(request: Request) {
     const { user, response } = await requireAuthUser();
     if (response || !user) return response || NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-    const body = (await request.json().catch(() => ({}))) as { clipIds?: unknown };
+    const body = await readJsonObject(request);
     const clipIds = Array.isArray(body.clipIds)
       ? body.clipIds.filter((id): id is string => typeof id === "string" && id.length > 0)
       : [];

--- a/apps/timeline-gstudio001/app/layout.tsx
+++ b/apps/timeline-gstudio001/app/layout.tsx
@@ -2,16 +2,22 @@ import type {Metadata} from 'next';
 import { Suspense } from 'react';
 import { AuthGate } from '@/components/auth/auth-gate';
 import { AuthProvider } from '@/components/auth/auth-provider';
+import { getAuthUser } from '@/lib/firebase-auth-session';
 import { TimelineSidebar } from '@/components/timeline/timeline-sidebar';
 import { Toaster } from '@/components/core/sonner';
 import './globals.css'; // Global styles
 
 export const metadata: Metadata = {
-  title: 'My Google AI Studio App',
-  description: 'My Google AI Studio App',
+  title: 'Storyboard Flow',
+  description: 'Build, nest, and preview storyboard timelines.',
 };
 
-export default function RootLayout({children}: {children: React.ReactNode}) {
+// Reading the session here makes this layout dynamic, which every route that
+// matters already was (the graph layout reads cookies to build its bootstrap
+// payloads). What it buys: AuthProvider starts with the answer instead of
+// blocking the whole tree on a client fetch for it — see `initialUser`.
+export default async function RootLayout({children}: {children: React.ReactNode}) {
+  const user = await getAuthUser();
   // `dark` is what switches on every `dark:` utility — the variant is rebound
   // to this class in globals.css, precisely so the app stops following the
   // reader's OS theme.
@@ -21,7 +27,7 @@ export default function RootLayout({children}: {children: React.ReactNode}) {
         {/* App-wide: the sidebar renders on every route, so anything it
             toasts needs a surface here rather than inside one view. */}
         <Toaster />
-        <AuthProvider>
+        <AuthProvider initialUser={user}>
           <AuthGate>
             <div className="relative flex min-h-screen overflow-x-clip bg-zinc-950 font-sans text-white">
               <Suspense fallback={null}>

--- a/apps/timeline-gstudio001/app/page.tsx
+++ b/apps/timeline-gstudio001/app/page.tsx
@@ -16,6 +16,7 @@ import {
 
 import { Button } from "@/components/core/button";
 import { Skeleton } from "@/components/core/skeleton";
+import { toast } from "@/components/core/sonner";
 import { cn } from "@/lib/utils";
 
 type TimelineProjectSummary = {
@@ -148,12 +149,20 @@ export default function Home() {
       });
 
       if (!response.ok) {
-        throw new Error(await response.text());
+        // The API answers JSON. Reading it as text put the raw envelope —
+        // `{"error":"…"}` — into the message the user was shown.
+        const result = (await response.json().catch(() => ({}))) as { error?: string };
+        throw new Error(result.error || "The server refused the delete.");
       }
 
       setProjects((prev) => prev.filter((p) => p.id !== id));
+      toast.success(`Deleted "${project.title}".`);
     } catch (error) {
-      alert("Failed to delete project: " + (error instanceof Error ? error.message : String(error)));
+      toast.error(
+        `Could not delete "${project.title}": ${
+          error instanceof Error ? error.message : "unknown error"
+        }`,
+      );
     }
   };
 
@@ -298,11 +307,18 @@ export default function Home() {
                 key={project.id}
                 className="relative group overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900/55 shadow-xl shadow-black/20 transition-all duration-200 hover:border-amber-400/55 hover:bg-zinc-900"
               >
-                {/* Link overlay covering the whole card area */}
+                {/* Link overlay covering the whole card area. It NEEDS a name:
+                    as a childless anchor its accessible name was empty, so a
+                    screen reader announced the card's only action as an
+                    unnamed "link" with no way to tell which project it opened
+                    (WCAG 2.4.4). The visible <h3> below is a heading, not this
+                    control's label. */}
                 <Link
                   href={`/timeline/${encodeURIComponent(project.id)}/graph`}
-                  className="absolute inset-0 z-10"
-                />
+                  className="absolute inset-0 z-10 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+                >
+                  <span className="sr-only">Open project {project.title}</span>
+                </Link>
 
                 <div className="relative aspect-video overflow-hidden border-b border-zinc-800 bg-zinc-950">
                   {project.thumbnailUrl ? (
@@ -318,12 +334,19 @@ export default function Home() {
                     </div>
                   )}
                   {/* Delete button positioned absolute top-right, z-20 so it sits on top of Link overlay */}
+                  {/* Hover-revealed, but it must also reveal on FOCUS: with
+                      only `group-hover:opacity-100` a keyboard user tabbed onto
+                      an invisible control with no focus indicator, one Enter
+                      away from a cascade delete (WCAG 2.4.7). `title` is not a
+                      reliable accessible name either, hence aria-label. */}
                   <button
+                    type="button"
                     onClick={(e) => handleDeleteProject(e, project.id)}
-                    className="absolute top-2.5 right-2.5 z-20 flex h-7 w-7 items-center justify-center rounded-md border border-zinc-800 bg-zinc-900/90 hover:bg-red-600/90 text-zinc-400 hover:text-white transition-all opacity-0 group-hover:opacity-100"
+                    aria-label={`Delete project ${project.title}`}
+                    className="absolute top-2.5 right-2.5 z-20 flex h-7 w-7 items-center justify-center rounded-md border border-zinc-800 bg-zinc-900/90 hover:bg-red-600/90 text-zinc-400 hover:text-white transition-all opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
                     title="Delete project"
                   >
-                    <Trash2 className="h-4 w-4" />
+                    <Trash2 aria-hidden="true" className="h-4 w-4" />
                   </button>
                 </div>
                 <div className="grid gap-3 p-4">

--- a/apps/timeline-gstudio001/components/auth/auth-provider.tsx
+++ b/apps/timeline-gstudio001/components/auth/auth-provider.tsx
@@ -38,10 +38,32 @@ async function readAuthResponse(response: Response) {
   return result.user ?? null;
 }
 
-export function AuthProvider({ children }: { children: React.ReactNode }) {
+export function AuthProvider({
+  initialUser,
+  children,
+}: {
+  /**
+   * The session the SERVER already resolved for this render (root layout).
+   *
+   * Without it this provider started at `isLoading: true` and AuthGate held
+   * the entire tree behind a spinner until `/api/auth/me` answered — one
+   * blocking round trip per page load, re-deriving an identity the RSC pass
+   * had in hand. It also negated the graph route's own work: the layout
+   * streams boot documents so the client boots with zero fetches, and none of
+   * it could render until that unrelated request landed.
+   *
+   * `null` means the server saw no session, which is a real answer, not an
+   * absent one — so nothing blocks in that case either. The mount effect below
+   * still revalidates.
+   */
+  initialUser: AuthUser | null;
+  children: React.ReactNode;
+}) {
   const router = useRouter();
-  const [user, setUser] = useState<AuthUser | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const [user, setUser] = useState<AuthUser | null>(initialUser);
+  // The server answered, so there is nothing to wait for. Revalidation runs in
+  // the background; only a session we have never resolved gates the UI.
+  const [isLoading, setIsLoading] = useState(false);
 
   // Pure request: resolves to the session user (or null) and never touches
   // state — so the mount effect can consume it through promise CALLBACKS
@@ -67,18 +89,21 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [requestUser]);
 
   useEffect(() => {
-    // Mount needs no sync loading reset — isLoading INITIALIZES true. The
-    // cancelled flag keeps a slow answer from writing into an unmounted tree.
+    // BACKGROUND revalidation, not a gate. The server already resolved the
+    // session for this render (see `initialUser`), so this only catches a
+    // cookie that expired between the RSC pass and hydration — it must never
+    // raise `isLoading`, or it would reintroduce the blocking spinner it
+    // replaced. The cancelled flag keeps a slow answer out of an unmounted
+    // tree.
     let cancelled = false;
     requestUser()
       .then((next) => {
         if (!cancelled) setUser(next);
       })
       .catch(() => {
-        if (!cancelled) setUser(null);
-      })
-      .finally(() => {
-        if (!cancelled) setIsLoading(false);
+        // A failed revalidation is not evidence of signing out — a network
+        // blip must not throw the user back to the sign-in form. Keep what the
+        // server told us; a genuinely dead session fails the next API call.
       });
     return () => {
       cancelled = true;

--- a/apps/timeline-gstudio001/components/graph-view/graph-asset-palette.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-asset-palette.tsx
@@ -33,6 +33,11 @@ const DEFAULT_VIDEO_SECONDS = 8;
  */
 const PALETTE_PAGE_SIZE = 12;
 
+/** How many browsed pages the drawer keeps. Enough that walking back up a
+ *  deep path is instant; small enough that a long session does not retain
+ *  every folder and search result it ever showed. */
+const PALETTE_PAGE_CACHE_LIMIT = 24;
+
 function createNodeFromAsset(asset: Asset): CollectionItemNode {
   clearPendingDetails();
   const id = parseNodeId(
@@ -267,7 +272,25 @@ export function AssetPaletteDrawer({
   // Visited folders answer instantly on the way back up; a provider fetch
   // per crumb-click would make the breadcrumb feel broken. Retry bypasses it
   // (the effect always network-fetches when loading), so a stale entry heals.
+  //
+  // BOUNDED: the drawer stays mounted for the whole session, so an unbounded
+  // map retained every folder, tag and search result the user ever visited —
+  // including every appended "load more" page merged into them. Oldest-first
+  // eviction matches how people browse: they come back UP a path, not back to
+  // a folder from an hour ago.
   const pageCacheRef = useRef(new Map<string, PalettePage>());
+  const cachePage = useCallback((key: string, page: PalettePage) => {
+    const cache = pageCacheRef.current;
+    // Re-inserting moves a key to the back, so a folder being paged through
+    // stays the most recent rather than aging out mid-scroll.
+    cache.delete(key);
+    cache.set(key, page);
+    while (cache.size > PALETTE_PAGE_CACHE_LIMIT) {
+      const oldest = cache.keys().next();
+      if (oldest.done) break;
+      cache.delete(oldest.value);
+    }
+  }, []);
   const panelRef = useRef<HTMLElement | null>(null);
   // Folders or tags — the SAME breadcrumb/tile machinery browses either;
   // only the wire params and the tile icon differ. The toggle renders only
@@ -408,7 +431,7 @@ export function AssetPaletteDrawer({
           ...(result.nextCursor === undefined ? {} : { nextCursor: result.nextCursor }),
         };
         // Cached under the key the request was ISSUED for, never the live one.
-        pageCacheRef.current.set(requestKey, merged);
+        cachePage(requestKey, merged);
         return { status: "ready", ...merged };
       });
     } catch {
@@ -418,7 +441,7 @@ export function AssetPaletteDrawer({
     } finally {
       setLoadingMore(false);
     }
-  }, [state, loadingMore, requestParams, pageKey]);
+  }, [state, loadingMore, requestParams, pageKey, cachePage]);
 
   const navigateTo = useCallback(
     (next: readonly string[], nextMode?: BrowseMode) => {
@@ -519,7 +542,7 @@ export function AssetPaletteDrawer({
           folders: result.folders ?? [],
           ...(result.nextCursor === undefined ? {} : { nextCursor: result.nextCursor }),
         };
-        pageCacheRef.current.set(cacheKey(providerId, mode, path, searchTerm), page);
+        cachePage(cacheKey(providerId, mode, path, searchTerm), page);
         setTagsAvailable(result.capabilities?.tags === true);
         setSearchAvailable(result.capabilities?.search === true);
         setState({ status: "ready", ...page });
@@ -535,7 +558,7 @@ export function AssetPaletteDrawer({
     return () => {
       cancelled = true;
     };
-  }, [open, state.status, path, mode, providerId, searchTerm, cacheKey, requestParams]);
+  }, [open, state.status, path, mode, providerId, searchTerm, cacheKey, requestParams, cachePage]);
 
   if (!open || typeof document === "undefined") return null;
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -302,13 +302,33 @@ function LiveDurationPill({ id, node }: { id: NodeId; node: MediaNode }) {
 }
 
 /**
- * Whether a COLLECTION above this card is disabled. Primitive return, per the
- * store's selector contract — the walk itself is
+ * Whether a COLLECTION above this card is disabled. The walk itself is
  * `isDisabledByAncestor` in graph-playhead-model, shared with the seek rail so
  * the card and the rail can never disagree about what is off.
+ *
+ * Memoized on the committed graph's IDENTITY, for the same reason as the two
+ * derivations above. As a bare `useCollectionsSelector` this ran the parent
+ * walk — allocating a `Set` each time — on EVERY store notification, and the
+ * store notifies for interaction updates too: drag begin/end, and each
+ * DISTINCT drop intent (`intentEqual` gates the raw pointer moves, so this was
+ * never per-tick, but it was still O(mounted cards × depth) per intent change
+ * on the drag hot path). Primitive equality stopped the re-RENDER; it never
+ * stopped the walk.
  */
 function useDisabledByAncestor(id: NodeId): boolean {
-  return useCollectionsSelector((snapshot) => isDisabledByAncestor(snapshot.graph, id as string));
+  const store = useCollectionsStore();
+  const [derive] = useState(() =>
+    createDerivedCache({
+      compute: (graph: CollectionsGraph, nodeId: NodeId) =>
+        isDisabledByAncestor(graph, nodeId as string),
+      contentKey: String,
+    }),
+  );
+  const getSnapshot = useCallback(
+    () => derive(store.getSnapshot().graph, id),
+    [store, derive, id],
+  );
+  return useSyncExternalStore(store.subscribe, getSnapshot, getSnapshot);
 }
 
 /**

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -18,6 +18,8 @@ import {
   type VideoMediaNode,
 } from "@storyboard/ui/dnd-collections";
 
+import { useDialogFocus } from "@/hooks/use-dialog-focus";
+import { useSeekedVideo } from "@/hooks/use-seeked-video";
 import { formatSeconds } from "@/lib/format-duration";
 import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
 import { CollectionDetailsBody } from "./graph-collection-details";
@@ -92,42 +94,6 @@ function previewTime(node: VideoMediaNode, trimIn: number, trimOut: number, side
     : Math.max(0, trimIn);
 }
 
-function useSeekedVideo(time: number) {
-  const videoRef = useRef<HTMLVideoElement | null>(null);
-  const targetRef = useRef(time);
-
-  useEffect(() => {
-    targetRef.current = time;
-  }, [time]);
-
-  const attachVideo = useCallback((video: HTMLVideoElement | null) => {
-    videoRef.current = video;
-  }, []);
-
-  useEffect(() => {
-    let raf = 0;
-    const tick = () => {
-      const video = videoRef.current;
-      if (
-        video &&
-        video.readyState >= 1 &&
-        !video.seeking &&
-        Math.abs(video.currentTime - targetRef.current) > 0.03
-      ) {
-        try {
-          video.currentTime = targetRef.current;
-        } catch {
-          // metadata raced away; next frame retries
-        }
-      }
-      raf = requestAnimationFrame(tick);
-    };
-    raf = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(raf);
-  }, []);
-
-  return attachVideo;
-}
 
 /**
  * Undo/redo SCOPED to this clip's trims (PL10-009).
@@ -326,13 +292,21 @@ function ModalBody({ node, onClose }: Readonly<{ node: MediaNode; onClose: () =>
   const fullDuration = video ? video.fullDurationSeconds : mediaDurationSeconds(node);
   const showing = Math.max(0, fullDuration - trimIn - trimOut);
   const rawTime = video ? previewTime(video, trimIn, trimOut, live?.side ?? null) : 0;
-  const videoRef = useSeekedVideo(Math.round(rawTime * 25) / 25);
+  // Gated on `video`: an image has no source window and no element to seek, so
+  // the settle loop had nothing to do but spin for as long as the modal stayed
+  // open.
+  const videoRef = useSeekedVideo(Math.round(rawTime * 25) / 25, video !== null);
 
   const [stripWidth, setStripWidth] = useState(0);
   const stripSlot = useCallback((element: HTMLElement | null) => {
     if (!element) return;
     setStripWidth(element.getBoundingClientRect().width);
   }, []);
+
+  // `aria-modal="true"` above is a promise about the rest of the page; this is
+  // what keeps it. Focus moves in, Tab cycles here, the board goes inert, and
+  // the card this was opened from gets focus back on close.
+  const { dialogProps } = useDialogFocus<HTMLDivElement>();
 
   // Escape closes and F2 renames. Both listen in CAPTURE, which is what makes
   // the editable guard load-bearing rather than defensive: a capture listener
@@ -372,7 +346,8 @@ function ModalBody({ node, onClose }: Readonly<{ node: MediaNode; onClose: () =>
       }}
     >
       <div
-        className="flex w-full max-w-3xl flex-col gap-3 rounded-lg border border-zinc-700 bg-zinc-950 p-4 shadow-2xl shadow-black/60"
+        {...dialogProps}
+        className="flex w-full max-w-3xl flex-col gap-3 rounded-lg border border-zinc-700 bg-zinc-950 p-4 shadow-2xl shadow-black/60 focus-visible:outline-none"
         onPointerDown={(event) => event.stopPropagation()}
       >
         <div className="flex items-center justify-between gap-3">

--- a/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
@@ -92,8 +92,17 @@ export function GraphViewNavProvider({
         // directly, rather than casting `parent` back to `string` at every
         // step of the walk.
         const projectNodeId = parseNodeId(projectId);
+        // The `seen` guard matches the other two parent walks in this app
+        // (`isDisabledByAncestor`, `useSelectionAggregate`). The graph's own
+        // invariants should make a parent cycle unreachable — `buildGraph`
+        // validates and the reducer refuses cycles — but this walk is the one
+        // where hitting one hangs the tab on an unbounded `chain`, and having
+        // two of the three guarded was the kind of split that turns into a bug
+        // the first time a new graph-construction path appears.
+        const seen = new Set<NodeId>();
         let parent = graph.parentById.get(parseNodeId(timelineId)) ?? null;
-        while (parent !== null && parent !== projectNodeId) {
+        while (parent !== null && parent !== projectNodeId && !seen.has(parent)) {
+          seen.add(parent);
           chain.unshift(parent);
           parent = graph.parentById.get(parent) ?? null;
         }

--- a/apps/timeline-gstudio001/components/graph-view/graph-save-status.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-save-status.tsx
@@ -51,29 +51,65 @@ export function GraphSaveStatus({ children }: Readonly<{ children?: ReactNode }>
 
   const justSaved = !busy && lastSavedAt !== null && now - lastSavedAt < SAVED_FLASH_MS;
 
+  // WHAT GETS ANNOUNCED, and what deliberately does not.
+  //
+  // All three states used to be plain text with a `title`, so a screen-reader
+  // user got no warning at all that edits were failing or conflicting — with
+  // undo history not surviving a reload, that is the one state with
+  // consequences. But wrapping the whole slot in a live region would announce
+  // "Saving… Saved… Saving… Saved…" on every debounce tick, which is worse
+  // than silence: it buries the failure it exists to surface.
+  //
+  // So: a persistent polite node carrying only SETTLED results (empty while
+  // busy, so the in-progress churn says nothing), and one assertive alert for
+  // failures. The visible chip is unchanged and stays aria-hidden — it is the
+  // same fact, and announcing it twice is its own noise.
+  const announcement = error !== null ? "" : justSaved ? "All changes saved." : "";
+
+  const liveRegion = (
+    <>
+      <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+        {announcement}
+      </span>
+      {error !== null ? (
+        <span className="sr-only" role="alert">
+          Your changes are not being saved. {error}
+        </span>
+      ) : null}
+    </>
+  );
+
   if (error !== null) {
     return (
-      <span
-        data-save-status="error"
-        title={error}
-        className="flex shrink-0 items-center gap-1.5 px-3 font-mono text-[11px] text-amber-300"
-      >
-        <CircleAlert aria-hidden="true" className="h-3.5 w-3.5" />
-        Not saved
-      </span>
+      <>
+        {liveRegion}
+        <span
+          aria-hidden="true"
+          data-save-status="error"
+          title={error}
+          className="flex shrink-0 items-center gap-1.5 px-3 font-mono text-[11px] text-amber-300"
+        >
+          <CircleAlert aria-hidden="true" className="h-3.5 w-3.5" />
+          Not saved
+        </span>
+      </>
     );
   }
 
   if (busy) {
     return (
-      <span
-        data-save-status="saving"
-        title="Writing your changes"
-        className="flex shrink-0 items-center gap-1.5 px-3 font-mono text-[11px] text-zinc-400"
-      >
-        <CloudUpload aria-hidden="true" className="h-3.5 w-3.5" />
-        Saving…
-      </span>
+      <>
+        {liveRegion}
+        <span
+          aria-hidden="true"
+          data-save-status="saving"
+          title="Writing your changes"
+          className="flex shrink-0 items-center gap-1.5 px-3 font-mono text-[11px] text-zinc-400"
+        >
+          <CloudUpload aria-hidden="true" className="h-3.5 w-3.5" />
+          Saving…
+        </span>
+      </>
     );
   }
 
@@ -81,16 +117,25 @@ export function GraphSaveStatus({ children }: Readonly<{ children?: ReactNode }>
   // A permanent "Saved" would be chrome that never says anything new.
   if (justSaved) {
     return (
-      <span
-        data-save-status="saved"
-        title="Every change is on the server"
-        className="flex shrink-0 items-center gap-1.5 px-3 font-mono text-[11px] text-zinc-300"
-      >
-        <Cloud aria-hidden="true" className="h-3.5 w-3.5" />
-        Saved
-      </span>
+      <>
+        {liveRegion}
+        <span
+          aria-hidden="true"
+          data-save-status="saved"
+          title="Every change is on the server"
+          className="flex shrink-0 items-center gap-1.5 px-3 font-mono text-[11px] text-zinc-300"
+        >
+          <Cloud aria-hidden="true" className="h-3.5 w-3.5" />
+          Saved
+        </span>
+      </>
     );
   }
 
-  return <>{children}</>;
+  return (
+    <>
+      {liveRegion}
+      {children}
+    </>
+  );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-save-status.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-save-status.tsx
@@ -60,23 +60,20 @@ export function GraphSaveStatus({ children }: Readonly<{ children?: ReactNode }>
   // "Saving… Saved… Saving… Saved…" on every debounce tick, which is worse
   // than silence: it buries the failure it exists to surface.
   //
-  // So: a persistent polite node carrying only SETTLED results (empty while
-  // busy, so the in-progress churn says nothing), and one assertive alert for
-  // failures. The visible chip is unchanged and stays aria-hidden — it is the
-  // same fact, and announcing it twice is its own noise.
-  const announcement = error !== null ? "" : justSaved ? "All changes saved." : "";
-
+  // So this announces exactly one thing: that a save SETTLED. Empty while busy,
+  // so the in-progress churn says nothing.
+  //
+  // FAILURES ARE NOT ANNOUNCED HERE. They already are, by the gateway's error
+  // banner in graph-timeline-view — which reads the SAME `errorBanner` string
+  // this chip does, is visible, and carries `role="alert"`. A second alert with
+  // the same text meant a screen-reader user heard the failure twice from two
+  // live regions, which is the noise problem this design exists to avoid. (The
+  // e2e caught it as a strict-mode violation: two elements matching one
+  // message.) The chip stays as the visual half of that one fact.
   const liveRegion = (
-    <>
-      <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
-        {announcement}
-      </span>
-      {error !== null ? (
-        <span className="sr-only" role="alert">
-          Your changes are not being saved. {error}
-        </span>
-      ) : null}
-    </>
+    <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+      {error === null && justSaved ? "All changes saved." : ""}
+    </span>
   );
 
   if (error !== null) {

--- a/apps/timeline-gstudio001/components/graph-view/graph-shortcuts.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-shortcuts.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
+
+import { useDialogFocus } from "@/hooks/use-dialog-focus";
 import { X } from "lucide-react";
 
 import { isEditableKeyboardTarget } from "@storyboard/ui/dnd-collections";
@@ -82,33 +84,11 @@ const SECTIONS: readonly Section[] = [
   },
 ];
 
-export function GraphShortcuts() {
-  const [open, setOpen] = useState(false);
-
-  useEffect(() => {
-    const onRequest = () => setOpen(true);
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.defaultPrevented) return;
-      if (event.key === "Escape" && open) {
-        setOpen(false);
-        return;
-      }
-      // "?" is Shift+/ on most layouts, so match the CHARACTER rather than the
-      // physical key — and never while typing.
-      if (event.key !== "?" || event.ctrlKey || event.metaKey || event.altKey) return;
-      if (isEditableKeyboardTarget(event.target)) return;
-      event.preventDefault();
-      setOpen((previous) => !previous);
-    };
-    window.addEventListener(GRAPH_SHORTCUTS_EVENT, onRequest);
-    window.addEventListener("keydown", onKeyDown);
-    return () => {
-      window.removeEventListener(GRAPH_SHORTCUTS_EVENT, onRequest);
-      window.removeEventListener("keydown", onKeyDown);
-    };
-  }, [open]);
-
-  if (!open) return null;
+/** Split out so the focus hook mounts and unmounts WITH the dialog — a hook
+ *  inside `GraphShortcuts` would run while it is closed and there is nothing
+ *  to trap. */
+function ShortcutsSheet({ onClose }: Readonly<{ onClose: () => void }>) {
+  const { dialogProps } = useDialogFocus<HTMLDivElement>();
 
   return createPortal(
     <div
@@ -117,16 +97,19 @@ export function GraphShortcuts() {
       aria-modal="true"
       aria-label="Keyboard shortcuts"
       onPointerDown={(event) => {
-        if (event.target === event.currentTarget) setOpen(false);
+        if (event.target === event.currentTarget) onClose();
       }}
       className="fixed inset-0 z-[90] flex items-center justify-center bg-black/80 p-6 backdrop-blur-sm"
     >
-      <div className="max-h-[80vh] w-full max-w-2xl overflow-y-auto rounded-lg border border-zinc-700 bg-zinc-950 p-5 shadow-2xl shadow-black/60">
+      <div
+        {...dialogProps}
+        className="max-h-[80vh] w-full max-w-2xl overflow-y-auto rounded-lg border border-zinc-700 bg-zinc-950 p-5 shadow-2xl shadow-black/60 focus-visible:outline-none"
+      >
         <div className="mb-4 flex items-center justify-between">
           <h2 className="text-sm font-semibold text-zinc-100">Keyboard shortcuts</h2>
           <button
             type="button"
-            onClick={() => setOpen(false)}
+            onClick={onClose}
             aria-label="Close the shortcuts sheet"
             className="rounded p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
           >
@@ -158,4 +141,35 @@ export function GraphShortcuts() {
     </div>,
     document.body,
   );
+}
+
+export function GraphShortcuts() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const onRequest = () => setOpen(true);
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      if (event.key === "Escape" && open) {
+        setOpen(false);
+        return;
+      }
+      // "?" is Shift+/ on most layouts, so match the CHARACTER rather than the
+      // physical key — and never while typing.
+      if (event.key !== "?" || event.ctrlKey || event.metaKey || event.altKey) return;
+      if (isEditableKeyboardTarget(event.target)) return;
+      event.preventDefault();
+      setOpen((previous) => !previous);
+    };
+    window.addEventListener(GRAPH_SHORTCUTS_EVENT, onRequest);
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener(GRAPH_SHORTCUTS_EVENT, onRequest);
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return <ShortcutsSheet onClose={() => setOpen(false)} />;
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -552,8 +552,15 @@ export function GraphTimelineView({
 
   return (
     <div className="flex flex-col gap-4">
+      {/* `role="alert"` because this banner only ever appears for a document
+          that failed to load or save — a state the user has to know about
+          before they close the tab, and one they were previously only told
+          about visually. */}
       {gatewayError !== null && (
-        <p className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+        <p
+          role="alert"
+          className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-200"
+        >
           {gatewayError}
         </p>
       )}

--- a/apps/timeline-gstudio001/components/graph-view/graph-trim-panel.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-trim-panel.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
+import { useSeekedVideo } from "@/hooks/use-seeked-video";
 import { formatSeconds } from "@/lib/format-duration";
 
 import {
@@ -44,53 +45,6 @@ function edgeSourceTime(node: MediaNode, live: LiveTrim): number {
     : Math.max(0, live.trimInSeconds);
 }
 
-/**
- * Keeps the preview element seeked to `time`, one in-flight seek at a time: a
- * per-frame settle loop issues a seek only while none is in flight and the
- * element isn't already on target, so a fast drag lands on the newest frame
- * without queueing dozens of decodes. A rAF loop rather than `seeked`
- * bookkeeping on purpose — it is self-healing (a missed event or a seek the
- * browser coalesced can't strand a stale frame; the next frame catches up),
- * and it only runs while the preview is mounted, i.e. during the gesture.
- * (`currentTime` reads back as the seek TARGET mid-seek, so the on-target
- * check doesn't re-issue while decoding either.)
- */
-function useSeekedVideo(time: number) {
-  const videoRef = useRef<HTMLVideoElement | null>(null);
-  const targetRef = useRef(time);
-
-  useEffect(() => {
-    targetRef.current = time;
-  }, [time]);
-
-  const attachVideo = useCallback((video: HTMLVideoElement | null) => {
-    videoRef.current = video;
-  }, []);
-
-  useEffect(() => {
-    let raf = 0;
-    const tick = () => {
-      const video = videoRef.current;
-      if (
-        video &&
-        video.readyState >= 1 &&
-        !video.seeking &&
-        Math.abs(video.currentTime - targetRef.current) > 0.03
-      ) {
-        try {
-          video.currentTime = targetRef.current;
-        } catch {
-          // metadata raced away; next frame retries
-        }
-      }
-      raf = requestAnimationFrame(tick);
-    };
-    raf = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(raf);
-  }, []);
-
-  return attachVideo;
-}
 
 /**
  * The live frame, during a trim drag. Sized to the board header's band and

--- a/apps/timeline-gstudio001/firestore.indexes.json
+++ b/apps/timeline-gstudio001/firestore.indexes.json
@@ -1,0 +1,44 @@
+{
+  "//": [
+    "Composite indexes for gstudioTimelineDocuments.",
+    "",
+    "Deploy with:  npx firebase deploy --only firestore:indexes --project <id>",
+    "(firebase-tools is already a devDependency of this workspace.)",
+    "",
+    "listFirebaseTimelineProjects filters on ownerUid AND isProject. Two",
+    "equality filters alone are merge-joined from the automatic single-field",
+    "indexes, so that query works WITHOUT this file — it is declared here",
+    "because the store's fallback path exists for deployments where the",
+    "planner does demand one, and because adding an orderBy/cursor to that",
+    "query (the natural next step past PROJECT_LIST_LIMIT) requires it.",
+    "",
+    "The updatedAt ordering matches the JS sort listFirebaseTimelineProjects",
+    "already applies, so switching to a server-side sort is a one-line change",
+    "once this is deployed."
+  ],
+  "indexes": [
+    {
+      "collectionGroup": "gstudioTimelineDocuments",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "ownerUid", "order": "ASCENDING" },
+        { "fieldPath": "isProject", "order": "ASCENDING" },
+        { "fieldPath": "updatedAt", "order": "DESCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": [
+    {
+      "collectionGroup": "mcpOAuthCodes",
+      "fieldPath": "expiresAt",
+      "ttl": true,
+      "indexes": []
+    },
+    {
+      "collectionGroup": "mcpOAuthRefreshTokens",
+      "fieldPath": "expiresAt",
+      "ttl": true,
+      "indexes": []
+    }
+  ]
+}

--- a/apps/timeline-gstudio001/hooks/use-dialog-focus.ts
+++ b/apps/timeline-gstudio001/hooks/use-dialog-focus.ts
@@ -1,0 +1,116 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * Makes `aria-modal="true"` true.
+ *
+ * The graph view's two portalled dialogs — the item details modal and the
+ * shortcuts sheet — declared `role="dialog" aria-modal="true"` and did none of
+ * what that attribute promises: focus stayed on whatever was behind the scrim,
+ * Tab walked straight out into the board, and closing left focus wherever the
+ * dialog had abandoned it. `aria-modal` tells assistive technology that
+ * everything outside is unavailable, so a screen-reader user tabbing out
+ * landed in content their reader had been told was hidden, with no way back.
+ *
+ * Three behaviours, which is what the attribute is short for:
+ *
+ *   1. Focus moves IN on open — the first focusable descendant, or the panel
+ *      itself (it takes `tabIndex={-1}` from `dialogProps`) when there is none.
+ *   2. Tab CYCLES inside. Computed per keypress rather than cached: these
+ *      dialogs mount controls conditionally (the rename editor swaps in for a
+ *      label, undo/redo enable and disable), so a list captured at open goes
+ *      stale while the dialog is still on screen.
+ *   3. Focus is RESTORED on close, to whatever held it before — the card the
+ *      modal was opened from, so the board's roving focus is not reset.
+ *
+ * Everything outside the dialog is also made `inert`, which is the DOM's own
+ * version of the same claim: it removes the background from the tab order and
+ * the accessibility tree together, so the two cannot disagree.
+ */
+
+/** Focusable candidates, in DOM order. `:not([inert] *)` keeps the background
+ *  out once it has been marked, and negative tabindex is excluded because it
+ *  is reachable by script but not by Tab. */
+const FOCUSABLE = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+function focusableWithin(root: HTMLElement): HTMLElement[] {
+  return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(
+    (element) =>
+      !element.hasAttribute("inert") &&
+      element.getAttribute("aria-hidden") !== "true" &&
+      // offsetParent is null for display:none; a fixed-position element has
+      // none either, hence the rect fallback.
+      (element.offsetParent !== null || element.getBoundingClientRect().height > 0),
+  );
+}
+
+export function useDialogFocus<T extends HTMLElement>() {
+  const panelRef = useRef<T | null>(null);
+
+  useEffect(() => {
+    const panel = panelRef.current;
+    if (!panel) return;
+
+    const restoreTo = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+    // Everything that is not this dialog's own portal root. `inert` covers the
+    // tab order AND the accessibility tree, so it is the one attribute that
+    // makes aria-modal's claim actually hold.
+    const backdrop = Array.from(document.body.children).filter(
+      (element): element is HTMLElement =>
+        element instanceof HTMLElement && !element.contains(panel),
+    );
+    const previouslyInert = backdrop.map((element) => element.hasAttribute("inert"));
+    for (const element of backdrop) element.setAttribute("inert", "");
+
+    const first = focusableWithin(panel)[0];
+    (first ?? panel).focus();
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Tab") return;
+      const focusable = focusableWithin(panel);
+      if (focusable.length === 0) {
+        // Nothing to move between — keep focus on the panel rather than
+        // letting Tab escape into the inert background.
+        event.preventDefault();
+        panel.focus();
+        return;
+      }
+      const edge = event.shiftKey ? focusable[0] : focusable[focusable.length - 1];
+      const wrapTo = event.shiftKey ? focusable[focusable.length - 1] : focusable[0];
+      const active = document.activeElement;
+      if (active === edge || !panel.contains(active)) {
+        event.preventDefault();
+        wrapTo.focus();
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown, true);
+      backdrop.forEach((element, index) => {
+        if (!previouslyInert[index]) element.removeAttribute("inert");
+      });
+      // The element may itself have been removed (the card was deleted while
+      // the modal was open) — focusing a detached node is a silent no-op, so
+      // check rather than trust.
+      if (restoreTo?.isConnected) restoreTo.focus();
+    };
+  }, []);
+
+  /** Spread onto the dialog's own element. `tabIndex={-1}` is what lets the
+   *  panel hold focus when it contains no focusable control. */
+  const dialogProps = { ref: panelRef, tabIndex: -1 } as const;
+
+  const focusPanel = useCallback(() => panelRef.current?.focus(), []);
+
+  return { panelRef, dialogProps, focusPanel };
+}

--- a/apps/timeline-gstudio001/hooks/use-seeked-video.ts
+++ b/apps/timeline-gstudio001/hooks/use-seeked-video.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * Keeps a preview `<video>` seeked to `time`, one in-flight seek at a time.
+ *
+ * A per-frame settle loop issues a seek only while none is in flight and the
+ * element isn't already on target, so a fast drag lands on the newest frame
+ * without queueing dozens of decodes. A rAF loop rather than `seeked`
+ * bookkeeping on purpose — it is self-healing: a missed event, or a seek the
+ * browser coalesced, cannot strand a stale frame because the next frame
+ * catches up. (`currentTime` reads back as the seek TARGET mid-seek, so the
+ * on-target check doesn't re-issue while decoding either.)
+ *
+ * `enabled` is what stops the loop from running when there is nothing to seek.
+ * This hook was duplicated verbatim in the trim panel and the item details
+ * modal; the trim panel's copy was correctly scoped (its component only mounts
+ * during a trim gesture), but the modal called it unconditionally — including
+ * for IMAGE nodes, where the target is a constant 0 and there is no video
+ * element at all — so opening the details view spun a 60fps loop checking a
+ * null ref for as long as it stayed open.
+ */
+export function useSeekedVideo(time: number, enabled = true) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const targetRef = useRef(time);
+
+  useEffect(() => {
+    targetRef.current = time;
+  }, [time]);
+
+  const attachVideo = useCallback((video: HTMLVideoElement | null) => {
+    videoRef.current = video;
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let raf = 0;
+    const tick = () => {
+      const video = videoRef.current;
+      if (
+        video &&
+        video.readyState >= 1 &&
+        !video.seeking &&
+        Math.abs(video.currentTime - targetRef.current) > 0.03
+      ) {
+        try {
+          video.currentTime = targetRef.current;
+        } catch {
+          // metadata raced away; next frame retries
+        }
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [enabled]);
+
+  return attachVideo;
+}

--- a/apps/timeline-gstudio001/lib/firebase-timeline-cascade-delete.test.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-cascade-delete.test.ts
@@ -21,6 +21,14 @@ const state = vi.hoisted(() => {
       data: () => (data ? { ...data } : undefined),
     };
   };
+  /** Ids in commit order, per batch — the deletion ORDER assertions read this,
+   *  and its shape proves the cascade travels as batches rather than as N
+   *  independent writes. */
+  const commits: string[][] = [];
+  /** Set to make the next commit reject, standing in for a transient failure
+   *  part-way through a large deletion. */
+  const failNextCommit = { value: false };
+
   const db = {
     collection: () => ({
       doc: (id: string) => ({
@@ -29,13 +37,27 @@ const state = vi.hoisted(() => {
           reads.push(id);
           return snapshot(id);
         },
-        delete: async () => {
-          docs.delete(id);
-        },
       }),
     }),
+    batch: () => {
+      const queued: string[] = [];
+      return {
+        delete: (ref: { id: string }) => {
+          queued.push(ref.id);
+        },
+        commit: async () => {
+          if (failNextCommit.value) {
+            failNextCommit.value = false;
+            throw new Error("simulated commit failure");
+          }
+          commits.push([...queued]);
+          // Atomic: every id in the batch lands, or none of them did.
+          for (const id of queued) docs.delete(id);
+        },
+      };
+    },
   };
-  return { docs, reads, db };
+  return { docs, reads, commits, failNextCommit, db };
 });
 
 vi.mock("server-only", () => ({}));
@@ -96,6 +118,8 @@ function seed(id: string, ownerUid: string | undefined, childIds: string[] = [])
 beforeEach(() => {
   state.docs.clear();
   state.reads.length = 0;
+  state.commits.length = 0;
+  state.failNextCommit.value = false;
 });
 
 describe("cascade deletion", () => {
@@ -196,30 +220,36 @@ describe("cascade deletion", () => {
     seed("child", "user-a", ["grandchild"]);
     seed("grandchild", "user-a");
 
-    const deleteOrder: string[] = [];
-    const original = state.db.collection;
-    state.db.collection = () => {
-      const inner = original();
-      return {
-        doc: (id: string) => {
-          const ref = inner.doc(id);
-          return {
-            ...ref,
-            delete: async () => {
-              deleteOrder.push(id);
-              await ref.delete();
-            },
-          };
-        },
-      };
-    };
+    await deleteFirebaseTimelineDocument("root", "user-a");
 
-    try {
-      await deleteFirebaseTimelineDocument("root", "user-a");
-    } finally {
-      state.db.collection = original;
-    }
+    expect(state.commits.flat()).toEqual(["grandchild", "child", "root"]);
+  });
 
-    expect(deleteOrder).toEqual(["grandchild", "child", "root"]);
+  // The walk used to await one read at a time and then one delete at a time,
+  // so a 500-document tree was 1000 sequential round trips and a transient
+  // failure mid-loop left the project half removed with no way to tell.
+  it("removes the whole cascade in a single atomic batch", async () => {
+    seed("root", "user-a", ["child"]);
+    seed("child", "user-a", ["grandchild"]);
+    seed("grandchild", "user-a");
+
+    await deleteFirebaseTimelineDocument("root", "user-a");
+
+    expect(state.commits).toHaveLength(1);
+    expect(state.docs.size).toBe(0);
+  });
+
+  it("leaves nothing deleted when the batch fails", async () => {
+    seed("root", "user-a", ["child"]);
+    seed("child", "user-a", ["grandchild"]);
+    seed("grandchild", "user-a");
+    state.failNextCommit.value = true;
+
+    await expect(deleteFirebaseTimelineDocument("root", "user-a")).rejects.toThrow(
+      /simulated commit failure/,
+    );
+
+    // All three still present: no partial deletion to reason about.
+    expect([...state.docs.keys()].sort()).toEqual(["child", "grandchild", "root"]);
   });
 });

--- a/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
@@ -74,6 +74,13 @@ export type TimelineProjectSummary = {
 const TIMELINE_COLLECTION = "gstudioTimelineDocuments";
 const FIREBASE_TIMEOUT_MS = 8_000;
 
+/**
+ * Ceiling on ONE user's project list. This is now a per-requester product
+ * limit rather than the global truncation it used to be — see
+ * `listFirebaseTimelineProjects`.
+ */
+const PROJECT_LIST_LIMIT = 200;
+
 async function withFirebaseTimeout<T>(operation: Promise<T>, label: string): Promise<T> {
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
@@ -194,26 +201,74 @@ function toProjectSummary(id: string, data: Partial<TimelineDocumentRecord>): Ti
   };
 }
 
-export async function listFirebaseTimelineProjects(requesterUid: string) {
-  const snapshot = await withFirebaseTimeout(
-    collection().where("isProject", "==", true).limit(100).get(),
-    "Loading timeline projects",
-  );
+/** A missing composite index — the one failure mode of the two-filter query
+ *  below that has a safe degradation rather than a bug. */
+function isMissingIndexError(error: unknown): boolean {
+  const code = typeof error === "object" && error && "code" in error ? String(error.code) : "";
+  const message = error instanceof Error ? error.message.toLowerCase() : "";
+  return code === "9" || code === "FAILED_PRECONDITION" || message.includes("requires an index");
+}
 
-  // Listing is now READ ONLY. It used to stamp `ownerUid` onto every ownerless
+/**
+ * The requester's own project rows.
+ *
+ * BOTH filters run in the QUERY. They used to be split — `isProject` in the
+ * query, ownership in JS after `.limit(100)` — which meant the limit selected
+ * from every user's rows before anyone's ownership was considered. With no
+ * `orderBy`, Firestore applies its implicit `__name__` ordering, and ids are
+ * `project-${Date.now()}-…`, so the window was the OLDEST hundred project
+ * documents in the collection. Past a hundred documents globally, a user's
+ * newly created project simply fell outside it: the library rendered empty
+ * while the project existed and its URL still resolved.
+ *
+ * Two equality filters need no composite index (Firestore merge-joins the
+ * single-field ones), so this needs no deploy to work. `firestore.indexes.json`
+ * declares the composite anyway — an ordered/paginated version of this query
+ * will want it — and a deployment that somehow does demand one degrades to the
+ * owner-only query rather than failing the page.
+ */
+async function ownedProjectDocs(requesterUid: string) {
+  const owned = collection().where("ownerUid", "==", requesterUid);
+  try {
+    const snapshot = await withFirebaseTimeout(
+      owned.where("isProject", "==", true).limit(PROJECT_LIST_LIMIT).get(),
+      "Loading timeline projects",
+    );
+    return snapshot.docs;
+  } catch (error) {
+    if (!isMissingIndexError(error)) throw error;
+    // Owner-only: always served by the automatic single-field index. Reads
+    // this user's child timelines too and filters `isProject` below — more
+    // rows than needed, but still only ever THIS user's, which is the property
+    // that matters. Loud, because it is a deployment fix, not a code path.
+    console.warn(
+      "[GSTUDIO_PROJECTS_INDEX_MISSING] Falling back to an owner-only project query. Deploy firestore.indexes.json.",
+    );
+    const snapshot = await withFirebaseTimeout(
+      owned.limit(PROJECT_LIST_LIMIT).get(),
+      "Loading timeline projects",
+    );
+    return snapshot.docs;
+  }
+}
+
+export async function listFirebaseTimelineProjects(requesterUid: string) {
+  const docs = await ownedProjectDocs(requesterUid);
+
+  // Listing is READ ONLY. It used to stamp `ownerUid` onto every ownerless
   // project in the result set — one batch write per list, granting ownership to
   // whoever happened to look first. The legacy records that justified it have
   // been migrated (see lib/timeline-ownership), so unowned projects are simply
   // not visible to anyone.
   //
-  // The `.limit(100)` still precedes the ownership filter, so this reads other
-  // users' rows and can miss a user's own projects once the collection exceeds
-  // 100 documents across all users. Fixing that needs a
-  // `.where("ownerUid", "==", requesterUid)` with a composite index deployed
-  // alongside it.
+  // The ownership check stays even though the query now filters on it: this is
+  // the module's one authorization invariant, and it should not depend on a
+  // query staying shaped the way it is today. The `isProject` check is what
+  // the index-missing fallback above relies on.
   const visible: { id: string; data: TimelineDocumentRecord }[] = [];
-  for (const doc of snapshot.docs) {
+  for (const doc of docs) {
     const data = doc.data() as TimelineDocumentRecord;
+    if (data.isProject !== true) continue;
     if (resolveOwnership(data.ownerUid, requesterUid) !== "owned") continue;
     visible.push({ id: doc.id, data });
   }
@@ -508,55 +563,102 @@ export class TimelineCascadeTooLargeError extends Error {
  * counting or explicit per-document parentage in the stored model, which is a
  * schema decision rather than a traversal fix.
  */
+/** Documents of one BFS level read at once. The walk used to await one read
+ *  at a time, so a 500-document tree was 500 sequential round trips before a
+ *  single delete had been issued. */
+const CASCADE_READ_CONCURRENCY = 12;
+/** Firestore's own ceiling on a WriteBatch, and the reason
+ *  MAX_CASCADE_DOCUMENTS is 500: the whole cascade fits in one atomic batch. */
+const FIRESTORE_BATCH_LIMIT = 500;
+
 export async function deleteFirebaseTimelineDocument(id: string, requesterUid: string) {
   const visited = new Set<string>([id]);
-  const queue: string[] = [id];
   // Root-first, so reversing it deletes the deepest documents first and the
-  // root last — a failure part-way leaves a visibly broken parent the user can
-  // retry from, rather than invisible orphans under a vanished root.
+  // root last — relevant only in the multi-batch path below, where a failure
+  // part-way leaves a visibly broken parent the user can retry from rather
+  // than invisible orphans under a vanished root.
   const toDelete: string[] = [];
+  let frontier: string[] = [id];
 
-  while (queue.length > 0) {
-    const currentId = queue.shift() as string;
-    const snapshot = await withFirebaseTimeout(
-      collection().doc(currentId).get(),
-      "Loading timeline document for deletion",
+  while (frontier.length > 0) {
+    // Bounded concurrency rather than one Promise.all over the whole level: a
+    // wide tree should overlap latency, not open an unbounded number of
+    // connections at once. Order is preserved so `toDelete` stays root-first.
+    const snapshots = await withFirebaseTimeout(
+      mapWithConcurrency(frontier, CASCADE_READ_CONCURRENCY, async (currentId) => ({
+        currentId,
+        snapshot: await collection().doc(currentId).get(),
+      })),
+      "Loading timeline documents for deletion",
     );
 
-    if (!snapshot.exists) {
-      // A dangling child reference is nothing to delete. The ROOT still gets a
-      // (no-op) delete so callers see the same success as before.
-      if (currentId === id) toDelete.push(currentId);
-      continue;
-    }
-
-    const data = snapshot.data() as TimelineDocumentRecord;
-    if (resolveOwnership(data.ownerUid, requesterUid) === "denied") {
-      // At the root this is the authorization answer. Deeper it means a stored
-      // clip pointed at someone else's document: skip it, and keep deleting
-      // the requester's own tree.
-      if (currentId === id) throw new TimelineAccessDeniedError(id);
-      continue;
-    }
-
-    toDelete.push(currentId);
-
-    for (const clip of data.document?.clips ?? []) {
-      if (clip.kind !== "collection" || !clip.childTimelineId) continue;
-      // Already queued or already deleted — a cycle or a diamond.
-      if (visited.has(clip.childTimelineId)) continue;
-      if (visited.size >= MAX_CASCADE_DOCUMENTS) {
-        throw new TimelineCascadeTooLargeError(id);
+    const next: string[] = [];
+    for (const { currentId, snapshot } of snapshots) {
+      if (!snapshot.exists) {
+        // A dangling child reference is nothing to delete. The ROOT still gets
+        // a (no-op) delete so callers see the same success as before.
+        if (currentId === id) toDelete.push(currentId);
+        continue;
       }
-      visited.add(clip.childTimelineId);
-      queue.push(clip.childTimelineId);
+
+      const data = snapshot.data() as TimelineDocumentRecord;
+      if (resolveOwnership(data.ownerUid, requesterUid) === "denied") {
+        // At the root this is the authorization answer. Deeper it means a
+        // stored clip pointed at someone else's document: skip it, and keep
+        // deleting the requester's own tree.
+        if (currentId === id) throw new TimelineAccessDeniedError(id);
+        continue;
+      }
+
+      toDelete.push(currentId);
+
+      for (const clip of data.document?.clips ?? []) {
+        if (clip.kind !== "collection" || !clip.childTimelineId) continue;
+        // Already queued or already deleted — a cycle or a diamond.
+        if (visited.has(clip.childTimelineId)) continue;
+        if (visited.size >= MAX_CASCADE_DOCUMENTS) {
+          throw new TimelineCascadeTooLargeError(id);
+        }
+        visited.add(clip.childTimelineId);
+        next.push(clip.childTimelineId);
+      }
     }
+    frontier = next;
   }
 
-  for (const documentId of toDelete.reverse()) {
-    await withFirebaseTimeout(
-      collection().doc(documentId).delete(),
-      "Deleting timeline document",
-    );
+  // ONE atomic batch for the whole cascade, where it fits — which, given
+  // MAX_CASCADE_DOCUMENTS, is every case that is allowed through. Individually
+  // awaited deletes meant a transient failure mid-loop left the project half
+  // removed; a batch either applies completely or not at all.
+  for (const group of chunk(toDelete.reverse(), FIRESTORE_BATCH_LIMIT)) {
+    const batch = getFirebaseDb().batch();
+    for (const documentId of group) batch.delete(collection().doc(documentId));
+    await withFirebaseTimeout(batch.commit(), "Deleting timeline documents");
   }
+}
+
+function chunk<T>(items: readonly T[], size: number): T[][] {
+  const groups: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    groups.push(items.slice(index, index + size));
+  }
+  return groups;
+}
+
+/** Run `task` over `items` with at most `limit` in flight, results in input
+ *  order. */
+async function mapWithConcurrency<In, Out>(
+  items: readonly In[],
+  limit: number,
+  task: (item: In) => Promise<Out>,
+): Promise<Out[]> {
+  const results: Out[] = new Array(items.length);
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    for (let index = cursor++; index < items.length; index = cursor++) {
+      results[index] = await task(items[index]);
+    }
+  });
+  await Promise.all(workers);
+  return results;
 }

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
@@ -442,7 +442,12 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
         return document;
       })
       .finally(() => {
-        inflight.delete(timelineId);
+        // Only evict OUR OWN entry. `reset()` (an auth rebind) clears the map
+        // wholesale, so a request that started under the previous user could
+        // otherwise settle later and delete the NEW session's entry for the
+        // same id — leaving that request undeduplicated, so a second fetch
+        // started and the two raced to install their responses.
+        if (inflight.get(timelineId) === request) inflight.delete(timelineId);
       });
     inflight.set(timelineId, request);
     return request;

--- a/apps/timeline-gstudio001/lib/graph-rsc-payloads.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-rsc-payloads.test.ts
@@ -27,9 +27,15 @@ const state = vi.hoisted(() => {
       get: (field: string) => (data ? data[field] : undefined),
     };
   };
+  /** Per-id storage read count — the loader must not re-read a document it
+   *  already pulled in to derive a parent's summaries. */
+  const reads = new Map<string, number>();
   const docRef = (id: string) => ({
     id,
-    get: async () => snapshot(id),
+    get: async () => {
+      reads.set(id, (reads.get(id) ?? 0) + 1);
+      return snapshot(id);
+    },
     set: async (data: Stored, opts?: { merge?: boolean }) => applySet(id, data, opts),
     delete: async () => {
       docs.delete(id);
@@ -58,7 +64,7 @@ const state = vi.hoisted(() => {
       };
     },
   };
-  return { docs, db };
+  return { docs, reads, db };
 });
 
 vi.mock("server-only", () => ({}));
@@ -122,6 +128,7 @@ function seed(id: string, ownerUid: string, clips: TimelineClip[], revision = 1)
 
 beforeEach(() => {
   state.docs.clear();
+  state.reads.clear();
 });
 
 describe("loadGraphBootstrapPayloads", () => {
@@ -182,5 +189,33 @@ describe("loadFocusPathPayloads", () => {
 
     const payloads = await loadFocusPathPayloads(["ghost", "scene", "scene"], "user-a");
     expect(payloads.map((payload) => payload.document.id)).toEqual(["scene"]);
+  });
+
+  // Serving a document already reads every child to derive its collection
+  // summaries. Serving those children as payloads then read each of them a
+  // second time, and their own children a third.
+  it("reads each document once across summary derivation and payload serving", async () => {
+    seed("grand", "user-a", [image("g", 0, 2)]);
+    seed("scene", "user-a", [collectionClip("gref", "grand", 0)]);
+    seed("mid", "user-a", [collectionClip("sref", "scene", 0)]);
+    state.reads.clear();
+
+    await loadFocusPathPayloads(["mid", "scene"], "user-a");
+
+    expect([...state.reads.values()].every((count) => count === 1)).toBe(true);
+  });
+
+  // MAX_PATH_PAYLOADS counts SUCCESSES, so it bounded nothing when nothing
+  // resolved: `activeTimelinePath` is a catch-all segment, so a URL with
+  // hundreds of unknown segments cost one storage read each while producing
+  // no payloads at all.
+  it("bounds storage reads for a path of unresolvable segments", async () => {
+    const segments = Array.from({ length: 300 }, (_, index) => `ghost-${index}`);
+    state.reads.clear();
+
+    const payloads = await loadFocusPathPayloads(segments, "user-a");
+
+    expect(payloads).toEqual([]);
+    expect(state.reads.size).toBeLessThanOrEqual(48);
   });
 });

--- a/apps/timeline-gstudio001/lib/graph-rsc-payloads.ts
+++ b/apps/timeline-gstudio001/lib/graph-rsc-payloads.ts
@@ -2,7 +2,11 @@ import "server-only";
 
 import { collectionChildIds } from "./derive-collection-summaries";
 import type { GraphServerPayload } from "./graph-documents-gateway";
-import { serveTimelineDocument, serveTrashDocument } from "./serve-timeline";
+import {
+  createTimelineEntryReader,
+  serveTimelineDocument,
+  serveTrashDocument,
+} from "./serve-timeline";
 
 // RSC read-path loaders (fold-in of the codex/rsc-graph-poc direction):
 // server components deliver served documents + revisions as PROPS, and the
@@ -19,6 +23,16 @@ export type { GraphServerPayload };
 const MAX_PATH_PAYLOADS = 16;
 
 /**
+ * Ceiling on documents ATTEMPTED, as distinct from payloads produced.
+ *
+ * `MAX_PATH_PAYLOADS` counts successes, so it bounded nothing when serves
+ * failed: `activeTimelinePath` is a catch-all route segment, so a URL carrying
+ * hundreds of unknown segments produced zero payloads while still costing one
+ * storage read per segment. This is the bound that actually holds.
+ */
+const MAX_PATH_ATTEMPTS = 48;
+
+/**
  * The boot payloads: the project document and the user's trash — the two
  * roots the graph builds from. Null when the project can't be served
  * (missing or denied): the client boots through its legacy fetch path and
@@ -29,9 +43,12 @@ export async function loadGraphBootstrapPayloads(
   requesterUid: string,
 ): Promise<readonly GraphServerPayload[] | null> {
   try {
-    const project = await serveTimelineDocument(projectId, requesterUid);
+    // One reader for the whole render: the project's own serve reads every
+    // child to derive summaries, and the trash read joins the same cache.
+    const read = createTimelineEntryReader(requesterUid);
+    const project = await serveTimelineDocument(projectId, requesterUid, read);
     if (!project) return null;
-    const trash = await serveTrashDocument(`trash-${requesterUid}`, requesterUid);
+    const trash = await serveTrashDocument(`trash-${requesterUid}`, requesterUid, read);
     // forUid lets the client's prime refuse payloads that survive an auth
     // transition in the router cache.
     return [
@@ -63,29 +80,47 @@ export async function loadFocusPathPayloads(
 ): Promise<readonly GraphServerPayload[]> {
   const payloads: GraphServerPayload[] = [];
   const seen = new Set<string>();
+  // Shared across every serve below, so a child read once for its parent's
+  // summaries is not read again to become a payload, and its own children are
+  // not read a third time.
+  const read = createTimelineEntryReader(requesterUid);
 
-  const serve = async (id: string) => {
-    if (seen.has(id) || payloads.length >= MAX_PATH_PAYLOADS) return null;
+  const serve = async (id: string): Promise<GraphServerPayload | null> => {
+    if (seen.has(id) || seen.size >= MAX_PATH_ATTEMPTS) return null;
+    if (payloads.length >= MAX_PATH_PAYLOADS) return null;
     seen.add(id);
     try {
-      const served = await serveTimelineDocument(id, requesterUid);
+      const served = await serveTimelineDocument(id, requesterUid, read);
       if (!served) return null;
-      const payload: GraphServerPayload = { ...served, forUid: requesterUid };
-      payloads.push(payload);
-      return payload;
+      return { ...served, forUid: requesterUid };
     } catch {
       return null;
     }
   };
 
+  // The focus chain stays SEQUENTIAL: it is an ancestor path, and each segment
+  // is only worth reading if the one above it resolved.
   const segments = options?.focusedOnly ? path.slice(-1) : path;
   let focused: GraphServerPayload | null = null;
   for (const segment of segments) {
-    focused = (await serve(segment)) ?? focused;
+    const payload = await serve(segment);
+    if (payload) {
+      payloads.push(payload);
+      focused = payload;
+    }
   }
+
   if (focused) {
-    for (const childId of collectionChildIds(focused.document)) {
-      await serve(childId);
+    // The eager child level is a FLAT set of independent documents — nothing
+    // about one gates another, so serialising them only added latency. Results
+    // are pushed in child order regardless of completion order, so the primes
+    // the client receives are deterministic.
+    const children = collectionChildIds(focused.document).slice(
+      0,
+      Math.max(0, MAX_PATH_PAYLOADS - payloads.length),
+    );
+    for (const payload of await Promise.all(children.map((childId) => serve(childId)))) {
+      if (payload) payloads.push(payload);
     }
   }
 

--- a/apps/timeline-gstudio001/lib/heal-timeline-document.test.ts
+++ b/apps/timeline-gstudio001/lib/heal-timeline-document.test.ts
@@ -151,3 +151,80 @@ describe("healTimelineDocument", () => {
     expect(changed).toBe(false);
   });
 });
+
+// The matcher used to reduce BOTH sides to a bare filename leaf, so assets
+// sharing a leaf across folders/projects overwrote each other in one flat map
+// and a clip was silently re-pointed at whichever was listed last — with the
+// caller persisting the result, from a plain GET.
+describe("asset resolution", () => {
+  /** `videoClip` is typed as the whole TimelineClip union, so spreading it to
+   *  add `sourceAsset` (a MEDIA-only field) needs the narrowed variant. */
+  function videoOf(publicId: string): Extract<TimelineClip, { kind: "video" }> {
+    const clip = videoClip(publicId, 0, 0, 8);
+    if (clip.kind !== "video") throw new Error("fixture is a video");
+    return clip;
+  }
+
+  function inFolder(folder: string, publicId: string, duration: number, url: string): CloudinaryAsset {
+    return {
+      ...videoAsset(publicId, duration, url),
+      id: `${folder}/${publicId}`,
+      pathname: `${folder}/${publicId}`,
+      relativePath: `${folder}/${publicId}`,
+    };
+  }
+
+  it("refuses a legacy filename that names more than one asset", () => {
+    const input = doc([videoClip("alley", 0, 0, 8)]);
+
+    const { document, changed } = healTimelineDocument(input, [
+      inFolder("project-a", "alley", 3, `${CLOUD}/a/alley.mp4`),
+      inFolder("project-b", "alley", 30, `${CLOUD}/b/alley.mp4`),
+    ]);
+
+    // Ambiguous: no rewrite in either direction, and no duration guess.
+    expect(changed).toBe(false);
+    expect(document).toBe(input);
+  });
+
+  it("still heals a legacy filename that names exactly one asset", () => {
+    const input = doc([videoClip("alley", 0, 0, 8)]);
+
+    const { document, changed } = healTimelineDocument(input, [
+      inFolder("project-a", "alley", 3, `${CLOUD}/a/alley.mp4`),
+      inFolder("project-b", "brook", 30, `${CLOUD}/b/brook.mp4`),
+    ]);
+
+    expect(changed).toBe(true);
+    expect(srcOf(document.clips[0])).toBe(`${CLOUD}/a/alley.mp4`);
+  });
+
+  it("resolves by sourceAsset provenance even when the leaf is ambiguous", () => {
+    const input = doc([
+      { ...videoOf("alley"), sourceAsset: { providerId: "cloudinary", assetId:"project-b/alley" } },
+    ]);
+
+    const { document, changed } = healTimelineDocument(input, [
+      inFolder("project-a", "alley", 3, `${CLOUD}/a/alley.mp4`),
+      inFolder("project-b", "alley", 30, `${CLOUD}/b/alley.mp4`),
+    ]);
+
+    expect(changed).toBe(true);
+    expect(srcOf(document.clips[0])).toBe(`${CLOUD}/b/alley.mp4`);
+    expect(document.clips[0].duration).toBe(30);
+  });
+
+  it("does not fall back to a same-named asset when provenance names a missing one", () => {
+    const input = doc([
+      { ...videoOf("alley"), sourceAsset: { providerId: "cloudinary", assetId:"deleted/alley" } },
+    ]);
+
+    const { document, changed } = healTimelineDocument(input, [
+      inFolder("project-a", "alley", 3, `${CLOUD}/a/alley.mp4`),
+    ]);
+
+    // The asset it was placed from is gone. A same-named neighbour is not it.
+    expect(changed).toBe(false);
+    expect(document).toBe(input);
+  });
+});

--- a/apps/timeline-gstudio001/lib/heal-timeline-document.ts
+++ b/apps/timeline-gstudio001/lib/heal-timeline-document.ts
@@ -1,5 +1,5 @@
 import { packTimelineClips } from "@storyboard/timeline-model";
-import type { TimelineDocument } from "@storyboard/timeline-model/types";
+import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
 
 import type { CloudinaryAsset } from "./cloudinary-media-store";
 
@@ -18,20 +18,81 @@ import type { CloudinaryAsset } from "./cloudinary-media-store";
 // A duration change shifts every following clip's startTime, so the document
 // is repacked (packTimelineClips — the same packing the app uses) whenever a
 // duration moved. Returns the SAME document reference when nothing changed so
-// the caller can skip the write.
+// the caller can skip the work.
+//
+// The result is SERVED, never persisted — see lib/serve-timeline.
 
 /** Durations within this many seconds are treated as already correct. */
 const DURATION_EPSILON = 0.05;
 
-/** Asset filename as stored (public_id leaf) — the key the src match uses. */
-function assetFilename(asset: CloudinaryAsset): string | undefined {
-  return asset.relativePath?.split("/").pop() || asset.pathname?.split("/").pop() || undefined;
+/**
+ * How a clip finds its asset.
+ *
+ * PROVENANCE FIRST. `sourceAsset` records the provider file a clip was placed
+ * from (`{ providerId, assetId }`, written by the asset palette), and
+ * `CloudinaryAsset.id` IS that `assetId` — so for anything placed through the
+ * palette this is an exact identity match with nothing to guess.
+ *
+ * The filename path below is the LEGACY fallback, for clips stored before
+ * provenance was recorded. It used to be the only path, and it keyed on the
+ * bare filename LEAF of both the asset and the clip URL — so two assets named
+ * `alley` in different folders or projects collapsed onto one key and the last
+ * one listed silently won. Because the caller then PERSISTED the result, a
+ * plain GET could rewrite a clip's src, poster and duration to point at a
+ * different project's file. Now: the full relative path is the key, and a leaf
+ * that resolves to more than one asset is refused rather than guessed.
+ */
+const CLOUDINARY_PROVIDER_ID = "cloudinary";
+
+function assetPath(asset: CloudinaryAsset): string | undefined {
+  return asset.relativePath || asset.pathname || undefined;
 }
 
-/** A clip's source URL reduced to the same filename key (extension stripped —
- *  Cloudinary public_ids carry none, but the delivery URL does). */
-function clipAssetKey(src: string): string | undefined {
-  return src.split("/").pop()?.split("?")[0]?.replace(/\.[^/.]+$/, "") || undefined;
+/** The leaf of a path, extension stripped — Cloudinary public_ids carry none,
+ *  but the delivery URL does. */
+function leafOf(value: string): string | undefined {
+  return value.split("/").pop()?.split("?")[0]?.replace(/\.[^/.]+$/, "") || undefined;
+}
+
+type AssetIndex = Readonly<{
+  byId: ReadonlyMap<string, CloudinaryAsset>;
+  byPath: ReadonlyMap<string, CloudinaryAsset>;
+  /** Leaf → asset, but only for leaves that name exactly ONE asset. An
+   *  ambiguous leaf maps to null and is refused. */
+  byUniqueLeaf: ReadonlyMap<string, CloudinaryAsset | null>;
+}>;
+
+function indexAssets(assets: readonly CloudinaryAsset[]): AssetIndex {
+  const byId = new Map<string, CloudinaryAsset>();
+  const byPath = new Map<string, CloudinaryAsset>();
+  const byUniqueLeaf = new Map<string, CloudinaryAsset | null>();
+
+  for (const asset of assets) {
+    if (asset.id) byId.set(asset.id, asset);
+    const path = assetPath(asset);
+    if (path) byPath.set(path.replace(/\.[^/.]+$/, ""), asset);
+    const leaf = path ? leafOf(path) : undefined;
+    if (!leaf) continue;
+    // Second sighting of a leaf poisons it: no legacy clip can be resolved by
+    // it any more, in either direction.
+    byUniqueLeaf.set(leaf, byUniqueLeaf.has(leaf) ? null : asset);
+  }
+
+  return { byId, byPath, byUniqueLeaf };
+}
+
+function resolveAsset(
+  clip: Extract<TimelineClip, { kind: "video" | "image" }>,
+  index: AssetIndex,
+): CloudinaryAsset | undefined {
+  if (clip.sourceAsset?.providerId === CLOUDINARY_PROVIDER_ID) {
+    // Provenance is authoritative: if it names an asset we can't see, the
+    // asset is gone, and guessing a same-named neighbour is not a repair.
+    return index.byId.get(clip.sourceAsset.assetId);
+  }
+  const leaf = leafOf(clip.src);
+  if (!leaf) return undefined;
+  return index.byUniqueLeaf.get(leaf) ?? undefined;
 }
 
 export function healTimelineDocument(
@@ -40,11 +101,7 @@ export function healTimelineDocument(
 ): { document: TimelineDocument; changed: boolean } {
   if (assets.length === 0) return { document, changed: false };
 
-  const assetMap = new Map<string, CloudinaryAsset>();
-  for (const asset of assets) {
-    const filename = assetFilename(asset);
-    if (filename) assetMap.set(filename, asset);
-  }
+  const index = indexAssets(assets);
 
   let changed = false;
   let durationsChanged = false;
@@ -52,9 +109,7 @@ export function healTimelineDocument(
   const healed = document.clips.map((clip) => {
     if (clip.kind !== "video" && clip.kind !== "image") return clip;
 
-    const key = clipAssetKey(clip.src);
-    if (!key) return clip;
-    const asset = assetMap.get(key);
+    const asset = resolveAsset(clip, index);
     if (!asset) return clip;
 
     let next = clip;

--- a/apps/timeline-gstudio001/lib/load-timeline-closure.ts
+++ b/apps/timeline-gstudio001/lib/load-timeline-closure.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import type { TimelineDocument } from "@storyboard/timeline-model/types";
 
-import { getFirebaseTimelineEntry } from "./firebase-timeline-store";
+import { getFirebaseTimelineEntry, type TimelineEntry } from "./firebase-timeline-store";
 
 // The nested document closure for a timeline: the root plus every document
 // reachable through collection clips, breadth-first with a visited set (a
@@ -11,10 +11,63 @@ import { getFirebaseTimelineEntry } from "./firebase-timeline-store";
 // missing, or another user's — is substituted with an EMPTY document and
 // reported, so a dangling reference degrades that branch to silence
 // instead of failing the whole preview.
+//
+// BOUNDED and LEVEL-PARALLEL. This used to await one read per document in a
+// `while (queue.length)` loop, with no ceiling on how many documents it would
+// visit — so latency was `depth × breadth` sequential round trips, and a
+// deeply nested (or maliciously shaped) tree could run past the platform's
+// execution limit. The preview manifest recompiles on a trailing 2.5s debounce
+// after every settled edit burst, so this is a hot path during editing, not a
+// once-per-session load.
+
+/**
+ * Ceiling on how many documents ONE closure may visit. Mirrors
+ * `MAX_CASCADE_DOCUMENTS` in the store: past this the structure is
+ * pathological, and a preview that refuses loudly beats a function that runs
+ * until the platform kills it.
+ */
+export const MAX_CLOSURE_DOCUMENTS = 500;
+
+/** How many documents of one BFS level are read at once. Firestore handles far
+ *  more, but the point is to overlap latency, not to fan out without limit. */
+const READ_CONCURRENCY = 12;
+
+export class TimelineClosureTooLargeError extends Error {
+  constructor(rootId: string) {
+    super(
+      `Timeline "${rootId}" reaches more than ${MAX_CLOSURE_DOCUMENTS} documents.`,
+    );
+    this.name = "TimelineClosureTooLargeError";
+  }
+}
+
+async function mapWithConcurrency<In, Out>(
+  items: readonly In[],
+  limit: number,
+  run: (item: In) => Promise<Out>,
+): Promise<Out[]> {
+  const results: Out[] = new Array(items.length);
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    for (let index = cursor++; index < items.length; index = cursor++) {
+      results[index] = await run(items[index]);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
 
 export async function loadTimelineClosure(
   rootId: string,
   requesterUid: string,
+  options?: Readonly<{
+    /**
+     * The root's already-read entry. The preview-manifest route reads the root
+     * itself (that read IS its 404 check) and used to hand this loader nothing,
+     * so the root was fetched a second time on every compile.
+     */
+    rootEntry?: TimelineEntry | null;
+  }>,
 ): Promise<{
   documents: Record<string, TimelineDocument>;
   missing: string[];
@@ -26,32 +79,49 @@ export async function loadTimelineClosure(
   const documents: Record<string, TimelineDocument> = {};
   const revisions: Record<string, number> = {};
   const missing: string[] = [];
-  const queue: string[] = [rootId];
   const seen = new Set<string>([rootId]);
 
-  while (queue.length > 0) {
-    const id = queue.shift();
-    if (id === undefined) break;
-    const entry = await getFirebaseTimelineEntry(id, requesterUid).catch(() => null);
+  const record = (id: string, entry: TimelineEntry | null): readonly string[] => {
     if (!entry) {
-      if (id !== rootId) {
-        missing.push(id);
-        documents[id] = { id, title: "", clips: [] };
-        continue;
-      }
-      // A missing ROOT is the caller's 404 to raise, not ours to hide.
-      documents[id] = { id, title: "", clips: [] };
+      // A missing ROOT is the caller's 404 to raise, not ours to hide — it is
+      // recorded exactly like a missing child so the caller sees it in
+      // `missing` either way.
       missing.push(id);
-      continue;
+      documents[id] = { id, title: "", clips: [] };
+      return [];
     }
     documents[id] = entry.document;
     revisions[id] = entry.revision;
+
+    const next: string[] = [];
     for (const clip of entry.document.clips) {
       if (clip.kind !== "collection" || !clip.childTimelineId) continue;
       if (seen.has(clip.childTimelineId)) continue;
+      if (seen.size >= MAX_CLOSURE_DOCUMENTS) throw new TimelineClosureTooLargeError(rootId);
       seen.add(clip.childTimelineId);
-      queue.push(clip.childTimelineId);
+      next.push(clip.childTimelineId);
     }
+    return next;
+  };
+
+  // `rootEntry: null` is a caller that looked and found nothing — honour it
+  // rather than re-reading to rediscover the same absence. `undefined` means
+  // the caller has no opinion.
+  const rootEntry =
+    options?.rootEntry !== undefined
+      ? options.rootEntry
+      : await getFirebaseTimelineEntry(rootId, requesterUid).catch(() => null);
+
+  let frontier: readonly string[] = record(rootId, rootEntry);
+
+  while (frontier.length > 0) {
+    const entries = await mapWithConcurrency(frontier, READ_CONCURRENCY, async (id) => ({
+      id,
+      entry: await getFirebaseTimelineEntry(id, requesterUid).catch(() => null),
+    }));
+    // Recorded in frontier order, so `documents` and `missing` keep the
+    // deterministic ordering the sequential walk produced.
+    frontier = entries.flatMap(({ id, entry }) => record(id, entry));
   }
 
   return { documents, missing, revisions };

--- a/apps/timeline-gstudio001/lib/rate-limit.ts
+++ b/apps/timeline-gstudio001/lib/rate-limit.ts
@@ -1,0 +1,77 @@
+/**
+ * A fixed-window rate limiter, in process memory.
+ *
+ * Deliberately NOT distributed. On a serverless platform each instance keeps
+ * its own counters, so the effective ceiling is `limit × instances` rather
+ * than `limit` — which is the honest trade for a limiter that needs no
+ * infrastructure and cannot itself fail a request. It turns "unlimited" into
+ * "bounded per instance", which is the difference that matters for the
+ * endpoint it guards; a hard global ceiling belongs at the edge (a WAF rule),
+ * and this does not pretend to be one.
+ *
+ * Pure and dependency-free so the window arithmetic is unit-testable.
+ */
+
+export type RateLimitVerdict = Readonly<{
+  allowed: boolean;
+  /** Seconds until this key's window resets — the `Retry-After` value. */
+  retryAfterSeconds: number;
+}>;
+
+export type RateLimiter = Readonly<{
+  check: (key: string, now?: number) => RateLimitVerdict;
+}>;
+
+type Window = { count: number; resetAt: number };
+
+export function createRateLimiter(
+  options: Readonly<{ limit: number; windowMs: number; maxKeys?: number }>,
+): RateLimiter {
+  const { limit, windowMs, maxKeys = 10_000 } = options;
+  const windows = new Map<string, Window>();
+
+  /** Bounded so a flood of distinct keys (one per spoofed IP) cannot grow this
+   *  map without limit — dropping the oldest insertions first. */
+  const evictIfNeeded = (now: number) => {
+    if (windows.size < maxKeys) return;
+    for (const [key, window] of windows) {
+      if (window.resetAt <= now) windows.delete(key);
+    }
+    while (windows.size >= maxKeys) {
+      const oldest = windows.keys().next();
+      if (oldest.done) break;
+      windows.delete(oldest.value);
+    }
+  };
+
+  return {
+    check: (key, now = Date.now()) => {
+      const existing = windows.get(key);
+      if (!existing || existing.resetAt <= now) {
+        evictIfNeeded(now);
+        windows.set(key, { count: 1, resetAt: now + windowMs });
+        return { allowed: true, retryAfterSeconds: Math.ceil(windowMs / 1000) };
+      }
+      const retryAfterSeconds = Math.max(1, Math.ceil((existing.resetAt - now) / 1000));
+      if (existing.count >= limit) {
+        return { allowed: false, retryAfterSeconds };
+      }
+      existing.count += 1;
+      return { allowed: true, retryAfterSeconds };
+    },
+  };
+}
+
+/**
+ * The caller's address, from the proxy headers Vercel sets.
+ *
+ * `x-forwarded-for` is client-controllable on a server reached directly, so
+ * this is a best-effort bucket key, not an identity — which is why the login
+ * route rate-limits on the ADDRESS too. The LEFTMOST entry is the client per
+ * the header's own convention.
+ */
+export function clientAddress(request: Request): string {
+  const forwarded = request.headers.get("x-forwarded-for");
+  const first = forwarded?.split(",")[0]?.trim();
+  return first || request.headers.get("x-real-ip")?.trim() || "unknown";
+}

--- a/apps/timeline-gstudio001/lib/read-json-body.ts
+++ b/apps/timeline-gstudio001/lib/read-json-body.ts
@@ -1,0 +1,28 @@
+/**
+ * Read a request body as a JSON OBJECT, or `{}` when it isn't one.
+ *
+ * Every route used to do this inline:
+ *
+ *     const body = (await request.json().catch(() => ({}))) as { writes?: … };
+ *
+ * which reads as safe and is not. `JSON.parse("null")` succeeds, so a literal
+ * `null` body skips the `.catch` entirely, `body` is `null`, and the very next
+ * property access throws a TypeError — caught by the route's outer handler and
+ * reported as a 500. A malformed request should be a 400. The same shape
+ * appeared in six routes (both auth routes, both timelines routes, the batch
+ * endpoint, and trash), so all six answered 500 to `null`, `[]`, `"x"`, and
+ * `42`.
+ *
+ * Returning `Record<string, unknown>` rather than an asserted shape is the
+ * other half: callers must narrow each field they read, which is what they
+ * were already doing by hand (`typeof body.title === "string"`) under a cast
+ * that claimed the narrowing had happened.
+ */
+export async function readJsonObject(request: Request): Promise<Record<string, unknown>> {
+  const parsed: unknown = await request.json().catch(() => null);
+  // Arrays are objects; a JSON array body is still not the record any of these
+  // routes expects, so it degrades to empty like every other non-object.
+  return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : {};
+}

--- a/apps/timeline-gstudio001/lib/serve-timeline.ts
+++ b/apps/timeline-gstudio001/lib/serve-timeline.ts
@@ -8,45 +8,82 @@ import {
   deriveCollectionSummaries,
 } from "./derive-collection-summaries";
 import {
-  getFirebaseTimelineDocument,
   getFirebaseTimelineEntry,
-  saveFirebaseTimelineEntry,
+  type TimelineEntry,
 } from "./firebase-timeline-store";
 import { healTimelineDocument } from "./heal-timeline-document";
 
 // The ONE serve path for a stored timeline document — used by the
 // GET /api/timelines/[id] route AND the RSC payload loaders, so the two
-// transports can never drift: load-time self-heal (persisted only when it
-// changed, with the served revision reflecting the heal write), then
-// read-time collection-summary derivation from the child documents.
+// transports can never drift: load-time self-heal (served, never persisted —
+// see below), then read-time collection-summary derivation from the child
+// documents. Both are READ-ONLY repairs: this path issues no writes, so the
+// revision it reports is always the one actually stored.
 
 export type ServedTimeline = Readonly<{
   document: TimelineDocument;
   revision: number;
 }>;
 
+/**
+ * A read of one stored entry, shared across everything serving ONE request.
+ *
+ * Serving a document reads all of its children to derive collection summaries.
+ * A caller that then serves those children individually (the RSC focus-path
+ * loader does exactly that) re-reads every one of them, plus their children.
+ * Passing the same reader through collapses those into one read per document
+ * per request.
+ *
+ * Rejections are memoized along with successes on purpose: a
+ * `TimelineAccessDeniedError` is a stable answer for the life of a request,
+ * and re-reading to rediscover it would defeat the point.
+ */
+export type TimelineEntryReader = (id: string) => Promise<TimelineEntry | null>;
+
+export function createTimelineEntryReader(requesterUid: string): TimelineEntryReader {
+  const inflight = new Map<string, Promise<TimelineEntry | null>>();
+  return (id) => {
+    const cached = inflight.get(id);
+    if (cached) return cached;
+    const request = getFirebaseTimelineEntry(id, requesterUid);
+    inflight.set(id, request);
+    return request;
+  };
+}
+
 /** Null when the document doesn't exist; throws TimelineAccessDeniedError
  *  for someone else's (callers map it to their 404). */
 export async function serveTimelineDocument(
   id: string,
   requesterUid: string,
+  /** Share one across a request to avoid re-reading documents (see
+   *  `createTimelineEntryReader`). Defaults to an un-shared direct read. */
+  read: TimelineEntryReader = (childId) => getFirebaseTimelineEntry(childId, requesterUid),
 ): Promise<ServedTimeline | null> {
-  const entry = await getFirebaseTimelineEntry(id, requesterUid);
+  const entry = await read(id);
   if (!entry) return null;
 
   const cloudinaryAssets = await listCloudinaryAssets(requesterUid).catch(() => []);
-  const { document: healedDocument, changed } = healTimelineDocument(
-    entry.document,
-    cloudinaryAssets,
-  );
+  const { document: healedDocument } = healTimelineDocument(entry.document, cloudinaryAssets);
 
-  // The served revision must reflect the heal write (it bumps the counter)
-  // or the client's first expected-revision write would conflict spuriously.
-  let revision = entry.revision;
-  if (changed) {
-    const saved = await saveFirebaseTimelineEntry(healedDocument, requesterUid).catch(() => null);
-    if (saved) revision = saved.revision;
-  }
+  // The heal is SERVED, NOT PERSISTED.
+  //
+  // It used to write itself back through `saveFirebaseTimelineEntry`, whose
+  // single-document path is explicitly last-write-wins — and it did so after
+  // awaiting the asset listing, holding a document read BEFORE that round
+  // trip. A batch write landing in the gap (another tab, the same tab's own
+  // autosave) was overwritten by this stale copy, and because the client's
+  // revision ledger still expected the version it wrote, the user's next edit
+  // lost its compare-and-set and was refused with "changed in another view".
+  // A GET should not be able to do that.
+  //
+  // Nothing is lost by only serving it: the client builds its graph from what
+  // it is served, so the repaired srcs and durations ride out on the next
+  // ordinary write through the batch path — which carries an expected
+  // revision and therefore cannot clobber a concurrent writer. Read-only
+  // sessions simply see correct content and write nothing at all. A repair
+  // that must be durable belongs in a migration script, not a read.
+  const revision = entry.revision;
 
   // Collection summaries derive from the CHILD documents at read time
   // (see deriveCollectionSummaries) — served fresh, never persisted. A
@@ -56,8 +93,8 @@ export async function serveTimelineDocument(
   const childDocuments = new Map(
     await Promise.all(
       childIds.map(async (childId) => {
-        const child = await getFirebaseTimelineDocument(childId, requesterUid).catch(() => null);
-        return [childId, child] as const;
+        const child = await read(childId).catch(() => null);
+        return [childId, child?.document ?? null] as const;
       }),
     ),
   );
@@ -71,8 +108,9 @@ export async function serveTimelineDocument(
 export async function serveTrashDocument(
   id: string,
   requesterUid: string,
+  read: TimelineEntryReader = (trashId) => getFirebaseTimelineEntry(trashId, requesterUid),
 ): Promise<ServedTimeline> {
-  const entry = await getFirebaseTimelineEntry(id, requesterUid);
+  const entry = await read(id);
   return {
     document: entry?.document ?? { id, title: "Trash Bin", clips: [] },
     revision: entry?.revision ?? 0,

--- a/apps/timeline-gstudio001/next.config.ts
+++ b/apps/timeline-gstudio001/next.config.ts
@@ -5,7 +5,13 @@ const nextConfig: NextConfig = {
   reactStrictMode: true,
   distDir: process.env.NODE_ENV === 'development' ? '.next-dev' : '.next',
   eslint: {
-    ignoreDuringBuilds: true,
+    // NOT ignored. The graph code treats react-hooks rules as correctness
+    // constraints, not style — `react-hooks/set-state-in-effect` is why several
+    // components adjust state during render instead of in an effect, and
+    // auth-gate carries a deliberate disable with a written justification. CI
+    // runs `npm run lint`, but a local or alternate deploy path that calls
+    // `next build` directly would have skipped all of it.
+    ignoreDuringBuilds: false,
   },
   typescript: {
     ignoreBuildErrors: false,


### PR DESCRIPTION
Fourteen fixes from two independent reviews of `4a14385`. Where the two disagreed, the better reading won; where only one found something, it's here.

## Critical — the library was hiding people's own projects

`listFirebaseTimelineProjects` applied `.limit(100)` **before** the ownership filter, with no `orderBy`. Firestore's implicit `__name__` ordering over `project-${Date.now()}-…` ids meant the window was the *oldest hundred project documents in the collection, across all users*. Past a hundred documents globally: create a project, get redirected into it, come back to `/`, see "No saved projects yet". The project still existed and its URL still resolved — every discovery path to it was gone. Same function backs the MCP `list_projects`.

Both filters now run in the query. Two equality filters are merge-joined without a composite index, so this needs no deploy; `firestore.indexes.json` declares one anyway for the ordered/paginated version, and the store degrades to an owner-only query rather than failing the page.

## High — a GET could destroy an edit

`serveTimelineDocument` healed a document and wrote it back through the **last-write-wins** single-save path, holding a copy read *before* an awaited Cloudinary listing. A batch write landing in that gap was overwritten by the stale copy — and because the client's ledger still expected its own revision, the user's next edit then lost its compare-and-set and was refused with *"changed in another view"*.

The heal is now served, never persisted: repairs ride out on the next ordinary write, which carries a revision. Separately it matched assets by bare filename **leaf**, so same-named assets in different folders collapsed onto one key and a clip could be re-pointed at another project's file. `sourceAsset` provenance resolves exactly now; the legacy filename path refuses an ambiguous leaf.

## Authorization

- `/api/timeline-media` guarded **both** its checks on the pathname parsing as project-scoped, so any path that didn't parse skipped authorization entirely — only the object name's entropy stood between a signed-in caller and any legacy object. Null now denies. `nosniff` on every response.
- Upload route: `formData` parts validated instead of asserted (`as Blob` on a text field was a 500, not a 400), size ceiling, content type from an extension allowlist instead of the client's declaration.
- `/api/auth/login` was unauthenticated, unthrottled, echoed Firebase and configuration errors verbatim, and answered `EMAIL_NOT_FOUND` distinctly — an account-enumeration oracle. Now shape-validated, rate-limited per address and per source, one generic answer, detail in the log.
- `JSON.parse("null")` is valid, so the `.catch(() => ({}))` idiom in **six** routes never fired and the next property read threw a 500 where a 400 belonged.

## Scalability

- `loadTimelineClosure`: serial per-document reads, no ceiling, on a path the preview refetches after every settled edit burst → level-parallel, capped at 500, takes the root the route already read.
- `loadFocusPathPayloads`: re-read every document that serving its parent had already pulled in for summaries, serialized the eager child level, and bounded *successes* rather than *attempts* — a catch-all route segment, so a URL of unknown segments cost a read each and produced nothing.
- Cascade delete: up to 500 serial reads then 500 serial deletes → bounded-concurrency reads, one atomic `WriteBatch`.

## Accessibility

- Both `aria-modal="true"` dialogs did none of what that attribute promises. One shared hook moves focus in, cycles Tab, marks the backdrop `inert`, restores on close.
- Project cards exposed a **nameless link** as their whole click target and an `opacity-0` delete button that was still focusable with no visible ring, one Enter from a cascade delete.
- Save state and the gateway banner were visual-only: settled results announced politely, failures assertively — and deliberately **once**, not from two live regions (see below).

## First paint

`AuthGate` held the whole tree behind a spinner until `/api/auth/me` answered — re-deriving over the network what the RSC pass had in hand, and negating the graph route's zero-fetch bootstrap. The root layout resolves the session and seeds the provider; revalidation runs in the background.

## Verification

| Gate | Result |
|---|---|
| Typecheck (app + `packages/ui`) | pass |
| Lint | 0 errors (4 pre-existing `<img>` warnings) |
| App tests | 493 pass |
| Unit tests | 408 pass |
| Story interaction tests | 165 pass |
| **e2e `graph-view`** | **101 / 101** |
| **e2e `dnd-collections`** | **24 / 24** |

**The e2e caught an a11y regression in this branch that every other gate missed.** My first pass gave `role="alert"` to both the gateway banner and the save-status chip — which read the *same* string from the same source, so one failure was announced twice. It surfaced as a strict-mode violation (`getByText` resolving to two elements). Fixed in the second commit by removing the duplication, not by narrowing the selector.

Regression tests pin: the listing bug (proved failing against the old query), ambiguous-asset match, provenance resolution, the closure cap, single root read, per-document read counts, the attempt bound, batch atomicity, and the unscoped media denial.

## Deploy notes

- `firestore.indexes.json` is **not required** for the listing fix. Deploy it if you want the ordered query later — it also declares the **TTL policy** on `mcpOAuthCodes` / `mcpOAuthRefreshTokens`, which does need deploying to take effect.
- The rate limiter is in-process, so the effective ceiling is `limit × instances`. It turns "unlimited" into "bounded per instance"; a hard global limit belongs at the edge.
- The root layout is now `async`. Intended — every route that mattered was already dynamic.

## Known, not addressed here

`tests/e2e/timeline-interactions.spec.ts` (29 tests, 799 lines) fails wholesale — pre-existing. It targets `ui-timeline-viewport-smoothscrolllist--*` stories and `data-testid="timeline-editor"`, all deleted in the `packages/ui` pruning (#182–186). It can only ever be red. Left alone deliberately; worth a follow-up to delete it and to get `graph-view` into CI, since that's the gap that let the regression above through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
