### PR TITLE
Clear the selection when a double-click drills into a collection

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
@@ -366,6 +366,26 @@ export function OpenKeyBoundary({
       node?.kind === "collection" || detailsStore.get(id)?.duplicateOfTimelineId !== undefined;
     if (!opensTimeline) return;
     event.preventDefault();
+    // Take back the selection the FIRST click made.
+    //
+    // A double-click is three handlers deep and each one is behaving as
+    // designed: click 1 selects (interaction-policy's `clickSelection`), click
+    // 2 is skipped by that file's `detail > 1` guard — load-bearing, it is what
+    // stops a rename-in-place gesture starting with nothing selected — and then
+    // this fires. Nobody undid click 1, so the user landed INSIDE a collection
+    // with that collection still selected: the header read "1 selected", no
+    // card on screen was selected, and the header's promoted Delete was armed
+    // against the container they were looking at.
+    //
+    // The chevron route never had this: it lives inside
+    // `[data-collections-keyboard-ignore]`, so the selection surface does not
+    // select on it in the first place. This is double-click's equivalent, and
+    // it makes both ways in agree — you are inside it, nothing is selected.
+    //
+    // Clearing outright rather than restoring the prior selection is correct:
+    // an unmodified click 1 has ALREADY collapsed any multi-selection to this
+    // one card by the time dblclick runs, so there is nothing left to restore.
+    store.clearSelection();
     nav?.openTimeline(nodeId);
   };
 

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -3271,6 +3271,44 @@ test.describe("graph view E2E", () => {
     await expect.poll(() => stripOrder(page, CHILD_ID)).toEqual(["c1", "c2"]);
   });
 
+  test("double-clicking a collection drills in WITHOUT leaving it selected", async ({ page }) => {
+    // #295. Three handlers, each correct on its own, adding up to a wrong end
+    // state: click 1 selects the card, click 2 is skipped by
+    // interaction-policy's `detail > 1` guard (which exists so rename-in-place
+    // does not start with nothing selected), then dblclick navigates. Nobody
+    // undid click 1 — so the user landed INSIDE the collection with that
+    // collection still selected, no selected card anywhere on screen, and the
+    // header's promoted Delete armed against the container they were viewing.
+    await installGraphApi(page);
+    await openGraph(page);
+
+    await strip(page, PROJECT_ID).locator(`[data-node-id="${CHILD_ID}"]`).dblclick();
+    await page.waitForURL(`**${GRAPH_URL}/${CHILD_ID}`, { timeout: 5000 });
+
+    // Nothing selected, and no summary claiming otherwise. The count is the
+    // assertion that actually fails without the fix: the drilled-in view has
+    // no card for the parent, so a `[data-selected="true"]` check alone passes
+    // for the wrong reason.
+    await expect(page.locator("[data-selection-summary]")).toHaveCount(0);
+    await expect(page.locator('[data-selected="true"]')).toHaveCount(0);
+  });
+
+  test("the chevron and double-click agree on the state you land in", async ({ page }) => {
+    // The chevron never had this bug — it sits inside
+    // `[data-collections-keyboard-ignore]`, so the selection surface does not
+    // select on it at all. Pinning the two routes together so they cannot
+    // drift apart again.
+    await installGraphApi(page);
+    await openGraph(page);
+
+    await strip(page, PROJECT_ID)
+      .locator(`[data-node-wrapper="${CHILD_ID}"]`)
+      .getByRole("button", { name: /^Open / })
+      .click();
+    await page.waitForURL(`**${GRAPH_URL}/${CHILD_ID}`, { timeout: 5000 });
+    await expect(page.locator("[data-selection-summary]")).toHaveCount(0);
+  });
+
   test("duplicate media ids across documents demote instead of blanking the collection", async ({
     page,
   }) => {


### PR DESCRIPTION
Closes #295.

## The bug

Double-clicking a collection drills in correctly, but leaves the collection **selected**. Observed on the real project:

```
before : /timeline/<project>/graph                       selected 0
after  : /timeline/<project>/graph/timeline-mse2ooukmhripq
         header "1 selected"
         selected cards on screen: 0
         header Delete: ENABLED
```

You end up **inside** a collection, the header claims one item is selected, nothing on screen is selected, and the selection-scoped actions are live against an invisible node — the container you are looking at. Given the existing test *"the header's promoted Delete acts on the whole selection"*, double-click followed by Delete is a plausible route to trashing the collection you just opened. (I did not fire Delete to confirm — that would have been destructive on real data. The enabled state and the count are directly observed.)

## Why it happened

Three handlers, each correct on its own:

| | |
|---|---|
| click 1 (`detail === 1`) | `interaction-policy.ts` applies `clickSelection` |
| click 2 (`detail === 2`) | the same file's `detail > 1` guard skips it |
| `dblclick` | `graph-navigation.tsx` opens the timeline |

Nobody undoes click 1. And the `detail > 1` guard is **load-bearing** — it exists because letting click 2 run used to *clear* the selection, so a rename-in-place gesture began with nothing selected. The fix for that bug is what let this one through, which is why loosening the guard is the wrong move here.

## The fix

`store.clearSelection()` in `openFromDoubleClick`, once the gesture is known to open a timeline.

The **chevron** route was already right — it sits inside `[data-collections-keyboard-ignore]`, so the selection surface never selects on it. This gives double-click the same outcome, so both ways in agree: you are inside it, nothing is selected.

Clearing outright rather than restoring the prior selection is deliberate: an unmodified click 1 has already collapsed any multi-selection down to this one card by the time `dblclick` runs, so there is no prior selection left to restore. `clearSelection` is a no-op when already empty and also clears the pivot and multi-select mode.

## Verification

Two new e2e tests (real mouse — this is a pointer gesture):

- **the regression test**, which asserts the route changed AND nothing is selected. **Proved it fails first**: reverting just the `clearSelection()` call gives `Expected: 0, Received: 1` on `[data-selection-summary]`.
- **a guard** pinning the chevron and double-click to the same landing state, so they cannot drift apart again. This one passes either way by design — it documents the reference behaviour rather than testing the fix.

The count assertion is the one that matters: the drilled-in view has no card for the parent, so a `[data-selected="true"]` check **alone would pass for the wrong reason**.

- **147/147 graph-view e2e** (1.6m)
- `npx vitest run` — 667 passed
- `npx tsc --noEmit` clean; `npm run lint` 0 errors
- **Confirmed on the real project in the running app**: drills in, `selectionSummary: 0`, no "N selected" text, 0 selected cards.

### Note on writing the tests

Both new tests failed at first for an unrelated reason — I omitted `installGraphApi(page)`, so `openGraph` waited on fixture nodes that were never served. Worth knowing that the chevron test failing too was the signal it was setup, not the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)