### PR TITLE
Add and remove tags from the item details view

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -23,6 +23,7 @@ import { DETAILS_HERO_FILL_CLASS, DETAILS_PANEL_HEIGHT_CLASS } from "./graph-vie
 import { useSeekedVideo } from "@/hooks/use-seeked-video";
 import { formatSeconds } from "@/lib/format-duration";
 import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
+import { TagEditor } from "./graph-tag-editor";
 import { CollectionDetailsBody } from "./graph-collection-details";
 import { ItemDisableToggle } from "./graph-item-disable-toggle";
 import { useItemDetails } from "./graph-item-details-context";
@@ -518,6 +519,20 @@ function ModalBody({ node, onClose }: Readonly<{ node: MediaNode; onClose: () =>
             <span>drag the card&apos;s edge on the strip to change how long it holds</span>
           </div>
         )}
+
+        {/* Tags. Here rather than on the card because the card's content
+            renders inside a <button>, where these remove buttons and the text
+            field would be invalid HTML — the card shows them, this edits them.
+
+            No undo: a tag change writes the detail side-table directly and
+            emits no patch, so `useScopedHistory` above never sees it. See
+            graph-tag-editor.tsx for why that is the deliberate trade. */}
+        <div className="flex flex-col gap-1.5 border-t border-white/10 pt-3">
+          <span className="font-mono text-[11px] tracking-[0.08em] text-zinc-500 uppercase">
+            Tags
+          </span>
+          <TagEditor nodeId={node.id} />
+        </div>
       </div>
     </div>,
     document.body,

