### PR TITLE
Reveal the select checkbox on hover, drop the amber selected-badge, match the count to the ring

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -877,7 +877,13 @@ function SelectModeHeader({ anchorName }: Readonly<{ anchorName: string | null }
         // Mono and tabular so the row does not twitch sideways as the count
         // crosses 9 — this number changes on every tap, which is precisely the
         // moment a reflowing toolbar is most annoying.
-        className="shrink-0 font-mono text-[13px] tabular-nums text-blue-400"
+        //
+        // blue-500, the SAME step as the ring around a selected card
+        // (`ring-2 ring-blue-500` in graph-item-content). This text is the
+        // count of exactly those ringed cards, so matching the ring is what
+        // ties the number to the thing it counts; blue-400 was a near-miss
+        // that read as a third accent rather than the selection colour.
+        className="shrink-0 font-mono text-[13px] tabular-nums text-blue-500"
       >
         {selectionCount} selected
       </span>

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -796,10 +796,17 @@ export const AnchorControlAndCountBadge: Story = {
     expect(controls()[0]?.getAttribute("aria-label")).toBe("Actions, 2 items selected");
     expect(badges()[0]?.getAttribute("aria-hidden")).toBe("true");
 
-    // Both selected cards keep their badge, the anchor included (R5.3). v2
-    // took the anchor's away, which left it reading as the one selected card
-    // that was not quite selected.
-    expect(doc.querySelectorAll("[data-card-selected-badge]")).toHaveLength(2);
+    // R5.3 used to be checked here as "both selected cards keep their amber
+    // badge, the anchor included". That badge is gone — the ring and the
+    // checkbox already said the same thing in two other places — so what is
+    // left to assert is that the anchor is not marked as LESS selected than its
+    // companion, which is the failure R5.3 existed to prevent.
+    expect(doc.querySelectorAll("[data-card-selected-badge]")).toHaveLength(0);
+    expect(
+      Array.from(doc.querySelectorAll("[data-selected]")).map((el) =>
+        el.getAttribute("data-selected"),
+      ),
+    ).toEqual(["true", "true"]);
   },
 };
 
@@ -1104,12 +1111,14 @@ export const CaptionWithoutTagsHasNoTagRow: Story = {
 };
 
 /**
- * The select-mode checkbox: present only while the mode is armed.
+ * The select-mode checkbox: PINNED ON while the mode is armed.
  *
  * DECORATIVE by necessity — this renders inside NodeCard's real <button>, and a
  * button may not contain interactive content. The assertion that it is not a
  * button is therefore a structural contract, not a style preference: making it
- * one would eject the rest of the card out of its own box.
+ * one would eject the rest of the card out of its own box. It stays true now
+ * that hover reveals the same circle: hovering advertises that the card can be
+ * picked, and the click that picks it belongs to the card underneath.
  */
 export const SelectModeShowsACheckbox: Story = {
   args: mediaArgs,
@@ -1121,9 +1130,14 @@ export const SelectModeShowsACheckbox: Story = {
       return found;
     });
     await expect(indicator.dataset.selectionIndicator).toBe("off");
+    await expect(indicator.dataset.selectionIndicatorReveal).toBe("armed");
     await expect(indicator.getBoundingClientRect().width).toBeGreaterThan(0);
     await expect(indicator.getAttribute("aria-hidden")).toBe("true");
     await expect(indicator.querySelector("button")).toBeNull();
+    // Armed means VISIBLE without a pointer anywhere near it. Opacity rather
+    // than presence, because the hover path below shares this element and only
+    // opacity separates the two states.
+    await expect(getComputedStyle(indicator).opacity).toBe("1");
 
     // ON THE ARTWORK, not on the caption below it. It moved into its own
     // positioning box for exactly this reason, and a regression would drop it
@@ -1135,12 +1149,34 @@ export const SelectModeShowsACheckbox: Story = {
   },
 };
 
