### PR TITLE
Review fixes: narrow the context menu's selectors, correct its Disable label

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -643,3 +643,86 @@ export const DisabledCollection: Story = {
     await expect(previewImages(canvasElement)).toHaveLength(1);
   },
 };
+
+/** Two sibling cards, so selecting one can be checked against the other. */
+const SIB_A = "sib-a" as NodeId;
+const SIB_B = "sib-b" as NodeId;
+/** Never clicked — the bystander the assertion is actually about. */
+const SIB_C = "sib-c" as NodeId;
+const siblingGraph = (() => {
+  const result = buildGraph([
+    {
+      kind: "collection",
+      id: "sib-root",
+      name: "Root",
+      children: [
+        { kind: "media", id: SIB_A, name: "A", src: poster("A", "#0ea5e9"), durationSeconds: 4 },
+        { kind: "media", id: SIB_B, name: "B", src: poster("B", "#f59e0b"), durationSeconds: 4 },
+        { kind: "media", id: SIB_C, name: "C", src: poster("C", "#22c55e"), durationSeconds: 4 },
+      ],
+    },
+  ]);
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.value;
+})();
+
+export const SelectingOneCardDoesNotRerenderTheOther: Story = {
+  // The package's bystander guarantee, asserted through the APP's own card
+  // registry rather than the package's defaults — this is the composition the
+  // graph actually ships, and nothing else covered it.
+  //
+  // Written while reviewing PL14-007, on a suspicion that turned out to be
+  // WRONG and is worth recording: the right-click menu wraps every card via
+  // the registered ItemShell and subscribed to `interaction.selectedIds` (the
+  // Set, which `setSelection` replaces on every change), which looked like it
+  // would re-render every card on any selection. It does not. `GraphMediaItem`
+  // and `GraphCollectionItem` are both `memo`, so the re-render stops at the
+  // thin wrapper and never reaches the card. This story PASSES against that
+  // version too — it is not a regression test for it.
+  //
+  // What it is worth: the memo boundary is the only thing holding that line,
+  // and nothing was asserting it. Remove a `memo`, or give the wrapper a prop
+  // that changes per selection, and this fails.
+  args: { id: SIB_A },
+  decorators: [
+    (Story) => (
+      <DndCollections initialGraph={siblingGraph}>
+        <GraphDetailsProvider store={createGraphDetailsStore({})}>
+          <div className="flex h-32 gap-2 bg-zinc-950 p-2">
+            <Story />
+          </div>
+        </GraphDetailsProvider>
+      </DndCollections>
+    ),
+  ],
+  render: () => (
+    <>
+      <ItemShell id={SIB_A} className="h-full w-24" />
+      <ItemShell id={SIB_B} className="h-full w-24" />
+      <ItemShell id={SIB_C} className="h-full w-24" />
+    </>
+  ),
+  play: async ({ canvasElement }) => {
+    // The count lives on the NodeCard button (`[data-node-id]`) for media
+    // cards, not on the CollectionItem wrapper.
+    const card = (id: string) =>
+      canvasElement.querySelector<HTMLElement>(`[data-node-id="${id}"]`)!;
+    const renders = (id: string) => card(id).getAttribute("data-render-count");
+
+    await waitFor(() => expect(card(SIB_C)).toBeTruthy());
+    expect(renders(SIB_C)).not.toBeNull();
+
+    // C is never touched. Two selection changes happen around it, and its
+    // render count must not move for either — that is the whole guarantee.
+    const bystander = renders(SIB_C);
+
+    await userEvent.click(card(SIB_A));
+    await waitFor(() => expect(card(SIB_A).getAttribute("data-selected")).toBe("true"));
+    expect(renders(SIB_C)).toBe(bystander);
+
+    await userEvent.click(card(SIB_B));
+    await waitFor(() => expect(card(SIB_B).getAttribute("data-selected")).toBe("true"));
+    expect(card(SIB_A).getAttribute("data-selected")).toBeNull();
+    expect(renders(SIB_C)).toBe(bystander);
+  },
+};

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-context-menu.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-context-menu.tsx
@@ -37,11 +37,41 @@ import { visibleItemActions, type ItemActionState } from "@/lib/graph-item-actio
 // user reached for "Delete" on all six.
 
 function useItemActionState(nodeId: NodeId): ItemActionState {
-  const selectedIds = useCollectionsSelector((s) => s.interaction.selectedIds);
+  // PRIMITIVES, not the Set. `setSelection` builds a new Set on every change,
+  // so subscribing to the reference re-renders this component whenever the
+  // selection changes ANYWHERE — and this component wraps every card on the
+  // board. That is the package's render-efficiency invariant
+  // (dnd-collections/CLAUDE.md: selectors must return primitives or references
+  // stable while the slice is unchanged), and reading the Set broke it.
+  //
+  // Two booleans and a number instead: each re-renders only when its own value
+  // changes, and a selection moving between two OTHER cards changes none of
+  // them.
+  // Each selector answers the question ALREADY NARROWED to this node, so an
+  // uninvolved card's values do not move when the selection changes elsewhere.
+  //
+  // Returning a primitive is not enough on its own: `selectedIds.size` is a
+  // number and still goes 0 → 1 when some other card is selected, which would
+  // re-render every card just as subscribing to the Set did. What makes these
+  // quiet is that an unselected node's answer does not depend on the selection
+  // at all.
+  const isSingleSelection = useCollectionsSelector((s) => {
+    const ids = s.interaction.selectedIds;
+    // Not in the selection: opening the menu will make this node the whole of
+    // it, so one item — whatever anyone else has selected.
+    return ids.has(nodeId) ? ids.size === 1 : true;
+  });
   const allDisabled = useCollectionsSelector((s) => {
-    const ids = [...s.interaction.selectedIds];
-    if (ids.length === 0) return false;
-    return ids.every((id) => s.graph.nodesById.get(id)?.disabled === true);
+    const ids = s.interaction.selectedIds;
+    // Same narrowing: outside the selection the honest answer is this node's
+    // own state, which is also what the menu is about to act on.
+    if (!ids.has(nodeId)) return s.graph.nodesById.get(nodeId)?.disabled === true;
+    // No spread — this runs per card per store notification, and the store
+    // notifies on every drop-intent change during a drag.
+    for (const id of ids) {
+      if (s.graph.nodesById.get(id)?.disabled !== true) return false;
+    }
+    return true;
   });
   // The clipboard is a module singleton, not store state — subscribe so the
   // menu's Copy/Cut↔Paste swap is right the moment it opens.
@@ -51,22 +81,18 @@ function useItemActionState(nodeId: NodeId): ItemActionState {
     () => false,
   );
 
-  // The count the menu should describe is the selection it will ACT on, which
-  // for an unselected node is the one about to be selected (see the note
-  // above) — otherwise the menu opens describing "no selection" and disables
-  // everything on a card the user just right-clicked.
-  const willActOnSelection = selectedIds.has(nodeId) ? selectedIds.size : 1;
-
   return {
-    hasSelection: willActOnSelection > 0,
-    isSingleSelection: willActOnSelection === 1,
+    // Right-clicking always gives the menu something to act on: this node, if
+    // nothing else. Never zero, so never a menu of dead rows.
+    hasSelection: true,
+    isSingleSelection,
     canPaste,
     // Not modelled. The receiving side already refuses an action while one is
     // in flight (`busyRef` in GraphItemActionsBridge), and a menu is open for
     // a moment rather than a session — mirroring the flag here would mean a
     // second subscription for a state this surface can barely observe.
     busy: false,
-    allDisabled: selectedIds.has(nodeId) ? allDisabled : false,
+    allDisabled,
   };
 }
 


