### PR TITLE
Let a first lane be made by dragging

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -1561,7 +1561,11 @@ export function GraphBoard({
     // The snapshot's type widens `DetailsById`'s values to `| undefined`;
     // every read below already treats a missing entry as absent.
     const model = splitLaneRows(graph, detailsSnapshot as DetailsById, focusedId);
-    if (model.layers.length === 0) return null;
+    // NOT gated on there being a layer. Supplying the clock is what turns
+    // placement on, and a board with nothing layered still needs somewhere to
+    // make the FIRST lane — otherwise the only route is a tool call. With an
+    // empty `layers` the strip draws no rows and its DOM is unchanged; it just
+    // offers a target while a drag is live.
     return {
       itemIds: model.pictureIds.map(parseNodeId),
       itemTimes: model.pictureTimes,

--- a/packages/ui/dnd-collections/API.md
+++ b/packages/ui/dnd-collections/API.md
@@ -1099,6 +1099,15 @@ a ROW beats the strip container (it is the more specific answer), and CROSSING
 a row beats a card (dragging a bed up onto the picture has to work anywhere on
 that row). Within one row a card still wins, so reorder is untouched.
 
+While a node drag is live the strip also offers ONE MORE row below the last
+occupied lane, which drops onto the next free lane. It is what makes a first
+lane reachable at all: rows render only for occupied lanes, so without it the
+gesture assumed a state only the consumer's own tooling could produce. It
+appears only during a drag (permanent chrome for an occasional gesture is a
+bad trade) and it is `aria-hidden` with no cells, so the grid tree is
+unaffected. Supplying `itemTimes` is what turns placement on — `layers` may be
+empty.
+
 Dropping on the picture row resolves to lane 0, which CLEARS the placement —
 the clip rejoins the cut at its array position. There is no time to land at on
 a row that packs end to end, and a move plus a placement is not expressible as

--- a/packages/ui/dnd-collections/VirtualStrip.stories.tsx
+++ b/packages/ui/dnd-collections/VirtualStrip.stories.tsx
@@ -2650,6 +2650,60 @@ export const DraggingBetweenLanesPlacesTheClip: Story = {
   },
 };
 
+/** A board with NOTHING layered — the state the first lane has to be made from. */
+function NoLanesYetHarness() {
+  return (
+    <DndCollections initialGraph={laneGraph()} animateMoves={false}>
+      <div className="flex w-[640px] flex-col gap-2">
+        <PlacementReadout id="shot3" />
+        <VirtualStrip
+          collectionId={parseNodeId("strip")}
+          itemIds={PICTURE_IDS}
+          itemTimes={PICTURE_TIMES}
+          layers={[]}
+          pixelsPerSecond={LANE_PPS}
+        />
+      </div>
+    </DndCollections>
+  );
+}
+
+export const AFirstLaneCanBeMadeByDragging: Story = {
+  // The dead end this closes: rows render only for OCCUPIED lanes, so with
+  // none there was nowhere to drop and the first lane could only be made by a
+  // tool call. The gesture assumed a state it could not produce.
+  render: () => <NoLanesYetHarness />,
+  play: async ({ canvasElement }) => {
+    const shot3 = nodeCard(canvasElement, "shot3");
+    await waitForLayout(shot3);
+    const newLaneRow = () =>
+      canvasElement.querySelector<HTMLElement>("[data-strip-new-lane]");
+    const readout = () =>
+      canvasElement.querySelector("[data-placement]")?.getAttribute("data-placement");
+
+    // AT REST there is no band — it would be permanent chrome on every board.
+    expect(newLaneRow()).toBeNull();
+    expect(readout()).toBe("-1@-1");
+
+    // Hold a shot mid-drag: the target appears, offering lane 1.
+    const shot1Box = nodeCard(canvasElement, "shot1").getBoundingClientRect();
+    await dragHoldAt(nodeHandle(canvasElement, "shot3"), {
+      x: shot1Box.left + 4,
+      y: shot1Box.bottom + 20,
+    });
+    await waitFor(() => expect(newLaneRow()).not.toBeNull());
+    expect(newLaneRow()!.getAttribute("data-strip-new-lane")).toBe("1");
+
+    // Release on it: the shot leaves the cut for a lane that did not exist.
+    const rowBox = newLaneRow()!.getBoundingClientRect();
+    await releaseAt({ x: rowBox.left + 4, y: rowBox.top + rowBox.height / 2 });
+    await waitFor(() => expect(readout()).toBe("1@0"));
+
+    // And it is gone again once the drag ends.
+    await waitFor(() => expect(newLaneRow()).toBeNull());
+  },
+};
+
 export const PlacementPreviewSnapsToACut: Story = {
   // The preview is the whole reason snapping is discoverable: without it a
   // user cannot tell that releasing here lands on the cut rather than 3px off.

--- a/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
@@ -155,7 +155,8 @@ function LaneRowDroppable({
   lane: number;
   resolveTime: (point: Readonly<{ x: number; y: number }>) => number;
   style: CSSProperties;
-  children: ReactNode;
+  /** Optional: the new-lane target is an empty band, not a row of cards. */
+  children?: ReactNode;
 }> &
   Readonly<Record<string, unknown>>) {
   // Read through a ref so the droppable's data closure never goes stale as the
@@ -409,6 +410,13 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
     const laneRows = layers !== undefined && layers.length > 0 && itemTimes !== undefined
       ? layers
       : null;
+    // The MACHINERY — the time map and the placement droppables — is separate
+    // from the visible ROWS, and it has to be, or lanes are a dead end: with
+    // no lane yet there is no row, with no row there is nowhere to drop, and
+    // the first lane could only ever be made by a tool call. A consumer that
+    // supplies a clock is opting into placement whether or not anything is
+    // layered yet.
+    const canPlace = itemTimes !== undefined && layers !== undefined;
     const layerHeight = finitePositiveOr(
       layerHeightOption,
       Math.max(MIN_LANE_ROW_HEIGHT, itemHeight * LANE_ROW_HEIGHT_FRACTION),
@@ -786,7 +794,7 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
     // it repacks — so a layer card downstream of a live trim lags by the trim
     // delta until the commit lands. Sub-second, and exact from then on.
     const laneTimeMap = useMemo(() => {
-      if (!laneRows || !itemTimes) return null;
+      if (!canPlace || !itemTimes) return null;
       const slots: LanePictureSlot[] = [];
       let x = firstItemGutter;
       for (let index = 0; index < childIds.length; index += 1) {
@@ -818,7 +826,7 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
       // it closes over the current render's functions, so it cannot go stale.
       // eslint-disable-next-line react-hooks/exhaustive-deps -- see above
     }, [
-      laneRows,
+      canPlace,
       itemTimes,
       childIds,
       firstItemGutter,
@@ -868,6 +876,15 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
       draggedId: (activeId as string | null) ?? "",
     };
 
+    // The NEXT free lane, offered as a drop target while a node drag is live.
+    // Only while dragging: at rest it would be a permanent empty band on every
+    // board, which is a lot of chrome to carry for an occasional gesture.
+    // Gated on a dragged NODE rather than `isDragging` alone — a palette drag
+    // is creating something that does not exist yet, and a placement command
+    // needs a node to name.
+    const newLane = (laneRows?.length ?? 0) + 1;
+    const showNewLaneRow = canPlace && activeId !== null;
+
     // Row 0 is the picture, then each layer in order — the shape the roving
     // resolver navigates. Empty without lanes, which is what keeps the plain
     // strip on its original 1D path.
@@ -900,7 +917,7 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
     const exactRef = useRef(false);
     const isDragging = useCollectionsSelector((s) => s.interaction.isDragging);
     useEffect(() => {
-      if (!isDragging || !laneRows) return;
+      if (!isDragging || !canPlace) return;
       const sync = (event: KeyboardEvent) => {
         exactRef.current = event.shiftKey;
       };
@@ -911,7 +928,7 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
         window.removeEventListener("keydown", sync);
         window.removeEventListener("keyup", sync);
       };
-    }, [isDragging, laneRows]);
+    }, [isDragging, canPlace]);
 
     // Pointer -> a start time on the CONSUMER'S clock, for one row.
     //
@@ -1429,9 +1446,16 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
                   virtualizer.getTotalSize() + (trailingSlot ? itemWidth + gap : 0),
                   layerPlacements.right,
                 ),
-                height: laneRows
-                  ? laneStackHeight(itemHeight, layerHeight, layerGap, laneRows.length)
-                  : itemHeight,
+                // Grows to hold the new-lane row while one is offered. Rows
+                // are positioned from the TOP, so nothing already on screen
+                // moves — the strip just gets taller for the length of the
+                // drag, which is also what makes room to aim at.
+                height: laneStackHeight(
+                  itemHeight,
+                  layerHeight,
+                  layerGap,
+                  (laneRows?.length ?? 0) + (showNewLaneRow ? 1 : 0),
+                ),
                 position: "relative",
                 // The left-handle "grows left" anchor (0 unless a left trim is
                 // in flight). Shifts the whole content layer so clips move
@@ -1493,6 +1517,28 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
                 pictureCells
               )}
               {laneRowElements}
+              {/* SOMEWHERE TO MAKE THE FIRST LANE. Without this the gesture
+                  assumes a state only a tool call could produce: rows render
+                  for occupied lanes, so with none there was nothing to drop
+                  on. Dashed and unlabelled — it is a target, not content, and
+                  it carries no cells, so it stays out of the grid tree. */}
+              {showNewLaneRow && (
+                <LaneRowDroppable
+                  collectionId={collectionId}
+                  lane={newLane}
+                  resolveTime={resolveTimeFor(newLane)}
+                  aria-hidden="true"
+                  data-strip-new-lane={newLane}
+                  className="rounded-sm border border-dashed border-border/70"
+                  style={{
+                    position: "absolute",
+                    left: 0,
+                    right: 0,
+                    top: laneRowTop(newLane, itemHeight, layerHeight, layerGap),
+                    height: layerHeight,
+                  }}
+                />
+              )}
               {trailingSlot && (
                 <div
                   data-virtual-trailing-slot


### PR DESCRIPTION
Follow-up to #405.

#399 shipped the drag and left a dead end I only noticed when asked how to see tracks in the UI: **lane rows render only for occupied lanes**, so with none there was nowhere to drop. Dragging could move a clip *between* lanes but never make one — the first lane could only ever come from a `set_lane` call.

The gesture assumed a state only the agent tools could produce, which made the whole feature agent-only in practice.

So while a node drag is live, the strip offers one more row below the last occupied lane, dropping onto the next free one.

## The gating had to split

Everything lane-shaped hung off *"are there layers"* — which is exactly the condition that is false when you need this most.

The **machinery** (the time map and the placement droppables) now follows `itemTimes`: supplying a clock is what opts a consumer into placement, and `layers` may be empty. The visible **rows** still follow `layers`, so a board with nothing layered renders exactly as before, down to the DOM — pinned by the existing `WithoutLanesTheStripIsUnchanged` story.

## Only during a drag

A permanent empty band on every board is a lot of chrome for an occasional gesture, and it would read as content rather than as a target.

Gated on a dragged **node** rather than `isDragging` alone: a palette drag is creating something that doesn't exist yet, and a placement command needs a node to name.

The content spacer grows to hold it. Rows are positioned from the top, so nothing already on screen moves — the strip just gets taller for the length of the drag, which is also what makes room to aim at. It's `aria-hidden` and carries no cells, so the grid tree is untouched.

Scope is the focused strip only: flat mode and sub-timeline rows pass no clock, and the grid has no time axis.

## Verified

- app + UI `tsc` clean; lint clean (same 5 pre-existing `<img>` warnings)
- **1078** app tests
- **671** shared unit tests
- **211** story interaction tests (+1: no band at rest, a band offering lane 1 mid-drag, a drop that creates it, and the band gone again after)
- graph-view e2e: **171/172** on each of two full local runs, a *different* test each time and both element-visibility timeouts. Each passes alone (2.1s against a 5s ceiling, 3/3 on repeat) — the contention shape, with another session holding the shared dev server. CI runs clean and is the arbiter here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
