### PR TITLE
Defer to the summary when the walk never saw the collection's start

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -160,7 +160,7 @@ const NO_PREVIEWS: readonly CollectionPreviewFrame[] = [];
  *  make useSyncExternalStore loop. */
 const NO_PREVIEW_RESULT: CollectionPreviewsResult = {
   frames: NO_PREVIEWS,
-  sawChildlessCollection: false,
+  firstFrameUncertain: false,
 };
 
 /**
@@ -197,7 +197,7 @@ function useHydratedCollectionPreviews(
       // on the frames alone and the cache hands back the stale reference, so
       // the card never repaints when its children finish loading.
       contentKey: (result) =>
-        `${result.sawChildlessCollection ? 1 : 0}\x02` +
+        `${result.firstFrameUncertain ? 1 : 0}\x02` +
         result.frames
           .map((p) => `${p.id}\0${p.poster ?? p.src}\0${p.trimIn ?? 0}`)
           .join("\x01"),

--- a/packages/timeline-domain/src/adapter.test.ts
+++ b/packages/timeline-domain/src/adapter.test.ts
@@ -1029,6 +1029,124 @@ describe("hydratedCollectionPreviews (card frames)", () => {
   });
 });
 
+describe("previews when the walk sees only PART of the subtree (#293)", () => {
+  // #290 covered the walk returning NOTHING. This is the other half: it returns
+  // something real, computed over an incomplete set, so the frames are WRONG
+  // rather than merely fewer.
+  //
+  // A card paints exactly one frame and it is always `frames[0]`, so the whole
+  // question is whether the walk could see the START of the collection.
+
+  const storedFirst = [
+    { id: "true-first", kind: "image" as const, src: "https://example.com/first.jpg", alt: "first" },
+  ];
+
+  it("defers to the summary when an unloaded branch sits BEFORE the first media", () => {
+    // run1 is a placeholder; run2 is loaded. The live walk cannot reach run1's
+    // media, so the first frame it finds belongs to run2 — a later branch. The
+    // server's summary was derived across the whole closure and knows the
+    // real first frame.
+    const focused = buildFocusedGraph(
+      {
+        scene: {
+          id: "scene",
+          title: "Scene one",
+          clips: packTimelineClips([
+            collectionClip("clip-run1", "run1", "Run 1"),
+            collectionClip("clip-run2", "run2", "Run 2"),
+          ]),
+        },
+        // run1 deliberately ABSENT.
+        run2: { id: "run2", title: "Run 2", clips: packTimelineClips([image("r2-a", 4)]) },
+      },
+      "scene",
+    );
+    if (!focused.ok) throw new Error(focused.error);
+
+    const live = hydratedCollectionPreviews(focused.value.graph, "scene");
+    // The walk DID find a frame — this is not the #290 blank case.
+    expect(live.frames.map((p) => p.id)).toEqual(["r2-a"]);
+    expect(live.firstFrameUncertain).toBe(true);
+    expect(resolveCollectionPreviews(live, storedFirst)).toEqual(storedFirst);
+  });
+
+  it("keeps the live frames when the unloaded branch is AFTER the first media", () => {
+    // The distinction that stops this from becoming "prefer stored whenever
+    // the walk is incomplete". run1 is loaded, so `frames[0]` is already the
+    // collection's real first frame and no summary can improve on it —
+    // deferring here would throw away an edit the user just made in run1.
+    const focused = buildFocusedGraph(
+      {
+        scene: {
+          id: "scene",
+          title: "Scene one",
+          clips: packTimelineClips([
+            collectionClip("clip-run1", "run1", "Run 1"),
+            collectionClip("clip-run2", "run2", "Run 2"),
+          ]),
+        },
+        run1: { id: "run1", title: "Run 1", clips: packTimelineClips([image("r1-a", 4)]) },
+        // run2 deliberately ABSENT.
+      },
+      "scene",
+    );
+    if (!focused.ok) throw new Error(focused.error);
+
+    const live = hydratedCollectionPreviews(focused.value.graph, "scene");
+    expect(live.frames.map((p) => p.id)).toEqual(["r1-a"]);
+    expect(live.firstFrameUncertain).toBe(false);
+    expect(resolveCollectionPreviews(live, storedFirst).map((p) => p.id)).toEqual(["r1-a"]);
+  });
+
+  it("shows what it found when there is no summary to fall back to", () => {
+    // A partial answer beats an empty card.
+    const focused = buildFocusedGraph(
+      {
+        scene: {
+          id: "scene",
+          title: "Scene one",
+          clips: packTimelineClips([
+            collectionClip("clip-run1", "run1", "Run 1"),
+            collectionClip("clip-run2", "run2", "Run 2"),
+          ]),
+        },
+        run2: { id: "run2", title: "Run 2", clips: packTimelineClips([image("r2-a", 4)]) },
+      },
+      "scene",
+    );
+    if (!focused.ok) throw new Error(focused.error);
+
+    const live = hydratedCollectionPreviews(focused.value.graph, "scene");
+    expect(live.firstFrameUncertain).toBe(true);
+    expect(resolveCollectionPreviews(live, undefined).map((p) => p.id)).toEqual(["r2-a"]);
+  });
+
+  it("does not defer for a collection whose OWN media lead it", () => {
+    // Media directly under the collection are found before any descent, so an
+    // unloaded sub-collection later in the list changes nothing visible.
+    const focused = buildFocusedGraph(
+      {
+        scene: {
+          id: "scene",
+          title: "Scene one",
+          clips: packTimelineClips([
+            image("own-a", 4),
+            collectionClip("clip-run2", "run2", "Run 2"),
+          ]),
+        },
+        // run2 deliberately ABSENT.
+      },
+      "scene",
+    );
+    if (!focused.ok) throw new Error(focused.error);
+
+    const live = hydratedCollectionPreviews(focused.value.graph, "scene");
+    expect(live.frames.map((p) => p.id)).toEqual(["own-a"]);
+    expect(live.firstFrameUncertain).toBe(false);
+    expect(resolveCollectionPreviews(live, storedFirst).map((p) => p.id)).toEqual(["own-a"]);
+  });
+});
+
 describe("previews when the walk cannot see the whole subtree (#290)", () => {
   // The reported bug, in its exact shape. On the project board a top-level
   // collection is HYDRATED — its own children are loaded — but those children
@@ -1062,7 +1180,7 @@ describe("previews when the walk cannot see the whole subtree (#290)", () => {
 
     const live = hydratedCollectionPreviews(focused.value.graph, "scene");
     expect(live.frames).toEqual([]);
-    expect(live.sawChildlessCollection).toBe(true);
+    expect(live.firstFrameUncertain).toBe(true);
 
     const stored = [
       { id: "s1", kind: "image" as const, src: "https://example.com/s1.jpg", alt: "s1" },
@@ -1089,7 +1207,7 @@ describe("previews when the walk cannot see the whole subtree (#290)", () => {
     const live = hydratedCollectionPreviews(focused.value.graph, "kid");
     expect(live.frames).toEqual([]);
     // No child COLLECTION was involved, so the empty result is authoritative.
-    expect(live.sawChildlessCollection).toBe(false);
+    expect(live.firstFrameUncertain).toBe(false);
 
     const stored = [
       { id: "old", kind: "image" as const, src: "https://example.com/old.jpg", alt: "old" },
@@ -1113,7 +1231,7 @@ describe("previews when the walk cannot see the whole subtree (#290)", () => {
 
     const live = hydratedCollectionPreviews(focused.value.graph, "scene");
     expect(live.frames.map((p) => p.id)).toEqual(["r-a"]);
-    expect(live.sawChildlessCollection).toBe(false);
+    expect(live.firstFrameUncertain).toBe(false);
 
     const stored = [
       { id: "s1", kind: "image" as const, src: "https://example.com/s1.jpg", alt: "s1" },

--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -483,11 +483,23 @@ export type CollectionPreviewFrame = Readonly<{
 export type CollectionPreviewsResult = Readonly<{
   frames: readonly CollectionPreviewFrame[];
   /**
-   * The walk descended into a collection with no children in the graph, so
-   * media under it could not be seen. Only meaningful when `frames` is empty —
-   * see `resolveCollectionPreviews`.
+   * The walk hit a collection with no children in the graph — an unloaded
+   * branch — BEFORE it had found any media. So whatever ended up first in
+   * `frames` is not necessarily the collection's first frame: the real one may
+   * live in the branch that could not be read.
+   *
+   * Deliberately "before the first media", not "anywhere in the walk". A card
+   * paints ONE frame (`useCollectionPreviewFrames`, PL13-003) and it is always
+   * `frames[0]`, so an unloaded branch encountered AFTER the first media
+   * cannot change anything anyone sees. Flagging those too would send a
+   * perfectly good live result back to the stored summary and throw away the
+   * user's just-made edits — the staleness this walk exists to fix.
+   *
+   * When `frames` is empty this is exactly the old `sawChildlessCollection`:
+   * every childless collection was necessarily seen before a first media that
+   * never arrived. That is why one field now covers both cases.
    */
