### PR TITLE
PL14-008: the trash drawer stops listing untouched empty collections

### DIFF
--- a/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
+++ b/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import { createPortal } from "react-dom";
 import {
   Trash2,
@@ -15,7 +22,7 @@ import { Button } from "@/components/core/button";
 import { toast } from "@/components/core/sonner";
 import { deletionWindowLabel } from "@/lib/asset-deletion-window";
 import { trashRowCaption } from "@/lib/trash-provenance";
-import { groupTrashClips } from "@/lib/trash-groups";
+import { groupTrashClips, visibleTrashClips } from "@/lib/trash-groups";
 import { discardTrashClips } from "@/lib/graph-trash-discard";
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 import { useAuth } from "@/components/auth/auth-provider";
@@ -67,6 +74,15 @@ const useIsMounted = () =>
 export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
   const { user } = useAuth();
   const [clips, setClips] = useState<TimelineClip[]>([]);
+  // What the drawer SHOWS: everything trashed except untouched empty
+  // collections (PL14-008). Derived once and used for the rows, the count and
+  // the empty state alike — filtering only the list would leave the header
+  // counting items nobody can see.
+  //
+  // `clips` stays the raw truth. Nothing about deleting changed: these are
+  // ordinary trashed nodes, undo restores them, and emptying the bin still
+  // clears the whole document including them.
+  const visibleClips = useMemo(() => visibleTrashClips(clips), [clips]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const isMounted = useIsMounted();
@@ -275,7 +291,7 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
     // longer keeps, which is worse than the blanket "permanently delete" it had
     // replaced.
     const confirmed = window.confirm(
-      `Empty the trash? The ${clips.length} item${clips.length === 1 ? "" : "s"} in the bin will be removed and cannot be restored. Uploaded files that nothing else uses are deleted after 30 days.`
+      `Empty the trash? The ${visibleClips.length} item${visibleClips.length === 1 ? "" : "s"} in the bin will be removed and cannot be restored. Uploaded files that nothing else uses are deleted after 30 days.`
     );
     if (!confirmed) return;
 
@@ -319,12 +335,12 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
               Trash Bin
             </h2>
             <p className="mt-0.5 text-xs text-zinc-500">
-              {clips.length} items in trash
+              {visibleClips.length} items in trash
             </p>
           </div>
 
           <div className="flex items-center gap-2">
-            {clips.length > 0 && (
+            {visibleClips.length > 0 && (
               <Button
                 type="button"
                 variant="outline"
@@ -361,7 +377,7 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
               <CircleAlert className="h-4 w-4" />
               {error}
             </div>
-          ) : clips.length === 0 && marked.length === 0 ? (
+          ) : visibleClips.length === 0 && marked.length === 0 ? (
             // Only when BOTH are empty. A bin with nothing in it but files on
             // their way out is not an empty drawer, and saying so would hide
             // the one thing here anybody still has a decision to make about.
@@ -371,9 +387,9 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
             </div>
           ) : (
             <>
-            {clips.length > 0 && (
+            {visibleClips.length > 0 && (
             <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4 p-5">
-              {groupTrashClips(clips).map((group, index) => {
+              {groupTrashClips(visibleClips).map((group, index) => {
                 // The row stands for the IMAGE, not one clip: every field it
                 // paints comes from the first copy, which is safe precisely
                 // because copies of one asset share them.
@@ -471,7 +487,7 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
                 // Bordered off from the bin above it, because these two lists
                 // answer different questions: what did I delete (and can put
                 // back), versus what is about to stop existing.
-                className={clips.length > 0 ? "border-t border-zinc-900" : undefined}
+                className={visibleClips.length > 0 ? "border-t border-zinc-900" : undefined}
               >
                 <header className="px-5 pt-4">
                   <h3

--- a/apps/timeline-gstudio001/lib/trash-groups.test.ts
+++ b/apps/timeline-gstudio001/lib/trash-groups.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import type { TimelineClip } from "@storyboard/timeline-model/types";
 
-import { groupTrashClips } from "./trash-groups";
+import {
+  groupTrashClips,
+  isUntouchedEmptyCollection,
+  visibleTrashClips,
+} from "./trash-groups";
 
 function image(id: string, overrides: Partial<TimelineClip> = {}): TimelineClip {
   return {
@@ -87,5 +91,70 @@ describe("groupTrashClips", () => {
   it("leaves a single clip as a group of one, and an empty bin as nothing", () => {
     expect(groupTrashClips([image("solo")])[0].clips).toHaveLength(1);
     expect(groupTrashClips([])).toEqual([]);
+  });
+});
+
+function collection(
+  id: string,
+  overrides: Partial<TimelineClip> = {},
+): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "collection",
+    title: "New Timeline",
+    childTimelineId: `${id}-doc`,
+    itemCount: 0,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 3,
+    sourceDuration: 3,
+    trimIn: 0,
+    trimOut: 0,
+    ...overrides,
+  } as TimelineClip;
+}
+
+describe("visibleTrashClips", () => {
+  // PL14-008. The bin exists to give WORK back, and an untouched empty
+  // collection is not work — it is what a mis-clicked Collection tool leaves
+  // behind. Hidden from the drawer only: the node is still trashed, undo still
+  // restores it, emptying still takes it.
+
+  it("hides a collection that is empty AND still has its minted name", () => {
+    expect(visibleTrashClips([collection("shell")])).toEqual([]);
+    expect(isUntouchedEmptyCollection(collection("shell"))).toBe(true);
+  });
+
+  it("SHOWS an empty collection that was renamed — the name is the work", () => {
+    const named = collection("named", { title: "Act One" });
+    expect(visibleTrashClips([named])).toHaveLength(1);
+    expect(isUntouchedEmptyCollection(named)).toBe(false);
+  });
+
+  it("SHOWS a collection that held content, which travels into the bin with it", () => {
+    const full = collection("full", { itemCount: 2 });
+    expect(visibleTrashClips([full])).toHaveLength(1);
+    expect(isUntouchedEmptyCollection(full)).toBe(false);
+  });
+
+  it("never hides media, however empty it looks", () => {
+    expect(isUntouchedEmptyCollection(image("pic"))).toBe(false);
+    expect(visibleTrashClips([image("pic")])).toHaveLength(1);
+  });
+
+  it("keeps the rest of the bin in order when it drops a shell from the middle", () => {
+    const visible = visibleTrashClips([
+      image("a"),
+      collection("shell"),
+      image("b"),
+    ]);
+    expect(visible.map((c) => c.id)).toEqual(["a", "b"]);
+  });
+
+  it("treats a whitespace-padded minted title as untouched", () => {
+    // The seeded title round-trips through a document; a stray space is not a
+    // rename.
+    expect(isUntouchedEmptyCollection(collection("s", { title: "  New Timeline " }))).toBe(true);
   });
 });

--- a/apps/timeline-gstudio001/lib/trash-groups.ts
+++ b/apps/timeline-gstudio001/lib/trash-groups.ts
@@ -27,6 +27,54 @@ function assetIdentity(clip: TimelineClip): string {
   return `clip:${clip.id}`;
 }
 
+/** The title a collection is minted with (graph-native-drop seeds both the node
+ *  name and the child document with it). A collection still wearing it has
+ *  never been named by anyone. */
+const UNTOUCHED_COLLECTION_TITLE = "New Timeline";
+
+/**
+ * A collection nobody ever did anything to: no items, never renamed (PL14-008).
+ *
+ * The bin exists to give work back, and one of these is not work — it is what
+ * you get from mis-clicking the Collection tool. Filling the drawer with shells
+ * makes it worse at the one job it has, so they are not shown.
+ *
+ * Deliberately CONSERVATIVE, because the cost of the two mistakes is not
+ * symmetric: hiding something the user wanted back is unrecoverable from the
+ * drawer, while showing one extra shell is merely untidy. So both conditions
+ * must hold, and anything else is treated as real work —
+ *
+ * - a RENAMED empty collection is shown (the name is the work), and
+ * - a collection that once held content is shown, because its children travel
+ *   into the bin with it, so `itemCount > 0` still reads true in there.
+ *
+ * This hides them from the DRAWER only. They are still ordinary trashed nodes
+ * in the document, undo still restores them, and emptying the bin still takes
+ * them — nothing about the delete path changed, which is the whole reason this
+ * is a display rule and not a new engine command.
+ */
+export function isUntouchedEmptyCollection(clip: TimelineClip): boolean {
+  return (
+    clip.kind === "collection" &&
+    clip.itemCount === 0 &&
+    clip.title.trim() === UNTOUCHED_COLLECTION_TITLE
+  );
+}
+
+/**
+ * What the drawer should treat as its contents — everything trashed except the
+ * shells above.
+ *
+ * Applied once, to the whole list, so the row count, the empty state and the
+ * rows themselves cannot disagree. Filtering only the rendered list would have
+ * left the header counting items the user cannot see.
+ */
+export function visibleTrashClips(
+  clips: readonly TimelineClip[],
+): readonly TimelineClip[] {
+  return clips.filter((clip) => !isUntouchedEmptyCollection(clip));
+}
+
 /**
  * Collapse repeats of one asset into a single row.
  *

--- a/punch-list/PUNCH-LIST-14.md
+++ b/punch-list/PUNCH-LIST-14.md
@@ -241,37 +241,52 @@ click, and reachable by keyboard (context-menu key / Shift+F10).
 
 ## PL14-008 — An untouched, empty collection is discarded, not trashed
 
-- Status: Not started — BLOCKED on a decision, see "What building it found"
-- Area: `packages/collections-core/commands.ts` (a new command), the delete
-  path shared by the sidebar action, the trash drop target and the Delete key
+- Status: Complete — solved as a DISPLAY rule, not a delete rule
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: `lib/trash-groups.ts`, `components/assets/trash-drawer.tsx`,
+  `lib/trash-groups.test.ts`
 - Screenshot: Not captured
 
-> **What building it found (2026-07-30).** This is bigger than the entry below
-> implies, and it was picked up as a small item.
->
-> **The engine has no removal command.** `CollectionsCommand` is exactly five
-> cases — `move-nodes`, `add-nodes`, `update-media`, `rename-node`,
-> `set-node-disabled`. Deleting IS moving to the trash root; nothing anywhere
-> can take a node OUT of the graph. So "skip the trash, just remove it" cannot
-> be a branch in the delete path — the thing it would branch to does not exist.
->
-> The patch half is already there (`nodes-removed` applies, verifies, and
-> inverts to `nodes-added`, so undo would round-trip), which makes a
-> `remove-nodes` command tractable — but it is a change to `collections-core`,
-> the package every surface depends on, for one narrow case.
->
-> **And it raises a question the entry never asked: what happens to the
-> collection's DOCUMENT?** A collection is a node plus its own timeline
-> document. Trashing re-parents the node and keeps the document. Removing the
-> node outright either orphans that document in Firebase or deletes it — and
-> "undo still restores it", which you asked for, means the document has to
-> survive or be recreated. That is a data-deletion decision, not a UI one.
->
-> Worth deciding before any code: is the goal *"the trash drawer should not
-> fill with shells"*? If so there is a cheaper answer that needs no engine
-> change — trash them as normal and have the DRAWER not list untouched empty
-> collections, or sweep them. Same outcome for the user, no new primitive, no
-> orphaned documents.
+The drawer no longer lists untouched empty collections. **Nothing about
+deleting changed** — they are still ordinary trashed nodes, undo still restores
+them, and emptying the bin still takes them.
+
+**The original plan was abandoned, and the reason is worth keeping.** "Skip the
+trash, just remove it" cannot be a branch in the delete path, because the thing
+it would branch to does not exist: `CollectionsCommand` is exactly five cases
+(`move-nodes`, `add-nodes`, `update-media`, `rename-node`,
+`set-node-disabled`) and **none of them takes a node out of the graph**.
+Deleting IS moving to the trash root. Implementing it as specified meant a new
+`remove-nodes` command in `collections-core` — the package every surface
+depends on — for one narrow case.
+
+It also raised a question the item never asked: a collection is a node PLUS its
+own timeline document. Trashing re-parents the node and keeps the document;
+removing outright either orphans it in Firebase or deletes it, and "undo still
+restores it" means it has to survive. That is a data-deletion decision.
+
+So the goal was checked instead of the method — *the drawer should not fill
+with shells* — and that needs no engine change, no new primitive and no
+orphaned documents. The owner chose this route.
+
+**"Untouched" is deliberately conservative**, because the two mistakes do not
+cost the same: hiding something wanted back is unrecoverable from the drawer,
+while showing one extra shell is untidy. Both must hold —
+
+- `itemCount === 0`, and
+- the title is still the minted `"New Timeline"` (trimmed, since a stray space
+  is not a rename).
+
+A renamed empty collection is shown, because the name IS the work. A collection
+that once held content is shown, because its children travel into the bin with
+it and `itemCount > 0` still reads true there.
+
+Filtered ONCE, over the whole list, so the rows, the header count, the empty
+state and the Empty Trash button cannot disagree — filtering only the rendered
+rows would have left the header counting items nobody can see.
+
+Six unit tests. Removing the title condition makes the renamed-collection test
+fail, so the conservative half is load-bearing rather than decorative.
 
 Deleting a collection that has never been changed — title never edited, holds no
 items, an empty shell — removes it outright instead of moving it to the trash.


### PR DESCRIPTION
The drawer no longer lists untouched empty collections. **Deleting is unchanged** — they are still ordinary trashed nodes, undo still restores them, and emptying the bin still takes them.

## Why this isn't the approach the item specified

The item said "skip the trash, just remove it". That cannot be a branch in the delete path, because the thing it would branch to does not exist.

`CollectionsCommand` is exactly five cases — `move-nodes`, `add-nodes`, `update-media`, `rename-node`, `set-node-disabled` — and **none of them takes a node out of the graph**. Deleting *is* moving to the trash root. Implementing it as written meant adding a `remove-nodes` command to `collections-core`, the package every surface depends on, for one narrow case.

It also raised a question the item never asked: a collection is a node **plus its own timeline document**. Trashing re-parents the node and keeps the document. Removing outright either orphans that document in Firebase or deletes it — and "undo still restores it" means it has to survive. That is a data-deletion decision, not a UI one.

So the *goal* got checked rather than the method — the drawer shouldn't fill with shells — and that needs no engine change, no new primitive, and no orphaned documents. Owner picked this route.

## "Untouched" is deliberately conservative

The two mistakes don't cost the same. Hiding something the user wanted back is unrecoverable *from the drawer*; showing one extra shell is untidy. So both conditions must hold:

- `itemCount === 0`, **and**
- the title is still the minted `"New Timeline"` (trimmed — a stray space is not a rename)

Which means:

- a **renamed** empty collection is shown — the name is the work
- a collection that **once held content** is shown, because its children travel into the bin with it, so `itemCount > 0` still reads true in there

## One filter point

Applied once over the whole list, so the rows, the header count, the empty state and the Empty Trash button cannot disagree. Filtering only the rendered rows would have left the header counting items nobody can see.

## Tests

Six new unit tests in `lib/trash-groups.test.ts`. Removing the title condition makes *"SHOWS an empty collection that was renamed"* fail — verified — so the conservative half is load-bearing rather than decorative.

| | |
|---|---|
| App vitest | 508 passed (6 new) |
| Unit | 408 passed |
| Storybook | 164 passed |
| graph-view e2e | 99 passed |
| Typecheck | clean |
| Lint | 0 errors (5 pre-existing `<img>` warnings) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)