### PR TITLE
A GET stops allocating shared timeline names

### DIFF
--- a/apps/timeline-gstudio001/app/api/timelines/[id]/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/[id]/route.ts
@@ -90,8 +90,18 @@ export async function GET(
       return NextResponse.json({ error: "Timeline was not found." }, { status: 404 });
     }
 
-    const saved = await saveFirebaseTimelineEntry(fallbackDocument, user.uid);
-    return NextResponse.json({ document: saved.document, revision: saved.revision });
+    // SERVED, NOT PERSISTED — the same rule the heal above follows, and for a
+    // sharper reason. These fixture ids are short and SHARED (`root`, `promo`,
+    // `workbench`…), and `checkUserScopedId` does not recognise them, so
+    // saving one here handed a global id to whoever asked first: every other
+    // user then got a permanent 404 on it, with no way to see or clear the
+    // document holding it. An audit found five already claimed this way,
+    // seeded across three dates — a READ was quietly allocating shared names.
+    //
+    // Nothing is lost by only serving it. `revision: 0` is a compare-and-set
+    // CREATE token, so the client's first real write through the batch path
+    // still brings the document into existence, owned by that writer.
+    return NextResponse.json({ document: fallbackDocument, revision: 0 });
   } catch (error) {
     return storageErrorResponse(error, "Unable to load the timeline document.");
   }

--- a/apps/timeline-gstudio001/app/api/timelines/timelines-authorization.test.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/timelines-authorization.test.ts
@@ -208,6 +208,22 @@ describe("timeline authorization", () => {
   // Both of these used to assert the opposite: a GET or a list CLAIMED an
   // unowned record for whoever arrived first. The legacy records that justified
   // that are migrated, so knowing an id is no longer a claim to it.
+  it("serves a demo fixture without claiming its global id", async () => {
+    // The fixture ids are short and SHARED (`root`, `promo`, `workbench`…) and
+    // `checkUserScopedId` does not recognise them, so persisting one on a READ
+    // handed a global name to whoever asked first — and every other user got a
+    // permanent 404 on it. A GET must serve the fixture and store nothing.
+    const response = await getTimeline(new Request("http://test.local"), params("root"));
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { document: TimelineDocument; revision: number };
+    expect(body.document.id).toBe("root");
+    // revision 0 is the compare-and-set CREATE token, so the client's first
+    // real write still brings the document into existence under its own owner.
+    expect(body.revision).toBe(0);
+    expect(state.docs.has("root")).toBe(false);
+  });
+
   it("GET denies an unowned document and writes nothing", async () => {
     seedProject("project-legacy", undefined);
 


### PR DESCRIPTION
Fixes #342.

`GET /api/timelines/[id]` fell back to a UI-package demo fixture and **persisted** it under the requested id, owned by whoever asked. Those ids are short and shared — `root`, `promo`, `archive`, `storyboard`, `workbench` — and `checkUserScopedId` does not recognise them, so nothing scoped them per user. The first account to open one took the global name; every other account then got a permanent 404, with no way to see or clear the document holding it.

## This one is measured, not argued

The issue was filed with an explicit gap: I could not tell from the repo whether the fallback ever actually ran. [#346](https://github.com/josulliv101/storyboard-flow/pull/346)'s audit answered it against 379 production documents:

```
fixture ids already claimed: 5 of 18
distinct owners holding them: 1
  archive     2026-07-13    promo     2026-07-13    root  2026-07-13
  storyboard  2026-06-27    workbench 2026-07-20
```

Five ids, three dates, six weeks apart. A read was quietly allocating shared names.

## The rule the route already stated

`lib/serve-timeline.ts:74-90` explains at length why the heal is served and not persisted, and ends:

> A GET should not be able to do that.

The fallback was doing exactly that, through the last-write-wins single-document writer, ten lines further down the same handler.

## The change

Serve the fixture; store nothing. `revision: 0` is the compare-and-set **create** token, so the client's first real write through the batch path still brings the document into existence, owned by that writer — the seeding just stops happening on a read.

## Verification

The new test in `timelines-authorization.test.ts` was **proven to fail first** — with the route change stashed out it reports `1 failed | 11 passed`, and `12 passed` with it restored. It asserts the fixture is served, `revision` is 0, and nothing lands in the store.

| Gate | Result |
| --- | --- |
| App tests | 704/704 across 69 files |
| App lint | 0 errors (5 pre-existing `<img>` warnings, untouched files) |

## Residual — deliberately not fixed here

**The ids are still global.** A user who *edits* a demo timeline can still collide with one another user already created. Closing that means namespacing the id (`${id}-${uid}`), which changes what the client routes on — a bigger change than this one, and a decision rather than a fix. This PR removes the accidental path (a read) and leaves the deliberate one (a write).

**The five already-claimed documents still hold their names.** They are production data, so removing them is not mine to do. Until they go, a second account still gets 404s on those five ids specifically. Re-check any time with:

```bash
npm run audit:review-findings --workspace=apps/timeline-gstudio001
```

(that script lands in #346, which is open with auto-merge armed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)