-  sawChildlessCollection: boolean;
+  firstFrameUncertain: boolean;
 }>;
 
 /**
@@ -522,7 +534,7 @@ export function hydratedCollectionPreviews(
 ): CollectionPreviewsResult {
   const media: CollectionPreviewFrame[] = [];
   const seen = new Set<string>([collectionId]);
-  let sawChildlessCollection = false;
+  let firstFrameUncertain = false;
   const collect = (id: NodeId): void => {
     for (const childId of getChildren(graph, id)) {
       const node = graph.nodesById.get(childId);
@@ -564,7 +576,10 @@ export function hydratedCollectionPreviews(
           // here. Either way this walk cannot see media under it. Recorded so
           // an EMPTY result can be told apart from "looked and found nothing";
           // `resolveCollectionPreviews` explains why conflating the two is safe.
-          if (getChildren(graph, childId).length === 0) sawChildlessCollection = true;
+          // Only while nothing has been found yet — see `firstFrameUncertain`.
+          if (media.length === 0 && getChildren(graph, childId).length === 0) {
+            firstFrameUncertain = true;
+          }
           collect(childId);
         }
       }
@@ -575,7 +590,7 @@ export function hydratedCollectionPreviews(
     media.length <= 3
       ? media
       : [media[0], media[Math.floor(media.length / 2)], media[media.length - 1]];
-  return { frames, sawChildlessCollection };
+  return { frames, firstFrameUncertain };
 }
 
 /**
@@ -596,21 +611,31 @@ export function hydratedCollectionPreviews(
  * and the fallback returns the same thing.
  *
  * What must keep working — and does — is a collection whose own media were all
- * deleted. No child collection is involved, so `sawChildlessCollection` stays
+ * deleted. No child collection is involved, so `firstFrameUncertain` stays
  * false, the empty result stands, and the card goes blank as it should. That is
  * the case a bare `frames.length === 0` check would have broken, resurrecting
  * stale frames on a collection the user just emptied.
  *
- * A NON-EMPTY partial walk is deliberately left alone: it is preferred as it
- * always has been, even though first/middle/last over a partially loaded tree
- * can pick different frames than the complete set would. That predates this and
- * is a separate concern from a card rendering blank.
+ * #293: a NON-EMPTY walk that never saw the START of the collection is now
+ * covered by the same rule, because it has the same defect — it knows less
+ * than the server's summary about the one frame that gets painted. A card
+ * shows `frames[0]`, and if an unloaded branch sits before the first media
+ * found, `frames[0]` belongs to a later branch and the true first frame was
+ * never reachable. Whatever the user just edited in a loaded child cannot be
+ * that frame either, so nothing fresh is lost by deferring.
+ *
+ * This is NOT "prefer stored whenever the walk is incomplete". An unloaded
+ * branch AFTER the first media leaves `frames[0]` correct, so the live result
+ * still wins — which is what keeps a just-made edit on screen. The
+ * middle/last slots of such a walk can still be unrepresentative; they are not
+ * rendered, and merging two ordered frame lists without duplicating media
+ * needs a rule that does not exist yet.
  */
 export function resolveCollectionPreviews(
   live: CollectionPreviewsResult,
   stored: readonly CollectionPreviewFrame[] | undefined,
 ): readonly CollectionPreviewFrame[] {
-  if (live.frames.length > 0 || !live.sawChildlessCollection) return live.frames;
+  if (!live.firstFrameUncertain) return live.frames;
   return stored ?? live.frames;
 }
 


