### PR TITLE
Answer the audit's follow-up questions without re-reading the collection

### DIFF
--- a/apps/timeline-gstudio001/.gitignore
+++ b/apps/timeline-gstudio001/.gitignore
@@ -11,3 +11,7 @@ playwright-report/
 
 # Vite intermediate output for the MCP Apps UI; the committed artifact is lib/mcp-apps/timeline-app-html.ts
 mcp-app/dist/
+
+# Written by `npm run audit:orphans` so --offline can re-answer questions
+# without re-reading the collection. Local cache; never committed.
+.orphan-snapshot.json

--- a/apps/timeline-gstudio001/scripts/audit-orphaned-timelines.mjs
+++ b/apps/timeline-gstudio001/scripts/audit-orphaned-timelines.mjs
@@ -19,6 +19,21 @@
 //   npm run audit:orphans
 //   npm run audit:orphans -- --list          every orphan, not the top 25
 //   npm run audit:orphans -- --uid <uid>     one owner instead of all
+//   npm run audit:orphans -- --offline       re-read the last snapshot, ZERO reads
+//   npm run audit:orphans -- --assets        also: would deleting them lose anything?
+//
+// A LIVE RUN IS NOT FREE, and this is why --offline exists. Every run is a
+// full-collection `.get()` — one document read per document, ~300-400 here.
+// That is invisible at the call site and cumulative: a single review session
+// that ran this, the prune's dry run, and a few one-off analysis scripts
+// twenty-odd times exhausted the project's daily free-tier read quota, and the
+// LIVE APP went down with `RESOURCE_EXHAUSTED` for the rest of the day.
+//
+// So every live run now writes what it read to a snapshot, at no extra cost,
+// and --offline answers the same questions from that file. Every follow-up
+// question in that session — how many orphans hold media, which assets are
+// unique to them, does the arithmetic reconcile — was answerable from ONE
+// scan. Re-scanning to confirm a number you already have is the mistake.
 //
 // Reads FIREBASE_PROJECT_ID / FIREBASE_CLIENT_EMAIL / FIREBASE_PRIVATE_KEY,
 // falling back to application-default credentials — the same inputs as
@@ -36,14 +51,39 @@
 //                                    project tree, so they are reported apart
 //                                    from the rest and are probably fine.
 
+import { readFileSync, writeFileSync } from "node:fs";
 import { cert, applicationDefault, initializeApp } from "firebase-admin/app";
 import { getFirestore } from "firebase-admin/firestore";
 
 // Must track TIMELINE_COLLECTION in lib/firebase-timeline-store.ts.
 const COLLECTION = "gstudioTimelineDocuments";
 const listAll = process.argv.includes("--list");
+const offline = process.argv.includes("--offline");
+const withAssets = process.argv.includes("--assets");
 const uidIndex = process.argv.indexOf("--uid");
 const onlyUid = uidIndex === -1 ? null : process.argv[uidIndex + 1];
