### PR TITLE
Let the inset be moved without an MCP call

### DIFF
--- a/apps/timeline-gstudio001/app/api/mcp/route.ts
+++ b/apps/timeline-gstudio001/app/api/mcp/route.ts
@@ -25,6 +25,7 @@ import {
   handleMoveClip,
   handleRemoveClip,
   handleSetLane,
+  handleSetLayerFrame,
   handleSetStart,
   handleRenameItem,
   handleSetTags,
@@ -359,6 +360,40 @@ const handler = createMcpHandler(
         const uid = uidFrom(extra);
         if (!uid) return errorResult(NO_IDENTITY);
         return fromToolResult(await handleSetLane(args, { requesterUid: uid }));
+      },
+    );
+
+    server.tool(
+      "set_layer_frame",
+      "Move a layered clip's INSET — where it draws inside the picture. Only for a clip already on a lane 1 or above that HAS a picture (video, image, or a nested collection): lane 0 IS the picture, so there is nothing for it to sit inside, and audio has no picture to draw. Pass position \"none\" to make it sound only again — mixed under the picture, not drawn." +
+        NO_LIVE_PUSH_NOTE,
+      {
+        timelineId: TIMELINE_ID_FIELD,
+        nodeId: nodeIdField,
+        position: z
+          .enum([
+            "top-left",
+            "top",
+            "top-right",
+            "left",
+            "center",
+            "right",
+            "bottom-left",
+            "bottom",
+            "bottom-right",
+            "none",
+          ])
+          .optional()
+          .describe("Corner or edge of the frame. \"none\" clears the inset. Defaults to bottom-right."),
+        size: z
+          .enum(["small", "medium", "large"])
+          .optional()
+          .describe("Fraction of the frame's width: 20%, 30%, 45%. Defaults to medium."),
+      },
+      async (args, extra) => {
+        const uid = uidFrom(extra);
+        if (!uid) return errorResult(NO_IDENTITY);
+        return fromToolResult(await handleSetLayerFrame(args, { requesterUid: uid }));
       },
     );
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -23,6 +23,8 @@ import { DETAILS_HERO_FILL_CLASS, DETAILS_PANEL_HEIGHT_CLASS } from "./graph-vie
 import { useSeekedVideo } from "@/hooks/use-seeked-video";
 import { formatSeconds } from "@/lib/format-duration";
 import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
+import { useClipDetail } from "./graph-details-context";
+import { LayerFramePicker } from "./graph-layer-frame-picker";
 import { TagEditor } from "./graph-tag-editor";
 import { CollectionDetailsBody } from "./graph-collection-details";
 import { ItemDisableToggle } from "./graph-item-disable-toggle";