### PR DESCRIPTION
Closes #293.

The issue asks for this to be **measured before anything is built**, and warns
off a bare *"prefer stored when incomplete"* because that throws away the edits
the live walk exists to surface. Measuring it makes the fix much smaller than
the issue supposed — and narrow enough to avoid that trap.

## The measurement

**A card paints one frame** (`useCollectionPreviewFrames`, PL13-003), and it is
always `frames[0]`, which is always `media[0]`.

So "first/middle/last computed over an incomplete set" is not the observable
defect — middle and last are never rendered. The only question is whether the
walk could see the **start** of the collection, and it could not exactly when
it hit an unloaded branch *before* finding any media.

## The fix

`sawChildlessCollection` becomes `firstFrameUncertain`, recorded only while
nothing has been found yet. That **subsumes** #290 rather than adding to it:
when the walk returns nothing, every childless collection was necessarily seen
before a first media that never arrived. One rule now covers both cases:

```ts
if (!live.firstFrameUncertain) return live.frames;
return stored ?? live.frames;
```

**Why this is not the bare version.** An unloaded branch *after* the first
media leaves `frames[0]` correct, so the live result still wins and a just-made
edit stays on screen. Deferring happens only when the frame that would be
painted provably belongs to a branch that could not be read — and whatever the
user edited in a loaded child cannot be that frame either, so nothing fresh is
lost.

## It is worth more than "cosmetic, self-corrects"

This resolver also feeds **persistence**. `graphChildrenToClips` gates the live
walk on the collection's own `hydrated`, but the walk descends into
*sub-collections* that may still be placeholders — so a partial result was
written back over the correct stored summary, and stayed wrong until that
collection was next written while fully hydrated.

## Left alone deliberately

The middle/last slots of a walk whose first frame *is* trustworthy can still be
unrepresentative. They are not rendered, and merging two ordered frame lists
without duplicating media needs a rule that does not exist yet — the issue's
own reasoning, unchanged.

## Verification

Verified discriminating by reverting **only the resolver rule** and keeping the
rename, so the rename could not mask the result:

| | |
|---|---|
| defers when the unloaded branch is BEFORE the first media | **fails without the fix** |
| keeps live frames when it is AFTER | passes either way (pins what must not change) |
| shows what it found when there is no summary | passes either way |
| does not defer when the collection's OWN media lead it | passes either way |
| all four #290 tests | pass either way |

539 unit + 192 story + 754 app + 168 e2e; typecheck clean in both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)