### PR TITLE
Cascade into the clips the product actually serves

### DIFF
--- a/apps/timeline-gstudio001/lib/firebase-timeline-cascade-delete.test.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-cascade-delete.test.ts
@@ -115,6 +115,36 @@ function seed(id: string, ownerUid: string | undefined, childIds: string[] = [])
   });
 }
 
+
+/**
+ * Seed a LEGACY record: clips at the top level only, with no nested
+ * `document`. `buildSavePayload` always writes all three fields today, so
+ * anything current code produced stays in sync — but a record written by an
+ * older path, restored from a backup, or created externally does not, and
+ * `toTimelineDocument` still serves these correctly.
+ */
+function seedLegacyTopLevel(id: string, ownerUid: string, childIds: string[] = []) {
+  const clips = childIds.map((childId, index) => ({
+    ...collectionClip(`${id}-c${index}`, childId),
+    index,
+  }));
+  state.docs.set(id, { id, title: `Doc ${id}`, clips, ownerUid });
+}
+
+/** Seed a record whose live clips resolve ONLY from the recovery snapshot. */
+function seedRecoveryOnly(id: string, ownerUid: string, childIds: string[] = []) {
+  const clips = childIds.map((childId, index) => ({
+    ...collectionClip(`${id}-c${index}`, childId),
+    index,
+  }));
+  state.docs.set(id, {
+    id,
+    title: `Doc ${id}`,
+    lastNonEmptyDocument: { id, title: `Doc ${id}`, clips },
+    ownerUid,
+  });
+}
+
 beforeEach(() => {
   state.docs.clear();
   state.reads.length = 0;
@@ -133,6 +163,66 @@ describe("cascade deletion", () => {
     await deleteFirebaseTimelineDocument("root", "user-a");
 
     expect([...state.docs.keys()]).toEqual(["unrelated"]);
+  });
+
+
+  // ── ONE DEFINITION OF "THIS RECORD'S CLIPS" ───────────────────────────────
+  //
+  // The walk used to read `data.document?.clips ?? []` — the only
+  // single-source read in the file, where every other reader resolves three
+  // sources. A record serving its clips from either of the other two enqueued
+  // no children, so the root was deleted and everything beneath it survived:
+  // unreachable, still owned, its media never eligible for reclaim, and with
+  // no path left to reach it. A silent, permanent storage leak.
+
+  it("cascades into children of a LEGACY record with no nested document", async () => {
+    seedLegacyTopLevel("root", "user-a", ["child-a"]);
+    seed("child-a", "user-a", ["grandchild"]);
+    seed("grandchild", "user-a");
+    seed("unrelated", "user-a");
+
+    await deleteFirebaseTimelineDocument("root", "user-a");
+
+    // Before the fix: only "root" went, leaving child-a and grandchild
+    // orphaned and unreachable.
+    expect([...state.docs.keys()]).toEqual(["unrelated"]);
+  });
+
+  it("cascades into children a record serves from its RECOVERY snapshot", async () => {
+    seedRecoveryOnly("root", "user-a", ["child-a"]);
+    seed("child-a", "user-a");
+    seed("unrelated", "user-a");
+
+    // This is what the product would show for that record, so it is what
+    // deleting it has to account for.
+    await deleteFirebaseTimelineDocument("root", "user-a");
+
+    expect([...state.docs.keys()]).toEqual(["unrelated"]);
+  });
+
+  it("does NOT cascade into a stale recovery snapshot when live clips exist", async () => {
+    // The asymmetry that rules out simply unioning all three sources, the way
+    // the reference COUNTER deliberately does. `moved-away` was removed from
+    // this collection and lives elsewhere now; the snapshot still names it.
+    // Deleting the parent must not follow that stale edge and destroy it.
+    state.docs.set("root", {
+      id: "root",
+      title: "Doc root",
+      document: { id: "root", title: "Doc root", clips: [{ ...collectionClip("root-c0", "child-a"), index: 0 }] },
+      clips: [{ ...collectionClip("root-c0", "child-a"), index: 0 }],
+      lastNonEmptyDocument: {
+        id: "root",
+        title: "Doc root",
+        clips: [{ ...collectionClip("root-old", "moved-away"), index: 0 }],
+      },
+      ownerUid: "user-a",
+    });
+    seed("child-a", "user-a");
+    seed("moved-away", "user-a");
+
+    await deleteFirebaseTimelineDocument("root", "user-a");
+
+    expect([...state.docs.keys()]).toEqual(["moved-away"]);
   });
 
   // The regression: this recursed A -> B -> A until the stack gave out, because

--- a/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
@@ -912,7 +912,32 @@ export async function deleteFirebaseTimelineDocument(id: string, requesterUid: s
 
       toDelete.push(currentId);
 
-      for (const clip of data.document?.clips ?? []) {
+      // THE SAME CLIPS THE PRODUCT SERVES, resolved by the same function.
+      //
+      // This read `data.document?.clips ?? []` and was the only single-source
+      // reader in the file. A record whose live clips resolve from the legacy
+      // top-level `clips`, or from the `lastNonEmptyDocument` recovery
+      // snapshot, has no `document.clips` — so the walk enqueued no children,
+      // deleted the root alone, and left every sub-collection beneath it
+      // unreachable but still owned. `collectOwnedTimelineClips` then goes on
+      // counting that orphan's clips as live references, so its media is never
+      // eligible for reclaim and nothing can reach the orphan to delete it: a
+      // silent, permanent storage leak.
+      //
+      // Calling `toTimelineDocument` rather than re-implementing the
+      // precedence is the point. That precedence is subtler than it looks —
+      // with no `document`, a recovery snapshot wins over top-level clips
+      // entirely — and a second copy of a rule like that is a second chance to
+      // disagree, which is the bug being fixed.
+      //
+      // NOT the superset `collectOwnedTimelineClips` uses. That one
+      // deliberately unions all three sources because over-counting a
+      // REFERENCE only leaks a file, while under-counting deletes one in use.
+      // Deleting has the opposite asymmetry: a child listed only in a stale
+      // recovery snapshot may have been moved elsewhere and be perfectly
+      // alive, and cascading into it would destroy live work. Delete what the
+      // product would show; count references from everything.
+      for (const clip of toTimelineDocument(currentId, data).clips) {
         if (clip.kind !== "collection" || !clip.childTimelineId) continue;
         // Already queued or already deleted — a cycle or a diamond.
         if (visited.has(clip.childTimelineId)) continue;


### PR DESCRIPTION
Closes #338.

Three readers of the same stored record disagreed about where a document's
clips live:

| reader | sources |
|---|---|
| `toTimelineDocument` | all three, in precedence order — this is what every served read returns |
| `collectOwnedTimelineClips` | all three, unioned on purpose |
| **the cascade walk** | **`data.document?.clips ?? []`** — the only single-source read in the file |

So a record serving its clips from the legacy top-level `clips`, or from the
`lastNonEmptyDocument` recovery snapshot, enqueued **no children**. The root
was deleted and everything beneath it survived: unreachable, still owned, and —
because the reference counter goes on counting an orphan's clips as live — its
media never eligible for reclaim either, with no path left to reach it.

A silent, permanent storage leak, and one more way to manufacture exactly the
orphans this codebase spent today learning to refuse.

## The fix

The walk now calls `toTimelineDocument`. **Reusing it rather than extracting
the rule is the point.** That precedence is subtler than it looks — with no
`document`, a recovery snapshot wins over top-level clips *entirely* — and a
second copy of a rule like that is a second chance to disagree, which is the
bug being fixed.

## Why not just union all three, like the counter does

The asymmetries run opposite ways:

- **Over-counting a reference** only leaks a file → counting unions everything.
- **Over-deleting destroys work.** A child named only in a stale recovery
  snapshot may have been moved elsewhere and be perfectly alive; cascading into
  it would take a live document with it.

Delete what the product would show; count references from everything. A test
pins that, so the union cannot be reintroduced later as a tidy-up.

## Verification

| test | without the fix |
|---|---|
| cascades into a LEGACY record's children | **fails** — child + grandchild left behind |
| cascades into children served from the RECOVERY snapshot | **fails** — child left behind |
| does NOT follow a stale snapshot when live clips exist | passes (pins what must not change) |

747 app tests, typecheck clean. `grep "document?.clips"` now returns only the
deliberate union in the counter.

## Caveat

Whether records lacking a `document` field still exist is **unverified** — it
needs a Firestore query and the project is out of read quota today. The issue
flags this too. Latent or live, the three readers should agree: the next
externally-written or restored record re-opens it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)