### PR TITLE
Close the way around the orphan guard

### DIFF
--- a/apps/timeline-gstudio001/app/api/timelines/[id]/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/[id]/route.ts
@@ -4,6 +4,7 @@ import type { TimelineClip } from "@storyboard/timeline-model/types";
 import {
   saveFirebaseTimelineEntry,
   deleteFirebaseTimelineDocument,
+  TimelineOrphanError,
 } from "@/lib/firebase-timeline-store";
 import { requireAuthUser } from "@/lib/firebase-auth-session";
 import { readJsonObject } from "@/lib/read-json-body";
@@ -145,6 +146,17 @@ export async function PATCH(
     const saved = await saveFirebaseTimelineEntry(body.document, user.uid);
     return NextResponse.json({ document: saved.document, revision: saved.revision });
   } catch (error) {
+    // Same shape the batch endpoint answers with, so a caller handling one
+    // handles both: 409, the message, and WHICH documents would have been
+    // stranded. The ids are the point — without them the client knows only
+    // that it was refused, not what it nearly lost.
+    if (error instanceof TimelineOrphanError) {
+      return NextResponse.json(
+        { error: error.message, orphans: error.orphans },
+        { status: 409 },
+      );
+    }
+
     if (
       error instanceof Error &&
       error.message.startsWith("Refusing to save an empty timeline")

--- a/apps/timeline-gstudio001/app/api/timelines/timelines-batch.test.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/timelines-batch.test.ts
@@ -513,6 +513,88 @@ describe("timeline batch writes", () => {
     expect(response.status).toBe(200);
   });
 
+  // ── THE SAME GUARD ON THE SINGLE-DOCUMENT PATH ────────────────────────────
+  //
+  // PATCH /api/timelines/[id] goes through saveFirebaseTimelineEntry, NOT the
+  // atomic batch write, and so had no orphan guard at all: the batch endpoint
+  // refused a write that dropped a collection's last parent, and this route
+  // took the same write and committed it. Nothing in the app sends PATCH
+  // today, but an open endpoint that can silently strand a document is the
+  // hole whether or not the app uses it.
+  //
+  // THE PARENT KEEPS A MEDIA CLIP in these. Emptying it would trip "Refusing
+  // to save an empty timeline" first — PATCH passes no allowEmptying — and the
+  // test would go green on the wrong 409 without the guard existing at all.
+  // Leaving one clip behind means only the orphan guard can reject this.
+  function seedParentWithChildAndMedia(parentId: string, childId: string) {
+    const parent: TimelineDocument = {
+      id: parentId,
+      title: `Timeline ${parentId}`,
+      clips: [collectionClip(childId), clip("keeper")],
+    };
+    state.docs.set(parentId, {
+      id: parentId, title: parent.title, document: parent, clips: parent.clips,
+      isProject: true, ownerUid: "user-a", revision: 1,
+    });
+  }
+
+  const patchWith = (id: string, document: TimelineDocument) =>
+    patchTimeline(
+      new Request(`http://test.local/api/timelines/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document }),
+      }),
+      params(id),
+    );
+
+  it("PATCH REFUSES a write that removes a collection nothing else takes up", async () => {
+    seedParentWithChildAndMedia("parent-1", "child-1");
+    state.docs.set("child-1", {
+      id: "child-1", title: "Timeline child-1", document: { id: "child-1", title: "Timeline child-1", clips: [clip("c0")] },
+      clips: [clip("c0")], isProject: false, ownerUid: "user-a", revision: 1,
+    });
+
+    const response = await patchWith("parent-1", {
+      id: "parent-1", title: "Timeline parent-1", clips: [clip("keeper")],
+    });
+
+    expect(response.status).toBe(409);
+    const body = (await response.json()) as { error: string; orphans?: { id: string }[] };
+    expect(body.error).toContain("Refusing to strand");
+    expect(body.orphans?.map((orphan) => orphan.id)).toEqual(["child-1"]);
+    // Nothing committed: the parent still points at it, at its original revision.
+    expect((state.docs.get("parent-1")?.clips as TimelineClip[]).length).toBe(2);
+    expect(state.docs.get("parent-1")?.revision).toBe(1);
+  });
+
+  it("PATCH ALLOWS a write that keeps the collection", async () => {
+    seedParentWithChildAndMedia("parent-1", "child-1");
+    state.docs.set("child-1", {
+      id: "child-1", title: "Timeline child-1", document: { id: "child-1", title: "Timeline child-1", clips: [clip("c0")] },
+      clips: [clip("c0")], isProject: false, ownerUid: "user-a", revision: 1,
+    });
+
+    const response = await patchWith("parent-1", {
+      id: "parent-1", title: "Renamed", clips: [collectionClip("child-1"), clip("keeper")],
+    });
+
+    expect(response.status).toBe(200);
+    expect(state.docs.get("parent-1")?.revision).toBe(2);
+  });
+
+  it("PATCH ALLOWS tidying a DANGLING reference to a child that does not exist", async () => {
+    seedParentWithChildAndMedia("parent-1", "ghost-child");
+
+    const response = await patchWith("parent-1", {
+      id: "parent-1", title: "Timeline parent-1", clips: [clip("keeper")],
+    });
+
+    // A repair, not a loss — there was never a document to strand.
+    expect(response.status).toBe(200);
+    expect(state.docs.get("parent-1")?.revision).toBe(2);
+  });
+
   it("rejects a batch that repeats a timeline id", async () => {
     seedTimeline("doc-1", "user-a", 1);
     const response = await batchWrite(

--- a/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
@@ -582,6 +582,45 @@ export async function saveFirebaseTimelineEntry(
         );
       }
 
+      // ORPHAN GUARD. The same rule `saveFirebaseTimelineDocumentsAtomic`
+      // enforces, applied to what is simply a batch of one.
+      //
+      // This path had none, which made it the way around the invariant: the
+      // batch endpoint refuses a write that drops a collection's last parent,
+      // and PATCH on this route would take exactly that write and commit it.
+      // Nothing in the app sends PATCH today — the graph view writes through
+      // the batch endpoint — but "no caller right now" is not a guarantee, and
+      // an open endpoint that can silently strand a document is the same hole
+      // whether or not the app happens to use it.
+      //
+      // "Released and unclaimed" means unreachable ONLY because an owning
+      // placement is unique (`clip.id === clip.childTimelineId`); a duplicate
+      // reference card is minted with its own clip id and so never counts as
+      // owning. That asymmetry is what makes this answerable without a reverse
+      // index. With one document there is nothing else to claim what it drops,
+      // so any owning child it releases is released for good.
+      if (existingDocument) {
+        const claimed = new Set(owningCollectionChildIds(normalizedDocument));
+        const released = owningCollectionChildIds(existingDocument).filter(
+          (childId) => !claimed.has(childId),
+        );
+        if (released.length > 0) {
+          // Reads, so they must happen before the `tx.set` below. Normally
+          // zero — a save that removes no collection never gets here.
+          const snapshots = await Promise.all(
+            released.map((childId) => tx.get(collection().doc(childId))),
+          );
+          // Already gone, or never there: a dangling reference being tidied
+          // up, which is a repair rather than a loss.
+          const stranded = released.filter((_childId, index) => snapshots[index].exists);
+          if (stranded.length > 0) {
+            throw new TimelineOrphanError(
+              stranded.map((id) => ({ id, fromTimelineId: normalizedDocument.id })),
+            );
+          }
+        }
+      }
+
       const next = (existingData?.revision ?? 0) + 1;
       tx.set(
         ref,


### PR DESCRIPTION
The batch endpoint refuses a write that drops a collection's last parent.
`PATCH /api/timelines/[id]` took the same write and **committed it** — it goes
through `saveFirebaseTimelineEntry`, not the atomic batch write, and that
function had no orphan guard at all.

Proven, not inferred: with the guard removed, the new test gets a **200** back
and the child is stranded.

## Nothing calls PATCH — that is not a reason to leave it

The graph view writes through the batch endpoint; a search for callers turns up
only tests. But an invariant with an open endpoint around it is not an
invariant, and "no caller right now" is a fact about this week, not a property
of the route.

## The rule

The batch rule applied to what is simply a batch of one. An owning child the
stored document holds and the incoming one does not is *released*, and with a
single document there is nothing else in the write to take it up.

It refuses only for children that still **exist** — a reference to a document
already gone is a dangling reference being tidied, which is a repair. Both
reads happen before the write, as a Firestore transaction requires.

"Released and unclaimed" means unreachable *only* because an owning placement
is unique (`clip.id === clip.childTimelineId`); a duplicate reference card
carries its own clip id and never counts as owning. That asymmetry is what
makes this answerable without a reverse index.

The route answers 409 with the same body the batch route uses — message plus
the ids that would have been stranded — so a caller handling one handles both.

## The test had to be built around a trap

PATCH passes no `allowEmptying`, so a parent emptied by the write trips
**"Refusing to save an empty timeline" first**. A test written the obvious way
goes green on the wrong 409 — and would pass with no orphan guard in the
codebase at all.

So the parent keeps a media clip, leaving the orphan guard as the only thing
that can reject it. The without-guard run then fails with `expected 200 to be
409`, not a different 409, which is what makes it proof.

| case | expected |
|---|---|
| PATCH drops a collection nothing takes up | 409, `orphans: ["child-1"]`, nothing committed, revision still 1 |
| PATCH keeps the collection | 200, revision 2 |
| PATCH drops a reference to a child that does not exist | 200 — a repair |

736 app tests pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)