### PR TITLE
Declare the index the change log has always needed

### DIFF
--- a/apps/timeline-gstudio001/firestore.indexes.json
+++ b/apps/timeline-gstudio001/firestore.indexes.json
@@ -14,7 +14,18 @@
     "",
     "The updatedAt ordering matches the JS sort listFirebaseTimelineProjects",
     "already applies, so switching to a server-side sort is a one-line change",
-    "once this is deployed."
+    "once this is deployed.",
+    "",
+    "timelineChanges: recentChanges() filters timelineIds with array-contains",
+    "AND orders by `at`. That combination REQUIRES a composite index — it is",
+    "not merge-joinable — so without this the query throws FAILED_PRECONDITION",
+    "every time. The log has been written faithfully for weeks and the one",
+    "helper built to read it could never run.",
+    "",
+    "The alternative, sorting client-side, was rejected: dropping the orderBy",
+    "means reading EVERY entry that ever touched the timeline just to find the",
+    "newest few, and that read grows without bound as the log does. Unbounded",
+    "reads are what exhausted this project's daily quota once already."
   ],
   "indexes": [
     {
@@ -24,6 +35,14 @@
         { "fieldPath": "ownerUid", "order": "ASCENDING" },
         { "fieldPath": "isProject", "order": "ASCENDING" },
         { "fieldPath": "updatedAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "timelineChanges",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "timelineIds", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "at", "order": "DESCENDING" }
       ]
     }
   ],

