### PR TITLE
CI: make the RenderEfficiency flake diagnosable, and settle its sample point

### DIFF
--- a/packages/ui/dnd-collections/DndCollections.stories.tsx
+++ b/packages/ui/dnd-collections/DndCollections.stories.tsx
@@ -17,6 +17,7 @@ import {
   rectCenter,
   rectPoint,
   releaseAt,
+  settledAttribute,
   waitForLayout,
 } from "./stories-helpers";
 
@@ -1004,15 +1005,36 @@ export const RenderEfficiencyDuringDrag: Story = {
       expect(target.parentElement?.querySelector('[data-drop-indicator="before"]')).toBeTruthy();
     });
 
-    const bystanderRendersBefore = bystander.getAttribute("data-render-count");
-    // Jitter the pointer within the same intent (still left half of t1).
-    await moveHeldPointer({ x: holdPoint.x + 3, y: holdPoint.y + 2 });
-    await moveHeldPointer({ x: holdPoint.x - 3, y: holdPoint.y - 2 });
-    await moveHeldPointer({ x: holdPoint.x + 2, y: holdPoint.y + 1 });
-    await moveHeldPointer(holdPoint);
+    // SETTLED, not sampled on the spot. The drop indicator appearing means the
+    // intent resolved, not that React has finished, so a straggler from
+    // drag-start could otherwise be charged to the jitter below. This does NOT
+    // make the number predictable and is not meant to: drag-start costs the
+    // bystander a genuinely variable count (9,9,9,9,7 measured across five
+    // local runs, 9,7,9 across three CI failures). What matters is only that
+    // nothing is still in flight when the window opens.
+    const bystanderRendersBefore = await settledAttribute(bystander, "data-render-count");
+
+    // Jitter the pointer within the same intent (still left half of t1),
+    // recording after EACH move. The assertion needs one number, but a failure
+    // needs to say WHICH move caused the render — three CI failures were
+    // reported as a bare "expected 10 to be 9", which is undiagnosable after
+    // the fact and is why this flake survived two rounds of investigation.
+    const jitter: Array<{ move: string; count: string | null }> = [];
+    const jitterTo = async (label: string, x: number, y: number) => {
+      await moveHeldPointer({ x, y });
+      jitter.push({ move: label, count: bystander.getAttribute("data-render-count") });
+    };
+    await jitterTo("+3,+2", holdPoint.x + 3, holdPoint.y + 2);
+    await jitterTo("-3,-2", holdPoint.x - 3, holdPoint.y - 2);
+    await jitterTo("+2,+1", holdPoint.x + 2, holdPoint.y + 1);
+    await jitterTo("back", holdPoint.x, holdPoint.y);
 
     // Zero re-renders for the uninvolved card across four pointer moves.
-    expect(bystander.getAttribute("data-render-count")).toBe(bystanderRendersBefore);
+    const trace = jitter.map((step) => `${step.move}:${step.count}`).join(" ");
+    expect(
+      bystander.getAttribute("data-render-count"),
+      `bystander re-rendered during jitter (baseline ${bystanderRendersBefore}; after each move ${trace})`,
+    ).toBe(bystanderRendersBefore);
 
     await releaseAt(holdPoint);
     await waitFor(() => {

--- a/packages/ui/dnd-collections/stories-helpers.ts
+++ b/packages/ui/dnd-collections/stories-helpers.ts
@@ -44,6 +44,49 @@ export async function dispatchPointerSequence(steps: readonly PointerStep[]): Pr
   }
 }
 
