### PR TITLE
The select row stops repeating itself, and a name is one click from editable

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -41,7 +41,11 @@ import { flattenMediaOrder } from "@storyboard/timeline-domain";
 
 import { formatDuration } from "@/lib/format-duration";
 import { graphClipboard } from "@/lib/graph-clipboard";
-import { itemActionSpec, type ItemActionState } from "@/lib/graph-item-action-specs";
+import {
+  itemActionShortLabel,
+  itemActionSpec,
+  type ItemActionState,
+} from "@/lib/graph-item-action-specs";
 import {
   GRAPH_BOARD_MENU_SLOT_ID,
   requestGraphItemAction,
@@ -827,7 +831,11 @@ function SelectModeButton() {
  * away rather than gone.
  */
 const SELECT_MODE_VERBS: readonly GraphItemAction[] = [
-  "details",
+  // EDIT IS NOT HERE. It acts on exactly one item, so in the one mode built for
+  // picking several it is dimmed more often than not — a permanent slot in the
+  // row spent on a verb that mostly cannot run, saying "one only" beside a
+  // count that says otherwise. It stays in the full menu, where a single
+  // selection reaches it in one click.
   "copy",
   "cut",
   "duplicate",
@@ -839,13 +847,15 @@ const SELECT_MODE_VERBS: readonly GraphItemAction[] = [
  * The order they SURVIVE in as the row narrows — first is kept longest.
  *
  * DELIBERATELY NOT the draw order. Dropping from the right would take Delete
- * first, and Delete plus Edit are the two verbs that were promoted when this
- * row held a fixed three; losing them to a narrow window while Cut stayed would
- * be a regression dressed up as responsiveness. Draw order is what reads well
- * left to right; this is what matters when there is not room for all of it.
+ * first — the verb most worth keeping — while Cut stayed, which would be a
+ * regression dressed up as responsiveness. Draw order is what reads well left
+ * to right; this is what matters when there is not room for all of it.
+ *
+ * Must hold exactly the same members as SELECT_MODE_VERBS: the fit maths looks
+ * each of these up by `indexOf` in that list, so a verb here and not there
+ * measures as zero width and one there and not here is never drawn at all.
  */
 const SELECT_MODE_VERB_PRIORITY: readonly GraphItemAction[] = [
-  "details",
   "delete",
   "duplicate",
   "copy",
@@ -958,11 +968,20 @@ function SelectModeVerb({
   state,
 }: Readonly<{ action: GraphItemAction; state: ItemActionState }>) {
   const spec = itemActionSpec(action);
-  const label = spec.label(state);
+  // VISIBLE text is uncounted; the ACCESSIBLE name keeps the count.
+  //
+  // The row already opens with "3 selected", so drawing "Cut 3 items · Copy 3
+  // items · Delete 3 items" beside it said the same number four times. But a
+  // screen-reader user arriving on the button by tab has not necessarily just
+  // heard the count, and "Delete" alone does not say what it is about to
+  // delete — so the name that is ANNOUNCED still carries it. Short label for
+  // the eye, full label for the ear.
+  const label = itemActionShortLabel(spec, state);
+  const spokenLabel = spec.label(state);
   const reason = spec.unavailableReason(state);
   const disabled = spec.disabled(state);
   const icon = createElement(spec.icon(state), { "aria-hidden": true, className: "h-4 w-4" });
-  const name = reason === null ? label : `${label}, ${reason}`;
+  const name = reason === null ? spokenLabel : `${spokenLabel}, ${reason}`;
 
   return (
     <button

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -193,12 +193,23 @@ export const PlaceholderAriaCountMatchesBadge: Story = {
     await expect(canvasElement).toHaveTextContent(/8\.0s\s*\/\s*2 items/);
 
     const name = canvasElement.querySelector<HTMLElement>(
-      '[title="Double-click or press F2 to rename"]',
+      '[title="Click or press F2 to rename"]',
     )!;
     const surfaceRect = surface.getBoundingClientRect();
     const nameRect = name.getBoundingClientRect();
-    await expect(nameRect.left - surfaceRect.left).toBeGreaterThanOrEqual(9);
-    await expect(surfaceRect.right - nameRect.right).toBeGreaterThanOrEqual(9);
+    // The name's TEXT must clear the card's edges — so its own padding counts.
+    //
+    // The label carries `-mx-1 px-1`: the box reaches 4px further out on each
+    // side to give the rename hover a target bigger than the glyphs, while the
+    // padding puts the text back exactly where it was. Measuring the raw box
+    // therefore reports a text inset 4px smaller than the one on screen, which
+    // is what this assertion used to do — it failed on a card whose text had
+    // not moved a pixel.
+    const style = getComputedStyle(name);
+    const padLeft = Number.parseFloat(style.paddingLeft) || 0;
+    const padRight = Number.parseFloat(style.paddingRight) || 0;
+    await expect(nameRect.left + padLeft - surfaceRect.left).toBeGreaterThanOrEqual(9);
+    await expect(surfaceRect.right - (nameRect.right - padRight)).toBeGreaterThanOrEqual(9);
     await expect(surfaceRect.bottom - nameRect.bottom).toBeGreaterThanOrEqual(7);
   },
 };
@@ -252,7 +263,9 @@ export const ComposedCardStructure: Story = {
     const label = Array.from(surface!.querySelectorAll("span")).find(
       (el) => el.textContent === "A timeline",
     )!;
-    await userEvent.dblClick(label);
+    // ONE click opens it now — the label used to swallow the first click
+    // and rename on the second.
+    await userEvent.click(label);
     const editor = canvasElement.querySelector<HTMLInputElement>(
       'input[aria-label="Timeline name"]',
     );
@@ -1455,7 +1468,7 @@ export const CollectionGridCaptionLeadsWithItsKind: Story = {
     // LEADS the name — left of it, on the same line. Both halves matter: an
     // icon that wrapped above the name would satisfy a left-of test on its own.
     const name = canvasElement.querySelector<HTMLElement>(
-      '[title="Double-click or press F2 to rename"]',
+      '[title="Click or press F2 to rename"]',
     )!;
     const kindRect = kind.getBoundingClientRect();
     const nameRect = name.getBoundingClientRect();

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -1096,6 +1096,46 @@ function renderCollectionInSelectMode(): Decorator {
 const CAPTION_INSET_PX = 13;
 const CAPTION_ICON_PX = 16;
 
+/**
+ * The caption block's height — the SAME on both card kinds, tagged or not.
+ *
+ * Two rows always: identity on top, tags underneath, and an untagged card keeps
+ * an empty second row rather than collapsing. Both halves of that were broken
+ * and neither was visible to a test that looked at one card alone:
+ *
+ *  - `min-h` on the tag row reserved the wrong thing. Under `border-box` it
+ *    includes the element's own padding, and the collection's row carries
+ *    `pt-1 pb-1.5` where the media card's carries none — so it reserved 14px
+ *    total, got 4px of content, and jumped to 24px once real chips arrived.
+ *    A tagged collection was 10px taller than an untagged one beside it.
+ *  - Row one collapsed to its ICON (16px) on a card with no name, against a
+ *    text line's 20px on a named one.
+ *
+ * Asserted in four stories against this one number rather than against each
+ * other, because a story renders one card and these two kinds cannot share a
+ * canvas. If a redesign moves it, move all four together.
+ */
+const CAPTION_BLOCK_PX = 54;
+
+/** Measure the caption block, whichever card kind rendered it. */
+async function expectCaptionBlockHeight(canvasElement: HTMLElement): Promise<void> {
+  const media = canvasElement.querySelector<HTMLElement>("[data-clip-caption]");
+  if (media !== null) {
+    await expect(Math.round(media.getBoundingClientRect().height)).toBe(CAPTION_BLOCK_PX);
+    return;
+  }
+  // The collection's two rows are siblings on the selection surface rather than
+  // children of one box (row one is the STRIP's footer too), so the block is
+  // measured across them — plus row one's top MARGIN, which is that card's
+  // version of the media caption's top padding.
+  const row = canvasElement.querySelector<HTMLElement>("[data-collection-metadata]")!;
+  const tags = canvasElement.querySelector<HTMLElement>("[data-collection-caption-tags]")!;
+  const marginTop = Number.parseFloat(getComputedStyle(row).marginTop) || 0;
+  const height =
+    tags.getBoundingClientRect().bottom - row.getBoundingClientRect().top + marginTop;
+  await expect(Math.round(height)).toBe(CAPTION_BLOCK_PX);
+}
+
 /** The caption's leading icon must start at the same inset on any card kind. */
 async function expectCaptionIconAligned(
   canvasElement: HTMLElement,
@@ -1135,6 +1175,8 @@ export const GridCardCaptionSitsUnderTheArtwork: Story = {
 
     // ALIGNED with a collection card's caption — see CAPTION_INSET_PX.
     await expectCaptionIconAligned(canvasElement, caption.querySelector("svg")!);
+    // ...and the same HEIGHT as one, with no tags to fill row two.
+    await expectCaptionBlockHeight(canvasElement);
 
     // BELOW the frame, not over it. Measured, because the whole change is a
     // geometric one and a caption that rendered on top of the artwork would
@@ -1222,6 +1264,10 @@ export const CaptionTagsFoldStatusFirst: Story = {
       .slice(0, 2)
       .map((chip) => chip.querySelector("[data-tag-accent]")?.getAttribute("data-tag-accent"));
     await expect(accents).toEqual(["ok", "progress"]);
+
+    // TAGGED, and exactly as tall as the untagged twin — the half the empty-row
+    // reservation exists for. See CAPTION_BLOCK_PX.
+    await expectCaptionBlockHeight(canvasElement);
   },
 };
 
@@ -1426,6 +1472,10 @@ export const CollectionGridTagsSitInTheCaption: Story = {
     await expect(caption.getBoundingClientRect().top).toBeGreaterThanOrEqual(
       frame.getBoundingClientRect().bottom - 1,
     );
+
+    // TAGGED, and exactly as tall as the untagged twin — this is the pairing
+    // that caught the reservation being 10px short. See CAPTION_BLOCK_PX.
+    await expectCaptionBlockHeight(canvasElement);
   },
 };
 
@@ -1451,6 +1501,7 @@ export const CollectionGridCaptionLeadsWithItsKind: Story = {
     // asserts the identical two numbers, which is what makes a mixed grid line
     // up. See CAPTION_INSET_PX.
     await expectCaptionIconAligned(canvasElement, kind);
+    await expectCaptionBlockHeight(canvasElement);
 
     // A LABEL: hidden from the a11y tree, and no control of its own.
     //

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -713,6 +713,70 @@ function ProvenanceLabel({
  */
 const CAPTION_TAG_GAP_PX = 4;
 
+/**
+ * The caption's two rows, shared by BOTH card kinds.
+ *
+ * A grid caption is always TWO rows: identity on top (kind glyph, name, and the
+ * metadata trailing right), tags underneath, right-justified. The two kinds
+ * used to disagree about the shape — a collection put its metadata on row one
+ * and its tags in a span of their own, media stacked name over
+ * metadata-plus-tags — so a mixed grid showed two different objects.
+ *
+ * Shared as CONSTANTS rather than as matching literals in two places, because
+ * matching literals is exactly what drifted: the alignment work before this had
+ * to reconcile four separate numbers that were only ever meant to be equal.
+ */
+const CAPTION_ROW_CLASS = "flex min-h-5 min-w-0 items-center gap-1.5";
+
+/**
+ * Row two, and it is ALWAYS RENDERED — an untagged card keeps an empty one.
+ *
+ * That is the whole point of the `min-h`: with the row omitted, a tagged card
+ * was taller than an untagged one, so a grid of mixed cards had captions of two
+ * heights and the artwork above them started at two different places. Reserving
+ * the height costs one empty row and buys every card the same box.
+ *
+ * The height is held by a SPACER (`CaptionTagRowSpacer`), not by a `min-h` on
+ * the row. `min-h` was the first attempt and it was measurably wrong: under
+ * `border-box` a min-height includes the element's own padding, so the
+ * collection's row — which carries `pt-1 pb-1.5` where the media card's does
+ * not — reserved 14px total and got 4px of content, then grew to 24px once real
+ * chips arrived. Media was 14px either way; the collection was 14 vs 24, so its
+ * artwork moved 10px depending on whether the card happened to be tagged. A
+ * spacer reserves CONTENT height, which every padding then adds to equally.
+ *
+ * NO display utility here, deliberately. The collection's copy is grid-gated
+ * (`hidden [[data-virtual-grid]_&]:flex`) and a `flex` baked in would collide
+ * with that `hidden` — two display utilities on one element, resolved by CSS
+ * source order rather than by the order they are written, which is a coin toss
+ * dressed up as a class list. Each caller states its own.
+ */
+const CAPTION_TAG_ROW_CLASS = "min-w-0 items-center justify-end";
+
+/**
+ * Holds row two open at exactly one chip's height when there are no tags.
+ *
+ * 14px is a chip's own box (`text-[10px] leading-none` + `py-0.5`); the ring is
+ * a box-shadow and costs no layout. Zero WIDTH so it cannot push the chips it
+ * stands in for, and `shrink-0` so a crowded row cannot squeeze it back to
+ * nothing — which would silently restore the height difference it exists to
+ * remove.
+ */
+function CaptionTagRowSpacer() {
+  return <span aria-hidden="true" className="block h-[14px] w-0 shrink-0" />;
+}
+
+/**
+ * The trailing metadata on row one — duration, and a collection's item count.
+ *
+ * Modelled on the collection card's, which is the one the owner picked: mono,
+ * medium, zinc-300, stepping up a size in the grid. `ml-auto` is what puts it
+ * at the row's right edge without a `justify-between` that would also fight the
+ * name's `flex-1`.
+ */
+const CAPTION_META_CLASS =
+  "ml-auto flex shrink-0 items-center gap-1 font-mono text-[11px] font-medium text-zinc-300 [[data-virtual-grid]_&]:text-xs";
+
 function CaptionTagRow({ tags }: Readonly<{ tags: readonly string[] }>) {
   const ordered = useMemo(() => sortTagsStatusFirst(tags), [tags]);
   const containerRef = useRef<HTMLSpanElement | null>(null);
@@ -1296,7 +1360,8 @@ const GraphClipContent = memo(function GraphClipContent({
         // contract, not the individual numbers, and the stories measure it.
         className="hidden min-w-0 flex-col gap-1 pt-2.5 pr-1.5 pb-1.5 pl-[7px] [[data-virtual-grid]_&]:flex"
       >
-        <span className="flex min-w-0 items-center gap-1.5">
+        {/* ROW ONE: kind, name, metadata — the collection card's shape. */}
+        <span className={CAPTION_ROW_CLASS}>
           {/* `size-4` AND lucide's default stroke, both matching the collection
               caption's Layers glyph.
 
@@ -1309,30 +1374,35 @@ const GraphClipContent = memo(function GraphClipContent({
               lead their captions with one glyph style. */}
           <KindIcon aria-hidden="true" className="size-4 shrink-0 text-zinc-400" />
           {/* Omitted, not blanked, when the clip has no authored name — see
-              `captionName`. The icon keeps the row's height and left edge, so
-              the meta line below stays put whether or not there is a name. */}
+              `captionName`. The icon holds the row's height and left edge, and
+              the metadata's `ml-auto` holds its right edge, so the row keeps
+              its shape whether or not there is a name between them. */}
           {captionName === null ? null : (
             <span className="min-w-0 flex-1 truncate text-sm font-semibold text-zinc-100">
               {captionName}
             </span>
           )}
-        </span>
-        {/* Row two is omitted ENTIRELY when it would be empty, rather than
-            rendered blank: an untagged image has neither duration nor chips,
-            and an empty row would still claim its gap and leave the caption
-            looking like it failed to load something. */}
-        {captionSeconds > 0 || detail?.tags?.length ? (
-          <span className="flex min-w-0 items-center gap-2">
+          {/* The duration, trailing right — where a collection's count sits. It
+              used to head row two, which put a number under the name on media
+              and beside it on collections. */}
+          <span className={CAPTION_META_CLASS}>
             {captionSeconds > 0 ? (
-              <span className="shrink-0 font-mono text-[11px] leading-none text-sky-300/90">
+              <span className="text-sky-300/90" title="Duration">
                 {formatDuration(captionSeconds)}
               </span>
             ) : null}
-            {detail?.tags?.length ? (
-              <CaptionTagRow tags={detail.tags} />
-            ) : null}
           </span>
-        ) : null}
+        </span>
+        {/* ROW TWO: tags, right-justified — and PRESENT even when empty, so a
+            tagged card and an untagged one are the same height. See
+            CAPTION_TAG_ROW_CLASS. */}
+        <span data-clip-caption-tag-row className={`flex ${CAPTION_TAG_ROW_CLASS}`}>
+          {detail?.tags?.length ? (
+            <CaptionTagRow tags={detail.tags} />
+          ) : (
+            <CaptionTagRowSpacer />
+          )}
+        </span>
       </span>
     </span>
   );
@@ -1699,7 +1769,14 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
           // contract.
           className={[
             "mt-1.5 flex items-center justify-between gap-1.5 pl-1 pb-0.5",
-            "[[data-virtual-grid]_&]:mt-2.5 [[data-virtual-grid]_&]:pl-1.5 [[data-virtual-grid]_&]:pb-1.5",
+            // GRID: no bottom padding, because this is no longer the caption's
+            // last row — the tag row below carries the caption's bottom edge and
+            // the 4px between the two. Left as-is in the STRIP, where this row
+            // IS the footer and there is nothing under it.
+            // `min-h-5` in the grid, matching CAPTION_ROW_CLASS on the media
+            // card: row one is a text line tall whether or not it holds text,
+            // so a nameless card is not shorter than a named one.
+            "[[data-virtual-grid]_&]:mt-2.5 [[data-virtual-grid]_&]:min-h-5 [[data-virtual-grid]_&]:pl-1.5 [[data-virtual-grid]_&]:pb-0",
             muted ? "pr-[4.75rem]" : "pr-1 [[data-virtual-grid]_&]:pr-1.5",
           ].join(" ")}
         >
@@ -1755,7 +1832,7 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
           >
             {displayName}
           </span>
-          <span className="flex shrink-0 items-center gap-1 font-mono text-[11px] font-medium text-zinc-300 [[data-virtual-grid]_&]:text-xs">
+          <span className={CAPTION_META_CLASS}>
             {typeof totalSeconds === "number" && totalSeconds > 0 ? (
               <>
                 <span className="text-sky-300/90" title="Total duration of contents">
@@ -1771,20 +1848,37 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
             </span>
           </span>
         </span>
-        {/* The collection's tags, in the GRID, under its name row — the twin of
-            the media card's caption tag row, and for the same reason: the cell
-            is tall enough to say this in words instead of stamping it over the
-            preview frames. A row of its own rather than squeezed in beside the
-            item count, which is already a name plus two numbers. */}
-        {detail?.tags?.length ? (
-          <span
-            aria-hidden="true"
-            data-collection-caption-tags={detail.tags.length}
-            className="hidden min-w-0 items-center pr-1.5 pb-1 pl-1.5 [[data-virtual-grid]_&]:flex"
-          >
+        {/* ROW TWO: the collection's tags, right-justified — the media card's
+            second row exactly, from the same two constants.
+
+            ALWAYS RENDERED in the grid, empty or not. It used to appear only
+            when there were tags, which made a tagged collection taller than an
+            untagged one sitting beside it. `data-collection-caption-tags` still
+            carries the count, so a test can tell "no tags" from "no row".
+
+            Grid-only, like everything else in this caption: the strip's footer
+            is a tight one-liner with no room for a second row. */}
+        <span
+          aria-hidden="true"
+          data-collection-caption-tags={detail?.tags?.length ?? 0}
+          // `pt-1` is the media caption's `gap-1` written as padding: these two
+          // rows are siblings on the selection surface rather than children of
+          // one flex column (row one is the STRIP's footer too, so it cannot be
+          // moved into a grid-only wrapper), and a gap needs a shared parent.
+          // Same 4px either way — the stories measure the two captions against
+          // each other rather than trusting that.
+          className={[
+            "hidden pt-1 pr-1.5 pb-1.5 pl-1.5",
+            "[[data-virtual-grid]_&]:flex",
+            CAPTION_TAG_ROW_CLASS,
+          ].join(" ")}
+        >
+          {detail?.tags?.length ? (
             <CaptionTagRow tags={detail.tags} />
-          </span>
-        ) : null}
+          ) : (
+            <CaptionTagRowSpacer />
+          )}
+        </span>
       </CollectionItem.SelectionSurface>
 
       {/* (PL10-001 moved the call-out itself onto the selection surface above.

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -784,7 +784,12 @@ function CaptionTagRow({ tags }: Readonly<{ tags: readonly string[] }>) {
       // space the chips are using", which is always yes — the fold then never
       // fires, or fires against a box that shrank because of the last answer.
       // Same one-way rule the select row's verb container follows.
-      className="relative flex min-w-0 flex-1 items-center gap-1 overflow-hidden"
+      //
+      // RIGHT-JUSTIFIED via `justify-end` rather than by letting the box shrink
+      // to its contents — the two look identical until the row is measured, and
+      // shrinking is the thing that breaks the fold. The container still spans
+      // the leftover width; only the chips inside it sit at its right edge.
+      className="relative flex min-w-0 flex-1 items-center justify-end gap-1 overflow-hidden"
     >
       {/* The ruler: every chip, laid out but invisible. `visibility:hidden`
           rather than `display:none` so the boxes still measure, absolute so it
@@ -1292,14 +1297,17 @@ const GraphClipContent = memo(function GraphClipContent({
         className="hidden min-w-0 flex-col gap-1 pt-2.5 pr-1.5 pb-1.5 pl-[7px] [[data-virtual-grid]_&]:flex"
       >
         <span className="flex min-w-0 items-center gap-1.5">
-          {/* `size-4`, matching the collection caption's Layers glyph. At
-              `size-3.5` the two icon boxes differed by 2px, so every name in a
-              mixed grid started at one of two x positions. */}
-          <KindIcon
-            aria-hidden="true"
-            strokeWidth={1.7}
-            className="size-4 shrink-0 text-zinc-400"
-          />
+          {/* `size-4` AND lucide's default stroke, both matching the collection
+              caption's Layers glyph.
+
+              The size was the visible half: at `size-3.5` the two icon boxes
+              differed by 2px, so every name in a mixed grid started at one of
+              two x positions. The WEIGHT was the quieter half — this carried
+              `strokeWidth={1.7}` against Layers' default 2, so at identical
+              size the media glyph still drew a lighter line than the collection
+              beside it. Same size, same weight, same colour: the two card kinds
+              lead their captions with one glyph style. */}
+          <KindIcon aria-hidden="true" className="size-4 shrink-0 text-zinc-400" />
           {/* Omitted, not blanked, when the clip has no authored name — see
               `captionName`. The icon keeps the row's height and left edge, so
               the meta line below stays put whether or not there is a name. */}
@@ -1712,28 +1720,38 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
             className="hidden size-4 shrink-0 text-zinc-400 [[data-virtual-grid]_&]:block"
           />
           <span
-            // The NAME swallows a plain click, so the card body's drill-in does
-            // not fire underneath it.
+            // ONE CLICK RENAMES. The name already swallowed the click — it had
+            // to, because a plain click on the card DRILLS IN, which unmounts
+            // this card before a second click can land, and that is what broke
+            // double-click-to-rename in the first place. So the click was being
+            // caught and thrown away: the label's advertised gesture cost two
+            // presses while one press did nothing at all. It now does the thing
+            // the label is for.
             //
-            // Required by the single-click drill-in, not decoration: click 1 of
-            // a double-click used to be harmless here (it selected), and now it
-            // NAVIGATES — which unmounts this card before the second click can
-            // arrive, so double-click-to-rename simply stopped working. Letting
-            // the label eat the single click is what gives the gesture somewhere
-            // to happen.
-            //
-            // The cost is a small dead zone: clicking a collection's name does
-            // nothing rather than opening it. That is the right trade for a
-            // label whose advertised gesture IS rename — and the rest of the
-            // card, which is most of it, still opens on one click.
-            onClick={(event) => event.stopPropagation()}
-            onDoubleClick={(event) => {
+            // `stopPropagation` is still what makes it work — without it the
+            // drill-in fires underneath and navigates away from the field that
+            // just opened. React's synthetic bubbling never reaches the
+            // surface's handler.
+            onClick={(event) => {
               event.stopPropagation();
               rename.begin();
               // (keyboard: F2 on the focused card — see OpenKeyBoundary)
             }}
-            title="Double-click or press F2 to rename"
-            className="min-w-0 flex-1 cursor-text truncate text-xs font-semibold text-zinc-100 [[data-virtual-grid]_&]:text-sm"
+            title="Click or press F2 to rename"
+            className={[
+              "min-w-0 flex-1 cursor-text truncate text-xs font-semibold text-zinc-100",
+              "[[data-virtual-grid]_&]:text-sm",
+              // HOVER SAYS IT IS A FIELD. A one-click target that looks exactly
+              // like static text is a trap in both directions: nobody discovers
+              // the rename, and anyone aiming at the card is surprised by an
+              // editor. The tint is the same shape the field itself takes, so
+              // the hover reads as a preview of what the click opens.
+              //
+              // Negative margin against the padding, so the hit area grows
+              // without the name shifting sideways on hover — and without it
+              // taking width from the count beside it at rest.
+              "-mx-1 rounded-sm px-1 transition-colors hover:bg-white/10",
+            ].join(" ")}
           >
             {displayName}
           </span>

--- a/apps/timeline-gstudio001/components/graph-view/graph-selection-menu.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-selection-menu.tsx
@@ -16,7 +16,11 @@ import {
   DropdownMenuSeparator,
 } from "@/components/core/dropdown-menu";
 import { cn } from "@/lib/utils";
-import { itemActionSections, type ItemActionState } from "@/lib/graph-item-action-specs";
+import {
+  itemActionSections,
+  itemActionShortLabel,
+  type ItemActionState,
+} from "@/lib/graph-item-action-specs";
 import { requestGraphItemAction, type GraphItemAction } from "@/lib/graph-view-events";
 
 // THE selection menu. One definition, three triggers: the anchor card's `⋮`,
@@ -127,10 +131,13 @@ function SelectionMenuRow({
   parts,
   state,
   spec,
+  shortLabels = false,
 }: Readonly<{
   parts: MenuParts;
   state: ItemActionState;
   spec: ReturnType<typeof itemActionSections>[number][number];
+  /** Drop the count from the visible text — see SelectionMenuOverflowItems. */
+  shortLabels?: boolean;
 }>) {
   const { Item } = parts;
   // `createElement` rather than `const Icon = spec.icon(state)`. The lookup
@@ -146,7 +153,10 @@ function SelectionMenuRow({
     // the glyph should register before the word does.
     className: cn(ICON_CLASS, destructive ? undefined : "text-zinc-400"),
   });
-  const label = spec.label(state);
+  // The ANNOUNCED name always carries the count, even where the visible text
+  // drops it — see SelectModeVerb for the same split and the reason.
+  const spokenLabel = spec.label(state);
+  const label = shortLabels ? itemActionShortLabel(spec, state) : spokenLabel;
   const reason = spec.unavailableReason(state);
   const disabled = spec.disabled(state);
   const shortcut = spec.shortcut;
@@ -158,7 +168,18 @@ function SelectionMenuRow({
       // The reason is part of the NAME, not a separate description (R12.5):
       // a description is announced late or not at all depending on the screen
       // reader's verbosity, and this is the half of the row that explains it.
-      aria-label={reason === null ? undefined : `${label}, ${reason}`}
+      //
+      // Also set whenever the visible text is SHORTENED, even with no reason to
+      // give: without it the accessible name falls back to the rendered text,
+      // which is exactly the string the count was just taken out of — so the
+      // row would announce "Cut" and never say how much it is about to cut.
+      aria-label={
+        reason === null
+          ? shortLabels
+            ? spokenLabel
+            : undefined
+          : `${spokenLabel}, ${reason}`
+      }
       onSelect={(event: Event) => {
         if (disabled) {
           event.preventDefault();
@@ -265,7 +286,17 @@ export function SelectionMenuOverflowItems({
           {index > 0 ? <Separator /> : null}
           <div role="group">
             {run.map((spec) => (
-              <SelectionMenuRow key={spec.action} parts={parts} state={state} spec={spec} />
+              <SelectionMenuRow
+                key={spec.action}
+                parts={parts}
+                state={state}
+                spec={spec}
+                // Uncounted, like the verbs beside it. This menu IS the select
+                // row's remainder and opens directly under its "3 selected", so
+                // a row reading "Cut 3 items" an inch from a "Cut" that does not
+                // would look like two different actions.
+                shortLabels
+              />
             ))}
           </div>
         </Fragment>

--- a/apps/timeline-gstudio001/lib/graph-item-action-specs.ts
+++ b/apps/timeline-gstudio001/lib/graph-item-action-specs.ts
@@ -79,6 +79,21 @@ export type ItemActionSpec = Readonly<{
   /** Resolved against state, because several change wording: Disable becomes
    *  Enable, and counts appear once a selection is plural. */
   label: (state: ItemActionState) => string;
+  /**
+   * The same label with the COUNT left off — for surfaces that already show it.
+   *
+   * The select row is one: it opens with "3 selected" and then drew "Cut 3
+   * items · Copy 3 items · Delete 3 items" beside it, saying the same number
+   * four times in one row. The menu keeps the counted `label`, because there it
+   * is doing real work — a row reached from a card can be acted on without the
+   * count being anywhere else on screen.
+   *
+   * OPTIONAL: absent on the verbs that never carry a count anyway (Edit,
+   * Rename, Paste into), where it would only be `label` written twice. Read it
+   * through `itemActionShortLabel` rather than directly, so a caller cannot
+   * forget the fallback and silently drop a label.
+   */
+  shortLabel?: (state: ItemActionState) => string;
   description: (state: ItemActionState) => string;
   icon: (state: ItemActionState) => LucideIcon;
   /** Shown right-aligned in the row (R7.8). These carry the majority of real
@@ -167,6 +182,7 @@ export const ITEM_ACTION_SPECS: readonly ItemActionSpec[] = [
     action: "copy",
     section: "clipboard",
     label: counted("Copy"),
+    shortLabel: () => "Copy",
     description: () => "Copy the selection",
     icon: () => Copy,
     shortcut: "Ctrl/⌘ C",
@@ -178,6 +194,7 @@ export const ITEM_ACTION_SPECS: readonly ItemActionSpec[] = [
     action: "cut",
     section: "clipboard",
     label: counted("Cut"),
+    shortLabel: () => "Cut",
     description: () => "Cut the selection — paste to move it",
     icon: () => Scissors,
     shortcut: "Ctrl/⌘ X",
@@ -189,6 +206,7 @@ export const ITEM_ACTION_SPECS: readonly ItemActionSpec[] = [
     action: "duplicate",
     section: "clipboard",
     label: counted("Duplicate"),
+    shortLabel: () => "Duplicate",
     description: () => "Duplicate the selection",
     icon: () => CopyPlus,
     shortcut: "Ctrl/⌘ D",
@@ -216,6 +234,7 @@ export const ITEM_ACTION_SPECS: readonly ItemActionSpec[] = [
     action: "toggle-disabled",
     section: "state",
     label: (s) => counted(s.allDisabled ? "Enable" : "Disable")(s),
+    shortLabel: (s) => (s.allDisabled ? "Enable" : "Disable"),
     description: (s) =>
       s.allDisabled ? "Play the selection again" : "Keep the slot, skip it on playback",
     icon: (s) => (s.allDisabled ? CircleCheck : Ban),
@@ -230,6 +249,7 @@ export const ITEM_ACTION_SPECS: readonly ItemActionSpec[] = [
     action: "delete",
     section: "destructive",
     label: counted("Delete"),
+    shortLabel: () => "Delete",
     description: () => "Move the selection to trash",
     icon: () => Trash2,
     shortcut: "Delete",
@@ -257,6 +277,20 @@ export function itemActionSpec(action: GraphItemAction): ItemActionSpec {
   const spec = ITEM_ACTION_SPECS.find((candidate) => candidate.action === action);
   if (spec === undefined) throw new Error(`No item action spec for "${action}"`);
   return spec;
+}
+
+/**
+ * The label for a surface that already shows the selection count.
+ *
+ * `shortLabel` where a spec has one, `label` otherwise — read it through here
+ * rather than reaching for the optional field, so a caller cannot forget the
+ * fallback and render `undefined` on the three verbs that never count.
+ */
+export function itemActionShortLabel(
+  spec: ItemActionSpec,
+  state: ItemActionState,
+): string {
+  return (spec.shortLabel ?? spec.label)(state);
 }
 
 /**

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -852,13 +852,23 @@ test.describe("graph view E2E", () => {
     const label = card.getByText("Heist Plan", { exact: true });
     const background = () =>
       label.evaluate((element) => getComputedStyle(element).backgroundColor);
+
+    // The resting value is asserted as a LITERAL rather than sampled first.
+    // Sampling was flaky and CI caught it: the rename click above leaves the
+    // pointer ON the label, so the sample landed mid-fade (`transition-colors`)
+    // and captured a transient oklab — which the settled value then never
+    // matched. Polling to a fixed transparent both waits out the transition and
+    // says what "at rest" means.
+    const TRANSPARENT = "rgba(0, 0, 0, 0)";
     await page.mouse.move(0, 0);
-    const atRest = await background();
+    await expect.poll(background).toBe(TRANSPARENT);
+
     await label.hover();
-    await expect.poll(background).not.toBe(atRest);
+    await expect.poll(background).not.toBe(TRANSPARENT);
+
     // ...and it lets go again, rather than leaving one card looking armed.
     await page.mouse.move(0, 0);
-    await expect.poll(background).toBe(atRest);
+    await expect.poll(background).toBe(TRANSPARENT);
     // And the child document — the source of truth — is persisted.
     await expect
       .poll(() => api.documents.get(CHILD_ID)?.title, { timeout: 5000 })

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -835,14 +835,30 @@ test.describe("graph view E2E", () => {
     const card = strip(page, PROJECT_ID).locator(`[data-node-id="${CHILD_ID}"]`);
     await expect(card).toHaveAttribute("aria-label", /^Scene A \(collection/);
 
-    // Double-click the card's name label → inline editor; commit with Enter.
-    await card.getByText("Scene A", { exact: true }).dblclick();
+    // ONE click on the card's name label → inline editor; commit with Enter.
+    await card.getByText("Scene A", { exact: true }).click();
     const editor = page.getByRole("textbox", { name: "Timeline name" });
     await editor.fill("Heist Plan");
     await editor.press("Enter");
 
     // node.name (the accessible name, ghost, and announcements) updates at once.
     await expect(card).toHaveAttribute("aria-label", /^Heist Plan \(collection/);
+
+    // THE HOVER AFFORDANCE. A one-click target that looks exactly like static
+    // text is a trap in both directions — nobody finds the rename, and anyone
+    // aiming at the card is surprised by an editor. E2E rather than a story
+    // because the tint is CSS `:hover`, which is browser state driven by real
+    // pointer position: no synthetic event sets it.
+    const label = card.getByText("Heist Plan", { exact: true });
+    const background = () =>
+      label.evaluate((element) => getComputedStyle(element).backgroundColor);
+    await page.mouse.move(0, 0);
+    const atRest = await background();
+    await label.hover();
+    await expect.poll(background).not.toBe(atRest);
+    // ...and it lets go again, rather than leaving one card looking armed.
+    await page.mouse.move(0, 0);
+    await expect.poll(background).toBe(atRest);
     // And the child document — the source of truth — is persisted.
     await expect
       .poll(() => api.documents.get(CHILD_ID)?.title, { timeout: 5000 })
@@ -6711,6 +6727,40 @@ test.describe("graph view E2E", () => {
     expect(
       await header.evaluate((e) => Math.round(e.getBoundingClientRect().height)),
     ).toBe(narrowHeight);
+  });
+
+  test("the select row drops Edit, and its verbs do not repeat the count", async ({
+    page,
+  }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    const surface = strip(page, PROJECT_ID);
+    await selectCard(surface.locator('[data-node-id="alpha"]'));
+    await toggleMultiSelect(page);
+    await surface.locator('[data-node-id="bravo"]').click();
+    await expect(page.locator("[data-select-mode-count]")).toHaveText("2 selected");
+
+    const run = page.locator("[data-select-mode-verbs]");
+
+    // EDIT IS NOT A ROW VERB. It acts on exactly one item, so in the one mode
+    // built for picking several it was dimmed more often than not — a permanent
+    // slot spent on a verb that mostly cannot run. Checked in the RULER too:
+    // the ruler holds the full run, so a verb removed from the drawn list but
+    // left in the measured one would still be reserving width for itself.
+    await expect(run.locator(":scope > [data-header-action='details']")).toHaveCount(0);
+    await expect(
+      run.locator("[data-select-mode-verb-ruler] [data-header-action='details']"),
+    ).toHaveCount(0);
+
+    // The count lives in "2 selected" and nowhere else on the row. It used to
+    // be repeated by every verb beside it — "Cut 2 items · Copy 2 items · …".
+    const del = run.locator(":scope > [data-header-action='delete']");
+    await expect(del).toHaveText("Delete");
+
+    // ...but the ANNOUNCED name still carries it. A screen-reader user arriving
+    // here by tab has not necessarily just heard the count, and "Delete" alone
+    // does not say what it is about to delete.
+    await expect(del).toHaveAttribute("aria-label", "Delete 2 items");
   });
 
   test("select mode takes the breadcrumb's place at the SAME height, from the first click", async ({


### PR DESCRIPTION
Follow-up to #333.

## Select row
- **Edit is gone from the row's verbs.** It acts on exactly one item, so in the one mode built for picking *several* it was dimmed more often than not — a permanent slot spent on a verb that mostly can't run, saying "one only" beside a count saying otherwise. It stays in the full menu.
- **Labels drop the count**: "Cut", not "Cut 3 items". The row opens with "3 selected" and then repeated that number once per verb. The row's own overflow menu drops it too — a menu row reading "Cut 3 items" an inch from a "Cut" that doesn't would read as two different actions.
- **The announced name still carries the count.** A screen-reader user arriving by tab hasn't necessarily just heard "3 selected", and "Delete" alone doesn't say what it's about to delete. Short label for the eye, full for the ear — including on menu rows, where the accessible name would otherwise fall back to the very text the count was removed from.

## Cards
- **The kind glyph matches the collection's weight**, not just its box. Sizes were already equal (#333); media carried `strokeWidth={1.7}` against Layers' default `2`, so at identical size it still drew a lighter line.
- **Tags right-justified** — via `justify-end`, not by letting the box shrink to its contents. Those look identical until the row is measured, and shrinking is exactly what breaks the overflow fold.
- **A collection's name renames on one click.** The label already *swallowed* the click (it has to: a plain click on the card drills in and unmounts it, which is what broke double-click rename originally), so the press was being caught and thrown away — one press did nothing while the advertised gesture cost two. Hover now tints it, because a one-click target that looks like static text is a trap both ways: nobody finds the rename, and anyone aiming at the card is surprised by an editor.

## Testing
- The select row had **no coverage** for its verb list — the two "header's Edit/Delete" tests exercise the browse row's separate `PROMOTED_HEADER_ACTIONS`. The new test checks Edit is absent from the drawn run **and the ruler**; left in the ruler it would still silently reserve width for itself.
- The rename hover is e2e, not a story: the tint is CSS `:hover`, real browser state no synthetic event sets. It also asserts the tint *releases*, so a card isn't left looking armed.
- `PlaceholderAriaCountMatchesBadge` now measures the name's **text** inset rather than its box. The label's `-mx-1 px-1` widens the hover target while the padding puts the text back — measuring the raw box reported an inset 4px smaller than the one on screen and failed on text that hadn't moved.

Verified: lint 0 errors · 189/189 stories · 157/157 graph-view e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)