### PR TITLE
Extract the filmstrip settle rule, and test its sentinel

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -66,6 +66,11 @@ import { formatDuration, formatSeconds } from "@/lib/format-duration";
 import { fittedTagCount } from "@/lib/caption-tag-fit";
 import { resolveCardProvenance } from "@/lib/card-provenance";
 import {
+  FRAME_COUNT_SETTLE_MS,
+  settleFrameCountStep,
+  visibleFrameCount,
+} from "@/lib/frame-count-settle";
+import {
   OVERVIEW_FRAME_SIZE,
   ghostPreviewFrames,
   mediaGhostSrc,
@@ -130,17 +135,6 @@ export function useElementSize(): [
 }
 
 /**
- * How long a CHANGED frame-count measurement must hold before the filmstrip
- * re-samples. A continuous px/s drag sweeps a card's width→count ratio
- * through several integers, and adopting each crossing re-times every frame
- * slot — swapping every `<img>` src on the card (a fresh CDN URL per slot)
- * several times per drag, per video card. Generous on purpose: the drag's
- * layout already tracks live (widths are CSS), only the frame REFINEMENT
- * waits for the size to hold still.
- */
-const FRAME_COUNT_SETTLE_MS = 400;
-
-/**
  * The measured frame count, SETTLED: the first real measurement is adopted
  * immediately — a freshly (re)mounted card, virtualization remounts included,
  * must not wait out the delay to show its filmstrip — while later changes
@@ -152,15 +146,16 @@ const FRAME_COUNT_SETTLE_MS = 400;
  */
 function useSettledFrameCount(measured: number): number {
   const [settled, setSettled] = useState(measured);
-  if (settled === 0 && measured !== 0) setSettled(measured);
+  // The render-time adoption (the repo's cascading-render-safe pattern; a
+  // synchronous setState in the effect would trip the lint). The DECISION is
+  // in lib/frame-count-settle, which is unit-tested; this owns the state.
+  if (settleFrameCountStep({ settled, measured }) === "adopt-now") setSettled(measured);
   useEffect(() => {
-    // settled === 0 means the render-time first adoption is already in
-    // flight — nothing to debounce yet.
-    if (measured === settled || settled === 0) return;
+    if (settleFrameCountStep({ settled, measured }) !== "debounce") return;
     const timer = setTimeout(() => setSettled(measured), FRAME_COUNT_SETTLE_MS);
     return () => clearTimeout(timer);
   }, [measured, settled]);
-  return settled === 0 ? measured : settled;
+  return visibleFrameCount({ settled, measured });
 }
 
 const NO_PREVIEWS: readonly CollectionPreviewFrame[] = [];

--- a/apps/timeline-gstudio001/lib/frame-count-settle.test.ts
+++ b/apps/timeline-gstudio001/lib/frame-count-settle.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { settleFrameCountStep, visibleFrameCount } from "./frame-count-settle";
+
+// #281: this state machine lived inside `useSettledFrameCount`, and the app's
+// vitest cannot parse `.tsx` — so the sentinel's two meanings had never been
+// pinned. Getting either wrong is invisible in review and obvious on screen:
+// a blank filmstrip, or every `<img>` src swapping several times per drag.
+
+describe("settleFrameCountStep", () => {
+  it("adopts the FIRST real measurement immediately", () => {
+    // A freshly (re)mounted card — virtualization remounts included — must not
+    // wait out 400ms before it shows a filmstrip at all.
+    expect(settleFrameCountStep({ settled: 0, measured: 6 })).toBe("adopt-now");
+  });
+
+  it("debounces a later CHANGE", () => {
+    // A drag sweeps the width→count ratio through several integers; adopting
+    // each crossing re-times every slot and swaps every src.
+    expect(settleFrameCountStep({ settled: 6, measured: 7 })).toBe("debounce");
+  });
+
+  it("holds when the measurement has not changed", () => {
+    expect(settleFrameCountStep({ settled: 6, measured: 6 })).toBe("hold");
+  });
+
+  it("HOLDS an unmeasured card rather than adopting a zero", () => {
+    // The ordering rule: equality is checked before the sentinel. Reversed,
+    // `settled: 0, measured: 0` would report "adopt-now" and the card would
+    // commit to a zero-frame filmstrip — an empty band, not a picture.
+    expect(settleFrameCountStep({ settled: 0, measured: 0 })).toBe("hold");
+  });
+
+  it("does not ALSO debounce while the render-time adoption is in flight", () => {
+    // The sentinel's second meaning. The effect runs in the same pass that
+    // adopted during render; if this said "debounce", a remount would
+    // double-schedule the same value.
+    expect(settleFrameCountStep({ settled: 0, measured: 9 })).not.toBe("debounce");
+  });
+
+  it("debounces a shrink as well as a growth", () => {
+    // Narrowing a card is the same churn in the other direction.
+    expect(settleFrameCountStep({ settled: 9, measured: 3 })).toBe("debounce");
+  });
+});
+
+describe("visibleFrameCount", () => {
+  it("shows the MEASURED value while nothing is settled", () => {
+    // So the card paints on the first frame it can, rather than waiting for
+    // the adoption to round-trip through state.
+    expect(visibleFrameCount({ settled: 0, measured: 6 })).toBe(6);
+  });
+
+  it("shows the SETTLED value once there is one", () => {
+    // Mid-debounce the card keeps the old count — that steadiness is the whole
+    // point of the delay.
+    expect(visibleFrameCount({ settled: 6, measured: 7 })).toBe(6);
+  });
+
+  it("is zero only when nothing has been measured at all", () => {
+    expect(visibleFrameCount({ settled: 0, measured: 0 })).toBe(0);
+  });
+});

--- a/apps/timeline-gstudio001/lib/frame-count-settle.ts
+++ b/apps/timeline-gstudio001/lib/frame-count-settle.ts
@@ -1,0 +1,68 @@
+/**
+ * When a video card's filmstrip may re-sample its frame count.
+ *
+ * Extracted from `useSettledFrameCount` in `graph-item-content.tsx` (#281).
+ * The hook keeps the state and the timer; this owns the decision, which is a
+ * small state machine with a sentinel that means two different things.
+ */
+
+/**
+ * How long a CHANGED measurement must hold before the filmstrip re-samples.
+ *
+ * A continuous px/s drag sweeps a card's width→count ratio through several
+ * integers, and adopting each crossing re-times every frame slot — swapping
+ * every `<img>` src on the card (a fresh CDN URL per slot) several times per
+ * drag, per video card. Generous on purpose: the drag's layout already tracks
+ * live (widths are CSS); only the frame REFINEMENT waits for the size to hold
+ * still.
+ */
+export const FRAME_COUNT_SETTLE_MS = 400;
+
+/** What the hook should do with a new measurement. */
+export type FrameCountStep =
+  /** Take it immediately — a freshly (re)mounted card must not wait out the
+   *  delay before it shows a filmstrip at all. */
+  | "adopt-now"
+  /** Start (or restart) the settle timer; the value is a refinement. */
+  | "debounce"
+  /** Nothing to do. */
+  | "hold";
+
+/**
+ * `settled === 0` IS THE SENTINEL, and it carries two readings that this
+ * function deliberately collapses into one answer:
+ *
+ *   Nothing has been adopted yet, so the first real measurement should be
+ *   taken at once rather than after 400ms of blank card.
+ *
+ *   The render-time adoption is already in flight — so the effect must NOT
+ *   also start a timer for the same value, or a remount would double-schedule.
+ *
+ * Both mean "do not debounce", which is why one branch covers them.
+ *
+ * Ordering matters: the equality check comes FIRST, so a genuinely unmeasured
+ * card (`settled === 0`, `measured === 0`) holds rather than adopting a zero
+ * that would render an empty filmstrip.
+ */
+export function settleFrameCountStep({
+  settled,
+  measured,
+}: Readonly<{ settled: number; measured: number }>): FrameCountStep {
+  if (measured === settled) return "hold";
+  if (settled === 0) return "adopt-now";
+  return "debounce";
+}
+
+/**
+ * What to render this pass.
+ *
+ * While nothing is settled the MEASURED value shows through, so the card
+ * paints its filmstrip on the first frame it can rather than after the
+ * adoption round-trips through state.
+ */
+export function visibleFrameCount({
+  settled,
+  measured,
+}: Readonly<{ settled: number; measured: number }>): number {
+  return settled === 0 ? measured : settled;
+}


### PR DESCRIPTION
#281, fourth and last extraction with real rules in `graph-item-content` —
what remains there is JSX that a split would relocate, not make testable.
Follows #382, #383, #384.

`useSettledFrameCount` decides when a video card's filmstrip may re-sample.
The whole thing turns on `settled === 0`, a sentinel carrying **two** meanings
that the old inline code collapsed silently:

- Nothing adopted yet, so take the first real measurement at once — a freshly
  (re)mounted card, virtualization remounts included, must not wait out 400ms
  showing a blank strip.
- The render-time adoption is already in flight, so the effect must **not**
  also start a timer for the same value, or a remount double-schedules it.

Both mean "do not debounce", which is why one branch covers them — but that is
a fact worth stating and testing, not inferring from `|| settled === 0`.

## The ordering is the subtle part

Equality is checked **before** the sentinel, so a genuinely unmeasured card
(`settled: 0, measured: 0`) *holds* rather than adopting a zero and committing
to an empty band.

Reverse those two lines and the bug is invisible in review and obvious on
screen. That case has a test.

## Tests

Nine, including the ordering case above and the "does not *also* debounce"
case — the one a refactor would most easily break.

The hook keeps the state and the timer and decides nothing. 2,198 → 2,193.

816 app tests (9 new), 35 card stories, 169 e2e; typecheck and lint clean.

## Across the four extractions

**41 new unit tests** over logic that had none, and `graph-item-content` is
down from 2,225 to 2,193. The line count was never the point — the app cannot
unit-test `.tsx`, so each of these rules was previously unreachable by any test
at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)