### PR TITLE
Tag media items: images, video and audio

### DIFF
--- a/apps/timeline-gstudio001/app/api/mcp/route.ts
+++ b/apps/timeline-gstudio001/app/api/mcp/route.ts
@@ -3,6 +3,8 @@ import { timingSafeEqual } from "node:crypto";
 import { createMcpHandler, withMcpAuth } from "mcp-handler";
 import { z } from "zod";
 
+import { MAX_TAGS_PER_CLIP } from "@storyboard/timeline-model/tags";
+
 import { TIMELINE_APP_HTML } from "@storyboard/timeline-widget";
 
 import { listFirebaseTimelineProjects } from "@/lib/firebase-timeline-store";
@@ -340,6 +342,16 @@ const handler = createMcpHandler(
           .positive()
           .optional()
           .describe("How long it plays. Defaults to the video's full length, or 3s for a still."),
+        tags: z
+          .array(z.string())
+          .max(MAX_TAGS_PER_CLIP)
+          .optional()
+          .describe(
+            "Labels to file this clip under, for finding it again later — what generated it, " +
+              "which checkpoint, which shot, its status. Free-form, e.g. " +
+              '["scail-2", "wan2.1", "S02", "keeper"]. Duplicates, blanks and stray whitespace ' +
+              "are cleaned up, and matching ignores case.",
+          ),
       },
       async (args, extra) => {
         const uid = uidFrom(extra);

--- a/apps/timeline-gstudio001/lib/mcp/upload.test.ts
+++ b/apps/timeline-gstudio001/lib/mcp/upload.test.ts
@@ -163,6 +163,41 @@ describe("attachMedia", () => {
     });
   });
 
