### PR TITLE
Mint attach_media clip ids instead of deriving them from the asset

### DIFF
--- a/apps/timeline-gstudio001/lib/assets/asset-references.ts
+++ b/apps/timeline-gstudio001/lib/assets/asset-references.ts
@@ -6,10 +6,10 @@
 // unit-tests without a backend.
 //
 // The rule: an asset dies when nothing references it. Not when its clip is
-// deleted — one upload can back several clips (this app mints stable per-asset
-// clip ids, so placing an asset twice makes two clips of one file), and the bin
-// is per-USER while an asset is per-project, so a bin spans everything its
-// owner owns.
+// deleted — one upload can back several clips (clip ids are minted per
+// PLACEMENT, so the same file can sit in several spots, each its own clip), and
+// the bin is per-USER while an asset is per-project, so a bin spans everything
+// its owner owns.
 
 import type { TimelineClip } from "@storyboard/timeline-model/types";
 

--- a/apps/timeline-gstudio001/lib/mcp/upload.test.ts
+++ b/apps/timeline-gstudio001/lib/mcp/upload.test.ts
@@ -114,6 +114,18 @@ function storedClips(id: string): TimelineClip[] {
   return ((state.docs.get(id) as { clips?: TimelineClip[] } | undefined)?.clips ?? []);
 }
 
