### PR TITLE
Add the render worker and its direct-upload ticket (#310, phase 1)

### DIFF
--- a/apps/timeline-gstudio001/app/api/renders/[id]/upload-ticket/route.ts
+++ b/apps/timeline-gstudio001/app/api/renders/[id]/upload-ticket/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+
+import {
+  createCloudinaryUploadTicket,
+  forgetCloudinaryAssetList,
+  hasCloudinaryConfig,
+} from "@/lib/cloudinary-media-store";
+import { readRenderJob } from "@/lib/render/job-store";
+import { mayReport } from "@/lib/render/job-state";
+import { authenticateWorker } from "@/lib/render/worker-request";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * A short-lived signed ticket for the worker to PUT its finished mp4 straight
+ * to Cloudinary.
+ *
+ * THE BYTES NEVER CROSS THIS SERVER, and that is not an optimisation. Vercel
+ * caps a serverless request body at 4.5MB — the upload route's own comment
+ * already concedes the platform limit bites before its 200MB ceiling — so a
+ * render coming back through the app would fail on every file worth making.
+ *
+ * The same mechanism `upload_media` already uses for agent uploads, for the
+ * same reason, and reusing it means no second copy of the signing code.
+ *
+ * The server still decides WHERE the file lands: `folder` and `public_id` are
+ * derived inside `createCloudinaryUploadTicket` from the job's owner and
+ * timeline, never taken from the caller. A worker-chosen path would either
+ * break the reclaim sweep or let a render write into another account's prefix.
+ */
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = authenticateWorker(_request);
+  if (!auth.ok) return NextResponse.json({ error: auth.error }, { status: auth.status });
+
+  if (!hasCloudinaryConfig()) {
+    return NextResponse.json({ error: "Uploads are not configured." }, { status: 503 });
+  }
+
+  const { id } = await params;
+  try {
+    const job = await readRenderJob(id);
+    if (!job) return NextResponse.json({ error: "Render was not found." }, { status: 404 });
+
+    // Only the worker that HOLDS the job may be handed a place to write. The
+    // ticket is a write credential scoped to the owner's prefix, so issuing
+    // one to a worker that does not hold this render would let a stale
+    // process drop a file into a live project.
+    if (!mayReport(job.workerId, auth.workerId)) {
+      return NextResponse.json({ error: "not-holder" }, { status: 409 });
+    }
+
+    const ticket = createCloudinaryUploadTicket(
+      `${job.id}.mp4`,
+      job.requestedBy,
+      job.timelineId,
+    );
+    // The direct-upload path never touches `uploadCloudinaryMedia`, which is
+    // what normally invalidates the listing cache — without this a
+    // just-rendered file is genuinely there and invisible.
+    forgetCloudinaryAssetList(job.requestedBy);
+
+    return NextResponse.json(ticket);
+  } catch (error) {
+    console.error("[GSTUDIO_RENDER_TICKET_ERROR]", error);
+    return NextResponse.json({ error: "Unable to issue an upload ticket." }, { status: 500 });
+  }
+}

