### PR TITLE
Add the render seam and its transport (#310, phase 1)

### DIFF
--- a/apps/timeline-gstudio001/app/api/renders/[id]/report/route.ts
+++ b/apps/timeline-gstudio001/app/api/renders/[id]/report/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from "next/server";
+
+import { readJsonObject } from "@/lib/read-json-body";
+import { reportRenderProgress } from "@/lib/render/job-store";
+import { authenticateWorker } from "@/lib/render/worker-request";
+import type { RenderEvent } from "@/lib/render/job-state";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/** Parse the worker's report into an event, or null if it is not one.
+ *  Validated HERE rather than trusted: this is a machine endpoint, and the
+ *  state machine's rules are only as good as what reaches them. */
+function parseEvent(body: Record<string, unknown> | null): RenderEvent | null {
+  const type = typeof body?.type === "string" ? body.type : "";
+  switch (type) {
+    case "start":
+      return { type: "start" };
+    case "progress": {
+      const fraction = typeof body?.fraction === "number" ? body.fraction : Number.NaN;
+      const message = typeof body?.message === "string" ? body.message : undefined;
+      return { type: "progress", fraction, ...(message === undefined ? {} : { message }) };
+    }
+    case "succeed": {
+      const outputUrl = typeof body?.outputUrl === "string" ? body.outputUrl : "";
+      // A success with no file is not a success — refuse it as malformed
+      // rather than storing a succeeded job nobody can open.
+      return outputUrl.length === 0 ? null : { type: "succeed", outputUrl };
+    }
+    case "fail": {
+      const message = typeof body?.message === "string" ? body.message : "";
+      return { type: "fail", message: message.slice(0, 500) || "The render failed." };
+    }
+    default:
+      return null;
+  }
+}
+
+const STATUS_BY_REASON: Readonly<Record<string, number>> = {
+  "not-found": 404,
+  // Someone else holds this job. 409 rather than 403: the credential was
+  // fine, the claim is what is wrong.
+  "not-holder": 409,
+  terminal: 409,
+  "out-of-order": 409,
+  invalid: 400,
+};
+
+/**
+ * A worker reports on the job it holds.
+ *
+ * Every rule that decides whether a report is legal lives in
+ * `lib/render/job-state` and is unit-tested there — this route validates the
+ * shape and hands over. The rules matter because the worker is a separate
+ * process: it can crash and come back, retry a report whose response timed
+ * out, or be a stale instance reporting over a render it no longer owns.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = authenticateWorker(request);
+  if (!auth.ok) return NextResponse.json({ error: auth.error }, { status: auth.status });
+
+  const { id } = await params;
+  const event = parseEvent(await readJsonObject(request));
+  if (event === null) {
+    return NextResponse.json({ error: "Unrecognised render report." }, { status: 400 });
+  }
+
+  try {
+    const result = await reportRenderProgress(
+      id,
+      auth.workerId,
+      event,
+      new Date().toISOString(),
+    );
+    if (!result.ok) {
+      return NextResponse.json(
+        { error: result.reason },
+        { status: STATUS_BY_REASON[result.reason] ?? 409 },
+      );
+    }
+    return NextResponse.json({ id, state: result.job.progress.state });
+  } catch (error) {
+    console.error("[GSTUDIO_RENDER_REPORT_ERROR]", error);
+    return NextResponse.json({ error: "Unable to record the report." }, { status: 500 });
+  }
+}

--- a/apps/timeline-gstudio001/app/api/renders/[id]/route.ts
+++ b/apps/timeline-gstudio001/app/api/renders/[id]/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+
+import { requireAuthUser } from "@/lib/firebase-auth-session";
+import { readRenderJob } from "@/lib/render/job-store";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * Where a render got to — what the app watches while it waits.
+ *
+ * Scoped to the requester: a render is addressed by an unguessable id, but
+ * "unguessable" is not an access rule, and the job carries the timeline it was
+ * compiled from. A plain 404 for someone else's, so ids cannot be probed.
+ *
+ * The CUT LIST is deliberately not returned. It is large, it is the worker's
+ * business, and the app only needs to know where the render is and where the
+ * file landed.
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { user, response } = await requireAuthUser();
+  if (response || !user) {
+    return response || NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+  try {
+    const job = await readRenderJob(id);
+    if (!job || job.requestedBy !== user.uid) {
+      return NextResponse.json({ error: "Render was not found." }, { status: 404 });
+    }
+    return NextResponse.json({
+      id: job.id,
+      timelineId: job.timelineId,
+      projectRevision: job.projectRevision,
+      providerId: job.providerId,
+      createdAt: job.createdAt,
+      updatedAt: job.updatedAt,
+      durationSeconds: job.cutList.durationSeconds,
+      cutCount: job.cutList.cuts.length,
+      ...job.progress,
+    });
+  } catch (error) {
+    console.error("[GSTUDIO_RENDER_READ_ERROR]", error);
+    return NextResponse.json({ error: "Unable to read the render." }, { status: 500 });
+  }
+}

--- a/apps/timeline-gstudio001/app/api/renders/claim/route.ts
+++ b/apps/timeline-gstudio001/app/api/renders/claim/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+
+import { readJsonObject } from "@/lib/read-json-body";
+import { claimNextRenderJob } from "@/lib/render/job-store";
+import { renderProviders } from "@/lib/render/registry";
+import { authenticateWorker } from "@/lib/render/worker-request";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * A worker asks for work.
+ *
+ * POLLING, not pushing, because the first provider is a machine behind NAT
+ * with no address the app can reach. That shape is not a concession — it is
+ * what makes the local renderer and a hosted one the same kind of thing, and a
+ * hosted worker is free to poll this too.
+ *
+ * 204 for "nothing queued" rather than 200 with a null body: the worker loop
+ * checks a status code far more often than it gets a job, and an empty answer
+ * should not have to be parsed to be understood.
+ */
+export async function POST(request: Request) {
+  const auth = authenticateWorker(request);
+  if (!auth.ok) return NextResponse.json({ error: auth.error }, { status: auth.status });
+
+  const body = await readJsonObject(request);
+  const providerId =
+    typeof body?.providerId === "string"
+      ? body.providerId
+      : renderProviders.defaultProvider()?.id;
+  if (providerId === undefined || renderProviders.get(providerId) === undefined) {
+    return NextResponse.json({ error: "Unknown render provider." }, { status: 400 });
+  }
+
+  try {
+    const job = await claimNextRenderJob(providerId, auth.workerId, new Date().toISOString());
+    if (job === null) return new NextResponse(null, { status: 204 });
+
+    // The cut list is the whole payload: resolved source URLs and absolute
+    // output positions. The worker needs nothing else and is given nothing
+    // else — it never sees the timeline, only the film to assemble.
+    return NextResponse.json({
+      id: job.id,
+      timelineId: job.timelineId,
+      projectRevision: job.projectRevision,
+      cutList: job.cutList,
+    });
+  } catch (error) {
+    console.error("[GSTUDIO_RENDER_CLAIM_ERROR]", error);
+    return NextResponse.json({ error: "Unable to claim a render." }, { status: 500 });
+  }
+}

--- a/apps/timeline-gstudio001/app/api/renders/route.ts
+++ b/apps/timeline-gstudio001/app/api/renders/route.ts
@@ -1,0 +1,114 @@
+import { NextResponse } from "next/server";
+
+import { requireAuthUser } from "@/lib/firebase-auth-session";
+import { readJsonObject } from "@/lib/read-json-body";
+import { compileTimelineManifest } from "@/lib/compile-timeline-manifest";
+import { checkUserScopedId, TimelineAccessDeniedError } from "@/lib/timeline-ownership";
+import { TimelineClosureTooLargeError } from "@/lib/load-timeline-closure";
+import { compileCutList, DEFAULT_RENDER_FORMAT } from "@/lib/render/cut-list";
+import { createRenderJob } from "@/lib/render/job-store";
+import { renderProviders } from "@/lib/render/registry";
+import type { RenderJob } from "@/lib/render/types";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function isValidTimelineId(id: string) {
+  return /^[a-zA-Z0-9_-]+$/.test(id);
+}
+
+function mintRenderId(): string {
+  return `render-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Submit a render: compile the timeline to a cut list, queue it, and tell the
+ * provider there is work.
+ *
+ * THE JOB IS COMPILED HERE, not by the worker. The worker gets resolved source
+ * URLs and absolute output positions and does no timeline arithmetic — which
+ * is what lets a third-party renderer be a thing that runs ffmpeg rather than
+ * a thing that understands this app's model. It also means a queued job is a
+ * snapshot: editing the timeline afterwards does not change what renders, and
+ * `projectRevision` records which version it was.
+ *
+ * The job document is created BEFORE dispatch. A provider that throws leaves a
+ * job that is still claimable, which is the recoverable direction; dispatching
+ * first could start work no document is waiting for.
+ */
+export async function POST(request: Request) {
+  try {
+    const { user, response } = await requireAuthUser();
+    if (response || !user) {
+      return response || NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await readJsonObject(request);
+    const timelineId = typeof body?.timelineId === "string" ? body.timelineId : "";
+    if (!isValidTimelineId(timelineId)) {
+      return NextResponse.json({ error: "Invalid timeline id." }, { status: 400 });
+    }
+    if (checkUserScopedId(timelineId, user.uid) === false) {
+      return NextResponse.json({ error: "Timeline was not found." }, { status: 404 });
+    }
+
+    const providerId =
+      typeof body?.providerId === "string" ? body.providerId : renderProviders.defaultProvider()?.id;
+    const provider = providerId === undefined ? undefined : renderProviders.get(providerId);
+    if (!provider) {
+      // No renderer configured at all, or one named that does not exist. 503
+      // rather than 400 for the former: the request is fine.
+      return NextResponse.json({ error: "No render provider is available." }, { status: 503 });
+    }
+
+    const compiled = await compileTimelineManifest(timelineId, user.uid);
+    if (!compiled) {
+      return NextResponse.json({ error: "Timeline was not found." }, { status: 404 });
+    }
+
+    const cutList = compileCutList(compiled.manifest, DEFAULT_RENDER_FORMAT);
+    if (cutList.cuts.length === 0) {
+      // Nothing enabled to render. A refusal rather than an empty file: an
+      // export that silently produced zero seconds would look like a failure
+      // of the renderer rather than of the edit.
+      return NextResponse.json(
+        { error: "Nothing to render — every clip is disabled or the timeline is empty." },
+        { status: 400 },
+      );
+    }
+
+    const job: RenderJob = {
+      id: mintRenderId(),
+      timelineId,
+      projectRevision: compiled.manifest.projectRevision,
+      cutList,
+      requestedBy: user.uid,
+      createdAt: new Date().toISOString(),
+    };
+    const stored = await createRenderJob(job, provider.id);
+    await provider.dispatch({ uid: user.uid }, job);
+
+    return NextResponse.json(
+      {
+        id: stored.id,
+        state: stored.progress.state,
+        providerId: provider.id,
+        durationSeconds: cutList.durationSeconds,
+        cutCount: cutList.cuts.length,
+        // Reported so a caller can see what was left out without re-reading
+        // the closure — a render missing a branch should not be a surprise.
+        missing: compiled.missing,
+      },
+      { status: 202 },
+    );
+  } catch (error) {
+    if (error instanceof TimelineAccessDeniedError) {
+      return NextResponse.json({ error: "Timeline was not found." }, { status: 404 });
+    }
+    if (error instanceof TimelineClosureTooLargeError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
+    console.error("[GSTUDIO_RENDER_SUBMIT_ERROR]", error);
+    return NextResponse.json({ error: "Unable to submit the render." }, { status: 500 });
+  }
+}

--- a/apps/timeline-gstudio001/app/api/timelines/[id]/preview-manifest/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/[id]/preview-manifest/route.ts
@@ -1,13 +1,8 @@
 import { NextResponse } from "next/server";
 
-import { compilePlaybackManifest } from "@storyboard/timeline-domain";
-import { deriveClosureSummaries } from "@/lib/derive-collection-summaries";
+import { compileTimelineManifest } from "@/lib/compile-timeline-manifest";
 import { requireAuthUser } from "@/lib/firebase-auth-session";
-import { readStoredTimelineEntry } from "@/lib/firebase-timeline-store";
-import {
-  loadTimelineClosure,
-  TimelineClosureTooLargeError,
-} from "@/lib/load-timeline-closure";
+import { TimelineClosureTooLargeError } from "@/lib/load-timeline-closure";
 import { checkUserScopedId, TimelineAccessDeniedError } from "@/lib/timeline-ownership";
 
 export const runtime = "nodejs";
@@ -41,35 +36,15 @@ export async function GET(
       return NextResponse.json({ error: "Timeline was not found." }, { status: 404 });
     }
 
-    const entry = await readStoredTimelineEntry(id, user.uid);
-    if (!entry) {
+    // Shared with the render-submit route — see compileTimelineManifest for
+    // why the stale-summary repair inside it must not be reimplemented by a
+    // second caller. Null means the timeline is not there (this read IS this
+    // route's 404 check).
+    const compiled = await compileTimelineManifest(id, user.uid);
+    if (!compiled) {
       return NextResponse.json({ error: "Timeline was not found." }, { status: 404 });
     }
-
-    // The root was just read above (that read IS this route's 404 check), so
-    // hand it straight to the walker rather than making it fetch the same
-    // document again and then overwriting the result.
-    const { documents, missing, revisions } = await loadTimelineClosure(id, user.uid, {
-      rootEntry: entry,
-    });
-
-    // Stored collection summaries go stale by design: the graph view's
-    // writes are patch-scoped, so editing a child never rewrites the
-    // parents that reference it. Every other read path repairs that at read
-    // time (serveTimelineDocument); compiling from the raw closure made this
-    // route the one reader that did not, so the preview both reported a
-    // different total than the board and windowed a grown child's newest
-    // clips out of playback entirely.
-    const summarized = deriveClosureSummaries(documents, new Set(missing));
-
-    const manifest = compilePlaybackManifest(
-      summarized,
-      id,
-      entry.revision,
-      new Date().toISOString(),
-      revisions,
-    );
-    return NextResponse.json({ manifest, missing });
+    return NextResponse.json({ manifest: compiled.manifest, missing: compiled.missing });
   } catch (error) {
     // Someone else's document: a plain not-found, so timeline ids can't be
     // probed for existence.

--- a/apps/timeline-gstudio001/lib/bearer-token.ts
+++ b/apps/timeline-gstudio001/lib/bearer-token.ts
@@ -1,0 +1,38 @@
+import { timingSafeEqual } from "node:crypto";
+
+/**
+ * Constant-time Bearer token check for MACHINE callers — the cron sweep and
+ * the render worker.
+ *
+ * Extracted when the render worker became the second caller. It is four lines,
+ * and four lines of security primitive copied twice is exactly the shape that
+ * drifts: one copy grows a `!==` fast path, or forgets the length check that
+ * makes `timingSafeEqual` safe to call at all (it throws on a length
+ * mismatch), and nothing fails visibly.
+ *
+ * `left.length === right.length &&` is load-bearing for that reason, and it
+ * also means length is NOT protected — comparing a 10-byte guess against a
+ * 40-byte secret returns immediately. That is the standard trade and it is
+ * fine: the secret's length is not the secret.
+ */
+export function bearerTokenMatches(header: string | null, secret: string): boolean {
+  const presented = header?.startsWith("Bearer ") === true ? header.slice(7) : "";
+  const left = Buffer.from(presented);
+  const right = Buffer.from(secret);
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+/**
+ * A configured secret, or null.
+ *
+ * Null must mean REFUSE, never "allow anyone" — these endpoints delete files
+ * and start renders. Callers return 503 rather than 401 for it, because an
+ * unconfigured deployment is a deployment problem, not a bad credential.
+ *
+ * An empty string counts as unset: a secret set to "" in an env file is a
+ * mistake, and treating it as a valid credential would make `Bearer ` (with
+ * nothing after it) authenticate.
+ */
+export function configuredSecret(value: string | undefined): string | null {
+  return value === undefined || value.length === 0 ? null : value;
+}

--- a/apps/timeline-gstudio001/lib/compile-timeline-manifest.ts
+++ b/apps/timeline-gstudio001/lib/compile-timeline-manifest.ts
@@ -1,0 +1,47 @@
+import "server-only";
+
+import { compilePlaybackManifest, type PlaybackManifest } from "@storyboard/timeline-domain";
+
+import { deriveClosureSummaries } from "./derive-collection-summaries";
+import { readStoredTimelineEntry } from "./firebase-timeline-store";
+import { loadTimelineClosure } from "./load-timeline-closure";
+
+/**
+ * Compile a timeline's playback manifest from STORED documents.
+ *
+ * Extracted when export became the second caller. The preview route had this
+ * as four steps in sequence, and the third one is the trap: stored collection
+ * summaries go stale BY DESIGN, because the graph view's writes are
+ * patch-scoped and editing a child never rewrites the parents referencing it.
+ * Every read path repairs that at read time; the preview route once did not,
+ * and reported a different total than the board while windowing a grown
+ * child's newest clips out of playback entirely.
+ *
+ * A second caller copying three of the four steps would have reproduced
+ * exactly that bug in export — where it would have been worse, because a wrong
+ * manifest there is a wrong FILE rather than a wrong preview.
+ */
+export async function compileTimelineManifest(
+  timelineId: string,
+  uid: string,
+): Promise<Readonly<{ manifest: PlaybackManifest; missing: readonly string[] }> | null> {
+  const entry = await readStoredTimelineEntry(timelineId, uid);
+  if (!entry) return null;
+
+  // The root was just read, so hand it to the walker rather than making it
+  // fetch the same document again.
+  const { documents, missing, revisions } = await loadTimelineClosure(timelineId, uid, {
+    rootEntry: entry,
+  });
+
+  const summarized = deriveClosureSummaries(documents, new Set(missing));
+
+  const manifest = compilePlaybackManifest(
+    summarized,
+    timelineId,
+    entry.revision,
+    new Date().toISOString(),
+    revisions,
+  );
+  return { manifest, missing };
+}

--- a/apps/timeline-gstudio001/lib/render/cut-list.test.ts
+++ b/apps/timeline-gstudio001/lib/render/cut-list.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+
+import type { PlaybackLeaf, PlaybackManifest } from "@storyboard/timeline-domain";
+
+import { DEFAULT_RENDER_FORMAT, compileCutList } from "./cut-list";
+
+// The board's spacing, baked into every stored startTime. The whole point of
+// the compiler is that this never reaches the output.
+const GAP = 0.12;
+
+function leaf(over: Partial<PlaybackLeaf> & { id: string }): PlaybackLeaf {
+  return {
+    collectionPath: ["root"],
+    kind: "video",
+    src: `https://cdn.test/${over.id}.mp4`,
+    timelineStart: 0,
+    timelineDuration: 4,
+    sourceStart: 0,
+    playbackRate: 1,
+    ...over,
+  };
+}
+
+/** Leaves laid out the way the board lays them: each after the last, plus a gap. */
+function packed(leaves: (Partial<PlaybackLeaf> & { id: string })[]): PlaybackLeaf[] {
+  let start = 0;
+  return leaves.map((spec) => {
+    const built = leaf({ ...spec, timelineStart: start });
+    start += built.timelineDuration + GAP;
+    return built;
+  });
+}
+
+function manifestOf(leaves: readonly PlaybackLeaf[]): PlaybackManifest {
+  const durationSeconds = leaves.reduce(
+    (total, l) => Math.max(total, l.timelineStart + l.timelineDuration),
+    0,
+  );
+  return {
+    projectId: "project-1",
+    projectRevision: 3,
+    durationSeconds,
+    leaves,
+    compiledAt: "2026-08-14T00:00:00.000Z",
+  };
+}
+
+describe("compileCutList", () => {
+  it("is empty for an empty timeline", () => {
+    const list = compileCutList(manifestOf([]));
+    expect(list.cuts).toEqual([]);
+    expect(list.durationSeconds).toBe(0);
+  });
+
+  it("CLOSES THE GAPS — cuts touch, and the output is shorter than the board", () => {
+    const manifest = manifestOf(packed([{ id: "a" }, { id: "b" }, { id: "c" }]));
+    // The board spans 3 clips + 2 gaps; a naive export would carry both gaps.
+    expect(manifest.durationSeconds).toBeCloseTo(12 + GAP * 2, 6);
+
+    const list = compileCutList(manifest);
+    expect(list.cuts.map((cut) => cut.outputStart)).toEqual([0, 4, 8]);
+    expect(list.durationSeconds).toBe(12);
+  });
+
+  it("DROPS DISABLED LEAVES and closes the hole they leave", () => {
+    const manifest = manifestOf(
+      packed([{ id: "a" }, { id: "b", disabled: true }, { id: "c" }]),
+    );
+
+    const list = compileCutList(manifest);
+    expect(list.cuts.map((cut) => cut.src)).toEqual([
+      "https://cdn.test/a.mp4",
+      "https://cdn.test/c.mp4",
+    ]);
+    // c follows a immediately — no silence where b was.
+    expect(list.cuts.map((cut) => cut.outputStart)).toEqual([0, 4]);
+    expect(list.durationSeconds).toBe(8);
+  });
+
+  it("drops a leaf disabled by an ANCESTOR collection the same way", () => {
+    // The manifest sets `disabled` on the leaf whether the leaf's own clip or
+    // a collection above it was switched off, so the compiler needs no second
+    // rule for the inherited case.
+    const manifest = manifestOf(packed([{ id: "a", disabled: true }, { id: "b" }]));
+    const list = compileCutList(manifest);
+    expect(list.cuts.map((cut) => cut.src)).toEqual(["https://cdn.test/b.mp4"]);
+    expect(list.cuts[0]?.outputStart).toBe(0);
+  });
+
+  it("is empty when everything is disabled, rather than emitting black", () => {
+    const manifest = manifestOf(packed([{ id: "a", disabled: true }, { id: "b", disabled: true }]));
+    const list = compileCutList(manifest);
+    expect(list.cuts).toEqual([]);
+    expect(list.durationSeconds).toBe(0);
+  });
+
+  it("carries the source in-point and rate a trimmed, scaled leaf resolved to", () => {
+    const manifest = manifestOf([
+      leaf({ id: "a", timelineStart: 0, timelineDuration: 2, sourceStart: 4.2, playbackRate: 2 }),
+    ]);
+    const list = compileCutList(manifest);
+    expect(list.cuts[0]).toMatchObject({
+      sourceStart: 4.2,
+      playbackRate: 2,
+      outputDuration: 2,
+      outputStart: 0,
+    });
+  });
+
+  it("normalises an image's source timing rather than making the worker know", () => {
+    // An image has no source timeline to seek into or play at a rate.
+    const manifest = manifestOf([
+      leaf({
+        id: "still",
+        kind: "image",
+        src: "https://cdn.test/still.png",
+        sourceStart: 9,
+        playbackRate: 3,
+      }),
+    ]);
+    const list = compileCutList(manifest);
+    expect(list.cuts[0]).toMatchObject({ kind: "image", sourceStart: 0, playbackRate: 1 });
+  });
+
+  it("keeps audio as an ordinary cut — phase 1 is a sequence", () => {
+    // Layered audio is not expressible in the stored model yet (trackIndex is
+    // always 0), so an audio leaf occupies its own slot like anything else.
+    // Pinned so that changing it is a decision rather than a surprise.
+    const manifest = manifestOf(
+      packed([{ id: "vo", kind: "audio", src: "https://cdn.test/vo.wav" }, { id: "b" }]),
+    );
+    const list = compileCutList(manifest);
+    expect(list.cuts.map((cut) => cut.kind)).toEqual(["audio", "video"]);
+    expect(list.cuts.map((cut) => cut.outputStart)).toEqual([0, 4]);
+  });
+
+  it("orders by TIME, not by array position", () => {
+    const manifest = manifestOf([
+      leaf({ id: "late", timelineStart: 10, timelineDuration: 2 }),
+      leaf({ id: "early", timelineStart: 0, timelineDuration: 2 }),
+    ]);
+    const list = compileCutList(manifest);
+    expect(list.cuts.map((cut) => cut.src)).toEqual([
+      "https://cdn.test/early.mp4",
+      "https://cdn.test/late.mp4",
+    ]);
+  });
+
+  it("drops a zero-length leaf rather than emitting a cut no frame can hold", () => {
+    const manifest = manifestOf([
+      leaf({ id: "a", timelineStart: 0, timelineDuration: 4 }),
+      leaf({ id: "sliver", timelineStart: 4, timelineDuration: 0 }),
+    ]);
+    const list = compileCutList(manifest);
+    expect(list.cuts.map((cut) => cut.src)).toEqual(["https://cdn.test/a.mp4"]);
+  });
+
+  it("defaults to the format the cuts use today, and takes an override", () => {
+    const manifest = manifestOf(packed([{ id: "a" }]));
+    expect(compileCutList(manifest).format).toEqual(DEFAULT_RENDER_FORMAT);
+    expect(DEFAULT_RENDER_FORMAT).toEqual({ width: 1152, height: 480, fps: 24 });
+
+    const square = compileCutList(manifest, { width: 1080, height: 1080, fps: 30 });
+    expect(square.format).toEqual({ width: 1080, height: 1080, fps: 30 });
+  });
+
+  it("leaves the manifest untouched — the sort must not reorder the input", () => {
+    const leaves = [
+      leaf({ id: "late", timelineStart: 10 }),
+      leaf({ id: "early", timelineStart: 0 }),
+    ];
+    const manifest = manifestOf(leaves);
+    compileCutList(manifest);
+    expect(manifest.leaves.map((l) => l.id)).toEqual(["late", "early"]);
+  });
+});

