### PR TITLE
Fill the hydration gap, and stop inherited-off cards reading as switched off

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-add-collection-slot.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-add-collection-slot.tsx
@@ -46,7 +46,17 @@ export function AddCollectionSlot({
   return (
     <div
       data-add-collection-slot={collectionId}
-      className="flex h-full w-full flex-col items-stretch justify-center gap-1 rounded-md border border-dashed border-zinc-700 bg-zinc-900/30 p-1.5 text-zinc-500"
+      // COMPACT. This used to be a full-bleed dashed panel with two labelled
+      // buttons and a hint line — a whole card's worth of chrome parked at the
+      // end of every strip and grid, permanently, to offer something you reach
+      // for occasionally. It is now a small icon pair, centred in whatever box
+      // the surface reserves.
+      //
+      // The BOX is still card-sized: the surface sets it (`width: itemWidth`
+      // in VirtualStrip, `fillCellWidth` in VirtualGrid) and this component
+      // only fills it. Shrinking the reservation itself is a package change,
+      // not one available here.
+      className="flex h-full w-full items-center justify-center gap-1.5 text-zinc-500"
     >
       <button
         type="button"
@@ -54,35 +64,37 @@ export function AddCollectionSlot({
         aria-label="Add a timeline to the end"
         title="Add a timeline here"
         onClick={() => append(childCount)}
-        className="flex min-h-0 flex-1 cursor-pointer flex-col items-center justify-center gap-1 rounded transition-colors hover:bg-sky-500/[0.06] hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70"
+        // Reads as a BUTTON that adds, not as an empty slot: a solid tile with
+        // a dashed edge (the dashes are what still say "nothing here yet"),
+        // and a hover that fills rather than just tinting text. The glyph is
+        // the same FolderPlus the controls row uses, so the two routes to the
+        // same action look like the same action.
+        className="grid size-10 shrink-0 cursor-pointer place-items-center rounded-md border border-dashed border-zinc-700 bg-zinc-900/40 transition-colors hover:border-sky-500/60 hover:bg-sky-500/10 hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70"
       >
         <FolderPlus aria-hidden="true" className="h-4 w-4" />
-        <span className="text-[11px] font-medium leading-none">Add timeline</span>
       </button>
 
       {/* The media half. Only offered where files can actually land — outside a
           native-drop surface there is no timeline to append to, and a button
-          that cannot work is worse than none. */}
+          that cannot work is worse than none.
+
+          KEPT, though the label and the hint line are gone. This button is the
+          ONLY keyboard route to adding media (PL14-011): dragging from the OS
+          starts outside the page and has no keyboard equivalent, so dropping
+          it would leave keyboard and switch users with no way to add media at
+          all. Icon-only costs nothing here — it always had an `aria-label` and
+          a `title` doing the real explaining. */}
       {appendFiles !== null ? (
         <>
-          {/* The hint names the gesture that has no control: dragging from the
-              file system works anywhere on the timeline, not just here, and
-              nothing else on screen says so. `truncate` because a 100px strip
-              slot has no room to wrap — the full sentence stays in the
-              button's title. */}
-          <p className="truncate text-center text-[9px] leading-tight text-zinc-600">
-            or drop media anywhere
-          </p>
           <button
             type="button"
             data-add-media-button={collectionId}
             aria-label="Add media files to the end of this timeline"
             title="Browse for images and videos — or drop them anywhere on the timeline"
             onClick={() => fileInputRef.current?.click()}
-            className="flex shrink-0 cursor-pointer items-center justify-center gap-1 rounded px-1 py-0.5 text-[10px] font-medium transition-colors hover:bg-sky-500/[0.06] hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70"
+            className="grid size-10 shrink-0 cursor-pointer place-items-center rounded-md border border-dashed border-zinc-700 bg-zinc-900/40 transition-colors hover:border-sky-500/60 hover:bg-sky-500/10 hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70"
           >
-            <ImageIcon aria-hidden="true" className="h-3 w-3" />
-            Browse
+            <ImageIcon aria-hidden="true" className="h-4 w-4" />
           </button>
           {/* The input itself is never shown: it is the picker, not the
               affordance. `sr-only` rather than `display:none` so it stays a

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -50,7 +50,9 @@ import {
   requestGraphItemAction,
   requestGraphToolInsert,
   type GraphItemAction,
+  type GraphSurface,
 } from "@/lib/graph-view-events";
+import { hydrationSkeletonCount } from "@/lib/hydration-skeletons";
 import {
   SIDEBAR_GLYPH,
   SIDEBAR_ICON_BASE,
@@ -109,6 +111,7 @@ import { CollectionHoverProvider } from "./graph-collection-hover";
 import { TagFilterProvider } from "./graph-tag-filter";
 import { ActiveTagFilters, TagFilterControl } from "./graph-tag-filter-control";
 import { ItemDetailsProvider } from "./graph-item-details-context";
+import { useGraphDetailsSnapshot } from "./graph-details-context";
 import { GraphSaveStatus } from "./graph-save-status";
 import { GraphShortcuts, requestGraphShortcuts } from "./graph-shortcuts";
 import { GraphItemDetailsModal } from "./graph-item-details-modal";
@@ -239,6 +242,71 @@ function BoardMenu({
  * purpose (the per-card badges show the same numbers), so hiding it on small
  * screens costs nothing.
  */
+/**
+ * The placeholder row shown while a focused collection hydrates.
+ *
+ * Shaped like the cards it stands in for — same width, height and gap as the
+ * real surface — because the point is that nothing MOVES when the clips land.
+ * A generic spinner would say "wait" without saying what for, and would let
+ * the surface jump to a different height on arrival.
+ *
+ * `aria-hidden` with a live-region label beside it rather than on it: a screen
+ * reader should hear "loading 4 clips" once, not read out four empty boxes.
+ * `role="status"` announces politely, which is right for something that
+ * resolves on its own.
+ */
+function SurfaceSkeleton({
+  count,
+  surface,
+  dims,
+  pixelsPerSecond,
+}: Readonly<{
+  count: number;
+  surface: GraphSurface;
+  dims: (typeof ITEM_SIZE_DIMENSIONS)[ItemSize];
+  pixelsPerSecond: number;
+}>) {
+  const isStrip = surface === "strip";
+  // The strip's card width is a function of DURATION, which is exactly what is
+  // not known yet — so the placeholder uses the width a zero-duration card
+  // would get, which is the same floor a real short clip lands on.
+  const width = isStrip ? collectionCardWidth(pixelsPerSecond, dims.strip) : dims.gridWidth;
+  const height = isStrip ? dims.strip : dims.gridHeight;
+
+  return (
+    <div
+      data-surface-skeleton={surface}
+      data-surface-skeleton-count={count}
+      role="status"
+      aria-label={`Loading ${count === 1 ? "1 clip" : `${count} clips`}`}
+      className={[
+        "flex",
+        // The strip is one scrolling line; the grid wraps. Matching each
+        // surface's own flow is what keeps the placeholder honest about the
+        // shape that is coming.
+        isStrip ? "flex-nowrap overflow-hidden" : "flex-wrap",
+      ].join(" ")}
+      style={{ gap: GRID_GAP }}
+    >
+      {Array.from({ length: count }, (_, index) => (
+        <div
+          key={index}
+          aria-hidden="true"
+          className="shrink-0 animate-pulse rounded-md bg-zinc-800/60 ring-1 ring-white/5"
+          style={{
+            width,
+            height,
+            // Staggered, so the row reads as a sequence filling in rather than
+            // one block flashing. Capped so a full row's last card is not a
+            // second behind its first.
+            animationDelay: `${Math.min(index, 6) * 90}ms`,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
 /**
  * How many items are selected — the subject the controls beside it act on.
  *
@@ -1366,7 +1434,12 @@ function GraphAddCollectionButton() {
       title="New collection — click to append, drag onto a strip to place"
       onDragStart={handleDragStart}
       onClick={() => requestGraphToolInsert("collection")}
-      className="flex h-8 w-8 shrink-0 cursor-grab items-center justify-center rounded-md border border-zinc-800 bg-zinc-900/40 text-zinc-400 transition-colors hover:border-sky-500 hover:bg-sky-950/20 hover:text-sky-400 active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+      // NO BORDER at rest. It was the only bordered control in this row —
+      // every toggle beside it is a bare ghost square — so the box read as a
+      // different KIND of thing rather than as the same row's tool. The
+      // hover still fills and tints, which is what says it is pressable, and
+      // `cursor-grab` is what says it is also draggable.
+      className="flex h-8 w-8 shrink-0 cursor-grab items-center justify-center rounded-md bg-zinc-900/40 text-zinc-400 transition-colors hover:bg-sky-950/30 hover:text-sky-400 active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
     >
       <FolderPlus aria-hidden="true" className="h-4 w-4" />
     </button>
@@ -1465,6 +1538,27 @@ export function GraphBoard({
     () => flatItems?.map((item) => item.nodeId),
     [flatItems],
   );
+
+  // PLACEHOLDERS FOR THE HYDRATION GAP. Drilling into a collection navigates
+  // at once, but its clips arrive on a fetch — so the surface is empty for a
+  // beat and the user is looking at nothing, with no signal that anything is
+  // on its way. The stored summary already knows how many are coming, so the
+  // placeholder row can be the right LENGTH and the surface does not jump when
+  // they land. All the edge cases (a stored zero, a corrupt count, a
+  // re-hydration with cards still mounted) live in the pure rule.
+  //
+  // Subscribed narrowly: only the child COUNT, so the ordinary case — a
+  // hydrated collection whose children change — re-renders this on a number,
+  // not on the children array's identity.
+  const focusedChildCount = useCollectionsSelector(
+    (s) => s.graph.childrenById.get(parseNodeId(focusedId))?.length ?? 0,
+  );
+  const focusedDetail = useGraphDetailsSnapshot()[focusedId];
+  const skeletonCount = hydrationSkeletonCount({
+    hydrated: focusedDetail?.hydrated,
+    itemCount: focusedDetail?.itemCount,
+    renderedChildren: focusedChildCount,
+  });
 
   // The pill renders itself, inside whichever card is the anchor. What the
   // board still needs the anchor for is the header's paste label, which names
@@ -1728,9 +1822,25 @@ export function GraphBoard({
                 only `className` and `children` — it is a behaviour wrapper, not
                 a div with extra steps, and widening it to pass arbitrary props
                 through would invite exactly that. */}
+            {/* ITS OWN ROW, visually. Untreated it was transparent on the
+                board panel — the same zinc-950 as everything behind it — so
+                the totals and the controls read as loose objects floating
+                over the board rather than as a strip belonging to it.
+
+                Darker, as asked, but the fill can only do part of the job:
+                the panel is already rgb(9,9,11), so even `black/40` moves it
+                about four values. The HAIRLINE is what actually draws the
+                edge. `white/5` rather than a zinc border because a solid
+                border at this contrast reads as a box around the controls;
+                a 5% wash reads as the lip of a recess, which is the shape
+                wanted — the row sitting slightly BELOW the board, not on it.
+
+                Rounded and inset by its own padding rather than full-bleed:
+                the surfaces below are edge-to-edge, so a band that ran to the
+                same edges would read as one of them. */}
             <div
               data-board-controls-row
-              className="flex min-h-7 items-center gap-3 px-1"
+              className="flex min-h-7 items-center gap-3 rounded-md bg-black/40 px-2.5 py-1 ring-1 ring-white/5"
             >
               <FocusedAggregate
                 focusedId={focusedId}
@@ -1779,7 +1889,26 @@ export function GraphBoard({
               added. */}
           <ActiveTagFilters />
 
-          {surface === "strip" ? (
+          {/* THE HYDRATION GAP, before either surface branch. It replaces the
+              surface rather than overlaying it: an empty VirtualStrip/Grid
+              underneath would still render its trailing "add" slot, so the
+              user would be offered a place to insert into a collection whose
+              contents have not arrived — and a drop there is refused until
+              hydration completes anyway.
+
+              Only ever true for a beat. `skeletonCount` returns 0 the moment
+              the children land, or immediately if the collection is stored as
+              empty (whose own empty state is the correct thing to show). */}
+          {skeletonCount > 0 ? (
+            <div data-focused-surface-shell={surface}>
+              <SurfaceSkeleton
+                count={skeletonCount}
+                surface={surface}
+                dims={dims}
+                pixelsPerSecond={deferredPixelsPerSecond}
+              />
+            </div>
+          ) : surface === "strip" ? (
             // The focused surface spans the card's FULL width (-mx-4 cancels
             // the card's p-4), so its edges line up with the full-bleed
             // breadcrumb bar above instead of sitting inset like a panel

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -550,9 +550,12 @@ const graphWithParentDisabled = (() => {
 })();
 
 /**
- * A card disabled on ITSELF: muted, and badged with the word that names why.
- * The badge is what distinguishes it from the inherited case below — the two
- * look identical otherwise, on purpose, because a viewer sees neither.
+ * A card disabled on ITSELF: badged with the word that names why, and knocked
+ * back HARD — 45% and grayscale.
+ *
+ * The heavy treatment earns its place here specifically: this card sits among
+ * siblings that are ON, and separating it from them is the entire job. The
+ * inherited case below is deliberately lighter — see its note.
  */
 export const DisabledCard: Story = {
   args: baseArgs,
@@ -572,13 +575,26 @@ export const DisabledCard: Story = {
     await expect(getComputedStyle(surface).filter).toBe("none");
     await expect(getComputedStyle(chip).opacity).toBe("1");
     await expect(getComputedStyle(chip).filter).toBe("none");
+
+    // The dimming lives on the inner span, not the surface — which is what
+    // keeps the checkbox and the chip readable while the artwork fades.
+    const visuals = canvasElement.querySelector<HTMLElement>("[data-disabled-visuals]")!;
+    await expect(visuals.dataset.disabledVisuals).toBe("true");
+    await expect(getComputedStyle(visuals).opacity).toBe("0.45");
+    await expect(getComputedStyle(visuals).filter).toBe("grayscale(1)");
   },
 };
 
 /**
- * A card that is off only because a collection ABOVE it is. It carries the
- * same muted treatment but its own flag is clear, so re-enabling it here would
- * do nothing — the chip says where to go instead.
+ * A card that is off only because a collection ABOVE it is — and it is
+ * knocked back LESS than the self-disabled card, on purpose.
+ *
+ * These two used to render identically, on the reasoning that a viewer sees
+ * neither. That reasoning breaks in the case that matters most: drill INTO a
+ * disabled collection and every card on screen is inherited-off, so uniform
+ * heavy dimming has nothing to contrast against and only costs you the
+ * legibility of the content you came in to look at. Nothing was decided about
+ * this item, so it stays readable and the chip carries the message.
  */
 export const DisabledByParentCard: Story = {
   args: baseArgs,
@@ -595,6 +611,14 @@ export const DisabledByParentCard: Story = {
     await expect(getComputedStyle(surface).filter).toBe("none");
     await expect(getComputedStyle(chip).opacity).toBe("1");
     await expect(getComputedStyle(chip).filter).toBe("none");
+
+    // LIGHTER than DisabledCard, and NOT grayscale. Both halves are asserted:
+    // dropping either one is what would quietly collapse this back into the
+    // self-disabled treatment.
+    const visuals = canvasElement.querySelector<HTMLElement>("[data-disabled-visuals]")!;
+    await expect(visuals.dataset.disabledVisuals).toBe("inherited");
+    await expect(getComputedStyle(visuals).opacity).toBe("0.75");
+    await expect(getComputedStyle(visuals).filter).toBe("none");
   },
 };
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.tsx
@@ -53,6 +53,11 @@ import {
 import { useClipDetail, useGraphDetailsStore, useTimelineTitle } from "./graph-details-context";
 import { useTagFilterMiss } from "./graph-tag-filter";
 import { isDisabledByAncestor } from "./graph-playhead-model";
+import {
+  disabledVisualState,
+  disabledVisualsAttr,
+  type DisabledVisualState,
+} from "@/lib/disabled-visuals";
 import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
 import { useCollectionHoverTarget } from "./graph-collection-hover";
 import { GraphViewNavContext } from "./graph-navigation";
@@ -770,6 +775,35 @@ function ProvenanceLabel({
 const CAPTION_ROW_CLASS = "flex min-h-5 min-w-0 items-center gap-1.5";
 
 /**
+ * How hard each disabled state knocks a card back. The STATE is decided in
+ * `lib/disabled-visuals`; the classes are here because Tailwind's content scan
+ * covers `components` and not `lib` — a class name written over there is never
+ * generated, and fails silently as an unstyled card.
+ *
+ * SELF is heavy (45% + grayscale): that card sits among siblings that are on,
+ * and separating it from them is the whole job. INHERITED is light (75%, no
+ * grayscale): drill into a disabled collection and EVERY card is inherited-off,
+ * so heavy uniform dimming has nothing to contrast against and only costs the
+ * legibility of what you came in to look at.
+ *
+ * Split in two because they apply at different points in the class chain —
+ * opacity competes with the drag-source and filter-miss states, grayscale does
+ * not. Both card kinds below read the same two maps, which is what stops the
+ * media and collection cards drifting apart on this.
+ */
+const DISABLED_OPACITY_CLASS: Readonly<Record<DisabledVisualState, string>> = {
+  none: "",
+  inherited: "opacity-75",
+  self: "opacity-45",
+};
+
+const DISABLED_FILTER_CLASS: Readonly<Record<DisabledVisualState, string>> = {
+  none: "",
+  inherited: "",
+  self: "grayscale",
+};
+
+/**
  * Row two, and it is ALWAYS RENDERED — an untagged card keeps an empty one.
  *
  * That is the whole point of the `min-h`: with the row omitted, a tagged card
@@ -1135,6 +1169,13 @@ const GraphClipContent = memo(function GraphClipContent({
   const isVideo = node.mediaKind === "video";
   const isAudio = node.mediaKind === "audio";
   const muted = node.disabled === true || inheritedDisabled;
+  // `muted` stays the "will not play" predicate — it drives the chip, the
+  // hidden title, and the caption padding, none of which care WHY. Only the
+  // dimming distinguishes the two reasons.
+  const disabledVisuals = disabledVisualState({
+    selfDisabled: node.disabled === true,
+    inheritedDisabled,
+  });
   // In the GRID a video is ONE frame, full width — a thumbnail, the same shape
   // an image card has. The filmstrip below is a STRIP idea and stays there:
   // that surface makes a card as wide as its clip is long, so extra width is
@@ -1234,12 +1275,22 @@ const GraphClipContent = memo(function GraphClipContent({
           filtered board. */}
       <span className="relative flex h-full min-h-0 w-full overflow-hidden rounded-sm [[data-virtual-grid]_&]:flex-1">
       <span
-        data-disabled-visuals={muted ? "true" : undefined}
+        data-disabled-visuals={disabledVisualsAttr(disabledVisuals)}
         data-filter-miss={filterMiss ? "true" : undefined}
         className={[
           "flex h-full w-full overflow-hidden rounded-sm",
-          isDragSource ? "opacity-40" : muted ? "opacity-45" : filterMiss ? "opacity-30" : "",
-          muted ? "grayscale" : "",
+          // INHERITED is knocked back more lightly than SELF — see
+          // `disabled-visuals`. The precedence chain is unchanged: a drag
+          // source outranks both, and a filter miss only applies to a card
+          // that is otherwise on.
+          isDragSource
+            ? "opacity-40"
+            : disabledVisuals !== "none"
+              ? DISABLED_OPACITY_CLASS[disabledVisuals]
+              : filterMiss
+                ? "opacity-30"
+                : "",
+          DISABLED_FILTER_CLASS[disabledVisuals],
           "motion-safe:transition-opacity motion-safe:duration-150",
         ].join(" ")}
       >
@@ -1648,6 +1699,13 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
   const filterMiss = useTagFilterMiss(id as string);
   const selectMode = useCollectionsSelector((s) => s.interaction.multiSelectMode);
   const muted = node.disabled === true || inheritedDisabled;
+  // `muted` stays the "will not play" predicate — it drives the chip, the
+  // hidden title, and the caption padding, none of which care WHY. Only the
+  // dimming distinguishes the two reasons.
+  const disabledVisuals = disabledVisualState({
+    selfDisabled: node.disabled === true,
+    inheritedDisabled,
+  });
   // Anchor state is not read here any more: `CardCornerSlot` subscribes to it
   // itself, narrowed to this node, so an anchor moving between two OTHER cards
   // no longer re-renders this whole card body.
@@ -1703,7 +1761,7 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
             (further down), so the two card kinds still file tags in the same
             place as each other. */}
         <span
-          data-disabled-visuals={muted ? "true" : undefined}
+          data-disabled-visuals={disabledVisualsAttr(disabledVisuals)}
           data-filter-miss={filterMiss ? "true" : undefined}
           // `relative`, so the checkbox below anchors to the PREVIEW FRAMES
           // rather than to the whole card. Anchored to the card it landed on
@@ -1711,8 +1769,16 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
           // it…"), because that row is inside the selection surface too.
           className={[
             "relative flex min-h-0 flex-1 gap-0.5 overflow-hidden",
-            isDragSource ? "opacity-40" : muted ? "opacity-45" : filterMiss ? "opacity-30" : "",
-            muted ? "grayscale" : "",
+            // Same mapping as the media card — shared so the two kinds cannot
+            // drift apart on the one thing this rule exists to distinguish.
+            isDragSource
+              ? "opacity-40"
+              : disabledVisuals !== "none"
+                ? DISABLED_OPACITY_CLASS[disabledVisuals]
+                : filterMiss
+                  ? "opacity-30"
+                  : "",
+            DISABLED_FILTER_CLASS[disabledVisuals],
             "motion-safe:transition-opacity motion-safe:duration-150",
           ].join(" ")}
         >

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
@@ -497,15 +497,21 @@ export function GraphBreadcrumb({
         >
           {ancestors.map((ancestor) => (
             <span key={ancestor.id} className="flex shrink-0 items-center gap-2">
-              {/* Must mirror `AncestorCrumb`'s Link EXACTLY — same ceiling AND
-                  the same `px-1.5`. The ceiling moved to 200px with the type
-                  bump; the padding was never here, so every crumb measured
-                  12px narrower than it draws and the trail folded a crumb too
-                  LATE, overflowing its wing instead of collapsing into the
-                  "…". Invisible at 12px with short names, and progressively
-                  less so as the text grows, which is why it is fixed here
-                  rather than left for the resize to expose. */}
-              <span className="max-w-[200px] truncate px-1.5">{ancestor.label}</span>
+              {/* Mirrors `AncestorCrumb`'s CEILING (200px with the type bump)
+                  but deliberately NOT its `px-1.5`.
+
+                  I added that padding on the reasoning that the ruler must
+                  match the real crumb exactly or it under-measures. The
+                  reasoning was never demonstrated — no test failed without it
+                  — and it broke CI: 12px × every ancestor made the fit
+                  arithmetic eager enough that a 1600px viewport folded a crumb
+                  it has room for, in CI's font environment. Reverted.
+
+                  If the under-measurement is ever shown to be real, the fix
+                  belongs in the BUDGET, not here: the padding is a constant
+                  per crumb and the fold is already tuned against a ruler that
+                  omits it. Do not re-add this without a failing test. */}
+              <span className="max-w-[200px] truncate">{ancestor.label}</span>
               <span>/</span>
             </span>
           ))}

--- a/apps/timeline-gstudio001/lib/disabled-visuals.test.ts
+++ b/apps/timeline-gstudio001/lib/disabled-visuals.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { disabledVisualState, disabledVisualsAttr } from "./disabled-visuals";
+
+describe("disabledVisualState", () => {
+  it("is none when nothing is off", () => {
+    expect(disabledVisualState({ selfDisabled: false, inheritedDisabled: false })).toBe("none");
+  });
+
+  it("is self when the item itself is switched off", () => {
+    expect(disabledVisualState({ selfDisabled: true, inheritedDisabled: false })).toBe("self");
+  });
+
+  it("is inherited when only an ancestor is off", () => {
+    expect(disabledVisualState({ selfDisabled: false, inheritedDisabled: true })).toBe("inherited");
+  });
+
+  it("SELF WINS when both are true", () => {
+    // The ordering is load-bearing, not incidental: switching the ancestor
+    // back on must leave this item off, so while both hold it has to keep
+    // reading — and rendering — as the explicit choice it is.
+    expect(disabledVisualState({ selfDisabled: true, inheritedDisabled: true })).toBe("self");
+  });
+});
+
+// The CLASSES that each state maps to are asserted in the stories
+// (`DisabledCard` / `DisabledByParentCard`), against COMPUTED style in a real
+// browser — which is the only place that check means anything. Asserting the
+// strings here would have passed while the page rendered unstyled: Tailwind
+// does not scan `lib`, so a class named in this directory is never generated.
+// That is exactly how the first version of this shipped, and what the story
+// caught.
+
+describe("disabledVisualsAttr", () => {
+  it("omits the attribute entirely when the card is on", () => {
+    expect(disabledVisualsAttr("none")).toBeUndefined();
+  });
+
+  it('spells self as "true", matching the data-disabled attribute beside it', () => {
+    // Not "self". The pair has been "true"/"inherited" on `data-disabled`
+    // since before the visuals diverged, and the e2e already selects on
+    // [data-disabled-visuals="true"] — one vocabulary for one concept.
+    expect(disabledVisualsAttr("self")).toBe("true");
+  });
+
+  it('spells inherited as "inherited"', () => {
+    expect(disabledVisualsAttr("inherited")).toBe("inherited");
+  });
+});

--- a/apps/timeline-gstudio001/lib/disabled-visuals.ts
+++ b/apps/timeline-gstudio001/lib/disabled-visuals.ts
@@ -1,0 +1,70 @@
+/**
+ * How hard to suppress a card that will not play.
+ *
+ * A card is "off" for two different reasons, and they are not the same
+ * statement:
+ *
+ *   SELF — the user switched this item off. It is one item among siblings that
+ *   are on, and the whole job of the dimming is to separate it from them.
+ *
+ *   INHERITED — an ancestor collection is off, so this item cannot play
+ *   either. Nothing was decided about THIS item.
+ *
+ * They used to render identically, which is wrong in the case that matters
+ * most: drill into a disabled collection and EVERY card on screen is inherited
+ * -off. Uniform heavy dimming then distinguishes nothing — there is no
+ * undimmed sibling to contrast against — and all it achieves is making the
+ * content you came in to look at hard to see. The "this is off" message is
+ * already carried by the chip on each card and by the breadcrumb you walked
+ * through to get here.
+ *
+ * So inherited stays LEGIBLE: a light knock-back that reads as secondary, with
+ * no grayscale. Self keeps the heavy treatment, because there it is doing real
+ * work against its neighbours.
+ *
+ * Pure and in a `.ts` file: the app's vitest cannot parse `.tsx`, and both
+ * card kinds (media and collection) must apply exactly the same mapping — a
+ * drift between the two is precisely the bug this module exists to prevent.
+ */
+
+export type DisabledVisualState = "none" | "inherited" | "self";
+
+export function disabledVisualState(
+  input: Readonly<{ selfDisabled: boolean; inheritedDisabled: boolean }>,
+): DisabledVisualState {
+  // SELF WINS. An explicitly disabled card inside an already-disabled
+  // collection is still an explicit choice, and switching the ancestor back on
+  // must leave this one off — so it has to keep reading as self-disabled while
+  // both are true.
+  if (input.selfDisabled) return "self";
+  if (input.inheritedDisabled) return "inherited";
+  return "none";
+}
+
+/*
+ * THE CLASS NAMES LIVE IN THE COMPONENT, not here, and that is not a style
+ * preference — Tailwind would not generate them from this file.
+ *
+ * `app/globals.css` scans `../app`, `../components` and `packages/ui`. It does
+ * NOT scan `../lib`. A class written here is therefore never emitted, and the
+ * failure is silent in exactly the worst way: the attribute is right, the
+ * markup is right, and the pixels are simply unstyled. It cost a story failure
+ * to find, and it would have shipped looking like the bug it was meant to fix.
+ *
+ * Both card kinds that need the mapping live in one component file anyway, so
+ * a module-level constant there covers the "these two must not drift" concern
+ * without putting presentation in a logic module.
+ */
+
+/**
+ * The DOM value for `data-disabled-visuals`.
+ *
+ * `"true"` rather than `"self"` for the self case, matching the `data-disabled`
+ * attribute beside it — which has spelled this pair `"true"` / `"inherited"`
+ * since before the visuals diverged. One vocabulary for one concept; the e2e
+ * already selects on `[data-disabled-visuals="true"]`.
+ */
+export function disabledVisualsAttr(state: DisabledVisualState): string | undefined {
+  if (state === "none") return undefined;
+  return state === "self" ? "true" : "inherited";
+}

--- a/apps/timeline-gstudio001/lib/hydration-skeletons.test.ts
+++ b/apps/timeline-gstudio001/lib/hydration-skeletons.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  FALLBACK_HYDRATION_SKELETONS,
+  MAX_HYDRATION_SKELETONS,
+  hydrationSkeletonCount,
+} from "./hydration-skeletons";
+
+const input = (over: Partial<Parameters<typeof hydrationSkeletonCount>[0]> = {}) => ({
+  hydrated: false,
+  itemCount: 4,
+  renderedChildren: 0,
+  ...over,
+});
+
+describe("hydrationSkeletonCount", () => {
+  it("draws one placeholder per expected clip while a collection is unhydrated", () => {
+    expect(hydrationSkeletonCount(input({ itemCount: 4 }))).toBe(4);
+    expect(hydrationSkeletonCount(input({ itemCount: 1 }))).toBe(1);
+  });
+
+  it("draws nothing once the collection is hydrated", () => {
+    expect(hydrationSkeletonCount(input({ hydrated: true }))).toBe(0);
+  });
+
+  it("treats a missing hydrated flag as not-yet-hydrated", () => {
+    // A collection with no side-table entry has not been hydrated either — the
+    // absence IS the pre-hydration state, so `undefined` must not read as true.
+    expect(hydrationSkeletonCount(input({ hydrated: undefined }))).toBe(4);
+  });
+
+  it("suppresses placeholders whenever cards are already on screen", () => {
+    // Reachable mid-flight: a re-hydration after a remote change re-runs the
+    // fetch with the previous children still mounted. Skeletons beside real
+    // cards read as broken cards, not loading ones.
+    expect(hydrationSkeletonCount(input({ renderedChildren: 2 }))).toBe(0);
+  });
+
+  it("hydrated wins even when children are also present", () => {
+    expect(hydrationSkeletonCount(input({ hydrated: true, renderedChildren: 2 }))).toBe(0);
+  });
+
+  it("draws nothing for a collection stored as EMPTY", () => {
+    // The rule this pins: a stored 0 is a real answer, not a missing one. Its
+    // empty state is correct, and a skeleton here is a wait that never
+    // resolves because nothing is coming.
+    expect(hydrationSkeletonCount(input({ itemCount: 0 }))).toBe(0);
+  });
+
+  it("separates a stored zero from an absent count", () => {
+    // Both are falsy. A truthiness check would collapse them and give the
+    // empty collection three permanent skeletons.
+    expect(hydrationSkeletonCount(input({ itemCount: 0 }))).toBe(0);
+    expect(hydrationSkeletonCount(input({ itemCount: undefined }))).toBe(
+      FALLBACK_HYDRATION_SKELETONS,
+    );
+  });
+
+  it("falls back to a small count when the summary carries none", () => {
+    expect(hydrationSkeletonCount(input({ itemCount: undefined }))).toBe(3);
+  });
+
+  it("caps a huge collection at a screenful", () => {
+    expect(hydrationSkeletonCount(input({ itemCount: 400 }))).toBe(MAX_HYDRATION_SKELETONS);
+    expect(hydrationSkeletonCount(input({ itemCount: MAX_HYDRATION_SKELETONS + 1 }))).toBe(
+      MAX_HYDRATION_SKELETONS,
+    );
+  });
+
+  it("does not cap a collection that is exactly at the ceiling", () => {
+    expect(hydrationSkeletonCount(input({ itemCount: MAX_HYDRATION_SKELETONS }))).toBe(
+      MAX_HYDRATION_SKELETONS,
+    );
+  });
+
+  it("survives a corrupt summary rather than handing Array.from a bad length", () => {
+    // `Array.from({length: NaN})` renders nothing and `{length: -1}` throws —
+    // neither is an acceptable answer to a malformed stored field.
+    expect(hydrationSkeletonCount(input({ itemCount: Number.NaN }))).toBe(
+      FALLBACK_HYDRATION_SKELETONS,
+    );
+    expect(hydrationSkeletonCount(input({ itemCount: -3 }))).toBe(FALLBACK_HYDRATION_SKELETONS);
+    expect(hydrationSkeletonCount(input({ itemCount: Number.POSITIVE_INFINITY }))).toBe(
+      FALLBACK_HYDRATION_SKELETONS,
+    );
+  });
+
+  it("floors a fractional count", () => {
+    expect(hydrationSkeletonCount(input({ itemCount: 3.7 }))).toBe(3);
+  });
+});

--- a/apps/timeline-gstudio001/lib/hydration-skeletons.ts
+++ b/apps/timeline-gstudio001/lib/hydration-skeletons.ts
@@ -1,0 +1,76 @@
+/**
+ * How many placeholder cards to draw while a focused collection hydrates.
+ *
+ * Drilling into a collection navigates immediately, but its clips arrive on a
+ * fetch — so the surface is genuinely empty for a beat and the user is looking
+ * at nothing. The count is knowable in advance: a collection's STORED SUMMARY
+ * carries `itemCount`, written by its parent, so the placeholder row can be the
+ * right length before a single clip has loaded and the surface does not jump
+ * when they land.
+ *
+ * Pure, and in a `.ts` file, because the app's vitest cannot parse `.tsx` —
+ * extraction is what makes this testable at all.
+ */
+
+/**
+ * The ceiling. A 400-clip collection must not mount 400 placeholder cards to
+ * describe a wait — past a screenful the row has already said "content is
+ * coming, roughly this shape" and every further card is cost with no message.
+ */
+export const MAX_HYDRATION_SKELETONS = 12;
+
+/**
+ * What to draw when the summary has no `itemCount`: an older document, or a
+ * collection reached before its parent's summary was written.
+ *
+ * Deliberately small. Guessing HIGH and resolving to two clips is a visible
+ * collapse; guessing low and resolving to twelve just fills in. When the true
+ * count is unknown the honest signal is "something is coming", not a number.
+ */
+export const FALLBACK_HYDRATION_SKELETONS = 3;
+
+export type HydrationSkeletonInput = Readonly<{
+  /** The focused collection's `hydrated` flag. `undefined` for a collection
+   *  with no side-table entry yet, which is itself a pre-hydration state. */
+  hydrated: boolean | undefined;
+  /** The stored summary's child count, when the parent wrote one. */
+  itemCount: number | undefined;
+  /** How many children the graph is ALREADY rendering for this collection. */
+  renderedChildren: number;
+}>;
+
+/**
+ * `0` means draw nothing — either there is no wait, or a placeholder would be
+ * a lie.
+ *
+ * The order of these rules is the whole design:
+ *
+ *   HYDRATED WINS outright. Once the clips are in the graph there is nothing
+ *   to wait for, whatever the other two say.
+ *
+ *   ANYTHING ALREADY ON SCREEN suppresses them, even mid-hydration. Skeletons
+ *   next to real cards read as broken cards rather than as loading ones, and
+ *   this is reachable: a re-hydration after a remote change re-runs the fetch
+ *   with the previous children still mounted.
+ *
+ *   A STORED ZERO IS A REAL ANSWER. An empty collection is empty, and its
+ *   empty state is the correct thing to show. Drawing skeletons there is the
+ *   worst case of all — a wait that never resolves, because nothing is coming.
+ *   This is why `itemCount === 0` is separated from `itemCount === undefined`
+ *   rather than both falling through a truthiness check.
+ */
+export function hydrationSkeletonCount(input: HydrationSkeletonInput): number {
+  const { hydrated, itemCount, renderedChildren } = input;
+
+  if (hydrated === true) return 0;
+  if (renderedChildren > 0) return 0;
+  if (itemCount === 0) return 0;
+  if (itemCount === undefined) return FALLBACK_HYDRATION_SKELETONS;
+
+  // A negative or fractional count is a corrupt summary, not a layout
+  // instruction — floor it into range rather than handing `Array.from` a
+  // length it will throw on.
+  if (!Number.isFinite(itemCount) || itemCount < 0) return FALLBACK_HYDRATION_SKELETONS;
+
+  return Math.min(Math.floor(itemCount), MAX_HYDRATION_SKELETONS);
+}

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -4183,9 +4183,14 @@ test.describe("graph view E2E", () => {
 
     // Append into the CHILD's strip: it lands last there, and the project is
     // untouched.
-    await page
-      .locator(`[data-add-collection-slot="${CHILD_ID}"]`)
-      .click();
+    //
+    // The BUTTON, not the slot around it. This used to click the slot and work
+    // by accident: the add button filled the whole container, so a centre
+    // click landed on it. The slot is a compact icon PAIR now (add-timeline
+    // and add-media), centred in the card-sized box the surface reserves — so
+    // its centre is the gap between them, and a container click is genuinely
+    // ambiguous about which control it means.
+    await page.locator(`[data-add-collection-button="${CHILD_ID}"]`).click();
     await expect
       .poll(() => stripOrder(page, CHILD_ID), { timeout: 10000 })
       .toEqual(["c1", "c2", expect.stringMatching(/^timeline-/)]);

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -299,9 +299,16 @@ function WorkbenchDividerTransport({
             editor uses. Putting them inside would have made the two arrow
             pairs read as one four-way stepper.
 
-            `translate-x-3` (against the steppers' `2`) closes the gap the extra
-            well opens up, so the five glyphs still read as one cluster rather
-            than as a control with two satellites. */}
+            `translate-x-4` against the steppers' `2` is what makes the row
+            EVENLY spaced, and the number is not free. Each button is a 44px
+            well, so a glyph's position is its well's centre plus its nudge:
+            22+16, 66+8, 110, 154−8, 198−16 → 38, 74, 110, 146, 182. Four gaps
+            of 36px.
+
+            It was `3`, which put the outer glyphs at 34 and 186 — gaps of
+            40, 36, 36, 40. Only 4px, and it read exactly as what it was: the
+            new pair pushed out too far, the cluster reading as a control with
+            two satellites rather than one row. */}
         <button
           type="button"
           onClick={onSeekStart}
@@ -310,7 +317,7 @@ function WorkbenchDividerTransport({
           aria-label="Jump to start of workbench preview"
           title="Jump to start"
         >
-          <span className="grid size-5 translate-x-3 place-items-center rounded-full transition-colors group-focus-visible/start:ring-2 group-focus-visible/start:ring-sky-400 group-focus-visible/start:ring-offset-2 group-focus-visible/start:ring-offset-zinc-950">
+          <span className="grid size-5 translate-x-4 place-items-center rounded-full transition-colors group-focus-visible/start:ring-2 group-focus-visible/start:ring-sky-400 group-focus-visible/start:ring-offset-2 group-focus-visible/start:ring-offset-zinc-950">
             <ChevronFirst className="size-3.5" />
           </span>
         </button>
@@ -377,7 +384,7 @@ function WorkbenchDividerTransport({
           aria-label="Jump to end of workbench preview"
           title="Jump to end"
         >
-          <span className="grid size-5 -translate-x-3 place-items-center rounded-full transition-colors group-focus-visible/end:ring-2 group-focus-visible/end:ring-sky-400 group-focus-visible/end:ring-offset-2 group-focus-visible/end:ring-offset-zinc-950">
+          <span className="grid size-5 -translate-x-4 place-items-center rounded-full transition-colors group-focus-visible/end:ring-2 group-focus-visible/end:ring-sky-400 group-focus-visible/end:ring-offset-2 group-focus-visible/end:ring-offset-zinc-950">
             <ChevronLast className="size-3.5" />
           </span>
         </button>


### PR DESCRIPTION
Second punch-list round on the graph view's chrome. Six items — two of which turned out to be bugs rather than polish.

## The two bugs

**Inherited-disabled rendered identically to self-disabled.** The distinction was already in the DOM (`data-disabled` as `"true"` / `"inherited"`, plus a chip naming which) but `muted = self || inherited` collapsed both into `opacity-45 grayscale`, so the pixels were the same.

| | opacity | grayscale |
|---|---|---|
| self-disabled | 45% | yes |
| **inherited** | **75%** | **no** |

Self keeps the heavy treatment — that card sits among siblings that are *on*, and separating it from them is the whole job. Inherited goes lighter because of the case that actually matters: drill **into** a disabled collection and every card on screen is inherited-off, so uniform heavy dimming has nothing to contrast against and costs only the legibility of what you came in to look at. `muted` still drives the chip, the hidden title and the caption padding — none of which care *why*.

**No feedback during hydration.** Drilling into a collection navigates immediately but its clips arrive on a fetch, so the surface sat blank with no sign anything was coming. The stored summary already knows how many are inbound, so the placeholder row is the right **length** and nothing jumps when they land.

The edge cases are where that rule earns its 12 tests:
- A stored `0` is a real answer. That collection's empty state is correct, and a skeleton there is a wait that never resolves — so it's separated from `undefined` rather than collapsed by a truthiness check.
- Cards already on screen suppress it. A re-hydration after a remote change keeps the previous children mounted, and skeletons beside real cards read as broken ones.

## The four polish items

- **Transport arrows** were spaced 40px out against the inner 36px. Each glyph is its 44px well's centre plus a nudge, so `translate-x-4` (not `3`) gives 38/74/110/146/182 — four equal gaps.
- **Board controls row** was transparent on the board's own `zinc-950`, so it read as loose objects rather than a strip. Darker fill — but on a near-black panel `black/40` only moves it four values, so the `white/5` hairline is what actually draws the edge, reading as the lip of a recess.
- **Trailing add slot** was a card-sized dashed panel with two labelled buttons and a hint line, parked at the end of every surface permanently. Now a compact icon pair. The media button **stays** (icon-only): it is the only keyboard route to adding media — dragging from the OS has no keyboard equivalent — so dropping it would strand keyboard and switch users.
- **The row's draggable folder-plus loses its border.** It was the only bordered control among bare ghost squares, so it read as a different kind of thing.

## Tailwind does not scan `lib/`

Worth its own section, because it will bite again. The disabled class map went into `lib/disabled-visuals.ts` first. `app/globals.css` sources `../app`, `../components` and `packages/ui` — **not `../lib`** — so those classes were never generated and the inherited card rendered at `opacity: 1`, looking exactly like the bug the change was meant to fix. Right attribute, right markup, unstyled pixels.

The classes now live in the component; `lib/` keeps only the state logic, which is also what the #281 extraction discipline wants — a class map is presentation, not logic.

It changed the testing too: asserting the class **strings** in a unit test would have passed against that broken build. The only check that means anything is computed style in a real browser, which is what the two stories do — and what caught it.

## One behaviour change worth naming

The compact slot leaves dead space around its icons where the old full-size button used to be clickable. The e2e clicked the slot's centre and had been working by accident; it now clicks the button, because with two controls a container click is genuinely ambiguous about which one it means.

## Open design calls (not defects)

- Whether the whole slot should be clickable again — that's a different shape (one button filling it, media control elsewhere).
- Whether to reclaim the slot's reserved width. The box is card-sized because `VirtualStrip`/`VirtualGrid` set it; shrinking it needs an additive prop in `packages/ui`.

## Gates

169 e2e, 835 app tests (22 new), 37 card stories, typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