+/**
+ * An attribute's value once it has STOPPED changing.
+ *
+ * For render-count assertions, where the question is "did this window cause
+ * any renders" and the answer is only meaningful if the previous window has
+ * finished. Sampling the instant some other condition goes true is too early:
+ * `waitFor` returns as soon as its predicate passes, while React may still
+ * have queued work behind it, and a straggler that lands after the sample gets
+ * charged to whatever the test does next.
+ *
+ * That is exactly how `RenderEfficiencyDuringDrag` failed on CI three times
+ * (2026-07-30). The tell was that the BASELINE varied — 9, 7, 9 across three
+ * runs, reproduced locally at 9,9,9,9,7 — which a settled setup cannot do. The
+ * extra renders were drag-start work arriving late, not renders the jitter
+ * caused; a slower machine simply moved the straggler to the far side of the
+ * sample.
+ *
+ * THROWS rather than giving up if it never settles. A drag that genuinely
+ * re-renders forever is a real failure and must not be quietly averaged away —
+ * this makes the sample point well-defined, it does not soften the assertion
+ * that follows.
+ */
+export async function settledAttribute(
+  element: HTMLElement,
+  name: string,
+  { stableFrames = 4, maxFrames = 180 }: { stableFrames?: number; maxFrames?: number } = {},
+): Promise<string | null> {
+  let value = element.getAttribute(name);
+  let stable = 0;
+  for (let frame = 0; frame < maxFrames; frame += 1) {
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+    const next = element.getAttribute(name);
+    stable = next === value ? stable + 1 : 0;
+    value = next;
+    if (stable >= stableFrames) return value;
+  }
+  throw new Error(
+    `"${name}" never settled: still changing after ${maxFrames} frames (last "${value}")`,
+  );
+}
+
 export async function waitForLayout(element: HTMLElement): Promise<void> {
   await waitFor(() => {
     const rect = element.getBoundingClientRect();


### PR DESCRIPTION
`Render Efficiency During Drag` failed **three times on CI today** (#243, #246, #249), passing on a plain re-run each time and never reproducing locally. I re-ran it three times without diagnosing it.

This is the diagnosis. **It is partial, and I'd rather say so than call it fixed.**

## What the numbers say

I had never actually read them. From attempt-1 logs:

| PR | expected (baseline) | received | delta |
|---|---|---|---|
| #243 | 9 | 10 | +1 |
| #246 | **7** | 9 | +2 |
| #249 | 9 | 10 | +1 |

**The baseline varies.** My notes recorded it as stable at 9, which sent the previous investigation at the wrong thing. Reproduced locally: **9, 9, 9, 9, 7** across five runs.

So the render count that drag *start* costs the bystander is genuinely variable on any machine — inherent to the gesture (pointer coalescing, how many intermediate intents resolve), not a defect and not a sampling artifact. What CI adds is +1 or +2 renders inside the **jitter window**, which is what the assertion charges to the jitter.

## What I could not do: reproduce it

Ten CPU hogs pinned the baseline at 7 and it passed three for three. Contention alone isn't the trigger, so I have **no local before/after** and cannot claim this fixes anything. CI is the only evidence available.

## Two changes, neither weakening the guarantee

**1. Sample the baseline after the render count goes quiet** (`settledAttribute`, new in `stories-helpers`). The drop indicator appearing means the intent resolved, not that React has finished, so a straggler from drag-start could be charged to the jitter. It **throws** rather than giving up if the count never settles — a drag that really re-renders forever must still fail.

This removes one plausible cause. It does *not* make the baseline predictable, and isn't meant to — I predicted it would and was wrong, which is how I learned the variance is inherent.

**2. Record the count after each of the four jitter moves, and name them in the failure.** All three CI failures read as a bare `expected 10 to be 9` — no way to tell which move caused it after the fact, which is exactly why this survived two rounds of investigation. A future failure now reads:

```
bystander re-rendered during jitter
(baseline 9; after each move +3,+2:9 -3,-2:9 +2,+1:9 back:9)
```

That line distinguishes *"the jitter genuinely causes a render on slow hardware"* from *"drag-start work is still landing"* — the two hypotheses I could not separate today.

| | |
|---|---|
| Storybook | 165 passed |
| Unit | 414 passed |
| App vitest | 514 passed |
| Typecheck | clean |
| Lint | 0 errors |

Story run 3× clean locally; forced-failure message verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)