--- a/apps/timeline-gstudio001/lib/render/cut-list.ts
+++ b/apps/timeline-gstudio001/lib/render/cut-list.ts
@@ -1,0 +1,92 @@
+// PlaybackManifest -> RenderCutList. The whole of export's timeline
+// arithmetic, in one pure function so it unit-tests without a renderer.
+//
+// The manifest already did the hard part: it flattens the COMPLETE nested
+// document closure into absolute-time leaves, resolving trim and time-scaling
+// at every level, so a leaf knows both where it plays and what it plays. This
+// turns that PLAYBACK read model into an OUTPUT one, and the two differ in
+// exactly two ways — both of which are decisions, not details.
+
+import type { PlaybackLeaf, PlaybackManifest } from "@storyboard/timeline-domain";
+
+import type { RenderCut, RenderCutList, RenderFormat } from "./types";
+
+/**
+ * What the 35s cuts use today, and the default until export grows a settings
+ * surface. Deliberately a constant with a name rather than a literal at the
+ * call site: the first thing anyone will want to change is the size, and the
+ * second is to know what it was when a given file was made.
+ */
+export const DEFAULT_RENDER_FORMAT: RenderFormat = {
+  width: 1152,
+  height: 480,
+  fps: 24,
+};
+
+/** Below this, a cut cannot survive rounding to a frame boundary and is more
+ *  likely a packing artefact than an intended shot. */
+const MIN_CUT_SECONDS = 1 / 1000;
+
+/**
+ * Compile the playback manifest into a render cut list.
+ *
+ * TWO differences from playback, and they are the point of this function:
+ *
+ * DISABLED LEAVES ARE DROPPED. The manifest compiles them IN, marked, and
+ * deliberately keeps their span — that is right for playback, where the
+ * playhead has to jump the span and a scrub has to be able to land inside it.
+ * A finished file has no playhead. Dropping them is not enough on its own:
+ * the span has to close too, or the export gets silence and black where the
+ * disabled clip was, which is the same bug as the gaps below.
+ *
+ * GAPS ARE CLOSED. `CLIP_GAP_SECONDS` (0.12) is baked into every stored
+ * `startTime` — it is a layout affordance so cards on the board do not touch.
+ * Honouring `timelineStart` literally would emit 0.12s of black between every
+ * clip: 2.28s across a 20-clip timeline, and a visible stutter at every join.
+ * So the cuts are re-laid back to back and `outputStart` is the running total.
+ *
+ * Both fall out of the same rule: **the output is the enabled leaves, in
+ * order, touching.** Which is why this is one pass and not two passes with a
+ * repair between them.
+ *
+ * Order comes from `timelineStart`, not from array position. The manifest
+ * emits leaves in document order today, so the sort is a no-op — but "output
+ * order is time order" is the property that matters, and depending on the
+ * compiler's traversal to supply it would be depending on something nobody
+ * has promised.
+ */
+export function compileCutList(
+  manifest: PlaybackManifest,
+  format: RenderFormat = DEFAULT_RENDER_FORMAT,
+): RenderCutList {
+  const playable = manifest.leaves
+    .filter((leaf) => leaf.disabled !== true)
+    .filter((leaf) => leaf.timelineDuration >= MIN_CUT_SECONDS)
+    .slice()
+    .sort((a, b) => a.timelineStart - b.timelineStart);
+
+  let outputStart = 0;
+  const cuts: RenderCut[] = playable.map((leaf) => {
+    const cut = cutFromLeaf(leaf, outputStart);
+    outputStart += cut.outputDuration;
+    return cut;
+  });
+
+  return { cuts, durationSeconds: outputStart, format };
+}
+
+function cutFromLeaf(leaf: PlaybackLeaf, outputStart: number): RenderCut {
+  return {
+    src: leaf.src,
+    kind: leaf.kind,
+    // An image has no source timeline to seek into; the manifest still
+    // reports 0, and normalising here keeps the worker from having to know
+    // which kinds can be sought.
+    sourceStart: leaf.kind === "image" ? 0 : leaf.sourceStart,
+    outputDuration: leaf.timelineDuration,
+    // Likewise: an image cannot play at a rate. Reported as 1 rather than
+    // omitted so every cut has one shape.
+    playbackRate: leaf.kind === "image" ? 1 : leaf.playbackRate,
+    outputStart,
+  };
+}

