### PR TITLE
Header: save status beside the crumb, zoom slider out of the menu

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -125,17 +125,11 @@ export type { FocusSurface, ItemSize };
  * and the menu itself knows nothing about sizing.
  */
 function BoardMenu({
-  surface,
   itemSize,
   onItemSizeChange,
-  pixelsPerSecond,
-  onPixelsPerSecondChange,
 }: Readonly<{
-  surface: FocusSurface;
   itemSize: ItemSize;
   onItemSizeChange: (size: ItemSize) => void;
-  pixelsPerSecond: number;
-  onPixelsPerSecondChange: (pixelsPerSecond: number) => void;
 }>) {
   return (
     <DropdownMenu>
@@ -176,20 +170,9 @@ function BoardMenu({
             ))}
           </DropdownMenuRadioGroup>
         </DropdownMenuGroup>
-        {/* Zoom is a strip-only axis: grid cells are sized by thumbnail size
-            and the grid playhead ignores clip width, so the control is a
-            no-op there. Omitted rather than shown disabled — same rule the
-            header used when it hosted the slider, and a settings row that
-            can never do anything is worse than one that isn't offered. */}
-        {surface === "strip" ? (
-          <>
-            <DropdownMenuSeparator className="-mx-2 my-2.5" />
-            <ZoomMenuItem
-              pixelsPerSecond={pixelsPerSecond}
-              onChange={onPixelsPerSecondChange}
-            />
-          </>
-        ) : null}
+        {/* Zoom used to be a row here. It is a real slider in the header's
+            view group now (see HeaderZoomControl) — this menu keeps the
+            settings you set once, not the axis you ride while reading. */}
         {/* LAST, and fenced off: everything above changes this board, while
             this one leaves it alone and opens a reference sheet. Sections that
             act and sections that explain do not belong in the same run. */}
@@ -229,11 +212,8 @@ function BoardMenu({
  * asserts it actually lands there, because a null slot would fail silently.
  */
 function BoardMenuSlot(props: Readonly<{
-  surface: FocusSurface;
   itemSize: ItemSize;
   onItemSizeChange: (size: ItemSize) => void;
-  pixelsPerSecond: number;
-  onPixelsPerSecondChange: (pixelsPerSecond: number) => void;
 }>) {
   const [slot] = useState<HTMLElement | null>(() =>
     typeof document === "undefined"
@@ -296,39 +276,27 @@ function FocusedAggregate({
   );
 }
 
-/** One arrow press. Coarse enough to cross the range in a sensible number of
- *  presses, fine enough to land where you meant. */
-const ZOOM_KEY_STEP = 4;
-
 /**
- * Horizontal zoom, as a labelled row of the board menu.
+ * Horizontal zoom, as a real slider in the header's view group.
  *
- * It used to sit bare in the header, and the comment here argued it had to: an
- * exploration tool reached WHILE reading the strip, where a menu would cost a
- * click per adjustment. That was the old call; the menu is where it lives now.
- * The trade is real and worth naming rather than pretending away — a zoom
- * sweep is open-menu-then-drag — but the header buys back the width, and the
- * control gains a visible name, a readable value, and units.
+ * It spent a while as a MENU ROW, and the comment there argued the shape was
+ * forced: a `role="menu"` moves its roving focus between `menuitem`s and
+ * nothing else, so a `<Slider>` dropped inside one is unreachable by keyboard —
+ * measured at the time, not assumed. That constraint belonged to the menu, and
+ * it leaves with it. Out here the slider is an ordinary focusable control: Tab
+ * reaches the thumb, arrows move it, and Radix supplies Home/End. None of the
+ * key handling this needed as a menu row survives, because none of it was about
+ * zoom.
  *
- * WHY THE ROW IS THE CONTROL, and not a `<Slider>` a keyboard user focuses.
+ * What the move buys back is the thing the menu cost: an exploration tool read
+ * WHILE watching the strip, where open-menu-then-drag charged a click per
+ * adjustment. It is a drag on a visible slider again.
  *
- * A `role="menu"` navigates between menu ITEMS. Radix implements exactly that:
- * its roving focus walks `menuitem`/`menuitemradio` and nothing else. A slider
- * dropped in as a child is therefore unreachable by arrow keys — measured, not
- * assumed: focus went straight from the last size badge to "Keyboard
- * shortcuts", skipping the thumb. It was also invalid composition, since a
- * `slider` is not something a menu may contain.
- *
- * So the MENU ITEM owns the value: Left/Right adjust it, and its accessible
- * name carries the current reading. The `<Slider>` beneath is the pointer
- * affordance and the visual — `aria-hidden`, with its thumb out of the tab
- * order so nothing focusable hides inside a hidden subtree.
- *
- * Up/Down are deliberately NOT claimed: they keep moving through the menu, so
- * the horizontal keys drive the horizontal control and the vertical keys drive
- * the vertical list. Nothing to learn.
+ * STRIP ONLY. Grid cells are sized by thumbnail size and the grid playhead
+ * ignores clip width, so the control is a no-op there — omitted rather than
+ * disabled, the same call the menu made.
  */
-function ZoomMenuItem({
+function HeaderZoomControl({
   pixelsPerSecond,
   onChange,
 }: Readonly<{
@@ -336,59 +304,41 @@ function ZoomMenuItem({
   onChange: (pixelsPerSecond: number) => void;
 }>) {
   const value = Math.round(pixelsPerSecond);
-  const stepBy = (delta: number) =>
-    onChange(Math.min(MAX_TIMELINE_PPS, Math.max(MIN_TIMELINE_PPS, value + delta)));
-
   return (
-    <DropdownMenuItem
-      data-board-menu-zoom
-      // Selecting must not close the menu: this row is a control you stay on,
-      // not a command you fire.
-      onSelect={(event) => event.preventDefault()}
-      onKeyDown={(event) => {
-        if (event.key === "ArrowRight") stepBy(ZOOM_KEY_STEP);
-        else if (event.key === "ArrowLeft") stepBy(-ZOOM_KEY_STEP);
-        else if (event.key === "Home") onChange(MIN_TIMELINE_PPS);
-        else if (event.key === "End") onChange(MAX_TIMELINE_PPS);
-        else return;
-        // Claimed — the menu must not also act on it.
-        event.preventDefault();
-        event.stopPropagation();
-      }}
-      // The whole reading, in the name: what it is, where it stands, and how
-      // to move it. A menu item announcing only "Timeline zoom" would leave a
-      // screen-reader user with no idea the arrows do anything here.
-      aria-label={`Timeline zoom, ${value} pixels per second. Left and right arrow keys adjust.`}
-      aria-keyshortcuts="ArrowLeft ArrowRight"
-      className="flex-col items-stretch gap-1.5 py-2 focus:bg-zinc-900"
+    <span
+      data-header-zoom
+      // Marks the whole control as non-background for the package's
+      // click-to-clear: the slider's role lives on its thumb, but the surface
+      // you click to jump the value is the track beside it, which would
+      // otherwise read as empty board and drop the selection.
+      data-collections-control
+      className="flex shrink-0 items-center gap-2"
     >
-      <span aria-hidden="true" className="flex items-baseline justify-between gap-3">
-        <span className="text-[10px] font-semibold uppercase tracking-[0.14em] text-zinc-500">
-          Timeline zoom
-        </span>
-        <span
-          data-board-menu-zoom-value
-          className="font-mono text-[11px] tabular-nums text-zinc-400"
-        >
-          {value} px/s
-        </span>
+      <Slider
+        // The name and the READING both go to the thumb, which is where Radix
+        // puts `role="slider"` (see components/core/slider). A bare number on
+        // an axis like pixels-per-second announces nothing on its own.
+        aria-label="Timeline zoom"
+        aria-valuetext={`${value} pixels per second`}
+        min={MIN_TIMELINE_PPS}
+        max={MAX_TIMELINE_PPS}
+        step={1}
+        value={[value]}
+        onValueChange={([next]) => {
+          if (typeof next === "number") onChange(next);
+        }}
+        className="w-24"
+      />
+      {/* Fixed width and tabular figures: the readout sits in a toolbar whose
+          controls must not shuffle as the number crosses 10 or 100. */}
+      <span
+        data-header-zoom-value
+        aria-hidden="true"
+        className="w-[52px] shrink-0 font-mono text-[11px] tabular-nums text-zinc-500"
+      >
+        {value} px/s
       </span>
-      <span aria-hidden="true" className="block py-0.5">
-        <Slider
-          thumbTabIndex={-1}
-          min={MIN_TIMELINE_PPS}
-          max={MAX_TIMELINE_PPS}
-          step={1}
-          value={[value]}
-          onValueChange={([next]) => {
-            if (typeof next === "number") onChange(next);
-          }}
-        />
-      </span>
-      <span aria-hidden="true" className="text-[11px] leading-snug text-zinc-500">
-        Stretch or squeeze the strip&apos;s time scale.
-      </span>
-    </DropdownMenuItem>
+    </span>
   );
 }
 
@@ -1104,6 +1054,15 @@ export function GraphBoard({
                 label={childrenShown ? "Hide children timelines" : "Show children timelines"}
                 title="Children timelines — show the nested timeline tree"
               />
+              {/* Zoom belongs in the VIEW group: like the two toggles beside
+                  it, it qualifies what the board shows rather than changing
+                  what is in it. Strip only — see HeaderZoomControl. */}
+              {surface === "strip" ? (
+                <HeaderZoomControl
+                  pixelsPerSecond={pixelsPerSecond}
+                  onChange={onPixelsPerSecondChange}
+                />
+              ) : null}
               <div aria-hidden="true" className="h-5 w-px shrink-0 bg-zinc-700" />
               {/* Paste used to sit here, fenced between the view group and
                   history. It is in the CENTRE now, with copy and cut — the
@@ -1115,13 +1074,7 @@ export function GraphBoard({
                   sidebar below the trash (PL14-005). Still mounted from this
                   component so they keep these props; only the DOM address
                   changed. */}
-              <BoardMenuSlot
-                surface={surface}
-                itemSize={itemSize}
-                onItemSizeChange={onItemSizeChange}
-                pixelsPerSecond={pixelsPerSecond}
-                onPixelsPerSecondChange={onPixelsPerSecondChange}
-              />
+              <BoardMenuSlot itemSize={itemSize} onItemSizeChange={onItemSizeChange} />
             </DragChromeFade>
 
             {/* The trash drop target (right side), shown only while a card is

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
@@ -322,8 +322,19 @@ export function GraphBreadcrumb({
         ? projectId
         : null;
 
+  // CONTENT-WIDTH, not stretched.
+  //
+  // This and the nav below used to carry `flex-1`, which made the trail claim
+  // its whole wing however short the path was — so the save status that trails
+  // it (see GraphSaveStatus) rendered hundreds of pixels away from the last
+  // crumb, hard against the centre readout, instead of beside the crumb. The
+  // WING still has `flex-1` in the board's header, which is what keeps the
+  // centre readout centred; the trail itself only needs to be as wide as it is.
+  //
+  // `min-w-0` and `overflow-hidden` stay: they are what let a long path shrink
+  // and truncate inside the wing rather than pushing it open.
   return (
-    <div className="flex min-w-0 flex-1 items-center gap-3 overflow-hidden">
+    <div className="flex min-w-0 items-center gap-3 overflow-hidden">
       <ParentLink
         href={parentHref}
         parentId={parentCrumbId}
@@ -331,7 +342,7 @@ export function GraphBreadcrumb({
       />
       <nav
         aria-label="Timeline focus path"
-        className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden text-xs text-zinc-400 select-none"
+        className="flex min-w-0 items-center gap-2 overflow-hidden text-xs text-zinc-400 select-none"
       >
         {/* The project is the ROOT crumb, not a child of a "Projects / Graph"
             chrome path: the trail reads as the timeline tree the user is

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -4945,8 +4945,18 @@ test.describe("graph view E2E", () => {
     await expect(alpha).not.toHaveAttribute("data-selected", "true");
 
     // The breadcrumb row's own empty space — chrome, but not a control.
-    const headerBox = (await header.boundingBox())!;
-    await page.mouse.click(headerBox.x + headerBox.width - 4, headerBox.y + headerBox.height / 2);
+    //
+    // Measured from the WING rather than from the nav. The nav used to stretch
+    // across its whole column, so "just inside its right edge" was empty space;
+    // it is content-width now (so the save status can sit beside the last
+    // crumb), which put that same point on the crumb button itself — a control,
+    // and correctly not a click-away. The empty chrome is now the wing's
+    // trailing end, past both the trail and the status.
+    const wingBox = (await page
+      .locator('[data-graph-board-header] > div')
+      .filter({ has: header })
+      .boundingBox())!;
+    await page.mouse.click(wingBox.x + wingBox.width - 8, wingBox.y + wingBox.height / 2);
     await expect(bravo).not.toHaveAttribute("data-selected", "true");
 
     // And well outside any surface: the page margin below the board.
@@ -6858,14 +6868,29 @@ test.describe("graph view E2E", () => {
     await surface.locator('[data-node-id="alpha"]').click();
     await expect(anchorMenuButton(page)).toBeVisible();
 
-    // Board options → zoom to the minimum.
-    await page.evaluate(() => {
-      const input = document.querySelector<HTMLInputElement>("[data-graph-zoom-input]");
-      if (input) {
-        input.value = "6";
-        input.dispatchEvent(new Event("input", { bubbles: true }));
-      }
-    });
+    // Zoom to the minimum with the header's slider — Home is the standard
+    // slider binding and Radix implements it.
+    //
+    // This used to poke a `[data-graph-zoom-input]` that has never existed in
+    // the source, behind an `if (input)` guard that swallowed the miss. The
+    // test passed without ever zooming, so its premise — a clip too narrow to
+    // host a control — was never actually set up. The assertion below is
+    // deliberately width-agnostic, which is why that went unnoticed.
+    const zoom = page.locator("[data-header-zoom] [role=\"slider\"]");
+    await expect(zoom).toBeVisible();
+    // Dragged to the left end with the POINTER, which is how this control is
+    // actually used and what the move out of the menu was for. Keyboard Home
+    // is Radix's to implement and is not what this test is about.
+    const track = (await page.locator("[data-header-zoom]").boundingBox())!;
+    await page.mouse.click(track.x + 1, track.y + track.height / 2);
+    // NEAR the floor, not exactly on it: the thumb has width, so a click at the
+    // track's left edge lands a step or two in. What the test needs is "zoomed
+    // right out", and the bound is expressed against the slider's OWN
+    // `aria-valuemin` so it cannot drift from the constant.
+    const zoomMin = Number(await zoom.getAttribute("aria-valuemin"));
+    await expect
+      .poll(async () => Number(await zoom.getAttribute("aria-valuenow")))
+      .toBeLessThanOrEqual(zoomMin + 4);
 
     // Whether the ⋮ survives depends on the clip's duration at that zoom;
     // what must hold either way is that the actions are reachable.

--- a/packages/ui/dnd-collections/react/use-background-clear.ts
+++ b/packages/ui/dnd-collections/react/use-background-clear.ts
@@ -51,6 +51,16 @@ const NON_BACKGROUND_SELECTOR = [
   // click lands. Clearing there would dismiss the toolbar out from under the
   // click that was aimed at it.
   "[role='toolbar']",
+  // The explicit opt-out, for a COMPOSITE control whose hit area is not the
+  // node carrying the role.
+  //
+  // A slider is the case that forced it: the role sits on the thumb, while the
+  // surface you click to jump the value is the TRACK — a sibling. `closest()`
+  // walks ancestors, so a click on the track matches nothing above and reads as
+  // background, and the selection is cleared by a press aimed squarely at a
+  // control. Marking the control's own wrapper is the general answer, and
+  // cheaper than teaching this list every composite widget's internals.
+  "[data-collections-control]",
 ].join(", ");
 
 /**


### PR DESCRIPTION
Two placement changes, and the two bugs they exposed.

## Save status

It already trailed the breadcrumb in the DOM, but the trail and its `nav` both carried `flex-1`, so they claimed the whole wing however short the path was — the status rendered ~480px past the last crumb, hard against the centre readout. The trail is content-width now; the **wing** keeps its `flex-1` (that's what centres the readout), so the status sits 12px after the last crumb, the row's own gap.

## Zoom

Out of the board-settings menu and into the header's view group, beside the ruler and children toggles — it qualifies what the board *shows*, like they do. Strip only, as before.

The menu row existed for a real reason: a `role="menu"` moves roving focus between `menuitem`s and nothing else, so a `<Slider>` dropped inside one is unreachable by keyboard. That constraint belonged to the menu and leaves with it — out here the thumb is an ordinary tab stop with Radix's arrows and Home/End, and the bespoke key handling the row needed is gone. It also buys back what the menu cost: an axis you ride while watching the strip, instead of one charging a click per adjustment.

`BoardMenu` no longer takes `surface`, `pixelsPerSecond` or `onPixelsPerSecondChange`.

## Two bugs surfaced by the moves

**Clicking the slider's track cleared the selection.** The package's background-clear matches `[role='slider']`, but Radix puts that role on the *thumb* while the surface you click to jump the value is a sibling *track* — `closest()` found nothing above it, so the press read as empty board. Adds `[data-collections-control]` to the package's non-background list (a general opt-out for a composite control whose hit area is not the node carrying the role) and marks the zoom wrapper. Verified load-bearing: removing it fails the test.

**A test that never tested anything.** The e2e step meant to zoom out poked a `[data-graph-zoom-input]` that has never existed in this codebase, behind an `if (input)` guard that swallowed the miss. `a card too narrow for a ⋮ still has the header overflow` has been passing without ever zooming, so its premise — a clip too narrow to host a control — was never set up. It drives the real slider now, and that is how the track bug above was found.

`clicking away anywhere that is not a control` also needed its target moved: it clicked just inside the nav's right edge, which was empty *only* because the nav was stretched. It measures from the wing now.

## Verification

142 e2e · 545 app vitest · 624 storybook · `packages/ui` typecheck · lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
