### PR TITLE
Queue renders from MCP, and file the finished cut into Renders

### DIFF
--- a/apps/timeline-gstudio001/app/api/mcp/route.ts
+++ b/apps/timeline-gstudio001/app/api/mcp/route.ts
@@ -12,6 +12,7 @@ import type { ToolResult } from "@/lib/webmcp/types";
 import { attachMedia, createUploadTickets } from "@/lib/mcp/upload";
 import { createCollection } from "@/lib/mcp/create-collection";
 import { handleReadTimeline } from "@/lib/mcp/read-timeline";
+import { handleRenderStatus, handleRenderTimeline } from "@/lib/mcp/render";
 import {
   intoField,
   nameField,
@@ -297,6 +298,45 @@ const handler = createMcpHandler(
         const uid = uidFrom(extra);
         if (!uid) return errorResult(NO_IDENTITY);
         return fromToolResult(await handleRemoveClip(args, { requesterUid: uid }));
+      },
+    );
+
+    // --- Render tools -------------------------------------------------------
+    //
+    // These edit nothing. `render_timeline` compiles a SNAPSHOT of the
+    // timeline and queues it, so editing afterwards does not change what
+    // renders. Two tools rather than one because an encode is not instant and
+    // a single blocking tool would sit on an MCP request for its whole length.
+
+    server.tool(
+      "render_timeline",
+      "Export a timeline as a single mp4: its complete nested contents, flattened, with the board's clip gaps closed and disabled clips skipped. Returns immediately with a render id — the encode happens on a render worker. Poll it with `render_status`. Note: layered audio is not supported yet; clips render in sequence.",
+      {
+        timelineId: z
+          .string()
+          .min(1)
+          .describe("The timeline to export. Its whole nested closure is included."),
+        width: z.number().int().positive().optional().describe("Output width. Defaults to 1152."),
+        height: z.number().int().positive().optional().describe("Output height. Defaults to 480."),
+        fps: z.number().int().positive().optional().describe("Frame rate. Defaults to 24."),
+      },
+      async (args, extra) => {
+        const uid = uidFrom(extra);
+        if (!uid) return errorResult(NO_IDENTITY);
+        return fromToolResult(await handleRenderTimeline(args, { requesterUid: uid }));
+      },
+    );
+
+    server.tool(
+      "render_status",
+      "Where a render got to, and the finished file's URL once it succeeds. A render sits `queued` until a worker picks it up — with no worker running, that is where it stays.",
+      {
+        renderId: z.string().min(1).describe("The id returned by `render_timeline`."),
+      },
+      async (args, extra) => {
+        const uid = uidFrom(extra);
+        if (!uid) return errorResult(NO_IDENTITY);
+        return fromToolResult(await handleRenderStatus(args, { requesterUid: uid }));
       },
     );
 

--- a/apps/timeline-gstudio001/app/api/renders/[id]/report/route.ts
+++ b/apps/timeline-gstudio001/app/api/renders/[id]/report/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 
 import { readJsonObject } from "@/lib/read-json-body";
 import { reportRenderProgress } from "@/lib/render/job-store";
+import { attachRenderOutput } from "@/lib/render/attach-output";
 import { authenticateWorker } from "@/lib/render/worker-request";
 import type { RenderEvent } from "@/lib/render/job-state";
 
@@ -81,6 +82,33 @@ export async function POST(
         { status: STATUS_BY_REASON[result.reason] ?? 409 },
       );
     }