--- a/apps/timeline-gstudio001/lib/render/job-state.test.ts
+++ b/apps/timeline-gstudio001/lib/render/job-state.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+
+import { applyRenderEvent, isTerminal, mayReport } from "./job-state";
+import type { RenderProgress } from "./types";
+
+const at = (state: RenderProgress["state"], over: Partial<RenderProgress> = {}): RenderProgress => ({
+  state,
+  ...over,
+});
+
+const WORKER = "worker-1";
+
+describe("isTerminal", () => {
+  it("is true for the two states nothing may change", () => {
+    expect(isTerminal("succeeded")).toBe(true);
+    expect(isTerminal("failed")).toBe(true);
+  });
+
+  it("is false while there is still work to do", () => {
+    expect(isTerminal("queued")).toBe(false);
+    expect(isTerminal("claimed")).toBe(false);
+    expect(isTerminal("rendering")).toBe(false);
+  });
+});
+
+describe("mayReport", () => {
+  it("admits the holder and nobody else", () => {
+    expect(mayReport(WORKER, WORKER)).toBe(true);
+    expect(mayReport(WORKER, "worker-2")).toBe(false);
+  });
+
+  it("admits nobody when the job is unheld", () => {
+    expect(mayReport(null, WORKER)).toBe(false);
+  });
+});
+
+describe("applyRenderEvent — claiming", () => {
+  it("claims a queued job", () => {
+    const result = applyRenderEvent(at("queued"), { type: "claim", workerId: WORKER }, null);
+    expect(result).toEqual({ ok: true, next: { state: "claimed" } });
+  });
+
+  it("REFUSES a second claim — a claim is not a restart", () => {
+    // A crashed worker's job stays claimed until something requeues it
+    // deliberately; a second claim must not do that silently.
+    const result = applyRenderEvent(at("claimed"), { type: "claim", workerId: "worker-2" }, WORKER);
+    expect(result).toEqual({ ok: false, reason: "out-of-order" });
+  });
+
+  it("refuses to claim work already in flight", () => {
+    expect(
+      applyRenderEvent(at("rendering"), { type: "claim", workerId: "worker-2" }, WORKER).ok,
+    ).toBe(false);
+  });
+});
+
+describe("applyRenderEvent — reporting", () => {
+  it("starts a claimed job at zero", () => {
+    const result = applyRenderEvent(at("claimed"), { type: "start" }, WORKER);
+    expect(result).toEqual({ ok: true, next: { state: "rendering", fraction: 0 } });
+  });
+
+  it("refuses to start a job nobody claimed", () => {
+    expect(applyRenderEvent(at("queued"), { type: "start" }, null)).toEqual({
+      ok: false,
+      reason: "out-of-order",
+    });
+  });
+
+  it("advances progress and carries the message", () => {
+    const result = applyRenderEvent(
+      at("rendering", { fraction: 0.2 }),
+      { type: "progress", fraction: 0.5, message: "encoding" },
+      WORKER,
+    );
+    expect(result).toEqual({
+      ok: true,
+      next: { state: "rendering", fraction: 0.5, message: "encoding" },
+    });
+  });
+
+  it("NEVER GOES BACKWARDS — a slipping bar reads as a stall", () => {
+    // ffmpeg's own reporting is not monotonic across stages.
+    const result = applyRenderEvent(
+      at("rendering", { fraction: 0.8 }),
+      { type: "progress", fraction: 0.3 },
+      WORKER,
+    );
+    expect(result).toMatchObject({ ok: true, next: { fraction: 0.8 } });
+  });
+
+  it("refuses a fraction outside 0..1", () => {
+    for (const fraction of [-0.1, 1.5, Number.NaN]) {
+      expect(
+        applyRenderEvent(at("rendering"), { type: "progress", fraction }, WORKER),
+      ).toEqual({ ok: false, reason: "invalid" });
+    }
+  });
+
+  it("refuses progress before the job started", () => {
+    expect(
+      applyRenderEvent(at("claimed"), { type: "progress", fraction: 0.5 }, WORKER),
+    ).toEqual({ ok: false, reason: "out-of-order" });
+  });
+
+  it("succeeds straight from claimed — a fast render never reports progress", () => {
+    const result = applyRenderEvent(
+      at("claimed"),
+      { type: "succeed", outputUrl: "https://cdn.test/out.mp4" },
+      WORKER,
+    );
+    expect(result).toEqual({
+      ok: true,
+      next: { state: "succeeded", fraction: 1, outputUrl: "https://cdn.test/out.mp4" },
+    });
+  });
+
+  it("fails from anywhere in flight", () => {
+    for (const state of ["claimed", "rendering"] as const) {
+      expect(
+        applyRenderEvent(at(state), { type: "fail", message: "ffmpeg exited 1" }, WORKER),
+      ).toEqual({ ok: true, next: { state: "failed", message: "ffmpeg exited 1" } });
+    }
+  });
+});
+
+describe("applyRenderEvent — terminal is forever", () => {
+  it("refuses to move a finished job back into flight", () => {
+    const done = at("succeeded", { fraction: 1, outputUrl: "https://cdn.test/out.mp4" });
+    expect(applyRenderEvent(done, { type: "start" }, WORKER)).toEqual({
+      ok: false,
+      reason: "terminal",
+    });
+    expect(applyRenderEvent(done, { type: "progress", fraction: 0.5 }, WORKER)).toEqual({
+      ok: false,
+      reason: "terminal",
+    });
+  });
+
+  it("refuses to turn a success into a failure, or the reverse", () => {
+    expect(
+      applyRenderEvent(at("succeeded"), { type: "fail", message: "late" }, WORKER).ok,
+    ).toBe(false);
+    expect(
+      applyRenderEvent(at("failed"), { type: "succeed", outputUrl: "x" }, WORKER).ok,
+    ).toBe(false);
+  });
+
+  it("is IDEMPOTENT for a retried report of the state it is already in", () => {
+    // A worker whose report landed but whose response timed out will retry.
+    // That is not a fault.
+    const done = at("succeeded", { fraction: 1, outputUrl: "https://cdn.test/out.mp4" });
+    expect(applyRenderEvent(done, { type: "succeed", outputUrl: "x" }, WORKER)).toEqual({
+      ok: true,
+      next: done,
+    });
+    const failed = at("failed", { message: "ffmpeg exited 1" });
+    expect(applyRenderEvent(failed, { type: "fail", message: "again" }, WORKER)).toEqual({
+      ok: true,
+      next: failed,
+    });
+  });
+});
+
+describe("applyRenderEvent — abandoning", () => {
+  it("abandons a job nobody has picked up", () => {
+    expect(applyRenderEvent(at("queued"), { type: "abandon" }, null)).toEqual({
+      ok: true,
+      next: { state: "failed", message: "Abandoned before it was claimed." },
+    });
+  });
+
+  it("REFUSES to abandon work in flight — the worker would render into nothing", () => {
+    expect(applyRenderEvent(at("rendering"), { type: "abandon" }, WORKER)).toEqual({
+      ok: false,
+      reason: "out-of-order",
+    });
+  });
+});

