### PR TITLE
Pin what move_clip does when it re-parents a collection

### DIFF
--- a/apps/timeline-gstudio001/lib/mcp/move-clip.test.ts
+++ b/apps/timeline-gstudio001/lib/mcp/move-clip.test.ts
@@ -144,6 +144,9 @@ beforeEach(() => {
 });
 
 describe("handleMoveClip — emptying the source", () => {
+
+
+
   it("moves the LAST clip out of a collection", async () => {
     seed("root", [collectionClip("src"), collectionClip("dst")]);
     seed("src", [clip("only")]);
@@ -190,5 +193,71 @@ describe("handleMoveClip — emptying the source", () => {
 
     expect(result.isError).toBeFalsy();
     expect(storedClipIds("lane")).toEqual(["b", "a"]);
+  });
+});
+
+describe("handleMoveClip — re-parenting a collection (#304)", () => {
+  // #304 reports a move leaving a node under BOTH parents, silently. These pin
+  // the shapes it describes; all of them detach correctly, so whatever
+  // produced that state is not reached by a plain move on a clean closure.
+
+  it("detaches a collection from its old parent", async () => {
+    seed("root", [collectionClip("A"), collectionClip("B")]);
+    seed("A", [collectionClip("C")]);
+    seed("B", []);
+    seed("C", [clip("leaf")]);
+
+    const result = await handleMoveClip(
+      { timelineId: "root", nodeId: "C", into: "B", position: "end" },
+      { requesterUid: OWNER },
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(storedClipIds("A")).toEqual([]);
+    expect(storedClipIds("B")).toEqual(["C"]);
+  });
+
+  it("detaches when the collection moves UP to the root", async () => {
+    seed("root", [collectionClip("A")]);
+    seed("A", [collectionClip("C")]);
+    seed("C", [clip("leaf")]);
+
+    const result = await handleMoveClip(
+      { timelineId: "root", nodeId: "C", into: "root", position: "end" },
+      { requesterUid: OWNER },
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(storedClipIds("root")).toEqual(["A", "C"]);
+    expect(storedClipIds("A")).toEqual([]);
+  });
+
+  it("leaves a DUPLICATE REFERENCE elsewhere in place — and that looks like #304", async () => {
+    // The one shape that reproduces the reported SYMPTOM. A duplicate
+    // reference card carries its own clip id; the owning placement is the one
+    // with `id === childTimelineId`. Moving the owning placement is not
+    // supposed to disturb the other card, so afterwards the collection is
+    // legitimately listed in two places — indistinguishable, on a re-read,
+    // from a move that failed to detach.
+    //
+    // It is NOT the duplicate-ID corruption #304 also describes: these two
+    // clips have different ids, so `buildGraph` is happy. That state needs two
+    // OWNING placements, which a move does not mint.
+    const duplicateReference = { ...collectionClip("C"), id: "ref-to-C" } as TimelineClip;
+    seed("root", [collectionClip("A"), collectionClip("B"), duplicateReference]);
+    seed("A", [collectionClip("C")]);
+    seed("B", []);
+    seed("C", [clip("leaf")]);
+
+    const result = await handleMoveClip(
+      { timelineId: "root", nodeId: "C", into: "B", position: "end" },
+      { requesterUid: OWNER },
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(storedClipIds("A")).toEqual([]);
+    expect(storedClipIds("B")).toEqual(["C"]);
+    // Still referenced from the root, by its own clip id.
+    expect(storedClipIds("root")).toEqual(["A", "B", "ref-to-C"]);
   });
 });


### PR DESCRIPTION
Follow-up to #370 (merged), which created the `move_clip` suite.

Investigating **#304** — a move leaving a node under *both* parents, silently.
**I could not reproduce it.** These are the shapes I checked, kept as tests
because `move_clip` had no coverage at all before #370.

Every plain re-parent detaches correctly: a collection between collections, and
a collection moved up to the root. So whatever produced that state is not
reached by a move on a clean closure.

## What does reproduce the symptom

A **duplicate reference elsewhere in the tree.**

A duplicate reference card carries its own clip id; the owning placement is the
one where `id === childTimelineId`. Moving the owning placement deliberately
leaves the other card alone — so afterwards the collection *is* listed in two
places, which on a re-read is indistinguishable from a move that failed to
detach.

```
before:  root → [A, B, ref-to-C]      A → [C]      (C owned by A)
move C into B
after:   root → [A, B, ref-to-C]      A → []       B → [C]
```

`C` now appears under `B` **and** under `root`. That is correct behaviour, and
it is pinned here with the reasoning, because the next person to hit it will
read it as the bug.

It is **not** the duplicate-ID corruption #304 also describes. Here the two
clips have different ids, so `buildGraph` is happy. That corruption needs two
*owning* placements for one child — which a move does not mint.

## Ruled out by reading

| candidate | why not |
|---|---|
| write set misses the source parent | `collectAffectedCollectionIds` adds **both** `fromParentId` and `toParentId` for a move |
| closure silently truncates | it throws `TimelineClosureTooLargeError` instead |
| a declared write set partially dropped | the only caller declares a single id, so the existing all-or-nothing guard covers it |

## #304 stays open

The evidence that would settle it is the change log for 2026-08-07 — it records
every MCP write, including which documents each call wrote. Unreadable until
the composite index from #367 is deployed.

754 app tests, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)