### PR TITLE
Let a lane clip start at any time (#310 phase 2, model)

### DIFF
--- a/apps/timeline-gstudio001/app/api/mcp/route.ts
+++ b/apps/timeline-gstudio001/app/api/mcp/route.ts
@@ -25,6 +25,7 @@ import {
   handleMoveClip,
   handleRemoveClip,
   handleSetLane,
+  handleSetStart,
   handleRenameItem,
   handleSetTags,
   handleTrimClip,
@@ -358,6 +359,26 @@ const handler = createMcpHandler(
         const uid = uidFrom(extra);
         if (!uid) return errorResult(NO_IDENTITY);
         return fromToolResult(await handleSetLane(args, { requesterUid: uid }));
+      },
+    );
+
+    server.tool(
+      "set_start",
+      "Place a clip at an exact time on its LANE — audio starts when it starts, and does not have to line up with anything on another lane. Only for clips on a lane above 0: the picture is a cut, whose clips pack end to end. Pass null to put the clip back in its lane's queue. If something is already playing on that lane at that moment, the clip moves to the first lane above with room and the result says so." +
+        NO_LIVE_PUSH_NOTE,
+      {
+        timelineId: TIMELINE_ID_FIELD,
+        nodeId: nodeIdField,
+        startSeconds: z
+          .number()
+          .min(0)
+          .nullable()
+          .describe("Seconds from the start of the collection, or null to re-queue it."),
+      },
+      async (args, extra) => {
+        const uid = uidFrom(extra);
+        if (!uid) return errorResult(NO_IDENTITY);
+        return fromToolResult(await handleSetStart(args, { requesterUid: uid }));
       },
     );
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-lane-rows.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-lane-rows.test.ts
@@ -110,6 +110,37 @@ describe("splitLaneRows", () => {
     ]);
   });
 
