### PR TITLE
PL14-011: the trailing slot browses for media

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-add-collection-slot.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-add-collection-slot.tsx
@@ -1,27 +1,41 @@
 "use client";
 
-import { FolderPlus } from "lucide-react";
+import { useRef } from "react";
+import { FolderPlus, Image as ImageIcon } from "lucide-react";
 
 import { getChildren, parseNodeId, useCollectionsSelector } from "@storyboard/ui/dnd-collections";
 
-import { useAppendCollection } from "./graph-native-drop";
+import { useAppendCollection, useAppendFiles } from "./graph-native-drop";
 
 /**
- * The trailing "add a timeline here" slot, at the end of a strip or grid.
+ * The trailing "add something here" slot, at the end of a strip or grid.
  *
- * Adding a nested timeline used to mean reaching for the sidebar's collection
- * tool, which lands next to the SELECTION — fine when you are working on a
- * card, wrong when what you want is "one more, at the end of this timeline".
- * This appends to the surface it sits in, whatever is selected elsewhere.
+ * Two ways in, because there are two things you can add. Adding a nested
+ * timeline used to mean reaching for the sidebar's collection tool, which
+ * lands next to the SELECTION — fine when you are working on a card, wrong
+ * when what you want is "one more, at the end of this timeline". Adding MEDIA
+ * had no keyboard route at all (PL14-011): the only way in was dragging from
+ * the OS, a gesture that starts outside the page and has no keyboard
+ * equivalent, so a keyboard or switch user could not add media to this app.
+ * The browse button is that route, and the browser's own picker is accessible
+ * for free.
  *
  * Deliberately not a card: dashed, muted, and no drag, selection or trim
  * behaviour. The surfaces render it past their own content extent, so it is
  * not an item to any of the index math either (see `trailingSlot`).
+ *
+ * A CONTAINER of controls rather than one button. It was a single `<button>`,
+ * which is exactly what a second control could not live inside — nested
+ * interactive elements are invalid, and this codebase has been bitten by that
+ * before (round 6 had to use `contentEditable` rather than an `<input>`
+ * because card content renders inside a button).
  */
 export function AddCollectionSlot({
   collectionId,
 }: Readonly<{ collectionId: string }>) {
   const append = useAppendCollection(collectionId);
+  const appendFiles = useAppendFiles();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   // Append means "after the last child", and the count is the index. Read
   // live so a drop or an undo elsewhere cannot leave this pointing at a
   // stale position.
@@ -30,16 +44,69 @@ export function AddCollectionSlot({
   );
 
   return (
-    <button
-      type="button"
+    <div
       data-add-collection-slot={collectionId}
-      aria-label="Add a timeline to the end"
-      title="Add a timeline here"
-      onClick={() => append(childCount)}
-      className="flex h-full w-full flex-col items-center justify-center gap-1 rounded-md border border-dashed border-zinc-700 bg-zinc-900/30 text-zinc-500 transition-colors hover:border-sky-500/60 hover:bg-sky-500/[0.06] hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70"
+      className="flex h-full w-full flex-col items-stretch justify-center gap-1 rounded-md border border-dashed border-zinc-700 bg-zinc-900/30 p-1.5 text-zinc-500"
     >
-      <FolderPlus aria-hidden="true" className="h-4 w-4" />
-      <span className="text-[11px] font-medium">Add timeline</span>
-    </button>
+      <button
+        type="button"
+        data-add-collection-button={collectionId}
+        aria-label="Add a timeline to the end"
+        title="Add a timeline here"
+        onClick={() => append(childCount)}
+        className="flex min-h-0 flex-1 cursor-pointer flex-col items-center justify-center gap-1 rounded transition-colors hover:bg-sky-500/[0.06] hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70"
+      >
+        <FolderPlus aria-hidden="true" className="h-4 w-4" />
+        <span className="text-[11px] font-medium leading-none">Add timeline</span>
+      </button>
+
+      {/* The media half. Only offered where files can actually land — outside a
+          native-drop surface there is no timeline to append to, and a button
+          that cannot work is worse than none. */}
+      {appendFiles !== null ? (
+        <>
+          {/* The hint names the gesture that has no control: dragging from the
+              file system works anywhere on the timeline, not just here, and
+              nothing else on screen says so. `truncate` because a 100px strip
+              slot has no room to wrap — the full sentence stays in the
+              button's title. */}
+          <p className="truncate text-center text-[9px] leading-tight text-zinc-600">
+            or drop media anywhere
+          </p>
+          <button
+            type="button"
+            data-add-media-button={collectionId}
+            aria-label="Add media files to the end of this timeline"
+            title="Browse for images and videos — or drop them anywhere on the timeline"
+            onClick={() => fileInputRef.current?.click()}
+            className="flex shrink-0 cursor-pointer items-center justify-center gap-1 rounded px-1 py-0.5 text-[10px] font-medium transition-colors hover:bg-sky-500/[0.06] hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70"
+          >
+            <ImageIcon aria-hidden="true" className="h-3 w-3" />
+            Browse
+          </button>
+          {/* The input itself is never shown: it is the picker, not the
+              affordance. `sr-only` rather than `display:none` so it stays a
+              real form control the button can open. */}
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            accept="image/*,video/*"
+            tabIndex={-1}
+            aria-hidden="true"
+            data-add-media-input={collectionId}
+            className="sr-only"
+            onChange={(event) => {
+              const files = [...(event.target.files ?? [])];
+              // Reset BEFORE handing off, so choosing the same file twice in a
+              // row fires `change` again — the input compares against its own
+              // value, and an unchanged one is silently inert.
+              event.target.value = "";
+              appendFiles(files);
+            }}
+          />
+        </>
+      ) : null}
+    </div>
   );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import {
+  createContext,
   useCallback,
+  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -793,7 +795,49 @@ function useNativeDrop(collectionId: string, projectId: string) {
     [insertTool, dropFiles],
   );
 
-  return { commitDrop, upload };
+  /**
+   * Add files WITHOUT a drag — the file picker's route in (PL14-011).
+   *
+   * Appends, because a picker has no pointer and therefore no boundary: the
+   * user chose files, not a position. `resolveAnchoredTarget` still resolves
+   * it at commit time, so a strip edited while the uploads run still lands
+   * them at its real end.
+   *
+   * Deliberately the SAME `dropFiles` the drop path calls, rather than a
+   * second upload route. Everything that makes a drop behave — one decode per
+   * video, bounded concurrency, per-file failure reporting, detail parking,
+   * and ONE undoable commit for the whole selection — lives in there, and a
+   * picker that reimplemented any of it would drift from the drag.
+   */
+  const appendFiles = useCallback(
+    (files: readonly File[]) => {
+      if (files.length === 0) return;
+      const children = getChildren(store.getSnapshot().graph, parseNodeId(collectionId));
+      void dropFiles(files, {
+        beforeId: children.length > 0 ? (children[children.length - 1] as string) : null,
+        afterId: null,
+        index: children.length,
+      });
+    },
+    [dropFiles, store, collectionId],
+  );
+
+  return { commitDrop, upload, appendFiles };
+}
+
+/**
+ * The surface's file-append entry, for anything rendered INSIDE it that has
+ * files but no drag — currently the trailing slot's picker.
+ *
+ * A context because the slot is passed to the virtual surface as
+ * `trailingSlot` and renders within this provider, while being constructed far
+ * away in the board. Null outside a native-drop surface, which is the honest
+ * answer: there is no timeline to append to.
+ */
+const AppendFilesContext = createContext<((files: readonly File[]) => void) | null>(null);
+
+export function useAppendFiles(): ((files: readonly File[]) => void) | null {
+  return useContext(AppendFilesContext);
 }
 
 /** The shared drop status line — a live region mounted at all times so its
@@ -834,7 +878,7 @@ export function NativeDropStrip({
   // resolves its drop boundary in whatever order it is SHOWING, and in flat
   // mode that is not this collection's children.
   const flatItems = useFlatItems();
-  const { commitDrop, upload } = useNativeDrop(collectionId, projectId);
+  const { commitDrop, upload, appendFiles } = useNativeDrop(collectionId, projectId);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const [indicatorX, setIndicatorX] = useState<number | null>(null);
   const armed = useNativeDragArmed();
@@ -1020,7 +1064,7 @@ export function NativeDropStrip({
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
     >
-      {children}
+      <AppendFilesContext.Provider value={appendFiles}>{children}</AppendFilesContext.Provider>
       {indicatorX !== null && (
         <div
           data-native-drop-indicator
@@ -1071,7 +1115,7 @@ export function NativeDropGrid({
   children,
 }: Readonly<{ collectionId: string; projectId: string; children: ReactNode }>) {
   const store = useCollectionsStore();
-  const { commitDrop, upload } = useNativeDrop(collectionId, projectId);
+  const { commitDrop, upload, appendFiles } = useNativeDrop(collectionId, projectId);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const [indicator, setIndicator] = useState<GridIndicator | null>(null);
   const armed = useNativeDragArmed();
@@ -1249,7 +1293,7 @@ export function NativeDropGrid({
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
     >
-      {children}
+      <AppendFilesContext.Provider value={appendFiles}>{children}</AppendFilesContext.Provider>
       {indicator !== null && (
         <div
           data-native-drop-indicator

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -3300,6 +3300,65 @@ test.describe("graph view E2E", () => {
       .toBe(5);
   });
 
+  test("the trailing slot browses for media — the only route that needs no pointer", async ({
+    page,
+  }) => {
+    // PL14-011. Until this, dragging from the OS file system was the ONLY way
+    // media entered a timeline — a gesture that starts outside the page and
+    // has no keyboard equivalent, so a keyboard or switch user could not add
+    // media to this app at all. The picker is that route.
+    //
+    // The point of the test is that it goes through the SAME pipeline as a
+    // drop, not a second upload path: same probe, same per-file failure
+    // handling, same single undoable commit.
+    const api = await installGraphApi(page);
+    let uploads = 0;
+    await page.route("**/api/timeline-media/upload", (route) => {
+      uploads += 1;
+      return route.fulfill({
+        json: { pathname: `picked-${uploads}.png`, url: PIXEL, thumbnailUrl: PIXEL },
+      });
+    });
+    await openGraph(page);
+
+    const before = (await stripOrder(page, PROJECT_ID)).length;
+    const input = page.locator(`[data-add-media-input="${PROJECT_ID}"]`);
+    const browse = page.locator(`[data-add-media-button="${PROJECT_ID}"]`);
+
+    // The affordance is a real button — reachable and pressable without a
+    // pointer, which is the whole reason this exists. The input behind it is
+    // deliberately out of the tab order: it is the picker, not the control.
+    await expect(browse).toBeVisible();
+    await expect(browse).toBeEnabled();
+    expect(await input.getAttribute("tabindex")).toBe("-1");
+    expect(await input.getAttribute("accept")).toBe("image/*,video/*");
+
+    await input.setInputFiles([
+      { name: "one.png", mimeType: "image/png", buffer: Buffer.from([137, 80, 78, 71]) },
+      { name: "two.png", mimeType: "image/png", buffer: Buffer.from([137, 80, 78, 71]) },
+    ]);
+
+    // Both land, APPENDED — a picker has no pointer and so no boundary.
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID).then((order) => order.length), { timeout: 15000 })
+      .toBe(before + 2);
+    expect(uploads).toBe(2);
+
+    // It persisted through the same batch path a drop uses. Polled, because
+    // the write is debounced ~900ms behind the commit — asserting it
+    // synchronously reads before the writer has run.
+    await expect
+      .poll(() => api.patchesFor(PROJECT_ID).length, { timeout: 5000 })
+      .toBeGreaterThan(0);
+
+    // ONE commit for the whole selection, like a drop: a single undo takes
+    // both back rather than peeling them off one at a time.
+    await undoButton(page).click();
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID).then((order) => order.length))
+      .toBe(before);
+  });
+
   test("an undecodable video fails ALONE — its siblings in the same drop still land", async ({
     page,
   }) => {

--- a/punch-list/PUNCH-LIST-14.md
+++ b/punch-list/PUNCH-LIST-14.md
@@ -556,64 +556,49 @@ Verified live in both dialogs: `<button>`, `aria-label="Rename …"`,
 `cursor: text`, hover class present, `tabIndex 0`; one click mounts the editor
 focused with the current value selected.
 
-## PL14-011 — The trailing slot should say how to add MEDIA, and offer a file picker
+## PL14-011 — The trailing slot says how to add MEDIA, and offers a file picker
 
-- Status: Not started
-- Area: `graph-add-collection-slot.tsx`, `graph-native-drop.tsx` (expose a
-  programmatic entry to `dropFiles`)
+- Status: Complete
+- URL: http://localhost:3000/timeline/project-1784393947379-3a6k68/graph
+- Area: `graph-add-collection-slot.tsx`, `graph-native-drop.tsx`,
+  `tests/e2e/graph-view.spec.ts`
 - Screenshot: Not captured
 
-The pseudo item at the end of a timeline currently offers one thing: "Add
-timeline", which mints a nested collection. It should also tell the user that
-media can be added by dragging files from the file system onto any point in the
-timeline, and offer a link that opens a file picker for people who would rather
-browse than drag.
+The slot now offers both things you can add: **Add timeline** as before, a hint
+that media can be dropped anywhere on the timeline, and a **Browse** button
+that opens a file picker.
 
-**This adds the app's first file-browse path.** There is no `type="file"` input
-anywhere in the app today — not in the graph view, not in the assets drawer
-(that drawer lists assets already uploaded). Every media item that has ever
-entered a timeline arrived by an OS drag-and-drop. So this is not a shortcut to
-an existing route; it is the second route.
+**This is the app's first file input, and the case for it is access, not
+convenience.** There was no `type="file"` anywhere — every media item that had
+ever entered a timeline arrived by an OS drag-and-drop. That gesture starts
+outside the page and has no keyboard equivalent, so a keyboard or switch user
+could not add media to this app at all. The browser's own picker is accessible
+for free; the work was giving it a route in.
 
-Which makes the strongest argument for it an accessibility one, not
-discoverability: **today a keyboard or switch user cannot add media at all.**
-Dragging from the OS file system is not something the app can offer a keyboard
-equivalent for — the gesture starts outside the page. A file input is the only
-way in, and browsers already give it a fully accessible picker.
+**It feeds the EXISTING pipeline.** `dropFiles` owns the one-decode-per-video
+probe, bounded concurrency, per-file failure reporting, detail parking and a
+single undoable commit for the whole selection. A picker that reimplemented any
+of that would drift from the drag, so the surfaces publish `appendFiles`
+through a context and the slot calls it. Appends rather than inserts, because a
+picker has no pointer and therefore no boundary — the user chose files, not a
+position.
 
-It must feed the EXISTING pipeline. `dropFiles` in `graph-native-drop.tsx` does
-classification, the one-decode-per-video probe, concurrent upload with per-file
-failure reporting, detail parking and a single atomic commit for the whole
-selection. A picker that re-implements any of that will drift from the drop
-path. The work is exposing a programmatic entry point that takes `File[]` plus
-an anchor and calls `dropFiles` — the hook currently surfaces only
-`commitDrop(event, anchor)`, which needs a `DragEvent`.
+Two things the earlier survey called correctly:
 
-Two constraints that will shape the markup:
+- **The slot was a single `<button>`**, which is exactly what a second control
+  cannot live inside. It is a container of controls now.
+- **Room is tight.** The strip slot measures 132px; the three stacked pieces
+  fit with no overflow, with the hint at 9px and truncating rather than
+  wrapping. The full sentence lives in the Browse button's `title`.
 
-- **The slot is a `<button>` today.** A link or a second control cannot go
-  inside it — nested interactive elements are invalid and this codebase has
-  been bitten by exactly that before (round 6 had to use `contentEditable`
-  instead of an `<input>` because the card content renders inside a button).
-  The slot needs to become a container holding two controls, with "Add
-  timeline" staying a button of its own.
-- **Room is tight in the strip.** The slot is card height — 100px at MD — and
-  already carries an icon plus an 11px label. Grid cells are much larger. The
-  hint copy may need to be strip-abbreviated, or shown only at grid size, or
-  moved to a `title`/tooltip on the strip. Worth deciding from a screenshot at
-  both sizes rather than in the abstract.
+The input itself is `sr-only` and `tabIndex={-1}` — it is the picker, not the
+affordance, and the button in front of it is the real control. Its value is
+cleared BEFORE the files are handed off, so choosing the same file twice in a
+row fires `change` again instead of being silently inert.
 
-Proposed copy, offered as a starting point rather than settled — the owner
-asked me to word it:
-
-> **Add timeline**
-> or drop media files anywhere on the timeline — [browse…]
-
-Done when: the trailing slot names both ways to add content, the browse link
-opens a native file picker filtered to the supported image/video types,
-selected files land through `dropFiles` (same probe, upload, failure reporting
-and single undoable commit as a drop), the whole slot is reachable and operable
-by keyboard, and the strip and grid presentations were both reviewed on screen.
+E2E drives the real path with `setInputFiles`: two files land appended, both
+upload, the write reaches the batch path, and ONE undo takes both back.
+Disconnecting the handler fails it (`Expected: 6, Received: 4`).
 
 ## PL14-012 — Ctrl+Arrows trim by a tenth of a second
 


### PR DESCRIPTION
The slot now offers both things you can add: **Add timeline** as before, a hint that media can be dropped anywhere on the timeline, and a **Browse** button that opens a file picker.

## This is the app's first file input, and the case is access

There was no `type="file"` anywhere in the app. Every media item that had ever entered a timeline arrived by an OS drag-and-drop — a gesture that starts outside the page and has **no keyboard equivalent**. A keyboard or switch user could not add media to this app at all.

The browser's own picker is accessible for free. The work was giving it a route in.

## It feeds the existing pipeline

`dropFiles` owns the one-decode-per-video probe, bounded concurrency, per-file failure reporting, detail parking, and a single undoable commit for the whole selection. A picker that reimplemented any of that would drift from the drag.

So the surfaces publish `appendFiles` through a context — the slot is passed to the virtual surface as `trailingSlot`, so it *renders* inside them while being *constructed* in the board — and the slot calls it. It **appends** rather than inserts: a picker has no pointer and therefore no boundary. The user chose files, not a position.

## Two constraints the earlier survey called correctly

- **The slot was a single `<button>`**, which is exactly what a second control cannot live inside — nested interactive elements are invalid, and this codebase has been bitten by that before. It's a container of controls now.
- **Room is tight.** The strip slot measures 132px; the three stacked pieces fit with no overflow, with the hint at 9px and truncating rather than wrapping. The full sentence lives in the Browse button's `title`.

## Details

The input is `sr-only` with `tabIndex={-1}` — it's the picker, not the affordance, and the button in front of it is the real control. Its value is cleared **before** the files are handed off, so choosing the same file twice in a row fires `change` again instead of being silently inert.

## The test

Drives the real path with `setInputFiles`: two files land appended, both upload, the write reaches the batch path, and **one** undo takes both back — same commit semantics as a drop.

Disconnecting the handler fails it: `Expected: 6, Received: 4`.

| | |
|---|---|
| App vitest | 514 passed |
| Unit | 414 passed |
| Storybook | 165 passed |
| graph-view e2e | 102 passed (1 new) |
| Typecheck | clean |
| Lint | 0 errors (5 pre-existing `<img>` warnings) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)