### PR TITLE
Touch (§11): additive-tap mode, 44px targets, and R11.1 dropped

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -467,6 +467,18 @@ function HeaderToggle({
  * floating toolbar is allowed to hide itself when its anchor scrolls away
  * (R6.6/R8.3): the actions are still one click from here.
  */
+/**
+ * Touch sizing for the header's selection controls (R11.2).
+ *
+ * These are the FALLBACK surface for the same actions the floating toolbar
+ * offers — the one that takes over when the anchor card scrolls away — so they
+ * need the same 44px minimum on a finger. The rest of the header row keeps its
+ * 32px: those are chrome you reach for deliberately, not the controls a touch
+ * user is steered to mid-gesture.
+ */
+const HEADER_SELECTION_SIZE =
+  "h-8 w-8 [@media(pointer:coarse)]:h-11 [@media(pointer:coarse)]:w-11";
+
 function HeaderSelectionCluster({
   anchorName,
 }: Readonly<{ anchorName: string | null }>) {
@@ -499,7 +511,7 @@ function HeaderSelectionCluster({
           requestGraphItemAction("paste");
         }}
         className={cn(
-          "h-8 w-8",
+          HEADER_SELECTION_SIZE,
           clipboardCount === 0 || state.busy
             ? "cursor-not-allowed text-zinc-600 hover:text-zinc-600"
             : HEADER_TOGGLE_IDLE,
@@ -517,7 +529,7 @@ function HeaderSelectionCluster({
             title="Clear selection (Esc)"
             data-clear-selection
             onClick={() => store.clearSelection()}
-            className={cn("h-8 w-8", HEADER_TOGGLE_IDLE)}
+            className={cn(HEADER_SELECTION_SIZE, HEADER_TOGGLE_IDLE)}
           >
             <X aria-hidden className="h-4 w-4" />
           </Button>
@@ -529,7 +541,7 @@ function HeaderSelectionCluster({
                 size="icon"
                 aria-label="More selection actions"
                 data-header-selection-overflow
-                className={cn("h-8 w-8", HEADER_TOGGLE_IDLE)}
+                className={cn(HEADER_SELECTION_SIZE, HEADER_TOGGLE_IDLE)}
               >
                 <EllipsisVertical aria-hidden className="h-4 w-4" />
               </Button>

--- a/apps/timeline-gstudio001/components/graph-view/graph-selection-toolbar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-selection-toolbar.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { EllipsisVertical } from "lucide-react";
+import { CopyCheck, EllipsisVertical } from "lucide-react";
 
 import {
   findNodeElement,
@@ -53,6 +53,21 @@ import {
 /** Matches the rail's width, which the toolbar must never slide under. */
 const RAIL_WIDTH = 72;
 
+/**
+ * Control size: 36px for a pointer, 44px for a finger (R11.2).
+ *
+ * Keyed off `pointer: coarse` rather than a viewport width, because the
+ * question is what is DOING the pointing, not how big the screen is — a
+ * touchscreen laptop needs the bigger target at desktop width, and a phone
+ * driven by a stylus does not.
+ */
+const CONTROL_SIZE = "h-9 w-9 [@media(pointer:coarse)]:h-11 [@media(pointer:coarse)]:w-11";
+
+/** A finger covers roughly this much more than a cursor does, so a toolbar
+ *  that had to flip BELOW its card clears the hand rather than hiding under
+ *  it (R11.3). */
+const COARSE_POINTER_GAP = 20;
+
 const TOOLBAR_ATTRIBUTE = "data-graph-selection-toolbar";
 
 function rectOf(el: Element | null): ToolbarRect | null {
@@ -101,7 +116,8 @@ function ActionButton({
         onFocus={() => setShowReason(true)}
         onBlur={() => setShowReason(false)}
         className={cn(
-          "inline-flex h-9 w-9 items-center justify-center rounded-lg transition-colors",
+          "inline-flex items-center justify-center rounded-lg transition-colors",
+          CONTROL_SIZE,
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70",
           disabled
             ? "cursor-not-allowed text-zinc-600"
@@ -144,6 +160,7 @@ function ActionButton({
 function SelectionToolbarFrame({ anchorId }: Readonly<{ anchorId: NodeId }>) {
   const store = useCollectionsStore();
   const state = useSelectionActionState();
+  const multiSelectMode = useCollectionsSelector((s) => s.interaction.multiSelectMode);
   const frameRef = useRef<HTMLDivElement | null>(null);
   const [visible, setVisible] = useState(false);
 
@@ -182,6 +199,12 @@ function SelectionToolbarFrame({ anchorId }: Readonly<{ anchorId: NodeId }>) {
         headerRect: rectOf(document.querySelector("[data-graph-board-header]")),
         railWidth: RAIL_WIDTH,
         viewport: { width: window.innerWidth, height: window.innerHeight },
+        // Asked per frame rather than cached: a hybrid machine can switch
+        // between a trackpad and its touchscreen without any event this
+        // component would see, and matchMedia is a cheap read.
+        gap: window.matchMedia?.("(pointer: coarse)").matches
+          ? COARSE_POINTER_GAP
+          : undefined,
       });
       if (!placement.visible) {
         // Setting the same value every frame is free — React bails out of an
@@ -294,6 +317,40 @@ function SelectionToolbarFrame({ anchorId }: Readonly<{ anchorId: NodeId }>) {
           {state.selectionCount}
         </span>
       ) : null}
+      {/* Additive-tap mode, and it sits with the COUNT rather than with the
+          verbs: both describe the selection, while everything to the right of
+          the divider acts on it. Keeping it out of that run is also what lets
+          R5.1 hold — the four actions stay at the same offsets whether or not
+          this is here.
+
+          Always rendered, not gated on `pointer: coarse`. Touch is why it
+          exists, but a device can have both a trackpad and a touchscreen, and
+          a control that appears and disappears depending on which one you
+          last used is worse than one extra button. It is a genuine
+          alternative to holding Ctrl for anyone who prefers it. */}
+      <button
+        type="button"
+        data-multi-select-toggle
+        aria-pressed={multiSelectMode}
+        aria-label={multiSelectMode ? "Stop adding to the selection" : "Add to the selection"}
+        title={
+          multiSelectMode
+            ? "Tapping stops adding — tap again to resume"
+            : "Tap items to add them to the selection (no Ctrl needed)"
+        }
+        onClick={() => store.setMultiSelectMode(!multiSelectMode)}
+        className={cn(
+          "inline-flex items-center justify-center rounded-lg transition-colors",
+          CONTROL_SIZE,
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70",
+          multiSelectMode
+            ? "bg-amber-400/15 text-amber-300 hover:bg-amber-400/25"
+            : "text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100",
+        )}
+      >
+        <CopyCheck aria-hidden="true" className="h-4 w-4" />
+      </button>
+      <span aria-hidden="true" className="mx-1 h-5 w-px shrink-0 bg-zinc-700" />
       {primary.map((spec, index) => {
         const Icon = spec.icon(state);
         return (
@@ -321,7 +378,8 @@ function SelectionToolbarFrame({ anchorId }: Readonly<{ anchorId: NodeId }>) {
             type="button"
             aria-label="More actions"
             className={cn(
-              "inline-flex h-9 w-9 items-center justify-center rounded-lg text-zinc-300 transition-colors",
+              "inline-flex items-center justify-center rounded-lg text-zinc-300 transition-colors",
+              CONTROL_SIZE,
               "hover:bg-zinc-800 hover:text-zinc-100",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70",
             )}

--- a/apps/timeline-gstudio001/lib/selection-toolbar-position.test.ts
+++ b/apps/timeline-gstudio001/lib/selection-toolbar-position.test.ts
@@ -84,6 +84,25 @@ describe("resolveToolbarPlacement", () => {
     expect(placement.left).toBe(RAIL + TOOLBAR_GAP);
   });
 
+  it("uses a larger gap when one is supplied, on both sides of the flip", () => {
+    // A finger covers more than a cursor does, so a toolbar that had to flip
+    // BELOW its card must clear the hand that just tapped it.
+    const above = resolveToolbarPlacement(input({ gap: 20 }));
+    expect(above.side).toBe("above");
+    expect(above.top).toBe(400 - TOOLBAR.height - 20);
+
+    const below = resolveToolbarPlacement(input({ anchorRect: card({ top: 60 }), gap: 20 }));
+    expect(below.side).toBe("below");
+    expect(below.top).toBe(60 + 96 + 20);
+  });
+
+  it("keeps the EDGE clamps at the base gap regardless", () => {
+    // The horizontal clamps are about not colliding with opaque chrome — the
+    // rail and the viewport edge — which a bigger fingertip does not move.
+    const placement = resolveToolbarPlacement(input({ anchorRect: card({ left: 80 }), gap: 20 }));
+    expect(placement.left).toBe(RAIL + TOOLBAR_GAP);
+  });
+
   it("hides when the anchor element is not mounted", () => {
     // A virtualized strip unmounts its off-screen cards; the grid re-creates a
     // card's element when a move re-parents it across rows.

--- a/apps/timeline-gstudio001/lib/selection-toolbar-position.ts
+++ b/apps/timeline-gstudio001/lib/selection-toolbar-position.ts
@@ -23,6 +23,11 @@ export type ToolbarPlacementInput = Readonly<{
   /** Width of the icon rail, which is also opaque and pinned. */
   railWidth: number;
   viewport: Readonly<{ width: number; height: number }>;
+  /** Distance between the card and the toolbar. Defaults to `TOOLBAR_GAP`;
+   *  callers pass a larger one for a coarse pointer, where a toolbar that had
+   *  to flip BELOW its card would otherwise sit under the hand that just
+   *  tapped it (R11.3). */
+  gap?: number;
 }>;
 
 export type ToolbarPlacement = Readonly<{
@@ -95,17 +100,20 @@ export function anchorVisibleRatio(input: ToolbarPlacementInput): number {
  */
 export function resolveToolbarPlacement(input: ToolbarPlacementInput): ToolbarPlacement {
   const { anchorRect, toolbarSize, headerRect, railWidth, viewport } = input;
+  const gap = input.gap ?? TOOLBAR_GAP;
   if (anchorRect === null) return HIDDEN;
   if (anchorVisibleRatio(input) < ANCHOR_MIN_VISIBLE_RATIO) return HIDDEN;
 
-  const above = anchorRect.top - toolbarSize.height - TOOLBAR_GAP;
+  const above = anchorRect.top - toolbarSize.height - gap;
   const headerBottom = headerRect === null ? 0 : Math.max(0, headerRect.top + headerRect.height);
   // "Insufficient space above" is measured against the header, not the viewport
   // top: on the first grid row the header IS the ceiling, and a toolbar tucked
   // between them would be half-covered by an opaque bar.
-  const side: "above" | "below" = above >= headerBottom + TOOLBAR_GAP ? "above" : "below";
-  const top = side === "above" ? above : anchorRect.top + anchorRect.height + TOOLBAR_GAP;
+  const side: "above" | "below" = above >= headerBottom + gap ? "above" : "below";
+  const top = side === "above" ? above : anchorRect.top + anchorRect.height + gap;
 
+  // The EDGE clamps stay at the base gap: they are about not colliding with
+  // opaque chrome, which a bigger finger does not change.
   const centred = anchorRect.left + anchorRect.width / 2 - toolbarSize.width / 2;
   const left = clamp(
     centred,

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -5780,7 +5780,16 @@ test.describe("graph view E2E", () => {
         .evaluateAll((els) => els.map((el) => el.getAttribute("aria-label") ?? ""));
 
     await surface.locator('[data-node-id="alpha"]').click();
-    expect(await labels()).toEqual(["Edit", "Copy", "Cut", "Delete", "More actions"]);
+    // The mode toggle LEADS the row, with the count — both describe the
+    // selection, while everything after the divider acts on it.
+    expect(await labels()).toEqual([
+      "Add to the selection",
+      "Edit",
+      "Copy",
+      "Cut",
+      "Delete",
+      "More actions",
+    ]);
 
     await surface.locator('[data-node-id="bravo"]').click({ modifiers: ["ControlOrMeta"] });
     await surface.locator('[data-node-id="charlie"]').click({ modifiers: ["ControlOrMeta"] });
@@ -5791,6 +5800,7 @@ test.describe("graph view E2E", () => {
     // changes constantly during a multi-select — so the row would shuffle
     // under the pointer mid-gesture.
     expect(await labels()).toEqual([
+      "Add to the selection",
       "Edit",
       "Copy 3 items",
       "Cut 3 items",
@@ -5959,15 +5969,22 @@ test.describe("graph view E2E", () => {
     await expect(selectionToolbar(page)).toBeVisible();
 
     // F10 is the toolbar convention, and is free of the modifier collisions
-    // the Alt layer and the trim chords have already claimed here.
+    // the Alt layer and the trim chords have already claimed here. It lands on
+    // the FIRST control, which is the mode toggle — the ARIA toolbar pattern,
+    // and skipping a control because it is less useful to this input would be
+    // a surprise of its own.
     await page.keyboard.press("F10");
-    await expect(selectionToolbar(page).getByRole("button", { name: "Edit" })).toBeFocused();
+    await expect(
+      selectionToolbar(page).getByRole("button", { name: "Add to the selection" }),
+    ).toBeFocused();
 
-    // Arrows move WITHIN the toolbar — one tab stop, not five.
+    // Arrows move WITHIN the toolbar — one tab stop, not six.
     await page.keyboard.press("ArrowRight");
-    await expect(selectionToolbar(page).getByRole("button", { name: "Copy" })).toBeFocused();
-    await page.keyboard.press("ArrowLeft");
     await expect(selectionToolbar(page).getByRole("button", { name: "Edit" })).toBeFocused();
+    await page.keyboard.press("ArrowLeft");
+    await expect(
+      selectionToolbar(page).getByRole("button", { name: "Add to the selection" }),
+    ).toBeFocused();
 
     // Escape clears the selection and hands focus back to the card, so the
     // keyboard route does not dead-end in a toolbar that just vanished.
@@ -6126,5 +6143,168 @@ test.describe("graph view E2E", () => {
     await expect.poll(selected).toEqual(["bravo", CHILD_ID]);
     await page.keyboard.press("Shift+ArrowLeft");
     await expect.poll(selected).toEqual(["bravo"]);
+  });
+
+  // ── Touch: additive-tap mode and hit targets (§11) ────────────────────────
+  //
+  // A touchscreen has no modifier keys, so Ctrl+tap and Shift+tap — the only
+  // routes to multi-select and ranges — cannot be performed on one at all. A
+  // mode is how that capability is reached without inventing a gesture:
+  // long-press, the obvious candidate, is already this app's DRAG activation
+  // on strip cards (250ms), so it would mean two things on two surfaces.
+
+  test("multi-select mode makes plain clicks additive, no modifier held", async ({ page }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    const surface = strip(page, PROJECT_ID);
+    const toggle = page.locator("[data-multi-select-toggle]");
+
+    await surface.locator('[data-node-id="alpha"]').click();
+    await expect(toggle).toHaveAttribute("aria-pressed", "false");
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-pressed", "true");
+
+    // Plain clicks now ADD, exactly as Ctrl+click does — the same store branch,
+    // so there is one behaviour to learn rather than two.
+    await surface.locator('[data-node-id="bravo"]').click();
+    await surface.locator('[data-node-id="charlie"]').click();
+    await expect(page.locator('[data-selected="true"]')).toHaveCount(3);
+
+    // And they still toggle OFF, which is how you correct a mis-tap.
+    await surface.locator('[data-node-id="bravo"]').click();
+    await expect(page.locator('[data-selected="true"]')).toHaveCount(2);
+  });
+
+  test("turning the mode off keeps what it collected", async ({ page }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    const surface = strip(page, PROJECT_ID);
+    const toggle = page.locator("[data-multi-select-toggle]");
+
+    await surface.locator('[data-node-id="alpha"]').click();
+    await toggle.click();
+    await surface.locator('[data-node-id="bravo"]').click();
+    await expect(page.locator('[data-selected="true"]')).toHaveCount(2);
+
+    // You stop adding in order to ACT on the selection; dropping it here would
+    // throw away the work the mode exists to make possible.
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-pressed", "false");
+    await expect(page.locator('[data-selected="true"]')).toHaveCount(2);
+
+    // Back to replace-on-click.
+    await surface.locator('[data-node-id="charlie"]').click();
+    await expect(page.locator('[data-selected="true"]')).toHaveCount(1);
+  });
+
+  test("the mode cannot get stranded on with nothing to turn it off", async ({ page }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    const surface = strip(page, PROJECT_ID);
+    const toggle = page.locator("[data-multi-select-toggle]");
+
+    await surface.locator('[data-node-id="alpha"]').click();
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-pressed", "true");
+
+    // Clearing takes the toolbar with it — and the toggle is ON the toolbar.
+    // Left armed, the mode would be invisible and would silently make the next
+    // several taps additive.
+    await page.keyboard.press("Escape");
+    await expect(toggle).toHaveCount(0);
+
+    await surface.locator('[data-node-id="bravo"]').click();
+    await expect(page.locator("[data-multi-select-toggle]")).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    await surface.locator('[data-node-id="charlie"]').click();
+    await expect(page.locator('[data-selected="true"]')).toHaveCount(1);
+  });
+
+  test("the action row keeps its offsets when the mode toggle is on", async ({ page }) => {
+    // R5.1 again: the toggle sits with the COUNT, left of the divider, so
+    // turning it on must not shift a single verb.
+    await installGraphApi(page);
+    await openGraph(page);
+    const surface = strip(page, PROJECT_ID);
+    const toolbar = page.getByRole("toolbar", { name: "Selection actions" });
+    const deleteBox = async () =>
+      (await toolbar.getByRole("button", { name: "Delete" }).boundingBox())!;
+
+    await surface.locator('[data-node-id="alpha"]').click();
+    const before = await deleteBox();
+    await page.locator("[data-multi-select-toggle]").click();
+    const after = await deleteBox();
+
+    expect(Math.round(after.x - before.x)).toBe(0);
+  });
+
+  // Its own context: `hasTouch` sets maxTouchPoints, which is what makes
+  // Chromium report `pointer: coarse` — the query the sizing keys off.
+  test.describe(() => {
+    test.use({ hasTouch: true });
+
+    test("touch gets 44px hit targets on every selection control", async ({ page }) => {
+      await installGraphApi(page);
+      await openGraph(page);
+      const surface = strip(page, PROJECT_ID);
+
+      // The premise, asserted first: without it the size checks below would
+      // pass or fail for reasons that have nothing to do with the CSS.
+      expect(await page.evaluate(() => window.matchMedia("(pointer: coarse)").matches)).toBe(
+        true,
+      );
+
+      await surface.locator('[data-node-id="alpha"]').click();
+      const toolbar = page.getByRole("toolbar", { name: "Selection actions" });
+      await expect(toolbar).toBeVisible();
+
+      // Every control in the toolbar, plus the header's fallback cluster —
+      // which is where a touch user is steered when the anchor scrolls away,
+      // so it cannot be the one surface with 32px targets.
+      const boxes = await toolbar
+        .getByRole("button")
+        .evaluateAll((els) =>
+          els.map((el) => {
+            const r = el.getBoundingClientRect();
+            return { w: Math.round(r.width), h: Math.round(r.height) };
+          }),
+        );
+      expect(boxes.length).toBeGreaterThan(4);
+      for (const box of boxes) {
+        expect(box.w, JSON.stringify(box)).toBeGreaterThanOrEqual(44);
+        expect(box.h, JSON.stringify(box)).toBeGreaterThanOrEqual(44);
+      }
+
+      const clear = (await page.locator("[data-clear-selection]").boundingBox())!;
+      expect(Math.round(clear.width)).toBeGreaterThanOrEqual(44);
+      expect(Math.round(clear.height)).toBeGreaterThanOrEqual(44);
+    });
+
+    test("a tap selects, and the toolbar comes with it", async ({ page }) => {
+      // R11.1 is deliberately NOT implemented: the spec wanted a ~500ms
+      // long-press to summon the toolbar, and long-press is already this
+      // app's drag activation on strip cards (250ms), so the gesture would
+      // mean two different things on two surfaces. A tap shows the toolbar
+      // and a second tap dismisses it, which is the same affordance without a
+      // hidden gesture — and `clickSelection: "toggle"` already gave us the
+      // dismissal for free.
+      await installGraphApi(page);
+      await openGraph(page);
+      const alpha = strip(page, PROJECT_ID).locator('[data-node-id="alpha"]');
+
+      await alpha.tap();
+      await expect(page.getByRole("toolbar", { name: "Selection actions" })).toBeVisible();
+
+      // Two SEPARATE taps, not a double-tap. Back to back they arrive as one
+      // gesture with `detail === 2`, which the click grammar deliberately
+      // ignores — that is the rename-in-place gesture, and letting its second
+      // click through used to collapse a selection and then clear it.
+      await page.waitForTimeout(500);
+      await alpha.tap();
+      await expect(page.getByRole("toolbar", { name: "Selection actions" })).toHaveCount(0);
+    });
   });
 });

--- a/packages/ui/dnd-collections/API.md
+++ b/packages/ui/dnd-collections/API.md
@@ -596,7 +596,8 @@ views — on each commit (drop/undo/redo). It honors `prefers-reduced-motion`.
 The interaction-policy props apply to BOTH card shells (`NodeCard` and the
 `CollectionItem` primitives) through one shared click grammar: Ctrl/Cmd+click
 is always the additive selection toggle (also how open-target nodes join a
-multi-drag); Shift+click extends the selection to that card via `selectRange`
+multi-drag) — as is a plain click while `multiSelectMode` is on, which is the
+only route to that gesture on a touchscreen; Shift+click extends the selection to that card via `selectRange`
 (checked BEFORE the open branch, so shift-clicking a collection extends rather
 than drilling in — losing a range to an accidental navigation is the worse
 outcome); a plain pointer click opens (when configured) or selects (per
@@ -708,7 +709,8 @@ type CollectionsChange = {
 | `setSelection` | `(ids: readonly NodeId[]) => void` | No-op (no notify) when the set AND the resulting pivot are unchanged — the pivot is the last id, so `[x,y]` and `[y,x]` are different states even though the set is not. Moves `selectionPivotId` to the last id. |
 | `toggleSelected` | `(id: NodeId) => void` | Moves `selectionPivotId` to `id`, including when the toggle DESELECTS it: the pivot is where the user last acted. |
 | `selectRange` | `(toId: NodeId) => void` | Replaces the selection with the inclusive run between `selectionPivotId` and `toId`, in their shared parent's child order (direction-agnostic). **The pivot does not move** — that is what lets a shift+click overshoot be corrected by shift+clicking back. Ids under different parents (or no pivot yet) fall back to selecting `toId` alone and re-pivoting there; there is no single order spanning two collections, and inventing one would select cards between them that the user cannot see. |
-| `clearSelection` | `() => void` | No-op when already empty AND unpivoted. Clears the pivot. |
+| `setMultiSelectMode` | `(on: boolean) => void` | Additive-tap mode: while on, a plain click takes the same branch as Ctrl/Cmd+click. Exists for TOUCH, which has no modifier keys — without it multi-select and ranges are unreachable there. Turning it OFF keeps the selection. It **cannot outlive the selection**: any transition to an empty selection clears it, because its only control lives on a surface that exists while something is selected, and an armed invisible mode silently makes the next taps additive. |
+| `clearSelection` | `() => void` | No-op when already empty, unpivoted AND unmoded. Clears the pivot and the mode. |
 | `beginDrag` | `(pressedId: NodeId) => void` | Drag set = the selection if it contains `pressedId` (pressed id first — it's the overlay primary), else just `pressedId`. Sets `isDragging`. |
 | `beginPaletteDrag` | `() => void` | Marks a palette drag live (`isDragging` without `activeIds`). Ends via `endDrag`. |
 | `setDropIntent` | `(intent: DropIntent \| null) => void` | Deduplicates equal intents; computes `dropIntentInvalid` once per change. Non-null intents are IGNORED while no drag is live (`isDragging` false) — a dnd-kit gesture can outlive the store's drag state (`replaceGraph` mid-drag, failed palette factory) and must not repaint indicators. `null` always clears. |
@@ -749,6 +751,7 @@ type CollectionsInteraction = {
   dropIntentInvalid: boolean;          // would that preview be a cycle rejection
   selectedIds: ReadonlySet<NodeId>;
   selectionPivotId: NodeId | null;     // where a RANGE extends from (see selectRange)
+  multiSelectMode: boolean;            // plain clicks are additive (touch has no Ctrl)
   rejectedIdSet: ReadonlySet<NodeId>;  // cards currently flashing a rejection
 };
 ```

--- a/packages/ui/dnd-collections/react/collections-store.test.ts
+++ b/packages/ui/dnd-collections/react/collections-store.test.ts
@@ -926,4 +926,84 @@ describe("createCollectionsStore", () => {
     store.selectRange(id("z"));
     expect(listener).not.toHaveBeenCalled();
   });
+
+  // ── Additive-tap mode ─────────────────────────────────────────────────────
+  //
+  // Touch has no modifier keys, so this mode is the ONLY route to multi-select
+  // and ranges on a touchscreen. Its danger is being armed with nothing on
+  // screen to disarm it, which is what these pin.
+
+  test("the mode makes a plain selection additive, exactly as Ctrl would", () => {
+    const store = createCollectionsStore(graphFixture());
+    store.setSelection([id("x")]);
+    store.setMultiSelectMode(true);
+
+    // Same branch as the modifier: toggleSelected, not setSelection.
+    store.toggleSelected(id("y"));
+    expect(new Set(selected(store))).toEqual(new Set([id("x"), id("y")]));
+  });
+
+  test("turning the mode off keeps the selection", () => {
+    // You stop adding in order to ACT on what you have; dropping the selection
+    // here would throw away the work the mode exists to make possible.
+    const store = createCollectionsStore(graphFixture());
+    store.setSelection([id("x")]);
+    store.setMultiSelectMode(true);
+    store.toggleSelected(id("y"));
+    store.setMultiSelectMode(false);
+
+    expect(new Set(selected(store))).toEqual(new Set([id("x"), id("y")]));
+    expect(store.getSnapshot().interaction.multiSelectMode).toBe(false);
+  });
+
+  test("the mode cannot outlive the selection, however the selection ends", () => {
+    // Its only control lives on a surface that exists while something is
+    // selected. Armed with an empty selection it is unreachable — on, invisible
+    // and quietly making the next taps additive. All four exits are checked
+    // because they take different paths through the store.
+    const store = createCollectionsStore(graphFixture());
+    const armed = () => {
+      store.setSelection([id("x")]);
+      store.setMultiSelectMode(true);
+      expect(store.getSnapshot().interaction.multiSelectMode).toBe(true);
+    };
+
+    armed();
+    store.clearSelection();
+    expect(store.getSnapshot().interaction.multiSelectMode).toBe(false);
+
+    armed();
+    store.toggleSelected(id("x")); // toggled the last one off
+    expect(store.getSnapshot().interaction.multiSelectMode).toBe(false);
+
+    armed();
+    store.setSelection([]);
+    expect(store.getSnapshot().interaction.multiSelectMode).toBe(false);
+
+    // And the one that does not go through setInteraction at all: pruning,
+    // after the selected node leaves the graph.
+    armed();
+    store.replaceGraph(
+      (() => {
+        const built = buildGraph([
+          { kind: "collection", id: "root-a", name: "A", children: [media("y")] },
+        ]);
+        if (!built.ok) throw new Error(JSON.stringify(built.error));
+        return built.value;
+      })(),
+    );
+    expect(selected(store)).toEqual([]);
+    expect(store.getSnapshot().interaction.multiSelectMode).toBe(false);
+  });
+
+  test("setting the mode to its current value does not notify", () => {
+    const store = createCollectionsStore(graphFixture());
+    store.setSelection([id("x")]);
+    store.setMultiSelectMode(true);
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    store.setMultiSelectMode(true);
+    expect(listener).not.toHaveBeenCalled();
+  });
 });

--- a/packages/ui/dnd-collections/react/collections-store.ts
+++ b/packages/ui/dnd-collections/react/collections-store.ts
@@ -57,6 +57,22 @@ export type CollectionsInteraction = Readonly<{
    * to the clicked card, which selects just that card.
    */
   selectionPivotId: NodeId | null;
+  /**
+   * While true, a PLAIN click is additive — exactly as if Ctrl/Cmd were held.
+   *
+   * This exists for TOUCH, which has no modifier keys at all: without it,
+   * multi-select and ranges are simply unreachable on a touchscreen. A mode is
+   * the compromise. Long-press would have been the obvious gesture and is
+   * already spent — a still press on a card marked `data-drag-activation="hold"`
+   * starts a DRAG at 250ms (see `pointer-sensors.ts`), so a long-press to
+   * multi-select would mean two different things on two surfaces.
+   *
+   * Not a policy prop: the policy is provider CONFIG, memoized on its fields,
+   * so toggling it there would invalidate the context and re-render every card
+   * that reads it. Here it rides the interaction slice the click handler
+   * already consults.
+   */
+  multiSelectMode: boolean;
   /** Ids briefly flashing a rejected-drop cue, as a Set for membership checks. */
   rejectedIdSet: ReadonlySet<NodeId>;
 }>;
@@ -236,6 +252,9 @@ export type CollectionsStore = Readonly<{
    * same thing a plain click would have done.
    */
   selectRange: (toId: NodeId) => void;
+  /** Turn additive-tap mode on or off. Turning it OFF keeps the selection —
+   *  you stop adding in order to act on what you have. */
+  setMultiSelectMode: (on: boolean) => void;
   clearSelection: () => void;
 
   /** Computes the drag set: the selection if the pressed node is in it, else just the pressed node. */
@@ -277,6 +296,7 @@ export function createCollectionsStore(
     dropIntentInvalid: false,
     selectedIds: EMPTY_SELECTION,
     selectionPivotId: null,
+    multiSelectMode: false,
     rejectedIdSet: EMPTY_SELECTION,
   };
   const history = createHistory({ maxEntries: options?.maxHistoryEntries });
@@ -368,6 +388,15 @@ export function createCollectionsStore(
 
   function setInteraction(next: Partial<CollectionsInteraction>) {
     interaction = { ...interaction, ...next };
+    // ONE invariant, enforced centrally rather than at each of the four places
+    // a selection can empty (clear, a toggle that removes the last item,
+    // setSelection([]), and pruning after a delete): additive-tap mode cannot
+    // outlive the selection. Its only control lives on a surface that exists
+    // while something is selected, so an armed mode with an empty selection is
+    // unreachable — on, invisible, and quietly making the next taps additive.
+    if (interaction.multiSelectMode && interaction.selectedIds.size === 0) {
+      interaction = { ...interaction, multiSelectMode: false };
+    }
     notify();
   }
 
@@ -392,6 +421,13 @@ export function createCollectionsStore(
     const pivot = interaction.selectionPivotId;
     if (pivot !== null && !graph.nodesById.has(pivot)) {
       interaction = { ...interaction, selectionPivotId: null };
+    }
+    // This path writes `interaction` directly rather than through
+    // `setInteraction`, so it repeats that function's mode invariant. Deleting
+    // the last selected card is the ordinary way to arrive here with an armed
+    // mode and nothing left to show its control.
+    if (interaction.multiSelectMode && interaction.selectedIds.size === 0) {
+      interaction = { ...interaction, multiSelectMode: false };
     }
   }
 
@@ -499,6 +535,7 @@ export function createCollectionsStore(
       dropIntentInvalid: false,
       selectedIds: interaction.selectedIds,
       selectionPivotId: interaction.selectionPivotId,
+      multiSelectMode: interaction.multiSelectMode,
       rejectedIdSet: EMPTY_SELECTION,
     };
     pruneMissingSelection();
@@ -594,8 +631,19 @@ export function createCollectionsStore(
       if (sameSet(interaction.selectedIds, next)) return;
       setInteraction({ selectedIds: next });
     },
+    setMultiSelectMode: (on) => {
+      if (interaction.multiSelectMode === on) return;
+      setInteraction({ multiSelectMode: on });
+    },
     clearSelection: () => {
-      if (interaction.selectedIds.size === 0 && interaction.selectionPivotId === null) return;
+      if (
+        interaction.selectedIds.size === 0 &&
+        interaction.selectionPivotId === null &&
+        !interaction.multiSelectMode
+      ) {
+        return;
+      }
+      // `setInteraction` drops the mode with it (see the invariant there).
       setInteraction({ selectedIds: EMPTY_SELECTION, selectionPivotId: null });
     },
 

--- a/packages/ui/dnd-collections/react/interaction-policy.ts
+++ b/packages/ui/dnd-collections/react/interaction-policy.ts
@@ -110,7 +110,11 @@ export function handleSelectionSurfaceClick(args: {
   // both fall through.
   if (event.detail > 1) return;
 
-  if (event.ctrlKey || event.metaKey) {
+  // Additive-tap MODE is the same branch as the modifier, deliberately: a
+  // touchscreen has no Ctrl to hold, so the mode is how that gesture is
+  // reached at all, and it must behave identically or it becomes a second
+  // thing to learn rather than a way in to the first.
+  if (event.ctrlKey || event.metaKey || store.getSnapshot().interaction.multiSelectMode) {
     store.toggleSelected(id);
     return;
   }


### PR DESCRIPTION
Three parts, one of which is a deliberate non-implementation.

## The gap the spec didn't notice

**A touchscreen has no modifier keys.** Ctrl+tap and Shift+tap — the only routes to multi-select and the ranges phase 2 just shipped — cannot be performed on one at all. §11 worried about hit-target size and never mentioned this.

A toolbar toggle makes plain taps additive until you turn it off. It takes the **same store branch** as the modifier, so there's one behaviour to learn rather than two, and it lives in the interaction slice rather than the policy props — the policy is provider config memoized on its fields, so toggling it there would invalidate the context and re-render every card that reads it.

### It cannot outlive the selection

Enforced centrally in `setInteraction`, and repeated in `pruneMissingSelection` because that one writes `interaction` directly. The toggle's only home is a surface that exists *while something is selected*, so an armed mode with an empty selection is unreachable: on, invisible, and quietly making the next several taps additive. All four exits are covered — clear, toggling the last item off, `setSelection([])`, and pruning after a delete.

The toggle sits with the **count**, left of the divider: both describe the selection while the verbs act on it. Keeping it out of that run is what lets R5.1 keep holding, and an e2e asserts Delete doesn't move a pixel when the mode comes on.

## R11.2 — 44×44 on touch

For the toolbar **and** the header's fallback cluster, which is where a touch user gets steered when the anchor scrolls away — it can't be the one surface still at 32px.

Keyed off `pointer: coarse` rather than a viewport width: the question is what's doing the pointing, not how big the screen is, so a touchscreen laptop gets the bigger target at desktop width. Proven under `hasTouch`, with the media query itself asserted first so the size checks can't pass for the wrong reason.

## R11.3 — a bigger gap on touch

So a toolbar that had to flip *below* its card clears the hand that just tapped it. The edge clamps stay at the base gap — those are about not colliding with opaque chrome, which a bigger fingertip doesn't move.

## R11.1 is dropped, on purpose

The spec wanted a ~500ms long-press to summon the toolbar. **Long-press is already this app's drag activation** on strip cards — 250ms, in `pointer-sensors.ts` — so the drag fires first, and implementing it would make one gesture mean two different things on two surfaces.

A tap shows the toolbar and a second tap dismisses it (`clickSelection: "toggle"` gave us the dismissal for free), which is the same affordance without a hidden gesture. There's an e2e carrying the reasoning so it doesn't get "fixed" later.

## Verification

Three claims proven to **fail** against pre-change behaviour:

| Claim | Reverted to | Result |
|---|---|---|
| Mode makes plain clicks additive | mode ignored in click grammar | fails |
| Mode can't get stranded on | invariant removed | fails |
| 44px targets under touch | single size | fails |

| | |
|---|---|
| graph-view e2e | 126 passed (6 new) |
| Unit | 446 passed (4 new) |
| Storybook | 168 passed |
| App vitest | 553 passed |
| Typecheck | clean, both workspaces |
| Lint | 0 errors |

Also driven by hand: toggled the mode on and took a 3-card selection with plain clicks, no modifier held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)