### PR TITLE
PL14-006: drive the preview pane instead of covering it

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -70,7 +70,11 @@ import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 import { requestGraphPreviewToggle } from "@/lib/graph-view-events";
 
 import { useGraphDetailsStore } from "./graph-details-context";
-import { TrimPreviewOverlay, TrimPreviewProvider } from "./graph-trim-preview";
+import {
+  TrimPreviewProvider,
+  useTrimPreviewFrame,
+  useTrimPreviewStore,
+} from "./graph-trim-preview";
 import { GRID_GAP, TIMELINE_PPS } from "./graph-view-config";
 
 /**
@@ -2006,6 +2010,11 @@ export function PreviewShell({
   // owner of the state. Only reachable while open, so toggle IS close.
   const handleClose = useCallback(() => requestGraphPreviewToggle(), []);
 
+  // Owned HERE because both ends are here: the cards publish into it (through
+  // the provider below) and the pane reads it as a prop (PL14-006).
+  const trimStore = useTrimPreviewStore();
+  const trimFrame = useTrimPreviewFrame(trimStore);
+
   return (
     <TimelineDocumentsProvider initialState={initialDocumentsState}>
       {enabled ? <GatewayDocumentsBridge /> : null}
@@ -2026,6 +2035,11 @@ export function PreviewShell({
               playing={playing}
               onPlayingChange={channel.setPlaying}
               onClose={handleClose}
+              // A trim drag hands the pane a frame to draw (PL14-006). Not an
+              // overlay over the pane — the pane's own canvas, its own cached
+              // video, its own geometry. `currentTime` above is untouched
+              // throughout, which is what keeps the playhead where it was.
+              frameOverride={trimFrame}
               className="h-full rounded-b-none border-b-0"
             />
           ) : null
@@ -2034,14 +2048,10 @@ export function PreviewShell({
         {/* The playhead and scrub band live in `children`; they read these
             spans so their time↔x mapping is the pane's clock, not their own. */}
         <PreviewCardSpansContext.Provider value={cardSpans}>
-          {/* A trim drag borrows the pane's picture while the pane is OPEN
-              (PL14-006). The provider wraps `children` because that is where
-              the board — and therefore every trim handle — renders; the
-              overlay is a sibling because it draws over the pane above.
-              Neither touches the clock. */}
-          <TrimPreviewProvider previewOpen={enabled}>
+          {/* The board renders here, so every trim handle is inside this
+              provider and can publish the frame it wants shown. */}
+          <TrimPreviewProvider previewOpen={enabled} store={trimStore}>
             {children}
-            <TrimPreviewOverlay />
           </TrimPreviewProvider>
         </PreviewCardSpansContext.Provider>
       </WorkbenchSplitPane>

