### PR TITLE
Stop letting the client choose which origin we advertise

### DIFF
--- a/apps/timeline-gstudio001/.env.example
+++ b/apps/timeline-gstudio001/.env.example
@@ -38,6 +38,15 @@ FIREBASE_STORAGE_BUCKET="MY_FIREBASE_STORAGE_BUCKET"
 # open. They are set per-environment on the host (Production and Preview are
 # separate values — updating one does not update the other).
 #
+# MCP_OAUTH_ISSUER pins the origin this deployment advertises in its
+# `.well-known` discovery documents and binds access-token audiences to. SET IT
+# ANYWHERE A SHARED CACHE OR PROXY SITS IN FRONT, which is every real
+# deployment. Left unset the origin is derived from `x-forwarded-host` — a
+# header the CLIENT sends — so the discovery documents are served `no-store`
+# and the token audience stops being a meaningful check. Both are safe, just
+# uncached and unenforced. Origin only; any path is stripped.
+#   MCP_OAUTH_ISSUER="https://your-app.vercel.app"
+#
 # MCP_OAUTH_SIGNING_SECRET signs AND verifies access tokens.
 # MUST BE AT LEAST 32 CHARACTERS. Below that, getSigningSecret() returns null,
 # the OAuth branch is skipped entirely, and every request 401s with no other

--- a/apps/timeline-gstudio001/app/.well-known/oauth-authorization-server/route.ts
+++ b/apps/timeline-gstudio001/app/.well-known/oauth-authorization-server/route.ts
@@ -1,7 +1,8 @@
 import {
-  METADATA_HEADERS,
+  METADATA_PREFLIGHT_HEADERS,
   authorizationServerMetadata,
-  originFromRequest,
+  metadataHeaders,
+  resolveIssuerOrigin,
 } from "@/lib/oauth/metadata";
 
 // RFC 8414 Authorization Server Metadata — where the client discovers the
@@ -11,12 +12,12 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export function GET(request: Request) {
-  const origin = originFromRequest(request);
+  const { origin, pinned } = resolveIssuerOrigin(request);
   return new Response(JSON.stringify(authorizationServerMetadata(origin), null, 2), {
-    headers: METADATA_HEADERS,
+    headers: metadataHeaders(pinned),
   });
 }
 
 export function OPTIONS() {
-  return new Response(null, { status: 204, headers: METADATA_HEADERS });
+  return new Response(null, { status: 204, headers: METADATA_PREFLIGHT_HEADERS });
 }

--- a/apps/timeline-gstudio001/app/.well-known/oauth-protected-resource/route.ts
+++ b/apps/timeline-gstudio001/app/.well-known/oauth-protected-resource/route.ts
@@ -1,6 +1,7 @@
 import {
-  METADATA_HEADERS,
-  originFromRequest,
+  METADATA_PREFLIGHT_HEADERS,
+  metadataHeaders,
+  resolveIssuerOrigin,
   protectedResourceMetadata,
 } from "@/lib/oauth/metadata";
 
@@ -12,12 +13,12 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export function GET(request: Request) {
-  const origin = originFromRequest(request);
+  const { origin, pinned } = resolveIssuerOrigin(request);
   return new Response(JSON.stringify(protectedResourceMetadata(origin), null, 2), {
-    headers: METADATA_HEADERS,
+    headers: metadataHeaders(pinned),
   });
 }
 
 export function OPTIONS() {
-  return new Response(null, { status: 204, headers: METADATA_HEADERS });
+  return new Response(null, { status: 204, headers: METADATA_PREFLIGHT_HEADERS });
 }

--- a/apps/timeline-gstudio001/app/api/mcp/route.ts
+++ b/apps/timeline-gstudio001/app/api/mcp/route.ts
@@ -29,7 +29,7 @@ import {
   NO_LIVE_PUSH_NOTE,
 } from "@/lib/mcp/write-handlers";
 import { MCP_SCOPE, getSigningSecret, verifyAccessToken } from "@/lib/oauth/core";
