### PR TITLE
Show a render's progress on the board

### DIFF
--- a/apps/timeline-gstudio001/app/api/renders/route.ts
+++ b/apps/timeline-gstudio001/app/api/renders/route.ts
@@ -6,7 +6,7 @@ import { compileTimelineManifest } from "@/lib/compile-timeline-manifest";
 import { checkUserScopedId, TimelineAccessDeniedError } from "@/lib/timeline-ownership";
 import { TimelineClosureTooLargeError } from "@/lib/load-timeline-closure";
 import { compileCutList, DEFAULT_RENDER_FORMAT } from "@/lib/render/cut-list";
-import { createRenderJob } from "@/lib/render/job-store";
+import { createRenderJob, listRenderJobsForTimeline } from "@/lib/render/job-store";
 import { renderProviders } from "@/lib/render/registry";
 import type { RenderJob } from "@/lib/render/types";
 
@@ -19,6 +19,47 @@ function isValidTimelineId(id: string) {
 
 function mintRenderId(): string {
   return `render-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * This timeline's recent renders, newest first — what the board's status chip
+ * polls.
+ *
+ * A LISTING rather than a per-id lookup, because a render is started from
+ * somewhere else entirely (the MCP tools, an agent) and the board has no id to
+ * ask about. The poll RATE is where the cost of that lives, and it is decided
+ * client-side in `lib/render/render-poll`: fast while something is encoding,
+ * slow when idle, and stopped completely while the tab is hidden.
+ *
+ * The cut list is not returned. It is large, it is the worker's business, and
+ * a chip needs a state, a fraction and a URL.
+ */
+export async function GET(request: Request) {
+  const { user, response } = await requireAuthUser();
+  if (response || !user) {
+    return response || NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const timelineId = new URL(request.url).searchParams.get("timelineId") ?? "";
+  if (!isValidTimelineId(timelineId)) {
+    return NextResponse.json({ error: "Invalid timeline id." }, { status: 400 });
+  }
+
+  try {
+    const jobs = await listRenderJobsForTimeline(timelineId, user.uid);
+    return NextResponse.json({
+      renders: jobs.map((job) => ({
+        id: job.id,
+        createdAt: job.createdAt,
+        updatedAt: job.updatedAt,
+        durationSeconds: job.cutList.durationSeconds,
+        ...job.progress,
+      })),
+    });
+  } catch (error) {
+    console.error("[GSTUDIO_RENDER_LIST_ERROR]", error);
+    return NextResponse.json({ error: "Unable to read renders." }, { status: 500 });
+  }
 }
 
 /**

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -115,6 +115,7 @@ import { ActiveTagFilters, TagFilterControl } from "./graph-tag-filter-control";
 import { ItemDetailsProvider } from "./graph-item-details-context";
 import { useGraphDetailsSnapshot } from "./graph-details-context";
 import { GraphSaveStatus } from "./graph-save-status";
+import { GraphRenderStatus } from "./graph-render-status";
 import { GraphShortcuts, requestGraphShortcuts } from "./graph-shortcuts";
 import { GraphItemDetailsModal } from "./graph-item-details-modal";
 import { SubTimelines } from "./graph-sub-timelines";
@@ -1697,6 +1698,13 @@ export function GraphBoard({
             <div data-crumb-wing className="flex min-w-0 flex-1 items-center gap-3">
               {breadcrumb}
               <GraphSaveStatus />
+              {/* Beside the save status, and for the same reason it sits here:
+                  "where am I / how is it doing" reads as one line, and both
+                  take no space when they have nothing to say. Renders are
+                  started from the MCP tools rather than from this board, so
+                  without this the only sign one had finished was a card
+                  appearing in Renders. */}
+              <GraphRenderStatus timelineId={projectId} />
             </div>
             {/* Middle summary and the right-hand controls fade out under the
                 drag readout that overlays this row, and fade back on drop. The

--- a/apps/timeline-gstudio001/components/graph-view/graph-render-status.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-render-status.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { cn } from "@/lib/utils";
+import { nextPollDelayMs, renderToShow } from "@/lib/render/render-poll";
+import type { RenderProgress } from "@/lib/render/types";
+
+// The render indicator, beside the save status it is modelled on.
+//
+// A render is started from somewhere ELSE — the `render_timeline` MCP tool, an
+// agent — and takes minutes. Without this the board said nothing at all while
+// one ran, and the only sign it had finished was a card appearing in Renders,
+// which is a poor way to learn that a thing you asked for worked.
+//
+// SAME SHAPE AS `GraphSaveStatus`: text only, trailing the breadcrumb, absent
+// when there is nothing to say. A render is rarer than a save but longer, so
+// the one thing it adds is a NUMBER — a percentage is the difference between
+// "still going" and "stuck", and that is the question anyone watching actually
+// has.
+
+/** One row of `GET /api/renders?timelineId=`. `updatedAt` is what the "ready"
+ *  flash times against — when the render SETTLED, not when it was asked for. */
+type RenderRow = RenderProgress &
+  Readonly<{ id: string; createdAt: string; updatedAt: string }>;
+
+/** How long "Render ready" stays up before the chip goes quiet. Longer than
+ *  the save flash: a render is a rarer, bigger event, and the file it made is
+ *  something you may want to go and open. */
+const READY_FLASH_MS = 20_000;
+
+const STATUS_CLASS = "shrink-0 whitespace-nowrap font-mono text-xs";
+
+/**
+ * Poll this timeline's renders, at a rate that follows what is happening — and
+ * not at all while the tab is hidden. The rule is in `lib/render/render-poll`,
+ * where it is unit-tested; this owns the fetching and the timer.
+ */
+function useTimelineRenders(timelineId: string | null): RenderRow[] {
+  const [renders, setRenders] = useState<RenderRow[]>([]);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  /**
+   * Fetch, and RETURN what was fetched.
+   *
+   * Returning the rows is what lets the scheduler below rate itself off them.
+   * The first version kept the latest rows in a ref and read that instead,
+   * which was wrong in a way only the browser showed: the continuation runs in
+   * the microtask after this resolves — BEFORE React has re-rendered and
+   * refreshed the ref — so the poll that discovered a running render still saw
+   * the previous, empty list and scheduled the 30s idle delay. The chip then
+   * sat a full idle cycle behind the render it had just found.
+   */
+  const poll = useCallback(async (): Promise<RenderRow[]> => {
+    if (timelineId === null) return [];
+    try {
+      const response = await fetch(
+        `/api/renders?timelineId=${encodeURIComponent(timelineId)}`,
+        { cache: "no-store" },
+      );
+      if (!response.ok) return [];
+      const body = (await response.json()) as { renders?: RenderRow[] };
+      const rows = body.renders ?? [];
+      setRenders(rows);
+      return rows;
+    } catch {
+      // A failed poll is ordinary — a deploy, a network blip. The next one
+      // covers it, and a chip that shouted about its own polling would be
+      // worse than one that is briefly stale. Reported as "nothing running",
+      // which backs the rate off rather than hammering a server that is down.
+      return [];
+    }
+  }, [timelineId]);
+
+  useEffect(() => {
+    if (timelineId === null) return;
+    let cancelled = false;
+
+    const scheduleFrom = (rows: readonly RenderRow[]) => {
+      if (cancelled) return;
+      const delay = nextPollDelayMs({
+        states: rows.map((render) => render.state),
+        visible: document.visibilityState === "visible",
+      });
+      // Null means the tab is hidden: schedule NOTHING, and wait for the
+      // visibility change below to start it again.
+      if (delay === null) return;
+      timerRef.current = setTimeout(() => {
+        void poll().then(scheduleFrom);
+      }, delay);
+    };
+
+    const restart = () => {
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+      // Coming back to the tab: read once immediately, because whatever was
+      // happening has moved on while nobody was polling.
+      if (document.visibilityState === "visible") void poll().then(scheduleFrom);
+    };
+
+    // Kicked off on a zero timer rather than called straight from the effect
+    // body. `poll` sets state, and the cascading-render lint cannot see that
+    // the fetch in between makes that asynchronous — the repo's usual answer.
+    // Zero is immediate in practice, and it means the first read takes exactly
+    // the same path every later one does.
+    timerRef.current = setTimeout(() => {
+      void poll().then(scheduleFrom);
+    }, 0);
+    document.addEventListener("visibilitychange", restart);
+    return () => {
+      cancelled = true;
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+      document.removeEventListener("visibilitychange", restart);
+    };
+  }, [timelineId, poll]);
+
+  return renders;
+}
+
+export function GraphRenderStatus({ timelineId }: Readonly<{ timelineId: string | null }>) {
+  const renders = useTimelineRenders(timelineId);
+  const showing = renderToShow(
+    renders.map((render) => ({ ...render, progress: { state: render.state } })),
+  );
+
+  // "Ready" is time-based, so it needs a tick of its own — the same problem
+  // the save status has, and the same answer.
+  const [now, setNow] = useState(() => Date.now());
+  const settledAt = showing?.updatedAt;
+  useEffect(() => {
+    if (showing === null || showing.state !== "succeeded") return;
+    const timer = setTimeout(() => setNow(Date.now()), READY_FLASH_MS);
+    return () => clearTimeout(timer);
+  }, [showing, settledAt]);
+
+  if (showing === null) return null;
+
+  if (showing.state === "failed") {
+    // Failures do NOT time out. A render that failed is work you asked for and
+    // did not get, and it leaves nothing behind to notice later — unlike a
+    // success, which leaves a card in Renders.
+    return (
+      <span
+        data-render-status="failed"
+        title={showing.message ?? "The render failed."}
+        className={cn(STATUS_CLASS, "text-amber-300")}
+      >
+        Render failed
+      </span>
+    );
+  }
+
+  if (showing.state === "succeeded") {
+    const fresh =
+      showing.updatedAt === undefined ||
+      now - new Date(showing.updatedAt).getTime() < READY_FLASH_MS;
+    if (!fresh) return null;
+    return (
+      <a
+        data-render-status="succeeded"
+        href={showing.outputUrl}
+        target="_blank"
+        rel="noreferrer"
+        title="Open the finished render. It is also filed in Renders."
+        className={cn(STATUS_CLASS, "text-sky-300 underline decoration-dotted underline-offset-2")}
+      >
+        Render ready
+      </a>
+    );
+  }
+
+  if (showing.state === "queued") {
+    return (
+      <span
+        data-render-status="queued"
+        // Says WHY nothing is happening. A queued render with no worker
+        // running sits here indefinitely, and "queued" alone reads as broken.
+        title="Waiting for a render worker to pick it up."
+        className={cn(STATUS_CLASS, "text-zinc-500")}
+      >
+        Render queued
+      </span>
+    );
+  }
+
+  // Claimed or rendering. The PERCENTAGE is the point — it separates "still
+  // going" from "stuck", which is the question anyone watching has.
+  const percent = showing.fraction === undefined ? null : Math.round(showing.fraction * 100);
+  return (
+    <span
+      data-render-status="rendering"
+      data-render-fraction={showing.fraction ?? undefined}
+      title={showing.message ?? "Assembling the render"}
+      className={cn(STATUS_CLASS, "text-zinc-400")}
+    >
+      {percent === null ? "Rendering…" : `Rendering ${percent}%`}
+    </span>
+  );
+}

--- a/apps/timeline-gstudio001/lib/render/job-store.ts
+++ b/apps/timeline-gstudio001/lib/render/job-store.ts
@@ -32,6 +32,12 @@ const RENDER_COLLECTION = "gstudioRenderJobs";
  */
 const CLAIM_SCAN_LIMIT = 20;
 
+/** How many of a timeline's renders one listing reads before narrowing to the
+ *  caller's own. Bounds the read cost of a poll that runs while a tab is open;
+ *  a project with more than this many renders still shows its newest, because
+ *  the sort happens after. */
+const LIST_SCAN_LIMIT = 20;
+
 type RenderJobRecord = {
   timelineId?: string;
   projectRevision?: number;
@@ -159,6 +165,31 @@ export async function claimNextRenderJob(
     if (claimed !== null) return claimed;
   }
   return null;
+}
+
+/**
+ * The most recent renders of one timeline, newest first.
+ *
+ * Equality-only query plus an in-memory sort, for the same reason the claim
+ * scan is: `where(timelineId).orderBy(createdAt)` needs a composite index and
+ * therefore a deploy, and a project has renders in the single figures. The
+ * limit is what keeps that true regardless.
+ */
+export async function listRenderJobsForTimeline(
+  timelineId: string,
+  requesterUid: string,
+  limit = 5,
+): Promise<StoredRenderJob[]> {
+  const snapshot = await collection()
+    .where("timelineId", "==", timelineId)
+    .limit(LIST_SCAN_LIMIT)
+    .get();
+
+  return snapshot.docs
+    .map((doc) => toStoredJob(doc.id, (doc.data() ?? {}) as RenderJobRecord))
+    .filter((job): job is StoredRenderJob => job !== null && job.requestedBy === requesterUid)
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+    .slice(0, limit);
 }
 
 export type ReportResult =

--- a/apps/timeline-gstudio001/lib/render/render-poll.test.ts
+++ b/apps/timeline-gstudio001/lib/render/render-poll.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ACTIVE_POLL_MS,
+  IDLE_POLL_MS,
+  hasActiveRender,
+  nextPollDelayMs,
+  renderToShow,
+} from "./render-poll";
+import type { RenderState } from "./types";
+
+const job = (state: RenderState, createdAt = "2026-08-14T00:00:00Z") => ({
+  createdAt,
+  progress: { state },
+});
+
+describe("hasActiveRender", () => {
+  it("is true while anything is queued, claimed or rendering", () => {
+    for (const state of ["queued", "claimed", "rendering"] as const) {
+      expect(hasActiveRender([state])).toBe(true);
+    }
+  });
+
+  it("is false once everything has finished, either way", () => {
+    expect(hasActiveRender(["succeeded", "failed"])).toBe(false);
+  });
+
+  it("is false with nothing to report", () => {
+    expect(hasActiveRender([])).toBe(false);
+  });
+
+  it("is true if ANY of several is still going", () => {
+    expect(hasActiveRender(["succeeded", "failed", "rendering"])).toBe(true);
+  });
+});
+
+describe("nextPollDelayMs", () => {
+  it("STOPS ENTIRELY when the tab is hidden", () => {
+    // The one that matters for cost: a tab left open for a day polling in the
+    // background is how this runs up a bill quietly.
+    expect(nextPollDelayMs({ states: ["rendering"], visible: false })).toBeNull();
+    expect(nextPollDelayMs({ states: [], visible: false })).toBeNull();
+  });
+
+  it("polls fast while something is actually encoding", () => {
+    expect(nextPollDelayMs({ states: ["rendering"], visible: true })).toBe(ACTIVE_POLL_MS);
+    expect(nextPollDelayMs({ states: ["queued"], visible: true })).toBe(ACTIVE_POLL_MS);
+  });
+
+  it("backs off when nothing is running", () => {
+    expect(nextPollDelayMs({ states: ["succeeded"], visible: true })).toBe(IDLE_POLL_MS);
+    expect(nextPollDelayMs({ states: [], visible: true })).toBe(IDLE_POLL_MS);
+  });
+
+  it("keeps the idle rate an order of magnitude slower than the active one", () => {
+    // Pinned as a relationship rather than two numbers: tuning one without the
+    // other is what turns an idle board into a busy one.
+    expect(IDLE_POLL_MS).toBeGreaterThanOrEqual(ACTIVE_POLL_MS * 10);
+  });
+});
+
+describe("renderToShow", () => {
+  it("is null when there are none", () => {
+    expect(renderToShow([])).toBeNull();
+  });
+
+  it("speaks for the ACTIVE render even when a newer one has finished", () => {
+    // "Rendering 40%" is a fact about now; a finished render has a card in the
+    // Renders collection, where the in-flight one has only this chip.
+    const newest = job("succeeded", "2026-08-14T03:00:00Z");
+    const active = job("rendering", "2026-08-14T01:00:00Z");
+    expect(renderToShow([newest, active])).toBe(active);
+  });
+
+  it("otherwise speaks for the newest", () => {
+    const newest = job("succeeded", "2026-08-14T03:00:00Z");
+    const older = job("failed", "2026-08-14T01:00:00Z");
+    expect(renderToShow([newest, older])).toBe(newest);
+  });
+
+  it("prefers the FIRST active one when several are running", () => {
+    const a = job("rendering", "2026-08-14T03:00:00Z");
+    const b = job("queued", "2026-08-14T02:00:00Z");
+    expect(renderToShow([a, b])).toBe(a);
+  });
+});

--- a/apps/timeline-gstudio001/lib/render/render-poll.ts
+++ b/apps/timeline-gstudio001/lib/render/render-poll.ts
@@ -1,0 +1,69 @@
+import { isTerminal } from "./job-state";
+import type { RenderState } from "./types";
+
+/**
+ * How often the board asks the server about renders.
+ *
+ * This is a COST decision as much as a UX one. The render is started from
+ * somewhere else entirely (an MCP tool, an agent), so the board cannot know a
+ * render exists without asking — and every ask is a Firestore read that runs
+ * for as long as a tab is open. A flat interval fast enough to feel live would
+ * be thousands of reads a day per tab, for a project that renders a handful of
+ * times.
+ *
+ * So the rate follows what is actually happening:
+ *
+ *   ACTIVE — something is queued or encoding, and the number on screen is
+ *   changing. Worth a read every few seconds, and it is bounded by the render.
+ *
+ *   IDLE — nothing is running. The only thing a poll can discover is a render
+ *   someone just started elsewhere, and being a few seconds late to notice
+ *   that costs nothing.
+ *
+ *   HIDDEN — the tab is in the background. Nobody is reading the number, so
+ *   the right rate is none at all. This is the one that matters most: a tab
+ *   left open for a day is the shape that runs up a bill quietly.
+ */
+export const ACTIVE_POLL_MS = 2500;
+export const IDLE_POLL_MS = 30_000;
+
+export type PollInput = Readonly<{
+  /** Every render state the board currently knows about for this timeline. */
+  states: readonly RenderState[];
+  /** `document.visibilityState === "visible"`. */
+  visible: boolean;
+}>;
+
+/** Whether any known render is still going. */
+export function hasActiveRender(states: readonly RenderState[]): boolean {
+  return states.some((state) => !isTerminal(state));
+}
+
+/**
+ * The next poll delay in milliseconds, or null to STOP POLLING ENTIRELY.
+ *
+ * Null rather than "a very long interval": a hidden tab should schedule
+ * nothing at all, so the work resumes on the visibility change rather than
+ * limping along in the background.
+ */
+export function nextPollDelayMs(input: PollInput): number | null {
+  if (!input.visible) return null;
+  return hasActiveRender(input.states) ? ACTIVE_POLL_MS : IDLE_POLL_MS;
+}
+
+/**
+ * Which render the chip should speak for, given the newest-first list.
+ *
+ * AN ACTIVE ONE ALWAYS WINS, even if a newer render has already finished.
+ * "Rendering 40%" is a fact about right now; "Render ready" is a fact about
+ * the past, and a finished render has a durable home — a card in the Renders
+ * collection — where the in-flight one has nothing but this chip.
+ *
+ * Otherwise the newest, so a just-finished render can say so.
+ */
+export function renderToShow<T extends { progress: { state: RenderState } }>(
+  newestFirst: readonly T[],
+): T | null {
+  const active = newestFirst.find((job) => !isTerminal(job.progress.state));
+  return active ?? newestFirst[0] ?? null;
+}


### PR DESCRIPTION
The last gap in #310's loop. A render is started elsewhere — the `render_timeline` MCP tool, an agent — and takes minutes. The board said nothing while one ran, and the only sign it had finished was a card appearing in Renders.

A chip beside the save status it is modelled on: text only, trailing the breadcrumb, absent when there is nothing to say. What it adds over that one is a **number** — "Rendering 45%" is the difference between still-going and stuck, which is the question anyone watching actually has.

| state | shows |
|---|---|
| rendering | `Rendering 45%`, with the worker's stage as the title |
| queued | `Render queued` — titled "Waiting for a render worker to pick it up", because a queued render with no worker sits there indefinitely and `queued` alone reads as broken |
| succeeded | `Render ready`, an **anchor** to the mp4, expiring after 20s |
| failed | `Render failed` in amber, and it **persists** |
| nothing | no chip |

Failures do not time out, unlike the ready flash: a render that failed is work you asked for and did not get, and it leaves nothing behind to notice later — where a success leaves a card in Renders.

## The poll rate is a cost decision

The board cannot know a render exists without asking, and every ask is a Firestore read that runs for as long as a tab is open. A flat interval fast enough to feel live is thousands of reads a day per tab, for a project that renders a handful of times.

- **2.5s** while something is encoding — bounded by the render itself
- **30s** when idle — being a few seconds late to notice a render someone just started costs nothing
- **nothing at all** while the tab is hidden

The last one is the one that matters: a tab left open overnight is the shape that runs up a bill quietly. The rule is pure and unit-tested in `lib/render/render-poll`, including that the idle rate stays an order of magnitude slower than the active one — tuning one without the other is how an idle board becomes a busy one.

## Verified in the real board, and it caught a bug the tests could not

The first version kept the latest renders in a **ref** and read that when scheduling the next poll. The scheduler runs in the microtask after the fetch resolves — **before React re-renders and refreshes the ref** — so the poll that discovered a running render still saw the previous empty list and scheduled the 30s idle delay instead of 2.5s. The chip sat a full idle cycle behind the render it had just found.

Deriving the delay from the fetched rows deletes the ref and the bug together.

Checked against the live board with a stubbed endpoint:

- `rendering` advances **70% → 90% within 3.5s**, so the active rate is in force
- `queued`, `succeeded` (an `<a>` with the file's href), `failed` (amber, persisting), and no chip when there is nothing
- polling **stops while hidden** — the preview tab genuinely reports `hidden`, and it did — and **resumes on `visibilitychange`**

Lint also caught the initial `poll()` being called straight from the effect body: it sets state, and the cascading-render rule cannot see that the fetch in between makes that asynchronous. It now goes through the same timer every later poll uses.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — **1018 passed** (was 1006)
- `npm run lint` — clean, the same 5 pre-existing `<img>` warnings
- `npx playwright test --project=graph-view` — **169/169 passed**

## What #310 still lacks

**Layered audio (phase 2).** `packTimelineClips` packs one sequence and `trackIndex` is always 0, so audio under picture remains unexpressible — left that way rather than faked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)