### PR TITLE
Tune the press animation: slower, smaller, accelerating into full size

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/press-feedback.ts
+++ b/apps/timeline-gstudio001/components/graph-view/press-feedback.ts
@@ -20,14 +20,34 @@
 // (`RenderEfficiencyDuringDrag`) fails when a bystander card re-renders.
 // Animating an element directly sidesteps all of it.
 
-/** Peak scale. Deliberately tiny — the brief is "barely even notice it", and
- *  anything past ~1.05 stops reading as acknowledgement and starts reading as
- *  a hover effect. */
-const PRESS_SCALE = 1.035;
+/**
+ * Peak scale. Deliberately tiny — the brief is "barely even notice it".
+ *
+ * Tuned DOWN twice by eye: 1.035 -> 1.02 -> 1.012. On a ~360px card frame
+ * that is roughly 12.7px -> 7.2px -> 4.3px of growth.
+ *
+ * The reason it kept needing to shrink is worth recording: duration and
+ * amplitude trade against each other. At the original 340ms a 3.5% swell was
+ * barely legible, but the motion was later slowed to 640ms, and once the eye
+ * has time to FOLLOW the movement the same number reads as a real zoom. If
+ * `PRESS_MS` is ever shortened again, this can afford to grow back.
+ */
+const PRESS_SCALE = 1.012;
 
-/** Out and back. Long enough to be a smooth swell rather than a twitch, short
- *  enough to be over before the 250ms selection hold resolves. */
-const PRESS_MS = 340;
+/**
+ * Out and back, in equal halves.
+ *
+ * Deliberately unhurried. 340ms was the first value and read as a twitch —
+ * the swell arrived and left before the eye settled on it. At 640 the motion
+ * is slow enough to follow, which is what makes something this small (3.5%)
+ * legible at all.
+ *
+ * It deliberately OUTLASTS the 250ms selection hold. The two are not sequential
+ * steps to be kept apart: the scale acknowledges the press, the selection
+ * answers what the press meant, and letting the first still be settling when
+ * the second lands reads as one continuous response rather than two events.
+ */
+const PRESS_MS = 640;
 
 /**
  * Acknowledge a press by letting the card's artwork swell very slightly.
@@ -57,13 +77,29 @@ export function spawnPressFeedback(host: HTMLElement): void {
     if (typeof image.animate !== "function") continue;
     image.animate(
       [
-        { transform: "scale(1)" },
-        { transform: `scale(${PRESS_SCALE})`, offset: 0.45 },
+        // PER-KEYFRAME easing, because the two halves want different curves
+        // and the timing option below could only apply one shape to both.
+        //
+        // GROW — starts almost imperceptibly and accelerates into full size.
+        // The acceleration is the point: a press should feel like it is being
+        // answered with increasing conviction, not like a value being
+        // interpolated.
+        { transform: "scale(1)", easing: "ease-in" },
+        // SHRINK — leaves the peak at the speed the grow arrived with, then
+        // decelerates to rest. Pairing ease-in up with ease-out down keeps the
+        // SPEED continuous through the apex; two ease-ins back to back would
+        // slam to a halt at full size and read as a bump.
+        //
+        // Exactly the MIDPOINT, so growing and shrinking still take the same
+        // wall time.
+        { transform: `scale(${PRESS_SCALE})`, offset: 0.5, easing: "ease-out" },
         { transform: "scale(1)" },
       ],
-      // ease-in-out both ways: the swell and the settle should feel like one
-      // motion. Easing only on the way out makes the return look like a snap.
-      { duration: PRESS_MS, easing: "ease-in-out" },
+      // LINEAR overall. The per-keyframe curves above do all the shaping; an
+      // easing here would warp PROGRESS as well, which moves the `offset: 0.5`
+      // keyframe off the midpoint in wall time and quietly breaks the equal
+      // halves.
+      { duration: PRESS_MS, easing: "linear" },
     );
   }
   // No cleanup: a Web Animations keyframe effect with no `fill` leaves the


### PR DESCRIPTION
Follow-up tuning to #298, three rounds of adjustment by eye against the real board.

| | before | after |
|---|---|---|
| duration | 340 ms | **640 ms** |
| peak scale | 1.035 | **1.012** |
| growth on a ~360 px frame | 12.7 px | **4.35 px** |
| easing | `ease-in-out` (whole run) | **per-keyframe** `ease-in` up / `ease-out` down |
| peak position | offset 0.45 | **offset 0.5** — exact midpoint |

## Why the amplitude kept coming down

Duration and amplitude trade against each other, and that is the whole story of these three rounds. At the original 340 ms a 3.5% swell was *barely legible*. Once the motion slowed to 640 ms the eye had time to **follow** it, and the same number started reading as a real zoom. Hence 1.035 → 1.02 → 1.012.

Recorded in the constant's comment, because the obvious future change — shortening the duration — would make the current amplitude nearly invisible, and the reason would not be guessable from the number alone.

## The easing, precisely

The request was that the **growth phase** start slowly and accelerate into full size — not the whole out-and-back run. That is per-keyframe easing, not a timing-level curve:

- **grow** (`ease-in`) — starts almost imperceptibly, accelerating into full size
- **shrink** (`ease-out`) — leaves the peak at the speed the growth arrived with, then decelerates

Pairing them that way keeps **speed continuous through the apex**. Two `ease-in`s back to back would slam to a halt at full size and read as a bump.

**Overall timing is `linear` on purpose.** The per-keyframe curves do all the shaping; an easing on the timing option warps *progress* as well, which moves the `offset: 0.5` keyframe off the midpoint in wall time and quietly breaks the equal grow/shrink halves that were asked for earlier. That was a real trap — an earlier attempt set `easing: "ease-in"` at the timing level and would have pushed the peak to roughly two-thirds through.

## Measured shape

Scrubbed from the live animation rather than sampled in real time (the harness throttles timers, which made wall-clock sampling useless). Growth in thousandths of image size:

```
  0ms   0
 80ms   1.1     +1.1
160ms   3.8     +2.7
240ms   7.4     +3.6      accelerating into the peak
320ms  12.0     +4.6   ← full size, exact midpoint
400ms   7.4     -4.6
480ms   3.8     -3.6      decelerating out of it
560ms   1.1     -2.7
640ms   0       -1.1
```

## Verification

- `npx vitest run` 667 passed; `npx tsc --noEmit` clean; lint 0 errors
- **147/147 graph-view e2e**
- Shape and pixel growth read off the live animation on the real project

🤖 Generated with [Claude Code](https://claude.com/claude-code)