### PR TITLE
Breadcrumbs during a cut, the last-clip removal fix, and first-frame thumbnails

### DIFF
--- a/apps/timeline-gstudio001/app/api/timelines/batch/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/batch/route.ts
@@ -57,6 +57,7 @@ export async function POST(request: Request) {
       const write = (typeof entry === "object" && entry !== null ? entry : {}) as {
         document?: unknown;
         expectedRevision?: unknown;
+        allowEmptying?: unknown;
       };
       // Full runtime validation (every clip, discriminated by kind): a
       // malformed client payload must never persist under a TimelineClip
@@ -93,11 +94,24 @@ export async function POST(request: Request) {
           { status: 400 },
         );
       }
+      // Says the empty this write produces is DELIBERATE, exempting just this
+      // document from the empty-over-non-empty guard in the store. Per-write,
+      // like `expectedRevision` and unlike a batch-wide option: a cross-timeline
+      // move empties its source and fills its target in one batch, and only the
+      // source is asking. Without it on the wire the app could never remove a
+      // collection's last clip, however the client asked.
+      if (write.allowEmptying !== undefined && typeof write.allowEmptying !== "boolean") {
+        return NextResponse.json(
+          { error: "allowEmptying must be a boolean." },
+          { status: 400 },
+        );
+      }
       writes.push({
         document: write.document,
         ...(write.expectedRevision !== undefined
           ? { expectedRevision: write.expectedRevision }
           : {}),
+        ...(write.allowEmptying === true ? { allowEmptying: true } : {}),
       });
     }
 

--- a/apps/timeline-gstudio001/app/api/timelines/timelines-batch.test.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/timelines-batch.test.ts
@@ -12,13 +12,24 @@ import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/
 
 type Stored = Record<string, unknown>;
 
