### PR TITLE
Enforce the resource an OAuth grant was actually issued for

### DIFF
--- a/apps/timeline-gstudio001/app/api/oauth/token/route.ts
+++ b/apps/timeline-gstudio001/app/api/oauth/token/route.ts
@@ -1,6 +1,7 @@
 import {
   ACCESS_TOKEN_TTL_SECONDS,
   getSigningSecret,
+  grantAllowsResource,
   loadClient,
   safeEqual,
   signAccessToken,
@@ -99,8 +100,18 @@ export async function POST(request: Request) {
     if (!verifyPkce(codeVerifier, grant.codeChallenge, grant.codeChallengeMethod)) {
       return oauthError("invalid_grant", "PKCE verification failed.");
     }
+    // RFC 8707: the code was bound to a resource at /authorize, and this is
+    // where that binding is honoured. `resource` here is derived from the
+    // request, so without the comparison a code issued for one deployment
+    // could be exchanged for a token audienced at another.
+    if (!grantAllowsResource(grant.resource, resource)) {
+      return oauthError("invalid_grant", "Code was issued for a different resource.");
+    }
 
-    return issueTokens(grant.uid, grant.scope, client.clientId, origin, resource, secret);
+    // The GRANT's resource, not the request's — they are equal by the check
+    // above, and using the stored one makes it unmistakable which is
+    // authoritative.
+    return issueTokens(grant.uid, grant.scope, client.clientId, origin, grant.resource, secret);
   }
 
   if (grantType === "refresh_token") {
@@ -112,10 +123,25 @@ export async function POST(request: Request) {
     if (rotated.grant.clientId !== client.clientId) {
       return oauthError("invalid_grant", "Refresh token was issued to a different client.");
     }
+    // The half that actually bit: a refresh token bound to one resource used
+    // to mint an access token audienced at whatever the current request said,
+    // because `rotated.grant.resource` was read from storage and then dropped.
+    // Note the token has ALREADY been consumed by `rotateRefreshToken` — a
+    // refusal here is terminal for it, which is the right outcome for a
+    // presentation at the wrong resource.
+    if (!grantAllowsResource(rotated.grant.resource, resource)) {
+      return oauthError("invalid_grant", "Refresh token was issued for a different resource.");
+    }
 
     return tokenResponse(
       signAccessToken(
-        buildClaims(rotated.grant.uid, rotated.grant.scope, client.clientId, origin, resource),
+        buildClaims(
+          rotated.grant.uid,
+          rotated.grant.scope,
+          client.clientId,
+          origin,
+          rotated.grant.resource,
+        ),
         secret,
       ),
       rotated.nextToken,

--- a/apps/timeline-gstudio001/lib/oauth/core.test.ts
+++ b/apps/timeline-gstudio001/lib/oauth/core.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   base64url,
   getSigningSecret,
+  grantAllowsResource,
   isRegisteredRedirectUri,
   loadClient,
   safeEqual,
@@ -130,6 +131,38 @@ describe("access tokens", () => {
 
   it("rejects malformed input", () => {
     expect(verifyAccessToken("not-a-token", SECRET, AUDIENCE)).toEqual({ ok: false, reason: "malformed" });
+  });
+});
+
+describe("grantAllowsResource", () => {
+  it("allows a grant redeemed at the resource it was issued for", () => {
+    expect(grantAllowsResource(AUDIENCE, AUDIENCE)).toBe(true);
+  });
+
+  it("refuses a grant presented at a different resource", () => {
+    // The whole point of the binding: a code or refresh token minted for one
+    // deployment must not mint a token audienced at another. Both sides of the
+    // comparison used to be recomputed from the live request, so this pair
+    // silently passed.
+    expect(grantAllowsResource(AUDIENCE, "https://evil.test/api/mcp")).toBe(false);
+  });
+
+  it("refuses a grant that records no resource at all", () => {
+    // An absent binding is not a wildcard. A stored grant predating the field
+    // needs one re-authorization rather than 30 days of unbound refreshes.
+    expect(grantAllowsResource(undefined, AUDIENCE)).toBe(false);
+  });
+
+  it("does not treat an empty string as a match for anything", () => {
+    expect(grantAllowsResource("", AUDIENCE)).toBe(false);
+    expect(grantAllowsResource(undefined, "")).toBe(false);
+  });
+
+  it("is exact — no prefix or host-suffix matching", () => {
+    // Same trap as redirect-uri matching: a prefix rule turns
+    // `https://app.test/api/mcp` into a licence for `https://app.test.evil/`.
+    expect(grantAllowsResource(AUDIENCE, `${AUDIENCE}/extra`)).toBe(false);
+    expect(grantAllowsResource("https://example.test", AUDIENCE)).toBe(false);
   });
 });
 

--- a/apps/timeline-gstudio001/lib/oauth/core.ts
+++ b/apps/timeline-gstudio001/lib/oauth/core.ts
@@ -149,6 +149,32 @@ export function verifyAccessToken(
   return { ok: true, claims };
 }
 
+// --- Resource binding (RFC 8707) -------------------------------------------
+
+/**
+ * Whether a stored grant may be redeemed at the resource this request names.
+ *
+ * The grant records the resource it was issued for, and until this existed
+ * nothing read it back: `/api/oauth/token` recomputed the audience from the
+ * live request on every exchange, and `/api/mcp` recomputed the expected
+ * audience the same way. Both float with the request's Host, so the binding
+ * this file's own `aud` comment promises — "a token minted for one resource
+ * can't be replayed at another" — was not being enforced anywhere. The field
+ * was written and never read.
+ *
+ * An ABSENT binding fails. A grant that cannot say what it was issued for is
+ * not thereby issued for everything, and treating it as a wildcard would keep
+ * the hole open for the whole 30-day refresh-token lifetime. The cost is that
+ * such a grant needs one re-authorization, which is a reconnect rather than a
+ * loss.
+ */
+export function grantAllowsResource(
+  grantResource: string | undefined,
+  requestedResource: string,
+): boolean {
+  return typeof grantResource === "string" && grantResource === requestedResource;
+}
+
 // --- Client registry -------------------------------------------------------
 
 /** Just the string map these readers need — `process.env` satisfies it, and so


### PR DESCRIPTION
Fixes #336.

Both grant types recorded a `resource` and nothing ever read it back:

```
$ grep -rn "\.resource\b" lib/oauth/ app/api/oauth/ app/api/mcp/
(no matches)
```

Written on issue at `store.ts:32` and `:73`, dropped on redemption. What ran instead was a recomputation from the **live request** on both sides — the token endpoint minted `aud` from `originFromRequest(request)` (`token/route.ts:59-60`), and the MCP endpoint checked incoming tokens against an expected audience derived the same way (`mcp/route.ts:498`). Two values that always agree with each other and never with the grant.

So the guarantee `core.ts:17-19` states at the `aud` claim —

> Bound so a token minted for one resource can't be replayed at another (RFC 8707 resource indicators).

— described something the code did not do. A refresh token bound to one deployment minted a token audienced at another simply by varying the Host header on the refresh call, because `rotated.grant.resource` was read from storage and then discarded.

## Where the check lives

In `core.ts`, not in the route. That file exists precisely so *"every security-critical rule here unit-tests directly"*, and a rule enforced only inside a Next route handler has no test seam at all. Both branches then use the **grant's** resource as the audience rather than the request's — equal by the check above, but it leaves no doubt which one is authoritative.

## An absent binding fails

A grant that cannot say what it was issued for is not thereby issued for everything. A wildcard reading would keep the hole open for a refresh token's full 30-day lifetime; refusing costs one reconnect.

## Not covered by the #335 result

Worth stating explicitly, since the two issues look adjacent: the [probe recorded on #335](https://github.com/josulliv101/storyboard-flow/issues/335) showed Vercel sanitises `X-Forwarded-Host`, which is why *that* issue downgraded. **This one is unaffected by that.** The mismatch here needs no header control, because the stored value was never compared to anything at all.

## Verification

`grantAllowsResource` is new, so its tests are specification rather than regression — a "fails first" run would just be a compile error and would prove nothing. Instead I checked they have teeth by weakening the implementation to `return true`:

```
× refuses a grant presented at a different resource
× refuses a grant that records no resource at all
× does not treat an empty string as a match for anything
× is exact — no prefix or host-suffix matching
  Tests  4 failed | 20 passed (24)
```

Four of the five catch a permissive implementation, including the prefix-matching trap that turns `https://app.test/api/mcp` into a licence for `https://app.test.evil/` — the same failure mode `isRegisteredRedirectUri` is exact for.

| Gate | Result |
| --- | --- |
| App tests | 708/708 across 69 files |
| App lint | 0 errors (5 pre-existing `<img>` warnings, untouched files) |

## Migration

A stored grant whose resource does not match the deployment it is presented at now needs one re-authorization.

For grants minted in production this is a **no-op** — the origin is stable, so the stored value already matches what the request derives. A token minted against a preview deployment will have to reconnect once, which is the binding working rather than breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)