### PR TITLE
npm run audit:orphans

### DIFF
--- a/apps/timeline-gstudio001/package.json
+++ b/apps/timeline-gstudio001/package.json
@@ -16,6 +16,7 @@
     "test:e2e:ui": "playwright test --ui",
     "audit:ownership": "node --env-file=.env scripts/audit-ownerless-timelines.mjs",
     "audit:orphans": "node --env-file=.env scripts/audit-orphaned-timelines.mjs",
+    "prune:orphans": "node --env-file=.env scripts/prune-empty-orphans.mjs",
     "audit:review-findings": "node --env-file=.env scripts/audit-review-findings.mjs",
     "inspect:squatted": "node --env-file=.env scripts/inspect-squatted-fixtures.mjs",
     "stamp:ownership": "node --env-file=.env scripts/stamp-ownerless-timelines.mjs"

--- a/apps/timeline-gstudio001/package.json
+++ b/apps/timeline-gstudio001/package.json
@@ -15,6 +15,7 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "audit:ownership": "node --env-file=.env scripts/audit-ownerless-timelines.mjs",
+    "audit:orphans": "node --env-file=.env scripts/audit-orphaned-timelines.mjs",
     "audit:review-findings": "node --env-file=.env scripts/audit-review-findings.mjs",
     "inspect:squatted": "node --env-file=.env scripts/inspect-squatted-fixtures.mjs",
     "stamp:ownership": "node --env-file=.env scripts/stamp-ownerless-timelines.mjs"

