### PR TITLE
Import the graph engine from collections-core in the MCP route

### DIFF
--- a/apps/timeline-gstudio001/lib/mcp/apply-command.ts
+++ b/apps/timeline-gstudio001/lib/mcp/apply-command.ts
@@ -3,7 +3,7 @@ import {
   type CollectionsCommand,
   type CollectionsGraph,
   type CommandRejection,
-} from "@storyboard/ui/dnd-collections";
+} from "@storyboard/collections-core";
 import {
   buildFocusedGraph,
   collectAffectedCollectionIds,

--- a/apps/timeline-gstudio001/lib/mcp/create-collection.ts
+++ b/apps/timeline-gstudio001/lib/mcp/create-collection.ts
@@ -1,4 +1,4 @@
-import { parseNodeId, type CollectionsGraph, type NodeId } from "@storyboard/ui/dnd-collections";
+import { parseNodeId, type CollectionsGraph, type NodeId } from "@storyboard/collections-core";
 import type { TimelineDocument } from "@storyboard/timeline-model/types";
 
 import { resolveMovePlacement } from "@/lib/webmcp/placement";

--- a/apps/timeline-gstudio001/lib/mcp/upload.ts
+++ b/apps/timeline-gstudio001/lib/mcp/upload.ts
@@ -1,4 +1,4 @@
-import { parseNodeId, type CollectionsGraph, type NodeId } from "@storyboard/ui/dnd-collections";
+import { parseNodeId, type CollectionsGraph, type NodeId } from "@storyboard/collections-core";
 
 import { CLOUDINARY_PROVIDER_ID } from "@/lib/assets/cloudinary-provider";
 import {

--- a/apps/timeline-gstudio001/lib/mcp/write-handlers.ts
+++ b/apps/timeline-gstudio001/lib/mcp/write-handlers.ts
@@ -4,7 +4,7 @@ import {
   parseNodeId,
   type CollectionsGraph,
   type NodeId,
-} from "@storyboard/ui/dnd-collections";
+} from "@storyboard/collections-core";
 
 import { describeDispatchRejection, toolError, toolOk } from "@/lib/webmcp/results";
 import { resolveMovePlacement, type PlacementError } from "@/lib/webmcp/placement";

--- a/apps/timeline-gstudio001/lib/webmcp/placement.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/placement.ts
@@ -1,4 +1,4 @@
-import { getChildren, type CollectionsGraph, type NodeId } from "@storyboard/ui/dnd-collections";
+import { getChildren, type CollectionsGraph, type NodeId } from "@storyboard/collections-core";
 
 // Pure placement math for move_clip: turn a SEMANTIC anchor (before/after a
 // sibling, or start/end of a collection) into the reducer's `toIndex`. The


### PR DESCRIPTION
The production deploy has been failing since #270 — the remote MCP write tools are merged but were never live, which is why the tool list still showed only the three read tools.

`app/api/mcp/route.ts` → `lib/mcp/*` imported `applyCommand`, `parseNodeId` and `getChildren` from the `@storyboard/ui/dnd-collections` barrel, which also exports the React bindings. Next refuses to compile a server route whose import graph reaches `useEffect`/`useRef` without `"use client"`:

```
../../packages/ui/dnd-collections/react/use-background-clear.ts
Error: You're importing a component that needs `useEffect`...

Import trace for requested module:
  ../../packages/ui/dnd-collections/index.ts
  ./lib/mcp/create-collection.ts
  ./app/api/mcp/route.ts
```

Every symbol is already exported by `@storyboard/collections-core` (already an app dependency, framework-free by design), so the five value imports move there — same code, taken at the height the server should have been importing it from. `lib/webmcp/placement.ts` moves too: it is a value import reached from the same route. Type-only barrel imports elsewhere are erased before the boundary check and are left alone.

**Why nothing caught it:** `tsc`, `npm run lint` and vitest all resolve the barrel happily — the RSC client-boundary check only exists inside `next build`, and CI never builds. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