+const DELETE_SENTINEL = "__delete__";
+
 const state = vi.hoisted(() => {
   const docs = new Map<string, Stored>();
   const current = { user: { uid: "user-a", email: null as string | null, name: null, picture: null } };
 
   const applySet = (id: string, data: Stored, opts?: { merge?: boolean }) => {
     const existing = docs.get(id);
-    docs.set(id, opts?.merge && existing ? { ...existing, ...data } : { ...data });
+    const merged = opts?.merge && existing ? { ...existing, ...data } : { ...data };
+    // Firestore's FieldValue.delete() REMOVES the field on a merge write. The
+    // store uses it to drop `lastNonEmptyDocument` on a deliberate empty, so a
+    // mock that stored the sentinel verbatim would leave the recovery snapshot
+    // in place and report an empty that silently re-hydrates as fine.
+    // Same sentinel as trash-empty.test.ts.
+    for (const [key, value] of Object.entries(merged)) {
+      if (value === DELETE_SENTINEL) delete merged[key];
+    }
+    docs.set(id, merged);
   };
   const snapshot = (id: string) => {
     const data = docs.get(id);
@@ -91,7 +102,10 @@ vi.mock("firebase-admin/firestore", () => {
       return new Date(0);
     }
   }
-  return { Timestamp, FieldValue: { serverTimestamp: () => new Timestamp() } };
+  return {
+    Timestamp,
+    FieldValue: { serverTimestamp: () => new Timestamp(), delete: () => "__delete__" },
+  };
 });
 vi.mock("@/lib/firebase-auth-session", () => ({
   requireAuthUser: async () => ({ user: state.current.user, response: null }),
@@ -139,7 +153,13 @@ function seedTimeline(id: string, ownerUid: string | undefined, revision?: numbe
   });
 }
 
-function batchRequest(writes: { document: TimelineDocument; expectedRevision?: number }[]) {
+function batchRequest(
+  writes: {
+    document: TimelineDocument;
+    expectedRevision?: number;
+    allowEmptying?: unknown;
+  }[],
+) {
   return new Request("http://test.local/api/timelines/batch", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -259,6 +279,94 @@ describe("timeline batch writes", () => {
     );
     expect(response.status).toBe(409);
     expect(state.docs.get("doc-1")).toEqual(before);
+  });
+
+  // The other half of that guard. Removing a collection's LAST clip is a legal
+  // edit, and until the flag reached this route the app could not do it at all
+  // — `allowEmptying` existed on the store and on the MCP path, but the batch
+  // body carried only `document` and `expectedRevision`, so the UI had no way
+  // to say the empty was deliberate.
+  it("allowEmptying lets a deliberate removal empty a document", async () => {
+    seedTimeline("doc-1", "user-a", 2);
+
+    const response = await batchWrite(
+      batchRequest([
+        {
+          document: { id: "doc-1", title: "Timeline doc-1", clips: [] },
+          expectedRevision: 2,
+          allowEmptying: true,
+        },
+      ]),
+    );
+    expect(response.status).toBe(200);
+    expect(state.docs.get("doc-1")?.clips).toEqual([]);
+    expect(state.docs.get("doc-1")?.revision).toBe(3);
+  });
+
+  // The empty must STICK. `toTimelineDocument` reads `lastNonEmptyDocument`
+  // back whenever a stored document has no clips, so permitting the write
+  // without dropping that snapshot would re-hydrate the very clip the user
+  // removed and the removal would silently undo itself on the next read.
+  it("a permitted empty drops the recovery snapshot, so it does not re-hydrate", async () => {
+    // Establish a REAL snapshot first: it is written by every non-empty save,
+    // and the seed does not carry one. Asserting it is absent without putting
+    // it there is a test that passes for the wrong reason.
+    seedTimeline("doc-1", "user-a", 1);
+    await batchWrite(batchRequest([{ document: docOf("doc-1", "keeper"), expectedRevision: 1 }]));
+    expect(state.docs.get("doc-1")?.lastNonEmptyDocument).toBeDefined();
+
+    const response = await batchWrite(
+      batchRequest([
+        {
+          document: { id: "doc-1", title: "Timeline doc-1", clips: [] },
+          expectedRevision: 2,
+          allowEmptying: true,
+        },
+      ]),
+    );
+    expect(response.status).toBe(200);
+    expect(state.docs.get("doc-1")?.clips).toEqual([]);
+    expect(state.docs.get("doc-1")?.lastNonEmptyDocument).toBeUndefined();
+  });
+
+  // Per-write, not per-batch. Stated as a CONTRAST, because a batch is
+  // all-or-nothing: flagging neither and flagging only one both end in 409, so
+  // only the flagged-both case can show the flag is what did it.
+  it("allowEmptying exempts ONLY the write that carries it", async () => {
+    const emptyDoc = (id: string) => ({ id, title: `Timeline ${id}`, clips: [] });
+
+    seedTimeline("doc-1", "user-a", 1);
+    seedTimeline("doc-2", "user-a", 1);
+    const unflagged = await batchWrite(
+      batchRequest([
+        { document: emptyDoc("doc-1"), expectedRevision: 1, allowEmptying: true },
+        { document: emptyDoc("doc-2"), expectedRevision: 1 },
+      ]),
+    );
+    expect(unflagged.status).toBe(409);
+    expect(state.docs.get("doc-1")?.clips).toHaveLength(1);
+    expect(state.docs.get("doc-2")?.clips).toHaveLength(1);
+
+    const bothFlagged = await batchWrite(
+      batchRequest([
+        { document: emptyDoc("doc-1"), expectedRevision: 1, allowEmptying: true },
+        { document: emptyDoc("doc-2"), expectedRevision: 1, allowEmptying: true },
+      ]),
+    );
+    expect(bothFlagged.status).toBe(200);
+    expect(state.docs.get("doc-1")?.clips).toEqual([]);
+    expect(state.docs.get("doc-2")?.clips).toEqual([]);
+  });
+
+  it("rejects a non-boolean allowEmptying as a 400", async () => {
+    seedTimeline("doc-1", "user-a", 1);
+    const response = await batchWrite(
+      batchRequest([
+        { document: docOf("doc-1", "x"), expectedRevision: 1, allowEmptying: "yes" },
+      ]),
+    );
+    expect(response.status).toBe(400);
+    expect(state.docs.get("doc-1")?.revision).toBe(1);
   });
 
   it("rejects a batch that repeats a timeline id", async () => {

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -75,6 +75,7 @@ import { Slider } from "@/components/core/slider";
 import {
   useClipboardCount,
   useHasPendingCut,
+  usePendingCutCount,
   useSelectionActionState,
   useSelectionAnchorId,
 } from "./graph-selection-actions";
@@ -1016,11 +1017,16 @@ function SelectModeVerb({
   );
 }
 
-function SelectModeHeader({ anchorName }: Readonly<{ anchorName: string | null }>) {
-  const store = useCollectionsStore();
-  const state = useSelectionActionState();
-  const { selectionCount } = state;
-
+/**
+ * The fitted run of verbs, and the `⋮` holding whatever did not fit.
+ *
+ * ITS OWN COMPONENT so the row can leave it out entirely while a cut is
+ * pending, where the breadcrumb takes the space instead. Branching around
+ * `useFittedVerbCount` inside the header would be a conditional hook; lifting
+ * the whole run out is what makes the swap legal, and it also stops the
+ * measuring ResizeObserver from running for a row that is not drawn.
+ */
+function SelectModeVerbRun({ state }: Readonly<{ state: ItemActionState }>) {
   const { containerRef, rulerRef, visible } = useFittedVerbCount(state);
   // What the row could not draw — exactly the overflow menu's contents, taken
   // in DRAW order so the two halves of one list stay in one order.
@@ -1030,8 +1036,96 @@ function SelectModeHeader({ anchorName }: Readonly<{ anchorName: string | null }
   );
 
   return (
+    /* The verb run, and the ruler it is measured against. `flex-1 min-w-0`
+       so the budget comes from the ROW rather than from the verbs — see
+       useFittedVerbCount for why that direction matters. */
+    <div
+      ref={containerRef}
+      data-select-mode-verbs={visible.size}
+      className="relative flex min-w-0 flex-1 items-center gap-x-5 overflow-hidden"
+    >
+      <div
+        ref={rulerRef}
+        aria-hidden="true"
+        inert
+        data-select-mode-verb-ruler=""
+        // Out of flow and invisible, but LAID OUT — `visibility: hidden`
+        // keeps the boxes measurable where `display: none` would report
+        // zero. Absolute so it cannot widen the container it is measured
+        // against, and `inert` so a hidden run of buttons is not a set of
+        // tab stops.
+        className="pointer-events-none invisible absolute left-0 top-0 flex items-center gap-x-5"
+      >
+        {SELECT_MODE_VERBS.map((action) => (
+          <SelectModeVerb key={action} action={action} state={state} />
+        ))}
+        {/* The `⋮`'s own width, MEASURED rather than assumed: it is 32px
+            under a mouse and 44px under a finger (HEADER_SELECTION_SIZE), so
+            a constant would reserve the wrong number on one of them and drop
+            a verb early. Kept LAST, past every verb index, so the per-verb
+            lookup by `indexOf` above is unaffected by its presence. */}
+        <span data-select-mode-overflow-ruler="" className={cn(HEADER_SELECTION_SIZE, "shrink-0")} />
+      </div>
+      {SELECT_MODE_VERBS.filter((action) => visible.has(action)).map((action) => (
+        <SelectModeVerb key={action} action={action} state={state} />
+      ))}
+      {/* ONLY what did not fit, and only WHEN something did not fit.
+
+          Inside the run, so it lands immediately after the last verb drawn
+          rather than at the far end of the row's leftover space — the run is
+          `flex-1`, so out here it floated an inch away from the verbs it
+          belongs to. And absent entirely when all six fit: a `⋮` that is
+          always there says the row is a summary of some longer list, which
+          is what made the row's own verbs look decorative. Appearing only on
+          overflow says the row IS the list and this is its remainder. */}
+      {hidden.size > 0 ? (
+        <DropdownMenu modal={false}>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label={`${hidden.size} more selection ${hidden.size === 1 ? "action" : "actions"}`}
+              data-header-selection-overflow
+              data-select-mode-overflow-count={hidden.size}
+              className={cn(HEADER_SELECTION_SIZE, HEADER_TOGGLE_IDLE, "shrink-0")}
+            >
+              <EllipsisVertical aria-hidden className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent side="bottom" align="center" className={SELECTION_MENU_CONTENT_CLASS}>
+            <SelectionMenuOverflowItems
+              parts={DROPDOWN_MENU_PARTS}
+              state={state}
+              actions={hidden}
+            />
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : null}
+    </div>
+  );
+}
+
+function SelectModeHeader({
+  anchorName,
+  breadcrumb,
+}: Readonly<{ anchorName: string | null; breadcrumb: React.ReactNode }>) {
+  const store = useCollectionsStore();
+  const state = useSelectionActionState();
+  const { selectionCount } = state;
+
+  // A cut CLEARS the selection (see `cutSelection`), so from here on
+  // `selectionCount` is 0 and every verb is dimmed by `!hasSelection`. Rather
+  // than draw five dead words, the row hands the space to the breadcrumb: the
+  // one thing a half-finished cut actually needs is a way to reach the
+  // collection it is going to be pasted into.
+  const cutCount = usePendingCutCount();
+  const cutPending = cutCount > 0;
+
+  return (
     <div
       data-select-mode-header=""
+      data-select-mode-cut-pending={cutPending ? "" : undefined}
       // NOT `flex-wrap` any more. Wrapping was how this row coped with running
       // out of width, and it coped by growing taller — which is exactly what
       // the header must never do, now that both faces of it are pinned to the
@@ -1039,7 +1133,7 @@ function SelectModeHeader({ anchorName }: Readonly<{ anchorName: string | null }
       className="flex min-w-0 flex-1 items-center gap-x-5"
     >
       <span
-        data-select-mode-count={selectionCount}
+        data-select-mode-count={cutPending ? cutCount : selectionCount}
         // Mono and tabular so the row does not twitch sideways as the count
         // crosses 9 — this number changes on every tap, which is precisely the
         // moment a reflowing toolbar is most annoying.
@@ -1051,75 +1145,26 @@ function SelectModeHeader({ anchorName }: Readonly<{ anchorName: string | null }
         // that read as a third accent rather than the selection colour.
         className="shrink-0 font-mono text-[13px] tabular-nums text-blue-500"
       >
-        {selectionCount} selected
+        {cutPending ? cutCount : selectionCount} selected
       </span>
-      {/* The verb run, and the ruler it is measured against. `flex-1 min-w-0`
-          so the budget comes from the ROW rather than from the verbs — see
-          useFittedVerbCount for why that direction matters. */}
-      <div
-        ref={containerRef}
-        data-select-mode-verbs={visible.size}
-        className="relative flex min-w-0 flex-1 items-center gap-x-5 overflow-hidden"
-      >
-        <div
-          ref={rulerRef}
-          aria-hidden="true"
-          inert
-          data-select-mode-verb-ruler=""
-          // Out of flow and invisible, but LAID OUT — `visibility: hidden`
-          // keeps the boxes measurable where `display: none` would report
-          // zero. Absolute so it cannot widen the container it is measured
-          // against, and `inert` so a hidden run of buttons is not a set of
-          // tab stops.
-          className="pointer-events-none invisible absolute left-0 top-0 flex items-center gap-x-5"
-        >
-          {SELECT_MODE_VERBS.map((action) => (
-            <SelectModeVerb key={action} action={action} state={state} />
-          ))}
-          {/* The `⋮`'s own width, MEASURED rather than assumed: it is 32px
-              under a mouse and 44px under a finger (HEADER_SELECTION_SIZE), so
-              a constant would reserve the wrong number on one of them and drop
-              a verb early. Kept LAST, past every verb index, so the per-verb
-              lookup by `indexOf` above is unaffected by its presence. */}
-          <span data-select-mode-overflow-ruler="" className={cn(HEADER_SELECTION_SIZE, "shrink-0")} />
-        </div>
-        {SELECT_MODE_VERBS.filter((action) => visible.has(action)).map((action) => (
-          <SelectModeVerb key={action} action={action} state={state} />
-        ))}
-        {/* ONLY what did not fit, and only WHEN something did not fit.
+      {/* THE SWAP. Dimmed verbs are worse than absent ones here: after a cut
+          all five are unavailable for the same reason, and the row still has
+          to get the user somewhere. The breadcrumb takes the identical wing —
+          `flex-1 min-w-0` either way — so nothing on either side of it moves.
 
-            Inside the run, so it lands immediately after the last verb drawn
-            rather than at the far end of the row's leftover space — the run is
-            `flex-1`, so out here it floated an inch away from the verbs it
-            belongs to. And absent entirely when all six fit: a `⋮` that is
-            always there says the row is a summary of some longer list, which
-            is what made the row's own verbs look decorative. Appearing only on
-            overflow says the row IS the list and this is its remainder. */}
-        {hidden.size > 0 ? (
-          <DropdownMenu modal={false}>
-            <DropdownMenuTrigger asChild>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                aria-label={`${hidden.size} more selection ${hidden.size === 1 ? "action" : "actions"}`}
-                data-header-selection-overflow
-                data-select-mode-overflow-count={hidden.size}
-                className={cn(HEADER_SELECTION_SIZE, HEADER_TOGGLE_IDLE, "shrink-0")}
-              >
-                <EllipsisVertical aria-hidden className="h-4 w-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent side="bottom" align="center" className={SELECTION_MENU_CONTENT_CLASS}>
-              <SelectionMenuOverflowItems
-                parts={DROPDOWN_MENU_PARTS}
-                state={state}
-                actions={hidden}
-              />
-            </DropdownMenuContent>
-          </DropdownMenu>
-        ) : null}
-      </div>
+          Its crumbs are also the up-a-level DROP targets, which is the other
+          half of "where am I pasting this": the same row now answers it by
+          click and by drag. */}
+      {cutPending ? (
+        <div
+          data-select-mode-breadcrumb=""
+          className="flex min-w-0 flex-1 items-center overflow-hidden"
+        >
+          {breadcrumb}
+        </div>
+      ) : (
+        <SelectModeVerbRun state={state} />
+      )}
       <HeaderPasteButton anchorName={anchorName} />
       {/* `ml-auto`: Done sits at the far end, away from Delete. Both end the
           gesture, only one of them destroys anything, and putting them
@@ -1132,13 +1177,22 @@ function SelectModeHeader({ anchorName }: Readonly<{ anchorName: string | null }
         variant="ghost"
         size="sm"
         data-select-mode-done
-        title="Finish selecting"
+        title={cutPending ? "Finish selecting and cancel the cut" : "Finish selecting"}
         // Clear THEN disarm. The store keeps the mode armed through an empty
         // selection for this view (keepMultiSelectModeWhenEmpty), so the clear
         // cannot disarm it out from under this and the order is only about
         // ending in one notify rather than leaving the row briefly showing "0
         // selected" on its way out.
+        //
+        // Done also ABANDONS a pending cut. Leaving without pasting is the
+        // user saying the move is not happening, and the alternative is worse
+        // than untidy: the sources would stay dimmed on a board with no select
+        // row and — since the `✕` that cancels a cut lives only in the BROWSE
+        // header — no obvious way back to them. `clear()` drops the entries and
+        // the pending set in one notify, which un-dims the sources in place;
+        // they never moved, so there is nothing to put back.
         onClick={() => {
+          graphClipboard.clear();
           store.clearSelection();
           store.setMultiSelectMode(false);
         }}
@@ -1493,7 +1547,7 @@ export function GraphBoard({
                 shape. It stays outside DragChromeFade with the breadcrumb,
                 because a save landing mid-drag is still worth seeing. */}
             {selectModeRow ? (
-              <SelectModeHeader anchorName={anchorName} />
+              <SelectModeHeader anchorName={anchorName} breadcrumb={breadcrumb} />
             ) : (
               <>
             <div className="flex min-w-0 flex-1 items-center gap-3">

--- a/apps/timeline-gstudio001/components/graph-view/graph-selection-actions.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-selection-actions.tsx
@@ -67,6 +67,26 @@ export function useHasPendingCut(): boolean {
 }
 
 /**
+ * HOW MANY items a cut is waiting to move.
+ *
+ * The select row needs the number, not the boolean above: a cut clears the
+ * selection (`cutSelection` in graph-item-actions), so `selectionCount` drops
+ * to zero and the row would otherwise report "0 selected" while three items sit
+ * dimmed waiting for a destination. During a cut this is what the count means.
+ *
+ * Separate from `useHasPendingCut` rather than replacing it — the browse header
+ * only ever asks "is one pending", and subscribing it to the Set's size would
+ * re-render it on every membership change for an answer it does not use.
+ */
+export function usePendingCutCount(): number {
+  return useSyncExternalStore(
+    graphClipboard.subscribe,
+    () => graphClipboard.pendingCutIds().size,
+    () => 0,
+  );
+}
+
+/**
  * The anchor: the card hosting the pill, and the card a paste follows.
  *
  * A plain store read now. It used to be derived here from `selectedIds` with a

--- a/apps/timeline-gstudio001/lib/graph-clipboard.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-clipboard.test.ts
@@ -40,6 +40,40 @@ describe("graphClipboard", () => {
     unsubscribe();
   });
 
+  // The pending-cut half had no coverage at all, and Done now depends on it:
+  // leaving select mode without pasting calls `clear()` to abandon the move,
+  // and the un-dimming of the sources is exactly this set emptying.
+  it("clear() abandons a pending cut, in the same notify as the contents", async () => {
+    const clipboard = await freshClipboard();
+    const seen: number[] = [];
+    const unsubscribe = clipboard.subscribe(() => seen.push(clipboard.pendingCutIds().size));
+
+    clipboard.set([entry]);
+    clipboard.markPendingCut([parseNodeId("m1"), parseNodeId("m2")]);
+    expect(clipboard.pendingCutIds().size).toBe(2);
+    expect(clipboard.isPendingCut(parseNodeId("m1"))).toBe(true);
+    expect(clipboard.isPendingCut(parseNodeId("nope"))).toBe(false);
+
+    clipboard.clear();
+    expect(clipboard.pendingCutIds().size).toBe(0);
+    expect(clipboard.isEmpty()).toBe(true);
+    // set → markPendingCut → clear. One notify each, and the clear reports
+    // both halves gone at once rather than emptying them in two steps.
+    expect(seen).toEqual([0, 2, 0]);
+    unsubscribe();
+  });
+
+  it("a fresh copy replaces a pending cut, so nothing stays dimmed for it", async () => {
+    const clipboard = await freshClipboard();
+    clipboard.set([entry]);
+    clipboard.markPendingCut([parseNodeId("m1")]);
+    // `set` clears the pending move: the dimmed sources belonged to a cut this
+    // copy just replaced, and a paste will no longer carry them.
+    clipboard.set([entry]);
+    expect(clipboard.pendingCutIds().size).toBe(0);
+    expect(clipboard.isEmpty()).toBe(false);
+  });
+
   it("binding a DIFFERENT user wipes the contents; same user keeps them", async () => {
     const clipboard = await freshClipboard();
     clipboard.bindUser("user-a");

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
@@ -498,14 +498,35 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
       abandonSaveInFlight?.();
     }
     if (dirtyIds.size === 0) return;
-    const writes: { document: TimelineDocument; expectedRevision?: number }[] = [];
+    const writes: {
+      document: TimelineDocument;
+      expectedRevision?: number;
+      allowEmptying?: boolean;
+    }[] = [];
     for (const timelineId of dirtyIds) {
       const document = documents[timelineId];
       if (!document) continue;
       const revision = revisions.get(timelineId);
+      // REMOVING THE LAST CLIP is a legal edit, and without this it is not:
+      // the store refuses to write an empty document over a non-empty one
+      // unless the write says the empty is deliberate. That escape reached the
+      // MCP surface only, so the app could not empty a collection at all — and
+      // a per-shot lane holds exactly one clip, so any correction to one hit it.
+      //
+      // Gated on `expectedRevision`, NOT set for every empty write. The guard
+      // exists to stop a stale or half-loaded client wiping a document it never
+      // really read; a write carrying a revision is CAS-protected against
+      // exactly that, so an empty one is an edit rather than an accident. A
+      // blind write (no revision known) still meets the guard, which is the
+      // case worth keeping it for.
+      //
+      // Per-document too, never per-batch: a move empties its source while
+      // filling its target, and only the source asked for the exemption.
+      const emptiesDocument = document.clips.length === 0 && revision !== undefined;
       writes.push({
         document,
         ...(revision !== undefined ? { expectedRevision: revision } : {}),
+        ...(emptiesDocument ? { allowEmptying: true } : {}),
       });
     }
     dirtyIds.clear();

--- a/apps/timeline-gstudio001/lib/video-frame-url.test.ts
+++ b/apps/timeline-gstudio001/lib/video-frame-url.test.ts
@@ -129,9 +129,58 @@ describe("videoFrameUrls", () => {
     expect(videoFrameUrls(["p"], 0, { trimInSeconds: 0, effectiveSeconds: 5 })).toEqual([]);
   });
 
+  // A LONE slot is a thumbnail for the whole clip, not one cell of a strip.
+  // The slot-centre rule put it at the clip's MIDPOINT, so a card stood for its
+  // shot with a frame from halfway through it.
+  it("samples a SINGLE frame at the start of the clip, not its midpoint", () => {
+    const times: number[] = [];
+    const record: VideoFrameUrlBuilder = (_url, t) => {
+      times.push(t);
+      return "x";
+    };
+    videoFrameUrls(["poster"], 1, { trimInSeconds: 0, effectiveSeconds: 8 }, record);
+    // 0.05 in, not 4. Nudged off the exact zero because an encode's first
+    // frame is so often black; one frame at 24fps, invisible as a thumbnail.
+    expect(times).toEqual([0.05]);
+  });
+
+  it("takes a trimmed clip's in-point exactly, with no nudge", () => {
+    const times: number[] = [];
+    const record: VideoFrameUrlBuilder = (_url, t) => {
+      times.push(t);
+      return "x";
+    };
+    videoFrameUrls(["poster"], 1, { trimInSeconds: 10, effectiveSeconds: 4 }, record);
+    // The user chose this frame and it is mid-source, so the black-frame
+    // reasoning behind the nudge does not apply.
+    expect(times).toEqual([10]);
+  });
+
+  it("never nudges a single frame past a very short clip", () => {
+    const times: number[] = [];
+    const record: VideoFrameUrlBuilder = (_url, t) => {
+      times.push(t);
+      return "x";
+    };
+    videoFrameUrls(["poster"], 1, { trimInSeconds: 0, effectiveSeconds: 0.04 }, record);
+    // Half the range rather than 0.05, which would sample past the end.
+    expect(times).toEqual([0.02]);
+  });
+
+  it("leaves multi-slot strips sampling at centres", () => {
+    const times: number[] = [];
+    const record: VideoFrameUrlBuilder = (_url, t) => {
+      times.push(t);
+      return "x";
+    };
+    // The single-frame rule must not leak into the filmstrip: its first slot
+    // stays at its centre so the frames remain evenly distributed.
+    videoFrameUrls(["poster"], 3, { trimInSeconds: 0, effectiveSeconds: 6 }, record);
+    expect(times).toEqual([1, 3, 5.95]);
+  });
+
   it("defaults to the Cloudinary builder", () => {
     const urls = videoFrameUrls([CLOUDINARY_FRAME], 1, { trimInSeconds: 0, effectiveSeconds: 4 });
-    // count 1 → centre at 2s.
-    expect(urls[0]).toContain("so_2,");
+    expect(urls[0]).toContain("so_0.05,");
   });
 });

--- a/apps/timeline-gstudio001/lib/video-frame-url.ts
+++ b/apps/timeline-gstudio001/lib/video-frame-url.ts
@@ -73,6 +73,19 @@ export function collectionPreviewFrameUrl(
 const LAST_FRAME_BACKOFF_SECONDS = 0.05;
 
 /**
+ * How far PAST the range's exact start a single-frame thumbnail samples.
+ *
+ * The mirror of the back-off above, and for the same reason: the exact in-cut
+ * of an encode is frequently black or a fade-in remnant. At 24fps this is
+ * roughly one frame in — indistinguishable from "the first frame" to a viewer,
+ * and the difference between a thumbnail and a black square.
+ *
+ * It is NOT applied to a trimmed clip's in-point, which is a frame the user
+ * chose deliberately and is mid-source rather than at an encode boundary.
+ */
+const FIRST_FRAME_NUDGE_SECONDS = 0.05;
+
+/**
  * `count` frame URLs sampled at even times across the clip's VISIBLE range
  * — [trimInSeconds, trimInSeconds + effectiveSeconds]. Interior frames are
  * read at slot CENTERS ((i + 0.5) / count) so the first isn't the exact
@@ -80,6 +93,12 @@ const LAST_FRAME_BACKOFF_SECONDS = 0.05;
  * small back-off) so the strip always finishes on the clip's final frame
  * (R7 #3). Falls back to the base poster when there is no usable frame URL
  * to transform.
+ *
+ * A SINGLE slot is the exception at both ends: it is a thumbnail standing for
+ * the whole clip, not one cell of a strip, and the slot-centre rule put it at
+ * the clip's MIDPOINT — the owner's report, and wrong for a card whose job is
+ * to say "this is that shot". It samples the START instead. Pinning it to the
+ * end was already rejected for the same reason in reverse.
  */
 export function videoFrameUrls(
   posters: readonly string[],
@@ -93,12 +112,20 @@ export function videoFrameUrls(
   const effective = Math.max(0, range.effectiveSeconds);
   const urls: string[] = [];
   for (let index = 0; index < slots; index += 1) {
-    // Single-slot strips keep the center sample — pinning them to the end
-    // would represent a whole clip by its final frame.
+    // A lone slot is a THUMBNAIL for the whole clip: it opens on the clip's
+    // first frame rather than its midpoint. Nudged off an untrimmed encode's
+    // exact zero, where a black frame is common; a real trim in-point is taken
+    // as given, since the user picked it and it is not an encode boundary.
+    const singleFrameTime =
+      range.trimInSeconds > 0
+        ? range.trimInSeconds
+        : Math.min(FIRST_FRAME_NUDGE_SECONDS, effective / 2);
     const time =
-      index === slots - 1 && slots > 1
-        ? range.trimInSeconds + Math.max(effective / 2, effective - LAST_FRAME_BACKOFF_SECONDS)
-        : range.trimInSeconds + ((index + 0.5) / slots) * effective;
+      slots === 1
+        ? singleFrameTime
+        : index === slots - 1
+          ? range.trimInSeconds + Math.max(effective / 2, effective - LAST_FRAME_BACKOFF_SECONDS)
+          : range.trimInSeconds + ((index + 0.5) / slots) * effective;
     urls.push(build(base, time));
   }
   return urls;

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -6829,6 +6829,124 @@ test.describe("graph view E2E", () => {
     expect(await height()).toBe(browseHeight);
   });
 
+  // ── A pending cut hands the row to the breadcrumb ─────────────────────────
+  //
+  // Cutting CLEARS the selection, so every verb in the row is dimmed by
+  // `!hasSelection` and the count drops to zero. Five dead words is the wrong
+  // thing to show at the one moment the user has to go somewhere else: the
+  // whole point of a cut is that the destination is elsewhere.
+
+  /** Arm a cut on one card from inside select mode. */
+  async function cutInSelectMode(
+    page: Page,
+    nodeId: string,
+    collectionId: string = PROJECT_ID,
+  ): Promise<void> {
+    await selectCard(strip(page, collectionId).locator(`[data-node-id="${nodeId}"]`));
+    await toggleMultiSelect(page);
+    await selectionAction(page, "Cut");
+    await expect(page.locator('[data-card-pending-cut="true"]')).toHaveCount(1);
+  }
+
+  test("a cut swaps the verb run for the breadcrumb, keeping the cut's own count", async ({
+    page,
+  }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    const header = page.locator("[data-graph-board-header]");
+
+    // Before: the verbs are there and the breadcrumb is not.
+    await selectCard(strip(page, PROJECT_ID).locator('[data-node-id="charlie"]'));
+    await toggleMultiSelect(page);
+    await expect(header.locator("[data-select-mode-verbs]")).toBeVisible();
+    await expect(header.locator("[data-select-mode-breadcrumb]")).toHaveCount(0);
+
+    await selectionAction(page, "Cut");
+    await expect(page.locator('[data-card-pending-cut="true"]')).toHaveCount(1);
+
+    // After: the run is GONE, not merely dimmed, and the breadcrumb has it.
+    await expect(header.locator("[data-select-mode-header]")).toHaveAttribute(
+      "data-select-mode-cut-pending",
+      "",
+    );
+    await expect(header.locator("[data-select-mode-verbs]")).toHaveCount(0);
+    await expect(header.locator("[data-select-mode-breadcrumb]")).toBeVisible();
+
+    // The count survives the cut clearing the selection: it now reports what
+    // is in flight, which is the only number that means anything here. Without
+    // `usePendingCutCount` this reads "0 selected".
+    await expect(page.locator("[data-select-mode-count]")).toHaveText("1 selected");
+    // Paste stays — it is the other half of finishing the gesture.
+    await expect(page.getByRole("button", { name: /^Paste 1 item/ })).toBeVisible();
+  });
+
+  test("the breadcrumb navigates during a cut, and the count follows the cut items", async ({
+    page,
+  }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    const header = page.locator("[data-graph-board-header]");
+
+    // Drill in first, so there is an ancestor crumb to travel back up through.
+    await drillButton(page, "Scene A").click();
+    await expect.poll(() => page.url().includes(CHILD_ID)).toBe(true);
+
+    // `c1` is a clip inside Scene A — cut it from DOWN here, so the paste
+    // destination is genuinely somewhere else.
+    await cutInSelectMode(page, "c1", CHILD_ID);
+
+    // The crumb is a real link inside the select row. Following it changes the
+    // focused collection, which is what gives the paste somewhere to land.
+    const crumb = header.locator("[data-select-mode-breadcrumb] a").first();
+    await expect(crumb).toBeVisible();
+    await crumb.click();
+    await expect.poll(() => page.url().includes(CHILD_ID)).toBe(false);
+
+    // Still one item in flight, on a screen where nothing is selected.
+    await expect(header.locator("[data-select-mode-header]")).toHaveAttribute(
+      "data-select-mode-cut-pending",
+      "",
+    );
+    await expect(page.locator("[data-select-mode-count]")).toHaveText("1 selected");
+    await expect(page.getByRole("button", { name: /^Paste 1 item/ })).toBeVisible();
+  });
+
+  test("Done during a pending cut abandons it and un-dims the sources", async ({ page }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    const before = await stripOrder(page, PROJECT_ID);
+
+    await cutInSelectMode(page, "charlie");
+    await page.locator("[data-select-mode-done]").click();
+
+    // Un-dimmed, still where they were, and the clipboard is empty — leaving
+    // without pasting is the user saying the move is off. The `✕` that cancels
+    // a cut lives only in the BROWSE header, so before this the items stayed
+    // dimmed with no control on screen to release them.
+    await expect(page.locator('[data-card-pending-cut="true"]')).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /^Paste/ })).toHaveCount(0);
+    await expect.poll(() => stripOrder(page, PROJECT_ID)).toEqual(before);
+  });
+
+  test("the header keeps the browse row's height with a cut pending", async ({ page }) => {
+    // The breadcrumb is a taller-looking thing than a run of text verbs, and
+    // the row is sized by its tallest child. Anything that changes this moves
+    // the preview and the trim frame, both of which measure this element.
+    await installGraphApi(page);
+    await openGraph(page);
+    const header = page.locator("[data-graph-board-header]");
+    const height = () =>
+      header.evaluate((element) => Math.round(element.getBoundingClientRect().height));
+
+    const browseHeight = await height();
+    await cutInSelectMode(page, "charlie");
+    await expect(header.locator("[data-select-mode-header]")).toHaveAttribute(
+      "data-select-mode-cut-pending",
+      "",
+    );
+    expect(await height()).toBe(browseHeight);
+  });
+
   test("the header row sits ABOVE the preview, in browse and in select mode", async ({
     page,
   }) => {


### PR DESCRIPTION
Three fixes from tonight's session, each independently green.

## 1. A pending cut gets the breadcrumb

Cutting calls `store.clearSelection()`, so all five select-row verbs dim on
`!hasSelection` and the count reads "0 selected". That is five dead words at
exactly the moment the user needs to navigate — and select mode had already
replaced the breadcrumb with those verbs.

- While a cut is pending, the verb run is **replaced** by the breadcrumb (not
  dimmed — they are all unavailable for the same reason, and the row still has
  to get you somewhere).
- The count reports the number **in flight**, via a new `usePendingCutCount`.
- **Done now abandons the cut**: un-dims the sources, empties the clipboard.
  Previously the `✕` that cancels a cut rendered only in the *browse* header,
  so a cut armed in select mode could not be abandoned without leaving the mode
  — the sources just stayed dimmed with no control on screen.
- The verb run became its own component so the swap is not a conditional hook.

## 2. The app can remove a collection's last clip

`saveFirebaseTimelineDocumentsAtomic` refuses an empty-over-non-empty write
without `allowEmptying`. #278 wired that escape through the MCP path and the
trash route, but the app's own writes go gateway → `POST /api/timelines/batch`,
which built each write from `document` and `expectedRevision` only. The flag was
never on the wire, so the UI could not do it at all.

Gated on `expectedRevision`, not set for every empty write: a CAS-protected
write is an edit, a blind one is the accident the guard is for.

Note for the tracker: **#305 looks stale** — it describes the MCP surface and
was filed three days *after* #278 merged the fix for it. Worth verifying against
`remove_clip` and closing; this PR is the app-side path, which was genuinely
unfixed.

## 3. Video thumbnails open on the first frame

`videoFrameUrls` samples every slot at its centre. Correct for a filmstrip,
wrong for a lone slot — a single frame is a thumbnail for the whole clip, and
`(0 + 0.5)/1` put it at the midpoint. Single slots now sample the start, nudged
0.05s off an untrimmed encode's zero (black-frame territory, ~1 frame at 24fps).
Trimmed in-points are taken exactly. Multi-slot strips unchanged.

## Verification

- `npx vitest run` — 722 passed
- `npx playwright test --project=graph-view` — 163 passed, including 4 new cases
  (verb run swapped for the breadcrumb, navigating mid-cut, Done abandoning a
  cut, and header height unchanged with a cut pending)
- `npx tsc --noEmit` clean, `npm run lint` 0 errors

The four new batch-route tests were confirmed to **fail without the fix** before
being trusted; two of them were vacuous on the first pass (the mock had no
`FieldValue.delete`, and one asserted a snapshot was absent when none had ever
been written) and were rewritten to discriminate.

## Not included

The **"a cut must never orphan anything"** invariant. Two collections were lost
to this tonight and recovered by hand — the deeper defect is that they left
their parent *without landing in the trash*, so a confirmation toast would not
have caught it. That needs its own investigation and plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)