### PR TITLE
Contextual selection toolbar: item actions move to the card

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -4,13 +4,16 @@ import { useContext, useDeferredValue, useEffect, useMemo, useState } from "reac
 import { createPortal } from "react-dom";
 import { useSearchParams } from "next/navigation";
 import {
+  ClipboardPaste,
   Command,
+  EllipsisVertical,
   FolderPlus,
   FolderTree,
   Redo2,
   Ruler,
   Settings,
   Undo2,
+  X,
 } from "lucide-react";
 
 import {
@@ -27,6 +30,7 @@ import { flattenMediaOrder } from "@storyboard/timeline-domain";
 import { formatDuration } from "@/lib/format-duration";
 import {
   GRAPH_BOARD_MENU_SLOT_ID,
+  requestGraphItemAction,
   requestGraphToolInsert,
 } from "@/lib/graph-view-events";
 import {
@@ -49,6 +53,13 @@ import {
 } from "@/components/core/dropdown-menu";
 import { Slider } from "@/components/core/slider";
 
+import {
+  SelectionOverflowItems,
+  useClipboardCount,
+  useSelectionActionState,
+  useSelectionAnchorId,
+} from "./graph-selection-actions";
+import { GraphSelectionToolbar } from "./graph-selection-toolbar";
 import { NativeDropGrid, NativeDropStrip, SidebarToolInsertBridge } from "./graph-native-drop";
 import { VideoFrameLookAhead } from "./graph-item-content";
 import { BreadcrumbDropZones, DragChromeFade } from "./graph-breadcrumb-drop";
@@ -438,6 +449,102 @@ function HeaderToggle({
 }
 
 /**
+ * Paste, and the two selection controls beside it.
+ *
+ * PASTE IS PERMANENT here, in both the idle and the selection state, and that
+ * is the point of moving it out of the item actions. Every verb in the floating
+ * toolbar acts ON the selection; paste needs a DESTINATION, and a selection is
+ * not a destination. Grouped with the other container-scoped controls (new
+ * folder, view toggles, undo/redo) it says one unambiguous thing: into the
+ * collection you are looking at.
+ *
+ * Its label carries payload AND destination (R9.4), because "Paste" alone
+ * cannot distinguish appending three clips at the end from dropping them after
+ * the card you last touched — and the difference is invisible until it has
+ * already happened.
+ *
+ * The `✕` and `⋮` appear only with a selection. The `⋮` is the reason the
+ * floating toolbar is allowed to hide itself when its anchor scrolls away
+ * (R6.6/R8.3): the actions are still one click from here.
+ */
+function HeaderSelectionCluster({
+  anchorName,
+}: Readonly<{ anchorName: string | null }>) {
+  const store = useCollectionsStore();
+  const state = useSelectionActionState();
+  const clipboardCount = useClipboardCount();
+
+  const payload = clipboardCount === 1 ? "1 item" : `${clipboardCount} items`;
+  const pasteLabel =
+    clipboardCount === 0
+      ? "Paste"
+      : anchorName === null
+        ? `Paste ${payload} at end`
+        : `Paste ${payload} after “${anchorName}”`;
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        aria-label={pasteLabel}
+        title={pasteLabel}
+        // Dimmed in place with an empty clipboard (R9.5), never hidden — a
+        // control that comes and goes as you copy things moves the ones beside
+        // it, and this row is where the eye returns for undo.
+        aria-disabled={clipboardCount === 0 || state.busy || undefined}
+        onClick={() => {
+          if (clipboardCount === 0 || state.busy) return;
+          requestGraphItemAction("paste");
+        }}
+        className={cn(
+          "h-8 w-8",
+          clipboardCount === 0 || state.busy
+            ? "cursor-not-allowed text-zinc-600 hover:text-zinc-600"
+            : HEADER_TOGGLE_IDLE,
+        )}
+      >
+        <ClipboardPaste aria-hidden className="h-4 w-4" />
+      </Button>
+      {state.hasSelection ? (
+        <>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label="Clear selection"
+            title="Clear selection (Esc)"
+            data-clear-selection
+            onClick={() => store.clearSelection()}
+            className={cn("h-8 w-8", HEADER_TOGGLE_IDLE)}
+          >
+            <X aria-hidden className="h-4 w-4" />
+          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label="More selection actions"
+                data-header-selection-overflow
+                className={cn("h-8 w-8", HEADER_TOGGLE_IDLE)}
+              >
+                <EllipsisVertical aria-hidden className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent side="bottom" align="end">
+              <SelectionOverflowItems state={state} />
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </>
+      ) : null}
+    </>
+  );
+}
+
+/**
  * Undo/redo as ICON buttons, matching the toolbar's other ghost icon controls
  * rather than the package's generic text-label `UndoRedoControls`. App-local
  * on purpose: the icon styling is this toolbar's design, so it stays out of
@@ -633,6 +740,15 @@ export function GraphBoard({
     [flatItems],
   );
 
+  // Resolved ONCE, here, and handed to both consumers. The floating toolbar
+  // anchors to this card and the header's paste label names it, so two
+  // independent resolutions could disagree — the toolbar pointing at one card
+  // while the label promised another.
+  const anchorId = useSelectionAnchorId();
+  const anchorName = useCollectionsSelector((s) =>
+    anchorId === null ? null : (s.graph.nodesById.get(anchorId)?.name ?? null),
+  );
+
   return (
     <OpenKeyBoundary trashId={trashRootId}>
       {/* Spans the header AND the surfaces: the toolbar toggle sets the mode,
@@ -659,6 +775,11 @@ export function GraphBoard({
         {/* The "?" sheet. Every gesture in this view is invisible otherwise —
             hold-to-drag, O, F2, the whole Alt layer (PL11-007). */}
         <GraphShortcuts />
+        {/* Item actions, anchored to the card they act on rather than parked
+            in the icon rail 1600px away. Portals to the body, so mounting it
+            here only decides which providers it can see — it needs the store
+            and the details context, both of which are above this point. */}
+        <GraphSelectionToolbar anchorId={anchorId} />
         <div className="flex flex-col gap-2">
           {/* Pinned so the controls stay reachable while scrolling the
               surfaces. It sticks just BELOW the sticky preview via the offset
@@ -743,6 +864,11 @@ export function GraphBoard({
                 label={childrenShown ? "Hide children timelines" : "Show children timelines"}
                 title="Children timelines — show the nested timeline tree"
               />
+              <div aria-hidden="true" className="h-5 w-px shrink-0 bg-zinc-700" />
+              {/* Container-scoped, so it sits with history rather than with the
+                  view group: paste changes what is IN the collection, undo and
+                  redo change what is in it too. */}
+              <HeaderSelectionCluster anchorName={anchorName} />
               <div aria-hidden="true" className="h-5 w-px shrink-0 bg-zinc-700" />
               <GraphUndoRedo />
               {/* Board options are no longer here — they render in the icon

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
@@ -5,6 +5,7 @@ import { useContext, useEffect, useRef, useState } from "react";
 import type { TimelineDocument } from "@storyboard/timeline-model/types";
 import {
   CollectionsContainerContext,
+  focusNodeWhenMounted,
   getChildren,
   isEditableKeyboardTarget,
   parseNodeId,
@@ -20,11 +21,13 @@ import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 import type { GraphDetailsStore } from "@/lib/graph-details-store";
 import { resolveInsertPlacement } from "@/lib/graph-insert-placement";
 import { cloneNodeForInsert, type CloneForInsert } from "@/lib/graph-node-clone";
+import { graphPasteFlash } from "@/lib/graph-paste-flash";
 import {
   GRAPH_ITEM_ACTION_EVENT,
   GRAPH_RESTORE_ITEM_EVENT,
   broadcastGraphRestoreResult,
   broadcastGraphSelection,
+  requestGraphRenameItem,
   type GraphItemAction,
 } from "@/lib/graph-view-events";
 
@@ -204,6 +207,37 @@ function pasteFromClipboard(store: CollectionsStore, focusedId: string): readonl
     snapshot.interaction.selectedIds,
     focusedId,
   );
+
+  // A pending CUT moves its originals rather than cloning them.
+  //
+  // This is what makes cut+paste a move in the way the word promises: the nodes
+  // keep their ids, their documents are never re-minted, and — the part that
+  // matters most — it is ONE `move-nodes` command, so one Ctrl+Z puts the whole
+  // gesture back. Cloning and then trashing the sources would be two commands
+  // and two history entries, and a single undo would restore the originals
+  // while leaving the copies behind.
+  //
+  // Sources that are no longer in the graph fall through to the clone path
+  // below. That is why Cut still captures a snapshot it usually does not need:
+  // the user can undo the cut away, or delete a source, between cut and paste.
+  const pendingCut = graphClipboard.pendingCutIds();
+  const movable =
+    pendingCut.size > 0
+      ? [...pendingCut].filter((id) => snapshot.graph.nodesById.has(id))
+      : [];
+  if (movable.length > 0 && movable.length === pendingCut.size) {
+    const moved = store.dispatch({
+      type: "move-nodes",
+      nodeIds: movable,
+      toParentId: parentId,
+      toIndex,
+    });
+    // A refused move (dropping a collection inside itself, say) must not fall
+    // back to cloning — that would answer a rejected move by silently making
+    // copies.
+    return moved.ok ? movable : [];
+  }
+
   const clones = entries.map((entry) =>
     cloneNodeForInsert(entry.node, entry.detail, {
       readDocument: (timelineId) => entry.documents[timelineId] ?? null,
@@ -211,6 +245,31 @@ function pasteFromClipboard(store: CollectionsStore, focusedId: string): readonl
     }),
   );
   return insertClones(store, clones, parentId, toIndex);
+}
+
+/**
+ * What happens AFTER a paste lands: select, reveal, highlight, announce.
+ *
+ * Selecting the arrivals (R9.6) is what makes chained work natural — paste,
+ * then immediately move or delete what you just pasted — and it puts the anchor
+ * on the last of them, since selection order is insertion order.
+ */
+function revealPasted(
+  store: CollectionsStore,
+  ids: readonly NodeId[],
+  announce: ((message: string) => void) | undefined,
+): void {
+  if (ids.length === 0) return;
+  store.setSelection(ids);
+  graphPasteFlash.flash(ids);
+  // Focusing scrolls it into view, and retries until virtualization has
+  // actually mounted the card — which is the case that matters, since a paste
+  // at the end of a long grid lands below the fold by definition.
+  const last = ids[ids.length - 1];
+  if (last !== undefined) focusNodeWhenMounted(document.body, last);
+  announce?.(
+    ids.length === 1 ? "1 item pasted." : `${ids.length} items pasted.`,
+  );
 }
 
 /**
@@ -447,26 +506,26 @@ export function GraphItemActionsBridge({
 
     const cutSelection = async () => {
       // Snapshot the ids BEFORE the async capture: the user can change the
-      // selection while documents load, and the trash move below must remove
-      // exactly what was captured — not whatever is selected by then.
+      // selection while documents load, and what is armed below must be exactly
+      // what was captured — not whatever is selected by then.
       const selected = [...store.getSnapshot().interaction.selectedIds];
       if (selected.length === 0) return;
       if (!(await captureSelection(store, details, selected))) return;
       // The capture awaited documents; the session can be torn down (project
-      // switch) meanwhile — the same guard Duplicate uses. Without it the move
-      // below dispatches into a dead store, leaving the clipboard populated
-      // while the originals were never actually removed in the live session.
+      // switch) meanwhile — the same guard Duplicate uses.
       if (!sessionAliveRef.current) return;
-      // Remove the originals (recoverable in trash); the clipboard holds an
-      // independent snapshot, so Paste still relocates them. Item mode stays
-      // alive because the clipboard is now non-empty (Paste remains available).
+      // The originals STAY, dimmed, until a paste says where they are going.
       //
-      // Clear the selection ONLY if the move actually landed: a drag starting
-      // mid-capture makes moveSelectionToTrash a no-op (returns 0, isDragging),
-      // and clearing anyway would leave Cut silently behaving like Copy —
-      // clipboard set, nothing trashed, selection gone.
-      const moved = moveSelectionToTrash(store, trashId, selected, details);
-      if (moved > 0) store.clearSelection();
+      // Cut used to trash them here and let Paste re-create them from the
+      // snapshot. That was recoverable but it was not a move: the item vanished
+      // at the moment of cutting (before the user had chosen a destination),
+      // the trash filled up with things nobody deleted, and pasting produced a
+      // new node with a new id rather than relocating the one you cut.
+      //
+      // The snapshot above is still taken, and is still the fallback when a
+      // source is gone by paste time — see `pasteFromClipboard`.
+      graphClipboard.markPendingCut(selected);
+      store.clearSelection();
     };
 
     const pasteSelection = () => {
@@ -474,9 +533,10 @@ export function GraphItemActionsBridge({
       // Nothing landed (refused dispatch): keep the clipboard so the user can
       // paste somewhere valid instead of silently losing what they copied.
       if (pasted.length === 0) return;
-      // Paste returns to the normal controls: drop the clipboard and selection.
+      // One paste per cut: clearing here is what disarms a pending cut, so the
+      // move cannot be replayed into a second destination.
       graphClipboard.clear();
-      store.clearSelection();
+      revealPasted(store, pasted, announce);
     };
 
     // The ONE funnel every trigger goes through — the sidebar's buttons (via
@@ -505,13 +565,50 @@ export function GraphItemActionsBridge({
         case "paste":
           pasteSelection();
           break;
+        case "paste-into": {
+          // The collection-scoped paste: INSIDE the selected collection rather
+          // than beside it. Same machinery, a different destination — passing
+          // the collection as the "focused" id is exactly what makes
+          // `resolveInsertPlacement` append into it, since the selection (that
+          // same collection) is not a child of itself and so cannot pull the
+          // insert alongside.
+          const selected = [...store.getSnapshot().interaction.selectedIds];
+          const target = selected.length === 1 ? selected[0] : undefined;
+          if (target === undefined) break;
+          if (store.getSnapshot().graph.nodesById.get(target)?.kind !== "collection") break;
+          const pasted = pasteFromClipboard(store, target as string);
+          if (pasted.length === 0) break;
+          graphClipboard.clear();
+          revealPasted(store, pasted, announce);
+          break;
+        }
+        case "rename": {
+          // Renaming is inline, at the card, and each rename site owns its own
+          // editor state — so this asks the SITE to open rather than doing it
+          // here. Same hand-off F2 uses.
+          const selected = [...store.getSnapshot().interaction.selectedIds];
+          const only = selected.length === 1 ? selected[0] : undefined;
+          if (only !== undefined) requestGraphRenameItem(only as string, "card");
+          break;
+        }
         case "duplicate":
           void runExclusive(duplicateSelection);
           break;
-        case "delete":
-          moveSelectionToTrash(store, trashId, undefined, details);
+        case "delete": {
+          const moved = moveSelectionToTrash(store, trashId, undefined, details);
           store.clearSelection();
+          // Says the COUNT, which is the job a confirmation dialog would have
+          // done — and this one does not stand between the user and the action.
+          // Delete here means "move to trash": recoverable from the drawer and
+          // undoable with Ctrl+Z, so a modal asking "are you sure" would guard
+          // a reversible step and train people to dismiss it.
+          if (moved > 0) {
+            toast(`Moved ${moved === 1 ? "1 item" : `${moved} items`} to trash.`, {
+              id: "graph-item-delete",
+            });
+          }
           break;
+        }
         case "toggle-disabled": {
           const selected = [...store.getSnapshot().interaction.selectedIds];
           if (selected.length === 0) break;

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -49,6 +49,8 @@ import { GraphViewNavContext } from "./graph-navigation";
 import { TrimPanel } from "./graph-trim-panel";
 import { GraphItemContextMenu } from "./graph-item-context-menu";
 import { createDerivedCache } from "@/lib/derived-cache";
+import { graphClipboard } from "@/lib/graph-clipboard";
+import { graphPasteFlash } from "@/lib/graph-paste-flash";
 import { formatDuration, formatSeconds } from "@/lib/format-duration";
 import {
   collectionPreviewFrameUrl,
@@ -1292,16 +1294,76 @@ const GraphMediaItem = memo(function GraphMediaItem({
  * primitive, so the dispatcher re-renders only if a node changes kind — which
  * never happens after creation.
  */
+/**
+ * This card's two clipboard states, each subscribed PER NODE.
+ *
+ * Narrowed on purpose. Both stores publish a set of ids, and reading the set
+ * would re-render every card on the board whenever anything anywhere was cut or
+ * pasted — the package's render-efficiency invariant, and the mistake the
+ * context menu's state hook already exists to avoid. Asking "is it me?" returns
+ * a boolean that does not move for an uninvolved card.
+ */
+function useCardClipboardState(id: NodeId): Readonly<{
+  pendingCut: boolean;
+  flashing: boolean;
+}> {
+  const pendingCut = useSyncExternalStore(
+    graphClipboard.subscribe,
+    () => graphClipboard.isPendingCut(id),
+    () => false,
+  );
+  const flashing = useSyncExternalStore(
+    graphPasteFlash.subscribe,
+    () => graphPasteFlash.isFlashing(id),
+    () => false,
+  );
+  return { pendingCut, flashing };
+}
+
 const GraphItemShell = memo(function GraphItemShell(props: CollectionItemShellProps) {
   const isCollection = useCollectionsSelector(
     (s) => s.graph.nodesById.get(props.id)?.kind === "collection",
   );
+  const { pendingCut, flashing } = useCardClipboardState(props.id);
+  // Merged into the content root's own class rather than painted here: the
+  // shell is a transparent interaction layer and all pixels belong to the
+  // content, which is also the only element in this chain with a box — the
+  // wrapper below is `display: contents` so the strip's width measurements
+  // cannot see it.
+  const className = [
+    props.className ?? "",
+    // Cut, not yet pasted: still here, still yours, visibly waiting (R9.9).
+    pendingCut ? "opacity-50" : "",
+    // Just arrived from a paste. `transition-shadow` is what makes it FADE
+    // rather than blink out when the flash store clears — Tailwind's ring is a
+    // box-shadow, so the same transition covers both ends.
+    "transition-shadow duration-500 motion-reduce:transition-none",
+    flashing ? "ring-2 ring-amber-400 ring-offset-2 ring-offset-zinc-950" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   // The right-click menu wraps at the SHELL (PL14-007), which is the one place
   // both card kinds pass through — so collections and media get it from a
   // single wiring rather than each content component growing its own.
   return (
     <GraphItemContextMenu nodeId={props.id}>
-      {isCollection ? <GraphCollectionItem {...props} /> : <GraphMediaItem {...props} />}
+      {/* `display: contents`, for the same reason the context-menu trigger is:
+          this sits inside a virtualized strip that measures item widths, and an
+          extra layout box would change them. It exists to carry the state as an
+          ATTRIBUTE — the classes above say how it looks, this says what it is,
+          which is what a test can ask about. */}
+      <span
+        className="contents"
+        data-card-pending-cut={pendingCut ? "true" : undefined}
+        data-card-just-pasted={flashing ? "true" : undefined}
+      >
+        {isCollection ? (
+          <GraphCollectionItem {...props} className={className} />
+        ) : (
+          <GraphMediaItem {...props} className={className} />
+        )}
+      </span>
     </GraphItemContextMenu>
   );
 });

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-context-menu.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-context-menu.tsx
@@ -55,12 +55,36 @@ function useItemActionState(nodeId: NodeId): ItemActionState {
   // re-render every card just as subscribing to the Set did. What makes these
   // quiet is that an unselected node's answer does not depend on the selection
   // at all.
-  const isSingleSelection = useCollectionsSelector((s) => {
+  const selectionCount = useCollectionsSelector((s) => {
     const ids = s.interaction.selectedIds;
     // Not in the selection: opening the menu will make this node the whole of
-    // it, so one item — whatever anyone else has selected.
-    return ids.has(nodeId) ? ids.size === 1 : true;
+    // it, so one item — whatever anyone else has selected. `ids.size` on its
+    // own would be a number that still moves 0 → 1 for every card on the board.
+    return ids.has(nodeId) ? ids.size : 1;
   });
+  const isSingleSelection = selectionCount === 1;
+  // Both false for a MIXED selection, which is what dims the type-specific
+  // actions. Narrowed like the rest: outside the selection the honest answer is
+  // this node's own kind, since that is what the menu is about to act on.
+  const allCollections = useCollectionsSelector((s) => {
+    const ids = s.interaction.selectedIds;
+    if (!ids.has(nodeId)) return s.graph.nodesById.get(nodeId)?.kind === "collection";
+    for (const id of ids) {
+      if (s.graph.nodesById.get(id)?.kind !== "collection") return false;
+    }
+    return true;
+  });
+  const allMedia = useCollectionsSelector((s) => {
+    const ids = s.interaction.selectedIds;
+    if (!ids.has(nodeId)) return s.graph.nodesById.get(nodeId)?.kind === "media";
+    for (const id of ids) {
+      if (s.graph.nodesById.get(id)?.kind !== "media") return false;
+    }
+    return true;
+  });
+  // Only ever this node's own name: a single selection containing this node IS
+  // this node, and outside the selection the menu is about to make it so.
+  const ownName = useCollectionsSelector((s) => s.graph.nodesById.get(nodeId)?.name ?? "");
   const allDisabled = useCollectionsSelector((s) => {
     const ids = s.interaction.selectedIds;
     // Same narrowing: outside the selection the honest answer is this node's
@@ -85,6 +109,7 @@ function useItemActionState(nodeId: NodeId): ItemActionState {
     // Right-clicking always gives the menu something to act on: this node, if
     // nothing else. Never zero, so never a menu of dead rows.
     hasSelection: true,
+    selectionCount,
     isSingleSelection,
     canPaste,
     // Not modelled. The receiving side already refuses an action while one is
@@ -93,6 +118,9 @@ function useItemActionState(nodeId: NodeId): ItemActionState {
     // second subscription for a state this surface can barely observe.
     busy: false,
     allDisabled,
+    allCollections,
+    allMedia,
+    singleName: isSingleSelection ? ownName : null,
   };
 }
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-selection-actions.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-selection-actions.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useEffect, useState, useSyncExternalStore } from "react";
+
+import { useCollectionsSelector, type NodeId } from "@storyboard/ui/dnd-collections";
+
+import { DropdownMenuGroup, DropdownMenuItem } from "@/components/core/dropdown-menu";
+import { graphClipboard } from "@/lib/graph-clipboard";
+import { resolveAnchorId, type SelectionAnchorMemo } from "@/lib/graph-selection-anchor";
+import {
+  visibleItemActions,
+  type ItemActionState,
+} from "@/lib/graph-item-action-specs";
+import {
+  GRAPH_SELECTION_EVENT,
+  requestGraphItemAction,
+  type GraphSelectionDetail,
+} from "@/lib/graph-view-events";
+
+// What the SELECTION-scoped surfaces share: the floating toolbar, its overflow,
+// and the header's fallback overflow. All three answer to one selection, unlike
+// the card right-click menu, which answers to the card under the pointer and
+// builds its own narrowed state (`graph-item-context-menu.tsx`).
+//
+// These are plain hooks rather than a context: `GraphBoard` renders every
+// consumer, so it resolves the anchor ONCE and hands it down. Two independent
+// anchor hooks would each keep their own memo and could disagree about which
+// card a paste follows — the toolbar pointing at one card while the header's
+// label named another.
+
+/**
+ * Whether an async item action is in flight.
+ *
+ * The flag lives in `GraphItemActionsBridge`, a SIBLING of the board rather
+ * than an ancestor, so there is no context to read it from — it already
+ * broadcasts on the window seam and this is the one thing still listening.
+ */
+export function useGraphActionBusy(): boolean {
+  const [busy, setBusy] = useState(false);
+  useEffect(() => {
+    const onSelection = (event: Event) => {
+      setBusy((event as CustomEvent<GraphSelectionDetail>).detail.busy);
+    };
+    window.addEventListener(GRAPH_SELECTION_EVENT, onSelection);
+    return () => window.removeEventListener(GRAPH_SELECTION_EVENT, onSelection);
+  }, []);
+  return busy;
+}
+
+/** The clipboard's payload size, for the header's "Paste 3 clips" label. */
+export function useClipboardCount(): number {
+  return useSyncExternalStore(
+    graphClipboard.subscribe,
+    () => graphClipboard.read().length,
+    () => 0,
+  );
+}
+
+/**
+ * The anchor: the card the toolbar attaches to and the card a paste follows.
+ *
+ * Call this ONCE per board. The memo it threads is what keeps the answer stable
+ * across renders that changed nothing (see `resolveAnchorId`).
+ */
+export function useSelectionAnchorId(): NodeId | null {
+  const selectedIds = useCollectionsSelector((s) => s.interaction.selectedIds);
+  const graph = useCollectionsSelector((s) => s.graph);
+  const [memo, setMemo] = useState<SelectionAnchorMemo>(() => ({
+    anchorId: null,
+    selectedIds,
+  }));
+
+  // React's "adjust state during render": setting state on the component
+  // currently rendering re-runs it immediately, before anything commits, so
+  // nothing downstream ever sees a stale anchor. A ref would have been the
+  // obvious way to carry the memo and is the wrong one — reading and writing
+  // one during render is what makes a component miss updates.
+  let current = memo;
+  if (memo.selectedIds !== selectedIds) {
+    current = { anchorId: resolveAnchorId(graph, selectedIds, memo), selectedIds };
+    setMemo(current);
+  }
+  return current.anchorId;
+}
+
+/** The live selection as the action specs want it. */
+export function useSelectionActionState(): ItemActionState {
+  const busy = useGraphActionBusy();
+  const selectionCount = useCollectionsSelector((s) => s.interaction.selectedIds.size);
+  const allDisabled = useCollectionsSelector((s) => {
+    const ids = s.interaction.selectedIds;
+    if (ids.size === 0) return false;
+    // No spread — this runs on every store notification, and the store notifies
+    // on every drop-intent change during a drag.
+    for (const id of ids) {
+      if (s.graph.nodesById.get(id)?.disabled !== true) return false;
+    }
+    return true;
+  });
+  const allCollections = useCollectionsSelector((s) => {
+    const ids = s.interaction.selectedIds;
+    if (ids.size === 0) return false;
+    for (const id of ids) {
+      if (s.graph.nodesById.get(id)?.kind !== "collection") return false;
+    }
+    return true;
+  });
+  const allMedia = useCollectionsSelector((s) => {
+    const ids = s.interaction.selectedIds;
+    if (ids.size === 0) return false;
+    for (const id of ids) {
+      if (s.graph.nodesById.get(id)?.kind !== "media") return false;
+    }
+    return true;
+  });
+  const singleName = useCollectionsSelector((s) => {
+    const ids = s.interaction.selectedIds;
+    if (ids.size !== 1) return null;
+    for (const id of ids) return s.graph.nodesById.get(id)?.name ?? null;
+    return null;
+  });
+  const canPaste = useSyncExternalStore(
+    graphClipboard.subscribe,
+    () => !graphClipboard.isEmpty(),
+    () => false,
+  );
+
+  return {
+    hasSelection: selectionCount > 0,
+    selectionCount,
+    isSingleSelection: selectionCount === 1,
+    canPaste,
+    busy,
+    allDisabled,
+    allCollections,
+    allMedia,
+    singleName,
+  };
+}
+
+/**
+ * The overflow menu's rows.
+ *
+ * ONE definition for both `⋮` triggers (R7.2) — the toolbar's, and the header's
+ * fallback for when the anchor card has scrolled out of view. They differ only
+ * in where the trigger sits, so only the trigger is duplicated.
+ */
+export function SelectionOverflowItems({ state }: Readonly<{ state: ItemActionState }>) {
+  return (
+    <DropdownMenuGroup>
+      {visibleItemActions(state, "overflow").map((spec) => {
+        const Icon = spec.icon(state);
+        const reason = spec.unavailableReason(state);
+        return (
+          <DropdownMenuItem
+            key={spec.action}
+            disabled={spec.disabled(state)}
+            // The reason travels as the row's accessible description, not as a
+            // tooltip: a disabled menu row is not hoverable in any useful way,
+            // and a screen reader must still be told why.
+            aria-description={reason ?? undefined}
+            onSelect={() => requestGraphItemAction(spec.action)}
+          >
+            <Icon aria-hidden="true" className="mr-2 h-4 w-4" />
+            {spec.label(state)}
+            {reason === null ? null : (
+              <span className="ml-auto pl-3 text-[11px] text-zinc-500">{reason}</span>
+            )}
+          </DropdownMenuItem>
+        );
+      })}
+    </DropdownMenuGroup>
+  );
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-selection-toolbar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-selection-toolbar.tsx
@@ -1,0 +1,350 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { EllipsisVertical } from "lucide-react";
+
+import {
+  findNodeElement,
+  focusNodeWhenMounted,
+  useCollectionsSelector,
+  useCollectionsStore,
+  type NodeId,
+} from "@storyboard/ui/dnd-collections";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/core/dropdown-menu";
+import { cn } from "@/lib/utils";
+import { visibleItemActions } from "@/lib/graph-item-action-specs";
+import { requestGraphItemAction } from "@/lib/graph-view-events";
+import {
+  resolveToolbarPlacement,
+  type ToolbarRect,
+} from "@/lib/selection-toolbar-position";
+import {
+  SelectionOverflowItems,
+  useSelectionActionState,
+} from "./graph-selection-actions";
+
+// The contextual selection toolbar: item actions, anchored to the card the user
+// last clicked, instead of 1600px away in the icon rail.
+//
+// The rail kept these actions until now, and paid three prices for it. Travel,
+// obviously. But also a FUNCTIONAL one — the rail's view toggles were replaced
+// while a selection existed, so you could not select clips and then switch to
+// the strip to look at them — and a layout jump on every selection change, in
+// peripheral vision, for a control cluster nobody was looking at yet.
+//
+// Anchored to the LAST-CLICKED card, deliberately not to the selection's
+// bounding box. A grid selection is a SET, not a region: select the top-left
+// and bottom-right cards and the box spans the viewport, putting the toolbar
+// over cards that are not in it. Last-clicked keeps travel near zero however
+// scattered the selection is, and the toolbar always sits on a card the user
+// just touched.
+//
+// PASTE IS NOT HERE. Every verb in this row acts ON the selection; paste needs
+// a destination, and a selection is not a destination. It lives in the header
+// with the other container-scoped controls, where it unambiguously means "into
+// the collection you are looking at".
+
+/** Matches the rail's width, which the toolbar must never slide under. */
+const RAIL_WIDTH = 72;
+
+const TOOLBAR_ATTRIBUTE = "data-graph-selection-toolbar";
+
+function rectOf(el: Element | null): ToolbarRect | null {
+  if (el === null) return null;
+  const r = el.getBoundingClientRect();
+  return { left: r.left, top: r.top, width: r.width, height: r.height };
+}
+
+function ActionButton({
+  label,
+  reason,
+  disabled,
+  onActivate,
+  children,
+}: Readonly<{
+  label: string;
+  reason: string | null;
+  disabled: boolean;
+  onActivate: () => void;
+  children: React.ReactNode;
+}>) {
+  const [showReason, setShowReason] = useState(false);
+  const reasonId = `selection-action-reason-${label.replace(/\W+/g, "-")}`;
+
+  return (
+    <span className="relative">
+      <button
+        type="button"
+        // `aria-disabled`, never the `disabled` attribute (R5.3/R12.5). A
+        // disabled button is unfocusable and silent — it cannot be tabbed to,
+        // it shows no tooltip on touch, and it answers nothing when pressed.
+        // This one stays reachable and says why instead.
+        aria-disabled={disabled || undefined}
+        aria-label={label}
+        aria-describedby={reason === null ? undefined : reasonId}
+        data-action-disabled={disabled ? "true" : undefined}
+        onClick={() => {
+          if (disabled) {
+            setShowReason(true);
+            return;
+          }
+          onActivate();
+        }}
+        onPointerEnter={() => setShowReason(true)}
+        onPointerLeave={() => setShowReason(false)}
+        onFocus={() => setShowReason(true)}
+        onBlur={() => setShowReason(false)}
+        className={cn(
+          "inline-flex h-9 w-9 items-center justify-center rounded-lg transition-colors",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70",
+          disabled
+            ? "cursor-not-allowed text-zinc-600"
+            : "text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100",
+        )}
+      >
+        {children}
+      </button>
+      {/* Rendered whenever a reason EXISTS, so it is in the accessibility tree
+          for `aria-describedby` to point at even while visually hidden. A
+          tooltip that only exists on hover is unreachable by touch and by
+          screen reader alike (R12.9). */}
+      {reason === null ? null : (
+        <span
+          id={reasonId}
+          role="tooltip"
+          className={cn(
+            "pointer-events-none absolute left-1/2 top-full z-10 mt-2 -translate-x-1/2 whitespace-nowrap",
+            "rounded-md border border-zinc-700 bg-zinc-900 px-2 py-1 text-[11px] text-zinc-200 shadow-lg",
+            "transition-opacity motion-reduce:transition-none",
+            showReason ? "opacity-100" : "opacity-0",
+          )}
+        >
+          {reason}
+        </span>
+      )}
+    </span>
+  );
+}
+
+/**
+ * The toolbar proper, mounted only while there is something to anchor to.
+ *
+ * Split from the component below so its `visible` state has the right
+ * lifetime: it starts false, the tracking loop turns it true once it has
+ * measured, and a gesture that takes the toolbar away (a drag, an empty
+ * selection) unmounts this instead of leaving stale state to flash at the
+ * wrong coordinates on the way back.
+ */
+function SelectionToolbarFrame({ anchorId }: Readonly<{ anchorId: NodeId }>) {
+  const store = useCollectionsStore();
+  const state = useSelectionActionState();
+  const frameRef = useRef<HTMLDivElement | null>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    let raf = 0;
+    const el = frameRef.current;
+    // Animate the MOVE between cards (R13.2), but only when the toolbar is
+    // already on screen somewhere — a first appearance would otherwise slide in
+    // from wherever the previous anchor was. Applied to the element rather than
+    // held in state, because a re-render mid-flight would restart it.
+    //
+    // It is removed again after one transition. During the tracking loop a
+    // position transition would make the toolbar lag its card by the
+    // transition's own duration, which is precisely the visible drift R6.5
+    // forbids while scrolling.
+    let settle = 0;
+    if (el !== null && el.dataset.placed === "true") {
+      el.style.transitionProperty = "left, top, opacity";
+      settle = window.setTimeout(() => {
+        el.style.transitionProperty = "opacity";
+      }, 160);
+    }
+
+    const tick = () => {
+      raf = requestAnimationFrame(tick);
+      const node = frameRef.current;
+      if (node === null) return;
+      // Re-queried EVERY frame rather than cached. A strip unmounts its
+      // off-screen cards, and the grid re-creates a card's element when a move
+      // re-parents it across rows — an element reference held from mount goes
+      // stale without warning, while an id does not.
+      const anchorEl = findNodeElement(document, anchorId);
+      const placement = resolveToolbarPlacement({
+        anchorRect: rectOf(anchorEl),
+        toolbarSize: { width: node.offsetWidth, height: node.offsetHeight },
+        headerRect: rectOf(document.querySelector("[data-graph-board-header]")),
+        railWidth: RAIL_WIDTH,
+        viewport: { width: window.innerWidth, height: window.innerHeight },
+      });
+      if (!placement.visible) {
+        // Setting the same value every frame is free — React bails out of an
+        // identical update — so the flips can be checked here rather than
+        // tracked separately.
+        setVisible(false);
+        return;
+      }
+      // Written straight to style, never through state, and BEFORE the flip to
+      // visible so the first painted frame is already in the right place.
+      // Re-rendering to move an overlay would re-render the board sixty times a
+      // second; this is the technique the trim edge frame already uses.
+      node.style.left = `${placement.left}px`;
+      node.style.top = `${placement.top}px`;
+      node.dataset.placed = "true";
+      setVisible(true);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => {
+      cancelAnimationFrame(raf);
+      if (settle) window.clearTimeout(settle);
+    };
+  }, [anchorId]);
+
+  const returnFocusToAnchor = useCallback(() => {
+    focusNodeWhenMounted(document.body, anchorId);
+  }, [anchorId]);
+
+  // Roving tabindex (R12.2): the toolbar is ONE tab stop, and arrows move
+  // between its controls once focus is inside — the pattern the ARIA toolbar
+  // role implies, and the reason a row of six buttons does not cost six tabs.
+  const onKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        store.clearSelection();
+        returnFocusToAnchor();
+        return;
+      }
+      if (event.key !== "ArrowRight" && event.key !== "ArrowLeft") return;
+      const el = frameRef.current;
+      if (el === null) return;
+      const controls = [...el.querySelectorAll<HTMLElement>("button")];
+      const at = controls.indexOf(document.activeElement as HTMLElement);
+      if (at < 0) return;
+      event.preventDefault();
+      const step = event.key === "ArrowRight" ? 1 : -1;
+      // Wraps, so the ends are not dead: a toolbar is a ring, not a list.
+      const next = (at + step + controls.length) % controls.length;
+      controls[next]?.focus();
+    },
+    [store, returnFocusToAnchor],
+  );
+
+  // F10 puts focus in the toolbar without a mouse (R12.3). The convention menus
+  // and toolbars already use, and free of the modifier collisions the Alt layer
+  // and the trim chords have claimed across this app.
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key !== "F10" || event.shiftKey || event.ctrlKey || event.metaKey) return;
+      const first = frameRef.current?.querySelector<HTMLElement>("button");
+      if (!first) return;
+      event.preventDefault();
+      first.focus();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  const primary = visibleItemActions(state, "primary");
+
+  return createPortal(
+    <div
+      ref={frameRef}
+      {...{ [TOOLBAR_ATTRIBUTE]: "" }}
+      role="toolbar"
+      aria-label="Selection actions"
+      aria-orientation="horizontal"
+      onKeyDown={onKeyDown}
+      // z-[35] sits above the grid's overlay layer (z-30) and below the board
+      // header (z-40) and the icon rail (z-50), both of which are opaque and
+      // pinned. The clamps in `resolveToolbarPlacement` are what actually keep
+      // it clear of those two; this is the backstop if a clamp is ever wrong.
+      className={cn(
+        "fixed z-[35] flex items-center gap-1 rounded-xl border border-zinc-700/80 bg-zinc-900/95 px-1.5 py-1 shadow-xl backdrop-blur-sm",
+        // Fade + a 4px rise on appear (R13.1). `prefers-reduced-motion` drops
+        // both the transition and the offset, so the toolbar simply is where it
+        // is — which is also why the translate lives on the hidden state rather
+        // than as a keyframe.
+        "transition-opacity duration-[120ms] ease-out motion-reduce:transition-none",
+        visible
+          ? "translate-y-0 opacity-100"
+          : "pointer-events-none invisible translate-y-1 opacity-0 motion-reduce:translate-y-0",
+      )}
+      // No left/top here on purpose. They are written imperatively by the
+      // tracking loop, and a JSX style prop would reset them to their initial
+      // values on every re-render — the count label alone changes often enough
+      // to make that a visible twitch. Until the first measurement lands the
+      // toolbar is `invisible`, so it never paints at the wrong coordinates.
+      style={{ transitionProperty: "opacity" }}
+    >
+      {/* The count leads the row so the actions read as selection-scoped rather
+          than card-scoped (R5.4) — "Delete" beside a "3" is unambiguous in a
+          way that "Delete" alone is not. */}
+      {state.selectionCount > 1 ? (
+        <span
+          data-selection-toolbar-count
+          className="px-1.5 font-mono text-[11px] tabular-nums text-amber-300/90"
+        >
+          {state.selectionCount}
+        </span>
+      ) : null}
+      {primary.map((spec, index) => {
+        const Icon = spec.icon(state);
+        return (
+          <span key={spec.action} className="flex items-center">
+            {/* Delete is fenced off from the non-destructive actions (R5.2) so
+                it is harder to hit on the way to something else. */}
+            {spec.action === "delete" && index > 0 ? (
+              <span aria-hidden="true" className="mx-1 h-5 w-px shrink-0 bg-zinc-700" />
+            ) : null}
+            <ActionButton
+              label={spec.label(state)}
+              reason={spec.unavailableReason(state)}
+              disabled={spec.disabled(state)}
+              onActivate={() => requestGraphItemAction(spec.action)}
+            >
+              <Icon aria-hidden="true" className="h-4 w-4" />
+            </ActionButton>
+          </span>
+        );
+      })}
+      <span aria-hidden="true" className="mx-1 h-5 w-px shrink-0 bg-zinc-700" />
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            aria-label="More actions"
+            className={cn(
+              "inline-flex h-9 w-9 items-center justify-center rounded-lg text-zinc-300 transition-colors",
+              "hover:bg-zinc-800 hover:text-zinc-100",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70",
+            )}
+          >
+            <EllipsisVertical aria-hidden="true" className="h-4 w-4" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent side="bottom" align="end">
+          <SelectionOverflowItems state={state} />
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>,
+    document.body,
+  );
+}
+
+export function GraphSelectionToolbar({
+  anchorId,
+}: Readonly<{ anchorId: NodeId | null }>) {
+  // Hidden for the whole of a drag (E6). A card being dragged is not a card
+  // being acted on, and a toolbar anchored to it would chase it across the
+  // board — competing with the drop indicator for the same attention.
+  const isDragging = useCollectionsSelector((s) => s.interaction.isDragging);
+  if (anchorId === null || isDragging) return null;
+  return <SelectionToolbarFrame anchorId={anchorId} />;
+}

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -1,42 +1,29 @@
 "use client";
 
-import React, { useState, useEffect, useRef, useSyncExternalStore } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import {
-  Ban,
-  CircleCheck,
-  ClipboardPaste,
-  Copy,
   ChevronsLeftRightEllipsis,
-  Pencil,
-  CopyPlus,
-  EllipsisVertical,
   Film,
   Folder,
   Image as ImageIcon,
   Layers,
   LogOut,
-  Scissors,
   Trash2,
   TvMinimal,
-  X,
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { TrashDrawer } from "@/components/assets/trash-drawer";
 import { useAuth } from "@/components/auth/auth-provider";
 import {
-  GRAPH_SELECTION_EVENT,
   GRAPH_TRASH_ARRIVAL_EVENT,
   GRAPH_BOARD_MENU_SLOT_ID,
   GRAPH_TRASH_HOVER_EVENT,
   GRAPH_VIEW_STATE_EVENT,
   isGraphViewRoute,
-  requestGraphItemAction,
   requestGraphFlatToggle,
   requestGraphPreviewToggle,
   requestGraphSurface,
-  type GraphItemAction,
-  type GraphSelectionDetail,
   type GraphSurface,
   type GraphViewStateDetail,
 } from "@/lib/graph-view-events";
@@ -45,20 +32,8 @@ import {
   SIDEBAR_ICON_BASE,
   SIDEBAR_ICON_IDLE,
 } from "./sidebar-icon-styles";
-import {
-  visibleItemActions,
-  type ItemActionState,
-} from "@/lib/graph-item-action-specs";
-import { graphClipboard } from "@/lib/graph-clipboard";
 import { toast } from "@/components/core/sonner";
 import { cn } from "@/lib/utils";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/core/dropdown-menu";
 
 import { SidebarTooltipLabel } from "./sidebar-tooltip-label";
 
@@ -187,14 +162,14 @@ const SIDEBAR_ICON_TOGGLE_ON =
  */
 const SIDEBAR_SEPARATOR_CLASS = "mx-auto my-2 h-px w-10 shrink-0";
 
-function SidebarSeparator({ selected = false }: Readonly<{ selected?: boolean }>) {
+function SidebarSeparator() {
   return (
     <div
       aria-hidden="true"
-      data-sidebar-separator={selected ? "selected" : "normal"}
+      data-sidebar-separator="normal"
       className={cn(
         SIDEBAR_SEPARATOR_CLASS,
-        selected ? "bg-amber-300/65" : "bg-zinc-500",
+        "bg-zinc-500",
       )}
     />
   );
@@ -307,167 +282,6 @@ function SurfaceIconControl({
   );
 }
 
-// Recessed, not invisible. One dimming step is enough: a solid zinc-500 glyph
-// reads as available-but-not-now, and the flat border plus the missing hover
-// response carry "disabled" on their own.
-const SIDEBAR_ICON_DISABLED =
-  "cursor-not-allowed text-zinc-500 before:bg-zinc-900/20";
-
-// Item mode borrows a restrained trace of the selection colour. These actions
-// relate to the selected card, but should remain secondary to the content.
-const SIDEBAR_ICON_ITEM_IDLE =
-  "text-amber-100/60 before:bg-amber-200/[0.035] hover:text-amber-100/85 hover:before:bg-amber-200/[0.075]";
-
-/** One button in the item-actions cluster — dispatches its action across the
- *  window-event seam for the graph provider to perform on the selection. */
-function ItemActionButton({
-  action,
-  icon: Icon,
-  label,
-  description,
-  disabled = false,
-  /** "item" acts on the selected card and carries its amber; "neutral" does
-   *  not — Done exits the mode rather than doing anything to the selection,
-   *  so it stays on the sidebar's ordinary zinc. */
-  tone = "item",
-}: Readonly<{
-  action: GraphItemAction;
-  icon: React.ComponentType<{ className?: string }>;
-  label: string;
-  description: string;
-  disabled?: boolean;
-  tone?: "item" | "neutral";
-}>) {
-  const tooltipId = `sidebar-tooltip-item-${action}`;
-  return (
-    <button
-      type="button"
-      aria-label={label}
-      aria-describedby={tooltipId}
-      disabled={disabled}
-      onClick={() => requestGraphItemAction(action)}
-      className={cn(
-        SIDEBAR_ICON_BASE,
-        disabled
-          ? SIDEBAR_ICON_DISABLED
-          : tone === "item"
-            ? SIDEBAR_ICON_ITEM_IDLE
-            : SIDEBAR_ICON_IDLE,
-      )}
-    >
-      <Icon className={SIDEBAR_GLYPH} />
-      <SidebarTooltipLabel id={tooltipId} label={label} description={description} />
-    </button>
-  );
-}
-
-function ItemActionsOverflow({ state }: Readonly<{ state: ItemActionState }>) {
-  const actions = visibleItemActions(state, "overflow");
-  const disabled = state.busy || !state.hasSelection;
-  const tooltipId = "sidebar-tooltip-item-more";
-
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          aria-label="More item actions"
-          aria-describedby={tooltipId}
-          disabled={disabled}
-          className={cn(
-            SIDEBAR_ICON_BASE,
-            disabled ? SIDEBAR_ICON_DISABLED : SIDEBAR_ICON_ITEM_IDLE,
-          )}
-        >
-          <EllipsisVertical className={SIDEBAR_GLYPH} />
-          <SidebarTooltipLabel
-            id={tooltipId}
-            label="More"
-            description="More actions for the selected item"
-          />
-        </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent side="right" align="start">
-        <DropdownMenuGroup>
-          {/* The rail's half of ITEM_ACTION_SPECS — the actions common enough
-              to keep but not common enough to spend a tile on. The card's
-              right-click menu inlines these instead, having no overflow to
-              fold into. */}
-          {actions.map((spec) => {
-            const Icon = spec.icon(state);
-            return (
-              <DropdownMenuItem
-                key={spec.action}
-                disabled={spec.disabled(state)}
-                onSelect={() => requestGraphItemAction(spec.action)}
-              >
-                <Icon className="mr-2 h-4 w-4" />
-                {spec.label(state)}
-              </DropdownMenuItem>
-            );
-          })}
-        </DropdownMenuGroup>
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
-
-/**
- * The contextual cluster shown while an item is selected (or something is on
- * the clipboard). Replaces the layout/toggle controls with actions on the
- * selected item. Copy/Cut are replaced by Paste while the clipboard is armed;
- * Duplicate/Delete need a live selection. Done exits back to the normal
- * controls (clearing the clipboard — with contents kept, item mode couldn't
- * close). While an async
- * action is in flight (`busy`) every button disables, so nothing double-fires.
- */
-function ItemActionsCluster({ state }: Readonly<{ state: ItemActionState }>) {
-  return (
-    <div className="flex w-full flex-col items-stretch gap-0">
-      {/* Only actions that operate on the selection or clipboard sit inside the amber
-          block — a wash, no border, so the group reads as one thing tied to
-          the selected card without drawing a box around itself. Done is
-          deliberately outside it: it exits the mode, it does nothing to the
-          card, and it keeps the sidebar's ordinary zinc. */}
-      <div
-        data-item-actions-cluster
-        className="flex w-full flex-col items-stretch gap-0 bg-amber-200/[0.025]"
-      >
-        {/* Rendered from ITEM_ACTION_SPECS (PL14-007), the same ordered list
-            the card's right-click menu walks — so the two surfaces cannot
-            drift apart about what an item can do, which is the whole reason
-            that list exists. The rail respects `group`, the flat menu ignores
-            it; neither had to bend its order to share.
-
-            Details still comes first, and still DISABLES rather than hides
-            past one selection: a control that vanishes teaches nothing, while
-            a disabled one says "wrong shape of selection for that". Copy/Cut
-            still swap for Paste — that is `visible` in the spec now. */}
-        {visibleItemActions(state, "primary").map((spec) => (
-          <ItemActionButton
-            key={spec.action}
-            action={spec.action}
-            icon={spec.icon(state)}
-            label={spec.label(state)}
-            description={spec.description(state)}
-            disabled={spec.disabled(state)}
-          />
-        ))}
-        <ItemActionsOverflow state={state} />
-      </div>
-      <SidebarSeparator selected />
-      <ItemActionButton
-        action="cancel"
-        icon={X}
-        label="Done"
-        description="Exit item actions and clear the clipboard"
-        disabled={state.busy}
-        tone="neutral"
-      />
-    </div>
-  );
-}
-
 const UTILITY_ITEMS: UtilityItem[] = [
   {
     id: "trash",
@@ -559,51 +373,19 @@ export function TimelineSidebar() {
     return () => window.removeEventListener(GRAPH_TRASH_HOVER_EVENT, handleHover);
   }, []);
 
-  // The graph broadcasts how many items are selected; while something is
-  // selected — OR the clipboard holds a copy/cut — the contextual controls
-  // switch to item actions (copy, cut, paste, duplicate, delete, cancel). The
-  // clipboard condition is what keeps Paste reachable after Copy clears the
-  // selection (copy here, drill into another timeline, paste there).
-  const [selectionCount, setSelectionCount] = useState(0);
-  const [actionBusy, setActionBusy] = useState(false);
-  const [selectionAllDisabled, setSelectionAllDisabled] = useState(false);
-  useEffect(() => {
-    const onSelection = (event: Event) => {
-      const detail = (event as CustomEvent<GraphSelectionDetail>).detail;
-      if (detail) {
-        setSelectionCount(detail.count);
-        setActionBusy(detail.busy);
-        setSelectionAllDisabled(detail.allDisabled);
-      }
-    };
-    window.addEventListener(GRAPH_SELECTION_EVENT, onSelection);
-    return () => window.removeEventListener(GRAPH_SELECTION_EVENT, onSelection);
-  }, []);
-  const canPaste = useSyncExternalStore(
-    graphClipboard.subscribe,
-    () => !graphClipboard.isEmpty(),
-    () => false,
-  );
-
+  // The rail is a VIEW rail, and stays one. It used to swap these controls for
+  // the selected item's actions the moment anything was selected, which cost
+  // three things: a full-width mouse trip to reach an action, a layout jump in
+  // peripheral vision on every selection change, and — the real one — access to
+  // view switching itself, so you could not select clips and then look at them
+  // in the strip. Item actions live in the floating selection toolbar now
+  // (`graph-selection-toolbar.tsx`), anchored to the card they act on.
+  //
+  // Nothing here reads the selection any more. The focus-restore effect that
+  // used to accompany the swap went with it: it existed only to catch focus
+  // orphaned by unmounting the control the user had just pressed.
   const onGraphRoute = isGraphViewRoute(pathname);
-  const itemMode = onGraphRoute && (selectionCount > 0 || canPaste);
-
-  // Swapping clusters unmounts the control that held keyboard focus (e.g. the
-  // Delete button the user just activated), dumping focus to <body>. Restore
-  // it to the rail's first enabled control — but ONLY on a real mode
-  // TRANSITION (not mount: focus starts on <body> on every page load, and
-  // grabbing it then would steal focus from the document), and ONLY when the
-  // swap actually orphaned focus: a mouse click on a card also flips
-  // itemMode, and focus is on the card then, which must not be stolen.
   const railRef = useRef<HTMLElement>(null);
-  const prevItemModeRef = useRef<boolean | null>(null);
-  useEffect(() => {
-    const previous = prevItemModeRef.current;
-    prevItemModeRef.current = itemMode;
-    if (previous === null || previous === itemMode) return;
-    if (document.activeElement !== document.body && document.activeElement !== null) return;
-    railRef.current?.querySelector<HTMLButtonElement>("button:not([disabled])")?.focus();
-  }, [itemMode]);
 
   const handleLogout = async () => {
     try {
@@ -637,19 +419,7 @@ export function TimelineSidebar() {
         SW
       </Link>
 
-      {activeProjectId && itemMode && (
-        <ItemActionsCluster
-          state={{
-            hasSelection: selectionCount > 0,
-            isSingleSelection: selectionCount === 1,
-            canPaste,
-            busy: actionBusy,
-            allDisabled: selectionAllDisabled,
-          }}
-        />
-      )}
-
-      {activeProjectId && !itemMode && (
+      {activeProjectId && (
         <div className="flex w-full flex-col items-stretch gap-0">
           {/* The graph's layout switch (was the breadcrumb row's strip/grid
               toggle). Grid first: it is the initial-load default. */}
@@ -674,7 +444,7 @@ export function TimelineSidebar() {
         </div>
       )}
 
-      {activeProjectId && !itemMode && (
+      {activeProjectId && (
         <>
           {/* zinc-500: the old zinc-800/80 vanished against the rail. */}
           <SidebarSeparator />

--- a/apps/timeline-gstudio001/lib/graph-clipboard.ts
+++ b/apps/timeline-gstudio001/lib/graph-clipboard.ts
@@ -1,5 +1,5 @@
 import type { TimelineDocument } from "@storyboard/timeline-model/types";
-import type { CollectionItemNode } from "@storyboard/ui/dnd-collections";
+import type { CollectionItemNode, NodeId } from "@storyboard/ui/dnd-collections";
 import type { ClipDetail } from "@storyboard/timeline-domain";
 
 // The graph view's copy/cut clipboard: a module singleton, like
@@ -27,6 +27,25 @@ export type ClipboardEntry = Readonly<{
 export type GraphClipboard = Readonly<{
   read: () => readonly ClipboardEntry[];
   /**
+   * The nodes a Cut is waiting to move, still live in the graph.
+   *
+   * Cut used to trash its originals immediately and let Paste re-create them
+   * from the snapshot above. It now leaves them in place, dimmed, until a paste
+   * says where they are going — which is what makes cut+paste a MOVE rather
+   * than a copy that happens to delete something.
+   *
+   * The snapshot is still captured, and is still what a paste falls back to
+   * when a source has since been deleted or undone out of the graph. So this is
+   * an optimisation of the common case, never a precondition.
+   */
+  pendingCutIds: () => ReadonlySet<NodeId>;
+  /** Per-node, so a card can subscribe to its OWN pending state without every
+   *  card re-rendering when the clipboard changes. */
+  isPendingCut: (id: NodeId) => boolean;
+  /** Arm the pending move. Call after a successful `set` — `set` clears it,
+   *  since a fresh copy replaces whatever the clipboard was doing. */
+  markPendingCut: (ids: Iterable<NodeId>) => void;
+  /**
    * Install new contents. Pass the `generation()` observed BEFORE any async
    * capture work: if the clipboard was rebound to a different user (or
    * otherwise reset) while the capture ran, the stale write is refused and
@@ -50,8 +69,11 @@ export type GraphClipboard = Readonly<{
   subscribe: (listener: () => void) => () => void;
 }>;
 
+const NO_PENDING_CUT: ReadonlySet<NodeId> = new Set();
+
 function createGraphClipboard(): GraphClipboard {
   let entries: readonly ClipboardEntry[] = [];
+  let pendingCut: ReadonlySet<NodeId> = NO_PENDING_CUT;
   let boundUid: string | null = null;
   let generation = 0;
   const listeners = new Set<() => void>();
@@ -60,26 +82,38 @@ function createGraphClipboard(): GraphClipboard {
   };
   return {
     read: () => entries,
+    pendingCutIds: () => pendingCut,
+    isPendingCut: (id) => pendingCut.has(id),
+    markPendingCut: (ids) => {
+      pendingCut = new Set(ids);
+      emit();
+    },
     set: (next, atGeneration) => {
       if (atGeneration !== undefined && atGeneration !== generation) return false;
       entries = next;
+      // A new copy (or a new cut, before it arms its own) replaces whatever the
+      // clipboard was doing, so nothing stays dimmed waiting for a paste that
+      // will never carry it.
+      pendingCut = NO_PENDING_CUT;
       emit();
       return true;
     },
     clear: () => {
-      if (entries.length === 0) return;
+      if (entries.length === 0 && pendingCut.size === 0) return;
       entries = [];
+      pendingCut = NO_PENDING_CUT;
       emit();
     },
     isEmpty: () => entries.length === 0,
     generation: () => generation,
     bindUser: (uid) => {
       if (boundUid === uid) return;
-      const hadEntries = entries.length > 0;
+      const hadState = entries.length > 0 || pendingCut.size > 0;
       boundUid = uid;
       generation += 1;
       entries = [];
-      if (hadEntries) emit();
+      pendingCut = NO_PENDING_CUT;
+      if (hadState) emit();
     },
     subscribe: (listener) => {
       listeners.add(listener);

--- a/apps/timeline-gstudio001/lib/graph-item-action-specs.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-item-action-specs.test.ts
@@ -6,96 +6,148 @@ import {
   type ItemActionState,
 } from "./graph-item-action-specs";
 
-// PL14-007. One ordered list, two surfaces: the sidebar's contextual rail
-// (which respects `group` and folds the rest behind "More") and a card's
-// right-click menu (which ignores `group` and shows everything).
+// PL14-007, reshaped for the floating selection toolbar. One ordered list,
+// three surfaces: the toolbar's row (`primary`), its `⋮` (`overflow`), and a
+// card's right-click menu (which ignores `group` and shows everything).
 //
-// These pin the SHAPES both surfaces depend on. The rail's and the menu's own
-// rendering is covered by the graph-view e2e; what cannot be seen from either
-// of those is that they are still reading the same list — which is the whole
-// point of the list existing.
+// These pin the SHAPES those surfaces depend on. Their rendering is covered by
+// the graph-view e2e; what cannot be seen from there is that they are still
+// reading the same list — which is the whole point of the list existing.
 
 const state = (over: Partial<ItemActionState> = {}): ItemActionState => ({
   hasSelection: true,
+  selectionCount: 1,
   isSingleSelection: true,
   canPaste: false,
   busy: false,
   allDisabled: false,
+  allCollections: false,
+  allMedia: true,
+  singleName: "Car Chase",
   ...over,
 });
+
+const multi = (over: Partial<ItemActionState> = {}): ItemActionState =>
+  state({ selectionCount: 3, isSingleSelection: false, ...over });
 
 const labels = (s: ItemActionState, group?: "primary" | "overflow") =>
   visibleItemActions(s, group).map((spec) => spec.label(s));
 
+const actions = (s: ItemActionState, group?: "primary" | "overflow") =>
+  visibleItemActions(s, group).map((spec) => spec.action);
+
 describe("item action specs", () => {
-  it("gives the rail exactly the run it had: Edit, Copy, Cut, Delete", () => {
+  it("gives the toolbar its row: Edit, Copy, Cut, Delete", () => {
     expect(labels(state(), "primary")).toEqual(["Edit", "Copy", "Cut", "Delete"]);
-    expect(labels(state(), "overflow")).toEqual(["Duplicate", "Disable"]);
+    expect(labels(state(), "overflow")).toEqual(["Duplicate", "Rename", "Disable"]);
   });
 
   it("gives the flat menu the same actions with the overflow inlined", () => {
-    // Same relative order, both overflow actions in place, and Delete still
-    // LAST — a destructive action at the end is harder to hit in passing, and
-    // a menu has no "More" button to sit before.
     expect(labels(state())).toEqual([
       "Edit",
       "Copy",
       "Cut",
-      "Duplicate",
-      "Disable",
       "Delete",
+      "Duplicate",
+      "Rename",
+      "Disable",
     ]);
   });
 
-  it("the two surfaces cover the same actions — no drift", () => {
-    // The reason this list exists. A rail action with no menu entry (or the
+  it("the surfaces cover the same actions — no drift", () => {
+    // The reason this list exists. A toolbar action with no menu entry (or the
     // reverse) is the failure it prevents.
-    const menu = visibleItemActions(state()).map((s) => s.action);
-    const rail = [
-      ...visibleItemActions(state(), "primary"),
-      ...visibleItemActions(state(), "overflow"),
-    ].map((s) => s.action);
-    expect([...menu].sort()).toEqual([...rail].sort());
+    const menu = actions(state());
+    const toolbar = [...actions(state(), "primary"), ...actions(state(), "overflow")];
+    expect([...menu].sort()).toEqual([...toolbar].sort());
   });
 
-  it("Copy and Cut swap for Paste when the clipboard is armed", () => {
-    expect(labels(state({ canPaste: true }))).toEqual([
+  it("keeps every primary action in place when the clipboard is armed", () => {
+    // R5.1. Copy and Cut used to be REPLACED by Paste here, which moved Delete
+    // one slot left the instant anything was copied. Paste now lives in the
+    // header, and this row does not move.
+    expect(labels(state(), "primary")).toEqual(labels(state({ canPaste: true }), "primary"));
+  });
+
+  it("never removes a primary action as the selection grows", () => {
+    // The muscle-memory guarantee, stated as identity of the action list —
+    // labels legitimately gain counts, positions must not move.
+    expect(actions(state(), "primary")).toEqual(actions(multi(), "primary"));
+    expect(actions(state({ hasSelection: false, selectionCount: 0 }), "primary")).toEqual(
+      actions(multi(), "primary"),
+    );
+  });
+
+  it("says the count out loud once a selection is plural", () => {
+    expect(labels(multi(), "primary")).toEqual([
       "Edit",
-      "Paste",
-      "Duplicate",
-      "Disable",
-      "Delete",
+      "Copy 3 items",
+      "Cut 3 items",
+      "Delete 3 items",
     ]);
   });
 
   it("Disable becomes Enable when the whole selection is already skipped", () => {
-    const enabled = visibleItemActions(state()).find((s) => s.action === "toggle-disabled")!;
-    const disabled = state({ allDisabled: true });
-    expect(enabled.label(state())).toBe("Disable");
-    expect(enabled.label(disabled)).toBe("Enable");
+    const toggle = visibleItemActions(state()).find((s) => s.action === "toggle-disabled")!;
+    const off = state({ allDisabled: true });
+    expect(toggle.label(state())).toBe("Disable");
+    expect(toggle.label(off)).toBe("Enable");
     // The icon follows the word — one concept, not two.
-    expect(enabled.icon(state())).not.toBe(enabled.icon(disabled));
+    expect(toggle.icon(state())).not.toBe(toggle.icon(off));
   });
 
-  it("Edit is the only action that needs a SINGLE selection", () => {
-    const multi = state({ isSingleSelection: false });
-    const blocked = ITEM_ACTION_SPECS.filter((s) => s.disabled(multi) && !s.disabled(state()));
-    expect(blocked.map((s) => s.action)).toEqual(["details"]);
+  it("Edit and Rename are the actions that need a SINGLE selection", () => {
+    const blocked = ITEM_ACTION_SPECS.filter((s) => s.disabled(multi()) && !s.disabled(state()));
+    expect(blocked.map((s) => s.action)).toEqual(["details", "rename"]);
   });
 
-  it("everything that touches the selection disables without one", () => {
-    const empty = state({ hasSelection: false, isSingleSelection: false });
-    // Paste is the exception by design: it acts on the CLIPBOARD, so it is
-    // available with nothing selected.
-    const live = visibleItemActions(empty).filter((s) => !s.disabled(empty));
-    expect(live.map((s) => s.action)).toEqual([]);
-    const armed = state({ hasSelection: false, isSingleSelection: false, canPaste: true });
-    expect(visibleItemActions(armed).filter((s) => !s.disabled(armed)).map((s) => s.action))
-      .toEqual(["paste"]);
+  it("states a reason for every action it dims on a multi-selection", () => {
+    // R5.3/R12.9: a dimmed control that cannot say why is a dead end, and the
+    // reason has to exist as DATA to reach a screen reader rather than only a
+    // tooltip.
+    for (const spec of visibleItemActions(multi())) {
+      if (!spec.disabled(multi())) continue;
+      expect(spec.unavailableReason(multi()), spec.action).not.toBeNull();
+    }
+  });
+
+  it("does not explain a dimmed action when nothing is selected", () => {
+    // The board already says so; a reason on every control would be six copies
+    // of "select something first".
+    const empty = state({ hasSelection: false, selectionCount: 0, isSingleSelection: false });
+    for (const spec of visibleItemActions(empty)) {
+      expect(spec.unavailableReason(empty), spec.action).toBeNull();
+    }
+  });
+
+  it("everything disables without a selection", () => {
+    const empty = state({ hasSelection: false, selectionCount: 0, isSingleSelection: false });
+    expect(visibleItemActions(empty).filter((s) => !s.disabled(empty))).toEqual([]);
+  });
+
+  it("offers Paste into only for a single selected collection", () => {
+    const collection = state({ allCollections: true, allMedia: false, canPaste: true });
+    expect(actions(collection, "overflow")).toContain("paste-into");
+    expect(labels(collection, "overflow")).toContain("Paste into “Car Chase”");
+
+    // A clip has no inside to paste into, and neither does a multi-selection —
+    // hidden rather than dimmed, because the label names a destination that
+    // does not exist.
+    expect(actions(state({ canPaste: true }), "overflow")).not.toContain("paste-into");
+    expect(
+      actions(multi({ allCollections: true, allMedia: false, canPaste: true }), "overflow"),
+    ).not.toContain("paste-into");
+  });
+
+  it("dims Paste into with an empty clipboard rather than hiding it", () => {
+    const collection = state({ allCollections: true, allMedia: false, canPaste: false });
+    const spec = visibleItemActions(collection, "overflow").find((s) => s.action === "paste-into")!;
+    expect(spec.disabled(collection)).toBe(true);
+    expect(spec.unavailableReason(collection)).toBe("Nothing on the clipboard");
   });
 
   it("busy disables everything, so nothing double-fires", () => {
-    const busy = state({ busy: true, canPaste: true });
+    const busy = state({ busy: true, canPaste: true, allCollections: true, allMedia: false });
     expect(visibleItemActions(busy).every((s) => s.disabled(busy))).toBe(true);
   });
 });

--- a/apps/timeline-gstudio001/lib/graph-item-action-specs.ts
+++ b/apps/timeline-gstudio001/lib/graph-item-action-specs.ts
@@ -6,6 +6,7 @@ import {
   CopyPlus,
   Pencil,
   Scissors,
+  TextCursorInput,
   Trash2,
   type LucideIcon,
 } from "lucide-react";
@@ -14,38 +15,50 @@ import type { GraphItemAction } from "./graph-view-events";
 
 // What an item's actions ARE, in one place (PL14-007).
 //
-// Two surfaces offer them now — the sidebar's contextual cluster and a card's
-// right-click menu — and a second definition is how two menus drift into
-// disagreeing about what an item can do. This module is the definition; both
-// surfaces render it.
+// Three surfaces offer them now — the floating selection toolbar, its overflow
+// menu, and a card's right-click menu — and a second definition is how two
+// menus drift into disagreeing about what an item can do. This module is the
+// definition; every surface renders it.
 //
-// Deliberately NOT a component. The two present the same actions very
-// differently (the rail is a column of icon tiles with tooltips and an amber
-// wash; the menu is a list of rows), so what they share is the DATA — which
-// actions exist, in what order, with what labels and icons, and when each is
-// available. Sharing markup would have forced one of them to look wrong.
+// Deliberately NOT a component. The surfaces present the same actions very
+// differently (the toolbar is a row of icon tiles; the menu is a list of rows),
+// so what they share is the DATA — which actions exist, in what order, with
+// what labels and icons, and when each is available. Sharing markup would have
+// forced one of them to look wrong.
 
 /** Everything an action needs to decide whether it applies right now. */
 export type ItemActionState = Readonly<{
   hasSelection: boolean;
+  /** How many items are selected. Labels say it out loud where scope would
+   *  otherwise be ambiguous — "Duplicate" reads as "this card". */
+  selectionCount: number;
   /** Exactly ONE item selected. The details view is the only action that
    *  cares — there is no honest way to render one clip's frames for six. */
   isSingleSelection: boolean;
-  /** The clipboard is armed, which SWAPS Copy/Cut for Paste. */
+  /** The clipboard is armed. No longer swaps anything out: paste lives in the
+   *  header now (it needs a DESTINATION, and a selection is not one), and the
+   *  only entry here is the collection-scoped "Paste into". */
   canPaste: boolean;
   /** An async action is in flight; everything disables so nothing double-fires. */
   busy: boolean;
   /** Every selected item is already skipped — flips Disable to Enable. */
   allDisabled: boolean;
+  /** Every selected item is a collection. Both of these are false for a MIXED
+   *  selection, which is what dims the type-specific actions (E10). */
+  allCollections: boolean;
+  allMedia: boolean;
+  /** The single selected item's name, for "Paste into 'Scene A'". Null unless
+   *  exactly one is selected. */
+  singleName: string | null;
 }>;
 
 /**
- * Where the RAIL puts an action. The rail is a narrow column, so it shows the
- * common few and folds the rest behind a "More" overflow; a flat menu has
- * nowhere to fold and shows everything.
+ * Where the TOOLBAR puts an action. The toolbar is a short row, so it shows the
+ * common few and folds the rest behind `⋮`; the right-click menu is flat and
+ * shows everything.
  *
- * Modelled here rather than in the rail because it is the last thing the two
- * surfaces disagreed about — with it, both render the same ordered list and
+ * Modelled here rather than in the surfaces because it is the last thing they
+ * disagreed about — with it, all of them render the same ordered list and
  * differ only in whether they respect the grouping.
  */
 export type ItemActionGroup = "primary" | "overflow";
@@ -53,36 +66,50 @@ export type ItemActionGroup = "primary" | "overflow";
 export type ItemActionSpec = Readonly<{
   action: GraphItemAction;
   group: ItemActionGroup;
-  /** Resolved against state, because two of them change wording: Disable
-   *  becomes Enable, and the icon follows. */
+  /** Resolved against state, because several change wording: Disable becomes
+   *  Enable, and counts appear once a selection is plural. */
   label: (state: ItemActionState) => string;
   description: (state: ItemActionState) => string;
   icon: (state: ItemActionState) => LucideIcon;
-  /** Present at all. Copy/Cut and Paste are mutually exclusive — a menu row
-   *  for an action that cannot exist in this state is worse than its absence. */
+  /** Present at all. Reserved for actions that are not merely unavailable but
+   *  MEANINGLESS in this state — "Paste into" with no collection selected
+   *  names a destination that does not exist. Everything else stays and dims;
+   *  a control that comes and goes shifts the ones after it, and selection
+   *  count changes constantly during a multi-select. */
   visible: (state: ItemActionState) => boolean;
   /** Present but unavailable. Preferred over hiding wherever the action is
    *  always CONCEPTUALLY available: a control that vanishes teaches nothing,
-   *  while a disabled one says "wrong shape of selection for that". */
+   *  while a dimmed one says "wrong shape of selection for that". */
   disabled: (state: ItemActionState) => boolean;
+  /** WHY it is dimmed, in the user's terms. Rendered as a tooltip and as the
+   *  control's accessible description — never tooltip-only, because a tooltip
+   *  is unreachable by touch and by screen reader alike. Null when the action
+   *  is available, or when the reason is simply "nothing is selected" and the
+   *  empty board already says so. */
+  unavailableReason: (state: ItemActionState) => string | null;
 }>;
 
 const always = () => true;
+const noReason = () => null;
+
+/** "item" / "3 items" — the phrase every count-bearing label ends with. */
+export function itemCountPhrase(count: number): string {
+  return count === 1 ? "item" : `${count} items`;
+}
 
 /**
  * The ordered list.
  *
  * Details first because it is the action that tells you WHAT you have selected
  * before you act on it — and because it lost its per-card trigger to get here
- * (PL13-009). Delete LAST, because a destructive action at the end of a menu
- * is harder to hit on the way to something else.
+ * (PL13-009). Delete LAST of the primaries, because a destructive action at the
+ * end is harder to hit on the way to something else; the toolbar additionally
+ * fences it off with a separator.
  *
- * ONE order serves both surfaces, which is what `group` buys. Walking it and
- * respecting the grouping gives the rail exactly what it had — Edit, Copy,
- * Cut (or Paste), Delete, then More(Duplicate, Disable). Walking it and
- * ignoring the grouping gives the menu exactly what it had — the same run with
- * both overflow actions inlined and Delete still last. Neither surface needed
- * its order bent to share the list.
+ * ONE order serves every surface, which is what `group` buys. Walking it and
+ * respecting the grouping gives the toolbar its row and its overflow; walking
+ * it and ignoring the grouping gives the right-click menu the same run with the
+ * overflow actions inlined and Delete still last.
  */
 export const ITEM_ACTION_SPECS: readonly ItemActionSpec[] = [
   {
@@ -93,42 +120,60 @@ export const ITEM_ACTION_SPECS: readonly ItemActionSpec[] = [
     icon: () => Pencil,
     visible: always,
     disabled: (s) => s.busy || !s.isSingleSelection,
+    unavailableReason: (s) =>
+      s.hasSelection && !s.isSingleSelection ? "Edit one item at a time" : null,
   },
   {
     action: "copy",
     group: "primary",
-    label: () => "Copy",
-    description: () => "Copy the selected item",
+    label: (s) => (s.selectionCount > 1 ? `Copy ${itemCountPhrase(s.selectionCount)}` : "Copy"),
+    description: () => "Copy the selection",
     icon: () => Copy,
-    visible: (s) => !s.canPaste,
+    visible: always,
     disabled: (s) => s.busy || !s.hasSelection,
+    unavailableReason: noReason,
   },
   {
     action: "cut",
     group: "primary",
-    label: () => "Cut",
-    description: () => "Cut the selected item — paste to move it",
+    label: (s) => (s.selectionCount > 1 ? `Cut ${itemCountPhrase(s.selectionCount)}` : "Cut"),
+    description: () => "Cut the selection — paste to move it",
     icon: () => Scissors,
-    visible: (s) => !s.canPaste,
+    visible: always,
     disabled: (s) => s.busy || !s.hasSelection,
+    unavailableReason: noReason,
   },
   {
-    action: "paste",
+    action: "delete",
     group: "primary",
-    label: () => "Paste",
-    description: () => "Paste into this timeline",
-    icon: () => ClipboardPaste,
-    visible: (s) => s.canPaste,
-    disabled: (s) => s.busy,
+    label: (s) => (s.selectionCount > 1 ? `Delete ${itemCountPhrase(s.selectionCount)}` : "Delete"),
+    description: () => "Move the selection to trash",
+    icon: () => Trash2,
+    visible: always,
+    disabled: (s) => s.busy || !s.hasSelection,
+    unavailableReason: noReason,
   },
   {
     action: "duplicate",
     group: "overflow",
-    label: () => "Duplicate",
-    description: () => "Duplicate the selected item",
+    label: (s) =>
+      s.selectionCount > 1 ? `Duplicate ${itemCountPhrase(s.selectionCount)}` : "Duplicate",
+    description: () => "Duplicate the selection",
     icon: () => CopyPlus,
     visible: always,
     disabled: (s) => s.busy || !s.hasSelection,
+    unavailableReason: noReason,
+  },
+  {
+    action: "rename",
+    group: "overflow",
+    label: () => "Rename",
+    description: () => "Rename the selected item",
+    icon: () => TextCursorInput,
+    visible: always,
+    disabled: (s) => s.busy || !s.isSingleSelection,
+    unavailableReason: (s) =>
+      s.hasSelection && !s.isSingleSelection ? "Rename one item at a time" : null,
   },
   {
     action: "toggle-disabled",
@@ -136,28 +181,35 @@ export const ITEM_ACTION_SPECS: readonly ItemActionSpec[] = [
     label: (s) => (s.allDisabled ? "Enable" : "Disable"),
     description: (s) =>
       s.allDisabled
-        ? "Play the selected item again"
+        ? "Play the selection again"
         : "Keep the slot, skip it on playback",
     icon: (s) => (s.allDisabled ? CircleCheck : Ban),
     visible: always,
     disabled: (s) => s.busy || !s.hasSelection,
+    unavailableReason: noReason,
   },
   {
-    action: "delete",
-    group: "primary",
-    label: () => "Delete",
-    description: () => "Move the selected item to trash",
-    icon: () => Trash2,
-    visible: always,
-    disabled: (s) => s.busy || !s.hasSelection,
+    // The collection-scoped paste: INTO the selected collection rather than
+    // beside it. Hidden rather than dimmed when no single collection is
+    // selected — its label names a destination, and a row reading "Paste
+    // into ''" is worse than no row. The header's paste (which always targets
+    // the collection on screen) is the one that is always present.
+    action: "paste-into",
+    group: "overflow",
+    label: (s) => `Paste into “${s.singleName ?? ""}”`,
+    description: () => "Paste the clipboard inside the selected collection",
+    icon: () => ClipboardPaste,
+    visible: (s) => s.isSingleSelection && s.allCollections,
+    disabled: (s) => s.busy || !s.canPaste,
+    unavailableReason: (s) => (!s.canPaste ? "Nothing on the clipboard" : null),
   },
 ];
 
 /**
  * What a surface should actually render, in order.
  *
- * `group` omitted = everything, which is the flat menu. Pass one and you get
- * the rail's halves.
+ * `group` omitted = everything, which is the flat right-click menu. Pass one
+ * and you get the toolbar's row or its overflow.
  */
 export function visibleItemActions(
   state: ItemActionState,

--- a/apps/timeline-gstudio001/lib/graph-paste-flash.ts
+++ b/apps/timeline-gstudio001/lib/graph-paste-flash.ts
@@ -1,0 +1,66 @@
+import type { NodeId } from "@storyboard/ui/dnd-collections";
+
+// A transient accent outline on cards that just arrived from a paste.
+//
+// Paste at the end of a long grid is otherwise SILENT: the user clicks, the
+// cards land below the fold or among thirty identical-looking siblings, and
+// nothing on screen distinguishes "it worked" from "the button did nothing".
+// Scrolling them into view answers where; this answers which.
+//
+// A module singleton, like `graphClipboard`, and for a duller reason than that
+// one: the cards are not mounted yet at the moment paste returns. Virtualized
+// rows mount on their own schedule and the grid re-creates card elements when a
+// move re-parents them, so writing a class onto DOM nodes here would miss most
+// of them. Publishing the IDS instead lets each card ask on mount, whenever
+// that turns out to be.
+
+/** How long the outline holds before fading. Long enough to find the cards
+ *  after a scroll, short enough not to become part of the card's look. */
+export const PASTE_FLASH_MS = 1500;
+
+export type GraphPasteFlash = Readonly<{
+  /** Per-node, so a card subscribes to its OWN state and an unrelated paste
+   *  elsewhere on the board does not re-render it. */
+  isFlashing: (id: NodeId) => boolean;
+  /** Start the outline on these nodes, replacing any previous run. */
+  flash: (ids: Iterable<NodeId>) => void;
+  subscribe: (listener: () => void) => () => void;
+}>;
+
+const NONE: ReadonlySet<NodeId> = new Set();
+
+function createGraphPasteFlash(): GraphPasteFlash {
+  let flashing: ReadonlySet<NodeId> = NONE;
+  let timer = 0;
+  const listeners = new Set<() => void>();
+  const emit = () => {
+    for (const listener of listeners) listener();
+  };
+  return {
+    isFlashing: (id) => flashing.has(id),
+    flash: (ids) => {
+      const next = new Set(ids);
+      if (timer) window.clearTimeout(timer);
+      flashing = next;
+      emit();
+      if (next.size === 0) return;
+      timer = window.setTimeout(() => {
+        timer = 0;
+        // Guarded: a SECOND paste during the first one's hold replaces the set
+        // and arms a new timer, and this stale one must not clear the new
+        // run's highlight early.
+        if (flashing !== next) return;
+        flashing = NONE;
+        emit();
+      }, PASTE_FLASH_MS);
+    },
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}
+
+export const graphPasteFlash = createGraphPasteFlash();

--- a/apps/timeline-gstudio001/lib/graph-selection-anchor.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-selection-anchor.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import { buildGraph, parseNodeId, type CollectionsGraph, type NodeId } from "@storyboard/ui/dnd-collections";
+
+import { resolveAnchorId, type SelectionAnchorMemo } from "./graph-selection-anchor";
+
+/**
+ * project ─ alpha, bravo, charlie, delta, scene-a[ c1, c2 ]
+ *
+ * Grid order for the top level is exactly that array. `scene-a`'s children are
+ * a second parent, which the removal fallback must not reach across.
+ */
+function fixture(): CollectionsGraph {
+  const built = buildGraph([
+    {
+      kind: "collection",
+      id: "project",
+      name: "Project",
+      children: [
+        { kind: "media", id: "alpha", name: "alpha" },
+        { kind: "media", id: "bravo", name: "bravo" },
+        { kind: "media", id: "charlie", name: "charlie" },
+        { kind: "media", id: "delta", name: "delta" },
+        {
+          kind: "collection",
+          id: "scene-a",
+          name: "Scene A",
+          children: [
+            { kind: "media", id: "c1", name: "c1" },
+            { kind: "media", id: "c2", name: "c2" },
+          ],
+        },
+      ],
+    },
+  ]);
+  if (!built.ok) throw new Error(JSON.stringify(built.error));
+  return built.value;
+}
+
+const id = (value: string): NodeId => parseNodeId(value);
+const sel = (...values: string[]): ReadonlySet<NodeId> => new Set(values.map(id));
+
+function memo(anchor: string | null, selected: ReadonlySet<NodeId>): SelectionAnchorMemo {
+  return { anchorId: anchor === null ? null : id(anchor), selectedIds: selected };
+}
+
+describe("resolveAnchorId", () => {
+  const graph = fixture();
+
+  it("is null for an empty selection", () => {
+    expect(resolveAnchorId(graph, sel(), null)).toBeNull();
+  });
+
+  it("is the only selected card for a plain click", () => {
+    expect(resolveAnchorId(graph, sel("bravo"), null)).toBe(id("bravo"));
+  });
+
+  it("follows the most recently added card, not grid order", () => {
+    // Ctrl+click charlie, then ctrl+click alpha: the anchor is alpha, the card
+    // just touched, even though charlie is later in the grid. This is the case
+    // a pure grid-order rule gets wrong, and it would park the toolbar on a
+    // card the user did not click.
+    const selection = sel("charlie", "alpha");
+
+    expect(resolveAnchorId(graph, selection, memo("charlie", sel("charlie")))).toBe(id("alpha"));
+  });
+
+  it("holds still when the selection has not changed", () => {
+    // The same Set instance means nothing moved. Re-deriving from insertion
+    // order here would be harmless, but the memo is what lets the fallback
+    // below survive to the next render.
+    const selection = sel("alpha", "charlie");
+
+    expect(resolveAnchorId(graph, selection, memo("alpha", selection))).toBe(id("alpha"));
+  });
+
+  it("moves to the last remaining card in GRID order when the anchor is deselected", () => {
+    // Selected alpha, delta, bravo in that click order, anchor bravo. Ctrl+click
+    // bravo off: insertion order would answer "delta" (picked second); grid
+    // order answers "delta" too here only because it is last on screen — so
+    // pick a case where they differ, below.
+    const before = sel("alpha", "delta", "bravo");
+    const after = sel("alpha", "delta");
+
+    expect(resolveAnchorId(graph, after, memo("bravo", before))).toBe(id("delta"));
+  });
+
+  it("prefers grid order over click order for that fallback", () => {
+    // Clicked delta first, then alpha, then charlie (the anchor). Removing
+    // charlie leaves {delta, alpha}: insertion order says alpha, grid order
+    // says delta — and grid order is the one the user can see.
+    const before = sel("delta", "alpha", "charlie");
+    const after = sel("delta", "alpha");
+
+    expect(resolveAnchorId(graph, after, memo("charlie", before))).toBe(id("delta"));
+  });
+
+  it("does not reach across parents for the fallback", () => {
+    // The removed anchor's siblings are all deselected; what remains is inside
+    // scene-a. "The next one along" is meaningless across two timelines, so it
+    // falls back to the most recent pick rather than inventing an order.
+    const before = sel("c1", "alpha");
+    const after = sel("c1");
+
+    expect(resolveAnchorId(graph, after, memo("alpha", before))).toBe(id("c1"));
+  });
+
+  it("is null once the last card is deselected", () => {
+    expect(resolveAnchorId(graph, sel(), memo("alpha", sel("alpha")))).toBeNull();
+  });
+
+  it("recovers when the memo's anchor was already gone", () => {
+    // A deleted anchor is pruned from the selection by the store, so the memo
+    // can arrive describing a card that no longer exists anywhere. That must
+    // resolve, not throw.
+    const stale = memo("ghost", sel("ghost", "alpha"));
+
+    expect(resolveAnchorId(graph, sel("alpha", "bravo"), stale)).toBe(id("bravo"));
+  });
+});

--- a/apps/timeline-gstudio001/lib/graph-selection-anchor.ts
+++ b/apps/timeline-gstudio001/lib/graph-selection-anchor.ts
@@ -1,0 +1,95 @@
+import { getChildren, type CollectionsGraph, type NodeId } from "@storyboard/ui/dnd-collections";
+
+// WHICH card the selection is "at" — the one the floating toolbar attaches to
+// and the one a paste lands after.
+//
+// Deliberately DERIVED rather than stored. The selection already carries the
+// answer: `selectedIds` is a Set, Sets iterate in insertion order, and every
+// mutator appends — `setSelection([id])` rebuilds around the clicked card,
+// `toggleSelected(id)` pushes a newly added one onto the end. So "the card the
+// user last touched that is still selected" is just the last entry, and adding
+// an `anchorId` field to the store would have been a second source of truth for
+// something the first one already knows. `resolveInsertPlacement` has been
+// reading the selection this way since before there was a toolbar.
+//
+// The one case the Set cannot answer alone is REMOVAL. Ctrl+clicking the anchor
+// off drops it from the set, and what remains last in INSERTION order is
+// whichever card happened to be picked before it — an order the user cannot see.
+// There the anchor moves to the last remaining card in GRID order, which they
+// can. Detecting that case is the only reason this takes a `previous`.
+
+export type SelectionAnchorMemo = Readonly<{
+  anchorId: NodeId | null;
+  /** The exact Set the anchor was resolved against. Compared by IDENTITY —
+   *  the store preserves a snapshot field's reference while its slice is
+   *  unchanged, so this is a reliable "nothing moved" test and not a guess. */
+  selectedIds: ReadonlySet<NodeId>;
+}>;
+
+function lastOf(ids: Iterable<NodeId>): NodeId | null {
+  let last: NodeId | null = null;
+  for (const id of ids) last = id;
+  return last;
+}
+
+/**
+ * The last SELECTED sibling of `nodeId`, in the order its parent renders them.
+ *
+ * Grid order is the parent's children array, which is exactly what the grid
+ * lays out left-to-right, top-to-bottom and the strip lays out end-to-end. A
+ * selection can span parents; only the departing anchor's own parent is
+ * consulted, because "the next one along" means nothing across two timelines.
+ */
+function lastSelectedSiblingInGridOrder(
+  graph: CollectionsGraph,
+  nodeId: NodeId,
+  selectedIds: ReadonlySet<NodeId>,
+): NodeId | null {
+  const parentId = graph.parentById.get(nodeId) ?? null;
+  if (parentId === null) return null;
+  let last: NodeId | null = null;
+  for (const childId of getChildren(graph, parentId)) {
+    if (selectedIds.has(childId)) last = childId;
+  }
+  return last;
+}
+
+/**
+ * Resolve the anchor for a selection.
+ *
+ * Pass the previous result back in; the memo is what makes the answer STABLE.
+ * Without it, the grid-order fallback below would apply for exactly one render
+ * and then the insertion-order rule would pull the anchor somewhere else on the
+ * next one, with no input from the user — the toolbar would hop between cards
+ * on an unrelated re-render.
+ */
+export function resolveAnchorId(
+  graph: CollectionsGraph,
+  selectedIds: ReadonlySet<NodeId>,
+  previous: SelectionAnchorMemo | null,
+): NodeId | null {
+  if (selectedIds.size === 0) return null;
+
+  // Nothing about the selection changed, so neither does the anchor. Identity,
+  // not contents: the store guarantees the reference survives a no-op.
+  if (previous !== null && previous.selectedIds === selectedIds) {
+    if (previous.anchorId !== null && selectedIds.has(previous.anchorId)) return previous.anchorId;
+  }
+
+  // The anchor was deselected (or deleted) while other cards stayed selected.
+  // Insertion order would surface whichever card was picked before it, so use
+  // the order that is on screen instead.
+  const droppedAnchor =
+    previous !== null &&
+    previous.anchorId !== null &&
+    previous.selectedIds.has(previous.anchorId) &&
+    !selectedIds.has(previous.anchorId);
+  if (droppedAnchor && previous.anchorId !== null) {
+    const sibling = lastSelectedSiblingInGridOrder(graph, previous.anchorId, selectedIds);
+    // No selected sibling under that parent — the rest of the selection lives
+    // elsewhere entirely, so there is no "next one along" to move to.
+    if (sibling !== null) return sibling;
+  }
+
+  return lastOf(selectedIds);
+}

--- a/apps/timeline-gstudio001/lib/graph-view-events.ts
+++ b/apps/timeline-gstudio001/lib/graph-view-events.ts
@@ -133,14 +133,21 @@ export type GraphSelectionDetail = Readonly<{
   allDisabled: boolean;
 }>;
 
-/** The per-item actions the sidebar's item-mode cluster can request. */
+/** The per-item actions a selection surface can request. */
 export type GraphItemAction =
   | "copy"
   | "cut"
+  /** Paste into the collection on screen. Lives in the HEADER, not the
+   *  selection toolbar: every other verb here acts ON the selection, while
+   *  paste needs a destination, and a selection is not a destination. */
   | "paste"
+  /** Paste INSIDE the one selected collection, rather than beside it. */
+  | "paste-into"
   | "duplicate"
   | "delete"
   | "cancel"
+  /** Open the inline name editor on the selected item's card. */
+  | "rename"
   /** Skip (or un-skip) the selection in playback, counts and time totals. */
   | "toggle-disabled"
   /** Open the details view for the selection. Meaningful for exactly ONE

--- a/apps/timeline-gstudio001/lib/selection-toolbar-position.test.ts
+++ b/apps/timeline-gstudio001/lib/selection-toolbar-position.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ANCHOR_MIN_VISIBLE_RATIO,
+  TOOLBAR_GAP,
+  anchorVisibleRatio,
+  resolveToolbarPlacement,
+  type ToolbarPlacementInput,
+  type ToolbarRect,
+} from "./selection-toolbar-position";
+
+const VIEWPORT = { width: 1200, height: 900 };
+const RAIL = 72;
+const HEADER: ToolbarRect = { left: 0, top: 0, width: 1200, height: 48 };
+const TOOLBAR = { width: 240, height: 40 };
+
+/** A card in open space: well clear of the header, the rail and both edges. */
+function card(overrides: Partial<ToolbarRect> = {}): ToolbarRect {
+  return { left: 500, top: 400, width: 128, height: 96, ...overrides };
+}
+
+function input(overrides: Partial<ToolbarPlacementInput> = {}): ToolbarPlacementInput {
+  return {
+    anchorRect: card(),
+    toolbarSize: TOOLBAR,
+    headerRect: HEADER,
+    railWidth: RAIL,
+    viewport: VIEWPORT,
+    ...overrides,
+  };
+}
+
+describe("resolveToolbarPlacement", () => {
+  it("centres on the anchor and sits one gap above it", () => {
+    const placement = resolveToolbarPlacement(input());
+
+    expect(placement.visible).toBe(true);
+    expect(placement.side).toBe("above");
+    // Card spans 500..628, so its centre is 564; a 240-wide toolbar starts 120 left of that.
+    expect(placement.left).toBe(444);
+    expect(placement.top).toBe(400 - TOOLBAR.height - TOOLBAR_GAP);
+  });
+
+  it("flips below when the header would cover the space above", () => {
+    // Top grid row: the card starts just under the header, leaving nowhere to go.
+    const placement = resolveToolbarPlacement(input({ anchorRect: card({ top: 60 }) }));
+
+    expect(placement.side).toBe("below");
+    expect(placement.top).toBe(60 + 96 + TOOLBAR_GAP);
+  });
+
+  it("measures the flip against the HEADER, not the viewport top", () => {
+    // 100px down there is room above in raw viewport terms (100 - 40 - 8 = 52),
+    // but the header's opaque band ends at 48 and the toolbar needs a gap under
+    // it, so 52 < 56 and it must still flip. This is the case a viewport-top
+    // check gets wrong, and it is the common one — the first row of a grid.
+    const placement = resolveToolbarPlacement(input({ anchorRect: card({ top: 100 }) }));
+
+    expect(placement.side).toBe("below");
+  });
+
+  it("keeps clear of the rail rather than centring under it", () => {
+    const placement = resolveToolbarPlacement(input({ anchorRect: card({ left: 80 }) }));
+
+    expect(placement.left).toBe(RAIL + TOOLBAR_GAP);
+  });
+
+  it("keeps clear of the right edge", () => {
+    // Overhanging the edge but still mostly on screen, so it is a clamp case
+    // and not a visibility one.
+    const placement = resolveToolbarPlacement(input({ anchorRect: card({ left: 1100 }) }));
+
+    expect(placement.left).toBe(VIEWPORT.width - TOOLBAR.width - TOOLBAR_GAP);
+  });
+
+  it("prefers the rail bound when the window is too narrow for both", () => {
+    // Both clamps cannot hold at once. The rail is opaque and pinned, so
+    // sliding under it hides controls outright; overhanging the right edge at
+    // a width this small is the lesser failure.
+    const placement = resolveToolbarPlacement(
+      input({ viewport: { width: 260, height: 900 }, anchorRect: card({ left: 100 }) }),
+    );
+
+    expect(placement.left).toBe(RAIL + TOOLBAR_GAP);
+  });
+
+  it("hides when the anchor element is not mounted", () => {
+    // A virtualized strip unmounts its off-screen cards; the grid re-creates a
+    // card's element when a move re-parents it across rows.
+    expect(resolveToolbarPlacement(input({ anchorRect: null })).visible).toBe(false);
+  });
+
+  it("hides once the anchor is less than half visible", () => {
+    // 96-tall card scrolled to -10, so it clears the header's 48px band by
+    // only 38px: 40%.
+    const placement = resolveToolbarPlacement(input({ anchorRect: card({ top: -10 }) }));
+
+    expect(placement.visible).toBe(false);
+  });
+
+  it("stays visible while the anchor is more than half on screen", () => {
+    // The same card at 0 clears the band by exactly 48 of its 96 — the
+    // boundary, which counts as visible.
+    const placement = resolveToolbarPlacement(input({ anchorRect: card({ top: 0 }) }));
+
+    expect(anchorVisibleRatio(input({ anchorRect: card({ top: 0 }) }))).toBe(0.5);
+    expect(placement.visible).toBe(true);
+  });
+});
+
+describe("anchorVisibleRatio", () => {
+  it("counts the header band as covering the card, not as viewport", () => {
+    const behindHeader = input({ anchorRect: card({ top: -60 }) });
+    // 96-tall card ending at 36, entirely above the header's 48px bottom.
+    expect(anchorVisibleRatio(behindHeader)).toBe(0);
+  });
+
+  it("counts the rail as covering the card", () => {
+    const behindRail = input({ anchorRect: card({ left: -60 }) });
+    // 128-wide card ending at 68, entirely left of the 72px rail edge.
+    expect(anchorVisibleRatio(behindRail)).toBe(0);
+  });
+
+  it("is 1 for a card in open space", () => {
+    expect(anchorVisibleRatio(input())).toBe(1);
+  });
+
+  it("reports a partially scrolled card proportionally", () => {
+    // Bottom edge of the viewport takes half the card's height.
+    const half = input({ anchorRect: card({ top: VIEWPORT.height - 48 }) });
+    expect(anchorVisibleRatio(half)).toBeCloseTo(0.5, 5);
+    expect(anchorVisibleRatio(half)).toBeGreaterThanOrEqual(ANCHOR_MIN_VISIBLE_RATIO);
+  });
+
+  it("treats a zero-area rect as invisible instead of dividing by zero", () => {
+    expect(anchorVisibleRatio(input({ anchorRect: card({ width: 0 }) }))).toBe(0);
+  });
+});

--- a/apps/timeline-gstudio001/lib/selection-toolbar-position.ts
+++ b/apps/timeline-gstudio001/lib/selection-toolbar-position.ts
@@ -1,0 +1,117 @@
+// Where the floating selection toolbar sits, as arithmetic.
+//
+// Split out from the component on purpose: this is the part with edges — the
+// flip, the two clamps, and the visibility cutoff — and a toolbar rendered into
+// a portal is awkward to assert against, while a function that takes four rects
+// and returns a point is not. Same seam that made `frame-override.test.ts`
+// possible for the preview override.
+//
+// Everything is in VIEWPORT coordinates, matching `getBoundingClientRect`, and
+// the caller writes the result straight to a `position: fixed` element.
+
+export type ToolbarRect = Readonly<{ left: number; top: number; width: number; height: number }>;
+
+export type ToolbarPlacementInput = Readonly<{
+  /** The anchor card's live rect, or null when it is not mounted — a strip
+   *  virtualizes its cards away, and the grid re-creates a card's element when
+   *  a move re-parents it across rows. Absence is normal, not an error. */
+  anchorRect: ToolbarRect | null;
+  toolbarSize: Readonly<{ width: number; height: number }>;
+  /** The sticky board header. It is opaque and it scrolls nothing, so a card
+   *  behind it is not visible and the toolbar must not sit under it either. */
+  headerRect: ToolbarRect | null;
+  /** Width of the icon rail, which is also opaque and pinned. */
+  railWidth: number;
+  viewport: Readonly<{ width: number; height: number }>;
+}>;
+
+export type ToolbarPlacement = Readonly<{
+  left: number;
+  top: number;
+  side: "above" | "below";
+  /** False when the toolbar must not render at all: no anchor element, or the
+   *  anchor has scrolled far enough behind the header/rail/viewport edge that
+   *  pointing at it would be a lie. The selection itself is unaffected. */
+  visible: boolean;
+}>;
+
+/** Gap between the card and the toolbar, and the minimum breathing room kept
+ *  against the rail and the viewport edges. */
+export const TOOLBAR_GAP = 8;
+
+/** Below this share of the anchor card still on screen, the toolbar hides and
+ *  the header's overflow takes over (R6.6). Half is generous enough that the
+ *  toolbar survives ordinary scrolling and strict enough that it never points
+ *  at a sliver. */
+export const ANCHOR_MIN_VISIBLE_RATIO = 0.5;
+
+const HIDDEN: ToolbarPlacement = { left: 0, top: 0, side: "above", visible: false };
+
+function clamp(value: number, min: number, max: number): number {
+  // max first: when the window is narrower than the toolbar the two bounds
+  // cross, and honouring the MIN keeps it against the rail rather than sliding
+  // under it — the rail is opaque, the right edge merely runs out of room.
+  return Math.max(min, Math.min(value, max));
+}
+
+function overlap(aMin: number, aMax: number, bMin: number, bMax: number): number {
+  return Math.max(0, Math.min(aMax, bMax) - Math.max(aMin, bMin));
+}
+
+/**
+ * How much of the anchor card is actually on screen, 0..1.
+ *
+ * Measured against the region a card can be SEEN in, not the raw viewport: the
+ * header band and the rail are opaque and fixed, so a card underneath either is
+ * hidden as surely as one scrolled off the bottom. Without that the toolbar
+ * would keep tracking a card sliding behind the header and end up pointing at
+ * the header itself.
+ */
+export function anchorVisibleRatio(input: ToolbarPlacementInput): number {
+  const { anchorRect, headerRect, railWidth, viewport } = input;
+  if (anchorRect === null) return 0;
+  const area = anchorRect.width * anchorRect.height;
+  if (area <= 0) return 0;
+
+  const contentTop = headerRect === null ? 0 : Math.max(0, headerRect.top + headerRect.height);
+  const visibleWidth = overlap(
+    anchorRect.left,
+    anchorRect.left + anchorRect.width,
+    railWidth,
+    viewport.width,
+  );
+  const visibleHeight = overlap(
+    anchorRect.top,
+    anchorRect.top + anchorRect.height,
+    contentTop,
+    viewport.height,
+  );
+  return (visibleWidth * visibleHeight) / area;
+}
+
+/**
+ * Centre on the anchor, prefer above, flip below when the header is in the way,
+ * then clamp into the free horizontal band.
+ */
+export function resolveToolbarPlacement(input: ToolbarPlacementInput): ToolbarPlacement {
+  const { anchorRect, toolbarSize, headerRect, railWidth, viewport } = input;
+  if (anchorRect === null) return HIDDEN;
+  if (anchorVisibleRatio(input) < ANCHOR_MIN_VISIBLE_RATIO) return HIDDEN;
+
+  const above = anchorRect.top - toolbarSize.height - TOOLBAR_GAP;
+  const headerBottom = headerRect === null ? 0 : Math.max(0, headerRect.top + headerRect.height);
+  // "Insufficient space above" is measured against the header, not the viewport
+  // top: on the first grid row the header IS the ceiling, and a toolbar tucked
+  // between them would be half-covered by an opaque bar.
+  const side: "above" | "below" = above >= headerBottom + TOOLBAR_GAP ? "above" : "below";
+  const top = side === "above" ? above : anchorRect.top + anchorRect.height + TOOLBAR_GAP;
+
+  const centred = anchorRect.left + anchorRect.width / 2 - toolbarSize.width / 2;
+  const left = clamp(
+    centred,
+    railWidth + TOOLBAR_GAP,
+    viewport.width - toolbarSize.width - TOOLBAR_GAP,
+  );
+
+  return { left, top, side, visible: true };
+}

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -508,6 +508,11 @@ async function dropOneFile(page: Page, collectionId: string, clientX: number): P
 // opens the timeline in place, and the second control that navigated away was
 // removed deliberately (see graph-sub-timelines). The collection CARD's own
 // open button is the affordance now, so navigation tests go through it.
+/** A button in the floating selection toolbar. Item actions live there now,
+ *  so tests that used to reach into the icon rail come here instead. */
+const toolbarButton = (page: Page, name: string): Locator =>
+  page.getByRole("toolbar", { name: "Selection actions" }).getByRole("button", { name });
+
 const drillButton = (page: Page, timelineName: string): Locator =>
   page.getByRole("button", { name: `Open ${timelineName}`, exact: true }).first();
 
@@ -895,9 +900,9 @@ test.describe("graph view E2E", () => {
     await expect(alphaCard.locator('[data-disabled="true"]')).toHaveCount(0);
   });
 
-  test("right-click offers the rail's actions, and respects the selection", async ({ page }) => {
-    // PL14-007. The menu renders ITEM_ACTION_SPECS — the same list the rail's
-    // contextual cluster renders — so the two cannot drift apart about what an
+  test("right-click offers the toolbar's actions, and respects the selection", async ({ page }) => {
+    // PL14-007. The menu renders ITEM_ACTION_SPECS — the same list the
+    // selection toolbar renders — so the two cannot drift apart about what an
     // item can do.
     //
     // The selection rules were the item's open question, settled to the
@@ -921,14 +926,16 @@ test.describe("graph view E2E", () => {
     await expect(alpha).toHaveAttribute("data-selected", "true");
     expect(await selectedCount()).toBe(1);
 
-    // The rail's actions, in the rail's order.
+    // The toolbar's actions, in the toolbar's order — this menu is flat, so
+    // the overflow half is inlined and Delete still ends the primary run.
     await expect(menu.getByRole("menuitem")).toHaveText([
       "Edit",
       "Copy",
       "Cut",
-      "Duplicate",
-      "Disable",
       "Delete",
+      "Duplicate",
+      "Rename",
+      "Disable",
     ]);
     await page.keyboard.press("Escape");
     await expect(menu).toHaveCount(0);
@@ -947,7 +954,7 @@ test.describe("graph view E2E", () => {
     await expect(menu.getByRole("menuitem", { name: "Delete" })).toBeEnabled();
     await page.keyboard.press("Escape");
 
-    // 3. It acts on the selection, through the same path the rail uses.
+    // 3. It acts on the selection, through the same path the toolbar uses.
     await alpha.click({ button: "right" });
     await menu.getByRole("menuitem", { name: "Disable" }).click();
     await expect(alpha.locator('[data-disabled="true"]')).toBeVisible();
@@ -2770,7 +2777,7 @@ test.describe("graph view E2E", () => {
       await bravo.click();
       await expect(bravo).toHaveAttribute("data-selected", "true", { timeout: 700 });
     }).toPass({ timeout: 10000 });
-    await page.getByRole("button", { name: "More item actions" }).click();
+    await toolbarButton(page, "More actions").click();
     await page.getByRole("menuitem", { name: "Disable", exact: true }).click();
 
     // The card stays exactly where it was, muted and badged — never removed.
@@ -2857,36 +2864,29 @@ test.describe("graph view E2E", () => {
     await expect(badge).toBeHidden({ timeout: 2000 });
   });
 
-  test("selecting a clip switches the rail to item actions; Duplicate clones it after itself; Delete returns to normal", async ({
+  test("selecting a clip opens the toolbar; Duplicate clones it after itself; Delete clears", async ({
     page,
   }) => {
     const api = await installGraphApi(page);
     await openGraph(page);
     const alpha = strip(page, PROJECT_ID).locator('[data-node-id="alpha"]');
 
-    // Normal rail: layout controls present, no item actions.
-    await expect(page.getByRole("button", { name: "Grid layout" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Duplicate", exact: true })).toHaveCount(0);
+    // Nothing selected: no toolbar at all.
+    await expect(page.getByRole("toolbar", { name: "Selection actions" })).toHaveCount(0);
 
-    // Select alpha → the contextual cluster switches to item actions, the
-    // layout controls give way, and Paste is absent while the clipboard is empty.
+    // Select alpha → the toolbar appears ON the card. The rail is untouched:
+    // it stopped answering to the selection when these actions moved here.
     await expect(async () => {
       await alpha.click();
       await expect(alpha).toHaveAttribute("data-selected", "true", { timeout: 700 });
     }).toPass({ timeout: 10000 });
-    await expect(page.getByRole("button", { name: "More item actions" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Duplicate", exact: true })).toHaveCount(0);
-    await expect(page.getByRole("button", { name: "Grid layout" })).toHaveCount(0);
-    await expect(page.getByRole("button", { name: "Paste", exact: true })).toHaveCount(0);
-    await expect(page.getByRole("button", { name: "Copy", exact: true })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Cut", exact: true })).toBeVisible();
-    await expect(page.locator("[data-item-actions-cluster] + div")).toHaveClass(
-      /bg-amber-300\/65/,
-    );
+    const toolbar = page.getByRole("toolbar", { name: "Selection actions" });
+    await expect(toolbar).toBeVisible();
+    await expect(page.getByRole("button", { name: "Grid layout" })).toBeVisible();
 
     // Duplicate → the clone lands right AFTER alpha (index 1), and the focused
     // document persists the add (one write, five clips).
-    await page.getByRole("button", { name: "More item actions" }).click();
+    await toolbar.getByRole("button", { name: "More actions" }).click();
     await page.getByRole("menuitem", { name: "Duplicate", exact: true }).click();
     await expect.poll(() => stripOrder(page, PROJECT_ID)).toHaveLength(5);
     const order = await stripOrder(page, PROJECT_ID);
@@ -2895,16 +2895,18 @@ test.describe("graph view E2E", () => {
     expect(order[2]).toBe("bravo");
     await expect.poll(() => api.patchesFor(PROJECT_ID).at(-1)?.clipIds.length).toBe(5);
 
-    // Delete removes the (now-selected) clone and returns to the normal rail.
-    await page.getByRole("button", { name: "Delete", exact: true }).click();
+    // Delete removes the (now-selected) clone. With nothing selected the
+    // toolbar has nothing to anchor to and goes away — the selection is what
+    // summons it, not a mode.
+    await toolbar.getByRole("button", { name: "Delete" }).click();
     await expect
       .poll(() => stripOrder(page, PROJECT_ID))
       .toEqual(["alpha", "bravo", CHILD_ID, "charlie"]);
+    await expect(page.getByRole("toolbar", { name: "Selection actions" })).toHaveCount(0);
     await expect(page.getByRole("button", { name: "Grid layout" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Duplicate", exact: true })).toHaveCount(0);
   });
 
-  test("Copy a clip, drill into a collection, and Paste it there — the rail stays available across the drill-in", async ({
+  test("Copy a clip, drill into a collection, and Paste it there — the clipboard survives the drill-in", async ({
     page,
   }) => {
     const api = await installGraphApi(page);
@@ -2916,26 +2918,32 @@ test.describe("graph view E2E", () => {
       await expect(alpha).toHaveAttribute("data-selected", "true", { timeout: 700 });
     }).toPass({ timeout: 10000 });
 
-    // Copy → Paste becomes enabled.
-    await page.getByRole("button", { name: "Copy", exact: true }).click();
-    await expect(page.getByRole("button", { name: "Paste", exact: true })).toBeEnabled();
-    await expect(page.getByRole("button", { name: "Copy", exact: true })).toHaveCount(0);
-    await expect(page.getByRole("button", { name: "Cut", exact: true })).toHaveCount(0);
+    // Copy → the header's paste arms and starts naming its payload. Copy and
+    // Cut STAY where they are: they used to be replaced by Paste, which moved
+    // every action after them the instant anything was copied.
+    await page.getByRole("toolbar", { name: "Selection actions" })
+      .getByRole("button", { name: "Copy" })
+      .click();
+    await expect(page.getByRole("button", { name: /^Paste 1 item/ })).toBeVisible();
+    await expect(
+      page.getByRole("toolbar", { name: "Selection actions" })
+        .getByRole("button", { name: "Copy" }),
+    ).toBeVisible();
 
     // Drill into the child collection. The clipboard is a module singleton, so
-    // it survives the client-side navigation: the rail stays in item mode with
-    // Paste available even though the selection is now out of view. The
-    // SELECTION survives the navigation too — see the placement test below for
-    // why the paste must ignore it here and append into the focused child.
+    // it survives the client-side navigation: paste stays available even
+    // though the selection is now out of view. The SELECTION survives the
+    // navigation too — see the placement test below for why the paste must
+    // ignore it here and append into the focused child.
     await page.getByRole("button", { name: "Open Scene A" }).first().click();
     await strip(page, CHILD_ID)
       .locator('[data-node-id="c1"]')
       .waitFor({ state: "visible", timeout: 30000 });
-    await expect(page.getByRole("button", { name: "Paste", exact: true })).toBeEnabled();
+    await expect(page.getByRole("button", { name: /^Paste 1 item/ })).toBeVisible();
 
-    // Paste → alpha's clone appends into the child (after c1/c2), the child
-    // document gets a write, and the rail returns to normal.
-    await page.getByRole("button", { name: "Paste", exact: true }).click();
+    // Paste → alpha's clone appends into the child (after c1/c2) and the child
+    // document gets a write.
+    await page.getByRole("button", { name: /^Paste 1 item/ }).click();
     await expect.poll(() => stripOrder(page, CHILD_ID)).toHaveLength(3);
     expect((await stripOrder(page, CHILD_ID)).slice(0, 2)).toEqual(["c1", "c2"]);
     await expect.poll(() => api.patchesFor(CHILD_ID).at(-1)?.clipIds.length).toBe(3);
@@ -2958,12 +2966,13 @@ test.describe("graph view E2E", () => {
       await alpha.click();
       await expect(alpha).toHaveAttribute("data-selected", "true", { timeout: 700 });
     }).toPass({ timeout: 10000 });
-    await page.getByRole("button", { name: "Copy", exact: true }).click();
-    await expect(page.getByRole("button", { name: "Paste", exact: true })).toBeEnabled();
+    await toolbarButton(page, "Copy").click();
+    await expect(page.getByRole("button", { name: /^Paste 1 item after/ })).toBeVisible();
 
     // alpha is still selected and still on screen → its clone lands at index 1,
-    // not at the end of the strip.
-    await page.getByRole("button", { name: "Paste", exact: true }).click();
+    // not at the end of the strip. The header's label says so BEFORE the
+    // click, which is the whole reason it names its destination.
+    await page.getByRole("button", { name: /^Paste 1 item after/ }).click();
     await expect.poll(() => stripOrder(page, PROJECT_ID)).toHaveLength(5);
     const order = await stripOrder(page, PROJECT_ID);
     expect(order[0]).toBe("alpha");
@@ -2980,7 +2989,7 @@ test.describe("graph view E2E", () => {
       await charlie.click();
       await expect(charlie).toHaveAttribute("data-selected", "true", { timeout: 700 });
     }).toPass({ timeout: 10000 });
-    await page.getByRole("button", { name: "Copy", exact: true }).click();
+    await toolbarButton(page, "Copy").click();
 
     await page.getByRole("button", { name: "Open Scene A" }).first().click();
     // The route change itself, not a CHILD card appearing — a sub-row strip
@@ -2989,7 +2998,7 @@ test.describe("graph view E2E", () => {
     await strip(page, CHILD_ID)
       .locator('[data-node-id="c1"]')
       .waitFor({ state: "visible", timeout: 30000 });
-    await page.getByRole("button", { name: "Paste", exact: true }).click();
+    await page.getByRole("button", { name: /^Paste 1 item/ }).click();
 
     // Appended into the FOCUSED child, after its own cards…
     await expect.poll(() => stripOrder(page, CHILD_ID)).toHaveLength(3);
@@ -3006,7 +3015,7 @@ test.describe("graph view E2E", () => {
     expect(api.patchesFor(PROJECT_ID).some((patch) => patch.clipIds.length > 5)).toBe(false);
   });
 
-  test("Cut removes the clip but keeps it on the clipboard; Paste relocates it", async ({
+  test("Cut then Paste in another collection MOVES the clip across", async ({
     page,
   }) => {
     await installGraphApi(page);
@@ -3018,28 +3027,25 @@ test.describe("graph view E2E", () => {
       await expect(bravo).toHaveAttribute("data-selected", "true", { timeout: 700 });
     }).toPass({ timeout: 10000 });
 
-    // Cut → bravo leaves the project strip (moved to trash), but the clipboard
-    // keeps an independent copy, so the rail stays in item mode with Paste on.
-    await page.getByRole("button", { name: "Cut", exact: true }).click();
+    // Cut leaves bravo in the strip, dimmed and waiting. It used to be trashed
+    // here, before the user had said where it was going.
+    await toolbarButton(page, "Cut").click();
+    await expect(page.locator('[data-card-pending-cut="true"]')).toHaveCount(1);
     await expect
       .poll(() => stripOrder(page, PROJECT_ID))
-      .toEqual(["alpha", CHILD_ID, "charlie"]);
-    await expect(page.getByRole("button", { name: "Paste", exact: true })).toBeEnabled();
+      .toEqual(["alpha", "bravo", CHILD_ID, "charlie"]);
 
-    // Paste into the child collection → the cut clip lands there (a move).
+    // Paste into the child collection → bravo MOVES there, keeping its id.
     await page.getByRole("button", { name: "Open Scene A" }).first().click();
     await strip(page, CHILD_ID)
       .locator('[data-node-id="c1"]')
       .waitFor({ state: "visible", timeout: 30000 });
-    await page.getByRole("button", { name: "Paste", exact: true }).click();
+    await page.getByRole("button", { name: /^Paste 1 item/ }).click();
     await expect.poll(() => stripOrder(page, CHILD_ID)).toHaveLength(3);
-    // The pasted card IS bravo's clone (same name, fresh id) — not just "some
-    // third child": a paste inserting the wrong entry would still pass a bare
-    // length check.
-    const pasted = strip(page, CHILD_ID).getByRole("button", { name: "bravo", exact: true });
-    await expect(pasted).toBeVisible();
-    await expect(pasted).not.toHaveAttribute("data-node-id", "bravo");
-    await expect(page.getByRole("button", { name: "Grid layout" })).toBeVisible();
+    // The SAME node, not a clone of it. Under the old cut-then-clone model
+    // this card carried a fresh id and the original sat in the trash; a move
+    // brings the item itself, which is what "cut" has always promised.
+    await expect(strip(page, CHILD_ID).locator('[data-node-id="bravo"]')).toBeVisible();
   });
 
   test("keyboard: Ctrl+C copies and Ctrl+V pastes after a drill-in (focus on <body>)", async ({
@@ -3057,7 +3063,7 @@ test.describe("graph view E2E", () => {
     // Ctrl+C — the copy toast is the only visible change, plus Paste arming.
     await page.keyboard.press("Control+c");
     await expect(page.getByText("Copied 1 item.").first()).toBeVisible();
-    await expect(page.getByRole("button", { name: "Paste", exact: true })).toBeEnabled();
+    await expect(page.getByRole("button", { name: /^Paste 1 item/ })).toBeVisible();
 
     // Drill in — focus drops to <body> here, which is exactly why the
     // shortcut listener is window-level and not a board-subtree boundary.
@@ -3093,12 +3099,12 @@ test.describe("graph view E2E", () => {
     expect(order[1]).toBe("bravo");
     expect(order[3]).toBe(CHILD_ID);
 
-    // Ctrl+X cuts the selected clone: gone from the strip, Paste armed.
+    // Ctrl+X arms the clone for a move: it stays on the strip, dimmed, and
+    // paste names it as its payload.
     await page.keyboard.press("Control+x");
-    await expect
-      .poll(() => stripOrder(page, PROJECT_ID))
-      .toEqual(["alpha", "bravo", CHILD_ID, "charlie"]);
-    await expect(page.getByRole("button", { name: "Paste", exact: true })).toBeEnabled();
+    await expect(page.locator('[data-card-pending-cut="true"]')).toHaveCount(1);
+    await expect.poll(() => stripOrder(page, PROJECT_ID)).toHaveLength(5);
+    await expect(page.getByRole("button", { name: /^Paste 1 item/ })).toBeVisible();
   });
 
   test("multi-select Duplicate in one parent is ONE undoable step", async ({ page }) => {
@@ -3119,8 +3125,10 @@ test.describe("graph view E2E", () => {
 
     // Both copies land as one contiguous block after the LAST source (bravo),
     // keeping the sources' relative order.
-    await page.getByRole("button", { name: "More item actions" }).click();
-    await page.getByRole("menuitem", { name: "Duplicate", exact: true }).click();
+    await toolbarButton(page, "More actions").click();
+    // The row says the COUNT once the selection is plural — "Duplicate" alone
+    // reads as "this card", which is the wrong promise with two selected.
+    await page.getByRole("menuitem", { name: "Duplicate 2 items" }).click();
     await expect.poll(() => stripOrder(page, PROJECT_ID)).toHaveLength(6);
     const order = await stripOrder(page, PROJECT_ID);
     expect(order.slice(0, 2)).toEqual(["alpha", "bravo"]);
@@ -4874,11 +4882,12 @@ test.describe("graph view E2E", () => {
       await expect(alpha).toHaveAttribute("data-selected", "true");
     };
 
-    // A CONTROL is an action, not a click-away. The sidebar's Copy button
-    // only exists WHILE something is selected, which makes it the sharpest
-    // case available: if the click cleared, the button it was on would vanish.
+    // A CONTROL is an action, not a click-away. The selection toolbar's Copy
+    // button only exists WHILE something is selected, which makes it the
+    // sharpest case available: if the click cleared, the button it was on
+    // would vanish out from under it.
     await select();
-    await page.getByRole("button", { name: "Copy", exact: true }).click();
+    await toolbarButton(page, "Copy").click();
     await expect(alpha).toHaveAttribute("data-selected", "true");
 
     // A card click still replaces rather than clears.
@@ -5668,5 +5677,342 @@ test.describe("graph view E2E", () => {
       el.scrollLeft = 30_000;
     });
     await expect.poll(markCount).toBeLessThan(120);
+  });
+
+  // ── Contextual selection toolbar ──────────────────────────────────────────
+  //
+  // Item actions moved out of the icon rail and onto the card they act on.
+  // What these pin is the three things that move cost the rail: the rail is a
+  // VIEW rail again, the toolbar is where the pointer already is, and its
+  // action row does not reshuffle as the selection grows.
+
+  /** The floating toolbar. Portalled to the body, so it is never inside a
+   *  surface locator. */
+  function selectionToolbar(page: Page) {
+    return page.getByRole("toolbar", { name: "Selection actions" });
+  }
+
+  test("the rail keeps its view toggles while items are selected", async ({ page }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+
+    // The regression that motivated the whole change: selecting used to
+    // REPLACE these with item actions, so you could not select clips and then
+    // go look at them in the other layout.
+    await strip(page, PROJECT_ID).locator('[data-node-id="alpha"]').click();
+    await expect(selectionToolbar(page)).toBeVisible();
+
+    const rail = page.locator("aside");
+    await expect(rail.getByRole("button", { name: "Grid layout" })).toBeVisible();
+    await expect(rail.getByRole("button", { name: "Strip layout" })).toBeVisible();
+    await expect(rail.getByRole("button", { name: /preview/i })).toBeVisible();
+    // And the actions are NOT there — they live on the card now.
+    await expect(rail.getByRole("button", { name: "Delete" })).toHaveCount(0);
+    await expect(rail.getByRole("button", { name: "Copy" })).toHaveCount(0);
+  });
+
+  test("selection survives switching between strip and grid", async ({ page }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    await strip(page, PROJECT_ID).locator('[data-node-id="bravo"]').click();
+    await expect(selectionToolbar(page)).toBeVisible();
+
+    await page.locator("aside").getByRole("button", { name: "Grid layout" }).click();
+    await expect
+      .poll(() => gridOrder(page, PROJECT_ID), { timeout: 15000 })
+      .toContain("bravo");
+
+    // Still selected, and the toolbar re-anchored to the card's new position
+    // rather than pointing at where it used to be.
+    await expect(
+      page.locator(
+        `[data-virtual-grid="${PROJECT_ID}"] [data-node-id="bravo"][data-selected="true"]`,
+      ),
+    ).toHaveCount(1);
+    await expect(selectionToolbar(page)).toBeVisible();
+    const card = (await page
+      .locator(`[data-virtual-grid="${PROJECT_ID}"] [data-node-id="bravo"]`)
+      .boundingBox())!;
+    const bar = (await selectionToolbar(page).boundingBox())!;
+    expect(Math.abs(bar.x + bar.width / 2 - (card.x + card.width / 2))).toBeLessThan(2);
+  });
+
+  test("the toolbar follows the last-clicked card, not the whole selection", async ({
+    page,
+  }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    const surface = strip(page, PROJECT_ID);
+
+    await surface.locator('[data-node-id="alpha"]').click();
+    const alpha = (await surface.locator('[data-node-id="alpha"]').boundingBox())!;
+    const onAlpha = (await selectionToolbar(page).boundingBox())!;
+    expect(Math.abs(onAlpha.x + onAlpha.width / 2 - (alpha.x + alpha.width / 2))).toBeLessThan(2);
+    // Adjacent to the card and never ON it. Which SIDE is not asserted: the
+    // strip sits directly under the sticky header, so there is no room above
+    // and the placement legitimately flips below — pinning "above" here would
+    // pin the fixture's scroll position rather than the behaviour.
+    const above = onAlpha.y + onAlpha.height <= alpha.y + 1;
+    const below = onAlpha.y >= alpha.y + alpha.height - 1;
+    expect(above || below).toBe(true);
+
+    // Ctrl+click a second card: the selection grows, and the toolbar moves to
+    // the card just touched. Anchoring to the selection's bounding box would
+    // have parked it between the two, over cards that are not selected.
+    await surface.locator('[data-node-id="charlie"]').click({ modifiers: ["ControlOrMeta"] });
+    await expect(page.locator('[data-selected="true"]')).toHaveCount(2);
+    const charlie = (await surface.locator('[data-node-id="charlie"]').boundingBox())!;
+    await expect
+      .poll(async () => {
+        const bar = (await selectionToolbar(page).boundingBox())!;
+        return Math.round(bar.x + bar.width / 2);
+      })
+      .toBe(Math.round(charlie.x + charlie.width / 2));
+  });
+
+  test("the action row does not reshuffle as the selection grows", async ({ page }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    const surface = strip(page, PROJECT_ID);
+    const labels = () =>
+      selectionToolbar(page)
+        .getByRole("button")
+        .evaluateAll((els) => els.map((el) => el.getAttribute("aria-label") ?? ""));
+
+    await surface.locator('[data-node-id="alpha"]').click();
+    expect(await labels()).toEqual(["Edit", "Copy", "Cut", "Delete", "More actions"]);
+
+    await surface.locator('[data-node-id="bravo"]').click({ modifiers: ["ControlOrMeta"] });
+    await surface.locator('[data-node-id="charlie"]').click({ modifiers: ["ControlOrMeta"] });
+    await expect(page.locator('[data-selected="true"]')).toHaveCount(3);
+
+    // Labels gain counts; POSITIONS do not move. Removing an unavailable
+    // action would slide every action after it, and the selection count
+    // changes constantly during a multi-select — so the row would shuffle
+    // under the pointer mid-gesture.
+    expect(await labels()).toEqual([
+      "Edit",
+      "Copy 3 items",
+      "Cut 3 items",
+      "Delete 3 items",
+      "More actions",
+    ]);
+    // The count leads the row so the verbs read as selection-scoped.
+    await expect(selectionToolbar(page).locator("[data-selection-toolbar-count]")).toHaveText("3");
+  });
+
+  test("Edit dims for a multi-selection but still says why", async ({ page }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    const surface = strip(page, PROJECT_ID);
+    await surface.locator('[data-node-id="alpha"]').click();
+    await surface.locator('[data-node-id="bravo"]').click({ modifiers: ["ControlOrMeta"] });
+
+    const edit = selectionToolbar(page).getByRole("button", { name: "Edit" });
+    // `aria-disabled`, never the `disabled` attribute: a disabled button
+    // cannot be focused, cannot be hovered usefully on touch, and answers
+    // nothing when pressed — so it can never explain itself.
+    await expect(edit).toHaveAttribute("aria-disabled", "true");
+    await expect(edit).not.toHaveAttribute("disabled", "");
+    await edit.focus();
+    await expect(edit).toBeFocused();
+
+    // The reason reaches a screen reader as a description, not only as a
+    // hover tooltip.
+    const describedBy = await edit.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    await expect(page.locator(`#${describedBy}`)).toHaveText("Edit one item at a time");
+
+    // And pressing it explains rather than doing nothing. `force` because
+    // Playwright's actionability check treats aria-disabled as unclickable —
+    // a real browser does not, which is exactly why the control uses the ARIA
+    // attribute instead of the native one.
+    await edit.click({ force: true });
+    await expect(page.locator(`#${describedBy}`)).toBeVisible();
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+  });
+
+  test("cut leaves the originals in place until a paste says where", async ({ page }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    const surface = strip(page, PROJECT_ID);
+
+    await surface.locator('[data-node-id="charlie"]').click();
+    await selectionToolbar(page).getByRole("button", { name: "Cut" }).click();
+
+    // Cut used to trash the originals immediately and let paste re-create
+    // them. The item now WAITS, dimmed, for a destination.
+    await expect(page.locator('[data-card-pending-cut="true"]')).toHaveCount(1);
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID))
+      .toEqual(["alpha", "bravo", CHILD_ID, "charlie"]);
+    await expect(page.getByRole("button", { name: /^Paste 1 item/ })).toBeVisible();
+  });
+
+  test("cut then paste is a MOVE, and one undo puts it back", async ({ page }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    const surface = strip(page, PROJECT_ID);
+    const before = await stripOrder(page, PROJECT_ID);
+
+    await surface.locator('[data-node-id="charlie"]').click();
+    await selectionToolbar(page).getByRole("button", { name: "Cut" }).click();
+    await expect(page.locator('[data-card-pending-cut="true"]')).toHaveCount(1);
+
+    await surface.locator('[data-node-id="alpha"]').click();
+    await page.getByRole("button", { name: /^Paste 1 item after/ }).click();
+
+    // It MOVED: same count, same id, now behind alpha. A clone-and-trash
+    // would have produced a new id and left the original in the bin.
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID), { timeout: 8000 })
+      .toEqual(["alpha", "charlie", "bravo", CHILD_ID]);
+    await expect(page.locator('[data-card-pending-cut="true"]')).toHaveCount(0);
+
+    // ONE undo, not two. This is the reason paste dispatches `move-nodes`
+    // rather than add-then-trash: two commands would be two history entries,
+    // and a single Ctrl+Z would restore the original while leaving the copy.
+    await page.keyboard.press("ControlOrMeta+z");
+    await expect.poll(() => stripOrder(page, PROJECT_ID), { timeout: 8000 }).toEqual(before);
+  });
+
+  test("paste with nothing selected appends to the end", async ({ page }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    const surface = strip(page, PROJECT_ID);
+
+    await surface.locator('[data-node-id="bravo"]').click();
+    await selectionToolbar(page).getByRole("button", { name: "Copy" }).click();
+    await page.keyboard.press("Escape");
+    await expect(page.locator('[data-selected="true"]')).toHaveCount(0);
+
+    await page.getByRole("button", { name: /^Paste 1 item at end/ }).click();
+    await expect.poll(() => stripOrder(page, PROJECT_ID), { timeout: 8000 }).toHaveLength(5);
+    const order = await stripOrder(page, PROJECT_ID);
+    expect(order.slice(0, 4)).toEqual(["alpha", "bravo", CHILD_ID, "charlie"]);
+  });
+
+  test("paste lands after the anchor even when the selection is scattered", async ({
+    page,
+  }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    const surface = strip(page, PROJECT_ID);
+
+    await surface.locator('[data-node-id="charlie"]').click();
+    await selectionToolbar(page).getByRole("button", { name: "Copy" }).click();
+
+    // A NON-CONTIGUOUS selection: the collection and alpha, with bravo between
+    // them, anchored on alpha (clicked last). There is deliberately no
+    // contiguity special case — contiguity is invisible to the user, and a
+    // rule that silently moved the destination because of it would read as a
+    // bug. The anchor is the card the toolbar is attached to.
+    await surface.locator(`[data-node-id="${CHILD_ID}"]`).click();
+    await surface.locator('[data-node-id="alpha"]').click({ modifiers: ["ControlOrMeta"] });
+    await expect(page.locator('[data-selected="true"]')).toHaveCount(2);
+
+    await page.getByRole("button", { name: /^Paste 1 item after/ }).click();
+    await expect.poll(() => stripOrder(page, PROJECT_ID), { timeout: 8000 }).toHaveLength(5);
+    const order = await stripOrder(page, PROJECT_ID);
+    expect(order[0]).toBe("alpha");
+    expect(order[2]).toBe("bravo");
+  });
+
+  test("pasted items end up selected and briefly highlighted", async ({ page }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    const surface = strip(page, PROJECT_ID);
+
+    await surface.locator('[data-node-id="bravo"]').click();
+    await selectionToolbar(page).getByRole("button", { name: "Copy" }).click();
+
+    // Watched rather than sampled: the highlight is transient by design, and
+    // a poll can straddle it.
+    await page.evaluate(() => {
+      const w = window as unknown as { __flash?: number };
+      w.__flash = 0;
+      const tick = () => {
+        const n = document.querySelectorAll('[data-card-just-pasted="true"]').length;
+        if (n > (w.__flash ?? 0)) w.__flash = n;
+        requestAnimationFrame(tick);
+      };
+      requestAnimationFrame(tick);
+    });
+
+    await page.getByRole("button", { name: /^Paste 1 item after/ }).click();
+    await expect.poll(() => stripOrder(page, PROJECT_ID), { timeout: 8000 }).toHaveLength(5);
+
+    // Paste into a long board is otherwise silent — the user clicks and
+    // nothing visibly happens.
+    await expect
+      .poll(() => page.evaluate(() => (window as unknown as { __flash?: number }).__flash ?? 0))
+      .toBeGreaterThan(0);
+    // Selected, so the next action chains onto what was just pasted.
+    await expect(page.locator('[data-selected="true"]')).toHaveCount(1);
+  });
+
+  test("the whole toolbar is reachable from the keyboard alone", async ({ page }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    const surface = strip(page, PROJECT_ID);
+    await surface.locator('[data-node-id="alpha"]').click();
+    await expect(selectionToolbar(page)).toBeVisible();
+
+    // F10 is the toolbar convention, and is free of the modifier collisions
+    // the Alt layer and the trim chords have already claimed here.
+    await page.keyboard.press("F10");
+    await expect(selectionToolbar(page).getByRole("button", { name: "Edit" })).toBeFocused();
+
+    // Arrows move WITHIN the toolbar — one tab stop, not five.
+    await page.keyboard.press("ArrowRight");
+    await expect(selectionToolbar(page).getByRole("button", { name: "Copy" })).toBeFocused();
+    await page.keyboard.press("ArrowLeft");
+    await expect(selectionToolbar(page).getByRole("button", { name: "Edit" })).toBeFocused();
+
+    // Escape clears the selection and hands focus back to the card, so the
+    // keyboard route does not dead-end in a toolbar that just vanished.
+    await page.keyboard.press("Escape");
+    await expect(selectionToolbar(page)).toHaveCount(0);
+    await expect(surface.locator('[data-node-id="alpha"]')).toBeFocused();
+  });
+
+  test("the header offers the same actions when the anchor is off the board", async ({
+    page,
+  }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    const surface = strip(page, PROJECT_ID);
+
+    await surface.locator('[data-node-id="alpha"]').click();
+    await expect(selectionToolbar(page)).toBeVisible();
+
+    // Drill into the collection. The selection survives the navigation (that
+    // is deliberate — it is what makes copy-here-paste-there work), but the
+    // anchor card is no longer rendered, so there is nothing to point at.
+    //
+    // Same code path as scrolling one out of view: the placement asks for the
+    // anchor's rect, gets nothing, and stands down rather than guessing. What
+    // must NOT go with it are the actions, which is the header overflow's
+    // entire job.
+    await page.getByRole("button", { name: "Open Scene A" }).first().click();
+    await strip(page, CHILD_ID)
+      .locator('[data-node-id="c1"]')
+      .waitFor({ state: "visible", timeout: 30000 });
+
+    await expect
+      .poll(
+        async () => {
+          const bar = selectionToolbar(page);
+          if ((await bar.count()) === 0) return "gone";
+          return (await bar.isVisible()) ? "visible" : "hidden";
+        },
+        { timeout: 5000 },
+      )
+      .not.toBe("visible");
+
+    const overflow = page.locator("[data-header-selection-overflow]");
+    await expect(overflow).toBeVisible();
+    await overflow.click();
+    await expect(page.getByRole("menuitem", { name: "Duplicate" })).toBeVisible();
   });
 });

--- a/packages/ui/dnd-collections/index.ts
+++ b/packages/ui/dnd-collections/index.ts
@@ -111,6 +111,14 @@ export { DndCollections, type DndCollectionsProps } from "./react/DndCollections
 export {
   KEYBOARD_IGNORE_ATTRIBUTE,
   isEditableKeyboardTarget,
+  // Finding a card by id, and focusing one that virtualization may not have
+  // mounted yet. Exported because an app rendering its own overlays against
+  // cards needs BOTH, and the alternatives are worse: a hand-rolled attribute
+  // selector skips the CSS.escape fallback (node ids are arbitrary strings),
+  // and a hand-rolled focus skips the mutation-observed retry that is the
+  // whole point when the target is inside a virtualized view.
+  findNodeElement,
+  focusNodeWhenMounted,
 } from "./react/node-dom";
 export {
   type CollectionsClickSelection,

--- a/packages/ui/dnd-collections/react/use-background-clear.ts
+++ b/packages/ui/dnd-collections/react/use-background-clear.ts
@@ -45,6 +45,12 @@ const NON_BACKGROUND_SELECTOR = [
   "[role='radio']",
   "[role='switch']",
   "[role='separator']",
+  // A toolbar's BUTTONS are already covered above, but its padding and its
+  // separators are not — and a toolbar that floats over the surface (a
+  // consumer's contextual selection toolbar, say) is exactly where a stray
+  // click lands. Clearing there would dismiss the toolbar out from under the
+  // click that was aimed at it.
+  "[role='toolbar']",
 ].join(", ");
 
 /**


### PR DESCRIPTION
Phase 1 of the spec. The icon rail is a **view rail** again, and item actions live in a floating toolbar anchored to the card you last clicked.

## Why

The rail swapped its view toggles for item actions the moment anything was selected. Three costs — a full-width mouse trip, a layout jump on every selection change, and the real one: **no access to view switching while a selection existed**, so you couldn't select clips and then look at them in the strip.

## Anchored to the last-clicked card, not the selection's bounding box

A grid selection is a *set*, not a region: top-left plus bottom-right spans the viewport and parks the toolbar over cards that aren't in it.

The anchor is **derived, not stored**. `selectedIds` is a Set, Sets iterate in insertion order, and every mutator appends — so "the card last touched that's still selected" is the last entry, which is the rule `resolveInsertPlacement` already used. The one case a Set can't answer is *removal*, where insertion order surfaces a card the user can't see; there the anchor moves to the last remaining card in **grid** order.

## Paste moved to the header, permanently

Every verb in the toolbar acts *on* the selection. Paste needs a destination, and a selection is not a destination. Its label names payload and destination — "Paste 3 items after 'Car Chase'" — because the difference between that and appending at the end is invisible until it has already happened.

## Cut no longer trashes on cut

Owner's call on R9.9. Originals stay in place, dimmed, until a paste says where they're going.

That turned out **strictly better than the spec asked for**: when the sources still exist, paste dispatches one `move-nodes`. It's a true move — ids preserved, documents not re-minted — and it's **one undo step**. Clone-then-trash would have been two commands, so a single Ctrl+Z would restore the originals and leave the copies behind. Sources deleted or undone away since the cut fall back to the clipboard snapshot, which is why cut still captures one.

## What I deferred, dropped, or found already done

**Deferred to phase 2** (separate PR): shift+click ranges, Cmd+A, arrow-key selection. These change selection semantics inside `packages/ui/dnd-collections`, which the strip, grid and keyboard controller all depend on. Bare arrows are currently roving *focus* — making them move selection is a semantic change, not an addition.

**Dropped, with reason:** instrumenting usage to pick the promoted verbs (R5.6/R15.1) and the two-release migration (R15.2). Both assume a userbase with muscle memory and a telemetry pipeline. The existing `group: "primary" | "overflow"` split already encodes the promoted-verb decision.

**Already shipped — not rebuilt:** the header's "N selected · duration" (R8.1) and the live region announcing selection counts (R12.6).

**E8 does not apply here.** The clipboard stores deep `structuredClone` snapshots, not ids, so a deleted original can't break a paste. No skip-and-report needed.

**No delete confirmation** (owner's call): delete means move-to-trash, which is recoverable and undoable, so a modal would guard a reversible step and train people to dismiss dialogs. A toast states the count instead.

## Verification

Five claims proven to **fail** against their pre-change behaviour, not just pass against the new one:

| Claim | Reverted to | Result |
|---|---|---|
| Toolbar follows the last-clicked card | first-in-set anchor | fails |
| Dimmed Edit says why | `unavailableReason: noReason` | fails |
| Action row never reshuffles | copy/cut hidden when clipboard armed | fails |
| Cut leaves originals in place | `moveSelectionToTrash` on cut | fails |
| Cut→paste is one undo | clone path instead of `move-nodes` | fails |

| | |
|---|---|
| graph-view e2e | 115 passed (13 new) |
| App vitest | 551 passed |
| Unit | 433 passed |
| Storybook | 166 passed |
| Typecheck | clean, both workspaces |
| Lint | 0 errors (5 pre-existing `<img>` warnings) |

Also driven by hand in the running app: cut→paste moves the card and one Ctrl+Z restores the original order; the paste highlight fires; the rail keeps its toggles throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)