### PR DESCRIPTION
Self-review of today's PL14 work. **Three findings; one was wrong**, and it's recorded as wrong rather than quietly dropped.

## ❌ Wrong — "every card re-renders on any selection change"

The right-click menu wraps every card via the registered `ItemShell` and subscribed to `interaction.selectedIds` — the Set, which `setSelection` replaces on every change. Against `dnd-collections/CLAUDE.md`'s selector invariant, that looked like a clear regression, and I wrote it up as High.

**It isn't.** `GraphMediaItem` and `GraphCollectionItem` are both `memo`, so the re-render stops at the thin wrapper and never reaches the card. I measured before claiming, and the new story passes against the previous version too.

## ✅ Real — wasted work per card, per notification

The `allDisabled` selector spread the selection (`[...selectedIds]`) and scanned it, for **every card**, on **every store notification** — and the store notifies on each drop-intent change during a drag. Selectors now iterate the Set directly and allocate nothing.

## ✅ Real — a wrong label

`allDisabled` returned `false` for a node outside the selection, so right-clicking an already-disabled unselected card offered **"Disable"**. Cosmetic only — `toggle-disabled` recomputes from the live graph, so the action was always right. Narrowing the selectors to the node makes the honest answer fall out.

## A subtlety worth naming

**A selector returning a primitive is not automatically quiet.** My first fix used `selectedIds.size` — a number, which still moves `0 → 1` when some *other* card is selected, re-rendering every card exactly as the Set did. What keeps these still is that an unselected node's answer doesn't depend on the selection at all:

```ts
return ids.has(nodeId) ? ids.size === 1 : true;
```

I caught that the same way I caught the wrong finding — by measuring instead of reasoning.

## The new story

`SelectingOneCardDoesNotRerenderTheOther` asserts the bystander guarantee through the **app's** card registry — the composition the graph actually ships, where the package's own story uses its defaults.

It is **not** a regression test for anything above; it passes either way. What it pins is the `memo` boundary that makes the wrapper harmless, which nothing was asserting. Remove a `memo`, or give the wrapper a prop that changes per selection, and it fails.

| | |
|---|---|
| App vitest | 522 passed |
| Unit | 414 passed |
| Storybook | 166 passed (1 new) |
| graph-view e2e | 102 passed |
| Typecheck | clean |
| Lint | 0 errors (5 pre-existing `<img>` warnings) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)