### PR TITLE
Let a deliberate removal empty a collection

### DIFF
--- a/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
@@ -40,6 +40,19 @@ export type TimelineBatchWrite = {
   /** Omit for last-write-wins (legacy semantics). When present, the write
    *  only applies if the stored revision still matches. */
   expectedRevision?: number;
+  /**
+   * This write MEANS to leave the document with no clips.
+   *
+   * Per-write rather than per-batch: a removal empties the collection the item
+   * came out of while the collection it went into gains one, and only the first
+   * is a deliberate empty. The blanket guard stays the default for everything
+   * else — an unexpected empty is still a stale client about to erase real work.
+   *
+   * Without this, removing the LAST item from a collection was impossible from
+   * the agent tools, which matters because a per-shot lane holds exactly one
+   * clip, so any correction to one hit the guard.
+   */
+  allowEmptying?: boolean;
 };
 
 export type TimelineRevisionConflict = {
@@ -564,6 +577,7 @@ export async function saveFirebaseTimelineDocumentsAtomic(
           ? toTimelineDocument(snapshot.id, existingData)
           : null;
         if (
+          !writes[index].allowEmptying &&
           existingDocument &&
           existingDocument.clips.length > 0 &&
           normalizedDocument.clips.length === 0
@@ -582,6 +596,12 @@ export async function saveFirebaseTimelineDocumentsAtomic(
             existingData,
             requesterUid,
             actualRevision + 1,
+            // Carries through to `lastNonEmptyDocument`, which MUST be dropped
+            // for a deliberate empty: `toTimelineDocument` reads that snapshot
+            // back whenever a stored document has no clips, so leaving it would
+            // re-hydrate the very clips this write removed and the empty would
+            // never stick.
+            { allowEmptying: writes[index].allowEmptying },
           ),
         });
       }

