### PR TITLE
PL12-004: the trash shows what is on its way out

### DIFF
--- a/apps/timeline-gstudio001/app/api/assets/marked/marked-route.test.ts
+++ b/apps/timeline-gstudio001/app/api/assets/marked/marked-route.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The recently-deleted list and its Keep action, over the REAL handlers and the
+// REAL tombstone store — only Firestore and the session are faked.
+
+type Stored = Record<string, unknown>;
+
+const state = vi.hoisted(() => {
+  const tombstones = new Map<string, Stored>();
+  const current = {
+    user: { uid: "user-a", email: null as string | null, name: null, picture: null },
+  };
+
+  const snapshot = (id: string) => ({
+    id,
+    exists: tombstones.has(id),
+    data: () => {
+      const data = tombstones.get(id);
+      return data ? { ...data } : undefined;
+    },
+  });
+  const docRef = (id: string) => ({
+    id,
+    get: async () => snapshot(id),
+    set: async (data: Stored) => {
+      tombstones.set(id, { ...data });
+    },
+    delete: async () => {
+      tombstones.delete(id);
+    },
+  });
+  const db = {
+    collection: () => ({
+      doc: docRef,
+      where: (field: string, _op: string, value: unknown) => ({
+        orderBy: () => ({ limit: () => ({ get: async () => rows(field, value) }) }),
+        limit: () => ({ get: async () => rows(field, value) }),
+        get: async () => rows(field, value),
+      }),
+    }),
+    batch: () => {
+      const writes: (() => void)[] = [];
+      return {
+        set: (ref: { id: string }, data: Stored) => {
+          writes.push(() => tombstones.set(ref.id, { ...data }));
+        },
+        delete: (ref: { id: string }) => {
+          writes.push(() => tombstones.delete(ref.id));
+        },
+        commit: async () => {
+          for (const write of writes) write();
+        },
+      };
+    },
+  };
+  const rows = (field: string, value: unknown) => ({
+    docs: [...tombstones.entries()]
+      .filter(([, data]) => data[field] === value)
+      .map(([id]) => snapshot(id)),
+  });
+  return { tombstones, current, db };
+});
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/firebase-admin", () => ({ getFirebaseDb: () => state.db }));
+vi.mock("@/lib/firebase-auth-session", () => ({
+  requireAuthUser: async () => ({ user: state.current.user, response: null }),
+}));
+
+import { markAssetsForDeletion } from "@/lib/asset-tombstones";
+
+import { DELETE as keepAssets, GET as listMarked } from "./route";
+
+const DAY = 24 * 60 * 60 * 1000;
+
+type MarkedRow = {
+  providerId: string;
+  assetId: string;
+  name: string;
+  thumbnailUrl: string;
+  deleteAfterMs: number;
+};
+
+const mark = (
+  ownerUid: string,
+  assetId: string,
+  overrides: Partial<{ name: string; thumbnailUrl: string; markedAt: number }> = {},
+) =>
+  markAssetsForDeletion(
+    ownerUid,
+    [
+      {
+        ref: { providerId: "cloudinary", assetId },
+        kind: "image",
+        name: overrides.name ?? assetId,
+        thumbnailUrl: overrides.thumbnailUrl ?? `https://cdn.test/${assetId}`,
+      },
+    ],
+    overrides.markedAt ?? Date.now(),
+  );
+
+const list = async (): Promise<MarkedRow[]> => {
+  const response = await listMarked();
+  const body = (await response.json()) as { assets: MarkedRow[] };
+  return body.assets;
+};
+
+const keep = (assets: unknown) =>
+  keepAssets(
+    new Request("http://test.local/api/assets/marked", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ assets }),
+    }),
+  );
+
+beforeEach(() => {
+  state.tombstones.clear();
+  state.current.user = { uid: "user-a", email: null, name: null, picture: null };
+});
+
+describe("GET /api/assets/marked", () => {
+  it("prints from the tombstone's own snapshot, with no provider call", async () => {
+    // There is no clip left to derive a name or a thumbnail from — that is
+    // what being marked MEANS — so the record has to carry them.
+    await mark("user-a", "gstudio/user-a/beach.png", {
+      name: "Beach, take 3",
+      thumbnailUrl: "https://cdn.test/beach-thumb.jpg",
+    });
+
+    expect(await list()).toEqual([
+      expect.objectContaining({
+        providerId: "cloudinary",
+        assetId: "gstudio/user-a/beach.png",
+        name: "Beach, take 3",
+        thumbnailUrl: "https://cdn.test/beach-thumb.jpg",
+        kind: "image",
+      }),
+    ]);
+  });
+
+  it("puts the soonest deadline first", async () => {
+    await mark("user-a", "later.png", { markedAt: Date.now() });
+    await mark("user-a", "sooner.png", { markedAt: Date.now() - 10 * DAY });
+
+    expect((await list()).map((row) => row.assetId)).toEqual(["sooner.png", "later.png"]);
+  });
+
+  it("shows only the caller's own marks", async () => {
+    await mark("user-a", "mine.png");
+    await mark("user-b", "theirs.png");
+
+    expect((await list()).map((row) => row.assetId)).toEqual(["mine.png"]);
+  });
+
+  it("is empty when nothing is marked", async () => {
+    expect(await list()).toEqual([]);
+  });
+});
+
+describe("DELETE /api/assets/marked", () => {
+  it("keeps the named asset by dropping its mark", async () => {
+    await mark("user-a", "keep-me.png");
+    await mark("user-a", "let-go.png");
+
+    const response = await keep([{ providerId: "cloudinary", assetId: "keep-me.png" }]);
+    expect(await response.json()).toEqual({ success: true, kept: 1 });
+    expect((await list()).map((row) => row.assetId)).toEqual(["let-go.png"]);
+  });
+
+  it("cannot reach another user's mark", async () => {
+    await mark("user-b", "theirs.png");
+
+    // Tombstone ids are owner-scoped, so this names a record that does not
+    // exist for THIS caller rather than one it is allowed to touch.
+    await keep([{ providerId: "cloudinary", assetId: "theirs.png" }]);
+    state.current.user = { uid: "user-b", email: null, name: null, picture: null };
+    expect((await list()).map((row) => row.assetId)).toEqual(["theirs.png"]);
+  });
+
+  it("rejects a request naming no usable asset", async () => {
+    await mark("user-a", "still-here.png");
+
+    for (const body of [[], "not-an-array", [{ providerId: "cloudinary" }], [{ assetId: "x" }]]) {
+      expect((await keep(body)).status).toBe(400);
+    }
+    expect(await list()).toHaveLength(1);
+  });
+});

