### PR TITLE
PL14-006: pressing a trim handle loads the frame before you drag

### DIFF
--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -4714,6 +4714,59 @@ test.describe("graph view E2E", () => {
     await expect(canvas).toBeVisible();
   });
 
+  test("pressing a trim handle shows the frame before any movement", async ({ page }) => {
+    // The live frame used to appear only on the first pointerMOVE, because
+    // `publishLive` was called nowhere else. Pressing now publishes the edge's
+    // current split at zero delta, which matters most where it is least
+    // visible: the preview pane starts its seek while the user is still
+    // deciding where to drag, rather than at the start of the drag.
+    const api = await installGraphApi(page);
+    await openGraph(page);
+
+    const alpha = strip(page, PROJECT_ID).locator('[data-node-id="alpha"]');
+    const wrapper = strip(page, PROJECT_ID).locator('[data-node-wrapper="alpha"]');
+    await expect(async () => {
+      await alpha.click();
+      await expect(alpha).toHaveAttribute("data-selected", "true", { timeout: 700 });
+    }).toPass({ timeout: 10000 });
+    await expect(page.locator("[data-trim-edge-frame]")).toHaveCount(0);
+
+    const widthBefore = (await alpha.boundingBox())!.width;
+    const patchesBefore = api.patchesFor(PROJECT_ID).length;
+
+    // PRESS ONLY — no move at all.
+    const handle = wrapper.locator("[data-trim-handle]").last();
+    const box = (await handle.boundingBox())!;
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+
+    await expect(page.locator('[data-trim-edge-frame="right"]')).toHaveCount(1);
+    // At zero delta the clip is unchanged — this shows a frame, it does not
+    // preview an edit.
+    expect((await alpha.boundingBox())!.width).toBeCloseTo(widthBefore, 0);
+
+    await page.mouse.up();
+
+    // And nothing committed: the frame clears and no write goes out.
+    //
+    // Weaker than it looks, said plainly because it would be easy to read as
+    // a guard it is not. `pending` stays null on press, so the release takes
+    // onUp's no-op branch — but even setting it would not commit, because
+    // `applyMediaUpdate` refuses an update whose trims equal the node's
+    // (`same-position`), and a refused command produces no patch, no history
+    // entry and no write. Verified by injecting `pending = initial.update`:
+    // this test still passed.
+    //
+    // So it pins the OUTCOME (a press leaves no trace) rather than the
+    // mechanism, and would catch a future change that let no-op updates
+    // through — which is worth having, just not the assurance it first reads
+    // as.
+    await expect(page.locator("[data-trim-edge-frame]")).toHaveCount(0);
+    expect((await alpha.boundingBox())!.width).toBeCloseTo(widthBefore, 0);
+    await page.waitForTimeout(1200); // past the persistence debounce
+    expect(api.patchesFor(PROJECT_ID).length).toBe(patchesBefore);
+  });
+
   test("a trim drag floats the edge frame above the clip", async ({ page }) => {
     // PL10-005/007. The live frame is its own small surface: sized to the
     // breadcrumb row (a size reference, not a location — it follows the CLIP,

--- a/packages/ui/dnd-collections/react/trim-gesture.ts
+++ b/packages/ui/dnd-collections/react/trim-gesture.ts
@@ -247,6 +247,25 @@ export function useTrimPointerDrag(
         if (!dispatched.ok) trimPreview.previewTrim(node.id, null);
       }
 
+      // Publish the edge's CURRENT split immediately, at zero delta, so
+      // anything showing the live frame has something to show from the press
+      // rather than from the first move.
+      //
+      // It matters most where it is least visible: the preview pane seeks to
+      // this frame, and a cold seek near the out point can take the better
+      // part of a second. Starting that on pointerdown spends the pause while
+      // the user is still deciding where to drag, instead of at the start of
+      // the drag itself.
+      //
+      // `pending` stays null deliberately. A press with no movement therefore
+      // still takes onUp's no-op branch — nothing dispatches, and the live
+      // preview clears on release exactly as an aborted gesture does. This
+      // shows a frame; it does not begin an edit.
+      const initial = resolve(0);
+      onLive?.(initial.live);
+      publishLive(node.id, initial.live);
+      trimPreview.previewTrim(node.id, initial.live);
+
       activeCleanupRef.current = abortGesture;
       window.addEventListener("pointermove", onMove);
       window.addEventListener("pointerup", onUp);


### PR DESCRIPTION
Requested: the preview should show the edge's frame on **mouse down**, not on the first move.

## Why it didn't

`publishLive` was called from `onMove` and nowhere else. Pressing a handle set up pointer capture and window listeners and published *nothing*, so anything rendering the live frame had nothing to render until the pointer actually travelled.

Press now publishes the edge's current split at **zero delta**.

## Why this matters more than it looks

The preview pane **seeks** to that frame, and a cold seek near the out point can take the better part of a second — the browser's buffer window follows `currentTime`, so visiting the in edge evicts the out edge ([#259](https://github.com/josulliv101/storyboard-flow/pull/259)).

Starting that seek on pointerdown spends the wait while you're still deciding where to drag, instead of at the start of the drag.

## It shows a frame; it does not begin an edit

`pending` stays null deliberately, so a press with no movement still takes `onUp`'s no-op branch.

## The test, and an honest note about half of it

New e2e: press without moving → the frame appears → release → nothing commits. Proven to fail without the change (`Expected: 1, Received: 0`).

**The no-commit half is weaker than it reads, and the test now says so.** I injected `pending = initial.update` — the exact mistake it appears to guard against — and it still passed. `applyMediaUpdate` refuses an update whose trims equal the node's (`same-position`), and a refused command produces no patch, no history entry, and no write.

So it pins the *outcome* (a press leaves no trace) rather than the *mechanism*, and would catch a future change that let no-op updates through. Worth keeping — just not the assurance it first looks like.

| | |
|---|---|
| App vitest | 522 passed |
| Unit | 433 passed |
| Storybook | 166 passed |
| graph-view e2e | 103 passed (1 new) |
| Typecheck | clean, both workspaces |
| Lint | 0 errors (5 pre-existing `<img>` warnings) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)