### PR TITLE
Let move_clip take the last clip out, and say so when it can't

### DIFF
--- a/apps/timeline-gstudio001/lib/mcp/apply-command.test.ts
+++ b/apps/timeline-gstudio001/lib/mcp/apply-command.test.ts
@@ -93,6 +93,25 @@ function clip(id: string): TimelineClip {
   };
 }
 
+
+function collectionClip(id: string): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "collection",
+    title: id,
+    childTimelineId: id,
+    alt: `${id} collection`,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 3,
+    sourceDuration: 3,
+    trimIn: 0,
+    trimOut: 0,
+  } as TimelineClip;
+}
+
 function seed(id: string, clips: TimelineClip[], ownerUid = OWNER, revision = 1) {
   const document: TimelineDocument = { id, title: id, clips };
   state.docs.set(id, { ...document, ownerUid, revision });
@@ -146,6 +165,45 @@ describe("applyCollectionsCommand", () => {
     expect(result.ok).toBe(true);
     const stored = state.docs.get("root") as { clips: TimelineClip[] };
     expect(stored.clips[0].title).toBe("Opening shot");
+  });
+
+
+  // ── THE STORE'S REFUSALS ARE ANSWERS, NOT CRASHES ─────────────────────────
+  //
+  // The catch here handled a revision conflict and an access denial and
+  // rethrew everything else. The store has two other refusals — the empty
+  // guard and the orphan guard — and both left this surface as a raw
+  // exception with no explanation. A refusal is a decision the caller has to
+  // read and act on, so it belongs in the result.
+
+  it("reports the empty-collection refusal instead of throwing", async () => {
+    seed("root", [collectionClip("src"), collectionClip("dst")]);
+    seed("src", [clip("only")]);
+    seed("dst", [clip("other")]);
+
+    // No allowEmptying: this stands in for any command that empties a source
+    // without meaning to. `move_clip` now passes the flag; this is the path
+    // taken when something does not.
+    const result = await applyCollectionsCommand(
+      "root",
+      {
+        type: "move-nodes",
+        nodeIds: [parseNodeId("only")],
+        toParentId: parseNodeId("dst"),
+        toIndex: 1,
+      },
+      OWNER,
+    );
+
+    expect(result.ok).toBe(false);
+    // Narrowed rather than cast: a "rejected" outcome carries a structured
+    // rejection and no message, and this must be the plain-error kind.
+    if (result.ok || result.kind !== "error") throw new Error("expected an error outcome");
+    expect(result.message).toMatch(/would empty a collection/i);
+    // Refused means refused — the destination must not have been written
+    // either, since the batch is atomic.
+    expect(storedClipIds("src")).toEqual(["only"]);
+    expect(storedClipIds("dst")).toEqual(["other"]);
   });
 
   it("surfaces a reducer refusal as a rejection rather than throwing", async () => {

--- a/apps/timeline-gstudio001/lib/mcp/apply-command.ts
+++ b/apps/timeline-gstudio001/lib/mcp/apply-command.ts
@@ -18,6 +18,7 @@ import type { TimelineDocument } from "@storyboard/timeline-model/types";
 
 import {
   saveFirebaseTimelineDocumentsAtomic,
+  TimelineOrphanError,
   TimelineRevisionConflictError,
   type TimelineBatchWrite,
 } from "@/lib/firebase-timeline-store";
@@ -428,6 +429,33 @@ export async function applyCollectionsCommand(
     }
     if (error instanceof TimelineAccessDeniedError) {
       return { ok: false, kind: "error", message: `Not authorized to edit timeline "${rootTimelineId}".` };
+    }
+    // The store's two REFUSALS. Both are answers — the write was understood
+    // and declined — so they belong in the tool result, where the caller can
+    // read and act on them. Rethrown, they left the MCP surface with a raw
+    // exception and no explanation, which is how `move_clip` emptying its
+    // source looked from the outside: not "refused because X" but a failure.
+    if (error instanceof TimelineOrphanError) {
+      const ids = error.orphans.map((orphan) => orphan.id).join(", ");
+      return {
+        ok: false,
+        kind: "error",
+        message:
+          `That change would leave ${ids} with no parent, so it was refused. ` +
+          `Move it somewhere else in the same call, or remove it to the trash instead.`,
+      };
+    }
+    if (
+      error instanceof Error &&
+      error.message.startsWith("Refusing to save an empty timeline")
+    ) {
+      return {
+        ok: false,
+        kind: "error",
+        message:
+          "That change would empty a collection, and this command did not ask to. " +
+          "Use remove_clip to take the last item out, or move something in first.",
+      };
     }
     throw error;
   }

--- a/apps/timeline-gstudio001/lib/mcp/move-clip.test.ts
+++ b/apps/timeline-gstudio001/lib/mcp/move-clip.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
+
+// `move_clip` against the same in-memory Firestore double the rest of lib/mcp
+// uses — the store, the graph adapter and the reducer all run for real, which
+// matters here because the bug was IN the store's guard and a mocked save
+// would have proved nothing.
+//
+// Issue #305 was filed against `remove_clip`, which had already been fixed
+// (2026-08-04) three days before the issue was opened. The symptom the report
+// describes — "cannot empty a one-clip collection" — was real, but it belonged
+// to `move_clip`, which never passed `allowEmptying` and so could not take the
+// last clip OUT of a collection. That also explains the workaround in the
+// report ("attach the replacement first"): adding a clip keeps the source
+// non-empty, which is only a workaround for a MOVE.
+type Stored = Record<string, unknown>;
+
+const state = vi.hoisted(() => {
+  const docs = new Map<string, Stored>();
+  const applySet = (id: string, data: Stored, opts?: { merge?: boolean }) => {
+    const existing = docs.get(id);
+    docs.set(id, opts?.merge && existing ? { ...existing, ...data } : { ...data });
+  };
+  const snapshot = (id: string) => {
+    const data = docs.get(id);
+    return {
+      id,
+      exists: data !== undefined,
+      data: () => (data ? { ...data } : undefined),
+      get: (field: string) => (data ? data[field] : undefined),
+    };
+  };
+  const docRef = (id: string) => ({
+    id,
+    get: async () => snapshot(id),
+    set: async (data: Stored, opts?: { merge?: boolean }) => applySet(id, data, opts),
+    delete: async () => {
+      docs.delete(id);
+    },
+  });
+  type Tx = {
+    get: (ref: { id: string }) => Promise<ReturnType<typeof snapshot>>;
+    set: (ref: { id: string }, data: Stored, opts?: { merge?: boolean }) => void;
+  };
+  const db = {
+    collection: () => ({
+      doc: docRef,
+      where: () => ({ orderBy: () => ({ limit: () => ({ get: async () => ({ docs: [] }) }) }) }),
+    }),
+    runTransaction: async <T>(fn: (tx: Tx) => Promise<T>): Promise<T> => {
+      const staged: Array<[string, Stored, { merge?: boolean } | undefined]> = [];
+      const tx: Tx = {
+        get: async (ref) => snapshot(ref.id),
+        set: (ref, data, opts) => {
+          staged.push([ref.id, data, opts]);
+        },
+      };
+      const result = await fn(tx);
+      for (const [id, data, opts] of staged) applySet(id, data, opts);
+      return result;
+    },
+  };
+  return { docs, db };
+});
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/firebase-admin", () => ({ getFirebaseDb: () => state.db }));
+vi.mock("firebase-admin/firestore", () => {
+  class Timestamp {
+    toDate() {
+      return new Date(0);
+    }
+  }
+  return {
+    Timestamp,
+    FieldValue: {
+      serverTimestamp: () => new Timestamp(),
+      // Emptying a collection deletes the `lastNonEmptyDocument` recovery
+      // snapshot — without that the next read re-hydrates the removed clips and
+      // the empty never sticks.
+      delete: () => "__DELETED__",
+    },
+  };
+});
+
+import { saveFirebaseTimelineDocumentsAtomic } from "@/lib/firebase-timeline-store";
+
+import { handleMoveClip } from "./write-handlers";
+const OWNER = "user-a";
+const TRASH = `trash-${OWNER}`;
+
+function clip(id: string): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "image",
+    src: "https://example.test/img.jpg",
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 4,
+    sourceDuration: 4,
+    trimIn: 0,
+    trimOut: 0,
+  };
+}
+
+function collectionClip(id: string): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "collection",
+    title: id,
+    // A collection clip's stored id equals its childTimelineId — the shape the
+    // whole app mints, and the one that used to break the graph build.
+    childTimelineId: id,
+    alt: `${id} collection`,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    itemCount: 0,
+    duration: 3,
+    sourceDuration: 3,
+    trimIn: 0,
+    trimOut: 0,
+  };
+}
+
+function seed(id: string, clips: TimelineClip[], ownerUid = OWNER, revision = 1) {
+  const document: TimelineDocument = { id, title: id, clips };
+  state.docs.set(id, { ...document, ownerUid, revision });
+  return document;
+}
+
+function storedClipIds(id: string): string[] {
+  const data = state.docs.get(id) as { clips?: TimelineClip[] } | undefined;
+  return (data?.clips ?? []).map((c) => c.id);
+}
+
+beforeEach(() => {
+  state.docs.clear();
+});
+
+describe("handleMoveClip — emptying the source", () => {
+  it("moves the LAST clip out of a collection", async () => {
+    seed("root", [collectionClip("src"), collectionClip("dst")]);
+    seed("src", [clip("only")]);
+    seed("dst", [clip("other")]);
+
+    const result = await handleMoveClip(
+      { timelineId: "root", nodeId: "only", into: "dst", position: "end" },
+      { requesterUid: OWNER },
+    );
+
+    // Before the fix this did not merely refuse — the store threw and
+    // apply-command rethrew, so the call failed with a raw exception.
+    expect(result.isError).toBeFalsy();
+    expect(storedClipIds("src")).toEqual([]);
+    expect(storedClipIds("dst")).toEqual(["other", "only"]);
+  });
+
+  it("still fills the destination when the source empties", async () => {
+    // The exemption is scoped per document: the source is allowed to empty,
+    // and the destination — which is gaining a clip — is untouched by it.
+    seed("root", [collectionClip("src"), collectionClip("dst")]);
+    seed("src", [clip("only")]);
+    seed("dst", []);
+
+    const result = await handleMoveClip(
+      { timelineId: "root", nodeId: "only", into: "dst", position: "end" },
+      { requesterUid: OWNER },
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(storedClipIds("src")).toEqual([]);
+    expect(storedClipIds("dst")).toEqual(["only"]);
+  });
+
+  it("reorders within a collection without emptying anything", async () => {
+    // The ordinary case, pinned so the exemption cannot be blamed for it.
+    seed("root", [collectionClip("lane")]);
+    seed("lane", [clip("a"), clip("b")]);
+
+    const result = await handleMoveClip(
+      { timelineId: "root", nodeId: "b", position: "start" },
+      { requesterUid: OWNER },
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(storedClipIds("lane")).toEqual(["b", "a"]);
+  });
+});

--- a/apps/timeline-gstudio001/lib/mcp/write-handlers.ts
+++ b/apps/timeline-gstudio001/lib/mcp/write-handlers.ts
@@ -119,6 +119,17 @@ export async function handleMoveClip(
       } as const;
     },
     ctx.requesterUid,
+    // A move EMPTIES ITS SOURCE whenever it takes the last clip out, and that
+    // is as deliberate as a removal — the same exemption `remove_clip` has
+    // carried since it hit this. Without it the store refused the write with
+    // "Refusing to save an empty timeline over an existing non-empty
+    // document", which the catch in apply-command rethrew, so the tool did not
+    // even fail politely.
+    //
+    // Safe to pass unconditionally: apply-command scopes the flag to the
+    // documents this command actually emptied, so the DESTINATION — which is
+    // gaining a clip, not losing one — never receives it.
+    { allowEmptying: true },
   );
 
   if (!outcome.ok) return reportFailure(outcome);


