### PR TITLE
Gate on the e2e suite, and cover the new card in stories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,17 @@ name: CI
 # assertion demanding 9px went unnoticed because nothing ran it. They need a
 # real Chromium but no dev server, which is what makes them affordable here.
 #
-# The Playwright e2e suite is still intentionally excluded — it needs a running
-# dev server and real trusted mouse input, too slow to gate every merge on. Run
-# it locally or in a separate manual workflow when a change warrants it.
+# The Playwright e2e suite runs too, as a SEPARATE job — see `e2e` below. It
+# was excluded for a long time on the reasoning that a dev server plus real
+# trusted mouse input is too slow to gate every merge on. That reasoning held
+# right up until it cost something: a change to the click grammar (collections
+# drill in on a single click now) broke eight e2e tests and merged green,
+# because the gate above cannot see them. The suite is the only thing in this
+# repo that exercises real pointer input, which is exactly the class of change
+# most likely to break silently.
+#
+# Its cost is contained by running it in PARALLEL with the gate above rather
+# than after it, so it adds its own wall time and not the sum.
 
 on:
   pull_request:
@@ -66,3 +74,62 @@ jobs:
       - name: Story interaction tests (headless Chromium)
         working-directory: apps/storybook
         run: npx vitest run --project=storybook
+
+  e2e:
+    name: E2E (Playwright)
+    runs-on: ubuntu-latest
+    # Generous but bounded. The graph-view suite is ~2 min locally at 6
+    # workers; a runner is slower and pays for two server boots on top.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install
+        run: npm install
+
+      # Both projects use the Desktop Chrome device; no other engine is needed.
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      # PLACEHOLDERS, not credentials. The suite mocks every API surface it
+      # touches at the network layer (`page.route`, including /api/auth/me), so
+      # the Next server never handles an authenticated request and
+      # `getFirebaseApp()` — which is lazy — is never reached. These exist only
+      # so nothing reads `undefined` while the dev server boots.
+      #
+      # FIREBASE_CLIENT_EMAIL and FIREBASE_PRIVATE_KEY are deliberately ABSENT:
+      # supplying a malformed key pair would make `cert()` the thing that
+      # throws, where omitting them falls through to `applicationDefault()`,
+      # which also only fails if something actually uses it.
+      - name: Write a placeholder env for the dev server
+        working-directory: apps/timeline-gstudio001
+        run: |
+          cat > .env <<'ENVEOF'
+          FIREBASE_PROJECT_ID=ci-placeholder
+          FIREBASE_WEB_API_KEY=ci-placeholder
+          NEXT_PUBLIC_FIREBASE_API_KEY=ci-placeholder
+          APP_URL=http://127.0.0.1:3000
+          ENVEOF
+
+      # The whole suite, both projects. Narrowing to one would not save much:
+      # Playwright starts every entry in the `webServer` array regardless of
+      # `--project`, so both servers boot either way and the second project is
+      # nearly free once they are up.
+      - name: E2E tests
+        working-directory: apps/timeline-gstudio001
+        run: npx playwright test
+
+      # Without this a CI-only failure is undebuggable — the report carries the
+      # per-test trace, the failure screenshot, and the DOM snapshot.
+      - name: Upload the Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: apps/timeline-gstudio001/playwright-report
+          retention-days: 7

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { Decorator, Meta, StoryObj } from "@storybook/react";
 import { expect, userEvent, waitFor } from "storybook/test";
 
