### PR TITLE
PL14-007: right-click a card for the rail's actions

### DIFF
--- a/apps/timeline-gstudio001/components/core/context-menu.tsx
+++ b/apps/timeline-gstudio001/components/core/context-menu.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import * as React from "react";
+import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
+
+import { cn } from "@/lib/utils";
+
+// The right-click menu (PL14-007). Radix's context-menu primitive rather than
+// a repositioned DropdownMenu, because everything that makes a context menu
+// correct is fiddly and already solved here: opening at the pointer, the
+// keyboard route (Shift+F10 and the context-menu key), Escape, outside-press,
+// focus return, and long-press on touch.
+//
+// Styled to match `dropdown-menu.tsx` deliberately — the rail's overflow menu
+// and this one offer the SAME actions, so they must not look like two
+// different features. Any change to one belongs in both.
+
+const ContextMenu = ContextMenuPrimitive.Root;
+const ContextMenuTrigger = ContextMenuPrimitive.Trigger;
+const ContextMenuGroup = ContextMenuPrimitive.Group;
+
+const ContextMenuContent = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Portal>
+    <ContextMenuPrimitive.Content
+      ref={ref}
+      className={cn(
+        "z-50 min-w-[11rem] overflow-hidden rounded-md border border-zinc-800 bg-zinc-950 p-1 text-zinc-100 shadow-lg",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        className,
+      )}
+      {...props}
+    />
+  </ContextMenuPrimitive.Portal>
+));
+ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName;
+
+const ContextMenuItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none transition-colors",
+      "focus:bg-zinc-800 focus:text-zinc-50 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  />
+));
+ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName;
+
+const ContextMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-zinc-800", className)}
+    {...props}
+  />
+));
+ContextMenuSeparator.displayName = ContextMenuPrimitive.Separator.displayName;
+
+export {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuGroup,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+};

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -47,6 +47,7 @@ import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
 import { useCollectionHoverTarget } from "./graph-collection-hover";
 import { GraphViewNavContext } from "./graph-navigation";
 import { TrimPanel } from "./graph-trim-panel";
