### PR TITLE
noUncheckedIndexedAccess in the three pure packages

### DIFF
--- a/packages/collections-core/commands.fuzz.test.ts
+++ b/packages/collections-core/commands.fuzz.test.ts
@@ -105,7 +105,11 @@ function childrenEqual(a: CollectionsGraph, b: CollectionsGraph): boolean {
 }
 
 function pick<T>(rand: () => number, items: readonly T[]): T {
-  return items[Math.floor(rand() * items.length)];
+  const chosen = items[Math.floor(rand() * items.length)];
+  // A fuzz run that silently picked `undefined` would report a failure against
+  // a value it never actually chose, so say which call was empty instead.
+  if (chosen === undefined) throw new Error("pick() was given an empty list");
+  return chosen;
 }
 
 describe("fuzz: command -> patch -> inverse round-trips", () => {

--- a/packages/collections-core/commands.ts
+++ b/packages/collections-core/commands.ts
@@ -305,8 +305,8 @@ export function applyCommand(
   const indexedParents = new Set(parentByMovingId.values());
   for (const parentId of indexedParents) {
     const children = getChildren(graph, parentId);
-    for (let index = 0; index < children.length; index++) {
-      sourceIndexById.set(children[index], index);
+    for (const [index, childId] of children.entries()) {
+      sourceIndexById.set(childId, index);
     }
   }
 

--- a/packages/collections-core/graph.ts
+++ b/packages/collections-core/graph.ts
@@ -390,7 +390,9 @@ export function buildGraph(
       // duplicate-id reporting deterministic (first duplicate in reading
       // order wins the error).
       for (let i = children.length - 1; i >= 0; i--) {
-        stack.push({ spec: children[i], parentId: id });
+        const spec = children[i];
+        if (spec === undefined) continue;
+        stack.push({ spec, parentId: id });
       }
     }
     parentById.set(id, parentId);
@@ -452,7 +454,10 @@ export function isSameOrAncestor(
 export function getDocumentOrder(graph: CollectionsGraph): ReadonlyMap<NodeId, number> {
   const order = new Map<NodeId, number>();
   const stack: NodeId[] = [];
-  for (let i = graph.rootIds.length - 1; i >= 0; i--) stack.push(graph.rootIds[i]);
+  for (let i = graph.rootIds.length - 1; i >= 0; i--) {
+    const rootId = graph.rootIds[i];
+    if (rootId !== undefined) stack.push(rootId);
+  }
 
   while (stack.length > 0) {
     const id = stack.pop()!;
@@ -460,7 +465,10 @@ export function getDocumentOrder(graph: CollectionsGraph): ReadonlyMap<NodeId, n
     order.set(id, order.size);
     const children = graph.childrenById.get(id);
     if (children) {
-      for (let i = children.length - 1; i >= 0; i--) stack.push(children[i]);
+      for (let i = children.length - 1; i >= 0; i--) {
+        const childId = children[i];
+        if (childId !== undefined) stack.push(childId);
+      }
     }
   }
   return order;

--- a/packages/collections-core/intents.ts
+++ b/packages/collections-core/intents.ts
@@ -248,10 +248,9 @@ export function resolveCommandFromIntent(
     // insert-adjacent branch below).
     const siblings = getChildren(graph, intent.collectionId);
     const boundary = Math.max(0, Math.min(intent.index, siblings.length));
-    let draggedBeforeBoundary = 0;
-    for (let i = 0; i < boundary; i++) {
-      if (draggedSet.has(siblings[i])) draggedBeforeBoundary++;
-    }
+    const draggedBeforeBoundary = siblings
+      .slice(0, boundary)
+      .filter((siblingId) => draggedSet.has(siblingId)).length;
     return {
       ok: true,
       value: {
@@ -277,10 +276,9 @@ export function resolveCommandFromIntent(
   const boundary = intent.side === "before" ? targetVisibleIndex : targetVisibleIndex + 1;
   // Post-removal index: subtract the dragged nodes sitting before the
   // boundary in this same collection.
-  let draggedBeforeBoundary = 0;
-  for (let i = 0; i < boundary; i++) {
-    if (draggedSet.has(siblings[i])) draggedBeforeBoundary++;
-  }
+  const draggedBeforeBoundary = siblings
+    .slice(0, boundary)
+    .filter((siblingId) => draggedSet.has(siblingId)).length;
 
   return {
     ok: true,

--- a/packages/collections-core/keyboard.ts
+++ b/packages/collections-core/keyboard.ts
@@ -176,7 +176,9 @@ function findSiblingCollection(
   direction: 1 | -1
 ): NodeId | null {
   for (let i = fromIndex + direction; i >= 0 && i < siblings.length; i += direction) {
-    if (graph.nodesById.get(siblings[i])?.kind === "collection") return siblings[i];
+    const siblingId = siblings[i];
+    if (siblingId === undefined) continue;
+    if (graph.nodesById.get(siblingId)?.kind === "collection") return siblingId;
   }
   return null;
 }

--- a/packages/collections-core/tsconfig.json
+++ b/packages/collections-core/tsconfig.json
@@ -3,6 +3,11 @@
     "target": "ES2020",
     "lib": ["esnext"],
     "strict": true,
+    // Types `arr[i]` and `record[key]` as `T | undefined`. #283, applied
+    // package by package. Every site fixed here was a provably in-range
+    // index loop; each got a real check or an idiom that does not index at
+    // all, because the mechanical `arr[i]!` defeats the point of the flag.
+    "noUncheckedIndexedAccess": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",

--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -586,10 +586,19 @@ export function hydratedCollectionPreviews(
     }
   };
   collect(parseNodeId(collectionId));
-  const frames =
+  // Same shape as `previewItemsFrom`: pick INDICES and read them back through
+  // a bounds check, rather than building an array of `T | undefined` and
+  // asserting the holes away. All three are provably in range, so nothing is
+  // dropped — but a future change to the arithmetic becomes a compile error
+  // instead of a frame with undefined fields written into storage.
+  const frameIndices =
     media.length <= 3
-      ? media
-      : [media[0], media[Math.floor(media.length / 2)], media[media.length - 1]];
+      ? media.map((_frame, index) => index)
+      : [0, Math.floor(media.length / 2), media.length - 1];
+  const frames = frameIndices.flatMap((index) => {
+    const frame = media[index];
+    return frame === undefined ? [] : [frame];
+  });
   return { frames, firstFrameUncertain };
 }
 

--- a/packages/timeline-domain/src/flat-order.ts
+++ b/packages/timeline-domain/src/flat-order.ts
@@ -103,6 +103,11 @@ export function resolveFlatDropTarget(
   if (clamped === 0) return { parentId: focusedId, index: 0 };
 
   const left = items[clamped - 1];
+  // `clamped` is already bounded by items.length and the zero case returned
+  // above, so this holds — and if the clamping ever stops holding, appending
+  // into the focused collection is the same safe reading the stale-list case
+  // below takes.
+  if (left === undefined) return { parentId: focusedId, index: 0 };
   const parentId = left.collectionPath[left.collectionPath.length - 1] ?? focusedId;
   const siblings = getChildren(graph, parentId);
   const leftIndex = siblings.indexOf(left.nodeId);

--- a/packages/timeline-domain/tsconfig.json
+++ b/packages/timeline-domain/tsconfig.json
@@ -3,6 +3,11 @@
     "target": "ES2020",
     "lib": ["esnext"],
     "strict": true,
+    // Types `arr[i]` and `record[key]` as `T | undefined`. #283, applied
+    // package by package. Every site fixed here was a provably in-range
+    // index loop; each got a real check or an idiom that does not index at
+    // all, because the mechanical `arr[i]!` defeats the point of the flag.
+    "noUncheckedIndexedAccess": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",

--- a/packages/timeline-model/clip-display.test.ts
+++ b/packages/timeline-model/clip-display.test.ts
@@ -191,8 +191,13 @@ describe("clipStripWidths", () => {
       media({ duration: 10 }),
       media({ duration: 100 }),
     ]);
-    expect(widths[0]).toBeLessThan(widths[1]);
-    expect(widths[1]).toBeLessThan(widths[2]);
+    // Length asserted first so the comparisons below read three defined
+    // numbers — and so a change that returns fewer widths fails HERE, saying
+    // what happened, rather than as a confusing comparison against undefined.
+    expect(widths).toHaveLength(3);
+    const [narrow, middle, wide] = widths as [number, number, number];
+    expect(narrow).toBeLessThan(middle);
+    expect(middle).toBeLessThan(wide);
   });
 
   // The actual regression: the old strip compressed a 30:1 duration range into

--- a/packages/timeline-model/documents.ts
+++ b/packages/timeline-model/documents.ts
@@ -8,6 +8,7 @@ import {
   TIMELINE_LEADING_PADDING_SECONDS,
 } from "./constants";
 import { isVisualClip } from "./types";
+import type { ImageTimelineClip, VideoTimelineClip } from "./types";
 import type { TimelineClip, TimelineDocument } from "./types";
 
 /** First/middle/last media of a collection's clips, as stored preview
@@ -19,23 +20,32 @@ export function previewItemsFrom(clips: TimelineClip[]) {
   // qualify, then be rendered as an <img> pointing at a .flac. Preview items
   // are persisted, so letting one through writes the mistake to storage.
   const mediaClips = clips.filter(isVisualClip);
-  const previewClips =
+  // Pick INDICES, then read them back through a bounds check rather than
+  // building an array of `T | undefined` and asserting the holes away. All
+  // three are provably in range (the branch guarantees length > 3), so
+  // `flatMap` drops nothing in practice — but writing it this way means a
+  // future change to the arithmetic gets caught by the compiler instead of
+  // producing a preview entry with `undefined` fields.
+  const indices =
     mediaClips.length <= 3
-      ? mediaClips
-      : [
-          mediaClips[0],
-          mediaClips[Math.floor(mediaClips.length / 2)],
-          mediaClips[mediaClips.length - 1],
-        ];
+      ? mediaClips.map((_clip, index) => index)
+      : [0, Math.floor(mediaClips.length / 2), mediaClips.length - 1];
 
-  return previewClips.map((clip) => ({
+  return indices.flatMap((index) => {
+    const clip = mediaClips[index];
+    return clip === undefined ? [] : [previewItemOf(clip)];
+  });
+}
+
+function previewItemOf(clip: ImageTimelineClip | VideoTimelineClip) {
+  return {
     id: clip.id,
     kind: clip.kind,
     src: clip.src,
     poster: clip.poster,
     ...(clip.kind === "video" && clip.trimIn > 0 ? { trimIn: clip.trimIn } : {}),
     alt: clip.alt,
-  }));
+  };
 }
 
 /** Derive startTime/index for a clip sequence: leading padding, then each
@@ -75,8 +85,10 @@ export function enabledClips(clips: readonly TimelineClip[]): TimelineClip[] {
  * span.
  */
 export function collectionSpanSeconds(clips: readonly TimelineClip[]): number {
-  if (clips.length === 0) return 3;
   const last = clips[clips.length - 1];
+  // The empty case and the unreachable out-of-range case answer alike: a
+  // zero-width collection card cannot be seen or clicked either way.
+  if (last === undefined) return 3;
   return last.startTime + last.duration + TIMELINE_LEADING_PADDING_SECONDS;
 }
 

--- a/packages/timeline-model/tsconfig.json
+++ b/packages/timeline-model/tsconfig.json
@@ -3,6 +3,15 @@
     "target": "ES2020",
     "lib": ["esnext"],
     "strict": true,
+    // Types `arr[i]` and `record[key]` as `T | undefined`. This package IS the
+    // packing arithmetic — first/middle/last picks, the last clip's startTime
+    // — which is exactly the code where an out-of-range index fails at runtime
+    // instead of at compile time. #283 turns this on package by package; this
+    // is step 1, the one with no dependencies.
+    //
+    // The mechanical fix (`arr[i]!`) defeats the point. Every site here got a
+    // real check that answers the way the surrounding code already does.
+    "noUncheckedIndexedAccess": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",


### PR DESCRIPTION
#283, steps 1–3. Not the whole repo — I measured first, and the issue's
prediction of "a large error count" holds for the two big surfaces but not
these:

| package | errors |
|---|---|
| `timeline-model` | 12 |
| `collections-core` | 9 |
| `timeline-domain` | 12 |
| `packages/ui` | **119** |
| the app | **366** |

So the pure packages land together — 33 sites, all covered by the existing unit
suites — and `ui` and the app stay separate PRs, which is the split the issue
asked for.

## No `arr[i]!` anywhere

The issue names the mechanical fix as the way to do this wrong. Every site was
a provably in-range index, and each got either an idiom that stops indexing or
a real check:

- **`entries()`** where a loop only wanted the position (`commands.ts`)
- **`slice().filter().length`** where a loop was counting (`intents.ts`, twice)
  — shorter than the counter it replaces, and it indexes nothing
- **read the element once into a `const`** where the body wanted it twice
  (`keyboard.ts`)
- **an explicit `continue` / early return** on the reverse-push walks
  (`graph.ts`, `flat-order.ts`). Unreachable today, and that is the point: a
  later change to the arithmetic becomes a compile error rather than a corrupt
  walk or an `undefined` pushed onto a stack.

## The two preview picks are the interesting ones

`previewItemsFrom` and `hydratedCollectionPreviews` both built
`[first, middle, last]` as an array of `T | undefined` and mapped over it. Both
now pick **indices** and read them back through a bounds check.

These write to **storage**, so a hole there would have persisted a preview
entry with `undefined` fields — exactly the class of bug the flag exists to
surface.

## Tests

`pick()` in the fuzz harness now throws on an empty list rather than returning
`undefined`: a fuzz run reporting a failure against a value it never chose is
worse than no fuzz run.

## Verification

All three packages typecheck clean **with** the flag; `ui` and the app still
compile against them; 539 unit + 193 story + 774 app + 169 e2e pass.

Remaining for #283: `packages/ui` (119) and the app (366).

🤖 Generated with [Claude Code](https://claude.com/claude-code)