--- a/apps/timeline-gstudio001/lib/change-log.test.ts
+++ b/apps/timeline-gstudio001/lib/change-log.test.ts
@@ -13,6 +13,39 @@ type Stored = Record<string, unknown>;
 const state = vi.hoisted(() => {
   const added: Stored[] = [];
   let addThrows = false;
+  let queryThrows: Error | null = null;
+  let queryResult: Stored[] = [];
+  const queryCalls: { where?: unknown[]; orderBy?: unknown[]; limit?: number }[] = [];
+
+  const query = () => {
+    // Records the chain so a test can assert the query SHAPE — the shape is
+    // what the composite index has to match, and a mismatch there is exactly
+    // the failure this suite exists for. Recorded on `where`, not here: every
+    // recordChange call goes through collection() too, and counting those
+    // would leave the read assertions reading someone else's writes.
+    const call: { where?: unknown[]; orderBy?: unknown[]; limit?: number } = {};
+    const chain = {
+      where: (...args: unknown[]) => {
+        call.where = args;
+        queryCalls.push(call);
+        return chain;
+      },
+      orderBy: (...args: unknown[]) => {
+        call.orderBy = args;
+        return chain;
+      },
+      limit: (value: number) => {
+        call.limit = value;
+        return chain;
+      },
+      get: async () => {
+        if (queryThrows) throw queryThrows;
+        return { docs: queryResult.map((data) => ({ data: () => data })) };
+      },
+    };
+    return chain;
+  };
+
   const db = {
     collection: () => ({
       add: async (data: Stored) => {
@@ -20,13 +53,21 @@ const state = vi.hoisted(() => {
         added.push(data);
         return { id: `entry-${added.length}` };
       },
+      ...query(),
     }),
   };
   return {
     added,
     db,
+    queryCalls,
     setAddThrows: (value: boolean) => {
       addThrows = value;
+    },
+    setQueryThrows: (error: Error | null) => {
+      queryThrows = error;
+    },
+    setQueryResult: (rows: Stored[]) => {
+      queryResult = rows;
     },
   };
 });
@@ -37,7 +78,7 @@ vi.mock("firebase-admin/firestore", () => ({
   FieldValue: { serverTimestamp: () => "SERVER_TIME" },
 }));
 
-import { changeLogDocuments, recordChange } from "./change-log";
+import { changeLogDocuments, recentChanges, recordChange } from "./change-log";
 
 function clip(id: string): TimelineClip {
   return {
@@ -62,7 +103,10 @@ function doc(id: string, clipIds: string[]): TimelineDocument {
 
 beforeEach(() => {
   state.added.length = 0;
+  state.queryCalls.length = 0;
   state.setAddThrows(false);
+  state.setQueryThrows(null);
+  state.setQueryResult([]);
 });
 
 describe("recordChange", () => {
@@ -136,5 +180,59 @@ describe("recordChange", () => {
     await recordChange({ uid: "user-a", source: "app", documents: [] });
 
     expect(state.added).toHaveLength(0);
+  });
+});
+
+// The log has been written faithfully for weeks; the one helper built to read
+// it could never run. array-contains combined with an orderBy needs a
+// composite index, and there wasn't one — so every call threw
+// FAILED_PRECONDITION, and nothing called it, so nobody found out.
+describe("recentChanges", () => {
+  it("asks the question the composite index is declared for", async () => {
+    state.setQueryResult([{ uid: "user-a", source: "app" }]);
+
+    const rows = await recentChanges("scene", 10);
+
+    expect(rows).toEqual([{ uid: "user-a", source: "app" }]);
+    // Pinned because firestore.indexes.json has to MATCH this shape. If the
+    // field or the direction moves here and not there, the query starts
+    // throwing again in exactly the way that went unnoticed before.
+    expect(state.queryCalls[0]).toEqual({
+      where: ["timelineIds", "array-contains", "scene"],
+      orderBy: ["at", "desc"],
+      limit: 10,
+    });
+  });
+
+  it("turns a missing index into the command that fixes it", async () => {
+    const missing = Object.assign(
+      new Error("9 FAILED_PRECONDITION: The query requires an index. Create it here: https://console.firebase.google.com/x"),
+      { code: 9 },
+    );
+    state.setQueryThrows(missing);
+
+    await expect(recentChanges("scene")).rejects.toThrow(
+      /firebase deploy --only firestore:indexes/,
+    );
+    // Firestore's own message carries a one-click link to create the index, so
+    // it must survive being wrapped rather than be replaced by ours.
+    await expect(recentChanges("scene")).rejects.toThrow(/console\.firebase\.google\.com/);
+  });
+
+  it("does NOT dress up an unrelated failure as a missing index", async () => {
+    state.setQueryThrows(new Error("permission denied"));
+
+    // The wrong diagnosis is worse than none: it would send someone to deploy
+    // an index that is already there.
+    await expect(recentChanges("scene")).rejects.toThrow(/^permission denied$/);
+  });
+
+  it("propagates the failure rather than reporting an empty history", async () => {
+    state.setQueryThrows(new Error("firestore unavailable"));
+
+    // recordChange swallows on purpose; this must not. An empty array here
+    // reads as "nothing ever touched this timeline", which is the opposite of
+    // the truth and the exact wrong answer during an investigation.
+    await expect(recentChanges("scene")).rejects.toThrow();
   });
 });

--- a/apps/timeline-gstudio001/lib/change-log.ts
+++ b/apps/timeline-gstudio001/lib/change-log.ts
@@ -98,13 +98,43 @@ export function changeLogDocuments(
  *
  * Deliberately queried on the denormalized `timelineIds` array rather than the
  * nested `documents` — Firestore cannot index into an array of objects.
+ *
+ * REQUIRES the timelineChanges composite index (firestore.indexes.json).
+ * array-contains combined with an orderBy is not merge-joinable from the
+ * automatic single-field indexes, so without it every call throws
+ * FAILED_PRECONDITION — which is exactly what this function did, unnoticed,
+ * for as long as it has existed: the log was written faithfully for weeks and
+ * the one helper built to read it could never run.
+ *
+ * Sorting client-side instead was rejected. Dropping the orderBy means reading
+ * EVERY entry that ever touched the timeline just to find the newest few, and
+ * that read grows without bound as the log does.
  */
 export async function recentChanges(timelineId: string, limit = 25) {
-  const snapshot = await getFirebaseDb()
-    .collection(CHANGE_LOG_COLLECTION)
-    .where("timelineIds", "array-contains", timelineId)
-    .orderBy("at", "desc")
-    .limit(limit)
-    .get();
-  return snapshot.docs.map((doc) => doc.data());
+  try {
+    const snapshot = await getFirebaseDb()
+      .collection(CHANGE_LOG_COLLECTION)
+      .where("timelineIds", "array-contains", timelineId)
+      .orderBy("at", "desc")
+      .limit(limit)
+      .get();
+    return snapshot.docs.map((doc) => doc.data());
+  } catch (error) {
+    // A missing index is an OPERATIONAL fact with a known fix, not a bug in
+    // the caller. Firestore's own message carries a one-click console link to
+    // create it, so it is preserved rather than replaced. Unlike recordChange
+    // above, this must NOT be swallowed: a read that silently returns nothing
+    // would read as "no changes", which is the opposite of the truth.
+    if (
+      error instanceof Error &&
+      (("code" in error && error.code === 9) || /requires an index/i.test(error.message))
+    ) {
+      throw new Error(
+        `The timelineChanges index is not deployed, so the change log cannot be read. ` +
+          `Deploy it with: npx firebase deploy --only firestore:indexes --project <id> ` +
+          `(see firestore.indexes.json). Original error: ${error.message}`,
+      );
+    }
+    throw error;
+  }
 }


### PR DESCRIPTION
`recentChanges()` filters `timelineIds` with `array-contains` **and** orders by
`at`. That combination is not merge-joinable from the automatic single-field
indexes, so it needs a composite one — and none was declared. Every call threw
`FAILED_PRECONDITION`.

Nobody noticed because **nothing calls it**. The log itself has been written
faithfully for weeks; the one helper built to read it could never run. During
last night's investigation I queried the collection by hand and sorted the
results client-side — precisely the work this function exists to save.

## Why not just sort client-side

Dropping the `orderBy` avoids the index, and it was tempting. It also means
reading **every entry that ever touched a timeline** to find the newest few,
and that read grows without bound as the log does. Unbounded reads already took
this project's quota — and the live app — down once today. The index is the
bounded answer.

## It still needs deploying

```bash
npx firebase deploy --only firestore:indexes --project <id>
```

Until then the query still fails, but it now fails **legibly**: a missing-index
error is rewritten to name that command, while preserving Firestore's own
message, which carries a one-click console link to create the index.

An unrelated failure is rethrown untouched. A wrong diagnosis is worse than
none — it would send someone off to deploy an index that is already there.

And unlike `recordChange`, this does **not** swallow. A read that quietly
returned `[]` would read as "nothing ever touched this timeline": the opposite
of the truth, and the worst possible answer mid-investigation.

## Verification

The test pins the query **shape** against the declared index, so moving a field
or a direction in one and not the other fails here rather than silently at
runtime — the way it failed before.

| test | |
|---|---|
| asks the question the index is declared for | pins `where` / `orderBy` / `limit` |
| turns a missing index into the fixing command | **fails without the fix** (raw `FAILED_PRECONDITION`) |
| does not dress up an unrelated failure | `permission denied` passes through intact |
| propagates rather than reporting empty history | rejects, never `[]` |

740 app tests pass; typecheck clean. The index declaration itself cannot be
verified without deploying it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)