### PR TITLE
Pack each lane independently (#310 phase 2, model)

### DIFF
--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -30,6 +30,10 @@ import {
   TIMELINE_LEADING_PADDING_SECONDS,
 } from "@storyboard/timeline-model/constants";
 import { tagsField } from "@storyboard/timeline-model/tags";
+// The lane normaliser the model packs with. Imported rather than re-derived:
+// this file's packing is the twin of `packTimelineClips`, and two different
+// answers to "which lane is this clip on" would move layered clips on save.
+import { trackIndexOf } from "@storyboard/timeline-model/documents";
 import type {
   AssetSourceRef,
   CollectionTimelineClip,
@@ -660,17 +664,25 @@ export function graphChildrenToClips(
   details: DetailsById,
   collectionId: string,
 ): TimelineClip[] {
-  let nextStartTime = TIMELINE_LEADING_PADDING_SECONDS;
+  // PER LANE, exactly as `packTimelineClips` does — this is the twin of that
+  // math, and the two drifting is the whole reason the comment at the top of
+  // this file insists they are identical. A graph write that packed one
+  // sequence while the model packed lanes would move every layered clip the
+  // moment it was saved.
+  const nextStartByTrack = new Map<number, number>();
+  const startFor = (track: number) =>
+    nextStartByTrack.get(track) ?? TIMELINE_LEADING_PADDING_SECONDS;
 
   return getChildren(graph, parseNodeId(collectionId)).map((childId, index) => {
     const node = graph.nodesById.get(childId);
     if (!node) throw new Error(`Graph child "${childId}" missing from nodesById.`);
     const detail = details[childId];
-    const startTime = nextStartTime;
+    const trackIndex = trackIndexOf({ trackIndex: detail?.trackIndex ?? 0 });
+    const startTime = startFor(trackIndex);
 
     if (node.kind === "media") {
       const duration = mediaDurationSeconds(node);
-      nextStartTime += duration + CLIP_GAP_SECONDS;
+      nextStartByTrack.set(trackIndex, startTime + duration + CLIP_GAP_SECONDS);
       const base = {
         // A demoted duplicate (see clipSpecs) writes back its STORED id.
         id: detail?.sourceClipId ?? (node.id as string),
@@ -682,7 +694,7 @@ export function graphChildrenToClips(
         alt: detail?.alt ?? node.name,
         ...(detail?.title === undefined ? {} : { title: detail.title }),
         aspect: detail?.aspect ?? 16 / 9,
-        trackIndex: detail?.trackIndex ?? 0,
+        trackIndex,
         startTime,
         duration,
         ...(detail?.playbackStartTime === undefined
@@ -760,7 +772,7 @@ export function graphChildrenToClips(
       ? hydratedCollectionPlayableDuration(graph, details, node.id)
       : detail?.playableDuration;
     const playableDuration = playable === duration ? undefined : playable;
-    nextStartTime += duration + CLIP_GAP_SECONDS;
+    nextStartByTrack.set(trackIndex, startTime + duration + CLIP_GAP_SECONDS);
     return {
       id: detail?.sourceClipId ?? (node.id as string),
       index,
@@ -777,7 +789,7 @@ export function graphChildrenToClips(
       ...(playableDuration === undefined ? {} : { playableDuration }),
       alt: detail?.alt ?? `${node.name} collection`,
       aspect: detail?.aspect ?? 16 / 9,
-      trackIndex: detail?.trackIndex ?? 0,
+      trackIndex,
       startTime,
       duration,
       sourceDuration: detail?.sourceDuration ?? duration,

--- a/packages/timeline-domain/src/lane-roundtrip.test.ts
+++ b/packages/timeline-domain/src/lane-roundtrip.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+
+import { CLIP_GAP_SECONDS } from "@storyboard/timeline-model/constants";
+import { packTimelineClips } from "@storyboard/timeline-model/documents";
+import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
+
+import { buildFocusedGraph, graphChildrenToClips } from "./adapter";
+
+// THE TWIN-MATH TEST.
+//
+// `graphChildrenToClips` re-derives startTime with "packing math identical to
+// packTimelineClips" — the module comment says so, and nothing enforced it.
+// Two answers to "where does this clip start" is not a cosmetic drift: the
+// graph write path runs on every save, so a document whose lanes the model
+// packed one way and the adapter another would MOVE its own clips the moment
+// it was touched.
+//
+// One sequence hid the problem, because with everything on track 0 both
+// implementations reduce to the same accumulator. Lanes are what make them
+// separable, so this is where the agreement has to be pinned.
+
+function media(
+  id: string,
+  duration: number,
+  over: Partial<TimelineClip> = {},
+): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "image",
+    src: `https://cdn.test/${id}.png`,
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration,
+    sourceDuration: duration,
+    trimIn: 0,
+    trimOut: 0,
+    ...over,
+  } as TimelineClip;
+}
+
+/** A picture lane of two shots, with a bed running under both on lane 1. */
+const layered: TimelineDocument = {
+  id: "col",
+  title: "Layered",
+  clips: packTimelineClips([
+    media("shot-1", 4),
+    media("shot-2", 4),
+    media("bed", 30, { trackIndex: 1, kind: "audio", src: "https://cdn.test/bed.wav" }),
+  ]),
+};
+
+function roundTrip(document: TimelineDocument): TimelineClip[] {
+  const built = buildFocusedGraph({ [document.id]: document }, document.id, 1);
+  if (!built.ok) throw new Error(built.error);
+  return graphChildrenToClips(built.value.graph, built.value.details, document.id);
+}
+
+describe("lanes survive the graph round trip", () => {
+  it("the stored document starts each lane at zero", () => {
+    // The premise the round trip is checked against — if this changed, the
+    // assertions below would pass while meaning nothing.
+    expect(layered.clips.map((clip) => [clip.id, clip.startTime])).toEqual([
+      ["shot-1", 0],
+      ["shot-2", 4 + CLIP_GAP_SECONDS],
+      ["bed", 0],
+    ]);
+  });
+
+  it("REPRODUCES the same startTimes the model packed", () => {
+    const out = roundTrip(layered);
+    expect(out.map((clip) => [clip.id, clip.startTime])).toEqual([
+      ["shot-1", 0],
+      ["shot-2", 4 + CLIP_GAP_SECONDS],
+      ["bed", 0],
+    ]);
+  });
+
+  it("keeps each clip in its own lane", () => {
+    const out = roundTrip(layered);
+    expect(out.map((clip) => [clip.id, clip.trackIndex])).toEqual([
+      ["shot-1", 0],
+      ["shot-2", 0],
+      ["bed", 1],
+    ]);
+  });
+
+  it("IS STABLE — a second round trip moves nothing", () => {
+    // The failure this guards is cumulative: a document that shifts a little
+    // on every save looks fine once and is unrecoverable after a week.
+    const once = roundTrip(layered);
+    const twice = roundTrip({ ...layered, clips: once });
+    expect(twice.map((c) => [c.id, c.startTime, c.trackIndex])).toEqual(
+      once.map((c) => [c.id, c.startTime, c.trackIndex]),
+    );
+  });
+
+  it("still agrees on a single-lane document — the compatibility case", () => {
+    const flat: TimelineDocument = {
+      id: "col",
+      title: "Flat",
+      clips: packTimelineClips([media("a", 4), media("b", 2), media("c", 3)]),
+    };
+    expect(roundTrip(flat).map((c) => c.startTime)).toEqual(
+      flat.clips.map((c) => c.startTime),
+    );
+  });
+
+  it("normalises a phantom lane the same way on both sides", () => {
+    // `validate` admits any finite number; both implementations must send a
+    // non-integer to lane 0 or they disagree about where it starts.
+    const odd: TimelineDocument = {
+      id: "col",
+      title: "Odd",
+      clips: packTimelineClips([media("a", 4), media("b", 2, { trackIndex: 1.5 })]),
+    };
+    expect(roundTrip(odd).map((c) => [c.startTime, c.trackIndex])).toEqual([
+      [0, 0],
+      [4 + CLIP_GAP_SECONDS, 0],
+    ]);
+  });
+});

--- a/packages/timeline-model/documents.test.ts
+++ b/packages/timeline-model/documents.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+
+import { CLIP_GAP_SECONDS } from "./constants";
+import {
+  collectionSpanSeconds,
+  effectiveDocument,
+  packTimelineClips,
+  trackIndexOf,
+} from "./documents";
+import type { TimelineClip, TimelineDocument } from "./types";
+
+function clip(
+  id: string,
+  duration: number,
+  over: Partial<TimelineClip> = {},
+): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "image",
+    src: `https://cdn.test/${id}.png`,
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration,
+    sourceDuration: duration,
+    trimIn: 0,
+    trimOut: 0,
+    ...over,
+  } as TimelineClip;
+}
+
+const starts = (clips: readonly TimelineClip[]) => clips.map((c) => c.startTime);
+
+describe("trackIndexOf", () => {
+  it("takes a non-negative integer at face value", () => {
+    expect(trackIndexOf({ trackIndex: 0 })).toBe(0);
+    expect(trackIndexOf({ trackIndex: 3 })).toBe(3);
+  });
+
+  it("sends anything that could mint a PHANTOM lane to track 0", () => {
+    // `validate` deliberately admits any finite number, so stored data can
+    // carry these. A lane nothing can author or see is worse than lane 0.
+    for (const track of [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(trackIndexOf({ trackIndex: track })).toBe(0);
+    }
+    expect(trackIndexOf({ trackIndex: undefined as unknown as number })).toBe(0);
+  });
+});
+
+describe("packTimelineClips", () => {
+  it("packs one lane end to end, with the gap between", () => {
+    const packed = packTimelineClips([clip("a", 4), clip("b", 2), clip("c", 3)]);
+    expect(starts(packed)).toEqual([0, 4 + CLIP_GAP_SECONDS, 4 + 2 + CLIP_GAP_SECONDS * 2]);
+  });
+
+  it("numbers clips by ARRAY position", () => {
+    const packed = packTimelineClips([clip("a", 4), clip("b", 2)]);
+    expect(packed.map((c) => c.index)).toEqual([0, 1]);
+  });
+
+  it("is UNCHANGED for a document that has never used lanes", () => {
+    // Every document written before lanes is entirely on track 0, so this is
+    // the compatibility guarantee the whole change rests on.
+    const clips = [clip("a", 4), clip("b", 2), clip("c", 3)];
+    expect(starts(packTimelineClips(clips))).toEqual([
+      0,
+      4 + CLIP_GAP_SECONDS,
+      4 + 2 + CLIP_GAP_SECONDS * 2,
+    ]);
+  });
+
+  it("STARTS EVERY LANE AT ZERO, so a bed runs under the picture", () => {
+    // The whole point: track 1 must not queue up behind track 0.
+    const packed = packTimelineClips([
+      clip("shot-1", 4),
+      clip("shot-2", 4),
+      clip("vo", 8, { trackIndex: 1 }),
+    ]);
+    expect(starts(packed)).toEqual([0, 4 + CLIP_GAP_SECONDS, 0]);
+  });
+
+  it("packs each lane independently, in its own order", () => {
+    const packed = packTimelineClips([
+      clip("v1", 4),
+      clip("a1", 1, { trackIndex: 1 }),
+      clip("v2", 4),
+      clip("a2", 1, { trackIndex: 1 }),
+    ]);
+    expect(starts(packed)).toEqual([0, 0, 4 + CLIP_GAP_SECONDS, 1 + CLIP_GAP_SECONDS]);
+  });
+
+  it("does not care whether lanes are contiguous or in order", () => {
+    const packed = packTimelineClips([
+      clip("music", 10, { trackIndex: 5 }),
+      clip("shot", 4),
+    ]);
+    expect(starts(packed)).toEqual([0, 0]);
+  });
+
+  it("treats a phantom lane index as track 0, packing it in sequence", () => {
+    const packed = packTimelineClips([clip("a", 4), clip("b", 2, { trackIndex: -1 })]);
+    expect(starts(packed)).toEqual([0, 4 + CLIP_GAP_SECONDS]);
+  });
+
+  it("is empty for no clips", () => {
+    expect(packTimelineClips([])).toEqual([]);
+  });
+});
+
+describe("collectionSpanSeconds", () => {
+  it("is the floor for an empty collection, so its card can be clicked", () => {
+    expect(collectionSpanSeconds([])).toBe(3);
+  });
+
+  it("reaches the end of a single lane", () => {
+    const packed = packTimelineClips([clip("a", 4), clip("b", 2)]);
+    expect(collectionSpanSeconds(packed)).toBe(4 + CLIP_GAP_SECONDS + 2);
+  });
+
+  it("REACHES THE FURTHEST END, not the last clip's", () => {
+    // A bed on track 1 outlasts the picture while sitting EARLIER in the
+    // array. Reading the last element would report a collection shorter than
+    // its own contents — shrinking its card and clipping the tail off a render.
+    const packed = packTimelineClips([
+      clip("bed", 30, { trackIndex: 1 }),
+      clip("shot-1", 4),
+      clip("shot-2", 4),
+    ]);
+    expect(collectionSpanSeconds(packed)).toBe(30);
+  });
+
+  it("still follows the picture when IT is the longer lane", () => {
+    const packed = packTimelineClips([
+      clip("sting", 2, { trackIndex: 1 }),
+      clip("shot-1", 10),
+      clip("shot-2", 10),
+    ]);
+    expect(collectionSpanSeconds(packed)).toBe(10 + CLIP_GAP_SECONDS + 10);
+  });
+});
+
+describe("effectiveDocument with lanes", () => {
+  const doc = (clips: TimelineClip[]): TimelineDocument => ({
+    id: "t1",
+    title: "T",
+    clips,
+  });
+
+  it("closes the gap a disabled clip leaves IN ITS OWN LANE ONLY", () => {
+    const packed = packTimelineClips([
+      clip("v1", 4),
+      clip("v2", 4, { disabled: true }),
+      clip("v3", 4),
+      clip("bed", 20, { trackIndex: 1 }),
+    ]);
+    const effective = effectiveDocument(doc(packed));
+    // v3 moves up into v2's place; the bed is untouched and still starts at 0.
+    expect(effective.clips.map((c) => [c.id, c.startTime])).toEqual([
+      ["v1", 0],
+      ["v3", 4 + CLIP_GAP_SECONDS],
+      ["bed", 0],
+    ]);
+  });
+
+  it("leaves a document with nothing disabled exactly as it was", () => {
+    const packed = packTimelineClips([clip("a", 4), clip("bed", 9, { trackIndex: 1 })]);
+    expect(effectiveDocument(doc(packed)).clips).toBe(packed);
+  });
+});

--- a/packages/timeline-model/documents.ts
+++ b/packages/timeline-model/documents.ts
@@ -48,19 +48,48 @@ function previewItemOf(clip: ImageTimelineClip | VideoTimelineClip) {
   };
 }
 
-/** Derive startTime/index for a clip sequence: leading padding, then each
- *  clip's duration plus the standard gap. The one packing definition every
- *  write path shares. */
+/**
+ * Which lane a clip plays in. Lanes pack independently, so this is what lets a
+ * voiceover run UNDER the picture rather than after it.
+ *
+ * Defensive rather than trusting: `validate` deliberately admits any finite
+ * number here, and a stray `1.5` or `-1` arriving from stored data would mint
+ * a phantom lane that nothing can author or see. Anything that is not a
+ * non-negative integer is track 0 — the same lane every document written
+ * before lanes existed is already on.
+ */
+export function trackIndexOf(clip: Pick<TimelineClip, "trackIndex">): number {
+  const track = clip.trackIndex;
+  return Number.isInteger(track) && track >= 0 ? track : 0;
+}
+
+/**
+ * Derive startTime/index for a clip sequence: leading padding, then each
+ * clip's duration plus the standard gap. The one packing definition every
+ * write path shares.
+ *
+ * PACKS PER LANE. Each `trackIndex` gets its own running start, so lane 1
+ * begins at the same instant lane 0 does and the two play together. Packing
+ * them into one sequence — which is what this did until lanes — is exactly
+ * what made a bed or a VO impossible to express: it could only ever be placed
+ * AFTER the picture, never under it.
+ *
+ * `index` stays the ARRAY position, not a per-lane counter. It is the
+ * document's own order and the tiebreak readers use; making it lane-relative
+ * would give two clips the same index and silently reorder them.
+ *
+ * Identical to the old behaviour for any document that has never used lanes,
+ * because every clip in one is on track 0 — which is every document written
+ * before this.
+ */
 export function packTimelineClips(clips: TimelineClip[]) {
-  let nextStartTime = TIMELINE_LEADING_PADDING_SECONDS;
+  const nextStartByTrack = new Map<number, number>();
 
   return clips.map((clip, index) => {
-    const nextClip = {
-      ...clip,
-      index,
-      startTime: nextStartTime,
-    };
-    nextStartTime += nextClip.duration + CLIP_GAP_SECONDS;
+    const track = trackIndexOf(clip);
+    const startTime = nextStartByTrack.get(track) ?? TIMELINE_LEADING_PADDING_SECONDS;
+    const nextClip = { ...clip, index, startTime };
+    nextStartByTrack.set(track, startTime + nextClip.duration + CLIP_GAP_SECONDS);
     return nextClip;
   });
 }
@@ -85,11 +114,21 @@ export function enabledClips(clips: readonly TimelineClip[]): TimelineClip[] {
  * span.
  */
 export function collectionSpanSeconds(clips: readonly TimelineClip[]): number {
-  const last = clips[clips.length - 1];
-  // The empty case and the unreachable out-of-range case answer alike: a
-  // zero-width collection card cannot be seen or clicked either way.
-  if (last === undefined) return 3;
-  return last.startTime + last.duration + TIMELINE_LEADING_PADDING_SECONDS;
+  // The empty case: a zero-width collection card cannot be seen or clicked.
+  if (clips.length === 0) return 3;
+  // THE FURTHEST END, not the last clip's.
+  //
+  // This read `clips[clips.length - 1]` while every document was one sequence,
+  // where the two are the same thing. With LANES they are not: a bed on track 1
+  // can outlast the picture on track 0 and still sit earlier in the array, and
+  // the old reading would have reported a collection SHORTER than its own
+  // contents — which shrinks its card, truncates its parent's packing, and
+  // clips the tail off a render.
+  const end = clips.reduce(
+    (furthest, clip) => Math.max(furthest, clip.startTime + clip.duration),
+    0,
+  );
+  return end + TIMELINE_LEADING_PADDING_SECONDS;
 }
 
 /**


### PR DESCRIPTION
First layer of phase 2 (layered audio) on #310. Staged as its own PR because the rest — manifest, player, mixing worker, board lanes — builds on this and would be unreviewable as one change.

## What changes

`trackIndex` now means something. Each lane gets its own running start, so lane 1 begins at the same instant lane 0 does:

```
before   shot-1 ──── shot-2 ──── bed          (a bed can only follow the picture)
after    shot-1 ──── shot-2                   (lane 0)
         bed ─────────────────────────        (lane 1, under it)
```

Packing everything into one sequence is precisely what made a VO or a bed impossible to express.

## Backward compatible by construction

Every document written before this is entirely on track 0, where per-lane packing is **arithmetically identical** to the accumulator it replaces. 1018 app tests and 561 shared unit tests pass unchanged — that is the evidence, not the claim.

## Two things this turned up

**`collectionSpanSeconds` read the last clip in the array.** With one sequence that IS the furthest end. With lanes it is not: a 30s bed can outlast the picture while sitting *earlier* in the array, and the old reading reports a collection shorter than its own contents — shrinking its card, truncating its parent's packing, and clipping the tail off a render. It takes the max now.

**The twin math had to move with it.** `graphChildrenToClips` re-derives startTime with "packing math identical to `packTimelineClips`" — the module comment says so, and nothing enforced it. The graph write path runs on every save, so a document the model packed one way and the adapter another would **move its own clips the moment it was touched**. One sequence hid this, because both implementations reduce to the same accumulator on track 0; lanes are what make them separable.

The adapter now imports the model's own lane normaliser rather than re-deriving it, so there is one answer to "which lane is this clip on".

## `trackIndexOf` is deliberately defensive

`validate` admits any finite number for `trackIndex`, so stored data can carry a `1.5` or a `-1` — which would mint a phantom lane nothing can author or see. Both sides send those to lane 0, and a test pins that they agree about it.

## Tests

`packTimelineClips` had **no direct test** before this — only indirect coverage through the adapter. It has one now, plus `lane-roundtrip.test.ts` pinning the twin-math agreement, including that a **second round trip moves nothing**. That failure mode is cumulative: a document that shifts slightly on every save looks fine once and is unrecoverable after a week.

**Proven non-vacuous.** Reverting the adapter to single-sequence packing fails the round-trip test:

```
× REPRODUCES the same startTimes the model packed
  AssertionError: expected [ [ 'shot-1', +0 ], …(2) ] to deeply equal …
  Tests  1 failed | 5 passed (6)
```

Restoring the fix passes it.

## Verification

- `npx tsc --noEmit` in the app and in `packages/ui` — clean
- `npx vitest run` (app) — **1018 passed**
- `npx vitest run --project=unit` — **561 passed** (was 555)
- `npm run lint` — clean, the same 5 pre-existing `<img>` warnings
- `npx playwright test --project=graph-view` — **169/169 passed**

## What is still ahead in phase 2

The manifest emitting overlapping leaves (it hardcodes `trackIndex: 0`), the preview player handling simultaneous leaves, the cut list and worker mixing rather than concatenating, and the board's lane UI. Nothing layered can be authored or rendered yet — this only makes it expressible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)