+import { GraphItemContextMenu } from "./graph-item-context-menu";
 import { createDerivedCache } from "@/lib/derived-cache";
 import { formatDuration, formatSeconds } from "@/lib/format-duration";
 import {
@@ -1295,7 +1296,14 @@ const GraphItemShell = memo(function GraphItemShell(props: CollectionItemShellPr
   const isCollection = useCollectionsSelector(
     (s) => s.graph.nodesById.get(props.id)?.kind === "collection",
   );
-  return isCollection ? <GraphCollectionItem {...props} /> : <GraphMediaItem {...props} />;
+  // The right-click menu wraps at the SHELL (PL14-007), which is the one place
+  // both card kinds pass through — so collections and media get it from a
+  // single wiring rather than each content component growing its own.
+  return (
+    <GraphItemContextMenu nodeId={props.id}>
+      {isCollection ? <GraphCollectionItem {...props} /> : <GraphMediaItem {...props} />}
+    </GraphItemContextMenu>
+  );
 });
 
 export const GRAPH_VIEW_COMPONENTS: CollectionsComponents = {

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-context-menu.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-context-menu.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+
+import {
+  useCollectionsSelector,
+  useCollectionsStore,
+  type NodeId,
+} from "@storyboard/ui/dnd-collections";
+
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/core/context-menu";
+import { graphClipboard } from "@/lib/graph-clipboard";
+import { requestGraphItemAction } from "@/lib/graph-view-events";
+import { visibleItemActions, type ItemActionState } from "@/lib/graph-item-action-specs";
+
+// Right-click a card, get the actions the rail offers (PL14-007).
+//
+// Rendered from `ITEM_ACTION_SPECS`, the same list the rail's contextual
+// cluster renders, so the two cannot drift into disagreeing about what an item
+// can do. Same order, so muscle memory transfers.
+//
+// SELECTION SEMANTICS, which the punch-list item left open and which are the
+// only real decision here. Both follow the convention every file manager and
+// editor uses, because a context menu that behaves unusually is worse than one
+// that behaves plainly:
+//
+//   right-click an UNSELECTED item  → select it first, then act on it
+//   right-click INSIDE a selection  → leave the selection, act on all of it
+//
+// The second is why this does not simply select the clicked node: doing that
+// would silently collapse a six-item selection to one at the exact moment the
+// user reached for "Delete" on all six.
+
+function useItemActionState(nodeId: NodeId): ItemActionState {
+  const selectedIds = useCollectionsSelector((s) => s.interaction.selectedIds);
+  const allDisabled = useCollectionsSelector((s) => {
+    const ids = [...s.interaction.selectedIds];
+    if (ids.length === 0) return false;
+    return ids.every((id) => s.graph.nodesById.get(id)?.disabled === true);
+  });
+  // The clipboard is a module singleton, not store state — subscribe so the
+  // menu's Copy/Cut↔Paste swap is right the moment it opens.
+  const canPaste = useSyncExternalStore(
+    graphClipboard.subscribe,
+    () => !graphClipboard.isEmpty(),
+    () => false,
+  );
+
+  // The count the menu should describe is the selection it will ACT on, which
+  // for an unselected node is the one about to be selected (see the note
+  // above) — otherwise the menu opens describing "no selection" and disables
+  // everything on a card the user just right-clicked.
+  const willActOnSelection = selectedIds.has(nodeId) ? selectedIds.size : 1;
+
+  return {
+    hasSelection: willActOnSelection > 0,
+    isSingleSelection: willActOnSelection === 1,
+    canPaste,
+    // Not modelled. The receiving side already refuses an action while one is
+    // in flight (`busyRef` in GraphItemActionsBridge), and a menu is open for
+    // a moment rather than a session — mirroring the flag here would mean a
+    // second subscription for a state this surface can barely observe.
+    busy: false,
+    allDisabled: selectedIds.has(nodeId) ? allDisabled : false,
+  };
+}
+
+export function GraphItemContextMenu({
+  nodeId,
+  children,
+}: Readonly<{ nodeId: NodeId; children: React.ReactNode }>) {
+  const store = useCollectionsStore();
+  const state = useItemActionState(nodeId);
+  const actions = visibleItemActions(state);
+
+  const claimSelection = useCallback(() => {
+    // Only when the node is OUTSIDE the current selection. Inside it, the
+    // selection is what the user meant and must survive the click.
+    if (store.getSnapshot().interaction.selectedIds.has(nodeId)) return;
+    store.setSelection([nodeId]);
+  }, [store, nodeId]);
+
+  return (
+    <ContextMenu>
+      {/* `display: contents` so the trigger generates no box: this sits inside
+          a virtualized strip that measures item widths, and an extra layout
+          box here would change them. Events still bubble to it, which is all a
+          context menu needs — its position comes from the pointer, not from
+          the trigger's rect. */}
+      <ContextMenuTrigger className="contents" onContextMenu={claimSelection}>
+        {children}
+      </ContextMenuTrigger>
+      <ContextMenuContent data-graph-item-context-menu={nodeId as string}>
+        {actions.map((spec) => {
+          const Icon = spec.icon(state);
+          return (
+            <ContextMenuItem
+              key={spec.action}
+              disabled={spec.disabled(state)}
+              onSelect={() => requestGraphItemAction(spec.action)}
+            >
+              <Icon aria-hidden="true" className="mr-2 h-4 w-4" />
+              {spec.label(state)}
+            </ContextMenuItem>
+          );
+        })}
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}

--- a/apps/timeline-gstudio001/lib/graph-item-action-specs.ts
+++ b/apps/timeline-gstudio001/lib/graph-item-action-specs.ts
@@ -1,0 +1,145 @@
+import {
+  Ban,
+  CircleCheck,
+  ClipboardPaste,
+  Copy,
+  CopyPlus,
+  Pencil,
+  Scissors,
+  Trash2,
+  type LucideIcon,
+} from "lucide-react";
+
+import type { GraphItemAction } from "./graph-view-events";
+
+// What an item's actions ARE, in one place (PL14-007).
+//
+// Two surfaces offer them now — the sidebar's contextual cluster and a card's
+// right-click menu — and a second definition is how two menus drift into
+// disagreeing about what an item can do. This module is the definition; both
+// surfaces render it.
+//
+// Deliberately NOT a component. The two present the same actions very
+// differently (the rail is a column of icon tiles with tooltips and an amber
+// wash; the menu is a list of rows), so what they share is the DATA — which
+// actions exist, in what order, with what labels and icons, and when each is
+// available. Sharing markup would have forced one of them to look wrong.
+
+/** Everything an action needs to decide whether it applies right now. */
+export type ItemActionState = Readonly<{
+  hasSelection: boolean;
+  /** Exactly ONE item selected. The details view is the only action that
+   *  cares — there is no honest way to render one clip's frames for six. */
+  isSingleSelection: boolean;
+  /** The clipboard is armed, which SWAPS Copy/Cut for Paste. */
+  canPaste: boolean;
+  /** An async action is in flight; everything disables so nothing double-fires. */
+  busy: boolean;
+  /** Every selected item is already skipped — flips Disable to Enable. */
+  allDisabled: boolean;
+}>;
+
+export type ItemActionSpec = Readonly<{
+  action: GraphItemAction;
+  /** Resolved against state, because two of them change wording: Disable
+   *  becomes Enable, and the icon follows. */
+  label: (state: ItemActionState) => string;
+  description: (state: ItemActionState) => string;
+  icon: (state: ItemActionState) => LucideIcon;
+  /** Present at all. Copy/Cut and Paste are mutually exclusive — a menu row
+   *  for an action that cannot exist in this state is worse than its absence. */
+  visible: (state: ItemActionState) => boolean;
+  /** Present but unavailable. Preferred over hiding wherever the action is
+   *  always CONCEPTUALLY available: a control that vanishes teaches nothing,
+   *  while a disabled one says "wrong shape of selection for that". */
+  disabled: (state: ItemActionState) => boolean;
+}>;
+
+const always = () => true;
+
+/**
+ * The ordered list.
+ *
+ * Details first because it is the action that tells you WHAT you have selected
+ * before you act on it — and because it lost its per-card trigger to get here
+ * (PL13-009). Delete LAST, because a destructive action at the end of a menu
+ * is harder to hit on the way to something else.
+ *
+ * Not identical to the rail's visual order, and it cannot be: the rail hides
+ * Duplicate and Disable behind a "More" overflow, which is an affordance
+ * rather than an action, so its Delete sits before that button. A flat menu
+ * has no overflow to hide behind and inlines both. Same actions, same relative
+ * grouping; the one difference is where Delete falls, and last is the safer
+ * answer for the surface that has no overflow.
+ *
+ * NOTE: the rail does not render from this list yet — it still has its own
+ * JSX. Folding it in means teaching this list about the primary/overflow split
+ * and is its own change; until then "one definition" is true of the menu and
+ * aspirational of the pair.
+ */
+export const ITEM_ACTION_SPECS: readonly ItemActionSpec[] = [
+  {
+    action: "details",
+    label: () => "Edit",
+    description: () => "Open the selected item's details",
+    icon: () => Pencil,
+    visible: always,
+    disabled: (s) => s.busy || !s.isSingleSelection,
+  },
+  {
+    action: "copy",
+    label: () => "Copy",
+    description: () => "Copy the selected item",
+    icon: () => Copy,
+    visible: (s) => !s.canPaste,
+    disabled: (s) => s.busy || !s.hasSelection,
+  },
+  {
+    action: "cut",
+    label: () => "Cut",
+    description: () => "Cut the selected item — paste to move it",
+    icon: () => Scissors,
+    visible: (s) => !s.canPaste,
+    disabled: (s) => s.busy || !s.hasSelection,
+  },
+  {
+    action: "paste",
+    label: () => "Paste",
+    description: () => "Paste into this timeline",
+    icon: () => ClipboardPaste,
+    visible: (s) => s.canPaste,
+    disabled: (s) => s.busy,
+  },
+  {
+    action: "duplicate",
+    label: () => "Duplicate",
+    description: () => "Duplicate the selected item",
+    icon: () => CopyPlus,
+    visible: always,
+    disabled: (s) => s.busy || !s.hasSelection,
+  },
+  {
+    action: "toggle-disabled",
+    label: (s) => (s.allDisabled ? "Enable" : "Disable"),
+    description: (s) =>
+      s.allDisabled
+        ? "Play the selected item again"
+        : "Keep the slot, skip it on playback",
+    icon: (s) => (s.allDisabled ? CircleCheck : Ban),
+    visible: always,
+    disabled: (s) => s.busy || !s.hasSelection,
+  },
+  {
+    action: "delete",
+    label: () => "Delete",
+    description: () => "Move the selected item to trash",
+    icon: () => Trash2,
+    visible: always,
+    disabled: (s) => s.busy || !s.hasSelection,
+  },
+];
+
+/** What a surface should actually render, in order. */
+export function visibleItemActions(state: ItemActionState): readonly ItemActionSpec[] {
+  return ITEM_ACTION_SPECS.filter((spec) => spec.visible(state));
+}

--- a/apps/timeline-gstudio001/package.json
+++ b/apps/timeline-gstudio001/package.json
@@ -25,6 +25,7 @@
     "@google/genai": "^2.4.0",
     "@hookform/resolvers": "^5.2.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
+    "@radix-ui/react-context-menu": "^2.3.7",
     "@radix-ui/react-dropdown-menu": "^2.1.21",
     "@radix-ui/react-slider": "^1.4.4",
     "@radix-ui/react-slot": "^1.3.0",

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -895,6 +895,65 @@ test.describe("graph view E2E", () => {
     await expect(alphaCard.locator('[data-disabled="true"]')).toHaveCount(0);
   });
 
+  test("right-click offers the rail's actions, and respects the selection", async ({ page }) => {
+    // PL14-007. The menu renders ITEM_ACTION_SPECS — the same list the rail's
+    // contextual cluster renders — so the two cannot drift apart about what an
+    // item can do.
+    //
+    // The selection rules were the item's open question, settled to the
+    // convention every file manager uses. Both halves are asserted here
+    // because the second one is destructive if wrong: collapsing a
+    // multi-selection at the moment the user reaches for Delete would delete
+    // one of six.
+    await installGraphApi(page);
+    await openGraph(page);
+
+    const alpha = strip(page, PROJECT_ID).locator('[data-node-id="alpha"]');
+    const bravo = strip(page, PROJECT_ID).locator('[data-node-id="bravo"]');
+    const menu = page.locator("[data-graph-item-context-menu]");
+    const selectedCount = () =>
+      strip(page, PROJECT_ID).locator('[data-node-id][aria-pressed="true"]').count();
+
+    // 1. Right-click an UNSELECTED card → it becomes the selection.
+    expect(await selectedCount()).toBe(0);
+    await alpha.click({ button: "right" });
+    await expect(menu).toHaveCount(1);
+    await expect(alpha).toHaveAttribute("data-selected", "true");
+    expect(await selectedCount()).toBe(1);
+
+    // The rail's actions, in the rail's order.
+    await expect(menu.getByRole("menuitem")).toHaveText([
+      "Edit",
+      "Copy",
+      "Cut",
+      "Duplicate",
+      "Disable",
+      "Delete",
+    ]);
+    await page.keyboard.press("Escape");
+    await expect(menu).toHaveCount(0);
+
+    // 2. Right-click INSIDE a multi-selection → the selection survives.
+    await bravo.click({ modifiers: ["Control"] });
+    expect(await selectedCount()).toBe(2);
+    await alpha.click({ button: "right" });
+    await expect(menu).toHaveCount(1);
+    expect(await selectedCount()).toBe(2);
+
+    // …and the menu describes THAT selection: Edit is single-selection only,
+    // so it disables rather than vanishing — a control that disappears
+    // teaches nothing.
+    await expect(menu.getByRole("menuitem", { name: "Edit" })).toBeDisabled();
+    await expect(menu.getByRole("menuitem", { name: "Delete" })).toBeEnabled();
+    await page.keyboard.press("Escape");
+
+    // 3. It acts on the selection, through the same path the rail uses.
+    await alpha.click({ button: "right" });
+    await menu.getByRole("menuitem", { name: "Disable" }).click();
+    await expect(alpha.locator('[data-disabled="true"]')).toBeVisible();
+    await expect(bravo.locator('[data-disabled="true"]')).toBeVisible();
+  });
+
   test("board options live in the icon rail, below the trash", async ({ page }) => {
     // PL14-005. The menu is rendered by the BOARD and portalled into a slot the
     // rail publishes, so it keeps its real props while its trigger sits with

--- a/package-lock.json
+++ b/package-lock.json
@@ -559,6 +559,7 @@
         "@google/genai": "^2.4.0",
         "@hookform/resolvers": "^5.2.1",
         "@modelcontextprotocol/sdk": "^1.26.0",
+        "@radix-ui/react-context-menu": "^2.3.7",
         "@radix-ui/react-dropdown-menu": "^2.1.21",
         "@radix-ui/react-slider": "^1.4.4",
         "@radix-ui/react-slot": "^1.3.0",
@@ -6089,10 +6090,578 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-context-menu": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.3.7.tgz",
+      "integrity": "sha512-CtXP35dxaB5T3zXSd+E3uHe/QpXcpYnZmxp6OaIbfthtfW4wyb77M23BG+bwIJDtsMwEP/YssdsmNyZu7jhWew==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-menu": "2.1.24",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
+      "integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
+      "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-context": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-direction": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
+      "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+      "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-id": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-menu": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.24.tgz",
+      "integrity": "sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-popper": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
+      "integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-rect": "1.1.4",
+        "@radix-ui/react-use-size": "1.1.4",
+        "@radix-ui/rect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
+      "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-is-hydrated": "0.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
+      "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
+      "integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+      "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/rect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
+      "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/react-direction": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz",
       "integrity": "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+      "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-effect-event": "0.0.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -6137,6 +6706,102 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
       "integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+      "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -6333,6 +6998,139 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+      "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+      "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/punch-list/PUNCH-LIST-14.md
+++ b/punch-list/PUNCH-LIST-14.md
@@ -335,24 +335,59 @@ instead of the outcome against reality.
 
 ## PL14-007 — Right-click context menu on an item
 
-- Status: Not started
-- Area: `graph-item-content.tsx`, `graph-item-actions.tsx`
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: `lib/graph-item-action-specs.ts` (new), `components/core/context-menu.tsx`
+  (new), `graph-item-context-menu.tsx` (new), `graph-item-content.tsx`,
+  `tests/e2e/graph-view.spec.ts`
 - Screenshot: Not captured
 
-Right-clicking an item should open a context menu offering the same options the
-sidebar item-actions cluster offers when an item is selected.
+Right-clicking a card opens the rail's actions: Edit, Copy, Cut (or Paste),
+Duplicate, Disable/Enable, Delete.
 
-The actions already exist in one place (PL13-009 moved Details into that
-cluster); this should present the same set rather than growing a second
-definition of what an item's actions are — one source, two surfaces.
+**The selection rules were the open question**, settled to the convention every
+file manager and editor uses, because a context menu that behaves unusually is
+worse than one that behaves plainly:
 
-Open: whether right-clicking an UNSELECTED item selects it first (the common
-convention) or acts on it without changing selection, and what the menu does
-when the right-clicked item is part of a multi-selection.
+- right-click an UNSELECTED item → it becomes the selection, then the action
+  applies to it
+- right-click INSIDE a selection → the selection survives and the action
+  applies to all of it
 
-Done when: right-click opens a menu with the item-actions options, driven from
-the same definition as the sidebar cluster, dismissible by Escape and outside
-click, and reachable by keyboard (context-menu key / Shift+F10).
+The second is the one that matters. Naively selecting the clicked node would
+collapse a six-item selection to one at the exact moment the user reached for
+Delete — so the e2e asserts it, and reverting the guard fails it with
+`Expected: 2, Received: 1`.
+
+**Wired at the SHELL**, which is the one place both card kinds pass through, so
+collections and media get it from a single wiring. The trigger is
+`display: contents` — it sits inside a virtualized strip that measures item
+widths, and an extra layout box there would change them. Events still bubble to
+it, which is all a context menu needs: its position comes from the pointer, not
+the trigger's rect.
+
+Radix's context-menu primitive rather than a repositioned DropdownMenu, because
+everything that makes a context menu correct is already solved there — opening
+at the pointer, the keyboard route (Shift+F10 and the context-menu key),
+Escape, outside-press, focus return, long-press on touch. Styled to match
+`dropdown-menu.tsx` deliberately: the rail's overflow menu and this one offer
+the same actions and must not look like two features.
+
+**`busy` is not modelled** in the menu. The receiving side already refuses an
+action while one is in flight, and a menu is open for a moment rather than a
+session — mirroring the flag would mean a second subscription for a state this
+surface can barely observe.
+
+### Still two definitions, and that is the follow-up
+
+The item asked for "one source, two surfaces". `ITEM_ACTION_SPECS` is that
+source and the MENU renders it — but the rail still has its own JSX, so the
+pair is not yet unified. Folding the rail in means teaching the list about the
+rail's primary/overflow split (it hides Duplicate and Disable behind "More",
+which is why the two orders differ: a flat menu has no overflow and puts Delete
+last, where a destructive action is hardest to hit on the way to something
+else). That is its own change and was not worth destabilising a heavily-tuned
+surface at the end of a long batch.
 
 ## PL14-008 — An untouched, empty collection is discarded, not trashed
 


### PR DESCRIPTION
Right-clicking a card opens the rail's actions: Edit, Copy, Cut (or Paste), Duplicate, Disable/Enable, Delete.

## The selection rules — the item's open question

Settled to the convention every file manager and editor uses, because a context menu that behaves unusually is worse than one that behaves plainly:

- right-click an **unselected** item → it becomes the selection, then the action applies to it
- right-click **inside** a selection → the selection survives, and the action applies to all of it

**The second is the one that matters.** Naively selecting the clicked node would collapse a six-item selection to one at the exact moment the user reached for Delete. The e2e asserts it; reverting the guard fails with `Expected: 2, Received: 1`.

## Where it's wired

At the **shell** — the one place both card kinds pass through — so collections and media get it from a single wiring rather than each content component growing its own.

The trigger is `display: contents`. It sits inside a virtualized strip that measures item widths, and an extra layout box would change them. Events still bubble to it, which is all a context menu needs: its position comes from the pointer, not the trigger's rect.

Radix's context-menu primitive rather than a repositioned `DropdownMenu`, because everything that makes a context menu correct is already solved there — opening at the pointer, the keyboard route (Shift+F10 and the context-menu key), Escape, outside-press, focus return, long-press on touch. Styled to match `dropdown-menu.tsx` deliberately: the rail's overflow menu and this one offer the same actions and must not look like two features.

`busy` is deliberately not modelled — the receiving side already refuses an action while one is in flight, and a menu is open for a moment rather than a session.

## Still two definitions — stated rather than claimed otherwise

The item asked for *"one source, two surfaces"*. `ITEM_ACTION_SPECS` is that source and the **menu** renders it — but the rail still has its own JSX, so the pair isn't unified yet.

Folding the rail in means teaching the list about its primary/overflow split. That split is also why the two orders differ: the rail hides Duplicate and Disable behind "More" (an affordance, not an action), so its Delete sits before that button; a flat menu has no overflow and puts Delete **last**, where a destructive action is hardest to hit on the way to something else.

That's its own change, and not worth destabilising a heavily-tuned surface at the end of a long batch. Happy to do it next.

## Dependency

Adds `@radix-ui/react-context-menu@2.3.7` — purely additive to the lockfile (798 insertions, **no deletions**).

| | |
|---|---|
| App vitest | 514 passed |
| Unit | 414 passed |
| Storybook | 165 passed |
| graph-view e2e | 101 passed (1 new) |
| Typecheck | clean, both workspaces |
| Lint | 0 errors (5 pre-existing `<img>` warnings) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)