--- a/apps/timeline-gstudio001/lib/render/ffmpeg-plan.test.ts
+++ b/apps/timeline-gstudio001/lib/render/ffmpeg-plan.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+
+// The worker is a standalone process, so its planner is a .mjs module — but it
+// is the part most able to be subtly wrong, so it is covered by the app suite
+// rather than only by looking at the output file.
+import {
+  atempoChain,
+  concatArgs,
+  concatListFile,
+  segmentArgs,
+  segmentFraction,
+} from "../../scripts/render-worker/ffmpeg-plan.mjs";
+
+const FORMAT = { width: 1152, height: 480, fps: 24 };
+
+const cut = (over: Record<string, unknown> = {}) => ({
+  src: "https://cdn.test/a.mp4",
+  kind: "video",
+  sourceStart: 0,
+  outputDuration: 4,
+  playbackRate: 1,
+  outputStart: 0,
+  ...over,
+});
+
+/** The value ffmpeg would receive for a flag, i.e. the token after it. */
+const valueAfter = (args: string[], flag: string) => args[args.indexOf(flag) + 1];
+/** Every value given for a flag that appears more than once (-map, -i, -t). */
+const allValuesAfter = (args: string[], flag: string) =>
+  args.flatMap((token, index) => (token === flag ? [args[index + 1] as string] : []));
+
+describe("segmentArgs — every segment must be concat-compatible", () => {
+  it("normalises size, rate, pixel format and codecs identically for each kind", () => {
+    const kinds = [
+      segmentArgs(cut(), FORMAT, "/tmp/0.mp4", { hasAudio: true }),
+      segmentArgs(cut({ kind: "image", src: "https://cdn.test/a.png" }), FORMAT, "/tmp/1.mp4"),
+      segmentArgs(cut({ kind: "audio", src: "https://cdn.test/a.wav" }), FORMAT, "/tmp/2.mp4"),
+    ] as string[][];
+    for (const args of kinds) {
+      expect(valueAfter(args, "-c:v")).toBe("libx264");
+      expect(valueAfter(args, "-pix_fmt")).toBe("yuv420p");
+      expect(valueAfter(args, "-r")).toBe("24");
+      expect(valueAfter(args, "-c:a")).toBe("aac");
+      expect(valueAfter(args, "-ar")).toBe("48000");
+      expect(valueAfter(args, "-ac")).toBe("2");
+    }
+  });
+
+  it("gives EVERY segment exactly one video and one audio map", () => {
+    // One silent clip in a sequence must not silence everything after it.
+    const kinds = [
+      segmentArgs(cut(), FORMAT, "/tmp/0.mp4", { hasAudio: true }),
+      segmentArgs(cut(), FORMAT, "/tmp/0.mp4", { hasAudio: false }),
+      segmentArgs(cut({ kind: "image" }), FORMAT, "/tmp/1.mp4"),
+      segmentArgs(cut({ kind: "audio" }), FORMAT, "/tmp/2.mp4"),
+    ] as string[][];
+    for (const args of kinds) {
+      const maps = allValuesAfter(args, "-map");
+      expect(maps).toHaveLength(2);
+      expect(maps.filter((m) => m.includes(":v:"))).toHaveLength(1);
+      expect(maps.filter((m) => m.includes(":a:"))).toHaveLength(1);
+      // A `?` would quietly yield a segment with no audio stream at all.
+      expect(maps.some((m) => m.endsWith("?"))).toBe(false);
+    }
+  });
+
+  it("takes the SOURCE audio when it has some, and adds no silent input", () => {
+    const args = segmentArgs(cut(), FORMAT, "/tmp/0.mp4", { hasAudio: true }) as string[];
+    expect(allValuesAfter(args, "-map")).toEqual(["0:v:0", "0:a:0"]);
+    expect(args.join(" ")).not.toContain("anullsrc");
+  });
+
+  it("SYNTHESISES silence for a source with none", () => {
+    const args = segmentArgs(cut(), FORMAT, "/tmp/0.mp4", { hasAudio: false }) as string[];
+    expect(allValuesAfter(args, "-map")).toEqual(["0:v:0", "1:a:0"]);
+    expect(args.join(" ")).toContain("anullsrc");
+  });
+
+  it("defaults to NO source audio when the caller did not probe", () => {
+    // Safer direction: a silent track over a clip that had sound is a missing
+    // sound; a missing stream breaks the concat for everything after it.
+    const args = segmentArgs(cut(), FORMAT, "/tmp/0.mp4") as string[];
+    expect(allValuesAfter(args, "-map")).toEqual(["0:v:0", "1:a:0"]);
+  });
+
+  it("seeks BEFORE the input, so a long source does not decode from zero", () => {
+    const args = segmentArgs(
+      cut({ sourceStart: 30 }),
+      FORMAT,
+      "/tmp/0.mp4",
+      { hasAudio: true },
+    ) as string[];
+    expect(args.indexOf("-ss")).toBeLessThan(args.indexOf("-i"));
+    expect(valueAfter(args, "-ss")).toBe("30");
+  });
+
+  it("consumes duration x rate of SOURCE for a rate-scaled cut", () => {
+    const args = segmentArgs(
+      cut({ outputDuration: 4, playbackRate: 2 }),
+      FORMAT,
+      "/tmp/0.mp4",
+      { hasAudio: true },
+    ) as string[];
+    // 4s of output at 2x needs 8s of source.
+    expect(valueAfter(args, "-t")).toBe("8");
+    expect(valueAfter(args, "-vf")).toContain("setpts=PTS/2");
+    expect(valueAfter(args, "-filter:a")).toBe("atempo=2");
+  });
+
+  it("does not add a rate filter at normal speed", () => {
+    const args = segmentArgs(cut(), FORMAT, "/tmp/0.mp4", { hasAudio: true }) as string[];
+    expect(args).not.toContain("-filter:a");
+    expect(valueAfter(args, "-vf")).not.toContain("setpts");
+  });
+
+  it("treats a nonsense rate as normal speed rather than dividing by zero", () => {
+    const args = segmentArgs(
+      cut({ playbackRate: 0 }),
+      FORMAT,
+      "/tmp/0.mp4",
+      { hasAudio: true },
+    ) as string[];
+    expect(valueAfter(args, "-vf")).not.toContain("setpts");
+    expect(valueAfter(args, "-t")).toBe("4");
+  });
+
+  it("fits without cropping, and pins the pixel aspect", () => {
+    const args = segmentArgs(cut(), FORMAT, "/tmp/0.mp4", { hasAudio: true }) as string[];
+    const vf = valueAfter(args, "-vf") as string;
+    expect(vf).toContain("force_original_aspect_ratio=decrease");
+    expect(vf).toContain("pad=1152:480");
+    expect(vf).toContain("setsar=1");
+  });
+
+  it("holds an image for its full span", () => {
+    const args = segmentArgs(
+      cut({ kind: "image", outputDuration: 3.5 }),
+      FORMAT,
+      "/tmp/1.mp4",
+    ) as string[];
+    expect(args).toContain("-loop");
+    expect(allValuesAfter(args, "-t")).toEqual(["3.5", "3.5"]);
+  });
+
+  it("plays an audio-only cut over black at the output size", () => {
+    const args = segmentArgs(
+      cut({ kind: "audio", src: "https://cdn.test/vo.wav" }),
+      FORMAT,
+      "/tmp/2.mp4",
+    ) as string[];
+    expect(args.join(" ")).toContain("color=c=black:s=1152x480:r=24");
+    expect(allValuesAfter(args, "-map")).toEqual(["0:v:0", "1:a:0"]);
+  });
+});
+
+describe("atempoChain", () => {
+  it("passes an in-range rate straight through", () => {
+    expect(atempoChain(1.5)).toBe("atempo=1.5");
+    expect(atempoChain(0.75)).toBe("atempo=0.75");
+  });
+
+  it("CHAINS past the filter's 2.0 ceiling rather than clamping", () => {
+    // Clamping would desync audio from a picture scaled by the full factor.
+    expect(atempoChain(4)).toBe("atempo=2.0,atempo=2");
+    expect(atempoChain(3)).toBe("atempo=2.0,atempo=1.5");
+  });
+
+  it("chains past the 0.5 floor the same way", () => {
+    expect(atempoChain(0.25)).toBe("atempo=0.5,atempo=0.5");
+  });
+
+  it("multiplies back out to the rate it was asked for", () => {
+    for (const rate of [0.3, 0.5, 1, 2, 3, 5.5, 8]) {
+      const product = atempoChain(rate)
+        .split(",")
+        .reduce((total, step) => total * Number(step.split("=")[1]), 1);
+      expect(product).toBeCloseTo(rate, 5);
+    }
+  });
+});
+
+describe("concatListFile", () => {
+  it("quotes each path on its own line", () => {
+    expect(concatListFile(["/tmp/0.mp4", "/tmp/1.mp4"])).toBe(
+      "file '/tmp/0.mp4'\nfile '/tmp/1.mp4'\n",
+    );
+  });
+
+  it("ESCAPES an apostrophe, which would otherwise truncate the list", () => {
+    // ffmpeg's parser treats a bare quote as a delimiter — an unescaped path
+    // loses that shot and every one after it, silently.
+    expect(concatListFile(["/tmp/joe's cut.mp4"])).toBe("file '/tmp/joe'\\''s cut.mp4'\n");
+  });
+});
+
+describe("concatArgs", () => {
+  it("remuxes rather than re-encoding, and allows absolute paths", () => {
+    const args = concatArgs("/tmp/list.txt", "/tmp/out.mp4") as string[];
+    expect(valueAfter(args, "-c")).toBe("copy");
+    expect(valueAfter(args, "-safe")).toBe("0");
+    expect(valueAfter(args, "-movflags")).toBe("+faststart");
+  });
+});
+
+describe("segmentFraction", () => {
+  it("advances with the segments and never reaches 1 before the concat", () => {
+    expect(segmentFraction(0, 4)).toBeCloseTo(0.2375, 4);
+    expect(segmentFraction(3, 4)).toBe(0.95);
+  });
+
+  it("is zero for nothing to do, rather than dividing by zero", () => {
+    expect(segmentFraction(0, 0)).toBe(0);
+  });
+});

