### PR TITLE
Filter the board by tag, by dimming rather than hiding

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -97,6 +97,8 @@ import {
 } from "./graph-preview";
 import { AddCollectionSlot } from "./graph-add-collection-slot";
 import { CollectionHoverProvider } from "./graph-collection-hover";
+import { TagFilterProvider } from "./graph-tag-filter";
+import { TagFilterControl } from "./graph-tag-filter-control";
 import { ItemDetailsProvider } from "./graph-item-details-context";
 import { GraphSaveStatus } from "./graph-save-status";
 import { GraphShortcuts, requestGraphShortcuts } from "./graph-shortcuts";
@@ -957,6 +959,7 @@ export function GraphBoard({
       <CollectionHoverProvider enabled={childrenShown}>
       {/* Published ABOVE the preview shell so the header aggregate and every
           time overlay inside it measure the run actually on screen. */}
+      <TagFilterProvider>
       <FlatItemsProvider items={flatItems}>
       <PreviewShell enabled={previewOn} focusedId={focusedId} channel={timeChannel}>
         {/* Outside the surface branch on purpose: the sidebar's tool buttons
@@ -1044,6 +1047,7 @@ export function GraphBoard({
                   (see timeline-sidebar) because it is one of the two controls
                   worth promoting to rail scale; this row keeps the ones that
                   only qualify the board in front of you. */}
+              <TagFilterControl />
               {flatOn ? (
                 <HeaderToggle
                   active={rulerOn}
@@ -1273,6 +1277,7 @@ export function GraphBoard({
         </div>
       </PreviewShell>
       </FlatItemsProvider>
+      </TagFilterProvider>
       </CollectionHoverProvider>
       </ItemDetailsProvider>
     </OpenKeyBoundary>

--- a/apps/timeline-gstudio001/components/graph-view/graph-details-context.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-details-context.tsx
@@ -41,6 +41,21 @@ export function useClipDetail(id: string): ClipDetail | undefined {
   );
 }
 
+/**
+ * The WHOLE details table.
+ *
+ * Deliberately coarse, unlike `useClipDetail`: a consumer that has to aggregate
+ * across every item (the tag filter's menu, which counts tags in use) has no
+ * single id to subscribe to, and subscribing per-id would mean knowing the ids
+ * in advance. `store.read()` returns the same object identity until a merge
+ * replaces it, so this re-renders on any detail change and not otherwise —
+ * acceptable for a control that only exists in the header.
+ */
+export function useGraphDetailsSnapshot(): Readonly<Record<string, ClipDetail | undefined>> {
+  const store = useGraphDetailsStore();
+  return useSyncExternalStore(store.subscribe, store.read, store.read);
+}
+
 /** A timeline's display NAME, read from its gateway document title — the
  *  app's source of truth for a collection's name (the chrome breadcrumb reads
  *  the same field, and the server derives parent clip titles from it).

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -44,6 +44,7 @@ import {
 } from "@storyboard/timeline-domain";
 
 import { useClipDetail, useGraphDetailsStore, useTimelineTitle } from "./graph-details-context";
+import { useTagFilterMiss } from "./graph-tag-filter";
 import { isDisabledByAncestor } from "./graph-playhead-model";
 import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
 import { useCollectionHoverTarget } from "./graph-collection-hover";
@@ -815,6 +816,12 @@ const GraphClipContent = memo(function GraphClipContent({
   const settledFrames = useSettledFrameCount(measuredFrames);
   // Above the collection early-return below — hooks may not be conditional.
   const inheritedDisabled = useDisabledByAncestor(id);
+  // Above the collection early-return below, with the other hooks — hooks may
+  // not be conditional. A filter MISS is a SEPARATE state from disabled, so it
+  // gets its own signal and its own treatment (opacity only): `opacity-45
+  // grayscale` is already disabled's language, and a card that is both must
+  // still read as both.
+  const filterMiss = useTagFilterMiss(id as string);
   const provenance = useCardProvenance(id);
   const frameLoading = useContext(VideoFrameLoadingContext);
   // The AUTHORED name, read straight from the side table rather than from
@@ -882,10 +889,12 @@ const GraphClipContent = memo(function GraphClipContent({
     >
       <span
         data-disabled-visuals={muted ? "true" : undefined}
+        data-filter-miss={filterMiss ? "true" : undefined}
         className={[
           "relative flex h-full w-full overflow-hidden rounded-sm",
-          isDragSource ? "opacity-40" : muted ? "opacity-45" : "",
+          isDragSource ? "opacity-40" : muted ? "opacity-45" : filterMiss ? "opacity-30" : "",
           muted ? "grayscale" : "",
+          "motion-safe:transition-opacity motion-safe:duration-150",
         ].join(" ")}
       >
       {frameSrcs.length === 0 ? (
@@ -1200,6 +1209,7 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
   const previews = useCollectionPreviewFrames(id as string, hydrated, detail?.previewItems);
   const displayName = title ?? node.name;
   const inheritedDisabled = useDisabledByAncestor(id);
+  const filterMiss = useTagFilterMiss(id as string);
   const muted = node.disabled === true || inheritedDisabled;
   // Anchor state is not read here any more: `CardCornerSlot` subscribes to it
   // itself, narrowed to this node, so an anchor moving between two OTHER cards
@@ -1254,10 +1264,12 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
         {detail?.tags?.length ? <TagRow tags={detail.tags} showAtMost={TAGS_SHOWN_NARROW} /> : null}
         <span
           data-disabled-visuals={muted ? "true" : undefined}
+          data-filter-miss={filterMiss ? "true" : undefined}
           className={[
             "flex min-h-0 flex-1 gap-0.5 overflow-hidden",
-            isDragSource ? "opacity-40" : muted ? "opacity-45" : "",
+            isDragSource ? "opacity-40" : muted ? "opacity-45" : filterMiss ? "opacity-30" : "",
             muted ? "grayscale" : "",
+            "motion-safe:transition-opacity motion-safe:duration-150",
           ].join(" ")}
         >
           {previews.length === 0 ? (

--- a/apps/timeline-gstudio001/components/graph-view/graph-tag-filter-control.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-tag-filter-control.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import { Tag } from "lucide-react";
+
+import { tagCounts } from "@/lib/tag-facets";
+
+import { useGraphDetailsSnapshot } from "./graph-details-context";
+import { useTagFilter } from "./graph-tag-filter";
+
+/**
+ * The board's tag filter: pick tags, non-matching cards dim.
+ *
+ * Lives in the header's VIEW group because it QUALIFIES what the board shows
+ * rather than changing the document — the same class of control as the ruler
+ * and waveform toggles beside it.
+ *
+ * The menu is built from the tags actually in use, not from a fixed list.
+ * Tag vocabulary here is emergent (a new checkpoint is a new tag), so anything
+ * curated would be stale within a week.
+ */
+export function TagFilterControl() {
+  const [open, setOpen] = useState(false);
+  const details = useGraphDetailsSnapshot();
+  const { activeTags, toggleTag, clear } = useTagFilter();
+  const counts = tagCounts(details);
+  const active = activeTags.size;
+
+  // Nothing tagged yet means nothing to filter by, and an empty menu is worse
+  // than no control at all.
+  if (counts.length === 0) return null;
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        data-tag-filter-trigger
+        aria-expanded={open}
+        aria-haspopup="menu"
+        onClick={() => setOpen((value) => !value)}
+        title="Filter the board by tag — non-matching cards dim"
+        aria-label={active > 0 ? `Tag filter, ${active} active` : "Filter by tag"}
+        className={[
+          "flex items-center gap-1 rounded px-1.5 py-1 text-[11px] font-medium transition-colors",
+          active > 0
+            ? "bg-sky-500/20 text-sky-200 ring-1 ring-sky-400/40"
+            : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100",
+        ].join(" ")}
+      >
+        <Tag aria-hidden="true" className="size-3.5" />
+        {active > 0 ? <span data-tag-filter-count>{active}</span> : null}
+      </button>
+
+      {open ? (
+        <div
+          role="menu"
+          data-tag-filter-menu
+          className="absolute top-full right-0 z-50 mt-1 flex max-h-72 w-56 flex-col gap-0.5 overflow-y-auto rounded-md bg-zinc-900 p-1 shadow-lg ring-1 ring-white/15"
+        >
+          {counts.map(({ tag, count }) => {
+            const on = activeTags.has(tag.toLowerCase());
+            return (
+              <button
+                key={tag}
+                type="button"
+                role="menuitemcheckbox"
+                aria-checked={on}
+                data-tag-filter-option={tag}
+                onClick={() => toggleTag(tag)}
+                className={[
+                  "flex items-center justify-between gap-2 rounded px-2 py-1 text-left text-[11px]",
+                  on ? "bg-sky-500/20 text-sky-100" : "text-zinc-300 hover:bg-zinc-800",
+                ].join(" ")}
+              >
+                <span className="truncate">{tag}</span>
+                <span className="shrink-0 font-mono text-[10px] text-zinc-500 tabular-nums">
+                  {count}
+                </span>
+              </button>
+            );
+          })}
+          {active > 0 ? (
+            <button
+              type="button"
+              data-tag-filter-clear
+              onClick={clear}
+              className="mt-0.5 rounded border-t border-white/10 px-2 py-1 text-left text-[11px] text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
+            >
+              Clear filter
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-tag-filter.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-tag-filter.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { createContext, useContext, useMemo, useState, type ReactNode } from "react";
+
+import { isTagFilterMiss, toggleTagKey } from "@/lib/tag-facets";
+
+import { useClipDetail } from "./graph-details-context";
+
+// Filtering the board by tag, WITHOUT changing what the board renders.
+//
+// This dims non-matching cards. It deliberately does not hide them, and that is
+// the whole design decision — hiding is where this feature would have broken
+// things that have nothing to do with tags:
+//
+//   * `VirtualStrip.resolveBoundary` returns an index into the list it
+//     rendered, and `resolveCommandFromIntent` clamps that index against the
+//     graph's FULL child list. Render a shorter list and every drop lands
+//     somewhere else, with no type error and no throw. The drop INDICATOR is
+//     pure geometry, so it keeps pointing at the correct gap while the
+//     committed index is wrong — exactly how the flat-mode drop bug survived
+//     its first fix.
+//   * `VirtualGrid` renders straight from `getChildren` and has no override
+//     prop at all, so the grid would need the same seam invented for it.
+//   * Ctrl/Cmd+A selects `getChildren(...)` regardless of view state, and the
+//     header's Delete acts on that selection — so a hiding filter would let
+//     someone delete cards they cannot see.
+//   * Alt+arrow moves index into `getChildren` too, so a move under a hiding
+//     filter would swap a card past a hidden neighbour: a reorder nobody saw.
+//   * `childSpans` zips `getChildren` against `graphChildrenToClips` BY INDEX,
+//     which is what keeps the ruler, playhead and seek rail aligned.
+//
+// Every one of those stays correct here by construction, because the rendered
+// list is still `getChildren`. If a genuinely hidden view is ever wanted it
+// should be a separate filtered VIEW that declares its index space is not the
+// graph's — the shape flat mode already uses — not a filter over the live
+// editing board.
+
+type TagFilterValue = Readonly<{
+  activeTags: ReadonlySet<string>;
+  toggleTag: (tag: string) => void;
+  clear: () => void;
+}>;
+
+const EMPTY: ReadonlySet<string> = new Set();
+
+const TagFilterContext = createContext<TagFilterValue>({
+  activeTags: EMPTY,
+  toggleTag: () => {},
+  clear: () => {},
+});
+
+export function TagFilterProvider({ children }: Readonly<{ children: ReactNode }>) {
+  const [activeTags, setActiveTags] = useState<ReadonlySet<string>>(EMPTY);
+  const value = useMemo<TagFilterValue>(
+    () => ({
+      activeTags,
+      toggleTag: (tag) => setActiveTags((current) => toggleTagKey(current, tag)),
+      clear: () => setActiveTags(EMPTY),
+    }),
+    [activeTags],
+  );
+  return <TagFilterContext.Provider value={value}>{children}</TagFilterContext.Provider>;
+}
+
+export function useTagFilter(): TagFilterValue {
+  return useContext(TagFilterContext);
+}
+
+/**
+ * True when a filter is on and THIS item does not carry any active tag.
+ *
+ * A miss, not a match: with no filter running every card must read normally, so
+ * the default has to be "not missed" rather than "not matched".
+ *
+ * OR across the active set, not AND. The question being asked is "show me the
+ * SCAIL-2 takes and the keepers", and a card carrying either belongs in that
+ * answer; requiring every tag would make a second selection almost always empty
+ * and read as a bug.
+ */
+export function useTagFilterMiss(nodeId: string): boolean {
+  const { activeTags } = useTagFilter();
+  const detail = useClipDetail(nodeId);
+  return isTagFilterMiss(activeTags, detail?.tags);
+}

--- a/apps/timeline-gstudio001/lib/tag-facets.test.ts
+++ b/apps/timeline-gstudio001/lib/tag-facets.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { isTagFilterMiss, tagCounts, tagKey, toggleTagKey } from "./tag-facets";
+
+const active = (...tags: string[]) => new Set(tags.map(tagKey));
+
+describe("isTagFilterMiss", () => {
+  it("misses nothing when no filter is running", () => {
+    // The default has to be "not missed": with the filter off, every card must
+    // read normally, including untagged ones.
+    expect(isTagFilterMiss(new Set(), undefined)).toBe(false);
+    expect(isTagFilterMiss(new Set(), [])).toBe(false);
+    expect(isTagFilterMiss(new Set(), ["keeper"])).toBe(false);
+  });
+
+  it("misses an untagged item once a filter is on", () => {
+    expect(isTagFilterMiss(active("keeper"), undefined)).toBe(true);
+    expect(isTagFilterMiss(active("keeper"), [])).toBe(true);
+  });
+
+  it("matches case-insensitively", () => {
+    expect(isTagFilterMiss(active("scail-2"), ["SCAIL-2"])).toBe(false);
+    expect(isTagFilterMiss(active("SCAIL-2"), ["scail-2"])).toBe(false);
+  });
+
+  it("ORs the active set rather than ANDing it", () => {
+    // "Show me the SCAIL-2 takes AND the keepers" means either qualifies.
+    // Requiring both would make a second selection almost always empty, which
+    // reads as a bug rather than as a narrower filter.
+    expect(isTagFilterMiss(active("scail-2", "keeper"), ["keeper"])).toBe(false);
+    expect(isTagFilterMiss(active("scail-2", "keeper"), ["scail-2"])).toBe(false);
+    expect(isTagFilterMiss(active("scail-2", "keeper"), ["h3"])).toBe(true);
+  });
+});
+
+describe("tagCounts", () => {
+  const details = {
+    a: { tags: ["SCAIL-2", "S02"] },
+    b: { tags: ["scail-2", "keeper"] },
+    c: { tags: ["Scail-2"] },
+    d: undefined,
+    e: {},
+  };
+
+  it("counts case-insensitively but keeps the first spelling for display", () => {
+    const counts = tagCounts(details);
+    expect(counts[0]).toEqual({ tag: "SCAIL-2", count: 3 });
+  });
+
+  it("sorts by use, then alphabetically ignoring case", () => {
+    // `localeCompare`, so "keeper" precedes "S02" among the ties — a menu is
+    // scanned by eye, and ASCII order (every capital before every lowercase)
+    // is not how anyone reads an alphabetical list.
+    expect(tagCounts(details).map((c) => c.tag)).toEqual(["SCAIL-2", "keeper", "S02"]);
+  });
+
+  it("tolerates missing and empty entries", () => {
+    expect(tagCounts({ a: undefined, b: {}, c: { tags: [] } })).toEqual([]);
+  });
+});
+
+describe("toggleTagKey", () => {
+  it("adds, removes, and never mutates the input", () => {
+    const first = toggleTagKey(new Set(), "SCAIL-2");
+    expect([...first]).toEqual(["scail-2"]);
+    const empty = toggleTagKey(first, "scail-2");
+    expect(empty.size).toBe(0);
+    // The original set is untouched — the context stores it in state.
+    expect([...first]).toEqual(["scail-2"]);
+  });
+
+  it("ignores a blank tag", () => {
+    const active = new Set(["keeper"]);
+    expect(toggleTagKey(active, "   ")).toBe(active);
+  });
+});

--- a/apps/timeline-gstudio001/lib/tag-facets.ts
+++ b/apps/timeline-gstudio001/lib/tag-facets.ts
@@ -1,0 +1,66 @@
+// The pure half of filtering the board by tag. Split from the React context so
+// it can be tested directly — app vitest cannot parse .tsx, and these are the
+// rules worth pinning: what counts as a miss, and how the filter menu is built.
+
+/** The form tags are COMPARED in. Display keeps its own spelling. */
+export function tagKey(tag: string): string {
+  return tag.trim().toLowerCase();
+}
+
+/**
+ * True when a filter is running and these tags do not satisfy it.
+ *
+ * A MISS rather than a match, because with no filter on every card must read
+ * normally — the default has to be "not missed".
+ *
+ * OR across the active set, not AND. The question is "show me the SCAIL-2 takes
+ * and the keepers", and a card carrying either belongs in that answer. Requiring
+ * all of them would make a second selection almost always empty, which reads as
+ * a bug rather than as a narrower filter.
+ */
+export function isTagFilterMiss(
+  activeTags: ReadonlySet<string>,
+  tags: readonly string[] | undefined,
+): boolean {
+  if (activeTags.size === 0) return false;
+  if (!tags || tags.length === 0) return true;
+  return !tags.some((tag) => activeTags.has(tagKey(tag)));
+}
+
+export type TagCount = Readonly<{ tag: string; count: number }>;
+
+/**
+ * Every tag in use with how many items carry it, most used first.
+ *
+ * Counting is case-insensitive but the FIRST spelling seen is kept for display
+ * — the same split between matching and display that storage uses, so the menu
+ * shows "SCAIL-2" rather than flattening it to lowercase.
+ */
+export function tagCounts(
+  details: Readonly<Record<string, { tags?: readonly string[] } | undefined>>,
+): TagCount[] {
+  const counts = new Map<string, { tag: string; count: number }>();
+  for (const detail of Object.values(details)) {
+    for (const raw of detail?.tags ?? []) {
+      const key = tagKey(raw);
+      if (key.length === 0) continue;
+      const seen = counts.get(key);
+      if (seen) seen.count += 1;
+      else counts.set(key, { tag: raw.trim(), count: 1 });
+    }
+  }
+  return [...counts.values()].sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
+}
+
+/** Toggle one tag in the active set, returning a new set. */
+export function toggleTagKey(
+  active: ReadonlySet<string>,
+  tag: string,
+): ReadonlySet<string> {
+  const key = tagKey(tag);
+  if (key.length === 0) return active;
+  const next = new Set(active);
+  if (next.has(key)) next.delete(key);
+  else next.add(key);
+  return next;
+}


### PR DESCRIPTION
Stage 4, the last of the tags vertical (#315). Builds on #317, #318, #319.

A tag control in the header's VIEW group beside the ruler and waveform toggles — it qualifies what the board *shows* rather than changing the document, which is what that cluster is for. Picking tags dims every card carrying none of them.

## Dimming, not hiding — this is the whole design

Rendering a filtered child list would have broken five things that have nothing to do with tags:

| | What breaks |
|---|---|
| **Drops** | `VirtualStrip.resolveBoundary` returns an index into the list it rendered, and `resolveCommandFromIntent` clamps that against the graph's **full** child list. Every drop lands somewhere else — no type error, no throw. The indicator is pure geometry, so it keeps pointing at the right gap while the committed index is wrong. That is exactly how the flat-mode drop bug survived its first fix. |
| **Grid** | `VirtualGrid` renders straight from `getChildren` with no override prop at all. |
| **Ctrl/Cmd+A** | Selects `getChildren(...)` regardless of view state, and the header's Delete acts on that selection — so a hiding filter lets someone **delete cards they cannot see**. |
| **Alt+arrow** | Indexes into `getChildren`, so a move swaps a card past a hidden neighbour: a reorder nobody saw. |
| **Time overlays** | `childSpans` zips `getChildren` against `graphChildrenToClips` **by index** — the only reason ruler, playhead and seek rail stay aligned. |

All five stay correct **by construction**: the rendered list is still `getChildren`. If a genuinely hidden view is ever wanted it should be a separate filtered *view* that declares its index space is not the graph's — the shape flat mode already uses.

## Behaviour

A miss is a **separate state from disabled**, with its own `data-filter-miss` and an opacity-only treatment. `opacity-45 grayscale` is already disabled's language, and a card that is both must stay readable as both.

The active set **ORs**, not ANDs. "Show me the SCAIL-2 takes and the keepers" means either qualifies; requiring all would make a second selection almost always empty — reads as a bug, not a narrower filter.

Matching ignores case, display does not — the same split storage uses, so the menu shows `SCAIL-2` rather than flattening it.

The menu is built from tags **actually in use**. Vocabulary here is emergent (a new checkpoint is a new tag), so a curated list would be stale in a week; with nothing tagged, the control does not render.

## Verification

- 686 app tests (9 new on `lib/tag-facets.ts`), 530 unit, 17 story tests
- `tsc --noEmit` clean; lint 0 errors

Pure rules live in `lib/tag-facets.ts` so they are testable — app vitest cannot parse `.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)