### PR TITLE
Destination mode: navigate to where you're pasting

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -74,6 +74,7 @@ import { Slider } from "@/components/core/slider";
 
 import {
   useClipboardCount,
+  useIsPickingDestination,
   useHasPendingCut,
   usePendingCutCount,
   useSelectionActionState,
@@ -1114,17 +1115,25 @@ function SelectModeHeader({
   const state = useSelectionActionState();
   const { selectionCount } = state;
 
-  // A cut CLEARS the selection (see `cutSelection`), so from here on
-  // `selectionCount` is 0 and every verb is dimmed by `!hasSelection`. Rather
-  // than draw five dead words, the row hands the space to the breadcrumb: the
-  // one thing a half-finished cut actually needs is a way to reach the
-  // collection it is going to be pasted into.
-  const cutCount = usePendingCutCount();
-  const cutPending = cutCount > 0;
+  // ARMED = the clipboard holds something, by Copy or by Cut. One state, one
+  // job: choose where it lands.
+  //
+  // Keyed on the clipboard rather than on the pending cut, because a copy needs
+  // the destination just as much — and on the COUNT rather than the selection,
+  // because a cut clears the selection outright and a copy loses it as soon as
+  // the user clicks into a collection to navigate. The clipboard is the only
+  // thing that still knows how many items are in flight.
+  const armedCount = useClipboardCount();
+  const armed = useIsPickingDestination() && armedCount > 0;
+  // Kept only to distinguish a cut from a copy for the tests and for anyone
+  // reading the DOM: the row itself treats the two identically, because from
+  // here on they want exactly the same things.
+  const cutPending = usePendingCutCount() > 0;
 
   return (
     <div
       data-select-mode-header=""
+      data-select-mode-armed={armed ? "" : undefined}
       data-select-mode-cut-pending={cutPending ? "" : undefined}
       // NOT `flex-wrap` any more. Wrapping was how this row coped with running
       // out of width, and it coped by growing taller — which is exactly what
@@ -1133,7 +1142,7 @@ function SelectModeHeader({
       className="flex min-w-0 flex-1 items-center gap-x-5"
     >
       <span
-        data-select-mode-count={cutPending ? cutCount : selectionCount}
+        data-select-mode-count={armed ? armedCount : selectionCount}
         // Mono and tabular so the row does not twitch sideways as the count
         // crosses 9 — this number changes on every tap, which is precisely the
         // moment a reflowing toolbar is most annoying.
@@ -1145,7 +1154,7 @@ function SelectModeHeader({
         // that read as a third accent rather than the selection colour.
         className="shrink-0 font-mono text-[13px] tabular-nums text-blue-500"
       >
-        {cutPending ? cutCount : selectionCount} selected
+        {armed ? armedCount : selectionCount} selected
       </span>
       {/* THE SWAP. Dimmed verbs are worse than absent ones here: after a cut
           all five are unavailable for the same reason, and the row still has
@@ -1155,9 +1164,10 @@ function SelectModeHeader({
           Its crumbs are also the up-a-level DROP targets, which is the other
           half of "where am I pasting this": the same row now answers it by
           click and by drag. */}
-      {cutPending ? (
+      {armed ? (
         <div
           data-select-mode-breadcrumb=""
+          data-crumb-wing
           className="flex min-w-0 flex-1 items-center overflow-hidden"
         >
           {breadcrumb}
@@ -1177,7 +1187,13 @@ function SelectModeHeader({
         variant="ghost"
         size="sm"
         data-select-mode-done
-        title={cutPending ? "Finish selecting and cancel the cut" : "Finish selecting"}
+        title={
+          armed
+            ? cutPending
+              ? "Cancel the cut and leave the items where they are"
+              : "Cancel — discard what was copied"
+            : "Finish selecting"
+        }
         // Clear THEN disarm. The store keeps the mode armed through an empty
         // selection for this view (keepMultiSelectModeWhenEmpty), so the clear
         // cannot disarm it out from under this and the order is only about
@@ -1210,7 +1226,11 @@ function SelectModeHeader({
           "text-zinc-100 hover:border-zinc-500 hover:bg-transparent hover:text-white",
         )}
       >
-        Done
+        {/* CANCEL while armed. The button does the same thing either way —
+            clear the clipboard, drop the selection, leave the mode — but the
+            word has to match what the user is walking away from. "Done" over a
+            half-finished paste reads as "commit it", which is the opposite. */}
+        {armed ? "Cancel" : "Done"}
       </Button>
       {/* History lives on the RIGHT of Done, fenced off by its own rule.
           Undo/redo are not selection verbs — they act on the board whatever is
@@ -1457,9 +1477,18 @@ export function GraphBoard({
   // things, and a mode that shows no sign of itself until the first item lands
   // reads as a button that did nothing. The row at zero is not empty either —
   // it says "0 selected" and offers Done, which is the way back out.
+  // A THIRD condition now: an armed clipboard keeps the row up on its own.
+  //
+  // Copy and Cut both leave multi-select, so the board can be navigated to a
+  // destination — checkboxes off, a click opens a collection again. That would
+  // have taken this row down with it, and the row is exactly what the user
+  // still needs: the count, the breadcrumb, Paste, and the way to cancel. So
+  // the row outlives the flag, and the two halves of the gesture are split —
+  // the flag governs the CARDS, the clipboard governs the HEADER.
   const multiSelectMode = useCollectionsSelector((s) => s.interaction.multiSelectMode);
   const isDragging = useCollectionsSelector((s) => s.interaction.isDragging);
-  const selectModeRow = multiSelectMode && !isDragging;
+  const pickingDestination = useIsPickingDestination();
+  const selectModeRow = (multiSelectMode || pickingDestination) && !isDragging;
 
   return (
     <OpenKeyBoundary trashId={trashRootId}>
@@ -1550,7 +1579,10 @@ export function GraphBoard({
               <SelectModeHeader anchorName={anchorName} breadcrumb={breadcrumb} />
             ) : (
               <>
-            <div className="flex min-w-0 flex-1 items-center gap-3">
+            {/* `data-crumb-wing`: the box whose width the trail measures
+                itself against. The trail is content-width on purpose, so it
+                cannot read its own budget — see useFittedAncestorCount. */}
+            <div data-crumb-wing className="flex min-w-0 flex-1 items-center gap-3">
               {breadcrumb}
               <GraphSaveStatus />
             </div>

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
@@ -572,6 +572,25 @@ export function GraphItemActionsBridge({
       // source is gone by paste time — see `pasteFromClipboard`.
       graphClipboard.markPendingCut(selected);
       store.clearSelection();
+      handOverToDestinationPicking();
+    };
+
+    /**
+     * Hand the board back for NAVIGATION once something is on the clipboard.
+     *
+     * With multi-select armed a plain click toggles selection
+     * (`handleSelectionSurfaceClick`), so a collection cannot be opened — and
+     * the destination is usually somewhere else in the tree. Leaving the mode
+     * restores click-to-open and takes the checkboxes off the cards.
+     *
+     * Only meaningful FROM select mode: the flag it records is what keeps the
+     * selection row on screen afterwards, and a copy made while ordinary
+     * browsing must leave the browse toolbar exactly where it is.
+     */
+    const handOverToDestinationPicking = () => {
+      if (!store.getSnapshot().interaction.multiSelectMode) return;
+      graphClipboard.markPickingDestination();
+      store.setMultiSelectMode(false);
     };
 
     const pasteSelection = () => {
@@ -602,6 +621,12 @@ export function GraphItemActionsBridge({
               toast(`Copied ${selected.length} item${selected.length === 1 ? "" : "s"}.`, {
                 id: "graph-item-copy",
               });
+              // Same reason as Cut: the next thing this gesture needs is a
+              // DESTINATION, and with multi-select armed a click cannot open a
+              // collection to reach one. The selection is deliberately kept —
+              // unlike Cut, nothing about a copy makes the source stale, and
+              // the ring is what says which items are on the clipboard.
+              handOverToDestinationPicking();
             }
           });
           break;

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -1718,6 +1718,32 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
             armed={selectMode}
             revealOnHover={SELECT_HOVER_REVEAL_COLLECTION}
           />
+          {/* THE COLLECTION MARK, dead centre over the frames.
+              A collection's frames are its children's pictures, so at a glance
+              the card looks like the media inside it — the dashed border and
+              the caption glyph both say "collection" at the EDGES, where the
+              eye is not. This says it over the picture itself.
+
+              Half-opacity on purpose: it has to be legible without hiding the
+              frame it sits on, since the frame is how you recognise WHICH
+              collection this is. `pointer-events-none` keeps the card's own
+              click, drag and checkbox untouched, and it is `aria-hidden`
+              because the surface's label already announces "collection".
+
+              Only over real frames — the empty state below draws its own
+              placeholder, and two glyphs stacked would just read as a bug. */}
+          {previews.length > 0 ? (
+            <span
+              data-collection-mark
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-0 z-10 grid place-items-center"
+            >
+              <Layers
+                className="h-10 w-10 text-white opacity-50 drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)]"
+                strokeWidth={1.5}
+              />
+            </span>
+          ) : null}
           {previews.length === 0 ? (
             <span
               data-empty-collection-preview

--- a/apps/timeline-gstudio001/components/graph-view/graph-selection-actions.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-selection-actions.tsx
@@ -87,6 +87,21 @@ export function usePendingCutCount(): number {
 }
 
 /**
+ * Whether the row should stay in its SELECT face while a destination is chosen.
+ *
+ * Copy and Cut leave multi-select so the board can be navigated, which would
+ * otherwise take this row down with them. True only when the gesture began in
+ * select mode — see `isPickingDestination`.
+ */
+export function useIsPickingDestination(): boolean {
+  return useSyncExternalStore(
+    graphClipboard.subscribe,
+    () => graphClipboard.isPickingDestination(),
+    () => false,
+  );
+}
+
+/**
  * The anchor: the card hosting the pill, and the card a paste follows.
  *
  * A plain store read now. It used to be derived here from `selectedIds` with a

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
@@ -2,7 +2,14 @@
 
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
-import { useContext, useSyncExternalStore } from "react";
+import {
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type RefObject,
+} from "react";
 import { useDroppable } from "@dnd-kit/core";
 
 import {
@@ -179,13 +186,124 @@ function AncestorCrumb({
   );
 }
 
-/** How many ancestors the trail shows before it starts folding, and how many
- *  it keeps visible when it does. Counting rather than measuring: a
- *  width-driven collapse has to observe the header, re-measure on every rename
- *  and resize, and still picks a threshold — this picks one honestly, and the
- *  crumbs it does show already truncate at 180px each. */
-const MAX_VISIBLE_ANCESTORS = 2;
-const VISIBLE_TRAILING_ANCESTORS = 1;
+/**
+ * The trail folds on MEASURED WIDTH, not on a fixed count.
+ *
+ * It used to fold past two ancestors whatever the window was doing, on the
+ * reasoning that measuring costs a ResizeObserver and a re-measure per rename.
+ * That reasoning traded the wrong thing away: on a wide screen the row had
+ * hundreds of empty pixels beside a trail that had hidden levels behind a "…"
+ * for no reason. Space that exists should be used.
+ *
+ * Same shape as `useFittedVerbCount` in graph-board — hidden ruler, two passes,
+ * one ResizeObserver — so there is one way this is done in the app, not two.
+ *
+ * Only ANCESTORS fold. The root and the focused crumb render outside the list
+ * and are never eligible; the immediate parent is kept longest, because it is
+ * the one the eye actually uses.
+ */
+const MIN_VISIBLE_ANCESTORS = 1;
+/** `gap-2` between a crumb and its separator, as a number. */
+const CRUMB_GAP_PX = 8;
+
+function useFittedAncestorCount(
+  ancestors: readonly CrumbEntry[],
+): Readonly<{
+  navRef: RefObject<HTMLElement | null>;
+  rulerRef: RefObject<HTMLDivElement | null>;
+  visibleCount: number;
+}> {
+  const navRef = useRef<HTMLElement | null>(null);
+  const rulerRef = useRef<HTMLDivElement | null>(null);
+  const [visibleCount, setVisibleCount] = useState(ancestors.length);
+
+  // The labels, as ONE string: the effect must re-measure when a rename changes
+  // a crumb's width, and the array identity changes on every render.
+  const signature = ancestors.map((ancestor) => ancestor.label).join(" ");
+
+  useEffect(() => {
+    const nav = navRef.current;
+    const ruler = rulerRef.current;
+    if (!nav || !ruler) return;
+
+    const measure = () => {
+      // The budget is the WING's width, not the nav's.
+      //
+      // The trail is deliberately content-width so the save status sits beside
+      // the last crumb rather than an inch away (see the note on the root
+      // below), which means the nav reports the width of its own contents and
+      // can never tell you there is room to grow. So: take the wing, subtract
+      // everything in it that is not the trail, and what is left is what the
+      // trail may use. Falls back to the nav's own width if the wing marker is
+      // missing, which folds exactly as it did before rather than crashing.
+      const wing = nav.closest("[data-crumb-wing]");
+      let budget = nav.clientWidth;
+      if (wing instanceof HTMLElement) {
+        let taken = 0;
+        for (const child of Array.from(wing.children)) {
+          if (!(child instanceof HTMLElement)) continue;
+          // The trail's own root counts only for the parts that are NOT the
+          // nav — the back arrow and the gap beside it.
+          taken += child.contains(nav)
+            ? child.offsetWidth - nav.offsetWidth
+            : child.offsetWidth;
+        }
+        budget = wing.clientWidth - taken;
+      }
+      // 0 while the row is not laid out (the other header face is showing) —
+      // keep the last answer rather than folding everything for one frame.
+      if (budget <= 0) return;
+      const children = Array.from(ruler.children).map((child) =>
+        Math.ceil((child as HTMLElement).getBoundingClientRect().width),
+      );
+      // Ruler order: [...ancestors+separators, "…"]. It holds ONLY the crumbs
+      // that can be hidden.
+      //
+      // The root and focused crumbs are measured from the REAL elements
+      // instead, because they are always on screen — and because duplicating
+      // their text into a hidden box makes `getByText(...).first()` resolve to
+      // the invisible copy, which is exactly how this broke an unrelated
+      // drill-in test. Never put text in the ruler that something else queries.
+      const overflowWidth = children[children.length - 1] ?? 0;
+      const ancestorWidths = children.slice(0, ancestors.length);
+      const fixed = Array.from(nav.querySelectorAll("[data-crumb-fixed]")).reduce(
+        (total, element) => total + Math.ceil(element.getBoundingClientRect().width),
+        0,
+      );
+
+      // PASS 1 — everything, with no "…" drawn at all. Asked first and against
+      // the FULL budget: when the trail fits there is no overflow control to
+      // reserve room for, and reserving it anyway is what folds a crumb purely
+      // to make space for the menu holding the crumb it just folded.
+      const whole = ancestorWidths.reduce((total, width) => total + width + CRUMB_GAP_PX, fixed);
+      if (whole <= budget) {
+        setVisibleCount(ancestors.length);
+        return;
+      }
+
+      // PASS 2 — it does not fit, so the "…" is going to be drawn and costs
+      // width like anything else. Keep the LAST ancestors (nearest the focused
+      // crumb) and fold the earliest, which is the direction the eye reads.
+      const reduced = budget - overflowWidth - CRUMB_GAP_PX - fixed;
+      let used = 0;
+      let fitted = 0;
+      for (let index = ancestorWidths.length - 1; index >= 0; index -= 1) {
+        const next = used + (ancestorWidths[index] ?? 0) + CRUMB_GAP_PX;
+        if (next > reduced) break;
+        used = next;
+        fitted += 1;
+      }
+      setVisibleCount(Math.max(MIN_VISIBLE_ANCESTORS, fitted));
+    };
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(nav);
+    return () => observer.disconnect();
+  }, [signature, ancestors.length]);
+
+  return { navRef, rulerRef, visibleCount };
+}
 
 type CrumbEntry = Readonly<{ id: string; href: string; label: string }>;
 
@@ -295,17 +413,13 @@ export function GraphBreadcrumb({
       .join("/")}`,
     label: documents[segment]?.title ?? segment,
   }));
-  // Deep paths crowd the header out. Past the threshold the EARLIEST ancestors
-  // fold into one "…" — the immediate parent stays put, because that is the
-  // one the eye actually uses, and the root and focused crumbs are never
-  // eligible (they are rendered outside this list).
-  const collapse = ancestors.length > MAX_VISIBLE_ANCESTORS;
-  const collapsedAncestors = collapse
-    ? ancestors.slice(0, ancestors.length - VISIBLE_TRAILING_ANCESTORS)
-    : [];
-  const visibleAncestors = collapse
-    ? ancestors.slice(ancestors.length - VISIBLE_TRAILING_ANCESTORS)
-    : ancestors;
+  // Deep paths crowd the header out — but only when they actually run out of
+  // room. What does not fit folds into one "…", earliest first, and everything
+  // that does fit is drawn.
+  const { navRef, rulerRef, visibleCount } = useFittedAncestorCount(ancestors);
+  const shown = Math.min(visibleCount, ancestors.length);
+  const collapsedAncestors = ancestors.slice(0, ancestors.length - shown);
+  const visibleAncestors = ancestors.slice(ancestors.length - shown);
   const parentHref =
     timelinePath.length > 1
       ? `${base}/${timelinePath.slice(0, -1).map(encodeURIComponent).join("/")}`
@@ -341,22 +455,50 @@ export function GraphBreadcrumb({
         title={focusedId === projectId ? "Go to Projects" : "Go to parent timeline"}
       />
       <nav
+        ref={navRef}
         aria-label="Timeline focus path"
-        className="flex min-w-0 items-center gap-2 overflow-hidden text-xs text-zinc-400 select-none"
+        // Still CONTENT-WIDTH, deliberately — see the root's note. `relative`
+        // is new, so the measuring ruler below positions against this box
+        // instead of some ancestor.
+        className="relative flex min-w-0 items-center gap-2 overflow-hidden text-xs text-zinc-400 select-none"
       >
+        {/* THE RULER — every crumb at its natural width, laid out but not
+            painted, in the order the measure reads them:
+            [root+separator, ...ancestors+separators, focused, "…"].
+            `visibility: hidden` rather than `display: none`, because a
+            display-none box measures as zero; `absolute` so it cannot widen the
+            box being measured; `inert` so a duplicate trail is not a second set
+            of tab stops for a keyboard or a screen reader. */}
+        <div
+          ref={rulerRef}
+          aria-hidden="true"
+          inert
+          data-crumb-ruler=""
+          className="pointer-events-none invisible absolute left-0 top-0 flex items-center gap-2"
+        >
+          {ancestors.map((ancestor) => (
+            <span key={ancestor.id} className="flex shrink-0 items-center gap-2">
+              <span className="max-w-[180px] truncate">{ancestor.label}</span>
+              <span>/</span>
+            </span>
+          ))}
+          <span className="shrink-0" data-crumb-overflow-ruler>
+            &hellip;
+          </span>
+        </div>
         {/* The project is the ROOT crumb, not a child of a "Projects / Graph"
             chrome path: the trail reads as the timeline tree the user is
             standing in. At the root the project IS the focused crumb, so it
             renders once, as the current one. */}
         {focusedId !== projectId && (
-          <>
+          <span data-crumb-fixed className="flex shrink-0 items-center gap-2">
             <AncestorCrumb
               crumbId={projectId}
               href={base}
               label={documents[projectId]?.title ?? projectId}
             />
-            <span aria-hidden="true" className="shrink-0">/</span>
-          </>
+            <span aria-hidden="true">/</span>
+          </span>
         )}
         {collapsedAncestors.length > 0 && (
           <span className="flex shrink-0 items-center gap-2">
@@ -370,7 +512,9 @@ export function GraphBreadcrumb({
             <span aria-hidden="true" className="shrink-0">/</span>
           </span>
         ))}
-        <EditableCrumbName crumbId={focusedId} label={focusedTitle} />
+        <span data-crumb-fixed className="flex min-w-0 items-center">
+          <EditableCrumbName crumbId={focusedId} label={focusedTitle} />
+        </span>
       </nav>
     </div>
   );

--- a/apps/timeline-gstudio001/lib/graph-clipboard.ts
+++ b/apps/timeline-gstudio001/lib/graph-clipboard.ts
@@ -46,6 +46,21 @@ export type GraphClipboard = Readonly<{
    *  since a fresh copy replaces whatever the clipboard was doing. */
   markPendingCut: (ids: Iterable<NodeId>) => void;
   /**
+   * Whether the copy/cut that armed this clipboard came from SELECT MODE.
+   *
+   * Copy and Cut both leave select mode, so the board can be navigated to a
+   * destination. The header row has to survive that — it carries the count, the
+   * breadcrumb, Paste and Cancel — but only when the gesture started there: a
+   * copy from ordinary browsing must leave the browse toolbar alone rather than
+   * replacing it with a selection row the user never asked for.
+   *
+   * Lives here because its lifetime is the clipboard's exactly: armed with the
+   * payload, gone the moment the payload is pasted, replaced or cancelled.
+   */
+  isPickingDestination: () => boolean;
+  /** Same contract as `markPendingCut` — call AFTER `set`, which resets it. */
+  markPickingDestination: () => void;
+  /**
    * Install new contents. Pass the `generation()` observed BEFORE any async
    * capture work: if the clipboard was rebound to a different user (or
    * otherwise reset) while the capture ran, the stale write is refused and
@@ -74,6 +89,7 @@ const NO_PENDING_CUT: ReadonlySet<NodeId> = new Set();
 function createGraphClipboard(): GraphClipboard {
   let entries: readonly ClipboardEntry[] = [];
   let pendingCut: ReadonlySet<NodeId> = NO_PENDING_CUT;
+  let pickingDestination = false;
   let boundUid: string | null = null;
   let generation = 0;
   const listeners = new Set<() => void>();
@@ -84,6 +100,12 @@ function createGraphClipboard(): GraphClipboard {
     read: () => entries,
     pendingCutIds: () => pendingCut,
     isPendingCut: (id) => pendingCut.has(id),
+    isPickingDestination: () => pickingDestination,
+    markPickingDestination: () => {
+      if (pickingDestination) return;
+      pickingDestination = true;
+      emit();
+    },
     markPendingCut: (ids) => {
       pendingCut = new Set(ids);
       emit();
@@ -95,24 +117,27 @@ function createGraphClipboard(): GraphClipboard {
       // clipboard was doing, so nothing stays dimmed waiting for a paste that
       // will never carry it.
       pendingCut = NO_PENDING_CUT;
+      pickingDestination = false;
       emit();
       return true;
     },
     clear: () => {
-      if (entries.length === 0 && pendingCut.size === 0) return;
+      if (entries.length === 0 && pendingCut.size === 0 && !pickingDestination) return;
       entries = [];
       pendingCut = NO_PENDING_CUT;
+      pickingDestination = false;
       emit();
     },
     isEmpty: () => entries.length === 0,
     generation: () => generation,
     bindUser: (uid) => {
       if (boundUid === uid) return;
-      const hadState = entries.length > 0 || pendingCut.size > 0;
+      const hadState = entries.length > 0 || pendingCut.size > 0 || pickingDestination;
       boundUid = uid;
       generation += 1;
       entries = [];
       pendingCut = NO_PENDING_CUT;
+      pickingDestination = false;
       if (hadState) emit();
     },
     subscribe: (listener) => {

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -3932,25 +3932,36 @@ test.describe("graph view E2E", () => {
     const trail = page.getByRole("navigation", { name: "Timeline focus path" });
     const overflow = trail.locator("[data-graph-crumb-overflow]");
 
-    // Three ancestors (d1, d2, d3) is past the threshold: the first two fold.
-    await expect(overflow).toBeVisible();
-    await expect(overflow).toHaveAttribute("aria-label", /2 hidden timelines/i);
-    await expect(trail.getByRole("link", { name: TITLES[0] })).toHaveCount(0);
-    await expect(trail.getByRole("link", { name: TITLES[1] })).toHaveCount(0);
-    // Kept: the root crumb, the immediate parent, and the focused crumb.
+    // WIDE: nothing folds. The fold used to be a fixed count — three ancestors
+    // collapsed two of them whatever the window was doing — so a wide screen
+    // hid levels behind a "…" with hundreds of empty pixels beside it. Space
+    // that exists gets used.
+    await page.setViewportSize({ width: 1600, height: 900 });
+    await expect.poll(() => overflow.count()).toBe(0);
+    for (const title of TITLES.slice(0, 3)) {
+      await expect(trail.getByRole("link", { name: title })).toBeVisible();
+    }
     await expect(trail.getByRole("link", { name: "E2E Project" })).toBeVisible();
-    await expect(trail.getByRole("link", { name: TITLES[2] })).toBeVisible();
     await expect(trail).toContainText(TITLES[3]);
 
-    // The folded levels are reachable: open the menu and navigate to one.
+    // NARROW: now it must fold, earliest first, and what folds stays reachable.
+    await page.setViewportSize({ width: 720, height: 900 });
+    await expect(overflow).toBeVisible();
+    // The immediate parent and the focused crumb survive — the parent is the
+    // one the eye uses, and the focused crumb is where you are.
+    await expect(trail.getByRole("link", { name: TITLES[2] })).toBeVisible();
+    await expect(trail).toContainText(TITLES[3]);
+    await expect(trail.getByRole("link", { name: TITLES[0] })).toHaveCount(0);
+
+    // Reachable: open the menu and navigate to a folded level.
     await overflow.click();
     const hidden = page.getByRole("menuitem", { name: TITLES[1] });
     await expect(hidden).toBeVisible();
     await hidden.click();
     await page.waitForURL(`**${GRAPH_URL}/${DEPTH_IDS[0]}/${DEPTH_IDS[1]}`);
 
-    // Two ancestors left — under the threshold, so nothing folds now.
-    await expect(trail.locator("[data-graph-crumb-overflow]")).toHaveCount(0);
+    // One ancestor left — it fits even at this width, so the "…" withdraws.
+    await expect.poll(() => overflow.count()).toBe(0);
     await expect(trail.getByRole("link", { name: TITLES[0] })).toBeVisible();
   });
 
@@ -6945,6 +6956,117 @@ test.describe("graph view E2E", () => {
       "",
     );
     expect(await height()).toBe(browseHeight);
+  });
+
+  // ── DESTINATION MODE ──────────────────────────────────────────────────────
+  //
+  // Copy and Cut both end with the same question — WHERE does this land? — and
+  // select mode is the wrong shape for answering it: a plain click toggles
+  // selection, so a collection cannot be opened to reach the place you mean.
+  // Both verbs now hand the board back for navigation and keep only the header.
+
+  test("a copy drops the checkboxes and shows the breadcrumb, with Cancel as the way out", async ({
+    page,
+  }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+    const header = page.locator("[data-graph-board-header]");
+    const surface = strip(page, PROJECT_ID);
+
+    await selectCard(surface.locator('[data-node-id="alpha"]'));
+    await toggleMultiSelect(page);
+    // Armed: every card is showing its checkbox pinned on.
+    await expect
+      .poll(() =>
+        surface.locator('[data-selection-indicator-reveal="armed"]').count(),
+      )
+      .toBeGreaterThan(0);
+
+    await selectionAction(page, /^Copy$/);
+
+    // The checkboxes go — the mode is over as far as the CARDS are concerned.
+    await expect
+      .poll(() => surface.locator('[data-selection-indicator-reveal="armed"]').count())
+      .toBe(0);
+    // The row does not: it still carries the count, the trail and the way out.
+    await expect(header).toHaveAttribute("data-header-mode", "select");
+    await expect(header.locator("[data-select-mode-breadcrumb]")).toBeVisible();
+    await expect(header.locator("[data-select-mode-verbs]")).toHaveCount(0);
+    await expect(page.locator("[data-select-mode-done]")).toHaveText("Cancel");
+    await expect(page.getByRole("button", { name: /^Paste 1 item/ })).toBeVisible();
+  });
+
+  test("after a copy a plain click DRILLS IN, which is the whole point", async ({ page }) => {
+    // The case that was impossible before: in select mode a click toggles
+    // selection, so there was no way to reach a destination inside a
+    // collection without leaving the gesture behind.
+    await installGraphApi(page);
+    await openGraph(page);
+
+    await selectCard(strip(page, PROJECT_ID).locator('[data-node-id="alpha"]'));
+    await toggleMultiSelect(page);
+    await selectionAction(page, /^Copy$/);
+
+    await drillButton(page, "Scene A").click();
+    await expect.poll(() => page.url().includes(CHILD_ID)).toBe(true);
+    // Still armed on the other side of the navigation.
+    await expect(page.getByRole("button", { name: /^Paste 1 item/ })).toBeVisible();
+  });
+
+  test("cut, navigate into a collection, paste — the items land there", async ({ page }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+
+    await selectCard(strip(page, PROJECT_ID).locator('[data-node-id="charlie"]'));
+    await toggleMultiSelect(page);
+    await selectionAction(page, "Cut");
+    await expect(page.locator('[data-card-pending-cut="true"]')).toHaveCount(1);
+
+    await drillButton(page, "Scene A").click();
+    await expect.poll(() => page.url().includes(CHILD_ID)).toBe(true);
+
+    await page.getByRole("button", { name: /^Paste 1 item/ }).click();
+
+    // Landed in the child, and gone from the project — a MOVE, end to end,
+    // through a destination the user had to navigate to.
+    await expect.poll(() => stripOrder(page, CHILD_ID)).toContain("charlie");
+    await expect.poll(() => stripOrder(page, PROJECT_ID)).not.toContain("charlie");
+    await expect(page.locator('[data-card-pending-cut="true"]')).toHaveCount(0);
+  });
+
+  test("Cancel after a copy discards the clipboard", async ({ page }) => {
+    await installGraphApi(page);
+    await openGraph(page);
+
+    await selectCard(strip(page, PROJECT_ID).locator('[data-node-id="alpha"]'));
+    await toggleMultiSelect(page);
+    await selectionAction(page, /^Copy$/);
+    await expect(page.getByRole("button", { name: /^Paste 1 item/ })).toBeVisible();
+
+    await page.locator("[data-select-mode-done]").click();
+
+    await expect(page.getByRole("button", { name: /^Paste/ })).toHaveCount(0);
+    await expect(page.locator("[data-graph-board-header]")).toHaveAttribute(
+      "data-header-mode",
+      "browse",
+    );
+  });
+
+  test("a copy made OUTSIDE select mode leaves the browse toolbar alone", async ({ page }) => {
+    // The row is kept by the gesture having STARTED in select mode, not merely
+    // by the clipboard being armed — otherwise an ordinary copy would replace
+    // the whole browse toolbar with a selection row nobody asked for.
+    await installGraphApi(page);
+    await openGraph(page);
+
+    await selectCard(strip(page, PROJECT_ID).locator('[data-node-id="alpha"]'));
+    await selectionAction(page, /^Copy$/);
+
+    await expect(page.locator("[data-graph-board-header]")).toHaveAttribute(
+      "data-header-mode",
+      "browse",
+    );
+    await expect(page.locator("[data-header-paste]")).toBeVisible();
   });
 
   test("the header row sits ABOVE the preview, in browse and in select mode", async ({


### PR DESCRIPTION
Everything from tonight's second round. 168 e2e + 722 unit passing.

## 1. Copy/cut hand the board back for navigation

Both verbs end with the same question — *where does this land?* — and select mode
is the wrong shape for answering it. A plain click toggles selection there
(`interaction-policy.ts:185`), so a collection could not be opened to reach the
destination, which is almost always somewhere else in the tree.

Both now leave multi-select: **checkboxes go, click-to-open comes back**, through
the package's own grammar rather than a new store field. The header row does not
go with them — it keys on the clipboard and keeps the count, the breadcrumb,
Paste and the way out.

**The row is kept by a `pickingDestination` flag, not by "the clipboard is
armed".** My first cut used the latter and it over-reached: a copy made while
ordinary browsing replaced the entire browse toolbar with a selection row nobody
asked for, and two existing tests caught it. Only a gesture that *started* in
select mode keeps the row.

Also: the breadcrumb swap now covers **copy** as well as cut, and Done reads
**Cancel** while armed. The button already cleared the clipboard — "Done" over a
half-finished paste just reads as "commit it".

## 2. The breadcrumb uses the space it has

It folded past two ancestors whatever the window was doing, so a wide screen hid
levels behind a "…" with hundreds of empty pixels beside it. Now width-driven,
using the same hidden-ruler/two-pass/ResizeObserver shape as `useFittedVerbCount`
so there is one way this is done in the app.

The budget is the **wing's** width, not the nav's — the trail is deliberately
content-width so the save status sits beside the last crumb, which means it
cannot report its own budget. The wing is marked `data-crumb-wing`.

The ruler holds only the crumbs that can be hidden. Duplicating the root and
focused crumb text into it made `getByText(...).first()` resolve to the
invisible copy and broke an unrelated drill-in test — worth knowing before
anyone adds to that ruler.

## 3. A collection glyph over the thumbnail

A collection's frames are its children's pictures, so at a glance the card looks
like the media inside it. `Layers` at 40px, 50% opacity, centred, over real
frames only.

## Verification

- `npx playwright test --project=graph-view` — **168 passed**, including 5 new
  destination-mode cases and a rewritten deep-breadcrumb test that asserts the
  fold in both directions (nothing at 1600px, folding at 720px).
- `npx vitest run` — 722 passed. `tsc` clean, lint 0 errors.

**Not visually verified:** the collection glyph's size and opacity. The dev
server needs a logged-in Firebase session, which the e2e suite sidesteps by
mocking the API, so I could not eyeball it. Behaviour is covered; the look is a
taste call and trivially adjustable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)