### PR TITLE
PL14-006: the trim overlay was behind the pane it was covering

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-trim-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-trim-preview.tsx
@@ -179,7 +179,10 @@ export function TrimPreviewOverlay() {
       ref={boxRef}
       data-trim-preview-overlay={frame.side}
       aria-hidden="true"
-      className="pointer-events-none fixed z-30 overflow-hidden bg-black"
+      // z-[60], the floating panel's level, and it has to be: the pane it
+      // covers is `sticky z-40`, so anything below that renders BEHIND the
+      // picture it is meant to replace — present, correctly sized, invisible.
+      className="pointer-events-none fixed z-[60] overflow-hidden bg-black"
       style={{ left: -9999, top: -9999 }}
     >
       <video

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -4575,6 +4575,28 @@ test.describe("graph view E2E", () => {
     expect(overlayBox.width).toBeCloseTo(canvasBox.width, 0);
     expect(overlayBox.height).toBeCloseTo(canvasBox.height, 0);
 
+    // …and it is ON TOP of the pane, which the box assertions above cannot
+    // tell you. That is exactly how this shipped broken the first time: the
+    // overlay was z-30 against the pane's `sticky z-40`, so it sat at these
+    // coordinates, at this size, BEHIND the picture it was meant to replace —
+    // every assertion above passed and the feature did nothing.
+    //
+    // Compared numerically rather than hit-tested, because the overlay is
+    // `pointer-events-none` and is therefore invisible to `elementFromPoint`.
+    // Both live in the body stacking context, so the raw values are
+    // comparable.
+    const stacking = await page.evaluate(() => {
+      const overlay = document.querySelector("[data-trim-preview-overlay]");
+      const region = document.querySelector('[data-testid="workbench-preview-region"]');
+      if (!overlay || !region) return null;
+      return {
+        overlay: Number(getComputedStyle(overlay).zIndex),
+        region: Number(getComputedStyle(region).zIndex),
+      };
+    });
+    expect(stacking).not.toBeNull();
+    expect(stacking!.overlay).toBeGreaterThan(stacking!.region);
+
     // THE constraint carried over from round 5: the clock does not move while
     // the pane is borrowed. Asserted DURING the gesture, which is the only
     // window where it means anything — releasing commits the trim, and a

--- a/punch-list/PUNCH-LIST-14.md
+++ b/punch-list/PUNCH-LIST-14.md
@@ -253,6 +253,30 @@ Done when: with the preview open, dragging a trim handle updates the preview
 surface and no overlay appears; with the preview closed, the overlay behaves
 exactly as today; the playhead does not move in either case.
 
+### It shipped invisible first — the fix, and the test that should have caught it
+
+The first version was **z-30 against the pane's `sticky z-40`**, so the overlay
+mounted at the right coordinates, at the right size, BEHIND the picture it was
+meant to replace. The suppression half worked, so the symptom was the worst
+kind: the floating panel correctly disappeared when the pane was open, and
+nothing took its place. Reported by the owner. Now `z-[60]`, the floating
+panel's own level.
+
+**The test passed against it**, and the reason generalizes: it asserted the
+overlay's bounding box matched the canvas's, and `boundingBox()` returns
+geometry regardless of occlusion. Geometry is not visibility. It now also
+compares the overlay's computed `z-index` against the preview region's and
+requires it to be higher — which fails with `Expected: > 40, Received: 30`
+against the broken version.
+
+Hit-testing with `elementFromPoint` would have been the more direct check and
+does NOT work here: the overlay is `pointer-events-none`, so it is not
+hit-testable and the API never returns it.
+
+That is twice in this punch list (see PL14-004) that a test was non-vacuous,
+passed, and still missed the defect — both times by measuring a mechanism that
+was working rather than the outcome the user looks at.
+
 ## PL14-007 — Right-click context menu on an item
 
 - Status: Not started


### PR DESCRIPTION
[PR #244](https://github.com/josulliv101/storyboard-flow/pull/244) shipped this feature invisible.

The overlay was `z-30` against the preview pane's `sticky z-40`, so it mounted at the right coordinates, at the right size, **behind the picture it was meant to replace**.

The symptom was the worst kind, because the other half worked: with the pane open the floating panel correctly stood down, and nothing took its place. Dragging a trim handle changed nothing on screen. Reported by the owner.

Now `z-[60]` — the floating panel's own level, which it should have matched from the start. The two are the same kind of ephemeral gesture overlay and there was no reason for them to differ.

## The test passed against the bug

It asserted the overlay's bounding box matched the canvas's:

```
expect(overlayBox.x).toBeCloseTo(canvasBox.x, 0);
expect(overlayBox.width).toBeCloseTo(canvasBox.width, 0);
```

All true, and all true of an element painted over by something else. **`boundingBox()` returns geometry regardless of occlusion.** Geometry is not visibility.

It now also compares computed z-index against the preview region's and requires the overlay to be higher. Against the broken version that fails with `Expected: > 40, Received: 30`.

`elementFromPoint` would be the more direct check and does **not** work here — the overlay is `pointer-events-none`, so it is not hit-testable and the API never returns it. Noted in the test so the next person doesn't try it.

## The pattern, twice now

This is the second time in this punch list that a test was non-vacuous, passed, and still missed the defect. [PL14-004](https://github.com/josulliv101/storyboard-flow/pull/241) was the same shape: the close transition genuinely ran, genuinely resolved, and genuinely morphed toward the card — while the modal had already unmounted, so there was nothing to morph from.

Both times the test measured a mechanism that was working instead of the outcome the user looks at. Both times the owner caught it.

| | |
|---|---|
| graph-view e2e | 100 passed |
| Typecheck | clean |
| Lint | 0 errors (5 pre-existing `<img>` warnings) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)