--- a/apps/timeline-gstudio001/lib/render/job-state.ts
+++ b/apps/timeline-gstudio001/lib/render/job-state.ts
@@ -1,0 +1,140 @@
+// The render job's STATE MACHINE — pure, so the rules that decide whether a
+// worker's report is legal unit-test without Firestore.
+//
+// It exists because the worker is a separate process the app does not control.
+// It can crash mid-render and come back, report out of order, or report
+// against a job someone else already took. Every one of those arrives as an
+// ordinary HTTP request, so "is this transition legal" has to be a decision
+// the server makes rather than something the client is trusted about.
+
+import type { RenderProgress, RenderState } from "./types";
+
+/** What can happen to a job. `claim` is the worker taking it; the rest are it
+ *  reporting. There is no `queue` — that is creation. */
+export type RenderEvent =
+  | Readonly<{ type: "claim"; workerId: string }>
+  | Readonly<{ type: "start" }>
+  | Readonly<{ type: "progress"; fraction: number; message?: string }>
+  | Readonly<{ type: "succeed"; outputUrl: string }>
+  | Readonly<{ type: "fail"; message: string }>
+  /** The app abandoning a job that has not been picked up. */
+  | Readonly<{ type: "abandon" }>;
+
+export type RenderTransition =
+  | Readonly<{ ok: true; next: RenderProgress }>
+  | Readonly<{ ok: false; reason: RenderTransitionError }>;
+
+export type RenderTransitionError =
+  /** The job has already finished; nothing may change it. */
+  | "terminal"
+  /** Legal event, wrong moment (progress before claim, start before claim). */
+  | "out-of-order"
+  /** Someone else holds this job. */
+  | "not-holder"
+  /** The event itself is malformed — a fraction outside 0..1. */
+  | "invalid";
+
+const TERMINAL: ReadonlySet<RenderState> = new Set<RenderState>(["succeeded", "failed"]);
+
+export function isTerminal(state: RenderState): boolean {
+  return TERMINAL.has(state);
+}
+
+/**
+ * Apply one event to a job's current progress.
+ *
+ * THREE rules carry the weight, and each exists because of a way a detached
+ * worker actually fails:
+ *
+ * TERMINAL IS FOREVER. A worker that finished, then retried its report after a
+ * network timeout, must not move a succeeded job back to `rendering` — the app
+ * has already shown the output and may have filed it. Re-reporting the SAME
+ * terminal state is idempotent rather than an error, because a retry of a
+ * report that did land is not a fault.
+ *
+ * ONLY THE HOLDER MAY REPORT. `claim` records a `workerId`, and everything
+ * after it checks that id. Without this, a second worker (a stale process, or
+ * the same machine restarted) reports over a render it is not doing, and the
+ * output URL that lands belongs to whichever finished last.
+ *
+ * A CLAIM IS NOT A RESTART. Only a `queued` job can be claimed. A crashed
+ * worker's job stays `claimed` until something requeues it deliberately —
+ * which is a decision with a timeout attached, not something a second claim
+ * should perform silently.
+ */
+export function applyRenderEvent(
+  current: RenderProgress,
+  event: RenderEvent,
+  holderWorkerId: string | null,
+): RenderTransition {
+  if (isTerminal(current.state)) {
+    // Idempotent re-report of the state we are already in.
+    if (event.type === "succeed" && current.state === "succeeded") {
+      return { ok: true, next: current };
+    }
+    if (event.type === "fail" && current.state === "failed") {
+      return { ok: true, next: current };
+    }
+    return { ok: false, reason: "terminal" };
+  }
+
+  if (event.type === "claim") {
+    if (current.state !== "queued") return { ok: false, reason: "out-of-order" };
+    return { ok: true, next: { state: "claimed" } };
+  }
+
+  if (event.type === "abandon") {
+    // Only before anyone picks it up. Once claimed, abandoning would leave a
+    // worker rendering into a job that no longer expects it.
+    if (current.state !== "queued") return { ok: false, reason: "out-of-order" };
+    return { ok: true, next: { state: "failed", message: "Abandoned before it was claimed." } };
+  }
+
+  // Everything below is the holder reporting on work it took.
+  if (holderWorkerId === null) return { ok: false, reason: "out-of-order" };
+
+  switch (event.type) {
+    case "start":
+      if (current.state !== "claimed") return { ok: false, reason: "out-of-order" };
+      return { ok: true, next: { state: "rendering", fraction: 0 } };
+
+    case "progress": {
+      if (current.state !== "rendering") return { ok: false, reason: "out-of-order" };
+      if (!(event.fraction >= 0 && event.fraction <= 1)) {
+        return { ok: false, reason: "invalid" };
+      }
+      // NEVER GOES BACKWARDS. Progress is what a human reads to decide whether
+      // to keep waiting, and ffmpeg's own reporting is not monotonic across
+      // stages — a bar that slips back reads as a stall or a restart.
+      const fraction = Math.max(current.fraction ?? 0, event.fraction);
+      return {
+        ok: true,
+        next: {
+          state: "rendering",
+          fraction,
+          ...(event.message === undefined ? {} : { message: event.message }),
+        },
+      };
+    }
+
+    case "succeed":
+      // From `claimed` too, not only `rendering`: a worker that renders fast
+      // enough never sends a progress report, and refusing its result would
+      // fail the one render that went perfectly.
+      return { ok: true, next: { state: "succeeded", fraction: 1, outputUrl: event.outputUrl } };
+
+    case "fail":
+      return { ok: true, next: { state: "failed", message: event.message } };
+  }
+}
+
+/**
+ * Whether `workerId` may report on a job held by `holderWorkerId`.
+ *
+ * Separate from the transition so the store can reject an impostor BEFORE
+ * reading the rest of the request, and so the rule is stated once for every
+ * reporting event rather than repeated per case.
+ */
+export function mayReport(holderWorkerId: string | null, workerId: string): boolean {
+  return holderWorkerId !== null && holderWorkerId === workerId;
+}

