### PR TITLE
PL14-006: a trim drag takes the preview pane when it is open

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -70,6 +70,7 @@ import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 import { requestGraphPreviewToggle } from "@/lib/graph-view-events";
 
 import { useGraphDetailsStore } from "./graph-details-context";
+import { TrimPreviewOverlay, TrimPreviewProvider } from "./graph-trim-preview";
 import { GRID_GAP, TIMELINE_PPS } from "./graph-view-config";
 
 /**
@@ -2033,7 +2034,15 @@ export function PreviewShell({
         {/* The playhead and scrub band live in `children`; they read these
             spans so their time↔x mapping is the pane's clock, not their own. */}
         <PreviewCardSpansContext.Provider value={cardSpans}>
-          {children}
+          {/* A trim drag borrows the pane's picture while the pane is OPEN
+              (PL14-006). The provider wraps `children` because that is where
+              the board — and therefore every trim handle — renders; the
+              overlay is a sibling because it draws over the pane above.
+              Neither touches the clock. */}
+          <TrimPreviewProvider previewOpen={enabled}>
+            {children}
+            <TrimPreviewOverlay />
+          </TrimPreviewProvider>
         </PreviewCardSpansContext.Provider>
       </WorkbenchSplitPane>
     </TimelineDocumentsProvider>

--- a/apps/timeline-gstudio001/components/graph-view/graph-trim-panel.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-trim-panel.tsx
@@ -6,6 +6,8 @@ import { createPortal } from "react-dom";
 import { useSeekedVideo } from "@/hooks/use-seeked-video";
 import { formatSeconds } from "@/lib/format-duration";
 