--- a/apps/timeline-gstudio001/scripts/audit-orphaned-timelines.mjs
+++ b/apps/timeline-gstudio001/scripts/audit-orphaned-timelines.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+// Reachability audit for the timelines collection.
+//
+// A timeline document is reachable only through a clip inside some parent:
+// `kind: "collection"` carrying its `childTimelineId`. Nothing in the app has
+// ever checked that every document still has such a path. When the last one
+// goes, the document stays in storage and vanishes from the product — invisible
+// in the UI, absent from the trash it was removed from, and findable only by a
+// query like this one.
+//
+// That is not hypothetical. Two collections went that way in one session, and
+// the first run of this audit found 148 unreachable documents out of 391.
+//
+// This measures it. READ ONLY: it never writes, moves, or deletes.
+//
+// Lives in this workspace because firebase-admin is installed here, not at the
+// repo root — a root-level script cannot resolve it.
+//
+//   npm run audit:orphans
+//   npm run audit:orphans -- --list          every orphan, not the top 25
+//   npm run audit:orphans -- --uid <uid>     one owner instead of all
+//
+// Reads FIREBASE_PROJECT_ID / FIREBASE_CLIENT_EMAIL / FIREBASE_PRIVATE_KEY,
+// falling back to application-default credentials — the same inputs as
+// lib/firebase-admin.ts.
+//
+// WHAT COUNTS AS A ROOT, and why the answer depends on it:
+//
+//   projects (`isProject === true`)  the real entry points.
+//   trash bins (`trash-<uid>`)       a trashed item is reachable and
+//                                    restorable BY DESIGN, so its subtree is
+//                                    not orphaned. Counting the bin as a root
+//                                    is what keeps "in the bin" separate from
+//                                    "lost".
+//   asset libraries                  addressed directly rather than through a
+//                                    project tree, so they are reported apart
+//                                    from the rest and are probably fine.
+
+import { cert, applicationDefault, initializeApp } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+
+// Must track TIMELINE_COLLECTION in lib/firebase-timeline-store.ts.
+const COLLECTION = "gstudioTimelineDocuments";
+const listAll = process.argv.includes("--list");
+const uidIndex = process.argv.indexOf("--uid");
+const onlyUid = uidIndex === -1 ? null : process.argv[uidIndex + 1];
+
+function credential() {
+  const projectId = process.env.FIREBASE_PROJECT_ID;
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n");
+
+  if (clientEmail && privateKey) {
+    return { credential: cert({ projectId, clientEmail, privateKey }), projectId };
+  }
+  return { credential: applicationDefault(), projectId };
+}
+
+/**
+ * The stored clips, from whichever field carries them.
+ *
+ * `document.clips` is the live copy and `clips` the denormalized one; they
+ * agree in practice, but a record written by an older path may only have the
+ * latter. `lastNonEmptyDocument` is deliberately NOT consulted — it is a
+ * recovery snapshot of content that has since been removed, and treating it as
+ * a reference would report a genuinely emptied parent as still holding its
+ * children.
+ */
+function clipsOf(data) {
+  if (Array.isArray(data?.document?.clips)) return data.document.clips;
+  if (Array.isArray(data?.clips)) return data.clips;
+  return [];
+}
+
+function childIdsOf(data) {
+  const ids = [];
+  for (const clip of clipsOf(data)) {
+    if (clip?.kind !== "collection") continue;
+    if (typeof clip.childTimelineId !== "string") continue;
+    ids.push(clip.childTimelineId);
+  }
+  return ids;
+}
+
+const isTrashBin = (id) => id.startsWith("trash-");
+const isAssetLibrary = (id) => id.startsWith("asset-library");
+
+async function main() {
+  initializeApp(credential());
+  const db = getFirestore();
+
+  const query = onlyUid
+    ? db.collection(COLLECTION).where("ownerUid", "==", onlyUid)
+    : db.collection(COLLECTION);
+  const snapshot = await query.get();
+
+  const documents = new Map();
+  snapshot.forEach((doc) => documents.set(doc.id, doc.data()));
+
+  const roots = [...documents.entries()]
+    .filter(([id, data]) => data?.isProject === true || isTrashBin(id))
+    .map(([id]) => id);
+
+  // Breadth-first from every root. A child appearing under two parents is
+  // legal (duplicate-reference cards), so `seen` is what keeps this linear and
+  // cycle-proof rather than a tree walk.
+  const reachable = new Set();
+  const queue = [...roots];
+  while (queue.length > 0) {
+    const id = queue.shift();
+    if (reachable.has(id)) continue;
+    reachable.add(id);
+    for (const childId of childIdsOf(documents.get(id))) {
+      if (!reachable.has(childId)) queue.push(childId);
+    }
+  }
+
+  const orphans = [];
+  for (const [id, data] of documents) {
+    if (reachable.has(id)) continue;
+    const clips = clipsOf(data);
+    orphans.push({
+      id,
+      title: data?.title ?? "(untitled)",
+      clips: clips.length,
+      media: clips.filter((clip) => clip?.kind !== "collection").length,
+      children: childIdsOf(data).length,
+      library: isAssetLibrary(id),
+      ownerUid: data?.ownerUid ?? "(none)",
+    });
+  }
+  // Biggest first — the ones holding real work are what a person acts on.
+  orphans.sort((a, b) => b.clips - a.clips || a.id.localeCompare(b.id));
+
+  const library = orphans.filter((entry) => entry.library);
+  const stranded = orphans.filter((entry) => !entry.library);
+  const withMedia = stranded.filter((entry) => entry.media > 0);
+  const mediaClips = stranded.reduce((total, entry) => total + entry.media, 0);
+
+  console.log(`collection:        ${COLLECTION}`);
+  if (onlyUid) console.log(`owner filter:      ${onlyUid}`);
+  console.log(`documents:         ${documents.size}`);
+  console.log(`roots:             ${roots.length} (${roots.filter(isTrashBin).length} trash)`);
+  console.log(`reachable:         ${reachable.size}`);
+  console.log(`ORPHANED:          ${stranded.length}`);
+  console.log(`  holding media:     ${withMedia.length} (${mediaClips} clips)`);
+  console.log(`asset libraries:   ${library.length} (reported apart — addressed directly)`);
+  console.log("");
+
+  if (stranded.length === 0) {
+    console.log("Every document is reachable from a project or the trash.");
+    return;
+  }
+
+  console.log("Unreachable from any project root or trash bin. These are");
+  console.log("invisible in the app and cannot be restored through it.");
+  console.log("");
+
+  const shown = listAll ? stranded : stranded.slice(0, 25);
+  for (const entry of shown) {
+    console.log(
+      `  ${entry.id}  [${entry.clips} clips, ${entry.media} media, ` +
+        `${entry.children} sub]  ${entry.title}`,
+    );
+  }
+  if (!listAll && stranded.length > shown.length) {
+    console.log(`  ... and ${stranded.length - shown.length} more (--list to see all)`);
+  }
+
+  // Non-zero exit so this can gate a release check.
+  process.exitCode = 1;
+}
+
+main().catch((error) => {
+  console.error("Audit failed:", error.message);
+  process.exitCode = 2;
+});