--- a/apps/timeline-gstudio001/components/graph-view/graph-tag-editor.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-tag-editor.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { X } from "lucide-react";
+
+import { useCollectionsStore, type NodeId } from "@storyboard/ui/dnd-collections";
+import { graphChildrenToClips } from "@storyboard/timeline-domain";
+import { MAX_TAGS_PER_CLIP, MAX_TAG_LENGTH, normalizeTags } from "@storyboard/timeline-model/tags";
+
+import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
+import { isTagWriteRefusal, planTagWrite } from "@/lib/tag-write-plan";
+
+import { useClipDetail, useGraphDetailsStore } from "./graph-details-context";
+
+// Editing tags is the ONE mutation in this view that does not go through a
+// graph command, and everything odd about this file follows from that.
+//
+// Tags live on the detail side-table because the engine does not model them.
+// `detailsStore.merge()` notifies its own subscribers and NOTHING else — it
+// produces no CollectionsPatch, so `store.subscribeToChanges` never fires and
+// PersistenceBridge never writes. An editor that merged and stopped would look
+// completely correct: the chips update, the card re-renders, and the change is
+// gone on reload. So this does the bridge's job explicitly, in the same order
+// the bridge does it: merge first, then project the parent from the MERGED
+// details and hand it to the gateway.
+//
+// Consequence worth knowing: a tag edit is NOT undoable. `useScopedHistory` in
+// the details modal whitelists `update-media` / `rename-node` /
+// `set-node-disabled`, and a change with no command adds no history entry at
+// all. Making tags undoable would mean making them a graph command, which would
+// put them in the engine — the thing the side-table exists to avoid.
+
+/** Persist a tag change for one node, and report whether it landed. */
+export function useSetTags(nodeId: NodeId) {
+  const store = useCollectionsStore();
+  const detailsStore = useGraphDetailsStore();
+
+  return useCallback(
+    (next: readonly string[]) => {
+      const graph = store.getSnapshot().graph;
+      const plan = planTagWrite(graph, detailsStore.read(), nodeId, next);
+      if (isTagWriteRefusal(plan)) return false;
+
+      // MERGE FIRST. The projection below reads the details side-table, so
+      // writing in the other order would persist the clip as it was and leave
+      // the new tags in memory only — the same ordering bug the restore path
+      // hit (see graph-item-actions).
+      detailsStore.merge({ [nodeId as string]: plan.detail });
+
+      // The SAME filters PersistenceBridge applies. A document nobody has
+      // loaded, an un-hydrated placeholder, or a conflicted one would each be
+      // refused by `writeClips` anyway; checking here keeps us from reporting
+      // a write that did not happen.
+      const current = detailsStore.read();
+      if (
+        graphDocumentsGateway.peek(plan.parentId) === null ||
+        current[plan.parentId]?.hydrated === false ||
+        graphDocumentsGateway.isConflicted(plan.parentId)
+      ) {
+        return false;
+      }
+      graphDocumentsGateway.writeClips(
+        plan.parentId,
+        graphChildrenToClips(graph, current, plan.parentId),
+      );
+      return true;
+    },
+    [nodeId, store, detailsStore],
+  );
+}
+
+/**
+ * Add and remove a clip's tags.
+ *
+ * Chips commit individually — a chip's remove button and the add field are
+ * separate controls, so this deliberately does NOT commit the text input on
+ * blur the way InlineNameEditor does. Clicking a remove button blurs the input,
+ * and a blur-commit would fire the add path with whatever half-typed text was
+ * sitting there at the same moment the remove fired.
+ */
+export function TagEditor({ nodeId }: Readonly<{ nodeId: NodeId }>) {
+  const detail = useClipDetail(nodeId as string);
+  const setTags = useSetTags(nodeId);
+  const [draft, setDraft] = useState("");
+  const tags = detail?.tags ?? [];
+  const full = tags.length >= MAX_TAGS_PER_CLIP;
+
+  const add = () => {
+    const candidate = draft.trim();
+    if (candidate.length === 0 || full) return;
+    // Round-trip through the same normalizer the store uses, so a duplicate
+    // differing only in case is dropped here rather than silently disappearing
+    // on save.
+    const next = normalizeTags([...tags, candidate]);
+    if (next.length !== tags.length) setTags(next);
+    setDraft("");
+  };
+
+  return (
+    <div className="flex flex-col gap-2" data-tag-editor>
+      <div className="flex flex-wrap items-center gap-1.5">
+        {tags.length === 0 && (
+          <span className="text-[11px] text-zinc-500">
+            No tags yet — label this clip to find it again later.
+          </span>
+        )}
+        {tags.map((tag) => (
+          <span
+            key={tag}
+            data-tag-chip={tag}
+            className="flex items-center gap-1 rounded bg-zinc-800 py-0.5 pr-0.5 pl-1.5 text-[11px] leading-none font-medium text-zinc-200 ring-1 ring-white/10"
+          >
+            {tag}
+            <button
+              type="button"
+              aria-label={`Remove tag ${tag}`}
+              title={`Remove ${tag}`}
+              onClick={() => setTags(tags.filter((candidate) => candidate !== tag))}
+              className="flex size-4 items-center justify-center rounded-sm text-zinc-400 transition-colors hover:bg-zinc-700 hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-sky-500/70 focus-visible:outline-none"
+            >
+              <X aria-hidden="true" className="size-3" />
+            </button>
+          </span>
+        ))}
+      </div>
+      <input
+        type="text"
+        value={draft}
+        disabled={full}
+        maxLength={MAX_TAG_LENGTH}
+        onChange={(event) => setDraft(event.target.value)}
+        onKeyDown={(event) => {
+          // Enter commits; comma too, because typing a list is the natural
+          // gesture and a comma inside a single tag has no meaning here.
+          if (event.key === "Enter" || event.key === ",") {
+            event.preventDefault();
+            add();
+            return;
+          }
+          // Backspace on an empty field removes the last chip — the standard
+          // token-field gesture, and the only keyboard route to removal that
+          // does not require tabbing through every chip.
+          if (event.key === "Backspace" && draft.length === 0 && tags.length > 0) {
+            event.preventDefault();
+            setTags(tags.slice(0, -1));
+          }
+        }}
+        aria-label="Add a tag"
+        placeholder={full ? `Limit of ${MAX_TAGS_PER_CLIP} tags reached` : "Add a tag…"}
+        className="w-full rounded-sm bg-zinc-900 px-2 py-1 text-[11px] text-zinc-100 ring-1 ring-white/10 outline-none placeholder:text-zinc-600 focus:ring-sky-500/70 disabled:cursor-not-allowed disabled:text-zinc-500"
+      />
+    </div>
+  );
+}

