### PR TITLE
Draw an audio waveform lane under the timeline cards

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -12,6 +12,7 @@ import {
 import { createPortal } from "react-dom";
 import { useSearchParams } from "next/navigation";
 import {
+  AudioLines,
   ClipboardPaste,
   Command,
   EllipsisVertical,
@@ -85,6 +86,7 @@ import {
   GraphPlayhead,
   GraphRuler,
   GraphSeekRails,
+  GraphWaveformBand,
   FlatItemsProvider,
   GraphStripSeekRail,
   PreviewShell,
@@ -854,6 +856,8 @@ export function GraphBoard({
   previewOn,
   rulerOn,
   onRulerToggle,
+  waveformOn,
+  onWaveformToggle,
   flatOn,
   childrenShown,
   onChildrenToggle,
@@ -882,6 +886,8 @@ export function GraphBoard({
    *  renders the state and asks for the change. */
   rulerOn: boolean;
   onRulerToggle: () => void;
+  waveformOn: boolean;
+  onWaveformToggle: () => void;
   /** Strip's flat mode: render the whole closure in order, not this
    *  collection's direct children. */
   flatOn: boolean;
@@ -1047,6 +1053,15 @@ export function GraphBoard({
                   title="Time ruler — tick marks over every strip"
                 />
               ) : null}
+              {flatOn ? (
+                <HeaderToggle
+                  active={waveformOn}
+                  onToggle={onWaveformToggle}
+                  icon={AudioLines}
+                  label={waveformOn ? "Hide audio waveform" : "Show audio waveform"}
+                  title="Audio waveform — peaks and pauses under the ruler"
+                />
+              ) : null}
               <HeaderToggle
                 active={childrenShown}
                 onToggle={onChildrenToggle}
@@ -1116,10 +1131,17 @@ export function GraphBoard({
                 // frame preview it used to only coincidentally line up with.
                 trimOverview="off"
                 overlay={
-                  previewOn || rulerOn ? (
+                  previewOn || rulerOn || waveformOn ? (
                     <>
                       {rulerOn ? (
                         <GraphRuler
+                          focusedId={focusedId}
+                          pixelsPerSecond={deferredPixelsPerSecond}
+                          cardHeight={dims.strip}
+                        />
+                      ) : null}
+                      {waveformOn ? (
+                        <GraphWaveformBand
                           focusedId={focusedId}
                           pixelsPerSecond={deferredPixelsPerSecond}
                           cardHeight={dims.strip}
@@ -1146,7 +1168,7 @@ export function GraphBoard({
                 className={[
                   "rounded-none border-0 p-0",
                   GRAPH_STRIP_TRACK_CLASS,
-                  previewOn || rulerOn ? "pt-4" : "",
+                  previewOn || rulerOn || waveformOn ? "pt-4" : "",
                 ].join(" ")}
               />
               {/* The strip's scrub control — the same rail treatment as the
@@ -1238,6 +1260,7 @@ export function GraphBoard({
                 pixelsPerSecond={deferredPixelsPerSecond}
                 previewOn={previewOn}
                 rulerOn={rulerOn}
+                waveformOn={waveformOn}
                 timeChannel={timeChannel}
               />
             </FlatItemsProvider>

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -66,8 +66,20 @@ import { createTimelineDocumentsState } from "@storyboard/ui/timeline/timeline-d
 import { formatSeconds } from "@storyboard/ui/timeline/utils";
 import type { TimelineClip, TimelineDocument } from "@storyboard/ui/timeline/types";
 
+import {
+  peakMagnitude,
+  peaksForWindow,
+} from "@storyboard/ui/timeline/viewport/waveform-peaks";
+
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 import { requestGraphPreviewToggle } from "@/lib/graph-view-events";
+import { sharedWaveformCache, type WaveformCache } from "@/lib/waveform-cache";
+
+import {
+  distinctWaveformKeys,
+  waveformSourcesFor,
+  type WaveformSource,
+} from "./graph-waveform-model";
 
 import { useGraphDetailsStore } from "./graph-details-context";
 import {
@@ -698,6 +710,185 @@ export function GraphRuler({
           </span>
         ) : null,
       )}
+    </div>
+  );
+}
+
+/** Lane height. Tall enough that a pause reads as a gap rather than a wobble,
+ *  short enough to sit under the ruler without eating card space. */
+const WAVEFORM_BAND_HEIGHT_PX = 28;
+
+/**
+ * The scrubbing waveform: each card's audio drawn at the card's own width, so a
+ * pause in the dialogue lines up with the frame it happens on.
+ *
+ * Modeled on `GraphRuler` above — same overlay layer, same windowing, same
+ * content coordinates — with one difference that matters: it draws to a CANVAS.
+ * Everything else in the rails is div + CSS, which is right for tens of ticks
+ * and wrong for thousands of waveform columns.
+ *
+ * The canvas is sized to the VISIBLE WINDOW, not to the full extent: at high
+ * zoom a long timeline's extent runs past the browser's maximum canvas width,
+ * and allocating that much backing store to show 1200px of it is waste besides.
+ */
+export function GraphWaveformBand({
+  focusedId,
+  pixelsPerSecond,
+  cardHeight,
+  /** Injected so a story can supply synthetic peaks without decoding audio. */
+  cache = sharedWaveformCache(),
+}: Readonly<{
+  focusedId: string;
+  pixelsPerSecond: number;
+  cardHeight: number;
+  cache?: WaveformCache;
+}>) {
+  const store = useCollectionsStore();
+  const detailsStore = useGraphDetailsStore();
+  const spans = useContext(PreviewCardSpansContext);
+  const [scroller, setScroller] = useState<HTMLElement | null>(null);
+  const bandRef = useCallback(
+    (element: HTMLElement | null) => setScroller(element ? stripScrollerAbove(element) : null),
+    [],
+  );
+  const tickWindow = useScrollerTickWindow(scroller);
+  const flatItems = useContext(FlatItemsContext);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const graph = useSyncExternalStore(
+    store.subscribe,
+    () => store.getSnapshot().graph,
+    () => store.getSnapshot().graph,
+  );
+  const details = useSyncExternalStore(
+    detailsStore.subscribe,
+    () => detailsStore.read(),
+    () => detailsStore.read(),
+  );
+  // Bumped when a decode lands, purely to re-run the paint effect.
+  const [peaksVersion, setPeaksVersion] = useState(0);
+  useEffect(
+    () => cache.subscribe(() => setPeaksVersion((version) => version + 1)),
+    [cache],
+  );
+
+  const { cards, sources, extent } = useMemo(() => {
+    const nextCards = cardsFor(
+      graph,
+      details,
+      focusedId,
+      spans,
+      pixelsPerSecond,
+      cardHeight,
+      flatItems,
+    );
+    return {
+      cards: nextCards,
+      // Index-aligned with the cards by contract — see graph-waveform-model.
+      sources: waveformSourcesFor(graph, details, focusedId, flatItems),
+      extent: buildStripOverlay(nextCards).extent,
+    };
+  }, [graph, details, spans, focusedId, pixelsPerSecond, cardHeight, flatItems]);
+
+  // Ask for the audio the VISIBLE cards need. Requesting the whole timeline
+  // would fetch every file on mount; the cache coalesces and caps concurrency,
+  // but the cheapest fetch is the one never issued.
+  useEffect(() => {
+    let cursor = 0;
+    const wanted: WaveformSource[] = [];
+    cards.forEach((card, index) => {
+      const visible = cursor + card.width >= tickWindow.startX && cursor <= tickWindow.endX;
+      const source = sources[index];
+      if (visible && source) wanted.push(source);
+      cursor += card.width + STRIP_GAP_PX;
+    });
+    for (const source of distinctWaveformKeys(wanted)) {
+      void cache.request(source.key, source.src);
+    }
+  }, [cache, cards, sources, tickWindow]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const windowWidth = Math.max(1, Math.min(extent, tickWindow.endX - tickWindow.startX));
+    const ratio = Math.max(1, window.devicePixelRatio || 1);
+    const pixelWidth = Math.round(windowWidth * ratio);
+    const pixelHeight = Math.round(WAVEFORM_BAND_HEIGHT_PX * ratio);
+    if (canvas.width !== pixelWidth || canvas.height !== pixelHeight) {
+      canvas.width = pixelWidth;
+      canvas.height = pixelHeight;
+    }
+
+    const context = canvas.getContext("2d");
+    if (!context) return;
+    context.setTransform(ratio, 0, 0, ratio, 0, 0);
+    context.clearRect(0, 0, windowWidth, WAVEFORM_BAND_HEIGHT_PX);
+
+    const midline = WAVEFORM_BAND_HEIGHT_PX / 2;
+    let cursor = 0;
+    let drawn = 0;
+
+    cards.forEach((card, index) => {
+      const cardStart = cursor;
+      cursor += card.width + STRIP_GAP_PX;
+
+      const source = sources[index];
+      if (!source) return;
+      if (cardStart + card.width < tickWindow.startX || cardStart > tickWindow.endX) return;
+
+      const peaks = cache.peek(source.key);
+      if (!peaks) return;
+
+      const columns = Math.max(1, Math.round(card.width));
+      const window_ = peaksForWindow(peaks, source.trimIn, source.trimOut, columns);
+      const magnitude = peakMagnitude(window_);
+      // Generated renders come out quiet and inconsistent, so normalise per
+      // clip — raw amplitude makes a whole lane look flat. Silence stays flat
+      // rather than being amplified into noise.
+      const scale = magnitude > 0.001 ? (WAVEFORM_BAND_HEIGHT_PX / 2 - 1) / magnitude : 0;
+
+      context.fillStyle = card.disabled === true ? "rgba(161,161,170,0.35)" : "rgba(125,211,252,0.85)";
+      for (let column = 0; column < columns; column += 1) {
+        const min = window_[column * 2] * scale;
+        const max = window_[column * 2 + 1] * scale;
+        const top = midline - Math.max(max, 0.5);
+        const height = Math.max(1, Math.max(max, 0.5) - Math.min(min, -0.5));
+        // Canvas x is window-relative: the element is translated to startX.
+        context.fillRect(cardStart + column - tickWindow.startX, top, 1, height);
+      }
+      drawn += 1;
+    });
+
+    canvas.dataset.waveformCards = String(drawn);
+  }, [cache, cards, sources, extent, tickWindow, peaksVersion]);
+
+  return (
+    <div
+      ref={bandRef}
+      aria-hidden="true"
+      data-graph-waveform
+      data-waveform-extent={Math.round(extent)}
+      // BOTTOM of the card, not the top. The overlay spans the full card
+      // height, so a lane at the top stacks under the ruler and eats a third of
+      // every thumbnail; along the bottom edge it reads the way audio does in
+      // any editor, over the least informative part of the frame.
+      className="pointer-events-none absolute inset-x-0 bottom-0 z-10"
+      style={{ height: WAVEFORM_BAND_HEIGHT_PX }}
+    >
+      <div
+        className="absolute inset-x-0 top-0 bg-gradient-to-t from-zinc-950/85 to-zinc-950/40"
+        style={{ height: WAVEFORM_BAND_HEIGHT_PX }}
+      />
+      <canvas
+        ref={canvasRef}
+        data-testid="graph-waveform-canvas"
+        className="absolute top-0"
+        style={{
+          transform: `translateX(${tickWindow.startX}px)`,
+          width: Math.max(1, Math.min(extent, tickWindow.endX - tickWindow.startX)),
+          height: WAVEFORM_BAND_HEIGHT_PX,
+        }}
+      />
     </div>
   );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-sub-timelines.tsx
@@ -35,6 +35,7 @@ import {
   GraphGridPlayhead,
   GraphPlayhead,
   GraphRuler,
+  GraphWaveformBand,
   GraphSeekRails,
   GraphStripSeekRail,
   collectionCardWidth,
@@ -100,6 +101,7 @@ function SubTimelineNode({
   pixelsPerSecond,
   previewOn,
   rulerOn,
+  waveformOn,
   timeChannel,
 }: Readonly<{
   projectId: string;
@@ -110,6 +112,7 @@ function SubTimelineNode({
   pixelsPerSecond: number;
   previewOn: boolean;
   rulerOn: boolean;
+  waveformOn: boolean;
   timeChannel: PreviewTimeChannel;
 }>) {
   const store = useCollectionsStore();
@@ -353,10 +356,17 @@ function SubTimelineNode({
                 trailingSlot={<AddCollectionSlot collectionId={id} />}
                 itemDragActivation="hold"
                 overlay={
-                  showPlayhead || rulerOn ? (
+                  showPlayhead || rulerOn || waveformOn ? (
                     <>
                       {rulerOn ? (
                         <GraphRuler
+                          focusedId={id}
+                          pixelsPerSecond={pixelsPerSecond}
+                          cardHeight={dims.strip}
+                        />
+                      ) : null}
+                      {waveformOn ? (
+                        <GraphWaveformBand
                           focusedId={id}
                           pixelsPerSecond={pixelsPerSecond}
                           cardHeight={dims.strip}
@@ -407,6 +417,7 @@ function SubTimelineNode({
                 pixelsPerSecond={pixelsPerSecond}
                 previewOn={previewOn}
                 rulerOn={rulerOn}
+                waveformOn={waveformOn}
                 timeChannel={timeChannel}
               />
             ))}
@@ -424,6 +435,7 @@ export function SubTimelines({
   pixelsPerSecond,
   previewOn,
   rulerOn,
+  waveformOn,
   timeChannel,
 }: Readonly<{
   projectId: string;
@@ -433,6 +445,7 @@ export function SubTimelines({
   pixelsPerSecond: number;
   previewOn: boolean;
   rulerOn: boolean;
+  waveformOn: boolean;
   timeChannel: PreviewTimeChannel;
 }>) {
   const childIds = useCollectionChildIds(parseNodeId(focusedId));
@@ -468,6 +481,7 @@ export function SubTimelines({
           pixelsPerSecond={pixelsPerSecond}
           previewOn={previewOn}
           rulerOn={rulerOn}
+          waveformOn={waveformOn}
           timeChannel={timeChannel}
         />
       ))}

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -250,6 +250,9 @@ export function GraphTimelineView({
   const [childrenShown, setChildrenShown] = useState(false);
   const [previewOn, setPreviewOn] = useState(false);
   const [rulerOn, setRulerOn] = useState(false);
+  // Waveform lane. Strip-only and flat-only for the same reason the ruler is:
+  // it draws against a single continuous time axis.
+  const [waveformOn, setWaveformOn] = useState(false);
   // Flat mode: every item in the focused closure, in order, no nesting.
   // Strip-only — grid has no equivalent, and leaving grid turns it off below.
   const [flatOn, setFlatOn] = useState(false);
@@ -281,6 +284,7 @@ export function GraphTimelineView({
   // a control that no longer lives there has no reason to pay for it.
   const toggleChildren = useCallback(() => setChildrenShown((current) => !current), []);
   const toggleRuler = useCallback(() => setRulerOn((current) => !current), []);
+  const toggleWaveform = useCallback(() => setWaveformOn((current) => !current), []);
 
   // …and this broadcast (on mount and every change) is what lets its
   // controls show the current surface, ruler, children, and preview state.
@@ -315,6 +319,9 @@ export function GraphTimelineView({
   if (prevFlatOn !== flatOn) {
     setPrevFlatOn(flatOn);
     if (!flatOn && rulerOn) setRulerOn(false);
+    // Same rule for the waveform lane: its control lives behind flat mode, so
+    // leaving flat must not strand a painted lane with no way to turn it off.
+    if (!flatOn && waveformOn) setWaveformOn(false);
   }
 
   // The closure hydration flat mode needs runs in `FlatClosureHydrator`, which
@@ -751,6 +758,8 @@ export function GraphTimelineView({
                 previewOn={previewOn}
                 rulerOn={rulerOn}
                 onRulerToggle={toggleRuler}
+                waveformOn={waveformOn}
+                onWaveformToggle={toggleWaveform}
                 flatOn={flatOn}
                 childrenShown={childrenShown}
                 onChildrenToggle={toggleChildren}

--- a/apps/timeline-gstudio001/components/graph-view/graph-waveform-model.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-waveform-model.ts
@@ -1,0 +1,97 @@
+import {
+  getChildren,
+  parseNodeId,
+  type CollectionsGraph,
+} from "@storyboard/collections-core";
+import type { DetailsById, FlatItem } from "@storyboard/timeline-domain";
+
+/**
+ * The PURE half of the waveform lane: which audio each drawn card refers to.
+ *
+ * `ChildSpan` (graph-playhead-model) carries a card's geometry but deliberately
+ * not its media — the playhead never needed it. The lane does: to draw a card's
+ * waveform it must know the source URL, the asset identity to cache under, and
+ * the trims, because two cards can show different windows of ONE file.
+ *
+ * No React, no DOM, for the same reason as its neighbour: the app's vitest globs
+ * `.test.ts` only, so the arithmetic lives here and the `.tsx` stays a shell.
+ */
+
+export type WaveformSource = Readonly<{
+  /** Cache key — the asset's durable id where there is one. */
+  key: string;
+  src: string;
+  /** Seconds removed from each end. NOT offsets into the source: the core's
+   *  `mediaDurationSeconds` computes `full - trimIn - trimOut`, and reading
+   *  these the other way is the bug that shipped in the MCP write path. */
+  trimIn: number;
+  trimOut: number;
+}>;
+
+type MediaLike = Readonly<{
+  kind: string;
+  mediaKind?: string;
+  src?: string;
+  trimInSeconds?: number;
+  trimOutSeconds?: number;
+}>;
+
+function sourceForNode(
+  graph: CollectionsGraph,
+  details: DetailsById,
+  nodeId: string,
+): WaveformSource | null {
+  const node = graph.nodesById.get(parseNodeId(nodeId)) as MediaLike | undefined;
+  // Collections have no audio of their own, and an image has none at all.
+  if (!node || node.kind !== "media" || node.mediaKind !== "video") return null;
+  if (!node.src) return null;
+
+  const asset = details[nodeId]?.sourceAsset;
+  return {
+    // Asset-keyed so one upload placed five times decodes once; the src is the
+    // fallback for clips minted before provenance was recorded.
+    key: asset ? `${asset.providerId}:${asset.assetId}` : `src:${node.src}`,
+    src: node.src,
+    trimIn: node.trimInSeconds ?? 0,
+    trimOut: node.trimOutSeconds ?? 0,
+  };
+}
+
+/**
+ * One entry per drawn card, index-aligned with `cardsFor`'s spans — `null` where
+ * the card has no audio to draw (a collection, an image, a missing node).
+ *
+ * The alignment is the whole contract: the lane pairs `sources[i]` with
+ * `cards[i]`, so this must walk children in exactly the order the span builders
+ * do — `flatCardSpans` over `items`, `childSpans` over `getChildren`.
+ */
+export function waveformSourcesFor(
+  graph: CollectionsGraph,
+  details: DetailsById,
+  focusedId: string,
+  flatItems: readonly FlatItem[] | null,
+): Array<WaveformSource | null> {
+  if (flatItems) {
+    return flatItems.map((item) => sourceForNode(graph, details, item.nodeId as string));
+  }
+  return getChildren(graph, parseNodeId(focusedId)).map((childId) =>
+    sourceForNode(graph, details, childId as string),
+  );
+}
+
+/**
+ * The distinct assets a set of sources needs, so the lane can request each once
+ * rather than once per card.
+ */
+export function distinctWaveformKeys(
+  sources: ReadonlyArray<WaveformSource | null>,
+): WaveformSource[] {
+  const seen = new Set<string>();
+  const out: WaveformSource[] = [];
+  for (const source of sources) {
+    if (!source || seen.has(source.key)) continue;
+    seen.add(source.key);
+    out.push(source);
+  }
+  return out;
+}

--- a/apps/timeline-gstudio001/lib/waveform-cache.test.ts
+++ b/apps/timeline-gstudio001/lib/waveform-cache.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createWaveformCache, waveformKeyFor } from "./waveform-cache";
+
+/** A decoded buffer stand-in: one channel of a constant level. */
+function fakeBuffer(level: number, duration = 1) {
+  const data = new Float32Array(1000).fill(level);
+  return { getChannelData: () => data, duration };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("waveformKeyFor", () => {
+  it("keys on the asset, so one upload placed twice decodes once", () => {
+    const asset = { providerId: "cloudinary", assetId: "folder/render-123" };
+    const first = waveformKeyFor({ src: "https://cdn/a.mp4?v=1", sourceAsset: asset });
+    const second = waveformKeyFor({ src: "https://cdn/a.mp4?v=2", sourceAsset: asset });
+
+    // Different URLs, same asset — the URLs carry cache-busting versions.
+    expect(first).toBe(second);
+  });
+
+  it("falls back to src for clips minted before provenance existed", () => {
+    expect(waveformKeyFor({ src: "https://cdn/a.mp4" })).toBe("src:https://cdn/a.mp4");
+  });
+
+  it("returns null when there is nothing to key on", () => {
+    expect(waveformKeyFor({})).toBeNull();
+  });
+});
+
+describe("createWaveformCache", () => {
+  it("decodes once and serves the rest from memory", async () => {
+    const fetchBytes = vi.fn(async () => new ArrayBuffer(8));
+    const decode = vi.fn(async () => fakeBuffer(0.5));
+    const cache = createWaveformCache({ fetchBytes, decode });
+
+    await cache.request("asset-a", "https://cdn/a.mp4");
+    await cache.request("asset-a", "https://cdn/a.mp4");
+    await cache.request("asset-a", "https://cdn/a.mp4");
+
+    expect(fetchBytes).toHaveBeenCalledTimes(1);
+    expect(decode).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces concurrent requests for the same asset", async () => {
+    const gate = deferred<ArrayBuffer>();
+    const fetchBytes = vi.fn(() => gate.promise);
+    const decode = vi.fn(async () => fakeBuffer(0.5));
+    const cache = createWaveformCache({ fetchBytes, decode });
+
+    const a = cache.request("asset-a", "https://cdn/a.mp4");
+    const b = cache.request("asset-a", "https://cdn/a.mp4");
+    gate.resolve(new ArrayBuffer(8));
+    await Promise.all([a, b]);
+
+    // Two callers, one network trip — the strip asks per visible card.
+    expect(fetchBytes).toHaveBeenCalledTimes(1);
+  });
+
+  it("peek is synchronous and empty until the decode lands", async () => {
+    const gate = deferred<ArrayBuffer>();
+    const cache = createWaveformCache({
+      fetchBytes: () => gate.promise,
+      decode: async () => fakeBuffer(0.25),
+    });
+
+    const pending = cache.request("asset-a", "https://cdn/a.mp4");
+    // The paint path calls peek and must never await.
+    expect(cache.peek("asset-a")).toBeNull();
+
+    gate.resolve(new ArrayBuffer(8));
+    await pending;
+    expect(cache.peek("asset-a")).not.toBeNull();
+  });
+
+  it("caps concurrent decodes", async () => {
+    let active = 0;
+    let highWater = 0;
+    const gates: Array<() => void> = [];
+    const cache = createWaveformCache({
+      maxConcurrent: 2,
+      fetchBytes: async () => {
+        active += 1;
+        highWater = Math.max(highWater, active);
+        await new Promise<void>((resolve) => gates.push(resolve));
+        active -= 1;
+        return new ArrayBuffer(8);
+      },
+      decode: async () => fakeBuffer(0.5),
+    });
+
+    const all = Promise.all(
+      ["a", "b", "c", "d", "e"].map((key) => cache.request(key, `https://cdn/${key}.mp4`)),
+    );
+    // Let the admitted ones start, then drain.
+    await Promise.resolve();
+    await Promise.resolve();
+    while (gates.length > 0) {
+      gates.shift()?.();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    }
+    await all;
+
+    // Each decode pulls a whole file; five at once is what this prevents.
+    expect(highWater).toBeLessThanOrEqual(2);
+  });
+
+  it("remembers a failure instead of refetching on every scroll", async () => {
+    const fetchBytes = vi.fn(async () => {
+      throw new Error("network");
+    });
+    const cache = createWaveformCache({ fetchBytes, decode: async () => fakeBuffer(0.5) });
+
+    expect(await cache.request("asset-a", "https://cdn/a.mp4")).toBeNull();
+    expect(await cache.request("asset-a", "https://cdn/a.mp4")).toBeNull();
+
+    expect(fetchBytes).toHaveBeenCalledTimes(1);
+    expect(cache.peek("asset-a")).toBeNull();
+  });
+
+  it("treats an undecodable file as a failure, not a crash", async () => {
+    // A clip with no audio track, or a container the browser will not decode.
+    const cache = createWaveformCache({
+      fetchBytes: async () => new ArrayBuffer(8),
+      decode: async () => {
+        throw new Error("EncodingError");
+      },
+    });
+
+    await expect(cache.request("asset-a", "https://cdn/a.mp4")).resolves.toBeNull();
+  });
+
+  it("notifies subscribers when peaks land, so the lane can repaint", async () => {
+    const listener = vi.fn();
+    const cache = createWaveformCache({
+      fetchBytes: async () => new ArrayBuffer(8),
+      decode: async () => fakeBuffer(0.5),
+    });
+    cache.subscribe(listener);
+
+    await cache.request("asset-a", "https://cdn/a.mp4");
+
+    expect(listener).toHaveBeenCalled();
+  });
+
+  it("carries the decoded duration onto the peaks", async () => {
+    const cache = createWaveformCache({
+      fetchBytes: async () => new ArrayBuffer(8),
+      decode: async () => fakeBuffer(0.5, 5.167),
+    });
+
+    const peaks = await cache.request("asset-a", "https://cdn/a.mp4");
+    // peaksForWindow maps trims against this, so a wrong duration skews the lane.
+    expect(peaks?.durationSeconds).toBeCloseTo(5.167, 3);
+  });
+});

--- a/apps/timeline-gstudio001/lib/waveform-cache.ts
+++ b/apps/timeline-gstudio001/lib/waveform-cache.ts
@@ -1,0 +1,196 @@
+/**
+ * Peaks for the scrubbing waveform: fetch, decode, reduce, remember.
+ *
+ * Keyed by the ASSET, not the clip. One upload placed five times on a timeline
+ * decodes once — `sourceAsset.assetId` is the durable identity for exactly this
+ * (see docs/asset-providers.md), and falling back to the src URL keeps clips
+ * that predate provenance working.
+ *
+ * Nothing here is persisted to the timeline document. Peaks are derived data:
+ * putting them on the stored model would bloat every save (the gateway already
+ * warns when a document outgrows the keepalive budget) and would duplicate the
+ * same array once per placement.
+ *
+ * Decoding uses its OWN `OfflineAudioContext`, deliberately not the preview
+ * mixer's context: `audio-graph.ts` keeps a narrow context type on purpose, and
+ * routing media through it is a one-way door. Decoding wants none of that.
+ */
+
+import {
+  bucketCountFor,
+  computePeaks,
+  type Peaks,
+} from "@storyboard/ui/timeline/viewport/waveform-peaks";
+
+/** Each decode fetches a WHOLE file. A strip can hold dozens of clips, so the
+ *  cache admits a few at a time rather than opening every connection at once —
+ *  same reasoning as MAX_CONCURRENT_MEDIA on the upload path. */
+const MAX_CONCURRENT_DECODES = 3;
+
+/** Marks an asset we tried and could not decode, so scrolling past it does not
+ *  re-fetch the file every time. */
+const FAILED = "failed" as const;
+
+type Entry = Peaks | typeof FAILED;
+
+export type WaveformCache = {
+  /** Peaks if they are already known, else null. Synchronous — the drawing code
+   *  must never await inside a paint. */
+  peek: (key: string) => Peaks | null;
+  /** Kick off a decode if this asset has neither succeeded nor failed. Returns
+   *  the peaks when they land, or null. Safe to call repeatedly. */
+  request: (key: string, src: string) => Promise<Peaks | null>;
+  /** Called whenever an entry resolves, so a view can repaint. */
+  subscribe: (listener: () => void) => () => void;
+  size: () => number;
+  clear: () => void;
+};
+
+export type WaveformCacheOptions = {
+  /** Injected for tests; defaults to the real network. */
+  fetchBytes?: (src: string, signal: AbortSignal) => Promise<ArrayBuffer>;
+  /** Injected for tests; defaults to OfflineAudioContext.decodeAudioData. */
+  decode?: (bytes: ArrayBuffer) => Promise<{ getChannelData: (channel: number) => Float32Array; duration: number }>;
+  maxConcurrent?: number;
+};
+
+async function defaultFetchBytes(src: string, signal: AbortSignal): Promise<ArrayBuffer> {
+  // Same CORS story as the preview's media elements: the response must be
+  // readable, which Cloudinary allows (`Access-Control-Allow-Origin: *`).
+  const response = await fetch(src, { signal, mode: "cors" });
+  if (!response.ok) throw new Error(`waveform fetch failed: ${response.status}`);
+  return response.arrayBuffer();
+}
+
+async function defaultDecode(bytes: ArrayBuffer) {
+  const Ctor =
+    typeof window === "undefined"
+      ? undefined
+      : (window as unknown as { OfflineAudioContext?: new (channels: number, length: number, rate: number) => BaseAudioContext })
+          .OfflineAudioContext;
+  if (!Ctor) throw new Error("OfflineAudioContext unavailable");
+  // Length and rate are irrelevant to decoding; the context is only a decoder.
+  const context = new Ctor(1, 1, 44100);
+  return context.decodeAudioData(bytes);
+}
+
+export function createWaveformCache(options: WaveformCacheOptions = {}): WaveformCache {
+  const fetchBytes = options.fetchBytes ?? defaultFetchBytes;
+  const decode = options.decode ?? defaultDecode;
+  const maxConcurrent = Math.max(1, options.maxConcurrent ?? MAX_CONCURRENT_DECODES);
+
+  const entries = new Map<string, Entry>();
+  const inFlight = new Map<string, Promise<Peaks | null>>();
+  const queue: Array<() => void> = [];
+  const listeners = new Set<() => void>();
+  let active = 0;
+
+  function notify() {
+    for (const listener of listeners) listener();
+  }
+
+  function pump() {
+    while (active < maxConcurrent && queue.length > 0) {
+      const next = queue.shift();
+      if (next) {
+        active += 1;
+        next();
+      }
+    }
+  }
+
+  /** Resolves only when a slot frees up, which is what bounds concurrency. */
+  function acquire(): Promise<void> {
+    return new Promise((resolve) => {
+      queue.push(resolve);
+      pump();
+    });
+  }
+
+  function release() {
+    active = Math.max(0, active - 1);
+    pump();
+  }
+
+  async function load(key: string, src: string): Promise<Peaks | null> {
+    await acquire();
+    const controller = new AbortController();
+    try {
+      const bytes = await fetchBytes(src, controller.signal);
+      const buffer = await decode(bytes);
+      const duration = Number.isFinite(buffer.duration) ? buffer.duration : 0;
+      const peaks = computePeaks(
+        buffer.getChannelData(0),
+        bucketCountFor(duration),
+        duration,
+      );
+      entries.set(key, peaks);
+      return peaks;
+    } catch {
+      // A clip with no audio track, an unsupported container, or a network
+      // failure all land here. Remember the failure so the lane simply draws
+      // nothing for this asset instead of retrying on every scroll.
+      entries.set(key, FAILED);
+      return null;
+    } finally {
+      release();
+      inFlight.delete(key);
+      notify();
+    }
+  }
+
+  return {
+    peek(key) {
+      const entry = entries.get(key);
+      return entry === undefined || entry === FAILED ? null : entry;
+    },
+
+    request(key, src) {
+      const entry = entries.get(key);
+      if (entry === FAILED) return Promise.resolve(null);
+      if (entry !== undefined) return Promise.resolve(entry);
+
+      const existing = inFlight.get(key);
+      if (existing) return existing;
+
+      const promise = load(key, src);
+      inFlight.set(key, promise);
+      return promise;
+    },
+
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+
+    size: () => entries.size,
+
+    clear() {
+      entries.clear();
+      inFlight.clear();
+    },
+  };
+}
+
+/**
+ * The cache key for a clip: its asset's durable id when it has one, else the
+ * source URL. Two placements of one upload MUST agree here or the file is
+ * decoded twice.
+ */
+export function waveformKeyFor(
+  clip: Readonly<{ src?: string; sourceAsset?: Readonly<{ providerId: string; assetId: string }> }>,
+): string | null {
+  if (clip.sourceAsset) return `${clip.sourceAsset.providerId}:${clip.sourceAsset.assetId}`;
+  return clip.src ? `src:${clip.src}` : null;
+}
+
+/** Process-wide instance. The decoded result is identical for every view, so
+ *  sharing one cache is what makes the grid and the strip cheap together. */
+let shared: WaveformCache | null = null;
+
+export function sharedWaveformCache(): WaveformCache {
+  shared ??= createWaveformCache();
+  return shared;
+}

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -5454,6 +5454,47 @@ test.describe("graph view E2E", () => {
     expect(onThisTool).toBe(true);
   });
 
+  test("the waveform lane toggles on in flat mode and spans every card", async ({ page }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+
+    // Off by default, and its control lives behind flat mode like the ruler's.
+    await expect(page.locator("[data-graph-waveform]")).toHaveCount(0);
+    await page.getByRole("button", { name: "Show all items in order" }).click();
+    await page.getByRole("button", { name: /show audio waveform/i }).click();
+
+    const band = page.locator("[data-graph-waveform]");
+    await expect(band).toHaveCount(1);
+
+    // The lane is laid out against the SAME cumulative extent the playhead map
+    // walks, so a wrong extent silently misaligns every card's audio.
+    const extent = await band.getAttribute("data-waveform-extent");
+    expect(Number(extent)).toBeGreaterThan(0);
+
+    // Sound itself is unobservable here — the fixture's media is a data URI
+    // with no audio track, so nothing ever decodes. The canvas existing at the
+    // right size is the honest assertion; the DRAWING is covered by
+    // waveform-peaks.test.ts and was verified against real clips by hand.
+    const canvas = page.getByTestId("graph-waveform-canvas");
+    await expect(canvas).toBeAttached();
+
+    await page.getByRole("button", { name: /hide audio waveform/i }).click();
+    await expect(page.locator("[data-graph-waveform]")).toHaveCount(0);
+  });
+
+  test("leaving flat mode takes the waveform lane with it", async ({ page }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    await page.getByRole("button", { name: "Show all items in order" }).click();
+    await page.getByRole("button", { name: /show audio waveform/i }).click();
+    await expect(page.locator("[data-graph-waveform]")).toHaveCount(1);
+
+    // Same rule the ruler follows: the control only exists in flat mode, so
+    // leaving flat must not strand a painted lane with no way to turn it off.
+    await page.getByRole("button", { name: "Show collections" }).click();
+    await expect(page.locator("[data-graph-waveform]")).toHaveCount(0);
+  });
+
   test("the ruler renders on EVERY displayed strip, not just the focused one", async ({
     page,
   }) => {

--- a/packages/ui/timeline/viewport/waveform-peaks.test.ts
+++ b/packages/ui/timeline/viewport/waveform-peaks.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  bucketCountFor,
+  computePeaks,
+  peakMagnitude,
+  peaksForWindow,
+  PEAK_BUCKETS_PER_SECOND,
+} from "./waveform-peaks";
+
+/** Read one bucket's [min, max] out of the interleaved array. */
+function bucket(values: Float32Array, index: number): [number, number] {
+  return [values[index * 2], values[index * 2 + 1]];
+}
+
+/** Compare a bucket with tolerance: these are Float32Array cells, so a literal
+ *  like -0.4 reads back as -0.4000000059604645 and exact equality is a trap. */
+function expectBucket(values: Float32Array, index: number, min: number, max: number) {
+  const [actualMin, actualMax] = bucket(values, index);
+  expect(actualMin).toBeCloseTo(min, 5);
+  expect(actualMax).toBeCloseTo(max, 5);
+}
+
+describe("computePeaks", () => {
+  it("keeps min AND max, so an asymmetric signal stays asymmetric", () => {
+    // A waveform drawn from absolute values would report these identically.
+    const peaks = computePeaks([-0.2, 0.9], 1, 1);
+    expectBucket(peaks.values, 0, -0.2, 0.9);
+  });
+
+  it("splits samples across buckets", () => {
+    const peaks = computePeaks([1, 1, -1, -1], 2, 1);
+    expect(bucket(peaks.values, 0)).toEqual([1, 1]);
+    expect(bucket(peaks.values, 1)).toEqual([-1, -1]);
+  });
+
+  it("reaches the LAST sample rather than stopping a stride short", () => {
+    // 7 samples into 2 buckets: a rounded stride of 3 would never read index 6.
+    const peaks = computePeaks([0, 0, 0, 0, 0, 0, 0.75], 2, 1);
+    expect(bucket(peaks.values, 1)[1]).toBe(0.75);
+  });
+
+  it("reports silence as a flat pair, not as noise", () => {
+    const peaks = computePeaks(new Float32Array(100), 4, 1);
+    expect(Array.from(peaks.values)).toEqual([0, 0, 0, 0, 0, 0, 0, 0]);
+  });
+
+  it("survives an empty source", () => {
+    const peaks = computePeaks([], 4, 2);
+    expect(peaks.values).toHaveLength(8);
+    expect(peakMagnitude(peaks.values)).toBe(0);
+    expect(peaks.durationSeconds).toBe(2);
+  });
+
+  it("ignores non-finite samples instead of poisoning the bucket", () => {
+    const peaks = computePeaks([Number.NaN, 0.5, Number.POSITIVE_INFINITY], 1, 1);
+    expect(bucket(peaks.values, 0)).toEqual([0.5, 0.5]);
+  });
+
+  it("clamps a nonsense bucket count to one", () => {
+    expect(computePeaks([1, 2, 3], 0, 1).values).toHaveLength(2);
+    expect(computePeaks([1, 2, 3], -5, 1).values).toHaveLength(2);
+  });
+});
+
+describe("bucketCountFor", () => {
+  it("scales with duration at the fixed rate", () => {
+    expect(bucketCountFor(1)).toBe(PEAK_BUCKETS_PER_SECOND);
+    expect(bucketCountFor(10)).toBe(PEAK_BUCKETS_PER_SECOND * 10);
+  });
+
+  it("never returns zero for a degenerate duration", () => {
+    expect(bucketCountFor(0)).toBe(1);
+    expect(bucketCountFor(-3)).toBe(1);
+    expect(bucketCountFor(Number.NaN)).toBe(1);
+  });
+});
+
+describe("peaksForWindow", () => {
+  /** 4 buckets over 4 seconds, each second a distinct level. */
+  const peaks = {
+    values: new Float32Array([-0.1, 0.1, -0.2, 0.2, -0.3, 0.3, -0.4, 0.4]),
+    durationSeconds: 4,
+  };
+
+  it("returns the whole source when nothing is trimmed", () => {
+    const out = peaksForWindow(peaks, 0, 0, 4);
+    expectBucket(out, 0, -0.1, 0.1);
+    expectBucket(out, 3, -0.4, 0.4);
+  });
+
+  it("treats trims as amounts REMOVED from each end", () => {
+    // 1s off the front and 1s off the back of a 4s source leaves buckets 1..2.
+    // This is the convention `mediaDurationSeconds` uses; reading them as
+    // absolute offsets is the bug that shipped in the MCP write path.
+    const out = peaksForWindow(peaks, 1, 1, 2);
+    expectBucket(out, 0, -0.2, 0.2);
+    expectBucket(out, 1, -0.3, 0.3);
+  });
+
+  it("shows only the tail when the head is trimmed", () => {
+    const out = peaksForWindow(peaks, 3, 0, 1);
+    expectBucket(out, 0, -0.4, 0.4);
+  });
+
+  it("returns silence when the trims consume the whole clip", () => {
+    // Not a stretched full view: there is no audio in this window.
+    const out = peaksForWindow(peaks, 2, 2, 4);
+    expect(peakMagnitude(out)).toBe(0);
+  });
+
+  it("returns silence rather than inverting when trims exceed the source", () => {
+    const out = peaksForWindow(peaks, 5, 5, 4);
+    expect(peakMagnitude(out)).toBe(0);
+  });
+
+  it("repeats buckets when asked for more detail than it stores", () => {
+    // Zooming past the stored resolution must not read empty ranges and draw
+    // gaps where there is sound.
+    const out = peaksForWindow(peaks, 0, 0, 16);
+    for (let i = 0; i < 16; i += 1) {
+      expect(Math.abs(bucket(out, i)[1])).toBeGreaterThan(0);
+    }
+  });
+
+  it("takes the extremes when several source buckets fold into one", () => {
+    const out = peaksForWindow(peaks, 0, 0, 1);
+    expectBucket(out, 0, -0.4, 0.4);
+  });
+
+  it("survives an empty peaks array", () => {
+    const out = peaksForWindow({ values: new Float32Array(0), durationSeconds: 5 }, 0, 0, 4);
+    expect(out).toHaveLength(8);
+    expect(peakMagnitude(out)).toBe(0);
+  });
+
+  it("returns silence for a zero-duration source", () => {
+    const out = peaksForWindow({ values: peaks.values, durationSeconds: 0 }, 0, 0, 4);
+    expect(peakMagnitude(out)).toBe(0);
+  });
+});
+
+describe("peakMagnitude", () => {
+  it("finds the loudest absolute value across both rails", () => {
+    expect(peakMagnitude(new Float32Array([-0.9, 0.2]))).toBeCloseTo(0.9, 5);
+  });
+
+  it("is zero for silence, which callers must not divide by", () => {
+    expect(peakMagnitude(new Float32Array([0, 0, 0, 0]))).toBe(0);
+  });
+});

--- a/packages/ui/timeline/viewport/waveform-peaks.ts
+++ b/packages/ui/timeline/viewport/waveform-peaks.ts
@@ -1,0 +1,174 @@
+/**
+ * Waveform peaks: the arithmetic behind the scrubbing waveform.
+ *
+ * Pure of React and the DOM, like `playback-skip.ts` and `audio-graph.ts` beside
+ * it — decoding and drawing live elsewhere, so all of this tests in a node
+ * environment (the app's vitest globs `.test.ts` only, see
+ * `graph-playhead-model.ts`).
+ *
+ * Peaks are stored PER ASSET at a fixed resolution, never per clip. Two clips
+ * can share one asset at different trims, and the zoom slider changes card width
+ * continuously — so the stored array is the whole source at a known bucket rate,
+ * and `peaksForWindow` re-samples it to whatever the card currently needs.
+ */
+
+/** Buckets per second of source. Fine enough that a syllable is visible at
+ *  normal zoom, coarse enough that a 60s clip is ~2400 pairs rather than
+ *  millions of samples. */
+export const PEAK_BUCKETS_PER_SECOND = 40;
+
+/**
+ * A min/max envelope, interleaved as `[min0, max0, min1, max1, …]`.
+ *
+ * Min AND max, not absolute peak: a waveform drawn from absolute values is
+ * symmetric and loses the asymmetry that makes speech read as speech. One flat
+ * array rather than two, so it survives a JSON round trip cheaply.
+ */
+export type Peaks = Readonly<{
+  /** Interleaved min/max pairs; length is `bucketCount * 2`. */
+  values: Float32Array;
+  /** Source seconds the array covers — needed to map a trim window onto it. */
+  durationSeconds: number;
+}>;
+
+function clampIndex(value: number, max: number): number {
+  if (!Number.isFinite(value) || value < 0) return 0;
+  if (value > max) return max;
+  return Math.floor(value);
+}
+
+/**
+ * Reduce raw mono samples to `bucketCount` min/max pairs.
+ *
+ * Buckets are computed from exact fractional boundaries rather than a rounded
+ * stride: a rounded stride drifts, and over a long clip the last bucket ends up
+ * reading a different amount of audio than the first.
+ */
+export function computePeaks(
+  samples: ArrayLike<number>,
+  bucketCount: number,
+  durationSeconds: number,
+): Peaks {
+  const buckets = Math.max(1, Math.floor(bucketCount));
+  const values = new Float32Array(buckets * 2);
+  const length = samples.length;
+
+  if (length === 0) {
+    return { values, durationSeconds: Math.max(0, durationSeconds) };
+  }
+
+  for (let bucket = 0; bucket < buckets; bucket += 1) {
+    const start = clampIndex((bucket * length) / buckets, length - 1);
+    // The final bucket must reach the LAST sample, not stop a stride short.
+    const rawEnd = ((bucket + 1) * length) / buckets;
+    const end = bucket === buckets - 1 ? length : clampIndex(rawEnd, length);
+
+    let min = 0;
+    let max = 0;
+    let seen = false;
+    for (let i = start; i < end; i += 1) {
+      const value = samples[i];
+      if (!Number.isFinite(value)) continue;
+      if (!seen) {
+        min = value;
+        max = value;
+        seen = true;
+        continue;
+      }
+      if (value < min) min = value;
+      if (value > max) max = value;
+    }
+
+    values[bucket * 2] = min;
+    values[bucket * 2 + 1] = max;
+  }
+
+  return { values, durationSeconds: Math.max(0, durationSeconds) };
+}
+
+/** How many buckets a source of this length should be reduced to. */
+export function bucketCountFor(durationSeconds: number): number {
+  if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) return 1;
+  return Math.max(1, Math.round(durationSeconds * PEAK_BUCKETS_PER_SECOND));
+}
+
+/**
+ * Re-sample an asset's peaks to the clip's visible window.
+ *
+ * `trimIn` / `trimOut` are AMOUNTS REMOVED from each end — the convention the
+ * core uses (`mediaDurationSeconds` computes `full - trimIn - trimOut`), and the
+ * one that cost a bug in the MCP write path. An untrimmed clip is 0/0.
+ *
+ * Returns `outBuckets` interleaved min/max pairs covering only the played span,
+ * so the drawing code maps bucket index straight to x across the card.
+ */
+export function peaksForWindow(
+  peaks: Peaks,
+  trimIn: number,
+  trimOut: number,
+  outBuckets: number,
+): Float32Array {
+  const count = Math.max(1, Math.floor(outBuckets));
+  const out = new Float32Array(count * 2);
+  const totalBuckets = Math.floor(peaks.values.length / 2);
+  if (totalBuckets === 0) return out;
+
+  const duration = peaks.durationSeconds;
+  const safeIn = Number.isFinite(trimIn) && trimIn > 0 ? trimIn : 0;
+  const safeOut = Number.isFinite(trimOut) && trimOut > 0 ? trimOut : 0;
+  const played = duration - safeIn - safeOut;
+  // A window trimmed to nothing (or a clip whose trims exceed its source) has
+  // no audio to show. Silence is the honest answer, not a stretched full view.
+  if (!(played > 0) || !(duration > 0)) return out;
+
+  const startBucket = (safeIn / duration) * totalBuckets;
+  const endBucket = ((duration - safeOut) / duration) * totalBuckets;
+  const span = endBucket - startBucket;
+
+  for (let i = 0; i < count; i += 1) {
+    const from = startBucket + (i * span) / count;
+    const to = startBucket + ((i + 1) * span) / count;
+    const fromIndex = clampIndex(from, totalBuckets - 1);
+    // Always consume at least one source bucket: zooming in past the stored
+    // resolution must repeat buckets, not read an empty range and draw a gap.
+    const toIndex = Math.max(fromIndex + 1, clampIndex(to, totalBuckets));
+
+    let min = 0;
+    let max = 0;
+    let seen = false;
+    for (let b = fromIndex; b < toIndex && b < totalBuckets; b += 1) {
+      const bucketMin = peaks.values[b * 2];
+      const bucketMax = peaks.values[b * 2 + 1];
+      if (!seen) {
+        min = bucketMin;
+        max = bucketMax;
+        seen = true;
+        continue;
+      }
+      if (bucketMin < min) min = bucketMin;
+      if (bucketMax > max) max = bucketMax;
+    }
+
+    out[i * 2] = min;
+    out[i * 2 + 1] = max;
+  }
+
+  return out;
+}
+
+/**
+ * The loudest absolute value across an envelope, for normalising the draw.
+ *
+ * Generated renders come out quiet and inconsistent — the clips this was built
+ * against peaked between -17 and -11 dB — so drawing raw amplitude makes a whole
+ * lane look flat. Returns 0 for silence, and callers must not divide by it
+ * blindly.
+ */
+export function peakMagnitude(values: Float32Array): number {
+  let peak = 0;
+  for (let i = 0; i < values.length; i += 1) {
+    const magnitude = Math.abs(values[i]);
+    if (magnitude > peak) peak = magnitude;
+  }
+  return peak;
+}


### PR DESCRIPTION
## What

Preview audio plays (#273), so the cut can be heard — but not seen. This draws each clip's waveform along the bottom of its card, so you can find a pause, a line landing, or a silent stretch without scrubbing blind.

Toggle sits beside the ruler's, flat mode only (both draw against one continuous time axis).

## The gating risk, retired first

Whether `decodeAudioData` handles an MP4 *video* container at all. Measured against a real clip before writing any feature code: **5.167s of AAC-in-MP4 decoded in 16ms**. If that had failed the whole approach would have changed.

## Why client-side peaks, not Cloudinary

- **Every clip that already exists has no stored peaks and never will**, so an on-demand path was required regardless. Building it first covers everything with no timeline-model change; upload-time precompute can layer on later as a cache warm-up rather than a prerequisite.
- Cloudinary can render a waveform **image** server-side, and it's the wrong tool: card width is `durationToWidth(clip.duration, pixelsPerSecond)`, a live function of the zoom slider, so a fixed image rescales badly — and it would leave the Firebase upload path with no equivalent, i.e. two code paths forever.

## Three parts

- **`packages/ui/timeline/viewport/waveform-peaks.ts`** — pure min/max envelope reduction plus re-sampling an asset's peaks onto a clip's *trimmed* window. Min AND max, not absolute peak: a symmetric waveform loses the asymmetry that makes speech read as speech. Trims are amounts REMOVED from each end, matching `mediaDurationSeconds`.
- **`apps/timeline-gstudio001/lib/waveform-cache.ts`** — fetch, decode via a **dedicated `OfflineAudioContext`** (not the preview mixer's — that type is deliberately narrow and routing through it is a one-way door), cache by `sourceAsset.assetId` so one upload placed five times decodes once. Concurrency-capped because each decode pulls a whole file; failures are remembered so scrolling past a silent clip doesn't refetch.
- **`GraphWaveformBand`** — one canvas, the first in the rails layer, sized to the **visible window** rather than the full extent: at high zoom the extent runs past the browser's max canvas width. Walks the same cumulative `x += width + STRIP_GAP_PX` the playhead map does, so a card's audio lines up with its frames.

## Placement

The lane sits along the **bottom** of the cards. It was under the ruler first, which stacked two lanes over the top third of every thumbnail. Padding can't fix that — the overlay lives *inside* the padded box, so it moves down with the cards. The bottom edge is where audio sits in any editor and where the frame carries least.

## Verification

Not just green tests — checked against the real clips in Demo one by reading canvas pixels:

| Window | Bar height |
|---|---|
| The 0.39s pause ffmpeg measures at 1.66s | **1.0** (flat) |
| Surrounding speech at 2.6–3.4s | **10.0** |

A 10× ratio exactly where the silence is, and the inter-card gap draws nothing.

- 20 unit tests on the peaks math (bucket reduction, trim mapping, silence, zoom past stored resolution, degenerate inputs)
- 11 on the cache (asset-keyed, coalescing, concurrency cap, negative caching, sync `peek`)
- 2 e2e (toggle on/off, and leaving flat mode takes the lane with it)

Green: 608 app, 496 unit, 170 storybook, 145 graph-view e2e, `tsc --noEmit` clean in both packages, lint unchanged.

## Not done

**No Storybook story for the band.** The `cache` prop seam exists so one can inject synthetic peaks without decoding, but the story itself isn't written — it needs the collections store, details store and preview contexts stood up, and the math it would cover is already unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)