### PR TITLE
Make the hover checkbox a real toggle, and stop it being a trap when hidden

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -835,13 +835,14 @@ function CaptionTagRow({
  * there — the design's card does the same thing (`if (selecting) toggleSelect`),
  * so its checkbox is only ever a second way to hit the same target.
  *
- * OUTSIDE the mode it now appears on HOVER, which is the design's own
- * behaviour. It is still `pointer-events-none`: hovering ADVERTISES that this
- * card can be picked, and the click that picks it belongs to the card
- * underneath (or, for a collection, to select mode — a plain click there
- * drills). Making the circle itself clickable would nest a control inside the
- * selection surface `<button>`, which is invalid HTML and is pinned against by
- * the composed-card structure tests.
+ * OUTSIDE the mode it appears on HOVER, which is the design's own behaviour,
+ * and CLICKING IT TOGGLES. That matters most on a collection: the rest of that
+ * card drills in, so this circle is the only pointer route to picking one
+ * without entering select mode first.
+ *
+ * It is a span that handles its own click rather than a `<button>` — see the
+ * note on the element itself for why, and for the keyboard path that covers
+ * what a non-focusable control gives up.
  *
  * DESKTOP ONLY, via `@media (hover: hover)`. A touch device has no hover state
  * to reveal it with, and without the query a tap would leave the checkbox
@@ -861,20 +862,30 @@ function CaptionTagRow({
  * a flat chip, because it sits on arbitrary artwork — a light frame and a dark
  * one both have to keep it legible.
  */
-/** Hover-reveal for a MEDIA card. Whole literal class names — see the note on
- *  `revealOnHover` above. */
+// Hover-reveal, per card kind. Whole literal class names — see the note on
+// `revealOnHover` above.
+//
+// `pointer-events-none` travels WITH the opacity and is not decoration: the
+// checkbox is a click target now, and an invisible one would be a trap. On
+// touch the `@media (hover: hover)` gate never opens, so without this a tap in
+// the card's bottom-right corner would toggle a selection through a control the
+// user cannot see. Hidden means unclickable, in the same rule, so the two can
+// never drift apart.
 const SELECT_HOVER_REVEAL_MEDIA = [
-  "opacity-0 motion-safe:transition-opacity motion-safe:duration-150",
+  "pointer-events-none opacity-0 motion-safe:transition-opacity motion-safe:duration-150",
+  "[@media(hover:hover)]:group-hover/media-item:pointer-events-auto",
   "[@media(hover:hover)]:group-hover/media-item:opacity-100",
 ].join(" ");
 
 /** The same, for a COLLECTION card's group. */
 const SELECT_HOVER_REVEAL_COLLECTION = [
-  "opacity-0 motion-safe:transition-opacity motion-safe:duration-150",
+  "pointer-events-none opacity-0 motion-safe:transition-opacity motion-safe:duration-150",
+  "[@media(hover:hover)]:group-hover/collection-item:pointer-events-auto",
   "[@media(hover:hover)]:group-hover/collection-item:opacity-100",
 ].join(" ");
 
 function SelectionIndicator({
+  id,
   selected,
   armed,
   revealOnHover,
@@ -884,7 +895,10 @@ function SelectionIndicator({
   armed: boolean;
   /** Literal hover-reveal classes for THIS card kind's group. */
   revealOnHover: string;
+  /** The card this toggles. */
+  id: NodeId;
 }>) {
+  const store = useCollectionsStore();
   return (
     <span
       aria-hidden="true"
@@ -892,8 +906,29 @@ function SelectionIndicator({
       // Distinguishes "permanently shown because the mode is armed" from
       // "revealed by the pointer", which a geometry-only assertion cannot see.
       data-selection-indicator-reveal={armed ? "armed" : "hover"}
+      // THE CHECKBOX IS THE TOGGLE, and on a collection it is the only one: the
+      // rest of that card drills in, so without this there is no pointer route
+      // to picking a collection outside select mode at all.
+      //
+      // A SPAN with its own click, not a <button>. This renders inside the
+      // card's selection surface, which IS a button, and nesting interactive
+      // semantics is invalid HTML — the composed-card tests pin that. The
+      // precedent is a few lines down: the collection's NAME span swallows its
+      // own click the same way so the card body's drill-in does not fire under
+      // it. `stopPropagation` is what makes that work; React's synthetic
+      // bubbling never reaches the surface's handler.
+      //
+      // The cost is that this is not keyboard-reachable, which is why it stays
+      // `aria-hidden`. Keyboard users are not stranded: select mode plus Space
+      // on the focused card is the same toggle, and it is the path a screen
+      // reader is already told about through the card's own name and state.
+      onPointerDown={(event) => event.stopPropagation()}
+      onClick={(event) => {
+        event.stopPropagation();
+        store.toggleSelected(id);
+      }}
       className={[
-        "pointer-events-none absolute right-2 bottom-2 z-20 grid size-[26px] place-items-center",
+        "absolute right-2 bottom-2 z-20 grid size-[26px] cursor-pointer place-items-center",
         "rounded-full border-2 backdrop-blur-sm motion-safe:transition-colors",
         selected ? "border-blue-500 bg-blue-500" : "border-white/90 bg-black/35",
         armed ? "" : revealOnHover,
@@ -1080,6 +1115,7 @@ const GraphClipContent = memo(function GraphClipContent({
           a hover that re-rendered every card would land on the drag/INP hot
           path the playhead comment above is careful about. */}
       <SelectionIndicator
+        id={id}
         selected={selected}
         armed={selectMode}
         revealOnHover={SELECT_HOVER_REVEAL_MEDIA}
@@ -1506,6 +1542,7 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
               select mode is the only pointer route to picking one at all — and
               on hover this is the only thing that says so. */}
           <SelectionIndicator
+            id={id}
             selected={selected}
             armed={selectMode}
             revealOnHover={SELECT_HOVER_REVEAL_COLLECTION}

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -6635,6 +6635,59 @@ test.describe("graph view E2E", () => {
     expect(await height()).toBe(browseHeight);
   });
 
+  test("clicking the checkbox toggles — on a collection, where the rest of the card drills", async ({
+    page,
+  }) => {
+    // THE COLLECTION CASE IS THE POINT. A plain click on a collection card
+    // drills in, so before this the only pointer route to picking one was to
+    // enter select mode first. The checkbox is that route, and it has to work
+    // WITHOUT navigating — a toggle that also drilled would be useless.
+    await installGraphApi(page);
+    await openGraph(page);
+    const surface = strip(page, PROJECT_ID);
+    const collection = surface.locator(`[data-node-id="${CHILD_ID}"]`);
+    const checkbox = collection.locator("[data-selection-indicator]");
+
+    // Hover to reveal it, then click IT rather than the card.
+    await collection.hover();
+    await expect.poll(() => checkbox.evaluate((e) => getComputedStyle(e).opacity)).toBe("1");
+    await checkbox.click();
+
+    // Selected, and still on the project — the drill-in did not fire underneath.
+    await expect(collection).toHaveAttribute("data-selected", "true");
+    await expect(page).toHaveURL(new RegExp(`${GRAPH_URL}(\\?.*)?$`));
+    await expect(strip(page, PROJECT_ID)).toHaveCount(1);
+
+    // And it TOGGLES: a second click takes it back off, still without drilling.
+    await checkbox.click();
+    await expect(collection).not.toHaveAttribute("data-selected", "true");
+    await expect(page).toHaveURL(new RegExp(`${GRAPH_URL}(\\?.*)?$`));
+
+    // The media card's checkbox toggles the same way — one grammar, both kinds.
+    const alpha = surface.locator('[data-node-id="alpha"]');
+    await alpha.hover();
+    await alpha.locator("[data-selection-indicator]").click();
+    await expect(alpha).toHaveAttribute("data-selected", "true");
+  });
+
+  test("a hidden checkbox is not a click trap", async ({ page }) => {
+    // The checkbox is a click target now, and it is revealed by opacity rather
+    // than by mounting — so `pointer-events` has to travel with the opacity or
+    // there is an invisible toggle sitting in every card's corner. Worst on
+    // touch, where the hover gate never opens at all and the control would be
+    // permanently invisible AND permanently clickable.
+    await installGraphApi(page);
+    await openGraph(page);
+    const alpha = strip(page, PROJECT_ID).locator('[data-node-id="alpha"]');
+    const checkbox = alpha.locator("[data-selection-indicator]");
+
+    await page.mouse.move(0, 0);
+    await expect
+      .poll(() => checkbox.evaluate((e) => getComputedStyle(e).pointerEvents))
+      .toBe("none");
+    await expect.poll(() => checkbox.evaluate((e) => getComputedStyle(e).opacity)).toBe("0");
+  });
+
   test("the select checkbox is revealed by a real hover, and pinned on by select mode", async ({
     page,
   }) => {


### PR DESCRIPTION
The circle revealed on hover advertised that a card could be picked without offering the click that picks it. Clicking it now toggles that card's selection.

## The collection case is the point

A plain click on a collection card drills in, so before this the only pointer route to picking one was to enter select mode first — the checkbox was pointing at an action it wouldn't perform. It toggles **without navigating** now, which is the whole reason it's worth having on that card kind.

## A span that handles its own click, not a `<button>`

This renders inside the card's selection surface, which *is* a button, and nesting interactive semantics is invalid HTML — the composed-card structure tests pin that, in both the e2e suite and the stories.

The precedent is a few lines below it: the collection's **name** span already swallows its own click so the card body's drill-in doesn't fire underneath. `stopPropagation` is what makes both work — React's synthetic bubbling never reaches the surface handler.

What that gives up is keyboard reach, which is why the circle stays `aria-hidden`. Keyboard users aren't stranded: select mode plus Space on the focused card is the same toggle, reached through the card's own name and state rather than through a control a screen reader was never told about.

## Hidden now means unclickable

`pointer-events-none` travels with the opacity **in the same rule**, so the two can't drift apart.

Without it the reveal would have left an invisible toggle in the bottom-right corner of every card — worst on touch, where the `@media (hover: hover)` gate never opens, so the control would be permanently invisible *and* permanently clickable, and a tap near the corner would silently select something.

## Tests

Two new e2e tests, both real-mouse:
- the checkbox toggles a **collection** on and off while the URL never changes (proving the drill-in didn't fire underneath), and the same grammar works on a media card
- a checkbox at rest computes `pointer-events: none`, not merely `opacity: 0`

## Verification

e2e 152/152 · stories 184/184 · typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)