--- a/apps/timeline-gstudio001/lib/render/job-store.ts
+++ b/apps/timeline-gstudio001/lib/render/job-store.ts
@@ -1,0 +1,213 @@
+import "server-only";
+
+import { getFirebaseDb } from "../firebase-admin";
+import { applyRenderEvent, mayReport, type RenderEvent } from "./job-state";
+import type { RenderCutList, RenderJob, RenderProgress } from "./types";
+
+/**
+ * Render jobs — the CONTRACT between the app and whatever renders.
+ *
+ * Every provider reports through this collection and the app watches only
+ * this, which is what makes "the owner's laptop" and "a hosted service"
+ * interchangeable. The job document is created queued; a worker claims it,
+ * reports against it, and finishes it.
+ *
+ * DELIBERATELY NOT under the timeline document. A render is about a timeline
+ * but is not part of it: it outlives the edit it was compiled from, it is
+ * written by a party that must not be able to touch timeline content, and
+ * putting it inside would put the worker's credential on the same document as
+ * the edit.
+ */
+const RENDER_COLLECTION = "gstudioRenderJobs";
+
+/**
+ * How many queued jobs a claim looks at.
+ *
+ * Equality-only query plus an in-memory sort, rather than
+ * `where(state).where(providerId).orderBy(createdAt)`, which would need a
+ * composite index and therefore a deploy before the first render could run
+ * (see #367 for how that goes). At this volume — renders are minutes apart,
+ * not milliseconds — reading twenty and picking the oldest is indistinguishable
+ * and costs no deployment step. Revisit if a queue ever really forms.
+ */
+const CLAIM_SCAN_LIMIT = 20;
+
+type RenderJobRecord = {
+  timelineId?: string;
+  projectRevision?: number;
+  providerId?: string;
+  cutList?: RenderCutList;
+  requestedBy?: string;
+  createdAt?: string;
+  state?: RenderProgress["state"];
+  fraction?: number;
+  message?: string;
+  outputUrl?: string;
+  workerId?: string;
+  updatedAt?: string;
+};
+
+export type StoredRenderJob = RenderJob &
+  Readonly<{
+    providerId: string;
+    progress: RenderProgress;
+    workerId: string | null;
+    updatedAt: string;
+  }>;
+
+function collection() {
+  return getFirebaseDb().collection(RENDER_COLLECTION);
+}
+
+function toStoredJob(id: string, data: RenderJobRecord): StoredRenderJob | null {
+  // A record missing its cut list is unrenderable; treating it as absent beats
+  // handing a worker a job it will fail on in a way that looks like ffmpeg's
+  // fault.
+  if (!data.cutList || !data.timelineId || !data.providerId) return null;
+  return {
+    id,
+    timelineId: data.timelineId,
+    projectRevision: data.projectRevision ?? 0,
+    cutList: data.cutList,
+    requestedBy: data.requestedBy ?? "",
+    createdAt: data.createdAt ?? "",
+    providerId: data.providerId,
+    workerId: data.workerId ?? null,
+    updatedAt: data.updatedAt ?? "",
+    progress: {
+      state: data.state ?? "queued",
+      ...(data.fraction === undefined ? {} : { fraction: data.fraction }),
+      ...(data.message === undefined ? {} : { message: data.message }),
+      ...(data.outputUrl === undefined ? {} : { outputUrl: data.outputUrl }),
+    },
+  };
+}
+
+export async function createRenderJob(
+  job: RenderJob,
+  providerId: string,
+): Promise<StoredRenderJob> {
+  const record: RenderJobRecord = {
+    timelineId: job.timelineId,
+    projectRevision: job.projectRevision,
+    providerId,
+    cutList: job.cutList,
+    requestedBy: job.requestedBy,
+    createdAt: job.createdAt,
+    state: "queued",
+    updatedAt: job.createdAt,
+  };
+  await collection().doc(job.id).set(record);
+  const stored = toStoredJob(job.id, record);
+  // Built from a record this function just constructed, so the guard inside
+  // toStoredJob cannot fire; throwing beats a non-null assertion.
+  if (stored === null) throw new Error("Render job was constructed incomplete.");
+  return stored;
+}
+
+export async function readRenderJob(id: string): Promise<StoredRenderJob | null> {
+  const snapshot = await collection().doc(id).get();
+  if (!snapshot.exists) return null;
+  return toStoredJob(snapshot.id, (snapshot.data() ?? {}) as RenderJobRecord);
+}
+
+/**
+ * Take the oldest queued job for a provider, atomically.
+ *
+ * The transaction is the whole point: two workers polling at once must not
+ * both come away holding the same render. The claim is a compare-and-set on
+ * `state` — the re-read inside the transaction is what makes the check and the
+ * write one step.
+ */
+export async function claimNextRenderJob(
+  providerId: string,
+  workerId: string,
+  nowIso: string,
+): Promise<StoredRenderJob | null> {
+  const queued = await collection()
+    .where("state", "==", "queued")
+    .limit(CLAIM_SCAN_LIMIT)
+    .get();
+
+  const candidates = queued.docs
+    .map((doc) => toStoredJob(doc.id, (doc.data() ?? {}) as RenderJobRecord))
+    .filter((job): job is StoredRenderJob => job !== null && job.providerId === providerId)
+    .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+
+  for (const candidate of candidates) {
+    const claimed = await getFirebaseDb().runTransaction(async (tx) => {
+      const ref = collection().doc(candidate.id);
+      const snapshot = await tx.get(ref);
+      if (!snapshot.exists) return null;
+      const current = toStoredJob(snapshot.id, (snapshot.data() ?? {}) as RenderJobRecord);
+      if (current === null) return null;
+      const transition = applyRenderEvent(
+        current.progress,
+        { type: "claim", workerId },
+        current.workerId,
+      );
+      // Someone claimed it between the query and the transaction. Not an
+      // error — try the next candidate.
+      if (!transition.ok) return null;
+      tx.set(
+        ref,
+        { state: transition.next.state, workerId, updatedAt: nowIso },
+        { merge: true },
+      );
+      return { ...current, progress: transition.next, workerId, updatedAt: nowIso };
+    });
+    if (claimed !== null) return claimed;
+  }
+  return null;
+}
+
+export type ReportResult =
+  | Readonly<{ ok: true; job: StoredRenderJob }>
+  | Readonly<{ ok: false; reason: "not-found" | "not-holder" | "terminal" | "out-of-order" | "invalid" }>;
+
+/**
+ * Apply a worker's report, under the state machine.
+ *
+ * In a transaction because the rules read the CURRENT state — a worker
+ * reporting progress while another request finishes the job would otherwise
+ * decide against a state that no longer holds.
+ */
+export async function reportRenderProgress(
+  id: string,
+  workerId: string,
+  event: RenderEvent,
+  nowIso: string,
+): Promise<ReportResult> {
+  return getFirebaseDb().runTransaction<ReportResult>(async (tx) => {
+    const ref = collection().doc(id);
+    const snapshot = await tx.get(ref);
+    if (!snapshot.exists) return { ok: false, reason: "not-found" };
+    const current = toStoredJob(snapshot.id, (snapshot.data() ?? {}) as RenderJobRecord);
+    if (current === null) return { ok: false, reason: "not-found" };
+
+    // Checked before the transition so an impostor is refused on identity
+    // rather than on whatever the state machine happens to say about its
+    // event — "you do not hold this" is the honest answer either way.
+    if (!mayReport(current.workerId, workerId)) return { ok: false, reason: "not-holder" };
+
+    const transition = applyRenderEvent(current.progress, event, current.workerId);
+    if (!transition.ok) return { ok: false, reason: transition.reason };
+
+    const next = transition.next;
+    tx.set(
+      ref,
+      {
+        state: next.state,
+        updatedAt: nowIso,
+        // Written as explicit undefined-free fields: Firestore rejects
+        // undefined, and a merge that omitted them would leave a stale
+        // fraction beside a terminal state.
+        ...(next.fraction === undefined ? {} : { fraction: next.fraction }),
+        ...(next.message === undefined ? {} : { message: next.message }),
+        ...(next.outputUrl === undefined ? {} : { outputUrl: next.outputUrl }),
+      },
+      { merge: true },
+    );
+    return { ok: true, job: { ...current, progress: next, updatedAt: nowIso } };
+  });
+}

