### PR TITLE
Make the drop target and the snap visible

### DIFF
--- a/packages/ui/dnd-collections/VirtualStrip.stories.tsx
+++ b/packages/ui/dnd-collections/VirtualStrip.stories.tsx
@@ -2726,10 +2726,16 @@ export const PlacementPreviewSnapsToACut: Story = {
 
     await waitFor(() => expect(marker()).not.toBeNull());
     expect(marker()!.getAttribute("data-place-indicator")).toBe("2");
-    // Snapped: the marker sits ON the cut, not 3px past it. Compared against
-    // shot 2's own left edge so this holds whatever the container's offset is.
-    const markerX = marker()!.getBoundingClientRect().left;
-    expect(Math.abs(markerX - shot2Box.left)).toBeLessThanOrEqual(1.5);
+    // The LANE is said by the row highlight, because the time indicator now
+    // spans the whole stack so the drag ghost cannot cover it.
+    expect(
+      canvasElement.querySelector('[data-strip-lane="2"][data-place-target="true"]'),
+    ).not.toBeNull();
+    // Snapped: the marker sits ON the cut, not 3px past it. Measured at its
+    // CENTRE, because the bar is centred on the time it marks — comparing its
+    // left edge would move with the bar's own width.
+    const box = marker()!.getBoundingClientRect();
+    expect(Math.abs(box.left + box.width / 2 - shot2Box.left)).toBeLessThanOrEqual(1.5);
 
     await releaseAt(near);
   },

--- a/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
@@ -1317,6 +1317,13 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
           role="row"
           aria-rowindex={layerIndex + 2}
           data-strip-lane={lane}
+          data-place-target={placingLane === lane ? "true" : undefined}
+          // WHICH ROW the drop lands on. The time indicator runs the full
+          // stack height so it cannot be hidden, which means it can no longer
+          // say which lane on its own — this does.
+          className={
+            placingLane === lane ? "rounded-sm bg-primary/10 ring-1 ring-primary/50" : undefined
+          }
           style={{
             position: "absolute",
             left: 0,
@@ -1471,15 +1478,20 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
                   user is aiming. On the picture row it is a full-height bar,
                   because dropping there means "rejoin the cut" rather than
                   "land at this instant". */}
-              {laneRows !== null && placingLane !== null && laneTimeMap !== null && (
+              {placingLane !== null && laneTimeMap !== null && (
                 <div
                   aria-hidden="true"
                   data-place-indicator={placingLane}
-                  className="pointer-events-none absolute z-20 w-0.5 -translate-x-1/2 rounded-full bg-primary"
+                  // FULL HEIGHT, and thicker. Confined to its own row it was a
+                  // 2px line directly under the drag ghost — which is centred
+                  // on the pointer, so the one thing that shows you the snap
+                  // was hidden by the thing you were dragging. Running the
+                  // whole stack clears the ghost at top and bottom, and it
+                  // reads against the picture, which is what a time is
+                  // measured against. WHICH row is the row highlight's job.
+                  className="pointer-events-none absolute inset-y-0 z-20 w-1 -translate-x-1/2 rounded-full bg-primary"
                   style={{
                     left: placingStart === null ? 0 : laneTimeMap.at(placingStart),
-                    top: laneRowTop(placingLane, itemHeight, layerHeight, layerGap),
-                    height: placingLane === 0 ? itemHeight : layerHeight,
                   }}
                 />
               )}
@@ -1503,6 +1515,10 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
                   role="row"
                   aria-rowindex={1}
                   data-strip-lane={0}
+                  data-place-target={placingLane === 0 ? "true" : undefined}
+                  className={
+                    placingLane === 0 ? "rounded-sm bg-primary/10 ring-1 ring-primary/50" : undefined
+                  }
                   style={{
                     position: "absolute",
                     left: 0,
@@ -1529,7 +1545,16 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
                   resolveTime={resolveTimeFor(newLane)}
                   aria-hidden="true"
                   data-strip-new-lane={newLane}
-                  className="rounded-sm border border-dashed border-border/70"
+                  data-place-target={placingLane === newLane ? "true" : undefined}
+                  // At border/70 on a dark board this was a rectangle you
+                  // could find once you knew it was there and would never
+                  // discover. It is an invitation, so it looks like one — and
+                  // it fills in when the drop would actually land on it.
+                  className={
+                    placingLane === newLane
+                      ? "rounded-sm border-2 border-dashed border-primary bg-primary/15"
+                      : "rounded-sm border-2 border-dashed border-muted-foreground/50"
+                  }
                   style={{
                     position: "absolute",
                     left: 0,


### PR DESCRIPTION
Follow-up to #406.

Both drag affordances were **correct and nearly invisible**. The tests couldn't tell me — they assert positions, and the positions were right. It took looking at a screenshot of an actual drag.

## The snap indicator was hidden by the thing being dragged

It was a 2px bar confined to its own row, and the drag ghost is centred on the pointer and drawn on top — so the one thing that tells you the drop will land on the cut sat underneath the card you were moving.

It runs the **full stack height** now and is twice as thick: it clears the ghost above and below, and it reads against the picture, which is what a time is measured against.

That costs it the ability to say which *lane*, so **the target row says it instead** — tinted and ringed while the drop would land there.

One signal each: the line is *when*, the row is *where*. Trying to carry both in one 2px mark is what made it illegible.

## The new-lane band was a rectangle you had to know about

`border-dashed border-border/70` on a dark board is not an invitation. It's a real border now, and it **fills in** when the drop would actually land on it.

That matters most for this one: it's the only route to a first lane, and a user who can't see it concludes the feature doesn't exist.

## The test caught the fix, correctly

Widening the bar moved its left edge by a pixel and the snap assertion failed at its 1.5px tolerance. The assertion was measuring the bar's **left edge** when the bar is centred on the time it marks — so the fix was to measure the **centre**, which is width-independent, rather than to loosen the tolerance.

## Verified

- app + UI `tsc` clean; lint clean (same 5 pre-existing `<img>` warnings)
- **1078** app tests
- **671** shared unit tests
- **211** story interaction tests
- **172** graph-view e2e — a clean run, no flakes

Re-shot both drags afterwards to confirm by eye rather than by assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
