### PR TITLE
Serve read_timeline instead of returning the stored record

### DIFF
--- a/apps/timeline-gstudio001/app/api/mcp/route.ts
+++ b/apps/timeline-gstudio001/app/api/mcp/route.ts
@@ -5,14 +5,11 @@ import { z } from "zod";
 
 import { TIMELINE_APP_HTML } from "@storyboard/timeline-widget";
 
-import {
-  getFirebaseTimelineDocument,
-  listFirebaseTimelineProjects,
-} from "@/lib/firebase-timeline-store";
-import { describeTimelineForAgent } from "@/lib/mcp-timeline-summary";
+import { listFirebaseTimelineProjects } from "@/lib/firebase-timeline-store";
 import type { ToolResult } from "@/lib/webmcp/types";
 import { attachMedia, createUploadTicket } from "@/lib/mcp/upload";
 import { createCollection } from "@/lib/mcp/create-collection";
+import { handleReadTimeline } from "@/lib/mcp/read-timeline";
 import { ProjectAssetScopeError } from "@/lib/project-asset-scope";
 import {
   handleMoveClip,
@@ -23,7 +20,6 @@ import {
 } from "@/lib/mcp/write-handlers";
 import { MCP_SCOPE, getSigningSecret, verifyAccessToken } from "@/lib/oauth/core";
 import { mcpResourceUrl, originFromRequest } from "@/lib/oauth/metadata";
-import { TimelineAccessDeniedError } from "@/lib/timeline-ownership";
 
 // Remote MCP endpoint — the "give Claude a URL" surface, distinct from the
 // in-page WebMCP tools (see docs/webmcp-agent-tools.md). Those run in the
@@ -173,19 +169,7 @@ const handler = createMcpHandler(
         const uid = uidFrom(extra);
         if (!uid) return errorResult(NO_IDENTITY);
 
-        try {
-          const document = await getFirebaseTimelineDocument(timelineId, uid);
-          if (!document) return errorResult(`No timeline document with id "${timelineId}".`);
-
-          return jsonResult(describeTimelineForAgent(document), { timeline: document });
-        } catch (error) {
-          // Ownership is enforced in the store; surface a refusal rather than
-          // leaking whether the id exists under another account.
-          if (error instanceof TimelineAccessDeniedError) {
-            return errorResult(`Not authorized to read timeline "${timelineId}".`);
-          }
-          throw error;
-        }
+        return fromToolResult(await handleReadTimeline({ timelineId }, { requesterUid: uid }));
       },
     );
 

