### PR TITLE
Take a list in create_upload and attach_media

### DIFF
--- a/apps/timeline-gstudio001/app/api/mcp/route.ts
+++ b/apps/timeline-gstudio001/app/api/mcp/route.ts
@@ -9,7 +9,7 @@ import { TIMELINE_APP_HTML } from "@storyboard/timeline-widget";
 
 import { listFirebaseTimelineProjects } from "@/lib/firebase-timeline-store";
 import type { ToolResult } from "@/lib/webmcp/types";
-import { attachMedia, createUploadTicket } from "@/lib/mcp/upload";
+import { attachMedia, createUploadTickets } from "@/lib/mcp/upload";
 import { createCollection } from "@/lib/mcp/create-collection";
 import { handleReadTimeline } from "@/lib/mcp/read-timeline";
 import {
@@ -146,6 +146,11 @@ function uidFrom(extra: { authInfo?: { extra?: Record<string, unknown> } }): str
   const uid = extra.authInfo?.extra?.uid;
   return typeof uid === "string" && uid.length > 0 ? uid : null;
 }
+
+// One signed ticket per file is cheap, but an unbounded list is a way to ask
+// the server to mint arbitrarily many. 50 covers a generation round (24 was
+// the case that prompted #307) without becoming a lever.
+const MAX_UPLOAD_BATCH = 50;
 
 const NO_IDENTITY = "Could not determine the account for this token.";
 