+import { usePublishTrimPreview } from "./graph-trim-preview";
+
 import {
   useLiveTrim,
   type LiveTrim,
@@ -148,10 +150,31 @@ export function TrimPanel({ id, node }: Readonly<{ id: NodeId; node: MediaNode }
   const live = useLiveTrim(id);
   const [anchor, setAnchor] = useState<HTMLSpanElement | null>(null);
 
-  if (node.mediaKind !== "video" || !node.src) return null;
+  const isVideo = node.mediaKind === "video" && !!node.src;
+  // Quantized the same way LiveEdgeFrame quantizes, so the two presentations
+  // seek to the same frames and neither issues a decode per pointer event.
+  const sourceTime =
+    live !== null && isVideo ? Math.round(edgeSourceTime(node, live) * 25) / 25 : 0;
+  // Published unconditionally — the hook decides whether the pane wants it,
+  // because "is the preview open" is the pane's fact, not the card's. It
+  // returns true when the pane TOOK the frame, which is exactly when the
+  // floating panel must stand down (PL14-006): one picture, not two.
+  const takenByPreview = usePublishTrimPreview(
+    live !== null && isVideo && node.src
+      ? {
+          nodeId: id as string,
+          src: node.src,
+          poster: node.posterSrcs?.[0],
+          sourceTime,
+          side: live.side === "right" ? "right" : "left",
+        }
+      : null,
+  );
+
+  if (!isVideo) return null;
   return (
     <span ref={setAnchor} aria-hidden="true" className="pointer-events-none absolute inset-0">
-      {anchor !== null && live !== null ? (
+      {anchor !== null && live !== null && !takenByPreview ? (
         <LiveEdgeFrame node={node} live={live} anchor={anchor} />
       ) : null}
     </span>

--- a/apps/timeline-gstudio001/components/graph-view/graph-trim-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-trim-preview.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+import { createPortal } from "react-dom";
+
+import { useSeekedVideo } from "@/hooks/use-seeked-video";
+import { formatSeconds } from "@/lib/format-duration";
+
+// Where a trim drag's live frame is SHOWN (PL14-006).
+//
+// The floating panel above the card (graph-trim-panel) exists because there was
+// nowhere else to put it. When the preview pane is open there IS somewhere
+// else — a large picture already pointed at by the user's attention — and a
+// second, smaller copy of the same frame floating over the board is one picture
+// too many.
+//
+// So: pane open → the frame takes the pane. Pane closed → the floating panel,
+// exactly as before. This module is the seam between the two, and it is a
+// React CONTEXT rather than a window event because both ends live inside the
+// graph's own tree (the board renders as the preview component's children).
+// The window-event bridge is for the sidebar, which does not.
+//
+// THE PLAYHEAD IS NOT TOUCHED. That was the constraint carried over from round
+// 5, when this half was deferred, and it is why nothing here goes near
+// `PreviewTimeChannel.set`: the clock keeps its time, the pane's own canvas
+// keeps rendering that time underneath, and this draws OVER it for the length
+// of the gesture. Release the handle and the overlay unmounts onto a pane that
+// never moved.
+
+export type TrimPreviewFrame = Readonly<{
+  nodeId: string;
+  src: string;
+  poster?: string;
+  /** SOURCE seconds — the frame the moving edge is currently on. */
+  sourceTime: number;
+  /** Which edge is moving, so the overlay can wear the handle's amber bar on
+   *  the same side the panel would have. */
+  side: "left" | "right";
+}>;
+
+type TrimPreviewStore = Readonly<{
+  get: () => TrimPreviewFrame | null;
+  set: (frame: TrimPreviewFrame | null) => void;
+  subscribe: (listener: () => void) => () => void;
+}>;
+
+type TrimPreviewValue = Readonly<{
+  /** Whether the pane is open — the whole condition of this feature. */
+  previewOpen: boolean;
+  store: TrimPreviewStore;
+}>;
+
+function createStore(): TrimPreviewStore {
+  let frame: TrimPreviewFrame | null = null;
+  const listeners = new Set<() => void>();
+  return {
+    get: () => frame,
+    set: (next) => {
+      frame = next;
+      for (const listener of listeners) listener();
+    },
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}
+
+/** Closed and inert by default, so a card rendered outside the provider (a
+ *  story, a test harness) keeps the floating-panel behaviour rather than
+ *  publishing into nothing. */
+const INERT: TrimPreviewValue = {
+  previewOpen: false,
+  store: { get: () => null, set: () => {}, subscribe: () => () => {} },
+};
+
+const TrimPreviewContext = createContext<TrimPreviewValue>(INERT);
+
+export function TrimPreviewProvider({
+  previewOpen,
+  children,
+}: Readonly<{ previewOpen: boolean; children: React.ReactNode }>) {
+  const [store] = useState(createStore);
+  // The store is stable; only the open flag changes identity, and it changes
+  // rarely (a pane toggle), so this is not a per-frame allocation.
+  const value = useMemo<TrimPreviewValue>(
+    () => ({ previewOpen, store }),
+    [previewOpen, store],
+  );
+  // Closing the pane mid-drag must not leave a frame parked in the store for
+  // the next drag to inherit.
+  useEffect(() => {
+    if (!previewOpen) store.set(null);
+  }, [previewOpen, store]);
+  return (
+    <TrimPreviewContext.Provider value={value}>{children}</TrimPreviewContext.Provider>
+  );
+}
+
+export function useTrimPreview(): TrimPreviewValue {
+  return useContext(TrimPreviewContext);
+}
+
+/**
+ * Publishes the live edge frame while a trim drag is running AND the pane is
+ * open. Returns whether it took the frame — the caller renders its floating
+ * panel only when this says no, so exactly one of the two is ever showing.
+ */
+export function usePublishTrimPreview(frame: TrimPreviewFrame | null): boolean {
+  const { previewOpen, store } = useTrimPreview();
+  const taken = previewOpen && frame !== null;
+
+  // TWO effects, deliberately. Publishing and clearing are keyed differently:
+  // the frame changes on every pointer move, while "is a drag running" changes
+  // twice. Folding them into one effect with a cleanup would set null between
+  // every pair of frames, and the overlay would unmount and remount its
+  // <video> — a black flash per pointer move instead of a seek.
+  useEffect(() => {
+    if (taken) store.set(frame);
+  }, [taken, frame, store]);
+
+  useEffect(() => {
+    if (!taken) return;
+    // Clearing on the way out is what ends the overlay — the gesture ending
+    // unmounts the panel, which is the only signal there is.
+    return () => store.set(null);
+  }, [taken, store]);
+
+  return taken;
+}
+
+/** The pane's picture area, which is what the overlay covers. */
+const CANVAS_SELECTOR = '[data-testid="workbench-display-canvas"]';
+
+/**
+ * The trim frame, drawn over the preview pane's picture for the length of the
+ * gesture.
+ *
+ * Positioned `fixed` against the canvas's measured rect rather than mounted
+ * inside the pane. The pane is a package component with its own layout
+ * (WorkbenchSplitPane sizes it, a divider drags it); slipping an absolutely
+ * positioned child into it would make this feature a `packages/ui` change and
+ * put a graph concern inside a generic surface. Measuring is the same
+ * technique the floating panel already uses, and it leaves the package alone.
+ */
+export function TrimPreviewOverlay() {
+  const { store } = useTrimPreview();
+  const frame = useSyncExternalStore(store.subscribe, store.get, () => null);
+  const videoRef = useSeekedVideo(frame?.sourceTime ?? 0, frame !== null);
+  const boxRef = useRef<HTMLDivElement | null>(null);
+
+  useLayoutEffect(() => {
+    const box = boxRef.current;
+    if (!box || !frame) return;
+    const canvas = document.querySelector(CANVAS_SELECTOR);
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    box.style.left = `${rect.left}px`;
+    box.style.top = `${rect.top}px`;
+    box.style.width = `${rect.width}px`;
+    box.style.height = `${rect.height}px`;
+  }, [frame]);
+
+  if (!frame) return null;
+
+  return createPortal(
+    <div
+      ref={boxRef}
+      data-trim-preview-overlay={frame.side}
+      aria-hidden="true"
+      className="pointer-events-none fixed z-30 overflow-hidden bg-black"
+      style={{ left: -9999, top: -9999 }}
+    >
+      <video
+        ref={videoRef}
+        src={frame.src}
+        poster={frame.poster}
+        muted
+        playsInline
+        preload="auto"
+        className="h-full w-full bg-black object-contain"
+      />
+      {/* Same amber bar the floating panel wears, on the same edge — the two
+          presentations should read as one feature in two places. */}
+      <span
+        className={[
+          "absolute inset-y-0 w-1 bg-amber-400",
+          frame.side === "right" ? "right-0" : "left-0",
+        ].join(" ")}
+      />
+      <span className="absolute bottom-0 right-0 bg-zinc-950/85 px-1.5 py-0.5 font-mono text-xs leading-tight tabular-nums text-amber-200">
+        {formatSeconds(frame.sourceTime)}
+      </span>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -4528,6 +4528,66 @@ test.describe("graph view E2E", () => {
     expect(storedTitle()).toBe("Belushi close-up");
   });
 
+  test("with the preview OPEN, a trim drag takes the pane instead of floating a panel", async ({
+    page,
+  }) => {
+    // PL14-006, and the other half of round 5's item 3 — deferred then, asked
+    // for now. The floating panel exists because there was nowhere else to put
+    // the frame; an open preview IS somewhere else, and two copies of the same
+    // frame is one too many.
+    await installGraphApi(page);
+    await openGraph(page);
+
+    // Open the pane BEFORE selecting: the rail swaps to the item-actions
+    // cluster while anything is selected, so the preview toggle is not there
+    // to click afterwards.
+    const canvas = page.getByTestId("workbench-display-canvas");
+    await previewToggle(page).click();
+    await expect(canvas).toBeVisible();
+
+    const alpha = strip(page, PROJECT_ID).locator('[data-node-id="alpha"]');
+    const wrapper = strip(page, PROJECT_ID).locator('[data-node-wrapper="alpha"]');
+    await expect(async () => {
+      await alpha.click();
+      await expect(alpha).toHaveAttribute("data-selected", "true", { timeout: 700 });
+    }).toPass({ timeout: 10000 });
+
+    // Where the clock stands before the drag — it must not move.
+    const timeBefore = await page.getByTestId("workbench-preview-time").textContent();
+
+    const handle = wrapper.locator("[data-trim-handle]").last();
+    const box = (await handle.boundingBox())!;
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box.x - 24, box.y + box.height / 2, { steps: 6 });
+
+    // The pane took it, and the floating panel stood down.
+    const overlay = page.locator('[data-trim-preview-overlay="right"]');
+    await expect(overlay).toHaveCount(1);
+    await expect(page.locator("[data-trim-edge-frame]")).toHaveCount(0);
+
+    // It covers the pane's picture — this is the preview showing the frame,
+    // not a panel that happens to be nearby.
+    const overlayBox = (await overlay.boundingBox())!;
+    const canvasBox = (await canvas.boundingBox())!;
+    expect(overlayBox.x).toBeCloseTo(canvasBox.x, 0);
+    expect(overlayBox.y).toBeCloseTo(canvasBox.y, 0);
+    expect(overlayBox.width).toBeCloseTo(canvasBox.width, 0);
+    expect(overlayBox.height).toBeCloseTo(canvasBox.height, 0);
+
+    // THE constraint carried over from round 5: the clock does not move while
+    // the pane is borrowed. Asserted DURING the gesture, which is the only
+    // window where it means anything — releasing commits the trim, and a
+    // committed trim changes the timeline's total duration on purpose, so the
+    // readout is expected to differ afterwards.
+    expect(await page.getByTestId("workbench-preview-time").textContent()).toBe(timeBefore);
+
+    await page.mouse.up();
+    // Released, the pane goes back to being the pane.
+    await expect(overlay).toHaveCount(0);
+    await expect(canvas).toBeVisible();
+  });
+
   test("a trim drag floats the edge frame above the clip", async ({ page }) => {
     // PL10-005/007. The live frame is its own small surface: sized to the
     // breadcrumb row (a size reference, not a location — it follows the CLIP,

--- a/punch-list/PUNCH-LIST-14.md
+++ b/punch-list/PUNCH-LIST-14.md
@@ -194,10 +194,45 @@ written when the gear was in the header — was inverted by this and now reads a
 
 ## PL14-006 — Trim drag drives the real preview when it is open
 
-- Status: Not started
-- Area: `graph-trim-panel.tsx`, `graph-preview.tsx`,
-  `packages/ui/timeline/viewport/workbench-display-surface.tsx`
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: `graph-trim-preview.tsx` (new), `graph-trim-panel.tsx`,
+  `graph-preview.tsx`, `tests/e2e/graph-view.spec.ts`.
+  `packages/ui` deliberately UNTOUCHED — see below.
 - Screenshot: Not captured
+
+Preview open → the trim frame takes the pane. Preview closed → the floating
+panel, exactly as before. Exactly one of the two ever shows.
+
+**The playhead does not move.** That was round 5's condition for ever building
+this, and it is why nothing here goes near `PreviewTimeChannel.set`: the clock
+keeps its time, the pane's own canvas keeps rendering that time underneath, and
+the frame is drawn OVER it for the length of the gesture. Release, and the
+overlay unmounts onto a pane that never moved.
+
+Three decisions worth keeping:
+
+- **A React context, not a window event.** Both ends live inside the graph's
+  own tree — the board renders as the preview component's `children` — and the
+  event bridge is explicitly for the sidebar, which does not. Same rule that
+  settled PL14-005 in the opposite direction.
+- **`packages/ui` is untouched.** The frame is a `fixed` overlay measured
+  against the pane's canvas rect, not a child slipped inside
+  `WorkbenchDisplaySurface`. That surface is a generic package component with
+  its own layout (the split pane sizes it, a divider drags it); putting a graph
+  concern inside it would have made this a package change for a view-specific
+  feature. Measuring is the technique the floating panel already uses.
+- **Two effects, not one.** Publishing the frame and clearing it are keyed
+  differently — the frame changes on every pointer move, "a drag is running"
+  changes twice. One effect with a cleanup would set null between every pair of
+  frames, remounting the `<video>`: a black flash per pointer move instead of
+  a seek.
+
+E2E covers both branches, and the assertion that matters is that the clock is
+unchanged DURING the gesture — after release the trim commits and the
+timeline's total duration legitimately changes, which is what the first version
+of the test wrongly flagged as the playhead moving. Proven to fail with the
+feature forced off.
 
 When a video clip is selected and the user grabs a trim handle, a small overlay
 preview appears above the card showing the frame at the moving edge. Add the


### PR DESCRIPTION
Preview open → the trim frame takes the pane. Preview closed → the floating panel above the card, exactly as before. Exactly one of the two ever shows.

This is the other half of **round 5's item 3** — built up to this point then deferred on your instruction ("do NOT build it until the user asks"). This is that ask.

The floating panel exists because there was nowhere else to put the frame. An open preview *is* somewhere else, already holding your attention, and a second smaller copy of the same frame floating over the board is one picture too many.

## The playhead does not move

That was round 5's condition for ever building this, and it's why nothing here goes near `PreviewTimeChannel.set`. The clock keeps its time, the pane's own canvas keeps rendering that time underneath, and the trim frame is drawn **over** it for the length of the gesture. Release, and the overlay unmounts onto a pane that never moved.

## Three decisions

- **A React context, not a window event.** Both ends live inside the graph's own tree — the board renders as the preview component's `children` — and the event bridge is explicitly for the sidebar, which does not. Same rule that settled PL14-005 in the *opposite* direction, where the control genuinely had to live in another tree.
- **`packages/ui` is untouched.** The frame is a `fixed` overlay measured against the pane's canvas rect, not a child slipped inside `WorkbenchDisplaySurface`. That surface is a generic package component with its own layout (the split pane sizes it, a divider drags it); putting a graph concern inside it would make this a package change for a view-specific feature. Measuring is the technique the floating panel already uses.
- **Two effects, not one.** Publishing the frame and clearing it are keyed differently — the frame changes on every pointer move, "a drag is running" changes twice. Folding them into one effect with a cleanup would set null between every pair of frames and remount the `<video>`: a black flash per pointer move instead of a seek.

## The test, and what it nearly got wrong

Covers both branches — pane open takes the overlay and suppresses the floating panel; pane closed still floats (the existing test, unchanged and still passing).

The assertion that matters is that the clock is unchanged **during** the gesture. My first version also asserted it after release and failed: `22.0s → 22.9s`. That was the timeline's **total duration** changing because the trim committed — correct behaviour, wrongly read as the playhead moving. Asserted only across the window where it means something now, with a comment saying why.

Proven to fail with the feature forced off (`Expected: 1, Received: 0`).

## Verification

| | |
|---|---|
| App vitest | 508 passed |
| Unit | 408 passed |
| Storybook | 164 passed |
| graph-view e2e | 100 passed (1 new) |
| Typecheck | clean, both workspaces |
| Lint | 0 errors (5 pre-existing `<img>` warnings) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)