### PR TITLE
Split the board's chrome into two rows, and end the paste gesture

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -47,7 +47,6 @@ import {
   type ItemActionState,
 } from "@/lib/graph-item-action-specs";
 import {
-  GRAPH_BOARD_MENU_SLOT_ID,
   requestGraphItemAction,
   requestGraphToolInsert,
   type GraphItemAction,
@@ -148,20 +147,28 @@ function BoardMenu({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        {/* Wears the icon RAIL's tile treatment, not the header's ghost
-            button: it sits with the trash and account tiles now (PL14-005) and
-            has to read as one of them. `side="right"` for the same reason —
-            a menu aligned to the end of a 72px rail would open off-screen. */}
-        <button
+        {/* Back to the header ghost-button treatment. It wore the icon RAIL's
+            tile styling while it lived down there with the trash and account
+            tiles (PL14-005); it is the last control in the board's own
+            controls row now, so it has to read as one of THOSE — same 32px
+            ghost square as the toggles beside it, via HeaderToggle's classes.
+
+            `side="bottom" align="end"` follows it back. `side="right"` existed
+            only because a menu aligned to the end of a 72px rail would have
+            opened off-screen; anchored to the row's right edge, dropping down
+            and end-aligned is what keeps it on screen. */}
+        <Button
           type="button"
+          variant="ghost"
+          size="icon"
           aria-label="Board options"
           title="Board options"
-          className={[SIDEBAR_ICON_BASE, SIDEBAR_ICON_IDLE].join(" ")}
+          className={cn("h-8 w-8", HEADER_TOGGLE_IDLE)}
         >
-          <Settings aria-hidden="true" className={SIDEBAR_GLYPH} />
-        </button>
+          <Settings aria-hidden className="h-4 w-4" />
+        </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent side="right" align="end" className="w-60 p-2">
+      <DropdownMenuContent side="bottom" align="end" className="w-60 p-2">
         <DropdownMenuGroup>
           <DropdownMenuLabel className="px-0.5 pb-2 pt-0.5">Thumbnail size</DropdownMenuLabel>
           {/* BADGES in a wrapping row, not a stack of rows: five sizes as
@@ -205,38 +212,18 @@ function BoardMenu({
   );
 }
 
-/**
- * Mounts `BoardMenu` into the icon sidebar's slot (PL14-005).
+/*
+ * `BoardMenuSlot` is gone with the trip to the icon rail.
  *
- * The node is looked up ONCE, in a lazy initializer, and that is safe here for
- * a specific reason: the whole graph tree mounts `ssr: false` (see
- * client-graph-view), so the app layout — rail included — is already committed
- * to the DOM before this component first renders. There is no frame in which
- * the slot is missing and we would need to retry.
- *
- * Which is why it is not an effect. Resolving it with `setState` inside one
- * re-renders the board on every mount to change nothing, and the repo's lint
- * rejects synchronous set-state in an effect for exactly that reason. If the
- * graph ever mounts with SSR, this has to become a subscription — not an
- * effect that sets state.
- *
- * Rendering it from HERE, inside the board, is the whole point: the menu keeps
- * the real `itemSize`/`pixelsPerSecond` props and stays inside the graph's
- * providers. Only its DOM address is in the sidebar. `graph-view.spec.ts`
- * asserts it actually lands there, because a null slot would fail silently.
+ * It portalled `BoardMenu` into a slot the rail published
+ * (`GRAPH_BOARD_MENU_SLOT_ID`), so the menu could keep its real
+ * `itemSize`/`onItemSizeChange` props and stay inside the graph's providers
+ * while its trigger sat with the trash and account tiles (PL14-005). The
+ * trigger is back in the board's own controls row, which is inside those
+ * providers already — so the portal, the slot lookup, and the rail's empty
+ * publishing div all had nothing left to do and are deleted rather than left
+ * behind pointing at each other.
  */
-function BoardMenuSlot(props: Readonly<{
-  itemSize: ItemSize;
-  onItemSizeChange: (size: ItemSize) => void;
-}>) {
-  const [slot] = useState<HTMLElement | null>(() =>
-    typeof document === "undefined"
-      ? null
-      : document.getElementById(GRAPH_BOARD_MENU_SLOT_ID),
-  );
-  if (!slot) return null;
-  return createPortal(<BoardMenu {...props} />, slot);
-}
 
 /**
  * The centre readout of the header row: normally the focused timeline's
@@ -252,37 +239,61 @@ function BoardMenuSlot(props: Readonly<{
  * purpose (the per-card badges show the same numbers), so hiding it on small
  * screens costs nothing.
  */
+/**
+ * How many items are selected — the subject the controls beside it act on.
+ *
+ * Lives in the HEADER, next to those controls: a group of verbs whose count has
+ * been moved away reads as chrome with no object. Visible at every breakpoint
+ * for the same reason.
+ *
+ * This and `FocusedAggregate` below were ONE component sharing one slot, which
+ * is why they were mutually exclusive — two numbers competing for the centre of
+ * the breadcrumb row, so the selection won whenever there was one. They are in
+ * different rows now, so the competition is gone and with it the reason to
+ * suppress either: the header says what you have picked, the controls row says
+ * what is in front of you, and both are true at once.
+ */
+function SelectionSummary() {
+  const selectedCount = useSelectionCount();
+  if (selectedCount === 0) return null;
+  return (
+    <span
+      data-selection-summary
+      className="block shrink-0 pl-3 text-center font-mono text-[11px] tabular-nums text-blue-400/90"
+      title="Selected items"
+    >
+      {/* COUNT ONLY. The selection's total duration was here and is not a
+          fact anyone acts on — nothing in the row does anything with it, and
+          it competed for the eye with the number that actually scopes the
+          verbs beside it. The timeline's own total still shows below, which is
+          where a duration means something. */}
+      {selectedCount} selected
+    </span>
+  );
+}
+
+/**
+ * What is in the focused timeline: "12 clips · 1:04".
+ *
+ * It describes the board rather than the selection, so it sits at the left of
+ * the controls row under the divider — beside the controls that qualify what
+ * that board shows — rather than in the breadcrumb trail above.
+ *
+ * No longer hidden below `sm`. It was competing for the breadcrumb row's centre
+ * slot with the selection count and with the clipboard verbs, and on a narrow
+ * viewport the total was the one worth dropping. In a row of its own there is
+ * nothing to lose it to.
+ */
 function FocusedAggregate({
   focusedId,
   pixelsPerSecond,
 }: Readonly<{ focusedId: string; pixelsPerSecond: number }>) {
-  const selectedCount = useSelectionCount();
   const { count, seconds } = useFocusedTimelineAggregate(focusedId, pixelsPerSecond);
-
-  if (selectedCount > 0) {
-    return (
-      <span
-        data-selection-summary
-        // Visible at EVERY breakpoint, unlike the idle total below. This is the
-        // subject the controls beside it act on, and a group of controls whose
-        // count has been hidden away reads as chrome with no object.
-        className="block shrink-0 pl-3 text-center font-mono text-[11px] tabular-nums text-blue-400/90"
-        title="Selected items"
-      >
-        {/* COUNT ONLY. The selection's total duration was here and is not a
-            fact anyone acts on — nothing in the row does anything with it, and
-            it competed for the eye with the number that actually scopes the
-            verbs beside it. The timeline's own total still shows when nothing
-            is selected, which is where a duration means something. */}
-        {selectedCount} selected
-      </span>
-    );
-  }
   if (count === 0) return null;
   return (
     <span
       data-focused-aggregate
-      className="hidden shrink-0 px-3 text-center font-mono text-[11px] tabular-nums text-zinc-400 sm:block"
+      className="shrink-0 font-mono text-[11px] tabular-nums text-zinc-400"
       title="Focused timeline total"
     >
       {count} {count === 1 ? "clip" : "clips"} · {formatDuration(seconds)}
@@ -1152,7 +1163,12 @@ function SelectModeHeader({
         // count of exactly those ringed cards, so matching the ring is what
         // ties the number to the thing it counts; blue-400 was a near-miss
         // that read as a third accent rather than the selection colour.
-        className="shrink-0 font-mono text-[13px] tabular-nums text-blue-500"
+        // `text-sm` (14px), matching the breadcrumb trail this row swaps
+        // places with. The two faces of the header have to read as the same
+        // row wearing a different hat — a count a pixel smaller than the trail
+        // it replaces is exactly the kind of drift that makes the swap feel
+        // like a different toolbar appearing.
+        className="shrink-0 font-mono text-sm tabular-nums text-blue-500"
       >
         {armed ? armedCount : selectionCount} selected
       </span>
@@ -1221,7 +1237,7 @@ function SelectModeHeader({
         // nudged the board down: this is the tallest thing in the row, so it
         // alone set the header's height — 61px against the browse row's 57.
         className={cn(
-          "ml-auto h-8 shrink-0 rounded-lg border border-zinc-700 px-3.5 text-[13px] font-medium",
+          "ml-auto h-8 shrink-0 rounded-lg border border-zinc-700 px-3.5 text-sm font-medium",
           "[@media(pointer:coarse)]:h-11",
           "text-zinc-100 hover:border-zinc-500 hover:bg-transparent hover:text-white",
         )}
@@ -1590,91 +1606,69 @@ export function GraphBoard({
                 drag readout that overlays this row, and fade back on drop. The
                 breadcrumb stays — it IS the drop target. */}
             <DragChromeFade className="flex items-center">
-              <FocusedAggregate
-                focusedId={focusedId}
-                pixelsPerSecond={deferredPixelsPerSecond}
-              />
+              <SelectionSummary />
               <SelectionCentreControls anchorName={anchorName} />
             </DragChromeFade>
-            {/* flex-wrap + wrap-capable controls so a narrow viewport folds the
-                toolbar onto a second line instead of pushing controls
-                off-screen. No effect when it fits. */}
+            {/* NO `flex-wrap`, despite what this comment used to claim: the
+                header's two faces are pinned to one height, so a cluster that
+                folded onto a second line would take the whole row — and the
+                board pinned beneath it — with it. Narrow viewports are
+                answered by moving controls OUT (the row under the divider now
+                carries four of them) rather than by wrapping. */}
             <DragChromeFade className="flex min-w-0 items-center justify-end gap-2">
-              {/* FILTER and SELECT lead the cluster, together, as the design
-                  has them. They are the two controls that change how you WORK
-                  with the board rather than what it contains or how it is
-                  drawn: one narrows the field to what you are hunting for, the
-                  other is how you then pick out of it. Reaching for them in
-                  sequence is the common path, so they sit as one pair.
+              {/* SELECT leads what is left of this cluster. It used to lead as
+                  a PAIR with the tag filter — the two controls that change how
+                  you WORK with the board rather than what it contains — and
+                  that pairing is gone deliberately: the filter moved down to
+                  the controls row under the divider, with the rest of the
+                  controls that qualify what the board shows. Select stays here
+                  because it is the one that arms an ACTION, and the verbs it
+                  arms (the centre cluster) are in this row.
 
-                  The filter used to live in the view group below, on the
-                  reasoning that it qualifies what the board shows — true, but
-                  it is also the control this row most needed to make findable,
-                  and buried among the ruler and waveform toggles it read as one
-                  more display switch. */}
-              <TagFilterControl />
+                  The Collection tool, the children-timelines toggle and the
+                  zoom slider all went down with the filter. What remains up
+                  here is the row's original job: where you are, what you have
+                  picked, and what you can do to it. */}
               <SelectModeButton />
               <div aria-hidden="true" className="h-5 w-px shrink-0 bg-zinc-700" />
-              {/* The Collection tool (moved here from the icon sidebar): the
-                  view's one "add structure" action, fenced off from the
-                  surface/history controls to its right. */}
-              <GraphAddCollectionButton />
-              <div aria-hidden="true" className="h-5 w-px shrink-0 bg-zinc-700" />
-              {/* The VIEW group: what the board shows. Fenced on both sides so
-                  the cluster reads as work | create | view | history | settings,
-                  and the fences stay put as its contents come and go — the ruler
-                  exists only in flat mode.
+              {/* Ruler and waveform stay: they draw ONTO the strip rather than
+                  changing what is on it, they are flat-mode only, and pairing
+                  them with the surface controls to the right is what keeps
+                  them out of the way in grid mode. The fence travels with them
+                  — an empty group between two fences is just a doubled line.
 
                   PREVIEW is deliberately not here. It lives in the icon rail
                   (see timeline-sidebar) because it is one of the two controls
-                  worth promoting to rail scale; this row keeps the ones that
-                  only qualify the board in front of you. */}
+                  worth promoting to rail scale. */}
               {flatOn ? (
-                <HeaderToggle
-                  active={rulerOn}
-                  onToggle={onRulerToggle}
-                  icon={Ruler}
-                  label={rulerOn ? "Hide time ruler" : "Show time ruler"}
-                  title="Time ruler — tick marks over every strip"
-                />
+                <>
+                  <HeaderToggle
+                    active={rulerOn}
+                    onToggle={onRulerToggle}
+                    icon={Ruler}
+                    label={rulerOn ? "Hide time ruler" : "Show time ruler"}
+                    title="Time ruler — tick marks over every strip"
+                  />
+                  <HeaderToggle
+                    active={waveformOn}
+                    onToggle={onWaveformToggle}
+                    icon={AudioLines}
+                    label={waveformOn ? "Hide audio waveform" : "Show audio waveform"}
+                    title="Audio waveform — peaks and pauses under the ruler"
+                  />
+                  <div aria-hidden="true" className="h-5 w-px shrink-0 bg-zinc-700" />
+                </>
               ) : null}
-              {flatOn ? (
-                <HeaderToggle
-                  active={waveformOn}
-                  onToggle={onWaveformToggle}
-                  icon={AudioLines}
-                  label={waveformOn ? "Hide audio waveform" : "Show audio waveform"}
-                  title="Audio waveform — peaks and pauses under the ruler"
-                />
-              ) : null}
-              <HeaderToggle
-                active={childrenShown}
-                onToggle={onChildrenToggle}
-                icon={FolderTree}
-                label={childrenShown ? "Hide children timelines" : "Show children timelines"}
-                title="Children timelines — show the nested timeline tree"
-              />
-              {/* Zoom belongs in the VIEW group: like the two toggles beside
-                  it, it qualifies what the board shows rather than changing
-                  what is in it. Strip only — see HeaderZoomControl. */}
-              {surface === "strip" ? (
-                <HeaderZoomControl
-                  pixelsPerSecond={pixelsPerSecond}
-                  onChange={onPixelsPerSecondChange}
-                />
-              ) : null}
-              <div aria-hidden="true" className="h-5 w-px shrink-0 bg-zinc-700" />
               {/* Paste used to sit here, fenced between the view group and
                   history. It is in the CENTRE now, with copy and cut — the
                   three clipboard verbs read as one group, which is worth more
                   than the container-scoped grouping it had here. This cluster
                   keeps only what qualifies the board itself. */}
               <GraphUndoRedo />
-              {/* Board options are no longer here — they render in the icon
-                  sidebar below the trash (PL14-005). Still mounted from this
-                  component so they keep these props; only the DOM address
-                  changed. */}
-              <BoardMenuSlot itemSize={itemSize} onItemSizeChange={onItemSizeChange} />
+              {/* Board options are not here — they are the last control in the
+                  board's own controls row under the divider, with the rest of
+                  the chrome that qualifies the board rather than navigates
+                  it. */}
             </DragChromeFade>
               </>
             )}
@@ -1707,6 +1701,75 @@ export function GraphBoard({
             The divider owns the clearance on BOTH of its sides now, which is
             the only way the two can be equal by construction. */}
         <div className="flex flex-col gap-2">
+          {/* THE BOARD CONTROLS ROW: what is in front of you, and the controls
+              that qualify it. Under the divider, directly above the surface it
+              describes.
+
+              Everything here came down out of the breadcrumb row, which was
+              carrying two unrelated jobs at once — WHERE AM I (the trail, the
+              save state, the selection and its verbs) and WHAT AM I LOOKING AT
+              (the totals, the filter, the tree toggle, the zoom). The second
+              job belongs next to the board, not in the navigation bar above
+              it, and splitting them is also what buys the trail the room to
+              grow: the breadcrumb row had run out of width for anything to be
+              bigger than 11px.
+
+              Deliberately NOT sticky, unlike the header. These qualify the
+              surface you are scrolled to, and the header already owns the
+              sticky budget the preview pane measures itself against.
+
+              `DragChromeFade` for the same reason the header's clusters have
+              it: while a card is in the air this is chrome in the way, and the
+              surface below is the thing that matters. It is a plain opacity
+              wrapper keyed on `isDragging`, so it carries no positioning of
+              its own and works as well here as in the header. */}
+          <DragChromeFade>
+            {/* The marker sits here rather than on DragChromeFade, which takes
+                only `className` and `children` — it is a behaviour wrapper, not
+                a div with extra steps, and widening it to pass arbitrary props
+                through would invite exactly that. */}
+            <div
+              data-board-controls-row
+              className="flex min-h-7 items-center gap-3 px-1"
+            >
+              <FocusedAggregate
+                focusedId={focusedId}
+                pixelsPerSecond={deferredPixelsPerSecond}
+              />
+              {/* Order preserved from the header cluster they came out of —
+                  filter (narrows the field) | collection (adds structure) |
+                  tree and zoom (draw what is left). Reshuffling them on the way
+                  down would have made this a second change wearing the first
+                  one's clothes. `ml-auto` rather than `justify-between` so the
+                  group still sits right when the aggregate renders nothing —
+                  an empty timeline would otherwise let it slide to the left. */}
+              <div className="ml-auto flex min-w-0 items-center gap-2">
+                <TagFilterControl />
+                <GraphAddCollectionButton />
+                <HeaderToggle
+                  active={childrenShown}
+                  onToggle={onChildrenToggle}
+                  icon={FolderTree}
+                  label={childrenShown ? "Hide children timelines" : "Show children timelines"}
+                  title="Children timelines — show the nested timeline tree"
+                />
+                {/* Strip only — there is no horizontal time axis to zoom in a
+                    grid. See HeaderZoomControl. */}
+                {surface === "strip" ? (
+                  <HeaderZoomControl
+                    pixelsPerSecond={pixelsPerSecond}
+                    onChange={onPixelsPerSecondChange}
+                  />
+                ) : null}
+                {/* LAST, at the far right of the row — the settings that
+                    outlive the session, after the controls you actually ride
+                    while working. Back from the icon rail (PL14-005); see the
+                    note where BoardMenuSlot used to be. */}
+                <BoardMenu itemSize={itemSize} onItemSizeChange={onItemSizeChange} />
+              </div>
+            </div>
+          </DragChromeFade>
+
           {/* OUTSIDE the sticky header, deliberately. It belongs to the board
               rather than the toolbar — it describes what you are looking at,
               and it is the one piece of chrome whose height varies (chips wrap

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-actions.tsx
@@ -276,11 +276,31 @@ function pasteFromClipboard(store: CollectionsStore, focusedId: string): PasteOu
 }
 
 /**
- * What happens AFTER a paste lands: select, reveal, highlight, announce.
+ * What happens AFTER a paste lands: reveal, highlight, announce — and END the
+ * gesture.
  *
- * Selecting the arrivals (R9.6) is what makes chained work natural — paste,
- * then immediately move or delete what you just pasted — and it puts the anchor
- * on the last of them, since selection order is insertion order.
+ * The paste is the LAST step of copy/cut → pick a destination → paste. Once it
+ * lands the operation is over, so nothing about the selected state may survive
+ * it: no count in the header, no ring on a card, no armed select mode. This is
+ * the one place that can say so, because it is the only step that knows the
+ * paste actually committed.
+ *
+ * This used to `setSelection(ids)` instead (R9.6), on the reasoning that
+ * selecting the arrivals makes chained work natural — paste, then immediately
+ * move or delete what you just pasted. In practice it read as a paste that had
+ * not finished: the header stayed up saying "1 selected" over the breadcrumb
+ * row, which is the selection UI advertising an operation the user had already
+ * completed. The arrivals are still made findable — the flash marks them and
+ * focus scrolls the last one into view — which is what that rule actually
+ * wanted; it does not need the selection to do it.
+ *
+ * `clearSelection` alone is not enough. This view runs the store with
+ * `keepMultiSelectModeWhenEmpty`, so clearing empties the selection and LEAVES
+ * select mode armed — checkboxes on the cards, and a "0 selected" row still
+ * sitting in the breadcrumb. Copy and Cut normally drop the mode on their way
+ * out (`handOverToDestinationPicking`), but a user who re-enters select mode
+ * before pasting would otherwise keep it, so the mode is dropped explicitly
+ * here rather than relying on how the destination was reached.
  */
 function revealPasted(
   store: CollectionsStore,
@@ -289,7 +309,8 @@ function revealPasted(
 ): void {
   const { ids, skipped, afterId } = outcome;
   if (ids.length === 0) return;
-  store.setSelection(ids);
+  store.clearSelection();
+  store.setMultiSelectMode(false);
   graphPasteFlash.flash(ids);
   // Focusing scrolls it into view, and retries until virtualization has
   // actually mounted the card — which is the case that matters, since a paste

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -269,6 +269,72 @@ export const PlaceholderAriaCountMatchesBadge: Story = {
   },
 };
 
+/**
+ * The collection mark — the Layers glyph dead centre over the frames — sits on
+ * a translucent disc.
+ *
+ * The glyph alone is white-on-whatever-the-children-happen-to-be: over a pale
+ * or busy frame its strokes break up, and the drop-shadow under it outlines
+ * them rather than giving them a ground. The disc is that ground.
+ *
+ * Asserted on COMPUTED style, not the class string. `bg-black/25` is a
+ * spelling; `rgba(0, 0, 0, 0.25)` is what the user actually sees, and the two
+ * stop agreeing the moment the utility is renamed or the token is re-themed.
+ *
+ * The alpha lives on the BACKGROUND rather than on the wrapper's `opacity`,
+ * which is why the wrapper's own opacity is pinned at 1: `opacity` there would
+ * multiply with the glyph's 0.5 and take it to an eighth, and the resulting
+ * card would look like a rendering bug rather than a mark.
+ */
+export const CollectionMarkSitsOnATranslucentDisc: Story = {
+  args: baseArgs,
+  decorators: [renderWithDetail([ASSET_A, ASSET_B])],
+  play: async ({ canvasElement }) => {
+    const mark = canvasElement.querySelector<HTMLElement>("[data-collection-mark]");
+    await expect(mark).not.toBeNull();
+
+    const disc = mark!.firstElementChild as HTMLElement | null;
+    await expect(disc).not.toBeNull();
+    await expect(disc!.querySelector("svg")).not.toBeNull();
+
+    const style = getComputedStyle(disc!);
+    // The ALPHA, parsed out of whatever colour space the toolchain serialises
+    // in — Tailwind v4 resolves this to `oklab(0 0 0 / 0.25)`, not the
+    // `rgba(0, 0, 0, 0.25)` the utility name suggests, and pinning either
+    // literal makes this story a test of the build rather than of the design.
+    // Both spellings put the alpha last, which is the part worth pinning.
+    const alpha = Number.parseFloat(/([\d.]+)\s*\)\s*$/.exec(style.backgroundColor)?.[1] ?? "1");
+    await expect(alpha).toBeCloseTo(0.25, 2);
+    await expect(style.opacity).toBe("1");
+
+    // A CIRCLE, which is a square box plus a radius — checking the radius
+    // alone would pass on a pill, and checking the box alone on a square.
+    const box = disc!.getBoundingClientRect();
+    await expect(Math.round(box.width)).toBe(Math.round(box.height));
+    await expect(style.borderRadius).not.toBe("0px");
+
+    // It has to sit OVER the frame, not beside it: the mark is positioned by
+    // the wrapper, and a disc that shrank the glyph out of the artwork would
+    // still satisfy every assertion above.
+    const frame = previewImages(canvasElement)[0]!.getBoundingClientRect();
+    await expect(box.left).toBeGreaterThanOrEqual(frame.left);
+    await expect(box.right).toBeLessThanOrEqual(frame.right);
+  },
+};
+
+/**
+ * …and NOT over the empty state, which draws its own placeholder glyph. Two
+ * glyphs stacked in the middle of one card just reads as a bug.
+ */
+export const EmptyCollectionHasNoCollectionMark: Story = {
+  args: baseArgs,
+  decorators: [renderWithDetail([])],
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelector("[data-empty-collection-preview]")).not.toBeNull();
+    await expect(canvasElement.querySelector("[data-collection-mark]")).toBeNull();
+  },
+};
+
 /** An empty or unresolved collection shows only the collection affordance;
  * no fallback copy is allowed to bleed through behind the folder glyph. */
 export const EmptyCardUsesCleanIconFallback: Story = {

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -1778,10 +1778,24 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
               aria-hidden="true"
               className="pointer-events-none absolute inset-0 z-10 grid place-items-center"
             >
-              <Layers
-                className="h-10 w-10 text-white opacity-50 drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)]"
-                strokeWidth={1.5}
-              />
+              {/* A disc behind the glyph, so the mark reads on ANY frame.
+                  The glyph alone is white-on-whatever-the-children-are: over a
+                  pale or busy frame the strokes break up, and the drop-shadow
+                  under it only outlines them rather than giving them a ground.
+                  The disc is that ground.
+
+                  Deliberately faint — `bg-black/25`. This sits over the frame
+                  that tells you WHICH collection this is, so it has to darken
+                  the picture without hiding it; anything heavier reads as a
+                  scrim over the card. It is a background-colour alpha, NOT
+                  `opacity` on the wrapper, which would take the glyph down to
+                  an eighth (0.25 × its own 0.5) along with it. */}
+              <span className="rounded-full bg-black/25 p-2">
+                <Layers
+                  className="h-10 w-10 text-white opacity-50 drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)]"
+                  strokeWidth={1.5}
+                />
+              </span>
             </span>
           ) : null}
           {previews.length === 0 ? (

--- a/apps/timeline-gstudio001/components/graph-view/graph-save-status.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-save-status.tsx
@@ -48,7 +48,10 @@ function useSaveState() {
 }
 
 /** One shape for all three states — only the words and the colour differ. */
-const STATUS_CLASS = "shrink-0 whitespace-nowrap font-mono text-[11px]";
+// 12px, up from 11px. It trails the breadcrumb and went up with it, but only
+// one step: this is a status that is usually absent and never acted on, so it
+// stays a rung BELOW the 14px trail it follows rather than competing with it.
+const STATUS_CLASS = "shrink-0 whitespace-nowrap font-mono text-xs";
 
 export function GraphSaveStatus() {
   const { pending, inFlight, lastSavedAt, error } = useSaveState();

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
@@ -102,7 +102,11 @@ function EditableCrumbName({
         onInput={rename.setDraft}
         onCommit={rename.commit}
         onCancel={rename.cancel}
-        className="h-7 min-w-0 w-full max-w-[250px] truncate rounded-md bg-zinc-800 px-1.5 font-semibold text-zinc-100 outline-none ring-1 ring-sky-500/60"
+        // h-8 to match the crumb's new line height, and the width ceilings
+        // below go up with the type: 14px text in a 250px box truncates a name
+        // that fitted at 12px, so holding the old ceiling would have traded
+        // legibility for ellipses on exactly the crumb you are reading.
+        className="h-8 min-w-0 w-full max-w-[280px] truncate rounded-md bg-zinc-800 px-1.5 font-semibold text-zinc-100 outline-none ring-1 ring-sky-500/60"
       />
     );
   }
@@ -115,7 +119,7 @@ function EditableCrumbName({
       title={`Rename ${displayName}`}
       onClick={rename.begin}
       className={cn(
-        "min-w-0 max-w-[250px] shrink cursor-text truncate rounded-md px-1.5 py-1 text-left transition-colors",
+        "min-w-0 max-w-[280px] shrink cursor-text truncate rounded-md px-1.5 py-1 text-left transition-colors",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70",
         "font-semibold text-zinc-100 hover:bg-zinc-800/70",
       )}
@@ -171,7 +175,7 @@ function AncestorCrumb({
         href={href}
         onClick={navigate}
         className={cn(
-          "block min-w-0 max-w-[180px] truncate rounded-md px-1.5 py-1 transition-colors",
+          "block min-w-0 max-w-[200px] truncate rounded-md px-1.5 py-1 transition-colors",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70",
           state === "hovered"
             ? "bg-sky-500/15 text-sky-200 underline decoration-sky-400 decoration-2 underline-offset-4"
@@ -370,10 +374,15 @@ function ParentLink({
     <Link
       href={href}
       onClick={parentId === null ? undefined : navigate}
-      className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-zinc-800 bg-zinc-950/50 text-zinc-400 transition-all hover:border-zinc-700 hover:bg-zinc-800 hover:text-zinc-100"
+      // h-8/w-8 with a 16px glyph, up from 28px/14px — the same square as
+      // every other control in this row (HeaderToggle, HEADER_SELECTION_SIZE).
+      // It was the one 28px control among 32px ones, which is why it read as
+      // slightly sunk; matching them also means the enlarged trail does NOT
+      // make the row taller, since h-8 was already setting the height.
+      className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-zinc-800 bg-zinc-950/50 text-zinc-400 transition-all hover:border-zinc-700 hover:bg-zinc-800 hover:text-zinc-100"
       title={title}
     >
-      <ArrowLeft className="h-3.5 w-3.5" />
+      <ArrowLeft className="h-4 w-4" />
     </Link>
   );
 }
@@ -460,7 +469,17 @@ export function GraphBreadcrumb({
         // Still CONTENT-WIDTH, deliberately — see the root's note. `relative`
         // is new, so the measuring ruler below positions against this box
         // instead of some ancestor.
-        className="relative flex min-w-0 items-center gap-2 overflow-hidden text-xs text-zinc-400 select-none"
+        // `text-sm` (14px), up from `text-xs`. This is the trail you read to
+        // know where you are, and at 12px in a row full of 32px icons it was
+        // the smallest thing on screen carrying the most important sentence.
+        //
+        // Set HERE, on the nav, which is what keeps the fit honest: the
+        // measuring ruler below is a child of this element, so it inherits the
+        // same size and `useFittedAncestorCount` still measures the crumbs at
+        // the width they actually render. Sizing the visible crumbs instead
+        // would have left the ruler measuring 12px text and folding a crumb
+        // too late.
+        className="relative flex min-w-0 items-center gap-2 overflow-hidden text-sm text-zinc-400 select-none"
       >
         {/* THE RULER — every crumb at its natural width, laid out but not
             painted, in the order the measure reads them:
@@ -478,7 +497,15 @@ export function GraphBreadcrumb({
         >
           {ancestors.map((ancestor) => (
             <span key={ancestor.id} className="flex shrink-0 items-center gap-2">
-              <span className="max-w-[180px] truncate">{ancestor.label}</span>
+              {/* Must mirror `AncestorCrumb`'s Link EXACTLY — same ceiling AND
+                  the same `px-1.5`. The ceiling moved to 200px with the type
+                  bump; the padding was never here, so every crumb measured
+                  12px narrower than it draws and the trail folded a crumb too
+                  LATE, overflowing its wing instead of collapsing into the
+                  "…". Invisible at 12px with short names, and progressively
+                  less so as the text grows, which is why it is fixed here
+                  rather than left for the resize to expose. */}
+              <span className="max-w-[200px] truncate px-1.5">{ancestor.label}</span>
               <span>/</span>
             </span>
           ))}

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -17,7 +17,6 @@ import { TrashDrawer } from "@/components/assets/trash-drawer";
 import { useAuth } from "@/components/auth/auth-provider";
 import {
   GRAPH_TRASH_ARRIVAL_EVENT,
-  GRAPH_BOARD_MENU_SLOT_ID,
   GRAPH_TRASH_HOVER_EVENT,
   GRAPH_VIEW_STATE_EVENT,
   isGraphViewRoute,
@@ -585,21 +584,12 @@ export function TimelineSidebar() {
           );
         })}
 
-        {/* Board options land HERE, below the trash (PL14-005), but the graph
-            renders them itself — this is only the address.
-
-            A slot rather than a control the sidebar owns, because the menu is
-            a radio group over thumbnail size plus a zoom slider: state that
-            lives in the graph's own tree. Publishing it through the window-event
-            bridge would mean mirroring two values and adding two commands, and
-            that bridge is explicitly for controls the SIDEBAR renders. A portal
-            keeps the menu inside the graph provider (real props, real Radix
-            context) while placing its trigger in the rail.
-
-            It also self-scopes: nothing portals in when the graph is not
-            mounted, so no route guard is needed and the empty div collapses to
-            nothing. */}
-        <div id={GRAPH_BOARD_MENU_SLOT_ID} className="contents" />
+        {/* The board-options slot used to sit here, below the trash
+            (PL14-005): an address the rail published for the graph to portal
+            its settings menu into. That menu is back in the board's own
+            controls row, under the divider, so the slot had nothing left to
+            receive — an empty publishing div is worse than no seam at all,
+            because the next reader has to prove nothing fills it. */}
 
         <button
           ref={buttonRef}

--- a/apps/timeline-gstudio001/lib/graph-view-events.ts
+++ b/apps/timeline-gstudio001/lib/graph-view-events.ts
@@ -88,21 +88,16 @@ export function requestGraphPreviewToggle(): void {
   window.dispatchEvent(new Event(GRAPH_PREVIEW_TOGGLE_EVENT));
 }
 
-/**
- * Where the sidebar lets the graph mount its board-options menu (PL14-005).
+/*
+ * `GRAPH_BOARD_MENU_SLOT_ID` lived here: the one seam in this file that was
+ * NOT an event — an ADDRESS the sidebar published so the graph could portal
+ * its board-options menu into the icon rail (PL14-005) without mirroring the
+ * menu's state across the bridge.
  *
- * The one seam here that is NOT an event, and deliberately so. Everything
- * above is state the SIDEBAR renders — a toggle it can draw from a boolean.
- * The board menu is a radio group plus a zoom slider whose values live in the
- * graph's own tree, so mirroring them across would mean publishing two more
- * fields and adding two commands to move them. Instead the sidebar publishes
- * an ADDRESS and the graph portals the real component into it, keeping its
- * props and its Radix context where they already work.
- *
- * The graph rendering it also scopes it for free: nothing portals in when the
- * graph is not mounted, so the slot needs no route guard.
+ * The menu is back in the board's own controls row, inside the graph
+ * providers, so nothing portals anywhere and every part of that seam is gone.
+ * Everything left in this file is what it says on the tin: events.
  */
-export const GRAPH_BOARD_MENU_SLOT_ID = "graph-board-menu-slot";
 
 /** Graph → sidebar: the current view state, for control highlighting. */
 export function broadcastGraphViewState(detail: GraphViewStateDetail): void {

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1164,33 +1164,39 @@ test.describe("graph view E2E", () => {
     await expect(bravo.locator('[data-disabled="true"]')).toBeVisible();
   });
 
-  test("board options live in the icon rail, below the trash", async ({ page }) => {
-    // PL14-005. The menu is rendered by the BOARD and portalled into a slot the
-    // rail publishes, so it keeps its real props while its trigger sits with
-    // the rail's other tiles. A null slot would fail silently — no menu, no
-    // error — which is what these assertions exist to catch.
+  test("board options are the last control in the board's controls row", async ({ page }) => {
+    // It spent a while in the icon rail below the trash (PL14-005), portalled
+    // into a slot the rail published. It is back in the board's own controls
+    // row — the row under the divider — as the RIGHTMOST control, and the
+    // portal, the slot and the published id are all gone with it.
     await installGraphApi(page);
     await openGraph(page);
 
     const trigger = page.getByRole("button", { name: "Board options" });
     await expect(trigger).toHaveCount(1);
 
-    // In the rail's slot, and no longer in the board header.
-    expect(
-      await trigger.evaluate((el) => !!el.closest("#graph-board-menu-slot")),
-    ).toBe(true);
-    await expect(
-      page.locator("header").getByRole("button", { name: "Board options" }),
-    ).toHaveCount(0);
+    // Rendered inline in the controls row — no portal, no rail.
+    const row = page.locator("[data-board-controls-row]");
+    await expect(row).toHaveCount(1);
+    expect(await trigger.evaluate((el) => !!el.closest("[data-board-controls-row]"))).toBe(true);
+    // The rail's publishing div is deleted, not merely unused. Asserted
+    // because an empty `className="contents"` div is invisible on screen and
+    // in a screenshot — the DOM is the only place its survival would show.
+    await expect(page.locator("#graph-board-menu-slot")).toHaveCount(0);
 
-    // Below the trash tile and above the account one — the position asked for.
-    const top = async (name: string) =>
-      (await page.getByRole("button", { name }).boundingBox())!.y;
-    expect(await top("Board options")).toBeGreaterThan(await top("Trash"));
-    expect(await top("Board options")).toBeLessThan(await top("Account"));
+    // RIGHTMOST: past every other control in the row, including the zoom
+    // slider, which is the one that only exists in strip mode.
+    const triggerBox = (await trigger.boundingBox())!;
+    const others = await row.locator("button, [data-header-zoom]").all();
+    for (const other of others) {
+      if (await other.evaluate((el, t) => el.contains(t), await trigger.elementHandle())) continue;
+      const box = await other.boundingBox();
+      if (box) expect(triggerBox.x).toBeGreaterThanOrEqual(box.x);
+    }
 
-    // And it still opens, with its contents intact. `side="right"` matters
-    // here: an end-aligned menu on a 72px rail would open off-screen.
+    // And it still opens, on screen. `side="bottom" align="end"` replaced the
+    // rail's `side="right"`: anchored to the right edge of a full-width row,
+    // an end-aligned drop is what keeps it inside the viewport.
     await trigger.click();
     const menu = page.getByRole("menu");
     await expect(menu).toBeVisible();
@@ -1844,10 +1850,17 @@ test.describe("graph view E2E", () => {
     await page.mouse.down();
     await page.waitForTimeout(400);
 
-    // The middle summary + right toolbar fade out under the drag readout (both
-    // DragChromeFade wrappers); the breadcrumb, the drop target, stays.
+    // THREE fades now: the header's middle cluster (selection count + verbs),
+    // the header's right toolbar, and the board controls row under the divider
+    // — every DragChromeFade wrapper. The breadcrumb is deliberately not one
+    // of them: it IS the drop target, so it has to stay legible mid-drag.
+    //
+    // Counted rather than named because the count is the invariant worth
+    // holding: a new cluster of chrome added to this view without a fade would
+    // sit there at full opacity under the drag readout, and nothing else in
+    // this suite would notice.
     const chromeFades = page.locator("[data-drag-chrome-fade]");
-    await expect(chromeFades).toHaveCount(2);
+    await expect(chromeFades).toHaveCount(3);
     for (const fade of await chromeFades.all()) {
       await expect(fade).toHaveAttribute("data-faded", "true");
     }
@@ -2302,7 +2315,9 @@ test.describe("graph view E2E", () => {
     // it — the transport overhangs far enough to crowd the preview more than
     // the timeline, and an even split read bottom-heavy.
     expect(dividerLineBox!.y + dividerLineBox!.height / 2).toBeCloseTo(dividerBox!.y + 24, 0);
-    expect(groupBox!.width).toBe(132);
+    // 5 × the 44px button well — jump-to-start, previous, play, next,
+    // jump-to-end. It was 132 (three wells) before the two edge buttons.
+    expect(groupBox!.width).toBe(220);
     expect(groupBox!.height).toBe(44);
     // Centered on the BAND, not on the box.
     expect(dividerLineBox!.y + dividerLineBox!.height / 2).toBeCloseTo(
@@ -2540,9 +2555,19 @@ test.describe("graph view E2E", () => {
       .poll(() =>
         buttonGroup.evaluate((element) => Math.round(element.getBoundingClientRect().width)),
       )
-      .toBe(132);
+      // 5 × 44px wells, up from 3 — see the static-transport test above.
+      .toBe(220);
     await expect(page.getByRole("button", { name: "Previous workbench clip" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Next workbench clip" })).toBeVisible();
+    // The whole point of this test is TOUCH reach, so the two new edge buttons
+    // have to clear the same bar as the rest — they are the outermost controls
+    // now, which is exactly where a too-tight row would clip first.
+    await expect(
+      page.getByRole("button", { name: "Jump to start of workbench preview" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Jump to end of workbench preview" }),
+    ).toBeVisible();
     await expect(page.getByTestId("workbench-preview-time")).toBeVisible();
 
     const canvas = page.getByTestId("workbench-display-canvas");
@@ -2566,13 +2591,22 @@ test.describe("graph view E2E", () => {
     );
 
     await page.getByRole("button", { name: "Play workbench preview" }).click();
+    // The SAME width while playing — this is the "stays static" half of the
+    // test: the transport must not resize or re-lay-out when playback starts.
+    // 5 × 44px wells, up from 3 with the two edge buttons.
     await expect
       .poll(() =>
         buttonGroup.evaluate((element) => Math.round(element.getBoundingClientRect().width)),
       )
-      .toBe(132);
+      .toBe(220);
     await expect(page.getByRole("button", { name: "Previous workbench clip" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Next workbench clip" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Jump to start of workbench preview" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Jump to end of workbench preview" }),
+    ).toBeVisible();
 
     await page.getByTestId("workbench-display-canvas").click({
       position: playbackCenter,
@@ -2629,7 +2663,21 @@ test.describe("graph view E2E", () => {
   }) => {
     // Narrow viewport → few responsive columns, so the 4 project clips wrap
     // onto at least two rows (needed to see the line change rows on seek).
-    await page.setViewportSize({ width: 420, height: 900 });
+    //
+    // Only the WIDTH carries that premise. The height is slack, and it used to
+    // be thinner than it looked: at 900 the hold-drag below put its drop point
+    // ~128px above the viewport bottom, which is close enough to dnd-kit's
+    // auto-scroll band that 40px of new chrome above the grid (the board
+    // controls row under the divider) took it to ~88px and the drag started
+    // landing a slot too far — 5 failures in 6 under parallel load, none with
+    // a single worker.
+    //
+    // Raised rather than worked around. Scrolling the cards away from the edge
+    // was tried first and was WORSE: centring the target pushed the source
+    // into the top band and the drag stopped resolving at all (6 in 6). Both
+    // edges auto-scroll, so a two-row drag in a short viewport has no safe
+    // scroll offset — it needs the room.
+    await page.setViewportSize({ width: 420, height: 1040 });
     await installGraphApi(page);
     await openGraph(page);
     // Switch the surface to grid, then turn Preview on.
@@ -6403,7 +6451,18 @@ test.describe("graph view E2E", () => {
     expect(order[2]).toBe("bravo");
   });
 
-  test("pasted items end up selected and briefly highlighted", async ({ page }) => {
+  test("a paste ends the gesture: arrivals are highlighted, and NOTHING stays selected", async ({
+    page,
+  }) => {
+    // The paste is the last step of copy → pick a destination → paste, so the
+    // selection UI has to go with it. It used to do the opposite and select the
+    // arrivals, which left the header sitting over the breadcrumb row saying
+    // "1 selected" after the user had already finished — the selection UI
+    // advertising an operation that was over.
+    //
+    // The arrivals still have to be FINDABLE, which is what that rule was
+    // really for, so the flash is asserted here alongside the absence: losing
+    // the selection must not cost the "here is what landed" cue.
     await installGraphApi(page);
     await openGraph(page);
     const surface = strip(page, PROJECT_ID);
@@ -6432,8 +6491,28 @@ test.describe("graph view E2E", () => {
     await expect
       .poll(() => page.evaluate(() => (window as unknown as { __flash?: number }).__flash ?? 0))
       .toBeGreaterThan(0);
-    // Selected, so the next action chains onto what was just pasted.
-    await expect(page.locator('[data-selected="true"]')).toHaveCount(1);
+
+    // No ring on any card — not the arrivals, and not the source that was
+    // selected when Copy was pressed.
+    await expect(page.locator('[data-selected="true"]')).toHaveCount(0);
+    // And no remnant in the header either. Both halves are checked because
+    // they fail independently: the count comes from the selection, while the
+    // row it sits in also survives on an armed clipboard, so a paste that
+    // cleared the selection but left the clipboard armed would still leave
+    // this cluster on screen.
+    await expect(page.locator("[data-selection-summary]")).toHaveCount(0);
+    await expect(page.locator("[data-selection-centre-controls]")).toHaveCount(0);
+    // Select mode is not merely empty, it is OFF — this view keeps the mode
+    // armed through an empty selection (`keepMultiSelectModeWhenEmpty`), so
+    // clearing alone would leave checkboxes on every card and the select-mode
+    // row in the header.
+    //
+    // Asserted POSITIVELY, on the browse value. The obvious spelling —
+    // `[data-select-mode="true"]` — is a locator that matches nothing in this
+    // app whatever the behaviour, so it would have passed against the very
+    // code this test exists to reject.
+    await expect(page.locator('[data-header-mode="browse"]')).toHaveCount(1);
+    await expect(page.locator("[data-select-mode-header]")).toHaveCount(0);
   });
 
   test("the menu is reachable and operable from the keyboard alone", async ({ page }) => {

--- a/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
+++ b/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
@@ -128,7 +128,12 @@ export const StickyPreview: Story = {
     const dividerBox = divider.getBoundingClientRect();
     const dividerLineBox = dividerLine!.getBoundingClientRect();
     expect(getComputedStyle(dividerLine!).backgroundImage).toContain("linear-gradient");
-    expect(buttonGroupBox.width).toBe(132);
+    // 5 × the 44px button well: jump-to-start, previous, play, next,
+    // jump-to-end. It was 132 (three wells) before the two edge buttons were
+    // added, and the number is pinned rather than derived because the time
+    // readout budgets its own max-width against half of it — the two have to
+    // be changed together, and a hard number is what makes that fail loudly.
+    expect(buttonGroupBox.width).toBe(220);
     expect(buttonGroupBox.height).toBe(44);
     expect(controls.querySelector("[data-transport-capsule]")).toBeNull();
     // The grip is the coarse-pointer affordance — always in the DOM, painted
@@ -159,6 +164,23 @@ export const StickyPreview: Story = {
       canvas.getByRole("button", { name: "Previous workbench clip" }),
     ).toBeVisible();
     expect(canvas.getByRole("button", { name: "Next workbench clip" })).toBeVisible();
+
+    // THE EDGE PAIR, outside the clip steppers. Order is asserted by x rather
+    // than by DOM position: what matters is that reading outward from play you
+    // get "one clip" then "all the way", and a DOM-order check would pass on a
+    // layout that visually interleaved them.
+    const jumpStart = canvas.getByRole("button", {
+      name: "Jump to start of workbench preview",
+    });
+    const jumpEnd = canvas.getByRole("button", { name: "Jump to end of workbench preview" });
+    const x = (el: HTMLElement) => el.getBoundingClientRect().x;
+    expect(x(jumpStart)).toBeLessThan(x(canvas.getByRole("button", { name: "Previous workbench clip" })));
+    expect(x(jumpEnd)).toBeGreaterThan(x(canvas.getByRole("button", { name: "Next workbench clip" })));
+    // Both live inside the button group, so the divider-drag guard on it (a
+    // transport press must never begin a resize) covers them too.
+    expect(buttonGroup!.contains(jumpStart)).toBe(true);
+    expect(buttonGroup!.contains(jumpEnd)).toBe(true);
+
     expect(canvas.getByTestId("workbench-preview-time")).toHaveTextContent("0s / 0s");
     expect(previewCanvas.getBoundingClientRect().bottom).toBeCloseTo(dividerBox.y, 0);
     expect(getComputedStyle(lowerPane).zIndex).toBe("0");

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -1,6 +1,17 @@
 "use client";
 
-import { GripHorizontal, Pause, Play, SkipBack, SkipForward, Volume2, VolumeX, X } from "lucide-react";
+import {
+  ChevronFirst,
+  ChevronLast,
+  GripHorizontal,
+  Pause,
+  Play,
+  SkipBack,
+  SkipForward,
+  Volume2,
+  VolumeX,
+  X,
+} from "lucide-react";
 import {
   useCallback,
   useEffect,
@@ -165,10 +176,16 @@ type WorkbenchDividerTransportProps = {
   canPlay: boolean;
   canSeekPrevious: boolean;
   canSeekNext: boolean;
+  /** Whether the playhead has anywhere to go at each END of the timeline —
+   *  distinct from the clip-to-clip pair above, which step between clips. */
+  canSeekStart: boolean;
+  canSeekEnd: boolean;
   previewHovered: boolean;
   onTogglePlaying: () => void;
   onSeekPrevious: () => void;
   onSeekNext: () => void;
+  onSeekStart: () => void;
+  onSeekEnd: () => void;
 };
 
 type WorkbenchAudioControlsProps = {
@@ -246,10 +263,14 @@ function WorkbenchDividerTransport({
   canPlay,
   canSeekPrevious,
   canSeekNext,
+  canSeekStart,
+  canSeekEnd,
   previewHovered,
   onTogglePlaying,
   onSeekPrevious,
   onSeekNext,
+  onSeekStart,
+  onSeekEnd,
 }: WorkbenchDividerTransportProps) {
   return (
     <div
@@ -259,8 +280,11 @@ function WorkbenchDividerTransport({
       data-testid="workbench-preview-controls"
       data-transport-layout="static"
     >
+      {/* FIVE controls now, so 13.75rem — the width is 5 × the 44px button
+          well (size-11) and has to be kept in step with the count, since the
+          time readout to the right budgets its own width against half of it. */}
       <div
-        className="pointer-events-auto absolute left-1/2 flex h-11 w-[8.25rem] items-center justify-center"
+        className="pointer-events-auto absolute left-1/2 flex h-11 w-[13.75rem] items-center justify-center"
         data-transport-button-group
         style={{ top: DIVIDER_BAND_CENTER_PX, transform: "translate(-50%, -50%)" }}
         onPointerDown={(event) => {
@@ -269,6 +293,28 @@ function WorkbenchDividerTransport({
           event.stopPropagation();
         }}
       >
+        {/* THE ENDS, outside the clip-steppers. The pairing is deliberate:
+            reading outwards from the play button you get "one clip back" then
+            "all the way back", which is the order every transport in every
+            editor uses. Putting them inside would have made the two arrow
+            pairs read as one four-way stepper.
+
+            `translate-x-3` (against the steppers' `2`) closes the gap the extra
+            well opens up, so the five glyphs still read as one cluster rather
+            than as a control with two satellites. */}
+        <button
+          type="button"
+          onClick={onSeekStart}
+          disabled={!canSeekStart}
+          className="group/start relative z-10 grid size-11 shrink-0 place-items-center text-zinc-400 transition-colors hover:text-white focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-30"
+          aria-label="Jump to start of workbench preview"
+          title="Jump to start"
+        >
+          <span className="grid size-5 translate-x-3 place-items-center rounded-full transition-colors group-focus-visible/start:ring-2 group-focus-visible/start:ring-sky-400 group-focus-visible/start:ring-offset-2 group-focus-visible/start:ring-offset-zinc-950">
+            <ChevronFirst className="size-3.5" />
+          </span>
+        </button>
+
         <button
           type="button"
           onClick={onSeekPrevious}
@@ -322,10 +368,27 @@ function WorkbenchDividerTransport({
             <SkipForward className="size-3.5 fill-current" />
           </span>
         </button>
+
+        <button
+          type="button"
+          onClick={onSeekEnd}
+          disabled={!canSeekEnd}
+          className="group/end relative z-10 grid size-11 shrink-0 place-items-center text-zinc-400 transition-colors hover:text-white focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-30"
+          aria-label="Jump to end of workbench preview"
+          title="Jump to end"
+        >
+          <span className="grid size-5 -translate-x-3 place-items-center rounded-full transition-colors group-focus-visible/end:ring-2 group-focus-visible/end:ring-sky-400 group-focus-visible/end:ring-offset-2 group-focus-visible/end:ring-offset-zinc-950">
+            <ChevronLast className="size-3.5" />
+          </span>
+        </button>
       </div>
 
       <span
-        className="absolute right-3 max-w-[calc(50%_-_5rem)] overflow-hidden text-ellipsis whitespace-nowrap rounded-full bg-zinc-900/90 px-2 py-0.5 font-mono text-[10px] text-zinc-400 shadow-sm"
+        // Budgeted against HALF the button group (now 13.75rem ⇒ 6.875rem)
+        // plus a gap, so the readout cannot slide under the outermost button.
+        // This number is not free-standing — it moves whenever the group's
+        // width does.
+        className="absolute right-3 max-w-[calc(50%_-_7.75rem)] overflow-hidden text-ellipsis whitespace-nowrap rounded-full bg-zinc-900/90 px-2 py-0.5 font-mono text-[10px] text-zinc-400 shadow-sm"
         aria-label={`Preview time ${formatSeconds(currentTime)} of ${formatSeconds(duration)}`}
         data-testid="workbench-preview-time"
         style={{ top: DIVIDER_BAND_CENTER_PX, transform: "translateY(-50%)" }}
@@ -1216,6 +1279,34 @@ export function WorkbenchDisplaySurface({
     [activeClip, activeClipIndex, currentTime, onCurrentTimeChange, renderFrameAtTime, sortedClips],
   );
 
+  /**
+   * Jump to either END of the timeline, ignoring clip boundaries.
+   *
+   * Deliberately NOT expressed as "step until you run out of clips": that
+   * lands on the last clip's START, which is not the end of the timeline, and
+   * for a long final clip is nowhere near it.
+   *
+   * `duration` is a position the renderer already produces — reaching the end
+   * during playback publishes exactly `durationRef.current` and draws that
+   * frame (see the tick loop) — so seeking there is the same state the user
+   * gets by letting it play out, not a new edge case.
+   *
+   * Same three lines as `seekToClip`, in the same order and for the same
+   * reasons: drop the playback anchor so a running preview re-times from the
+   * new position rather than snapping back, draw immediately, then publish.
+   */
+  const seekToEdge = useCallback(
+    (edge: "start" | "end") => {
+      if (sortedClips.length === 0) return;
+      const target = edge === "start" ? 0 : duration;
+      currentTimeRef.current = target;
+      playbackAnchorRef.current = null;
+      renderFrameAtTime(target, false, true);
+      onCurrentTimeChange(target);
+    },
+    [duration, onCurrentTimeChange, renderFrameAtTime, sortedClips],
+  );
+
   useEffect(() => {
     const cancelQueuedFrame = () => {
       if (animationFrameRef.current !== null) {
@@ -1342,6 +1433,12 @@ export function WorkbenchDisplaySurface({
   const canPlay = duration > 0 && sortedClips.length > 0;
   const canSeekPrevious = sortedClips.length > 0 && currentTime > 0;
   const canSeekNext = sortedClips.length > 0 && activeClipIndex < sortedClips.length - 1;
+  // The EDGE pair asks a different question from the stepper pair above:
+  // "is there anywhere left in that direction", not "is there another clip".
+  // At the last clip's start `canSeekNext` is already false while the end of
+  // the timeline is still seconds away, which is the gap these two close.
+  const canSeekStart = sortedClips.length > 0 && currentTime > 0;
+  const canSeekEnd = sortedClips.length > 0 && currentTime < duration;
 
   const isPointerOverPlaybackSurface = useCallback(
     (event: CanvasPointEvent) => {
@@ -1470,6 +1567,8 @@ export function WorkbenchDisplaySurface({
         canPlay={canPlay}
         canSeekPrevious={canSeekPrevious}
         canSeekNext={canSeekNext}
+        canSeekStart={canSeekStart}
+        canSeekEnd={canSeekEnd}
         previewHovered={canPlay && previewHovered}
         onTogglePlaying={() => {
           // This click IS the user gesture the AudioContext has been waiting
@@ -1479,6 +1578,8 @@ export function WorkbenchDisplaySurface({
         }}
         onSeekPrevious={() => seekToClip(-1)}
         onSeekNext={() => seekToClip(1)}
+        onSeekStart={() => seekToEdge("start")}
+        onSeekEnd={() => seekToEdge("end")}
       />
     </section>
   );


### PR DESCRIPTION
Six punch-list items, all in the graph view's chrome.

The breadcrumb row was carrying two unrelated jobs: **where am I** (the trail, the save state, the selection and its verbs) and **what am I looking at** (the timeline totals, the filter, the tree toggle, the zoom). The second job moves to a new row under the divider, directly above the surface it describes — which is also what buys the trail room to grow from 12px to 14px, since it had run out of width for anything to be bigger.

## The six

- **Disc behind the collection mark.** A translucent circle under the card's centre Layers glyph so it reads on a pale or busy frame. The alpha is on the *background*, not the wrapper — `opacity` there would multiply with the glyph's own 0.5 and take it to an eighth.
- **Paste ends the gesture.** `revealPasted` was calling `setSelection(ids)`, so a finished paste left the header saying "1 selected" over an operation the user had already completed. The file's own doc comment already said paste should clear the clipboard *and* selection. `clearSelection` alone isn't enough: this view runs the store with `keepMultiSelectModeWhenEmpty`, so select mode is dropped explicitly too. The arrivals stay findable via the flash and scroll-into-view, which is what selecting them was really for.
- **New board controls row.** Timeline total on the left; filter, collection tool, children toggle and (strip-only) zoom on the right. `FocusedAggregate` split in two on the way — the selection count stays in the header beside the verbs it scopes. The two were mutually exclusive only because they shared one slot.
- **Bigger breadcrumb**, 12px → 14px, with the select-mode header matched so both faces of the header stay consistent. Header height is unchanged at 57px — the 32px controls were already setting it.
- **Jump to start / end** flanking the transport. They seek to `0` and to `duration` rather than stepping to the last clip's *start*, which is not the end of the timeline. `duration` is a position the renderer already produces when playback runs out.
- **Board options back from the icon rail** to the controls row, rightmost. The portal, the rail's publishing div and `GRAPH_BOARD_MENU_SLOT_ID` are deleted rather than left pointing at each other.

## Two fixes found while measuring, neither asked for

- The breadcrumb's **measuring ruler was missing the `px-1.5`** its real crumbs carry, so every crumb measured 12px narrower than it draws and the trail folded *late* — overflowing its wing instead of collapsing into the "…". Invisible at 12px; the type bump would have exposed it.
- A comment claiming the header cluster wraps onto a second line. It has no `flex-wrap`, and must not: both header faces are pinned to one height.

## A regression this introduced, and how it was caught

The new row costs exactly **40px** above the surface, and that destabilised the grid hold-drag e2e. Measured against `main`, the drop point went from **128px of bottom clearance to 88px** — inside dnd-kit's auto-scroll band — so the card travelled one slot too far.

| same test, 6 runs, matched load | result |
|---|---|
| `main` | 6 passed |
| this branch, before the fix | **1 passed, 5 failed** |
| this branch, after | 6 passed, then 12/12 |

It passed a full 169/169 run earlier purely because suite load sits at the lucky end of that distribution. Running it in isolation under load is what exposed it.

The fix: that test's premise lives in its **width** (few columns ⇒ two grid rows); its height was slack that the new chrome consumed, so the height goes 900 → 1040. Scrolling the cards clear of the edge was tried first and was *worse* — centring the target pushed the source into the top auto-scroll band and the drag stopped resolving at all (6/6 failed). Both edges auto-scroll, so a two-row drag in a short viewport has no safe scroll offset.

## Coverage

Two stories for the disc — asserted on **computed alpha**, since Tailwind v4 serialises it as `oklab(0 0 0 / 0.25)`, not `rgba` — plus one pinning that it never appears over the empty state. The transport's edge pair is pinned by x-order in the split-pane story. The paste e2e is rewritten to assert the *absence* of every selection remnant, and asserts `[data-header-mode="browse"]` **positively**: the obvious `[data-select-mode="true"]` matches nothing in this app and would have passed against the very code it exists to reject.

## Gates

169 e2e (12/12 on the repaired hold-drag under load), 816 app tests, 195 story, 539 unit, both typechecks, lint clean.

## Known gaps

- The **filter button** is wired into the new row but was never seen rendering — `TagFilterControl` returns `null` when nothing is tagged, and no test project has tags. Its placement in the row is unverified visually.
- The 40px is a permanent cost to vertical space on short viewports. Fine on a desktop, but it's real, not a test artifact — it's what broke the drag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