--- a/apps/timeline-gstudio001/app/api/assets/marked/route.ts
+++ b/apps/timeline-gstudio001/app/api/assets/marked/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from "next/server";
+
+import { clearAssetTombstones, listAssetTombstones } from "@/lib/asset-tombstones";
+import type { AssetSourceRef } from "@/lib/assets/types";
+import { requireAuthUser } from "@/lib/firebase-auth-session";
+import { readJsonObject } from "@/lib/read-json-body";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * The signed-in user's assets marked for deletion — what the trash drawer's
+ * "Recently deleted" section reads.
+ *
+ * Everything a row prints comes off the tombstone itself (see the display
+ * snapshot on `AssetDeletionCandidate`): no provider call, no listing, no
+ * project scope. That is not an optimization — the whole point of a marked
+ * asset is that no clip names it any more, so there is nothing left to derive
+ * a name or a thumbnail FROM.
+ *
+ * Soonest deadline first: the rows that can still be acted on are the ones
+ * running out.
+ */
+export async function GET() {
+  const { user, response } = await requireAuthUser();
+  if (response || !user) {
+    return response || NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const tombstones = await listAssetTombstones(user.uid);
+  const assets = [...tombstones]
+    .sort((left, right) => left.deleteAfterMs - right.deleteAfterMs)
+    .map((tombstone) => ({
+      providerId: tombstone.ref.providerId,
+      assetId: tombstone.ref.assetId,
+      kind: tombstone.kind,
+      name: tombstone.name,
+      thumbnailUrl: tombstone.thumbnailUrl,
+      markedAtMs: tombstone.markedAtMs,
+      deleteAfterMs: tombstone.deleteAfterMs,
+    }));
+
+  return NextResponse.json({ assets });
+}
+
+/**
+ * Keep: drop the marks on the named assets.
+ *
+ * A DELETE that deletes MARKS, not files — which is the whole point. Nothing
+ * moved when the asset was marked, so keeping it is pure bookkeeping: the file
+ * has been sitting in the library the entire window, and this only withdraws
+ * the intention to remove it.
+ *
+ * Refs are cleared by exact `{providerId, assetId}` pair and scoped to the
+ * caller's own tombstone ids, so a request naming someone else's asset finds
+ * nothing to clear rather than reaching it.
+ */
+export async function DELETE(request: Request) {
+  const { user, response } = await requireAuthUser();
+  if (response || !user) {
+    return response || NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await readJsonObject(request);
+  const refs = readRefs(body.assets);
+  if (refs.length === 0) {
+    return NextResponse.json({ error: "assets is required." }, { status: 400 });
+  }
+
+  const kept = await clearAssetTombstones(user.uid, refs);
+  return NextResponse.json({ success: true, kept });
+}
+
+function readRefs(value: unknown): readonly AssetSourceRef[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    if (typeof entry !== "object" || entry === null) return [];
+    const { providerId, assetId } = entry as Partial<AssetSourceRef>;
+    if (typeof providerId !== "string" || providerId.length === 0) return [];
+    if (typeof assetId !== "string" || assetId.length === 0) return [];
+    return [{ providerId, assetId }];
+  });
+}

--- a/apps/timeline-gstudio001/app/api/assets/reclaim/reclaim-route.test.ts
+++ b/apps/timeline-gstudio001/app/api/assets/reclaim/reclaim-route.test.ts
@@ -160,7 +160,7 @@ async function mark(
 ) {
   await markAssetsForDeletion(
     ownerUid,
-    [{ ref: { providerId, assetId }, kind }],
+    [{ ref: { providerId, assetId }, kind, name: assetId, thumbnailUrl: "" }],
     Date.now() + daysFromNow * DAY_MS - 30 * DAY_MS,
   );
 }

