### PR TITLE
Print a delete command the operator's shell can actually run

### DIFF
--- a/apps/timeline-gstudio001/scripts/apply-flag.mjs
+++ b/apps/timeline-gstudio001/scripts/apply-flag.mjs
@@ -35,18 +35,48 @@ export function readApplyFlag(script, envVar) {
 }
 
 /**
+ * The env fallback, in the syntax of the shell actually in use.
+ *
+ * THE SECOND FAILURE. The first version of this notice printed the bash form
+ * unconditionally. On Windows/PowerShell `PRUNE_APPLY=1 npm run …` is not a
+ * command at all — PowerShell answers "PRUNE_APPLY=1 is not recognized" — so
+ * the notice told a PowerShell operator to run something that cannot work.
+ * Printing a confident, wrong instruction is the same bug this file exists to
+ * stop, so the escape hatch has to be written in the reader's shell.
+ */
+function envForms(script, envVar) {
+  if (process.platform !== "win32") return [`  ${envVar}=1 npm run ${script}`];
+  return [
+    `  $env:${envVar}="1"; npm run ${script}     (PowerShell)`,
+    `  set ${envVar}=1 && npm run ${script}      (cmd.exe)`,
+    "",
+    `  In PowerShell $env:${envVar} STAYS SET for the rest of the session, so a`,
+    `  later plain \`npm run ${script}\` will also delete. Clear it when done:`,
+    `  Remove-Item Env:${envVar}`,
+  ];
+}
+
+/**
  * The closing line of a dry run. Deliberately states the NEGATIVE outcome
  * first: "Dry run" alone reads as a mode, not as a result, and the whole
  * failure above was someone reading it as success.
+ *
+ * `-- --apply` is given first because it is the one form that works from both
+ * the repo root and this workspace, in every shell, and leaves nothing behind.
+ * It only survives the root proxy because those scripts end in a trailing `--`
+ * (root package.json) — without it npm re-swallows the flag one level down.
  */
 export function dryRunNotice(script, envVar) {
   return [
     "",
     "NOTHING WAS DELETED — this was a dry run.",
     "",
-    "To actually delete, use one of these EXACTLY:",
+    "To actually delete, run this EXACTLY (works from the repo root or this",
+    "workspace, in any shell):",
     `  npm run ${script} -- --apply        (note the bare -- separator)`,
-    `  ${envVar}=1 npm run ${script}`,
+    "",
+    "Or set the environment variable instead:",
+    ...envForms(script, envVar),
     "",
     `Beware: \`npm run ${script} --apply\` without the separator is silently`,
     "discarded by npm. The script never sees it and you get this message again.",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "build-storybook": "npm run build-storybook --workspace=apps/storybook",
     "dev:frontend": "npm run dev --workspace=apps/timeline-gstudio001",
     "audit:ui": "node scripts/find-unreachable-ui.mjs",
-    "audit:ownership": "npm run audit:ownership --workspace=apps/timeline-gstudio001",
-    "audit:orphans": "npm run audit:orphans --workspace=apps/timeline-gstudio001",
-    "prune:orphans": "npm run prune:orphans --workspace=apps/timeline-gstudio001"
+    "audit:ownership": "npm run audit:ownership --workspace=apps/timeline-gstudio001 --",
+    "audit:orphans": "npm run audit:orphans --workspace=apps/timeline-gstudio001 --",
+    "prune:orphans": "npm run prune:orphans --workspace=apps/timeline-gstudio001 --"
   },
   "devDependencies": {
     "cross-env": "^10.1.0",


### PR DESCRIPTION
The prune has now failed to happen twice. Neither time was it the operator's
mistake — two separate traps, both mine.

## From the repo root, the documented form was swallowed too

The root proxy was `npm run prune:orphans --workspace=…`, so the form I
documented expanded to:

```
npm run prune:orphans --workspace=apps/timeline-gstudio001 --apply
```

The flag lands after the *inner* script name with no separator — which is
precisely the bug the separator exists to avoid, reappearing one level down.

Verified read-only with `audit:orphans -- --list`: the flag never arrived and
output stayed capped at 25. Fixed by ending each root proxy with a trailing
`--`. Confirmed `--list` now arrives and the no-arg path is unchanged.

## The env fallback was bash-only, on a Windows machine

The notice printed `PRUNE_APPLY=1 npm run …` unconditionally. In PowerShell
that is not a command:

```
PRUNE_APPLY=1 : The term 'PRUNE_APPLY=1' is not recognized as the name of a cmdlet…
```

So on the shell actually in use, **neither documented form worked** — which is
why "done" came back with 139 orphans still standing. The notice now prints
PowerShell and cmd.exe syntax on win32.

It also warns that `$env:` persists for the rest of the session. A sticky flag
on a destructive script would quietly turn the next innocent dry run into a
delete, so the notice says how to clear it.

## Why this matters beyond the typo

Confidently printing a wrong instruction is the same failure the file was
written to prevent, just relocated from npm to me. The original bug was a dry
run that read as success; this was a remedy that read as authoritative. Both
cost a real delete that everyone believed had happened.

`-- --apply` is now listed first because it is the single form that works from
the repo root and the workspace, in every shell, and leaves nothing behind.

| form | flag arrives |
|---|---|
| `npm run x --apply` | **false** (swallowed by npm) |
| `npm run x -- --apply` from root | **false → now true** (needed the trailing `--`) |
| `npm run x -- --apply` from workspace | true |
| `PRUNE_APPLY=1 npm run x` in PowerShell | **not a command** |
| `$env:PRUNE_APPLY="1"; npm run x` | true |

🤖 Generated with [Claude Code](https://claude.com/claude-code)