### PR TITLE
Turn noUncheckedIndexedAccess on for the app

### DIFF
--- a/apps/timeline-gstudio001/app/api/timelines/timelines-authorization.test.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/timelines-authorization.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
+import { at } from "../../../lib/test-support/at";
 
 // Two-user authorization tests over the REAL route handlers and the REAL
 // firebase-timeline-store enforcement — only the process boundaries are
@@ -230,7 +231,7 @@ describe("timeline authorization", () => {
     };
     const patchResponse = await patchTimeline(patchRequest(updated), params("project-a1"));
     expect(patchResponse.status).toBe(200);
-    expect((state.docs.get("project-a1")?.document as TimelineDocument).clips[0].id).toBe("new");
+    expect(at((state.docs.get("project-a1")?.document as TimelineDocument).clips, 0).id).toBe("new");
     expect(state.docs.get("project-a1")?.ownerUid).toBe("user-a");
   });
 

--- a/apps/timeline-gstudio001/app/api/timelines/timelines-batch.test.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/timelines-batch.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
+import { at } from "../../../lib/test-support/at";
 
 // Batch-write tests over the REAL route handler and the REAL
 // firebase-timeline-store transaction — only the process boundaries are
@@ -233,8 +234,8 @@ describe("timeline batch writes", () => {
       { id: "doc-2", revision: 1 },
     ]);
 
-    expect((state.docs.get("doc-1")?.document as TimelineDocument).clips[0].id).toBe("new-1");
-    expect((state.docs.get("doc-2")?.document as TimelineDocument).clips[0].id).toBe("new-2");
+    expect(at((state.docs.get("doc-1")?.document as TimelineDocument).clips, 0).id).toBe("new-1");
+    expect(at((state.docs.get("doc-2")?.document as TimelineDocument).clips, 0).id).toBe("new-2");
     expect(state.docs.get("doc-1")?.revision).toBe(4);
     expect(state.docs.get("doc-1")?.ownerUid).toBe("user-a");
     expect(state.docs.get("doc-1")?.isProject).toBe(true); // preserved, not reset