--- a/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
+++ b/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
@@ -13,6 +13,7 @@ import { usePathname } from "next/navigation";
 
 import { Button } from "@/components/core/button";
 import { toast } from "@/components/core/sonner";
+import { deletionWindowLabel } from "@/lib/asset-deletion-window";
 import { trashRowCaption } from "@/lib/trash-provenance";
 import { groupTrashClips } from "@/lib/trash-groups";
 import { discardTrashClips } from "@/lib/graph-trash-discard";
@@ -31,6 +32,25 @@ type TrashDrawerProps = {
   isOpen: boolean;
   onClose: () => void;
 };
+
+/**
+ * An uploaded file marked for deletion, as `/api/assets/marked` serves it.
+ *
+ * Every field is a SNAPSHOT taken when the mark was written — there is no clip
+ * left pointing at this asset, which is precisely why it is marked, so nothing
+ * here can be re-derived and none of it is a lookup key.
+ */
+type MarkedAsset = {
+  providerId: string;
+  assetId: string;
+  kind: "image" | "video";
+  name: string;
+  thumbnailUrl: string;
+  markedAtMs: number;
+  deleteAfterMs: number;
+};
+
+const markedAssetKey = (asset: MarkedAsset) => `${asset.providerId}|${asset.assetId}`;
 
 // "Am I on the client?" as an external-store read: the server snapshot says
 // no, the client snapshot says yes, and nothing ever notifies — React swaps
@@ -97,6 +117,55 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
       cancelled = true;
     };
   }, [isOpen, user, requestTrashClips]);
