### PR TITLE
Measure the preview manifest's read cost, and guard it

### DIFF
--- a/apps/timeline-gstudio001/app/api/timelines/timelines-preview-manifest.test.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/timelines-preview-manifest.test.ts
@@ -170,6 +170,49 @@ describe("preview manifest route", () => {
     expect(body.manifest.leaves[1].timelineStart).toBeCloseTo(4.12, 6);
   });
 
+
+  // #284 asked whether this route needs a server-side cache, and said to
+  // measure first. It does not, and this is the measurement kept as a guard.
+  //
+  // A 7-document closure costs exactly 7 reads — one per document, no repeats
+  // — because `createTimelineEntryReader` dedupes within a request. And the
+  // client fetches this on focus change and 2500ms after a commit settles
+  // (MANIFEST_REFRESH_DELAY_MS), not on a poll, so requests are per edit
+  // BURST rather than per second.
+  //
+  // What this test protects is the "one read per document" part. An N+1 —
+  // re-reading a child while walking, say — would not fail any existing test;
+  // it would just quietly multiply the cost of every preview, which is the
+  // thing that would eventually make a cache necessary.
+  it("costs one read per document in the closure, and no more", async () => {
+    const sceneIds: string[] = [];
+    for (let index = 0; index < 6; index += 1) {
+      const id = `scene-${index}`;
+      sceneIds.push(id);
+      seed(id, "user-a", [
+        image(`${id}-a`, 0, 2),
+        image(`${id}-b`, 2, 2),
+        image(`${id}-c`, 4, 2),
+        image(`${id}-d`, 6, 2),
+      ]);
+    }
+    seed(
+      "root-1",
+      "user-a",
+      sceneIds.map((id, index) => collectionClip(`${id}-ref`, id, index * 8, 8)),
+    );
+
+    state.reads.clear();
+    await getPreviewManifest(new Request("http://test.local"), params("root-1"));
+
+    const documents = sceneIds.length + 1;
+    const total = [...state.reads.values()].reduce((sum, count) => sum + count, 0);
+    expect(state.reads.size).toBe(documents);
+    expect(total).toBe(documents);
+    // Every document read exactly once — not "mostly once".
+    expect([...state.reads.values()].every((count) => count === 1)).toBe(true);
+  });
+
   it("reads the root exactly once", async () => {
     seed("scene", "user-a", [image("a", 0, 2)]);
     seed("root-1", "user-a", [collectionClip("scene-ref", "scene", 0, 2)]);


### PR DESCRIPTION
Closes #284, **by measuring rather than building** — which is what the issue
asked for: *"the per-request reader may already make this cheap enough that a
cache is not worth the invalidation surface"*.

It is.

## The measurement

| | |
|---|---|
| closure | 7 documents (a project + 6 scenes × 4 clips) |
| reads per request | **7** — one per document, none repeated |
| second request | 7 again (no cross-request cache) |

`createTimelineEntryReader` already dedupes within a request, so there is no
waste to remove. And the client fetches this **on focus change and 2500ms
after a commit settles** (`MANIFEST_REFRESH_DELAY_MS`), not on a poll —
requests are per edit *burst*, not per second.

## Why not build the cache

A cache would buy a handful of reads per burst in exchange for an invalidation
surface and, as the issue warns, a correctness risk that is not theoretical:
this route serves **per-user authorized data**, and `serveTimelineDocument`
throws per *requester*. A key missing the uid leaks one account's timeline into
another's preview.

That is a bad trade at seven reads.

## What ships instead

The measurement, as a test — the number is the whole argument, and it can rot.

What it protects is the **one read per document** part. An N+1 — re-reading a
child while walking, say — fails no existing test today; it would quietly
multiply the cost of every preview, which is precisely what would eventually
make a cache necessary.

Verified discriminating by adding a second read inside the closure walker: the
test fails.

775 app tests, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)