### PR TITLE
Hold a collection's click-selection for the double-click window

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
@@ -366,21 +366,20 @@ export function OpenKeyBoundary({
       node?.kind === "collection" || detailsStore.get(id)?.duplicateOfTimelineId !== undefined;
     if (!opensTimeline) return;
     event.preventDefault();
-    // Take back the selection the FIRST click made.
+    // BACKSTOP, not the mechanism.
     //
-    // A double-click is three handlers deep and each one is behaving as
-    // designed: click 1 selects (interaction-policy's `clickSelection`), click
-    // 2 is skipped by that file's `detail > 1` guard — load-bearing, it is what
-    // stops a rename-in-place gesture starting with nothing selected — and then
-    // this fires. Nobody undid click 1, so the user landed INSIDE a collection
-    // with that collection still selected: the header read "1 selected", no
-    // card on screen was selected, and the header's promoted Delete was armed
-    // against the container they were looking at.
+    // Click 1 on a collection no longer selects immediately — the provider's
+    // `deferSelection` holds it for the double-click window and the second
+    // click drops it, so an ordinary double-click never paints a selection at
+    // all. That is what makes the drill-in look clean; doing it here could
+    // only ever undo a selection the user had already seen.
     //
-    // The chevron route never had this: it lives inside
-    // `[data-collections-keyboard-ignore]`, so the selection surface does not
-    // select on it in the first place. This is double-click's equivalent, and
-    // it makes both ways in agree — you are inside it, nothing is selected.
+    // This still runs because the hold has a deadline (`SELECTION_DEFER_MS`).
+    // A deliberately slow double-click outlasts it, the selection lands, and
+    // without this the user would end up INSIDE the collection with that
+    // collection still selected: header reading "1 selected", no selected card
+    // on screen, and the header's promoted Delete armed against the container
+    // they are looking at.
     //
     // Clearing outright rather than restoring the prior selection is correct:
     // an unmodified click 1 has ALREADY collapsed any multi-selection to this

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -612,6 +612,25 @@ export function GraphTimelineView({
       detailsStore.get(nodeId as string)?.duplicateOfTimelineId !== undefined,
     [detailsStore],
   );
+  // Hold a COLLECTION's click-selection for the double-click window, because
+  // double-click is how a collection drills in.
+  //
+  // Without this the user watches the card select and then unselect on its way
+  // into the drill-in: click 1 selects and paints, and the dblclick handler is
+  // only reached after that, so it can undo the selection but not un-show it.
+  // Deferring is the only point at which it can be prevented rather than
+  // reversed.
+  //
+  // Collections only. Media clips have no second meaning for a double-click,
+  // so delaying their selection would be cost with nothing bought. Duplicate
+  // references are excluded too — `openOnClick` already opens those on a
+  // SINGLE click, so there is no second click to wait for.
+  const deferSelection = useCallback(
+    (nodeId: NodeId, node: CollectionItemNode) =>
+      node.kind === "collection" &&
+      detailsStore.get(nodeId as string)?.duplicateOfTimelineId === undefined,
+    [detailsStore],
+  );
 
   if (boot.status === "loading") {
     return <GraphViewLoadingSkeleton />;
@@ -679,6 +698,7 @@ export function GraphTimelineView({
         dragGhostHeight={40}
         onOpenNode={handleOpenNode}
         openOnClick={openOnClick}
+        deferSelection={deferSelection}
         commandPolicy={commandPolicy}
         mapDropCommand={handleMapDropCommand}
         itemInstructions="Press O to open the focused collection, or F2 to rename it."

--- a/packages/ui/dnd-collections/react/DndCollections.tsx
+++ b/packages/ui/dnd-collections/react/DndCollections.tsx
@@ -127,6 +127,15 @@ export type DndCollectionsProps = Readonly<{
    *  set). Default: `node.kind === "collection"`. */
   openOnClick?: (id: NodeId, node: CollectionItemNode) => boolean;
   /**
+   * Hold these nodes' click-selection for the double-click window, for
+   * consumers where a DOUBLE-click opens a node. Without it the card visibly
+   * selects and then unselects on its way into the drill-in — click 1 paints
+   * before any dblclick handler can run. Costs a short delay on the single
+   * click, so return false for anything a double-click does not open.
+   * See `SELECTION_DEFER_MS`.
+   */
+  deferSelection?: (id: NodeId, node: CollectionItemNode) => boolean;
+  /**
    * Render media trim handles only on SELECTED cards, default `false`.
    * Unselected card edges become plain card body (press = drag/click), and
    * content's `trimEnabled` follows, so duration readouts gate with the
@@ -285,6 +294,7 @@ export function DndCollections({
   clickSelection,
   onOpenNode,
   openOnClick,
+  deferSelection,
   trimRequiresSelection,
   commandPolicy,
   mapDropCommand,
@@ -300,6 +310,7 @@ export function DndCollections({
     clickSelection,
     onOpenNode,
     openOnClick,
+    deferSelection,
     trimRequiresSelection,
   });
   // Live trim values ride a ref-backed emitter (never the store): only

--- a/packages/ui/dnd-collections/react/interaction-policy.test.ts
+++ b/packages/ui/dnd-collections/react/interaction-policy.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { buildGraph, parseNodeId, type CollectionsGraph, type GraphNodeSpec } from "../core/graph";
+import { createCollectionsStore } from "./collections-store";
+import {
+  cancelPendingSelection,
+  handleSelectionSurfaceClick,
+  SELECTION_DEFER_MS,
+  type CollectionsInteractionPolicy,
+} from "./interaction-policy";
+
+// DEFERRED click-selection, for consumers where a double-click opens a node.
+//
+// The bug it exists for is a visual one and so has no natural assertion: on a
+// double-click the card SELECTED and then unselected on its way into the
+// drill-in. Nothing was wrong with the end state — the selection was cleared —
+// but the user saw it happen. Undoing it at `dblclick` is too late by
+// construction: the browser fires click(1) → click(2) → dblclick, so click 1
+// has already selected and painted.
+//
+// What these pin is therefore about TIMING, not the final value: nothing is
+// selected during the window, and a second click inside the window means
+// nothing ever gets selected at all.
+
+const media = (id: string): GraphNodeSpec => ({ kind: "media", id, name: id });
+
+function graphFixture(): CollectionsGraph {
+  const result = buildGraph([
+    {
+      kind: "collection",
+      id: "root",
+      name: "Root",
+      children: [
+        { kind: "collection", id: "folder", name: "Folder", children: [media("m1")] },
+        media("clip"),
+      ],
+    },
+  ]);
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.value;
+}
+
+function setup(policyOverrides: Partial<CollectionsInteractionPolicy> = {}) {
+  const store = createCollectionsStore(graphFixture());
+  const policy: CollectionsInteractionPolicy = {
+    clickSelection: "replace",
+    trimRequiresSelection: false,
+    // Collections defer; media does not — a clip has no double-click meaning.
+    deferSelection: (_id, node) => node.kind === "collection",
+    ...policyOverrides,
+  };
+  const click = (id: string, detail = 1, modifiers: Partial<MouseEvent> = {}) => {
+    const nodeId = parseNodeId(id);
+    const node = store.getSnapshot().graph.nodesById.get(nodeId);
+    if (!node) throw new Error(`no node ${id}`);
+    handleSelectionSurfaceClick({
+      event: { ctrlKey: false, metaKey: false, shiftKey: false, detail, ...modifiers },
+      id: nodeId,
+      node,
+      store,
+      policy,
+    });
+  };
+  const selected = () => [...store.getSnapshot().interaction.selectedIds].map(String);
+  return { store, click, selected };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  cancelPendingSelection();
+  vi.useRealTimers();
+});
+
+describe("deferred click-selection", () => {
+  test("a deferred node is NOT selected while the window is open", () => {
+    // The whole point: at no instant before the deadline is it selected, so a
+    // double-click that lands inside the window never paints one.
+    const { click, selected } = setup();
+
+    click("folder");
+    expect(selected()).toEqual([]);
+
+    vi.advanceTimersByTime(SELECTION_DEFER_MS - 1);
+    expect(selected()).toEqual([]);
+  });
+
+  test("it lands once the window closes, so a plain click still selects", () => {
+    const { click, selected } = setup();
+
+    click("folder");
+    vi.advanceTimersByTime(SELECTION_DEFER_MS);
+    expect(selected()).toEqual(["folder"]);
+  });
+
+  test("a second click inside the window cancels it — nothing is ever selected", () => {
+    // The double-click case. click 2 is where a second click first becomes
+    // KNOWN, so it is where the held selection is dropped.
+    const { click, selected } = setup();
+
+    click("folder", 1);
+    click("folder", 2);
+    vi.advanceTimersByTime(SELECTION_DEFER_MS * 4);
+
+    expect(selected()).toEqual([]);
+  });
+
+  test("media selects IMMEDIATELY — deferring it would buy nothing", () => {
+    const { click, selected } = setup();
+
+    click("clip");
+    expect(selected()).toEqual(["clip"]);
+  });
+
+  test("no policy means no delay at all — existing consumers are untouched", () => {
+    const { click, selected } = setup({ deferSelection: undefined });
+
+    click("folder");
+    expect(selected()).toEqual(["folder"]);
+  });
+
+  test("Ctrl+click is immediate even on a deferred node", () => {
+    // An explicit multi-select gesture has no double-click meaning, so making
+    // the user wait for it would be pure cost.
+    const { click, selected } = setup();
+
+    click("folder", 1, { ctrlKey: true });
+    expect(selected()).toEqual(["folder"]);
+  });
+
+  test("clicking a DIFFERENT node supersedes a pending one", () => {
+    // Only one selection can be in flight; the newer click wins rather than
+    // both landing.
+    const { click, selected } = setup();
+
+    click("folder");
+    click("root");
+    vi.advanceTimersByTime(SELECTION_DEFER_MS);
+
+    expect(selected()).toEqual(["root"]);
+  });
+
+  test("cancelPendingSelection stops a landed-nowhere selection, and is idempotent", () => {
+    // Exported for the consumer's own drill-in routes: a keyboard open or a
+    // chevron click during the window must not be followed by a selection
+    // appearing behind the new view.
+    const { click, selected } = setup();
+
+    click("folder");
+    cancelPendingSelection();
+    cancelPendingSelection();
+    vi.advanceTimersByTime(SELECTION_DEFER_MS * 4);
+
+    expect(selected()).toEqual([]);
+  });
+});

--- a/packages/ui/dnd-collections/react/interaction-policy.ts
+++ b/packages/ui/dnd-collections/react/interaction-policy.ts
@@ -41,8 +41,66 @@ export type CollectionsInteractionPolicy = Readonly<{
   clickSelection: CollectionsClickSelection;
   onOpenNode?: (id: NodeId) => void;
   openOnClick?: (id: NodeId, node: CollectionItemNode) => boolean;
+  /**
+   * Nodes this returns true for do not select on click 1 — the selection is
+   * HELD for the double-click window and dropped if a second click arrives.
+   *
+   * For consumers where a double-click opens a node. The browser fires
+   * `click(detail 1)` → `click(detail 2)` → `dblclick`, so by the time a
+   * dblclick handler runs, click 1 has already selected AND PAINTED: the user
+   * sees the card select and then unselect on its way into the drill-in. No
+   * handler that runs at dblclick can fix that, because it is undoing
+   * something already on screen. Holding click 1 is the only point where the
+   * selection can be prevented rather than reversed.
+   *
+   * The cost is real and lands on the COMMON gesture: a plain click on one of
+   * these nodes selects `SELECTION_DEFER_MS` later. Return false for anything
+   * a double-click does not open — a media clip has no second meaning, so
+   * delaying it would buy nothing.
+   */
+  deferSelection?: (id: NodeId, node: CollectionItemNode) => boolean;
   trimRequiresSelection: boolean;
 }>;
+
+/**
+ * How long a deferred selection waits for a second click.
+ *
+ * A compromise, and worth knowing which way it errs. Windows' own double-click
+ * threshold defaults to 500ms; matching that would make every collection click
+ * feel broken. At 250ms a DELIBERATELY slow double-click can still let the
+ * selection land first — the card selects, then the drill-in clears it, which
+ * is the old flash. That path stays correct (the navigation handler clears the
+ * selection either way); it just is not invisible.
+ */
+export const SELECTION_DEFER_MS = 250;
+
+// Module-scoped because clicks are SERIAL: a pointer produces one click
+// sequence at a time, so there is never more than one selection in flight, and
+// keeping it here means both card shells share the same pending slot without
+// threading state through either of them.
+let pendingSelection: { timer: ReturnType<typeof setTimeout> } | null = null;
+
+/**
+ * Drop a held selection before it lands. Idempotent.
+ *
+ * Called on a second click (see `handleSelectionSurfaceClick`) and exported for
+ * the consumer's own drill-in paths — a keyboard open or a chevron click during
+ * the window should not be followed by a selection appearing behind it.
+ */
+export function cancelPendingSelection(): void {
+  if (pendingSelection === null) return;
+  clearTimeout(pendingSelection.timer);
+  pendingSelection = null;
+}
+
+function schedulePendingSelection(id: NodeId, apply: () => void): void {
+  cancelPendingSelection();
+  const timer = setTimeout(() => {
+    pendingSelection = null;
+    apply();
+  }, SELECTION_DEFER_MS);
+  pendingSelection = { timer };
+}
 
 const DEFAULT_POLICY: CollectionsInteractionPolicy = {
   clickSelection: "replace",
@@ -62,14 +120,16 @@ export function useCollectionsInteractionPolicyValue(props: {
   clickSelection?: CollectionsClickSelection;
   onOpenNode?: (id: NodeId) => void;
   openOnClick?: (id: NodeId, node: CollectionItemNode) => boolean;
+  deferSelection?: (id: NodeId, node: CollectionItemNode) => boolean;
   trimRequiresSelection?: boolean;
 }): CollectionsInteractionPolicy {
-  const { clickSelection, onOpenNode, openOnClick, trimRequiresSelection } = props;
+  const { clickSelection, onOpenNode, openOnClick, deferSelection, trimRequiresSelection } = props;
   return useMemo<CollectionsInteractionPolicy>(() => {
     if (
       clickSelection === undefined &&
       onOpenNode === undefined &&
       openOnClick === undefined &&
+      deferSelection === undefined &&
       trimRequiresSelection === undefined
     ) {
       return DEFAULT_POLICY;
@@ -78,9 +138,10 @@ export function useCollectionsInteractionPolicyValue(props: {
       clickSelection: clickSelection ?? "replace",
       onOpenNode,
       openOnClick,
+      deferSelection,
       trimRequiresSelection: trimRequiresSelection ?? false,
     };
-  }, [clickSelection, onOpenNode, openOnClick, trimRequiresSelection]);
+  }, [clickSelection, onOpenNode, openOnClick, deferSelection, trimRequiresSelection]);
 }
 
 /**
@@ -108,7 +169,14 @@ export function handleSelectionSurfaceClick(args: {
   // CLEARED it on click 2, so the user began renaming with nothing selected.
   // Keyboard activation (detail === 0) and a plain single click (detail === 1)
   // both fall through.
-  if (event.detail > 1) return;
+  //
+  // The cancel is what makes `deferSelection` work: this is the earliest point
+  // at which a second click is KNOWN, so it is where a pending selection from
+  // click 1 gets called off before it can paint.
+  if (event.detail > 1) {
+    cancelPendingSelection();
+    return;
+  }
 
   // Additive-tap MODE is the same branch as the modifier, deliberately: a
   // touchscreen has no Ctrl to hold, so the mode is how that gesture is
@@ -144,15 +212,26 @@ export function handleSelectionSurfaceClick(args: {
     return;
   }
 
-  if (policy.clickSelection === "toggle") {
-    const selected = store.getSnapshot().interaction.selectedIds;
-    if (selected.has(id) && selected.size === 1) {
-      store.clearSelection();
-    } else {
-      store.setSelection([id]);
+  // The plain-select branches, applied NOW or held for the double-click
+  // window — see `deferSelection`. Ctrl/Cmd and Shift above never defer: those
+  // are explicit multi-select gestures with no double-click meaning, and making
+  // the user wait for a modifier-click to land would be pure cost.
+  const apply = () => {
+    if (policy.clickSelection === "toggle") {
+      const selected = store.getSnapshot().interaction.selectedIds;
+      if (selected.has(id) && selected.size === 1) {
+        store.clearSelection();
+      } else {
+        store.setSelection([id]);
+      }
+      return;
     }
+    store.setSelection([id]);
+  };
+
+  if (policy.deferSelection?.(id, node) === true) {
+    schedulePendingSelection(id, apply);
     return;
   }
-
-  store.setSelection([id]);
+  apply();
 }


### PR DESCRIPTION
Follow-up to #296, which fixed the end state of #295 but not what you actually see.

## Why #296 wasn't enough

Clearing the selection at `dblclick` **cannot** remove the flash. The browser fires:

```
click (detail 1)  →  click (detail 2)  →  dblclick
```

Click 1 has already selected **and painted** by the time any `dblclick` handler runs. Undoing it there is reversing something already on screen — so the card visibly selected and then unselected on its way into the drill-in. The end state was right; the transition was not.

A selection can only be **prevented** at click 1, never reversed later. That is the whole of this change.

## What it does

The provider gains `deferSelection(id, node)`. Nodes it returns true for hold their click-selection for `SELECTION_DEFER_MS` instead of applying it; the second click — the earliest point at which a double-click is *known* — drops the pending one. An ordinary double-click therefore never paints a selection at all.

Wired in the graph view for **collections only**. Media clips have no second meaning for a double-click, and duplicate references already open on a *single* click (`openOnClick`), so neither waits.

## The cost, stated plainly

**A plain click on a collection now selects 250 ms later.** That lands on the more common gesture to remove a flash on the rarer one — a deliberate trade, and the one place I'd expect you to want a different call.

`250` is a compromise. Windows' own double-click threshold defaults to **500 ms**; matching that would make every collection click feel broken. Erring short means a *deliberately* slow double-click can still outlast the hold and let the selection land — so the navigation handler keeps clearing it, now documented as a **backstop rather than the mechanism**. That path is correct, just not invisible.

## Verification

**8 new unit tests** in `packages/ui/dnd-collections/react/interaction-policy.test.ts`. They pin **timing**, not the final value — the bug had no natural assertion, since the end state was already right:

- nothing is selected at click 1, nor mid-window
- it lands once the window closes, so a plain click still selects
- a second click inside the window means nothing is *ever* selected
- media selects immediately; no policy means no delay (existing consumers untouched); Ctrl+click is immediate
- a click on a different node supersedes a pending one
- `cancelPendingSelection` is idempotent

**Proved they fail first**: removing just the defer branch fails 3 of 8, all `expected [ 'folder' ] to deeply equal []` — the selection landing immediately, which is the flash. The other 5 pass either way by design; they guard against over-applying the delay.

**Observed in the running app on the real project**, which is the only check that speaks to the actual complaint:

| | `data-selected` |
|---|---|
| immediately after click 1 (double-click) | `absent` |
| 90 ms later, mid-window | `absent` |
| after the gesture | card gone — drilled in |
| single click, t=0 | `absent` |
| single click, t=300 ms | `true` |

- `--project=unit` 511 passed, `--project=storybook` 170 passed
- app `vitest run` 667 passed
- **147/147 graph-view e2e**
- `tsc --noEmit` clean in `packages/ui` and the app; lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)