### PR TITLE
Draw lanes as time-aligned rows on the board (#310 phase 2, board)

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -37,7 +37,7 @@ import {
   useCollectionsStore,
 } from "@storyboard/ui/dnd-collections";
 
-import { flattenMediaOrder } from "@storyboard/timeline-domain";
+import { flattenMediaOrder, type DetailsById } from "@storyboard/timeline-domain";
 
 import { formatDuration } from "@/lib/format-duration";
 import { graphClipboard } from "@/lib/graph-clipboard";
@@ -108,6 +108,7 @@ import {
   useSelectionCount,
   type PreviewTimeChannel,
 } from "./graph-preview";
+import { splitLaneRows } from "./graph-lane-rows";
 import { AddCollectionSlot } from "./graph-add-collection-slot";
 import { CollectionHoverProvider } from "./graph-collection-hover";
 import { TagFilterProvider } from "./graph-tag-filter";
@@ -1542,6 +1543,38 @@ export function GraphBoard({
     [flatItems],
   );
 
+  // LANE ROWS. The picture (lane 0) keeps the virtualizer; everything on a
+  // higher lane draws as its own time-aligned row under it, so a bed visibly
+  // spans the shots it plays beneath instead of sitting in the queue after
+  // them.
+  //
+  // Null unless there is actually something on a lane, and the strip's lane
+  // paths are gated on the props being present — so an ordinary board renders
+  // exactly as it did before lanes existed, down to the DOM.
+  //
+  // Off in FLAT mode: a flat run spans many parents, so a card's lane would
+  // have to come from the manifest's lane-from-root rather than the local
+  // detail entry — a second lane source, and one this does not need.
+  const detailsSnapshot = useGraphDetailsSnapshot();
+  const laneRows = useMemo(() => {
+    if (flatOn) return null;
+    // The snapshot's type widens `DetailsById`'s values to `| undefined`;
+    // every read below already treats a missing entry as absent.
+    const model = splitLaneRows(graph, detailsSnapshot as DetailsById, focusedId);
+    if (model.layers.length === 0) return null;
+    return {
+      itemIds: model.pictureIds.map(parseNodeId),
+      itemTimes: model.pictureTimes,
+      layers: model.layers.map((layer) => ({
+        items: layer.items.map((item) => ({
+          id: parseNodeId(item.id),
+          startSeconds: item.startSeconds,
+          durationSeconds: item.durationSeconds,
+        })),
+      })),
+    };
+  }, [flatOn, graph, detailsSnapshot, focusedId]);
+
   // PLACEHOLDERS FOR THE HYDRATION GAP. Drilling into a collection navigates
   // at once, but its clips arrive on a fetch — so the surface is empty for a
   // beat and the user is looking at nothing, with no signal that anything is
@@ -1556,7 +1589,7 @@ export function GraphBoard({
   const focusedChildCount = useCollectionsSelector(
     (s) => s.graph.childrenById.get(parseNodeId(focusedId))?.length ?? 0,
   );
-  const focusedDetail = useGraphDetailsSnapshot()[focusedId];
+  const focusedDetail = detailsSnapshot[focusedId];
   const skeletonCount = hydrationSkeletonCount({
     hydrated: focusedDetail?.hydrated,
     itemCount: focusedDetail?.itemCount,
@@ -1932,7 +1965,13 @@ export function GraphBoard({
                 <NativeDropStrip collectionId={focusedId} projectId={projectId}>
               <VirtualStrip
                 collectionId={parseNodeId(focusedId)}
-                itemIds={flatItemIds}
+                // Flat mode owns the item source when it is on; otherwise the
+                // lane split does, but ONLY when something is on a lane —
+                // undefined means "your own children", which is the original
+                // behaviour and the one every unlayered board still gets.
+                itemIds={flatItemIds ?? laneRows?.itemIds}
+                itemTimes={laneRows?.itemTimes}
+                layers={laneRows?.layers}
                 pixelsPerSecond={deferredPixelsPerSecond}
                 overscan={GRAPH_STRIP_OVERSCAN_ITEMS}
                 itemWidth={collectionCardWidth(deferredPixelsPerSecond, dims.strip)}
@@ -1956,6 +1995,7 @@ export function GraphBoard({
                           focusedId={focusedId}
                           pixelsPerSecond={deferredPixelsPerSecond}
                           cardHeight={dims.strip}
+                          laneScope="picture"
                         />
                       ) : null}
                       {waveformOn ? (
@@ -1963,6 +2003,7 @@ export function GraphBoard({
                           focusedId={focusedId}
                           pixelsPerSecond={deferredPixelsPerSecond}
                           cardHeight={dims.strip}
+                          laneScope="picture"
                         />
                       ) : null}
                       {previewOn ? (
@@ -1971,6 +2012,7 @@ export function GraphBoard({
                           channel={timeChannel}
                           pixelsPerSecond={deferredPixelsPerSecond}
                           cardHeight={dims.strip}
+                          laneScope="picture"
                         />
                       ) : null}
                     </>
@@ -2000,6 +2042,7 @@ export function GraphBoard({
                   channel={timeChannel}
                   pixelsPerSecond={deferredPixelsPerSecond}
                   cardHeight={dims.strip}
+                  laneScope="picture"
                 />
               )}
                 </NativeDropStrip>

--- a/apps/timeline-gstudio001/components/graph-view/graph-lane-rows.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-lane-rows.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "vitest";
+
+import { buildGraph, type GraphNodeSpec } from "@storyboard/collections-core";
+import type { ClipDetail, DetailsById } from "@storyboard/timeline-domain";
+import { CLIP_GAP_SECONDS } from "@storyboard/timeline-model/constants";
+
+import { laneDropBoundary, laneDropIndex, splitLaneRows } from "./graph-lane-rows";
+
+const media = (id: string, durationSeconds: number): GraphNodeSpec => ({
+  kind: "media",
+  id,
+  name: id,
+  durationSeconds,
+});
+
+const collection = (id: string, children: readonly GraphNodeSpec[] = []): GraphNodeSpec => ({
+  kind: "collection",
+  id,
+  name: id,
+  children,
+});
+
+function graphOf(roots: readonly GraphNodeSpec[]) {
+  const result = buildGraph(roots);
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.value;
+}
+
+/** A side-table entry with only the fields a test cares about set. */
+const detail = (over: Partial<ClipDetail> = {}): ClipDetail => ({
+  alt: "",
+  aspect: 16 / 9,
+  trackIndex: 0,
+  ...over,
+});
+
+/** A details side table putting the named nodes on a lane. */
+function lanes(byId: Readonly<Record<string, number>>): DetailsById {
+  const details: Record<string, ClipDetail> = {};
+  for (const [id, trackIndex] of Object.entries(byId)) details[id] = detail({ trackIndex });
+  return details;
+}
+
+describe("splitLaneRows", () => {
+  it("puts everything on the picture when nothing has a lane", () => {
+    const graph = graphOf([collection("scene", [media("a", 4), media("b", 4)])]);
+    const model = splitLaneRows(graph, {} as DetailsById, "scene");
+
+    expect(model.pictureIds).toEqual(["a", "b"]);
+    expect(model.layers).toEqual([]);
+    expect(model.pictureTimes).toEqual([
+      { startSeconds: 0, durationSeconds: 4 },
+      { startSeconds: 4 + CLIP_GAP_SECONDS, durationSeconds: 4 },
+    ]);
+  });
+
+  it("is empty for a collection with no children", () => {
+    const graph = graphOf([collection("scene", [])]);
+    expect(splitLaneRows(graph, {} as DetailsById, "scene")).toEqual({
+      pictureIds: [],
+      pictureTimes: [],
+      layers: [],
+    });
+  });
+
+  it("pulls a lane-1 clip off the picture and onto its own row", () => {
+    const graph = graphOf([
+      collection("scene", [media("shot1", 4), media("bed", 12), media("shot2", 4)]),
+    ]);
+    const model = splitLaneRows(graph, lanes({ bed: 1 }), "scene");
+
+    expect(model.pictureIds).toEqual(["shot1", "shot2"]);
+    expect(model.layers).toHaveLength(1);
+    expect(model.layers[0]?.lane).toBe(1);
+    expect(model.layers[0]?.items).toEqual([
+      { id: "bed", startSeconds: 0, durationSeconds: 12 },
+    ]);
+  });
+
+  it("closes the gap the layered clip left in the picture", () => {
+    // THE point of packing per lane: shot2 now follows shot1 directly instead
+    // of starting after a 12s bed that no longer sits between them.
+    const graph = graphOf([
+      collection("scene", [media("shot1", 4), media("bed", 12), media("shot2", 4)]),
+    ]);
+    const model = splitLaneRows(graph, lanes({ bed: 1 }), "scene");
+
+    expect(model.pictureTimes[1]?.startSeconds).toBe(4 + CLIP_GAP_SECONDS);
+  });
+
+  it("starts every lane at the same instant, so a bed runs UNDER the picture", () => {
+    const graph = graphOf([
+      collection("scene", [media("shot1", 4), media("shot2", 4), media("bed", 8)]),
+    ]);
+    const model = splitLaneRows(graph, lanes({ bed: 1 }), "scene");
+
+    expect(model.pictureTimes[0]?.startSeconds).toBe(0);
+    expect(model.layers[0]?.items[0]?.startSeconds).toBe(0);
+  });
+
+  it("packs several cards on one lane in their own sequence", () => {
+    const graph = graphOf([
+      collection("scene", [media("shot", 20), media("vo1", 3), media("vo2", 3)]),
+    ]);
+    const model = splitLaneRows(graph, lanes({ vo1: 1, vo2: 1 }), "scene");
+
+    expect(model.layers[0]?.items).toEqual([
+      { id: "vo1", startSeconds: 0, durationSeconds: 3 },
+      { id: "vo2", startSeconds: 3 + CLIP_GAP_SECONDS, durationSeconds: 3 },
+    ]);
+  });
+
+  it("gives each occupied lane its own row, in ascending order", () => {
+    const graph = graphOf([
+      collection("scene", [media("shot", 10), media("music", 10), media("vo", 4)]),
+    ]);
+    const model = splitLaneRows(graph, lanes({ vo: 2, music: 1 }), "scene");
+
+    expect(model.layers.map((layer) => layer.lane)).toEqual([1, 2]);
+    expect(model.layers[0]?.items[0]?.id).toBe("music");
+    expect(model.layers[1]?.items[0]?.id).toBe("vo");
+  });
+
+  it("skips unoccupied lanes rather than reserving a row for each", () => {
+    // set_lane accepts any non-negative integer; reserving would draw fifty
+    // rows for one clip. The chip still names the real lane.
+    const graph = graphOf([collection("scene", [media("shot", 10), media("bed", 10)])]);
+    const model = splitLaneRows(graph, lanes({ bed: 50 }), "scene");
+
+    expect(model.layers).toHaveLength(1);
+    expect(model.layers[0]?.lane).toBe(50);
+  });
+
+  it("treats a fractional or negative lane as the picture", () => {
+    const graph = graphOf([
+      collection("scene", [media("a", 4), media("b", 4), media("c", 4)]),
+    ]);
+    const model = splitLaneRows(graph, lanes({ b: 1.5, c: -1 }), "scene");
+
+    expect(model.pictureIds).toEqual(["a", "b", "c"]);
+    expect(model.layers).toEqual([]);
+  });
+
+  it("carries a hydrated collection child's whole span onto the row model", () => {
+    const graph = graphOf([
+      collection("scene", [
+        collection("inner", [media("x", 5), media("y", 5)]),
+        media("bed", 20),
+      ]),
+    ]);
+    // `hydrated` is what makes a collection derive its span from live
+    // children rather than the stored summary — the board's normal state
+    // once a collection's contents have arrived.
+    const details: DetailsById = {
+      inner: detail({ hydrated: true }),
+      bed: detail({ trackIndex: 1 }),
+    };
+    const model = splitLaneRows(graph, details, "scene");
+
+    expect(model.pictureIds).toEqual(["inner"]);
+    // A collection card is a fixed WIDTH holding an arbitrary span; the row
+    // model reports the span, and the lane map stretches the card across it.
+    expect(model.pictureTimes[0]?.durationSeconds).toBeGreaterThan(10);
+  });
+});
+
+describe("laneDropBoundary", () => {
+  // Document order: shot1, bed(lane 1), shot2, shot3.
+  const siblings = ["shot1", "bed", "shot2", "shot3"];
+  const pictureIds = ["shot1", "shot2", "shot3"];
+
+  it("maps the strip's boundary onto the card it sits before", () => {
+    expect(laneDropBoundary(pictureIds, siblings, 0)).toBe(0);
+    // THE bug this exists for: lane-0 boundary 1 is "before shot2", which is
+    // index 2 in the real list — reading it as 1 would insert before the bed.
+    expect(laneDropBoundary(pictureIds, siblings, 1)).toBe(2);
+    expect(laneDropBoundary(pictureIds, siblings, 2)).toBe(3);
+  });
+
+  it("appends past the last picture card", () => {
+    expect(laneDropBoundary(pictureIds, siblings, 3)).toBe(4);
+    expect(laneDropBoundary(pictureIds, siblings, 99)).toBe(4);
+  });
+
+  it("clamps a negative boundary to the start", () => {
+    expect(laneDropBoundary(pictureIds, siblings, -3)).toBe(0);
+  });
+
+  it("appends rather than guessing when the lists disagree", () => {
+    expect(laneDropBoundary(["gone"], siblings, 0)).toBe(4);
+    expect(laneDropBoundary(pictureIds, siblings, 1.5)).toBe(4);
+  });
+
+  it("is the identity on a board with no layers", () => {
+    const plain = ["a", "b", "c"];
+    expect(plain.map((_, k) => laneDropBoundary(plain, plain, k))).toEqual([0, 1, 2]);
+    expect(laneDropBoundary(plain, plain, 3)).toBe(3);
+  });
+});
+
+describe("laneDropIndex", () => {
+  const siblings = ["shot1", "bed", "shot2", "shot3"];
+  const pictureIds = ["shot1", "shot2", "shot3"];
+
+  it("subtracts dragged nodes already before the boundary", () => {
+    // Dragging shot1 to sit before shot3: the translated boundary is 3, and
+    // shot1 leaves a hole behind it, so the post-removal index is 2.
+    expect(laneDropIndex(pictureIds, siblings, 2, ["shot1"])).toBe(2);
+  });
+
+  it("leaves a boundary before every dragged node alone", () => {
+    expect(laneDropIndex(pictureIds, siblings, 0, ["shot3"])).toBe(0);
+  });
+
+  it("counts a dragged LAYER card sitting before the boundary", () => {
+    // The bed is at index 1, before the translated boundary 3.
+    expect(laneDropIndex(pictureIds, siblings, 2, ["bed"])).toBe(2);
+  });
+
+  it("adds with no drag set at the translated boundary", () => {
+    expect(laneDropIndex(pictureIds, siblings, 1, [])).toBe(2);
+  });
+});

--- a/apps/timeline-gstudio001/components/graph-view/graph-lane-rows.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-lane-rows.ts
@@ -1,0 +1,142 @@
+import { getChildren, parseNodeId, type CollectionsGraph } from "@storyboard/collections-core";
+import { graphChildrenToClips, type DetailsById } from "@storyboard/timeline-domain";
+import { trackIndexOf } from "@storyboard/timeline-model/documents";
+
+// Splitting a collection's children into the PICTURE and the lanes that run
+// under it — the read model behind the board's lane rows.
+//
+// Pure and framework-free (and a .ts, not a .tsx) so the app's vitest can
+// parse it: the arithmetic here decides where a bed is drawn AND where a drop
+// lands, and both need to be testable without a board.
+
+/** A slot on the timeline clock — the shape `VirtualStrip` wants for its
+ *  `itemTimes` and layer items. Structural, so this module owes the UI
+ *  package no import. */
+export type LaneTimedSlot = Readonly<{
+  startSeconds: number;
+  durationSeconds: number;
+}>;
+
+export type LaneCard = LaneTimedSlot & Readonly<{ id: string }>;
+
+export type LaneRowsModel = Readonly<{
+  /** Lane-0 child ids in document order — what the strip virtualizes. */
+  pictureIds: readonly string[];
+  /** Their times, aligned 1:1 with `pictureIds`. */
+  pictureTimes: readonly LaneTimedSlot[];
+  /**
+   * One row per OCCUPIED lane, ascending. Empty lanes are skipped rather than
+   * reserved: `set_lane` accepts any non-negative integer, so reserving them
+   * would let a single clip on lane 50 draw fifty rows. The lane a card is
+   * actually on stays legible through its `LaneChip`, which names the number.
+   */
+  layers: readonly Readonly<{ lane: number; items: readonly LaneCard[] }>[];
+}>;
+
+const EMPTY: LaneRowsModel = { pictureIds: [], pictureTimes: [], layers: [] };
+
+/**
+ * Split `collectionId`'s children by lane, with each card's time window.
+ *
+ * Times come from `graphChildrenToClips` — the same projection the playhead,
+ * ruler and export read — so the row a bed draws on and the clock the player
+ * runs cannot disagree. It packs PER LANE, which is what makes a lane-1 start
+ * time mean "alongside the picture" rather than "after it".
+ *
+ * Zipped by INDEX against `getChildren`: `graphChildrenToClips` maps over that
+ * same array, and a projection clip reports `detail.sourceClipId` rather than
+ * the node id, so matching on id would drop exactly those cards.
+ */
+export function splitLaneRows(
+  graph: CollectionsGraph,
+  details: DetailsById,
+  collectionId: string,
+): LaneRowsModel {
+  const childIds = getChildren(graph, parseNodeId(collectionId));
+  if (childIds.length === 0) return EMPTY;
+
+  const clips = graphChildrenToClips(graph, details, collectionId);
+  const pictureIds: string[] = [];
+  const pictureTimes: LaneTimedSlot[] = [];
+  const byLane = new Map<number, LaneCard[]>();
+
+  childIds.forEach((childId, index) => {
+    const clip = clips[index];
+    if (clip === undefined) return;
+    const slot: LaneTimedSlot = {
+      startSeconds: clip.startTime,
+      durationSeconds: clip.duration,
+    };
+    const lane = trackIndexOf(clip);
+    if (lane === 0) {
+      pictureIds.push(childId as string);
+      pictureTimes.push(slot);
+      return;
+    }
+    const row = byLane.get(lane);
+    const card: LaneCard = { id: childId as string, ...slot };
+    if (row) row.push(card);
+    else byLane.set(lane, [card]);
+  });
+
+  const layers = [...byLane.keys()]
+    .sort((a, b) => a - b)
+    .map((lane) => ({ lane, items: byLane.get(lane) ?? [] }));
+
+  return { pictureIds, pictureTimes, layers };
+}
+
+/**
+ * Translate a boundary the STRIP published into one the graph understands.
+ *
+ * The strip is handed lane-0 children only, so the boundary it reports counts
+ * lane-0 cards — while `resolveCommandFromIntent` reads it as an index into
+ * the collection's FULL child list. On any board with a layer those two
+ * disagree, and a drop lands somewhere nobody chose. This is the correction,
+ * applied through `mapDropCommand` (the same seam flat mode uses).
+ *
+ * Boundary k means "immediately before the k-th lane-0 card", which is that
+ * card's own position in the full list; past the last one means the very end.
+ * Any layer cards that end up on the far side of the insert are unaffected —
+ * lanes pack independently, so only the relative order WITHIN a lane matters,
+ * and this preserves it for both.
+ */
+export function laneDropBoundary(
+  pictureIds: readonly string[],
+  siblings: readonly string[],
+  boundary: number,
+): number {
+  if (!Number.isInteger(boundary)) return siblings.length;
+  const clamped = Math.max(0, Math.min(boundary, pictureIds.length));
+  if (clamped >= pictureIds.length) return siblings.length;
+  const nextId = pictureIds[clamped];
+  const index = nextId === undefined ? -1 : siblings.indexOf(nextId);
+  // A lane-0 id the child list does not contain means the two were derived
+  // from different graphs; appending is the honest answer, not a guess at a
+  // position in a list this boundary was never measured against.
+  return index === -1 ? siblings.length : index;
+}
+
+/**
+ * The post-removal `toIndex` for a lane-aware drop — the boundary above, less
+ * the dragged nodes already sitting before it.
+ *
+ * Mirrors `resolveCommandFromIntent`'s own convention deliberately: that is
+ * the arithmetic being corrected, and re-deriving it from the translated
+ * boundary is what makes the correction complete rather than an offset patch
+ * on a number that was computed against the wrong list.
+ */
+export function laneDropIndex(
+  pictureIds: readonly string[],
+  siblings: readonly string[],
+  boundary: number,
+  draggedIds: readonly string[],
+): number {
+  const translated = laneDropBoundary(pictureIds, siblings, boundary);
+  if (draggedIds.length === 0) return translated;
+  const dragged = new Set(draggedIds);
+  const draggedBefore = siblings
+    .slice(0, translated)
+    .filter((siblingId) => dragged.has(siblingId)).length;
+  return translated - draggedBefore;
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { buildGraph, parseNodeId, type GraphNodeSpec } from "@storyboard/collections-core";
-import type { PlaybackLeaf, PlaybackManifest } from "@storyboard/timeline-domain";
+import type { ClipDetail, PlaybackLeaf, PlaybackManifest } from "@storyboard/timeline-domain";
 
 import {
   buildPlayheadMap,
@@ -45,6 +45,16 @@ function graphOf(roots: readonly GraphNodeSpec[]) {
   if (!result.ok) throw new Error(JSON.stringify(result.error));
   return result.value;
 }
+
+/** A side-table entry that puts a clip on a lane above the picture. */
+const laneDetail = (trackIndex: number): ClipDetail => ({
+  alt: "",
+  aspect: 16 / 9,
+  trackIndex,
+});
+
+/** Packing sums 0.12s gaps, so exact equality trips on binary float error. */
+const round = (value: number) => Math.round(value * 100) / 100;
 
 function leaf(
   id: string,
@@ -107,6 +117,51 @@ describe("childSpans", () => {
     // The invariant the map's binary search requires.
     const times = cards.flatMap((card) => [card.startTime, card.endTime]);
     expect([...times].sort((left, right) => left - right)).toEqual(times);
+  });
+
+  // LANES. Everything above measures one row, because until lanes existed
+  // there was only one. These pin the two ways that assumption broke.
+  it("leaves layered clips out of the picture's geometry when asked for it", () => {
+    // The strip draws lane 1 as its OWN row, so a card there has no place in
+    // the picture row's card list — and leaving it in did more than add an
+    // entry: the monotonic clamp dragged shot2 from 4.12s to 16s, because the
+    // 12s bed was treated as sitting between them.
+    //
+    // Opt-IN, not the default: a surface drawing one card per child (the grid,
+    // a sub-timeline row, the header readout) must keep every clip or its
+    // index pairing shifts, and that failure is silent.
+    const graph = graphOf([
+      collection("root", [media("shot1", 4), media("bed", 12), media("shot2", 4)]),
+    ]);
+    const details = { bed: laneDetail(1) };
+
+    const cards = childSpans(graph, details, "root", null, flatWidth, "picture");
+
+    expect(cards.map((card) => [round(card.startTime), round(card.endTime)])).toEqual([
+      [0, 4],
+      [4.12, 8.12],
+    ]);
+  });
+
+  it("keeps layered clips by DEFAULT, each on its own clock", () => {
+    // One card per child is the default precisely because the grid and the
+    // sub-timeline rows pair cards to cells by INDEX.
+    const graph = graphOf([
+      collection("root", [media("shot1", 4), media("bed", 12), media("shot2", 4)]),
+    ]);
+    const details = { bed: laneDetail(1) };
+
+    const cards = childSpans(graph, details, "root", null, flatWidth);
+
+    // The bed starts at ZERO — alongside the picture, not after it. The clamp
+    // is per lane now, so lane 0's running end cannot reach across and move it.
+    expect(
+      cards.map((card) => [card.lane, round(card.startTime), round(card.endTime)]),
+    ).toEqual([
+      [0, 0, 4],
+      [1, 0, 12],
+      [0, 4.12, 8.12],
+    ]);
   });
 
   it("passes manifest spans through untouched when they are already ordered", () => {
@@ -224,6 +279,26 @@ describe("playableSpanSeconds", () => {
 
   it("is zero when every card is disabled", () => {
     expect(playableSpanSeconds([card(0, 4, true), card(4.12, 8.12, true)])).toBe(0);
+  });
+
+  it("takes the LONGEST lane, not the sum of them", () => {
+    // Two 4s shots with an 8s bed under them. Summing would claim 16s of
+    // viewing for 8s of timeline — and the board now plainly shows the bed
+    // running alongside the picture, so the readout has to agree with it.
+    const onLane = (lane: number, startTime: number, endTime: number): ChildSpan => ({
+      ...card(startTime, endTime),
+      lane,
+    });
+    const cards = [onLane(0, 0, 4), onLane(1, 0, 8), onLane(0, 4.12, 8.12)];
+    expect(playableSpanSeconds(cards)).toBeCloseTo(8.12, 6);
+  });
+
+  it("still counts a lane that outlasts the picture", () => {
+    const onLane = (lane: number, startTime: number, endTime: number): ChildSpan => ({
+      ...card(startTime, endTime),
+      lane,
+    });
+    expect(playableSpanSeconds([onLane(0, 0, 4), onLane(1, 0, 30)])).toBeCloseTo(30, 6);
   });
 });
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.ts
@@ -14,6 +14,7 @@ import {
   CLIP_GAP_SECONDS,
   TIMELINE_LEADING_PADDING_SECONDS,
 } from "@storyboard/timeline-model/constants";
+import { trackIndexOf } from "@storyboard/timeline-model/documents";
 import type { TimelineClip } from "@storyboard/timeline-model/types";
 import { formatTick } from "@/lib/format-duration";
 
@@ -175,10 +176,21 @@ export function shouldRetryManifestFetch(
   return consecutiveFailures > 0 && consecutiveFailures <= maxRetries;
 }
 
+/**
+ * Which lanes a card set covers. Geometry wants "picture": the strip draws
+ * lane 0 in its row and every higher lane in its own, so an overlay measured
+ * against all of them would be measuring a layout that is not there. Readouts
+ * want "all" — a bed is a clip the user put on this timeline whatever row it
+ * ended up on.
+ */
+export type LaneScope = "picture" | "all";
+
 export type ChildSpan = Readonly<{
   startTime: number;
   endTime: number;
   width: number;
+  /** Which lane the card plays on; absent means the picture. */
+  lane?: number;
   /** Won't play — the seek rail dims this stretch and the player jumps it.
    *  True for a clip disabled outright AND for one whose collection ancestor
    *  is (see `isDisabledByAncestor`); the rail draws no distinction, because
@@ -239,6 +251,18 @@ export function childSpans(
   collectionId: string,
   spans: PreviewCardSpans | null,
   widthForClip: (clip: TimelineClip) => number,
+  /**
+   * Defaults to EVERY lane, which is what a surface drawing one card per child
+   * needs — the grid, a sub-timeline row, the header readout. Only a surface
+   * that draws lanes as separate ROWS asks for "picture", because there a
+   * layered card is not in the row being measured.
+   *
+   * The default is deliberately the pre-lanes behaviour: a caller that is
+   * never updated keeps pairing one card to one child, which is the failure
+   * that would be silent. Asking for "picture" by mistake shifts a marker
+   * visibly.
+   */
+  laneScope: LaneScope = "all",
 ): ChildSpan[] {
   const childIds = getChildren(graph, parseNodeId(collectionId));
   // Drilled INTO a disabled collection: none of these children carry the flag
@@ -248,23 +272,36 @@ export function childSpans(
   const focusDisabled =
     graph.nodesById.get(parseNodeId(collectionId))?.disabled === true ||
     isDisabledByAncestor(graph, collectionId);
-  let previousEnd = 0;
-  return graphChildrenToClips(graph, details, collectionId).map((clip, index) => {
+  // PER LANE, not one running total. The clamp exists to keep ONE row's times
+  // sorted, because the playhead map binary-searches them. Applied across
+  // lanes it does the opposite: lanes all start at zero, so a bed on lane 1
+  // would be dragged forward to wherever the picture had reached — reported as
+  // starting at 12s when it starts at 0 — and every later card pushed along
+  // with it. Harmless while every document was one sequence; wrong the moment
+  // one is not.
+  const previousEndByLane = new Map<number, number>();
+  return graphChildrenToClips(graph, details, collectionId).flatMap((clip, index) => {
+    const lane = trackIndexOf(clip);
+    if (laneScope === "picture" && lane !== 0) return [];
     const childId = childIds[index] as string;
     // Media first (parent-qualified — see mediaSpanKey), then the bare id a
     // collection child is keyed under. A demoted duplicate's `dup:`-prefixed
     // node id matches neither and falls through to projection times, which
     // is the honest degradation for a card the manifest can't name.
     const span = spans?.get(mediaSpanKey(collectionId, childId)) ?? spans?.get(childId);
+    const previousEnd = previousEndByLane.get(lane) ?? 0;
     const startTime = Math.max(span ? span.start : clip.startTime, previousEnd);
     const endTime = Math.max(span ? span.end : clip.startTime + clip.duration, startTime);
-    previousEnd = endTime;
-    return {
-      width: widthForClip(clip),
-      startTime,
-      endTime,
-      ...(focusDisabled || clip.disabled === true ? { disabled: true } : {}),
-    };
+    previousEndByLane.set(lane, endTime);
+    return [
+      {
+        width: widthForClip(clip),
+        startTime,
+        endTime,
+        lane,
+        ...(focusDisabled || clip.disabled === true ? { disabled: true } : {}),
+      },
+    ];
   });
 }
 
@@ -399,10 +436,27 @@ export function buildStripOverlay(
 export function playableSpanSeconds(cards: readonly ChildSpan[]): number {
   const enabled = cards.filter((card) => card.disabled !== true);
   if (enabled.length === 0) return 0;
-  const content = enabled.reduce((total, card) => total + (card.endTime - card.startTime), 0);
-  return (
-    TIMELINE_LEADING_PADDING_SECONDS + content + CLIP_GAP_SECONDS * (enabled.length - 1)
-  );
+  // PER LANE, then the LONGEST of them — lanes play together, so the span is
+  // the one that finishes last, not the sum. Summing would claim a 4s bed
+  // under a 4s shot makes an 8s timeline, and the board now plainly shows
+  // otherwise. Reduces to exactly the old single-total formula whenever
+  // everything is on the picture, which is every document without lanes.
+  const byLane = new Map<number, ChildSpan[]>();
+  for (const card of enabled) {
+    const lane = card.lane ?? 0;
+    const row = byLane.get(lane);
+    if (row) row.push(card);
+    else byLane.set(lane, [card]);
+  }
+  let longest = 0;
+  for (const row of byLane.values()) {
+    const content = row.reduce((total, card) => total + (card.endTime - card.startTime), 0);
+    longest = Math.max(
+      longest,
+      TIMELINE_LEADING_PADDING_SECONDS + content + CLIP_GAP_SECONDS * (row.length - 1),
+    );
+  }
+  return longest;
 }
 
 export type PlayheadMap = Readonly<{

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -48,6 +48,7 @@ import {
   STRIP_GAP_PX,
   type ChildSpan,
   type GridPlayheadMap,
+  type LaneScope,
   type PlayheadMap,
   type PreviewCardSpans,
   type RulerWindow,
@@ -145,7 +146,12 @@ export function useFocusedTimelineAggregate(
   return useMemo(() => {
     // 0 card height: this readout is counts and seconds, never geometry, so
     // the collection aspect floor has nothing to act on here.
-    const cards = cardsFor(graph, details, focusedId, spans, pixelsPerSecond, 0, flatItems);
+    //
+    // ALL lanes, unlike every other caller: a bed is a clip the user put on
+    // this timeline whatever row it ended up on, so it belongs in the count —
+    // and `playableSpanSeconds` takes the LONGEST lane, not their sum, so it
+    // still reports what a viewer would sit through.
+    const cards = cardsFor(graph, details, focusedId, spans, pixelsPerSecond, 0, flatItems, "all");
     // Enabled-only, both numbers: this readout says what a viewer would sit
     // through, which is NOT how far the playhead travels now that disabled
     // cards keep their span. The two disagree by design — the ruler runs
@@ -164,10 +170,15 @@ export function GraphPlayhead({
   pixelsPerSecond,
   cardHeight,
   activeWindow,
+  laneScope = "all",
 }: Readonly<{
   focusedId: string;
   channel: PreviewTimeChannel;
   pixelsPerSecond: number;
+  /** "picture" when the strip below draws lanes as separate ROWS, so this
+   *  measures the row it is actually over. Sub-timeline rows draw every child
+   *  in ONE row and keep the default. */
+  laneScope?: LaneScope;
   /** The strip's `itemHeight`. Feeds the collection aspect floor, so this
    *  marker lands on the same card edges the strip actually draws. */
   cardHeight: number;
@@ -197,7 +208,16 @@ export function GraphPlayhead({
       lastGraph = graph;
       lastDetails = details;
       map = buildPlayheadMap(
-        cardsFor(graph, details, focusedId, spans, pixelsPerSecond, cardHeight, flatItems),
+        cardsFor(
+          graph,
+          details,
+          focusedId,
+          spans,
+          pixelsPerSecond,
+          cardHeight,
+          flatItems,
+          laneScope,
+        ),
       );
       return true;
     };
@@ -251,6 +271,7 @@ export function GraphPlayhead({
     cardHeight,
     activeWindow,
     flatItems,
+    laneScope,
   ]);
 
   // No cap on the line: the seek rail's circular thumb above IS the
@@ -308,9 +329,12 @@ export function GraphRuler({
   focusedId,
   pixelsPerSecond,
   cardHeight,
+  laneScope = "all",
 }: Readonly<{
   focusedId: string;
   pixelsPerSecond: number;
+  /** See GraphPlayhead: "picture" when the strip draws lanes as rows. */
+  laneScope?: LaneScope;
   /** The strip's `itemHeight` — feeds the collection aspect floor so ticks
    *  and collection stretches land on the widths the strip draws. */
   cardHeight: number;
@@ -345,7 +369,16 @@ export function GraphRuler({
   // tick count follows the VIEWPORT, not the duration. Scrolling recomputes
   // only on chunk crossings (tickWindow identity is stable between them).
   const { ticks, collectionSpans, skips } = useMemo(() => {
-    const cards = cardsFor(graph, details, focusedId, spans, pixelsPerSecond, cardHeight, flatItems);
+    const cards = cardsFor(
+      graph,
+      details,
+      focusedId,
+      spans,
+      pixelsPerSecond,
+      cardHeight,
+      flatItems,
+      laneScope,
+    );
     // A flat run holds no collections at all, so every card is ruled — the
     // blank-interior rule exists only for collection cards.
     const isCollection = flatItems
@@ -364,7 +397,17 @@ export function GraphRuler({
       // range as the ticks beside them.
       skips: buildStripOverlay(cards, tickWindow).skips,
     };
-  }, [graph, details, spans, focusedId, pixelsPerSecond, cardHeight, tickWindow, flatItems]);
+  }, [
+    graph,
+    details,
+    spans,
+    focusedId,
+    pixelsPerSecond,
+    cardHeight,
+    tickWindow,
+    flatItems,
+    laneScope,
+  ]);
 
   return (
     <div
@@ -450,12 +493,16 @@ export function GraphWaveformBand({
   focusedId,
   pixelsPerSecond,
   cardHeight,
+  laneScope = "all",
   /** Injected so a story can supply synthetic peaks without decoding audio. */
   cache = sharedWaveformCache(),
 }: Readonly<{
   focusedId: string;
   pixelsPerSecond: number;
   cardHeight: number;
+  /** See GraphPlayhead: "picture" when the strip draws lanes as rows. The
+   *  waveform sources are picture-only to match, so the two stay aligned. */
+  laneScope?: LaneScope;
   cache?: WaveformCache;
 }>) {
   const store = useCollectionsStore();
@@ -669,7 +716,13 @@ export function GraphGridPlayhead({
         // 0 card height: grid cells are uniform and this map lays out by
         // `cellWidth`, never by the per-clip width, so the strip's collection
         // aspect floor has nothing to act on here.
-        childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond, 0)),
+        //
+        // ALL lanes, and it must be: this map pairs cards to cells BY INDEX,
+        // and a grid draws every child — it has no time axis, so nothing is
+        // laid onto a lane there. Handing it the strip's picture-only cards
+        // would shift every cell after the first layered clip and point the
+        // marker at the wrong one.
+        childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond, 0), "all"),
         columns,
         cellWidth,
         cellHeight,

--- a/apps/timeline-gstudio001/components/graph-view/graph-seek-rails.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seek-rails.tsx
@@ -41,6 +41,7 @@ import {
   childSpans,
   type ChildSpan,
   type GridPlayheadMap,
+  type LaneScope,
 } from "./graph-playhead-model";
 import { GRID_GAP } from "./graph-view-config";
 import { cardsFor, clipWidthAt } from "./preview-card-geometry";
@@ -410,7 +411,11 @@ export function GraphSeekRails({
   const cards = useMemo(
     // 0 card height, as in GraphGridPlayhead: the grid rails measure their
     // row from `cellWidth`, so per-clip widths never reach the geometry.
-    () => childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond, 0)),
+    //
+    // ALL lanes, as in GraphGridPlayhead and for the same reason: these rails
+    // are indexed against the grid's CELLS, and a grid draws every child. Only
+    // the strip lays clips onto lanes.
+    () => childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond, 0), "all"),
     [graph, details, spans, focusedId, pixelsPerSecond],
   );
   const cardCount = cards.length;
@@ -546,6 +551,7 @@ export function GraphStripSeekRail({
   pixelsPerSecond,
   cardHeight,
   ariaLabel = "Seek preview",
+  laneScope = "all",
 }: Readonly<{
   focusedId: string;
   channel: PreviewTimeChannel;
@@ -554,6 +560,9 @@ export function GraphStripSeekRail({
    *  the rail's thumb in lockstep with the playhead line below it. */
   cardHeight: number;
   ariaLabel?: string;
+  /** "picture" when the strip below draws lanes as separate ROWS, so the
+   *  thumb tracks the same row the playhead line does. */
+  laneScope?: LaneScope;
 }>) {
   const store = useCollectionsStore();
   const detailsStore = useGraphDetailsStore();
@@ -584,8 +593,18 @@ export function GraphStripSeekRail({
     () => detailsStore.read(),
   );
   const cards = useMemo(
-    () => cardsFor(graph, details, focusedId, spans, pixelsPerSecond, cardHeight, flatItems),
-    [graph, details, spans, focusedId, pixelsPerSecond, cardHeight, flatItems],
+    () =>
+      cardsFor(
+        graph,
+        details,
+        focusedId,
+        spans,
+        pixelsPerSecond,
+        cardHeight,
+        flatItems,
+        laneScope,
+      ),
+    [graph, details, spans, focusedId, pixelsPerSecond, cardHeight, flatItems, laneScope],
   );
   const map = useMemo(() => buildPlayheadMap(cards), [cards]);
   const start = cards[0]?.startTime ?? 0;

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -15,6 +15,7 @@ import {
   ClearSelectionOnOutsideClick,
   DndCollections,
   buildGraph,
+  getChildren,
   parseNodeId,
   useCollectionsStore,
   type CollectionItemNode,
@@ -56,6 +57,7 @@ import { bootSessionKey } from "./boot-session-key";
 import { trashDocumentId as deriveTrashDocumentId } from "./trash-document-id";
 
 import { GraphBoard, type FocusSurface, type ItemSize } from "./graph-board";
+import { laneDropIndex, splitLaneRows } from "./graph-lane-rows";
 import { GraphViewLoadingSkeleton } from "./graph-view-loading";
 import { GraphDetailsProvider } from "./graph-details-context";
 import { FlatClosureHydrator, HydrationController } from "./graph-hydration";
@@ -534,19 +536,49 @@ export function GraphTimelineView({
       intent: DropIntent,
       graph: CollectionsGraph,
     ) => {
-      if (!flatOn) return command;
       const focused = parseNodeId(focusedId);
-      // The flat strip's own boundary, and nothing else.
+      // The focused surface's own boundary, and nothing else — every other
+      // drop names its target directly and is already right.
       if (intent.type !== "insert-at-index" || intent.collectionId !== focused) return command;
-      const target = resolveFlatDropTarget(
-        graph,
-        flattenMediaOrder(graph, focused, MAX_SUBTREE_DEPTH),
-        focused,
-        command.toIndex,
-      );
-      return { ...command, toParentId: target.parentId, toIndex: target.index };
+
+      if (flatOn) {
+        const target = resolveFlatDropTarget(
+          graph,
+          flattenMediaOrder(graph, focused, MAX_SUBTREE_DEPTH),
+          focused,
+          command.toIndex,
+        );
+        return { ...command, toParentId: target.parentId, toIndex: target.index };
+      }
+
+      // LANE TRANSLATION — the other view whose boundaries do not mean what
+      // the intent assumes.
+      //
+      // A strip with lane rows is handed the PICTURE's children only, so the
+      // boundary it publishes counts lane-0 cards, while `resolveCommandFromIntent`
+      // reads it as an index into the collection's full child list. On any
+      // board with a layer those disagree and the drop lands somewhere nobody
+      // chose. The grid is unaffected: it shows every child, so its boundaries
+      // already index the real list.
+      //
+      // Re-derived from the RAW boundary (`intent.index`) rather than patched
+      // onto `command.toIndex`, which was computed against the wrong list —
+      // the post-removal subtraction has to happen against the translated
+      // position, not be carried over from the untranslated one.
+      if (surface !== "strip") return command;
+      const model = splitLaneRows(graph, detailsStore.read(), focusedId);
+      if (model.layers.length === 0) return command;
+      return {
+        ...command,
+        toIndex: laneDropIndex(
+          model.pictureIds,
+          getChildren(graph, focused),
+          intent.index,
+          command.type === "move-nodes" ? command.nodeIds : [],
+        ),
+      };
     },
-    [flatOn, focusedId],
+    [flatOn, focusedId, surface, detailsStore],
   );
 
   const commandPolicy = useCallback<CommandPolicy>(

--- a/apps/timeline-gstudio001/components/graph-view/graph-waveform-model.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-waveform-model.ts
@@ -4,6 +4,7 @@ import {
   type CollectionsGraph,
 } from "@storyboard/collections-core";
 import type { DetailsById, FlatItem } from "@storyboard/timeline-domain";
+import { trackIndexOf } from "@storyboard/timeline-model/documents";
 
 /**
  * The PURE half of the waveform lane: which audio each drawn card refers to.
@@ -80,8 +81,13 @@ export function waveformSourcesFor(
   if (flatItems) {
     return flatItems.map((item) => sourceForNode(graph, details, item.nodeId as string));
   }
-  return getChildren(graph, parseNodeId(focusedId)).map((childId) =>
-    sourceForNode(graph, details, childId as string),
+  // PICTURE ONLY, to hold the index alignment with `cardsFor`, which measures
+  // the strip's own row and so drops anything on a lane. A lane row's own
+  // waveform is a separate band this does not draw yet.
+  return getChildren(graph, parseNodeId(focusedId)).flatMap((childId) =>
+    trackIndexOf({ trackIndex: details[childId as string]?.trackIndex ?? 0 }) === 0
+      ? [sourceForNode(graph, details, childId as string)]
+      : [],
   );
 }
 

--- a/apps/timeline-gstudio001/components/graph-view/preview-card-geometry.ts
+++ b/apps/timeline-gstudio001/components/graph-view/preview-card-geometry.ts
@@ -7,6 +7,7 @@ import {
   childSpans,
   flatCardSpans,
   type ChildSpan,
+  type LaneScope,
   type PreviewCardSpans,
 } from "./graph-playhead-model";
 import { TIMELINE_PPS } from "./graph-view-config";
@@ -81,10 +82,21 @@ export function cardsFor(
    *  Callers that consume times and counts rather than geometry pass 0. */
   cardHeight: number,
   flatItems: readonly FlatItem[] | null,
+  /** Defaults to EVERY lane — see `childSpans`. Only an overlay measured
+   *  against a strip that draws lanes as separate ROWS passes "picture". Flat
+   *  mode is a single sequence either way. */
+  laneScope: LaneScope = "all",
 ): ChildSpan[] {
   return flatItems
     ? flatCardSpans(graph, flatItems, focusedId, spans, (seconds) =>
         durationToWidth(seconds, pixelsPerSecond),
       )
-    : childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond, cardHeight));
+    : childSpans(
+        graph,
+        details,
+        focusedId,
+        spans,
+        clipWidthAt(pixelsPerSecond, cardHeight),
+        laneScope,
+      );
 }

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -211,9 +211,28 @@ type GraphApi = {
 
 async function installGraphApi(
   page: Page,
-  options: { blockChildDocument?: boolean } = {},
+  options: {
+    blockChildDocument?: boolean;
+    /** Put named PROJECT clips on a lane above the picture, by id. */
+    lanes?: Readonly<Record<string, number>>;
+  } = {},
 ): Promise<GraphApi> {
   const documents = buildFixtureDocuments();
+  // The fixtures are all trackIndex 0 — they predate lanes — so this is how a
+  // test gets a layered board without maintaining a second fixture set.
+  const lanes = options.lanes;
+  if (lanes) {
+    const project = documents.get(PROJECT_ID);
+    if (project) {
+      documents.set(PROJECT_ID, {
+        ...project,
+        clips: project.clips.map((clip) => {
+          const lane = lanes[clip.id];
+          return lane === undefined ? clip : { ...clip, trackIndex: lane };
+        }),
+      });
+    }
+  }
   const patches: RecordedPatch[] = [];
   const batches: string[][] = [];
   // Served on GET and enforced on batch writes, like the real API: the
@@ -323,6 +342,16 @@ const strip = (page: Page, collectionId: string): Locator =>
 
 async function stripOrder(page: Page, collectionId: string): Promise<string[]> {
   return strip(page, collectionId)
+    .locator("[data-node-id]")
+    .evaluateAll((els) => els.map((el) => (el as HTMLElement).dataset.nodeId ?? ""));
+}
+
+/** The ids on one ROW of a layered strip — lane 0 is the picture, 1+ are the
+ *  layers under it. `stripOrder` collects every card in the strip, so on a
+ *  layered board it no longer describes the shot sequence. */
+async function laneOrder(page: Page, collectionId: string, lane: number): Promise<string[]> {
+  return strip(page, collectionId)
+    .locator(`[data-strip-lane="${lane}"]`)
     .locator("[data-node-id]")
     .evaluateAll((els) => els.map((el) => (el as HTMLElement).dataset.nodeId ?? ""));
 }
@@ -499,6 +528,34 @@ async function holdDrag(
   // its click propagates past window but is stopped before React's root
   // handler. Outlast the window before handing control back.
   await page.waitForTimeout(80);
+}
+
+/** `holdDrag` to an explicit POINT rather than onto a card — for drops that
+ *  must land in a GAP, where no card is under the pointer and the intent
+ *  resolves through the strip's container droppable (insert-at-index) instead
+ *  of against a card (insert-adjacent). The two take different paths through
+ *  the command resolver, and only the container one carries a boundary index. */
+async function holdDragToPoint(
+  page: Page,
+  source: Locator,
+  x: number,
+  y: number,
+): Promise<void> {
+  await source.waitFor({ state: "visible" });
+  await settleMoveAnimations(page);
+  const sourceBox = await source.boundingBox();
+  expect(sourceBox).not.toBeNull();
+
+  await page.mouse.move(
+    sourceBox!.x + sourceBox!.width / 2,
+    sourceBox!.y + sourceBox!.height / 2,
+  );
+  await page.mouse.down();
+  await page.waitForTimeout(400); // past the hold delay — the drag activates
+  await page.mouse.move(x, y, { steps: 12 });
+  await page.waitForTimeout(150); // dwell: let collision/intent settle
+  await page.mouse.up();
+  await page.waitForTimeout(80); // outlast dnd-kit's click suppressor
 }
 
 const undoButton = (page: Page): Locator => page.getByRole("button", { name: /undo/i });
@@ -8178,5 +8235,74 @@ test.describe("graph view E2E", () => {
     await expect(page.locator("[data-header-selection-overflow]")).toBeVisible();
     await page.locator("[data-header-selection-overflow]").click();
     await expect(page.getByRole("menuitem", { name: /^Delete/ })).toBeVisible();
+  });
+
+  // LANE ROWS (#397). A layered clip runs alongside the picture, so the board
+  // draws it as its own time-aligned row instead of a slot in the shot
+  // sequence. These drive the APP wiring — the lane split feeding the strip,
+  // and the drop translation that filtering the strip's item source forces.
+  test("a layered clip leaves the shot sequence and draws as its own row", async ({
+    page,
+  }) => {
+    await installGraphApi(page, { lanes: { bravo: 1 } });
+    await openGraph(page);
+
+    // Off the picture entirely, and the gap it left has closed.
+    await expect
+      .poll(() => laneOrder(page, PROJECT_ID, 0))
+      .toEqual(["alpha", CHILD_ID, "charlie"]);
+    expect(await laneOrder(page, PROJECT_ID, 1)).toEqual(["bravo"]);
+
+    // A ROW, not a slot: below the picture, and starting where the picture is
+    // at its own start time. Lanes each pack from zero, so it begins ALONGSIDE
+    // alpha rather than after it — which is the whole point of the feature.
+    const alphaBox = (await strip(page, PROJECT_ID)
+      .locator('[data-node-id="alpha"]')
+      .boundingBox())!;
+    const bravoBox = (await strip(page, PROJECT_ID)
+      .locator('[data-node-id="bravo"]')
+      .boundingBox())!;
+    expect(bravoBox.y).toBeGreaterThanOrEqual(alphaBox.y + alphaBox.height);
+    expect(Math.abs(bravoBox.x - alphaBox.x)).toBeLessThanOrEqual(1);
+  });
+
+  test("a gap drop lands where the PICTURE says, not where the raw boundary would", async ({
+    page,
+  }) => {
+    await installGraphApi(page, { lanes: { bravo: 1 } });
+    await openGraph(page);
+    await expect
+      .poll(() => laneOrder(page, PROJECT_ID, 0))
+      .toEqual(["alpha", CHILD_ID, "charlie"]);
+
+    // Drop alpha in the gap BEFORE charlie — picture boundary 2. The strip
+    // publishes boundaries into the PICTURE list, while the intent resolver
+    // reads them against the collection's FULL children, where the layered
+    // bravo still sits at index 1. Untranslated that boundary resolves one
+    // short and lands alpha back where it started — a silent no-op. Translated
+    // it lands after clip-scene, which is what the indicator said.
+    const sceneBox = (await strip(page, PROJECT_ID)
+      .locator(`[data-node-id="${CHILD_ID}"]`)
+      .boundingBox())!;
+    const charlieBox = (await strip(page, PROJECT_ID)
+      .locator('[data-node-id="charlie"]')
+      .boundingBox())!;
+    const gapX = (sceneBox.x + sceneBox.width + charlieBox.x) / 2;
+    expect(gapX).toBeGreaterThan(sceneBox.x + sceneBox.width);
+    expect(gapX).toBeLessThan(charlieBox.x);
+
+    await holdDragToPoint(
+      page,
+      strip(page, PROJECT_ID).locator('[data-node-id="alpha"]'),
+      gapX,
+      charlieBox.y + charlieBox.height / 2,
+    );
+
+    await expect
+      .poll(() => laneOrder(page, PROJECT_ID, 0))
+      .toEqual([CHILD_ID, "alpha", "charlie"]);
+    // And the reorder left the LANE alone — moving within the picture is not
+    // a lane change (that is a detail write, and a separate gesture).
+    expect(await laneOrder(page, PROJECT_ID, 1)).toEqual(["bravo"]);
   });
 });

--- a/packages/ui/dnd-collections/API.md
+++ b/packages/ui/dnd-collections/API.md
@@ -1003,6 +1003,10 @@ type VirtualStripProps = {
   itemContent?: CollectionItemContentComponent;          // per-view card pixels; overrides the provider registry
   itemShell?: CollectionItemShellComponent;              // per-view ITEM renderer (default NodeCard; registry ItemShell in between) — see "Custom item content"
   overlay?: ReactNode;                                   // STRICTLY PRESENTATIONAL content-coordinate layer over the strip (playhead, markers): rides scroll + live-trim transform. aria-hidden + pointer-events none — no interactive/focusable children (focusable-inside-aria-hidden is an a11y violation); interactive scrubbers belong in your own layer outside the strip
+  itemTimes?: readonly StripTimedSlot[];                 // the CONSUMER'S clock for the rendered items, aligned 1:1 by index. Required by `layers`, ignored without them. The strip cannot derive it — its own duration notion knows nothing of a document's inter-clip gap or the span a collection card stands for, so a width-derived clock drifts one gap per gutter. Caller owns reference stability
+  layers?: readonly StripLayer[];                        // LANE ROWS drawn under the picture, time-aligned to it — a music bed, a voiceover. `StripLayer = { items: readonly StripLayerItem[] }`, `StripLayerItem = { id: NodeId; startSeconds: number; durationSeconds: number }`. Requires `itemTimes`. NOT virtualized (layers are few and long where shots are many and short), so the picture virtualizer's index space is untouched
+  layerHeight?: number;                                  // default max(16, itemHeight / 3) — a bed reads as a slim band under full-height shots
+  layerGap?: number;                                     // default 6, above each lane row
   className?: string;
 };
 type VirtualStripHandle = {
@@ -1051,6 +1055,43 @@ only, floored clips cap at their right edge, out-of-range times clamp, and
 the transient first-item gutter is excluded. `timeToOffset({ ...,
 timeSeconds })` remains the one-shot convenience. Strips sized by a custom
 `itemWidthFor` need their own mapping against that same function.
+
+A lane carries its OWN clock: `startSeconds` is arbitrary, so a layer card may
+begin inside one picture card, cross a gutter and end inside another, and two
+cards on one lane need neither touch nor tile. Past the last picture card the
+map extrapolates at that card's rate rather than clamping — a lane can outlast
+the picture (music under a short cut) — and the content spacer grows to cover
+it. Before the first card it clamps, since content coordinates start at 0.
+
+**Lane rows.** With `layers` (and `itemTimes`) the strip becomes a stack:
+the picture keeps its virtualizer as row 1, and each layer draws under it as
+its own `role="row"`, positioned by TIME. A layer card's box is both edges
+run through the picture's time → x map, so a bed spans exactly the shots it
+plays under — gutters included. Sizing it by `durationToWidth` instead would
+leave it short by one pack gap per shot, because a strip is not a linear time
+axis. The map is piecewise linear and anchored on the card edges the strip
+measured, so an `itemWidthFor` override and a live trim both carry through;
+mid-trim, cards downstream of the trimmed one lag by the trim delta until the
+commit lands (only the consumer knows how it repacks), and are exact after.
+
+Roving focus becomes 2D over one flat list spanning every row, so the grid
+keeps its single tab stop: Left/Right step within a row, Home/End hit that
+row's ends, Up/Down cross rows at the nearest time. Vertical arrows stay
+UNHANDLED on a single-row strip — that is how the page scrolls with the
+pointer over one. `aria-rowcount` is `1 + layers.length` and an empty layer
+emits no row element (a row with no cells is an invalid grid tree) while
+keeping its index reserved.
+
+Cross-lane DRAG is deliberately not modelled: a lane is consumer data, not
+something this package's engine knows about. Layer cards drag like any other
+card and their drops resolve through the same container droppable, so a drop
+reorders within the collection and leaves the lane alone. Note that a strip
+handed a FILTERED `itemIds` (which is what a lane split produces) publishes
+boundaries into that filtered list — so the same `mapDropCommand` translation
+`itemIds` already documents applies, or drops land at the wrong position.
+
+A strip with no `layers` renders exactly as it did before they existed, down
+to the DOM: every lane path is gated.
 
 When `trimPixelsPerSecond` is set and a mounted video is selected,
 `VirtualStrip` renders the source-window overview (`TrimOverviewStrip`) as a

--- a/packages/ui/dnd-collections/ARCHITECTURE.md
+++ b/packages/ui/dnd-collections/ARCHITECTURE.md
@@ -86,7 +86,10 @@ react/
                             views over historyEntries.
 virtual/
   VirtualStrip.tsx          Horizontal virtualized strip (TanStack Virtual):
-                            fixed or metadata-driven variable widths.
+                            fixed or metadata-driven variable widths, plus
+                            optional LANE ROWS under the picture.
+  virtual-strip-lanes.ts    Pure lane geometry: the picture's time -> x map,
+                            layer placement, row offsets, 2D roving.
   VirtualGrid.tsx           Vertical fixed-cell grid: fixed or responsive
                             column count, row-based virtualizer.
 DndCollections.stories.tsx  Storybook stories; their play functions are the
@@ -500,6 +503,51 @@ offscreen items in and focusing them (only the roving card is `tabIndex=0`),
 with `aria-row/colcount` + per-cell indexes exposing the real position under
 virtualization. It stands down while a drag is live (`isDragging`) or Alt/
 Ctrl/Meta are held, so it never collides with the other two.
+
+With LANE ROWS the strip becomes a stack of rows, and navigation goes 2D
+over one flat list spanning them — so the grid still has a single tab stop.
+The resolver (`resolveLaneStripIndex`) clamps WITHIN a row, because the hook
+clamps globally and an unclamped step off the last shot would silently land
+on the first layer card. Up/Down cross rows at the nearest time, preferring
+the window that CONTAINS the current card's start. On a single-row strip
+vertical arrows return null rather than the current index: returning it
+would have the hook `preventDefault` a key it did nothing with, and vertical
+arrows are how the page scrolls with the pointer over a strip.
+
+## Lane rows: why the consumer owns the clock
+
+Layers are positioned by TIME, which means the strip needs a time -> x map
+for the picture row. It does not derive one. Its own notion of duration
+knows nothing about the gap a document packs between clips (0.12s in this
+repo) or the span a collection card stands for, so a clock derived from
+widths drifts by one gap per gutter — a few pixels per card, and a bed
+visibly sliding off the shots it covers by the tenth one. The consumer
+already has the real times; it passes them as `itemTimes` and the strip
+pairs them with the widths it measured.
+
+The map is therefore piecewise linear and anchored on card EDGES: at a
+card's start time it returns that card's left edge exactly, and it
+interpolates across the gutter between two cards rather than snapping. A
+layer card's width is both its edges through that map, not
+`durationToWidth` — which is only right on a linear axis and would leave a
+bed short by one pack gap per shot it spans.
+
+A lane is NOT bounded by the picture's cuts, and the map reflects that in
+both directions. A card's start is arbitrary — it may begin inside one shot
+and end inside another, and two cards on one lane need neither touch nor
+tile — so nothing here assumes alignment or ordering among layer items.
+Past the last picture card the map extrapolates at that card's rate instead
+of clamping, because a lane can outlast the picture; clamping drew a 30s bed
+under a 12s cut as though it ended with the cut. Before the first card it
+still clamps, since content coordinates start at 0.
+
+Lanes stop at geometry. A card's lane is CONSUMER data — the engine has no
+`trackIndex` and no command that changes one — so cross-lane drag is not
+modelled here: layer cards drag like any other card and resolve through the
+same container droppable. A consumer that splits its children by lane is
+also handing the strip a FILTERED item source, which makes its published
+boundaries mean something different; `mapDropCommand` is where that gets
+corrected, the same seam a flat strip uses.
 
 ## FLIP animation: a layer above the reducer
 

--- a/packages/ui/dnd-collections/VirtualStrip.stories.tsx
+++ b/packages/ui/dnd-collections/VirtualStrip.stories.tsx
@@ -11,7 +11,11 @@ import {
 import { useCollectionsStore } from "./react/collections-store";
 import { DndCollections } from "./react/DndCollections";
 import { UndoRedoControls } from "./react/history-views";
-import { VirtualStrip, type VirtualStripHandle } from "./virtual/VirtualStrip";
+import {
+  VirtualStrip,
+  type StripLayer,
+  type VirtualStripHandle,
+} from "./virtual/VirtualStrip";
 import { durationToWidth } from "./virtual/virtual-strip-geometry";
 import {
   dispatchPointerSequence,
@@ -2391,5 +2395,276 @@ export const DropIndicatorCentersInGap: Story = {
     expect(barCenter()!).toBeCloseTo((m0Box.right + m1Box.left) / 2, 0);
 
     await releaseAt(insideM0Right);
+  },
+};
+
+// --- lane rows ---------------------------------------------------------------
+//
+// #397. A layered clip runs ALONGSIDE the picture, so it draws as its own
+// time-aligned row instead of taking a slot in the shot sequence. The picture
+// keeps the virtualizer; lane cards are real, focusable cards positioned by
+// time — few and long, where shots are many and short.
+
+const LANE_PPS = 40;
+
+function laneGraph() {
+  const result = buildGraph([
+    {
+      kind: "collection",
+      id: "strip",
+      name: "Strip",
+      children: [
+        { kind: "media", id: "shot1", name: "Shot 1", durationSeconds: 4 },
+        { kind: "media", id: "bed", name: "Bed", durationSeconds: 12.24 },
+        { kind: "media", id: "shot2", name: "Shot 2", durationSeconds: 4 },
+        { kind: "media", id: "vo", name: "VO", durationSeconds: 2 },
+        { kind: "media", id: "shot3", name: "Shot 3", durationSeconds: 4 },
+      ],
+    },
+  ]);
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.value;
+}
+
+// The PICTURE's clock: three 4s shots separated by the document's 0.12s pack
+// gap, which the 8px gutter absorbs — the case a width-derived clock drifts on.
+const PICTURE_IDS = ["shot1", "shot2", "shot3"].map(parseNodeId);
+const PICTURE_TIMES = [
+  { startSeconds: 0, durationSeconds: 4 },
+  { startSeconds: 4.12, durationSeconds: 4 },
+  { startSeconds: 8.24, durationSeconds: 4 },
+];
+// Lane 1: a bed under all three shots. Lane 2: a VO that lines up with
+// NOTHING — it starts inside shot 2, crosses a gutter and ends inside shot 3,
+// which is what audio actually does. A lane is not tied to the picture's cuts.
+const LANE_LAYERS: readonly StripLayer[] = [
+  { items: [{ id: parseNodeId("bed"), startSeconds: 0, durationSeconds: 12.24 }] },
+  { items: [{ id: parseNodeId("vo"), startSeconds: 5.5, durationSeconds: 3.6 }] },
+];
+
+function LaneHarness({ layers = LANE_LAYERS }: { layers?: readonly StripLayer[] }) {
+  return (
+    <DndCollections initialGraph={laneGraph()}>
+      <div className="w-[640px]">
+        <VirtualStrip
+          collectionId={parseNodeId("strip")}
+          itemIds={PICTURE_IDS}
+          itemTimes={PICTURE_TIMES}
+          layers={layers}
+          pixelsPerSecond={LANE_PPS}
+        />
+      </div>
+    </DndCollections>
+  );
+}
+
+export const LaneRowSpansTheShotsItPlaysUnder: Story = {
+  render: () => <LaneHarness />,
+  play: async ({ canvasElement }) => {
+    const shot1 = nodeCard(canvasElement, "shot1");
+    await waitForLayout(shot1);
+    const shot2 = nodeCard(canvasElement, "shot2");
+    const shot3 = nodeCard(canvasElement, "shot3");
+    const bed = nodeCard(canvasElement, "bed");
+    const vo = nodeCard(canvasElement, "vo");
+
+    // THE assertion this feature exists for: the bed's edges land on the
+    // picture it covers — shot 1's left edge to shot 3's right edge, the two
+    // gutters in between included. A duration*pps width would fall short by
+    // exactly those gutters.
+    expect(bed.getBoundingClientRect().left).toBeCloseTo(
+      shot1.getBoundingClientRect().left,
+      0,
+    );
+    expect(bed.getBoundingClientRect().right).toBeCloseTo(
+      shot3.getBoundingClientRect().right,
+      0,
+    );
+
+    // The VO lines up with NOTHING: it begins inside shot 2, crosses the
+    // gutter, and ends inside shot 3. A lane carries its own clock, so a card
+    // on one is not required to touch any edge on any other row.
+    const shot2Box = shot2.getBoundingClientRect();
+    const shot3Box = shot3.getBoundingClientRect();
+    const voBox = vo.getBoundingClientRect();
+    expect(voBox.left).toBeGreaterThan(shot2Box.left);
+    expect(voBox.left).toBeLessThan(shot2Box.right);
+    expect(voBox.right).toBeGreaterThan(shot3Box.left);
+    expect(voBox.right).toBeLessThan(shot3Box.right);
+
+    // And they are ROWS: each sits below the picture, and below each other.
+    expect(bed.getBoundingClientRect().top).toBeGreaterThan(
+      shot1.getBoundingClientRect().bottom - 1,
+    );
+    expect(vo.getBoundingClientRect().top).toBeGreaterThan(
+      bed.getBoundingClientRect().bottom - 1,
+    );
+  },
+};
+
+export const LaneRowOutlastsThePicture: Story = {
+  // Music under a short cut. A lane is not bounded by the picture, so the bed
+  // has to draw its TRUE length and the content has to grow to hold it —
+  // clamping at the last shot drew a 30s bed as though it ended with the cut.
+  render: () => (
+    <LaneHarness
+      layers={[
+        { items: [{ id: parseNodeId("bed"), startSeconds: 0, durationSeconds: 30 }] },
+      ]}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const shot3 = nodeCard(canvasElement, "shot3");
+    await waitForLayout(nodeCard(canvasElement, "shot1"));
+    const bed = nodeCard(canvasElement, "bed");
+
+    // Past the last shot's right edge, by the 17.76s it runs on for.
+    expect(bed.getBoundingClientRect().right).toBeGreaterThan(
+      shot3.getBoundingClientRect().right + 100,
+    );
+    // And the scrollable content grew to cover it, rather than clipping it.
+    const scroller = canvasElement.querySelector<HTMLElement>('[data-virtual-strip="strip"]')!;
+    expect(scroller.scrollWidth).toBeGreaterThan(
+      shot3.getBoundingClientRect().right - scroller.getBoundingClientRect().left,
+    );
+  },
+};
+
+export const LaneRowsCarryGridRowSemantics: Story = {
+  render: () => <LaneHarness />,
+  play: async ({ canvasElement }) => {
+    await waitForLayout(nodeCard(canvasElement, "shot1"));
+    const strip = canvasElement.querySelector<HTMLElement>('[data-virtual-strip="strip"]')!;
+
+    // One row for the picture plus one per lane, and the widest row's count.
+    expect(strip).toHaveAttribute("aria-rowcount", "3");
+    expect(strip).toHaveAttribute("aria-colcount", "3");
+    // Every card is announced, layer cards included.
+    expect(strip).toHaveAttribute("aria-label", "Strip, 5 items");
+
+    const rows = [...strip.querySelectorAll('[role="row"]')];
+    expect(rows.map((row) => row.getAttribute("aria-rowindex"))).toEqual(["1", "2", "3"]);
+    // The picture is row 1 and is NOT the spacer any more — a row may not
+    // contain a row, so it gets its own element once lanes are siblings.
+    expect(rows[0]).toHaveAttribute("data-strip-lane", "0");
+    expect(rows[1]).toHaveAttribute("data-strip-lane", "1");
+  },
+};
+
+export const ArrowKeysCrossBetweenLanes: Story = {
+  render: () => <LaneHarness />,
+  play: async ({ canvasElement }) => {
+    const user = userEvent.setup();
+    const shot1 = nodeCard(canvasElement, "shot1");
+    await waitForLayout(shot1);
+
+    // Down from shot 1 lands on what is playing UNDER it.
+    shot1.focus();
+    await user.keyboard("{ArrowDown}");
+    await waitFor(() => {
+      const bed = nodeCard(canvasElement, "bed");
+      expect(bed.ownerDocument.activeElement).toBe(bed);
+    });
+
+    // Down again reaches the second lane — the VO, the only card there.
+    await user.keyboard("{ArrowDown}");
+    await waitFor(() => {
+      const vo = nodeCard(canvasElement, "vo");
+      expect(vo.ownerDocument.activeElement).toBe(vo);
+    });
+
+    // Up from the VO (4.12s) lands on the bed, which is playing then.
+    await user.keyboard("{ArrowUp}");
+    await waitFor(() => {
+      const bed = nodeCard(canvasElement, "bed");
+      expect(bed.ownerDocument.activeElement).toBe(bed);
+    });
+
+    // Up again lands on shot 1, NOT the shot we came down from. Each move
+    // anchors on the current card's own start, and the bed starts at 0 — so
+    // up/down is not an inverse when the rows are cut differently, which is
+    // the normal case for a bed.
+    await user.keyboard("{ArrowUp}");
+    await waitFor(() => {
+      const shot1Again = nodeCard(canvasElement, "shot1");
+      expect(shot1Again.ownerDocument.activeElement).toBe(shot1Again);
+    });
+  },
+};
+
+export const ArrowRightStopsAtTheEndOfItsOwnRow: Story = {
+  render: () => <LaneHarness />,
+  play: async ({ canvasElement }) => {
+    const user = userEvent.setup();
+    await waitForLayout(nodeCard(canvasElement, "shot1"));
+    const shot3 = nodeCard(canvasElement, "shot3");
+
+    // The roving list is every row concatenated, so an unclamped step off the
+    // last shot would land on the bed — Right must never change rows.
+    shot3.focus();
+    await user.keyboard("{ArrowRight}");
+    await waitFor(() => expect(shot3.ownerDocument.activeElement).toBe(shot3));
+  },
+};
+
+export const LaneCardsSelectLikeAnyOther: Story = {
+  render: () => <LaneHarness />,
+  play: async ({ canvasElement }) => {
+    const user = userEvent.setup();
+    await waitForLayout(nodeCard(canvasElement, "shot1"));
+
+    await user.click(nodeCard(canvasElement, "bed"));
+    await waitFor(() =>
+      expect(nodeCard(canvasElement, "bed")).toHaveAttribute("data-selected", "true"),
+    );
+  },
+};
+
+export const AnEmptyLaneDrawsNoRow: Story = {
+  render: () => <LaneHarness layers={[{ items: [] }, LANE_LAYERS[0]!]} />,
+  play: async ({ canvasElement }) => {
+    await waitForLayout(nodeCard(canvasElement, "shot1"));
+    const strip = canvasElement.querySelector<HTMLElement>('[data-virtual-strip="strip"]')!;
+
+    // A row with no cells is an invalid grid tree, so the empty lane emits no
+    // element — the same way virtualization omits columns. Its INDEX is still
+    // reserved, so the lane below it stays row 3.
+    expect(strip).toHaveAttribute("aria-rowcount", "3");
+    const rows = [...strip.querySelectorAll('[role="row"]')];
+    expect(rows.map((row) => row.getAttribute("aria-rowindex"))).toEqual(["1", "3"]);
+  },
+};
+
+export const WithoutLanesTheStripIsUnchanged: Story = {
+  // The regression pin for every board that has no layers: the lane paths are
+  // gated all the way down to the DOM, so nothing about an ordinary strip
+  // moves — including vertical arrows staying unhandled, which is how the
+  // page scrolls with the pointer over a strip.
+  render: () => (
+    <DndCollections initialGraph={laneGraph()}>
+      <div className="w-[640px]">
+        <VirtualStrip collectionId={parseNodeId("strip")} pixelsPerSecond={LANE_PPS} />
+      </div>
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    await waitForLayout(nodeCard(canvasElement, "shot1"));
+    const strip = canvasElement.querySelector<HTMLElement>('[data-virtual-strip="strip"]')!;
+
+    expect(strip).toHaveAttribute("aria-rowcount", "1");
+    expect(strip.querySelectorAll("[data-strip-lane]")).toHaveLength(0);
+    // The spacer is still the one row itself.
+    const rows = [...strip.querySelectorAll('[role="row"]')];
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveAttribute("aria-rowindex", "1");
+
+    nodeCard(canvasElement, "shot1").focus();
+    const keydown = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "ArrowDown",
+    });
+    strip.dispatchEvent(keydown);
+    expect(keydown.defaultPrevented).toBe(false);
   },
 };

--- a/packages/ui/dnd-collections/index.ts
+++ b/packages/ui/dnd-collections/index.ts
@@ -197,6 +197,9 @@ export { useEdgeAutoScroll } from "./react/use-edge-autoscroll";
 // cells + responsive columns (grid). VIRTUALIZATION-PLAN.md is the build log.
 export {
   VirtualStrip,
+  type StripLayer,
+  type StripLayerItem,
+  type StripTimedSlot,
   type VirtualStripHandle,
   type VirtualStripProps,
 } from "./virtual/VirtualStrip";

--- a/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
@@ -63,8 +63,21 @@ import {
   resolveBoundaryIndex,
   slotSizeFor,
 } from "./virtual-strip-geometry";
+import {
+  createLaneTimeMap,
+  laneFlatIndex,
+  laneItemPlacement,
+  laneRowPosition,
+  laneRowTop,
+  laneStackHeight,
+  resolveLaneStripIndex,
+  type LanePictureSlot,
+  type LaneRowLayout,
+} from "./virtual-strip-lanes";
 
 // 1D roving navigation: Left/Right step one item, Home/End jump to the ends.
+// Used when the strip has no lane rows; `resolveLaneStripIndex` takes over
+// when it does, and reduces to exactly this for a single row.
 function resolveStripIndex(key: string, current: number, count: number): number | null {
   switch (key) {
     case "ArrowRight":
@@ -112,10 +125,41 @@ const STRIP_PAN_DISABLED: PanWithMomentumOptions = { disabled: true };
 // Gap between the floating overview tooltip and the top of the strip.
 const OVERVIEW_GAP = 8;
 
+// A lane row draws as a slim band under the picture — the editor idiom, where
+// a bed or a voiceover must not compete with the shots for height. A fraction
+// rather than a fixed size so every item size gets a proportionate row, with a
+// floor so the smallest board still has something clickable.
+const LANE_ROW_HEIGHT_FRACTION = 1 / 3;
+const MIN_LANE_ROW_HEIGHT = 16;
+const DEFAULT_LANE_ROW_GAP = 6;
+
 // Layering inside the strip content: drop indicator and trim-handle hit
 // zones sit at z-20, the default trim-preview bubble at z-30; the consumer
 // overlay shares the bubble tier — above cards and handles, below nothing.
 const OVERLAY_Z_INDEX = 30;
+
+/** A slot on the consumer's clock. Times are the CONSUMER'S, not the strip's
+ *  — see `itemTimes`. */
+export type StripTimedSlot = Readonly<{
+  startSeconds: number;
+  durationSeconds: number;
+}>;
+
+/** One card on a lane row. */
+export type StripLayerItem = StripTimedSlot & Readonly<{ id: NodeId }>;
+
+/**
+ * A LANE ROW — content that plays *alongside* the picture rather than after
+ * it: a music bed, a voiceover. Drawn as its own row under the picture,
+ * time-aligned to it, so a bed under shots 1-3 visibly spans those cards.
+ *
+ * Layer cards are NOT virtualized. They are few and long where shots are many
+ * and short, so the case virtualization exists for does not apply, and leaving
+ * them out keeps the picture virtualizer's index space intact.
+ */
+export type StripLayer = Readonly<{
+  items: readonly StripLayerItem[];
+}>;
 
 export type VirtualStripProps = Readonly<{
   collectionId: NodeId;
@@ -225,6 +269,42 @@ export type VirtualStripProps = Readonly<{
    * belongs in your own positioned layer OUTSIDE the strip.
    */
   overlay?: ReactNode;
+  /**
+   * THE CONSUMER'S CLOCK for the rendered items, aligned 1:1 by index with
+   * `itemIds` (or the collection's own children). Required by `layers`, and
+   * ignored without them.
+   *
+   * The strip cannot derive this. Its own notion of duration knows nothing
+   * about the inter-clip gap a document packs with, nor about the span a
+   * collection card stands for, so a clock derived from widths would drift by
+   * one gap per gutter — a few pixels per card, and a lane row visibly sliding
+   * off the shots it covers by the tenth one. The consumer already knows the
+   * real times; it hands them over and the strip pairs them with the widths it
+   * measured.
+   *
+   * Caller owns reference stability, as with `itemIds`.
+   */
+  itemTimes?: readonly StripTimedSlot[];
+  /**
+   * Rows drawn UNDER the picture, time-aligned to it — see `StripLayer`.
+   * Requires `itemTimes`; without it there is no clock to align against and
+   * layers are ignored.
+   *
+   * A strip with no layers renders exactly as it did before they existed:
+   * every path below is gated, down to the DOM.
+   *
+   * NOTE cross-lane DRAG is not modelled here. Layer cards drag like any
+   * other card and their drops resolve through the same container droppable,
+   * so a drop reorders within the collection and leaves the lane alone.
+   * Moving a card BETWEEN lanes is the consumer's own write (the lane is
+   * consumer data — this package's engine does not model it).
+   */
+  layers?: readonly StripLayer[];
+  /** Height of each lane row. Shorter than `itemHeight` by default — a bed
+   *  reads as a slim band under full-height shots. */
+  layerHeight?: number;
+  /** Vertical gap above each lane row. */
+  layerGap?: number;
   className?: string;
 }>;
 
@@ -256,6 +336,10 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
       itemContent,
       itemShell,
       overlay,
+      itemTimes,
+      layers,
+      layerHeight: layerHeightOption,
+      layerGap: layerGapOption,
       className,
     },
     ref
@@ -264,6 +348,17 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
     const itemWidth = finitePositiveOr(itemWidthOption, 128);
     const itemHeight = finitePositiveOr(itemHeightOption, 96);
     const gap = finiteNonNegativeOr(gapOption, 8);
+    // Lane rows need a clock to align against; without one they cannot be
+    // placed, so they are ignored rather than guessed at. This single flag
+    // gates every lane path, including the DOM shape.
+    const laneRows = layers !== undefined && layers.length > 0 && itemTimes !== undefined
+      ? layers
+      : null;
+    const layerHeight = finitePositiveOr(
+      layerHeightOption,
+      Math.max(MIN_LANE_ROW_HEIGHT, itemHeight * LANE_ROW_HEIGHT_FRACTION),
+    );
+    const layerGap = finiteNonNegativeOr(layerGapOption, DEFAULT_LANE_ROW_GAP);
     const overscan = nonNegativeIntegerOr(overscanOption, 4);
     // One scale for widths AND trims by default: the handles inherit
     // pixelsPerSecond unless explicitly overridden.
@@ -622,6 +717,106 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
       // eslint-disable-next-line react-hooks/exhaustive-deps -- liveTrim intentionally omitted (see comment)
     }, [dataVersion, graphGeneration, store, scrollRef]);
 
+    // --- lane rows ---------------------------------------------------------
+
+    // The picture row's time -> content-x map, paired from what the strip
+    // MEASURED (x, so an itemWidthFor override and a live trim are included)
+    // and what the consumer's clock says (t). Only walked when there are
+    // lanes to place: a strip without them never runs any of this.
+    //
+    // Mid-trim it follows the LIVE x's, so a bed stays attached to the shots
+    // it covers while one of them is being trimmed, and the trimmed slot takes
+    // the gesture's live duration so its interior stays self-consistent. Slots
+    // AFTER it keep their committed start times — only the consumer knows how
+    // it repacks — so a layer card downstream of a live trim lags by the trim
+    // delta until the commit lands. Sub-second, and exact from then on.
+    const laneTimeMap = useMemo(() => {
+      if (!laneRows || !itemTimes) return null;
+      const slots: LanePictureSlot[] = [];
+      let x = firstItemGutter;
+      for (let index = 0; index < childIds.length; index += 1) {
+        const childId = childIds[index];
+        const time = itemTimes[index];
+        const live =
+          childId !== undefined && liveTrim?.nodeId === childId ? liveTrim.trim : null;
+        // Mirrors estimateSize exactly (with resizeItem's override applied for
+        // the trimmed slot), which IS the virtualizer's layout — the strip
+        // never dynamically measures a card.
+        const size =
+          live && childId !== undefined
+            ? previewSlotSize(childId, live)
+            : widthForIndex(index) + gap;
+        if (time) {
+          slots.push({
+            left: x,
+            width: size - gap,
+            startSeconds: time.startSeconds,
+            durationSeconds: live ? live.effectiveSeconds : time.durationSeconds,
+          });
+        }
+        x += size;
+      }
+      return createLaneTimeMap(slots);
+      // widthForIndex/previewSlotSize are re-created every render by design;
+      // the graph data they read is covered by dataVersion/graphGeneration,
+      // and the layout inputs are listed explicitly. When this memo does re-run
+      // it closes over the current render's functions, so it cannot go stale.
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- see above
+    }, [
+      laneRows,
+      itemTimes,
+      childIds,
+      firstItemGutter,
+      gap,
+      liveTrim,
+      dataVersion,
+      graphGeneration,
+      pixelsPerSecond,
+      itemWidth,
+      itemWidthFor,
+    ]);
+
+    // Every layer card's box, plus the furthest right edge any of them reach —
+    // the spacer has to cover a bed that outlasts the picture.
+    const layerPlacements = useMemo(() => {
+      const byId = new Map<NodeId, Readonly<{ left: number; width: number }>>();
+      let right = 0;
+      if (laneRows && laneTimeMap) {
+        for (const layer of laneRows) {
+          for (const item of layer.items) {
+            const placement = laneItemPlacement(laneTimeMap, item);
+            byId.set(item.id, placement);
+            right = Math.max(right, placement.left + placement.width);
+          }
+        }
+      }
+      return { byId, right };
+    }, [laneRows, laneTimeMap]);
+
+    // Row 0 is the picture, then each layer in order — the shape the roving
+    // resolver navigates. Empty without lanes, which is what keeps the plain
+    // strip on its original 1D path.
+    const rowLayout: LaneRowLayout = useMemo(
+      () => (laneRows && itemTimes ? [itemTimes, ...laneRows.map((layer) => layer.items)] : []),
+      [laneRows, itemTimes],
+    );
+    // Roving focus navigates ONE list spanning every row, so the grid keeps a
+    // single tab stop. Deliberately separate from `indexById`, which stays the
+    // PICTURE's index space — the virtualizer's resizeItem, the reorder no-op
+    // test and scrollToIndex all address it and would be corrupted by layer
+    // entries.
+    const rovingIds = useMemo(
+      () =>
+        laneRows
+          ? [...childIds, ...laneRows.flatMap((layer) => layer.items.map((item) => item.id))]
+          : childIds,
+      [laneRows, childIds],
+    );
+    const rovingIndexById = useMemo(
+      () => (laneRows ? new Map(rovingIds.map((id, index) => [id, index])) : indexById),
+      [laneRows, rovingIds, indexById],
+    );
+
     // Pointer -> visible boundary index from the virtualizer's measurements
     // (O(log n), variable widths included) — never from card rects, since
     // most cards aren't mounted. The spacer's rect shifts with scroll, so
@@ -664,11 +859,26 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
     const scrollToNode = useCallback(
       (id: NodeId): boolean => {
         const index = indexById.get(id);
-        if (index === undefined) return false;
-        virtualizer.scrollToIndex(index);
+        if (index !== undefined) {
+          virtualizer.scrollToIndex(index);
+          return true;
+        }
+        // A layer card. It is always mounted (lanes are not virtualized) but
+        // can still be scrolled out of view, so bring its box inside by the
+        // smallest move that does it — the virtualizer knows nothing about it.
+        const placement = layerPlacements.byId.get(id);
+        const scroller = scrollRef.current;
+        if (!placement || !scroller) return false;
+        const viewLeft = scroller.scrollLeft;
+        const viewRight = viewLeft + scroller.clientWidth;
+        if (placement.left < viewLeft) {
+          scroller.scrollLeft = placement.left;
+        } else if (placement.left + placement.width > viewRight) {
+          scroller.scrollLeft = placement.left + placement.width - scroller.clientWidth;
+        }
         return true;
       },
-      [indexById, virtualizer]
+      [indexById, virtualizer, layerPlacements, scrollRef]
     );
     const focusNode = useFocusNode(scrollRef, scrollToNode);
 
@@ -681,17 +891,27 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
       (index: number) => {
         // The roving index can outlive the list it points into for a render
         // after a removal; focusing nothing is the right answer there.
-        const childId = childIds[index];
-        if (childId !== undefined) focusNode(childId);
+        const id = rovingIds[index];
+        if (id !== undefined) focusNode(id);
       },
-      [focusNode, childIds]
+      [focusNode, rovingIds]
+    );
+    // 2D once there are lanes, and `resolveLaneStripIndex` reduces to exactly
+    // the 1D behaviour for a single row — including leaving vertical arrows
+    // alone, which is how the page scrolls with the pointer over a strip.
+    const resolveNextIndex = useCallback(
+      (key: string, current: number, count: number) =>
+        rowLayout.length > 0
+          ? resolveLaneStripIndex(key, current, rowLayout)
+          : resolveStripIndex(key, current, count),
+      [rowLayout]
     );
     const { focusedIndex, onKeyDown, onItemFocus } = useVirtualRovingFocus({
-      itemIds: childIds,
-      indexById,
+      itemIds: rovingIds,
+      indexById: rovingIndexById,
       isDragging: () => store.getSnapshot().interaction.isDragging,
       focusByIndex,
-      resolveNextIndex: resolveStripIndex,
+      resolveNextIndex,
       // Arrows carry the selection with them (the file-manager convention),
       // so a keyboard user acts on what they navigated to instead of having to
       // press Space at every stop. Shift extends from the pivot.
@@ -706,10 +926,29 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
     // Keep the roving tab stop on a MOUNTED card: if the focused index scrolled
     // out of view (mouse/pan), fall back to the first mounted item so the strip
     // stays tabbable.
+    //
+    // With lanes the focused index is FLAT across rows, so it has to be
+    // resolved to a row first: a focused LAYER card means no picture card is
+    // the tab stop (-1 matches no index), and the layer cell claims it
+    // instead. An index that resolves to no row at all (a render behind a
+    // removal) falls back to the picture, so the grid never ends up with no
+    // tab stop.
     const mountedItems = virtualizer.getVirtualItems();
-    const rovingIndex = mountedItems.some((v) => v.index === focusedIndex)
-      ? focusedIndex
-      : mountedItems[0]?.index ?? 0;
+    const focusedPosition = rowLayout.length > 0 ? laneRowPosition(focusedIndex, rowLayout) : null;
+    const pictureFocusIndex =
+      rowLayout.length === 0
+        ? focusedIndex
+        : focusedPosition === null
+          ? 0
+          : focusedPosition.row === 0
+            ? focusedPosition.column
+            : -1;
+    const rovingIndex =
+      pictureFocusIndex === -1
+        ? -1
+        : mountedItems.some((v) => v.index === pictureFocusIndex)
+          ? pictureFocusIndex
+          : mountedItems[0]?.index ?? 0;
 
     // The overview is a floating TOOLTIP above the selected clip — it does NOT
     // reserve a band in the row, so showing it never displaces the clips. To
@@ -849,6 +1088,113 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
     };
     const indicatorLeft = indicatorIndex !== null ? boundaryLeft(indicatorIndex) : null;
 
+    // The picture row's cells. Hoisted out of the tree because they render in
+    // one of two places: directly in the spacer (no lanes — the spacer IS the
+    // row, exactly as before lanes existed), or inside their own row element
+    // when lane rows are siblings, since a row may not contain a row.
+    const pictureCells = virtualizer.getVirtualItems().map((item) => {
+      // Resolved ONCE per item. The virtualizer's window can lag a
+      // removal by a render, so an index here is not guaranteed to
+      // still name a child; skipping is the only correct answer, and
+      // it keeps both reads below honest about it.
+      const childId = childIds[item.index];
+      if (childId === undefined) return null;
+      return (
+        <div
+          key={item.key}
+          data-virtual-index={item.index}
+          role="gridcell"
+          aria-colindex={item.index + 1}
+          // Sync the roving index to whatever card actually gains focus
+          // (click, programmatic focus), not just keyboard navigation.
+          onFocus={() => onItemFocus(childId)}
+          style={
+            {
+              position: "absolute",
+              top: 0,
+              left: 0,
+              width: item.size - gap,
+              height: itemHeight,
+              transform: `translateX(${item.start}px)`,
+              // Only the FIRST card's leading side is special: there
+              // is no gap before it, and the scroll box clips anything
+              // pulled out into the container's padding. Its trailing
+              // side has an ordinary gap and gets the ordinary offset.
+              "--dnd-drop-indicator-half-gap-before":
+                item.index === 0 ? "0px" : `${gap / 2}px`,
+              "--dnd-drop-indicator-half-gap-after": `${gap / 2}px`,
+            } as CSSProperties
+          }
+        >
+          {/* Explicit sizing: the item fills its (possibly variable) slot.
+              With panToScroll, item drags move to the grip bar or behind
+              a press-and-hold so the body is free to pan the strip. */}
+          <ItemShell
+            id={childId}
+            className="h-full w-full"
+            dragActivation={cardActivation}
+            rovingTabIndex={item.index === rovingIndex ? 0 : -1}
+            trimPixelsPerSecond={trimPixelsPerSecond}
+            itemContent={itemContent}
+          />
+        </div>
+      );
+    });
+
+    // Lane rows: real, focusable cards positioned by TIME rather than by the
+    // virtualizer's sequence, so each one spans the picture it actually plays
+    // under. They ride inside the content spacer, so scroll, auto-scroll and
+    // the live-trim anchor transform all apply to them for free.
+    const laneRowElements = laneRows?.map((layer, layerIndex) => {
+      if (layer.items.length === 0) return null;
+      return (
+        <div
+          key={`lane-${layerIndex}`}
+          role="row"
+          aria-rowindex={layerIndex + 2}
+          data-strip-lane={layerIndex + 1}
+          style={{
+            position: "absolute",
+            left: 0,
+            right: 0,
+            top: laneRowTop(layerIndex + 1, itemHeight, layerHeight, layerGap),
+            height: layerHeight,
+          }}
+        >
+          {layer.items.map((item, column) => {
+            const placement = layerPlacements.byId.get(item.id);
+            if (!placement) return null;
+            const flatIndex = laneFlatIndex(layerIndex + 1, column, rowLayout);
+            return (
+              <div
+                key={item.id}
+                role="gridcell"
+                aria-colindex={column + 1}
+                onFocus={() => onItemFocus(item.id)}
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  width: placement.width,
+                  height: layerHeight,
+                  transform: `translateX(${placement.left}px)`,
+                }}
+              >
+                <ItemShell
+                  id={item.id}
+                  className="h-full w-full"
+                  dragActivation={cardActivation}
+                  rovingTabIndex={flatIndex !== null && flatIndex === focusedIndex ? 0 : -1}
+                  trimPixelsPerSecond={trimPixelsPerSecond}
+                  itemContent={itemContent}
+                />
+              </div>
+            );
+          })}
+        </div>
+      );
+    });
+
     return (
       <TrimPreviewContext.Provider value={trimPreview}>
         {/* Wrapper so the overview tooltip can float ABOVE the strip without
@@ -882,11 +1228,20 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
             // aria-colindex expose the true position ("column 500 of 1000") even
             // though only a handful of cells are mounted.
             role="grid"
-            aria-label={`${name}, ${childIds.length} items`}
+            aria-label={`${name}, ${rovingIds.length} items`}
             // An empty strip has no rows (the spacer drops its row role too);
             // claiming rowcount 1 over an empty row is an invalid grid tree.
-            aria-rowcount={childIds.length === 0 ? 0 : 1}
-            aria-colcount={childIds.length}
+            // With lanes the picture is row 1 and each layer adds one under
+            // it; a layer with nothing in it emits no row element, the same
+            // way virtualization omits columns, so the indices stay stable.
+            aria-rowcount={
+              laneRows ? 1 + laneRows.length : childIds.length === 0 ? 0 : 1
+            }
+            aria-colcount={
+              laneRows
+                ? Math.max(childIds.length, ...laneRows.map((layer) => layer.items.length))
+                : childIds.length
+            }
             onKeyDown={onKeyDown}
             // Empty space is the "deselect" target. The pointerdown half only
             // records where the press started, so a PAN (which also ends in a
@@ -907,14 +1262,29 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
             <VirtualEmptyHint visible={childIds.length === 0} />
             <div
               ref={contentRef}
-              {...(childIds.length > 0 ? { role: "row", "aria-rowindex": 1 } : {})}
+              // Without lanes the spacer IS the one row. With them it becomes
+              // the rows' container instead — a row may not contain a row —
+              // and the picture gets its own row element below.
+              {...(childIds.length > 0 && !laneRows
+                ? { role: "row", "aria-rowindex": 1 }
+                : {})}
               style={{
                 // The slot's width is ADDED here and nowhere else: every
                 // boundary and model reads `getTotalSize()`, which stays the
                 // cards' own extent, so the slot cannot shift an index.
-                width:
+                //
+                // A lane row can reach PAST the picture (a bed that outlasts
+                // the last shot), so the spacer covers the furthest of the
+                // two. Widening it does not move a boundary for the same
+                // reason the trailing slot doesn't — boundaries read
+                // getTotalSize(), not this.
+                width: Math.max(
                   virtualizer.getTotalSize() + (trailingSlot ? itemWidth + gap : 0),
-                height: itemHeight,
+                  layerPlacements.right,
+                ),
+                height: laneRows
+                  ? laneStackHeight(itemHeight, layerHeight, layerGap, laneRows.length)
+                  : itemHeight,
                 position: "relative",
                 // The left-handle "grows left" anchor (0 unless a left trim is
                 // in flight). Shifts the whole content layer so clips move
@@ -931,58 +1301,25 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
                   style={{ left: indicatorLeft }}
                 />
               )}
-              {virtualizer.getVirtualItems().map((item) => {
-                // Resolved ONCE per item. The virtualizer's window can lag a
-                // removal by a render, so an index here is not guaranteed to
-                // still name a child; skipping is the only correct answer, and
-                // it keeps both reads below honest about it.
-                const childId = childIds[item.index];
-                if (childId === undefined) return null;
-                return (
+              {laneRows && childIds.length > 0 ? (
                 <div
-                  key={item.key}
-                  data-virtual-index={item.index}
-                  role="gridcell"
-                  aria-colindex={item.index + 1}
-                  // Sync the roving index to whatever card actually gains focus
-                  // (click, programmatic focus), not just keyboard navigation.
-                  onFocus={() => onItemFocus(childId)}
-                  style={
-                    {
-                      position: "absolute",
-                      top: 0,
-                      left: 0,
-                      width: item.size - gap,
-                      height: itemHeight,
-                      transform: `translateX(${item.start}px)`,
-                      // Only the FIRST card's leading side is special: there
-                      // is no gap before it, and the scroll box clips anything
-                      // pulled out into the container's padding. Its trailing
-                      // side has an ordinary gap and gets the ordinary offset.
-                      // Only the FIRST card's leading side is special: there
-                      // is no gap before it, and the scroll box clips anything
-                      // pulled out into the container's padding. Its trailing
-                      // side has an ordinary gap and gets the ordinary offset.
-                      "--dnd-drop-indicator-half-gap-before":
-                        item.index === 0 ? "0px" : `${gap / 2}px`,
-                      "--dnd-drop-indicator-half-gap-after": `${gap / 2}px`,
-                    } as CSSProperties
-                  }
+                  role="row"
+                  aria-rowindex={1}
+                  data-strip-lane={0}
+                  style={{
+                    position: "absolute",
+                    left: 0,
+                    right: 0,
+                    top: 0,
+                    height: itemHeight,
+                  }}
                 >
-                  {/* Explicit sizing: the item fills its (possibly variable) slot.
-                      With panToScroll, item drags move to the grip bar or behind
-                      a press-and-hold so the body is free to pan the strip. */}
-                  <ItemShell
-                    id={childId}
-                    className="h-full w-full"
-                    dragActivation={cardActivation}
-                    rovingTabIndex={item.index === rovingIndex ? 0 : -1}
-                    trimPixelsPerSecond={trimPixelsPerSecond}
-                    itemContent={itemContent}
-                  />
+                  {pictureCells}
                 </div>
-                );
-              })}
+              ) : (
+                pictureCells
+              )}
+              {laneRowElements}
               {trailingSlot && (
                 <div
                   data-virtual-trailing-slot

--- a/packages/ui/dnd-collections/virtual/virtual-strip-lanes.test.ts
+++ b/packages/ui/dnd-collections/virtual/virtual-strip-lanes.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it } from "vitest";
+
+import { MIN_ITEM_WIDTH } from "./virtual-strip-geometry";
+import {
+  createLaneTimeMap,
+  laneFlatIndex,
+  laneItemPlacement,
+  laneRowPosition,
+  laneRowTop,
+  laneStackHeight,
+  resolveLaneStripIndex,
+  type LaneRowLayout,
+} from "./virtual-strip-lanes";
+
+// Three 4s shots at 40px/s, separated by an 8px gutter that absorbs the
+// document's 0.12s pack gap — the layout the app actually produces, and the
+// one where deriving time from widths drifts.
+const SHOTS = [
+  { left: 0, width: 160, startSeconds: 0, durationSeconds: 4 },
+  { left: 168, width: 160, startSeconds: 4.12, durationSeconds: 4 },
+  { left: 336, width: 160, startSeconds: 8.24, durationSeconds: 4 },
+];
+
+describe("createLaneTimeMap", () => {
+  it("returns 0 for every time when there are no slots", () => {
+    const map = createLaneTimeMap([]);
+    expect(map.at(0)).toBe(0);
+    expect(map.at(12)).toBe(0);
+  });
+
+  it("lands exactly on a card's left edge at its start time", () => {
+    const map = createLaneTimeMap(SHOTS);
+    expect(map.at(0)).toBe(0);
+    expect(map.at(4.12)).toBe(168);
+    expect(map.at(8.24)).toBe(336);
+  });
+
+  it("lands exactly on a card's right edge at its end time", () => {
+    const map = createLaneTimeMap(SHOTS);
+    expect(map.at(4)).toBe(160);
+    expect(map.at(12.24)).toBe(496);
+  });
+
+  it("interpolates linearly inside a card", () => {
+    const map = createLaneTimeMap(SHOTS);
+    expect(map.at(2)).toBe(80);
+    expect(map.at(1)).toBe(40);
+  });
+
+  it("interpolates across the gutter rather than snapping to the next card", () => {
+    const map = createLaneTimeMap(SHOTS);
+    // The gutter spans 4s -> 4.12s in time and 160px -> 168px in x.
+    expect(map.at(4.06)).toBeCloseTo(164, 6);
+  });
+
+  it("clamps before the run to the first left edge", () => {
+    const map = createLaneTimeMap(SHOTS);
+    expect(map.at(-10)).toBe(0);
+    expect(map.at(Number.NaN)).toBe(0);
+  });
+
+  it("extrapolates PAST the run at the last card's rate", () => {
+    // A lane can outlast the picture — music under a short cut. Clamping here
+    // drew a 30s bed as though it ended with the last shot.
+    const map = createLaneTimeMap(SHOTS);
+    // The last shot runs 4s across 160px, so 40px/s past its end.
+    expect(map.at(12.24)).toBe(496);
+    expect(map.at(13.24)).toBeCloseTo(536, 6);
+    expect(map.at(22.24)).toBeCloseTo(896, 6);
+  });
+
+  it("clamps past the run when the last card offers no rate", () => {
+    const map = createLaneTimeMap([
+      { left: 0, width: 160, startSeconds: 0, durationSeconds: 4 },
+      { left: 168, width: 128, startSeconds: 4.12, durationSeconds: 0 },
+    ]);
+    expect(map.at(99)).toBe(296);
+  });
+
+  it("resolves a zero-duration card to its left edge", () => {
+    // A collection card the consumer reports no span for: it owns width but no
+    // interval, so there is nothing to interpolate across.
+    const map = createLaneTimeMap([
+      { left: 0, width: 160, startSeconds: 0, durationSeconds: 4 },
+      { left: 168, width: 128, startSeconds: 4.12, durationSeconds: 0 },
+      { left: 304, width: 160, startSeconds: 4.24, durationSeconds: 4 },
+    ]);
+    expect(map.at(4.12)).toBe(168);
+  });
+
+  it("honours a fixed-width card holding an arbitrary span", () => {
+    // A collection: 100s of content inside 128px. Half way through its span is
+    // half way across its card, which a duration*pps mapping could never say.
+    const map = createLaneTimeMap([
+      { left: 0, width: 160, startSeconds: 0, durationSeconds: 4 },
+      { left: 168, width: 128, startSeconds: 4.12, durationSeconds: 100 },
+    ]);
+    expect(map.at(54.12)).toBe(232);
+  });
+});
+
+describe("laneItemPlacement", () => {
+  const map = createLaneTimeMap(SHOTS);
+
+  it("spans the shots a bed covers, gutters included", () => {
+    // A bed running under all three shots: 0 -> 12.24s.
+    expect(laneItemPlacement(map, { startSeconds: 0, durationSeconds: 12.24 })).toEqual({
+      left: 0,
+      width: 496,
+    });
+  });
+
+  it("is wider than duration*pps by exactly the gutters it spans", () => {
+    const bed = laneItemPlacement(map, { startSeconds: 0, durationSeconds: 12.24 });
+    // 12.24s at 40px/s is 489.6px; the two 8px gutters make up the rest.
+    expect(bed.width - 12.24 * 40).toBeCloseTo(6.4, 6);
+  });
+
+  it("places a voiceover that starts mid-shot", () => {
+    expect(laneItemPlacement(map, { startSeconds: 2, durationSeconds: 2 })).toEqual({
+      left: 80,
+      width: 80,
+    });
+  });
+
+  it("places a card that lines up with NOTHING on any other row", () => {
+    // A lane is not tied to the picture's cuts: audio can start and end at any
+    // timestamp. This one starts inside shot 2, crosses a gutter, and ends
+    // inside shot 3 — no edge it touches is a card edge.
+    //   5.5s  -> shot 2 (4.12-8.12) at 34.5% -> 168 + 55.2 = 223.2
+    //   9.1s  -> shot 3 (8.24-12.24) at 21.5% -> 336 + 34.4 = 370.4
+    const placement = laneItemPlacement(map, { startSeconds: 5.5, durationSeconds: 3.6 });
+    expect(placement.left).toBeCloseTo(223.2, 6);
+    expect(placement.width).toBeCloseTo(147.2, 6);
+  });
+
+  it("places two cards on one lane that neither touch nor tile", () => {
+    // Nothing requires a lane to be a contiguous run — a gap between two
+    // voiceovers is just silence, and the geometry has no opinion about it.
+    const first = laneItemPlacement(map, { startSeconds: 0.5, durationSeconds: 1 });
+    const second = laneItemPlacement(map, { startSeconds: 9, durationSeconds: 1 });
+    expect(first.left + first.width).toBeLessThan(second.left);
+  });
+
+  it("draws a bed that OUTLASTS the picture at its true length", () => {
+    // 30s of music under a 12.24s cut. Clamping past the last shot drew this
+    // as 496px — the picture's width — which reads as a bed that stops when
+    // the picture does.
+    const bed = laneItemPlacement(map, { startSeconds: 0, durationSeconds: 30 });
+    expect(bed.left).toBe(0);
+    // 12.24s of picture (496px) plus 17.76s past it at the last card's 40px/s.
+    expect(bed.width).toBeCloseTo(496 + 17.76 * 40, 6);
+  });
+
+  it("draws a card that starts after the picture has ended", () => {
+    const placement = laneItemPlacement(map, { startSeconds: 20, durationSeconds: 5 });
+    expect(placement.left).toBeCloseTo(496 + 7.76 * 40, 6);
+    expect(placement.width).toBeCloseTo(200, 6);
+  });
+
+  it("floors a near-zero layer card at the clickable minimum", () => {
+    const placement = laneItemPlacement(map, { startSeconds: 1, durationSeconds: 0 });
+    expect(placement.width).toBe(MIN_ITEM_WIDTH);
+  });
+
+  it("treats a negative duration as zero rather than inverting the card", () => {
+    const placement = laneItemPlacement(map, { startSeconds: 4, durationSeconds: -5 });
+    expect(placement.width).toBe(MIN_ITEM_WIDTH);
+  });
+});
+
+describe("laneRowTop / laneStackHeight", () => {
+  it("puts the picture at the top", () => {
+    expect(laneRowTop(0, 132, 40, 6)).toBe(0);
+  });
+
+  it("stacks each layer under the picture, gap first", () => {
+    expect(laneRowTop(1, 132, 40, 6)).toBe(138);
+    expect(laneRowTop(2, 132, 40, 6)).toBe(184);
+  });
+
+  it("is exactly the item height when there are no layers", () => {
+    expect(laneStackHeight(132, 40, 6, 0)).toBe(132);
+  });
+
+  it("grows by a gap plus a row per layer", () => {
+    expect(laneStackHeight(132, 40, 6, 1)).toBe(178);
+    expect(laneStackHeight(132, 40, 6, 2)).toBe(224);
+  });
+
+  it("leaves the last row's bottom flush with the stack height", () => {
+    expect(laneRowTop(2, 132, 40, 6) + 40).toBe(laneStackHeight(132, 40, 6, 2));
+  });
+});
+
+describe("laneRowPosition / laneFlatIndex", () => {
+  const rows: LaneRowLayout = [
+    [
+      { startSeconds: 0, durationSeconds: 4 },
+      { startSeconds: 4.12, durationSeconds: 4 },
+    ],
+    [{ startSeconds: 0, durationSeconds: 8 }],
+  ];
+
+  it("maps the concatenated list back to a row and column", () => {
+    expect(laneRowPosition(0, rows)).toEqual({ row: 0, column: 0 });
+    expect(laneRowPosition(1, rows)).toEqual({ row: 0, column: 1 });
+    expect(laneRowPosition(2, rows)).toEqual({ row: 1, column: 0 });
+  });
+
+  it("returns null past the end and for a nonsense index", () => {
+    expect(laneRowPosition(3, rows)).toBeNull();
+    expect(laneRowPosition(-1, rows)).toBeNull();
+    expect(laneRowPosition(1.5, rows)).toBeNull();
+  });
+
+  it("round-trips", () => {
+    for (let flat = 0; flat < 3; flat += 1) {
+      const position = laneRowPosition(flat, rows);
+      expect(position).not.toBeNull();
+      expect(laneFlatIndex(position!.row, position!.column, rows)).toBe(flat);
+    }
+  });
+
+  it("skips over an empty row when numbering", () => {
+    const withEmpty: LaneRowLayout = [[{ startSeconds: 0, durationSeconds: 4 }], [], [
+      { startSeconds: 0, durationSeconds: 8 },
+    ]];
+    expect(laneRowPosition(1, withEmpty)).toEqual({ row: 2, column: 0 });
+    expect(laneFlatIndex(2, 0, withEmpty)).toBe(1);
+  });
+});
+
+describe("resolveLaneStripIndex", () => {
+  // Picture: three 4s shots. Layer: two back-to-back beds, 0-6s and 6-12s.
+  const rows: LaneRowLayout = [
+    [
+      { startSeconds: 0, durationSeconds: 4 },
+      { startSeconds: 4.12, durationSeconds: 4 },
+      { startSeconds: 8.24, durationSeconds: 4 },
+    ],
+    [
+      { startSeconds: 0, durationSeconds: 6 },
+      { startSeconds: 6, durationSeconds: 6.24 },
+    ],
+  ];
+  const singleRow: LaneRowLayout = [rows[0]!];
+
+  it("steps within the row and stops at its ends", () => {
+    expect(resolveLaneStripIndex("ArrowRight", 0, rows)).toBe(1);
+    expect(resolveLaneStripIndex("ArrowLeft", 1, rows)).toBe(0);
+    expect(resolveLaneStripIndex("ArrowLeft", 0, rows)).toBe(0);
+  });
+
+  it("does NOT spill off the end of the picture row into the first layer", () => {
+    // The whole reason this resolver clamps per row: index 2 is the last shot,
+    // and an unclamped current+1 would be the first bed.
+    expect(resolveLaneStripIndex("ArrowRight", 2, rows)).toBe(2);
+  });
+
+  it("sends Home/End to the current row's ends, not the list's", () => {
+    expect(resolveLaneStripIndex("Home", 4, rows)).toBe(3);
+    expect(resolveLaneStripIndex("End", 3, rows)).toBe(4);
+    expect(resolveLaneStripIndex("Home", 1, rows)).toBe(0);
+    expect(resolveLaneStripIndex("End", 1, rows)).toBe(2);
+  });
+
+  it("crosses rows at the nearest time", () => {
+    // Shot 1 (0-4s) sits over the first bed (0-6s).
+    expect(resolveLaneStripIndex("ArrowDown", 0, rows)).toBe(3);
+    // Shot 3 (8.24-12.24s) sits over the second bed (6-12.24s).
+    expect(resolveLaneStripIndex("ArrowDown", 2, rows)).toBe(4);
+  });
+
+  it("goes back up to whatever is playing at the layer card's own start", () => {
+    // Not necessarily the shot you came down from: the second bed starts at
+    // 6s, which is inside shot 2 (4.12-8.12s), so Up from it lands on shot 2
+    // even though Down from shot 3 reached it. The anchor is the card's start
+    // time, and up/down is not required to be an inverse when the rows are
+    // cut differently — which is the normal case for a bed.
+    expect(resolveLaneStripIndex("ArrowUp", 4, rows)).toBe(1);
+  });
+
+  it("prefers the window that CONTAINS the time over the nearest start", () => {
+    // Shot 2 starts at 4.12s, inside the first bed (0-6s). Nearest-start alone
+    // would pick the second bed (|6 - 4.12| < |0 - 4.12|) — the wrong one.
+    expect(resolveLaneStripIndex("ArrowDown", 1, rows)).toBe(3);
+  });
+
+  it("ignores vertical arrows on a plain single-row strip", () => {
+    // Returning the current index instead would have the hook preventDefault
+    // the key, and vertical arrows are how the page scrolls over a strip.
+    expect(resolveLaneStripIndex("ArrowDown", 0, singleRow)).toBeNull();
+    expect(resolveLaneStripIndex("ArrowUp", 0, singleRow)).toBeNull();
+  });
+
+  it("ignores a vertical arrow at the top and bottom of the stack", () => {
+    expect(resolveLaneStripIndex("ArrowUp", 0, rows)).toBeNull();
+    expect(resolveLaneStripIndex("ArrowDown", 3, rows)).toBeNull();
+  });
+
+  it("skips an empty layer rather than landing nowhere", () => {
+    const withEmpty: LaneRowLayout = [rows[0]!, [], rows[1]!];
+    expect(resolveLaneStripIndex("ArrowDown", 0, withEmpty)).toBe(3);
+  });
+
+  it("matches the old 1D behaviour on a single row", () => {
+    expect(resolveLaneStripIndex("ArrowRight", 0, singleRow)).toBe(1);
+    expect(resolveLaneStripIndex("ArrowLeft", 2, singleRow)).toBe(1);
+    expect(resolveLaneStripIndex("Home", 2, singleRow)).toBe(0);
+    expect(resolveLaneStripIndex("End", 0, singleRow)).toBe(2);
+  });
+
+  it("ignores keys it does not own, and an out-of-range index", () => {
+    expect(resolveLaneStripIndex("PageDown", 0, rows)).toBeNull();
+    expect(resolveLaneStripIndex("ArrowRight", 99, rows)).toBeNull();
+    expect(resolveLaneStripIndex("ArrowRight", 0, [])).toBeNull();
+  });
+});

--- a/packages/ui/dnd-collections/virtual/virtual-strip-lanes.ts
+++ b/packages/ui/dnd-collections/virtual/virtual-strip-lanes.ts
@@ -1,0 +1,304 @@
+// Pure geometry for the strip's LANE ROWS — the layers that run *alongside*
+// the picture rather than after it (a music bed, a voiceover). Split out of
+// VirtualStrip for the same reason virtual-strip-geometry is: the arithmetic
+// is testable without a virtualizer, DOM, or rAF loop.
+//
+// The picture row keeps the virtualizer. Layers do not get one: they are FEW
+// and LONG where shots are many and short, so the thing virtualization exists
+// for does not apply to them, and skipping it keeps one virtualizer's index
+// space intact.
+
+import { MIN_ITEM_WIDTH } from "./virtual-strip-geometry";
+
+/**
+ * One laid-out slot on the PICTURE row, pairing what the strip measured with
+ * what the consumer's clock says about it.
+ *
+ * The pairing is the whole point. The x half (`left`/`width`) is the strip's —
+ * it comes from the same width resolution the cards are drawn with, so it
+ * survives an `itemWidthFor` override and a live trim. The time half is the
+ * CONSUMER'S, because the strip cannot derive it: its own notion of duration
+ * knows nothing about the inter-clip gap a document packs with (0.12s here),
+ * nor about the span a collection card stands for. Deriving time from widths
+ * would drift by one gap per gutter — a few pixels per card, and a lane row
+ * visibly sliding off the shots it covers by the tenth one.
+ */
+export type LanePictureSlot = Readonly<{
+  /** Measured content-x of the slot's left edge. */
+  left: number;
+  /** Measured slot width, EXCLUDING the trailing gap. */
+  width: number;
+  startSeconds: number;
+  durationSeconds: number;
+}>;
+
+export type LaneTimeMap = Readonly<{
+  /** Content-x for a time on the picture's clock — O(log n). */
+  at: (timeSeconds: number) => number;
+}>;
+
+/**
+ * Build the picture row's time → content-x map: piecewise linear, anchored on
+ * the card edges the strip actually drew.
+ *
+ * A strip is NOT a linear time axis. Card width is duration·pps, but the
+ * gutter between two cards absorbs the pack gap at no fixed rate, a collection
+ * card is a fixed width holding an arbitrary span, and a fully-trimmed clip
+ * floors at `MIN_ITEM_WIDTH` while owning almost no time. Anchoring on
+ * measured edges makes every one of those exact instead of approximated: at a
+ * card's start time the map returns that card's left edge, full stop.
+ *
+ * Interpolating ACROSS the gutter (rather than snapping to the next card)
+ * matters for the playhead-adjacent case a lane row shares: a bed whose window
+ * ends between two shots should draw its right edge in the gutter, where that
+ * moment actually is, not jumped forward to the next shot's edge.
+ *
+ * Times BEFORE the first card clamp to its left edge; times past the last one
+ * extrapolate at that card's rate, because a lane can outlast the picture.
+ *
+ * `slots` must be ordered by `startSeconds` — the binary search assumes it.
+ * That holds by construction for a packed document; this does not re-sort per
+ * render to prove it. Note the LAYER items placed through this map carry no
+ * such requirement: a lane's cards may start anywhere, in any order, and need
+ * not touch each other or line up with anything on another row.
+ */
+export function createLaneTimeMap(slots: readonly LanePictureSlot[]): LaneTimeMap {
+  const count = slots.length;
+
+  // Stated once rather than bounds-checking every access on a path that runs
+  // per layer card per render. Throws rather than falling back to 0, which
+  // would silently draw a lane card at the strip's origin — far harder to
+  // trace than a stop that names the index.
+  const slotAt = (index: number): LanePictureSlot => {
+    const slot = slots[index];
+    if (slot === undefined) {
+      throw new RangeError(`lane geometry: slot ${index} outside 0..${count - 1}`);
+    }
+    return slot;
+  };
+
+  /** Index of the last slot starting at or before `t`. */
+  const locate = (t: number): number => {
+    let lo = 0;
+    let hi = count - 1;
+    while (lo < hi) {
+      const mid = (lo + hi + 1) >> 1;
+      if (slotAt(mid).startSeconds <= t) lo = mid;
+      else hi = mid - 1;
+    }
+    return lo;
+  };
+
+  const at = (timeSeconds: number): number => {
+    if (count === 0) return 0;
+    const first = slotAt(0);
+    if (!Number.isFinite(timeSeconds) || timeSeconds <= first.startSeconds) return first.left;
+    // PAST THE PICTURE. A lane is not bounded by the cut — music can outlast
+    // the last shot — so this extrapolates at the final card's own rate
+    // rather than clamping. Clamping drew a 30s bed under a 12s sequence as
+    // 12s long, which reads as a bed that stops when it does not.
+    //
+    // The rate is the last card's px-per-second, which on a uniformly scaled
+    // strip IS `pixelsPerSecond`; taking it from the card keeps this honest
+    // under an `itemWidthFor` override too. A zero-duration last card offers
+    // no rate, so there it still clamps.
+    const last = slotAt(count - 1);
+    const lastEnd = last.startSeconds + last.durationSeconds;
+    if (timeSeconds >= lastEnd) {
+      const rate = last.durationSeconds > 0 ? last.width / last.durationSeconds : 0;
+      return last.left + last.width + (timeSeconds - lastEnd) * rate;
+    }
+
+    const index = locate(timeSeconds);
+    const slot = slotAt(index);
+    const slotEnd = slot.startSeconds + slot.durationSeconds;
+    // Inside the card. A zero-duration card owns no interval to interpolate
+    // across, so every time that lands on it resolves to its left edge.
+    if (timeSeconds <= slotEnd) {
+      if (slot.durationSeconds <= 0) return slot.left;
+      const within = (timeSeconds - slot.startSeconds) / slot.durationSeconds;
+      return slot.left + within * slot.width;
+    }
+    // In the gutter after it. `locate` only returns the last index when the
+    // time is past its end, and that case already clamped above, so a next
+    // slot always exists here.
+    const next = slotAt(index + 1);
+    const gutterSeconds = next.startSeconds - slotEnd;
+    const from = slot.left + slot.width;
+    if (gutterSeconds <= 0) return next.left;
+    return from + ((timeSeconds - slotEnd) / gutterSeconds) * (next.left - from);
+  };
+
+  return { at };
+}
+
+/**
+ * Where a layer card sits and how wide it draws: both edges through the map,
+ * so the card spans exactly the picture the consumer says it covers. A bed
+ * over shots 1-3 lines up with those three cards AND the two gutters between
+ * them, at any zoom.
+ *
+ * Width is deliberately NOT `durationToWidth(duration)`. That is only right on
+ * a linear axis; here it would leave a bed short by one gap per shot it spans.
+ *
+ * Floored at `minimumWidth` for the same reason the picture's slots are: a
+ * near-zero card is invisible and unclickable.
+ */
+export function laneItemPlacement(
+  map: LaneTimeMap,
+  item: Readonly<{ startSeconds: number; durationSeconds: number }>,
+  minimumWidth: number = MIN_ITEM_WIDTH,
+): Readonly<{ left: number; width: number }> {
+  const left = map.at(item.startSeconds);
+  const right = map.at(item.startSeconds + Math.max(0, item.durationSeconds));
+  return { left, width: Math.max(minimumWidth, right - left) };
+}
+
+/**
+ * Top offset of a row within the strip's content layer. Row 0 is the picture
+ * and sits at the top; layer rows stack under it, each preceded by its gap.
+ */
+export function laneRowTop(
+  rowIndex: number,
+  itemHeight: number,
+  layerHeight: number,
+  layerGap: number,
+): number {
+  if (rowIndex <= 0) return 0;
+  return itemHeight + layerGap + (rowIndex - 1) * (layerHeight + layerGap);
+}
+
+/**
+ * Total height of the picture row plus every layer row under it — what the
+ * content spacer grows to.
+ *
+ * Growing the SPACER is what carries the overlay slot along for free: it
+ * renders at `inset: 0` inside this box, so a playhead drawn `bottom-0`
+ * crosses every lane without knowing lanes exist.
+ */
+export function laneStackHeight(
+  itemHeight: number,
+  layerHeight: number,
+  layerGap: number,
+  layerCount: number,
+): number {
+  if (layerCount <= 0) return itemHeight;
+  return itemHeight + layerCount * (layerGap + layerHeight);
+}
+
+// --- roving focus across rows ------------------------------------------------
+
+/** A row entry as the roving resolver needs to see it: just its time window. */
+export type LaneRowItem = Readonly<{ startSeconds: number; durationSeconds: number }>;
+
+/** Row 0 is the picture; the rest are layers, in the order they are drawn. */
+export type LaneRowLayout = readonly (readonly LaneRowItem[])[];
+
+/**
+ * The flat list the roving-focus hook navigates is every row's ids
+ * concatenated (picture first). These two convert between that index and a
+ * (row, column) pair, which is what the arrow keys actually reason about.
+ */
+export function laneRowPosition(
+  flatIndex: number,
+  rows: LaneRowLayout,
+): Readonly<{ row: number; column: number }> | null {
+  if (!Number.isInteger(flatIndex) || flatIndex < 0) return null;
+  let remaining = flatIndex;
+  for (let row = 0; row < rows.length; row += 1) {
+    const size = rows[row]?.length ?? 0;
+    if (remaining < size) return { row, column: remaining };
+    remaining -= size;
+  }
+  return null;
+}
+
+export function laneFlatIndex(row: number, column: number, rows: LaneRowLayout): number | null {
+  const items = rows[row];
+  if (!items || column < 0 || column >= items.length) return null;
+  let base = 0;
+  for (let r = 0; r < row; r += 1) base += rows[r]?.length ?? 0;
+  return base + column;
+}
+
+/**
+ * The column in `items` whose time window is nearest `timeSeconds` — the
+ * vertical anchor for an up/down move, so pressing Down on shot 2 lands on
+ * the bed that is actually playing under shot 2.
+ *
+ * Distance is zero for a window that CONTAINS the time, which is what makes a
+ * row of back-to-back beds resolve correctly; nearest-start alone would pick
+ * the following bed for any time past its midpoint. Ties go to the earlier
+ * column.
+ */
+function nearestColumn(items: readonly LaneRowItem[], timeSeconds: number): number {
+  let best = 0;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (let column = 0; column < items.length; column += 1) {
+    const item = items[column];
+    if (!item) continue;
+    const end = item.startSeconds + Math.max(0, item.durationSeconds);
+    const distance = Math.max(0, item.startSeconds - timeSeconds, timeSeconds - end);
+    if (distance < bestDistance) {
+      best = column;
+      bestDistance = distance;
+    }
+  }
+  return best;
+}
+
+/** The next non-empty row in `direction`, or null when there is none. */
+function stepRow(row: number, direction: 1 | -1, rows: LaneRowLayout): number | null {
+  for (let next = row + direction; next >= 0 && next < rows.length; next += direction) {
+    if ((rows[next]?.length ?? 0) > 0) return next;
+  }
+  return null;
+}
+
+/**
+ * 2D roving navigation over the lane stack: Left/Right step within a row,
+ * Home/End jump to that row's ends, Up/Down cross to the adjacent row at the
+ * nearest time.
+ *
+ * Returns a flat index into the concatenated list, already valid — the hook's
+ * own clamp is a no-op on it. That is deliberate: the hook clamps GLOBALLY, so
+ * an unclamped `current + 1` at the end of the picture row would spill into
+ * the first layer and Right would silently change rows.
+ *
+ * Up/Down return null rather than the current index when there is no row to
+ * move to, which is every plain single-row strip. Returning the current index
+ * would have the hook preventDefault a key it did nothing with, and vertical
+ * arrows are how the page scrolls when the pointer is over a strip.
+ */
+export function resolveLaneStripIndex(
+  key: string,
+  currentFlatIndex: number,
+  rows: LaneRowLayout,
+): number | null {
+  const position = laneRowPosition(currentFlatIndex, rows);
+  if (!position) return null;
+  const items = rows[position.row];
+  if (!items || items.length === 0) return null;
+
+  switch (key) {
+    case "ArrowRight":
+      return laneFlatIndex(position.row, Math.min(position.column + 1, items.length - 1), rows);
+    case "ArrowLeft":
+      return laneFlatIndex(position.row, Math.max(position.column - 1, 0), rows);
+    case "Home":
+      return laneFlatIndex(position.row, 0, rows);
+    case "End":
+      return laneFlatIndex(position.row, items.length - 1, rows);
+    case "ArrowDown":
+    case "ArrowUp": {
+      const targetRow = stepRow(position.row, key === "ArrowDown" ? 1 : -1, rows);
+      if (targetRow === null) return null;
+      const target = rows[targetRow];
+      if (!target || target.length === 0) return null;
+      const from = items[position.column];
+      return laneFlatIndex(targetRow, nearestColumn(target, from?.startSeconds ?? 0), rows);
+    }
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
Closes #397.

A layered clip already packed, mixed and played alongside the picture — but the board still drew it in the same single strip as the shots, marked only by an `L1` chip. It took horizontal space it does not own, and nothing showed it running *under* anything.

Lane 0 keeps the virtualizer. Lanes 1+ draw as rows beneath it, positioned by **time**, so a bed under shots 1-3 spans exactly those three cards. Approach **B** from the issue.

## The load-bearing decision: the strip does not derive the clock

Its own notion of duration knows nothing about the 0.12s gap a document packs between clips, nor the span a collection card stands for, so a clock derived from widths drifts by one gap per gutter — a few pixels a card, and a bed visibly off the shots it covers by the tenth one. The consumer passes `itemTimes` and the strip pairs them with the widths it measured.

I built the width-derived version first, on the assumption the axis was contiguous in time, and threw it away when `CLIP_GAP_SECONDS` said otherwise.

The map is piecewise linear and anchored on card **edges**, and a layer card's width is *both* its edges through it — `durationToWidth` is only right on a linear axis and leaves a bed short by one pack gap per shot it spans. Measured in Chromium: a 12.24s bed over three 4s shots draws **496px**, where `12.24 × 40` is 489.6.

## A lane is not tied to the picture's cuts

`startSeconds` is arbitrary — a card may begin inside one shot, cross a gutter and end inside another, and two cards on one lane need neither touch nor tile. The story's voiceover starts at 5.5s and ends at 9.1s, touching no edge on any row: **264.2 → 411.4px**.

The map also **extrapolates** past the last shot rather than clamping, because a lane can outlast the picture. A 30s bed under a 12.24s cut clamped to 496px — reading as a bed that stops when it does not — and now draws **1206.4px** (496 plus 17.76s at the last card's own 40px/s), with the content growing so it can be scrolled to.

The *model* cannot express such a start yet — every lane packs as a sequence from zero and `startTime` is always derived — which is #400. Nothing in the strip will need to change when it can.

## Filtering the item source is not free

Handing the strip lane-0 children only changes what a published boundary index **means**, while `resolveCommandFromIntent` still reads it against the collection's full child list. `mapDropCommand` — the seam flat mode already uses — retranslates it.

Without that, a drop on any layered board lands somewhere nobody chose. The new e2e proves it: with the translation removed it fails by becoming a **silent no-op**, which is the worst shape of wrong.

The same class of mistake nearly reached the overlays. Only the focused strip draws lanes as rows; the grid and sub-timeline rows draw one card per child and pair cards to cells **by index**, so picture-only cards would shift every marker after the first layered clip. `childSpans` therefore defaults to every lane (the pre-lanes behaviour) and only row-drawing surfaces opt into `"picture"` — that way round on purpose, so a caller nobody updates keeps working.

## Two things lanes made wrong

- `childSpans` clamped card times monotonic across **all** children. The clamp keeps one row's times sorted for the playhead's binary search; across lanes it dragged a bed starting at 0s up to wherever the picture had reached and pushed every later ruler tick along. It is per lane now.
- `playableSpanSeconds` summed every card, so a 4s bed under a 4s shot claimed an 8s timeline. It takes the longest **lane** now, and reduces to the old formula exactly when everything is on the picture.

The playhead needed nothing: it draws `bottom-0` inside the content spacer, so growing the spacer carried it across every row for free.

## Deliberately not here

**Cross-lane drag** is #399 — a lane lives in the detail side table and the engine has no command for it, so a drop that changes lanes is `move-nodes` plus a detail write that has to land with it. Layer cards drag exactly as before and reorder within the collection, keeping their lane.

**Flat mode** stays a single row: its lane would have to come from the manifest's lane-from-root rather than the local detail entry.

A board with no layers renders exactly as it did, down to the DOM — every lane path is gated, and a story pins it (including vertical arrows staying unhandled, which is how the page scrolls with the pointer over a strip).

## Verified

- app + UI `tsc` clean; lint clean (same 5 pre-existing `<img>` warnings)
- **1067** app tests
- **614** shared unit tests (+39 lane geometry)
- **206** story interaction tests in real Chromium (+8 lane stories)
- **171** graph-view e2e (+2 lane tests)

Two e2e failures seen on one contended run were reproduced as environmental (both passed in isolation in ~2s against a 30s timeout; three subsequent clean full runs were green) — another session's dev server was holding the shared `next dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
