### PR TITLE
Show a clip's tags on its card

### DIFF
--- a/apps/storybook/.storybook/globals.css
+++ b/apps/storybook/.storybook/globals.css
@@ -10,9 +10,11 @@
 .border-dashed {
   /* border-style: none !important; */
 }
-.z-10 > .truncate, .z-10 > .font-mono {
-  display: none !important;
-}
+/* NOTE: a `.z-10 > .truncate, .z-10 > .font-mono { display: none !important }`
+   rule lived here from a 2026-06-17 refactor. It was debug cruft that HID real
+   content — any overlay with `z-10` whose children truncate (a chip row, for
+   instance) rendered at zero size in Storybook while being correct in the app,
+   so the story suite reported a false negative on markup that worked. */
 
 @custom-variant dark (&:is(.dark *));
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -805,3 +805,97 @@ export const AnchorControlAndCountBadge: Story = {
     expect(doc.querySelectorAll("[data-card-selected-badge]")).toHaveLength(2);
   },
 };
+
+// ── Tags ────────────────────────────────────────────────────────────────────
+
+/** A tagged COLLECTION card. Collections route through
+ *  GraphCollectionItemParts rather than GraphClipContent, so they need their
+ *  own cover — a media-only implementation would leave tagged collections
+ *  showing nothing at all. */
+function renderWithTags(tags: string[]) {
+  const detail: ClipDetail = {
+    alt: "A timeline",
+    aspect: 16 / 9,
+    trackIndex: 0,
+    hydrated: false,
+    itemCount: 2,
+    previewItems: [ASSET_A, ASSET_B],
+    tags,
+  };
+  const store = createGraphDetailsStore({ [COLLECTION_ID]: detail });
+  const decorator: Decorator = (Story) => (
+    <DndCollections initialGraph={providerGraph}>
+      <GraphDetailsProvider store={store}>
+        <div className="h-32 w-40 bg-zinc-950 p-2">
+          <Story />
+        </div>
+      </GraphDetailsProvider>
+    </DndCollections>
+  );
+  return decorator;
+}
+
+/** A few tags render in full, in the order they were stored. */
+export const TaggedCollectionCard: Story = {
+  args: baseArgs,
+  decorators: [renderWithTags(["scail-2", "S02"])],
+  play: async ({ canvasElement }) => {
+    const row = canvasElement.querySelector<HTMLElement>("[data-clip-tags]")!;
+    await expect(row).not.toBeNull();
+    await expect(row.dataset.clipTags).toBe("2");
+    await expect(row.textContent).toBe("scail-2S02");
+    for (const chip of Array.from(row.children) as HTMLElement[]) {
+      await expect(chip.getBoundingClientRect().width).toBeGreaterThan(0);
+    }
+    // Decorative: the card's own label already names it, and nothing in here
+    // may be interactive — this subtree renders inside a selection surface.
+    await expect(row.getAttribute("aria-hidden")).toBe("true");
+    await expect(row.querySelector("button")).toBeNull();
+  },
+};
+
+/**
+ * Past three tags the rest fold into a counter.
+ *
+ * The failure this guards is INVISIBLE: the content root is `overflow-hidden`
+ * with no ellipsis, so an unbounded row is clipped with nothing to show it was
+ * clipped — a set that reads as complete but is not.
+ */
+export const ManyTagsFoldIntoACounter: Story = {
+  args: baseArgs,
+  decorators: [renderWithTags(["scail-2", "wan2.1", "S02", "keeper", "multirole"])],
+  play: async ({ canvasElement }) => {
+    const row = canvasElement.querySelector<HTMLElement>("[data-clip-tags]")!;
+    await expect(row.dataset.clipTags).toBe("5");
+    const overflow = canvasElement.querySelector<HTMLElement>("[data-clip-tags-overflow]")!;
+    await expect(overflow).not.toBeNull();
+    await expect(overflow.dataset.clipTagsOverflow).toBe("3");
+    await expect(overflow.textContent).toBe("+3");
+
+    // MEASURED, not read. The first version of this asserted `textContent` and
+    // passed while all three chips were flex-shrunk to ZERO width — text
+    // present, nothing on screen. Assert every chip actually occupies space,
+    // and that the row stays inside the card, because the card is
+    // `overflow-hidden` with no ellipsis and clips silently.
+    const chips = Array.from(row.children) as HTMLElement[];
+    for (const chip of chips) {
+      await expect(chip.getBoundingClientRect().width).toBeGreaterThan(0);
+      await expect(chip.getBoundingClientRect().height).toBeGreaterThan(0);
+    }
+    const card = canvasElement.querySelector<HTMLElement>("[data-node-id]")!;
+    const cardBox = card.getBoundingClientRect();
+    const rowBox = row.getBoundingClientRect();
+    await expect(rowBox.left).toBeGreaterThanOrEqual(cardBox.left);
+    await expect(rowBox.right).toBeLessThanOrEqual(cardBox.right + 0.5);
+  },
+};
+
+/** An untagged card grows no row at all — absence is the default everywhere
+ *  else in this model, and an empty chip strip would read as a data glitch. */
+export const UntaggedCardHasNoTagRow: Story = {
+  args: baseArgs,
+  decorators: [renderWithTags([])],
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelector("[data-clip-tags]")).toBeNull();
+  },
+};

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -725,6 +725,77 @@ function ProvenanceLabel({
   );
 }
 