+/**
+ * The id of the clip an attach minted. Ids are MINTED, not derived from the
+ * asset, so a test cannot spell one out — read the one the tool reports. (These
+ * assertions used to match on the public id inside the clip id, which is
+ * exactly the coupling that stopped an asset being attached twice.)
+ */
+function attachedNodeId(result: Awaited<ReturnType<typeof attachMedia>>): string {
+  const { nodeId } = (result.structuredContent ?? {}) as { nodeId?: string };
+  if (nodeId === undefined) throw new Error("expected the attach to report a nodeId");
+  return nodeId;
+}
+
 beforeEach(() => {
   state.docs.clear();
   state.assets.length = 0;
@@ -138,7 +150,7 @@ describe("attachMedia", () => {
     );
 
     expect(result.isError).toBeFalsy();
-    const added = storedClips(PROJECT).find((c) => c.id.includes("render-123"));
+    const added = storedClips(PROJECT).find((c) => c.id === attachedNodeId(result));
     expect(added).toBeDefined();
     // TimelineClip is a union; provenance only exists on media clips.
     if (!added || added.kind === "collection") throw new Error("expected a media clip");
@@ -207,7 +219,7 @@ describe("attachMedia", () => {
   it("places it after a named sibling rather than always appending", async () => {
     seed(PROJECT, [clip("a"), clip("b")]);
 
-    await attachMedia(
+    const result = await attachMedia(
       {
         timelineId: PROJECT,
         projectId: PROJECT,
@@ -217,11 +229,41 @@ describe("attachMedia", () => {
       OWNER,
     );
 
+    expect(storedClips(PROJECT).map((c) => c.id)).toEqual(["a", attachedNodeId(result), "b"]);
+  });
+
+  // Node ids used to be `clip-<publicId>`, which made the id a function of the
+  // asset: the same file could exist at exactly one place, and the second
+  // attach was refused with "already on this timeline". Nothing about the
+  // product wanted that rule — a shot legitimately reuses a plate, and the
+  // read projection already has to demote cross-document collisions to `dup:`
+  // ids. Provenance is what identifies the asset; the id only has to be unique.
+  it("attaches the same asset twice, as two independent clips", async () => {
+    seed(PROJECT, []);
+    const args = {
+      timelineId: PROJECT,
+      projectId: PROJECT,
+      publicId: "media/user-a/project-alpha/render-123",
+    };
+
+    const first = await attachMedia(args, OWNER);
+    const second = await attachMedia(args, OWNER);
+
+    expect(first.isError).toBeFalsy();
+    expect(second.isError).toBeFalsy();
     expect(storedClips(PROJECT).map((c) => c.id)).toEqual([
-      "a",
-      "clip-media/user-a/project-alpha/render-123",
-      "b",
+      attachedNodeId(first),
+      attachedNodeId(second),
     ]);
+    // Both carry the same provenance — one file, two placements. That is what
+    // keeps reclaim correct: the asset stays referenced until BOTH are gone.
+    for (const added of storedClips(PROJECT)) {
+      if (added.kind === "collection") throw new Error("expected media clips");
+      expect(added.sourceAsset).toEqual({
+        providerId: "cloudinary",
+        assetId: "media/user-a/project-alpha/render-123",
+      });
+    }
   });
 
   it("refuses when the upload never landed, instead of minting a dead clip", async () => {

--- a/apps/timeline-gstudio001/lib/mcp/upload.ts
+++ b/apps/timeline-gstudio001/lib/mcp/upload.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import { parseNodeId, type CollectionsGraph, type NodeId } from "@storyboard/collections-core";
 
 import { CLOUDINARY_PROVIDER_ID } from "@/lib/assets/cloudinary-provider";
@@ -88,9 +90,16 @@ export async function attachMedia(
   const displayName =
     (args.name ?? asset.relativePath ?? asset.pathname).trim() || asset.pathname;
 
-  // A fresh node id derived from the public id, which already carries an
-  // upload timestamp — so it cannot collide with an existing node.
-  const newNodeId = parseNodeId(`clip-${asset.pathname}`);
+  // A freshly MINTED id, not one derived from the public id. Deriving it made
+  // the id a function of the asset, so attaching one asset twice produced two
+  // nodes with the same id — which node ids, being the addressing scheme,
+  // cannot allow. That forced a "one asset, one place" rule nothing about the
+  // product wanted, and it collided across documents too (the read projection
+  // in timeline-domain has to demote such clips to `dup:` ids to keep the whole
+  // tree from being rejected). Asset identity lives in `sourceAsset` below,
+  // which is what every reader actually uses to recover it; the id only has to
+  // be unique. Same prefixes as the drag-drop path so both mint alike.
+  const newNodeId = parseNodeId(`${isVideo ? "video" : "image"}-${randomUUID().slice(0, 8)}`);
   let placedIndex = -1;
   let placedParent: NodeId | null = null;
 
@@ -106,10 +115,6 @@ export async function attachMedia(
           message: `Target "${targetId}" is a clip, not a collection — clips can only go inside a collection.`,
         } as const;
       }
-      if (graph.nodesById.has(newNodeId)) {
-        return { ok: false, message: `"${asset.pathname}" is already on this timeline.` } as const;
-      }
-
       const placement = resolveMovePlacement(graph, {
         nodeId: newNodeId,
         targetId,


### PR DESCRIPTION
`attach_media` built its node id as `clip-<publicId>`, making the id a function of the asset. Node ids are the addressing scheme and must be graph-unique, so the same file could exist in exactly **one** place:

- a second attach was refused with `"…" is already on this timeline.`
- the same asset in two documents collided hard enough that the read projection in `timeline-domain` has to demote such clips to synthetic `dup:` ids, or `buildGraph` rejects the whole tree

Nothing about the product wanted that rule — a shot legitimately reuses a plate, and the workaround was "one asset, one collection", enforced by hand.

## The fix

Mint the id per **placement**, using the same `video-`/`image-` prefixes the drag-drop path already mints, and drop the guard the old scheme forced. Every other id-minting path in the repo (native drop, clone, `create_collection`) was already unique — `attach_media` was the sole asset-derived one.

Asset identity was never in the id anyway. It lives in `sourceAsset`, which is what every reader actually uses to recover it, and nothing in the repo parses a clip id back into an asset id.

## Why this is safe for reclaim

`assetCandidatesFromClips` already de-duplicates by asset ref key and works off `sourceAsset`, not ids — its header comment even says one upload can back several clips. Two clips of one file keep the asset referenced until both are gone. Updated the comment there, which still described the removed scheme.

The `dup:` demotion in `adapter.ts` stays: documents written under the old scheme still hold colliding ids.

## Verification

- New test `attaches the same asset twice, as two independent clips` — **proven to fail on the old code** (and it fails even with the guard removed, because the reducer itself rejects `duplicate-node-id`, confirming the id scheme was the real cause).
- Two existing tests that pinned the literal `clip-media/user-a/project-alpha/render-123` id now read the minted id back off the tool result.
- `npx vitest run` — 668 passed (67 files); `tsc --noEmit` clean; `npm run lint` clean (5 pre-existing `<img>` warnings in unrelated files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
