### PR TITLE
Never orphan: refuse the write, don't notice afterwards

### DIFF
--- a/apps/timeline-gstudio001/app/api/timelines/batch/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/batch/route.ts
@@ -5,6 +5,7 @@ import { requireAuthUser } from "@/lib/firebase-auth-session";
 import { readJsonObject } from "@/lib/read-json-body";
 import {
   saveFirebaseTimelineDocumentsAtomic,
+  TimelineOrphanError,
   TimelineRevisionConflictError,
   type TimelineBatchWrite,
 } from "@/lib/firebase-timeline-store";
@@ -132,6 +133,16 @@ export async function POST(request: Request) {
     if (error instanceof TimelineRevisionConflictError) {
       return NextResponse.json(
         { error: error.message, conflicts: error.conflicts },
+        { status: 409 },
+      );
+    }
+    // A write that would strand a collection. 409 like the other refusals the
+    // client already knows how to back off from, and NOT lumped in with the
+    // conflict branch: it carries no `conflicts` array, so the gateway's
+    // conflict handling (reload the named ids) would have nothing to act on.
+    if (error instanceof TimelineOrphanError) {
+      return NextResponse.json(
+        { error: error.message, orphans: error.orphans },
         { status: 409 },
       );
     }

--- a/apps/timeline-gstudio001/app/api/timelines/timelines-batch.test.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/timelines-batch.test.ts
@@ -167,6 +167,45 @@ function batchRequest(
   });
 }
 
+function collectionClip(childTimelineId: string, clipId = childTimelineId): TimelineClip {
+  return {
+    id: clipId,
+    index: 0,
+    kind: "collection",
+    childTimelineId,
+    title: `Timeline ${childTimelineId}`,
+    itemCount: 0,
+    previewItems: [],
+    alt: `${childTimelineId} collection`,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 3,
+    sourceDuration: 3,
+    trimIn: 0,
+    trimOut: 0,
+  } as unknown as TimelineClip;
+}
+
+function seedParentWithChild(parentId: string, childId: string, revision = 1) {
+  const document: TimelineDocument = {
+    id: parentId,
+    title: `Timeline ${parentId}`,
+    clips: [collectionClip(childId)],
+  };
+  state.docs.set(parentId, {
+    id: parentId, title: document.title, document, clips: document.clips,
+    isProject: true, ownerUid: "user-a", revision,
+  });
+  const child: TimelineDocument = { id: childId, title: `Timeline ${childId}`, clips: [clip(`${childId}-c0`)] };
+  state.docs.set(childId, {
+    id: childId, title: child.title, document: child, clips: child.clips,
+    isProject: false, ownerUid: "user-a", revision: 1,
+  });
+}
+
+const emptyDoc = (id: string): TimelineDocument => ({ id, title: `Timeline ${id}`, clips: [] });
+
 function docOf(id: string, clipId: string): TimelineDocument {
   return { id, title: `Timeline ${id}`, clips: [clip(clipId)] };
 }
