### PR TITLE
PL12-001..003: the grid glyph, a longer active bar, and reference-counted asset deletion

### DIFF
--- a/apps/timeline-gstudio001/.env.example
+++ b/apps/timeline-gstudio001/.env.example
@@ -64,3 +64,14 @@ MCP_OAUTH_REDIRECT_URIS="https://claude.ai/api/mcp/auth_callback"
 # active when BOTH are set; either one alone silently disables the path.
 MCP_BEARER_TOKEN="MY_STATIC_BEARER_TOKEN"
 MCP_OWNER_UID="MY_FIREBASE_UID"
+
+# The reclaim sweep's shared secret. Vercel Cron sends it as
+# `Authorization: Bearer <CRON_SECRET>`; /api/assets/reclaim refuses with 503
+# when it is unset — an endpoint that deletes uploaded files must never default
+# to open. Generate one with:
+#   node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))"
+#
+# The schedule lives in vercel.json. Without it nothing sweeps: assets marked
+# by emptying the trash simply wait, which is the safe direction (storage
+# leaks; no file is lost).
+CRON_SECRET="MY_CRON_SECRET"

--- a/apps/timeline-gstudio001/app/api/assets/assets-route.test.ts
+++ b/apps/timeline-gstudio001/app/api/assets/assets-route.test.ts
@@ -160,7 +160,7 @@ describe("GET /api/assets/providers", () => {
       {
         id: "cloudinary",
         label: "Cloudinary",
-        capabilities: { folders: true, tags: true, search: true, upload: false, delete: false },
+        capabilities: { folders: true, tags: true, search: true, upload: false, delete: true },
       },
     ]);
   });

--- a/apps/timeline-gstudio001/app/api/assets/reclaim/reclaim-route.test.ts
+++ b/apps/timeline-gstudio001/app/api/assets/reclaim/reclaim-route.test.ts
@@ -1,0 +1,280 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TimelineClip } from "@storyboard/timeline-model/types";
+
+// The reclaim sweep over the REAL handler, the REAL tombstone store and the
+// REAL reference rule — only the process boundaries are faked (Firestore, the
+// provider registry, the clock via an injected `deleteAfterMs`).
+//
+// What these pin is the property the whole design rests on: a tombstone is an
+// INTENTION, not an authority. The sweep re-reads the owner's documents and
+// spares anything that came back into use, so the marking side is allowed to
+// be merely careful.
+
+type Stored = Record<string, unknown>;
+
+const state = vi.hoisted(() => {
+  const docs = new Map<string, Stored>();
+  const tombstones = new Map<string, Stored>();
+  const removed: { providerId: string; assetId: string; kind: string; uid: string }[] = [];
+  const failing = new Set<string>();
+
+  const snapshot = (store: Map<string, Stored>, id: string) => ({
+    id,
+    exists: store.has(id),
+    data: () => {
+      const data = store.get(id);
+      return data ? { ...data } : undefined;
+    },
+  });
+  const docRef = (store: Map<string, Stored>) => (id: string) => ({
+    id,
+    get: async () => snapshot(store, id),
+    set: async (data: Stored) => {
+      store.set(id, { ...data });
+    },
+    delete: async () => {
+      store.delete(id);
+    },
+    __store: store,
+  });
+
+  type Filter = { field: string; op: string; value: unknown };
+  const query = (store: Map<string, Stored>, filters: Filter[]) => {
+    const build = (after: string | null, limit: number | null) => ({
+      where: (field: string, op: string, value: unknown) =>
+        query(store, [...filters, { field, op, value }]).__build(after, limit),
+      orderBy: () => build(after, limit),
+      // The real call hands back a QueryDocumentSnapshot (see
+      // collectOwnedTimelineClips); only its id matters here.
+      startAfter: (cursor: { id: string }) => build(cursor.id, limit),
+      limit: (next: number) => build(after, next),
+      get: async () => {
+        const matches = (data: Stored) =>
+          filters.every((filter) => {
+            const value = data[filter.field];
+            if (filter.op === "<=") return typeof value === "number" && value <= Number(filter.value);
+            return value === filter.value;
+          });
+        const rows = [...store.entries()]
+          .filter(([, data]) => matches(data))
+          .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+          .filter(([id]) => after === null || id > after);
+        const page = limit === null ? rows : rows.slice(0, limit);
+        return { docs: page.map(([id]) => snapshot(store, id)) };
+      },
+      __build: build,
+    });
+    return build(null, null);
+  };
+
+  const db = {
+    collection: (name: string) => {
+      const store = name === "gstudioAssetTombstones" ? tombstones : docs;
+      return { doc: docRef(store), ...query(store, []) };
+    },
+    batch: () => {
+      const writes: (() => void)[] = [];
+      return {
+        set: (ref: { id: string; __store: Map<string, Stored> }, data: Stored) => {
+          writes.push(() => ref.__store.set(ref.id, { ...data }));
+        },
+        delete: (ref: { id: string; __store: Map<string, Stored> }) => {
+          writes.push(() => ref.__store.delete(ref.id));
+        },
+        commit: async () => {
+          for (const write of writes) write();
+        },
+      };
+    },
+  };
+  return { docs, tombstones, removed, failing, db };
+});
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/firebase-admin", () => ({ getFirebaseDb: () => state.db }));
+vi.mock("firebase-admin/firestore", () => {
+  class Timestamp {
+    toDate() {
+      return new Date(0);
+    }
+  }
+  return { Timestamp, FieldValue: { serverTimestamp: () => new Timestamp(), delete: () => "__delete__" } };
+});
+vi.mock("@/lib/assets/registry", () => ({
+  assetProviders: {
+    get: (id: string) =>
+      id === "cloudinary"
+        ? {
+            id,
+            remove: async (
+              ctx: { uid: string },
+              target: { assetId: string; kind: string },
+            ) => {
+              if (state.failing.has(target.assetId)) throw new Error("vendor exploded");
+              state.removed.push({ providerId: id, uid: ctx.uid, ...target });
+            },
+          }
+        : // "s3" stands in for a provider that is no longer configured.
+          undefined,
+  },
+}));
+
+import { markAssetsForDeletion } from "@/lib/asset-tombstones";
+
+import { GET as reclaim } from "./route";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const SECRET = "cron-secret";
+
+function clip(id: string, assetId: string): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "image",
+    src: `https://example.test/${assetId}`,
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 4,
+    sourceDuration: 4,
+    trimIn: 0,
+    trimOut: 0,
+    sourceAsset: { providerId: "cloudinary", assetId },
+  } as TimelineClip;
+}
+
+function seedLiveTimeline(id: string, assetIds: string[], ownerUid = "user-a") {
+  const clips = assetIds.map((assetId, index) => clip(`${id}-c${index}`, assetId));
+  state.docs.set(id, { id, title: id, document: { id, title: id, clips }, clips, ownerUid });
+}
+
+/** Mark an asset with a deadline relative to now — negative days are due. */
+async function mark(
+  ownerUid: string,
+  assetId: string,
+  daysFromNow: number,
+  providerId = "cloudinary",
+  kind: "image" | "video" = "image",
+) {
+  await markAssetsForDeletion(
+    ownerUid,
+    [{ ref: { providerId, assetId }, kind }],
+    Date.now() + daysFromNow * DAY_MS - 30 * DAY_MS,
+  );
+}
+
+const sweep = (token = SECRET) =>
+  reclaim(
+    new Request("http://test.local/api/assets/reclaim", {
+      headers: token === "" ? {} : { authorization: `Bearer ${token}` },
+    }),
+  );
+
+beforeEach(() => {
+  state.docs.clear();
+  state.tombstones.clear();
+  state.removed.length = 0;
+  state.failing.clear();
+  process.env.CRON_SECRET = SECRET;
+});
+
+describe("GET /api/assets/reclaim", () => {
+  it("deletes a due tombstone nothing references", async () => {
+    await mark("user-a", "gstudio/user-a/orphan.png", 0);
+
+    const body = await (await sweep()).json();
+    expect(body).toEqual({ due: 1, deleted: 1, spared: 0, skipped: 0 });
+    expect(state.removed).toEqual([
+      { providerId: "cloudinary", uid: "user-a", assetId: "gstudio/user-a/orphan.png", kind: "image" },
+    ]);
+    // The record goes with the file: an intention that outlived its object
+    // would be retried forever.
+    expect(state.tombstones.size).toBe(0);
+  });
+
+  it("SPARES an asset that came back into use, and drops the mark", async () => {
+    // The property the grace period exists for: a mark placed by an imperfect
+    // scan self-corrects rather than losing a file.
+    await mark("user-a", "gstudio/user-a/back.png", 0);
+    seedLiveTimeline("project-live", ["gstudio/user-a/back.png"]);
+
+    expect(await (await sweep()).json()).toEqual({ due: 1, deleted: 0, spared: 1, skipped: 0 });
+    expect(state.removed).toEqual([]);
+    expect(state.tombstones.size).toBe(0);
+  });
+
+  it("leaves a tombstone whose 30 days have not run out", async () => {
+    await mark("user-a", "gstudio/user-a/waiting.png", 5);
+
+    expect(await (await sweep()).json()).toEqual({ due: 0, deleted: 0, spared: 0, skipped: 0 });
+    expect(state.removed).toEqual([]);
+    expect(state.tombstones.size).toBe(1);
+  });
+
+  it("scopes the reference check to the tombstone's OWNER", async () => {
+    // Another user's document referencing the same id must not save it — and
+    // must not be readable by this scan at all.
+    await mark("user-a", "gstudio/user-a/orphan.png", 0);
+    seedLiveTimeline("project-other", ["gstudio/user-a/orphan.png"], "user-b");
+
+    expect(await (await sweep()).json()).toEqual({ due: 1, deleted: 1, spared: 0, skipped: 0 });
+    expect(state.removed).toHaveLength(1);
+  });
+
+  it("keeps the tombstone when the vendor delete fails", async () => {
+    await mark("user-a", "gstudio/user-a/stuck.png", 0);
+    state.failing.add("gstudio/user-a/stuck.png");
+
+    expect(await (await sweep()).json()).toEqual({ due: 1, deleted: 0, spared: 0, skipped: 1 });
+    expect(state.tombstones.size).toBe(1);
+  });
+
+  it("keeps the tombstone when the provider is no longer configured", async () => {
+    await mark("user-a", "media/user-a/dropped.png", 0, "s3");
+
+    expect(await (await sweep()).json()).toEqual({ due: 1, deleted: 0, spared: 0, skipped: 1 });
+    // Forgetting the intention would strand the object with nothing left to
+    // say it should go.
+    expect(state.tombstones.size).toBe(1);
+  });
+
+  it("passes the recorded kind through, 30 days after the clip is gone", async () => {
+    await mark("user-a", "gstudio/user-a/movie.mp4", 0, "cloudinary", "video");
+
+    await sweep();
+    expect(state.removed[0]).toMatchObject({ kind: "video" });
+  });
+
+  it("sweeps several owners independently", async () => {
+    await mark("user-a", "gstudio/user-a/a.png", 0);
+    await mark("user-b", "gstudio/user-b/b.png", 0);
+    seedLiveTimeline("project-b", ["gstudio/user-b/b.png"], "user-b");
+
+    expect(await (await sweep()).json()).toEqual({ due: 2, deleted: 1, spared: 1, skipped: 0 });
+    expect(state.removed).toEqual([
+      { providerId: "cloudinary", uid: "user-a", assetId: "gstudio/user-a/a.png", kind: "image" },
+    ]);
+  });
+
+  it("refuses without the right bearer token", async () => {
+    await mark("user-a", "gstudio/user-a/orphan.png", 0);
+
+    for (const token of ["", "wrong-secret", "cron-secret-longer"]) {
+      expect((await sweep(token)).status).toBe(401);
+    }
+    expect(state.removed).toEqual([]);
+    expect(state.tombstones.size).toBe(1);
+  });
+
+  it("refuses entirely when no secret is configured", async () => {
+    // An unset secret must never read as "anyone may run this" — the endpoint
+    // deletes files.
+    delete process.env.CRON_SECRET;
+    await mark("user-a", "gstudio/user-a/orphan.png", 0);
+
+    expect((await sweep()).status).toBe(503);
+    expect(state.removed).toEqual([]);
+  });
+});

