### PR TITLE
Cover the audio clip, and stop painting a .flac as a picture

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -84,6 +84,34 @@ const audioCollectionGraph = (() => {
   return result.value;
 })();
 
+
+/** An audio MEDIA card — the clip itself, not a collection that leads with one.
+ *  #314: the feature shipped without this. An audio card has no frame to draw
+ *  and no poster to fall back to, so what it paints is the placeholder, and
+ *  the kind stamp has to say AUDIO rather than defaulting to IMAGE. */
+const AUDIO_CLIP_ID = "vo-solo" as NodeId;
+const audioClipGraph = (() => {
+  const result = buildGraph([
+    {
+      kind: "collection",
+      id: "audio-parent" as NodeId,
+      name: "Takes",
+      children: [
+        {
+          kind: "media",
+          id: AUDIO_CLIP_ID,
+          name: "Pat VO",
+          mediaKind: "audio",
+          src: "data:audio/wav;base64,UklGRg==",
+          fullDurationSeconds: 8,
+        },
+      ],
+    },
+  ]);
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.value;
+})();
+
 const emptyCollectionNode = emptyCollectionGraph.nodesById.get(EMPTY_COLLECTION_ID);
 if (emptyCollectionNode?.kind !== "collection") {
   throw new Error("Empty collection ghost fixture did not build.");
@@ -321,6 +349,54 @@ export const AudioLedCollectionShowsMusicGlyph: Story = {
     // nothing about this change.
     await expect(fallback!.getAttribute("data-collection-preview-kind")).toBe("audio");
     await expect(previewImages(canvasElement)).toHaveLength(0);
+  },
+};
+
+/**
+ * #314 item 2: an audio CLIP had no card story at all — and writing one found
+ * a live bug.
+ *
+ * The media card here is the PACKAGE default (`NodeThumbnail`); the graph view
+ * registers its own shell for COLLECTIONS only. That default asked "is it
+ * video?", and everything else took the image branch — so an audio node, which
+ * does have a `src`, rendered `<img src="…take.flac">`: a broken image on
+ * every audio card. Exactly the shape of #312.
+ */
+export const AudioClipCardDoesNotRenderItsFlacAsAnImage: Story = {
+  args: { ...baseArgs, id: AUDIO_CLIP_ID },
+  decorators: [
+    (Story) => {
+      const store = createGraphDetailsStore({
+        [AUDIO_CLIP_ID]: {
+          alt: "Pat VO",
+          aspect: 16 / 9,
+          trackIndex: 0,
+          duration: 8,
+        } satisfies ClipDetail,
+      });
+      return (
+        <DndCollections initialGraph={audioClipGraph}>
+          <GraphDetailsProvider store={store}>
+            <div className="h-32 w-40 bg-zinc-950 p-2">
+              <Story />
+            </div>
+          </GraphDetailsProvider>
+        </DndCollections>
+      );
+    },
+  ],
+  play: async ({ canvasElement }) => {
+    // THE REGRESSION GUARD. One <img> here means the audio branch is gone and
+    // a .flac is being painted as a picture.
+    await expect(previewImages(canvasElement)).toHaveLength(0);
+    await expect(
+      canvasElement.querySelector("[data-node-thumbnail='image']"),
+    ).toBeNull();
+
+    // And it says what it IS. "No preview" would describe a picture that
+    // failed; there was never going to be one.
+    await expect(canvasElement.textContent).toContain("Audio");
+    await expect(canvasElement.textContent).not.toContain("No image");
   },
 };
 