+const snapshotIndex = process.argv.indexOf("--snapshot");
+const SNAPSHOT_PATH =
+  snapshotIndex === -1 ? ".orphan-snapshot.json" : process.argv[snapshotIndex + 1];
+
+/**
+ * The subset of a document this audit reasons about. Deliberately NOT the raw
+ * document: the snapshot exists to be re-read many times, and the media `src`
+ * strings alone are most of the payload. Everything below is needed —
+ * `clips` for reachability and counts, `src` for the --assets cross-reference.
+ */
+function toSnapshotEntry(data) {
+  return {
+    title: data?.title ?? null,
+    ownerUid: data?.ownerUid ?? null,
+    isProject: data?.isProject === true,
+    clips: clipsOf(data).map((clip) => ({
+      kind: clip?.kind ?? null,
+      childTimelineId: clip?.childTimelineId ?? null,
+      src: clip?.src ?? clip?.assetId ?? null,
+    })),
+  };
+}
 
 function credential() {
   const projectId = process.env.FIREBASE_PROJECT_ID;
@@ -85,10 +125,42 @@ function childIdsOf(data) {
 const isTrashBin = (id) => id.startsWith("trash-");
 const isAssetLibrary = (id) => id.startsWith("asset-library");
 
-async function main() {
+/** A clip's asset identity, or null when it names none. Collection clips have
+ *  no src — they are the edges of the graph, not its payload. */
+function srcOf(clip) {
+  const value = clip?.src ?? clip?.assetId;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+/**
+ * The documents, from Firestore or from the last snapshot.
+ *
+ * A live read always writes the snapshot back. That costs nothing — the data
+ * is already in hand — and it means the NEXT question can be asked for free
+ * instead of re-reading the collection.
+ */
+async function loadDocuments() {
+  if (offline) {
+    let raw;
+    try {
+      raw = JSON.parse(readFileSync(SNAPSHOT_PATH, "utf8"));
+    } catch (error) {
+      console.error(`No usable snapshot at ${SNAPSHOT_PATH}: ${error.message}`);
+      console.error("Run the audit live once (without --offline) to create one.");
+      process.exitCode = 2;
+      return null;
+    }
+    return {
+      documents: new Map(Object.entries(raw.documents ?? {})),
+      takenAt: raw.takenAt ?? "unknown",
+      forUid: raw.forUid ?? null,
+    };
+  }
+
   initializeApp(credential());
   const db = getFirestore();
-
   const query = onlyUid
     ? db.collection(COLLECTION).where("ownerUid", "==", onlyUid)
     : db.collection(COLLECTION);
@@ -96,6 +168,39 @@ async function main() {
 
   const documents = new Map();
   snapshot.forEach((doc) => documents.set(doc.id, doc.data()));
+
+  const takenAt = new Date().toISOString();
+  try {
+    writeFileSync(
+      SNAPSHOT_PATH,
+      JSON.stringify({
+        takenAt,
+        forUid: onlyUid,
+        documents: Object.fromEntries(
+          [...documents].map(([id, data]) => [id, toSnapshotEntry(data)]),
+        ),
+      }),
+    );
+  } catch (error) {
+    // Never fail the audit over the cache.
+    console.error(`(could not write ${SNAPSHOT_PATH}: ${error.message})`);
+  }
+  return { documents, takenAt, forUid: onlyUid };
+}
+
+async function main() {
+  const loaded = await loadDocuments();
+  if (loaded === null) return;
+  const { documents, takenAt } = loaded;
+
+  if (offline) {
+    // Say it loudly. An offline run answering a question about live data is
+    // only safe if the reader knows how old the answer is — and the whole
+    // point of the mode is that it will be re-run many times.
+    console.log(`SNAPSHOT from ${takenAt} — no reads. Live state may differ.`);
+    if (loaded.forUid !== null) console.log(`snapshot covers only uid ${loaded.forUid}`);
+    console.log("");
+  }
 
   const roots = [...documents.entries()]
     .filter(([id, data]) => data?.isProject === true || isTrashBin(id))
@@ -183,6 +288,50 @@ async function main() {
   if (stranded.length === 0) {
     console.log("Every document is reachable from a project or the trash.");
     return;
+  }
+
+  // The question anyone actually has before deleting these: would it lose
+  // anything? An orphaned collection is a GROUPING, not the footage — if every
+  // asset it holds is also reachable elsewhere, binning it costs an
+  // arrangement. If not, that document is the last handle on the asset.
+  //
+  // This decided the real case: 49 unreachable documents holding 90 media
+  // clips, and ZERO assets held only by an orphan — which is what made a bulk
+  // sweep safe rather than merely plausible. Worth having in the tool that
+  // reports the orphans, instead of a throwaway script written under pressure.
+  if (withAssets) {
+    const safe = new Set();
+    for (const [id, data] of documents) {
+      if (!reachable.has(id) && !isAssetLibrary(id)) continue;
+      for (const clip of clipsOf(data)) {
+        const src = srcOf(clip);
+        if (src !== null) safe.add(src);
+      }
+    }
+    const orphanOnly = new Map();
+    for (const [id, data] of documents) {
+      if (reachable.has(id) || isAssetLibrary(id)) continue;
+      for (const clip of clipsOf(data)) {
+        if (clip?.kind === "collection") continue;
+        const src = srcOf(clip);
+        if (src !== null && !safe.has(src)) {
+          if (!orphanOnly.has(src)) orphanOnly.set(src, []);
+          orphanOnly.get(src).push(id);
+        }
+      }
+    }
+    console.log(`assets reachable elsewhere:            ${safe.size}`);
+    console.log(`DISTINCT assets held only by an orphan: ${orphanOnly.size}`);
+    if (orphanOnly.size === 0) {
+      console.log("  Deleting the orphans below would lose arrangements, not footage.");
+    } else {
+      console.log("  These have no other handle — re-file before deleting anything:");
+      for (const [src, holders] of orphanOnly) {
+        console.log(`    ${src}`);
+        console.log(`      held by ${holders.join(", ")}`);
+      }
+    }
+    console.log("");
   }
 
   console.log("Unreachable from any project root or trash bin. These are");


### PR DESCRIPTION
Every audit run is a full-collection `.get()` — one read per document, ~350
here. That cost is invisible at the call site and cumulative, and a single
review session made it expensive: the audit, the prune's dry run, and a handful
of one-off analysis scripts, run twenty-odd times between them, exhausted the
project's daily free-tier read quota. **The live app went down with
`RESOURCE_EXHAUSTED` for the rest of the day.**

Almost none of those reads were necessary. Every question after the first — how
many orphans hold media, which assets are unique to them, does the arithmetic
reconcile — was answerable from the data the first scan already had.

## `--offline`

A live run now writes what it read to `.orphan-snapshot.json` (free — the data
is already in hand), and `--offline` re-answers from that file with **zero
reads**.

An offline run announces itself on the first line with the snapshot's
timestamp:

```
SNAPSHOT from 2026-08-13T18:00:00.000Z — no reads. Live state may differ.
```

A stale answer mistaken for a live one would be worse than the cost it saves,
so that line is not optional. A missing snapshot exits 2 with an instruction
rather than a stack.

## `--assets`

Folds in what was a throwaway script written under pressure, and is the
question anyone actually has before deleting: **would this lose anything?**

An orphaned collection is a *grouping*, not the footage. If every asset it
holds is reachable elsewhere, binning it costs an arrangement. If not, that
document is the last handle on the asset. This is what made the real sweep safe
rather than merely plausible — 49 unreachable documents, 90 media clips, zero
assets held only by an orphan. It belongs in the tool that reports the orphans.

## Verification

Against a fixture snapshot exercising all five cases at once — a reachable
child, an orphan, a dangling ref, an asset library, and an asset held only by
the orphan:

| checked | result |
|---|---|
| reconciliation | 3 reachable + 1 orphan + 1 library = 5 documents |
| dangling | `ghost` excluded from reachable, reported against `project-1` |
| assets | `asset-B` flagged as having no other handle; `asset-A` safe |
| missing snapshot | exits 2 with an instruction, no stack |

**Not yet exercised:** the snapshot *write*, which needs a live scan to run. It
is wrapped so that a write failure cannot fail the audit.

Follow-up worth doing: `prune:orphans` and `bin:orphans` dry runs are also full
scans and could read the same snapshot. Left out to keep this focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)