### PR TITLE
Revert the RenderEfficiency settle; keep the diagnostics

### DIFF
--- a/packages/ui/dnd-collections/DndCollections.stories.tsx
+++ b/packages/ui/dnd-collections/DndCollections.stories.tsx
@@ -17,7 +17,6 @@ import {
   rectCenter,
   rectPoint,
   releaseAt,
-  settledAttribute,
   waitForLayout,
 } from "./stories-helpers";
 
@@ -1005,14 +1004,16 @@ export const RenderEfficiencyDuringDrag: Story = {
       expect(target.parentElement?.querySelector('[data-drop-indicator="before"]')).toBeTruthy();
     });
 
-    // SETTLED, not sampled on the spot. The drop indicator appearing means the
-    // intent resolved, not that React has finished, so a straggler from
-    // drag-start could otherwise be charged to the jitter below. This does NOT
-    // make the number predictable and is not meant to: drag-start costs the
-    // bystander a genuinely variable count (9,9,9,9,7 measured across five
-    // local runs, 9,7,9 across three CI failures). What matters is only that
-    // nothing is still in flight when the window opens.
-    const bystanderRendersBefore = await settledAttribute(bystander, "data-render-count");
+    // Sampled immediately, NOT after waiting for the render count to settle.
+    // A settle was tried (PR #251) on the theory that a drag-start straggler
+    // was being charged to the jitter — and it inserted a pause mid-drag that
+    // had not been there. The very next CI run failed differently: the DROP
+    // stopped landing. dnd-kit recomputes `over` on a measure cadence, so
+    // holding the pointer still for extra frames gives the resolved intent
+    // more chances to move before release. Reverted rather than defended: it
+    // was a speculative fix for a failure that was never reproduced, and it
+    // plausibly bought a worse one.
+    const bystanderRendersBefore = bystander.getAttribute("data-render-count");
 
     // Jitter the pointer within the same intent (still left half of t1),
     // recording after EACH move. The assertion needs one number, but a failure

--- a/packages/ui/dnd-collections/stories-helpers.ts
+++ b/packages/ui/dnd-collections/stories-helpers.ts
@@ -44,49 +44,6 @@ export async function dispatchPointerSequence(steps: readonly PointerStep[]): Pr
   }
 }
 
-/**
- * An attribute's value once it has STOPPED changing.
- *
- * For render-count assertions, where the question is "did this window cause
- * any renders" and the answer is only meaningful if the previous window has
- * finished. Sampling the instant some other condition goes true is too early:
- * `waitFor` returns as soon as its predicate passes, while React may still
- * have queued work behind it, and a straggler that lands after the sample gets
- * charged to whatever the test does next.
- *
- * That is exactly how `RenderEfficiencyDuringDrag` failed on CI three times
- * (2026-07-30). The tell was that the BASELINE varied — 9, 7, 9 across three
- * runs, reproduced locally at 9,9,9,9,7 — which a settled setup cannot do. The
- * extra renders were drag-start work arriving late, not renders the jitter
- * caused; a slower machine simply moved the straggler to the far side of the
- * sample.
- *
- * THROWS rather than giving up if it never settles. A drag that genuinely
- * re-renders forever is a real failure and must not be quietly averaged away —
- * this makes the sample point well-defined, it does not soften the assertion
- * that follows.
- */
-export async function settledAttribute(
-  element: HTMLElement,
-  name: string,
-  { stableFrames = 4, maxFrames = 180 }: { stableFrames?: number; maxFrames?: number } = {},
-): Promise<string | null> {
-  let value = element.getAttribute(name);
-  let stable = 0;
-  for (let frame = 0; frame < maxFrames; frame += 1) {
-    await new Promise<void>((resolve) => {
-      requestAnimationFrame(() => resolve());
-    });
-    const next = element.getAttribute(name);
-    stable = next === value ? stable + 1 : 0;
-    value = next;
-    if (stable >= stableFrames) return value;
-  }
-  throw new Error(
-    `"${name}" never settled: still changing after ${maxFrames} frames (last "${value}")`,
-  );
-}
-
 export async function waitForLayout(element: HTMLElement): Promise<void> {
   await waitFor(() => {
     const rect = element.getBoundingClientRect();


### PR DESCRIPTION
[PR #251](https://github.com/josulliv101/storyboard-flow/pull/251) made two changes to `Render Efficiency During Drag`. One was speculative and one wasn't. **The speculative one is out.**

## What happened

#251 sampled the bystander's render count only after it had gone quiet (`settledAttribute`), on the theory that a drag-start straggler was being charged to the jitter window. I couldn't reproduce the failure it targeted, so that fix was **never validated** — I said so at the time.

The very next CI run — [PR #252](https://github.com/josulliv101/storyboard-flow/pull/252), an app-only change touching no package file — failed **differently**:

```
expected [ 't1', 't2', 't3' ] to deeply equal [ 'w0', 't1', 't2', 't3' ]
```

Not the render count. The **drop itself** didn't land. All three prior failures were the render-count assertion; this mode was new, and it appeared on the first run after the settle landed.

## Why that's plausible, not coincidence

The settle holds the pointer still for extra frames mid-drag, which hadn't happened before. **dnd-kit recomputes `over` on a measure cadence** — this repo's own notes record that as the classic CI-only drag flake — so a longer hold gives the resolved intent more chances to move before release.

Buying a speculative fix for an unreproduced failure at the cost of a new failure mode is a bad trade.

## What's kept

The per-move diagnostic, which carries **no timing change** and is the half with real value:

```
bystander re-rendered during jitter
(baseline 9; after each move +3,+2:9 -3,-2:9 +2,+1:9 back:9)
```

## Where that leaves it

The original flake is **still unfixed and still undiagnosed**, exactly as it was before #251 — but the next occurrence will say which move caused it. That's the honest position, and better than carrying a change I couldn't justify.

| | |
|---|---|
| Storybook | 165 passed |
| Unit | 414 passed |
| App vitest | 514 passed |
| Typecheck | clean |
| Lint | 0 errors |

Story file run 3× clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)