### PR TITLE
One corner-control inset for every card kind, and more room above

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-anchor-menu.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-anchor-menu.tsx
@@ -265,7 +265,14 @@ export function CardCornerSlot({
   return (
     <span
       // NOT `overflow-hidden` — the count badge overhangs this box (R6.10).
-      className={cn("absolute right-2 top-2 z-20 flex items-center gap-1.5", className)}
+      //
+      // `right-5` (20px) is the shared card-control inset — see
+      // CARD_CONTROL_INSET_RIGHT in graph-item-content, which puts the check
+      // badge at the matching distance on the opposite corner. It exists for
+      // trim handles, which only CLIPS have, but every card kind uses it: at
+      // 8px on collections and 20px on clips the controls visibly jumped
+      // between card kinds in the same grid.
+      className={cn("absolute right-5 top-3 z-20 flex items-center gap-1.5", className)}
     >
       <span className="relative grid size-6 place-items-center">
         {chevron === undefined ? null : (
@@ -306,14 +313,11 @@ export function ClipCornerSlot({
   // 0 is "not measured yet", not "too narrow" — rendering nothing until the
   // first ResizeObserver callback would flash the control in on every mount.
   if (width > 0 && width < MIN_ANCHOR_CONTROL_WIDTH) return null;
-  // `right-4` rather than the collection card's `right-2`: a selected clip
-  // carries an 8px trim-handle hit zone pinned to its right edge, and the
-  // default inset put the `⋮` flush against the amber handle. Collections have
-  // no handles and keep the tighter inset. See TRIM_CLEARANCE in
-  // graph-item-content.
-  // TRACKS THE CONTROL SIZE. This was `right-4` while the controls were 24px;
-  // at 28px the measured gap to the trim handle fell from 8px to 4px, which the
-  // e2e clearance test caught. Resizing CARD_CONTROL_CLASS means moving this and
-  // TRIM_CLEARANCE_LEFT with it — nothing but that test connects the three.
-  return <CardCornerSlot nodeId={nodeId} className="right-5" />;
+  // NO inset override any more. This used to widen the clip's inset past the
+  // collection card's, because only a clip carries the 8px trim-handle hit zone
+  // the control has to clear. That was correct per card kind and wrong on
+  // screen: the two sat side by side in one grid and the controls jumped
+  // between them. `CardCornerSlot` now carries the wider inset for everything,
+  // so this differs from a collection's slot only in the width guard above.
+  return <CardCornerSlot nodeId={nodeId} />;
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -505,16 +505,20 @@ function CollectionLeaderPlaceholder() {
  * off the other's line is exactly what stops them reading as a pair.
  */
 /**
- * How far the corner controls sit in on a card that carries TRIM HANDLES.
+ * How far a card's corner controls sit in from its edge. ONE value, every card
+ * kind.
  *
- * A handle's hit zone is 8px (`w-2`, pinned to `left-0`/`right-0` in the
- * package's TrimHandles), and the ordinary corner inset is also 8px — so on a
- * selected clip the checkmark and the `⋮` landed flush against the amber
- * handles with no gap at all, reading as one crowded cluster.
+ * It is 20px because of TRIM HANDLES: a handle's hit zone is 8px (`w-2`, pinned
+ * to `left-0`/`right-0` in the package's TrimHandles), and at the old 8px inset
+ * the checkmark and the `⋮` landed flush against the amber handles, reading as
+ * one crowded cluster. 20px clears a handle by its own width again.
  *
- * 20px clears the handle by its own width again. Applied on CLIPS only:
- * collections have no handles, and shifting their controls to match would move
- * them for a constraint they do not have.
+ * APPLIED EVERYWHERE, INCLUDING COLLECTIONS, which have no handles. That looks
+ * like padding a card for a constraint it does not have — and it was, until the
+ * two kinds were seen side by side. Collections sat at 8px and clips at 20px, so
+ * the check and the drill control visibly JUMPED as the eye moved between card
+ * kinds in the same grid. A shared inset with one card kind's reason behind it
+ * beats two correct-in-isolation values that disagree on screen.
  *
  * THIS TRACKS THE CONTROL SIZE. It was 16px while the controls were 24px; they
  * grew to 28px and the measured gap fell from 8px to 4px, which the e2e
@@ -522,24 +526,27 @@ function CollectionLeaderPlaceholder() {
  * to move this with it — the two numbers are not independent, and nothing but
  * that test connects them.
  *
- * Both controls only exist on a SELECTED card, and a selected clip always shows
- * its right handle — so there is no state where this inset is reserved against
- * a handle that never arrives.
- *
  * Written as WHOLE literal class names. Tailwind's JIT scans source text, so an
  * interpolated `left-${n}` is a class that never gets generated — the control
  * would silently fall back to `left: auto` and sit in the wrong place.
  */
-const TRIM_CLEARANCE_LEFT = "left-5";
-const TRIM_CLEARANCE_RIGHT = "right-5";
+/** Left/right inset, shared by every card kind. */
+export const CARD_CONTROL_INSET_LEFT = "left-5";
+export const CARD_CONTROL_INSET_RIGHT = "right-5";
+/** Top inset, `top-3` (12px) rather than the `top-2` these started at: at
+ *  8px the controls sat tight under the card's edge once they grew to 28px.
+ *  The badge and the corner slot are TOP-ALIGNED and must move together, so
+ *  `CardCornerSlot` in graph-anchor-menu carries the literal twin of this —
+ *  it cannot import from here without a cycle. */
+export const CARD_CONTROL_INSET_TOP = "top-3";
 
-function CardSelectedBadge({ clearsTrimHandles = false }: Readonly<{ clearsTrimHandles?: boolean }>) {
+function CardSelectedBadge() {
   return (
     <span
       data-card-selected-badge
       aria-hidden="true"
       className={[
-        "pointer-events-none absolute top-2 z-20 flex items-center justify-center",
+        "pointer-events-none absolute top-3 z-20 flex items-center justify-center",
         // NO CHIP, deliberately — this is a STATUS MARK, not a control.
         //
         // It has been three things, and the middle one is the instructive
@@ -571,7 +578,7 @@ function CardSelectedBadge({ clearsTrimHandles = false }: Readonly<{ clearsTrimH
         // enough against a lit sky. A single heavier blur is not the fix either
         // — it reads as a smudge under the mark rather than an edge around it.
         "[filter:drop-shadow(0_0_1.5px_rgb(9_9_11))_drop-shadow(0_0_1.5px_rgb(9_9_11))_drop-shadow(0_0_1.5px_rgb(9_9_11))_drop-shadow(0_0_3px_rgb(0_0_0/0.85))]",
-        clearsTrimHandles ? TRIM_CLEARANCE_LEFT : "left-2",
+        CARD_CONTROL_INSET_LEFT,
       ].join(" ")}
     >
       {/* size-6 and a heavy stroke, where the CONTROLS use size-5 at lucide's
@@ -1375,7 +1382,7 @@ const GraphMediaItem = memo(function GraphMediaItem({
       <NodeCard {...props} className="h-full w-full" />
       {/* The anchor keeps its badge too (R5.3) — see the collection card. It
           clears the trim handles, which a selected clip always carries. */}
-      {mediaSelected && <CardSelectedBadge clearsTrimHandles />}
+      {mediaSelected && <CardSelectedBadge />}
       {/* A clip has no chevron to morph, so the `⋮` simply fades in (R5.6).
           No chevron is added here for symmetry. */}
       <ClipCornerSlot nodeId={props.id} width={size.width} />


### PR DESCRIPTION
The corner controls sat at different insets depending on card kind:

| | collection | clip |
|---|---|---|
| check badge | `left-2` (8px) | `left-5` (20px) |
| corner slot | `right-2` (8px) | `right-5` (20px) |

Each was defensible on its own — only a clip carries the 8px trim-handle hit zone the control has to clear — and wrong together. **The two kinds sit side by side in the same grid**, so the check and the drill control visibly jumped as the eye moved between them.

## The clip value wins

It is the one with a reason behind it. Collections now pay 20px for a constraint they do not have, which is the cheaper mistake: a shared inset with one card kind's justification beats two values that are each correct in isolation and disagree on screen.

Top inset also goes 8px → 12px, on both marks together — they are top-aligned, so moving one alone would break the cluster's shared line.

## It deletes more than it adds

- **`clearsTrimHandles`** prop on `CardSelectedBadge` — every card clears now, so the branch has nothing to choose between
- **`ClipCornerSlot`'s inset override** — it now differs from a collection's slot only in its narrow-card width guard
- **`TRIM_CLEARANCE_RIGHT`**, which was **already dead**. The right side is positioned by `CardCornerSlot`, so that constant moved nothing — and it cost two wrong attempts to discover while widening the clearance in #301. Worth knowing it is gone rather than merely unused.

`TRIM_CLEARANCE_*` → `CARD_CONTROL_INSET_*`: the old name described the *reason*, which now applies to cards with no trim handles at all.

## Verification

Zero per-kind overrides remain — both card kinds resolve to the same literal classes:

```
badge : absolute top-3 … + CARD_CONTROL_INSET_LEFT  (left-5)
slot  : absolute right-5 top-3 …
CardCornerSlot className overrides: 0
```

- **147/147 graph-view e2e**, including `the corner controls clear a selected clip's trim handles` — the assertion that guarantees the wider inset still does its original job at the new top offset
- `graph-item-content` story suite green; `npx vitest run` 667 passed
- `npx tsc --noEmit` clean; lint 0 errors
- Confirmed on the real board

🤖 Generated with [Claude Code](https://claude.com/claude-code)