-/** Idle, there is no checkbox at all — it is a mode affordance, not chrome. */
-export const NoCheckboxOutsideSelectMode: Story = {
+/**
+ * Idle, the checkbox is RENDERED but invisible, waiting on hover.
+ *
+ * The change from "absent" to "transparent" is the whole mechanism: hover is
+ * owned by CSS so that no pointer state has to reach React, where a hover that
+ * re-rendered every card would land on the drag/INP hot path. So the old
+ * `toBeNull` is the wrong assertion now and would pass for the wrong reason if
+ * the reveal ever broke — opacity is what to measure.
+ *
+ * THE REVEAL ITSELF IS NOT TESTABLE HERE, and the first version of this story
+ * pretended otherwise. `userEvent.hover` dispatches synthetic pointer events;
+ * CSS `:hover` is a browser state driven by real pointer position, and no
+ * synthetic event sets it. The story sat at opacity 0 and failed, which was the
+ * test being wrong rather than the CSS. Real-mouse hover lives in the e2e suite
+ * ("the select checkbox appears on hover…"), which is the layer this repo keeps
+ * for trusted input.
+ */
+export const CheckboxWaitsForHoverOutsideSelectMode: Story = {
   args: mediaArgs,
   decorators: [renderMediaCard({ surface: "grid" })],
   play: async ({ canvasElement }) => {
-    await expect(canvasElement.querySelector("[data-selection-indicator]")).toBeNull();
+    const indicator = canvasElement.querySelector<HTMLElement>("[data-selection-indicator]");
+    await expect(indicator).not.toBeNull();
+    await expect(indicator!.dataset.selectionIndicatorReveal).toBe("hover");
+    await expect(getComputedStyle(indicator!).opacity).toBe("0");
+    // Transparent, NOT display:none — it has to keep its box, or the reveal
+    // would relayout the card under the pointer.
+    await expect(indicator!.getBoundingClientRect().width).toBeGreaterThan(0);
   },
 };
 
@@ -1271,5 +1307,30 @@ export const CollectionSelectModeCheckboxClearsTheMetadata: Story = {
       metadata.getBoundingClientRect().top + 1,
     );
     await expect(metadata.textContent).toContain("2 items");
+  },
+};
+
+/**
+ * The collection card's checkbox waits on hover too.
+ *
+ * Its own story rather than a second case in the media one, because the two
+ * card kinds carry DIFFERENT literal class strings
+ * (`group-hover/collection-item` vs `group-hover/media-item`). Tailwind's JIT
+ * scans source text, so a wrong or interpolated group name produces a class
+ * that is never generated and a checkbox that silently never appears — and the
+ * media story would still be green. Two kinds, two literals, two covers.
+ *
+ * Collections are the kind that needs it most: a plain click drills IN, so this
+ * circle is the only thing on the card that says it can be picked at all.
+ */
+export const CollectionCheckboxWaitsForHover: Story = {
+  args: baseArgs,
+  decorators: [renderWithTags([], "grid")],
+  play: async ({ canvasElement }) => {
+    const indicator = canvasElement.querySelector<HTMLElement>("[data-selection-indicator]");
+    await expect(indicator).not.toBeNull();
+    await expect(indicator!.dataset.selectionIndicatorReveal).toBe("hover");
+    await expect(getComputedStyle(indicator!).opacity).toBe("0");
+    await expect(indicator!.getBoundingClientRect().width).toBeGreaterThan(0);
   },
 };

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -590,82 +590,32 @@ function CollectionLeaderPlaceholder() {
  * interpolated `left-${n}` is a class that never gets generated — the control
  * would silently fall back to `left: auto` and sit in the wrong place.
  */
-/** Left/right inset, shared by every card kind. */
-export const CARD_CONTROL_INSET_LEFT = "left-5";
+/** Right inset, shared by every card kind. (The LEFT twin went with the amber
+ *  selected-badge — it was the only thing in that corner, and nothing has
+ *  replaced it.) */
 export const CARD_CONTROL_INSET_RIGHT = "right-5";
 /** Top inset, `top-3` (12px) rather than the `top-2` these started at: at
  *  8px the controls sat tight under the card's edge once they grew to 28px.
- *  The badge and the corner slot are TOP-ALIGNED and must move together, so
  *  `CardCornerSlot` in graph-anchor-menu carries the literal twin of this —
  *  it cannot import from here without a cycle. */
 export const CARD_CONTROL_INSET_TOP = "top-3";
 
-/**
- * The badge, stood down while select mode is armed.
- *
- * Both exist to make a multi-selection legible at a glance, and in select mode
- * the checkbox does it better: it is on every card, so it shows the UNPICKED
- * ones too, which a badge that only appears when selected cannot. Two marks for
- * one fact, in different corners and different colours, just reads as two
- * different facts.
- *
- * Its own component so neither card shell has to grow a hook for this.
- */
-function CardSelectedBadgeUnlessSelecting() {
-  const selectMode = useCollectionsSelector((s) => s.interaction.multiSelectMode);
-  if (selectMode) return null;
-  return <CardSelectedBadge />;
-}
-
-function CardSelectedBadge() {
-  return (
-    <span
-      data-card-selected-badge
-      aria-hidden="true"
-      className={[
-        "pointer-events-none absolute top-3 z-20 flex items-center justify-center",
-        // NO CHIP, deliberately — this is a STATUS MARK, not a control.
-        //
-        // It has been three things, and the middle one is the instructive
-        // failure. It began as a filled amber block, which at equal measured
-        // size read as larger than its two siblings (irradiation: a bright
-        // shape on a dark ground appears to expand past its own edges). The fix
-        // for that was to give it the same dark chip the drill and overflow
-        // controls wear — which cured the size illusion and immediately caused
-        // a worse problem: it then looked exactly like the two things beside it
-        // that ARE buttons, while being `pointer-events-none`. Matching the
-        // controls' surface is matching their AFFORDANCE, and the affordance is
-        // a lie here.
-        //
-        // A bare glyph carries no surface and so promises no press. The dark
-        // halo does the work the chip used to: it is what keeps amber legible
-        // over bright artwork, without drawing a pressable-looking box.
-        //
-        // Amber stays — it is the selection colour (PL13-006), and that meaning
-        // has to survive however the mark is drawn.
-        "text-amber-300",
-        // FOUR passes, and the mix is the point. Three tight ones stack into a
-        // dense hard edge — each pass darkens what the last left translucent,
-        // which is how a blur becomes an outline — and the fourth, wider and
-        // softer, drops the artwork immediately around the mark so amber still
-        // separates from a sunlit frame.
-        //
-        // Two tight passes was the first attempt and it vanished on bright
-        // thumbnails: enough to define the glyph against mid tones, nowhere near
-        // enough against a lit sky. A single heavier blur is not the fix either
-        // — it reads as a smudge under the mark rather than an edge around it.
-        "[filter:drop-shadow(0_0_1.5px_rgb(9_9_11))_drop-shadow(0_0_1.5px_rgb(9_9_11))_drop-shadow(0_0_1.5px_rgb(9_9_11))_drop-shadow(0_0_3px_rgb(0_0_0/0.85))]",
-        CARD_CONTROL_INSET_LEFT,
-      ].join(" ")}
-    >
-      {/* size-6 and a heavy stroke, where the CONTROLS use size-5 at lucide's
-          default. Deliberately not matched: those glyphs sit inside a 28px chip
-          that lends them presence, and this one has none, so an identical glyph
-          would read as the smaller, fainter mark of the three. */}
-      <Check className="size-6" strokeWidth={3} />
-    </span>
-  );
-}
+// THE AMBER CHECK IN THE TOP-LEFT CORNER IS GONE.
+//
+// It marked a selected card, and by the end it was the third thing doing that.
+// The ring around the card says it (`ring-2 ring-blue-500`), the bottom-right
+// checkbox says it, and this said it a third time in a different corner in a
+// different colour — which reads as three different facts rather than one.
+//
+// The checkbox is the one that survives because it is the one that can say the
+// most: it is on every card, so it shows the UNPICKED ones too, which a mark
+// that only appears when selected never could.
+//
+// Worth keeping from its long comment, for whatever next needs a status mark on
+// artwork: a bare glyph with a layered drop-shadow halo (three tight passes for
+// a hard edge, one wide soft pass to drop the artwork behind it) stays legible
+// over a sunlit frame WITHOUT wearing a chip — and a chip is what made an
+// earlier version read as a button it was not.
 
 // THE SHARED CARD-CONTROL LOOK IS GONE, with the last control that wore it.
 //
@@ -883,11 +833,27 @@ function CaptionTagRow({
  *
  * Nothing is lost in select mode, because the whole card is already the toggle
  * there — the design's card does the same thing (`if (selecting) toggleSelect`),
- * so its checkbox is only ever a second way to hit the same target. What IS
- * lost is the design's hover-to-select-without-opening outside the mode, which
- * is exactly the gesture our shell cannot host. Hence: shown only while the
- * mode is armed, where it is honest about being an indicator rather than
- * offering a click that the card underneath would have handled anyway.
+ * so its checkbox is only ever a second way to hit the same target.
+ *
+ * OUTSIDE the mode it now appears on HOVER, which is the design's own
+ * behaviour. It is still `pointer-events-none`: hovering ADVERTISES that this
+ * card can be picked, and the click that picks it belongs to the card
+ * underneath (or, for a collection, to select mode — a plain click there
+ * drills). Making the circle itself clickable would nest a control inside the
+ * selection surface `<button>`, which is invalid HTML and is pinned against by
+ * the composed-card structure tests.
+ *
+ * DESKTOP ONLY, via `@media (hover: hover)`. A touch device has no hover state
+ * to reveal it with, and without the query a tap would leave the checkbox
+ * stuck on the last-tapped card — the sticky-hover bug — where it would read as
+ * a selection that is not there. The repo writes these as arbitrary variants
+ * (see the `[@media(pointer:coarse)]` sizing elsewhere) rather than trusting a
+ * framework default, so the intent survives a Tailwind upgrade.
+ *
+ * `revealOnHover` is a literal class string per card kind rather than an
+ * interpolated group name: Tailwind's JIT scans source text, so a computed
+ * `group-hover/${kind}` is a class that never gets generated and the checkbox
+ * would silently never appear.
  *
  * Two details worth keeping if this is ever restyled. The check is ALWAYS
  * rendered and only its opacity changes, so the circle never resizes as it
@@ -895,15 +861,42 @@ function CaptionTagRow({
  * a flat chip, because it sits on arbitrary artwork — a light frame and a dark
  * one both have to keep it legible.
  */
-function SelectionIndicator({ selected }: Readonly<{ selected: boolean }>) {
+/** Hover-reveal for a MEDIA card. Whole literal class names — see the note on
+ *  `revealOnHover` above. */
+const SELECT_HOVER_REVEAL_MEDIA = [
+  "opacity-0 motion-safe:transition-opacity motion-safe:duration-150",
+  "[@media(hover:hover)]:group-hover/media-item:opacity-100",
+].join(" ");
+
+/** The same, for a COLLECTION card's group. */
+const SELECT_HOVER_REVEAL_COLLECTION = [
+  "opacity-0 motion-safe:transition-opacity motion-safe:duration-150",
+  "[@media(hover:hover)]:group-hover/collection-item:opacity-100",
+].join(" ");
+
+function SelectionIndicator({
+  selected,
+  armed,
+  revealOnHover,
+}: Readonly<{
+  selected: boolean;
+  /** Select mode is on, so the checkbox is permanent rather than hover-only. */
+  armed: boolean;
+  /** Literal hover-reveal classes for THIS card kind's group. */
+  revealOnHover: string;
+}>) {
   return (
     <span
       aria-hidden="true"
       data-selection-indicator={selected ? "on" : "off"}
+      // Distinguishes "permanently shown because the mode is armed" from
+      // "revealed by the pointer", which a geometry-only assertion cannot see.
+      data-selection-indicator-reveal={armed ? "armed" : "hover"}
       className={[
         "pointer-events-none absolute right-2 bottom-2 z-20 grid size-[26px] place-items-center",
         "rounded-full border-2 backdrop-blur-sm motion-safe:transition-colors",
         selected ? "border-blue-500 bg-blue-500" : "border-white/90 bg-black/35",
+        armed ? "" : revealOnHover,
       ].join(" ")}
     >
       <Check
@@ -1079,8 +1072,18 @@ const GraphClipContent = memo(function GraphClipContent({
       {/* Bottom-RIGHT of the ARTWORK, opposite the duration, so the two never
           contend for a corner — the design makes the same split. Shown on muted
           cards too: a disabled clip is still something you might be gathering
-          up to delete. */}
-      {selectMode && <SelectionIndicator selected={selected} />}
+          up to delete.
+
+          ALWAYS RENDERED now. Select mode pins it on; otherwise it is revealed
+          by hover, on hover-capable devices only. Rendering it unconditionally
+          is what lets CSS own that, so no pointer state has to reach React —
+          a hover that re-rendered every card would land on the drag/INP hot
+          path the playhead comment above is careful about. */}
+      <SelectionIndicator
+        selected={selected}
+        armed={selectMode}
+        revealOnHover={SELECT_HOVER_REVEAL_MEDIA}
+      />
       </span>
       {/* Kind tag (R6 #7): a WORD, bottom-left. The glyph version (a 4px film
           or picture icon in the top corner) was ambiguous at small item sizes
@@ -1500,8 +1503,13 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
         >
           {/* Collections get the same checkbox as media, and they are the cards
               that need it most: a plain click drills INTO a collection now, so
-              select mode is the only pointer route to picking one at all. */}
-          {selectMode && <SelectionIndicator selected={selected} />}
+              select mode is the only pointer route to picking one at all — and
+              on hover this is the only thing that says so. */}
+          <SelectionIndicator
+            selected={selected}
+            armed={selectMode}
+            revealOnHover={SELECT_HOVER_REVEAL_COLLECTION}
+          />
           {previews.length === 0 ? (
             <span
               data-empty-collection-preview
@@ -1654,13 +1662,10 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
           O key (OpenKeyBoundary), and data-collections-keyboard-ignore excludes
           them from the strip's pan surface (isPannableStripSurface), so a press
           here never scrolls the strip out from under it. */}
-      {/* Every selected card keeps its badge, the anchor included (R5.3). In
-          v2 the anchor gave it up to make room for a toolbar in the same band,
-          and the missing checkmark was doing double duty as "this is the
-          anchor" — which meant the anchor read as the one selected card that
-          was not quite selected. The `⋮` and its count say "anchor" now, so the
-          selection signal can be consistent across all of them. */}
-      {selected && <CardSelectedBadgeUnlessSelecting />}
+      {/* (No selected-badge here any more — see the note by the checkbox. R5.3
+          was "every selected card keeps its badge, the anchor included", and
+          that stays true of the marks that remain: the ring is on every
+          selected card, anchor or not, so nothing reads as almost-selected.) */}
       {/* THE DRILL CONTROL IS GONE. The slot now hosts only the anchor's `⋮`.
 
           It was the one pointer route into a collection back when a plain click
@@ -1777,14 +1782,12 @@ const GraphMediaItem = memo(function GraphMediaItem({
   ...props
 }: CollectionItemShellProps) {
   const node = useCollectionsSelector((s) => s.graph.nodesById.get(props.id) ?? null);
-  // NodeCard knows whether it is selected, but keeps it inside its own shell —
-  // and the badge has to be a SIBLING of that shell, like everything else here,
-  // because a span inside the card's `<button>` would still be inside a button.
-  // A boolean selector, so this re-renders only when THIS card's selection
-  // actually flips, not on every selection change on the board.
-  const mediaSelected = useCollectionsSelector((s) =>
-    s.interaction.selectedIds.has(props.id),
-  );
+  // (A per-card `selectedIds` subscription lived here to drive the amber
+  // selected-badge, which was a SIBLING of NodeCard's shell because a span
+  // inside the card's `<button>` would still be inside a button. The badge is
+  // gone and the marks that replaced it live inside the card, where NodeCard
+  // already knows its own selection — so this shell no longer subscribes at
+  // all, and a selection change on the board re-renders one card fewer.)
   const detail = useClipDetail(props.id as string);
   // Seeded with the AUTHORED title when there is one, so re-naming edits what
   // the user wrote rather than making them delete a filename first.
@@ -1798,9 +1801,10 @@ const GraphMediaItem = memo(function GraphMediaItem({
   return (
     <div ref={sizeRef} className={["group/media-item relative", className ?? ""].join(" ")}>
       <NodeCard {...props} className="h-full w-full" />
-      {/* The anchor keeps its badge too (R5.3) — see the collection card. It
-          clears the trim handles, which a selected clip always carries. */}
-      {mediaSelected && <CardSelectedBadgeUnlessSelecting />}
+      {/* (The selected-badge that used to sit here is gone with its collection
+          twin. It was the mark that had to clear a selected clip's LEFT trim
+          handle; nothing occupies that corner now, so only the `⋮` below still
+          owes the handles clearance.) */}
       {/* A clip has no chevron to morph, so the `⋮` simply fades in (R5.6).
           No chevron is added here for symmetry. */}
       <ClipCornerSlot nodeId={props.id} width={size.width} />

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -6590,10 +6590,92 @@ test.describe("graph view E2E", () => {
     await expect(page.locator('[data-selected="true"]')).toHaveCount(1);
   });
 
+  test("the select checkbox is revealed by a real hover, and pinned on by select mode", async ({
+    page,
+  }) => {
+    // E2E RATHER THAN A STORY, and not by preference. The reveal is CSS
+    // `:hover`, which is browser state driven by real pointer position — no
+    // synthetic event sets it, so a story using `userEvent.hover` measures
+    // opacity 0 forever and fails for a reason that has nothing to do with the
+    // component. Trusted mouse input is this suite's job.
+    //
+    // It is also the only check that the Tailwind class is REAL. The reveal is
+    // a literal `[@media(hover:hover)]:group-hover/media-item:opacity-100`;
+    // Tailwind's JIT scans source text, so a mistyped or interpolated group
+    // name yields a class that is never generated and a checkbox that silently
+    // never appears. Nothing but a computed style catches that.
+    await installGraphApi(page);
+    await openGraph(page);
+    const surface = strip(page, PROJECT_ID);
+    const card = surface.locator('[data-node-id="alpha"]');
+    const checkbox = card.locator("[data-selection-indicator]");
+    const opacity = () =>
+      checkbox.evaluate((element) => getComputedStyle(element).opacity);
+
+    // RENDERED but transparent, with nothing selected and the pointer away. Not
+    // absent: it keeps its box so the reveal cannot relayout the card under the
+    // pointer, which is also why presence is the wrong thing to assert.
+    await expect(checkbox).toHaveAttribute("data-selection-indicator-reveal", "hover");
+    await page.mouse.move(0, 0);
+    await expect.poll(opacity).toBe("0");
+
+    await card.hover();
+    await expect.poll(opacity).toBe("1");
+
+    // And away again — a checkbox left behind would read as a selection that
+    // is not there.
+    await page.mouse.move(0, 0);
+    await expect.poll(opacity).toBe("0");
+
+    // SELECT MODE pins it on with the pointer nowhere near the card: the mode
+    // needs every card to show its state at once, unpicked ones included, which
+    // a hover reveal can never do for more than one card at a time.
+    await card.click();
+    await toggleMultiSelect(page);
+    await page.mouse.move(0, 0);
+    await expect(checkbox).toHaveAttribute("data-selection-indicator-reveal", "armed");
+    await expect.poll(opacity).toBe("1");
+  });
+
   // Its own context: `hasTouch` sets maxTouchPoints, which is what makes
   // Chromium report `pointer: coarse` — the query the sizing keys off.
   test.describe(() => {
     test.use({ hasTouch: true });
+
+    test("touch gets NO hover checkbox — tapping a card never leaves one stuck on", async ({
+      page,
+    }) => {
+      // The other half of the desktop-only reveal, and the reason the CSS
+      // carries an explicit `@media (hover: hover)` instead of trusting a
+      // framework default. Without the query, a tap sets `:hover` on the
+      // tapped card and Chromium LEAVES IT THERE until something else is
+      // touched — so the checkbox would sit on the last card tapped, saying
+      // "picked" about a card that is not.
+      await installGraphApi(page);
+      await openGraph(page);
+      const surface = strip(page, PROJECT_ID);
+      const card = surface.locator('[data-node-id="alpha"]');
+      const checkbox = card.locator("[data-selection-indicator]");
+      const opacity = () =>
+        checkbox.evaluate((element) => getComputedStyle(element).opacity);
+
+      // The premise, asserted first — `hasTouch` is what makes Chromium report
+      // this, and without it the checks below would pass for the wrong reason.
+      expect(await page.evaluate(() => window.matchMedia("(hover: none)").matches)).toBe(true);
+
+      await expect.poll(opacity).toBe("0");
+      await card.tap();
+      await expect(card).toHaveAttribute("data-selected", "true", { timeout: 2000 });
+      // Selected, and STILL no checkbox: on touch the ring is the whole
+      // selection signal outside select mode.
+      await expect.poll(opacity).toBe("0");
+
+      // Select mode still works here — it is a mode, not a hover affordance,
+      // and touch is exactly the input that has no other way to multi-select.
+      await toggleMultiSelect(page);
+      await expect(checkbox).toHaveAttribute("data-selection-indicator-reveal", "armed");
+      await expect.poll(opacity).toBe("1");
+    });
 
     test("touch gets 44px hit targets on every selection control", async ({ page }) => {
       await installGraphApi(page);
@@ -6735,12 +6817,17 @@ test.describe("graph view E2E", () => {
     await expect(page.locator(`[data-anchor-menu='${CHILD_ID}']`)).toBeVisible();
 
     // R5.3, and the v2 behaviour this REVERSES. The anchor used to give up its
-    // badge to make room for a pill in the same band, which left the anchor
-    // reading as the one selected card that was not quite selected. Nothing
-    // competes for that corner now, so the selection signal is consistent
-    // across the whole selection and the ⋮ alone says "anchor".
-    await expect(wrapper(CHILD_ID).locator("[data-card-selected-badge]")).toHaveCount(1);
-    await expect(page.locator("[data-card-selected-badge]")).toHaveCount(2);
+    // amber badge to make room for a pill in the same band, which left the
+    // anchor reading as the one selected card that was not quite selected.
+    //
+    // That badge is gone entirely now — the ring and the checkbox were already
+    // saying the same thing in two other places — so the rule is checked on
+    // what remains: both cards carry the selected state, and the anchor is not
+    // marked as any less selected than its companion. The `⋮` alone says
+    // "anchor".
+    await expect(page.locator("[data-card-selected-badge]")).toHaveCount(0);
+    await expect(wrapper(CHILD_ID).locator('[data-selected="true"]')).toHaveCount(1);
+    await expect(page.locator('[data-selected="true"]')).toHaveCount(2);
 
     // "Nothing competes for that corner", asserted rather than asserted-by-
     // comment. This used to be a CROSS-FADE: the corner held a drill chevron
@@ -6793,10 +6880,15 @@ test.describe("graph view E2E", () => {
     }
   });
 
-  test("the corner controls clear a selected clip's trim handles", async ({ page }) => {
+  test("the corner control clears a selected clip's trim handles", async ({ page }) => {
     // A trim handle's hit zone is 8px pinned to the card's edge, and the
-    // ordinary corner inset is also 8px — so the checkmark and the ⋮ sat flush
-    // against the amber handles, reading as one crowded cluster.
+    // ordinary corner inset is also 8px — so the ⋮ sat flush against the amber
+    // handles, reading as one crowded cluster.
+    //
+    // ONE control now, not two. The amber checkmark in the opposite corner had
+    // the same clearance to keep against the LEFT handle, and it is gone — so
+    // that half of this measurement went with it rather than being kept alive
+    // against an element that no longer exists.
     //
     // Measured as a GAP rather than asserted on a class, because the failure is
     // geometric: the inset, the handle width and the card's own box all feed
@@ -6806,29 +6898,23 @@ test.describe("graph view E2E", () => {
     const surface = strip(page, PROJECT_ID);
     await surface.locator('[data-node-id="alpha"]').click();
 
-    const gaps = await page.evaluate(() => {
+    const gap = await page.evaluate(() => {
       const card = document.querySelector('[data-node-id][data-selected="true"]');
       const wrap = card?.closest("[data-node-wrapper]");
       const box = (sel: string, root: ParentNode | null | undefined) =>
         root?.querySelector(sel)?.getBoundingClientRect() ?? null;
       const right = box('[data-trim-handle="right"]', wrap);
-      const left = box('[data-trim-handle="left"]', wrap);
-      const badge = box("[data-card-selected-badge]", document);
       const dots = box("[data-anchor-menu]", document);
-      return {
-        // Null when that handle does not exist (images have no left handle),
-        // which the assertions below treat as "nothing to clear".
-        beforeRightHandle: right && dots ? Math.round(right.left - dots.right) : null,
-        pastLeftHandle: left && badge ? Math.round(badge.left - left.right) : null,
-      };
+      return right && dots ? Math.round(right.left - dots.right) : null;
     });
 
+    // Not null, asserted rather than tolerated: alpha is a VIDEO and always has
+    // a right handle, so a null here means the measurement found nothing and
+    // the test would otherwise pass having checked nothing at all.
+    expect(gap).not.toBeNull();
     // Flush was 0. Anything at or above the handle's own width reads as
     // deliberate separation rather than a near-miss.
-    if (gaps.beforeRightHandle !== null) expect(gaps.beforeRightHandle).toBeGreaterThanOrEqual(6);
-    if (gaps.pastLeftHandle !== null) expect(gaps.pastLeftHandle).toBeGreaterThanOrEqual(6);
-    // At least one handle must have been found, or this asserted nothing.
-    expect(gaps.beforeRightHandle ?? gaps.pastLeftHandle).not.toBeNull();
+    expect(gap!).toBeGreaterThanOrEqual(6);
   });
 
   test("the count badge appears at 2+, and is absent at exactly 1", async ({ page }) => {


### PR DESCRIPTION
Three marks were saying "selected" — the ring around the card, the bottom-right checkbox, and an amber check in the top-left corner — in three places and three colours. Read together they look like three different facts.

## The checkbox now appears on hover (desktop)

It was shown only while select mode was armed, on the reasoning that outside the mode it would offer a click the card underneath already handled. **It still does not offer that click** — it stays `pointer-events-none`, because making the circle interactive would nest a control inside the selection surface `<button>`, which is invalid HTML and is pinned against by the composed-card tests. What it does now is *advertise* that the card can be picked — the thing collections most needed, since a plain click drills into one and nothing on the card said there was another option.

Desktop only, via an explicit `@media (hover: hover)` rather than a framework default: without the query a tap sets `:hover` on the tapped card and Chromium leaves it there, so the checkbox would sit on the last card touched claiming a selection that isn't there.

Hover is owned entirely by CSS — the indicator is always rendered and only its opacity changes, so no pointer state reaches React. A hover that re-rendered every card would land on the drag/INP hot path.

## The amber top-left check is gone

The checkbox is the mark worth keeping because it's the one that can say the most: it's on every card, so in select mode it shows the **unpicked** ones too, which a badge that only appears when selected never could.

Its shell's per-card `selectedIds` subscription goes with it, so a selection change re-renders one card fewer. `CARD_CONTROL_INSET_LEFT` goes too — it was the only thing in that corner.

## The select-mode count matches the ring

`text-blue-400` → `text-blue-500`, the same step as `ring-2 ring-blue-500` on a selected card. The text counts exactly those ringed cards; the near-miss read as a third accent rather than as the selection colour.

## Tests — and a correction worth recording

The hover reveal **cannot** be tested in a story. `userEvent.hover` dispatches synthetic events, and CSS `:hover` is browser state that no synthetic event sets — so my first attempt sat at opacity 0 and failed. That was the test being wrong, not the CSS. Real-mouse hover moved to the e2e suite, the layer this repo keeps for trusted input.

It's also the only check that the Tailwind class is *real*: the reveal is a literal `[@media(hover:hover)]:group-hover/media-item:opacity-100`, and the JIT scans source text — a mistyped or interpolated group name yields a class that is never generated and a checkbox that silently never appears. The two card kinds carry different literals, so both are covered.

New e2e:
- hover reveals and un-reveals it; select mode pins it on with the pointer away
- under `hasTouch` (verified to report `hover: none`) a tap leaves no checkbox behind, while select mode still arms one

Stories keep the at-rest half — rendered, transparent, still occupying its box so the reveal cannot relayout the card under the pointer.

## Verification

| suite | result |
| --- | --- |
| e2e (`--project=graph-view`) | 149/149 |
| stories (`--project=storybook`) | 184/184 |
| app (`npx vitest run`) | 702/702 |
| `tsc --noEmit` (app + `packages/ui`) | clean |
| `npm run lint` | 0 errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)