--- a/apps/timeline-gstudio001/lib/mcp/apply-command.ts
+++ b/apps/timeline-gstudio001/lib/mcp/apply-command.ts
@@ -82,6 +82,17 @@ export type ApplyCommandOptions = Readonly<{
    * and loading it costs a second closure read.
    */
   includeTrash?: boolean;
+  /**
+   * This command is allowed to leave a collection with no clips.
+   *
+   * Only removals set it. The store otherwise refuses an empty write, because
+   * an unexpected empty is a stale client about to erase real work — but that
+   * blanket guard made it impossible to remove the LAST item from a collection,
+   * and a per-shot lane holds exactly one clip, so every correction hit it.
+   *
+   * Applied per-document, to the ones this command actually emptied.
+   */
+  allowEmptying?: boolean;
 }>;
 
 /**
@@ -328,6 +339,13 @@ export async function applyCollectionsCommand(
       // another tab, or a second agent call) bumps the revision and aborts the
       // WHOLE batch rather than letting half a change land.
       expectedRevision: revisions[id],
+      // Only a command that MEANS to remove may leave a collection empty, and
+      // only the documents this command actually emptied. A move empties its
+      // source and fills its target; marking every write in the batch would
+      // hand a blanket exemption to writes that never intended one.
+      ...(options.allowEmptying && document.clips.length === 0
+        ? { allowEmptying: true }
+        : {}),
     };
   });
 

--- a/apps/timeline-gstudio001/lib/mcp/remove-clip.test.ts
+++ b/apps/timeline-gstudio001/lib/mcp/remove-clip.test.ts
@@ -69,8 +69,19 @@ vi.mock("firebase-admin/firestore", () => {
       return new Date(0);
     }
   }
-  return { Timestamp, FieldValue: { serverTimestamp: () => new Timestamp() } };
+  return {
+    Timestamp,
+    FieldValue: {
+      serverTimestamp: () => new Timestamp(),
+      // Emptying a collection deletes the `lastNonEmptyDocument` recovery
+      // snapshot — without that the next read re-hydrates the removed clips and
+      // the empty never sticks.
+      delete: () => "__DELETED__",
+    },
+  };
 });
+
+import { saveFirebaseTimelineDocumentsAtomic } from "@/lib/firebase-timeline-store";
 
 import { handleRemoveClip } from "./write-handlers";
 
@@ -183,19 +194,48 @@ describe("handleRemoveClip", () => {
     expect(storedClipIds(TRASH)).toEqual(["sub"]);
   });
 
-  it("refuses to remove the LAST item in a collection (known gap)", async () => {
-    // `saveFirebaseTimelineDocumentsAtomic` throws rather than write a document
-    // empty over a non-empty one, and unlike the single-document save it has no
-    // `allowEmptying` escape. So emptying a collection is impossible from ANY
-    // remote write tool, not just this one. Pinned so the limitation is visible
-    // and the day it is lifted this test fails loudly.
+  it("removes the LAST item in a collection", async () => {
+    // A per-shot lane holds exactly one clip, so this is the common case, not
+    // an edge one. The store's blanket empty-guard used to make it impossible.
     seed("root", [clip("only")]);
 
+    const result = await handleRemoveClip(
+      { timelineId: "root", nodeId: "only" },
+      { requesterUid: OWNER },
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(storedClipIds("root")).toEqual([]);
+    expect(storedClipIds(TRASH)).toEqual(["only"]);
+  });
+
+  it("drops the recovery snapshot so the empty actually sticks", async () => {
+    // `toTimelineDocument` reads `lastNonEmptyDocument` back whenever a stored
+    // document has no clips. Leaving it behind would re-hydrate the very clip
+    // this removal took out, and the collection would look full again on the
+    // next read — an empty that silently undoes itself.
+    seed("root", [clip("only")]);
+
+    await handleRemoveClip({ timelineId: "root", nodeId: "only" }, { requesterUid: OWNER });
+
+    const stored = state.docs.get("root") as { lastNonEmptyDocument?: unknown };
+    expect(stored.lastNonEmptyDocument).toBe("__DELETED__");
+  });
+
+  it("still refuses an empty write that nothing asked for", async () => {
+    // The exemption is per-write and only set by a removal. Everything else
+    // keeps the guard, because an unexpected empty is a stale client about to
+    // erase real work.
+    seed("root", [clip("a"), clip("b")]);
+
     await expect(
-      handleRemoveClip({ timelineId: "root", nodeId: "only" }, { requesterUid: OWNER }),
+      saveFirebaseTimelineDocumentsAtomic(
+        [{ document: { id: "root", title: "root", clips: [] }, expectedRevision: 1 }],
+        OWNER,
+      ),
     ).rejects.toThrow(/Refusing to save an empty timeline/);
 
-    expect(storedClipIds("root")).toEqual(["only"]);
+    expect(storedClipIds("root")).toEqual(["a", "b"]);
   });
 
   it("reports an unknown node without touching anything", async () => {

--- a/apps/timeline-gstudio001/lib/mcp/write-handlers.ts
+++ b/apps/timeline-gstudio001/lib/mcp/write-handlers.ts
@@ -325,7 +325,10 @@ export async function handleRemoveClip(
       } as const;
     },
     ctx.requesterUid,
-    { includeTrash: true },
+    // A removal is the one command that legitimately empties a collection —
+    // taking the last clip out of a lane is the whole point of the call, not a
+    // stale client about to erase work.
+    { includeTrash: true, allowEmptying: true },
   );
 
   if (!outcome.ok) return reportFailure(outcome);


### PR DESCRIPTION
## Why

`saveFirebaseTimelineDocumentsAtomic` refused to write a document empty over a non-empty one, and unlike the single-document save it had no `allowEmptying` escape. So `remove_clip` could not remove the **last** item from a collection.

Not an edge case: a per-shot lane holds exactly one clip, so any correction to one hit the guard. It blocked a real fix within an hour of being documented as a known gap in #275, and the workaround was to attach a replacement first purely to make the removal legal.

## What

`allowEmptying` is now **per-write**, not per-batch, and set only for documents a removal actually emptied. A move empties its source while filling its target — a blanket per-batch flag would hand an exemption to writes that never asked for one. Every other write keeps the guard.

**The subtle half:** `lastNonEmptyDocument` is a recovery snapshot, and `toTimelineDocument` reads it back whenever a stored document has no clips. Permitting the empty write *alone* would have re-hydrated the removed clip on the next read — an empty that silently undoes itself. `buildSavePayload` already drops the snapshot when told the empty is deliberate; the batch path now tells it.

## Testing

The test that pinned this as a known gap is replaced by three that pin the fix:
- the last clip in a collection can be removed
- the recovery snapshot is dropped, so the empty sticks
- an empty write nothing asked for is **still refused**

640 tests (from 638), typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)