+
+    // FILE THE RESULT, after the job is already marked succeeded.
+    //
+    // The order is the whole point: a failure here loses the FILING, never the
+    // render. The output URL is on the job either way, so a project that was
+    // renamed or restructured mid-encode costs a card in a collection rather
+    // than a finished file. Attaching first — or letting this fail the report
+    // — would turn a completed render into a lost one.
+    //
+    // Idempotency comes from the state machine above: a retried `succeed` on
+    // an already-succeeded job returns early as a no-op transition, so this
+    // does not run twice and cannot file the same render twice.
+    const outputUrl = result.job.progress.outputUrl;
+    if (event.type === "succeed" && outputUrl !== undefined && result.changed) {
+      const attached = await attachRenderOutput(result.job, outputUrl);
+      if (!attached.ok) {
+        console.warn("[GSTUDIO_RENDER_ATTACH_FAILED]", id, attached.reason);
+      }
+      return NextResponse.json({
+        id,
+        state: result.job.progress.state,
+        ...(attached.ok
+          ? { attachedTo: attached.collectionId, nodeId: attached.nodeId }
+          : { attachWarning: attached.reason }),
+      });
+    }
+
     return NextResponse.json({ id, state: result.job.progress.state });
   } catch (error) {
     console.error("[GSTUDIO_RENDER_REPORT_ERROR]", error);

--- a/apps/timeline-gstudio001/eslint.config.mjs
+++ b/apps/timeline-gstudio001/eslint.config.mjs
@@ -71,6 +71,16 @@ export default defineConfig([
             // flagged anyway. Every Next dynamic segment in this app has the
             // same shape, so any future entry needs the same treatment.
             "app/api/timelines/\\[id\\]/preview-manifest/route.ts",
+            // Reads the root raw, then derives explicitly via loadTimelineClosure
+            // + deriveClosureSummaries — this IS that sequence, extracted from
+            // the preview route above so export and preview cannot diverge on
+            // the repair.
+            "lib/compile-timeline-manifest.ts",
+            // Existence check ("does this project have a Renders collection")
+            // plus the root's title. Reads no summary field, and deriving here
+            // would load the whole closure to answer a question the stored
+            // document answers directly.
+            "lib/render/attach-output.ts",
         ],
         rules: {
             "no-restricted-imports": [
@@ -85,6 +95,24 @@ export default defineConfig([
                             ],
                             message:
                                 "Stored collection summaries (itemCount, previewItems, duration) are stale by design. Use serveTimelineDocument from @/lib/serve-timeline for anything served to a reader. If this is a write round-trip, an existence check, or a revision read, add the file to the allowlist in eslint.config.mjs with a reason.",
+                        },
+                        // THE SAME MODULE BY ITS RELATIVE PATH. Without this the
+                        // guard was one keystroke wide: `from "./firebase-timeline-store"`
+                        // inside lib/ resolves to the identical module and matched
+                        // nothing, so a file could take the restricted import
+                        // without ever being asked for a reason — which is exactly
+                        // how compile-timeline-manifest.ts got in.
+                        //
+                        // Only lib/ siblings can spell it this way; app/ and
+                        // components/ are too far down to reach it relatively.
+                        {
+                            name: "./firebase-timeline-store",
+                            importNames: [
+                                "readStoredTimelineDocument",
+                                "readStoredTimelineEntry",
+                            ],
+                            message:
+                                "Same restriction as @/lib/firebase-timeline-store — a relative path is the same module. See that entry.",
                         },
                     ],
                 },

--- a/apps/timeline-gstudio001/lib/compile-timeline-manifest.ts
+++ b/apps/timeline-gstudio001/lib/compile-timeline-manifest.ts
@@ -3,7 +3,10 @@ import "server-only";
 import { compilePlaybackManifest, type PlaybackManifest } from "@storyboard/timeline-domain";
 
 import { deriveClosureSummaries } from "./derive-collection-summaries";
-import { readStoredTimelineEntry } from "./firebase-timeline-store";
+// Aliased deliberately, not relative: the no-restricted-imports guard on this
+// function only matches the alias, so a relative import silently escapes it.
+// This file is allowlisted in eslint.config.mjs with its reason instead.
+import { readStoredTimelineEntry } from "@/lib/firebase-timeline-store";
 import { loadTimelineClosure } from "./load-timeline-closure";
 
 /**

--- a/apps/timeline-gstudio001/lib/mcp/render.ts
+++ b/apps/timeline-gstudio001/lib/mcp/render.ts
@@ -1,0 +1,129 @@
+import "server-only";
+
+import { checkUserScopedId } from "@/lib/timeline-ownership";
+import { toolError, toolOk } from "@/lib/webmcp/results";
+import type { ToolResult } from "@/lib/webmcp/types";
+
+import { compileTimelineManifest } from "@/lib/compile-timeline-manifest";
+import { compileCutList, DEFAULT_RENDER_FORMAT } from "@/lib/render/cut-list";
+import { createRenderJob, readRenderJob } from "@/lib/render/job-store";
+import { renderProviders } from "@/lib/render/registry";
+import type { RenderJob } from "@/lib/render/types";
+
+import type { WriteContext } from "./write-handlers";
+
+// The render tools. Unlike the write tools beside them these do not edit the
+// timeline at all — they compile a SNAPSHOT of it and queue that as a job, so
+// editing afterwards does not change what renders. `projectRevision` records
+// which version a given file came from.
+//
+// Two tools rather than one because a render is not instant and the caller is
+// an agent: `render_timeline` returns immediately with an id, and
+// `render_status` is how you find out what happened. A single blocking tool
+// would sit on an MCP request for the length of an encode.
+
+export type RenderTimelineArgs = Readonly<{
+  timelineId: string;
+  width?: number;
+  height?: number;
+  fps?: number;
+}>;
+
+function mintRenderId(): string {
+  return `render-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export async function handleRenderTimeline(
+  args: RenderTimelineArgs,
+  ctx: WriteContext,
+): Promise<ToolResult> {
+  if (checkUserScopedId(args.timelineId, ctx.requesterUid) === false) {
+    return toolError(`No timeline with id "${args.timelineId}".`);
+  }
+
+  const provider = renderProviders.defaultProvider();
+  if (!provider) {
+    return toolError("No render provider is configured for this deployment.");
+  }
+
+  const compiled = await compileTimelineManifest(args.timelineId, ctx.requesterUid);
+  if (!compiled) return toolError(`No timeline with id "${args.timelineId}".`);
+
+  const format = {
+    width: args.width ?? DEFAULT_RENDER_FORMAT.width,
+    height: args.height ?? DEFAULT_RENDER_FORMAT.height,
+    fps: args.fps ?? DEFAULT_RENDER_FORMAT.fps,
+  };
+  const cutList = compileCutList(compiled.manifest, format);
+  if (cutList.cuts.length === 0) {
+    // A refusal, not an empty file: an export that produced zero seconds would
+    // read as the renderer failing rather than as the edit being empty.
+    return toolError(
+      "Nothing to render — every clip is disabled, or the timeline is empty.",
+    );
+  }
+
+  const job: RenderJob = {
+    id: mintRenderId(),
+    timelineId: args.timelineId,
+    projectRevision: compiled.manifest.projectRevision,
+    cutList,
+    requestedBy: ctx.requesterUid,
+    createdAt: new Date().toISOString(),
+  };
+  await createRenderJob(job, provider.id);
+  await provider.dispatch({ uid: ctx.requesterUid }, job);
+
+  return toolOk(
+    `Queued render "${job.id}": ${cutList.cuts.length} cuts, ` +
+      `${cutList.durationSeconds.toFixed(2)}s at ${format.width}x${format.height}. ` +
+      `Poll it with render_status.`,
+    {
+      renderId: job.id,
+      state: "queued",
+      cutCount: cutList.cuts.length,
+      durationSeconds: cutList.durationSeconds,
+      format,
+      // What the compile could not read. A render quietly missing a branch is
+      // the kind of thing that is only noticed after watching it.
+      ...(compiled.missing.length === 0 ? {} : { missingDocuments: compiled.missing }),
+    },
+  );
+}
+
+export type RenderStatusArgs = Readonly<{ renderId: string }>;
+
+export async function handleRenderStatus(
+  args: RenderStatusArgs,
+  ctx: WriteContext,
+): Promise<ToolResult> {
+  const job = await readRenderJob(args.renderId);
+  // Scoped to the requester, and a plain not-found for someone else's, so
+  // render ids cannot be probed for existence.
+  if (!job || job.requestedBy !== ctx.requesterUid) {
+    return toolError(`No render with id "${args.renderId}".`);
+  }
+
+  const { state, fraction, message, outputUrl } = job.progress;
+  const percent = fraction === undefined ? "" : ` (${Math.round(fraction * 100)}%)`;
+  const detail = message === undefined ? "" : ` — ${message}`;
+
+  return toolOk(
+    state === "succeeded"
+      ? `Render "${job.id}" finished: ${outputUrl}`
+      : state === "queued"
+        ? `Render "${job.id}" is queued. It starts when a render worker picks it up.`
+        : `Render "${job.id}" is ${state}${percent}${detail}.`,
+    {
+      renderId: job.id,
+      timelineId: job.timelineId,
+      state,
+      ...(fraction === undefined ? {} : { fraction }),
+      ...(message === undefined ? {} : { message }),
+      ...(outputUrl === undefined ? {} : { outputUrl }),
+      durationSeconds: job.cutList.durationSeconds,
+      cutCount: job.cutList.cuts.length,
+      updatedAt: job.updatedAt,
+    },
+  );
+}

--- a/apps/timeline-gstudio001/lib/render/attach-output.ts
+++ b/apps/timeline-gstudio001/lib/render/attach-output.ts
@@ -1,0 +1,183 @@
+import "server-only";
+
+import { parseNodeId, type CollectionsGraph } from "@storyboard/collections-core";
+import type { TimelineDocument } from "@storyboard/timeline-model/types";
+
+import { applyCollectionsCommand } from "@/lib/mcp/apply-command";
+import { readStoredTimelineEntry } from "@/lib/firebase-timeline-store";
+
+import {
+  RENDERS_COLLECTION_NAME,
+  findRendersCollectionId,
+  renderClipName,
+} from "./renders-collection";
+import type { StoredRenderJob } from "./job-store";
+
+/**
+ * File a finished render into the project's Renders collection.
+ *
+ * BEST EFFORT, and that is the important property. It runs after the job has
+ * already been marked succeeded, so a failure here loses the FILING, never the
+ * render — the output URL is on the job either way, and the alternative
+ * (attaching first, or letting a filing error fail the report) would turn a
+ * finished encode into a lost one over a timeline that had been renamed or
+ * moved in the meantime.
+ *
+ * Two writes rather than one: `add-nodes` targets a single parent, so creating
+ * the Renders collection and putting a clip inside it cannot be the same
+ * command. Each is atomic on its own, and the failure between them is a
+ * created-but-empty collection — visible, harmless, and reused by the next
+ * render.
+ */
+export type AttachResult =
+  | Readonly<{ ok: true; collectionId: string; nodeId: string }>
+  | Readonly<{ ok: false; reason: string }>;
+
+/** Default seconds a render's card claims before anything measures it. The
+ *  cut list already knows the real length, so this is never a guess. */
+function mintClipId(): string {
+  return `render-clip-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function mintTimelineId(): string {
+  return `timeline-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * The Renders collection's id, creating it if the project has none.
+ *
+ * Read from the ROOT DOCUMENT's clips rather than from a built graph: the
+ * question is "does this project have a Renders collection", which the stored
+ * document answers directly and cheaply. Building a closure to ask it would
+ * load every document in the project.
+ */
+async function ensureRendersCollection(
+  timelineId: string,
+  uid: string,
+): Promise<Readonly<{ ok: true; id: string }> | Readonly<{ ok: false; reason: string }>> {
+  const entry = await readStoredTimelineEntry(timelineId, uid);
+  if (!entry) return { ok: false, reason: `No timeline with id "${timelineId}".` };
+
+  const existing = findRendersCollectionId(entry.document.clips);
+  if (existing !== null) return { ok: true, id: existing };
+
+  const childId = mintTimelineId();
+  const outcome = await applyCollectionsCommand(
+    timelineId,
+    (graph: CollectionsGraph) => {
+      const rootId = parseNodeId(timelineId);
+      const root = graph.nodesById.get(rootId);
+      if (!root) return { ok: false, message: `No timeline with id "${timelineId}".` } as const;
+      const childDocument: TimelineDocument = {
+        id: childId,
+        title: RENDERS_COLLECTION_NAME,
+        clips: [],
+      };
+      return {
+        ok: true,
+        command: {
+          type: "add-nodes",
+          toParentId: rootId,
+          // At the END of the project. Renders are output, not content — they
+          // should not push the edit down the board.
+          toIndex: graph.childrenById.get(rootId)?.length ?? 0,
+          nodes: [
+            { id: parseNodeId(childId), kind: "collection" as const, name: RENDERS_COLLECTION_NAME },
+          ],
+        },
+        details: {
+          [childId]: {
+            alt: `${RENDERS_COLLECTION_NAME} collection`,
+            aspect: 16 / 9,
+            trackIndex: 0,
+            itemCount: 0,
+            duration: 3,
+            sourceDuration: 3,
+            trimIn: 0,
+            trimOut: 0,
+            // Brand-new and empty, so drops into it must not bounce off the
+            // un-hydrated-target veto.
+            hydrated: true,
+          },
+        },
+        newDocuments: [childDocument],
+      } as const;
+    },
+    uid,
+  );
+
+  if (!outcome.ok) {
+    return {
+      ok: false,
+      reason: outcome.kind === "rejected" ? outcome.rejection.reason : outcome.message,
+    };
+  }
+  return { ok: true, id: childId };
+}
+
+export async function attachRenderOutput(
+  job: StoredRenderJob,
+  outputUrl: string,
+): Promise<AttachResult> {
+  const collection = await ensureRendersCollection(job.timelineId, job.requestedBy);
+  if (!collection.ok) return { ok: false, reason: collection.reason };
+
+  const entry = await readStoredTimelineEntry(job.timelineId, job.requestedBy);
+  const name = renderClipName(entry?.document.title ?? "", job.createdAt);
+  const clipId = mintClipId();
+
+  const outcome = await applyCollectionsCommand(
+    // The ROOT is the timeline whose closure gets loaded; the Renders
+    // collection is a child of it, so it is in the graph.
+    job.timelineId,
+    (graph: CollectionsGraph) => {
+      const parentId = parseNodeId(collection.id);
+      if (!graph.nodesById.has(parentId)) {
+        return { ok: false, message: `Renders collection "${collection.id}" is not loaded.` } as const;
+      }
+      return {
+        ok: true,
+        command: {
+          type: "add-nodes",
+          toParentId: parentId,
+          // Newest last, so the collection reads in the order cuts were made.
+          toIndex: graph.childrenById.get(parentId)?.length ?? 0,
+          nodes: [
+            {
+              id: parseNodeId(clipId),
+              kind: "media" as const,
+              mediaKind: "video" as const,
+              name,
+              src: outputUrl,
+              // The cut list already knows exactly how long this is — the
+              // renderer produced it — so nothing here is estimated.
+              fullDurationSeconds: job.cutList.durationSeconds,
+              trimInSeconds: 0,
+              trimOutSeconds: 0,
+            },
+          ],
+        },
+        details: {
+          [clipId]: {
+            alt: name,
+            title: name,
+            aspect: job.cutList.format.width / job.cutList.format.height,
+            trackIndex: 0,
+            // Provenance: which render made this file. Not `sourceAsset` —
+            // that names a provider file, and this names the JOB.
+            tags: ["render"],
+          },
+        },
+      } as const;
+    },
+    job.requestedBy,
+  );
+
+  if (!outcome.ok) {
+    return {
+      ok: false,
+      reason: outcome.kind === "rejected" ? outcome.rejection.reason : outcome.message,
+    };
+  }
+  return { ok: true, collectionId: collection.id, nodeId: clipId };
+}

--- a/apps/timeline-gstudio001/lib/render/job-store.test.ts
+++ b/apps/timeline-gstudio001/lib/render/job-store.test.ts
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { RenderCutList, RenderJob } from "./types";
+
+// Store tests over the REAL transaction logic — only the Firestore SDK is
+// faked, with an all-or-nothing runTransaction, the same shape
+// app/api/timelines/timelines-batch.test.ts uses.
+
+type Stored = Record<string, unknown>;
+
+const state = vi.hoisted(() => {
+  const docs = new Map<string, Stored>();
+  const applySet = (id: string, data: Stored, opts?: { merge?: boolean }) => {
+    const existing = docs.get(id);
+    docs.set(id, opts?.merge && existing ? { ...existing, ...data } : { ...data });
+  };
+  const snapshot = (id: string) => {
+    const data = docs.get(id);
+    return { id, exists: data !== undefined, data: () => (data ? { ...data } : undefined) };
+  };
+  const docRef = (id: string) => ({
+    id,
+    get: async () => snapshot(id),
+    set: async (data: Stored, opts?: { merge?: boolean }) => applySet(id, data, opts),
+  });
+  const db = {
+    collection: () => ({
+      doc: docRef,
+      where: (field: string, _op: string, value: unknown) => ({
+        limit: () => ({
+          get: async () => ({
+            docs: [...docs.keys()].filter((id) => docs.get(id)?.[field] === value).map(snapshot),
+          }),
+        }),
+      }),
+    }),
+    runTransaction: async <T>(fn: (tx: unknown) => Promise<T>): Promise<T> => {
+      const staged: (() => void)[] = [];
+      const tx = {
+        get: async (ref: { id: string }) => snapshot(ref.id),
+        set: (ref: { id: string }, data: Stored, opts?: { merge?: boolean }) => {
+          staged.push(() => applySet(ref.id, data, opts));
+        },
+      };
+      const result = await fn(tx);
+      for (const op of staged) op();
+      return result;
+    },
+  };
+  return { docs, db };
+});
+
+vi.mock("server-only", () => ({}));
+vi.mock("../firebase-admin", () => ({ getFirebaseDb: () => state.db }));
+
+import { claimNextRenderJob, createRenderJob, readRenderJob, reportRenderProgress } from "./job-store";
+
+const CUT_LIST: RenderCutList = {
+  cuts: [
+    {
+      src: "https://cdn.test/a.mp4",
+      kind: "video",
+      sourceStart: 0,
+      outputDuration: 4,
+      playbackRate: 1,
+      outputStart: 0,
+    },
+  ],
+  durationSeconds: 4,
+  format: { width: 1152, height: 480, fps: 24 },
+};
+
+const job = (id: string): RenderJob => ({
+  id,
+  timelineId: "project-1",
+  projectRevision: 3,
+  cutList: CUT_LIST,
+  requestedBy: "user-a",
+  createdAt: "2026-08-14T00:00:00.000Z",
+});
+
+const NOW = "2026-08-14T00:01:00.000Z";
+
+beforeEach(() => {
+  state.docs.clear();
+});
+
+describe("createRenderJob / readRenderJob", () => {
+  it("stores a job queued and reads it back whole", async () => {
+    await createRenderJob(job("render-1"), "local");
+    const stored = await readRenderJob("render-1");
+    expect(stored).toMatchObject({
+      id: "render-1",
+      providerId: "local",
+      workerId: null,
+      progress: { state: "queued" },
+      cutList: CUT_LIST,
+    });
+  });
+
+  it("is null for a job that does not exist", async () => {
+    expect(await readRenderJob("nope")).toBeNull();
+  });
+});
+
+describe("claimNextRenderJob", () => {
+  it("claims the OLDEST queued job for the provider", async () => {
+    await createRenderJob({ ...job("render-new"), createdAt: "2026-08-14T02:00:00Z" }, "local");
+    await createRenderJob({ ...job("render-old"), createdAt: "2026-08-14T01:00:00Z" }, "local");
+
+    const claimed = await claimNextRenderJob("local", "worker-1", NOW);
+    expect(claimed?.id).toBe("render-old");
+    expect(claimed?.progress.state).toBe("claimed");
+    expect(claimed?.workerId).toBe("worker-1");
+  });
+
+  it("does not take another provider's work", async () => {
+    await createRenderJob(job("render-1"), "hosted");
+    expect(await claimNextRenderJob("local", "worker-1", NOW)).toBeNull();
+  });
+
+  it("is null when nothing is queued", async () => {
+    expect(await claimNextRenderJob("local", "worker-1", NOW)).toBeNull();
+  });
+
+  it("NEVER hands one job to two workers", async () => {
+    await createRenderJob(job("render-1"), "local");
+    expect((await claimNextRenderJob("local", "worker-1", NOW))?.id).toBe("render-1");
+    // The second worker gets nothing rather than the same render.
+    expect(await claimNextRenderJob("local", "worker-2", NOW)).toBeNull();
+  });
+});
+
+describe("reportRenderProgress", () => {
+  async function claimed(id = "render-1") {
+    await createRenderJob(job(id), "local");
+    await claimNextRenderJob("local", "worker-1", NOW);
+    return id;
+  }
+
+  it("refuses a report from a worker that does not hold the job", async () => {
+    const id = await claimed();
+    const result = await reportRenderProgress(id, "worker-2", { type: "start" }, NOW);
+    expect(result).toEqual({ ok: false, reason: "not-holder" });
+  });
+
+  it("refuses a report against a job that does not exist", async () => {
+    expect(
+      await reportRenderProgress("nope", "worker-1", { type: "start" }, NOW),
+    ).toEqual({ ok: false, reason: "not-found" });
+  });
+
+  it("advances the job and persists the fraction", async () => {
+    const id = await claimed();
+    await reportRenderProgress(id, "worker-1", { type: "start" }, NOW);
+    const result = await reportRenderProgress(
+      id,
+      "worker-1",
+      { type: "progress", fraction: 0.5, message: "cut 2 of 4" },
+      NOW,
+    );
+    expect(result).toMatchObject({ ok: true, changed: false });
+    expect((await readRenderJob(id))?.progress).toEqual({
+      state: "rendering",
+      fraction: 0.5,
+      message: "cut 2 of 4",
+    });
+  });
+
+  it("reports CHANGED when the state actually moves", async () => {
+    const id = await claimed();
+    const result = await reportRenderProgress(id, "worker-1", { type: "start" }, NOW);
+    expect(result).toMatchObject({ ok: true, changed: true });
+  });
+
+  it("stores the output URL on success", async () => {
+    const id = await claimed();
+    await reportRenderProgress(
+      id,
+      "worker-1",
+      { type: "succeed", outputUrl: "https://cdn.test/out.mp4" },
+      NOW,
+    );
+    expect((await readRenderJob(id))?.progress).toMatchObject({
+      state: "succeeded",
+      outputUrl: "https://cdn.test/out.mp4",
+    });
+  });
+
+  it("A RETRIED SUCCESS IS NOT A SECOND ONE — changed is false", async () => {
+    // This is what stops a finished render being filed twice. A worker whose
+    // report landed but whose response timed out will retry, and two cards in
+    // the Renders collection for one encode reads as a bug in the renderer.
+    const id = await claimed();
+    const first = await reportRenderProgress(
+      id,
+      "worker-1",
+      { type: "succeed", outputUrl: "https://cdn.test/out.mp4" },
+      NOW,
+    );
+    const retry = await reportRenderProgress(
+      id,
+      "worker-1",
+      { type: "succeed", outputUrl: "https://cdn.test/out.mp4" },
+      NOW,
+    );
+    expect(first).toMatchObject({ ok: true, changed: true });
+    expect(retry).toMatchObject({ ok: true, changed: false });
+    // And the stored URL is still the first one.
+    expect((await readRenderJob(id))?.progress.outputUrl).toBe("https://cdn.test/out.mp4");
+  });
+
+  it("refuses to reopen a finished job", async () => {
+    const id = await claimed();
+    await reportRenderProgress(id, "worker-1", { type: "succeed", outputUrl: "u" }, NOW);
+    expect(
+      await reportRenderProgress(id, "worker-1", { type: "progress", fraction: 0.1 }, NOW),
+    ).toEqual({ ok: false, reason: "terminal" });
+  });
+
+  it("records a failure with its message", async () => {
+    const id = await claimed();
+    await reportRenderProgress(id, "worker-1", { type: "fail", message: "ffmpeg exited 1" }, NOW);
+    expect((await readRenderJob(id))?.progress).toMatchObject({
+      state: "failed",
+      message: "ffmpeg exited 1",
+    });
+  });
+});

--- a/apps/timeline-gstudio001/lib/render/job-store.ts
+++ b/apps/timeline-gstudio001/lib/render/job-store.ts
@@ -162,7 +162,21 @@ export async function claimNextRenderJob(
 }
 
 export type ReportResult =
-  | Readonly<{ ok: true; job: StoredRenderJob }>
+  | Readonly<{
+      ok: true;
+      job: StoredRenderJob;
+      /**
+       * Whether this report MOVED the job, as opposed to being an idempotent
+       * re-report of a state it was already in.
+       *
+       * The caller needs the difference for anything with a side effect. A
+       * worker whose success landed but whose response timed out will retry,
+       * and filing the finished render twice — two cards in the collection for
+       * one encode — is exactly the kind of duplicate that looks like a bug in
+       * the renderer rather than in the retry.
+       */
+      changed: boolean;
+    }>
   | Readonly<{ ok: false; reason: "not-found" | "not-holder" | "terminal" | "out-of-order" | "invalid" }>;
 
 /**
@@ -194,6 +208,11 @@ export async function reportRenderProgress(
     if (!transition.ok) return { ok: false, reason: transition.reason };
 
     const next = transition.next;
+    // A no-op transition is the state machine's idempotent branch: the job was
+    // already terminal and this report agrees with it. Compared by state
+    // rather than by object identity so the answer does not depend on whether
+    // the machine happened to return the same reference.
+    const changed = next.state !== current.progress.state;
     tx.set(
       ref,
       {
@@ -208,6 +227,6 @@ export async function reportRenderProgress(
       },
       { merge: true },
     );
-    return { ok: true, job: { ...current, progress: next, updatedAt: nowIso } };
+    return { ok: true, changed, job: { ...current, progress: next, updatedAt: nowIso } };
   });
 }

--- a/apps/timeline-gstudio001/lib/render/renders-collection.test.ts
+++ b/apps/timeline-gstudio001/lib/render/renders-collection.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import type { TimelineClip } from "@storyboard/timeline-model/types";
+
+import {
+  RENDERS_COLLECTION_NAME,
+  findRendersCollectionId,
+  renderClipName,
+} from "./renders-collection";
+
+function collectionClip(
+  title: string,
+  childTimelineId: string,
+  clipId = childTimelineId,
+): TimelineClip {
+  return {
+    id: clipId,
+    index: 0,
+    kind: "collection",
+    childTimelineId,
+    title,
+    itemCount: 0,
+    previewItems: [],
+    alt: `${title} collection`,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 3,
+    sourceDuration: 3,
+    trimIn: 0,
+    trimOut: 0,
+  } as unknown as TimelineClip;
+}
+
+function mediaClip(id: string): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "image",
+    src: "https://cdn.test/a.png",
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 4,
+    sourceDuration: 4,
+    trimIn: 0,
+    trimOut: 0,
+  } as unknown as TimelineClip;
+}
+
+describe("findRendersCollectionId", () => {
+  it("finds the Renders collection and returns its CHILD timeline id", () => {
+    const clips = [mediaClip("a"), collectionClip("Renders", "timeline-renders")];
+    expect(findRendersCollectionId(clips)).toBe("timeline-renders");
+  });
+
+  it("is null when the project has none", () => {
+    expect(findRendersCollectionId([mediaClip("a"), collectionClip("Scene 1", "t1")])).toBeNull();
+  });
+
+  it("is null for an empty project", () => {
+    expect(findRendersCollectionId([])).toBeNull();
+  });
+
+  it("matches case- and whitespace-insensitively, because a human typed it", () => {
+    // Creating a second collection over a capital letter would quietly split
+    // a project's output in two.
+    for (const title of ["renders", "RENDERS", " Renders ", "ReNdErS"]) {
+      expect(findRendersCollectionId([collectionClip(title, "t-r")])).toBe("t-r");
+    }
+  });
+
+  it("does not match a name that merely contains it", () => {
+    expect(findRendersCollectionId([collectionClip("Old Renders", "t-r")])).toBeNull();
+    expect(findRendersCollectionId([collectionClip("Renders 2024", "t-r")])).toBeNull();
+  });
+
+  it("IGNORES a duplicate reference — writing there files renders under another project", () => {
+    // clip id != childTimelineId is a reference to a collection owned
+    // elsewhere. The first render into it would look fine.
+    const clips = [collectionClip("Renders", "timeline-elsewhere", "ref-clip-1")];
+    expect(findRendersCollectionId(clips)).toBeNull();
+  });
+
+  it("prefers the owning placement when a reference sits beside it", () => {
+    const clips = [
+      collectionClip("Renders", "timeline-elsewhere", "ref-clip-1"),
+      collectionClip("Renders", "timeline-mine"),
+    ];
+    expect(findRendersCollectionId(clips)).toBe("timeline-mine");
+  });
+
+  it("ignores media clips that happen to share the name", () => {
+    const named = { ...mediaClip("Renders"), alt: "Renders" } as TimelineClip;
+    expect(findRendersCollectionId([named])).toBeNull();
+  });
+
+  it("uses the same name it looks for", () => {
+    expect(findRendersCollectionId([collectionClip(RENDERS_COLLECTION_NAME, "t-r")])).toBe("t-r");
+  });
+});
+
+describe("renderClipName", () => {
+  it("stamps the cut so a stack of renders is tellable apart", () => {
+    expect(renderClipName("Joe", "2026-08-14T23:45:05.123Z")).toBe("Joe — 2026-08-14 23:45");
+  });
+
+  it("sorts in the order the cuts were made", () => {
+    const names = ["2026-08-14T09:00:00Z", "2026-08-14T23:45:00Z", "2026-08-15T01:00:00Z"].map(
+      (iso) => renderClipName("Joe", iso),
+    );
+    expect([...names].sort()).toEqual(names);
+  });
+
+  it("falls back rather than producing a name that starts with a dash", () => {
+    expect(renderClipName("   ", "2026-08-14T23:45:05Z")).toBe("Timeline — 2026-08-14 23:45");
+  });
+});

--- a/apps/timeline-gstudio001/lib/render/renders-collection.ts
+++ b/apps/timeline-gstudio001/lib/render/renders-collection.ts
@@ -1,0 +1,54 @@
+import type { TimelineClip } from "@storyboard/timeline-model/types";
+
+/**
+ * Where finished renders land: a collection named "Renders" at the top of the
+ * project, which is the convention this project already follows for finished
+ * cuts.
+ *
+ * Resolved BY NAME rather than by a configured id. A hardcoded id would tie
+ * the app to one owner's project, and an env var would be one more thing to
+ * set correctly before an export could work at all. A name is self-configuring
+ * — it finds an existing Renders collection, and creates one if there is none.
+ */
+export const RENDERS_COLLECTION_NAME = "Renders";
+
+/**
+ * The child timeline id of the project's Renders collection, or null.
+ *
+ * Matches case-insensitively on the trimmed title, because this name is typed
+ * by a human: "renders" and "Renders " are the same intent, and creating a
+ * second collection because of a capital letter is the kind of thing that
+ * quietly splits a project's output in two.
+ *
+ * OWNING PLACEMENTS ONLY. A collection clip whose id differs from its
+ * `childTimelineId` is a duplicate REFERENCE to a collection that lives
+ * somewhere else — writing renders into it would file them under a timeline
+ * this project does not own, and the first one would look fine.
+ *
+ * Direct children only, not a recursive search: "the project's Renders
+ * collection" is a specific place, and a nested one belonging to some scene is
+ * a different thing that happens to share a name.
+ */
+export function findRendersCollectionId(clips: readonly TimelineClip[]): string | null {
+  for (const clip of clips) {
+    if (clip.kind !== "collection") continue;
+    if (clip.childTimelineId !== clip.id) continue;
+    if (clip.title.trim().toLowerCase() !== RENDERS_COLLECTION_NAME.toLowerCase()) continue;
+    return clip.childTimelineId;
+  }
+  return null;
+}
+
+/**
+ * A name for the finished file, as it will read on the card.
+ *
+ * The timestamp is the point: renders accumulate, they are all of the same
+ * timeline, and "Render" repeated eleven times tells you nothing about which
+ * one you just made. Sortable form (YYYY-MM-DD HH:MM) so the collection reads
+ * in the order the cuts were made.
+ */
+export function renderClipName(timelineTitle: string, madeAtIso: string): string {
+  const stamp = madeAtIso.slice(0, 16).replace("T", " ");
+  const base = timelineTitle.trim() || "Timeline";
+  return `${base} — ${stamp}`;
+}


### PR DESCRIPTION
Closes the usable gap left by #391 and #392. Rendering worked, but a render was a hand-written POST and the finished mp4's URL sat in a job document nothing read.

Both choices here were the owner's: **MCP tool** for the trigger, **auto-attach to `Joe > Renders`** for the output.

## Two tools, not one

- **`render_timeline`** — compiles a SNAPSHOT of the timeline and queues it, returning an id immediately.
- **`render_status`** — where it got to, and the finished URL once it succeeds.

An encode is not instant, and a single blocking tool would hold an MCP request open for its whole length. Because the job carries a snapshot, editing the timeline afterwards does not change what renders; `projectRevision` records which version it came from.

## Filing resolves "Renders" by NAME

Not a hardcoded id (which would tie the app to one owner's project) and not an env var (one more thing to set correctly before an export worked at all). A name finds the existing collection and creates one where there is none.

Two details that are decisions rather than defaults, both tested:

- **Case- and whitespace-insensitive.** A human typed this name; creating a second collection over a capital letter would quietly split a project's output in two.
- **Owning placements only.** A collection clip whose id differs from its `childTimelineId` is a duplicate REFERENCE to a collection living elsewhere — filing renders into it would put them under a timeline this project does not own, and the first one would look fine.

## Filing runs AFTER the job is marked succeeded

Deliberately. A failure there loses the **filing**, never the render — the output URL is on the job either way, so a project restructured mid-encode costs a card in a collection rather than a finished file. Attaching first, or letting a filing error fail the worker's report, inverts that.

Doing it safely needed one change underneath: **the store now reports whether a report MOVED the job.** A worker whose success landed but whose response timed out will retry, and the state machine's idempotent branch made that indistinguishable from a first success — so without `changed`, one encode becomes two cards in Renders. Pinned by a test.

## A guard rule had a hole, and it was mine

`readStoredTimelineEntry` is restricted by `no-restricted-imports` because stored collection summaries are stale by design. The rule matched only `@/lib/firebase-timeline-store` — so `from "./firebase-timeline-store"` inside `lib/` resolves to the identical module and matched nothing.

That is exactly how `compile-timeline-manifest.ts` got in during #391 without ever being asked for a reason.

Fixed three ways: the relative specifier is now restricted too, both files are allowlisted with their actual reasons, and the fix was **proven rather than assumed** — a throwaway probe file importing relatively was correctly rejected:

```
error  'readStoredTimelineEntry' import from './firebase-timeline-store' is restricted.
       Same restriction as @/lib/firebase-timeline-store — a relative path is the same module.
```

The two other relative importers (`load-timeline-closure.ts`, `project-asset-scope.ts`) were already allowlisted by path, so closing the hole breaks nothing.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — **1006 passed** (was 980; +26)
- `npm run lint` — clean, the same 5 pre-existing `<img>` warnings
- `npx playwright test --project=graph-view` — **169/169 passed**

## What #310 still lacks

No progress surface in the UI — the fraction is in the job document and served by the API, and nothing renders it. And **layered audio is still phase 2**: `packTimelineClips` packs one sequence and `trackIndex` is always 0, so audio under picture remains unexpressible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)