@@ -284,6 +286,9 @@ function CollectionDetails({
 
 function ModalBody({ node, onClose }: Readonly<{ node: MediaNode; onClose: () => void }>) {
   const live = useLiveTrim(node.id);
+  // For the inset picker: the clip's shape decides the inset's height, and
+  // therefore which preset a stored rectangle came from.
+  const detail = useClipDetail(node.id as string);
   const history = useScopedHistory(node.id);
   const rename = useInlineRename(node.id, node.name, "item-details");
   // A still has no source window to map, so the trim half of this view is
@@ -517,6 +522,23 @@ function ModalBody({ node, onClose }: Readonly<{ node: MediaNode; onClose: () =>
           <div className="flex items-center justify-between font-mono text-[11px] text-zinc-500">
             <span className="text-blue-300/90">still · {formatSeconds(showing)} on screen</span>
             <span>drag the card&apos;s edge on the strip to change how long it holds</span>
+          </div>
+        )}
+
+        {/* WHERE IT DRAWS, for a clip that is under the picture. Only shown
+            when it is actually on a lane and actually has a picture: the
+            control describes a rectangle inside the frame, and neither the
+            picture itself nor a voiceover has one.
+
+            The first FORM control for a placement field — lane and placed
+            start are drag-only. It exists because the write path stamps a
+            default corner when a clip lands on a lane, and a default nobody
+            can move is worse than no default at all. Dispatches
+            `set-node-placement`, so unlike the tag editor below it IS
+            undoable. */}
+        {(node.trackIndex ?? 0) > 0 && node.mediaKind !== "audio" && (
+          <div className="flex flex-col gap-1.5 border-t border-white/10 pt-3">
+            <LayerFramePicker node={node} aspect={detail?.aspect} disabled={live !== null} />
           </div>
         )}
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-layer-frame-picker.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-layer-frame-picker.stories.tsx
@@ -1,0 +1,193 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, userEvent, within } from "storybook/test";
+
+import {
+  DndCollections,
+  buildGraph,
+  useCollectionsSelector,
+  type CollectionsGraph,
+  type NodeId,
+} from "@storyboard/ui/dnd-collections";
+
+import { LayerFramePicker } from "./graph-layer-frame-picker";
+
+// The first FORM control for a placement field — lane and placed start are
+// drag-only. Deterministic and offline: an in-memory graph, no network, no
+// details store beyond the aspect passed in.
+
+const NODE_ID = "pip" as NodeId;
+
+function graphWith(layerFrame?: { x: number; y: number; width: number }): CollectionsGraph {
+  const result = buildGraph([
+    {
+      kind: "collection",
+      id: "root",
+      name: "Root",
+      children: [
+        {
+          kind: "media",
+          id: NODE_ID,
+          name: "pip",
+          trackIndex: 1,
+          ...(layerFrame === undefined ? {} : { layerFrame }),
+        },
+      ],
+    },
+  ]);
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.value;
+}
+
+/** Re-reads the node from the store so the picker sees its own commits, and
+ *  publishes the stored rectangle for assertions — pixels are not observable
+ *  here, but what was written is. */
+function Harness() {
+  const node = useCollectionsSelector((snapshot) => snapshot.graph.nodesById.get(NODE_ID));
+  if (!node) return null;
+  return (
+    <div className="w-[420px] bg-zinc-950 p-4 text-zinc-100">
+      <LayerFramePicker node={node} aspect={16 / 9} disabled={false} />
+      <output data-frame={node.layerFrame === undefined ? "none" : JSON.stringify(node.layerFrame)}>
+        {node.layerFrame === undefined ? "none" : JSON.stringify(node.layerFrame)}
+      </output>
+    </div>
+  );
+}
+
+const meta: Meta<typeof LayerFramePicker> = {
+  title: "graph-view/LayerFramePicker",
+  component: LayerFramePicker,
+};
+export default meta;
+type Story = StoryObj<typeof LayerFramePicker>;
+
+const frameOf = (canvasElement: HTMLElement) =>
+  canvasElement.querySelector("[data-frame]")!.getAttribute("data-frame");
+
+/** The default the write path stamps reads back as a preset, so the picker
+ *  opens with a button already lit rather than looking untouched. */
+export const ShowsTheCurrentPreset: Story = {
+  render: () => (
+    <DndCollections initialGraph={graphWith({ x: 0.665, y: 0.511, width: 0.3 })}>
+      <Harness />
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByRole("button", { name: "Bottom right" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(canvas.getByRole("button", { name: "medium inset" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  },
+};
+
+/** Picking a corner writes the rectangle, and the button follows. */
+export const PickingACornerMovesTheInset: Story = {
+  render: () => (
+    <DndCollections initialGraph={graphWith({ x: 0.665, y: 0.511, width: 0.3 })}>
+      <Harness />
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const user = userEvent.setup();
+    const before = frameOf(canvasElement);
+
+    await user.click(canvas.getByRole("button", { name: "Top left" }));
+
+    expect(canvas.getByRole("button", { name: "Top left" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    // It really wrote a different rectangle, not just a different highlight.
+    expect(frameOf(canvasElement)).not.toBe(before);
+    // Top-left, so both coordinates are small — the margin, not the far edge.
+    const frame = JSON.parse(frameOf(canvasElement)!);
+    expect(frame.x).toBeLessThan(0.2);
+    expect(frame.y).toBeLessThan(0.3);
+  },
+};
+
+/** Size keeps the position. Changing one axis of a preset must not silently
+ *  reset the other. */
+export const ChangingSizeKeepsThePosition: Story = {
+  render: () => (
+    <DndCollections initialGraph={graphWith({ x: 0.665, y: 0.511, width: 0.3 })}>
+      <Harness />
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const user = userEvent.setup();
+
+    await user.click(canvas.getByRole("button", { name: "Top left" }));
+    await user.click(canvas.getByRole("button", { name: "large inset" }));
+
+    expect(canvas.getByRole("button", { name: "Top left" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(JSON.parse(frameOf(canvasElement)!).width).toBeGreaterThan(0.3);
+  },
+};
+
+/** "Sound only" is a real choice, not a reset — it puts the clip back to
+ *  contributing audio and no picture, which is what a bed wants. */
+export const SoundOnlyClearsTheInset: Story = {
+  render: () => (
+    <DndCollections initialGraph={graphWith({ x: 0.665, y: 0.511, width: 0.3 })}>
+      <Harness />
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const user = userEvent.setup();
+
+    await user.click(canvas.getByRole("button", { name: "sound only" }));
+
+    expect(frameOf(canvasElement)).toBe("none");
+    // Nothing is lit, because nothing is set — and the control disables
+    // itself rather than offering to clear what is already clear.
+    expect(canvas.getByRole("button", { name: "Bottom right" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(canvas.getByRole("button", { name: "sound only" })).toBeDisabled();
+  },
+};
+
+/** A rectangle no preset produces is named CUSTOM rather than rounded to the
+ *  nearest button — which is what a hand-written frame looks like, and what
+ *  dragging an inset will produce. */
+export const ACustomRectangleSaysSo: Story = {
+  render: () => (
+    <DndCollections initialGraph={graphWith({ x: 0.123, y: 0.456, width: 0.321 })}>
+      <Harness />
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByText("custom")).toBeInTheDocument();
+    for (const name of ["Bottom right", "Top left", "Centre"]) {
+      expect(canvas.getByRole("button", { name })).toHaveAttribute("aria-pressed", "false");
+    }
+  },
+};
+
+/** A layer with no inset yet: sound only, and every button ready. */
+export const NoInsetYet: Story = {
+  render: () => (
+    <DndCollections initialGraph={graphWith()}>
+      <Harness />
+    </DndCollections>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByText("no inset")).toBeInTheDocument();
+    expect(frameOf(canvasElement)).toBe("none");
+  },
+};

--- a/apps/timeline-gstudio001/components/graph-view/graph-layer-frame-picker.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-layer-frame-picker.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import {
+  LAYER_FRAME_POSITIONS,
+  LAYER_FRAME_SIZES,
+  type LayerFramePosition,
+  type LayerFrameSize,
+} from "@storyboard/timeline-model/layer-frame";
+import { useCollectionsStore, type CollectionItemNode } from "@storyboard/ui/dnd-collections";
+
+import { layerFrameForChoice, presetForLayerFrame } from "@/lib/default-layer-frame";
+import { cn } from "@/lib/utils";
+
+// WHERE THE INSET SITS, without an MCP call.
+//
+// The first FORM control for a placement field — lane and placed start are
+// drag-only. It exists because the write path stamps a default corner, and a
+// default nobody can move is worse than no default: the clip appears in the
+// bottom right and stays there.
+//
+// Presets rather than four numbers, and presets FIRST rather than a drag: the
+// useful range is narrow, picking from it is faster than typing into it, and a
+// preset stores exactly the rectangle a drag would — so dragging an inset on
+// the preview later is additive rather than a second representation to keep in
+// step.
+
+const POSITION_LABELS: Readonly<Record<LayerFramePosition, string>> = {
+  "top-left": "Top left",
+  top: "Top",
+  "top-right": "Top right",
+  left: "Left",
+  center: "Centre",
+  right: "Right",
+  "bottom-left": "Bottom left",
+  bottom: "Bottom",
+  "bottom-right": "Bottom right",
+};
+
+const SIZE_LABELS: Readonly<Record<LayerFrameSize, string>> = {
+  small: "S",
+  medium: "M",
+  large: "L",
+};
+
+export function LayerFramePicker({
+  node,
+  aspect,
+  disabled,
+}: Readonly<{
+  node: CollectionItemNode;
+  /** The clip's shape, which decides the inset's height and therefore which
+   *  preset a stored rectangle came from. */
+  aspect: number | undefined;
+  disabled: boolean;
+}>) {
+  const store = useCollectionsStore();
+  const frame = node.layerFrame;
+  const current = presetForLayerFrame(frame, aspect);
+  // A rectangle no preset produces — a hand-written one, or one a future drag
+  // made. Named rather than rounded to the nearest button.
+  const isCustom = frame !== undefined && current === null;
+
+  const set = (position: LayerFramePosition, size: LayerFrameSize) => {
+    store.dispatch({
+      type: "set-node-placement",
+      nodeIds: [node.id],
+      placement: { layerFrame: layerFrameForChoice(position, size, aspect) },
+    });
+  };
+
+  // Clearing is a real choice, not a reset: it puts the clip back to
+  // contributing SOUND ONLY, which is what a layer did before compositing and
+  // what you want for a bed that happens to be a video file.
+  const clear = () => {
+    store.dispatch({
+      type: "set-node-placement",
+      nodeIds: [node.id],
+      placement: { layerFrame: null },
+    });
+  };
+
+  const size = current?.size ?? "medium";
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <span className="font-mono text-[11px] tracking-[0.08em] text-zinc-500 uppercase">
+          Inset
+        </span>
+        <span className="font-mono text-[11px] text-zinc-500">
+          {frame === undefined
+            ? "no inset"
+            : isCustom
+              ? "custom"
+              : `${POSITION_LABELS[current!.position].toLowerCase()} · ${Math.round(frame.width * 100)}%`}
+        </span>
+      </div>
+
+      <div className="flex items-start gap-3">
+        {/* The 3x3 reads as the frame it describes, so the button's POSITION
+            is the label — the accessible name carries the words. */}
+        <div className="grid grid-cols-3 gap-1" role="group" aria-label="Inset position">
+          {LAYER_FRAME_POSITIONS.map((position) => {
+            const active = current?.position === position;
+            return (
+              <button
+                key={position}
+                type="button"
+                disabled={disabled}
+                aria-label={POSITION_LABELS[position]}
+                aria-pressed={active}
+                data-layer-position={position}
+                onClick={() => set(position, size)}
+                className={cn(
+                  "h-5 w-7 rounded-sm border transition-colors disabled:opacity-40",
+                  active
+                    ? "border-primary bg-primary/30"
+                    : "border-white/15 bg-white/5 hover:bg-white/10",
+                )}
+              />
+            );
+          })}
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <div className="flex gap-1" role="group" aria-label="Inset size">
+            {LAYER_FRAME_SIZES.map((option) => {
+              const active = current?.size === option;
+              return (
+                <button
+                  key={option}
+                  type="button"
+                  disabled={disabled}
+                  aria-label={`${option} inset`}
+                  aria-pressed={active}
+                  data-layer-size={option}
+                  onClick={() => set(current?.position ?? "bottom-right", option)}
+                  className={cn(
+                    "h-5 w-6 rounded-sm border font-mono text-[10px] transition-colors disabled:opacity-40",
+                    active
+                      ? "border-primary bg-primary/30 text-zinc-100"
+                      : "border-white/15 bg-white/5 text-zinc-400 hover:bg-white/10",
+                  )}
+                >
+                  {SIZE_LABELS[option]}
+                </button>
+              );
+            })}
+          </div>
+          <button
+            type="button"
+            disabled={disabled || frame === undefined}
+            data-layer-frame-clear
+            onClick={clear}
+            className="rounded-sm border border-white/15 bg-white/5 px-1.5 py-0.5 font-mono text-[10px] text-zinc-400 transition-colors hover:bg-white/10 disabled:opacity-40"
+          >
+            sound only
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/timeline-gstudio001/lib/default-layer-frame.test.ts
+++ b/apps/timeline-gstudio001/lib/default-layer-frame.test.ts
@@ -2,7 +2,18 @@ import { describe, expect, it } from "vitest";
 
 import { buildGraph, parseNodeId, type GraphNodeSpec } from "@storyboard/collections-core";
 
-import { defaultLayerFrame, defaultLayerFramePlacement, hasPicture } from "./default-layer-frame";
+import {
+  LAYER_FRAME_POSITIONS,
+  LAYER_FRAME_SIZES,
+} from "@storyboard/timeline-model/layer-frame";
+
+import {
+  defaultLayerFrame,
+  defaultLayerFramePlacement,
+  hasPicture,
+  layerFrameForChoice,
+  presetForLayerFrame,
+} from "./default-layer-frame";
 
 // A clip dropped on a lane has to be VISIBLE, or the gesture is the same dead
 // end lanes themselves were before the empty lane row: you do it, nothing
@@ -110,6 +121,57 @@ describe("defaultLayerFramePlacement", () => {
   it("still works with no detail recorded for the clip", () => {
     expect(defaultLayerFramePlacement(nodeIn(specs, "img"), undefined)).toEqual({
       layerFrame: defaultLayerFrame(undefined),
+    });
+  });
+});
+
+describe("presetForLayerFrame", () => {
+  it("round-trips every one of the twenty-seven", () => {
+    for (const position of LAYER_FRAME_POSITIONS) {
+      for (const size of LAYER_FRAME_SIZES) {
+        const frame = layerFrameForChoice(position, size, 16 / 9);
+        expect(presetForLayerFrame(frame, 16 / 9)).toEqual({ position, size });
+      }
+    }
+  });
+
+  it("says CUSTOM for a rectangle no preset produces", () => {
+    // Not an error, and not "whichever is nearest" — it is what a hand-written
+    // frame looks like, and what dragging an inset will produce.
+    expect(presetForLayerFrame({ x: 0.123, y: 0.456, width: 0.321 }, 16 / 9)).toBeNull();
+  });
+
+  it("says custom for no frame at all", () => {
+    expect(presetForLayerFrame(undefined, 16 / 9)).toBeNull();
+  });
+
+  it("is judged against the CLIP's aspect, not a fixed one", () => {
+    // The same stored rectangle means a different preset for a differently
+    // shaped clip, because `y` absorbs the height.
+    const squarish = layerFrameForChoice("bottom-right", "medium", 4 / 3);
+    expect(presetForLayerFrame(squarish, 4 / 3)).toEqual({
+      position: "bottom-right",
+      size: "medium",
+    });
+    expect(presetForLayerFrame(squarish, 16 / 9)).toBeNull();
+  });
+
+  it("collapses onto the FIRST match when a clip is too tall to move vertically", () => {
+    // A 9:16 clip at 30% of a 2.4:1 frame's width is taller than the frame, so
+    // every vertical position clamps to the same rectangle — top-right and
+    // bottom-right become the same picture. Reading order decides, and the
+    // picker lights up the top row. Not a defect: there is genuinely nowhere
+    // else for that inset to sit, and the alternative would be a picker whose
+    // buttons all do the same thing while pretending otherwise.
+    const tall = layerFrameForChoice("bottom-right", "medium", 9 / 16);
+    expect(layerFrameForChoice("top-right", "medium", 9 / 16)).toEqual(tall);
+    expect(presetForLayerFrame(tall, 9 / 16)?.position).toBe("top-right");
+  });
+
+  it("matches the default the write path stamps", () => {
+    expect(presetForLayerFrame(defaultLayerFrame(16 / 9), 16 / 9)).toEqual({
+      position: "bottom-right",
+      size: "medium",
     });
   });
 });

--- a/apps/timeline-gstudio001/lib/default-layer-frame.ts
+++ b/apps/timeline-gstudio001/lib/default-layer-frame.ts
@@ -1,8 +1,13 @@
 import {
   DEFAULT_LAYER_POSITION,
   DEFAULT_LAYER_SIZE,
+  LAYER_FRAME_POSITIONS,
+  LAYER_FRAME_SIZES,
   layerFrameForPreset,
+  sameLayerFrame,
   type LayerFrame,
+  type LayerFramePosition,
+  type LayerFrameSize,
 } from "@storyboard/timeline-model/layer-frame";
 import type { CollectionItemNode } from "@storyboard/ui/dnd-collections";
 
@@ -68,4 +73,51 @@ export function defaultLayerFramePlacement(
 ): Readonly<{ layerFrame?: LayerFrame }> {
   if (!hasPicture(node) || node?.layerFrame !== undefined) return {};
   return { layerFrame: defaultLayerFrame(detail?.aspect) };
+}
+
+/**
+ * The rectangle a preset produces at THIS project's output size.
+ *
+ * The picker and the tool both go through here so neither has to know the
+ * output aspect, and neither can pick a different one from the other.
+ */
+export function layerFrameForChoice(
+  position: LayerFramePosition,
+  size: LayerFrameSize,
+  aspect: number | undefined,
+): LayerFrame {
+  return layerFrameForPreset(position, size, aspect ?? FALLBACK_ASPECT, FRAME_ASPECT);
+}
+
+export type LayerFrameChoice = Readonly<{
+  position: LayerFramePosition;
+  size: LayerFrameSize;
+}>;
+
+/**
+ * Which preset a stored rectangle came from, if any.
+ *
+ * Reverse-mapped by generating all 27 and comparing, rather than by solving
+ * the geometry backwards: the forward function is the definition, and anything
+ * that re-derived it could drift from it. Twenty-seven cheap comparisons run
+ * when a modal opens, not per frame.
+ *
+ * `null` means CUSTOM — a rectangle no preset produces. That is not an error:
+ * it is what a hand-written frame looks like, and what dragging an inset will
+ * produce when that ships. The picker says so rather than lighting up whichever
+ * preset happens to be nearest.
+ */
+export function presetForLayerFrame(
+  frame: LayerFrame | undefined,
+  aspect: number | undefined,
+): LayerFrameChoice | null {
+  if (frame === undefined) return null;
+  for (const position of LAYER_FRAME_POSITIONS) {
+    for (const size of LAYER_FRAME_SIZES) {
+      if (sameLayerFrame(frame, layerFrameForChoice(position, size, aspect))) {
+        return { position, size };
+      }
+    }
+  }
+  return null;
 }

--- a/apps/timeline-gstudio001/lib/mcp/write-handlers.ts
+++ b/apps/timeline-gstudio001/lib/mcp/write-handlers.ts
@@ -23,7 +23,19 @@ import {
   type ApplyCommandOutcome,
 } from "./apply-command";
 import type { DetailsById } from "@storyboard/timeline-domain";
-import { defaultLayerFramePlacement } from "@/lib/default-layer-frame";
+import {
+  DEFAULT_LAYER_POSITION,
+  DEFAULT_LAYER_SIZE,
+  LAYER_FRAME_POSITIONS,
+  LAYER_FRAME_SIZES,
+  type LayerFramePosition,
+  type LayerFrameSize,
+} from "@storyboard/timeline-model/layer-frame";
+import {
+  defaultLayerFramePlacement,
+  hasPicture,
+  layerFrameForChoice,
+} from "@/lib/default-layer-frame";
 
 // Remote (server-side) write tools. Each one translates arguments into a single
 // CollectionsCommand and hands it to `applyCollectionsCommand`, which owns the
@@ -663,5 +675,98 @@ export async function handleSetStart(
       bumped: wasBumped,
       written: outcome.affectedIds,
     },
+  );
+}
+
+// --- set_layer_frame ---------------------------------------------------------
+
+export type SetLayerFrameArgs = Readonly<{
+  timelineId: string;
+  nodeId: string;
+  /** A named corner, or `"none"` to go back to sound only. */
+  position?: LayerFramePosition | "none";
+  size?: LayerFrameSize;
+}>;
+
+/**
+ * Move a layered clip's INSET — where it draws inside the picture.
+ *
+ * PRESETS, not four numbers, for the same reason the picker offers them: the
+ * useful range is narrow, and a preset stores exactly the rectangle a drag
+ * would, so the two authoring routes cannot diverge.
+ *
+ * The two refusals both describe something that cannot exist rather than
+ * something disallowed. A clip on lane 0 IS the picture, so there is no frame
+ * for it to sit inside. Audio has no picture to draw — and a frame on one is
+ * worse than useless, because a normalised audio segment carries a synthesised
+ * BLACK video stream that would paint over the shot.
+ */
+export async function handleSetLayerFrame(
+  args: SetLayerFrameArgs,
+  ctx: WriteContext,
+): Promise<ToolResult> {
+  const nodeId = parseNodeId(args.nodeId);
+  const position = args.position ?? DEFAULT_LAYER_POSITION;
+  const size = args.size ?? DEFAULT_LAYER_SIZE;
+  if (position !== "none" && !LAYER_FRAME_POSITIONS.includes(position)) {
+    return toolError(
+      `\`position\` must be one of ${LAYER_FRAME_POSITIONS.join(", ")}, or "none" for sound only.`,
+    );
+  }
+  if (!LAYER_FRAME_SIZES.includes(size)) {
+    return toolError(`\`size\` must be one of ${LAYER_FRAME_SIZES.join(", ")}.`);
+  }
+
+  let landedWidth = 0;
+
+  const outcome = await applyCollectionsCommand(
+    args.timelineId,
+    (graph: CollectionsGraph, details) => {
+      const node = graph.nodesById.get(nodeId);
+      if (!node) return { ok: false, message: `No node with id "${args.nodeId}".` } as const;
+      if ((graph.parentById.get(nodeId) ?? null) === null) {
+        return {
+          ok: false,
+          message: `"${args.nodeId}" is a timeline itself, not a clip inside one.`,
+        } as const;
+      }
+      if ((node.trackIndex ?? 0) === 0) {
+        return {
+          ok: false,
+          message:
+            `"${args.nodeId}" is on the picture, so there is no frame for it to sit inside — ` +
+            `an inset is where a clip draws WITHIN the picture. Put it on a lane with set_lane first.`,
+        } as const;
+      }
+      if (!hasPicture(node)) {
+        return {
+          ok: false,
+          message:
+            `"${args.nodeId}" has no picture to place — it is audio, and it is already mixed ` +
+            `under the picture. Only video, images and collections can be inset.`,
+        } as const;
+      }
+
+      if (position === "none") {
+        return {
+          ok: true,
+          command: { type: "set-node-placement", nodeIds: [nodeId], placement: { layerFrame: null } },
+        } as const;
+      }
+      const layerFrame = layerFrameForChoice(position, size, details[nodeId as string]?.aspect);
+      landedWidth = layerFrame.width;
+      return {
+        ok: true,
+        command: { type: "set-node-placement", nodeIds: [nodeId], placement: { layerFrame } },
+      } as const;
+    },
+    ctx.requesterUid,
+  );
+  if (!outcome.ok) return reportFailure(outcome);
+  return toolOk(
+    position === "none"
+      ? `"${args.nodeId}" is sound only now — it plays under the picture without being drawn.`
+      : `"${args.nodeId}" now draws ${position.replace("-", " ")}, at ${Math.round(landedWidth * 100)}% of the frame's width.`,
+    { nodeId: args.nodeId, position, size, written: outcome.affectedIds },
   );
 }

--- a/packages/timeline-model/layer-frame.ts
+++ b/packages/timeline-model/layer-frame.ts
@@ -48,6 +48,23 @@ export type LayerFramePosition =
 
 export type LayerFrameSize = "small" | "medium" | "large";
 
+/** Every position, in READING ORDER — which is also the order a 3x3 picker
+ *  lays them out, so a consumer can map straight over it. */
+export const LAYER_FRAME_POSITIONS: readonly LayerFramePosition[] = [
+  "top-left",
+  "top",
+  "top-right",
+  "left",
+  "center",
+  "right",
+  "bottom-left",
+  "bottom",
+  "bottom-right",
+];
+
+/** Smallest first. */
+export const LAYER_FRAME_SIZES: readonly LayerFrameSize[] = ["small", "medium", "large"];
+
 /** Width as a fraction of the frame. Three steps rather than a number, because
  *  the useful range is narrow and picking from it is faster than typing into
  *  it. A free rect can still be written directly; these are just the presets. */


### PR DESCRIPTION
Last of the arc (#408, #409, #410). The write path stamps a default corner when a clip lands on a lane, and until now nothing in the UI could move it — **a default nobody can reposition is worse than no default**: the clip appears bottom-right and stays there.

A 3×3 of positions and three sizes in the clip details modal, plus a `set_layer_frame` tool so the agent route exists too. Both go through one resolver, so picking a corner by hand and calling the tool produce the same rectangle.

## Presets rather than four numbers, and before a drag

The useful range is narrow, picking from it is faster than typing into it, and a preset stores **exactly the rectangle a drag would** — so dragging an inset on the preview later is additive rather than a second representation to keep in step.

## Only where an inset can exist

Shown for a clip that is on a lane **and** has a picture. The control describes a rectangle inside the frame, and neither the picture itself nor a voiceover has one. The tool refuses the same two cases with the reason rather than a rule:

- lane 0 **is** the picture, so there is nothing for it to sit inside;
- audio has no picture to draw — and a frame on audio is worse than useless, since a normalised audio segment carries a synthesised *black* video stream that would paint over the shot.

## "Sound only" is a choice, not a reset

It puts the clip back to contributing audio and no picture — what you want for a bed that happens to be a video file, and the only way back now that landing on a lane stamps a frame.

## Custom is named, not rounded

A rectangle no preset produces says **custom** rather than lighting up whichever button was closest. That's what a hand-written frame looks like, and what a drag will produce; claiming the inset is somewhere it isn't would be worse than saying nothing.

Reverse-mapped by generating all twenty-seven and comparing, rather than solving the geometry backwards — the forward function is the definition, and anything re-deriving it could drift. Twenty-seven comparisons when a modal opens, not per frame.

**Worth recording, because the test found it rather than the code:** the mapping is *ambiguous* for an extreme aspect. A 9:16 clip at 30% of a 2.4:1 frame's width is taller than the frame, so every vertical position clamps to the same rectangle — top-right and bottom-right become the same picture. Reading order decides and the picker lights the top row. Not a defect (there is genuinely nowhere else for that inset to sit) but pinned now rather than left to surprise someone.

The picker dispatches `set-node-placement`, so unlike the tag editor beside it, this **is** undoable.

## Verified

- app + UI `tsc` clean; lint clean (same 5 pre-existing `<img>` warnings)
- **1135** app tests (+6)
- **719** shared unit tests
- **224** story interaction tests (+6)
- **173** graph-view e2e — a clean run

**On the e2e:** three earlier full runs each lost one or two tests to page-load visibility timeouts, a different victim each time and every one passing in isolation in ~2s against a 5s ceiling. Measured rather than assumed — the shared `next dev` on :3000 is sitting at **7.4 GB resident**, which is what pushes a cold page load past the ceiling under parallel load. Restarting that server clears it.

---

That completes the arc: lanes are audible (#408), visible in the preview (#409), composited into the render (#410), and now positionable by hand. Free drag on the preview canvas remains deliberately deferred — `trim-handles.tsx` is the precedent when it comes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