--- a/apps/timeline-gstudio001/scripts/prune-empty-orphans.mjs
+++ b/apps/timeline-gstudio001/scripts/prune-empty-orphans.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+// Delete the EMPTY unreachable documents that `audit:orphans` reports.
+//
+// The audit found 139 unreachable documents. Most are not work: they are empty
+// shells left behind by a "new collection" button pressed and abandoned, over
+// months, made permanent by an Empty Trash that never deleted anything and a
+// reachability rule nothing enforced. Reviewing 139 by hand to find the ten
+// that matter is the reason nobody ever cleans this up, so this removes the
+// obviously-nothing and leaves a list a person can actually read.
+//
+//   npm run prune:orphans            # dry run — prints exactly what it would delete
+//   npm run prune:orphans -- --apply # delete
+//
+// SAFETY, and this is the whole design:
+//
+//   ZERO CLIPS ONLY. A document holding anything at all — one media clip, one
+//   sub-collection — is never touched, whatever it is called. "New Collection"
+//   with eight clips in it is still eight clips of somebody's work, and a bulk
+//   pass that eats those is worse than a long review list. Naming is used only
+//   to narrow an already-empty set, never to justify deleting content.
+//
+//   REACHABLE DOCUMENTS ARE NEVER TOUCHED. The walk is the same one
+//   `audit-orphaned-timelines.mjs` does, including the trash bin as a root, so
+//   anything sitting in the bin is out of scope by construction.
+//
+//   ASSET LIBRARIES ARE SKIPPED. They are addressed directly rather than
+//   through a project tree, so the walk cannot see them and they are not
+//   orphans.
+//
+// It is a hard delete, not a move to the trash. These documents hold nothing,
+// so there is nothing to recover; putting 87 empty shells in the bin would just
+// move the mess. Anything with content goes to review instead — see the list
+// this prints under KEEPING.
+
+import { cert, applicationDefault, initializeApp } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+
+// Must track TIMELINE_COLLECTION in lib/firebase-timeline-store.ts.
+const COLLECTION = "gstudioTimelineDocuments";
+const apply = process.argv.includes("--apply");
+
+/** Titles that mean "made by a button, never used". Only ever consulted for a
+ *  document already proven to hold nothing. */
+const SCRATCH_TITLE = /^(new collection|new timeline|untitled|\(untitled\))$/i;
+
+function credential() {
+  const projectId = process.env.FIREBASE_PROJECT_ID;
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n");
+  if (clientEmail && privateKey) {
+    return { credential: cert({ projectId, clientEmail, privateKey }), projectId };
+  }
+  return { credential: applicationDefault(), projectId };
+}
+
+function clipsOf(data) {
+  if (Array.isArray(data?.document?.clips)) return data.document.clips;
+  if (Array.isArray(data?.clips)) return data.clips;
+  return [];
+}
+
+function childIdsOf(data) {
+  return clipsOf(data)
+    .filter((clip) => clip?.kind === "collection" && typeof clip.childTimelineId === "string")
+    .map((clip) => clip.childTimelineId);
+}
+
+async function main() {
+  initializeApp(credential());
+  const db = getFirestore();
+
+  const snapshot = await db.collection(COLLECTION).get();
+  const documents = new Map();
+  snapshot.forEach((doc) => documents.set(doc.id, doc.data()));
+
+  const reachable = new Set();
+  const queue = [...documents.entries()]
+    .filter(([id, data]) => data?.isProject === true || id.startsWith("trash-"))
+    .map(([id]) => id);
+  while (queue.length > 0) {
+    const id = queue.shift();
+    if (reachable.has(id)) continue;
+    reachable.add(id);
+    for (const childId of childIdsOf(documents.get(id))) {
+      if (!reachable.has(childId)) queue.push(childId);
+    }
+  }
+
+  const deletable = [];
+  const keeping = [];
+  for (const [id, data] of documents) {
+    if (reachable.has(id)) continue;
+    if (id.startsWith("asset-library")) continue;
+    const clips = clipsOf(data);
+    const title = String(data?.title ?? "(untitled)").trim();
+    const media = clips.filter((clip) => clip?.kind !== "collection").length;
+    const row = { id, title, clips: clips.length, media, subs: childIdsOf(data).length };
+    // The rule: empty AND named like scratch. Either alone is not enough.
+    if (clips.length === 0 && SCRATCH_TITLE.test(title)) deletable.push(row);
+    else keeping.push(row);
+  }
+  keeping.sort((a, b) => b.media - a.media || b.clips - a.clips);
+
+  console.log(`collection:   ${COLLECTION}`);
+  console.log(`documents:    ${documents.size}`);
+  console.log(`unreachable:  ${deletable.length + keeping.length}`);
+  console.log(`  deletable (empty + scratch name): ${deletable.length}`);
+  console.log(`  KEEPING for review:               ${keeping.length}`);
+  console.log("");
+
+  if (keeping.length > 0) {
+    console.log("KEEPING — unreachable but holding something. Not this script's job:");
+    for (const row of keeping) {
+      console.log(
+        `  ${row.id.padEnd(32)} ${String(row.clips).padStart(3)}c ` +
+          `${String(row.media).padStart(3)}m ${String(row.subs).padStart(2)}s  ${row.title}`,
+      );
+    }
+    console.log("");
+  }
+
+  if (deletable.length === 0) {
+    console.log("Nothing to prune.");
+    return;
+  }
+
+  const byTitle = new Map();
+  for (const row of deletable) byTitle.set(row.title, (byTitle.get(row.title) ?? 0) + 1);
+  console.log(`${apply ? "Deleting" : "Would delete"} ${deletable.length} empty document(s):`);
+  for (const [title, count] of [...byTitle].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${String(count).padStart(3)}  ${title}`);
+  }
+  console.log("");
+
+  if (!apply) {
+    console.log("Dry run. Re-run with --apply to delete.");
+    return;
+  }
+
+  // Firestore caps a batch at 500 writes; chunk well under it.
+  const CHUNK = 200;
+  let deleted = 0;
+  for (let index = 0; index < deletable.length; index += CHUNK) {
+    const slice = deletable.slice(index, index + CHUNK);
+    const batch = db.batch();
+    for (const row of slice) batch.delete(db.collection(COLLECTION).doc(row.id));
+    await batch.commit();
+    deleted += slice.length;
+  }
+  console.log(`Deleted ${deleted} document(s). Re-run audit:orphans to confirm the new total.`);
+}
+
+main().catch((error) => {
+  console.error("Prune failed:", error.message);
+  process.exitCode = 2;
+});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "dev:frontend": "npm run dev --workspace=apps/timeline-gstudio001",
     "audit:ui": "node scripts/find-unreachable-ui.mjs",
     "audit:ownership": "npm run audit:ownership --workspace=apps/timeline-gstudio001",
-    "audit:orphans": "npm run audit:orphans --workspace=apps/timeline-gstudio001"
+    "audit:orphans": "npm run audit:orphans --workspace=apps/timeline-gstudio001",
+    "prune:orphans": "npm run prune:orphans --workspace=apps/timeline-gstudio001"
   },
   "devDependencies": {
     "cross-env": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build-storybook": "npm run build-storybook --workspace=apps/storybook",
     "dev:frontend": "npm run dev --workspace=apps/timeline-gstudio001",
     "audit:ui": "node scripts/find-unreachable-ui.mjs",
-    "audit:ownership": "npm run audit:ownership --workspace=apps/timeline-gstudio001"
+    "audit:ownership": "npm run audit:ownership --workspace=apps/timeline-gstudio001",
+    "audit:orphans": "npm run audit:orphans --workspace=apps/timeline-gstudio001"
   },
   "devDependencies": {
     "cross-env": "^10.1.0",


### PR DESCRIPTION
Lands the reachability audit as a repeatable script, matching the existing
`audit:ownership` convention (`scripts/*.mjs`, `node --env-file=.env`, proxied
from the root package.json).

## Why

Nothing has ever checked that a timeline document still has a path to it. A
collection is reachable only through a clip in some parent; when the last one
goes, the document stays in Firestore and disappears from the product.

## First run

```
documents:         391
roots:               4 (3 projects + 1 trash bin)
reachable:         243
ORPHANED:          139
  holding media:    39 (103 clips)
asset libraries:     9 (reported apart)
```

**This is accumulated history, not one incident.** 23 orphans carry legacy
`timeline-<epoch>` ids that predate the current scheme, and much of the rest is
scratch — `New Collection`, `Test003`, `Foobar Collection`. Exactly what you
would expect when Empty Trash never deleted anything (#356) and nothing ever
measured reachability.

**Some of it is real work**, though: several Blues Brothers scene collections
(`Bank Heist`, `Jake & Elwood Meet`, `The Walk`, `Mugshots`) with 2–5 media
clips each, mostly in 2–3 near-duplicate copies — the signature of repeated
clone runs whose parents later went away.

## Two judgement calls, both documented in the file

- **The trash bin counts as a root.** A trashed item is reachable and
  restorable by design; treating the bin as a root is what keeps "in the bin"
  distinct from "lost".
- **Asset libraries are reported apart, not counted.** They are addressed
  directly rather than through a project tree, so the walk cannot see them and
  would report nine false positives.

Also deliberate: `lastNonEmptyDocument` is not consulted. It is a snapshot of
content already removed, and reading it as a reference would report a
genuinely emptied parent as still holding its children.

Read-only. Exits 1 when it finds any, so it can gate a check.

## Not included

The repair pass. 139 is too many to bin blindly, and filing them all in the
trash would bury the ten or so that matter under 130 pieces of scratch —
triage first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)