### PR TITLE
Empty Trash: delete the documents, not just the entries

### DIFF
--- a/apps/timeline-gstudio001/app/api/trash/route.ts
+++ b/apps/timeline-gstudio001/app/api/trash/route.ts
@@ -4,9 +4,11 @@ import { readJsonObject } from "@/lib/read-json-body";
 import { requireAuthUser } from "@/lib/firebase-auth-session";
 import {
   collectOwnedTimelineClips,
+  deleteFirebaseTimelineDocument,
   readStoredTimelineDocument,
   saveFirebaseTimelineDocument,
 } from "@/lib/firebase-timeline-store";
+import type { TimelineClip } from "@storyboard/timeline-model/types";
 import {
   assetCandidatesFromClips,
   assetKeysFromClips,
@@ -16,6 +18,56 @@ import { markAssetsForDeletion } from "@/lib/asset-tombstones";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+
+/**
+ * The collection documents a set of bin entries OWNS.
+ *
+ * A trashed collection sits in the bin as a clip whose id is the child
+ * timeline's own id. Dropping that clip without deleting the document behind
+ * it leaves the document in storage with nothing pointing at it — invisible in
+ * the UI, absent from the bin it was just removed from, and reachable only by
+ * querying the database. Emptying the bin did exactly that, to every
+ * collection in it, every time.
+ *
+ * A clip whose `id` differs from its `childTimelineId` is a duplicate
+ * reference and owns nothing, so it is excluded — the same rule the write
+ * guard uses (`owningCollectionChildIds` in firebase-timeline-store).
+ */
+function owningCollectionIds(clips: readonly TimelineClip[]): string[] {
+  const ids: string[] = [];
+  for (const clip of clips) {
+    if (clip.kind !== "collection") continue;
+    if (clip.childTimelineId !== clip.id) continue;
+    ids.push(clip.childTimelineId);
+  }
+  return ids;
+}
+
+/**
+ * Delete the documents behind trashed collections, BEFORE the bin lets go.
+ *
+ * The order is the whole point, and it is the OPPOSITE of the asset marking
+ * below. Marking leaks storage when it fails, which is the failure direction
+ * that design deliberately chose. This one cannot use the same order: clear
+ * first and fail here, and the documents are stranded — the exact state the
+ * app is now supposed to be unable to reach. Delete first and fail to clear,
+ * and the bin points at documents that no longer exist: visible, harmless, and
+ * tidied by the next empty.
+ *
+ * So unlike marking, this is allowed to FAIL THE REQUEST. The bin stays as it
+ * was and the user can retry; nothing is stranded either way.
+ */
+async function deleteTrashedCollections(
+  clips: readonly TimelineClip[],
+  requesterUid: string,
+): Promise<void> {
+  // Sequential on purpose: each of these walks and deletes a whole subtree, so
+  // running them together is a burst of unbounded width. A bin holds tens of
+  // entries, not thousands.
+  for (const id of owningCollectionIds(clips)) {
+    await deleteFirebaseTimelineDocument(id, requesterUid);
+  }
+}
 
 /**
  * Empty the signed-in user's trash bin, and MARK the uploaded files nothing
@@ -46,6 +98,10 @@ export async function DELETE() {
     if (!trashDoc || cleared === 0) return NextResponse.json({ success: true, cleared });
 
     const candidates = assetCandidatesFromClips(trashDoc.clips);
+
+    // BEFORE the bin lets go — see `deleteTrashedCollections`. A failure here
+    // aborts the request with the bin intact rather than stranding documents.
+    await deleteTrashedCollections(trashDoc.clips, user.uid);
 
     // `allowEmptying` is what makes this work at all. The save path refuses
     // an empty write over a non-empty document (a stale client erasing real
@@ -139,14 +195,21 @@ export async function POST(request: Request) {
     // trashed from two timelines arrives twice), and a caller asking to
     // discard one of them must not lose the other.
     const remaining = [...trashDoc.clips];
-    let discarded = 0;
+    const dropped: TimelineClip[] = [];
     for (const clipId of clipIds) {
       const index = remaining.findIndex((clip) => clip.id === clipId);
       if (index === -1) continue;
+      dropped.push(remaining[index]);
       remaining.splice(index, 1);
-      discarded += 1;
     }
+    const discarded = dropped.length;
     if (discarded === 0) return NextResponse.json({ success: true, discarded: 0 });
+
+    // Only what this request actually drops, and only the OWNING entry: the bin
+    // can hold the same id twice, and a copy staying behind still needs its
+    // document or restoring it would restore nothing. Before the write, for the
+    // reason in `deleteTrashedCollections`.
+    await deleteTrashedCollections(dropped, user.uid);
 
     await saveFirebaseTimelineDocument({ ...trashDoc, clips: remaining }, user.uid, {
       allowEmptying: true,

--- a/apps/timeline-gstudio001/app/api/trash/trash-empty.test.ts
+++ b/apps/timeline-gstudio001/app/api/trash/trash-empty.test.ts
@@ -211,6 +211,40 @@ function seedTrash(clips: TimelineClip[], revision = 3) {
   });
 }
 
+/** A trashed COLLECTION entry: its clip id IS the child timeline's id. */
+function trashedCollection(childTimelineId: string): TimelineClip {
+  return {
+    id: childTimelineId,
+    index: 0,
+    kind: "collection",
+    childTimelineId,
+    title: `Timeline ${childTimelineId}`,
+    itemCount: 0,
+    previewItems: [],
+    alt: `${childTimelineId} collection`,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 3,
+    sourceDuration: 3,
+    trimIn: 0,
+    trimOut: 0,
+  } as unknown as TimelineClip;
+}
+
+/** The document behind a trashed collection, plus an optional child of its own. */
+function seedCollectionDocument(id: string, childIds: string[] = [], ownerUid = "user-a") {
+  const clips = childIds.map((childId) => trashedCollection(childId));
+  state.docs.set(id, {
+    id,
+    title: `Timeline ${id}`,
+    document: { id, title: `Timeline ${id}`, clips },
+    clips,
+    ownerUid,
+    revision: 1,
+  });
+}
+
 /** A LIVE (non-trash) document that still points at `assetIds`. */
 function seedLiveTimeline(id: string, assetIds: string[], ownerUid = "user-a") {
   const clips = assetIds.map((assetId, index) =>
@@ -242,6 +276,48 @@ beforeEach(() => {
 });
 
 describe("DELETE /api/trash", () => {
+  // ── Trashed COLLECTIONS have documents behind them ────────────────────────
+  //
+  // Emptying the bin cleared its clips and left every collection document in
+  // storage with nothing pointing at it: invisible in the UI, gone from the bin
+  // it was just removed from, reachable only by querying the database.
+
+  it("DELETES the document behind a trashed collection, not just the bin entry", async () => {
+    seedTrash([trashedCollection("timeline-gone")]);
+    seedCollectionDocument("timeline-gone");
+
+    const response = await emptyTrash();
+    expect(response.status).toBe(200);
+
+    // The whole point: no unreachable record left behind.
+    expect(state.docs.has("timeline-gone")).toBe(false);
+    expect((await readBack()).clips).toEqual([]);
+  });
+
+  it("cascades into the trashed collection's own children", async () => {
+    seedTrash([trashedCollection("timeline-parent")]);
+    seedCollectionDocument("timeline-parent", ["timeline-nested"]);
+    seedCollectionDocument("timeline-nested");
+
+    await emptyTrash();
+
+    // A subtree, not one document — a nested collection is just as unreachable.
+    expect(state.docs.has("timeline-parent")).toBe(false);
+    expect(state.docs.has("timeline-nested")).toBe(false);
+  });
+
+  it("leaves a DUPLICATE REFERENCE entry's document alone", async () => {
+    // A second card for a timeline that lives elsewhere: its clip id differs
+    // from the child id, it owns nothing, and the real placement still needs
+    // the document.
+    const reference = { ...trashedCollection("timeline-shared"), id: "clip-duplicate-ref" };
+    seedTrash([reference as TimelineClip]);
+    seedCollectionDocument("timeline-shared");
+
+    expect((await emptyTrash()).status).toBe(200);
+    expect(state.docs.has("timeline-shared")).toBe(true);
+  });
+
   it("empties the bin", async () => {
     seedTrash([
       clip("c1", "https://example.test/a.png"),
@@ -393,6 +469,20 @@ const discard = (clipIds: unknown) =>
 // the open timeline, and the copies that never moved have to go too — or the
 // row returns holding duplicates of something already taken back.
 describe("POST /api/trash", () => {
+  it("DELETES the document behind a discarded collection", async () => {
+    seedTrash([trashedCollection("timeline-a"), trashedCollection("timeline-b")]);
+    seedCollectionDocument("timeline-a");
+    seedCollectionDocument("timeline-b");
+
+    const response = await discard(["timeline-a"]);
+    expect(response.status).toBe(200);
+
+    // Only the discarded one — the entry left in the bin still needs its
+    // document, or restoring it would restore nothing.
+    expect(state.docs.has("timeline-a")).toBe(false);
+    expect(state.docs.has("timeline-b")).toBe(true);
+  });
+
   it("discards the named entries and leaves the rest", async () => {
     seedTrash([
       clip("c1", "https://example.test/a.png"),


### PR DESCRIPTION
The largest remaining orphan hole, flagged as still-open in #355.

## The bug

Emptying the bin cleared its clips and left every collection document in
storage with **nothing pointing at it** — invisible in the UI, gone from the
bin it was just removed from, reachable only by querying the database.
Discarding a single entry did the same.

Both routes call `saveFirebaseTimelineDocument`, a single-document transaction,
so the orphan guard added in #355 never saw them. Every collection you have
ever emptied from the trash is still in Firestore.

## The fix

Both paths now cascade-delete the documents they own, reusing
`deleteFirebaseTimelineDocument` — a subtree walk, so a trashed collection's
own children go with it.

**Before the bin lets go, and that ordering is the point.** It is the opposite
of the asset marking further down the same file, and deliberately so:

- Marking leaks storage when it fails. That is the failure direction that
  design chose, which is why it runs last and never fails the request.
- This cannot use that order. Clear first and fail here, and the documents are
  stranded — the exact state the app is now supposed to be unable to reach.
  Delete first and fail to clear, and the bin points at documents that no
  longer exist: visible, harmless, tidied by the next empty.

So unlike marking, this is allowed to fail the request. The bin stays as it
was and the user retries; nothing is stranded either way.

**Owning entries only.** The bin can hold the same id twice, and a duplicate
reference owns nothing — deleting on its behalf would take a document the real
placement still needs. Same rule as the write guard in #355.

## Verification

733 unit + 168 e2e passing.

Three of the four new tests fail without the fix. The fourth is the
duplicate-reference guard, which passes either way by design — so I checked it
was not decoration by removing the owning check and confirming it fails. Worth
doing: two tests earlier in this session looked fine and were vacuous.

## Still open after this

- **Reachability audit** (`npm run audit:orphans`) and a repair pass.
  `timeline-msrk3310t3k7n7` is a live specimen to test it against.
- **`recentChanges()` cannot run** — the composite index for
  `timelineIds array-contains` + `orderBy at` does not exist, so the audit
  trail has never been readable by the helper written to read it.
- **`PATCH /api/timelines/[id]`** still bypasses the guard: a single-document
  write whose clips array simply omits a collection clip can strand it.
- **`allowEmptying` should narrow to intent.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)