### PR TITLE
Details-only writes, and a set_tags tool on top of them

### DIFF
--- a/apps/timeline-gstudio001/app/api/mcp/route.ts
+++ b/apps/timeline-gstudio001/app/api/mcp/route.ts
@@ -24,6 +24,7 @@ import {
   handleMoveClip,
   handleRemoveClip,
   handleRenameItem,
+  handleSetTags,
   handleTrimClip,
   NO_LIVE_PUSH_NOTE,
 } from "@/lib/mcp/write-handlers";
@@ -247,6 +248,30 @@ const handler = createMcpHandler(
         const uid = uidFrom(extra);
         if (!uid) return errorResult(NO_IDENTITY);
         return fromToolResult(await handleRenameItem(args, { requesterUid: uid }));
+      },
+    );
+
+    server.tool(
+      "set_tags",
+      "Replace the tags on a clip or collection — labels for finding it again later, like what " +
+        "generated it, which checkpoint, which shot, or its status. This REPLACES the whole set, " +
+        "so read the current tags first if you mean to add one, and pass `[]` to clear them." +
+        NO_LIVE_PUSH_NOTE,
+      {
+        timelineId: TIMELINE_ID_FIELD,
+        nodeId: nodeIdField,
+        tags: z
+          .array(z.string())
+          .max(MAX_TAGS_PER_CLIP)
+          .describe(
+            'The complete new set, e.g. ["scail-2", "wan2.1", "S02", "keeper"]. Duplicates, ' +
+              "blanks and stray whitespace are cleaned up, and matching ignores case.",
+          ),
+      },
+      async (args, extra) => {
+        const uid = uidFrom(extra);
+        if (!uid) return errorResult(NO_IDENTITY);
+        return fromToolResult(await handleSetTags(args, { requesterUid: uid }));
       },
     );
 

