### PR TITLE
Draw a lane clip inside the picture

### DIFF
--- a/apps/timeline-gstudio001/app/api/mcp/route.ts
+++ b/apps/timeline-gstudio001/app/api/mcp/route.ts
@@ -344,7 +344,7 @@ const handler = createMcpHandler(
 
     server.tool(
       "set_lane",
-      "Move a clip between LANES. Lane 0 is the picture; anything above it plays UNDER the picture at the same time — a voiceover, a music bed. Every lane starts at the beginning of its collection, so putting a clip on lane 1 makes it run alongside the shots rather than after them." +
+      "Move a clip between LANES. Lane 0 is the picture; anything above it plays UNDER the picture at the same time — a voiceover, a music bed. Every lane starts at the beginning of its collection, so putting a clip on lane 1 makes it run alongside the shots rather than after them. A clip that HAS a picture (video, image, or a whole nested scene) also gets a default inset in the bottom-right when it lands on a lane, so it is composited over the picture rather than contributing only its sound; moving it back to lane 0 clears that." +
         NO_LIVE_PUSH_NOTE,
       {
         timelineId: TIMELINE_ID_FIELD,

--- a/apps/timeline-gstudio001/components/graph-view/graph-layer-frame.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-layer-frame.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildGraph,
+  parseNodeId,
+  type GraphNodeSpec,
+  type NodeId,
+  type SetNodePlacementCommand,
+} from "@storyboard/collections-core";
+
+import { defaultLayerFrame } from "@/lib/default-layer-frame";
+
+import { withDefaultLayerFrame } from "./graph-layer-frame";
+
+const SPECS: GraphNodeSpec[] = [
+  { kind: "media", id: "img", name: "img" },
+  { kind: "media", id: "img2", name: "img2" },
+  {
+    kind: "media",
+    mediaKind: "audio",
+    id: "vo",
+    name: "vo",
+    fullDurationSeconds: 5,
+    trimInSeconds: 0,
+    trimOutSeconds: 0,
+  },
+  { kind: "media", id: "framed", name: "framed", layerFrame: { x: 0.1, y: 0.1, width: 0.2 } },
+];
+
+const GRAPH = (() => {
+  const built = buildGraph([{ kind: "collection", id: "root", name: "Root", children: SPECS }]);
+  if (!built.ok) throw new Error(JSON.stringify(built.error));
+  return built.value;
+})();
+
+const ASPECTS: Record<string, number> = { img: 16 / 9, img2: 16 / 9, vo: 16 / 9, framed: 16 / 9 };
+const aspectOf = (nodeId: NodeId) => ASPECTS[nodeId as string];
+
+const place = (
+  ids: readonly string[],
+  placement: SetNodePlacementCommand["placement"],
+): SetNodePlacementCommand => ({
+  type: "set-node-placement",
+  nodeIds: ids.map(parseNodeId),
+  placement,
+});
+
+const mapped = (command: SetNodePlacementCommand) =>
+  withDefaultLayerFrame(command, GRAPH, aspectOf);
+
+describe("withDefaultLayerFrame", () => {
+  it("stamps the default when a picture clip moves onto a lane", () => {
+    expect(mapped(place(["img"], { trackIndex: 1, placedStart: 2 })).placement).toEqual({
+      trackIndex: 1,
+      placedStart: 2,
+      layerFrame: defaultLayerFrame(16 / 9),
+    });
+  });
+
+  it("leaves a drag ALONG a lane alone, so an adjusted inset survives it", () => {
+    // No `trackIndex` means the lane is not changing — only the time is.
+    // Re-stamping here would drag a positioned inset back to the corner every
+    // time the clip was nudged along its lane.
+    const command = place(["img"], { placedStart: 4 });
+    expect(mapped(command)).toBe(command);
+  });
+
+  it("leaves a move onto the PICTURE alone — that path clears the frame instead", () => {
+    const command = place(["img"], { trackIndex: null, placedStart: null, layerFrame: null });
+    expect(mapped(command)).toBe(command);
+  });
+
+  it("never overrides a frame the placement already names", () => {
+    const chosen = { x: 0.02, y: 0.03, width: 0.5 };
+    expect(mapped(place(["img"], { trackIndex: 1, layerFrame: chosen })).placement.layerFrame).toEqual(
+      chosen,
+    );
+  });
+
+  it("leaves AUDIO as sound", () => {
+    const command = place(["vo"], { trackIndex: 1, placedStart: 0 });
+    expect(mapped(command)).toBe(command);
+  });
+
+  it("leaves a clip that already has a frame alone", () => {
+    const command = place(["framed"], { trackIndex: 2 });
+    expect(mapped(command)).toBe(command);
+  });
+
+  it("stamps a mixed batch off the first clip WITH a picture", () => {
+    // The audio in the batch cannot supply an aspect and must not veto the
+    // stamp for the clips that can.
+    expect(mapped(place(["vo", "img"], { trackIndex: 1 })).placement.layerFrame).toEqual(
+      defaultLayerFrame(16 / 9),
+    );
+  });
+
+  it("leaves the WHOLE batch alone when any member is already positioned", () => {
+    // One command carries one rectangle for N nodes, so there is no way to
+    // stamp the bare ones and leave the rest. Leaving all of them is the half
+    // that never destroys a position somebody chose.
+    const command = place(["img", "framed"], { trackIndex: 1 });
+    expect(mapped(command)).toBe(command);
+  });
+
+  it("is a no-op for a node that is not in the graph", () => {
+    const command = place(["ghost"], { trackIndex: 1 });
+    expect(mapped(command)).toBe(command);
+  });
+});

--- a/apps/timeline-gstudio001/components/graph-view/graph-layer-frame.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-layer-frame.ts
@@ -1,0 +1,61 @@
+import type {
+  CollectionsGraph,
+  NodeId,
+  SetNodePlacementCommand,
+} from "@storyboard/ui/dnd-collections";
+
+import { defaultLayerFrame, hasPicture } from "@/lib/default-layer-frame";
+
+// The DRAG's half of default-inset stamping. The rule itself — which nodes get
+// one and what it is — lives in `lib/default-layer-frame`, shared with the
+// `set_lane` tool so the two authoring routes cannot diverge.
+//
+// This is wired through `mapPlacementCommand`, which exists because the
+// rectangle depends on the clip's aspect and the project's output size. A
+// generic collections engine knows neither and should not learn them.
+
+/**
+ * Add the default inset to a placement that is moving clips ONTO a lane.
+ *
+ * Left alone in every other case:
+ *
+ * - the placement already names a frame — the caller has decided;
+ * - it is not moving onto a lane (`trackIndex` absent, null, or 0) — a drag
+ *   ALONG a lane must not reset an inset the user adjusted, and a drop back
+ *   onto the picture clears it in `resolvePlacementCommand` instead;
+ * - nothing being placed has a picture — an all-audio drop stays sound;
+ * - anything being placed ALREADY has a frame. One command carries one
+ *   rectangle for N nodes, so there is no way to stamp the bare ones and leave
+ *   the rest; leaving all of them is the predictable half of that choice, and
+ *   it never overwrites a position somebody chose.
+ *
+ * The aspect comes from the first node with a picture, so a mixed multi-select
+ * gets one shared rectangle — the same simplification the placement already
+ * makes for `placedStart`, which puts every dragged clip at the same time.
+ */
+export function withDefaultLayerFrame(
+  command: SetNodePlacementCommand,
+  graph: CollectionsGraph,
+  aspectOf: (nodeId: NodeId) => number | undefined,
+): SetNodePlacementCommand {
+  const { trackIndex, layerFrame } = command.placement;
+  if (layerFrame !== undefined) return command;
+  if (trackIndex === undefined || trackIndex === null || trackIndex === 0) return command;
+
+  let sawPicture = false;
+  let aspect: number | undefined;
+  for (const nodeId of command.nodeIds) {
+    const node = graph.nodesById.get(nodeId);
+    if (!hasPicture(node)) continue;
+    // Already positioned — see the note above about one rectangle for N nodes.
+    if (node?.layerFrame !== undefined) return command;
+    sawPicture = true;
+    aspect ??= aspectOf(nodeId);
+  }
+  if (!sawPicture) return command;
+
+  return {
+    ...command,
+    placement: { ...command.placement, layerFrame: defaultLayerFrame(aspect) },
+  };
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -25,6 +25,7 @@ import {
   type DropIntent,
   type GraphNodeSpec,
   type MoveNodesCommand,
+  type SetNodePlacementCommand,
   type NodeId,
 } from "@storyboard/ui/dnd-collections";
 import {
@@ -58,6 +59,7 @@ import { trashDocumentId as deriveTrashDocumentId } from "./trash-document-id";
 
 import { GraphBoard, type FocusSurface, type ItemSize } from "./graph-board";
 import { laneDropIndex, splitLaneRows } from "./graph-lane-rows";
+import { withDefaultLayerFrame } from "./graph-layer-frame";
 import { GraphViewLoadingSkeleton } from "./graph-view-loading";
 import { GraphDetailsProvider } from "./graph-details-context";
 import { FlatClosureHydrator, HydrationController } from "./graph-hydration";
@@ -581,6 +583,20 @@ export function GraphTimelineView({
     [flatOn, focusedId, surface, detailsStore],
   );
 
+  // A clip dragged onto a lane gets the default inset, so the drop is visible
+  // rather than silently sound-only. Here rather than in the engine because
+  // the rectangle depends on the clip's aspect and the project's output size
+  // — see graph-layer-frame.ts.
+  const handleMapPlacementCommand = useCallback(
+    (command: SetNodePlacementCommand, _intent: DropIntent, graph: CollectionsGraph) =>
+      withDefaultLayerFrame(
+        command,
+        graph,
+        (nodeId) => detailsStore.read()[nodeId as string]?.aspect,
+      ),
+    [detailsStore],
+  );
+
   const commandPolicy = useCallback<CommandPolicy>(
     (command) => {
       // FLAT MODE refuses POSITION-based commands.
@@ -734,6 +750,7 @@ export function GraphTimelineView({
         keepMultiSelectModeWhenEmpty
         commandPolicy={commandPolicy}
         mapDropCommand={handleMapDropCommand}
+        mapPlacementCommand={handleMapPlacementCommand}
         itemInstructions="Press O to open the focused collection, or F2 to rename it."
       >
           <PersistenceBridge onSync={onSync} />

--- a/apps/timeline-gstudio001/lib/default-layer-frame.test.ts
+++ b/apps/timeline-gstudio001/lib/default-layer-frame.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import { buildGraph, parseNodeId, type GraphNodeSpec } from "@storyboard/collections-core";
+
+import { defaultLayerFrame, defaultLayerFramePlacement, hasPicture } from "./default-layer-frame";
+
+// A clip dropped on a lane has to be VISIBLE, or the gesture is the same dead
+// end lanes themselves were before the empty lane row: you do it, nothing
+// happens, you conclude the feature is broken. But absence has to keep meaning
+// "sound only" so no stored document changes what it exports — so the default
+// is stamped on the way IN rather than inferred on the way out.
+
+function graphOf(specs: readonly GraphNodeSpec[]) {
+  const built = buildGraph([{ kind: "collection", id: "root", name: "Root", children: specs }]);
+  if (!built.ok) throw new Error(JSON.stringify(built.error));
+  return built.value;
+}
+
+const nodeIn = (specs: readonly GraphNodeSpec[], id: string) =>
+  graphOf(specs).nodesById.get(parseNodeId(id));
+
+describe("hasPicture", () => {
+  it("is true for an image, a video, and a whole nested scene", () => {
+    const specs: GraphNodeSpec[] = [
+      { kind: "media", id: "img", name: "img" },
+      {
+        kind: "media",
+        mediaKind: "video",
+        id: "vid",
+        name: "vid",
+        fullDurationSeconds: 5,
+        trimInSeconds: 0,
+        trimOutSeconds: 0,
+      },
+      { kind: "collection", id: "scene", name: "scene", children: [] },
+    ];
+    for (const id of ["img", "vid", "scene"]) {
+      expect(hasPicture(nodeIn(specs, id))).toBe(true);
+    }
+  });
+
+  it("is FALSE for audio — a voiceover has nowhere to be drawn", () => {
+    const specs: GraphNodeSpec[] = [
+      {
+        kind: "media",
+        mediaKind: "audio",
+        id: "vo",
+        name: "vo",
+        fullDurationSeconds: 5,
+        trimInSeconds: 0,
+        trimOutSeconds: 0,
+      },
+    ];
+    expect(hasPicture(nodeIn(specs, "vo"))).toBe(false);
+  });
+
+  it("is false for a node that is not there", () => {
+    expect(hasPicture(undefined)).toBe(false);
+  });
+});
+
+describe("defaultLayerFrame", () => {
+  it("is a real rectangle inside the frame, in the bottom-right", () => {
+    const frame = defaultLayerFrame(16 / 9);
+    expect(frame.width).toBeGreaterThan(0);
+    expect(frame.x).toBeGreaterThan(0.5);
+    expect(frame.x + frame.width).toBeLessThanOrEqual(1);
+  });
+
+  it("falls back to widescreen for a clip with no recorded aspect", () => {
+    expect(defaultLayerFrame(undefined)).toEqual(defaultLayerFrame(16 / 9));
+  });
+
+  it("MOVES with the aspect — a tall clip does not sit where a wide one does", () => {
+    // The frame is stored without a height, so `y` has to absorb the shape.
+    // If these matched, the stored rectangle would be ignoring the clip.
+    expect(defaultLayerFrame(9 / 16).y).not.toBe(defaultLayerFrame(16 / 9).y);
+  });
+});
+
+describe("defaultLayerFramePlacement", () => {
+  const specs: GraphNodeSpec[] = [
+    { kind: "media", id: "img", name: "img" },
+    {
+      kind: "media",
+      mediaKind: "audio",
+      id: "vo",
+      name: "vo",
+      fullDurationSeconds: 5,
+      trimInSeconds: 0,
+      trimOutSeconds: 0,
+    },
+    { kind: "media", id: "framed", name: "framed", layerFrame: { x: 0.1, y: 0.1, width: 0.2 } },
+  ];
+
+  it("gives a picture clip the default", () => {
+    expect(defaultLayerFramePlacement(nodeIn(specs, "img"), { aspect: 16 / 9 })).toEqual({
+      layerFrame: defaultLayerFrame(16 / 9),
+    });
+  });
+
+  it("gives AUDIO nothing — a bed on a lane is still just sound", () => {
+    expect(defaultLayerFramePlacement(nodeIn(specs, "vo"), { aspect: 16 / 9 })).toEqual({});
+  });
+
+  it("leaves an existing frame alone, so moving between lanes keeps the position", () => {
+    expect(defaultLayerFramePlacement(nodeIn(specs, "framed"), { aspect: 16 / 9 })).toEqual({});
+  });
+
+  it("still works with no detail recorded for the clip", () => {
+    expect(defaultLayerFramePlacement(nodeIn(specs, "img"), undefined)).toEqual({
+      layerFrame: defaultLayerFrame(undefined),
+    });
+  });
+});

--- a/apps/timeline-gstudio001/lib/default-layer-frame.ts
+++ b/apps/timeline-gstudio001/lib/default-layer-frame.ts
@@ -1,0 +1,71 @@
+import {
+  DEFAULT_LAYER_POSITION,
+  DEFAULT_LAYER_SIZE,
+  layerFrameForPreset,
+  type LayerFrame,
+} from "@storyboard/timeline-model/layer-frame";
+import type { CollectionItemNode } from "@storyboard/ui/dnd-collections";
+
+import { DEFAULT_RENDER_FORMAT } from "./render/cut-list";
+
+// THE DEFAULT INSET a clip gets when it lands on a lane.
+//
+// Shared by the two authoring routes — the drag (`withDefaultLayerFrame`) and
+// the `set_lane` tool — so that dragging a clip onto a lane and calling the
+// tool produce the same thing. Splitting the rule would give one of them a
+// visible layer and the other a silent one, which is the kind of difference
+// nobody notices until a render comes out wrong.
+//
+// Why the write path stamps a default at all: a layered clip with no frame
+// renders as SOUND ONLY, and that has to stay true so no stored document
+// changes what it exports. But a clip dropped on a lane that shows nothing is
+// the dead end the empty lane row fixed for lanes themselves — you make the
+// gesture, nothing happens, you conclude it is broken. Stamping on the way in
+// buys both.
+
+/** The output frame's aspect. Fixed today; when export grows a settings
+ *  surface this is the one place that has to start reading it. */
+const FRAME_ASPECT = DEFAULT_RENDER_FORMAT.width / DEFAULT_RENDER_FORMAT.height;
+
+/** What the details store falls back to for a clip with no recorded aspect. */
+const FALLBACK_ASPECT = 16 / 9;
+
+/**
+ * Does this node have a picture to inset?
+ *
+ * A collection does — a whole nested scene under the picture is a legitimate
+ * layer and composites like anything else. Audio does not, and putting a
+ * rectangle on a voiceover would describe where something that can never draw
+ * should be drawn.
+ */
+export function hasPicture(node: CollectionItemNode | undefined): boolean {
+  if (node === undefined) return false;
+  if (node.kind === "collection") return true;
+  return node.mediaKind !== "audio";
+}
+
+/** The inset a clip gets when nobody has said where it should sit. */
+export function defaultLayerFrame(aspect: number | undefined): LayerFrame {
+  return layerFrameForPreset(
+    DEFAULT_LAYER_POSITION,
+    DEFAULT_LAYER_SIZE,
+    aspect ?? FALLBACK_ASPECT,
+    FRAME_ASPECT,
+  );
+}
+
+/**
+ * The `layerFrame` half of a placement that is moving ONE node onto a lane —
+ * `{ layerFrame }` when it should get the default, `{}` when it should be left
+ * exactly as it is.
+ *
+ * Left alone when the node has no picture (audio stays sound) or already has a
+ * frame (moving between lanes must not throw away a position the user chose).
+ */
+export function defaultLayerFramePlacement(
+  node: CollectionItemNode | undefined,
+  detail: Readonly<{ aspect?: number }> | undefined,
+): Readonly<{ layerFrame?: LayerFrame }> {
+  if (!hasPicture(node) || node?.layerFrame !== undefined) return {};
+  return { layerFrame: defaultLayerFrame(detail?.aspect) };
+}

--- a/apps/timeline-gstudio001/lib/mcp/write-handlers.ts
+++ b/apps/timeline-gstudio001/lib/mcp/write-handlers.ts
@@ -23,6 +23,7 @@ import {
   type ApplyCommandOutcome,
 } from "./apply-command";
 import type { DetailsById } from "@storyboard/timeline-domain";
+import { defaultLayerFramePlacement } from "@/lib/default-layer-frame";
 
 // Remote (server-side) write tools. Each one translates arguments into a single
 // CollectionsCommand and hands it to `applyCollectionsCommand`, which owns the
@@ -498,10 +499,17 @@ export async function handleSetLane(
       // change moves the parent's span, and every ancestor stores a duration
       // for it. And because it is a command, it is undoable.
       //
-      // Lane 0 CLEARS the field rather than storing a 0 — absence is the
-      // picture, everywhere else in the model. It clears the placement too:
-      // the picture is a cut, so a placed start there means nothing, and
-      // leaving a stale one would resurface if the clip returned to a lane.
+      // Lane 0 CLEARS the fields rather than storing a 0 — absence is the
+      // picture, everywhere else in the model. It clears the placement and the
+      // inset too: the picture is a cut, so a placed start there means
+      // nothing, and a frame describes where a clip sits INSIDE the picture,
+      // which the picture cannot do. Leaving either would resurface the moment
+      // the clip returned to a lane, in a place nobody chose.
+      //
+      // Going the other way, a clip with a picture gets the default inset —
+      // the same one the drag stamps, so the two authoring routes land in the
+      // same place rather than one producing a visible layer and the other a
+      // silent one.
       return {
         ok: true,
         command: {
@@ -509,8 +517,11 @@ export async function handleSetLane(
           nodeIds: [nodeId],
           placement:
             args.lane === 0
-              ? { trackIndex: null, placedStart: null }
-              : { trackIndex: args.lane },
+              ? { trackIndex: null, placedStart: null, layerFrame: null }
+              : {
+                  trackIndex: args.lane,
+                  ...defaultLayerFramePlacement(graph.nodesById.get(nodeId), details[nodeId]),
+                },
         },
       } as const;
     },

--- a/packages/collections-core/commands.test.ts
+++ b/packages/collections-core/commands.test.ts
@@ -864,6 +864,108 @@ describe("set-node-placement", () => {
     });
     expect(result.ok).toBe(false);
   });
+
+  // THE LAYER FRAME — where a lane clip draws inside the picture. Third member
+  // of the family, and the only one that is an OBJECT, which is the whole
+  // reason it needs its own cases.
+  const FRAME = { x: 0.65, y: 0.6, width: 0.3 };
+
+  test("carries a frame, and clears it with null", () => {
+    const set = applyCommand(fixture(), {
+      type: "set-node-placement",
+      nodeIds: [parseNodeId("A")],
+      placement: { trackIndex: 1, layerFrame: FRAME },
+    });
+    if (!set.ok) throw new Error("expected ok");
+    expect(nodeOf(set.value.graph, "A").layerFrame).toEqual(FRAME);
+
+    const cleared = applyCommand(set.value.graph, {
+      type: "set-node-placement",
+      nodeIds: [parseNodeId("A")],
+      placement: { layerFrame: null },
+    });
+    if (!cleared.ok) throw new Error("expected ok");
+    // Deleted, not zeroed — absent is what "no picture" is spelled as.
+    expect("layerFrame" in nodeOf(cleared.value.graph, "A")).toBe(false);
+    // And clearing the frame left the LANE alone.
+    expect(nodeOf(cleared.value.graph, "A").trackIndex).toBe(1);
+  });
+
+  test("REFUSES an unchanged frame, so a drag that lands where it started is not undoable", () => {
+    // The reason the frame is compared by value instead of riding the `===`
+    // loop the scalar fields use. Two identical rectangles are not `===`, so
+    // without this every dispatch would look like a change and stack a no-op
+    // entry into undo history.
+    const set = applyCommand(fixture(), {
+      type: "set-node-placement",
+      nodeIds: [parseNodeId("A")],
+      placement: { trackIndex: 1, layerFrame: FRAME },
+    });
+    if (!set.ok) throw new Error("expected ok");
+
+    const again = applyCommand(set.value.graph, {
+      type: "set-node-placement",
+      nodeIds: [parseNodeId("A")],
+      // A DIFFERENT object with the same numbers — what a second drag to the
+      // same place actually produces.
+      placement: { layerFrame: { ...FRAME } },
+    });
+    expect(again.ok).toBe(false);
+  });
+
+  test("a frame that differs in ANY component is a real change", () => {
+    const set = applyCommand(fixture(), {
+      type: "set-node-placement",
+      nodeIds: [parseNodeId("A")],
+      placement: { trackIndex: 1, layerFrame: FRAME },
+    });
+    if (!set.ok) throw new Error("expected ok");
+
+    for (const next of [
+      { ...FRAME, x: 0.1 },
+      { ...FRAME, y: 0.1 },
+      { ...FRAME, width: 0.45 },
+    ]) {
+      const moved = applyCommand(set.value.graph, {
+        type: "set-node-placement",
+        nodeIds: [parseNodeId("A")],
+        placement: { layerFrame: next },
+      });
+      if (!moved.ok) throw new Error("expected ok");
+      expect(nodeOf(moved.value.graph, "A").layerFrame).toEqual(next);
+    }
+  });
+
+  test("rejects a non-finite frame rather than storing one", () => {
+    const result = applyCommand(fixture(), {
+      type: "set-node-placement",
+      nodeIds: [parseNodeId("A")],
+      placement: { layerFrame: { x: Number.NaN, y: 0.5, width: 0.3 } },
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.reason).toBe("invalid-placement");
+  });
+
+  test("a frame change is UNDOABLE, which is the whole reason it lives on the node", () => {
+    const graph = fixture();
+    const set = applyCommand(graph, {
+      type: "set-node-placement",
+      nodeIds: [parseNodeId("A")],
+      placement: { trackIndex: 1, layerFrame: FRAME },
+    });
+    if (!set.ok) throw new Error("expected ok");
+    const moved = applyCommand(set.value.graph, {
+      type: "set-node-placement",
+      nodeIds: [parseNodeId("A")],
+      placement: { layerFrame: { x: 0.05, y: 0.05, width: 0.2 } },
+    });
+    if (!moved.ok) throw new Error("expected ok");
+
+    // `nodes-updated` inverts by swapping before/after, so undo is free.
+    const back = applyPatch(moved.value.graph, invertPatch(moved.value.patch));
+    expect(nodeOf(back, "A").layerFrame).toEqual(FRAME);
+  });
 });
 
 describe("set-node-disabled", () => {

--- a/packages/collections-core/commands.ts
+++ b/packages/collections-core/commands.ts
@@ -132,6 +132,9 @@ export type CollectionsCommand =
       placement: Readonly<{
         trackIndex?: number | null;
         placedStart?: number | null;
+        /** Where it draws inside the picture. Same tri-state as the other two:
+         *  absent leaves it, null clears it back to no picture at all. */
+        layerFrame?: Readonly<{ x: number; y: number; width: number }> | null;
       }>;
     }>;
 
@@ -505,7 +508,11 @@ function applySetDisabled(
 function applySetPlacement(
   graph: CollectionsGraph,
   nodeIds: readonly NodeId[],
-  placement: Readonly<{ trackIndex?: number | null; placedStart?: number | null }>
+  placement: Readonly<{
+    trackIndex?: number | null;
+    placedStart?: number | null;
+    layerFrame?: Readonly<{ x: number; y: number; width: number }> | null;
+  }>
 ): Result<ApplyCommandSuccess, CommandRejection> {
   if (nodeIds.length === 0) return { ok: false, error: { reason: "nothing-to-add" } };
 
@@ -543,6 +550,39 @@ function applySetPlacement(
       next[field] = wanted;
       changed = true;
     }
+
+    // THE FRAME IS COMPARED BY VALUE, and that is why it is not in the loop
+    // above. Every check there is `===`, which for two identical rectangles is
+    // false — so an unchanged frame would look like a change on every dispatch
+    // and push a no-op entry into undo history. A drag that ends where it
+    // started would then need an undo to get back to where it already was.
+    const wantedFrame = placement.layerFrame;
+    if (wantedFrame !== undefined) {
+      const currentFrame = node.layerFrame;
+      if (wantedFrame === null) {
+        if (currentFrame !== undefined) {
+          delete next.layerFrame;
+          changed = true;
+        }
+      } else if (
+        !Number.isFinite(wantedFrame.x) ||
+        !Number.isFinite(wantedFrame.y) ||
+        !Number.isFinite(wantedFrame.width)
+      ) {
+        // Rejected rather than dropped, for the same reason a non-finite lane
+        // is: this is a caller naming a value, not a stored document being read.
+        return { ok: false, error: { reason: "invalid-placement", nodeId } };
+      } else if (
+        currentFrame === undefined ||
+        currentFrame.x !== wantedFrame.x ||
+        currentFrame.y !== wantedFrame.y ||
+        currentFrame.width !== wantedFrame.width
+      ) {
+        next.layerFrame = { x: wantedFrame.x, y: wantedFrame.y, width: wantedFrame.width };
+        changed = true;
+      }
+    }
+
     // A node already in the target state contributes nothing. Skipped rather
     // than rejected, so placing a partly-placed selection still works.
     if (!changed) continue;

--- a/packages/collections-core/graph.ts
+++ b/packages/collections-core/graph.ts
@@ -79,6 +79,20 @@ export type ImageMediaNode = Readonly<{
    */
   trackIndex?: number;
   placedStart?: number;
+  /**
+   * Where this draws inside the picture when it runs under one — normalized
+   * 0..1 of the output frame, top-left corner and width.
+   *
+   * Third member of the placement family, on the node for the same single
+   * reason: `set-node-placement` changes it, so it has to ride the patch path
+   * to be undoable. The engine understands it exactly as little as it
+   * understands the other two.
+   *
+   * Structural rather than the domain's `LayerFrame` type because this package
+   * has NO dependencies and must keep none — which costs nothing here, since
+   * an opaque carried value is all the engine ever needed.
+   */
+  layerFrame?: Readonly<{ x: number; y: number; width: number }>;
 }>;
 
 export type VideoMediaNode = Readonly<{
@@ -113,6 +127,7 @@ export type VideoMediaNode = Readonly<{
   /** See ImageMediaNode — lane and placement, carried not interpreted. */
   trackIndex?: number;
   placedStart?: number;
+  layerFrame?: Readonly<{ x: number; y: number; width: number }>;
 }>;
 
 /**
@@ -150,6 +165,7 @@ export type AudioMediaNode = Readonly<{
   /** See ImageMediaNode — lane and placement, carried not interpreted. */
   trackIndex?: number;
   placedStart?: number;
+  layerFrame?: Readonly<{ x: number; y: number; width: number }>;
 }>;
 
 export type MediaNode = ImageMediaNode | VideoMediaNode | AudioMediaNode;
@@ -172,6 +188,7 @@ export type CollectionNode = Readonly<{
    *  picture is a legitimate layer. */
   trackIndex?: number;
   placedStart?: number;
+  layerFrame?: Readonly<{ x: number; y: number; width: number }>;
 }>;
 
 export type CollectionItemNode = MediaNode | CollectionNode;
@@ -263,6 +280,7 @@ export type GraphNodeSpec =
       disabled?: boolean;
       trackIndex?: number;
       placedStart?: number;
+      layerFrame?: Readonly<{ x: number; y: number; width: number }>;
     }>
   | Readonly<{
       kind: "media";
@@ -277,6 +295,7 @@ export type GraphNodeSpec =
       disabled?: boolean;
       trackIndex?: number;
       placedStart?: number;
+      layerFrame?: Readonly<{ x: number; y: number; width: number }>;
     }>
   | Readonly<{
       kind: "media";
@@ -290,6 +309,7 @@ export type GraphNodeSpec =
       disabled?: boolean;
       trackIndex?: number;
       placedStart?: number;
+      layerFrame?: Readonly<{ x: number; y: number; width: number }>;
     }>
   | Readonly<{
       kind: "collection";
@@ -299,6 +319,7 @@ export type GraphNodeSpec =
       disabled?: boolean;
       trackIndex?: number;
       placedStart?: number;
+      layerFrame?: Readonly<{ x: number; y: number; width: number }>;
     }>;
 
 /** A media spec, i.e. every member of GraphNodeSpec that is not a collection. */
@@ -326,8 +347,12 @@ type MediaNodeSpec = Extract<GraphNodeSpec, { kind: "media" }>;
  * graph is concerned.
  */
 function placementOf(
-  spec: Readonly<{ trackIndex?: unknown; placedStart?: unknown }>,
-): Readonly<{ trackIndex?: number; placedStart?: number }> {
+  spec: Readonly<{ trackIndex?: unknown; placedStart?: unknown; layerFrame?: unknown }>,
+): Readonly<{
+  trackIndex?: number;
+  placedStart?: number;
+  layerFrame?: Readonly<{ x: number; y: number; width: number }>;
+}> {
   const lane = spec.trackIndex;
   const start = spec.placedStart;
   return {
@@ -335,7 +360,26 @@ function placementOf(
     ...(typeof start === "number" && Number.isFinite(start) && start >= 0
       ? { placedStart: start }
       : {}),
+    ...(frameOf(spec.layerFrame) === undefined ? {} : { layerFrame: frameOf(spec.layerFrame) }),
   };
+}
+
+/**
+ * A layer frame kept only when it is structurally a rectangle.
+ *
+ * STRUCTURE ONLY — three finite numbers — and deliberately not the domain's
+ * 0..1 range check. Same posture as the fractional lane above: the engine's job
+ * here is to refuse to carry something that is not a rectangle at all, while
+ * the domain normalizer decides which rectangles are meaningful. Tightening
+ * this would fail to hydrate a document the timeline model is happy to read.
+ */
+function frameOf(value: unknown): Readonly<{ x: number; y: number; width: number }> | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const { x, y, width } = value as Record<string, unknown>;
+  if (typeof x !== "number" || !Number.isFinite(x)) return undefined;
+  if (typeof y !== "number" || !Number.isFinite(y)) return undefined;
+  if (typeof width !== "number" || !Number.isFinite(width)) return undefined;
+  return { x, y, width };
 }
 
 function mediaNodeFromSpec(id: NodeId, spec: MediaNodeSpec): MediaNode {

--- a/packages/collections-core/index.ts
+++ b/packages/collections-core/index.ts
@@ -47,6 +47,7 @@ export {
   type CommandRejection,
   type MediaUpdate,
   type MoveNodesCommand,
+  type SetNodePlacementCommand,
   type UpdateMediaCommand,
 } from "./commands";
 export { hydrateCollection, type HydrateRejection } from "./hydrate";

--- a/packages/collections-core/intents.test.ts
+++ b/packages/collections-core/intents.test.ts
@@ -354,14 +354,22 @@ describe("resolvePlacementCommand", () => {
     });
   });
 
-  test("LANE 0 CLEARS BOTH FIELDS and ignores the time", () => {
+  test("LANE 0 CLEARS THE WHOLE PLACEMENT and ignores the time", () => {
     // Dropping onto the picture means "rejoin the cut". There is no "here" to
     // place at on that row — its clips pack end to end from array order — so
     // the clip takes the slot its position gives it. One command, one undo;
     // a move as well would have cost two.
+    //
+    // The INSET goes with them: it says where the clip sits inside the
+    // picture, and a clip that IS the picture has nowhere to sit. Left behind,
+    // it would reappear unannounced the next time the clip went on a lane.
     const result = place(0, 7.5);
     if (!result.ok) throw new Error(JSON.stringify(result.error));
-    expect(result.value.placement).toEqual({ trackIndex: null, placedStart: null });
+    expect(result.value.placement).toEqual({
+      trackIndex: null,
+      placedStart: null,
+      layerFrame: null,
+    });
   });
 
   test("clamps a drag past the left edge to the very start", () => {

--- a/packages/collections-core/intents.ts
+++ b/packages/collections-core/intents.ts
@@ -387,7 +387,13 @@ export function resolvePlacementCommand(
       value: {
         type: "set-node-placement",
         nodeIds: draggedIds,
-        placement: { trackIndex: null, placedStart: null },
+        // The frame goes with them. It describes where the clip sits INSIDE
+        // the picture, and a clip that IS the picture has nowhere to sit —
+        // leaving one behind would be an inset waiting to reappear the next
+        // time the clip was put on a lane, in a place nobody chose. Clearing
+        // needs no domain knowledge, so unlike stamping a default (see
+        // `mapPlacementCommand`) it belongs here.
+        placement: { trackIndex: null, placedStart: null, layerFrame: null },
       },
     };
   }

--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -34,6 +34,7 @@ import { tagsField } from "@storyboard/timeline-model/tags";
 // this file's packing is the twin of `packTimelineClips`, and two different
 // answers to "which lane is this clip on" would move layered clips on save.
 import { placedStartOf, trackIndexOf } from "@storyboard/timeline-model/documents";
+import { layerFrameOf } from "@storyboard/timeline-model/layer-frame";
 import type {
   AssetSourceRef,
   CollectionTimelineClip,
@@ -140,11 +141,16 @@ type BuildContext = {
  * only reroutes which side of the seam carries them. No data migration.
  */
 function placementSpec(
-  clip: Pick<TimelineClip, "trackIndex" | "placedStart">,
-): Readonly<{ trackIndex?: number; placedStart?: number }> {
+  clip: Pick<TimelineClip, "trackIndex" | "placedStart" | "layerFrame">,
+): Readonly<{
+  trackIndex?: number;
+  placedStart?: number;
+  layerFrame?: Readonly<{ x: number; y: number; width: number }>;
+}> {
   return {
     ...(clip.trackIndex === undefined ? {} : { trackIndex: clip.trackIndex }),
     ...(clip.placedStart === undefined ? {} : { placedStart: clip.placedStart }),
+    ...(clip.layerFrame === undefined ? {} : { layerFrame: clip.layerFrame }),
   };
 }
 
@@ -290,6 +296,7 @@ function clipSpecs(
         name: clip.title,
         children: [],
         ...(clip.disabled ? { disabled: true } : {}),
+        ...placementSpec(clip),
       };
     }
     ctx.used.add(childId);
@@ -303,6 +310,7 @@ function clipSpecs(
         name: clip.title,
         children: clipSpecs(ctx, childDoc, hydrateLevels - 1),
         ...(clip.disabled ? { disabled: true } : {}),
+        ...placementSpec(clip),
       };
     }
 
@@ -314,6 +322,7 @@ function clipSpecs(
       name: clip.title,
       children: [],
       ...(clip.disabled ? { disabled: true } : {}),
+      ...placementSpec(clip),
     };
   });
 }
@@ -713,6 +722,11 @@ export function graphChildrenToClips(
     // rather than re-implemented so the twins cannot drift on the one field
     // whose whole purpose is to override the cursor.
     const placedStart = placedStartOf({ placedStart: node.placedStart }, trackIndex);
+    // Same rule as the two above, and the same reason for using the model's own
+    // normalizer: this value is HONOURED, so a rectangle that is not one has to
+    // become "no picture" rather than an inset nobody asked for. Lane 0 never
+    // carries a frame — the picture is not inside itself.
+    const layerFrame = trackIndex === 0 ? undefined : layerFrameOf(node.layerFrame);
     const startTime = placedStart ?? startFor(trackIndex);
 
     if (node.kind === "media") {
@@ -734,6 +748,7 @@ export function graphChildrenToClips(
         // record, so omitting it here would silently un-place the clip on
         // the next save and drop it back into its lane's queue.
         ...(placedStart === undefined ? {} : { placedStart }),
+        ...(layerFrame === undefined ? {} : { layerFrame }),
         startTime,
         duration,
         ...(detail?.playbackStartTime === undefined
@@ -830,6 +845,7 @@ export function graphChildrenToClips(
       aspect: detail?.aspect ?? 16 / 9,
       trackIndex,
       ...(placedStart === undefined ? {} : { placedStart }),
+      ...(layerFrame === undefined ? {} : { layerFrame }),
       startTime,
       duration,
       sourceDuration: detail?.sourceDuration ?? duration,

--- a/packages/timeline-domain/src/lane-manifest.test.ts
+++ b/packages/timeline-domain/src/lane-manifest.test.ts
@@ -180,3 +180,83 @@ describe("manifest lanes", () => {
     });
   });
 });
+
+// WHERE A LAYER DRAWS. Absent means sound only, which is what every layered
+// clip did before compositing — so the manifest must not invent one.
+
+const INSET = { x: 0.65, y: 0.6, width: 0.3 };
+const frameOf = (manifest: ReturnType<typeof compile>, id: string) =>
+  manifest.leaves.find((leaf) => leaf.id === id)?.layerFrame;
+
+describe("manifest layer frames", () => {
+  it("carries the inset on a layered clip", () => {
+    const manifest = compile({
+      root: doc("root", [
+        media("shot", 10),
+        media("pip", 4, { trackIndex: 1, kind: "video", layerFrame: INSET }),
+      ]),
+    });
+    expect(frameOf(manifest, "pip")).toEqual(INSET);
+  });
+
+  it("emits NOTHING for a layer without one — sound only", () => {
+    const manifest = compile({
+      root: doc("root", [media("shot", 10), media("bed", 4, { trackIndex: 1 })]),
+    });
+    expect(frameOf(manifest, "bed")).toBeUndefined();
+    expect("layerFrame" in manifest.leaves[1]!).toBe(false);
+  });
+
+  it("DROPS a stale inset left on a clip that is back on the picture", () => {
+    // Moving a clip to lane 0 clears the frame on the write path, but a
+    // document written by anything else can still carry one. Lane 0 has
+    // nothing to be inset within, so it is not an instruction.
+    const manifest = compile({
+      root: doc("root", [media("shot", 10, { layerFrame: INSET })]),
+    });
+    expect(frameOf(manifest, "shot")).toBeUndefined();
+  });
+
+  it("does NOT inherit a collection's inset onto its children", () => {
+    // Lane is inherited — the outermost non-zero one wins, because "picture or
+    // under-layer" is settled by the outermost thing. A RECTANGLE is not:
+    // a frame on the scene says where the SCENE sits, and there is no defined
+    // composition of that with a frame inside it. So each leaf answers for
+    // itself, and a leaf that never had one has none.
+    const manifest = compile({
+      root: doc("root", [
+        media("shot", 10),
+        collection("scene", "child", 6, { trackIndex: 1, layerFrame: INSET }),
+      ]),
+      child: doc("child", [media("inner", 6)]),
+    });
+    // Under the picture, because the collection above it is…
+    expect(laneOf(manifest, "inner")).toBe(1);
+    // …but with no frame of its own.
+    expect(frameOf(manifest, "inner")).toBeUndefined();
+  });
+
+  it("keeps a leaf's OWN inset inside a layered collection", () => {
+    const manifest = compile({
+      root: doc("root", [
+        media("shot", 10),
+        collection("scene", "child", 6, { trackIndex: 1 }),
+      ]),
+      child: doc("child", [media("inner", 6, { layerFrame: INSET })]),
+    });
+    expect(frameOf(manifest, "inner")).toEqual(INSET);
+  });
+
+  it("drops a rectangle that is not one", () => {
+    const manifest = compile({
+      root: doc("root", [
+        media("shot", 10),
+        media("pip", 4, {
+          trackIndex: 1,
+          layerFrame: { x: 0.5, y: 0.5, width: 0 } as unknown as typeof INSET,
+        }),
+      ]),
+    });
+    expect(frameOf(manifest, "pip")).toBeUndefined();
+  });
+});

--- a/packages/timeline-domain/src/lane-roundtrip.test.ts
+++ b/packages/timeline-domain/src/lane-roundtrip.test.ts
@@ -171,3 +171,165 @@ describe("lanes survive the graph round trip", () => {
     ]);
   });
 });
+
+// THE LAYER FRAME. Where a lane clip draws inside the picture — the one member
+// of the placement family that is an OBJECT, and the one whose write-back is
+// duplicated across `graphChildrenToClips`'s two branches. Missing either is
+// silent data loss on the next save rather than a crash, which is exactly the
+// failure mode that needs a test rather than a reading.
+
+const INSET = { x: 0.65, y: 0.6, width: 0.3 };
+
+describe("a layer frame survives the round trip", () => {
+  const framed: TimelineDocument = {
+    id: "col",
+    title: "Framed",
+    clips: packTimelineClips([
+      media("shot-1", 4),
+      media("pip", 6, { trackIndex: 1, kind: "video", layerFrame: INSET }),
+    ]),
+  };
+
+  it("comes back unchanged on a MEDIA clip", () => {
+    const pip = roundTrip(framed).find((clip) => clip.id === "pip");
+    expect(pip?.layerFrame).toEqual(INSET);
+  });
+
+  it("comes back unchanged on a COLLECTION clip — the other write-back", () => {
+    // The branch it would be easy to wire only the first of. A whole nested
+    // scene can sit under the picture, so it can carry an inset too.
+    const withScene: TimelineDocument = {
+      id: "col",
+      title: "Framed scene",
+      clips: packTimelineClips([
+        media("shot-1", 4),
+        {
+          id: "scene",
+          index: 1,
+          kind: "collection",
+          childTimelineId: "child",
+          title: "Scene",
+          alt: "scene collection",
+          aspect: 16 / 9,
+          trackIndex: 1,
+          layerFrame: INSET,
+          startTime: 0,
+          duration: 5,
+          sourceDuration: 5,
+          trimIn: 0,
+          trimOut: 0,
+          itemCount: 0,
+        } as TimelineClip,
+      ]),
+    };
+    const built = buildFocusedGraph(
+      {
+        [withScene.id]: withScene,
+        child: { id: "child", title: "Child", clips: [] },
+      },
+      withScene.id,
+      1,
+    );
+    if (!built.ok) throw new Error(built.error);
+    const clips = graphChildrenToClips(built.value.graph, built.value.details, withScene.id);
+    expect(clips.find((clip) => clip.id === "scene")?.layerFrame).toEqual(INSET);
+  });
+
+  it("IS STABLE — a second round trip does not drift the rectangle", () => {
+    const once = roundTrip(framed);
+    const twice = roundTrip({ ...framed, clips: once });
+    expect(twice.find((clip) => clip.id === "pip")?.layerFrame).toEqual(INSET);
+  });
+
+  it("DROPS a frame on the picture — lane 0 is not inside itself", () => {
+    const onPicture: TimelineDocument = {
+      id: "col",
+      title: "Stale inset",
+      clips: packTimelineClips([media("shot-1", 4, { layerFrame: INSET })]),
+    };
+    expect(roundTrip(onPicture)[0]?.layerFrame).toBeUndefined();
+  });
+
+  it("drops a rectangle that is not one, rather than storing it", () => {
+    const broken: TimelineDocument = {
+      id: "col",
+      title: "Broken inset",
+      clips: packTimelineClips([
+        media("shot-1", 4),
+        media("pip", 6, {
+          trackIndex: 1,
+          layerFrame: { x: 0.5, y: 0.5, width: 0 } as unknown as typeof INSET,
+        }),
+      ]),
+    };
+    expect(roundTrip(broken).find((clip) => clip.id === "pip")?.layerFrame).toBeUndefined();
+  });
+
+  it("leaves a document that uses no insets without the field", () => {
+    for (const clip of roundTrip(layered)) {
+      expect("layerFrame" in clip).toBe(false);
+    }
+  });
+});
+
+// A COLLECTION ON A LANE — found while carrying the frame through, and broken
+// well before it.
+//
+// The three collection-clip spec builders carried `disabled` but not the
+// placement family at all, so a layered scene lost its lane and its placed
+// start on the way IN: stored `trackIndex: 1, placedStart: 3` hydrated to a
+// node with neither, and the very next save wrote it back as `trackIndex: 0,
+// startTime: 0`. A whole nested scene under the picture snapped onto the cut,
+// and the graph node type says in as many words that it is allowed to sit
+// there. Media clips were fine, which is why nothing caught it.
+describe("a layered COLLECTION keeps its placement", () => {
+  const scene = (over: Partial<TimelineClip>): TimelineClip =>
+    ({
+      id: "scene",
+      index: 0,
+      kind: "collection",
+      childTimelineId: "child",
+      title: "Scene",
+      alt: "scene collection",
+      aspect: 16 / 9,
+      trackIndex: 0,
+      startTime: 0,
+      duration: 5,
+      sourceDuration: 5,
+      trimIn: 0,
+      trimOut: 0,
+      itemCount: 0,
+      ...over,
+    }) as TimelineClip;
+
+  const tripScene = (clip: TimelineClip) => {
+    const document: TimelineDocument = { id: "col", title: "T", clips: [clip] };
+    const built = buildFocusedGraph(
+      { col: document, child: { id: "child", title: "Child", clips: [] } },
+      "col",
+      1,
+    );
+    if (!built.ok) throw new Error(built.error);
+    return graphChildrenToClips(built.value.graph, built.value.details, "col")[0];
+  };
+
+  it("keeps its LANE", () => {
+    expect(tripScene(scene({ trackIndex: 1 }))?.trackIndex).toBe(1);
+  });
+
+  it("keeps its PLACED START, and the startTime derived from it", () => {
+    const back = tripScene(scene({ trackIndex: 1, placedStart: 3, startTime: 3 }));
+    expect(back?.placedStart).toBe(3);
+    expect(back?.startTime).toBe(3);
+  });
+
+  it("keeps its INSET", () => {
+    expect(tripScene(scene({ trackIndex: 1, layerFrame: INSET }))?.layerFrame).toEqual(INSET);
+  });
+
+  it("still puts an unlayered scene on the picture", () => {
+    const back = tripScene(scene({}));
+    expect(back?.trackIndex).toBe(0);
+    expect(back?.layerFrame).toBeUndefined();
+  });
+});

--- a/packages/timeline-domain/src/playback-manifest.ts
+++ b/packages/timeline-domain/src/playback-manifest.ts
@@ -19,6 +19,7 @@
 // (draw it grayed).
 
 import { trackIndexOf } from "@storyboard/timeline-model/documents";
+import { layerFrameOf, type LayerFrame } from "@storyboard/timeline-model/layer-frame";
 import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
 
 export type PlaybackLeaf = Readonly<{
@@ -49,6 +50,19 @@ export type PlaybackLeaf = Readonly<{
    * Absent is impossible; 0 is the answer for everything written before lanes.
    */
   trackIndex: number;
+  /**
+   * Where this draws inside the picture, normalized 0..1 of the output frame.
+   * Absent means it contributes SOUND ONLY, which is what every layer did
+   * before compositing existed.
+   *
+   * The leaf's OWN frame, unlike `trackIndex` above, which takes the outermost
+   * lane on the path. Lane answers "is this picture or under-layer", and a
+   * collection above can settle that for everything beneath it. A rectangle
+   * cannot be settled that way: a frame on the collection would describe where
+   * the SCENE sits, and there is no defined composition of the two — so an
+   * inset inside a layered collection is not inherited, it is its own.
+   */
+  layerFrame?: Readonly<{ x: number; y: number; width: number }>;
   /** Skipped by the PLAYER, not by this compiler. A disabled leaf keeps its
    *  full span on the timeline — that span is what the playhead jumps over
    *  while playing and what a scrub can land inside. Set when the leaf's own
@@ -81,6 +95,14 @@ type TimeWindow = Readonly<{
   outputStart: number;
   outputDuration: number;
 }>;
+
+/** The leaf's frame, defended through the model's own normalizer so a stored
+ *  rectangle that is not one compiles to "sound only" rather than to an inset
+ *  in an undefined place. */
+function frameField(clip: TimelineClip): Readonly<{ layerFrame?: LayerFrame }> {
+  const frame = layerFrameOf(clip.layerFrame);
+  return frame === undefined ? {} : { layerFrame: frame };
+}
 
 function documentDuration(document: TimelineDocument): number {
   return document.clips.reduce(
@@ -115,6 +137,10 @@ function addMediaLeaf(
     sourceStart: clip.trimIn + clipProgress * sourceRange,
     playbackRate: (sourceRange / Math.max(0.001, clip.duration)) / outputScale,
     trackIndex,
+    // Only where it actually runs under the picture. A frame left behind on a
+    // clip that has since been moved back onto the cut is stale authoring, not
+    // an instruction — and lane 0 has nothing to be inset within.
+    ...(trackIndex === 0 ? {} : frameField(clip)),
     ...(disabled ? { disabled: true } : {}),
   });
 }

--- a/packages/timeline-model/index.ts
+++ b/packages/timeline-model/index.ts
@@ -3,5 +3,6 @@ export * from "./tags";
 export * from "./constants";
 export * from "./documents";
 export * from "./placement";
+export * from "./layer-frame";
 export * from "./validate";
 export * from "./clip-display";

--- a/packages/timeline-model/layer-frame.test.ts
+++ b/packages/timeline-model/layer-frame.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_LAYER_POSITION,
+  DEFAULT_LAYER_SIZE,
+  layerFrameForPreset,
+  layerFrameHeight,
+  layerFrameOf,
+  layerFrameRect,
+  sameLayerFrame,
+} from "./layer-frame";
+
+// The shipping output format is 1152x480 — a 2.4:1 frame, which is wide enough
+// that anything treating the two axes as interchangeable shows up immediately.
+const FRAME = 1152 / 480;
+const WIDESCREEN = 16 / 9;
+
+describe("layerFrameHeight", () => {
+  it("keeps a 16:9 clip undistorted in a 2.4:1 frame", () => {
+    // 0.3 of 1152 = 345.6px wide; 16:9 makes that 194.4px tall; over 480 that
+    // is 0.405 of the frame's height.
+    expect(layerFrameHeight(0.3, WIDESCREEN, FRAME)).toBeCloseTo(0.405, 4);
+  });
+
+  it("is TALLER than it is wide in normalized units, for a wide frame", () => {
+    // The trap this exists to avoid: treating width and height as the same
+    // unit. In a 2.4:1 frame a 16:9 inset covers a bigger fraction of the
+    // height than of the width, and drawing it as a square fraction squashes
+    // it — invisible in a story fixture, obvious in a render.
+    expect(layerFrameHeight(0.3, WIDESCREEN, FRAME)).toBeGreaterThan(0.3);
+  });
+
+  it("is the same fraction on both axes when the frame matches the clip", () => {
+    expect(layerFrameHeight(0.3, WIDESCREEN, WIDESCREEN)).toBeCloseTo(0.3, 6);
+  });
+
+  it("treats a nonsense aspect as square rather than dividing by zero", () => {
+    expect(Number.isFinite(layerFrameHeight(0.3, 0, FRAME))).toBe(true);
+  });
+});
+
+describe("layerFrameForPreset", () => {
+  it("puts the default inset in the bottom-right, inside the frame", () => {
+    const frame = layerFrameForPreset(
+      DEFAULT_LAYER_POSITION,
+      DEFAULT_LAYER_SIZE,
+      WIDESCREEN,
+      FRAME,
+    );
+    const rect = layerFrameRect(frame, WIDESCREEN, FRAME);
+    expect(rect.x + rect.width).toBeLessThanOrEqual(1);
+    expect(rect.y + rect.height).toBeLessThanOrEqual(1);
+    // Past the middle on both axes — that is what "bottom-right" has to mean.
+    expect(rect.x).toBeGreaterThan(0.5);
+    expect(rect.y).toBeGreaterThan(0.5);
+  });
+
+  it("uses an EVEN margin in pixels, not in normalized units", () => {
+    // The reason MARGIN is scaled by the frame aspect. Left gap and bottom gap
+    // must be the same number of PIXELS; comparing the raw normalized values
+    // would have them differ by 2.4x and look wrong on screen.
+    const frame = layerFrameForPreset("bottom-left", "medium", WIDESCREEN, FRAME);
+    const rect = layerFrameRect(frame, WIDESCREEN, FRAME);
+    const leftPx = rect.x * 1152;
+    const bottomPx = (1 - (rect.y + rect.height)) * 480;
+    expect(Math.abs(leftPx - bottomPx)).toBeLessThanOrEqual(0.5);
+  });
+
+  it("centres on both axes for the middle position", () => {
+    const frame = layerFrameForPreset("center", "small", WIDESCREEN, FRAME);
+    const rect = layerFrameRect(frame, WIDESCREEN, FRAME);
+    expect(rect.x + rect.width / 2).toBeCloseTo(0.5, 6);
+    expect(rect.y + rect.height / 2).toBeCloseTo(0.5, 6);
+  });
+
+  it("orders the three sizes, and keeps them all inside the frame", () => {
+    const widths = (["small", "medium", "large"] as const).map(
+      (size) => layerFrameForPreset("top-left", size, WIDESCREEN, FRAME).width,
+    );
+    expect(widths[0]).toBeLessThan(widths[1]);
+    expect(widths[1]).toBeLessThan(widths[2]);
+    for (const position of ["top-left", "top-right", "bottom-left", "bottom-right"] as const) {
+      const rect = layerFrameRect(
+        layerFrameForPreset(position, "large", WIDESCREEN, FRAME),
+        WIDESCREEN,
+        FRAME,
+      );
+      expect(rect.x).toBeGreaterThanOrEqual(0);
+      expect(rect.y).toBeGreaterThanOrEqual(0);
+      expect(rect.x + rect.width).toBeLessThanOrEqual(1 + 1e-9);
+      expect(rect.y + rect.height).toBeLessThanOrEqual(1 + 1e-9);
+    }
+  });
+
+  it("still fits a TALL clip, which a large preset would otherwise overflow", () => {
+    // A 9:16 clip at 45% width is far taller than the frame in a 2.4:1 output.
+    // Clamped rather than allowed to hang off the top and bottom.
+    const rect = layerFrameRect(
+      layerFrameForPreset("bottom-right", "large", 9 / 16, FRAME),
+      9 / 16,
+      FRAME,
+    );
+    expect(rect.y).toBeGreaterThanOrEqual(0);
+    expect(rect.height).toBeLessThanOrEqual(1);
+    expect(rect.y + rect.height).toBeLessThanOrEqual(1 + 1e-9);
+  });
+});
+
+describe("layerFrameRect", () => {
+  it("nudges a stored frame back inside a frame it no longer fits", () => {
+    // A rectangle written at one output size, rendered at another. Cropping the
+    // picture would be the worse answer.
+    const rect = layerFrameRect({ x: 0.95, y: 0.95, width: 0.3 }, WIDESCREEN, FRAME);
+    expect(rect.x + rect.width).toBeCloseTo(1, 6);
+    expect(rect.y + rect.height).toBeCloseTo(1, 6);
+  });
+});
+
+describe("layerFrameOf", () => {
+  it("takes a real rectangle", () => {
+    expect(layerFrameOf({ x: 0.6, y: 0.5, width: 0.3 })).toEqual({ x: 0.6, y: 0.5, width: 0.3 });
+  });
+
+  it("drops anything that is not one, so a bad value means NO PICTURE", () => {
+    // Honoured, not derived: a value that cannot be trusted has to fall back to
+    // the safe default rather than put a layer somewhere nobody asked for.
+    for (const bad of [
+      undefined,
+      null,
+      "0.5",
+      42,
+      {},
+      { x: 0.5, y: 0.5 },
+      { x: Number.NaN, y: 0.5, width: 0.3 },
+      { x: -0.1, y: 0.5, width: 0.3 },
+      { x: 1.4, y: 0.5, width: 0.3 },
+      { x: 0.5, y: 0.5, width: 0 },
+      { x: 0.5, y: 0.5, width: -0.3 },
+      { x: 0.5, y: 0.5, width: 1.2 },
+    ]) {
+      expect(layerFrameOf(bad)).toBeUndefined();
+    }
+  });
+
+  it("keeps only the three fields, so a fattened stored value cannot leak", () => {
+    expect(layerFrameOf({ x: 0.1, y: 0.2, width: 0.3, height: 0.9, junk: true })).toEqual({
+      x: 0.1,
+      y: 0.2,
+      width: 0.3,
+    });
+  });
+});
+
+describe("sameLayerFrame", () => {
+  it("compares by VALUE — the whole reason it exists", () => {
+    // The graph's placement command decides "did this change" with ===, which
+    // for two identical objects is false. Without this, every dispatch would
+    // look like a change and put a no-op entry in undo history.
+    expect(sameLayerFrame({ x: 0.1, y: 0.2, width: 0.3 }, { x: 0.1, y: 0.2, width: 0.3 })).toBe(
+      true,
+    );
+    expect(sameLayerFrame({ x: 0.1, y: 0.2, width: 0.3 }, { x: 0.1, y: 0.2, width: 0.4 })).toBe(
+      false,
+    );
+  });
+
+  it("treats absent as a value of its own", () => {
+    expect(sameLayerFrame(undefined, undefined)).toBe(true);
+    expect(sameLayerFrame(undefined, { x: 0.1, y: 0.2, width: 0.3 })).toBe(false);
+    expect(sameLayerFrame({ x: 0.1, y: 0.2, width: 0.3 }, undefined)).toBe(false);
+  });
+});

--- a/packages/timeline-model/layer-frame.ts
+++ b/packages/timeline-model/layer-frame.ts
@@ -1,0 +1,194 @@
+// WHERE AN UNDER-LAYER DRAWS INSIDE THE PICTURE.
+//
+// A clip on lane 1 or above runs UNDER the picture — that is what the model has
+// always meant, and it stays exactly true of sound: its audio is mixed beneath
+// the cut. It cannot be true of a PICTURE. Something drawn under the picture is
+// not dimly visible, it is not visible at all. So a layer with a frame is
+// composited OVER, in a sub-rectangle of the output: "under" describes the mix,
+// "over" describes the screen, and both are the same clip.
+//
+// The rectangle is stored NORMALIZED, 0..1 of the output frame, because the
+// output size is a per-render setting (`DEFAULT_RENDER_FORMAT` today, an
+// override from the render tool) and a pixel rectangle would mean something
+// different at every size.
+//
+// HEIGHT IS NOT STORED. It follows from the clip's own aspect, so an inset can
+// never be stretched — there is no way to express a distorted one, which is the
+// only thing anybody would ever do with the extra degree of freedom by mistake.
+
+/**
+ * The stored rectangle: top-left corner and width, normalized to the output
+ * frame. Top-left rather than centre because that is what both consumers want
+ * — canvas `drawImage` and ffmpeg `overlay=x:y` are both corner-addressed.
+ */
+export type LayerFrame = Readonly<{
+  x: number;
+  y: number;
+  width: number;
+}>;
+
+/** A resolved rectangle, height included, in the same normalized units. */
+export type LayerRect = Readonly<{
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}>;
+
+export type LayerFramePosition =
+  | "top-left"
+  | "top"
+  | "top-right"
+  | "left"
+  | "center"
+  | "right"
+  | "bottom-left"
+  | "bottom"
+  | "bottom-right";
+
+export type LayerFrameSize = "small" | "medium" | "large";
+
+/** Width as a fraction of the frame. Three steps rather than a number, because
+ *  the useful range is narrow and picking from it is faster than typing into
+ *  it. A free rect can still be written directly; these are just the presets. */
+const SIZE_WIDTHS: Readonly<Record<LayerFrameSize, number>> = {
+  small: 0.2,
+  medium: 0.3,
+  large: 0.45,
+};
+
+/**
+ * The gap from the edge, as a fraction of frame WIDTH.
+ *
+ * Applied to the vertical edges through `frameAspect` rather than reused
+ * directly, or it would not look like a margin at all: the render format is
+ * 1152x480, so a flat 0.035 is 40px at the sides and 17px top and bottom — an
+ * inset visibly hugging the floor while floating away from the wall.
+ */
+const MARGIN = 0.035;
+
+/** Bottom-right, medium — the corner a picture-in-picture goes in unless you
+ *  say otherwise, and small enough to sit over a corner of the shot rather than
+ *  compete with it. */
+export const DEFAULT_LAYER_POSITION: LayerFramePosition = "bottom-right";
+export const DEFAULT_LAYER_SIZE: LayerFrameSize = "medium";
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * The inset's height, normalized to the frame.
+ *
+ * `width` is a fraction of frame WIDTH and the answer is a fraction of frame
+ * HEIGHT, so both aspects appear: `width * frameAspect` converts to pixels
+ * relative to the frame's height, and dividing by the clip's own aspect is what
+ * keeps the clip undistorted.
+ */
+export function layerFrameHeight(width: number, clipAspect: number, frameAspect: number): number {
+  const aspect = clipAspect > 0 ? clipAspect : 1;
+  return (width * frameAspect) / aspect;
+}
+
+/**
+ * A stored frame resolved against a real output size and a real clip.
+ *
+ * Clamped into the frame rather than refused. A stored rectangle can be older
+ * than the format it is being rendered at — the render tool takes width, height
+ * and fps — so a frame that fitted when it was written can hang off the edge
+ * later. Cropping the picture at the boundary is a worse answer than nudging
+ * the inset back inside it.
+ */
+export function layerFrameRect(
+  frame: LayerFrame,
+  clipAspect: number,
+  frameAspect: number,
+): LayerRect {
+  const width = clamp(frame.width, 0, 1);
+  const height = clamp(layerFrameHeight(width, clipAspect, frameAspect), 0, 1);
+  return {
+    x: clamp(frame.x, 0, 1 - width),
+    y: clamp(frame.y, 0, 1 - height),
+    width,
+    height,
+  };
+}
+
+/**
+ * A preset resolved to the rectangle that gets stored.
+ *
+ * Presets and a free rectangle produce the SAME stored shape, which is the
+ * point: dragging an inset around later writes exactly what picking a corner
+ * writes, so the drag is additive rather than a second representation to keep
+ * in step.
+ */
+export function layerFrameForPreset(
+  position: LayerFramePosition,
+  size: LayerFrameSize,
+  clipAspect: number,
+  frameAspect: number,
+): LayerFrame {
+  const width = SIZE_WIDTHS[size];
+  const height = layerFrameHeight(width, clipAspect, frameAspect);
+  const marginX = MARGIN;
+  // See MARGIN: the same gap in pixels, expressed against the other axis.
+  const marginY = MARGIN * frameAspect;
+
+  const left = marginX;
+  const middleX = (1 - width) / 2;
+  const right = 1 - marginX - width;
+  const top = marginY;
+  const middleY = (1 - height) / 2;
+  const bottom = 1 - marginY - height;
+
+  const x =
+    position === "top-left" || position === "left" || position === "bottom-left"
+      ? left
+      : position === "top-right" || position === "right" || position === "bottom-right"
+        ? right
+        : middleX;
+  const y =
+    position === "top-left" || position === "top" || position === "top-right"
+      ? top
+      : position === "bottom-left" || position === "bottom" || position === "bottom-right"
+        ? bottom
+        : middleY;
+
+  // Through the same clamp every stored frame goes through, so a preset on an
+  // extreme aspect cannot produce something a hand-written frame could not.
+  const rect = layerFrameRect({ x, y, width }, clipAspect, frameAspect);
+  return { x: rect.x, y: rect.y, width: rect.width };
+}
+
+/**
+ * A stored value defended rather than recomputed.
+ *
+ * This field is HONOURED — whatever is here is where the inset draws — so
+ * anything that is not a real in-range rectangle has to fall back to "no
+ * picture" rather than putting a layer somewhere nobody asked for. Same rule as
+ * `placedStartOf`, and the opposite of a derived field like `startTime`, which
+ * is simply recalculated.
+ *
+ * A zero or negative width is dropped: an inset of no width is not a smaller
+ * inset, it is an invisible one, and storing it would be indistinguishable from
+ * meaning it.
+ */
+export function layerFrameOf(value: unknown): LayerFrame | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const frame = value as Record<string, unknown>;
+  const { x, y, width } = frame;
+  if (typeof x !== "number" || !Number.isFinite(x) || x < 0 || x > 1) return undefined;
+  if (typeof y !== "number" || !Number.isFinite(y) || y < 0 || y > 1) return undefined;
+  if (typeof width !== "number" || !Number.isFinite(width) || width <= 0 || width > 1) {
+    return undefined;
+  }
+  return { x, y, width };
+}
+
+/** Whether two frames are the same rectangle. The graph's placement command
+ *  compares fields with `===` to decide whether anything changed, which for an
+ *  object is always "yes" — every dispatch would push a no-op onto undo. */
+export function sameLayerFrame(a: LayerFrame | undefined, b: LayerFrame | undefined): boolean {
+  if (a === undefined || b === undefined) return a === b;
+  return a.x === b.x && a.y === b.y && a.width === b.width;
+}

--- a/packages/timeline-model/types.ts
+++ b/packages/timeline-model/types.ts
@@ -7,6 +7,8 @@
 // family) ride along on TimelineItemBase because stored clips round-trip
 // through view state in the legacy pipeline.
 
+import type { LayerFrame } from "./layer-frame";
+
 export type MediaKind = "image" | "video";
 export type CollectionEndpoint = "first" | "last";
 
@@ -58,6 +60,31 @@ export type TimelineItemBase = {
    * answer, and a stray value here must not open one.
    */
   placedStart?: number;
+
+  /**
+   * WHERE THIS DRAWS INSIDE THE PICTURE, when it runs under one.
+   *
+   * A lane clip has always been mixed UNDER the picture, and for sound that is
+   * the whole story. A picture cannot be under a picture — it would simply not
+   * be visible — so a layer that has a frame is composited OVER, into this
+   * sub-rectangle. "Under" describes the mix, "over" describes the screen.
+   *
+   * ABSENT MEANS NO PICTURE: the clip contributes its sound and nothing else,
+   * which is what every layered clip did before this existed, so no stored
+   * document changes what it renders. Discoverability is bought on the WRITE
+   * side instead — dropping a visual clip onto a lane stamps the default inset
+   * — rather than by inferring a frame here, which would silently change the
+   * output of timelines nobody has touched.
+   *
+   * IGNORED ON LANE 0, like `placedStart`. The picture is not inside itself.
+   *
+   * Normalized 0..1 of the OUTPUT frame, whose size is a per-render setting; a
+   * pixel rectangle would mean something different at every size. Height is
+   * absent on purpose — it follows from `aspect`, so an inset cannot be
+   * stretched. See {@link layerFrameRect} for resolving one, and
+   * {@link layerFrameForPreset} for the corner presets that write it.
+   */
+  layerFrame?: LayerFrame;
 
   /** Absolute timeline position. DERIVED by packing — see `placedStart`,
    *  which is the authored input this is computed from on lanes 1+. */

--- a/packages/timeline-model/validate.ts
+++ b/packages/timeline-model/validate.ts
@@ -7,6 +7,7 @@
 // round-trips and legacy writers produce nulls), while every REQUIRED
 // numeric must be a finite number (NaN/Infinity poison packing).
 
+import { layerFrameOf } from "./layer-frame";
 import { areTagsValid } from "./tags";
 import type { TimelineClip, TimelineDocument } from "./types";
 
@@ -124,6 +125,14 @@ function hasClipBase(clip: Record<string, unknown>): boolean {
     // by packing, so a NaN or a negative arriving from stored data would put
     // a clip somewhere no author asked for rather than being recomputed away.
     isOptionalNonNegative(clip.placedStart) &&
+    // Absent, or a rectangle `layerFrameOf` recognises. Delegated rather than
+    // spelled out here so the WRITE gate and the READ normalizer cannot drift
+    // apart and disagree about which stored rectangles are real — a frame that
+    // passed this and was then dropped on read would be an inset that saved
+    // and then vanished.
+    (clip.layerFrame === undefined ||
+      clip.layerFrame === null ||
+      layerFrameOf(clip.layerFrame) !== undefined) &&
     // Strictly boolean-or-absent. This gate guards the WRITE path, and a
     // truthy non-boolean would be read as "skip this clip" by the playback
     // and summary passes — a stored string "false" would silently drop a

--- a/packages/ui/dnd-collections/index.ts
+++ b/packages/ui/dnd-collections/index.ts
@@ -44,6 +44,7 @@ export {
   type CommandRejection,
   type MediaUpdate,
   type MoveNodesCommand,
+  type SetNodePlacementCommand,
   type UpdateMediaCommand,
 } from "./core/commands";
 export { hydrateCollection, type HydrateRejection } from "./core/hydrate";

--- a/packages/ui/dnd-collections/react/DndCollections.tsx
+++ b/packages/ui/dnd-collections/react/DndCollections.tsx
@@ -31,7 +31,11 @@ import {
 import { getEventCoordinates } from "@dnd-kit/utilities";
 
 import { getChildren, type CollectionItemNode, type CollectionsGraph, type NodeId } from "../core/graph";
-import type { AddNodesCommand, MoveNodesCommand } from "../core/commands";
+import type {
+  AddNodesCommand,
+  MoveNodesCommand,
+  SetNodePlacementCommand,
+} from "../core/commands";
 import {
   decodeDropTarget,
   encodeDropTarget,
@@ -194,6 +198,25 @@ export type DndCollectionsProps = Readonly<{
     graph: CollectionsGraph,
   ) => MoveNodesCommand | AddNodesCommand;
   /**
+   * Last look at a PLACEMENT before it commits — a drop onto a lane row.
+   *
+   * Separate from `mapDropCommand` rather than folded into it, because the two
+   * correct different things. That one fixes a BOUNDARY whose meaning a view
+   * changed; a lane and a time already mean the same thing in every view, so a
+   * placement has no boundary to fix. What a consumer wants here is to add
+   * DOMAIN detail the engine has no business computing — for the timeline, the
+   * inset a clip draws in once it is under the picture, which depends on the
+   * clip's aspect ratio and the project's output size. Neither is something a
+   * generic collections engine can or should know.
+   *
+   * Returning the command unchanged is a no-op.
+   */
+  mapPlacementCommand?: (
+    command: SetNodePlacementCommand,
+    intent: DropIntent,
+    graph: CollectionsGraph,
+  ) => SetNodePlacementCommand;
+  /**
    * Fires when a palette drag's factory-created nodes will NEVER commit —
    * cancelled, refused (including by `commandPolicy`), or orphaned by a
    * mid-drag graph replacement. Factories mint node ids and often park
@@ -315,6 +338,7 @@ export function DndCollections({
   keepMultiSelectModeWhenEmpty,
   commandPolicy,
   mapDropCommand,
+  mapPlacementCommand,
   onPaletteDiscard,
   dragGhostScale = 1,
   dragGhostWidth,
@@ -346,11 +370,13 @@ export function DndCollections({
   const onChangeRef = useRef(onChange);
   const commandPolicyRef = useRef(commandPolicy);
   const mapDropCommandRef = useRef(mapDropCommand);
+  const mapPlacementCommandRef = useRef(mapPlacementCommand);
   const onPaletteDiscardRef = useRef(onPaletteDiscard);
   useLayoutEffect(() => {
     onChangeRef.current = onChange;
     commandPolicyRef.current = commandPolicy;
     mapDropCommandRef.current = mapDropCommand;
+    mapPlacementCommandRef.current = mapPlacementCommand;
     onPaletteDiscardRef.current = onPaletteDiscard;
   });
   // Stable identity so the palette controller (and everything depending on
@@ -365,6 +391,11 @@ export function DndCollections({
   const handleMapDropCommand = useCallback(
     (command: MoveNodesCommand | AddNodesCommand, intent: DropIntent, graph: CollectionsGraph) =>
       mapDropCommandRef.current?.(command, intent, graph) ?? command,
+    []
+  );
+  const handleMapPlacementCommand = useCallback(
+    (command: SetNodePlacementCommand, intent: DropIntent, graph: CollectionsGraph) =>
+      mapPlacementCommandRef.current?.(command, intent, graph) ?? command,
     []
   );
 
@@ -392,6 +423,7 @@ export function DndCollections({
             <DndCollectionsContext
               animateMoves={animateMoves}
               mapDropCommand={handleMapDropCommand}
+              mapPlacementCommand={handleMapPlacementCommand}
               onPaletteDiscard={handlePaletteDiscard}
               dragGhostScale={dragGhostScale}
               dragGhostWidth={dragGhostWidth}
@@ -428,6 +460,7 @@ function DndCollectionsContext({
   children,
   animateMoves,
   mapDropCommand,
+  mapPlacementCommand,
   onPaletteDiscard,
   dragGhostScale,
   dragGhostWidth,
@@ -443,6 +476,12 @@ function DndCollectionsContext({
     intent: DropIntent,
     graph: CollectionsGraph,
   ) => MoveNodesCommand | AddNodesCommand;
+  /** Same treatment, for a drop onto a lane row — see the prop's doc above. */
+  mapPlacementCommand: (
+    command: SetNodePlacementCommand,
+    intent: DropIntent,
+    graph: CollectionsGraph,
+  ) => SetNodePlacementCommand;
   onPaletteDiscard: (nodes: readonly CollectionItemNode[]) => void;
   dragGhostScale: number;
   dragGhostWidth: number | undefined;
@@ -795,7 +834,9 @@ function DndCollectionsContext({
       // callback per render never leaves a stale mapping armed mid-drag.
       const command =
         commandResult.value.type === "set-node-placement"
-          ? commandResult.value
+          ? // A placement has no boundary to correct, but it CAN want domain
+            // detail the engine must not compute — see `mapPlacementCommand`.
+            mapPlacementCommand(commandResult.value, intent, graph)
           : mapDropCommand(commandResult.value, intent, graph);
 
       // Measure the ghost BEFORE the commit — dispatching unmounts the

--- a/packages/ui/dnd-collections/react/history-views.tsx
+++ b/packages/ui/dnd-collections/react/history-views.tsx
@@ -27,12 +27,22 @@ function describeCommand(command: CollectionsCommand): string {
       // Only the fields the command actually names — `undefined` means "leave
       // it alone", so listing it would describe a change that did not happen.
       const parts: string[] = [];
-      const { trackIndex, placedStart } = command.placement;
+      const { trackIndex, placedStart, layerFrame } = command.placement;
       if (trackIndex !== undefined) {
         parts.push(trackIndex === null ? "lane cleared" : `lane ${trackIndex}`);
       }
       if (placedStart !== undefined) {
         parts.push(placedStart === null ? "unplaced" : `at ${placedStart}s`);
+      }
+      // Adding a FIELD to an existing command is not a compile error here, the
+      // way adding a command type is — so this line is easy to forget, and
+      // forgetting it labels an inset change as if nothing had changed.
+      if (layerFrame !== undefined) {
+        parts.push(
+          layerFrame === null
+            ? "no inset"
+            : `inset ${Math.round(layerFrame.width * 100)}%`,
+        );
       }
       return `place [${command.nodeIds.join(", ")}] ${parts.join(", ")}`;
     }

--- a/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
+++ b/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
@@ -660,3 +660,87 @@ export const WithoutLanesNothingIsLive: Story = {
     expect(canvas.getByLabelText("shot-a preview")).toBeInTheDocument();
   },
 };
+
+// ── PICTURE IN PICTURE ──────────────────────────────────────────────────────
+//
+// Solid colours, because this is the only assertion in the suite that can read
+// the CANVAS rather than a data attribute: a red picture with a blue inset in
+// the bottom-right, sampled back with getImageData. Data URIs never taint the
+// canvas, so the pixels are readable.
+
+const RED =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR42mO4IycHAALyARlNudhnAAAAAElFTkSuQmCC";
+const BLUE =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR42mOQs7kDAAGyATfBjyy7AAAAAElFTkSuQmCC";
+
+/** The inset the default preset produces, near enough for a fixture: bottom
+ *  right, 30% of the frame's width. */
+const PIP_FRAME = { x: 0.66, y: 0.6, width: 0.3 };
+
+const PICTURE = laneClip("picture", 0, 10, 0, { src: RED, poster: RED });
+const PIP = laneClip("pip", 0, 10, 1, { src: BLUE, poster: BLUE, layerFrame: PIP_FRAME });
+
+/**
+ * Sample one pixel as `r,g,b`, in fractions of the PICTURE BOX — not of the
+ * canvas.
+ *
+ * The two are not the same and sampling the canvas gets you the letterbox: the
+ * pane fits the source inside the canvas and pads the rest with #050505, and
+ * the fixture's source is a 1x1 PNG, so the picture is a centred SQUARE with
+ * black bars either side. Compositing is positioned against that box for the
+ * same reason — the bars are not part of the frame.
+ */
+async function pixelAt(canvasElement: HTMLElement, fx: number, fy: number) {
+  const canvas = canvasElement.querySelector("canvas")!;
+  const context = canvas.getContext("2d")!;
+  const side = Math.min(canvas.width, canvas.height);
+  const left = (canvas.width - side) / 2;
+  const top = (canvas.height - side) / 2;
+  const x = Math.floor(left + side * fx);
+  const y = Math.floor(top + side * fy);
+  const [r, g, b] = context.getImageData(x, y, 1, 1).data;
+  return `${r},${g},${b}`;
+}
+
+const isRed = (pixel: string) => Number(pixel.split(",")[0]) > 150;
+const isBlue = (pixel: string) => Number(pixel.split(",")[2]) > 150;
+
+/** A video on a lane DRAWS, in the corner it was given — over the picture,
+ *  even though its sound is mixed under it. */
+export const ALayerWithAFrameIsComposited: Story = {
+  render: () => <LayeredFixture time={4} clips={[PICTURE, PIP]} />,
+  play: async ({ canvasElement }) => {
+    // The pane paints from async image `load` listeners, so wait for the
+    // picture to land before sampling anything.
+    await waitFor(async () => expect(isRed(await pixelAt(canvasElement, 0.5, 0.5))).toBe(true));
+
+    // The inset spans x 0.66-0.96 and, at 16:9 inside a square picture box,
+    // y 0.6-0.77. So its middle is BLUE…
+    await waitFor(async () => expect(isBlue(await pixelAt(canvasElement, 0.8, 0.68))).toBe(true));
+    // …while the same height on the far side is still the picture. A wash over
+    // the whole frame would pass the assertion above and fail this one.
+    expect(isRed(await pixelAt(canvasElement, 0.2, 0.68))).toBe(true);
+    // And so is directly ABOVE it, which pins the top edge.
+    expect(isRed(await pixelAt(canvasElement, 0.8, 0.4))).toBe(true);
+  },
+};
+
+/** WITHOUT a frame the same clip is sound only — which is what every layered
+ *  clip did before compositing, and what keeps stored timelines unchanged. */
+export const ALayerWithoutAFrameStaysInvisible: Story = {
+  render: () => (
+    <LayeredFixture
+      time={4}
+      clips={[PICTURE, laneClip("bed", 0, 10, 1, { src: BLUE, poster: BLUE })]}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const surface = within(canvasElement).getByTestId("workbench-display-surface");
+    await waitFor(async () => expect(isRed(await pixelAt(canvasElement, 0.5, 0.5))).toBe(true));
+    // Live — it is playing…
+    expect(surface).toHaveAttribute("data-live-layer-count", "1");
+    // …and nowhere on screen: where the framed version drew, this one leaves
+    // the picture.
+    expect(isRed(await pixelAt(canvasElement, 0.8, 0.68))).toBe(true);
+  },
+};

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -29,6 +29,7 @@ import { useTimelineDocuments } from "../timeline-document-store";
 
 import { createAudioMixer, type AudioMixer } from "./audio-graph";
 
+import { layerFrameOf, layerFrameRect, type LayerFrame } from "@storyboard/timeline-model/layer-frame";
 import type { CollectionTimelineClip, TimelineClip } from "../types";
 import { formatSeconds } from "../utils";
 import {
@@ -623,21 +624,48 @@ function getActiveClip(
   return getPictureClip(clips, currentTime);
 }
 
-/** Every under-layer audible at this instant, as resolvable media. The picture
- *  is excluded — it arrives separately as the thing that DRAWS. */
-function getLayerMedia(
+/** One under-layer running at this instant: what to play, and — when it has
+ *  been given a frame — where to draw it inside the picture. */
+type LiveLayer = Readonly<{
+  media: DisplayMedia;
+  /** Absent means SOUND ONLY, which is what every layer did before
+   *  compositing. It is not a default waiting to be filled in here. */
+  frame?: LayerFrame;
+  /** The clip's own shape, so the inset is never stretched. */
+  aspect: number;
+  /** Which lane, for draw order. */
+  lane: number;
+}>;
+
+/**
+ * Every under-layer live at this instant. The picture is excluded — it arrives
+ * separately as the thing that decides the frame.
+ *
+ * Sorted so the LOWEST lane is drawn last and therefore ends up on top,
+ * matching "lowest lane wins" everywhere else here. Sorting at resolve time
+ * rather than per draw: the live set changes far less often than the canvas
+ * repaints, and there are only ever a handful of them.
+ */
+function getLiveLayers(
   clips: TimelineClip[],
   currentTime: number,
   getCollectionClipFramePreview: GetCollectionClipFramePreview,
-): DisplayMedia[] {
+): LiveLayer[] {
   const live = getLiveLayerClips(clips, currentTime);
   if (live.length === 0) return [];
-  const media: DisplayMedia[] = [];
+  const layers: LiveLayer[] = [];
   for (const clip of live) {
-    const resolved = resolveClipMedia(clip, currentTime, getCollectionClipFramePreview);
-    if (resolved !== null) media.push(resolved);
+    const media = resolveClipMedia(clip, currentTime, getCollectionClipFramePreview);
+    if (media === null) continue;
+    const frame = layerFrameOf(clip.layerFrame);
+    layers.push({
+      media,
+      ...(frame === undefined ? {} : { frame }),
+      aspect: clip.aspect > 0 ? clip.aspect : 16 / 9,
+      lane: clip.trackIndex,
+    });
   }
-  return media;
+  return layers.sort((a, b) => b.lane - a.lane);
 }
 
 // normalizePlaybackTime is `nextPlayableTime` (./playback-skip): it decides
@@ -669,7 +697,7 @@ export function WorkbenchDisplaySurface({
   const activeClipDisabledRef = useRef(false);
   // The under-layers audible right now. The picture is `activeMediaRef`; these
   // play alongside it and, in this phase, are heard and not seen.
-  const liveLayerMediaRef = useRef<DisplayMedia[]>([]);
+  const liveLayerMediaRef = useRef<LiveLayer[]>([]);
   const animationFrameRef = useRef<number | null>(null);
   const timeoutFrameRef = useRef<number | null>(null);
   // PER ELEMENT, keyed by media key. This was a single slot, which was correct
@@ -886,7 +914,56 @@ export function WorkbenchDisplaySurface({
     // its true black, and a leaked filter would tint the next frame drawn.
     if (activeClipDisabledRef.current) context.filter = "grayscale(1) opacity(0.45)";
     context.drawImage(drawable, left, top, width, height);
+    // Reset BEFORE compositing, not just after: an inset is its own clip and
+    // must not inherit the picture's grayed-out treatment.
     context.filter = "none";
+
+    // THE UNDER-LAYERS, OVER THE PICTURE.
+    //
+    // Inside `drawDrawable` deliberately. Nine call sites repaint this canvas
+    // — the clock, six async media listeners, a ResizeObserver, and the frame
+    // override's settle loop — and every one of them that draws a picture
+    // arrives here. Compositing at the call sites instead would mean finding
+    // all nine, and missing one shows up as an inset that vanishes whenever
+    // some unrelated image finishes loading.
+    //
+    // Positioned against the PICTURE box, not the canvas: the black bars are
+    // letterboxing, not part of the frame. Note this is the one place preview
+    // and render can disagree — the stored rectangle is normalized to the
+    // OUTPUT frame (2.4:1 today) while the preview box takes the source's
+    // aspect, so when those differ an inset's vertical margin here is not
+    // exactly the margin in the file. The render is authoritative; this is
+    // close enough to position by eye and exact in x and in size.
+    const picture = playbackSurfaceRectRef.current;
+    if (picture === null) return;
+    const frameAspect = picture.height > 0 ? picture.width / picture.height : 1;
+    for (const layer of liveLayerMediaRef.current) {
+      if (layer.frame === undefined) continue;
+      const cached = cacheRef.current.get(layer.media.key);
+      // An <audio> has no frames, so a rectangle on one draws nothing. It
+      // should never have got a frame at all — see `hasPicture` on the write
+      // path — but a stored document can carry anything.
+      if (!cached || cached.kind === "audio") continue;
+      // Not decoded yet. Skipped rather than drawn as a blank: the next
+      // repaint picks it up, and the picture underneath stays intact.
+      const element =
+        cached.kind === "image"
+          ? cached.element.complete && cached.element.naturalWidth > 0
+            ? cached.element
+            : null
+          : cached.element.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA
+            ? cached.element
+            : null;
+      if (element === null) continue;
+      const rect = layerFrameRect(layer.frame, layer.aspect, frameAspect);
+      context.drawImage(
+        element,
+        picture.left + rect.x * picture.width,
+        picture.top + rect.y * picture.height,
+        rect.width * picture.width,
+        rect.height * picture.height,
+      );
+    }
   }, []);
 
   const drawEmptyFrame = useCallback(() => {
@@ -1163,7 +1240,7 @@ export function WorkbenchDisplaySurface({
     // The under-layers playing at this instant, alongside the picture rather
     // than instead of it. Resolved even when the picture is missing: a bed
     // running under a gap keeps playing, which is the whole point of a bed.
-    const layers = getLayerMedia(
+    const layers = getLiveLayers(
       sortedClipsRef.current,
       timelineTime,
       getCollectionClipFramePreview,
@@ -1172,13 +1249,16 @@ export function WorkbenchDisplaySurface({
 
     const liveKeys = new Set<string>();
     if (media) liveKeys.add(media.key);
-    for (const layer of layers) liveKeys.add(layer.key);
+    for (const layer of layers) liveKeys.add(layer.media.key);
     pauseClipsNotLive(liveKeys);
 
     for (const layer of layers) {
-      // Never `draws` — an under-layer is audible in this phase, not visible.
+      // Never `draws`: a layer does not own the canvas, so it must not trigger
+      // a repaint of its own. The picture does that, and `drawDrawable`
+      // composites whatever is live at the time — so an inset lands on the
+      // picture's schedule rather than each layer demanding its own.
       // Never `silent` — getLiveLayerClips already dropped the disabled ones.
-      syncMediaElement(layer, { shouldPlay, forceSeek, draws: false, silent: false });
+      syncMediaElement(layer.media, { shouldPlay, forceSeek, draws: false, silent: false });
     }
 
     if (!media) {
@@ -1530,7 +1610,7 @@ export function WorkbenchDisplaySurface({
     };
     const activeKey = activeMediaRef.current?.key;
     if (activeKey) raise(activeKey, activeClipDisabledRef.current);
-    for (const layer of liveLayerMediaRef.current) raise(layer.key, false);
+    for (const layer of liveLayerMediaRef.current) raise(layer.media.key, false);
   }, [activeMuted, activeVolume, applyGain, getMixer]);
 
   const canPlay = duration > 0 && sortedClips.length > 0;


### PR DESCRIPTION
Follow-up to #408. That made a layer **audible**; this makes it **visible**. A clip on a lane now carries a rectangle saying where it draws inside the frame, and the preview composites it — a video under the picture is a picture-in-picture rather than a disembodied soundtrack.

## "Under" describes the mix, "over" describes the screen

The model has always said a lane runs *under* the picture, and that stays exactly true of sound. It cannot be true of a picture: something drawn under the picture is not dimly visible, it is not visible at all. So a layer with a frame composites **on top**, into a sub-rectangle — same clip, two different senses of the word.

`layerFrame` is `{x, y, width}`, normalized 0..1 of the **output** frame, because the output size is a per-render setting and a pixel rectangle would mean something different at every size. **Height is not stored** — it follows from the clip's aspect, so there is no way to express a stretched inset.

## Absent still means sound only

No stored document changes what it exports. Discoverability is bought on the **write** side instead: dropping a clip that has a picture onto a lane stamps the default inset, and so does `set_lane`. Inferring one at read time would have quietly changed the output of timelines nobody has touched.

The rule lives in one place shared by both routes — split, one of them would produce a visible layer and the other a silent one.

## The frame needed a structural compare

It's the third member of the placement family and rides the same command, so undo is free. But it could not join the `===` loop the two scalars use: two identical rectangles are not `===`, so every dispatch would have looked like a change and stacked a no-op onto undo. A drag that ended where it started would have needed an undo to get back to where it already was.

## Found on the way, and older than this change

**A collection on a lane lost its placement on every reload.** The three collection-clip spec builders carried `disabled` but not the placement family at all, so a layered scene hydrated to a node with no lane and the next save wrote it back onto the picture. Measured:

```
stored:  trackIndex: 1, placedStart: 3, startTime: 3
back:    trackIndex: 0, placedStart: undefined, startTime: 0
```

Media clips were fine, which is why nothing caught it. Fixed here because the frame travels the same path, and pinned by its own tests.

## Where the composite lives

Inside `drawDrawable`. Nine call sites repaint that canvas — the clock, six async media listeners, a `ResizeObserver`, and the override's settle loop — and every one that draws a picture arrives there. Compositing at the call sites would mean finding all nine, and missing one reads as an inset that vanishes whenever an unrelated image finishes loading.

**Known limit, stated rather than hidden:** the preview positions the inset against the visible picture box, whose aspect is the *source's*, while the stored rectangle is normalized to the output frame (2.4:1). When those differ, the vertical margin on screen is not exactly the margin in the file. Exact in x and in size; the render is authoritative.

## Proof

The compositing test reads **actual pixels**, which nothing else in this suite does — a red picture with a blue inset, sampled with `getImageData` at four points: inside the inset, beside it, above it, and mid-picture. A wash over the whole frame passes the first and fails the rest.

And the decoder ceiling the plan flagged as a risk was measured, not assumed: **64 concurrent h264 elements decode and advance with zero stalls**, so it does not bind at any plausible number of lanes.

## Verified

- app + UI `tsc` clean; lint clean (same 5 pre-existing `<img>` warnings)
- **1109** app tests (+19)
- **719** shared unit tests (+36)
- **218** story interaction tests (+2)
- **173** graph-view e2e — a clean run. One load-sensitive grid test failed on two earlier full runs and passed 8/8 in isolation; it is unrelated to this change and passed on the clean run.

Still to come: the ffmpeg overlay so the export composites too (it currently mixes a layer's audio and ignores its picture), and the corner-preset picker in the details modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
