### PR TITLE
Drag a clip between lanes, and along one (#399, phase B)

### DIFF
--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -8266,6 +8266,42 @@ test.describe("graph view E2E", () => {
     expect(Math.abs(bravoBox.x - alphaBox.x)).toBeLessThanOrEqual(1);
   });
 
+  test("dragging a layered clip onto the picture row puts it back in the cut", async ({
+    page,
+  }) => {
+    // #399 phase B, in the real app. The drop resolves to a LANE (0) rather
+    // than a boundary index, and commits as `set-node-placement` — which is a
+    // command, so Ctrl+Z puts it back.
+    await installGraphApi(page, { lanes: { bravo: 1 } });
+    await openGraph(page);
+    await expect.poll(() => laneOrder(page, PROJECT_ID, 1)).toEqual(["bravo"]);
+
+    // Aim at a picture CARD, not a gap. Crossing a row has to beat the card
+    // underneath or the gesture would need the user to hunt for a gutter.
+    const alphaBox = (await strip(page, PROJECT_ID)
+      .locator('[data-node-id="alpha"]')
+      .boundingBox())!;
+    await holdDragToPoint(
+      page,
+      strip(page, PROJECT_ID).locator('[data-node-id="bravo"]'),
+      alphaBox.x + alphaBox.width / 2,
+      alphaBox.y + alphaBox.height / 2,
+    );
+
+    // Lane 1 is empty, and bravo is back among the shots at its array
+    // position. Read through `stripOrder`, not the lane-0 row: with nothing
+    // left on a lane the board drops the row DOM entirely and renders as the
+    // plain strip it was before lanes — which is the gating working.
+    await expect.poll(() => laneOrder(page, PROJECT_ID, 1)).toEqual([]);
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID))
+      .toEqual(["alpha", "bravo", CHILD_ID, "charlie"]);
+
+    // And it is UNDOABLE, which is what phase A was for.
+    await undoButton(page).click();
+    await expect.poll(() => laneOrder(page, PROJECT_ID, 1)).toEqual(["bravo"]);
+  });
+
   test("a gap drop lands where the PICTURE says, not where the raw boundary would", async ({
     page,
   }) => {

--- a/packages/collections-core/commands.ts
+++ b/packages/collections-core/commands.ts
@@ -170,6 +170,11 @@ export type AddNodesCommand = Extract<CollectionsCommand, { type: "add-nodes" }>
 /** The `update-media` variant — what the pointer trim handles and keyboard trim produce. */
 export type UpdateMediaCommand = Extract<CollectionsCommand, { type: "update-media" }>;
 
+export type SetNodePlacementCommand = Extract<
+  CollectionsCommand,
+  { type: "set-node-placement" }
+>;
+
 export type ApplyCommandSuccess = Readonly<{
   graph: CollectionsGraph;
   patch: CollectionsPatch;

--- a/packages/collections-core/intents.test.ts
+++ b/packages/collections-core/intents.test.ts
@@ -6,6 +6,7 @@ import {
   isIntentInvalid,
   resolveCommandFromIntent,
   resolveDropIntent,
+  resolvePlacementCommand,
   type RectLike,
 } from "./intents";
 
@@ -332,5 +333,67 @@ describe("resolveCommandFromIntent (post-removal index math)", () => {
       ids(["A"])
     );
     expect(result).toEqual({ ok: false, error: { reason: "missing-node", nodeId: "ghost" } });
+  });
+});
+
+describe("resolvePlacementCommand", () => {
+  const ids = (list: readonly string[]) => list.map(parseNodeId);
+  const place = (lane: number, startSeconds: number) =>
+    resolvePlacementCommand(
+      { type: "place-at-time", collectionId: parseNodeId("root"), lane, startSeconds },
+      ids(["A"]),
+    );
+
+  test("carries the lane and the time onto a set-node-placement", () => {
+    const result = place(1, 7.5);
+    if (!result.ok) throw new Error(JSON.stringify(result.error));
+    expect(result.value).toEqual({
+      type: "set-node-placement",
+      nodeIds: ids(["A"]),
+      placement: { trackIndex: 1, placedStart: 7.5 },
+    });
+  });
+
+  test("LANE 0 CLEARS BOTH FIELDS and ignores the time", () => {
+    // Dropping onto the picture means "rejoin the cut". There is no "here" to
+    // place at on that row — its clips pack end to end from array order — so
+    // the clip takes the slot its position gives it. One command, one undo;
+    // a move as well would have cost two.
+    const result = place(0, 7.5);
+    if (!result.ok) throw new Error(JSON.stringify(result.error));
+    expect(result.value.placement).toEqual({ trackIndex: null, placedStart: null });
+  });
+
+  test("clamps a drag past the left edge to the very start", () => {
+    const result = place(1, -3);
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.value.placement.placedStart).toBe(0);
+  });
+
+  test("refuses a fractional or negative lane", () => {
+    expect(place(1.5, 1).ok).toBe(false);
+    expect(place(-1, 1).ok).toBe(false);
+  });
+
+  test("refuses a non-finite time", () => {
+    expect(place(1, Number.NaN).ok).toBe(false);
+    expect(place(1, Number.POSITIVE_INFINITY).ok).toBe(false);
+  });
+
+  test("refuses an empty drag set", () => {
+    const result = resolvePlacementCommand(
+      { type: "place-at-time", collectionId: parseNodeId("root"), lane: 1, startSeconds: 1 },
+      [],
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  test("places a whole multi-selection in ONE command", () => {
+    const result = resolvePlacementCommand(
+      { type: "place-at-time", collectionId: parseNodeId("root"), lane: 2, startSeconds: 3 },
+      ids(["A", "B"]),
+    );
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.value.nodeIds).toEqual(ids(["A", "B"]));
   });
 });

--- a/packages/collections-core/intents.ts
+++ b/packages/collections-core/intents.ts
@@ -6,7 +6,11 @@ import {
   getChildren,
   isSameOrAncestor,
 } from "./graph";
-import { type AddNodesCommand, type MoveNodesCommand } from "./commands";
+import {
+  type AddNodesCommand,
+  type MoveNodesCommand,
+  type SetNodePlacementCommand,
+} from "./commands";
 
 // The intent layer answers "what did the user seem to mean?" from raw
 // geometry (which droppable, where in its rect), completely separately from
@@ -46,7 +50,27 @@ export type DropIntent =
    * cards still occupy their slots during a drag, and the post-removal
    * conversion happens in `resolveCommandFromIntent`, nowhere else.
    */
-  | Readonly<{ type: "insert-at-index"; collectionId: NodeId; index: number }>;
+  | Readonly<{ type: "insert-at-index"; collectionId: NodeId; index: number }>
+  /**
+   * Drop onto a LANE at a TIME, rather than into a sequence at an index.
+   *
+   * The engine does not interpret either number — it does not pack and does
+   * not know what a second is. It routes them, exactly as it stores
+   * `trackIndex`/`placedStart` on a node without reading them. What makes
+   * this an intent rather than a consumer callback is that the result is
+   * still a command, so a placement made by dragging is undoable like any
+   * other change.
+   *
+   * `startSeconds` is on the CONSUMER'S clock, already snapped (or not) by
+   * whatever resolved it. Lane 0 is legitimate: dragging a clip back onto
+   * the picture is how it rejoins the cut.
+   */
+  | Readonly<{
+      type: "place-at-time";
+      collectionId: NodeId;
+      lane: number;
+      startSeconds: number;
+    }>;
 
 export type RectLike = Readonly<{ left: number; top: number; width: number; height: number }>;
 
@@ -184,6 +208,11 @@ export function intentDestination(graph: CollectionsGraph, intent: DropIntent): 
       return intent.collectionId;
     case "insert-adjacent":
       return graph.parentById.get(intent.targetId) ?? null;
+    // A placement does not RE-PARENT: the clip stays where it is in the tree
+    // and only its lane and start change. The destination is therefore the
+    // collection it is already in, which is the one the row belongs to.
+    case "place-at-time":
+      return intent.collectionId;
   }
 }
 