--- a/apps/timeline-gstudio001/lib/assets/asset-references.test.ts
+++ b/apps/timeline-gstudio001/lib/assets/asset-references.test.ts
@@ -12,7 +12,7 @@ import {
 function mediaClip(
   id: string,
   source?: { providerId: string; assetId: string },
-  kind: "image" | "video" = "image",
+  kind: "image" | "video" | "audio" = "image",
 ): TimelineClip {
   return {
     id,
@@ -89,6 +89,53 @@ describe("assetCandidatesFromClips", () => {
         kind: "video",
       }),
     ]);
+  });
+
+  // #314. The polarity here was inverted so audio yields a candidate at all —
+  // `sourceAssetOf` excludes COLLECTIONS rather than allow-listing image and
+  // video, precisely so a new media kind cannot be silently omitted. Nothing
+  // tested it. An omitted kind is never marked for reclaim, so its file lives
+  // in storage forever and NOTHING FAILS: the app looks perfect while the
+  // bill grows. That is the whole reason this test exists.
+  it("yields a reclaim candidate for an AUDIO clip", () => {
+    const ref = { providerId: "cloudinary", assetId: "takes/vo.flac" };
+
+    const candidates = assetCandidatesFromClips([mediaClip("a1", ref, "audio")]);
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({ ref });
+  });
+
+  it("addresses audio as the provider's `video` resource type", () => {
+    // AssetKind is the PROVIDER's taxonomy, not the clip's. Cloudinary serves
+    // audio under `video` and its destroy endpoint is per resource type, so
+    // `kind: "audio"` here would fail to delete the file — the same leak by a
+    // different route.
+    const candidates = assetCandidatesFromClips([
+      mediaClip("a1", { providerId: "cloudinary", assetId: "takes/vo.flac" }, "audio"),
+    ]);
+
+    expect(candidates[0].kind).toBe("video");
+  });
+
+  it("gives audio an EMPTY thumbnail rather than its own src", () => {
+    // Audio has no poster and is not its own thumbnail. Falling back to `src`
+    // would put a .flac URL in the recently-deleted list where a row renders
+    // it as an <img> — a broken image for every deleted voice take.
+    const candidates = assetCandidatesFromClips([
+      mediaClip("a1", { providerId: "cloudinary", assetId: "takes/vo.flac" }, "audio"),
+    ]);
+
+    expect(candidates[0].thumbnailUrl).toBe("");
+  });
+
+  it("still names an audio candidate from the asset id when it has no title", () => {
+    const candidates = assetCandidatesFromClips([
+      mediaClip("a1", { providerId: "cloudinary", assetId: "takes/vo.flac" }, "audio"),
+    ]);
+
+    // A row that prints nothing at all is worse than one printing the leaf.
+    expect(candidates[0].name).toBe("a1");
   });
 
   it("snapshots a name and a thumbnail, because no clip will be left to ask", () => {

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -37,7 +37,7 @@ type FixtureDocument = { id: string; title: string; clips: FixtureClip[] };
 
 function mediaClip(
   id: string,
-  kind: "image" | "video",
+  kind: "image" | "video" | "audio",
   index: number,
   duration: number,
   sourceDuration = duration,
@@ -47,7 +47,10 @@ function mediaClip(
     index,
     kind,
     src: PIXEL,
-    poster: PIXEL,
+    // Audio must NOT carry a poster: the field exists on the shared type, and
+    // a poster minted for a sound file is a broken image wherever a card or
+    // the recently-deleted list paints one.
+    ...(kind === "audio" ? {} : { poster: PIXEL }),
     alt: id,
     aspect: 16 / 9,
     trackIndex: 0,
@@ -675,6 +678,37 @@ test.describe("graph view E2E", () => {
     expect(labelBox).not.toBeNull();
     expect(stripBox).not.toBeNull();
     expect(Math.abs(stripBox!.x - labelBox!.x)).toBeLessThanOrEqual(2);
+  });
+
+  // #314 item 3: the e2e suite never asserted `data-media-kind="audio"`. The
+  // stamp is three-way since audio landed, and its ternary asks "is it video?"
+  // first — so a lost audio arm falls through to IMAGE and a voice take is
+  // labelled a picture. That is invisible on a board of images, which is how
+  // #312 shipped.
+  //
+  // Its own document rather than the shared fixture: 160-odd tests assert that
+  // fixture's exact contents, and adding a clip to it would be a large blast
+  // radius for one attribute.
+  test("an audio clip is stamped AUDIO, not IMAGE", async ({ page }) => {
+    const api = await installGraphApi(page);
+    api.documents
+      .get(CHILD_ID)!
+      .clips.push(collectionClip("clip-takes", GRANDCHILD_ID, 2, "Takes", 1));
+    api.documents.set(GRANDCHILD_ID, {
+      id: GRANDCHILD_ID,
+      title: "Takes",
+      clips: [mediaClip("vo-1", "audio", 0, 8)],
+    });
+
+    await openGraph(page);
+    await expandSubGraph(page, "Scene A");
+    await expandSubGraph(page, "Takes");
+
+    const card = strip(page, GRANDCHILD_ID).locator('[data-node-id="vo-1"]');
+    await expect(card).toBeVisible();
+    const stamp = card.locator("[data-media-kind]");
+    await expect(stamp).toHaveAttribute("data-media-kind", "audio");
+    await expect(stamp).toHaveText("AUDIO");
   });
 
   test("sub-graphs nest recursively: expanding a child reveals its own collapsed children", async ({

--- a/packages/ui/dnd-collections/react/node-thumbnail.tsx
+++ b/packages/ui/dnd-collections/react/node-thumbnail.tsx
@@ -19,6 +19,16 @@ export const NodeThumbnail = memo(function NodeThumbnail({ node }: { node: Media
     return <VideoThumbnail key={JSON.stringify(posters)} node={node} posters={posters} />;
   }
 
+  // AUDIO HAS NO PICTURE, and it has a `src` — so without this it fell through
+  // to the image branch and rendered `<img src="…/take.flac">`: a broken image
+  // on every audio card. The same shape as #312, where audio sailed through
+  // gates that only ever asked "is it video?".
+  //
+  // Labelled "Audio" rather than "No preview": the other fallbacks describe a
+  // picture that is missing or failed, and this one is neither — there was
+  // never going to be a picture, and saying so is not an error state.
+  if (node.mediaKind === "audio") return <ThumbnailFallback label="Audio" />;
+
   if (!node.src) return <ThumbnailFallback label="No image" />;
   return <ImageThumbnail key={node.src} src={node.src} />;
 });


### PR DESCRIPTION
Closes #314.

Writing the coverage the issue asked for turned up a live bug it did not know
about — roughly the argument the issue was making.

## Found: audio rendered as a broken image

`NodeThumbnail`, the dnd-collections package's default media preview, asked
*"is it video?"* and sent everything else down the **image** branch. Audio has
a `src`, so an audio node rendered:

```html
<img src="…/take.flac">
```

A broken image on every card using the package default. Exactly the shape of
**#312**, where audio sailed through five gates that only tested
`kind !== "video"`. It now has its own branch, labelled `"Audio"` rather than
`"No preview"` — the other fallbacks describe a picture that is missing or
failed, and this is neither.

## 1. The reclaim leak guard (the issue's highest-ranked item)

`sourceAssetOf` excludes **collections** rather than allow-listing image and
video, precisely so a new media kind cannot be silently omitted — and nothing
tested it. An omitted kind is never marked for reclaim, so its file lives in
storage forever and **nothing fails**.

Four tests pin it: audio yields a candidate at all; it is addressed as the
provider's `video` resource type (Cloudinary serves audio there and its destroy
endpoint is per type, so `kind: "audio"` would fail to delete); it gets an
**empty** thumbnail rather than its own `.flac` URL; and it still names itself.

Verified by restoring the allow-list form the issue quotes — all four fail.

## 2. A story for an audio clip card

There was none. It asserts **no `<img>`** and no `data-node-thumbnail="image"`
— the regression above — rather than "a placeholder is present", which would
pass either way.

## 3. An e2e for `data-media-kind="audio"`

Never asserted. The stamp's ternary asks "is it video?" first, so a lost audio
arm falls through to `IMAGE` and labels a voice take a picture.

It gets its **own document** rather than joining the shared fixture: 160-odd
tests assert that fixture's exact contents, and one attribute is not worth that
blast radius. `mediaClip` now mints audio and deliberately omits `poster` — the
field exists on the shared type, and a poster on a sound file is a broken image
wherever one is painted.

## Verification

768 app + 539 unit + 193 story + 169 e2e; typecheck clean in both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)