### PR DESCRIPTION
Closes #305.

## The issue names the wrong tool

It is filed against `remove_clip`, which was **already fixed on 2026-08-04** —
three days *before* the issue was opened. I probed it four ways against the
real store (not a mock): a one-clip lane, a one-clip root, removing the only
collection, and a lane two levels down. Every one empties cleanly.

The symptom is real; it belongs to **`move_clip`**. That handler never passed
`allowEmptying`, so taking the last clip *out* of a collection hit the store's
empty guard:

```
Error: Refusing to save an empty timeline over an existing non-empty document.
```

The report's own workaround gives it away — *"attach the replacement first"*
only helps a **move**, because adding a clip is what keeps the source
non-empty.

A move that empties its source is as deliberate as a removal, so it now carries
the same exemption. Safe to pass unconditionally: `apply-command` scopes the
flag to the documents a command actually emptied, so the destination — which is
*gaining* a clip — never receives it.

## It did not even fail politely

`applyCollectionsCommand` caught revision conflicts and access denials and
**rethrew everything else**. So the store's two refusals — the empty guard, and
the orphan guard added earlier today — reached the MCP surface as raw
exceptions.

A refusal is an answer: the write was understood and declined, and the caller
has to read it to know what to do instead. Both now return a tool error naming
what was refused and the way forward. The orphan case matters more than the one
that prompted this — an agent that gets *"would leave X with no parent"* can
fix its call, where a stack trace tells it nothing.

## Verification

| test | without the fix |
|---|---|
| moves the LAST clip out of a collection | **fails** — the exact error from the report |
| still fills the destination when the source empties | **fails** — same |
| reorders within a collection | passes (pins the ordinary case) |
| reports the empty refusal instead of throwing | **fails** — throws |

751 app tests, typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)