--- a/apps/timeline-gstudio001/lib/mcp/read-timeline.test.ts
+++ b/apps/timeline-gstudio001/lib/mcp/read-timeline.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  CollectionTimelineClip,
+  TimelineClip,
+  TimelineDocument,
+} from "@storyboard/timeline-model/types";
+
+// `read_timeline` against the same in-memory Firestore double the rest of
+// lib/mcp uses, so the store, the closure walk and the summary derivation all
+// run for real.
+//
+// The thing worth proving: this tool SERVES the document rather than returning
+// the stored record. Collection summaries live denormalized on the PARENT's
+// clip and writes are patch-scoped, so a stored parent carries whatever it was
+// last told — which for a collection of collections is usually nothing at all.
+// Every fixture below stores a deliberately WRONG summary and asserts the
+// derived one comes back.
+
+type Stored = Record<string, unknown>;
+
+const state = vi.hoisted(() => {
+  const docs = new Map<string, Stored>();
+  const snapshot = (id: string) => {
+    const data = docs.get(id);
+    return {
+      id,
+      exists: data !== undefined,
+      data: () => (data ? { ...data } : undefined),
+      get: (field: string) => (data ? data[field] : undefined),
+    };
+  };
+  const db = {
+    collection: () => ({
+      doc: (id: string) => ({ id, get: async () => snapshot(id) }),
+      where: () => ({ orderBy: () => ({ limit: () => ({ get: async () => ({ docs: [] }) }) }) }),
+    }),
+  };
+  return { docs, db };
+});
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/firebase-admin", () => ({ getFirebaseDb: () => state.db }));
+vi.mock("@/lib/cloudinary-media-store", () => ({ listCloudinaryAssets: async () => [] }));
+vi.mock("firebase-admin/firestore", () => {
+  class Timestamp {
+    toDate() {
+      return new Date(0);
+    }
+  }
+  return { Timestamp, FieldValue: { serverTimestamp: () => new Timestamp(), delete: () => null } };
+});
+
+import { handleReadTimeline } from "./read-timeline";
+
+const OWNER = "user-a";
+
+function image(id: string): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "image",
+    src: `https://example.test/${id}.jpg`,
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 4,
+    sourceDuration: 4,
+    trimIn: 0,
+    trimOut: 0,
+  };
+}
+
+/** A collection clip carrying the summary the PARENT last stored for it —
+ *  which is exactly the value a raw read would hand back. */
+function collectionClip(
+  id: string,
+  stale: { itemCount: number; previewItems?: CollectionTimelineClip["previewItems"] },
+): CollectionTimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "collection",
+    title: id,
+    childTimelineId: id,
+    alt: `${id} collection`,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 3,
+    sourceDuration: 3,
+    trimIn: 0,
+    trimOut: 0,
+    itemCount: stale.itemCount,
+    previewItems: stale.previewItems ?? [],
+  };
+}
+
+function seed(id: string, clips: TimelineClip[], ownerUid = OWNER) {
+  state.docs.set(id, { id, title: id, clips, ownerUid, revision: 1 });
+}
+
+function payloadOf(result: Awaited<ReturnType<typeof handleReadTimeline>>): TimelineDocument {
+  const json = result.content[1];
+  if (!json || !("text" in json)) throw new Error("no JSON block in result");
+  return (JSON.parse(json.text) as { timeline: TimelineDocument }).timeline;
+}
+
+/** The served clip at `index`, narrowed to the collection variant — the
+ *  summary fields under test exist only there. */
+function servedCollection(
+  result: Awaited<ReturnType<typeof handleReadTimeline>>,
+  index = 0,
+): CollectionTimelineClip {
+  const clip = payloadOf(result).clips[index];
+  if (clip.kind !== "collection") throw new Error(`clip ${index} is ${clip.kind}, not a collection`);
+  return clip;
+}
+
+function textOf(result: Awaited<ReturnType<typeof handleReadTimeline>>): string {
+  return result.content.map((part) => ("text" in part ? part.text : "")).join(" ");
+}
+
+beforeEach(() => {
+  state.docs.clear();
+});
+
+describe("handleReadTimeline", () => {
+  it("derives previewItems the stored parent never had", async () => {
+    // The reported bug: a run folder holding real renders showed the agent
+    // `previewItems: []`, because nothing writes preview frames onto a parent
+    // whose own children are collections.
+    seed("root", [collectionClip("run-1", { itemCount: 0 })]);
+    seed("run-1", [image("shot-a"), image("shot-b")]);
+
+    const result = await handleReadTimeline({ timelineId: "root" }, { requesterUid: OWNER });
+
+    expect(servedCollection(result).previewItems?.map((item) => item.id)).toEqual([
+      "shot-a",
+      "shot-b",
+    ]);
+  });
+
+  it("corrects an itemCount left over from an earlier shape of the tree", async () => {
+    seed("root", [collectionClip("run-1", { itemCount: 6 })]);
+    seed("run-1", [image("only")]);
+
+    const result = await handleReadTimeline({ timelineId: "root" }, { requesterUid: OWNER });
+
+    expect(servedCollection(result).itemCount).toBe(1);
+  });
+
+  it("derives through a collection of collections, not just one level down", async () => {
+    // Bottom-up across the whole closure. One level would leave `scene` reading
+    // its child's STORED (empty) summary and still report no preview frames.
+    seed("root", [collectionClip("scene", { itemCount: 99 })]);
+    seed("scene", [collectionClip("run-1", { itemCount: 99 })]);
+    seed("run-1", [image("deep")]);
+
+    const result = await handleReadTimeline({ timelineId: "root" }, { requesterUid: OWNER });
+
+    const scene = servedCollection(result);
+    expect(scene.itemCount).toBe(1);
+    expect(scene.previewItems?.map((item) => item.id)).toEqual(["deep"]);
+  });
+
+  it("summarizes the document for the agent in the first text block", async () => {
+    seed("root", [image("a"), collectionClip("run-1", { itemCount: 0 })]);
+    seed("run-1", []);
+
+    const result = await handleReadTimeline({ timelineId: "root" }, { requesterUid: OWNER });
+
+    expect(result.content[0].text).toContain("2 clips");
+    expect(result.content[0].text).toContain("run-1 (collection)");
+  });
+
+  it("reports a missing document without throwing", async () => {
+    const result = await handleReadTimeline({ timelineId: "nope" }, { requesterUid: OWNER });
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain('No timeline document with id "nope"');
+  });
+
+  it("refuses another account's timeline", async () => {
+    seed("root", [image("a")], "someone-else");
+
+    const result = await handleReadTimeline({ timelineId: "root" }, { requesterUid: OWNER });
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain("Not authorized");
+  });
+});

