### PR TITLE
Let the preview play what the export already renders

### DIFF
--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -150,14 +150,31 @@ function compileFixtureManifest(
      *  no way back on the way down: an enabled child of a disabled parent
      *  still does not play. */
     inheritedDisabled: boolean,
+    /** The OUTERMOST non-zero lane seen on the way down, 0 while still on the
+     *  picture — the same one-way shape as `inheritedDisabled`.
+     *
+     *  Missing here for the same reason `disabled` once was, and it would have
+     *  failed the same way: this mock emitted no `trackIndex` at all, so every
+     *  leaf arrived on lane 0 and the manifest said the timeline had no lanes.
+     *  A test asserting that a bed plays under the picture would have passed
+     *  against a manifest in which there was no bed. */
+    laneFromRoot: number,
   ) => {
     const doc = documents.get(documentId);
     if (!doc) return;
     for (const clip of doc.clips) {
       const clipDisabled = inheritedDisabled || clip.disabled === true;
+      const clipLane =
+        laneFromRoot !== 0 ? laneFromRoot : ((clip.trackIndex as number | undefined) ?? 0);
       if (clip.kind === "collection") {
         const childId = clip.childTimelineId as string;
-        walk(childId, [...path, childId], offset + (clip.startTime as number), clipDisabled);
+        walk(
+          childId,
+          [...path, childId],
+          offset + (clip.startTime as number),
+          clipDisabled,
+          clipLane,
+        );
         continue;
       }
       leaves.push({
@@ -170,12 +187,15 @@ function compileFixtureManifest(
         timelineDuration: clip.duration,
         sourceStart: clip.trimIn ?? 0,
         playbackRate: 1,
+        // Always present, exactly as the real compiler emits it — 0 is the
+        // answer for everything written before lanes, never absence.
+        trackIndex: clipLane,
         // Omitted when false, exactly as the real compiler emits it.
         ...(clipDisabled ? { disabled: true } : {}),
       });
     }
   };
-  walk(rootId, [rootId], 0, false);
+  walk(rootId, [rootId], 0, false, 0);
   const durationSeconds = root.clips.reduce(
     (duration, clip) =>
       Math.max(duration, (clip.startTime as number) + (clip.duration as number)),
@@ -8340,5 +8360,50 @@ test.describe("graph view E2E", () => {
     // And the reorder left the LANE alone — moving within the picture is not
     // a lane change (that is a detail write, and a separate gesture).
     expect(await laneOrder(page, PROJECT_ID, 1)).toEqual(["bravo"]);
+  });
+
+  // LAYERED PLAYBACK. The board has drawn lanes since #397 and the export has
+  // mixed them since phase 2, but the PREVIEW silenced everything except one
+  // clip — so a bed was audible in the finished mp4 and not while you worked
+  // on it. This drives the whole app path: lane on the clip → trackIndex in
+  // the manifest → a second element live in the pane.
+  test("a layered clip is LIVE in the preview, and the picture HOLDS under it", async ({
+    page,
+  }) => {
+    await installGraphApi(page, { lanes: { bravo: 1 } });
+    await openGraph(page);
+    await expect.poll(() => laneOrder(page, PROJECT_ID, 1)).toEqual(["bravo"]);
+
+    await previewToggle(page).click();
+    const surface = page.getByTestId("workbench-display-surface");
+    await expect(surface).toBeVisible();
+    // On the MANIFEST before scrubbing — only it carries `trackIndex`, so the
+    // projection fallback would report no lanes at all. Same reasoning as the
+    // disabled-clip scrub above.
+    await expect(page.locator("[data-preview-source]")).toHaveAttribute(
+      "data-preview-source",
+      "manifest",
+    );
+
+    // bravo spans 6-10 (fixture starts are `1 + index * 5`), and the picture
+    // has NOTHING there: alpha ends at 7 and clip-scene starts at 11. So this
+    // window is both halves of the change at once — a layer that has to be
+    // live, over a picture gap the surface has to hold across.
+    const rail = page.locator("[data-graph-seek-rail]").first();
+    await expect(rail).toBeVisible();
+    const box = (await rail.boundingBox())!;
+    const canvas = surface.locator("canvas");
+
+    await expect(async () => {
+      for (const fraction of [0.4, 0.42, 0.44, 0.46]) {
+        await page.mouse.click(box.x + box.width * fraction, box.y + box.height / 2);
+        if ((await surface.getAttribute("data-live-layer-count")) === "1") break;
+      }
+      await expect(surface).toHaveAttribute("data-live-layer-count", "1", { timeout: 700 });
+      // Holding alpha, NOT drawing bravo. Resolving "what covers this time"
+      // would answer bravo here — that is the flash this fixes, and packing
+      // puts a gap like it at every cut.
+      await expect(canvas).toHaveAttribute("aria-label", "alpha preview", { timeout: 700 });
+    }).toPass({ timeout: 10000 });
   });
 });