--- a/apps/timeline-gstudio001/components/graph-view/graph-trim-panel.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-trim-panel.tsx
@@ -160,15 +160,7 @@ export function TrimPanel({ id, node }: Readonly<{ id: NodeId; node: MediaNode }
   // returns true when the pane TOOK the frame, which is exactly when the
   // floating panel must stand down (PL14-006): one picture, not two.
   const takenByPreview = usePublishTrimPreview(
-    live !== null && isVideo && node.src
-      ? {
-          nodeId: id as string,
-          src: node.src,
-          poster: node.posterSrcs?.[0],
-          sourceTime,
-          side: live.side === "right" ? "right" : "left",
-        }
-      : null,
+    live !== null && isVideo ? { clipId: id as string, sourceTime } : null,
   );
 
   if (!isVideo) return null;

--- a/apps/timeline-gstudio001/components/graph-view/graph-trim-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-trim-preview.tsx
@@ -4,16 +4,10 @@ import {
   createContext,
   useContext,
   useEffect,
-  useLayoutEffect,
   useMemo,
-  useRef,
   useState,
   useSyncExternalStore,
 } from "react";
-import { createPortal } from "react-dom";
-
-import { useSeekedVideo } from "@/hooks/use-seeked-video";
-import { formatSeconds } from "@/lib/format-duration";
 
 // Where a trim drag's live frame is SHOWN (PL14-006).
 //
@@ -36,15 +30,20 @@ import { formatSeconds } from "@/lib/format-duration";
 // of the gesture. Release the handle and the overlay unmounts onto a pane that
 // never moved.
 
+/**
+ * Exactly what the pane needs to draw the frame, and nothing else.
+ *
+ * It carried `src`, `poster` and `side` while this was an overlay, because an
+ * overlay had to build its own `<video>`. The pane already has the clip — it is
+ * rendering that timeline — so an id and a source time is the whole request.
+ * Matches `WorkbenchDisplaySurface.frameOverride` field for field on purpose:
+ * this is that prop, in flight.
+ */
 export type TrimPreviewFrame = Readonly<{
-  nodeId: string;
-  src: string;
-  poster?: string;
+  /** The graph node id, which is the clip id in the pane's own list. */
+  clipId: string;
   /** SOURCE seconds — the frame the moving edge is currently on. */
   sourceTime: number;
-  /** Which edge is moving, so the overlay can wear the handle's amber bar on
-   *  the same side the panel would have. */
-  side: "left" | "right";
 }>;
 
 type TrimPreviewStore = Readonly<{
@@ -87,13 +86,33 @@ const INERT: TrimPreviewValue = {
 
 const TrimPreviewContext = createContext<TrimPreviewValue>(INERT);
 
+/**
+ * Own the store from the component that renders BOTH ends.
+ *
+ * It cannot live inside the provider: the pane is passed to the split pane as a
+ * `surface` PROP and needs the frame as a prop too, so the owner has to read
+ * the store and provide it in the same render. A provider that created it
+ * internally would be reachable from the cards and invisible to the pane.
+ */
+export function useTrimPreviewStore(): TrimPreviewStore {
+  const [store] = useState(createStore);
+  return store;
+}
+
+/** Subscribe to the live frame. For the owner, to hand to the pane. */
+export function useTrimPreviewFrame(store: TrimPreviewStore): TrimPreviewFrame | null {
+  return useSyncExternalStore(store.subscribe, store.get, () => null);
+}
+
 export function TrimPreviewProvider({
   previewOpen,
+  store,
   children,
-}: Readonly<{ previewOpen: boolean; children: React.ReactNode }>) {
-  const [store] = useState(createStore);
-  // The store is stable; only the open flag changes identity, and it changes
-  // rarely (a pane toggle), so this is not a per-frame allocation.
+}: Readonly<{
+  previewOpen: boolean;
+  store: TrimPreviewStore;
+  children: React.ReactNode;
+}>) {
   const value = useMemo<TrimPreviewValue>(
     () => ({ previewOpen, store }),
     [previewOpen, store],
@@ -140,72 +159,19 @@ export function usePublishTrimPreview(frame: TrimPreviewFrame | null): boolean {
   return taken;
 }
 
-/** The pane's picture area, which is what the overlay covers. */
-const CANVAS_SELECTOR = '[data-testid="workbench-display-canvas"]';
-
 /**
- * The trim frame, drawn over the preview pane's picture for the length of the
- * gesture.
+ * WHY THIS IS A FRAME REQUEST AND NOT AN OVERLAY.
  *
- * Positioned `fixed` against the canvas's measured rect rather than mounted
- * inside the pane. The pane is a package component with its own layout
- * (WorkbenchSplitPane sizes it, a divider drags it); slipping an absolutely
- * positioned child into it would make this feature a `packages/ui` change and
- * put a graph concern inside a generic surface. Measuring is the same
- * technique the floating panel already uses, and it leaves the package alone.
+ * The first version portalled a second `<video>` over the pane's rect. It
+ * looked right and was not: it decoded the file a second time instead of
+ * reusing the pane's cache, it left the pane's transport readout describing a
+ * different moment than its own picture, its CSS `object-contain` only
+ * approximated the canvas's draw math, and a playing pane went on playing
+ * invisibly underneath it. It also shipped a full version behind the pane's
+ * `z-40` — invisible — because covering something is a stacking problem that
+ * driving it does not have.
+ *
+ * Covering a component is not the same as driving it. The frame now goes to
+ * `WorkbenchDisplaySurface.frameOverride`, so the pane's OWN canvas draws it,
+ * from the element it already had cached.
  */
-export function TrimPreviewOverlay() {
-  const { store } = useTrimPreview();
-  const frame = useSyncExternalStore(store.subscribe, store.get, () => null);
-  const videoRef = useSeekedVideo(frame?.sourceTime ?? 0, frame !== null);
-  const boxRef = useRef<HTMLDivElement | null>(null);
-
-  useLayoutEffect(() => {
-    const box = boxRef.current;
-    if (!box || !frame) return;
-    const canvas = document.querySelector(CANVAS_SELECTOR);
-    if (!canvas) return;
-    const rect = canvas.getBoundingClientRect();
-    box.style.left = `${rect.left}px`;
-    box.style.top = `${rect.top}px`;
-    box.style.width = `${rect.width}px`;
-    box.style.height = `${rect.height}px`;
-  }, [frame]);
-
-  if (!frame) return null;
-
-  return createPortal(
-    <div
-      ref={boxRef}
-      data-trim-preview-overlay={frame.side}
-      aria-hidden="true"
-      // z-[60], the floating panel's level, and it has to be: the pane it
-      // covers is `sticky z-40`, so anything below that renders BEHIND the
-      // picture it is meant to replace — present, correctly sized, invisible.
-      className="pointer-events-none fixed z-[60] overflow-hidden bg-black"
-      style={{ left: -9999, top: -9999 }}
-    >
-      <video
-        ref={videoRef}
-        src={frame.src}
-        poster={frame.poster}
-        muted
-        playsInline
-        preload="auto"
-        className="h-full w-full bg-black object-contain"
-      />
-      {/* Same amber bar the floating panel wears, on the same edge — the two
-          presentations should read as one feature in two places. */}
-      <span
-        className={[
-          "absolute inset-y-0 w-1 bg-amber-400",
-          frame.side === "right" ? "right-0" : "left-0",
-        ].join(" ")}
-      />
-      <span className="absolute bottom-0 right-0 bg-zinc-950/85 px-1.5 py-0.5 font-mono text-xs leading-tight tabular-nums text-amber-200">
-        {formatSeconds(frame.sourceTime)}
-      </span>
-    </div>,
-    document.body,
-  );
-}

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -4561,41 +4561,26 @@ test.describe("graph view E2E", () => {
     await page.mouse.down();
     await page.mouse.move(box.x - 24, box.y + box.height / 2, { steps: 6 });
 
-    // The pane took it, and the floating panel stood down.
-    const overlay = page.locator('[data-trim-preview-overlay="right"]');
-    await expect(overlay).toHaveCount(1);
+    // The PANE was asked for the frame, and the floating panel stood down.
+    // There is no second element anywhere: the pane's own canvas draws this,
+    // from the video element it already had cached.
+    const surface = page.getByTestId("workbench-display-surface");
+    await expect(surface).toHaveAttribute("data-frame-override", "alpha");
     await expect(page.locator("[data-trim-edge-frame]")).toHaveCount(0);
+    await expect(page.locator("[data-trim-preview-overlay]")).toHaveCount(0);
 
-    // It covers the pane's picture — this is the preview showing the frame,
-    // not a panel that happens to be nearby.
-    const overlayBox = (await overlay.boundingBox())!;
-    const canvasBox = (await canvas.boundingBox())!;
-    expect(overlayBox.x).toBeCloseTo(canvasBox.x, 0);
-    expect(overlayBox.y).toBeCloseTo(canvasBox.y, 0);
-    expect(overlayBox.width).toBeCloseTo(canvasBox.width, 0);
-    expect(overlayBox.height).toBeCloseTo(canvasBox.height, 0);
-
-    // …and it is ON TOP of the pane, which the box assertions above cannot
-    // tell you. That is exactly how this shipped broken the first time: the
-    // overlay was z-30 against the pane's `sticky z-40`, so it sat at these
-    // coordinates, at this size, BEHIND the picture it was meant to replace —
-    // every assertion above passed and the feature did nothing.
+    // WHAT THIS DOES NOT PROVE, stated so nobody reads more into it: that the
+    // canvas is painting the right frame. Which pixels a canvas holds is not
+    // readable back, and this fixture's "video" is a 1x1 GIF data URL that
+    // never reaches HAVE_CURRENT_DATA — no frame decodes here at all. The
+    // attribute pins the REQUEST reaching the pane; the drawing is the pane's
+    // existing, already-covered path (`syncActiveVideo` → `drawActiveFrame`),
+    // and the picture itself needs a human with a real video.
     //
-    // Compared numerically rather than hit-tested, because the overlay is
-    // `pointer-events-none` and is therefore invisible to `elementFromPoint`.
-    // Both live in the body stacking context, so the raw values are
-    // comparable.
-    const stacking = await page.evaluate(() => {
-      const overlay = document.querySelector("[data-trim-preview-overlay]");
-      const region = document.querySelector('[data-testid="workbench-preview-region"]');
-      if (!overlay || !region) return null;
-      return {
-        overlay: Number(getComputedStyle(overlay).zIndex),
-        region: Number(getComputedStyle(region).zIndex),
-      };
-    });
-    expect(stacking).not.toBeNull();
-    expect(stacking!.overlay).toBeGreaterThan(stacking!.region);
+    // An earlier version of this test asserted an overlay's bounding box
+    // matched the canvas's, which passed while the overlay sat BEHIND the pane
+    // at z-30. Geometry is not visibility, and a witness that says "asked" is
+    // worth more than one that says "positioned".
 
     // THE constraint carried over from round 5: the clock does not move while
     // the pane is borrowed. Asserted DURING the gesture, which is the only
@@ -4605,8 +4590,9 @@ test.describe("graph view E2E", () => {
     expect(await page.getByTestId("workbench-preview-time").textContent()).toBe(timeBefore);
 
     await page.mouse.up();
-    // Released, the pane goes back to being the pane.
-    await expect(overlay).toHaveCount(0);
+    // Released, the pane goes back to being the pane — the override clears and
+    // the clock owns the picture again.
+    await expect(surface).not.toHaveAttribute("data-frame-override", /.*/);
     await expect(canvas).toBeVisible();
   });
 

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -72,6 +72,26 @@ type WorkbenchDisplaySurfaceProps = {
    *  corner. Omit and no button is drawn — a consumer that has no way to hide
    *  the preview must not show one. */
   onClose?: () => void;
+  /**
+   * Draw THIS frame instead of the one the clock is on, for as long as it is
+   * set. Null (the default) means the clock decides, which is every existing
+   * consumer.
+   *
+   * Exists for gestures that are about a frame rather than a moment — trimming
+   * being the one that asked for it: the user is choosing an in/out point, and
+   * the answer to "what does that point look like" belongs on the biggest
+   * picture available rather than in a thumbnail floated next to the handle.
+   *
+   * `sourceTime` is in SOURCE seconds, not timeline seconds, and that is the
+   * point: mid-drag the clip's own trim values are still the committed ones, so
+   * a timeline time would map through stale trims. The caller knows the source
+   * frame it wants; this draws it.
+   *
+   * The CLOCK IS NOT TOUCHED. `currentTime` keeps its value, `onCurrentTimeChange`
+   * is not called, and clearing this redraws whatever the clock was always on.
+   * A consumer cannot move the playhead through this prop, by construction.
+   */
+  frameOverride?: Readonly<{ clipId: string; sourceTime: number }> | null;
 };
 
 const BUFFER_WINDOW_SIZE = 4;
@@ -245,6 +265,33 @@ type GetCollectionClipFramePreview = (
   parentPlaybackRate?: number,
 ) => CollectionFramePreview | null;
 
+/**
+ * The media for an explicit SOURCE frame, bypassing the clock (`frameOverride`).
+ *
+ * Video only — an image has one frame and a collection has no source of its
+ * own, so neither has a frame to be asked for.
+ *
+ * The `key` is byte-identical to the one `resolveClipMedia` builds for the same
+ * clip, and that is deliberate rather than incidental: it lands on the SAME
+ * cache entry, so an override seeks the element the pane is already holding
+ * instead of loading a second copy of the file.
+ */
+function resolveOverrideMedia(clip: TimelineClip, sourceTime: number): DisplayMedia | null {
+  if (clip.kind !== "video") return null;
+  return {
+    key: `${clip.id}:video:${clip.src}`,
+    kind: "video",
+    src: clip.src,
+    poster: clip.poster,
+    alt: clip.alt,
+    sourceTime: clamp(sourceTime, 0, Math.max(0, clip.sourceDuration - 0.001)),
+    // Unused for drawing; the clock is not involved in an override.
+    timelineTime: 0,
+    clipTitle: clipLabel(clip),
+    playbackRate: 1,
+  };
+}
+
 function resolveClipMedia(
   clip: TimelineClip,
   timelineTime: number,
@@ -371,6 +418,7 @@ export function WorkbenchDisplaySurface({
   playing,
   onPlayingChange,
   onClose,
+  frameOverride = null,
 }: WorkbenchDisplaySurfaceProps) {
   const { getCollectionClipFramePreview } = useTimelineDocuments();
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -567,6 +615,8 @@ export function WorkbenchDisplaySurface({
     }
   }, [drawDrawable, drawEmptyFrame]);
 
+  const frameOverrideRef = useRef(frameOverride);
+
   const pauseInactiveVideos = useCallback((activeKey: string | null) => {
     cacheRef.current.forEach((cached, key) => {
       if (cached.kind === "video" && key !== activeKey) {
@@ -627,6 +677,12 @@ export function WorkbenchDisplaySurface({
   }, [drawActiveFrame, ensureCachedMedia]);
 
   const renderFrameAtTime = useCallback((timelineTime: number, shouldPlay: boolean, forceSeek = false) => {
+    // An override owns the picture while it is set. Guarding HERE rather than
+    // at each caller is what makes that true of all of them at once — the
+    // `currentTime` effect, the clip-list effect, and the playback loop all
+    // arrive through this function, and any one of them repainting mid-gesture
+    // would flick the frame back to the clock's.
+    if (frameOverrideRef.current !== null) return;
     const active = getActiveClip(sortedClipsRef.current, timelineTime, preferredClipId);
     const media = active
       ? resolveClipMedia(active, timelineTime, getCollectionClipFramePreview)
@@ -681,6 +737,51 @@ export function WorkbenchDisplaySurface({
     observer.observe(canvas);
     return () => observer.disconnect();
   }, [drawActiveFrame]);
+
+  /**
+   * Apply (and release) `frameOverride` — the pane's own canvas drawing a frame
+   * the clock is not on.
+   *
+   * Every video is paused for the duration. The override is a still: leaving
+   * the previously active element running would have it advancing behind a
+   * picture that is not it, which is the mistake the first version of this
+   * feature made from the outside with an overlay.
+   *
+   * Releasing repaints from `currentTime` — unchanged throughout, because
+   * nothing here writes it — so the pane lands back exactly where it was, with
+   * whatever play state it actually has.
+   */
+  useEffect(() => {
+    frameOverrideRef.current = frameOverride;
+
+    if (frameOverride === null) {
+      renderFrameAtTime(currentTimeRef.current, isPlayingRef.current, true);
+      return;
+    }
+
+    const clip = sortedClipsRef.current.find((candidate) => candidate.id === frameOverride.clipId);
+    const media = clip ? resolveOverrideMedia(clip, frameOverride.sourceTime) : null;
+    if (!media) {
+      // Nothing to draw for this request (missing clip, or a kind with no
+      // source frame). Hand the picture back to the clock rather than freezing
+      // on a stale frame.
+      frameOverrideRef.current = null;
+      return;
+    }
+
+    activeMediaRef.current = media;
+    lastRenderedMediaKeyRef.current = media.key;
+    activeClipDisabledRef.current = false;
+    pauseInactiveVideos(null);
+    ensureCachedMedia(media);
+    syncActiveVideo(media, false, true);
+  }, [
+    ensureCachedMedia,
+    frameOverride,
+    pauseInactiveVideos,
+    renderFrameAtTime,
+    syncActiveVideo,
+  ]);
 
   useEffect(() => {
     bufferedMedia.forEach((media) => {
@@ -871,6 +972,12 @@ export function WorkbenchDisplaySurface({
       data-testid="workbench-display-surface"
       data-buffered-media-count={bufferedMedia.length}
       data-preview-playing={isPlaying}
+      // Which clip's frame the pane is drawing INSTEAD of the clock's, if any.
+      // A witness, because the alternative is unobservable: whether a canvas
+      // holds one decoded frame or another is not something a test can read
+      // back, and the e2e fixture's "video" is a 1x1 GIF that never decodes at
+      // all. This at least pins that the request reached the pane.
+      data-frame-override={frameOverride ? frameOverride.clipId : undefined}
     >
       <div className="relative min-h-0 flex-1 overflow-hidden rounded-[inherit] bg-black">
         <canvas

--- a/punch-list/PUNCH-LIST-14.md
+++ b/punch-list/PUNCH-LIST-14.md
@@ -253,29 +253,49 @@ Done when: with the preview open, dragging a trim handle updates the preview
 surface and no overlay appears; with the preview closed, the overlay behaves
 exactly as today; the playhead does not move in either case.
 
-### It shipped invisible first — the fix, and the test that should have caught it
+### It shipped as a FACADE first, twice wrong
 
-The first version was **z-30 against the pane's `sticky z-40`**, so the overlay
-mounted at the right coordinates, at the right size, BEHIND the picture it was
-meant to replace. The suppression half worked, so the symptom was the worst
-kind: the floating panel correctly disappeared when the pane was open, and
-nothing took its place. Reported by the owner. Now `z-[60]`, the floating
-panel's own level.
+Two corrections, both reported by the owner, and the second is the one that
+matters.
 
-**The test passed against it**, and the reason generalizes: it asserted the
-overlay's bounding box matched the canvas's, and `boundingBox()` returns
-geometry regardless of occlusion. Geometry is not visibility. It now also
-compares the overlay's computed `z-index` against the preview region's and
-requires it to be higher — which fails with `Expected: > 40, Received: 30`
-against the broken version.
+**1. Invisible.** The first version was z-30 against the pane's `sticky z-40`,
+so it mounted at the right coordinates, at the right size, behind the picture
+it was meant to replace. The test asserted its bounding box matched the
+canvas's and passed — `boundingBox()` returns geometry regardless of occlusion.
+Geometry is not visibility.
 
-Hit-testing with `elementFromPoint` would have been the more direct check and
-does NOT work here: the overlay is `pointer-events-none`, so it is not
-hit-testable and the API never returns it.
+**2. It was an overlay at all.** Fixing the z-index made a facade visible
+rather than making the feature right. It was a SECOND `<video>` portalled over
+the pane; the pane's own canvas never learned a trim was happening. The owner
+asked directly whether that was what it was, and it was.
 
-That is twice in this punch list (see PL14-004) that a test was non-vacuous,
-passed, and still missed the defect — both times by measuring a mechanism that
-was working rather than the outcome the user looks at.
+What that actually cost, beyond the principle:
+
+- a second decode of the same file, bypassing the pane's media cache
+- the pane's transport readout describing a different moment than its own
+  picture
+- CSS `object-contain` only approximating the canvas's letterboxing math
+- a playing pane going on playing, invisibly, underneath the still
+
+**The real implementation is a prop.** `WorkbenchDisplaySurface` gained
+`frameOverride?: {clipId, sourceTime} | null`: the pane's own canvas draws that
+frame, from the element it already had cached, with its own geometry. Guarded
+in `renderFrameAtTime` — one place, so the `currentTime` effect, the clip-list
+effect and the playback loop all defer to it at once — and every video is
+paused for the duration, since an override is a still.
+
+`sourceTime` is in SOURCE seconds deliberately: mid-drag the clip's committed
+trims are stale, so a timeline time would map through the wrong values.
+
+The clock is untouched by construction — the prop cannot reach `currentTime`,
+so a consumer cannot move the playhead through it.
+
+**What the e2e does NOT prove**, recorded because it would be easy to assume
+otherwise: that the canvas paints the right frame. Canvas pixels are not
+readable back, and the fixture's "video" is a 1x1 GIF that never decodes. The
+test pins that the request reaches the pane (`data-frame-override`) and that
+the floating panel stands down; the picture itself needs a human with a real
+video.
 
 ## PL14-007 — Right-click context menu on an item
 


### PR DESCRIPTION
The previous version was a facade, and you were right to ask.

A second `<video>` was portalled over the pane's rect. The pane's own canvas never learned a trim was happening — it kept drawing the playhead's frame underneath, hidden.

## What the overlay actually cost

Beyond the principle, four things — the last two I only found while writing this up:

- **A second decode.** The surface keeps a media cache keyed per clip; the overlay bypassed it and loaded the same file again.
- **The pane's chrome disagreed with its picture.** The transport readout showed the playhead's time while the image showed the trim frame.
- **Geometry only approximated.** CSS `object-contain` on a raw `<video>` versus the canvas's own letterboxing math.
- **A playing pane kept playing underneath**, invisibly, behind a still.

## The real implementation

`WorkbenchDisplaySurface` gains:

```ts
frameOverride?: Readonly<{ clipId: string; sourceTime: number }> | null
```

The pane's **own canvas** draws that frame, from the element it already had cached. The override media's cache key is byte-identical to the one normal playback builds for that clip — that identity is what makes it the same element rather than a second one.

Guarded inside `renderFrameAtTime`: one place, so the `currentTime` effect, the clip-list effect and the playback loop all defer to it at once instead of each needing to know. Every video is paused for the duration, because an override is a still.

`sourceTime` is in **source** seconds deliberately — mid-drag the clip's committed trims are stale, so a timeline time would map through the wrong values.

**The clock is now untouched by construction, not by discipline.** The prop has no path to `currentTime`, so a consumer cannot move the playhead through it even by accident.

## What the test does not prove

Said plainly, because it would be easy to assume otherwise: it does **not** prove the canvas paints the right frame. Canvas pixels aren't readable back, and this fixture's "video" is a 1×1 GIF data URL that never reaches `HAVE_CURRENT_DATA` — nothing decodes in the harness at all.

The test pins that the request reaches the pane (`data-frame-override`) and that the floating panel stands down. The picture itself needs a human with a real video.

## Second correction on this item

The first shipped it **invisible** — z-30 behind the pane's `sticky z-40` — and the test passed because it asserted a bounding box, which is returned regardless of occlusion. Fixing the z-index made a facade visible rather than making the feature right; this makes it right.

| | |
|---|---|
| App vitest | 508 passed |
| Unit | 408 passed |
| Storybook | 164 passed |
| graph-view e2e | 100 passed |
| Typecheck | clean, both workspaces |
| Lint | 0 errors (5 pre-existing `<img>` warnings) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)