@@ -325,19 +330,43 @@ const handler = createMcpHandler(
 
     server.tool(
       "create_upload",
-      "Start uploading a local media file (mp4, webm, mov, jpg, png, webp). Returns a short-lived signed ticket: POST the file to `uploadUrl` as multipart/form-data with every field from `fields` plus the file itself as `file`. Then call attach_media with the returned publicId. The file's bytes never pass through this tool.",
+      "Start uploading local media (mp4, webm, mov, jpg, png, webp, flac, wav, mp3, m4a, aac, ogg, opus). Returns a short-lived signed ticket per file: POST each file to its `uploadUrl` as multipart/form-data with every field from `fields` plus the file itself as `file`. Then call attach_media with the returned publicId(s). PASS `filenames` FOR A BATCH — filing 24 images one at a time costs 48 round trips. The bytes never pass through this tool.",
       {
         projectId: z.string().min(1).describe("Project the asset belongs to."),
-        filename: z.string().min(1).describe("Original filename, used to name the stored asset."),
+        filename: z
+          .string()
+          .min(1)
+          .optional()
+          .describe("One file. Give this or `filenames`, not both."),
+        filenames: z
+          .array(z.string().min(1))
+          .min(1)
+          .max(MAX_UPLOAD_BATCH)
+          .optional()
+          .describe(
+            "Several files in one call, returning one ticket each in the same order. " +
+              "Prefer this whenever you have more than one file.",
+          ),
       },
       async (args, extra) => {
         const uid = uidFrom(extra);
         if (!uid) return errorResult(NO_IDENTITY);
         try {
-          const ticket = await createUploadTicket(args, uid);
+          const tickets = await createUploadTickets(args, uid);
+          const [ticket] = tickets;
+          if (!ticket) return errorResult("Give `filename` or a non-empty `filenames`.");
+          // The SINGLE response shape is unchanged — the ticket's own fields at
+          // the top level — so an existing caller reads exactly what it did
+          // before. A batch answers with `tickets` instead.
+          if (args.filenames === undefined) {
+            return jsonResult(
+              `Upload ticket for "${ticket.publicId}" (${ticket.resourceType}). POST the file to ${ticket.uploadUrl} with the given fields, then call attach_media with publicId "${ticket.publicId}". Expires ${ticket.expiresAt}.`,
+              ticket,
+            );
+          }
           return jsonResult(
-            `Upload ticket for "${args.filename}" (${ticket.resourceType}). POST the file to ${ticket.uploadUrl} with the given fields, then call attach_media with publicId "${ticket.publicId}". Expires ${ticket.expiresAt}.`,
-            ticket,
+            `${tickets.length} upload tickets. POST each file to its own uploadUrl with that ticket's fields, then call attach_media ONCE with all the publicIds in \`items\`. They expire ${ticket.expiresAt}.`,
+            { tickets },
           );
         } catch (error) {
           if (error instanceof ProjectAssetScopeError) return errorResult(error.message);
@@ -348,12 +377,37 @@ const handler = createMcpHandler(
 
     server.tool(
       "attach_media",
-      "Add an already-uploaded file to a timeline as a clip. Verifies the upload landed, then places it — give at most one of `after`, `before` or `position`." +
+      "Add already-uploaded file(s) to a timeline as clips. Verifies each upload landed, then places them — give at most one of `after`, `before` or `position`. PASS `items` FOR A BATCH: it lands them in ONE write, in the order given, and verifies them with ONE asset listing instead of one per file." +
         NO_LIVE_PUSH_NOTE,
       {
         timelineId: z.string().min(1).describe("Timeline document to add the clip to."),
         projectId: z.string().min(1).describe("Project the asset was uploaded under."),
-        publicId: z.string().min(1).describe("`publicId` returned by create_upload."),
+        publicId: z
+          .string()
+          .min(1)
+          .optional()
+          .describe("One file. Give this or `items`, not both."),
+        items: z
+          .array(
+            z.object({
+              publicId: z.string().min(1).describe("`publicId` returned by create_upload."),
+              name: z.string().optional().describe("Name for this clip."),
+              durationSeconds: z
+                .number()
+                .positive()
+                .optional()
+                .describe("How long this clip plays."),
+              tags: z.array(z.string()).max(MAX_TAGS_PER_CLIP).optional(),
+            }),
+          )
+          .min(1)
+          .max(MAX_UPLOAD_BATCH)
+          .optional()
+          .describe(
+            "Several files landed in ONE write, in this order, from the resolved " +
+              "position. Prefer this whenever you have more than one — it is the " +
+              "difference between 1 timeline write and N.",
+          ),
         into: z
           .string()
           .optional()

--- a/apps/timeline-gstudio001/lib/mcp/upload.test.ts
+++ b/apps/timeline-gstudio001/lib/mcp/upload.test.ts
@@ -77,16 +77,18 @@ vi.mock("@/lib/cloudinary-media-store", () => ({
   // Pure extension test, so the mock mirrors the real rule rather than
   // stubbing it — a stub here would let a wrong clip kind pass unnoticed.
   isAudioAsset: (value: string) => /\.(flac|wav|mp3|m4a|aac|ogg|oga|opus)$/i.test(value),
-  createCloudinaryUploadTicket: () => ({
+  createCloudinaryUploadTicket: (filename: string) => ({
     uploadUrl: "https://api.cloudinary.com/v1_1/demo/video/upload",
-    fields: { api_key: "k", folder: "f", public_id: "p", timestamp: "1", signature: "s" },
-    publicId: "f/p",
+    fields: { api_key: "k", folder: "f", public_id: filename, timestamp: "1", signature: "s" },
+    // Keyed on the filename so a batch's tickets are distinguishable — a fixed
+    // publicId would let a wrong-order or dropped-file bug pass unnoticed.
+    publicId: `f/${filename}`,
     resourceType: "video",
     expiresAt: new Date().toISOString(),
   }),
 }));
 
-import { attachMedia } from "./upload";
+import { attachMedia, createUploadTickets } from "./upload";
 
 const OWNER = "user-a";
 const PROJECT = "project-alpha";
@@ -398,5 +400,152 @@ describe("attachMedia", () => {
 
     expect(result.isError).toBe(true);
     expect(storedClips(PROJECT).map((c) => c.id)).toEqual(["a"]);
+  });
+});
+
+// #307. Filing 24 images took 48 sequential calls — a ticket and an attach per
+// image — so the timeline document was rewritten 24 times (24 chances to lose a
+// revision race) and the project's assets were re-listed 24 times to verify
+// them. Both halves of the pair take a list now.
+describe("batching (#307)", () => {
+  /** Three uploads sitting in the project, ready to attach. */
+  function seedThreeAssets() {
+    state.assets.length = 0;
+    for (const name of ["shot-a", "shot-b", "shot-c"]) {
+      state.assets.push({
+        id: name,
+        pathname: `media/user-a/project-alpha/${name}`,
+        url: `https://res.cloudinary.com/demo/image/upload/${name}.jpg`,
+        thumbnailUrl: `https://res.cloudinary.com/demo/image/upload/${name}.jpg`,
+        resourceType: "image",
+        relativePath: name,
+      });
+    }
+  }
+
+  it("mints one ticket per filename, in order", async () => {
+    seed(PROJECT, []);
+    const tickets = await createUploadTickets(
+      { projectId: PROJECT, filenames: ["a.jpg", "b.jpg", "c.jpg"] },
+      OWNER,
+    );
+
+    expect(tickets.map((ticket) => ticket.publicId)).toEqual(["f/a.jpg", "f/b.jpg", "f/c.jpg"]);
+  });
+
+  it("names EVERY unsupported file, not just the first", async () => {
+    seed(PROJECT, []);
+    // One bad name per round trip is the cost this change exists to remove.
+    await expect(
+      createUploadTickets({ projectId: PROJECT, filenames: ["a.jpg", "b.txt", "c.exe"] }, OWNER),
+    ).rejects.toThrow(/"b\.txt", "c\.exe"/);
+  });
+
+  it("lands a batch in ONE write, in the order given", async () => {
+    seed(PROJECT, [clip("existing")]);
+    seedThreeAssets();
+
+    const result = await attachMedia(
+      {
+        timelineId: PROJECT,
+        projectId: PROJECT,
+        items: [
+          { publicId: "media/user-a/project-alpha/shot-a" },
+          { publicId: "media/user-a/project-alpha/shot-b" },
+          { publicId: "media/user-a/project-alpha/shot-c" },
+        ],
+        position: "end",
+      },
+      OWNER,
+    );
+
+    expect(result.isError).toBeFalsy();
+    const stored = storedClips(PROJECT);
+    expect(stored).toHaveLength(4);
+    // Order preserved: `add-nodes` inserts the array at one index, so the batch
+    // must not arrive reversed or scattered.
+    expect(stored.slice(1).map((entry) => entry.alt)).toEqual(["shot-a", "shot-b", "shot-c"]);
+    // ONE write. The revision moved by exactly one, which is the whole point —
+    // three attaches would have bumped it three times.
+    expect((state.docs.get(PROJECT) as { revision: number }).revision).toBe(2);
+  });
+
+  it("reports every attached clip, and keeps the single-file shape intact", async () => {
+    seed(PROJECT, []);
+    seedThreeAssets();
+
+    const batch = await attachMedia(
+      {
+        timelineId: PROJECT,
+        projectId: PROJECT,
+        items: [
+          { publicId: "media/user-a/project-alpha/shot-a" },
+          { publicId: "media/user-a/project-alpha/shot-b" },
+        ],
+      },
+      OWNER,
+    );
+    const batchContent = (batch.structuredContent ?? {}) as {
+      attached?: { nodeId: string; toIndex: number }[];
+      nodeId?: string;
+    };
+    expect(batchContent.attached).toHaveLength(2);
+    expect(batchContent.attached!.map((entry) => entry.toIndex)).toEqual([0, 1]);
+
+    // A single attach answers exactly as it always did — no `attached`, the
+    // clip's own fields at the top level — so existing callers are untouched.
+    const single = await attachMedia(
+      { timelineId: PROJECT, projectId: PROJECT, publicId: "media/user-a/project-alpha/shot-c" },
+      OWNER,
+    );
+    const singleContent = (single.structuredContent ?? {}) as { attached?: unknown; nodeId?: string };
+    expect(singleContent.attached).toBeUndefined();
+    expect(typeof singleContent.nodeId).toBe("string");
+  });
+
+  it("carries per-item name and duration rather than one setting for all", async () => {
+    seed(PROJECT, []);
+    seedThreeAssets();
+
+    await attachMedia(
+      {
+        timelineId: PROJECT,
+        projectId: PROJECT,
+        items: [
+          { publicId: "media/user-a/project-alpha/shot-a", name: "Opening", durationSeconds: 2 },
+          { publicId: "media/user-a/project-alpha/shot-b", name: "Closing", durationSeconds: 7 },
+        ],
+      },
+      OWNER,
+    );
+
+    const stored = storedClips(PROJECT);
+    expect(stored.map((entry) => entry.title)).toEqual(["Opening", "Closing"]);
+    expect(stored.map((entry) => entry.duration)).toEqual([2, 7]);
+  });
+
+  it("refuses the WHOLE batch, naming every missing upload", async () => {
+    seed(PROJECT, [clip("existing")]);
+    seedThreeAssets();
+
+    const result = await attachMedia(
+      {
+        timelineId: PROJECT,
+        projectId: PROJECT,
+        items: [
+          { publicId: "media/user-a/project-alpha/shot-a" },
+          { publicId: "never-uploaded" },
+          { publicId: "also-missing" },
+        ],
+      },
+      OWNER,
+    );
+
+    expect(result.isError).toBe(true);
+    const text = result.content.map((part) => ("text" in part ? part.text : "")).join(" ");
+    expect(text).toContain("never-uploaded");
+    expect(text).toContain("also-missing");
+    // Nothing partially landed: one bad id must not leave the others attached.
+    expect(storedClips(PROJECT)).toHaveLength(1);
   });
 });

--- a/apps/timeline-gstudio001/lib/mcp/upload.ts
+++ b/apps/timeline-gstudio001/lib/mcp/upload.ts
@@ -32,28 +32,69 @@ import { applyCollectionsCommand } from "./apply-command";
 
 const ALLOWED = /\.(mp4|webm|mov|jpe?g|png|webp|flac|wav|mp3|m4a|aac|ogg|oga|opus)$/i;
 
-export type CreateUploadArgs = Readonly<{ projectId: string; filename: string }>;
+export type CreateUploadArgs = Readonly<{
+  projectId: string;
+  /** One file. Mutually exclusive with `filenames`. */
+  filename?: string;
+  /** A BATCH. Filing 24 images took 24 tickets and 24 attach calls — 48 round
+   *  trips — so both halves of the pair take a list now. */
+  filenames?: readonly string[];
+}>;
+
+/** Every ticket a `create_upload` call minted, in the order asked for. */
+export async function createUploadTickets(
+  args: CreateUploadArgs,
+  requesterUid: string,
+): Promise<CloudinaryUploadTicket[]> {
+  const filenames = args.filenames ?? (args.filename === undefined ? [] : [args.filename]);
+  if (filenames.length === 0) throw new Error("Give `filename` or a non-empty `filenames`.");
+
+  // Scope-checked ONCE for the whole batch rather than per file.
+  const projectId = await requireProjectAssetScope(args.projectId, requesterUid);
+  const unsupported = filenames.filter((name) => !ALLOWED.test(name));
+  if (unsupported.length > 0) {
+    // ALL of them, not the first: a caller fixing one name at a time pays a
+    // round trip per mistake, which is the cost this whole change is about.
+    throw new Error(
+      `Unsupported file type(s): ${unsupported.map((name) => `"${name}"`).join(", ")}. ` +
+        `Allowed: mp4, webm, mov, jpg, jpeg, png, webp, flac, wav, mp3, m4a, aac, ogg, opus.`,
+    );
+  }
+  return Promise.all(
+    filenames.map((filename) => createCloudinaryUploadTicket(filename, requesterUid, projectId)),
+  );
+}
 
 export async function createUploadTicket(
   args: CreateUploadArgs,
   requesterUid: string,
 ): Promise<CloudinaryUploadTicket> {
-  const projectId = await requireProjectAssetScope(args.projectId, requesterUid);
-  if (!ALLOWED.test(args.filename)) {
-    throw new Error(
-      `Unsupported file type "${args.filename}". Allowed: mp4, webm, mov, jpg, jpeg, ` +
-        `png, webp, flac, wav, mp3, m4a, aac, ogg, opus.`,
-    );
-  }
-  return createCloudinaryUploadTicket(args.filename, requesterUid, projectId);
+  const [ticket] = await createUploadTickets(args, requesterUid);
+  if (!ticket) throw new Error("Give `filename` or a non-empty `filenames`.");
+  return ticket;
 }
 
 // --- attach_media ------------------------------------------------------------
 
+/** One file to land. The per-clip half of a batch attach. */
+export type AttachMediaItem = Readonly<{
+  publicId: string;
+  name?: string;
+  durationSeconds?: number;
+  tags?: readonly string[];
+}>;
+
 export type AttachMediaArgs = Readonly<{
   timelineId: string;
   projectId: string;
-  publicId: string;
+  /** One file. Mutually exclusive with `items`. */
+  publicId?: string;
+  /** A BATCH, landed in ONE write. Attaching 24 images one at a time rewrote
+   *  the timeline document 24 times — 24 chances to lose a revision race with
+   *  another writer — and re-listed the project's assets 24 times to verify
+   *  them. Placement applies to the group: they land consecutively from the
+   *  resolved index, in the order given. */
+  items?: readonly AttachMediaItem[];
   into?: string;
   name?: string;
   after?: string;
@@ -76,48 +117,127 @@ export async function attachMedia(
   args: AttachMediaArgs,
   requesterUid: string,
 ): Promise<ToolResult> {
+  const items: readonly AttachMediaItem[] =
+    args.items ??
+    (args.publicId === undefined
+      ? []
+      : [
+          {
+            publicId: args.publicId,
+            ...(args.name === undefined ? {} : { name: args.name }),
+            ...(args.durationSeconds === undefined
+              ? {}
+              : { durationSeconds: args.durationSeconds }),
+            ...(args.tags === undefined ? {} : { tags: args.tags }),
+          },
+        ]);
+  if (items.length === 0) return toolError("Give `publicId` or a non-empty `items`.");
+
   const projectId = await requireProjectAssetScope(args.projectId, requesterUid);
 
-  // Verify the file actually landed and read its REAL url/duration rather than
-  // trusting arguments. This is what catches a caller whose upload never ran or
-  // whose ticket expired — otherwise we would mint a clip pointing at nothing.
-  // Drop the cached listing first: nothing invalidated it, because the bytes
-  // went straight to Cloudinary without passing through this server.
+  // ONE listing for the whole batch. Verify the files actually landed and read
+  // their REAL url/duration rather than trusting arguments — this is what
+  // catches a caller whose upload never ran or whose ticket expired, otherwise
+  // we would mint a clip pointing at nothing. Drop the cached listing first:
+  // nothing invalidated it, because the bytes went straight to Cloudinary
+  // without passing through this server.
   forgetCloudinaryAssetList(requesterUid);
   const assets = await listCloudinaryAssets(requesterUid, projectId);
-  const asset = assets.find((candidate) => candidate.pathname === args.publicId);
-  if (!asset) {
+  const byPathname = new Map(assets.map((asset) => [asset.pathname, asset]));
+
+  // EVERY missing id, not just the first. A batch that reports one failure per
+  // round trip costs exactly what batching was meant to save.
+  const missing = items.filter((item) => !byPathname.has(item.publicId));
+  if (missing.length > 0) {
     return toolError(
-      `No uploaded asset "${args.publicId}" in project "${projectId}". Upload the file using the ticket from create_upload first, then retry.`,
+      `No uploaded asset${missing.length > 1 ? "s" : ""} ` +
+        `${missing.map((item) => `"${item.publicId}"`).join(", ")} in project "${projectId}". ` +
+        `Upload the file using the ticket from create_upload first, then retry.`,
     );
   }
 
-  // Cloudinary serves AUDIO under resourceType "video" — there is no separate
-  // audio type — so the clip kind comes from the FORMAT, never from
-  // resourceType. Reading resourceType here would file every voice take as a
-  // video clip with a broken poster.
-  //
-  // NOT `pathname`: a Cloudinary public_id has no extension ("brian-take-6s",
-  // not "brian-take-6s.flac"), so testing it always says "not audio". `format`
-  // is the field that carries it; the secure_url is the fallback for a listing
-  // that omitted it.
-  const isAudio = isAudioAsset(asset.format ?? asset.url);
-  const isVideo = !isAudio && asset.resourceType === "video";
-  const sourceSeconds = asset.duration ?? DEFAULT_VIDEO_SECONDS;
-  const displayName =
-    (args.name ?? asset.relativePath ?? asset.pathname).trim() || asset.pathname;
+  const prepared = items.map((item) => {
+    const asset = byPathname.get(item.publicId)!;
+    // Cloudinary serves AUDIO under resourceType "video" — there is no separate
+    // audio type — so the clip kind comes from the FORMAT, never from
+    // resourceType. Reading resourceType here would file every voice take as a
+    // video clip with a broken poster.
+    //
+    // NOT `pathname`: a Cloudinary public_id has no extension ("brian-take-6s",
+    // not "brian-take-6s.flac"), so testing it always says "not audio".
+    // `format` is the field that carries it; the secure_url is the fallback for
+    // a listing that omitted it.
+    const isAudio = isAudioAsset(asset.format ?? asset.url);
+    const isVideo = !isAudio && asset.resourceType === "video";
+    const sourceSeconds = asset.duration ?? DEFAULT_VIDEO_SECONDS;
+    const displayName =
+      (item.name ?? asset.relativePath ?? asset.pathname).trim() || asset.pathname;
 
-  // A freshly MINTED id, not one derived from the public id. Deriving it made
-  // the id a function of the asset, so attaching one asset twice produced two
-  // nodes with the same id — which node ids, being the addressing scheme,
-  // cannot allow. That forced a "one asset, one place" rule nothing about the
-  // product wanted, and it collided across documents too (the read projection
-  // in timeline-domain has to demote such clips to `dup:` ids to keep the whole
-  // tree from being rejected). Asset identity lives in `sourceAsset` below,
-  // which is what every reader actually uses to recover it; the id only has to
-  // be unique. Same prefixes as the drag-drop path so both mint alike.
-  const kindPrefix = isAudio ? "audio" : isVideo ? "video" : "image";
-  const newNodeId = parseNodeId(`${kindPrefix}-${randomUUID().slice(0, 8)}`);
+    // A freshly MINTED id, not one derived from the public id. Deriving it made
+    // the id a function of the asset, so attaching one asset twice produced two
+    // nodes with the same id — which node ids, being the addressing scheme,
+    // cannot allow. Asset identity lives in `sourceAsset`, which is what every
+    // reader actually uses to recover it; the id only has to be unique. Same
+    // prefixes as the drag-drop path so both mint alike.
+    const kindPrefix = isAudio ? "audio" : isVideo ? "video" : "image";
+    const nodeId = parseNodeId(`${kindPrefix}-${randomUUID().slice(0, 8)}`);
+
+    const node =
+      isVideo || isAudio
+        ? {
+            id: nodeId,
+            kind: "media" as const,
+            // Both WINDOWED kinds mint identically — same source length, same
+            // trims. Audio simply has no posterSrcs.
+            mediaKind: isAudio ? ("audio" as const) : ("video" as const),
+            name: displayName,
+            src: asset.url,
+            fullDurationSeconds: sourceSeconds,
+            trimInSeconds: 0,
+            // Trims are AMOUNTS REMOVED from each end, not offsets into the
+            // source — `mediaDurationSeconds` computes `full - trimIn -
+            // trimOut`, so an untrimmed clip is 0/0. Passing the play length
+            // straight through as `trimOutSeconds` trimmed the whole clip away
+            // and packed it at zero width.
+            trimOutSeconds: Math.max(
+              0,
+              sourceSeconds - Math.min(item.durationSeconds ?? sourceSeconds, sourceSeconds),
+            ),
+          }
+        : {
+            id: nodeId,
+            kind: "media" as const,
+            mediaKind: "image" as const,
+            name: displayName,
+            src: asset.url,
+            durationSeconds: item.durationSeconds ?? DEFAULT_IMAGE_SECONDS,
+          };
+
+    const detail = {
+      alt: displayName,
+      // An explicit `name` argument is an AUTHORED title, so record it as one.
+      // Cards render `title` and never `alt` — deliberately, so a library of
+      // machine-named clips does not read as a rename backlog — which meant a
+      // caller-supplied name was accepted, stored as `alt`, and shown nowhere.
+      //
+      // It matters most for AUDIO: an audio card has no thumbnail, so the title
+      // is the only thing distinguishing one take from another.
+      ...(item.name?.trim() ? { title: item.name.trim() } : {}),
+      aspect: 16 / 9,
+      trackIndex: 0,
+      sourceAsset: { providerId: CLOUDINARY_PROVIDER_ID, assetId: asset.pathname },
+      // Tagged at mint time so agent-uploaded media arrives filed. This is the
+      // only chance to do it automatically — a clip that lands untagged stays
+      // untagged until someone opens it by hand.
+      ...tagsField(item.tags),
+      // No poster for audio: Cloudinary would mint a still-frame jpg URL for a
+      // resource that has no frames, and it renders broken.
+      ...(!isAudio && asset.thumbnailUrl ? { poster: asset.thumbnailUrl } : {}),
+    };
+
+    return { nodeId, node, detail, displayName, asset };
+  });
+
   let placedIndex = -1;
   let placedParent: NodeId | null = null;
 
@@ -133,8 +253,11 @@ export async function attachMedia(
           message: `Target "${targetId}" is a clip, not a collection — clips can only go inside a collection.`,
         } as const;
       }
+      // Placement is resolved for the FIRST node; `add-nodes` inserts the whole
+      // array at that index, so a batch lands consecutively in the order given
+      // rather than reversed or scattered.
       const placement = resolveMovePlacement(graph, {
-        nodeId: newNodeId,
+        nodeId: prepared[0]!.nodeId,
         targetId,
         ...(args.before === undefined ? {} : { before: parseNodeId(args.before) }),
         ...(args.after === undefined ? {} : { after: parseNodeId(args.after) }),
@@ -159,69 +282,15 @@ export async function attachMedia(
           type: "add-nodes",
           toParentId: placement.toParentId,
           toIndex: placement.toIndex,
-          nodes: [
-            isVideo || isAudio
-              ? {
-                  id: newNodeId,
-                  kind: "media" as const,
-                  // Both WINDOWED kinds mint identically — same source length,
-                  // same trims. Audio simply has no posterSrcs.
-                  mediaKind: isAudio ? ("audio" as const) : ("video" as const),
-                  name: displayName,
-                  src: asset.url,
-                  fullDurationSeconds: sourceSeconds,
-                  trimInSeconds: 0,
-                  // Trims are AMOUNTS REMOVED from each end, not offsets into
-                  // the source — `mediaDurationSeconds` computes
-                  // `full - trimIn - trimOut`, so an untrimmed clip is 0/0.
-                  // Passing the play length straight through as `trimOutSeconds`
-                  // trimmed the whole clip away and packed it at zero width.
-                  trimOutSeconds: Math.max(
-                    0,
-                    sourceSeconds - Math.min(args.durationSeconds ?? sourceSeconds, sourceSeconds),
-                  ),
-                }
-              : {
-                  id: newNodeId,
-                  kind: "media" as const,
-                  mediaKind: "image" as const,
-                  name: displayName,
-                  src: asset.url,
-                  durationSeconds: args.durationSeconds ?? DEFAULT_IMAGE_SECONDS,
-                },
-          ],
+          nodes: prepared.map((entry) => entry.node),
         },
         // PROVENANCE — not optional. `graphChildrenToClips` reads sourceAsset
-        // from details, not the node, so without this the clip is written with
-        // no provenance, is never marked for reclaim, and its file leaks in
+        // from details, not the node, so without this a clip is written with no
+        // provenance, is never marked for reclaim, and its file leaks in
         // storage forever (docs/asset-providers.md).
-        details: {
-          [newNodeId as string]: {
-            alt: displayName,
-            // An explicit `name` argument is an AUTHORED title, so record it as
-            // one. Cards render `title` and never `alt` — deliberately, so a
-            // library of machine-named clips does not read as a rename backlog
-            // — which meant a caller-supplied name was accepted, stored as
-            // `alt`, and then shown nowhere.
-            //
-            // It matters most for AUDIO: an audio card has no thumbnail, so the
-            // title is the only thing distinguishing one take from another.
-            // Absent when the caller passed no name, which keeps the
-            // "unnamed looks neutral" rule intact.
-            ...(args.name?.trim() ? { title: args.name.trim() } : {}),
-            aspect: 16 / 9,
-            trackIndex: 0,
-            sourceAsset: { providerId: CLOUDINARY_PROVIDER_ID, assetId: asset.pathname },
-            // Tagged at mint time so agent-uploaded media arrives filed. This
-            // is the only chance to do it automatically — a clip that lands
-            // untagged stays untagged until someone opens it by hand, which is
-            // exactly how the naming problem started.
-            ...tagsField(args.tags),
-            // No poster for audio: Cloudinary would mint a still-frame jpg
-            // URL for a resource that has no frames, and it renders broken.
-            ...(!isAudio && asset.thumbnailUrl ? { poster: asset.thumbnailUrl } : {}),
-          },
-        },
+        details: Object.fromEntries(
+          prepared.map((entry) => [entry.nodeId as string, entry.detail]),
+        ),
       } as const;
     },
     requesterUid,
@@ -235,12 +304,28 @@ export async function attachMedia(
     );
   }
 
-  return toolOk(`Added "${displayName}" to ${placedParent} at index ${placedIndex}.`, {
-    nodeId: newNodeId as string,
-    toParentId: placedParent,
-    toIndex: placedIndex,
-    src: asset.url,
-    sourceAsset: { providerId: CLOUDINARY_PROVIDER_ID, assetId: asset.pathname },
-    written: outcome.affectedIds,
-  });
+  const attached = prepared.map((entry, offset) => ({
+    nodeId: entry.nodeId as string,
+    toIndex: placedIndex + offset,
+    src: entry.asset.url,
+    sourceAsset: { providerId: CLOUDINARY_PROVIDER_ID, assetId: entry.asset.pathname },
+  }));
+
+  // The single-file response shape is UNCHANGED, so every existing caller keeps
+  // reading the same fields; a batch adds `attached` alongside them.
+  const first = prepared[0]!;
+  return toolOk(
+    prepared.length === 1
+      ? `Added "${first.displayName}" to ${placedParent} at index ${placedIndex}.`
+      : `Added ${prepared.length} clips to ${placedParent} from index ${placedIndex}.`,
+    {
+      nodeId: first.nodeId as string,
+      toParentId: placedParent,
+      toIndex: placedIndex,
+      src: first.asset.url,
+      sourceAsset: { providerId: CLOUDINARY_PROVIDER_ID, assetId: first.asset.pathname },
+      ...(prepared.length === 1 ? {} : { attached }),
+      written: outcome.affectedIds,
+    },
+  );
 }


### PR DESCRIPTION
Closes #307.

Filing 24 images took **48 sequential MCP calls** — a ticket and an attach
each. Both halves take a list now.

- `create_upload` accepts `filenames`, returns one ticket per file, scope-checked once.
- `attach_media` accepts `items` and lands them in **one** `add-nodes` command: one timeline write instead of 24, so one revision bump and one chance to lose a race with another writer rather than 24.

## The bigger saving is the verification

Not mentioned in the issue. `attachMedia` drops the cached Cloudinary listing
and re-fetches it to confirm the bytes actually landed — **per call**. Twenty-
four attaches meant twenty-four full listings of the project. A batch does that
once and looks every id up in a `Map`.

## Errors report all of them

Every unsupported filename, every `publicId` with no upload behind it. One
failure per round trip is exactly the cost this change exists to remove. A
missing id refuses the whole batch, so nothing lands half-attached.

## Backward compatible by construction

`publicId` / `filename` still work, and their responses are byte-for-byte what
they were — the clip's fields at the top level, no `attached` key — so every
existing caller is untouched. A batch adds `attached` / `tickets` alongside.

Placement applies to the group: clips land consecutively from the resolved
index, in the order given, because `add-nodes` inserts the whole array at one
index.

Capped at **50** per call. One signed ticket is cheap; an unbounded list is a
way to ask the server to mint arbitrarily many.

## Verification

With `upload.ts` reverted, all six new tests fail.

| test | |
|---|---|
| one ticket per filename, in order | keyed on filename so a dropped/reordered file shows |
| names EVERY unsupported file | not just the first |
| lands a batch in ONE write | revision moves by exactly 1, order preserved |
| reports every attached clip | and the single-file shape is unchanged |
| per-item name and duration | not one setting for all |
| refuses the WHOLE batch | names every missing id, nothing partially lands |

774 app tests, typecheck and lint clean.

**For the operator:** connectors cache the tool list, so `filenames` and
`items` need a connector refresh before an agent can use them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)