@@ -220,6 +249,14 @@ export function resolveCommandFromIntent(
   draggedIds: readonly NodeId[]
 ): Result<MoveNodesCommand, IntentRejection> {
   const draggedSet = new Set(draggedIds);
+
+  // A PLACEMENT is not a move: it rewrites two fields and leaves the structure
+  // alone. Refused here rather than handled, so the one function that does
+  // post-removal index math keeps its narrow contract — `resolvePlacementCommand`
+  // is its counterpart.
+  if (intent.type === "place-at-time") {
+    return { ok: false, error: { reason: "invalid-index", index: intent.lane } };
+  }
 
   if (intent.type === "nest-inside" || intent.type === "append-to-collection") {
     const children = getChildren(graph, intent.collectionId);
@@ -314,3 +351,60 @@ export function resolveAddCommandFromIntent(
   };
 }
 
+
+/**
+ * A `place-at-time` intent -> the command that carries it.
+ *
+ * Separate from `resolveCommandFromIntent` because a placement is NOT a move:
+ * it rewrites two fields on a node and leaves the structure alone, so it
+ * resolves to `set-node-placement` and that function keeps its narrow
+ * move-nodes contract.
+ *
+ * LANE 0 CLEARS BOTH FIELDS, and drops the time on the floor. The picture is
+ * a cut — its clips pack end to end from array order — so there is no "here"
+ * to place a clip at on that row. Dropping onto it means "rejoin the cut", and
+ * the clip takes the slot its array position gives it; nudging it along from
+ * there is the ordinary reorder drag, which already exists. The alternative
+ * was a move AND a placement for one gesture, which this store cannot express
+ * as a single history entry — it would have cost two undos for one drag.
+ *
+ * Every other lane places at the time given. Non-finite values are refused
+ * rather than stored, the same way the reducer refuses them.
+ */
+export function resolvePlacementCommand(
+  intent: Extract<DropIntent, { type: "place-at-time" }>,
+  draggedIds: readonly NodeId[]
+): Result<SetNodePlacementCommand, IntentRejection> {
+  if (draggedIds.length === 0) {
+    return { ok: false, error: { reason: "invalid-index", index: 0 } };
+  }
+  if (!Number.isInteger(intent.lane) || intent.lane < 0) {
+    return { ok: false, error: { reason: "invalid-index", index: intent.lane } };
+  }
+  if (intent.lane === 0) {
+    return {
+      ok: true,
+      value: {
+        type: "set-node-placement",
+        nodeIds: draggedIds,
+        placement: { trackIndex: null, placedStart: null },
+      },
+    };
+  }
+  if (!Number.isFinite(intent.startSeconds)) {
+    return { ok: false, error: { reason: "invalid-index", index: intent.startSeconds } };
+  }
+  return {
+    ok: true,
+    value: {
+      type: "set-node-placement",
+      nodeIds: draggedIds,
+      placement: {
+        trackIndex: intent.lane,
+        // Never negative: the picture starts at zero and a lane shares its
+        // origin, so a drag past the left edge means "at the very start".
+        placedStart: Math.max(0, intent.startSeconds),
+      },
+    },
+  };
+}

--- a/packages/ui/dnd-collections/API.md
+++ b/packages/ui/dnd-collections/API.md
@@ -1082,15 +1082,32 @@ pointer over one. `aria-rowcount` is `1 + layers.length` and an empty layer
 emits no row element (a row with no cells is an invalid grid tree) while
 keeping its index reserved.
 
-Cross-lane DRAG is deliberately not modelled by the strip: layer cards drag
-like any other card and their drops resolve through the same container
-droppable, so a drop reorders within the collection and leaves the placement
-alone. The VALUES themselves are engine state — `trackIndex` and
-`placedStart` are node fields changed by `set-node-placement`, so a lane or
-placement change is undoable like any other command. Note that a strip handed
-a FILTERED `itemIds` (which is what a lane split produces) publishes
-boundaries into that filtered list — so the same `mapDropCommand` translation
-`itemIds` already documents applies, or drops land at the wrong position.
+**Dragging onto a lane.** Each row registers its own droppable
+(`VirtualPlaceTarget`) resolving the pointer to a lane and a TIME rather than
+a boundary index — an index means nothing on a lane, where clips are
+positioned by their own start. The provider forms a `place-at-time` intent and
+`resolvePlacementCommand` turns it into `set-node-placement`, so a drag is
+undoable like any other command. The time comes from `LaneTimeMap.timeAt`, the
+inverse of `at`.
+
+Snapping is measured in PIXELS (`8px`), because the scale changes with zoom:
+targets are the picture's cuts and the other clips on the destination lane,
+never the dragged clip itself. Holding SHIFT places exactly.
+
+Two precedence rules extend the package's existing "a card beats a container":
+a ROW beats the strip container (it is the more specific answer), and CROSSING
+a row beats a card (dragging a bed up onto the picture has to work anywhere on
+that row). Within one row a card still wins, so reorder is untouched.
+
+Dropping on the picture row resolves to lane 0, which CLEARS the placement —
+the clip rejoins the cut at its array position. There is no time to land at on
+a row that packs end to end, and a move plus a placement is not expressible as
+one history entry.
+
+A placement skips `mapDropCommand`: that seam corrects a BOUNDARY whose meaning
+a view changed, and a lane and a time mean the same thing in every view. A
+strip handed a FILTERED `itemIds` still needs it for ordinary inserts, though —
+so the translation `itemIds` documents applies, or those drops land wrong.
 
 A strip with no `layers` renders exactly as it did before they existed, down
 to the DOM: every lane path is gated.

--- a/packages/ui/dnd-collections/ARCHITECTURE.md
+++ b/packages/ui/dnd-collections/ARCHITECTURE.md
@@ -548,13 +548,25 @@ engine carries and never interprets, and putting them behind a command is
 what makes them ride the patch path and undo. The side-table rule is "does
 the engine MUTATE it", not "does the engine understand it".
 
-What the STRIP still does not model is the cross-lane DRAG. Layer cards drag
-like any other card and resolve through the same container droppable, so a
-drop reorders within the collection and leaves the placement alone. A
-consumer that splits its children by lane is also handing the strip a
-FILTERED item source, which makes its published boundaries mean something
-different; `mapDropCommand` is where that gets corrected, the same seam a
-flat strip uses.
+Dragging onto a lane goes through the SAME pipeline as everything else, with
+one extra target shape. A row registers a `VirtualPlaceTarget` resolving to a
+lane and a time — a boundary index means nothing where clips are positioned by
+their own start — the provider forms a `place-at-time` intent, and
+`resolvePlacementCommand` turns it into `set-node-placement`. It is not a move,
+so it does not go near the post-removal index math and does not consult
+`mapDropCommand`: that seam corrects a BOUNDARY whose meaning a view changed,
+and a lane and a time mean the same thing everywhere.
+
+Collision precedence gained two rules, both extending "a card beats a
+container" and for the same reason (pointerWithin ranks by distance-to-centre
+with no notion of z-order): a ROW beats the strip container, and CROSSING a row
+beats a card. The second is what lets a bed be dragged up onto the picture
+anywhere on that row rather than only through a gutter; within one row a card
+still wins, so reorder is untouched.
+
+A consumer that splits its children by lane is still handing the strip a
+FILTERED item source, so ordinary inserts keep needing the `mapDropCommand`
+translation a flat strip uses.
 
 ## FLIP animation: a layer above the reducer
 

