### PR TITLE
Carry lanes through the manifest, and mix them in the render (#310 phase 2)

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.test.ts
@@ -57,6 +57,9 @@ function leaf(
     collectionPath,
     kind: "image",
     src: `https://cdn.test/${id}.jpg`,
+    // Lane 0 — the picture. These fixtures predate lanes and none of them
+    // exercise layering.
+    trackIndex: 0,
     timelineStart,
     timelineDuration,
     sourceStart: 0,

--- a/apps/timeline-gstudio001/lib/render/cut-list.test.ts
+++ b/apps/timeline-gstudio001/lib/render/cut-list.test.ts
@@ -177,3 +177,144 @@ describe("compileCutList", () => {
     expect(manifest.leaves.map((l) => l.id)).toEqual(["late", "early"]);
   });
 });
+
+// ── LANES (phase 2) ─────────────────────────────────────────────────────────
+//
+// Lane 0 is the picture and concatenates; anything above it runs UNDER and
+// must be repositioned, because closing the gaps moves the picture out from
+// under it.
+
+describe("compileCutList — layers", () => {
+  it("has no layers at all for a timeline that uses none", () => {
+    const list = compileCutList(manifestOf(packed([{ id: "a" }, { id: "b" }])));
+    expect(list.layers).toEqual([]);
+  });
+
+  it("keeps the picture out of the layers, and the layers out of the picture", () => {
+    const manifest = manifestOf([
+      ...packed([{ id: "shot-1" }, { id: "shot-2" }]),
+      leaf({
+        id: "bed",
+        kind: "audio",
+        src: "https://cdn.test/bed.wav",
+        trackIndex: 1,
+        timelineStart: 0,
+        timelineDuration: 30,
+      }),
+    ]);
+    const list = compileCutList(manifest);
+    expect(list.cuts.map((cut) => cut.src)).toEqual([
+      "https://cdn.test/shot-1.mp4",
+      "https://cdn.test/shot-2.mp4",
+    ]);
+    expect(list.layers.map((cut) => cut.src)).toEqual(["https://cdn.test/bed.wav"]);
+  });
+
+  it("THE PICTURE decides the length, and a long bed is clipped to it", () => {
+    // A 30s bed under 8s of picture makes an 8s film with the bed cut off —
+    // which is what a bed is for. Extending to the longest layer would end the
+    // film on however much black the bed had left.
+    const manifest = manifestOf([
+      ...packed([{ id: "shot-1" }, { id: "shot-2" }]),
+      leaf({ id: "bed", trackIndex: 1, timelineStart: 0, timelineDuration: 30 }),
+    ]);
+    const list = compileCutList(manifest);
+    expect(list.durationSeconds).toBe(8);
+    expect(list.layers[0]).toMatchObject({ outputStart: 0, outputDuration: 8 });
+  });
+
+  it("REMAPS a layer through the closed gaps, so it stays on its shot", () => {
+    // The bed lines up with shot-2, which starts at board 4.12 and output 4.
+    // Positioning by board time would land it 0.12s late — and that error
+    // compounds, a second across twenty joins, which is a VO on the wrong shot.
+    const shots = packed([{ id: "shot-1" }, { id: "shot-2" }, { id: "shot-3" }]);
+    const shot2Start = shots[1]!.timelineStart;
+    const manifest = manifestOf([
+      ...shots,
+      leaf({ id: "vo", trackIndex: 1, timelineStart: shot2Start, timelineDuration: 4 }),
+    ]);
+    const list = compileCutList(manifest);
+    expect(shot2Start).toBeCloseTo(4 + GAP, 6);
+    expect(list.layers[0]?.outputStart).toBe(4);
+  });
+
+  it("remaps a layer that starts INSIDE a shot to the same offset within it", () => {
+    const shots = packed([{ id: "shot-1" }, { id: "shot-2" }]);
+    const oneIntoShot2 = shots[1]!.timelineStart + 1;
+    const manifest = manifestOf([
+      ...shots,
+      leaf({ id: "vo", trackIndex: 1, timelineStart: oneIntoShot2, timelineDuration: 2 }),
+    ]);
+    expect(compileCutList(manifest).layers[0]?.outputStart).toBe(5);
+  });
+
+  it("pulls a layer that starts IN A GAP forward to the next shot", () => {
+    // The gap does not exist in the output, so there is nowhere else for it.
+    const shots = packed([{ id: "shot-1" }, { id: "shot-2" }]);
+    const inTheGap = shots[0]!.timelineDuration + GAP / 2;
+    const manifest = manifestOf([
+      ...shots,
+      leaf({ id: "sting", trackIndex: 1, timelineStart: inTheGap, timelineDuration: 2 }),
+    ]);
+    expect(compileCutList(manifest).layers[0]?.outputStart).toBe(4);
+  });
+
+  it("DROPS a layer that starts after the picture ends", () => {
+    // A layer is defined by what it runs under; with no picture left there is
+    // nothing for it to be under.
+    const shots = packed([{ id: "shot-1" }]);
+    const manifest = manifestOf([
+      ...shots,
+      leaf({ id: "tail", trackIndex: 1, timelineStart: 100, timelineDuration: 5 }),
+    ]);
+    const list = compileCutList(manifest);
+    expect(list.layers).toEqual([]);
+    expect(list.durationSeconds).toBe(4);
+  });
+
+  it("drops a disabled layer like any other disabled leaf", () => {
+    const manifest = manifestOf([
+      ...packed([{ id: "shot-1" }]),
+      leaf({ id: "bed", trackIndex: 1, timelineStart: 0, timelineDuration: 4, disabled: true }),
+    ]);
+    expect(compileCutList(manifest).layers).toEqual([]);
+  });
+
+  it("closes the picture's gaps even when a DISABLED shot sat between them", () => {
+    // The layer map is built from the surviving picture, so a dropped shot
+    // pulls later layers forward with it rather than leaving them stranded.
+    const shots = packed([{ id: "a" }, { id: "b", disabled: true }, { id: "c" }]);
+    const cStart = shots[2]!.timelineStart;
+    const manifest = manifestOf([
+      ...shots,
+      leaf({ id: "vo", trackIndex: 1, timelineStart: cStart, timelineDuration: 2 }),
+    ]);
+    const list = compileCutList(manifest);
+    expect(list.cuts.map((cut) => cut.outputStart)).toEqual([0, 4]);
+    expect(list.layers[0]?.outputStart).toBe(4);
+  });
+
+  it("keeps SEVERAL layers, which is a VO over a bed", () => {
+    const manifest = manifestOf([
+      ...packed([{ id: "shot-1" }, { id: "shot-2" }]),
+      leaf({ id: "bed", trackIndex: 1, timelineStart: 0, timelineDuration: 8 }),
+      leaf({ id: "vo", trackIndex: 2, timelineStart: 0, timelineDuration: 3 }),
+    ]);
+    const list = compileCutList(manifest);
+    expect(list.layers.map((cut) => cut.src)).toEqual([
+      "https://cdn.test/bed.mp4",
+      "https://cdn.test/vo.mp4",
+    ]);
+  });
+
+  it("has no picture, and therefore no layers, when only lanes above 0 survive", () => {
+    // Nothing to run under. An audio-only export is a different feature.
+    const manifest = manifestOf([
+      leaf({ id: "bed", trackIndex: 1, timelineStart: 0, timelineDuration: 8 }),
+    ]);
+    const list = compileCutList(manifest);
+    expect(list.cuts).toEqual([]);
+    expect(list.layers).toEqual([]);
+    expect(list.durationSeconds).toBe(0);
+  });
+});

