### PR TITLE
Say what went wrong instead of showing a blank page

### DIFF
--- a/apps/timeline-gstudio001/app/error.tsx
+++ b/apps/timeline-gstudio001/app/error.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+
+// The app had NO error boundary anywhere. Any throw React could not handle
+// reached Next's built-in fallback, which renders the bare string
+// "Application error: a client-side exception has occurred (see the browser
+// console for more information)" — no clue what failed, nothing to click, and
+// on a production build no stack either. That is what the owner hit when the
+// project ran out of Firestore read quota.
+//
+// This does not stop things throwing; it makes a throw legible and
+// recoverable. `reset()` re-renders the segment without a full reload, which
+// is the right first move for a transient backend failure — the quota case
+// literally fixes itself, and so does a dropped connection.
+//
+// Scope: this covers every route under `app/`, but NOT a throw inside the root
+// layout itself — React needs the boundary above the thing that failed, and
+// nothing in this file is mounted until the root layout has rendered. That
+// case belongs to `global-error.tsx` beside this file.
+export default function AppError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // The console is where the built-in fallback told people to look, so keep
+    // putting something useful there. `digest` is the only handle on a
+    // production stack (the message is minified away), which makes it the one
+    // thing worth quoting in a bug report.
+    console.error("Unhandled error rendering this page:", error);
+  }, [error]);
+
+  return (
+    <div className="mx-auto flex w-full max-w-[1400px] flex-col gap-5 p-6">
+      <div
+        role="alert"
+        className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-4 text-sm text-zinc-300"
+      >
+        <p className="font-semibold text-zinc-100">Something went wrong loading this page</p>
+        <p className="mt-1">
+          This is usually temporary — the app could not reach its data. Trying again is
+          often enough; if it keeps happening, the storage backend may be unavailable or
+          out of quota for the day.
+        </p>
+        {error.digest !== undefined && (
+          <p className="mt-2 text-xs text-zinc-500">
+            Reference: <code>{error.digest}</code>
+          </p>
+        )}
+        <div className="mt-3 flex items-center gap-4">
+          <button
+            type="button"
+            onClick={reset}
+            className="rounded-md border border-zinc-700 bg-zinc-800/60 px-3 py-1.5 text-xs font-medium text-zinc-100 hover:bg-zinc-800"
+          >
+            Try again
+          </button>
+          <Link href="/projects" className="text-xs text-sky-400 underline underline-offset-4">
+            Back to Projects
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/timeline-gstudio001/app/global-error.tsx
+++ b/apps/timeline-gstudio001/app/global-error.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect } from "react";
+
+// The LAST resort: a throw in the root layout itself, which `app/error.tsx`
+// cannot catch because that boundary only exists once the root layout has
+// rendered. React replaces the entire document here, so this component has to
+// supply its own <html> and <body> — and it cannot rely on the app's providers,
+// fonts, or even globals.css being present, which is why the styling below is
+// inline rather than Tailwind classes.
+//
+// Deliberately plain. Anything clever here risks throwing inside the handler
+// for a throw, and there is no boundary left underneath to catch that.
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Unhandled error in the root layout:", error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body style={{ margin: 0, background: "#09090b", color: "#d4d4d8", fontFamily: "system-ui, sans-serif" }}>
+        <div style={{ maxWidth: "34rem", margin: "0 auto", padding: "4rem 1.5rem" }}>
+          <div
+            role="alert"
+            style={{
+              border: "1px solid #27272a",
+              background: "rgba(24,24,27,0.4)",
+              borderRadius: "0.5rem",
+              padding: "1rem",
+              fontSize: "0.875rem",
+              lineHeight: 1.5,
+            }}
+          >
+            <p style={{ margin: 0, fontWeight: 600, color: "#f4f4f5" }}>
+              The app could not start
+            </p>
+            <p style={{ marginTop: "0.25rem" }}>
+              Something failed before the page could render. This is usually temporary —
+              reloading often clears it.
+            </p>
+            {error.digest !== undefined && (
+              <p style={{ marginTop: "0.5rem", fontSize: "0.75rem", color: "#71717a" }}>
+                Reference: <code>{error.digest}</code>
+              </p>
+            )}
+            <button
+              type="button"
+              onClick={reset}
+              style={{
+                marginTop: "0.75rem",
+                border: "1px solid #3f3f46",
+                background: "rgba(39,39,42,0.6)",
+                color: "#f4f4f5",
+                borderRadius: "0.375rem",
+                padding: "0.375rem 0.75rem",
+                fontSize: "0.75rem",
+                fontWeight: 500,
+                cursor: "pointer",
+              }}
+            >
+              Try again
+            </button>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
Running out of Firestore read quota took the live app to:

> Application error: a client-side exception has occurred (see the browser
> console for more information)

No indication of what failed, nothing to click, and on a production build no
stack either — the message points at the console, and the console has a
minified frame.

The cause of *that* is not the quota. **The app had no error boundary
anywhere**, so any throw React could not handle reached Next's built-in
fallback.

## The fix

- `app/error.tsx` — covers every route under `app/`.
- `app/global-error.tsx` — covers a throw in the root layout, which the first
  cannot catch, because it is not mounted until the root layout has rendered.
  It replaces the whole document, so it ships its own `<html>`/`<body>` and
  inline styles rather than assuming providers, fonts or `globals.css` survived.

`reset()` re-renders the segment without a full reload — the right first move
here, since a quota outage clears itself and so does a dropped connection.
`digest` is surfaced because on a production build it is the only handle on the
real stack.

## What this is not

**I could not reproduce the original crash, and this does not claim to fix its
cause.** Driving the app with every timeline read returning 500 — shallow path,
deep path, and with auth failing too — was handled gracefully every time,
rendering "Could not load this project's graph view. Quota exceeded." with no
`pageerror`. Checked and ruled out:

| path | behaviour |
|---|---|
| `fetchDocument` in the gateway | records the error, returns `null` |
| `loadGraphBootstrapPayloads` | catches, returns `null` |
| `loadFocusPathPayloads` | catches per segment |
| `getAuthUser` | catches, returns `null` |

So the throw is somewhere I could not reach from a dev server, most likely
production-only. That is the argument *for* a boundary rather than against one:
a boundary does not need to know which component threw, and the failure it
converts is precisely the one nobody could diagnose.

## Verification

A temporary route throwing on render produced the panel below instead of the
bare fallback, with the surrounding chrome intact and no `pageerror`:

> Something went wrong loading this page — This is usually temporary… **Try
> again** · Back to Projects

The probe is deleted. A permanent test would need a throwing route shipped in
the app; I judged that surface not worth it, but say the word and I will add
one behind a test-only flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)