### PR TITLE
Play clip audio in the workbench preview, through a mixer

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -115,14 +115,58 @@ export type PreviewTimeChannel = Readonly<{
   isPlaying: () => boolean;
   setPlaying: (playing: boolean) => void;
   subscribePlaying: (listener: () => void) => () => void;
+  /** Audio level, held here for the same reason play state is: it must survive
+   *  the preview pane toggling off and back on. Volume is 0..1. */
+  getVolume: () => number;
+  setVolume: (volume: number) => void;
+  isMuted: () => boolean;
+  setMuted: (muted: boolean) => void;
+  subscribeAudio: (listener: () => void) => () => void;
 }>;
+
+const AUDIO_PREFERENCE_KEY = "storyboard:preview-audio";
+
+/** The preference is read once at channel construction and written on change.
+ *  Persistence lives in the app, NOT in `packages/ui` — the surface takes
+ *  volume/muted as props and stays framework-agnostic. */
+function readStoredAudio(): { volume: number; muted: boolean } {
+  if (typeof window === "undefined") return { volume: 1, muted: false };
+  try {
+    const raw = window.localStorage.getItem(AUDIO_PREFERENCE_KEY);
+    if (!raw) return { volume: 1, muted: false };
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) return { volume: 1, muted: false };
+    const record = parsed as { volume?: unknown; muted?: unknown };
+    const volume =
+      typeof record.volume === "number" && Number.isFinite(record.volume)
+        ? Math.min(1, Math.max(0, record.volume))
+        : 1;
+    return { volume, muted: record.muted === true };
+  } catch {
+    // A malformed or blocked store is not worth failing a preview over.
+    return { volume: 1, muted: false };
+  }
+}
+
+function writeStoredAudio(volume: number, muted: boolean) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(AUDIO_PREFERENCE_KEY, JSON.stringify({ volume, muted }));
+  } catch {
+    // Private mode / quota. The session still works, it just will not persist.
+  }
+}
 
 export function createPreviewTimeChannel(): PreviewTimeChannel {
   let time = 0;
   let playing = false;
   let scrub: PreviewScrubPosition | null = null;
+  const stored = readStoredAudio();
+  let volume = stored.volume;
+  let muted = stored.muted;
   const listeners = new Set<() => void>();
   const playListeners = new Set<() => void>();
+  const audioListeners = new Set<() => void>();
   return {
     get: () => time,
     set: (next) => {
@@ -150,6 +194,27 @@ export function createPreviewTimeChannel(): PreviewTimeChannel {
       playListeners.add(listener);
       return () => {
         playListeners.delete(listener);
+      };
+    },
+    getVolume: () => volume,
+    setVolume: (next) => {
+      const clamped = Math.min(1, Math.max(0, Number.isFinite(next) ? next : 0));
+      if (volume === clamped) return;
+      volume = clamped;
+      writeStoredAudio(volume, muted);
+      for (const listener of audioListeners) listener();
+    },
+    isMuted: () => muted,
+    setMuted: (next) => {
+      if (muted === next) return;
+      muted = next;
+      writeStoredAudio(volume, muted);
+      for (const listener of audioListeners) listener();
+    },
+    subscribeAudio: (listener) => {
+      audioListeners.add(listener);
+      return () => {
+        audioListeners.delete(listener);
       };
     },
   };
@@ -1948,6 +2013,11 @@ export function PreviewShell({
     channel.isPlaying,
     channel.isPlaying,
   );
+  // Same pattern for audio. The server snapshot returns the DEFAULTS rather
+  // than the stored preference: localStorage is unreadable during SSR, and
+  // returning a different value there than on the client would hydrate-mismatch.
+  const volume = useSyncExternalStore(channel.subscribeAudio, channel.getVolume, () => 1);
+  const muted = useSyncExternalStore(channel.subscribeAudio, channel.isMuted, () => false);
   const handleTimeChange = useCallback(
     (next: number) => {
       setTime(next);
@@ -2006,6 +2076,10 @@ export function PreviewShell({
               onCurrentTimeChange={handleTimeChange}
               playing={playing}
               onPlayingChange={channel.setPlaying}
+              volume={volume}
+              onVolumeChange={channel.setVolume}
+              muted={muted}
+              onMutedChange={channel.setMuted}
               onClose={handleClose}
               // A trim drag hands the pane a frame to draw (PL14-006). Not an
               // overlay over the pane — the pane's own canvas, its own cached

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -2295,6 +2295,39 @@ test.describe("graph view E2E", () => {
     await expect.poll(primaryColor).toBe(restingColor);
   });
 
+  test("preview audio: mute and volume survive a pane toggle", async ({ page }) => {
+    const api = await installGraphApi(page);
+    api.documents.get(PROJECT_ID)!.clips[0]!.kind = "image";
+    api.documents.get(PROJECT_ID)!.clips[0]!.startTime = 0;
+    await openGraph(page);
+    await previewToggle(page).click();
+
+    const surface = page.getByTestId("workbench-display-surface");
+    // Sound is not observable from a test — the fixture's "video" is a data-URI
+    // image with no audio track at all. These witnesses pin the state the mixer
+    // is driven with, which is the regression worth catching.
+    await expect(surface).toHaveAttribute("data-preview-muted", "false");
+    await expect(surface).toHaveAttribute("data-preview-volume", "1");
+
+    const volume = page.getByTestId("workbench-preview-volume");
+    await expect(volume).toHaveValue("1");
+
+    await page.getByRole("button", { name: "Mute workbench preview" }).click();
+    await expect(surface).toHaveAttribute("data-preview-muted", "true");
+    await expect(volume).toHaveValue("0");
+
+    // The whole reason audio state lives on the channel rather than in the
+    // surface: closing the pane unmounts the surface, and the setting must not
+    // die with it.
+    await previewToggle(page).click();
+    await expect(surface).toBeHidden();
+    await previewToggle(page).click();
+    await expect(surface).toHaveAttribute("data-preview-muted", "true");
+
+    await page.getByRole("button", { name: "Unmute workbench preview" }).click();
+    await expect(surface).toHaveAttribute("data-preview-muted", "false");
+  });
+
   test("preview divider transport keeps all controls visible for touch", async ({
     page,
   }) => {

--- a/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
+++ b/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
@@ -290,9 +290,83 @@ export const ControlledPlayback: Story = {
       /0(?:\.\d+)?s \/ 30\.0s/,
     );
 
+    // Tab order follows the DOM: the audio controls overlay the picture, so
+    // they come BEFORE the divider transport. Walk past them and the transport
+    // is still reachable, which is what this ever asserted.
+    await user.tab();
+    expect(canvas.getByTestId("workbench-preview-mute")).toHaveFocus();
+    await user.tab();
+    expect(canvas.getByTestId("workbench-preview-volume")).toHaveFocus();
     await user.tab();
     expect(controls.contains(document.activeElement)).toBe(true);
     expect(controls).toHaveAttribute("data-transport-layout", "static");
+  },
+};
+
+function ControlledAudioFixture() {
+  const [currentTime, setCurrentTime] = useState(0);
+  const [volume, setVolume] = useState(1);
+  const [muted, setMuted] = useState(false);
+
+  return (
+    <main className="min-h-[900px] bg-zinc-950 p-4 text-zinc-100">
+      <p data-testid="audio-readout" className="mb-3 font-mono text-sm">
+        {`volume=${volume} muted=${muted}`}
+      </p>
+      <WorkbenchSplitPane
+        surface={
+          <WorkbenchDisplaySurface
+            clips={[PLAYABLE_CLIP]}
+            currentTime={currentTime}
+            onCurrentTimeChange={setCurrentTime}
+            volume={volume}
+            onVolumeChange={setVolume}
+            muted={muted}
+            onMutedChange={setMuted}
+            className="h-full rounded-b-none border-b-0"
+          />
+        }
+      >
+        <div className="min-h-24" />
+      </WorkbenchSplitPane>
+    </main>
+  );
+}
+
+/** Audio is controlled on the same contract as `playing`: supply `volume` and
+ *  `muted` and the transport REFLECTS them, reporting intent back out. The
+ *  surface also publishes both as `data-*`, because sound itself is not
+ *  observable from a test. */
+export const ControlledAudio: Story = {
+  render: () => <ControlledAudioFixture />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const user = userEvent.setup();
+    const surface = canvas.getByTestId("workbench-display-surface");
+
+    // Audible by default — a preview that opens silent looks broken.
+    expect(surface).toHaveAttribute("data-preview-muted", "false");
+    expect(surface).toHaveAttribute("data-preview-volume", "1");
+    expect(canvas.getByTestId("audio-readout")).toHaveTextContent("volume=1 muted=false");
+
+    const mute = canvas.getByRole("button", { name: "Mute workbench preview" });
+    expect(mute).toHaveAttribute("aria-pressed", "false");
+
+    await user.click(mute);
+
+    // The controlled prop round-trips through the fixture and comes back.
+    expect(await canvas.findByRole("button", { name: "Unmute workbench preview" })).toBeInTheDocument();
+    expect(surface).toHaveAttribute("data-preview-muted", "true");
+    expect(canvas.getByTestId("audio-readout")).toHaveTextContent("muted=true");
+
+    // A muted preview shows the slider at zero regardless of the held volume,
+    // so the control never claims to be audible while it is not.
+    const slider = canvas.getByRole("slider", { name: "Workbench preview volume" });
+    expect(slider).toHaveValue("0");
+
+    await user.click(canvas.getByRole("button", { name: "Unmute workbench preview" }));
+    expect(surface).toHaveAttribute("data-preview-muted", "false");
+    expect(slider).toHaveValue("1");
   },
 };
 

--- a/packages/ui/timeline/viewport/audio-graph.test.ts
+++ b/packages/ui/timeline/viewport/audio-graph.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  clampVolume,
+  createAudioMixer,
+  volumeToGain,
+  type MinimalAudioContext,
+  type MinimalGainNode,
+} from "./audio-graph";
+
+/** A fake Web Audio context: enough surface for the mixer, none of the browser.
+ *  `sourceCalls` is what proves the attach-once guard, since the real
+ *  `createMediaElementSource` throws on a second call for one element. */
+function createFakeContext() {
+  const gains: MinimalGainNode[] = [];
+  const sourceCalls: HTMLMediaElement[] = [];
+  let state = "suspended";
+  let closed = false;
+
+  const context: MinimalAudioContext = {
+    get state() {
+      return state;
+    },
+    destination: {},
+    createGain: () => {
+      const node: MinimalGainNode = {
+        gain: { value: 1 },
+        connect: () => undefined,
+        disconnect: () => undefined,
+      };
+      gains.push(node);
+      return node;
+    },
+    createMediaElementSource: (element) => {
+      if (sourceCalls.includes(element)) {
+        throw new Error("HTMLMediaElement already connected");
+      }
+      sourceCalls.push(element);
+      return { connect: () => undefined };
+    },
+    resume: async () => {
+      state = "running";
+    },
+    close: async () => {
+      closed = true;
+    },
+  };
+
+  return {
+    context,
+    gains,
+    sourceCalls,
+    isClosed: () => closed,
+    getState: () => state,
+  };
+}
+
+/** Only the three properties the mixer touches. */
+function fakeElement() {
+  return { muted: true, volume: 0 } as unknown as HTMLMediaElement;
+}
+
+describe("clampVolume", () => {
+  it("holds the 0..1 range", () => {
+    expect(clampVolume(0.5)).toBe(0.5);
+    expect(clampVolume(-1)).toBe(0);
+    expect(clampVolume(2)).toBe(1);
+  });
+
+  it("falls to SILENCE on non-finite input, not to full volume", () => {
+    // Deliberate asymmetry with the clamp above: Infinity is out of range at
+    // the top, but a bad number reaching a volume control should never blast
+    // the user at full level. Silence is the recoverable failure.
+    expect(clampVolume(Number.NaN)).toBe(0);
+    expect(clampVolume(Number.POSITIVE_INFINITY)).toBe(0);
+  });
+});
+
+describe("volumeToGain", () => {
+  it("is a squared curve, so the endpoints are exact", () => {
+    expect(volumeToGain(0)).toBe(0);
+    expect(volumeToGain(1)).toBe(1);
+  });
+
+  it("puts a mid slider BELOW half gain — the point of the curve", () => {
+    // A linear map would return 0.5 here and spend most of the travel at the
+    // top of the range, which is what makes a linear volume slider feel dead.
+    expect(volumeToGain(0.5)).toBeCloseTo(0.25, 5);
+  });
+
+  it("clamps before curving rather than returning a negative gain", () => {
+    expect(volumeToGain(-0.5)).toBe(0);
+    expect(volumeToGain(4)).toBe(1);
+  });
+});
+
+describe("createAudioMixer", () => {
+  it("routes an element once, however many times attach is called", () => {
+    const fake = createFakeContext();
+    const mixer = createAudioMixer(() => fake.context);
+    const element = fakeElement();
+
+    mixer.attach(element);
+    mixer.attach(element);
+    mixer.attach(element);
+
+    // Two calls would throw in a real context and lose the element's audio.
+    expect(fake.sourceCalls).toHaveLength(1);
+  });
+
+  it("starts every source silent so a prefetched clip is inaudible", () => {
+    const fake = createFakeContext();
+    const mixer = createAudioMixer(() => fake.context);
+
+    mixer.attach(fakeElement());
+
+    // gains[0] is the master, created with the context; gains[1] is the source.
+    expect(fake.gains[1].gain.value).toBe(0);
+  });
+
+  it("takes level away from the element so the two do not multiply", () => {
+    const fake = createFakeContext();
+    const mixer = createAudioMixer(() => fake.context);
+    const element = fakeElement();
+
+    mixer.attach(element);
+
+    expect(element.muted).toBe(false);
+    expect(element.volume).toBe(1);
+  });
+
+  it("applies the curve to a source's gain", () => {
+    const fake = createFakeContext();
+    const mixer = createAudioMixer(() => fake.context);
+    const element = fakeElement();
+
+    mixer.attach(element);
+    mixer.setSourceGain(element, 0.5);
+
+    expect(fake.gains[1].gain.value).toBeCloseTo(0.25, 5);
+  });
+
+  it("zeroes master gain while muted and restores the level on unmute", () => {
+    const fake = createFakeContext();
+    const mixer = createAudioMixer(() => fake.context);
+    mixer.attach(fakeElement());
+    mixer.setMasterVolume(0.5);
+
+    const master = fake.gains[0];
+    expect(master.gain.value).toBeCloseTo(0.25, 5);
+
+    mixer.setMuted(true);
+    expect(master.gain.value).toBe(0);
+
+    mixer.setMuted(false);
+    expect(master.gain.value).toBeCloseTo(0.25, 5);
+  });
+
+  it("resumes a suspended context, which is how the play gesture unblocks it", async () => {
+    const fake = createFakeContext();
+    const mixer = createAudioMixer(() => fake.context);
+
+    expect(fake.getState()).toBe("suspended");
+    await mixer.resume();
+    expect(fake.getState()).toBe("running");
+  });
+
+  describe("without Web Audio", () => {
+    it("reports unsupported rather than throwing", () => {
+      const mixer = createAudioMixer(() => null);
+      expect(mixer.isSupported()).toBe(false);
+    });
+
+    it("falls back to the element's own volume instead of going silent", () => {
+      const mixer = createAudioMixer(() => null);
+      const element = fakeElement();
+
+      mixer.attach(element);
+      mixer.setSourceGain(element, 1);
+
+      expect(element.muted).toBe(false);
+      expect(element.volume).toBe(1);
+    });
+
+    it("still honours master volume and mute in the fallback path", () => {
+      const mixer = createAudioMixer(() => null);
+      const element = fakeElement();
+      mixer.attach(element);
+      mixer.setSourceGain(element, 1);
+
+      mixer.setMasterVolume(0.5);
+      expect(element.volume).toBeCloseTo(0.25, 5);
+
+      mixer.setMuted(true);
+      expect(element.muted).toBe(true);
+    });
+
+    it("keeps a zero-gain source muted, so prefetch stays silent", () => {
+      const mixer = createAudioMixer(() => null);
+      const element = fakeElement();
+
+      mixer.attach(element);
+
+      expect(element.muted).toBe(true);
+    });
+  });
+
+  it("closes the context on dispose", () => {
+    const fake = createFakeContext();
+    const mixer = createAudioMixer(() => fake.context);
+    mixer.attach(fakeElement());
+
+    mixer.dispose();
+
+    expect(fake.isClosed()).toBe(true);
+  });
+});

--- a/packages/ui/timeline/viewport/audio-graph.ts
+++ b/packages/ui/timeline/viewport/audio-graph.ts
@@ -1,0 +1,227 @@
+/**
+ * The preview's audio mixer.
+ *
+ * The surface plays its clips through off-DOM `<video>` elements. Routing those
+ * through Web Audio rather than just unmuting them buys ONE thing that matters
+ * later: a place where independent sources can be summed. A background-music
+ * track becomes another `attach`ed element with its own gain, and the playback
+ * loop does not change.
+ *
+ * Pure of React and of the DOM-framework layer, like `playback-skip.ts` beside
+ * it — the arithmetic below is exported separately so it tests without a DOM.
+ *
+ * TWO constraints drive the shape of this file:
+ *
+ *  - `createMediaElementSource` THROWS if called twice for the same element,
+ *    and the surface caches and reuses its elements across seeks. Hence the
+ *    `WeakMap` guard; `attach` is idempotent by contract.
+ *  - Routing an element through Web Audio is a ONE-WAY DOOR: from then on its
+ *    output reaches the speakers only through this graph. So `attach` also
+ *    neutralises the element's own controls (`muted = false`, `volume = 1`),
+ *    or the two attenuations would multiply.
+ */
+
+/** Volume and gain both live in 0..1. */
+export function clampVolume(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+/**
+ * Perceived loudness is closer to the square of amplitude than to amplitude, so
+ * a linear slider mapped straight to gain spends most of its travel in the top
+ * of the range and feels dead at the bottom. Squaring puts the useful detail
+ * where the hand is.
+ */
+export function volumeToGain(volume: number): number {
+  const safe = clampVolume(volume);
+  return safe * safe;
+}
+
+/** The subset of `AudioContext` this module uses — narrow so a test can fake it
+ *  without standing up Web Audio, and so no `any` is needed. */
+export type MinimalGainNode = {
+  gain: { value: number };
+  connect: (destination: MinimalGainNode | MinimalAudioDestination) => void;
+  disconnect: () => void;
+};
+
+export type MinimalAudioDestination = { readonly __brand?: "destination" };
+
+export type MinimalAudioContext = {
+  readonly state: string;
+  readonly destination: MinimalAudioDestination;
+  createGain: () => MinimalGainNode;
+  createMediaElementSource: (element: HTMLMediaElement) => { connect: (node: MinimalGainNode) => void };
+  resume: () => Promise<void>;
+  close: () => Promise<void>;
+};
+
+export type AudioMixer = {
+  /** Route an element into the mixer. Idempotent — safe to call on every cache
+   *  hit. A no-op when Web Audio is unavailable. */
+  attach: (element: HTMLMediaElement) => void;
+  /** Per-source level, 0..1. This is how the active clip is heard and the
+   *  prefetched and disabled ones are held silent. */
+  setSourceGain: (element: HTMLMediaElement, volume: number) => void;
+  setMasterVolume: (volume: number) => void;
+  setMuted: (muted: boolean) => void;
+  /** Browsers start the context suspended until a user gesture. Call from the
+   *  play handler; resolves either way so callers need no branch. */
+  resume: () => Promise<void>;
+  /** False when Web Audio is missing (SSR, jsdom, ancient browsers). Callers
+   *  degrade to element-level volume — see `setSourceGain`. */
+  isSupported: () => boolean;
+  dispose: () => void;
+};
+
+type AudioContextConstructor = new () => MinimalAudioContext;
+
+function resolveAudioContextConstructor(): AudioContextConstructor | null {
+  if (typeof window === "undefined") return null;
+  const scope = window as unknown as {
+    AudioContext?: AudioContextConstructor;
+    webkitAudioContext?: AudioContextConstructor;
+  };
+  return scope.AudioContext ?? scope.webkitAudioContext ?? null;
+}
+
+/**
+ * `createContext` is injectable so the unit test can drive a fake and assert
+ * the attach-once and gain behavior without Web Audio.
+ */
+export function createAudioMixer(
+  createContext: () => MinimalAudioContext | null = () => {
+    const Ctor = resolveAudioContextConstructor();
+    return Ctor ? new Ctor() : null;
+  },
+): AudioMixer {
+  let context: MinimalAudioContext | null = null;
+  let master: MinimalGainNode | null = null;
+  let unsupported = false;
+  let masterVolume = 1;
+  let muted = false;
+  const gains = new WeakMap<HTMLMediaElement, MinimalGainNode>();
+  /** Levels are remembered even when Web Audio is absent, so the element-volume
+   *  fallback and the master control compose the same way. */
+  const levels = new WeakMap<HTMLMediaElement, number>();
+  const fallbackElements = new Set<HTMLMediaElement>();
+
+  function ensureContext(): MinimalAudioContext | null {
+    if (context || unsupported) return context;
+    const created = createContext();
+    if (!created) {
+      unsupported = true;
+      return null;
+    }
+    context = created;
+    master = created.createGain();
+    master.gain.value = muted ? 0 : volumeToGain(masterVolume);
+    master.connect(created.destination);
+    return context;
+  }
+
+  /** Without Web Audio the element's own controls are all there is. Master
+   *  volume and mute still have to apply, so fold them in here. */
+  function applyFallback(element: HTMLMediaElement) {
+    const level = levels.get(element) ?? 0;
+    element.muted = muted || level <= 0;
+    element.volume = clampVolume(volumeToGain(level * masterVolume));
+  }
+
+  function applyAllFallbacks() {
+    for (const element of fallbackElements) applyFallback(element);
+  }
+
+  return {
+    attach(element) {
+      if (gains.has(element)) return;
+
+      const ctx = ensureContext();
+      if (!ctx || !master) {
+        // Degrade rather than go silent: the element keeps its own volume.
+        fallbackElements.add(element);
+        if (!levels.has(element)) levels.set(element, 0);
+        applyFallback(element);
+        return;
+      }
+
+      const gain = ctx.createGain();
+      // Start silent. The surface raises the ACTIVE clip; everything the
+      // prefetch window pulled in stays down until it is the one playing.
+      gain.gain.value = 0;
+      gain.connect(master);
+
+      try {
+        ctx.createMediaElementSource(element).connect(gain);
+      } catch {
+        // Already routed by someone else, or the element is not eligible.
+        // Falling back keeps sound rather than losing it to a thrown guard.
+        gain.disconnect();
+        fallbackElements.add(element);
+        if (!levels.has(element)) levels.set(element, 0);
+        applyFallback(element);
+        return;
+      }
+
+      // The element's own attenuation would multiply with the graph's, so the
+      // graph takes sole ownership of level from here.
+      element.muted = false;
+      element.volume = 1;
+      gains.set(element, gain);
+      if (!levels.has(element)) levels.set(element, 0);
+    },
+
+    setSourceGain(element, volume) {
+      const level = clampVolume(volume);
+      levels.set(element, level);
+      const gain = gains.get(element);
+      if (gain) {
+        gain.gain.value = volumeToGain(level);
+        return;
+      }
+      if (fallbackElements.has(element)) applyFallback(element);
+    },
+
+    setMasterVolume(volume) {
+      masterVolume = clampVolume(volume);
+      if (master && !muted) master.gain.value = volumeToGain(masterVolume);
+      applyAllFallbacks();
+    },
+
+    setMuted(next) {
+      muted = next;
+      if (master) master.gain.value = next ? 0 : volumeToGain(masterVolume);
+      applyAllFallbacks();
+    },
+
+    async resume() {
+      const ctx = ensureContext();
+      if (!ctx) return;
+      if (ctx.state === "suspended") {
+        try {
+          await ctx.resume();
+        } catch {
+          // A refused resume is not actionable here — the surface reports the
+          // blocked state from the rejected play() instead.
+        }
+      }
+    },
+
+    isSupported() {
+      // Probe rather than report "unknown": callers ask this to decide how to
+      // label the control, before anything has been attached.
+      return ensureContext() !== null;
+    },
+
+    dispose() {
+      const ctx = context;
+      context = null;
+      master = null;
+      fallbackElements.clear();
+      if (ctx) void ctx.close().catch(() => undefined);
+    },
+  };
+}

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { GripHorizontal, Pause, Play, SkipBack, SkipForward, X } from "lucide-react";
+import { GripHorizontal, Pause, Play, SkipBack, SkipForward, Volume2, VolumeX, X } from "lucide-react";
 import {
   useCallback,
   useEffect,
@@ -15,6 +15,8 @@ import {
 import { cn } from "../../lib/utils";
 import type { CollectionFramePreview } from "../timeline-documents";
 import { useTimelineDocuments } from "../timeline-document-store";
+
+import { createAudioMixer, type AudioMixer } from "./audio-graph";
 
 import type { CollectionTimelineClip, TimelineClip } from "../types";
 import { formatSeconds } from "../utils";
@@ -68,6 +70,13 @@ type WorkbenchDisplaySurfaceProps = {
    *  Omit for the default uncontrolled behavior (internal play state). */
   playing?: boolean;
   onPlayingChange?: (playing: boolean) => void;
+  /** Controlled audio, same contract as `playing` above: supply both to own the
+   *  state, omit for internal defaults. Volume is 0..1 and is a MASTER level —
+   *  per-clip levels are the mixer's business, not a consumer's. */
+  volume?: number;
+  onVolumeChange?: (volume: number) => void;
+  muted?: boolean;
+  onMutedChange?: (muted: boolean) => void;
   /** When supplied, the surface renders a close affordance in its top-right
    *  corner. Omit and no button is drawn — a consumer that has no way to hide
    *  the preview must not show one. */
@@ -130,6 +139,74 @@ type WorkbenchDividerTransportProps = {
   onSeekPrevious: () => void;
   onSeekNext: () => void;
 };
+
+type WorkbenchAudioControlsProps = {
+  volume: number;
+  muted: boolean;
+  onToggleMuted: () => void;
+  onVolumeChange: (volume: number) => void;
+  /** True once an unmuted play() was refused for want of a user gesture. The
+   *  control says so rather than leaving the user to wonder why it is silent. */
+  audioBlocked: boolean;
+};
+
+/**
+ * Volume lives INSIDE the preview, not on the divider beside play/pause.
+ *
+ * The divider is a resize handle first: its whole band is the drag target, and
+ * parking a button at its left end quietly shrank that target — the e2e that
+ * hovers the divider at x=20 caught it immediately. Overlaying the picture is
+ * also simply where every video player puts this control.
+ */
+function WorkbenchAudioControls({
+  volume,
+  muted,
+  onToggleMuted,
+  onVolumeChange,
+  audioBlocked,
+}: WorkbenchAudioControlsProps) {
+  const silent = muted || volume <= 0;
+
+  return (
+    <div
+      className="absolute bottom-2 left-2 z-20 flex items-center gap-1.5 rounded-full bg-zinc-950/70 px-1.5 py-1 backdrop-blur-sm"
+      data-testid="workbench-preview-audio"
+      onPointerDown={(event) => {
+        // The canvas below toggles play on click. These controls are their own
+        // island — pressing one must not also start the preview.
+        event.stopPropagation();
+      }}
+      onClick={(event) => {
+        event.stopPropagation();
+      }}
+    >
+      <button
+        type="button"
+        onClick={onToggleMuted}
+        className="grid size-6 shrink-0 place-items-center rounded-full text-zinc-300 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+        aria-label={silent ? "Unmute workbench preview" : "Mute workbench preview"}
+        aria-pressed={silent}
+        title={audioBlocked ? "Click to enable sound" : silent ? "Unmute" : "Mute"}
+        data-testid="workbench-preview-mute"
+        data-audio-blocked={audioBlocked || undefined}
+      >
+        {silent ? <VolumeX className="size-3.5" /> : <Volume2 className="size-3.5" />}
+      </button>
+
+      <input
+        type="range"
+        min={0}
+        max={1}
+        step={0.01}
+        value={muted ? 0 : volume}
+        onChange={(event) => onVolumeChange(Number(event.target.value))}
+        className="h-1 w-16 cursor-pointer appearance-none rounded-full bg-zinc-700 accent-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+        aria-label="Workbench preview volume"
+        data-testid="workbench-preview-volume"
+      />
+    </div>
+  );
+}
 
 function WorkbenchDividerTransport({
   currentTime,
@@ -440,6 +517,10 @@ export function WorkbenchDisplaySurface({
   preferredClipId,
   playing,
   onPlayingChange,
+  volume,
+  onVolumeChange,
+  muted,
+  onMutedChange,
   onClose,
   frameOverride = null,
 }: WorkbenchDisplaySurfaceProps) {
@@ -472,6 +553,39 @@ export function WorkbenchDisplaySurface({
     },
     [isControlledPlayback, onPlayingChange],
   );
+
+  // Audio follows the same controlled-or-uncontrolled contract as playback.
+  const isControlledVolume = volume !== undefined;
+  const isControlledMuted = muted !== undefined;
+  const [uncontrolledVolume, setUncontrolledVolume] = useState(1);
+  const [uncontrolledMuted, setUncontrolledMuted] = useState(false);
+  const [audioBlocked, setAudioBlocked] = useState(false);
+  const activeVolume = volume ?? uncontrolledVolume;
+  const activeMuted = muted ?? uncontrolledMuted;
+  const setVolume = useCallback(
+    (next: number) => {
+      if (isControlledVolume) onVolumeChange?.(next);
+      else setUncontrolledVolume(next);
+    },
+    [isControlledVolume, onVolumeChange],
+  );
+  const setMuted = useCallback(
+    (next: boolean) => {
+      if (isControlledMuted) onMutedChange?.(next);
+      else setUncontrolledMuted(next);
+    },
+    [isControlledMuted, onMutedChange],
+  );
+  // One mixer for the surface's lifetime. Created lazily on first use so a
+  // never-played preview never constructs an AudioContext.
+  const mixerRef = useRef<AudioMixer | null>(null);
+  const getMixer = useCallback(() => {
+    mixerRef.current ??= createAudioMixer();
+    return mixerRef.current;
+  }, []);
+  // Read inside callbacks that must not re-create when the level changes.
+  const audioLevelRef = useRef({ volume: activeVolume, muted: activeMuted });
+  audioLevelRef.current = { volume: activeVolume, muted: activeMuted };
 
   const sortedClips = useMemo(
     () => [...clips].sort((a, b) => getClipPlaybackStart(a) - getClipPlaybackStart(b) || a.index - b.index),
@@ -535,10 +649,20 @@ export function WorkbenchDisplaySurface({
       const video = document.createElement("video");
       video.preload = "auto";
       video.playsInline = true;
-      video.muted = true;
+      // CORS-clean or Web Audio hands back SILENCE for cross-origin media —
+      // `createMediaElementSource` on a tainted element produces zeros rather
+      // than failing loudly. Must be set BEFORE `src`; setting it after would
+      // need a reload. Only for absolute http(s) sources: a host that does not
+      // send CORS headers would refuse the request outright, and blob:/data:
+      // sources are same-origin already. (Cloudinary, which serves every clip
+      // here, sends `Access-Control-Allow-Origin: *`.)
+      if (/^https?:\/\//i.test(media.src)) video.crossOrigin = "anonymous";
       if (media.poster) video.poster = media.poster;
       video.src = media.src;
       video.load();
+      // Attach BEFORE any play(): the mixer starts every source at zero gain,
+      // so a prefetched clip is inaudible until it becomes the active one.
+      getMixer().attach(video);
       const nextCached: CachedMedia = { kind: "video", element: video };
       cacheRef.current.set(media.key, nextCached);
       return nextCached;
@@ -550,7 +674,7 @@ export function WorkbenchDisplaySurface({
     const nextCached: CachedMedia = { kind: "image", element: image };
     cacheRef.current.set(media.key, nextCached);
     return nextCached;
-  }, []);
+  }, [getMixer]);
 
   const drawDrawable = useCallback((drawable: HTMLImageElement | HTMLVideoElement) => {
     const canvas = canvasRef.current;
@@ -641,12 +765,28 @@ export function WorkbenchDisplaySurface({
   const frameOverrideRef = useRef(frameOverride);
 
   const pauseInactiveVideos = useCallback((activeKey: string | null) => {
+    const mixer = getMixer();
     cacheRef.current.forEach((cached, key) => {
-      if (cached.kind === "video" && key !== activeKey) {
+      if (cached.kind !== "video") return;
+      if (key !== activeKey) {
         cached.element.pause();
+        // The prefetch window pulls in the next few clips REGARDLESS of whether
+        // they are disabled, so silence is decided here rather than there.
+        mixer.setSourceGain(cached.element, 0);
       }
     });
-  }, []);
+  }, [getMixer]);
+
+  /** The active clip is the only audible one, and a DISABLED clip is silent
+   *  even though scrubbing can rest on it and draw its grayed frame. */
+  const applyActiveGain = useCallback(
+    (element: HTMLVideoElement) => {
+      const { volume: level, muted: isMuted } = audioLevelRef.current;
+      const audible = !isMuted && !activeClipDisabledRef.current;
+      getMixer().setSourceGain(element, audible ? level : 0);
+    },
+    [getMixer],
+  );
 
   const syncActiveVideo = useCallback((media: DisplayMedia, shouldPlay: boolean, forceSeek = false) => {
     const cached = ensureCachedMedia(media);
@@ -663,7 +803,11 @@ export function WorkbenchDisplaySurface({
       const maxDrift = shouldPlay ? 0.18 : 0.05;
       if (Number.isFinite(media.playbackRate) && media.playbackRate > 0) {
         video.playbackRate = clamp(media.playbackRate, 0.0625, 16);
+        // A time-scaled clip would otherwise chipmunk: rate is a picture
+        // decision, and the voice should not move with it.
+        video.preservesPitch = true;
       }
+      applyActiveGain(video);
       if (forceSeek || drift > maxDrift) {
         pendingSeekDrawCleanupRef.current?.();
         pendingSeekDrawCleanupRef.current = null;
@@ -683,7 +827,14 @@ export function WorkbenchDisplaySurface({
         video.currentTime = targetTime;
       }
       if (shouldPlay && video.paused) {
-        void video.play().catch(() => undefined);
+        // Unmuted playback needs a user gesture. Swallowing the rejection here
+        // would leave a silent-and-frozen preview with nothing to explain it,
+        // so record it: the transport offers "click to enable sound", and the
+        // next gesture-driven play clears the flag.
+        void video
+          .play()
+          .then(() => setAudioBlocked(false))
+          .catch(() => setAudioBlocked(true));
       } else if (!shouldPlay) {
         video.pause();
       }
@@ -697,7 +848,7 @@ export function WorkbenchDisplaySurface({
 
     video.addEventListener("loadedmetadata", seek, { once: true });
     video.addEventListener("loadeddata", drawActiveFrame, { once: true });
-  }, [drawActiveFrame, ensureCachedMedia]);
+  }, [applyActiveGain, drawActiveFrame, ensureCachedMedia]);
 
   const renderFrameAtTime = useCallback((timelineTime: number, shouldPlay: boolean, forceSeek = false) => {
     // An override owns the picture while it is set. Guarding HERE rather than
@@ -1014,8 +1165,24 @@ export function WorkbenchDisplaySurface({
       pendingSeekDrawCleanupRef.current?.();
       pendingSeekDrawCleanupRef.current = null;
       mediaCache.clear();
+      mixerRef.current?.dispose();
+      mixerRef.current = null;
     };
   }, []);
+
+  // Master level lives on the mixer, but the ACTIVE source's own gain also
+  // carries the mute (so a muted preview is silent even mid-clip). Re-apply
+  // both whenever either changes.
+  useEffect(() => {
+    const mixer = getMixer();
+    mixer.setMasterVolume(activeVolume);
+    mixer.setMuted(activeMuted);
+
+    const activeKey = activeMediaRef.current?.key ?? null;
+    if (!activeKey) return;
+    const cached = cacheRef.current.get(activeKey);
+    if (cached?.kind === "video") applyActiveGain(cached.element);
+  }, [activeMuted, activeVolume, applyActiveGain, getMixer]);
 
   const canPlay = duration > 0 && sortedClips.length > 0;
   const canSeekPrevious = sortedClips.length > 0 && currentTime > 0;
@@ -1061,6 +1228,13 @@ export function WorkbenchDisplaySurface({
       // back, and the e2e fixture's "video" is a 1x1 GIF that never decodes at
       // all. This at least pins that the request reached the pane.
       data-frame-override={frameOverride ? frameOverride.src : undefined}
+      // Audio witnesses, for the same reason as the frame override above and
+      // more so: SOUND is not observable from a test at all, and the fixture's
+      // 1x1 GIF has no audio track to make. These pin the state the mixer was
+      // driven with, which is the part worth regressing on.
+      data-preview-muted={activeMuted}
+      data-preview-volume={activeVolume}
+      data-preview-audio-blocked={audioBlocked || undefined}
     >
       <div className="relative min-h-0 flex-1 overflow-hidden rounded-[inherit] bg-black">
         <canvas
@@ -1085,6 +1259,25 @@ export function WorkbenchDisplaySurface({
           onPointerLeave={() => setPreviewHovered(false)}
           onClick={(event) => {
             if (isPointerOverPlaybackSurface(event)) setPlaying(!isPlaying);
+          }}
+        />
+        <WorkbenchAudioControls
+          volume={activeVolume}
+          muted={activeMuted}
+          audioBlocked={audioBlocked}
+          onToggleMuted={() => {
+            // This click IS a user gesture — resume the context on it.
+            void getMixer().resume();
+            // Unmuting from a zeroed slider must actually be audible, or the
+            // control appears to do nothing.
+            if (activeMuted && activeVolume <= 0) setVolume(1);
+            setMuted(!activeMuted);
+          }}
+          onVolumeChange={(next) => {
+            void getMixer().resume();
+            setVolume(next);
+            // Dragging the slider up is an unmute in every player people know.
+            if (next > 0 && activeMuted) setMuted(false);
           }}
         />
         {/* Names what the grayed frame means. Only ever visible while
@@ -1123,7 +1316,12 @@ export function WorkbenchDisplaySurface({
         canSeekPrevious={canSeekPrevious}
         canSeekNext={canSeekNext}
         previewHovered={canPlay && previewHovered}
-        onTogglePlaying={() => setPlaying(!isPlaying)}
+        onTogglePlaying={() => {
+          // This click IS the user gesture the AudioContext has been waiting
+          // for, so resume before play() rather than after it is refused.
+          void getMixer().resume();
+          setPlaying(!isPlaying);
+        }}
         onSeekPrevious={() => seekToClip(-1)}
         onSeekNext={() => seekToClip(1)}
       />


### PR DESCRIPTION
## What

The preview decoded and played video but was **silent** — the off-DOM elements it drives were created with `muted = true` ([workbench-display-surface.tsx:538](https://github.com/josulliv101/storyboard-flow/blob/main/packages/ui/timeline/viewport/workbench-display-surface.tsx#L538)). Clips now carry generated speech, so reviewing a cut without sound judges half the work.

## Why a mixer and not just an unmute

Background-music tracks are a likely follow-on. Routing each element through a source gain → master gain means a music track later becomes another `attach`ed element with its own gain, with **no change to the playback loop**. The data model for audio clips is deliberately out of scope.

New pure module `packages/ui/timeline/viewport/audio-graph.ts`, beside `playback-skip.ts` and to the same discipline — no React, no DOM framework, arithmetic exported so it tests without a DOM. It degrades to element-level volume where Web Audio is unavailable rather than going silent.

## Three things beyond flipping the flag

- **`crossOrigin = "anonymous"`, set before `src`.** `createMediaElementSource` on a cross-origin element yields **silence** rather than failing, and every clip is served from Cloudinary. Verified it answers `Access-Control-Allow-Origin: *`. Applied only to absolute `http(s)` sources, since a host *without* CORS headers would refuse the request outright.
- **`preservesPitch`** — clips play at a computed `playbackRate`, and a time-scaled clip would otherwise chipmunk.
- **Gain policy.** The prefetch window buffers 4 clips ahead *regardless of whether they are disabled*, so gain is decided where inactive videos are paused: only the active, enabled clip is audible.

Autoplay rejection is no longer swallowed — unmuted `play()` needs a gesture, so the refusal is recorded and the control offers to enable sound. The context resumes on the play/mute/slider gesture.

Volume and mute live on `PreviewTimeChannel` like play state, so they survive the pane toggling; the preference persists in `localStorage` from the **app layer**, keeping `packages/ui` framework-agnostic.

## Placement

The controls overlay the picture rather than joining the divider transport. The divider is a resize handle whose whole band is the drag target, and parking a button at its left end shrank it — **two e2e failures caught that**, and the fix is placement, not a looser assertion. Tab order changes as a result, so the playback story now walks through the new controls explicitly.

## Testing

Sound is not observable from a test — the e2e fixture's "video" is a data URI with no audio track — so the surface publishes `data-preview-muted` / `-volume` / `-audio-blocked` as witnesses, following the existing `data-frame-override` precedent.

- 15 new unit tests (`audio-graph.test.ts`): squared gain curve, clamping, attach-once against a fake context, and the no-Web-Audio fallback
- New `ControlledAudio` story with a `play` function
- New e2e: mute survives a pane toggle

Green: **577** app tests, **476** unit, **170** storybook, **143** graph-view e2e, `tsc --noEmit` clean in both packages, lint unchanged.

Verified live against real clips: every routed element reports `crossOrigin anonymous`, `muted false`, `volume 1`; mute drives master and source gain to 0; the slider at half lands on **0.25** gain — the squared curve the unit test pins.

## Follow-on this prepares for

`mixer.attach` is the plug-in point for music tracks. A scrubbing waveform would use the same context via `decodeAudioData`, and needs the CORS work landed here — though peaks should be precomputed at upload in `probeVideo` rather than decoded per-scrub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)