--- a/apps/timeline-gstudio001/scripts/render-worker/ffmpeg-plan.mjs
+++ b/apps/timeline-gstudio001/scripts/render-worker/ffmpeg-plan.mjs
@@ -1,0 +1,209 @@
+// Cut list -> ffmpeg arguments. PURE: data in, argument arrays out, no
+// spawning and no filesystem, so the part that is easy to get subtly wrong is
+// unit-tested rather than discovered by watching a bad file.
+//
+// A .mjs module rather than app TypeScript because the worker is a standalone
+// process the app does not bundle — but it is imported by a test in the app's
+// suite, so it is covered like everything else.
+//
+// THE INVARIANT THE WHOLE FILE SERVES: every segment must come out with the
+// SAME video size, frame rate, pixel format, codec, AND an audio stream. The
+// concat demuxer does not transcode; it stitches. Feed it segments that
+// disagree on any of those and it produces silence after the first cut, or a
+// file that stalls at a join, or nothing at all — and it does so without
+// failing, which is why this is normalise-then-concat rather than one pass.
+
+/** Silent stereo audio, for sources that have none of their own. An image has
+ *  no audio track and plenty of video files do not either. Concat needs every
+ *  segment to have the same streams, so a missing one is SYNTHESISED rather
+ *  than omitted: without this, one silent clip in a sequence silences
+ *  everything after it. */
+const SILENT_AUDIO = "anullsrc=channel_layout=stereo:sample_rate=48000";
+
+/**
+ * Fit the source into the output frame WITHOUT cropping: scale to fit, then
+ * pad the remainder. `force_original_aspect_ratio=decrease` is what keeps a
+ * portrait clip from being stretched across a landscape frame, and `setsar=1`
+ * stops a non-square pixel aspect surviving into the concat, where it shows up
+ * as one stretched segment among correct ones.
+ */
+function fitFilter(width, height) {
+  return [
+    `scale=${width}:${height}:force_original_aspect_ratio=decrease`,
+    `pad=${width}:${height}:(ow-iw)/2:(oh-ih)/2`,
+    "setsar=1",
+  ].join(",");
+}
+
+/** Encoder settings shared by every segment. Being IDENTICAL across segments
+ *  is the requirement; the particular values are ordinary. */
+function encodeArgs(fps) {
+  return [
+    "-c:v", "libx264",
+    "-preset", "veryfast",
+    "-pix_fmt", "yuv420p",
+    "-r", String(fps),
+    "-c:a", "aac",
+    "-ar", "48000",
+    "-ac", "2",
+    // Stops a synthesised silent track, which has no natural end, from
+    // extending a segment past its picture.
+    "-shortest",
+  ];
+}
+
+/**
+ * ffmpeg arguments that turn ONE cut into one normalised segment file.
+ *
+ * `hasAudio` says whether the SOURCE carries an audio stream, and the caller
+ * has to find out — ffmpeg cannot express "map the real audio if there is any,
+ * otherwise this silence". There is no conditional mapping, and mapping both
+ * would either fail on the missing stream or mix silence into real sound. So
+ * the worker probes (see probeHasAudio) and the decision arrives here as data,
+ * which is also what makes it testable.
+ *
+ * `-ss` goes BEFORE `-i` deliberately: after the input, ffmpeg decodes and
+ * discards everything up to the seek point, which on a long source is the
+ * difference between instant and minutes.
+ */
+export function segmentArgs(cut, format, outputPath, options = {}) {
+  const { width, height, fps } = format;
+  const hasAudio = options.hasAudio === true;
+  const fit = fitFilter(width, height);
+  const rate = cut.playbackRate > 0 ? cut.playbackRate : 1;
+
+  if (cut.kind === "image") {
+    // A still becomes a clip of the required length, over synthesised silence.
+    return [
+      "-y",
+      "-loop", "1", "-t", String(cut.outputDuration), "-i", cut.src,
+      "-f", "lavfi", "-t", String(cut.outputDuration), "-i", SILENT_AUDIO,
+      "-vf", `${fit},fps=${fps}`,
+      "-map", "0:v:0",
+      "-map", "1:a:0",
+      ...encodeArgs(fps),
+      outputPath,
+    ];
+  }
+
+  if (cut.kind === "audio") {
+    // Audio in a SEQUENCE — phase 1 has no layering — still has to occupy a
+    // span of picture, so it plays over black rather than being dropped.
+    return [
+      "-y",
+      "-f", "lavfi", "-t", String(cut.outputDuration),
+      "-i", `color=c=black:s=${width}x${height}:r=${fps}`,
+      "-ss", String(cut.sourceStart), "-t", String(cut.outputDuration * rate), "-i", cut.src,
+      ...(rate === 1 ? [] : ["-filter:a", atempoChain(rate)]),
+      "-map", "0:v:0",
+      "-map", "1:a:0",
+      ...encodeArgs(fps),
+      outputPath,
+    ];
+  }
+
+  // VIDEO. `-t` on the input is measured in SOURCE seconds, so a rate-scaled
+  // cut consumes duration x rate of source to fill duration of output.
+  const videoFilters = [fit, `fps=${fps}`];
+  if (rate !== 1) videoFilters.unshift(`setpts=PTS/${rate}`);
+
+  const input = [
+    "-ss", String(cut.sourceStart),
+    "-t", String(cut.outputDuration * rate),
+    "-i", cut.src,
+  ];
+  const silence = hasAudio
+    ? []
+    : ["-f", "lavfi", "-t", String(cut.outputDuration), "-i", SILENT_AUDIO];
+
+  return [
+    "-y",
+    ...input,
+    ...silence,
+    "-vf", videoFilters.join(","),
+    ...(hasAudio && rate !== 1 ? ["-filter:a", atempoChain(rate)] : []),
+    "-map", "0:v:0",
+    // The real track when there is one, the synthesised one otherwise — never
+    // both, and never a `?` that would quietly yield a segment with no audio.
+    "-map", hasAudio ? "0:a:0" : "1:a:0",
+    ...encodeArgs(fps),
+    outputPath,
+  ];
+}
+
+/**
+ * `atempo` accepts 0.5..2.0 per instance, so a rate outside that is chained.
+ *
+ * Chained rather than clamped: clamping would desync audio from a picture that
+ * HAS been scaled by the full factor, which is the worst available outcome —
+ * it reads as a sync bug in the render rather than as a refusal.
+ */
+export function atempoChain(rate) {
+  const steps = [];
+  let remaining = rate;
+  while (remaining > 2) {
+    steps.push("atempo=2.0");
+    remaining /= 2;
+  }
+  while (remaining < 0.5) {
+    steps.push("atempo=0.5");
+    remaining *= 2;
+  }
+  steps.push(`atempo=${round(remaining)}`);
+  return steps.join(",");
+}
+
+function round(value) {
+  return Math.round(value * 1e6) / 1e6;
+}
+
+/**
+ * The concat demuxer's list file. Paths are single-quoted with embedded quotes
+ * escaped, because ffmpeg's own parser treats a bare quote as a delimiter — a
+ * path with an apostrophe in it would truncate the list at that line and lose
+ * a shot silently.
+ */
+export function concatListFile(segmentPaths) {
+  return segmentPaths.map((path) => `file '${path.replace(/'/g, "'\\''")}'`).join("\n") + "\n";
+}
+
+/**
+ * Stitch the normalised segments. `-c copy` is the point: they were already
+ * encoded to identical settings, so this is a remux — fast, and it cannot
+ * introduce a second generation of loss.
+ */
+export function concatArgs(listPath, outputPath) {
+  return [
+    "-y",
+    "-f", "concat",
+    // Required for absolute paths, which every path here is.
+    "-safe", "0",
+    "-i", listPath,
+    "-c", "copy",
+    "-movflags", "+faststart",
+    outputPath,
+  ];
+}
+
+/** ffprobe arguments that answer "does this source have an audio stream". */
+export function probeAudioArgs(src) {
+  return [
+    "-v", "error",
+    "-select_streams", "a:0",
+    "-show_entries", "stream=codec_type",
+    "-of", "csv=p=0",
+    src,
+  ];
+}
+
+/**
+ * How far through the render we are, from the cut currently being normalised.
+ *
+ * Caps below 1 deliberately: the concat still has to run after the last
+ * segment, and a bar sitting at 100% through a final step is the kind of small
+ * lie that makes people think a job has hung.
+ */
+export function segmentFraction(index, total) {
+  if (total <= 0) return 0;
+  return Math.min(0.95, ((index + 1) / total) * 0.95);
+}

