### PR TITLE
PL14-004: the modal was unmounting one render before the close transition

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -534,11 +534,30 @@ export function GraphItemDetailsModal() {
   // selected: the trigger lives on a card, and a card can be pressed without
   // being the selection. Any media item qualifies — a video gets the frame and
   // the source strip, a still gets its image and its duration (PL10-012).
+  // The id currently ON SCREEN, which is deliberately not the same thing as
+  // the id the context wants open — and that difference is the entire closing
+  // animation (PL14-004).
+  //
+  // This used to be a boolean `mounted`, with the node read from `openId`
+  // alone. Closing sets `openId` to null, so `node` went null on the very next
+  // render and the guard below unmounted the modal THERE — one render before
+  // the effect could start a transition. The transition then ran against a
+  // page the modal had already left: it started, it resolved, the card took
+  // the hero name, and every one of those was observable while the user saw a
+  // hard cut, because the "before" frame no longer had a modal in it.
+  //
+  // Keeping the id here means the modal survives the close render and is still
+  // on screen when the browser captures "before". The transition callback is
+  // what clears it, which is exactly when it should go.
+  const [mountedId, setMountedId] = useState<string | null>(null);
+  const mounted = mountedId !== null;
   const node = useCollectionsSelector((s) => {
-    if (openId === null) return null;
-    return s.graph.nodesById.get(parseNodeId(openId)) ?? null;
+    // `openId` while opening and open; `mountedId` while closing, when the
+    // context has already let go but the pixels are still here.
+    const id = openId ?? mountedId;
+    if (id === null) return null;
+    return s.graph.nodesById.get(parseNodeId(id)) ?? null;
   });
-  const [mounted, setMounted] = useState(false);
   const openIdRef = useRef<string | null>(null);
 
   // Opening and closing are driven by the context flag so the toolbar button,
@@ -557,14 +576,17 @@ export function GraphItemDetailsModal() {
         // Hand the name over: the card gives it up in the same frame the
         // modal takes it, so exactly one element ever carries it.
         card?.style.removeProperty("view-transition-name");
-        setMounted(true);
+        setMountedId(node.id as string);
       });
       return;
     }
 
     const card = openIdRef.current ? cardElement(openIdRef.current) : null;
     void withViewTransition(() => {
-      setMounted(false);
+      // Clearing this is what unmounts the modal, and it happens HERE — inside
+      // the callback, after the browser has captured the frame the modal is
+      // still in. That ordering is the animation.
+      setMountedId(null);
       card?.style.setProperty("view-transition-name", HERO);
     }).then(() => {
       card?.style.removeProperty("view-transition-name");

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -3886,7 +3886,8 @@ test.describe("graph view E2E", () => {
         calls: number;
         skipped: boolean | null;
         heroHolderAtReady: string | null;
-      } = { calls: 0, skipped: null, heroHolderAtReady: null };
+        modalPresentAtCapture: boolean | null;
+      } = { calls: 0, skipped: null, heroHolderAtReady: null, modalPresentAtCapture: null };
       (window as unknown as { __closeProbe: typeof probe }).__closeProbe = probe;
       const doc = document as Document & {
         startViewTransition: (cb: () => void) => { ready: Promise<void> };
@@ -3894,6 +3895,12 @@ test.describe("graph view E2E", () => {
       const original = doc.startViewTransition.bind(doc);
       doc.startViewTransition = (callback: () => void) => {
         probe.calls += 1;
+        // THE assertion. The browser captures the "before" frame when this is
+        // called, and the callback is what removes the modal — so the modal has
+        // to still be here right now. If it unmounted on an earlier render, a
+        // transition still runs and still resolves, but it has nothing to morph
+        // FROM and the close reads as a hard cut.
+        probe.modalPresentAtCapture = !!document.querySelector("[data-item-details]");
         const transition = original(callback);
         transition.ready.then(
           () => {
@@ -3921,6 +3928,7 @@ test.describe("graph view E2E", () => {
       calls: number;
       skipped: boolean | null;
       heroHolderAtReady: string | null;
+      modalPresentAtCapture: boolean | null;
     }>;
     const probe = await page
       .waitForFunction((): CloseProbe | null => {
@@ -3929,10 +3937,12 @@ test.describe("graph view E2E", () => {
       })
       .then((handle) => handle.jsonValue() as Promise<CloseProbe>);
 
-    // A transition ran, it PLAYED rather than being skipped, and the thing it
-    // played into was alpha's card — the spot the modal came from.
+    // A transition ran, it PLAYED rather than being skipped, the modal was
+    // still on screen to be captured, and the thing it played into was alpha's
+    // card — the spot the modal came from.
     expect(probe.calls).toBe(1);
     expect(probe.skipped).toBe(false);
+    expect(probe.modalPresentAtCapture).toBe(true);
     expect(probe.heroHolderAtReady).toBe("alpha");
 
     // And nothing is left holding it, so the next open still morphs.

--- a/punch-list/PUNCH-LIST-14.md
+++ b/punch-list/PUNCH-LIST-14.md
@@ -76,35 +76,51 @@ Verified live on a selected card: badge `top: 8px / left: 8px`, cluster
 
 ## PL14-004 — The modal needs a closing view transition
 
-- Status: Complete — ALREADY IMPLEMENTED; coverage was what was missing
+- Status: Complete — FIXED (an earlier pass wrongly closed this as already done)
 - URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
-- Area: `tests/e2e/graph-view.spec.ts` (no source change)
+- Area: `graph-item-details-modal.tsx`, `tests/e2e/graph-view.spec.ts`
 - Screenshot: Not captured
 
-Reported as: opening animates, closing just disappears. **Closing already runs
-the same morph in reverse**, and has since PL10-008. Nothing needed fixing.
+Closing was a hard cut back to the card. It now morphs, the reverse of the open.
 
-What is there: the close path calls `withViewTransition`, hands `trim-subject`
-back from the modal's frame to the card inside the callback, and the CSS is
-symmetric — `::view-transition-old(trim-subject)` and `-new(...)` both get
-260ms with the same easing. Proven by a new e2e that asserts a transition
-runs on close, `ready` RESOLVES (so it plays rather than being skipped), and
-the element it morphs into is the originating card. Reverting the close path
-to a plain state update makes that test time out, so it is not vacuous.
+**The modal was unmounting one render too early.** The node was read from
+`openId` alone and the render guard was `if (!mounted || node === null) return
+null`. Closing sets `openId` to null, so `node` went null on the very next
+render and the guard removed the modal THERE — before the effect could start a
+transition. The transition then ran against a page the modal had already left.
 
-**A measurement trap worth recording.** First attempt looked like proof of the
-bug: instrumenting `startViewTransition` in the Browser pane showed the
-transition aborting with `InvalidStateError` — on OPEN as well as close. It was
-the harness. That pane runs the page with `document.visibilityState ===
-"hidden"`, and view transitions are skipped outright in a hidden document. Any
-view-transition work here has to be verified under Playwright, where the page
-is really visible; the new test asserts `visibilityState === "visible"` first so
-a future run cannot quietly prove nothing.
+Which is why it was so easy to get wrong: the close mechanism was entirely
+present and entirely observable. `withViewTransition` ran, `ready` resolved
+rather than skipping, and the card took the hero name in the callback — all
+true, all while the user saw a hard cut, because the "before" frame had no
+modal in it.
 
-Still open, since the report came from somewhere: if the close ever DOES look
-like a plain disappearance, the likely cause is `cardElement()` returning null
-(nothing to morph into, so the whole page cross-fades instead). Worth a look if
-it recurs — with a note about which card and what had just happened.
+The fix is a state change, not a new animation: the boolean `mounted` became
+`mountedId`, and the node resolves from `openId ?? mountedId`. The modal now
+survives the close render and is still on screen when the browser captures
+"before"; the transition callback is what clears it, which is exactly when it
+should go.
+
+### Two ways this was misdiagnosed first, both worth keeping
+
+1. **The harness lied.** Instrumenting `startViewTransition` in the automated
+   browser pane showed the transition aborting with `InvalidStateError` — on
+   OPEN as well as close. That pane runs the page with `visibilityState ===
+   "hidden"`, and view transitions are skipped outright in a hidden document.
+   View-transition work has to be verified under Playwright; the test asserts
+   `visibilityState === "visible"` first so a future run cannot prove nothing.
+
+2. **The first test passed against the bug.** It asserted a transition ran, was
+   not skipped, and morphed toward the card — three true things that are all
+   compatible with the modal having already vanished. The assertion that
+   actually bites is `modalPresentAtCapture`: the modal must still be in the
+   DOM at the moment `startViewTransition` is called, because the callback is
+   what removes it. A test can be non-vacuous (this one failed when the
+   transition was removed) and still miss the defect, if it measures the
+   mechanism instead of the outcome.
+
+Reported by the owner after the first pass shipped, which is the only reason it
+was caught — worth remembering when a fix's evidence is all mechanism.
 
 ## PL14-005 — Move the settings icon to the icon sidebar
 


### PR DESCRIPTION
Closing the item modal was a hard cut back to the card. [PR #240](https://github.com/josulliv101/storyboard-flow/pull/240) closed this item as "already implemented" — that was wrong, and how it got there is the useful part.

## The bug

The node was read from `openId` alone, and the render guard was:

```
if (!mounted || node === null) return null;
```

Closing sets `openId` to null, so `node` goes null on the very next render and the guard removes the modal **there** — one render before the effect can start a transition. The transition then runs against a page the modal has already left.

## Why it looked finished

Every observable part of the mechanism was working:

- `withViewTransition` ran on close
- its `ready` **resolved** rather than skipping
- the card took the `trim-subject` hero name inside the callback

All three are true. All three are also true when the modal has already vanished — because the frame the browser captured as "before" had no modal in it.

## The fix

State, not animation. The boolean `mounted` becomes `mountedId`, and the node resolves from `openId ?? mountedId`. The modal survives the close render and is still on screen when the browser captures "before"; the transition callback is what clears it, which is exactly when it should go.

## The test that missed it

The test added in #240 asserted a transition ran, was not skipped, and morphed toward the card. It now also asserts:

```
probe.modalPresentAtCapture === true
```

The modal must be in the DOM at the moment `startViewTransition` is called, since the callback is what removes it. Confirmed failing before this change (`Received: false`) and passing after.

Worth stating plainly, because it is the lesson rather than the bug: **that test was not vacuous** — it failed when the close transition was removed entirely — and it still missed the defect, because it measured the mechanism instead of the outcome. Non-vacuous is a weaker guarantee than it feels like.

A related trap from the same investigation, now pinned in the test: the automated browser pane runs the page with `document.visibilityState === "hidden"`, and view transitions are **skipped outright in a hidden document**. Instrumenting there showed transitions aborting with `InvalidStateError` on open as well as close, which reads as damning evidence and is purely the harness. The test asserts visibility first so a future run cannot quietly prove nothing.

Caught only because the owner re-reported it after #240 shipped.

## Verification

| | |
|---|---|
| App vitest | 502 passed |
| Unit | 408 passed |
| Storybook | 164 passed |
| graph-view e2e | 98 passed |
| Typecheck | clean |
| Lint | 0 errors (5 pre-existing `<img>` warnings) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)