### PR TITLE
Extract the ghost and overview frame rules, and test them

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -64,6 +64,12 @@ import { graphClipboard } from "@/lib/graph-clipboard";
 import { graphPasteFlash } from "@/lib/graph-paste-flash";
 import { formatDuration, formatSeconds } from "@/lib/format-duration";
 import { fittedTagCount } from "@/lib/caption-tag-fit";
+import {
+  OVERVIEW_FRAME_SIZE,
+  ghostPreviewFrames,
+  mediaGhostSrc,
+  overviewFrameCount,
+} from "@/lib/card-ghost-frames";
 import { sortTagsStatusFirst } from "@/lib/tag-facets";
 import { TagAccentDot } from "./tag-accent-dot";
 import {
@@ -1422,9 +1428,6 @@ const GraphClipContent = memo(function GraphClipContent({
 
 /** Square overview frames — the strip is h-11 (44px), matching the package
  *  default so only the SAMPLING differs. */
-const OVERVIEW_FRAME_SIZE = 44;
-const OVERVIEW_FRAME_CAP = 40;
-
 /**
  * The trim overview's background (the "sequence above" a selected video),
  * replacing the package default via the `OverviewContent` registry slot. The
@@ -1447,10 +1450,7 @@ const GraphTrimOverviewContent = memo(
     // Enough square frames to cover the strip width (ceil so the row fills;
     // the container clips the overflow), capped so a long source stays
     // bounded.
-    const frameCount = Math.max(
-      1,
-      Math.min(OVERVIEW_FRAME_CAP, Math.ceil(fullWidth / OVERVIEW_FRAME_SIZE)),
-    );
+    const frameCount = overviewFrameCount(fullWidth);
     // The overview shows the FULL source (the amber window marks the visible
     // part), so the sample range is [0, fullDurationSeconds] — not the
     // trimmed range the card uses.
@@ -1512,15 +1512,6 @@ const GraphTrimHandle = memo(function GraphTrimHandle({
 
 /** A media clip's own frame: a video's poster, an image's source (null when
  *  it has neither — the ghost then falls back to a labelled tile). */
-function mediaGhostSrc(node: CollectionGhostContentProps["node"]): string | null {
-  if (node.kind !== "media") return null;
-  // Audio has no frame, and its `src` is a media file — returning it here put
-  // a .flac into an <img> and drew a broken-image ghost. Null makes the ghost
-  // fall back to its labelled name+duration tile, which is the right answer.
-  if (node.mediaKind === "audio") return null;
-  return node.mediaKind === "video" ? (node.posterSrcs?.[0] ?? null) : (node.src ?? null);
-}
-
 /**
  * The drag ghost: a SQUARE thumbnail of the item being moved (the provider
  * sizes the overlay box square via `dragGhostWidth`/`dragGhostHeight`), so the
@@ -1547,10 +1538,7 @@ const GraphGhost = memo(function GraphGhost({ node, extraCount }: CollectionGhos
     : [];
   // FIRST and LAST only (or the single frame) — never three, exactly as the
   // card picks its two representative frames.
-  // Built by index PAIR rather than as a literal of two possibly-undefined
-  // reads — same two frames, and the ghost cannot end up rendering a hole.
-  const chosen =
-    all.length > 1 ? [0, all.length - 1].flatMap((i) => all[i] ?? []) : all;
+  const chosen = ghostPreviewFrames(all);
   const derivedFrames: string[] = isCollection
     ? chosen.map((preview) => collectionPreviewFrameUrl(preview)).filter(Boolean)
     : (() => {

--- a/apps/timeline-gstudio001/lib/card-ghost-frames.test.ts
+++ b/apps/timeline-gstudio001/lib/card-ghost-frames.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import type { CollectionPreviewFrame } from "@storyboard/timeline-domain";
+
+import {
+  OVERVIEW_FRAME_CAP,
+  OVERVIEW_FRAME_SIZE,
+  ghostPreviewFrames,
+  mediaGhostSrc,
+  overviewFrameCount,
+} from "./card-ghost-frames";
+
+// #281: these were pure all along, just unreachable — the app's vitest cannot
+// parse `.tsx`, so nothing in graph-item-content had ever been unit-tested.
+
+const frame = (id: string): CollectionPreviewFrame => ({
+  id,
+  kind: "image",
+  src: `https://example.test/${id}.jpg`,
+  alt: id,
+});
+
+describe("mediaGhostSrc", () => {
+  it("gives an image its own src", () => {
+    expect(mediaGhostSrc({ kind: "media", mediaKind: "image", src: "a.jpg" })).toBe("a.jpg");
+  });
+
+  it("gives a video its first POSTER, never the movie file", () => {
+    // `src` is an mp4; an <img> pointing at it draws a broken tile.
+    expect(
+      mediaGhostSrc({
+        kind: "media",
+        mediaKind: "video",
+        src: "clip.mp4",
+        posterSrcs: ["p0.jpg", "p1.jpg"],
+      }),
+    ).toBe("p0.jpg");
+  });
+
+  it("refuses AUDIO even though it has a src", () => {
+    // THE REGRESSION GUARD. Audio has a `src`, so every "does it have a
+    // source?" test waves it through — and a .flac in an <img> is a broken
+    // ghost. The package's NodeThumbnail shipped exactly this omission.
+    expect(mediaGhostSrc({ kind: "media", mediaKind: "audio", src: "take.flac" })).toBeNull();
+  });
+
+  it("returns null for a collection, which has no frame of its own", () => {
+    expect(mediaGhostSrc({ kind: "collection" })).toBeNull();
+  });
+
+  it("returns null for a poster-less video rather than falling back to src", () => {
+    expect(mediaGhostSrc({ kind: "media", mediaKind: "video", src: "clip.mp4" })).toBeNull();
+  });
+});
+
+describe("ghostPreviewFrames", () => {
+  it("takes FIRST and LAST, not first/middle/last", () => {
+    const all = ["a", "b", "c", "d"].map(frame);
+    expect(ghostPreviewFrames(all).map((f) => f.id)).toEqual(["a", "d"]);
+  });
+
+  it("passes a single frame through untouched", () => {
+    expect(ghostPreviewFrames([frame("only")]).map((f) => f.id)).toEqual(["only"]);
+  });
+
+  it("is empty for no frames, so the ghost falls back to its labelled tile", () => {
+    expect(ghostPreviewFrames([])).toEqual([]);
+  });
+
+  it("returns two frames for exactly two, not a duplicate of one", () => {
+    expect(ghostPreviewFrames([frame("a"), frame("b")]).map((f) => f.id)).toEqual(["a", "b"]);
+  });
+});
+
+describe("overviewFrameCount", () => {
+  it("ceils so the row fills its strip", () => {
+    // 100 / 44 = 2.27 — three frames, with the container clipping the overflow.
+    expect(overviewFrameCount(100)).toBe(3);
+  });
+
+  it("is exact on a whole multiple", () => {
+    expect(overviewFrameCount(OVERVIEW_FRAME_SIZE * 4)).toBe(4);
+  });
+
+  it("caps a long source", () => {
+    expect(overviewFrameCount(100_000)).toBe(OVERVIEW_FRAME_CAP);
+  });
+
+  it("never drops below one — a zero-frame band reads as a failed load", () => {
+    expect(overviewFrameCount(0)).toBe(1);
+    expect(overviewFrameCount(-50)).toBe(1);
+  });
+
+  it("survives an unmeasured width instead of returning NaN frames", () => {
+    // A pre-layout read can hand this NaN; `Array.from({length: NaN})` would
+    // silently render nothing.
+    expect(overviewFrameCount(Number.NaN)).toBe(1);
+  });
+});

--- a/apps/timeline-gstudio001/lib/card-ghost-frames.ts
+++ b/apps/timeline-gstudio001/lib/card-ghost-frames.ts
@@ -1,0 +1,70 @@
+import type { CollectionPreviewFrame } from "@storyboard/timeline-domain";
+
+/**
+ * Pure frame-selection rules for the drag ghost and the trim overview.
+ *
+ * Extracted from `graph-item-content.tsx` (#281). All three were already pure
+ * — they were simply unreachable by a test, because the app's vitest cannot
+ * parse `.tsx`. `mediaGhostSrc` in particular encodes a bug class this repo
+ * has now hit twice (a `.flac` handed to an `<img>`), which is exactly the
+ * kind of rule that should be pinned.
+ */
+
+/** Width of one square frame in the trim overview, px. */
+export const OVERVIEW_FRAME_SIZE = 44;
+/** Ceiling on frames, so a long source cannot mount hundreds of `<img>`. */
+export const OVERVIEW_FRAME_CAP = 40;
+
+/** A media node, narrowed to what these rules actually read. */
+export type GhostMediaNode = Readonly<{
+  kind: string;
+  mediaKind?: string;
+  src?: string;
+  posterSrcs?: readonly string[];
+}>;
+
+/**
+ * The single frame a media drag ghost shows, or null to fall back to the
+ * labelled name+duration tile.
+ *
+ * AUDIO IS NULL, deliberately. An audio node has a `src`, so every
+ * "does it have a source?" test waves it through — and the result is a `.flac`
+ * URL in an `<img>`, drawing a broken-image ghost. The same omission shipped in
+ * the package's `NodeThumbnail` and had to be fixed separately, which is why
+ * this rule is worth a test rather than a comment.
+ *
+ * A VIDEO uses its first poster, never `src`: `src` is the movie file, and an
+ * `<img>` pointing at an mp4 is the same broken tile by another route.
+ */
+export function mediaGhostSrc(node: GhostMediaNode): string | null {
+  if (node.kind !== "media") return null;
+  if (node.mediaKind === "audio") return null;
+  return node.mediaKind === "video" ? (node.posterSrcs?.[0] ?? null) : (node.src ?? null);
+}
+
+/**
+ * The two frames a COLLECTION ghost shows: first and last.
+ *
+ * Not first/middle/last — the ghost is a small square and three slices of a
+ * composition read as noise. Built by index pair rather than as a literal of
+ * two reads, so the result can never contain a hole for the renderer to paint.
+ */
+export function ghostPreviewFrames(
+  all: readonly CollectionPreviewFrame[],
+): readonly CollectionPreviewFrame[] {
+  if (all.length <= 1) return all;
+  return [0, all.length - 1].flatMap((index) => all[index] ?? []);
+}
+
+/**
+ * How many square frames the trim overview draws across `fullWidth`.
+ *
+ * CEIL so the row fills its strip (the container clips the overflow) rather
+ * than leaving a gap at the right edge; CAPPED so a long source stays bounded;
+ * and never below one, because a zero-frame overview is an empty band that
+ * reads as a failed load.
+ */
+export function overviewFrameCount(fullWidth: number): number {
+  if (!Number.isFinite(fullWidth)) return 1;
+  return Math.max(1, Math.min(OVERVIEW_FRAME_CAP, Math.ceil(fullWidth / OVERVIEW_FRAME_SIZE)));
+}


### PR DESCRIPTION
Follow-up to #382 (merged). #281, continuing in `graph-item-content` — the file
the issue's stale numbers mis-rank (it has **grown** to 2,225 while
`graph-preview` was already split down to 1,112).

Three functions that were pure all along and simply unreachable by a test,
because the app's vitest cannot parse `.tsx`.

## `mediaGhostSrc` — the one worth pinning

Audio **has** a `src`, so every "does it have a source?" test waves it through
— and the result is a `.flac` handed to an `<img>`: a broken-image drag ghost.

The package's own `NodeThumbnail` shipped exactly that omission and had to be
fixed separately today. Same rule, two places, one of which was wrong. It now
has a test that fails if the audio arm is dropped.

Video gets its **poster**, never `src`, for the same reason in a different
costume: an `<img>` pointing at an mp4 is the same broken tile.

## `ghostPreviewFrames`

First and **last**, not first/middle/last. The ghost is a small square and
three slices of a composition read as noise.

## `overviewFrameCount`

Ceil so the row fills its strip, capped so a long source cannot mount hundreds
of `<img>`, and never below one because a zero-frame band reads as a failed
load.

It also now survives a **NaN** width — a pre-layout read used to produce
`Array.from({length: NaN})`, which renders nothing at all rather than failing.

## A note on how this branch was built

The first attempt was cut from `main` before #382 merged, and a stash pop left
conflict markers that I committed and pushed. I caught it on the next
typecheck, rebuilt from a clean base, and deleted that branch. Worth recording
because the push happened before the check — the ordering, not the conflict, is
the mistake.

14 tests. The component keeps the JSX and decides none of this.

799 app tests (14 new), 169 e2e; typecheck and lint clean. `graph-item-content`
is at 2,191 across the two extractions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)