### PR TITLE
Make a lane and a placement undoable (#399, phase A)

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-clip-card.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-clip-card.tsx
@@ -102,9 +102,9 @@ export const GraphClipContent = memo(function GraphClipContent({
   // `node.name`: the node's name falls back to the derived alt, so it can't
   // tell "named by someone" from "named by the file system".
   const detail = useClipDetail(id as string);
-  // Which lane this plays in. Lives in the details side table because the
-  // engine does not model it — see set_lane.
-  const lane = laneOf(detail);
+  // Which lane this plays in. Read from the NODE: lane and placement moved
+  // there when they became a command, which is what makes them undoable.
+  const lane = laneOf(node);
 
   // MEDIA pixels only. This guard is defensive: nothing in the graph view
   // reaches it with a collection node.

--- a/apps/timeline-gstudio001/components/graph-view/graph-collection-card.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-collection-card.tsx
@@ -152,7 +152,7 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
         {/* A whole collection can sit under the picture too — every leaf
             inside it then plays underneath, however its own children are
             arranged. */}
-        {laneOf(detail) > 0 && <LaneChip lane={laneOf(detail)} />}
+        {laneOf(node) > 0 && <LaneChip lane={laneOf(node)} />}
         {/* Collections are taggable too — `tags` sits on TimelineItemBase, not
             on the media members — and they route through THIS component rather
             than GraphClipContent (which returns null for them at its guard).

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -147,15 +147,29 @@ function renderWithDetail(previewItems: PreviewItem[], trackIndex = 0) {
   const detail: ClipDetail = {
     alt: "A timeline",
     aspect: 16 / 9,
-    trackIndex,
     hydrated: false,
     itemCount: previewItems.length,
     duration: previewItems.length * 4,
     previewItems,
   };
   const store = createGraphDetailsStore({ [COLLECTION_ID]: detail });
+  // The LANE lives on the node, so it is built into the graph rather than
+  // merged into the detail — see the note on `set-node-placement`.
+  const graph = (() => {
+    const result = buildGraph([
+      {
+        kind: "collection",
+        id: COLLECTION_ID,
+        name: "A timeline",
+        children: [],
+        ...(trackIndex === 0 ? {} : { trackIndex }),
+      },
+    ]);
+    if (!result.ok) throw new Error(JSON.stringify(result.error));
+    return result.value;
+  })();
   const decorator: Decorator = (Story) => (
-    <DndCollections initialGraph={providerGraph}>
+    <DndCollections initialGraph={graph}>
       <GraphDetailsProvider store={store}>
         <div className="h-32 w-40 bg-zinc-950 p-2">
           <Story />
@@ -385,7 +399,6 @@ export const AudioLedCollectionShowsMusicGlyph: Story = {
         [AUDIO_COLLECTION_ID]: {
           alt: "Voice takes",
           aspect: 16 / 9,
-          trackIndex: 0,
           hydrated: true,
           itemCount: 1,
           duration: 8,
@@ -434,7 +447,6 @@ export const AudioClipCardDoesNotRenderItsFlacAsAnImage: Story = {
         [AUDIO_CLIP_ID]: {
           alt: "Pat VO",
           aspect: 16 / 9,
-          trackIndex: 0,
           duration: 8,
         } satisfies ClipDetail,
       });
@@ -507,7 +519,6 @@ function renderWithGraph(graph: CollectionsGraph) {
   const detail: ClipDetail = {
     alt: "A timeline",
     aspect: 16 / 9,
-    trackIndex: 0,
     hydrated: false,
     itemCount: 2,
     previewItems: [ASSET_A, ASSET_B],
@@ -903,7 +914,6 @@ export const DisabledCollection: Story = {
         [COLLECTION_ID]: {
           alt: "A timeline",
           aspect: 16 / 9,
-          trackIndex: 0,
           hydrated: false,
           itemCount: 2,
           duration: 8,
@@ -1128,7 +1138,6 @@ function renderWithTags(tags: string[], surface: "grid" | "strip" = "strip") {
   const detail: ClipDetail = {
     alt: "A timeline",
     aspect: 16 / 9,
-    trackIndex: 0,
     hydrated: false,
     itemCount: 2,
     previewItems: [ASSET_A, ASSET_B],
@@ -1303,7 +1312,6 @@ function renderMediaCard(
       [VIDEO_ID as string]: {
         alt: "A video",
         aspect: 16 / 9,
-        trackIndex: 0,
         hydrated: false,
         tags,
       },
@@ -1349,7 +1357,6 @@ function renderCollectionInSelectMode(): Decorator {
       [COLLECTION_ID]: {
         alt: "A timeline",
         aspect: 16 / 9,
-        trackIndex: 0,
         hydrated: false,
         itemCount: 2,
         duration: 51.8,

--- a/apps/timeline-gstudio001/components/graph-view/graph-lane-rows.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-lane-rows.test.ts
@@ -6,12 +6,12 @@ import { CLIP_GAP_SECONDS } from "@storyboard/timeline-model/constants";
 
 import { laneDropBoundary, laneDropIndex, splitLaneRows } from "./graph-lane-rows";
 
-const media = (id: string, durationSeconds: number): GraphNodeSpec => ({
-  kind: "media",
-  id,
-  name: id,
-  durationSeconds,
-});
+const media = (
+  id: string,
+  durationSeconds: number,
+  over: Partial<GraphNodeSpec> = {},
+): GraphNodeSpec =>
+  ({ kind: "media", id, name: id, durationSeconds, ...over }) as GraphNodeSpec;
 
 const collection = (id: string, children: readonly GraphNodeSpec[] = []): GraphNodeSpec => ({
   kind: "collection",
@@ -26,25 +26,20 @@ function graphOf(roots: readonly GraphNodeSpec[]) {
   return result.value;
 }
 
-/** A side-table entry with only the fields a test cares about set. */
+/** A side-table entry with only the fields a test cares about set. Lane and
+ *  placement are NOT among them any more — they live on the node. */
 const detail = (over: Partial<ClipDetail> = {}): ClipDetail => ({
   alt: "",
   aspect: 16 / 9,
-  trackIndex: 0,
   ...over,
 });
 
-/** A details side table putting the named nodes on a lane. */
-function lanes(byId: Readonly<Record<string, number>>): DetailsById {
-  const details: Record<string, ClipDetail> = {};
-  for (const [id, trackIndex] of Object.entries(byId)) details[id] = detail({ trackIndex });
-  return details;
-}
+const NO_DETAILS = {} as DetailsById;
 
 describe("splitLaneRows", () => {
   it("puts everything on the picture when nothing has a lane", () => {
     const graph = graphOf([collection("scene", [media("a", 4), media("b", 4)])]);
-    const model = splitLaneRows(graph, {} as DetailsById, "scene");
+    const model = splitLaneRows(graph, NO_DETAILS, "scene");
 
     expect(model.pictureIds).toEqual(["a", "b"]);
     expect(model.layers).toEqual([]);
@@ -56,7 +51,7 @@ describe("splitLaneRows", () => {
 
   it("is empty for a collection with no children", () => {
     const graph = graphOf([collection("scene", [])]);
-    expect(splitLaneRows(graph, {} as DetailsById, "scene")).toEqual({
+    expect(splitLaneRows(graph, NO_DETAILS, "scene")).toEqual({
       pictureIds: [],
       pictureTimes: [],
       layers: [],
@@ -65,9 +60,13 @@ describe("splitLaneRows", () => {
 
   it("pulls a lane-1 clip off the picture and onto its own row", () => {
     const graph = graphOf([
-      collection("scene", [media("shot1", 4), media("bed", 12), media("shot2", 4)]),
+      collection("scene", [
+        media("shot1", 4),
+        media("bed", 12, { trackIndex: 1 }),
+        media("shot2", 4),
+      ]),
     ]);
-    const model = splitLaneRows(graph, lanes({ bed: 1 }), "scene");
+    const model = splitLaneRows(graph, NO_DETAILS, "scene");
 
     expect(model.pictureIds).toEqual(["shot1", "shot2"]);
     expect(model.layers).toHaveLength(1);
@@ -81,18 +80,26 @@ describe("splitLaneRows", () => {
     // THE point of packing per lane: shot2 now follows shot1 directly instead
     // of starting after a 12s bed that no longer sits between them.
     const graph = graphOf([
-      collection("scene", [media("shot1", 4), media("bed", 12), media("shot2", 4)]),
+      collection("scene", [
+        media("shot1", 4),
+        media("bed", 12, { trackIndex: 1 }),
+        media("shot2", 4),
+      ]),
     ]);
-    const model = splitLaneRows(graph, lanes({ bed: 1 }), "scene");
+    const model = splitLaneRows(graph, NO_DETAILS, "scene");
 
     expect(model.pictureTimes[1]?.startSeconds).toBe(4 + CLIP_GAP_SECONDS);
   });
 
   it("starts every lane at the same instant, so a bed runs UNDER the picture", () => {
     const graph = graphOf([
-      collection("scene", [media("shot1", 4), media("shot2", 4), media("bed", 8)]),
+      collection("scene", [
+        media("shot1", 4),
+        media("shot2", 4),
+        media("bed", 8, { trackIndex: 1 }),
+      ]),
     ]);
-    const model = splitLaneRows(graph, lanes({ bed: 1 }), "scene");
+    const model = splitLaneRows(graph, NO_DETAILS, "scene");
 
     expect(model.pictureTimes[0]?.startSeconds).toBe(0);
     expect(model.layers[0]?.items[0]?.startSeconds).toBe(0);
@@ -100,9 +107,13 @@ describe("splitLaneRows", () => {
 
   it("packs several cards on one lane in their own sequence", () => {
     const graph = graphOf([
-      collection("scene", [media("shot", 20), media("vo1", 3), media("vo2", 3)]),
+      collection("scene", [
+        media("shot", 20),
+        media("vo1", 3, { trackIndex: 1 }),
+        media("vo2", 3, { trackIndex: 1 }),
+      ]),
     ]);
-    const model = splitLaneRows(graph, lanes({ vo1: 1, vo2: 1 }), "scene");
+    const model = splitLaneRows(graph, NO_DETAILS, "scene");
 
     expect(model.layers[0]?.items).toEqual([
       { id: "vo1", startSeconds: 0, durationSeconds: 3 },
@@ -114,9 +125,13 @@ describe("splitLaneRows", () => {
     // #400. The board's geometry already accepted an arbitrary start; this is
     // the seam that finally supplies one — a voiceover at 7.5s with nothing
     // 7.5s long in front of it.
-    const graph = graphOf([collection("scene", [media("shot", 30), media("vo", 2)])]);
-    const details: DetailsById = { vo: detail({ trackIndex: 1, placedStart: 7.5 }) };
-    const model = splitLaneRows(graph, details, "scene");
+    const graph = graphOf([
+      collection("scene", [
+        media("shot", 30),
+        media("vo", 2, { trackIndex: 1, placedStart: 7.5 }),
+      ]),
+    ]);
+    const model = splitLaneRows(graph, NO_DETAILS, "scene");
 
     expect(model.layers[0]?.items).toEqual([
       { id: "vo", startSeconds: 7.5, durationSeconds: 2 },
@@ -127,13 +142,13 @@ describe("splitLaneRows", () => {
 
   it("queues an unplaced clip behind a placed one on the same lane", () => {
     const graph = graphOf([
-      collection("scene", [media("shot", 30), media("vo", 2), media("tail", 2)]),
+      collection("scene", [
+        media("shot", 30),
+        media("vo", 2, { trackIndex: 1, placedStart: 7.5 }),
+        media("tail", 2, { trackIndex: 1 }),
+      ]),
     ]);
-    const details: DetailsById = {
-      vo: detail({ trackIndex: 1, placedStart: 7.5 }),
-      tail: detail({ trackIndex: 1 }),
-    };
-    const model = splitLaneRows(graph, details, "scene");
+    const model = splitLaneRows(graph, NO_DETAILS, "scene");
 
     expect(model.layers[0]?.items.map((item) => item.startSeconds)).toEqual([
       7.5,
@@ -143,9 +158,13 @@ describe("splitLaneRows", () => {
 
   it("gives each occupied lane its own row, in ascending order", () => {
     const graph = graphOf([
-      collection("scene", [media("shot", 10), media("music", 10), media("vo", 4)]),
+      collection("scene", [
+        media("shot", 10),
+        media("music", 10, { trackIndex: 1 }),
+        media("vo", 4, { trackIndex: 2 }),
+      ]),
     ]);
-    const model = splitLaneRows(graph, lanes({ vo: 2, music: 1 }), "scene");
+    const model = splitLaneRows(graph, NO_DETAILS, "scene");
 
     expect(model.layers.map((layer) => layer.lane)).toEqual([1, 2]);
     expect(model.layers[0]?.items[0]?.id).toBe("music");
@@ -155,8 +174,10 @@ describe("splitLaneRows", () => {
   it("skips unoccupied lanes rather than reserving a row for each", () => {
     // set_lane accepts any non-negative integer; reserving would draw fifty
     // rows for one clip. The chip still names the real lane.
-    const graph = graphOf([collection("scene", [media("shot", 10), media("bed", 10)])]);
-    const model = splitLaneRows(graph, lanes({ bed: 50 }), "scene");
+    const graph = graphOf([
+      collection("scene", [media("shot", 10), media("bed", 10, { trackIndex: 50 })]),
+    ]);
+    const model = splitLaneRows(graph, NO_DETAILS, "scene");
 
     expect(model.layers).toHaveLength(1);
     expect(model.layers[0]?.lane).toBe(50);
@@ -164,9 +185,13 @@ describe("splitLaneRows", () => {
 
   it("treats a fractional or negative lane as the picture", () => {
     const graph = graphOf([
-      collection("scene", [media("a", 4), media("b", 4), media("c", 4)]),
+      collection("scene", [
+        media("a", 4),
+        media("b", 4, { trackIndex: 1.5 }),
+        media("c", 4, { trackIndex: -1 }),
+      ]),
     ]);
-    const model = splitLaneRows(graph, lanes({ b: 1.5, c: -1 }), "scene");
+    const model = splitLaneRows(graph, NO_DETAILS, "scene");
 
     expect(model.pictureIds).toEqual(["a", "b", "c"]);
     expect(model.layers).toEqual([]);
@@ -176,16 +201,14 @@ describe("splitLaneRows", () => {
     const graph = graphOf([
       collection("scene", [
         collection("inner", [media("x", 5), media("y", 5)]),
-        media("bed", 20),
+        media("bed", 20, { trackIndex: 1 }),
       ]),
     ]);
     // `hydrated` is what makes a collection derive its span from live
     // children rather than the stored summary — the board's normal state
-    // once a collection's contents have arrived.
-    const details: DetailsById = {
-      inner: detail({ hydrated: true }),
-      bed: detail({ trackIndex: 1 }),
-    };
+    // once a collection's contents have arrived. It is still a DETAIL: the
+    // engine does not model hydration, only lane and placement moved.
+    const details: DetailsById = { inner: detail({ hydrated: true }) };
     const model = splitLaneRows(graph, details, "scene");
 
     expect(model.pictureIds).toEqual(["inner"]);

--- a/apps/timeline-gstudio001/components/graph-view/graph-native-drop-engine.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-native-drop-engine.ts
@@ -248,7 +248,6 @@ export function useNativeDrop(collectionId: string, projectId: string) {
                 detail: {
                   alt: file.name,
                   aspect: 16 / 9,
-                  trackIndex: 0,
                   poster: hosted.thumbnailUrl,
                   ...(sourceAsset === undefined ? {} : { sourceAsset }),
                 },
@@ -268,7 +267,6 @@ export function useNativeDrop(collectionId: string, projectId: string) {
               detail: {
                 alt: file.name,
                 aspect: 16 / 9,
-                trackIndex: 0,
                 sourceDuration: IMAGE_CLIP_SECONDS,
                 trimIn: 0,
                 trimOut: 0,

--- a/apps/timeline-gstudio001/components/graph-view/graph-native-drop-insertion.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-native-drop-insertion.ts
@@ -74,7 +74,6 @@ export function useToolInsertion(collectionId: string) {
       parkPendingDetail(childId, {
         alt: "New Timeline collection",
         aspect: 16 / 9,
-        trackIndex: 0,
         itemCount: 0,
         duration: 3,
         sourceDuration: 3,

--- a/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playhead-model.test.ts
@@ -28,12 +28,18 @@ import {
 } from "./graph-playhead-model";
 import { at } from "../../lib/test-support/at";
 
-const media = (id: string, durationSeconds: number): GraphNodeSpec => ({
-  kind: "media",
-  id,
-  name: id,
-  durationSeconds,
-});
+const media = (
+  id: string,
+  durationSeconds: number,
+  over: Partial<GraphNodeSpec> = {},
+): GraphNodeSpec =>
+  ({
+    kind: "media",
+    id,
+    name: id,
+    durationSeconds,
+    ...over,
+  }) as GraphNodeSpec;
 
 const collection = (
   id: string,
@@ -45,13 +51,6 @@ function graphOf(roots: readonly GraphNodeSpec[]) {
   if (!result.ok) throw new Error(JSON.stringify(result.error));
   return result.value;
 }
-
-/** A side-table entry that puts a clip on a lane above the picture. */
-const laneDetail = (trackIndex: number): ClipDetail => ({
-  alt: "",
-  aspect: 16 / 9,
-  trackIndex,
-});
 
 /** Packing sums 0.12s gaps, so exact equality trips on binary float error. */
 const round = (value: number) => Math.round(value * 100) / 100;
@@ -131,11 +130,14 @@ describe("childSpans", () => {
     // a sub-timeline row, the header readout) must keep every clip or its
     // index pairing shifts, and that failure is silent.
     const graph = graphOf([
-      collection("root", [media("shot1", 4), media("bed", 12), media("shot2", 4)]),
+      collection("root", [
+        media("shot1", 4),
+        media("bed", 12, { trackIndex: 1 }),
+        media("shot2", 4),
+      ]),
     ]);
-    const details = { bed: laneDetail(1) };
 
-    const cards = childSpans(graph, details, "root", null, flatWidth, "picture");
+    const cards = childSpans(graph, {}, "root", null, flatWidth, "picture");
 
     expect(cards.map((card) => [round(card.startTime), round(card.endTime)])).toEqual([
       [0, 4],
@@ -147,11 +149,14 @@ describe("childSpans", () => {
     // One card per child is the default precisely because the grid and the
     // sub-timeline rows pair cards to cells by INDEX.
     const graph = graphOf([
-      collection("root", [media("shot1", 4), media("bed", 12), media("shot2", 4)]),
+      collection("root", [
+        media("shot1", 4),
+        media("bed", 12, { trackIndex: 1 }),
+        media("shot2", 4),
+      ]),
     ]);
-    const details = { bed: laneDetail(1) };
 
-    const cards = childSpans(graph, details, "root", null, flatWidth);
+    const cards = childSpans(graph, {}, "root", null, flatWidth);
 
     // The bed starts at ZERO — alongside the picture, not after it. The clamp
     // is per lane now, so lane 0's running end cannot reach across and move it.

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-config.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-config.ts
@@ -164,7 +164,6 @@ export const MAX_SUBTREE_DEPTH = 12;
 export const FALLBACK_DETAIL: ClipDetail = {
   alt: "",
   aspect: 16 / 9,
-  trackIndex: 0,
 };
 
 /**

--- a/apps/timeline-gstudio001/components/graph-view/graph-waveform-model.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-waveform-model.ts
@@ -85,7 +85,7 @@ export function waveformSourcesFor(
   // the strip's own row and so drops anything on a lane. A lane row's own
   // waveform is a separate band this does not draw yet.
   return getChildren(graph, parseNodeId(focusedId)).flatMap((childId) =>
-    trackIndexOf({ trackIndex: details[childId as string]?.trackIndex ?? 0 }) === 0
+    trackIndexOf({ trackIndex: graph.nodesById.get(childId)?.trackIndex ?? 0 }) === 0
       ? [sourceForNode(graph, details, childId as string)]
       : [],
   );

--- a/apps/timeline-gstudio001/lib/graph-details-store.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-details-store.test.ts
@@ -12,7 +12,7 @@ import type { ClipDetail } from "@storyboard/timeline-domain";
 import { collectReachableDetailIds, createGraphDetailsStore } from "./graph-details-store";
 
 function detail(alt: string): ClipDetail {
-  return { alt, aspect: 16 / 9, trackIndex: 0 };
+  return { alt, aspect: 16 / 9 };
 }
 
 describe("createGraphDetailsStore", () => {

--- a/apps/timeline-gstudio001/lib/graph-node-clone.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-node-clone.test.ts
@@ -73,7 +73,6 @@ describe("cloneNodeForInsert: media", () => {
     const detail: ClipDetail = {
       alt: "Pic",
       aspect: 16 / 9,
-      trackIndex: 0,
       // Must be dropped: reusing it would collide with the source clip.
       sourceClipId: "m1",
     };
@@ -101,7 +100,6 @@ describe("cloneNodeForInsert: collection deep clone", () => {
   const detail: ClipDetail = {
     alt: "Root",
     aspect: 16 / 9,
-    trackIndex: 0,
     itemCount: 2,
     duration: 10,
     hydrated: false,
@@ -206,7 +204,6 @@ describe("cloneNodeForInsert: collection deep clone", () => {
     const refDetail: ClipDetail = {
       alt: "Ref",
       aspect: 16 / 9,
-      trackIndex: 0,
       hydrated: false,
       duplicateOfTimelineId: "S",
     };

--- a/apps/timeline-gstudio001/lib/mcp/write-handlers.ts
+++ b/apps/timeline-gstudio001/lib/mcp/write-handlers.ts
@@ -492,26 +492,26 @@ export async function handleSetLane(
           message: `"${args.nodeId}" is a timeline itself, not a clip inside one — no lane to put it on.`,
         } as const;
       }
-      const existing = details[nodeId as string];
-
-      // The parent and everything above it: a lane change can shorten or
-      // lengthen the parent, which every ancestor stores a duration for.
-      const affected: string[] = [];
-      let current: NodeId | null = parentId;
-      while (current !== null && !affected.includes(current as string)) {
-        affected.push(current as string);
-        current = graph.parentById.get(current) ?? null;
-      }
-
+      // ONE COMMAND. The ancestor write set comes from the patch now —
+      // `collectAffectedCollectionIds` walks them for `nodes-updated`, which
+      // is exactly the rule the hand-rolled walk here implemented: a lane
+      // change moves the parent's span, and every ancestor stores a duration
+      // for it. And because it is a command, it is undoable.
+      //
+      // Lane 0 CLEARS the field rather than storing a 0 — absence is the
+      // picture, everywhere else in the model. It clears the placement too:
+      // the picture is a cut, so a placed start there means nothing, and
+      // leaving a stale one would resurface if the clip returned to a lane.
       return {
         ok: true,
-        // Spread the WHOLE existing entry — `graphChildrenToClips` rebuilds the
-        // clip from this record, so dropping `sourceAsset`, `poster` or `alt`
-        // here would erase them from the stored clip on save.
-        details: {
-          [nodeId as string]: { ...existing, trackIndex: args.lane } as DetailsById[string],
+        command: {
+          type: "set-node-placement",
+          nodeIds: [nodeId],
+          placement:
+            args.lane === 0
+              ? { trackIndex: null, placedStart: null }
+              : { trackIndex: args.lane },
         },
-        affectedCollectionIds: affected,
       } as const;
     },
     ctx.requesterUid,
@@ -582,8 +582,8 @@ export async function handleSetStart(
           message: `"${args.nodeId}" is a timeline itself, not a clip inside one — nothing to place.`,
         } as const;
       }
-      const existing = details[nodeId as string];
-      const lane = trackIndexOf({ trackIndex: existing?.trackIndex ?? 0 });
+      // From the NODE — lane and placement are engine-carried now.
+      const lane = trackIndexOf({ trackIndex: graph.nodesById.get(nodeId)?.trackIndex ?? 0 });
       if (lane === 0) {
         return {
           ok: false,
@@ -603,7 +603,9 @@ export async function handleSetStart(
           ? { lane, bumped: false }
           : resolvePlacement(
               graphChildrenToClips(graph, details, parentId as string),
-              existing?.sourceClipId ?? (nodeId as string),
+              // The projection reports a demoted duplicate under its STORED
+              // clip id, so match on that where there is one.
+              details[nodeId as string]?.sourceClipId ?? (nodeId as string),
               lane,
               start,
             );
@@ -611,30 +613,21 @@ export async function handleSetStart(
       landedLane = placement.lane;
       wasBumped = placement.bumped;
 
-      // The parent and everything above it: a placement can lengthen or
-      // shorten the parent, which every ancestor stores a duration for.
-      const affected: string[] = [];
-      let current: NodeId | null = parentId;
-      while (current !== null && !affected.includes(current as string)) {
-        affected.push(current as string);
-        current = graph.parentById.get(current) ?? null;
-      }
-
-      // Spread the WHOLE existing entry, as `set_lane` does: the clip is
-      // rebuilt from this record, so omitting a field erases it on save.
-      // `placedStart` is dropped entirely when re-queuing — absence IS the
-      // "queued" state, and writing a sentinel would be a second way to say it.
-      const { placedStart: _dropped, ...rest } = existing ?? {};
-      const next = {
-        ...rest,
-        trackIndex: placement.lane,
-        ...(start === null ? {} : { placedStart: start }),
-      } as DetailsById[string];
-
+      // ONE COMMAND, so the change rides the patch path: it lands in undo
+      // history, and `collectAffectedCollectionIds` walks the ancestors a
+      // `nodes-updated` patch implies — which is the same write set the
+      // hand-rolled walk here used to compute, for the same reason (a
+      // placement moves the parent's span, and every ancestor stores a
+      // duration for it).
+      //
+      // `null` CLEARS the placement, because absence IS the queued state.
       return {
         ok: true,
-        details: { [nodeId as string]: next },
-        affectedCollectionIds: affected,
+        command: {
+          type: "set-node-placement",
+          nodeIds: [nodeId],
+          placement: { trackIndex: placement.lane, placedStart: start },
+        },
       } as const;
     },
     ctx.requesterUid,

--- a/apps/timeline-gstudio001/lib/tag-write-plan.test.ts
+++ b/apps/timeline-gstudio001/lib/tag-write-plan.test.ts
@@ -32,16 +32,15 @@ const graph = (() => {
 })();
 
 const details: DetailsById = {
-  root: { alt: "Root", aspect: 16 / 9, trackIndex: 0, hydrated: true },
+  root: { alt: "Root", aspect: 16 / 9, hydrated: true },
   "clip-a": {
     alt: "A",
     aspect: 16 / 9,
-    trackIndex: 0,
     poster: "https://example.test/a.jpg",
     sourceAsset: { providerId: "cloudinary", assetId: "x/a" },
   },
-  inner: { alt: "Inner", aspect: 16 / 9, trackIndex: 0, hydrated: true },
-  "clip-b": { alt: "B", aspect: 16 / 9, trackIndex: 0, tags: ["old"] },
+  inner: { alt: "Inner", aspect: 16 / 9, hydrated: true },
+  "clip-b": { alt: "B", aspect: 16 / 9, tags: ["old"] },
 };
 
 function plan(nodeId: string, tags: string[]): TagWritePlan {

--- a/packages/collections-core/commands.test.ts
+++ b/packages/collections-core/commands.test.ts
@@ -720,6 +720,152 @@ describe("patch inversion round-trips", () => {
   });
 });
 
+describe("set-node-placement", () => {
+  const nodeOf = (graph: CollectionsGraph, id: string) => graph.nodesById.get(parseNodeId(id))!;
+
+  test("sets a lane and a start on media and on collections, leaving structure alone", () => {
+    // A whole nested scene under the picture is a legitimate layer, so a
+    // collection has to be placeable too.
+    for (const target of ["A", "F"]) {
+      const graph = fixture();
+      const result = applyCommand(graph, {
+        type: "set-node-placement",
+        nodeIds: [parseNodeId(target)],
+        placement: { trackIndex: 1, placedStart: 7.5 },
+      });
+      if (!result.ok) throw new Error(JSON.stringify(result.error));
+      expect(nodeOf(result.value.graph, target).trackIndex).toBe(1);
+      expect(nodeOf(result.value.graph, target).placedStart).toBe(7.5);
+      for (const [id] of graph.childrenById) {
+        expect([...getChildren(result.value.graph, id)]).toEqual([...getChildren(graph, id)]);
+      }
+      expect(findGraphInvariantViolation(result.value.graph)).toBeNull();
+    }
+  });
+
+  test("an omitted field is LEFT ALONE, so a lane change cannot un-place a clip", () => {
+    const placed = applyCommand(fixture(), {
+      type: "set-node-placement",
+      nodeIds: [parseNodeId("A")],
+      placement: { trackIndex: 1, placedStart: 7.5 },
+    });
+    if (!placed.ok) throw new Error("expected ok");
+
+    const moved = applyCommand(placed.value.graph, {
+      type: "set-node-placement",
+      nodeIds: [parseNodeId("A")],
+      placement: { trackIndex: 2 },
+    });
+    if (!moved.ok) throw new Error("expected ok");
+    expect(nodeOf(moved.value.graph, "A").trackIndex).toBe(2);
+    expect(nodeOf(moved.value.graph, "A").placedStart).toBe(7.5);
+  });
+
+  test("null CLEARS a field, deleting the key rather than writing 0", () => {
+    const placed = applyCommand(fixture(), {
+      type: "set-node-placement",
+      nodeIds: [parseNodeId("A")],
+      placement: { trackIndex: 1, placedStart: 7.5 },
+    });
+    if (!placed.ok) throw new Error("expected ok");
+
+    const cleared = applyCommand(placed.value.graph, {
+      type: "set-node-placement",
+      nodeIds: [parseNodeId("A")],
+      placement: { placedStart: null },
+    });
+    if (!cleared.ok) throw new Error("expected ok");
+    // Absence IS the queued state; a 0 would mean "placed at the very start".
+    expect("placedStart" in nodeOf(cleared.value.graph, "A")).toBe(false);
+    expect(nodeOf(cleared.value.graph, "A").trackIndex).toBe(1);
+  });
+
+  test("a no-op change is refused, so it never enters history", () => {
+    const noop = applyCommand(fixture(), {
+      type: "set-node-placement",
+      nodeIds: [parseNodeId("A")],
+      placement: { placedStart: null },
+    });
+    expect(noop.ok).toBe(false);
+    if (!noop.ok) expect(noop.error.reason).toBe("same-position");
+  });
+
+  test("a missing node is refused", () => {
+    const result = applyCommand(fixture(), {
+      type: "set-node-placement",
+      nodeIds: [parseNodeId("nope")],
+      placement: { trackIndex: 1 },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.reason).toBe("missing-node");
+  });
+
+  test("a non-finite value is refused rather than stored", () => {
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY]) {
+      const result = applyCommand(fixture(), {
+        type: "set-node-placement",
+        nodeIds: [parseNodeId("A")],
+        placement: { placedStart: bad },
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.reason).toBe("invalid-placement");
+    }
+  });
+
+  test("UNDO restores the previous placement — the whole point of the command", () => {
+    // Lane and placement used to live in a consumer side-table, where a change
+    // emitted no patch and could not be undone at all.
+    const placed = applyCommand(fixture(), {
+      type: "set-node-placement",
+      nodeIds: [parseNodeId("A")],
+      placement: { trackIndex: 1, placedStart: 7.5 },
+    });
+    if (!placed.ok) throw new Error("expected ok");
+
+    const undone = applyPatch(placed.value.graph, invertPatch(placed.value.patch));
+    expect("trackIndex" in nodeOf(undone, "A")).toBe(false);
+    expect("placedStart" in nodeOf(undone, "A")).toBe(false);
+
+    const redone = applyPatch(undone, placed.value.patch);
+    expect(nodeOf(redone, "A").trackIndex).toBe(1);
+    expect(nodeOf(redone, "A").placedStart).toBe(7.5);
+  });
+
+  test("a whole selection is placed in ONE patch, and comes back in one undo", () => {
+    const graph = fixture();
+    const result = applyCommand(graph, {
+      type: "set-node-placement",
+      nodeIds: ids(["A", "B"]),
+      placement: { trackIndex: 1 },
+    });
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.value.patch.type).toBe("nodes-updated");
+
+    const undone = applyPatch(result.value.graph, invertPatch(result.value.patch));
+    for (const id of ["A", "B"]) expect("trackIndex" in nodeOf(undone, id)).toBe(false);
+  });
+
+  test("a repeated id contributes one update, so the patch stays reversible", () => {
+    const result = applyCommand(fixture(), {
+      type: "set-node-placement",
+      nodeIds: ids(["A", "A"]),
+      placement: { trackIndex: 1 },
+    });
+    if (!result.ok) throw new Error("expected ok");
+    if (result.value.patch.type !== "nodes-updated") throw new Error("expected nodes-updated");
+    expect(result.value.patch.updates).toHaveLength(1);
+  });
+
+  test("an empty batch is refused", () => {
+    const result = applyCommand(fixture(), {
+      type: "set-node-placement",
+      nodeIds: [],
+      placement: { trackIndex: 1 },
+    });
+    expect(result.ok).toBe(false);
+  });
+});
+
 describe("set-node-disabled", () => {
   const nodeOf = (graph: CollectionsGraph, id: string) => graph.nodesById.get(parseNodeId(id))!;
 

--- a/packages/collections-core/commands.ts
+++ b/packages/collections-core/commands.ts
@@ -108,6 +108,31 @@ export type CollectionsCommand =
        *  One decision for the whole batch — a mixed selection resolves to a
        *  single target state rather than each item flipping its own way. */
       disabled: boolean;
+    }>
+  | Readonly<{
+      type: "set-node-placement";
+      /**
+       * Any nodes — media or collection. Structure is untouched.
+       *
+       * A LIST for the same reason `set-node-disabled` is one: moving a
+       * multi-selection onto a lane is ONE user action, and per-node dispatch
+       * would give it N history entries to undo one at a time.
+       */
+      nodeIds: readonly NodeId[];
+      /**
+       * Which lane, and where on it. `undefined` LEAVES A FIELD ALONE; null
+       * CLEARS it back to the default. The two are distinct because the common
+       * drag sets both while a lane change on its own must not silently
+       * un-place a clip.
+       *
+       * The engine stores these and never reads them — see the note on
+       * `ImageMediaNode`. It is the consumer that decides what lane 0 means
+       * and how a placed start packs.
+       */
+      placement: Readonly<{
+        trackIndex?: number | null;
+        placedStart?: number | null;
+      }>;
     }>;
 
 export type CommandRejection =
@@ -128,6 +153,8 @@ export type CommandRejection =
   | Readonly<{ reason: "not-media-node"; nodeId: NodeId }>
   /** `rename-node` was given a blank name. */
   | Readonly<{ reason: "invalid-node-name"; nodeId: NodeId }>
+  /** `set-node-placement` was given a non-finite lane or start. */
+  | Readonly<{ reason: "invalid-placement"; nodeId: NodeId }>
   /** `update-media`'s payload doesn't match the node's mediaKind, or carries non-finite values. */
   | Readonly<{ reason: "invalid-media-update"; nodeId: NodeId }>
   | Readonly<{ reason: "nothing-to-move" }>
@@ -158,6 +185,9 @@ export function applyCommand(
   }
   if (command.type === "set-node-disabled") {
     return applySetDisabled(graph, command.nodeIds, command.disabled);
+  }
+  if (command.type === "set-node-placement") {
+    return applySetPlacement(graph, command.nodeIds, command.placement);
   }
   if (command.type === "rename-node") {
     return applyRename(graph, command.nodeId, command.name);
@@ -446,6 +476,72 @@ function applySetDisabled(
       after = rest as CollectionItemNode;
     }
     updates.push({ nodeId, before: node, after });
+  }
+
+  if (updates.length === 0) return { ok: false, error: { reason: "same-position" } };
+
+  const patch: CollectionsPatch = { type: "nodes-updated", updates };
+  return { ok: true, value: { graph: applyPatch(graph, patch), patch } };
+}
+
+/**
+ * Set the lane and/or the placed start of a batch of nodes.
+ *
+ * Deliberately the same shape as `applySetDisabled`, because it is the same
+ * kind of change: a DOMAIN fact the engine carries and never interprets,
+ * emitted as `nodes-updated` so it rides the patch path — which is what makes
+ * undo and redo work on it for free, since that patch already inverts by
+ * swapping before/after.
+ *
+ * `undefined` leaves a field untouched; `null` clears it. Only actual changes
+ * become updates, so a batch that asks for what is already true is a no-op
+ * rather than a history entry.
+ */
+function applySetPlacement(
+  graph: CollectionsGraph,
+  nodeIds: readonly NodeId[],
+  placement: Readonly<{ trackIndex?: number | null; placedStart?: number | null }>
+): Result<ApplyCommandSuccess, CommandRejection> {
+  if (nodeIds.length === 0) return { ok: false, error: { reason: "nothing-to-add" } };
+
+  const updates: { nodeId: NodeId; before: CollectionItemNode; after: CollectionItemNode }[] = [];
+  const seen = new Set<NodeId>();
+  for (const nodeId of nodeIds) {
+    // A repeated id would emit two updates for one node, and the second's
+    // `before` would already be the first's `after` — an unreversible patch.
+    if (seen.has(nodeId)) continue;
+    seen.add(nodeId);
+    const node = graph.nodesById.get(nodeId);
+    // A MISSING node is still an error: the caller named something that does
+    // not exist, and silently skipping it would hide a real bug.
+    if (!node) return { ok: false, error: { reason: "missing-node", nodeId } };
+
+    const next: Record<string, unknown> = { ...node };
+    let changed = false;
+    for (const field of ["trackIndex", "placedStart"] as const) {
+      const wanted = placement[field];
+      if (wanted === undefined) continue;
+      const current = node[field];
+      if (wanted === null) {
+        if (current === undefined) continue;
+        delete next[field];
+        changed = true;
+        continue;
+      }
+      // A non-finite value would be stored verbatim and read back as a
+      // placement nobody can express — rejected rather than silently dropped,
+      // because unlike hydration this is a caller naming a value.
+      if (!Number.isFinite(wanted)) {
+        return { ok: false, error: { reason: "invalid-placement", nodeId } };
+      }
+      if (current === wanted) continue;
+      next[field] = wanted;
+      changed = true;
+    }
+    // A node already in the target state contributes nothing. Skipped rather
+    // than rejected, so placing a partly-placed selection still works.
+    if (!changed) continue;
+    updates.push({ nodeId, before: node, after: next as CollectionItemNode });
   }
 
   if (updates.length === 0) return { ok: false, error: { reason: "same-position" } };

--- a/packages/collections-core/graph.ts
+++ b/packages/collections-core/graph.ts
@@ -57,6 +57,28 @@ export type ImageMediaNode = Readonly<{
    * re-enabling removes the key rather than writing `false`.
    */
   disabled?: boolean;
+  /**
+   * WHICH LANE this plays on, and WHERE on it — the same kind of fact as
+   * `disabled`, carried here for the same reason.
+   *
+   * Lane 0 is the picture; anything above runs underneath it at the same
+   * time. `placedStart` is an explicit start on that lane, in seconds;
+   * absent means "queue behind the clip before it", which is what every
+   * document did before placement existed.
+   *
+   * THE ENGINE NEVER INTERPRETS EITHER. It does not pack, it does not know
+   * what a second is, and a node with a lane moves, trims and reorders
+   * exactly like one without. They live on the node rather than in a
+   * consumer's side-table for one reason: they are changed by a COMMAND
+   * (`set-node-placement`), so they ride the patch path and undo/redo work
+   * on them. The rule is "does the engine mutate it", not "does the engine
+   * understand it".
+   *
+   * Absent means the default in both cases; clearing removes the key rather
+   * than writing 0, so documents that never use lanes never grow the fields.
+   */
+  trackIndex?: number;
+  placedStart?: number;
 }>;
 
 export type VideoMediaNode = Readonly<{
@@ -88,6 +110,9 @@ export type VideoMediaNode = Readonly<{
    * re-enabling removes the key rather than writing `false`.
    */
   disabled?: boolean;
+  /** See ImageMediaNode — lane and placement, carried not interpreted. */
+  trackIndex?: number;
+  placedStart?: number;
 }>;
 
 /**
@@ -122,6 +147,9 @@ export type AudioMediaNode = Readonly<{
   /** Seconds trimmed off the END. 0 = untrimmed. */
   trimOutSeconds: number;
   disabled?: boolean;
+  /** See ImageMediaNode — lane and placement, carried not interpreted. */
+  trackIndex?: number;
+  placedStart?: number;
 }>;
 
 export type MediaNode = ImageMediaNode | VideoMediaNode | AudioMediaNode;
@@ -139,6 +167,11 @@ export type CollectionNode = Readonly<{
    * re-enabling removes the key rather than writing `false`.
    */
   disabled?: boolean;
+  /** See ImageMediaNode — lane and placement, carried not interpreted. A
+   *  COLLECTION can sit on a lane too: a whole nested scene under the
+   *  picture is a legitimate layer. */
+  trackIndex?: number;
+  placedStart?: number;
 }>;
 
 export type CollectionItemNode = MediaNode | CollectionNode;
@@ -228,6 +261,8 @@ export type GraphNodeSpec =
       src?: string;
       durationSeconds?: number; // default 4
       disabled?: boolean;
+      trackIndex?: number;
+      placedStart?: number;
     }>
   | Readonly<{
       kind: "media";
@@ -240,6 +275,8 @@ export type GraphNodeSpec =
       trimInSeconds?: number; // default 0
       trimOutSeconds?: number; // default 0
       disabled?: boolean;
+      trackIndex?: number;
+      placedStart?: number;
     }>
   | Readonly<{
       kind: "media";
@@ -251,6 +288,8 @@ export type GraphNodeSpec =
       trimInSeconds?: number; // default 0
       trimOutSeconds?: number; // default 0
       disabled?: boolean;
+      trackIndex?: number;
+      placedStart?: number;
     }>
   | Readonly<{
       kind: "collection";
@@ -258,6 +297,8 @@ export type GraphNodeSpec =
       name: string;
       children?: readonly GraphNodeSpec[];
       disabled?: boolean;
+      trackIndex?: number;
+      placedStart?: number;
     }>;
 
 /** A media spec, i.e. every member of GraphNodeSpec that is not a collection. */
@@ -274,8 +315,32 @@ type MediaNodeSpec = Extract<GraphNodeSpec, { kind: "media" }>;
  * hold, and adding a fourth kind is a compile error rather than a silent
  * coercion.
  */
+/**
+ * The lane/placement fields, kept only when they are real numbers.
+ *
+ * DROPS rather than rejects. A stored document may legitimately carry a
+ * fractional lane — the timeline model's own validator admits any finite
+ * number there and normalises at read time — so rejecting the node would fail
+ * to hydrate a document that works today. Absent is the default for both, and
+ * the engine never reads either value, so dropping is lossless as far as the
+ * graph is concerned.
+ */
+function placementOf(
+  spec: Readonly<{ trackIndex?: unknown; placedStart?: unknown }>,
+): Readonly<{ trackIndex?: number; placedStart?: number }> {
+  const lane = spec.trackIndex;
+  const start = spec.placedStart;
+  return {
+    ...(typeof lane === "number" && Number.isFinite(lane) ? { trackIndex: lane } : {}),
+    ...(typeof start === "number" && Number.isFinite(start) && start >= 0
+      ? { placedStart: start }
+      : {}),
+  };
+}
+
 function mediaNodeFromSpec(id: NodeId, spec: MediaNodeSpec): MediaNode {
   const disabled = spec.disabled ? { disabled: true as const } : {};
+  const placement = placementOf(spec);
   switch (spec.mediaKind) {
     case "video":
       return {
@@ -291,6 +356,7 @@ function mediaNodeFromSpec(id: NodeId, spec: MediaNodeSpec): MediaNode {
         trimInSeconds: spec.trimInSeconds ?? 0,
         trimOutSeconds: spec.trimOutSeconds ?? 0,
         ...disabled,
+        ...placement,
       };
     case "audio":
       return {
@@ -303,6 +369,7 @@ function mediaNodeFromSpec(id: NodeId, spec: MediaNodeSpec): MediaNode {
         trimInSeconds: spec.trimInSeconds ?? 0,
         trimOutSeconds: spec.trimOutSeconds ?? 0,
         ...disabled,
+        ...placement,
       };
     case "image":
     case undefined:
@@ -314,6 +381,7 @@ function mediaNodeFromSpec(id: NodeId, spec: MediaNodeSpec): MediaNode {
         src: spec.src,
         durationSeconds: spec.durationSeconds ?? 4,
         ...disabled,
+        ...placement,
       };
     default: {
       // A new media kind reaches here as a build error, not as an image.
@@ -383,6 +451,7 @@ export function buildGraph(
         kind: "collection",
         name: spec.name,
         ...(spec.disabled ? { disabled: true } : {}),
+        ...placementOf(spec),
       });
       const children = spec.children ?? [];
       childrenById.set(id, children.map((child) => child.id as NodeId));
@@ -728,7 +797,13 @@ export function parseCollectionItemNode(
   if (value.kind === "collection") {
     return {
       ok: true,
-      value: { id, kind: "collection", name, ...(value.disabled ? { disabled: true } : {}) },
+      value: {
+        id,
+        kind: "collection",
+        name,
+        ...(value.disabled ? { disabled: true } : {}),
+        ...placementOf(value),
+      },
     };
   }
 
@@ -745,6 +820,7 @@ export function parseCollectionItemNode(
     name,
     src: value.src as string | undefined,
     ...(value.disabled ? { disabled: true } : {}),
+    ...placementOf(value),
   } as const;
   const spec: MediaNodeSpec =
     value.mediaKind === "video"

--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -64,13 +64,10 @@ export type ClipDetail = Readonly<{
    *  at all, so "" and undefined are not interchangeable here. */
   title?: string;
   aspect: number;
-  trackIndex: number;
-  /** Where the author placed this clip on its lane, when they placed it —
-   *  see `TimelineItemBase.placedStart`. Rides the side table for the same
-   *  reason `trackIndex` does: the collections engine models neither lanes
-   *  nor time, so there is no graph command that could carry it. Absent
-   *  means queued; ignored on lane 0. */
-  placedStart?: number;
+  // NO trackIndex / placedStart. They live on the NODE now — see
+  // `placementSpec`. The engine mutates them through `set-node-placement`,
+  // which is what makes a lane change undoable, and the side-table is for
+  // fields the engine never touches.
   poster?: string;
   playbackStartTime?: number;
   playbackDuration?: number;
@@ -130,6 +127,27 @@ type BuildContext = {
   used: Set<string>;
 };
 
+/**
+ * Lane and placement, for the NODE spec.
+ *
+ * These moved off the detail side-table and onto the node when they became a
+ * command (`set-node-placement`), which is what makes them undoable. The rule
+ * the side-table follows is "does the ENGINE MUTATE it" — not "does the engine
+ * understand it" — and the engine now mutates these, so they belong here
+ * beside `disabled`, which is the same kind of fact for the same reason.
+ *
+ * The STORED clip is unchanged: both fields were already clip fields, so this
+ * only reroutes which side of the seam carries them. No data migration.
+ */
+function placementSpec(
+  clip: Pick<TimelineClip, "trackIndex" | "placedStart">,
+): Readonly<{ trackIndex?: number; placedStart?: number }> {
+  return {
+    ...(clip.trackIndex === undefined ? {} : { trackIndex: clip.trackIndex }),
+    ...(clip.placedStart === undefined ? {} : { placedStart: clip.placedStart }),
+  };
+}
+
 function mediaSpec(clip: Exclude<TimelineClip, CollectionTimelineClip>): GraphNodeSpec {
   if (clip.kind === "video") {
     return {
@@ -143,6 +161,7 @@ function mediaSpec(clip: Exclude<TimelineClip, CollectionTimelineClip>): GraphNo
       trimInSeconds: clip.trimIn,
       trimOutSeconds: clip.trimOut,
       ...(clip.disabled ? { disabled: true } : {}),
+      ...placementSpec(clip),
     };
   }
   if (clip.kind === "audio") {
@@ -160,6 +179,7 @@ function mediaSpec(clip: Exclude<TimelineClip, CollectionTimelineClip>): GraphNo
       trimInSeconds: clip.trimIn,
       trimOutSeconds: clip.trimOut,
       ...(clip.disabled ? { disabled: true } : {}),
+      ...placementSpec(clip),
     };
   }
   return {
@@ -169,6 +189,7 @@ function mediaSpec(clip: Exclude<TimelineClip, CollectionTimelineClip>): GraphNo
     src: clip.src,
     durationSeconds: clip.duration,
     ...(clip.disabled ? { disabled: true } : {}),
+    ...placementSpec(clip),
   };
 }
 
@@ -177,11 +198,6 @@ function mediaDetail(clip: Exclude<TimelineClip, CollectionTimelineClip>): ClipD
     alt: clip.alt,
     ...(clip.title === undefined ? {} : { title: clip.title }),
     aspect: clip.aspect,
-    trackIndex: clip.trackIndex,
-    // Captured INBOUND as well as written back out: without this a stored
-    // placement is lost the moment the document is hydrated into a graph, and
-    // the clip silently rejoins its lane's queue on the next save.
-    ...(clip.placedStart === undefined ? {} : { placedStart: clip.placedStart }),
     ...(clip.poster === undefined ? {} : { poster: clip.poster }),
     ...(clip.sourceAsset === undefined ? {} : { sourceAsset: clip.sourceAsset }),
     ...tagsField(clip.tags),
@@ -199,8 +215,6 @@ function collectionDetail(clip: CollectionTimelineClip, hydrated: boolean): Clip
   return {
     alt: clip.alt,
     aspect: clip.aspect,
-    trackIndex: clip.trackIndex,
-    ...(clip.placedStart === undefined ? {} : { placedStart: clip.placedStart }),
     ...tagsField(clip.tags),
     ...(clip.trashedAt === undefined ? {} : { trashedAt: clip.trashedAt }),
     ...(clip.trashedFrom === undefined ? {} : { trashedFrom: clip.trashedFrom }),
@@ -693,11 +707,12 @@ export function graphChildrenToClips(
     const node = graph.nodesById.get(childId);
     if (!node) throw new Error(`Graph child "${childId}" missing from nodesById.`);
     const detail = details[childId];
-    const trackIndex = trackIndexOf({ trackIndex: detail?.trackIndex ?? 0 });
+    // From the NODE, not the detail: these are engine-carried now.
+    const trackIndex = trackIndexOf({ trackIndex: node.trackIndex ?? 0 });
     // PLACED or queued — the same resolution the model packer uses, imported
     // rather than re-implemented so the twins cannot drift on the one field
     // whose whole purpose is to override the cursor.
-    const placedStart = placedStartOf({ placedStart: detail?.placedStart }, trackIndex);
+    const placedStart = placedStartOf({ placedStart: node.placedStart }, trackIndex);
     const startTime = placedStart ?? startFor(trackIndex);
 
     if (node.kind === "media") {

--- a/packages/ui/dnd-collections/API.md
+++ b/packages/ui/dnd-collections/API.md
@@ -1082,11 +1082,13 @@ pointer over one. `aria-rowcount` is `1 + layers.length` and an empty layer
 emits no row element (a row with no cells is an invalid grid tree) while
 keeping its index reserved.
 
-Cross-lane DRAG is deliberately not modelled: a lane is consumer data, not
-something this package's engine knows about. Layer cards drag like any other
-card and their drops resolve through the same container droppable, so a drop
-reorders within the collection and leaves the lane alone. Note that a strip
-handed a FILTERED `itemIds` (which is what a lane split produces) publishes
+Cross-lane DRAG is deliberately not modelled by the strip: layer cards drag
+like any other card and their drops resolve through the same container
+droppable, so a drop reorders within the collection and leaves the placement
+alone. The VALUES themselves are engine state — `trackIndex` and
+`placedStart` are node fields changed by `set-node-placement`, so a lane or
+placement change is undoable like any other command. Note that a strip handed
+a FILTERED `itemIds` (which is what a lane split produces) publishes
 boundaries into that filtered list — so the same `mapDropCommand` translation
 `itemIds` already documents applies, or drops land at the wrong position.
 

--- a/packages/ui/dnd-collections/ARCHITECTURE.md
+++ b/packages/ui/dnd-collections/ARCHITECTURE.md
@@ -541,13 +541,20 @@ of clamping, because a lane can outlast the picture; clamping drew a 30s bed
 under a 12s cut as though it ended with the cut. Before the first card it
 still clamps, since content coordinates start at 0.
 
-Lanes stop at geometry. A card's lane is CONSUMER data — the engine has no
-`trackIndex` and no command that changes one — so cross-lane drag is not
-modelled here: layer cards drag like any other card and resolve through the
-same container droppable. A consumer that splits its children by lane is
-also handing the strip a FILTERED item source, which makes its published
-boundaries mean something different; `mapDropCommand` is where that gets
-corrected, the same seam a flat strip uses.
+Lanes stop at geometry HERE, but not in the engine. `trackIndex` and
+`placedStart` are node fields, changed through `set-node-placement` — the
+same shape as `disabled`, and for the same reason: they are DOMAIN facts the
+engine carries and never interprets, and putting them behind a command is
+what makes them ride the patch path and undo. The side-table rule is "does
+the engine MUTATE it", not "does the engine understand it".
+
+What the STRIP still does not model is the cross-lane DRAG. Layer cards drag
+like any other card and resolve through the same container droppable, so a
+drop reorders within the collection and leaves the placement alone. A
+consumer that splits its children by lane is also handing the strip a
+FILTERED item source, which makes its published boundaries mean something
+different; `mapDropCommand` is where that gets corrected, the same seam a
+flat strip uses.
 
 ## FLIP animation: a layer above the reducer
 

--- a/packages/ui/dnd-collections/VirtualStrip.stories.tsx
+++ b/packages/ui/dnd-collections/VirtualStrip.stories.tsx
@@ -8,7 +8,7 @@ import {
   parseNodeId,
   type GraphNodeSpec,
 } from "./core/graph";
-import { useCollectionsStore } from "./react/collections-store";
+import { useCollectionsSelector, useCollectionsStore } from "./react/collections-store";
 import { DndCollections } from "./react/DndCollections";
 import { UndoRedoControls } from "./react/history-views";
 import {
@@ -2527,6 +2527,79 @@ export const LaneRowOutlastsThePicture: Story = {
     expect(scroller.scrollWidth).toBeGreaterThan(
       shot3.getBoundingClientRect().right - scroller.getBoundingClientRect().left,
     );
+  },
+};
+
+/** Reads the lane/placement off the node, so the assertions below watch the
+ *  GRAPH rather than the rendered rows — the strip is handed `layers` as a
+ *  prop and does not derive them. */
+function PlacementReadout({ id }: { id: string }) {
+  const lane = useCollectionsSelector(
+    (s) => s.graph.nodesById.get(parseNodeId(id))?.trackIndex ?? -1,
+  );
+  const start = useCollectionsSelector(
+    (s) => s.graph.nodesById.get(parseNodeId(id))?.placedStart ?? -1,
+  );
+  return <output data-placement={`${lane}@${start}`}>{`${lane}@${start}`}</output>;
+}
+
+function PlaceBedButton() {
+  const store = useCollectionsStore();
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        store.dispatch({
+          type: "set-node-placement",
+          nodeIds: [parseNodeId("bed")],
+          placement: { trackIndex: 2, placedStart: 7.5 },
+        })
+      }
+    >
+      place bed
+    </button>
+  );
+}
+
+export const PlacementIsUndoable: Story = {
+  // THE reason lane and placement moved from a consumer side-table onto the
+  // node. A side-table write emits no patch, so it never entered history and
+  // could not be undone; as a command it rides the same path every other
+  // change does.
+  render: () => (
+    <DndCollections initialGraph={laneGraph()} animateMoves={false}>
+      <div className="flex w-[640px] flex-col gap-2">
+        <UndoRedoControls />
+        <PlaceBedButton />
+        <PlacementReadout id="bed" />
+      </div>
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    const user = userEvent.setup();
+    const canvas = within(canvasElement);
+    // By attribute, not by role: `<output>` is implicitly role="status" and so
+    // is the provider's own drag live region, so the role query is ambiguous.
+    const readout = () =>
+      canvasElement.querySelector("[data-placement]")?.getAttribute("data-placement");
+    const undo = () => canvas.getByRole("button", { name: /undo/i });
+    const redo = () => canvas.getByRole("button", { name: /redo/i });
+
+    // Nothing placed, and nothing to undo.
+    expect(readout()).toBe("-1@-1");
+    expect(undo()).toBeDisabled();
+
+    await user.click(canvas.getByRole("button", { name: "place bed" }));
+    await waitFor(() => expect(readout()).toBe("2@7.5"));
+    // It entered history — the whole claim.
+    await waitFor(() => expect(undo()).toBeEnabled());
+
+    await user.click(undo());
+    // Back to ABSENT, not to a zero: absence is the default for both fields.
+    await waitFor(() => expect(readout()).toBe("-1@-1"));
+
+    await user.click(redo());
+    await waitFor(() => expect(readout()).toBe("2@7.5"));
   },
 };
 

--- a/packages/ui/dnd-collections/react/history-views.tsx
+++ b/packages/ui/dnd-collections/react/history-views.tsx
@@ -23,6 +23,19 @@ function describeCommand(command: CollectionsCommand): string {
       return `rename ${command.nodeId} → "${command.name}"`;
     case "set-node-disabled":
       return `${command.disabled ? "disable" : "enable"} [${command.nodeIds.join(", ")}]`;
+    case "set-node-placement": {
+      // Only the fields the command actually names — `undefined` means "leave
+      // it alone", so listing it would describe a change that did not happen.
+      const parts: string[] = [];
+      const { trackIndex, placedStart } = command.placement;
+      if (trackIndex !== undefined) {
+        parts.push(trackIndex === null ? "lane cleared" : `lane ${trackIndex}`);
+      }
+      if (placedStart !== undefined) {
+        parts.push(placedStart === null ? "unplaced" : `at ${placedStart}s`);
+      }
+      return `place [${command.nodeIds.join(", ")}] ${parts.join(", ")}`;
+    }
   }
 }
 


### PR DESCRIPTION
Phase A of #399. Groundwork for dragging a clip between lanes and along one — no drag yet.

A drag that cannot be undone is much worse than a tag edit that cannot be, because a drag is easy to do by accident. So the values a drag writes had to become real graph state first.

They were not. `trackIndex` and `placedStart` lived in the app's detail side-table, and `detailsStore.merge()` emits no `CollectionsPatch`: nothing entered history, `store.subscribeToChanges` never fired, and the caller had to do PersistenceBridge's job by hand or the change looked correct and was gone on reload. The warning at the top of `graph-tag-editor.tsx` documents that trap.

## The side-table rule is not what it looked like

It reads *"the app-level fields the engine doesn't model"*, which sounds like it is about comprehension — and by that reading lanes belong there forever, because the engine has no idea what a second is.

But `disabled` was already on the **node**, with a comment saying exactly why: "skip this" is a DOMAIN fact about the timeline, and the engine treats a disabled node like any other — it still occupies its slot, still moves, still trims. The real rule is **"does the engine MUTATE it"**. Once a lane is changed by a command, it does.

So `trackIndex` and `placedStart` are node fields now, beside `disabled` and carrying the same note, changed through `set-node-placement`.

## Undo came free

`applySetDisabled` was the template almost line for line: dedupe ids, a missing node is an error, skip nodes already in the target state, emit `nodes-updated`. That patch type already inverts by swapping before/after — **no new patch type and no new inverse**.

The command distinguishes `undefined` (leave the field alone) from `null` (clear it), because a lane change on its own must not silently un-place a clip.

## What moved, and what did not

**The stored document is untouched.** Both were already clip fields; this only reroutes which side of the seam carries them between clip and graph. No data migration, and the lane round-trip test — the guard that the packer and its adapter twin agree — passes unchanged.

**`set_lane` and `set_start` dispatch the command** instead of merging details, and both lose their hand-rolled ancestor walk: `collectAffectedCollectionIds` already walks ancestors for a `nodes-updated` patch, which is the same rule those loops implemented. `set_lane 0` now **clears** both fields rather than storing a zero — absence is the picture everywhere else in the model, and a stale placement left behind would resurface if the clip returned to a lane.

**The domain rules stayed in the domain.** Lane-0 refusal and `resolvePlacement`'s auto-bump are still in `timeline-model`. The engine carries the value; it does not decide it.

Nothing in the packing changed, so a document with no lanes packs identically — which is every document written before lanes existed.

I also corrected two doc paragraphs I wrote in #401 that this makes false ("a card's lane is CONSUMER data — the engine has no `trackIndex`").

## Verified

- app + UI `tsc` clean; lint clean (same 5 pre-existing `<img>` warnings)
- **1078** app tests
- **652** shared unit tests (+10 for the command, including its inverse)
- **207** story interaction tests (+1: a placement dispatched through the real store, undone, and redone — the whole point)
- **171** graph-view e2e

## Next

Phase B is the drag itself: a droppable per lane row, snapping to cuts with Shift to override, both directions (picture ↔ lane), and a lane-aware drop indicator. The commit is the command added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
