### PR TITLE
Acknowledge a card press with a subtle artwork scale

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
@@ -22,6 +22,7 @@ import type { ClipDetail } from "@storyboard/timeline-domain";
 import type { GraphDetailsStore } from "@/lib/graph-details-store";
 
 import { useGraphDetailsStore } from "./graph-details-context";
+import { pressFeedbackHostFor, spawnPressFeedback } from "./press-feedback";
 
 type GraphViewNav = Readonly<{
   /**
@@ -388,8 +389,39 @@ export function OpenKeyBoundary({
     nav?.openTimeline(nodeId);
   };
 
+  /**
+   * Acknowledge the press IMMEDIATELY, whatever the click turns out to mean.
+   *
+   * A collection's selection is deliberately held for the double-click window
+   * so a drill-in never paints a selection first — which leaves a stretch where
+   * the click has landed and nothing has changed, and that reads as a missed
+   * click. The ripple covers it: it starts on POINTERDOWN, before the gesture
+   * is resolved, so the feedback cannot be late by construction.
+   *
+   * ONE listener here rather than per card, and this is not just economy: the
+   * collection card's root is `CollectionItem.SelectionSurface`, a package
+   * primitive with an explicit prop list and no rest spread, so there is no
+   * per-card seam to hang a handler on for collections at all. Delegating from
+   * above covers every card shape identically.
+   *
+   * Never stops propagation — the press still has to reach the drag sensor
+   * underneath.
+   */
+  const acknowledgePress = (event: React.PointerEvent<HTMLDivElement>) => {
+    // Secondary buttons open menus rather than acting on the card.
+    if (event.button !== 0) return;
+    if (store.getSnapshot().interaction.isDragging) return;
+    const host = pressFeedbackHostFor(event.target);
+    if (host) spawnPressFeedback(host);
+  };
+
   return (
-    <div style={{ display: "contents" }} onKeyDown={handleKeyDown} onDoubleClick={openFromDoubleClick}>
+    <div
+      style={{ display: "contents" }}
+      onKeyDown={handleKeyDown}
+      onPointerDown={acknowledgePress}
+      onDoubleClick={openFromDoubleClick}
+    >
       {children}
     </div>
   );

--- a/apps/timeline-gstudio001/components/graph-view/press-feedback.ts
+++ b/apps/timeline-gstudio001/components/graph-view/press-feedback.ts
@@ -1,0 +1,86 @@
+// Immediate press feedback on a card — the acknowledgement a deferred
+// selection cannot give.
+//
+// A collection's click-selection is HELD for the double-click window
+// (`SELECTION_DEFER_MS`) so an ordinary double-click never paints a selection
+// on its way into the drill-in. Correct, but it leaves a stretch where a click
+// has landed and nothing on screen has changed, and that reads as the app
+// missing the click. This fills it: the animation starts on POINTERDOWN, before
+// the selection question is even asked, so the answer to "did that register?"
+// no longer depends on what the click turns out to mean.
+//
+// It therefore plays for EVERY press — single click, the first click of a
+// double, and the start of a drag. That is the point. Feedback conditional on
+// the gesture's outcome would arrive exactly as late as the thing it covers for.
+//
+// IMPERATIVE, not React state. This is transient decoration no other component
+// reads, and routing it through state would re-render the pressed card on every
+// press — the dnd-collections efficiency model is built on cards NOT
+// re-rendering when nothing they display has changed, and a story test
+// (`RenderEfficiencyDuringDrag`) fails when a bystander card re-renders.
+// Animating an element directly sidesteps all of it.
+
+/** Peak scale. Deliberately tiny — the brief is "barely even notice it", and
+ *  anything past ~1.05 stops reading as acknowledgement and starts reading as
+ *  a hover effect. */
+const PRESS_SCALE = 1.035;
+
+/** Out and back. Long enough to be a smooth swell rather than a twitch, short
+ *  enough to be over before the 250ms selection hold resolves. */
+const PRESS_MS = 340;
+
+/**
+ * Acknowledge a press by letting the card's artwork swell very slightly.
+ *
+ * THE IMAGES, not the card. Two reasons, and the first is a correctness one:
+ *
+ *  - dnd-kit drives drags with `transform` on the card and its wrapper. A press
+ *    is also where a drag begins, so animating the card's own transform would
+ *    put this in direct conflict with the drag it may be starting.
+ *  - The frame row that holds the images already clips (`overflow-hidden`), so
+ *    scaling the images inside it reads as a gentle zoom WITHIN the frame. The
+ *    card's own geometry never moves, which is what keeps neighbouring cards
+ *    still and the effect subtle.
+ *
+ * Scaling every image covers both card shapes without either knowing about
+ * this: media cards carry one filmstrip frame, collection cards up to three
+ * preview frames, and both are plain `<img>`.
+ */
+export function spawnPressFeedback(host: HTMLElement): void {
+  if (typeof window === "undefined") return;
+  // Reduced motion means NO animation. The effect IS the motion, so there is
+  // no static fallback worth substituting.
+  if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+
+  const images = host.querySelectorAll<HTMLElement>("img");
+  for (const image of images) {
+    if (typeof image.animate !== "function") continue;
+    image.animate(
+      [
+        { transform: "scale(1)" },
+        { transform: `scale(${PRESS_SCALE})`, offset: 0.45 },
+        { transform: "scale(1)" },
+      ],
+      // ease-in-out both ways: the swell and the settle should feel like one
+      // motion. Easing only on the way out makes the return look like a snap.
+      { duration: PRESS_MS, easing: "ease-in-out" },
+    );
+  }
+  // No cleanup: a Web Animations keyframe effect with no `fill` leaves the
+  // element exactly as it found it, so nothing has to be undone — and an
+  // element that unmounts mid-animation (a drill-in does that immediately)
+  // takes its animation with it.
+}
+
+/**
+ * The card a press landed on, or null when the press does not deserve feedback.
+ *
+ * Controls own their own gestures and their own feedback — the chevron and the
+ * `⋮` already have hover and active states, so animating the whole card
+ * underneath them would claim something happened to the card when it did not.
+ */
+export function pressFeedbackHostFor(target: EventTarget | null): HTMLElement | null {
+  if (!(target instanceof Element)) return null;
+  if (target.closest("[data-collections-keyboard-ignore]") !== null) return null;
+  return target.closest<HTMLElement>("[data-node-id]");
+}


### PR DESCRIPTION
Follow-up to #297. That change made a collection's selection wait for the double-click window, so a drill-in never paints a selection on its way in — but it left a stretch where the click has landed and **nothing on screen has changed**, which reads as the app missing the click.

## What this does

Feedback now starts on **pointerdown**, before the gesture is resolved, so it cannot be late by construction. The card's artwork swells to `1.035` and settles back over 340ms.

Measured on the real board:

| ~elapsed | image scale |
|---|---|
| 0 ms | 1.0000 |
| 80 ms | 1.0061 |
| 150 ms | **1.0329** |
| 250 ms | 1.0092 |
| 400 ms | 1.0000 |

`getAnimations()` is empty afterwards — the keyframe effect has no `fill`, so it leaves the element exactly as it found it and nothing needs undoing.

## The images, not the card — and that is a correctness point, not a style one

dnd-kit drives drags with `transform` on the card and its wrapper. **A press is also where a drag begins**, so animating the card's own transform would put this in direct conflict with the drag it may be starting.

Scaling the images avoids that entirely, and happens to look better: the frame row already clips (`overflow-hidden`), so the images zoom *within* the frame and the card's own geometry never moves. Neighbouring cards stay perfectly still.

Every card shape is covered without either knowing about this — media cards carry one filmstrip frame, collection cards up to three preview frames, and both are plain `<img>`.

## Two rejected attempts, recorded so they are not retried

- **A ripple** — rejected as too decorative. It also could not work as a *fill*: measured on the real board, a low-alpha white wash over full-bleed artwork is effectively invisible, and the alpha needed to see it turned the card into a flashbulb. Switching it to a ring made it visible, but by then it was the wrong effect anyway.
- **An inset edge flash** — reused the card's existing ring vocabulary and read cleanly on any backdrop, but still too present.

## Two structural notes

**One delegated listener, not per-card.** Not only economy: the collection card's root is `CollectionItem.SelectionSurface`, a package primitive with an explicit prop list and **no rest spread**, so there is no per-card seam to hang a handler on for collections at all. Delegating from the graph-view root covers every card shape identically — and keeps this out of `packages/ui`, whose invariant is that the shell paints nothing.

**Imperative, not React state.** This is transient decoration no other component reads. Routing it through state would re-render the pressed card on every press, against the package's render-efficiency model — there is a story test (`RenderEfficiencyDuringDrag`) that fails when a bystander card re-renders.

Skipped entirely under `prefers-reduced-motion`, and on the chevron / `⋮`, which own their own gestures and already have their own hover and active states.

## Verification

- Scale curve sampled from `getComputedStyle` on the live board (table above)
- Fires on all three card types; no residue afterwards
- No feedback on the chevron — it is both inside a `keyboard-ignore` region and outside `[data-node-id]`, so both guards agree
- `npx vitest run` 667 passed; `npx tsc --noEmit` clean; lint 0 errors
- **147/147 graph-view e2e** — the suite that drives these gestures with a real mouse

🤖 Generated with [Claude Code](https://claude.com/claude-code)