### PR TITLE
Give every save its own revision number

### DIFF
--- a/apps/timeline-gstudio001/app/api/timelines/timelines-authorization.test.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/timelines-authorization.test.ts
@@ -15,9 +15,19 @@ const state = vi.hoisted(() => {
   const docs = new Map<string, Stored>();
   const current = { user: { uid: "user-a", email: null as string | null, name: null, picture: null } };
 
+  // Lets one test drop a COMPETING write in immediately after ours lands —
+  // the only way an in-memory double can pose the "someone else wrote between
+  // your write and your read-back" question at all. Fires once, then clears.
+  const hooks: { afterSet?: () => void } = {};
+
   const applySet = (id: string, data: Stored, opts?: { merge?: boolean }) => {
     const existing = docs.get(id);
     docs.set(id, opts?.merge && existing ? { ...existing, ...data } : { ...data });
+    const hook = hooks.afterSet;
+    if (hook) {
+      hooks.afterSet = undefined;
+      hook();
+    }
   };
   const snapshot = (id: string) => {
     const data = docs.get(id);
@@ -70,8 +80,26 @@ const state = vi.hoisted(() => {
         },
       };
     },
+    // Writes STAGE and apply on commit, like the real thing — a double that
+    // applied them eagerly would hide a throw-after-write.
+    runTransaction: async <T>(
+      fn: (tx: {
+        get: (ref: { id: string }) => Promise<ReturnType<typeof snapshot>>;
+        set: (ref: { id: string }, data: Stored, opts?: { merge?: boolean }) => void;
+      }) => Promise<T>,
+    ): Promise<T> => {
+      const staged: Array<[string, Stored, { merge?: boolean } | undefined]> = [];
+      const result = await fn({
+        get: async (ref) => snapshot(ref.id),
+        set: (ref, data, opts) => {
+          staged.push([ref.id, data, opts]);
+        },
+      });
+      for (const [id, data, opts] of staged) applySet(id, data, opts);
+      return result;
+    },
   };
-  return { docs, current, db };
+  return { docs, current, db, hooks };
 });
 
 vi.mock("server-only", () => ({}));
