### PR TITLE
Extract the caption tag fold, and test it for the first time

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -63,6 +63,7 @@ import { createDerivedCache } from "@/lib/derived-cache";
 import { graphClipboard } from "@/lib/graph-clipboard";
 import { graphPasteFlash } from "@/lib/graph-paste-flash";
 import { formatDuration, formatSeconds } from "@/lib/format-duration";
+import { fittedTagCount } from "@/lib/caption-tag-fit";
 import { sortTagsStatusFirst } from "@/lib/tag-facets";
 import { TagAccentDot } from "./tag-accent-dot";
 import {
@@ -745,8 +746,6 @@ function ProvenanceLabel({
  * measuring the real row would be circular — hiding a chip changes the width
  * you are measuring from, so the answer would depend on the previous answer.
  */
-const CAPTION_TAG_GAP_PX = 4;
-
 /**
  * The caption's two rows, shared by BOTH card kinds.
  *
@@ -823,42 +822,21 @@ function CaptionTagRow({ tags }: Readonly<{ tags: readonly string[] }>) {
     const ruler = rulerRef.current;
     if (!container || !ruler) return;
 
+    // MEASURE here, DECIDE in lib/caption-tag-fit. The two-pass rule and the
+    // at-least-one-chip floor are the interesting part and they are now
+    // unit-tested; this side owns only the DOM reads.
     const measure = () => {
-      const budget = container.clientWidth;
-      // 0 while the caption is display:none (the strip is showing) — keep the
-      // last answer rather than folding everything for a frame.
-      if (budget === 0) return;
       const widths = Array.from(ruler.children).map((child) =>
         Math.ceil((child as HTMLElement).getBoundingClientRect().width),
       );
-      const counterWidth = counterRef.current?.getBoundingClientRect().width ?? 0;
-
-      // Pass 1 — do they ALL fit with no counter? Asked against the full
-      // budget, because with nothing folded there is no "+N" to leave room for.
-      const whole = widths.reduce(
-        (total, width, index) => total + width + (index > 0 ? CAPTION_TAG_GAP_PX : 0),
-        0,
-      );
-      if (whole <= budget) {
-        setFitted(ordered.length);
-        return;
-      }
-
-      // Pass 2 — something folds, so the counter is going to be drawn and costs
-      // width like a chip. Two passes keeps it one-way: the reserve depends on
-      // pass 1 and never on its own outcome, so it cannot oscillate.
-      const reduced = budget - Math.ceil(counterWidth) - CAPTION_TAG_GAP_PX;
-      let used = 0;
-      let count = 0;
-      for (const width of widths) {
-        const next = used + width + (count > 0 ? CAPTION_TAG_GAP_PX : 0);
-        if (next > reduced) break;
-        used = next;
-        count += 1;
-      }
-      // At least one chip. A row that is only "+4" says there are tags without
-      // showing a single one, which is strictly worse than one chip and "+3".
-      setFitted(Math.max(1, count));
+      const next = fittedTagCount({
+        widths,
+        budget: container.clientWidth,
+        counterWidth: counterRef.current?.getBoundingClientRect().width ?? 0,
+      });
+      // null = the row is not laid out yet; keep the previous answer rather
+      // than folding everything for a frame.
+      if (next !== null) setFitted(next);
     };
 
     measure();

--- a/apps/timeline-gstudio001/lib/caption-tag-fit.test.ts
+++ b/apps/timeline-gstudio001/lib/caption-tag-fit.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { CAPTION_TAG_GAP_PX, fittedTagCount } from "./caption-tag-fit";
+
+// #281: this arithmetic lived inside `CaptionTagRow`, and the app's vitest
+// cannot parse `.tsx` — so the fold rules had never been tested. They are the
+// interesting part of that component; the JSX around them is not.
+
+const GAP = CAPTION_TAG_GAP_PX;
+
+describe("fittedTagCount", () => {
+  it("shows every chip when they all fit with no counter", () => {
+    // 3 chips of 20 + 2 gaps = 68.
+    expect(fittedTagCount({ widths: [20, 20, 20], budget: 68, counterWidth: 30 })).toBe(3);
+  });
+
+  it("asks pass one against the FULL budget, not one reduced by the counter", () => {
+    // Exactly 68 of room and a fat counter. Reserving for a "+N" that will
+    // never be drawn would fold a row that fits — the bug the two passes exist
+    // to prevent.
+    expect(fittedTagCount({ widths: [20, 20, 20], budget: 68, counterWidth: 999 })).toBe(3);
+  });
+
+  it("reserves the counter's width once something folds", () => {
+    // 4 chips need 92; the budget is 70, so pass one fails. Pass two fits
+    // against 70 - 30 - 4 = 36: two chips (20 + 4 + 20 = 44) is too much, so
+    // one.
+    expect(fittedTagCount({ widths: [20, 20, 20, 20], budget: 70, counterWidth: 30 })).toBe(1);
+  });
+
+  it("counts the gaps BETWEEN chips, not after the last one", () => {
+    // Two 20s with one gap is 44. A budget of 44 fits; 43 does not.
+    expect(fittedTagCount({ widths: [20, 20], budget: 44, counterWidth: 0 })).toBe(2);
+    expect(fittedTagCount({ widths: [20, 20], budget: 43, counterWidth: 0 })).toBeLessThan(2);
+  });
+
+  it("keeps at least one chip even when nothing fits", () => {
+    // A row reading only "+4" says there are tags without showing one.
+    expect(fittedTagCount({ widths: [500, 500], budget: 40, counterWidth: 30 })).toBe(1);
+  });
+
+  it("reports NO OPINION for an unlaid-out row rather than folding to nothing", () => {
+    // budget 0 = the caption is display:none while the strip shows. The caller
+    // keeps its last answer; a count here would be a wrong one.
+    expect(fittedTagCount({ widths: [20, 20], budget: 0, counterWidth: 10 })).toBeNull();
+  });
+
+  it("is 0 for no tags, which is not the same as no opinion", () => {
+    expect(fittedTagCount({ widths: [], budget: 100, counterWidth: 10 })).toBe(0);
+  });
+
+  it("does not oscillate: the answer is stable when fed back its own outcome", () => {
+    // The one-way property. Fold once, then re-ask with the same inputs — a
+    // rule that reserved the counter in pass one could flip between 3 and 2
+    // forever as the "+N" appeared and disappeared.
+    const inputs = { widths: [30, 30, 30, 30], budget: 100, counterWidth: 24 } as const;
+    const first = fittedTagCount(inputs);
+    expect(fittedTagCount(inputs)).toBe(first);
+    expect(first).toBeLessThan(4);
+  });
+
+  it("rounds the counter UP, so a fractional measurement cannot overflow the row", () => {
+    // getBoundingClientRect returns fractions; truncating would leave the row
+    // a sub-pixel over budget and wrap.
+    const fractional = fittedTagCount({ widths: [30, 30], budget: 70, counterWidth: 29.4 });
+    const rounded = fittedTagCount({ widths: [30, 30], budget: 70, counterWidth: 30 });
+    expect(fractional).toBe(rounded);
+  });
+
+  it("honours a caller-supplied gap", () => {
+    // 2 chips of 20 with a 20px gap is 60 — fits exactly at 60, not at 59.
+    expect(fittedTagCount({ widths: [20, 20], budget: 60, counterWidth: 0, gap: 20 })).toBe(2);
+    expect(fittedTagCount({ widths: [20, 20], budget: 59, counterWidth: 0, gap: 20 })).toBe(1);
+  });
+});

--- a/apps/timeline-gstudio001/lib/caption-tag-fit.ts
+++ b/apps/timeline-gstudio001/lib/caption-tag-fit.ts
@@ -1,0 +1,63 @@
+/**
+ * How many tag chips fit on a caption's second row.
+ *
+ * Extracted from `CaptionTagRow` (#281). The app's vitest cannot parse `.tsx`,
+ * so while this lived inside the component it could not be tested at all — and
+ * it is the part with the interesting rules, not the JSX around it. The
+ * component keeps the measuring (a ruler element, a ResizeObserver); this owns
+ * the arithmetic.
+ */
+
+/** Gap between chips, in px. Must match the row's `gap-1` in the component. */
+export const CAPTION_TAG_GAP_PX = 4;
+
+/**
+ * The count to show, given each chip's measured width and the row's budget.
+ *
+ * TWO PASSES, and the order matters. Pass one asks whether everything fits with
+ * NO counter, because when nothing folds there is no "+N" to leave room for.
+ * Only if that fails does pass two reserve the counter's width and re-fit.
+ *
+ * Written this way so the answer is ONE-WAY: the reserve depends on pass one's
+ * outcome and never on its own, so the fold cannot oscillate between "fits" and
+ * "does not fit" as the counter appears and disappears.
+ *
+ * AT LEAST ONE CHIP, always. A row reading only "+4" says there are tags
+ * without showing any, which is strictly worse than one chip and "+3".
+ *
+ * A budget of 0 means the row is not laid out yet (the caption is
+ * `display:none` while the strip is showing). The caller keeps its previous
+ * answer rather than folding everything for a frame, so this reports `null` —
+ * "no opinion" — instead of a count that would be wrong.
+ */
+export function fittedTagCount({
+  widths,
+  budget,
+  counterWidth,
+  gap = CAPTION_TAG_GAP_PX,
+}: Readonly<{
+  widths: readonly number[];
+  budget: number;
+  counterWidth: number;
+  gap?: number;
+}>): number | null {
+  if (budget <= 0) return null;
+  if (widths.length === 0) return 0;
+
+  const whole = widths.reduce(
+    (total, width, index) => total + width + (index > 0 ? gap : 0),
+    0,
+  );
+  if (whole <= budget) return widths.length;
+
+  const reduced = budget - Math.ceil(counterWidth) - gap;
+  let used = 0;
+  let count = 0;
+  for (const width of widths) {
+    const next = used + width + (count > 0 ? gap : 0);
+    if (next > reduced) break;
+    used = next;
+    count += 1;
+  }
+  return Math.max(1, count);
+}


### PR DESCRIPTION
First bite of #281, taking the issue's own framing: the app cannot unit-test
`.tsx`, so moving pure logic into a `.ts` module is what makes it testable at
all. **Prefer extracting logic over relocating JSX.**

## The issue's numbers are stale, and the priority has flipped

| file | issue says | actual |
|---|---|---|
| `graph-preview.tsx` | 2,297 | **1,112** — already split since it was filed |
| `graph-item-content.tsx` | 1,419 | **2,225** — grew 57% |
| `graph-native-drop.tsx` | 1,318 | 1,327 |

The file "trending the wrong way" is no longer `graph-preview`. It is
`graph-item-content`, which is where this extraction comes from.

## What moved

`CaptionTagRow` measures chips against the row and folds the overflow into a
"+N". Three rules, all easy to get wrong, none tested:

**Two passes, in that order.** Pass one asks whether everything fits with *no*
counter, because when nothing folds there is no "+N" to leave room for. Only if
that fails does pass two reserve the counter. That ordering is what makes the
answer **one-way** — reserving in pass one lets the fold oscillate as the "+N"
appears and disappears.

**At least one chip.** A row reading only "+4" says there are tags without
showing any, which is worse than one chip and "+3".

**A zero budget is not zero chips.** The caption is `display:none` while the
strip is showing; folding everything for that frame is wrong. The function
returns `null` — *no opinion* — and the caller keeps its last answer. The old
inline `if (budget === 0) return;` made that distinction silently.

## Tests

Ten, including the two that pin the *shape* rather than the output:

- pass one is measured against the **full** budget — a fat counter must not
  fold a row that fits
- the answer is **stable when fed back its own outcome** (the anti-oscillation
  property)

The component keeps the DOM reads — a ruler element and a `ResizeObserver` —
and now decides nothing.

785 app tests (10 new), 169 e2e, typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)