-import { mcpResourceUrl, originFromRequest } from "@/lib/oauth/metadata";
+import { mcpResourceUrl, resolveIssuerOrigin } from "@/lib/oauth/metadata";
 
 // Remote MCP endpoint — the "give Claude a URL" surface, distinct from the
 // in-page WebMCP tools (see docs/webmcp-agent-tools.md). Those run in the
@@ -495,7 +495,10 @@ const authedHandler = withMcpAuth(
     //    so a token minted for another resource can't be replayed here.
     const signingSecret = getSigningSecret();
     if (signingSecret) {
-      const audience = mcpResourceUrl(originFromRequest(request));
+      // PINNED where configured. Deriving this from the request made the
+      // check self-referential: the token was minted against the same
+      // client-supplied header it is verified against, so it always matched.
+      const audience = mcpResourceUrl(resolveIssuerOrigin(request).origin);
       const verified = verifyAccessToken(bearerToken, signingSecret, audience);
       if (verified.ok) {
         return {

--- a/apps/timeline-gstudio001/app/api/oauth/authorize/route.ts
+++ b/apps/timeline-gstudio001/app/api/oauth/authorize/route.ts
@@ -4,7 +4,7 @@ import {
   successRedirectUrl,
   validateAuthorizeRequest,
 } from "@/lib/oauth/authorize-request";
-import { mcpResourceUrl, originFromRequest } from "@/lib/oauth/metadata";
+import { mcpResourceUrl, resolveIssuerOrigin } from "@/lib/oauth/metadata";
 import { issueAuthCode } from "@/lib/oauth/store";
 import { getAuthUser } from "@/lib/firebase-auth-session";
 
@@ -67,7 +67,7 @@ export async function POST(request: Request) {
     );
   }
 
-  const origin = originFromRequest(request);
+  const { origin } = resolveIssuerOrigin(request);
   const code = await issueAuthCode({
     clientId: validation.params.clientId,
     redirectUri: validation.params.redirectUri,

--- a/apps/timeline-gstudio001/app/api/oauth/token/route.ts
+++ b/apps/timeline-gstudio001/app/api/oauth/token/route.ts
@@ -7,7 +7,7 @@ import {
   signAccessToken,
   verifyPkce,
 } from "@/lib/oauth/core";
-import { mcpResourceUrl, originFromRequest } from "@/lib/oauth/metadata";
+import { mcpResourceUrl, resolveIssuerOrigin } from "@/lib/oauth/metadata";
 import { consumeAuthCode, issueRefreshToken, rotateRefreshToken } from "@/lib/oauth/store";
 
 // OAuth 2.1 token endpoint: authorization_code (with PKCE) and refresh_token.
@@ -73,7 +73,7 @@ export async function POST(request: Request) {
     return oauthError("invalid_client", "Unknown client or bad secret.", 401);
   }
 
-  const origin = originFromRequest(request);
+  const { origin } = resolveIssuerOrigin(request);
   const resource = mcpResourceUrl(origin);
   const grantType = form.get("grant_type");
 

--- a/apps/timeline-gstudio001/lib/oauth/metadata.test.ts
+++ b/apps/timeline-gstudio001/lib/oauth/metadata.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  authorizationServerMetadata,
+  mcpResourceUrl,
+  metadataHeaders,
+  originFromRequest,
+  resolveIssuerOrigin,
+} from "./metadata";
+
+// #335. The advertised origin came from `x-forwarded-host` — a header the
+// CLIENT sets — and the discovery documents carrying it were served
+// `public, max-age=300` with no `Vary`, so the cache key was the path alone.
+// One poisoned request could park a document naming an attacker's
+// `token_endpoint` in any shared cache in front of the app.
+//
+// The same header also fed the token AUDIENCE, which is the sharper half: the
+// mint and the check both derived it the same way, so the comparison was an
+// attacker's value against the same attacker's value.
+
+const POISONED = new Request("https://real.example/.well-known/oauth-authorization-server", {
+  headers: { "x-forwarded-host": "evil.example", "x-forwarded-proto": "https" },
+});
+
+const ORIGINAL = process.env.MCP_OAUTH_ISSUER;
+
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.MCP_OAUTH_ISSUER;
+  else process.env.MCP_OAUTH_ISSUER = ORIGINAL;
+});
+
+describe("resolveIssuerOrigin", () => {
+  it("ignores a poisoned header when the issuer is pinned", () => {
+    process.env.MCP_OAUTH_ISSUER = "https://real.example";
+
+    const resolved = resolveIssuerOrigin(POISONED);
+
+    expect(resolved).toEqual({ origin: "https://real.example", pinned: true });
+    // The whole point: the endpoints a client would be sent to.
+    const metadata = authorizationServerMetadata(resolved.origin);
+    expect(metadata.token_endpoint).toBe("https://real.example/api/oauth/token");
+    expect(metadata.authorization_endpoint).toBe("https://real.example/oauth/authorize");
+  });
+
+  it("normalizes a pinned issuer to its origin", () => {
+    // A trailing path or slash in the env var must not end up doubled inside
+    // every advertised endpoint.
+    process.env.MCP_OAUTH_ISSUER = "https://real.example/some/path";
+
+    expect(resolveIssuerOrigin(POISONED).origin).toBe("https://real.example");
+  });
+
+  it("falls back to the request — UNPINNED — when nothing is configured", () => {
+    delete process.env.MCP_OAUTH_ISSUER;
+
+    const resolved = resolveIssuerOrigin(POISONED);
+
+    // Still derived, because local dev and previews need it. The protection is
+    // that `pinned: false` forces `no-store` below, so a derived origin can
+    // never be cached and handed to someone else.
+    expect(resolved).toEqual({ origin: "https://evil.example", pinned: false });
+  });
+
+  it("falls back rather than throwing on a malformed pin, and does not claim pinned", () => {
+    // A typo in an env var must not take the deployment down — but it must
+    // also not leave an operator believing the pin took effect.
+    process.env.MCP_OAUTH_ISSUER = "not a url";
+
+    expect(resolveIssuerOrigin(POISONED)).toEqual({
+      origin: "https://evil.example",
+      pinned: false,
+    });
+  });
+
+  it("refuses a non-http scheme", () => {
+    process.env.MCP_OAUTH_ISSUER = "javascript:alert(1)";
+
+    expect(resolveIssuerOrigin(POISONED).pinned).toBe(false);
+  });
+
+  it("still reads the header directly — that is why callers must not", () => {
+    // Pinning is the caller's decision, made in resolveIssuerOrigin. This
+    // helper stays honest about what it does.
+    expect(originFromRequest(POISONED)).toBe("https://evil.example");
+  });
+});
+
+describe("metadataHeaders", () => {
+  it("caches only a pinned origin", () => {
+    expect(metadataHeaders(true)["cache-control"]).toBe("public, max-age=300");
+  });
+
+  it("refuses to cache a request-derived origin", () => {
+    // The combination that made poisoning worth doing: a body that depends on
+    // a header, stored under a key that ignores it.
+    expect(metadataHeaders(false)["cache-control"]).toBe("no-store");
+  });
+
+  it("varies on the headers the body can depend on, either way", () => {
+    for (const pinned of [true, false]) {
+      expect(metadataHeaders(pinned).vary).toContain("X-Forwarded-Host");
+      expect(metadataHeaders(pinned).vary).toContain("Host");
+    }
+  });
+});
+
+describe("the audience bound to a token", () => {
+  it("is a per-deployment constant once pinned, not the caller's own header", () => {
+    process.env.MCP_OAUTH_ISSUER = "https://real.example";
+
+    const minted = mcpResourceUrl(resolveIssuerOrigin(POISONED).origin);
+    const checked = mcpResourceUrl(
+      resolveIssuerOrigin(
+        new Request("https://real.example/api/mcp", {
+          headers: { "x-forwarded-host": "other.example" },
+        }),
+      ).origin,
+    );
+
+    // Two different poisoned headers, one audience. Unpinned these would each
+    // have echoed their own header and matched trivially, which is what made
+    // the replay guard vacuous.
+    expect(minted).toBe("https://real.example/api/mcp");
+    expect(checked).toBe(minted);
+  });
+});

--- a/apps/timeline-gstudio001/lib/oauth/metadata.ts
+++ b/apps/timeline-gstudio001/lib/oauth/metadata.ts
@@ -8,11 +8,73 @@ import { MCP_SCOPE } from "./core";
 export function originFromRequest(request: Request): string {
   // x-forwarded-* is what Vercel sets in front of the function; fall back to
   // the request URL for local dev.
+  //
+  // CLIENT-CONTROLLED unless something upstream overwrites it. Never call this
+  // directly — go through `resolveIssuerOrigin`, which decides whether the
+  // derived value may be trusted and tells the caller.
   const headers = request.headers;
   const forwardedHost = headers.get("x-forwarded-host") ?? headers.get("host");
   const forwardedProto = headers.get("x-forwarded-proto") ?? "https";
   if (forwardedHost) return `${forwardedProto}://${forwardedHost}`;
   return new URL(request.url).origin;
+}
+
+/** The env var that pins the advertised origin. Set it in any deployment that
+ *  sits behind a shared cache, which is every real one. */
+const ISSUER_ENV = "MCP_OAUTH_ISSUER";
+
+/**
+ * The origin this deployment advertises, and whether it is TRUSTWORTHY.
+ *
+ * Deriving it from the request is convenient — one build serves localhost,
+ * previews and production — but `x-forwarded-host` is a header the client
+ * sets. Two things went wrong with trusting it:
+ *
+ *   POISONED DISCOVERY. `/.well-known/*` served the derived origin with
+ *   `cache-control: public, max-age=300` and no `Vary`, so the cache key was
+ *   the path alone. One request carrying `X-Forwarded-Host: evil.example`
+ *   could park a document advertising `token_endpoint:
+ *   https://evil.example/api/oauth/token` in any shared cache in front of the
+ *   app, and legitimate clients would send their `client_secret` and
+ *   authorization code there for the next five minutes.
+ *
+ *   A SELF-REFERENTIAL AUDIENCE CHECK. `/api/mcp` binds tokens to
+ *   `mcpResourceUrl(origin)` so "a token minted for another resource can't be
+ *   replayed here" — but when both the minting and the checking derive the
+ *   origin from the same client-supplied header, the comparison is between an
+ *   attacker's value and the same attacker's value. It always agreed, so it
+ *   was never protection at all.
+ *
+ * Pinned, both problems disappear: the advertised origin cannot be moved, and
+ * the audience becomes a real per-deployment constant.
+ *
+ * UNSET IS STILL SAFE, just uncacheable — callers must use `metadataHeaders`,
+ * which switches to `no-store` when the origin is derived. The insecure
+ * combination (derived AND publicly cached) is the one thing that can no
+ * longer be expressed.
+ *
+ * A MALFORMED value falls back to derived rather than throwing: a typo in an
+ * env var should not take the deployment down, and falling back is safe
+ * because it also drops caching. It is logged, because silently ignoring the
+ * pin would leave an operator believing they were protected.
+ */
+export function resolveIssuerOrigin(request: Request): {
+  origin: string;
+  pinned: boolean;
+} {
+  const configured = process.env[ISSUER_ENV]?.trim();
+  if (configured) {
+    try {
+      const url = new URL(configured);
+      if (url.protocol === "https:" || url.protocol === "http:") {
+        return { origin: url.origin, pinned: true };
+      }
+      console.error(`${ISSUER_ENV} must be http(s), got "${configured}" — ignoring it.`);
+    } catch {
+      console.error(`${ISSUER_ENV} is not a valid URL: "${configured}" — ignoring it.`);
+    }
+  }
+  return { origin: originFromRequest(request), pinned: false };
 }
 
 export function mcpResourceUrl(origin: string): string {
@@ -49,11 +111,30 @@ export function authorizationServerMetadata(origin: string) {
   };
 }
 
-/** Discovery documents are public and fetched cross-origin by the client. */
-export const METADATA_HEADERS = {
-  "content-type": "application/json",
-  "cache-control": "public, max-age=300",
+/**
+ * Discovery documents are public and fetched cross-origin by the client.
+ *
+ * CACHING IS CONDITIONAL on the origin being pinned. A derived origin means
+ * the body depends on a request header, and a shared cache keyed on the path
+ * alone would hand one client's header to the next client. `Vary` is sent
+ * either way — it is the honest description of the response even when
+ * `no-store` already settles it, and it protects any cache that honours
+ * `Vary` but not the store directive.
+ */
+export function metadataHeaders(pinned: boolean): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    "cache-control": pinned ? "public, max-age=300" : "no-store",
+    vary: "X-Forwarded-Host, X-Forwarded-Proto, Host",
+    "access-control-allow-origin": "*",
+    "access-control-allow-methods": "GET, OPTIONS",
+    "access-control-allow-headers": "*",
+  };
+}
+
+/** Preflight carries no body, so it never depends on the origin. */
+export const METADATA_PREFLIGHT_HEADERS: Record<string, string> = {
   "access-control-allow-origin": "*",
   "access-control-allow-methods": "GET, OPTIONS",
   "access-control-allow-headers": "*",
-} as const;
+};