--- a/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
+++ b/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
@@ -531,3 +531,132 @@ export const ClosablePreview: Story = {
     expect(await canvas.findByTestId("preview-closed")).toBeInTheDocument();
   },
 };
+
+// ── LANES ───────────────────────────────────────────────────────────────────
+//
+// A timeline shaped like a real one: two shots with the packing gap between
+// them, and a bed running underneath across the cut.
+//
+// CLIP_GAP_SECONDS is 0.12, so shot B starts at 4.12 and the window 4.00-4.12
+// is covered by nothing but the bed. That window is the interesting one twice
+// over: the bed has to be audible in it, and the surface has to keep showing
+// shot A rather than the bed's stand-in.
+
+function laneClip(
+  id: string,
+  startTime: number,
+  duration: number,
+  trackIndex: number,
+  extra: Partial<TimelineClip> = {},
+): TimelineClip {
+  return {
+    id,
+    index: 0,
+    kind: "image",
+    src: PIXEL,
+    alt: id,
+    title: id,
+    aspect: 16 / 9,
+    trackIndex,
+    startTime,
+    duration,
+    sourceDuration: duration,
+    trimIn: 0,
+    trimOut: 0,
+    ...extra,
+  } as TimelineClip;
+}
+
+const SHOT_A = laneClip("shot-a", 0, 4, 0);
+const SHOT_B = laneClip("shot-b", 4.12, 4, 0);
+const BED = laneClip("bed", 0, 6, 1);
+
+function LayeredFixture({ time, clips }: { time: number; clips: TimelineClip[] }) {
+  const [currentTime, setCurrentTime] = useState(time);
+
+  return (
+    <main className="min-h-[900px] bg-zinc-950 p-4 text-zinc-100">
+      <WorkbenchDisplaySurface
+        clips={clips}
+        currentTime={currentTime}
+        onCurrentTimeChange={setCurrentTime}
+        className="h-[320px]"
+      />
+    </main>
+  );
+}
+
+/** A bed under the picture is LIVE alongside it, not instead of it. The export
+ *  has always mixed layered audio; until this, the preview silenced it. */
+export const LayeredAudioPlaysUnderThePicture: Story = {
+  render: () => <LayeredFixture time={2} clips={[SHOT_A, SHOT_B, BED]} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const surface = canvas.getByTestId("workbench-display-surface");
+
+    // Two clips cover t=2: the shot and the bed. The shot supplies the frame…
+    expect(canvas.getByLabelText("shot-a preview")).toBeInTheDocument();
+    // …and the bed is playing underneath it rather than being paused to zero.
+    expect(surface).toHaveAttribute("data-live-layer-count", "1");
+  },
+};
+
+/** THE GAP AT EVERY CUT. Packing leaves 0.12s between shots; a bed covers it.
+ *  The surface must hold the outgoing shot — resolving "what covers this time"
+ *  would answer "the bed" and flash its stand-in three frames per cut. */
+export const APictureGapHoldsTheOutgoingShot: Story = {
+  render: () => <LayeredFixture time={4.06} clips={[SHOT_A, SHOT_B, BED]} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const surface = canvas.getByTestId("workbench-display-surface");
+
+    expect(canvas.getByLabelText("shot-a preview")).toBeInTheDocument();
+    // Still sounding through the cut — the gap is a picture gap, not a hole in
+    // the timeline.
+    expect(surface).toHaveAttribute("data-live-layer-count", "1");
+  },
+};
+
+/** A layer that has ENDED is not held the way a frame is. The screen cannot
+ *  show nothing, so the picture holds; sound can stop, so it stops. */
+export const AFinishedLayerGoesSilent: Story = {
+  render: () => <LayeredFixture time={7} clips={[SHOT_A, SHOT_B, BED]} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const surface = canvas.getByTestId("workbench-display-surface");
+
+    expect(canvas.getByLabelText("shot-b preview")).toBeInTheDocument();
+    expect(surface).toHaveAttribute("data-live-layer-count", "0");
+  },
+};
+
+/** A disabled layer is silent, while a disabled PICTURE is still drawn (grayed)
+ *  because scrubbing can rest inside it. */
+export const ADisabledLayerIsNotLive: Story = {
+  render: () => (
+    <LayeredFixture
+      time={2}
+      clips={[SHOT_A, SHOT_B, laneClip("bed", 0, 6, 1, { disabled: true })]}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByTestId("workbench-display-surface")).toHaveAttribute(
+      "data-live-layer-count",
+      "0",
+    );
+  },
+};
+
+/** Nothing lane-shaped changes for a timeline that uses no lanes. */
+export const WithoutLanesNothingIsLive: Story = {
+  render: () => <LayeredFixture time={2} clips={[SHOT_A, SHOT_B]} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByTestId("workbench-display-surface")).toHaveAttribute(
+      "data-live-layer-count",
+      "0",
+    );
+    expect(canvas.getByLabelText("shot-a preview")).toBeInTheDocument();
+  },
+};

--- a/packages/ui/timeline/viewport/playback-skip.test.ts
+++ b/packages/ui/timeline/viewport/playback-skip.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 
 import type { TimelineClip } from "../types";
