### PR TITLE
CI: fix the render-efficiency flake — the page auto-scrolled, the guarantee never failed

### DIFF
--- a/packages/ui/dnd-collections/DndCollections.stories.tsx
+++ b/packages/ui/dnd-collections/DndCollections.stories.tsx
@@ -993,6 +993,27 @@ export const RenderEfficiencyDuringDrag: Story = {
     const bystander = nodeCard(canvasElement, "w20");
     await waitForLayout(target);
 
+    // Centre the target BEFORE the drag, and this is the fix for a CI-only
+    // flake that survived three investigations. Left alone, t1 sits ~54px from
+    // the bottom of the viewport — inside dnd-kit's auto-scroll threshold — so
+    // holding the pointer there scrolls the page for as long as the drag runs.
+    // Locally that is invisible because the story is already scrolled to its
+    // limit (scrollY 252 === scrollHeight 1152 - innerHeight 900), so the
+    // scroll is clamped to nothing. CI has room, the page drifts under a
+    // stationary pointer, and once it drifts far enough the hold coordinate is
+    // no longer over t1 at all: `over` resolves elsewhere, dnd-kit's context
+    // churns, and every droppable re-renders — the bystander included.
+    //
+    // That is the whole flake. It was reported as an efficiency failure three
+    // times ("expected 10 to be 9") and the guarantee was never the thing
+    // breaking. Reproduced locally by giving the page 800px of runway and
+    // nudging the scroll 90px mid-jitter, which yields the CI trace exactly:
+    // `+3,+2:9/before -3,-2:10/none +2,+1:10/none back:10/none`.
+    //
+    // Centred, the pointer is nowhere near the threshold and nothing scrolls.
+    target.scrollIntoView({ block: "center" });
+    await waitForLayout(target);
+
     // Establish the drag, THEN re-aim at the target's LIVE left half:
     // starting a drag can shift layout (here the wide panel reflows and t1
     // rises), so a hold point computed from the pre-drag rect would strand
@@ -1033,13 +1054,27 @@ export const RenderEfficiencyDuringDrag: Story = {
       if (parent?.querySelector('[data-drop-indicator="after"]')) return "after";
       return "none";
     };
-    const jitter: Array<{ move: string; count: string | null; intent: string }> = [];
+    // Recorded beside the count and intent, because the intent alone could not
+    // say WHY the intent moved. `!OUT` means the hold coordinate is no longer
+    // inside t1 — the signature of the page having scrolled out from under a
+    // stationary pointer, which is exactly what the centring above prevents.
+    const geometry = () => {
+      const r = target.getBoundingClientRect();
+      const inside =
+        holdPoint.x >= r.left &&
+        holdPoint.x <= r.right &&
+        holdPoint.y >= r.top &&
+        holdPoint.y <= r.bottom;
+      return `t1@${Math.round(r.left)},${Math.round(r.top)}${inside ? "" : "!OUT"}`;
+    };
+    const jitter: Array<{ move: string; count: string | null; intent: string; geom: string }> = [];
     const jitterTo = async (label: string, x: number, y: number) => {
       await moveHeldPointer({ x, y });
       jitter.push({
         move: label,
         count: bystander.getAttribute("data-render-count"),
         intent: indicator(),
+        geom: geometry(),
       });
     };
     await jitterTo("+3,+2", holdPoint.x + 3, holdPoint.y + 2);
@@ -1048,8 +1083,19 @@ export const RenderEfficiencyDuringDrag: Story = {
     await jitterTo("back", holdPoint.x, holdPoint.y);
 
     const trace = jitter
-      .map((step) => `${step.move}:${step.count}/${step.intent}`)
+      .map((step) => `${step.move}:${step.count}/${step.intent}/${step.geom}`)
       .join(" ");
+
+    // FIRST precondition, ahead of the intent one it explains. If the page
+    // moved under the pointer, the hold coordinate no longer means what it
+    // meant when it was measured, and everything downstream is measuring a
+    // different scenario than the one the story describes. Checked as its own
+    // assertion so a recurrence says "the page scrolled" in one line instead
+    // of being re-diagnosed from a render count for a fourth time.
+    expect(
+      jitter.map((step) => step.geom.includes("!OUT")),
+      `the page scrolled out from under the pointer mid-jitter, so the assertions below never had their premise (${trace})`,
+    ).toEqual([false, false, false, false]);
 
     // PRECONDITION, checked before the guarantee it qualifies. The story's
     // premise is "jitter within the SAME intent"; if the intent moved, the


### PR DESCRIPTION
Diagnosed, reproduced locally, and fixed at the cause. Three CI failures over four days reported this as an efficiency regression (`expected 10 to be 9`). It was not one.

## What was actually happening

`t1` sits ~54px from the bottom of the viewport — inside dnd-kit's auto-scroll threshold — so holding the pointer there scrolls the page for as long as the drag runs.

**Locally the story is already at its scroll limit** (`scrollY 252 === scrollHeight 1152 − innerHeight 900`), so the scroll is clamped to nothing and the fixture looks rock stable. That is why this never reproduced on a developer machine, with or without CPU contention — the earlier "browser resource contention" explanation was looking in the wrong place entirely.

CI has room. The page drifts under a stationary pointer, and once it drifts far enough the hold coordinate is no longer over `t1` at all: `over` resolves elsewhere, dnd-kit's context churns, and every droppable re-renders — the bystander included. **That re-render is legitimate and always was.**

## What made it findable

The intent recorder from [#257](https://github.com/josulliv101/storyboard-flow/pull/257). Its trace:

```
+3,+2:9/before   -3,-2:10/none   +2,+1:10/none   back:10/none
```

The bystander re-renders at exactly the move the intent changes — and the intent does **not** return when the pointer goes back to the coordinate that produced it. Same input, different answer, so the geometry had moved. That ruled out the near-tie collision theory the fixture had already been patched for once.

Reproduced locally by giving the page 800px of runway and nudging the scroll 90px mid-jitter, which yields that CI trace exactly, plus the two things CI couldn't see: `!OUT` (hold coordinate outside `t1`) and `sy` climbing 274 → 389 → 409 → 424 on its own.

## The change

- **Fix:** centre the target before the drag. The pointer is then nowhere near the auto-scroll threshold and nothing scrolls.
- **Guard:** the trace records `t1`'s rect per move and marks `!OUT` when the hold coordinate leaves it, asserted as the **first** precondition — so a recurrence says "the page scrolled out from under the pointer" in one line rather than being re-diagnosed from a render count for a fourth time.

## Validation

This is the part the previous attempt ([#251](https://github.com/josulliv101/storyboard-flow/pull/251), reverted) did not have. Both halves were checked:

| | |
|---|---|
| With the fix | 6/6 clean runs |
| With the reproduction | 3/3 fail on the **geometry** precondition, not the efficiency assertion |
| Story suite | 166 passed |
| Unit | 433 passed |
| `packages/ui` typecheck | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)