### PR TITLE
PL14-012: Ctrl+Arrows trim by a tenth of a second

### DIFF
--- a/packages/ui/dnd-collections/VirtualStrip.stories.tsx
+++ b/packages/ui/dnd-collections/VirtualStrip.stories.tsx
@@ -1386,6 +1386,71 @@ export const KeyboardTrim: Story = {
   },
 };
 
+export const FineKeyboardTrim: Story = {
+  // PL14-012. CTRL+Arrows are the same four trims at a TENTH the step — the
+  // fine control for landing an edge a second cannot reach.
+  //
+  // Its own chord rather than a modifier on Alt+Shift+Arrow, which would have
+  // made it a four-key combination nobody performs. Ctrl was available: the
+  // keyboard controller used to reject a held Ctrl on its first line.
+  render: () => (
+    <DndCollections initialGraph={trimGraph()} animateMoves={false}>
+      <div className="flex w-[640px] flex-col gap-2">
+        <UndoRedoControls />
+        <VirtualStrip
+          collectionId={parseNodeId("strip")}
+          itemWidthFor={(node) =>
+            node.kind === "media" ? mediaDurationSeconds(node) * TRIM_PPS : undefined
+          }
+          trimPixelsPerSecond={TRIM_PPS}
+        />
+      </div>
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const user = userEvent.setup();
+    const width = (id: string) =>
+      Math.round(nodeCard(canvasElement, id).getBoundingClientRect().width);
+
+    const img = nodeCard(canvasElement, "img");
+    await waitForLayout(img);
+    expect(width("img")).toBe(96); // 4s at 24px/s
+
+    // TEN presses = ONE Alt+Shift press. That equality is the assertion: at a
+    // 1s step these would add ten seconds and land at 336px, so reaching 120px
+    // is what proves the step is a tenth.
+    await user.click(img);
+    for (let step = 0; step < 10; step += 1) {
+      await user.keyboard("{Control>}{ArrowRight}{/Control}");
+    }
+    await waitFor(() => expect(width("img")).toBe(120));
+
+    // And back the other way.
+    for (let step = 0; step < 10; step += 1) {
+      await user.keyboard("{Control>}{ArrowLeft}{/Control}");
+    }
+    await waitFor(() => expect(width("img")).toBe(96));
+
+    // The video's START edge answers to the vertical pair, same grammar as
+    // Alt+Shift — one fine trim is one command, so ten are ten undo steps.
+    const vid = nodeCard(canvasElement, "vid");
+    await user.click(vid);
+    expect(width("vid")).toBe(240); // 10s
+    for (let step = 0; step < 5; step += 1) {
+      await user.keyboard("{Control>}{ArrowUp}{/Control}");
+    }
+    await waitFor(() => expect(width("vid")).toBe(228)); // 9.5s
+
+    // A held Shift is the COARSE chord, not this one — Ctrl+Shift+Arrow is
+    // neither, and must fall through untouched rather than trimming by either
+    // step.
+    await user.keyboard("{Control>}{Shift>}{ArrowUp}{/Shift}{/Control}");
+    expect(width("vid")).toBe(228);
+    expect(canvas.queryByText(/images can only be trimmed at the end/i)).toBeNull();
+  },
+};
+
 // Phase B fixture: a strip WIDE enough to scroll (needed for the right-edge
 // anchor — a left-handle drag grows the item and shifts scrollLeft to hold
 // the right edge, which only has room on a scrollable strip), with a video at

--- a/packages/ui/dnd-collections/react/use-keyboard-controller.ts
+++ b/packages/ui/dnd-collections/react/use-keyboard-controller.ts
@@ -86,6 +86,24 @@ const TRIM_ACTION_BY_KEY: Readonly<Record<string, KeyboardTrimAction | undefined
 /** One keypress = one second, clamped by the reducer exactly like a drag. */
 const TRIM_STEP_SECONDS = 1;
 