### PR DESCRIPTION
Closes #335.

`x-forwarded-host` is a header the **client** sends, and the advertised origin
was derived from it. The two `.well-known` documents carrying that origin went
out `public, max-age=300` with **no `Vary`**, so the cache key was the path
alone. One request with `X-Forwarded-Host: evil.example` could park a document
naming `token_endpoint: https://evil.example/api/oauth/token` in any shared
cache in front of the app, and real clients would post their `client_secret`
and authorization code there for the next five minutes.

## The issue understates it

The same header feeds the token **audience**, and that is the sharper half.
`/api/mcp` binds tokens to `mcpResourceUrl(origin)` so that *"a token minted
for another resource can't be replayed here"* — but the mint and the check both
derived the origin from the caller's own header. The comparison was an
attacker's value against the same attacker's value; it always agreed. **That
guard has never done anything** on a deployment where the header reaches the
function.

## The fix

`resolveIssuerOrigin` pins the origin to `MCP_OAUTH_ISSUER` and reports whether
it is trustworthy. All **five** call sites now go through it — both discovery
routes, the audience check, `/authorize` and `/token` — so there is one answer
to "who are we" instead of five derivations of a spoofable header.

**Unset still works, and is still safe.** Localhost and previews keep deriving,
but `metadataHeaders(pinned)` switches those responses to `no-store`. The
dangerous combination — a body that depends on a request header, cached under a
key that ignores it — is the one thing that can no longer be expressed. `Vary`
is sent either way, for caches that honour it but not the store directive.

A malformed pin falls back to derived rather than throwing: a typo should not
take a deployment down, and the fallback is safe because it also drops caching.
It logs, because silently ignoring the pin would leave an operator believing
they were covered.

## Not verified

Whether Vercel's edge overwrites a client-supplied `x-forwarded-host` before
the function sees it — the issue flags this too. It decides whether this was
exploitable in production *today*. It does not change whether the code should
trust the header, and the audience check is vacuous either way.

## Verification

With the module reverted, all eight new tests fail.

| | |
|---|---|
| ignores a poisoned header when pinned | endpoints stay on the real host |
| normalizes a pinned issuer to its origin | a stray path can't double up |
| unset → derived but **unpinned** | preview/localhost keep working |
| malformed pin → falls back, does **not** claim pinned | a typo can't silently un-protect |
| non-http scheme refused | |
| caches only a pinned origin | `no-store` otherwise |
| audience is a per-deployment constant | two different poisoned headers, one audience |

764 app tests, typecheck and lint clean. `MCP_OAUTH_ISSUER` documented in
`.env.example`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)