--- a/apps/timeline-gstudio001/lib/render/cut-list.test.ts
+++ b/apps/timeline-gstudio001/lib/render/cut-list.test.ts
@@ -17,6 +17,9 @@ function leaf(over: Partial<PlaybackLeaf> & { id: string }): PlaybackLeaf {
     timelineDuration: 4,
     sourceStart: 0,
     playbackRate: 1,
+    // Lane 0 unless a case overrides it — every cut-list test so far is a
+    // single sequence.
+    trackIndex: 0,
     ...over,
   };
 }

--- a/apps/timeline-gstudio001/lib/render/cut-list.ts
+++ b/apps/timeline-gstudio001/lib/render/cut-list.ts
@@ -65,14 +65,74 @@ export function compileCutList(
     .slice()
     .sort((a, b) => a.timelineStart - b.timelineStart);
 
+  // Lane 0 is the picture; everything above it runs underneath. The manifest
+  // has already resolved which is which, including for nested collections.
+  const picture = playable.filter((leaf) => leaf.trackIndex === 0);
+  const under = playable.filter((leaf) => leaf.trackIndex !== 0);
+
   let outputStart = 0;
-  const cuts: RenderCut[] = playable.map((leaf) => {
+  const cuts: RenderCut[] = picture.map((leaf) => {
     const cut = cutFromLeaf(leaf, outputStart);
     outputStart += cut.outputDuration;
     return cut;
   });
 
-  return { cuts, durationSeconds: outputStart, format };
+  const toOutputTime = boardToOutputTime(picture, outputStart);
+  const layers: RenderCut[] = under.flatMap((leaf) => {
+    const start = toOutputTime(leaf.timelineStart);
+    // Past the end of the picture entirely: it would play over nothing. A
+    // layer is defined by what it runs UNDER, so with no picture left there is
+    // nothing for it to be under.
+    if (start >= outputStart) return [];
+    const cut = cutFromLeaf(leaf, start);
+    // Clipped to the picture, for the same reason the output length is the
+    // picture's: a bed does not extend the film past its last frame.
+    const outputDuration = Math.min(cut.outputDuration, outputStart - start);
+    return outputDuration < MIN_CUT_SECONDS ? [] : [{ ...cut, outputDuration }];
+  });
+
+  return { cuts, layers, durationSeconds: outputStart, format };
+}
+
+/**
+ * Board time → output time, along the picture.
+ *
+ * Needed because closing the gaps MOVES everything. A bed that starts eight
+ * seconds into the board does not start eight seconds into the film: the
+ * picture before it has lost 0.12s per join and every disabled clip it
+ * contained, so the same instant of picture now arrives earlier. Positioning a
+ * layer by its board time would drift it later and later against the cut it
+ * was lined up with — by a second across twenty joins, which is a VO landing
+ * on the wrong shot.
+ *
+ * The map is piecewise-linear over the picture's cuts: inside a cut, offset
+ * from that cut's own output start; in the gap between two, the next cut's
+ * start, since the gap does not exist in the output; past the end, the end.
+ */
+function boardToOutputTime(
+  picture: readonly PlaybackLeaf[],
+  totalOutput: number,
+): (boardTime: number) => number {
+  // Built once and closed over: a layer list is short, but this is O(picture)
+  // per lookup otherwise and the picture is not.
+  const spans = picture.map((leaf, index) => ({
+    boardStart: leaf.timelineStart,
+    boardEnd: leaf.timelineStart + leaf.timelineDuration,
+    outputStart: picture
+      .slice(0, index)
+      .reduce((total, earlier) => total + earlier.timelineDuration, 0),
+  }));
+
+  return (boardTime: number) => {
+    if (spans.length === 0) return 0;
+    for (const span of spans) {
+      if (boardTime < span.boardStart) return span.outputStart;
+      if (boardTime < span.boardEnd) {
+        return span.outputStart + (boardTime - span.boardStart);
+      }
+    }
+    return totalOutput;
+  };
 }
 
 function cutFromLeaf(leaf: PlaybackLeaf, outputStart: number): RenderCut {

--- a/apps/timeline-gstudio001/lib/render/ffmpeg-plan.test.ts
+++ b/apps/timeline-gstudio001/lib/render/ffmpeg-plan.test.ts
@@ -7,6 +7,7 @@ import {
   atempoChain,
   concatArgs,
   concatListFile,
+  mixArgs,
   segmentArgs,
   segmentFraction,
 } from "../../scripts/render-worker/ffmpeg-plan.mjs";
@@ -210,5 +211,64 @@ describe("segmentFraction", () => {
 
   it("is zero for nothing to do, rather than dividing by zero", () => {
     expect(segmentFraction(0, 0)).toBe(0);
+  });
+});
+
+describe("mixArgs — layers under the picture", () => {
+  const layer = (path: string, outputStart: number) => ({ path, outputStart });
+  const args = (layers: { path: string; outputStart: number }[]) =>
+    mixArgs("/tmp/picture.mp4", layers, "/tmp/out.mp4") as string[] | null;
+
+  it("is NULL with nothing to mix, so the concat IS the finished file", () => {
+    // Re-encoding to add nothing would cost a whole generation of the film.
+    expect(args([])).toBeNull();
+  });
+
+  it("delays each layer to its own start, in MILLISECONDS and per channel", () => {
+    // A single adelay value delays only the first channel — not a late start
+    // but a stereo image sliding apart.
+    const filter = valueAfter(args([layer("/tmp/vo.mp4", 1.5)])!, "-filter_complex");
+    expect(filter).toContain("[1:a]adelay=1500|1500[l1]");
+  });
+
+  it("rounds a fractional start to a whole millisecond", () => {
+    const filter = valueAfter(args([layer("/tmp/vo.mp4", 2.0004)])!, "-filter_complex");
+    expect(filter).toContain("adelay=2000|2000");
+  });
+
+  it("never delays by a negative amount", () => {
+    const filter = valueAfter(args([layer("/tmp/vo.mp4", -1)])!, "-filter_complex");
+    expect(filter).toContain("adelay=0|0");
+  });
+
+  it("MIXES WITHOUT NORMALISING — a bed must not halve the dialogue", () => {
+    // amix normalises by default, dividing every input by the input count.
+    const filter = valueAfter(args([layer("/tmp/bed.mp4", 0)])!, "-filter_complex");
+    expect(filter).toContain("normalize=0");
+  });
+
+  it("follows the PICTURE's length, not the longest layer", () => {
+    const filter = valueAfter(args([layer("/tmp/bed.mp4", 0)])!, "-filter_complex");
+    expect(filter).toContain("duration=first");
+  });
+
+  it("mixes the picture's own audio in with the layers", () => {
+    const filter = valueAfter(args([layer("/tmp/bed.mp4", 0)])!, "-filter_complex");
+    expect(filter).toContain("[0:a][l1]amix=inputs=2");
+  });
+
+  it("takes several layers — a VO over a bed", () => {
+    const out = args([layer("/tmp/bed.mp4", 0), layer("/tmp/vo.mp4", 3)])!;
+    const filter = valueAfter(out, "-filter_complex");
+    expect(filter).toContain("[1:a]adelay=0|0[l1]");
+    expect(filter).toContain("[2:a]adelay=3000|3000[l2]");
+    expect(filter).toContain("[0:a][l1][l2]amix=inputs=3");
+    expect(allValuesAfter(out, "-i")).toEqual(["/tmp/picture.mp4", "/tmp/bed.mp4", "/tmp/vo.mp4"]);
+  });
+
+  it("COPIES the video rather than re-encoding the whole film to add sound", () => {
+    const out = args([layer("/tmp/bed.mp4", 0)])!;
+    expect(valueAfter(out, "-c:v")).toBe("copy");
+    expect(allValuesAfter(out, "-map")).toEqual(["0:v", "[aout]"]);
   });
 });

--- a/apps/timeline-gstudio001/lib/render/job-store.test.ts
+++ b/apps/timeline-gstudio001/lib/render/job-store.test.ts
@@ -66,6 +66,7 @@ const CUT_LIST: RenderCutList = {
       outputStart: 0,
     },
   ],
+  layers: [],
   durationSeconds: 4,
   format: { width: 1152, height: 480, fps: 24 },
 };

--- a/apps/timeline-gstudio001/lib/render/provider.test.ts
+++ b/apps/timeline-gstudio001/lib/render/provider.test.ts
@@ -70,7 +70,7 @@ describe("localRenderProvider", () => {
         id: "render-1",
         timelineId: "project-1",
         projectRevision: 3,
-        cutList: { cuts: [], durationSeconds: 0, format: { width: 1, height: 1, fps: 24 } },
+        cutList: { cuts: [], layers: [], durationSeconds: 0, format: { width: 1, height: 1, fps: 24 } },
         requestedBy: "user-a",
         createdAt: "2026-08-14T00:00:00.000Z",
       }),

--- a/apps/timeline-gstudio001/lib/render/types.ts
+++ b/apps/timeline-gstudio001/lib/render/types.ts
@@ -56,17 +56,30 @@ export type RenderFormat = Readonly<{
  * The finished cut list — everything a renderer needs and nothing about how it
  * renders.
  *
- * PHASE 1 IS A SEQUENCE. `cuts` never overlap, because the stored model cannot
- * express overlap: `packTimelineClips` packs one sequence and `trackIndex` is
- * carried but always 0. Layered audio (VO or a bed UNDER the picture) needs
- * per-track packing in the model first, and is deliberately out of scope here
- * rather than faked — an export that silently flattened a layered mix into a
- * sequence would be worse than one that cannot express it yet.
+ * TWO PARTS, because a timeline has two kinds of content. `cuts` is the
+ * PICTURE: lane 0, concatenated, gaps closed. `layers` is everything placed
+ * UNDER it — a voiceover, a music bed — which does not concatenate, because
+ * the whole point of it is to play at the same time as something else.
  */
 export type RenderCutList = Readonly<{
+  /** The picture, in order, touching. Never overlapping. */
   cuts: readonly RenderCut[];
-  /** Total output length: the sum of the cut durations, gaps already removed.
-   *  NOT the manifest's `durationSeconds`, which is board time. */
+  /**
+   * Everything on a lane above the picture, positioned in OUTPUT time.
+   *
+   * These DO overlap the cuts — that is what makes them layers — and they may
+   * overlap each other, which is a VO over a bed. Empty for any timeline that
+   * uses no lanes, which is every one written before phase 2.
+   */
+  layers: readonly RenderCut[];
+  /**
+   * Total output length: the sum of the PICTURE's durations, gaps removed.
+   *
+   * The picture decides, not the longest layer. A 30-second bed under eight
+   * seconds of picture makes an eight-second film with the bed cut off at the
+   * end — which is what a bed is for. The alternative, extending the output to
+   * the longest layer, ends the film on however much black the bed had left.
+   */
   durationSeconds: number;
   format: RenderFormat;
 }>;

--- a/apps/timeline-gstudio001/scripts/render-worker/ffmpeg-plan.mjs
+++ b/apps/timeline-gstudio001/scripts/render-worker/ffmpeg-plan.mjs
@@ -207,3 +207,69 @@ export function segmentFraction(index, total) {
   if (total <= 0) return 0;
   return Math.min(0.95, ((index + 1) / total) * 0.95);
 }
+
+/**
+ * Mix the under-layers into the concatenated picture.
+ *
+ * Input 0 is the picture (video + its own audio); inputs 1..N are the layer
+ * segments, already normalised by `segmentArgs`, so their audio is 48k stereo
+ * like everything else. Only their AUDIO is used — a layer's picture, if it
+ * had one, is not composited. That is phase 2's stated limit: lanes carry
+ * sound under the picture, not picture over it.
+ *
+ * THREE ffmpeg details, each of which is a wrong file if missed:
+ *
+ * `normalize=0` on amix. It defaults to ON, which divides every input by the
+ * number of inputs — so adding a quiet bed would silently halve the dialogue
+ * that was already there. The layers were levelled when they were made; the
+ * mixer must not second-guess them.
+ *
+ * `duration=first` so the output follows the PICTURE. Without it amix runs to
+ * the longest input and a 30s bed under 8s of picture yields 30 seconds, the
+ * last 22 of them black.
+ *
+ * `adelay` in MILLISECONDS, and per channel — `adelay=1500|1500` for stereo.
+ * A single value delays only the first channel, which is not a late start but
+ * a stereo image that slides apart.
+ */
+export function mixArgs(picturePath, layers, outputPath) {
+  if (layers.length === 0) {
+    // Nothing to mix. Returning the concat's own arguments would re-encode for
+    // no reason; the caller uses the picture as the finished file instead.
+    return null;
+  }
+
+  const inputs = ["-i", picturePath];
+  const chains = [];
+  const mixLabels = ["[0:a]"];
+
+  layers.forEach((layer, index) => {
+    const streamIndex = index + 1;
+    inputs.push("-i", layer.path);
+    const delayMs = Math.max(0, Math.round(layer.outputStart * 1000));
+    const label = `[l${streamIndex}]`;
+    chains.push(`[${streamIndex}:a]adelay=${delayMs}|${delayMs}${label}`);
+    mixLabels.push(label);
+  });
+
+  const filter = [
+    ...chains,
+    `${mixLabels.join("")}amix=inputs=${mixLabels.length}:duration=first:normalize=0[aout]`,
+  ].join(";");
+
+  return [
+    "-y",
+    ...inputs,
+    "-filter_complex", filter,
+    "-map", "0:v",
+    "-map", "[aout]",
+    // The picture is already encoded exactly right by the concat — copying it
+    // keeps the mix from costing a second generation of the whole film.
+    "-c:v", "copy",
+    "-c:a", "aac",
+    "-ar", "48000",
+    "-ac", "2",
+    "-movflags", "+faststart",
+    outputPath,
+  ];
+}

--- a/apps/timeline-gstudio001/scripts/render-worker/index.mjs
+++ b/apps/timeline-gstudio001/scripts/render-worker/index.mjs
@@ -25,6 +25,7 @@ import { join } from "node:path";
 import {
   concatArgs,
   concatListFile,
+  mixArgs,
   probeAudioArgs,
   segmentArgs,
   segmentFraction,
@@ -139,32 +140,57 @@ async function renderJob(job) {
   const workDir = await mkdtemp(join(tmpdir(), `render-${job.id}-`));
   try {
     await report(job.id, { type: "start" });
-    const { cuts, format } = job.cutList;
-    const segments = [];
+    const { cuts, layers = [], format } = job.cutList;
+    // Both kinds normalise the same way, so one loop makes both. Only what
+    // happens AFTER differs: the picture concatenates, the layers get mixed
+    // underneath it.
+    const total = cuts.length + layers.length;
+    let done = 0;
 
-    for (const [index, cut] of cuts.entries()) {
+    const normalise = async (cut, name) => {
       // Downloaded rather than streamed: a 404 or an expired URL then fails
       // here, clearly, instead of surfacing as an opaque ffmpeg error four
       // steps later.
-      const sourcePath = join(workDir, `src-${index}${extensionFor(cut)}`);
+      const sourcePath = join(workDir, `src-${name}${extensionFor(cut)}`);
       await download(cut.src, sourcePath);
-
       const hasAudio = cut.kind === "video" ? await probeHasAudio(sourcePath) : false;
-      const segmentPath = join(workDir, `seg-${String(index).padStart(4, "0")}.mp4`);
+      const segmentPath = join(workDir, `seg-${name}.mp4`);
       await run("ffmpeg", segmentArgs({ ...cut, src: sourcePath }, format, segmentPath, { hasAudio }));
-      segments.push(segmentPath);
-
       await report(job.id, {
         type: "progress",
-        fraction: segmentFraction(index, cuts.length),
-        message: `cut ${index + 1} of ${cuts.length}`,
+        fraction: segmentFraction(done, total),
+        message: `${done + 1} of ${total}`,
       });
+      done += 1;
+      return segmentPath;
+    };
+
+    const segments = [];
+    for (const [index, cut] of cuts.entries()) {
+      segments.push(await normalise(cut, `pic-${String(index).padStart(4, "0")}`));
     }
 
     const listPath = join(workDir, "concat.txt");
     await writeFile(listPath, concatListFile(segments));
-    const outputPath = join(workDir, `${job.id}.mp4`);
-    await run("ffmpeg", concatArgs(listPath, outputPath));
+    const picturePath = join(workDir, `picture-${job.id}.mp4`);
+    await run("ffmpeg", concatArgs(listPath, picturePath));
+
+    // THE LAYERS. Each is normalised like a cut — so a trimmed or rate-scaled
+    // VO is resolved exactly the way a shot would be — and only its audio is
+    // used by the mix.
+    const layerSegments = [];
+    for (const [index, layer] of layers.entries()) {
+      layerSegments.push({
+        path: await normalise(layer, `lay-${String(index).padStart(4, "0")}`),
+        outputStart: layer.outputStart,
+      });
+    }
+
+    const mix = mixArgs(picturePath, layerSegments, join(workDir, `${job.id}.mp4`));
+    // Null means nothing to mix: the concat already IS the finished file, and
+    // re-encoding to add nothing would cost a generation of the whole film.
+    const outputPath = mix === null ? picturePath : join(workDir, `${job.id}.mp4`);
+    if (mix !== null) await run("ffmpeg", mix);
 
     const url = await uploadResult(job.id, outputPath);
     await report(job.id, { type: "succeed", outputUrl: url });

--- a/apps/timeline-gstudio001/scripts/render-worker/smoke-test.mjs
+++ b/apps/timeline-gstudio001/scripts/render-worker/smoke-test.mjs
@@ -24,6 +24,7 @@ import {
   segmentArgs,
   concatArgs,
   concatListFile,
+  mixArgs,
   probeAudioArgs,
 } from "./ffmpeg-plan.mjs";
 
@@ -112,6 +113,64 @@ try {
   // segment. If concat dropped it, the audio stream would be short.
   const audioDuration = Number(await run("ffprobe", ["-v", "error", "-select_streams", "a:0", "-show_entries", "stream=duration", "-of", "csv=p=0", finalPath]));
   check("audio runs the WHOLE file, not just the first cut", audioDuration.toFixed(2), (d) => Math.abs(Number(d) - expectedDuration) < 0.35);
+
+  // --- LANES: mix a bed and a VO UNDER the finished picture ---------------
+  //
+  // The phase 2 claim. `finalPath` is the picture; the two layers are
+  // normalised the same way a cut is, then delayed and mixed beneath it.
+  const bedSeg = join(dir, "layer-bed.mp4");
+  await run("ffmpeg", segmentArgs(
+    { src: voice, kind: "audio", sourceStart: 0, outputDuration: 6, playbackRate: 1, outputStart: 0 },
+    FORMAT, bedSeg,
+  ));
+  const voSeg = join(dir, "layer-vo.mp4");
+  await run("ffmpeg", segmentArgs(
+    { src: withAudio, kind: "video", sourceStart: 0, outputDuration: 2, playbackRate: 1, outputStart: 0 },
+    FORMAT, voSeg, { hasAudio: true },
+  ));
+
+  const mixed = join(dir, "mixed.mp4");
+  const mix = mixArgs(finalPath, [
+    { path: bedSeg, outputStart: 0 },
+    { path: voSeg, outputStart: 3 },
+  ], mixed);
+  check("mixArgs produced a command for two layers", mix !== null, true);
+  await run("ffmpeg", mix);
+
+  const mixedDuration = Number(await run("ffprobe", ["-v", "error", "-show_entries", "format=duration", "-of", "csv=p=0", mixed]));
+  // duration=first: the PICTURE decides, so the mix is the same length even
+  // though a layer was delayed 3s into it.
+  check("mixing does not lengthen the film", mixedDuration.toFixed(2), (d) => Math.abs(Number(d) - expectedDuration) < 0.35);
+
+  const mixedStreams = await run("ffprobe", ["-v", "error", "-show_entries", "stream=codec_type", "-of", "csv=p=0", mixed]);
+  check("mixed file still has video AND audio", mixedStreams.split("\n").map((s) => s.trim()).sort().join(","), "audio,video");
+
+  const mixedVideoCodec = await run("ffprobe", ["-v", "error", "-select_streams", "v:0", "-show_entries", "stream=codec_name", "-of", "csv=p=0", mixed]);
+  check("video was COPIED, not re-encoded", mixedVideoCodec, "h264");
+
+  // The audible proof: measure loudness before and after. Adding a bed and a
+  // VO must make the film LOUDER, not quieter — which is what amix's default
+  // normalising would have done by dividing every input by the input count.
+  // `volumedetect` reports on STDERR, like everything ffmpeg says about a
+  // file — `run` resolves stdout, so this needs its own capture.
+  const meanVolume = (path) =>
+    new Promise((resolve) => {
+      const child = spawn("ffmpeg", [
+        "-hide_banner", "-nostats",
+        "-i", path,
+        "-af", "volumedetect",
+        "-f", "null", "-",
+      ]);
+      let err = "";
+      child.stderr.on("data", (chunk) => (err += chunk));
+      child.on("close", () => {
+        const match = /mean_volume:\s*(-?[\d.]+) dB/.exec(err);
+        resolve(match ? Number(match[1]) : Number.NaN);
+      });
+    });
+  const before = await meanVolume(finalPath);
+  const after = await meanVolume(mixed);
+  check(`mix is LOUDER than the picture alone (${before.toFixed(1)} -> ${after.toFixed(1)} dB)`, after > before, true);
 } finally {
   await rm(dir, { recursive: true, force: true });
 }

--- a/packages/timeline-domain/src/lane-manifest.test.ts
+++ b/packages/timeline-domain/src/lane-manifest.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+
+import { packTimelineClips } from "@storyboard/timeline-model/documents";
+import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
+
+import { compilePlaybackManifest } from "./playback-manifest";
+
+// What the manifest says about LANES — the read model export and the player
+// both consume, so "is this leaf picture or under-layer" gets decided here
+// exactly once.
+
+function media(
+  id: string,
+  duration: number,
+  over: Partial<TimelineClip> = {},
+): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "image",
+    src: `https://cdn.test/${id}.png`,
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration,
+    sourceDuration: duration,
+    trimIn: 0,
+    trimOut: 0,
+    ...over,
+  } as TimelineClip;
+}
+
+function collection(
+  id: string,
+  childTimelineId: string,
+  duration: number,
+  over: Partial<TimelineClip> = {},
+): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "collection",
+    childTimelineId,
+    title: id,
+    itemCount: 1,
+    previewItems: [],
+    alt: `${id} collection`,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration,
+    sourceDuration: duration,
+    trimIn: 0,
+    trimOut: 0,
+    ...over,
+  } as unknown as TimelineClip;
+}
+
+const doc = (id: string, clips: TimelineClip[]): TimelineDocument => ({
+  id,
+  title: id,
+  clips: packTimelineClips(clips),
+});
+
+const compile = (documents: Record<string, TimelineDocument>, root = "root") =>
+  compilePlaybackManifest(documents, root, 1, "2026-08-15T00:00:00.000Z");
+
+const laneOf = (manifest: ReturnType<typeof compile>, id: string) =>
+  manifest.leaves.find((leaf) => leaf.id === id)?.trackIndex;
+
+describe("manifest lanes", () => {
+  it("puts everything on the picture when nothing uses lanes", () => {
+    const manifest = compile({ root: doc("root", [media("a", 4), media("b", 4)]) });
+    expect(manifest.leaves.map((leaf) => leaf.trackIndex)).toEqual([0, 0]);
+  });
+
+  it("EMITS OVERLAPPING LEAVES for a bed under the picture", () => {
+    // The whole point of phase 2: two leaves live at the same instant.
+    const manifest = compile({
+      root: doc("root", [
+        media("shot-1", 4),
+        media("shot-2", 4),
+        media("bed", 30, { trackIndex: 1, kind: "audio", src: "https://cdn.test/bed.wav" }),
+      ]),
+    });
+    const bed = manifest.leaves.find((leaf) => leaf.id === "bed");
+    const shot2 = manifest.leaves.find((leaf) => leaf.id === "shot-2");
+    expect(bed?.timelineStart).toBe(0);
+    expect(bed?.trackIndex).toBe(1);
+    // shot-2 starts while the bed is still running — they overlap.
+    expect(shot2!.timelineStart).toBeGreaterThan(0);
+    expect(shot2!.timelineStart).toBeLessThan(bed!.timelineStart + bed!.timelineDuration);
+  });
+
+  it("reports the whole timeline's duration as the FURTHEST lane end", () => {
+    const manifest = compile({
+      root: doc("root", [media("shot", 4), media("bed", 30, { trackIndex: 1 })]),
+    });
+    expect(manifest.durationSeconds).toBe(30);
+  });
+
+  it("a bed inside a lane-0 collection is UNDER — its own lane decides", () => {
+    const manifest = compile({
+      root: doc("root", [collection("scene", "scene-doc", 20)]),
+      "scene-doc": doc("scene-doc", [
+        media("shot", 4),
+        media("bed", 20, { trackIndex: 1 }),
+      ]),
+    });
+    expect(laneOf(manifest, "shot")).toBe(0);
+    expect(laneOf(manifest, "bed")).toBe(1);
+  });
+
+  it("EVERYTHING inside a lane-1 collection is under, however it is arranged", () => {
+    // The outermost placement decides the role. A shot on lane 0 inside a
+    // collection that was itself placed under the picture is still under it.
+    const manifest = compile({
+      root: doc("root", [
+        media("picture", 10),
+        collection("under", "under-doc", 10, { trackIndex: 1 }),
+      ]),
+      "under-doc": doc("under-doc", [media("inner", 10)]),
+    });
+    expect(laneOf(manifest, "picture")).toBe(0);
+    expect(laneOf(manifest, "inner")).toBe(1);
+  });
+
+  it("does NOT let an inner lane override an outer one", () => {
+    // A lane-2 clip inside a lane-1 collection is still "under the picture at
+    // lane 1" — the inner index only described that collection's own layout,
+    // which the window math has already resolved.
+    const manifest = compile({
+      root: doc("root", [collection("under", "under-doc", 10, { trackIndex: 1 })]),
+      "under-doc": doc("under-doc", [media("deep", 10, { trackIndex: 2 })]),
+    });
+    expect(laneOf(manifest, "deep")).toBe(1);
+  });
+
+  it("normalises a phantom lane to the picture", () => {
+    const manifest = compile({
+      root: doc("root", [media("odd", 4, { trackIndex: -3 })]),
+    });
+    expect(laneOf(manifest, "odd")).toBe(0);
+  });
+
+  it("keeps carrying disabled independently of the lane", () => {
+    const manifest = compile({
+      root: doc("root", [
+        media("shot", 4),
+        media("bed", 20, { trackIndex: 1, disabled: true }),
+      ]),
+    });
+    expect(manifest.leaves.find((leaf) => leaf.id === "bed")).toMatchObject({
+      trackIndex: 1,
+      disabled: true,
+    });
+  });
+});

--- a/packages/timeline-domain/src/playback-manifest.ts
+++ b/packages/timeline-domain/src/playback-manifest.ts
@@ -18,6 +18,7 @@
 // only it knows whether the user is playing (jump the span) or scrubbing
 // (draw it grayed).
 
+import { trackIndexOf } from "@storyboard/timeline-model/documents";
 import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
 
 export type PlaybackLeaf = Readonly<{
@@ -31,6 +32,23 @@ export type PlaybackLeaf = Readonly<{
   timelineDuration: number;
   sourceStart: number;
   playbackRate: number;
+  /**
+   * Which lane this plays in, relative to the ROOT timeline: 0 is the picture,
+   * anything higher runs under it.
+   *
+   * THE OUTERMOST NON-ZERO LANE ON THE PATH, not the leaf's own. Where a thing
+   * sits relative to the root is what decides whether it is picture or
+   * under-layer; a lane inside a collection only governs that collection's own
+   * layout, which the window math has already resolved by the time a leaf
+   * exists.
+   *
+   * So a bed on lane 1 inside a lane-0 scene is lane 1 — it runs under. And
+   * every leaf inside a lane-1 collection is lane 1, however its own children
+   * are arranged, because the whole collection was placed under the picture.
+   *
+   * Absent is impossible; 0 is the answer for everything written before lanes.
+   */
+  trackIndex: number;
   /** Skipped by the PLAYER, not by this compiler. A disabled leaf keeps its
    *  full span on the timeline — that span is what the playhead jumps over
    *  while playing and what a scrub can land inside. Set when the leaf's own
@@ -79,6 +97,7 @@ function addMediaLeaf(
   overlapStart: number,
   overlapEnd: number,
   disabled: boolean,
+  trackIndex: number,
 ): void {
   const localSpan = Math.max(0.001, window.localEnd - window.localStart);
   const outputScale = window.outputDuration / localSpan;
@@ -95,6 +114,7 @@ function addMediaLeaf(
     timelineDuration: (overlapEnd - overlapStart) * outputScale,
     sourceStart: clip.trimIn + clipProgress * sourceRange,
     playbackRate: (sourceRange / Math.max(0.001, clip.duration)) / outputScale,
+    trackIndex,
     ...(disabled ? { disabled: true } : {}),
   });
 }
@@ -111,6 +131,11 @@ function flattenDocument(
    *  the way down — an enabled child of a disabled parent still does not play.
    */
   inheritedDisabled: boolean,
+  /** The outermost non-zero lane seen on the way down, or 0 while still on the
+   *  picture. Once a collection has put us under the picture, everything below
+   *  it is under there too — there is no way back up, the same shape
+   *  `inheritedDisabled` has. */
+  laneFromRoot: number,
 ): void {
   if (visited.has(documentId)) throw new Error(`Collection cycle detected at "${documentId}".`);
   const document = documents[documentId];
@@ -130,9 +155,13 @@ function flattenDocument(
     // it is marked. That span is what the player jumps over and what a scrub
     // can land inside.
     const clipDisabled = inheritedDisabled || clip.disabled === true;
+    // The OUTERMOST non-zero lane wins: once something above put us under the
+    // picture, a lane index down here only described that collection's own
+    // internal layout, which the window math has already resolved.
+    const clipLane = laneFromRoot !== 0 ? laneFromRoot : trackIndexOf(clip);
 
     if (clip.kind !== "collection") {
-      addMediaLeaf(leaves, clip, path, window, overlapStart, overlapEnd, clipDisabled);
+      addMediaLeaf(leaves, clip, path, window, overlapStart, overlapEnd, clipDisabled, clipLane);
       continue;
     }
 
@@ -159,6 +188,7 @@ function flattenDocument(
       nextVisited,
       leaves,
       clipDisabled,
+      clipLane,
     );
   }
 }
@@ -199,6 +229,9 @@ export function compilePlaybackManifest(
     new Set(),
     leaves,
     false,
+    // The root IS the picture. Everything descends from lane 0 until some clip
+    // on the way down says otherwise.
+    0,
   );
 
   return {
@@ -228,7 +261,9 @@ export function manifestToClips(manifest: PlaybackManifest): TimelineClip[] {
       index,
       alt: leaf.id,
       aspect: 16 / 9,
-      trackIndex: 0,
+      // The leaf's REAL lane, so the player lays simultaneous leaves out the
+      // way the board does rather than stacking them all on the picture.
+      trackIndex: leaf.trackIndex,
       startTime: leaf.timelineStart,
       duration: leaf.timelineDuration,
       sourceDuration: leaf.sourceStart + sourceRange,


### PR DESCRIPTION
Layers 2 and 3 of phase 2, on top of #395 (per-lane packing). Two commits, kept separate because they are separable: the read model, then export.

## Layer 2 — the manifest carries a lane

The window math was **already lane-agnostic** — it reads each clip's stored `startTime` rather than accumulating — so overlapping clips produced overlapping leaves the moment packing allowed it. What was missing is that a leaf did not say *which* lane, and `manifestToClips` stamped every one with `trackIndex: 0`.

**The outermost non-zero lane on the path wins.** Where a thing sits relative to the root decides whether it is picture or under-layer; a lane index inside a collection only ever described that collection's own layout, which the window math has already resolved by the time a leaf exists.

- a bed on lane 1 inside a lane-0 scene is lane 1 — it runs under
- every leaf inside a lane-1 collection is lane 1, however its children are arranged
- an inner lane **cannot** override an outer one, which stops a nested index quietly promoting itself back onto the picture

It rides down the walk exactly like `inheritedDisabled`, and for the same reason: once something above has put you under the picture there is no way back up.

## Layer 3 — export mixes

The cut list splits in two: `cuts` is the PICTURE (lane 0, concatenated, gaps closed, unchanged) and `layers` is everything under it, positioned in output time.

**Remapping is the interesting part.** Closing the gaps MOVES the picture, so a bed that starts eight seconds into the board does not start eight seconds into the film — every join before it lost 0.12s and every disabled shot its whole span. Positioning a layer by board time drifts it later and later against the cut it was lined up with: about a second across twenty joins, which is a VO landing on the wrong shot. `boardToOutputTime` is piecewise-linear along the surviving picture — inside a cut, the same offset within it; in a gap, the next cut's start, because the gap does not exist in the output.

**The picture decides the length.** A 30s bed under 8s of picture makes an 8s film with the bed cut off, which is what a bed is for. A layer starting after the picture ends is dropped — a layer is defined by what it runs UNDER, and there is nothing left for it to be under.

### Three ffmpeg details, each a wrong file if missed

| | why |
|---|---|
| `normalize=0` on amix | defaults **on**, dividing every input by the input count — adding a quiet bed would have halved the dialogue already there |
| `duration=first` | otherwise a 30s bed under 8s of picture yields 30 seconds, 22 of them black |
| `adelay` per channel | a single value delays one channel: not a late start but a stereo image sliding apart |

The video is **copied** into the mix, so adding sound costs no second generation of the whole film.

## Proven against real ffmpeg, including the audible part

The smoke test now mixes a bed and a delayed VO under the assembled picture:

```
PASS  mixArgs produced a command for two layers: true
PASS  mixing does not lengthen the film: 7.52
PASS  mixed file still has video AND audio: audio,video
PASS  video was COPIED, not re-encoded: h264
PASS  mix is LOUDER than the picture alone (-25.9 -> -22.1 dB): true
ALL CHECKS PASSED   (20/20, ffmpeg 8.1.2)
```

That last check is what catches `amix` normalising — a silent failure that makes a film quieter the more you add to it, and one no argument assertion can see. (The loudness probe reads **stderr**: `volumedetect` reports there, like everything ffmpeg says about a file, so the first version measured `NaN`.)

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` (app) — **1038 passed** (was 1018)
- `npx vitest run --project=unit` — **569 passed**
- `npm run lint` — clean, the same 5 pre-existing `<img>` warnings
- `npx playwright test --project=graph-view` — **169/169 passed**
- `node scripts/render-worker/smoke-test.mjs` — **20/20** against ffmpeg 8.1.2

## What is left in phase 2

The preview player handling simultaneous leaves, and the board's lane UI — the authoring surface. Until that lands, a layered timeline can be rendered correctly but can only be *created* through an MCP call, and the board still draws every lane inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)