+// CTRL+Arrows are the same four trims at a TENTH the step (PL14-012) — the
+// fine control you reach for when a second is too coarse to land an edge.
+//
+// Its own chord rather than a modifier on the existing one, because the
+// existing one is already Alt+Shift+Arrow and Alt+Shift+Ctrl+Arrow is not a
+// keystroke anyone performs. Ctrl was free here: this handler used to reject a
+// held Ctrl outright on its first line.
+//
+// Same actions, same directions, so there is one grammar to learn and the fine
+// version is not a different feature — horizontal is the end edge every media
+// has, vertical is the video start edge.
+const FINE_TRIM_ACTION_BY_KEY = TRIM_ACTION_BY_KEY;
+
+/** A tenth of the Alt+Shift step. Sub-frame at 24fps, which is the point: the
+ *  reducer clamps it exactly like a drag, so the floor is the media's, not
+ *  this constant's. */
+const FINE_TRIM_STEP_SECONDS = 0.1;
+
 // Alt+Shift+Home/End SLIDE a video's source window (trim-in/out shift
 // together, showing duration constant) — the keyboard equivalent of dragging
 // the overview filmstrip. Home = earlier footage, End = later.
@@ -209,10 +227,10 @@ export function useCollectionsKeyboard(args: {
   );
 
   const handleTrim = useCallback(
-    (nodeId: NodeId, action: KeyboardTrimAction) => {
+    (nodeId: NodeId, action: KeyboardTrimAction, stepSeconds = TRIM_STEP_SECONDS) => {
       const { graph } = store.getSnapshot();
       const name = graph.nodesById.get(nodeId)?.name ?? "item";
-      const resolved = resolveTrimCommand(graph, nodeId, action, TRIM_STEP_SECONDS);
+      const resolved = resolveTrimCommand(graph, nodeId, action, stepSeconds);
       if (!resolved.ok) {
         const message = TRIM_REJECTION_MESSAGES[resolved.error.reason];
         if (message) announce(message);
@@ -323,10 +341,22 @@ export function useCollectionsKeyboard(args: {
 
   const handleKeyDownCapture = useCallback(
     (event: ReactKeyboardEvent) => {
-      if (!event.altKey || event.ctrlKey || event.metaKey) return;
+      // TWO grammars reach this handler. Alt(+Shift) is the established one;
+      // Ctrl+Arrow alone is the fine trim (PL14-012). Checked as an exact
+      // chord — a held Alt, Meta or Shift makes it something else, which the
+      // Alt grammar below or the browser should have.
+      const fineTrimAction =
+        event.ctrlKey && !event.altKey && !event.metaKey && !event.shiftKey
+          ? FINE_TRIM_ACTION_BY_KEY[event.key]
+          : undefined;
+
+      if (fineTrimAction === undefined && (!event.altKey || event.ctrlKey || event.metaKey)) {
+        return;
+      }
       // A control inside the card owns its own keys — see
       // `isEditableKeyboardTarget`. Without this, Alt+Arrow in an <input>
-      // reordered the card instead of moving the caret by word.
+      // reordered the card instead of moving the caret by word — and Ctrl+Arrow
+      // in one is move-by-word, which this must never steal.
       if (isEditableKeyboardTarget(event.target)) return;
       // The focused element is either the card button (data-node-id) or its
       // grip bar — a sibling inside the data-node-wrapper host.
@@ -337,6 +367,17 @@ export function useCollectionsKeyboard(args: {
         card?.getAttribute("data-node-id") ?? card?.getAttribute("data-node-wrapper");
       if (!rawId) return;
       const nodeId = rawId as NodeId;
+
+      // Fine trim, before the Alt grammar: it is a different chord and shares
+      // none of the branching below. Same drag guard as everything else — a
+      // live dnd-kit drag owns movement until it commits.
+      if (fineTrimAction !== undefined) {
+        event.preventDefault();
+        event.stopPropagation();
+        if (store.getSnapshot().interaction.isDragging) return;
+        handleTrim(nodeId, fineTrimAction, FINE_TRIM_STEP_SECONDS);
+        return;
+      }
 
       // Alt+Delete moves the focused card to the registered trash collection.
       // EXACTLY Alt+Delete: a held Shift makes it a different chord, left for

--- a/punch-list/PUNCH-LIST-14.md
+++ b/punch-list/PUNCH-LIST-14.md
@@ -579,3 +579,41 @@ opens a native file picker filtered to the supported image/video types,
 selected files land through `dropFiles` (same probe, upload, failure reporting
 and single undoable commit as a drop), the whole slot is reachable and operable
 by keyboard, and the strip and grid presentations were both reviewed on screen.
+
+## PL14-012 — Ctrl+Arrows trim by a tenth of a second
+
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: `packages/ui/dnd-collections/react/use-keyboard-controller.ts`,
+  `packages/ui/dnd-collections/VirtualStrip.stories.tsx`
+- Screenshot: Not captured
+
+Fine trim from the keyboard: **Ctrl+Arrow** moves an edge 0.1s, against
+Alt+Shift+Arrow's 1s.
+
+**Not a new feature — a second step size on an existing one.** Keyboard trim
+already existed with all four directions bound (horizontal = the end edge every
+media has, vertical = the video start edge), resolving to the same
+`update-media` command the pointer handles dispatch. This adds a step, not a
+grammar: same actions, same directions, so there is one thing to learn and the
+fine version is not a separate feature to discover.
+
+**Its own chord rather than a modifier on the existing one.** The established
+chord is already Alt+Shift+Arrow; Alt+Shift+Ctrl+Arrow is not a keystroke
+anyone performs. Ctrl turned out to be free — the controller's first line was
+`if (!event.altKey || event.ctrlKey || event.metaKey) return`, so a held Ctrl
+was rejected outright.
+
+Guards it inherits by being in the same handler: the editable-target check (so
+Ctrl+Arrow in an `<input>` stays move-by-word and is never stolen), the live-drag
+veto, and the reducer's own clamping — the floor is the media's, not the
+constant's. `Ctrl+Shift+Arrow` is neither chord and falls through untouched.
+
+Pinned by a story rather than a unit test because the assertion is a WIDTH: at
+`TRIM_PPS` the card's width is its duration, so **ten Ctrl presses must equal
+one Alt+Shift press**. That equality is the proof — at a 1s step the same ten
+presses land at 336px instead of 120px, which is exactly how the story fails
+when the constant is wrong (verified).
+
+Open, and cheap if wanted: Mac. `Ctrl+Arrow` is Mission Control there, so a Mac
+user would want `Cmd` — the handler currently returns on `metaKey`.


### PR DESCRIPTION
Fine keyboard trim: **Ctrl+Arrow moves an edge 0.1s**, against Alt+Shift+Arrow's 1s.

## It's a step size, not a new feature

Keyboard trim already existed with all four directions bound — horizontal is the end edge every media has, vertical is the video's start edge — resolving to the same `update-media` command the pointer handles dispatch.

This reuses that action map verbatim. Same actions, same directions, so there's one grammar with two step sizes rather than two features to learn.

## Why its own chord

The established chord is already `Alt+Shift+Arrow`. Adding Ctrl as a fine modifier would make it `Alt+Shift+Ctrl+Arrow`, which is not a keystroke anyone performs.

Ctrl turned out to be free — the controller's first line was:

```ts
if (!event.altKey || event.ctrlKey || event.metaKey) return;
```

So a held Ctrl was rejected outright.

## Guards it inherits

By living in the same handler rather than a new listener:

- **the editable-target check** — `Ctrl+Arrow` inside an `<input>` is move-by-word and must never be stolen
- **the live-drag veto** — a dnd-kit drag owns movement until it commits
- **the reducer's clamping** — the floor is the media's, not this constant's

`Ctrl+Shift+Arrow` is neither chord and falls through untouched (asserted).

## The test

A story, because the assertion is a **width**: at `TRIM_PPS` a card's width *is* its duration, so **ten Ctrl presses must equal one Alt+Shift press**.

That equality is the proof. At a 1s step the same ten presses land at 336px instead of 120px — which is exactly how the story fails when the constant is wrong. Verified by setting it to 1:

```
× Fine Keyboard Trim
  expected 336 to be 120
```

## One thing left open

On macOS `Ctrl+Arrow` is Mission Control, so a Mac user would want `Cmd` — the handler returns on `metaKey` today. Left as a decision rather than guessed at.

| | |
|---|---|
| Storybook | 165 passed (1 new) |
| Unit | 414 passed |
| App vitest | 514 passed |
| graph-view e2e | 100 passed |
| Typecheck | clean |
| Lint | 0 errors (5 pre-existing `<img>` warnings) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)