### PR TITLE
PL13-003..007: the collection card — one frame, one control cluster, one selection mark

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -133,36 +133,36 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-/** Distinct first/last assets: the ordinary two-frame collection card. */
+/**
+ * The ordinary collection card: ONE frame, full width (PL13-003).
+ *
+ * It used to be a first/last PAIR, which at card size meant two ~80px slots —
+ * too narrow to recognize a face, and the crop turned a composition into a
+ * slice of one. What is worth pinning now is WHICH frame: the first child's,
+ * not the last, not an arbitrary one.
+ */
 export const DistinctFrames: Story = {
   args: baseArgs,
   decorators: [renderWithDetail([ASSET_A, ASSET_B])],
   play: async ({ canvasElement }) => {
     const images = previewImages(canvasElement);
-    await expect(images).toHaveLength(2);
+    await expect(images).toHaveLength(1);
+    await expect(images[0]).toHaveAttribute("src", ASSET_A.poster);
   },
 };
 
-/**
- * The regression: the same asset is BOTH the first and last preview item (the
- * same clip placed at the start and end of a child timeline — real data per
- * the adapter's demotion comment). First and last therefore share an id, which
- * used to collide on the React key and reconcile to a single stretched frame.
- * Both frames must render.
+/*
+ * REMOVED with the frame pair (PL13-003): `RepeatedFirstAndLastFrame`.
+ *
+ * It pinned a real regression — the same asset as BOTH the first and last
+ * preview item shares an id, which used to collide on the React key and
+ * reconcile to one stretched frame, fixed by keying on the SLOT. A card that
+ * renders a single frame cannot have two slots to collide, so the story could
+ * only have asserted "one image", which is what every other story here already
+ * says. Deleted rather than kept as a vacuous pin. If the pair ever returns,
+ * so should it — the fixture was [ASSET_A, ASSET_B, ASSET_A] and the rule is
+ * key by slot, never by content.
  */
