### PR TITLE
Layers icon for the drill control, and a bigger card-control cluster

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-anchor-menu.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-anchor-menu.tsx
@@ -198,18 +198,23 @@ export function AnchorMenuButton({
             focusNodeWhenMounted(document.body, nodeId);
           }}
           className={cn(
-            "relative z-20 flex size-6 shrink-0 items-center justify-center rounded",
+            "relative z-20 flex size-7 shrink-0 items-center justify-center rounded",
             "bg-zinc-950/80 text-zinc-100 shadow-sm shadow-black/40 backdrop-blur-[1px]",
             "cursor-pointer transition-colors hover:bg-zinc-800 hover:text-white",
             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300",
             // 44px effective target on a coarse pointer (R6.3), from padding —
-            // the visual control stays 24px so it matches the chevron.
+            // the visual control stays 28px so it matches the drill control it
+            // replaces. Those two CROSS-FADE on the anchor card, so any size
+            // difference between them shows up as a jump at the swap: they have
+            // to be resized together, and this file hard-codes the look rather
+            // than importing CARD_CONTROL_CLASS, so changing that alone is not
+            // enough.
             "after:absolute after:left-1/2 after:top-1/2 after:-translate-x-1/2 after:-translate-y-1/2",
             "after:content-[''] [@media(pointer:coarse)]:after:h-11 [@media(pointer:coarse)]:after:w-11",
             className,
           )}
         >
-          <EllipsisVertical aria-hidden="true" className="size-4" />
+          <EllipsisVertical aria-hidden="true" className="size-5" />
           <AnchorCountBadge count={state.selectionCount} />
         </button>
       </DropdownMenuTrigger>
