### PR TITLE
Make the app's index reads safe, ahead of turning the flag on

### DIFF
--- a/apps/timeline-gstudio001/app/api/trash/route.ts
+++ b/apps/timeline-gstudio001/app/api/trash/route.ts
@@ -199,7 +199,8 @@ export async function POST(request: Request) {
     for (const clipId of clipIds) {
       const index = remaining.findIndex((clip) => clip.id === clipId);
       if (index === -1) continue;
-      dropped.push(remaining[index]);
+      const removed = remaining[index];
+      if (removed !== undefined) dropped.push(removed);
       remaining.splice(index, 1);
     }
     const discarded = dropped.length;

--- a/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
+++ b/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
@@ -394,6 +394,11 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
                 // paints comes from the first copy, which is safe precisely
                 // because copies of one asset share them.
                 const clip = group.clips[0];
+                // A group is BUILT from at least one clip, so this holds —
+                // rendering nothing is still the right answer if a future
+                // grouping ever produces an empty one, rather than a row of
+                // "undefined" where a filename should be.
+                if (clip === undefined) return null;
                 const busy = group.clips.some((entry) => restoringIds.includes(entry.id));
                 // `title` lives only on a COLLECTION clip, so it needs the
                 // discriminant to reach — media clips fall straight through to

--- a/apps/timeline-gstudio001/components/graph-view/graph-hydration.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-hydration.tsx
@@ -167,6 +167,10 @@ export function HydrationController({
       // grandchildren stay lazy. Best-effort per child: a failure reports its
       // own issue (see hydrateTimeline) and never blocks the focus view.
       const focusedId = focusChain[focusChain.length - 1];
+      // Inside the async body, AFTER every hook — an early return placed above
+      // a hook is a rules-of-hooks violation, which is how the first attempt
+      // at this guard broke lint.
+      if (focusedId === undefined) return;
       for (const childId of getChildren(store.getSnapshot().graph, parseNodeId(focusedId))) {
         if (cancelled) return;
         const child = store.getSnapshot().graph.nodesById.get(childId);

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
@@ -535,7 +535,10 @@ export function GraphItemActionsBridge({
         const siblings = getChildren(store.getSnapshot().graph, parentId);
         const at = (item: Built) => siblings.indexOf(item.sourceId);
         group.sort((a, b) => at(a) - at(b));
-        const lastAt = at(group[group.length - 1]);
+        const lastOfGroup = group[group.length - 1];
+        // A group only exists because something was put in it; appending is
+        // the same answer the not-found branch already gives.
+        const lastAt = lastOfGroup === undefined ? -1 : at(lastOfGroup);
         const toIndex = lastAt >= 0 ? lastAt + 1 : siblings.length;
         newIds.push(
           ...insertClones(

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -314,7 +314,9 @@ export function useCollectionPreviewFrames(
   // Picture" for one collection. A representative frame (the midpoint of the
   // collection's own duration) is the better answer and needs the preview
   // machinery to resolve a time, which is its own change.
-  return useMemo(() => (all.length > 1 ? [all[0]] : all), [all]);
+  // `slice(0, 1)` rather than `[all[0]]`: it yields the same one-frame list
+  // without constructing an array that could hold `undefined`.
+  return useMemo(() => (all.length > 1 ? all.slice(0, 1) : all), [all]);
 }
 
 /**
@@ -1567,7 +1569,10 @@ const GraphGhost = memo(function GraphGhost({ node, extraCount }: CollectionGhos
     : [];
   // FIRST and LAST only (or the single frame) — never three, exactly as the
   // card picks its two representative frames.
-  const chosen = all.length > 1 ? [all[0], all[all.length - 1]] : all;
+  // Built by index PAIR rather than as a literal of two possibly-undefined
+  // reads — same two frames, and the ghost cannot end up rendering a hole.
+  const chosen =
+    all.length > 1 ? [0, all.length - 1].flatMap((i) => all[i] ?? []) : all;
   const derivedFrames: string[] = isCollection
     ? chosen.map((preview) => collectionPreviewFrameUrl(preview)).filter(Boolean)
     : (() => {

--- a/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-native-drop.tsx
@@ -126,9 +126,11 @@ function neighborsAt(
   children: readonly NodeId[],
   index: number,
 ): Pick<DropAnchor, "beforeId" | "afterId"> {
+  // `?? null` rather than a cast: an index at either edge legitimately has no
+  // neighbour, which is exactly what the null already means to DropAnchor.
   return {
-    beforeId: index > 0 ? children[index - 1] : null,
-    afterId: index < children.length ? children[index] : null,
+    beforeId: (index > 0 ? children[index - 1] : null) ?? null,
+    afterId: (index < children.length ? children[index] : null) ?? null,
   };
 }
 
@@ -187,8 +189,12 @@ async function mapWithConcurrency<T, R>(
   const worker = async () => {
     for (;;) {
       const index = cursor++;
-      if (index >= items.length) return;
-      results[index] = await run(items[index]);
+      const item = items[index];
+      // The bound above already stops at the end; reading the item through a
+      // check keeps the worker from calling `run(undefined)` if the list is
+      // ever mutated while the pool is draining it.
+      if (index >= items.length || item === undefined) return;
+      results[index] = await run(item);
     }
   };
   await Promise.all(
@@ -748,7 +754,7 @@ function useNativeDrop(collectionId: string, projectId: string) {
           // no error — the upload silently went nowhere.
           if (!added) {
             commitError =
-              landed.length === 1
+              landed.length === 1 && landed[0] !== undefined
                 ? `"${landed[0].node.name}" uploaded but could not be added here.`
                 : `${landed.length} files uploaded but could not be added here.`;
           }
@@ -1202,7 +1208,7 @@ export function NativeDropGrid({
     // boundary. The same `before` cell resolves the actual DropAnchor below,
     // so the line cannot advertise one insertion point and commit another.
     const beforeIndex = before ? geometry.cells.indexOf(before) : -1;
-    const previous = beforeIndex > 0 ? geometry.cells[beforeIndex - 1] : null;
+    const previous = (beforeIndex > 0 ? geometry.cells[beforeIndex - 1] : null) ?? null;
     const boundaryStartsRow = before !== null && previous !== null && previous.top < before.top - 1;
     const anchorPreviousRowEnd = boundaryStartsRow && previous !== null && clientY <= previous.bottom;
     const halfGap = geometry.gap / 2;
@@ -1210,8 +1216,11 @@ export function NativeDropGrid({
     let x: number;
     let y: number;
     let height: number;
+    const last = geometry.cells[geometry.cells.length - 1];
+    // No cells means nothing to draw an indicator against — the caller's own
+    // empty-strip path already covers that case.
+    if (last === undefined) return null;
     if (!before) {
-      const last = geometry.cells[geometry.cells.length - 1];
       x = last.right + halfGap - halfIndicator - geometry.wrapperLeft;
       y = last.top - geometry.wrapperTop;
       height = last.bottom - last.top;

--- a/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.ts
@@ -421,22 +421,42 @@ export function buildPlayheadMap(cards: readonly ChildSpan[]): PlayheadMap {
     x += card.width + STRIP_GAP_PX;
   }
   const count = times.length;
-  const total = count > 0 ? times[count - 1] : 0;
+  const total = times[count - 1] ?? 0;
+
+  /**
+   * Read one of the two parallel arrays.
+   *
+   * `times` and `xs` are pushed in the same loop, two entries per card, so
+   * they always share `count` — and every index below is 0, `count - 1`, or a
+   * binary-search midpoint between them. This states that once rather than
+   * bounds-checking each of the ten reads in a mapping that runs per frame
+   * while scrubbing.
+   *
+   * Throws rather than defaulting: a 0 here would map the playhead to the
+   * start of the strip, which looks like a seek the user did not make.
+   */
+  const readAt = (values: readonly number[], index: number): number => {
+    const value = values[index];
+    if (value === undefined) {
+      throw new RangeError(`playhead map: index ${index} outside 0..${count - 1}`);
+    }
+    return value;
+  };
 
   const interpolate = (value: number, from: number[], to: number[]): number => {
     if (count === 0) return 0;
-    if (value <= from[0]) return to[0];
-    if (value >= from[count - 1]) return to[count - 1];
+    if (value <= readAt(from, 0)) return readAt(to, 0);
+    if (value >= readAt(from, count - 1)) return readAt(to, count - 1);
     let low = 0;
     let high = count - 1;
     while (low < high - 1) {
       const middle = (low + high) >> 1;
-      if (from[middle] <= value) low = middle;
+      if (readAt(from, middle) <= value) low = middle;
       else high = middle;
     }
-    const span = from[high] - from[low];
-    const fraction = span > 0 ? (value - from[low]) / span : 0;
-    return to[low] + fraction * (to[high] - to[low]);
+    const span = readAt(from, high) - readAt(from, low);
+    const fraction = span > 0 ? (value - readAt(from, low)) / span : 0;
+    return readAt(to, low) + fraction * (readAt(to, high) - readAt(to, low));
   };
 
   return {
@@ -459,7 +479,10 @@ export function rulerMajorSpacing(pixelsPerSecond: number): number {
   const target = RULER_LABEL_MIN_GAP_PX / Math.max(1, pixelsPerSecond);
   return (
     RULER_NICE_SECONDS.find((step) => step >= target) ??
-    RULER_NICE_SECONDS[RULER_NICE_SECONDS.length - 1]
+    RULER_NICE_SECONDS[RULER_NICE_SECONDS.length - 1] ??
+    // Only reachable if the constant is emptied; one second is the smallest
+    // spacing that still draws a ruler rather than dividing by zero.
+    1
   );
 }
 
@@ -545,13 +568,13 @@ export function buildRulerTicks(
   // walks — one pass carrying the running left edge.
   const ranges: Array<{ x0: number; x1: number; isCollection: boolean }> = [];
   let cursorX = 0;
-  for (let index = 0; index < cards.length; index += 1) {
+  for (const [index, card] of cards.entries()) {
     ranges.push({
       x0: cursorX,
-      x1: cursorX + cards[index].width,
+      x1: cursorX + card.width,
       isCollection: isCollectionCard[index] === true,
     });
-    cursorX += cards[index].width + STRIP_GAP_PX;
+    cursorX += card.width + STRIP_GAP_PX;
   }
 
   // Ranges are sorted and disjoint (widths are positive, the gap separates
@@ -559,15 +582,19 @@ export function buildRulerTicks(
   // edge lies before it. Binary search for that candidate, then apply the
   // exact interior predicate to it alone.
   const inCollectionInterior = (cx: number): boolean => {
-    if (ranges[0].x0 >= cx) return false;
+    const first = ranges[0];
+    // No cards means no interiors — the same answer as "left of the first".
+    if (first === undefined || first.x0 >= cx) return false;
     let low = 0;
     let high = ranges.length - 1;
     while (low < high) {
       const middle = (low + high + 1) >> 1;
-      if (ranges[middle].x0 < cx) low = middle;
+      const candidate = ranges[middle];
+      if (candidate !== undefined && candidate.x0 < cx) low = middle;
       else high = middle - 1;
     }
     const range = ranges[low];
+    if (range === undefined) return false;
     return range.isCollection && cx > range.x0 + 1 && cx <= range.x1;
   };
 
@@ -627,8 +654,7 @@ export function buildRulerCollectionSpans(
 ): RulerCollectionSpan[] {
   const out: RulerCollectionSpan[] = [];
   let cursorX = 0;
-  for (let index = 0; index < cards.length; index += 1) {
-    const card = cards[index];
+  for (const [index, card] of cards.entries()) {
     const x1 = cursorX + card.width;
     if (
       isCollectionCard[index] === true &&
@@ -668,24 +694,42 @@ export function buildGridPlayheadMap(
   const cellY = (index: number) => Math.floor(index / columns) * (cellHeight + GRID_GAP);
   const clamp01 = (value: number) => Math.min(1, Math.max(0, value));
 
+  /**
+   * Read one of the two parallel span arrays.
+   *
+   * `starts` and `ends` are built together with one entry per cell, and every
+   * index below is clamped to `0..count - 1` before it gets here. Stated once
+   * rather than per read, in a mapping the grid playhead runs every frame.
+   *
+   * Throws rather than defaulting: a 0 would place the playhead at the origin,
+   * which reads as a seek nobody asked for.
+   */
+  const spanAt = (values: readonly number[], index: number): number => {
+    const value = values[index];
+    if (value === undefined) {
+      throw new RangeError(`grid playhead: index ${index} outside 0..${count - 1}`);
+    }
+    return value;
+  };
+
   return {
     rowHeight: cellHeight,
-    totalDurationSeconds: total,
+    totalDurationSeconds: total ?? 0,
     posAt: (time) => {
       if (count === 0) return { x: 0, y: 0 };
       let low = 0;
-      if (time >= starts[count - 1]) {
+      if (time >= spanAt(starts, count - 1)) {
         low = count - 1;
-      } else if (time > starts[0]) {
+      } else if (time > spanAt(starts, 0)) {
         let high = count - 1;
         while (low < high - 1) {
           const middle = (low + high) >> 1;
-          if (starts[middle] <= time) low = middle;
+          if (spanAt(starts, middle) <= time) low = middle;
           else high = middle;
         }
       }
-      const span = ends[low] - starts[low];
-      const fraction = span > 0 ? clamp01((time - starts[low]) / span) : 0;
+      const span = spanAt(ends, low) - spanAt(starts, low);
+      const fraction = span > 0 ? clamp01((time - spanAt(starts, low)) / span) : 0;
       return { x: cellX(low) + fraction * cellWidth, y: cellY(low) };
     },
     timeAt: (x, y) => {
@@ -695,8 +739,8 @@ export function buildGridPlayheadMap(
       const index = Math.max(0, Math.min(count - 1, row * columns + column));
       const fraction = clamp01((x - cellX(index)) / cellWidth);
       return Math.min(
-        total,
-        Math.max(0, starts[index] + fraction * (ends[index] - starts[index])),
+        total ?? 0,
+        Math.max(0, spanAt(starts, index) + fraction * (spanAt(ends, index) - spanAt(starts, index))),
       );
     },
   };

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -564,8 +564,13 @@ export function GraphWaveformBand({
 
       context.fillStyle = card.disabled === true ? "rgba(161,161,170,0.35)" : "rgba(125,211,252,0.85)";
       for (let column = 0; column < columns; column += 1) {
-        const min = window_[column * 2] * scale;
-        const max = window_[column * 2 + 1] * scale;
+        // Peaks are written in min/max PAIRS; a half-written column is skipped
+        // rather than drawn as a spike at zero.
+        const rawMin = window_[column * 2];
+        const rawMax = window_[column * 2 + 1];
+        if (rawMin === undefined || rawMax === undefined) continue;
+        const min = rawMin * scale;
+        const max = rawMax * scale;
         const top = midline - Math.max(max, 0.5);
         const height = Math.max(1, Math.max(max, 0.5) - Math.min(min, -0.5));
         // Canvas x is window-relative: the element is translated to startX.
@@ -1036,10 +1041,9 @@ export function PreviewShell({
     channel.set(0);
   }, [channel, focusedId]);
 
+  const lastClip = clips[clips.length - 1];
   const totalDuration =
-    clips.length > 0
-      ? clips[clips.length - 1].startTime + clips[clips.length - 1].duration
-      : 0;
+    lastClip === undefined ? 0 : lastClip.startTime + lastClip.duration;
   useEffect(() => {
     if (channel.get() > totalDuration) channel.set(totalDuration);
   }, [channel, totalDuration]);

--- a/apps/timeline-gstudio001/components/graph-view/graph-seek-rails.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seek-rails.tsx
@@ -139,8 +139,11 @@ function SeekRailRow({
   const cells = rowCards.length;
   const pitch = cellWidth + GRID_GAP;
   const extent = Math.max(1, cells * pitch - GRID_GAP);
-  const rowStart = rowCards[0].startTime;
-  const rowEnd = rowCards[cells - 1].endTime;
+  // Defaults rather than an early return: this sits above the hooks below, and
+  // returning here would call them conditionally. An empty row collapses to a
+  // zero-length span, which the rail already renders as nothing.
+  const rowStart = rowCards[0]?.startTime ?? 0;
+  const rowEnd = rowCards[cells - 1]?.endTime ?? 0;
 
   // Thumb/fill/aria track the channel imperatively — time moves at pointer
   // rate during a scrub, no reason to re-render. Deps cover everything the
@@ -585,8 +588,8 @@ export function GraphStripSeekRail({
     [graph, details, spans, focusedId, pixelsPerSecond, cardHeight, flatItems],
   );
   const map = useMemo(() => buildPlayheadMap(cards), [cards]);
-  const start = cards.length > 0 ? cards[0].startTime : 0;
-  const end = cards.length > 0 ? cards[cards.length - 1].endTime : 0;
+  const start = cards[0]?.startTime ?? 0;
+  const end = cards[cards.length - 1]?.endTime ?? 0;
   // The rail is a SIBLING of the strip, so it queries across for the scroller
   // rather than climbing to it like the ruler does — same window, two routes.
   const [scroller, setScroller] = useState<HTMLElement | null>(null);

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
@@ -451,7 +451,7 @@ export function GraphBreadcrumb({
     <div className="flex min-w-0 items-center gap-3 overflow-hidden">
       <ParentLink
         href={parentHref}
-        parentId={parentCrumbId}
+        parentId={parentCrumbId ?? null}
         title={focusedId === projectId ? "Go to Projects" : "Go to parent timeline"}
       />
       <nav

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-config.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-config.ts
@@ -127,7 +127,9 @@ export const DEFAULT_ITEM_SIZE: ItemSize = "lg";
  */
 export function stepDownItemSize(size: ItemSize): ItemSize {
   const index = ITEM_SIZES.indexOf(size);
-  return ITEM_SIZES[Math.max(0, index - 1)];
+  // One step down, never past the smallest. Unreachable for a non-empty
+  // constant — stated so the function stays total whatever the caller passes.
+  return ITEM_SIZES[Math.max(0, index - 1)] ?? ITEM_SIZES[0];
 }
 
 /**

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -37,6 +37,13 @@ import { cn } from "@/lib/utils";
 
 import { SidebarTooltipLabel } from "./sidebar-tooltip-label";
 
+/** The avatar letter. Written once because the same nested ternary appeared in
+ *  two places, and an empty name string made `name[0]` undefined in both. */
+function initialOf(user: { name?: string | null; email?: string | null } | null | undefined): string {
+  return (user?.name?.[0] ?? user?.email?.[0] ?? "U").toUpperCase();
+}
+
+
 type UtilityItem = {
   id: "assets" | "trash";
   label: string;
@@ -614,7 +621,7 @@ export function TimelineSidebar() {
             />
           ) : (
             <div className="flex h-8 w-8 items-center justify-center rounded-full border border-zinc-700 bg-zinc-800/60 text-xs font-bold text-zinc-400 transition-colors select-none group-hover/sidebar-item:border-zinc-600 group-hover/sidebar-item:bg-zinc-800 group-hover/sidebar-item:text-zinc-100">
-              {user?.name ? user.name[0].toUpperCase() : (user?.email ? user.email[0].toUpperCase() : "U")}
+              {initialOf(user)}
             </div>
           )}
           <SidebarTooltipLabel
@@ -638,7 +645,7 @@ export function TimelineSidebar() {
                 />
               ) : (
                 <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-zinc-700 bg-zinc-800/60 text-sm font-bold text-zinc-300">
-                  {user?.name ? user.name[0].toUpperCase() : (user?.email ? user.email[0].toUpperCase() : "U")}
+                  {initialOf(user)}
                 </div>
               )}
               <div className="min-w-0 flex-1">

--- a/apps/timeline-gstudio001/hooks/use-dialog-focus.ts
+++ b/apps/timeline-gstudio001/hooks/use-dialog-focus.ts
@@ -87,7 +87,10 @@ export function useDialogFocus<T extends HTMLElement>() {
       const edge = event.shiftKey ? focusable[0] : focusable[focusable.length - 1];
       const wrapTo = event.shiftKey ? focusable[focusable.length - 1] : focusable[0];
       const active = document.activeElement;
-      if (active === edge || !panel.contains(active)) {
+      // `focusable` was length-checked above, so both ends exist; with nothing
+      // to wrap to there is no trap to enforce and the key should pass through
+      // rather than be swallowed.
+      if (wrapTo !== undefined && (active === edge || !panel.contains(active))) {
         event.preventDefault();
         wrapTo.focus();
       }

--- a/apps/timeline-gstudio001/lib/assets/asset-references.test.ts
+++ b/apps/timeline-gstudio001/lib/assets/asset-references.test.ts
@@ -8,6 +8,7 @@ import {
   assetRefKey,
   unreferencedCandidates,
 } from "./asset-references";
+import { at } from "../../lib/test-support/at";
 
 function mediaClip(
   id: string,
@@ -115,7 +116,7 @@ describe("assetCandidatesFromClips", () => {
       mediaClip("a1", { providerId: "cloudinary", assetId: "takes/vo.flac" }, "audio"),
     ]);
 
-    expect(candidates[0].kind).toBe("video");
+    expect(at(candidates, 0).kind).toBe("video");
   });
 
   it("gives audio an EMPTY thumbnail rather than its own src", () => {
@@ -126,7 +127,7 @@ describe("assetCandidatesFromClips", () => {
       mediaClip("a1", { providerId: "cloudinary", assetId: "takes/vo.flac" }, "audio"),
     ]);
 
-    expect(candidates[0].thumbnailUrl).toBe("");
+    expect(at(candidates, 0).thumbnailUrl).toBe("");
   });
 
   it("still names an audio candidate from the asset id when it has no title", () => {
@@ -135,7 +136,7 @@ describe("assetCandidatesFromClips", () => {
     ]);
 
     // A row that prints nothing at all is worse than one printing the leaf.
-    expect(candidates[0].name).toBe("a1");
+    expect(at(candidates, 0).name).toBe("a1");
   });
 
   it("snapshots a name and a thumbnail, because no clip will be left to ask", () => {

--- a/apps/timeline-gstudio001/lib/cloudinary-media-store.test.ts
+++ b/apps/timeline-gstudio001/lib/cloudinary-media-store.test.ts
@@ -6,6 +6,7 @@ import {
   listCloudinaryAssets,
   uploadCloudinaryMedia,
 } from "./cloudinary-media-store";
+import { at } from "../lib/test-support/at";
 
 const CLOUDINARY_URL = "cloudinary://key:secret@demo";
 
@@ -46,7 +47,7 @@ describe("Cloudinary project folders", () => {
 
     const assets = await listCloudinaryAssets("user-project-list", "project-a");
     expect(assets).toHaveLength(1);
-    expect(assets[0].relativePath).toBe("Scenes/frame-1");
+    expect(at(assets, 0).relativePath).toBe("Scenes/frame-1");
 
     const imageRequest = new URL(
       requests.find((request) => request.url.includes("/resources/image/upload"))!.url,
@@ -131,8 +132,8 @@ describe("Cloudinary project folders", () => {
     });
 
     expect(requests).toHaveLength(2);
-    const firstHeaders = new Headers(requests[0].headers);
-    const secondHeaders = new Headers(requests[1].headers);
+    const firstHeaders = new Headers(at(requests, 0).headers);
+    const secondHeaders = new Headers(at(requests, 1).headers);
     expect(firstHeaders.get("Content-Range")).toBe(
       `bytes 0-${20 * 1024 * 1024 - 1}/${20 * 1024 * 1024 + 1}`,
     );
@@ -143,9 +144,9 @@ describe("Cloudinary project folders", () => {
     expect(secondHeaders.get("X-Unique-Upload-Id")).toBe(
       firstHeaders.get("X-Unique-Upload-Id"),
     );
-    expect(((requests[0].body as FormData).get("file") as Blob).size).toBe(
+    expect(((at(requests, 0).body as FormData).get("file") as Blob).size).toBe(
       20 * 1024 * 1024,
     );
-    expect(((requests[1].body as FormData).get("file") as Blob).size).toBe(1);
+    expect(((at(requests, 1).body as FormData).get("file") as Blob).size).toBe(1);
   });
 });

--- a/apps/timeline-gstudio001/lib/derive-collection-summaries.ts
+++ b/apps/timeline-gstudio001/lib/derive-collection-summaries.ts
@@ -69,11 +69,12 @@ function nestedPreviewItemsFrom(clips: readonly TimelineDocument["clips"][number
       : previewItemsFrom([clip]),
   );
   if (nested.length <= 3) return nested;
-  return [
-    nested[0],
-    nested[Math.floor(nested.length / 2)],
-    nested[nested.length - 1],
-  ];
+  // Indices then a bounds check, matching `previewItemsFrom` and
+  // `hydratedCollectionPreviews` — this projection is PERSISTED, so a hole
+  // would write a summary entry with undefined fields.
+  return [0, Math.floor(nested.length / 2), nested.length - 1].flatMap(
+    (index) => nested[index] ?? [],
+  );
 }
 
 export function deriveCollectionSummaries(

--- a/apps/timeline-gstudio001/lib/firebase-media-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-media-store.ts
@@ -164,7 +164,10 @@ export async function getMediaMetadata(pathname: string) {
 export function createMediaReadStream(
   pathname: string,
   range?: { start: number; end: number },
-  bucketName = getFirebaseBucketNames()[0],
+  // The first configured bucket. `?? ""` keeps the default total; an empty
+  // name fails in the SDK with the bucket it was given, which is a clearer
+  // error than a TypeError here.
+  bucketName = getFirebaseBucketNames()[0] ?? "",
 ) {
   const file = getFirebaseBucketByName(bucketName).file(pathname);
   return range

--- a/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
@@ -612,7 +612,7 @@ export async function saveFirebaseTimelineEntry(
           );
           // Already gone, or never there: a dangling reference being tidied
           // up, which is a repair rather than a loss.
-          const stranded = released.filter((_childId, index) => snapshots[index].exists);
+          const stranded = released.filter((_childId, index) => snapshots[index]?.exists === true);
           if (stranded.length > 0) {
             throw new TimelineOrphanError(
               stranded.map((id) => ({ id, fromTimelineId: normalizedDocument.id })),
@@ -697,9 +697,13 @@ export async function saveFirebaseTimelineDocumentsAtomic(
       const releasedChildren = new Map<string, string>();
       const claimedChildren = new Set<string>();
 
-      for (let index = 0; index < writes.length; index += 1) {
-        const normalizedDocument = normalizeDocument(writes[index].document);
+      // entries() pairs each write with its own snapshot instead of indexing
+      // two arrays separately — they are produced together by the Promise.all
+      // above, and reading them apart is what let them drift in principle.
+      for (const [index, write] of writes.entries()) {
+        const normalizedDocument = normalizeDocument(write.document);
         const snapshot = snapshots[index];
+        if (snapshot === undefined) continue;
         const existingData = snapshot.exists
           ? (snapshot.data() as TimelineDocumentRecord)
           : undefined;
@@ -709,7 +713,7 @@ export async function saveFirebaseTimelineDocumentsAtomic(
         }
 
         const actualRevision = existingData?.revision ?? 0;
-        const expected = writes[index].expectedRevision;
+        const expected = write.expectedRevision;
         if (expected !== undefined && expected !== actualRevision) {
           conflicts.push({ id: normalizedDocument.id, actualRevision });
           continue;
@@ -737,7 +741,7 @@ export async function saveFirebaseTimelineDocumentsAtomic(
         }
 
         if (
-          !writes[index].allowEmptying &&
+          !write.allowEmptying &&
           existingDocument &&
           existingDocument.clips.length > 0 &&
           normalizedDocument.clips.length === 0
@@ -747,8 +751,13 @@ export async function saveFirebaseTimelineDocumentsAtomic(
           );
         }
 
+        const ref = refs[index];
+        // Built by the same map as `writes`, so this holds; skipping keeps a
+        // mismatch from staging a write against the WRONG document reference,
+        // which is the one failure worse than not writing at all.
+        if (ref === undefined) continue;
         staged.push({
-          ref: refs[index],
+          ref,
           id: normalizedDocument.id,
           revision: actualRevision + 1,
           payload: buildSavePayload(
@@ -761,7 +770,7 @@ export async function saveFirebaseTimelineDocumentsAtomic(
             // back whenever a stored document has no clips, so leaving it would
             // re-hydrate the very clips this write removed and the empty would
             // never stick.
-            { allowEmptying: writes[index].allowEmptying },
+            { allowEmptying: write.allowEmptying },
           ),
         });
       }
@@ -797,7 +806,7 @@ export async function saveFirebaseTimelineDocumentsAtomic(
         // for the same timeline is minted with its own clip id and so is not
         // owning — which is exactly what makes "released and unclaimed" mean
         // "unreachable" without a reverse index to consult.
-        const stranded = orphaned.filter((_id, index) => orphanSnapshots[index].exists);
+        const stranded = orphaned.filter((_id, index) => orphanSnapshots[index]?.exists === true);
         if (stranded.length > 0) {
           throw new TimelineOrphanError(
             stranded.map((id) => ({ id, fromTimelineId: releasedChildren.get(id) ?? null })),
@@ -981,7 +990,11 @@ async function mapWithConcurrency<In, Out>(
   let cursor = 0;
   const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
     for (let index = cursor++; index < items.length; index = cursor++) {
-      results[index] = await task(items[index]);
+      const item = items[index];
+      // The bound stops at the end; the check also covers the list being
+      // mutated while this pool drains it.
+      if (item === undefined) continue;
+      results[index] = await task(item);
     }
   });
   await Promise.all(workers);

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
 
 import { createGraphDocumentsGateway } from "./graph-documents-gateway";
+import { at } from "../lib/test-support/at";
 
 const SAVE_DEBOUNCE_MS = 900;
 const SAVE_RETRY_MS = 5000;
@@ -234,8 +235,8 @@ describe("graph-documents-gateway", () => {
     await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
     const batches = batchesOf(calls);
     expect(batches).toHaveLength(1);
-    expect(batches[0].writes).toHaveLength(2);
-    const byId = new Map(batches[0].writes?.map((write) => [write.document.id, write]));
+    expect(at(batches, 0).writes).toHaveLength(2);
+    const byId = new Map(at(batches, 0).writes?.map((write) => [write.document.id, write]));
     expect(clipIds(byId.get("a")?.document)).toEqual(["a2"]);
     expect(byId.get("a")?.expectedRevision).toBe(3);
     expect(clipIds(byId.get("b")?.document)).toEqual(["b2"]);
@@ -276,8 +277,8 @@ describe("graph-documents-gateway", () => {
     await vi.advanceTimersByTimeAsync(0);
     const batches = batchesOf(calls);
     expect(batches).toHaveLength(2);
-    expect(clipIds(batches[1].writes?.[0].document)).toEqual(["a4"]);
-    expect(batches[1].writes?.[0].expectedRevision).toBe(2);
+    expect(clipIds(at(batches, 1).writes?.[0].document)).toEqual(["a4"]);
+    expect(at(batches, 1).writes?.[0].expectedRevision).toBe(2);
   });
 
   // The refresh/save race. Awaiting only the batch that happened to be in
@@ -346,8 +347,8 @@ describe("graph-documents-gateway", () => {
     gateway.flushPendingWrites({ keepalive: true });
     const batches = batchesOf(calls);
     expect(batches).toHaveLength(1);
-    expect(batches[0].keepalive).toBe(true);
-    expect(clipIds(batches[0].writes?.[0].document)).toEqual(["a2"]);
+    expect(at(batches, 0).keepalive).toBe(true);
+    expect(clipIds(at(batches, 0).writes?.[0].document)).toEqual(["a2"]);
 
     // The debounce timer was consumed — no duplicate batch later.
     await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
@@ -380,12 +381,12 @@ describe("graph-documents-gateway", () => {
 
     const batches = batchesOf(calls);
     expect(batches).toHaveLength(2); // it did NOT wait for the stuck request
-    expect(batches[0].signal?.aborted).toBe(true); // the stuck one was abandoned
-    expect(batches[1].keepalive).toBe(true);
+    expect(at(batches, 0).signal?.aborted).toBe(true); // the stuck one was abandoned
+    expect(at(batches, 1).keepalive).toBe(true);
     // Carries the LATEST cache, and still expects the revision the abandoned
     // batch expected — no response landed, so the ledger never advanced.
-    expect(clipIds(batches[1].writes?.[0].document)).toEqual(["a3"]);
-    expect(batches[1].writes?.[0].expectedRevision).toBe(1);
+    expect(clipIds(at(batches, 1).writes?.[0].document)).toEqual(["a3"]);
+    expect(at(batches, 1).writes?.[0].expectedRevision).toBe(1);
     // Abandoning is not a failure: it must not surface as a save error.
     expect(gateway.lastError()).toBeNull();
   });
@@ -410,8 +411,8 @@ describe("graph-documents-gateway", () => {
     // The in-flight batch's own content is what would have been lost.
     const batches = batchesOf(calls);
     expect(batches).toHaveLength(2);
-    expect(batches[1].keepalive).toBe(true);
-    expect(clipIds(batches[1].writes?.[0].document)).toEqual(["a2"]);
+    expect(at(batches, 1).keepalive).toBe(true);
+    expect(clipIds(at(batches, 1).writes?.[0].document)).toEqual(["a2"]);
   });
 
   it("a second unload flush leaves an already-keepalive batch alone", async () => {
@@ -452,10 +453,10 @@ describe("graph-documents-gateway", () => {
 
     const batches = batchesOf(calls);
     expect(batches).toHaveLength(1);
-    expect(batches[0].bodyBytes).toBeGreaterThan(64 * 1024);
-    expect(batches[0].keepalive).toBeFalsy(); // sent best-effort instead
+    expect(at(batches, 0).bodyBytes).toBeGreaterThan(64 * 1024);
+    expect(at(batches, 0).keepalive).toBeFalsy(); // sent best-effort instead
     // The batch still went out INTACT — atomicity is not traded away.
-    expect(clipIds(batches[0].writes?.[0].document)).toEqual(["a2"]);
+    expect(clipIds(at(batches, 0).writes?.[0].document)).toEqual(["a2"]);
     // And the risk is surfaced rather than swallowed.
     expect(gateway.lastError()).toMatch(/too large/i);
   });
@@ -473,8 +474,8 @@ describe("graph-documents-gateway", () => {
     gateway.flushPendingWrites({ keepalive: true });
 
     const batches = batchesOf(calls);
-    expect(batches[0].bodyBytes).toBeLessThan(56 * 1024);
-    expect(batches[0].keepalive).toBe(true);
+    expect(at(batches, 0).bodyBytes).toBeLessThan(56 * 1024);
+    expect(at(batches, 0).keepalive).toBe(true);
     expect(gateway.lastError()).toBeNull();
   });
 

--- a/apps/timeline-gstudio001/lib/http-range.ts
+++ b/apps/timeline-gstudio001/lib/http-range.ts
@@ -37,7 +37,10 @@ export function parseRangeHeader(header: string | null, size: number): ParsedRan
   const match = /^\s*bytes\s*=\s*(.*)$/i.exec(header);
   if (!match) return IGNORE;
 
-  const spec = match[1].trim();
+  // The capture group is part of the pattern that just matched, so it is
+  // present; IGNORE is the same answer the non-matching branch above gives.
+  const spec = match[1]?.trim();
+  if (spec === undefined) return IGNORE;
   // Multiple ranges (`bytes=0-1,5-6`) are valid but unimplemented — serve the
   // whole body rather than pretending the first part was the whole request,
   // which is what the old unanchored regex silently did.

--- a/apps/timeline-gstudio001/lib/load-timeline-closure.ts
+++ b/apps/timeline-gstudio001/lib/load-timeline-closure.ts
@@ -50,7 +50,9 @@ async function mapWithConcurrency<In, Out>(
   let cursor = 0;
   const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
     for (let index = cursor++; index < items.length; index = cursor++) {
-      results[index] = await run(items[index]);
+      const item = items[index];
+      if (item === undefined) return;
+      results[index] = await run(item);
     }
   });
   await Promise.all(workers);

--- a/apps/timeline-gstudio001/lib/mcp/apply-command.ts
+++ b/apps/timeline-gstudio001/lib/mcp/apply-command.ts
@@ -132,13 +132,13 @@ function buildRootsGraph(
     {
       kind: "collection",
       id: rootTimelineId,
-      name: documents[rootTimelineId].title,
+      name: documents[rootTimelineId]?.title ?? rootTimelineId,
       children: rootSpecs.value.specs,
     },
     {
       kind: "collection",
       id: trashId,
-      name: documents[trashId].title || "Trash Bin",
+      name: documents[trashId]?.title || "Trash Bin",
       children: trashSpecs.value.specs,
     },
   ];
@@ -382,8 +382,11 @@ export async function applyCollectionsCommand(
     return { document, expectedRevision: 0 };
   });
   const writes: TimelineBatchWrite[] = affectedIds.map((id) => {
+    const existing = documents[id];
+    // `affectedIds` is filtered to loaded documents just above, so this holds.
+    if (existing === undefined) throw new Error(`no loaded document "${id}" to write`);
     const document: TimelineDocument = {
-      ...documents[id],
+      ...existing,
       ...(id === retitled && command?.type === "rename-node" ? { title: command.name } : {}),
       clips: graphChildrenToClips(nextGraph, details, id),
     };

--- a/apps/timeline-gstudio001/lib/mcp/write-handlers.ts
+++ b/apps/timeline-gstudio001/lib/mcp/write-handlers.ts
@@ -140,9 +140,9 @@ export async function handleMoveClip(
   // subsequent read_timeline.
   const parentId = placedParent as NodeId | null;
   const newOrder =
-    parentId && outcome.documents[parentId as string]
-      ? outcome.documents[parentId as string].clips.map((clip) => clip.id)
-      : undefined;
+    parentId === null
+      ? undefined
+      : outcome.documents[parentId as string]?.clips.map((clip) => clip.id);
 
   return toolOk(`Moved "${args.nodeId}" into "${parentId}" at index ${placedIndex}.`, {
     movedId: args.nodeId,

--- a/apps/timeline-gstudio001/lib/oauth/core.ts
+++ b/apps/timeline-gstudio001/lib/oauth/core.ts
@@ -129,6 +129,12 @@ export function verifyAccessToken(
   const parts = token.split(".");
   if (parts.length !== 3) return { ok: false, reason: "malformed" };
   const [header, payload, signature] = parts;
+  // `length === 3` above guarantees all three; a malformed token is the same
+  // answer either way, and saying so keeps the crypto below reading real
+  // strings rather than "undefined".
+  if (header === undefined || payload === undefined || signature === undefined) {
+    return { ok: false, reason: "malformed" };
+  }
 
   if (!safeEqual(hmac(signingInput(header, payload), secret), signature)) {
     return { ok: false, reason: "bad-signature" };

--- a/apps/timeline-gstudio001/lib/tag-facets.ts
+++ b/apps/timeline-gstudio001/lib/tag-facets.ts
@@ -111,7 +111,9 @@ export function tagAccent(tag: string): TagAccent {
     hash ^= key.charCodeAt(i);
     hash = Math.imul(hash, 0x01000193) >>> 0;
   }
-  return DESCRIPTIVE_ACCENTS[hash % DESCRIPTIVE_ACCENTS.length];
+  // Modulo into a non-empty constant, so the fallback is unreachable — it is
+  // here so emptying the palette degrades to one accent instead of undefined.
+  return DESCRIPTIVE_ACCENTS[hash % DESCRIPTIVE_ACCENTS.length] ?? DESCRIPTIVE_ACCENTS[0];
 }
 
 /** True for the tags that say where something STANDS rather than what it is. */

--- a/apps/timeline-gstudio001/lib/test-support/at.ts
+++ b/apps/timeline-gstudio001/lib/test-support/at.ts
@@ -1,0 +1,30 @@
+/**
+ * Read an array element in a TEST, asserting it exists.
+ *
+ * Under `noUncheckedIndexedAccess` an assertion like `writes[1].document` no
+ * longer type-checks, and the two obvious repairs are both worse:
+ *
+ *   `writes[1]!.document` compiles and then fails as "cannot read document of
+ *   undefined", naming neither the index nor the length — in a test, whose
+ *   whole job is to say what went wrong.
+ *
+ *   `expect(writes[1]).toBeDefined()` before every access doubles the
+ *   assertion and still leaves the access unnarrowed.
+ *
+ * This fails with the index AND the actual length, which is usually the whole
+ * diagnosis: the batch was shorter than the test expected.
+ *
+ * A twin of `packages/ui/test-support/at.ts`. Deliberately duplicated rather
+ * than imported across the package boundary: `@storyboard/ui` is consumed by
+ * subpath and does not export test-only modules, and widening its public
+ * surface for a five-line test helper is the worse trade.
+ */
+export function at<T>(items: readonly T[], index: number): T {
+  const value = items[index];
+  if (value === undefined) {
+    throw new Error(
+      `expected an element at index ${index}, but the list has ${items.length}`,
+    );
+  }
+  return value;
+}

--- a/apps/timeline-gstudio001/lib/timeline-media-client.test.ts
+++ b/apps/timeline-gstudio001/lib/timeline-media-client.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { uploadTimelineMedia } from "./timeline-media-client";
+import { at } from "../lib/test-support/at";
 
 // The upload boundary. `response.json()` is `any`, so the function's
 // `Promise<TimelineMediaUploadResult>` annotation proves nothing about what
@@ -162,13 +163,13 @@ describe("uploadTimelineMedia video thumbnails", () => {
     ).resolves.toEqual(ok);
 
     expect(bodies).toHaveLength(1);
-    expect(bodies[0].get("projectId")).toBe("project-a");
+    expect(at(bodies, 0).get("projectId")).toBe("project-a");
     // FormData re-wraps a Blob as a File, so compare content, not identity.
-    const sent = bodies[0].get("thumbnail");
+    const sent = at(bodies, 0).get("thumbnail");
     expect(sent).toBeInstanceOf(Blob);
     expect((sent as Blob).type).toBe("image/jpeg");
     expect(await (sent as Blob).arrayBuffer()).toEqual(await poster.arrayBuffer());
-    expect(String(bodies[0].get("thumbnailFilename"))).toMatch(/^timeline-thumbnails\/a-thumbnail-/);
+    expect(String(at(bodies, 0).get("thumbnailFilename"))).toMatch(/^timeline-thumbnails\/a-thumbnail-/);
   });
 
   it("treats a supplied null thumbnail as 'already tried, none available'", async () => {
@@ -182,8 +183,8 @@ describe("uploadTimelineMedia video thumbnails", () => {
       }),
     ).resolves.toEqual(ok);
 
-    expect(bodies[0].get("thumbnail")).toBeNull();
-    expect(bodies[0].get("thumbnailFilename")).toBeNull();
+    expect(at(bodies, 0).get("thumbnail")).toBeNull();
+    expect(at(bodies, 0).get("thumbnailFilename")).toBeNull();
   });
 
   it("passes an abort signal through to the request", async () => {

--- a/apps/timeline-gstudio001/lib/trash-groups.test.ts
+++ b/apps/timeline-gstudio001/lib/trash-groups.test.ts
@@ -7,6 +7,7 @@ import {
   isUntouchedEmptyCollection,
   visibleTrashClips,
 } from "./trash-groups";
+import { at } from "../lib/test-support/at";
 
 function image(id: string, overrides: Partial<TimelineClip> = {}): TimelineClip {
   return {
@@ -37,7 +38,7 @@ describe("groupTrashClips", () => {
       image("b", { sourceAsset: CLOUDINARY }),
     ]);
     expect(groups).toHaveLength(1);
-    expect(groups[0].clips.map((c) => c.id)).toEqual(["a", "b"]);
+    expect(at(groups, 0).clips.map((c) => c.id)).toEqual(["a", "b"]);
   });
 
   it("falls back to src for clips minted before provenance was tracked", () => {
@@ -74,7 +75,7 @@ describe("groupTrashClips", () => {
       image("first-again", { src: "https://cdn.test/1.jpg" }),
     ]);
     expect(groups.map((g) => g.clips[0].id)).toEqual(["first", "second"]);
-    expect(groups[0].clips).toHaveLength(2);
+    expect(at(groups, 0).clips).toHaveLength(2);
   });
 
   it("keeps EVERY copy in the group — restoring the row restores them all", () => {
@@ -85,7 +86,7 @@ describe("groupTrashClips", () => {
       image("b", { sourceAsset: CLOUDINARY }),
       image("c", { sourceAsset: CLOUDINARY }),
     ]);
-    expect(groups[0].clips.map((c) => c.id)).toEqual(["a", "b", "c"]);
+    expect(at(groups, 0).clips.map((c) => c.id)).toEqual(["a", "b", "c"]);
   });
 
   it("leaves a single clip as a group of one, and an empty bin as nothing", () => {

--- a/apps/timeline-gstudio001/lib/video-frame-url.test.ts
+++ b/apps/timeline-gstudio001/lib/video-frame-url.test.ts
@@ -6,6 +6,7 @@ import {
   videoFrameUrls,
   type VideoFrameUrlBuilder,
 } from "./video-frame-url";
+import { at } from "../lib/test-support/at";
 
 const CLOUDINARY_FRAME =
   "https://res.cloudinary.com/demo/video/upload/so_0.35,w_640,h_360,c_fill,q_auto,f_jpg/folder/Scene.jpg";
@@ -120,7 +121,7 @@ describe("videoFrameUrls", () => {
     // effective 0.06s: end - 0.05 = 0.01 would land BEFORE the first slot's
     // centre — the midpoint floor keeps the pair ordered.
     videoFrameUrls(["poster"], 2, { trimInSeconds: 0, effectiveSeconds: 0.06 }, record);
-    expect(times[1]).toBeGreaterThanOrEqual(times[0]);
+    expect(at(times, 1)).toBeGreaterThanOrEqual(at(times, 0));
     expect(times[1]).toBeCloseTo(0.03);
   });
 

--- a/apps/timeline-gstudio001/lib/video-frame-url.ts
+++ b/apps/timeline-gstudio001/lib/video-frame-url.ts
@@ -126,7 +126,7 @@ export function videoFrameUrls(
         : index === slots - 1
           ? range.trimInSeconds + Math.max(effective / 2, effective - LAST_FRAME_BACKOFF_SECONDS)
           : range.trimInSeconds + ((index + 0.5) / slots) * effective;
-    urls.push(build(base, time));
+    if (base !== undefined) urls.push(build(base, time));
   }
   return urls;
 }

--- a/apps/timeline-gstudio001/tests/e2e/dnd-collections.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/dnd-collections.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Locator, type Page } from '@playwright/test';
+import { at } from "../../lib/test-support/at";
 
 // E2E coverage for packages/ui/dnd-collections, driven with REAL mouse input
 // against the Storybook iframe (the vitest story tests dispatch synthetic
@@ -100,7 +101,7 @@ test.describe('DndCollections E2E', () => {
       const ids = await panelOrder(page, 'panel-a');
       expect(ids).toHaveLength(4);
       expect(ids[3]).toMatch(/^col-/);
-      newId = ids[3];
+      newId = at(ids, 3);
     }).toPass();
 
     // The fresh collection is immediately droppable: nest alpha inside.

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Locator, type Page } from "@playwright/test";
+import { at } from "../../lib/test-support/at";
 
 // E2E for the graph project view (/timeline/[projectId]/graph) — the REAL
 // Next app driven with real mouse input. The server surface the view touches
@@ -3947,7 +3948,7 @@ test.describe("graph view E2E", () => {
     const TITLES = ["Depth One", "Depth Two", "Depth Three", "Depth Four"];
     // project → d1 → d2 → d3 → d4
     api.documents.get(PROJECT_ID)!.clips.push(
-      collectionClip("clip-d1", DEPTH_IDS[0], 9, TITLES[0], 1),
+      collectionClip("clip-d1", at(DEPTH_IDS, 0), 9, at(TITLES, 0), 1),
     );
     DEPTH_IDS.forEach((id, index) => {
       const child = DEPTH_IDS[index + 1];
@@ -3961,7 +3962,7 @@ test.describe("graph view E2E", () => {
     });
 
     await page.goto(`${GRAPH_URL}/${DEPTH_IDS.join("/")}?surface=strip`);
-    await expect(strip(page, DEPTH_IDS[3])).toBeVisible({ timeout: 30000 });
+    await expect(strip(page, at(DEPTH_IDS, 3))).toBeVisible({ timeout: 30000 });
 
     const trail = page.getByRole("navigation", { name: "Timeline focus path" });
     const overflow = trail.locator("[data-graph-crumb-overflow]");
@@ -3976,7 +3977,7 @@ test.describe("graph view E2E", () => {
       await expect(trail.getByRole("link", { name: title })).toBeVisible();
     }
     await expect(trail.getByRole("link", { name: "E2E Project" })).toBeVisible();
-    await expect(trail).toContainText(TITLES[3]);
+    await expect(trail).toContainText(at(TITLES, 3));
 
     // NARROW: now it must fold, earliest first, and what folds stays reachable.
     await page.setViewportSize({ width: 720, height: 900 });
@@ -3984,7 +3985,7 @@ test.describe("graph view E2E", () => {
     // The immediate parent and the focused crumb survive — the parent is the
     // one the eye uses, and the focused crumb is where you are.
     await expect(trail.getByRole("link", { name: TITLES[2] })).toBeVisible();
-    await expect(trail).toContainText(TITLES[3]);
+    await expect(trail).toContainText(at(TITLES, 3));
     await expect(trail.getByRole("link", { name: TITLES[0] })).toHaveCount(0);
 
     // Reachable: open the menu and navigate to a folded level.
@@ -5810,7 +5811,10 @@ test.describe("graph view E2E", () => {
         (els, range) =>
           els.filter((el) => {
             const match = /translateX\(([\d.]+)px\)/.exec((el as HTMLElement).style.transform);
-            return match !== null && +match[1] >= range.fromX && +match[1] <= range.toX;
+            // Read into a local: this callback is serialized into the BROWSER,
+            // where the test file's imports do not exist.
+            const x = match?.[1];
+            return x !== undefined && +x >= range.fromX && +x <= range.toX;
           }).length,
         { fromX, toX },
       );


### PR DESCRIPTION
#283 step 5, **part 1 of 2**. The app had 366 `noUncheckedIndexedAccess` errors
when I measured it. Every **source** file is now clean; the remaining 136 are
all in test files. The flag itself lands with those in the follow-up, because
it cannot be enabled while anything still fails.

Worth landing on its own: nothing here depends on the flag. Each change is a
bounds check, a better failure, or an idiom that stops indexing — the same
discipline as the pure packages and `packages/ui`, and **no `arr[i]!`
anywhere**.

## The interesting ones

**Two more hot-path interpolations** — the strip playhead and the grid playhead
— read parallel arrays through one documented accessor apiece rather than a
check per access. They **throw** instead of defaulting to `0`, because a `0`
there maps the playhead to the origin, which reads as a seek the user did not
make.

**A third copy of the first/middle/last preview pick**, in
`derive-collection-summaries`. Same fix as the two in the pure packages: pick
indices, read them back through a check. This one is persisted too, so a hole
would write a summary entry with `undefined` fields.

**`verifyAccessToken`** split a JWT into three parts, checked `length === 3`,
then handed the pieces to the HMAC as possibly-undefined. It now refuses a
malformed token explicitly instead of hashing `"undefined"`.

**The batch write loop** paired `writes[index]` with `snapshots[index]` and
`refs[index]` by index in three places. It iterates `writes.entries()` now and
skips rather than staging a write against a *mismatched* document reference —
the one failure worse than not writing at all.

## Two regressions I introduced and caught

Both from patching mechanically, and both worth naming:

- An early-return guard landed **above a `useEffect`** in two components — a
  rules-of-hooks violation. Lint caught it. Replaced with defaults computed
  before the hooks in one, and a guard moved inside the async body in the
  other.
- A guard was inserted into a Playwright `evaluateAll` callback, which is
  serialized into the **browser**, where the test file's imports do not exist.
  The e2e failed with `_at is not defined`. That callback reads into a local
  now.

## Verification

774 app tests, 169 e2e, lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)