### PR TITLE
One reachability walk, and dry runs that cost nothing

### DIFF
--- a/apps/timeline-gstudio001/scripts/audit-orphaned-timelines.mjs
+++ b/apps/timeline-gstudio001/scripts/audit-orphaned-timelines.mjs
@@ -51,186 +51,32 @@
 //                                    project tree, so they are reported apart
 //                                    from the rest and are probably fine.
 
-import { readFileSync, writeFileSync } from "node:fs";
-import { cert, applicationDefault, initializeApp } from "firebase-admin/app";
-import { getFirestore } from "firebase-admin/firestore";
+import {
+  COLLECTION,
+  announceSnapshot,
+  clipsOf,
+  childIdsOf,
+  isAssetLibrary,
+  isTrashBin,
+  loadDocuments,
+  snapshotFlags,
+  srcOf,
+  walkReachable,
+} from "./timeline-snapshot.mjs";
 
-// Must track TIMELINE_COLLECTION in lib/firebase-timeline-store.ts.
-const COLLECTION = "gstudioTimelineDocuments";
 const listAll = process.argv.includes("--list");
-const offline = process.argv.includes("--offline");
 const withAssets = process.argv.includes("--assets");
 const uidIndex = process.argv.indexOf("--uid");
 const onlyUid = uidIndex === -1 ? null : process.argv[uidIndex + 1];