+/**
+ * Below this card width the tag row is dropped entirely.
+ *
+ * ONE threshold, not a fold ladder — the same call ClipCornerSlot made
+ * (MIN_ANCHOR_CONTROL_WIDTH). Two chips plus a counter need roughly this much
+ * before they start colliding with the card's own padding, and the content root
+ * is `overflow-hidden` with no ellipsis, so an over-wide row is clipped
+ * INVISIBLY rather than degrading. Better to show nothing than a silently
+ * truncated set someone might read as complete.
+ */
+const TAG_ROW_MIN_WIDTH = 132;
+/**
+ * Chips shown before the rest fold into a +N counter, by card width.
+ *
+ * Two, not three, until the card is wide enough. MEASURED: on a 144px card the
+ * row has ~128px to work with, and three chips plus a counter want ~150px —
+ * so they were being flex-shrunk to ZERO width. Every chip still had its text
+ * content, so a `textContent` assertion passed while nothing was on screen.
+ * `shrink-0` below is what stops the collapse; this is what stops the overflow
+ * that made shrinking necessary.
+ */
+const TAGS_SHOWN_WIDE = 3;
+const TAGS_SHOWN_NARROW = 2;
+const TAG_ROW_WIDE_WIDTH = 220;
+
+/**
+ * A clip's tags, bottom-left and STACKED above the kind chip.
+ *
+ * Every other edge is taken: the title spans the top, ProvenanceLabel and the
+ * selected badge hold the top-left, the corner menu the top-right, and the
+ * duration pill and disabled chip the bottom-right.
+ *
+ * Decorative for AT — the card's own label already names the clip, and the tags
+ * are reachable through the item details panel where they can also be edited.
+ * Nothing here is interactive: this renders inside NodeCard's <button>, so an
+ * interactive child would be invalid HTML and an ambiguous a11y tree.
+ */
+function TagRow({
+  tags,
+  showAtMost,
+}: Readonly<{ tags: readonly string[]; showAtMost: number }>) {
+  const shown = tags.slice(0, showAtMost);
+  const extra = tags.length - shown.length;
+  return (
+    <span
+      aria-hidden="true"
+      data-clip-tags={tags.length}
+      className="pointer-events-none absolute bottom-8 left-2 z-10 flex max-w-[calc(100%-1rem)] items-center gap-1"
+    >
+      {shown.map((tag) => (
+        <span
+          key={tag}
+          className="max-w-[6.5rem] shrink-0 truncate rounded bg-black/75 px-1 py-0.5 text-[8px] leading-none font-semibold text-zinc-200 ring-1 ring-white/15"
+        >
+          {tag}
+        </span>
+      ))}
+      {extra > 0 && (
+        <span
+          data-clip-tags-overflow={extra}
+          // Circle at one digit, stadium beyond — `rounded-full` + a min width,
+          // the same shape AnchorCountBadge gets without special-casing digits.
+          className="min-w-[1.05rem] shrink-0 rounded-full bg-black/75 px-1 py-0.5 text-center text-[8px] leading-none font-semibold text-zinc-400 ring-1 ring-white/15"
+        >
+          +{extra}
+        </span>
+      )}
+    </span>
+  );
+}
+
 const GraphClipContent = memo(function GraphClipContent({
   id,
   node,
@@ -859,6 +930,23 @@ const GraphClipContent = memo(function GraphClipContent({
       >
         {isVideo ? "VIDEO" : isAudio ? "AUDIO" : "IMAGE"}
       </span>
+      {/* Tags, stacked above the kind chip. Shown on DISABLED cards too,
+          unlike the title: a disabled clip is exactly the one someone is
+          hunting for by tag, so hiding its labels would work against the
+          reason tags exist. Width 0 means "not measured yet" — render, or the
+          row flashes in on every mount. */}
+      {detail?.tags?.length ? (
+        cardSize.width === 0 || cardSize.width >= TAG_ROW_MIN_WIDTH ? (
+          <TagRow
+            tags={detail.tags}
+            showAtMost={
+              cardSize.width === 0 || cardSize.width >= TAG_ROW_WIDE_WIDTH
+                ? TAGS_SHOWN_WIDE
+                : TAGS_SHOWN_NARROW
+            }
+          />
+        ) : null
+      ) : null}
       {/* The clip's NAME, shown only when someone gave it one (PL11-004).
           Every clip has an `alt` — a filename, usually — so a card that
           rendered "the name" would render something on all of them, and a
@@ -1158,6 +1246,12 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
         ].join(" ")}
       >
         {muted && <DisabledChip inherited={node.disabled !== true} />}
+        {/* Collections are taggable too — `tags` sits on TimelineItemBase, not
+            on the media members — and they route through THIS component rather
+            than GraphClipContent (which returns null for them at the guard
+            above). Skipping it here would ship a half-feature where a tagged
+            collection silently shows nothing. */}
+        {detail?.tags?.length ? <TagRow tags={detail.tags} showAtMost={TAGS_SHOWN_NARROW} /> : null}
         <span
           data-disabled-visuals={muted ? "true" : undefined}
           className={[


### PR DESCRIPTION
Stage 2 of the tags vertical (#315). Builds on #317.

A tag row bottom-left, stacked above the kind chip — the only free edge left. The title spans the top, `ProvenanceLabel` and the selected badge hold the top-left, the corner menu the top-right, the duration pill and disabled chip the bottom-right.

**Collections get it too.** `tags` lives on `TimelineItemBase`, and collections route through `GraphCollectionItemParts` rather than `GraphClipContent` (which returns `null` for them at its guard). A media-only version would have shipped a half-feature where a tagged collection silently showed nothing.

Shown on **disabled** cards, unlike the title — a disabled clip is exactly the one someone is hunting for by tag.

## Two sizing bugs, both caught by measuring rather than reading

**1. The chips were rendering at zero width.** Three chips plus a counter want ~150px; a 144px card gives the row ~128px. They're flex items with `truncate` (overflow hidden), so they got flex-shrunk to nothing — while keeping their text content, which meant my first `textContent` assertion passed with an empty card on screen.

Fixed with `shrink-0` plus a per-width chip budget: 3 when wide, 2 when narrow. The collection card measures nothing, so it takes the conservative count, which can never clip.

**2. Storybook was hiding them outright.**

```css
.z-10 > .truncate, .z-10 > .font-mono { display: none !important; }
```

Debug cruft in `apps/storybook/.storybook/globals.css` from a 2026-06-17 refactor — the app's own `globals.css` never had it. It **hid real content**: any `z-10` overlay whose children truncate rendered at zero size in Storybook while being correct in the app, so the story suite returned a false negative on working markup. Removed, with a note explaining why. **All 173 story tests pass without it.**

## Testing

Stories now assert `getBoundingClientRect` rather than `textContent`, and check the row stays within the card bounds — the content root is `overflow-hidden` with no ellipsis, so an over-wide row is clipped with nothing to indicate it.

- `--project=storybook` 173 passed (3 new, in real headless Chromium)
- `--project=unit` 530 passed; app suite 673 passed
- `tsc --noEmit` clean; lint 0 errors

Nothing in the row is interactive — it renders inside `NodeCard`'s `<button>`, where an interactive child would be invalid HTML and an ambiguous a11y tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)