### PR TITLE
Extract the card provenance label rule, and test it

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -64,6 +64,7 @@ import { graphClipboard } from "@/lib/graph-clipboard";
 import { graphPasteFlash } from "@/lib/graph-paste-flash";
 import { formatDuration, formatSeconds } from "@/lib/format-duration";
 import { fittedTagCount } from "@/lib/caption-tag-fit";
+import { resolveCardProvenance } from "@/lib/card-provenance";
 import {
   OVERVIEW_FRAME_SIZE,
   ghostPreviewFrames,
@@ -445,9 +446,15 @@ function useCardProvenance(
   // the collection card and the breadcrumb use, so a rename shows here too.
   const title = useTimelineTitle((parentId ?? "") as string);
 
-  if (parentId === null || focusedId === null) return null;
-  if ((parentId as string) === focusedId) return null;
-  return { parentId, name: title ?? nodeName ?? (parentId as string) };
+  // The DECISION lives in lib/card-provenance (unit-tested); this hook owns
+  // only the three subscriptions above.
+  const resolved = resolveCardProvenance({
+    parentId: (parentId as string | null) ?? null,
+    focusedId,
+    title: title ?? null,
+    nodeName,
+  });
+  return resolved === null ? null : { parentId: resolved.parentId as NodeId, name: resolved.name };
 }
 
 /**

--- a/apps/timeline-gstudio001/lib/card-provenance.test.ts
+++ b/apps/timeline-gstudio001/lib/card-provenance.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveCardProvenance } from "./card-provenance";
+
+// #281: this decision lived inside `useCardProvenance`, and the app's vitest
+// cannot parse `.tsx` — so the resolution order and both null rules had never
+// been tested.
+
+describe("resolveCardProvenance", () => {
+  it("labels a card whose parent is NOT the focused collection", () => {
+    expect(
+      resolveCardProvenance({
+        parentId: "scene-b",
+        focusedId: "project",
+        title: "Scene B",
+        nodeName: "scene-b node",
+      }),
+    ).toEqual({ parentId: "scene-b", name: "Scene B" });
+  });
+
+  it("says nothing when the parent IS the focused collection", () => {
+    // The flat-run rule that needs no mode flag: in a nested strip every
+    // card's parent is the focused one, so this branch silences them all.
+    expect(
+      resolveCardProvenance({
+        parentId: "project",
+        focusedId: "project",
+        title: "Project",
+        nodeName: "project",
+      }),
+    ).toBeNull();
+  });
+
+  it("says nothing for a root card, which has no parent to name", () => {
+    expect(
+      resolveCardProvenance({ parentId: null, focusedId: "project", title: null, nodeName: null }),
+    ).toBeNull();
+  });
+
+  it("says nothing before a focus is known", () => {
+    expect(
+      resolveCardProvenance({ parentId: "scene-b", focusedId: null, title: "Scene B", nodeName: null }),
+    ).toBeNull();
+  });
+
+  it("prefers the stored TITLE over the graph node's name", () => {
+    // The order that makes a rename show up here. Reversed, a renamed
+    // collection keeps its old name in this label while the breadcrumb and the
+    // card itself show the new one.
+    expect(
+      resolveCardProvenance({
+        parentId: "scene-b",
+        focusedId: "project",
+        title: "Renamed",
+        nodeName: "Stale optimistic name",
+      })?.name,
+    ).toBe("Renamed");
+  });
+
+  it("falls back to the node name while the document is still loading", () => {
+    expect(
+      resolveCardProvenance({
+        parentId: "scene-b",
+        focusedId: "project",
+        title: null,
+        nodeName: "Optimistic",
+      })?.name,
+    ).toBe("Optimistic");
+  });
+
+  it("falls back to the id last, so the row never prints nothing", () => {
+    expect(
+      resolveCardProvenance({ parentId: "scene-b", focusedId: "project", title: null, nodeName: null })
+        ?.name,
+    ).toBe("scene-b");
+  });
+
+  it("carries the parent id through, so the label can navigate", () => {
+    expect(
+      resolveCardProvenance({
+        parentId: "scene-b",
+        focusedId: "project",
+        title: "Scene B",
+        nodeName: null,
+      })?.parentId,
+    ).toBe("scene-b");
+  });
+});

--- a/apps/timeline-gstudio001/lib/card-provenance.ts
+++ b/apps/timeline-gstudio001/lib/card-provenance.ts
@@ -1,0 +1,44 @@
+/**
+ * Where a card's item actually LIVES, when that is not the timeline on screen.
+ *
+ * Extracted from `useCardProvenance` in `graph-item-content.tsx` (#281). The
+ * hook keeps the three store subscriptions; this owns the decision, which is
+ * the part with rules — and the part the app's vitest could not reach while it
+ * sat in a `.tsx` file.
+ */
+
+/**
+ * The label for a card whose parent is not the focused collection, or null
+ * when no label belongs there.
+ *
+ * NO MODE FLAG, deliberately. In the ordinary nested strip every card's parent
+ * IS the focused collection, so the comparison is false by construction and
+ * the label never appears. In a flat run the cards drawn from nested
+ * collections differ, and exactly those get one. Direct children of the
+ * focused timeline stay unlabelled in both readings, which is right — their
+ * collection is the one being looked at.
+ *
+ * THE NAME'S RESOLUTION ORDER IS LOAD-BEARING: the stored document title wins
+ * over the graph node's name, because the document is the source of truth and
+ * the node is the optimistic fallback until it loads. Reversing them means a
+ * renamed collection keeps its old name here while the breadcrumb and the card
+ * show the new one. The id is the last resort, so a row can never print
+ * nothing at all.
+ */
+export function resolveCardProvenance({
+  parentId,
+  focusedId,
+  title,
+  nodeName,
+}: Readonly<{
+  parentId: string | null;
+  focusedId: string | null;
+  title: string | null;
+  nodeName: string | null;
+}>): Readonly<{ parentId: string; name: string }> | null {
+  if (parentId === null || focusedId === null) return null;
+  // A root card has no parent to name; a card whose parent is on screen needs
+  // no pointer to it.
+  if (parentId === focusedId) return null;
+  return { parentId, name: title ?? nodeName ?? parentId };
+}


### PR DESCRIPTION
#281, third extraction from `graph-item-content`. Follows #382 and #383, both
merged.

`useCardProvenance` decides whether a card should say where its item actually
*lives*, and what to call that place. Three rules, none previously testable:

**No mode flag.** In the ordinary nested strip every card's parent *is* the
focused collection, so the comparison is false by construction and no card is
labelled. In a flat run the cards drawn from nested collections differ, and
exactly those get a label. One comparison covers both readings — which is why
there is no "am I flat?" argument to get wrong.

**The name's resolution order is load-bearing.** Stored document title, then
the graph node's name, then the id. The document is the source of truth and the
node is the optimistic fallback until it loads — reversed, a renamed collection
keeps its old name in this label while the breadcrumb and the card itself show
the new one. The id last means a row can never print nothing.

**A root card, or a card seen before focus resolves, says nothing.**

## This one grew the file

2,191 → 2,198. The hook now maps `NodeId` to `string` across the call, which
costs more lines than the branchy return it replaced.

Worth stating plainly rather than burying: #281's goal is reviewability and
testability, not a smaller number, and eight tests on a rule that had none is
the trade. The two earlier extractions did shrink it.

## Also checked

`isDisabledByAncestor`, the other candidate in this area, already lives in
`graph-playhead-model.ts` **and** is already tested — nothing to do.

807 app tests (8 new), 169 e2e; typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)