### PR TITLE
noUncheckedIndexedAccess in packages/ui

### DIFF
--- a/packages/ui/dnd-collections/CustomItemContent.stories.tsx
+++ b/packages/ui/dnd-collections/CustomItemContent.stories.tsx
@@ -320,7 +320,9 @@ const UserCollectionBookendCover = memo(function UserCollectionBookendCover({
   const lastImageSrc = useCollectionsSelector((snapshot) => {
     const childIds = snapshot.graph.childrenById.get(id) ?? [];
     for (let index = childIds.length - 1; index >= 0; index -= 1) {
-      const child = snapshot.graph.nodesById.get(childIds[index]);
+      const childId = childIds[index];
+      if (childId === undefined) continue;
+      const child = snapshot.graph.nodesById.get(childId);
       if (
         child?.kind === "media" &&
         child.mediaKind !== "video" &&

--- a/packages/ui/dnd-collections/PaletteTrash.stories.tsx
+++ b/packages/ui/dnd-collections/PaletteTrash.stories.tsx
@@ -17,6 +17,7 @@ import {
   releaseAt,
   waitForLayout,
 } from "./stories-helpers";
+import { at } from "../test-support/at";
 
 // Phase 6 coverage: external palette sources (brand-new nodes committed as
 // add-nodes) and trash (a hidden root collection fed by the ordinary move
@@ -258,7 +259,7 @@ export const PaletteDropAddsNewCollection: Story = {
       expect(order.slice(0, 3)).toEqual(["alpha", "bravo", "charlie"]);
       expect(order[3]).toMatch(/^col-/);
     });
-    const newId = panelOrder(canvasElement, "panel-a")[3];
+    const newId = at(panelOrder(canvasElement, "panel-a"), 3);
     expect(nodeCard(canvasElement, newId).getAttribute("aria-label")).toMatch(
       /collection, 0 items/i
     );

--- a/packages/ui/dnd-collections/react/collections-store.test.ts
+++ b/packages/ui/dnd-collections/react/collections-store.test.ts
@@ -6,6 +6,7 @@ import {
   createCollectionsStore,
   type CollectionsChange,
 } from "./collections-store";
+import { at } from "../../test-support/at";
 
 // Direct tests for the store's CONTRACTS — the invariants every selector
 // depends on and a refactor can silently break: snapshot fields keep their
@@ -73,7 +74,7 @@ describe("createCollectionsStore", () => {
     expect(canUndo).toBe(true);
     expect(historyEntries).toHaveLength(1);
     expect(changes).toHaveLength(1);
-    expect(changes[0].origin).toBe("command");
+    expect(at(changes, 0).origin).toBe("command");
   });
 
   test("reentrant listeners preserve onChange order and graph-patch pairing", () => {
@@ -100,8 +101,8 @@ describe("createCollectionsStore", () => {
         change.command?.type === "move-nodes" ? change.command.nodeIds[0] : null
       )
     ).toEqual(["x", "y"]);
-    expect([...(changes[0].graph.childrenById.get(id("root-b")) ?? [])]).toEqual(["x"]);
-    expect([...(changes[1].graph.childrenById.get(id("root-b")) ?? [])]).toEqual([
+    expect([...(at(changes, 0).graph.childrenById.get(id("root-b")) ?? [])]).toEqual(["x"]);
+    expect([...(at(changes, 1).graph.childrenById.get(id("root-b")) ?? [])]).toEqual([
       "y",
       "x",
     ]);
@@ -1290,7 +1291,7 @@ describe("applyRemotePatch", () => {
     store.applyRemotePatch(patch);
 
     expect(changes).toHaveLength(1);
-    expect(changes[0].origin).toBe("remote");
-    expect(changes[0].command).toBeUndefined();
+    expect(at(changes, 0).origin).toBe("remote");
+    expect(at(changes, 0).command).toBeUndefined();
   });
 });

--- a/packages/ui/dnd-collections/react/node-thumbnail.tsx
+++ b/packages/ui/dnd-collections/react/node-thumbnail.tsx
@@ -80,7 +80,11 @@ function VideoThumbnail({
       className="flex min-h-0 flex-1 overflow-hidden rounded-sm bg-muted"
     >
       {Array.from({ length: count }).map((_, index) => {
-        const src = posters[index % posters.length];
+        // The caller returns a fallback when `posters` is empty, so the
+        // modulo always lands; `?? ""` keeps that provable rather than
+        // asserted, and an empty src would take the same failed-image path the
+        // component already handles.
+        const src = posters[index % posters.length] ?? "";
         const frameClass =
           "h-full min-w-0 flex-1 border-r border-background object-cover last:border-r-0";
         return failedSources.has(src) ? (

--- a/packages/ui/dnd-collections/react/use-announcements.ts
+++ b/packages/ui/dnd-collections/react/use-announcements.ts
@@ -132,7 +132,13 @@ export const LiveAnnouncementRegion = memo(function LiveAnnouncementRegion({
       speak("Selection cleared.");
     } else if (selectedIds.size === 1) {
       const [onlyId] = selectedIds;
-      const name = store.getSnapshot().graph.nodesById.get(onlyId)?.name ?? "item";
+      // `size === 1` guarantees it; `?? "item"` is the same fallback the
+      // missing-node case already uses, so the announcement degrades the way
+      // the rest of this function does rather than saying "undefined".
+      const name =
+        onlyId === undefined
+          ? "item"
+          : (store.getSnapshot().graph.nodesById.get(onlyId)?.name ?? "item");
       speak(`"${name}" selected.`);
     } else {
       speak(`${selectedIds.size} items selected.`);

--- a/packages/ui/dnd-collections/react/use-flip-graph-animation.ts
+++ b/packages/ui/dnd-collections/react/use-flip-graph-animation.ts
@@ -88,8 +88,12 @@ function matchBeforeRects(
 
   for (const [nodeId, afterCandidates] of unmatchedAfterById) {
     const beforeCandidates = unmatchedBeforeById.get(nodeId);
-    if (beforeCandidates?.length === 1 && afterCandidates.length === 1) {
-      matches.set(afterCandidates[0].card, beforeCandidates[0].point);
+    const onlyAfter = afterCandidates.length === 1 ? afterCandidates[0] : undefined;
+    const onlyBefore = beforeCandidates?.length === 1 ? beforeCandidates[0] : undefined;
+    // Read through the same length check that gates the pairing, so the "exactly
+    // one on each side" rule is stated once instead of being asserted twice.
+    if (onlyAfter !== undefined && onlyBefore !== undefined) {
+      matches.set(onlyAfter.card, onlyBefore.point);
     }
   }
 

--- a/packages/ui/dnd-collections/react/use-palette-drag.ts
+++ b/packages/ui/dnd-collections/react/use-palette-drag.ts
@@ -142,7 +142,10 @@ export function usePaletteDrag(args: {
       return true;
     }
     const targetName = graph.nodesById.get(command.toParentId)?.name ?? "collection";
-    announce(`Added "${nodes[0].name}" to "${targetName}".`);
+    // A drop always carries at least one node; naming the count is the honest
+    // reading if that ever stops holding, rather than announcing "undefined".
+    const firstName = nodes[0]?.name ?? `${nodes.length} items`;
+    announce(`Added "${firstName}" to "${targetName}".`);
     return true;
   }, [paletteNodes, store, intentRef, announce, onDiscard, setPaletteNodes]);
 

--- a/packages/ui/dnd-collections/react/use-pan-with-momentum.ts
+++ b/packages/ui/dnd-collections/react/use-pan-with-momentum.ts
@@ -138,7 +138,11 @@ export function usePanWithMomentum(
       lastPosition = position;
       const now = performance.now();
       samples.push({ t: now, p: position });
-      while (samples.length > 1 && now - samples[0].t > SAMPLE_WINDOW_MS) samples.shift();
+      // `length > 1` guarantees samples[0]; the `?? now` keeps that provable
+      // and makes the window a no-op rather than a crash if it ever does not.
+      while (samples.length > 1 && now - (samples[0]?.t ?? now) > SAMPLE_WINDOW_MS) {
+        samples.shift();
+      }
     };
 
     const endPan = (event: PointerEvent) => {

--- a/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
@@ -253,7 +253,12 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
       (s) => s.graph.nodesById.get(collectionId)?.name ?? String(collectionId)
     );
     const focusByIndex = useCallback(
-      (index: number) => focusNode(childIds[index]),
+      (index: number) => {
+        // The roving index can outlive the list it points into for a render
+        // after a removal; focusing nothing is the right answer there.
+        const childId = childIds[index];
+        if (childId !== undefined) focusNode(childId);
+      },
       [focusNode, childIds]
     );
     const resolveGridIndex = useCallback(

--- a/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
@@ -350,7 +350,13 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
       }
       return Math.max(MIN_ITEM_WIDTH, itemWidth);
     };
-    const widthForIndex = (index: number): number => widthForNode(nodesById.get(childIds[index]));
+    const widthForIndex = (index: number): number => {
+      const childId = childIds[index];
+      // An out-of-range estimate falls back to the same minimum an unknown node
+      // gets — the virtualizer asks about indexes around the edges of its
+      // window, so this is a normal question, not an error.
+      return widthForNode(childId === undefined ? undefined : nodesById.get(childId));
+    };
 
     // The LIVE slot size for a mid-gesture trim, routed through the SAME
     // width resolution as the committed layout by synthesizing a node that
@@ -382,7 +388,14 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
     // closure here would rebuild all N measurements — re-running
     // itemWidthFor for every item — on every render, e.g. once per indicator
     // move during a drag (WidthCallbackColdDuringDrag pins this).
-    const getItemKey = useCallback((index: number) => childIds[index], [childIds]);
+    // Falls back to the INDEX rather than returning undefined: the virtualizer
+    // memoizes measurements by this key, and an undefined key would collapse
+    // every out-of-range probe onto one entry. The index is unique and stable
+    // for the render where the id is momentarily missing.
+    const getItemKey = useCallback(
+      (index: number) => childIds[index] ?? index,
+      [childIds],
+    );
 
     // The FIRST item is the one case that can't reveal its overview's
     // trimmed-in room by scrolling: its offset is 0 with no content (and no
@@ -665,7 +678,12 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
       (s) => s.graph.nodesById.get(collectionId)?.name ?? String(collectionId)
     );
     const focusByIndex = useCallback(
-      (index: number) => focusNode(childIds[index]),
+      (index: number) => {
+        // The roving index can outlive the list it points into for a render
+        // after a removal; focusing nothing is the right answer there.
+        const childId = childIds[index];
+        if (childId !== undefined) focusNode(childId);
+      },
       [focusNode, childIds]
     );
     const { focusedIndex, onKeyDown, onItemFocus } = useVirtualRovingFocus({
@@ -913,7 +931,14 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
                   style={{ left: indicatorLeft }}
                 />
               )}
-              {virtualizer.getVirtualItems().map((item) => (
+              {virtualizer.getVirtualItems().map((item) => {
+                // Resolved ONCE per item. The virtualizer's window can lag a
+                // removal by a render, so an index here is not guaranteed to
+                // still name a child; skipping is the only correct answer, and
+                // it keeps both reads below honest about it.
+                const childId = childIds[item.index];
+                if (childId === undefined) return null;
+                return (
                 <div
                   key={item.key}
                   data-virtual-index={item.index}
@@ -921,7 +946,7 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
                   aria-colindex={item.index + 1}
                   // Sync the roving index to whatever card actually gains focus
                   // (click, programmatic focus), not just keyboard navigation.
-                  onFocus={() => onItemFocus(childIds[item.index])}
+                  onFocus={() => onItemFocus(childId)}
                   style={
                     {
                       position: "absolute",
@@ -948,7 +973,7 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
                       With panToScroll, item drags move to the grip bar or behind
                       a press-and-hold so the body is free to pan the strip. */}
                   <ItemShell
-                    id={childIds[item.index]}
+                    id={childId}
                     className="h-full w-full"
                     dragActivation={cardActivation}
                     rovingTabIndex={item.index === rovingIndex ? 0 : -1}
@@ -956,7 +981,8 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
                     itemContent={itemContent}
                   />
                 </div>
-              ))}
+                );
+              })}
               {trailingSlot && (
                 <div
                   data-virtual-trailing-slot

--- a/packages/ui/dnd-collections/virtual/virtual-strip-geometry.ts
+++ b/packages/ui/dnd-collections/virtual/virtual-strip-geometry.ts
@@ -175,26 +175,46 @@ export function createTimeToOffset(config: TimeToOffsetConfig): TimeToOffsetLook
   const count = timeStarts.length;
   const endOffset = lastMediaRight;
 
+  /**
+   * Read one of the four parallel arrays.
+   *
+   * They are built together in the walk above and never grow again, and every
+   * index below is either produced by `locate()` (bounded by `count - 1`) or
+   * guarded by `< count`. This states that invariant ONCE instead of putting a
+   * bounds check on every access in a per-frame scrub path.
+   *
+   * It throws rather than falling back to 0: a fallback would silently distort
+   * the geometry — a clip drawn at the wrong offset, a playhead that drifts —
+   * which is far harder to trace than a stop that names the index.
+   */
+  const readAt = (values: readonly number[], index: number): number => {
+    const value = values[index];
+    if (value === undefined) {
+      throw new RangeError(`strip geometry: index ${index} outside 0..${count - 1}`);
+    }
+    return value;
+  };
+
   /** Index of the last segment whose start time is <= t (t must be >= 0). */
   const locate = (t: number): number => {
     let lo = 0;
     let hi = count - 1;
     while (lo < hi) {
       const mid = (lo + hi + 1) >> 1;
-      if (timeStarts[mid] <= t) lo = mid;
+      if (readAt(timeStarts, mid) <= t) lo = mid;
       else hi = mid - 1;
     }
     return lo;
   };
 
   const offsetWithin = (index: number, t: number): number => {
-    const within = Math.max(0, t - timeStarts[index]) * pixelsPerSecond;
-    return xStarts[index] + Math.min(within, widths[index]);
+    const within = Math.max(0, t - readAt(timeStarts, index)) * pixelsPerSecond;
+    return readAt(xStarts, index) + Math.min(within, readAt(widths, index));
   };
 
   const at = (timeSeconds: number): number => {
     if (count === 0) return endOffset;
-    if (timeSeconds <= timeStarts[0]) return xStarts[0];
+    if (timeSeconds <= readAt(timeStarts, 0)) return readAt(xStarts, 0);
     if (timeSeconds >= clock) return endOffset;
     return offsetWithin(locate(timeSeconds), timeSeconds);
   };
@@ -206,17 +226,17 @@ export function createTimeToOffset(config: TimeToOffsetConfig): TimeToOffsetLook
       return {
         at: (timeSeconds: number): number => {
           if (count === 0) return endOffset;
-          if (timeSeconds <= timeStarts[0]) return xStarts[0];
+          if (timeSeconds <= readAt(timeStarts, 0)) return readAt(xStarts, 0);
           if (timeSeconds >= clock) return endOffset;
-          if (timeSeconds < timeStarts[index]) {
+          if (timeSeconds < readAt(timeStarts, index)) {
             // Backward seek: re-anchor.
             index = locate(timeSeconds);
-          } else if (timeSeconds >= timeStarts[index] + durations[index]) {
+          } else if (timeSeconds >= readAt(timeStarts, index) + readAt(durations, index)) {
             // Forward: the adjacent segment is the common playback hop (O(1));
             // anything farther is a seek (O(log n)).
             if (
               index + 1 < count &&
-              timeSeconds < timeStarts[index + 1] + durations[index + 1]
+              timeSeconds < readAt(timeStarts, index + 1) + readAt(durations, index + 1)
             ) {
               index += 1;
             } else {

--- a/packages/ui/test-support/at.ts
+++ b/packages/ui/test-support/at.ts
@@ -1,0 +1,25 @@
+/**
+ * Read an array element in a TEST, asserting it exists.
+ *
+ * Under `noUncheckedIndexedAccess` an assertion like `packed[1].startTime` no
+ * longer type-checks, and the two obvious repairs are both worse than this:
+ *
+ *   `packed[1]!.startTime` compiles and then fails as "cannot read startTime
+ *   of undefined", naming neither the index nor the length — in a test, whose
+ *   entire job is to say what went wrong.
+ *
+ *   `expect(packed[1]).toBeDefined()` before every access doubles the length
+ *   of the assertion and still leaves the access unnarrowed.
+ *
+ * This fails with the index AND the actual length, which is usually the whole
+ * diagnosis: the list was shorter than the test expected.
+ */
+export function at<T>(items: readonly T[], index: number): T {
+  const value = items[index];
+  if (value === undefined) {
+    throw new Error(
+      `expected an element at index ${index}, but the list has ${items.length}`,
+    );
+  }
+  return value;
+}

--- a/packages/ui/timeline/constants.ts
+++ b/packages/ui/timeline/constants.ts
@@ -16,7 +16,11 @@ export const VIDEO_SOURCES = [
   "https://raw.githubusercontent.com/intel-iot-devkit/sample-videos/master/people-detection.mp4",
   "https://raw.githubusercontent.com/intel-iot-devkit/sample-videos/master/store-aisle-detection.mp4",
   "https://raw.githubusercontent.com/intel-iot-devkit/sample-videos/master/bottle-detection.mp4",
-];
+  // `as const` makes this a TUPLE, so the fixed indexes below (VIDEO_SOURCES[0]
+  // … [6] in the MEDIA table) are known to exist rather than being
+  // `string | undefined` under noUncheckedIndexedAccess. Typing the literal is
+  // the honest fix here: the entries really are fixed and really are present.
+] as const;
 
 export type ItemSize = "xs" | "sm" | "md" | "lg" | "xl";
 

--- a/packages/ui/timeline/hooks/use-timeline-clips.test.ts
+++ b/packages/ui/timeline/hooks/use-timeline-clips.test.ts
@@ -8,6 +8,7 @@ import {
   packClipsLeftToRight,
   resizeClipsFromBaseline,
 } from "./use-timeline-clips";
+import { at } from "../../test-support/at";
 
 function clip(overrides: Partial<TimelineClip> = {}): TimelineClip {
   return {
@@ -34,8 +35,8 @@ describe("timeline clip math", () => {
       clip({ id: "clip-1", index: 1, startTime: 20, duration: 2 }),
     ], 0, clip());
 
-    expect(packed[0].startTime).toBe(0);
-    expect(packed[1].startTime).toBeCloseTo(4 + CLIP_GAP_SECONDS);
+    expect(at(packed, 0).startTime).toBe(0);
+    expect(at(packed, 1).startTime).toBeCloseTo(4 + CLIP_GAP_SECONDS);
   });
 
   it("lays out both sides of an anchored clip", () => {
@@ -47,21 +48,21 @@ describe("timeline clip math", () => {
     const next = layoutClipsAroundAnchor(
       clips,
       1,
-      { ...clips[1], startTime: 10, duration: 4 },
+      { ...at(clips, 1), startTime: 10, duration: 4 },
     );
 
-    expect(next[0].startTime + next[0].duration + CLIP_GAP_SECONDS).toBeCloseTo(10);
-    expect(next[2].startTime).toBeCloseTo(14 + CLIP_GAP_SECONDS);
+    expect(at(next, 0).startTime + at(next, 0).duration + CLIP_GAP_SECONDS).toBeCloseTo(10);
+    expect(at(next, 2).startTime).toBeCloseTo(14 + CLIP_GAP_SECONDS);
   });
 
   it("left trim grows into available source and preserves trim accounting", () => {
-    const [resized] = resizeClipsFromBaseline({
+    const resized = at(resizeClipsFromBaseline({
       baselineClips: [clip()],
       anchorIndex: 0,
       edge: "left",
       deltaTime: -2,
       minDuration: 0.6,
-    });
+    }), 0);
 
     expect(resized.duration).toBe(6);
     expect(resized.trimIn).toBe(1);
@@ -69,26 +70,26 @@ describe("timeline clip math", () => {
   });
 
   it("enforces minimum duration while right trimming", () => {
-    const [resized] = resizeClipsFromBaseline({
+    const resized = at(resizeClipsFromBaseline({
       baselineClips: [clip()],
       anchorIndex: 0,
       edge: "right",
       deltaTime: -20,
       minDuration: 0.6,
-    });
+    }), 0);
 
     expect(resized.duration).toBe(0.6);
     expect(resized.trimOut).toBeCloseTo(6.4);
   });
 
   it("resizes images without source-duration clamping", () => {
-    const [resized] = resizeClipsFromBaseline({
+    const resized = at(resizeClipsFromBaseline({
       baselineClips: [clip({ kind: "image", duration: 4, sourceDuration: 4, trimIn: 0, trimOut: 0 })],
       anchorIndex: 0,
       edge: "right",
       deltaTime: 2,
       minDuration: 0.6,
-    });
+    }), 0);
 
     expect(resized.duration).toBe(6);
     expect(resized.sourceDuration).toBe(6);
@@ -97,13 +98,13 @@ describe("timeline clip math", () => {
   });
 
   it("moves a video source window without changing visible duration", () => {
-    const [edited] = editVideoSourceWindowFromBaseline({
+    const edited = at(editVideoSourceWindowFromBaseline({
       baselineClips: [clip()],
       anchorIndex: 0,
       mode: "move",
       deltaTime: 2,
       minDuration: 0.6,
-    });
+    }), 0);
 
     expect(edited.duration).toBe(4);
     expect(edited.trimIn).toBe(1);
@@ -111,13 +112,13 @@ describe("timeline clip math", () => {
   });
 
   it("uses image source handles to resize duration", () => {
-    const [edited] = editVideoSourceWindowFromBaseline({
+    const edited = at(editVideoSourceWindowFromBaseline({
       baselineClips: [clip({ kind: "image", duration: 4, sourceDuration: 4, trimIn: 0, trimOut: 0 })],
       anchorIndex: 0,
       mode: "right",
       deltaTime: 2,
       minDuration: 0.6,
-    });
+    }), 0);
 
     expect(edited.duration).toBe(6);
     expect(edited.sourceDuration).toBe(6);

--- a/packages/ui/timeline/hooks/use-timeline-clips.ts
+++ b/packages/ui/timeline/hooks/use-timeline-clips.ts
@@ -2,6 +2,7 @@ import { TimelineClip, VideoSourceWindowEditMode } from "../types";
 import {
   baseWidth,
   clamp,
+  cycle,
   getPackedDurationBefore,
   getSpec,
 } from "../utils";
@@ -25,7 +26,7 @@ export function createClip(
     spec = {
       ...spec,
       kind: "video",
-      src: VIDEO_SOURCES[index % VIDEO_SOURCES.length],
+      src: cycle(VIDEO_SOURCES, index, "VIDEO_SOURCES"),
       duration: 12,
     };
   }
@@ -97,19 +98,25 @@ export function layoutClipsAroundAnchor(
   const nextClips = clips.map((clip) => ({ ...clip }));
   nextClips[anchorIndex] = anchorClip;
 
+  // Walking OUTWARD from the anchor, so each step's neighbour was written by
+  // the previous one and `current` is inside the array by the loop bound. Both
+  // are read into consts and checked rather than indexed three times each: a
+  // hole here would silently produce `NaN` startTimes that pack every later
+  // clip on top of its neighbour, which is far harder to trace than a stop.
   for (let index = anchorIndex - 1; index >= 0; index -= 1) {
     const clipToRight = nextClips[index + 1];
+    const current = nextClips[index];
+    if (clipToRight === undefined || current === undefined) break;
     const endTime = clipToRight.startTime - CLIP_GAP_SECONDS;
-    nextClips[index] = {
-      ...nextClips[index],
-      startTime: endTime - nextClips[index].duration,
-    };
+    nextClips[index] = { ...current, startTime: endTime - current.duration };
   }
 
   for (let index = anchorIndex + 1; index < nextClips.length; index += 1) {
     const clipToLeft = nextClips[index - 1];
+    const current = nextClips[index];
+    if (clipToLeft === undefined || current === undefined) break;
     nextClips[index] = {
-      ...nextClips[index],
+      ...current,
       startTime: clipToLeft.startTime + clipToLeft.duration + CLIP_GAP_SECONDS,
     };
   }
@@ -202,13 +209,13 @@ export function packClipsLeftToRight(
   const nextClips = clips.map((clip) => ({ ...clip }));
   nextClips[anchorIndex] = anchorClip;
 
+  // entries() rather than an index: the loop only ever wanted each clip and
+  // its position, and indexing three times per iteration is what made this
+  // read as three separate lookups that could disagree.
   let nextStartTime = TIMELINE_LEADING_PADDING_SECONDS;
-  for (let index = 0; index < nextClips.length; index += 1) {
-    nextClips[index] = {
-      ...nextClips[index],
-      startTime: nextStartTime,
-    };
-    nextStartTime += nextClips[index].duration + CLIP_GAP_SECONDS;
+  for (const [index, clip] of nextClips.entries()) {
+    nextClips[index] = { ...clip, startTime: nextStartTime };
+    nextStartTime += clip.duration + CLIP_GAP_SECONDS;
   }
 
   return nextClips;
@@ -242,6 +249,10 @@ export function reorderClipsFromBaseline({
 
   const nextClips = baselineClips.map((clip) => ({ ...clip }));
   const [activeClip] = nextClips.splice(sourceIndex, 1);
+  // `findIndex` found it above, so the splice removed exactly one — but the
+  // destructure cannot know that. Returning the baseline unchanged is the same
+  // answer the not-found branch already gives.
+  if (activeClip === undefined) return baselineClips;
   nextClips.splice(clamp(Math.floor(targetIndex), 0, nextClips.length), 0, activeClip);
 
   return reindexAndPackClips(nextClips);

--- a/packages/ui/timeline/timeline-documents.ts
+++ b/packages/ui/timeline/timeline-documents.ts
@@ -442,8 +442,11 @@ export function syncParentCollectionsInState(
   let nextDocuments = state.documents;
 
   let totalDuration = 3;
-  if (childClips.length > 0) {
-    const lastClip = childClips[childClips.length - 1];
+  const lastClip = childClips[childClips.length - 1];
+  // The empty case and the unreachable out-of-range case answer alike, which is
+  // the same rule `collectionSpanSeconds` follows: a zero-width collection card
+  // cannot be seen or clicked either way.
+  if (lastClip !== undefined) {
     totalDuration = lastClip.startTime + lastClip.duration + TIMELINE_LEADING_PADDING_SECONDS;
   }
 

--- a/packages/ui/timeline/utils.ts
+++ b/packages/ui/timeline/utils.ts
@@ -66,8 +66,25 @@ export function getFallbackImage(
   };
 }
 
+/**
+ * Read a fixture array cyclically.
+ *
+ * Both callers index a non-empty literal with a modulo, so this never throws.
+ * Written as a throw rather than `!` so that emptying the array fails HERE,
+ * naming which array, instead of surfacing as `undefined.aspect` several
+ * frames away in a caller.
+ *
+ * The double modulo also makes a NEGATIVE index wrap rather than miss, which
+ * the bare `index % length` did not.
+ */
+export function cycle<T>(items: readonly T[], index: number, name: string): T {
+  const value = items[((index % items.length) + items.length) % items.length];
+  if (value === undefined) throw new Error(`${name} is empty`);
+  return value;
+}
+
 export function getSpec(index: number) {
-  return MEDIA[index % MEDIA.length];
+  return cycle(MEDIA, index, "MEDIA");
 }
 
 export function baseWidth(index: number) {
@@ -77,8 +94,11 @@ export function baseWidth(index: number) {
 export function getPackedDurationBefore(clips: TimelineClip[], anchorIndex: number) {
   let durationBefore = 0;
 
-  for (let index = 0; index < anchorIndex; index += 1) {
-    durationBefore += clips[index].duration;
+  // slice() rather than an index loop: `anchorIndex` is a caller's number and
+  // may sit past the end, in which case slice simply stops — the old loop
+  // would have added `undefined.duration`.
+  for (const clip of clips.slice(0, Math.max(0, anchorIndex))) {
+    durationBefore += clip.duration;
     durationBefore += CLIP_GAP_SECONDS;
   }
 

--- a/packages/ui/timeline/viewport/audio-graph.test.ts
+++ b/packages/ui/timeline/viewport/audio-graph.test.ts
@@ -7,6 +7,7 @@ import {
   type MinimalAudioContext,
   type MinimalGainNode,
 } from "./audio-graph";
+import { at } from "../../test-support/at";
 
 /** A fake Web Audio context: enough surface for the mixer, none of the browser.
  *  `sourceCalls` is what proves the attach-once guard, since the real
@@ -115,7 +116,7 @@ describe("createAudioMixer", () => {
     mixer.attach(fakeElement());
 
     // gains[0] is the master, created with the context; gains[1] is the source.
-    expect(fake.gains[1].gain.value).toBe(0);
+    expect(at(fake.gains, 1).gain.value).toBe(0);
   });
 
   it("takes level away from the element so the two do not multiply", () => {
@@ -137,7 +138,7 @@ describe("createAudioMixer", () => {
     mixer.attach(element);
     mixer.setSourceGain(element, 0.5);
 
-    expect(fake.gains[1].gain.value).toBeCloseTo(0.25, 5);
+    expect(at(fake.gains, 1).gain.value).toBeCloseTo(0.25, 5);
   });
 
   it("zeroes master gain while muted and restores the level on unmute", () => {
@@ -146,7 +147,7 @@ describe("createAudioMixer", () => {
     mixer.attach(fakeElement());
     mixer.setMasterVolume(0.5);
 
-    const master = fake.gains[0];
+    const master = at(fake.gains, 0);
     expect(master.gain.value).toBeCloseTo(0.25, 5);
 
     mixer.setMuted(true);

--- a/packages/ui/timeline/viewport/waveform-peaks.test.ts
+++ b/packages/ui/timeline/viewport/waveform-peaks.test.ts
@@ -10,7 +10,14 @@ import {
 
 /** Read one bucket's [min, max] out of the interleaved array. */
 function bucket(values: Float32Array, index: number): [number, number] {
-  return [values[index * 2], values[index * 2 + 1]];
+  const min = values[index * 2];
+  const max = values[index * 2 + 1];
+  // Buckets are written in pairs, so asking for one past the end is a bug in
+  // the TEST — say which bucket rather than comparing against undefined.
+  if (min === undefined || max === undefined) {
+    throw new Error(`no bucket ${index} in ${values.length / 2} buckets`);
+  }
+  return [min, max];
 }
 
 /** Compare a bucket with tolerance: these are Float32Array cells, so a literal

--- a/packages/ui/timeline/viewport/waveform-peaks.ts
+++ b/packages/ui/timeline/viewport/waveform-peaks.ts
@@ -68,7 +68,9 @@ export function computePeaks(
     let seen = false;
     for (let i = start; i < end; i += 1) {
       const value = samples[i];
-      if (!Number.isFinite(value)) continue;
+      // `Number.isFinite` already rejects undefined at runtime, but it is not a
+      // type guard — the explicit check is what lets `min`/`max` stay numbers.
+      if (value === undefined || !Number.isFinite(value)) continue;
       if (!seen) {
         min = value;
         max = value;
@@ -139,6 +141,11 @@ export function peaksForWindow(
     for (let b = fromIndex; b < toIndex && b < totalBuckets; b += 1) {
       const bucketMin = peaks.values[b * 2];
       const bucketMax = peaks.values[b * 2 + 1];
+      // Buckets are written in min/max PAIRS, so both halves exist for any b
+      // inside the loop bound. Skipping a half-written pair keeps the running
+      // min/max as numbers instead of letting one `undefined` poison the whole
+      // span into NaN and flatten the lane.
+      if (bucketMin === undefined || bucketMax === undefined) continue;
       if (!seen) {
         min = bucketMin;
         max = bucketMax;
@@ -166,8 +173,10 @@ export function peaksForWindow(
  */
 export function peakMagnitude(values: Float32Array): number {
   let peak = 0;
-  for (let i = 0; i < values.length; i += 1) {
-    const magnitude = Math.abs(values[i]);
+  // for...of over a Float32Array yields numbers directly — no index, nothing
+  // to be undefined.
+  for (const value of values) {
+    const magnitude = Math.abs(value);
     if (magnitude > peak) peak = magnitude;
   }
   return peak;

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -5,6 +5,13 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
+    // Types `arr[i]` and `record[key]` as `T | undefined`. #283 step 4.
+    // 119 sites, and no `arr[i]!` among them: the flag is only worth having
+    // if the fixes are real. The hot paths (strip geometry, the virtual
+    // window) read through one documented accessor rather than a bounds
+    // check per access; tests read through `test-support/at`, which names
+    // the index and the actual length when a list is shorter than expected.
+    "noUncheckedIndexedAccess": true,
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
#283 step 4. **119 sites, and no `arr[i]!` among them.** The issue names the
mechanical fix as the way to do this wrong, and it is right — the flag only
earns its keep if the repairs are real.

Most of the count came from a few roots rather than 119 separate decisions.

## `getSpec` / the MEDIA table

Indexed `VIDEO_SOURCES` by fixed position. Typed the constant `as const` so
those really are known-present entries, and gave the modulo reads one `cycle()`
helper — which also makes a **negative** index wrap rather than miss, a small
bug the bare `index % length` had.

## The strip geometry

Its binary search and cursor read four parallel arrays in a per-frame scrub
path. They now go through one `readAt` that states the invariant once (all four
are built together; every index comes from `locate()` or a `< count` guard)
rather than a bounds check per access.

It **throws** rather than falling back to `0`: a fallback would silently draw a
clip at the wrong offset or drift the playhead, which is far harder to trace
than a stop that names the index.

*Tried and reverted:* `Float64Array` views, on the theory that a typed array
index is `number`. TypeScript applies the flag to typed arrays too, so it
bought nothing.

## The virtual strip

Resolves each item's id **once** at the top of the map and skips the item if it
has gone. The virtualizer's window can lag a removal by a render, so an index
there genuinely may not name a child.

`getItemKey` falls back to the **index** rather than `undefined`: the
virtualizer memoizes measurements by that key, and `undefined` would collapse
every out-of-range probe onto one entry.

## Elsewhere, an idiom that stops indexing

`entries()` where a loop wanted position and value; `for...of` over a
`Float32Array`; `slice()` where a loop was summing a prefix.

`Number.isFinite(value)` needed an explicit `value === undefined` beside it —
it rejects `undefined` at runtime but is not a type guard, so the narrowing
never followed.

## Tests

They read through `test-support/at`, which fails with the index **and** the
actual length — usually the whole diagnosis. `packed[1]!.startTime` would have
compiled and then failed as "cannot read startTime of undefined", in a file
whose only job is to say what went wrong.

## Verification

539 unit + 193 story + 774 app + 169 e2e; the app still typechecks against it.

Remaining for #283: the app (366).

🤖 Generated with [Claude Code](https://claude.com/claude-code)