### PR TITLE
Give the board a select mode, and the grid card a caption

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -13,6 +13,7 @@ import { createPortal } from "react-dom";
 import { useSearchParams } from "next/navigation";
 import {
   AudioLines,
+  CircleCheck,
   ClipboardPaste,
   Command,
   EllipsisVertical,
@@ -98,7 +99,7 @@ import {
 import { AddCollectionSlot } from "./graph-add-collection-slot";
 import { CollectionHoverProvider } from "./graph-collection-hover";
 import { TagFilterProvider } from "./graph-tag-filter";
-import { TagFilterControl } from "./graph-tag-filter-control";
+import { ActiveTagFilters, TagFilterControl } from "./graph-tag-filter-control";
 import { ItemDetailsProvider } from "./graph-item-details-context";
 import { GraphSaveStatus } from "./graph-save-status";
 import { GraphShortcuts, requestGraphShortcuts } from "./graph-shortcuts";
@@ -740,6 +741,125 @@ function HeaderPasteButton({
 }
 
 /**
+ * Enter select mode — the pointer route to picking things deliberately.
+ *
+ * It earns its place because a plain click DRILLS IN now. Before that, clicking
+ * a collection selected it and this control would have been a convenience; now
+ * it is the only pointer gesture that picks a collection at all. Touch has the
+ * same problem for every kind of card, having no Ctrl to hold.
+ *
+ * The SAME store flag the anchor menu's "Add to selection by tapping" row
+ * toggles — one piece of state behind two controls, so arming it from either
+ * place behaves identically and neither can disagree about whether it is on.
+ * The menu row keeps its bare `Check`, which is a checkmark doing tick-box duty
+ * beside a label; this is the design's `CircleCheck`, which reads as a control
+ * rather than a state. The word beside it is what makes it a mode and not a verb.
+ *
+ * Rendered only while the mode is DISARMED or nothing is picked yet — once
+ * there is a selection the whole row becomes `SelectModeHeader`, which carries
+ * its own way out. So this shows its armed state (a pressed toggle you can
+ * press again) for exactly the window in which it is still on screen.
+ */
+function SelectModeButton() {
+  const store = useCollectionsStore();
+  const armed = useCollectionsSelector((s) => s.interaction.multiSelectMode);
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      data-select-mode-toggle={armed ? "on" : "off"}
+      aria-pressed={armed}
+      title={
+        armed
+          ? "Stop selecting — clicks go back to opening and trimming"
+          : "Select several items to act on them at once"
+      }
+      onClick={() => store.setMultiSelectMode(!armed)}
+      className={cn(
+        "h-8 shrink-0 gap-1.5 px-2 text-[11px] font-medium",
+        "[@media(pointer:coarse)]:h-11",
+        armed ? HEADER_TOGGLE_ACTIVE : HEADER_TOGGLE_IDLE,
+      )}
+    >
+      <CircleCheck aria-hidden className="h-4 w-4" strokeWidth={1.7} />
+      Select
+    </Button>
+  );
+}
+
+/**
+ * The header row while a selection is being assembled — the breadcrumb's place,
+ * taken over by the thing the user is actually doing.
+ *
+ * It replaces rather than joins, because the two say different things about
+ * where you are: the trail answers "which collection am I in", and in this mode
+ * the answer that matters is "what have I got". The trail comes back the moment
+ * the selection empties, which is also the moment it becomes useful again.
+ *
+ * NOT shown merely because the mode is armed. With nothing picked this would be
+ * a row of dimmed verbs and a count of zero — it says nothing, and it would
+ * take the trail away at the exact moment the user is still navigating to find
+ * what they want. The mode's armed state lives on `SelectModeButton` until
+ * there is something to show.
+ *
+ * The verbs are `SelectionCentreControls` unchanged, not a second set: the
+ * promoted actions, paste, the `⋮` fallback menu and the `✕` all behave here
+ * exactly as they do in the centre slot, and they are driven by the same action
+ * specs, so this row cannot come to disagree with the anchor card's menu about
+ * what applies. What is added is only what this mode needs — a count to say
+ * what is held, and a way out.
+ */
+function SelectModeHeader({ anchorName }: Readonly<{ anchorName: string | null }>) {
+  const store = useCollectionsStore();
+  const { selectionCount } = useSelectionActionState();
+
+  return (
+    <div
+      data-select-mode-header=""
+      className="flex min-w-0 flex-1 flex-wrap items-center gap-x-1 gap-y-2"
+    >
+      <span
+        data-select-mode-count={selectionCount}
+        // Mono and tabular so the row does not twitch sideways as the count
+        // crosses 9 — this number changes on every tap, which is precisely the
+        // moment a reflowing toolbar is most annoying.
+        className="shrink-0 px-1 font-mono text-xs tabular-nums text-sky-200"
+      >
+        {selectionCount} selected
+      </span>
+      <SelectionCentreControls anchorName={anchorName} />
+      {/* `ml-auto`: Done sits at the far end, away from Delete. Both end the
+          gesture, only one of them destroys anything, and putting them
+          shoulder to shoulder is how a mis-click becomes a deletion. */}
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        data-select-mode-done
+        title="Finish selecting"
+        // Clear THEN disarm. The store keeps the mode armed through an empty
+        // selection for this view (keepMultiSelectModeWhenEmpty), so the clear
+        // cannot disarm it out from under this and the order is only about
+        // ending in one notify rather than leaving the row briefly showing "0
+        // selected" on its way out.
+        onClick={() => {
+          store.clearSelection();
+          store.setMultiSelectMode(false);
+        }}
+        className={cn(
+          "ml-auto h-8 shrink-0 px-3 text-[11px] font-medium",
+          "[@media(pointer:coarse)]:h-11",
+          HEADER_TOGGLE_IDLE,
+        )}
+      >
+        Done
+      </Button>
+    </div>
+  );
+}
+
+/**
  * Undo/redo as ICON buttons, matching the toolbar's other ghost icon controls
  * rather than the package's generic text-label `UndoRedoControls`. App-local
  * on purpose: the icon styling is this toolbar's design, so it stays out of
@@ -947,6 +1067,26 @@ export function GraphBoard({
     anchorId === null ? null : (s.graph.nodesById.get(anchorId)?.name ?? null),
   );
 
+  // Which face the header row wears. Three conditions, and each is load-bearing:
+  //
+  //   the mode is armed  — this row belongs to select mode, nothing else.
+  //   something is held  — see SelectModeHeader: an empty selection has nothing
+  //                        to report, and taking the trail away while the user
+  //                        is still navigating to find their items is exactly
+  //                        backwards.
+  //   nothing is dragging — the ancestor crumbs ARE the "move up a level" drop
+  //                        targets (see GraphBreadcrumb), and a multi-drag out
+  //                        of a selection is precisely when someone reaches for
+  //                        them. Hiding the trail mid-drag would delete the
+  //                        drop target the user is already aiming at. The
+  //                        selection bar has nothing to offer during a drag
+  //                        anyway — DragChromeFade fades the rest of the chrome
+  //                        for the same reason.
+  const multiSelectMode = useCollectionsSelector((s) => s.interaction.multiSelectMode);
+  const selectionSize = useCollectionsSelector((s) => s.interaction.selectedIds.size);
+  const isDragging = useCollectionsSelector((s) => s.interaction.isDragging);
+  const selectModeRow = multiSelectMode && selectionSize > 0 && !isDragging;
+
   return (
     <OpenKeyBoundary trashId={trashRootId}>
       {/* Spans the header AND the surfaces: the toolbar toggle sets the mode,
@@ -988,7 +1128,18 @@ export function GraphBoard({
               p-4 padding. */}
           <div
             data-graph-board-header=""
-            className="sticky z-40 grid min-w-0 grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-x-3 border-b border-zinc-800/70 bg-zinc-950/95 py-3 backdrop-blur-sm"
+            data-header-mode={selectModeRow ? "select" : "browse"}
+            className={cn(
+              "sticky z-40 min-w-0 items-center gap-x-3 border-b border-zinc-800/70 bg-zinc-950/95 py-3 backdrop-blur-sm",
+              // The browse row is a three-column grid so the aggregate sits at
+              // the row's TRUE centre whatever the wings contain. The select row
+              // has no centre to hold — it is one group that reads left to right
+              // and ends with Done — so it is a plain flex row rather than a
+              // grid with two empty tracks.
+              selectModeRow
+                ? "flex"
+                : "grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)]",
+            )}
             style={{ top: "var(--workbench-preview-offset, 0px)" }}
           >
             {/* Seek thumbs are centered on the timeline edge and intentionally
@@ -1015,6 +1166,10 @@ export function GraphBoard({
                 beside it — a status that hides live controls is the wrong
                 shape. It stays outside DragChromeFade with the breadcrumb,
                 because a save landing mid-drag is still worth seeing. */}
+            {selectModeRow ? (
+              <SelectModeHeader anchorName={anchorName} />
+            ) : (
+              <>
             <div className="flex min-w-0 flex-1 items-center gap-3">
               {breadcrumb}
               <GraphSaveStatus />
@@ -1033,21 +1188,35 @@ export function GraphBoard({
                 toolbar onto a second line instead of pushing controls
                 off-screen. No effect when it fits. */}
             <DragChromeFade className="flex min-w-0 items-center justify-end gap-2">
+              {/* FILTER and SELECT lead the cluster, together, as the design
+                  has them. They are the two controls that change how you WORK
+                  with the board rather than what it contains or how it is
+                  drawn: one narrows the field to what you are hunting for, the
+                  other is how you then pick out of it. Reaching for them in
+                  sequence is the common path, so they sit as one pair.
+
+                  The filter used to live in the view group below, on the
+                  reasoning that it qualifies what the board shows — true, but
+                  it is also the control this row most needed to make findable,
+                  and buried among the ruler and waveform toggles it read as one
+                  more display switch. */}
+              <TagFilterControl />
+              <SelectModeButton />
+              <div aria-hidden="true" className="h-5 w-px shrink-0 bg-zinc-700" />
               {/* The Collection tool (moved here from the icon sidebar): the
-                  view's one "add structure" action leads the cluster, fenced
-                  off from the surface/history controls to its right. */}
+                  view's one "add structure" action, fenced off from the
+                  surface/history controls to its right. */}
               <GraphAddCollectionButton />
               <div aria-hidden="true" className="h-5 w-px shrink-0 bg-zinc-700" />
               {/* The VIEW group: what the board shows. Fenced on both sides so
-                  the cluster reads as create | view | history | settings, and
-                  the fences stay put as its contents come and go — the ruler
+                  the cluster reads as work | create | view | history | settings,
+                  and the fences stay put as its contents come and go — the ruler
                   exists only in flat mode.
 
                   PREVIEW is deliberately not here. It lives in the icon rail
                   (see timeline-sidebar) because it is one of the two controls
                   worth promoting to rail scale; this row keeps the ones that
                   only qualify the board in front of you. */}
-              <TagFilterControl />
               {flatOn ? (
                 <HeaderToggle
                   active={rulerOn}
@@ -1095,6 +1264,8 @@ export function GraphBoard({
                   changed. */}
               <BoardMenuSlot itemSize={itemSize} onItemSizeChange={onItemSizeChange} />
             </DragChromeFade>
+              </>
+            )}
 
             {/* The trash drop target (right side), shown only while a card is
                 being dragged. The "move up a level" targets are the ancestor
@@ -1103,6 +1274,14 @@ export function GraphBoard({
                 provider so its droppable joins the DndContext. */}
             <BreadcrumbDropZones trashId={trashRootId} />
           </div>
+
+          {/* OUTSIDE the sticky header, deliberately. It belongs to the board
+              rather than the toolbar — it describes what you are looking at,
+              and it is the one piece of chrome whose height varies (chips wrap
+              on a narrow viewport). Inside the sticky row that variation would
+              move the surfaces underneath it every time a tag was added, and
+              the header's `top` offset is shared with the preview shell. */}
+          <ActiveTagFilters />
 
           {surface === "strip" ? (
             // The focused surface spans the card's FULL width (-mx-4 cancels

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -12,7 +12,14 @@ import {
   useSyncExternalStore,
   type ReactNode,
 } from "react";
-import { Check, CornerRightDown, Layers } from "lucide-react";
+import {
+  AudioWaveform,
+  Check,
+  CornerRightDown,
+  Image as ImageIcon,
+  Layers,
+  Video,
+} from "lucide-react";
 
 import {
   CollectionItem,
@@ -56,6 +63,8 @@ import { createDerivedCache } from "@/lib/derived-cache";
 import { graphClipboard } from "@/lib/graph-clipboard";
 import { graphPasteFlash } from "@/lib/graph-paste-flash";
 import { formatDuration, formatSeconds } from "@/lib/format-duration";
+import { sortTagsStatusFirst } from "@/lib/tag-facets";
+import { TagAccentDot } from "./tag-accent-dot";
 import {
   collectionPreviewFrameUrl,
   videoFrameUrls,
@@ -766,14 +775,20 @@ const TAG_ROW_WIDE_WIDTH = 220;
 function TagRow({
   tags,
   showAtMost,
-}: Readonly<{ tags: readonly string[]; showAtMost: number }>) {
-  const shown = tags.slice(0, showAtMost);
+  className = "",
+}: Readonly<{ tags: readonly string[]; showAtMost: number; className?: string }>) {
+  const shown = sortTagsStatusFirst(tags).slice(0, showAtMost);
   const extra = tags.length - shown.length;
   return (
     <span
       aria-hidden="true"
       data-clip-tags={tags.length}
-      className="pointer-events-none absolute bottom-8 left-2 z-10 flex max-w-[calc(100%-1rem)] items-center gap-1"
+      className={[
+        "pointer-events-none absolute bottom-8 left-2 z-10 flex max-w-[calc(100%-1rem)] items-center gap-1",
+        // Callers add surface-scoped variants — the media card hides this in
+        // the grid, where its tags live in the caption instead.
+        className,
+      ].join(" ")}
     >
       {shown.map((tag) => (
         <span
@@ -793,6 +808,101 @@ function TagRow({
           +{extra}
         </span>
       )}
+    </span>
+  );
+}
+
+/**
+ * The caption's tag chips — in flow, under the artwork, grid only.
+ *
+ * A separate component from the overlay `TagRow` above rather than a mode on
+ * it: that one is an absolutely-positioned stack pinned over a picture and
+ * legible against arbitrary artwork; this one sits on the card's own
+ * background in a row that has to share width with the meta line. They have
+ * different jobs and almost no shared pixels.
+ *
+ * COUNTED, not measured. The design measures every chip against the real row
+ * width so whole chips drop before any label clips — worth it there, because
+ * its cards are one size and its tags are long English phrases. Here the grid
+ * cell is a known width per item size and the row is already the widest place
+ * a tag appears, so a count gets the same answer without an off-screen mirror
+ * and a ResizeObserver on every card. The strip is where width genuinely varies
+ * with content, and the strip does not use this row at all.
+ */
+function CaptionTagRow({
+  tags,
+  showAtMost,
+}: Readonly<{ tags: readonly string[]; showAtMost: number }>) {
+  const ordered = sortTagsStatusFirst(tags);
+  const shown = ordered.slice(0, showAtMost);
+  const extra = ordered.length - shown.length;
+  return (
+    <span
+      data-clip-caption-tags={tags.length}
+      className="ml-auto flex min-w-0 shrink items-center gap-1 overflow-hidden"
+    >
+      {shown.map((tag) => (
+        <span
+          key={tag}
+          title={tag}
+          className="inline-flex max-w-[7rem] shrink-0 items-center gap-1 rounded-full bg-zinc-800 px-1.5 py-0.5 text-[10px] leading-none font-medium text-zinc-300 ring-1 ring-white/10"
+        >
+          <TagAccentDot tag={tag} />
+          <span className="min-w-0 truncate">{tag}</span>
+        </span>
+      ))}
+      {extra > 0 && (
+        <span
+          data-clip-caption-tags-overflow={extra}
+          className="shrink-0 font-mono text-[10px] leading-none text-zinc-500"
+        >
+          +{extra}
+        </span>
+      )}
+    </span>
+  );
+}
+
+/**
+ * The selection checkbox, bottom-right, while select mode is armed.
+ *
+ * DECORATIVE, not a control — and that is forced, not a shortcut. This renders
+ * inside NodeCard's real `<button>`, and a button may not contain interactive
+ * content: browsers auto-close the outer one at the first nested button, which
+ * ejects the rest of the card out of its own box. (The design's own notes hit
+ * the same wall and answered it by making the card a `div role="button"`, which
+ * costs hand-wiring Enter/Space and the focus ring across every card in both
+ * surfaces. Worth doing one day; not smuggled in behind a checkbox.)
+ *
+ * Nothing is lost in select mode, because the whole card is already the toggle
+ * there — the design's card does the same thing (`if (selecting) toggleSelect`),
+ * so its checkbox is only ever a second way to hit the same target. What IS
+ * lost is the design's hover-to-select-without-opening outside the mode, which
+ * is exactly the gesture our shell cannot host. Hence: shown only while the
+ * mode is armed, where it is honest about being an indicator rather than
+ * offering a click that the card underneath would have handled anyway.
+ *
+ * Two details worth keeping if this is ever restyled. The check is ALWAYS
+ * rendered and only its opacity changes, so the circle never resizes as it
+ * fills. And the ring is `border-2` on a translucent, blurred fill rather than
+ * a flat chip, because it sits on arbitrary artwork — a light frame and a dark
+ * one both have to keep it legible.
+ */
+function SelectionIndicator({ selected }: Readonly<{ selected: boolean }>) {
+  return (
+    <span
+      aria-hidden="true"
+      data-selection-indicator={selected ? "on" : "off"}
+      className={[
+        "pointer-events-none absolute right-2 bottom-2 z-20 grid size-[26px] place-items-center",
+        "rounded-full border-2 backdrop-blur-sm motion-safe:transition-colors",
+        selected ? "border-sky-400 bg-sky-500" : "border-white/90 bg-black/35",
+      ].join(" ")}
+    >
+      <Check
+        className={["size-4 text-white", selected ? "opacity-100" : "opacity-0"].join(" ")}
+        strokeWidth={3}
+      />
     </span>
   );
 }
@@ -822,6 +932,9 @@ const GraphClipContent = memo(function GraphClipContent({
   // grayscale` is already disabled's language, and a card that is both must
   // still read as both.
   const filterMiss = useTagFilterMiss(id as string);
+  // Select mode, for the checkbox below. Above the collection early-return with
+  // the other hooks — hooks may not be conditional.
+  const selectMode = useCollectionsSelector((s) => s.interaction.multiSelectMode);
   const provenance = useCardProvenance(id);
   const frameLoading = useContext(VideoFrameLoadingContext);
   // The AUTHORED name, read straight from the side table rather than from
@@ -862,6 +975,16 @@ const GraphClipContent = memo(function GraphClipContent({
         isAudio || !node.src
         ? []
         : [node.src];
+  // CAPTION values (grid only — see the caption span at the end of the card).
+  const KindIcon = isVideo ? Video : isAudio ? AudioWaveform : ImageIcon;
+  // Falls back to the KIND, never to the machine name. PL11-004 keeps
+  // `detail.title` absent until someone actually names a clip, exactly so a
+  // library of filenames does not read as a rename backlog — and inventing one
+  // here would undo that. But a caption whose first line can be empty reads as
+  // broken, so the kind fills it, which is also what the artwork's chip said in
+  // the strip. "Video" rather than "VIDEO": this is a caption, not a stamp.
+  const captionName = detail?.title ?? (isVideo ? "Video" : isAudio ? "Audio" : "Image");
+  const captionSeconds = Number(mediaDurationSeconds(node)) || 0;
   return (
     <span
       ref={cardSizeRef}
@@ -873,6 +996,13 @@ const GraphClipContent = memo(function GraphClipContent({
         // the identical adjacency, so full-bleed pressed into it there too.
         // The card's outer box (and so width = duration) is unchanged.
         "relative flex h-full w-full overflow-hidden rounded-md bg-zinc-900 p-1.5",
+        // GRID STACKS: artwork on top, a real caption underneath — the shape
+        // the grid cell was already sized for (see ITEM_SIZE_DIMENSIONS, which
+        // made grid cells tall and boxy for exactly this) and the shape the
+        // collection card has always had. The strip stays one artwork box: a
+        // caption row there is fixed overhead on every clip, and clip width is
+        // duration, so a narrow clip has no room for one anyway.
+        "[[data-virtual-grid]_&]:flex-col",
         selected ? "ring-1 ring-inset ring-amber-300/65" : "ring-1 ring-white/15",
         rejected ? "ring-2 ring-red-500 motion-safe:animate-pulse" : "",
         // Disabled reads as MUTED, never as missing: the card keeps its slot
@@ -887,11 +1017,24 @@ const GraphClipContent = memo(function GraphClipContent({
       // truthy for "this card is muted".
       data-disabled={node.disabled ? "true" : inheritedDisabled ? "inherited" : undefined}
     >
+      {/* THE ARTWORK BOX — the frame, plus anything that belongs ON the frame
+          rather than on the card.
+
+          It exists to be a positioning context that is not also the dimmed one.
+          In the grid this box stops filling the card (the caption below takes
+          the rest), so anything anchored to the CARD's bottom would sit over
+          the caption; anchored here it stays on the picture, which is what it
+          means. And keeping the dimming on the inner span means the selection
+          checkbox does not fade with the artwork — a filter miss drops the
+          frame to opacity-30, and a checkbox that went with it would make the
+          selection unreadable exactly while someone is picking through a
+          filtered board. */}
+      <span className="relative flex h-full min-h-0 w-full overflow-hidden rounded-sm [[data-virtual-grid]_&]:flex-1">
       <span
         data-disabled-visuals={muted ? "true" : undefined}
         data-filter-miss={filterMiss ? "true" : undefined}
         className={[
-          "relative flex h-full w-full overflow-hidden rounded-sm",
+          "flex h-full w-full overflow-hidden rounded-sm",
           isDragSource ? "opacity-40" : muted ? "opacity-45" : filterMiss ? "opacity-30" : "",
           muted ? "grayscale" : "",
           "motion-safe:transition-opacity motion-safe:duration-150",
@@ -926,6 +1069,12 @@ const GraphClipContent = memo(function GraphClipContent({
         </span>
       )}
       </span>
+      {/* Bottom-RIGHT of the ARTWORK, opposite the duration, so the two never
+          contend for a corner — the design makes the same split. Shown on muted
+          cards too: a disabled clip is still something you might be gathering
+          up to delete. */}
+      {selectMode && <SelectionIndicator selected={selected} />}
+      </span>
       {/* Kind tag (R6 #7): a WORD, bottom-left. The glyph version (a 4px film
           or picture icon in the top corner) was ambiguous at small item sizes
           — the two lucide marks read as the same smudge — so it says which it
@@ -935,7 +1084,10 @@ const GraphClipContent = memo(function GraphClipContent({
       <span
         aria-hidden="true"
         data-media-kind={isVideo ? "video" : isAudio ? "audio" : "image"}
-        className="pointer-events-none absolute bottom-2 left-2 z-10 rounded bg-black/75 px-1.5 py-0.5 font-mono text-[11px] leading-none font-semibold tracking-[0.08em] text-zinc-100"
+        // Hidden in the GRID, where the kind is the caption's leading icon
+        // instead. A word stamped on the artwork and an icon under it would say
+        // the same thing twice, and the word is the one that costs picture.
+        className="pointer-events-none absolute bottom-2 left-2 z-10 rounded bg-black/75 px-1.5 py-0.5 font-mono text-[11px] leading-none font-semibold tracking-[0.08em] text-zinc-100 [[data-virtual-grid]_&]:hidden"
       >
         {isVideo ? "VIDEO" : isAudio ? "AUDIO" : "IMAGE"}
       </span>
@@ -953,6 +1105,9 @@ const GraphClipContent = memo(function GraphClipContent({
                 ? TAGS_SHOWN_WIDE
                 : TAGS_SHOWN_NARROW
             }
+            // GRID puts these in the caption instead (see below), where they
+            // sit beside the meta line rather than over the picture.
+            className="[[data-virtual-grid]_&]:hidden"
           />
         ) : null
       ) : null}
@@ -967,7 +1122,11 @@ const GraphClipContent = memo(function GraphClipContent({
         <span
           aria-hidden="true"
           data-clip-title
-          className="pointer-events-none absolute inset-x-2 top-2 z-10 truncate rounded bg-black/75 px-1.5 py-0.5 text-[11px] leading-tight font-semibold text-zinc-100"
+          // Hidden in the GRID: the caption below carries the name there, which
+          // is the whole point of giving the cell room for one. Stamping it on
+          // the artwork as well would cover the picture to repeat the line
+          // directly beneath it.
+          className="pointer-events-none absolute inset-x-2 top-2 z-10 truncate rounded bg-black/75 px-1.5 py-0.5 text-[11px] leading-tight font-semibold text-zinc-100 [[data-virtual-grid]_&]:hidden"
         >
           {detail.title}
         </span>
@@ -982,6 +1141,50 @@ const GraphClipContent = memo(function GraphClipContent({
           Rides the same per-node live-trim channel as the pill. Its other
           half, the source map, is docked under the strip by the board. */}
       {trimEnabled && <TrimPanel id={id} node={node} />}
+      {/* THE CAPTION — grid only, and the point of the whole restructure.
+          Everything here used to be stamped ON the artwork: the name across the
+          top, the kind bottom-left, the tags stacked above it. That is right in
+          the strip, where a card is as wide as its clip is long and every pixel
+          of height is charged to every row. In the grid the cell is already
+          tall and boxy for this, so the picture gets to be a picture and the
+          words get a line of their own.
+
+          Two rows, following the design: identity first (what is this), then
+          data (how long, how filed). Decorative for AT — NodeCard's button
+          already names the card, which is why the overlay title it replaces was
+          aria-hidden too. */}
+      <span
+        aria-hidden="true"
+        data-clip-caption
+        className="hidden min-w-0 flex-col gap-1 pt-2 pr-0.5 pb-0.5 pl-1 [[data-virtual-grid]_&]:flex"
+      >
+        <span className="flex min-w-0 items-center gap-1.5">
+          <KindIcon
+            aria-hidden="true"
+            strokeWidth={1.7}
+            className="size-3.5 shrink-0 text-zinc-400"
+          />
+          <span className="min-w-0 flex-1 truncate text-sm font-semibold text-zinc-100">
+            {captionName}
+          </span>
+        </span>
+        {/* Row two is omitted ENTIRELY when it would be empty, rather than
+            rendered blank: an untagged image has neither duration nor chips,
+            and an empty row would still claim its gap and leave the caption
+            looking like it failed to load something. */}
+        {captionSeconds > 0 || detail?.tags?.length ? (
+          <span className="flex min-w-0 items-center gap-2">
+            {captionSeconds > 0 ? (
+              <span className="shrink-0 font-mono text-[11px] leading-none text-sky-300/90">
+                {formatDuration(captionSeconds)}
+              </span>
+            ) : null}
+            {detail?.tags?.length ? (
+              <CaptionTagRow tags={detail.tags} showAtMost={TAGS_SHOWN_NARROW} />
+            ) : null}
+          </span>
+        ) : null}
+      </span>
     </span>
   );
 });
@@ -1210,6 +1413,7 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
   const displayName = title ?? node.name;
   const inheritedDisabled = useDisabledByAncestor(id);
   const filterMiss = useTagFilterMiss(id as string);
+  const selectMode = useCollectionsSelector((s) => s.interaction.multiSelectMode);
   const muted = node.disabled === true || inheritedDisabled;
   // Anchor state is not read here any more: `CardCornerSlot` subscribes to it
   // itself, narrowed to this node, so an anchor moving between two OTHER cards
@@ -1256,6 +1460,10 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
         ].join(" ")}
       >
         {muted && <DisabledChip inherited={node.disabled !== true} />}
+        {/* Collections get the same checkbox as media. They are the cards that
+            need it most: a plain click drills INTO a collection now, so select
+            mode is the only pointer route to picking one at all. */}
+        {selectMode && <SelectionIndicator selected={selected} />}
         {/* Collections are taggable too — `tags` sits on TimelineItemBase, not
             on the media members — and they route through THIS component rather
             than GraphClipContent (which returns null for them at the guard

--- a/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-navigation.tsx
@@ -298,13 +298,27 @@ export function OpenKeyBoundary({
   };
 
   /**
-   * Escape clears the selection (R4.7).
+   * Escape backs out of selecting (R4.7).
    *
    * It lives here, with the board's other card keys, because nothing else owns
    * it. The v2 pill handled Escape itself — it rendered INSIDE the card, so a
    * focused card's Escape reached it by bubbling — and deleting the pill took
    * that with it. The package does not claim the key either: its keyboard
    * controller passes a bare Escape through deliberately.
+   *
+   * It backs out of ONE thing at a time, outermost first, which is what Escape
+   * means everywhere else:
+   *
+   *   in select MODE — leave the mode, dropping whatever it collected. The mode
+   *     is the outer state; clearing the selection but staying armed would look
+   *     like nothing happened, since the row it painted is still there.
+   *   otherwise      — clear the selection, as it always did.
+   *
+   * Note the mode branch has to run even with NOTHING selected. Arming select
+   * mode and picking nothing is an ordinary place to end up (it is the state
+   * you are in the instant you press Select), and the old guard returned early
+   * on an empty selection — which would have left Escape doing nothing at all
+   * in the one state a user is most likely to want out of.
    *
    * Two things it must not do. It must not fight dnd-kit, which uses Escape to
    * CANCEL a keyboard drag — hence the isDragging guard. And it must not fire
@@ -314,13 +328,15 @@ export function OpenKeyBoundary({
    */
   const clearFromKey = (event: React.KeyboardEvent<HTMLDivElement>) => {
     const { interaction } = store.getSnapshot();
-    if (interaction.isDragging || interaction.selectedIds.size === 0) return;
+    if (interaction.isDragging) return;
+    if (!interaction.multiSelectMode && interaction.selectedIds.size === 0) return;
     event.preventDefault();
     // Focus goes back to the card that was anchored, not to wherever the key
     // was pressed — the anchor is the card the user was working on, and the
     // control they may have been standing on is about to unmount.
     const anchorId = interaction.anchorId;
     store.clearSelection();
+    if (interaction.multiSelectMode) store.setMultiSelectMode(false);
     if (anchorId !== null) focusNodeWhenMounted(document.body, anchorId);
   };
 
@@ -336,58 +352,18 @@ export function OpenKeyBoundary({
     else if (event.key === "Escape") clearFromKey(event);
   };
 
-  /**
-   * Double-click opens (R10.5).
-   *
-   * Needed because the anchor card no longer has a chevron — it cross-fades
-   * into the `⋮` — so without this the one card the user is working on would be
-   * the one card with no pointer route in. The O key already covered the
-   * keyboard, and Enter could NOT be used here: the dnd-collections grammar
-   * binds it to picking a card up for a keyboard drag (Space selects, Enter
-   * grabs), and taking it would remove keyboard drag-and-drop to add a second
-   * way to do what O already does.
-   *
-   * BUBBLE phase, deliberately. The card's own label stops propagation on
-   * double-click to claim the gesture for inline rename, and that layering only
-   * works if this listener runs after the target's.
-   */
-  const openFromDoubleClick = (event: React.MouseEvent<HTMLDivElement>) => {
-    if (event.defaultPrevented || store.getSnapshot().interaction.isDragging) return;
-    const target = event.target as HTMLElement;
-    // Controls inside the card own their own gestures — a double-click that
-    // lands on the `⋮` or the chevron is two clicks on that control, not an
-    // instruction to drill in.
-    if (target.closest("[data-collections-keyboard-ignore]") !== null) return;
-    const id = target.closest<HTMLElement>("[data-node-id]")?.dataset.nodeId;
-    if (!id) return;
-    const graph = store.getSnapshot().graph;
-    const nodeId = parseNodeId(id);
-    const node = graph.nodesById.get(nodeId);
-    const opensTimeline =
-      node?.kind === "collection" || detailsStore.get(id)?.duplicateOfTimelineId !== undefined;
-    if (!opensTimeline) return;
-    event.preventDefault();
-    // BACKSTOP, not the mechanism.
-    //
-    // Click 1 on a collection no longer selects immediately — the provider's
-    // `deferSelection` holds it for the double-click window and the second
-    // click drops it, so an ordinary double-click never paints a selection at
-    // all. That is what makes the drill-in look clean; doing it here could
-    // only ever undo a selection the user had already seen.
-    //
-    // This still runs because the hold has a deadline (`SELECTION_DEFER_MS`).
-    // A deliberately slow double-click outlasts it, the selection lands, and
-    // without this the user would end up INSIDE the collection with that
-    // collection still selected: header reading "1 selected", no selected card
-    // on screen, and the header's promoted Delete armed against the container
-    // they are looking at.
-    //
-    // Clearing outright rather than restoring the prior selection is correct:
-    // an unmodified click 1 has ALREADY collapsed any multi-selection to this
-    // one card by the time dblclick runs, so there is nothing left to restore.
-    store.clearSelection();
-    nav?.openTimeline(nodeId);
-  };
+  // Double-click-to-open (R10.5) is GONE, with the double-click drill-in it
+  // backstopped. It existed because the anchor card trades its chevron for the
+  // `⋮`, which left the one card the user was working on with no pointer route
+  // in; a plain click opens every collection now, anchor included, so there is
+  // nothing left for it to cover.
+  //
+  // Removed rather than left harmlessly redundant, because it was neither.
+  // Click 1 navigates and unmounts the card, so the second click of a habitual
+  // double-click lands on whatever now occupies that spot — and this handler
+  // would have read THAT card's id and drilled a second level down, clearing
+  // the selection on its way. In select mode it would also have thrown away a
+  // selection the user was still assembling.
 
   /**
    * Acknowledge the press IMMEDIATELY, whatever the click turns out to mean.
@@ -420,7 +396,6 @@ export function OpenKeyBoundary({
       style={{ display: "contents" }}
       onKeyDown={handleKeyDown}
       onPointerDown={acknowledgePress}
-      onDoubleClick={openFromDoubleClick}
     >
       {children}
     </div>

--- a/apps/timeline-gstudio001/components/graph-view/graph-tag-filter-control.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-tag-filter-control.tsx
@@ -1,37 +1,63 @@
 "use client";
 
-import { useState } from "react";
-import { Tag } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Check, Filter, X } from "lucide-react";
 
-import { tagCounts } from "@/lib/tag-facets";
+import { tagCounts, tagKey } from "@/lib/tag-facets";
 
 import { useGraphDetailsSnapshot } from "./graph-details-context";
 import { useTagFilter } from "./graph-tag-filter";
+import { TagAccentDot } from "./tag-accent-dot";
 
 /**
  * The board's tag filter: pick tags, non-matching cards dim.
  *
- * Lives in the header's VIEW group because it QUALIFIES what the board shows
- * rather than changing the document — the same class of control as the ruler
- * and waveform toggles beside it.
+ * Leads the header's right cluster paired with Select — the two controls that
+ * change how you WORK with the board rather than what it contains. It used to
+ * sit in the view group beside the ruler and waveform toggles, on the reasoning
+ * that it qualifies what the board shows; true, but among those it read as one
+ * more display switch, and this is the control the row most needed to make
+ * findable.
  *
- * The menu is built from the tags actually in use, not from a fixed list.
- * Tag vocabulary here is emergent (a new checkpoint is a new tag), so anything
+ * The menu is built from the tags actually IN USE, not a fixed list. Tag
+ * vocabulary here is emergent — a new checkpoint is a new tag — so anything
  * curated would be stale within a week.
  */
 export function TagFilterControl() {
   const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
   const details = useGraphDetailsSnapshot();
   const { activeTags, toggleTag, clear } = useTagFilter();
   const counts = tagCounts(details);
   const active = activeTags.size;
+
+  // Dismissal, both ways round. Escape is captured so it closes THIS before it
+  // reaches the board — where the same key would drop the selection or leave
+  // select mode, which is not what someone with a menu open means by it.
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (event: MouseEvent) => {
+      if (!wrapRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.stopPropagation();
+      setOpen(false);
+    };
+    document.addEventListener("click", onDocClick);
+    document.addEventListener("keydown", onKey, true);
+    return () => {
+      document.removeEventListener("click", onDocClick);
+      document.removeEventListener("keydown", onKey, true);
+    };
+  }, [open]);
 
   // Nothing tagged yet means nothing to filter by, and an empty menu is worse
   // than no control at all.
   if (counts.length === 0) return null;
 
   return (
-    <div className="relative">
+    <div ref={wrapRef} className="relative">
       <button
         type="button"
         data-tag-filter-trigger
@@ -39,26 +65,49 @@ export function TagFilterControl() {
         aria-haspopup="menu"
         onClick={() => setOpen((value) => !value)}
         title="Filter the board by tag — non-matching cards dim"
-        aria-label={active > 0 ? `Tag filter, ${active} active` : "Filter by tag"}
+        aria-label={active > 0 ? `Filter by tag, ${active} active` : "Filter by tag"}
         className={[
-          "flex items-center gap-1 rounded px-1.5 py-1 text-[11px] font-medium transition-colors",
+          "flex h-8 shrink-0 items-center gap-1.5 rounded-md px-2 text-[11px] font-medium transition-colors",
+          "[@media(pointer:coarse)]:h-11",
           active > 0
-            ? "bg-sky-500/20 text-sky-200 ring-1 ring-sky-400/40"
+            ? "bg-sky-500/20 text-sky-100 ring-1 ring-sky-400/40"
             : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100",
         ].join(" ")}
       >
-        <Tag aria-hidden="true" className="size-3.5" />
-        {active > 0 ? <span data-tag-filter-count>{active}</span> : null}
+        <Filter aria-hidden="true" className="size-3.5" strokeWidth={1.7} />
+        Filter
+        {active > 0 ? (
+          <span
+            data-tag-filter-count
+            className="grid h-4 min-w-4 place-items-center rounded-full bg-sky-500 px-1 font-mono text-[10px] text-white tabular-nums"
+          >
+            {active}
+          </span>
+        ) : null}
       </button>
 
       {open ? (
         <div
           role="menu"
           data-tag-filter-menu
-          className="absolute top-full right-0 z-50 mt-1 flex max-h-72 w-56 flex-col gap-0.5 overflow-y-auto rounded-md bg-zinc-900 p-1 shadow-lg ring-1 ring-white/15"
+          className="absolute top-full right-0 z-50 mt-1.5 flex max-h-80 w-60 flex-col overflow-y-auto rounded-md bg-zinc-900 p-1.5 shadow-lg ring-1 ring-white/15"
         >
+          <div className="flex items-center px-1.5 pt-0.5 pb-1.5 text-[11px] text-zinc-500">
+            Filter by tag
+            {active > 0 ? (
+              <button
+                type="button"
+                data-tag-filter-clear
+                onClick={clear}
+                className="ml-auto rounded px-1 hover:text-zinc-100"
+              >
+                Clear all
+              </button>
+            ) : null}
+          </div>
+
           {counts.map(({ tag, count }) => {
-            const on = activeTags.has(tag.toLowerCase());
+            const on = activeTags.has(tagKey(tag));
             return (
               <button
                 key={tag}
@@ -68,29 +117,95 @@ export function TagFilterControl() {
                 data-tag-filter-option={tag}
                 onClick={() => toggleTag(tag)}
                 className={[
-                  "flex items-center justify-between gap-2 rounded px-2 py-1 text-left text-[11px]",
+                  "flex h-8 w-full items-center gap-2 rounded px-1.5 text-left text-[11px] transition-colors",
                   on ? "bg-sky-500/20 text-sky-100" : "text-zinc-300 hover:bg-zinc-800",
                 ].join(" ")}
               >
-                <span className="truncate">{tag}</span>
+                <TagAccentDot tag={tag} className="size-[7px]" />
+                <span className="min-w-0 flex-1 truncate">{tag}</span>
                 <span className="shrink-0 font-mono text-[10px] text-zinc-500 tabular-nums">
                   {count}
                 </span>
+                {/* Always rendered, opacity-toggled: a check that appeared and
+                    disappeared would shift the count beside it on every tap. */}
+                <Check
+                  aria-hidden="true"
+                  strokeWidth={3}
+                  className={["size-3 shrink-0 text-sky-300", on ? "opacity-100" : "opacity-0"].join(
+                    " ",
+                  )}
+                />
               </button>
             );
           })}
-          {active > 0 ? (
-            <button
-              type="button"
-              data-tag-filter-clear
-              onClick={clear}
-              className="mt-0.5 rounded border-t border-white/10 px-2 py-1 text-left text-[11px] text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
-            >
-              Clear filter
-            </button>
-          ) : null}
         </div>
       ) : null}
+    </div>
+  );
+}
+
+/**
+ * What the filter is currently doing, as removable chips under the header.
+ *
+ * The trigger's count says HOW MANY tags are running; this says WHICH — and
+ * that difference matters more here than it would in most apps, because the
+ * filter DIMS rather than hides. A hiding filter announces itself: the board
+ * empties out. A dimming one leaves every card in place, so a filter left on by
+ * accident looks almost exactly like a board where most things happen not to
+ * match, and the only tell is a small badge in the corner of the toolbar.
+ *
+ * Each chip is its own OFF switch, which is the common correction — narrowing
+ * by three tags and wanting the second one back. "Clear all" is separate and
+ * last, so removing one tag can never be a misclick away from removing them all.
+ *
+ * Renders nothing at rest, so it costs no vertical space until it is true.
+ */
+export function ActiveTagFilters() {
+  const { activeTags, toggleTag, clear } = useTagFilter();
+  const details = useGraphDetailsSnapshot();
+
+  if (activeTags.size === 0) return null;
+
+  // The active set stores COMPARISON keys (lowercased); the counts carry the
+  // spelling the user actually typed. Show the spelling — a chip reading
+  // "scail-2" for a tag written "SCAIL-2" is the filter appearing to have
+  // changed the data.
+  const spelling = new Map(tagCounts(details).map(({ tag }) => [tagKey(tag), tag]));
+
+  return (
+    <div
+      data-active-tag-filters={activeTags.size}
+      className="flex flex-wrap items-center gap-1.5 px-0.5 pt-2"
+    >
+      <span className="text-[11px] text-zinc-500">Filtered by</span>
+      {[...activeTags].map((key) => {
+        const label = spelling.get(key) ?? key;
+        return (
+          <button
+            key={key}
+            type="button"
+            data-active-tag-filter={label}
+            onClick={() => toggleTag(label)}
+            title={`Stop filtering by “${label}”`}
+            aria-label={`Stop filtering by ${label}`}
+            className="group inline-flex h-6 max-w-[12rem] items-center gap-1.5 rounded-full bg-sky-500/10 py-0 pr-1 pl-2 text-[11px] text-sky-100 ring-1 ring-sky-400/40 transition-colors hover:bg-sky-500/20"
+          >
+            <TagAccentDot tag={label} />
+            <span className="min-w-0 truncate">{label}</span>
+            <span className="grid size-3.5 shrink-0 place-items-center rounded-full text-sky-300/70 group-hover:bg-white/10 group-hover:text-sky-100">
+              <X aria-hidden="true" className="size-2.5" strokeWidth={2.5} />
+            </span>
+          </button>
+        );
+      })}
+      <button
+        type="button"
+        data-active-tag-filters-clear
+        onClick={clear}
+        className="rounded px-1 py-1 text-[11px] text-zinc-500 hover:text-zinc-100"
+      >
+        Clear all
+      </button>
     </div>
   );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -601,36 +601,33 @@ export function GraphTimelineView({
   // registers itself into this ref.
   const openNodeRef = useRef<(nodeId: NodeId) => void>(() => {});
   const handleOpenNode = useCallback((nodeId: NodeId) => openNodeRef.current(nodeId), []);
-  // A plain click on a COLLECTION now SELECTS it (so it can be trashed with
-  // Delete like any clip); its own folder button is the only pointer path
-  // that drills in (see GraphClipContent). Duplicate-reference cards — media
-  // standing in for a twice-referenced timeline — have no such button, so a
-  // plain click still opens those. The O key opens both regardless
-  // (OpenKeyBoundary), so keyboard drill-in is unchanged.
+  // A plain click on a COLLECTION drills in — one click, no second click to
+  // wait for. Duplicate-reference cards (media standing in for a twice-
+  // referenced timeline) open the same way, which is what they always did.
+  //
+  // This is `openOnClick`'s own default, spelled out rather than omitted: the
+  // predicate is the documented seam for "which nodes open", and leaving it off
+  // to inherit `node.kind === "collection"` hides that decision in the package.
+  //
+  // SELECTING a collection is select mode's job now (see the header's Select
+  // control). That is a straight trade and worth naming: click used to select a
+  // collection so Delete could trash it, and the only pointer route in was the
+  // card's own folder button. Now click goes in, and picking collections to act
+  // on is a mode you enter deliberately — which is also the only way to pick
+  // several. Ctrl/Cmd+click still toggles one without entering the mode, and
+  // the O key still opens from the keyboard (OpenKeyBoundary).
   const openOnClick = useCallback(
-    (nodeId: NodeId) =>
+    (nodeId: NodeId, node: CollectionItemNode) =>
+      node.kind === "collection" ||
       detailsStore.get(nodeId as string)?.duplicateOfTimelineId !== undefined,
     [detailsStore],
   );
-  // Hold a COLLECTION's click-selection for the double-click window, because
-  // double-click is how a collection drills in.
-  //
-  // Without this the user watches the card select and then unselect on its way
-  // into the drill-in: click 1 selects and paints, and the dblclick handler is
-  // only reached after that, so it can undo the selection but not un-show it.
-  // Deferring is the only point at which it can be prevented rather than
-  // reversed.
-  //
-  // Collections only. Media clips have no second meaning for a double-click,
-  // so delaying their selection would be cost with nothing bought. Duplicate
-  // references are excluded too — `openOnClick` already opens those on a
-  // SINGLE click, so there is no second click to wait for.
-  const deferSelection = useCallback(
-    (nodeId: NodeId, node: CollectionItemNode) =>
-      node.kind === "collection" &&
-      detailsStore.get(nodeId as string)?.duplicateOfTimelineId === undefined,
-    [detailsStore],
-  );
+  // No `deferSelection`: it existed ONLY because a double-click drilled in, and
+  // click 1's selection had to be held back so the user never watched a card
+  // select and then unselect on its way into the collection. With a single
+  // click there is no second click to wait for, and holding one back would add
+  // SELECTION_DEFER_MS (250ms) of dead time to every collection click to buy
+  // nothing.
 
   if (boot.status === "loading") {
     return <GraphViewLoadingSkeleton />;
@@ -698,7 +695,12 @@ export function GraphTimelineView({
         dragGhostHeight={40}
         onOpenNode={handleOpenNode}
         openOnClick={openOnClick}
-        deferSelection={deferSelection}
+        // Select mode is armed from the header, which is on screen whether or
+        // not anything is selected — so the mode must survive an empty
+        // selection. Without this the store disarms it the instant it is turned
+        // on with nothing picked, and the first tap would drill in instead of
+        // selecting. Exiting is the header's job (Done / Escape).
+        keepMultiSelectModeWhenEmpty
         commandPolicy={commandPolicy}
         mapDropCommand={handleMapDropCommand}
         itemInstructions="Press O to open the focused collection, or F2 to rename it."

--- a/apps/timeline-gstudio001/components/graph-view/press-feedback.ts
+++ b/apps/timeline-gstudio001/components/graph-view/press-feedback.ts
@@ -1,13 +1,14 @@
-// Immediate press feedback on a card — the acknowledgement a deferred
-// selection cannot give.
+// Immediate press feedback on a card — an acknowledgement that does not wait
+// to find out what the press meant.
 //
-// A collection's click-selection is HELD for the double-click window
-// (`SELECTION_DEFER_MS`) so an ordinary double-click never paints a selection
-// on its way into the drill-in. Correct, but it leaves a stretch where a click
-// has landed and nothing on screen has changed, and that reads as the app
-// missing the click. This fills it: the animation starts on POINTERDOWN, before
-// the selection question is even asked, so the answer to "did that register?"
-// no longer depends on what the click turns out to mean.
+// It was introduced to cover a 250ms selection hold (`SELECTION_DEFER_MS`),
+// back when a double-click drilled in and click 1's selection had to be held
+// so it never painted on the way. That hold is gone with the single-click
+// drill-in, but the gap it filled was never really about the hold: a press may
+// still resolve into a selection, a drill-in, or the start of a drag, and every
+// one of those settles some time after the finger lands. This starts on
+// POINTERDOWN, before the question is even asked, so "did that register?" never
+// depends on the answer.
 //
 // It therefore plays for EVERY press — single click, the first click of a
 // double, and the start of a drag. That is the point. Feedback conditional on
@@ -40,10 +41,11 @@ const PRESS_SCALE = 1.012;
  * Tuned by eye: 340ms read as a twitch (the swell arrived and left before the
  * eye settled on it), 640 was slower than wanted, 400 is the settled value.
  *
- * It deliberately OUTLASTS the 250ms selection hold. The two are not sequential
- * steps to be kept apart: the scale acknowledges the press, the selection
- * answers what the press meant, and letting the first still be settling when
- * the second lands reads as one continuous response rather than two events.
+ * It was tuned to OUTLAST the 250ms selection hold, so that the swell was still
+ * settling when the selection landed and the two read as one continuous
+ * response rather than two events. The hold is gone, but the value stands on
+ * the eye-tuning above — and the same overlap now covers the drill-in, which
+ * unmounts the card mid-animation and takes the animation with it.
  */
 const PRESS_MS = 400;
 

--- a/apps/timeline-gstudio001/components/graph-view/tag-accent-dot.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/tag-accent-dot.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { tagAccent, type TagAccent } from "@/lib/tag-facets";
+
+/**
+ * The colour a tag family paints, as WHOLE literal class names.
+ *
+ * Never built at runtime (`bg-${accent}-400`): Tailwind scans source text for
+ * complete class names, so an interpolated one is simply absent from the built
+ * CSS — and the failure is silent, a dot that renders with no colour at all.
+ */
+const TAG_ACCENT_DOT: Record<TagAccent, string> = {
+  place: "bg-sky-400",
+  role: "bg-violet-400",
+  source: "bg-teal-400",
+  ok: "bg-emerald-400",
+  progress: "bg-amber-400",
+  blocked: "bg-rose-400",
+};
+
+/**
+ * A tag's colour, as a dot.
+ *
+ * Shared by the three places tags are shown — the card caption, the filter
+ * menu, and the active-filter summary — because a tag that changed colour
+ * between where you FILTER by it and where you SEE it would defeat the only
+ * thing the colour is for. One module, one answer.
+ *
+ * Decorative everywhere it is used: the label sits right beside it in all
+ * three, so the colour is a scanning aid rather than information of its own.
+ */
+export function TagAccentDot({
+  tag,
+  className = "size-1.5",
+}: Readonly<{ tag: string; className?: string }>) {
+  return (
+    <span
+      aria-hidden="true"
+      data-tag-accent={tagAccent(tag)}
+      className={["shrink-0 rounded-full", className, TAG_ACCENT_DOT[tagAccent(tag)]].join(" ")}
+    />
+  );
+}

--- a/apps/timeline-gstudio001/lib/tag-facets.test.ts
+++ b/apps/timeline-gstudio001/lib/tag-facets.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import { isTagFilterMiss, tagCounts, tagKey, toggleTagKey } from "./tag-facets";
+import {
+  isStatusTag,
+  isTagFilterMiss,
+  sortTagsStatusFirst,
+  tagAccent,
+  tagCounts,
+  tagKey,
+  toggleTagKey,
+} from "./tag-facets";
 
 const active = (...tags: string[]) => new Set(tags.map(tagKey));
 
@@ -72,5 +80,73 @@ describe("toggleTagKey", () => {
   it("ignores a blank tag", () => {
     const active = new Set(["keeper"]);
     expect(toggleTagKey(active, "   ")).toBe(active);
+  });
+});
+
+describe("tagAccent", () => {
+  it("recognises status by word, including inside a longer tag", () => {
+    // The whole reason status is matched as a SUBSTRING: nobody is going to
+    // register "pending-client-approval" anywhere, and it is still a status.
+    expect(tagAccent("approved")).toBe("ok");
+    expect(tagAccent("pending-client-approval")).toBe("progress");
+    expect(tagAccent("needs-color-correction")).toBe("blocked");
+    expect(tagAccent("keeper")).toBe("ok");
+  });
+
+  it("matches status case-insensitively, like the rest of tag handling", () => {
+    expect(tagAccent("  WIP  ")).toBe("progress");
+    expect(tagAccent("Locked")).toBe("blocked");
+  });
+
+  it("gives a descriptive tag a stable colour", () => {
+    // Stability is the property the whole scheme rests on — a tag that changed
+    // colour between cards would be worse than no colour at all.
+    expect(tagAccent("scail-2")).toBe(tagAccent("scail-2"));
+    expect(tagAccent("scail-2")).toBe(tagAccent("SCAIL-2"));
+    expect(["place", "role", "source"]).toContain(tagAccent("scail-2"));
+  });
+
+  it("spreads tags that share a prefix across families", () => {
+    // The reason for FNV-1a rather than a character sum: these differ in one
+    // trailing digit, and a summing hash walks them through adjacent buckets.
+    const accents = new Set(
+      ["shot-01", "shot-02", "shot-03", "shot-04", "shot-05", "shot-06"].map(tagAccent),
+    );
+    expect(accents.size).toBeGreaterThan(1);
+  });
+
+  it("never calls an ordinary word a status", () => {
+    expect(isStatusTag("exterior")).toBe(false);
+    expect(isStatusTag("wan2.1")).toBe(false);
+    // `ok` is deliberately absent from the status words — as a substring it
+    // would claim both of these.
+    expect(isStatusTag("smoke-test")).toBe(false);
+    expect(isStatusTag("look-dev")).toBe(false);
+  });
+});
+
+describe("sortTagsStatusFirst", () => {
+  it("puts status first so it survives truncation", () => {
+    expect(sortTagsStatusFirst(["exterior", "night", "approved"])).toEqual([
+      "approved",
+      "exterior",
+      "night",
+    ]);
+  });
+
+  it("keeps the original order within each class", () => {
+    // Stable, so adding one tag cannot reshuffle the chips already on a card.
+    expect(sortTagsStatusFirst(["night", "wip", "exterior", "approved"])).toEqual([
+      "wip",
+      "approved",
+      "night",
+      "exterior",
+    ]);
+  });
+
+  it("returns a new array and leaves the input alone", () => {
+    const tags = ["night", "approved"];
+    expect(sortTagsStatusFirst(tags)).not.toBe(tags);
+    expect(tags).toEqual(["night", "approved"]);
   });
 });

--- a/apps/timeline-gstudio001/lib/tag-facets.ts
+++ b/apps/timeline-gstudio001/lib/tag-facets.ts
@@ -52,6 +52,94 @@ export function tagCounts(
   return [...counts.values()].sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
 }
 
+/**
+ * Words that mark a tag as STATUS rather than description.
+ *
+ * Matched as substrings of the normalized tag, so `pending-client-approval`
+ * and `needs-color-correction` are caught by `pending` and `needs` without
+ * either being listed. Substring matching is also why `ok` is not in here: it
+ * would claim `smoke-test` and `look-dev`.
+ */
+const STATUS_WORDS: readonly (readonly [string, TagAccent])[] = [
+  ["approved", "ok"],
+  ["keeper", "ok"],
+  ["final", "ok"],
+  ["done", "ok"],
+  ["wip", "progress"],
+  ["pending", "progress"],
+  ["review", "progress"],
+  ["draft", "progress"],
+  ["needs", "blocked"],
+  ["blocked", "blocked"],
+  ["locked", "blocked"],
+  ["reject", "blocked"],
+  ["broken", "blocked"],
+];
+
+/** The descriptive families, cycled by hash. Deliberately FEW: colour here
+ *  separates tags at a glance, and a unique hue per tag separates nothing. */
+const DESCRIPTIVE_ACCENTS = ["place", "role", "source"] as const;
+
+export type TagAccent = "place" | "role" | "source" | "ok" | "progress" | "blocked";
+
+/**
+ * Which colour family a tag belongs to.
+ *
+ * DERIVED, never registered. The design this follows ships a fixed table of
+ * fourteen known tags with hand-assigned colours, which works for a mockup and
+ * cannot work here: tag vocabulary in this app is emergent — a new checkpoint
+ * is a new tag — so every real tag (`scail-2`, `wan2.1`, `S02`) would miss the
+ * table and come out the same fallback grey, and the whole point of colour
+ * would be lost on exactly the tags that are actually used.
+ *
+ * So status is recognised by WORD (the one part of the vocabulary that really
+ * is shared), and everything else is hashed into a small set of families. A
+ * hash is not meaningful — `night` and `hero` may collide — but it is STABLE,
+ * which is the property that matters: a tag keeps its colour across cards,
+ * across sessions and across renames of its neighbours, so the eye can learn it.
+ */
+export function tagAccent(tag: string): TagAccent {
+  const key = tagKey(tag);
+  for (const [word, accent] of STATUS_WORDS) {
+    if (key.includes(word)) return accent;
+  }
+  // FNV-1a, for a stable spread that does not clump on shared prefixes the way
+  // a plain character sum does — `shot-01`…`shot-09` would otherwise land in
+  // near-adjacent buckets and colour identically.
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < key.length; i += 1) {
+    hash ^= key.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return DESCRIPTIVE_ACCENTS[hash % DESCRIPTIVE_ACCENTS.length];
+}
+
+/** True for the tags that say where something STANDS rather than what it is. */
+export function isStatusTag(tag: string): boolean {
+  const accent = tagAccent(tag);
+  return accent === "ok" || accent === "progress" || accent === "blocked";
+}
+
+/**
+ * Status first, then original order.
+ *
+ * Card space runs out before tags do, and what gets dropped is whatever sorted
+ * last — so this decides what survives truncation. Status wins because it is
+ * what people scan a board for ("what still needs work"), and because a
+ * descriptive tag is usually recoverable from the picture itself while
+ * "approved" is not visible anywhere else on the card.
+ *
+ * A STABLE partition, not a comparison sort on a derived key: tags that share a
+ * class keep the order they were added in, so a card's chips do not reshuffle
+ * when an unrelated one is added.
+ */
+export function sortTagsStatusFirst(tags: readonly string[]): string[] {
+  const status: string[] = [];
+  const rest: string[] = [];
+  for (const tag of tags) (isStatusTag(tag) ? status : rest).push(tag);
+  return [...status, ...rest];
+}
+
 /** Toggle one tag in the active set, returning a new set. */
 export function toggleTagKey(
   active: ReadonlySet<string>,

--- a/packages/ui/dnd-collections/react/DndCollections.tsx
+++ b/packages/ui/dnd-collections/react/DndCollections.tsx
@@ -143,6 +143,16 @@ export type DndCollectionsProps = Readonly<{
    */
   trimRequiresSelection?: boolean;
   /**
+   * Let additive-tap mode stay armed while the selection is EMPTY.
+   *
+   * Off by default: the mode's usual control is the anchor card's menu, which
+   * exists only while something is selected, so an armed-and-empty mode would
+   * be invisible and unreachable. Pass this when the consumer gives the mode a
+   * control that is always on screen — a toolbar toggle — which makes "arm it,
+   * then pick" the ordinary way in. The consumer then owns the way OUT too.
+   */
+  keepMultiSelectModeWhenEmpty?: boolean;
+  /**
    * Pre-commit application veto (see `CommandPolicy`). Consulted on EVERY
    * dispatch — pointer drop, keyboard move, trash, palette add — so a rule
    * the pure reducer cannot express ("that collection is still loading") is
@@ -296,6 +306,7 @@ export function DndCollections({
   openOnClick,
   deferSelection,
   trimRequiresSelection,
+  keepMultiSelectModeWhenEmpty,
   commandPolicy,
   mapDropCommand,
   onPaletteDiscard,
@@ -361,6 +372,7 @@ export function DndCollections({
     createCollectionsStore(initialGraph, {
       onChange: (change) => onChangeRef.current?.(change),
       maxHistoryEntries,
+      keepMultiSelectModeWhenEmpty,
       commandPolicy: (command, graph) => commandPolicyRef.current?.(command, graph) ?? null,
     })
   );

--- a/packages/ui/dnd-collections/react/collections-store.test.ts
+++ b/packages/ui/dnd-collections/react/collections-store.test.ts
@@ -999,6 +999,81 @@ describe("createCollectionsStore", () => {
     expect(store.getSnapshot().interaction.multiSelectMode).toBe(false);
   });
 
+  test("keepMultiSelectModeWhenEmpty arms the mode with nothing selected", () => {
+    // The entry point the option exists for. A toolbar toggle is pressed BEFORE
+    // anything is picked, so if arming with an empty selection did not stick
+    // there would be no way to enter the mode from such a control at all — the
+    // first tap would land in the plain-select branch and, on a collection,
+    // drill in instead.
+    const store = createCollectionsStore(graphFixture(), {
+      keepMultiSelectModeWhenEmpty: true,
+    });
+    store.setMultiSelectMode(true);
+
+    expect(store.getSnapshot().interaction.multiSelectMode).toBe(true);
+    expect(selected(store)).toEqual([]);
+  });
+
+  test("keepMultiSelectModeWhenEmpty survives every way the selection ends", () => {
+    // The mirror of "the mode cannot outlive the selection": same four exits,
+    // opposite expectation. Emptying the selection while the mode is armed is
+    // ordinary here — you cleared to pick again, and the way out is the
+    // consumer's control, not a side effect of the last card leaving.
+    const store = createCollectionsStore(graphFixture(), {
+      keepMultiSelectModeWhenEmpty: true,
+    });
+    const armed = () => {
+      store.setSelection([id("x")]);
+      store.setMultiSelectMode(true);
+      expect(store.getSnapshot().interaction.multiSelectMode).toBe(true);
+    };
+
+    armed();
+    store.clearSelection();
+    expect(store.getSnapshot().interaction.multiSelectMode).toBe(true);
+
+    armed();
+    store.toggleSelected(id("x")); // toggled the last one off
+    expect(store.getSnapshot().interaction.multiSelectMode).toBe(true);
+
+    armed();
+    store.setSelection([]);
+    expect(store.getSnapshot().interaction.multiSelectMode).toBe(true);
+
+    // And the path that writes `interaction` directly rather than through
+    // setInteraction: pruning, after the selected node leaves the graph.
+    armed();
+    store.replaceGraph(
+      (() => {
+        const built = buildGraph([
+          { kind: "collection", id: "root-a", name: "A", children: [media("y")] },
+        ]);
+        if (!built.ok) throw new Error(JSON.stringify(built.error));
+        return built.value;
+      })(),
+    );
+    expect(selected(store)).toEqual([]);
+    expect(store.getSnapshot().interaction.multiSelectMode).toBe(true);
+  });
+
+  test("clearing an already-empty selection does not notify while the mode is armed", () => {
+    // The early return in `clearSelection` has to ignore an armed-but-allowed
+    // mode. Without that, every clear on an empty selection would build a fresh
+    // interaction object and re-render every subscriber for no change at all —
+    // and background-clear fires one of these on any click that misses a card.
+    const store = createCollectionsStore(graphFixture(), {
+      keepMultiSelectModeWhenEmpty: true,
+    });
+    store.setMultiSelectMode(true);
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    store.clearSelection();
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(store.getSnapshot().interaction.multiSelectMode).toBe(true);
+  });
+
   test("setting the mode to its current value does not notify", () => {
     const store = createCollectionsStore(graphFixture());
     store.setSelection([id("x")]);

--- a/packages/ui/dnd-collections/react/collections-store.ts
+++ b/packages/ui/dnd-collections/react/collections-store.ts
@@ -330,6 +330,21 @@ export function createCollectionsStore(
     maxHistoryEntries?: number;
     /** Pre-commit application veto — see `CommandPolicy`. */
     commandPolicy?: CommandPolicy;
+    /**
+     * Let additive-tap mode stay armed while the selection is EMPTY.
+     *
+     * Off by default, because the mode's usual control is the anchor card's
+     * menu — a surface that exists only while something is selected, so an
+     * armed mode with nothing selected would be on, invisible, and quietly
+     * making the next taps additive (see `setInteraction`).
+     *
+     * Turn it on when the consumer gives the mode a control that is ALWAYS
+     * reachable — a toolbar toggle, say. Then "armed with nothing selected" is
+     * not a dead end but the ordinary way in: arm the mode, THEN pick. Owning
+     * that control means owning the way out of it too; nothing here will
+     * disarm the mode for you.
+     */
+    keepMultiSelectModeWhenEmpty?: boolean;
   }>
 ): CollectionsStore {
   const initialValidation = validateGraph(initialGraph);
@@ -354,6 +369,7 @@ export function createCollectionsStore(
   const changeListeners = new Set<(change: CollectionsChange) => void>();
   const onChange = options?.onChange;
   const commandPolicy = options?.commandPolicy;
+  const keepMultiSelectModeWhenEmpty = options?.keepMultiSelectModeWhenEmpty ?? false;
   const pendingChanges: CollectionsChange[] = [];
   let notificationDepth = 0;
   let emittingChanges = false;
@@ -444,7 +460,11 @@ export function createCollectionsStore(
     // outlive the selection. Its only control lives on a surface that exists
     // while something is selected, so an armed mode with an empty selection is
     // unreachable — on, invisible, and quietly making the next taps additive.
-    if (interaction.multiSelectMode && interaction.selectedIds.size === 0) {
+    //
+    // Unless the consumer says otherwise: a mode with an ALWAYS-reachable
+    // control is not unreachable when empty, and "arm it, then pick" is how
+    // such a control is used (see `keepMultiSelectModeWhenEmpty`).
+    if (!keepMultiSelectModeWhenEmpty && interaction.multiSelectMode && interaction.selectedIds.size === 0) {
       interaction = { ...interaction, multiSelectMode: false };
     }
     notify();
@@ -498,10 +518,10 @@ export function createCollectionsStore(
       };
     }
     // This path writes `interaction` directly rather than through
-    // `setInteraction`, so it repeats that function's mode invariant. Deleting
-    // the last selected card is the ordinary way to arrive here with an armed
-    // mode and nothing left to show its control.
-    if (interaction.multiSelectMode && interaction.selectedIds.size === 0) {
+    // `setInteraction`, so it repeats that function's mode invariant — opt-out
+    // included. Deleting the last selected card is the ordinary way to arrive
+    // here with an armed mode and nothing left to show its control.
+    if (!keepMultiSelectModeWhenEmpty && interaction.multiSelectMode && interaction.selectedIds.size === 0) {
       interaction = { ...interaction, multiSelectMode: false };
     }
   }
@@ -767,11 +787,18 @@ export function createCollectionsStore(
         interaction.selectedIds.size === 0 &&
         interaction.anchorId === null &&
         interaction.selectionPivotId === null &&
-        !interaction.multiSelectMode
+        // A mode that is ALLOWED to be armed while empty is not something
+        // clearing has to undo, so it must not defeat this early return
+        // either — otherwise every clear on an already-empty selection hands
+        // out a fresh interaction identity and re-renders for nothing.
+        (keepMultiSelectModeWhenEmpty || !interaction.multiSelectMode)
       ) {
         return;
       }
-      // `setInteraction` drops the mode with it (see the invariant there).
+      // `setInteraction` drops the mode with it, unless the consumer opted to
+      // keep it (see the invariant there) — in which case clearing empties the
+      // selection and LEAVES the user in select mode, ready to pick again.
+      // Getting out is then the toolbar's job, not this one's.
       setInteraction({ selectedIds: EMPTY_SELECTION, anchorId: null, selectionPivotId: null });
     },
 


### PR DESCRIPTION
Ports the card-grid mockup's select mode, card caption and filter treatment onto the graph board. The mockup was taken as a design reference rather than merged — its `CollectionBrowser` hides non-matching items and ANDs multiple tags, both the opposite of what shipped in #320, and its filtering would have reintroduced the index-space failures documented in `graph-tag-filter.tsx`.

## Single-click drill-in

`openOnClick` now covers collections and `deferSelection` is gone, which also removes 250ms of dead time from every collection click. A plain click used to *select* a collection so Delete could trash it; that job moves to select mode.

Double-click-to-open goes with it. It existed only because the anchor card trades its chevron for the kebab, leaving it no pointer route in. Left in place it would have drilled a **second** level down — click 1 unmounts the card, so click 2 lands on whatever replaced it, and the handler would have read that card's id and cleared the selection on its way.

## Select mode

`Select` leads the header cluster beside the filter. Arming it alone keeps the breadcrumb — a toolbar of dimmed verbs over a count of zero says nothing, and the trail is what you still need while hunting. Once something is picked the row becomes the selection bar, which reuses `SelectionCentreControls` unchanged so it cannot drift from the anchor card's menu about which actions apply.

The breadcrumb also returns mid-drag: the ancestor crumbs *are* the "move up a level" drop targets, and a multi-drag out of a selection is exactly when someone reaches for them.

Cards show the design's circular checkbox while armed. It is decorative, not a control — card content renders inside `NodeCard`'s real `<button>`, and the mockup's own notes hit the same wall and answered it by making the card a `div role="button"`. Nothing is lost in select mode, where the whole card is already the toggle.

### `keepMultiSelectModeWhenEmpty`

The store's invariant — additive-tap mode cannot outlive the selection — was premised on the mode's only control living on a surface that exists while something is selected. A header button falsifies that premise: arming with nothing selected is the entry point. The opt-out is a store option, so the default and its existing tests are untouched.

## Grid card caption

Grid cards put their chrome under the artwork instead of stamped across it, using the `[data-virtual-grid]` variants the collection card already used — so the two card kinds finally agree on shape. The strip keeps its overlays: width there is duration, and a caption is fixed overhead on every clip.

An artwork box now wraps the frame, for two reasons: the frame no longer fills the card, so anything anchored to the card's bottom would sit over the caption; and the dimming stays on an inner span so the checkbox does not fade with the artwork. A filter miss drops the frame to `opacity-30`, and a checkbox that went with it would be unreadable exactly while picking through a filtered board.

Tag colour is **derived, not registered**. The mockup ships a fixed table of fourteen tags, which cannot work here — every tag actually in use (`scail-2`, `wan2.1`, `S02`) would miss the table and come out the same fallback grey. Status is matched by word as a substring (`pending-client-approval` → progress, `needs-color-correction` → blocked); everything else is FNV-1a hashed into three families. Not meaningful, but stable, which is the property that matters. Status sorts first so it survives truncation.

## Filter

Restyled to the design (icon, label, count badge; menu header with Clear all, accent dots, opacity-toggled check) and moved out of the view group, where it read as one more display switch.

Adds the active-filter summary strip. It earns its space here more than it would elsewhere: a dimming filter leaves every card in place, so one left on by accident looked much like a board where little happened to match. Each chip is its own off switch; Clear all is separate and last.

Semantics are unchanged — still dim rather than hide, still OR rather than AND.

## Verification

Driven in the running app: select → pick → `1 selected` → pick → `2 selected` → Done; single-click drill-in advancing the URL; caption rendering `Video | 5.6s | approved | scail-2 | +1` with correct accent dots; strip reading `Filtered by · approved · night · Clear all`, chips removing individually, Clear all emptying it. Strip surface confirmed unchanged throughout (caption hidden, kind chip back, height still 132).

702 app tests, 533 unit tests, 173 story interaction tests, `packages/ui` typecheck and lint all pass. The three new store tests were confirmed to fail with the option forced off.

Two test projects were tagged during verification and restored afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
