### PR TITLE
Converge an open tab on remote removals, and record who changed what

### DIFF
--- a/apps/timeline-gstudio001/app/api/timelines/batch/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/batch/route.ts
@@ -8,6 +8,7 @@ import {
   TimelineRevisionConflictError,
   type TimelineBatchWrite,
 } from "@/lib/firebase-timeline-store";
+import { changeLogDocuments, recordChange } from "@/lib/change-log";
 import { checkUserScopedId, TimelineAccessDeniedError } from "@/lib/timeline-ownership";
 
 export const runtime = "nodejs";
@@ -101,6 +102,17 @@ export async function POST(request: Request) {
     }
 
     const results = await saveFirebaseTimelineDocumentsAtomic(writes, user.uid);
+    // After the commit, never inside it — the log must not be able to fail a
+    // save, and must not claim a change that did not land.
+    await recordChange({
+      uid: user.uid,
+      source: "app",
+      documents: changeLogDocuments(
+        results,
+        Object.fromEntries(writes.map((write) => [write.document.id, write.document])),
+        Object.fromEntries(writes.map((write) => [write.document.id, write.expectedRevision])),
+      ),
+    });
     return NextResponse.json({ results });
   } catch (error) {
     if (error instanceof TimelineRevisionConflictError) {

--- a/apps/timeline-gstudio001/components/graph-view/graph-remote-changes.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-remote-changes.tsx
@@ -8,12 +8,14 @@ import {
   getChildren,
   parseNodeId,
   useCollectionsStore,
+  verifyPatchApplies,
   type CollectionItemNode,
   type NodeId,
 } from "@storyboard/ui/dnd-collections";
 
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 
+import { buildRemovalPatch, diffRemoteChildren } from "./graph-remote-diff";
 import { parkPendingDetail, unparkPendingDetail } from "./graph-pending-details";
 
 // Live updates for writes this tab cannot hear.
@@ -26,11 +28,17 @@ import { parkPendingDetail, unparkPendingDetail } from "./graph-pending-details"
 // connection, so pushing would need a shared bus. So: poll a tiny revisions
 // endpoint, and pull only when it says something moved.
 //
-// ADDITIONS ONLY, on purpose. New clips are spliced into the live graph and
-// animate in like any other drop. Remote MOVES and TRIMS are deliberately not
-// applied — reconciling those against in-flight local edits is a different
-// problem, and silently rewriting a clip somebody is dragging would be worse
-// than not updating at all. Those still need a reload.
+// ADDITIONS and REMOVALS. New clips are spliced into the live graph and animate
+// in like any other drop; children that have DEPARTED remotely are taken out.
+// Remote moves-within and trims are still not applied — reconciling those
+// against in-flight local edits is a different problem, and silently rewriting a
+// clip somebody is dragging would be worse than not updating at all.
+//
+// Removals were originally left out with the rest, and that turned out to be the
+// hole that let a project silently revert: an agent removed collections through
+// the MCP endpoint, this tab never learned, kept them in its live graph, and
+// re-asserted them on its next write — against a fresh revision, so the
+// compare-and-set passed. Additions-only convergence is not convergence.
 //
 // Applied through `store.applyRemotePatch`, NOT `store.dispatch`: this is not
 // the local user's action, so it must not enter their undo stack. Undo should
@@ -73,11 +81,18 @@ export function RemoteChangesBridge({
       const parentId = parseNodeId(timelineId);
       if (!live.nodesById.has(parentId)) return;
 
-      const known = new Set(getChildren(live, parentId).map(String));
-      const incoming = getChildren(built.value.graph, parentId).filter(
-        (id) => !known.has(String(id)),
+      const { added: incoming, departed } = diffRemoteChildren(
+        live,
+        built.value.graph,
+        parentId,
       );
-      if (incoming.length === 0) return;
+
+      // A pending local write means this session has unsaved intent for the
+      // document. Converging under it would delete work the user is part-way
+      // through, so leave the whole thing alone — the next poll will catch it
+      // once their write settles.
+      const settled = !graphDocumentsGateway.hasPendingWrite(timelineId);
+      if (incoming.length === 0 && (departed.length === 0 || !settled)) return;
 
       const nodes: CollectionItemNode[] = [];
       const parked: string[] = [];
@@ -94,22 +109,40 @@ export function RemoteChangesBridge({
         }
         nodes.push(node);
       }
-      if (nodes.length === 0) return;
 
-      // NOT `store.dispatch` — that records an undo entry, and this is not the
-      // local user's action. With it in the stack, Ctrl+Z would delete a clip
-      // an agent just uploaded, and the autosave would persist that deletion.
-      // Run the reducer purely to get the patch, then apply it without history.
-      const applied = applyCommand(live, {
-        type: "add-nodes",
-        nodes,
-        toParentId: parentId,
-        toIndex: getChildren(live, parentId).length,
-      });
-      const ok = applied.ok && store.applyRemotePatch(applied.value.patch);
-      // On refusal the details must not be left parked — they would attach
-      // themselves to whatever later minted a node with the same id.
-      if (!ok) for (const id of parked) unparkPendingDetail(id);
+      // ADDITIONS FIRST. A clip moved from one collection to another on the same
+      // board is seen by two polls — departed from A, arriving at B. Adding
+      // before removing means it is never briefly absent from both.
+      if (nodes.length > 0) {
+        // NOT `store.dispatch` — that records an undo entry, and this is not the
+        // local user's action. With it in the stack, Ctrl+Z would delete a clip
+        // an agent just uploaded, and the autosave would persist that deletion.
+        // Run the reducer purely to get the patch, then apply it without history.
+        const applied = applyCommand(live, {
+          type: "add-nodes",
+          nodes,
+          toParentId: parentId,
+          toIndex: getChildren(live, parentId).length,
+        });
+        const ok = applied.ok && store.applyRemotePatch(applied.value.patch);
+        // On refusal the details must not be left parked — they would attach
+        // themselves to whatever later minted a node with the same id.
+        if (!ok) for (const id of parked) unparkPendingDetail(id);
+      }
+
+      if (departed.length === 0 || !settled || cancelled) return;
+
+      // Built against the graph as it stands NOW — the additions above committed
+      // and shifted the indices.
+      const after = store.getSnapshot().graph;
+      const patch = buildRemovalPatch(after, parentId, departed);
+      if (!patch) return;
+
+      // Verify before applying, the same gate `store.undo` uses — `applyPatch`
+      // does not validate, and a patch built from a stale read would corrupt the
+      // indices rather than fail.
+      if (!verifyPatchApplies(after, patch).ok) return;
+      store.applyRemotePatch(patch);
     }
 
     async function tick() {

--- a/apps/timeline-gstudio001/components/graph-view/graph-remote-diff.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-remote-diff.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyPatch,
+  buildGraph,
+  getChildren,
+  parseNodeId,
+  verifyPatchApplies,
+  type CollectionsGraph,
+  type GraphNodeSpec,
+} from "@storyboard/collections-core";
+
+import { buildRemovalPatch, diffRemoteChildren } from "./graph-remote-diff";
+
+// Convergence on remote REMOVALS. Additions were already handled; leaving
+// removals out is what let a project silently revert — an agent removed
+// collections over MCP, the open tab kept them in its live graph, and
+// re-asserted them on its next write against a fresh revision.
+
+function media(id: string): GraphNodeSpec {
+  return { kind: "media", id, name: id };
+}
+
+function graph(childIds: string[]): CollectionsGraph {
+  const built = buildGraph([
+    { kind: "collection", id: "root", name: "root", children: childIds.map(media) },
+  ]);
+  if (!built.ok) throw new Error(JSON.stringify(built.error));
+  return built.value;
+}
+
+const ROOT = parseNodeId("root");
+
+describe("diffRemoteChildren", () => {
+  it("reports a child that departed remotely", () => {
+    const diff = diffRemoteChildren(graph(["a", "b", "c"]), graph(["a", "c"]), ROOT);
+
+    expect(diff.departed.map(String)).toEqual(["b"]);
+    expect(diff.added).toEqual([]);
+  });
+
+  it("still reports additions", () => {
+    const diff = diffRemoteChildren(graph(["a"]), graph(["a", "b"]), ROOT);
+
+    expect(diff.added.map(String)).toEqual(["b"]);
+    expect(diff.departed).toEqual([]);
+  });
+
+  it("reports both when a child is swapped", () => {
+    const diff = diffRemoteChildren(graph(["a", "b"]), graph(["a", "c"]), ROOT);
+
+    expect(diff.added.map(String)).toEqual(["c"]);
+    expect(diff.departed.map(String)).toEqual(["b"]);
+  });
+
+  it("reports nothing when a child merely moved position", () => {
+    // Reordering is NOT convergence's job — applying it would fight a local
+    // drag. Membership is what matters.
+    const diff = diffRemoteChildren(graph(["a", "b", "c"]), graph(["c", "b", "a"]), ROOT);
+
+    expect(diff.added).toEqual([]);
+    expect(diff.departed).toEqual([]);
+  });
+});
+
+describe("buildRemovalPatch", () => {
+  it("produces a patch that verifies and removes the node", () => {
+    const live = graph(["a", "b", "c"]);
+    const patch = buildRemovalPatch(live, ROOT, [parseNodeId("b")]);
+    if (!patch) throw new Error("expected a patch");
+
+    expect(verifyPatchApplies(live, patch).ok).toBe(true);
+    const next = applyPatch(live, patch);
+    expect(getChildren(next, ROOT).map(String)).toEqual(["a", "c"]);
+  });
+
+  it("indexes against the graph passed in, not the pre-addition one", () => {
+    // The bridge applies additions first, which shifts indices. A patch built
+    // from the stale graph would remove the wrong child.
+    const afterAdditions = graph(["new", "a", "b"]);
+    const patch = buildRemovalPatch(afterAdditions, ROOT, [parseNodeId("b")]);
+    if (!patch) throw new Error("expected a patch");
+
+    expect(verifyPatchApplies(afterAdditions, patch).ok).toBe(true);
+    expect(getChildren(applyPatch(afterAdditions, patch), ROOT).map(String)).toEqual([
+      "new",
+      "a",
+    ]);
+  });
+
+  it("removes several departed children at once", () => {
+    const live = graph(["a", "b", "c", "d"]);
+    const patch = buildRemovalPatch(live, ROOT, [parseNodeId("b"), parseNodeId("d")]);
+    if (!patch) throw new Error("expected a patch");
+
+    expect(verifyPatchApplies(live, patch).ok).toBe(true);
+    expect(getChildren(applyPatch(live, patch), ROOT).map(String)).toEqual(["a", "c"]);
+  });
+
+  it("returns null for an id that is not in the graph", () => {
+    // Skips the verify/apply round trip rather than emitting an empty patch.
+    expect(buildRemovalPatch(graph(["a"]), ROOT, [parseNodeId("ghost")])).toBeNull();
+  });
+
+  it("returns null when nothing departed", () => {
+    expect(buildRemovalPatch(graph(["a"]), ROOT, [])).toBeNull();
+  });
+});

--- a/apps/timeline-gstudio001/components/graph-view/graph-remote-diff.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-remote-diff.ts
@@ -1,0 +1,65 @@
+import {
+  getChildren,
+  type CollectionsGraph,
+  type CollectionsPatch,
+  type NodeId,
+} from "@storyboard/collections-core";
+
+// The pure half of RemoteChangesBridge: given the live graph and one freshly
+// fetched from storage, what changed under this collection?
+//
+// Split out of the .tsx because the app's vitest cannot parse TSX, and this is
+// the part worth testing — the component around it is a poll timer and a fetch.
+
+export type RemoteDiff = Readonly<{
+  /** Children present remotely but not locally, in remote order. */
+  added: readonly NodeId[];
+  /** Children present locally but not remotely. */
+  departed: readonly NodeId[];
+}>;
+
+export function diffRemoteChildren(
+  live: CollectionsGraph,
+  fetched: CollectionsGraph,
+  parentId: NodeId,
+): RemoteDiff {
+  const liveChildren = getChildren(live, parentId);
+  const fetchedChildren = getChildren(fetched, parentId);
+  const known = new Set(liveChildren.map(String));
+  const remote = new Set(fetchedChildren.map(String));
+  return {
+    added: fetchedChildren.filter((id) => !known.has(String(id))),
+    departed: liveChildren.filter((id) => !remote.has(String(id))),
+  };
+}
+
+/**
+ * A `nodes-removed` patch for children that departed remotely.
+ *
+ * There is no remove COMMAND in this engine — deletion is a move into the
+ * trash, and the trash is not necessarily loaded in a board's graph. But
+ * `applyRemotePatch` takes a PATCH, and `nodes-removed` is one, so the removal
+ * is expressed directly rather than faked as a move to somewhere.
+ *
+ * Built against the graph as it stands at call time (`current`), NOT the graph
+ * the diff was computed from: additions are applied first and shift indices.
+ *
+ * Returns null when there is nothing to remove, so the caller can skip the
+ * verify/apply round trip entirely.
+ */
+export function buildRemovalPatch(
+  current: CollectionsGraph,
+  parentId: NodeId,
+  departed: readonly NodeId[],
+): CollectionsPatch | null {
+  const children = getChildren(current, parentId);
+  const removals = departed.flatMap((nodeId) => {
+    const node = current.nodesById.get(nodeId);
+    if (!node) return [];
+    const index = children.indexOf(nodeId);
+    if (index < 0) return [];
+    return [{ node, parentId, index }];
+  });
+  if (removals.length === 0) return null;
+  return { type: "nodes-removed", removals };
+}

--- a/apps/timeline-gstudio001/lib/change-log.test.ts
+++ b/apps/timeline-gstudio001/lib/change-log.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
+
+// The change log is the record that did not exist when a project silently
+// reverted — so what is worth pinning is not "it writes a row" but the three
+// properties that make it trustworthy: it records the clip ids (the thing that
+// actually identifies a structural change), it records WHICH surface wrote, and
+// it can never fail the user's save.
+
+type Stored = Record<string, unknown>;
+
+const state = vi.hoisted(() => {
+  const added: Stored[] = [];
+  let addThrows = false;
+  const db = {
+    collection: () => ({
+      add: async (data: Stored) => {
+        if (addThrows) throw new Error("firestore unavailable");
+        added.push(data);
+        return { id: `entry-${added.length}` };
+      },
+    }),
+  };
+  return {
+    added,
+    db,
+    setAddThrows: (value: boolean) => {
+      addThrows = value;
+    },
+  };
+});
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/firebase-admin", () => ({ getFirebaseDb: () => state.db }));
+vi.mock("firebase-admin/firestore", () => ({
+  FieldValue: { serverTimestamp: () => "SERVER_TIME" },
+}));
+
+import { changeLogDocuments, recordChange } from "./change-log";
+
+function clip(id: string): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "image",
+    src: "https://example.test/img.jpg",
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 4,
+    sourceDuration: 4,
+    trimIn: 0,
+    trimOut: 0,
+  };
+}
+
+function doc(id: string, clipIds: string[]): TimelineDocument {
+  return { id, title: id, clips: clipIds.map(clip) };
+}
+
+beforeEach(() => {
+  state.added.length = 0;
+  state.setAddThrows(false);
+});
+
+describe("recordChange", () => {
+  it("records the clip ids, so a structural change is reconstructable", async () => {
+    await recordChange({
+      uid: "user-a",
+      source: "mcp",
+      documents: changeLogDocuments(
+        [{ id: "scene", revision: 8 }],
+        { scene: doc("scene", ["a", "b"]) },
+        { scene: 7 },
+      ),
+    });
+
+    expect(state.added).toHaveLength(1);
+    const entry = state.added[0] as {
+      uid: string;
+      source: string;
+      timelineIds: string[];
+      documents: { id: string; fromRevision?: number; toRevision: number; clipIds: string[] }[];
+    };
+    expect(entry.uid).toBe("user-a");
+    expect(entry.source).toBe("mcp");
+    // Denormalized for querying — Firestore cannot index into an array of objects.
+    expect(entry.timelineIds).toEqual(["scene"]);
+    expect(entry.documents[0]).toMatchObject({
+      id: "scene",
+      fromRevision: 7,
+      toRevision: 8,
+      clipIds: ["a", "b"],
+    });
+  });
+
+  it("distinguishes the app from the agent", async () => {
+    await recordChange({
+      uid: "user-a",
+      source: "app",
+      documents: changeLogDocuments([{ id: "scene", revision: 2 }], { scene: doc("scene", []) }),
+    });
+
+    expect((state.added[0] as { source: string }).source).toBe("app");
+  });
+
+  it("omits fromRevision for a create rather than inventing one", async () => {
+    await recordChange({
+      uid: "user-a",
+      source: "app",
+      // No prior revision known — a compare-and-set create.
+      documents: changeLogDocuments([{ id: "fresh", revision: 1 }], { fresh: doc("fresh", ["x"]) }),
+    });
+
+    expect(state.added[0]).toMatchObject({ documents: [{ id: "fresh", toRevision: 1 }] });
+    expect((state.added[0] as { documents: Stored[] }).documents[0]).not.toHaveProperty(
+      "fromRevision",
+    );
+  });
+
+  it("NEVER throws — a logging failure must not fail the write", async () => {
+    state.setAddThrows(true);
+
+    await expect(
+      recordChange({
+        uid: "user-a",
+        source: "app",
+        documents: changeLogDocuments([{ id: "scene", revision: 2 }], { scene: doc("scene", []) }),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("writes nothing when no document changed", async () => {
+    await recordChange({ uid: "user-a", source: "app", documents: [] });
+
+    expect(state.added).toHaveLength(0);
+  });
+});

--- a/apps/timeline-gstudio001/lib/change-log.ts
+++ b/apps/timeline-gstudio001/lib/change-log.ts
@@ -1,0 +1,110 @@
+import "server-only";
+
+import { FieldValue } from "firebase-admin/firestore";
+
+import { getFirebaseDb } from "@/lib/firebase-admin";
+import type { TimelineDocument } from "@storyboard/timeline-model/types";
+
+// An append-only record of who changed which timeline, and to what.
+//
+// Written because there was NO way to answer "what wrote this document, when,
+// and what did it contain before?". A project silently reverted while an agent
+// edited it over MCP and a browser tab held a stale graph, and reconstructing
+// that took an hour of inference from `trashedAt` stamps on surviving clips.
+// `revision` and `updatedAt` only ever describe the LATEST state.
+//
+// `clipIds` is the load-bearing field: it is what makes "Scene one went from
+// [a,b,c] to [a,b], written by mcp at 01:02" answerable. Full document
+// snapshots are deliberately NOT stored — they would multiply the collection's
+// size for little extra signal, and the ids are what identifies a structural
+// change.
+//
+// Best-effort by contract. Every caller must treat a logging failure as
+// nothing: an audit trail that can fail a user's edit is worse than no audit
+// trail. Same posture as the trash route's post-commit asset marking.
+
+const CHANGE_LOG_COLLECTION = "timelineChanges";
+
+/** Which surface performed the write. */
+export type ChangeSource = "app" | "mcp";
+
+export type ChangeLogDocument = Readonly<{
+  id: string;
+  /** Revision read before the write; absent for a create. */
+  fromRevision?: number;
+  /** Revision the write produced. */
+  toRevision: number;
+  clipIds: readonly string[];
+}>;
+
+export type ChangeLogEntry = Readonly<{
+  uid: string;
+  source: ChangeSource;
+  documents: readonly ChangeLogDocument[];
+}>;
+
+/**
+ * Append one entry describing a committed write.
+ *
+ * Call AFTER the write succeeds and outside its transaction — the log must not
+ * be able to abort a save, and it must never claim a change that did not land.
+ * Never throws.
+ */
+export async function recordChange(entry: ChangeLogEntry): Promise<void> {
+  if (entry.documents.length === 0) return;
+  try {
+    await getFirebaseDb()
+      .collection(CHANGE_LOG_COLLECTION)
+      .add({
+        uid: entry.uid,
+        source: entry.source,
+        at: FieldValue.serverTimestamp(),
+        // Denormalized so the common query ("what touched this timeline?")
+        // needs no collection-group scan over the nested array.
+        timelineIds: entry.documents.map((document) => document.id),
+        documents: entry.documents.map((document) => ({
+          id: document.id,
+          ...(document.fromRevision === undefined
+            ? {}
+            : { fromRevision: document.fromRevision }),
+          toRevision: document.toRevision,
+          clipIds: document.clipIds,
+        })),
+      });
+  } catch {
+    // Swallowed on purpose — see the contract above.
+  }
+}
+
+/**
+ * Build the per-document part of an entry from what a write already had to
+ * hand, so callers don't re-derive it and can't disagree about what "changed".
+ */
+export function changeLogDocuments(
+  written: readonly { id: string; revision: number }[],
+  documents: Readonly<Record<string, TimelineDocument>>,
+  priorRevisions: Readonly<Record<string, number | undefined>> = {},
+): ChangeLogDocument[] {
+  return written.map(({ id, revision }) => ({
+    id,
+    ...(priorRevisions[id] === undefined ? {} : { fromRevision: priorRevisions[id] }),
+    toRevision: revision,
+    clipIds: (documents[id]?.clips ?? []).map((clip) => clip.id),
+  }));
+}
+
+/**
+ * The most recent changes touching a timeline, newest first.
+ *
+ * Deliberately queried on the denormalized `timelineIds` array rather than the
+ * nested `documents` — Firestore cannot index into an array of objects.
+ */
+export async function recentChanges(timelineId: string, limit = 25) {
+  const snapshot = await getFirebaseDb()
+    .collection(CHANGE_LOG_COLLECTION)
+    .where("timelineIds", "array-contains", timelineId)
+    .orderBy("at", "desc")
+    .limit(limit)
+    .get();
+  return snapshot.docs.map((doc) => doc.data());
+}

--- a/apps/timeline-gstudio001/lib/mcp/apply-command.ts
+++ b/apps/timeline-gstudio001/lib/mcp/apply-command.ts
@@ -20,6 +20,7 @@ import {
   TimelineRevisionConflictError,
   type TimelineBatchWrite,
 } from "@/lib/firebase-timeline-store";
+import { changeLogDocuments, recordChange } from "@/lib/change-log";
 import { loadTimelineClosure, TimelineClosureTooLargeError } from "@/lib/load-timeline-closure";
 import { serveTrashDocument } from "@/lib/serve-timeline";
 import { TimelineAccessDeniedError } from "@/lib/timeline-ownership";
@@ -330,8 +331,20 @@ export async function applyCollectionsCommand(
     };
   });
 
+  const committed = [...seedWrites, ...writes];
   try {
-    await saveFirebaseTimelineDocumentsAtomic([...seedWrites, ...writes], requesterUid);
+    const results = await saveFirebaseTimelineDocumentsAtomic(committed, requesterUid);
+    // After the commit, never inside it. Agent writes are exactly the ones with
+    // no human watching, so they are the ones most worth having a record of.
+    await recordChange({
+      uid: requesterUid,
+      source: "mcp",
+      documents: changeLogDocuments(
+        results,
+        nextDocuments,
+        Object.fromEntries(committed.map((write) => [write.document.id, write.expectedRevision])),
+      ),
+    });
   } catch (error) {
     if (error instanceof TimelineRevisionConflictError) {
       const ids = error.conflicts.map((conflict) => conflict.id).join(", ");


### PR DESCRIPTION
## Why

A project silently reverted while an agent edited it over MCP and a browser tab was open on the same data.

**The revision CAS was not the hole.** It already blocks a stale write, and the gateway already marks a conflicted id and refuses further clip writes for it. The hole was **convergence**: `RemoteChangesBridge` polls for remote writes and splices in what's new, but it was **additions-only by design** — a child removed remotely stayed in the live graph forever. The tab never learned about the removals, kept the nodes, and re-asserted them on its next write against a fresh revision, so CAS passed.

Additions-only convergence is not convergence.

## What

**Removals converge.** There is no remove *command* in this engine — deletion is a move into the trash, which a board's graph need not contain — but `applyRemotePatch` takes a *patch* and `nodes-removed` is one, so the removal is expressed directly instead of faked as a move.

- Additions apply **first**, so a clip moving between two collections on the same board is never briefly absent from both
- The removal patch is indexed against the **post-addition** graph
- Gated on `verifyPatchApplies` (the same gate `store.undo` uses)
- **Skipped entirely while the document has a pending local write** — convergence must not delete work the user is part-way through
- Reordering is deliberately *not* converged; membership only

**`lib/change-log.ts`** — append-only record of who wrote which timeline, from which surface (`app` | `mcp`), and the resulting clip ids. Reconstructing the incident took an hour of inference from `trashedAt` stamps, because `revision`/`updatedAt` only describe the latest state. Written *after* the commit, never inside it, and `recordChange` never throws.

## Testing

- `graph-remote-diff.test.ts` — 9 cases: departure, addition, swap, reorder-is-not-a-change, multi-removal, post-addition indexing, unknown id
- `change-log.test.ts` — 5 cases including "never throws" and "omits fromRevision for a create"
- 630 app tests (up from 616), typecheck clean, lint 0 errors

The diff/patch logic lives in `graph-remote-diff.ts` because the app's vitest cannot parse TSX and this is the half worth testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)