--- a/apps/timeline-gstudio001/lib/tag-write-plan.test.ts
+++ b/apps/timeline-gstudio001/lib/tag-write-plan.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import { buildGraph, parseNodeId } from "@storyboard/collections-core";
+import type { DetailsById } from "@storyboard/timeline-domain";
+
+import { isTagWriteRefusal, planTagWrite, type TagWritePlan } from "./tag-write-plan";
+
+// Editing tags is the one graph-view mutation with no command behind it, so
+// nothing downstream can catch a mistake here: `detailsStore.merge()` emits no
+// patch, PersistenceBridge never fires, and a wrong answer shows correct chips
+// that vanish on reload.
+
+const graph = (() => {
+  const built = buildGraph([
+    {
+      kind: "collection",
+      id: "root",
+      name: "Root",
+      children: [
+        { kind: "media", id: "clip-a", name: "A", durationSeconds: 4 },
+        {
+          kind: "collection",
+          id: "inner",
+          name: "Inner",
+          children: [{ kind: "media", id: "clip-b", name: "B", durationSeconds: 4 }],
+        },
+      ],
+    },
+  ]);
+  if (!built.ok) throw new Error(JSON.stringify(built.error));
+  return built.value;
+})();
+
+const details: DetailsById = {
+  root: { alt: "Root", aspect: 16 / 9, trackIndex: 0, hydrated: true },
+  "clip-a": {
+    alt: "A",
+    aspect: 16 / 9,
+    trackIndex: 0,
+    poster: "https://example.test/a.jpg",
+    sourceAsset: { providerId: "cloudinary", assetId: "x/a" },
+  },
+  inner: { alt: "Inner", aspect: 16 / 9, trackIndex: 0, hydrated: true },
+  "clip-b": { alt: "B", aspect: 16 / 9, trackIndex: 0, tags: ["old"] },
+};
+
+function plan(nodeId: string, tags: string[]): TagWritePlan {
+  const result = planTagWrite(graph, details, parseNodeId(nodeId), tags);
+  if (isTagWriteRefusal(result)) throw new Error(`refused: ${result.reason}`);
+  return result;
+}
+
+describe("planTagWrite", () => {
+  it("names the clip's own parent, and only that", () => {
+    // A clip is stored in its parent's `clips` array, and a tag changes no
+    // ancestor's summary — not duration, not itemCount, not previewItems. This
+    // mirrors the server rule in handleSetTags; the two surfaces must agree.
+    expect(plan("clip-a", ["keeper"]).parentId).toBe("root");
+    expect(plan("clip-b", ["keeper"]).parentId).toBe("inner");
+  });
+
+  it("keeps every other field on the detail", () => {
+    // The merge rebuilds the stored clip. Dropping poster or sourceAsset here
+    // would erase provenance and leak the file.
+    const { detail } = plan("clip-a", ["keeper"]);
+    expect(detail.poster).toBe("https://example.test/a.jpg");
+    expect(detail.sourceAsset).toEqual({ providerId: "cloudinary", assetId: "x/a" });
+    expect(detail.alt).toBe("A");
+    expect(detail.tags).toEqual(["keeper"]);
+  });
+
+  it("normalizes on the way in", () => {
+    const { detail, tags } = plan("clip-a", ["  Keeper ", "keeper", "", "S02"]);
+    expect(tags).toEqual(["Keeper", "S02"]);
+    expect(detail.tags).toEqual(["Keeper", "S02"]);
+  });
+
+  it("clearing REMOVES the key rather than storing an empty array", () => {
+    // Absence is what "untagged" means everywhere else in this model; an empty
+    // array would make a document grow a field it does not use.
+    const { detail } = plan("clip-b", []);
+    expect("tags" in detail).toBe(false);
+  });
+
+  it("does not mutate the details it was given", () => {
+    const before = JSON.stringify(details);
+    plan("clip-b", ["something-else"]);
+    expect(JSON.stringify(details)).toBe(before);
+  });
+
+  it("refuses a root — a timeline is not a clip in anyone's document", () => {
+    const result = planTagWrite(graph, details, parseNodeId("root"), ["x"]);
+    expect(isTagWriteRefusal(result)).toBe(true);
+    if (!isTagWriteRefusal(result)) throw new Error("expected a refusal");
+    expect(result.reason).toBe("is-root");
+  });
+
+  it("refuses an unknown node", () => {
+    const result = planTagWrite(graph, details, parseNodeId("nope"), ["x"]);
+    expect(isTagWriteRefusal(result)).toBe(true);
+  });
+
+  it("refuses a node with no detail entry rather than writing a bare one", () => {
+    // Writing `{tags}` alone would rebuild the clip without its alt, poster or
+    // sourceAsset — the erasure this refusal exists to prevent.
+    const thin: DetailsById = { root: details.root };
+    const result = planTagWrite(graph, thin, parseNodeId("clip-a"), ["x"]);
+    expect(isTagWriteRefusal(result)).toBe(true);
+    if (!isTagWriteRefusal(result)) throw new Error("expected a refusal");
+    expect(result.reason).toBe("no-detail");
+  });
+});

