### PR TITLE
Put the board header above the preview, and give the divider room

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -1123,7 +1123,10 @@ function SelectModeHeader({ anchorName }: Readonly<{ anchorName: string | null }
       <HeaderPasteButton anchorName={anchorName} />
       {/* `ml-auto`: Done sits at the far end, away from Delete. Both end the
           gesture, only one of them destroys anything, and putting them
-          shoulder to shoulder is how a mis-click becomes a deletion. */}
+          shoulder to shoulder is how a mis-click becomes a deletion. The
+          empty space is what separates it on this side — a rule here as well
+          fenced Done in from both directions and made the way OUT read as
+          just another item in the verb run. */}
       <Button
         type="button"
         variant="ghost"
@@ -1155,6 +1158,20 @@ function SelectModeHeader({ anchorName }: Readonly<{ anchorName: string | null }
       >
         Done
       </Button>
+      {/* History lives on the RIGHT of Done, fenced off by its own rule.
+          Undo/redo are not selection verbs — they act on the board whatever is
+          picked — so they sit outside the run of verbs and outside the way
+          out, as their own group.
+
+          Select mode used to drop them entirely: `GraphUndoRedo` was rendered
+          only in the browse branch, so arming the mode took undo away at
+          exactly the moment a multi-select delete makes it most wanted.
+
+          Already `h-8` icon buttons, so the row's height is unchanged — which
+          matters, because both faces of the header are pinned to one height
+          and the last thing to break that was a single `h-9` on Done. */}
+      <div aria-hidden="true" className="h-5 w-px shrink-0 bg-zinc-700" />
+      <GraphUndoRedo />
     </div>
   );
 }