-const snapshotIndex = process.argv.indexOf("--snapshot");
-const SNAPSHOT_PATH =
-  snapshotIndex === -1 ? ".orphan-snapshot.json" : process.argv[snapshotIndex + 1];
-
-/**
- * The subset of a document this audit reasons about. Deliberately NOT the raw
- * document: the snapshot exists to be re-read many times, and the media `src`
- * strings alone are most of the payload. Everything below is needed —
- * `clips` for reachability and counts, `src` for the --assets cross-reference.
- */
-function toSnapshotEntry(data) {
-  return {
-    title: data?.title ?? null,
-    ownerUid: data?.ownerUid ?? null,
-    isProject: data?.isProject === true,
-    clips: clipsOf(data).map((clip) => ({
-      kind: clip?.kind ?? null,
-      childTimelineId: clip?.childTimelineId ?? null,
-      src: clip?.src ?? clip?.assetId ?? null,
-    })),
-  };
-}
-
-function credential() {
-  const projectId = process.env.FIREBASE_PROJECT_ID;
-  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
-  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n");
-
-  if (clientEmail && privateKey) {
-    return { credential: cert({ projectId, clientEmail, privateKey }), projectId };
-  }
-  return { credential: applicationDefault(), projectId };
-}
-
-/**
- * The stored clips, from whichever field carries them.
- *
- * `document.clips` is the live copy and `clips` the denormalized one; they
- * agree in practice, but a record written by an older path may only have the
- * latter. `lastNonEmptyDocument` is deliberately NOT consulted — it is a
- * recovery snapshot of content that has since been removed, and treating it as
- * a reference would report a genuinely emptied parent as still holding its
- * children.
- */
-function clipsOf(data) {
-  if (Array.isArray(data?.document?.clips)) return data.document.clips;
-  if (Array.isArray(data?.clips)) return data.clips;
-  return [];
-}
-
-function childIdsOf(data) {
-  const ids = [];
-  for (const clip of clipsOf(data)) {
-    if (clip?.kind !== "collection") continue;
-    if (typeof clip.childTimelineId !== "string") continue;
-    ids.push(clip.childTimelineId);
-  }
-  return ids;
-}
-
-const isTrashBin = (id) => id.startsWith("trash-");
-const isAssetLibrary = (id) => id.startsWith("asset-library");
-
-/** A clip's asset identity, or null when it names none. Collection clips have
- *  no src — they are the edges of the graph, not its payload. */
-function srcOf(clip) {
-  const value = clip?.src ?? clip?.assetId;
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  return trimmed === "" ? null : trimmed;
-}
-
-/**
- * The documents, from Firestore or from the last snapshot.
- *
- * A live read always writes the snapshot back. That costs nothing — the data
- * is already in hand — and it means the NEXT question can be asked for free
- * instead of re-reading the collection.
- */
-async function loadDocuments() {
-  if (offline) {
-    let raw;
-    try {
-      raw = JSON.parse(readFileSync(SNAPSHOT_PATH, "utf8"));
-    } catch (error) {
-      console.error(`No usable snapshot at ${SNAPSHOT_PATH}: ${error.message}`);
-      console.error("Run the audit live once (without --offline) to create one.");
-      process.exitCode = 2;
-      return null;
-    }
-    return {
-      documents: new Map(Object.entries(raw.documents ?? {})),
-      takenAt: raw.takenAt ?? "unknown",
-      forUid: raw.forUid ?? null,
-    };
-  }
-
-  initializeApp(credential());
-  const db = getFirestore();
-  const query = onlyUid
-    ? db.collection(COLLECTION).where("ownerUid", "==", onlyUid)
-    : db.collection(COLLECTION);
-  const snapshot = await query.get();
-
-  const documents = new Map();
-  snapshot.forEach((doc) => documents.set(doc.id, doc.data()));
-
-  const takenAt = new Date().toISOString();
-  try {
-    writeFileSync(
-      SNAPSHOT_PATH,
-      JSON.stringify({
-        takenAt,
-        forUid: onlyUid,
-        documents: Object.fromEntries(
-          [...documents].map(([id, data]) => [id, toSnapshotEntry(data)]),
-        ),
-      }),
-    );
-  } catch (error) {
-    // Never fail the audit over the cache.
-    console.error(`(could not write ${SNAPSHOT_PATH}: ${error.message})`);
-  }
-  return { documents, takenAt, forUid: onlyUid };
-}
+const { offline, snapshotPath } = snapshotFlags();
 
 async function main() {
-  const loaded = await loadDocuments();
+  const loaded = await loadDocuments({ offline, snapshotPath, onlyUid });
   if (loaded === null) return;
-  const { documents, takenAt } = loaded;
+  const { documents } = loaded;
+  announceSnapshot(loaded);
 
-  if (offline) {
-    // Say it loudly. An offline run answering a question about live data is
-    // only safe if the reader knows how old the answer is — and the whole
-    // point of the mode is that it will be re-run many times.
-    console.log(`SNAPSHOT from ${takenAt} — no reads. Live state may differ.`);
-    if (loaded.forUid !== null) console.log(`snapshot covers only uid ${loaded.forUid}`);
-    console.log("");
-  }
-
-  const roots = [...documents.entries()]
-    .filter(([id, data]) => data?.isProject === true || isTrashBin(id))
-    .map(([id]) => id);
-
-  // Breadth-first from every root. A child appearing under two parents is
-  // legal (duplicate-reference cards), so `seen` is what keeps this linear and
-  // cycle-proof rather than a tree walk.
-  //
-  // A childTimelineId can name a document that does not exist — the mirror
-  // image of an orphan, and just as invisible: the parent shows a collection
-  // card that opens onto nothing. Those ids are recorded separately and kept
-  // OUT of `reachable`, which otherwise counts them and reports more reachable
-  // documents than the collection contains.
-  const reachable = new Set();
-  const dangling = new Map();
-  const queue = [...roots];
-  while (queue.length > 0) {
-    const id = queue.shift();
-    if (reachable.has(id)) continue;
-    reachable.add(id);
-    for (const childId of childIdsOf(documents.get(id))) {
-      if (!documents.has(childId)) {
-        if (!dangling.has(childId)) dangling.set(childId, []);
-        dangling.get(childId).push(id);
-        continue;
-      }
-      if (!reachable.has(childId)) queue.push(childId);
-    }
-  }
+  const { roots, reachable, dangling } = walkReachable(documents);
 
   const orphans = [];
   for (const [id, data] of documents) {

--- a/apps/timeline-gstudio001/scripts/bin-unreachable-timelines.mjs
+++ b/apps/timeline-gstudio001/scripts/bin-unreachable-timelines.mjs
@@ -34,36 +34,22 @@
 //   they are addressed directly rather than through a project tree, so the
 //   walk cannot see them and they are not orphans.
 
-import { cert, applicationDefault, initializeApp } from "firebase-admin/app";
 import { getFirestore, FieldValue } from "firebase-admin/firestore";
 
 import { dryRunNotice, readApplyFlag } from "./apply-flag.mjs";
+import {
+  COLLECTION,
+  announceSnapshot,
+  clipsOf,
+  childIdsOf,
+  loadDocuments,
+  refuseOfflineWrite,
+  snapshotFlags,
+  walkReachable,
+} from "./timeline-snapshot.mjs";
 
-// Must track TIMELINE_COLLECTION in lib/firebase-timeline-store.ts.
-const COLLECTION = "gstudioTimelineDocuments";
 const apply = readApplyFlag("bin:orphans", "BIN_APPLY");
-
-function credential() {
-  const projectId = process.env.FIREBASE_PROJECT_ID;
-  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
-  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n");
-  if (clientEmail && privateKey) {
-    return { credential: cert({ projectId, clientEmail, privateKey }), projectId };
-  }
-  return { credential: applicationDefault(), projectId };
-}
-
-const clipsOf = (data) =>
-  Array.isArray(data?.document?.clips)
-    ? data.document.clips
-    : Array.isArray(data?.clips)
-      ? data.clips
-      : [];
-
-const childIdsOf = (data) =>
-  clipsOf(data)
-    .filter((clip) => clip?.kind === "collection" && typeof clip.childTimelineId === "string")
-    .map((clip) => clip.childTimelineId);
+const { offline, snapshotPath } = snapshotFlags();
 
 /** A collection clip in the shape the app stores, so a filed document is
  *  indistinguishable from one binned through the UI. `id === childTimelineId`
@@ -100,25 +86,14 @@ function collectionClip(id, data, index, startTime) {
 }
 
 async function main() {
-  initializeApp(credential());
-  const db = getFirestore();
+  if (refuseOfflineWrite({ offline, apply, script: "bin:orphans" })) return;
 
-  const snapshot = await db.collection(COLLECTION).get();
-  const documents = new Map();
-  snapshot.forEach((doc) => documents.set(doc.id, doc.data()));
+  const loaded = await loadDocuments({ offline, snapshotPath });
+  if (loaded === null) return;
+  const { documents } = loaded;
+  announceSnapshot(loaded);
 
-  const reachable = new Set();
-  const queue = [...documents.entries()]
-    .filter(([id, data]) => data?.isProject === true || id.startsWith("trash-"))
-    .map(([id]) => id);
-  while (queue.length > 0) {
-    const id = queue.shift();
-    if (reachable.has(id)) continue;
-    reachable.add(id);
-    for (const childId of childIdsOf(documents.get(id))) {
-      if (!reachable.has(childId)) queue.push(childId);
-    }
-  }
+  const { reachable } = walkReachable(documents);
 
   // Group by owner: each owner's orphans go to that owner's bin, never a
   // shared one.
@@ -189,6 +164,10 @@ async function main() {
     console.log(dryRunNotice("bin:orphans", "BIN_APPLY", "file"));
     return;
   }
+
+  // Live only — refuseOfflineWrite above guarantees it, so the app is
+  // initialized and this handle is safe to take.
+  const db = getFirestore();
 
   for (const plan of plans) {
     if (plan.additions.length === 0) continue;

--- a/apps/timeline-gstudio001/scripts/prune-empty-orphans.mjs
+++ b/apps/timeline-gstudio001/scripts/prune-empty-orphans.mjs
@@ -9,8 +9,14 @@
 // obviously-nothing and leaves a list a person can actually read.
 //
 //   npm run prune:orphans                  # dry run
+//   npm run prune:orphans -- --offline     # dry run from the last snapshot, ZERO reads
 //   npm run prune:orphans -- --apply       # delete (note the bare -- separator)
 //   PRUNE_APPLY=1 npm run prune:orphans    # delete, in a form npm cannot swallow
+//
+// A dry run reading the whole collection to tell you what it WOULD do is the
+// clearest case of a read that need not be live: --offline answers from the
+// snapshot the last live run wrote. --offline with --apply is REFUSED — see
+// refuseOfflineWrite in timeline-snapshot.mjs.
 //
 // `npm run prune:orphans --apply` WITHOUT the separator is discarded by npm
 // before the script runs — see scripts/apply-flag.mjs.
@@ -36,61 +42,36 @@
 // move the mess. Anything with content goes to review instead — see the list
 // this prints under KEEPING.
 
-import { cert, applicationDefault, initializeApp } from "firebase-admin/app";
 import { getFirestore } from "firebase-admin/firestore";
 
 import { dryRunNotice, readApplyFlag } from "./apply-flag.mjs";
+import {
+  COLLECTION,
+  announceSnapshot,
+  clipsOf,
+  childIdsOf,
+  loadDocuments,
+  refuseOfflineWrite,
+  snapshotFlags,
+  walkReachable,
+} from "./timeline-snapshot.mjs";
 
-// Must track TIMELINE_COLLECTION in lib/firebase-timeline-store.ts.
-const COLLECTION = "gstudioTimelineDocuments";
 const apply = readApplyFlag("prune:orphans", "PRUNE_APPLY");
+const { offline, snapshotPath } = snapshotFlags();
 
 /** Titles that mean "made by a button, never used". Only ever consulted for a
  *  document already proven to hold nothing. */
 const SCRATCH_TITLE = /^(new collection|new timeline|untitled|\(untitled\))$/i;
 
-function credential() {
-  const projectId = process.env.FIREBASE_PROJECT_ID;
-  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
-  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n");
-  if (clientEmail && privateKey) {
-    return { credential: cert({ projectId, clientEmail, privateKey }), projectId };
-  }
-  return { credential: applicationDefault(), projectId };
-}
-
-function clipsOf(data) {
-  if (Array.isArray(data?.document?.clips)) return data.document.clips;
-  if (Array.isArray(data?.clips)) return data.clips;
-  return [];
-}
-
-function childIdsOf(data) {
-  return clipsOf(data)
-    .filter((clip) => clip?.kind === "collection" && typeof clip.childTimelineId === "string")
-    .map((clip) => clip.childTimelineId);
-}
-
 async function main() {
-  initializeApp(credential());
-  const db = getFirestore();
+  if (refuseOfflineWrite({ offline, apply, script: "prune:orphans" })) return;
 
-  const snapshot = await db.collection(COLLECTION).get();
-  const documents = new Map();
-  snapshot.forEach((doc) => documents.set(doc.id, doc.data()));
+  const loaded = await loadDocuments({ offline, snapshotPath });
+  if (loaded === null) return;
+  const { documents } = loaded;
+  announceSnapshot(loaded);
 
-  const reachable = new Set();
-  const queue = [...documents.entries()]
-    .filter(([id, data]) => data?.isProject === true || id.startsWith("trash-"))
-    .map(([id]) => id);
-  while (queue.length > 0) {
-    const id = queue.shift();
-    if (reachable.has(id)) continue;
-    reachable.add(id);
-    for (const childId of childIdsOf(documents.get(id))) {
-      if (!reachable.has(childId)) queue.push(childId);
-    }
-  }
+  const { reachable } = walkReachable(documents);
 
   const deletable = [];
   const keeping = [];
@@ -142,6 +123,10 @@ async function main() {
     console.log(dryRunNotice("prune:orphans", "PRUNE_APPLY"));
     return;
   }
+
+  // Live only — refuseOfflineWrite above guarantees it, so the app is
+  // initialized and this handle is safe to take.
+  const db = getFirestore();
 
   // Firestore caps a batch at 500 writes; chunk well under it.
   const CHUNK = 200;

--- a/apps/timeline-gstudio001/scripts/timeline-snapshot.mjs
+++ b/apps/timeline-gstudio001/scripts/timeline-snapshot.mjs
@@ -1,0 +1,240 @@
+// Shared plumbing for the three timeline scripts: audit:orphans,
+// prune:orphans and bin:orphans.
+//
+// WHY THIS EXISTS. All three begin the same way — read every document in the
+// collection, walk reachability from the project roots and the trash — and all
+// three had their own copy of that code. Three copies is three chances for the
+// walks to disagree about what "reachable" means, which is exactly the
+// disagreement that would make one script delete what another considers live.
+//
+// And all three paid the same cost. A full-collection `.get()` is one read per
+// document, ~350 here, invisible at the call site. The audit, the prune's dry
+// run, and a few one-off scripts, run twenty-odd times in one review session,
+// exhausted the project's daily free-tier read quota and took the live app
+// down with RESOURCE_EXHAUSTED for the remainder of the day. A dry run reading
+// the whole collection to tell you what it WOULD do is the clearest case of a
+// read that did not need to be live.
+//
+// So: one walk, one snapshot, and an --offline mode any of them can use.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { cert, applicationDefault, initializeApp } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+
+/** Must track TIMELINE_COLLECTION in lib/firebase-timeline-store.ts. */
+export const COLLECTION = "gstudioTimelineDocuments";
+
+export const isTrashBin = (id) => id.startsWith("trash-");
+export const isAssetLibrary = (id) => id.startsWith("asset-library");
+
+/**
+ * The stored clips, from whichever field carries them.
+ *
+ * `document.clips` is the live copy and `clips` the denormalized one; they
+ * agree in practice, but a record written by an older path may only have the
+ * latter. A snapshot entry stores its clips flat, so the same fallback reads
+ * both shapes and callers never care which they hold.
+ *
+ * `lastNonEmptyDocument` is deliberately NOT consulted — it is a recovery
+ * snapshot of content since removed, and treating it as a reference would
+ * report a genuinely emptied parent as still holding its children.
+ */
+export function clipsOf(data) {
+  if (Array.isArray(data?.document?.clips)) return data.document.clips;
+  if (Array.isArray(data?.clips)) return data.clips;
+  return [];
+}
+
+export function childIdsOf(data) {
+  const ids = [];
+  for (const clip of clipsOf(data)) {
+    if (clip?.kind !== "collection") continue;
+    if (typeof clip.childTimelineId !== "string") continue;
+    ids.push(clip.childTimelineId);
+  }
+  return ids;
+}
+
+/** A clip's asset identity, or null when it names none. Collection clips have
+ *  no src — they are the edges of the graph, not its payload. */
+export function srcOf(clip) {
+  const value = clip?.src ?? clip?.assetId;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+/**
+ * Breadth-first from every root. A child appearing under two parents is legal
+ * (duplicate-reference cards), so `seen` is what keeps this linear and
+ * cycle-proof rather than a tree walk.
+ *
+ * A childTimelineId can name a document that does not exist — the mirror image
+ * of an orphan, and just as invisible: the parent shows a collection card that
+ * opens onto nothing. Those ids are recorded separately and kept OUT of
+ * `reachable`, which otherwise reports more reachable documents than the
+ * collection contains.
+ *
+ * WHAT COUNTS AS A ROOT, and why the answer depends on it:
+ *   projects (`isProject === true`)  the real entry points.
+ *   trash bins (`trash-<uid>`)       a trashed item is reachable and
+ *                                    restorable BY DESIGN, so its subtree is
+ *                                    not orphaned. Counting the bin as a root
+ *                                    keeps "in the bin" separate from "lost".
+ */
+export function walkReachable(documents) {
+  const roots = [...documents.entries()]
+    .filter(([id, data]) => data?.isProject === true || isTrashBin(id))
+    .map(([id]) => id);
+
+  const reachable = new Set();
+  const dangling = new Map();
+  const queue = [...roots];
+  while (queue.length > 0) {
+    const id = queue.shift();
+    if (reachable.has(id)) continue;
+    reachable.add(id);
+    for (const childId of childIdsOf(documents.get(id))) {
+      if (!documents.has(childId)) {
+        if (!dangling.has(childId)) dangling.set(childId, []);
+        dangling.get(childId).push(id);
+        continue;
+      }
+      if (!reachable.has(childId)) queue.push(childId);
+    }
+  }
+  return { roots, reachable, dangling };
+}
+
+function credential() {
+  const projectId = process.env.FIREBASE_PROJECT_ID;
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n");
+  if (clientEmail && privateKey) {
+    return { credential: cert({ projectId, clientEmail, privateKey }), projectId };
+  }
+  return { credential: applicationDefault(), projectId };
+}
+
+/** The `--offline` / `--snapshot <path>` pair, read the same way everywhere. */
+export function snapshotFlags(argv = process.argv) {
+  const index = argv.indexOf("--snapshot");
+  return {
+    offline: argv.includes("--offline"),
+    snapshotPath: index === -1 ? ".orphan-snapshot.json" : argv[index + 1],
+  };
+}
+
+/**
+ * The subset of a document these scripts reason about. Deliberately NOT the
+ * raw document: the snapshot exists to be re-read many times, and the media
+ * `src` strings alone are most of the payload.
+ */
+function toSnapshotEntry(data) {
+  return {
+    title: data?.title ?? null,
+    ownerUid: data?.ownerUid ?? null,
+    isProject: data?.isProject === true,
+    revision: typeof data?.revision === "number" ? data.revision : null,
+    clips: clipsOf(data).map((clip) => ({
+      kind: clip?.kind ?? null,
+      childTimelineId: clip?.childTimelineId ?? null,
+      src: srcOf(clip),
+      duration: typeof clip?.duration === "number" ? clip.duration : null,
+    })),
+  };
+}
+
+/**
+ * The documents, from Firestore or from the last snapshot.
+ *
+ * A live read always writes the snapshot back. That costs nothing — the data
+ * is already in hand — and it means the NEXT question can be asked for free
+ * instead of re-reading the collection.
+ *
+ * Returns null (having printed why, and set a non-zero exit code) when
+ * --offline is asked for and no snapshot exists.
+ */
+export async function loadDocuments({ offline, snapshotPath, onlyUid = null }) {
+  if (offline) {
+    let raw;
+    try {
+      raw = JSON.parse(readFileSync(snapshotPath, "utf8"));
+    } catch (error) {
+      console.error(`No usable snapshot at ${snapshotPath}: ${error.message}`);
+      console.error("Run it live once (without --offline) to create one.");
+      process.exitCode = 2;
+      return null;
+    }
+    return {
+      documents: new Map(Object.entries(raw.documents ?? {})),
+      takenAt: raw.takenAt ?? "unknown",
+      forUid: raw.forUid ?? null,
+      live: false,
+    };
+  }
+
+  initializeApp(credential());
+  const db = getFirestore();
+  const query = onlyUid
+    ? db.collection(COLLECTION).where("ownerUid", "==", onlyUid)
+    : db.collection(COLLECTION);
+  const snapshot = await query.get();
+
+  const documents = new Map();
+  snapshot.forEach((doc) => documents.set(doc.id, doc.data()));
+
+  const takenAt = new Date().toISOString();
+  try {
+    writeFileSync(
+      snapshotPath,
+      JSON.stringify({
+        takenAt,
+        forUid: onlyUid,
+        documents: Object.fromEntries(
+          [...documents].map(([id, data]) => [id, toSnapshotEntry(data)]),
+        ),
+      }),
+    );
+  } catch (error) {
+    // Never fail over the cache.
+    console.error(`(could not write ${snapshotPath}: ${error.message})`);
+  }
+  return { documents, takenAt, forUid: onlyUid, live: true };
+}
+
+/**
+ * The line an offline run leads with. A stale answer presented as a live one
+ * would be worse than the reads it saves, so this is not optional — and it
+ * carries the timestamp, because "how old" is the only thing that decides
+ * whether the answer can be acted on.
+ */
+export function announceSnapshot(loaded) {
+  if (loaded.live) return;
+  console.log(`SNAPSHOT from ${loaded.takenAt} — no reads. Live state may differ.`);
+  if (loaded.forUid !== null) console.log(`snapshot covers only uid ${loaded.forUid}`);
+  console.log("");
+}
+
+/**
+ * Refuse to WRITE from a snapshot.
+ *
+ * The whole value of --offline is that the data is old, and every one of these
+ * scripts decides what to destroy from exactly the data it just read. Applying
+ * a delete computed from a stale snapshot would act on a graph that has since
+ * changed — deleting something re-filed in the meantime, or missing something
+ * newly orphaned. Reading stale is a saving; writing stale is a bug with the
+ * same shape as the accident these scripts exist to clean up after.
+ */
+export function refuseOfflineWrite({ offline, apply, script }) {
+  if (!offline || !apply) return false;
+  console.error("REFUSING: --offline is for dry runs only.");
+  console.error("");
+  console.error(`--apply decides what to change from the data it just read, and a`);
+  console.error(`snapshot is by definition out of date. Acting on one could touch a`);
+  console.error(`document that has been re-filed since, or miss one newly orphaned.`);
+  console.error("");
+  console.error(`Run \`npm run ${script} -- --apply\` against live data instead.`);
+  process.exitCode = 2;
+  return true;
+}


### PR DESCRIPTION
Stacked on #364 — review that first.

The prune and bin **dry runs** were still full-collection reads: ~350 document
reads each, to tell you what they *would* do. That is the clearest case of a
read that need not be live, and together with the audit it is what exhausted
the daily quota and took the live app down.

Both now take `--offline` and answer from the snapshot the last live run wrote.

## `--offline` with `--apply` is refused

This guard is the point of the change, not a detail.

`--offline` is valuable *precisely because* the data is old — and `--apply`
decides what to destroy from exactly the data it just read. A delete computed
from a stale snapshot would act on a graph that has since moved: removing
something re-filed in the meantime, or missing something newly orphaned.
Reading stale saves quota; writing stale is a bug with the same shape as the
accident these scripts exist to clean up after.

```
REFUSING: --offline is for dry runs only.

--apply decides what to change from the data it just read, and a
snapshot is by definition out of date. Acting on one could touch a
document that has been re-filed since, or miss one newly orphaned.

Run `npm run prune:orphans -- --apply` against live data instead.
```

Exits 2, and names the live command.

## One walk instead of three

The shared parts moved to `scripts/timeline-snapshot.mjs`. All three scripts
had their **own** copy of the reachability walk, `clipsOf`, `childIdsOf` and
`credential` — three chances to disagree about what "reachable" means, which is
exactly the disagreement that would have one script delete what another
considers live.

That was not hypothetical. The dangling-reference fix from #361 existed in only
one of the three copies, so prune and bin were still counting documents that do
not exist as reachable.

## Verification

Against a fixture snapshot (reachable child, orphan with media, empty
scratch-named orphan, dangling ref, asset library, orphan-only asset):

| | result |
|---|---|
| audit `--offline --assets --list` | **byte-identical** to pre-refactor output |
| prune `--offline` | 1 deletable, 1 keeping |
| bin `--offline` | plans 2, "NOTHING WAS FILED" |
| prune `--offline --apply` | refused, exit 2 |
| bin `--offline --apply` | refused, exit 2 |

All four files pass `node --check`. The live read/write paths are unchanged and
still need a real scan to exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)