-import { getContainingClip, getTimelineDuration, nextPlayableTime } from "./playback-skip";
+import {
+  getContainingClip,
+  getLiveLayerClips,
+  getPictureClip,
+  getTimelineDuration,
+  nextPlayableTime,
+} from "./playback-skip";
 
 function image(
   id: string,
@@ -170,5 +176,108 @@ describe("getContainingClip with lanes", () => {
     expect(getContainingClip(clips, 2)?.id).toBe("a");
     expect(getContainingClip(clips, 9)?.id).toBe("c");
     expect(getContainingClip(clips, 30)).toBeNull();
+  });
+
+  it("RETURNS THE BED IN A PICTURE GAP — correct here, wrong to draw", () => {
+    // Packing leaves CLIP_GAP_SECONDS between every two picture clips, so this
+    // is the shape of every cut on a timeline that has a bed under it. Asking
+    // "is this time inside material" the answer really is the bed, and
+    // nextPlayableTime needs that or it would snap the clock across the gap
+    // while the bed is still playing.
+    //
+    // It is the WRONG answer to "what do I draw", which is why the surface
+    // resolves the picture through getPictureClip instead.
+    const shots = [image("a", 0, 4), image("c", 4.12, 4)];
+    const bed = onLane(image("bed", 0, 30), 1);
+    expect(getContainingClip([...shots, bed], 4.06)?.id).toBe("bed");
+  });
+});
+
+// ── WHAT DRAWS, AND WHAT MERELY PLAYS ───────────────────────────────────────
+//
+// Two questions, previously answered by one function. getContainingClip stays
+// the answer to "is this time inside material" (nextPlayableTime's question).
+// These two split out the surface's question: exactly one clip supplies the
+// frame, and any number of others are simultaneously audible underneath it.
+
+describe("getPictureClip", () => {
+  it("is the lane-0 clip covering the time", () => {
+    const bed = onLane(image("bed", 0, 30), 1);
+    const shot = image("shot", 0, 4);
+    expect(getPictureClip([bed, shot], 2)?.id).toBe("shot");
+  });
+
+  it("HOLDS THE OUTGOING SHOT ACROSS A PICTURE GAP, bed or no bed", () => {
+    // The bug this function exists for. Packing puts CLIP_GAP_SECONDS between
+    // every two picture clips, so with a bed under the cut there is a 120ms
+    // window at EVERY cut that only the bed covers — and drawing the bed means
+    // flashing the audio stand-in three frames per cut.
+    //
+    // A gap carries no new frame. It is not an instruction to stop showing the
+    // shot that was on screen.
+    const shots = [image("a", 0, 4), image("c", 4.12, 4)];
+    const bed = onLane(image("bed", 0, 30), 1);
+    expect(getPictureClip([...shots, bed], 4.06)?.id).toBe("a");
+    expect(getPictureClip(shots, 4.06)?.id).toBe("a");
+  });
+
+  it("holds the last shot past the end of the picture", () => {
+    const shot = image("shot", 0, 4);
+    const bed = onLane(image("bed", 0, 30), 1);
+    expect(getPictureClip([shot, bed], 20)?.id).toBe("shot");
+  });
+
+  it("draws nothing in a LEADING gap, before any shot has started", () => {
+    // Nothing has been shown yet, so there is nothing to hold.
+    expect(getPictureClip([image("shot", 4, 4)], 1)).toBeNull();
+  });
+
+  it("falls back to any lane when the timeline has NO picture at all", () => {
+    // A timeline of nothing but audio still has to draw its stand-in rather
+    // than an empty surface — there is no picture to prefer or to hold.
+    const vo = onLane(image("vo", 0, 10), 1);
+    const bed = onLane(image("bed", 0, 10), 2);
+    expect(getPictureClip([bed, vo], 5)?.id).toBe("vo");
+  });
+
+  it("prefers a real picture over a lane clip that started earlier", () => {
+    const bed = onLane(image("bed", 0, 30), 1);
+    const shot = image("shot", 10, 4);
+    expect(getPictureClip([bed, shot], 12)?.id).toBe("shot");
+  });
+});
+
+describe("getLiveLayerClips", () => {
+  it("is every lane clip covering the time, and never the picture", () => {
+    const shot = image("shot", 0, 10);
+    const bed = onLane(image("bed", 0, 30), 1);
+    const vo = onLane(image("vo", 2, 4), 2);
+    expect(getLiveLayerClips([shot, bed, vo], 3).map((clip) => clip.id)).toEqual(["bed", "vo"]);
+  });
+
+  it("DOES NOT HOLD a finished layer — a bed that ended is silent", () => {
+    // The opposite rule to the picture. Holding a frame across a gap is right
+    // because the screen cannot show nothing; holding SOUND across one would
+    // keep playing a bed that ended.
+    const shot = image("shot", 0, 30);
+    const bed = onLane(image("bed", 0, 4), 1);
+    expect(getLiveLayerClips([shot, bed], 10)).toEqual([]);
+  });
+
+  it("leaves out a disabled layer", () => {
+    const bed = onLane(image("bed", 0, 30, true), 1);
+    const vo = onLane(image("vo", 0, 30), 2);
+    expect(getLiveLayerClips([bed, vo], 5).map((clip) => clip.id)).toEqual(["vo"]);
+  });
+
+  it("is empty for a timeline that uses no lanes", () => {
+    expect(getLiveLayerClips(clips, 2)).toEqual([]);
+  });
+
+  it("returns the SAME empty array every time, since this runs per frame", () => {
+    // Allocating a fresh [] 60 times a second for the overwhelmingly common
+    // case — a timeline with no lanes at all — is the kind of per-frame garbage
+    // getContainingClip's manual loop exists to avoid.
+    expect(getLiveLayerClips(clips, 2)).toBe(getLiveLayerClips(clips, 5));
   });
 });