--- a/packages/ui/dnd-collections/VirtualStrip.stories.tsx
+++ b/packages/ui/dnd-collections/VirtualStrip.stories.tsx
@@ -2603,6 +2603,117 @@ export const PlacementIsUndoable: Story = {
   },
 };
 
+/** The lane harness with history controls and a readout, for drag stories. */
+function LaneDragHarness() {
+  return (
+    <DndCollections initialGraph={laneGraph()} animateMoves={false}>
+      <div className="flex w-[640px] flex-col gap-2">
+        <UndoRedoControls />
+        <PlacementReadout id="bed" />
+        <VirtualStrip
+          collectionId={parseNodeId("strip")}
+          itemIds={PICTURE_IDS}
+          itemTimes={PICTURE_TIMES}
+          layers={LANE_LAYERS}
+          pixelsPerSecond={LANE_PPS}
+        />
+      </div>
+    </DndCollections>
+  );
+}
+
+export const DraggingBetweenLanesPlacesTheClip: Story = {
+  // #399 phase B. Dragging a bed onto another lane row resolves to a LANE and
+  // a TIME, not a boundary index — and commits as `set-node-placement`, so it
+  // is undoable like any other change.
+  render: () => <LaneDragHarness />,
+  play: async ({ canvasElement }) => {
+    const shot1 = nodeCard(canvasElement, "shot1");
+    await waitForLayout(shot1);
+    const readout = () =>
+      canvasElement.querySelector("[data-placement]")?.getAttribute("data-placement");
+
+    // The bed starts unplaced on lane 1 (its row comes from the `layers` prop).
+    expect(readout()).toBe("-1@-1");
+
+    // Drop it onto the SECOND lane row, over shot 2.
+    const lane2 = canvasElement.querySelector<HTMLElement>('[data-strip-lane="2"]')!;
+    const shot2Box = nodeCard(canvasElement, "shot2").getBoundingClientRect();
+    const laneBox = lane2.getBoundingClientRect();
+    // 20px in from shot 2's edge is OUTSIDE the 8px snap range, so this lands
+    // exactly where the pointer is: 20px at 40px/s is 0.5s past 4.12.
+    const target = { x: shot2Box.left + 20, y: laneBox.top + laneBox.height / 2 };
+
+    await dragToPoint(nodeHandle(canvasElement, "bed"), target);
+
+    await waitFor(() => expect(readout()).toBe("2@4.62"));
+  },
+};
+
+export const PlacementPreviewSnapsToACut: Story = {
+  // The preview is the whole reason snapping is discoverable: without it a
+  // user cannot tell that releasing here lands on the cut rather than 3px off.
+  render: () => <LaneDragHarness />,
+  play: async ({ canvasElement }) => {
+    const shot1 = nodeCard(canvasElement, "shot1");
+    await waitForLayout(shot1);
+    const shot2Box = nodeCard(canvasElement, "shot2").getBoundingClientRect();
+    const lane2 = canvasElement.querySelector<HTMLElement>('[data-strip-lane="2"]')!;
+    const laneBox = lane2.getBoundingClientRect();
+    const marker = () =>
+      canvasElement.querySelector<HTMLElement>("[data-place-indicator]");
+
+    // Nothing to preview until a drag is live.
+    expect(marker()).toBeNull();
+
+    // HOLD 3px past shot 2's left edge — inside the 8px snap range.
+    const near = { x: shot2Box.left + 3, y: laneBox.top + laneBox.height / 2 };
+    await dragHoldAt(nodeHandle(canvasElement, "bed"), near);
+
+    await waitFor(() => expect(marker()).not.toBeNull());
+    expect(marker()!.getAttribute("data-place-indicator")).toBe("2");
+    // Snapped: the marker sits ON the cut, not 3px past it. Compared against
+    // shot 2's own left edge so this holds whatever the container's offset is.
+    const markerX = marker()!.getBoundingClientRect().left;
+    expect(Math.abs(markerX - shot2Box.left)).toBeLessThanOrEqual(1.5);
+
+    await releaseAt(near);
+  },
+};
+
+export const DraggingOntoThePictureRejoinsTheCut: Story = {
+  render: () => <LaneDragHarness />,
+  play: async ({ canvasElement }) => {
+    const shot1 = nodeCard(canvasElement, "shot1");
+    await waitForLayout(shot1);
+    const readout = () =>
+      canvasElement.querySelector("[data-placement]")?.getAttribute("data-placement");
+    const undo = () => within(canvasElement).getByRole("button", { name: /undo/i });
+
+    // Put it somewhere first, so clearing is observable.
+    const lane2 = canvasElement.querySelector<HTMLElement>('[data-strip-lane="2"]')!;
+    const laneBox = lane2.getBoundingClientRect();
+    await dragToPoint(nodeHandle(canvasElement, "bed"), {
+      x: shot1.getBoundingClientRect().left + 4,
+      y: laneBox.top + laneBox.height / 2,
+    });
+    await waitFor(() => expect(readout()).toBe("2@0"));
+
+    // Now drag it onto the PICTURE row: lane and placement both clear, and the
+    // clip takes the slot its array position gives it in the cut. One command,
+    // so one undo puts it back.
+    const pictureBox = shot1.getBoundingClientRect();
+    await dragToPoint(nodeHandle(canvasElement, "bed"), {
+      x: pictureBox.left + 40,
+      y: pictureBox.top + pictureBox.height / 2,
+    });
+    await waitFor(() => expect(readout()).toBe("-1@-1"));
+
+    await userEvent.setup().click(undo());
+    await waitFor(() => expect(readout()).toBe("2@0"));
+  },
+};
+
 export const LaneRowsCarryGridRowSemantics: Story = {
   render: () => <LaneHarness />,
   play: async ({ canvasElement }) => {

--- a/packages/ui/dnd-collections/index.ts
+++ b/packages/ui/dnd-collections/index.ts
@@ -187,8 +187,11 @@ export {
 } from "./react/container-context";
 export {
   VIRTUAL_INSERT_DATA_KEY,
+  VIRTUAL_PLACE_DATA_KEY,
   isVirtualInsertTarget,
+  isVirtualPlaceTarget,
   type VirtualInsertTarget,
+  type VirtualPlaceTarget,
 } from "./react/virtual-droppable";
 export { useEdgeAutoScroll } from "./react/use-edge-autoscroll";
 

--- a/packages/ui/dnd-collections/react/DndCollections.tsx
+++ b/packages/ui/dnd-collections/react/DndCollections.tsx
@@ -37,6 +37,7 @@ import {
   encodeDropTarget,
   intentDestination,
   resolveCommandFromIntent,
+  resolvePlacementCommand,
   resolveDropIntent,
   type DropIntent,
   type PanelChildRect,
@@ -73,7 +74,12 @@ import { LiveAnnouncementRegion, useAnnounceChannel } from "./use-announcements"
 import { useCollectionsKeyboard } from "./use-keyboard-controller";
 import { usePaletteDrag } from "./use-palette-drag";
 import { createEdgeAutoScrollCoordinator } from "./edge-autoscroll-coordinator";
-import { VIRTUAL_INSERT_DATA_KEY, isVirtualInsertTarget } from "./virtual-droppable";
+import {
+  VIRTUAL_INSERT_DATA_KEY,
+  VIRTUAL_PLACE_DATA_KEY,
+  isVirtualInsertTarget,
+  isVirtualPlaceTarget,
+} from "./virtual-droppable";
 
 // Provider wiring: dnd-kit supplies the sensors, collision built-ins, and
 // the DragOverlay; this file owns collision -> intent resolution and the
@@ -525,12 +531,29 @@ function DndCollectionsContext({
       // them resolves an intent the store flags as invalid (cycle), which
       // drives the "Cannot drop" preview instead of dead silence.
       const draggedIds = new Set<string>(activeIds);
+      // Which row the dragged clip is on now — the picture unless it says
+      // otherwise. Decides which ROW targets can apply to this drag at all.
+      const draggedLane = graph.nodesById.get(activeIds[0] as NodeId)?.trackIndex ?? 0;
       const droppableContainers = args.droppableContainers.filter((container) => {
         // Virtualized containers carry their own resolver (see
         // react/virtual-droppable.ts) instead of an encoded target id.
         const virtualInsert = container.data.current?.[VIRTUAL_INSERT_DATA_KEY];
         if (isVirtualInsertTarget(virtualInsert)) {
           return graph.nodesById.get(virtualInsert.collectionId)?.kind === "collection";
+        }
+        const virtualPlace = container.data.current?.[VIRTUAL_PLACE_DATA_KEY];
+        if (isVirtualPlaceTarget(virtualPlace)) {
+          // THE PICTURE IS ORDERED; A LANE IS PLACED. So the picture row is a
+          // placement target only for a clip arriving FROM a lane ("put this
+          // back in the cut"). For a clip already on the picture it is removed
+          // from consideration entirely, or an ordinary reorder resolves to a
+          // no-op placement instead of an insert — and REMOVED, not merely
+          // ranked lower, because the row's rect is smaller than the strip's
+          // and pointerWithin ranks by distance-to-centre, so it would win by
+          // accident. That regression is what `a gap drop lands where the
+          // PICTURE says` caught.
+          if (virtualPlace.lane === 0 && draggedLane === 0) return false;
+          return graph.nodesById.get(virtualPlace.collectionId)?.kind === "collection";
         }
         const target = decodeDropTarget(String(container.id));
         if (!target) return false; // unknown droppables are never winners
@@ -577,7 +600,17 @@ function DndCollectionsContext({
         const nodeHit = collisions.find(
           (collision) => decodeDropTarget(String(collision.id))?.type === "node"
         );
-        if (nodeHit && nodeHit !== collisions[0]) {
+        // A ROW BEATS A CARD. Only rows that can apply to this drag survived
+        // the filter above, so any row still here is the answer: dragging a
+        // bed up onto the picture has to work anywhere on that row, not only
+        // through a gutter between two shots.
+        const rowHit = collisions.find((collision) => {
+          const container = droppableContainers.find((c) => c.id === collision.id);
+          return isVirtualPlaceTarget(container?.data.current?.[VIRTUAL_PLACE_DATA_KEY]);
+        });
+        if (rowHit && rowHit !== collisions[0]) {
+          collisions = [rowHit, ...collisions.filter((c) => c !== rowHit)];
+        } else if (nodeHit && nodeHit !== collisions[0]) {
           collisions = [nodeHit, ...collisions.filter((c) => c !== nodeHit)];
         }
       }
@@ -615,6 +648,29 @@ function DndCollectionsContext({
           type: "insert-at-index",
           collectionId: virtualInsert.collectionId,
           index,
+        };
+        return collisions;
+      }
+
+      // A LANE ROW: a lane and a time rather than a boundary index.
+      const virtualPlace = winnerContainer?.data.current?.[VIRTUAL_PLACE_DATA_KEY];
+      if (isVirtualPlaceTarget(virtualPlace)) {
+        let startSeconds: number;
+        try {
+          startSeconds = virtualPlace.resolveTime(point);
+        } catch {
+          intentRef.current = null;
+          return collisions;
+        }
+        if (!Number.isFinite(startSeconds)) {
+          intentRef.current = null;
+          return collisions;
+        }
+        intentRef.current = {
+          type: "place-at-time",
+          collectionId: virtualPlace.collectionId,
+          lane: virtualPlace.lane,
+          startSeconds,
         };
         return collisions;
       }
@@ -718,7 +774,16 @@ function DndCollectionsContext({
         return;
       }
 
-      const commandResult = resolveCommandFromIntent(graph, intent, activeIds);
+      // A PLACEMENT takes its own resolver: it rewrites two fields on the
+      // node and leaves the structure alone, so it is not a move and does not
+      // go through the post-removal index math. It also skips
+      // `mapDropCommand`, which exists to correct a BOUNDARY whose meaning a
+      // view changed — a placement carries a lane and a time, which mean the
+      // same thing in every view.
+      const commandResult =
+        intent.type === "place-at-time"
+          ? resolvePlacementCommand(intent, activeIds)
+          : resolveCommandFromIntent(graph, intent, activeIds);
       if (!commandResult.ok) {
         store.endDrag();
         announce("Cancelled drag.");
@@ -728,7 +793,10 @@ function DndCollectionsContext({
       // collection's own children gets to correct the target here — see
       // `mapDropCommand`. Read through the ref so a consumer that rebuilds the
       // callback per render never leaves a stale mapping armed mid-drag.
-      const command = mapDropCommand(commandResult.value, intent, graph);
+      const command =
+        commandResult.value.type === "set-node-placement"
+          ? commandResult.value
+          : mapDropCommand(commandResult.value, intent, graph);
 
       // Measure the ghost BEFORE the commit — dispatching unmounts the
       // overlay, and this box is where the dropped card's motion should
@@ -761,6 +829,20 @@ function DndCollectionsContext({
       store.endDrag();
 
       if (dispatched.ok) {
+        // A PLACEMENT did not move anything between collections, so the
+        // move wording would be wrong — it says which lane the clip landed
+        // on, which is the thing that changed and the thing a screen-reader
+        // user cannot see.
+        if (command.type === "set-node-placement") {
+          const lane = command.placement.trackIndex;
+          const what = activeIds.length > 1 ? `${activeIds.length} items` : "item";
+          announce(
+            lane === null || lane === undefined || lane === 0
+              ? `Moved ${what} onto the picture.`
+              : `Moved ${what} to lane ${lane}.`
+          );
+          return;
+        }
         const targetName = graph.nodesById.get(command.toParentId)?.name ?? "collection";
         announce(
           activeIds.length > 1

--- a/packages/ui/dnd-collections/react/collections-store.ts
+++ b/packages/ui/dnd-collections/react/collections-store.ts
@@ -937,6 +937,15 @@ function intentEqual(a: DropIntent | null, b: DropIntent | null): boolean {
         a.collectionId === b.collectionId &&
         a.index === b.index
       );
+    case "place-at-time":
+      return (
+        b.type === "place-at-time" &&
+        a.collectionId === b.collectionId &&
+        a.lane === b.lane &&
+        // A placement moves CONTINUOUSLY, so equality here is what keeps a
+        // drag from re-rendering on every sub-pixel pointer move.
+        a.startSeconds === b.startSeconds
+      );
   }
 }
 

--- a/packages/ui/dnd-collections/react/virtual-droppable.ts
+++ b/packages/ui/dnd-collections/react/virtual-droppable.ts
@@ -29,3 +29,39 @@ export function isVirtualInsertTarget(value: unknown): value is VirtualInsertTar
     typeof target.collectionId === "string" && typeof target.resolveBoundary === "function"
   );
 }
+
+/**
+ * The other virtualized drop shape: a LANE ROW, which resolves to a lane and a
+ * TIME rather than to a boundary index.
+ *
+ * A row cannot use `VirtualInsertTarget` because an index means nothing on a
+ * lane — clips there are positioned by their own start, not by their place in
+ * a queue. `resolveTime` maps the pointer to a time on the consumer's clock,
+ * with whatever snapping the view applies already done, so the provider only
+ * has to route the number.
+ *
+ * Lane 0 (the picture) registers one too: dropping a layered clip onto it is
+ * how the clip rejoins the cut.
+ */
+export type VirtualPlaceTarget = Readonly<{
+  collectionId: NodeId;
+  /** 0 is the picture; anything above runs underneath it. */
+  lane: number;
+  /** Viewport-space pointer -> a start time on the consumer's clock. */
+  resolveTime: (point: Readonly<{ x: number; y: number }>) => number;
+}>;
+
+/** Key under which the target sits in a droppable's `data`. */
+export const VIRTUAL_PLACE_DATA_KEY = "virtualPlace";
+
+/** Runtime guard, for the same reason `isVirtualInsertTarget` has one: dnd-kit's
+ *  `data` bag is untyped, so narrow at the seam rather than casting. */
+export function isVirtualPlaceTarget(value: unknown): value is VirtualPlaceTarget {
+  if (typeof value !== "object" || value === null) return false;
+  const target = value as Record<string, unknown>;
+  return (
+    typeof target.collectionId === "string" &&
+    typeof target.lane === "number" &&
+    typeof target.resolveTime === "function"
+  );
+}

--- a/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
@@ -63,6 +63,11 @@ import {
   resolveBoundaryIndex,
   slotSizeFor,
 } from "./virtual-strip-geometry";
+import { useDroppable } from "@dnd-kit/core";
+import {
+  VIRTUAL_PLACE_DATA_KEY,
+  type VirtualPlaceTarget,
+} from "../react/virtual-droppable";
 import {
   createLaneTimeMap,
   laneFlatIndex,
@@ -71,6 +76,8 @@ import {
   laneRowTop,
   laneStackHeight,
   resolveLaneStripIndex,
+  snapEdgesFor,
+  snapToEdges,
   type LanePictureSlot,
   type LaneRowLayout,
 } from "./virtual-strip-lanes";
@@ -124,6 +131,54 @@ const STRIP_PAN_DISABLED: PanWithMomentumOptions = { disabled: true };
 
 // Gap between the floating overview tooltip and the top of the strip.
 const OVERVIEW_GAP = 8;
+
+/** How close (in px) a dragged clip has to be to a cut before it snaps to it. */
+const SNAP_THRESHOLD_PX = 8;
+
+/**
+ * One row registered as a drop target that resolves to a LANE and a TIME.
+ *
+ * A component rather than a loop of hooks: the row count changes with the
+ * data, and `useDroppable` cannot be called conditionally. Each row owns its
+ * own registration and hands the provider a resolver, exactly as the strip
+ * container does for boundary indices.
+ */
+function LaneRowDroppable({
+  collectionId,
+  lane,
+  resolveTime,
+  style,
+  children,
+  ...rest
+}: Readonly<{
+  collectionId: NodeId;
+  lane: number;
+  resolveTime: (point: Readonly<{ x: number; y: number }>) => number;
+  style: CSSProperties;
+  children: ReactNode;
+}> &
+  Readonly<Record<string, unknown>>) {
+  // Read through a ref so the droppable's data closure never goes stale as the
+  // layout changes mid-drag — the same indirection the container droppable's
+  // `resolveBoundary` uses.
+  const resolveRef = useRef(resolveTime);
+  resolveRef.current = resolveTime;
+  const { setNodeRef } = useDroppable({
+    id: `vlane:${collectionId}:${lane}`,
+    data: {
+      [VIRTUAL_PLACE_DATA_KEY]: {
+        collectionId,
+        lane,
+        resolveTime: (point) => resolveRef.current(point),
+      } satisfies VirtualPlaceTarget,
+    },
+  });
+  return (
+    <div ref={setNodeRef} style={style} {...rest}>
+      {children}
+    </div>
+  );
+}
 
 // A lane row draws as a slim band under the picture — the editor idiom, where
 // a bed or a voiceover must not compete with the shots for height. A fraction
@@ -776,6 +831,12 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
       itemWidthFor,
     ]);
 
+    // Read imperatively by the drop resolver, which runs on dnd-kit's collision
+    // cadence rather than React's — a closure captured at render would be a
+    // frame behind the layout it is measuring against.
+    const laneMapRef = useRef(laneTimeMap);
+    laneMapRef.current = laneTimeMap;
+
     // Every layer card's box, plus the furthest right edge any of them reach —
     // the spacer has to cover a bed that outlasts the picture.
     const layerPlacements = useMemo(() => {
@@ -792,6 +853,20 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
       }
       return { byId, right };
     }, [laneRows, laneTimeMap]);
+
+    // What snapping measures against: the picture's cuts, each lane's own
+    // clips, and which clip is being dragged (it must not snap to itself).
+    const laneRowsRef = useRef<{
+      picture: readonly StripTimedSlot[];
+      byLane: Map<number, readonly StripLayerItem[]>;
+      draggedId: string;
+    }>({ picture: [], byLane: new Map(), draggedId: "" });
+    const activeId = useCollectionsSelector((s) => s.interaction.activeIds[0] ?? null);
+    laneRowsRef.current = {
+      picture: itemTimes ?? [],
+      byLane: new Map((laneRows ?? []).map((layer, index) => [index + 1, layer.items])),
+      draggedId: (activeId as string | null) ?? "",
+    };
 
     // Row 0 is the picture, then each layer in order — the shape the roving
     // resolver navigates. Empty without lanes, which is what keeps the plain
@@ -815,6 +890,55 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
     const rovingIndexById = useMemo(
       () => (laneRows ? new Map(rovingIds.map((id, index) => [id, index])) : indexById),
       [laneRows, rovingIds, indexById],
+    );
+
+    // SHIFT places exactly, overriding the snap. Tracked here rather than read
+    // off the drag event because dnd-kit's collision pass carries no
+    // modifiers, and the user can press or release Shift mid-drag — the answer
+    // has to be live at the moment the pointer moves, not at pick-up. Listeners
+    // only exist while a drag does.
+    const exactRef = useRef(false);
+    const isDragging = useCollectionsSelector((s) => s.interaction.isDragging);
+    useEffect(() => {
+      if (!isDragging || !laneRows) return;
+      const sync = (event: KeyboardEvent) => {
+        exactRef.current = event.shiftKey;
+      };
+      window.addEventListener("keydown", sync);
+      window.addEventListener("keyup", sync);
+      return () => {
+        exactRef.current = false;
+        window.removeEventListener("keydown", sync);
+        window.removeEventListener("keyup", sync);
+      };
+    }, [isDragging, laneRows]);
+
+    // Pointer -> a start time on the CONSUMER'S clock, for one row.
+    //
+    // The dragged clip is placed by its LEFT EDGE, which is what the indicator
+    // draws and what a user aims with — grabbing a bed in the middle and
+    // dropping it should not bury its start half a card to the left.
+    const resolveTimeFor = useCallback(
+      (lane: number) => (point: VirtualViewPoint) => {
+        const content = contentRef.current;
+        const map = laneMapRef.current;
+        if (!content || !map) return 0;
+        const contentX = point.x - content.getBoundingClientRect().left;
+        const raw = map.timeAt(contentX);
+        if (exactRef.current) return raw;
+        const rows = laneRowsRef.current;
+        return snapToEdges(
+          map,
+          raw,
+          snapEdgesFor(
+            rows.picture,
+            lane === 0 ? [] : (rows.byLane.get(lane) ?? []),
+            rows.draggedId,
+          ),
+          SNAP_THRESHOLD_PX,
+        );
+      },
+      [contentRef],
     );
 
     // Pointer -> visible boundary index from the virtualizer's measurements
@@ -1075,6 +1199,25 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
       return intent.index;
     });
 
+    // A live PLACEMENT intent aimed at this strip: which row, and at what
+    // time. Selected as primitives rather than the intent object so the
+    // subscription compares by value — the intent is a fresh object on every
+    // pointer move.
+    const placingLane = useCollectionsSelector((s) => {
+      const intent = s.interaction.dropIntent;
+      return intent?.type === "place-at-time" &&
+        intent.collectionId === collectionId &&
+        !s.interaction.dropIntentInvalid
+        ? intent.lane
+        : null;
+    });
+    const placingStart = useCollectionsSelector((s) => {
+      const intent = s.interaction.dropIntent;
+      return intent?.type === "place-at-time" && intent.collectionId === collectionId
+        ? intent.startSeconds
+        : null;
+    });
+
     // Boundary k's line sits in the gap before item k (measured offsets, so
     // variable widths align). Boundaries under the pointer are always near
     // the viewport, so the mounted-items lookup is sufficient; k === count
@@ -1147,17 +1290,21 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
     // the live-trim anchor transform all apply to them for free.
     const laneRowElements = laneRows?.map((layer, layerIndex) => {
       if (layer.items.length === 0) return null;
+      const lane = layerIndex + 1;
       return (
-        <div
+        <LaneRowDroppable
           key={`lane-${layerIndex}`}
+          collectionId={collectionId}
+          lane={lane}
+          resolveTime={resolveTimeFor(lane)}
           role="row"
           aria-rowindex={layerIndex + 2}
-          data-strip-lane={layerIndex + 1}
+          data-strip-lane={lane}
           style={{
             position: "absolute",
             left: 0,
             right: 0,
-            top: laneRowTop(layerIndex + 1, itemHeight, layerHeight, layerGap),
+            top: laneRowTop(lane, itemHeight, layerHeight, layerGap),
             height: layerHeight,
           }}
         >
@@ -1191,7 +1338,7 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
               </div>
             );
           })}
-        </div>
+        </LaneRowDroppable>
       );
     });
 
@@ -1293,6 +1440,25 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
                 transform: dragShiftX ? `translateX(${dragShiftX}px)` : undefined,
               }}
             >
+              {/* PLACEMENT preview. The insert indicator marks a boundary
+                  between two cards; a placement has no boundary — it lands at
+                  a moment on a row — so it draws where the clip's LEFT EDGE
+                  will be, which is what the drop actually sets and what the
+                  user is aiming. On the picture row it is a full-height bar,
+                  because dropping there means "rejoin the cut" rather than
+                  "land at this instant". */}
+              {laneRows !== null && placingLane !== null && laneTimeMap !== null && (
+                <div
+                  aria-hidden="true"
+                  data-place-indicator={placingLane}
+                  className="pointer-events-none absolute z-20 w-0.5 -translate-x-1/2 rounded-full bg-primary"
+                  style={{
+                    left: placingStart === null ? 0 : laneTimeMap.at(placingStart),
+                    top: laneRowTop(placingLane, itemHeight, layerHeight, layerGap),
+                    height: placingLane === 0 ? itemHeight : layerHeight,
+                  }}
+                />
+              )}
               {indicatorLeft !== null && (
                 <div
                   aria-hidden="true"
@@ -1302,7 +1468,14 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
                 />
               )}
               {laneRows && childIds.length > 0 ? (
-                <div
+                // A drop target too, so a layered clip dragged up here
+                // rejoins the cut. It resolves to lane 0, which the command
+                // resolver reads as "clear the placement" — the picture packs
+                // from array order, so there is no time to land at.
+                <LaneRowDroppable
+                  collectionId={collectionId}
+                  lane={0}
+                  resolveTime={resolveTimeFor(0)}
                   role="row"
                   aria-rowindex={1}
                   data-strip-lane={0}
@@ -1315,7 +1488,7 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
                   }}
                 >
                   {pictureCells}
-                </div>
+                </LaneRowDroppable>
               ) : (
                 pictureCells
               )}

--- a/packages/ui/dnd-collections/virtual/virtual-strip-lanes.test.ts
+++ b/packages/ui/dnd-collections/virtual/virtual-strip-lanes.test.ts
@@ -9,6 +9,8 @@ import {
   laneRowTop,
   laneStackHeight,
   resolveLaneStripIndex,
+  snapEdgesFor,
+  snapToEdges,
   type LaneRowLayout,
 } from "./virtual-strip-lanes";
 
@@ -96,6 +98,96 @@ describe("createLaneTimeMap", () => {
       { left: 168, width: 128, startSeconds: 4.12, durationSeconds: 100 },
     ]);
     expect(map.at(54.12)).toBe(232);
+  });
+});
+
+describe("timeAt — the inverse a drag needs", () => {
+  const map = createLaneTimeMap(SHOTS);
+
+  it("returns 0 for every x when there are no slots", () => {
+    expect(createLaneTimeMap([]).timeAt(100)).toBe(0);
+  });
+
+  it("inverts `at` exactly on card edges", () => {
+    for (const time of [0, 4, 4.12, 8.24, 12.24]) {
+      expect(map.timeAt(map.at(time))).toBeCloseTo(time, 6);
+    }
+  });
+
+  it("inverts `at` inside a card and across a gutter", () => {
+    for (const time of [1, 2, 3.9, 4.06, 5.5, 9.1, 11]) {
+      expect(map.timeAt(map.at(time))).toBeCloseTo(time, 6);
+    }
+  });
+
+  it("clamps before the run and extrapolates past it, mirroring `at`", () => {
+    expect(map.timeAt(-50)).toBe(0);
+    // 40px past the last shot's right edge is 1s past its end.
+    expect(map.timeAt(496 + 40)).toBeCloseTo(13.24, 6);
+    expect(map.timeAt(Number.NaN)).toBe(0);
+  });
+
+  it("round-trips a time that is past the picture", () => {
+    for (const time of [13, 20, 42]) {
+      expect(map.timeAt(map.at(time))).toBeCloseTo(time, 6);
+    }
+  });
+});
+
+describe("snapToEdges", () => {
+  const map = createLaneTimeMap(SHOTS);
+
+  it("snaps to a cut the pointer is near", () => {
+    // Shot 2 starts at 4.12s (x=168). A drop at x=170 is 2px away.
+    const near = map.timeAt(170);
+    expect(snapToEdges(map, near, [4.12], 6)).toBe(4.12);
+  });
+
+  it("leaves a time alone when nothing is close enough", () => {
+    const far = map.timeAt(240);
+    expect(snapToEdges(map, far, [4.12], 6)).toBe(far);
+  });
+
+  it("measures in PIXELS, so the same gesture holds at any zoom", () => {
+    // The same 0.15s gap is 6px at 40px/s and 60px at 400px/s: snappable at
+    // one zoom and not the other, which is the point of a pixel threshold.
+    const zoomed = createLaneTimeMap([
+      { left: 0, width: 1600, startSeconds: 0, durationSeconds: 4 },
+    ]);
+    expect(snapToEdges(map, 3.85, [4], 8)).toBe(4);
+    expect(snapToEdges(zoomed, 3.85, [4], 8)).toBe(3.85);
+  });
+
+  it("takes the NEAREST edge when several are in range", () => {
+    const near = map.timeAt(166);
+    expect(snapToEdges(map, near, [4, 4.12], 20)).toBe(4.12);
+  });
+
+  it("is inert with no edges, which is how a caller turns it off", () => {
+    expect(snapToEdges(map, 5.5, [], 6)).toBe(5.5);
+    expect(snapToEdges(map, 5.5, [5.5], 0)).toBe(5.5);
+  });
+});
+
+describe("snapEdgesFor", () => {
+  const picture = [
+    { startSeconds: 0, durationSeconds: 4 },
+    { startSeconds: 4.12, durationSeconds: 4 },
+  ];
+
+  it("offers both ends of every picture card", () => {
+    // Rounded: an end is start + duration, and 4.12 + 4 is not 8.12 in binary.
+    const round = (value: number) => Math.round(value * 100) / 100;
+    expect(snapEdgesFor(picture, [], "x").map(round)).toEqual([0, 4, 4.12, 8.12]);
+  });
+
+  it("offers the other clips on the lane, but never the dragged one", () => {
+    const lane = [
+      { id: "bed", startSeconds: 0, durationSeconds: 6 },
+      { id: "vo", startSeconds: 9, durationSeconds: 2 },
+    ];
+    // `bed` is being dragged, so its own edges are not targets.
+    expect(snapEdgesFor([], lane, "bed")).toEqual([9, 11]);
   });
 });
 