+  it("carries a PLACED start onto the row, lining up with nothing", () => {
+    // #400. The board's geometry already accepted an arbitrary start; this is
+    // the seam that finally supplies one — a voiceover at 7.5s with nothing
+    // 7.5s long in front of it.
+    const graph = graphOf([collection("scene", [media("shot", 30), media("vo", 2)])]);
+    const details: DetailsById = { vo: detail({ trackIndex: 1, placedStart: 7.5 }) };
+    const model = splitLaneRows(graph, details, "scene");
+
+    expect(model.layers[0]?.items).toEqual([
+      { id: "vo", startSeconds: 7.5, durationSeconds: 2 },
+    ]);
+    // The picture is untouched by a placement on a lane.
+    expect(model.pictureTimes[0]?.startSeconds).toBe(0);
+  });
+
+  it("queues an unplaced clip behind a placed one on the same lane", () => {
+    const graph = graphOf([
+      collection("scene", [media("shot", 30), media("vo", 2), media("tail", 2)]),
+    ]);
+    const details: DetailsById = {
+      vo: detail({ trackIndex: 1, placedStart: 7.5 }),
+      tail: detail({ trackIndex: 1 }),
+    };
+    const model = splitLaneRows(graph, details, "scene");
+
+    expect(model.layers[0]?.items.map((item) => item.startSeconds)).toEqual([
+      7.5,
+      9.5 + CLIP_GAP_SECONDS,
+    ]);
+  });
+
   it("gives each occupied lane its own row, in ascending order", () => {
     const graph = graphOf([
       collection("scene", [media("shot", 10), media("music", 10), media("vo", 4)]),

--- a/apps/timeline-gstudio001/lib/mcp/set-start.test.ts
+++ b/apps/timeline-gstudio001/lib/mcp/set-start.test.ts
@@ -1,0 +1,287 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
+
+// `set_start` against the same in-memory Firestore double the rest of lib/mcp
+// uses — the store, the graph adapter and the packer all run for real. That
+// matters more here than usual: the whole point of the feature is that a
+// placed start survives the graph round trip and comes back out of packing
+// unchanged, and a mocked save would prove none of it.
+type Stored = Record<string, unknown>;
+
+const state = vi.hoisted(() => {
+  const docs = new Map<string, Stored>();
+  const applySet = (id: string, data: Stored, opts?: { merge?: boolean }) => {
+    const existing = docs.get(id);
+    docs.set(id, opts?.merge && existing ? { ...existing, ...data } : { ...data });
+  };
+  const snapshot = (id: string) => {
+    const data = docs.get(id);
+    return {
+      id,
+      exists: data !== undefined,
+      data: () => (data ? { ...data } : undefined),
+      get: (field: string) => (data ? data[field] : undefined),
+    };
+  };
+  const docRef = (id: string) => ({
+    id,
+    get: async () => snapshot(id),
+    set: async (data: Stored, opts?: { merge?: boolean }) => applySet(id, data, opts),
+    delete: async () => {
+      docs.delete(id);
+    },
+  });
+  type Tx = {
+    get: (ref: { id: string }) => Promise<ReturnType<typeof snapshot>>;
+    set: (ref: { id: string }, data: Stored, opts?: { merge?: boolean }) => void;
+  };
+  const db = {
+    collection: () => ({
+      doc: docRef,
+      where: () => ({ orderBy: () => ({ limit: () => ({ get: async () => ({ docs: [] }) }) }) }),
+    }),
+    runTransaction: async <T>(fn: (tx: Tx) => Promise<T>): Promise<T> => {
+      const staged: Array<[string, Stored, { merge?: boolean } | undefined]> = [];
+      const tx: Tx = {
+        get: async (ref) => snapshot(ref.id),
+        set: (ref, data, opts) => {
+          staged.push([ref.id, data, opts]);
+        },
+      };
+      const result = await fn(tx);
+      for (const [id, data, opts] of staged) applySet(id, data, opts);
+      return result;
+    },
+  };
+  return { docs, db };
+});
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/firebase-admin", () => ({ getFirebaseDb: () => state.db }));
+vi.mock("firebase-admin/firestore", () => {
+  class Timestamp {
+    toDate() {
+      return new Date(0);
+    }
+  }
+  return {
+    Timestamp,
+    FieldValue: {
+      serverTimestamp: () => new Timestamp(),
+      delete: () => "__DELETED__",
+    },
+  };
+});
+
+import { handleSetStart } from "./write-handlers";
+
+const OWNER = "user-a";
+
+function clip(id: string, over: Partial<TimelineClip> = {}): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "image",
+    src: "https://example.test/img.jpg",
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 4,
+    sourceDuration: 4,
+    trimIn: 0,
+    trimOut: 0,
+    ...over,
+  } as TimelineClip;
+}
+
+function collectionClip(id: string): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "collection",
+    title: id,
+    childTimelineId: id,
+    alt: `${id} collection`,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    itemCount: 1,
+    duration: 3,
+    sourceDuration: 3,
+    trimIn: 0,
+    trimOut: 0,
+  };
+}
+
+function seed(id: string, clips: TimelineClip[], revision = 1) {
+  const document: TimelineDocument = { id, title: id, clips };
+  state.docs.set(id, { ...document, ownerUid: OWNER, revision });
+}
+
+function storedClips(id: string): TimelineClip[] {
+  return ((state.docs.get(id) as { clips?: TimelineClip[] } | undefined)?.clips ?? []);
+}
+
+const storedClip = (docId: string, clipId: string) =>
+  storedClips(docId).find((c) => c.id === clipId);
+
+beforeEach(() => {
+  state.docs.clear();
+});
+
+describe("handleSetStart", () => {
+  it("places a lane clip at the time it was given", async () => {
+    seed("t1", [clip("shot", { duration: 30 }), clip("vo", { trackIndex: 1, duration: 2 })]);
+
+    const result = await handleSetStart(
+      { timelineId: "t1", nodeId: "vo", startSeconds: 7.5 },
+      { requesterUid: OWNER },
+    );
+
+    expect(result.isError).not.toBe(true);
+    expect(storedClip("t1", "vo")?.placedStart).toBe(7.5);
+    // The point of the whole feature: it comes back out of packing where it
+    // was put, rather than at the head of its lane's queue.
+    expect(storedClip("t1", "vo")?.startTime).toBe(7.5);
+    // ...and the picture did not move.
+    expect(storedClip("t1", "shot")?.startTime).toBe(0);
+  });
+
+  it("REFUSES a clip on the picture, and says what to do instead", async () => {
+    seed("t1", [clip("a"), clip("b")]);
+
+    const result = await handleSetStart(
+      { timelineId: "t1", nodeId: "b", startSeconds: 7.5 },
+      { requesterUid: OWNER },
+    );
+
+    expect(result.isError).toBe(true);
+    const text = JSON.stringify(result);
+    expect(text).toContain("set_lane");
+    // Nothing was written.
+    expect(storedClip("t1", "b")?.placedStart).toBeUndefined();
+  });
+
+  it("bumps to the next lane when something is already there, and reports it", async () => {
+    seed("t1", [
+      clip("shot", { duration: 30 }),
+      clip("bed", { trackIndex: 1, duration: 10 }),
+      clip("vo", { trackIndex: 1, duration: 2 }),
+    ]);
+
+    const result = await handleSetStart(
+      { timelineId: "t1", nodeId: "vo", startSeconds: 5 },
+      { requesterUid: OWNER },
+    );
+
+    expect(result.isError).not.toBe(true);
+    expect(storedClip("t1", "vo")?.trackIndex).toBe(2);
+    expect(storedClip("t1", "vo")?.startTime).toBe(5);
+    expect(JSON.stringify(result)).toContain("lane 2");
+    // The bed kept its place — a bump moves the clip being placed, nothing else.
+    expect(storedClip("t1", "bed")?.startTime).toBe(0);
+  });
+
+  it("stays on the requested lane when there is room", async () => {
+    seed("t1", [
+      clip("shot", { duration: 30 }),
+      clip("bed", { trackIndex: 1, duration: 4 }),
+      clip("vo", { trackIndex: 1, duration: 2 }),
+    ]);
+
+    await handleSetStart(
+      { timelineId: "t1", nodeId: "vo", startSeconds: 20 },
+      { requesterUid: OWNER },
+    );
+
+    expect(storedClip("t1", "vo")?.trackIndex).toBe(1);
+    expect(storedClip("t1", "vo")?.startTime).toBe(20);
+  });
+
+  it("re-queues on null, dropping the field rather than writing a sentinel", async () => {
+    seed("t1", [
+      clip("shot", { duration: 30 }),
+      clip("bed", { trackIndex: 1, duration: 4 }),
+      clip("vo", { trackIndex: 1, duration: 2, placedStart: 20 }),
+    ]);
+
+    await handleSetStart(
+      { timelineId: "t1", nodeId: "vo", startSeconds: null },
+      { requesterUid: OWNER },
+    );
+
+    expect(storedClip("t1", "vo")?.placedStart).toBeUndefined();
+    // Back behind the bed on its lane: 4s + the pack gap.
+    expect(storedClip("t1", "vo")?.startTime).toBeGreaterThan(4);
+  });
+
+  it("keeps the rest of the clip's detail intact", async () => {
+    seed("t1", [
+      clip("shot", { duration: 30 }),
+      clip("vo", {
+        trackIndex: 1,
+        duration: 2,
+        title: "Narration",
+        tags: ["keeper"],
+        sourceAsset: { providerId: "cloudinary", assetId: "abc" },
+      }),
+    ]);
+
+    await handleSetStart(
+      { timelineId: "t1", nodeId: "vo", startSeconds: 7.5 },
+      { requesterUid: OWNER },
+    );
+
+    const saved = storedClip("t1", "vo");
+    // The failure this guards is silent: the detail entry is what the clip is
+    // rebuilt from, so a handler that does not spread it erases these on save.
+    expect(saved?.title).toBe("Narration");
+    expect(saved?.tags).toEqual(["keeper"]);
+    // `sourceAsset` lives on media clips only, so narrow before reading it.
+    if (!saved || saved.kind === "collection") throw new Error("expected a media clip");
+    expect(saved.sourceAsset).toEqual({ providerId: "cloudinary", assetId: "abc" });
+  });
+
+  it("writes the parent AND its ancestors", async () => {
+    // A placement can lengthen or shorten the parent, and every ancestor
+    // stores a duration for it — the same write set `set_lane` computes.
+    seed("root", [collectionClip("scene")]);
+    seed("scene", [clip("shot", { duration: 30 }), clip("vo", { trackIndex: 1, duration: 2 })]);
+
+    const result = await handleSetStart(
+      { timelineId: "root", nodeId: "vo", startSeconds: 7.5 },
+      { requesterUid: OWNER },
+    );
+
+    expect(result.isError).not.toBe(true);
+    const written = JSON.stringify(result);
+    expect(written).toContain("scene");
+    expect(written).toContain("root");
+  });
+
+  it("rejects a start that is not a real non-negative time", async () => {
+    seed("t1", [clip("shot", { duration: 30 }), clip("vo", { trackIndex: 1, duration: 2 })]);
+
+    for (const bad of [-1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const result = await handleSetStart(
+        { timelineId: "t1", nodeId: "vo", startSeconds: bad },
+        { requesterUid: OWNER },
+      );
+      expect(result.isError).toBe(true);
+    }
+    expect(storedClip("t1", "vo")?.placedStart).toBeUndefined();
+  });
+
+  it("reports an unknown node rather than writing anything", async () => {
+    seed("t1", [clip("shot", { duration: 30 })]);
+
+    const result = await handleSetStart(
+      { timelineId: "t1", nodeId: "nope", startSeconds: 5 },
+      { requesterUid: OWNER },
+    );
+
+    expect(result.isError).toBe(true);
+  });
+});

--- a/apps/timeline-gstudio001/lib/mcp/write-handlers.ts
+++ b/apps/timeline-gstudio001/lib/mcp/write-handlers.ts
@@ -8,6 +8,9 @@ import {
 } from "@storyboard/collections-core";
 
 import { normalizeTags, tagsField } from "@storyboard/timeline-model/tags";
+import { trackIndexOf } from "@storyboard/timeline-model/documents";
+import { resolvePlacement } from "@storyboard/timeline-model/placement";
+import { graphChildrenToClips } from "@storyboard/timeline-domain";
 
 import { checkUserScopedId } from "@/lib/timeline-ownership";
 import { describeDispatchRejection, toolError, toolOk } from "@/lib/webmcp/results";
@@ -519,5 +522,142 @@ export async function handleSetLane(
       ? `Moved "${args.nodeId}" onto the picture.`
       : `Moved "${args.nodeId}" to lane ${args.lane} — it now plays under the picture.`,
     { nodeId: args.nodeId, lane: args.lane, written: outcome.affectedIds },
+  );
+}
+
+// --- set_start ---------------------------------------------------------------
+
+export type SetStartArgs = Readonly<{
+  timelineId: string;
+  nodeId: string;
+  /** Seconds from the start of the collection, or null to re-queue the clip. */
+  startSeconds: number | null;
+}>;
+
+/**
+ * Place a clip at an explicit time on its lane — what makes a lane a TIMELINE
+ * rather than a parallel queue. Audio starts when it starts; a voiceover at
+ * 7.5s should not need 7.5s of something in front of it.
+ *
+ * A detail-only write, like `set_lane`: `placedStart` lives in the side table
+ * because the engine models neither lanes nor time, so the graph is genuinely
+ * unchanged and there is no command to issue. It carries the same ancestor
+ * write set for the same reason — a placement moves the parent's span, and
+ * every ancestor stores a duration for it.
+ *
+ * REFUSES THE PICTURE. Lane 0 is a cut: trimming a shot closes the gap behind
+ * it and reordering repacks, and a hole there is not silence — the player
+ * holds the last frame. Placing a shot is a different feature; this says so
+ * rather than writing a field that packing would ignore anyway.
+ *
+ * ON A COLLISION IT BUMPS rather than failing. Placing a clip on top of
+ * something already on its lane moves it to the first lane above with room,
+ * and the result says where it landed. See `resolvePlacement` for why that is
+ * decided by packing rather than by comparing against current positions.
+ */
+export async function handleSetStart(
+  args: SetStartArgs,
+  ctx: WriteContext,
+): Promise<ToolResult> {
+  const nodeId = parseNodeId(args.nodeId);
+  const start = args.startSeconds;
+  if (start !== null && (!Number.isFinite(start) || start < 0)) {
+    return toolError("`startSeconds` must be a number of seconds, 0 or more — or null to re-queue.");
+  }
+
+  let requestedLane = 0;
+  let landedLane = 0;
+  let wasBumped = false;
+
+  const outcome = await applyCollectionsCommand(
+    args.timelineId,
+    (graph: CollectionsGraph, details) => {
+      if (!graph.nodesById.has(nodeId)) {
+        return { ok: false, message: `No node with id "${args.nodeId}".` } as const;
+      }
+      const parentId = graph.parentById.get(nodeId) ?? null;
+      if (parentId === null) {
+        return {
+          ok: false,
+          message: `"${args.nodeId}" is a timeline itself, not a clip inside one — nothing to place.`,
+        } as const;
+      }
+      const existing = details[nodeId as string];
+      const lane = trackIndexOf({ trackIndex: existing?.trackIndex ?? 0 });
+      if (lane === 0) {
+        return {
+          ok: false,
+          message:
+            `"${args.nodeId}" is on the picture, which is a cut — its clips pack end to end and ` +
+            `a gap in it holds the last frame rather than going silent. Put it on a lane first ` +
+            `with set_lane, then place it.`,
+        } as const;
+      }
+
+      // Judged against the layout this write would PRODUCE — see
+      // `resolvePlacement`. The clips come from the same projection the board
+      // and the player read, so "does it collide" means the same thing here as
+      // it will on screen.
+      const placement =
+        start === null
+          ? { lane, bumped: false }
+          : resolvePlacement(
+              graphChildrenToClips(graph, details, parentId as string),
+              existing?.sourceClipId ?? (nodeId as string),
+              lane,
+              start,
+            );
+      requestedLane = lane;
+      landedLane = placement.lane;
+      wasBumped = placement.bumped;
+
+      // The parent and everything above it: a placement can lengthen or
+      // shorten the parent, which every ancestor stores a duration for.
+      const affected: string[] = [];
+      let current: NodeId | null = parentId;
+      while (current !== null && !affected.includes(current as string)) {
+        affected.push(current as string);
+        current = graph.parentById.get(current) ?? null;
+      }
+
+      // Spread the WHOLE existing entry, as `set_lane` does: the clip is
+      // rebuilt from this record, so omitting a field erases it on save.
+      // `placedStart` is dropped entirely when re-queuing — absence IS the
+      // "queued" state, and writing a sentinel would be a second way to say it.
+      const { placedStart: _dropped, ...rest } = existing ?? {};
+      const next = {
+        ...rest,
+        trackIndex: placement.lane,
+        ...(start === null ? {} : { placedStart: start }),
+      } as DetailsById[string];
+
+      return {
+        ok: true,
+        details: { [nodeId as string]: next },
+        affectedCollectionIds: affected,
+      } as const;
+    },
+    ctx.requesterUid,
+  );
+  if (!outcome.ok) return reportFailure(outcome);
+
+  if (start === null) {
+    return toolOk(
+      `"${args.nodeId}" is queued again — it now follows the clip before it on lane ${landedLane}.`,
+      { nodeId: args.nodeId, lane: landedLane, placedStart: null, written: outcome.affectedIds },
+    );
+  }
+  return toolOk(
+    wasBumped
+      ? `Placed "${args.nodeId}" at ${start}s. Lane ${requestedLane} was already busy at that ` +
+          `moment, so it moved to lane ${landedLane}.`
+      : `Placed "${args.nodeId}" at ${start}s on lane ${landedLane}.`,
+    {
+      nodeId: args.nodeId,
+      lane: landedLane,
+      placedStart: start,
+      bumped: wasBumped,
+      written: outcome.affectedIds,
+    },
   );
 }