--- a/packages/ui/timeline/viewport/playback-skip.ts
+++ b/packages/ui/timeline/viewport/playback-skip.ts
@@ -55,6 +55,85 @@ export function getContainingClip(clips: readonly TimelineClip[], currentTime: n
   return best;
 }
 
+/** One array, reused. `getLiveLayerClips` runs per frame and the overwhelming
+ *  majority of timelines have no lanes at all, so the common answer must not
+ *  allocate. */
+const NO_LAYERS: readonly TimelineClip[] = [];
+
+/**
+ * The clip the surface draws its frame FROM — the picture, and only ever the
+ * picture.
+ *
+ * `getContainingClip` answers a different question ("is this time inside
+ * material"), and its answer is right for `nextPlayableTime` and wrong here.
+ * The two diverge at every cut: packing leaves `CLIP_GAP_SECONDS` between
+ * picture clips, so on a timeline with a bed under it there is a ~120ms window
+ * at EVERY cut that only the bed covers. Drawing what covers the time there
+ * means flashing the audio stand-in three frames per cut.
+ *
+ * So, in order:
+ *
+ * - a lane-0 clip covering this time, first in array order — the common case;
+ * - otherwise the most recently started lane-0 clip, HELD. A gap carries no new
+ *   frame; it is not an instruction to stop showing the shot that was on
+ *   screen. This is what closes the flash, and it is also the pre-existing gap
+ *   rule, now restricted to the picture;
+ * - otherwise, if the timeline has no lane-0 material AT ALL, whatever covers
+ *   the time on any lane. A timeline of nothing but audio still has to draw its
+ *   stand-in rather than an empty surface.
+ *
+ * Disabled clips are NOT skipped: scrubbing can rest inside one and the surface
+ * draws it grayed. That is the opposite of `getLiveLayerClips` below, and the
+ * asymmetry is deliberate — a disabled clip still occupies the screen, but it
+ * must not make a sound.
+ */
+export function getPictureClip(clips: readonly TimelineClip[], currentTime: number) {
+  let held: TimelineClip | null = null;
+  let sawPicture = false;
+
+  for (const clip of clips) {
+    if (clip.trackIndex !== 0) continue;
+    sawPicture = true;
+    // First match wins, preserving the array-order rule within a lane.
+    if (clipContainsPlaybackTime(clip, currentTime)) return clip;
+    const start = getClipPlaybackStart(clip);
+    if (start > currentTime) continue;
+    if (held === null || start > getClipPlaybackStart(held)) held = clip;
+  }
+
+  if (held !== null) return held;
+  // A leading gap on a real picture correctly yields null — nothing has been
+  // shown yet, so there is nothing to hold.
+  return sawPicture ? null : getContainingClip(clips, currentTime);
+}
+
+/**
+ * Every under-layer audible at this instant: lane 1 and above, enabled, and
+ * STRICTLY covering the time.
+ *
+ * Strict, where the picture holds. Holding a frame across a gap is right
+ * because the screen cannot show nothing; holding SOUND across one would keep
+ * playing a bed after it ended.
+ *
+ * Returned in array order rather than lane order. Draw order is the caller's
+ * business and changes far less often than once a frame — sorting here would
+ * allocate on every tick to answer a question that only matters when the live
+ * set itself changes.
+ */
+export function getLiveLayerClips(
+  clips: readonly TimelineClip[],
+  currentTime: number,
+): readonly TimelineClip[] {
+  let live: TimelineClip[] | null = null;
+  for (const clip of clips) {
+    if (clip.trackIndex === 0) continue;
+    if (clip.disabled === true) continue;
+    if (!clipContainsPlaybackTime(clip, currentTime)) continue;
+    (live ??= []).push(clip);
+  }
+  return live ?? NO_LAYERS;
+}
+
 export function getTimelineDuration(clips: readonly TimelineClip[]) {
   return clips.reduce(
     (duration, clip) =>

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -35,10 +35,15 @@ import {
   clipContainsPlaybackTime,
   getClipPlaybackDuration,
   getClipPlaybackStart,
-  getContainingClip,
+  getLiveLayerClips,
+  getPictureClip,
   getTimelineDuration,
   nextPlayableTime,
 } from "./playback-skip";
+
+/** "Stop everything." One shared instance — the override effect asks for it on
+ *  every change, and a fresh Set per call would be litter. */
+const NO_LIVE_KEYS: ReadonlySet<string> = new Set<string>();
 
 type DisplayMedia = {
   key: string;
@@ -610,25 +615,29 @@ function getActiveClip(
     return preferredClip;
   }
 
-  const containing = getContainingClip(clips, currentTime);
-  if (containing) return containing;
+  // The PICTURE, which also holds the last shot across a gap — see
+  // `getPictureClip`. It used to be `getContainingClip` plus a hold loop right
+  // here, and the difference is the whole reason that function was split:
+  // packing leaves a gap at every cut, and a lane clip covering that gap made
+  // the surface try to draw an under-layer.
+  return getPictureClip(clips, currentTime);
+}
 
-  // Nothing covers this time: the playhead sits in a GAP between clips, or
-  // past the last one. Hold the clip that most recently started instead of
-  // returning null — null renders the empty surface, so a gap flashed to
-  // black mid-timeline. A gap carries no NEW frame; it is not an instruction
-  // to blank what a real clip last showed. (The old special case for "past
-  // the final clip" was this same rule, applied only at the tail.)
-  //
-  // Scans for the greatest start rather than trusting array order, so it
-  // holds the right frame even for a caller that has not sorted. A leading
-  // gap — before any clip has started — correctly still yields null.
-  let held: TimelineClip | null = null;
-  for (const clip of clips) {
-    if (getClipPlaybackStart(clip) > currentTime) continue;
-    if (!held || getClipPlaybackStart(clip) > getClipPlaybackStart(held)) held = clip;
+/** Every under-layer audible at this instant, as resolvable media. The picture
+ *  is excluded — it arrives separately as the thing that DRAWS. */
+function getLayerMedia(
+  clips: TimelineClip[],
+  currentTime: number,
+  getCollectionClipFramePreview: GetCollectionClipFramePreview,
+): DisplayMedia[] {
+  const live = getLiveLayerClips(clips, currentTime);
+  if (live.length === 0) return [];
+  const media: DisplayMedia[] = [];
+  for (const clip of live) {
+    const resolved = resolveClipMedia(clip, currentTime, getCollectionClipFramePreview);
+    if (resolved !== null) media.push(resolved);
   }
-  return held;
+  return media;
 }
 
 // normalizePlaybackTime is `nextPlayableTime` (./playback-skip): it decides
@@ -658,9 +667,16 @@ export function WorkbenchDisplaySurface({
   const cacheRef = useRef(new Map<string, CachedMedia>());
   const activeMediaRef = useRef<DisplayMedia | null>(null);
   const activeClipDisabledRef = useRef(false);
+  // The under-layers audible right now. The picture is `activeMediaRef`; these
+  // play alongside it and, in this phase, are heard and not seen.
+  const liveLayerMediaRef = useRef<DisplayMedia[]>([]);
   const animationFrameRef = useRef<number | null>(null);
   const timeoutFrameRef = useRef<number | null>(null);
-  const pendingSeekDrawCleanupRef = useRef<(() => void) | null>(null);
+  // PER ELEMENT, keyed by media key. This was a single slot, which was correct
+  // while exactly one element could ever be seeking: a second element seeking
+  // concurrently would run the first's cleanup as if it were its own, leaving
+  // the first's listeners attached and its own removed.
+  const pendingSeekDrawCleanupRef = useRef(new Map<string, () => void>());
   const playbackAnchorRef = useRef<{ timelineTime: number; startedAtMs: number } | null>(null);
   const lastPublishedAtRef = useRef(0);
   const lastRenderedMediaKeyRef = useRef<string | null>(null);
@@ -734,6 +750,12 @@ export function WorkbenchDisplaySurface({
   const activeClipIndex = useMemo(
     () => (activeClip ? sortedClips.findIndex((clip) => clip.id === activeClip.id) : -1),
     [activeClip, sortedClips],
+  );
+  // Derived in render from the same pure function the clock path uses, so the
+  // published count and the elements actually playing cannot disagree.
+  const liveLayers = useMemo(
+    () => getLiveLayerClips(sortedClips, currentTime),
+    [currentTime, sortedClips],
   );
   const activeMedia = useMemo(
     () =>
@@ -983,36 +1005,70 @@ export function WorkbenchDisplaySurface({
 
   const frameOverrideRef = useRef(frameOverride);
 
-  const pauseInactiveVideos = useCallback((activeKey: string | null) => {
+  /**
+   * Everything that is NOT live right now goes quiet and stops.
+   *
+   * Live is a SET, not one key. It used to be one: the picture. But a bed on a
+   * lane is playing at the same instant as the shot it runs under, and the
+   * export has always mixed it — silencing it here is what made the preview
+   * disagree with the finished file.
+   */
+  const pauseClipsNotLive = useCallback((liveKeys: ReadonlySet<string>) => {
     const mixer = getMixer();
     cacheRef.current.forEach((cached, key) => {
       if (!isPlayable(cached)) return;
-      if (key !== activeKey) {
-        cached.element.pause();
-        // The prefetch window pulls in the next few clips REGARDLESS of whether
-        // they are disabled, so silence is decided here rather than there.
-        mixer.setSourceGain(cached.element, 0);
-      }
+      if (liveKeys.has(key)) return;
+      cached.element.pause();
+      // The prefetch window pulls in the next few clips REGARDLESS of whether
+      // they are disabled, so silence is decided here rather than there.
+      mixer.setSourceGain(cached.element, 0);
     });
   }, [getMixer]);
 
-  /** The active clip is the only audible one, and a DISABLED clip is silent
-   *  even though scrubbing can rest on it and draw its grayed frame. */
-  const applyActiveGain = useCallback(
+  /**
+   * Raise one live element to the current level.
+   *
+   * `silent` is passed rather than read from a ref because it is a PER-CLIP
+   * fact and there is now more than one live clip: the picture can be disabled
+   * (scrubbed into, drawn grayed, and heard by nobody) while the bed under it
+   * plays perfectly normally. A single `activeClipDisabledRef` consulted here
+   * would mute the bed for the picture's sake.
+   */
+  const applyGain = useCallback(
     // HTMLMediaElement, not HTMLVideoElement: the mixer takes either, and
     // audio clips need their gain applied on the same path or a volume change
     // reaches every clip except the one that is playing.
-    (element: HTMLMediaElement) => {
+    (element: HTMLMediaElement, silent: boolean) => {
       const { volume: level, muted: isMuted } = audioLevelRef.current;
-      const audible = !isMuted && !activeClipDisabledRef.current;
-      getMixer().setSourceGain(element, audible ? level : 0);
+      getMixer().setSourceGain(element, isMuted || silent ? 0 : level);
     },
     [getMixer],
   );
 
-  const syncActiveVideo = useCallback((media: DisplayMedia, shouldPlay: boolean, forceSeek = false) => {
+  /**
+   * Bring one media element into line with the clock: right source time, right
+   * rate, right gain, playing or not.
+   *
+   * `draws` separates the picture from an under-layer. Both are seeked and both
+   * are played; only the picture repaints the canvas when its seek lands. A
+   * layer that repainted would be asking the surface to redraw the picture on
+   * the layer's schedule, several times a second, for no change in pixels.
+   *
+   * `silent` is the clip's own disabled state — see `applyGain`.
+   */
+  const syncMediaElement = useCallback((
+    media: DisplayMedia,
+    { shouldPlay, forceSeek = false, draws, silent }:
+      { shouldPlay: boolean; forceSeek?: boolean; draws: boolean; silent: boolean },
+  ) => {
     const cached = ensureCachedMedia(media);
     if (!isPlayable(cached)) return;
+    // Metadata-only preload is right for a clip the prefetch window merely
+    // pulled in (a lossless voice take is large, and speculatively fetching
+    // four of them to play one is waste). It is wrong the moment the element
+    // has to actually play, so buying the rest of the file is deferred to
+    // exactly here — the first time this element is live.
+    if (shouldPlay && cached.element.preload !== "auto") cached.element.preload = "auto";
 
     // Named `video` throughout because every call below is HTMLMediaElement
     // API that an <audio> satisfies identically — readyState, currentTime,
@@ -1032,23 +1088,27 @@ export function WorkbenchDisplaySurface({
         // decision, and the voice should not move with it.
         video.preservesPitch = true;
       }
-      applyActiveGain(video);
+      applyGain(video, silent);
       if (forceSeek || drift > maxDrift) {
-        pendingSeekDrawCleanupRef.current?.();
-        pendingSeekDrawCleanupRef.current = null;
+        const pending = pendingSeekDrawCleanupRef.current;
+        // This element's own pending cleanup, not whatever seeked last.
+        pending.get(media.key)?.();
+        pending.delete(media.key);
 
-        const drawAfterSeek = () => {
-          pendingSeekDrawCleanupRef.current?.();
-          pendingSeekDrawCleanupRef.current = null;
-          drawActiveFrame();
-        };
+        if (draws) {
+          const drawAfterSeek = () => {
+            pending.get(media.key)?.();
+            pending.delete(media.key);
+            drawActiveFrame();
+          };
 
-        video.addEventListener("seeked", drawAfterSeek, { once: true });
-        video.addEventListener("loadeddata", drawAfterSeek, { once: true });
-        pendingSeekDrawCleanupRef.current = () => {
-          video.removeEventListener("seeked", drawAfterSeek);
-          video.removeEventListener("loadeddata", drawAfterSeek);
-        };
+          video.addEventListener("seeked", drawAfterSeek, { once: true });
+          video.addEventListener("loadeddata", drawAfterSeek, { once: true });
+          pending.set(media.key, () => {
+            video.removeEventListener("seeked", drawAfterSeek);
+            video.removeEventListener("loadeddata", drawAfterSeek);
+          });
+        }
         video.currentTime = targetTime;
       }
       if (shouldPlay && video.paused) {
@@ -1063,7 +1123,7 @@ export function WorkbenchDisplaySurface({
       } else if (!shouldPlay) {
         video.pause();
       }
-      drawActiveFrame();
+      if (draws) drawActiveFrame();
     };
 
     if (video.readyState >= HTMLMediaElement.HAVE_METADATA) {
@@ -1072,8 +1132,8 @@ export function WorkbenchDisplaySurface({
     }
 
     video.addEventListener("loadedmetadata", seek, { once: true });
-    video.addEventListener("loadeddata", drawActiveFrame, { once: true });
-  }, [applyActiveGain, drawActiveFrame, ensureCachedMedia]);
+    if (draws) video.addEventListener("loadeddata", drawActiveFrame, { once: true });
+  }, [applyGain, drawActiveFrame, ensureCachedMedia]);
 
   const renderFrameAtTime = useCallback((timelineTime: number, shouldPlay: boolean, forceSeek = false) => {
     // An override owns the picture while it is set. Guarding HERE rather than
@@ -1100,13 +1160,32 @@ export function WorkbenchDisplaySurface({
     // disabled span before anything is drawn (see nextPlayableTime).
     activeClipDisabledRef.current = active?.disabled === true;
 
+    // The under-layers playing at this instant, alongside the picture rather
+    // than instead of it. Resolved even when the picture is missing: a bed
+    // running under a gap keeps playing, which is the whole point of a bed.
+    const layers = getLayerMedia(
+      sortedClipsRef.current,
+      timelineTime,
+      getCollectionClipFramePreview,
+    );
+    liveLayerMediaRef.current = layers;
+
+    const liveKeys = new Set<string>();
+    if (media) liveKeys.add(media.key);
+    for (const layer of layers) liveKeys.add(layer.key);
+    pauseClipsNotLive(liveKeys);
+
+    for (const layer of layers) {
+      // Never `draws` — an under-layer is audible in this phase, not visible.
+      // Never `silent` — getLiveLayerClips already dropped the disabled ones.
+      syncMediaElement(layer, { shouldPlay, forceSeek, draws: false, silent: false });
+    }
+
     if (!media) {
-      pauseInactiveVideos(null);
       drawEmptyFrame();
       return;
     }
 
-    pauseInactiveVideos(media.key);
     const cached = ensureCachedMedia(media);
 
     if (cached.kind === "image") {
@@ -1118,15 +1197,21 @@ export function WorkbenchDisplaySurface({
       return;
     }
 
-    syncActiveVideo(media, shouldPlay, forceSeek || mediaChanged);
+    syncMediaElement(media, {
+      shouldPlay,
+      forceSeek: forceSeek || mediaChanged,
+      draws: true,
+      silent: activeClipDisabledRef.current,
+    });
   }, [
     drawActiveFrame,
     drawDrawable,
     drawEmptyFrame,
     ensureCachedMedia,
-    pauseInactiveVideos,
+    getCollectionClipFramePreview,
+    pauseClipsNotLive,
     preferredClipId,
-    syncActiveVideo,
+    syncMediaElement,
   ]);
 
   useLayoutEffect(() => {
@@ -1168,15 +1253,19 @@ export function WorkbenchDisplaySurface({
     activeMediaRef.current = media;
     lastRenderedMediaKeyRef.current = media.key;
     activeClipDisabledRef.current = false;
-    pauseInactiveVideos(null);
+    // NOTHING is live under an override — it owns the picture, and the layers
+    // stop with it. An override is a still, so a bed left running underneath
+    // would be sound advancing against a frame that is not moving.
+    liveLayerMediaRef.current = [];
+    pauseClipsNotLive(NO_LIVE_KEYS);
     ensureCachedMedia(media);
-    // NOTE: no `syncActiveVideo` here. The override's seeking is driven by the
+    // NOTE: no `syncMediaElement` here. The override's seeking is driven by the
     // settle loop below instead — see the comment there for why this path
     // cannot use the clock path's issue-and-listen approach.
   }, [
     ensureCachedMedia,
     frameOverride,
-    pauseInactiveVideos,
+    pauseClipsNotLive,
     renderFrameAtTime,
   ]);
 
@@ -1415,8 +1504,9 @@ export function WorkbenchDisplaySurface({
           cached.element.load();
         }
       });
-      pendingSeekDrawCleanupRef.current?.();
-      pendingSeekDrawCleanupRef.current = null;
+      const pending = pendingSeekDrawCleanupRef.current;
+      pending.forEach((cleanup) => cleanup());
+      pending.clear();
       mediaCache.clear();
       mixerRef.current?.dispose();
       mixerRef.current = null;
@@ -1431,11 +1521,17 @@ export function WorkbenchDisplaySurface({
     mixer.setMasterVolume(activeVolume);
     mixer.setMuted(activeMuted);
 
-    const activeKey = activeMediaRef.current?.key ?? null;
-    if (!activeKey) return;
-    const cached = cacheRef.current.get(activeKey);
-    if (isPlayable(cached)) applyActiveGain(cached.element);
-  }, [activeMuted, activeVolume, applyActiveGain, getMixer]);
+    // EVERY live source, not just the picture. A volume change that reached
+    // only the active clip would leave a bed playing at the level it was
+    // started with — audible proof that the two were on different paths.
+    const raise = (key: string, silent: boolean) => {
+      const cached = cacheRef.current.get(key);
+      if (isPlayable(cached)) applyGain(cached.element, silent);
+    };
+    const activeKey = activeMediaRef.current?.key;
+    if (activeKey) raise(activeKey, activeClipDisabledRef.current);
+    for (const layer of liveLayerMediaRef.current) raise(layer.key, false);
+  }, [activeMuted, activeVolume, applyGain, getMixer]);
 
   const canPlay = duration > 0 && sortedClips.length > 0;
   const canSeekPrevious = sortedClips.length > 0 && currentTime > 0;
@@ -1481,6 +1577,11 @@ export function WorkbenchDisplaySurface({
       data-testid="workbench-display-surface"
       data-buffered-media-count={bufferedMedia.length}
       data-preview-playing={isPlaying}
+      // How many UNDER-LAYERS are audible right now, alongside the picture.
+      // A witness for the same reason as the audio ones below — that a bed is
+      // sounding is not observable from a test — and the one that says the
+      // preview and the export agree about what is playing.
+      data-live-layer-count={liveLayers.length}
       // Which clip's frame the pane is drawing INSTEAD of the clock's, if any.
       // A witness, because the alternative is unobservable: whether a canvas
       // holds one decoded frame or another is not something a test can read


### PR DESCRIPTION
Phase 1 of making lanes visible (#310 phase 2). Before any of it can be *seen*, it has to be *heard* — and it wasn't.

## The preview and the export disagreed

|  | Preview | Export |
| --- | --- | --- |
| Lane **audio** | **silent** | mixes correctly (`mixArgs`) |
| Lane **video** | invisible | audio only (`-map 0:v`) |

The player drew and played exactly one clip per instant. `pauseInactiveVideos` paused *and zero-gained* every other cached element; its own comment read "the active clip is the only audible one." `trackIndex` appeared in the entire player in **one line**.

So a bed under a shot was audible in the finished mp4 and silent while you worked on it.

## The same place carried a live bug

`getContainingClip` was answering two questions for two callers:

- `nextPlayableTime` — *"is this time inside material?"* A bed counts, and a test pins it.
- `getActiveClip` — *"what do I draw?"* A bed must not.

Packing leaves `CLIP_GAP_SECONDS` between every two picture clips. With any lane clip present, that **120ms window at every cut** is covered by nothing but the lane clip — so the surface drew its stand-in instead of holding the outgoing shot. About three frames of placeholder per cut, appearing only once you start using lanes.

They're two functions now. `getContainingClip` is untouched. `getPictureClip` resolves lane 0 and holds the last shot across a gap, falling back to any lane only when there's no picture at all so an audio-only timeline still draws. `getLiveLayerClips` is the opposite rule deliberately — strict, never holding, because the screen cannot show nothing but sound can stop.

## Four single-value refs had to become per-element

Each one a real bug the moment two things play at once:

- **`pendingSeekDrawCleanupRef`** was one slot — a second element seeking concurrently would run the first's cleanup as its own, leaving the first's listeners attached and removing its own.
- **Gain** read the disabled flag from a global ref, which would mute an ordinary bed because the picture above it was disabled.
- **The volume effect** reached only the active clip, so a bed would keep playing at the level it started with.
- **Preload** stayed `metadata` for audio — correct for a clip the prefetch window merely pulled in, wrong once it has to play. Buying the rest of the file is deferred to the first time an element is live.

**The mixer needed no changes.** It has been multi-source since it was written; its header anticipates this case exactly.

## Found on the way: a second vacuous fixture

In the same function whose comment documents the first. `compileFixtureManifest` emitted no `trackIndex`, so its manifest said every leaf was on lane 0 — a test asserting a bed plays under the picture would have passed against a manifest containing no bed. It carries the lane down the walk now, outermost non-zero wins, like the real compiler.

## Both proofs fail first, for the right reason

Not merely on a missing attribute. With the picture preference removed, the story and the e2e both go red, and the e2e reports what the old code actually drew mid-cut:

```
Expected: "alpha preview"
Received: "bravo preview"
```

The bed, where a shot should have been held.

## Verified

- app + UI `tsc` clean; lint clean (same 5 pre-existing `<img>` warnings)
- **1090** app tests
- **683** shared unit tests (+12)
- **216** story interaction tests (+5)
- **173** graph-view e2e (+1) — a clean run

Phases 2-4 (geometry on the model, the preview compositing, the ffmpeg overlay, the preset picker) follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
