### PR TITLE
Give the MCP endpoint a working delete, and stop duplicate refs bricking a project

### DIFF
--- a/apps/timeline-gstudio001/app/api/mcp/route.ts
+++ b/apps/timeline-gstudio001/app/api/mcp/route.ts
@@ -254,12 +254,16 @@ const handler = createMcpHandler(
 
     server.tool(
       "remove_clip",
-      "Move a clip to the trash. This is recoverable — nothing is hard-deleted, so the clip can be restored from the bin." +
+      "Move a clip OR a collection to the trash. This is recoverable — nothing is hard-deleted, so it can be restored from the bin." +
         NO_LIVE_PUSH_NOTE,
       {
-        timelineId: z.string().min(1).describe("The timeline document that contains the clip."),
-        nodeId: z.string().min(1).describe("The clip to remove."),
-        trashId: z.string().min(1).describe("The trash collection's id, from read_timeline."),
+        timelineId: z.string().min(1).describe("The timeline document that contains the item."),
+        nodeId: z.string().min(1).describe("The clip or collection to remove."),
+        trashId: z
+          .string()
+          .min(1)
+          .optional()
+          .describe("Rarely needed — defaults to your own bin, which is where removals go."),
       },
       async (args, extra) => {
         const uid = uidFrom(extra);

--- a/apps/timeline-gstudio001/lib/mcp/apply-command.test.ts
+++ b/apps/timeline-gstudio001/lib/mcp/apply-command.test.ts
@@ -173,12 +173,17 @@ describe("applyCollectionsCommand", () => {
       OWNER,
     );
 
+    // Asserted unconditionally. Guarding on `result.kind === "error"` made this
+    // vacuous: a denied read is swallowed into an EMPTY substitute document, so
+    // the root IS present and the failure arrives as a reducer `rejected`
+    // (missing node), never the `error` branch — the assertions never ran.
     expect(result.ok).toBe(false);
-    if (!result.ok && result.kind === "error") {
-      // Same wording as a genuinely absent id — knowing an id is not a claim to it.
-      expect(result.message).toContain("No timeline document");
-      expect(result.message).not.toMatch(/authoriz|permission|owner/i);
-    }
+    if (result.ok) throw new Error("expected a refusal");
+    // Whatever shape it takes, it must not say WHY — knowing an id is not a
+    // claim to it.
+    const message =
+      result.kind === "error" ? result.message : JSON.stringify(result.rejection);
+    expect(message).not.toMatch(/authoriz|permission|owner/i);
     expect(storedClipIds("root")).toEqual(["a"]);
   });
 

--- a/apps/timeline-gstudio001/lib/mcp/apply-command.ts
+++ b/apps/timeline-gstudio001/lib/mcp/apply-command.ts
@@ -1,11 +1,14 @@
 import {
   applyCommand,
+  buildGraph,
   type CollectionsCommand,
   type CollectionsGraph,
   type CommandRejection,
+  type GraphNodeSpec,
 } from "@storyboard/collections-core";
 import {
   buildFocusedGraph,
+  buildHydrationSpecs,
   collectAffectedCollectionIds,
   graphChildrenToClips,
   type DetailsById,
@@ -17,7 +20,8 @@ import {
   TimelineRevisionConflictError,
   type TimelineBatchWrite,
 } from "@/lib/firebase-timeline-store";
-import { loadTimelineClosure } from "@/lib/load-timeline-closure";
+import { loadTimelineClosure, TimelineClosureTooLargeError } from "@/lib/load-timeline-closure";
+import { serveTrashDocument } from "@/lib/serve-timeline";
 import { TimelineAccessDeniedError } from "@/lib/timeline-ownership";
 
 // The server-side twin of the in-page dispatch path. WebMCP tools mutate the
@@ -67,6 +71,74 @@ function syncRenameIntoDetails(
   return {
     ...details,
     [command.nodeId as string]: { ...existing, title: command.name } as DetailsById[string],
+  };
+}
+
+export type ApplyCommandOptions = Readonly<{
+  /**
+   * Also load the requester's trash as a SECOND graph root, so a command can
+   * move nodes into it. Off by default: the other tools never target the bin,
+   * and loading it costs a second closure read.
+   */
+  includeTrash?: boolean;
+}>;
+
+/**
+ * The requester's own bin. Derived from the VERIFIED uid, never from tool
+ * arguments — `checkUserScopedId` only ever accepts `trash-<requesterUid>`, so
+ * deriving it is both the correct id and the only reachable one.
+ */
+export function trashDocumentIdFor(requesterUid: string): string {
+  return `trash-${requesterUid}`;
+}
+
+/**
+ * A graph spanning the project AND the trash, mirroring the in-page boot's
+ * `buildGraph([projectRoot, trashRoot])`.
+ *
+ * `buildHydrationSpecs` takes the already-used ids so a node reachable from
+ * both roots demotes to a reference card instead of colliding — node ids must
+ * be unique across the WHOLE graph, not per root.
+ */
+function buildRootsGraph(
+  documents: Record<string, TimelineDocument>,
+  rootTimelineId: string,
+  trashId: string,
+): Readonly<{ ok: true; value: { graph: CollectionsGraph; details: DetailsById } }
+  | Readonly<{ ok: false; error: string }>> {
+  const rootSpecs = buildHydrationSpecs(documents, rootTimelineId, HYDRATE_ALL_LEVELS);
+  if (!rootSpecs.ok) return rootSpecs;
+  const trashSpecs = buildHydrationSpecs(documents, trashId, HYDRATE_ALL_LEVELS, [
+    rootTimelineId,
+    ...Object.keys(rootSpecs.value.details),
+  ]);
+  if (!trashSpecs.ok) return trashSpecs;
+
+  const roots: GraphNodeSpec[] = [
+    {
+      kind: "collection",
+      id: rootTimelineId,
+      name: documents[rootTimelineId].title,
+      children: rootSpecs.value.specs,
+    },
+    {
+      kind: "collection",
+      id: trashId,
+      name: documents[trashId].title || "Trash Bin",
+      children: trashSpecs.value.specs,
+    },
+  ];
+
+  const built = buildGraph(roots);
+  if (!built.ok) {
+    return { ok: false, error: `Could not build graph: ${JSON.stringify(built.error)}` };
+  }
+  return {
+    ok: true,
+    value: {
+      graph: built.value,
+      details: { ...rootSpecs.value.details, ...trashSpecs.value.details },
+    },
   };
 }
 
@@ -135,18 +207,57 @@ export async function applyCollectionsCommand(
   rootTimelineId: string,
   commandOrBuilder: CollectionsCommand | CommandBuilder,
   requesterUid: string,
+  options: ApplyCommandOptions = {},
 ): Promise<ApplyCommandOutcome> {
   // The closure loader reads through `getFirebaseTimelineEntry`, which enforces
   // ownership, but it swallows the refusal (`.catch(() => null)`) and reports
   // the document as missing. That is the behaviour we want here too: a denied
   // id and an absent id are indistinguishable to the caller, so knowing an id
   // is not a claim to it. The write below re-checks ownership and throws.
-  const { documents, revisions } = await loadTimelineClosure(rootTimelineId, requesterUid);
+  let loaded: Awaited<ReturnType<typeof loadTimelineClosure>>;
+  try {
+    loaded = await loadTimelineClosure(rootTimelineId, requesterUid);
+  } catch (error) {
+    // The loader THROWS past its own budget. Report it as a tool error rather
+    // than letting it escape the handler as a 500 — including the trash
+    // closure below makes the ceiling easier to reach.
+    if (error instanceof TimelineClosureTooLargeError) {
+      return { ok: false, kind: "error", message: error.message };
+    }
+    throw error;
+  }
+  const documents: Record<string, TimelineDocument> = { ...loaded.documents };
+  const revisions: Record<string, number> = { ...loaded.revisions };
   if (!documents[rootTimelineId]) {
     return { ok: false, kind: "error", message: `No timeline document with id "${rootTimelineId}".` };
   }
 
-  const built = buildFocusedGraph(documents, rootTimelineId, HYDRATE_ALL_LEVELS);
+  // The trash is a SIBLING ROOT, never a collection clip inside a project, so
+  // it is absent from the project's closure and a command targeting it would be
+  // rejected as `missing-node`. Load it as a second root, exactly as the
+  // in-page boot does (graph-timeline-view.tsx) — that is the only way a
+  // remove can reach the bin.
+  const trashId = options.includeTrash ? trashDocumentIdFor(requesterUid) : null;
+  if (trashId) {
+    const served = await serveTrashDocument(trashId, requesterUid);
+    const trashClosure = await loadTimelineClosure(trashId, requesterUid, {
+      rootEntry: { document: served.document, revision: served.revision },
+    });
+    for (const [id, document] of Object.entries(trashClosure.documents)) {
+      documents[id] ??= document;
+    }
+    for (const [id, revision] of Object.entries(trashClosure.revisions)) {
+      revisions[id] ??= revision;
+    }
+    // `serveTrashDocument` defaults a not-yet-created bin to revision 0, so the
+    // existing compare-and-set write CREATES it on first use.
+    documents[trashId] = served.document;
+    revisions[trashId] ??= served.revision;
+  }
+
+  const built = trashId
+    ? buildRootsGraph(documents, rootTimelineId, trashId)
+    : buildFocusedGraph(documents, rootTimelineId, HYDRATE_ALL_LEVELS);
   if (!built.ok) return { ok: false, kind: "error", message: built.error };
 
   let command: CollectionsCommand;

--- a/apps/timeline-gstudio001/lib/mcp/remove-clip.test.ts
+++ b/apps/timeline-gstudio001/lib/mcp/remove-clip.test.ts
@@ -1,0 +1,244 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
+
+// `remove_clip` end to end, against the same in-memory Firestore double the rest
+// of lib/mcp uses — the store, the graph adapter and the reducer all run for
+// real, because the thing worth proving is that a removal reaches a bin that
+// lives OUTSIDE the project's closure.
+//
+// It could not, before: `trashId` was a required argument sourced "from
+// read_timeline", but the trash is a sibling root and never appears in a project
+// read, so every call failed with `No trash collection with id`.
+
+type Stored = Record<string, unknown>;
+
+const state = vi.hoisted(() => {
+  const docs = new Map<string, Stored>();
+  const applySet = (id: string, data: Stored, opts?: { merge?: boolean }) => {
+    const existing = docs.get(id);
+    docs.set(id, opts?.merge && existing ? { ...existing, ...data } : { ...data });
+  };
+  const snapshot = (id: string) => {
+    const data = docs.get(id);
+    return {
+      id,
+      exists: data !== undefined,
+      data: () => (data ? { ...data } : undefined),
+      get: (field: string) => (data ? data[field] : undefined),
+    };
+  };
+  const docRef = (id: string) => ({
+    id,
+    get: async () => snapshot(id),
+    set: async (data: Stored, opts?: { merge?: boolean }) => applySet(id, data, opts),
+    delete: async () => {
+      docs.delete(id);
+    },
+  });
+  type Tx = {
+    get: (ref: { id: string }) => Promise<ReturnType<typeof snapshot>>;
+    set: (ref: { id: string }, data: Stored, opts?: { merge?: boolean }) => void;
+  };
+  const db = {
+    collection: () => ({
+      doc: docRef,
+      where: () => ({ orderBy: () => ({ limit: () => ({ get: async () => ({ docs: [] }) }) }) }),
+    }),
+    runTransaction: async <T>(fn: (tx: Tx) => Promise<T>): Promise<T> => {
+      const staged: Array<[string, Stored, { merge?: boolean } | undefined]> = [];
+      const tx: Tx = {
+        get: async (ref) => snapshot(ref.id),
+        set: (ref, data, opts) => {
+          staged.push([ref.id, data, opts]);
+        },
+      };
+      const result = await fn(tx);
+      for (const [id, data, opts] of staged) applySet(id, data, opts);
+      return result;
+    },
+  };
+  return { docs, db };
+});
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/firebase-admin", () => ({ getFirebaseDb: () => state.db }));
+vi.mock("firebase-admin/firestore", () => {
+  class Timestamp {
+    toDate() {
+      return new Date(0);
+    }
+  }
+  return { Timestamp, FieldValue: { serverTimestamp: () => new Timestamp() } };
+});
+
+import { handleRemoveClip } from "./write-handlers";
+
+const OWNER = "user-a";
+const TRASH = `trash-${OWNER}`;
+
+function clip(id: string): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "image",
+    src: "https://example.test/img.jpg",
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 4,
+    sourceDuration: 4,
+    trimIn: 0,
+    trimOut: 0,
+  };
+}
+
+function collectionClip(id: string): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "collection",
+    title: id,
+    // A collection clip's stored id equals its childTimelineId — the shape the
+    // whole app mints, and the one that used to break the graph build.
+    childTimelineId: id,
+    alt: `${id} collection`,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    itemCount: 0,
+    duration: 3,
+    sourceDuration: 3,
+    trimIn: 0,
+    trimOut: 0,
+  };
+}
+
+function seed(id: string, clips: TimelineClip[], ownerUid = OWNER, revision = 1) {
+  const document: TimelineDocument = { id, title: id, clips };
+  state.docs.set(id, { ...document, ownerUid, revision });
+  return document;
+}
+
+function storedClipIds(id: string): string[] {
+  const data = state.docs.get(id) as { clips?: TimelineClip[] } | undefined;
+  return (data?.clips ?? []).map((c) => c.id);
+}
+
+function textOf(result: Awaited<ReturnType<typeof handleRemoveClip>>): string {
+  return result.content.map((part) => ("text" in part ? part.text : "")).join(" ");
+}
+
+beforeEach(() => {
+  state.docs.clear();
+});
+
+describe("handleRemoveClip", () => {
+  it("removes a clip with no trashId, creating the bin on first use", async () => {
+    seed("root", [clip("a"), clip("b")]);
+
+    const result = await handleRemoveClip(
+      { timelineId: "root", nodeId: "a" },
+      { requesterUid: OWNER },
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(storedClipIds("root")).toEqual(["b"]);
+    // The bin did not exist — the revision-0 compare-and-set created it.
+    expect(storedClipIds(TRASH)).toEqual(["a"]);
+  });
+
+  it("appends to a bin that already holds something", async () => {
+    seed("root", [clip("a"), clip("keep")]);
+    seed(TRASH, [clip("older")]);
+
+    await handleRemoveClip({ timelineId: "root", nodeId: "a" }, { requesterUid: OWNER });
+
+    expect(storedClipIds(TRASH)).toEqual(["older", "a"]);
+  });
+
+  it("stamps where the item came from, for the bin's row caption", async () => {
+    seed("root", [clip("a"), clip("keep")]);
+
+    await handleRemoveClip({ timelineId: "root", nodeId: "a" }, { requesterUid: OWNER });
+
+    const trashed = (state.docs.get(TRASH) as { clips?: TimelineClip[] }).clips?.[0];
+    expect(trashed?.trashedAt).toEqual(expect.any(String));
+    // The SOURCE TIMELINE, not the clip's own name.
+    expect(trashed?.trashedFrom).toEqual({ timelineId: "root", title: "root" });
+  });
+
+  it("removes a COLLECTION, not just media", async () => {
+    seed("root", [collectionClip("sub"), clip("keep")]);
+    seed("sub", []);
+
+    const result = await handleRemoveClip(
+      { timelineId: "root", nodeId: "sub" },
+      { requesterUid: OWNER },
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(storedClipIds("root")).toEqual(["keep"]);
+    expect(storedClipIds(TRASH)).toEqual(["sub"]);
+  });
+
+  it("refuses to remove the LAST item in a collection (known gap)", async () => {
+    // `saveFirebaseTimelineDocumentsAtomic` throws rather than write a document
+    // empty over a non-empty one, and unlike the single-document save it has no
+    // `allowEmptying` escape. So emptying a collection is impossible from ANY
+    // remote write tool, not just this one. Pinned so the limitation is visible
+    // and the day it is lifted this test fails loudly.
+    seed("root", [clip("only")]);
+
+    await expect(
+      handleRemoveClip({ timelineId: "root", nodeId: "only" }, { requesterUid: OWNER }),
+    ).rejects.toThrow(/Refusing to save an empty timeline/);
+
+    expect(storedClipIds("root")).toEqual(["only"]);
+  });
+
+  it("reports an unknown node without touching anything", async () => {
+    seed("root", [clip("a")]);
+
+    const result = await handleRemoveClip(
+      { timelineId: "root", nodeId: "nope" },
+      { requesterUid: OWNER },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain('No node with id "nope"');
+    expect(storedClipIds("root")).toEqual(["a"]);
+  });
+
+  it("cannot reach another account's bin", async () => {
+    seed("root", [clip("a")]);
+    seed("trash-someone-else", [], "someone-else");
+
+    const result = await handleRemoveClip(
+      { timelineId: "root", nodeId: "a", trashId: "trash-someone-else" },
+      { requesterUid: OWNER },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(storedClipIds("root")).toEqual(["a"]);
+    expect(storedClipIds("trash-someone-else")).toEqual([]);
+  });
+
+  it("refuses another account's timeline without revealing that it exists", async () => {
+    seed("root", [clip("a")], "someone-else");
+
+    const result = await handleRemoveClip(
+      { timelineId: "root", nodeId: "a" },
+      { requesterUid: OWNER },
+    );
+
+    // A denied read is swallowed into an EMPTY substitute document
+    // (load-timeline-closure), so the refusal surfaces as "that node isn't
+    // here" rather than a 404 — which is the point: a denied id and an absent
+    // id have to be indistinguishable.
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).not.toMatch(/authoriz|permission|owner/i);
+    expect(storedClipIds("root")).toEqual(["a"]);
+  });
+});

--- a/apps/timeline-gstudio001/lib/mcp/write-handlers.ts
+++ b/apps/timeline-gstudio001/lib/mcp/write-handlers.ts
@@ -10,7 +10,11 @@ import { describeDispatchRejection, toolError, toolOk } from "@/lib/webmcp/resul
 import { resolveMovePlacement, type PlacementError } from "@/lib/webmcp/placement";
 import type { ToolResult } from "@/lib/webmcp/types";
 
-import { applyCollectionsCommand, type ApplyCommandOutcome } from "./apply-command";
+import {
+  applyCollectionsCommand,
+  trashDocumentIdFor,
+  type ApplyCommandOutcome,
+} from "./apply-command";
 
 // Remote (server-side) write tools. Each one translates arguments into a single
 // CollectionsCommand and hands it to `applyCollectionsCommand`, which owns the
@@ -248,28 +252,50 @@ export async function handleRenameItem(
 
 // --- remove_clip -------------------------------------------------------------
 
-export type RemoveClipArgs = Readonly<{ timelineId: string; nodeId: string; trashId: string }>;
+export type RemoveClipArgs = Readonly<{
+  timelineId: string;
+  nodeId: string;
+  /** Optional and normally omitted — the caller's own bin is derived. */
+  trashId?: string;
+}>;
 
 /**
  * Delete is a MOVE into the trash root — there is no delete command, and that
  * is deliberate: everything the agent removes stays recoverable from the bin.
+ *
+ * The bin is DERIVED from the verified uid rather than supplied. It used to be
+ * a required argument sourced "from read_timeline", which no tool could
+ * actually provide: the trash is a sibling root, never a collection clip inside
+ * a project, so it never appeared in a project read and never landed in the
+ * loaded closure. Every call failed. `includeTrash` loads it as a second graph
+ * root so the move has somewhere to go.
  */
 export async function handleRemoveClip(
   args: RemoveClipArgs,
   ctx: WriteContext,
 ): Promise<ToolResult> {
   const nodeId = parseNodeId(args.nodeId);
-  const trashId = parseNodeId(args.trashId);
+  const trashId = parseNodeId(args.trashId ?? trashDocumentIdFor(ctx.requesterUid));
 
   const outcome = await applyCollectionsCommand(
     args.timelineId,
-    (graph: CollectionsGraph) => {
+    (graph: CollectionsGraph, details) => {
       if (!graph.nodesById.has(nodeId)) {
         return { ok: false, message: `No node with id "${args.nodeId}".` } as const;
       }
       if (!graph.nodesById.has(trashId)) {
-        return { ok: false, message: `No trash collection with id "${args.trashId}".` } as const;
+        return {
+          ok: false,
+          message: `Could not reach the trash ("${trashId as string}").`,
+        } as const;
       }
+      const existing = details[nodeId as string];
+      // Read the parent BEFORE the move — afterwards it IS the trash. `title`
+      // is the SOURCE TIMELINE's name, not the clip's, and both fields are
+      // required, so an unnamed parent means no stamp at all rather than half
+      // of one (identical to the in-page path in graph-navigation.tsx).
+      const parentId = graph.parentById.get(nodeId) ?? null;
+      const parentTitle = parentId === null ? undefined : graph.nodesById.get(parentId)?.name;
       return {
         ok: true,
         command: {
@@ -278,9 +304,28 @@ export async function handleRemoveClip(
           toParentId: trashId,
           toIndex: getChildren(graph, trashId).length,
         },
+        // Provenance for the bin's row caption ("trashed 5 minutes ago, from
+        // Scene one"), matching what the in-page path stamps before dispatch.
+        // It rides the details side-table, not the graph node — the engine
+        // never reads it. MERGED onto the existing entry: a detail is the whole
+        // clip's stored shape, and replacing it would drop src/poster/provenance.
+        ...(existing
+          ? {
+              details: {
+                [nodeId as string]: {
+                  ...existing,
+                  trashedAt: new Date().toISOString(),
+                  ...(parentId !== null && parentTitle
+                    ? { trashedFrom: { timelineId: parentId as string, title: parentTitle } }
+                    : {}),
+                },
+              },
+            }
+          : {}),
       } as const;
     },
     ctx.requesterUid,
+    { includeTrash: true },
   );
 
   if (!outcome.ok) return reportFailure(outcome);

--- a/packages/timeline-domain/src/adapter.test.ts
+++ b/packages/timeline-domain/src/adapter.test.ts
@@ -552,6 +552,62 @@ describe("collectAffectedCollectionIds", () => {
   });
 });
 
+describe("duplicate collection-reference demotion", () => {
+  // The shape that matters is the REAL one: a collection clip's stored id
+  // equals its childTimelineId (both `create_collection` and the graph
+  // write-back mint them that way). Demoting to `clip.id` therefore reproduced
+  // the very id that collided, buildGraph returned `duplicate-id`, and because
+  // every write builds the graph first, the whole project became unwritable.
+  const SAME = "timeline-run";
+  const DOUBLED: TimelineDocument = {
+    id: "scene",
+    title: "Scene",
+    clips: packTimelineClips([
+      collectionClip(SAME, SAME, "Result"),
+      collectionClip(SAME, SAME, "Result"),
+    ]),
+  };
+
+  it("builds a graph when one document references the same child twice", () => {
+    const built = buildFocusedGraph({ scene: DOUBLED }, "scene", 2);
+
+    expect(built.ok).toBe(true);
+    if (!built.ok) return;
+    expect(getChildren(built.value.graph, parseNodeId("scene"))).toHaveLength(2);
+  });
+
+  it("gives the demoted reference an id that is not already taken", () => {
+    const payload = buildHydrationSpecs({ scene: DOUBLED }, "scene", 0);
+    if (!payload.ok) throw new Error(payload.error);
+
+    expect(payload.value.specs.map((spec) => spec.id)).toEqual([
+      SAME,
+      `dup:scene:${SAME}`,
+    ]);
+    expect(payload.value.details[`dup:scene:${SAME}`]).toMatchObject({
+      duplicateOfTimelineId: SAME,
+      sourceClipId: SAME,
+    });
+  });
+
+  it("round-trips both references back to their stored id and child pointer", () => {
+    const built = buildFocusedGraph({ scene: DOUBLED }, "scene", 2);
+    if (!built.ok) throw new Error(built.error);
+
+    const clips = graphChildrenToClips(
+      built.value.graph,
+      built.value.details,
+      parseNodeId("scene"),
+    );
+
+    // A demoted node must not leak its synthetic id into storage.
+    expect(clips.map((clip) => clip.id)).toEqual([SAME, SAME]);
+    expect(
+      clips.map((clip) => (clip.kind === "collection" ? clip.childTimelineId : null)),
+    ).toEqual([SAME, SAME]);
+  });
+});
+
 describe("duplicate media-id demotion", () => {
   it("demotes a media id already used in the live graph, preserving the stored id", () => {
     // "c-img" already exists elsewhere in the graph (legacy stable per-asset

--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -209,14 +209,30 @@ function clipSpecs(
     if (ctx.used.has(childId)) {
       // Same child referenced twice inside the hydrated area: demote to a
       // non-navigable reference card keyed by the clip's own id.
-      ctx.used.add(clip.id);
-      ctx.details[clip.id] = {
+      //
+      // That key is not enough on its own. A collection clip's stored id
+      // normally EQUALS its childTimelineId (both the graph write-back and
+      // `create_collection` mint them that way), so `clip.id` is usually the
+      // very id that just collided — falling back to it reproduced the
+      // duplicate and `buildGraph` rejected the whole tree, which blocked
+      // every write to the project rather than surfacing one bad card. Fall
+      // through to the same synthetic form the media branch uses.
+      let nodeId = clip.id;
+      if (ctx.used.has(nodeId)) {
+        nodeId = `dup:${doc.id}:${clip.id}`;
+        while (ctx.used.has(nodeId)) nodeId = `${nodeId}~`;
+      }
+      ctx.used.add(nodeId);
+      // `sourceClipId` (from collectionDetail) and `duplicateOfTimelineId`
+      // are what let the write path round-trip a synthetic id back to the
+      // stored clip id and its real child pointer — see graphChildrenToClips.
+      ctx.details[nodeId] = {
         ...collectionDetail(clip, false),
         duplicateOfTimelineId: childId,
       };
       return {
         kind: "collection",
-        id: clip.id,
+        id: nodeId,
         name: clip.title,
         children: [],
         ...(clip.disabled ? { disabled: true } : {}),


### PR DESCRIPTION
## What

Two faults found together while an agent reorganised a project into per-run folders and left it unwritable.

**`remove_clip` could never succeed.** It required a `trashId` that had to be a node in the graph built from the target timeline's closure — but the trash is a *sibling root*, never a collection clip inside a project, so it was never in that closure. Every call failed with `No trash collection with id`. The schema told callers to get the id "from `read_timeline`", which never returns it.

The id is now derived from the verified uid, and `applyCollectionsCommand` takes `includeTrash` to load the bin as a second graph root — the same `buildGraph([projectRoot, trashRoot])` the in-page boot already does. `serveTrashDocument` supplies the empty default so the existing revision-0 CAS creates the bin on first use.

**Why that mattered:** `clipSpecs` is written to demote a duplicate reference rather than crash. The media branch does it correctly (`dup:<doc>:<clip>`, looping until unused); the collection branch fell back to `clip.id` with no uniqueness check — and a collection clip's stored id *equals* its `childTimelineId`, so the fallback reproduced the colliding id. `buildGraph` returned `duplicate-id`, and since every write builds the graph first, **one duplicated reference made an entire project unwritable** — no rename, no create, and no remove to clear it.

## Testing

- `packages/timeline-domain/src/adapter.test.ts` — 3 new cases; verified they fail with the real production error (`{"reason":"duplicate-id"}`) when the uniqueness guard is reverted
- `apps/timeline-gstudio001/lib/mcp/remove-clip.test.ts` — 8 new cases against the in-memory Firestore double
- Unvacuums an ownership test whose assertions were guarded on a branch that never ran
- 616 app tests, 499 unit tests, both typechecks clean, lint 0 errors

## Known gap (pinned by a test)

`saveFirebaseTimelineDocumentsAtomic` refuses to write a document empty over a non-empty one and has no `allowEmptying` escape, so removing the **last** item in a collection still fails. Predates this change; affects every remote write tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)