--- a/packages/ui/dnd-collections/virtual/virtual-strip-lanes.ts
+++ b/packages/ui/dnd-collections/virtual/virtual-strip-lanes.ts
@@ -35,6 +35,15 @@ export type LanePictureSlot = Readonly<{
 export type LaneTimeMap = Readonly<{
   /** Content-x for a time on the picture's clock — O(log n). */
   at: (timeSeconds: number) => number;
+  /**
+   * The inverse: a content-x back to a time. What a DRAG needs, since a
+   * pointer arrives in pixels and a placement is stored in seconds.
+   *
+   * Exactly inverts `at` on the range it covers, including across gutters.
+   * Outside the picture it extrapolates and clamps the same way `at` does, so
+   * `timeAt(at(t)) === t` for any t the picture can express.
+   */
+  timeAt: (contentX: number) => number;
 }>;
 
 /**
@@ -129,7 +138,109 @@ export function createLaneTimeMap(slots: readonly LanePictureSlot[]): LaneTimeMa
     return from + ((timeSeconds - slotEnd) / gutterSeconds) * (next.left - from);
   };
 
-  return { at };
+  /** Index of the last slot whose LEFT EDGE is at or before `x`. */
+  const locateX = (x: number): number => {
+    let lo = 0;
+    let hi = count - 1;
+    while (lo < hi) {
+      const mid = (lo + hi + 1) >> 1;
+      if (slotAt(mid).left <= x) lo = mid;
+      else hi = mid - 1;
+    }
+    return lo;
+  };
+
+  const timeAt = (contentX: number): number => {
+    if (count === 0) return 0;
+    const first = slotAt(0);
+    if (!Number.isFinite(contentX) || contentX <= first.left) return first.startSeconds;
+    const last = slotAt(count - 1);
+    const lastRight = last.left + last.width;
+    const lastEnd = last.startSeconds + last.durationSeconds;
+    // Past the picture, at the last card's own rate — the mirror of `at`,
+    // which extrapolates there rather than clamping because a lane can
+    // outlast the picture.
+    if (contentX >= lastRight) {
+      const rate = last.width > 0 ? last.durationSeconds / last.width : 0;
+      return lastEnd + (contentX - lastRight) * rate;
+    }
+
+    const index = locateX(contentX);
+    const slot = slotAt(index);
+    const slotRight = slot.left + slot.width;
+    if (contentX <= slotRight) {
+      if (slot.width <= 0) return slot.startSeconds;
+      const within = (contentX - slot.left) / slot.width;
+      return slot.startSeconds + within * slot.durationSeconds;
+    }
+    // In the gutter after it — `locateX` only returns the last index when x is
+    // past its right edge, and that already clamped above.
+    const next = slotAt(index + 1);
+    const gutterPx = next.left - slotRight;
+    const from = slot.startSeconds + slot.durationSeconds;
+    if (gutterPx <= 0) return next.startSeconds;
+    return from + ((contentX - slotRight) / gutterPx) * (next.startSeconds - from);
+  };
+
+  return { at, timeAt };
+}
+
+/**
+ * Snap a dragged time to a nearby edge, IN PIXELS.
+ *
+ * The threshold has to be a pixel distance rather than a duration: the strip's
+ * scale changes with zoom, so "within 0.2s" is a hand-width at one zoom and
+ * invisible at another, while "within 6px" is the same gesture everywhere.
+ *
+ * `edges` are the times worth landing on — the picture's cuts, and the ends of
+ * the other clips on the lane being dropped onto. The caller decides what
+ * belongs in that list; this only measures. The nearest edge inside the
+ * threshold wins, and ties go to the earlier one so the result is stable as
+ * the pointer jitters.
+ *
+ * Returns the original time when nothing is close enough, which is also how a
+ * caller disables snapping — pass no edges.
+ */
+export function snapToEdges(
+  map: LaneTimeMap,
+  timeSeconds: number,
+  edges: readonly number[],
+  thresholdPx: number,
+): number {
+  if (edges.length === 0 || !(thresholdPx > 0)) return timeSeconds;
+  const x = map.at(timeSeconds);
+  let best = timeSeconds;
+  let bestDistance = thresholdPx;
+  for (const edge of edges) {
+    const distance = Math.abs(map.at(edge) - x);
+    // Strictly less, so the first edge at a given distance keeps it.
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = edge;
+    }
+  }
+  return best;
+}
+
+/**
+ * The times a drop should snap to: every picture card's start and end, plus
+ * the ends of the clips already on the target lane — minus the clip being
+ * dragged, which must not snap to itself.
+ */
+export function snapEdgesFor(
+  picture: readonly LaneRowItem[],
+  laneItems: readonly Readonly<{ id: string; startSeconds: number; durationSeconds: number }>[],
+  draggedId: string,
+): number[] {
+  const edges: number[] = [];
+  for (const item of picture) {
+    edges.push(item.startSeconds, item.startSeconds + Math.max(0, item.durationSeconds));
+  }
+  for (const item of laneItems) {
+    if (item.id === draggedId) continue;
+    edges.push(item.startSeconds, item.startSeconds + Math.max(0, item.durationSeconds));
+  }
+  return edges;
 }
 
 /**


### PR DESCRIPTION
Closes #399. Phase A made lane and placement real graph state behind a command; this is the gesture. A bed can be dragged onto another lane, slid along one to line up with a cut, and dragged back onto the picture — and every one of those is undoable, because it commits as the command phase A added.

## A lane row is a different kind of target

The strip's existing droppable resolves a pointer to a boundary **index**, which means nothing on a lane: clips there are positioned by their own start, not by their place in a queue.

So rows register their own target (`VirtualPlaceTarget`) resolving to a lane and a **time**, the provider forms a `place-at-time` intent, and `resolvePlacementCommand` turns it into `set-node-placement`. One pipeline, one mutation path, one history entry.

The time comes from inverting the map #401 already had — `timeAt` is the same piecewise walk read backwards, anchored on the same measured card edges, so `timeAt(at(t)) === t` for anything the picture can express (gutters and past-the-end extrapolation included). That round trip is the invariant the whole gesture rests on, and it's pinned directly.

## Snapping is measured in pixels

The scale changes with zoom, so *"within 0.2s"* is a hand-width at one zoom and invisible at another, while *"within 8px"* is the same gesture everywhere. Targets are the picture's cuts and the other clips on the destination lane — never the dragged clip itself, which would snap to where it already is.

**Shift places exactly.** It's tracked with listeners rather than read off the drag event, because dnd-kit's collision pass carries no modifiers and the key can be pressed mid-drag: the answer has to be live when the pointer moves, not at pick-up.

## Collision precedence — and the regression it cost me

A row is a smaller rect than the strip container, and `pointerWithin` ranks by distance-to-centre with no notion of z-order, so a row can win by accident. **Ranking it lower is not enough — an inapplicable row has to be removed from the candidate set.**

The rule is that the picture is **ordered** and a lane is **placed**:

- A lane row always applies.
- The picture row applies only to a clip arriving *from* a lane — "put this back in the cut", which has to work anywhere on that row rather than only through a gutter between two shots.
- For a clip already on the picture it's excluded outright, or an ordinary reorder resolves to a no-op placement instead of an insert.

I shipped the merely-ranked version first and the e2e caught it: *"a gap drop lands where the PICTURE says"* went from passing to a silent no-op — the worst shape of wrong, and exactly the failure that test was written for in #401. Both cases have a test now, and the lane e2e drops onto a **card** deliberately, because that's the case the crossing rule exists for.

## Dropping on the picture clears the placement

The clip takes the slot its array position gives it. There's no "here" to land at on a row that packs end to end, and the alternative — a move *and* a placement for one gesture — isn't expressible as a single history entry in this store. It would have cost two undos for one drag. Nudging it along from there is the ordinary reorder drag, which already exists.

## The preview

Draws where the clip's **left edge** will be — what the drop sets and what the user is aiming — not a boundary line between two cards, because a placement has no boundary. Without it snapping is invisible: there's no way to tell that releasing here lands on the cut rather than 3px off.

## The app needed no changes

A placement skips `mapDropCommand` (that seam corrects a *boundary* whose meaning a view changed, and a lane and a time mean the same thing in every view), and it emits a patch, so PersistenceBridge saves it like anything else. The e2e proves the whole path in the real app, undo included.

## Verified

- app + UI `tsc` clean; lint clean (same 5 pre-existing `<img>` warnings)
- **1078** app tests
- **671** shared unit tests
- **210** story interaction tests (+4: a cross-lane drag, a drop onto the picture with its undo, the snapped preview, and the placement command through the real store)
- **172** graph-view e2e (+1: a real-mouse lane drag with its undo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