@@ -1404,36 +1421,43 @@ export function GraphBoard({
           time overlay inside it measure the run actually on screen. */}
       <TagFilterProvider>
       <FlatItemsProvider items={flatItems}>
-      <PreviewShell enabled={previewOn} focusedId={focusedId} channel={timeChannel}>
-        {/* Outside the surface branch on purpose: the sidebar's tool buttons
-            must insert in grid mode too, where no NativeDropStrip exists. */}
-        <SidebarToolInsertBridge collectionId={focusedId} />
-        {/* Also outside it (PL10-012): details are not a strip idea. A grid
-            card has no trim handles, but it has a name, a duration, and
-            whatever an item grows next — so it opens the same view. The modal
-            portals to the body, so where it mounts only decides which
-            providers it can see. */}
-        <GraphItemDetailsModal />
-        {/* The "?" sheet. Every gesture in this view is invisible otherwise —
-            hold-to-drag, O, F2, the whole Alt layer (PL11-007). */}
-        <GraphShortcuts />
-        <div className="flex flex-col gap-2">
-          {/* Pinned so the controls stay reachable while scrolling the
-              surfaces. It sticks just BELOW the sticky preview via the offset
-              the split pane publishes (0 when the preview is closed). The
-              opaque background is load-bearing twice over: it reads as a
-              toolbar, and it OCCLUDES the strip/grid scrolling underneath —
-              which is what stops a playhead marker from bleeding up into the
-              breadcrumb row. z-40 to sit ABOVE the strip's z-30 playhead
-              overlay (z-20 was below it, so the marker bled through the
-              header); it matches the sticky preview's z-40. The negative
-              margins let that background span the card's full width past its
-              p-4 padding. */}
+      <PreviewShell
+        enabled={previewOn}
+        focusedId={focusedId}
+        channel={timeChannel}
+        /*
+         * TOP of the sticky stack, above the preview rather than below it.
+         *
+         * It used to render with the surfaces and pin itself beneath the
+         * preview via `--workbench-preview-offset`. It cannot reach above the
+         * preview from there — a sticky element will not rise past the top of
+         * its containing block — so it moved into the pane's own `header`
+         * slot, which renders before the surface. The pane measures it and
+         * pins the surface underneath; nothing here sets `top` any more.
+         *
+         * The opaque background stays load-bearing twice over: it reads as a
+         * toolbar, and it OCCLUDES the strip/grid scrolling underneath, which
+         * is what stops a playhead marker from bleeding up into the breadcrumb
+         * row. The z-index moved to the pane wrapper (z-50, above the
+         * surface's z-40, above the strip's z-30 overlay).
+         */
+        header={
           <div
             data-graph-board-header=""
             data-header-mode={selectModeRow ? "select" : "browse"}
             className={cn(
-              "sticky z-40 min-w-0 items-center gap-x-3 border-b border-zinc-800/70 bg-zinc-950/95 py-3 backdrop-blur-sm",
+              // No `sticky`/`z`/`top` here any more — the pane's header
+              // wrapper owns all three. Leaving a second sticky context
+              // nested inside that one pinned this row against ITSELF and it
+              // stopped tracking the wrapper.
+              //
+              // No margin below it either: the row meets the preview directly,
+              // and the divider owns the clearance on both of ITS sides. An
+              // 8px gap here (restoring what the board column's `gap-2` used
+              // to give this row) was tried and removed — it bought nothing
+              // visually and only existed to keep one trim-frame assertion off
+              // its clamp.
+              "min-w-0 items-center gap-x-3 border-b border-zinc-800/70 bg-zinc-950/95 py-3 backdrop-blur-sm",
               // The browse row is a three-column grid so the aggregate sits at
               // the row's TRUE centre whatever the wings contain. The select row
               // has no centre to hold — it is one group that reads left to right
@@ -1443,7 +1467,6 @@ export function GraphBoard({
                 ? "flex"
                 : "grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)]",
             )}
-            style={{ top: "var(--workbench-preview-offset, 0px)" }}
           >
             {/* Seek thumbs are centered on the timeline edge and intentionally
                 extend six pixels beyond it. Mask that overhang only while it
@@ -1577,13 +1600,34 @@ export function GraphBoard({
                 provider so its droppable joins the DndContext. */}
             <BreadcrumbDropZones trashId={trashRootId} />
           </div>
-
+        }
+      >
+        {/* Outside the surface branch on purpose: the sidebar's tool buttons
+            must insert in grid mode too, where no NativeDropStrip exists. */}
+        <SidebarToolInsertBridge collectionId={focusedId} />
+        {/* Also outside it (PL10-012): details are not a strip idea. A grid
+            card has no trim handles, but it has a name, a duration, and
+            whatever an item grows next — so it opens the same view. The modal
+            portals to the body, so where it mounts only decides which
+            providers it can see. */}
+        <GraphItemDetailsModal />
+        {/* The "?" sheet. Every gesture in this view is invisible otherwise —
+            hold-to-drag, O, F2, the whole Alt layer (PL11-007). */}
+        <GraphShortcuts />
+        {/* NO top padding here, deliberately. This column sits directly under
+            the divider, so anything added at its top is read as space below
+            the divider band — which broke the band's symmetry: 10px above it
+            (inside the divider box) against 10 + 8 below.
+            The divider owns the clearance on BOTH of its sides now, which is
+            the only way the two can be equal by construction. */}
+        <div className="flex flex-col gap-2">
           {/* OUTSIDE the sticky header, deliberately. It belongs to the board
               rather than the toolbar — it describes what you are looking at,
               and it is the one piece of chrome whose height varies (chips wrap
-              on a narrow viewport). Inside the sticky row that variation would
-              move the surfaces underneath it every time a tag was added, and
-              the header's `top` offset is shared with the preview shell. */}
+              on a narrow viewport). Inside the header that variation would
+              move everything below it — surfaces AND the preview, which now
+              pins to the header's measured height — every time a tag was
+              added. */}
           <ActiveTagFilters />
 
           {surface === "strip" ? (

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -958,11 +958,21 @@ export function PreviewShell({
   enabled,
   focusedId,
   channel,
+  header,
   children,
 }: Readonly<{
   enabled: boolean;
   focusedId: string;
   channel: PreviewTimeChannel;
+  /**
+   * Pinned above the preview surface — the board's breadcrumb/select row.
+   *
+   * Passed straight through to the split pane's own slot rather than rendered
+   * with `children`. React resolves context by where an element RENDERS, not
+   * where it was created, and the pane sits inside the same providers as the
+   * rest of the board — so the row keeps everything it reads today.
+   */
+  header?: React.ReactNode;
   children: React.ReactNode;
 }>) {
   const graph = useCollectionsSelector((snapshot) => snapshot.graph);
@@ -1056,6 +1066,7 @@ export function PreviewShell({
         <span data-preview-source={manifest !== null ? "manifest" : "projection"} hidden />
       ) : null}
       <WorkbenchSplitPane
+        header={header}
         // The shell and lower pane stay mounted whether the surface is open or
         // closed. That keeps the virtual strip DOM node—and therefore its
         // horizontal scroll position—alive through the preview toggle.

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1329,12 +1329,13 @@ test.describe("graph view E2E", () => {
     await expect.poll(heightOf).toBeGreaterThan(0);
     const initial = await heightOf();
 
-    // The 16px box is the DRAG TARGET and never changes; the visible band is
-    // smaller and centred inside it (8px at desktop, 12 where it has to hold
-    // the grip), so the space above it reads as clearance under the preview.
+    // The 44px box is the DRAG TARGET and never changes; the visible band is
+    // smaller and sits just below centre inside it (8px at desktop, 12 where
+    // it has to hold the grip), so the space either side of it reads as
+    // clearance between the preview and the timeline.
     expect(
       await divider.evaluate((el) => Math.round(el.getBoundingClientRect().height)),
-    ).toBe(16);
+    ).toBe(44);
     expect(
       await divider
         .locator("[data-divider-line]")
@@ -1394,9 +1395,17 @@ test.describe("graph view E2E", () => {
     expect(naturalTop).toBeGreaterThan(0);
     await page.evaluate((top) => window.scrollTo({ top, behavior: "instant" }), naturalTop + 40);
     await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
+    // Pinned BENEATH the board header, not at the viewport top: the header is
+    // the top of the sticky stack now, and the preview is offset by its
+    // measured height. Measured rather than hard-coded — the header wraps at
+    // narrow widths, so a constant here would be a viewport-dependent flake.
+    const headerHeight = await page
+      .locator("[data-graph-board-header]")
+      .evaluate((element) => element.getBoundingClientRect().height);
+    expect(headerHeight).toBeGreaterThan(0);
     await expect
       .poll(() => previewRegion.evaluate((element) => element.getBoundingClientRect().top))
-      .toBeCloseTo(0, 0);
+      .toBeCloseTo(headerHeight, 0);
     expect(await main.evaluate((element) => getComputedStyle(element).overflowY)).toBe("visible");
     expect(await main.evaluate((element) => element.scrollTop)).toBe(0);
 
@@ -2252,9 +2261,12 @@ test.describe("graph view E2E", () => {
     // smaller and centred on one fixed mid-line, so its height can differ by
     // breakpoint (8 here at desktop, 12 where it hosts the grip) with nothing
     // else moving.
-    expect(dividerBox!.height).toBe(16);
+    expect(dividerBox!.height).toBe(44);
     expect(dividerLineBox!.height).toBe(8);
-    expect(dividerLineBox!.y + dividerLineBox!.height / 2).toBeCloseTo(dividerBox!.y + 10, 0);
+    // Just BELOW centre, so there is more clearance above the band than below
+    // it — the transport overhangs far enough to crowd the preview more than
+    // the timeline, and an even split read bottom-heavy.
+    expect(dividerLineBox!.y + dividerLineBox!.height / 2).toBeCloseTo(dividerBox!.y + 24, 0);
     expect(groupBox!.width).toBe(132);
     expect(groupBox!.height).toBe(44);
     // Centered on the BAND, not on the box.
@@ -5050,8 +5062,18 @@ test.describe("graph view E2E", () => {
     // Sized to the breadcrumb row, and 16:9 from that.
     expect(frameBox.height).toBeCloseTo(band.height, 0);
     expect(frameBox.width).toBeCloseTo(Math.round((band.height * 16) / 9), 0);
-    // Placed against the CLIP: sitting just above it, not in the header band.
-    expect(frameBox.y + frameBox.height).toBeCloseTo(cardBox.y - 8, 0);
+    // Placed against the CLIP — sitting just above it, not parked in the
+    // header band — EXCEPT where that would push it off the top of the
+    // viewport, which graph-trim-panel.tsx clamps to the same 8px margin.
+    //
+    // The clamp is asserted as part of the rule rather than assumed away. It
+    // used to read `cardBox.y - 8` flat, which held only because this fixture
+    // left the frame exactly 0px of slack above the top card: a 3px layout
+    // shift anywhere above the strip flipped it, and the test then reported a
+    // trim-panel bug that did not exist. Expressing the whole rule makes it
+    // describe the behaviour instead of one viewport's arithmetic.
+    const expectedTop = Math.max(8, cardBox.y - frameBox.height - 8);
+    expect(frameBox.y).toBeCloseTo(expectedTop, 0);
     // Out-edge drag: the frame's RIGHT edge rides the clip's right edge.
     expect(frameBox.x + frameBox.width).toBeCloseTo(cardBox.x + cardBox.width, 0);
 
@@ -6805,6 +6827,94 @@ test.describe("graph view E2E", () => {
 
     // Same height at zero, and the board underneath has not moved.
     expect(await height()).toBe(browseHeight);
+  });
+
+  test("the header row sits ABOVE the preview, in browse and in select mode", async ({
+    page,
+  }) => {
+    // The row used to pin BENEATH the preview, via the offset the split pane
+    // published. Nothing asserted the order, so the only thing standing between
+    // this and a silent regression was the CSS itself.
+    //
+    // Both modes, because the select row is a different element with a
+    // different height — a stack that only holds for the browse row would put
+    // the preview through a jump every time the mode is armed.
+    await installGraphApi(page);
+    await openGraph(page);
+    const header = page.locator("[data-graph-board-header]");
+    const preview = page.getByTestId("workbench-preview-region");
+
+    // The preview has to be OPEN for there to be a stack at all.
+    await previewToggle(page).click();
+    await expect(preview).toBeVisible();
+
+    const assertStacked = async (mode: string) => {
+      await expect(header).toHaveAttribute("data-header-mode", mode);
+      // DOM order IS the stack order — the header renders in the pane's own
+      // header slot, before the surface.
+      expect(
+        await header.evaluate(
+          (element, other) => element.compareDocumentPosition(other!),
+          await preview.elementHandle(),
+        ),
+      ).toBe(4 /* DOCUMENT_POSITION_FOLLOWING */);
+      // And the surface pins to the header's measured height rather than 0,
+      // so the two touch with no overlap and no gap.
+      const headerBox = (await header.boundingBox())!;
+      const previewBox = (await preview.boundingBox())!;
+      expect(previewBox.y).toBeGreaterThanOrEqual(headerBox.y + headerBox.height - 1);
+      expect(previewBox.y).toBeLessThanOrEqual(headerBox.y + headerBox.height + 1);
+      await expect
+        .poll(() => preview.evaluate((element) => getComputedStyle(element).top))
+        .toBe(`${Math.round(headerBox.height)}px`);
+    };
+
+    await assertStacked("browse");
+
+    // The select row is a DIFFERENT element with a different height, so the
+    // offset has to follow it — a stack that only held in browse mode would
+    // jump the preview every time the mode is armed.
+    await selectCard(strip(page, PROJECT_ID).locator('[data-node-id="alpha"]'));
+    await toggleMultiSelect(page);
+    await assertStacked("select");
+  });
+
+  test("select mode keeps undo/redo, to the right of Done and fenced by a rule", async ({
+    page,
+  }) => {
+    // Arming the mode used to take undo AWAY — `GraphUndoRedo` rendered only
+    // in the browse branch — at exactly the moment a multi-select delete makes
+    // it most wanted.
+    await installGraphApi(page);
+    await openGraph(page);
+    const header = page.locator("[data-graph-board-header]");
+
+    await selectCard(strip(page, PROJECT_ID).locator('[data-node-id="alpha"]'));
+    await toggleMultiSelect(page);
+    await expect(header).toHaveAttribute("data-header-mode", "select");
+
+    const done = page.locator("[data-select-mode-done]");
+    const undo = header.getByRole("button", { name: "Undo" });
+    const redo = header.getByRole("button", { name: "Redo" });
+    await expect(undo).toBeVisible();
+    await expect(redo).toBeVisible();
+
+    // RIGHT of Done, and in reading order among themselves.
+    const doneBox = (await done.boundingBox())!;
+    const undoBox = (await undo.boundingBox())!;
+    const redoBox = (await redo.boundingBox())!;
+    expect(undoBox.x).toBeGreaterThanOrEqual(doneBox.x + doneBox.width);
+    expect(redoBox.x).toBeGreaterThanOrEqual(undoBox.x + undoBox.width);
+
+    // EXACTLY ONE rule, and it sits after Done. Done's own separation on the
+    // left is the empty space `ml-auto` opens up; a rule there too fenced it
+    // in from both sides and made the way OUT read as one more item in the
+    // verb run.
+    const rules = header.locator('[data-select-mode-header] > [aria-hidden="true"].w-px');
+    await expect(rules).toHaveCount(1);
+    const ruleBox = (await rules.first().boundingBox())!;
+    expect(ruleBox.x).toBeGreaterThanOrEqual(doneBox.x + doneBox.width);
+    expect(ruleBox.x).toBeLessThan(undoBox.x);
   });
 
   test("the grid card carries NO ⋮ — the select row holds its actions", async ({

--- a/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
+++ b/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
@@ -40,6 +40,45 @@ function StickyPreviewFixture() {
   );
 }
 
+/** A consumer toolbar in the `header` slot, above the preview. */
+function StickyHeaderFixture() {
+  const [currentTime, setCurrentTime] = useState(0);
+
+  return (
+    <main className="min-h-[1600px] bg-zinc-950 p-4 text-zinc-100">
+      <WorkbenchSplitPane
+        header={
+          <div
+            data-testid="fixture-header"
+            className="flex h-14 items-center gap-3 border-b border-zinc-800 bg-zinc-950/95 px-3 text-sm"
+          >
+            Home / Scene A
+          </div>
+        }
+        surface={
+          <WorkbenchDisplaySurface
+            clips={[]}
+            currentTime={currentTime}
+            onCurrentTimeChange={setCurrentTime}
+            className="h-full rounded-b-none border-b-0"
+          />
+        }
+      >
+        <div className="grid gap-3">
+          {Array.from({ length: 18 }, (_, index) => (
+            <section
+              key={index}
+              className="grid min-h-24 place-items-center rounded-lg border border-zinc-800 bg-zinc-900/60 text-sm text-zinc-400"
+            >
+              Timeline section {index + 1}
+            </section>
+          ))}
+        </div>
+      </WorkbenchSplitPane>
+    </main>
+  );
+}
+
 const meta = {
   title: "UI/Timeline/Viewport/WorkbenchSplitPane",
   component: WorkbenchSplitPane,
@@ -96,12 +135,20 @@ export const StickyPreview: Story = {
     // only at tablet width and below (md:hidden), so presence is what this
     // story can assert without pinning the canvas width.
     expect(divider.querySelector("[data-divider-grip]")).not.toBeNull();
-    // The box is the hit target and stays 16 at every breakpoint. The visible
+    // The box is the hit target and stays 44 at every breakpoint. The visible
     // band is smaller and CENTERED on one fixed mid-line, so its height can
     // change (8 desktop / 12 coarse-pointer) without moving anything.
-    expect(dividerBox.height).toBe(16);
+    expect(dividerBox.height).toBe(44);
     expect(dividerLineBox.height).toBeLessThan(dividerBox.height);
-    expect(dividerLineBox.y + dividerLineBox.height / 2).toBeCloseTo(dividerBox.y + 10, 0);
+    expect(dividerLineBox.y + dividerLineBox.height / 2).toBeCloseTo(dividerBox.y + 24, 0);
+    // The band sits BELOW centre on purpose: more clearance above it than
+    // below. The transport is centred on the same line and overhangs the band
+    // far enough to crowd the preview above more than the timeline below, so
+    // an even split still read bottom-heavy. Asserted as an inequality rather
+    // than a number, so it survives a retune of the exact gap.
+    const above = dividerLineBox.y - dividerBox.y;
+    const below = dividerBox.y + dividerBox.height - (dividerLineBox.y + dividerLineBox.height);
+    expect(above).toBeGreaterThan(below);
     // The transport centers on the BAND, not on the padded box.
     expect(dividerLineBox.y + dividerLineBox.height / 2).toBeCloseTo(
       buttonGroupBox.y + buttonGroupBox.height / 2,
@@ -150,6 +197,58 @@ function PersistentLowerPaneFixture() {
 
 /** Opening the optional surface must not replace the lower-pane DOM node or
  * reset state owned by it, including a virtual timeline's horizontal scroll. */
+/**
+ * The `header` slot pins ABOVE the preview, and the preview pins beneath it —
+ * one sticky stack, in that order. The offset is MEASURED, so a consumer's
+ * header of any height lands the surface in the right place.
+ */
+export const StickyHeaderAbovePreview: Story = {
+  render: () => <StickyHeaderFixture />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const header = canvas.getByTestId("workbench-header-region");
+    const preview = canvas.getByTestId("workbench-preview-region");
+
+    // DOM order is the stack order: header first, then the surface.
+    expect(header.compareDocumentPosition(preview)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+
+    // The header owns the top; the surface is offset by the header's measured
+    // height rather than a constant.
+    expect(getComputedStyle(header).top).toBe("0px");
+    const headerHeight = header.getBoundingClientRect().height;
+    expect(headerHeight).toBeGreaterThan(0);
+    await waitFor(() =>
+      expect(getComputedStyle(preview).top).toBe(`${headerHeight}px`),
+    );
+
+    // Stacked so a playhead marker (z-30) in the timeline scrolling beneath is
+    // occluded by both, and the surface never paints over the header.
+    expect(Number(getComputedStyle(header).zIndex)).toBeGreaterThan(
+      Number(getComputedStyle(preview).zIndex),
+    );
+
+    // Neither overlaps the other: the surface starts at or below the header's
+    // bottom edge.
+    const headerBox = header.getBoundingClientRect();
+    const previewBox = preview.getBoundingClientRect();
+    expect(previewBox.top).toBeGreaterThanOrEqual(headerBox.bottom - 1);
+  },
+};
+
+/** Without a `header`, nothing extra is rendered and the surface keeps the top. */
+export const NoHeaderKeepsPreviewAtTop: Story = {
+  render: () => <StickyPreviewFixture />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.queryByTestId("workbench-header-region")).toBeNull();
+    expect(
+      getComputedStyle(canvas.getByTestId("workbench-preview-region")).top,
+    ).toBe("0px");
+  },
+};
+
 export const PersistentLowerPane: Story = {
   render: () => <PersistentLowerPaneFixture />,
   play: async ({ canvasElement }) => {

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -133,15 +133,30 @@ const MIN_SURFACE_HEIGHT = 120;
 const MIN_TIMELINE_SPACE = 260;
 /** The divider button's full height — the DRAG HIT TARGET, and what
  *  `--workbench-preview-offset` is built from. Constant at every breakpoint
- *  (Tailwind h-4), so the band inside it can change height without moving the
- *  preview, the transport, or anything sticking below. */
-const DIVIDER_HEIGHT_PX = 16;
+ *  (Tailwind h-7), so the band inside it can change height without moving the
+ *  preview, the transport, or anything sticking below.
+ *
+ *  44 rather than 16: the band needs clear space on BOTH sides of it, and at
+ *  16 with the mid-line at 10 it had 10 above and 6 below — the surface and
+ *  the timeline crowded it from either side.
+ *
+ *  It is also the drag hit target, and a taller one is strictly easier to
+ *  grab — there is no cost here to spend against. */
+const DIVIDER_HEIGHT_PX = 44;
 /** Where the visible band's mid-line falls inside that box. The band is
  *  CENTERED on this line at every breakpoint rather than sized from the top,
  *  which is what lets it be 8px on desktop and 12px on coarse-pointer widths
  *  (where it hosts the grip) without the transport shifting. The transport is
- *  centered on the same line and may overhang the band freely. */
-const DIVIDER_BAND_CENTER_PX = 10;
+ *  centered on the same line and may overhang the band freely.
+ *
+ *  DELIBERATELY BELOW CENTRE — 24 in a 44 box, so the band gets 20 clear above
+ *  and 16 below. Optical, not arithmetic: the transport (h-11) is centred on
+ *  this same line and overhangs the band by more than the clearance either
+ *  side, so it crowds the preview above more than it crowds the timeline
+ *  below, and a mathematically even 22/22 still read bottom-heavy. It is a
+ *  constant rather than a fraction of the height for exactly that reason —
+ *  the right value is judged, not derived. */
+const DIVIDER_BAND_CENTER_PX = 24;
 
 type WorkbenchDividerTransportProps = {
   currentTime: number;
@@ -1475,6 +1490,18 @@ type WorkbenchSplitPaneProps = {
    * mounted, preserving stateful content such as a virtual strip's scroll.
    */
   surface: ReactNode | null;
+  /**
+   * Content pinned ABOVE the upper pane — a consumer's toolbar or breadcrumb
+   * row. The pane measures it and pins `surface` beneath it, so the two form
+   * one sticky stack in that order.
+   *
+   * A SLOT rather than a CSS variable the consumer publishes. The offset has
+   * to travel from whatever sits on top down to the surface, and a variable
+   * would mean this package reading something an app defines — the dependency
+   * pointing the wrong way. Owning the stack keeps the knowledge here: the
+   * pane needs only "something occupies the top", never what it is.
+   */
+  header?: ReactNode;
   children: ReactNode;
   /** Read ONCE at mount for a height carried over from a previous mount (e.g.
    *  the consumer toggled this pane off and back on). Returning a number makes
@@ -1490,11 +1517,18 @@ type WorkbenchSplitPaneProps = {
 
 export function WorkbenchSplitPane({
   surface,
+  header,
   children,
   getInitialSurfaceHeight,
   onSurfaceHeightChange,
 }: WorkbenchSplitPaneProps) {
   const hasSurface = surface !== null;
+  const headerRef = useRef<HTMLDivElement | null>(null);
+  // MEASURED, not assumed. The header's height is whatever the consumer put
+  // there — it wraps on a narrow viewport, and it swaps between rows of
+  // different heights — so the surface's pin has to follow it live rather
+  // than sit at a constant somebody has to remember to update.
+  const [headerHeight, setHeaderHeight] = useState(0);
   // Read once, at mount. `undefined` means nothing to restore → fit instead.
   const [restoredSurfaceHeight] = useState(() => getInitialSurfaceHeight?.());
   const [surfaceHeight, setSurfaceHeight] = useState(
@@ -1511,6 +1545,23 @@ export function WorkbenchSplitPane({
   const dragStartRef = useRef<{ pointerY: number; height: number } | null>(null);
   const clampFrameRef = useRef<number | null>(null);
   const didInitialSizeRef = useRef(false);
+
+  // LAYOUT effect, so the surface is pinned at the right offset in the same
+  // frame the header first paints — measuring in a passive effect showed the
+  // surface at top 0 for a frame and then jumped it down.
+  useLayoutEffect(() => {
+    const element = headerRef.current;
+    if (!element) {
+      setHeaderHeight(0);
+      return;
+    }
+    const measure = () => setHeaderHeight(element.getBoundingClientRect().height);
+    measure();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [header]);
 
   const getViewportBoundaryBottom = useCallback(() => {
     const root = rootRef.current;
@@ -1712,25 +1763,45 @@ export function WorkbenchSplitPane({
       // panes at the container's width; children overflow-scroll inside it.
       className="grid min-h-0 w-full grid-cols-[minmax(0,1fr)] gap-0"
       data-testid="workbench-split-pane"
-      // The sticky preview region's height (surface + divider), published so a
-      // descendant that wants to pin BELOW it — e.g. a sticky board header —
-      // has a live offset to stick to as the divider resizes. The split pane
-      // remains mounted while closed, so publish an explicit zero then.
+      // How far down the WHOLE sticky stack reaches — header, surface and
+      // divider — published so a descendant wanting to pin below all of it has
+      // a live offset as the divider resizes. The split pane remains mounted
+      // while closed, so the surface's share is an explicit zero then; the
+      // header's is not conditional, because a header pins whether or not the
+      // upper pane is open.
       style={
         {
-          "--workbench-preview-offset": hasSurface
-            ? `${surfaceHeight + DIVIDER_HEIGHT_PX}px`
-            : "0px",
+          "--workbench-preview-offset": `${
+            headerHeight + (hasSurface ? surfaceHeight + DIVIDER_HEIGHT_PX : 0)
+          }px`,
         } as React.CSSProperties
       }
     >
+      {header === undefined ? null : (
+        <div
+          ref={headerRef}
+          // TOP of the stack, so z-50 — above the surface's z-40, which is
+          // itself above the strip's z-30 playhead overlay. Getting this
+          // wrong is not subtle: at a lower index a marker in the timeline
+          // scrolling underneath paints straight through the header.
+          className="sticky top-0 z-50 min-w-0 bg-zinc-950"
+          data-testid="workbench-header-region"
+        >
+          {header}
+        </div>
+      )}
       {hasSurface ? (
         <div
         // z-40 (above the strip's z-30 consumer overlay) so a playhead marker
         // in a timeline scrolling underneath is occluded by the sticky
         // preview, not painted over it. At z-30 the marker tied the preview
         // and, being later in the DOM, bled through into the preview area.
-        className="sticky top-0 z-40 min-w-0 overflow-visible bg-zinc-950"
+        //
+        // Pinned BENEATH the header rather than at 0 — the two are one stack,
+        // and the offset is measured because the header's height is the
+        // consumer's business, not a constant this file can know.
+        className="sticky z-40 min-w-0 overflow-visible bg-zinc-950"
+        style={{ top: headerHeight }}
         data-testid="workbench-preview-region"
       >
         {/* A seek thumb is intentionally centered on the timeline edge, so
@@ -1776,11 +1847,12 @@ export function WorkbenchSplitPane({
           aria-valuemin={MIN_SURFACE_HEIGHT}
           aria-valuenow={Math.round(surfaceHeight)}
           aria-label="Resize workbench display"
-          // h-4 = DIVIDER_HEIGHT_PX: the whole box is the drag target, and it
+          // h-11 = DIVIDER_HEIGHT_PX: the whole box is the drag target, and it
           // stays this height at every breakpoint. The visible band inside is
-          // smaller and centered, so the space above it reads as the gap under
-          // the preview without being separate padding.
-          className="group relative block h-4 w-full cursor-row-resize bg-transparent focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-400 focus-visible:outline-offset-2"
+          // smaller and centered, so the space either side of it reads as the
+          // gap between the preview and the timeline without being separate
+          // padding on each.
+          className="group relative block h-11 w-full cursor-row-resize bg-transparent focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-400 focus-visible:outline-offset-2"
           data-workbench-divider
           onPointerDown={handleDividerPointerDown}
           onPointerMove={handleDividerPointerMove}


### PR DESCRIPTION
Four UI changes to the graph board, requested and reviewed live.

## 1. The header row moved above the preview

The breadcrumb row pinned *beneath* the preview, and could not do otherwise from where it lived: a sticky element will not rise past the top of its containing block, and the row rendered inside the split pane's lower half.

So `WorkbenchSplitPane` grew a **`header` slot**, rendered before the surface. It measures that slot and pins the surface underneath, making the two one sticky stack in that order — header `z-50`, surface `z-40`, above the strip's `z-30` playhead overlay.

A **slot rather than a CSS variable the app publishes.** The offset has to travel from whatever sits on top down to the surface, and a variable would have meant `packages/ui` reading something an app defines — the dependency pointing the wrong way, which `packages/ui/AGENTS.md` forbids. Owning the stack keeps the knowledge in the pane, which needs only "something occupies the top", never what it is.

The row keeps everything it had, including the swap to the select-state row when the mode is armed — React resolves context by where an element *renders*, and the pane sits inside the same providers the board always did.

## 2. Divider clearance

16 → 44, with the band's mid-line at 24 rather than half the height. It had 10px above and 6 below, which read as a seam rather than a gap.

Deliberately **not** an even split: the transport is `h-11` and centres on the same mid-line, so it overhangs the 8px band far enough to crowd the preview above more than the timeline below — an even 22/22 still looked bottom-heavy. Measured in the running app at **20 above / 16 below**.

## 3. Undo/redo in the select row

`GraphUndoRedo` rendered only in the browse branch, so arming select mode took undo **away** — at exactly the moment a multi-select delete makes it most wanted. It now sits to the right of Done, fenced by one rule.

Done keeps `ml-auto`; its left-hand separation is the empty space that opens up. A rule there too fenced it in from both sides and made the way *out* read as one more item in the verb run. Already `h-8` buttons, so the header's height is unchanged — which matters, because both faces of it are pinned to one height and a stray `h-9` on Done once broke exactly that.

## Two things the move broke, fixed rather than asserted away

- A JSX comment cannot live inside `header={…}`. It described the old below-the-preview arrangement anyway, so it was rewritten.
- The row carried its own `sticky`/`z`/`top`. Left in place, that nested a second sticky context inside the pane's wrapper and pinned the row against itself.

## One test changed meaning — please look at this one

`a trim drag floats the edge frame above the clip` asserted `cardBox.y - 8` flat. That held only because the fixture left the frame **exactly 0px of slack** above the top card: a 3px shift anywhere above the strip flipped it, and it then reported a trim-panel bug that did not exist.

It now asserts the rule `graph-trim-panel.tsx` actually implements, clamp included:

```ts
const expectedTop = Math.max(8, cardBox.y - frameBox.height - 8);
```

That is layout-independent. It is also the one place in this PR where I loosened an assertion rather than fixing code to satisfy it, so it deserves a second opinion. Reverting it is one line if you'd rather the layout absorbed the difference.

The four hard-coded divider numbers across the story and e2e specs moved with the constant.

## Coverage

- Two new stories: `StickyHeaderAbovePreview`, `NoHeaderKeepsPreviewAtTop`
- New e2e: header above the preview in **both** browse and select mode (the select row is a different element with a different height, so a stack that only held in browse would jump the preview every time the mode is armed)
- New e2e: undo/redo right of Done with exactly one rule after it

## Gates

Unit 533/533 · Storybook 191/191 · App 712/712 · both typechecks clean · lint 0 errors.

**e2e: a full local run reported 3 failures** — `grid mode with preview: seek rail scrubs`, `the trash lists files on their way out`, `crafted focus URLs are rejected`. All three pass in isolation, and none touches the header, the divider or the select row. I suspect contention: I killed three in-flight e2e runs while iterating on the design, and that run took 3.1m against a usual 2.5m. I am re-running clean to confirm rather than assuming. **CI's own e2e is the gate here** — if these are real, this PR should not merge, and the required check will say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)