### PR TITLE
Give the chrome a grammar, and make the two surfaces look different

### DIFF
--- a/apps/timeline-gstudio001/components/core/dropdown-menu.tsx
+++ b/apps/timeline-gstudio001/components/core/dropdown-menu.tsx
@@ -97,6 +97,47 @@ const DropdownMenuRadioItem = React.forwardRef<
 ));
 DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
 
+/**
+ * A radio item shaped like a BADGE instead of a row.
+ *
+ * For small enumerated values — sizes, densities — where a stack of five
+ * full-width rows costs far more menu height than the choice is worth. Put
+ * several in a `flex-wrap` container and they read as one compact group,
+ * wrapping to a second line when they must.
+ *
+ * Semantically identical to `DropdownMenuRadioItem`: still `menuitemradio`,
+ * still driven by `DropdownMenuRadioGroup`, so exactly one is selected and the
+ * menu's roving focus reaches each one. Only the shape differs, and with it
+ * how "checked" reads — the badge's own fill carries it, so there is no check
+ * indicator and no left gutter reserved for one.
+ *
+ * The focus ring is deliberately a different channel from the checked fill
+ * (ring vs. background): with five badges side by side, "which one is
+ * selected" and "which one am I on" are two different questions and must not
+ * be answered by the same pixel.
+ */
+const DropdownMenuRadioBadge = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "flex-1 cursor-default select-none rounded-sm border px-2 py-1 text-center",
+      "text-[11px] font-semibold tracking-wide tabular-nums outline-none transition-colors",
+      "border-zinc-800 bg-zinc-900/60 text-zinc-400",
+      "data-[state=checked]:border-amber-400/60 data-[state=checked]:bg-amber-400/15 data-[state=checked]:text-amber-200",
+      "focus:ring-2 focus:ring-inset focus:ring-zinc-400 focus:text-zinc-100",
+      "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+));
+DropdownMenuRadioBadge.displayName = "DropdownMenuRadioBadge";
+
 export {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -104,6 +145,7 @@ export {
   DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuRadioBadge,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSeparator,

--- a/apps/timeline-gstudio001/components/core/slider.tsx
+++ b/apps/timeline-gstudio001/components/core/slider.tsx
@@ -5,24 +5,73 @@ import * as SliderPrimitive from "@radix-ui/react-slider";
 
 import { cn } from "@/lib/utils";
 
+/**
+ * Labelling props belong on the THUMB, not the root.
+ *
+ * Radix puts `role="slider"` — and aria-valuenow/valuemin/valuemax — on
+ * `Slider.Thumb`; `Slider.Root` is an unlabelled wrapper. So spreading
+ * `aria-label` onto Root, which this component used to do (along with every
+ * shadcn-derived slider), attaches the name to an element that has no role,
+ * and the control a screen reader actually lands on ends up with NO accessible
+ * name. It reads as correct in the JSX and is silent in use.
+ *
+ * These four are therefore split off the rest and forwarded to the thumb.
+ * `aria-valuetext` earns its place for the same reason: without it a reader
+ * announces a bare number, which on an axis like pixels-per-second says
+ * nothing on its own.
+ */
+type ThumbAriaProps = Pick<
+  React.ComponentPropsWithoutRef<"span">,
+  "aria-label" | "aria-labelledby" | "aria-describedby" | "aria-valuetext"
+>;
+
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <SliderPrimitive.Root
-    ref={ref}
-    className={cn(
-      "relative flex w-full touch-none select-none items-center",
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> &
+    ThumbAriaProps & {
+      /**
+       * Tab-order position of the thumb. Pass `-1` where the slider is a
+       * POINTER affordance for a control that is exposed some other way — a
+       * focusable thumb inside an `aria-hidden` wrapper is itself an
+       * accessibility fault, so hiding one means silencing the other too.
+       */
+      thumbTabIndex?: number;
+    }
+>(
+  (
+    {
       className,
-    )}
-    {...props}
-  >
-    <SliderPrimitive.Track className="relative h-1 w-full grow overflow-hidden rounded-full bg-zinc-800">
-      <SliderPrimitive.Range className="absolute h-full bg-amber-400/70" />
-    </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-3 w-3 rounded-full border border-amber-400 bg-zinc-950 shadow transition-colors hover:bg-zinc-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 disabled:pointer-events-none disabled:opacity-50" />
-  </SliderPrimitive.Root>
-));
+      thumbTabIndex,
+      "aria-label": ariaLabel,
+      "aria-labelledby": ariaLabelledBy,
+      "aria-describedby": ariaDescribedBy,
+      "aria-valuetext": ariaValueText,
+      ...props
+    },
+    ref,
+  ) => (
+    <SliderPrimitive.Root
+      ref={ref}
+      className={cn(
+        "relative flex w-full touch-none select-none items-center",
+        className,
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track className="relative h-1 w-full grow overflow-hidden rounded-full bg-zinc-800">
+        <SliderPrimitive.Range className="absolute h-full bg-amber-400/70" />
+      </SliderPrimitive.Track>
+      <SliderPrimitive.Thumb
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        aria-describedby={ariaDescribedBy}
+        aria-valuetext={ariaValueText}
+        tabIndex={thumbTabIndex}
+        className="block h-3 w-3 rounded-full border border-amber-400 bg-zinc-950 shadow transition-colors hover:bg-zinc-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 disabled:pointer-events-none disabled:opacity-50"
+      />
+    </SliderPrimitive.Root>
+  ),
+);
 Slider.displayName = SliderPrimitive.Root.displayName;
 
 export { Slider };

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -2,7 +2,15 @@
 
 import { useContext, useDeferredValue, useMemo } from "react";
 import { useSearchParams } from "next/navigation";
-import { FolderPlus, Redo2, Settings, Undo2 } from "lucide-react";
+import {
+  Command,
+  FolderPlus,
+  FolderTree,
+  Redo2,
+  Ruler,
+  Settings,
+  Undo2,
+} from "lucide-react";
 
 import {
   CollectionsContainerContext,
@@ -17,6 +25,7 @@ import { flattenMediaOrder } from "@storyboard/timeline-domain";
 
 import { formatDuration } from "@/lib/format-duration";
 import { requestGraphToolInsert } from "@/lib/graph-view-events";
+import { cn } from "@/lib/utils";
 import { Button } from "@/components/core/button";
 import {
   DropdownMenu,
@@ -24,8 +33,9 @@ import {
   DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuRadioBadge,
   DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/core/dropdown-menu";
 import { Slider } from "@/components/core/slider";
@@ -79,11 +89,17 @@ export type { FocusSurface, ItemSize };
  * and the menu itself knows nothing about sizing.
  */
 function BoardMenu({
+  surface,
   itemSize,
   onItemSizeChange,
+  pixelsPerSecond,
+  onPixelsPerSecondChange,
 }: Readonly<{
+  surface: FocusSurface;
   itemSize: ItemSize;
   onItemSizeChange: (size: ItemSize) => void;
+  pixelsPerSecond: number;
+  onPixelsPerSecondChange: (pixelsPerSecond: number) => void;
 }>) {
   return (
     <DropdownMenu>
@@ -99,27 +115,55 @@ function BoardMenu({
           <Settings aria-hidden="true" className="h-4 w-4" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
+      <DropdownMenuContent align="end" className="w-60 p-2">
         <DropdownMenuGroup>
-          <DropdownMenuItem onSelect={() => requestGraphShortcuts()}>
-            Keyboard shortcuts
-            <span className="ml-auto pl-6 font-mono text-[11px] text-zinc-500">?</span>
-          </DropdownMenuItem>
-        </DropdownMenuGroup>
-        <DropdownMenuGroup>
-          <DropdownMenuLabel>Thumbnail size</DropdownMenuLabel>
+          <DropdownMenuLabel className="px-0.5 pb-2 pt-0.5">Thumbnail size</DropdownMenuLabel>
+          {/* BADGES in a wrapping row, not a stack of rows: five sizes as
+              full-width items ate most of the menu's height for a choice that
+              is five short tokens. Still one radio group — exactly one
+              selected, and the menu's roving focus still reaches each badge —
+              only the shape changed. `flex-wrap` lets them take a second line
+              on a narrow menu rather than squeezing past legibility. */}
           <DropdownMenuRadioGroup
+            className="flex flex-wrap gap-1 pt-0.5"
             value={itemSize}
             onValueChange={(value) => {
               if (isItemSize(value)) onItemSizeChange(value);
             }}
           >
             {ITEM_SIZES.map((option) => (
-              <DropdownMenuRadioItem key={option} value={option}>
+              <DropdownMenuRadioBadge key={option} value={option}>
                 {option.toUpperCase()}
-              </DropdownMenuRadioItem>
+              </DropdownMenuRadioBadge>
             ))}
           </DropdownMenuRadioGroup>
+        </DropdownMenuGroup>
+        {/* Zoom is a strip-only axis: grid cells are sized by thumbnail size
+            and the grid playhead ignores clip width, so the control is a
+            no-op there. Omitted rather than shown disabled — same rule the
+            header used when it hosted the slider, and a settings row that
+            can never do anything is worse than one that isn't offered. */}
+        {surface === "strip" ? (
+          <>
+            <DropdownMenuSeparator className="-mx-2 my-2.5" />
+            <ZoomMenuItem
+              pixelsPerSecond={pixelsPerSecond}
+              onChange={onPixelsPerSecondChange}
+            />
+          </>
+        ) : null}
+        {/* LAST, and fenced off: everything above changes this board, while
+            this one leaves it alone and opens a reference sheet. Sections that
+            act and sections that explain do not belong in the same run. */}
+        <DropdownMenuSeparator className="-mx-2 my-2.5" />
+        <DropdownMenuGroup>
+          <DropdownMenuItem onSelect={() => requestGraphShortcuts()}>
+            Keyboard shortcuts
+            <Command
+              aria-hidden="true"
+              className="ml-auto h-3.5 w-3.5 shrink-0 text-zinc-500"
+            />
+          </DropdownMenuItem>
         </DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>
@@ -170,45 +214,187 @@ function FocusedAggregate({
   );
 }
 
+/** One arrow press. Coarse enough to cross the range in a sensible number of
+ *  presses, fine enough to land where you meant. */
+const ZOOM_KEY_STEP = 4;
+
 /**
- * Horizontal zoom. Lives in the header rather than the overflow menu because
- * it is an exploration tool, not a setting — you reach for it WHILE reading
- * the strip, to pull a sub-second clip open or squeeze a minute-long one into
- * view. Burying it behind a menu would cost a click per adjustment.
+ * Horizontal zoom, as a labelled row of the board menu.
+ *
+ * It used to sit bare in the header, and the comment here argued it had to: an
+ * exploration tool reached WHILE reading the strip, where a menu would cost a
+ * click per adjustment. That was the old call; the menu is where it lives now.
+ * The trade is real and worth naming rather than pretending away — a zoom
+ * sweep is open-menu-then-drag — but the header buys back the width, and the
+ * control gains a visible name, a readable value, and units.
+ *
+ * WHY THE ROW IS THE CONTROL, and not a `<Slider>` a keyboard user focuses.
+ *
+ * A `role="menu"` navigates between menu ITEMS. Radix implements exactly that:
+ * its roving focus walks `menuitem`/`menuitemradio` and nothing else. A slider
+ * dropped in as a child is therefore unreachable by arrow keys — measured, not
+ * assumed: focus went straight from the last size badge to "Keyboard
+ * shortcuts", skipping the thumb. It was also invalid composition, since a
+ * `slider` is not something a menu may contain.
+ *
+ * So the MENU ITEM owns the value: Left/Right adjust it, and its accessible
+ * name carries the current reading. The `<Slider>` beneath is the pointer
+ * affordance and the visual — `aria-hidden`, with its thumb out of the tab
+ * order so nothing focusable hides inside a hidden subtree.
+ *
+ * Up/Down are deliberately NOT claimed: they keep moving through the menu, so
+ * the horizontal keys drive the horizontal control and the vertical keys drive
+ * the vertical list. Nothing to learn.
  */
-function ScaleSlider({
+function ZoomMenuItem({
   pixelsPerSecond,
   onChange,
 }: Readonly<{
   pixelsPerSecond: number;
   onChange: (pixelsPerSecond: number) => void;
 }>) {
+  const value = Math.round(pixelsPerSecond);
+  const stepBy = (delta: number) =>
+    onChange(Math.min(MAX_TIMELINE_PPS, Math.max(MIN_TIMELINE_PPS, value + delta)));
+
   return (
-    // Compact, label-less: the tooltip carries what it does AND the live
-    // value (the slider's own aria-valuenow has it too) — the header row
-    // earns back the label's width.
-    <div
-      className="flex w-24 shrink-0 items-center"
-      title={`Timeline zoom — stretch or squeeze the strip's time scale (${Math.round(pixelsPerSecond)} px/s)`}
+    <DropdownMenuItem
+      data-board-menu-zoom
+      // Selecting must not close the menu: this row is a control you stay on,
+      // not a command you fire.
+      onSelect={(event) => event.preventDefault()}
+      onKeyDown={(event) => {
+        if (event.key === "ArrowRight") stepBy(ZOOM_KEY_STEP);
+        else if (event.key === "ArrowLeft") stepBy(-ZOOM_KEY_STEP);
+        else if (event.key === "Home") onChange(MIN_TIMELINE_PPS);
+        else if (event.key === "End") onChange(MAX_TIMELINE_PPS);
+        else return;
+        // Claimed — the menu must not also act on it.
+        event.preventDefault();
+        event.stopPropagation();
+      }}
+      // The whole reading, in the name: what it is, where it stands, and how
+      // to move it. A menu item announcing only "Timeline zoom" would leave a
+      // screen-reader user with no idea the arrows do anything here.
+      aria-label={`Timeline zoom, ${value} pixels per second. Left and right arrow keys adjust.`}
+      aria-keyshortcuts="ArrowLeft ArrowRight"
+      className="flex-col items-stretch gap-1.5 py-2 focus:bg-zinc-900"
     >
-      <Slider
-        aria-label="Timeline scale"
-        min={MIN_TIMELINE_PPS}
-        max={MAX_TIMELINE_PPS}
-        step={1}
-        value={[pixelsPerSecond]}
-        onValueChange={([next]) => onChange(next)}
-      />
-    </div>
+      <span aria-hidden="true" className="flex items-baseline justify-between gap-3">
+        <span className="text-[10px] font-semibold uppercase tracking-[0.14em] text-zinc-500">
+          Timeline zoom
+        </span>
+        <span
+          data-board-menu-zoom-value
+          className="font-mono text-[11px] tabular-nums text-zinc-400"
+        >
+          {value} px/s
+        </span>
+      </span>
+      <span aria-hidden="true" className="block py-0.5">
+        <Slider
+          thumbTabIndex={-1}
+          min={MIN_TIMELINE_PPS}
+          max={MAX_TIMELINE_PPS}
+          step={1}
+          value={[value]}
+          onValueChange={([next]) => {
+            if (typeof next === "number") onChange(next);
+          }}
+        />
+      </span>
+      <span aria-hidden="true" className="text-[11px] leading-snug text-zinc-500">
+        Stretch or squeeze the strip&apos;s time scale.
+      </span>
+    </DropdownMenuItem>
+  );
+}
+
+/**
+ * The ACTIVE styling shared by every toggle in this row: an ACCENT TINT — a
+ * low-opacity sky wash under a sky glyph.
+ *
+ * The contrast comes from the GLYPH, not from a slab behind it. These are
+ * toolbar toggles sitting inches from the board's own content, so an active
+ * one has to be obvious without becoming the brightest object on the screen —
+ * which is exactly what the previous treatment (a near-white fill, near-black
+ * glyph) did: with three toggles lit, the toolbar out-shouted the timeline it
+ * was there to control.
+ *
+ * The tint is deliberately weak. It exists to bound the accent, not to be seen
+ * on its own; the colour is doing the work.
+ *
+ * SKY, and specifically `sky-300` on the glyph, because that is the colour of
+ * PLAYED time on the seek rail (`data-rail-fill` is `bg-sky-300/80`). The rail
+ * is where this app already says "this is live, this is what is on", so an
+ * active toggle borrowing it inherits a meaning the user has been reading all
+ * along instead of introducing a hue that means nothing yet.
+ *
+ * Not amber: amber means SELECTION here — selected cards, trim handles, the
+ * focus ring. A toggle being on is a different fact from a card being chosen,
+ * and the two are on screen together during a drag.
+ *
+ * The rail uses the same accent as an indicator BAR rather than a tint (see
+ * SIDEBAR_ICON_PRESSED / SIDEBAR_ICON_TOGGLE_ON) — nav reads as position, a
+ * toggle reads as on/off. One hue, two treatments; keep them in step.
+ *
+ * The idle half keeps the plain ghost treatment it shares with the undo, redo
+ * and menu buttons beside it, so an inactive toggle still reads as one of that
+ * cluster rather than a control in a scheme of its own.
+ */
+const HEADER_TOGGLE_ACTIVE =
+  "bg-sky-400/15 text-sky-300 hover:bg-sky-400/25 hover:text-sky-200";
+const HEADER_TOGGLE_IDLE = "text-zinc-400 hover:text-zinc-100";
+
+/**
+ * A view toggle in the breadcrumb row: time ruler, preview pane, children
+ * timelines — all moved here from the icon sidebar.
+ *
+ * ONE component because the three are the same control with a different glyph,
+ * and because their active styling has to stay identical. It was three
+ * near-copies before this, which is exactly how the styling drifts.
+ */
+function HeaderToggle({
+  active,
+  onToggle,
+  icon: Icon,
+  label,
+  title,
+}: Readonly<{
+  active: boolean;
+  onToggle: () => void;
+  icon: React.ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
+  /**
+   * Reflects STATE, not just the control — "Hide …" once on, "Show …" once
+   * off. These are the exact names the sidebar buttons carried, so assistive
+   * tech (and the e2e that drives them) sees controls that MOVED rather than
+   * ones that vanished and were replaced by new ones.
+   */
+  label: string;
+  title: string;
+}>) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      aria-label={label}
+      aria-pressed={active}
+      title={title}
+      onClick={onToggle}
+      className={cn("h-8 w-8", active ? HEADER_TOGGLE_ACTIVE : HEADER_TOGGLE_IDLE)}
+    >
+      <Icon aria-hidden className="h-4 w-4" />
+    </Button>
   );
 }
 
 /**
  * Undo/redo as ICON buttons, matching the toolbar's other ghost icon controls
- * (preview, children) rather than the package's generic text-label
- * `UndoRedoControls`. App-local on purpose: the icon styling is this toolbar's
- * design, so it stays out of the framework-agnostic package — but the store
- * wiring (and best-effort announce) is exactly the package control's.
+ * rather than the package's generic text-label `UndoRedoControls`. App-local
+ * on purpose: the icon styling is this toolbar's design, so it stays out of
+ * the framework-agnostic package — but the store wiring (and best-effort
+ * announce) is exactly the package control's.
  */
 function GraphUndoRedo() {
   const store = useCollectionsStore();
@@ -321,8 +507,10 @@ export function GraphBoard({
   onPixelsPerSecondChange,
   previewOn,
   rulerOn,
+  onRulerToggle,
   flatOn,
   childrenShown,
+  onChildrenToggle,
   timeChannel,
   trashRootId,
   syncEntries,
@@ -338,15 +526,25 @@ export function GraphBoard({
   onItemSizeChange: (size: ItemSize) => void;
   pixelsPerSecond: number;
   onPixelsPerSecondChange: (pixelsPerSecond: number) => void;
-  /** Toggled from the SIDEBAR's preview icon; the board only renders it. */
+  /** The preview pane above the board. The board RENDERS it; the toggle
+   *  lives in the icon rail (timeline-sidebar) and reaches this state through
+   *  the window-event bus, which the pane's own close button and the WebMCP
+   *  `set_preview` tool already share. */
   previewOn: boolean;
-  /** Toggled from the SIDEBAR's ruler icon (strip mode only). */
+  /** The strip's time ruler. Its toggle lives in this header now (see
+   *  `GraphRulerToggle`) and only mounts in flat mode, so the board both
+   *  renders the state and asks for the change. */
   rulerOn: boolean;
+  onRulerToggle: () => void;
   /** Strip's flat mode: render the whole closure in order, not this
    *  collection's direct children. */
   flatOn: boolean;
-  /** Toggled from the SIDEBAR's children icon; the board only renders it. */
+  /** Whether the nested-timeline tree renders below the focused surface. The
+   *  toggle for it lives in this header now (see `GraphChildrenToggle`), so
+   *  unlike the sidebar-driven flags around it the board both renders the
+   *  state and asks for the change. */
   childrenShown: boolean;
+  onChildrenToggle: () => void;
   timeChannel: PreviewTimeChannel;
   trashRootId: string | null;
   syncEntries: readonly SyncEntry[];
@@ -472,23 +670,39 @@ export function GraphBoard({
                   off from the surface/history controls to its right. */}
               <GraphAddCollectionButton />
               <div aria-hidden="true" className="h-5 w-px shrink-0 bg-zinc-700" />
-              {/* px/s is a strip-only axis: grid cells are sized by thumbnail
-                  size, and the grid playhead ignores clip width, so the slider
-                  is a no-op in grid mode. Hidden there (state is preserved, so
-                  returning to strip restores the last zoom). */}
-              {surface === "strip" ? (
-                <>
-                  <ScaleSlider
-                    pixelsPerSecond={pixelsPerSecond}
-                    onChange={onPixelsPerSecondChange}
-                  />
-                  <div aria-hidden="true" className="h-5 w-px shrink-0 bg-zinc-700" />
-                </>
+              {/* The VIEW group: what the board shows. Fenced on both sides so
+                  the cluster reads as create | view | history | settings, and
+                  the fences stay put as its contents come and go — the ruler
+                  exists only in flat mode.
+
+                  PREVIEW is deliberately not here. It lives in the icon rail
+                  (see timeline-sidebar) because it is one of the two controls
+                  worth promoting to rail scale; this row keeps the ones that
+                  only qualify the board in front of you. */}
+              {flatOn ? (
+                <HeaderToggle
+                  active={rulerOn}
+                  onToggle={onRulerToggle}
+                  icon={Ruler}
+                  label={rulerOn ? "Hide time ruler" : "Show time ruler"}
+                  title="Time ruler — tick marks over every strip"
+                />
               ) : null}
+              <HeaderToggle
+                active={childrenShown}
+                onToggle={onChildrenToggle}
+                icon={FolderTree}
+                label={childrenShown ? "Hide children timelines" : "Show children timelines"}
+                title="Children timelines — show the nested timeline tree"
+              />
+              <div aria-hidden="true" className="h-5 w-px shrink-0 bg-zinc-700" />
               <GraphUndoRedo />
               <BoardMenu
+                surface={surface}
                 itemSize={itemSize}
                 onItemSizeChange={onItemSizeChange}
+                pixelsPerSecond={pixelsPerSecond}
+                onPixelsPerSecondChange={onPixelsPerSecondChange}
               />
             </DragChromeFade>
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-collection-details.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-collection-details.tsx
@@ -9,6 +9,7 @@ import {
   type CollectionItemNode,
 } from "@storyboard/ui/dnd-collections";
 
+import { useDialogFocus } from "@/hooks/use-dialog-focus";
 import { formatDuration } from "@/lib/format-duration";
 import { collectionPreviewFrameUrl } from "@/lib/video-frame-url";
 
@@ -20,6 +21,7 @@ import {
   useHydratedCollectionSeconds,
 } from "./graph-item-content";
 import { GraphViewNavContext } from "./graph-navigation";
+import { DETAILS_HERO_FILL_CLASS, DETAILS_PANEL_HEIGHT_CLASS } from "./graph-view-config";
 
 // A COLLECTION's details (PL11-012).
 //
@@ -66,6 +68,8 @@ export function CollectionDetailsBody({
     (hydrated ? liveSeconds : (detail?.playableDuration ?? detail?.duration)) ?? 0;
   const previews = useCollectionPreviewFrames(node.id as string, hydrated, detail?.previewItems);
 
+  const { dialogProps } = useDialogFocus<HTMLDivElement>();
+
   const beginRename = rename.begin;
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -99,8 +103,14 @@ export function CollectionDetailsBody({
         if (event.target === event.currentTarget) onClose();
       }}
     >
+      {/* This dialog was left out when the clip modal gained focus management,
+          so it still declared `aria-modal="true"` while doing none of what
+          that promises — focus stayed behind the scrim and Tab walked out into
+          a board the reader had been told was hidden. Same hook, same three
+          behaviours: move in, trap, restore. */}
       <div
-        className="flex w-full max-w-3xl flex-col gap-3 rounded-lg border border-zinc-700 bg-zinc-950 p-4 shadow-2xl shadow-black/60"
+        {...dialogProps}
+        className={`flex w-full max-w-3xl flex-col gap-3 rounded-lg border border-zinc-700 bg-zinc-950 p-4 shadow-2xl shadow-black/60 focus-visible:outline-none ${DETAILS_PANEL_HEIGHT_CLASS}`}
         onPointerDown={(event) => event.stopPropagation()}
       >
         <div className="flex items-center justify-between gap-3">
@@ -161,10 +171,14 @@ export function CollectionDetailsBody({
           </div>
         </div>
 
+        {/* Fills whatever the fixed panel leaves, exactly as the clip modal's
+            hero does — see DETAILS_HERO_FILL_CLASS. This body carries less
+            chrome than the clip's, so its hero simply ends up larger; the
+            dialog itself is the same box either way. */}
         <div
           data-item-details-frame
           style={{ viewTransitionName: hero }}
-          className="flex min-h-32 gap-1 overflow-hidden rounded-md border border-dashed border-sky-500/40 bg-sky-500/[0.06] p-2"
+          className={`flex ${DETAILS_HERO_FILL_CLASS} gap-1 overflow-hidden rounded-md border border-dashed border-sky-500/40 bg-sky-500/[0.06] p-2`}
         >
           {previews.length === 0 ? (
             <span className="flex w-full items-center justify-center font-mono text-[11px] text-zinc-500">
@@ -181,7 +195,12 @@ export function CollectionDetailsBody({
                 src={collectionPreviewFrameUrl(preview)}
                 alt=""
                 draggable={false}
-                className="h-32 min-w-0 flex-1 rounded-sm object-cover"
+                // `object-contain`, not `cover`, now that the frame is tall:
+                // cover would crop a 16:9 still to a near-square column and
+                // throw away most of the shot. Contain letterboxes instead —
+                // the same choice the clip modal's hero makes, and the reason
+                // a fixed height is safe for both.
+                className="h-full min-w-0 flex-1 rounded-sm object-contain"
               />
             ))
           )}

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -907,9 +907,21 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
           // collection is legal at all — so the state needs to stay
           // observable to the drop-policy e2e that asserts on it.
           data-collection-hydrated={hydrated ? "true" : "false"}
+          // The grid-scoped variants are what make the two surfaces read as
+          // different objects rather than the same card wrapped. A grid cell is
+          // boxy and tall (see ITEM_SIZE_DIMENSIONS) precisely so this row can
+          // be a real caption; in the strip it stays a tight one-line footer,
+          // because height there is pure overhead on every clip.
+          //
+          // Scoped by the container's own `data-virtual-grid` marker rather
+          // than by a prop: the card renderer is shared by both surfaces and
+          // has no idea which one it is in, and threading that down just to
+          // change two font sizes would put a layout concern into the item
+          // contract.
           className={[
             "mt-1.5 flex items-center justify-between gap-1.5 pl-1 pb-0.5",
-            muted ? "pr-[4.75rem]" : "pr-1",
+            "[[data-virtual-grid]_&]:mt-2.5 [[data-virtual-grid]_&]:pl-1.5 [[data-virtual-grid]_&]:pb-1.5",
+            muted ? "pr-[4.75rem]" : "pr-1 [[data-virtual-grid]_&]:pr-1.5",
           ].join(" ")}
         >
           <span
@@ -919,11 +931,11 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
               // (keyboard: F2 on the focused card — see OpenKeyBoundary)
             }}
             title="Double-click or press F2 to rename"
-            className="min-w-0 flex-1 cursor-text truncate text-xs font-semibold text-zinc-100"
+            className="min-w-0 flex-1 cursor-text truncate text-xs font-semibold text-zinc-100 [[data-virtual-grid]_&]:text-sm"
           >
             {displayName}
           </span>
-          <span className="flex shrink-0 items-center gap-1 font-mono text-[11px] font-medium text-zinc-300">
+          <span className="flex shrink-0 items-center gap-1 font-mono text-[11px] font-medium text-zinc-300 [[data-virtual-grid]_&]:text-xs">
             {typeof totalSeconds === "number" && totalSeconds > 0 ? (
               <>
                 <span className="text-sky-300/90" title="Total duration of contents">
@@ -966,7 +978,13 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
           event.stopPropagation();
           nav?.openTimeline(id);
         }}
-        className="absolute left-1/2 top-[41%] flex aspect-square h-[34%] -translate-x-1/2 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full bg-zinc-950/70 text-sky-200 ring-1 ring-sky-400/50 backdrop-blur-[2px] transition-colors hover:bg-zinc-900/85 hover:text-sky-100 hover:ring-sky-300"
+        // Sized as a FRACTION of the card so it stays proportionate at every
+        // item size — but the fraction itself has to differ per surface. 34%
+        // of a short strip card is a ~45px target; 34% of the new tall grid
+        // cell is ~75px, which stopped reading as a control on the artwork and
+        // started reading as the artwork. The grid gets a smaller share of a
+        // much bigger card, which lands back at a similar physical size.
+        className="absolute left-1/2 top-[41%] flex aspect-square h-[34%] -translate-x-1/2 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full bg-zinc-950/70 text-sky-200 ring-1 ring-sky-400/50 backdrop-blur-[2px] transition-colors hover:bg-zinc-900/85 hover:text-sky-100 hover:ring-sky-300 [[data-virtual-grid]_&]:h-[24%]"
       >
         {/* CornerRightDown — turn and descend, the verb this control performs:
             NAVIGATE into the timeline. The sidebar's FolderTree toggles whether

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -19,6 +19,7 @@ import {
 } from "@storyboard/ui/dnd-collections";
 
 import { useDialogFocus } from "@/hooks/use-dialog-focus";
+import { DETAILS_HERO_FILL_CLASS, DETAILS_PANEL_HEIGHT_CLASS } from "./graph-view-config";
 import { useSeekedVideo } from "@/hooks/use-seeked-video";
 import { formatSeconds } from "@/lib/format-duration";
 import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
@@ -347,7 +348,7 @@ function ModalBody({ node, onClose }: Readonly<{ node: MediaNode; onClose: () =>
     >
       <div
         {...dialogProps}
-        className="flex w-full max-w-3xl flex-col gap-3 rounded-lg border border-zinc-700 bg-zinc-950 p-4 shadow-2xl shadow-black/60 focus-visible:outline-none"
+        className={`flex w-full max-w-3xl flex-col gap-3 rounded-lg border border-zinc-700 bg-zinc-950 p-4 shadow-2xl shadow-black/60 focus-visible:outline-none ${DETAILS_PANEL_HEIGHT_CLASS}`}
         onPointerDown={(event) => event.stopPropagation()}
       >
         <div className="flex items-center justify-between gap-3">
@@ -420,7 +421,7 @@ function ModalBody({ node, onClose }: Readonly<{ node: MediaNode; onClose: () =>
         <div
           data-item-details-frame
           style={{ viewTransitionName: HERO }}
-          className="relative overflow-hidden rounded-md bg-black"
+          className={`relative overflow-hidden rounded-md bg-black ${DETAILS_HERO_FILL_CLASS}`}
         >
           {video ? (
             <video
@@ -430,14 +431,14 @@ function ModalBody({ node, onClose }: Readonly<{ node: MediaNode; onClose: () =>
               muted
               playsInline
               preload="auto"
-              className="max-h-[46vh] w-full bg-black object-contain"
+              className="h-full w-full bg-black object-contain"
             />
           ) : (
             // eslint-disable-next-line @next/next/no-img-element
             <img
               src={node.src}
               alt={node.name}
-              className="max-h-[46vh] w-full bg-black object-contain"
+              className="h-full w-full bg-black object-contain"
             />
           )}
           {live !== null && (

--- a/apps/timeline-gstudio001/components/graph-view/graph-mcp-tools.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-mcp-tools.tsx
@@ -22,6 +22,7 @@ const INITIAL_VIEW_STATE: GraphViewStateDetail = {
   rulerOn: false,
   childrenShown: false,
   previewOn: false,
+  assetsOpen: false,
     flatOn: false,
     flatLoading: false,
 };

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -42,10 +42,8 @@ import {
 } from "@/lib/graph-documents-gateway";
 import {
   GRAPH_ASSETS_TOGGLE_EVENT,
-  GRAPH_CHILDREN_TOGGLE_EVENT,
   GRAPH_PREVIEW_TOGGLE_EVENT,
   GRAPH_FLAT_TOGGLE_EVENT,
-  GRAPH_RULER_TOGGLE_EVENT,
   GRAPH_SURFACE_EVENT,
   GRAPH_TRASH_EMPTIED_EVENT,
   broadcastGraphViewState,
@@ -188,29 +186,39 @@ export function GraphTimelineView({
       const detail = (event as CustomEvent<GraphSurface>).detail;
       if (detail === "strip" || detail === "grid") setSurface(detail);
     };
-    const onRulerToggle = () => setRulerOn((current) => !current);
     const onFlatToggle = () => setFlatOn((current) => !current);
-    const onChildrenToggle = () => setChildrenShown((current) => !current);
     const onPreviewToggle = () => setPreviewOn((current) => !current);
     window.addEventListener(GRAPH_SURFACE_EVENT, onSurface);
     window.addEventListener(GRAPH_FLAT_TOGGLE_EVENT, onFlatToggle);
-    window.addEventListener(GRAPH_RULER_TOGGLE_EVENT, onRulerToggle);
-    window.addEventListener(GRAPH_CHILDREN_TOGGLE_EVENT, onChildrenToggle);
     window.addEventListener(GRAPH_PREVIEW_TOGGLE_EVENT, onPreviewToggle);
     return () => {
       window.removeEventListener(GRAPH_SURFACE_EVENT, onSurface);
       window.removeEventListener(GRAPH_FLAT_TOGGLE_EVENT, onFlatToggle);
-      window.removeEventListener(GRAPH_RULER_TOGGLE_EVENT, onRulerToggle);
-      window.removeEventListener(GRAPH_CHILDREN_TOGGLE_EVENT, onChildrenToggle);
       window.removeEventListener(GRAPH_PREVIEW_TOGGLE_EVENT, onPreviewToggle);
     };
   }, []);
 
+  // Neither the children toggle NOR the ruler toggle is in that list any more:
+  // both controls moved into the board header, which is inside this
+  // component's own tree, so they call straight down through props. The
+  // window-event bridge exists only to reach the SIDEBAR across React trees —
+  // a control that no longer lives there has no reason to pay for it.
+  const toggleChildren = useCallback(() => setChildrenShown((current) => !current), []);
+  const toggleRuler = useCallback(() => setRulerOn((current) => !current), []);
+
   // …and this broadcast (on mount and every change) is what lets its
   // controls show the current surface, ruler, children, and preview state.
   useEffect(() => {
-    broadcastGraphViewState({ surface, rulerOn, childrenShown, previewOn, flatOn, flatLoading });
-  }, [surface, rulerOn, childrenShown, previewOn, flatOn, flatLoading]);
+    broadcastGraphViewState({
+      surface,
+      rulerOn,
+      childrenShown,
+      previewOn,
+      flatOn,
+      flatLoading,
+      assetsOpen,
+    });
+  }, [surface, rulerOn, childrenShown, previewOn, flatOn, flatLoading, assetsOpen]);
 
   // Flat mode is a STRIP reading. Leaving strip drops it rather than letting it
   // sit armed and re-apply invisibly on the way back — the grid never showed a
@@ -673,8 +681,10 @@ export function GraphTimelineView({
                 onPixelsPerSecondChange={setPixelsPerSecond}
                 previewOn={previewOn}
                 rulerOn={rulerOn}
+                onRulerToggle={toggleRuler}
                 flatOn={flatOn}
                 childrenShown={childrenShown}
+                onChildrenToggle={toggleChildren}
                 timeChannel={timeChannel}
                 trashRootId={boot.trashRootId}
                 syncEntries={syncLog}

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-config.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-config.ts
@@ -53,21 +53,37 @@ export function isItemSize(value: string): value is ItemSize {
  * pixels-per-second, so the horizontal time scale is the zoom slider's job,
  * not the size control's — a size change must never move the playhead there.
  *
- * GRID scales BOTH dimensions, proportionally: a grid cell's width is unrelated
- * to duration (it is a wrapped 2-D layout), so scaling only its height stretched
- * cells into wide-short rectangles. Width and height move together now, keeping
- * a ~16:10 thumbnail at every step. The column count is width-derived, so bigger
- * cells simply wrap into fewer columns.
+ * GRID scales BOTH dimensions. A grid cell's width is unrelated to duration (it
+ * is a wrapped 2-D layout), so scaling only its height stretched cells into
+ * wide-short rectangles. The column count is width-derived, so bigger cells
+ * simply wrap into fewer columns.
  *
- * `md` is the default; the ladder was rescaled up so the smallest step is a
- * usable "sm-like" size rather than a cramped one.
+ * WHY THE TWO NO LONGER SHARE A HEIGHT. `strip` and `gridHeight` used to be the
+ * SAME NUMBER at every step (132 and 132 at `lg`), and the grid card was the
+ * strip card at the same size — so switching surfaces produced a layout that
+ * looked identical, wrapped. The difference between them is real and large, and
+ * nothing on screen said so.
+ *
+ * They are now deliberately different shapes, not just different arrangements:
+ *
+ *   - The strip stays SHORT and wide, because width there is time and height is
+ *     only legibility. A tall strip wastes vertical space on every row.
+ *   - The grid goes TALL and boxy — roughly 5:4 rather than the old 16:10. A
+ *     cell that is not measuring anything can afford to be a card: a big
+ *     thumbnail with a label that is actually readable under it (the metadata
+ *     row grows to match — see `graph-item-content`).
+ *
+ * At `lg` that is a 220px grid cell against a 132px strip card, and roughly
+ * four columns across the board's max width instead of six. Fewer, bigger,
+ * squarer — a different way of looking at the same timeline, which is what the
+ * surface switch is for.
  */
 export const ITEM_SIZE_DIMENSIONS = {
-  xs: { strip: 56, gridWidth: 90, gridHeight: 56 },
-  sm: { strip: 76, gridWidth: 122, gridHeight: 76 },
-  md: { strip: 100, gridWidth: 160, gridHeight: 100 },
-  lg: { strip: 132, gridWidth: 211, gridHeight: 132 },
-  xl: { strip: 172, gridWidth: 275, gridHeight: 172 },
+  xs: { strip: 56, gridWidth: 132, gridHeight: 104 },
+  sm: { strip: 76, gridWidth: 168, gridHeight: 132 },
+  md: { strip: 100, gridWidth: 216, gridHeight: 170 },
+  lg: { strip: 132, gridWidth: 280, gridHeight: 220 },
+  xl: { strip: 172, gridWidth: 360, gridHeight: 284 },
 } as const satisfies Record<
   ItemSize,
   { strip: number; gridWidth: number; gridHeight: number }
@@ -134,3 +150,36 @@ export const FALLBACK_DETAIL: ClipDetail = {
  * derived from one source.
  */
 export const SUBTIMELINE_PANEL_RIGHT_INSET_PX = 13;
+
+/**
+ * The details dialog's PANEL box, shared by the clip modal and the collection
+ * modal so the two are one dialog that shows different things — not two
+ * dialogs of different size.
+ *
+ * They had drifted badly: same `max-w-3xl` width, but 588px tall against 253px
+ * (measured at an 871px viewport), so moving between a clip and a timeline
+ * resized the box by a third of the screen.
+ *
+ * The height is FIXED here rather than left to the content, because the two
+ * bodies carry different chrome — the clip's has trim numbers and a source
+ * strip the collection's has no equivalent for, worth ~81px. Matching only the
+ * heroes still left that gap. Fixing the panel and letting each hero absorb
+ * the remainder (see `DETAILS_HERO_FILL_CLASS`) is what makes them identical:
+ * the clip gets a slightly smaller hero because it spends more on controls,
+ * and the box never changes.
+ *
+ * `max-h-full` keeps it inside the scrim's padding on short viewports, where a
+ * flat 68vh would otherwise be the taller constraint.
+ */
+export const DETAILS_PANEL_HEIGHT_CLASS = "h-[68vh] max-h-full";
+
+/**
+ * How a details hero fills whatever the panel's fixed height leaves it.
+ *
+ * `min-h-0` is not optional: a flex child's default `min-height: auto` refuses
+ * to shrink below its content, so without it a tall video would push the panel
+ * past its fixed height and the two dialogs would disagree again — the exact
+ * failure this pair exists to prevent. Both heroes render with
+ * `object-contain`, so the space they are given letterboxes rather than crops.
+ */
+export const DETAILS_HERO_FILL_CLASS = "min-h-0 flex-1";

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -6,18 +6,16 @@ import {
   CircleCheck,
   ClipboardPaste,
   Copy,
+  ChevronsLeftRightEllipsis,
   CopyPlus,
   EllipsisVertical,
+  Film,
   Folder,
-  FolderTree,
-  GalleryHorizontalEnd,
   Image as ImageIcon,
   Layers,
-  LayoutGrid,
-  ListOrdered,
   LogOut,
-  Ruler,
   Scissors,
+  Table,
   Trash2,
   TvMinimal,
   X,
@@ -33,11 +31,9 @@ import {
   GRAPH_TRASH_HOVER_EVENT,
   GRAPH_VIEW_STATE_EVENT,
   isGraphViewRoute,
-  requestGraphChildrenToggle,
   requestGraphItemAction,
-  requestGraphPreviewToggle,
   requestGraphFlatToggle,
-  requestGraphRulerToggle,
+  requestGraphPreviewToggle,
   requestGraphSurface,
   type GraphItemAction,
   type GraphSelectionDetail,
@@ -103,20 +99,91 @@ function MediaFolderIcon({ className }: Readonly<{ className?: string }>) {
 // rail's width and `aspect-square` makes the height follow it. Sized this way
 // rather than with a fixed `size-*` so the two can never drift — change the
 // rail's width and every tile (and the logo) resizes with it.
-const SIDEBAR_ICON_BASE =
-  "group/sidebar-item relative flex w-full aspect-square items-center justify-center transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-zinc-400";
+/**
+ * A tile's BOX, which is not the same thing as the shape you see.
+ *
+ * The box stays `w-full aspect-square` — that is what keeps the rail's rhythm
+ * even and the tiles on one grid. What you actually see is the `::before`
+ * layer, inset from that box, so every fill (idle, hover, pressed, disabled)
+ * paints as a rounded pill floating inside its square rather than a band
+ * running edge to edge. They used to be the same rectangle, so an active tile
+ * read as a full-width stripe across the rail.
+ *
+ * The fills therefore live on `before:*` in each state constant below, never
+ * on the button. The focus ring moved with them for the same reason: a
+ * square inset ring around a pill highlight would have described a shape that
+ * is no longer there.
+ */
+const SIDEBAR_ICON_BASE = [
+  "group/sidebar-item relative flex w-full aspect-square items-center justify-center",
+  "transition-all duration-200 focus-visible:outline-none",
+  "before:absolute before:inset-2 before:rounded-2xl before:transition-colors before:content-['']",
+  "focus-visible:before:ring-2 focus-visible:before:ring-zinc-400",
+].join(" ");
 /** The glyph inside a tile. Larger than the old h-4: legibility is the point
- *  of the bigger tiles, and a 16px icon in a 72px square reads as a dot. */
-const SIDEBAR_GLYPH = "h-7 w-7 [stroke-width:1.5] transition-colors";
+ *  of the bigger tiles, and a 16px icon in a 72px square reads as a dot.
+ *
+ *  `relative` is load-bearing: the pill above is an absolutely-positioned
+ *  pseudo-element, so a statically-positioned glyph would paint UNDER it. */
+const SIDEBAR_GLYPH = "relative h-7 w-7 [stroke-width:1.5] transition-colors";
 const SIDEBAR_ICON_IDLE =
-  "bg-zinc-900/40 text-zinc-400 hover:bg-zinc-800/80 hover:text-zinc-100";
-// No `translate-y-px` any more: with the tiles flush against each other, a
-// pressed tile nudging down by a pixel opened a hairline seam above it and
-// read as misalignment rather than as a press. The lifted background and the
-// inset shadow carry the state on their own.
-const SIDEBAR_ICON_PRESSED =
-  "bg-zinc-800 text-zinc-100 shadow-inner shadow-black/50";
-const SIDEBAR_SEPARATOR_CLASS = "mx-auto my-2 h-px w-7 shrink-0";
+  "text-zinc-400 before:bg-zinc-900/40 hover:text-zinc-100 hover:before:bg-zinc-800/80";
+/**
+ * The active tile: an INDICATOR BAR at the rail's edge, over a quietly lifted
+ * pill.
+ *
+ * This is the nav treatment. The rail answers "where am I", and a bar riding
+ * the edge reads as a POSITION in a list — the same signal a browser tab or an
+ * IDE gutter uses — where a filled tile only reads as a button someone pressed.
+ *
+ * It replaces a full inversion (near-white pill, near-black glyph). That was
+ * legible, but it made the active tile the brightest object on the screen,
+ * competing with the board it was only labelling; with several toggles lit at
+ * once the rail became the loudest thing in the app. The bar is louder in the
+ * only way that matters — position — while the tile itself stays quiet.
+ *
+ * The bar is anchored to the TILE edge, not the pill: it belongs to the rail's
+ * left boundary, so it stays put while the pill floats inset from it.
+ *
+ * No `translate-y-px`: a pressed tile nudging down by a pixel opened a hairline
+ * seam above it and read as misalignment rather than as a press.
+ */
+const SIDEBAR_ICON_PRESSED = [
+  "text-zinc-50 before:bg-zinc-800",
+  "after:absolute after:left-0 after:top-1/2 after:h-7 after:w-[3px]",
+  "after:-translate-y-1/2 after:rounded-r-full after:bg-sky-300 after:content-['']",
+].join(" ");
+
+/**
+ * The active state for a rail tile that is a TOGGLE rather than a place.
+ *
+ * Identical to `HEADER_TOGGLE_ACTIVE` in graph-board.tsx — an accent tint,
+ * carried on the pill instead of the button because that is where this rail
+ * paints its fills. Keep the two in step.
+ *
+ * The distinction the rail draws is location vs. state, not sidebar vs.
+ * toolbar. Grid and Strip say WHERE you are, so they get the indicator bar
+ * above. Flat mode, preview, and the two drawers change what is ON without
+ * moving you — the same kind of fact as the ruler toggle in the breadcrumb
+ * row, and they should read like it rather than like more destinations.
+ *
+ * `sky-300` is the seek rail's PLAYED-time colour (`bg-sky-300/80`), which is
+ * where this app already says "this is live". Both treatments share it — bar
+ * and tint differ in SHAPE, not hue, so the rail reads as one system.
+ */
+const SIDEBAR_ICON_TOGGLE_ON =
+  "text-sky-300 before:bg-sky-400/15 hover:text-sky-200 hover:before:bg-sky-400/25";
+/**
+ * The rule between tile groups: longer than the glyphs it separates, with air
+ * above and below.
+ *
+ * It has been both extremes. Flush against the tiles it disappeared into them;
+ * as a short 28px hairline with 8px of margin it read as a gap the tiles had
+ * fallen out of. What makes it work is the pill treatment above — the tiles no
+ * longer run edge to edge either, so a wider rule with matching breathing room
+ * sits in the same rhythm instead of interrupting one.
+ */
+const SIDEBAR_SEPARATOR_CLASS = "mx-auto my-2 h-px w-10 shrink-0";
 
 function SidebarSeparator({ selected = false }: Readonly<{ selected?: boolean }>) {
   return (
@@ -129,6 +196,22 @@ function SidebarSeparator({ selected = false }: Readonly<{ selected?: boolean }>
       )}
     />
   );
+}
+
+/**
+ * The strip layout's glyph: lucide's `Film`, turned on its side.
+ *
+ * The icon is drawn with its sprocket holes down the left and right edges — a
+ * reel standing upright. The surface it names runs HORIZONTALLY, so a quarter
+ * turn puts the perforations along the top and bottom and the frame divisions
+ * across it, which is what a strip of film actually looks like laid out flat.
+ *
+ * A wrapper rather than an `iconClassName` prop on the control: the rotation
+ * belongs to this glyph, not to the control that happens to render it, and
+ * `SurfaceIconControl` already takes any `ComponentType<{ className?: string }>`.
+ */
+function FilmStripGlyph({ className }: { className?: string }) {
+  return <Film className={cn(className, "rotate-90")} />;
 }
 
 type SurfaceIconControlProps = {
@@ -192,12 +275,12 @@ function SurfaceIconControl({
 // reads as available-but-not-now, and the flat border plus the missing hover
 // response carry "disabled" on their own.
 const SIDEBAR_ICON_DISABLED =
-  "cursor-not-allowed bg-zinc-900/20 text-zinc-500";
+  "cursor-not-allowed text-zinc-500 before:bg-zinc-900/20";
 
 // Item mode borrows a restrained trace of the selection colour. These actions
 // relate to the selected card, but should remain secondary to the content.
 const SIDEBAR_ICON_ITEM_IDLE =
-  "bg-amber-200/[0.035] text-amber-100/60 hover:bg-amber-200/[0.075] hover:text-amber-100/85";
+  "text-amber-100/60 before:bg-amber-200/[0.035] hover:text-amber-100/85 hover:before:bg-amber-200/[0.075]";
 
 /** One button in the item-actions cluster — dispatches its action across the
  *  window-event seam for the graph provider to perform on the selection. */
@@ -449,6 +532,7 @@ export function TimelineSidebar() {
     rulerOn: false,
     childrenShown: false,
     previewOn: false,
+    assetsOpen: false,
     flatOn: false,
     flatLoading: false,
   });
@@ -578,7 +662,7 @@ export function TimelineSidebar() {
             surface="grid"
             onGraphRoute={onGraphRoute}
             href={graphHref}
-            icon={LayoutGrid}
+            icon={Table}
             isActive={onGraphRoute && graphView.surface === "grid"}
             label="Grid layout"
             description="Graph timelines as grids"
@@ -587,7 +671,7 @@ export function TimelineSidebar() {
             surface="strip"
             onGraphRoute={onGraphRoute}
             href={`${graphHref}?surface=strip`}
-            icon={GalleryHorizontalEnd}
+            icon={FilmStripGlyph}
             isActive={onGraphRoute && graphView.surface === "strip"}
             label="Strip layout"
             description="Graph timelines as strips"
@@ -601,8 +685,18 @@ export function TimelineSidebar() {
           <SidebarSeparator />
 
           <div className="flex w-full flex-col items-stretch gap-0">
-            {/* The preview-pane toggle leads the cluster (was the breadcrumb
-                row's TV icon). */}
+            {/* PREVIEW leads this group, directly under the separator.
+
+                It is a toggle, not a destination, so it wears the tint rather
+                than the indicator bar — but it sits in the rail rather than
+                with the other toggles in the breadcrumb row because it is one
+                of the two controls worth calling out at rail scale. The rail
+                is where the eye goes first; giving up a slot there is how a
+                control gets promoted above the toolbar's noise.
+
+                Ungated by surface deliberately: the pane plays the focused
+                timeline in grid as well as strip, so hiding it in grid would
+                remove a working control. */}
             {onGraphRoute && (
               <button
                 type="button"
@@ -612,7 +706,7 @@ export function TimelineSidebar() {
                 onClick={requestGraphPreviewToggle}
                 className={cn(
                   SIDEBAR_ICON_BASE,
-                  graphView.previewOn ? SIDEBAR_ICON_PRESSED : SIDEBAR_ICON_IDLE,
+                  graphView.previewOn ? SIDEBAR_ICON_TOGGLE_ON : SIDEBAR_ICON_IDLE,
                 )}
               >
                 <TvMinimal className={SIDEBAR_GLYPH} />
@@ -624,33 +718,8 @@ export function TimelineSidebar() {
               </button>
             )}
 
-            {/* The children-timelines toggle. (The Collection tool moved to
-                the board's breadcrumb row, and its card-drag trash target
-                moved there too — the sidebar no longer hosts either.) */}
-            {onGraphRoute && (
-              <button
-                type="button"
-                aria-pressed={graphView.childrenShown}
-                aria-label={
-                  graphView.childrenShown
-                    ? "Hide children timelines"
-                    : "Show children timelines"
-                }
-                aria-describedby="sidebar-tooltip-children"
-                onClick={requestGraphChildrenToggle}
-                className={cn(
-                  SIDEBAR_ICON_BASE,
-                  graphView.childrenShown ? SIDEBAR_ICON_PRESSED : SIDEBAR_ICON_IDLE,
-                )}
-              >
-                <FolderTree className={SIDEBAR_GLYPH} />
-                <SidebarTooltipLabel
-                  id="sidebar-tooltip-children"
-                  label="Children timelines"
-                  description="Show the nested timeline tree"
-                />
-              </button>
-            )}
+            {/* The children-timelines toggle is in the board's breadcrumb row
+                (see graph-board), alongside the ruler. */}
 
             {/* Flat mode — strip only. Grid keeps its nesting, so there is
                 nothing to flatten there. */}
@@ -664,10 +733,11 @@ export function TimelineSidebar() {
                 onClick={requestGraphFlatToggle}
                 className={cn(
                   SIDEBAR_ICON_BASE,
-                  graphView.flatOn ? SIDEBAR_ICON_PRESSED : SIDEBAR_ICON_IDLE,
+                  // TOGGLE, not a destination — see SIDEBAR_ICON_TOGGLE_ON.
+                  graphView.flatOn ? SIDEBAR_ICON_TOGGLE_ON : SIDEBAR_ICON_IDLE,
                 )}
               >
-                <ListOrdered
+                <ChevronsLeftRightEllipsis
                   className={cn(
                     SIDEBAR_GLYPH,
                     // Loading the closure can take a moment on a deep project,
@@ -688,34 +758,10 @@ export function TimelineSidebar() {
               </button>
             )}
 
-            {/* The strip's time-ruler toggle, BELOW flat mode and scoped to
-                it: a ruler is a single continuous time axis, which only the
-                flat run actually is. In the nested strip a collection card
-                holds an arbitrary duration in a fixed width, so the ticks
-                beside it measure nothing the user can act on. Grid has no
-                time axis at all. Flat turning off also turns the ruler off
-                (see graph-timeline-view) — otherwise this control vanishes
-                while its ruler stays painted. */}
-            {onGraphRoute && graphView.surface === "strip" && graphView.flatOn && (
-              <button
-                type="button"
-                aria-pressed={graphView.rulerOn}
-                aria-label={graphView.rulerOn ? "Hide time ruler" : "Show time ruler"}
-                aria-describedby="sidebar-tooltip-ruler"
-                onClick={requestGraphRulerToggle}
-                className={cn(
-                  SIDEBAR_ICON_BASE,
-                  graphView.rulerOn ? SIDEBAR_ICON_PRESSED : SIDEBAR_ICON_IDLE,
-                )}
-              >
-                <Ruler className={SIDEBAR_GLYPH} />
-                <SidebarTooltipLabel
-                  id="sidebar-tooltip-ruler"
-                  label="Time ruler"
-                  description="Tick marks over every strip"
-                />
-              </button>
-            )}
+            {/* The time-ruler toggle moved to the board's breadcrumb row,
+                sitting left of the children toggle. It is still scoped to flat
+                mode and still appears and disappears with it — only its home
+                changed, joining the view controls it belongs with. */}
           </div>
         </>
       )}
@@ -732,7 +778,12 @@ export function TimelineSidebar() {
 
           const Icon = item.icon;
           const tooltipId = `sidebar-tooltip-utility-${item.id}`;
-          const isPressed = item.id === "trash" && isTrashOpen;
+          // Both drawers report their real state now. Assets used to be
+          // hard-coded false here — the graph view owns `assetsOpen` and did
+          // not publish it, so this button permanently claimed to be off while
+          // toggling a drawer.
+          const isPressed =
+            item.id === "trash" ? isTrashOpen : graphView.assetsOpen;
           const handleClick =
             item.id === "assets"
               ? () => {
@@ -753,7 +804,11 @@ export function TimelineSidebar() {
               onClick={handleClick}
               className={cn(
                 SIDEBAR_ICON_BASE,
-                isPressed ? SIDEBAR_ICON_PRESSED : SIDEBAR_ICON_IDLE,
+                // Assets and Trash open a DRAWER over the board; they do not
+                // take you anywhere, and the board behind them is still the
+                // page you are on. That makes them state, not location — the
+                // tint, like flat mode above (see SIDEBAR_ICON_TOGGLE_ON).
+                isPressed ? SIDEBAR_ICON_TOGGLE_ON : SIDEBAR_ICON_IDLE,
               )}
             >
               <Icon

--- a/apps/timeline-gstudio001/lib/graph-view-events.ts
+++ b/apps/timeline-gstudio001/lib/graph-view-events.ts
@@ -45,11 +45,16 @@ export function requestGraphToolInsert(tool: GraphInsertTool): void {
 // (on mount and on every change) so the sidebar controls can reflect it.
 
 export const GRAPH_SURFACE_EVENT = "graph-view:set-surface";
-export const GRAPH_RULER_TOGGLE_EVENT = "graph-view:toggle-ruler";
+// No ruler-toggle event either, for the same reason as the children one below:
+// that control moved into the board header and calls a prop.
 /** Strip only: show every item in the focused closure in playback order, with
  *  no collections and no nesting. */
 export const GRAPH_FLAT_TOGGLE_EVENT = "graph-view:toggle-flat";
-export const GRAPH_CHILDREN_TOGGLE_EVENT = "graph-view:toggle-children";
+// No children-toggle event: that control moved into the board header, which
+// renders inside the graph provider's own tree, so it calls a prop instead.
+// This bridge is for the SIDEBAR — app chrome in a different React tree — and
+// nothing else should pay for it. `childrenShown` below is still published:
+// the STATE is part of what the view reports, only the command is gone.
 export const GRAPH_PREVIEW_TOGGLE_EVENT = "graph-view:toggle-preview";
 export const GRAPH_VIEW_STATE_EVENT = "graph-view:view-state";
 
@@ -61,6 +66,12 @@ export type GraphViewStateDetail = Readonly<{
   rulerOn: boolean;
   childrenShown: boolean;
   previewOn: boolean;
+  /** Whether the asset palette drawer is open. The SIDEBAR owns that button
+   *  but not the state, so without this published it could not show the
+   *  drawer as open — it reported `aria-pressed="false"` permanently while
+   *  actually toggling one, which is a lie to assistive tech as well as a
+   *  missing highlight. */
+  assetsOpen: boolean;
   /** Strip's flat mode. Strip-only, like the ruler — grid has no equivalent. */
   flatOn: boolean;
   /** True while flat mode is loading the closure it needs (every nested
@@ -76,19 +87,9 @@ export function requestGraphSurface(surface: GraphSurface): void {
   );
 }
 
-/** Ask the graph view to toggle the strip's time ruler. */
-export function requestGraphRulerToggle(): void {
-  window.dispatchEvent(new Event(GRAPH_RULER_TOGGLE_EVENT));
-}
-
 /** Ask the strip to toggle flat mode (all items in order, no nesting). */
 export function requestGraphFlatToggle(): void {
   window.dispatchEvent(new Event(GRAPH_FLAT_TOGGLE_EVENT));
-}
-
-/** Ask the graph view to toggle the children-timelines tree. */
-export function requestGraphChildrenToggle(): void {
-  window.dispatchEvent(new Event(GRAPH_CHILDREN_TOGGLE_EVENT));
 }
 
 /** Ask the graph view to toggle the preview pane. */

--- a/apps/timeline-gstudio001/lib/webmcp/tools.test.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/tools.test.ts
@@ -51,6 +51,7 @@ function viewSpies() {
     rulerOn: false,
     childrenShown: false,
     previewOn: false,
+    assetsOpen: false,
     flatOn: false,
     flatLoading: false,
   };

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -2726,9 +2726,17 @@ test.describe("graph view E2E", () => {
     await lastRail.hover({ position: { x: 10, y: 4 } });
     await page.mouse.down();
     await page.mouse.move(lastBox.x - cellW, lastBox.y + 4, { steps: 6 });
+    // Row pitch is MEASURED, not assumed. This used to hardcode 108 — the
+    // `md` cell height plus the gap — so it silently described a layout the
+    // app had moved on from, and failed the moment grid cells were rebuilt
+    // taller to distinguish the surface from the strip. Cell height is a
+    // per-size constant (ITEM_SIZE_DIMENSIONS); read it off the rendered card
+    // the same way `cellW` is read off the grid.
+    const rowPitch =
+      (await grid.locator("[data-node-id]").first().boundingBox())!.height + 8;
     await expect
       .poll(async () => (await translate()).y)
-      .toBeLessThan((rows - 1) * 108 - 20); // strictly above the last row
+      .toBeLessThan((rows - 1) * rowPitch - 20); // strictly above the last row
     await page.mouse.up();
 
     // …and overshooting row 0's tail runs forward into the next row.


### PR DESCRIPTION
A session of UI iteration that settled three rules and turned up three bugs on the way.

## 1. Where a control lives

The icon rail had accumulated controls that change the **board** rather than move you anywhere. Ruler and children-timelines moved into the breadcrumb row beside the board they act on; the zoom slider moved into the board menu.

Preview moved there too and then **came back to the rail** on your call. That reversal was right: I was reasoning about *category* (it's a view toggle, group it with view toggles), you were reasoning about *weight* — the rail is where the eye lands first, so a slot there is how something gets promoted above toolbar noise. Category is the default; weight overrides it for the few things that earn it.

Controls that moved into the graph's own tree dropped their window events with them — that bridge exists only to cross from the sidebar into the route-scoped tree. `GRAPH_RULER_TOGGLE_EVENT` and `GRAPH_CHILDREN_TOGGLE_EVENT` are gone.

**Preview's event stays**, and that asymmetry is deliberate: the pane's own close button and the WebMCP `set_preview` tool already drive it. One path beats three. Verified both directions — the pane's ✕ flips the rail toggle, and vice versa.

## 2. How "active" reads

The rule is **location vs. state**, not sidebar vs. toolbar:

| | treatment |
|---|---|
| Grid / Strip — *where you are* | **indicator bar** at the rail's edge |
| Flat, preview, drawers, ruler, children — *what's on* | **accent tint**, contrast from the glyph |

Both in **`sky-300`** — the seek rail's played-time colour — so an active control borrows a meaning the app already reads rather than introducing one. Amber stays reserved for **selection**; a toggle being on and a card being chosen are different facts that share the screen during a drag.

This replaced a white-on-dark inversion that made the active control the brightest object on screen. With three toggles lit, the chrome out-shouted the timeline it exists to control.

Tiles also stopped painting edge to edge: every fill moved onto an inset `::before` pill, so the square box keeps the rail's rhythm while the shape you see floats inside it.

## 3. The two surfaces looked identical

`strip` and `gridHeight` were **the same number** at every step (132 and 132 at `lg`) — a grid cell was a strip card that wrapped, so switching surfaces changed nothing visible.

|  | before | after |
|---|---|---|
| Grid cell | 211 × 132 (1.6:1) | **290 × 220 (1.32:1)** |
| Strip card | 235 × 132 | unchanged |
| Grid caption | 19px row / 12px text | **26px / 14px** |
| Columns @ 1400px | ~6 | **~4** |

The strip stays short and wide because width there is *time* and height is pure overhead on every row. The grid isn't measuring anything, so it can be a card. The drill circle takes a smaller share of the bigger cell (34% → 24%, ~75px → 53px) so it stays a control *on* the artwork rather than becoming it.

## Bugs found on the way — none cosmetic

- **`Slider` had no accessible name.** It spread `aria-label` onto Radix's `Root`, but `role="slider"` is on the `Thumb`. The zoom control announced nothing. Labelling props now reach the thumb, `aria-valuetext` included.
- **The collection details modal declared `aria-modal="true"` with no focus management.** The clip modal got that fixed in #229; this one was missed. Same hook now — move in, trap, restore.
- **The Assets tile reported `aria-pressed="false"` permanently** while toggling a drawer. The graph view owned `assetsOpen` and never published it, so the tile could not tell the truth *or* show its state. It's in the broadcast now.

## Also

Collection modal is the same box as the clip modal (768 × 592 measured — fixed panel, hero absorbs each body's different chrome). Size options are badges in a wrapping row instead of five full-width rows. Shortcuts moved last behind a separator with the ⌘ glyph. Menu sections got breathing room.

**A slider cannot live in a `role="menu"` as a focusable child** — measured, not assumed: arrow navigation skipped it entirely, jumping from the last size badge to "Keyboard shortcuts". So the zoom **row** is the control, its accessible name carrying the live reading and Left/Right adjusting it, with the slider as the pointer affordance and its thumb out of the tab order.

## One stale test

An e2e assertion hardcoded **`108`** as the grid row pitch — `md`'s cell height plus the gap, while the app defaults to `lg`. It had been describing a layout the app didn't have; it only failed once the numbers moved far enough to cross the threshold. It measures the rendered card now, the way it already read `cellW` off the DOM.

## Verification

| Gate | Result |
|---|---|
| Typecheck (app + `packages/ui`) | pass |
| Lint | 0 errors (4 pre-existing `<img>` warnings) |
| App tests | 493 |
| Unit tests | 408 |
| Story interaction tests | 165 |
| **e2e `graph-view`** | **101 / 101** |

Every visual claim above was measured in the running app, not eyeballed — cell and modal boxes via `getBoundingClientRect`, colours via `getComputedStyle`, the film icon's rotation via a sprocket rail that must render 21 × 0 px instead of 0 × 21.

## Worth a look

The grid ladder is a uniform ~1.27:1 across all five steps, so `xs` is now 132 × 104 (was 90 × 56). If `xs` was serving a "fit lots on screen" purpose, it's less dense than it was — easy to flatten the low end while keeping the big steps boxy.

`sky` now does three jobs: collection affordances, playback, and active toggles. Fine today since they never share a slot, but it's the constraint to remember if a fourth use appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
