### PR TITLE
PL14-012: the fine-trim chord accepts Cmd as well as Ctrl

### DIFF
--- a/packages/ui/dnd-collections/VirtualStrip.stories.tsx
+++ b/packages/ui/dnd-collections/VirtualStrip.stories.tsx
@@ -1432,6 +1432,19 @@ export const FineKeyboardTrim: Story = {
     }
     await waitFor(() => expect(width("img")).toBe(96));
 
+    // META is the same chord. Ctrl-only shipped first and left macOS with no
+    // fine trim at all — Ctrl+Arrow is Mission Control there and never reaches
+    // the page. Either modifier now, matching what copy/paste and multi-select
+    // already accept.
+    for (let step = 0; step < 10; step += 1) {
+      await user.keyboard("{Meta>}{ArrowRight}{/Meta}");
+    }
+    await waitFor(() => expect(width("img")).toBe(120));
+    for (let step = 0; step < 10; step += 1) {
+      await user.keyboard("{Meta>}{ArrowLeft}{/Meta}");
+    }
+    await waitFor(() => expect(width("img")).toBe(96));
+
     // The video's START edge answers to the vertical pair, same grammar as
     // Alt+Shift — one fine trim is one command, so ten are ten undo steps.
     const vid = nodeCard(canvasElement, "vid");

--- a/packages/ui/dnd-collections/react/use-keyboard-controller.ts
+++ b/packages/ui/dnd-collections/react/use-keyboard-controller.ts
@@ -342,11 +342,18 @@ export function useCollectionsKeyboard(args: {
   const handleKeyDownCapture = useCallback(
     (event: ReactKeyboardEvent) => {
       // TWO grammars reach this handler. Alt(+Shift) is the established one;
-      // Ctrl+Arrow alone is the fine trim (PL14-012). Checked as an exact
-      // chord — a held Alt, Meta or Shift makes it something else, which the
-      // Alt grammar below or the browser should have.
+      // Ctrl/Cmd+Arrow alone is the fine trim (PL14-012).
+      //
+      // Ctrl OR META, because that is already this codebase's convention for
+      // "the platform's modifier" — the copy/cut/paste shortcuts and the
+      // multi-select policy both accept either. Ctrl-only shipped first and
+      // was the outlier: on macOS Ctrl+Arrow is Mission Control and never
+      // reaches the page at all, so a Mac user had no fine trim.
+      //
+      // Still an exact chord otherwise: a held Alt or Shift makes it something
+      // else, which the Alt grammar below or the browser should have.
       const fineTrimAction =
-        event.ctrlKey && !event.altKey && !event.metaKey && !event.shiftKey
+        (event.ctrlKey || event.metaKey) && !event.altKey && !event.shiftKey
           ? FINE_TRIM_ACTION_BY_KEY[event.key]
           : undefined;
 

--- a/punch-list/PUNCH-LIST-14.md
+++ b/punch-list/PUNCH-LIST-14.md
@@ -643,5 +643,10 @@ one Alt+Shift press**. That equality is the proof — at a 1s step the same ten
 presses land at 336px instead of 120px, which is exactly how the story fails
 when the constant is wrong (verified).
 
-Open, and cheap if wanted: Mac. `Ctrl+Arrow` is Mission Control there, so a Mac
-user would want `Cmd` — the handler currently returns on `metaKey`.
+**Closed the Mac gap.** Ctrl-only shipped first and left macOS with no fine
+trim at all — `Ctrl+Arrow` is Mission Control there and never reaches the page.
+The chord accepts Ctrl OR Meta now, which is not a new decision so much as
+joining the convention already in the codebase: the copy/cut/paste shortcuts
+(`graph-item-actions.tsx`) and the multi-select policy (`interaction-policy.ts`)
+both accept either. Ctrl-only was the outlier. The story presses both; reverting
+to Ctrl-only fails the Meta half (`expected 96 to be 120`).


### PR DESCRIPTION
Ctrl-only shipped first and left **macOS with no fine trim at all** — `Ctrl+Arrow` is Mission Control there and never reaches the page.

## Less a new decision than joining an existing convention

I'd flagged this as your call. Looking at what's already in the codebase, it isn't really one:

- `graph-item-actions.tsx:575` — `if (!(event.ctrlKey || event.metaKey) || event.altKey) return;` (copy/cut/paste)
- `interaction-policy.ts:113` — `if (event.ctrlKey || event.metaKey)` (multi-select)

Both already treat Ctrl and Meta as the same "platform modifier". The fine-trim chord requiring Ctrl and *explicitly rejecting* Meta was the **outlier**, not the norm it was matching.

## Still an exact chord

A held Alt or Shift makes it something else, which the Alt grammar or the browser should have. The Alt-grammar guard below is untouched, so it still rejects a held Ctrl/Meta exactly as before.

## Pinned, not assumed

The story presses both modifiers. Reverting to Ctrl-only fails the Meta half:

```
× Fine Keyboard Trim
  expected 96 to be 120
```

| | |
|---|---|
| Storybook | 165 passed |
| Unit | 414 passed |
| App vitest | 522 passed |
| graph-view e2e | 102 passed |
| Typecheck | clean |
| Lint | 0 errors (5 pre-existing `<img>` warnings) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)