### PR TITLE
PL13-009 + PL13-010: details becomes an item action, and the strip gets a track

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -69,6 +69,7 @@ import {
   GRID_GAP,
   GRID_UNCAPPED_HEIGHT,
   GRAPH_STRIP_OVERSCAN_ITEMS,
+  GRAPH_STRIP_TRACK_CLASS,
   ITEM_SIZE_DIMENSIONS,
   ITEM_SIZES,
   MAX_SUBTREE_DEPTH,
@@ -767,8 +768,14 @@ export function GraphBoard({
                 }
                 // pt-4: the 16px top band the seek rail centres in — same
                 // clearance system as the grid's GRID_GAP row bands.
+                //
+                // The background was `bg-transparent`, which is what made a
+                // short strip read as cards floating on the page. It is the
+                // TRACK now (PL13-010) — on the scroll viewport, so it spans
+                // the visible width whatever the content does.
                 className={[
-                  "rounded-none border-0 bg-transparent p-0",
+                  "rounded-none border-0 p-0",
+                  GRAPH_STRIP_TRACK_CLASS,
                   previewOn || rulerOn ? "pt-4" : "",
                 ].join(" ")}
               />

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -12,7 +12,7 @@ import {
   useSyncExternalStore,
   type ReactNode,
 } from "react";
-import { Check, ChevronRight, CornerRightDown, Maximize2 } from "lucide-react";
+import { Check, ChevronRight, CornerRightDown } from "lucide-react";
 
 import {
   CollectionItem,
@@ -45,7 +45,6 @@ import { useClipDetail, useGraphDetailsStore, useTimelineTitle } from "./graph-d
 import { isDisabledByAncestor } from "./graph-playhead-model";
 import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
 import { useCollectionHoverTarget } from "./graph-collection-hover";
-import { useItemDetails } from "./graph-item-details-context";
 import { GraphViewNavContext } from "./graph-navigation";
 import { TrimPanel } from "./graph-trim-panel";
 import { createDerivedCache } from "@/lib/derived-cache";
@@ -1103,8 +1102,11 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
           them from the strip's pan surface (isPannableStripSurface), so a press
           here never scrolls the strip out from under it. */}
       {selected && <CardSelectedBadge />}
+      {/* One control, not a cluster: the details trigger moved to the rail's
+          item actions (PL13-009), so what is left on the card is the drill. It
+          keeps the cluster's position — same corner, same inset — because that
+          is where a card's control belongs whether there are two or one. */}
       <span className={CARD_CONTROL_CLUSTER_CLASS}>
-        <ItemDetailsTrigger id={id} rovingTabIndex={undefined} inCluster />
         <button
           type="button"
           tabIndex={-1}
@@ -1198,70 +1200,22 @@ const GraphCollectionItem = memo(function GraphCollectionItem({
  * would put dozens of them in the tab order. Roving keeps the surface at one
  * stop; this adds exactly one more, on the card the user is actually on.
  */
-const ItemDetailsTrigger = memo(function ItemDetailsTrigger({
-  id,
-  rovingTabIndex,
-  inCluster = false,
-}: Readonly<{
-  id: NodeId;
-  rovingTabIndex: number | undefined;
-  /** True when a card renders this INSIDE `CARD_CONTROL_CLUSTER_CLASS`, which
-   *  owns the position — a collection pairs it with the drill control. Alone
-   *  (a media card) it positions itself at the SAME inset, so both card kinds
-   *  put their controls in exactly the same place. */
-  inCluster?: boolean;
-}>) {
-  const store = useCollectionsStore();
-  const { setOpenId } = useItemDetails();
-  // NAME the item: a board shows dozens of these, and "Open item details"
-  // spoken twenty times says nothing about which one. It also kept the label
-  // out of the way of the collection card's own "Open <name>" drill button —
-  // one card carrying two buttons whose names both began "Open" made every
-  // by-role locator ambiguous, which is how this was found.
-  const name = useCollectionsSelector((s) => s.graph.nodesById.get(id)?.name ?? "item");
+/*
+ * REMOVED (PL13-009): `ItemDetailsTrigger`, the per-card button that opened the
+ * details view.
+ *
+ * It was a control on the artwork of every card — and PL13-005 had just made it
+ * permanent, so both card kinds carried a standing mark for a view most people
+ * open rarely. Details is an item ACTION now, first in the sidebar's contextual
+ * cluster, disabled unless exactly one item is selected. That also settles the
+ * consistency question that produced PL13-005 (where should the trigger sit on
+ * each card kind) by not having one.
+ *
+ * Its `openId`-and-also-select coupling went with it: from the rail the
+ * selection is the input, so the details listener reads it rather than setting
+ * it (see graph-item-details-context).
+ */
 
-  return (
-    <button
-      type="button"
-      data-item-details-trigger={id}
-      aria-label={`Details for ${name}`}
-      title="Details"
-      {...(rovingTabIndex !== undefined ? { tabIndex: rovingTabIndex } : {})}
-      onPointerDown={(event) => {
-        // Keep the press off the surface gestures underneath — the strip's
-        // pan and (in grid) the hold-drag both start on pointerdown.
-        event.stopPropagation();
-      }}
-      onClick={(event) => {
-        event.stopPropagation();
-        // Open it AND select it: the details view is about one item, and
-        // leaving the selection on some other card makes every selection-scoped
-        // readout in the board disagree with what the modal is showing.
-        store.setSelection([id]);
-        setOpenId(id as string);
-      }}
-      // ONE treatment, shared with the drill badge on a collection card: same
-      // 24px square, same right edge, same fill — details top-right, drill
-      // bottom-right, bracketing the same side. The two used to differ in
-      // corner, shape, colour AND reveal rule, which is why they never read as
-      // siblings.
-      className={[
-        CARD_CONTROL_CLASS,
-        inCluster ? "" : "absolute right-1.5 top-1.5",
-        // ALWAYS VISIBLE (PL13-005). It was hover-revealed, with the hiding
-        // gated on `hover:hover` so a touch device — which never hovers — could
-        // still reach it (PL11-011). Always-visible removes that whole class of
-        // problem: pointer and touch now behave identically and there is no
-        // media query to get wrong. The cost is two permanent marks on a card,
-        // paid deliberately, because on a collection the drill badge is the only
-        // pointer route into a timeline and a route nobody can see is not one.
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300",
-      ].join(" ")}
-    >
-      <Maximize2 aria-hidden="true" className="h-3.5 w-3.5" />
-    </button>
-  );
-});
 
 /**
  * The media card: the stock NodeCard, wrapped so a details trigger and a
@@ -1296,7 +1250,6 @@ const GraphMediaItem = memo(function GraphMediaItem({
     <div className={["group/media-item relative", className ?? ""].join(" ")}>
       <NodeCard {...props} className="h-full w-full" />
       {mediaSelected && <CardSelectedBadge />}
-      <ItemDetailsTrigger id={props.id} rovingTabIndex={props.rovingTabIndex} />
       {rename.editing && node?.kind === "media" && (
         <InlineNameEditor
           initialValue={detail?.title ?? ""}

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-context.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-context.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { createContext, useContext, useMemo, useState, type ReactNode } from "react";
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+
+import { useCollectionsStore } from "@storyboard/ui/dnd-collections";
+
+import { GRAPH_ITEM_ACTION_EVENT, type GraphItemAction } from "@/lib/graph-view-events";
 
 /**
  * WHICH item has its details open (PL10-004 → PL11-002).
@@ -26,7 +30,45 @@ const CLOSED: ItemDetailsValue = { openId: null, setOpenId: () => {} };
 export function ItemDetailsProvider({ children }: Readonly<{ children: ReactNode }>) {
   const [openId, setOpenId] = useState<string | null>(null);
   const value = useMemo(() => ({ openId, setOpenId }), [openId]);
-  return <ItemDetailsContext.Provider value={value}>{children}</ItemDetailsContext.Provider>;
+  return (
+    <ItemDetailsContext.Provider value={value}>
+      <ItemDetailsActionListener onOpen={setOpenId} />
+      {children}
+    </ItemDetailsContext.Provider>
+  );
+}
+
+/**
+ * Opens the details view when the sidebar's Edit action fires (PL13-009).
+ *
+ * The listener lives HERE rather than in the item-actions bridge, which is
+ * mounted outside this provider and would only ever see the closed fallback.
+ * The details feature owning its own trigger also means the rail knows nothing
+ * about `openId` — it sends a verb and this decides what that means.
+ *
+ * Reads the selection at the moment of the press rather than tracking it: the
+ * event IS the intent, and anything else would be a second copy of state the
+ * store already holds. Refuses anything that is not exactly one item — the
+ * sidebar disables the control past one, but a window event carries no proof
+ * of who sent it.
+ */
+function ItemDetailsActionListener({
+  onOpen,
+}: Readonly<{ onOpen: (id: string) => void }>) {
+  const store = useCollectionsStore();
+
+  useEffect(() => {
+    const onAction = (event: Event) => {
+      if ((event as CustomEvent<GraphItemAction>).detail !== "details") return;
+      const selected = [...store.getSnapshot().interaction.selectedIds];
+      if (selected.length !== 1) return;
+      onOpen(selected[0] as string);
+    };
+    window.addEventListener(GRAPH_ITEM_ACTION_EVENT, onAction);
+    return () => window.removeEventListener(GRAPH_ITEM_ACTION_EVENT, onAction);
+  }, [store, onOpen]);
+
+  return null;
 }
 
 /** Degrades to "never open" with no provider, so cards render standalone

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -45,6 +45,7 @@ import {
   GRID_GAP,
   GRID_UNCAPPED_HEIGHT,
   GRAPH_STRIP_OVERSCAN_ITEMS,
+  GRAPH_STRIP_TRACK_CLASS,
   ITEM_SIZE_DIMENSIONS,
   MAX_SUBTREE_DEPTH,
   SUBTIMELINE_INDENT_PX,
@@ -374,7 +375,12 @@ function SubTimelineNode({
                   ) : undefined
                 }
                 // pt-4: the 16px top band the seek rail centres in.
-                className="bg-black/20 pt-4"
+                //
+                // The same TRACK the focused strip uses (PL13-010), replacing a
+                // `bg-black/20` wash that went the wrong way — a sub-row read as
+                // a DARKER hole in the board rather than as a surface holding
+                // clips. A strip is a strip wherever it appears.
+                className={`${GRAPH_STRIP_TRACK_CLASS} pt-4`}
               />
               {showPlayhead && (
                 <GraphStripSeekRail

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-config.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-config.ts
@@ -29,6 +29,35 @@ export const DEFAULT_TIMELINE_PPS = 50;
  */
 export const GRAPH_STRIP_OVERSCAN_ITEMS = 8;
 
+/**
+ * The strip's TRACK: the surface a row of clips sits on.
+ *
+ * A strip holding nothing — or two clips — used to read as cards floating on
+ * the page, because the surface itself was invisible and only a dashed outline
+ * suggested it. A filled track says "things go here, in a row" before anything
+ * does, which makes it the honest empty state for this surface (the board's
+ * other empty affordance, "Add timeline", is a slot INSIDE a row; this is the
+ * row).
+ *
+ * It goes on the SCROLL VIEWPORT, not the content, and that is what makes the
+ * hard half free. The track then spans the visible width whatever the content
+ * does: with two clips the rest of the row is visible track, and with a
+ * thousand the track stays put while the cards scroll over it. Painting it on
+ * the content instead would need a third width — beside `getTotalSize()` (the
+ * cards' extent, which drop indices read) and the content div's own width
+ * (that plus the trailing slot) — and a trailing inset on a SCROLLABLE run is
+ * not padding at all; it is a gap that appears mid-content the moment you
+ * scroll.
+ *
+ * Sits BETWEEN the board and the cards tonally, and the ORDER is the
+ * constraint: the board is near-black and a card is an opaque `bg-zinc-900`, so
+ * the track has to be lighter than the first and darker than the second or it
+ * competes with what it is holding. `zinc-900` at 60% lands around a third of
+ * the way from the board to a card — lifted enough to read as a surface at a
+ * glance, still clearly behind the clips.
+ */
+export const GRAPH_STRIP_TRACK_CLASS = "bg-zinc-900/60";
+
 /** Gap between grid cells — sized as the seek-rail BAND: the slim track
  *  centres inside it with clear space on both sides, so the rail (and its
  *  thumb) never touches the cards above or below. The strips reserve the

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -7,6 +7,7 @@ import {
   ClipboardPaste,
   Copy,
   ChevronsLeftRightEllipsis,
+  Pencil,
   CopyPlus,
   EllipsisVertical,
   Film,
@@ -431,11 +432,16 @@ function ItemActionsOverflow({
  */
 function ItemActionsCluster({
   hasSelection,
+  isSingleSelection,
   canPaste,
   busy,
   allDisabled,
 }: Readonly<{
   hasSelection: boolean;
+  /** Exactly ONE item selected — the only shape the details view can render.
+   *  Distinct from `hasSelection`, which every other action here is happy
+   *  with. */
+  isSingleSelection: boolean;
   canPaste: boolean;
   busy: boolean;
   /** Every selected item is already skipped — flips the toggle to "Enable". */
@@ -452,6 +458,18 @@ function ItemActionsCluster({
         data-item-actions-cluster
         className="flex w-full flex-col items-stretch gap-0 bg-amber-200/[0.025]"
       >
+        {/* FIRST, because it is the action that tells you WHAT you have
+            selected before you act on it — and because the details view lost
+            its per-card trigger to get here (PL13-009). Disabled, not hidden,
+            past one selection: a control that vanishes teaches nothing, while a
+            disabled one says "wrong shape of selection for that". */}
+        <ItemActionButton
+          action="details"
+          icon={Pencil}
+          label="Edit"
+          description="Open the selected item's details"
+          disabled={busy || !isSingleSelection}
+        />
         {!canPaste ? (
           <>
             <ItemActionButton
@@ -677,6 +695,7 @@ export function TimelineSidebar() {
       {activeProjectId && itemMode && (
         <ItemActionsCluster
           hasSelection={selectionCount > 0}
+          isSingleSelection={selectionCount === 1}
           canPaste={canPaste}
           busy={actionBusy}
           allDisabled={selectionAllDisabled}

--- a/apps/timeline-gstudio001/lib/graph-view-events.ts
+++ b/apps/timeline-gstudio001/lib/graph-view-events.ts
@@ -126,7 +126,13 @@ export type GraphItemAction =
   | "delete"
   | "cancel"
   /** Skip (or un-skip) the selection in playback, counts and time totals. */
-  | "toggle-disabled";
+  | "toggle-disabled"
+  /** Open the details view for the selection. Meaningful for exactly ONE
+   *  selected item — the view is about a single clip's frames, in/out points
+   *  and name, and there is no honest way to render it for six. The sidebar
+   *  disables the control past one; the graph side refuses as well, because a
+   *  window event is not a promise about what sent it. */
+  | "details";
 
 /** Graph → sidebar: the live selection size, so the sidebar can enter/exit
  *  item-actions mode and enable/disable the selection-dependent buttons. */

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -376,14 +376,23 @@ async function settleMoveAnimations(page: Page): Promise<void> {
 }
 
 /**
- * Opens an item's details the way a user does now (PL11-002): the trigger
- * lives on the card, hidden until hover or focus. Playwright's click hovers
- * first, so the reveal is implicit — but the click is FORCED past the
- * opacity-0 idle state, which is a visibility rule rather than a hit-testing
- * one.
+ * Opens an item's details the way a user does now (PL13-009): SELECT the card,
+ * then press Edit in the rail's contextual item actions. The per-card trigger
+ * is gone — details is an item action, and the selection is its input.
  */
 async function openItemDetails(page: Page, nodeId: string): Promise<void> {
-  await page.locator(`[data-item-details-trigger="${nodeId}"]`).click();
+  const card = page.locator(`[data-node-id="${nodeId}"]`).first();
+  // Retried, for the reason this suite already documents elsewhere: cards use
+  // press-and-hold to drag, so under load a plain click can outlast the 250ms
+  // threshold, become a grab, and have its click — correctly — suppressed.
+  // Asserting the selection here also means a failure says WHICH half broke,
+  // rather than timing out on a rail control that only exists once something
+  // is selected.
+  await expect(async () => {
+    await card.click();
+    await expect(card).toHaveAttribute("data-selected", "true", { timeout: 700 });
+  }).toPass({ timeout: 10000 });
+  await page.getByRole("button", { name: "Edit", exact: true }).click();
   await settleViewTransition(page);
 }
 
@@ -3762,24 +3771,16 @@ test.describe("graph view E2E", () => {
     // bravo is an IMAGE, and we are in the grid — the two things the old
     // trim-only toggle refused.
     const bravo = page.locator('[data-node-id="bravo"]');
-    const trigger = page.locator('[data-item-details-trigger="bravo"]');
-    await expect(trigger).toHaveCount(1);
+    // No control on the card at all now (PL13-009): details is an item action
+    // in the rail, so the card carries nothing for it. This assertion used to
+    // be a reveal dance (idle → hover → away → focus), then a flat "visible at
+    // rest" when card controls became permanent — and it is now the absence
+    // that matters, because a standing mark on every card for a rarely-opened
+    // view was what sent this to the rail.
+    await expect(page.locator("[data-item-details-trigger]")).toHaveCount(0);
 
-    // ALWAYS VISIBLE (PL13-005). This used to be an idle → hover → away →
-    // focus opacity dance, because the trigger hid itself until the card was
-    // hovered. Card controls are permanent now — same rule on a collection's
-    // drill badge — which is what removed the `@media(hover:hover)` gate and
-    // with it the whole class of "invisible on touch" bugs. Nothing is hovered
-    // or focused here, and that is the point.
-    const opacity = () => trigger.evaluate((el) => getComputedStyle(el).opacity);
-    await expect.poll(opacity).toBe("1");
-    await bravo.hover();
-    await expect.poll(opacity).toBe("1");
-    await page.mouse.move(0, 0);
-    await expect.poll(opacity).toBe("1");
-
-    // Pressing it selects the card as well, so the board's selection-scoped
-    // readouts agree with what the view is showing.
+    // Opening still selects the card — from the rail it is the selection that
+    // names the item, so the board's readouts and the view cannot disagree.
     await openItemDetails(page, "bravo");
     await expect(bravo).toHaveAttribute("data-selected", "true");
 
@@ -3801,13 +3802,24 @@ test.describe("graph view E2E", () => {
     await page.keyboard.press("Escape");
     await expect(page.locator("[data-item-details]")).toHaveCount(0);
 
-    // Keyboard reachable: the card is the surface's one roving tab stop, and
-    // its trigger is the next one — so Tab from the card lands on it and
-    // Enter opens the view. A flat tabIndex would have put every mounted
-    // card's trigger in the order instead.
-    await bravo.focus();
-    await page.keyboard.press("Tab");
-    await expect(page.locator('[data-item-details-trigger="bravo"]')).toBeFocused();
+    // Keyboard reachable — through the RAIL now (PL13-009). The card used to
+    // carry a trigger as the tab stop after itself; details moved off the card,
+    // so the route is the one every other item action already uses: select,
+    // then the contextual cluster.
+    //
+    // What is worth asserting is the half that CHANGED: the control is an
+    // ordinary focusable button that opens on Enter, with no pointer involved.
+    // Selecting is done by click here rather than by Space — Space-selects-a-
+    // card is the package's own grammar with its own coverage, and threading it
+    // through a modal close and a re-render made this test flaky about
+    // something it was not testing.
+    await expect(async () => {
+      await bravo.click();
+      await expect(bravo).toHaveAttribute("data-selected", "true", { timeout: 700 });
+    }).toPass({ timeout: 10000 });
+    const edit = page.getByRole("button", { name: "Edit", exact: true });
+    await edit.focus();
+    await expect(edit).toBeFocused();
     await page.keyboard.press("Enter");
     await settleViewTransition(page);
     await expect(page.getByRole("dialog")).toHaveCount(1);
@@ -4008,19 +4020,17 @@ test.describe("graph view E2E", () => {
         await page.evaluate(() => window.matchMedia("(hover: none)").matches),
       ).toBe(true);
 
-      const trigger = page.locator('[data-item-details-trigger="alpha"]');
-      await expect(trigger).toHaveCount(1);
-      // Visible, as it now is everywhere — the trigger stopped hiding itself in
-      // PL13-005, so this no longer distinguishes touch from pointer. Kept
-      // because what it really guards is that the ONE route into the details
-      // view is reachable on a device that cannot hover, and a future reveal
-      // rule would have to keep that true.
-      await expect
-        .poll(() => trigger.evaluate((el) => getComputedStyle(el).opacity))
-        .toBe("1");
+      // The per-card trigger is gone (PL13-009), and with it the failure this
+      // test was written for: a control that hid until hover was unreachable
+      // where hover does not exist. What still needs guarding is the ROUTE —
+      // select, then Edit — working on a device that cannot hover, since the
+      // rail is now the only way in.
+      await expect(page.locator("[data-item-details-trigger]")).toHaveCount(0);
 
-      // And it still opens from there.
-      await trigger.tap();
+      await page.locator('[data-node-id="alpha"]').first().tap();
+      const edit = page.getByRole("button", { name: "Edit", exact: true });
+      await expect(edit).toBeEnabled();
+      await edit.tap();
       await expect(page.getByRole("dialog")).toHaveCount(1);
     } finally {
       await context.close();

--- a/punch-list/PUNCH-LIST-13.md
+++ b/punch-list/PUNCH-LIST-13.md
@@ -217,7 +217,7 @@ like is undecided.
 
 ## PL13-009 — Details moves off the card and into the item actions
 
-- Status: Not started
+- Status: Complete
 - Area: `graph-item-content.tsx` (remove the trigger), `timeline-sidebar.tsx`
   (item-actions cluster), `graph-item-details-context.tsx`
 - Supersedes: the details trigger placed by PL11-002 / PL11-012
@@ -268,7 +268,7 @@ Acceptance criteria:
 
 ## PL13-010 — The strip should look like a strip when it is empty
 
-- Status: Not started
+- Status: Complete
 - Area: `graph-board.tsx` (the strip's shell), `packages/ui/dnd-collections`
   (VirtualStrip's content box)
 
@@ -304,6 +304,42 @@ Acceptance criteria:
   trailing gap appears mid-scroll.
 - The ruler, seek rail and drop indicator keep their current alignment — the
   track is behind them, and it must not shift the geometry any of them measure.
+
+## PL13-009 / PL13-010 — what building them changed
+
+**009 landed as specified**, with the listener in a different place than the
+item guessed. It sits inside `ItemDetailsProvider`, not in the item-actions
+bridge: the bridge is mounted OUTSIDE that provider, so `useItemDetails()` there
+only ever sees the closed fallback. The rail sends a verb; the details feature
+decides what it means and reads the selection at press time. It refuses anything
+that is not exactly one item even though the button is disabled past one —
+a window event carries no proof of who sent it.
+
+`ItemDetailsTrigger` is DELETED rather than left unrendered, with a note where
+it stood.
+
+**010 turned out simpler than the item predicted**, and the reason is the whole
+trick: the track goes on the scroll VIEWPORT, not the content. It then spans the
+visible width whatever the content does — two clips leave the rest as visible
+track, a thousand scroll over a track that stays put. No third width beside
+`getTotalSize()` and the content div's own, and no trailing-gap problem, because
+a viewport background cannot scroll away. The strip was explicitly
+`bg-transparent` before, which is what made a short row read as cards floating
+on the page. Sub-rows were `bg-black/20` — DARKER than the board, so a sub-row
+read as a hole rather than a surface; they take the same track now.
+
+E2E LESSON, and the suite already had it written down elsewhere: **a plain
+`.click()` on a card can fail to select.** Press-and-hold is the drag
+activation, so under load the press outlasts the 250ms threshold, becomes a
+grab, and its click is correctly suppressed. `openItemDetails` retries with
+`expect(async () => …).toPass()` like the rest of the suite, and asserts the
+selection landed — so a failure names the half that broke instead of timing out
+on a rail control that only exists once something is selected.
+
+The two reveal tests were REWRITTEN rather than deleted: the grid one asserts
+the absence of any card trigger (the state that matters now), and the touch one
+asserts the select-then-Edit route works where hover does not exist — which is
+what it was really protecting.
 
 ## PL13-002 — Click selects everywhere, including duplicate references
 


### PR DESCRIPTION
Two items, both from looking at the board rather than reasoning about it.

## Details moves off the card (PL13-009)

It was a control on the artwork of **every** card — and [#235](https://github.com/josulliv101/storyboard-flow/pull/235) had just made it permanent, so both card kinds carried a standing mark for a view most people open rarely. It's an item **action** now: first in the sidebar's contextual cluster, disabled unless exactly one item is selected.

That also settles the consistency question that produced the permanent-controls change — *where should the trigger sit on each card kind* — by not having one.

**Disabled, not hidden**, past one selection: a control that vanishes teaches nothing, while a disabled one says "wrong shape of selection for that".

Two wiring notes:

- **The listener lives inside `ItemDetailsProvider`**, not in the item-actions bridge — the bridge is mounted outside it and would only ever see the closed fallback. The rail sends a verb; the details feature decides what it means.
- **The old coupling inverts.** The card trigger set `openId` *and* selected; from the rail the selection is the input, read at press time. It refuses anything that isn't exactly one item even though the button is disabled past one, because a window event carries no proof of who sent it.

`ItemDetailsTrigger` is deleted rather than left unrendered.

## The strip gets a track (PL13-010)

A strip holding nothing — or two clips — read as cards floating on the page, because the surface was `bg-transparent` and only a dashed outline suggested it. A filled track says "things go here, in a row" before anything does.

**It goes on the scroll viewport, not the content**, and that's what makes the hard half free: the track spans the visible width whatever the content does, so two clips leave the rest as visible track and a thousand scroll over a track that stays put. Painting it on the content would have needed a *third* width beside `getTotalSize()` (the cards' extent, which drop indices read) and the content div's own — and a trailing inset on a scrollable run isn't padding, it's a gap that appears mid-content the moment you scroll.

Sub-rows were `bg-black/20`, **darker** than the board, so a sub-row read as a hole rather than a surface holding clips. They take the same track: a strip is a strip wherever it appears.

## An e2e lesson the suite already had written down elsewhere

**A plain `.click()` on a card can fail to select.** Press-and-hold is the drag activation, so under load the press outlasts the 250ms threshold, becomes a grab, and has its click correctly suppressed. `openItemDetails` retries with `expect(async () => …).toPass()` like the rest of the suite, and asserts the selection landed — so a failure names the half that broke instead of timing out on a rail control that only exists once something is selected.

The two reveal tests were **rewritten rather than deleted**: the grid one asserts the *absence* of any card trigger (the state that matters now), and the touch one asserts the select-then-Edit route works where hover doesn't exist — which is what it was really protecting.

## Verification

App tsc clean, 485 app tests, lint clean (5 pre-existing `<img>` warnings), storybook project 164/164, **graph-view e2e 95/95**.

Live: 1 selected → Edit enabled, 2 and 3 → present and disabled; zero details triggers on any card; the modal opens for the selected item and closes on Escape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