@@ -141,6 +169,7 @@ function patchRequest(document: TimelineDocument) {
 
 beforeEach(() => {
   state.docs.clear();
+  state.hooks.afterSet = undefined;
   asUser("user-a");
 });
 
@@ -208,6 +237,35 @@ describe("timeline authorization", () => {
   // Both of these used to assert the opposite: a GET or a list CLAIMED an
   // unowned record for whoever arrived first. The legacy records that justified
   // that are migrated, so knowing an id is no longer a claim to it.
+  it("reports the revision THIS save produced, not a racing writer's", async () => {
+    // `revision` is the compare-and-set token every other writer trusts. The
+    // save used to write, then RE-READ, and hand back whatever it found — so a
+    // writer landing in that gap had its number reported as the caller's own.
+    // The caller then held an expectation matching content it never produced,
+    // and its next CAS passed instead of refusing: the stale overwrite the
+    // token exists to stop.
+    //
+    // Reporting our own number instead fails CLOSED — the caller's next CAS is
+    // refused and it refetches.
+    seedProject("project-a1", "user-a");
+    state.hooks.afterSet = () => {
+      const stored = state.docs.get("project-a1");
+      state.docs.set("project-a1", { ...stored, revision: 99 });
+    };
+
+    const response = await patchTimeline(
+      patchRequest({ id: "project-a1", title: "Mine", clips: [clip("c1")] }),
+      params("project-a1"),
+    );
+
+    expect(response.status).toBe(200);
+    const { revision } = (await response.json()) as { revision: number };
+    expect(revision).toBe(1);
+    // The racing writer's value is genuinely in the store — this is not the
+    // hook failing to fire.
+    expect(state.docs.get("project-a1")?.revision).toBe(99);
+  });
+
   it("serves a demo fixture without claiming its global id", async () => {
     // The fixture ids are short and SHARED (`root`, `promo`, `workbench`…) and
     // `checkUserScopedId` does not recognise them, so persisting one on a READ

--- a/apps/timeline-gstudio001/app/api/trash/trash-empty.test.ts
+++ b/apps/timeline-gstudio001/app/api/trash/trash-empty.test.ts
@@ -105,6 +105,34 @@ const state = vi.hoisted(() => {
         },
       };
     },
+    // Refs here carry their own `__store`, so the transaction resolves the
+    // collection from the ref rather than closing over one. Writes STAGE and
+    // apply on commit, like the real thing — a double that applied them
+    // eagerly would hide a throw-after-write.
+    runTransaction: async <T>(
+      fn: (tx: {
+        get: (ref: { id: string; __store: Map<string, Stored> }) => Promise<
+          ReturnType<typeof snapshot>
+        >;
+        set: (
+          ref: { id: string; __store: Map<string, Stored> },
+          data: Stored,
+          opts?: { merge?: boolean },
+        ) => void;
+      }) => Promise<T>,
+    ): Promise<T> => {
+      const staged: Array<
+        [Map<string, Stored>, string, Stored, { merge?: boolean } | undefined]
+      > = [];
+      const result = await fn({
+        get: async (ref) => snapshot(ref.__store, ref.id),
+        set: (ref, data, opts) => {
+          staged.push([ref.__store, ref.id, data, opts]);
+        },
+      });
+      for (const [store, id, data, opts] of staged) applySet(store, id, data, opts);
+      return result;
+    },
   };
   return { docs, tombstones, current, db, cloudinaryDeletes };
 });

--- a/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
@@ -494,46 +494,72 @@ export async function saveFirebaseTimelineEntry(
 
   const normalizedDocument = normalizeDocument(document);
   const ref = collection().doc(normalizedDocument.id);
-  const existing = await withFirebaseTimeout(ref.get(), "Loading timeline document");
-  const existingData = existing.exists
-    ? (existing.data() as TimelineDocumentRecord)
-    : undefined;
-  if (existingData && resolveOwnership(existingData.ownerUid, requesterUid) === "denied") {
-    throw new TimelineAccessDeniedError(normalizedDocument.id);
-  }
-  const existingDocument = existingData
-    ? toTimelineDocument(existing.id, existingData)
-    : null;
 
-  if (
-    !options?.allowEmptying &&
-    existingDocument &&
-    existingDocument.clips.length > 0 &&
-    normalizedDocument.clips.length === 0
-  ) {
-    throw new Error(
-      "Refusing to save an empty timeline over an existing non-empty document.",
-    );
-  }
+  // ONE TRANSACTION for read, checks and write.
+  //
+  // Content here stays LAST-WRITE-WINS — legacy views carry no expectation and
+  // this path deliberately doesn't invent one. What could not stay loose is the
+  // REVISION. It was read outside any transaction and written back as
+  // `existing + 1`, so two concurrent saves both read 5 and both wrote 6 — and
+  // that number is not decoration, it is the compare-and-set token every OTHER
+  // writer trusts (`saveFirebaseTimelineDocumentsAtomic`, and the agent path
+  // through lib/mcp/apply-command.ts). A reader who took 6 between those two
+  // writes then passed CAS against a document whose content had been replaced
+  // underneath them: the exact stale-overwrite the check exists to stop,
+  // permitted because two distinct writes shared one number.
+  //
+  // Reading inside the transaction makes `existing + 1` sound, so every write
+  // gets its own number. It also closes the smaller TOCTOU the old shape had:
+  // ownership and the empty-over-non-empty guard were evaluated against a read
+  // that the write no longer had any claim on.
+  const { revision } = await withFirebaseTimeout(
+    getFirebaseDb().runTransaction(async (tx) => {
+      const existing = await tx.get(ref);
+      const existingData = existing.exists
+        ? (existing.data() as TimelineDocumentRecord)
+        : undefined;
+      if (existingData && resolveOwnership(existingData.ownerUid, requesterUid) === "denied") {
+        throw new TimelineAccessDeniedError(normalizedDocument.id);
+      }
+      const existingDocument = existingData
+        ? toTimelineDocument(existing.id, existingData)
+        : null;
 
-  // No expectation here: the single-save path keeps last-write-wins (legacy
-  // views). It still STAMPS the next revision so batch writers see honest
-  // counters.
-  const revision = (existingData?.revision ?? 0) + 1;
-  await withFirebaseTimeout(
-    ref.set(
-      buildSavePayload(normalizedDocument, existingData, requesterUid, revision, options),
-      { merge: true },
-    ),
+      if (
+        !options?.allowEmptying &&
+        existingDocument &&
+        existingDocument.clips.length > 0 &&
+        normalizedDocument.clips.length === 0
+      ) {
+        throw new Error(
+          "Refusing to save an empty timeline over an existing non-empty document.",
+        );
+      }
+
+      const next = (existingData?.revision ?? 0) + 1;
+      tx.set(
+        ref,
+        buildSavePayload(normalizedDocument, existingData, requesterUid, next, options),
+        { merge: true },
+      );
+      return { revision: next };
+    }),
     "Saving timeline document",
   );
 
-  const snapshot = await withFirebaseTimeout(ref.get(), "Loading timeline document");
-  const savedData = snapshot.data() as TimelineDocumentRecord;
-  return {
-    document: toTimelineDocument(snapshot.id, savedData),
-    revision: savedData.revision ?? revision,
-  };
+  // THIS write's document and THIS write's revision, not a re-read of both.
+  //
+  // The old re-read could return a LATER writer's revision alongside a later
+  // writer's content, and handing that pair back is worse than useless: the
+  // caller would hold an expectation that passes CAS for content it never
+  // produced. Reporting our own number instead fails CLOSED — if someone else
+  // has since written, the caller's next compare-and-set is refused and it
+  // refetches, which is the outcome the token is for.
+  //
+  // Nothing is lost by not re-reading: a TimelineDocument is id/title/
+  // description/clips, all of which we just wrote. The server-resolved fields
+  // (createdAt, updatedAt) are not part of it.
+  return { document: normalizedDocument, revision };
 }
 
 export async function saveFirebaseTimelineDocument(


### PR DESCRIPTION
Fixes #339.

`revision` is not bookkeeping. It is the compare-and-set token every other writer trusts — `saveFirebaseTimelineDocumentsAtomic` compares against it (`:595-600`), and the agent path carries it as `expectedRevision` (`lib/mcp/apply-command.ts:392`).

The single-save path read it outside any transaction and wrote back `existing + 1`:

```ts
const revision = (existingData?.revision ?? 0) + 1;
await withFirebaseTimeout(ref.set(buildSavePayload(...), { merge: true }), ...);
```

Two concurrent saves both read 5 and both wrote 6. A reader who took 6 between them then passed CAS against a document whose content had been replaced underneath it — the exact stale overwrite the check exists to stop, permitted because two distinct writes shared one number.

Two tabs on one project is all it takes; the trash route uses this path too (`app/api/trash/route.ts:56,151`).

## The change

**Read inside a transaction**, so `existing + 1` is sound again. Content stays **last-write-wins** — that is this path's deliberate contract for legacy views, and it is untouched. Only the numbering is fixed.

The transaction also closes the smaller TOCTOU the old shape had: ownership and the empty-over-non-empty guard were evaluated against a read the write no longer had any claim on.

**Return this write's own number**, not a re-read. The save used to write, re-read, and hand back whatever it found — so a writer landing in that gap had *its* revision reported as the caller's own. The caller then held an expectation matching content it never produced, and its next CAS would **pass** instead of refuse. Returning our own number fails **closed**: if someone else has since written, the caller's next compare-and-set is refused and it refetches.

Nothing is lost by dropping the re-read — a `TimelineDocument` is id/title/description/clips, all of which we just wrote. `createdAt`/`updatedAt` are not part of it.

## Verification

**Proven to fail first.** Against the old code the new test reports exactly the bug:

```
× reports the revision THIS save produced, not a racing writer's
AssertionError: expected 99 to be 1
```

Two test doubles gained `runTransaction` — staging writes and applying them on commit, like the real thing, so a throw-after-write cannot hide. The authorization double also gained an `afterSet` hook, which is the only way an in-memory double can pose "someone else wrote between your write and your read-back" at all. The test asserts the racing value really is in the store, so a hook that silently failed to fire would not read as a pass.

| Gate | Result |
| --- | --- |
| App tests | 712/712 across 69 files |
| App lint | 0 errors (5 pre-existing `<img>` warnings, untouched files) |

## What the tests do NOT cover

**The distinct-numbers guarantee itself.** These doubles do not model Firestore contention or transaction retry, so a test asserting "two concurrent saves get 6 and 7" would be asserting my double's behaviour, not Firestore's. That half rests on using a transaction correctly rather than on a test, and I would rather say so than let a green tick imply coverage it does not have.

The half that *is* tested — reporting your own revision — is the half that was silently handing out a wrong token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)