### PR TITLE
PL14-006: address the frame by src, not clip id — it was inert in the app

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-trim-panel.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-trim-panel.tsx
@@ -160,7 +160,9 @@ export function TrimPanel({ id, node }: Readonly<{ id: NodeId; node: MediaNode }
   // returns true when the pane TOOK the frame, which is exactly when the
   // floating panel must stand down (PL14-006): one picture, not two.
   const takenByPreview = usePublishTrimPreview(
-    live !== null && isVideo ? { clipId: id as string, sourceTime } : null,
+    live !== null && isVideo && node.src
+      ? { src: node.src, poster: node.posterSrcs?.[0], sourceTime }
+      : null,
   );
 
   if (!isVideo) return null;

--- a/apps/timeline-gstudio001/components/graph-view/graph-trim-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-trim-preview.tsx
@@ -40,8 +40,12 @@ import {
  * this is that prop, in flight.
  */
 export type TrimPreviewFrame = Readonly<{
-  /** The graph node id, which is the clip id in the pane's own list. */
-  clipId: string;
+  /** The media SOURCE. Not a clip id: the pane plays either the focused
+   *  level's projection (ids are node ids) or the compiled manifest (ids are
+   *  path-qualified), so an id matches in one model and misses in the other.
+   *  A src is the same string in both. */
+  src: string;
+  poster?: string;
   /** SOURCE seconds — the frame the moving edge is currently on. */
   sourceTime: number;
 }>;

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -4565,7 +4565,7 @@ test.describe("graph view E2E", () => {
     // There is no second element anywhere: the pane's own canvas draws this,
     // from the video element it already had cached.
     const surface = page.getByTestId("workbench-display-surface");
-    await expect(surface).toHaveAttribute("data-frame-override", "alpha");
+    await expect(surface).toHaveAttribute("data-frame-override", PIXEL);
     await expect(page.locator("[data-trim-edge-frame]")).toHaveCount(0);
     await expect(page.locator("[data-trim-preview-overlay]")).toHaveCount(0);
 

--- a/packages/ui/timeline/viewport/frame-override.test.ts
+++ b/packages/ui/timeline/viewport/frame-override.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import type { TimelineClip } from "../types";
+import { resolveOverrideMedia } from "./workbench-display-surface";
+
+// PL14-006. `frameOverride` asks the pane to draw a specific SOURCE frame, and
+// the only interesting question is how that request finds its media.
+//
+// It shipped matching on CLIP ID and did nothing in a real project. The pane
+// plays one of two models and their ids do not agree:
+//
+//   projection (focused level) → clip.id IS the graph node id
+//   manifest   (compiled, nested) → clip.id is `collectionPath:leafId`,
+//                                   because leaf ids repeat across documents
+//
+// The e2e fixture never lands a manifest, so it exercised the projection alone
+// and passed while the feature was dead in the app. These cases are the pair
+// the e2e could not be.
+
+const VIDEO_SRC = "https://cdn.test/take-1.mp4";
+
+function videoClip(id: string, src = VIDEO_SRC): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "video",
+    src,
+    poster: `${src}.jpg`,
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 6,
+    sourceDuration: 8,
+    trimIn: 0,
+    trimOut: 2,
+  } as TimelineClip;
+}
+
+const request = { src: VIDEO_SRC, sourceTime: 3.5 };
+
+describe("resolveOverrideMedia", () => {
+  it("reuses the pane's cache key when the source is on screen (projection ids)", () => {
+    const media = resolveOverrideMedia([videoClip("alpha")], request);
+    // Byte-identical to what resolveClipMedia builds for that clip, which is
+    // what makes this seek the already-cached element instead of loading a
+    // second copy of the file.
+    expect(media.key).toBe(`alpha:video:${VIDEO_SRC}`);
+    expect(media.sourceTime).toBe(3.5);
+  });
+
+  it("REGRESSION: resolves against MANIFEST ids, which are path-qualified", () => {
+    // The shape that broke it. Matching on id would miss this entirely and the
+    // pane would draw nothing — silently, because a miss is indistinguishable
+    // from "no override".
+    const media = resolveOverrideMedia(
+      [videoClip("scene-a/take-1:alpha"), videoClip("scene-b:beta", "https://cdn.test/other.mp4")],
+      request,
+    );
+    expect(media.key).toBe(`scene-a/take-1:alpha:video:${VIDEO_SRC}`);
+    expect(media.src).toBe(VIDEO_SRC);
+  });
+
+  it("still draws a source the pane is not currently showing", () => {
+    // A miss is not a failure: the request carries its own src, so it resolves
+    // to a private key rather than returning null. The earlier version treated
+    // "no matching clip" as "nothing to draw".
+    const media = resolveOverrideMedia([videoClip("unrelated", "https://cdn.test/x.mp4")], request);
+    expect(media.key).toBe(`frame-override:video:${VIDEO_SRC}`);
+    expect(media.src).toBe(VIDEO_SRC);
+  });
+
+  it("does not clamp against the clip's sourceDuration", () => {
+    // The manifest SYNTHESIZES sourceDuration per leaf (sourceStart + range),
+    // so clamping to it would cut a legitimate frame off a trim. The element's
+    // own duration is the real bound and syncActiveVideo already clamps there.
+    const media = resolveOverrideMedia([videoClip("alpha")], { src: VIDEO_SRC, sourceTime: 99 });
+    expect(media.sourceTime).toBe(99);
+  });
+
+  it("floors a negative request at zero", () => {
+    const media = resolveOverrideMedia([videoClip("alpha")], { src: VIDEO_SRC, sourceTime: -4 });
+    expect(media.sourceTime).toBe(0);
+  });
+
+  it("ignores same-src clips of another kind", () => {
+    const image = { ...videoClip("img"), kind: "image" } as TimelineClip;
+    const media = resolveOverrideMedia([image, videoClip("vid")], request);
+    expect(media.key).toBe(`vid:video:${VIDEO_SRC}`);
+  });
+});

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -87,11 +87,19 @@ type WorkbenchDisplaySurfaceProps = {
    * a timeline time would map through stale trims. The caller knows the source
    * frame it wants; this draws it.
    *
+   * Addressed by `src` rather than by clip id, which is the correction that
+   * made this work at all. The pane plays one of TWO models — the focused
+   * level's projection, whose clip ids are graph node ids, or the compiled
+   * manifest, whose ids are path-qualified (`path/to:leafId`) precisely
+   * because leaf ids repeat across documents. A clip id is therefore not a
+   * stable handle across the boundary; the source URL is, and it is what the
+   * media cache is really about.
+   *
    * The CLOCK IS NOT TOUCHED. `currentTime` keeps its value, `onCurrentTimeChange`
    * is not called, and clearing this redraws whatever the clock was always on.
    * A consumer cannot move the playhead through this prop, by construction.
    */
-  frameOverride?: Readonly<{ clipId: string; sourceTime: number }> | null;
+  frameOverride?: Readonly<{ src: string; poster?: string; sourceTime: number }> | null;
 };
 
 const BUFFER_WINDOW_SIZE = 4;
@@ -268,26 +276,41 @@ type GetCollectionClipFramePreview = (
 /**
  * The media for an explicit SOURCE frame, bypassing the clock (`frameOverride`).
  *
- * Video only — an image has one frame and a collection has no source of its
- * own, so neither has a frame to be asked for.
+ * Matched on `src`, NOT on clip id, and that is the whole correctness of it.
+ * The pane plays one of two models: the focused level's projection, whose clip
+ * ids are graph node ids, or the compiled manifest, whose ids are
+ * `collectionPath:leafId` because leaf ids repeat across documents. An id from
+ * outside therefore matches in one model and silently misses in the other —
+ * which is exactly how this shipped: it worked against the projection the
+ * e2e fixture uses and did nothing in a real project, where the manifest wins.
  *
- * The `key` is byte-identical to the one `resolveClipMedia` builds for the same
- * clip, and that is deliberate rather than incidental: it lands on the SAME
- * cache entry, so an override seeks the element the pane is already holding
- * instead of loading a second copy of the file.
+ * Finding the clip is only for the CACHE KEY: matching one makes the key
+ * byte-identical to `resolveClipMedia`'s, so the override seeks the element
+ * the pane is already holding rather than loading a second copy. Nothing else
+ * is taken from it — notably not `sourceDuration`, which the manifest
+ * synthesizes per leaf and would clamp against the wrong range. The element's
+ * own duration is the real bound and `syncActiveVideo` already clamps to it.
  */
-function resolveOverrideMedia(clip: TimelineClip, sourceTime: number): DisplayMedia | null {
-  if (clip.kind !== "video") return null;
+export function resolveOverrideMedia(
+  clips: readonly TimelineClip[],
+  override: Readonly<{ src: string; poster?: string; sourceTime: number }>,
+): DisplayMedia {
+  const match = clips.find(
+    (clip): clip is Extract<TimelineClip, { kind: "video" }> =>
+      clip.kind === "video" && clip.src === override.src,
+  );
   return {
-    key: `${clip.id}:video:${clip.src}`,
+    // Same key as normal playback when the source is on screen; a stable
+    // private one when it is not, so an off-screen source still draws.
+    key: match ? `${match.id}:video:${match.src}` : `frame-override:video:${override.src}`,
     kind: "video",
-    src: clip.src,
-    poster: clip.poster,
-    alt: clip.alt,
-    sourceTime: clamp(sourceTime, 0, Math.max(0, clip.sourceDuration - 0.001)),
+    src: override.src,
+    poster: override.poster ?? match?.poster,
+    alt: match?.alt ?? "",
+    sourceTime: Math.max(0, override.sourceTime),
     // Unused for drawing; the clock is not involved in an override.
     timelineTime: 0,
-    clipTitle: clipLabel(clip),
+    clipTitle: match ? clipLabel(match) : "",
     playbackRate: 1,
   };
 }
@@ -759,15 +782,12 @@ export function WorkbenchDisplaySurface({
       return;
     }
 
-    const clip = sortedClipsRef.current.find((candidate) => candidate.id === frameOverride.clipId);
-    const media = clip ? resolveOverrideMedia(clip, frameOverride.sourceTime) : null;
-    if (!media) {
-      // Nothing to draw for this request (missing clip, or a kind with no
-      // source frame). Hand the picture back to the clock rather than freezing
-      // on a stale frame.
-      frameOverrideRef.current = null;
-      return;
-    }
+    // Always resolvable: the request carries its own `src`, so a source the
+    // pane is not currently showing still draws. Matching a clip is an
+    // optimisation (cache reuse), never a precondition — the earlier version
+    // treated a lookup miss as "nothing to draw" and silently did nothing,
+    // which is precisely what a path-qualified manifest id produced.
+    const media = resolveOverrideMedia(sortedClipsRef.current, frameOverride);
 
     activeMediaRef.current = media;
     lastRenderedMediaKeyRef.current = media.key;
@@ -977,7 +997,7 @@ export function WorkbenchDisplaySurface({
       // holds one decoded frame or another is not something a test can read
       // back, and the e2e fixture's "video" is a 1x1 GIF that never decodes at
       // all. This at least pins that the request reached the pane.
-      data-frame-override={frameOverride ? frameOverride.clipId : undefined}
+      data-frame-override={frameOverride ? frameOverride.src : undefined}
     >
       <div className="relative min-h-0 flex-1 overflow-hidden rounded-[inherit] bg-black">
         <canvas

--- a/punch-list/PUNCH-LIST-14.md
+++ b/punch-list/PUNCH-LIST-14.md
@@ -290,12 +290,48 @@ trims are stale, so a timeline time would map through the wrong values.
 The clock is untouched by construction — the prop cannot reach `currentTime`,
 so a consumer cannot move the playhead through it.
 
-**What the e2e does NOT prove**, recorded because it would be easy to assume
-otherwise: that the canvas paints the right frame. Canvas pixels are not
-readable back, and the fixture's "video" is a 1x1 GIF that never decodes. The
-test pins that the request reaches the pane (`data-frame-override`) and that
-the floating panel stands down; the picture itself needs a human with a real
-video.
+**Then it was dead in the app anyway — the third correction.** The prop
+addressed the frame by CLIP ID, and a clip id is not a stable handle here. The
+pane plays one of two models: the focused level's projection, whose ids are
+graph node ids, or the compiled manifest, whose ids are
+`collectionPath:leafId` (path-qualified because leaf ids repeat across
+documents). The lookup matched the projection and missed the manifest — and the
+manifest is what a settled real project plays. A miss was treated as "nothing
+to draw", so it failed silently.
+
+It is addressed by `src` now, which is the same string in both models and is
+what the media cache is really about. Finding a clip is an OPTIMISATION (it
+makes the cache key byte-identical to normal playback's, so the override seeks
+the element the pane already holds) and never a precondition — a source the
+pane is not currently showing still draws, under a private key.
+
+Nothing else is taken from the matched clip, notably not `sourceDuration`: the
+manifest synthesizes that per leaf, so clamping to it would cut real frames off
+a trim. The element's own duration is the true bound and `syncActiveVideo`
+already clamps there.
+
+**Why the e2e could not catch it, and what does.** The fixture never lands a
+manifest, so the e2e exercises the projection alone — it passed against a
+feature that did nothing in the app. `frame-override.test.ts` is the pair it
+could not be: six unit cases over `resolveOverrideMedia`, including a
+manifest-shaped id list. Reverting to id matching fails the manifest case.
+
+The e2e still cannot prove the canvas paints the right frame — canvas pixels
+are not readable back and the fixture's "video" is a 1x1 GIF that never
+decodes. It pins that the request reaches the pane and that the floating panel
+stands down. The picture needs a human with a real video.
+
+### Three corrections on one item
+
+Worth counting, because they rhyme: shipped invisible (z-30 behind the pane's
+z-40, and the test asserted a bounding box, which is returned regardless of
+occlusion); shipped as a facade (an overlay covering the pane rather than
+driving it); shipped inert (matching on an id whose shape depends on which
+playback model is live, verified only against the model the fixture uses).
+
+Every one passed its tests. Every one was caught by the owner using the app.
+The common thread is testing the mechanism against the harness's happy path
+instead of the outcome against reality.
 
 ## PL14-007 — Right-click context menu on an item
 


### PR DESCRIPTION
The pane was being asked for a frame by **clip id**, and a clip id is not a stable handle at that boundary.

The pane plays one of two models:

| model | `clip.id` |
|---|---|
| projection (focused level) | the graph node id |
| manifest (compiled, nested) | `collectionPath:leafId` — path-qualified, because leaf ids repeat across documents |

The lookup matched the projection and missed the manifest. **A settled real project plays the manifest.** And a miss was treated as "nothing to draw", so it failed silently — exactly what you saw.

## The fix

Addressed by `src`: the same string in both models, and what the media cache is really keyed on anyway.

Finding a clip is now an **optimisation**, not a precondition — it makes the cache key byte-identical to normal playback's, so the override seeks the element the pane already holds. A source the pane is *not* currently showing still draws, under a private key.

Nothing else is taken from the matched clip, notably **not `sourceDuration`**: the manifest synthesizes that per leaf (`sourceStart + range`), so clamping to it would cut real frames off a trim. The element's own duration is the true bound, and `syncActiveVideo` already clamps there.

## Why the e2e couldn't catch this

The fixture never lands a manifest, so the e2e exercises the projection alone. It passed against a feature that was dead in the app.

`frame-override.test.ts` is the pair it couldn't be — six unit cases over `resolveOverrideMedia`:

- projection ids → reuses the pane's exact cache key
- **manifest ids → resolves** (this is the regression; reverting to id matching fails it)
- a source the pane isn't showing → still draws
- no clamping against a synthesized `sourceDuration`
- negative request floored at zero
- same-`src` clips of another kind ignored

The e2e still cannot prove the canvas paints the right frame. Canvas pixels aren't readable back and the fixture's "video" is a 1×1 GIF that never decodes. It pins that the request reaches the pane and that the floating panel stands down.

## Third correction on this item

Worth counting, because they rhyme:

1. **Shipped invisible** — z-30 behind the pane's `sticky z-40`. The test asserted a bounding box, which is returned regardless of occlusion.
2. **Shipped as a facade** — an overlay covering the pane rather than driving it.
3. **Shipped inert** — an id whose shape depends on which playback model is live, verified only against the model the fixture uses.

Each passed its tests. Each was caught by you using the app. The common thread is testing the mechanism against the harness's happy path instead of the outcome against reality.

| | |
|---|---|
| App vitest | 514 passed |
| Unit | 414 passed (6 new) |
| Storybook | 164 passed |
| graph-view e2e | 100 passed |
| Typecheck | clean, both workspaces |
| Lint | 0 errors (5 pre-existing `<img>` warnings) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)