--- a/apps/timeline-gstudio001/lib/tag-write-plan.ts
+++ b/apps/timeline-gstudio001/lib/tag-write-plan.ts
@@ -1,0 +1,77 @@
+import type { CollectionsGraph, NodeId } from "@storyboard/collections-core";
+import type { ClipDetail, DetailsById } from "@storyboard/timeline-domain";
+import { normalizeTags } from "@storyboard/timeline-model/tags";
+
+// The DECISION half of editing tags in the browser, split out from the IO so it
+// can be tested without a React tree or a gateway.
+//
+// It exists because tags are the one mutation in the graph view that does not
+// go through a graph command. `detailsStore.merge()` emits no CollectionsPatch,
+// so PersistenceBridge never fires, so the editor has to work out for itself
+// which document to rewrite. Getting that wrong is invisible: the chips update
+// and the change is gone on reload.
+
+export type TagWritePlan = Readonly<{
+  /** The detail entry to merge, already normalized. */
+  detail: ClipDetail;
+  /** The document whose clip list must be re-projected and written. */
+  parentId: string;
+  /** The cleaned tags, for reporting back to the caller. */
+  tags: readonly string[];
+}>;
+
+export type TagWriteRefusal = Readonly<{
+  reason: "unknown-node" | "no-detail" | "is-root";
+}>;
+
+/**
+ * Work out what a tag change means, or why it cannot be made.
+ *
+ * Returns the merged detail and the ONE document to rewrite: a clip's stored
+ * form lives in its parent's `clips` array, and a tag changes no ancestor's
+ * summary (not duration, not itemCount, not previewItems), so nothing above the
+ * parent needs touching. This mirrors the server-side rule in
+ * `handleSetTags`/`applyCollectionsCommand`, deliberately — the two surfaces
+ * must agree about what a tag write affects.
+ *
+ * Clearing is expressed as REMOVING the key, not storing `[]`. Absence is what
+ * "untagged" means everywhere else in this model, and an empty array would make
+ * a document grow a field it does not use.
+ */
+export function planTagWrite(
+  graph: CollectionsGraph,
+  details: DetailsById,
+  nodeId: NodeId,
+  tags: readonly string[],
+): TagWritePlan | TagWriteRefusal {
+  if (!graph.nodesById.has(nodeId)) return { reason: "unknown-node" };
+
+  const existing = details[nodeId as string];
+  // No detail entry means nothing to merge INTO — writing a bare `{tags}` here
+  // would rebuild the clip without its alt, poster or sourceAsset, which is how
+  // provenance gets erased and a file leaks.
+  if (!existing) return { reason: "no-detail" };
+
+  // A root has no parent, so it is not a clip in any document and has nowhere
+  // for tags to live.
+  const parentId = graph.parentById.get(nodeId) ?? null;
+  if (parentId === null) return { reason: "is-root" };
+
+  const next = normalizeTags(tags);
+  const detail: ClipDetail =
+    next.length === 0
+      ? (() => {
+          const { tags: _dropped, ...rest } = existing;
+          return rest;
+        })()
+      : { ...existing, tags: [...next] };
+
+  return { detail, parentId: parentId as string, tags: next };
+}
+
+/** Narrow a plan result. */
+export function isTagWriteRefusal(
+  result: TagWritePlan | TagWriteRefusal,
+): result is TagWriteRefusal {
+  return "reason" in result;
+}


### PR DESCRIPTION
Stage 3 of the tags vertical (#315). Builds on #317 (write path) and #318 (card display).

A token field in the details modal: chips with remove buttons, an input committing on Enter or comma, Backspace-on-empty to drop the last. **In the modal rather than on the card** because card content renders inside a `<button>`, where these controls would be invalid HTML and an ambiguous a11y tree. The card shows tags; this edits them.

## The trap this avoids

Tags are the one mutation in the graph view with **no graph command behind it**. `detailsStore.merge()` notifies its own subscribers and nothing else — no `CollectionsPatch`, so `store.subscribeToChanges` never fires and `PersistenceBridge` never writes.

An editor that merged and stopped would look **entirely correct** — chips update, card re-renders — and lose the change on reload.

So this does the bridge's job explicitly, in the same order it does: merge first, then project the parent from the *merged* details, then hand it to the gateway — applying the same `peek` / `hydrated` / `isConflicted` filters, so it never reports a write that did not happen.

## Why a pure function

The decision half lives in `lib/tag-write-plan.ts` because none of it is testable through a React tree: app vitest cannot parse `.tsx`, and a hook harness would end up testing the harness.

It names exactly the clip's **parent** — a clip is stored in its parent's `clips` array, and a tag changes no ancestor's summary. That is the same rule the server's `handleSetTags` follows; the two surfaces must agree about what a tag write affects.

Clearing **removes the key** rather than storing `[]` — absence is what "untagged" means everywhere else in this model.

Three refusals are explicit and covered: a root (not a clip in any document), an unknown node, and a node with no detail entry. That last one matters: writing a bare `{tags}` would rebuild the clip without its `alt`, `poster` and `sourceAsset`, erasing provenance and leaking the file.

## Known limitation, stated in the code

**A tag edit is not undoable.** `useScopedHistory` whitelists `update-media` / `rename-node` / `set-node-disabled`, and a change with no command adds no history entry at all. Making tags undoable means making them a graph command, which puts them in the engine — precisely what the side-table exists to avoid.

## Verification

- 685 app tests (8 new on the planner), 530 unit
- `tsc --noEmit` clean; lint 0 errors
- Not commit-on-blur, unlike `InlineNameEditor`: clicking a chip's remove button blurs the input, and a blur-commit would fire the add path with half-typed text at the same moment the remove fired

🤖 Generated with [Claude Code](https://claude.com/claude-code)