-export const RepeatedFirstAndLastFrame: Story = {
-  args: baseArgs,
-  decorators: [renderWithDetail([ASSET_A, ASSET_B, ASSET_A])],
-  play: async ({ canvasElement }) => {
-    const images = previewImages(canvasElement);
-    // Both frames render despite first and last sharing an asset id — the
-    // regression rendered a single stretched frame after React collapsed the
-    // duplicate key.
-    await expect(images).toHaveLength(2);
-    await expect(images[0]).toHaveAttribute("src", ASSET_A.poster);
-    await expect(images[1]).toHaveAttribute("src", ASSET_A.poster);
-  },
-};
 
 /** A single-item collection shows one frame across the full width. */
 export const SingleFrame: Story = {
@@ -629,14 +629,17 @@ export const DisabledCollection: Story = {
     await expect(metadata.textContent).toContain("A timeline");
     await expect(metadata.textContent).toContain("8.0s");
     await expect(metadata.textContent).toContain("2 items");
-    const folderGlyph = canvasElement.querySelector<SVGElement>(
+    // The drill control's glyph is a CHEVRON now (PL13-004), at lucide's own
+    // stroke weight — it was CornerRightDown at 1.5 while it was a large
+    // circle on the artwork.
+    const drillGlyph = canvasElement.querySelector<SVGElement>(
       'button[aria-label="Open A timeline"] svg',
     )!;
-    await expect(folderGlyph.getAttribute("stroke-width")).toBe("1.5");
+    await expect(drillGlyph.getAttribute("stroke-width")).toBe("2");
     await userEvent.click(card as HTMLElement);
     await expect((card as HTMLElement).className).toContain("ring-amber-300/65");
     await expect((card as HTMLElement).className).toContain("ring-inset");
-    // The frames still render — a disabled card shows its content, muted.
-    await expect(previewImages(canvasElement)).toHaveLength(2);
+    // The frame still renders — a disabled card shows its content, muted.
+    await expect(previewImages(canvasElement)).toHaveLength(1);
   },
 };

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -12,7 +12,7 @@ import {
   useSyncExternalStore,
   type ReactNode,
 } from "react";
-import { CornerRightDown, Maximize2 } from "lucide-react";
+import { Check, ChevronRight, CornerRightDown, Maximize2 } from "lucide-react";
 
 import {
   CollectionItem,
@@ -238,7 +238,18 @@ export function useCollectionPreviewFrames(
 ): readonly CollectionPreviewFrame[] {
   const live = useHydratedCollectionPreviews(id, hydrated);
   const all = hydrated ? live : (stored ?? NO_PREVIEWS);
-  return useMemo(() => (all.length > 1 ? [all[0], all[all.length - 1]] : all), [all]);
+  // ONE frame, full width (PL13-003). It used to be a first/last PAIR, which
+  // at card size meant two ~80px slots: too narrow to recognize a face, and the
+  // crop turned a composition into a slice of one. The item count beside the
+  // duration already says how many, so the pair was not carrying that either.
+  //
+  // KNOWN LIMITATION, deliberate and worth revisiting: this is the FIRST
+  // child's frame, and in a video project a first frame is very often a slate,
+  // a logo or a fade from black — this repo's own demo renders "A Universal
+  // Picture" for one collection. A representative frame (the midpoint of the
+  // collection's own duration) is the better answer and needs the preview
+  // machinery to resolve a time, which is its own change.
+  return useMemo(() => (all.length > 1 ? [all[0]] : all), [all]);
 }
 
 /**
@@ -400,7 +411,120 @@ function DisabledChip({ inherited }: { inherited: boolean }) {
  * ghost. A single-stroke turn-and-descend mark reads at small sizes where the
  * old compound folder/arrow went muddy, and it says the verb the control
  * actually performs: go DOWN into this timeline. */
-function CollectionFolderGlyph({ className }: Readonly<{ className?: string }>) {
+/**
+ * What an EMPTY collection shows: an academy-leader countdown frame.
+ *
+ * The slot used to be blank — a dark rectangle that read as a broken thumbnail
+ * rather than as "nothing in here yet". A leader frame is the film industry's
+ * own mark for "before the picture starts", which is exactly the state, and it
+ * gives the card a recognizable silhouette at strip size where any label would
+ * be too small to read.
+ *
+ * Drawn rather than loaded. At card size the geometry is the whole message —
+ * the ring, the crosshair, the sweep — and the reference photograph's grain and
+ * scratches are invisible; a vector costs no request, stays crisp in the grid's
+ * much larger cells, and takes the board's own palette instead of fighting it
+ * with a bright sepia field. (If the scanned frame itself is wanted, this is the
+ * one place to swap it.)
+ *
+ * `preserveAspectRatio="none"` on the CROSSHAIR only would stretch the ring, so
+ * the whole thing scales as one and the card's own overflow crops the excess —
+ * the leader is centred, which is where a projectionist would expect it.
+ */
+function CollectionLeaderPlaceholder() {
+  return (
+    <svg
+      viewBox="0 0 160 90"
+      aria-hidden="true"
+      className="h-full w-full text-zinc-500/70"
+      preserveAspectRatio="xMidYMid slice"
+    >
+      {/* Paper, not black: an empty card reads as a FRAME rather than a hole. */}
+      <rect width="160" height="90" className="fill-zinc-800/40" />
+      {/* The sweep — the sector a leader's rotating hand has already passed. */}
+      <path d="M80 45 L80 6 A39 39 0 0 1 114 26 Z" className="fill-zinc-700/45" />
+      <g stroke="currentColor" fill="none" strokeWidth="1.5">
+        {/* Crosshair, edge to edge. */}
+        <path d="M80 0 V90 M0 45 H160" strokeWidth="1" />
+        {/* The ring: two concentric strokes, the leader's signature. */}
+        <circle cx="80" cy="45" r="39" />
+        <circle cx="80" cy="45" r="33" />
+      </g>
+    </svg>
+  );
+}
+
+/**
+ * SELECTED, as a badge — a tick in the card's top-left, present only while the
+ * card is selected.
+ *
+ * A BADGE, not a control, and the distinction is the whole design. A checkbox
+ * you click to select was built and rejected (PL13-001): with the card body
+ * already selecting, it was a second affordance for one act, and being
+ * invisible-but-clickable it swallowed clicks meant for the card. This appears
+ * BECAUSE the card is selected and does nothing when pressed —
+ * `pointer-events-none`, so it cannot repeat that mistake.
+ *
+ * It earns its place by making a MULTI-selection legible. The `ring-amber-300`
+ * on a selected card is a fine binary signal on one card and a weak one across
+ * a board of forty, where the eye has to compare border colours; a row of ticks
+ * reads at a glance. Same amber as the ring on purpose — one selection colour,
+ * two ways of saying it.
+ *
+ * `aria-hidden`: the card already exposes `aria-pressed` and `data-selected`.
+ * Announcing "selected" twice per card is noise, not access.
+ *
+ * Top-LEFT, mirroring the control cluster in the top-right, and 20px against
+ * their 24px — a marker should not read as a button you failed to press.
+ */
+function CardSelectedBadge() {
+  return (
+    <span
+      data-card-selected-badge
+      aria-hidden="true"
+      className="pointer-events-none absolute left-1.5 top-1.5 z-20 flex size-5 items-center justify-center rounded bg-amber-300 text-zinc-950 shadow-sm shadow-black/50"
+    >
+      <Check className="size-3.5" strokeWidth={3} />
+    </span>
+  );
+}
+
+/** The drill mark: CornerRightDown — turn and descend, the verb "go into this
+ *  timeline". NOT a folder, despite what this was called until PL13-004: the
+ *  old name read as a container mark, which is how it ended up paired with a
+ *  chevron in the drill badge — two direction arrows for one act. The
+ *  sidebar's FolderTree toggles whether the children tree is SHOWN, a
+ *  different verb that deliberately does not share this icon. */
+/**
+ * The look every CARD-LEVEL control shares: a 24px square on the card's right
+ * edge, dark enough to sit on artwork, always visible.
+ *
+ * Shared so a card reads as having ONE kind of control rather than a collection
+ * of one-offs. Before this the details trigger and the drill badge differed in
+ * corner, shape, colour and reveal rule — four differences, which is why they
+ * looked unrelated. Position and focus ring stay with the caller; everything
+ * else is here.
+ */
+const CARD_CONTROL_CLASS = [
+  "z-20 flex size-6 shrink-0 items-center justify-center rounded",
+  "bg-zinc-950/80 text-zinc-300 shadow-sm shadow-black/40 backdrop-blur-[1px]",
+  "transition-colors hover:bg-zinc-900 hover:text-zinc-50",
+].join(" ");
+
+/**
+ * Where those controls sit: one cluster in the card's top-right, same inset
+ * from both edges and the same gap between them.
+ *
+ * A cluster rather than two independently-positioned buttons, because that is
+ * what kept going wrong — details at `top-1 right-1` and the drill badge at
+ * `bottom-8 right-1.5` read as two unrelated marks, and every size change meant
+ * re-tuning an offset against the label row's height (which differs per
+ * surface). Grouped, they align by construction and a media card's single
+ * control lands in exactly the same place as a collection's pair.
+ */
+const CARD_CONTROL_CLUSTER_CLASS = "absolute right-1.5 top-1.5 z-20 flex items-center gap-1.5";
+
+function CollectionDrillGlyph({ className }: Readonly<{ className?: string }>) {
   return <CornerRightDown aria-hidden="true" className={className} strokeWidth={1.5} />;
 }
 
@@ -760,7 +884,7 @@ const GraphGhost = memo(function GraphGhost({ node, extraCount }: CollectionGhos
           data-empty-collection-ghost
           className="flex h-full w-full items-center justify-center"
         >
-          <CollectionFolderGlyph className="h-7 w-7 text-sky-200" />
+          <CollectionDrillGlyph className="h-7 w-7 text-sky-200" />
         </span>
       ) : (
         <span className="flex h-full w-full flex-col items-center justify-center gap-1 p-2 text-center">
@@ -875,8 +999,10 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
             <span
               data-empty-collection-preview
               aria-hidden="true"
-              className="flex flex-1 items-center justify-center"
-            />
+              className="flex flex-1 items-center justify-center overflow-hidden rounded-sm"
+            >
+              <CollectionLeaderPlaceholder />
+            </span>
           ) : (
             previews.map((preview, index) => (
               // eslint-disable-next-line @next/next/no-img-element
@@ -958,42 +1084,51 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
           to be on the card, and an element's own `overflow-hidden` clips its
           children, never its own transform.) */}
 
-      {/* The drill affordance — a REAL button now that it composes as a
-          SIBLING of the selection surface. Centred over the preview area (the
-          card minus its label row), sized as a fraction of the card so it
-          stays prominent at every item size. Pointer-only by design:
-          tabIndex -1 keeps roving views at one tab stop per item, and
-          keyboard drill-in stays on the O key (OpenKeyBoundary). The
-          data-collections-keyboard-ignore marker also excludes it from the
-          strip's pan surface (see isPannableStripSurface), so a press here
-          drills without the strip scrolling under it — no pointerdown guard
-          needed. */}
-      <button
-        type="button"
-        tabIndex={-1}
-        aria-label={`Open ${displayName}`}
-        title="Open this timeline"
-        data-collections-keyboard-ignore
-        onClick={(event) => {
-          event.stopPropagation();
-          nav?.openTimeline(id);
-        }}
-        // Sized as a FRACTION of the card so it stays proportionate at every
-        // item size — but the fraction itself has to differ per surface. 34%
-        // of a short strip card is a ~45px target; 34% of the new tall grid
-        // cell is ~75px, which stopped reading as a control on the artwork and
-        // started reading as the artwork. The grid gets a smaller share of a
-        // much bigger card, which lands back at a similar physical size.
-        className="absolute left-1/2 top-[41%] flex aspect-square h-[34%] -translate-x-1/2 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full bg-zinc-950/70 text-sky-200 ring-1 ring-sky-400/50 backdrop-blur-[2px] transition-colors hover:bg-zinc-900/85 hover:text-sky-100 hover:ring-sky-300 [[data-virtual-grid]_&]:h-[24%]"
-      >
-        {/* CornerRightDown — turn and descend, the verb this control performs:
-            NAVIGATE into the timeline. The sidebar's FolderTree toggles whether
-            the children tree is shown, which is a different verb and does not
-            share this icon. */}
-        {/* 45%, not 55%: the mark crowded the ring it sits in. The circle's
-            own size is unchanged — only the glyph inside it shrank. */}
-        <CollectionFolderGlyph className="h-[45%] w-[45%]" />
-      </button>
+      {/* The card's controls, as ONE cluster in the top-right: drill, then
+          details. Both were placed independently before — details at the top
+          corner, the drill badge down at the artwork's bottom edge — which read
+          as two unrelated marks and made the drill's offset a per-surface
+          tuning problem against the label row's height. Grouped, they align by
+          construction, and a media card's single control lands in exactly the
+          same place.
+
+          The chevron sits nearest the corner deliberately: read left to right,
+          the mark closest to the edge is the one that takes you past it.
+
+          Still real buttons composed as SIBLINGS of the selection surface — a
+          button inside the surface's button would be invalid HTML, which is why
+          this is positioned rather than placed. Pointer-only: tabIndex -1 keeps
+          roving views at one tab stop per item, keyboard drill-in stays on the
+          O key (OpenKeyBoundary), and data-collections-keyboard-ignore excludes
+          them from the strip's pan surface (isPannableStripSurface), so a press
+          here never scrolls the strip out from under it. */}
+      {selected && <CardSelectedBadge />}
+      <span className={CARD_CONTROL_CLUSTER_CLASS}>
+        <ItemDetailsTrigger id={id} rovingTabIndex={undefined} inCluster />
+        <button
+          type="button"
+          tabIndex={-1}
+          aria-label={`Open ${displayName}`}
+          title="Open this timeline"
+          data-collections-keyboard-ignore
+          onClick={(event) => {
+            event.stopPropagation();
+            nav?.openTimeline(id);
+          }}
+          className={[
+            CARD_CONTROL_CLASS,
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300",
+          ].join(" ")}
+        >
+          {/* ONE glyph. It briefly carried CornerRightDown as well, on the
+              reasoning that the badge had to say "container" and "way in" at
+              once — but that name lies: `CollectionDrillGlyph` draws
+              CornerRightDown, so the pair was two direction arrows saying the
+              same thing twice. A chevron alone reads as "enter"; what says
+              CONTAINER is the card. */}
+          <ChevronRight className="size-4" aria-hidden="true" />
+        </button>
+      </span>
 
       {/* The rename editor — a REAL input, overlaying the label row while
           editing. A sibling of the surface, so it nests in no button. */}
@@ -1010,7 +1145,6 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
       {/* Same control the media card carries (PL11-012): a timeline has
           details worth reading — what is inside it, how long it runs, whether
           it is loaded — without drilling in to find out. */}
-      <ItemDetailsTrigger id={id} rovingTabIndex={undefined} />
 
       <CollectionItem.DropIndicators />
     </>
@@ -1067,7 +1201,16 @@ const GraphCollectionItem = memo(function GraphCollectionItem({
 const ItemDetailsTrigger = memo(function ItemDetailsTrigger({
   id,
   rovingTabIndex,
-}: Readonly<{ id: NodeId; rovingTabIndex: number | undefined }>) {
+  inCluster = false,
+}: Readonly<{
+  id: NodeId;
+  rovingTabIndex: number | undefined;
+  /** True when a card renders this INSIDE `CARD_CONTROL_CLUSTER_CLASS`, which
+   *  owns the position — a collection pairs it with the drill control. Alone
+   *  (a media card) it positions itself at the SAME inset, so both card kinds
+   *  put their controls in exactly the same place. */
+  inCluster?: boolean;
+}>) {
   const store = useCollectionsStore();
   const { setOpenId } = useItemDetails();
   // NAME the item: a board shows dozens of these, and "Open item details"
@@ -1097,23 +1240,22 @@ const ItemDetailsTrigger = memo(function ItemDetailsTrigger({
         store.setSelection([id]);
         setOpenId(id as string);
       }}
+      // ONE treatment, shared with the drill badge on a collection card: same
+      // 24px square, same right edge, same fill — details top-right, drill
+      // bottom-right, bracketing the same side. The two used to differ in
+      // corner, shape, colour AND reveal rule, which is why they never read as
+      // siblings.
       className={[
-        "absolute top-1 right-1 z-20 flex size-6 items-center justify-center rounded",
-        "bg-zinc-950/80 text-zinc-300 shadow-sm shadow-black/40 backdrop-blur-[1px]",
-        "hover:bg-zinc-900 hover:text-zinc-50",
-        // Hidden until the card is hovered or something inside it has focus —
-        // including this button, which is why `focus-within` is on the group
-        // rather than `focus-visible` here alone.
-        //
-        // The HIDING is gated on hover existing at all (PL11-011). A touch
-        // device never hovers, so an unconditional `opacity-0` made this the
-        // only way to open the details view AND made it unreachable there.
-        // Visible by default, hidden only where a pointer can reveal it: busy
-        // beats unreachable.
-        "transition-opacity duration-150 [@media(hover:hover)]:opacity-0",
-        "group-hover/media-item:opacity-100 group-focus-within/media-item:opacity-100",
-        "group-hover/collection-item:opacity-100 group-focus-within/collection-item:opacity-100",
-        "focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300",
+        CARD_CONTROL_CLASS,
+        inCluster ? "" : "absolute right-1.5 top-1.5",
+        // ALWAYS VISIBLE (PL13-005). It was hover-revealed, with the hiding
+        // gated on `hover:hover` so a touch device — which never hovers — could
+        // still reach it (PL11-011). Always-visible removes that whole class of
+        // problem: pointer and touch now behave identically and there is no
+        // media query to get wrong. The cost is two permanent marks on a card,
+        // paid deliberately, because on a collection the drill badge is the only
+        // pointer route into a timeline and a route nobody can see is not one.
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300",
       ].join(" ")}
     >
       <Maximize2 aria-hidden="true" className="h-3.5 w-3.5" />
@@ -1137,6 +1279,14 @@ const GraphMediaItem = memo(function GraphMediaItem({
   ...props
 }: CollectionItemShellProps) {
   const node = useCollectionsSelector((s) => s.graph.nodesById.get(props.id) ?? null);
+  // NodeCard knows whether it is selected, but keeps it inside its own shell —
+  // and the badge has to be a SIBLING of that shell, like everything else here,
+  // because a span inside the card's `<button>` would still be inside a button.
+  // A boolean selector, so this re-renders only when THIS card's selection
+  // actually flips, not on every selection change on the board.
+  const mediaSelected = useCollectionsSelector((s) =>
+    s.interaction.selectedIds.has(props.id),
+  );
   const detail = useClipDetail(props.id as string);
   // Seeded with the AUTHORED title when there is one, so re-naming edits what
   // the user wrote rather than making them delete a filename first.
@@ -1145,6 +1295,7 @@ const GraphMediaItem = memo(function GraphMediaItem({
   return (
     <div className={["group/media-item relative", className ?? ""].join(" ")}>
       <NodeCard {...props} className="h-full w-full" />
+      {mediaSelected && <CardSelectedBadge />}
       <ItemDetailsTrigger id={props.id} rovingTabIndex={props.rovingTabIndex} />
       {rename.editing && node?.kind === "media" && (
         <InlineNameEditor

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -3765,18 +3765,17 @@ test.describe("graph view E2E", () => {
     const trigger = page.locator('[data-item-details-trigger="bravo"]');
     await expect(trigger).toHaveCount(1);
 
-    // Hidden until the card is hovered or focused. Asserted BEFORE anything is
-    // clicked: clicking a card focuses it, and focus legitimately reveals the
-    // trigger, so a click first would make the idle state untestable. (Real
-    // hover only — the reveal is a CSS `:hover` rule, which synthetic mouse
-    // events cannot produce.)
+    // ALWAYS VISIBLE (PL13-005). This used to be an idle → hover → away →
+    // focus opacity dance, because the trigger hid itself until the card was
+    // hovered. Card controls are permanent now — same rule on a collection's
+    // drill badge — which is what removed the `@media(hover:hover)` gate and
+    // with it the whole class of "invisible on touch" bugs. Nothing is hovered
+    // or focused here, and that is the point.
     const opacity = () => trigger.evaluate((el) => getComputedStyle(el).opacity);
-    await expect.poll(opacity).toBe("0");
+    await expect.poll(opacity).toBe("1");
     await bravo.hover();
     await expect.poll(opacity).toBe("1");
     await page.mouse.move(0, 0);
-    await expect.poll(opacity).toBe("0");
-    await trigger.focus();
     await expect.poll(opacity).toBe("1");
 
     // Pressing it selects the card as well, so the board's selection-scoped
@@ -4011,7 +4010,11 @@ test.describe("graph view E2E", () => {
 
       const trigger = page.locator('[data-item-details-trigger="alpha"]');
       await expect(trigger).toHaveCount(1);
-      // Nothing hovered, nothing focused: hover-capable would read "0".
+      // Visible, as it now is everywhere — the trigger stopped hiding itself in
+      // PL13-005, so this no longer distinguishes touch from pointer. Kept
+      // because what it really guards is that the ONE route into the details
+      // view is reachable on a device that cannot hover, and a future reveal
+      // rule would have to keep that true.
       await expect
         .poll(() => trigger.evaluate((el) => getComputedStyle(el).opacity))
         .toBe("1");

--- a/punch-list/PUNCH-LIST-13.md
+++ b/punch-list/PUNCH-LIST-13.md
@@ -1,0 +1,282 @@
+# Punch List 13
+
+## PL13-001 — Collection card: checkbox + click-to-open, TRIED AND REJECTED
+
+- Status: Rejected — reverted before commit. Kept as the record of why.
+- Area: `graph-item-content.tsx`, `tests/e2e/graph-view.spec.ts` (both reverted)
+- Screenshot: user mockup (3 collection cards, checkbox top-left, hover "Open",
+  `0:53 · 2` bottom row)
+
+The mockup moved selection onto a checkbox in the card's top-left and made a
+plain click DRILL IN. Built, verified working, then rejected on the owner's
+call — and the implementation is what produced the argument against it.
+
+**A checkbox only earns its place when click stops meaning select.** That was
+the design's whole logic: if click drills, selection needs a target of its own.
+But media cards select on click and always have, so the collection card doing
+something else is the inconsistency — not the thing that fixes one. With click
+still meaning select, the checkbox is a second affordance for what the card body
+already does, which is what round 7 rejected when it killed three controls doing
+one job.
+
+Two findings from building it, both of which argue the same way:
+
+- **The card is out of room.** A drill button in the middle, a details trigger
+  top-right, a checkbox top-left. An e2e test had ALREADY been written to click
+  `{x: 10, y: 10}` to dodge the drill button, and the checkbox landed exactly
+  there; the fix was hunting for a third point that was neither control. When a
+  test has to search for somewhere on a card that isn't a control, the card is
+  over-furnished.
+- **A new control is a new class of bug.** The hover-hidden checkbox swallowed
+  clicks meant for the card — `opacity-0` still hit-tests — which the e2e caught
+  as "subtree intercepts pointer events". Real, and it only existed because
+  there was something new to get wrong.
+
+**What the rejection costs**, stated plainly so it is a decision and not an
+oversight: discoverable multi-select. It stays on Ctrl/Cmd+click, which nobody
+finds by accident. The cheap mitigations if that nags later are a shortcuts-sheet
+row and the header's existing `N selected` readout — neither costs pixels on the
+card.
+
+Surviving this item, as separate work:
+
+- **PL13-002** — click means select EVERYWHERE (the dup-ref exception).
+- **PL13-003** — one representative frame instead of tiled slices.
+
+## PL13-004 — The drill control comes off the middle of the picture
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `graph-item-content.tsx`
+- Screenshot: Not captured (two variants were shown live before choosing)
+
+The affordance was a circle at 34% of the card, centred at 41% height — which
+put the control that navigates INTO a timeline directly on top of the frame you
+would use to recognize it. Nothing belongs in the middle of a picture.
+
+Two variants were built and looked at in the running app:
+
+- **A — a chevron in the LABEL ROW**, artwork completely uncovered. Cleanest
+  image, but it had a flaw that only showed once it was on screen: as built it
+  was not a CONTROL at all, just an aria-hidden mark. And that matters more now
+  than it would have an hour earlier, because PL13-001 was rejected and click
+  still means SELECT — so the drill control is the only pointer path into a
+  timeline. At 16px in a row of metadata it reads as punctuation.
+- **B — a corner BADGE** at the artwork's bottom-right, on a translucent pill.
+  Unmistakably a control, big enough to hit, clear of the frame's centre.
+
+**B was chosen**, with ONE glyph: a chevron. It shipped briefly with two, on
+the reasoning that the badge had to say "container" and "way in" at once — and
+that reasoning was built on a false premise. `CollectionFolderGlyph` is not a
+folder; it renders `CornerRightDown` under a misleading name. So the pair was
+two direction arrows saying the same thing twice, which the owner spotted on
+sight. The glyph is now `CollectionDrillGlyph`, named for what it draws, so the
+next reader cannot make the same mistake. What says CONTAINER is the card, not
+a second arrow.
+
+Still a real button composed as a SIBLING of the selection surface — a button
+inside the surface's button would be invalid HTML, which is why it is positioned
+rather than placed — and still `tabIndex -1` with
+`data-collections-keyboard-ignore`, so it stays out of the roving tab order and
+out of the strip's pan surface. Keyboard drill-in is unchanged (`O`).
+
+The offset is measured from the CARD's bottom, not the artwork's, because the
+artwork is inside the surface and this is not — the label row's height is the
+difference, and it differs per surface (a tight footer in the strip, a real
+caption in the grid). Tuned live to the same 7px clearance above the label row
+in both: `bottom-8` in the strip, `bottom-10` in the grid.
+
+Verified: 7px clearance measured on both surfaces, app tsc clean, 485 app tests,
+lint clean (5 pre-existing `<img>` warnings), graph-view e2e 95/95 — the 13
+assertions that address this control by name still pass, since `Open <name>` is
+unchanged.
+
+STILL OPEN: with the badge down to a bare chevron, nothing on the card says
+"container" except the item count and the border. Once PL13-003 lands a single
+representative frame, check whether that reads as a collection at a glance — the
+stacked-edge treatment is the fallback if it does not.
+
+## PL13-005 — One treatment for a card's controls, both always visible
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `graph-item-content.tsx`, `tests/e2e/graph-view.spec.ts`
+- Screenshot: Not captured
+
+The details trigger and the drill badge never read as siblings, and measuring
+said why — they differed in FOUR ways at once:
+
+| | details trigger | drill badge |
+| --- | --- | --- |
+| corner | `top-1 right-1` | `bottom-8 right-1.5` |
+| shape | 24px square | ~28×22 pill |
+| colour | zinc fill, zinc icon | zinc fill, SKY ring and icon |
+| reveal | hover-revealed | always visible |
+
+One rule now: **card controls live in ONE CLUSTER in the top-right, identical
+in size, shape and fill, always visible.** The look is a shared
+`CARD_CONTROL_CLASS`, the placement a shared `CARD_CONTROL_CLUSTER_CLASS` —
+6px from both edges, 6px between — and a media card's single control lands in
+exactly the same place (measured: 6/6 on both kinds).
+
+The first arrangement put details top-right and the drill bottom-right,
+bracketing the edge. It read as two unrelated marks, and it made the drill's
+offset a per-surface tuning problem against the label row's height. A cluster
+aligns them by construction and deletes that tuning entirely. The chevron sits
+nearest the corner deliberately: read left to right, the mark closest to the
+edge is the one that takes you past it.
+
+**Always visible is the substantive half.** The trigger used to hide until
+hover, with the hiding gated on `@media(hover:hover)` so a touch device — which
+never hovers — could still reach it (PL11-011). Making both permanent deletes
+that gate and the whole class of bug behind it: pointer and touch now behave
+identically and there is no media query to get wrong. The cost is two standing
+marks on a collection card, paid deliberately, because since PL13-001 was
+rejected click means SELECT — so the drill badge is the ONLY pointer route into
+a timeline, and a route nobody can see is not a route.
+
+The bottom-right placement needed an offset measured from the CARD's bottom
+rather than the artwork's — the artwork lives inside the selection surface and
+the badge does not, so the label row's height was the difference, and it differs
+per surface. Two hand-tuned magic numbers. The cluster removed the need for
+both.
+
+TESTS THIS MADE FALSE, both updated rather than deleted: the idle → hover → away
+→ focus opacity dance is now a flat "visible at rest", and the touch test's
+rationale changed — it no longer distinguishes touch from pointer, but it still
+guards that the one route into the details view is reachable without hover,
+which any future reveal rule would have to keep true.
+
+Verified: 7px clearance and a shared right edge measured on both surfaces, app
+tsc clean, 485 app tests, lint clean (5 pre-existing `<img>` warnings),
+graph-view e2e 95/95.
+
+## PL13-006 — Selected, as a badge on both card kinds
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `graph-item-content.tsx`
+- Screenshot: Not captured
+
+A tick in the card's top-left, present only while the card is selected, on
+collections and media alike.
+
+**A badge, not a control — that distinction is the whole design.** A checkbox
+you click to select was built and rejected (PL13-001): with the card body
+already selecting, it was a second affordance for one act, and being
+invisible-but-clickable it swallowed clicks meant for the card. This one appears
+BECAUSE the card is selected and does nothing when pressed
+(`pointer-events-none`, so it cannot repeat that mistake), and it is
+`aria-hidden` because the card already exposes `aria-pressed` and
+`data-selected` — announcing "selected" twice per card is noise, not access.
+
+What it earns: a MULTI-selection you can read. `ring-amber-300/65` is a fine
+binary signal on one card and a weak one across a board of forty, where the eye
+has to compare border colours. Same amber as the ring on purpose — one
+selection colour, two ways of saying it.
+
+Top-LEFT, mirroring the control cluster in the top-right, and 20px against
+their 24px: a marker should not read as a button you failed to press.
+
+The media wrapper reads selection with its own boolean selector rather than
+taking it from NodeCard, which keeps it inside its own shell — and the badge has
+to be a SIBLING of that shell like everything else here, since a span inside the
+card's `<button>` is still inside a button. A boolean selector re-renders that
+card only when ITS selection flips, not on every selection change on the board.
+
+Verified live on both kinds (amber fill measured as `oklch(0.879 0.169 91.6)`,
+`pointer-events: none`), app tsc clean, 485 app tests, lint clean, graph-view
+e2e 95/95.
+
+## PL13-007 — An empty collection shows a leader frame
+
+- Status: Complete
+- Area: `graph-item-content.tsx`
+- Screenshot: user reference (a scanned academy-leader countdown frame)
+
+The empty slot was a blank span — a dark rectangle that read as a broken
+thumbnail rather than as "nothing in here yet". It shows an academy leader now:
+the film industry's own mark for "before the picture starts", which is exactly
+the state, and a recognizable silhouette at strip size where a label would be
+too small to read.
+
+DRAWN, not loaded. The reference was a photograph of a scanned leader with grain
+and scratches; at card size the geometry is the whole message — ring, crosshair,
+sweep — and the grain is invisible. A vector costs no request, stays crisp in
+the grid's much larger cells, and takes the board's palette instead of putting a
+bright sepia field on a near-black board. `CollectionLeaderPlaceholder` is the
+one place to swap in the photograph if the texture is ever wanted.
+
+STILL OPEN, and visible the moment it shipped: the placeholder now means TWO
+things. A collection with 0 items is genuinely empty, and "before the picture
+starts" is right. A collection that simply is not HYDRATED yet has content —
+"Jake's Exit" reads `4:58 / 2 items` beside a leader frame — and for that one
+the mark says "nothing" about something with plenty. The card already publishes
+`data-collection-hydrated`, so telling them apart is cheap; what it should look
+like is undecided.
+
+## PL13-002 — Click selects everywhere, including duplicate references
+
+- Status: Not started
+- Area: `graph-timeline-view.tsx` (`openOnClick`)
+
+If consistency is the reason PL13-001 was rejected, this is the one place the
+app still breaks it. A duplicate-reference card — media standing in for a
+twice-referenced timeline — OPENS on a plain click, because it has no drill
+button to do it (`openOnClick` in graph-timeline-view returns true exactly for
+`duplicateOfTimelineId`). Every other card selects.
+
+So click should select there too, and drilling into a duplicate reference goes
+through the `O` key like every other keyboard drill-in — or its own control, if
+it turns out one is wanted.
+
+Acceptance criteria:
+
+- A plain click on a duplicate-reference card selects it, like any other card.
+- `O` still opens it.
+- No card kind opens on a plain click.
+
+## PL13-003 — One frame on a collection card
+
+- Status: Complete, with the frame CHOICE still open (see the end)
+- URL: http://localhost:3000/timeline/project-1785180655904-uc9isj/graph
+- Area: `graph-item-content.tsx` (`useCollectionPreviewFrames`)
+
+Independent of the interaction model, and it survives PL13-001 on its own
+merits. Collection cards tile the first and last child's frames; at card size
+each slot is ~80px wide — too small to recognize a face, and the crop turns a
+composition into a slice of one. The item count is printed next to the duration,
+so the tiles are not carrying "how many" either.
+
+**But not the FIRST frame.** This project's own demo proves why: the "Intro"
+collection currently renders "A Universal Picture" — a studio slate. First
+frames are logos, black, and fades-up. Pick a representative one: the midpoint
+of the collection's own duration (the preview machinery already resolves a time
+to a frame for the playhead), or the first clip's midpoint as the cheaper
+variant.
+
+What the tiles were also carrying is "this is a container, not a clip". With
+them gone, check whether the count, the drill button and the border treatment
+say it well enough; a few px of stacked edge behind the image is the fallback
+that costs far less width than a second tile.
+
+**Media cards keep their filmstrip.** Those frames are distinct samples across
+ONE clip's visible range, ending on its last frame, resampled as the card
+resizes (rounds 6-7, `useSettledFrameCount`) — a duration readout, not a
+contents summary.
+
+`useCollectionPreviewFrames` returned a first/last PAIR; it returns one frame.
+Everything else about the card is unchanged, and media cards keep their
+filmstrip.
+
+Acceptance criteria:
+
+- A collection card shows one frame, filling the artwork area. ✅
+- Media cards are untouched. ✅
+- The frame is not the first frame of the first clip — **NOT MET.** It is the
+  first child's frame, and the demo now proves the cost at full width rather
+  than in a thumbnail slice: the "Intro" card is a wall of "Universal Picture".
+  A representative frame (the midpoint of the collection's own duration) needs
+  the preview machinery to resolve a TIME rather than take a stored poster,
+  which is its own change. Logged as the open half of this item rather than
+  quietly dropped.


### PR DESCRIPTION
Punch list 13. One pass over the collection card, driven by looking at it in the running app rather than reasoning about it — which is also why two designs got built and thrown away on the way.

## One frame (PL13-003)

`useCollectionPreviewFrames` returned a first/last **pair**. At card size that meant two ~80px slots — too narrow to recognize a face, and the crop turned a composition into a slice of one. The item count beside the duration already says how many, so the pair wasn't carrying that either.

## One control cluster (PL13-004, PL13-005)

The drill affordance was a circle at 34% of the card, centred at 41% height: **the control that navigates into a timeline was sitting on top of the frame you'd use to recognize it.** Two variants were built and looked at side by side; the corner badge won, then moved again after seeing it. Details and drill now sit **together in the top-right** — 6px from each edge, 6px apart, same 24px box, same fill. A media card's single control lands in exactly the same place (measured 6/6 on both kinds).

They had differed in **four** ways at once — corner, shape, colour, reveal rule — which is why they never read as siblings. The bottom-right placement also needed the drill's offset measured from the *card's* bottom rather than the artwork's (the artwork is inside the selection surface; the badge isn't), a hand-tuned magic number per surface. Clustering deleted both.

**Always visible.** The details trigger used to hide until hover, with the hiding gated on `@media(hover:hover)` so touch devices could still reach it (PL11-011). Permanent controls delete that gate *and* the class of bug behind it. The cost — two standing marks — is paid deliberately: click still means SELECT, so the drill badge is the only pointer route into a timeline, and a route nobody can see is not a route.

## Selected, as a badge (PL13-006)

A tick in the top-left while a card is selected, on both kinds. **A badge, not a control.** A checkbox you click to select was built and rejected earlier: with the card body already selecting it was a second affordance for one act, and being invisible-but-clickable it swallowed clicks meant for the card. This one appears *because* the card is selected, is `pointer-events-none` so it can't repeat that, and is `aria-hidden` because `aria-pressed` already says it. What it earns is a multi-selection you can read across a board of forty, where comparing ring colours fails.

## A leader frame for empty (PL13-007)

The empty slot was a blank span that read as a broken thumbnail. It shows an academy leader now — the industry's own mark for "before the picture starts". Drawn as a vector: at card size the geometry is the message and the reference photograph's grain is invisible.

## Also

`CollectionFolderGlyph` → `CollectionDrillGlyph`. It does not draw a folder — it draws `CornerRightDown`, and the misleading name is exactly how it ended up paired with a chevron in the badge: two direction arrows saying the same thing twice.

Two tests this made false, **updated rather than deleted**: the details trigger's idle → hover → away → focus opacity dance became "visible at rest", and the touch test's rationale changed — it no longer distinguishes touch from pointer, but it still guards that the one route into the details view is reachable without hover.

## Verification

App tsc clean, 485 app tests, lint clean (5 pre-existing `<img>` warnings), **graph-view e2e 95/95**. Every change measured live on both surfaces: shared 6px insets, 6px gap, 24px controls, amber badge fill matching the selection ring.

## Known and logged, not fixed here

- The single frame is the **first child's**, so a collection whose first clip opens on a slate now shows that slate full-width — this repo's own demo renders "A Universal Picture". A representative frame (the collection's midpoint) needs the preview machinery to resolve a *time* rather than take a stored poster.
- The leader placeholder currently means both "empty" and "not hydrated yet" — "Jake's Exit" shows one beside `4:58 / 2 items`. The card already publishes `data-collection-hydrated`, so telling them apart is cheap; what it should look like is undecided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