--- a/apps/timeline-gstudio001/lib/mcp/apply-command.test.ts
+++ b/apps/timeline-gstudio001/lib/mcp/apply-command.test.ts
@@ -246,7 +246,11 @@ describe("applyCollectionsCommand — details-only writes", () => {
   it("leaves every other stored field on the clip intact", async () => {
     // The builder spreads the existing detail; if it did not, the clip would be
     // rebuilt without its provenance and the file would leak.
-    seed("root", [{ ...clip("a"), sourceAsset: { providerId: "cloudinary", assetId: "x/y" } }]);
+    // `clip()` is typed as the whole TimelineClip union, and a collection has no
+    // `sourceAsset` — narrow before spreading rather than casting past it.
+    const base = clip("a");
+    if (base.kind === "collection") throw new Error("fixture must be a media clip");
+    seed("root", [{ ...base, sourceAsset: { providerId: "cloudinary", assetId: "x/y" } }]);
 
     await applyCollectionsCommand(
       "root",

--- a/apps/timeline-gstudio001/lib/mcp/apply-command.test.ts
+++ b/apps/timeline-gstudio001/lib/mcp/apply-command.test.ts
@@ -213,3 +213,88 @@ describe("applyCollectionsCommand", () => {
     expect(storedClipIds("root")).toEqual(["a", "b"]);
   });
 });
+
+// A DETAILS-ONLY change: no graph mutation, so no command and no patch. The
+// write set is normally derived from the patch, so this path exists precisely
+// because there is nothing to derive it from — and its failure mode is a silent
+// `ok: true` with nothing written, which is what these cover.
+describe("applyCollectionsCommand — details-only writes", () => {
+  it("persists a detail change with no command at all", async () => {
+    seed("root", [clip("a"), clip("b")]);
+
+    const result = await applyCollectionsCommand(
+      "root",
+      (_graph, details) => ({
+        ok: true,
+        details: { a: { ...details.a, tags: ["keeper", "S02"] } },
+        affectedCollectionIds: ["root"],
+      }),
+      OWNER,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected the write to succeed");
+    expect(result.affectedIds).toEqual(["root"]);
+    const stored = (state.docs.get("root") as { clips: TimelineClip[] }).clips;
+    expect(stored.find((c) => c.id === "a")?.tags).toEqual(["keeper", "S02"]);
+    // The rest of the document is untouched — a details-only write still
+    // rebuilds the WHOLE clip list, so losing a sibling here is a real risk.
+    expect(stored.map((c) => c.id)).toEqual(["a", "b"]);
+    expect(stored.find((c) => c.id === "b")?.tags).toBeUndefined();
+  });
+
+  it("leaves every other stored field on the clip intact", async () => {
+    // The builder spreads the existing detail; if it did not, the clip would be
+    // rebuilt without its provenance and the file would leak.
+    seed("root", [{ ...clip("a"), sourceAsset: { providerId: "cloudinary", assetId: "x/y" } }]);
+
+    await applyCollectionsCommand(
+      "root",
+      (_graph, details) => ({
+        ok: true,
+        details: { a: { ...details.a, tags: ["keeper"] } },
+        affectedCollectionIds: ["root"],
+      }),
+      OWNER,
+    );
+
+    const stored = (state.docs.get("root") as { clips: TimelineClip[] }).clips[0];
+    if (stored.kind === "collection") throw new Error("expected a media clip");
+    expect(stored.sourceAsset).toEqual({ providerId: "cloudinary", assetId: "x/y" });
+    expect(stored.tags).toEqual(["keeper"]);
+  });
+
+  it("bumps the revision so a concurrent writer still loses", async () => {
+    seed("root", [clip("a")], OWNER, 4);
+
+    await applyCollectionsCommand(
+      "root",
+      (_graph, details) => ({
+        ok: true,
+        details: { a: { ...details.a, tags: ["keeper"] } },
+        affectedCollectionIds: ["root"],
+      }),
+      OWNER,
+    );
+
+    expect((state.docs.get("root") as { revision: number }).revision).toBe(5);
+  });
+
+  it("reports an error rather than a silent success when the declared document is not loaded", async () => {
+    // The empty-affected short-circuit is correct for a patch-derived set, but
+    // for a DECLARED one it would report success having written nothing.
+    seed("root", [clip("a")]);
+
+    const result = await applyCollectionsCommand(
+      "root",
+      () => ({ ok: true, details: {}, affectedCollectionIds: ["not-loaded"] }),
+      OWNER,
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected a failure");
+    expect(result.kind).toBe("error");
+    if (result.kind !== "error") throw new Error("expected an error outcome");
+    expect(result.message).toContain("not-loaded");
+  });
+});

--- a/apps/timeline-gstudio001/lib/mcp/apply-command.ts
+++ b/apps/timeline-gstudio001/lib/mcp/apply-command.ts
@@ -3,6 +3,7 @@ import {
   buildGraph,
   type CollectionsCommand,
   type CollectionsGraph,
+  type CollectionsPatch,
   type CommandRejection,
   type GraphNodeSpec,
 } from "@storyboard/collections-core";
@@ -62,10 +63,10 @@ const HYDRATE_ALL_LEVELS = Number.MAX_SAFE_INTEGER;
  */
 function syncRenameIntoDetails(
   details: DetailsById,
-  command: CollectionsCommand,
+  command: CollectionsCommand | null,
   graph: CollectionsGraph,
 ): DetailsById {
-  if (command.type !== "rename-node") return details;
+  if (!command || command.type !== "rename-node") return details;
   const node = graph.nodesById.get(command.nodeId);
   if (!node || node.kind !== "media") return details;
   const existing = details[command.nodeId as string];
@@ -181,9 +182,39 @@ export type CommandBuilder = (
 ) =>
   | Readonly<{
       ok: true;
-      command: CollectionsCommand;
       /**
-       * Details to park for nodes this command CREATES, merged before write-back.
+       * The graph mutation, when there is one.
+       *
+       * OMITTED for a change that only touches the detail side-table — tags,
+       * for instance. Those fields exist precisely because the engine does not
+       * model them, so there is no command that expresses the edit: the graph
+       * is genuinely unchanged and `applyCommand` is skipped. A caller
+       * omitting this MUST name the documents to rewrite in
+       * `affectedCollectionIds`, because the write set is normally derived
+       * from the patch and there is no patch.
+       *
+       * Manufacturing a no-op command instead does not work and must not be
+       * attempted: `applyRename` REJECTS a same-name rename outright
+       * (collections-core/commands.ts, `same-position`), and a command that
+       * did slip through would put a phantom entry in undo history.
+       */
+      command?: CollectionsCommand;
+      /**
+       * Collections whose stored document this change rewrites, on top of
+       * whatever the patch reports. REQUIRED when `command` is omitted.
+       *
+       * A clip's stored form lives in its PARENT's `clips` array, so a
+       * detail-only edit names exactly that parent — not its ancestors.
+       * `collectAffectedCollectionIds` walks ancestors for a `nodes-updated`
+       * patch because a trim changes a child's duration and therefore the
+       * parent's denormalized collection summary; a tag changes no summary
+       * (not `duration`, not `itemCount`, not `previewItems`), so rewriting
+       * ancestors would be pure write amplification and extra CAS conflicts.
+       */
+      affectedCollectionIds?: readonly string[];
+      /**
+       * Details to park for nodes this command CREATES OR MODIFIES, merged
+       * before write-back.
        *
        * Not optional bookkeeping: `graphChildrenToClips` reads `poster` and —
        * critically — `sourceAsset` from the details side-table, not the graph
@@ -272,23 +303,33 @@ export async function applyCollectionsCommand(
     : buildFocusedGraph(documents, rootTimelineId, HYDRATE_ALL_LEVELS);
   if (!built.ok) return { ok: false, kind: "error", message: built.error };
 
-  let command: CollectionsCommand;
+  let command: CollectionsCommand | null = null;
   let parkedDetails: DetailsById = {};
   let seeded: readonly TimelineDocument[] = [];
+  let declaredAffected: readonly string[] = [];
   if (typeof commandOrBuilder === "function") {
     const requested = commandOrBuilder(built.value.graph, built.value.details);
     if (!requested.ok) return { ok: false, kind: "error", message: requested.message };
-    command = requested.command;
+    command = requested.command ?? null;
     parkedDetails = requested.details ?? {};
     seeded = requested.newDocuments ?? [];
+    declaredAffected = requested.affectedCollectionIds ?? [];
   } else {
     command = commandOrBuilder;
   }
 
-  const applied = applyCommand(built.value.graph, command);
-  if (!applied.ok) return { ok: false, kind: "rejected", rejection: applied.error };
+  // A detail-only change has no command, so nothing is applied and the graph
+  // carries through untouched — which is what makes re-projecting the affected
+  // documents from it safe.
+  let nextGraph = built.value.graph;
+  let patch: CollectionsPatch | null = null;
+  if (command !== null) {
+    const applied = applyCommand(built.value.graph, command);
+    if (!applied.ok) return { ok: false, kind: "rejected", rejection: applied.error };
+    nextGraph = applied.value.graph;
+    patch = applied.value.patch;
+  }
 
-  const { graph: nextGraph, patch } = applied.value;
   const details = syncRenameIntoDetails(
     { ...built.value.details, ...parkedDetails },
     command,
@@ -299,8 +340,9 @@ export async function applyCollectionsCommand(
   // reports every affected collection including ancestors, but a nested
   // collection's clips live in its own document, so an ancestor's clip list is
   // unchanged by a change inside its child.
+  const patchAffected = patch === null ? [] : collectAffectedCollectionIds(nextGraph, patch);
   const affected = new Set(
-    collectAffectedCollectionIds(nextGraph, patch).filter((id) => documents[id] !== undefined),
+    [...patchAffected, ...declaredAffected].filter((id) => documents[id] !== undefined),
   );
 
   // Renaming a COLLECTION also has to retitle the collection's own document.
@@ -309,12 +351,24 @@ export async function applyCollectionsCommand(
   // name while the stored title (breadcrumb, project list) keeps the old one.
   // The in-page path does this through the bridge's `renameTimeline`.
   const retitled =
-    command.type === "rename-node" && documents[command.nodeId as string] !== undefined
+    command?.type === "rename-node" && documents[command.nodeId as string] !== undefined
       ? (command.nodeId as string)
       : null;
   if (retitled) affected.add(retitled);
 
   const affectedIds = [...affected];
+  // A DECLARED write set that survives none of the filtering is a failure, not
+  // a no-op. The empty short-circuit below is right for a patch-derived set (an
+  // ancestor above the loaded root legitimately has nothing to write), but a
+  // caller that named its documents and got silence would report success while
+  // saving nothing — the exact failure this whole path exists to remove.
+  if (affectedIds.length === 0 && declaredAffected.length > 0) {
+    return {
+      ok: false,
+      kind: "error",
+      message: `None of the collections to update (${declaredAffected.join(", ")}) are loaded documents under "${rootTimelineId}".`,
+    };
+  }
   if (affectedIds.length === 0 && seeded.length === 0) {
     return { ok: true, affectedIds: [], documents, details };
   }
@@ -329,7 +383,7 @@ export async function applyCollectionsCommand(
   const writes: TimelineBatchWrite[] = affectedIds.map((id) => {
     const document: TimelineDocument = {
       ...documents[id],
-      ...(id === retitled && command.type === "rename-node" ? { title: command.name } : {}),
+      ...(id === retitled && command?.type === "rename-node" ? { title: command.name } : {}),
       clips: graphChildrenToClips(nextGraph, details, id),
     };
     nextDocuments[id] = document;

--- a/apps/timeline-gstudio001/lib/mcp/write-handlers.ts
+++ b/apps/timeline-gstudio001/lib/mcp/write-handlers.ts
@@ -6,6 +6,8 @@ import {
   type NodeId,
 } from "@storyboard/collections-core";
 
+import { normalizeTags, tagsField } from "@storyboard/timeline-model/tags";
+
 import { describeDispatchRejection, toolError, toolOk } from "@/lib/webmcp/results";
 import { resolveMovePlacement, type PlacementError } from "@/lib/webmcp/placement";
 import type { ToolResult } from "@/lib/webmcp/types";
@@ -15,6 +17,7 @@ import {
   trashDocumentIdFor,
   type ApplyCommandOutcome,
 } from "./apply-command";
+import type { DetailsById } from "@storyboard/timeline-domain";
 
 // Remote (server-side) write tools. Each one translates arguments into a single
 // CollectionsCommand and hands it to `applyCollectionsCommand`, which owns the
@@ -248,6 +251,75 @@ export async function handleRenameItem(
     name,
     written: outcome.affectedIds,
   });
+}
+
+// --- set_tags ----------------------------------------------------------------
+
+export type SetTagsArgs = Readonly<{
+  timelineId: string;
+  nodeId: string;
+  tags: readonly string[];
+}>;
+
+/**
+ * Replace an item's tags — the first write that touches ONLY the detail
+ * side-table.
+ *
+ * There is no command for it, and that is correct rather than a gap: tags exist
+ * because the engine does not model them, so the graph is genuinely unchanged.
+ * The builder therefore omits `command` and names the document to rewrite
+ * instead. See CommandBuilder in apply-command.ts for why a manufactured no-op
+ * command is not an option (`applyRename` rejects a same-name rename outright).
+ *
+ * REPLACE, not merge. Add-one and remove-one both reduce to "here is the new
+ * set", which keeps the tool idempotent and lets a caller clear tags by passing
+ * `[]` — with a merge-only tool there would be no way to remove anything.
+ */
+export async function handleSetTags(
+  args: SetTagsArgs,
+  ctx: WriteContext,
+): Promise<ToolResult> {
+  const nodeId = parseNodeId(args.nodeId);
+  const tags = normalizeTags(args.tags);
+
+  const outcome = await applyCollectionsCommand(
+    args.timelineId,
+    (graph: CollectionsGraph, details) => {
+      if (!graph.nodesById.has(nodeId)) {
+        return { ok: false, message: `No node with id "${args.nodeId}".` } as const;
+      }
+      // A ROOT has no parent, so it is not a clip in anyone's document and has
+      // nowhere for tags to live. Reject rather than write into the void.
+      const parentId = graph.parentById.get(nodeId) ?? null;
+      if (parentId === null) {
+        return {
+          ok: false,
+          message: `"${args.nodeId}" is a timeline itself, not a clip inside one — tag a clip in it instead.`,
+        } as const;
+      }
+      const existing = details[nodeId as string];
+      return {
+        ok: true,
+        // Spread the WHOLE existing entry: `graphChildrenToClips` rebuilds the
+        // clip from this record, so dropping `sourceAsset`, `poster` or `alt`
+        // here would erase them from the stored clip on save.
+        details: {
+          [nodeId as string]: { ...existing, ...tagsField(tags) } as DetailsById[string],
+        },
+        // Exactly the parent — a clip is stored in its parent's `clips` array,
+        // and a tag changes no ancestor's summary.
+        affectedCollectionIds: [parentId as string],
+      } as const;
+    },
+    ctx.requesterUid,
+  );
+  if (!outcome.ok) return reportFailure(outcome);
+  return toolOk(
+    tags.length === 0
+      ? `Cleared the tags on "${args.nodeId}".`
+      : `Tagged "${args.nodeId}": ${tags.join(", ")}.`,
+    { nodeId: args.nodeId, tags, written: outcome.affectedIds },
+  );
 }
 
 // --- remove_clip -------------------------------------------------------------


### PR DESCRIPTION
Stage 1 of the tags vertical (#315). Unblocks the in-app tag editor.

## The bug this removes

Tags live on the `ClipDetail` side-table because the graph engine does not model them. That made them **unwritable after creation**: `applyCollectionsCommand` required a `CollectionsCommand`, derived its write set from the resulting patch, and a change with no patch fell straight into the empty short-circuit — `ok: true`, `affectedIds: []`, nothing saved.

A silent false success, which is the worst shape a persistence bug can take.

## The change

The builder may now omit `command` and declare `affectedCollectionIds` instead. With no command the graph carries through untouched — that is exactly what makes re-projecting the affected documents from it safe.

**Only the parent is rewritten, not the ancestors.** A clip's stored form lives in its parent's `clips` array. `collectAffectedCollectionIds` walks ancestors for a `nodes-updated` patch because a trim changes a child's duration and therefore the parent's denormalized summary — but a tag changes no summary (not `duration`, not `itemCount`, not `previewItems`). Declaring ancestors would be write amplification and extra CAS conflicts for nothing.

**A declared write set that survives none of the filtering is now an error.** The empty short-circuit stays correct for a patch-derived set (an ancestor above the loaded root genuinely has nothing to write), but for a declared one it would report success having saved nothing.

## Why not fake a no-op command

It cannot work. `applyRename` **rejects** a same-name rename outright with `same-position`, so the hack fails at the reducer — and anything that did slip through would write a phantom entry into undo history.

## set_tags

Replaces the set rather than merging. Add-one and remove-one both reduce to "here is the new set", the tool stays idempotent, and `[]` clears. The handler spreads the whole existing detail: dropping `sourceAsset` there would erase provenance from the stored clip and leak the file (docs/asset-providers.md).

Roots are rejected explicitly — a timeline has no parent document to store tags in.

## Verification

I removed the declared-ids union and re-ran: **3 of the 4 new tests fail.** That is what makes them worth having.

- app suite 677 passed, unit suite 530 passed
- `tsc --noEmit` clean; `npm run lint` 0 errors (5 pre-existing warnings)
- New coverage: details-only write persists; siblings and `sourceAsset` survive; revision bumps so concurrent writers still lose; unloaded declared id errors instead of lying

🤖 Generated with [Claude Code](https://claude.com/claude-code)