### PR TITLE
Ask for allowEmptying because a write empties, not because it looks empty

### DIFF
--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
@@ -44,7 +44,11 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
-type BatchWrite = { document: TimelineDocument; expectedRevision?: number };
+type BatchWrite = {
+  document: TimelineDocument;
+  expectedRevision?: number;
+  allowEmptying?: boolean;
+};
 
 type FetchCall = {
   method: string;
@@ -119,6 +123,82 @@ describe("graph-documents-gateway", () => {
     await gateway.ensure("a");
     expect(getsOf(calls)).toHaveLength(1);
     expect(clipIds(gateway.peek("a"))).toEqual(["a1"]);
+  });
+
+
+  // ── allowEmptying ─────────────────────────────────────────────────────────
+  //
+  // The store refuses to write an empty document over a non-empty one unless
+  // the write says the empty is deliberate. What earns that exemption is the
+  // TRANSITION — clips going from some to none — not the projection happening
+  // to be empty at flush time. The two differ for a document that was already
+  // empty and is written for another reason, where the old test handed the
+  // exemption to a write that empties nothing.
+
+  const serveEmptyThenBatch = (seed: TimelineClip[]) =>
+    installFetch((call) =>
+      call.method === "POST"
+        ? okResults(call.writes)
+        : jsonResponse({ document: doc(call.id, seed), revision: 4 }),
+    );
+
+  it("asks for allowEmptying when the write actually empties the document", async () => {
+    const calls = serveEmptyThenBatch([clip("a1")]);
+    const gateway = createGraphDocumentsGateway();
+    await gateway.ensure("a");
+
+    gateway.writeClips("a", []);
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+
+    expect(batchesOf(calls)[0].writes?.[0]).toMatchObject({
+      allowEmptying: true,
+      expectedRevision: 4,
+    });
+  });
+
+  it("does NOT ask for it when the document was ALREADY empty", async () => {
+    // A rename on an empty collection. Nothing is being removed, so nothing
+    // needs exempting — the old projection-based test flagged this anyway.
+    const calls = serveEmptyThenBatch([]);
+    const gateway = createGraphDocumentsGateway();
+    await gateway.ensure("a");
+
+    await gateway.renameTimeline("a", "Renamed");
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+
+    const write = batchesOf(calls)[0].writes?.[0];
+    expect(write?.document.title).toBe("Renamed");
+    expect(write).not.toHaveProperty("allowEmptying");
+  });
+
+  it("drops the request when the clips come back before the flush", async () => {
+    // Emptied then undone inside one debounce window: the write that lands is
+    // not an emptying write, so it must not carry the exemption.
+    const calls = serveEmptyThenBatch([clip("a1")]);
+    const gateway = createGraphDocumentsGateway();
+    await gateway.ensure("a");
+
+    gateway.writeClips("a", []);
+    gateway.writeClips("a", [clip("a1")]);
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+
+    expect(batchesOf(calls)[0].writes?.[0]).not.toHaveProperty("allowEmptying");
+  });
+
+  it("does not carry the exemption into a LATER unrelated write", async () => {
+    // Spent on commit. Left set, one emptying would exempt every subsequent
+    // write to that document for the rest of the session.
+    const calls = serveEmptyThenBatch([clip("a1")]);
+    const gateway = createGraphDocumentsGateway();
+    await gateway.ensure("a");
+
+    gateway.writeClips("a", []);
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+    expect(batchesOf(calls)[0].writes?.[0]).toMatchObject({ allowEmptying: true });
+
+    await gateway.renameTimeline("a", "After");
+    await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+    expect(batchesOf(calls)[1].writes?.[0]).not.toHaveProperty("allowEmptying");
   });
 
   it("writeClips is a no-op for documents the session has not loaded", async () => {

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
@@ -238,6 +238,14 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
   // change that touches several documents writes them in the same window,
   // so they travel in the SAME atomic batch.
   const dirtyIds = new Set<string>();
+  // Documents this session has actually EMPTIED — observed at the moment the
+  // clips went from some to none, not inferred later from a projection that
+  // happens to be empty. The store refuses an empty-over-non-empty write
+  // unless told the empty is deliberate, and this is what earns that
+  // exemption. Held until the write COMMITS: a retry after an abandoned
+  // request carries the same intent, and forgetting it there would fail the
+  // resend on the very guard the first attempt was exempt from.
+  const emptiedIds = new Set<string>();
   let saveTimer: ReturnType<typeof setTimeout> | null = null;
   // At most one batch in flight; a write requested meanwhile queues one
   // trailing batch that re-reads the latest cache. Without this, an older
@@ -331,6 +339,7 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
     abandonSaveInFlight?.();
     abandonSaveInFlight = null;
     dirtyIds.clear();
+    emptiedIds.clear();
     saveInFlight = null;
     saveQueued = false;
     saveInFlightKeepalive = false;
@@ -544,7 +553,17 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
       //
       // Per-document too, never per-batch: a move empties its source while
       // filling its target, and only the source asked for the exemption.
-      const emptiesDocument = document.clips.length === 0 && revision !== undefined;
+      //
+      // Read from `emptiedIds`, which records the moment clips went from some
+      // to none, rather than asking "is this projection empty?" here. The two
+      // differ for a document that was ALREADY empty and is being written for
+      // another reason — a rename, or a resend — where the old test handed out
+      // the exemption to a write that empties nothing. Harmless, since the
+      // store's guard only fires against an existing non-empty document, but
+      // it made the flag mean "happens to be empty" instead of "this write
+      // empties it", and a flag that overstates what it permits is the kind
+      // that gets widened later by someone reading it literally.
+      const emptiesDocument = emptiedIds.has(timelineId) && revision !== undefined;
       writes.push({
         document,
         ...(revision !== undefined ? { expectedRevision: revision } : {}),
@@ -631,6 +650,10 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
             };
             if (gen !== generation) return;
             lastSavedAt = Date.now();
+            // Committed, so the intent is spent. Left set, a document emptied
+            // once would carry the exemption for the rest of the session and
+            // hand it to some later, unrelated write.
+            for (const write of writes) emptiedIds.delete(write.document.id);
             for (const write of writes) setError(write.document.id, null);
             for (const entry of result.results ?? []) {
               if (typeof entry.revision === "number") revisions.set(entry.id, entry.revision);
@@ -681,6 +704,10 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
               // Anything already queued for these ids was projected from the
               // stale graph too.
               dirtyIds.delete(timelineId);
+              // The change this belonged to no longer exists, so neither does
+              // the intent behind it. `refresh()` rebuilds from the server and
+              // any re-emptying is recorded fresh.
+              emptiedIds.delete(timelineId);
               if (!conflictIds.has(timelineId)) continue;
               // The message lands AFTER the reload (a successful fetch
               // clears that document's error slot — set before, it would
@@ -825,6 +852,13 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
       // GRAPH these clips were projected from is not; writing them would
       // overwrite the other writer's content with a stale full collection.
       if (conflictedIds.has(timelineId)) return;
+      // THE TRANSITION, recorded where it is visible. This is the only place
+      // both the previous clips and the new ones are in hand; by flush time
+      // the old ones are gone and all that is left is "it is empty now",
+      // which is a different question. Re-filling clears it, so an empty
+      // followed by an undo in the same window asks for no exemption.
+      if (clips.length === 0 && document.clips.length > 0) emptiedIds.add(timelineId);
+      else if (clips.length > 0) emptiedIds.delete(timelineId);
       documents = { ...documents, [timelineId]: { ...document, clips } };
       notify();
       dirtyIds.add(timelineId);


### PR DESCRIPTION
The gateway inferred the exemption at flush time — `clips.length === 0 && revision !== undefined` — which is a question about the **projection**, not about the **edit**. A document that was already empty and written for some other reason (a rename, a resend) got the flag too, asking the store's permission to remove something it was not removing.

**Harmless today.** The store's guard only fires against an existing non-empty document, so the extra flag changed no outcome. It is the *meaning* that was wrong: `allowEmptying: true` on the wire read as "this document is empty" rather than "this write empties it" — and a flag that overstates what it permits is the kind someone widens later on the strength of its name.

## Where it moved

`writeClips` is the one place that holds both the previous clips and the new ones. By flush time the old ones are gone and only "it is empty now" remains. Re-filling clears it, so an empty and an undo inside one debounce window ask for nothing.

**The intent is held until the write commits**, not cleared at flush. A batch abandoned by an unload takeover is re-sent from the same cache, and dropping the flag in between would fail the resend on the very guard the first attempt was exempt from. It clears on:

- commit — otherwise one emptying exempts that document for the rest of the session
- the 409/4xx drop — the change it belonged to no longer exists
- an auth rebind

## This is NOT a safety fix

Worth being plain, since the plan filed it as one. It said narrowing to intent was safe now that the orphan guard covers the dangerous case. **It doesn't.** The two guards protect different things:

| guard | catches |
|---|---|
| orphan guard | released collection **children** |
| empty guard | wiping **all** clips — including a media-only document with no collections at all |

Neither can replace the other, so `allowEmptying` cannot be deleted. And narrowing buys no new safety either: a bad projection emptying a full document is indistinguishable from a deliberate empty at every layer that can see it. This is hygiene, and only hygiene.

## Verification

| test | without the fix |
|---|---|
| asks for it when the write actually empties | passes (pins behaviour that must not change) |
| **does NOT ask when already empty** | **fails** — flag present |
| drops the request when clips come back before flush | passes (ditto) |
| **does not carry into a later unrelated write** | **fails** — flag present |

744 app tests, 168 e2e, typecheck clean. No gateway test covered this flag before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)