--- a/apps/timeline-gstudio001/scripts/render-worker/index.mjs
+++ b/apps/timeline-gstudio001/scripts/render-worker/index.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+// The render worker: claims a job, assembles it with ffmpeg, uploads the file.
+//
+// IT RUNS ANYWHERE. Nothing about it is specific to the owner's machine —
+// every connection is OUTBOUND to the app, so it needs no address, no inbound
+// port and no tunnel. Point it at a deployment, give it the shared secret, and
+// it works from a laptop, a container, or a CI runner. That is the whole point
+// of treating "local" as a third party: the day this moves to a hosted runner,
+// this file is what moves.
+//
+// Usage:
+//   RENDER_APP_URL=https://your-app RENDER_WORKER_SECRET=... \
+//     node scripts/render-worker/index.mjs
+//
+// Optional: RENDER_WORKER_ID (defaults to hostname+pid),
+//           RENDER_PROVIDER_ID (defaults to "local"),
+//           RENDER_POLL_SECONDS (defaults to 10).
+
+import { spawn } from "node:child_process";
+import { hostname } from "node:os";
+import { mkdtemp, rm, writeFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  concatArgs,
+  concatListFile,
+  probeAudioArgs,
+  segmentArgs,
+  segmentFraction,
+} from "./ffmpeg-plan.mjs";
+
+const APP_URL = (process.env.RENDER_APP_URL ?? "").replace(/\/$/, "");
+const SECRET = process.env.RENDER_WORKER_SECRET ?? "";
+const WORKER_ID = process.env.RENDER_WORKER_ID ?? `${hostname()}-${process.pid}`;
+const PROVIDER_ID = process.env.RENDER_PROVIDER_ID ?? "local";
+const POLL_MS = Number(process.env.RENDER_POLL_SECONDS ?? 10) * 1000;
+
+if (!APP_URL || !SECRET) {
+  console.error("Set RENDER_APP_URL and RENDER_WORKER_SECRET.");
+  process.exit(1);
+}
+
+const headers = {
+  authorization: `Bearer ${SECRET}`,
+  "x-render-worker-id": WORKER_ID,
+  "content-type": "application/json",
+};
+
+/** Run a command to completion, resolving its stdout. Rejects with the tail of
+ *  stderr, because ffmpeg's actual complaint is always in the last few lines
+ *  and the preceding hundred are banner. */
+function run(command, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let out = "";
+    let err = "";
+    child.stdout.on("data", (chunk) => (out += chunk));
+    child.stderr.on("data", (chunk) => (err += chunk));
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) resolve(out.trim());
+      else reject(new Error(`${command} exited ${code}: ${err.trim().split("\n").slice(-4).join(" ")}`));
+    });
+  });
+}
+
+async function report(jobId, body) {
+  const response = await fetch(`${APP_URL}/api/renders/${jobId}/report`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  // A refused report is worth SAYING rather than swallowing: it means this
+  // worker no longer holds the job (a restart, or a second instance), and the
+  // render it is doing is going nowhere.
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    console.warn(`[report ${body.type}] ${response.status} ${detail}`);
+  }
+  return response.ok;
+}
+
+async function claim() {
+  const response = await fetch(`${APP_URL}/api/renders/claim`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ providerId: PROVIDER_ID }),
+  });
+  if (response.status === 204) return null;
+  if (!response.ok) throw new Error(`claim failed: ${response.status} ${await response.text()}`);
+  return response.json();
+}
+
+/** Whether a source carries an audio stream. ffmpeg has no way to express
+ *  "use the real audio if there is any", so this decides it — see
+ *  segmentArgs. A probe that fails is treated as NO audio, which is the safe
+ *  direction: a silent track is a missing sound, a missing stream breaks the
+ *  concat for every segment after it. */
+async function probeHasAudio(path) {
+  try {
+    return (await run("ffprobe", probeAudioArgs(path))).includes("audio");
+  } catch {
+    return false;
+  }
+}
+
+async function download(url, path) {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`Could not fetch ${url}: ${response.status}`);
+  await writeFile(path, Buffer.from(await response.arrayBuffer()));
+}
+
+async function uploadResult(jobId, filePath) {
+  const ticketResponse = await fetch(`${APP_URL}/api/renders/${jobId}/upload-ticket`, {
+    method: "POST",
+    headers,
+  });
+  if (!ticketResponse.ok) {
+    throw new Error(`upload ticket refused: ${ticketResponse.status}`);
+  }
+  const ticket = await ticketResponse.json();
+
+  // STRAIGHT TO CLOUDINARY, not through the app: a serverless request body is
+  // capped at 4.5MB and a render is not. The signature came from the app, so
+  // the app still decided where this lands.
+  const form = new FormData();
+  for (const [key, value] of Object.entries(ticket.fields)) form.append(key, value);
+  form.append("file", new Blob([await readFile(filePath)]), `${jobId}.mp4`);
+
+  const upload = await fetch(ticket.uploadUrl, { method: "POST", body: form });
+  if (!upload.ok) throw new Error(`upload failed: ${upload.status} ${await upload.text()}`);
+  const result = await upload.json();
+  if (!result.secure_url) throw new Error("upload returned no URL");
+  return result.secure_url;
+}
+
+async function renderJob(job) {
+  const workDir = await mkdtemp(join(tmpdir(), `render-${job.id}-`));
+  try {
+    await report(job.id, { type: "start" });
+    const { cuts, format } = job.cutList;
+    const segments = [];
+
+    for (const [index, cut] of cuts.entries()) {
+      // Downloaded rather than streamed: a 404 or an expired URL then fails
+      // here, clearly, instead of surfacing as an opaque ffmpeg error four
+      // steps later.
+      const sourcePath = join(workDir, `src-${index}${extensionFor(cut)}`);
+      await download(cut.src, sourcePath);
+
+      const hasAudio = cut.kind === "video" ? await probeHasAudio(sourcePath) : false;
+      const segmentPath = join(workDir, `seg-${String(index).padStart(4, "0")}.mp4`);
+      await run("ffmpeg", segmentArgs({ ...cut, src: sourcePath }, format, segmentPath, { hasAudio }));
+      segments.push(segmentPath);
+
+      await report(job.id, {
+        type: "progress",
+        fraction: segmentFraction(index, cuts.length),
+        message: `cut ${index + 1} of ${cuts.length}`,
+      });
+    }
+
+    const listPath = join(workDir, "concat.txt");
+    await writeFile(listPath, concatListFile(segments));
+    const outputPath = join(workDir, `${job.id}.mp4`);
+    await run("ffmpeg", concatArgs(listPath, outputPath));
+
+    const url = await uploadResult(job.id, outputPath);
+    await report(job.id, { type: "succeed", outputUrl: url });
+    console.log(`rendered ${job.id} -> ${url}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`render ${job.id} failed:`, message);
+    await report(job.id, { type: "fail", message });
+  } finally {
+    // Renders are large and temporary. Left behind, a few of them fill a disk
+    // and the failure lands on something unrelated.
+    await rm(workDir, { recursive: true, force: true });
+  }
+}
+
+function extensionFor(cut) {
+  if (cut.kind === "image") return ".img";
+  if (cut.kind === "audio") return ".audio";
+  return ".mp4";
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function main() {
+  console.log(`render worker ${WORKER_ID} -> ${APP_URL} (provider: ${PROVIDER_ID})`);
+  for (;;) {
+    try {
+      const job = await claim();
+      if (job === null) {
+        await sleep(POLL_MS);
+        continue;
+      }
+      console.log(`claimed ${job.id}: ${job.cutList.cuts.length} cuts`);
+      await renderJob(job);
+    } catch (error) {
+      // A poll that fails is ordinary — the app redeploys, the network blips.
+      // Log and keep going; the alternative is a worker that quietly stops.
+      console.error("worker loop:", error instanceof Error ? error.message : error);
+      await sleep(POLL_MS);
+    }
+  }
+}
+
+main();

--- a/apps/timeline-gstudio001/scripts/render-worker/smoke-test.mjs
+++ b/apps/timeline-gstudio001/scripts/render-worker/smoke-test.mjs
@@ -1,0 +1,120 @@
+// End-to-end proof that the planner's arguments actually assemble a file:
+// synthesise one video-with-audio, one silent video, one still and one audio
+// source, run the REAL ffmpeg through segmentArgs + concatArgs, then ffprobe
+// the result.
+//
+// NOT part of the app's vitest suite, and it cannot be: it needs ffmpeg and
+// ffprobe on PATH, and CI's ubuntu-latest image does not carry them (the
+// request to add ffmpeg was declined upstream). So it lives here as a script
+// to run by hand when the plan changes:
+//
+//   node scripts/render-worker/smoke-test.mjs
+//
+// The unit tests in lib/render/ffmpeg-plan.test.ts prove the ARGUMENTS are
+// shaped right. This proves ffmpeg accepts them and that the concat produces
+// the duration and the streams asked for — in particular that audio survives
+// past the first cut, which is the failure the whole normalise-then-concat
+// design exists to prevent, and which no argument assertion can catch.
+import { spawn } from "node:child_process";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  segmentArgs,
+  concatArgs,
+  concatListFile,
+  probeAudioArgs,
+} from "./ffmpeg-plan.mjs";
+
+const FORMAT = { width: 640, height: 360, fps: 24 };
+
+function run(cmd, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let out = "", err = "";
+    child.stdout.on("data", (c) => (out += c));
+    child.stderr.on("data", (c) => (err += c));
+    child.on("error", reject);
+    child.on("close", (code) =>
+      code === 0 ? resolve(out.trim()) : reject(new Error(`${cmd} ${code}: ${err.trim().split("\n").slice(-6).join("\n")}`)),
+    );
+  });
+}
+
+const dir = await mkdtemp(join(tmpdir(), "render-smoke-"));
+let failures = 0;
+const check = (label, actual, expected) => {
+  const ok = typeof expected === "function" ? expected(actual) : actual === expected;
+  if (!ok) failures += 1;
+  console.log(`${ok ? "PASS" : "FAIL"}  ${label}: ${actual}`);
+};
+
+try {
+  // --- synthesise sources -------------------------------------------------
+  const withAudio = join(dir, "with-audio.mp4");
+  await run("ffmpeg", ["-y", "-f", "lavfi", "-i", "testsrc=size=320x240:rate=24:duration=6",
+    "-f", "lavfi", "-i", "sine=frequency=440:duration=6",
+    "-c:v", "libx264", "-pix_fmt", "yuv420p", "-c:a", "aac", "-shortest", withAudio]);
+
+  const silent = join(dir, "silent.mp4");
+  await run("ffmpeg", ["-y", "-f", "lavfi", "-i", "testsrc=size=800x600:rate=30:duration=4",
+    "-c:v", "libx264", "-pix_fmt", "yuv420p", silent]);
+
+  const still = join(dir, "still.png");
+  await run("ffmpeg", ["-y", "-f", "lavfi", "-i", "color=c=red:s=1000x400", "-frames:v", "1", still]);
+
+  const voice = join(dir, "voice.wav");
+  await run("ffmpeg", ["-y", "-f", "lavfi", "-i", "sine=frequency=220:duration=5", voice]);
+
+  // Confirm the fixtures are what the test needs them to be.
+  check("probe finds audio in the audio-bearing source", (await run("ffprobe", probeAudioArgs(withAudio))).includes("audio"), true);
+  check("probe finds NO audio in the silent source", (await run("ffprobe", probeAudioArgs(silent))).includes("audio"), false);
+
+  // --- the cut list -------------------------------------------------------
+  // Deliberately mixed: differing sizes (320x240, 800x600, 1000x400), frame
+  // rates (24, 30), audio presence, a trim, and a rate change.
+  const cuts = [
+    { src: withAudio, kind: "video", sourceStart: 1, outputDuration: 2, playbackRate: 1, outputStart: 0 },
+    { src: silent, kind: "video", sourceStart: 0, outputDuration: 1.5, playbackRate: 1, outputStart: 2 },
+    { src: still, kind: "image", sourceStart: 0, outputDuration: 1, playbackRate: 1, outputStart: 3.5 },
+    { src: voice, kind: "audio", sourceStart: 0.5, outputDuration: 2, playbackRate: 1, outputStart: 4.5 },
+    { src: withAudio, kind: "video", sourceStart: 0, outputDuration: 1, playbackRate: 2, outputStart: 6.5 },
+  ];
+  const expectedDuration = 7.5;
+
+  const segments = [];
+  for (const [index, cut] of cuts.entries()) {
+    const hasAudio = cut.kind === "video" ? (await run("ffprobe", probeAudioArgs(cut.src))).includes("audio") : false;
+    const out = join(dir, `seg-${index}.mp4`);
+    await run("ffmpeg", segmentArgs(cut, FORMAT, out, { hasAudio }));
+    segments.push(out);
+
+    const streams = await run("ffprobe", ["-v", "error", "-show_entries", "stream=codec_type", "-of", "csv=p=0", out]);
+    check(`segment ${index} (${cut.kind}) has video AND audio`, streams.split("\n").map((s) => s.trim()).sort().join(","), "audio,video");
+    const size = await run("ffprobe", ["-v", "error", "-select_streams", "v:0", "-show_entries", "stream=width,height", "-of", "csv=p=0:s=x", out]);
+    check(`segment ${index} normalised to the output frame`, size, "640x360");
+  }
+
+  // --- concat -------------------------------------------------------------
+  const listPath = join(dir, "list.txt");
+  await writeFile(listPath, concatListFile(segments));
+  const finalPath = join(dir, "final.mp4");
+  await run("ffmpeg", concatArgs(listPath, finalPath));
+
+  const duration = Number(await run("ffprobe", ["-v", "error", "-show_entries", "format=duration", "-of", "csv=p=0", finalPath]));
+  check(`final duration ~= ${expectedDuration}s (gaps closed)`, duration.toFixed(2), (d) => Math.abs(Number(d) - expectedDuration) < 0.35);
+
+  const finalStreams = await run("ffprobe", ["-v", "error", "-show_entries", "stream=codec_type", "-of", "csv=p=0", finalPath]);
+  check("final file has video AND audio", finalStreams.split("\n").map((s) => s.trim()).sort().join(","), "audio,video");
+
+  // The bug this whole design guards against: audio surviving PAST the first
+  // segment. If concat dropped it, the audio stream would be short.
+  const audioDuration = Number(await run("ffprobe", ["-v", "error", "-select_streams", "a:0", "-show_entries", "stream=duration", "-of", "csv=p=0", finalPath]));
+  check("audio runs the WHOLE file, not just the first cut", audioDuration.toFixed(2), (d) => Math.abs(Number(d) - expectedDuration) < 0.35);
+} finally {
+  await rm(dir, { recursive: true, force: true });
+}
+
+console.log(failures === 0 ? "\nALL CHECKS PASSED" : `\n${failures} CHECK(S) FAILED`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Closes the loop opened by #391: the worker claims a job, assembles it with ffmpeg, and puts the finished mp4 straight into Cloudinary.

## It runs anywhere

Every connection is **outbound to the app** — claim, report, ticket. The worker needs no address, no inbound port and no tunnel, so it works from a laptop, a container or a CI runner without changing a line. That is the payoff of modelling "local" as a third party: when this moves to a hosted runner, this script is what moves, and nothing above the seam changes.

```
worker  ──POST /api/renders/claim──▶        app     (anything for me?)
worker  ──POST /api/renders/:id/report──▶   app     (25% … done, here is the URL)
worker  ──POST /api/renders/:id/upload-ticket──▶ app  (where do I put it?)
worker  ──POST the mp4────────────────────▶ Cloudinary
```

## The bytes never cross the app

Vercel caps a serverless request body at **4.5MB** and a render is not that. So the worker takes a short-lived Cloudinary signature and uploads direct — the same `createCloudinaryUploadTicket` the agent upload path already uses, for the same stated reason ("the bytes never pass through this server"), so there is no second copy of the signing code.

The server still decides WHERE the file lands: `folder` and `public_id` are derived from the job's owner and timeline inside the ticket helper, never taken from the caller. A worker-chosen path would either break the reclaim sweep or let a render write into another account's prefix. The ticket is also only issued to the worker that HOLDS the job, so a stale process cannot drop a file into a live project.

## Why normalise-then-concat

The concat demuxer **stitches, it does not transcode**. Segments that disagree on size, frame rate, pixel format, codec or stream layout produce silence after the first cut, or a file that stalls at a join — and they do it *without failing*.

So every cut becomes a segment with identical settings and **always both a video and an audio stream**, synthesising silence where a source has none. One silent clip in a sequence would otherwise silence everything after it.

That needed a real fix rather than a flag: **ffmpeg cannot express "use the source's audio if it has any, otherwise this silence."** There is no conditional mapping, and mapping both either fails on the missing stream or mixes silence into real sound. So the worker probes with `ffprobe` and the answer reaches the planner as data — which is also what makes it testable. (My first draft of this used `-map -1:a:0?`, which is not valid ffmpeg and would have failed at run time.)

## Verified against real ffmpeg, not asserted

`scripts/render-worker/smoke-test.mjs` synthesises four sources that disagree on everything that matters — 320x240@24 with audio, 800x600@30 silent, a 1000x400 still, a wav — runs the actual planner output through ffmpeg, and ffprobes the result:

```
PASS  probe finds audio in the audio-bearing source: true
PASS  probe finds NO audio in the silent source: false
PASS  segment 0..4 has video AND audio        (all five)
PASS  segment 0..4 normalised to the output frame: 640x360   (all five)
PASS  final duration ~= 7.5s (gaps closed): 7.52
PASS  final file has video AND audio: audio,video
PASS  audio runs the WHOLE file, not just the first cut: 7.50
ALL CHECKS PASSED   (15/15, ffmpeg 8.1.2)
```

That last check is the one the whole design exists for, and no argument assertion could catch it.

It **cannot** join the vitest suite: CI's `ubuntu-latest` carries neither ffmpeg nor ffprobe (the request to add them was declined upstream), so it is a script to run by hand when the plan changes. The 21 unit tests in `lib/render/ffmpeg-plan.test.ts` cover the argument shapes in CI, including a property test that chained `atempo` filters multiply back to the requested rate.

## To run it

```
RENDER_APP_URL=https://your-app RENDER_WORKER_SECRET=... \
  node scripts/render-worker/index.mjs
```

`RENDER_WORKER_SECRET` must match the value in the deployment's env. Unset, the endpoints refuse with 503 rather than defaulting open. With the worker off, jobs sit `queued` — visible, and not a failure.

## Verification

- `node scripts/render-worker/smoke-test.mjs` — **15/15** against ffmpeg 8.1.2
- `npx tsc --noEmit` — clean
- `npx vitest run` — **980 passed** (was 959; +21)
- `npm run lint` — clean, the same 5 pre-existing `<img>` warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)