### PR TITLE
Explain the rejections that used to read as "The edit was refused"

### DIFF
--- a/apps/timeline-gstudio001/lib/webmcp/results.test.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/results.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { parseNodeId } from "@storyboard/collections-core";
+
+import { describeDispatchRejection } from "./results";
+
+// Every rejection an agent can provoke must come back as something it can act
+// on. Six reasons used to fall through to the bare "The edit was refused",
+// which is indistinguishable from a real failure — a reorder that was actually
+// a no-op read as a broken tool and cost real diagnosis time.
+
+const NODE = parseNodeId("clip-a");
+
+describe("describeDispatchRejection", () => {
+  it("explains a no-op instead of reporting a refusal", () => {
+    const message = describeDispatchRejection({ reason: "same-position" });
+
+    expect(message).toMatch(/nothing changed/i);
+    expect(message).not.toBe("The edit was refused.");
+  });
+
+  it.each([
+    ["invalid-index", /index/i],
+    ["nothing-to-move", /movable/i],
+    ["nothing-to-add", /add/i],
+  ] as const)("explains %s", (reason, pattern) => {
+    const message = describeDispatchRejection({ reason });
+
+    expect(message).toMatch(pattern);
+    expect(message).not.toBe("The edit was refused.");
+  });
+
+  it.each([
+    ["not-media-node", /collection, not a clip/i],
+    ["invalid-node-name", /blank name/i],
+    ["invalid-media-update", /media kind|non-finite/i],
+  ] as const)("explains %s and names the node", (reason, pattern) => {
+    const message = describeDispatchRejection({ reason, nodeId: NODE });
+
+    expect(message).toMatch(pattern);
+    expect(message).toContain("clip-a");
+  });
+
+  it("still names the node for the reasons that already worked", () => {
+    expect(describeDispatchRejection({ reason: "missing-node", nodeId: NODE })).toContain(
+      "clip-a",
+    );
+  });
+});

--- a/apps/timeline-gstudio001/lib/webmcp/results.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/results.ts
@@ -35,6 +35,25 @@ export function describeDispatchRejection(error: DispatchRejection): string {
       return "That node id is empty or blank.";
     case "invalid-node":
       return "The node failed validation.";
+    case "not-media-node":
+      return `"${error.nodeId}" is a collection, not a clip — only clips can be trimmed.`;
+    case "invalid-node-name":
+      return `"${error.nodeId}" was given a blank name.`;
+    case "invalid-media-update":
+      return `The trim doesn't match "${error.nodeId}"'s media kind, or carries a non-finite value.`;
+    // The no-op family. These used to fall through to the default, which made an
+    // ordinary "nothing changed" indistinguishable from a real refusal — and
+    // cost real time chasing a reorder "bug" that was a duplicate-id problem
+    // elsewhere. A rejection the caller cannot act on is a bug in the message,
+    // not in the caller.
+    case "same-position":
+      return "Nothing changed — the item is already where you asked to put it.";
+    case "invalid-index":
+      return "That index is outside the target collection.";
+    case "nothing-to-move":
+      return "No movable items were given.";
+    case "nothing-to-add":
+      return "No items were given to add.";
     case "blocked-by-policy":
       return (
         error.message ??


### PR DESCRIPTION
Six reducer rejection reasons had no case in `describeDispatchRejection` and collapsed into the bare default: `same-position`, `invalid-index`, `nothing-to-move`, `nothing-to-add`, `not-media-node`, `invalid-node-name` (plus `invalid-media-update`).

That's worse than unhelpful — a `same-position` **no-op** and a genuine failure came back with identical text, so an agent reordering an item to a position it already occupied couldn't tell "nothing to do" from "the tool is broken".

It cost real diagnosis time: an MCP reorder returned "The edit was refused" and I investigated it as a placement-math bug. `resolveMovePlacement` and the reducer's no-op detection were both correct — the actual cause was a duplicate node id elsewhere in the graph making the target ambiguous.

**A rejection the caller cannot act on is a bug in the message, not in the caller.**

`results.test.ts` (new) — 8 cases asserting each reason produces something actionable and never the bare default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)