--- a/apps/timeline-gstudio001/app/api/assets/reclaim/route.ts
+++ b/apps/timeline-gstudio001/app/api/assets/reclaim/route.ts
@@ -1,0 +1,125 @@
+import { timingSafeEqual } from "node:crypto";
+
+import { NextResponse } from "next/server";
+
+import {
+  clearAssetTombstones,
+  listDueAssetTombstones,
+  type AssetTombstone,
+} from "@/lib/asset-tombstones";
+import { assetKeysFromClips, assetRefKey } from "@/lib/assets/asset-references";
+import { assetProviders } from "@/lib/assets/registry";
+import { collectOwnedTimelineClips } from "@/lib/firebase-timeline-store";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/** One run's ceiling. Whatever it doesn't reach stays due and is taken by the
+ *  next run — a sweep is allowed to be slow, never to be unbounded. */
+const SWEEP_LIMIT = 200;
+
+/**
+ * The reclaim sweep: delete the uploaded files whose 30 days have run out and
+ * that STILL nothing points at.
+ *
+ * The re-check is the point. A tombstone is an intention recorded 30 days ago
+ * by a scan that may have been wrong, or right about a world that has since
+ * changed — so this reads the owner's documents again and drops the tombstone
+ * instead of the file whenever the asset is back in use. That is what lets the
+ * marking side be merely careful rather than perfect.
+ *
+ * Driven by cron (see vercel.json) rather than by a user path: a lazy sweep on
+ * a read is both a write on a read path (which round 12 took out of this app)
+ * and useless for the user who stops signing in, who is precisely the one
+ * accumulating storage.
+ */
+export async function GET(request: Request) {
+  const secret = process.env.CRON_SECRET;
+  if (secret === undefined || secret.length === 0) {
+    // Refusing beats defaulting to open: this endpoint deletes files, and an
+    // unset secret must never mean "anyone may run it".
+    return NextResponse.json({ error: "Reclaim is not configured." }, { status: 503 });
+  }
+  if (!authorized(request.headers.get("authorization"), secret)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const due = await listDueAssetTombstones(Date.now(), SWEEP_LIMIT);
+  const byOwner = new Map<string, AssetTombstone[]>();
+  for (const tombstone of due) {
+    const owned = byOwner.get(tombstone.ownerUid);
+    if (owned === undefined) byOwner.set(tombstone.ownerUid, [tombstone]);
+    else owned.push(tombstone);
+  }
+
+  let deleted = 0;
+  let spared = 0;
+  let skipped = 0;
+  for (const [ownerUid, tombstones] of byOwner) {
+    let referenced: ReadonlySet<string>;
+    try {
+      referenced = new Set(assetKeysFromClips(await collectOwnedTimelineClips(ownerUid)));
+    } catch (error) {
+      // Could not establish what this owner still uses — so nothing of theirs
+      // can be deleted this run. The tombstones stay due.
+      console.error("[ASSET_RECLAIM_SCAN_ERROR]", ownerUid, error);
+      skipped += tombstones.length;
+      continue;
+    }
+
+    // Back in use: the mark is withdrawn, and the file was never touched.
+    const spare = tombstones.filter((tombstone) => referenced.has(assetRefKey(tombstone.ref)));
+    await clearAssetTombstones(ownerUid, spare.map((tombstone) => tombstone.ref));
+    spared += spare.length;
+
+    for (const tombstone of tombstones) {
+      if (referenced.has(assetRefKey(tombstone.ref))) continue;
+      const outcome = await deleteAsset(ownerUid, tombstone);
+      if (outcome === "deleted") deleted += 1;
+      else skipped += 1;
+    }
+  }
+
+  return NextResponse.json({ due: due.length, deleted, spared, skipped });
+}
+
+/** Constant-time bearer comparison. Lengths are compared first because
+ *  `timingSafeEqual` throws on a mismatch rather than returning false. */
+function authorized(header: string | null, secret: string): boolean {
+  const presented = header?.startsWith("Bearer ") === true ? header.slice(7) : "";
+  const left = Buffer.from(presented);
+  const right = Buffer.from(secret);
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+/**
+ * Delete one asset through its provider, then drop the tombstone.
+ *
+ * The tombstone is removed ONLY after the provider reports success. A provider
+ * that is no longer configured (S3 dropped from the environment), or one that
+ * cannot delete, leaves the record in place: forgetting the intention would
+ * strand the file with nothing left to say it should go.
+ */
+async function deleteAsset(
+  ownerUid: string,
+  tombstone: AssetTombstone,
+): Promise<"deleted" | "skipped"> {
+  const provider = assetProviders.get(tombstone.ref.providerId);
+  if (provider?.remove === undefined) {
+    console.warn("[ASSET_RECLAIM_NO_PROVIDER]", tombstone.ref.providerId);
+    return "skipped";
+  }
+  try {
+    await provider.remove({ uid: ownerUid }, {
+      assetId: tombstone.ref.assetId,
+      kind: tombstone.kind,
+    });
+  } catch (error) {
+    // Left due: a transient vendor failure should be retried tomorrow, and a
+    // permanent one is a record someone can find.
+    console.error("[ASSET_RECLAIM_DELETE_ERROR]", tombstone.ref.assetId, error);
+    return "skipped";
+  }
+  await clearAssetTombstones(ownerUid, [tombstone.ref]);
+  return "deleted";
+}

--- a/apps/timeline-gstudio001/app/api/trash/route.ts
+++ b/apps/timeline-gstudio001/app/api/trash/route.ts
@@ -3,23 +3,37 @@ import { NextResponse } from "next/server";
 import { readJsonObject } from "@/lib/read-json-body";
 import { requireAuthUser } from "@/lib/firebase-auth-session";
 import {
+  collectOwnedTimelineClips,
   getFirebaseTimelineDocument,
   saveFirebaseTimelineDocument,
 } from "@/lib/firebase-timeline-store";
+import {
+  assetCandidatesFromClips,
+  assetKeysFromClips,
+  unreferencedCandidates,
+} from "@/lib/assets/asset-references";
+import { markAssetsForDeletion } from "@/lib/asset-tombstones";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 /**
- * Empty the signed-in user's trash bin: clear the document, and nothing else.
+ * Empty the signed-in user's trash bin, and MARK the uploaded files nothing
+ * points at any more.
  *
- * The UPLOADED FILES ARE DELIBERATELY LEFT ALONE. This endpoint used to delete
- * the Cloudinary asset behind every trashed clip, which was unsafe (one upload
- * can be referenced from several timelines — this app mints stable per-asset
- * clip ids, so placing an asset twice makes two clips of one file) and, more
- * to the point, is not what emptying a bin should mean here: the files stay
- * browsable in the Assets library and can be placed again. Reclaiming unused
- * storage is a separate, deliberate job — see the note in the trash drawer.
+ * Marking, not deleting. An earlier version of this endpoint deleted the
+ * Cloudinary asset behind every trashed clip, which was unsafe for a reason
+ * that has not gone away: one upload can back several clips (this app mints
+ * stable per-asset clip ids, so placing an asset twice makes two clips of one
+ * file), and the bin is per-USER while an asset is per-project, so one bin
+ * spans everything its owner owns. The rule is therefore REFERENCES — an asset
+ * is marked only when no document of this user's still points at it — and even
+ * then the file survives a 30-day grace period the sweep re-checks before
+ * honouring (see lib/asset-tombstones).
+ *
+ * A failure to mark leaks storage. That is the failure direction this whole
+ * design is built to have, so marking runs AFTER the bin is safely emptied and
+ * never fails the request.
  */
 export async function DELETE() {
   try {
@@ -29,23 +43,55 @@ export async function DELETE() {
     const trashId = `trash-${user.uid}`;
     const trashDoc = await getFirebaseTimelineDocument(trashId, user.uid);
     const cleared = trashDoc?.clips.length ?? 0;
+    if (!trashDoc || cleared === 0) return NextResponse.json({ success: true, cleared });
 
-    if (trashDoc && cleared > 0) {
-      // `allowEmptying` is what makes this work at all. The save path refuses
-      // an empty write over a non-empty document (a stale client erasing real
-      // work) and, separately, reads `lastNonEmptyDocument` back whenever the
-      // stored clips are empty — so without the opt-in this endpoint threw
-      // 500, and had it not thrown the bin would have re-read full anyway.
-      // A copy, not a mutation of the loaded document.
-      await saveFirebaseTimelineDocument({ ...trashDoc, clips: [] }, user.uid, {
-        allowEmptying: true,
-      });
-    }
+    const candidates = assetCandidatesFromClips(trashDoc.clips);
 
-    return NextResponse.json({ success: true, cleared });
+    // `allowEmptying` is what makes this work at all. The save path refuses
+    // an empty write over a non-empty document (a stale client erasing real
+    // work) and, separately, reads `lastNonEmptyDocument` back whenever the
+    // stored clips are empty — so without the opt-in this endpoint threw
+    // 500, and had it not thrown the bin would have re-read full anyway.
+    // A copy, not a mutation of the loaded document.
+    await saveFirebaseTimelineDocument({ ...trashDoc, clips: [] }, user.uid, {
+      allowEmptying: true,
+    });
+
+    const marked = await markUnreferencedAssets(user.uid, trashId, candidates);
+    return NextResponse.json({ success: true, cleared, marked });
   } catch (error) {
     console.error("[TRASH_EMPTY_ERROR]", error);
     return NextResponse.json({ error: "Unable to empty the trash." }, { status: 500 });
+  }
+}
+
+/**
+ * Which of the emptied bin's assets nothing else points at, marked.
+ *
+ * The bin itself is EXCLUDED from the scan — its clips are the candidates, and
+ * a candidate is not a reference to itself. (It has already been written empty
+ * by the time this runs, but excluding it explicitly means the rule does not
+ * depend on that ordering.)
+ *
+ * Never throws. Emptying the bin is the user's request and it has already
+ * succeeded; a scan that failed, or that could not be completed, must leave the
+ * files alone rather than fail the response — and an incomplete scan
+ * (`TimelineScanIncompleteError`) must never be read as "nothing references
+ * this".
+ */
+async function markUnreferencedAssets(
+  uid: string,
+  trashId: string,
+  candidates: ReturnType<typeof assetCandidatesFromClips>,
+): Promise<number> {
+  if (candidates.length === 0) return 0;
+  try {
+    const liveClips = await collectOwnedTimelineClips(uid, { excludeIds: [trashId] });
+    const orphans = unreferencedCandidates(candidates, new Set(assetKeysFromClips(liveClips)));
+    return await markAssetsForDeletion(uid, orphans);
+  } catch (error) {
+    console.error("[TRASH_MARK_ERROR]", error);
+    return 0;
   }
 }
 
@@ -64,8 +110,12 @@ export async function DELETE() {
  * a mounted graph view holds these clips as nodes under its trash root and
  * would write them straight back on the next commit that touches the trash.
  *
- * Uploaded files are untouched, exactly as for emptying: one upload can back
- * several clips, and discarding a bin entry is not deleting a file.
+ * Uploaded files are untouched, and UNLIKE emptying this path marks nothing.
+ * The asymmetry is deliberate: discarding is what a RESTORE does to the
+ * leftover copies (see lib/graph-trash-discard — the drawer restores one clip
+ * and discards its duplicates), so a discard usually means an asset is coming
+ * back into use, not going out of it. Emptying the bin is the deliberate "I am
+ * finished with this" that earns a mark.
  */
 export async function POST(request: Request) {
   try {

--- a/apps/timeline-gstudio001/app/api/trash/trash-empty.test.ts
+++ b/apps/timeline-gstudio001/app/api/trash/trash-empty.test.ts
@@ -11,9 +11,10 @@ import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/
 // `lastNonEmptyDocument` whenever the stored clips are empty, so the bin
 // would have come straight back. Both are pinned here.
 //
-// The Cloudinary double is here to prove a NEGATIVE: emptying the bin must
-// never delete an uploaded file. The files stay in the Assets library, where
-// they can be placed again; reclaiming storage is a separate, deliberate job.
+// Emptying the bin now MARKS the uploaded files nothing points at (PL12-003).
+// The Cloudinary double still proves a negative and it is the important one:
+// emptying deletes no file THEN — a mark is a tombstone, and only the reclaim
+// sweep, 30 days and one re-check later, may act on it.
 
 type Stored = Record<string, unknown>;
 
@@ -21,13 +22,14 @@ const DELETE_SENTINEL = "__delete__";
 
 const state = vi.hoisted(() => {
   const docs = new Map<string, Stored>();
+  const tombstones = new Map<string, Stored>();
   const current = {
     user: { uid: "user-a", email: null as string | null, name: null, picture: null },
   };
   const cloudinaryDeletes: { publicId: string; resourceType: string }[] = [];
 
-  const applySet = (id: string, data: Stored, opts?: { merge?: boolean }) => {
-    const existing = docs.get(id);
+  const applySet = (store: Map<string, Stored>, id: string, data: Stored, opts?: { merge?: boolean }) => {
+    const existing = store.get(id);
     const merged = opts?.merge && existing ? { ...existing, ...data } : { ...data };
     // Firestore's FieldValue.delete() removes the field on a merge write;
     // the in-memory double honours it so the read-back path is exercised
@@ -35,10 +37,10 @@ const state = vi.hoisted(() => {
     for (const [key, value] of Object.entries(merged)) {
       if (value === "__delete__") delete merged[key];
     }
-    docs.set(id, merged);
+    store.set(id, merged);
   };
-  const snapshot = (id: string) => {
-    const data = docs.get(id);
+  const snapshot = (store: Map<string, Stored>, id: string) => {
+    const data = store.get(id);
     return {
       id,
       exists: data !== undefined,
@@ -46,21 +48,65 @@ const state = vi.hoisted(() => {
       get: (field: string) => (data ? data[field] : undefined),
     };
   };
-  const docRef = (id: string) => ({
+  const docRef = (store: Map<string, Stored>) => (id: string) => ({
     id,
-    get: async () => snapshot(id),
-    set: async (data: Stored, opts?: { merge?: boolean }) => applySet(id, data, opts),
+    get: async () => snapshot(store, id),
+    set: async (data: Stored, opts?: { merge?: boolean }) => applySet(store, id, data, opts),
     delete: async () => {
-      docs.delete(id);
+      store.delete(id);
     },
+    __store: store,
   });
-  const db = {
-    collection: () => ({
-      doc: docRef,
-      where: () => ({ limit: () => ({ get: async () => ({ docs: [] }) }) }),
-    }),
+
+  /**
+   * Enough of a query to serve the reference scan: one equality filter, an
+   * order by document id, an optional cursor and a limit. Nothing else in
+   * these tests queries, so the double stays exactly this literal.
+   */
+  const query = (store: Map<string, Stored>, filter: { field: string; value: unknown } | null) => {
+    const build = (after: string | null, limit: number | null) => ({
+      where: (field: string, _op: string, value: unknown) =>
+        query(store, { field, value }).__build(after, limit),
+      orderBy: () => build(after, limit),
+      // The real call hands back a QueryDocumentSnapshot (see
+      // collectOwnedTimelineClips); only its id matters here.
+      startAfter: (cursor: { id: string }) => build(cursor.id, limit),
+      limit: (next: number) => build(after, next),
+      get: async () => {
+        const rows = [...store.entries()]
+          .filter(([, data]) => filter === null || data[filter.field] === filter.value)
+          .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+          .filter(([id]) => after === null || id > after);
+        const page = limit === null ? rows : rows.slice(0, limit);
+        return { docs: page.map(([id]) => snapshot(store, id)) };
+      },
+      __build: build,
+    });
+    return build(null, null);
   };
-  return { docs, current, db, cloudinaryDeletes };
+
+  const collectionFor = (name: string) => {
+    const store = name === "gstudioAssetTombstones" ? tombstones : docs;
+    return { doc: docRef(store), ...query(store, null) };
+  };
+  const db = {
+    collection: collectionFor,
+    batch: () => {
+      const writes: (() => void)[] = [];
+      return {
+        set: (ref: { id: string; __store: Map<string, Stored> }, data: Stored) => {
+          writes.push(() => ref.__store.set(ref.id, { ...data }));
+        },
+        delete: (ref: { id: string; __store: Map<string, Stored> }) => {
+          writes.push(() => ref.__store.delete(ref.id));
+        },
+        commit: async () => {
+          for (const write of writes) write();
+        },
+      };
+    },
+  };
+  return { docs, tombstones, current, db, cloudinaryDeletes };
 });
 
 vi.mock("server-only", () => ({}));
@@ -81,6 +127,7 @@ vi.mock("@/lib/firebase-auth-session", () => ({
 }));
 vi.mock("@/lib/cloudinary-media-store", () => ({
   listCloudinaryAssets: async () => [],
+  cloudinaryUserPrefix: (uid: string) => `gstudio/${uid}/`,
   deleteCloudinaryAsset: async (publicId: string, resourceType: string) => {
     state.cloudinaryDeletes.push({ publicId, resourceType });
   },
@@ -91,7 +138,12 @@ import { GET as getTimeline } from "../timelines/[id]/route";
 
 const TRASH_ID = "trash-user-a";
 
-function clip(id: string, src: string, kind: "image" | "video" = "image"): TimelineClip {
+function clip(
+  id: string,
+  src: string,
+  kind: "image" | "video" = "image",
+  sourceAsset?: { providerId: string; assetId: string },
+): TimelineClip {
   return {
     id,
     index: 0,
@@ -105,8 +157,16 @@ function clip(id: string, src: string, kind: "image" | "video" = "image"): Timel
     sourceDuration: 4,
     trimIn: 0,
     trimOut: 0,
+    ...(sourceAsset === undefined ? {} : { sourceAsset }),
   } as TimelineClip;
 }
+
+/** The provenance a clip minted from the asset seam carries — the only thing
+ *  that makes an asset nameable, and so deletable. */
+const asset = (assetId: string) => ({ providerId: "cloudinary", assetId });
+
+const markedIds = () =>
+  [...state.tombstones.values()].map((row) => row.assetId as string).sort();
 
 function seedTrash(clips: TimelineClip[], revision = 3) {
   const document: TimelineDocument = { id: TRASH_ID, title: "Trash Bin", clips };
@@ -123,15 +183,17 @@ function seedTrash(clips: TimelineClip[], revision = 3) {
   });
 }
 
-/** A LIVE (non-trash) document that still points at `srcs`. */
-function seedLiveTimeline(id: string, srcs: string[]) {
-  const clips = srcs.map((src, index) => clip(`${id}-c${index}`, src));
+/** A LIVE (non-trash) document that still points at `assetIds`. */
+function seedLiveTimeline(id: string, assetIds: string[], ownerUid = "user-a") {
+  const clips = assetIds.map((assetId, index) =>
+    clip(`${id}-c${index}`, `https://example.test/${assetId}`, "image", asset(assetId)),
+  );
   state.docs.set(id, {
     id,
     title: id,
     document: { id, title: id, clips },
     clips,
-    ownerUid: "user-a",
+    ownerUid,
     revision: 1,
   });
 }
@@ -146,6 +208,7 @@ const readBack = async (): Promise<TimelineDocument> => {
 
 beforeEach(() => {
   state.docs.clear();
+  state.tombstones.clear();
   state.cloudinaryDeletes.length = 0;
   state.current.user = { uid: "user-a", email: null, name: null, picture: null };
 });
@@ -159,7 +222,7 @@ describe("DELETE /api/trash", () => {
 
     const response = await emptyTrash();
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ success: true, cleared: 2 });
+    expect(await response.json()).toEqual({ success: true, cleared: 2, marked: 0 });
 
     // Stored: no clips, no recovery snapshot, revision bumped.
     const stored = state.docs.get(TRASH_ID)!;
@@ -182,26 +245,82 @@ describe("DELETE /api/trash", () => {
     expect((await readBack()).clips).toEqual([]);
   });
 
-  it("NEVER deletes an uploaded file, whoever else does or doesn't use it", async () => {
-    // Every shape the old asset-deleting version treated differently: a
-    // Cloudinary image, a Cloudinary video, an asset placed in a live
-    // timeline, and one placed nowhere else at all. None of them is touched —
-    // the files stay in the Assets library.
-    const orphan = "https://res.cloudinary.com/demo/image/upload/v1/folder/orphan.png";
-    const shared = "https://res.cloudinary.com/demo/image/upload/v1/folder/shared.png";
+  it("marks only what nothing else points at, and deletes no file yet", async () => {
+    // The exact shape that made the old delete-on-empty version unsafe: one
+    // upload backing a clip in the bin AND a clip on a board. Deleting the
+    // file behind the trashed copy would have pulled it out from under the
+    // live one.
     seedTrash([
-      clip("c1", orphan),
-      clip("c2", shared),
-      clip("c3", "https://res.cloudinary.com/demo/video/upload/v1/folder/movie.mp4", "video"),
-      clip("c4", "https://example.test/not-cloudinary.png"),
+      clip("c1", "https://example.test/orphan.png", "image", asset("gstudio/user-a/orphan.png")),
+      clip("c2", "https://example.test/shared.png", "image", asset("gstudio/user-a/shared.png")),
+      clip("c3", "https://example.test/movie.mp4", "video", asset("gstudio/user-a/movie.mp4")),
+      // No provenance: unnameable, so never deletable. Leaks, never loses.
+      clip("c4", "https://example.test/legacy.png"),
     ]);
-    seedLiveTimeline("project-live", [shared]);
+    seedLiveTimeline("project-live", ["gstudio/user-a/shared.png"]);
 
     const response = await emptyTrash();
-    expect(await response.json()).toEqual({ success: true, cleared: 4 });
+    expect(await response.json()).toEqual({ success: true, cleared: 4, marked: 2 });
+    expect(markedIds()).toEqual(["gstudio/user-a/movie.mp4", "gstudio/user-a/orphan.png"]);
+    // Marking is not deleting: nothing reaches the vendor until the sweep has
+    // waited out the grace period and re-checked.
     expect(state.cloudinaryDeletes).toEqual([]);
     // The bin still emptied — that is the whole job.
     expect(state.docs.get(TRASH_ID)?.clips).toEqual([]);
+  });
+
+  it("records the kind, because the sweep will have no clip left to ask", async () => {
+    seedTrash([
+      clip("c1", "https://example.test/movie.mp4", "video", asset("gstudio/user-a/movie.mp4")),
+    ]);
+
+    await emptyTrash();
+    const [tombstone] = [...state.tombstones.values()];
+    expect(tombstone).toMatchObject({
+      providerId: "cloudinary",
+      assetId: "gstudio/user-a/movie.mp4",
+      kind: "video",
+      ownerUid: "user-a",
+    });
+    // 30 days out, not now.
+    const grace = (tombstone.deleteAfterMs as number) - (tombstone.markedAtMs as number);
+    expect(grace).toBe(30 * 24 * 60 * 60 * 1000);
+  });
+
+  it("counts a reference held only by the recovery snapshot", async () => {
+    // `lastNonEmptyDocument` is one ordinary read away from being the live
+    // document again (see toTimelineDocument), so a clip reachable only
+    // through it is still a reference. Over-count, never under-count.
+    const held = "gstudio/user-a/held.png";
+    seedTrash([clip("c1", "https://example.test/held.png", "image", asset(held))]);
+    state.docs.set("project-emptied", {
+      id: "project-emptied",
+      title: "Emptied",
+      document: { id: "project-emptied", title: "Emptied", clips: [] },
+      clips: [],
+      lastNonEmptyDocument: {
+        id: "project-emptied",
+        title: "Emptied",
+        clips: [clip("live", "https://example.test/held.png", "image", asset(held))],
+      },
+      ownerUid: "user-a",
+      revision: 2,
+    });
+
+    expect(await (await emptyTrash()).json()).toEqual({ success: true, cleared: 1, marked: 0 });
+    expect(markedIds()).toEqual([]);
+  });
+
+  it("ignores another user's reference to the same asset id", async () => {
+    // Assets are per-user in both providers, so this cannot happen today — but
+    // the scan is what enforces it, and a scan that read everyone's documents
+    // would be the round-12 bug again in a new place.
+    const orphan = "gstudio/user-a/orphan.png";
+    seedTrash([clip("c1", "https://example.test/orphan.png", "image", asset(orphan))]);
+    seedLiveTimeline("project-other", [orphan], "user-b");
+
+    expect(await (await emptyTrash()).json()).toEqual({ success: true, cleared: 1, marked: 1 });
+    expect(markedIds()).toEqual([orphan]);
   });
 
   it("is a no-op on an already-empty bin", async () => {

--- a/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
+++ b/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
@@ -198,12 +198,15 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
   };
 
   const handleEmptyTrash = async () => {
-    // Says what actually happens: the BIN entries go (with no restore path,
-    // so it really is permanent), while the uploads behind them stay in the
-    // Assets library and can be placed again. The old wording promised a
-    // blanket "permanently delete", which read as losing the files too.
+    // Says what actually happens, and it changed with PL12-003: an upload that
+    // nothing else points at is now MARKED, and deleted for real 30 days later
+    // (a file still used by a clip on a board is never marked, and a marked one
+    // is spared the moment it is used again). The previous wording — "your
+    // uploaded files stay in the Assets library" — became a promise this app no
+    // longer keeps, which is worse than the blanket "permanently delete" it had
+    // replaced.
     const confirmed = window.confirm(
-      `Empty the trash? The ${clips.length} item${clips.length === 1 ? "" : "s"} in the bin will be removed and cannot be restored. Your uploaded files stay in the Assets library.`
+      `Empty the trash? The ${clips.length} item${clips.length === 1 ? "" : "s"} in the bin will be removed and cannot be restored. Uploaded files that nothing else uses are deleted after 30 days.`
     );
     if (!confirmed) return;
 

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -15,7 +15,6 @@ import {
   Layers,
   LogOut,
   Scissors,
-  Table,
   Trash2,
   TvMinimal,
   X,
@@ -147,10 +146,14 @@ const SIDEBAR_ICON_IDLE =
  *
  * No `translate-y-px`: a pressed tile nudging down by a pixel opened a hairline
  * seam above it and read as misalignment rather than as a press.
+ *
+ * `h-9` (36px) against the 56px pill: long enough to read as a bar rather than
+ * a tick, short enough that it still marks a position instead of drawing a
+ * second edge down the rail.
  */
 const SIDEBAR_ICON_PRESSED = [
   "text-zinc-50 before:bg-zinc-800",
-  "after:absolute after:left-0 after:top-1/2 after:h-7 after:w-[3px]",
+  "after:absolute after:left-0 after:top-1/2 after:h-9 after:w-[3px]",
   "after:-translate-y-1/2 after:rounded-r-full after:bg-sky-300 after:content-['']",
 ].join(" ");
 
@@ -212,6 +215,40 @@ function SidebarSeparator({ selected = false }: Readonly<{ selected?: boolean }>
  */
 function FilmStripGlyph({ className }: { className?: string }) {
   return <Film className={cn(className, "rotate-90")} />;
+}
+
+/** Where the grid glyph's cells start on each axis, in viewBox units: three
+ *  4-unit cells with a 2-unit gutter, inset 4 from the 24-unit box. */
+const GRID_GLYPH_TRACKS = [4, 10, 16];
+
+/**
+ * The grid layout's glyph: nine filled cells, replacing lucide's `Table`.
+ *
+ * `Table` drew a bordered frame divided by rules — a spreadsheet, which is the
+ * wrong noun for a wall of cards. Nine separate cells say the thing the surface
+ * actually is.
+ *
+ * Filled rather than stroked, so it is the one glyph in the rail that does not
+ * take `[stroke-width:1.5]` from `SIDEBAR_GLYPH`; `fill="currentColor"` is what
+ * keeps it in step with the rail's idle / hover / active colours instead, and
+ * Tailwind's `transition-colors` covers `fill` as well as `color`.
+ */
+function GridLayoutGlyph({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      className={className}
+    >
+      {GRID_GLYPH_TRACKS.map((y) =>
+        GRID_GLYPH_TRACKS.map((x) => (
+          <rect key={`${x}-${y}`} x={x} y={y} width="4" height="4" />
+        )),
+      )}
+    </svg>
+  );
 }
 
 type SurfaceIconControlProps = {
@@ -662,7 +699,7 @@ export function TimelineSidebar() {
             surface="grid"
             onGraphRoute={onGraphRoute}
             href={graphHref}
-            icon={Table}
+            icon={GridLayoutGlyph}
             isActive={onGraphRoute && graphView.surface === "grid"}
             label="Grid layout"
             description="Graph timelines as grids"

--- a/apps/timeline-gstudio001/lib/asset-tombstones.ts
+++ b/apps/timeline-gstudio001/lib/asset-tombstones.ts
@@ -1,0 +1,161 @@
+import "server-only";
+
+import { getFirebaseDb } from "./firebase-admin";
+import { assetRefKey, type AssetDeletionCandidate } from "./assets/asset-references";
+import type { AssetKind, AssetSourceRef } from "./assets/types";
+
+/**
+ * Assets marked for deletion, and the 30 days they get to be un-marked in.
+ *
+ * A tombstone is an INTENTION, never an authority: the sweep re-checks
+ * references before it deletes anything, so a mark placed by an imperfect scan
+ * self-corrects if the asset is referenced again inside the window. That is
+ * what the grace period buys beyond user forgiveness — it turns "the scan must
+ * be right" into "the scan must be roughly right".
+ *
+ * DO NOT give this collection a Firestore TTL policy. This repo already uses
+ * TTL (`mcpOAuthCodes`, `mcpOAuthRefreshTokens` in `firestore.indexes.json`)
+ * and reaching for it here is the obvious mistake: TTL would expire the RECORD
+ * at day 30 and leave the FILE forever — the exact inverse of the job. A
+ * tombstone must outlive its own deadline until a sweeper honours it and
+ * removes it deliberately.
+ */
+const TOMBSTONE_COLLECTION = "gstudioAssetTombstones";
+
+/** How long a marked asset survives before the sweep may delete it. */
+export const ASSET_DELETE_GRACE_DAYS = 30;
+const GRACE_MS = ASSET_DELETE_GRACE_DAYS * 24 * 60 * 60 * 1000;
+
+/** Firestore's WriteBatch ceiling. */
+const BATCH_LIMIT = 500;
+
+export type AssetTombstone = Readonly<{
+  ref: AssetSourceRef;
+  kind: AssetKind;
+  ownerUid: string;
+  markedAtMs: number;
+  /** Epoch millis after which the sweep may delete. Stored as a NUMBER rather
+   *  than a Timestamp: it is only ever compared, it queries identically, and it
+   *  survives every serialization boundary between here and a cron job. */
+  deleteAfterMs: number;
+}>;
+
+type TombstoneRecord = {
+  providerId?: string;
+  assetId?: string;
+  kind?: string;
+  ownerUid?: string;
+  markedAtMs?: number;
+  deleteAfterMs?: number;
+};
+
+function tombstones() {
+  return getFirebaseDb().collection(TOMBSTONE_COLLECTION);
+}
+
+/**
+ * The document id: owner, then the asset ref key, every part percent-encoded
+ * and joined with "|".
+ *
+ * Scoped by OWNER even though asset ids are already per-user in both installed
+ * providers — a tombstone is a statement about one person's library, and an id
+ * that can only ever describe one is the cheap way to keep it that way.
+ */
+function tombstoneId(ownerUid: string, ref: AssetSourceRef): string {
+  return `${encodeURIComponent(ownerUid)}|${assetRefKey(ref)}`;
+}
+
+function toTombstone(data: TombstoneRecord): AssetTombstone | null {
+  const { providerId, assetId, kind, ownerUid, markedAtMs, deleteAfterMs } = data;
+  if (typeof providerId !== "string" || typeof assetId !== "string") return null;
+  if (kind !== "image" && kind !== "video") return null;
+  if (typeof ownerUid !== "string" || ownerUid.length === 0) return null;
+  if (typeof deleteAfterMs !== "number" || typeof markedAtMs !== "number") return null;
+  return { ref: { providerId, assetId }, kind, ownerUid, markedAtMs, deleteAfterMs };
+}
+
+/**
+ * Mark assets for deletion, `ASSET_DELETE_GRACE_DAYS` from now.
+ *
+ * Idempotent by document id, and a re-mark RESTARTS the clock rather than
+ * preserving the original deadline. That is the correct reading rather than a
+ * shortcut: a tombstone is cleared the moment anything references the asset
+ * again, so a second mark means it became unreferenced a second time, and the
+ * grace period is measured from that.
+ */
+export async function markAssetsForDeletion(
+  ownerUid: string,
+  candidates: readonly AssetDeletionCandidate[],
+  now: number = Date.now(),
+): Promise<number> {
+  if (candidates.length === 0) return 0;
+  const db = getFirebaseDb();
+  for (let start = 0; start < candidates.length; start += BATCH_LIMIT) {
+    const batch = db.batch();
+    for (const candidate of candidates.slice(start, start + BATCH_LIMIT)) {
+      batch.set(tombstones().doc(tombstoneId(ownerUid, candidate.ref)), {
+        providerId: candidate.ref.providerId,
+        assetId: candidate.ref.assetId,
+        kind: candidate.kind,
+        ownerUid,
+        markedAtMs: now,
+        deleteAfterMs: now + GRACE_MS,
+      });
+    }
+    await batch.commit();
+  }
+  return candidates.length;
+}
+
+/** Un-mark — what restoring from the bin does, and what the sweep does to an
+ *  asset that got referenced again. The file never moved during the window, so
+ *  this is bookkeeping and not a re-upload. */
+export async function clearAssetTombstones(
+  ownerUid: string,
+  refs: readonly AssetSourceRef[],
+): Promise<number> {
+  if (refs.length === 0) return 0;
+  const db = getFirebaseDb();
+  for (let start = 0; start < refs.length; start += BATCH_LIMIT) {
+    const batch = db.batch();
+    for (const ref of refs.slice(start, start + BATCH_LIMIT)) {
+      batch.delete(tombstones().doc(tombstoneId(ownerUid, ref)));
+    }
+    await batch.commit();
+  }
+  return refs.length;
+}
+
+/** One user's marked assets — what the trash drawer's recently-deleted section
+ *  reads (PL12-004). */
+export async function listAssetTombstones(
+  ownerUid: string,
+): Promise<readonly AssetTombstone[]> {
+  const snapshot = await tombstones().where("ownerUid", "==", ownerUid).get();
+  return snapshot.docs.flatMap((doc) => {
+    const tombstone = toTombstone(doc.data() as TombstoneRecord);
+    return tombstone === null ? [] : [tombstone];
+  });
+}
+
+/**
+ * Tombstones whose grace period has run out, oldest deadline first.
+ *
+ * A single-field inequality — served by Firestore's automatic index, so this
+ * needs no deploy. The limit is the sweep's batch size, not a filter: what it
+ * does not reach stays due and is taken by the next run.
+ */
+export async function listDueAssetTombstones(
+  now: number = Date.now(),
+  limit = 200,
+): Promise<readonly AssetTombstone[]> {
+  const snapshot = await tombstones()
+    .where("deleteAfterMs", "<=", now)
+    .orderBy("deleteAfterMs")
+    .limit(limit)
+    .get();
+  return snapshot.docs.flatMap((doc) => {
+    const tombstone = toTombstone(doc.data() as TombstoneRecord);
+    return tombstone === null ? [] : [tombstone];
+  });
+}

--- a/apps/timeline-gstudio001/lib/assets/asset-references.test.ts
+++ b/apps/timeline-gstudio001/lib/assets/asset-references.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+
+import type { TimelineClip } from "@storyboard/timeline-model/types";
+
+import {
+  assetCandidatesFromClips,
+  assetKeysFromClips,
+  assetRefKey,
+  unreferencedCandidates,
+} from "./asset-references";
+
+function mediaClip(
+  id: string,
+  source?: { providerId: string; assetId: string },
+  kind: "image" | "video" = "image",
+): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind,
+    src: `https://example.test/${id}`,
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 4,
+    sourceDuration: 4,
+    trimIn: 0,
+    trimOut: 0,
+    ...(source === undefined ? {} : { sourceAsset: source }),
+  } as TimelineClip;
+}
+
+function collectionClip(id: string): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "collection",
+    title: id,
+    childTimelineId: `${id}-child`,
+    itemCount: 2,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 8,
+    sourceDuration: 8,
+    trimIn: 0,
+    trimOut: 0,
+  } as TimelineClip;
+}
+
+describe("assetRefKey", () => {
+  it("survives a path-shaped asset id", () => {
+    // Cloudinary public ids contain "/" — the key must stay one Firestore-legal
+    // segment, so the encoding has to escape it.
+    const key = assetRefKey({ providerId: "cloudinary", assetId: "root/user-a/proj/clip.mp4" });
+    expect(key).toBe("cloudinary|root%2Fuser-a%2Fproj%2Fclip.mp4");
+    expect(key).not.toContain("/");
+  });
+
+  it("cannot be forged by an id containing the delimiter", () => {
+    // Without encoding, these two collide: "a|b" + "c" vs "a" + "b|c".
+    const left = assetRefKey({ providerId: "a|b", assetId: "c" });
+    const right = assetRefKey({ providerId: "a", assetId: "b|c" });
+    expect(left).not.toBe(right);
+  });
+
+  it("distinguishes the same asset id under different providers", () => {
+    expect(assetRefKey({ providerId: "cloudinary", assetId: "same" })).not.toBe(
+      assetRefKey({ providerId: "s3", assetId: "same" }),
+    );
+  });
+});
+
+describe("assetCandidatesFromClips", () => {
+  it("takes provenance and the kind the provider will need", () => {
+    const candidates = assetCandidatesFromClips([
+      mediaClip("c1", { providerId: "cloudinary", assetId: "a.png" }),
+      mediaClip("c2", { providerId: "cloudinary", assetId: "b.mp4" }, "video"),
+    ]);
+
+    expect(candidates).toEqual([
+      { ref: { providerId: "cloudinary", assetId: "a.png" }, kind: "image" },
+      { ref: { providerId: "cloudinary", assetId: "b.mp4" }, kind: "video" },
+    ]);
+  });
+
+  it("de-duplicates: two clips of one file are one asset", () => {
+    // The exact shape that made the old delete-on-empty unsafe.
+    const ref = { providerId: "cloudinary", assetId: "shared.png" };
+    expect(assetCandidatesFromClips([mediaClip("c1", ref), mediaClip("c2", ref)])).toHaveLength(1);
+  });
+
+  it("ignores clips with no provenance, and collections", () => {
+    // An asset nobody can name is never deleted: un-provenanced media leaks
+    // storage, which is the failure direction this is allowed to have.
+    expect(
+      assetCandidatesFromClips([mediaClip("legacy"), collectionClip("folder")]),
+    ).toEqual([]);
+  });
+});
+
+describe("unreferencedCandidates", () => {
+  const orphan = { providerId: "cloudinary", assetId: "orphan.png" };
+  const shared = { providerId: "cloudinary", assetId: "shared.png" };
+
+  it("keeps only what nothing points at", () => {
+    const candidates = assetCandidatesFromClips([
+      mediaClip("t1", orphan),
+      mediaClip("t2", shared),
+    ]);
+    const referenced = new Set(assetKeysFromClips([mediaClip("live", shared)]));
+
+    expect(unreferencedCandidates(candidates, referenced)).toEqual([
+      { ref: orphan, kind: "image" },
+    ]);
+  });
+
+  it("counts a reference from a DIFFERENT provider as a different asset", () => {
+    const candidates = assetCandidatesFromClips([mediaClip("t1", orphan)]);
+    const referenced = new Set(
+      assetKeysFromClips([mediaClip("live", { providerId: "s3", assetId: "orphan.png" })]),
+    );
+
+    expect(unreferencedCandidates(candidates, referenced)).toHaveLength(1);
+  });
+
+  it("deletes nothing when everything is still in use", () => {
+    const candidates = assetCandidatesFromClips([mediaClip("t1", shared)]);
+    const referenced = new Set(assetKeysFromClips([mediaClip("live", shared)]));
+
+    expect(unreferencedCandidates(candidates, referenced)).toEqual([]);
+  });
+});

--- a/apps/timeline-gstudio001/lib/assets/asset-references.ts
+++ b/apps/timeline-gstudio001/lib/assets/asset-references.ts
@@ -1,0 +1,92 @@
+// Which uploaded files is anything still pointing at?
+//
+// PURE and isomorphic — no Firestore, no provider, no clock. The two callers
+// that matter (emptying the bin, the nightly reclaim sweep) differ only in
+// where they get their documents from, so the RULE lives here on its own and
+// unit-tests without a backend.
+//
+// The rule: an asset dies when nothing references it. Not when its clip is
+// deleted — one upload can back several clips (this app mints stable per-asset
+// clip ids, so placing an asset twice makes two clips of one file), and the bin
+// is per-USER while an asset is per-project, so a bin spans everything its
+// owner owns.
+
+import type { TimelineClip } from "@storyboard/timeline-model/types";
+
+import type { AssetKind, AssetSourceRef } from "./types";
+
+/**
+ * A stable string key for an `AssetSourceRef`, and the id its tombstone is
+ * stored under.
+ *
+ * Both halves are percent-encoded before being joined. `encodeURIComponent`
+ * escapes `|` (to `%7C`) and `/` (to `%2F`), so no provider id or asset id can
+ * fake the delimiter however path-shaped it is — the NodeId lesson, applied
+ * before it can bite: assume the id contains your separator.
+ *
+ * Escaping `/` is also what makes this a legal Firestore document id. The other
+ * id rules are unreachable here: the key always begins with an encoded provider
+ * id ("cloudinary", "s3"), so it can be neither "." nor ".." nor a match for
+ * the reserved `__.*__`.
+ */
+export function assetRefKey(ref: AssetSourceRef): string {
+  return `${encodeURIComponent(ref.providerId)}|${encodeURIComponent(ref.assetId)}`;
+}
+
+/** An asset a caller is considering deleting: the ref, plus the `kind` its
+ *  provider needs to address it (Cloudinary's destroy endpoint is per resource
+ *  type). Recorded on the tombstone so the sweep, running 30 days later with
+ *  no clip in hand, still knows how to ask. */
+export type AssetDeletionCandidate = Readonly<{
+  ref: AssetSourceRef;
+  kind: AssetKind;
+}>;
+
+/** Media clips carry provenance; collection clips have no file behind them. */
+function sourceAssetOf(clip: TimelineClip): AssetDeletionCandidate | null {
+  if (clip.kind !== "image" && clip.kind !== "video") return null;
+  if (clip.sourceAsset === undefined) return null;
+  return { ref: clip.sourceAsset, kind: clip.kind };
+}
+
+/**
+ * The distinct assets behind a set of clips, de-duplicated by ref key.
+ *
+ * A clip WITHOUT `sourceAsset` contributes nothing. That is deliberate and it
+ * is the conservative direction: provenance is only recorded on clips minted
+ * from the asset seam, so a clip that predates it (or arrived by another path)
+ * names no asset, and an asset nobody can name is never deleted. Un-provenanced
+ * media leaks storage; it can never lose a file.
+ */
+export function assetCandidatesFromClips(
+  clips: readonly TimelineClip[],
+): readonly AssetDeletionCandidate[] {
+  const byKey = new Map<string, AssetDeletionCandidate>();
+  for (const clip of clips) {
+    const candidate = sourceAssetOf(clip);
+    if (candidate === null) continue;
+    byKey.set(assetRefKey(candidate.ref), candidate);
+  }
+  return [...byKey.values()];
+}
+
+/** Every asset key referenced by a set of clips — the other side of the same
+ *  walk, for building the "still in use" set out of live documents. */
+export function assetKeysFromClips(clips: readonly TimelineClip[]): readonly string[] {
+  return assetCandidatesFromClips(clips).map((candidate) => assetRefKey(candidate.ref));
+}
+
+/**
+ * The candidates nothing points at.
+ *
+ * `referenced` is the union of keys found in every document that is NOT the bin
+ * being emptied — the caller decides what to exclude, because "the trash's own
+ * clips are not references to themselves" is a fact about the caller's
+ * situation, not about this rule.
+ */
+export function unreferencedCandidates(
+  candidates: readonly AssetDeletionCandidate[],
+  referenced: ReadonlySet<string>,
+): readonly AssetDeletionCandidate[] {
+  return candidates.filter((candidate) => !referenced.has(assetRefKey(candidate.ref)));
+}

--- a/apps/timeline-gstudio001/lib/assets/cloudinary-provider.test.ts
+++ b/apps/timeline-gstudio001/lib/assets/cloudinary-provider.test.ts
@@ -8,6 +8,7 @@ const state = vi.hoisted(() => ({
   vendorAssets: [] as CloudinaryAsset[],
   listedForUid: null as string | null,
   listedForProject: null as string | null,
+  deletes: [] as { publicId: string; resourceType: string }[],
 }));
 
 vi.mock("@/lib/cloudinary-media-store", () => ({
@@ -15,6 +16,10 @@ vi.mock("@/lib/cloudinary-media-store", () => ({
     state.listedForUid = uid;
     state.listedForProject = projectId;
     return state.vendorAssets;
+  },
+  cloudinaryUserPrefix: (uid: string) => `gstudio/${uid}/`,
+  deleteCloudinaryAsset: async (publicId: string, resourceType: string) => {
+    state.deletes.push({ publicId, resourceType });
   },
 }));
 
@@ -40,6 +45,35 @@ beforeEach(() => {
   state.vendorAssets = [];
   state.listedForUid = null;
   state.listedForProject = null;
+  state.deletes.length = 0;
+});
+
+describe("remove", () => {
+  it("destroys the public id, per resource type", async () => {
+    // The kind is not decoration: Cloudinary's destroy endpoint is per
+    // resource type, and the sweep calling this has no clip left to ask.
+    await cloudinaryAssetProvider.remove?.(
+      { uid: "user-1" },
+      { assetId: "gstudio/user-1/project-a/clip.mp4", kind: "video" },
+    );
+    expect(state.deletes).toEqual([
+      { publicId: "gstudio/user-1/project-a/clip.mp4", resourceType: "video" },
+    ]);
+  });
+
+  it("refuses a public id outside the owner's folder", async () => {
+    for (const assetId of [
+      "gstudio/user-2/project-a/clip.png",
+      // The prefix's trailing slash is what stops "user-1" matching "user-10".
+      "gstudio/user-10/project-a/clip.png",
+      "somewhere-else/clip.png",
+    ]) {
+      await expect(
+        cloudinaryAssetProvider.remove?.({ uid: "user-1" }, { assetId, kind: "image" }),
+      ).rejects.toThrow(/outside the owner's folder/);
+    }
+    expect(state.deletes).toEqual([]);
+  });
 });
 
 describe("cloudinaryAssetToAsset", () => {
@@ -123,16 +157,21 @@ describe("cloudinaryAssetProvider.list", () => {
     expect(scenes.folders).toEqual([{ name: "Heist", path: ["Scenes", "Heist"] }]);
   });
 
-  it("declares folders, tags and search on; the write capabilities off", () => {
+  it("declares folders, tags, search and delete on; upload off", () => {
     expect(cloudinaryAssetProvider.capabilities).toEqual({
       folders: true,
       tags: true,
       // Derived in memory from the same full listing folders and tags come
       // from — no vendor search API, so it is as complete as browsing is.
       search: true,
+      // Uploads still go through the vendor store directly (the drop-on-board
+      // route), so this stays off until that moves behind the seam.
       upload: false,
-      delete: false,
+      delete: true,
     });
+    // The capability and the method are one claim; a provider declaring the
+    // first without the second is a bug the registry cannot catch.
+    expect(cloudinaryAssetProvider.remove).toBeTypeOf("function");
   });
 
   it("carries vendor tags through and serves a tagPath query as a TAG page", async () => {

--- a/apps/timeline-gstudio001/lib/assets/cloudinary-provider.ts
+++ b/apps/timeline-gstudio001/lib/assets/cloudinary-provider.ts
@@ -3,7 +3,12 @@
 // it directly; this adapter only translates its LISTING into the neutral
 // `Asset` shape for the panel/API surface.
 
-import { listCloudinaryAssets, type CloudinaryAsset } from "@/lib/cloudinary-media-store";
+import {
+  cloudinaryUserPrefix,
+  deleteCloudinaryAsset,
+  listCloudinaryAssets,
+  type CloudinaryAsset,
+} from "@/lib/cloudinary-media-store";
 
 import { pageFromFlatListing, pageFromSearch, pageFromTagListing } from "./path-folders";
 import type { AssetContext, AssetProvider } from "./provider";
@@ -64,7 +69,10 @@ export const cloudinaryAssetProvider: AssetProvider = {
     // this is as complete as browsing is.
     search: true,
     upload: false,
-    delete: false,
+    // The seam's `remove` is implemented below. Uploading still happens through
+    // the vendor store directly (the drop-on-board route), so that one stays
+    // honestly off until it moves behind the seam.
+    delete: true,
   },
   async list(ctx: AssetContext, query) {
     // The store's listing is already user/project-scoped and paginated at the vendor
@@ -81,5 +89,20 @@ export const cloudinaryAssetProvider: AssetProvider = {
     return query.tagPath !== undefined
       ? pageFromTagListing(assets, query)
       : pageFromFlatListing(assets, query);
+  },
+  async remove(ctx, target) {
+    // The id has to be one of THIS user's. Nothing upstream can currently send
+    // another user's id — tombstones are written from the owner's own clips —
+    // but a delete is the one operation where "currently" is not good enough,
+    // and the public id carries the owner, so the check is free.
+    const prefix = cloudinaryUserPrefix(ctx.uid);
+    if (!target.assetId.startsWith(prefix)) {
+      throw new Error("Refusing to delete a Cloudinary asset outside the owner's folder.");
+    }
+    // Cloudinary answers a destroy for a missing public id with 200 and
+    // `{ result: "not found" }`, so an already-deleted asset resolves rather
+    // than throwing — which is what the sweep needs (see `remove` on the
+    // provider type: the desired end state is "not there").
+    await deleteCloudinaryAsset(target.assetId, target.kind);
   },
 };

--- a/apps/timeline-gstudio001/lib/assets/provider.ts
+++ b/apps/timeline-gstudio001/lib/assets/provider.ts
@@ -4,16 +4,26 @@
 // adapters are.
 
 import type {
+  AssetKind,
   AssetPage,
   AssetProviderCapabilities,
   AssetProviderDescriptor,
   AssetQuery,
 } from "./types";
 
-/** Per-request context. Today just the signed-in user; per-user OAuth
- *  credentials (Drive/Dropbox) will arrive here when that track lands, which
- *  is why every provider method takes it rather than reading globals. */
-export type AssetContext = Readonly<{ uid: string; projectId: string }>;
+/** Who is asking. Per-user OAuth credentials (Drive/Dropbox) will arrive here
+ *  when that track lands, which is why every provider method takes it rather
+ *  than reading globals. */
+export type AssetOwnerContext = Readonly<{ uid: string }>;
+
+/** Per-request context for BROWSING, which is always scoped to one project. */
+export type AssetContext = AssetOwnerContext & Readonly<{ projectId: string }>;
+
+/** What `remove` needs to address a file. The `kind` is here because a
+ *  provider can need it (Cloudinary's destroy endpoint is per resource type)
+ *  and the caller is a sweep running 30 days after the clip was deleted, with
+ *  no clip left to ask. */
+export type AssetDeleteTarget = Readonly<{ assetId: string; kind: AssetKind }>;
 
 export type AssetProvider = AssetProviderDescriptor &
   Readonly<{
@@ -21,6 +31,19 @@ export type AssetProvider = AssetProviderDescriptor &
      *  outside its capabilities by ignoring them (never throwing): the
      *  capabilities gate the UI, not the wire. */
     list: (ctx: AssetContext, query: AssetQuery) => Promise<AssetPage>;
+    /**
+     * Permanently delete one asset. Present exactly when
+     * `capabilities.delete` is true — the registry has no way to enforce that
+     * pairing, so an adapter declaring the capability without the method is a
+     * bug its own tests should catch.
+     *
+     * Takes an OWNER context, not a project one: deletion addresses a durable
+     * asset id, and by the time this runs there is no project view of it. A
+     * missing asset is a SUCCESS — the desired end state is "this file is not
+     * there", and a sweep that throws on an already-deleted object would jam
+     * behind it forever.
+     */
+    remove?: (ctx: AssetOwnerContext, target: AssetDeleteTarget) => Promise<void>;
   }>;
 
 export type AssetProviderRegistry = Readonly<{

--- a/apps/timeline-gstudio001/lib/assets/s3-provider.test.ts
+++ b/apps/timeline-gstudio001/lib/assets/s3-provider.test.ts
@@ -15,13 +15,19 @@ const ENV = {
   S3_ASSETS_PUBLIC_URL: "https://cdn.test",
 } as const;
 
-function deps(objects: readonly S3ObjectSummary[]): S3Deps {
+function deps(
+  objects: readonly S3ObjectSummary[],
+  deletes: string[] = [],
+): S3Deps {
   return {
     listObjects: async () => objects,
     // Public-base style: encoded key appended. The presigned path is exercised
     // separately below.
     urlFor: async (key) =>
       `https://cdn.test/${key.split("/").map(encodeURIComponent).join("/")}`,
+    deleteObject: async (key) => {
+      deletes.push(key);
+    },
   };
 }
 
@@ -147,8 +153,10 @@ describe("createS3AssetProvider", () => {
       // S3 has no search API and needs none: the same in-memory derivation
       // over the same listing that already serves folders.
       search: true,
+      // Nothing uploads to S3 through this app yet; deleting is implemented
+      // (see the remove tests below).
       upload: false,
-      delete: false,
+      delete: true,
     });
     // A stray tagPath is ignored (contract: never throw), served as folders.
     const page = await s3.list(
@@ -173,10 +181,65 @@ describe("createS3AssetProvider", () => {
     const created = createS3AssetProvider(ENV, {
       listObjects,
       urlFor: async (key) => `https://cdn.test/${key}`,
+      deleteObject: async () => {},
     });
     if (created === null) throw new Error("expected provider");
     await created.list({ uid: "u", projectId: "project-a" }, {});
     await created.list({ uid: "u", projectId: "project-b" }, { folder: ["x"] });
     expect(listObjects).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("remove", () => {
+  it("deletes the object by key", async () => {
+    const deletes: string[] = [];
+    const created = createS3AssetProvider(ENV, deps([], deletes));
+    if (created === null) throw new Error("expected provider");
+
+    await created.remove?.({ uid: "u" }, { assetId: "media/u/project-a/a.png", kind: "image" });
+    expect(deletes).toEqual(["media/u/project-a/a.png"]);
+  });
+
+  it("refuses a key outside the owner's prefix", async () => {
+    // The listing only ever exposes `<prefix>/<uid>/<projectId>/…`, so that is
+    // the boundary a delete has to be held to as well.
+    const deletes: string[] = [];
+    const created = createS3AssetProvider(ENV, deps([], deletes));
+    if (created === null) throw new Error("expected provider");
+
+    for (const assetId of [
+      "media/other-user/project-a/a.png",
+      // The trailing slash in the prefix is what stops a uid prefix-matching a
+      // longer one.
+      "media/u2/project-a/a.png",
+      "somewhere/else.png",
+    ]) {
+      await expect(created.remove?.({ uid: "u" }, { assetId, kind: "image" })).rejects.toThrow(
+        /outside the owner's prefix/,
+      );
+    }
+    expect(deletes).toEqual([]);
+  });
+
+  it("declares the capability it implements", () => {
+    expect(provider([]).capabilities.delete).toBe(true);
+    expect(provider([]).remove).toBeTypeOf("function");
+  });
+
+  it("drops the listing cache, so a deleted object stops being served", async () => {
+    const listObjects = vi.fn(async () => [{ key: "media/u/p/a.png" }] as S3ObjectSummary[]);
+    const created = createS3AssetProvider(ENV, {
+      listObjects,
+      urlFor: async (key) => `https://cdn.test/${key}`,
+      deleteObject: async () => {},
+    });
+    if (created === null) throw new Error("expected provider");
+
+    await created.list({ uid: "u", projectId: "p" }, {});
+    await created.remove?.({ uid: "u" }, { assetId: "media/u/p/a.png", kind: "image" });
+    await created.list({ uid: "u", projectId: "p" }, {});
+    // Without the invalidation the second browse is served from the 30s cache
+    // and renders a tile whose URL now 404s.
+    expect(listObjects).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/timeline-gstudio001/lib/assets/s3-provider.ts
+++ b/apps/timeline-gstudio001/lib/assets/s3-provider.ts
@@ -34,6 +34,10 @@ export type S3Deps = Readonly<{
   listObjects: () => Promise<readonly S3ObjectSummary[]>;
   /** A browser-usable URL for an object key (public base or presigned). */
   urlFor: (key: string) => Promise<string>;
+  /** Permanently remove one object. S3's DeleteObject is idempotent — deleting
+   *  a key that isn't there succeeds — which is exactly the contract the
+   *  provider's `remove` wants. */
+  deleteObject: (key: string) => Promise<void>;
 }>;
 
 export type S3Config = Readonly<{
@@ -145,14 +149,23 @@ function createSdkDeps(config: S3Config): S3Deps {
       nextToken?: string;
     }>;
     presign: (key: string) => Promise<string>;
+    remove: (key: string) => Promise<void>;
   };
   let handlesPromise: Promise<SdkHandles> | null = null;
   const handles = () =>
     (handlesPromise ??= (async () => {
-      const [{ S3Client, ListObjectsV2Command, GetObjectCommand }, { getSignedUrl }] =
-        await Promise.all([import("@aws-sdk/client-s3"), import("@aws-sdk/s3-request-presigner")]);
+      const [
+        { S3Client, ListObjectsV2Command, GetObjectCommand, DeleteObjectCommand },
+        { getSignedUrl },
+      ] = await Promise.all([
+        import("@aws-sdk/client-s3"),
+        import("@aws-sdk/s3-request-presigner"),
+      ]);
       const client = new S3Client({ region: config.region });
       return {
+        remove: async (key: string) => {
+          await client.send(new DeleteObjectCommand({ Bucket: config.bucket, Key: key }));
+        },
         send: async ({ prefix, token }) => {
           const output = await client.send(
             new ListObjectsV2Command({
@@ -210,6 +223,7 @@ function createSdkDeps(config: S3Config): S3Deps {
       }
       return handles().then((sdk) => sdk.presign(key));
     },
+    deleteObject: (key) => handles().then((sdk) => sdk.remove(key)),
   };
 }
 
@@ -251,7 +265,9 @@ export function createS3AssetProvider(
       // needed, so this is exactly as complete as browsing is here.
       search: true,
       upload: false,
-      delete: false,
+      // `remove` below. Nothing uploads to S3 through this app yet, so that
+      // capability stays off.
+      delete: true,
     },
     async list(ctx, query) {
       const objects = await listing();
@@ -271,6 +287,20 @@ export function createS3AssetProvider(
       // never throw) — without tags every asset would sit at the tags root,
       // which is just the folder-flat view, so serve folders regardless.
       return pageFromFlatListing(assets, query);
+    },
+    async remove(ctx, target) {
+      // Keys are exposed only beneath `<prefix>/<uid>/<projectId>/`, which is
+      // the ownership boundary this adapter already browses by — so it is also
+      // what a delete must be held to. `kind` is unused: S3 addresses an
+      // object by key alone.
+      const ownerPrefix = `${config.prefix}${ctx.uid}/`;
+      if (!target.assetId.startsWith(ownerPrefix)) {
+        throw new Error("Refusing to delete an S3 object outside the owner's prefix.");
+      }
+      await deps.deleteObject(target.assetId);
+      // The listing cache would otherwise keep serving the deleted object for
+      // up to its TTL, and the palette would render a tile whose URL 404s.
+      cached = null;
     },
   };
 }

--- a/apps/timeline-gstudio001/lib/cloudinary-media-store.ts
+++ b/apps/timeline-gstudio001/lib/cloudinary-media-store.ts
@@ -309,6 +309,19 @@ function invalidateAssetListCache(userId?: string) {
   }
 }
 
+/**
+ * The public-id prefix every one of a user's assets sits under.
+ *
+ * Exported so a DELETE can prove an id belongs to the user asking, without
+ * re-deriving the layout at the call site. A public id is a path and this app
+ * builds it as `<folder>/<uid>/<projectId>/…` (see `listCloudinaryAssetsUncached`
+ * and the upload path); the trailing slash is what stops `uid` matching
+ * `uid-2`.
+ */
+export function cloudinaryUserPrefix(userId: string) {
+  return `${getCloudinaryConfig().folder}/${userId}/`;
+}
+
 export async function listCloudinaryAssets(userId: string, projectId?: string) {
   const key = assetListCacheKey(userId, projectId);
   const cached = assetListCache.get(key);

--- a/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
@@ -282,6 +282,89 @@ export async function listFirebaseTimelineProjects(requesterUid: string) {
     });
 }
 
+/** One page of the reference scan. Small enough that a user with a handful of
+ *  documents pays one round trip. */
+const REFERENCE_SCAN_PAGE = 200;
+/**
+ * Hard ceiling on a single reference scan, in DOCUMENTS.
+ *
+ * Reached, the scan THROWS rather than returning what it has. An asset is
+ * deleted on the strength of "nothing references this", so a scan that
+ * silently stopped early is indistinguishable from a clean bill of health and
+ * would take a file out from under a live clip. Incomplete must fail loudly;
+ * the one failure this design accepts is leaking storage, never losing media.
+ */
+const REFERENCE_SCAN_MAX_DOCUMENTS = 5_000;
+
+/** A reference scan could not be completed, so its result must not be treated
+ *  as "nothing points at this". */
+export class TimelineScanIncompleteError extends Error {
+  constructor(scanned: number) {
+    super(
+      `Reference scan exceeded ${scanned} documents. Refusing to report an incomplete result.`,
+    );
+    this.name = "TimelineScanIncompleteError";
+  }
+}
+
+/**
+ * Every clip stored under a user's documents — the input to "is this uploaded
+ * file still referenced".
+ *
+ * Deliberately a SUPERSET. It reads `document.clips`, the legacy top-level
+ * `clips`, and the `lastNonEmptyDocument` recovery snapshot, because
+ * `toTimelineDocument` will hand any of the three back as the live document
+ * depending on what is empty — a clip only reachable through the recovery
+ * snapshot is one ordinary read away from being on screen again, so it counts
+ * as a reference. Over-counting leaves a file nobody uses; under-counting
+ * deletes one somebody does.
+ *
+ * Paged to exhaustion, ordered by document id so the cursor is total. The
+ * ownership filter is in the QUERY (round 12's lesson: an authorization filter
+ * applied after a limit selects from everyone's rows) and re-checked here,
+ * which is this module's one invariant.
+ */
+export async function collectOwnedTimelineClips(
+  requesterUid: string,
+  options: Readonly<{ excludeIds?: readonly string[] }> = {},
+): Promise<TimelineClip[]> {
+  const excluded = new Set(options.excludeIds ?? []);
+  const clips: TimelineClip[] = [];
+  // The last DOCUMENT SNAPSHOT, not its id: with `orderBy("__name__")` a
+  // cursor has to resolve to a document path, and handing back the snapshot
+  // the SDK just produced is the form that cannot be got wrong.
+  let cursor: FirebaseFirestore.QueryDocumentSnapshot | null = null;
+  let scanned = 0;
+
+  for (;;) {
+    let query = collection()
+      .where("ownerUid", "==", requesterUid)
+      .orderBy("__name__")
+      .limit(REFERENCE_SCAN_PAGE);
+    if (cursor !== null) query = query.startAfter(cursor);
+
+    const snapshot = await withFirebaseTimeout(query.get(), "Scanning timeline documents");
+    if (snapshot.docs.length === 0) return clips;
+
+    for (const doc of snapshot.docs) {
+      scanned += 1;
+      if (scanned > REFERENCE_SCAN_MAX_DOCUMENTS) {
+        throw new TimelineScanIncompleteError(REFERENCE_SCAN_MAX_DOCUMENTS);
+      }
+      cursor = doc;
+      if (excluded.has(doc.id)) continue;
+      const data = doc.data() as TimelineDocumentRecord;
+      if (resolveOwnership(data.ownerUid, requesterUid) !== "owned") continue;
+
+      for (const source of [data.document?.clips, data.clips, data.lastNonEmptyDocument?.clips]) {
+        if (Array.isArray(source)) clips.push(...source);
+      }
+    }
+
+    if (snapshot.docs.length < REFERENCE_SCAN_PAGE) return clips;
+  }
+}
+
 export async function getFirebaseTimelineEntry(
   id: string,
   requesterUid: string,

--- a/apps/timeline-gstudio001/vercel.json
+++ b/apps/timeline-gstudio001/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/assets/reclaim",
+      "schedule": "17 4 * * *"
+    }
+  ]
+}

--- a/docs/asset-providers.md
+++ b/docs/asset-providers.md
@@ -105,8 +105,9 @@ serves both; only the source differs:
    work). The SDK loads lazily and the deps (`listObjects` / `urlFor`) are
    injectable, so the adapter unit-tests without AWS. The provider registers
    only when the bucket is configured; the palette's picker `<select>`
-   appears only when more than one provider is installed. Upload/delete
-   through the seam is still ahead (both providers declare them off).
+   appears only when more than one provider is installed. Upload through the
+   seam is still ahead (both providers declare it off — media enters this app
+   by being dropped on the board, which uses the vendor store directly).
 5. ✅ Retire the legacy virtual-timeline pipeline onto the seam, then delete
    it. Phase 5 first moved the `/api/timelines/asset-library-*` GET branch
    onto the Cloudinary provider (no more bespoke listing or hand-rolled
@@ -118,11 +119,45 @@ serves both; only the source differs:
    route branch and their tests — since nothing else ever requested those
    ids. The palette browses `/api/assets` and needs no timeline document.
 
+6. ✅ **Deletion** (PL12-003). `AssetProvider.remove(ctx, { assetId, kind })`,
+   declared by `capabilities.delete`, implemented by both adapters, and taking
+   an OWNER context rather than a project one — a delete addresses a durable
+   asset id, and by the time it runs there is no project view of it. Each
+   adapter refuses an id outside its owner's prefix, and a missing asset is a
+   SUCCESS: the desired end state is "not there", and a sweep that threw on an
+   already-deleted object would jam behind it forever.
+
 The seam is now the only asset-BROWSING path in the app. `listCloudinaryAssets`
 survives in exactly two places: the Cloudinary provider adapter (its data
 source), and `serve-timeline`'s document HEALING (validating a stored clip's
 media still exists) — a different concern from browsing, left as-is. No route
 lists assets to browse them except through a provider.
+
+## Reclaiming storage
+
+Nothing deleted an uploaded file until PL12-003, so a Cloudinary/S3 object
+outlived every timeline that referenced it. The rule now is REFERENCES, and it
+runs in two halves:
+
+- **Marking** — `DELETE /api/trash` (emptying the bin) scans the owner's
+  documents and writes a tombstone for each trashed clip's `sourceAsset` that
+  no surviving clip points at. `lib/assets/asset-references.ts` holds the pure
+  rule; `lib/asset-tombstones.ts` the records.
+- **Sweeping** — `GET /api/assets/reclaim`, cron-driven (`vercel.json`,
+  `CRON_SECRET`), takes tombstones past their 30-day grace period,
+  **re-checks references**, and deletes only what is still unreferenced.
+  Anything back in use loses its tombstone instead.
+
+Three properties worth preserving if this is ever rewritten:
+
+- The re-check is what lets the marking scan be merely careful. A mark is an
+  intention, never an authority.
+- Every failure leaks storage rather than losing a file: an un-provenanced clip
+  names no asset and is never marked; an incomplete document scan throws
+  (`TimelineScanIncompleteError`) instead of reporting "unreferenced"; a failed
+  vendor delete leaves the tombstone due.
+- The tombstone collection must NOT get a Firestore TTL policy. TTL would expire
+  the record and strand the file — the exact inverse of the job.
 
 ## Enabling S3
 

--- a/punch-list/PUNCH-LIST-12.md
+++ b/punch-list/PUNCH-LIST-12.md
@@ -1,0 +1,207 @@
+# Punch List 12
+
+## PL12-005 — Retire the asset tray
+
+- Status: Not started
+- Area: `graph-asset-palette.tsx`, `timeline-sidebar.tsx`
+- Blocked by: PL12-003, PL12-004
+
+The tray browses a BYPRODUCT. Media enters this app by being dropped on the
+board (`/api/timeline-media/upload`), and every asset is minted
+`projectIds: [projectId]` — scoped to the project it was uploaded into, so
+there is no cross-project reuse for the tray to serve. What it shows that the
+board does not is orphans: assets in storage that no timeline references.
+
+Once PL12-003 reclaims those, orphans stop accumulating and the tray has
+nothing left of its own to show. PL12-004 gives the one remaining case — media
+that is deleted but still recoverable — a better home.
+
+What must NOT be lost with it: the ability to find something. That is a
+separate need and a different target (clips on the board, searched by the
+`title` PL11-004 added), not an asset browser. Log it as its own item rather
+than smuggling it in here.
+
+## PL12-004 — The trash becomes the recently-deleted surface
+
+- Status: Not started
+- Area: `trash-drawer.tsx`, `/api/trash`
+- Blocked by: PL12-003
+
+Two waiting rooms is one too many. PL12-003 marks an asset and deletes it 30
+days later, but a mark with no UI is a clock nobody can see or act on, while
+the trash is already a holding area with a restore control.
+
+So the trash grows a "Recently deleted" section: assets carrying a tombstone,
+with days remaining, and a restore that clears the tombstone. The file never
+went anywhere during the window — restoring is bookkeeping, not a re-upload.
+
+This is what the trash becomes once the tray is gone: the surface for
+everything that is not currently on a board. It is also where the copy debt
+is — the empty-trash confirm still promises that uploaded files stay in the
+Assets library, which PL12-003 makes false.
+
+## PL12-003 — Reference-counted asset deletion
+
+- Status: Complete
+- Area: `lib/assets/asset-references.ts` (new), `lib/asset-tombstones.ts`
+  (new), `app/api/assets/reclaim/route.ts` (new), `/api/trash`,
+  `firebase-timeline-store.ts`, both provider adapters, `vercel.json` (new)
+- Screenshot: n/a (server-side)
+
+Nothing in this app has ever reclaimed storage: both providers declare
+`delete: false`, so a Cloudinary/S3 object outlives every timeline that
+referenced it, forever. Emptying the trash is the moment the user says the
+media is finished with, and today it is the moment the app forgets the media
+exists while continuing to pay for it.
+
+The naive version of this shipped once and was REVERTED as unsafe — see the
+comment in `/api/trash`: one upload can back several clips (stable per-asset
+clip ids mean placing an asset twice makes two clips of one file), and the bin
+is per-USER (`trash-${uid}`) while an asset is per-project, so one bin spans
+everything the user owns. Deleting the file behind a trashed clip could pull
+it out from under a clip still on a board.
+
+The rule is therefore REFERENCES, not the bin: an asset dies when nothing
+points at it. `sourceAsset` is recorded on every clip minted from an asset for
+exactly this ("the hook for re-linking, usage queries, and safe deletion
+later").
+
+And the delete is DEFERRED by 30 days, which buys more than user forgiveness:
+the sweep re-checks references before it deletes, so the mark is advisory and
+a scan that missed a reference self-corrects instead of losing a file. The
+correctness requirement drops from "the scan must be right" to "the scan must
+be roughly right".
+
+Decisions:
+
+- **The tombstone lives in Firestore**, keyed by `AssetSourceRef`
+  (`{providerId, assetId}`), not as a vendor tag — Cloudinary tags and S3
+  object tags would be two implementations of one idea, below a seam built to
+  stop exactly that.
+- **No Firestore TTL policy on it**, even though this repo already uses TTL
+  (`mcpOAuthCodes`, `mcpOAuthRefreshTokens` in `firestore.indexes.json`). TTL
+  would expire the RECORD and keep the FILE — precisely inverted. The
+  tombstone must outlive its own deadline until a sweeper honours it.
+- **A cron-triggered, token-guarded reclaim route**, daily against a 30-day
+  window. Not a lazy sweep on a read path: round 12 took writes off read
+  paths, and a user who does not sign in for two months would never reclaim.
+- **Restore-from-trash is the only un-mark.** Once the tray is gone nothing
+  else can resurrect an asset — a re-upload mints a NEW public id, so it could
+  not match the tombstone anyway.
+- **Scan, don't index.** "Is this referenced" reads the user's documents.
+  Acceptable at empty-time and in a batched nightly sweep; a usage index
+  (`assetId → documents`) is the follow-up if it gets slow, not the first
+  build.
+
+Acceptance criteria:
+
+- Emptying the bin marks only assets NOTHING references; a file backing a clip
+  still on a board is never marked. ✅
+- The sweep re-checks references and deletes only what is still unreferenced
+  after 30 days; a re-referenced asset loses its tombstone instead. ✅
+- A failure to mark leaks storage rather than losing a file. ✅
+- Restoring from the trash clears the tombstone — NOT BUILT, and it turned out
+  not to be reachable: a tombstone only exists after the bin was emptied, and
+  emptying leaves no entry to restore. The equivalent case (an asset marked,
+  then re-placed from the tray) is covered by the sweep's re-check. An explicit
+  un-mark control belongs with PL12-004, which is where a marked asset first
+  becomes visible.
+
+What was built:
+
+- **`lib/assets/asset-references.ts`** — the pure rule, no Firestore and no
+  clock: `assetRefKey` (both halves percent-encoded before joining on `|`, so
+  no path-shaped Cloudinary id can fake the delimiter — and escaping `/` is
+  also what makes it a legal Firestore document id), `assetCandidatesFromClips`,
+  `unreferencedCandidates`.
+- **`lib/asset-tombstones.ts`** — the records, in `gstudioAssetTombstones`,
+  carrying `kind` because the sweep runs 30 days after the last clip that knew
+  it. A re-mark restarts the clock, which is the correct reading rather than a
+  shortcut: a tombstone is cleared the moment anything references the asset, so
+  a second mark means it became unreferenced a second time.
+- **`collectOwnedTimelineClips`** in the store — paged to exhaustion, ownership
+  filtered IN the query, and reading `document.clips`, the legacy top-level
+  `clips` AND `lastNonEmptyDocument` because `toTimelineDocument` will hand any
+  of the three back as the live document. Past 5,000 documents it THROWS
+  (`TimelineScanIncompleteError`) rather than returning what it has: an asset
+  dies on the strength of "nothing references this", so a scan that stopped
+  early is indistinguishable from a clean bill of health.
+- **`AssetProvider.remove`** + `capabilities.delete` on both adapters, taking
+  an OWNER context rather than a project one. Each refuses an id outside its
+  owner's prefix (`gstudio/<uid>/`, `<prefix>/<uid>/` — the trailing slash is
+  what stops `user-1` matching `user-10`), and S3's drops the listing cache so
+  a deleted object stops being served.
+- **`GET /api/assets/reclaim`** — cron-driven, `CRON_SECRET` bearer compared in
+  constant time, 503 (never open) when unset. Groups due tombstones by owner,
+  re-scans, spares what came back, deletes the rest. A failed scan skips that
+  OWNER entirely; a failed vendor delete or an unconfigured provider leaves the
+  tombstone due, because forgetting the intention would strand the file.
+
+Both halves proven fail-first: without the reference check, emptying marks a
+file two clips share (2 red); without the sweep's re-check, an asset back in use
+is deleted (2 red).
+
+Verified: app tsc clean, 521 app tests, lint clean (4 pre-existing `<img>`
+warnings), graph-view e2e 101/101, and the live route answers 503 with no
+`CRON_SECRET` configured.
+
+Two things for the user to confirm before this does anything in production:
+
+- `CRON_SECRET` must be set in the Vercel environment, or the sweep never runs
+  (which is the safe direction — storage leaks, nothing is lost).
+- `vercel.json` is at `apps/timeline-gstudio001/`, which assumes the Vercel
+  project's Root Directory is that app. If the project deploys from the repo
+  root instead, the cron entry has to move with it.
+
+## PL12-002 — A longer active-tile bar
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `timeline-sidebar.tsx`
+- Screenshot: Not captured
+
+The sky bar marking the active layout tile (grid / strip) went from `h-7` to
+`h-9` — 28px to 36px, against a 56px pill inside a 71px tile.
+
+Long enough to read as a bar rather than a tick, short enough that it still
+marks a POSITION instead of drawing a second edge down the rail, which is the
+whole reason the treatment is a bar and not a filled tile.
+
+Verified live: the active tile's `::after` computes to 36px × 3px in
+`oklch(0.828 0.111 230.318)` (sky-300), the idle tile has none, and the bar
+follows the surface when the layout is switched.
+
+## PL12-001 — The grid layout's glyph is nine cells
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `timeline-sidebar.tsx`
+- Screenshot: Not captured
+
+Supplied as an SVG (`menu-grid-r`, SVG Repo): a 3×3 of filled 4-unit cells on a
+24-unit box. It replaces lucide's `Table`, which drew a bordered frame divided
+by rules — a spreadsheet, which is the wrong noun for a wall of cards.
+
+Inlined as a local `GridLayoutGlyph` beside `FilmStripGlyph` rather than
+shipped as a file: every other rail glyph is a component, and an `<img>` could
+not take the rail's colour. Two changes to what was handed over, both
+load-bearing:
+
+- `fill="#000000"` → `fill="currentColor"`, so the glyph follows idle /
+  hover / active with the rest of the rail. Verified live: zinc-400
+  (`oklch(0.705 …)`) at rest, zinc-50 when the surface is active. Tailwind's
+  `transition-colors` covers `fill`, so it cross-fades like its neighbours.
+- The nine paths become nine `<rect>`s generated from one `[4, 10, 16]` track
+  list — identical geometry, and it reads as the 3×3 it is meant to be.
+
+It is the one glyph in the rail that ignores `SIDEBAR_GLYPH`'s
+`[stroke-width:1.5]`, being filled rather than stroked. Worth a look on the
+next pass: against the 1.5-stroke outlines around it a solid 3×3 carries more
+weight, which PL11-001 spent effort taking out of the rail.
+
+Acceptance criteria:
+
+- The grid tile renders the nine-cell glyph at 28px.
+- Its colour tracks the rail's idle, hover and active states.
+- The `Grid layout` label and `aria-pressed` behaviour are unchanged (the e2e
+  addresses the control by that name).


### PR DESCRIPTION
Punch list 12, items 1-3. Two small rail changes and one substantial one behind them.

## PL12-001 — nine cells for the grid layout

The rail's grid glyph was lucide's `Table`: a bordered frame divided by rules, which is a spreadsheet and the wrong noun for a wall of cards. Now nine filled cells (user-supplied SVG), inlined as a component beside `FilmStripGlyph` — an `<img>` could not take the rail's colour. `fill="currentColor"` keeps it in step with idle / hover / active, and Tailwind's `transition-colors` covers `fill` as well as `color`. Verified live: zinc-400 at rest, zinc-50 when the surface is active.

## PL12-002 — a longer active-tile bar

`h-7` to `h-9` (28px to 36px against a 56px pill). Long enough to read as a bar rather than a tick, short enough that it still marks a position instead of drawing a second edge down the rail.

## PL12-003 — reference-counted asset deletion

Nothing in this app had ever reclaimed storage: both providers declared `delete: false`, so a Cloudinary/S3 object outlived every timeline that referenced it, forever.

The naive version of this shipped once and was reverted as unsafe, and the reason has not gone away: **one upload can back several clips** (stable per-asset clip ids mean placing an asset twice makes two clips of one file), and the bin is per-USER while an asset is per-project, so one bin spans everything its owner owns. Deleting the file behind a trashed clip could pull it out from under a clip still on a board.

So the rule is REFERENCES, in two halves:

- **Marking** — `DELETE /api/trash` scans the owner's documents and writes a tombstone only for trashed clips' assets that no surviving clip points at.
- **Sweeping** — `GET /api/assets/reclaim`, cron-driven, takes tombstones past their 30-day grace period, **re-reads the documents**, spares anything back in use, and deletes the rest.

The re-check is the load-bearing half: it makes a mark an intention rather than an authority, so the marking scan only has to be roughly right.

**Every failure leaks storage rather than losing media.** A clip with no `sourceAsset` names no asset and is never marked. A document scan that cannot be completed **throws** rather than reporting "unreferenced" — a `.limit()`-shaped partial result is exactly how you delete a file someone is using. A failed vendor delete, or a provider dropped from the environment, leaves the tombstone due rather than forgetting the intention.

What landed:

- `lib/assets/asset-references.ts` — the pure rule, no Firestore and no clock. Both halves of a ref key are percent-encoded before joining on `|`, so no path-shaped public id can fake the delimiter; escaping `/` is also what makes it a legal Firestore document id.
- `lib/asset-tombstones.ts` — the records, carrying `kind` because the sweep runs 30 days after the last clip that knew it. Deliberately **no Firestore TTL policy**, though this repo uses TTL elsewhere: TTL would expire the record and strand the file, the exact inverse of the job.
- `collectOwnedTimelineClips` — paged to exhaustion, ownership filtered IN the query, reading `document.clips`, the legacy `clips` array AND `lastNonEmptyDocument`, because `toTimelineDocument` will hand any of the three back as the live document.
- `AssetProvider.remove` + `capabilities.delete` on both adapters, taking an OWNER context rather than a project one. Each refuses an id outside its owner's prefix; a missing asset is a success, since a sweep that threw on an already-deleted object would jam behind it forever.
- `GET /api/assets/reclaim` — `CRON_SECRET` bearer compared in constant time, 503 when unset, because an endpoint that deletes files must never default to open.

The trash's confirm no longer promises that uploaded files stay in the library, which this change made false.

### Proven fail-first

Without the reference check, emptying marks a file two clips share (2 tests red). Without the sweep's re-check, an asset back in use is deleted (2 tests red).

### Verification

App tsc clean, 521 app tests, lint clean (4 pre-existing `<img>` warnings), **graph-view e2e 101/101**, and the live route answers 503 with no `CRON_SECRET` configured.

### Needs an operator step

- `CRON_SECRET` must be set in the Vercel environment or the sweep never runs — the safe direction (storage leaks, nothing is lost), but nothing is reclaimed either.
- `vercel.json` is at `apps/timeline-gstudio001/`, which assumes that app is the Vercel project's Root Directory. If it deploys from the repo root, the cron entry moves with it.

### Deliberately not built

"Restoring from the trash clears the tombstone" turned out to be unreachable: a tombstone only exists after the bin was emptied, so there is no entry left to restore. The equivalent case — marked, then re-placed from the tray — is what the sweep's re-check handles. An explicit un-mark belongs with PL12-004, where a marked asset first becomes visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