@@ -306,5 +311,9 @@ export function ClipCornerSlot({
   // default inset put the `⋮` flush against the amber handle. Collections have
   // no handles and keep the tighter inset. See TRIM_CLEARANCE in
   // graph-item-content.
-  return <CardCornerSlot nodeId={nodeId} className="right-4" />;
+  // TRACKS THE CONTROL SIZE. This was `right-4` while the controls were 24px;
+  // at 28px the measured gap to the trim handle fell from 8px to 4px, which the
+  // e2e clearance test caught. Resizing CARD_CONTROL_CLASS means moving this and
+  // TRIM_CLEARANCE_LEFT with it — nothing but that test connects the three.
+  return <CardCornerSlot nodeId={nodeId} className="right-5" />;
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -629,9 +629,13 @@ export const DisabledCollection: Story = {
     await expect(metadata.textContent).toContain("A timeline");
     await expect(metadata.textContent).toContain("8.0s");
     await expect(metadata.textContent).toContain("2 items");
-    // The drill control's glyph is a CHEVRON now (PL13-004), at lucide's own
-    // stroke weight — it was CornerRightDown at 1.5 while it was a large
-    // circle on the artwork.
+    // The drill control's glyph is LAYERS, at lucide's own stroke weight.
+    // It has been three things: CornerRightDown at 1.5 while it was a large
+    // circle on the artwork, then a chevron (PL13-004), now layers — a chevron
+    // said "enter" but nothing about WHAT it opens. The assertion is on stroke
+    // WEIGHT rather than the icon because that is the part that regressed: a
+    // hand-set 1.5, left over from the large-circle era, looked thin once the
+    // glyph shrank.
     const drillGlyph = canvasElement.querySelector<SVGElement>(
       'button[aria-label="Open A timeline"] svg',
     )!;

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -12,7 +12,7 @@ import {
   useSyncExternalStore,
   type ReactNode,
 } from "react";
-import { Check, ChevronRight, CornerRightDown } from "lucide-react";
+import { Check, CornerRightDown, Layers } from "lucide-react";
 
 import {
   CollectionItem,
@@ -512,9 +512,15 @@ function CollectionLeaderPlaceholder() {
  * selected clip the checkmark and the `⋮` landed flush against the amber
  * handles with no gap at all, reading as one crowded cluster.
  *
- * 16px clears the handle by its own width again. Applied on CLIPS only:
+ * 20px clears the handle by its own width again. Applied on CLIPS only:
  * collections have no handles, and shifting their controls to match would move
  * them for a constraint they do not have.
+ *
+ * THIS TRACKS THE CONTROL SIZE. It was 16px while the controls were 24px; they
+ * grew to 28px and the measured gap fell from 8px to 4px, which the e2e
+ * clearance test caught. Anything that changes `CARD_CONTROL_CLASS`'s size has
+ * to move this with it — the two numbers are not independent, and nothing but
+ * that test connects them.
  *
  * Both controls only exist on a SELECTED card, and a selected clip always shows
  * its right handle — so there is no state where this inset is reserved against
@@ -524,8 +530,8 @@ function CollectionLeaderPlaceholder() {
  * interpolated `left-${n}` is a class that never gets generated — the control
  * would silently fall back to `left: auto` and sit in the wrong place.
  */
-const TRIM_CLEARANCE_LEFT = "left-4";
-const TRIM_CLEARANCE_RIGHT = "right-4";
+const TRIM_CLEARANCE_LEFT = "left-5";
+const TRIM_CLEARANCE_RIGHT = "right-5";
 
 function CardSelectedBadge({ clearsTrimHandles = false }: Readonly<{ clearsTrimHandles?: boolean }>) {
   return (
@@ -533,12 +539,17 @@ function CardSelectedBadge({ clearsTrimHandles = false }: Readonly<{ clearsTrimH
       data-card-selected-badge
       aria-hidden="true"
       className={[
-        "pointer-events-none absolute top-2 z-20 flex size-5 items-center justify-center",
+        "pointer-events-none absolute top-2 z-20 flex size-7 items-center justify-center",
         "rounded bg-amber-300 text-zinc-950 shadow-sm shadow-black/50",
         clearsTrimHandles ? TRIM_CLEARANCE_LEFT : "left-2",
       ].join(" ")}
     >
-      <Check className="size-3.5" strokeWidth={3} />
+      {/* size-5, matching the drill and overflow glyphs. The three controls in
+          this cluster read as one family, so a glyph a size apart is the odd
+          one out even from the opposite corner. strokeWidth 3 stays: a check on
+          a filled amber chip needs more weight than an outline glyph on dark
+          artwork to carry the same. */}
+      <Check className="size-5" strokeWidth={3} />
     </span>
   );
 }
@@ -550,7 +561,7 @@ function CardSelectedBadge({ clearsTrimHandles = false }: Readonly<{ clearsTrimH
  *  sidebar's FolderTree toggles whether the children tree is SHOWN, a
  *  different verb that deliberately does not share this icon. */
 /**
- * The look every CARD-LEVEL control shares: a 24px square on the card's right
+ * The look every CARD-LEVEL control shares: a 28px square on the card's right
  * edge, dark enough to sit on artwork, always visible.
  *
  * Shared so a card reads as having ONE kind of control rather than a collection
@@ -572,7 +583,7 @@ function CardSelectedBadge({ clearsTrimHandles = false }: Readonly<{ clearsTrimH
  *   "selected" about a thing you are merely pointing at.
  */
 const CARD_CONTROL_CLASS = [
-  "z-20 flex size-6 shrink-0 items-center justify-center rounded",
+  "z-20 flex size-7 shrink-0 items-center justify-center rounded",
   "bg-zinc-950/80 text-zinc-300 shadow-sm shadow-black/40 backdrop-blur-[1px]",
   "cursor-pointer transition-colors hover:bg-zinc-800 hover:text-zinc-50",
 ].join(" ");
@@ -1192,13 +1203,21 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300",
             ].join(" ")}
           >
-            {/* ONE glyph. It briefly carried CornerRightDown as well, on the
-                reasoning that the badge had to say "container" and "way in" at
-                once — but that name lies: `CollectionDrillGlyph` draws
-                CornerRightDown, so the pair was two direction arrows saying the
-                same thing twice. A chevron alone reads as "enter"; what says
-                CONTAINER is the card. */}
-            <ChevronRight className="size-4" aria-hidden="true" />
+            {/* LAYERS, not a direction arrow.
+                This was a chevron, on the reasoning that the card itself says
+                "container" so the badge only had to say "enter". True as far as
+                it went, but it left the control saying nothing about WHAT it
+                opens — and a chevron is the most generic glyph in the set,
+                doing disclosure duty everywhere else in the UI. Layers names
+                the thing: a stack of timelines, which is what a collection is.
+                Still ONE glyph. An earlier version paired the arrow with
+                CornerRightDown and ended up with two direction marks saying the
+                same thing twice; pairing layers with an arrow would repeat that
+                in a new costume.
+                No `strokeWidth` — lucide's default of 2 is deliberate and a
+                story asserts it (the old CornerRightDown ran at 1.5 only
+                because it was drawn much larger). */}
+            <Layers className="size-5" aria-hidden="true" />
           </button>
         }
       />

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -6486,9 +6486,9 @@ test.describe("graph view E2E", () => {
       const anchor = anchorMenuButton(page).first();
       await expect(anchor).toBeVisible();
 
-      // The control is 24px so it matches the chevron it replaces, so it
+      // The control is 28px so it matches the drill control it replaces, so it
       // cannot BE 44px — the target comes from a padded `::after` layer
-      // instead (R6.3). Measuring the button's own box would report 24 and
+      // instead (R6.3). Measuring the button's own box would report 28 and
       // prove nothing; this measures the layer that actually receives the tap.
       const hit = await anchor.evaluate((el) => {
         const after = getComputedStyle(el, "::after");


### PR DESCRIPTION
## Icon

The collection card's drill control was a chevron. A chevron says *"enter"* but nothing about **what** it opens — and it is the most generic glyph in the set, already doing disclosure duty everywhere else. `Layers` names the thing: a stack of timelines, which is what a collection is.

Still one glyph. An earlier version paired the arrow with `CornerRightDown` and ended up with two direction marks saying the same thing twice; pairing layers with an arrow would repeat that in a new costume.

## Size

All three corner controls now match, at a 28px box with a 20px glyph:

| control | before | after |
|---|---|---|
| drill (`Layers`) | 24 / 16 | **28 / 20** |
| overflow (`⋮`) | 24 / 16 | **28 / 20** |
| selected badge (`Check`) | 20 / 14 | **28 / 20** |

The check badge was a size apart from the other two even before this, which is why it needed more than a proportional bump to sit with them.

**The `⋮` hard-codes the control look** rather than importing `CARD_CONTROL_CLASS`, so changing the shared constant alone leaves it behind — and the two **cross-fade** on the anchor card, so any size difference between them shows up as a jump at the swap. Noted at both sites.

## The part that wasn't obvious: trim clearance tracks control size

On a selected clip the corner controls sit against an 8px trim-handle hit zone. Growing them by 4px cut the measured gap from 8px to **4px** — the exact crowding the clearance was added to prevent, caught by `the corner controls clear a selected clip's trim handles`.

Both insets moved to 20px, and both now carry a note that they track the control size:

- `TRIM_CLEARANCE_LEFT` — the check badge
- `ClipCornerSlot`'s own `right-5` — the `⋮`

Worth flagging for whoever resizes these next: **`TRIM_CLEARANCE_RIGHT` is defined but never used.** The right side is positioned by `ClipCornerSlot` instead, so changing that constant does nothing — I changed it first and the gap stayed at 4.

## Verification

- **147/147 graph-view e2e**, including the clearance test that caught the regression
- `graph-item-content` story suite 14 passed — its assertion is on stroke weight, which lucide's default of 2 preserves across the icon swap
- `npx vitest run` 667 passed; `npx tsc --noEmit` clean; lint 0 errors
- Measured in the running app: all three controls report exactly 28×28 with 20×20 glyphs

Stale comments naming the old chevron and the old 24px are updated in the story and the e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)