### PR TITLE
Fix MCP clip trims collapsing attached videos to zero duration

### DIFF
--- a/apps/timeline-gstudio001/app/api/mcp/route.ts
+++ b/apps/timeline-gstudio001/app/api/mcp/route.ts
@@ -220,13 +220,13 @@ const handler = createMcpHandler(
 
     server.tool(
       "trim_clip",
-      "Change how much of a clip plays. Videos take `trimInSeconds`/`trimOutSeconds` (offsets into the source); images take `durationSeconds`." +
+      "Change how much of a clip plays. Videos take `trimInSeconds`/`trimOutSeconds` (seconds REMOVED from each end — an untrimmed clip is 0/0); images take `durationSeconds`." +
         NO_LIVE_PUSH_NOTE,
       {
         timelineId: z.string().min(1).describe("The timeline document that contains the clip."),
         nodeId: z.string().min(1).describe("The clip to trim."),
-        trimInSeconds: z.number().min(0).optional().describe("Video only: seconds into the source where it starts."),
-        trimOutSeconds: z.number().min(0).optional().describe("Video only: seconds into the source where it ends."),
+        trimInSeconds: z.number().min(0).optional().describe("Video only: seconds removed from the START. 0 keeps the opening."),
+        trimOutSeconds: z.number().min(0).optional().describe("Video only: seconds removed from the END. 0 keeps the ending."),
         durationSeconds: z.number().positive().optional().describe("Image only: how long it stays on screen."),
       },
       async (args, extra) => {

--- a/apps/timeline-gstudio001/lib/mcp/upload.test.ts
+++ b/apps/timeline-gstudio001/lib/mcp/upload.test.ts
@@ -163,6 +163,47 @@ describe("attachMedia", () => {
     expect(added.sourceDuration).toBe(12);
   });
 
+  // Trims are AMOUNTS REMOVED from each end (`mediaDurationSeconds` computes
+  // `full - trimIn - trimOut`), so an untrimmed clip is 0/0. Passing the play
+  // length through as `trimOutSeconds` trimmed the entire clip away: the clip
+  // packed at zero width and had to be dragged back out by hand. The test above
+  // only checked `sourceDuration`, which stayed correct throughout — `duration`
+  // is the field that collapsed, so assert it here.
+  it("attaches a video at its full length, not zero", async () => {
+    seed(PROJECT, []);
+
+    await attachMedia(
+      { timelineId: PROJECT, projectId: PROJECT, publicId: "media/user-a/project-alpha/render-123" },
+      OWNER,
+    );
+
+    const added = storedClips(PROJECT)[0];
+    if (added.kind !== "video") throw new Error("expected a video clip");
+    expect(added.trimIn).toBe(0);
+    expect(added.trimOut).toBe(0);
+    expect(added.duration).toBe(12);
+  });
+
+  it("honours durationSeconds by trimming the tail, leaving the rest playable", async () => {
+    seed(PROJECT, []);
+
+    await attachMedia(
+      {
+        timelineId: PROJECT,
+        projectId: PROJECT,
+        publicId: "media/user-a/project-alpha/render-123",
+        durationSeconds: 5,
+      },
+      OWNER,
+    );
+
+    const added = storedClips(PROJECT)[0];
+    if (added.kind !== "video") throw new Error("expected a video clip");
+    expect(added.duration).toBe(5);
+    expect(added.trimIn).toBe(0);
+    expect(added.trimOut).toBe(7);
+  });
+
   it("places it after a named sibling rather than always appending", async () => {
     seed(PROJECT, [clip("a"), clip("b")]);
 

--- a/apps/timeline-gstudio001/lib/mcp/upload.ts
+++ b/apps/timeline-gstudio001/lib/mcp/upload.ts
@@ -146,7 +146,15 @@ export async function attachMedia(
                   src: asset.url,
                   fullDurationSeconds: sourceSeconds,
                   trimInSeconds: 0,
-                  trimOutSeconds: Math.min(args.durationSeconds ?? sourceSeconds, sourceSeconds),
+                  // Trims are AMOUNTS REMOVED from each end, not offsets into
+                  // the source — `mediaDurationSeconds` computes
+                  // `full - trimIn - trimOut`, so an untrimmed clip is 0/0.
+                  // Passing the play length straight through as `trimOutSeconds`
+                  // trimmed the whole clip away and packed it at zero width.
+                  trimOutSeconds: Math.max(
+                    0,
+                    sourceSeconds - Math.min(args.durationSeconds ?? sourceSeconds, sourceSeconds),
+                  ),
                 }
               : {
                   id: newNodeId,

--- a/apps/timeline-gstudio001/lib/mcp/write-handlers.ts
+++ b/apps/timeline-gstudio001/lib/mcp/write-handlers.ts
@@ -188,16 +188,19 @@ export async function handleTrimClip(
       }
       const trimIn = args.trimInSeconds ?? node.trimInSeconds;
       const trimOut = args.trimOutSeconds ?? node.trimOutSeconds;
+      // Trims are AMOUNTS REMOVED from each end, matching
+      // `mediaDurationSeconds` (`full - trimIn - trimOut`) and what the UI
+      // writes — an untrimmed clip is 0/0, NOT 0/fullDuration.
       // Report the bounds rather than clamping — a silent clamp hides a mistake
       // in the caller's own numbers.
-      if (trimIn < 0 || trimOut > node.fullDurationSeconds) {
+      if (trimIn < 0 || trimOut < 0) {
+        return { ok: false, message: "Trims cannot be negative — they are seconds removed from each end." } as const;
+      }
+      if (!(trimIn + trimOut < node.fullDurationSeconds)) {
         return {
           ok: false,
-          message: `Trim is outside the source: this clip is ${node.fullDurationSeconds}s long, so trims must fall in 0–${node.fullDurationSeconds}.`,
+          message: `Trims remove the whole clip: this source is ${node.fullDurationSeconds}s long, so \`trimInSeconds\` + \`trimOutSeconds\` must be less than ${node.fullDurationSeconds}.`,
         } as const;
-      }
-      if (!(trimIn < trimOut)) {
-        return { ok: false, message: `\`trimInSeconds\` (${trimIn}) must be less than \`trimOutSeconds\` (${trimOut}).` } as const;
       }
       return {
         ok: true,


### PR DESCRIPTION
## What

`attach_media` minted every video with `trimOutSeconds` set to the clip's play length, treating trims as **absolute offsets into the source**. The core reads them as **amounts removed from each end** — `mediaDurationSeconds` computes `full - trimIn - trimOut` — so a full-length attach became `12 - 0 - 12 = 0`.

Found live: a 5.17s render attached via MCP landed at zero width and had to be dragged out by hand in filmstrip mode before it was usable.

## Scope

- **`attach_media`** — trim from the tail instead of passing the play length through. The `durationSeconds` path was inverted, not just zeroed: asking for 5s of a 12s source produced a **7s** clip.
- **`trim_clip`** — same mistaken convention in its validation, where it was worse than wrong: requiring `trimIn < trimOut` made an untrimmed clip (`0/0`) unexpressible. Now checks the two amounts don't consume the whole source.
- **Tool descriptions** — said "offsets into the source", which is what led the code astray.

## Which convention is right

Every UI-authored clip stores untrimmed video as `trimIn: 0, trimOut: 0` with `duration == sourceDuration`. The MCP write layer (shipped yesterday in #270) was the side that disagreed.

## Tests

The existing attach test asserted `sourceDuration`, which stayed correct throughout — `duration` is the field that collapsed, so the suite was blind to it. Two new tests cover full-length and `durationSeconds` attaches; both fail against the old expression (verified by reverting it), while the 4 pre-existing tests still pass.

561 tests pass, `tsc --noEmit` clean.

## Not covered

`trim_clip` still has no test file — the validation change is reasoned from the core's arithmetic and the stored-document evidence, not pinned by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)