### PR TITLE
PL14-007 follow-up: the rail renders the shared action list too

### DIFF
--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -45,6 +45,10 @@ import {
   SIDEBAR_ICON_BASE,
   SIDEBAR_ICON_IDLE,
 } from "./sidebar-icon-styles";
+import {
+  visibleItemActions,
+  type ItemActionState,
+} from "@/lib/graph-item-action-specs";
 import { graphClipboard } from "@/lib/graph-clipboard";
 import { toast } from "@/components/core/sonner";
 import { cn } from "@/lib/utils";
@@ -357,16 +361,9 @@ function ItemActionButton({
   );
 }
 
-function ItemActionsOverflow({
-  hasSelection,
-  busy,
-  allDisabled,
-}: Readonly<{
-  hasSelection: boolean;
-  busy: boolean;
-  allDisabled: boolean;
-}>) {
-  const disabled = busy || !hasSelection;
+function ItemActionsOverflow({ state }: Readonly<{ state: ItemActionState }>) {
+  const actions = visibleItemActions(state, "overflow");
+  const disabled = state.busy || !state.hasSelection;
   const tooltipId = "sidebar-tooltip-item-more";
 
   return (
@@ -392,24 +389,23 @@ function ItemActionsOverflow({
       </DropdownMenuTrigger>
       <DropdownMenuContent side="right" align="start">
         <DropdownMenuGroup>
-          <DropdownMenuItem
-            disabled={disabled}
-            onSelect={() => requestGraphItemAction("duplicate")}
-          >
-            <CopyPlus className="mr-2 h-4 w-4" />
-            Duplicate
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            disabled={disabled}
-            onSelect={() => requestGraphItemAction("toggle-disabled")}
-          >
-            {allDisabled ? (
-              <CircleCheck className="mr-2 h-4 w-4" />
-            ) : (
-              <Ban className="mr-2 h-4 w-4" />
-            )}
-            {allDisabled ? "Enable" : "Disable"}
-          </DropdownMenuItem>
+          {/* The rail's half of ITEM_ACTION_SPECS — the actions common enough
+              to keep but not common enough to spend a tile on. The card's
+              right-click menu inlines these instead, having no overflow to
+              fold into. */}
+          {actions.map((spec) => {
+            const Icon = spec.icon(state);
+            return (
+              <DropdownMenuItem
+                key={spec.action}
+                disabled={spec.disabled(state)}
+                onSelect={() => requestGraphItemAction(spec.action)}
+              >
+                <Icon className="mr-2 h-4 w-4" />
+                {spec.label(state)}
+              </DropdownMenuItem>
+            );
+          })}
         </DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>
@@ -425,23 +421,7 @@ function ItemActionsOverflow({
  * close). While an async
  * action is in flight (`busy`) every button disables, so nothing double-fires.
  */
-function ItemActionsCluster({
-  hasSelection,
-  isSingleSelection,
-  canPaste,
-  busy,
-  allDisabled,
-}: Readonly<{
-  hasSelection: boolean;
-  /** Exactly ONE item selected — the only shape the details view can render.
-   *  Distinct from `hasSelection`, which every other action here is happy
-   *  with. */
-  isSingleSelection: boolean;
-  canPaste: boolean;
-  busy: boolean;
-  /** Every selected item is already skipped — flips the toggle to "Enable". */
-  allDisabled: boolean;
-}>) {
+function ItemActionsCluster({ state }: Readonly<{ state: ItemActionState }>) {
   return (
     <div className="flex w-full flex-col items-stretch gap-0">
       {/* Only actions that operate on the selection or clipboard sit inside the amber
@@ -453,57 +433,27 @@ function ItemActionsCluster({
         data-item-actions-cluster
         className="flex w-full flex-col items-stretch gap-0 bg-amber-200/[0.025]"
       >
-        {/* FIRST, because it is the action that tells you WHAT you have
-            selected before you act on it — and because the details view lost
-            its per-card trigger to get here (PL13-009). Disabled, not hidden,
-            past one selection: a control that vanishes teaches nothing, while a
-            disabled one says "wrong shape of selection for that". */}
-        <ItemActionButton
-          action="details"
-          icon={Pencil}
-          label="Edit"
-          description="Open the selected item's details"
-          disabled={busy || !isSingleSelection}
-        />
-        {!canPaste ? (
-          <>
-            <ItemActionButton
-              action="copy"
-              icon={Copy}
-              label="Copy"
-              description="Copy the selected item"
-              disabled={busy || !hasSelection}
-            />
-            <ItemActionButton
-              action="cut"
-              icon={Scissors}
-              label="Cut"
-              description="Cut the selected item — paste to move it"
-              disabled={busy || !hasSelection}
-            />
-          </>
-        ) : null}
-        {canPaste ? (
+        {/* Rendered from ITEM_ACTION_SPECS (PL14-007), the same ordered list
+            the card's right-click menu walks — so the two surfaces cannot
+            drift apart about what an item can do, which is the whole reason
+            that list exists. The rail respects `group`, the flat menu ignores
+            it; neither had to bend its order to share.
+
+            Details still comes first, and still DISABLES rather than hides
+            past one selection: a control that vanishes teaches nothing, while
+            a disabled one says "wrong shape of selection for that". Copy/Cut
+            still swap for Paste — that is `visible` in the spec now. */}
+        {visibleItemActions(state, "primary").map((spec) => (
           <ItemActionButton
-            action="paste"
-            icon={ClipboardPaste}
-            label="Paste"
-            description="Paste into this timeline"
-            disabled={busy}
+            key={spec.action}
+            action={spec.action}
+            icon={spec.icon(state)}
+            label={spec.label(state)}
+            description={spec.description(state)}
+            disabled={spec.disabled(state)}
           />
-        ) : null}
-        <ItemActionButton
-          action="delete"
-          icon={Trash2}
-          label="Delete"
-          description="Move the selected item to trash"
-          disabled={busy || !hasSelection}
-        />
-        <ItemActionsOverflow
-          hasSelection={hasSelection}
-          busy={busy}
-          allDisabled={allDisabled}
-        />
+        ))}
+        <ItemActionsOverflow state={state} />
       </div>
       <SidebarSeparator selected />
       <ItemActionButton
@@ -511,7 +461,7 @@ function ItemActionsCluster({
         icon={X}
         label="Done"
         description="Exit item actions and clear the clipboard"
-        disabled={busy}
+        disabled={state.busy}
         tone="neutral"
       />
     </div>
@@ -689,11 +639,13 @@ export function TimelineSidebar() {
 
       {activeProjectId && itemMode && (
         <ItemActionsCluster
-          hasSelection={selectionCount > 0}
-          isSingleSelection={selectionCount === 1}
-          canPaste={canPaste}
-          busy={actionBusy}
-          allDisabled={selectionAllDisabled}
+          state={{
+            hasSelection: selectionCount > 0,
+            isSingleSelection: selectionCount === 1,
+            canPaste,
+            busy: actionBusy,
+            allDisabled: selectionAllDisabled,
+          }}
         />
       )}
 

--- a/apps/timeline-gstudio001/lib/graph-item-action-specs.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-item-action-specs.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ITEM_ACTION_SPECS,
+  visibleItemActions,
+  type ItemActionState,
+} from "./graph-item-action-specs";
+
+// PL14-007. One ordered list, two surfaces: the sidebar's contextual rail
+// (which respects `group` and folds the rest behind "More") and a card's
+// right-click menu (which ignores `group` and shows everything).
+//
+// These pin the SHAPES both surfaces depend on. The rail's and the menu's own
+// rendering is covered by the graph-view e2e; what cannot be seen from either
+// of those is that they are still reading the same list — which is the whole
+// point of the list existing.
+
+const state = (over: Partial<ItemActionState> = {}): ItemActionState => ({
+  hasSelection: true,
+  isSingleSelection: true,
+  canPaste: false,
+  busy: false,
+  allDisabled: false,
+  ...over,
+});
+
+const labels = (s: ItemActionState, group?: "primary" | "overflow") =>
+  visibleItemActions(s, group).map((spec) => spec.label(s));
+
+describe("item action specs", () => {
+  it("gives the rail exactly the run it had: Edit, Copy, Cut, Delete", () => {
+    expect(labels(state(), "primary")).toEqual(["Edit", "Copy", "Cut", "Delete"]);
+    expect(labels(state(), "overflow")).toEqual(["Duplicate", "Disable"]);
+  });
+
+  it("gives the flat menu the same actions with the overflow inlined", () => {
+    // Same relative order, both overflow actions in place, and Delete still
+    // LAST — a destructive action at the end is harder to hit in passing, and
+    // a menu has no "More" button to sit before.
+    expect(labels(state())).toEqual([
+      "Edit",
+      "Copy",
+      "Cut",
+      "Duplicate",
+      "Disable",
+      "Delete",
+    ]);
+  });
+
+  it("the two surfaces cover the same actions — no drift", () => {
+    // The reason this list exists. A rail action with no menu entry (or the
+    // reverse) is the failure it prevents.
+    const menu = visibleItemActions(state()).map((s) => s.action);
+    const rail = [
+      ...visibleItemActions(state(), "primary"),
+      ...visibleItemActions(state(), "overflow"),
+    ].map((s) => s.action);
+    expect([...menu].sort()).toEqual([...rail].sort());
+  });
+
+  it("Copy and Cut swap for Paste when the clipboard is armed", () => {
+    expect(labels(state({ canPaste: true }))).toEqual([
+      "Edit",
+      "Paste",
+      "Duplicate",
+      "Disable",
+      "Delete",
+    ]);
+  });
+
+  it("Disable becomes Enable when the whole selection is already skipped", () => {
+    const enabled = visibleItemActions(state()).find((s) => s.action === "toggle-disabled")!;
+    const disabled = state({ allDisabled: true });
+    expect(enabled.label(state())).toBe("Disable");
+    expect(enabled.label(disabled)).toBe("Enable");
+    // The icon follows the word — one concept, not two.
+    expect(enabled.icon(state())).not.toBe(enabled.icon(disabled));
+  });
+
+  it("Edit is the only action that needs a SINGLE selection", () => {
+    const multi = state({ isSingleSelection: false });
+    const blocked = ITEM_ACTION_SPECS.filter((s) => s.disabled(multi) && !s.disabled(state()));
+    expect(blocked.map((s) => s.action)).toEqual(["details"]);
+  });
+
+  it("everything that touches the selection disables without one", () => {
+    const empty = state({ hasSelection: false, isSingleSelection: false });
+    // Paste is the exception by design: it acts on the CLIPBOARD, so it is
+    // available with nothing selected.
+    const live = visibleItemActions(empty).filter((s) => !s.disabled(empty));
+    expect(live.map((s) => s.action)).toEqual([]);
+    const armed = state({ hasSelection: false, isSingleSelection: false, canPaste: true });
+    expect(visibleItemActions(armed).filter((s) => !s.disabled(armed)).map((s) => s.action))
+      .toEqual(["paste"]);
+  });
+
+  it("busy disables everything, so nothing double-fires", () => {
+    const busy = state({ busy: true, canPaste: true });
+    expect(visibleItemActions(busy).every((s) => s.disabled(busy))).toBe(true);
+  });
+});

--- a/apps/timeline-gstudio001/lib/graph-item-action-specs.ts
+++ b/apps/timeline-gstudio001/lib/graph-item-action-specs.ts
@@ -39,8 +39,20 @@ export type ItemActionState = Readonly<{
   allDisabled: boolean;
 }>;
 
+/**
+ * Where the RAIL puts an action. The rail is a narrow column, so it shows the
+ * common few and folds the rest behind a "More" overflow; a flat menu has
+ * nowhere to fold and shows everything.
+ *
+ * Modelled here rather than in the rail because it is the last thing the two
+ * surfaces disagreed about — with it, both render the same ordered list and
+ * differ only in whether they respect the grouping.
+ */
+export type ItemActionGroup = "primary" | "overflow";
+
 export type ItemActionSpec = Readonly<{
   action: GraphItemAction;
+  group: ItemActionGroup;
   /** Resolved against state, because two of them change wording: Disable
    *  becomes Enable, and the icon follows. */
   label: (state: ItemActionState) => string;
@@ -65,21 +77,17 @@ const always = () => true;
  * (PL13-009). Delete LAST, because a destructive action at the end of a menu
  * is harder to hit on the way to something else.
  *
- * Not identical to the rail's visual order, and it cannot be: the rail hides
- * Duplicate and Disable behind a "More" overflow, which is an affordance
- * rather than an action, so its Delete sits before that button. A flat menu
- * has no overflow to hide behind and inlines both. Same actions, same relative
- * grouping; the one difference is where Delete falls, and last is the safer
- * answer for the surface that has no overflow.
- *
- * NOTE: the rail does not render from this list yet — it still has its own
- * JSX. Folding it in means teaching this list about the primary/overflow split
- * and is its own change; until then "one definition" is true of the menu and
- * aspirational of the pair.
+ * ONE order serves both surfaces, which is what `group` buys. Walking it and
+ * respecting the grouping gives the rail exactly what it had — Edit, Copy,
+ * Cut (or Paste), Delete, then More(Duplicate, Disable). Walking it and
+ * ignoring the grouping gives the menu exactly what it had — the same run with
+ * both overflow actions inlined and Delete still last. Neither surface needed
+ * its order bent to share the list.
  */
 export const ITEM_ACTION_SPECS: readonly ItemActionSpec[] = [
   {
     action: "details",
+    group: "primary",
     label: () => "Edit",
     description: () => "Open the selected item's details",
     icon: () => Pencil,
@@ -88,6 +96,7 @@ export const ITEM_ACTION_SPECS: readonly ItemActionSpec[] = [
   },
   {
     action: "copy",
+    group: "primary",
     label: () => "Copy",
     description: () => "Copy the selected item",
     icon: () => Copy,
@@ -96,6 +105,7 @@ export const ITEM_ACTION_SPECS: readonly ItemActionSpec[] = [
   },
   {
     action: "cut",
+    group: "primary",
     label: () => "Cut",
     description: () => "Cut the selected item — paste to move it",
     icon: () => Scissors,
@@ -104,6 +114,7 @@ export const ITEM_ACTION_SPECS: readonly ItemActionSpec[] = [
   },
   {
     action: "paste",
+    group: "primary",
     label: () => "Paste",
     description: () => "Paste into this timeline",
     icon: () => ClipboardPaste,
@@ -112,6 +123,7 @@ export const ITEM_ACTION_SPECS: readonly ItemActionSpec[] = [
   },
   {
     action: "duplicate",
+    group: "overflow",
     label: () => "Duplicate",
     description: () => "Duplicate the selected item",
     icon: () => CopyPlus,
@@ -120,6 +132,7 @@ export const ITEM_ACTION_SPECS: readonly ItemActionSpec[] = [
   },
   {
     action: "toggle-disabled",
+    group: "overflow",
     label: (s) => (s.allDisabled ? "Enable" : "Disable"),
     description: (s) =>
       s.allDisabled
@@ -131,6 +144,7 @@ export const ITEM_ACTION_SPECS: readonly ItemActionSpec[] = [
   },
   {
     action: "delete",
+    group: "primary",
     label: () => "Delete",
     description: () => "Move the selected item to trash",
     icon: () => Trash2,
@@ -139,7 +153,17 @@ export const ITEM_ACTION_SPECS: readonly ItemActionSpec[] = [
   },
 ];
 
-/** What a surface should actually render, in order. */
-export function visibleItemActions(state: ItemActionState): readonly ItemActionSpec[] {
-  return ITEM_ACTION_SPECS.filter((spec) => spec.visible(state));
+/**
+ * What a surface should actually render, in order.
+ *
+ * `group` omitted = everything, which is the flat menu. Pass one and you get
+ * the rail's halves.
+ */
+export function visibleItemActions(
+  state: ItemActionState,
+  group?: ItemActionGroup,
+): readonly ItemActionSpec[] {
+  return ITEM_ACTION_SPECS.filter(
+    (spec) => spec.visible(state) && (group === undefined || spec.group === group),
+  );
 }

--- a/punch-list/PUNCH-LIST-14.md
+++ b/punch-list/PUNCH-LIST-14.md
@@ -378,16 +378,24 @@ action while one is in flight, and a menu is open for a moment rather than a
 session — mirroring the flag would mean a second subscription for a state this
 surface can barely observe.
 
-### Still two definitions, and that is the follow-up
+### One definition now — the follow-up landed
 
-The item asked for "one source, two surfaces". `ITEM_ACTION_SPECS` is that
-source and the MENU renders it — but the rail still has its own JSX, so the
-pair is not yet unified. Folding the rail in means teaching the list about the
-rail's primary/overflow split (it hides Duplicate and Disable behind "More",
-which is why the two orders differ: a flat menu has no overflow and puts Delete
-last, where a destructive action is hardest to hit on the way to something
-else). That is its own change and was not worth destabilising a heavily-tuned
-surface at the end of a long batch.
+Shipped in two steps. The menu rendered `ITEM_ACTION_SPECS` first while the
+rail kept its own JSX, which was two definitions with a shared intention. The
+rail renders the list too now.
+
+What made it possible was `group: "primary" | "overflow"`. The rail is a narrow
+column that folds the uncommon actions behind "More"; a flat menu has nowhere
+to fold. With the grouping in the data, ONE ordered list serves both: walk it
+respecting `group` and the rail gets exactly what it had (Edit, Copy, Cut or
+Paste, Delete, then More→Duplicate, Disable); walk it ignoring `group` and the
+menu gets exactly what it had (the same run, overflow inlined, Delete still
+last). Neither surface had its order bent to share.
+
+Verified as invisible: the rail still renders Edit, Copy, Cut, Delete, More
+with Done outside the amber block, and the overflow still holds Duplicate and
+Disable. Eight unit tests pin the shapes, including that the two surfaces cover
+the SAME action set — the drift this list exists to prevent.
 
 ## PL14-008 — An untouched, empty collection is discarded, not trashed
 


### PR DESCRIPTION
[PR #249](https://github.com/josulliv101/storyboard-flow/pull/249) shipped PL14-007 with **two definitions**, and said so: `ITEM_ACTION_SPECS` was the source, the card's right-click menu rendered it, and the sidebar rail kept its own JSX. That's a shared intention, not one definition. This closes it.

## What made one list serve both

`group: "primary" | "overflow"`.

The rail is a narrow column that folds the uncommon actions behind "More". A flat menu has nowhere to fold. With that grouping in the data, one ordered list gives both surfaces exactly what they already had:

| walk the list… | result |
|---|---|
| respecting `group` | Edit, Copy, Cut (or Paste), Delete, then More→(Duplicate, Disable) — the rail |
| ignoring `group` | the same order, overflow inlined, Delete still last — the menu |

**Neither surface had its order bent to share.** Delete stays last in the menu because a destructive action at the end is harder to hit on the way to something else; the rail's Delete stays before "More" because "More" is an affordance rather than an action.

## Verified invisible

This refactor should change nothing on screen, so I checked in the running app rather than assuming:

- rail: Edit, Copy, Cut, Delete, More — with Done still outside the amber block
- overflow: Duplicate, Disable

Both identical to before.

## The test that justifies the whole exercise

Eight unit cases pin the shapes, including:

```
it("the two surfaces cover the same actions — no drift")
```

A rail action with no menu entry (or the reverse) is precisely the failure this list exists to prevent — and it's something neither the rail's own coverage nor the menu's e2e can see, because each only knows about itself.

Also pinned: the Copy/Cut↔Paste swap, Disable↔Enable flipping its word *and* its icon together, Edit being the only action that needs a single selection, Paste being the only one available with nothing selected, and `busy` disabling everything.

| | |
|---|---|
| App vitest | 522 passed (8 new) |
| Unit | 414 passed |
| Storybook | 165 passed |
| graph-view e2e | 102 passed |
| Typecheck | clean |
| Lint | 0 errors (5 pre-existing `<img>` warnings) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)