### PR TITLE
Stop counting documents that do not exist as reachable

### DIFF
--- a/apps/timeline-gstudio001/scripts/audit-orphaned-timelines.mjs
+++ b/apps/timeline-gstudio001/scripts/audit-orphaned-timelines.mjs
@@ -104,13 +104,25 @@ async function main() {
   // Breadth-first from every root. A child appearing under two parents is
   // legal (duplicate-reference cards), so `seen` is what keeps this linear and
   // cycle-proof rather than a tree walk.
+  //
+  // A childTimelineId can name a document that does not exist — the mirror
+  // image of an orphan, and just as invisible: the parent shows a collection
+  // card that opens onto nothing. Those ids are recorded separately and kept
+  // OUT of `reachable`, which otherwise counts them and reports more reachable
+  // documents than the collection contains.
   const reachable = new Set();
+  const dangling = new Map();
   const queue = [...roots];
   while (queue.length > 0) {
     const id = queue.shift();
     if (reachable.has(id)) continue;
     reachable.add(id);
     for (const childId of childIdsOf(documents.get(id))) {
+      if (!documents.has(childId)) {
+        if (!dangling.has(childId)) dangling.set(childId, []);
+        dangling.get(childId).push(id);
+        continue;
+      }
       if (!reachable.has(childId)) queue.push(childId);
     }
   }
@@ -145,7 +157,28 @@ async function main() {
   console.log(`ORPHANED:          ${stranded.length}`);
   console.log(`  holding media:     ${withMedia.length} (${mediaClips} clips)`);
   console.log(`asset libraries:   ${library.length} (reported apart — addressed directly)`);
+  console.log(`DANGLING refs:     ${dangling.size} (parent points at a document that does not exist)`);
   console.log("");
+
+  // These three plus the dangling count must account for every document. If
+  // they do not, the walk is wrong and so is everything below it.
+  const accounted = reachable.size + stranded.length + library.length;
+  if (accounted !== documents.size) {
+    console.log(`INTERNAL: ${accounted} accounted for vs ${documents.size} documents — the`);
+    console.log("walk is inconsistent. Do not act on the list below.");
+    console.log("");
+    process.exitCode = 2;
+    return;
+  }
+
+  if (dangling.size > 0) {
+    console.log("Referenced as a child, but no such document exists. The parent shows a");
+    console.log("collection card that opens onto nothing:");
+    for (const [childId, parents] of dangling) {
+      console.log(`  ${childId}  referenced by ${parents.join(", ")}`);
+    }
+    console.log("");
+  }
 
   if (stranded.length === 0) {
     console.log("Every document is reachable from a project or the trash.");


### PR DESCRIPTION
The audit reported **299 reachable of 307** documents, with 0 orphaned and 9
libraries. That sums to **308** — one more than exists.

A `childTimelineId` can name a document that was never created or has since
gone. The walk enqueued that id, added it to `reachable`, and counted it. The
headline was inflated by every broken reference in the graph, and nothing ever
noticed because the individual lists below it were still correct.

## Two fixes

- A dangling id is recorded and kept **out** of `reachable`, so the count means
  "documents that exist and can be reached".
- The three buckets are **reconciled against the collection size** before
  anything is printed. If they disagree, the run says so and exits 2 rather
  than emitting a list that looks authoritative. An audit that cannot add up
  must not be trusted to say what is safe to delete.

## And it now reports dangling references

This is the point. A dangling ref is the mirror image of an orphan and just as
invisible:

- an **orphan** is a document no parent points at
- a **dangling ref** is a parent pointing at no document

The app renders the second as a collection card that opens onto nothing. The
standing rule for this data is that nothing may be left parentless — the same
walk answers the other half for free, and was silently discarding the evidence.

One exists today: `timeline-ms909pnvm6x6kk`, referenced by "My Foobar 002".

## After

```
documents:         307
reachable:         298
ORPHANED:          0
asset libraries:   9
DANGLING refs:     1
```

298 + 0 + 9 = 307. It reconciles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)