### PR TITLE
Stop retrying a save the server will never accept

### DIFF
--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
@@ -5,6 +5,7 @@ import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/
 import { createGraphDocumentsGateway } from "./graph-documents-gateway";
 
 const SAVE_DEBOUNCE_MS = 900;
+const SAVE_RETRY_MS = 5000;
 
 function clip(id: string, startTime = 0): TimelineClip {
   return {
@@ -514,6 +515,75 @@ describe("graph-documents-gateway", () => {
     expect(batchesOf(calls)).toHaveLength(2); // no third batch
     expect(clipIds(gateway.peek("a"))).toEqual(["a-server"]); // cache untouched
     expect(gateway.lastError()).toContain("not being saved");
+  });
+
+  it("stops retrying a payload the server rejects on its merits, and releases the pending flag", async () => {
+    // A 400 is not a bad moment, it is a bad payload: the same bytes get the
+    // same answer forever. Re-queueing it span a 5s save loop indefinitely,
+    // and because the id stayed dirty `hasPendingWrite` stayed true — which
+    // made the preview's install guard refuse every manifest and re-poll on
+    // its own timer. Two unbounded loops on an idle tab from one permanent
+    // error.
+    const calls = installFetch((call) => {
+      if (call.method === "GET") {
+        return jsonResponse({ document: doc(call.id, [clip(`${call.id}-seed`)]), revision: 1 });
+      }
+      return jsonResponse({ error: "Every batch write needs a valid timeline document." }, 400);
+    });
+    const gateway = createGraphDocumentsGateway();
+    await gateway.ensure("a");
+
+    gateway.writeClips("a", [clip("a2")]);
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+    expect(batchesOf(calls)).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The rejection is surfaced, and says waiting will not help.
+    expect(gateway.lastError()).toContain("not being saved");
+
+    // NO retry — the whole point. Well past the retry cadence.
+    await vi.advanceTimersByTimeAsync(SAVE_RETRY_MS * 3);
+    expect(batchesOf(calls)).toHaveLength(1);
+
+    // The pending flag is released, so the preview's install guard stops
+    // refusing manifests and its poll loop ends with it.
+    expect(gateway.hasPendingWrite("a")).toBe(false);
+
+    // And a further edit is blocked rather than re-sending the same reject,
+    // exactly as a conflict is.
+    gateway.writeClips("a", [clip("a3")]);
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+    expect(batchesOf(calls)).toHaveLength(1);
+    expect(gateway.isConflicted("a")).toBe(true);
+  });
+
+  it("still retries a 5xx, which really is transient", async () => {
+    // The other half of the split: a server having a bad minute must not be
+    // treated as a bad payload, or a blip would strand the user's edit.
+    let failOnce = true;
+    const calls = installFetch((call) => {
+      if (call.method === "GET") {
+        return jsonResponse({ document: doc(call.id, [clip(`${call.id}-seed`)]), revision: 1 });
+      }
+      if (failOnce) {
+        failOnce = false;
+        return jsonResponse({ error: "upstream exploded" }, 503);
+      }
+      return okResults(call.writes);
+    });
+    const gateway = createGraphDocumentsGateway();
+    await gateway.ensure("a");
+
+    gateway.writeClips("a", [clip("a2")]);
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+    expect(batchesOf(calls)).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Re-queued and retried on the slower cadence, and it lands.
+    await vi.advanceTimersByTimeAsync(SAVE_RETRY_MS);
+    expect(batchesOf(calls)).toHaveLength(2);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(gateway.isConflicted("a")).toBe(false);
   });
 
   it("lifts the conflict block when the graph is rebuilt via refresh", async () => {

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
@@ -642,11 +642,48 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
             if (dirtyIds.size > 0) scheduleFlush();
             return;
           }
-          // Non-conflict failure (5xx, 400…): surface it AND re-queue —
-          // clearing dirtyIds before the request must not permanently drop
-          // the change when the server balks. The slower retry cadence
-          // keeps a struggling server from being hammered, and re-dirtied
-          // ids ride any later unload flush.
+          // A 4xx the conflict branch did not claim is TERMINAL. The server
+          // rejected this payload on its merits — a malformed document, a bad
+          // id, a bad expectedRevision, an empty-over-non-empty write, a
+          // repeated id in one batch — so the SAME BYTES will be rejected
+          // every time.
+          //
+          // Re-queueing them span forever. Worse, the ids stayed in `dirtyIds`,
+          // so `hasPendingWrite` stayed true, so the preview's install guard
+          // refused every compiled manifest and re-polled on its own timer:
+          // two unbounded request loops on an idle tab, in every open tab,
+          // from one permanent error that waiting could never fix.
+          //
+          // So end it the way the 409 above already does — stop retrying, block
+          // further clip writes for these ids (a stale projection must not keep
+          // re-sending), and say so. `refresh()` lifts the block once the graph
+          // is rebuilt, which is the same recovery a conflict gets.
+          if (response.status >= 400 && response.status < 500) {
+            for (const write of writes) {
+              // COMPOSED, never the server's string alone. Its reason is the
+              // useful part ("Every batch write needs a valid timeline
+              // document.") but it describes the payload, not the consequence
+              // — and the consequence is the bit the user has to act on: this
+              // is not going to retry, so waiting is not a plan. Same shape as
+              // the conflict message above, for the same reason.
+              const reason =
+                result.error ?? `the server rejected it (${response.status})`;
+              setError(
+                write.document.id,
+                `"${write.document.title}" could not be saved: ${reason} Your unsaved edits to it are not being saved — reopen this timeline to continue editing.`,
+              );
+              dirtyIds.delete(write.document.id);
+              conflictedIds.add(write.document.id);
+            }
+            notify();
+            return;
+          }
+
+          // 5xx and anything else: genuinely transient, so surface it AND
+          // re-queue — clearing dirtyIds before the request must not
+          // permanently drop the change when the server balks. The slower
+          // retry cadence keeps a struggling server from being hammered, and
+          // re-dirtied ids ride any later unload flush.
           for (const write of writes) {
             setError(
               write.document.id,


### PR DESCRIPTION
Fixes #343.

The gateway treated every non-409 failure as a bad *moment*. A 400 is a bad **payload**: `batch/route.ts` returns it for a malformed document, a bad id, or a bad `expectedRevision` (`:44,49,67,71,93`), so the same bytes get the same answer forever. Nothing capped the attempts — `grep -n "attempts\|maxRetr\|giveUp"` over the file finds nothing — so it span at `SAVE_RETRY_MS` (5s) indefinitely.

## The second loop is what makes it more than noise

The ids stayed in `dirtyIds`, so `hasPendingWrite` stayed true (`:793-794`), so `manifestTrailsLedger` classed every compiled manifest as untrusted (`graph-playhead-model.ts:110`), so the preview's install guard refused it and re-polled on its own 2.5s timer (`graph-preview.tsx:889-899`). That path deliberately does not increment `failureCountRef` — a 200 response legitimately ends a failure streak — so `MAX_MANIFEST_FETCH_RETRIES` never applied.

Two unbounded request loops on an idle tab, in every open tab, from one permanent error that waiting could never fix.

## The change

End it the way the 409 branch ten lines above already does: drop the ids from `dirtyIds`, add them to `conflictedIds` so `writeClips` stops re-sending a projection the server has already refused, and surface it. `refresh()` lifts the block once the graph is rebuilt — the same recovery a conflict gets, already covered by an existing test.

Releasing `dirtyIds` also releases the preview loop, which was never the gateway's business but was its doing.

Note this also catches the **409s the conflict branch does not claim** — `Refusing to save an empty timeline`, `A batch write must not repeat a timeline id`, the placeholder refusal. Those are terminal for the same payload too, and previously fell through to the same infinite retry.

## A second thing the test caught

My first version echoed the server's error string alone. That tells the user *what* is wrong (`"Every batch write needs a valid timeline document."`) and not what it *means* — and the meaning is the part they have to act on: this is not going to retry, so waiting is not a plan. The message now composes the server's reason with the consequence, matching the conflict message's shape.

I changed the message rather than the assertion.

## 5xx is untouched

Server errors and network failures keep the re-queue and the slower cadence — those really are transient, and a blip must not strand an edit.

## Verification

The 4xx test was **proven to fail first**: with the fix stashed out, `1 failed | 24 passed`; restored, `25 passed`.

The 5xx test passes with **or without** this change, deliberately — it is a characterization test guarding the half I kept, not evidence for the half I changed. Flagging that rather than letting two green ticks imply more than they do.

| Gate | Result |
| --- | --- |
| App tests | 711/711 across 69 files |
| App lint | 0 errors (5 pre-existing `<img>` warnings, untouched files) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)