### PR TITLE
Move the grid card's ⋮ down into the caption, off the artwork

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-anchor-menu.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-anchor-menu.tsx
@@ -277,7 +277,27 @@ export function CardCornerSlot({
       // trim handles, which only CLIPS have, but every card kind uses it: at
       // 8px on collections and 20px on clips the controls visibly jumped
       // between card kinds in the same grid.
-      className={cn("absolute right-5 top-3 z-20 flex items-center gap-1.5", className)}
+      className={cn(
+        "absolute right-5 top-3 z-20 flex items-center gap-1.5",
+        // GRID: down into the CAPTION band, trailing the name — the mockup's
+        // shape, where the title row is chrome (type, name, actions) and the
+        // thumbnail stays content. Over the artwork it was the one piece of
+        // chrome still stamped across the picture.
+        //
+        // Anchored to the card's BOTTOM rather than to the caption's top, and
+        // that is what makes one offset work for both card kinds: a media
+        // caption (name + meta/tags) and a collection caption (name + count,
+        // plus optional tags) are different heights, but both END at the card's
+        // bottom padding. Measured on a 220px grid cell: artwork ends at 247,
+        // the caption band runs 247-292, the card ends at 298 — so `bottom-3`
+        // lands inside the band on either kind.
+        //
+        // The STRIP keeps the corner. Its cards are as narrow as their duration
+        // and have no caption row to sit in, which is the same reason the kind
+        // icon and the caption tags are grid-only.
+        "[[data-virtual-grid]_&]:top-auto [[data-virtual-grid]_&]:bottom-3 [[data-virtual-grid]_&]:right-3",
+        className,
+      )}
     >
       <span className="relative grid size-6 place-items-center">
         {showMenu ? (

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -6635,6 +6635,88 @@ test.describe("graph view E2E", () => {
     expect(await height()).toBe(browseHeight);
   });
 
+  test("in the grid the anchor's ⋮ sits in the CAPTION, not on the artwork", async ({
+    page,
+  }) => {
+    // The mockup's split: the title row is chrome (type, name, actions) and the
+    // thumbnail is content. Ours had the one remaining piece of chrome stamped
+    // across the picture, in the top-right corner.
+    //
+    // Measured as bands rather than asserted on classes, because the property
+    // is positional and three things feed it — the card's own box, the caption's
+    // height, and the offset. A class assertion would pass with the control
+    // sitting anywhere.
+    await installGraphApi(page);
+    await openGraph(page);
+    await surfaceButton(page, "grid").click();
+
+    for (const nodeId of ["alpha", CHILD_ID]) {
+      // Ctrl/Cmd+click: a plain click on the COLLECTION would drill in, and
+      // this needs the card to become the anchor while staying on screen.
+      await page
+        .locator(`[data-virtual-grid] [data-node-id="${nodeId}"]`)
+        .click({ modifiers: ["ControlOrMeta"] });
+      const geometry = await page.evaluate((id) => {
+        const card = document.querySelector(`[data-virtual-grid] [data-node-id="${CSS.escape(id)}"]`);
+        const dots = document.querySelector("[data-anchor-menu]");
+        const art = card?.querySelector("img");
+        if (!card || !dots) return null;
+        const c = card.getBoundingClientRect();
+        const d = dots.getBoundingClientRect();
+        return {
+          artworkBottom: art ? art.getBoundingClientRect().bottom : null,
+          dotsTop: d.top,
+          dotsBottom: d.bottom,
+          cardBottom: c.bottom,
+          cardRight: c.right,
+          dotsRight: d.right,
+        };
+      }, nodeId);
+      expect(geometry, `no anchor ⋮ for ${nodeId}`).not.toBeNull();
+
+      // BELOW the artwork — the assertion the old top-right position failed.
+      if (geometry!.artworkBottom !== null) {
+        expect(geometry!.dotsTop).toBeGreaterThanOrEqual(geometry!.artworkBottom - 1);
+      }
+      // …and still inside the card, not hanging off its bottom edge.
+      expect(geometry!.dotsBottom).toBeLessThanOrEqual(geometry!.cardBottom);
+      // Trailing the row, not floating mid-card.
+      expect(geometry!.cardRight - geometry!.dotsRight).toBeLessThanOrEqual(16);
+    }
+  });
+
+  test("the STRIP keeps its ⋮ on the card, where there is no caption to hold it", async ({
+    page,
+  }) => {
+    // The other half of the pair. A strip card is as narrow as its duration and
+    // grows no caption row, so the grid's placement has nowhere to go here —
+    // the same reason the kind icon and the caption tags are grid-only. Pinned
+    // together with the grid test because they are one decision, and a
+    // regression would most likely make both surfaces the same again.
+    await installGraphApi(page);
+    await openGraph(page);
+    await strip(page, PROJECT_ID).locator('[data-node-id="alpha"]').click();
+    const geometry = await page.evaluate(() => {
+      // Resolve the card through the control's OWN value rather than by walking
+      // up the DOM — `data-anchor-menu` carries the node id, and the two shells
+      // nest it differently.
+      const dots = document.querySelector("[data-anchor-menu]");
+      const id = dots?.getAttribute("data-anchor-menu") ?? "";
+      const card = document.querySelector(`[data-node-id="${CSS.escape(id)}"]`);
+      if (!dots || !card) return null;
+      return {
+        dotsTop: dots.getBoundingClientRect().top,
+        cardTop: card.getBoundingClientRect().top,
+        cardBottom: card.getBoundingClientRect().bottom,
+      };
+    });
+    expect(geometry).not.toBeNull();
+    // In the TOP half of the card — over the artwork, as it always was.
+    expect(geometry!.dotsTop - geometry!.cardTop).toBeLessThan(
+      (geometry!.cardBottom - geometry!.cardTop) / 2,
+    );
+  });
+
   test("clicking the checkbox toggles — on a collection, where the rest of the card drills", async ({
     page,
   }) => {


### PR DESCRIPTION
The mockup's split is that the title row is **chrome** — type, name, actions — and the thumbnail is **content**. Ours had the one remaining piece of chrome stamped across the picture, in the card's top-right corner. In the grid the `⋮` now sits in the caption band, trailing the name.

## Which cards show it is unchanged

Still the anchor's, still exactly one on screen, still carrying the selection count.

The mockup reveals a `⋮` on every card on hover, but that's a *different control* — a per-card menu acting on that card rather than on the selection — and retiring "exactly one `⋮` = the paste destination" isn't part of moving it. **Position only.**

## Anchored to the card's bottom

Not to the caption's top, and that's what makes one offset work for both card kinds: a media caption (name + meta/tags) and a collection caption (name + count, plus optional tags) are different heights, but both *end* at the card's bottom padding.

Measured on a 220px grid cell — artwork ends at 247, caption band runs 247–292, card ends at 298 — so `bottom-3` lands inside the band on either kind.

| | before | after |
|---|---|---|
| `⋮` vertical span | 90–118 (over artwork) | 262–290 (in caption) |

## The strip keeps the corner

A strip card is as narrow as its duration and grows no caption row, so the grid's placement has nowhere to go there. Same reason the kind icon and the caption tags are already grid-only.

## Tests

Two, pinned as a pair because they're one decision and a regression would most likely make both surfaces the same again. Both measure **bands** rather than assert on classes — the property is positional and three things feed it (the card's box, the caption's height, the offset), so a class assertion would pass with the control sitting anywhere.

- grid: runs over **both card kinds**, checks the `⋮` is below the artwork, inside the card, and trailing the row
- strip: checks it's still in the card's top half

## Verification

e2e 154/154 · stories 184/184 · typecheck clean · lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)