### PR TITLE
Settle the press animation at 400ms

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/press-feedback.ts
+++ b/apps/timeline-gstudio001/components/graph-view/press-feedback.ts
@@ -37,17 +37,15 @@ const PRESS_SCALE = 1.012;
 /**
  * Out and back, in equal halves.
  *
- * Deliberately unhurried. 340ms was the first value and read as a twitch —
- * the swell arrived and left before the eye settled on it. At 640 the motion
- * is slow enough to follow, which is what makes something this small (3.5%)
- * legible at all.
+ * Tuned by eye: 340ms read as a twitch (the swell arrived and left before the
+ * eye settled on it), 640 was slower than wanted, 400 is the settled value.
  *
  * It deliberately OUTLASTS the 250ms selection hold. The two are not sequential
  * steps to be kept apart: the scale acknowledges the press, the selection
  * answers what the press meant, and letting the first still be settling when
  * the second lands reads as one continuous response rather than two events.
  */
-const PRESS_MS = 640;
+const PRESS_MS = 400;
 
 /**
  * Acknowledge a press by letting the card's artwork swell very slightly.


### PR DESCRIPTION
Final tuning pass on #298 / #299. 640 ms was slower than wanted.

| | #299 | now |
|---|---|---|
| duration | 640 ms | **400 ms** |
| peak at | 320 ms | **200 ms** — still the exact midpoint |
| peak growth | 4.35 px | 4.30 px (unchanged scale) |

Measured on the live board, growth in pixels on a 362 px frame:

```
  0ms  0
 80ms  0.92
160ms  2.97
200ms  4.30   ← full size, exact midpoint
240ms  2.97
320ms  0.92
400ms  0
```

Same accelerating grow (`ease-in`) and mirrored settle (`ease-out`), and the overall timing stays `linear` so the midpoint keyframe still lands at the midpoint in wall time.

**Amplitude deliberately left at 1.012.** The constant's own note records that duration and scale trade against each other — a shorter run makes the same scale less legible, so 1.012 *could* afford to grow back now. But that is a by-eye judgement on the shortened timing, and pre-applying it would be guessing at a call that has already been made three times by looking at it.

## Verification

- `npx vitest run` 667 passed; `npx tsc --noEmit` clean; lint 0 errors
- 147/147 graph-view e2e
- Shape read off the live animation on the real project

🤖 Generated with [Claude Code](https://claude.com/claude-code)