### PR TITLE
One minimum clip duration, in the reducer where every path inherits it

### DIFF
--- a/apps/timeline-gstudio001/lib/mcp/write-handlers.ts
+++ b/apps/timeline-gstudio001/lib/mcp/write-handlers.ts
@@ -1,6 +1,7 @@
 import {
   getChildren,
   isVideoMedia,
+  MIN_MEDIA_DURATION_SECONDS,
   parseNodeId,
   type CollectionsGraph,
   type NodeId,
@@ -189,8 +190,11 @@ export async function handleTrimClip(
         if (args.durationSeconds === undefined) {
           return { ok: false, message: "Give `durationSeconds` for an image clip." } as const;
         }
-        if (!(args.durationSeconds > 0)) {
-          return { ok: false, message: "`durationSeconds` must be greater than 0." } as const;
+        if (!(args.durationSeconds >= MIN_MEDIA_DURATION_SECONDS)) {
+          return {
+            ok: false,
+            message: `\`durationSeconds\` must be at least ${MIN_MEDIA_DURATION_SECONDS}s.`,
+          } as const;
         }
         return {
           ok: true,
@@ -215,10 +219,14 @@ export async function handleTrimClip(
       if (trimIn < 0 || trimOut < 0) {
         return { ok: false, message: "Trims cannot be negative — they are seconds removed from each end." } as const;
       }
-      if (!(trimIn + trimOut < node.fullDurationSeconds)) {
+      // Reported against the SHARED floor rather than a local "> 0", so this
+      // guard and the reducer's clamp cannot drift into disagreeing about the
+      // same edit — which is what #341 was.
+      const longestTrim = node.fullDurationSeconds - MIN_MEDIA_DURATION_SECONDS;
+      if (!(trimIn + trimOut <= longestTrim)) {
         return {
           ok: false,
-          message: `Trims remove the whole clip: this source is ${node.fullDurationSeconds}s long, so \`trimInSeconds\` + \`trimOutSeconds\` must be less than ${node.fullDurationSeconds}.`,
+          message: `Trims would leave less than ${MIN_MEDIA_DURATION_SECONDS}s showing: this source is ${node.fullDurationSeconds}s long, so \`trimInSeconds\` + \`trimOutSeconds\` must be at most ${longestTrim}.`,
         } as const;
       }
       return {

--- a/packages/collections-core/commands.test.ts
+++ b/packages/collections-core/commands.test.ts
@@ -8,7 +8,11 @@ import {
   type CollectionsGraph,
   type GraphNodeSpec,
 } from "./graph";
-import { applyCommand, type CollectionsCommand } from "./commands";
+import {
+  applyCommand,
+  MIN_MEDIA_DURATION_SECONDS,
+  type CollectionsCommand,
+} from "./commands";
 import { applyPatch, invertPatch } from "./patches";
 
 const media = (id: string): GraphNodeSpec => ({ kind: "media", id, name: id });
@@ -574,13 +578,36 @@ describe("applyCommand: update-media", () => {
     expect(dur(graph, "V")).toBe(5); // 10 - 1 - 4
   });
 
-  test("video: clamps trim so the effective duration never goes negative", () => {
+  // REVERSED (#341). This asserted the ends could meet at exactly 0, which is
+  // what let a drag leave a clip showing nothing while the agent path refused
+  // the identical edit. The floor is now the reducer's, so every surface —
+  // pointer, keyboard, agent — inherits it.
+  test("video: clamps trim so at least the minimum stays showing", () => {
     const { graph: next } = apply(withVideo(), {
       type: "update-media",
       nodeId: parseNodeId("V"),
       update: { mediaKind: "video", trimInSeconds: 8, trimOutSeconds: 8 },
     });
-    expect(dur(next, "V")).toBe(0); // trimIn -> 10, trimOut -> 0
+    // trimIn -> 9.9 (10 - floor), trimOut -> 0.
+    expect(dur(next, "V")).toBeCloseTo(MIN_MEDIA_DURATION_SECONDS, 6);
+  });
+
+  test("video: an over-trimmed START edge alone still leaves the minimum", () => {
+    const { graph: next } = apply(withVideo(), {
+      type: "update-media",
+      nodeId: parseNodeId("V"),
+      update: { mediaKind: "video", trimInSeconds: 99 },
+    });
+    expect(dur(next, "V")).toBeCloseTo(MIN_MEDIA_DURATION_SECONDS, 6);
+  });
+
+  test("image: a zero or negative duration lands on the floor, not on nothing", () => {
+    const { graph: next } = apply(withVideo(), {
+      type: "update-media",
+      nodeId: parseNodeId("A"),
+      update: { mediaKind: "image", durationSeconds: 0 },
+    });
+    expect(dur(next, "A")).toBe(MIN_MEDIA_DURATION_SECONDS);
   });
 
   test("rejects non-media targets, kind mismatch, non-finite values, and no-ops", () => {

--- a/packages/collections-core/commands.ts
+++ b/packages/collections-core/commands.ts
@@ -20,6 +20,27 @@ import { type CollectionsPatch, type NodeAdd, type NodeMove, applyPatch } from "
 // `update-media` is the one DATA mutation (image duration / video trim).
 
 /**
+ * The shortest a media clip may be left showing.
+ *
+ * THE REDUCER IS WHERE THIS BELONGS, because every surface reaches media
+ * duration through it: pointer drags on the trim handles, the keyboard trim
+ * actions (which resolve to an `update-media` command and do no clamping of
+ * their own), and the agent's `trim_clip`. Putting a floor in the UI instead
+ * would leave the other two free to go under it, which is how the paths came
+ * to disagree — the reducer let the trim ends meet while the agent path
+ * refused the same edit outright.
+ *
+ * 0.1s matches the finest keyboard trim step (`FINE_TRIM_STEP_SECONDS`), so
+ * stepping down lands exactly on the floor rather than stopping short of it.
+ *
+ * A zero-length clip is not a rendering hazard — `durationToWidth` floors
+ * every slot at `MIN_ITEM_WIDTH`, so it stays visible and grabbable. It is
+ * simply not a thing the product means to store: it plays nothing, counts as
+ * nothing, and the agent path has always said so.
+ */
+export const MIN_MEDIA_DURATION_SECONDS = 0.1;
+
+/**
  * A media node's new trim/duration, discriminated to match the node's kind.
  * For video, omitted `trim*` fields keep the current value (change one end).
  */
@@ -459,10 +480,17 @@ function applyMediaUpdate(
     if (!Number.isFinite(nextIn) || !Number.isFinite(nextOut)) {
       return { ok: false, error: { reason: "invalid-media-update", nodeId } };
     }
-    // Clamp so both ends are >= 0 and together never exceed the source length
-    // (effective duration stays >= 0) — a drag past the limit lands at it.
-    const trimInSeconds = Math.max(0, Math.min(nextIn, node.fullDurationSeconds));
-    const trimOutSeconds = Math.max(0, Math.min(nextOut, node.fullDurationSeconds - trimInSeconds));
+    // Clamp so both ends are >= 0 and together leave at least
+    // MIN_MEDIA_DURATION_SECONDS showing — a drag past the limit lands at it.
+    //
+    // It used to allow the ends to meet, so `trimIn + trimOut` could equal the
+    // source length and the clip persisted showing nothing. A source SHORTER
+    // than the floor cannot honour it, and the whole clip is then the most it
+    // can show, so the floor is itself clamped to the source.
+    const full = node.fullDurationSeconds;
+    const floor = Math.min(MIN_MEDIA_DURATION_SECONDS, full);
+    const trimInSeconds = Math.max(0, Math.min(nextIn, full - floor));
+    const trimOutSeconds = Math.max(0, Math.min(nextOut, full - trimInSeconds - floor));
     if (trimInSeconds === node.trimInSeconds && trimOutSeconds === node.trimOutSeconds) {
       return { ok: false, error: { reason: "same-position" } };
     }
@@ -477,7 +505,8 @@ function applyMediaUpdate(
     if (!Number.isFinite(update.durationSeconds)) {
       return { ok: false, error: { reason: "invalid-media-update", nodeId } };
     }
-    const durationSeconds = Math.max(0, update.durationSeconds);
+    // An image has no source length to bound it, so the floor always applies.
+    const durationSeconds = Math.max(MIN_MEDIA_DURATION_SECONDS, update.durationSeconds);
     if (durationSeconds === node.durationSeconds) {
       return { ok: false, error: { reason: "same-position" } };
     }

--- a/packages/collections-core/index.ts
+++ b/packages/collections-core/index.ts
@@ -40,6 +40,7 @@ export {
 } from "./graph";
 export {
   applyCommand,
+  MIN_MEDIA_DURATION_SECONDS,
   type AddNodesCommand,
   type ApplyCommandSuccess,
   type CollectionsCommand,

--- a/packages/ui/dnd-collections/VirtualStrip.stories.tsx
+++ b/packages/ui/dnd-collections/VirtualStrip.stories.tsx
@@ -1238,15 +1238,17 @@ export const TrimMediaWithHandles: Story = {
     await dragHandleBy(handle("vid", "left")!, 48);
     await waitFor(() => expect(width("vid")).toBe(120));
 
-    // Over-drag the end: effective duration clamps at 0 (slot width 0, so the
-    // card bottoms out at its ~18px chrome — never negative, never huge).
-    // The pill (now DefaultItemContent's readout) reports 0 showing of the
-    // full 10s source.
+    // Over-drag the end: the effective duration bottoms out at the reducer's
+    // MIN_MEDIA_DURATION_SECONDS, not at 0 (#341). It used to reach 0 — a clip
+    // showing nothing, which the agent path refused for the same edit. The
+    // card still bottoms out at its ~18px chrome because the slot floors at
+    // MIN_ITEM_WIDTH; that floor is why a zero-length clip was never actually
+    // unreachable, and it is unchanged here.
     await dragHandleBy(handle("vid", "right")!, -600);
     await waitFor(() => expect(width("vid")).toBeLessThanOrEqual(20));
     expect(
       nodeCard(canvasElement, "vid").querySelector("[data-trim-pill]")!.textContent
-    ).toBe("0.00s / 10.00s");
+    ).toBe("0.10s / 10.00s");
   },
 };
 


### PR DESCRIPTION
Closes #341.

The reducer let a video's trim ends **meet** — `trimIn + trimOut` could equal
the source length — and let an image's duration be set to `0`. The agent path
refused the identical edit. So the same change was accepted from a pointer and
rejected from `trim_clip`.

The floor now lives in the **reducer**, the one place all three surfaces pass
through: pointer drags, the keyboard trim actions (which build an
`update-media` command and do no clamping of their own), and the agent. A floor
in the UI would have left the other two free to go under it.

`0.1s`, matching `FINE_TRIM_STEP_SECONDS`, so stepping down lands exactly on
the floor instead of stopping short. A source shorter than the floor cannot
honour it, so the floor is itself clamped to the source and such a clip keeps
its full length.

## Two corrections to the issue

Both from checking rather than reading, and the issue explicitly asked for the
second one.

**`keyboard.ts:298` is not a third permissive path.** That line is the source
*window slide*, which preserves `room` — total trim is invariant, so effective
duration cannot change there. The keyboard *trim* path never clamped at all; it
delegates to the reducer, and so inherits this fix for free.

**A zero-length clip did not become unhittable.** `durationToWidth` floors every
slot at `MIN_ITEM_WIDTH` — *"the clickable slot minimum"* — so the card stayed
visible and grabbable. There was no unrecoverable state and no undo-only
escape. **Severity is lower than the issue supposed**: this is the paths
agreeing, not a rescue.

## Two tests asserted the old behaviour

Rewritten, not deleted, since they record a reversed decision:

- the reducer unit test pinning effective duration reaching exactly `0`
- the `VirtualStrip` story expecting an over-drag to read `"0.00s / 10.00s"`

Both now record the floor and why.

## The agent path

Keeps its explicit rejection — an agent naming an impossible number should be
told, not silently clamped — but both thresholds are now expressed against the
shared constant, so the guard and the clamp cannot drift back apart.

## Verification

With the reducer change reverted, all three new floor tests fail at `0`.

| suite | |
|---|---|
| unit (collections-core) | 535 |
| story interaction | 192 |
| app | 754 |
| e2e (real trim drags) | 168 |

Typecheck clean in `packages/ui` and the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)