### PR TITLE
PL14-006: stop restarting the seek on every trim update

### DIFF
--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -788,13 +788,31 @@ export function WorkbenchDisplaySurface({
     // treated a lookup miss as "nothing to draw" and silently did nothing,
     // which is precisely what a path-qualified manifest id produced.
     const media = resolveOverrideMedia(sortedClipsRef.current, frameOverride);
+    // Force a seek only when the SOURCE changes, exactly as the clock-driven
+    // path does. Forcing one on every update looked harmless and was not: it
+    // skips the drift check AND tears down the pending draw listener before
+    // installing a new one, so a drag issuing ~25 updates a second restarts
+    // the seek 25 times a second. Where seeks complete quickly the draws land
+    // and nothing looks wrong; where they do not, none of them ever finishes
+    // until the pointer slows down.
+    //
+    // That asymmetry is the bug's signature: dragging the OUT handle seeks
+    // near the end of the source, which is typically not buffered yet, while
+    // the IN handle seeks near t=0, which always is. Half a second of lag on
+    // the right handle only, and not once the region had been visited.
+    //
+    // Letting the drift check decide costs a little granularity — the trim is
+    // quantized to 1/25s and `maxDrift` is 0.05s, so an update lands roughly
+    // every other step — and that is far cheaper than a seek that never
+    // completes.
+    const mediaChanged = media.key !== lastRenderedMediaKeyRef.current;
 
     activeMediaRef.current = media;
     lastRenderedMediaKeyRef.current = media.key;
     activeClipDisabledRef.current = false;
     pauseInactiveVideos(null);
     ensureCachedMedia(media);
-    syncActiveVideo(media, false, true);
+    syncActiveVideo(media, false, mediaChanged);
   }, [
     ensureCachedMedia,
     frameOverride,


### PR DESCRIPTION
**Reported:** dragging the *right* trim handle sometimes lags half a second to a second before the preview catches up. Intermittent, and the left handle never does it.

## My bug

The override effect called:

```ts
syncActiveVideo(media, false, true);   // forceSeek unconditionally
```

`forceSeek: true` does two things beyond issuing a seek — it **skips the drift check**, and it **tears down the pending draw listener** before installing a new one.

A drag produces ~25 updates a second. So the seek was being restarted ~25 times a second, with the previous pending draw cancelled each time. Where seeks complete quickly the draws still land and nothing looks wrong. Where they don't, **none of them ever finishes** until the pointer slows down.

## The asymmetry is what identified it

The report said *right handle*, and that's the whole diagnosis:

- the **out** handle seeks near the **end** of the source — typically not buffered yet
- the **in** handle seeks near **t=0** — always buffered

Hence lag on one handle and not the other, and "not always there" — once that region has been visited it's buffered and the seeks are fast again.

## The fix

Force a seek only when the **source changes**, which is exactly what the clock-driven path already does (`forceSeek || mediaChanged`).

Cost: a little granularity. The trim quantizes to 1/25s against a 0.05s drift threshold, so an update lands roughly every other step. That is far cheaper than a seek that never completes.

## No test proves this

Stated plainly: none can, here. The e2e fixture's "video" is a 1×1 GIF data URL that never decodes, so there is no seek to be slow and no frame to arrive late.

The suites below confirm nothing regressed. **The fix itself needs the reporter, on a real video over a real network.**

| | |
|---|---|
| App vitest | 522 passed |
| Unit | 433 passed |
| Storybook | 166 passed |
| graph-view e2e | 102 passed |
| Typecheck | clean, both workspaces |
| Lint | 0 errors (5 pre-existing `<img>` warnings) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)