### PR TITLE
Refuse a write that gives a collection two owning parents

### DIFF
--- a/apps/timeline-gstudio001/app/api/timelines/[id]/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/[id]/route.ts
@@ -4,6 +4,7 @@ import type { TimelineClip } from "@storyboard/timeline-model/types";
 import {
   saveFirebaseTimelineEntry,
   deleteFirebaseTimelineDocument,
+  TimelineDuplicateOwnerError,
   TimelineOrphanError,
 } from "@/lib/firebase-timeline-store";
 import { requireAuthUser } from "@/lib/firebase-auth-session";
@@ -153,6 +154,13 @@ export async function PATCH(
     if (error instanceof TimelineOrphanError) {
       return NextResponse.json(
         { error: error.message, orphans: error.orphans },
+        { status: 409 },
+      );
+    }
+    // Likewise the same shape as the batch endpoint's, for the same reason.
+    if (error instanceof TimelineDuplicateOwnerError) {
+      return NextResponse.json(
+        { error: error.message, duplicates: error.duplicates },
         { status: 409 },
       );
     }

--- a/apps/timeline-gstudio001/app/api/timelines/batch/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/batch/route.ts
@@ -5,6 +5,7 @@ import { requireAuthUser } from "@/lib/firebase-auth-session";
 import { readJsonObject } from "@/lib/read-json-body";
 import {
   saveFirebaseTimelineDocumentsAtomic,
+  TimelineDuplicateOwnerError,
   TimelineOrphanError,
   TimelineRevisionConflictError,
   type TimelineBatchWrite,
@@ -143,6 +144,16 @@ export async function POST(request: Request) {
     if (error instanceof TimelineOrphanError) {
       return NextResponse.json(
         { error: error.message, orphans: error.orphans },
+        { status: 409 },
+      );
+    }
+    // A write that would give a collection a second owning placement. 409 for
+    // the same reason as the orphan refusal beside it, and with its own array
+    // rather than `conflicts` — there is nothing to reload and retry here; the
+    // write is malformed, not stale.
+    if (error instanceof TimelineDuplicateOwnerError) {
+      return NextResponse.json(
+        { error: error.message, duplicates: error.duplicates },
         { status: 409 },
       );
     }

--- a/apps/timeline-gstudio001/app/api/timelines/timelines-batch.test.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/timelines-batch.test.ts
@@ -514,6 +514,145 @@ describe("timeline batch writes", () => {
     expect(response.status).toBe(200);
   });
 
+  // ── THE OTHER HALF OF THE INVARIANT: NO CHILD GETS TWO OWNERS ─────────────
+  //
+  // "A collection child has exactly one owning placement" was enforced in ONE
+  // direction only — the orphan guard above refuses a write that drops a
+  // child's LAST owner, and nothing refused a write that gave it a SECOND.
+  // `claimedChildren` is a Set, so two documents in one batch claiming the same
+  // child collapsed into one entry and committed silently.
+  //
+  // That is #304's failure mode at the write boundary: whatever minted the
+  // second owning placement, the store took it without a word, which is why the
+  // corruption was silent and only visible later as `buildGraph` failing with
+  // `{reason:"duplicate-id"}` — by which point every write to that subtree was
+  // blocked.
+  //
+  // BOTH DOCUMENTS KEEP A MEDIA CLIP in these, for the same reason the PATCH
+  // tests below do: an empty document would trip "Refusing to save an empty
+  // timeline" first and the test would go green on the wrong refusal.
+  function seedOwner(parentId: string, childId: string | null, revision = 1) {
+    const clips = childId === null ? [clip("keeper")] : [collectionClip(childId), clip("keeper")];
+    const document: TimelineDocument = { id: parentId, title: `Timeline ${parentId}`, clips };
+    state.docs.set(parentId, {
+      id: parentId, title: document.title, document, clips,
+      isProject: true, ownerUid: "user-a", revision,
+    });
+  }
+
+  const docWith = (id: string, clips: TimelineClip[]): TimelineDocument => ({
+    id, title: `Timeline ${id}`, clips,
+  });
+
+  it("REFUSES a batch in which two documents both OWN the same child", async () => {
+    seedOwner("parent-a", "child-1");
+    seedOwner("parent-b", null);
+    state.docs.set("child-1", {
+      id: "child-1", title: "Timeline child-1",
+      document: docWith("child-1", [clip("c0")]), clips: [clip("c0")],
+      isProject: false, ownerUid: "user-a", revision: 1,
+    });
+
+    // The move that failed to detach: parent-a still lists child-1 and
+    // parent-b has gained it.
+    const response = await batchWrite(
+      batchRequest([
+        {
+          document: docWith("parent-a", [collectionClip("child-1"), clip("keeper")]),
+          expectedRevision: 1,
+        },
+        {
+          document: docWith("parent-b", [collectionClip("child-1"), clip("keeper")]),
+          expectedRevision: 1,
+        },
+      ]),
+    );
+
+    expect(response.status).toBe(409);
+    const body = (await response.json()) as {
+      error: string;
+      duplicates?: { childId: string; timelineIds: string[] }[];
+    };
+    expect(body.error).toContain("child-1");
+    expect(body.duplicates).toEqual([
+      { childId: "child-1", timelineIds: ["parent-a", "parent-b"] },
+    ]);
+    // NOTHING committed — the whole batch is refused, so parent-b did not gain
+    // the child either.
+    expect(state.docs.get("parent-b")?.revision).toBe(1);
+    expect((state.docs.get("parent-b")?.clips as TimelineClip[]).length).toBe(1);
+  });
+
+  it("ALLOWS the same move when it DOES detach — one owner throughout", async () => {
+    seedOwner("parent-a", "child-1");
+    seedOwner("parent-b", null);
+
+    const response = await batchWrite(
+      batchRequest([
+        { document: docWith("parent-a", [clip("keeper")]), expectedRevision: 1 },
+        {
+          document: docWith("parent-b", [collectionClip("child-1"), clip("keeper")]),
+          expectedRevision: 1,
+        },
+      ]),
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  // The asymmetry the whole guard rests on: multi-parent IS legal in this
+  // model, expressed as a duplicate REFERENCE card whose clip id differs from
+  // its childTimelineId. Counting those as owners would refuse the legitimate
+  // edit this test makes.
+  it("ALLOWS a second document holding a duplicate REFERENCE to the same child", async () => {
+    seedOwner("parent-a", "child-1");
+    seedOwner("parent-b", null);
+
+    const response = await batchWrite(
+      batchRequest([
+        {
+          document: docWith("parent-a", [collectionClip("child-1"), clip("keeper")]),
+          expectedRevision: 1,
+        },
+        {
+          document: docWith("parent-b", [
+            // clip id ≠ childTimelineId → a reference, owning nothing.
+            collectionClip("child-1", "ref-clip-1"),
+            clip("keeper"),
+          ]),
+          expectedRevision: 1,
+        },
+      ]),
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it("REFUSES one document that owns the same child TWICE", async () => {
+    seedOwner("parent-a", "child-1");
+
+    const response = await batchWrite(
+      batchRequest([
+        {
+          document: docWith("parent-a", [
+            collectionClip("child-1"),
+            collectionClip("child-1"),
+            clip("keeper"),
+          ]),
+          expectedRevision: 1,
+        },
+      ]),
+    );
+
+    expect(response.status).toBe(409);
+    const body = (await response.json()) as {
+      duplicates?: { childId: string; timelineIds: string[] }[];
+    };
+    expect(body.duplicates).toEqual([
+      { childId: "child-1", timelineIds: ["parent-a", "parent-a"] },
+    ]);
+  });
+
   // ── THE SAME GUARD ON THE SINGLE-DOCUMENT PATH ────────────────────────────
   //
   // PATCH /api/timelines/[id] goes through saveFirebaseTimelineEntry, NOT the
@@ -548,6 +687,37 @@ describe("timeline batch writes", () => {
       }),
       params(id),
     );
+
+  it("PATCH REFUSES a document that owns the same child twice", async () => {
+    seedParentWithChildAndMedia("parent-1", "child-1");
+
+    const response = await patchWith("parent-1", {
+      id: "parent-1",
+      title: "Timeline parent-1",
+      clips: [collectionClip("child-1"), collectionClip("child-1"), clip("keeper")],
+    });
+
+    expect(response.status).toBe(409);
+    const body = (await response.json()) as {
+      duplicates?: { childId: string; timelineIds: string[] }[];
+    };
+    expect(body.duplicates).toEqual([
+      { childId: "child-1", timelineIds: ["parent-1", "parent-1"] },
+    ]);
+    expect(state.docs.get("parent-1")?.revision).toBe(1);
+  });
+
+  it("PATCH ALLOWS a document holding one owner and one REFERENCE to the same child", async () => {
+    seedParentWithChildAndMedia("parent-1", "child-1");
+
+    const response = await patchWith("parent-1", {
+      id: "parent-1",
+      title: "Timeline parent-1",
+      clips: [collectionClip("child-1"), collectionClip("child-1", "ref-1"), clip("keeper")],
+    });
+
+    expect(response.status).toBe(200);
+  });
 
   it("PATCH REFUSES a write that removes a collection nothing else takes up", async () => {
     seedParentWithChildAndMedia("parent-1", "child-1");

--- a/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
@@ -90,6 +90,72 @@ export class TimelineOrphanError extends Error {
   }
 }
 
+/** A child claimed as OWNED by more than one placement in a single write. */
+export type TimelineDuplicateOwner = Readonly<{
+  childId: string;
+  /** Every document in the write that claimed it, in write order. The same id
+   *  appears twice when one document owns the same child twice. */
+  timelineIds: readonly string[];
+}>;
+
+/**
+ * A write was refused because it would give one collection TWO owning
+ * placements.
+ *
+ * The other half of the invariant `TimelineOrphanError` protects. That one
+ * refuses a write that drops a child's LAST owner; this refuses one that gives
+ * it a SECOND. Only both together mean "exactly one owning placement", which is
+ * what the rest of the system assumes: two owning placements for one child make
+ * `buildGraph` fail with `{reason:"duplicate-id"}`, and every write goes
+ * through it — so once both parents are hydrated, create/rename/remove all
+ * start failing on that subtree (#304).
+ *
+ * It was missing entirely, which is why that corruption was SILENT. The store
+ * took the write without a word and the damage only surfaced later, somewhere
+ * else, as a subtree that had stopped accepting edits.
+ *
+ * SCOPE: one write. Two documents in the same batch (or one document twice) are
+ * caught, because they are both in hand and cost nothing to compare. A second
+ * owner introduced by a SEPARATE write is not — answering that needs either a
+ * reverse index or a parent pointer on the child document, and a read per
+ * claimed child on every save. Deliberately not done: a move writes both
+ * parents in one batch, so the shape #304 describes is inside this scope.
+ */
+export class TimelineDuplicateOwnerError extends Error {
+  readonly duplicates: readonly TimelineDuplicateOwner[];
+
+  constructor(duplicates: readonly TimelineDuplicateOwner[]) {
+    super(
+      `Refusing to give ${duplicates.map((duplicate) => duplicate.childId).join(", ")} ` +
+        `a second owning placement: ` +
+        duplicates
+          .map((duplicate) => `${duplicate.childId} claimed by ${duplicate.timelineIds.join(" and ")}`)
+          .join("; ") +
+        `. A collection belongs to exactly one parent; a second card pointing at it must be a ` +
+        `reference (its own clip id), not an owning placement.`,
+    );
+    this.name = "TimelineDuplicateOwnerError";
+    this.duplicates = duplicates;
+  }
+}
+
+/**
+ * The children claimed by more than one owning placement across a write.
+ *
+ * Returns one entry per over-claimed child, each listing its claimants in write
+ * order — so the error can name both parents rather than only the child, which
+ * is the difference between "something is wrong" and "here is where".
+ */
+function duplicateOwners(
+  claimantsByChild: ReadonlyMap<string, readonly string[]>,
+): TimelineDuplicateOwner[] {
+  const duplicates: TimelineDuplicateOwner[] = [];
+  for (const [childId, timelineIds] of claimantsByChild) {
+    if (timelineIds.length > 1) duplicates.push({ childId, timelineIds });
+  }
+  return duplicates;
+}
+
 export class TimelineRevisionConflictError extends Error {
   readonly conflicts: readonly TimelineRevisionConflict[];
 
@@ -599,8 +665,24 @@ export async function saveFirebaseTimelineEntry(
       // owning. That asymmetry is what makes this answerable without a reverse
       // index. With one document there is nothing else to claim what it drops,
       // so any owning child it releases is released for good.
+      // THE DUPLICATE-OWNER GUARD, applied to a batch of one — where "the
+      // batch" is this single document, so what it can catch is one document
+      // owning the same child twice. Unconditional (not inside the
+      // `existingDocument` check below): a brand-new document can arrive
+      // double-claiming just as easily as an edited one.
+      const ownedHere = owningCollectionChildIds(normalizedDocument);
+      const claimantsHere = new Map<string, readonly string[]>();
+      for (const childId of ownedHere) {
+        claimantsHere.set(childId, [
+          ...(claimantsHere.get(childId) ?? []),
+          normalizedDocument.id,
+        ]);
+      }
+      const duplicatesHere = duplicateOwners(claimantsHere);
+      if (duplicatesHere.length > 0) throw new TimelineDuplicateOwnerError(duplicatesHere);
+
       if (existingDocument) {
-        const claimed = new Set(owningCollectionChildIds(normalizedDocument));
+        const claimed = new Set(ownedHere);
         const released = owningCollectionChildIds(existingDocument).filter(
           (childId) => !claimed.has(childId),
         );
@@ -696,6 +778,11 @@ export async function saveFirebaseTimelineDocumentsAtomic(
       // sides of every document, so the guard costs no extra reads here.
       const releasedChildren = new Map<string, string>();
       const claimedChildren = new Set<string>();
+      /** Every owning claim, keyed by child — the duplicate-owner guard's
+       *  input. Separate from `claimedChildren` because that one must stay a
+       *  Set: the orphan guard asks "did anything take this up", where a
+       *  repeat is not interesting. Here the repeat IS the finding. */
+      const claimantsByChild = new Map<string, readonly string[]>();
 
       // entries() pairs each write with its own snapshot instead of indexing
       // two arrays separately — they are produced together by the Promise.all
@@ -733,6 +820,13 @@ export async function saveFirebaseTimelineDocumentsAtomic(
         // is what makes it safe to reason about from inside one batch.
         for (const childId of owningCollectionChildIds(normalizedDocument)) {
           claimedChildren.add(childId);
+          // The DUPLICATE-OWNER half of the invariant. `claimedChildren` is a
+          // Set, so two documents claiming the same child collapse into one
+          // entry there and the orphan guard is satisfied — which is exactly
+          // how a double-parented collection used to commit in silence (#304).
+          // This keeps every claimant so the write can be refused and both
+          // parents named.
+          claimantsByChild.set(childId, [...(claimantsByChild.get(childId) ?? []), normalizedDocument.id]);
         }
         if (existingDocument) {
           for (const childId of owningCollectionChildIds(existingDocument)) {
@@ -776,6 +870,19 @@ export async function saveFirebaseTimelineDocumentsAtomic(
       }
 
       if (conflicts.length > 0) throw new TimelineRevisionConflictError(conflicts);
+
+      // THE DUPLICATE-OWNER GUARD, the twin of the orphan guard below.
+      //
+      // Before the conflict check would be wrong: a stale write that happens to
+      // double-claim should come back as the conflict it is, so the client
+      // reloads and retries rather than treating a routine race as corruption.
+      // Before the ORPHAN guard is deliberate the other way — a batch that
+      // double-claims is malformed whatever else it strands, and naming the two
+      // parents is the more useful failure.
+      //
+      // Needs no reads: every claim came from a document already in this write.
+      const duplicates = duplicateOwners(claimantsByChild);
+      if (duplicates.length > 0) throw new TimelineDuplicateOwnerError(duplicates);
 
       // THE ORPHAN GUARD.
       //

--- a/apps/timeline-gstudio001/lib/mcp/apply-command.ts
+++ b/apps/timeline-gstudio001/lib/mcp/apply-command.ts
@@ -18,6 +18,7 @@ import type { TimelineDocument } from "@storyboard/timeline-model/types";
 
 import {
   saveFirebaseTimelineDocumentsAtomic,
+  TimelineDuplicateOwnerError,
   TimelineOrphanError,
   TimelineRevisionConflictError,
   type TimelineBatchWrite,
@@ -433,11 +434,30 @@ export async function applyCollectionsCommand(
     if (error instanceof TimelineAccessDeniedError) {
       return { ok: false, kind: "error", message: `Not authorized to edit timeline "${rootTimelineId}".` };
     }
-    // The store's two REFUSALS. Both are answers — the write was understood
-    // and declined — so they belong in the tool result, where the caller can
-    // read and act on them. Rethrown, they left the MCP surface with a raw
+    // The store's REFUSALS. Each is an answer — the write was understood and
+    // declined — so they belong in the tool result, where the caller can read
+    // and act on them. Rethrown, they left the MCP surface with a raw
     // exception and no explanation, which is how `move_clip` emptying its
     // source looked from the outside: not "refused because X" but a failure.
+    //
+    // This one matters most HERE. #304 was hit through these tools, and its
+    // whole character was silence: `move_clip` reported success and the damage
+    // surfaced later as a subtree that had stopped accepting edits. An agent
+    // reading this message knows immediately which child and which two parents,
+    // at the moment it happens.
+    if (error instanceof TimelineDuplicateOwnerError) {
+      const named = error.duplicates
+        .map((duplicate) => `${duplicate.childId} (claimed by ${duplicate.timelineIds.join(" and ")})`)
+        .join("; ");
+      return {
+        ok: false,
+        kind: "error",
+        message:
+          `That change would leave ${named} with two owning parents, so it was refused. ` +
+          `A collection belongs to exactly one parent — re-read the timeline and check ` +
+          `whether the move already applied before trying it again.`,
+      };
+    }
     if (error instanceof TimelineOrphanError) {
       const ids = error.orphans.map((orphan) => orphan.id).join(", ");
       return {


### PR DESCRIPTION
Relates to #304. **Deliberately does not close it** — see "What this is not" below.

## The gap

"A collection child has exactly one owning placement" (`clip.id === clip.childTimelineId`) was enforced in **one direction only**.

`owningCollectionChildIds` computes exactly the set both halves of that invariant need. Both call sites used it solely for the release side — the orphan guard, which refuses a write that drops a child's *last* owner. Nothing refused a write that gave a child a *second* owner.

In the batch path, claims were accumulated into a `Set`:

```js
for (const childId of owningCollectionChildIds(normalizedDocument)) {
  claimedChildren.add(childId);   // two documents -> one entry -> committed
}
```

That is #304's failure mode at the write boundary. Whatever minted the second owning placement, the store took it **silently**, and the damage surfaced later and elsewhere as `buildGraph` failing with `{reason:"duplicate-id"}` — at which point create/rename/remove all stop working on that subtree.

## What ships

A `TimelineDuplicateOwnerError` refusal on all three surfaces:

- **batch endpoint** — two documents in one write owning the same child, or one document owning it twice
- **PATCH `/api/timelines/[id]`** — the orphan guard's own comment already names this route as "the way around the invariant"
- **the MCP tool result** — a raw exception here would have repeated exactly the silence #304 was made of, so it lands as a readable refusal naming the child and both parents

No extra Firestore reads: every claim comes from a document already in the write.

## What this is NOT

**A root cause for #304.** Working through the graph path, it *structurally cannot* produce this shape: `nodesById` and `parentById` are Maps, so a node id is unique and appears as a child of exactly one collection — therefore `graphChildrenToClips` emits at most one owning claim per child across every document in a write. The e2e (169/169) confirms empirically that the guard never fires on normal graph writes.

So whatever corrupted the Locations tree did not come through `applyCollectionsCommand`, and #304's actual question — what mints two owning placements — is still open. The guard makes it cheaper to answer: a recurrence now produces a named error at the moment it happens, rather than silence and a broken subtree days later.

I also re-checked the other minting paths while investigating and found them sound: `cloneDocumentTree` mints fresh ids throughout, `collectionDetail` always records `sourceClipId` so references round-trip, and the trash restore path already filters on the owning rule.

## Tests

**6 new**, and the first was proven to fail before the fix — the batch committed a double-owned child with `200`.

Three of them pin the asymmetry the guard rests on, because getting this wrong would refuse legitimate edits:

- a duplicate **reference** (clip id ≠ `childTimelineId`) owns nothing and stays legal
- a move that **correctly detaches** still passes
- one document may hold both an owner and a reference to the same child

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — **918 passed** (was 912)
- `npm run lint` — clean, the same 5 pre-existing `<img>` warnings
- `npx playwright test --project=graph-view` — **169/169 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)