### PR TITLE
PL14-001/009: disable from the details modal, tint crumbs during a drag

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-collection-details.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-collection-details.tsx
@@ -15,6 +15,7 @@ import { collectionPreviewFrameUrl } from "@/lib/video-frame-url";
 
 import { useClipDetail, useTimelineTitle } from "./graph-details-context";
 import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
+import { ItemDisableToggle } from "./graph-item-disable-toggle";
 import {
   useCollectionPreviewFrames,
   useEnabledChildCount,
@@ -146,6 +147,7 @@ export function CollectionDetailsBody({
             <span className="font-mono text-[11px] tabular-nums text-zinc-400">
               {count} {count === 1 ? "item" : "items"} · {formatDuration(seconds)}
             </span>
+            <ItemDisableToggle nodeId={node.id as string} />
             <div className="flex items-center gap-1">
               <button
                 type="button"

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -24,6 +24,7 @@ import { useSeekedVideo } from "@/hooks/use-seeked-video";
 import { formatSeconds } from "@/lib/format-duration";
 import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
 import { CollectionDetailsBody } from "./graph-collection-details";
+import { ItemDisableToggle } from "./graph-item-disable-toggle";
 import { useItemDetails } from "./graph-item-details-context";
 
 // The trim MODAL (PL10-008, an experiment replacing the docked map).
@@ -402,6 +403,7 @@ function ModalBody({ node, onClose }: Readonly<{ node: MediaNode; onClose: () =>
             <span className="font-mono text-[11px] tabular-nums text-zinc-400">
               {video ? `${formatSeconds(showing)} of ${formatSeconds(fullDuration)}` : formatSeconds(showing)}
             </span>
+            <ItemDisableToggle nodeId={node.id as string} />
             {/* Scoped to this clip's own trims — see useScopedHistory. Each
                 release is one commit, so these step through the adjustments
                 one at a time. */}

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-disable-toggle.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-disable-toggle.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Ban, CircleCheck } from "lucide-react";
+
+import {
+  parseNodeId,
+  useCollectionsSelector,
+  useCollectionsStore,
+} from "@storyboard/ui/dnd-collections";
+
+/**
+ * Disable/enable the one item a details modal is showing (PL14-001).
+ *
+ * An ACTION whose label flips, not a switch — the same shape the rail's item
+ * actions already use (`Ban` + "Disable" / `CircleCheck` + "Enable"). Two
+ * controls for one concept should look like one concept, and the rail got
+ * there first.
+ *
+ * Dispatched as `set-node-disabled` over a single-node list, which is exactly
+ * what the modal's scoped history already recognises (`useScopedHistory`
+ * accepts that command when it names one node, and that node is this one) — so
+ * the modal's own undo covers this without any further wiring.
+ *
+ * No toast. The rail toasts because its selection can be forty items and the
+ * board may not show what changed; here the button's own label flips and the
+ * item is on screen, so a toast would narrate something the user is looking
+ * at.
+ *
+ * Shared by both dialogs — the clip modal and the collection one. Disabling a
+ * collection means the same thing it means anywhere: the item keeps its slot
+ * and its span, and playback skips it (see playback-skip.ts).
+ */
+export function ItemDisableToggle({ nodeId }: Readonly<{ nodeId: string }>) {
+  const store = useCollectionsStore();
+  const disabled = useCollectionsSelector(
+    (snapshot) => snapshot.graph.nodesById.get(parseNodeId(nodeId))?.disabled === true,
+  );
+  const Icon = disabled ? CircleCheck : Ban;
+  const label = disabled ? "Enable" : "Disable";
+
+  return (
+    <button
+      type="button"
+      data-item-details-disable
+      aria-pressed={disabled}
+      onClick={() => {
+        store.dispatch({
+          type: "set-node-disabled",
+          nodeIds: [parseNodeId(nodeId)],
+          disabled: !disabled,
+        });
+      }}
+      aria-label={`${label} this item`}
+      title={
+        disabled
+          ? "Enable — play this item again"
+          : "Disable — keep the slot, skip it on playback"
+      }
+      className={[
+        "flex cursor-pointer items-center gap-1.5 rounded px-1.5 py-1",
+        "text-[11px] font-medium transition-colors",
+        disabled
+          ? "text-amber-300 hover:bg-zinc-800 hover:text-amber-200"
+          : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100",
+      ].join(" ")}
+    >
+      <Icon aria-hidden="true" className="h-3.5 w-3.5" />
+      {label}
+    </button>
+  );
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
@@ -123,11 +123,20 @@ function EditableCrumbName({
  * The trail already IS the ancestor chain (root … parent), so dropping a card
  * on any ancestor crumb moves it to THAT collection — up one level, or several,
  * all the way to the root, in a single motion. Idle it is a plain nav link;
- * during a drag every ancestor crumb reads as droppable (a dotted underline),
- * and the crumb under the pointer shows where the item will land (a solid sky
- * underline). Text-decoration only, so the crumb's width never changes and
- * nothing shifts as the states toggle. The focused (current) crumb is NOT one
- * of these — the item already lives there.
+ * during a drag every ancestor crumb reads as droppable (a dotted underline
+ * over a faint fill), and the crumb under the pointer shows where the item will
+ * land (a solid sky underline over a sky tint). The focused (current) crumb is
+ * NOT one of these — the item already lives there.
+ *
+ * The fill was added in PL14-005's round (PL14-009): an underline alone is a
+ * mark ON the text, and at a glance the trail still read as text rather than as
+ * somewhere a card could go. A background says "region", which is what a drop
+ * target is. Kept deliberately faint — it is a hint that something is possible
+ * here, not a competitor to the hovered state or to the drop indicator.
+ *
+ * Still no geometry: decoration and background are both layout-neutral, so the
+ * crumb's width never changes and nothing shifts as the states toggle. That
+ * constraint is why this is a fill and not a border or a ring.
  */
 function AncestorCrumb({
   crumbId,
@@ -158,9 +167,9 @@ function AncestorCrumb({
           "block min-w-0 max-w-[180px] truncate rounded-md px-1.5 py-1 transition-colors",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70",
           state === "hovered"
-            ? "text-sky-200 underline decoration-sky-400 decoration-2 underline-offset-4"
+            ? "bg-sky-500/15 text-sky-200 underline decoration-sky-400 decoration-2 underline-offset-4"
             : state === "droppable"
-              ? "text-zinc-300 underline decoration-dotted decoration-zinc-500 underline-offset-4"
+              ? "bg-zinc-800/50 text-zinc-300 underline decoration-dotted decoration-zinc-500 underline-offset-4"
               : "text-zinc-400 hover:bg-zinc-800/60 hover:text-zinc-100",
         )}
       >

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -865,6 +865,36 @@ test.describe("graph view E2E", () => {
     ).toBeVisible();
   });
 
+  test("the details modal can disable and re-enable its item", async ({ page }) => {
+    // PL14-001. An ACTION whose label flips, matching the rail's item-actions
+    // toggle — not a switch, because two controls for one concept should look
+    // like one concept.
+    await installGraphApi(page);
+    await openGraph(page);
+    await openItemDetails(page, "alpha");
+    await settleViewTransition(page);
+
+    const toggle = page.locator("[data-item-details-disable]");
+    await expect(toggle).toHaveText("Disable");
+    await expect(toggle).toHaveAttribute("aria-pressed", "false");
+
+    await toggle.click();
+    await expect(toggle).toHaveText("Enable");
+    await expect(toggle).toHaveAttribute("aria-pressed", "true");
+    // The card behind the modal agrees — this is one graph, not a modal-local
+    // flag. `data-disabled` rides the CONTENT span inside the dnd button, not
+    // the button itself (same locator the disabled-clip test uses).
+    const alphaCard = page.locator('[data-node-id="alpha"]');
+    await expect(alphaCard.locator('[data-disabled="true"]')).toBeVisible();
+
+    // The modal's SCOPED undo covers it: `useScopedHistory` already accepted
+    // `set-node-disabled` naming a single node, so this needed no new wiring —
+    // which is the reason the command is dispatched that way.
+    await page.locator("[data-item-details-undo]").click();
+    await expect(toggle).toHaveText("Disable");
+    await expect(alphaCard.locator('[data-disabled="true"]')).toHaveCount(0);
+  });
+
   test("board options live in the icon rail, below the trash", async ({ page }) => {
     // PL14-005. The menu is rendered by the BOARD and portalled into a slot the
     // rail publishes, so it keeps its real props while its trigger sits with
@@ -1542,12 +1572,27 @@ test.describe("graph view E2E", () => {
       await expect(fade).toHaveAttribute("data-faded", "true");
     }
 
+    // PL14-009: while a drag is live, an ancestor crumb takes a faint FILL as
+    // well as its dotted underline — the pointer is still on the card here, so
+    // this is the "droppable, not hovered" state. A background is what makes
+    // the crumb read as a region you can drop into; an underline alone is a
+    // mark on text. Layout-neutral by design (see AncestorCrumb).
+    await expect
+      .poll(async () => (await parentCrumb.getAttribute("class")) ?? "")
+      .toContain("bg-zinc-800/50");
+    expect(
+      await parentCrumb.evaluate((el) => getComputedStyle(el).backgroundColor),
+    ).not.toBe("rgba(0, 0, 0, 0)");
+
     // Over MOVE-TO-PARENT → the parent crumb lights up; trash icon still calm.
     const pz = (await parentZone.boundingBox())!;
     await page.mouse.move(pz.x + pz.width / 2, pz.y + pz.height / 2, { steps: 12 });
     await expect
       .poll(async () => (await parentCrumb.getAttribute("class")) ?? "")
       .toContain("decoration-sky-400");
+    // …and the fill steps up to the sky tint, so hovered still outranks merely
+    // droppable (PL14-009).
+    await expect(parentCrumb).toHaveClass(/bg-sky-500\/15/);
     await expect(trashIcon).not.toHaveClass(/animate-trash-hover-attention/);
 
     // The ghost covers the crumb, so the trash slot borrows its pixels to name

--- a/punch-list/PUNCH-LIST-14.md
+++ b/punch-list/PUNCH-LIST-14.md
@@ -6,26 +6,40 @@ names, not from investigation.
 
 ## PL14-001 — Enable/disable an item from the details modal
 
-- Status: Not started
+- Status: Complete
 - URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
-- Area: `graph-item-details-modal.tsx`, `graph-item-actions.tsx`
+- Area: `graph-item-disable-toggle.tsx` (new), `graph-item-details-modal.tsx`,
+  `graph-collection-details.tsx`, `tests/e2e/graph-view.spec.ts`
 - Screenshot: Not captured
 
-When a media item or a collection item is shown in the modal, the modal should
-let the user disable or enable it.
+Both dialogs now carry a disable/enable control in the header, beside the
+readout.
 
-The disable feature already exists as a play-time skip — a disabled item keeps
-its slot and its span, and the player jumps it (see the `set-node-disabled`
-command and `playback-skip.ts`). This item is only about surfacing that control
-in the modal; it is not a change to what disabling means.
+**An ACTION whose label flips, not a switch** — the open question, settled by
+precedent rather than taste: the rail's item actions already do exactly this
+(`Ban` + "Disable" / `CircleCheck` + "Enable", flipping on `allDisabled`). Two
+controls for one concept should look like one concept, and the rail got there
+first. Same icons, same words.
 
-Open: whether the control reads as a toggle (switch) or as an action that flips
-label between Disable and Enable. The item-actions cluster is the precedent to
-match.
+Nothing about what disabling MEANS changed: `set-node-disabled`, the item keeps
+its slot and its span, playback skips it (`playback-skip.ts`).
 
-Done when: the modal shows the current enabled/disabled state for both card
-kinds, flipping it dispatches through the same command path as the existing
-action (so undo covers it), and the card reflects the change on close.
+Two things fell out of dispatching it the same way the rail does:
+
+- **The modal's scoped undo already covered it.** `useScopedHistory` was
+  written to accept `set-node-disabled` when it names exactly one node — this
+  item's node — so the modal's own undo button steps through a disable with no
+  further wiring. That acceptance clause predates this item; it was waiting.
+- **No toast.** The rail toasts because its selection can be forty items and
+  the board may not show what moved. Here the button's own label flips and the
+  item is on screen, so a toast would narrate what the user is looking at.
+
+Shared by both dialogs, for the reason PL14-010 learned the hard way: the
+collection details view is a modal too, not a card surface.
+
+Verified live and by e2e: label and `aria-pressed` flip, the card behind the
+modal picks up `data-disabled` (it rides the content span, not the dnd button),
+and the modal's scoped undo reverts it.
 
 ## PL14-002 — Drill-down chevron needs a hover state and the right cursor
 
@@ -227,10 +241,37 @@ click, and reachable by keyboard (context-menu key / Shift+F10).
 
 ## PL14-008 — An untouched, empty collection is discarded, not trashed
 
-- Status: Not started
-- Area: the delete path shared by the sidebar action, the trash drop target and
-  the Delete key; `graph-collection-details.tsx` for the "untouched" test
+- Status: Not started — BLOCKED on a decision, see "What building it found"
+- Area: `packages/collections-core/commands.ts` (a new command), the delete
+  path shared by the sidebar action, the trash drop target and the Delete key
 - Screenshot: Not captured
+
+> **What building it found (2026-07-30).** This is bigger than the entry below
+> implies, and it was picked up as a small item.
+>
+> **The engine has no removal command.** `CollectionsCommand` is exactly five
+> cases — `move-nodes`, `add-nodes`, `update-media`, `rename-node`,
+> `set-node-disabled`. Deleting IS moving to the trash root; nothing anywhere
+> can take a node OUT of the graph. So "skip the trash, just remove it" cannot
+> be a branch in the delete path — the thing it would branch to does not exist.
+>
+> The patch half is already there (`nodes-removed` applies, verifies, and
+> inverts to `nodes-added`, so undo would round-trip), which makes a
+> `remove-nodes` command tractable — but it is a change to `collections-core`,
+> the package every surface depends on, for one narrow case.
+>
+> **And it raises a question the entry never asked: what happens to the
+> collection's DOCUMENT?** A collection is a node plus its own timeline
+> document. Trashing re-parents the node and keeps the document. Removing the
+> node outright either orphans that document in Firebase or deletes it — and
+> "undo still restores it", which you asked for, means the document has to
+> survive or be recreated. That is a data-deletion decision, not a UI one.
+>
+> Worth deciding before any code: is the goal *"the trash drawer should not
+> fill with shells"*? If so there is a cheaper answer that needs no engine
+> change — trash them as normal and have the DRAWER not list untouched empty
+> collections, or sweep them. Same outcome for the user, no new primitive, no
+> orphaned documents.
 
 Deleting a collection that has never been changed — title never edited, holds no
 items, an empty shell — removes it outright instead of moving it to the trash.
@@ -267,21 +308,33 @@ for honouring it rather than second-guessing the user.
 
 ## PL14-009 — Breadcrumbs tint while an item is dragged
 
-- Status: Not started
-- Area: `graph-breadcrumb-drop.tsx`, `graph-board.tsx`
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: `graph-view-chrome.tsx` (`AncestorCrumb`), `tests/e2e/graph-view.spec.ts`
 - Screenshot: Not captured
 
-While an item is being dragged, the breadcrumb entries should take an ever so
-slight background colour change — enough to suggest the breadcrumb area is now
-a drop target for the dragged element.
+Ancestor crumbs take a faint fill while a drag is live, stepping up to a sky
+tint when the pointer is actually over one.
 
-The breadcrumb is already droppable; this is the missing affordance, not new
-behaviour. Deliberately subtle: the owner asked for a hint that something is
-possible there, not a highlight competing with the drop indicator.
+The crumbs were already droppable and already signalled it — with a dotted
+underline, and a solid sky underline when hovered. The gap was that both are
+marks ON TEXT, so at a glance the trail still read as text rather than as
+somewhere a card could go. A background says "region", which is what a drop
+target is.
 
-Done when: the tint appears for the duration of a drag and clears on drop or
-cancel, and it is distinguishable from (and weaker than) the active
-drop-target treatment a crumb takes when the pointer is actually over it.
+Two states, kept ranked so the stronger one still wins: `bg-zinc-800/50` for
+droppable, `bg-sky-500/15` for hovered. Faint on purpose — the owner asked for
+a hint that something is possible, not a highlight competing with the drop
+indicator.
+
+The existing rationale survives intact and is why this is a FILL: decoration
+and background are both layout-neutral, so the crumb's width never changes as
+the states toggle. A border or a ring would have moved the trail.
+
+Pinned in the existing drop-zone e2e rather than a new test — that test already
+holds a live drag over each zone, which is the only state where any of this is
+visible. It asserts the droppable fill while the pointer is still on the card,
+and the sky fill once it is over the crumb.
 
 ## PL14-010 — The modal's name field opens on a single click
 


### PR DESCRIPTION
Two more off [Punch List 14](punch-list/PUNCH-LIST-14.md). **008 was in the intended batch and is not here** — see the bottom.

## PL14-001 — enable/disable from the details modal

Both dialogs gain the control in their header, beside the readout.

**An action whose label flips, not a switch.** That was the item's open question, and precedent settles it rather than taste: the rail's item actions already do exactly this — `Ban` + "Disable" / `CircleCheck` + "Enable". Two controls for one concept should look like one concept, so this uses the same icons and the same words.

Nothing about what disabling *means* changed: `set-node-disabled`, the item keeps its slot and its span, playback skips it.

Two things fell out of dispatching it the same way the rail does:

- **The modal's scoped undo already covered it.** `useScopedHistory` was written to accept `set-node-disabled` when it names exactly one node — this item's node — so the modal's own undo button steps through a disable with no new wiring. That clause predates this item; it was waiting for it.
- **No toast.** The rail toasts because its selection can be forty items and the board may not show what moved. Here the label flips and the item is on screen, so a toast would narrate what the user is looking at.

Shared by both dialogs, for the reason PL14-010 learned the hard way: the collection details view is a modal too, not a card surface.

## PL14-009 — crumbs tint while a drag is live

Ancestor crumbs take a faint fill during a drag, stepping up to a sky tint under the pointer.

They were already droppable and already signalled it — a dotted underline, solid sky when hovered. But both are marks **on text**, so at a glance the trail still read as text rather than as somewhere a card could go. A background says "region", which is what a drop target is.

Ranked so the stronger state still wins: `bg-zinc-800/50` droppable, `bg-sky-500/15` hovered. Faint on purpose — a hint that something is possible, not a competitor to the drop indicator.

The existing rationale survives intact, and is why this is a fill: decoration and background are both layout-neutral, so the crumb's width never changes as the states toggle. A border or a ring would have moved the trail.

Pinned in the existing drop-zone e2e rather than a new test — that one already holds a live drag over each zone, which is the only state where any of this is visible.

## PL14-008 is not in this PR

It was picked up as a small item and it is not one.

**The engine has no removal command.** `CollectionsCommand` is exactly five cases — `move-nodes`, `add-nodes`, `update-media`, `rename-node`, `set-node-disabled`. Deleting *is* moving to the trash root; nothing can take a node out of the graph. So "skip the trash, just remove it" cannot be a branch in the delete path, because the thing it would branch to does not exist.

The patch half is already there (`nodes-removed` applies, verifies, and inverts to `nodes-added`, so undo would round-trip), which makes a `remove-nodes` command tractable — but it is a change to `collections-core`, which every surface depends on, for one narrow case.

It also raises a question the item never asked: **what happens to the collection's own document?** Trashing re-parents the node and keeps the document. Removing outright either orphans it or deletes it — and "undo still restores it" means it has to survive or be recreated. That is a data-deletion decision, not a UI one.

Worth deciding first: if the goal is *"the trash drawer shouldn't fill with shells"*, there is a cheaper answer with no engine change and no orphaned documents — trash them as normal and have the drawer not list untouched empty collections. Same outcome for the user.

## Verification

| | |
|---|---|
| App vitest | 502 passed |
| Unit | 408 passed |
| Storybook | 164 passed |
| graph-view e2e | 99 passed (1 new, 1 extended) |
| Typecheck | clean, both workspaces |
| Lint | 0 errors (5 pre-existing `<img>` warnings) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)