### PR TITLE
Enforce the stored model's numeric invariants at the write boundary

### DIFF
--- a/packages/timeline-model/validate.test.ts
+++ b/packages/timeline-model/validate.test.ts
@@ -144,3 +144,95 @@ describe("isStoredTimelineDocument", () => {
     expect(isStoredTimelineDocument({ id: "", title: "Doc", clips: [] })).toBe(false);
   });
 });
+
+// Numeric invariants (external review, 2026-07-30). Finiteness alone let a
+// payload satisfy the guard and still violate the model it claims to be —
+// negative spans, a fractional index, a zero aspect, trims longer than the
+// source. Each was accepted, persisted, and only failed later in packing or
+// hydration, a long way from the write that caused it.
+//
+// The ACCEPT cases matter as much as the reject ones: this guards the write
+// path our own client goes through, so a rule that is merely stricter is a
+// rule that stops the app saving.
+
+describe("numeric invariants", () => {
+  const clip = (over: Record<string, unknown>) => ({ ...image, ...over });
+
+  it.each([
+    ["a negative duration", { duration: -1 }],
+    ["a negative start time", { startTime: -0.5 }],
+    ["a negative source duration", { sourceDuration: -4 }],
+    ["a negative trim in", { trimIn: -1 }],
+    ["a negative trim out", { trimOut: -1 }],
+    ["a negative playback duration", { playbackDuration: -2 }],
+    ["a fractional index", { index: 1.5 }],
+    ["a negative index", { index: -1 }],
+    ["a zero aspect", { aspect: 0 }],
+    ["a negative aspect", { aspect: -1.78 }],
+  ])("rejects %s", (_label, over) => {
+    expect(isTimelineClip(clip(over))).toBe(false);
+  });
+
+  it("rejects trims that leave nothing of the source", () => {
+    // 6 + 5 > 10: the clip would have negative effective duration, which the
+    // packer turns into overlapping geometry rather than an error.
+    expect(isTimelineClip(clip({ sourceDuration: 10, trimIn: 6, trimOut: 5 }))).toBe(false);
+  });
+
+  it("ACCEPTS trims that exactly consume the source", () => {
+    // Reachable by dragging a handle to the end. `<` would refuse a save the
+    // user can perform.
+    expect(isTimelineClip(clip({ sourceDuration: 10, trimIn: 4, trimOut: 6 }))).toBe(true);
+  });
+
+  it("ACCEPTS float dust past the source", () => {
+    // Trims accumulate from pointer deltas; 0.1 + 0.2 is famously not 0.3.
+    // The tolerance is arithmetic, not slack.
+    expect(isTimelineClip(clip({ sourceDuration: 0.3, trimIn: 0.1, trimOut: 0.2 }))).toBe(true);
+  });
+
+  it("ACCEPTS a zero duration — an empty hydrated collection has no span", () => {
+    expect(isTimelineClip(clip({ duration: 0, sourceDuration: 0, trimIn: 0, trimOut: 0 })))
+      .toBe(true);
+  });
+
+  it("ACCEPTS a fractional trackIndex, deliberately", () => {
+    // It should be an integer, but a legacy stored detail carrying a float
+    // would then be unable to write itself back, and the field is inert until
+    // multi-track lands. Pinned so the leniency is a decision, not a gap.
+    expect(isTimelineClip(clip({ trackIndex: 0.5 }))).toBe(true);
+  });
+
+  it("rejects a fractional or negative collection itemCount", () => {
+    expect(isTimelineClip({ ...collection, itemCount: 2.5 })).toBe(false);
+    expect(isTimelineClip({ ...collection, itemCount: -1 })).toBe(false);
+  });
+
+  it("rejects a playable duration longer than the span it is drawn from", () => {
+    // playableDuration counts the ENABLED subset, so it cannot exceed the
+    // layout span that includes the disabled ones too.
+    expect(isTimelineClip({ ...collection, duration: 4, playableDuration: 9 })).toBe(false);
+    expect(isTimelineClip({ ...collection, duration: 9, playableDuration: 4 })).toBe(true);
+  });
+
+  it("rejects a negative preview trimIn", () => {
+    expect(
+      isTimelineClip({
+        ...collection,
+        previewItems: [
+          { id: "p", kind: "image", src: "s", alt: "a", trimIn: -1 },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("still rejects the whole document when one clip breaks a rule", () => {
+    expect(
+      isStoredTimelineDocument({
+        id: "doc",
+        title: "Doc",
+        clips: [image, clip({ duration: -1 })],
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/timeline-model/validate.ts
+++ b/packages/timeline-model/validate.ts
@@ -13,12 +13,57 @@ function isFiniteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
 }
 
-function isOptionalString(value: unknown): boolean {
-  return value == null || typeof value === "string";
+// Finiteness alone let a payload satisfy the guard and still violate the model
+// it claims to be: negative durations, a negative trim, a fractional array
+// index, a zero aspect. Each of those is accepted today and only fails LATER —
+// in packing math or graph hydration, where the cause is a long way from the
+// write that caused it.
+//
+// The rules below are deliberately the ones that cannot be argued with, and
+// stop short of two the app's own writer would trip over:
+//
+//   - `duration` may be ZERO. An empty hydrated collection genuinely has no
+//     span (`hydratedCollectionDuration` over no children), so "> 0" would
+//     refuse a legitimate save.
+//   - `trackIndex` is left as any finite number. It should be a non-negative
+//     integer, but a legacy stored detail carrying a float would then be
+//     unable to write itself back, and the value is inert until multi-track
+//     lands.
+
+/** Times, spans and counts: a negative one is not a value, it is corruption. */
+function isNonNegative(value: unknown): value is number {
+  return isFiniteNumber(value) && value >= 0;
 }
 
-function isOptionalFiniteNumber(value: unknown): boolean {
-  return value == null || isFiniteNumber(value);
+function isOptionalNonNegative(value: unknown): boolean {
+  return value == null || isNonNegative(value);
+}
+
+/** Array positions and counts. Fractional ones index nothing. */
+function isNonNegativeInteger(value: unknown): value is number {
+  return isNonNegative(value) && Number.isInteger(value);
+}
+
+/**
+ * Trims must leave something behind.
+ *
+ * The tolerance is not slack, it is float arithmetic: trims are accumulated
+ * from pointer deltas and a legitimate full-length clip lands on
+ * `trimIn + trimOut` a few ulps past `sourceDuration`. Rejecting that would
+ * refuse a save the user can produce by dragging a handle to the end.
+ */
+const TRIM_EPSILON_SECONDS = 1e-6;
+
+function trimsFitInSource(clip: Record<string, unknown>): boolean {
+  const { trimIn, trimOut, sourceDuration } = clip;
+  if (!isFiniteNumber(trimIn) || !isFiniteNumber(trimOut) || !isFiniteNumber(sourceDuration)) {
+    return false;
+  }
+  return trimIn + trimOut <= sourceDuration + TRIM_EPSILON_SECONDS;
+}
+
+function isOptionalString(value: unknown): boolean {
+  return value == null || typeof value === "string";
 }
 
 /** Same null leniency as every optional field; when present, BOTH halves of
@@ -55,17 +100,24 @@ function hasClipBase(clip: Record<string, unknown>): boolean {
   return (
     typeof clip.id === "string" &&
     clip.id.length > 0 &&
-    isFiniteNumber(clip.index) &&
+    // An array position, so an integer — and the writer derives it from
+    // `.map((child, index) =>`, which cannot produce anything else.
+    isNonNegativeInteger(clip.index) &&
     typeof clip.alt === "string" &&
+    // Strictly positive: the ratio is a DIVISOR in layout, so zero is an
+    // infinity waiting to happen and a negative one inverts the box.
     isFiniteNumber(clip.aspect) &&
+    clip.aspect > 0 &&
     isFiniteNumber(clip.trackIndex) &&
-    isFiniteNumber(clip.startTime) &&
-    isFiniteNumber(clip.duration) &&
-    isFiniteNumber(clip.sourceDuration) &&
-    isFiniteNumber(clip.trimIn) &&
-    isFiniteNumber(clip.trimOut) &&
-    isOptionalFiniteNumber(clip.playbackStartTime) &&
-    isOptionalFiniteNumber(clip.playbackDuration) &&
+    isNonNegative(clip.startTime) &&
+    // Zero is legal here — see the note above `isNonNegative`.
+    isNonNegative(clip.duration) &&
+    isNonNegative(clip.sourceDuration) &&
+    isNonNegative(clip.trimIn) &&
+    isNonNegative(clip.trimOut) &&
+    trimsFitInSource(clip) &&
+    isOptionalNonNegative(clip.playbackStartTime) &&
+    isOptionalNonNegative(clip.playbackDuration) &&
     // Strictly boolean-or-absent. This gate guards the WRITE path, and a
     // truthy non-boolean would be read as "skip this clip" by the playback
     // and summary passes — a stored string "false" would silently drop a
@@ -94,7 +146,18 @@ export function isTimelineClip(value: unknown): value is TimelineClip {
     if (typeof clip.childTimelineId !== "string" || clip.childTimelineId.length === 0) {
       return false;
     }
-    if (!isFiniteNumber(clip.itemCount)) return false;
+    // A count of children: integral and never negative.
+    if (!isNonNegativeInteger(clip.itemCount)) return false;
+    // The playable half of a collection's span. Optional, and never longer
+    // than the layout span it is derived from — it counts the ENABLED subset.
+    if (!isOptionalNonNegative(clip.playableDuration)) return false;
+    if (
+      isFiniteNumber(clip.playableDuration) &&
+      isFiniteNumber(clip.duration) &&
+      clip.playableDuration > clip.duration + TRIM_EPSILON_SECONDS
+    ) {
+      return false;
+    }
     if (clip.previewItems == null) return true;
     if (!Array.isArray(clip.previewItems)) return false;
     return clip.previewItems.every((item) => {
@@ -106,7 +169,8 @@ export function isTimelineClip(value: unknown): value is TimelineClip {
         typeof preview.src === "string" &&
         typeof preview.alt === "string" &&
         isOptionalString(preview.poster) &&
-        isOptionalFiniteNumber(preview.trimIn)
+        // A source offset, so the same rule its clip-level twin follows.
+        isOptionalNonNegative(preview.trimIn)
       );
     });
   }


### PR DESCRIPTION
From the external review that opened the session — the one item on its list that was both a real defect and fully in hand.

## The gap

`isTimelineClip` required every number to be **finite** and nothing more. So a payload could satisfy the guard and still violate the model it claims to be:

- negative `duration`, `startTime`, `sourceDuration`, `trimIn`, `trimOut`
- a **fractional** array `index`
- a **zero** `aspect` — which is a divisor in layout
- `trimIn + trimOut` longer than `sourceDuration`, giving negative effective duration
- a collection `playableDuration` longer than the span it's derived from

All accepted, all persisted, and all failing **later** — in packing math or graph hydration, a long way from the write that caused them.

## Why tightening is safe here

**Both call sites are writes** — the PATCH route and the batch route. `GET` doesn't validate. So nothing here can reject a document that's already stored; only what a client may newly persist.

I checked that first rather than assuming it, because the opposite would have made this change dangerous.

## The real risk was the other direction

A rule that's merely *stricter* is a rule that stops **our own client** saving. Three deliberate leniencies, each pinned by an **accepting** test so it reads as a decision rather than a gap:

| Leniency | Why |
|---|---|
| `duration` may be **zero** | An empty hydrated collection genuinely has no span. `> 0` would refuse a legitimate save. |
| `trimIn + trimOut === sourceDuration` allowed, ±1e-6 | Trims accumulate from pointer deltas; dragging a handle to the end lands a few ulps past. The tolerance is float arithmetic, not slack. |
| `trackIndex` stays any finite number | Should be a non-negative integer, but a legacy stored detail carrying a float could then never write itself back — and the field is inert until multi-track lands. |

## Out of scope, deliberately

The review also asked to reject or strip **transient view fields** before storage. That changes what an existing writer may *send*, rather than tightening what a value *means* — different risk profile, wants its own change.

## Verification

19 new unit tests. But the assurance that matters more: **102 graph-view e2e tests save real documents through the batch route**, and all still pass — that's the app's own writer proving the new rules don't refuse it.

| | |
|---|---|
| App vitest | 522 passed |
| Unit | 433 passed (19 new) |
| Storybook | 166 passed |
| graph-view e2e | 102 passed |
| Typecheck | clean, both workspaces |
| Lint | 0 errors (5 pre-existing `<img>` warnings) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)