+  // Tagging at mint time is the only chance to do it automatically: a clip
+  // that lands untagged stays untagged until someone opens it by hand. This
+  // goes through the real store transaction, so it proves the tags survive the
+  // detail side-table and the projection back to stored clips — not just that
+  // the argument was accepted.
+  it("files agent-uploaded media under the tags it was given", async () => {
+    seed(PROJECT, []);
+
+    await attachMedia(
+      {
+        timelineId: PROJECT,
+        projectId: PROJECT,
+        publicId: "media/user-a/project-alpha/render-123",
+        tags: ["  SCAIL-2 ", "scail-2", "", "S02", "keeper"],
+      },
+      OWNER,
+    );
+
+    const added = storedClips(PROJECT)[0];
+    // Cleaned on the way in: trimmed, de-duplicated case-insensitively with
+    // the first spelling kept, blanks dropped.
+    expect(added.tags).toEqual(["SCAIL-2", "S02", "keeper"]);
+  });
+
+  it("leaves an untagged upload with no tags field", async () => {
+    seed(PROJECT, []);
+
+    await attachMedia(
+      { timelineId: PROJECT, projectId: PROJECT, publicId: "media/user-a/project-alpha/render-123" },
+      OWNER,
+    );
+
+    expect("tags" in storedClips(PROJECT)[0]).toBe(false);
+  });
+
   it("carries the real source duration and url from the upload", async () => {
     seed(PROJECT, []);
 

--- a/apps/timeline-gstudio001/lib/mcp/upload.ts
+++ b/apps/timeline-gstudio001/lib/mcp/upload.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import { parseNodeId, type CollectionsGraph, type NodeId } from "@storyboard/collections-core";
+import { tagsField } from "@storyboard/timeline-model/tags";
 
 import { CLOUDINARY_PROVIDER_ID } from "@/lib/assets/cloudinary-provider";
 import {
@@ -59,6 +60,10 @@ export type AttachMediaArgs = Readonly<{
   before?: string;
   position?: "start" | "end";
   durationSeconds?: number;
+  /** Labels to file this clip under — generator, checkpoint, shot, status.
+   *  Cleaned by `normalizeTags`, so a caller may pass duplicates, blanks or
+   *  odd whitespace without corrupting the document. */
+  tags?: readonly string[];
 }>;
 
 /** The app's own default on-screen time for a still. */
@@ -207,6 +212,11 @@ export async function attachMedia(
             aspect: 16 / 9,
             trackIndex: 0,
             sourceAsset: { providerId: CLOUDINARY_PROVIDER_ID, assetId: asset.pathname },
+            // Tagged at mint time so agent-uploaded media arrives filed. This
+            // is the only chance to do it automatically — a clip that lands
+            // untagged stays untagged until someone opens it by hand, which is
+            // exactly how the naming problem started.
+            ...tagsField(args.tags),
             // No poster for audio: Cloudinary would mint a still-frame jpg
             // URL for a resource that has no frames, and it renders broken.
             ...(!isAudio && asset.thumbnailUrl ? { poster: asset.thumbnailUrl } : {}),

--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -29,6 +29,7 @@ import {
   CLIP_GAP_SECONDS,
   TIMELINE_LEADING_PADDING_SECONDS,
 } from "@storyboard/timeline-model/constants";
+import { tagsField } from "@storyboard/timeline-model/tags";
 import type {
   AssetSourceRef,
   CollectionTimelineClip,
@@ -74,6 +75,11 @@ export type ClipDetail = Readonly<{
   /** Which asset-provider file this media clip came from — pure provenance
    *  (the engine never reads it), round-tripped like poster. */
   sourceAsset?: AssetSourceRef;
+  /** Free-form labels for finding this clip again. Provenance like
+   *  `sourceAsset`: the engine never reads them, so they ride the side-table
+   *  rather than the graph node, and no graph command is needed to change
+   *  them. Absent means untagged; an empty list is never stored. */
+  tags?: string[];
   /** When this clip was trashed, and from where. Provenance again: the engine
    *  never reads it, so it rides the side-table rather than the graph node —
    *  the same seam `sourceAsset` uses, and for the same reason. */
@@ -164,6 +170,7 @@ function mediaDetail(clip: Exclude<TimelineClip, CollectionTimelineClip>): ClipD
     trackIndex: clip.trackIndex,
     ...(clip.poster === undefined ? {} : { poster: clip.poster }),
     ...(clip.sourceAsset === undefined ? {} : { sourceAsset: clip.sourceAsset }),
+    ...tagsField(clip.tags),
     ...(clip.trashedAt === undefined ? {} : { trashedAt: clip.trashedAt }),
     ...(clip.trashedFrom === undefined ? {} : { trashedFrom: clip.trashedFrom }),
     ...(clip.playbackStartTime === undefined ? {} : { playbackStartTime: clip.playbackStartTime }),
@@ -179,6 +186,7 @@ function collectionDetail(clip: CollectionTimelineClip, hydrated: boolean): Clip
     alt: clip.alt,
     aspect: clip.aspect,
     trackIndex: clip.trackIndex,
+    ...tagsField(clip.tags),
     ...(clip.trashedAt === undefined ? {} : { trashedAt: clip.trashedAt }),
     ...(clip.trashedFrom === undefined ? {} : { trashedFrom: clip.trashedFrom }),
     sourceClipId: clip.id,
@@ -650,6 +658,10 @@ export function graphChildrenToClips(
           ? {}
           : { playbackDuration: detail.playbackDuration }),
         ...(detail?.sourceAsset === undefined ? {} : { sourceAsset: detail.sourceAsset }),
+        // THE WRITE-BACK. Tags live only on the detail, so without this line
+        // they are dropped on every save — silently, because nothing else
+        // reads them and no type would complain.
+        ...tagsField(detail?.tags),
         ...(detail?.trashedAt === undefined ? {} : { trashedAt: detail.trashedAt }),
         ...(detail?.trashedFrom === undefined ? {} : { trashedFrom: detail.trashedFrom }),
         // Read from the NODE, not `detail`: disabling goes through a graph
@@ -738,6 +750,7 @@ export function graphChildrenToClips(
       trimIn: detail?.trimIn ?? 0,
       trimOut: detail?.trimOut ?? 0,
       ...(node.disabled ? { disabled: true } : {}),
+      ...tagsField(detail?.tags),
       ...(detail?.trashedAt === undefined ? {} : { trashedAt: detail.trashedAt }),
       ...(detail?.trashedFrom === undefined ? {} : { trashedFrom: detail.trashedFrom }),
     };

--- a/packages/timeline-domain/src/tags-roundtrip.test.ts
+++ b/packages/timeline-domain/src/tags-roundtrip.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
+
+import { buildFocusedGraph, graphChildrenToClips } from "./adapter";
+
+// Tags live only on the DETAIL side-table — the engine never reads them, the
+// same seam `sourceAsset` uses. That makes the write-back in
+// graphChildrenToClips load-bearing and invisible: drop it and tags are lost on
+// every save, with no type error and nothing else to notice.
+//
+// So this covers the full loop (clip -> graph+details -> clip) rather than
+// either half, and it covers all three media kinds because the projection
+// returns from a DIFFERENT branch for each one.
+
+function clip(over: Partial<TimelineClip> & Pick<TimelineClip, "id" | "kind">): TimelineClip {
+  return {
+    index: 0,
+    alt: "take",
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 4,
+    sourceDuration: 4,
+    trimIn: 0,
+    trimOut: 0,
+    src: "https://example.test/take",
+    ...over,
+  } as TimelineClip;
+}
+
+const TAGS = ["scail-2", "wan2.1", "S02", "keeper"];
+
+function roundTrip(doc: TimelineDocument): TimelineClip[] {
+  const built = buildFocusedGraph({ [doc.id]: doc }, doc.id, 1);
+  expect(built.ok).toBe(true);
+  if (!built.ok) throw new Error(built.error);
+  return graphChildrenToClips(built.value.graph, built.value.details, doc.id);
+}
+
+describe("tags survive the graph round-trip", () => {
+  for (const kind of ["image", "video", "audio"] as const) {
+    it(`for a ${kind} clip`, () => {
+      const out = roundTrip({
+        id: "col",
+        title: "Takes",
+        clips: [clip({ id: `${kind}-1`, kind, tags: [...TAGS] })],
+      });
+      expect(out).toHaveLength(1);
+      expect(out[0].kind).toBe(kind);
+      expect(out[0].tags).toEqual(TAGS);
+    });
+  }
+
+  it("for a collection clip", () => {
+    // Collections are tagged through a different detail builder and a
+    // different return branch, so the media cases above do not cover this.
+    const out = roundTrip({
+      id: "col",
+      title: "Takes",
+      clips: [
+        {
+          id: "child",
+          index: 0,
+          kind: "collection",
+          alt: "August tenth collection",
+          title: "August tenth",
+          childTimelineId: "child",
+          itemCount: 0,
+          aspect: 16 / 9,
+          trackIndex: 0,
+          startTime: 0,
+          duration: 3,
+          sourceDuration: 3,
+          trimIn: 0,
+          trimOut: 0,
+          tags: ["dailies"],
+        },
+      ],
+    });
+    expect(out[0].tags).toEqual(["dailies"]);
+  });
+
+  it("cleans tags on the way in rather than storing them raw", () => {
+    const out = roundTrip({
+      id: "col",
+      title: "Takes",
+      clips: [clip({ id: "video-1", kind: "video", tags: ["  keeper ", "KEEPER", "", "S02"] })],
+    });
+    expect(out[0].tags).toEqual(["keeper", "S02"]);
+  });
+
+  it("leaves an untagged clip with no tags key at all", () => {
+    // Absence is the default: a document that never uses tags must not grow
+    // the field just by being loaded and saved.
+    const out = roundTrip({
+      id: "col",
+      title: "Takes",
+      clips: [clip({ id: "image-1", kind: "image" })],
+    });
+    expect("tags" in out[0]).toBe(false);
+  });
+});

--- a/packages/timeline-model/index.ts
+++ b/packages/timeline-model/index.ts
@@ -1,4 +1,5 @@
 export * from "./types";
+export * from "./tags";
 export * from "./constants";
 export * from "./documents";
 export * from "./validate";

--- a/packages/timeline-model/tags.test.ts
+++ b/packages/timeline-model/tags.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MAX_TAGS_PER_CLIP,
+  MAX_TAG_LENGTH,
+  areTagsValid,
+  normalizeTags,
+  tagsField,
+} from "./tags";
+
+describe("normalizeTags", () => {
+  it("keeps ordinary tags in the order they were given", () => {
+    expect(normalizeTags(["scail-2", "wan2.1", "S02"])).toEqual(["scail-2", "wan2.1", "S02"]);
+  });
+
+  it("trims and collapses whitespace so spacing variants are one tag", () => {
+    expect(normalizeTags(["  flux   dev  "])).toEqual(["flux dev"]);
+  });
+
+  it("dedupes case-insensitively but keeps the first spelling", () => {
+    // Matching has to ignore case or nobody finds anything; DISPLAY must not,
+    // or every tag ends up lowercased in the UI.
+    expect(normalizeTags(["SCAIL-2", "scail-2", "Scail-2"])).toEqual(["SCAIL-2"]);
+  });
+
+  it("drops blanks and non-strings rather than failing the whole write", () => {
+    expect(normalizeTags(["keeper", "", "   ", 42, null, undefined, {}])).toEqual(["keeper"]);
+  });
+
+  it("returns an empty list for anything that is not an array", () => {
+    for (const bad of [undefined, null, "keeper", 7, {}]) {
+      expect(normalizeTags(bad)).toEqual([]);
+    }
+  });
+
+  it("truncates an over-long tag instead of rejecting it", () => {
+    const long = "x".repeat(MAX_TAG_LENGTH + 25);
+    expect(normalizeTags([long])).toEqual(["x".repeat(MAX_TAG_LENGTH)]);
+  });
+
+  it("caps the number of tags", () => {
+    const many = Array.from({ length: MAX_TAGS_PER_CLIP + 10 }, (_, i) => `tag-${i}`);
+    const out = normalizeTags(many);
+    expect(out).toHaveLength(MAX_TAGS_PER_CLIP);
+    expect(out[0]).toBe("tag-0");
+  });
+
+  it("does not mutate its input", () => {
+    const input = ["  b  ", "b", "a"];
+    const copy = [...input];
+    normalizeTags(input);
+    expect(input).toEqual(copy);
+  });
+});
+
+describe("areTagsValid", () => {
+  it("accepts absence and a clean list", () => {
+    expect(areTagsValid(undefined)).toBe(true);
+    expect(areTagsValid([])).toBe(true);
+    expect(areTagsValid(["scail-2", "S02"])).toBe(true);
+  });
+
+  it("rejects the shapes normalizeTags would have cleaned", () => {
+    // Stricter than the front door on purpose: reaching storage in one of
+    // these states means a writer skipped normalization.
+    expect(areTagsValid(["", "ok"])).toBe(false);
+    expect(areTagsValid([" padded"])).toBe(false);
+    expect(areTagsValid(["dup", "DUP"])).toBe(false);
+    expect(areTagsValid(["x".repeat(MAX_TAG_LENGTH + 1)])).toBe(false);
+    expect(areTagsValid([1, 2])).toBe(false);
+    expect(areTagsValid("scail-2")).toBe(false);
+    expect(
+      areTagsValid(Array.from({ length: MAX_TAGS_PER_CLIP + 1 }, (_, i) => `t${i}`)),
+    ).toBe(false);
+  });
+});
+
+describe("tagsField", () => {
+  it("writes nothing when there is nothing to write", () => {
+    // Absence is the default: a document that never uses tags must not grow
+    // the key, same rule `disabled` follows.
+    expect(tagsField(undefined)).toEqual({});
+    expect(tagsField([])).toEqual({});
+    expect(tagsField(["", "  "])).toEqual({});
+  });
+
+  it("writes the cleaned list when there is", () => {
+    expect(tagsField([" keeper ", "keeper", "S02"])).toEqual({ tags: ["keeper", "S02"] });
+  });
+});

--- a/packages/timeline-model/tags.ts
+++ b/packages/timeline-model/tags.ts
@@ -1,0 +1,87 @@
+// Tags: free-form labels on a clip, for finding things again.
+//
+// The problem they solve is provenance. A generated take carries the tool and
+// the checkpoint that made it, and today that information lives in the clip's
+// NAME — strings like "S02 van pan — MiniMax H3 ref2va int8, 4 cast refs —
+// prompt v8, seed 883". A title doing a database's job cannot be filtered or
+// counted, and it breaks the moment someone shortens it for readability.
+//
+// Deliberately untyped as a set of strings rather than a fixed facet enum. The
+// vocabulary in use (generator, checkpoint, shot, status, character) is still
+// moving, and an enum would have to be widened by a code change every time a
+// new tool enters the pipeline.
+
+/** Upper bound on tags per clip. Generous for real use, low enough that a
+ *  runaway writer cannot bloat a stored document. */
+export const MAX_TAGS_PER_CLIP = 32;
+/** Upper bound on one tag's length, in characters. */
+export const MAX_TAG_LENGTH = 48;
+
+/**
+ * Clean untrusted tag input into the stored form.
+ *
+ * Rules, and why each one is here:
+ *  - non-strings and blanks are dropped, so a malformed write degrades to
+ *    fewer tags rather than to a corrupt document;
+ *  - surrounding whitespace is trimmed and internal runs collapse to a single
+ *    space, so " flux  dev " and "flux dev" are the same tag;
+ *  - duplicates are removed CASE-INSENSITIVELY but the first spelling is kept.
+ *    Matching has to ignore case (nobody will type "SCAIL-2" the same way
+ *    twice) while display should not, so "SCAIL-2" stays "SCAIL-2" rather than
+ *    being flattened to lowercase;
+ *  - order is preserved, because the order they were typed in is the only
+ *    ordering signal there is;
+ *  - over-long tags are truncated and excess tags dropped, at the boundary,
+ *    rather than rejected — a paste that is slightly too long should still
+ *    save.
+ *
+ * Returns a new array; never mutates the input.
+ */
+export function normalizeTags(input: unknown): string[] {
+  if (!Array.isArray(input)) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of input) {
+    if (typeof raw !== "string") continue;
+    const tag = raw.trim().replace(/\s+/g, " ").slice(0, MAX_TAG_LENGTH);
+    if (tag.length === 0) continue;
+    const key = tag.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(tag);
+    if (out.length >= MAX_TAGS_PER_CLIP) break;
+  }
+  return out;
+}
+
+/**
+ * True when the value is a legal STORED tag list — already normalized.
+ *
+ * Stricter than `normalizeTags` accepts, on purpose: normalize is the front
+ * door for untrusted input, this is the gate on the write path. A document
+ * that reached storage with a blank or duplicate tag is a bug upstream, and
+ * waving it through here is what would let it spread.
+ */
+export function areTagsValid(value: unknown): boolean {
+  if (value === undefined) return true;
+  if (!Array.isArray(value)) return false;
+  if (value.length > MAX_TAGS_PER_CLIP) return false;
+  const seen = new Set<string>();
+  for (const tag of value) {
+    if (typeof tag !== "string") return false;
+    if (tag.length === 0 || tag.length > MAX_TAG_LENGTH) return false;
+    if (tag !== tag.trim()) return false;
+    const key = tag.toLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+  }
+  return true;
+}
+
+/** Spread helper: `...tagsField(tags)` writes the key only when there is
+ *  something to write, so clips that never use tags never grow the field —
+ *  the same absence-is-the-default rule `disabled` follows. */
+export function tagsField(tags: unknown): { tags?: string[] } {
+  const normalized = normalizeTags(tags);
+  return normalized.length === 0 ? {} : { tags: normalized };
+}

--- a/packages/timeline-model/types.ts
+++ b/packages/timeline-model/types.ts
@@ -59,6 +59,20 @@ export type TimelineItemBase = {
    * `false`, so documents that never use the feature never grow the field.
    */
   disabled?: boolean;
+  /**
+   * Free-form labels for finding this clip again — the generator that made
+   * it, the checkpoint, the shot, its status.
+   *
+   * On the BASE rather than on the media members so a collection can be
+   * tagged too: "every take from 10 August" is the same kind of question as
+   * "every SCAIL-2 multirole take", and answering one but not the other would
+   * be an arbitrary split.
+   *
+   * Absent means untagged; an empty list is never written, so documents that
+   * do not use tags never grow the field. See {@link normalizeTags} for the
+   * cleaning rules and the caps.
+   */
+  tags?: string[];
   /** ISO instant this clip was moved to trash. Absent on every live clip —
    *  its presence IS the record that a clip is in the bin, which is why it is
    *  cleared on restore rather than left as stale metadata. */

--- a/packages/timeline-model/validate.ts
+++ b/packages/timeline-model/validate.ts
@@ -7,6 +7,7 @@
 // round-trips and legacy writers produce nulls), while every REQUIRED
 // numeric must be a finite number (NaN/Infinity poison packing).
 
+import { areTagsValid } from "./tags";
 import type { TimelineClip, TimelineDocument } from "./types";
 
 function isFiniteNumber(value: unknown): value is number {
@@ -124,7 +125,12 @@ function hasClipBase(clip: Record<string, unknown>): boolean {
     // clip from the timeline.
     (clip.disabled === undefined || typeof clip.disabled === "boolean") &&
     isOptionalString(clip.trashedAt) &&
-    isOptionalTrashOrigin(clip.trashedFrom)
+    isOptionalTrashOrigin(clip.trashedFrom) &&
+    // Already-normalized form only. Writers clean input with `normalizeTags`
+    // before it gets here, so a blank, over-long or duplicate tag at this
+    // point means a writer skipped that step — which is exactly the thing
+    // that must not reach storage and spread.
+    (clip.tags === undefined || clip.tags === null || areTagsValid(clip.tags))
   );
 }
 


### PR DESCRIPTION
Closes part of #315 — the data model and the write path. Filtering UI is still open.

## Why

Provenance had nowhere to live except the clip title, so it ended up encoded in strings like `S02 van pan — MiniMax H3 ref2va int8, 4 cast refs — prompt v8, seed 883`. That cannot be filtered or counted, and it breaks as soon as someone shortens the name.

## Where tags live, and why there

On the **detail side-table**, the same seam `sourceAsset` and `trashedAt` already use. The graph engine never reads tags, so no graph command, no patch, and `collections-core` is untouched.

The field is on `TimelineItemBase` rather than on the media members, so a collection can be tagged too — *"every take from 10 August"* is the same kind of question as *"every SCAIL-2 multirole take"*, and answering one but not the other would be an arbitrary split.

## Normalization

`normalizeTags` is the front door for untrusted input: trim, collapse internal whitespace, drop blanks and non-strings, dedupe **case-insensitively while keeping the first spelling** (matching must ignore case; display must not), cap at 32 tags of 48 chars. Over-long input is truncated rather than rejected — a slightly-too-long paste should still save.

`areTagsValid` is deliberately stricter, because it gates the write path. A blank or duplicate tag reaching storage means a writer skipped normalization, and accepting it there is what would let it spread.

Absent means untagged; an empty list is never written, so documents that do not use tags never grow the field — the rule `disabled` already follows.

## The load-bearing line

Tags exist only on the detail, so the write-back in `graphChildrenToClips` is what keeps them. Without it they are dropped on **every save** — silently, with no type error, because nothing else reads them.

I removed it and re-ran: **5 of the 6 round-trip tests fail**, and the one that passes is the "untagged clip stays untagged" case that should. Verified rather than assumed.

## Not in this change

Editing tags on **existing** clips. Every graph command mutates the graph, and there is no details-only write path yet. Faking one with a same-name `rename-node` would work but would write a bogus entry into undo history, so it belongs in its own change.

## Verification

- `npx vitest run --project=unit` — 530 passed (12 new normalization, 6 new round-trip)
- `npx vitest run` in the app — 671 passed (2 new: attach_media files its tags, and an untagged upload grows no field)
- `tsc --noEmit` clean in `packages/ui`, `packages/timeline-domain`, and the app
- `npm run lint` — 0 errors (5 pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)