### PR TITLE
Share the MCP tool field definitions across both transports

### DIFF
--- a/apps/timeline-gstudio001/app/api/mcp/route.ts
+++ b/apps/timeline-gstudio001/app/api/mcp/route.ts
@@ -10,6 +10,13 @@ import type { ToolResult } from "@/lib/webmcp/types";
 import { attachMedia, createUploadTicket } from "@/lib/mcp/upload";
 import { createCollection } from "@/lib/mcp/create-collection";
 import { handleReadTimeline } from "@/lib/mcp/read-timeline";
+import {
+  intoField,
+  nameField,
+  nodeIdField,
+  placementFields,
+  trimFields,
+} from "@/lib/webmcp/tool-fields";
 import { ProjectAssetScopeError } from "@/lib/project-asset-scope";
 import {
   handleMoveClip,
@@ -139,6 +146,18 @@ function uidFrom(extra: { authInfo?: { extra?: Record<string, unknown> } }): str
 
 const NO_IDENTITY = "Could not determine the account for this token.";
 
+/**
+ * REMOTE-ONLY, and deliberately not in the shared field module.
+ *
+ * The in-page tools act on the focused timeline, which the browser already
+ * knows. Server-side there is no focus, so every call must name the root whose
+ * closure gets loaded — and that root must contain every node the call touches.
+ */
+const TIMELINE_ID_FIELD = z
+  .string()
+  .min(1)
+  .describe("The timeline document that contains the item.");
+
 const handler = createMcpHandler(
   (server) => {
     server.tool(
@@ -185,15 +204,10 @@ const handler = createMcpHandler(
       "Move a clip or collection: reorder it within its current collection, or put it inside another one. Give at most one of `after`, `before` or `position`." +
         NO_LIVE_PUSH_NOTE,
       {
-        timelineId: z.string().min(1).describe("The timeline document that contains the clip."),
-        nodeId: z.string().min(1).describe("The clip or collection to move."),
-        into: z
-          .string()
-          .optional()
-          .describe("Target collection id. Omit to reorder within the current parent."),
-        after: z.string().optional().describe("Place directly after this sibling."),
-        before: z.string().optional().describe("Place directly before this sibling."),
-        position: z.enum(["start", "end"]).optional().describe("Place at the start or end."),
+        timelineId: TIMELINE_ID_FIELD,
+        nodeId: nodeIdField,
+        into: intoField,
+        ...placementFields,
       },
       async (args, extra) => {
         const uid = uidFrom(extra);
@@ -207,11 +221,9 @@ const handler = createMcpHandler(
       "Change how much of a clip plays. Videos take `trimInSeconds`/`trimOutSeconds` (seconds REMOVED from each end — an untrimmed clip is 0/0); images take `durationSeconds`." +
         NO_LIVE_PUSH_NOTE,
       {
-        timelineId: z.string().min(1).describe("The timeline document that contains the clip."),
-        nodeId: z.string().min(1).describe("The clip to trim."),
-        trimInSeconds: z.number().min(0).optional().describe("Video only: seconds removed from the START. 0 keeps the opening."),
-        trimOutSeconds: z.number().min(0).optional().describe("Video only: seconds removed from the END. 0 keeps the ending."),
-        durationSeconds: z.number().positive().optional().describe("Image only: how long it stays on screen."),
+        timelineId: TIMELINE_ID_FIELD,
+        nodeId: nodeIdField,
+        ...trimFields,
       },
       async (args, extra) => {
         const uid = uidFrom(extra);
@@ -225,9 +237,9 @@ const handler = createMcpHandler(
       "Rename a clip or a collection. Renaming a collection also retitles its own timeline document, so the board and the project list agree." +
         NO_LIVE_PUSH_NOTE,
       {
-        timelineId: z.string().min(1).describe("The timeline document that contains the item."),
-        nodeId: z.string().min(1).describe("The clip or collection to rename."),
-        name: z.string().min(1).describe("The new name."),
+        timelineId: TIMELINE_ID_FIELD,
+        nodeId: nodeIdField,
+        name: nameField,
       },
       async (args, extra) => {
         const uid = uidFrom(extra);
@@ -241,8 +253,8 @@ const handler = createMcpHandler(
       "Move a clip OR a collection to the trash. This is recoverable — nothing is hard-deleted, so it can be restored from the bin." +
         NO_LIVE_PUSH_NOTE,
       {
-        timelineId: z.string().min(1).describe("The timeline document that contains the item."),
-        nodeId: z.string().min(1).describe("The clip or collection to remove."),
+        timelineId: TIMELINE_ID_FIELD,
+        nodeId: nodeIdField,
         trashId: z
           .string()
           .min(1)

--- a/apps/timeline-gstudio001/lib/webmcp/tool-fields.test.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/tool-fields.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import { createGraphTools } from "./tools";
+import type { GraphToolContext } from "./tools";
+
+// The in-page tool schemas are GENERATED from zod now, and they are what an
+// agent reads before calling. Two things have to hold, and neither is obvious
+// from the generator:
+//
+//   1. the generated JSON Schema still says what the hand-written one said —
+//      same required keys, same bounds, still closed to unknown properties;
+//   2. the semantics that were LOST in the hand-written copy are present.
+//
+// (2) is the reason this refactor happened. The in-page `trimInSeconds` read
+// "Video only." while the remote one explained that it is seconds REMOVED from
+// the start, not a timestamp. The constraints agreed, so nothing validated
+// differently and no test could fail — the only symptom was an agent being told
+// less than it needed. Asserting on description text is unusual; here the
+// description IS the contract.
+
+/** The tools only need a context to close over; no schema test calls execute. */
+const ctx = {} as GraphToolContext;
+
+function schemaFor(name: string): Record<string, unknown> {
+  const tool = createGraphTools(ctx).find((t) => t.name === name);
+  if (!tool) throw new Error(`no tool named ${name}`);
+  return tool.inputSchema as Record<string, unknown>;
+}
+
+function props(name: string): Record<string, Record<string, unknown>> {
+  return schemaFor(name).properties as Record<string, Record<string, unknown>>;
+}
+
+describe("generated in-page tool schemas", () => {
+  it("keeps trim_clip's shape, bounds and closedness", () => {
+    const schema = schemaFor("trim_clip");
+    expect(schema.type).toBe("object");
+    expect(schema.required).toEqual(["nodeId"]);
+    // An unknown key is far more likely a caller confusing two tools than a
+    // forward-compatible extension — failing loudly beats ignoring it.
+    expect(schema.additionalProperties).toBe(false);
+
+    const p = props("trim_clip");
+    expect(p.trimInSeconds).toMatchObject({ type: "number", minimum: 0 });
+    expect(p.trimOutSeconds).toMatchObject({ type: "number", minimum: 0 });
+    // `.positive()` must land as EXCLUSIVE — a zero-length image is not a clip.
+    expect(p.durationSeconds).toMatchObject({ type: "number", exclusiveMinimum: 0 });
+  });
+
+  it("tells the agent trims are seconds REMOVED, not a start timestamp", () => {
+    // The regression this refactor exists to prevent. "Video only." passes
+    // every structural assertion above and still invites the wrong call.
+    const p = props("trim_clip");
+    expect(p.trimInSeconds.description).toMatch(/removed from the START/i);
+    expect(p.trimOutSeconds.description).toMatch(/removed from the END/i);
+  });
+
+  it("keeps move_clip's placement fields, and its in-page-only `select`", () => {
+    const schema = schemaFor("move_clip");
+    expect(schema.required).toEqual(["nodeId"]);
+    const p = props("move_clip");
+    expect(Object.keys(p).sort()).toEqual(
+      ["after", "before", "into", "nodeId", "position", "select"].sort(),
+    );
+    expect(p.position).toMatchObject({ enum: ["start", "end"] });
+    // Selection is a viewport concept; the remote transport has none, so this
+    // field must NOT leak into the shared definition.
+    expect(p.select).toMatchObject({ type: "boolean" });
+  });
+
+  it("keeps rename_item requiring a non-empty name", () => {
+    expect(schemaFor("rename_item").required).toEqual(["nodeId", "name"]);
+    // Empty is not a name — it would silently unlabel the card.
+    expect(props("rename_item").name).toMatchObject({ type: "string", minLength: 1 });
+  });
+
+  it("keeps remove_clip to just a nodeId", () => {
+    expect(Object.keys(props("remove_clip"))).toEqual(["nodeId"]);
+    expect(schemaFor("remove_clip").required).toEqual(["nodeId"]);
+  });
+
+  it("leaves read_timeline alone — it is NOT the same tool as the remote one", () => {
+    // In-page it walks the live graph from the focused node; remote it serves
+    // one stored document by id. Sharing a schema would force two different
+    // operations into one shape, so `timelineId` must not appear here.
+    const p = props("read_timeline");
+    expect(Object.keys(p).sort()).toEqual(["collectionId", "depth"]);
+    expect(p.timelineId).toBeUndefined();
+  });
+});

--- a/apps/timeline-gstudio001/lib/webmcp/tool-fields.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/tool-fields.ts
@@ -1,0 +1,94 @@
+import { z } from "zod";
+
+// ONE definition of the fields both MCP transports accept.
+//
+// The same edit tools are exposed twice — as in-page WebMCP tools against the
+// live CollectionsStore (`lib/webmcp/tools.ts`) and as remote MCP tools against
+// Firestore (`app/api/mcp/route.ts`). Their schemas were written independently,
+// and the halves diverged in the way that matters least visibly and most:
+//
+//   trimInSeconds, in-page : "Video only."
+//   trimInSeconds, remote  : "Video only: seconds removed from the START.
+//                             0 keeps the opening."
+//
+// The CONSTRAINTS agreed (`minimum: 0` both sides), so nothing validated
+// differently and no test could have caught it. But for a tool an LLM calls,
+// the description IS the contract: "Video only." never says that trimInSeconds
+// is seconds REMOVED rather than a start timestamp, so the in-page tool invited
+// exactly the wrong call. That is the cost of two definitions, and it is why
+// these live in one place now.
+//
+// WHAT IS NOT SHARED, deliberately:
+//   - `timelineId` — remote only. There is no "focused" timeline without a
+//     browser, so every server-side call must name its root. In-page, the focus
+//     IS the context.
+//   - `select` — in-page only. Selection is a UI concept; the remote transport
+//     has no viewport to reveal anything in.
+//   - `read_timeline` — not the same tool on both sides. In-page it walks the
+//     live graph from the focused node (`collectionId`, `depth`); remote it
+//     serves one stored document (`timelineId`). Sharing a schema there would
+//     be forcing two different operations into one shape.
+//
+// The remote wording won wherever the two disagreed: it was written later,
+// against real agent use, and it is the one that explains the semantics.
+
+/** The node an edit acts on. */
+export const nodeIdField = z.string().min(1).describe("The clip or collection to act on.");
+
+/**
+ * Where a moved node lands. Callers give at MOST one of these — the mutual
+ * exclusion is a runtime check in `resolveMovePlacement`, not a schema union,
+ * so that a caller sending two gets a sentence explaining the conflict rather
+ * than a schema rejection it cannot read.
+ */
+export const placementFields = {
+  after: z.string().optional().describe("Place directly after this sibling."),
+  before: z.string().optional().describe("Place directly before this sibling."),
+  position: z.enum(["start", "end"]).optional().describe("Place at the start or end."),
+} as const;
+
+/** The collection a node moves into. Omit to reorder where it already is. */
+export const intoField = z
+  .string()
+  .optional()
+  .describe("Target collection id. Omit to reorder within the current parent.");
+
+/**
+ * How much of a clip plays. Videos trim from each end; images just hold.
+ *
+ * The "seconds REMOVED" wording is load-bearing — an untrimmed clip is 0/0, not
+ * 0/duration — and it is the exact thing the in-page copy had lost.
+ */
+export const trimFields = {
+  trimInSeconds: z
+    .number()
+    .min(0)
+    .optional()
+    .describe("Video only: seconds removed from the START. 0 keeps the opening."),
+  trimOutSeconds: z
+    .number()
+    .min(0)
+    .optional()
+    .describe("Video only: seconds removed from the END. 0 keeps the ending."),
+  durationSeconds: z
+    .number()
+    .positive()
+    .optional()
+    .describe("Image only: how long it stays on screen."),
+} as const;
+
+/** A user-facing name. Empty is not a name — it would silently unlabel a card. */
+export const nameField = z.string().min(1).describe("The new name.");
+
+/**
+ * The in-page transport wants JSON Schema, the remote one wants zod. This is
+ * the one-way door between them.
+ *
+ * `additionalProperties: false` (via `.strict()`) is preserved from the
+ * hand-written schemas: an unknown key is far more likely a caller confusing
+ * two tools than a forward-compatible extension, and failing loudly beats
+ * silently ignoring the argument someone meant to pass.
+ */
+export function jsonSchemaFor(shape: z.ZodRawShape): unknown {
+  return z.toJSONSchema(z.object(shape).strict());
+}

--- a/apps/timeline-gstudio001/lib/webmcp/tools.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/tools.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import {
   getChildren,
   isVideoMedia,
@@ -11,6 +13,14 @@ import type { GraphViewStateDetail } from "@/lib/graph-view-events";
 
 import { resolveMovePlacement } from "./placement";
 import { describeDispatchRejection, toolError, toolOk } from "./results";
+import {
+  intoField,
+  jsonSchemaFor,
+  nameField,
+  nodeIdField,
+  placementFields,
+  trimFields,
+} from "./tool-fields";
 import { buildTimelineTree, type TimelineTree } from "./timeline-tree";
 import type { ToolDef } from "./types";
 
@@ -155,25 +165,17 @@ function moveClipTool(ctx: GraphToolContext): ToolDef {
     name: "move_clip",
     description:
       "Move or reorder a clip or collection. Give the node id and where it should land: into a collection (omit to reorder within its current parent) and one of before/after a sibling, or position start/end.",
-    inputSchema: {
-      type: "object",
-      required: ["nodeId"],
-      properties: {
-        nodeId: { type: "string" },
-        into: {
-          type: "string",
-          description: "Target collection id. Omit to reorder within the current parent.",
-        },
-        after: { type: "string", description: "Place immediately after this sibling id." },
-        before: { type: "string", description: "Place immediately before this sibling id." },
-        position: { type: "string", enum: ["start", "end"] },
-        select: {
-          type: "boolean",
-          description: "Select the moved node afterward so it's visible. Default true.",
-        },
-      },
-      additionalProperties: false,
-    },
+    // `select` is in-page only — the remote transport has no viewport to
+    // reveal anything in. Everything else comes from the shared fields.
+    inputSchema: jsonSchemaFor({
+      nodeId: nodeIdField,
+      into: intoField,
+      ...placementFields,
+      select: z
+        .boolean()
+        .optional()
+        .describe("Select the moved node afterward so it's visible. Default true."),
+    }),
     execute: (args) => {
       const nodeIdStr = readString(args, "nodeId");
       if (!nodeIdStr) return toolError("move_clip requires a nodeId.");
@@ -232,17 +234,7 @@ function trimClipTool(ctx: GraphToolContext): ToolDef {
     name: "trim_clip",
     description:
       "Set a media clip's trim or duration. Video: trimInSeconds / trimOutSeconds (omitted ones keep their current value). Image: durationSeconds.",
-    inputSchema: {
-      type: "object",
-      required: ["nodeId"],
-      properties: {
-        nodeId: { type: "string" },
-        trimInSeconds: { type: "number", minimum: 0, description: "Video only." },
-        trimOutSeconds: { type: "number", minimum: 0, description: "Video only." },
-        durationSeconds: { type: "number", exclusiveMinimum: 0, description: "Image only." },
-      },
-      additionalProperties: false,
-    },
+    inputSchema: jsonSchemaFor({ nodeId: nodeIdField, ...trimFields }),
     execute: (args) => {
       const nodeIdStr = readString(args, "nodeId");
       if (!nodeIdStr) return toolError("trim_clip requires a nodeId.");
@@ -315,15 +307,7 @@ function renameItemTool(ctx: GraphToolContext): ToolDef {
     name: "rename_item",
     description:
       "Rename a clip or collection. Renaming a collection also updates its child document's title.",
-    inputSchema: {
-      type: "object",
-      required: ["nodeId", "name"],
-      properties: {
-        nodeId: { type: "string" },
-        name: { type: "string", minLength: 1 },
-      },
-      additionalProperties: false,
-    },
+    inputSchema: jsonSchemaFor({ nodeId: nodeIdField, name: nameField }),
     execute: (args) => {
       const nodeIdStr = readString(args, "nodeId");
       if (!nodeIdStr) return toolError("rename_item requires a nodeId.");
@@ -346,12 +330,7 @@ function removeClipTool(ctx: GraphToolContext): ToolDef {
   return {
     name: "remove_clip",
     description: "Move a clip or collection to the trash. Recoverable — not a hard delete.",
-    inputSchema: {
-      type: "object",
-      required: ["nodeId"],
-      properties: { nodeId: { type: "string" } },
-      additionalProperties: false,
-    },
+    inputSchema: jsonSchemaFor({ nodeId: nodeIdField }),
     execute: (args) => {
       const nodeIdStr = readString(args, "nodeId");
       if (!nodeIdStr) return toolError("remove_clip requires a nodeId.");


### PR DESCRIPTION
Closes #280 — though **the issue's premise turned out to be wrong**, and the real finding is more interesting.

## What #280 assumed vs what is actually there

I filed it as "five tools defined twice, schemas that can drift." Auditing the two definitions first:

| tool | in-page | remote |
|---|---|---|
| `read_timeline` | `collectionId`, `depth` | `timelineId` |
| `move_clip` | `nodeId, into, after, before, position, select` | `timelineId, nodeId, into, after, before, position` |
| `trim_clip` | `nodeId` + trims | `timelineId, nodeId` + trims |
| `rename_item` | `nodeId, name` | `timelineId, nodeId, name` |
| `remove_clip` | `nodeId` | `timelineId, nodeId, trashId` |

They are not the same schema twice. Every remote tool takes `timelineId` because **there is no focused timeline without a browser**; the in-page ones act on the focus. `select` is a viewport concept the remote transport has none of. And `read_timeline` is not the same operation at all — in-page it walks the live graph from a node, remote it serves one stored document.

## The real drift, and why no test could have caught it

The **constraints** already agreed — `minimum: 0` ↔ `.min(0)`, `exclusiveMinimum: 0` ↔ `.positive()`. Nothing validated differently. The **descriptions** had diverged:

| | in-page | remote |
|---|---|---|
| `trimInSeconds` | *"Video only."* | *"Video only: seconds removed from the START. 0 keeps the opening."* |
| `trimOutSeconds` | *"Video only."* | *"Video only: seconds removed from the END. 0 keeps the ending."* |

For a tool an LLM calls, the description **is** the contract. "Video only." never says `trimInSeconds` is seconds *removed* rather than a start timestamp — an untrimmed clip is `0/0`, not `0/duration`. The in-page tool was inviting the wrong call, and because the bounds matched, no schema test would ever have gone red.

## Change

`lib/webmcp/tool-fields.ts` holds one definition of `nodeId`, the placement fields, `into`, the trim fields and `name`. Both transports build from it; `jsonSchemaFor` is the one-way door to JSON Schema for the in-page side (`z.toJSONSchema` — zod 4.4.3, already a direct dependency, no new package). The remote wording won wherever the two disagreed: written later, against real agent use, and it explains the semantics.

Scoped to the genuinely shared payload fields. `timelineId`, `select` and `read_timeline` stay where they are, with the reasons recorded in the module comment so the next person does not "finish the job" by force-merging them.

## Verification

Generated output is equivalent to what the tools advertised before — same `required`, same bounds, still `additionalProperties: false` — plus `minLength: 1` on `nodeId` (a tightening) and the missing descriptions.

New `lib/webmcp/tool-fields.test.ts` (6 tests) asserts both halves: the structural shape per tool, **and** that the trim descriptions carry "removed from the START/END". Asserting on description text is unusual; here it is the thing that regressed and the only thing that would catch it again.

- `npx vitest run` — 652 passed (65 files)
- `npx tsc --noEmit` clean
- `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)