### PR TITLE
Show every select-row verb that fits, and overflow the rest into the menu

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -7,7 +7,9 @@ import {
   useDeferredValue,
   useEffect,
   useMemo,
+  useRef,
   useState,
+  type RefObject,
 } from "react";
 import { createPortal } from "react-dom";
 import { useSearchParams } from "next/navigation";
@@ -815,7 +817,115 @@ function SelectModeButton() {
  * matters, and the other two stay in the `⋮`. Two adjacent controls that both
  * end the gesture is how a mis-click becomes a surprise.
  */
-const SELECT_MODE_VERBS: readonly GraphItemAction[] = ["details", "duplicate", "delete"];
+/**
+ * The verbs this row will show, IN THE ORDER THEY ARE DRAWN.
+ *
+ * Everything here is also in the `⋮`, which renders the full action list from
+ * one definition — so promoting a verb is only ever a shortcut, never the only
+ * way to reach it, and a verb pushed out by a narrow window is still one click
+ * away rather than gone.
+ */
+const SELECT_MODE_VERBS: readonly GraphItemAction[] = [
+  "details",
+  "copy",
+  "cut",
+  "duplicate",
+  "toggle-disabled",
+  "delete",
+];
+
+/**
+ * The order they SURVIVE in as the row narrows — first is kept longest.
+ *
+ * DELIBERATELY NOT the draw order. Dropping from the right would take Delete
+ * first, and Delete plus Edit are the two verbs that were promoted when this
+ * row held a fixed three; losing them to a narrow window while Cut stayed would
+ * be a regression dressed up as responsiveness. Draw order is what reads well
+ * left to right; this is what matters when there is not room for all of it.
+ */
+const SELECT_MODE_VERB_PRIORITY: readonly GraphItemAction[] = [
+  "details",
+  "delete",
+  "duplicate",
+  "copy",
+  "cut",
+  "toggle-disabled",
+];
+
+/** `gap-x-5`, as a number — the fit maths has to add the gaps back. */
+const SELECT_MODE_VERB_GAP_PX = 20;
+
+/**
+ * How many verbs fit, measured rather than guessed.
+ *
+ * A RULER copy of the full run is rendered alongside the real one, invisible
+ * and out of flow, and its children are what get measured. Measuring the real
+ * run instead would be circular — hiding a verb changes the width you are
+ * measuring, so the answer would depend on the previous answer and could
+ * oscillate. The ruler always holds all of them, so its widths are stable.
+ *
+ * The budget is the container's own width, and the container is `flex-1
+ * min-w-0`: its width comes from the row, never from its contents. That is what
+ * keeps this a one-way calculation — nothing the hook decides can feed back
+ * into the number it measured against.
+ *
+ * Re-measured on resize AND whenever the action state changes, because labels
+ * are state-dependent: "Disable" becomes "Enable", and the counted labels grow
+ * a number past one selected item.
+ */
+function useFittedVerbCount(
+  state: ItemActionState,
+): Readonly<{
+  containerRef: RefObject<HTMLDivElement | null>;
+  rulerRef: RefObject<HTMLDivElement | null>;
+  visible: ReadonlySet<GraphItemAction>;
+}> {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const rulerRef = useRef<HTMLDivElement | null>(null);
+  const [count, setCount] = useState(SELECT_MODE_VERBS.length);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const ruler = rulerRef.current;
+    if (!container || !ruler) return;
+
+    const measure = () => {
+      const budget = container.clientWidth;
+      // 0 while the row is display:none (the browse header is showing) — keep
+      // the last answer rather than collapsing to zero verbs and flashing them
+      // all back in on the next frame.
+      if (budget === 0) return;
+      const widths = Array.from(ruler.children).map((child) =>
+        Math.ceil((child as HTMLElement).getBoundingClientRect().width),
+      );
+      let used = 0;
+      let fitted = 0;
+      for (const action of SELECT_MODE_VERB_PRIORITY) {
+        const index = SELECT_MODE_VERBS.indexOf(action);
+        const width = widths[index] ?? 0;
+        const next = used + width + (fitted > 0 ? SELECT_MODE_VERB_GAP_PX : 0);
+        if (next > budget) break;
+        used = next;
+        fitted += 1;
+      }
+      // At least one, even in a window too narrow for it: a row with a count
+      // and no verbs at all reads as broken, and the `⋮` beside it still holds
+      // everything.
+      setCount(Math.max(1, fitted));
+    };
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [state]);
+
+  const visible = useMemo(
+    () => new Set(SELECT_MODE_VERB_PRIORITY.slice(0, count)),
+    [count],
+  );
+  return { containerRef, rulerRef, visible };
+}
 
 /** One labelled verb. Same spec data as the icon buttons, more room to say it. */
 function SelectModeVerb({
@@ -867,10 +977,16 @@ function SelectModeHeader({ anchorName }: Readonly<{ anchorName: string | null }
   const state = useSelectionActionState();
   const { selectionCount } = state;
 
+  const { containerRef, rulerRef, visible } = useFittedVerbCount(state);
+
   return (
     <div
       data-select-mode-header=""
-      className="flex min-w-0 flex-1 flex-wrap items-center gap-x-5 gap-y-2"
+      // NOT `flex-wrap` any more. Wrapping was how this row coped with running
+      // out of width, and it coped by growing taller — which is exactly what
+      // the header must never do, now that both faces of it are pinned to the
+      // same height. Verbs move into the `⋮` instead.
+      className="flex min-w-0 flex-1 items-center gap-x-5"
     >
       <span
         data-select-mode-count={selectionCount}
@@ -887,9 +1003,34 @@ function SelectModeHeader({ anchorName }: Readonly<{ anchorName: string | null }
       >
         {selectionCount} selected
       </span>
-      {SELECT_MODE_VERBS.map((action) => (
-        <SelectModeVerb key={action} action={action} state={state} />
-      ))}
+      {/* The verb run, and the ruler it is measured against. `flex-1 min-w-0`
+          so the budget comes from the ROW rather than from the verbs — see
+          useFittedVerbCount for why that direction matters. */}
+      <div
+        ref={containerRef}
+        data-select-mode-verbs={visible.size}
+        className="relative flex min-w-0 flex-1 items-center gap-x-5 overflow-hidden"
+      >
+        <div
+          ref={rulerRef}
+          aria-hidden="true"
+          inert
+          data-select-mode-verb-ruler=""
+          // Out of flow and invisible, but LAID OUT — `visibility: hidden`
+          // keeps the boxes measurable where `display: none` would report
+          // zero. Absolute so it cannot widen the container it is measured
+          // against, and `inert` so a hidden run of buttons is not a set of
+          // tab stops.
+          className="pointer-events-none invisible absolute left-0 top-0 flex items-center gap-x-5"
+        >
+          {SELECT_MODE_VERBS.map((action) => (
+            <SelectModeVerb key={action} action={action} state={state} />
+          ))}
+        </div>
+        {SELECT_MODE_VERBS.filter((action) => visible.has(action)).map((action) => (
+          <SelectModeVerb key={action} action={action} state={state} />
+        ))}
+      </div>
       <HeaderPasteButton anchorName={anchorName} />
       {/* Everything not promoted above — the SAME menu the anchor's `⋮` opens,
           rendered from the identical definition rather than a hand-assembled

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -6592,6 +6592,60 @@ test.describe("graph view E2E", () => {
     await expect(page.locator('[data-selected="true"]')).toHaveCount(0);
   });
 
+  test("the select row shows every verb that fits, and overflows the rest into the menu", async ({
+    page,
+  }) => {
+    // The row promotes as many verbs as the width allows and pushes the rest
+    // into the `⋮`. Asserted as a RELATIONSHIP between two widths rather than
+    // against fixed counts: the exact number that fits depends on font
+    // metrics, and pinning "5 verbs at 1280px" would be a test about this
+    // machine's text rendering.
+    await installGraphApi(page);
+    await openGraph(page);
+    await selectCard(strip(page, PROJECT_ID).locator('[data-node-id="alpha"]'));
+    await toggleMultiSelect(page);
+
+    const run = page.locator("[data-select-mode-verbs]");
+    // `:scope >` matters: the RULER lives inside this container and holds a
+    // full copy of the run, so an unscoped lookup counts every verb twice.
+    const shown = () => run.locator(":scope > [data-header-action]").count();
+    const declared = () =>
+      run.locator("[data-select-mode-verb-ruler] [data-header-action]").count();
+
+    await page.setViewportSize({ width: 1400, height: 800 });
+    await expect.poll(shown).toBeGreaterThan(1);
+    const wide = await shown();
+    // The ruler always holds the FULL run — that is what makes it a stable
+    // yardstick — so the visible count can never exceed it.
+    expect(wide).toBeLessThanOrEqual(await declared());
+
+    // Narrow: strictly fewer verbs, and never zero — a count with no verbs at
+    // all reads as broken, and the `⋮` still holds everything either way.
+    await page.setViewportSize({ width: 620, height: 800 });
+    await expect.poll(shown).toBeLessThan(wide);
+    expect(await shown()).toBeGreaterThanOrEqual(1);
+
+    // THE ROW NEVER GROWS TALLER. Wrapping was the old answer to running out
+    // of width, and it moved the whole board down — the thing the height
+    // pinning above exists to prevent.
+    const header = page.locator("[data-graph-board-header]");
+    const narrowHeight = await header.evaluate((e) =>
+      Math.round(e.getBoundingClientRect().height),
+    );
+    await page.setViewportSize({ width: 1400, height: 800 });
+    await expect.poll(shown).toBe(wide);
+    expect(
+      await header.evaluate((e) => Math.round(e.getBoundingClientRect().height)),
+    ).toBe(narrowHeight);
+
+    // Everything dropped is still reachable: the `⋮` renders the full action
+    // list from one definition, so overflow is a shortcut being withdrawn, not
+    // a capability.
+    await page.locator("[data-header-selection-overflow]").click();
+    await expect(page.getByRole("menu")).toHaveCount(1);
+    await expect(page.getByRole("menuitem", { name: /^Delete/ })).toBeVisible();
+  });
+
   test("select mode takes the breadcrumb's place at the SAME height, from the first click", async ({
     page,
   }) => {


### PR DESCRIPTION
The row promoted a fixed three — Edit, Duplicate, Delete — and everything else lived in the `⋮` whatever the window size. It now shows **Edit, Copy, Cut, Duplicate, Disable and Delete**, as many as the width allows, and pushes the rest into the menu only when there's genuinely no room.

## Measured, via a ruler

A hidden copy of the **full** run is rendered beside the real one, and its children are what get measured.

Measuring the visible run would be circular — hiding a verb changes the width being measured, so the answer would depend on the previous answer and could oscillate. The ruler always holds all six, so its widths are stable. It's `visibility: hidden` rather than `display: none` because the second reports zero, and `inert` because a hidden run of buttons shouldn't be a set of tab stops.

The budget is the container's own width, and the container is `flex-1 min-w-0` — its width comes from the row, never from its contents. That's what keeps this a **one-way** calculation: nothing the hook decides can feed back into the number it measured against.

Re-measured on resize *and* whenever the action state changes, because labels are state-dependent ("Disable" → "Enable", and counted labels grow a number past one selected item).

## Draw order is not drop order

Deliberately. Dropping from the right would take **Delete** first — and Delete and Edit are the two verbs that were promoted when this row held a fixed three. Losing them to a narrow window while Cut stayed would be a regression dressed as responsiveness.

| | order |
|---|---|
| drawn | Edit, Copy, Cut, Duplicate, Disable, Delete |
| survives | Edit, Delete, Duplicate, Copy, Cut, Disable |

## No more `flex-wrap`

Wrapping was how this row coped with running out of width, and it coped by growing **taller** — the one thing the header must not do now that both its faces are pinned to the same height. Verbs move into the `⋮` instead.

Nothing becomes unreachable: the `⋮` renders the full action list from one definition, so overflow withdraws a *shortcut*, not a capability.

## The test asserts a relationship, not fixed counts

The number that fits depends on font metrics — pinning "5 verbs at 1280px" would be a test about this machine's text rendering. Instead: wide shows more than narrow, narrow never shows zero, the header's height is identical at both widths, and Delete is still in the menu.

## Verification

e2e 155/155 · stories 184/184 · app 702/702 · typecheck clean (both packages) · lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)