+
+  // The marked assets are a SEPARATE request with a separate failure: the bin
+  // is the drawer's job and this section is an addition to it, so a marked-list
+  // that fails to load leaves the bin working and simply shows nothing. One
+  // combined error surface would let a broken side-panel hide the trash.
+  const [marked, setMarked] = useState<readonly MarkedAsset[]>([]);
+  const [keepingKeys, setKeepingKeys] = useState<readonly string[]>([]);
+
+  useEffect(() => {
+    if (!isOpen || !user) return;
+    let cancelled = false;
+    fetch("/api/assets/marked", { cache: "no-store" })
+      .then((response) => (response.ok ? response.json() : { assets: [] }))
+      .then((result: { assets?: MarkedAsset[] }) => {
+        if (!cancelled) setMarked(result.assets ?? []);
+      })
+      .catch((err: unknown) => {
+        console.error(err);
+        if (!cancelled) setMarked([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, user]);
+
+  /** Withdraw the mark. The file never moved, so this is bookkeeping — no
+   *  re-upload, and nothing returns to a timeline. */
+  const handleKeep = async (asset: MarkedAsset) => {
+    const key = markedAssetKey(asset);
+    setKeepingKeys((current) => [...current, key]);
+    try {
+      const response = await fetch("/api/assets/marked", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          assets: [{ providerId: asset.providerId, assetId: asset.assetId }],
+        }),
+      });
+      if (!response.ok) throw new Error("Failed to keep asset.");
+      setMarked((current) => current.filter((entry) => markedAssetKey(entry) !== key));
+      toast(`Keeping ${asset.name}.`, { id: `asset-kept-${key}` });
+    } catch (err) {
+      console.error(err);
+      // The row stays, which is the truthful outcome: the mark is still there.
+      toast("Unable to keep that file.", { id: `asset-keep-failed-${key}` });
+    } finally {
+      setKeepingKeys((current) => current.filter((entry) => entry !== key));
+    }
+  };
 
   // RESTORE puts an item back into the timeline the user is looking at — which
   // is also how they choose the destination: navigate there, then restore. The
@@ -292,12 +361,17 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
               <AlertCircle className="h-4 w-4" />
               {error}
             </div>
-          ) : clips.length === 0 ? (
+          ) : clips.length === 0 && marked.length === 0 ? (
+            // Only when BOTH are empty. A bin with nothing in it but files on
+            // their way out is not an empty drawer, and saying so would hide
+            // the one thing here anybody still has a decision to make about.
             <div className="flex flex-col items-center justify-center py-16 text-zinc-500">
               <Trash2 className="h-10 w-10 stroke-[1.2] mb-2 text-zinc-600" />
               <span className="text-sm font-medium">Trash is empty</span>
             </div>
           ) : (
+            <>
+            {clips.length > 0 && (
             <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4 p-5">
               {groupTrashClips(clips).map((group, index) => {
                 // The row stands for the IMAGE, not one clip: every field it
@@ -389,6 +463,87 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
                 );
               })}
             </div>
+            )}
+
+            {marked.length > 0 && (
+              <section
+                aria-labelledby="trash-recently-deleted"
+                // Bordered off from the bin above it, because these two lists
+                // answer different questions: what did I delete (and can put
+                // back), versus what is about to stop existing.
+                className={clips.length > 0 ? "border-t border-zinc-900" : undefined}
+              >
+                <header className="px-5 pt-4">
+                  <h3
+                    id="trash-recently-deleted"
+                    className="text-xs font-semibold text-zinc-300"
+                  >
+                    Recently deleted files
+                  </h3>
+                  <p className="mt-0.5 text-[11px] text-zinc-500">
+                    {marked.length} uploaded file{marked.length === 1 ? "" : "s"} nothing
+                    uses any more. They stay in your library until they are deleted, and
+                    keeping one stops the clock.
+                  </p>
+                </header>
+                <ul className="grid grid-cols-2 gap-3 p-5 md:grid-cols-3 lg:grid-cols-4">
+                  {marked.map((asset) => {
+                    const key = markedAssetKey(asset);
+                    const busy = keepingKeys.includes(key);
+                    return (
+                      <li
+                        key={key}
+                        className="flex min-w-0 items-center gap-3 rounded-lg border border-zinc-900 bg-zinc-900/20 p-2"
+                      >
+                        <div className="relative size-12 shrink-0 overflow-hidden rounded border border-zinc-800/40 bg-black/60">
+                          {asset.thumbnailUrl ? (
+                            // The file is still there for the whole window, so
+                            // its own URL keeps resolving right up until it
+                            // doesn't — no provider round trip to render this.
+                            <img
+                              src={asset.thumbnailUrl}
+                              alt=""
+                              className="h-full w-full object-cover opacity-80"
+                            />
+                          ) : (
+                            <span className="flex h-full w-full items-center justify-center text-[8px] font-semibold uppercase tracking-wider text-zinc-500">
+                              {asset.kind}
+                            </span>
+                          )}
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <p className="truncate text-xs font-semibold text-zinc-200">
+                            {asset.name}
+                          </p>
+                          <p className="truncate text-[10px] text-zinc-500">
+                            {deletionWindowLabel(asset.deleteAfterMs)}
+                          </p>
+                        </div>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          disabled={busy}
+                          onClick={() => handleKeep(asset)}
+                          // The visible word is "Keep"; the accessible name
+                          // says WHICH, because a column of identical buttons
+                          // announces nothing otherwise.
+                          aria-label={`Keep ${asset.name}`}
+                          className="h-6 shrink-0 border-zinc-800 px-2 text-[10px] text-zinc-300 hover:border-sky-500/50 hover:text-sky-300 cursor-pointer"
+                        >
+                          {busy ? (
+                            <Loader2 className="h-3 w-3 animate-spin" />
+                          ) : (
+                            "Keep"
+                          )}
+                        </Button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </section>
+            )}
+            </>
           )}
         </main>
       </div>

--- a/apps/timeline-gstudio001/lib/asset-deletion-window.test.ts
+++ b/apps/timeline-gstudio001/lib/asset-deletion-window.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { daysUntilDeletion, deletionWindowLabel } from "./asset-deletion-window";
+
+const NOW = Date.UTC(2026, 6, 29, 12, 0, 0);
+const DAY = 24 * 60 * 60 * 1000;
+
+describe("daysUntilDeletion", () => {
+  it("rounds UP, so a partial day still counts", () => {
+    // 19.5 days left is honestly "20", never "19": the deadline is when
+    // deletion becomes allowed, and the file is safe until then.
+    expect(daysUntilDeletion(NOW + 19.5 * DAY, NOW)).toBe(20);
+    expect(daysUntilDeletion(NOW + 0.1 * DAY, NOW)).toBe(1);
+  });
+
+  it("is exact on whole days", () => {
+    expect(daysUntilDeletion(NOW + 30 * DAY, NOW)).toBe(30);
+    expect(daysUntilDeletion(NOW + DAY, NOW)).toBe(1);
+  });
+
+  it("floors at zero for a deadline already passed", () => {
+    // A due tombstone waits for the next sweep; it must never read as a
+    // negative countdown.
+    expect(daysUntilDeletion(NOW, NOW)).toBe(0);
+    expect(daysUntilDeletion(NOW - 5 * DAY, NOW)).toBe(0);
+  });
+});
+
+describe("deletionWindowLabel", () => {
+  it("counts down in days, singular at one", () => {
+    expect(deletionWindowLabel(NOW + 30 * DAY, NOW)).toBe("Deletes in 30 days");
+    expect(deletionWindowLabel(NOW + 2 * DAY, NOW)).toBe("Deletes in 2 days");
+    expect(deletionWindowLabel(NOW + DAY, NOW)).toBe("Deletes in 1 day");
+  });
+
+  it("does not say '0 days' when the window has run out", () => {
+    // Deletion happens on the sweep's schedule, and is still refused if the
+    // asset came back into use — so the words must be neither a countdown nor
+    // an obituary.
+    expect(deletionWindowLabel(NOW - DAY, NOW)).toBe("Deletes any time now");
+  });
+});

--- a/apps/timeline-gstudio001/lib/asset-deletion-window.ts
+++ b/apps/timeline-gstudio001/lib/asset-deletion-window.ts
@@ -1,0 +1,35 @@
+// How long a marked asset has left, as a number and as the words for it.
+//
+// Pure and isomorphic — the drawer renders these, and they are the one thing on
+// that row a user might act on, so the rule they follow is worth stating once
+// and testing rather than inlining a `Math.floor` at the call site.
+
+/**
+ * Whole days between now and the deadline, rounded UP, never below zero.
+ *
+ * Up, because the deadline is when deletion becomes ALLOWED and the sweep runs
+ * daily: something with nineteen and a half days left is honestly described as
+ * "20 days" and dishonestly as "19". Rounding the other way would let a row
+ * read "0 days" while the file is still safe, which reads as "gone".
+ */
+export function daysUntilDeletion(deleteAfterMs: number, now: number = Date.now()): number {
+  const remaining = deleteAfterMs - now;
+  if (remaining <= 0) return 0;
+  return Math.ceil(remaining / (24 * 60 * 60 * 1000));
+}
+
+/**
+ * The words on the row.
+ *
+ * Zero says "any time now" rather than "0 days left" or "today": a due
+ * tombstone is deleted by whenever the sweep next runs, which is a fact about
+ * a cron schedule and not a promise anyone should read as a countdown. It is
+ * also still recoverable at that point — the re-check spares anything back in
+ * use — so the phrasing must not sound final either.
+ */
+export function deletionWindowLabel(deleteAfterMs: number, now: number = Date.now()): string {
+  const days = daysUntilDeletion(deleteAfterMs, now);
+  if (days === 0) return "Deletes any time now";
+  if (days === 1) return "Deletes in 1 day";
+  return `Deletes in ${days} days`;
+}

--- a/apps/timeline-gstudio001/lib/asset-tombstones.ts
+++ b/apps/timeline-gstudio001/lib/asset-tombstones.ts
@@ -32,6 +32,10 @@ const BATCH_LIMIT = 500;
 export type AssetTombstone = Readonly<{
   ref: AssetSourceRef;
   kind: AssetKind;
+  /** Display snapshot, taken at mark time — see `AssetDeletionCandidate`.
+   *  Nothing looks anything up with these. */
+  name: string;
+  thumbnailUrl: string;
   ownerUid: string;
   markedAtMs: number;
   /** Epoch millis after which the sweep may delete. Stored as a NUMBER rather
@@ -44,6 +48,8 @@ type TombstoneRecord = {
   providerId?: string;
   assetId?: string;
   kind?: string;
+  name?: string;
+  thumbnailUrl?: string;
   ownerUid?: string;
   markedAtMs?: number;
   deleteAfterMs?: number;
@@ -66,12 +72,25 @@ function tombstoneId(ownerUid: string, ref: AssetSourceRef): string {
 }
 
 function toTombstone(data: TombstoneRecord): AssetTombstone | null {
-  const { providerId, assetId, kind, ownerUid, markedAtMs, deleteAfterMs } = data;
+  const { providerId, assetId, kind, name, thumbnailUrl, ownerUid, markedAtMs, deleteAfterMs } =
+    data;
   if (typeof providerId !== "string" || typeof assetId !== "string") return null;
   if (kind !== "image" && kind !== "video") return null;
   if (typeof ownerUid !== "string" || ownerUid.length === 0) return null;
   if (typeof deleteAfterMs !== "number" || typeof markedAtMs !== "number") return null;
-  return { ref: { providerId, assetId }, kind, ownerUid, markedAtMs, deleteAfterMs };
+  return {
+    ref: { providerId, assetId },
+    kind,
+    // The DISPLAY fields are the only ones allowed to be missing without
+    // voiding the record: a tombstone written before they existed still names
+    // a real file with a real deadline, and the sweep needs nothing else. A
+    // row with no snapshot prints its id's leaf instead of disappearing.
+    name: typeof name === "string" && name.length > 0 ? name : assetId,
+    thumbnailUrl: typeof thumbnailUrl === "string" ? thumbnailUrl : "",
+    ownerUid,
+    markedAtMs,
+    deleteAfterMs,
+  };
 }
 
 /**
@@ -97,6 +116,8 @@ export async function markAssetsForDeletion(
         providerId: candidate.ref.providerId,
         assetId: candidate.ref.assetId,
         kind: candidate.kind,
+        name: candidate.name,
+        thumbnailUrl: candidate.thumbnailUrl,
         ownerUid,
         markedAtMs: now,
         deleteAfterMs: now + GRACE_MS,

--- a/apps/timeline-gstudio001/lib/assets/asset-references.test.ts
+++ b/apps/timeline-gstudio001/lib/assets/asset-references.test.ts
@@ -80,9 +80,44 @@ describe("assetCandidatesFromClips", () => {
     ]);
 
     expect(candidates).toEqual([
-      { ref: { providerId: "cloudinary", assetId: "a.png" }, kind: "image" },
-      { ref: { providerId: "cloudinary", assetId: "b.mp4" }, kind: "video" },
+      expect.objectContaining({
+        ref: { providerId: "cloudinary", assetId: "a.png" },
+        kind: "image",
+      }),
+      expect.objectContaining({
+        ref: { providerId: "cloudinary", assetId: "b.mp4" },
+        kind: "video",
+      }),
     ]);
+  });
+
+  it("snapshots a name and a thumbnail, because no clip will be left to ask", () => {
+    // Authored title first, then the derived description, then the id's leaf —
+    // the same precedence the card reads by (PL11-004). The thumbnail is a
+    // video's poster or an image itself.
+    const [authored] = assetCandidatesFromClips([
+      { ...mediaClip("c1", { providerId: "cloudinary", assetId: "a.png" }), title: "Beach, take 3" } as TimelineClip,
+    ]);
+    expect(authored).toMatchObject({ name: "Beach, take 3", thumbnailUrl: "https://example.test/c1" });
+
+    const [described] = assetCandidatesFromClips([
+      mediaClip("c2", { providerId: "cloudinary", assetId: "b.png" }),
+    ]);
+    // `alt` is the clip id in this fixture's builder.
+    expect(described).toMatchObject({ name: "c2" });
+
+    const [postered] = assetCandidatesFromClips([
+      {
+        ...mediaClip("c3", { providerId: "cloudinary", assetId: "folder/movie.mp4" }, "video"),
+        poster: "https://example.test/poster.jpg",
+        alt: "",
+      } as TimelineClip,
+    ]);
+    expect(postered).toMatchObject({
+      // No title, no alt: the id's LEAF, never the whole path.
+      name: "movie.mp4",
+      thumbnailUrl: "https://example.test/poster.jpg",
+    });
   });
 
   it("de-duplicates: two clips of one file are one asset", () => {
@@ -112,7 +147,7 @@ describe("unreferencedCandidates", () => {
     const referenced = new Set(assetKeysFromClips([mediaClip("live", shared)]));
 
     expect(unreferencedCandidates(candidates, referenced)).toEqual([
-      { ref: orphan, kind: "image" },
+      expect.objectContaining({ ref: orphan, kind: "image" }),
     ]);
   });
 

--- a/apps/timeline-gstudio001/lib/assets/asset-references.ts
+++ b/apps/timeline-gstudio001/lib/assets/asset-references.ts
@@ -33,20 +33,44 @@ export function assetRefKey(ref: AssetSourceRef): string {
   return `${encodeURIComponent(ref.providerId)}|${encodeURIComponent(ref.assetId)}`;
 }
 
-/** An asset a caller is considering deleting: the ref, plus the `kind` its
- *  provider needs to address it (Cloudinary's destroy endpoint is per resource
- *  type). Recorded on the tombstone so the sweep, running 30 days later with
- *  no clip in hand, still knows how to ask. */
+/**
+ * An asset a caller is considering deleting: the ref, the `kind` its provider
+ * needs to address it (Cloudinary's destroy endpoint is per resource type),
+ * and a display SNAPSHOT.
+ *
+ * All three are recorded on the tombstone because the sweep — and the
+ * recently-deleted list the user sees — run with no clip in hand. The snapshot
+ * follows `TrashOrigin`'s rule: `name` and `thumbnailUrl` are what the row
+ * PRINTS, taken at mark time, not keys to look anything up with. There is no
+ * clip left to re-derive them from, and the file itself is still there for the
+ * whole window, so the thumbnail keeps resolving until the moment it doesn't.
+ */
 export type AssetDeletionCandidate = Readonly<{
   ref: AssetSourceRef;
   kind: AssetKind;
+  name: string;
+  thumbnailUrl: string;
 }>;
 
 /** Media clips carry provenance; collection clips have no file behind them. */
 function sourceAssetOf(clip: TimelineClip): AssetDeletionCandidate | null {
   if (clip.kind !== "image" && clip.kind !== "video") return null;
   if (clip.sourceAsset === undefined) return null;
-  return { ref: clip.sourceAsset, kind: clip.kind };
+  return {
+    ref: clip.sourceAsset,
+    kind: clip.kind,
+    // The authored name first, the derived description second — the same
+    // precedence the card and the details view read by (PL11-004). Falling
+    // back to the id's leaf keeps a row from printing nothing at all.
+    name: clip.title || clip.alt || leafOf(clip.sourceAsset.assetId),
+    // A video's poster is a still; an image IS its own thumbnail.
+    thumbnailUrl: clip.poster || clip.src,
+  };
+}
+
+function leafOf(assetId: string): string {
+  const segments = assetId.split("/").filter((segment) => segment.length > 0);
+  return segments[segments.length - 1] ?? assetId;
 }
 
 /**

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -267,6 +267,14 @@ async function installGraphApi(
     });
   });
 
+  // Registered AFTER the palette mock above, which matters: Playwright matches
+  // handlers in reverse registration order, and `**/api/assets**` would
+  // otherwise answer the trash drawer's recently-deleted request with a page of
+  // palette assets. Empty by default; the test that cares overrides it.
+  await page.route("**/api/assets/marked**", (route) =>
+    route.fulfill({ json: { assets: [] } }),
+  );
+
   // Two-segment path, so the generic single-segment mock below never sees it.
   await page.route("**/api/timelines/*/preview-manifest", (route) => {
     const id = decodeURIComponent(
@@ -2880,6 +2888,74 @@ test.describe("graph view E2E", () => {
     await page.getByRole("button", { name: "Close trash" }).click();
     await undoButton(page).click();
     await expect.poll(() => stripOrder(page, CHILD_ID)).toEqual(["c1", "c2"]);
+  });
+
+  test("the trash lists files on their way out, and Keep withdraws the mark", async ({
+    page,
+  }) => {
+    const marked = [
+      {
+        providerId: "cloudinary",
+        assetId: "gstudio/user/folder/orphan.png",
+        kind: "image",
+        name: "Beach, take 3",
+        thumbnailUrl: "",
+        markedAtMs: Date.now(),
+        deleteAfterMs: Date.now() + 24 * 60 * 60 * 1000,
+      },
+      {
+        providerId: "cloudinary",
+        assetId: "gstudio/user/folder/spare.mp4",
+        kind: "video",
+        name: "Unused take",
+        thumbnailUrl: "",
+        markedAtMs: Date.now(),
+        deleteAfterMs: Date.now() + 26 * 24 * 60 * 60 * 1000,
+      },
+    ];
+    const kept: { providerId: string; assetId: string }[] = [];
+    await installGraphApi(page);
+    // AFTER installGraphApi, deliberately: handlers match in reverse
+    // registration order, so the empty default it installs would otherwise
+    // win over this one.
+    await page.route("**/api/assets/marked**", (route) => {
+      if (route.request().method() === "DELETE") {
+        const body = route.request().postDataJSON() as {
+          assets?: { providerId: string; assetId: string }[];
+        };
+        kept.push(...(body.assets ?? []));
+        return route.fulfill({ json: { success: true, kept: 1 } });
+      }
+      return route.fulfill({
+        json: {
+          assets: marked.filter(
+            (asset) => !kept.some((ref) => ref.assetId === asset.assetId),
+          ),
+        },
+      });
+    });
+
+    await page.goto(GRAPH_URL);
+    // The rail's drawer button only mounts once the board is up.
+    await expect(page.locator(`[data-virtual-grid="${PROJECT_ID}"]`)).toBeVisible();
+    await page.getByRole("button", { name: "Trash", exact: true }).click();
+
+    // The bin and this section answer different questions, so both are here:
+    // what did I delete, and what is about to stop existing.
+    await expect(page.getByRole("heading", { name: "Recently deleted files" })).toBeVisible();
+    await expect(page.getByText("Deletes in 1 day")).toBeVisible();
+    await expect(page.getByText("Deletes in 26 days")).toBeVisible();
+
+    // "Keep" withdraws the mark — the file never moved, so nothing is restored
+    // and nothing returns to a timeline.
+    const keep = page.getByRole("button", { name: "Keep Beach, take 3" });
+    await keep.click();
+    await expect(keep).toHaveCount(0);
+    expect(kept).toEqual([
+      { providerId: "cloudinary", assetId: "gstudio/user/folder/orphan.png" },
+    ]);
+    // The other one is untouched: Keep is per-row, not a blanket reprieve.
+    await expect(page.getByRole("button", { name: "Keep Unused take" })).toBeVisible();
   });
 
   test("crafted focus URLs are rejected; valid deep links still work", async ({ page }) => {

--- a/punch-list/PUNCH-LIST-12.md
+++ b/punch-list/PUNCH-LIST-12.md
@@ -23,22 +23,62 @@ than smuggling it in here.
 
 ## PL12-004 — The trash becomes the recently-deleted surface
 
-- Status: Not started
-- Area: `trash-drawer.tsx`, `/api/trash`
-- Blocked by: PL12-003
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `trash-drawer.tsx`, `app/api/assets/marked/route.ts` (new),
+  `lib/asset-deletion-window.ts` (new), `lib/asset-tombstones.ts`
+- Screenshot: Not captured
 
 Two waiting rooms is one too many. PL12-003 marks an asset and deletes it 30
 days later, but a mark with no UI is a clock nobody can see or act on, while
 the trash is already a holding area with a restore control.
 
-So the trash grows a "Recently deleted" section: assets carrying a tombstone,
-with days remaining, and a restore that clears the tombstone. The file never
-went anywhere during the window — restoring is bookkeeping, not a re-upload.
+The drawer now carries both, bordered apart because they answer different
+questions: what did I delete (and can put back), versus what is about to stop
+existing. Each row shows the file, its name, `Deletes in N days`, and **Keep**.
 
-This is what the trash becomes once the tray is gone: the surface for
-everything that is not currently on a board. It is also where the copy debt
-is — the empty-trash confirm still promises that uploaded files stay in the
-Assets library, which PL12-003 makes false.
+The word is **Keep**, not Restore, and that is the honest one. Nothing moved
+when the asset was marked — the file has been in the library the whole window —
+so this withdraws an intention and puts nothing back on a timeline. Calling it
+"restore" would promise a clip that never arrives.
+
+**A tombstone has to carry its own display.** There is no clip left pointing at
+a marked asset — that is what being marked MEANS — so nothing can be re-derived
+from the graph and no provider call can be scoped to a project that no longer
+references it. The mark therefore records `name` and `thumbnailUrl` at write
+time, the same snapshot rule `TrashOrigin` follows. The file survives the whole
+window, so its own URL keeps resolving right up until it doesn't.
+
+Three smaller decisions:
+
+- **Rounded UP.** 19.5 days left reads "20 days": the deadline is when deletion
+  becomes ALLOWED, so rounding down would show "19" for something still safe.
+  Zero says "Deletes any time now" rather than "0 days" — the actual moment is a
+  cron schedule, and it is still recoverable, so the words must be neither a
+  countdown nor an obituary.
+- **A separate request with a separate failure.** The bin is the drawer's job;
+  this section is an addition to it. A marked-list that fails to load shows
+  nothing and leaves the bin working, where one combined error surface would let
+  a broken side-panel hide the trash.
+- **The big "Trash is empty" state now needs BOTH lists empty.** A bin with
+  nothing in it but files on their way out is not an empty drawer, and saying so
+  would hide the only thing there is still a decision to make about.
+
+E2E TRAP worth keeping: the suite's palette mock is `**/api/assets**`, which
+also matches `/api/assets/marked` — it would have answered the drawer with a
+page of palette assets. Playwright matches handlers in REVERSE registration
+order, so the fix is a narrower route registered after it (and a per-test
+override registered after `installGraphApi`, not before).
+
+Verified live against the running app with two seeded tombstones: the section
+rendered, the labels read "Deletes in 1 day" / "Deletes in 26 days", Keep
+cleared the mark on the server and dropped the row, and the other row was
+untouched. Proven fail-first: with Keep not calling the server, the e2e's
+payload assertion fails.
+
+Not built, and named here rather than assumed: once PL12-005 retires the tray,
+a kept asset has no way back onto a board. Whatever replaces the tray owes an
+insertion path — this section is a decision surface, not an inserter.
 
 ## PL12-003 — Reference-counted asset deletion
 


### PR DESCRIPTION
Punch list 12, item 4. Follows [#231](https://github.com/josulliv101/storyboard-flow/pull/231), which introduced the marks this makes visible.

PL12-003 marks an asset and deletes it 30 days later, but a mark with no UI is a clock nobody can see or act on — while the trash is already a holding area with a restore control sitting right there. Two waiting rooms is one too many, so the drawer now carries both, bordered apart because they answer different questions: **what did I delete** (and can put back) versus **what is about to stop existing**.

## Keep, not Restore

Nothing moved when the asset was marked — the file has been in the library the whole window — so the button withdraws an intention and puts nothing back on a timeline. Calling it "restore" would promise a clip that never arrives.

## A tombstone has to carry its own display

There is no clip left pointing at a marked asset; that is what marked MEANS. So nothing can be re-derived from the graph, and no provider listing can be scoped to a project that no longer references it. `name` and `thumbnailUrl` are recorded at mark time — the same snapshot rule `TrashOrigin` follows. The file survives the whole window, so its own URL keeps resolving right up until it doesn't.

## Details worth reviewing

- **`lib/asset-deletion-window.ts`** — days remaining, rounded **up**: 19.5 days left reads "20 days", because the deadline is when deletion becomes ALLOWED and rounding down would show "19" for something still safe. Zero says "Deletes any time now" rather than "0 days" — the real moment is a cron schedule, and it is still recoverable, so the words are neither a countdown nor an obituary.
- **`/api/assets/marked`** — GET lists the caller's own marks, soonest deadline first; DELETE drops the named ones. A DELETE that deletes MARKS, not files.
- **A separate request with a separate failure.** A marked-list that fails to load shows nothing and leaves the bin working, where one combined error surface would let a broken side-panel hide the trash.
- **The big "Trash is empty" state now needs BOTH lists empty.** A bin with nothing in it but files on their way out is not an empty drawer, and saying so would hide the only thing there is still a decision to make about.

## E2E trap fixed on the way

The suite's palette mock is `**/api/assets**`, which also matches `/api/assets/marked` — it would have answered the drawer with a page of palette assets. Playwright matches handlers in **reverse** registration order, so the fix is a narrower route registered after it (and a per-test override registered after `installGraphApi`, not before).

## Verification

App tsc clean, 534 app tests, lint clean (5 warnings — one new `<img>`, matching this file's existing pattern), **graph-view e2e 102/102** including a new test, proven fail-first: with Keep not calling the server, the payload assertion fails.

Also verified live against the running app with two seeded tombstones rather than by emptying a real bin (that is irreversible): the section rendered, labels read "Deletes in 1 day" / "Deletes in 26 days", Keep cleared the mark on the server and dropped its row, and the other row was untouched. Seeds removed afterwards.

## Known gap, for PL12-005

Once the tray is retired, a kept asset has no way back onto a board. Whatever replaces the tray owes an insertion path — this section is a decision surface, not an inserter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
