### PR TITLE
The select row owns the card's actions, and amber becomes blue

### DIFF
--- a/apps/timeline-gstudio001/app/page.tsx
+++ b/apps/timeline-gstudio001/app/page.tsx
@@ -204,7 +204,7 @@ export default function Home() {
     <div className="mx-auto grid w-full max-w-[1400px] gap-6 pt-7 animate-fade-in">
       <header className="flex flex-col gap-4 border-b border-zinc-800 pb-5 md:flex-row md:items-end md:justify-between">
         <div className="grid min-w-0 flex-1 gap-2">
-          <div className="flex items-center gap-2 text-[10px] font-black uppercase tracking-[0.24em] text-amber-300">
+          <div className="flex items-center gap-2 text-[10px] font-black uppercase tracking-[0.24em] text-blue-400">
             <FolderOpen className="h-4 w-4" />
             Projects
           </div>
@@ -227,12 +227,12 @@ export default function Home() {
             onChange={(event) => setProjectTitle(event.target.value)}
             maxLength={80}
             placeholder="New project name"
-            className="h-9 min-w-0 flex-1 rounded-md border border-zinc-800 bg-zinc-950 px-3 text-sm text-zinc-100 outline-none transition-colors placeholder:text-zinc-600 focus:border-amber-400"
+            className="h-9 min-w-0 flex-1 rounded-md border border-zinc-800 bg-zinc-950 px-3 text-sm text-zinc-100 outline-none transition-colors placeholder:text-zinc-600 focus:border-blue-500"
           />
           <Button
             type="submit"
             disabled={isCreating}
-            className="h-9 shrink-0 gap-2 bg-amber-400 px-3 text-xs font-bold uppercase tracking-widest text-zinc-950 hover:bg-amber-300"
+            className="h-9 shrink-0 gap-2 bg-blue-500 px-3 text-xs font-bold uppercase tracking-widest text-zinc-950 hover:bg-blue-400"
           >
             {isCreating ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
             New Project
@@ -305,7 +305,7 @@ export default function Home() {
             {projects.map((project) => (
               <div
                 key={project.id}
-                className="relative group overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900/55 shadow-xl shadow-black/20 transition-all duration-200 hover:border-amber-400/55 hover:bg-zinc-900"
+                className="relative group overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900/55 shadow-xl shadow-black/20 transition-all duration-200 hover:border-blue-500/55 hover:bg-zinc-900"
               >
                 {/* Link overlay covering the whole card area. It NEEDS a name:
                     as a childless anchor its accessible name was empty, so a
@@ -315,7 +315,7 @@ export default function Home() {
                     control's label. */}
                 <Link
                   href={`/timeline/${encodeURIComponent(project.id)}/graph`}
-                  className="absolute inset-0 z-10 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+                  className="absolute inset-0 z-10 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                 >
                   <span className="sr-only">Open project {project.title}</span>
                 </Link>
@@ -343,7 +343,7 @@ export default function Home() {
                     type="button"
                     onClick={(e) => handleDeleteProject(e, project.id)}
                     aria-label={`Delete project ${project.title}`}
-                    className="absolute top-2.5 right-2.5 z-20 flex h-7 w-7 items-center justify-center rounded-md border border-zinc-800 bg-zinc-900/90 hover:bg-red-600/90 text-zinc-400 hover:text-white transition-all opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+                    className="absolute top-2.5 right-2.5 z-20 flex h-7 w-7 items-center justify-center rounded-md border border-zinc-800 bg-zinc-900/90 hover:bg-red-600/90 text-zinc-400 hover:text-white transition-all opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                     title="Delete project"
                   >
                     <Trash2 aria-hidden="true" className="h-4 w-4" />

--- a/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
+++ b/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
@@ -369,7 +369,7 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
         <main className="flex-1 overflow-y-auto min-h-0 bg-zinc-950">
           {isLoading ? (
             <div className="flex h-32 items-center justify-center gap-2 text-sm text-zinc-400">
-              <LoaderCircle className="h-4 w-4 animate-spin text-amber-500" />
+              <LoaderCircle className="h-4 w-4 animate-spin text-blue-600" />
               Loading trash...
             </div>
           ) : error ? (

--- a/apps/timeline-gstudio001/components/auth/auth-gate.tsx
+++ b/apps/timeline-gstudio001/components/auth/auth-gate.tsx
@@ -66,7 +66,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
     return (
       <div className="grid min-h-screen flex-1 place-items-center bg-zinc-950 text-zinc-400">
         <div className="flex items-center gap-2 text-sm">
-          <LoaderCircle className="h-4 w-4 animate-spin text-amber-300" />
+          <LoaderCircle className="h-4 w-4 animate-spin text-blue-400" />
           Loading session
         </div>
       </div>
@@ -105,7 +105,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
     <div className="flex min-h-screen flex-1 items-center justify-center bg-zinc-950 px-6 py-10 text-white">
       <div className="grid w-full max-w-[420px] gap-6">
         <div className="grid gap-3 text-center">
-          <div className="mx-auto grid size-12 place-items-center rounded-lg border border-amber-500/40 bg-amber-500/10 text-[13px] font-black text-amber-300">
+          <div className="mx-auto grid size-12 place-items-center rounded-lg border border-blue-600/40 bg-blue-600/10 text-[13px] font-black text-blue-400">
             SW
           </div>
           <div className="grid gap-1">
@@ -134,7 +134,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
             <label htmlFor="auth-email" className="text-xs font-semibold uppercase tracking-widest text-zinc-400">
               Email
             </label>
-            <div className="flex h-10 items-center gap-2 rounded-md border border-zinc-800 bg-zinc-950 px-3 focus-within:border-amber-400">
+            <div className="flex h-10 items-center gap-2 rounded-md border border-zinc-800 bg-zinc-950 px-3 focus-within:border-blue-500">
               <Mail className="h-4 w-4 shrink-0 text-zinc-600" />
               <input
                 id="auth-email"
@@ -161,7 +161,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
           <Button
             type="submit"
             disabled={isSubmitting}
-            className="h-10 gap-2 bg-amber-400 text-xs font-bold uppercase tracking-widest text-zinc-950 hover:bg-amber-300"
+            className="h-10 gap-2 bg-blue-500 text-xs font-bold uppercase tracking-widest text-zinc-950 hover:bg-blue-400"
           >
             {isSubmitting ? (
               <LoaderCircle className="h-4 w-4 animate-spin" />
@@ -182,7 +182,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
             }}
             className={cn(
               "h-9 rounded-md text-xs font-semibold text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-100",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
             )}
           >
             Use a different email

--- a/apps/timeline-gstudio001/components/core/dropdown-menu.tsx
+++ b/apps/timeline-gstudio001/components/core/dropdown-menu.tsx
@@ -89,7 +89,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <DropdownMenuPrimitive.ItemIndicator>
-        <Check className="h-3.5 w-3.5 text-amber-400" />
+        <Check className="h-3.5 w-3.5 text-blue-500" />
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
     {children}
@@ -126,7 +126,7 @@ const DropdownMenuRadioBadge = React.forwardRef<
       "flex-1 cursor-default select-none rounded-sm border px-2 py-1 text-center",
       "text-[11px] font-semibold tracking-wide tabular-nums outline-none transition-colors",
       "border-zinc-800 bg-zinc-900/60 text-zinc-400",
-      "data-[state=checked]:border-amber-400/60 data-[state=checked]:bg-amber-400/15 data-[state=checked]:text-amber-200",
+      "data-[state=checked]:border-blue-500/60 data-[state=checked]:bg-blue-500/15 data-[state=checked]:text-blue-300",
       "focus:ring-2 focus:ring-inset focus:ring-zinc-400 focus:text-zinc-100",
       "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,

--- a/apps/timeline-gstudio001/components/core/slider.tsx
+++ b/apps/timeline-gstudio001/components/core/slider.tsx
@@ -59,7 +59,7 @@ const Slider = React.forwardRef<
       {...props}
     >
       <SliderPrimitive.Track className="relative h-1 w-full grow overflow-hidden rounded-full bg-zinc-800">
-        <SliderPrimitive.Range className="absolute h-full bg-amber-400/70" />
+        <SliderPrimitive.Range className="absolute h-full bg-blue-500/70" />
       </SliderPrimitive.Track>
       <SliderPrimitive.Thumb
         aria-label={ariaLabel}
@@ -67,7 +67,7 @@ const Slider = React.forwardRef<
         aria-describedby={ariaDescribedBy}
         aria-valuetext={ariaValueText}
         tabIndex={thumbTabIndex}
-        className="block h-3 w-3 rounded-full border border-amber-400 bg-zinc-950 shadow transition-colors hover:bg-zinc-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 disabled:pointer-events-none disabled:opacity-50"
+        className="block h-3 w-3 rounded-full border border-blue-500 bg-zinc-950 shadow transition-colors hover:bg-zinc-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:pointer-events-none disabled:opacity-50"
       />
     </SliderPrimitive.Root>
   ),

--- a/apps/timeline-gstudio001/components/core/sonner.tsx
+++ b/apps/timeline-gstudio001/components/core/sonner.tsx
@@ -23,7 +23,7 @@ const Toaster = ({ ...props }: ToasterProps) => (
         toast:
           "group toast group-[.toaster]:bg-zinc-900 group-[.toaster]:text-zinc-100 group-[.toaster]:border group-[.toaster]:border-zinc-800 group-[.toaster]:shadow-lg",
         description: "group-[.toast]:text-zinc-400",
-        actionButton: "group-[.toast]:bg-amber-400 group-[.toast]:text-zinc-950",
+        actionButton: "group-[.toast]:bg-blue-500 group-[.toast]:text-zinc-950",
         cancelButton: "group-[.toast]:bg-zinc-800 group-[.toast]:text-zinc-400",
         error: "group-[.toaster]:border-red-900/60",
         success: "group-[.toaster]:border-emerald-900/60",

--- a/apps/timeline-gstudio001/components/graph-view/graph-anchor-menu.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-anchor-menu.tsx
@@ -207,7 +207,7 @@ export function AnchorMenuButton({
             "relative z-20 flex size-7 shrink-0 items-center justify-center rounded",
             "bg-zinc-950/80 text-zinc-100 shadow-sm shadow-black/40 backdrop-blur-[1px]",
             "cursor-pointer transition-colors hover:bg-zinc-800 hover:text-white",
-            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400",
             // 44px effective target on a coarse pointer (R6.3), from padding —
             // the visual control stays 28px so it matches the drill control it
             // replaces. Those two CROSS-FADE on the anchor card, so any size
@@ -242,6 +242,10 @@ export function AnchorMenuButton({
 /**
  * The card's top-right corner slot, holding the `⋮` when this card is the
  * anchor — and nothing at all otherwise.
+ *
+ * STRIP ONLY now. The grid hides it (see the class below); its actions are all
+ * in the select row there. This component still renders and still tracks the
+ * anchor on both surfaces, so restoring the grid `⋮` is a one-class change.
  *
  * It used to be a two-tenant slot: a collection card carried a drill chevron
  * here, and the `⋮` CROSS-FADED with it (R6.2) so the swap cost no layout. The
@@ -279,23 +283,32 @@ export function CardCornerSlot({
       // between card kinds in the same grid.
       className={cn(
         "absolute right-5 top-3 z-20 flex items-center gap-1.5",
-        // GRID: down into the CAPTION band, trailing the name — the mockup's
-        // shape, where the title row is chrome (type, name, actions) and the
-        // thumbnail stays content. Over the artwork it was the one piece of
-        // chrome still stamped across the picture.
+        // NO `⋮` IN THE GRID.
         //
-        // Anchored to the card's BOTTOM rather than to the caption's top, and
-        // that is what makes one offset work for both card kinds: a media
-        // caption (name + meta/tags) and a collection caption (name + count,
-        // plus optional tags) are different heights, but both END at the card's
-        // bottom padding. Measured on a 220px grid cell: artwork ends at 247,
-        // the caption band runs 247-292, the card ends at 298 — so `bottom-3`
-        // lands inside the band on either kind.
+        // Every action it opened is in the select row now — arm select mode (or
+        // click a card's checkbox, which arms it) and the row carries Edit,
+        // Copy, Cut, Duplicate, Disable and Delete, with the rest in its own
+        // overflow. A per-card menu on top of that is a second route to the
+        // same list, parked in the corner of every cell.
         //
-        // The STRIP keeps the corner. Its cards are as narrow as their duration
-        // and have no caption row to sit in, which is the same reason the kind
-        // icon and the caption tags are grid-only.
-        "[[data-virtual-grid]_&]:top-auto [[data-virtual-grid]_&]:bottom-3 [[data-virtual-grid]_&]:right-3",
+        // HIDDEN, not deleted, and `display:none` rather than opacity — a
+        // control that is invisible but still focusable is a tab stop that goes
+        // nowhere. Everything above and below this line still works: flip this
+        // one class back to the positioning it replaced and the grid `⋮`
+        // returns exactly as it was. That positioning was:
+        //
+        //   [[data-virtual-grid]_&]:top-auto bottom-3 right-3
+        //
+        // — down in the CAPTION band, anchored to the card's BOTTOM so one
+        // offset served both card kinds (their captions are different heights
+        // but both end at the card's bottom padding; measured on a 220px cell,
+        // artwork ends at 247, the band runs 247-292, the card ends at 298).
+        //
+        // The STRIP keeps its corner `⋮`: its cards are as narrow as their
+        // duration and have no caption band or select-row equivalent to fall
+        // back on, which is the same reason the kind icon and the caption tags
+        // are grid-only.
+        "[[data-virtual-grid]_&]:hidden",
         className,
       )}
     >

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -78,6 +78,7 @@ import {
   DROPDOWN_MENU_PARTS,
   SELECTION_MENU_CONTENT_CLASS,
   SelectionMenuItems,
+  SelectionMenuOverflowItems,
 } from "./graph-selection-menu";
 import { NativeDropGrid, NativeDropStrip, SidebarToolInsertBridge } from "./graph-native-drop";
 import { VideoFrameLookAhead } from "./graph-item-content";
@@ -259,7 +260,7 @@ function FocusedAggregate({
         // Visible at EVERY breakpoint, unlike the idle total below. This is the
         // subject the controls beside it act on, and a group of controls whose
         // count has been hidden away reads as chrome with no object.
-        className="block shrink-0 pl-3 text-center font-mono text-[11px] tabular-nums text-amber-300/90"
+        className="block shrink-0 pl-3 text-center font-mono text-[11px] tabular-nums text-blue-400/90"
         title="Selected items"
       >
         {/* COUNT ONLY. The selection's total duration was here and is not a
@@ -898,19 +899,43 @@ function useFittedVerbCount(
       const widths = Array.from(ruler.children).map((child) =>
         Math.ceil((child as HTMLElement).getBoundingClientRect().width),
       );
+      // The ruler's LAST child is the `⋮`, sitting past every verb index — see
+      // the note on it in SelectModeHeader.
+      const overflowWidth = widths[SELECT_MODE_VERBS.length] ?? 0;
+
+      // PASS 1 — does the whole run fit with NO `⋮` at all? Asked first, and
+      // against the full budget, because when everything fits there is no
+      // overflow control to make room for. Reserving its width unconditionally
+      // is what used to push the last verb into a menu that then existed only
+      // to hold the verb its own width had displaced.
+      const wholeRun = SELECT_MODE_VERBS.reduce(
+        (total, _action, index) =>
+          total + (widths[index] ?? 0) + (index > 0 ? SELECT_MODE_VERB_GAP_PX : 0),
+        0,
+      );
+      if (wholeRun <= budget) {
+        setCount(SELECT_MODE_VERBS.length);
+        return;
+      }
+
+      // PASS 2 — it does not fit, so the `⋮` IS going to be drawn, and it costs
+      // width like anything else beside it. Two passes rather than one is what
+      // keeps this one-way: the reserve depends on pass 1's answer and never on
+      // its own, so it cannot oscillate between "fits" and "does not".
+      const reduced = budget - overflowWidth - SELECT_MODE_VERB_GAP_PX;
       let used = 0;
       let fitted = 0;
       for (const action of SELECT_MODE_VERB_PRIORITY) {
         const index = SELECT_MODE_VERBS.indexOf(action);
         const width = widths[index] ?? 0;
         const next = used + width + (fitted > 0 ? SELECT_MODE_VERB_GAP_PX : 0);
-        if (next > budget) break;
+        if (next > reduced) break;
         used = next;
         fitted += 1;
       }
       // At least one, even in a window too narrow for it: a row with a count
       // and no verbs at all reads as broken, and the `⋮` beside it still holds
-      // everything.
+      // everything it dropped.
       setCount(Math.max(1, fitted));
     };
 
@@ -978,6 +1003,12 @@ function SelectModeHeader({ anchorName }: Readonly<{ anchorName: string | null }
   const { selectionCount } = state;
 
   const { containerRef, rulerRef, visible } = useFittedVerbCount(state);
+  // What the row could not draw — exactly the overflow menu's contents, taken
+  // in DRAW order so the two halves of one list stay in one order.
+  const hidden = useMemo(
+    () => new Set(SELECT_MODE_VERBS.filter((action) => !visible.has(action))),
+    [visible],
+  );
 
   return (
     <div
@@ -1026,32 +1057,51 @@ function SelectModeHeader({ anchorName }: Readonly<{ anchorName: string | null }
           {SELECT_MODE_VERBS.map((action) => (
             <SelectModeVerb key={action} action={action} state={state} />
           ))}
+          {/* The `⋮`'s own width, MEASURED rather than assumed: it is 32px
+              under a mouse and 44px under a finger (HEADER_SELECTION_SIZE), so
+              a constant would reserve the wrong number on one of them and drop
+              a verb early. Kept LAST, past every verb index, so the per-verb
+              lookup by `indexOf` above is unaffected by its presence. */}
+          <span data-select-mode-overflow-ruler="" className={cn(HEADER_SELECTION_SIZE, "shrink-0")} />
         </div>
         {SELECT_MODE_VERBS.filter((action) => visible.has(action)).map((action) => (
           <SelectModeVerb key={action} action={action} state={state} />
         ))}
+        {/* ONLY what did not fit, and only WHEN something did not fit.
+
+            Inside the run, so it lands immediately after the last verb drawn
+            rather than at the far end of the row's leftover space — the run is
+            `flex-1`, so out here it floated an inch away from the verbs it
+            belongs to. And absent entirely when all six fit: a `⋮` that is
+            always there says the row is a summary of some longer list, which
+            is what made the row's own verbs look decorative. Appearing only on
+            overflow says the row IS the list and this is its remainder. */}
+        {hidden.size > 0 ? (
+          <DropdownMenu modal={false}>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label={`${hidden.size} more selection ${hidden.size === 1 ? "action" : "actions"}`}
+                data-header-selection-overflow
+                data-select-mode-overflow-count={hidden.size}
+                className={cn(HEADER_SELECTION_SIZE, HEADER_TOGGLE_IDLE, "shrink-0")}
+              >
+                <EllipsisVertical aria-hidden className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent side="bottom" align="center" className={SELECTION_MENU_CONTENT_CLASS}>
+              <SelectionMenuOverflowItems
+                parts={DROPDOWN_MENU_PARTS}
+                state={state}
+                actions={hidden}
+              />
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : null}
       </div>
       <HeaderPasteButton anchorName={anchorName} />
-      {/* Everything not promoted above — the SAME menu the anchor's `⋮` opens,
-          rendered from the identical definition rather than a hand-assembled
-          superset. */}
-      <DropdownMenu modal={false}>
-        <DropdownMenuTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            aria-label="More selection actions"
-            data-header-selection-overflow
-            className={cn(HEADER_SELECTION_SIZE, HEADER_TOGGLE_IDLE)}
-          >
-            <EllipsisVertical aria-hidden className="h-4 w-4" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent side="bottom" align="center" className={SELECTION_MENU_CONTENT_CLASS}>
-          <SelectionMenuItems parts={DROPDOWN_MENU_PARTS} state={state} />
-        </DropdownMenuContent>
-      </DropdownMenu>
       {/* `ml-auto`: Done sits at the far end, away from Delete. Both end the
           gesture, only one of them destroys anything, and putting them
           shoulder to shoulder is how a mis-click becomes a deletion. */}

--- a/apps/timeline-gstudio001/components/graph-view/graph-collection-details.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-collection-details.tsx
@@ -123,7 +123,7 @@ export function CollectionDetailsBody({
               onCommit={rename.commit}
               onCancel={rename.cancel}
               ariaLabel="Timeline name"
-              className="min-w-0 flex-1 rounded-sm bg-zinc-900 px-1 py-0.5 text-sm font-semibold text-zinc-100 outline-none ring-1 ring-amber-400/70"
+              className="min-w-0 flex-1 rounded-sm bg-zinc-900 px-1 py-0.5 text-sm font-semibold text-zinc-100 outline-none ring-1 ring-blue-500/70"
             />
           ) : (
             /* Single click to rename (PL14-010) — see the note on the clip

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -845,58 +845,115 @@ function renderWithTags(tags: string[], surface: "grid" | "strip" = "strip") {
   return decorator;
 }
 
+/** The chips actually on screen, excluding the measuring ruler and the +N. */
+function visibleTagChips(canvasElement: HTMLElement): HTMLElement[] {
+  const row = canvasElement.querySelector<HTMLElement>("[data-clip-caption-tags]")!;
+  return Array.from(
+    row.querySelectorAll<HTMLElement>(
+      ":scope > [title]:not([data-clip-caption-tags-overflow])",
+    ),
+  );
+}
+
 /** A few tags render in full, in the order they were stored. */
 export const TaggedCollectionCard: Story = {
   args: baseArgs,
-  decorators: [renderWithTags(["scail-2", "S02"])],
+  decorators: [renderWithTags(["scail-2", "S02"], "grid")],
   play: async ({ canvasElement }) => {
-    const row = canvasElement.querySelector<HTMLElement>("[data-clip-tags]")!;
+    // GRID, because tags are a grid idea now — the strip's overlay row is gone
+    // (see StripCardHasNoTagRow below).
+    const row = canvasElement.querySelector<HTMLElement>("[data-clip-caption-tags]")!;
     await expect(row).not.toBeNull();
-    await expect(row.dataset.clipTags).toBe("2");
-    await expect(row.textContent).toBe("scail-2S02");
-    for (const chip of Array.from(row.children) as HTMLElement[]) {
+    await expect(row.dataset.clipCaptionTags).toBe("2");
+
+    // Both fit at this width, so nothing folds.
+    const chips = visibleTagChips(canvasElement);
+    await expect(chips.map((chip) => chip.title)).toEqual(["scail-2", "S02"]);
+    await expect(canvasElement.querySelector("[data-clip-caption-tags-overflow]")).toBeNull();
+    for (const chip of chips) {
       await expect(chip.getBoundingClientRect().width).toBeGreaterThan(0);
     }
-    // Decorative: the card's own label already names it, and nothing in here
-    // may be interactive — this subtree renders inside a selection surface.
-    await expect(row.getAttribute("aria-hidden")).toBe("true");
+
+    // Nothing in here may be interactive — this subtree renders inside the
+    // card's selection surface, which is itself a <button>.
     await expect(row.querySelector("button")).toBeNull();
   },
 };
 
 /**
- * Past three tags the rest fold into a counter.
+ * Too many to fit: whole chips drop and the rest fold into a counter that
+ * LISTS them on hover.
  *
- * The failure this guards is INVISIBLE: the content root is `overflow-hidden`
- * with no ellipsis, so an unbounded row is clipped with nothing to show it was
- * clipped — a set that reads as complete but is not.
+ * The failure this guards is INVISIBLE: the row is `overflow-hidden` with no
+ * ellipsis, so an unbounded set is clipped with nothing to show it was clipped
+ * — a set that reads as complete but is not.
  */
 export const ManyTagsFoldIntoACounter: Story = {
   args: baseArgs,
-  decorators: [renderWithTags(["scail-2", "wan2.1", "S02", "keeper", "multirole"])],
+  decorators: [
+    renderWithTags(["scail-2", "wan2.1", "S02", "keeper", "multirole"], "grid"),
+  ],
   play: async ({ canvasElement }) => {
-    const row = canvasElement.querySelector<HTMLElement>("[data-clip-tags]")!;
-    await expect(row.dataset.clipTags).toBe("5");
-    const overflow = canvasElement.querySelector<HTMLElement>("[data-clip-tags-overflow]")!;
-    await expect(overflow).not.toBeNull();
-    await expect(overflow.dataset.clipTagsOverflow).toBe("3");
-    await expect(overflow.textContent).toBe("+3");
+    const row = canvasElement.querySelector<HTMLElement>("[data-clip-caption-tags]")!;
+    await expect(row.dataset.clipCaptionTags).toBe("5");
 
-    // MEASURED, not read. The first version of this asserted `textContent` and
-    // passed while all three chips were flex-shrunk to ZERO width — text
-    // present, nothing on screen. Assert every chip actually occupies space,
-    // and that the row stays inside the card, because the card is
-    // `overflow-hidden` with no ellipsis and clips silently.
-    const chips = Array.from(row.children) as HTMLElement[];
+    const overflow = await waitFor(() => {
+      const found = canvasElement.querySelector<HTMLElement>(
+        "[data-clip-caption-tags-overflow]",
+      );
+      if (found === null) throw new Error("no overflow counter yet");
+      return found;
+    });
+
+    // FITTED, not a fixed count. The old row always showed exactly two; this
+    // shows however many the width takes, so the assertion is a relationship
+    // (some shown, some folded, and the two add up) rather than a magic number
+    // that would only be about this machine's text metrics.
+    const chips = visibleTagChips(canvasElement);
+    await expect(chips.length).toBeGreaterThanOrEqual(1);
+    await expect(chips.length).toBeLessThan(5);
+    await expect(Number(overflow.dataset.clipCaptionTagsOverflow)).toBe(5 - chips.length);
+    await expect(overflow.textContent).toBe(`+${5 - chips.length}`);
+
+    // HOVER LISTS THE REST — and lists exactly the ones NOT on screen, which is
+    // the whole point of the counter.
+    const shownTitles = chips.map((chip) => chip.title);
+    const listed = overflow.title.split("\n");
+    await expect(listed.length).toBe(5 - chips.length);
+    for (const title of shownTitles) await expect(listed).not.toContain(title);
+
+    // MEASURED, not read. An earlier version asserted `textContent` and passed
+    // while every chip was flex-shrunk to ZERO width — text present, nothing on
+    // screen. And the row must stay inside the card, which clips silently.
     for (const chip of chips) {
       await expect(chip.getBoundingClientRect().width).toBeGreaterThan(0);
       await expect(chip.getBoundingClientRect().height).toBeGreaterThan(0);
     }
-    const card = canvasElement.querySelector<HTMLElement>("[data-node-id]")!;
-    const cardBox = card.getBoundingClientRect();
+    const cardBox = canvasElement
+      .querySelector<HTMLElement>("[data-node-id]")!
+      .getBoundingClientRect();
     const rowBox = row.getBoundingClientRect();
     await expect(rowBox.left).toBeGreaterThanOrEqual(cardBox.left);
     await expect(rowBox.right).toBeLessThanOrEqual(cardBox.right + 0.5);
+  },
+};
+
+/**
+ * The STRIP shows no tags at all.
+ *
+ * A strip clip's width IS its duration, so the overlay row this replaces let a
+ * clip's LENGTH decide which of its tags you saw — two clips with identical
+ * tags disagreed about them, and a short one covered its own frame to do it.
+ */
+export const StripCardHasNoTagRow: Story = {
+  args: baseArgs,
+  decorators: [renderWithTags(["scail-2", "wan2.1", "S02"], "strip")],
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelector("[data-clip-tags]")).toBeNull();
+    const caption = canvasElement.querySelector<HTMLElement>("[data-clip-caption-tags]");
+    // The caption row is CSS-gated rather than unmounted, so absence is not the
+    // assertion — zero height is.
+    await expect(caption?.getBoundingClientRect().height ?? 0).toBe(0);
   },
 };
 
@@ -904,8 +961,9 @@ export const ManyTagsFoldIntoACounter: Story = {
  *  else in this model, and an empty chip strip would read as a data glitch. */
 export const UntaggedCardHasNoTagRow: Story = {
   args: baseArgs,
-  decorators: [renderWithTags([])],
+  decorators: [renderWithTags([], "grid")],
   play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelector("[data-clip-caption-tags]")).toBeNull();
     await expect(canvasElement.querySelector("[data-clip-tags]")).toBeNull();
   },
 };
@@ -1008,6 +1066,37 @@ function renderCollectionInSelectMode(): Decorator {
 }
 
 /**
+ * The caption geometry EVERY grid card shares, media and collection alike:
+ * the distance from the card's outer edge to its caption icon, and that icon's
+ * box. 13px = 1px border + 6px card padding + 6px caption padding.
+ *
+ * Asserted in both card kinds' stories against these numbers rather than
+ * against each other, because the two cannot be rendered in one canvas — which
+ * is exactly how they drifted apart. Media was 4px in with a 14px icon,
+ * collection 6px with a 16px one; and even after matching those, media still
+ * landed a pixel left, because the collection's dashed border consumes layout
+ * where media's `ring` does not. All three had to agree.
+ *
+ * If a redesign moves these, move BOTH stories together. The shared number is
+ * the contract; either story alone can be made to pass by breaking alignment.
+ */
+const CAPTION_INSET_PX = 13;
+const CAPTION_ICON_PX = 16;
+
+/** The caption's leading icon must start at the same inset on any card kind. */
+async function expectCaptionIconAligned(
+  canvasElement: HTMLElement,
+  icon: Element,
+): Promise<void> {
+  const card = canvasElement.querySelector<HTMLElement>("[data-node-id]")!;
+  const iconBox = icon.getBoundingClientRect();
+  await expect(Math.round(iconBox.left - card.getBoundingClientRect().left)).toBe(
+    CAPTION_INSET_PX,
+  );
+  await expect(Math.round(iconBox.width)).toBe(CAPTION_ICON_PX);
+}
+
+/**
  * In the GRID the chrome sits UNDER the artwork, not stamped across it.
  *
  * The two overlays it replaces have to go, or the card says everything twice
@@ -1020,9 +1109,19 @@ export const GridCardCaptionSitsUnderTheArtwork: Story = {
     const caption = canvasElement.querySelector<HTMLElement>("[data-clip-caption]")!;
     await expect(caption).not.toBeNull();
     await expect(caption.getBoundingClientRect().height).toBeGreaterThan(0);
-    // Unnamed clips caption as their KIND rather than a filename (PL11-004
-    // keeps `title` absent until authored) — never an empty first line.
-    await expect(caption.textContent).toContain("Video");
+    // An unnamed clip captions as NOTHING — no filler word.
+    //
+    // This used to assert the opposite: the caption fell back to the KIND, so
+    // an un-authored clip read "Video" in the name's own weight and size and
+    // looked like it had been named that. PL11-004 keeps `title` absent until
+    // someone authors one; the fallback quietly undid it. The kind ICON holds
+    // the row instead, which is what keeps the line from collapsing.
+    await expect(caption.textContent).not.toContain("Video");
+    await expect(caption.querySelector("svg")).not.toBeNull();
+    await expect(caption.getBoundingClientRect().height).toBeGreaterThan(0);
+
+    // ALIGNED with a collection card's caption — see CAPTION_INSET_PX.
+    await expectCaptionIconAligned(canvasElement, caption.querySelector("svg")!);
 
     // BELOW the frame, not over it. Measured, because the whole change is a
     // geometric one and a caption that rendered on top of the artwork would
@@ -1078,25 +1177,128 @@ export const CaptionTagsFoldStatusFirst: Story = {
     const row = canvasElement.querySelector<HTMLElement>("[data-clip-caption-tags]")!;
     await expect(row.dataset.clipCaptionTags).toBe("4");
 
-    const chips = Array.from(row.querySelectorAll<HTMLElement>("span[title]"));
-    // The two STATUS tags are the ones kept, though neither was stored first.
-    await expect(chips.map((chip) => chip.title)).toEqual(["approved", "wip"]);
+    const chips = visibleTagChips(canvasElement);
+    // The two STATUS tags LEAD, though neither was stored first.
+    //
+    // Asserted as an ordering rather than as an exact kept-set: the row fits as
+    // many chips as the width takes now, so pinning "exactly these two survive"
+    // would be a test about this machine's text metrics. What must hold at any
+    // width is that status sorts to the front — so if anything folds, the
+    // status tags are never what goes.
+    await expect(chips.length).toBeGreaterThanOrEqual(2);
+    await expect(chips.slice(0, 2).map((chip) => chip.title)).toEqual(["approved", "wip"]);
     for (const chip of chips) {
       await expect(chip.getBoundingClientRect().width).toBeGreaterThan(0);
     }
 
+    // And whatever folded, if anything did, holds NO status tag.
     const overflow = canvasElement.querySelector<HTMLElement>(
       "[data-clip-caption-tags-overflow]",
-    )!;
-    await expect(overflow.dataset.clipCaptionTagsOverflow).toBe("2");
-    await expect(overflow.textContent).toBe("+2");
+    );
+    if (overflow !== null) {
+      const folded = overflow.title.split("\n");
+      await expect(folded).not.toContain("approved");
+      await expect(folded).not.toContain("wip");
+    }
 
     // Colour is DERIVED, so the two status words must land in their own
-    // families rather than sharing one — that is what the dot is for.
-    const accents = chips.map((chip) =>
-      chip.querySelector("[data-tag-accent]")?.getAttribute("data-tag-accent"),
-    );
+    // families rather than sharing one — that is what the dot is for. Scoped to
+    // the two leading chips for the same reason as above: how many chips follow
+    // them depends on the width, and those carry their own (non-status) accent.
+    const accents = chips
+      .slice(0, 2)
+      .map((chip) => chip.querySelector("[data-tag-accent]")?.getAttribute("data-tag-accent"));
     await expect(accents).toEqual(["ok", "progress"]);
+  },
+};
+
+/**
+ * A GRID video is ONE frame, full width — a thumbnail, like an image card.
+ *
+ * It used to split the cell between a first and last frame at 50% each, which
+ * showed two half-width crops and said nothing about duration that the cell's
+ * own width could carry (a grid cell's width is the cell's, not the clip's).
+ * Pinned as a PAIR with the strip story below, because the two are one decision
+ * and a regression would most likely make both surfaces the same again.
+ */
+export const GridVideoIsASingleFrame: Story = {
+  args: mediaArgs,
+  decorators: [renderMediaCard({ surface: "grid" })],
+  play: async ({ canvasElement }) => {
+    const frames = await waitFor(() => {
+      const found = Array.from(canvasElement.querySelectorAll<HTMLImageElement>("img"));
+      if (found.length === 0) throw new Error("no frames yet");
+      return found;
+    });
+    await expect(frames).toHaveLength(1);
+
+    // FULL WIDTH, which is the half that "one frame" alone does not promise —
+    // a single frame flex-shrunk into half the card would satisfy a count.
+    const artwork = frames[0]!.getBoundingClientRect();
+    const card = canvasElement
+      .querySelector<HTMLElement>("[data-node-id]")!
+      .getBoundingClientRect();
+    await expect(artwork.width).toBeGreaterThan(card.width * 0.8);
+  },
+};
+
+/** The STRIP keeps its filmstrip: there, a card's width IS its duration, so
+ *  extra width is extra time and a sequence of frames is what belongs in it. */
+export const StripVideoKeepsItsFilmstrip: Story = {
+  args: mediaArgs,
+  decorators: [renderMediaCard({ surface: "strip" })],
+  play: async ({ canvasElement }) => {
+    const frames = await waitFor(() => {
+      const found = Array.from(canvasElement.querySelectorAll<HTMLImageElement>("img"));
+      if (found.length < 2) throw new Error("filmstrip has not sampled yet");
+      return found;
+    });
+    await expect(frames.length).toBeGreaterThan(1);
+  },
+};
+
+/**
+ * A GRID card carries NO corner `⋮`, even as the anchor.
+ *
+ * Everything it opened lives in the select row now, so a per-card menu was a
+ * second route to the same list parked in every cell. Hidden rather than
+ * deleted — see CardCornerSlot, which still renders and still anchors; the grid
+ * just does not show it.
+ */
+export const GridCardHasNoCornerMenu: Story = {
+  args: mediaArgs,
+  decorators: [renderMediaCard({ surface: "grid", selectMode: true })],
+  play: async ({ canvasElement }) => {
+    const card = canvasElement.querySelector<HTMLElement>("[data-node-id]")!;
+    await userEvent.click(card);
+    await waitFor(() => expect(card.getAttribute("data-selected")).toBe("true"));
+
+    // ANCHORED — so the slot's own condition is met and the only thing keeping
+    // the control off screen is the grid rule. Asserting mere absence would
+    // pass just as well on a card that was never the anchor, which is the
+    // wrong reason and would not catch the rule being dropped.
+    const menu = canvasElement.ownerDocument.querySelector<HTMLElement>("[data-anchor-menu]");
+    await expect(menu?.getBoundingClientRect().height ?? 0).toBe(0);
+  },
+};
+
+/** The STRIP keeps its corner `⋮`: narrow cards with no caption band, and no
+ *  select-row equivalent to fall back on. Pinned as a pair with the story
+ *  above — a regression would most likely make both surfaces agree again. */
+export const StripCardKeepsItsCornerMenu: Story = {
+  args: mediaArgs,
+  decorators: [renderMediaCard({ surface: "strip", selectMode: true })],
+  play: async ({ canvasElement }) => {
+    const card = canvasElement.querySelector<HTMLElement>("[data-node-id]")!;
+    await userEvent.click(card);
+    await waitFor(() => expect(card.getAttribute("data-selected")).toBe("true"));
+
+    const menu = await waitFor(() => {
+      const found = canvasElement.ownerDocument.querySelector<HTMLElement>("[data-anchor-menu]");
+      if (found === null) throw new Error("no corner menu yet");
+      return found;
+    });
+    await expect(menu.getBoundingClientRect().height).toBeGreaterThan(0);
   },
 };
 
@@ -1231,6 +1433,11 @@ export const CollectionGridCaptionLeadsWithItsKind: Story = {
     const kind = canvasElement.querySelector<SVGElement>("[data-collection-kind]")!;
     await expect(kind).not.toBeNull();
     await expect(kind.getBoundingClientRect().width).toBeGreaterThan(0);
+
+    // The OTHER half of the shared caption geometry — the media card's story
+    // asserts the identical two numbers, which is what makes a mixed grid line
+    // up. See CAPTION_INSET_PX.
+    await expectCaptionIconAligned(canvasElement, kind);
 
     // A LABEL: hidden from the a11y tree, and no control of its own.
     //

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -13,11 +13,11 @@ import {
   type ReactNode,
 } from "react";
 import {
-  AudioWaveform,
   Check,
   CornerRightDown,
   Image as ImageIcon,
   Layers,
+  Music,
   Video,
 } from "lucide-react";
 
@@ -432,7 +432,7 @@ function DisabledChip({ inherited }: { inherited: boolean }) {
         "pointer-events-none absolute right-2 bottom-2 z-20 rounded px-1 py-0.5 font-mono text-[8px] leading-none font-semibold tracking-[0.08em]",
         inherited
           ? "bg-zinc-950/95 text-zinc-100 ring-1 ring-zinc-400/70"
-          : "bg-zinc-950/95 text-amber-200",
+          : "bg-zinc-950/95 text-blue-300",
       ].join(" ")}
     >
       {inherited ? "PARENT OFF" : "DISABLED"}
@@ -465,52 +465,36 @@ function DisabledChip({ inherited }: { inherited: boolean }) {
  * the leader is centred, which is where a projectionist would expect it.
  */
 /**
- * An audio card's stand-in: a drawn waveform.
+ * An audio card's stand-in: a music glyph on paper.
  *
- * DRAWN, not decoded. Real peaks require fetching and decoding the whole file,
- * and a board can hold dozens of cards — decoding per card would pull every
- * take on screen at mount. Actual peaks belong to the waveform LANE, which is
- * already cached, capped at three concurrent decodes and limited to visible
- * cards. This is the same call `CollectionLeaderPlaceholder` makes: draw the
- * idea of the thing rather than load it.
+ * A SYMBOL, not a drawn waveform. The drawn waveform this replaces was a fixed
+ * pseudo-random bar set — it looked like data while being decoration, and the
+ * peaks it implied belonged to no particular file, so two different takes drew
+ * the identical "waveform". A glyph makes no such claim: it says "this is
+ * sound" and stops.
  *
- * Bars are a fixed pseudo-random-looking set rather than `Math.random()` so a
- * card does not reshuffle on every re-render.
+ * Real peaks are still not an option here, for the reason the drawn version
+ * gave: decoding requires fetching whole files and a board holds dozens of
+ * cards. Actual peaks belong to the waveform LANE, which is cached, capped at
+ * three concurrent decodes and limited to visible cards.
+ *
+ * Paper, not black — the same call `CollectionLeaderPlaceholder` makes: an
+ * audio card is a FRAME with no picture, not a hole where one failed to load.
  */
-const AUDIO_PLACEHOLDER_BARS = [
-  0.25, 0.55, 0.38, 0.82, 0.62, 0.95, 0.7, 0.45, 0.78, 0.52, 0.88, 0.34,
-  0.66, 0.9, 0.48, 0.72, 0.3, 0.6, 0.85, 0.42, 0.75, 0.58, 0.28, 0.68,
-];
-
-function AudioWaveformPlaceholder() {
+function AudioPlaceholder() {
   return (
-    <svg
-      viewBox="0 0 160 90"
-      aria-hidden="true"
-      className="h-full w-full text-zinc-500/70"
-      preserveAspectRatio="xMidYMid slice"
-    >
-      {/* Paper, not black — same reasoning as the leader: an audio card is a
-          FRAME with no picture, not a hole where one failed to load. */}
-      <rect width="160" height="90" className="fill-zinc-800/40" />
-      {/* Centre line, so the bars read as a waveform rather than a bar chart. */}
-      <path d="M6 45 H154" stroke="currentColor" strokeWidth="0.75" opacity="0.5" />
-      <g className="fill-zinc-400/70">
-        {AUDIO_PLACEHOLDER_BARS.map((amplitude, index) => {
-          const height = amplitude * 62;
-          return (
-            <rect
-              key={index}
-              x={7 + index * 6.2}
-              y={45 - height / 2}
-              width="3.2"
-              height={height}
-              rx="1.6"
-            />
-          );
-        })}
-      </g>
-    </svg>
+    <span className="flex h-full w-full items-center justify-center bg-zinc-800/40">
+      <Music
+        aria-hidden="true"
+        strokeWidth={1.5}
+        // Sized off the CARD's height rather than fixed, so one glyph serves a
+        // tall grid cell and a short strip clip alike; clamped at both ends so
+        // it can neither fill a large cell nor shrink to a speck. Height-based
+        // because a strip clip's WIDTH is its duration — keying off that would
+        // swell the note on a long clip and crush it on a short one.
+        className="h-1/2 max-h-10 min-h-3 w-auto text-zinc-400/70"
+      />
+    </span>
   );
 }
 
@@ -548,7 +532,7 @@ function CollectionLeaderPlaceholder() {
  * BECAUSE the card is selected and does nothing when pressed —
  * `pointer-events-none`, so it cannot repeat that mistake.
  *
- * It earns its place by making a MULTI-selection legible. The `ring-amber-300`
+ * It earns its place by making a MULTI-selection legible. The `ring-blue-400`
  * on a selected card is a fine binary signal on one card and a weak one across
  * a board of forty, where the eye has to compare border colours; a row of ticks
  * reads at a glance. Same amber as the ring on purpose — one selection colour,
@@ -699,82 +683,12 @@ function ProvenanceLabel({
   );
 }
 
-/**
- * Below this card width the tag row is dropped entirely.
- *
- * ONE threshold, not a fold ladder — the same call ClipCornerSlot made
- * (MIN_ANCHOR_CONTROL_WIDTH). Two chips plus a counter need roughly this much
- * before they start colliding with the card's own padding, and the content root
- * is `overflow-hidden` with no ellipsis, so an over-wide row is clipped
- * INVISIBLY rather than degrading. Better to show nothing than a silently
- * truncated set someone might read as complete.
- */
-const TAG_ROW_MIN_WIDTH = 132;
-/**
- * Chips shown before the rest fold into a +N counter, by card width.
- *
- * Two, not three, until the card is wide enough. MEASURED: on a 144px card the
- * row has ~128px to work with, and three chips plus a counter want ~150px —
- * so they were being flex-shrunk to ZERO width. Every chip still had its text
- * content, so a `textContent` assertion passed while nothing was on screen.
- * `shrink-0` below is what stops the collapse; this is what stops the overflow
- * that made shrinking necessary.
- */
-const TAGS_SHOWN_WIDE = 3;
-const TAGS_SHOWN_NARROW = 2;
-const TAG_ROW_WIDE_WIDTH = 220;
-
-/**
- * A clip's tags, bottom-left and STACKED above the kind chip.
- *
- * Every other edge is taken: the title spans the top, ProvenanceLabel and the
- * selected badge hold the top-left, the corner menu the top-right, and the
- * duration pill and disabled chip the bottom-right.
- *
- * Decorative for AT — the card's own label already names the clip, and the tags
- * are reachable through the item details panel where they can also be edited.
- * Nothing here is interactive: this renders inside NodeCard's <button>, so an
- * interactive child would be invalid HTML and an ambiguous a11y tree.
- */
-function TagRow({
-  tags,
-  showAtMost,
-  className = "",
-}: Readonly<{ tags: readonly string[]; showAtMost: number; className?: string }>) {
-  const shown = sortTagsStatusFirst(tags).slice(0, showAtMost);
-  const extra = tags.length - shown.length;
-  return (
-    <span
-      aria-hidden="true"
-      data-clip-tags={tags.length}
-      className={[
-        "pointer-events-none absolute bottom-8 left-2 z-10 flex max-w-[calc(100%-1rem)] items-center gap-1",
-        // Callers add surface-scoped variants — the media card hides this in
-        // the grid, where its tags live in the caption instead.
-        className,
-      ].join(" ")}
-    >
-      {shown.map((tag) => (
-        <span
-          key={tag}
-          className="max-w-[6.5rem] shrink-0 truncate rounded bg-black/75 px-1 py-0.5 text-[8px] leading-none font-semibold text-zinc-200 ring-1 ring-white/15"
-        >
-          {tag}
-        </span>
-      ))}
-      {extra > 0 && (
-        <span
-          data-clip-tags-overflow={extra}
-          // Circle at one digit, stadium beyond — `rounded-full` + a min width,
-          // the same shape AnchorCountBadge gets without special-casing digits.
-          className="min-w-[1.05rem] shrink-0 rounded-full bg-black/75 px-1 py-0.5 text-center text-[8px] leading-none font-semibold text-zinc-400 ring-1 ring-white/15"
-        >
-          +{extra}
-        </span>
-      )}
-    </span>
-  );
-}
+// The strip's overlay `TagRow` lived here, with a pair of card-width
+// thresholds (132px to show anything, 220px for a third chip) deciding how
+// many chips a clip got. It is GONE with the strip tag row itself: a strip
+// clip's width is its DURATION, so those thresholds meant a clip's length
+// decided which of its tags you saw. Tags are a grid idea now, and the grid
+// caption's `CaptionTagRow` below is the one renderer.
 
 /**
  * The caption's tag chips — in flow, under the artwork, grid only.
@@ -785,32 +699,124 @@ function TagRow({
  * background in a row that has to share width with the meta line. They have
  * different jobs and almost no shared pixels.
  *
- * COUNTED, not measured. The design measures every chip against the real row
- * width so whole chips drop before any label clips — worth it there, because
- * its cards are one size and its tags are long English phrases. Here the grid
- * cell is a known width per item size and the row is already the widest place
- * a tag appears, so a count gets the same answer without an off-screen mirror
- * and a ResizeObserver on every card. The strip is where width genuinely varies
- * with content, and the strip does not use this row at all.
+ * MEASURED, not counted. It used to show a fixed two and fold the rest, on the
+ * reasoning that a grid cell is a known width per item size. That is true of
+ * the CELL and false of this row: tags are free text, so two long ones overflow
+ * where four short ones would have fitted, and a fixed count both clipped the
+ * long case and hid tags there was room for in the short one. The row now fits
+ * as many whole chips as the width actually takes and folds the remainder.
+ *
+ * Same ruler technique as the select row's verbs (`useFittedVerbCount`): an
+ * invisible, out-of-flow copy of every chip is what gets measured, because
+ * measuring the real row would be circular — hiding a chip changes the width
+ * you are measuring from, so the answer would depend on the previous answer.
  */
-function CaptionTagRow({
-  tags,
-  showAtMost,
-}: Readonly<{ tags: readonly string[]; showAtMost: number }>) {
-  const ordered = sortTagsStatusFirst(tags);
-  const shown = ordered.slice(0, showAtMost);
+const CAPTION_TAG_GAP_PX = 4;
+
+function CaptionTagRow({ tags }: Readonly<{ tags: readonly string[] }>) {
+  const ordered = useMemo(() => sortTagsStatusFirst(tags), [tags]);
+  const containerRef = useRef<HTMLSpanElement | null>(null);
+  const rulerRef = useRef<HTMLSpanElement | null>(null);
+  const counterRef = useRef<HTMLSpanElement | null>(null);
+  const [fitted, setFitted] = useState(ordered.length);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const ruler = rulerRef.current;
+    if (!container || !ruler) return;
+
+    const measure = () => {
+      const budget = container.clientWidth;
+      // 0 while the caption is display:none (the strip is showing) — keep the
+      // last answer rather than folding everything for a frame.
+      if (budget === 0) return;
+      const widths = Array.from(ruler.children).map((child) =>
+        Math.ceil((child as HTMLElement).getBoundingClientRect().width),
+      );
+      const counterWidth = counterRef.current?.getBoundingClientRect().width ?? 0;
+
+      // Pass 1 — do they ALL fit with no counter? Asked against the full
+      // budget, because with nothing folded there is no "+N" to leave room for.
+      const whole = widths.reduce(
+        (total, width, index) => total + width + (index > 0 ? CAPTION_TAG_GAP_PX : 0),
+        0,
+      );
+      if (whole <= budget) {
+        setFitted(ordered.length);
+        return;
+      }
+
+      // Pass 2 — something folds, so the counter is going to be drawn and costs
+      // width like a chip. Two passes keeps it one-way: the reserve depends on
+      // pass 1 and never on its own outcome, so it cannot oscillate.
+      const reduced = budget - Math.ceil(counterWidth) - CAPTION_TAG_GAP_PX;
+      let used = 0;
+      let count = 0;
+      for (const width of widths) {
+        const next = used + width + (count > 0 ? CAPTION_TAG_GAP_PX : 0);
+        if (next > reduced) break;
+        used = next;
+        count += 1;
+      }
+      // At least one chip. A row that is only "+4" says there are tags without
+      // showing a single one, which is strictly worse than one chip and "+3".
+      setFitted(Math.max(1, count));
+    };
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [ordered]);
+
+  const shown = ordered.slice(0, fitted);
   const extra = ordered.length - shown.length;
+  const chipClass =
+    "inline-flex max-w-[7rem] shrink-0 items-center gap-1 rounded-full bg-zinc-800 px-1.5 py-0.5 text-[10px] leading-none font-medium text-zinc-300 ring-1 ring-white/10";
+
   return (
     <span
+      ref={containerRef}
       data-clip-caption-tags={tags.length}
-      className="ml-auto flex min-w-0 shrink items-center gap-1 overflow-hidden"
+      // `flex-1 min-w-0`, NOT `ml-auto shrink`. The budget has to come from the
+      // ROW, never from these chips: a content-sized box reports the width its
+      // contents already take, so measuring it asks "do the chips fit in the
+      // space the chips are using", which is always yes — the fold then never
+      // fires, or fires against a box that shrank because of the last answer.
+      // Same one-way rule the select row's verb container follows.
+      className="relative flex min-w-0 flex-1 items-center gap-1 overflow-hidden"
     >
+      {/* The ruler: every chip, laid out but invisible. `visibility:hidden`
+          rather than `display:none` so the boxes still measure, absolute so it
+          cannot widen the container it is measured against, and `inert` so a
+          hidden copy of the row is not in the tab order or the a11y tree. */}
+      <span
+        ref={rulerRef}
+        aria-hidden="true"
+        inert
+        data-clip-caption-tags-ruler=""
+        className="pointer-events-none invisible absolute top-0 left-0 flex items-center gap-1"
+      >
+        {ordered.map((tag) => (
+          <span key={tag} className={chipClass}>
+            <TagAccentDot tag={tag} />
+            <span className="min-w-0 truncate">{tag}</span>
+          </span>
+        ))}
+      </span>
+      {/* The counter's own width, measured the same way rather than guessed —
+          it grows with the digit count ("+9" against "+12"). */}
+      <span
+        ref={counterRef}
+        aria-hidden="true"
+        inert
+        className="pointer-events-none invisible absolute top-0 left-0 shrink-0 font-mono text-[10px] leading-none"
+      >
+        +{ordered.length}
+      </span>
+
       {shown.map((tag) => (
-        <span
-          key={tag}
-          title={tag}
-          className="inline-flex max-w-[7rem] shrink-0 items-center gap-1 rounded-full bg-zinc-800 px-1.5 py-0.5 text-[10px] leading-none font-medium text-zinc-300 ring-1 ring-white/10"
-        >
+        <span key={tag} title={tag} className={chipClass}>
           <TagAccentDot tag={tag} />
           <span className="min-w-0 truncate">{tag}</span>
         </span>
@@ -818,7 +824,14 @@ function CaptionTagRow({
       {extra > 0 && (
         <span
           data-clip-caption-tags-overflow={extra}
-          className="shrink-0 font-mono text-[10px] leading-none text-zinc-500"
+          // HOVER LISTS THE REST. A `title` rather than a real tooltip, and not
+          // for lack of one: this renders inside the card's selection surface,
+          // which is a `<button>`, and a Radix tooltip trigger is interactive
+          // content — nesting it would auto-close the card's own button and
+          // eject the rest of the card out of its box (the same wall the
+          // select-mode checkbox hit). A title costs nothing and works.
+          title={ordered.slice(fitted).join("\n")}
+          className="shrink-0 cursor-help font-mono text-[10px] leading-none text-zinc-500"
         >
           +{extra}
         </span>
@@ -843,9 +856,12 @@ function CaptionTagRow({
  * so its checkbox is only ever a second way to hit the same target.
  *
  * OUTSIDE the mode it appears on HOVER, which is the design's own behaviour,
- * and CLICKING IT TOGGLES. That matters most on a collection: the rest of that
- * card drills in, so this circle is the only pointer route to picking one
- * without entering select mode first.
+ * and CLICKING IT TOGGLES *and ARMS the mode*. That matters most on a
+ * collection: the rest of that card drills in, so this circle is the only
+ * pointer route to picking one at all. Arming is the point rather than a side
+ * effect — it is what swaps the breadcrumb trail for the selection row, so the
+ * pick has somewhere to be counted and acted on. See the handler for why it
+ * arms on the way in only.
  *
  * It is a span that handles its own click rather than a `<button>` — see the
  * note on the element itself for why, and for the keyboard path that covers
@@ -933,6 +949,20 @@ function SelectionIndicator({
       onClick={(event) => {
         event.stopPropagation();
         store.toggleSelected(id);
+        // PICKING IS ENTERING THE MODE. The header row is driven by
+        // `multiSelectMode` alone (see GraphBoard's `selectModeRow`), so
+        // toggling the selection without arming left the checkbox filling in
+        // while the breadcrumb trail sat there unchanged — a selection with no
+        // way to act on it and no visible way out. Since a plain click OPENS
+        // and never selects, this checkbox IS the pointer gesture that means
+        // "I am selecting now", and that is the same statement the Select
+        // button makes.
+        //
+        // Only on the way IN. Un-checking the last item leaves the mode armed
+        // at "0 selected · Done", which is exactly where pressing Select and
+        // picking nothing lands you — whereas disarming on empty would yank
+        // the row away mid-correction, the moment a mis-pick is undone.
+        if (!selected) store.setMultiSelectMode(true);
       }}
       className={[
         "absolute right-2 bottom-2 z-20 grid size-[26px] cursor-pointer place-items-center",
@@ -963,6 +993,27 @@ const GraphClipContent = memo(function GraphClipContent({
   // integer-ratio crossing — computed above the early return because the
   // settle hook must run unconditionally.
   const [cardSizeRef, cardSize] = useElementSize();
+  // Which SURFACE this card is being drawn in, read from the container's own
+  // `[data-virtual-grid]` marker rather than passed down.
+  //
+  // Deliberately the same mechanism the CSS uses (`[[data-virtual-grid]_&]:…`
+  // all over this file). The card renderer is shared by both surfaces and has
+  // no idea which one it is in; threading a prop just to change a frame count
+  // would put a layout concern into the item contract, and the two surfaces
+  // would then have two different ways of answering the same question.
+  const [inGrid, setInGrid] = useState(false);
+  const surfaceRef = useCallback((element: HTMLElement | null) => {
+    setInGrid(element !== null && element.closest("[data-virtual-grid]") !== null);
+  }, []);
+  // One element, two callback refs — React takes a single ref per element, so
+  // they are composed here rather than by giving the node two attributes.
+  const cardRef = useCallback(
+    (element: HTMLElement | null) => {
+      cardSizeRef(element);
+      surfaceRef(element);
+    },
+    [cardSizeRef, surfaceRef],
+  );
   const measuredFrames =
     cardSize.height > 0 ? Math.round(cardSize.width / cardSize.height) : 0;
   const settledFrames = useSettledFrameCount(measuredFrames);
@@ -995,14 +1046,27 @@ const GraphClipContent = memo(function GraphClipContent({
   const isVideo = node.mediaKind === "video";
   const isAudio = node.mediaKind === "audio";
   const muted = node.disabled === true || inheritedDisabled;
-  // A wider clip shows MORE distinct frames rather than the same still tiled
-  // — falling back to a duration-based count until first measured.
-  const frames = isVideo
-    ? Math.max(
-        1,
-        Math.min(settledFrames || videoFrameCount(mediaDurationSeconds(node), 6), VIDEO_FRAME_CAP),
-      )
-    : 1;
+  // In the GRID a video is ONE frame, full width — a thumbnail, the same shape
+  // an image card has. The filmstrip below is a STRIP idea and stays there:
+  // that surface makes a card as wide as its clip is long, so extra width is
+  // extra time and a sequence of frames is the honest thing to put in it. A
+  // grid cell's width is just the cell's, so splitting it between a first and
+  // last frame was showing two half-width pictures to say nothing about
+  // duration, and neither of them read as a thumbnail.
+  //
+  // A wider STRIP clip shows MORE distinct frames rather than the same still
+  // tiled — falling back to a duration-based count until first measured.
+  const frames = !isVideo
+    ? 1
+    : inGrid
+      ? 1
+      : Math.max(
+          1,
+          Math.min(
+            settledFrames || videoFrameCount(mediaDurationSeconds(node), 6),
+            VIDEO_FRAME_CAP,
+          ),
+        );
   // Each video frame is sampled at its own time across the visible clip (R6
   // #6); an image is just its one src.
   const frameSrcs =
@@ -1018,18 +1082,26 @@ const GraphClipContent = memo(function GraphClipContent({
         ? []
         : [node.src];
   // CAPTION values (grid only — see the caption span at the end of the card).
-  const KindIcon = isVideo ? Video : isAudio ? AudioWaveform : ImageIcon;
-  // Falls back to the KIND, never to the machine name. PL11-004 keeps
-  // `detail.title` absent until someone actually names a clip, exactly so a
-  // library of filenames does not read as a rename backlog — and inventing one
-  // here would undo that. But a caption whose first line can be empty reads as
-  // broken, so the kind fills it, which is also what the artwork's chip said in
-  // the strip. "Video" rather than "VIDEO": this is a caption, not a stamp.
-  const captionName = detail?.title ?? (isVideo ? "Video" : isAudio ? "Audio" : "Image");
+  const KindIcon = isVideo ? Video : isAudio ? Music : ImageIcon;
+  // ONLY a real, authored name — no fallback.
+  //
+  // This used to fall back to the KIND ("Image", "Video", "Audio") on the
+  // reasoning that a caption whose first line can be empty reads as broken.
+  // That was the wrong trade: it put a word on every unnamed card, in the
+  // name's own typography, that said nothing the leading kind icon was not
+  // already saying — so an unnamed card read as though it had been named
+  // "Image". PL11-004 keeps `detail.title` absent until someone actually names
+  // a clip, precisely so a library of filenames does not look like a rename
+  // backlog, and inventing a name here undid that.
+  //
+  // The row does NOT collapse when this is null: the kind icon still holds the
+  // line, so an unnamed card's caption stays on the same grid as a named one's
+  // and as a collection's.
+  const captionName = detail?.title ?? null;
   const captionSeconds = Number(mediaDurationSeconds(node)) || 0;
   return (
     <span
-      ref={cardSizeRef}
+      ref={cardRef}
       className={[
         // p-1.5 on BOTH surfaces: the artwork is inset like the collection
         // card's (its frame + label row keep its pixels off the card edges),
@@ -1084,7 +1156,7 @@ const GraphClipContent = memo(function GraphClipContent({
       >
       {frameSrcs.length === 0 ? (
         isAudio ? (
-          <AudioWaveformPlaceholder />
+          <AudioPlaceholder />
         ) : (
           <span className="flex h-full w-full items-center justify-center text-[11px] text-zinc-500">
             No preview
@@ -1144,26 +1216,15 @@ const GraphClipContent = memo(function GraphClipContent({
       >
         {isVideo ? "VIDEO" : isAudio ? "AUDIO" : "IMAGE"}
       </span>
-      {/* Tags, stacked above the kind chip. Shown on DISABLED cards too,
-          unlike the title: a disabled clip is exactly the one someone is
-          hunting for by tag, so hiding its labels would work against the
-          reason tags exist. Width 0 means "not measured yet" — render, or the
-          row flashes in on every mount. */}
-      {detail?.tags?.length ? (
-        cardSize.width === 0 || cardSize.width >= TAG_ROW_MIN_WIDTH ? (
-          <TagRow
-            tags={detail.tags}
-            showAtMost={
-              cardSize.width === 0 || cardSize.width >= TAG_ROW_WIDE_WIDTH
-                ? TAGS_SHOWN_WIDE
-                : TAGS_SHOWN_NARROW
-            }
-            // GRID puts these in the caption instead (see below), where they
-            // sit beside the meta line rather than over the picture.
-            className="[[data-virtual-grid]_&]:hidden"
-          />
-        ) : null
-      ) : null}
+      {/* NO tag row in the strip. Tags are a GRID idea now: they live in the
+          caption, under the artwork, on both card kinds.
+
+          They used to be stamped over the picture here, folded by a pair of
+          card-width thresholds. A strip clip's width IS its duration, so which
+          tags a clip showed depended on how long it was — two cards with the
+          same tags disagreed about them, and a short clip covered most of its
+          own frame to say so. The grid cell has a stable width and a row of
+          its own for exactly this, which is where they went. */}
       {/* The clip's NAME, shown only when someone gave it one (PL11-004).
           Every clip has an `alt` — a filename, usually — so a card that
           rendered "the name" would render something on all of them, and a
@@ -1209,17 +1270,44 @@ const GraphClipContent = memo(function GraphClipContent({
       <span
         aria-hidden="true"
         data-clip-caption
-        className="hidden min-w-0 flex-col gap-1 pt-2 pr-0.5 pb-0.5 pl-1 [[data-virtual-grid]_&]:flex"
+        // Metrics MATCH the collection caption's grid values — 6px right, 6px
+        // bottom, 10px above (`pt-2.5` against its `mt-2.5`). They were
+        // 4px/2px/2px/8px here, so a grid mixing the two card kinds showed two
+        // different left edges and two name positions.
+        //
+        // The left is `7px`, NOT 6, and the odd pixel is the point. A
+        // collection card's surface carries a real 1px dashed border, and a
+        // border consumes layout under `border-box` where this card's `ring`
+        // does not — so an identical 6px padding still lands a pixel to the
+        // left of a collection's. This makes up the difference at the caption,
+        // which is where the alignment is visible.
+        //
+        // Deliberately NOT solved by giving this card a matching transparent
+        // border: that aligns the caption by moving the card's whole content
+        // box, which shifts the artwork and everything positioned off it — it
+        // moved the floating trim frame a pixel and the e2e caught it.
+        //
+        // If either side is retuned, retune both. The alignment is the
+        // contract, not the individual numbers, and the stories measure it.
+        className="hidden min-w-0 flex-col gap-1 pt-2.5 pr-1.5 pb-1.5 pl-[7px] [[data-virtual-grid]_&]:flex"
       >
         <span className="flex min-w-0 items-center gap-1.5">
+          {/* `size-4`, matching the collection caption's Layers glyph. At
+              `size-3.5` the two icon boxes differed by 2px, so every name in a
+              mixed grid started at one of two x positions. */}
           <KindIcon
             aria-hidden="true"
             strokeWidth={1.7}
-            className="size-3.5 shrink-0 text-zinc-400"
+            className="size-4 shrink-0 text-zinc-400"
           />
-          <span className="min-w-0 flex-1 truncate text-sm font-semibold text-zinc-100">
-            {captionName}
-          </span>
+          {/* Omitted, not blanked, when the clip has no authored name — see
+              `captionName`. The icon keeps the row's height and left edge, so
+              the meta line below stays put whether or not there is a name. */}
+          {captionName === null ? null : (
+            <span className="min-w-0 flex-1 truncate text-sm font-semibold text-zinc-100">
+              {captionName}
+            </span>
+          )}
         </span>
         {/* Row two is omitted ENTIRELY when it would be empty, rather than
             rendered blank: an untagged image has neither duration nor chips,
@@ -1233,7 +1321,7 @@ const GraphClipContent = memo(function GraphClipContent({
               </span>
             ) : null}
             {detail?.tags?.length ? (
-              <CaptionTagRow tags={detail.tags} showAtMost={TAGS_SHOWN_NARROW} />
+              <CaptionTagRow tags={detail.tags} />
             ) : null}
           </span>
         ) : null}
@@ -1317,7 +1405,13 @@ const GraphTrimHandle = memo(function GraphTrimHandle({
   return (
     <span
       className={[
-        "flex h-full w-full items-center justify-center bg-amber-400 opacity-95",
+        // blue-500 — the SELECTION colour (the ring on a selected card, the
+        // count in the select row). These handles only exist on a selected
+        // clip, so wearing the selection's colour is what ties them to the
+        // thing they act on. Amber is left over from when amber WAS the
+        // selection colour; once selection moved to blue it read as a second,
+        // unrelated accent on the one card already wearing the first.
+        "flex h-full w-full items-center justify-center bg-blue-500 opacity-95",
         side === "left" ? "rounded-l-md" : "rounded-r-md",
       ].join(" ")}
     >
@@ -1386,7 +1480,7 @@ const GraphGhost = memo(function GraphGhost({ node, extraCount }: CollectionGhos
   return (
     // Slightly transparent so the breadcrumb drop zones read THROUGH the ghost
     // while dragging over them — the user can see where they're aiming.
-    <span className="relative flex h-full w-full items-center justify-center overflow-hidden rounded-md bg-zinc-900 opacity-80 shadow-2xl ring-2 ring-amber-400">
+    <span className="relative flex h-full w-full items-center justify-center overflow-hidden rounded-md bg-zinc-900 opacity-80 shadow-2xl ring-2 ring-blue-500">
       {frames.length > 0 ? (
         <span className="flex h-full w-full gap-px">
           {frames.map((src, index) => (
@@ -1416,7 +1510,7 @@ const GraphGhost = memo(function GraphGhost({ node, extraCount }: CollectionGhos
         </span>
       )}
       {extraCount > 0 && (
-        <span className="absolute -top-2 -right-2 flex h-6 min-w-6 items-center justify-center rounded-full bg-amber-400 px-1 text-[11px] font-bold text-black shadow">
+        <span className="absolute -top-2 -right-2 flex h-6 min-w-6 items-center justify-center rounded-full bg-blue-500 px-1 text-[11px] font-bold text-black shadow">
           +{extraCount}
         </span>
       )}
@@ -1518,18 +1612,10 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
             than GraphClipContent (which returns null for them at the guard
             above). Skipping it here would ship a half-feature where a tagged
             collection silently shows nothing. */}
-        {detail?.tags?.length ? (
-          <TagRow
-            tags={detail.tags}
-            showAtMost={TAGS_SHOWN_NARROW}
-            // Same split the media card makes: overlaid on the artwork in the
-            // strip, in the caption in the grid. Without this the two card
-            // kinds would file their tags in two different places within one
-            // grid, which is the sort of inconsistency nobody reports and
-            // everybody notices.
-            className="[[data-virtual-grid]_&]:hidden"
-          />
-        ) : null}
+        {/* NO tag row in the strip — see the note on the media card's, which
+            this used to mirror. Collections keep theirs in the GRID caption
+            (further down), so the two card kinds still file tags in the same
+            place as each other. */}
         <span
           data-disabled-visuals={muted ? "true" : undefined}
           data-filter-miss={filterMiss ? "true" : undefined}
@@ -1678,7 +1764,7 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
             data-collection-caption-tags={detail.tags.length}
             className="hidden min-w-0 items-center pr-1.5 pb-1 pl-1.5 [[data-virtual-grid]_&]:flex"
           >
-            <CaptionTagRow tags={detail.tags} showAtMost={TAGS_SHOWN_NARROW} />
+            <CaptionTagRow tags={detail.tags} />
           </span>
         ) : null}
       </CollectionItem.SelectionSurface>
@@ -1733,7 +1819,7 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
           onInput={rename.setDraft}
           onCommit={rename.commit}
           onCancel={rename.cancel}
-          className="absolute inset-x-2.5 bottom-2 z-20 rounded-sm bg-zinc-950/95 px-1 py-0.5 text-xs font-semibold text-zinc-100 outline-none ring-1 ring-amber-400/70"
+          className="absolute inset-x-2.5 bottom-2 z-20 rounded-sm bg-zinc-950/95 px-1 py-0.5 text-xs font-semibold text-zinc-100 outline-none ring-1 ring-blue-500/70"
         />
       )}
 
@@ -1859,7 +1945,7 @@ const GraphMediaItem = memo(function GraphMediaItem({
           onCommit={rename.commit}
           onCancel={rename.cancel}
           ariaLabel="Clip name"
-          className="absolute inset-x-1 top-1 z-30 rounded-sm bg-zinc-950/95 px-1 py-0.5 text-[11px] font-semibold text-zinc-100 outline-none ring-1 ring-amber-400/70"
+          className="absolute inset-x-1 top-1 z-30 rounded-sm bg-zinc-950/95 px-1 py-0.5 text-[11px] font-semibold text-zinc-100 outline-none ring-1 ring-blue-500/70"
         />
       )}
     </div>
@@ -1918,7 +2004,7 @@ const GraphItemShell = memo(function GraphItemShell(props: CollectionItemShellPr
     // rather than blink out when the flash store clears — Tailwind's ring is a
     // box-shadow, so the same transition covers both ends.
     "transition-shadow duration-500 motion-reduce:transition-none",
-    flashing ? "ring-2 ring-amber-400 ring-offset-2 ring-offset-zinc-950" : "",
+    flashing ? "ring-2 ring-blue-500 ring-offset-2 ring-offset-zinc-950" : "",
   ]
     .filter(Boolean)
     .join(" ");

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -260,7 +260,7 @@ function SecondsField({
           }
         }}
         onBlur={(event) => onCommit(event.target.value)}
-        className="w-16 rounded-sm bg-zinc-900 px-1.5 py-0.5 text-right tabular-nums text-amber-200/90 outline-none ring-1 ring-zinc-700 focus:ring-amber-400/70 disabled:opacity-40"
+        className="w-16 rounded-sm bg-zinc-900 px-1.5 py-0.5 text-right tabular-nums text-blue-300/90 outline-none ring-1 ring-zinc-700 focus:ring-blue-500/70 disabled:opacity-40"
       />
       <span className="text-zinc-600">s</span>
     </label>
@@ -383,7 +383,7 @@ function ModalBody({ node, onClose }: Readonly<{ node: MediaNode; onClose: () =>
               onCommit={rename.commit}
               onCancel={rename.cancel}
               ariaLabel="Clip name"
-              className="min-w-0 flex-1 rounded-sm bg-zinc-900 px-1 py-0.5 text-sm font-semibold text-zinc-100 outline-none ring-1 ring-amber-400/70"
+              className="min-w-0 flex-1 rounded-sm bg-zinc-900 px-1 py-0.5 text-sm font-semibold text-zinc-100 outline-none ring-1 ring-blue-500/70"
             />
           ) : (
             <button
@@ -471,13 +471,13 @@ function ModalBody({ node, onClose }: Readonly<{ node: MediaNode; onClose: () =>
             <span
               data-item-details-edge={live.side === "right" ? "right" : "left"}
               className={[
-                "absolute inset-y-0 w-1.5 bg-amber-400",
+                "absolute inset-y-0 w-1.5 bg-blue-500",
                 live.side === "right" ? "right-0" : "left-0",
               ].join(" ")}
             />
           )}
           {video && (
-            <span className="absolute right-2 bottom-2 rounded bg-black/80 px-1.5 py-0.5 font-mono text-[11px] tabular-nums text-amber-200">
+            <span className="absolute right-2 bottom-2 rounded bg-black/80 px-1.5 py-0.5 font-mono text-[11px] tabular-nums text-blue-300">
               {formatSeconds(rawTime)}
             </span>
           )}
@@ -515,7 +515,7 @@ function ModalBody({ node, onClose }: Readonly<{ node: MediaNode; onClose: () =>
           </>
         ) : (
           <div className="flex items-center justify-between font-mono text-[11px] text-zinc-500">
-            <span className="text-amber-200/90">still · {formatSeconds(showing)} on screen</span>
+            <span className="text-blue-300/90">still · {formatSeconds(showing)} on screen</span>
             <span>drag the card&apos;s edge on the strip to change how long it holds</span>
           </div>
         )}

--- a/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
@@ -1072,7 +1072,7 @@ export function NativeDropStrip({
           // left-0 for the same reason the grid's indicator needs it: the
           // translate is measured from the wrapper's origin, so the element
           // must be anchored there rather than left at its static position.
-          className="pointer-events-none absolute inset-y-1 left-0 z-30 w-0.5 rounded bg-amber-400 shadow-[0_0_6px_rgba(251,191,36,0.9)]"
+          className="pointer-events-none absolute inset-y-1 left-0 z-30 w-0.5 rounded bg-blue-500 shadow-[0_0_6px_rgba(59,130,246,0.9)]"
           style={{ transform: `translateX(${indicatorX}px)` }}
         />
       )}
@@ -1305,7 +1305,7 @@ export function NativeDropGrid({
           // (`wrapperLeft`/`wrapperTop`), so without the anchor the line drew
           // a whole grid's height too low. z-30 clears the grid's own
           // overlay tier as well as its cards.
-          className="pointer-events-none absolute left-0 top-0 z-30 w-0.5 rounded bg-amber-400 shadow-[0_0_6px_rgba(251,191,36,0.9)]"
+          className="pointer-events-none absolute left-0 top-0 z-30 w-0.5 rounded bg-blue-500 shadow-[0_0_6px_rgba(59,130,246,0.9)]"
           style={{
             transform: `translate(${indicator.x}px, ${indicator.y}px)`,
             height: `${indicator.height}px`,

--- a/apps/timeline-gstudio001/components/graph-view/graph-selection-menu.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-selection-menu.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/components/core/dropdown-menu";
 import { cn } from "@/lib/utils";
 import { itemActionSections, type ItemActionState } from "@/lib/graph-item-action-specs";
-import { requestGraphItemAction } from "@/lib/graph-view-events";
+import { requestGraphItemAction, type GraphItemAction } from "@/lib/graph-view-events";
 
 // THE selection menu. One definition, three triggers: the anchor card's `⋮`,
 // any card's right-click, and the header's `⋮`.
@@ -25,8 +25,15 @@ import { requestGraphItemAction } from "@/lib/graph-view-events";
 // v2 had two renderings of this list — a row of icon tiles inside the card and
 // an overflow menu for whatever the row could not fit — and keeping them
 // lossless was a standing bug source, because an action in neither place is
-// simply gone. There is one rendering now, so there is nothing to fold and
-// nothing to lose.
+// simply gone. THE MENU is still one rendering, and the card `⋮` and
+// right-click still open the whole list.
+//
+// The select row folds, via `SelectionMenuOverflowItems`, and that is not a
+// return to v2's problem: v2 folded from a hand-assembled tile row into a
+// hand-assembled menu, so an action could fall between them. Here the row and
+// the fold are computed from the SAME `SELECT_MODE_VERBS` list — what the row
+// could not draw is precisely what the fold shows — and every one of those
+// verbs is in the full menu regardless. Nothing can land in neither.
 //
 // The two menu primitives (dropdown / context) are styled identically but come
 // from different Radix packages, so the parts are injected rather than the
@@ -216,6 +223,54 @@ function MultiSelectToggleRow({
         {enabled ? "Stop adding to selection" : "Add to selection by tapping"}
       </span>
     </Item>
+  );
+}
+
+/**
+ * ONLY the actions named, as menu rows — the select row's overflow.
+ *
+ * Distinct from `SelectionMenuItems` on purpose. That one is THE menu: the
+ * whole action list, wherever it is opened from. This is the tail of a toolbar
+ * that ran out of width, so it holds exactly what the toolbar could not draw
+ * and nothing else. Repeating a verb that is already on screen an inch to the
+ * left is what made the old `⋮` read as "everything is in here anyway", which
+ * in turn made the row's own verbs look decorative.
+ *
+ * Grouping still comes from `itemActionSections`, and empty runs are dropped
+ * BEFORE the separators are emitted — so the same "separators between runs"
+ * derivation keeps a leading, trailing, or doubled separator unexpressible when
+ * an arbitrary subset survives.
+ *
+ * No scope header and no multi-select toggle: both belong to the full menu,
+ * which is still one click away on the anchor card's own `⋮`.
+ */
+export function SelectionMenuOverflowItems({
+  parts,
+  state,
+  actions,
+}: Readonly<{
+  parts: MenuParts;
+  state: ItemActionState;
+  actions: ReadonlySet<GraphItemAction>;
+}>) {
+  const { Separator } = parts;
+  const runs = itemActionSections(state)
+    .map((run) => run.filter((spec) => actions.has(spec.action)))
+    .filter((run) => run.length > 0);
+
+  return (
+    <>
+      {runs.map((run, index) => (
+        <Fragment key={run[0]?.action ?? index}>
+          {index > 0 ? <Separator /> : null}
+          <div role="group">
+            {run.map((spec) => (
+              <SelectionMenuRow key={spec.action} parts={parts} state={state} spec={spec} />
+            ))}
+          </div>
+        </Fragment>
+      ))}
+    </>
   );
 }
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-shortcuts.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-shortcuts.tsx
@@ -123,7 +123,7 @@ function ShortcutsSheet({ onClose }: Readonly<{ onClose: () => void }>) {
         <div className="grid gap-5 sm:grid-cols-2">
           {SECTIONS.map((section) => (
             <section key={section.title}>
-              <h3 className="text-[11px] font-semibold tracking-wide text-amber-200/80 uppercase">
+              <h3 className="text-[11px] font-semibold tracking-wide text-blue-300/80 uppercase">
                 {section.title}
               </h3>
               {section.note && (

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -656,7 +656,7 @@ export function GraphTimelineView({
       {gatewayError !== null && (
         <p
           role="alert"
-          className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-200"
+          className="rounded-md border border-blue-600/40 bg-blue-600/10 px-3 py-2 text-xs text-blue-300"
         >
           {gatewayError}
         </p>

--- a/apps/timeline-gstudio001/components/graph-view/graph-trim-panel.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-trim-panel.tsx
@@ -120,15 +120,17 @@ function LiveEdgeFrame({
         preload="auto"
         className="h-full w-full bg-black object-cover"
       />
-      {/* The trim-handle look — amber bar — on the pinned edge, so the frame
-          reads as an extension of the handle under the pointer. */}
+      {/* The trim-handle look — the same blue bar — on the pinned edge, so the
+          frame reads as an extension of the handle under the pointer. Tracks
+          GraphTrimHandle's colour: these two are one control seen twice, so
+          they must never diverge. */}
       <span
         className={[
-          "absolute inset-y-0 w-1 bg-amber-400",
+          "absolute inset-y-0 w-1 bg-blue-500",
           activeEdge === "right" ? "right-0" : "left-0",
         ].join(" ")}
       />
-      <span className="absolute right-0 bottom-0 bg-zinc-950/85 px-1 font-mono text-[11px] leading-tight tabular-nums text-amber-200">
+      <span className="absolute right-0 bottom-0 bg-zinc-950/85 px-1 font-mono text-[11px] leading-tight tabular-nums text-blue-300">
         {formatSeconds(time)}
       </span>
     </div>,

--- a/apps/timeline-gstudio001/tests/e2e/dnd-collections.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/dnd-collections.spec.ts
@@ -393,7 +393,7 @@ test.describe('DndCollections E2E', () => {
     expect(await widthOf(vid)).toBe(192); // duration (and width) unchanged
   });
 
-  test('trim overview: amber window stays aligned to the clip during a real drag', async ({
+  test('trim overview: the showing window stays aligned to the clip during a real drag', async ({
     page,
   }) => {
     // TrimPlayground pre-selects "vid" (SelectOnMount), so the overview band

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -563,8 +563,36 @@ const anchorMenuButton = (page: Page): Locator =>
  * with like. One menu, one lookup.
  */
 async function selectionAction(page: Page, name: string | RegExp): Promise<void> {
-  await anchorMenuButton(page).first().click();
+  // The CARD's ⋮ where there is one, the HEADER's where there is not.
+  //
+  // Two cases have no card control: the grid, which carries none at all now
+  // (its actions are on the select row), and a strip clip too narrow to hold
+  // one. Both have always been served by the header's selection ⋮, which opens
+  // the identical menu from the identical definition — so this picks by LAYOUT
+  // rather than by surface and one helper covers every call site.
+  await openSelectionMenu(page);
   await page.getByRole("menuitem", { name }).first().click();
+}
+
+/**
+ * Open THE selection menu, from wherever this surface keeps its trigger.
+ *
+ * The card's `⋮` where there is one, the HEADER's where there is not. Two cases
+ * have no card control: the grid, which carries none at all now (its actions
+ * are on the select row), and a strip clip too narrow to hold one. Both have
+ * always been served by the header's `⋮`, which opens the identical menu from
+ * the identical definition — so this picks by LAYOUT rather than by surface and
+ * every call site works on both.
+ *
+ * `isVisible()`, NEVER `boundingBox()`. boundingBox WAITS for visibility, so
+ * asking it about the grid's `⋮` — `display:none` there — burns the whole 60s
+ * timeout and fails on a control that is behaving correctly. isVisible resolves
+ * immediately and answers exactly the question being asked.
+ */
+async function openSelectionMenu(page: Page): Promise<void> {
+  const onCard = anchorMenuButton(page).first();
+  if (await onCard.isVisible()) await onCard.click();
+  else await page.locator("[data-header-selection-overflow]").first().click();
 }
 
 /**
@@ -4388,7 +4416,9 @@ test.describe("graph view E2E", () => {
     // through a modal close and a re-render made this test flaky about
     // something it was not testing.
     await selectCard(bravo);
-    await anchorMenuButton(page).first().click();
+    // Whichever `⋮` this surface has — the grid's cards carry none, so here it
+    // is the header's. The menu is the same definition either way.
+    await openSelectionMenu(page);
     const edit = page.getByRole("menuitem", { name: "Edit", exact: true });
     await edit.focus();
     await expect(edit).toBeFocused();
@@ -5956,23 +5986,24 @@ test.describe("graph view E2E", () => {
       .poll(() => gridOrder(page, PROJECT_ID), { timeout: 15000 })
       .toContain("bravo");
 
-    // Still selected, and the toolbar re-anchored to the card's new position
-    // rather than pointing at where it used to be.
+    // Still selected — which is what this test is actually about.
     await expect(
       page.locator(
         `[data-virtual-grid="${PROJECT_ID}"] [data-node-id="bravo"][data-selected="true"]`,
       ),
     ).toHaveCount(1);
-    await expect(anchorMenuButton(page)).toBeVisible();
-    const card = (await page
-      .locator(`[data-virtual-grid="${PROJECT_ID}"] [data-node-id="bravo"]`)
-      .boundingBox())!;
-    const bar = (await anchorMenuButton(page).boundingBox())!;
-    // Contained by the card, in its top-right corner slot. Not a centre check:
-    // the control took the chevron's place, so its centre is deliberately not
-    // the card's.
-    expect(bar.x).toBeGreaterThanOrEqual(card.x - 1);
-    expect(bar.x + bar.width).toBeLessThanOrEqual(card.x + card.width + 1);
+
+    // The card's ⋮ does NOT come with it: the grid carries none. This used to
+    // assert the opposite (visible, and contained by the card's box), which was
+    // the placement test before the control left the grid entirely.
+    //
+    // `toBeHidden`, not a boundingBox measurement — boundingBox WAITS for
+    // visibility, so measuring a `display:none` control burns the timeout.
+    await expect(anchorMenuButton(page).first()).toBeHidden();
+
+    // But the SELECTION's actions are still one click away, from the header —
+    // the same fallback a too-narrow strip clip uses.
+    await expect(page.locator("[data-header-selection-overflow]").first()).toBeVisible();
   });
 
   test("the ⋮ follows the last-clicked card, not the whole selection", async ({
@@ -6612,18 +6643,39 @@ test.describe("graph view E2E", () => {
     const declared = () =>
       run.locator("[data-select-mode-verb-ruler] [data-header-action]").count();
 
+    const overflow = page.locator("[data-header-selection-overflow]");
+
+    // WIDE: the whole run fits, so there is NO `⋮` at all. It used to be
+    // permanent, which said the row was a summary of some longer list and made
+    // the verbs beside it look decorative.
     await page.setViewportSize({ width: 1400, height: 800 });
-    await expect.poll(shown).toBeGreaterThan(1);
+    await expect.poll(shown).toBe(await declared());
     const wide = await shown();
-    // The ruler always holds the FULL run — that is what makes it a stable
-    // yardstick — so the visible count can never exceed it.
-    expect(wide).toBeLessThanOrEqual(await declared());
+    expect(wide).toBeGreaterThan(1);
+    await expect(overflow).toHaveCount(0);
 
     // Narrow: strictly fewer verbs, and never zero — a count with no verbs at
-    // all reads as broken, and the `⋮` still holds everything either way.
+    // all reads as broken, and the `⋮` holds whatever it dropped.
     await page.setViewportSize({ width: 620, height: 800 });
     await expect.poll(shown).toBeLessThan(wide);
-    expect(await shown()).toBeGreaterThanOrEqual(1);
+    const narrow = await shown();
+    expect(narrow).toBeGreaterThanOrEqual(1);
+
+    // ...and NOW it appears, reporting exactly how many it swallowed.
+    await expect(overflow).toBeVisible();
+    await expect(overflow).toHaveAttribute(
+      "data-select-mode-overflow-count",
+      String(wide - narrow),
+    );
+
+    // It sits WITH the verbs, not at the far end of the row. Asserted
+    // structurally rather than by coordinates: the run is `flex-1`, so a `⋮`
+    // outside it floats away from the verbs by however much space is spare,
+    // and being inside the container is what puts it against the last verb
+    // drawn whatever the width.
+    expect(
+      await overflow.evaluate((e) => e.closest("[data-select-mode-verbs]") !== null),
+    ).toBe(true);
 
     // THE ROW NEVER GROWS TALLER. Wrapping was the old answer to running out
     // of width, and it moved the whole board down — the thing the height
@@ -6632,18 +6684,33 @@ test.describe("graph view E2E", () => {
     const narrowHeight = await header.evaluate((e) =>
       Math.round(e.getBoundingClientRect().height),
     );
+
+    // THE MENU HOLDS THE REMAINDER, NOT THE WHOLE LIST. Every verb already on
+    // the row was also in here, an inch to the left of itself — which is what
+    // made the fold look like it had not happened at all.
+    const onRow = await run
+      .locator(":scope > [data-header-action]")
+      .evaluateAll((els) => els.map((e) => e.getAttribute("data-header-action")));
+    await overflow.click();
+    const menu = page.getByRole("menu");
+    await expect(menu).toHaveCount(1);
+    const inMenu = await menu
+      .locator("[data-menu-action]")
+      .evaluateAll((els) => els.map((e) => e.getAttribute("data-menu-action")));
+    // Nothing repeated...
+    for (const action of onRow) expect(inMenu).not.toContain(action);
+    // ...and nothing lost: the two halves add back up to the full run.
+    expect(inMenu.length).toBe(wide - narrow);
+    await page.keyboard.press("Escape");
+    await expect(menu).toHaveCount(0);
+
+    // Back to wide: every verb returns and the `⋮` withdraws with them.
     await page.setViewportSize({ width: 1400, height: 800 });
     await expect.poll(shown).toBe(wide);
+    await expect(overflow).toHaveCount(0);
     expect(
       await header.evaluate((e) => Math.round(e.getBoundingClientRect().height)),
     ).toBe(narrowHeight);
-
-    // Everything dropped is still reachable: the `⋮` renders the full action
-    // list from one definition, so overflow is a shortcut being withdrawn, not
-    // a capability.
-    await page.locator("[data-header-selection-overflow]").click();
-    await expect(page.getByRole("menu")).toHaveCount(1);
-    await expect(page.getByRole("menuitem", { name: /^Delete/ })).toBeVisible();
   });
 
   test("select mode takes the breadcrumb's place at the SAME height, from the first click", async ({
@@ -6680,54 +6747,53 @@ test.describe("graph view E2E", () => {
     expect(await height()).toBe(browseHeight);
   });
 
-  test("in the grid the anchor's ⋮ sits in the CAPTION, not on the artwork", async ({
+  test("the grid card carries NO ⋮ — the select row holds its actions", async ({
     page,
   }) => {
-    // The mockup's split: the title row is chrome (type, name, actions) and the
-    // thumbnail is content. Ours had the one remaining piece of chrome stamped
-    // across the picture, in the top-right corner.
+    // This used to assert WHERE the grid's ⋮ sat (down in the caption band,
+    // trailing the name). It is gone from the grid entirely: every action it
+    // opened is on the select row, so a per-card menu was a second route to the
+    // same list parked in the corner of every cell.
     //
-    // Measured as bands rather than asserted on classes, because the property
-    // is positional and three things feed it — the card's own box, the caption's
-    // height, and the offset. A class assertion would pass with the control
-    // sitting anywhere.
+    // Measured as zero height rather than as absence. The control is HIDDEN,
+    // not deleted — `CardCornerSlot` still renders and still tracks the anchor
+    // so restoring it is one class — so it is still in the DOM, and an absence
+    // assertion would fail for a reason that is not the behaviour.
     await installGraphApi(page);
     await openGraph(page);
     await surfaceButton(page, "grid").click();
 
     for (const nodeId of ["alpha", CHILD_ID]) {
       // Ctrl/Cmd+click: a plain click on the COLLECTION would drill in, and
-      // this needs the card to become the anchor while staying on screen.
+      // this needs the card to become the ANCHOR while staying on screen —
+      // which is the point. Asserting on a card that was never anchored would
+      // pass whether or not the grid rule exists.
       await page
         .locator(`[data-virtual-grid] [data-node-id="${nodeId}"]`)
         .click({ modifiers: ["ControlOrMeta"] });
-      const geometry = await page.evaluate((id) => {
-        const card = document.querySelector(`[data-virtual-grid] [data-node-id="${CSS.escape(id)}"]`);
-        const dots = document.querySelector("[data-anchor-menu]");
-        const art = card?.querySelector("img");
-        if (!card || !dots) return null;
-        const c = card.getBoundingClientRect();
-        const d = dots.getBoundingClientRect();
-        return {
-          artworkBottom: art ? art.getBoundingClientRect().bottom : null,
-          dotsTop: d.top,
-          dotsBottom: d.bottom,
-          cardBottom: c.bottom,
-          cardRight: c.right,
-          dotsRight: d.right,
-        };
-      }, nodeId);
-      expect(geometry, `no anchor ⋮ for ${nodeId}`).not.toBeNull();
+      await expect(
+        page.locator(`[data-virtual-grid] [data-node-id="${nodeId}"]`),
+      ).toHaveAttribute("data-selected", "true");
 
-      // BELOW the artwork — the assertion the old top-right position failed.
-      if (geometry!.artworkBottom !== null) {
-        expect(geometry!.dotsTop).toBeGreaterThanOrEqual(geometry!.artworkBottom - 1);
-      }
-      // …and still inside the card, not hanging off its bottom edge.
-      expect(geometry!.dotsBottom).toBeLessThanOrEqual(geometry!.cardBottom);
-      // Trailing the row, not floating mid-card.
-      expect(geometry!.cardRight - geometry!.dotsRight).toBeLessThanOrEqual(16);
+      const dots = await page.evaluate(() => {
+        const found = document.querySelector("[data-anchor-menu]");
+        return found === null ? null : found.getBoundingClientRect().height;
+      });
+      expect(dots ?? 0, `grid ⋮ still laid out for ${nodeId}`).toBe(0);
     }
+
+    // And the actions ARE reachable: arming select mode gives the row.
+    await page.locator("[data-select-mode-toggle]").click();
+    await expect(page.locator("[data-graph-board-header]")).toHaveAttribute(
+      "data-header-mode",
+      "select",
+    );
+    // Scoped to the run's OWN children: the row renders a hidden ruler copy of
+    // every verb to measure against, so an unscoped lookup finds each of them
+    // twice and trips strict mode.
+    await expect(
+      page.locator("[data-select-mode-verbs] > [data-header-action='delete']"),
+    ).toBeVisible();
   });
 
   test("the STRIP keeps its ⋮ on the card, where there is no caption to hold it", async ({
@@ -6795,6 +6861,41 @@ test.describe("graph view E2E", () => {
     await alpha.hover();
     await alpha.locator("[data-selection-indicator]").click();
     await expect(alpha).toHaveAttribute("data-selected", "true");
+  });
+
+  test("the checkbox ARMS the mode — the header swaps its breadcrumbs for the select row", async ({
+    page,
+  }) => {
+    // THE HEADER IS THE BUG. The checkbox filled in, but the row above it is
+    // driven by `multiSelectMode` alone (GraphBoard's `selectModeRow`), and
+    // toggling a selection never armed that — so a picked card got no count, no
+    // verbs and no Done, while the breadcrumb trail sat there as if nothing had
+    // happened. Pressing Select produced the right row; the checkbox did not.
+    await installGraphApi(page);
+    await openGraph(page);
+    const surface = strip(page, PROJECT_ID);
+    const card = surface.locator('[data-node-id="alpha"]');
+    const header = page.locator("[data-graph-board-header]");
+    const checkbox = card.locator("[data-selection-indicator]");
+
+    // The premise: browsing, with the trail showing.
+    await expect(header).toHaveAttribute("data-header-mode", "browse");
+
+    await card.hover();
+    await checkbox.click();
+
+    await expect(card).toHaveAttribute("data-selected", "true");
+    await expect(header).toHaveAttribute("data-header-mode", "select");
+    await expect(page.locator("[data-select-mode-count]")).toHaveText("1 selected");
+
+    // Un-checking the last card does NOT throw you back out. It holds at
+    // "0 selected", which is where pressing Select and picking nothing lands
+    // too — disarming here would yank the row away at the exact moment someone
+    // is correcting a mis-pick, and Done is the deliberate way out.
+    await checkbox.click();
+    await expect(card).not.toHaveAttribute("data-selected", "true");
+    await expect(header).toHaveAttribute("data-header-mode", "select");
+    await expect(page.locator("[data-select-mode-count]")).toHaveText("0 selected");
   });
 
   test("a hidden checkbox is not a click trap", async ({ page }) => {

--- a/packages/ui/dnd-collections/react/default-item-content.tsx
+++ b/packages/ui/dnd-collections/react/default-item-content.tsx
@@ -49,7 +49,7 @@ function DefaultTrimReadout({ id, node }: { id: NodeId; node: MediaNode }) {
       {live !== null && (
         <span
           data-trim-preview={live.effectiveSeconds}
-          className="pointer-events-none absolute -top-5 left-1/2 z-30 -translate-x-1/2 rounded bg-amber-300 px-1.5 py-0.5 text-[10px] font-bold text-black shadow"
+          className="pointer-events-none absolute -top-5 left-1/2 z-30 -translate-x-1/2 rounded bg-blue-400 px-1.5 py-0.5 text-[10px] font-bold text-black shadow"
         >
           {roundSecondsForDisplay(live.effectiveSeconds)}s
         </span>

--- a/packages/ui/dnd-collections/react/trim-handles.tsx
+++ b/packages/ui/dnd-collections/react/trim-handles.tsx
@@ -21,18 +21,18 @@ import { resolveTrim, useTrimPointerDrag, type TrimSide } from "./trim-gesture";
 // never reach dnd-kit's item-drag sensor or the strip's pan; they also carry
 // `data-trim-handle` so the pan's surface filter skips them) — while the
 // pixels INSIDE each zone come from the `TrimHandleContent` registry slot,
-// defaulting to the amber grip bar below. Duration readouts (the pill, the
+// defaulting to the blue grip bar below. Duration readouts (the pill, the
 // live preview bubble) are CONTENT, not handle chrome: the default ones live
 // in `DefaultItemContent`, driven by `useLiveTrim`.
 
-/** The stock handle pixels: amber fill, visible-on-hover, center grip line. */
+/** The stock handle pixels: blue fill, visible-on-hover, center grip line. */
 export const DefaultTrimHandleContent = memo(function DefaultTrimHandleContent({
   side,
 }: CollectionTrimHandleContentProps) {
   return (
     <span
       className={[
-        "flex h-full w-full items-center justify-center bg-amber-300 opacity-70 transition-opacity hover:opacity-100 group-hover:opacity-100",
+        "flex h-full w-full items-center justify-center bg-blue-500 opacity-70 transition-opacity hover:opacity-100 group-hover:opacity-100",
         side === "left" ? "rounded-l-md" : "rounded-r-md",
       ].join(" ")}
     >

--- a/packages/ui/dnd-collections/react/trim-overview.tsx
+++ b/packages/ui/dnd-collections/react/trim-overview.tsx
@@ -199,21 +199,25 @@ export const TrimOverviewStrip = memo(function TrimOverviewStrip({
         style={{ width: trimOut * scale }}
       />
 
-      {/* The amber "showing" window, with draggable trim grips on each edge. */}
+      {/* The "showing" window, with draggable trim grips on each edge.
+          BLUE, matching the trim handles on the clip itself and the ring on a
+          selected card — this control only appears for a selected clip, and
+          the window plus its grips are the same gesture as those handles seen
+          at source scale, so one accent covers the whole trim widget. */}
       <div
         data-trim-overview-window
-        className="absolute inset-y-0 rounded-sm border-2 border-amber-300 bg-amber-300/10 shadow-[0_0_0_1px_rgba(0,0,0,0.5)]"
+        className="absolute inset-y-0 rounded-sm border-2 border-blue-500 bg-blue-500/10 shadow-[0_0_0_1px_rgba(0,0,0,0.5)]"
         style={{ width: windowWidth, transform: `translateX(${trimInWidth}px)` }}
       >
         <span
           data-trim-overview-handle="left"
           onPointerDown={startTrim("left")}
-          className="absolute inset-y-0 left-0 z-10 w-2 cursor-ew-resize rounded-l-sm bg-amber-200/90"
+          className="absolute inset-y-0 left-0 z-10 w-2 cursor-ew-resize rounded-l-sm bg-blue-400/90"
         />
         <span
           data-trim-overview-handle="right"
           onPointerDown={startTrim("right")}
-          className="absolute inset-y-0 right-0 z-10 w-2 cursor-ew-resize rounded-r-sm bg-amber-200/90"
+          className="absolute inset-y-0 right-0 z-10 w-2 cursor-ew-resize rounded-r-sm bg-blue-400/90"
         />
       </div>
     </div>

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -1425,7 +1425,7 @@ export function WorkbenchDisplaySurface({
             Top-LEFT: the close button owns the right corner. */}
         {activeClip?.disabled === true && (
           <span
-            className="pointer-events-none absolute left-2 top-2 z-10 rounded bg-black/80 px-1.5 py-0.5 font-mono text-[10px] leading-none font-semibold tracking-[0.08em] text-amber-300 ring-1 ring-amber-400/40"
+            className="pointer-events-none absolute left-2 top-2 z-10 rounded bg-black/80 px-1.5 py-0.5 font-mono text-[10px] leading-none font-semibold tracking-[0.08em] text-blue-400 ring-1 ring-blue-500/40"
             data-testid="workbench-display-disabled"
           >
             DISABLED


### PR DESCRIPTION
Ten UI fixes from a review pass, plus an app-wide accent sweep.

## Selection
- **The card's round checkbox now arms select mode.** It toggled the selection and nothing else, so the card filled in while the breadcrumb trail sat unchanged — a pick with no count, no verbs, and no visible way back out.
- **The select row's `⋮` appears only when a verb does not fit**, sits inside the run right after Delete, and holds *only* what was folded. It used to be permanent and carry the whole action list, which made the row's own verbs read as decorative. Fitting is a two-pass measurement so the menu's width is reserved only once something has actually overflowed.
- **Grid cards carry no corner menu.** Hidden, not deleted — one class in `CardCornerSlot` brings it back. The strip keeps its own: narrow cards, no caption band, no select row to fall back on.

## Cards
- **An unnamed clip captions as nothing.** It fell back to the kind, which put "Image" on every un-authored card in the name's own typography and undid what PL11-004 set out to do.
- **Media and collection captions line up.** Three separate causes, each invisible until the previous was fixed: padding (`4/2/2/8` vs `6/6/6/10`), icon box (14 vs 16), and the last pixel — the collection's dashed border consumes layout where media's `ring` does not. Compensated at the caption rather than by giving media a matching border, which moved the whole content box and shifted the trim frame by 1px (the e2e caught it).
- **Audio cards show a music glyph.** The drawn waveform was a fixed pseudo-random bar set, so every audio file drew identical peaks — it looked like data while being decoration.
- **A grid video is one full-width frame.** The strip keeps its filmstrip, where a card's width *is* its duration.
- **Tags are grid-only, fitted by measurement, `+N` lists the rest on hover.** In the strip, two width thresholds meant a clip's *length* decided which of its tags you saw.

## Colour
amber → blue app-wide (`400` → `500`, the selection step). Amber was the selection colour once; after selection moved to blue it read as a second, unrelated accent.

**Four amber uses are deliberately kept**, because they carry meaning rather than accent — blue would erase the distinction, and one would collide with the selection colour itself:

| Where | Meaning |
|---|---|
| `tag-accent-dot` | the `progress` tag family (`wip` is amber in the mock) |
| `graph-save-status` | save **failed** |
| `graph-item-disable-toggle` | clip is **disabled** — blue would read as selected |
| `graph-persistence` | bounced write |

## Testing
- The checkbox regression was **proven to fail first** (`expected "select", received "browse"`).
- Caption alignment is pinned in **both** card kinds against one shared constant — either story alone can be made to pass by breaking alignment.
- Grid/strip pairs for the frame count and the corner menu, both asserted while the card is the **anchor**, so absence cannot pass for the wrong reason.
- New `openSelectionMenu` helper picks the card's menu or the header's by layout. Worth knowing: `boundingBox()` **waits for visibility**, so measuring a `display:none` control burns the full timeout — use `isVisible()`.

Verified: lint 0 errors · `packages/ui` typecheck clean · 189/189 stories · 156/156 graph-view e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)