--- a/apps/timeline-gstudio001/lib/mcp/read-timeline.ts
+++ b/apps/timeline-gstudio001/lib/mcp/read-timeline.ts
@@ -1,0 +1,62 @@
+import { describeTimelineForAgent } from "@/lib/mcp-timeline-summary";
+import { serveTimelineDocument } from "@/lib/serve-timeline";
+import { TimelineAccessDeniedError } from "@/lib/timeline-ownership";
+import type { ToolResult } from "@/lib/webmcp/types";
+
+// read_timeline — one stored timeline document, as an agent should see it.
+//
+// SERVE, DON'T READ RAW. Collection summaries — `itemCount`, `previewItems`,
+// `duration` — are denormalized onto the PARENT's collection clip, and writes
+// are patch-scoped: editing a child never touches the parent that summarizes
+// it. `serveTimelineDocument` recomputes them across the whole closure, which
+// is exactly what the app's own GET route and the RSC loaders do.
+//
+// `derive-collection-summaries.ts` justifies "served, never persisted" with
+// "every view loads through the same GET route, so no reader ever sees a stale
+// summary". That stopped being true the moment this endpoint became a SECOND
+// reader. Reading the stored document directly showed an agent whatever was
+// last written: a collection whose children are all collections reported
+// `previewItems: []` (nothing ever writes preview frames that far up) and an
+// `itemCount` left over from an earlier shape of the tree.
+//
+// Kept as its own module, like every other tool in this directory, so it can be
+// tested without standing up the MCP handler — and so the serve path can't be
+// quietly swapped back for a raw store read.
+
+/** Both text blocks the tool returns: the sentence a model reads, then the
+ *  machine-readable payload. Split out so the route stays a wiring layer. */
+function readResult(summary: string, payload: unknown): ToolResult {
+  return {
+    content: [
+      { type: "text", text: summary },
+      { type: "text", text: JSON.stringify(payload, null, 2) },
+    ],
+  };
+}
+
+function readError(text: string): ToolResult {
+  return { content: [{ type: "text", text }], isError: true };
+}
+
+/**
+ * @param requesterUid the uid from the verified token — never from tool args.
+ */
+export async function handleReadTimeline(
+  { timelineId }: { timelineId: string },
+  { requesterUid }: { requesterUid: string },
+): Promise<ToolResult> {
+  try {
+    const served = await serveTimelineDocument(timelineId, requesterUid);
+    if (!served) return readError(`No timeline document with id "${timelineId}".`);
+
+    const document = served.document;
+    return readResult(describeTimelineForAgent(document), { timeline: document });
+  } catch (error) {
+    // Ownership is enforced in the store; surface a refusal rather than
+    // leaking whether the id exists under another account.
+    if (error instanceof TimelineAccessDeniedError) {
+      return readError(`Not authorized to read timeline "${timelineId}".`);
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
## The bug

`read_timeline` on the remote MCP endpoint called `getFirebaseTimelineDocument`, which is `return entry?.document ?? null` — the **raw stored record, no derivation**. Every other reader in the app (the GET route, the RSC loaders) goes through `serveTimelineDocument`.

Collection summaries — `itemCount`, `previewItems`, `duration` — are denormalized onto the **parent's** collection clip, and writes are patch-scoped: editing a child never touches the parent that summarizes it. `derive-collection-summaries.ts` justifies "served, never persisted" with *"every view loads through the same GET route, so no reader ever sees a stale summary"*. That stopped being true when this endpoint became a **second reader**.

Observed live on `project-1785765266842-92sagu`:

- a collection whose children are all collections returned `previewItems: []` — nothing ever writes preview frames that far up the tree
- `itemCount: 6` on a collection holding 2 direct children, left over from an earlier shape of the tree

## The fix

Swap the raw read for `serveTimelineDocument`, which recomputes summaries bottom-up across the whole closure. Same signature shape (`ServedTimeline | null`, throws `TimelineAccessDeniedError`), so it's a drop-in.

Extracted into `lib/mcp/read-timeline.ts` — matching `create-collection.ts`, `write-handlers.ts` and `upload.ts`, which all live in `lib/mcp/` with their own tests while the route stays a wiring layer. Importing `route.ts` in a test would drag in `mcp-handler` and the built widget bundle; this way the read path is directly testable, and it can't be quietly swapped back for a raw read without a test failing.

The route's wire shape is unchanged: `handleReadTimeline` returns the same two text blocks (agent summary, then JSON payload) and `fromToolResult` preserves both.

## Not in scope

The stored values are still stale in Firestore — this fixes what readers *see*, matching how the rest of the app already works. Persisting derived summaries is a separate call.

## Verification

- New `lib/mcp/read-timeline.test.ts` — 6 tests against the in-memory Firestore double used by the rest of `lib/mcp`, so the store, the closure walk and the derivation all run for real. Each fixture stores a deliberately **wrong** summary and asserts the derived one comes back, including one level deeper than a single-level derivation would reach.
- **Proved they fail first**: reverting `handleReadTimeline` to `getFirebaseTimelineDocument` fails 3 of 6 — `expected [] to deeply equal [ 'shot-a', 'shot-b' ]`, `expected 6 to be 1`, `expected 99 to be 1`. The other 3 (summary text, missing document, cross-account refusal) pass either way by design.
- `npx tsc --noEmit` — clean
- `npx vitest run` in `apps/timeline-gstudio001` — 646 passed
- `npx vitest run --project=unit` from `apps/storybook` — 499 passed
- `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)