--- a/apps/timeline-gstudio001/lib/render/local-provider.ts
+++ b/apps/timeline-gstudio001/lib/render/local-provider.ts
@@ -1,0 +1,42 @@
+// The OWNER'S OWN MACHINE, as a render provider.
+//
+// Modelled as a third party on purpose. It is the first renderer and it will
+// not be the last, and the way to make that swap cheap is to give the local
+// machine no privileges the next one will not have: it claims queued work over
+// the same API, reports through the same job document, and is registered like
+// any other adapter. Nothing above this file knows a render happens on a
+// laptop.
+//
+// WHY DISPATCH IS EMPTY. A hosted runner is told there is work; this one
+// cannot be, because the machine is behind NAT and has no address the app can
+// reach. So it POLLS — the worker asks for the next queued job, claims it, and
+// writes its own progress back. `dispatch` therefore has nothing to do, and
+// that is a property of the transport rather than a gap: the job document
+// already exists and already says `queued` by the time dispatch is called,
+// which IS the message.
+//
+// The consequence worth stating: a render only progresses while the worker is
+// running. A job submitted with the machine off sits `queued` indefinitely,
+// which is correct and visible, rather than failing. Swapping in a hosted
+// provider is what removes that condition.
+
+import { MINIMAL_RENDER_CAPABILITIES, type RenderProvider } from "./provider";
+
+export const LOCAL_RENDER_PROVIDER_ID = "local";
+
+export const localRenderProvider: RenderProvider = {
+  id: LOCAL_RENDER_PROVIDER_ID,
+  label: "This machine",
+  capabilities: {
+    ...MINIMAL_RENDER_CAPABILITIES,
+    // The worker writes its own progress to the job document as it goes, so
+    // the app gets a fraction without this provider having to poll for one.
+    progress: true,
+    // No cancel: stopping work in flight means reaching the process, and
+    // there is no channel to it. A queued job can still be abandoned by the
+    // app — that needs no provider involvement.
+    cancel: false,
+  },
+  // The job document is the message. See the note above.
+  dispatch: async () => {},
+};

