### PR TITLE
Name the un-derived timeline reads, and enforce the boundary

### DIFF
--- a/apps/timeline-gstudio001/app/api/timelines/[id]/preview-manifest/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/[id]/preview-manifest/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 import { compilePlaybackManifest } from "@storyboard/timeline-domain";
 import { deriveClosureSummaries } from "@/lib/derive-collection-summaries";
 import { requireAuthUser } from "@/lib/firebase-auth-session";
-import { getFirebaseTimelineEntry } from "@/lib/firebase-timeline-store";
+import { readStoredTimelineEntry } from "@/lib/firebase-timeline-store";
 import {
   loadTimelineClosure,
   TimelineClosureTooLargeError,
@@ -41,7 +41,7 @@ export async function GET(
       return NextResponse.json({ error: "Timeline was not found." }, { status: 404 });
     }
 
-    const entry = await getFirebaseTimelineEntry(id, user.uid);
+    const entry = await readStoredTimelineEntry(id, user.uid);
     if (!entry) {
       return NextResponse.json({ error: "Timeline was not found." }, { status: 404 });
     }

--- a/apps/timeline-gstudio001/app/api/timelines/revisions/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/revisions/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { requireAuthUser } from "@/lib/firebase-auth-session";
-import { getFirebaseTimelineEntry } from "@/lib/firebase-timeline-store";
+import { readStoredTimelineEntry } from "@/lib/firebase-timeline-store";
 import { TimelineAccessDeniedError } from "@/lib/timeline-ownership";
 
 export const runtime = "nodejs";
@@ -43,7 +43,7 @@ export async function GET(request: Request) {
   await Promise.all(
     ids.map(async (id) => {
       try {
-        const entry = await getFirebaseTimelineEntry(id, user.uid);
+        const entry = await readStoredTimelineEntry(id, user.uid);
         // A missing or refused document is simply OMITTED rather than reported
         // as absent — a poller has no business learning which ids exist under
         // another account, and the client only acts on numbers it recognises.

--- a/apps/timeline-gstudio001/app/api/trash/route.ts
+++ b/apps/timeline-gstudio001/app/api/trash/route.ts
@@ -4,7 +4,7 @@ import { readJsonObject } from "@/lib/read-json-body";
 import { requireAuthUser } from "@/lib/firebase-auth-session";
 import {
   collectOwnedTimelineClips,
-  getFirebaseTimelineDocument,
+  readStoredTimelineDocument,
   saveFirebaseTimelineDocument,
 } from "@/lib/firebase-timeline-store";
 import {
@@ -41,7 +41,7 @@ export async function DELETE() {
     if (response || !user) return response || NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
     const trashId = `trash-${user.uid}`;
-    const trashDoc = await getFirebaseTimelineDocument(trashId, user.uid);
+    const trashDoc = await readStoredTimelineDocument(trashId, user.uid);
     const cleared = trashDoc?.clips.length ?? 0;
     if (!trashDoc || cleared === 0) return NextResponse.json({ success: true, cleared });
 
@@ -131,7 +131,7 @@ export async function POST(request: Request) {
     }
 
     const trashId = `trash-${user.uid}`;
-    const trashDoc = await getFirebaseTimelineDocument(trashId, user.uid);
+    const trashDoc = await readStoredTimelineDocument(trashId, user.uid);
     if (!trashDoc) return NextResponse.json({ success: true, discarded: 0 });
 
     // Drop ONE entry per requested id, not every clip sharing it: the bin can

--- a/apps/timeline-gstudio001/eslint.config.mjs
+++ b/apps/timeline-gstudio001/eslint.config.mjs
@@ -31,4 +31,64 @@ export default defineConfig([
     {
         extends: [...next],
     },
+    // Anything SERVED to a reader must derive its collection summaries.
+    //
+    // `itemCount`, `previewItems` and `duration` are denormalized onto the
+    // PARENT's collection clip, and writes are patch-scoped — editing a child
+    // never rewrites the parent that summarizes it. `serveTimelineDocument`
+    // recomputes them across the closure; the stored record does not, and its
+    // values are routinely wrong.
+    //
+    // `derive-collection-summaries.ts` justified "served, never persisted" with
+    // "every view loads through the same GET route, so no reader ever sees a
+    // stale summary". That invariant lived only in a comment, and the remote
+    // MCP `read_timeline` broke it — returning the stored record straight to an
+    // agent, which saw `previewItems: []` and a stale `itemCount`. It shipped
+    // and merged; human review did not catch it (#279, #282). Hence a rule.
+    //
+    // The allowlist below is the complete set of places raw reads are correct.
+    // Adding to it should require saying why in the same breath.
+    {
+        files: ["app/**/*.{ts,tsx}", "lib/**/*.{ts,tsx}", "components/**/*.{ts,tsx}"],
+        ignores: [
+            // The derive machinery itself — these READ raw in order to derive.
+            "lib/serve-timeline.ts",
+            "lib/load-timeline-closure.ts",
+            // Write round-trips: read, mutate, write back. Deriving here would
+            // PERSIST the summaries, which is the thing the design forbids.
+            "app/api/trash/route.ts",
+            // Existence + ownership check only; the content is never read.
+            "lib/project-asset-scope.ts",
+            "lib/project-asset-scope.test.ts",
+            // Reads `revision` alone.
+            "app/api/timelines/revisions/route.ts",
+            // Reads the root raw, then derives explicitly via loadTimelineClosure
+            // + deriveClosureSummaries — see the comment at its call site.
+            //
+            // The BRACKETS MUST BE ESCAPED. `ignores` takes globs, where
+            // `[id]` is a character class matching one of `i`, `d`, `n` — so
+            // the unescaped path silently matches nothing and this file gets
+            // flagged anyway. Every Next dynamic segment in this app has the
+            // same shape, so any future entry needs the same treatment.
+            "app/api/timelines/\\[id\\]/preview-manifest/route.ts",
+        ],
+        rules: {
+            "no-restricted-imports": [
+                "error",
+                {
+                    paths: [
+                        {
+                            name: "@/lib/firebase-timeline-store",
+                            importNames: [
+                                "readStoredTimelineDocument",
+                                "readStoredTimelineEntry",
+                            ],
+                            message:
+                                "Stored collection summaries (itemCount, previewItems, duration) are stale by design. Use serveTimelineDocument from @/lib/serve-timeline for anything served to a reader. If this is a write round-trip, an existence check, or a revision read, add the file to the allowlist in eslint.config.mjs with a reason.",
+                        },
+                    ],
+                },
+            ],
+        },
+    },
 ]);

--- a/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
@@ -378,7 +378,32 @@ export async function collectOwnedTimelineClips(
   }
 }
 
-export async function getFirebaseTimelineEntry(
+/**
+ * ONE stored record, EXACTLY as written — collection summaries and all.
+ *
+ * "Stored" is the load-bearing word, and the counterpart to `serveTimelineDocument`.
+ * A collection clip's `itemCount`, `previewItems` and `duration` are denormalized
+ * onto the PARENT, and writes are patch-scoped: editing a child never rewrites
+ * the parent that summarizes it. So those fields here are routinely, expectedly
+ * WRONG — often empty for a collection whose own children are collections,
+ * because nothing writes preview frames that far up the tree.
+ *
+ * **Raw is correct when the document is not being shown to anyone:**
+ *   - a write round-trip (read, mutate, write back) — deriving here would
+ *     PERSIST the summaries, which `derive-collection-summaries.ts` forbids
+ *   - an existence or ownership check that never looks at the content
+ *   - reading `revision` alone
+ *
+ * **Raw is WRONG for anything served to a reader** — a route response, an RSC
+ * payload, an agent tool result. Use `serveTimelineDocument`, which recomputes
+ * summaries bottom-up across the whole closure.
+ *
+ * That distinction used to live only in a comment, and the remote MCP
+ * `read_timeline` broke it: it returned this straight to an agent, which saw
+ * `previewItems: []` and a stale `itemCount` (#279). An eslint rule now keeps
+ * the legitimate callers to an explicit allowlist — see `eslint.config.mjs`.
+ */
+export async function readStoredTimelineEntry(
   id: string,
   requesterUid: string,
 ): Promise<TimelineEntry | null> {
@@ -400,8 +425,9 @@ export async function getFirebaseTimelineEntry(
   };
 }
 
-export async function getFirebaseTimelineDocument(id: string, requesterUid: string) {
-  const entry = await getFirebaseTimelineEntry(id, requesterUid);
+/** `readStoredTimelineEntry` without the revision — same caveats, read them there. */
+export async function readStoredTimelineDocument(id: string, requesterUid: string) {
+  const entry = await readStoredTimelineEntry(id, requesterUid);
   return entry?.document ?? null;
 }
 

--- a/apps/timeline-gstudio001/lib/load-timeline-closure.ts
+++ b/apps/timeline-gstudio001/lib/load-timeline-closure.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import type { TimelineDocument } from "@storyboard/timeline-model/types";
 
-import { getFirebaseTimelineEntry, type TimelineEntry } from "./firebase-timeline-store";
+import { readStoredTimelineEntry, type TimelineEntry } from "./firebase-timeline-store";
 
 // The nested document closure for a timeline: the root plus every document
 // reachable through collection clips, breadth-first with a visited set (a
@@ -117,7 +117,7 @@ export async function loadTimelineClosure(
   // rather than re-reading to rediscover the same absence. `undefined` means
   // the caller has no opinion.
   const read =
-    options?.read ?? ((childId: string) => getFirebaseTimelineEntry(childId, requesterUid));
+    options?.read ?? ((childId: string) => readStoredTimelineEntry(childId, requesterUid));
   const rootEntry =
     options?.rootEntry !== undefined
       ? options.rootEntry

--- a/apps/timeline-gstudio001/lib/mcp/apply-command.ts
+++ b/apps/timeline-gstudio001/lib/mcp/apply-command.ts
@@ -221,7 +221,7 @@ export async function applyCollectionsCommand(
   requesterUid: string,
   options: ApplyCommandOptions = {},
 ): Promise<ApplyCommandOutcome> {
-  // The closure loader reads through `getFirebaseTimelineEntry`, which enforces
+  // The closure loader reads through `readStoredTimelineEntry`, which enforces
   // ownership, but it swallows the refusal (`.catch(() => null)`) and reports
   // the document as missing. That is the behaviour we want here too: a denied
   // id and an absent id are indistinguishable to the caller, so knowing an id

--- a/apps/timeline-gstudio001/lib/project-asset-scope.test.ts
+++ b/apps/timeline-gstudio001/lib/project-asset-scope.test.ts
@@ -10,7 +10,7 @@ vi.mock("./firebase-timeline-store", async () => {
   const { TimelineAccessDeniedError } =
     await vi.importActual<typeof import("./timeline-ownership")>("./timeline-ownership");
   return {
-    getFirebaseTimelineDocument: async (id: string) => {
+    readStoredTimelineDocument: async (id: string) => {
       if (state.denied) throw new TimelineAccessDeniedError(id);
       return state.result;
     },

--- a/apps/timeline-gstudio001/lib/project-asset-scope.ts
+++ b/apps/timeline-gstudio001/lib/project-asset-scope.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { getFirebaseTimelineDocument } from "./firebase-timeline-store";
+import { readStoredTimelineDocument } from "./firebase-timeline-store";
 import { TimelineAccessDeniedError } from "./timeline-ownership";
 
 const PROJECT_ID_PATTERN = /^project-[a-zA-Z0-9_-]{1,160}$/;
@@ -30,7 +30,7 @@ export async function requireProjectAssetScope(
   }
 
   try {
-    const project = await getFirebaseTimelineDocument(value, uid);
+    const project = await readStoredTimelineDocument(value, uid);
     if (project === null) {
       throw new ProjectAssetScopeError(`Project "${value}" was not found.`, 404);
     }

--- a/apps/timeline-gstudio001/lib/serve-timeline.ts
+++ b/apps/timeline-gstudio001/lib/serve-timeline.ts
@@ -13,7 +13,7 @@ import {
   TimelineClosureTooLargeError,
 } from "./load-timeline-closure";
 import {
-  getFirebaseTimelineEntry,
+  readStoredTimelineEntry,
   type TimelineEntry,
 } from "./firebase-timeline-store";
 import { healTimelineDocument } from "./heal-timeline-document";
@@ -50,7 +50,7 @@ export function createTimelineEntryReader(requesterUid: string): TimelineEntryRe
   return (id) => {
     const cached = inflight.get(id);
     if (cached) return cached;
-    const request = getFirebaseTimelineEntry(id, requesterUid);
+    const request = readStoredTimelineEntry(id, requesterUid);
     inflight.set(id, request);
     return request;
   };
@@ -63,7 +63,7 @@ export async function serveTimelineDocument(
   requesterUid: string,
   /** Share one across a request to avoid re-reading documents (see
    *  `createTimelineEntryReader`). Defaults to an un-shared direct read. */
-  read: TimelineEntryReader = (childId) => getFirebaseTimelineEntry(childId, requesterUid),
+  read: TimelineEntryReader = (childId) => readStoredTimelineEntry(childId, requesterUid),
 ): Promise<ServedTimeline | null> {
   const entry = await read(id);
   if (!entry) return null;
@@ -145,7 +145,7 @@ export async function serveTimelineDocument(
 export async function serveTrashDocument(
   id: string,
   requesterUid: string,
-  read: TimelineEntryReader = (trashId) => getFirebaseTimelineEntry(trashId, requesterUid),
+  read: TimelineEntryReader = (trashId) => readStoredTimelineEntry(trashId, requesterUid),
 ): Promise<ServedTimeline> {
   const entry = await read(id);
   return {


### PR DESCRIPTION
Closes #282.

## The rule, stated more precisely than the issue did

Auditing the call sites changed my read of this. The rule is **not** "always derive" — raw reads are correct, and required, in three cases:

- **a write round-trip** (read, mutate, write back) — deriving here would **persist** the summaries, exactly what `derive-collection-summaries.ts` forbids
- **an existence or ownership check** that never looks at content
- **reading `revision` alone**

Raw is wrong only for something **served to a reader**: a route response, an RSC payload, an agent tool result.

## Audit result: no further live bugs

| call site | verdict |
|---|---|
| `app/api/trash/route.ts` ×2 | correct — write round-trip |
| `lib/project-asset-scope.ts` | correct — existence + ownership only |
| `app/api/timelines/revisions/route.ts` | correct — reads `revision` |
| `app/api/timelines/[id]/preview-manifest/route.ts` | correct — derives explicitly right after, and its comment already names this hazard |
| `lib/serve-timeline.ts`, `lib/load-timeline-closure.ts` | correct — they *are* the derive machinery |
| `app/api/mcp/route.ts` | was wrong; fixed in #279 |

**One historical violation, already fixed.** So this PR is a guard-rail against the next one, not a bug fix.

## Changes

**Rename**, so rawness is visible at the call site — `stored` is the deliberate counterpart to `serve`:

```
getFirebaseTimelineEntry    -> readStoredTimelineEntry
getFirebaseTimelineDocument -> readStoredTimelineDocument
```

The doc comment on `readStoredTimelineEntry` states the rule above, including *when raw is right*, so the next reader does not over-correct into deriving on a write path.

**Enforcement** — `no-restricted-imports` over `app/`, `lib/`, `components/`, with an allowlist naming every legitimate raw reader and its reason. Human review already missed this once, so a rule that fails CI earns its keep over a rename alone.

## Verification

- **Proved it catches the real bug**: re-adding the #279 import to `app/api/mcp/route.ts` fails lint with the guidance message. Reverted after checking.
- **Proved it does not false-positive**: `npm run lint` is 0 errors on the current tree (5 pre-existing `no-img-element` warnings, untouched).
- `npx tsc --noEmit` clean; `npx vitest run` 646 passed.

### One trap worth flagging for the next allowlist entry

`ignores: ["app/api/timelines/[id]/preview-manifest/route.ts"]` **silently matches nothing** — `ignores` takes globs, where `[id]` is a character class matching one of `i`, `d`, `n`. The file got flagged anyway until the brackets were escaped. Every Next dynamic segment in this app has that shape, so any future entry needs the same treatment. Called out in a comment at the allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)