### PR TITLE
PL14-002/003/010: card controls read as controls, modal names open on one click

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-collection-details.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-collection-details.tsx
@@ -124,13 +124,23 @@ export function CollectionDetailsBody({
               className="min-w-0 flex-1 rounded-sm bg-zinc-900 px-1 py-0.5 text-sm font-semibold text-zinc-100 outline-none ring-1 ring-amber-400/70"
             />
           ) : (
-            <span
-              onDoubleClick={rename.begin}
-              title="Double-click or press F2 to rename"
-              className="min-w-0 flex-1 cursor-text truncate text-sm font-semibold text-zinc-100"
+            /* Single click to rename (PL14-010) — see the note on the clip
+               modal's title. Both dialogs get it because neither has a
+               competing click meaning; the CARD surfaces keep their double
+               click, because there click already means select. */
+            <button
+              type="button"
+              onClick={rename.begin}
+              aria-label={`Rename ${displayName}`}
+              title={`Rename ${displayName}`}
+              className={[
+                "min-w-0 flex-1 cursor-text truncate rounded-md px-1.5 py-1 text-left",
+                "text-sm font-semibold text-zinc-100 transition-colors hover:bg-zinc-800/70",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70",
+              ].join(" ")}
             >
               {displayName}
-            </span>
+            </button>
           )}
           <div className="flex items-center gap-3">
             <span className="font-mono text-[11px] tabular-nums text-zinc-400">

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -475,13 +475,17 @@ function CollectionLeaderPlaceholder() {
  *
  * Top-LEFT, mirroring the control cluster in the top-right, and 20px against
  * their 24px — a marker should not read as a button you failed to press.
+ *
+ * The 8px inset is shared with that cluster and the two must move TOGETHER
+ * (PL14-002/003 bumped both from 6px): they are top-aligned, so nudging one
+ * off the other's line is exactly what stops them reading as a pair.
  */
 function CardSelectedBadge() {
   return (
     <span
       data-card-selected-badge
       aria-hidden="true"
-      className="pointer-events-none absolute left-1.5 top-1.5 z-20 flex size-5 items-center justify-center rounded bg-amber-300 text-zinc-950 shadow-sm shadow-black/50"
+      className="pointer-events-none absolute left-2 top-2 z-20 flex size-5 items-center justify-center rounded bg-amber-300 text-zinc-950 shadow-sm shadow-black/50"
     >
       <Check className="size-3.5" strokeWidth={3} />
     </span>
@@ -503,11 +507,23 @@ function CardSelectedBadge() {
  * corner, shape, colour and reveal rule — four differences, which is why they
  * looked unrelated. Position and focus ring stay with the caller; everything
  * else is here.
+ *
+ * It must LOOK pressable, which took two things (PL14-002):
+ *
+ * - `cursor-pointer` is not redundant. Tailwind v4's preflight stopped setting
+ *   it on `<button>`, so every control wearing this class fell back to the UA
+ *   arrow — the one cue that says "this is a control and not a decal" was
+ *   simply absent.
+ * - The hover was `bg-zinc-950/80 → bg-zinc-900`: near-black onto near-black,
+ *   a step too small to register over artwork. `zinc-800` is a visible change
+ *   at the same neutral temperature. Deliberately NOT amber or sky — amber is
+ *   the selection colour (PL13-006) and colouring a hover with it would say
+ *   "selected" about a thing you are merely pointing at.
  */
 const CARD_CONTROL_CLASS = [
   "z-20 flex size-6 shrink-0 items-center justify-center rounded",
   "bg-zinc-950/80 text-zinc-300 shadow-sm shadow-black/40 backdrop-blur-[1px]",
-  "transition-colors hover:bg-zinc-900 hover:text-zinc-50",
+  "cursor-pointer transition-colors hover:bg-zinc-800 hover:text-zinc-50",
 ].join(" ");
 
 /**
@@ -520,8 +536,11 @@ const CARD_CONTROL_CLASS = [
  * re-tuning an offset against the label row's height (which differs per
  * surface). Grouped, they align by construction and a media card's single
  * control lands in exactly the same place as a collection's pair.
+ *
+ * The 8px inset is shared with `CardSelectedBadge` in the opposite corner —
+ * see the note there; the two are top-aligned and move together.
  */
-const CARD_CONTROL_CLUSTER_CLASS = "absolute right-1.5 top-1.5 z-20 flex items-center gap-1.5";
+const CARD_CONTROL_CLUSTER_CLASS = "absolute right-2 top-2 z-20 flex items-center gap-1.5";
 
 function CollectionDrillGlyph({ className }: Readonly<{ className?: string }>) {
   return <CornerRightDown aria-hidden="true" className={className} strokeWidth={1.5} />;

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -353,10 +353,27 @@ function ModalBody({ node, onClose }: Readonly<{ node: MediaNode; onClose: () =>
       >
         <div className="flex items-center justify-between gap-3">
           {/* The clip's name, editable here (PL10-010) — the same hook the
-              collection card, breadcrumb and sub-row rename through, so the
-              grammar is identical: double-click or F2 to open, Enter commits,
-              Escape cancels, blur commits. For MEDIA the name is the stored
-              `alt`, which the persistence bridge updates on this patch. */}
+              collection card, breadcrumb and sub-row rename through. Enter
+              commits, Escape cancels, blur commits. For MEDIA the name is the
+              stored `alt`, which the persistence bridge updates on this patch.
+
+              Opens on a SINGLE click (PL14-010), adopting the breadcrumb
+              crumb's treatment wholesale: a real button wearing `cursor-text`
+              and a hover tint, labelled `Rename …`. A double click with no
+              hover feedback is undiscoverable — nothing on screen said the
+              title was a field.
+
+              Why single click is available HERE and not on the cards: click
+              already means select on a card, so rename has to be the double
+              click there (and PL13-001 was rejected partly for adding a second
+              affordance around that conflict). Neither the current crumb nor
+              this title has a competing click meaning, so the cheaper gesture
+              is free. The card and sub-row keep their double click.
+
+              A <button> rather than the old <span> also puts rename in the tab
+              order, which is how it becomes reachable without the F2 shortcut
+              (still handled in capture above, and still the only route while
+              the dialog's focus sits elsewhere). */}
           {rename.editing ? (
             <InlineNameEditor
               initialValue={node.name}
@@ -367,13 +384,19 @@ function ModalBody({ node, onClose }: Readonly<{ node: MediaNode; onClose: () =>
               className="min-w-0 flex-1 rounded-sm bg-zinc-900 px-1 py-0.5 text-sm font-semibold text-zinc-100 outline-none ring-1 ring-amber-400/70"
             />
           ) : (
-            <span
-              onDoubleClick={rename.begin}
-              title="Double-click or press F2 to rename"
-              className="min-w-0 flex-1 cursor-text truncate text-sm font-semibold text-zinc-100"
+            <button
+              type="button"
+              onClick={rename.begin}
+              aria-label={`Rename ${node.name}`}
+              title={`Rename ${node.name}`}
+              className={[
+                "min-w-0 flex-1 cursor-text truncate rounded-md px-1.5 py-1 text-left",
+                "text-sm font-semibold text-zinc-100 transition-colors hover:bg-zinc-800/70",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70",
+              ].join(" ")}
             >
               {node.name}
-            </span>
+            </button>
           )}
           <div className="flex items-center gap-3">
             <span className="font-mono text-[11px] tabular-nums text-zinc-400">

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -3856,7 +3856,8 @@ test.describe("graph view E2E", () => {
     await expect(details.locator("img")).toHaveCount(1);
 
     // The name is editable here as well — the point of the view generalizing.
-    await details.locator("text=bravo").first().dblclick();
+    // One click, like the breadcrumb crumb (PL14-010).
+    await details.getByRole("button", { name: "Rename bravo" }).click();
     const editor = page.getByRole("textbox", { name: "Clip name" });
     await editor.fill("Establishing shot");
     await editor.press("Enter");
@@ -4120,7 +4121,7 @@ test.describe("graph view E2E", () => {
 
     // Rename lands the same way it does from the card — through the child
     // document's title, which is the source of truth for a collection's name.
-    await details.locator("text=Scene A").first().dblclick();
+    await details.getByRole("button", { name: "Rename Scene A" }).click();
     const editor = page.getByRole("textbox", { name: "Timeline name" });
     await editor.fill("Opening beat");
     await editor.press("Enter");
@@ -4304,8 +4305,11 @@ test.describe("graph view E2E", () => {
     expect(storedTitle()).toBeUndefined();
     expect(storedClip()?.alt).toBe("alpha");
 
-    // Double-click the name, type, Enter.
-    await page.locator("[data-item-details] >> text=alpha").first().dblclick();
+    // Click the name once, type, Enter.
+    await page
+      .locator("[data-item-details]")
+      .getByRole("button", { name: "Rename alpha" })
+      .click();
     const editor = page.getByRole("textbox", { name: "Clip name" });
     await expect(editor).toBeVisible();
     await editor.fill("Belushi close-up");
@@ -4332,7 +4336,10 @@ test.describe("graph view E2E", () => {
 
     // Escape cancels an edit instead of closing the modal — the capture-phase
     // key handler has to yield to the editor.
-    await page.locator("[data-item-details] >> text=Belushi close-up").first().dblclick();
+    await page
+      .locator("[data-item-details]")
+      .getByRole("button", { name: "Rename Belushi close-up" })
+      .click();
     const reopened = page.getByRole("textbox", { name: "Clip name" });
     await reopened.fill("Discarded");
     await reopened.press("Escape");

--- a/punch-list/PUNCH-LIST-14.md
+++ b/punch-list/PUNCH-LIST-14.md
@@ -1,0 +1,322 @@
+# Punch List 14
+
+Captured 2026-07-30 from a spoken walkthrough. Nothing started — every item is
+Not started until the owner says otherwise. Areas are best guesses from the file
+names, not from investigation.
+
+## PL14-001 — Enable/disable an item from the details modal
+
+- Status: Not started
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: `graph-item-details-modal.tsx`, `graph-item-actions.tsx`
+- Screenshot: Not captured
+
+When a media item or a collection item is shown in the modal, the modal should
+let the user disable or enable it.
+
+The disable feature already exists as a play-time skip — a disabled item keeps
+its slot and its span, and the player jumps it (see the `set-node-disabled`
+command and `playback-skip.ts`). This item is only about surfacing that control
+in the modal; it is not a change to what disabling means.
+
+Open: whether the control reads as a toggle (switch) or as an action that flips
+label between Disable and Enable. The item-actions cluster is the precedent to
+match.
+
+Done when: the modal shows the current enabled/disabled state for both card
+kinds, flipping it dispatches through the same command path as the existing
+action (so undo covers it), and the card reflects the change on close.
+
+## PL14-002 — Drill-down chevron needs a hover state and the right cursor
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: `graph-item-content.tsx` (`CARD_CONTROL_CLASS`)
+- Screenshot: Not captured
+
+The chevron that drills into a collection item did not read as clickable. Two
+separate causes, and the class already had what looked like a fix for one:
+
+- **No cursor.** `CARD_CONTROL_CLASS` never set one, and Tailwind v4's
+  preflight stopped setting `cursor: pointer` on `<button>` — so it fell back
+  to the UA arrow. Verified live before the change: `cursor: default`.
+- **A hover too small to see.** `hover:bg-zinc-900` over a `bg-zinc-950/80`
+  base is near-black onto near-black. Now `zinc-800`, a real step at the same
+  neutral temperature.
+
+Deliberately NOT amber or sky. Amber is the selection colour (PL13-006), and
+tinting a hover with it would say "selected" about a thing you are only
+pointing at.
+
+Fixed in the shared class, so it applies to every card control rather than to
+the chevron alone — which is the point of PL13-005. Focus ring untouched.
+
+Verified live: computed `cursor: pointer`, `hover:bg-zinc-800` present on the
+element and the rule emitted by Tailwind.
+
+## PL14-003 — Selected badge needs more padding from the card edges
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: `graph-item-content.tsx` (`CardSelectedBadge`, `CARD_CONTROL_CLUSTER_CLASS`)
+- Screenshot: Not captured
+
+The amber check badge sat 6px from the card's corner. Now 8px.
+
+**The control cluster moved with it.** The badge is top-LEFT specifically to
+mirror the cluster top-RIGHT, and the two are top-aligned — nudging one alone
+would have put them 2px out of line, which is exactly what stops them reading
+as a pair. Both are now 8px, and both comments say they move together.
+
+Everything else about the badge is unchanged: still 20px against the cluster's
+24px, still `pointer-events-none`, still `aria-hidden`.
+
+Verified live on a selected card: badge `top: 8px / left: 8px`, cluster
+`top: 8px / right: 8px`, both rendering at the same Y.
+
+## PL14-004 — The modal needs a closing view transition
+
+- Status: Not started
+- Area: `graph-item-details-modal.tsx`
+- Screenshot: Not captured
+
+Opening the modal animates with a view transition. Closing does not — it just
+disappears. It should animate back to the card it came from.
+
+Done when: closing runs a CSS view transition that returns the modal to its
+originating card's position, matching the open animation in reverse. Should
+respect `prefers-reduced-motion`.
+
+## PL14-005 — Move the settings icon to the icon sidebar
+
+- Status: Not started
+- Area: `graph-board.tsx` (remove from breadcrumb row), the icon sidebar
+  component (add below the trash slot)
+- Screenshot: Not captured
+
+The settings icon currently lives in the breadcrumb row. Move it to the icon
+sidebar, positioned below the trash folder icon at the bottom.
+
+Watch the trash drop slot: the sidebar's trash target is a portaled droppable
+that fills its slot, and a previous round lost sidebar tool drags to a slot div
+that covered them (`pointer-events-none` was the fix, PL round 6 / PR #128).
+Anything placed adjacent to it needs the same check.
+
+## PL14-006 — Trim drag drives the real preview when it is open
+
+- Status: Not started
+- Area: `graph-trim-panel.tsx`, `graph-preview.tsx`,
+  `packages/ui/timeline/viewport/workbench-display-surface.tsx`
+- Screenshot: Not captured
+
+When a video clip is selected and the user grabs a trim handle, a small overlay
+preview appears above the card showing the frame at the moving edge. Add the
+conditional: if the real preview area up top is OPEN, drive that surface during
+the drag instead of showing the overlay. If the preview area is closed, keep
+showing the overlay as it does now.
+
+**This un-defers a decision.** The preview-area override was built up to this
+point in round 5 and then explicitly deferred on the owner's instruction — the
+floating overlay shipped, the override did not. This item is the owner asking
+for it.
+
+Constraint carried over from that round: commandeering the preview surface must
+leave the playhead untouched — the preview shows the trim frame during the drag
+and returns to the playhead's frame after, without moving the clock.
+
+Done when: with the preview open, dragging a trim handle updates the preview
+surface and no overlay appears; with the preview closed, the overlay behaves
+exactly as today; the playhead does not move in either case.
+
+## PL14-007 — Right-click context menu on an item
+
+- Status: Not started
+- Area: `graph-item-content.tsx`, `graph-item-actions.tsx`
+- Screenshot: Not captured
+
+Right-clicking an item should open a context menu offering the same options the
+sidebar item-actions cluster offers when an item is selected.
+
+The actions already exist in one place (PL13-009 moved Details into that
+cluster); this should present the same set rather than growing a second
+definition of what an item's actions are — one source, two surfaces.
+
+Open: whether right-clicking an UNSELECTED item selects it first (the common
+convention) or acts on it without changing selection, and what the menu does
+when the right-clicked item is part of a multi-selection.
+
+Done when: right-click opens a menu with the item-actions options, driven from
+the same definition as the sidebar cluster, dismissible by Escape and outside
+click, and reachable by keyboard (context-menu key / Shift+F10).
+
+## PL14-008 — An untouched, empty collection is discarded, not trashed
+
+- Status: Not started
+- Area: the delete path shared by the sidebar action, the trash drop target and
+  the Delete key; `graph-collection-details.tsx` for the "untouched" test
+- Screenshot: Not captured
+
+Deleting a collection that has never been changed — title never edited, holds no
+items, an empty shell — removes it outright instead of moving it to the trash.
+Undo still restores it.
+
+**Delete = move-to-trash is the settled rule everywhere else**, so this is a
+deliberate exception and it needs a reason that holds: the trash exists to
+recover work, and an untouched empty collection is not work. Filling the drawer
+with shells the user made by mis-clicking the Collection tool makes the trash
+worse at the one job it has.
+
+The load-bearing part is the definition of "untouched", and it should be
+conservative — when in doubt, trash it. Both conditions together:
+
+- no children, and
+- the title is still the one it was minted with (the user never renamed it).
+
+Anything else — a rename, a child added and later removed, arriving via undo of
+a previous delete — is a collection the user did something to, and it goes to
+the trash like everything else. A shell that once held content is NOT untouched.
+
+Undo is unaffected: the delete still commits as a normal reversible patch, so
+Ctrl+Z brings the collection back. Only the trash entry is skipped.
+
+Done when: deleting a never-renamed, empty collection removes it with no trash
+entry; undo restores it; a renamed-but-empty collection and an emptied-out
+collection both still go to the trash; and all three paths (sidebar action,
+trash drop target, Delete key) agree, because they should share one predicate
+rather than three.
+
+Open: whether the drop-on-trash gesture should also skip — dragging a shell
+ONTO the trash is an explicit request to trash it, which is a reasonable case
+for honouring it rather than second-guessing the user.
+
+## PL14-009 — Breadcrumbs tint while an item is dragged
+
+- Status: Not started
+- Area: `graph-breadcrumb-drop.tsx`, `graph-board.tsx`
+- Screenshot: Not captured
+
+While an item is being dragged, the breadcrumb entries should take an ever so
+slight background colour change — enough to suggest the breadcrumb area is now
+a drop target for the dragged element.
+
+The breadcrumb is already droppable; this is the missing affordance, not new
+behaviour. Deliberately subtle: the owner asked for a hint that something is
+possible there, not a highlight competing with the drop indicator.
+
+Done when: the tint appears for the duration of a drag and clears on drop or
+cancel, and it is distinguishable from (and weaker than) the active
+drop-target treatment a crumb takes when the pointer is actually over it.
+
+## PL14-010 — The modal's name field opens on a single click
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: `graph-item-details-modal.tsx`, `graph-collection-details.tsx`,
+  `tests/e2e/graph-view.spec.ts` — modelled on `graph-view-chrome.tsx:103-117`
+- Screenshot: Not captured
+
+Renaming an item from its details modal takes a double click. It should take a
+single click, the way the last breadcrumb crumb already works.
+
+The two sites today, both driving the same `useInlineRename` hook:
+
+- breadcrumb (current crumb) — `onClick={rename.begin}`, a `<button>` wearing
+  `cursor-text` and `hover:bg-zinc-800/70`, labelled `Rename {name}`, swapping
+  to `InlineNameEditor` on activation.
+- modal title — `onDoubleClick={rename.begin}`.
+
+So this is adopting the crumb's treatment wholesale, not inventing one: single
+click, the text cursor, and the hover tint, which together are what make it
+look editable in the first place. A double click with no hover affordance is
+undiscoverable — nothing on screen says the title is a field.
+
+**Why single click is available here and NOT on the cards.** Click already means
+something on a card: it selects. Rename has to be the double click there, and
+PL13-001 was rejected partly for trying to add a second affordance around that
+conflict. The crumb has no competing meaning — it is the CURRENT location, so
+clicking it navigates nowhere — and neither does a modal's title.
+
+**Correction made while building it.** This item originally said
+`graph-collection-details.tsx:128` would keep its double click, listing it with
+the card surfaces. That was wrong — it is a MODAL, the collection twin of the
+clip one: same `role="dialog"`, same scrim, same panel classes, same header
+row. It got the same treatment, and the reasoning above is why it had to. Found
+by opening a collection's modal to verify the change and seeing the old span
+still there.
+
+So: **both dialogs** open on a single click. The genuinely card-level sites —
+`graph-item-content.tsx` and `graph-sub-timelines.tsx` — keep their double
+click.
+
+Both titles are now `<button>` rather than `<span>`, which also puts rename in
+the dialog's tab order; F2 still works and is still the only route while focus
+sits elsewhere.
+
+Four e2e tests double-clicked these titles. They still passed afterwards — the
+second click races React's re-render — but that is passing by accident, so they
+now click once and locate by the new accessible name
+(`getByRole("button", {name: "Rename …"})`). That locator names an element the
+old markup did not have, so the tests cannot pass against it.
+
+Verified live in both dialogs: `<button>`, `aria-label="Rename …"`,
+`cursor: text`, hover class present, `tabIndex 0`; one click mounts the editor
+focused with the current value selected.
+
+## PL14-011 — The trailing slot should say how to add MEDIA, and offer a file picker
+
+- Status: Not started
+- Area: `graph-add-collection-slot.tsx`, `graph-native-drop.tsx` (expose a
+  programmatic entry to `dropFiles`)
+- Screenshot: Not captured
+
+The pseudo item at the end of a timeline currently offers one thing: "Add
+timeline", which mints a nested collection. It should also tell the user that
+media can be added by dragging files from the file system onto any point in the
+timeline, and offer a link that opens a file picker for people who would rather
+browse than drag.
+
+**This adds the app's first file-browse path.** There is no `type="file"` input
+anywhere in the app today — not in the graph view, not in the assets drawer
+(that drawer lists assets already uploaded). Every media item that has ever
+entered a timeline arrived by an OS drag-and-drop. So this is not a shortcut to
+an existing route; it is the second route.
+
+Which makes the strongest argument for it an accessibility one, not
+discoverability: **today a keyboard or switch user cannot add media at all.**
+Dragging from the OS file system is not something the app can offer a keyboard
+equivalent for — the gesture starts outside the page. A file input is the only
+way in, and browsers already give it a fully accessible picker.
+
+It must feed the EXISTING pipeline. `dropFiles` in `graph-native-drop.tsx` does
+classification, the one-decode-per-video probe, concurrent upload with per-file
+failure reporting, detail parking and a single atomic commit for the whole
+selection. A picker that re-implements any of that will drift from the drop
+path. The work is exposing a programmatic entry point that takes `File[]` plus
+an anchor and calls `dropFiles` — the hook currently surfaces only
+`commitDrop(event, anchor)`, which needs a `DragEvent`.
+
+Two constraints that will shape the markup:
+
+- **The slot is a `<button>` today.** A link or a second control cannot go
+  inside it — nested interactive elements are invalid and this codebase has
+  been bitten by exactly that before (round 6 had to use `contentEditable`
+  instead of an `<input>` because the card content renders inside a button).
+  The slot needs to become a container holding two controls, with "Add
+  timeline" staying a button of its own.
+- **Room is tight in the strip.** The slot is card height — 100px at MD — and
+  already carries an icon plus an 11px label. Grid cells are much larger. The
+  hint copy may need to be strip-abbreviated, or shown only at grid size, or
+  moved to a `title`/tooltip on the strip. Worth deciding from a screenshot at
+  both sizes rather than in the abstract.
+
+Proposed copy, offered as a starting point rather than settled — the owner
+asked me to word it:
+
+> **Add timeline**
+> or drop media files anywhere on the timeline — [browse…]
+
+Done when: the trailing slot names both ways to add content, the browse link
+opens a native file picker filtered to the supported image/video types,
+selected files land through `dropFiles` (same probe, upload, failure reporting
+and single undoable commit as a drop), the whole slot is reachable and operable
+by keyboard, and the strip and grid presentations were both reviewed on screen.


### PR DESCRIPTION
First three items off [Punch List 14](punch-list/PUNCH-LIST-14.md), which lands with them. The other eight stay `Not started`.

## PL14-002 — the drill chevron did not look pressable

Two causes, and the shared class already looked like it handled one.

- **No cursor.** `CARD_CONTROL_CLASS` never set one, and Tailwind v4's preflight stopped setting `cursor: pointer` on `<button>` — so it fell back to the UA arrow. Verified live before the change as `cursor: default`.
- **A hover too small to see.** `bg-zinc-950/80 → bg-zinc-900` is near-black onto near-black. Now `zinc-800`, a real step at the same neutral temperature.

Deliberately not amber or sky: amber is the selection colour (PL13-006), and tinting a hover with it would say "selected" about a thing you are only pointing at.

Fixed in the shared class, so it reaches every card control rather than the chevron alone — the point of PL13-005. Focus ring untouched.

## PL14-003 — selected badge moved 6px → 8px from the corner

**The control cluster moved with it.** The badge is top-LEFT precisely to mirror the cluster top-RIGHT, and they are top-aligned; nudging one alone puts them 2px out of line, which is what stops them reading as a pair. Both comments now record that they move together.

Otherwise unchanged: 20px against the cluster's 24px, `pointer-events-none`, `aria-hidden`.

## PL14-010 — a modal's name opens on a single click

Adopts the breadcrumb crumb's treatment whole: a real button with `cursor-text`, a hover tint, and a `Rename …` label. A double click with no hover feedback is undiscoverable — nothing on screen said the title was a field.

Single click is available here because neither the current crumb nor a modal title has a competing click meaning. On a **card**, click already selects, so rename stays the double click — `graph-item-content.tsx` and `graph-sub-timelines.tsx` are unchanged.

**A correction from building it.** The punch-list item scoped this to one file and listed `graph-collection-details.tsx` with the card surfaces. That was wrong: it is a modal, the collection twin of the clip one — same `role="dialog"`, scrim, panel classes and header row. Both dialogs get the change, and the reasoning above is why they had to. Found by opening a collection's modal to verify and seeing the old span still there.

Both titles are `<button>` now, which also puts rename in the dialog's tab order. F2 is unchanged.

### The e2e that had to change

Four tests double-clicked these titles. They **still passed** after the change — the second click races React's re-render — but that is passing by accident, so they now click once and locate by the new accessible name:

```
page.locator("[data-item-details]").getByRole("button", { name: "Rename alpha" }).click()
```

That locator names an element the old markup did not have (a `<span>` with no role or label), so these cannot pass against the previous implementation.

## Verification

| | |
|---|---|
| App vitest | 502 passed |
| Unit | 408 passed |
| Storybook | 164 passed |
| graph-view e2e | 96 passed |
| Typecheck | clean, both workspaces |
| Lint | 0 errors (5 pre-existing `<img>` warnings) |

Each item checked in the running app, not just the suites — computed `cursor: pointer` on the chevron; badge and cluster both at 8px and rendering at the same Y on a selected card; both dialogs showing `<button aria-label="Rename …">` with one click mounting the focused editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)