--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -33,7 +33,7 @@ import { tagsField } from "@storyboard/timeline-model/tags";
 // The lane normaliser the model packs with. Imported rather than re-derived:
 // this file's packing is the twin of `packTimelineClips`, and two different
 // answers to "which lane is this clip on" would move layered clips on save.
-import { trackIndexOf } from "@storyboard/timeline-model/documents";
+import { placedStartOf, trackIndexOf } from "@storyboard/timeline-model/documents";
 import type {
   AssetSourceRef,
   CollectionTimelineClip,
@@ -65,6 +65,12 @@ export type ClipDetail = Readonly<{
   title?: string;
   aspect: number;
   trackIndex: number;
+  /** Where the author placed this clip on its lane, when they placed it —
+   *  see `TimelineItemBase.placedStart`. Rides the side table for the same
+   *  reason `trackIndex` does: the collections engine models neither lanes
+   *  nor time, so there is no graph command that could carry it. Absent
+   *  means queued; ignored on lane 0. */
+  placedStart?: number;
   poster?: string;
   playbackStartTime?: number;
   playbackDuration?: number;
@@ -172,6 +178,10 @@ function mediaDetail(clip: Exclude<TimelineClip, CollectionTimelineClip>): ClipD
     ...(clip.title === undefined ? {} : { title: clip.title }),
     aspect: clip.aspect,
     trackIndex: clip.trackIndex,
+    // Captured INBOUND as well as written back out: without this a stored
+    // placement is lost the moment the document is hydrated into a graph, and
+    // the clip silently rejoins its lane's queue on the next save.
+    ...(clip.placedStart === undefined ? {} : { placedStart: clip.placedStart }),
     ...(clip.poster === undefined ? {} : { poster: clip.poster }),
     ...(clip.sourceAsset === undefined ? {} : { sourceAsset: clip.sourceAsset }),
     ...tagsField(clip.tags),
@@ -190,6 +200,7 @@ function collectionDetail(clip: CollectionTimelineClip, hydrated: boolean): Clip
     alt: clip.alt,
     aspect: clip.aspect,
     trackIndex: clip.trackIndex,
+    ...(clip.placedStart === undefined ? {} : { placedStart: clip.placedStart }),
     ...tagsField(clip.tags),
     ...(clip.trashedAt === undefined ? {} : { trashedAt: clip.trashedAt }),
     ...(clip.trashedFrom === undefined ? {} : { trashedFrom: clip.trashedFrom }),
@@ -672,17 +683,26 @@ export function graphChildrenToClips(
   const nextStartByTrack = new Map<number, number>();
   const startFor = (track: number) =>
     nextStartByTrack.get(track) ?? TIMELINE_LEADING_PADDING_SECONDS;
+  // The cursor never rewinds, exactly as in `packTimelineClips`: a clip
+  // placed earlier than its lane's queue has reached must not drag the
+  // following queued clip back on top of a neighbour.
+  const advance = (track: number, end: number) =>
+    nextStartByTrack.set(track, Math.max(startFor(track), end));
 
   return getChildren(graph, parseNodeId(collectionId)).map((childId, index) => {
     const node = graph.nodesById.get(childId);
     if (!node) throw new Error(`Graph child "${childId}" missing from nodesById.`);
     const detail = details[childId];
     const trackIndex = trackIndexOf({ trackIndex: detail?.trackIndex ?? 0 });
-    const startTime = startFor(trackIndex);
+    // PLACED or queued — the same resolution the model packer uses, imported
+    // rather than re-implemented so the twins cannot drift on the one field
+    // whose whole purpose is to override the cursor.
+    const placedStart = placedStartOf({ placedStart: detail?.placedStart }, trackIndex);
+    const startTime = placedStart ?? startFor(trackIndex);
 
     if (node.kind === "media") {
       const duration = mediaDurationSeconds(node);
-      nextStartByTrack.set(trackIndex, startTime + duration + CLIP_GAP_SECONDS);
+      advance(trackIndex, startTime + duration + CLIP_GAP_SECONDS);
       const base = {
         // A demoted duplicate (see clipSpecs) writes back its STORED id.
         id: detail?.sourceClipId ?? (node.id as string),
@@ -695,6 +715,10 @@ export function graphChildrenToClips(
         ...(detail?.title === undefined ? {} : { title: detail.title }),
         aspect: detail?.aspect ?? 16 / 9,
         trackIndex,
+        // THE WRITE-BACK, like tags: the stored clip is rebuilt from this
+        // record, so omitting it here would silently un-place the clip on
+        // the next save and drop it back into its lane's queue.
+        ...(placedStart === undefined ? {} : { placedStart }),
         startTime,
         duration,
         ...(detail?.playbackStartTime === undefined
@@ -772,7 +796,7 @@ export function graphChildrenToClips(
       ? hydratedCollectionPlayableDuration(graph, details, node.id)
       : detail?.playableDuration;
     const playableDuration = playable === duration ? undefined : playable;
-    nextStartByTrack.set(trackIndex, startTime + duration + CLIP_GAP_SECONDS);
+    advance(trackIndex, startTime + duration + CLIP_GAP_SECONDS);
     return {
       id: detail?.sourceClipId ?? (node.id as string),
       index,
@@ -790,6 +814,7 @@ export function graphChildrenToClips(
       alt: detail?.alt ?? `${node.name} collection`,
       aspect: detail?.aspect ?? 16 / 9,
       trackIndex,
+      ...(placedStart === undefined ? {} : { placedStart }),
       startTime,
       duration,
       sourceDuration: detail?.sourceDuration ?? duration,

--- a/packages/timeline-domain/src/lane-manifest.test.ts
+++ b/packages/timeline-domain/src/lane-manifest.test.ts
@@ -100,6 +100,29 @@ describe("manifest lanes", () => {
     expect(manifest.durationSeconds).toBe(30);
   });
 
+  it("compiles a PLACED clip at the time it was placed", () => {
+    // #400, and the reason the read side needed no changes: the manifest has
+    // always read `clip.startTime`, so a start the packer honours arrives here
+    // on its own. This is what the render mixes against, so it is where
+    // "placed at 7.5s" becomes "audible at 7.5s".
+    const manifest = compile({
+      root: doc("root", [
+        media("shot", 30),
+        media("vo", 2, {
+          trackIndex: 1,
+          placedStart: 7.5,
+          kind: "audio",
+          src: "https://cdn.test/vo.wav",
+        }),
+      ]),
+    });
+    const vo = manifest.leaves.find((leaf) => leaf.id === "vo");
+    expect(vo?.timelineStart).toBe(7.5);
+    expect(vo?.trackIndex).toBe(1);
+    // And the picture is where it always was.
+    expect(manifest.leaves.find((leaf) => leaf.id === "shot")?.timelineStart).toBe(0);
+  });
+
   it("a bed inside a lane-0 collection is UNDER — its own lane decides", () => {
     const manifest = compile({
       root: doc("root", [collection("scene", "scene-doc", 20)]),

--- a/packages/timeline-domain/src/lane-roundtrip.test.ts
+++ b/packages/timeline-domain/src/lane-roundtrip.test.ts
@@ -108,6 +108,55 @@ describe("lanes survive the graph round trip", () => {
     );
   });
 
+  it("carries a PLACED start through unchanged", () => {
+    // The twin-math risk lands hardest on this field: it is the one input that
+    // overrides the cursor, so an adapter that dropped it would re-queue every
+    // placed clip on the next save — silently, and only for layered documents.
+    const placed: TimelineDocument = {
+      id: "col",
+      title: "Placed",
+      clips: packTimelineClips([
+        media("shot", 30),
+        media("vo", 2, { trackIndex: 1, placedStart: 7.5 }),
+      ]),
+    };
+    expect(roundTrip(placed).map((c) => [c.id, c.startTime, c.placedStart])).toEqual([
+      ["shot", 0, undefined],
+      ["vo", 7.5, 7.5],
+    ]);
+  });
+
+  it("keeps a placed start stable across a SECOND round trip", () => {
+    const placed: TimelineDocument = {
+      id: "col",
+      title: "Placed",
+      clips: packTimelineClips([
+        media("shot", 30),
+        media("vo", 2, { trackIndex: 1, placedStart: 7.5 }),
+        media("next", 2, { trackIndex: 1 }),
+      ]),
+    };
+    const once = roundTrip(placed);
+    const twice = roundTrip({ ...placed, clips: once });
+    expect(twice.map((c) => [c.id, c.startTime])).toEqual(
+      once.map((c) => [c.id, c.startTime]),
+    );
+    // And the queued clip behind it still clears it.
+    expect(once.find((c) => c.id === "next")?.startTime).toBe(9.5 + CLIP_GAP_SECONDS);
+  });
+
+  it("agrees that a placement on the PICTURE is ignored", () => {
+    const onPicture: TimelineDocument = {
+      id: "col",
+      title: "Picture",
+      clips: packTimelineClips([media("a", 4), media("b", 2, { placedStart: 30 })]),
+    };
+    expect(roundTrip(onPicture).map((c) => c.startTime)).toEqual([
+      0,
+      4 + CLIP_GAP_SECONDS,
+    ]);
+  });
+
   it("normalises a phantom lane the same way on both sides", () => {
     // `validate` admits any finite number; both implementations must send a
     // non-integer to lane 0 or they disagree about where it starts.

--- a/packages/timeline-model/documents.test.ts
+++ b/packages/timeline-model/documents.test.ts
@@ -107,6 +107,72 @@ describe("packTimelineClips", () => {
   it("is empty for no clips", () => {
     expect(packTimelineClips([])).toEqual([]);
   });
+
+  // PLACED starts — what makes a lane a timeline rather than a parallel queue.
+  it("starts a placed clip exactly where it was placed", () => {
+    const packed = packTimelineClips([
+      clip("shot", 4),
+      clip("vo", 2, { trackIndex: 1, placedStart: 7.5 }),
+    ]);
+    expect(starts(packed)).toEqual([0, 7.5]);
+  });
+
+  it("queues a lane clip with no placement, exactly as before", () => {
+    const packed = packTimelineClips([
+      clip("shot", 20),
+      clip("bed", 4, { trackIndex: 1 }),
+      clip("vo", 2, { trackIndex: 1 }),
+    ]);
+    expect(starts(packed)).toEqual([0, 0, 4 + CLIP_GAP_SECONDS]);
+  });
+
+  it("queues a following clip AFTER a placed one, gap included", () => {
+    const packed = packTimelineClips([
+      clip("shot", 30),
+      clip("vo", 2, { trackIndex: 1, placedStart: 7.5 }),
+      clip("next", 2, { trackIndex: 1 }),
+    ]);
+    expect(starts(packed)).toEqual([0, 7.5, 9.5 + CLIP_GAP_SECONDS]);
+  });
+
+  it("never REWINDS the lane cursor for a clip placed behind the queue", () => {
+    // `late` already carried the lane to 10s. Placing `early` at 1s must not
+    // drag `tail` back on top of `late` — a placement is one clip's business.
+    const packed = packTimelineClips([
+      clip("shot", 40),
+      clip("late", 10, { trackIndex: 1 }),
+      clip("early", 2, { trackIndex: 1, placedStart: 1 }),
+      clip("tail", 2, { trackIndex: 1 }),
+    ]);
+    expect(starts(packed)).toEqual([0, 0, 1, 10 + CLIP_GAP_SECONDS]);
+  });
+
+  it("IGNORES a placement on the picture — lane 0 is a cut", () => {
+    const packed = packTimelineClips([
+      clip("a", 4),
+      clip("b", 2, { placedStart: 30 }),
+    ]);
+    expect(starts(packed)).toEqual([0, 4 + CLIP_GAP_SECONDS]);
+  });
+
+  it("ignores a placement that is not a real non-negative time", () => {
+    for (const bad of [-1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const packed = packTimelineClips([
+        clip("shot", 20),
+        clip("vo", 2, { trackIndex: 1, placedStart: bad }),
+      ]);
+      expect(starts(packed)[1]).toBe(0);
+    }
+  });
+
+  it("lets two lanes be placed independently of each other", () => {
+    const packed = packTimelineClips([
+      clip("shot", 30),
+      clip("bed", 5, { trackIndex: 1, placedStart: 2 }),
+      clip("vo", 3, { trackIndex: 2, placedStart: 11.25 }),
+    ]);
+    expect(starts(packed)).toEqual([0, 2, 11.25]);
+  });
 });
 
 describe("collectionSpanSeconds", () => {

--- a/packages/timeline-model/documents.ts
+++ b/packages/timeline-model/documents.ts
@@ -81,17 +81,56 @@ export function trackIndexOf(clip: Pick<TimelineClip, "trackIndex">): number {
  * Identical to the old behaviour for any document that has never used lanes,
  * because every clip in one is on track 0 — which is every document written
  * before this.
+ *
+ * HONOURS `placedStart` on lanes 1+, which is what makes a lane a timeline
+ * rather than a parallel queue: a voiceover can begin at 7.5s without 7.5s of
+ * something in front of it. Absent means queued, so a document with nothing
+ * placed packs exactly as it did before the field existed.
  */
 export function packTimelineClips(clips: TimelineClip[]) {
   const nextStartByTrack = new Map<number, number>();
 
   return clips.map((clip, index) => {
     const track = trackIndexOf(clip);
-    const startTime = nextStartByTrack.get(track) ?? TIMELINE_LEADING_PADDING_SECONDS;
+    const placed = placedStartOf(clip, track);
+    const startTime = placed ?? nextStartByTrack.get(track) ?? TIMELINE_LEADING_PADDING_SECONDS;
     const nextClip = { ...clip, index, startTime };
-    nextStartByTrack.set(track, startTime + nextClip.duration + CLIP_GAP_SECONDS);
+    // The cursor NEVER REWINDS. A clip placed earlier than its lane's queue
+    // has already reached would otherwise drag the following queued clip back
+    // on top of a neighbour — the placement is one clip's business, and it
+    // must not reorganise the ones it was dropped in front of.
+    //
+    // No gap is added BEFORE a placed start: `CLIP_GAP_SECONDS` separates
+    // consecutive shots, and a placed start is already exact. It still
+    // applies AFTER one, so a queued clip following a placed clip clears it.
+    nextStartByTrack.set(
+      track,
+      Math.max(
+        nextStartByTrack.get(track) ?? TIMELINE_LEADING_PADDING_SECONDS,
+        startTime + nextClip.duration + CLIP_GAP_SECONDS,
+      ),
+    );
     return nextClip;
   });
+}
+
+/**
+ * The authored start this clip should pack at, or undefined to queue it.
+ *
+ * Defensive in the same way `trackIndexOf` is, and for the same reason: this
+ * value is HONOURED rather than recomputed, so anything that is not a real
+ * non-negative time has to fall back to queuing instead of placing a clip
+ * where nobody asked. Lane 0 never places — the picture is a cut.
+ */
+export function placedStartOf(
+  clip: Pick<TimelineClip, "placedStart">,
+  track: number,
+): number | undefined {
+  if (track <= 0) return undefined;
+  const placed = clip.placedStart;
+  return typeof placed === "number" && Number.isFinite(placed) && placed >= 0
+    ? placed
+    : undefined;
 }
 
 /** The clips that actually play and count. Absent `disabled` means enabled. */

--- a/packages/timeline-model/index.ts
+++ b/packages/timeline-model/index.ts
@@ -2,5 +2,6 @@ export * from "./types";
 export * from "./tags";
 export * from "./constants";
 export * from "./documents";
+export * from "./placement";
 export * from "./validate";
 export * from "./clip-display";

--- a/packages/timeline-model/placement.test.ts
+++ b/packages/timeline-model/placement.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+
+import { CLIP_GAP_SECONDS } from "./constants";
+import { resolvePlacement, spansOverlap } from "./placement";
+import type { TimelineClip } from "./types";
+
+function clip(
+  id: string,
+  duration: number,
+  over: Partial<TimelineClip> = {},
+): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "image",
+    src: `https://cdn.test/${id}.png`,
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration,
+    sourceDuration: duration,
+    trimIn: 0,
+    trimOut: 0,
+    ...over,
+  } as TimelineClip;
+}
+
+describe("spansOverlap", () => {
+  it("is true when they genuinely share time", () => {
+    expect(spansOverlap(0, 5, 4, 9)).toBe(true);
+    expect(spansOverlap(4, 9, 0, 5)).toBe(true);
+    // Fully contained.
+    expect(spansOverlap(2, 3, 0, 10)).toBe(true);
+  });
+
+  it("is FALSE for spans that merely touch", () => {
+    // The ordinary back-to-back case. Counting it would bump every clip that
+    // simply follows another.
+    expect(spansOverlap(0, 4, 4, 8)).toBe(false);
+    expect(spansOverlap(4, 8, 0, 4)).toBe(false);
+  });
+
+  it("is false when they are apart", () => {
+    expect(spansOverlap(0, 4, 10, 12)).toBe(false);
+  });
+
+  it("puts a zero-length span INSIDE another one in collision", () => {
+    // Not an edge case worth special-casing away: an instant inside a clip is
+    // inside it. What matters is that it does not collide at the edges, which
+    // is where a zero-length clip would otherwise trip the back-to-back rule.
+    expect(spansOverlap(5, 5, 0, 10)).toBe(true);
+    expect(spansOverlap(0, 0, 0, 10)).toBe(false);
+    expect(spansOverlap(10, 10, 0, 10)).toBe(false);
+  });
+});
+
+describe("resolvePlacement", () => {
+  it("keeps the requested lane when there is room", () => {
+    const clips = [clip("shot", 30), clip("vo", 2, { trackIndex: 1 })];
+    expect(resolvePlacement(clips, "vo", 1, 7.5)).toEqual({ lane: 1, bumped: false });
+  });
+
+  it("bumps to the next lane when the placement lands on a neighbour", () => {
+    // `bed` occupies lane 1 from 0 to 10; placing `vo` at 5 collides.
+    const clips = [
+      clip("shot", 30),
+      clip("bed", 10, { trackIndex: 1 }),
+      clip("vo", 2, { trackIndex: 1 }),
+    ];
+    expect(resolvePlacement(clips, "vo", 1, 5)).toEqual({ lane: 2, bumped: true });
+  });
+
+  it("does NOT bump when the placement merely touches a neighbour", () => {
+    const clips = [
+      clip("shot", 30),
+      clip("bed", 10, { trackIndex: 1 }),
+      clip("vo", 2, { trackIndex: 1 }),
+    ];
+    expect(resolvePlacement(clips, "vo", 1, 10)).toEqual({ lane: 1, bumped: false });
+  });
+
+  it("escalates past several occupied lanes", () => {
+    const clips = [
+      clip("shot", 30),
+      clip("a", 10, { trackIndex: 1 }),
+      clip("b", 10, { trackIndex: 2 }),
+      clip("c", 10, { trackIndex: 3 }),
+      clip("vo", 2, { trackIndex: 1 }),
+    ];
+    expect(resolvePlacement(clips, "vo", 1, 5)).toEqual({ lane: 4, bumped: true });
+  });
+
+  it("measures against the layout the write would PRODUCE, not the current one", () => {
+    // `vo` sits on lane 1 today, queued behind `bed` at 10.12s. Placing it at
+    // 5 must be judged against a lane 1 where `vo` is no longer queued behind
+    // anything — the queue closes up the moment it moves. Comparing to its
+    // present position (10.12) would see no collision and leave it on top of
+    // the bed.
+    const clips = [
+      clip("shot", 30),
+      clip("bed", 10, { trackIndex: 1 }),
+      clip("vo", 2, { trackIndex: 1 }),
+    ];
+    expect(clips[2]?.startTime).toBe(0);
+    expect(resolvePlacement(clips, "vo", 1, 5).bumped).toBe(true);
+  });
+
+  it("never returns the picture, whatever lane was asked for", () => {
+    const clips = [clip("shot", 30), clip("vo", 2, { trackIndex: 1 })];
+    for (const asked of [0, -3, 0.5, Number.NaN]) {
+      expect(resolvePlacement(clips, "vo", asked, 7.5).lane).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("starts from the lane asked for rather than the lowest free one", () => {
+    // Lane 1 is wide open, but the caller asked for 3 — honour it.
+    const clips = [clip("shot", 30), clip("vo", 2, { trackIndex: 3 })];
+    expect(resolvePlacement(clips, "vo", 3, 7.5)).toEqual({ lane: 3, bumped: false });
+  });
+
+  it("ignores clips on OTHER lanes when judging a collision", () => {
+    const clips = [
+      clip("shot", 30),
+      clip("bed", 30, { trackIndex: 2 }),
+      clip("vo", 2, { trackIndex: 1 }),
+    ];
+    expect(resolvePlacement(clips, "vo", 1, 5)).toEqual({ lane: 1, bumped: false });
+  });
+
+  it("ignores the PICTURE when judging a collision", () => {
+    // The picture runs the whole time; a lane clip is meant to sit under it.
+    const clips = [clip("shot", 30), clip("vo", 2, { trackIndex: 1 })];
+    expect(resolvePlacement(clips, "vo", 1, 5)).toEqual({ lane: 1, bumped: false });
+  });
+
+  it("finds room above a lane whose queued clips fill it", () => {
+    const clips = [
+      clip("shot", 60),
+      clip("q1", 10, { trackIndex: 1 }),
+      clip("q2", 10, { trackIndex: 1 }),
+      clip("vo", 2, { trackIndex: 1 }),
+    ];
+    // q1 [0,10], q2 [10.12, 20.12] — placing at 15 collides with q2.
+    expect(resolvePlacement(clips, "vo", 1, 15)).toEqual({ lane: 2, bumped: true });
+    // The SEAM between them is only CLIP_GAP_SECONDS wide, so a 2s clip does
+    // not fit in it — placing at 10 runs to 12, well inside q2.
+    expect(CLIP_GAP_SECONDS).toBeLessThan(2);
+    expect(resolvePlacement(clips, "vo", 1, 10)).toEqual({ lane: 2, bumped: true });
+    // Past the end of the queue there is room, and touching q2's end is fine.
+    expect(resolvePlacement(clips, "vo", 1, 20.12)).toEqual({ lane: 1, bumped: false });
+  });
+
+  it("returns an unknown id unmoved rather than throwing", () => {
+    const clips = [clip("shot", 30)];
+    expect(resolvePlacement(clips, "nope", 2, 5)).toEqual({ lane: 2, bumped: false });
+  });
+
+  it("places into an empty collection", () => {
+    expect(resolvePlacement([clip("vo", 2, { trackIndex: 1 })], "vo", 1, 7.5)).toEqual({
+      lane: 1,
+      bumped: false,
+    });
+  });
+});

--- a/packages/timeline-model/placement.ts
+++ b/packages/timeline-model/placement.ts
@@ -1,0 +1,98 @@
+import { packTimelineClips, trackIndexOf } from "./documents";
+import type { TimelineClip } from "./types";
+
+// Where a PLACED clip actually ends up.
+//
+// Placing a clip at an explicit time can put it on top of something already on
+// that lane. Rather than refusing the write, the placement moves UP to the
+// first lane with room — so a placement never fails and two clips never share
+// a span on one row. The caller reports where it landed.
+
+/**
+ * Do two spans overlap? Touching does NOT count: a clip ending exactly where
+ * the next begins is the ordinary back-to-back case, and treating it as a
+ * collision would bump every clip that simply follows another.
+ *
+ * A zero-length span is inside another one when it falls strictly within it,
+ * and clear of it at either edge. Left as it falls out of the comparison
+ * rather than special-cased: an instant inside a clip IS inside it, and the
+ * edges — where a zero-length clip would otherwise trip the back-to-back
+ * rule — already read correctly.
+ */
+export function spansOverlap(
+  aStart: number,
+  aEnd: number,
+  bStart: number,
+  bEnd: number,
+): boolean {
+  return aStart < bEnd && bStart < aEnd;
+}
+
+export type Placement = Readonly<{
+  /** The lane the clip ends up on — the one asked for, or the first above it
+   *  with room. Never 0. */
+  lane: number;
+  /** True when a collision pushed it off the lane that was asked for. */
+  bumped: boolean;
+}>;
+
+/**
+ * Resolve the lane a clip should land on when placed at `placedStart`.
+ *
+ * WHY THIS PACKS RATHER THAN COMPARING NUMBERS. Overlap can only be judged
+ * against packed positions, and the packed positions depend on the very
+ * placement being judged: the moment this clip leaves its old lane, the queued
+ * clips behind it close up, and the moment it arrives on a new one it pushes
+ * the queue there along. Testing a proposed start against the CURRENT layout
+ * would therefore compare it to positions that will not exist once the write
+ * lands. So each candidate lane is applied for real, packed, and measured.
+ *
+ * Searches UPWARD from the requested lane and never considers lane 0 — lanes
+ * stack away from the picture on the board, and the picture is a cut. The
+ * search is bounded by the highest lane in use plus one, which by construction
+ * holds nothing, so it always terminates with room found.
+ *
+ * `clips` is the collection's whole child list; `clipId` must be in it (an
+ * unknown id is returned unmoved, which is what a caller that has already
+ * validated existence will never see).
+ */
+export function resolvePlacement(
+  clips: readonly TimelineClip[],
+  clipId: string,
+  desiredLane: number,
+  placedStart: number,
+): Placement {
+  // Never the picture, whatever was asked for.
+  const from = Math.max(1, trackIndexOf({ trackIndex: desiredLane }));
+  if (!clips.some((clip) => clip.id === clipId)) return { lane: from, bumped: false };
+
+  const highest = clips.reduce((top, clip) => Math.max(top, trackIndexOf(clip)), 0);
+
+  for (let lane = from; lane <= highest + 1; lane += 1) {
+    const packed = packTimelineClips(
+      clips.map((clip) =>
+        clip.id === clipId ? { ...clip, trackIndex: lane, placedStart } : clip,
+      ),
+    );
+    const moved = packed.find((clip) => clip.id === clipId);
+    if (!moved) continue;
+    const movedEnd = moved.startTime + moved.duration;
+    const collides = packed.some(
+      (other) =>
+        other.id !== clipId &&
+        trackIndexOf(other) === lane &&
+        spansOverlap(
+          moved.startTime,
+          movedEnd,
+          other.startTime,
+          other.startTime + other.duration,
+        ),
+    );
+    if (!collides) return { lane, bumped: lane !== from };
+  }
+
+  // Unreachable: `highest + 1` holds nothing to collide with. Returned rather
+  // than thrown so a caller can still write something sane if the invariant
+  // above is ever broken by a future change to packing.
+  return { lane: highest + 1, bumped: highest + 1 !== from };
+}

--- a/packages/timeline-model/types.ts
+++ b/packages/timeline-model/types.ts
@@ -37,7 +37,30 @@ export type TimelineItemBase = {
   aspect: number;
   trackIndex: number;
 
-  /** Absolute timeline position. */
+  /**
+   * WHERE THE AUTHOR PUT THIS CLIP on its lane, when they put it somewhere.
+   *
+   * The counterpart to `startTime`, which is always DERIVED: packing gives
+   * each lane a running cursor and every clip's start comes out of it, so a
+   * lane is a parallel queue and the only way to place a voiceover at 7.5s
+   * would be to put 7.5s of something in front of it. This is the field that
+   * says "start here" and means it.
+   *
+   * ABSENT MEANS QUEUED — pack behind the previous clip on this lane, which
+   * is what every document written before this did, so nothing needs
+   * migrating. Absence is also the safe default: a writer that forgets this
+   * field gets the old behaviour rather than moving a clip to zero.
+   *
+   * IGNORED ON LANE 0, deliberately and defensively. The picture is a CUT:
+   * trimming a shot closes the gap behind it and reordering repacks. A hole
+   * there is not silence either — the player holds the last frame — so
+   * deliberate gaps in the picture are a different feature with a different
+   * answer, and a stray value here must not open one.
+   */
+  placedStart?: number;
+
+  /** Absolute timeline position. DERIVED by packing — see `placedStart`,
+   *  which is the authored input this is computed from on lanes 1+. */
   startTime: number;
   /** Visible duration after trimming. */
   duration: number;

--- a/packages/timeline-model/validate.test.ts
+++ b/packages/timeline-model/validate.test.ts
@@ -61,6 +61,18 @@ describe("isTimelineClip", () => {
     expect(isTimelineClip({ ...image, sourceAsset: null })).toBe(true);
   });
 
+  it("gates placedStart, which packing HONOURS rather than recomputes", () => {
+    // Sharper than the other optionals: a bad value here does not get
+    // recalculated away, it puts a clip somewhere nobody asked for.
+    expect(isTimelineClip({ ...image, placedStart: 7.5 })).toBe(true);
+    expect(isTimelineClip({ ...image, placedStart: 0 })).toBe(true);
+    expect(isTimelineClip({ ...image, placedStart: null })).toBe(true);
+    expect(isTimelineClip({ ...image, placedStart: -1 })).toBe(false);
+    expect(isTimelineClip({ ...image, placedStart: Number.NaN })).toBe(false);
+    expect(isTimelineClip({ ...image, placedStart: Number.POSITIVE_INFINITY })).toBe(false);
+    expect(isTimelineClip({ ...image, placedStart: "7.5" })).toBe(false);
+  });
+
   it("accepts a finite preview trim and rejects malformed preview trims", () => {
     const preview = collection.previewItems[0];
     expect(

--- a/packages/timeline-model/validate.ts
+++ b/packages/timeline-model/validate.ts
@@ -119,6 +119,11 @@ function hasClipBase(clip: Record<string, unknown>): boolean {
     trimsFitInSource(clip) &&
     isOptionalNonNegative(clip.playbackStartTime) &&
     isOptionalNonNegative(clip.playbackDuration) &&
+    // Absent OR a real non-negative time. Gated the same way
+    // `playbackStartTime` is, and for a sharper reason: this one is HONOURED
+    // by packing, so a NaN or a negative arriving from stored data would put
+    // a clip somewhere no author asked for rather than being recomputed away.
+    isOptionalNonNegative(clip.placedStart) &&
     // Strictly boolean-or-absent. This gate guards the WRITE path, and a
     // truthy non-boolean would be read as "skip this clip" by the playback
     // and summary passes — a stored string "false" would silently drop a


### PR DESCRIPTION
Closes #400.

#401 drew lanes as rows, and that geometry already accepted an arbitrary start. What the **model** could not do was express one: `packTimelineClips` gave each lane its own running cursor and derived every `startTime` from it, so a lane was a parallel **queue**. The only way to put a voiceover at 7.5s was to put 7.5s of something in front of it.

Audio does not work like that. It starts when it starts, and it does not line up with anything on another lane.

## `placedStart`

Absent means **queued** — every document that exists — so nothing migrates and a document with nothing placed packs byte-identically. Absence is also the safe default: a writer that forgets the field gets the old behaviour rather than moving a clip to zero.

**Ignored on lane 0**, defensively, the way `trackIndexOf` already ignores a fractional lane. The picture is a cut: trimming a shot closes the gap behind it, reordering repacks, and a hole there is not silence because the player holds the last frame.

## The read side needed nothing

Which is why this is small. `flattenDocument` already reads `clip.startTime`, `collectionSpanSeconds` already takes the furthest end rather than the last clip's, and the board reads times straight from `graphChildrenToClips`. Give the packer a start it honours and playback, export and the board all follow — pinned by a manifest test that compiles a clip placed at 7.5s to `timelineStart: 7.5`, which is what the render mixes against.

## Two things that needed care

**The cursor never rewinds.** A clip placed *earlier* than its lane's queue has already reached would otherwise drag the following queued clip back on top of its neighbour. A placement is one clip's business; it must not reorganise the clips it was dropped in front of. No gap is added *before* a placed start either — `CLIP_GAP_SECONDS` separates consecutive shots and a placed start is already exact — but it still applies after one.

**The twins had to move together.** `graphChildrenToClips` is the twin of `packTimelineClips`, and this is the one field whose whole purpose is to override the cursor — so an adapter that dropped it would silently re-queue every placed clip on the next save, and only on layered documents. It imports the same resolver rather than re-implementing it, captures the field inbound when hydrating, and writes it back out. The lane round-trip test pins all three, including stability across a second round trip.

## Collisions bump rather than refuse

`resolvePlacement` tries the requested lane, applies the change for real, packs, and measures; on an overlap it goes up a lane and repacks.

It **packs rather than comparing numbers** because overlap can only be judged against the layout the write would produce — the moment the clip leaves its old lane the queue behind it closes up, so testing against current positions compares against positions that will not exist. A test pins exactly that case. Touching is not overlapping, or every clip that simply follows another would bump. Never lane 0, bounded by the highest lane in use plus one.

## `set_start`

`{ timelineId, nodeId, startSeconds }`, `null` to re-queue. Refuses a lane-0 clip and names `set_lane` as the way out; spreads the whole existing detail entry (the clip is rebuilt from that record, so omitting a field erases it on save); writes the parent **and every ancestor** for the reason `set_lane` documents; and says which lane it actually landed on when it bumped.

## Still missing

Dragging a clip along its lane to place it, which belongs with cross-lane drag (#399) — both are the same gesture on the board. Until then a placement is a tool call and the board draws the result.

## Verified

- app + UI `tsc` clean; lint clean (same 5 pre-existing `<img>` warnings)
- **1078** app tests
- **642** shared unit tests
- **206** story interaction tests
- **171** graph-view e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)
