### PR TITLE
CI: record the drop INTENT beside the render count, and check it first

### DIFF
--- a/packages/ui/dnd-collections/DndCollections.stories.tsx
+++ b/packages/ui/dnd-collections/DndCollections.stories.tsx
@@ -1020,21 +1020,53 @@ export const RenderEfficiencyDuringDrag: Story = {
     // needs to say WHICH move caused the render — three CI failures were
     // reported as a bare "expected 10 to be 9", which is undiagnosable after
     // the fact and is why this flake survived two rounds of investigation.
-    const jitter: Array<{ move: string; count: string | null }> = [];
+    //
+    // The INTENT is recorded beside the count, because the two failures
+    // together are ambiguous without it. CI has shown both (+2,+1,0,0) and
+    // (+1,+1,+1,0): renders landing per move rather than trickling in from
+    // drag-start. That is either the efficiency guarantee failing on slow
+    // hardware, or the jitter leaving the intent it claims to stay inside —
+    // and only the resolved intent tells them apart.
+    const indicator = () => {
+      const parent = target.parentElement;
+      if (parent?.querySelector('[data-drop-indicator="before"]')) return "before";
+      if (parent?.querySelector('[data-drop-indicator="after"]')) return "after";
+      return "none";
+    };
+    const jitter: Array<{ move: string; count: string | null; intent: string }> = [];
     const jitterTo = async (label: string, x: number, y: number) => {
       await moveHeldPointer({ x, y });
-      jitter.push({ move: label, count: bystander.getAttribute("data-render-count") });
+      jitter.push({
+        move: label,
+        count: bystander.getAttribute("data-render-count"),
+        intent: indicator(),
+      });
     };
     await jitterTo("+3,+2", holdPoint.x + 3, holdPoint.y + 2);
     await jitterTo("-3,-2", holdPoint.x - 3, holdPoint.y - 2);
     await jitterTo("+2,+1", holdPoint.x + 2, holdPoint.y + 1);
     await jitterTo("back", holdPoint.x, holdPoint.y);
 
+    const trace = jitter
+      .map((step) => `${step.move}:${step.count}/${step.intent}`)
+      .join(" ");
+
+    // PRECONDITION, checked before the guarantee it qualifies. The story's
+    // premise is "jitter within the SAME intent"; if the intent moved, the
+    // scenario never ran, and reporting that as an efficiency failure is how
+    // this test wasted two investigations. A drop-intent change legitimately
+    // re-renders every droppable — that is dnd-kit's context churning, not
+    // this package's selectors leaking.
+    const intentsSeen = [...new Set(jitter.map((step) => step.intent))];
+    expect(
+      intentsSeen,
+      `the jitter left its intent, so the render assertion below never had its premise (${trace})`,
+    ).toEqual(["before"]);
+
     // Zero re-renders for the uninvolved card across four pointer moves.
-    const trace = jitter.map((step) => `${step.move}:${step.count}`).join(" ");
     expect(
       bystander.getAttribute("data-render-count"),
-      `bystander re-rendered during jitter (baseline ${bystanderRendersBefore}; after each move ${trace})`,
+      `bystander re-rendered during jitter (baseline ${bystanderRendersBefore}; ${trace})`,
     ).toBe(bystanderRendersBefore);
 
     await releaseAt(holdPoint);


### PR DESCRIPTION
The per-move diagnostic from [#251](https://github.com/josulliv101/storyboard-flow/pull/251) paid off. Two CI failures today gave numbers for the first time:

```
baseline 9; +3,+2:11  -3,-2:12  +2,+1:12  back:12
baseline 9; +3,+2:10  -3,-2:11  +2,+1:12  back:12
```

**That kills the theory I shipped a speculative fix for.** The renders land **per move**, not as drag-start stragglers trickling in after the sample — and both runs converge on 12. Something about each pointer move costs the bystander a render on CI hardware.

## Two candidates remain, and the trace can't separate them

1. The efficiency guarantee **genuinely fails** on slow hardware.
2. The jitter **leaves the intent** it claims to stay inside — and a drop-intent change legitimately re-renders every droppable, because that's dnd-kit's context churning rather than this package's selectors leaking.

Only the resolved intent tells them apart. So it's now recorded beside each count and asserted **first**, as the precondition it always was:

```
the jitter left its intent, so the render assertion below never had its premise
(+3,+2:11/before -3,-2:12/none …)
```

The story's premise is *"jitter within the same intent"*. If the intent moved, the scenario never ran — and reporting that as an efficiency failure is exactly how this test wasted two investigations.

The indicator lookup also covers candidate 2's likely shape: a flip between the **card** and the **panel** droppable (the near-tie this fixture was already patched for once) moves the indicator off `t1` entirely, which reads as `"none"` here rather than slipping by unnoticed.

## This does not fix the flake

Stated plainly because two speculative fixes for this test have now shipped and [one made things worse](https://github.com/josulliv101/storyboard-flow/pull/253). **It will still fail on CI** — with a message that finally says which of the two it is.

Given the history, one more failing run to get the answer is the cheaper trade than a third guess.

⚠️ It's also now failing *consistently* (2/2), not intermittently, so it will block merges until resolved. [#256](https://github.com/josulliv101/storyboard-flow/pull/256) needed an admin merge for this reason.

| | |
|---|---|
| Storybook | 166 passed |
| Unit | 433 passed |
| Typecheck | clean |

Story file run 3× clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)