### PR TITLE
Draw the picture, and put clips on a lane (#310 phase 2)

### DIFF
--- a/apps/timeline-gstudio001/app/api/mcp/route.ts
+++ b/apps/timeline-gstudio001/app/api/mcp/route.ts
@@ -24,6 +24,7 @@ import { ProjectAssetScopeError } from "@/lib/project-asset-scope";
 import {
   handleMoveClip,
   handleRemoveClip,
+  handleSetLane,
   handleRenameItem,
   handleSetTags,
   handleTrimClip,
@@ -337,6 +338,26 @@ const handler = createMcpHandler(
         const uid = uidFrom(extra);
         if (!uid) return errorResult(NO_IDENTITY);
         return fromToolResult(await handleRenderStatus(args, { requesterUid: uid }));
+      },
+    );
+
+    server.tool(
+      "set_lane",
+      "Move a clip between LANES. Lane 0 is the picture; anything above it plays UNDER the picture at the same time — a voiceover, a music bed. Every lane starts at the beginning of its collection, so putting a clip on lane 1 makes it run alongside the shots rather than after them." +
+        NO_LIVE_PUSH_NOTE,
+      {
+        timelineId: TIMELINE_ID_FIELD,
+        nodeId: nodeIdField,
+        lane: z
+          .number()
+          .int()
+          .min(0)
+          .describe("0 is the picture. 1 and above run underneath it."),
+      },
+      async (args, extra) => {
+        const uid = uidFrom(extra);
+        if (!uid) return errorResult(NO_IDENTITY);
+        return fromToolResult(await handleSetLane(args, { requesterUid: uid }));
       },
     );
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-card-badges.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-card-badges.tsx
@@ -83,7 +83,15 @@ export function LiveDurationPill({ id, node }: { id: NodeId; node: MediaNode }) 
 export function ProvenanceLabel({
   parentId,
   name,
-}: Readonly<{ parentId: NodeId; name: string }>) {
+  shifted = false,
+}: Readonly<{
+  parentId: NodeId;
+  name: string;
+  /** A LaneChip has taken the corner — move along rather than sit under it.
+   *  Whole literal class names below, since Tailwind never generates an
+   *  interpolated offset. */
+  shifted?: boolean;
+}>) {
   const nav = useContext(GraphViewNavContext);
   return (
     <span
@@ -105,7 +113,10 @@ export function ProvenanceLabel({
       // duration pill right, and the label spanning both would sit under
       // them), and the top-right belongs to the disabled chip. Capped width so
       // a long collection name truncates instead of running into that chip.
-      className="pointer-events-auto absolute left-1 top-1 z-10 max-w-[70%] cursor-pointer truncate rounded bg-sky-950/85 px-1 py-0.5 text-[8px] leading-none font-semibold text-sky-200 ring-1 ring-sky-400/30 hover:bg-sky-900/90 hover:text-sky-100"
+      className={[
+        "pointer-events-auto absolute top-1 z-10 max-w-[70%] cursor-pointer truncate rounded bg-sky-950/85 px-1 py-0.5 text-[8px] leading-none font-semibold text-sky-200 ring-1 ring-sky-400/30 hover:bg-sky-900/90 hover:text-sky-100",
+        shifted ? "left-8" : "left-1",
+      ].join(" ")}
     >
       {name}
     </span>
@@ -260,6 +271,37 @@ export function SelectionIndicator({
         className={["size-4 text-white", selected ? "opacity-100" : "opacity-0"].join(" ")}
         strokeWidth={3}
       />
+    </span>
+  );
+}
+
+/**
+ * Which LANE a card is on, when it is not the picture.
+ *
+ * Absent on lane 0, which is almost every card — a badge that appeared on
+ * everything would say nothing. It shows up exactly when a clip has been put
+ * somewhere surprising, and "surprising" is the whole message: this does not
+ * play after the clip beside it, it plays UNDER the shots.
+ *
+ * Sky, matching the provenance label rather than the amber disabled chip: a
+ * lane is a placement, not a warning.
+ *
+ * TOP-LEFT, and it shares that corner with the provenance label — which they
+ * CAN both want at once. A flat run draws cards from nested collections
+ * inline, and one of those can perfectly well be on lane 1, so "they never
+ * appear together" is not true. The lane takes the corner and provenance
+ * shifts along, because a lane changes what you HEAR while provenance only
+ * says where a card is filed.
+ */
+export function LaneChip({ lane }: Readonly<{ lane: number }>) {
+  return (
+    <span
+      aria-hidden="true"
+      data-lane-chip={lane}
+      title={`Lane ${lane} — plays under the picture, not after it`}
+      className="pointer-events-none absolute left-1 top-1 z-20 rounded bg-sky-950/85 px-1 py-0.5 font-mono text-[8px] leading-none font-semibold tracking-[0.08em] text-sky-200 ring-1 ring-sky-400/30"
+    >
+      L{lane}
     </span>
   );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-card-model.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-card-model.ts
@@ -179,3 +179,16 @@ export function collectionCardSeconds(
   if (input.hydrated) return input.liveSeconds;
   return input.storedPlayableDuration ?? input.storedDuration ?? null;
 }
+
+/**
+ * Which LANE a card's clip plays in, from its side-table entry.
+ *
+ * Defensive in the same way `trackIndexOf` in the model is, and for the same
+ * reason: a detail entry can carry anything a stored document did, and a
+ * fractional or negative index would put a chip on a card that packs as
+ * picture. One answer to "which lane", on both sides of the seam.
+ */
+export function laneOf(detail: Readonly<{ trackIndex?: number }> | undefined): number {
+  const track = detail?.trackIndex;
+  return typeof track === "number" && Number.isInteger(track) && track >= 0 ? track : 0;
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-clip-card.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-clip-card.tsx
@@ -20,6 +20,7 @@ import { TrimPanel } from "./graph-trim-panel";
 import { AudioPlaceholder } from "./graph-card-placeholders";
 import {
   DisabledChip,
+  LaneChip,
   LiveDurationPill,
   ProvenanceLabel,
   SELECT_HOVER_REVEAL_MEDIA,
@@ -33,7 +34,7 @@ import {
   CaptionTagRowSpacer,
 } from "./graph-card-caption";
 import { cardDimmingClass } from "./graph-card-dimming";
-import { cardVideoFrameCount } from "./graph-card-model";
+import { cardVideoFrameCount, laneOf } from "./graph-card-model";
 import { useElementSize, useSettledFrameCount } from "./graph-card-measure";
 import { useVideoFrameLoading } from "./graph-card-frame-loading";
 import { useCardProvenance, useDisabledByAncestor } from "./graph-card-derivations";
@@ -101,6 +102,9 @@ export const GraphClipContent = memo(function GraphClipContent({
   // `node.name`: the node's name falls back to the derived alt, so it can't
   // tell "named by someone" from "named by the file system".
   const detail = useClipDetail(id as string);
+  // Which lane this plays in. Lives in the details side table because the
+  // engine does not model it — see set_lane.
+  const lane = laneOf(detail);
 
   // MEDIA pixels only. This guard is defensive: nothing in the graph view
   // reaches it with a collection node.
@@ -301,7 +305,16 @@ export const GraphClipContent = memo(function GraphClipContent({
         </span>
       )}
       {muted && <DisabledChip inherited={node.disabled !== true} />}
-      {provenance && <ProvenanceLabel parentId={provenance.parentId} name={provenance.name} />}
+      {/* Lane 0 is the picture and says nothing; anything above it is a
+          placement worth announcing on the card. */}
+      {lane > 0 && <LaneChip lane={lane} />}
+      {provenance && (
+        <ProvenanceLabel
+          parentId={provenance.parentId}
+          name={provenance.name}
+          shifted={lane > 0}
+        />
+      )}
       {trimEnabled && !muted && <LiveDurationPill id={id} node={node} />}
       {/* The live trim frame (video only): the source at the edge being
           dragged, floated into the header band for the length of the gesture.

--- a/apps/timeline-gstudio001/components/graph-view/graph-collection-card.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-collection-card.tsx
@@ -27,6 +27,7 @@ import {
 } from "./graph-card-placeholders";
 import {
   DisabledChip,
+  LaneChip,
   SELECT_HOVER_REVEAL_COLLECTION,
   SelectionIndicator,
 } from "./graph-card-badges";
@@ -37,7 +38,7 @@ import {
   CaptionTagRowSpacer,
 } from "./graph-card-caption";
 import { cardDimmingClass } from "./graph-card-dimming";
-import { collectionCardItemCount, collectionCardSeconds } from "./graph-card-model";
+import { collectionCardItemCount, collectionCardSeconds, laneOf } from "./graph-card-model";
 import {
   useCollectionPreviewFrames,
   useDisabledByAncestor,
@@ -148,6 +149,10 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
         ].join(" ")}
       >
         {muted && <DisabledChip inherited={node.disabled !== true} />}
+        {/* A whole collection can sit under the picture too — every leaf
+            inside it then plays underneath, however its own children are
+            arranged. */}
+        {laneOf(detail) > 0 && <LaneChip lane={laneOf(detail)} />}
         {/* Collections are taggable too — `tags` sits on TimelineItemBase, not
             on the media members — and they route through THIS component rather
             than GraphClipContent (which returns null for them at its guard).

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -143,11 +143,11 @@ const ASSET_B: PreviewItem = {
  *  `hydrated: false` keeps the frames coming from the stored `previewItems`
  *  here — a hydrated card would instead derive them from live graph children,
  *  which this offline fixture deliberately does not carry. */
-function renderWithDetail(previewItems: PreviewItem[]) {
+function renderWithDetail(previewItems: PreviewItem[], trackIndex = 0) {
   const detail: ClipDetail = {
     alt: "A timeline",
     aspect: 16 / 9,
-    trackIndex: 0,
+    trackIndex,
     hydrated: false,
     itemCount: previewItems.length,
     duration: previewItems.length * 4,
@@ -628,6 +628,57 @@ export const NoDisabledChipWhenEnabled: Story = {
     const surface = canvasElement.querySelector<HTMLElement>("[data-node-id]")!;
     await expect(surface.classList.contains("is-disabled-card")).toBe(false);
     await expect(canvasElement.querySelector("[data-disabled-chip]")).toBeNull();
+  },
+};
+
+// ── Lanes ───────────────────────────────────────────────────────────────────
+//
+// Lane 0 is the picture; anything above it plays UNDER the picture at the same
+// time. The chip exists because that placement is invisible otherwise: the
+// card sits in the same strip either way, and nothing else on it says that it
+// will be heard rather than watched in turn.
+
+/**
+ * A card on lane 1 says so. `L1`, sky rather than the disabled chip's amber —
+ * a lane is a placement, not a warning.
+ */
+export const LaneChipOnAnUnderLayer: Story = {
+  args: baseArgs,
+  decorators: [renderWithDetail([ASSET_A, ASSET_B], 1)],
+  play: async ({ canvasElement }) => {
+    const chip = canvasElement.querySelector<HTMLElement>("[data-lane-chip]")!;
+    await expect(chip).not.toBeNull();
+    await expect(chip.dataset.laneChip).toBe("1");
+    await expect(chip.textContent).toBe("L1");
+    await expect(getComputedStyle(chip).opacity).toBe("1");
+  },
+};
+
+/**
+ * The PICTURE carries no chip at all. Almost every card is lane 0, and a badge
+ * that appeared on everything would say nothing — the chip earns its place by
+ * marking the surprising case only.
+ */
+export const NoLaneChipOnThePicture: Story = {
+  args: baseArgs,
+  decorators: [renderWithDetail([ASSET_A, ASSET_B], 0)],
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelector("[data-lane-chip]")).toBeNull();
+  },
+};
+
+/**
+ * A phantom lane index reads as the picture, matching how the model packs it.
+ *
+ * `validate` admits any finite number for `trackIndex`, so stored data can
+ * carry a fractional or negative one. It packs as lane 0, so a chip claiming
+ * otherwise would describe a placement the file does not have.
+ */
+export const PhantomLaneShowsNoChip: Story = {
+  args: baseArgs,
+  decorators: [renderWithDetail([ASSET_A, ASSET_B], -2)],
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelector("[data-lane-chip]")).toBeNull();
   },
 };
 

--- a/apps/timeline-gstudio001/lib/mcp/write-handlers.ts
+++ b/apps/timeline-gstudio001/lib/mcp/write-handlers.ts
@@ -440,3 +440,84 @@ export async function handleRemoveClip(
     written: outcome.affectedIds,
   });
 }
+
+// --- set_lane ----------------------------------------------------------------
+
+export type SetLaneArgs = Readonly<{
+  timelineId: string;
+  nodeId: string;
+  lane: number;
+}>;
+
+/**
+ * Move a clip between LANES: 0 is the picture, anything above runs under it.
+ *
+ * A detail-only write, like `set_tags` — `trackIndex` lives in the side table
+ * because the engine does not model it, so the graph is genuinely unchanged and
+ * there is no command to issue.
+ *
+ * BUT UNLIKE TAGS, THIS CHANGES PACKING. A tag alters nothing about where
+ * anything sits; a lane re-packs the whole parent (every lane starts at zero,
+ * so pulling a clip out of the picture closes the gap behind it) and can change
+ * the parent's own SPAN — a 30s bed moved onto lane 1 no longer extends the
+ * sequence, so the collection gets shorter, which changes the duration its own
+ * parent stores for it, and so on up. So the write set is the parent AND its
+ * ancestors, where `set_tags` correctly names only the parent.
+ *
+ * Getting that wrong would not fail loudly: the clip would move, and every
+ * ancestor would keep a stale duration until something unrelated rewrote it.
+ */
+export async function handleSetLane(
+  args: SetLaneArgs,
+  ctx: WriteContext,
+): Promise<ToolResult> {
+  const nodeId = parseNodeId(args.nodeId);
+  if (!Number.isInteger(args.lane) || args.lane < 0) {
+    return toolError("`lane` must be a whole number, 0 or more. 0 is the picture.");
+  }
+
+  const outcome = await applyCollectionsCommand(
+    args.timelineId,
+    (graph: CollectionsGraph, details) => {
+      if (!graph.nodesById.has(nodeId)) {
+        return { ok: false, message: `No node with id "${args.nodeId}".` } as const;
+      }
+      const parentId = graph.parentById.get(nodeId) ?? null;
+      if (parentId === null) {
+        return {
+          ok: false,
+          message: `"${args.nodeId}" is a timeline itself, not a clip inside one — no lane to put it on.`,
+        } as const;
+      }
+      const existing = details[nodeId as string];
+
+      // The parent and everything above it: a lane change can shorten or
+      // lengthen the parent, which every ancestor stores a duration for.
+      const affected: string[] = [];
+      let current: NodeId | null = parentId;
+      while (current !== null && !affected.includes(current as string)) {
+        affected.push(current as string);
+        current = graph.parentById.get(current) ?? null;
+      }
+
+      return {
+        ok: true,
+        // Spread the WHOLE existing entry — `graphChildrenToClips` rebuilds the
+        // clip from this record, so dropping `sourceAsset`, `poster` or `alt`
+        // here would erase them from the stored clip on save.
+        details: {
+          [nodeId as string]: { ...existing, trackIndex: args.lane } as DetailsById[string],
+        },
+        affectedCollectionIds: affected,
+      } as const;
+    },
+    ctx.requesterUid,
+  );
+  if (!outcome.ok) return reportFailure(outcome);
+  return toolOk(
+    args.lane === 0
+      ? `Moved "${args.nodeId}" onto the picture.`
+      : `Moved "${args.nodeId}" to lane ${args.lane} — it now plays under the picture.`,
+    { nodeId: args.nodeId, lane: args.lane, written: outcome.affectedIds },
+  );
+}

--- a/packages/ui/timeline/viewport/playback-skip.test.ts
+++ b/packages/ui/timeline/viewport/playback-skip.test.ts
@@ -118,3 +118,57 @@ describe("nextPlayableTime", () => {
     }
   });
 });
+
+// ── LANES ───────────────────────────────────────────────────────────────────
+//
+// Several clips can cover one instant now: lane 0 is the picture, anything
+// above it runs underneath. The surface draws frames from what this returns,
+// so picking an under-layer means trying to draw a clip with no picture.
+
+function onLane(clip: TimelineClip, trackIndex: number): TimelineClip {
+  return { ...clip, trackIndex };
+}
+
+describe("getContainingClip with lanes", () => {
+  it("prefers the PICTURE when a layer covers the same instant", () => {
+    // The array is sorted by start time, so a bed starting at 0 is found
+    // before a shot starting at 0 — the old array-order rule drew the bed.
+    const bed = onLane(image("bed", 0, 30), 1);
+    const shot = image("shot", 0, 4);
+    expect(getContainingClip([bed, shot], 2)?.id).toBe("shot");
+  });
+
+  it("picks the picture whichever order they arrive in", () => {
+    const bed = onLane(image("bed", 0, 30), 1);
+    const shot = image("shot", 0, 4);
+    expect(getContainingClip([shot, bed], 2)?.id).toBe("shot");
+  });
+
+  it("prefers the LOWEST lane, not merely lane 0", () => {
+    const vo = onLane(image("vo", 0, 10), 2);
+    const bed = onLane(image("bed", 0, 10), 1);
+    expect(getContainingClip([vo, bed], 5)?.id).toBe("bed");
+  });
+
+  it("still returns a layer when nothing else covers the time", () => {
+    // Past the picture, a bed is all there is — and the caller needs to know
+    // the time is inside material rather than in a gap.
+    const bed = onLane(image("bed", 0, 30), 1);
+    const shot = image("shot", 0, 4);
+    expect(getContainingClip([bed, shot], 20)?.id).toBe("bed");
+  });
+
+  it("keeps ARRAY ORDER within a single lane", () => {
+    // Two clips on the picture overlapping is not something packing produces,
+    // but the old behaviour was first-wins and nothing should change for it.
+    const first = image("first", 0, 10);
+    const second = image("second", 0, 10);
+    expect(getContainingClip([first, second], 5)?.id).toBe("first");
+  });
+
+  it("is unchanged for a timeline that uses no lanes", () => {
+    expect(getContainingClip(clips, 2)?.id).toBe("a");
+    expect(getContainingClip(clips, 9)?.id).toBe("c");
+    expect(getContainingClip(clips, 30)).toBeNull();
+  });
+});

--- a/packages/ui/timeline/viewport/playback-skip.ts
+++ b/packages/ui/timeline/viewport/playback-skip.ts
@@ -29,11 +29,30 @@ export function clipContainsPlaybackTime(clip: TimelineClip, currentTime: number
   return currentTime >= playbackStart && currentTime <= playbackStart + playbackDuration;
 }
 
-/** The clip that literally covers this time — never one held over from
- *  earlier. Callers deciding whether a time is INSIDE material (as opposed to
- *  what to draw at it) must use this. */
+/**
+ * The clip that literally covers this time — never one held over from
+ * earlier. Callers deciding whether a time is INSIDE material (as opposed to
+ * what to draw at it) must use this.
+ *
+ * THE LOWEST LANE WINS when several cover the same instant, which is what
+ * lanes made possible. This used to take the first match in array order, and
+ * the array is sorted by start time — so a bed starting at 0 could be found
+ * before the shot starting at 0, and the surface would try to draw a clip
+ * that has no picture. Lane 0 IS the picture; anything above it is running
+ * underneath and is never what a frame comes from.
+ *
+ * `reduce` rather than a sort: this runs per frame while playing, and the
+ * answer is one element.
+ */
 export function getContainingClip(clips: readonly TimelineClip[], currentTime: number) {
-  return clips.find((clip) => clipContainsPlaybackTime(clip, currentTime)) ?? null;
+  let best: TimelineClip | null = null;
+  for (const clip of clips) {
+    if (!clipContainsPlaybackTime(clip, currentTime)) continue;
+    // Strictly lower, so the FIRST clip on a given lane still wins ties —
+    // preserving the old array-order behaviour within a lane.
+    if (best === null || clip.trackIndex < best.trackIndex) best = clip;
+  }
+  return best;
 }
 
 export function getTimelineDuration(clips: readonly TimelineClip[]) {


### PR DESCRIPTION
Layers 4 and 5 of phase 2, on top of #396. Two commits, separable: the player, then authoring.

## The player — draw the picture, not the layer over it

`getContainingClip` took the FIRST clip in array order covering a time. Unambiguous while a timeline was one sequence, because only one clip ever covered an instant. Lanes break it: several do now, the array is sorted by start time, so **a bed starting at 0 is found before the shot starting at 0** — leaving the surface trying to draw a frame from a clip that has no picture.

The lowest lane wins. Strictly-lower rather than `<=`, so the first clip on a given lane still wins ties and nothing changes for a timeline without lanes. It still returns a **layer** when nothing else covers the time — past the picture a bed is all there is, and callers asking "is this inside material" need the truth rather than a null that reads as a gap.

Proven non-vacuous: restoring the first-match implementation fails exactly the two lane-preference cases and leaves the other fourteen green.

## Authoring — `set_lane`, and a chip that says where a clip sits

`set_lane` is a detail-only write like `set_tags`: `trackIndex` lives in the side table because the engine does not model it, so the graph is genuinely unchanged and there is no command to issue.

**But unlike tags, it changes packing, and the write set has to say so.** A tag alters nothing about where anything sits. A lane re-packs the whole parent — every lane starts at zero, so pulling a clip off the picture closes the gap behind it — and can change the parent's own SPAN: a 30s bed moved to lane 1 stops extending the sequence, so the collection gets shorter, so its parent's stored duration for it is wrong, and so on up. The write names the parent **and its ancestors**.

That failure would not be loud: the clip moves, and every ancestor keeps a stale duration until something unrelated rewrites it.

**The chip marks the surprising case only.** Almost every card is lane 0, and a badge on everything says nothing. `L1` appears exactly when a clip will be HEARD under the shots rather than watched in turn — which nothing else on the card conveys, since it sits in the same strip either way.

It collides with the provenance label, which I first claimed it could not: a flat run draws nested collections' cards inline and one of those can perfectly well be on lane 1. The lane takes the corner and provenance shifts along, because a lane changes what you hear while provenance only says where a card is filed.

`laneOf` normalises defensively for the same reason the model's `trackIndexOf` does — a fractional or negative index packs as lane 0, so a chip claiming otherwise would describe a placement the file does not have.

## What this is NOT

Lanes drawn as time-aligned ROWS with their own drag-and-drop. That is filed as #397 with everything scoping it turned up — chiefly that `VirtualStrip`'s `overlay` slot cannot host them (`aria-hidden`, `pointer-events: none`, no focusable children by contract), so it needs the strip itself to render multiple interactive rows.

Until then a layered timeline is authored by `set_lane`, marked on the card, packed, previewed and rendered correctly — but still drawn in one strip.

## Verification

- `npx tsc --noEmit` in the app and `packages/ui` — clean
- `npx vitest run` (app) — **1044 passed** (was 1038)
- `npx vitest run --project=unit` — **575 passed** (was 569)
- `npx vitest run --project=storybook` — **198 passed** (was 195; +3 lane stories in real Chromium)
- `npm run lint` — clean, the same 5 pre-existing `<img>` warnings
- `npx playwright test --project=graph-view` — **169/169 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)