### PR TITLE
PL14-004/005: pin the modal's close morph, move board options to the rail

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useContext, useDeferredValue, useMemo } from "react";
+import { useContext, useDeferredValue, useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
 import { useSearchParams } from "next/navigation";
 import {
   Command,
@@ -24,7 +25,15 @@ import {
 import { flattenMediaOrder } from "@storyboard/timeline-domain";
 
 import { formatDuration } from "@/lib/format-duration";
-import { requestGraphToolInsert } from "@/lib/graph-view-events";
+import {
+  GRAPH_BOARD_MENU_SLOT_ID,
+  requestGraphToolInsert,
+} from "@/lib/graph-view-events";
+import {
+  SIDEBAR_GLYPH,
+  SIDEBAR_ICON_BASE,
+  SIDEBAR_ICON_IDLE,
+} from "@/components/timeline/sidebar-icon-styles";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/core/button";
 import {
@@ -105,18 +114,20 @@ function BoardMenu({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button
+        {/* Wears the icon RAIL's tile treatment, not the header's ghost
+            button: it sits with the trash and account tiles now (PL14-005) and
+            has to read as one of them. `side="right"` for the same reason —
+            a menu aligned to the end of a 72px rail would open off-screen. */}
+        <button
           type="button"
-          variant="ghost"
-          size="icon"
           aria-label="Board options"
           title="Board options"
-          className="h-8 w-8 text-zinc-500 hover:text-zinc-200"
+          className={[SIDEBAR_ICON_BASE, SIDEBAR_ICON_IDLE].join(" ")}
         >
-          <Settings aria-hidden="true" className="h-4 w-4" />
-        </Button>
+          <Settings aria-hidden="true" className={SIDEBAR_GLYPH} />
+        </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-60 p-2">
+      <DropdownMenuContent side="right" align="end" className="w-60 p-2">
         <DropdownMenuGroup>
           <DropdownMenuLabel className="px-0.5 pb-2 pt-0.5">Thumbnail size</DropdownMenuLabel>
           {/* BADGES in a wrapping row, not a stack of rows: five sizes as
@@ -169,6 +180,42 @@ function BoardMenu({
       </DropdownMenuContent>
     </DropdownMenu>
   );
+}
+
+/**
+ * Mounts `BoardMenu` into the icon sidebar's slot (PL14-005).
+ *
+ * The node is looked up ONCE, in a lazy initializer, and that is safe here for
+ * a specific reason: the whole graph tree mounts `ssr: false` (see
+ * client-graph-view), so the app layout — rail included — is already committed
+ * to the DOM before this component first renders. There is no frame in which
+ * the slot is missing and we would need to retry.
+ *
+ * Which is why it is not an effect. Resolving it with `setState` inside one
+ * re-renders the board on every mount to change nothing, and the repo's lint
+ * rejects synchronous set-state in an effect for exactly that reason. If the
+ * graph ever mounts with SSR, this has to become a subscription — not an
+ * effect that sets state.
+ *
+ * Rendering it from HERE, inside the board, is the whole point: the menu keeps
+ * the real `itemSize`/`pixelsPerSecond` props and stays inside the graph's
+ * providers. Only its DOM address is in the sidebar. `graph-view.spec.ts`
+ * asserts it actually lands there, because a null slot would fail silently.
+ */
+function BoardMenuSlot(props: Readonly<{
+  surface: FocusSurface;
+  itemSize: ItemSize;
+  onItemSizeChange: (size: ItemSize) => void;
+  pixelsPerSecond: number;
+  onPixelsPerSecondChange: (pixelsPerSecond: number) => void;
+}>) {
+  const [slot] = useState<HTMLElement | null>(() =>
+    typeof document === "undefined"
+      ? null
+      : document.getElementById(GRAPH_BOARD_MENU_SLOT_ID),
+  );
+  if (!slot) return null;
+  return createPortal(<BoardMenu {...props} />, slot);
 }
 
 /**
@@ -698,7 +745,11 @@ export function GraphBoard({
               />
               <div aria-hidden="true" className="h-5 w-px shrink-0 bg-zinc-700" />
               <GraphUndoRedo />
-              <BoardMenu
+              {/* Board options are no longer here — they render in the icon
+                  sidebar below the trash (PL14-005). Still mounted from this
+                  component so they keep these props; only the DOM address
+                  changed. */}
+              <BoardMenuSlot
                 surface={surface}
                 itemSize={itemSize}
                 onItemSizeChange={onItemSizeChange}

--- a/apps/timeline-gstudio001/components/timeline/sidebar-icon-styles.ts
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-icon-styles.ts
@@ -1,0 +1,25 @@
+// The icon rail's tile styling, shared.
+//
+// Split out of timeline-sidebar.tsx when board options moved into the rail
+// (PL14-005): that menu is rendered by the GRAPH and portalled in, so its
+// trigger has to wear the rail's treatment without the graph importing the
+// whole sidebar module. Style constants are the only thing it needs, and they
+// are the only thing here.
+
+/** A rail tile: the square hit area plus the pill drawn behind the glyph. */
+export const SIDEBAR_ICON_BASE = [
+  "group/sidebar-item relative flex w-full aspect-square items-center justify-center",
+  "transition-all duration-200 focus-visible:outline-none",
+  "before:absolute before:inset-2 before:rounded-2xl before:transition-colors before:content-['']",
+  "focus-visible:before:ring-2 focus-visible:before:ring-zinc-400",
+].join(" ");
+
+/** The glyph inside a tile. Larger than the old h-4: legibility is the point
+ *  of the bigger tiles, and a 16px icon in a 72px square reads as a dot.
+ *
+ *  `relative` is load-bearing: the pill above is an absolutely-positioned
+ *  pseudo-element, so a statically-positioned glyph would paint UNDER it. */
+export const SIDEBAR_GLYPH = "relative h-7 w-7 [stroke-width:1.5] transition-colors";
+
+export const SIDEBAR_ICON_IDLE =
+  "text-zinc-400 before:bg-zinc-900/40 hover:text-zinc-100 hover:before:bg-zinc-800/80";

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -27,6 +27,7 @@ import { useAuth } from "@/components/auth/auth-provider";
 import {
   GRAPH_SELECTION_EVENT,
   GRAPH_TRASH_ARRIVAL_EVENT,
+  GRAPH_BOARD_MENU_SLOT_ID,
   GRAPH_TRASH_HOVER_EVENT,
   GRAPH_VIEW_STATE_EVENT,
   isGraphViewRoute,
@@ -39,6 +40,11 @@ import {
   type GraphSurface,
   type GraphViewStateDetail,
 } from "@/lib/graph-view-events";
+import {
+  SIDEBAR_GLYPH,
+  SIDEBAR_ICON_BASE,
+  SIDEBAR_ICON_IDLE,
+} from "./sidebar-icon-styles";
 import { graphClipboard } from "@/lib/graph-clipboard";
 import { toast } from "@/components/core/sonner";
 import { cn } from "@/lib/utils";
@@ -113,20 +119,9 @@ function MediaFolderIcon({ className }: Readonly<{ className?: string }>) {
  * square inset ring around a pill highlight would have described a shape that
  * is no longer there.
  */
-const SIDEBAR_ICON_BASE = [
-  "group/sidebar-item relative flex w-full aspect-square items-center justify-center",
-  "transition-all duration-200 focus-visible:outline-none",
-  "before:absolute before:inset-2 before:rounded-2xl before:transition-colors before:content-['']",
-  "focus-visible:before:ring-2 focus-visible:before:ring-zinc-400",
-].join(" ");
-/** The glyph inside a tile. Larger than the old h-4: legibility is the point
- *  of the bigger tiles, and a 16px icon in a 72px square reads as a dot.
- *
- *  `relative` is load-bearing: the pill above is an absolutely-positioned
- *  pseudo-element, so a statically-positioned glyph would paint UNDER it. */
-const SIDEBAR_GLYPH = "relative h-7 w-7 [stroke-width:1.5] transition-colors";
-const SIDEBAR_ICON_IDLE =
-  "text-zinc-400 before:bg-zinc-900/40 hover:text-zinc-100 hover:before:bg-zinc-800/80";
+// SIDEBAR_ICON_BASE / SIDEBAR_GLYPH / SIDEBAR_ICON_IDLE now live in
+// ./sidebar-icon-styles, so the graph's portalled board-options trigger can
+// wear the rail's treatment without importing this module (PL14-005).
 /**
  * The active tile: an INDICATOR BAR at the rail's edge, over a quietly lifted
  * pill.
@@ -860,6 +855,22 @@ export function TimelineSidebar() {
             </button>
           );
         })}
+
+        {/* Board options land HERE, below the trash (PL14-005), but the graph
+            renders them itself — this is only the address.
+
+            A slot rather than a control the sidebar owns, because the menu is
+            a radio group over thumbnail size plus a zoom slider: state that
+            lives in the graph's own tree. Publishing it through the window-event
+            bridge would mean mirroring two values and adding two commands, and
+            that bridge is explicitly for controls the SIDEBAR renders. A portal
+            keeps the menu inside the graph provider (real props, real Radix
+            context) while placing its trigger in the rail.
+
+            It also self-scopes: nothing portals in when the graph is not
+            mounted, so no route guard is needed and the empty div collapses to
+            nothing. */}
+        <div id={GRAPH_BOARD_MENU_SLOT_ID} className="contents" />
 
         <button
           ref={buttonRef}

--- a/apps/timeline-gstudio001/lib/graph-view-events.ts
+++ b/apps/timeline-gstudio001/lib/graph-view-events.ts
@@ -88,6 +88,22 @@ export function requestGraphPreviewToggle(): void {
   window.dispatchEvent(new Event(GRAPH_PREVIEW_TOGGLE_EVENT));
 }
 
+/**
+ * Where the sidebar lets the graph mount its board-options menu (PL14-005).
+ *
+ * The one seam here that is NOT an event, and deliberately so. Everything
+ * above is state the SIDEBAR renders — a toggle it can draw from a boolean.
+ * The board menu is a radio group plus a zoom slider whose values live in the
+ * graph's own tree, so mirroring them across would mean publishing two more
+ * fields and adding two commands to move them. Instead the sidebar publishes
+ * an ADDRESS and the graph portals the real component into it, keeping its
+ * props and its Radix context where they already work.
+ *
+ * The graph rendering it also scopes it for free: nothing portals in when the
+ * graph is not mounted, so the slot needs no route guard.
+ */
+export const GRAPH_BOARD_MENU_SLOT_ID = "graph-board-menu-slot";
+
 /** Graph → sidebar: the current view state, for control highlighting. */
 export function broadcastGraphViewState(detail: GraphViewStateDetail): void {
   window.dispatchEvent(

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -865,13 +865,51 @@ test.describe("graph view E2E", () => {
     ).toBeVisible();
   });
 
+  test("board options live in the icon rail, below the trash", async ({ page }) => {
+    // PL14-005. The menu is rendered by the BOARD and portalled into a slot the
+    // rail publishes, so it keeps its real props while its trigger sits with
+    // the rail's other tiles. A null slot would fail silently — no menu, no
+    // error — which is what these assertions exist to catch.
+    await installGraphApi(page);
+    await openGraph(page);
+
+    const trigger = page.getByRole("button", { name: "Board options" });
+    await expect(trigger).toHaveCount(1);
+
+    // In the rail's slot, and no longer in the board header.
+    expect(
+      await trigger.evaluate((el) => !!el.closest("#graph-board-menu-slot")),
+    ).toBe(true);
+    await expect(
+      page.locator("header").getByRole("button", { name: "Board options" }),
+    ).toHaveCount(0);
+
+    // Below the trash tile and above the account one — the position asked for.
+    const top = async (name: string) =>
+      (await page.getByRole("button", { name }).boundingBox())!.y;
+    expect(await top("Board options")).toBeGreaterThan(await top("Trash"));
+    expect(await top("Board options")).toBeLessThan(await top("Account"));
+
+    // And it still opens, with its contents intact. `side="right"` matters
+    // here: an end-aligned menu on a 72px rail would open off-screen.
+    await trigger.click();
+    const menu = page.getByRole("menu");
+    await expect(menu).toBeVisible();
+    await expect(menu).toContainText("Thumbnail size");
+    const box = (await menu.boundingBox())!;
+    expect(box.x).toBeGreaterThan(0);
+    expect(box.x + box.width).toBeLessThanOrEqual(page.viewportSize()!.width);
+  });
+
   test("focused strip and grid surfaces have no outer shell padding", async ({ page }) => {
     await installGraphApi(page);
     await openGraph(page);
 
+    // The gear now lives in the icon rail (PL14-005); it is still the settings
+    // glyph and still the only one.
     await expect(page.getByRole("button", { name: "Board options" }).locator("svg"))
       .toHaveClass(/lucide-settings/);
-    await expect(page.locator("aside").getByRole("button", { name: "Settings" })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Settings" })).toHaveCount(0);
 
     const boxStyles = (selector: string) =>
       page.locator(selector).evaluate((element) => {
@@ -3821,6 +3859,93 @@ test.describe("graph view E2E", () => {
     await openItemDetails(page, "alpha");
     await expect(page.getByRole("dialog")).toHaveCount(1);
     expect(await heroCount()).toBe(1);
+  });
+
+  test("closing the modal morphs back to the card, it does not just vanish", async ({ page }) => {
+    // PL14-004. Opening grows the card into the modal; closing has to run the
+    // same morph in reverse or the modal just disappears, which reads as a
+    // different interaction from the one that opened it.
+    //
+    // Asserted THROUGH the API rather than by watching pixels: a transition
+    // that starts and is then skipped looks identical to one that never ran,
+    // and `getAnimations()` cannot tell them apart either — the animations only
+    // exist after the browser captures a frame. `ready` resolving is the signal
+    // that the morph is actually going to play.
+    await installGraphApi(page);
+    await openGraph(page);
+
+    // View transitions are SKIPPED outright in a hidden document, so a run
+    // where this is not "visible" proves nothing in either direction.
+    expect(await page.evaluate(() => document.visibilityState)).toBe("visible");
+
+    await openItemDetails(page, "alpha");
+    await settleViewTransition(page);
+
+    await page.evaluate(() => {
+      const probe: {
+        calls: number;
+        skipped: boolean | null;
+        heroHolderAtReady: string | null;
+      } = { calls: 0, skipped: null, heroHolderAtReady: null };
+      (window as unknown as { __closeProbe: typeof probe }).__closeProbe = probe;
+      const doc = document as Document & {
+        startViewTransition: (cb: () => void) => { ready: Promise<void> };
+      };
+      const original = doc.startViewTransition.bind(doc);
+      doc.startViewTransition = (callback: () => void) => {
+        probe.calls += 1;
+        const transition = original(callback);
+        transition.ready.then(
+          () => {
+            probe.skipped = false;
+            // By `ready` the callback has run, so whoever holds the name now
+            // is what the modal is morphing INTO.
+            const holder = [...document.querySelectorAll<HTMLElement>("*")].find(
+              (el) => el.style?.viewTransitionName === "trim-subject",
+            );
+            probe.heroHolderAtReady =
+              holder?.closest("[data-node-id]")?.getAttribute("data-node-id") ?? null;
+          },
+          () => {
+            probe.skipped = true;
+          },
+        );
+        return transition;
+      };
+    });
+
+    await page.keyboard.press("Escape");
+    await expect(page.locator("[data-item-details]")).toHaveCount(0);
+
+    type CloseProbe = Readonly<{
+      calls: number;
+      skipped: boolean | null;
+      heroHolderAtReady: string | null;
+    }>;
+    const probe = await page
+      .waitForFunction((): CloseProbe | null => {
+        const p = (window as unknown as { __closeProbe: CloseProbe }).__closeProbe;
+        return p.calls > 0 && p.skipped !== null ? p : null;
+      })
+      .then((handle) => handle.jsonValue() as Promise<CloseProbe>);
+
+    // A transition ran, it PLAYED rather than being skipped, and the thing it
+    // played into was alpha's card — the spot the modal came from.
+    expect(probe.calls).toBe(1);
+    expect(probe.skipped).toBe(false);
+    expect(probe.heroHolderAtReady).toBe("alpha");
+
+    // And nothing is left holding it, so the next open still morphs.
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            [...document.querySelectorAll<HTMLElement>("*")].filter(
+              (el) => el.style?.viewTransitionName === "trim-subject",
+            ).length,
+        ),
+      )
+      .toBe(0);
   });
 
   test("item details open from the GRID too, and for a still", async ({ page }) => {

--- a/punch-list/PUNCH-LIST-14.md
+++ b/punch-list/PUNCH-LIST-14.md
@@ -76,31 +76,91 @@ Verified live on a selected card: badge `top: 8px / left: 8px`, cluster
 
 ## PL14-004 — The modal needs a closing view transition
 
-- Status: Not started
-- Area: `graph-item-details-modal.tsx`
+- Status: Complete — ALREADY IMPLEMENTED; coverage was what was missing
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: `tests/e2e/graph-view.spec.ts` (no source change)
 - Screenshot: Not captured
 
-Opening the modal animates with a view transition. Closing does not — it just
-disappears. It should animate back to the card it came from.
+Reported as: opening animates, closing just disappears. **Closing already runs
+the same morph in reverse**, and has since PL10-008. Nothing needed fixing.
 
-Done when: closing runs a CSS view transition that returns the modal to its
-originating card's position, matching the open animation in reverse. Should
-respect `prefers-reduced-motion`.
+What is there: the close path calls `withViewTransition`, hands `trim-subject`
+back from the modal's frame to the card inside the callback, and the CSS is
+symmetric — `::view-transition-old(trim-subject)` and `-new(...)` both get
+260ms with the same easing. Proven by a new e2e that asserts a transition
+runs on close, `ready` RESOLVES (so it plays rather than being skipped), and
+the element it morphs into is the originating card. Reverting the close path
+to a plain state update makes that test time out, so it is not vacuous.
+
+**A measurement trap worth recording.** First attempt looked like proof of the
+bug: instrumenting `startViewTransition` in the Browser pane showed the
+transition aborting with `InvalidStateError` — on OPEN as well as close. It was
+the harness. That pane runs the page with `document.visibilityState ===
+"hidden"`, and view transitions are skipped outright in a hidden document. Any
+view-transition work here has to be verified under Playwright, where the page
+is really visible; the new test asserts `visibilityState === "visible"` first so
+a future run cannot quietly prove nothing.
+
+Still open, since the report came from somewhere: if the close ever DOES look
+like a plain disappearance, the likely cause is `cardElement()` returning null
+(nothing to morph into, so the whole page cross-fades instead). Worth a look if
+it recurs — with a note about which card and what had just happened.
 
 ## PL14-005 — Move the settings icon to the icon sidebar
 
-- Status: Not started
-- Area: `graph-board.tsx` (remove from breadcrumb row), the icon sidebar
-  component (add below the trash slot)
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: `graph-board.tsx`, `timeline-sidebar.tsx`,
+  `components/timeline/sidebar-icon-styles.ts` (new),
+  `lib/graph-view-events.ts`, `tests/e2e/graph-view.spec.ts`
 - Screenshot: Not captured
 
-The settings icon currently lives in the breadcrumb row. Move it to the icon
-sidebar, positioned below the trash folder icon at the bottom.
+The gear moved from the breadcrumb row to the icon rail, between the trash tile
+and the account one.
 
-Watch the trash drop slot: the sidebar's trash target is a portaled droppable
-that fills its slot, and a previous round lost sidebar tool drags to a slot div
-that covered them (`pointer-events-none` was the fix, PL round 6 / PR #128).
-Anything placed adjacent to it needs the same check.
+**Not a relocation — the menu could not simply move.** It is a radio group over
+thumbnail size plus a zoom slider, and both values live in the graph's tree
+(`graph-timeline-view` owns them). The rail is app chrome in a different React
+tree, which is why every other rail control talks to the board through window
+events.
+
+Two ways to bridge it, and the codebase already argues for one. The event
+bridge would mean publishing `itemSize` and `pixelsPerSecond` in the broadcast
+state and adding two commands to move them — and that file says explicitly what
+the bridge is for: *"This bridge is for the SIDEBAR — app chrome in a different
+React tree — and nothing else should pay for it"*, with a precedent of NOT
+adding an event when the control can render inside the graph's own tree.
+
+So: the rail publishes an ADDRESS (`GRAPH_BOARD_MENU_SLOT_ID`) and the board
+portals the real `BoardMenu` into it. The menu keeps its props and its Radix
+context; only its DOM address changed. It also self-scopes — nothing portals in
+when the graph is not mounted, so the slot needs no route guard and collapses
+to nothing (`display: contents`) elsewhere.
+
+(An events-based version was written first and backed out. The bridge file's own
+comments are what settled it.)
+
+Details worth keeping:
+
+- **The trigger wears the rail's tile treatment**, so `SIDEBAR_ICON_BASE` /
+  `SIDEBAR_GLYPH` / `SIDEBAR_ICON_IDLE` moved to
+  `components/timeline/sidebar-icon-styles.ts` — the graph needs the styles,
+  not the sidebar module.
+- **`side="right"` on the menu.** End-aligned against a 72px rail it would have
+  opened off-screen; the e2e asserts the menu's box stays inside the viewport.
+- **The slot node is resolved in a lazy `useState` initializer, not an effect.**
+  The graph tree mounts `ssr: false`, so the rail is already committed before
+  the board first renders — there is no frame to retry. Doing it in an effect
+  also trips the repo's set-state-in-an-effect lint, which is the same
+  objection: a re-render that changes nothing. If the graph ever gains SSR this
+  has to become a subscription, and the comment says so.
+- A null slot fails SILENTLY (no menu, no error), so the e2e asserts the trigger
+  is inside the slot, is gone from the header, and sits between Trash and
+  Account.
+
+A stale assertion in the padding test — "no button named Settings in the aside",
+written when the gear was in the header — was inverted by this and now reads as
+"no button named Settings anywhere", which is still true and still meaningful.
 
 ## PL14-006 — Trim drag drives the real preview when it is open
 


### PR DESCRIPTION
## PL14-004 — needed no fix; it was already implemented

Reported as "opening animates, closing just disappears". **The close path has run the same morph in reverse since PL10-008.** It calls `withViewTransition`, hands `trim-subject` back from the modal frame to the card inside the callback, and the CSS is symmetric — `::view-transition-old(trim-subject)` and `-new(...)` both get 260ms with the same easing.

What was actually missing was coverage. The existing hero test only asserted the name returned to 0 after close, not that a transition *ran*. The new test asserts three things:

- a transition starts on close,
- its `ready` **resolves** — so it plays rather than being skipped, which is the distinction that matters and the one `getAnimations()` cannot make,
- the element it morphs into is the originating card.

Reverting the close path to a plain state update makes it time out, so it is not vacuous.

### A measurement trap worth knowing

The first investigation looked like proof of the bug. Instrumenting `startViewTransition` in the automated browser pane showed the transition aborting with `InvalidStateError` — **on open as well as close**. That was the harness: the pane runs the page with `document.visibilityState === "hidden"`, and view transitions are skipped outright in a hidden document.

Any view-transition work here has to be verified under Playwright, where the page is really visible. The new test asserts `visibilityState === "visible"` first, so a future run cannot quietly prove nothing.

## PL14-005 — board options move to the icon rail

The gear moves from the breadcrumb row to the rail, between the trash and account tiles.

**It could not simply move.** The menu is a radio group over thumbnail size plus a zoom slider, and both values are owned by the graph's tree (`graph-timeline-view`). The rail is app chrome in a different React tree.

The window-event bridge is how every other rail control talks to the board, so that was the obvious route — publish `itemSize`/`pixelsPerSecond` in the broadcast state, add two commands. I built that, then backed it out, because the bridge file argues against it in its own comments: *"This bridge is for the SIDEBAR — app chrome in a different React tree — and nothing else should pay for it"*, alongside a precedent of declining to add an event for a control that can render inside the graph's own tree.

So the rail publishes an **address** (`GRAPH_BOARD_MENU_SLOT_ID`) and the board portals the real `BoardMenu` into it. The menu keeps its props and its Radix context; only its DOM address changed. It also self-scopes — nothing portals in when the graph is unmounted, so the slot needs no route guard and collapses to nothing elsewhere.

Details that took a decision:

- **The trigger wears the rail's tile treatment**, so `SIDEBAR_ICON_BASE` / `SIDEBAR_GLYPH` / `SIDEBAR_ICON_IDLE` moved to `components/timeline/sidebar-icon-styles.ts`. The graph needs the styles, not the whole sidebar module.
- **`side="right"`.** End-aligned against a 72px rail, the menu opened off-screen. The e2e asserts its box stays inside the viewport.
- **The slot resolves in a lazy `useState` initializer, not an effect.** The graph tree mounts `ssr: false`, so the rail is already committed before the board first renders — there is no frame to retry. An effect here also trips the repo's set-state-in-an-effect lint, which is the same objection: a re-render that changes nothing. If the graph ever gains SSR this must become a subscription; the comment says so.
- **A null slot fails silently** — no menu, no error. So the e2e pins that the trigger is inside the slot, gone from the header, and sits between Trash and Account.

One stale assertion updated: the padding test asserted "no button named `Settings` in the aside", written when the gear was in the header. This inverted it, so it now reads "no button named `Settings` anywhere" — still true, still meaningful.

## Verification

| | |
|---|---|
| App vitest | 502 passed |
| Unit | 408 passed |
| Storybook | 164 passed |
| graph-view e2e | 98 passed (2 new) |
| Typecheck | clean, both workspaces |
| Lint | 0 errors (5 pre-existing `<img>` warnings) |

Checked in the running app: the gear renders inside the rail slot at 638 → 709 → 780 with the trash and account tiles, on the rail's 71px rhythm, and is absent from the header row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)