@@ -367,6 +406,111 @@ describe("timeline batch writes", () => {
     );
     expect(response.status).toBe(400);
     expect(state.docs.get("doc-1")?.revision).toBe(1);
+  });
+
+  // ── THE ORPHAN GUARD ──────────────────────────────────────────────────────
+  //
+  // A collection is reachable only through a clip in some parent. Drop the last
+  // one and the document survives in storage with no path to it: invisible in
+  // the UI, absent from the trash, recoverable only by querying the database.
+
+  it("REFUSES a write that removes a collection nothing else takes up", async () => {
+    seedParentWithChild("parent-1", "child-1");
+
+    const response = await batchWrite(
+      batchRequest([{ document: emptyDoc("parent-1"), expectedRevision: 1, allowEmptying: true }]),
+    );
+
+    expect(response.status).toBe(409);
+    const body = (await response.json()) as { error: string; orphans?: { id: string }[] };
+    expect(body.error).toContain("Refusing to strand");
+    expect(body.orphans?.map((orphan) => orphan.id)).toEqual(["child-1"]);
+    // Nothing committed — the parent still points at it.
+    expect((state.docs.get("parent-1")?.clips as TimelineClip[]).length).toBe(1);
+  });
+
+  it("ALLOWS a move: the destination takes it up in the same batch", async () => {
+    seedParentWithChild("parent-1", "child-1");
+    state.docs.set("parent-2", {
+      id: "parent-2", title: "Timeline parent-2", document: emptyDoc("parent-2"),
+      clips: [], isProject: true, ownerUid: "user-a", revision: 1,
+    });
+
+    const response = await batchWrite(
+      batchRequest([
+        { document: emptyDoc("parent-1"), expectedRevision: 1, allowEmptying: true },
+        {
+          document: { id: "parent-2", title: "Timeline parent-2", clips: [collectionClip("child-1")] },
+          expectedRevision: 1,
+        },
+      ]),
+    );
+
+    expect(response.status).toBe(200);
+    expect((state.docs.get("parent-2")?.clips as TimelineClip[])[0].id).toBe("child-1");
+  });
+
+  it("ALLOWS a delete: the trash is the document taking it up", async () => {
+    seedParentWithChild("parent-1", "child-1");
+    state.docs.set("trash-user-a", {
+      id: "trash-user-a", title: "Trash Bin", document: emptyDoc("trash-user-a"),
+      clips: [], isProject: false, ownerUid: "user-a", revision: 1,
+    });
+
+    const response = await batchWrite(
+      batchRequest([
+        { document: emptyDoc("parent-1"), expectedRevision: 1, allowEmptying: true },
+        {
+          document: { id: "trash-user-a", title: "Trash Bin", clips: [collectionClip("child-1")] },
+          expectedRevision: 1,
+        },
+      ]),
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it("ALLOWS dropping a DUPLICATE REFERENCE — it never owned the child", async () => {
+    // A second card for the same timeline is minted with its own clip id. The
+    // owning placement is elsewhere and untouched, so removing this strands
+    // nothing; counting it would refuse a legitimate edit.
+    const parent: TimelineDocument = {
+      id: "parent-1",
+      title: "Timeline parent-1",
+      clips: [collectionClip("child-1", "clip-duplicate-ref")],
+    };
+    state.docs.set("parent-1", {
+      id: "parent-1", title: parent.title, document: parent, clips: parent.clips,
+      isProject: true, ownerUid: "user-a", revision: 1,
+    });
+    const child: TimelineDocument = { id: "child-1", title: "Timeline child-1", clips: [clip("c0")] };
+    state.docs.set("child-1", {
+      id: "child-1", title: child.title, document: child, clips: child.clips,
+      isProject: false, ownerUid: "user-a", revision: 1,
+    });
+
+    const response = await batchWrite(
+      batchRequest([{ document: emptyDoc("parent-1"), expectedRevision: 1, allowEmptying: true }]),
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it("ALLOWS tidying a DANGLING reference to a child that does not exist", async () => {
+    const parent: TimelineDocument = {
+      id: "parent-1", title: "Timeline parent-1", clips: [collectionClip("ghost-child")],
+    };
+    state.docs.set("parent-1", {
+      id: "parent-1", title: parent.title, document: parent, clips: parent.clips,
+      isProject: true, ownerUid: "user-a", revision: 1,
+    });
+
+    const response = await batchWrite(
+      batchRequest([{ document: emptyDoc("parent-1"), expectedRevision: 1, allowEmptying: true }]),
+    );
+
+    // A repair, not a loss — there was never a document to strand.
+    expect(response.status).toBe(200);
   });
 
   it("rejects a batch that repeats a timeline id", async () => {

--- a/apps/timeline-gstudio001/components/graph-view/graph-remote-changes.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-remote-changes.tsx
@@ -79,7 +79,21 @@ export function RemoteChangesBridge({
 
       const live = store.getSnapshot().graph;
       const parentId = parseNodeId(timelineId);
-      if (!live.nodesById.has(parentId)) return;
+      // REFRESHED BUT NOT ABSORBED — the dangerous half-state.
+      //
+      // `ensure` above has already replaced the cached document AND advanced
+      // the revision ledger. Returning here leaves the graph without the
+      // change, and nothing else notices: a later edit anywhere BELOW this
+      // document still writes it (the affected set walks ancestors), projecting
+      // the stale graph over the fresh cache with a revision that is current,
+      // so CAS passes and the other writer's content is deleted.
+      //
+      // Blocking clip writes for the document is the same posture the conflict
+      // gate takes, and for the same reason — see `markGraphBehind`.
+      if (!live.nodesById.has(parentId)) {
+        graphDocumentsGateway.markGraphBehind(timelineId, "not on this board");
+        return;
+      }
 
       const { added: incoming, departed } = diffRemoteChildren(
         live,
@@ -127,10 +141,23 @@ export function RemoteChangesBridge({
         const ok = applied.ok && store.applyRemotePatch(applied.value.patch);
         // On refusal the details must not be left parked — they would attach
         // themselves to whatever later minted a node with the same id.
-        if (!ok) for (const id of parked) unparkPendingDetail(id);
+        if (!ok) {
+          for (const id of parked) unparkPendingDetail(id);
+          // Refused, so the graph does not have the arrivals the cache does.
+          graphDocumentsGateway.markGraphBehind(timelineId, "remote additions refused");
+          return;
+        }
       }
 
-      if (departed.length === 0 || !settled || cancelled) return;
+      if (departed.length === 0 || cancelled) return;
+      // Departures are deliberately skipped while a local write is pending —
+      // converging under it would delete work in progress. But the cache and
+      // the ledger already moved, so the same half-state applies and the next
+      // ancestor write would resurrect what the other writer removed.
+      if (!settled) {
+        graphDocumentsGateway.markGraphBehind(timelineId, "local edit in flight");
+        return;
+      }
 
       // Built against the graph as it stands NOW — the additions above committed
       // and shifted the indices.

--- a/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
@@ -62,6 +62,34 @@ export type TimelineRevisionConflict = {
 
 /** A batch was rejected because at least one expected revision no longer
  *  matched — NOTHING in the batch was written. */
+export type TimelineOrphan = Readonly<{
+  /** The child that would be left with no path to it. */
+  id: string;
+  /** The parent that let go of it, for the message. */
+  fromTimelineId: string | null;
+}>;
+
+/**
+ * A write was refused because it would strand a collection document.
+ *
+ * Deliberately an error and not a repair. A collection reachable from nowhere
+ * is invisible in the UI, absent from the trash, and recoverable only by
+ * querying the database — so the owner's rule is that the app must never be
+ * able to reach that state, rather than notice afterwards that it has.
+ */
+export class TimelineOrphanError extends Error {
+  readonly orphans: readonly TimelineOrphan[];
+
+  constructor(orphans: readonly TimelineOrphan[]) {
+    super(
+      `Refusing to strand ${orphans.map((orphan) => orphan.id).join(", ")}: ` +
+        `removed from its parent with nothing in this write taking it up.`,
+    );
+    this.name = "TimelineOrphanError";
+    this.orphans = orphans;
+  }
+}
+
 export class TimelineRevisionConflictError extends Error {
   readonly conflicts: readonly TimelineRevisionConflict[];
 
@@ -117,6 +145,24 @@ async function withFirebaseTimeout<T>(operation: Promise<T>, label: string): Pro
 
 function collection() {
   return getFirebaseDb().collection(TIMELINE_COLLECTION);
+}
+
+/**
+ * The children this document OWNS, as opposed to merely points at.
+ *
+ * A collection clip whose `id` equals its `childTimelineId` is the owning
+ * placement — the one whose removal makes the child unreachable. A duplicate
+ * reference card is minted with its own clip id and so is excluded, which is
+ * what keeps the orphan guard from refusing a legitimate edit to one.
+ */
+function owningCollectionChildIds(document: TimelineDocument): string[] {
+  const owned: string[] = [];
+  for (const clip of document.clips) {
+    if (clip.kind !== "collection") continue;
+    if (clip.childTimelineId !== clip.id) continue;
+    owned.push(clip.childTimelineId);
+  }
+  return owned;
 }
 
 function normalizeDocument(document: TimelineDocument): TimelineDocument {
@@ -606,6 +652,11 @@ export async function saveFirebaseTimelineDocumentsAtomic(
         revision: number;
         payload: ReturnType<typeof buildSavePayload>;
       }[] = [];
+      // For the orphan guard below: which children this batch lets go of, and
+      // which it takes up. Gathered in the loop that is already reading both
+      // sides of every document, so the guard costs no extra reads here.
+      const releasedChildren = new Map<string, string>();
+      const claimedChildren = new Set<string>();
 
       for (let index = 0; index < writes.length; index += 1) {
         const normalizedDocument = normalizeDocument(writes[index].document);
@@ -628,6 +679,24 @@ export async function saveFirebaseTimelineDocumentsAtomic(
         const existingDocument = existingData
           ? toTimelineDocument(snapshot.id, existingData)
           : null;
+
+        // OWNING placements only, on both sides.
+        //
+        // A collection clip whose `id` differs from its `childTimelineId` is a
+        // DUPLICATE REFERENCE — a second card pointing at a timeline that lives
+        // somewhere else. Dropping one of those orphans nothing, because the
+        // owning placement is untouched, so counting them here would refuse a
+        // legitimate edit. Multi-parent is legal in this model; that asymmetry
+        // is what makes it safe to reason about from inside one batch.
+        for (const childId of owningCollectionChildIds(normalizedDocument)) {
+          claimedChildren.add(childId);
+        }
+        if (existingDocument) {
+          for (const childId of owningCollectionChildIds(existingDocument)) {
+            releasedChildren.set(childId, normalizedDocument.id);
+          }
+        }
+
         if (
           !writes[index].allowEmptying &&
           existingDocument &&
@@ -659,6 +728,43 @@ export async function saveFirebaseTimelineDocumentsAtomic(
       }
 
       if (conflicts.length > 0) throw new TimelineRevisionConflictError(conflicts);
+
+      // THE ORPHAN GUARD.
+      //
+      // A collection document is reachable only through a clip in some parent.
+      // Drop the last such clip and the document survives in storage with no
+      // path to it: invisible in the UI, absent from the trash, unrecoverable
+      // without a database query. There is no reverse index to consult, so
+      // this asks the one question that IS answerable from inside the batch —
+      // did anything take up what this batch put down?
+      //
+      // A legitimate operation always answers yes, by construction. A move
+      // writes source and destination together; a delete is a move into the
+      // trash bin, which is itself one of the written documents. What fails is
+      // half a change: the source write arriving alone, which is precisely the
+      // shape the client's own error paths used to manufacture.
+      const orphaned = [...releasedChildren.keys()].filter((id) => !claimedChildren.has(id));
+      if (orphaned.length > 0) {
+        // Reads, and they must all happen before the first `tx.set` below.
+        // Bounded by the batch size, and normally zero — a batch that removes
+        // nothing never gets here.
+        const orphanSnapshots = await Promise.all(
+          orphaned.map((id) => tx.get(collection().doc(id))),
+        );
+        // Already gone, or never existed: a dangling reference being tidied up,
+        // which is a repair rather than a loss.
+        //
+        // Nothing else to check. An OWNING placement is unique — a second card
+        // for the same timeline is minted with its own clip id and so is not
+        // owning — which is exactly what makes "released and unclaimed" mean
+        // "unreachable" without a reverse index to consult.
+        const stranded = orphaned.filter((_id, index) => orphanSnapshots[index].exists);
+        if (stranded.length > 0) {
+          throw new TimelineOrphanError(
+            stranded.map((id) => ({ id, fromTimelineId: releasedChildren.get(id) ?? null })),
+          );
+        }
+      }
 
       for (const entry of staged) tx.set(entry.ref, entry.payload, { merge: true });
       return staged.map(({ id, revision }) => ({ id, revision }));

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
@@ -461,7 +461,55 @@ describe("graph-documents-gateway", () => {
     expect(clipIds(refetched)).toEqual(["v2"]);
   });
 
-  it("a revision conflict reloads the conflicted document, surfaces it, and re-queues the rest", async () => {
+  // The OTHER way the cache gets ahead of the graph — and the one that actually
+  // cost two collections. No conflict, no error, nothing rejected: the poller
+  // refreshes a document, declines to apply the difference to the graph, and
+  // the revision ledger moves anyway. The next projection of the stale graph
+  // then passes CAS with a perfectly current revision.
+  it("a refreshed-but-unabsorbed document blocks clip writes, CAS or no CAS", async () => {
+    const calls = installFetch((call) =>
+      call.method === "GET"
+        ? jsonResponse({ document: doc(call.id, [clip("a-seed")]), revision: 1 })
+        : okResults(call.writes),
+    );
+    const gateway = createGraphDocumentsGateway();
+    await gateway.ensure("a");
+
+    // Normal edit: goes out, carrying the revision it read.
+    gateway.writeClips("a", [clip("a2")]);
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+    expect(batchesOf(calls)).toHaveLength(1);
+    expect(batchesOf(calls)[0].writes?.[0].expectedRevision).toBe(1);
+
+    // Now the poller refreshes it and declines to apply — the state that used
+    // to be invisible. Without this marker the write below goes out with a
+    // CURRENT revision and a STALE clip list, which is the whole bug: the
+    // server accepts it and the other writer's content is gone.
+    gateway.markGraphBehind("a", "not on this board");
+    expect(gateway.isConflicted("a")).toBe(true);
+
+    gateway.writeClips("a", [clip("a3")]);
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+    expect(batchesOf(calls)).toHaveLength(1); // refused, no second batch
+    expect(gateway.lastError()).toContain("could not merge it");
+
+    // Reopening the view rebuilds the graph from fresh documents, which is the
+    // reconciliation the block was waiting for — the same lifting point a
+    // conflict uses.
+    gateway.refresh();
+    expect(gateway.isConflicted("a")).toBe(false);
+  });
+
+  it("markGraphBehind is inert for a document the cache has never seen", async () => {
+    installFetch(() => okResults([]));
+    const gateway = createGraphDocumentsGateway();
+    // Nothing to protect and nothing to name in a message — marking an unknown
+    // id would block a document that might legitimately arrive later.
+    gateway.markGraphBehind("never-loaded", "not on this board");
+    expect(gateway.isConflicted("never-loaded")).toBe(false);
+  });
+
+  it("a revision conflict reloads the conflicted document and DROPS THE WHOLE BATCH", async () => {
     let conflictOnce = true;
     const serverA = doc("a", [clip("a-server")]);
     const calls = installFetch((call) => {
@@ -496,11 +544,24 @@ describe("graph-documents-gateway", () => {
     expect(clipIds(gateway.peek("a"))).toEqual(["a-server"]);
     expect(gateway.lastError()).toContain('"Timeline a" changed in another view');
 
-    // The unconflicted write re-queued and goes out on its own.
+    // The UNCONFLICTED write is dropped too, and this expectation is a
+    // reversal: it used to assert that "b" re-queued and went out on its own.
+    //
+    // That broke the all-or-nothing guarantee this module promises, from the
+    // client side, after the server had honoured it. A batch is one CHANGE —
+    // a move is `[source -child, destination +child]`, a delete is
+    // `[parent -child, trash +child]`. The server rejected the pair, so
+    // sending the surviving half applies half a change: the source loses the
+    // child and nothing gains it. An orphan, manufactured by the error path.
     await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
-    const second = batchesOf(calls)[1];
-    expect(second.writes?.map((write) => write.document.id)).toEqual(["b"]);
-    expect(second.writes?.[0].expectedRevision).toBe(1);
+    expect(batchesOf(calls)).toHaveLength(1); // no second batch at all
+    expect(gateway.isConflicted("b")).toBe(true);
+
+    // And "b" is blocked from further clip writes for the same reason "a" is:
+    // the change its projection belonged to no longer exists.
+    gateway.writeClips("b", [clip("b3")]);
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+    expect(batchesOf(calls)).toHaveLength(1);
 
     // The next edit to "a" is BLOCKED, and this expectation is the fix.
     //
@@ -512,7 +573,7 @@ describe("graph-documents-gateway", () => {
     // against a revision fresh enough that the server accepts it.
     gateway.writeClips("a", [clip("a3")]);
     await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
-    expect(batchesOf(calls)).toHaveLength(2); // no third batch
+    expect(batchesOf(calls)).toHaveLength(1); // still no further batch
     expect(clipIds(gateway.peek("a"))).toEqual(["a-server"]); // cache untouched
     expect(gateway.lastError()).toContain("not being saved");
   });

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
@@ -137,6 +137,28 @@ export type GraphDocumentsGateway = Readonly<{
    * not get, or to surface the state in their own UI.
    */
   isConflicted: (timelineId: string) => boolean;
+  /**
+   * Declare that the CACHE is ahead of the live graph for this document, so
+   * clip writes projected from that graph must stop.
+   *
+   * `writeClips` already refuses this exact hazard for a document that lost a
+   * revision conflict, and says why: the cache is fresh while the graph the
+   * clips came from is not, so writing them overwrites the other writer's
+   * content with a stale full collection. A 409 was only ever ONE way to reach
+   * that state. The remote-change poller reaches it too — it refreshes a
+   * document (and its revision) and then declines to apply the difference, at
+   * which point the ledger is current, CAS will happily pass, and the next
+   * ancestor write silently deletes whatever the other writer added.
+   *
+   * That is not hypothetical: it is how an open tab reverted two collections an
+   * agent had just created, ~40s after each write, with CAS passing both times.
+   * Mandatory CAS would not have caught it — the revision was correct; the
+   * CONTENT was not.
+   *
+   * Same block and same lifting point as a conflict: cleared by `refresh()`,
+   * when entering the view rebuilds the graph from fresh documents.
+   */
+  markGraphBehind: (timelineId: string, reason: string) => void;
   /** Cache-change notifications (documents landing, clips written). */
   subscribe: (listener: () => void) => () => void;
   /**
@@ -634,31 +656,44 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
             // claim, actually re-persists the entire stale collection against
             // the fresh revision and silently deletes the other writer's
             // additions. Further clip writes are therefore BLOCKED for these
-            // ids until the graph is rebuilt from documents. Unconflicted
-            // writes from the batch re-queue as-is.
+            // ids until the graph is rebuilt from documents.
+            //
+            // THE WHOLE BATCH IS DROPPED, not just the conflicted ids.
+            //
+            // This used to re-queue the unconflicted writes and flush them on
+            // their own, and that broke the all-or-nothing guarantee this
+            // module's header promises — from the client side, after the server
+            // had honoured it. A batch is one CHANGE: a move is
+            // `[source −child, destination +child]`, a delete is
+            // `[parent −child, trash +child]`. The server rejected the pair, so
+            // re-sending the surviving half applies half a change — the source
+            // loses the child and nothing gains it. That is an orphan, created
+            // deliberately by the error path.
+            //
+            // The conflicted document reloads; the rest are blocked too,
+            // because the change they belonged to no longer exists and their
+            // projections came from the same now-suspect graph. Everything
+            // lifts together on `refresh()`.
             for (const write of writes) {
               const timelineId = write.document.id;
-              if (conflictIds.has(timelineId)) {
-                staleIds.add(timelineId);
-                conflictedIds.add(timelineId);
-                // Anything already queued for this id was projected from the
-                // stale graph too.
-                dirtyIds.delete(timelineId);
-                // The message lands AFTER the reload (a successful fetch
-                // clears that document's error slot — set before, it would
-                // flash and vanish); it then stands until the document next
-                // saves cleanly. A failed reload keeps its own load error.
-                void ensure(timelineId).then((document) => {
-                  if (document !== null) {
-                    setError(
-                      timelineId,
-                      `"${write.document.title}" changed in another view. Your unsaved edits to it are not being saved — reopen this timeline to continue editing.`,
-                    );
-                  }
-                });
-              } else {
-                dirtyIds.add(timelineId);
-              }
+              staleIds.add(timelineId);
+              conflictedIds.add(timelineId);
+              // Anything already queued for these ids was projected from the
+              // stale graph too.
+              dirtyIds.delete(timelineId);
+              if (!conflictIds.has(timelineId)) continue;
+              // The message lands AFTER the reload (a successful fetch
+              // clears that document's error slot — set before, it would
+              // flash and vanish); it then stands until the document next
+              // saves cleanly. A failed reload keeps its own load error.
+              void ensure(timelineId).then((document) => {
+                if (document !== null) {
+                  setError(
+                    timelineId,
+                    `"${write.document.title}" changed in another view. Your unsaved edits to it are not being saved — reopen this timeline to continue editing.`,
+                  );
+                }
+              });
             }
             if (dirtyIds.size > 0) scheduleFlush();
             return;
@@ -851,6 +886,16 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
     hasPendingWrite: (timelineId) =>
       dirtyIds.has(timelineId) || saveInFlightIds.includes(timelineId),
     isConflicted: (timelineId) => conflictedIds.has(timelineId),
+    markGraphBehind: (timelineId, reason) => {
+      if (documents[timelineId] === undefined) return;
+      if (conflictedIds.has(timelineId)) return;
+      conflictedIds.add(timelineId);
+      setError(
+        timelineId,
+        `"${documents[timelineId]?.title ?? timelineId}" changed in another view and this board could not merge it. Its edits are not being saved — reopen this timeline to continue. (${reason})`,
+      );
+      notify();
+    },
     saveState: readSaveState,
     subscribe: (listener) => {
       listeners.add(listener);


### PR DESCRIPTION
Part B, first two thirds. Two client-side paths that destroyed content, and a
server-side guard so neither shape can reach storage again.

729 unit + 168 e2e passing.

## The headline correction

Chasing this found the mechanism behind your reverted MCP writes, and it is
**not** what the plan assumed:

1. MCP adds a child to Joe; the server's Joe is now revision N.
2. The tab's poller calls `ensure(Joe)`, refreshing the cached document **and**
   the revision ledger to N.
3. The poller then declines to apply the difference to the graph.
4. A later edit anywhere *below* Joe writes Joe too — the affected set walks
   ancestors — projecting the stale graph over the fresh cache.
5. The write carries `expectedRevision: N`, which is **current**. CAS passes.

**Mandatory CAS would not have caught this.** The revision was right; the
content was wrong. That was going to be a wasted breaking change across four
call sites, so it is not in here.

## 1. The poller's half-state

`writeClips` already refuses this exact hazard for a conflicted document, and
says why in its comment — *"the cache is fresh but the GRAPH these clips were
projected from is not"*. A 409 was only ever one way to reach that state.
`markGraphBehind` marks the other three: parent not on this board, local write
in flight, remote additions refused. Same block, same message, same lifting
point (`refresh()`).

## 2. The 409 handler re-sent half a change

It dropped the conflicted write and **re-queued the unconflicted half alone**.
A batch is one change — `[source −child, destination +child]` — so re-sending
half applies half: the source loses the child and nothing gains it. An orphan,
manufactured by the error path, client-side, after the server had honoured
all-or-nothing. The whole batch is now dropped and blocked together.

The test asserting the old re-queue is **rewritten, not deleted** — it is the
record of a decision being reversed.

## 3. The orphan guard

Inside the existing transaction: did anything take up what this batch put down?
A move writes both parents; a delete writes the trash. Half a change does not,
and is refused with a 409 carrying the stranded ids.

**Owning placements only** — a clip whose `id` differs from its
`childTimelineId` is a duplicate reference and dropping it strands nothing.
That asymmetry is also why "released and unclaimed" can mean "unreachable"
without a reverse index: an owning placement is unique.

One read per released child, normally zero, before the first write.

## Verification

The refusal test was confirmed to fail without the guard, and it asserts on
`"Refusing to strand"` plus the orphan id — not merely on a 409, which the
empty-collection guard also returns. The four **permissive** tests matter more
than the refusal: move, delete, duplicate reference, dangling reference all
still pass, and the full e2e suite exercises real drags, deletes and
cut/paste against the guard without a single refusal.

## Still open

- **`PATCH /api/timelines/[id]` and both trash routes bypass this entirely.**
  They call `saveFirebaseTimelineEntry`, a single-document transaction with no
  cross-document view and no CAS. **Empty Trash orphans collection documents
  today** — it clears the bin's clips and does not cascade-delete.
- **Reachability audit** (`npm run audit:orphans`) and the repair pass.
- **`recentChanges()` cannot run** — the composite index for
  `timelineIds array-contains` + `orderBy at` does not exist, so the audit
  trail has never been readable by the helper built to read it.
- **`allowEmptying` should narrow to intent** now that the orphan case is
  covered directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)