@@ -447,7 +448,7 @@ describe("timeline batch writes", () => {
     );
 
     expect(response.status).toBe(200);
-    expect((state.docs.get("parent-2")?.clips as TimelineClip[])[0].id).toBe("child-1");
+    expect(at((state.docs.get("parent-2")?.clips as TimelineClip[]), 0).id).toBe("child-1");
   });
 
   it("ALLOWS a delete: the trash is the document taking it up", async () => {

--- a/apps/timeline-gstudio001/app/api/timelines/timelines-preview-manifest.test.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/timelines-preview-manifest.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { PlaybackManifest } from "@storyboard/timeline-domain";
 import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
+import { at } from "../../../lib/test-support/at";
 
 // Preview-manifest tests over the REAL route handler, closure loader, and
 // store against the in-memory fake Firestore: the nested closure flattens
@@ -166,8 +167,8 @@ describe("preview manifest route", () => {
     // applies, which is the point: both read models report one timeline.
     expect(body.manifest.durationSeconds).toBeCloseTo(8.12, 6);
     expect(body.manifest.leaves.map((leaf) => leaf.id)).toEqual(["intro", "a", "b"]);
-    expect(body.manifest.leaves[1].collectionPath).toEqual(["root-1", "scene"]);
-    expect(body.manifest.leaves[1].timelineStart).toBeCloseTo(4.12, 6);
+    expect(at(body.manifest.leaves, 1).collectionPath).toEqual(["root-1", "scene"]);
+    expect(at(body.manifest.leaves, 1).timelineStart).toBeCloseTo(4.12, 6);
   });
 
   it("reads the root exactly once", async () => {
@@ -241,7 +242,7 @@ describe("preview manifest route", () => {
 
     const served = await serveTimelineDocument("root-1", "user-a");
     const servedClips = served?.document.clips ?? [];
-    const last = servedClips[servedClips.length - 1];
+    const last = at(servedClips, servedClips.length - 1);
     const servedDuration = last.startTime + last.duration;
 
     const response = await getPreviewManifest(new Request("http://test.local"), params("root-1"));

--- a/apps/timeline-gstudio001/app/api/trash/trash-empty.test.ts
+++ b/apps/timeline-gstudio001/app/api/trash/trash-empty.test.ts
@@ -387,6 +387,7 @@ describe("DELETE /api/trash", () => {
       ownerUid: "user-a",
     });
     // 30 days out, not now.
+    if (tombstone === undefined) throw new Error("no tombstone was written");
     const grace = (tombstone.deleteAfterMs as number) - (tombstone.markedAtMs as number);
     expect(grace).toBe(30 * 24 * 60 * 60 * 1000);
   });

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -693,7 +693,10 @@ export const TrimOverviewSamplesDistinctFrames: Story = {
     });
     expect(new Set(offsets).size).toBe(offsets.length);
     for (let i = 1; i < offsets.length; i += 1) {
-      expect(offsets[i]).toBeGreaterThan(offsets[i - 1]);
+      const current = offsets[i];
+      const previous = offsets[i - 1];
+      if (current === undefined || previous === undefined) throw new Error(`missing offset ${i}`);
+      expect(current).toBeGreaterThan(previous);
     }
 
     // The last slot is pinned to the source's end (10s − 0.05 back-off) —

--- a/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.test.ts
@@ -26,6 +26,7 @@ import {
   type PreviewCardSpans,
   type RulerTick,
 } from "./graph-playhead-model";
+import { at } from "../../lib/test-support/at";
 
 const media = (id: string, durationSeconds: number): GraphNodeSpec => ({
   kind: "media",
@@ -187,7 +188,7 @@ describe("disabled cards", () => {
 
     expect(isDisabledByAncestor(graph, "inner")).toBe(true);
     expect(isDisabledByAncestor(graph, "deep")).toBe(true);
-    expect(childSpans(graph, {}, "inner", null, flatWidth)[0].disabled).toBe(true);
+    expect(at(childSpans(graph, {}, "inner", null, flatWidth), 0).disabled).toBe(true);
   });
 
   it("does not report a node's OWN flag as inherited", () => {

--- a/apps/timeline-gstudio001/lib/derive-collection-summaries.test.ts
+++ b/apps/timeline-gstudio001/lib/derive-collection-summaries.test.ts
@@ -11,6 +11,7 @@ import {
   deriveClosureSummaries,
   deriveCollectionSummaries,
 } from "./derive-collection-summaries";
+import { at } from "../lib/test-support/at";
 
 function mediaClip(
   id: string,
@@ -58,6 +59,18 @@ function collectionClip(
 
 function docOf(id: string, clips: TimelineClip[], title = `Timeline ${id}`): TimelineDocument {
   return { id, title, clips };
+}
+
+
+/** A closure document by key, asserted. These fixtures always contain the key
+ *  under test; naming the missing one beats reading `.clips` of undefined.
+ *  NOT `docOf` — that name is already the fixture BUILDER above. */
+function closureDoc(closure: Record<string, TimelineDocument>, key: string): TimelineDocument {
+  const document = closure[key];
+  if (document === undefined) {
+    throw new Error(`no "${key}" in the closure (${Object.keys(closure).join(", ")})`);
+  }
+  return document;
 }
 
 describe("deriveCollectionSummaries", () => {
@@ -164,10 +177,10 @@ describe("deriveCollectionSummaries", () => {
 
     const { document, changed } = deriveCollectionSummaries(parent, new Map([["child-1", child]]));
     expect(changed).toBe(true);
-    expect(document.clips[0].duration).toBe(11);
-    expect(document.clips[0].startTime).toBe(0);
+    expect(at(document.clips, 0).duration).toBe(11);
+    expect(at(document.clips, 0).startTime).toBe(0);
     // duration + CLIP_GAP_SECONDS
-    expect(document.clips[1].startTime).toBeCloseTo(11.12, 10);
+    expect(at(document.clips, 1).startTime).toBeCloseTo(11.12, 10);
     expect(document.clips.map((entry) => entry.index)).toEqual([0, 1]);
   });
 });
@@ -188,8 +201,8 @@ describe("deriveClosureSummaries", () => {
 
     const closure = deriveClosureSummaries(closureOf(root, child, grandchild));
 
-    expect(closure.child.clips[0].duration).toBe(10);
-    expect(closure.root.clips[0].duration).toBe(10);
+    expect(at(closureDoc(closure, "child").clips, 0).duration).toBe(10);
+    expect(at(closureDoc(closure, "root").clips, 0).duration).toBe(10);
   });
 
   it("bubbles a nested media preview through collection-only ancestors", () => {
@@ -206,8 +219,8 @@ describe("deriveClosureSummaries", () => {
     const root = docOf("root", [collectionClip("middle-ref", "middle")]);
 
     const closure = deriveClosureSummaries(closureOf(root, middle, leaf));
-    const middlePreview = (closure.middle.clips[0] as CollectionTimelineClip).previewItems;
-    const rootPreview = (closure.root.clips[0] as CollectionTimelineClip).previewItems;
+    const middlePreview = (at(closureDoc(closure, "middle").clips, 0) as CollectionTimelineClip).previewItems;
+    const rootPreview = (at(closureDoc(closure, "root").clips, 0) as CollectionTimelineClip).previewItems;
 
     expect(middlePreview).toEqual([
       {
@@ -233,7 +246,7 @@ describe("deriveClosureSummaries", () => {
 
     const closure = deriveClosureSummaries(closureOf(root, ghost), new Set(["ghost"]));
 
-    const summary = closure.root.clips[0] as CollectionTimelineClip;
+    const summary = at(closureDoc(closure, "root").clips, 0) as CollectionTimelineClip;
     expect(summary.duration).toBe(18);
     expect(summary.itemCount).toBe(6);
     expect(closure.root).toBe(root);
@@ -319,7 +332,7 @@ describe("disabled clips split geometry from the readouts", () => {
 
     const derived = deriveClosureSummaries(documents);
 
-    const leafSummary = derived.mid.clips[0] as CollectionTimelineClip;
+    const leafSummary = at(closureDoc(derived, "mid").clips, 0) as CollectionTimelineClip;
     expect(leafSummary.itemCount).toBe(1);
     expect(leafSummary.duration).toBeCloseTo(8.12, 6);
     expect(leafSummary.playableDuration).toBeCloseTo(4, 6);
@@ -329,7 +342,7 @@ describe("disabled clips split geometry from the readouts", () => {
     // that pins the propagation THROUGH a collection child: mid's playable
     // time has to read leaf-ref's playableDuration (4), not its layout
     // duration (8.12), or a deep disable would stop one level up.
-    const midSummary = derived.root.clips[0] as CollectionTimelineClip;
+    const midSummary = at(closureDoc(derived, "root").clips, 0) as CollectionTimelineClip;
     expect(midSummary.itemCount).toBe(1);
     expect(midSummary.playableDuration).toBeCloseTo(4, 6);
     expect(midSummary.duration).toBeCloseTo(8.12, 6);
@@ -395,6 +408,6 @@ describe("disabled clips split geometry from the readouts", () => {
     const { document } = deriveCollectionSummaries(parent, new Map([["child-1", child]]));
 
     expect(document.clips.map((clip) => clip.id)).toEqual(["off", "col"]);
-    expect(document.clips[0].disabled).toBe(true);
+    expect(at(document.clips, 0).disabled).toBe(true);
   });
 });

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
@@ -87,6 +87,35 @@ function installFetch(handler: (call: FetchCall) => Promise<MockResponse> | Mock
 }
 
 const batchesOf = (calls: FetchCall[]) => calls.filter((call) => call.method === "POST");
+
+/**
+ * The Nth write of the Nth batch, asserted.
+ *
+ * `writeOf(calls, 0, 0)` is what these assertions used to say, and
+ * when the batch never happened it failed as "cannot read writes of
+ * undefined" — which does not distinguish "no batch was sent" from "the batch
+ * was empty". Those are different bugs, so this names which.
+ */
+const writeOf = (calls: FetchCall[], batchIndex = 0, writeIndex = 0): BatchWrite => {
+  const batch = batchesOf(calls)[batchIndex];
+  if (batch === undefined) {
+    throw new Error(`expected batch ${batchIndex}, but only ${batchesOf(calls).length} were sent`);
+  }
+  const write = batch.writes?.[writeIndex];
+  if (write === undefined) {
+    throw new Error(`batch ${batchIndex} carried no write ${writeIndex}`);
+  }
+  return write;
+};
+
+/** A batch's Nth write, asserted. `writeAt(batch, 0)` reads as optional but
+ *  never is in these tests — every batch under assertion carried writes. */
+const writeAt = (batch: FetchCall, index = 0): BatchWrite => {
+  const write = batch.writes?.[index];
+  if (write === undefined) throw new Error(`batch carried no write ${index}`);
+  return write;
+};
+
 const getsOf = (calls: FetchCall[], id?: string) =>
   calls.filter((call) => call.method === "GET" && (id === undefined || call.id === id));
 const clipIds = (document: TimelineDocument | null | undefined) =>
@@ -151,7 +180,7 @@ describe("graph-documents-gateway", () => {
     gateway.writeClips("a", []);
     await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
 
-    expect(batchesOf(calls)[0].writes?.[0]).toMatchObject({
+    expect(writeOf(calls, 0, 0)).toMatchObject({
       allowEmptying: true,
       expectedRevision: 4,
     });
@@ -167,7 +196,7 @@ describe("graph-documents-gateway", () => {
     await gateway.renameTimeline("a", "Renamed");
     await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
 
-    const write = batchesOf(calls)[0].writes?.[0];
+    const write = writeOf(calls, 0, 0);
     expect(write?.document.title).toBe("Renamed");
     expect(write).not.toHaveProperty("allowEmptying");
   });
@@ -183,7 +212,7 @@ describe("graph-documents-gateway", () => {
     gateway.writeClips("a", [clip("a1")]);
     await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
 
-    expect(batchesOf(calls)[0].writes?.[0]).not.toHaveProperty("allowEmptying");
+    expect(writeOf(calls, 0, 0)).not.toHaveProperty("allowEmptying");
   });
 
   it("does not carry the exemption into a LATER unrelated write", async () => {
@@ -195,11 +224,11 @@ describe("graph-documents-gateway", () => {
 
     gateway.writeClips("a", []);
     await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
-    expect(batchesOf(calls)[0].writes?.[0]).toMatchObject({ allowEmptying: true });
+    expect(writeOf(calls, 0, 0)).toMatchObject({ allowEmptying: true });
 
     await gateway.renameTimeline("a", "After");
     await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
-    expect(batchesOf(calls)[1].writes?.[0]).not.toHaveProperty("allowEmptying");
+    expect(writeOf(calls, 1, 0)).not.toHaveProperty("allowEmptying");
   });
 
   it("writeClips is a no-op for documents the session has not loaded", async () => {
@@ -246,9 +275,9 @@ describe("graph-documents-gateway", () => {
     // expects 4, not 3.
     gateway.writeClips("a", [clip("a3")]);
     await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
-    const second = batchesOf(calls)[1];
+    const second = at(batchesOf(calls), 1);
     expect(second.writes).toHaveLength(1);
-    expect(second.writes?.[0].expectedRevision).toBe(4);
+    expect(writeAt(second, 0).expectedRevision).toBe(4);
   });
 
   it("serializes batches: writes during a flight queue one trailing batch with the latest cache", async () => {
@@ -277,8 +306,8 @@ describe("graph-documents-gateway", () => {
     await vi.advanceTimersByTimeAsync(0);
     const batches = batchesOf(calls);
     expect(batches).toHaveLength(2);
-    expect(clipIds(at(batches, 1).writes?.[0].document)).toEqual(["a4"]);
-    expect(at(batches, 1).writes?.[0].expectedRevision).toBe(2);
+    expect(clipIds(writeAt(at(batches, 1), 0).document)).toEqual(["a4"]);
+    expect(writeAt(at(batches, 1), 0).expectedRevision).toBe(2);
   });
 
   // The refresh/save race. Awaiting only the batch that happened to be in
@@ -348,7 +377,7 @@ describe("graph-documents-gateway", () => {
     const batches = batchesOf(calls);
     expect(batches).toHaveLength(1);
     expect(at(batches, 0).keepalive).toBe(true);
-    expect(clipIds(at(batches, 0).writes?.[0].document)).toEqual(["a2"]);
+    expect(clipIds(writeAt(at(batches, 0), 0).document)).toEqual(["a2"]);
 
     // The debounce timer was consumed — no duplicate batch later.
     await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
@@ -385,8 +414,8 @@ describe("graph-documents-gateway", () => {
     expect(at(batches, 1).keepalive).toBe(true);
     // Carries the LATEST cache, and still expects the revision the abandoned
     // batch expected — no response landed, so the ledger never advanced.
-    expect(clipIds(at(batches, 1).writes?.[0].document)).toEqual(["a3"]);
-    expect(at(batches, 1).writes?.[0].expectedRevision).toBe(1);
+    expect(clipIds(writeAt(at(batches, 1), 0).document)).toEqual(["a3"]);
+    expect(writeAt(at(batches, 1), 0).expectedRevision).toBe(1);
     // Abandoning is not a failure: it must not surface as a save error.
     expect(gateway.lastError()).toBeNull();
   });
@@ -412,7 +441,7 @@ describe("graph-documents-gateway", () => {
     const batches = batchesOf(calls);
     expect(batches).toHaveLength(2);
     expect(at(batches, 1).keepalive).toBe(true);
-    expect(clipIds(at(batches, 1).writes?.[0].document)).toEqual(["a2"]);
+    expect(clipIds(writeAt(at(batches, 1), 0).document)).toEqual(["a2"]);
   });
 
   it("a second unload flush leaves an already-keepalive batch alone", async () => {
@@ -433,7 +462,7 @@ describe("graph-documents-gateway", () => {
     // must not abandon and re-send a request that is already unload-safe.
     gateway.flushPendingWrites({ keepalive: true });
     expect(batchesOf(calls)).toHaveLength(1);
-    expect(batchesOf(calls)[0].signal?.aborted).toBe(false);
+    expect(at(batchesOf(calls), 0).signal?.aborted).toBe(false);
   });
 
   it("an over-budget unload batch drops keepalive rather than being refused outright", async () => {
@@ -456,7 +485,7 @@ describe("graph-documents-gateway", () => {
     expect(at(batches, 0).bodyBytes).toBeGreaterThan(64 * 1024);
     expect(at(batches, 0).keepalive).toBeFalsy(); // sent best-effort instead
     // The batch still went out INTACT — atomicity is not traded away.
-    expect(clipIds(at(batches, 0).writes?.[0].document)).toEqual(["a2"]);
+    expect(clipIds(writeAt(at(batches, 0), 0).document)).toEqual(["a2"]);
     // And the risk is surfaced rather than swallowed.
     expect(gateway.lastError()).toMatch(/too large/i);
   });
@@ -510,7 +539,7 @@ describe("graph-documents-gateway", () => {
     expect(getsOf(calls)).toHaveLength(2);
     gateway.writeClips("a", [clip("v3")]);
     await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
-    expect(batchesOf(calls)[0].writes?.[0].expectedRevision).toBe(6);
+    expect(writeOf(calls, 0, 0).expectedRevision).toBe(6);
   });
 
   it("a stale ensure waits for the in-flight batch to settle before refetching", async () => {
@@ -560,7 +589,7 @@ describe("graph-documents-gateway", () => {
     gateway.writeClips("a", [clip("a2")]);
     await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
     expect(batchesOf(calls)).toHaveLength(1);
-    expect(batchesOf(calls)[0].writes?.[0].expectedRevision).toBe(1);
+    expect(writeOf(calls, 0, 0).expectedRevision).toBe(1);
 
     // Now the poller refreshes it and declines to apply — the state that used
     // to be invisible. Without this marker the write below goes out with a
@@ -761,7 +790,7 @@ describe("graph-documents-gateway", () => {
     gateway.writeClips("a", [clip("a4")]);
     await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
     expect(batchesOf(calls)).toHaveLength(2);
-    expect(clipIds(batchesOf(calls)[1].writes?.[0].document)).toEqual(["a4"]);
+    expect(clipIds(writeOf(calls, 1, 0).document)).toEqual(["a4"]);
   });
 
   it("reportIssue surfaces app-reported problems in the banner without touching gateway errors", async () => {
@@ -790,9 +819,9 @@ describe("graph-documents-gateway", () => {
 
     gateway.writeClips("fresh", [clip("f1")]);
     await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
-    const batch = batchesOf(calls)[0];
-    expect(batch.writes?.[0].expectedRevision).toBe(0); // CAS create
-    expect(clipIds(batch.writes?.[0].document)).toEqual(["f1"]);
+    const batch = at(batchesOf(calls), 0);
+    expect(writeAt(batch, 0).expectedRevision).toBe(0); // CAS create
+    expect(clipIds(writeAt(batch, 0).document)).toEqual(["f1"]);
 
     // Seeding never clobbers an existing cache entry.
     gateway.seed({ ...doc("fresh"), title: "Other" });
@@ -813,7 +842,7 @@ describe("graph-documents-gateway", () => {
 
     gateway.writeClips("a", [clip("a2")]);
     await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
-    expect(batchesOf(calls)[0].writes?.[0].expectedRevision).toBe(7);
+    expect(writeOf(calls, 0, 0).expectedRevision).toBe(7);
   });
 
   it("holds primes that arrive before bind and replays them for the bound user only", () => {

--- a/apps/timeline-gstudio001/lib/graph-node-clone.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-node-clone.test.ts
@@ -5,6 +5,7 @@ import { parseNodeId, type CollectionItemNode } from "@storyboard/ui/dnd-collect
 import type { ClipDetail } from "@storyboard/timeline-domain";
 
 import { cloneNodeForInsert, type CloneDeps } from "./graph-node-clone";
+import { at } from "./test-support/at";
 
 /** A deterministic minter so ids are predictable and collision-free in tests. */
 function counterMint(): CloneDeps["mintId"] {
@@ -134,7 +135,7 @@ describe("cloneNodeForInsert: collection deep clone", () => {
     // Media content is preserved through the clone.
     const rootImage = root.clips.find((clip) => clip.kind === "image");
     expect(rootImage && rootImage.kind === "image" ? rootImage.src : null).toBe("a.png");
-    const subImage = sub.clips[0];
+    const subImage = at(sub.clips, 0);
     expect(subImage.kind === "image" ? subImage.src : null).toBe("b.png");
 
     // NOTHING from the source survives as an id anywhere in the clone.
@@ -191,8 +192,8 @@ describe("cloneNodeForInsert: collection deep clone", () => {
     expect(result.newDocuments).toHaveLength(2);
     const cloneA = result.newDocuments.find((doc) => doc.id === result.node.id)!;
     const cloneB = result.newDocuments.find((doc) => doc.id !== result.node.id)!;
-    const aRef = cloneA.clips[0];
-    const bRef = cloneB.clips[0];
+    const aRef = at(cloneA.clips, 0);
+    const bRef = at(cloneB.clips, 0);
     if (aRef.kind !== "collection" || bRef.kind !== "collection") throw new Error("fixture");
     // A' → B' and B' → A' — the clone is a closed, independent cycle. A back
     // reference to the SOURCE "A" would wire the copy to the original.

--- a/apps/timeline-gstudio001/lib/graph-rsc-payloads.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-rsc-payloads.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
+import { at } from "../lib/test-support/at";
 
 // RSC payload-loader tests over the REAL serve path (heal + read-time
 // summary derivation) against the in-memory fake Firestore: bootstrap
@@ -147,8 +148,8 @@ describe("loadGraphBootstrapPayloads", () => {
   it("serves an unstored trash as an empty revision-0 document", async () => {
     seed("project-1", "user-a", [image("a", 0, 4)]);
     const payloads = await loadGraphBootstrapPayloads("project-1", "user-a");
-    expect(payloads![1].document.clips).toEqual([]);
-    expect(payloads![1].revision).toBe(0);
+    expect(at(payloads ?? [], 1).document.clips).toEqual([]);
+    expect(at(payloads ?? [], 1).revision).toBe(0);
   });
 
   it("returns null for a missing or foreign project — the client boot handles it", async () => {

--- a/apps/timeline-gstudio001/lib/heal-timeline-document.test.ts
+++ b/apps/timeline-gstudio001/lib/heal-timeline-document.test.ts
@@ -5,6 +5,7 @@ import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/
 
 import type { CloudinaryAsset } from "./cloudinary-media-store";
 import { healTimelineDocument } from "./heal-timeline-document";
+import { at } from "../lib/test-support/at";
 
 const CLOUD = "https://res.cloudinary.com/demo/video/upload/v1";
 
@@ -84,7 +85,8 @@ describe("healTimelineDocument", () => {
     ]);
 
     expect(changed).toBe(true);
-    const [a, b] = document.clips;
+    const a = at(document.clips, 0);
+    const b = at(document.clips, 1);
     expect(a.duration).toBe(12.4);
     expect(a.sourceDuration).toBe(12.4);
     // Downstream clip repacked behind the longer first clip.
@@ -101,7 +103,7 @@ describe("healTimelineDocument", () => {
 
     expect(changed).toBe(false);
     expect(document).toBe(input); // same reference — caller skips the write
-    expect(document.clips[0].sourceDuration).toBe(8);
+    expect(at(document.clips, 0).sourceDuration).toBe(8);
   });
 
   it("leaves an already-correct untrimmed video alone (within epsilon)", () => {
@@ -120,10 +122,10 @@ describe("healTimelineDocument", () => {
     ]);
 
     expect(changed).toBe(true);
-    expect(srcOf(document.clips[0])).toBe(moved);
-    expect(posterOf(document.clips[0])).toBe(`${CLOUD}/v-a.jpg`);
+    expect(srcOf(at(document.clips, 0))).toBe(moved);
+    expect(posterOf(at(document.clips, 0))).toBe(`${CLOUD}/v-a.jpg`);
     // No duration moved → startTimes preserved, not repacked.
-    expect(document.clips[1].startTime).toBe(5.12);
+    expect(at(document.clips, 1).startTime).toBe(5.12);
   });
 
   it("does both heals at once and repacks from the duration change", () => {
@@ -133,9 +135,9 @@ describe("healTimelineDocument", () => {
     const { document, changed } = healTimelineDocument(input, [videoAsset("v-a", 3, moved)]);
 
     expect(changed).toBe(true);
-    expect(srcOf(document.clips[0])).toBe(moved);
-    expect(document.clips[0].duration).toBe(3);
-    expect(document.clips[1].startTime).toBeCloseTo(3 + CLIP_GAP_SECONDS, 5);
+    expect(srcOf(at(document.clips, 0))).toBe(moved);
+    expect(at(document.clips, 0).duration).toBe(3);
+    expect(at(document.clips, 1).startTime).toBeCloseTo(3 + CLIP_GAP_SECONDS, 5);
   });
 
   it("is a no-op with no assets", () => {
@@ -196,7 +198,7 @@ describe("asset resolution", () => {
     ]);
 
     expect(changed).toBe(true);
-    expect(srcOf(document.clips[0])).toBe(`${CLOUD}/a/alley.mp4`);
+    expect(srcOf(at(document.clips, 0))).toBe(`${CLOUD}/a/alley.mp4`);
   });
 
   it("resolves by sourceAsset provenance even when the leaf is ambiguous", () => {
@@ -210,8 +212,8 @@ describe("asset resolution", () => {
     ]);
 
     expect(changed).toBe(true);
-    expect(srcOf(document.clips[0])).toBe(`${CLOUD}/b/alley.mp4`);
-    expect(document.clips[0].duration).toBe(30);
+    expect(srcOf(at(document.clips, 0))).toBe(`${CLOUD}/b/alley.mp4`);
+    expect(at(document.clips, 0).duration).toBe(30);
   });
 
   it("does not fall back to a same-named asset when provenance names a missing one", () => {

--- a/apps/timeline-gstudio001/lib/mcp/apply-command.test.ts
+++ b/apps/timeline-gstudio001/lib/mcp/apply-command.test.ts
@@ -73,6 +73,7 @@ vi.mock("firebase-admin/firestore", () => {
 import { parseNodeId } from "@storyboard/ui/dnd-collections";
 
 import { applyCollectionsCommand } from "./apply-command";
+import { at } from "../../lib/test-support/at";
 
 const OWNER = "user-a";
 
@@ -164,7 +165,7 @@ describe("applyCollectionsCommand", () => {
 
     expect(result.ok).toBe(true);
     const stored = state.docs.get("root") as { clips: TimelineClip[] };
-    expect(stored.clips[0].title).toBe("Opening shot");
+    expect(at(stored.clips, 0).title).toBe("Opening shot");
   });
 
 
@@ -282,11 +283,15 @@ describe("applyCollectionsCommand — details-only writes", () => {
 
     const result = await applyCollectionsCommand(
       "root",
-      (_graph, details) => ({
-        ok: true,
-        details: { a: { ...details.a, tags: ["keeper", "S02"] } },
-        affectedCollectionIds: ["root"],
-      }),
+      (_graph, details) => {
+        const detail = details.a;
+        if (detail === undefined) throw new Error('the fixture has no detail for "a"');
+        return {
+          ok: true,
+          details: { a: { ...detail, tags: ["keeper", "S02"] } },
+          affectedCollectionIds: ["root"],
+        };
+      },
       OWNER,
     );
 
@@ -312,15 +317,19 @@ describe("applyCollectionsCommand — details-only writes", () => {
 
     await applyCollectionsCommand(
       "root",
-      (_graph, details) => ({
-        ok: true,
-        details: { a: { ...details.a, tags: ["keeper"] } },
-        affectedCollectionIds: ["root"],
-      }),
+      (_graph, details) => {
+        const detail = details.a;
+        if (detail === undefined) throw new Error('the fixture has no detail for "a"');
+        return {
+          ok: true,
+          details: { a: { ...detail, tags: ["keeper"] } },
+          affectedCollectionIds: ["root"],
+        };
+      },
       OWNER,
     );
 
-    const stored = (state.docs.get("root") as { clips: TimelineClip[] }).clips[0];
+    const stored = at((state.docs.get("root") as { clips: TimelineClip[] }).clips, 0);
     if (stored.kind === "collection") throw new Error("expected a media clip");
     expect(stored.sourceAsset).toEqual({ providerId: "cloudinary", assetId: "x/y" });
     expect(stored.tags).toEqual(["keeper"]);
@@ -331,11 +340,15 @@ describe("applyCollectionsCommand — details-only writes", () => {
 
     await applyCollectionsCommand(
       "root",
-      (_graph, details) => ({
-        ok: true,
-        details: { a: { ...details.a, tags: ["keeper"] } },
-        affectedCollectionIds: ["root"],
-      }),
+      (_graph, details) => {
+        const detail = details.a;
+        if (detail === undefined) throw new Error('the fixture has no detail for "a"');
+        return {
+          ok: true,
+          details: { a: { ...detail, tags: ["keeper"] } },
+          affectedCollectionIds: ["root"],
+        };
+      },
       OWNER,
     );
 

--- a/apps/timeline-gstudio001/lib/mcp/create-collection.test.ts
+++ b/apps/timeline-gstudio001/lib/mcp/create-collection.test.ts
@@ -73,6 +73,7 @@ vi.mock("firebase-admin/firestore", () => {
 import { parseNodeId } from "@storyboard/ui/dnd-collections";
 
 import { createCollection } from "./create-collection";
+import { at } from "../test-support/at";
 
 const OWNER = "user-a";
 
@@ -123,7 +124,7 @@ describe("createCollection", () => {
     seed("root", []);
     await createCollection({ timelineId: "root", name: "demo one" }, OWNER);
     const parent = state.docs.get("root") as { clips: TimelineClip[] };
-    const added = parent.clips[0];
+    const added = at(parent.clips, 0);
     if (added.kind !== "collection") throw new Error("expected a collection clip");
     expect(added.itemCount).toBe(0);
   });

--- a/apps/timeline-gstudio001/lib/mcp/read-timeline.test.ts
+++ b/apps/timeline-gstudio001/lib/mcp/read-timeline.test.ts
@@ -52,6 +52,7 @@ vi.mock("firebase-admin/firestore", () => {
 });
 
 import { handleReadTimeline } from "./read-timeline";
+import { at } from "../../lib/test-support/at";
 
 const OWNER = "user-a";
 
@@ -113,7 +114,7 @@ function servedCollection(
   result: Awaited<ReturnType<typeof handleReadTimeline>>,
   index = 0,
 ): CollectionTimelineClip {
-  const clip = payloadOf(result).clips[index];
+  const clip = at(payloadOf(result).clips, index);
   if (clip.kind !== "collection") throw new Error(`clip ${index} is ${clip.kind}, not a collection`);
   return clip;
 }
@@ -171,8 +172,8 @@ describe("handleReadTimeline", () => {
 
     const result = await handleReadTimeline({ timelineId: "root" }, { requesterUid: OWNER });
 
-    expect(result.content[0].text).toContain("2 clips");
-    expect(result.content[0].text).toContain("run-1 (collection)");
+    expect(at(result.content, 0).text).toContain("2 clips");
+    expect(at(result.content, 0).text).toContain("run-1 (collection)");
   });
 
   it("reports a missing document without throwing", async () => {

--- a/apps/timeline-gstudio001/lib/mcp/upload.test.ts
+++ b/apps/timeline-gstudio001/lib/mcp/upload.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
+import { at } from "../../lib/test-support/at";
 
 // attach_media, over the real graph adapter and the real store transaction.
 // Cloudinary is faked at its module boundary (nothing here should reach the
@@ -156,6 +157,9 @@ describe("attachMedia", () => {
 
     expect(result.isError).toBeFalsy();
     const added = storedClips(PROJECT).find((c) => c.id === attachedNodeId(result));
+    // The attach reported this id, so the clip must be there; saying so names
+    // the failure instead of every later assertion reading undefined.
+    if (added === undefined) throw new Error("the attached clip is not in the document");
     expect(added).toBeDefined();
     // TimelineClip is a union; provenance only exists on media clips.
     if (!added || added.kind === "collection") throw new Error("expected a media clip");
@@ -183,7 +187,7 @@ describe("attachMedia", () => {
       OWNER,
     );
 
-    const added = storedClips(PROJECT)[0];
+    const added = at(storedClips(PROJECT), 0);
     // Cleaned on the way in: trimmed, de-duplicated case-insensitively with
     // the first spelling kept, blanks dropped.
     expect(added.tags).toEqual(["SCAIL-2", "S02", "keeper"]);
@@ -197,7 +201,7 @@ describe("attachMedia", () => {
       OWNER,
     );
 
-    expect("tags" in storedClips(PROJECT)[0]).toBe(false);
+    expect("tags" in at(storedClips(PROJECT), 0)).toBe(false);
   });
 
   it("carries the real source duration and url from the upload", async () => {
@@ -208,7 +212,7 @@ describe("attachMedia", () => {
       OWNER,
     );
 
-    const added = storedClips(PROJECT)[0];
+    const added = at(storedClips(PROJECT), 0);
     if (added.kind === "collection") throw new Error("expected a media clip");
     expect(added.kind).toBe("video");
     expect(added.src).toBe("https://res.cloudinary.com/demo/video/upload/render-123.mp4");
@@ -229,7 +233,7 @@ describe("attachMedia", () => {
       OWNER,
     );
 
-    const added = storedClips(PROJECT)[0];
+    const added = at(storedClips(PROJECT), 0);
     if (added.kind !== "video") throw new Error("expected a video clip");
     expect(added.trimIn).toBe(0);
     expect(added.trimOut).toBe(0);
@@ -249,7 +253,7 @@ describe("attachMedia", () => {
       OWNER,
     );
 
-    const added = storedClips(PROJECT)[0];
+    const added = at(storedClips(PROJECT), 0);
     if (added.kind !== "video") throw new Error("expected a video clip");
     expect(added.duration).toBe(5);
     expect(added.trimIn).toBe(0);
@@ -334,7 +338,7 @@ describe("attachMedia", () => {
     );
 
     expect(result.isError).toBeFalsy();
-    const added = storedClips(PROJECT)[0];
+    const added = at(storedClips(PROJECT), 0);
     expect(added.kind).toBe("audio");
     if (added.kind !== "audio") throw new Error("expected an audio clip");
     // Windowed like video: the full source length with no trim taken.
@@ -370,7 +374,7 @@ describe("attachMedia", () => {
     );
 
     expect(result.isError).toBeFalsy();
-    const added = storedClips(PROJECT)[0];
+    const added = at(storedClips(PROJECT), 0);
     expect(added.title).toBe('Brian VO — "You worry about the door"');
     expect(added.alt).toBe('Brian VO — "You worry about the door"');
   });
@@ -386,7 +390,7 @@ describe("attachMedia", () => {
       OWNER,
     );
 
-    expect(storedClips(PROJECT)[0].title).toBeUndefined();
+    expect(at(storedClips(PROJECT), 0).title).toBeUndefined();
   });
 
   it("refuses when the upload never landed, instead of minting a dead clip", async () => {

--- a/apps/timeline-gstudio001/lib/oauth/authorize-request.test.ts
+++ b/apps/timeline-gstudio001/lib/oauth/authorize-request.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { successRedirectUrl, validateAuthorizeRequest } from "./authorize-request";
 import type { OAuthClient } from "./core";
+import { at } from "../../lib/test-support/at";
 
 const CLIENT: OAuthClient = {
   clientId: "client-abc",
@@ -12,7 +13,7 @@ const CLIENT: OAuthClient = {
 function query(overrides: Record<string, string | null> = {}) {
   const base: Record<string, string> = {
     client_id: CLIENT.clientId,
-    redirect_uri: CLIENT.redirectUris[0],
+    redirect_uri: at(CLIENT.redirectUris, 0),
     response_type: "code",
     code_challenge: "a".repeat(43),
     code_challenge_method: "S256",

--- a/apps/timeline-gstudio001/lib/tag-write-plan.test.ts
+++ b/apps/timeline-gstudio001/lib/tag-write-plan.test.ts
@@ -103,7 +103,9 @@ describe("planTagWrite", () => {
   it("refuses a node with no detail entry rather than writing a bare one", () => {
     // Writing `{tags}` alone would rebuild the clip without its alt, poster or
     // sourceAsset — the erasure this refusal exists to prevent.
-    const thin: DetailsById = { root: details.root };
+    const rootDetail = details.root;
+    if (rootDetail === undefined) throw new Error("the fixture has no root detail");
+    const thin: DetailsById = { root: rootDetail };
     const result = planTagWrite(graph, thin, parseNodeId("clip-a"), ["x"]);
     expect(isTagWriteRefusal(result)).toBe(true);
     if (!isTagWriteRefusal(result)) throw new Error("expected a refusal");

--- a/apps/timeline-gstudio001/lib/trash-groups.test.ts
+++ b/apps/timeline-gstudio001/lib/trash-groups.test.ts
@@ -74,7 +74,7 @@ describe("groupTrashClips", () => {
       image("second", { src: "https://cdn.test/2.jpg" }),
       image("first-again", { src: "https://cdn.test/1.jpg" }),
     ]);
-    expect(groups.map((g) => g.clips[0].id)).toEqual(["first", "second"]);
+    expect(groups.map((g) => at(g.clips, 0).id)).toEqual(["first", "second"]);
     expect(at(groups, 0).clips).toHaveLength(2);
   });
 
@@ -90,7 +90,7 @@ describe("groupTrashClips", () => {
   });
 
   it("leaves a single clip as a group of one, and an empty bin as nothing", () => {
-    expect(groupTrashClips([image("solo")])[0].clips).toHaveLength(1);
+    expect(at(groupTrashClips([image("solo")]), 0).clips).toHaveLength(1);
     expect(groupTrashClips([])).toEqual([]);
   });
 });

--- a/apps/timeline-gstudio001/lib/webmcp/timeline-tree.test.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/timeline-tree.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { buildGraph, parseNodeId, type CollectionsGraph } from "@storyboard/ui/dnd-collections";
 
 import { buildTimelineTree } from "./timeline-tree";
+import { at } from "../../lib/test-support/at";
 
 /** project ─ img1 (image 3s), vid1 (video full 10, trim 1/2 → 7s), scene-a[ c1, c2 ] */
 function fixture(): CollectionsGraph {
@@ -61,21 +62,21 @@ describe("buildTimelineTree", () => {
 
   it("summarizes a nested collection at depth 1 (no children)", () => {
     const tree = buildTimelineTree(graph, project, "project", 1, allHydrated);
-    const collection = tree.nodes[2];
+    const collection = at(tree.nodes, 2);
     expect(collection).toMatchObject({ id: "scene-a", kind: "collection", hydrated: true, childCount: 2 });
     expect(collection.children).toBeUndefined();
   });
 
   it("expands a hydrated collection at depth 2", () => {
     const tree = buildTimelineTree(graph, project, "project", 2, allHydrated);
-    expect(tree.nodes[2].children?.map((c) => c.id)).toEqual(["c1", "c2"]);
+    expect(at(tree.nodes, 2).children?.map((c) => c.id)).toEqual(["c1", "c2"]);
   });
 
   it("never expands an un-hydrated placeholder, even within depth", () => {
     const isHydrated = (id: string) => id !== "scene-a";
     const tree = buildTimelineTree(graph, project, "project", 2, isHydrated);
     expect(tree.nodes[2]).toMatchObject({ id: "scene-a", hydrated: false });
-    expect(tree.nodes[2].children).toBeUndefined();
+    expect(at(tree.nodes, 2).children).toBeUndefined();
   });
 
   it("reports focused:false when reading a non-focused collection", () => {

--- a/apps/timeline-gstudio001/lib/webmcp/tool-fields.test.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/tool-fields.test.ts
@@ -31,6 +31,14 @@ function props(name: string): Record<string, Record<string, unknown>> {
   return schemaFor(name).properties as Record<string, Record<string, unknown>>;
 }
 
+/** One property of a generated schema, asserted — a missing field should say
+ *  WHICH field, not fail as "cannot read description of undefined". */
+function prop(name: string, field: string): Record<string, unknown> {
+  const value = props(name)[field];
+  if (value === undefined) throw new Error(`${name} has no "${field}" property`);
+  return value;
+}
+
 describe("generated in-page tool schemas", () => {
   it("keeps trim_clip's shape, bounds and closedness", () => {
     const schema = schemaFor("trim_clip");
@@ -51,8 +59,8 @@ describe("generated in-page tool schemas", () => {
     // The regression this refactor exists to prevent. "Video only." passes
     // every structural assertion above and still invites the wrong call.
     const p = props("trim_clip");
-    expect(p.trimInSeconds.description).toMatch(/removed from the START/i);
-    expect(p.trimOutSeconds.description).toMatch(/removed from the END/i);
+    expect(prop("trim_clip", "trimInSeconds").description).toMatch(/removed from the START/i);
+    expect(prop("trim_clip", "trimOutSeconds").description).toMatch(/removed from the END/i);
   });
 
   it("keeps move_clip's placement fields, and its in-page-only `select`", () => {

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -3954,9 +3954,9 @@ test.describe("graph view E2E", () => {
       const child = DEPTH_IDS[index + 1];
       api.documents.set(id, {
         id,
-        title: TITLES[index],
+        title: at(TITLES, index),
         clips: child
-          ? [collectionClip(`clip-${child}`, child, 0, TITLES[index + 1], 1)]
+          ? [collectionClip(`clip-${child}`, child, 0, at(TITLES, index + 1), 1)]
           : [mediaClip("deep-leaf", "image", 0, 4)],
       });
     });
@@ -4053,7 +4053,10 @@ test.describe("graph view E2E", () => {
     // edge: each sample is further right than the last, and the last one is
     // near the card's far side rather than back at its start.
     for (let i = 1; i < samples.length; i++) {
-      expect(samples[i]).toBeGreaterThan(samples[i - 1]);
+      const current = samples[i];
+      const previous = samples[i - 1];
+      if (current === undefined || previous === undefined) throw new Error(`missing sample ${i}`);
+      expect(current).toBeGreaterThan(previous);
     }
     expect(samples[samples.length - 1]).toBeGreaterThan(card.x + card.width * 0.6);
   });
@@ -4101,7 +4104,10 @@ test.describe("graph view E2E", () => {
     await page.mouse.up();
 
     for (let i = 1; i < samples.length; i++) {
-      expect(samples[i]).toBeGreaterThan(samples[i - 1]);
+      const current = samples[i];
+      const previous = samples[i - 1];
+      if (current === undefined || previous === undefined) throw new Error(`missing sample ${i}`);
+      expect(current).toBeGreaterThan(previous);
     }
     expect(samples[samples.length - 1]).toBeGreaterThan(cell.x + cell.width * 0.5);
   });
@@ -5208,11 +5214,16 @@ test.describe("graph view E2E", () => {
       animation.currentTime = 128; // the 1.06 peak
       const peak = snap();
       animation.play();
-      return peak.flatMap((size, i) =>
-        size === rest[i]
+      return peak.flatMap((size, i) => {
+        // Read into locals: this runs in the BROWSER, so the test file's
+        // helpers do not exist here.
+        const before = rest[i];
+        const element = chain[i];
+        if (before === undefined || element === undefined) return [];
+        return size === before
           ? []
-          : [`${chain[i].tagName}.${chain[i].className}: ${rest[i]} -> ${size}`],
-      );
+          : [`${element.tagName}.${element.className}: ${before} -> ${size}`];
+      });
     });
     expect(changed).toEqual([]);
   });

--- a/apps/timeline-gstudio001/tsconfig.json
+++ b/apps/timeline-gstudio001/tsconfig.json
@@ -9,6 +9,12 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
+    // Types `arr[i]` and `record[key]` as `T | undefined`. #283 step 5, the
+    // last one — 366 sites at first measure. No `arr[i]!` anywhere: the two
+    // playhead interpolations read through one documented accessor apiece,
+    // and tests go through `lib/test-support/at`, which names the index and
+    // the actual length when a list is shorter than the test assumed.
+    "noUncheckedIndexedAccess": true,
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",


### PR DESCRIPTION
Closes #283. Step 5, part 2 — the last one. 366 sites at first measure; the
source half landed in #379, this is the 136 in test files plus the flag.

**Every package in the repo now has it.**

## Tests

Same treatment as the packages, for the same reason: `at()` fails with the
index **and** the actual length, where `writes[0]!.document` fails as "cannot
read document of undefined" — in a file whose only job is to say what went
wrong.

Where a shape repeated, the fix is one asserted reader rather than a hundred
call sites:

- **`writeAt(batch, n)`** in the gateway suite, which distinguishes "no batch
  was sent" from "the batch was empty". Those are different bugs, and
  `batchesOf(calls)[0].writes?.[0]` reported neither.
- **`closureDoc(closure, key)`** in the summaries suite — a record read by key
  is `T | undefined` too, and naming the missing key beats reading `.clips` of
  undefined.
- **`prop(name, field)`** in the schema suite, which names the missing field.

Mostly the fix was at the **derivation** — `const last = at(clips, n)` —
rather than at each of the ten places the variable is then read.

## What automating this cost

The honest lesson. Three mechanical passes each introduced a defect:

| pass | defect | caught by |
|---|---|---|
| 1 | ate the `?.` of an optional-chained index → `at(x?., 0)` | tsc (syntax) |
| 2 | re-wrapped an already-wrapped line, corrupting `calls` → `cal` | tsc |
| 3 | rewrote inside a Playwright `evaluate` callback | **e2e, at run time** |

The last is the one worth remembering: a patch that type-checks can still be
wrong about **where the code runs**. That callback is serialized into the
browser, where the test file's imports do not exist. Every pass after it
skipped `evaluate` bodies.

## Verification

0 errors with the flag on. 774 app + 539 unit + 193 story + 169 e2e; lint
clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)