### PR TITLE
Show the select row from the first click, at the breadcrumb's exact height, and put the count badge in selection blue

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-anchor-menu.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-anchor-menu.tsx
@@ -81,11 +81,17 @@ function AnchorCountBadge({ count }: Readonly<{ count: number }>) {
         // `rounded-full` + `min-width: height` is a circle at one digit and a
         // stadium at two or more, from ONE rule (R6.6). No digit special-casing.
         "rounded-full text-[10px] font-semibold leading-none",
-        // Amber on near-black, verified against the lightest thumbnails in the
-        // library rather than a mid-tone (R6.11): the badge sits over card
-        // artwork that includes near-white content, so it carries its own
-        // opaque fill and a dark ring to hold an edge against it.
-        "bg-amber-300 text-zinc-950 ring-1 ring-zinc-950/60",
+        // SELECTION BLUE with white text — the same step as the ring around a
+        // selected card and the checkbox fill. This badge counts exactly those
+        // cards, so it should wear their colour; amber-on-near-black was left
+        // over from when amber was the selection colour and had become the only
+        // thing on the board still saying so.
+        //
+        // The opaque fill and dark ring stay, and the reason is unchanged
+        // (R6.11): the badge sits over card artwork that includes near-white
+        // content, verified against the lightest thumbnails in the library
+        // rather than a mid-tone, so it cannot rely on the artwork behind it.
+        "bg-blue-500 text-white ring-1 ring-zinc-950/60",
         // Proportional digits jitter the width as a shift-drag sweeps through
         // counts (R6.7).
         "tabular-nums",

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -932,8 +932,13 @@ function SelectModeHeader({ anchorName }: Readonly<{ anchorName: string | null }
         // BORDERED, unlike every other control on this row. It is the way out,
         // and the only one here that is not a verb acting on the selection —
         // an outline is what separates "leave" from "do something to these".
+        //
+        // `h-8`, matching every other header control (HEADER_SELECTION_SIZE).
+        // It was `h-9`, and that 4px was the whole reason entering select mode
+        // nudged the board down: this is the tallest thing in the row, so it
+        // alone set the header's height — 61px against the browse row's 57.
         className={cn(
-          "ml-auto h-9 shrink-0 rounded-lg border border-zinc-700 px-3.5 text-[13px] font-medium",
+          "ml-auto h-8 shrink-0 rounded-lg border border-zinc-700 px-3.5 text-[13px] font-medium",
           "[@media(pointer:coarse)]:h-11",
           "text-zinc-100 hover:border-zinc-500 hover:bg-transparent hover:text-white",
         )}
@@ -1152,13 +1157,9 @@ export function GraphBoard({
     anchorId === null ? null : (s.graph.nodesById.get(anchorId)?.name ?? null),
   );
 
-  // Which face the header row wears. Three conditions, and each is load-bearing:
+  // Which face the header row wears. Two conditions now:
   //
   //   the mode is armed  — this row belongs to select mode, nothing else.
-  //   something is held  — see SelectModeHeader: an empty selection has nothing
-  //                        to report, and taking the trail away while the user
-  //                        is still navigating to find their items is exactly
-  //                        backwards.
   //   nothing is dragging — the ancestor crumbs ARE the "move up a level" drop
   //                        targets (see GraphBreadcrumb), and a multi-drag out
   //                        of a selection is precisely when someone reaches for
@@ -1167,10 +1168,17 @@ export function GraphBoard({
   //                        selection bar has nothing to offer during a drag
   //                        anyway — DragChromeFade fades the rest of the chrome
   //                        for the same reason.
+  //
+  // There used to be a third — `selectionSize > 0` — on the reasoning that an
+  // empty selection has nothing to report, so taking the trail away while the
+  // user is still navigating to find their items was backwards. It is dropped
+  // deliberately: pressing Select is the user SAYING they are about to pick
+  // things, and a mode that shows no sign of itself until the first item lands
+  // reads as a button that did nothing. The row at zero is not empty either —
+  // it says "0 selected" and offers Done, which is the way back out.
   const multiSelectMode = useCollectionsSelector((s) => s.interaction.multiSelectMode);
-  const selectionSize = useCollectionsSelector((s) => s.interaction.selectedIds.size);
   const isDragging = useCollectionsSelector((s) => s.interaction.isDragging);
-  const selectModeRow = multiSelectMode && selectionSize > 0 && !isDragging;
+  const selectModeRow = multiSelectMode && !isDragging;
 
   return (
     <OpenKeyBoundary trashId={trashRootId}>

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -6577,17 +6577,62 @@ test.describe("graph view E2E", () => {
     // when the key is pressed with a card focused, and does not when focus is
     // left wherever the closing menu put it — a difference this test should not
     // encode, because the guarantee below holds either way.
+    //
+    // WHICH control it is now depends on the row. The select row replaces the
+    // breadcrumb the moment the mode is armed — including at zero selected —
+    // and the header's Select toggle goes with the browse row it lives in. So
+    // armed-and-empty is served by Done, and only the disarmed state shows the
+    // toggle. The guarantee is unchanged and is what this asserts: whatever the
+    // selection, SOME visible control reports the mode and turns it off.
+    const header = page.locator("[data-graph-board-header]");
     const headerToggle = page.locator("[data-select-mode-toggle]");
-    await expect(headerToggle).toBeVisible();
-    if ((await headerToggle.getAttribute("data-select-mode-toggle")) === "on") {
-      await headerToggle.click();
+    if ((await header.getAttribute("data-header-mode")) === "select") {
+      const done = page.getByRole("button", { name: "Done" });
+      await expect(done).toBeVisible();
+      await done.click();
     }
+    await expect(header).toHaveAttribute("data-header-mode", "browse");
+    await expect(headerToggle).toBeVisible();
     await expect(headerToggle).toHaveAttribute("data-select-mode-toggle", "off");
 
     // With it off, plain clicks REPLACE rather than accumulate.
     await surface.locator('[data-node-id="bravo"]').click();
     await surface.locator('[data-node-id="charlie"]').click();
     await expect(page.locator('[data-selected="true"]')).toHaveCount(1);
+  });
+
+  test("select mode takes the breadcrumb's place at the SAME height, from the first click", async ({
+    page,
+  }) => {
+    // TWO promises in one test because they are one experience: pressing
+    // Select swaps the row, and the swap must not move the board.
+    //
+    // The height half is measured, not asserted on classes. Entering the mode
+    // pushed everything down 4px — the row is sized by its tallest child, the
+    // Done button was `h-9` where every other header control is `h-8`, and
+    // nothing connected those two numbers. 61px against 57px.
+    await installGraphApi(page);
+    await openGraph(page);
+    const header = page.locator("[data-graph-board-header]");
+    const height = () =>
+      header.evaluate((element) => Math.round(element.getBoundingClientRect().height));
+
+    await expect(header).toHaveAttribute("data-header-mode", "browse");
+    const browseHeight = await height();
+
+    // ARMED WITH NOTHING SELECTED is the case that regressed: the row used to
+    // wait for `selectionSize > 0`, so pressing Select left the breadcrumb up
+    // and read as a button that did nothing. Clear the selection that arming
+    // the mode required, and the row must stay.
+    await strip(page, PROJECT_ID).locator('[data-node-id="alpha"]').click();
+    await toggleMultiSelect(page);
+    await page.keyboard.press("Escape");
+    await expect.poll(() => page.locator('[data-selected="true"]').count()).toBe(0);
+    await expect(header).toHaveAttribute("data-header-mode", "select");
+    await expect(page.locator("[data-select-mode-count]")).toHaveText("0 selected");
+
+    // Same height at zero, and the board underneath has not moved.
+    expect(await height()).toBe(browseHeight);
   });
 
   test("the select checkbox is revealed by a real hover, and pinned on by select mode", async ({


### PR DESCRIPTION
Three fixes to the select-mode header, all reported from using it.

## The row appears when the mode is armed, not when the first item lands

It was gated on `multiSelectMode && selectionSize > 0`, reasoning that an empty selection has nothing to report and taking the breadcrumb away mid-navigation is backwards. That loses to the simpler fact it ignored: **pressing Select *is* the user saying they're about to pick things**, and a mode that shows no sign of itself until the first item reads as a button that did nothing.

At zero the row isn't empty either — it says "0 selected" and offers Done, which is the way back out.

The `!isDragging` condition stays, and is unrelated: the ancestor crumbs are the "move up a level" drop targets, so hiding the trail mid-drag would delete the target the user is aiming at.

## Same height as the breadcrumb row

Entering select mode no longer nudges the board down. Measured rather than eyeballed:

| row | before | after |
|---|---|---|
| browse | 57px | 57px |
| select | **61px** | **57px** |

The row is sized by its tallest child, and Done was `h-9` where every other header control is `h-8` (`HEADER_SELECTION_SIZE`) — two numbers with nothing connecting them.

## The count badge is selection blue

White text on `blue-500`, not amber on black. It counts exactly the ringed cards, so it should wear their colour; amber was left over from when amber was the selection colour and had become the last thing on the board still saying so.

The opaque fill and dark ring stay for the original reason (R6.11) — the badge sits over artwork that includes near-white content, so it can't rely on what's behind it.

## One test followed the control rather than being silenced

*"the mode always has a visible control, whatever the selection"* pins that armed-and-empty can never be a mode with no way out. The select row now replaces the browse row that hosts the Select toggle, so at zero selected that control is **Done** instead. The guarantee is intact; the test asserts it against whichever row is showing.

New regression test covers both halves of the first two fixes: armed with nothing selected, the row is present, says "0 selected", and measures exactly the browse row's height.

## Verification

e2e 150/150 · stories 184/184 · typecheck clean · lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)