--- a/apps/timeline-gstudio001/lib/render/provider.test.ts
+++ b/apps/timeline-gstudio001/lib/render/provider.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  MINIMAL_RENDER_CAPABILITIES,
+  createRenderProviderRegistry,
+  type RenderProvider,
+} from "./provider";
+import { LOCAL_RENDER_PROVIDER_ID, localRenderProvider } from "./local-provider";
+
+const fake = (id: string, label = id): RenderProvider => ({
+  id,
+  label,
+  capabilities: MINIMAL_RENDER_CAPABILITIES,
+  dispatch: async () => {},
+});
+
+describe("createRenderProviderRegistry", () => {
+  it("resolves a provider by id", () => {
+    const registry = createRenderProviderRegistry([fake("local"), fake("hosted")]);
+    expect(registry.get("hosted")?.id).toBe("hosted");
+  });
+
+  it("is undefined for an id nobody registered, rather than throwing", () => {
+    expect(createRenderProviderRegistry([fake("local")]).get("nope")).toBeUndefined();
+  });
+
+  it("is legal to register nothing — a deployment that cannot render", () => {
+    const registry = createRenderProviderRegistry([]);
+    expect(registry.describeAll()).toEqual([]);
+    expect(registry.defaultProvider()).toBeUndefined();
+  });
+
+  it("REFUSES a duplicate id at construction, not at request time", () => {
+    // A duplicate would route a render to whichever adapter registered last —
+    // a job running somewhere nobody is watching.
+    expect(() => createRenderProviderRegistry([fake("local"), fake("local", "other")])).toThrow(
+      /Duplicate render provider id "local"/,
+    );
+  });
+
+  it("takes the FIRST registered as the default", () => {
+    const registry = createRenderProviderRegistry([fake("local"), fake("hosted")]);
+    expect(registry.defaultProvider()?.id).toBe("local");
+  });
+
+  it("describes providers without leaking the methods", () => {
+    const registry = createRenderProviderRegistry([fake("local", "This machine")]);
+    expect(registry.describeAll()).toEqual([
+      { id: "local", label: "This machine", capabilities: MINIMAL_RENDER_CAPABILITIES },
+    ]);
+  });
+});
+
+describe("localRenderProvider", () => {
+  it("declares progress and not cancel, and carries the method for neither more than it claims", () => {
+    expect(localRenderProvider.capabilities).toEqual({ cancel: false, progress: true });
+    // The capability and the method are ONE claim. Cancel is declared false,
+    // so the method must be absent — the registry cannot enforce the pairing,
+    // which is why the adapter's own test does.
+    expect(localRenderProvider.cancel).toBeUndefined();
+  });
+
+  it("has an empty dispatch — the job document IS the message", async () => {
+    // The machine is behind NAT and cannot be pushed to; the worker polls for
+    // queued work. Pinned because an empty dispatch reads like an oversight,
+    // and the next provider's will not be empty.
+    const spy = vi.fn();
+    await expect(
+      localRenderProvider.dispatch({ uid: "user-a" }, {
+        id: "render-1",
+        timelineId: "project-1",
+        projectRevision: 3,
+        cutList: { cuts: [], durationSeconds: 0, format: { width: 1, height: 1, fps: 24 } },
+        requestedBy: "user-a",
+        createdAt: "2026-08-14T00:00:00.000Z",
+      }),
+    ).resolves.toBeUndefined();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("registers under the id the worker claims against", () => {
+    expect(localRenderProvider.id).toBe(LOCAL_RENDER_PROVIDER_ID);
+  });
+});

--- a/apps/timeline-gstudio001/lib/render/provider.ts
+++ b/apps/timeline-gstudio001/lib/render/provider.ts
@@ -1,0 +1,103 @@
+// The render provider interface and its registry — pure module (no server
+// imports), so registry behaviour unit-tests with in-memory fakes. The
+// INSTANCE the routes use lives in ./registry.ts, which is server-only
+// because the real adapters are.
+//
+// Deliberately the same shape as lib/assets/provider.ts. That seam turned out
+// well and the two problems rhyme: an interface, capabilities a caller can ask
+// about, a registry that resolves an id, and adapters that know a vendor.
+
+import type {
+  RenderJob,
+  RenderProgress,
+  RenderProviderCapabilities,
+  RenderProviderDescriptor,
+} from "./types";
+
+/** Who is asking. A hosted provider will need per-deployment credentials here
+ *  rather than reading globals, which is why the methods take it. */
+export type RenderOwnerContext = Readonly<{ uid: string }>;
+
+/**
+ * THE JOB DOCUMENT IS THE CONTRACT, not this interface.
+ *
+ * Every provider reports through the same stored job — state, progress,
+ * output URL — and the app watches that and only that. `dispatch` exists to
+ * TELL a backend there is work, and what that means is the one thing
+ * providers genuinely differ on:
+ *
+ *   - the local machine cannot be pushed to (it is behind NAT), so it POLLS
+ *     for queued work and `dispatch` has nothing to do;
+ *   - a hosted runner is told, so `dispatch` fires its trigger.
+ *
+ * Modelling it this way is what keeps "my laptop" and "some service" the same
+ * kind of thing. A provider that needs no push is not a special case; it is a
+ * provider whose dispatch is empty.
+ */
+export type RenderProvider = RenderProviderDescriptor &
+  Readonly<{
+    /**
+     * Hand a queued job to the backend. Called AFTER the job document exists,
+     * so a provider that throws leaves a job that is still claimable — which
+     * is the recoverable direction. Returning normally is not a promise that
+     * the render started, only that the backend was told.
+     */
+    dispatch: (ctx: RenderOwnerContext, job: RenderJob) => Promise<void>;
+
+    /**
+     * Stop work already in flight. Present exactly when `capabilities.cancel`
+     * is true — the registry cannot enforce that pairing, so an adapter
+     * declaring the capability without the method is a bug its own tests
+     * should catch. Abandoning a job that has not been claimed needs no
+     * provider involvement and is the app's own business.
+     */
+    cancel?: (ctx: RenderOwnerContext, jobId: string) => Promise<void>;
+
+    /**
+     * Ask the backend where a job got to, for providers whose worker cannot
+     * report for itself. Absent when the worker writes its own progress to
+     * the job document, which is the local worker's arrangement and the
+     * simpler one.
+     */
+    poll?: (ctx: RenderOwnerContext, jobId: string) => Promise<RenderProgress>;
+  }>;
+
+export type RenderProviderRegistry = Readonly<{
+  get: (id: string) => RenderProvider | undefined;
+  /** Every registered provider, in registration order. Unlike the asset
+   *  registry — which lost its `describeAll` with the picker — this one keeps
+   *  it: a render has to be routed somewhere at submit time, and offering the
+   *  choice needs the list. */
+  describeAll: () => readonly RenderProviderDescriptor[];
+  /** Who serves a request naming no provider: the first registered. */
+  defaultProvider: () => RenderProvider | undefined;
+}>;
+
+export function createRenderProviderRegistry(
+  providers: readonly RenderProvider[],
+): RenderProviderRegistry {
+  const byId = new Map<string, RenderProvider>();
+  for (const provider of providers) {
+    if (byId.has(provider.id)) {
+      // Fail at construction, not at request time: a duplicate id would send
+      // a render to whichever adapter happened to register last, which is a
+      // job silently running somewhere nobody is watching.
+      throw new Error(`Duplicate render provider id "${provider.id}".`);
+    }
+    byId.set(provider.id, provider);
+  }
+  const ordered = [...byId.values()];
+  return {
+    get: (id) => byId.get(id),
+    describeAll: () =>
+      ordered.map(({ id, label, capabilities }) => ({ id, label, capabilities })),
+    defaultProvider: () => ordered[0],
+  };
+}
+
+/** Capability set for an adapter that can do neither yet — the starting point
+ *  for a new provider; spread and override what the backend supports. */
+export const MINIMAL_RENDER_CAPABILITIES: RenderProviderCapabilities = {
+  cancel: false,
+  progress: false,
+};

--- a/apps/timeline-gstudio001/lib/render/registry.ts
+++ b/apps/timeline-gstudio001/lib/render/registry.ts
@@ -1,0 +1,13 @@
+// THE registry instance the render routes resolve providers from. Server-only
+// by composition, matching lib/assets/registry.ts.
+//
+// Adding a renderer = one adapter file + one entry here. The local machine is
+// first, which also makes it the default — deliberate while it is the only
+// one, and the line to change when a hosted renderer should take over.
+
+import { localRenderProvider } from "./local-provider";
+import { createRenderProviderRegistry, type RenderProvider } from "./provider";
+
+const providers: RenderProvider[] = [localRenderProvider];
+
+export const renderProviders = createRenderProviderRegistry(providers);

--- a/apps/timeline-gstudio001/lib/render/types.ts
+++ b/apps/timeline-gstudio001/lib/render/types.ts
@@ -1,0 +1,113 @@
+// The provider-NEUTRAL render model. Nothing above this seam names a
+// particular renderer, a particular machine, or ffmpeg — a render provider's
+// whole job is to take a CutList somewhere it can be turned into a file and
+// report where that got to.
+//
+// Isomorphic on purpose: the client renders progress from these shapes, so
+// this module must import nothing server-only.
+//
+// The first provider is the OWNER'S OWN MACHINE, deliberately modelled as a
+// third party rather than as a special case. It receives work the same way a
+// hosted worker would — by claiming a queued job — so swapping in a hosted
+// renderer later is a new adapter and a registry entry, not a rewrite. See
+// lib/assets/provider.ts, which is the same seam for asset storage and the
+// pattern this follows.
+
+/** What a single cut plays. Images have no source timeline of their own. */
+export type RenderCutKind = "image" | "video" | "audio";
+
+/**
+ * ONE piece of media in the finished render, with every position already
+ * resolved — the worker does no timeline arithmetic.
+ *
+ * `outputStart` is where it lands in the FINISHED FILE, not on the board. The
+ * two differ: the board spaces clips by CLIP_GAP_SECONDS so cards do not
+ * touch, and a stored `startTime` carries that spacing. A render that honoured
+ * it would emit 0.12s of black between every clip (2.28s across a 20-clip
+ * timeline), so the compiler closes the gaps — see `compileCutList`.
+ */
+export type RenderCut = Readonly<{
+  /** Fetchable media URL. Public by design — see the Cloudinary delivery
+   *  decision — so a worker needs no credential to READ its inputs. */
+  src: string;
+  kind: RenderCutKind;
+  /** Seconds into the SOURCE file where this cut begins. */
+  sourceStart: number;
+  /** How long the cut runs in the OUTPUT, in seconds. */
+  outputDuration: number;
+  /** Source seconds consumed per output second; 1 is normal speed. Carried
+   *  even for images (always 1) so every cut has the same shape. */
+  playbackRate: number;
+  /** Where the cut begins in the OUTPUT — the running total of everything
+   *  before it, with gaps closed. */
+  outputStart: number;
+}>;
+
+/** Output format. Fixed per job rather than per cut: the worker normalises
+ *  every source to this before concatenating, because ffmpeg's concat
+ *  demuxer requires identical parameters and produces garbage without it. */
+export type RenderFormat = Readonly<{
+  width: number;
+  height: number;
+  fps: number;
+}>;
+
+/**
+ * The finished cut list — everything a renderer needs and nothing about how it
+ * renders.
+ *
+ * PHASE 1 IS A SEQUENCE. `cuts` never overlap, because the stored model cannot
+ * express overlap: `packTimelineClips` packs one sequence and `trackIndex` is
+ * carried but always 0. Layered audio (VO or a bed UNDER the picture) needs
+ * per-track packing in the model first, and is deliberately out of scope here
+ * rather than faked — an export that silently flattened a layered mix into a
+ * sequence would be worse than one that cannot express it yet.
+ */
+export type RenderCutList = Readonly<{
+  cuts: readonly RenderCut[];
+  /** Total output length: the sum of the cut durations, gaps already removed.
+   *  NOT the manifest's `durationSeconds`, which is board time. */
+  durationSeconds: number;
+  format: RenderFormat;
+}>;
+
+/** Where a render has got to. Terminal states are `succeeded` and `failed`. */
+export type RenderState = "queued" | "claimed" | "rendering" | "succeeded" | "failed";
+
+export type RenderJob = Readonly<{
+  id: string;
+  /** The timeline this was compiled from, and the revision it was compiled at
+   *  — a render is only honest about a specific version of the edit. */
+  timelineId: string;
+  projectRevision: number;
+  cutList: RenderCutList;
+  requestedBy: string;
+  createdAt: string;
+}>;
+
+export type RenderProgress = Readonly<{
+  state: RenderState;
+  /** 0..1 where the provider can report it; absent when it cannot. A worker
+   *  that only knows "started" and "done" says so by omitting this rather
+   *  than by inventing a number. */
+  fraction?: number;
+  /** Provider-side detail for a human: the current stage, or the failure. */
+  message?: string;
+  /** Set exactly when `state` is "succeeded": the finished file. */
+  outputUrl?: string;
+}>;
+
+export type RenderProviderCapabilities = Readonly<{
+  /** Whether a running render can be stopped. A queued job can always be
+   *  abandoned by the app; this is about work already in flight. */
+  cancel: boolean;
+  /** Whether the provider reports a fraction, or only state transitions. */
+  progress: boolean;
+}>;
+
+export type RenderProviderDescriptor = Readonly<{
+  id: string;
+  /** Human label ("This machine", "GitHub Actions") — status lines and logs. */
+  label: string;
+  capabilities: RenderProviderCapabilities;
+}>;

--- a/apps/timeline-gstudio001/lib/render/worker-request.ts
+++ b/apps/timeline-gstudio001/lib/render/worker-request.ts
@@ -1,0 +1,42 @@
+import "server-only";
+
+import { bearerTokenMatches, configuredSecret } from "../bearer-token";
+
+/**
+ * Authenticating the RENDER WORKER — a machine, not a person.
+ *
+ * A dedicated secret rather than a user session, and that is the point of the
+ * whole seam: the owner's laptop authenticates exactly the way a hosted
+ * renderer would, holding a credential scoped to two endpoints and nothing
+ * else. It cannot read a timeline, cannot write one, and cannot act as anyone.
+ *
+ * Unset means REFUSE. An endpoint that hands out work and accepts results must
+ * never default to open, and 503 is the honest status: the deployment is not
+ * configured, which is not the caller's fault and not fixable by presenting a
+ * better token.
+ */
+export type WorkerAuth =
+  | Readonly<{ ok: true; workerId: string }>
+  | Readonly<{ ok: false; status: 401 | 503; error: string }>;
+
+/** Identifies WHICH worker, so a report can be checked against the holder.
+ *  Self-asserted — it distinguishes workers, it does not authenticate them;
+ *  the shared secret does that. */
+const WORKER_ID_HEADER = "x-render-worker-id";
+
+export function authenticateWorker(request: Request): WorkerAuth {
+  const secret = configuredSecret(process.env.RENDER_WORKER_SECRET);
+  if (secret === null) {
+    return { ok: false, status: 503, error: "Rendering is not configured." };
+  }
+  if (!bearerTokenMatches(request.headers.get("authorization"), secret)) {
+    return { ok: false, status: 401, error: "Unauthorized" };
+  }
+  const workerId = request.headers.get(WORKER_ID_HEADER)?.trim();
+  if (!workerId) {
+    // Required, because "who holds this job" is what stops a restarted worker
+    // reporting over a render its predecessor is still doing.
+    return { ok: false, status: 401, error: `Missing ${WORKER_ID_HEADER}.` };
+  }
+  return { ok: true, workerId };
+}


### PR DESCRIPTION
Phase 1 of #310, and deliberately **not** the whole of it — see "What is not here".

Export compiles a timeline to a cut list, queues it as a job, and lets a worker claim it. The first worker is the owner's own machine, modelled as a **third party** rather than a special case: it claims work over the same API a hosted renderer would, reports through the same job document, and registers like any other adapter. Nothing above the seam knows a render happens on a laptop.

The seam mirrors `lib/assets/provider.ts` — same problem shape, and that one turned out well.

## The framing that makes the swap cheap

**The job document is the contract; `dispatch` is only how a backend gets told.**

The owner's machine is behind NAT and has no address the app can reach, so the worker POLLS for queued work and the local provider's `dispatch` is legitimately empty — a property of the transport, not a gap. A hosted provider fires its trigger in the same slot. That is the only thing the two differ on.

## What the cut list decides

The playback manifest already flattens the complete nested closure into absolute-time leaves, so export's arithmetic reduces to one rule: **the output is the enabled leaves, in order, TOUCHING.** Both halves are owner decisions:

- **Gaps close.** `CLIP_GAP_SECONDS` (0.12) is baked into every stored `startTime` as a board affordance so cards do not touch. Honouring it literally emits 0.12s of black between every clip — 2.28s across twenty, and a visible stutter at every join.
- **Disabled leaves drop, and their hole closes.** The manifest compiles them in and keeps their span on purpose, because a playhead has to jump it. A finished file has no playhead.

12 tests, including that a 3-clip board spanning 12.24s exports as exactly 12.00s.

## Why there is a state machine

The worker is a process the app does not control. It crashes and comes back, retries a report whose response timed out, and can be a stale instance reporting over a render it no longer owns. So:

- **Terminal is forever** — but re-reporting the SAME terminal state is idempotent, because a retry of a report that did land is not a fault.
- **Only the claim holder may report** — otherwise a restarted worker overwrites its predecessor's render and the output URL that lands is whichever finished last.
- **Progress never goes backwards** — ffmpeg's own reporting is not monotonic across stages, and a slipping bar reads as a stall.

20 tests, all pure.

## Two extractions rather than second copies

- **`lib/bearer-token.ts`** — the reclaim cron was about to have a second copy of a security primitive, including the length check that makes `timingSafeEqual` safe to call at all (it throws on a length mismatch).
- **`lib/compile-timeline-manifest.ts`** — the load-bearing one. The four-step compile includes a stale-summary repair that the preview route once lacked, which made it report a different total than the board and window a grown child's newest clips out of playback. A second caller copying three of four steps would have reproduced that bug in export, where it yields a wrong **file** rather than a wrong preview.

## What is NOT here, and why

**The worker script and the upload path.** The finished mp4 cannot come back through the app: Vercel caps serverless request bodies at **4.5MB**, which the upload route's own comment already concedes bites before its own 200MB ceiling. The worker will take a short-lived Cloudinary signature from the app and PUT the file straight to Cloudinary — credentials stay server-side, no large body crosses Vercel. That is the follow-up PR.

**Layered audio.** Phase 1 is a SEQUENCE. VO or a bed UNDER the picture needs per-track packing in the stored model first (`trackIndex` is carried but always 0, and the manifest hardcodes it), and is left unexpressible rather than faked — an export that silently flattened a layered mix into a sequence would be worse than one that cannot express it yet.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — **959 passed** (was 918; +41 new)
- `npm run lint` — clean, the same 5 pre-existing `<img>` warnings
- `npx playwright test --project=graph-view` — **169/169 passed** (run because the `preview-manifest` refactor touches a live playback read path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)