### PR TITLE
Un-swallowable --apply, and a music glyph for audio collections

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -57,6 +57,33 @@ const emptyCollectionGraph = (() => {
   return result.value;
 })();
 
+/** A HYDRATED collection whose first child is audio. Audio is skipped by the
+ *  preview walk (it has no frame), so this card has nothing to draw — and the
+ *  film-leader glyph it used to fall back to says "no picture" where the true
+ *  answer is "this is sound". */
+const AUDIO_COLLECTION_ID = "audio-col" as NodeId;
+const audioCollectionGraph = (() => {
+  const result = buildGraph([
+    {
+      kind: "collection",
+      id: AUDIO_COLLECTION_ID,
+      name: "Voice takes",
+      children: [
+        {
+          kind: "media",
+          id: "vo-1" as NodeId,
+          name: "Pat VO",
+          mediaKind: "audio",
+          src: "data:audio/wav;base64,UklGRg==",
+          fullDurationSeconds: 8,
+        },
+      ],
+    },
+  ]);
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.value;
+})();
+
 const emptyCollectionNode = emptyCollectionGraph.nodesById.get(EMPTY_COLLECTION_ID);
 if (emptyCollectionNode?.kind !== "collection") {
   throw new Error("Empty collection ghost fixture did not build.");
@@ -247,6 +274,56 @@ export const EmptyCardUsesCleanIconFallback: Story = {
  * plain click opens the collection now, so a 28px corner button was a second
  * way to do the easy thing, parked over the artwork of every collection card.
  */
+/**
+ * A collection that LEADS WITH AUDIO shows the music glyph, not the leader.
+ *
+ * The thumbnail is the first child's frame and audio has none, so a collection
+ * of voice takes fell through to `CollectionLeaderPlaceholder` — the film
+ * crosshair, which means "no picture here". For sound that is the wrong
+ * sentence, and the audio media card already had the right glyph.
+ */
+export const AudioLedCollectionShowsMusicGlyph: Story = {
+  args: { ...baseArgs, id: AUDIO_COLLECTION_ID },
+  decorators: [
+    (Story) => {
+      // HYDRATED, unlike the other stories here: the audio branch reads the
+      // collection's live graph children, which is the only place the lead
+      // child's kind exists. A stored summary carries no entry for audio.
+      const store = createGraphDetailsStore({
+        [AUDIO_COLLECTION_ID]: {
+          alt: "Voice takes",
+          aspect: 16 / 9,
+          trackIndex: 0,
+          hydrated: true,
+          itemCount: 1,
+          duration: 8,
+          previewItems: [],
+        } satisfies ClipDetail,
+      });
+      return (
+        <DndCollections initialGraph={audioCollectionGraph}>
+          <GraphDetailsProvider store={store}>
+            <div className="h-32 w-40 bg-zinc-950 p-2">
+              <Story />
+            </div>
+          </GraphDetailsProvider>
+        </DndCollections>
+      );
+    },
+  ],
+  play: async ({ canvasElement }) => {
+    const fallback = canvasElement.querySelector<HTMLElement>(
+      "[data-empty-collection-preview]",
+    );
+    await expect(fallback).not.toBeNull();
+    // The marker is what distinguishes the two glyphs — both are bare SVGs, so
+    // asserting "an svg is present" would pass for the leader too and prove
+    // nothing about this change.
+    await expect(fallback!.getAttribute("data-collection-preview-kind")).toBe("audio");
+    await expect(previewImages(canvasElement)).toHaveLength(0);
+  },
+};
+
 export const ComposedCardStructure: Story = {
   args: baseArgs,
   decorators: [renderWithDetail([ASSET_A, ASSET_B])],

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -226,6 +226,38 @@ function useHydratedCollectionPreviews(
  * two copies of "enabled children" would drift, and the two sit on screen
  * together.
  */
+/**
+ * Whether this collection LEADS with audio.
+ *
+ * A collection's thumbnail is its first child's frame, and audio has no frame
+ * — so a collection of voice takes fell through to `CollectionLeaderPlaceholder`,
+ * the film-leader crosshair, which says "no picture here" when the honest
+ * answer is "this is sound". The audio card already has the right glyph
+ * (`AudioPlaceholder`); this is what lets the collection reach for it.
+ *
+ * FIRST child, not "any" and not "all": it mirrors exactly what the thumbnail
+ * would otherwise have shown, so the glyph and the frame it replaces are
+ * answering the same question. A collection whose first item is a video and
+ * whose second is audio still shows the video's frame, which is correct.
+ *
+ * Hydrated collections only. A placeholder has no graph children to read and
+ * its stored summary carries no preview entry for audio, so it keeps the
+ * leader — visibly wrong-ish, but inventing an answer from no data is worse.
+ */
+export function useFirstChildIsAudio(id: NodeId): boolean {
+  const store = useCollectionsStore();
+  const getSnapshot = useCallback(() => {
+    const graph = store.getSnapshot().graph;
+    const first = graph.childrenById.get(id)?.[0];
+    if (first === undefined) return false;
+    const node = graph.nodesById.get(first);
+    return node?.kind === "media" && node.mediaKind === "audio";
+  }, [store, id]);
+  // A boolean, so the selector's identity is stable by construction — the
+  // package's render-efficiency model requires selectors not to allocate.
+  return useSyncExternalStore(store.subscribe, getSnapshot, getSnapshot);
+}
+
 export function useEnabledChildCount(id: NodeId): number {
   const store = useCollectionsStore();
   const [derive] = useState(() =>
@@ -1624,6 +1656,9 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
   // card without a reload; placeholders fall back to their stored summary.
   const hydrated = detail?.hydrated === true;
   const enabledChildCount = useEnabledChildCount(id);
+  // Audio has no frame, so a collection leading with it has no thumbnail to
+  // show — see useFirstChildIsAudio.
+  const leadsWithAudio = useFirstChildIsAudio(id);
   const liveSeconds = useHydratedCollectionSeconds(id as string, hydrated);
 
   // ENABLED children only, so the card agrees with the time totals and with
@@ -1747,10 +1782,14 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
           {previews.length === 0 ? (
             <span
               data-empty-collection-preview
+              data-collection-preview-kind={leadsWithAudio ? "audio" : "leader"}
               aria-hidden="true"
               className="flex flex-1 items-center justify-center overflow-hidden rounded-sm"
             >
-              <CollectionLeaderPlaceholder />
+              {/* The film leader means "no picture". For a collection of voice
+                  takes that is the wrong sentence — the right one is "this is
+                  sound", and the audio card's own glyph already says it. */}
+              {leadsWithAudio ? <AudioPlaceholder /> : <CollectionLeaderPlaceholder />}
             </span>
           ) : (
             previews.map((preview, index) => (

--- a/apps/timeline-gstudio001/scripts/apply-flag.mjs
+++ b/apps/timeline-gstudio001/scripts/apply-flag.mjs
@@ -1,0 +1,54 @@
+// Read the "yes, actually write" signal for a destructive script.
+//
+// THE FAILURE THIS EXISTS FOR. `npm run prune:orphans --apply` does not pass
+// the flag to the script: npm treats anything between the script name and a
+// `--` separator as its own config. The script then printed "Dry run" and
+// deleted nothing, which is indistinguishable from the dry run the operator
+// had deliberately run a minute earlier — so it read as "done" and 87
+// documents survived a delete everyone believed had happened.
+//
+// AND IT CANNOT BE DETECTED. Verified on npm 11.12.1: an unrecognised flag is
+// discarded outright. No `npm_config_apply`, no `npm_config_argv` (removed in
+// npm 7+), nothing in `npm_lifecycle_script`. The script has no way to know it
+// was asked. An earlier version of this file tried to catch it that way and
+// silently never fired, which was the same bug wearing a hat.
+//
+// So the mitigation is twofold, and neither half is detection:
+//
+//   1. AN ENV FORM npm CANNOT EAT. `PRUNE_APPLY=1 npm run …` survives every
+//      layer, so there is a spelling that cannot fail quietly. It must be
+//      typed on the command line to mean anything, which is the same
+//      deliberate act as `--apply`.
+//   2. A DRY RUN THAT SAYS SO. The closing line states that nothing was
+//      deleted and names both working forms, so the outcome is legible even to
+//      someone who believes they just ran the real thing.
+
+/**
+ * @param {string} script  npm script name, for the printed commands.
+ * @param {string} envVar  the un-swallowable alternative, e.g. "PRUNE_APPLY".
+ * @returns {boolean} true when the caller genuinely asked to write.
+ */
+export function readApplyFlag(script, envVar) {
+  if (process.argv.includes("--apply")) return true;
+  const fromEnv = process.env[envVar];
+  return fromEnv !== undefined && fromEnv !== "" && fromEnv !== "0" && fromEnv !== "false";
+}
+
+/**
+ * The closing line of a dry run. Deliberately states the NEGATIVE outcome
+ * first: "Dry run" alone reads as a mode, not as a result, and the whole
+ * failure above was someone reading it as success.
+ */
+export function dryRunNotice(script, envVar) {
+  return [
+    "",
+    "NOTHING WAS DELETED — this was a dry run.",
+    "",
+    "To actually delete, use one of these EXACTLY:",
+    `  npm run ${script} -- --apply        (note the bare -- separator)`,
+    `  ${envVar}=1 npm run ${script}`,
+    "",
+    `Beware: \`npm run ${script} --apply\` without the separator is silently`,
+    "discarded by npm. The script never sees it and you get this message again.",
+  ].join("\n");
+}

--- a/apps/timeline-gstudio001/scripts/prune-empty-orphans.mjs
+++ b/apps/timeline-gstudio001/scripts/prune-empty-orphans.mjs
@@ -8,8 +8,12 @@
 // that matter is the reason nobody ever cleans this up, so this removes the
 // obviously-nothing and leaves a list a person can actually read.
 //
-//   npm run prune:orphans            # dry run — prints exactly what it would delete
-//   npm run prune:orphans -- --apply # delete
+//   npm run prune:orphans                  # dry run
+//   npm run prune:orphans -- --apply       # delete (note the bare -- separator)
+//   PRUNE_APPLY=1 npm run prune:orphans    # delete, in a form npm cannot swallow
+//
+// `npm run prune:orphans --apply` WITHOUT the separator is discarded by npm
+// before the script runs — see scripts/apply-flag.mjs.
 //
 // SAFETY, and this is the whole design:
 //
@@ -35,9 +39,11 @@
 import { cert, applicationDefault, initializeApp } from "firebase-admin/app";
 import { getFirestore } from "firebase-admin/firestore";
 
+import { dryRunNotice, readApplyFlag } from "./apply-flag.mjs";
+
 // Must track TIMELINE_COLLECTION in lib/firebase-timeline-store.ts.
 const COLLECTION = "gstudioTimelineDocuments";
-const apply = process.argv.includes("--apply");
+const apply = readApplyFlag("prune:orphans", "PRUNE_APPLY");
 
 /** Titles that mean "made by a button, never used". Only ever consulted for a
  *  document already proven to hold nothing. */
@@ -133,7 +139,7 @@ async function main() {
   console.log("");
 
   if (!apply) {
-    console.log("Dry run. Re-run with --apply to delete.");
+    console.log(dryRunNotice("prune:orphans", "PRUNE_APPLY"));
     return;
   }
 

--- a/apps/timeline-gstudio001/scripts/stamp-ownerless-timelines.mjs
+++ b/apps/timeline-gstudio001/scripts/stamp-ownerless-timelines.mjs
@@ -18,11 +18,13 @@
 import { cert, applicationDefault, initializeApp } from "firebase-admin/app";
 import { getFirestore } from "firebase-admin/firestore";
 
+import { dryRunNotice, readApplyFlag } from "./apply-flag.mjs";
+
 // Must track TIMELINE_COLLECTION in lib/firebase-timeline-store.ts.
 const COLLECTION = "gstudioTimelineDocuments";
 const BATCH_SIZE = 400; // Firestore caps a batch at 500 writes.
 
-const apply = process.argv.includes("--apply");
+const apply = readApplyFlag("stamp:ownership", "STAMP_APPLY");
 
 function credential() {
   const projectId = process.env.FIREBASE_PROJECT_ID;
@@ -83,7 +85,7 @@ async function main() {
   console.log("");
 
   if (!apply) {
-    console.log("Dry run. Re-run with --apply to write.");
+    console.log(dryRunNotice("stamp:ownership", "STAMP_APPLY"));
     return;
   }
 


### PR DESCRIPTION
Two fixes that came out of running the prune for real.

## 1. A destructive script's dry run could not be told from success

`npm run prune:orphans --apply` does not pass the flag to the script — npm
treats anything between the script name and a `--` separator as its own config.
The script printed "Dry run" and deleted nothing, which is **identical to the
dry run you deliberately ran a minute earlier**. It read as done; 87 documents
survived a delete everyone believed had happened. That happened here, for real.

**It cannot be detected.** Verified on npm 11.12.1: an unrecognised flag is
discarded outright — no `npm_config_apply`, no `npm_config_argv` (gone since
npm 7), nothing in `npm_lifecycle_script`. My first attempt at this fix tried
to catch it exactly that way and silently never fired, which was the same bug
wearing a hat.

So the mitigation is not detection:

- **A form npm cannot eat** — `PRUNE_APPLY=1 npm run prune:orphans` survives
  every layer, so there is a spelling that cannot fail quietly.
- **A dry run that says so** — the closing line now leads with `NOTHING WAS
  DELETED`, names both working forms, and warns about the swallowed one.
  "Dry run" alone reads as a mode, not a result.

Applied to `stamp:ownership` too — same trap, also writes, would have failed
the same silent way.

All four invocations verified:

| form | flag arrives |
|---|---|
| `npm run x --apply` | **false** (swallowed) |
| `npm run x -- --apply` | true |
| `PRUNE_APPLY=1 npm run x` | true |
| `npm run x` | false |

## 2. Audio collections showed the film-leader glyph

A collection's thumbnail is its first child's frame, and audio has none —
`hydratedCollectionPreviews` skips it deliberately, since an audio src would
otherwise persist into `previewItems` as an image. So a collection of voice
takes fell through to the film crosshair, which says "no picture here" when the
answer is "this is sound". The audio media card already had the right glyph.

FIRST child only, and only when there is genuinely nothing to draw: the preview
walk descends for images, so a collection leading with audio but holding a video
deeper still shows the video's frame. Hydrated collections only — a placeholder
has no children to read and its stored summary has no entry for audio, so it
keeps the leader rather than inventing an answer.

## Verification

733 unit + 168 e2e + 34 story tests. The new story asserts
`data-collection-preview-kind`, not "an svg is present" — both glyphs are bare
SVGs, so the looser check would pass for the leader and prove nothing. Confirmed
discriminating by forcing the flag false and watching it fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)