@@ -6,6 +6,7 @@ import type { ClipDetail } from "@storyboard/timeline-domain";
 import {
   DndCollections,
   buildGraph,
+  useCollectionsStore,
   type CollectionGhostContentComponent,
   type CollectionItemShellComponent,
   type CollectionItemShellProps,
@@ -812,7 +813,7 @@ export const AnchorControlAndCountBadge: Story = {
  *  GraphCollectionItemParts rather than GraphClipContent, so they need their
  *  own cover — a media-only implementation would leave tagged collections
  *  showing nothing at all. */
-function renderWithTags(tags: string[]) {
+function renderWithTags(tags: string[], surface: "grid" | "strip" = "strip") {
   const detail: ClipDetail = {
     alt: "A timeline",
     aspect: 16 / 9,
@@ -826,7 +827,13 @@ function renderWithTags(tags: string[]) {
   const decorator: Decorator = (Story) => (
     <DndCollections initialGraph={providerGraph}>
       <GraphDetailsProvider store={store}>
-        <div className="h-32 w-40 bg-zinc-950 p-2">
+        {/* The grid marker is what the card matches on, so a "grid" story sets
+            it here exactly as VirtualGrid does — and gets the taller box a
+            grid cell actually has, since the caption needs somewhere to go. */}
+        <div
+          {...(surface === "grid" ? { "data-virtual-grid": "story" } : {})}
+          className={surface === "grid" ? "h-52 w-64 bg-zinc-950 p-2" : "h-32 w-40 bg-zinc-950 p-2"}
+        >
           <Story />
         </div>
       </GraphDetailsProvider>
@@ -897,5 +904,244 @@ export const UntaggedCardHasNoTagRow: Story = {
   decorators: [renderWithTags([])],
   play: async ({ canvasElement }) => {
     await expect(canvasElement.querySelector("[data-clip-tags]")).toBeNull();
+  },
+};
+
+// ---------------------------------------------------------------------------
+// The GRID card's caption, and the select-mode checkbox.
+//
+// Both are surface-dependent, and the surface is signalled by a CSS ancestor
+// marker (`[data-virtual-grid]`) rather than a prop — the card renderer is
+// shared and has no idea which view it is in. So these stories set that marker
+// themselves, exactly as VirtualGrid does, and a strip story simply omits it.
+// ---------------------------------------------------------------------------
+
+/** Arms select mode from inside the provider, where the store is reachable. */
+function ArmSelectMode() {
+  const store = useCollectionsStore();
+  useEffect(() => {
+    store.setMultiSelectMode(true);
+  }, [store]);
+  return null;
+}
+
+function renderMediaCard(
+  options: Readonly<{ surface: "grid" | "strip"; tags?: string[]; selectMode?: boolean }>,
+): Decorator {
+  const { surface, tags = [], selectMode = false } = options;
+  return function MediaCardDecorator(Story) {
+    const store = createGraphDetailsStore({
+      [VIDEO_ID as string]: {
+        alt: "A video",
+        aspect: 16 / 9,
+        trackIndex: 0,
+        hydrated: false,
+        tags,
+      },
+    });
+    return (
+      <DndCollections
+        initialGraph={videoGraph}
+        components={GRAPH_VIEW_COMPONENTS}
+        keepMultiSelectModeWhenEmpty
+      >
+        <GraphDetailsProvider store={store}>
+          {selectMode ? <ArmSelectMode /> : null}
+          <VideoFrameLookAhead>
+            {/* The grid marker goes on an ANCESTOR, which is the whole point:
+                the card matches `[[data-virtual-grid]_&]` through the DOM, so
+                nothing has to be threaded down to it. */}
+            <div
+              {...(surface === "grid" ? { "data-virtual-grid": "story" } : {})}
+              className="bg-zinc-950 p-2"
+            >
+              <div style={{ width: 260, height: surface === "grid" ? 210 : 120 }}>
+                <Story />
+              </div>
+            </div>
+          </VideoFrameLookAhead>
+        </GraphDetailsProvider>
+      </DndCollections>
+    );
+  };
+}
+
+const mediaArgs = { id: VIDEO_ID, className: "h-full w-full" };
+
+/**
+ * In the GRID the chrome sits UNDER the artwork, not stamped across it.
+ *
+ * The two overlays it replaces have to go, or the card says everything twice
+ * and covers its own picture to do it.
+ */
+export const GridCardCaptionSitsUnderTheArtwork: Story = {
+  args: mediaArgs,
+  decorators: [renderMediaCard({ surface: "grid" })],
+  play: async ({ canvasElement }) => {
+    const caption = canvasElement.querySelector<HTMLElement>("[data-clip-caption]")!;
+    await expect(caption).not.toBeNull();
+    await expect(caption.getBoundingClientRect().height).toBeGreaterThan(0);
+    // Unnamed clips caption as their KIND rather than a filename (PL11-004
+    // keeps `title` absent until authored) — never an empty first line.
+    await expect(caption.textContent).toContain("Video");
+
+    // BELOW the frame, not over it. Measured, because the whole change is a
+    // geometric one and a caption that rendered on top of the artwork would
+    // still satisfy every text assertion above.
+    const artwork = canvasElement.querySelector<HTMLElement>("img")!;
+    await expect(caption.getBoundingClientRect().top).toBeGreaterThanOrEqual(
+      artwork.getBoundingClientRect().bottom - 1,
+    );
+
+    // The overlay the caption replaces is gone in this surface.
+    const kindChip = canvasElement.querySelector<HTMLElement>("[data-media-kind]")!;
+    await expect(kindChip.getBoundingClientRect().height).toBe(0);
+  },
+};
+
+/**
+ * The STRIP keeps its overlays and grows no caption.
+ *
+ * The divergence is deliberate: a strip card's width IS its duration, so a
+ * caption row is fixed overhead on every clip and unreadable on a short one.
+ * Pinned as a pair with the story above, because the two are one decision and
+ * a regression would most likely make both surfaces the same again.
+ */
+export const StripCardKeepsItsOverlays: Story = {
+  args: mediaArgs,
+  decorators: [renderMediaCard({ surface: "strip" })],
+  play: async ({ canvasElement }) => {
+    const caption = canvasElement.querySelector<HTMLElement>("[data-clip-caption]");
+    // Present in the DOM but not laid out — it is CSS-gated, not conditionally
+    // rendered, so `toBeNull` would be the wrong assertion and would pass for
+    // the wrong reason if the gate were ever removed.
+    await expect(caption?.getBoundingClientRect().height ?? 0).toBe(0);
+
+    const kindChip = canvasElement.querySelector<HTMLElement>("[data-media-kind]")!;
+    await expect(kindChip.getBoundingClientRect().height).toBeGreaterThan(0);
+    await expect(kindChip.textContent).toBe("VIDEO");
+  },
+};
+
+/**
+ * Caption tags fold into a counter, and STATUS survives the fold.
+ *
+ * The ordering is the assertion that matters. Card space runs out before tags
+ * do, so whatever sorts last is what disappears — and "approved" is not
+ * recoverable from the picture the way "night" is.
+ */
+export const CaptionTagsFoldStatusFirst: Story = {
+  args: mediaArgs,
+  decorators: [
+    renderMediaCard({ surface: "grid", tags: ["night", "approved", "scail-2", "wip"] }),
+  ],
+  play: async ({ canvasElement }) => {
+    const row = canvasElement.querySelector<HTMLElement>("[data-clip-caption-tags]")!;
+    await expect(row.dataset.clipCaptionTags).toBe("4");
+
+    const chips = Array.from(row.querySelectorAll<HTMLElement>("span[title]"));
+    // The two STATUS tags are the ones kept, though neither was stored first.
+    await expect(chips.map((chip) => chip.title)).toEqual(["approved", "wip"]);
+    for (const chip of chips) {
+      await expect(chip.getBoundingClientRect().width).toBeGreaterThan(0);
+    }
+
+    const overflow = canvasElement.querySelector<HTMLElement>(
+      "[data-clip-caption-tags-overflow]",
+    )!;
+    await expect(overflow.dataset.clipCaptionTagsOverflow).toBe("2");
+    await expect(overflow.textContent).toBe("+2");
+
+    // Colour is DERIVED, so the two status words must land in their own
+    // families rather than sharing one — that is what the dot is for.
+    const accents = chips.map((chip) =>
+      chip.querySelector("[data-tag-accent]")?.getAttribute("data-tag-accent"),
+    );
+    await expect(accents).toEqual(["ok", "progress"]);
+  },
+};
+
+/** No tags, no row — and the caption still renders its meta line. */
+export const CaptionWithoutTagsHasNoTagRow: Story = {
+  args: mediaArgs,
+  decorators: [renderMediaCard({ surface: "grid" })],
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelector("[data-clip-caption-tags]")).toBeNull();
+    await expect(canvasElement.querySelector("[data-clip-caption]")).not.toBeNull();
+  },
+};
+
+/**
+ * The select-mode checkbox: present only while the mode is armed.
+ *
+ * DECORATIVE by necessity — this renders inside NodeCard's real <button>, and a
+ * button may not contain interactive content. The assertion that it is not a
+ * button is therefore a structural contract, not a style preference: making it
+ * one would eject the rest of the card out of its own box.
+ */
+export const SelectModeShowsACheckbox: Story = {
+  args: mediaArgs,
+  decorators: [renderMediaCard({ surface: "grid", selectMode: true })],
+  play: async ({ canvasElement }) => {
+    const indicator = await waitFor(() => {
+      const found = canvasElement.querySelector<HTMLElement>("[data-selection-indicator]");
+      if (!found) throw new Error("no selection indicator");
+      return found;
+    });
+    await expect(indicator.dataset.selectionIndicator).toBe("off");
+    await expect(indicator.getBoundingClientRect().width).toBeGreaterThan(0);
+    await expect(indicator.getAttribute("aria-hidden")).toBe("true");
+    await expect(indicator.querySelector("button")).toBeNull();
+
+    // ON THE ARTWORK, not on the caption below it. It moved into its own
+    // positioning box for exactly this reason, and a regression would drop it
+    // onto the caption where it would sit over the tags.
+    const artwork = canvasElement.querySelector<HTMLElement>("img")!;
+    await expect(indicator.getBoundingClientRect().bottom).toBeLessThanOrEqual(
+      artwork.getBoundingClientRect().bottom + 1,
+    );
+  },
+};
+
+/** Idle, there is no checkbox at all — it is a mode affordance, not chrome. */
+export const NoCheckboxOutsideSelectMode: Story = {
+  args: mediaArgs,
+  decorators: [renderMediaCard({ surface: "grid" })],
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelector("[data-selection-indicator]")).toBeNull();
+  },
+};
+
+/**
+ * In the GRID a collection files its tags in the caption, not over its preview
+ * frames — the same split the media card makes.
+ *
+ * Pinned because the two card kinds are rendered by DIFFERENT components
+ * (collections route through the composed CollectionItem shell, media through
+ * NodeCard), so nothing structural forces them to agree. They diverged once
+ * already: media moved its tags into the caption and collections did not, which
+ * put two kinds of card in one grid filing the same thing in two places.
+ */
+export const CollectionGridTagsSitInTheCaption: Story = {
+  args: baseArgs,
+  decorators: [renderWithTags(["scail-2", "approved"], "grid")],
+  play: async ({ canvasElement }) => {
+    const caption = canvasElement.querySelector<HTMLElement>("[data-collection-caption-tags]")!;
+    await expect(caption).not.toBeNull();
+    await expect(caption.getBoundingClientRect().height).toBeGreaterThan(0);
+
+    // Status first, as everywhere else tags are shown.
+    const chips = Array.from(caption.querySelectorAll<HTMLElement>("span[title]"));
+    await expect(chips.map((chip) => chip.title)).toEqual(["approved", "scail-2"]);
+
+    // And the OVERLAY row is stood down here, or the card would say it twice.
+    const overlay = canvasElement.querySelector<HTMLElement>("[data-clip-tags]");
+    await expect(overlay?.getBoundingClientRect().height ?? 0).toBe(0);
+
+    // Below the preview frames, not on them.
+    const frame = canvasElement.querySelector<HTMLElement>("img")!;
+    await expect(caption.getBoundingClientRect().top).toBeGreaterThanOrEqual(
+      frame.getBoundingClientRect().bottom - 1,
+    );
   },
 };

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -1469,7 +1469,18 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
             than GraphClipContent (which returns null for them at the guard
             above). Skipping it here would ship a half-feature where a tagged
             collection silently shows nothing. */}
-        {detail?.tags?.length ? <TagRow tags={detail.tags} showAtMost={TAGS_SHOWN_NARROW} /> : null}
+        {detail?.tags?.length ? (
+          <TagRow
+            tags={detail.tags}
+            showAtMost={TAGS_SHOWN_NARROW}
+            // Same split the media card makes: overlaid on the artwork in the
+            // strip, in the caption in the grid. Without this the two card
+            // kinds would file their tags in two different places within one
+            // grid, which is the sort of inconsistency nobody reports and
+            // everybody notices.
+            className="[[data-virtual-grid]_&]:hidden"
+          />
+        ) : null}
         <span
           data-disabled-visuals={muted ? "true" : undefined}
           data-filter-miss={filterMiss ? "true" : undefined}
@@ -1577,6 +1588,20 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
             </span>
           </span>
         </span>
+        {/* The collection's tags, in the GRID, under its name row — the twin of
+            the media card's caption tag row, and for the same reason: the cell
+            is tall enough to say this in words instead of stamping it over the
+            preview frames. A row of its own rather than squeezed in beside the
+            item count, which is already a name plus two numbers. */}
+        {detail?.tags?.length ? (
+          <span
+            aria-hidden="true"
+            data-collection-caption-tags={detail.tags.length}
+            className="hidden min-w-0 items-center pr-1.5 pb-1 pl-1.5 [[data-virtual-grid]_&]:flex"
+          >
+            <CaptionTagRow tags={detail.tags} showAtMost={TAGS_SHOWN_NARROW} />
+          </span>
+        ) : null}
       </CollectionItem.SelectionSurface>
 
       {/* (PL10-001 moved the call-out itself onto the selection surface above.


### PR DESCRIPTION
Closes the gap that let #322 merge with eight broken e2e tests, and covers the card relayout with the story coverage the repo rules ask for.

## E2E joins CI

It was excluded on the reasoning that a dev server plus real trusted mouse input is too slow to gate every merge on. That held right up until it cost something: the single-click drill-in broke **8 e2e tests and merged green**, because the existing gate cannot see them. This suite is the only thing in the repo exercising real pointer input — exactly the class of change that breaks silently.

Design choices, all about containing the cost that motivated the original exclusion:

- **A separate job, parallel with `validate`**, so it adds its own wall time rather than the sum.
- **Both projects.** Playwright starts every `webServer` entry regardless of `--project`, so narrowing to `graph-view` would still pay both server boots and save almost nothing.
- **Report uploaded on failure** (7-day retention). A CI-only failure is otherwise undebuggable — the report carries the trace, screenshot, and DOM snapshot.
- **Placeholder env, not credentials.** The suite mocks every API surface it touches at the network layer, including `/api/auth/me`, so the Next server never handles an authenticated request and `getFirebaseApp()` (which is lazy) is never reached. `FIREBASE_CLIENT_EMAIL` / `FIREBASE_PRIVATE_KEY` are deliberately *absent* — a malformed pair would make `cert()` the thing that throws, where omitting them falls through to `applicationDefault()`, which also only fails if something uses it.

⚠️ **This job is not a required check until you add it in branch protection.** Auto-merge only waits on required checks, so until then a PR can still merge while e2e is red.

## Story coverage for the card

Seven new stories covering what the relayout actually changed:

- the caption sitting **under** the artwork, asserted geometrically — a caption rendered on top would satisfy every text assertion
- the strip **keeping its overlays**, pinned as a pair with the grid story, because the two are one decision and a regression would most likely collapse them back together
- caption tags folding **status-first** into a counter, with the derived accent families asserted
- the select-mode checkbox, its absence when idle, and that it is **not** a `<button>` — a structural contract, since making it one would eject the rest of the card out of its own box
- the checkbox staying **on the artwork** rather than drifting onto the caption

I verified these fail when the surface gate is broken rather than assuming: breaking `[[data-virtual-grid]_&]` fails exactly the two caption stories.

## Collection cards file their tags the same way

Media moved its tags into the caption and collections did not, so one grid had two kinds of card putting the same thing in two places. They are rendered by **different components** — collections through the composed `CollectionItem` shell, media through `NodeCard` — so nothing structural forces them to agree, which is why the new story pins it.

## Verification

- E2E: **147 passed**, 0 failed
- Story interaction: **180 passed** (was 173)
- App tests: **702 passed**
- `tsc --noEmit` (app + `packages/ui`), lint: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
