### PR TITLE
attach_media: record an explicit name as an authored TITLE, not just alt

### DIFF
--- a/apps/timeline-gstudio001/lib/mcp/upload.test.ts
+++ b/apps/timeline-gstudio001/lib/mcp/upload.test.ts
@@ -315,6 +315,43 @@ describe("attachMedia", () => {
     expect(attachedNodeId(result).startsWith("audio-")).toBe(true);
   });
 
+  // Cards render `title` and never `alt`, so a caller-supplied name that only
+  // reached `alt` was stored and then displayed nowhere. Audio is where this
+  // bites hardest: no thumbnail, so the title is the only way to tell two takes
+  // apart on the board.
+  it("records an explicit name as an authored title, not just alt", async () => {
+    seed(PROJECT, []);
+
+    const result = await attachMedia(
+      {
+        timelineId: PROJECT,
+        projectId: PROJECT,
+        publicId: "media/user-a/project-alpha/render-123",
+        name: 'Brian VO — "You worry about the door"',
+      },
+      OWNER,
+    );
+
+    expect(result.isError).toBeFalsy();
+    const added = storedClips(PROJECT)[0];
+    expect(added.title).toBe('Brian VO — "You worry about the door"');
+    expect(added.alt).toBe('Brian VO — "You worry about the door"');
+  });
+
+  // The complement: an UNNAMED clip must stay untitled. "Only authored titles
+  // are shown" is what keeps a library of machine-named clips from reading as
+  // a rename backlog — defaulting a title from the filename would break it.
+  it("leaves title absent when no name was given", async () => {
+    seed(PROJECT, []);
+
+    await attachMedia(
+      { timelineId: PROJECT, projectId: PROJECT, publicId: "media/user-a/project-alpha/render-123" },
+      OWNER,
+    );
+
+    expect(storedClips(PROJECT)[0].title).toBeUndefined();
+  });
+
   it("refuses when the upload never landed, instead of minting a dead clip", async () => {
     seed(PROJECT, [clip("a")]);
     state.assets.length = 0;

--- a/apps/timeline-gstudio001/lib/mcp/upload.ts
+++ b/apps/timeline-gstudio001/lib/mcp/upload.ts
@@ -193,6 +193,17 @@ export async function attachMedia(
         details: {
           [newNodeId as string]: {
             alt: displayName,
+            // An explicit `name` argument is an AUTHORED title, so record it as
+            // one. Cards render `title` and never `alt` — deliberately, so a
+            // library of machine-named clips does not read as a rename backlog
+            // — which meant a caller-supplied name was accepted, stored as
+            // `alt`, and then shown nowhere.
+            //
+            // It matters most for AUDIO: an audio card has no thumbnail, so the
+            // title is the only thing distinguishing one take from another.
+            // Absent when the caller passed no name, which keeps the
+            // "unnamed looks neutral" rule intact.
+            ...(args.name?.trim() ? { title: args.name.trim() } : {}),
             aspect: 16 / 9,
             trackIndex: 0,
             sourceAsset: { providerId: CLOUDINARY_PROVIDER_ID, assetId: asset.pathname },

--- a/packages/timeline-domain/src/audio-roundtrip.test.ts
+++ b/packages/timeline-domain/src/audio-roundtrip.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import type { TimelineDocument } from "@storyboard/timeline-model/types";
+
+import { buildFocusedGraph } from "./adapter";
+
+// Reproduction for the deployed-app report: an audio clip renders with the
+// IMAGE chip. The stored document is correct (kind: "audio"), and mediaSpec has
+// an audio branch, so the question is what the GRAPH ends up holding — that is
+// what the card reads.
+
+const audioDoc: TimelineDocument = {
+  id: "col",
+  title: "Audio",
+  clips: [
+    {
+      id: "audio-db58631e",
+      index: 0,
+      kind: "audio",
+      alt: 'Brian VO — "You worry about the door"',
+      aspect: 16 / 9,
+      trackIndex: 0,
+      startTime: 0,
+      duration: 5.875,
+      sourceDuration: 5.875,
+      trimIn: 0,
+      trimOut: 0,
+      src: "https://res.cloudinary.com/x/video/upload/brian.flac",
+      sourceAsset: { providerId: "cloudinary", assetId: "brian" },
+    },
+  ],
+};
+
+describe("audio clip document -> graph", () => {
+  it("keeps mediaKind audio on the built node", () => {
+    const built = buildFocusedGraph({ col: audioDoc }, "col", 1);
+    expect(built.ok).toBe(true);
+    if (!built.ok) throw new Error(built.error);
+
+    const node = built.value.graph.nodesById.get("audio-db58631e" as never);
+    expect(node).toBeDefined();
+    if (!node || node.kind !== "media") throw new Error("expected a media node");
+
+    // THE ASSERTION THAT MATTERS: the card reads node.mediaKind, and "image"
+    // here is exactly what puts an IMAGE chip and an <img> on an audio card.
+    expect(node.mediaKind).toBe("audio");
+  });
+});


### PR DESCRIPTION
Cards render `title` and **never** `alt` — deliberately, so a library of machine-named clips doesn't read as a rename backlog (PL11-004). But `attach_media` only ever wrote the caller's `name` into `alt`, so a name passed through the MCP tool was accepted, stored, and then **displayed nowhere**.

Surfaced by the audio work, which is where it hurts most: an audio card has no thumbnail, so the title is the only thing distinguishing one voice take from another. Two 6-second clips of the same character are otherwise identical rectangles.

Only set when the caller actually passed a name — an unnamed clip stays untitled, keeping "unnamed looks neutral" true.

Also includes `audio-roundtrip.test.ts`, written while diagnosing a report that audio clips render with an IMAGE chip in the deployed app. It asserts a `kind: "audio"` document survives `buildFocusedGraph` with `mediaKind: "audio"` intact — the property the card reads. It **passes**, which is what proved the conversion was fine and pointed at the real cause: a stale browser bundle had rewritten the stored clip to `kind: "image"` through the write-back path. Worth keeping as a regression guard on that conversion.

## Verification

- `npx vitest run lib/mcp/upload.test.ts` — 10 passed, including the two new cases
- `tsc --noEmit` clean
- Confirmed live: a freshly attached `.flac` renders `kind: "audio"`, chip reads `audio`, and draws the waveform placeholder SVG rather than an `<img>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
