### PR TITLE
Make the inset picker visible, and put the inset where the render will

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-layer-frame-picker.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-layer-frame-picker.tsx
@@ -42,6 +42,26 @@ const SIZE_LABELS: Readonly<Record<LayerFrameSize, string>> = {
   large: "L",
 };
 
+// LITERAL SKY, NOT `bg-primary`, and this is load-bearing rather than a style
+// preference.
+//
+// The design tokens are declared only under `.graph-view-theme` (see
+// app/globals.css, which says so and explains why: defining them globally would
+// repaint the legacy views). This modal is PORTALED TO document.body, which is
+// outside that element — so inside it `--gv-primary` does not resolve,
+// `bg-primary/30` computes to `rgba(0,0,0,0)` and `border-primary` falls back
+// to `currentColor`. Measured, not guessed: the first version of this picker
+// marked its selection with a transparent fill and a white border, and looked
+// almost identical to the unselected state.
+//
+// Everything else in this modal is already written in literal zinc/sky for the
+// same reason, so this matches the neighbours as well as the app's active
+// treatment (HEADER_TOGGLE_ACTIVE in graph-board.tsx).
+const CELL_ACTIVE = "bg-sky-400/70 ring-1 ring-sky-300";
+const CELL_IDLE = "bg-white/10 hover:bg-white/20";
+const CHIP_ACTIVE = "border-sky-400/70 bg-sky-400/15 text-sky-200";
+const CHIP_IDLE = "border-white/15 bg-white/5 text-zinc-400 hover:bg-white/10";
+
 export function LayerFramePicker({
   node,
   aspect,
@@ -96,10 +116,17 @@ export function LayerFramePicker({
         </span>
       </div>
 
-      <div className="flex items-start gap-3">
-        {/* The 3x3 reads as the frame it describes, so the button's POSITION
-            is the label — the accessible name carries the words. */}
-        <div className="grid grid-cols-3 gap-1" role="group" aria-label="Inset position">
+      <div className="flex items-center gap-4">
+        {/* ONE BORDERED BOX, not nine floating chips — it has to read as the
+            FRAME the inset sits inside, or "bottom right" is a word rather
+            than a place. Proportioned 2.4:1 to match the render's own output
+            shape, and the cells are hairline-separated rather than gapped so
+            the box stays a box. */}
+        <div
+          role="group"
+          aria-label="Inset position"
+          className="grid aspect-[2.4] w-[120px] shrink-0 grid-cols-3 grid-rows-3 gap-px overflow-hidden rounded-[3px] border border-white/25 bg-white/25 p-px"
+        >
           {LAYER_FRAME_POSITIONS.map((position) => {
             const active = current?.position === position;
             return (
@@ -111,18 +138,17 @@ export function LayerFramePicker({
                 aria-pressed={active}
                 data-layer-position={position}
                 onClick={() => set(position, size)}
+                title={POSITION_LABELS[position]}
                 className={cn(
-                  "h-5 w-7 rounded-sm border transition-colors disabled:opacity-40",
-                  active
-                    ? "border-primary bg-primary/30"
-                    : "border-white/15 bg-white/5 hover:bg-white/10",
+                  "transition-colors disabled:opacity-40",
+                  active ? CELL_ACTIVE : CELL_IDLE,
                 )}
               />
             );
           })}
         </div>
 
-        <div className="flex flex-col gap-1">
+        <div className="flex flex-col items-start gap-1.5">
           <div className="flex gap-1" role="group" aria-label="Inset size">
             {LAYER_FRAME_SIZES.map((option) => {
               const active = current?.size === option;
@@ -136,10 +162,8 @@ export function LayerFramePicker({
                   data-layer-size={option}
                   onClick={() => set(current?.position ?? "bottom-right", option)}
                   className={cn(
-                    "h-5 w-6 rounded-sm border font-mono text-[10px] transition-colors disabled:opacity-40",
-                    active
-                      ? "border-primary bg-primary/30 text-zinc-100"
-                      : "border-white/15 bg-white/5 text-zinc-400 hover:bg-white/10",
+                    "h-6 w-7 rounded-sm border font-mono text-[10px] transition-colors disabled:opacity-40",
+                    active ? CHIP_ACTIVE : CHIP_IDLE,
                   )}
                 >
                   {SIZE_LABELS[option]}
@@ -147,12 +171,14 @@ export function LayerFramePicker({
               );
             })}
           </div>
+          {/* Quieter than the two groups above: it is the way OUT of the
+              feature, not a fourth position. */}
           <button
             type="button"
             disabled={disabled || frame === undefined}
             data-layer-frame-clear
             onClick={clear}
-            className="rounded-sm border border-white/15 bg-white/5 px-1.5 py-0.5 font-mono text-[10px] text-zinc-400 transition-colors hover:bg-white/10 disabled:opacity-40"
+            className="font-mono text-[10px] text-zinc-500 underline decoration-dotted underline-offset-2 transition-colors hover:text-zinc-300 disabled:no-underline disabled:opacity-40 disabled:hover:text-zinc-500"
           >
             sound only
           </button>

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -12,6 +12,8 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 
+import { DEFAULT_RENDER_FORMAT } from "@/lib/render/cut-list";
+
 import {
   MIN_ITEM_WIDTH,
   durationToWidth,
@@ -1131,6 +1133,11 @@ export function PreviewShell({
           enabled ? (
             <WorkbenchDisplaySurface
               clips={clips}
+              // So a layered clip's inset lands where the RENDER will put it.
+              // Its rectangle is normalized to the output frame, which is a
+              // different box from the picture whenever the source's shape
+              // differs from the render's.
+              outputAspect={DEFAULT_RENDER_FORMAT.width / DEFAULT_RENDER_FORMAT.height}
               currentTime={time}
               onCurrentTimeChange={handleTimeChange}
               playing={playing}

--- a/packages/timeline-model/layer-frame.test.ts
+++ b/packages/timeline-model/layer-frame.test.ts
@@ -7,6 +7,7 @@ import {
   layerFrameHeight,
   layerFrameOf,
   layerFrameRect,
+  outputFrameRect,
   sameLayerFrame,
 } from "./layer-frame";
 
@@ -168,5 +169,61 @@ describe("sameLayerFrame", () => {
     expect(sameLayerFrame(undefined, undefined)).toBe(true);
     expect(sameLayerFrame(undefined, { x: 0.1, y: 0.2, width: 0.3 })).toBe(false);
     expect(sameLayerFrame({ x: 0.1, y: 0.2, width: 0.3 }, undefined)).toBe(false);
+  });
+});
+
+describe("outputFrameRect", () => {
+  // A 640x360 picture drawn at (0,0), and a 2.4:1 render.
+  const PICTURE = { left: 0, top: 0, width: 640, height: 360 };
+
+  it("PILLARBOXES a picture narrower than the output", () => {
+    // What ffmpeg's decrease+pad does: same height, wider frame, centred.
+    const out = outputFrameRect(PICTURE, FRAME);
+    expect(out.height).toBe(360);
+    expect(out.width).toBeCloseTo(360 * FRAME, 3);
+    expect(out.left).toBeCloseTo((640 - 360 * FRAME) / 2, 3);
+    // The frame extends PAST the picture on both sides — that is the padding,
+    // and an inset near an edge legitimately lands on it.
+    expect(out.left).toBeLessThan(0);
+  });
+
+  it("letterboxes a picture wider than the output", () => {
+    const out = outputFrameRect({ left: 0, top: 0, width: 640, height: 100 }, 1.0);
+    expect(out.width).toBe(640);
+    expect(out.height).toBe(640);
+  });
+
+  it("is the picture itself when the shapes already agree", () => {
+    const out = outputFrameRect(PICTURE, 16 / 9);
+    expect(out.width).toBeCloseTo(640, 3);
+    expect(out.height).toBeCloseTo(360, 3);
+    expect(out.left).toBeCloseTo(0, 3);
+    expect(out.top).toBeCloseTo(0, 3);
+  });
+
+  it("stays centred on the picture, wherever the picture is", () => {
+    const offset = outputFrameRect({ left: 100, top: 40, width: 640, height: 360 }, FRAME);
+    const centreX = offset.left + offset.width / 2;
+    const centreY = offset.top + offset.height / 2;
+    expect(centreX).toBeCloseTo(100 + 320, 3);
+    expect(centreY).toBeCloseTo(40 + 180, 3);
+  });
+
+  it("REPRODUCES THE RENDER'S MARGINS, which is the whole point", () => {
+    // The number that sent me here: composing the default inset against the
+    // picture box gave 22px and 68px where the render gives 40px and 40px.
+    // Against the output frame the preview agrees with the file.
+    const frame = layerFrameForPreset("bottom-right", "medium", WIDESCREEN, FRAME);
+    const out = outputFrameRect(PICTURE, FRAME);
+    const rect = layerFrameRect(frame, WIDESCREEN, FRAME);
+    const right = out.width - (rect.x + rect.width) * out.width;
+    const bottom = out.height - (rect.y + rect.height) * out.height;
+    // Even in pixels, as the margin rule intends — and in the same ratio the
+    // 1152x480 render produces.
+    expect(Math.abs(right - bottom)).toBeLessThan(1);
+  });
+
+  it("survives a nonsense aspect", () => {
+    expect(Number.isFinite(outputFrameRect(PICTURE, 0).width)).toBe(true);
   });
 });

--- a/packages/timeline-model/layer-frame.ts
+++ b/packages/timeline-model/layer-frame.ts
@@ -107,6 +107,43 @@ export function layerFrameHeight(width: number, clipAspect: number, frameAspect:
   return (width * frameAspect) / aspect;
 }
 
+/** A box in whatever units the caller is working in — canvas pixels, usually. */
+export type Box = Readonly<{ left: number; top: number; width: number; height: number }>;
+
+/**
+ * The OUTPUT FRAME a drawn picture sits inside.
+ *
+ * The stored rectangle is normalized to the output frame, not to the picture,
+ * and the two are different boxes whenever the source's shape differs from the
+ * render's: the export fits the source into the output and PADS the remainder
+ * (`fitFilter`, decrease + pad), so a 16:9 shot in a 2.4:1 render is
+ * pillarboxed and the frame extends past the picture on both sides.
+ *
+ * A preview that placed the inset against the PICTURE instead would put it in
+ * the wrong place, and not subtly: for the default bottom-right inset the
+ * render's margins are 40.3px and 40.3px, while composing against a 16:9
+ * picture box gives 22.4px and 68.0px. Measured, which is how this was found —
+ * it looked wrong in a screenshot before it looked wrong in a number.
+ *
+ * Returns the output frame centred on the picture, which is where padding puts
+ * it. An inset near an edge can therefore land over the padding, exactly as it
+ * does in the finished file.
+ */
+export function outputFrameRect(picture: Box, outputAspect: number): Box {
+  const aspect = outputAspect > 0 ? outputAspect : 1;
+  const pictureAspect = picture.height > 0 ? picture.width / picture.height : aspect;
+  // Narrower than the output means the output is WIDER at the same height —
+  // pillarboxed. Otherwise it is letterboxed and the width is what is shared.
+  const width = pictureAspect < aspect ? picture.height * aspect : picture.width;
+  const height = pictureAspect < aspect ? picture.height : picture.width / aspect;
+  return {
+    left: picture.left + (picture.width - width) / 2,
+    top: picture.top + (picture.height - height) / 2,
+    width,
+    height,
+  };
+}
+
 /**
  * A stored frame resolved against a real output size and a real clip.
  *

--- a/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
+++ b/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
@@ -744,3 +744,85 @@ export const ALayerWithoutAFrameStaysInvisible: Story = {
     expect(isRed(await pixelAt(canvasElement, 0.8, 0.68))).toBe(true);
   },
 };
+
+/**
+ * THE SAME INSET, composed against the RENDER's frame rather than the picture.
+ *
+ * The stored rectangle is normalized to the output frame, and that is a
+ * different box from the picture whenever the source's shape differs from the
+ * render's — the export fits the source in and pads the rest. Composing
+ * against the picture put the default inset at 22px and 68px of margin where
+ * the render gives 40px and 40px; against the output frame the preview agrees
+ * with the file.
+ *
+ * The fixture's source is 1x1, so its picture box is SQUARE and a 2.4:1 output
+ * frame extends well past it either side — which is exactly the padding the
+ * render would add, and an inset near the edge sits over it on purpose.
+ */
+export const TheInsetLandsWhereTheRenderPutsIt: Story = {
+  render: () => (
+    <main className="min-h-[900px] bg-zinc-950 p-4 text-zinc-100">
+      <WorkbenchDisplaySurface
+        clips={[PICTURE, PIP]}
+        currentTime={4}
+        onCurrentTimeChange={() => {}}
+        outputAspect={1152 / 480}
+        className="h-[320px]"
+      />
+    </main>
+  ),
+  play: async ({ canvasElement }) => {
+    await waitFor(async () => expect(isRed(await pixelAt(canvasElement, 0.5, 0.5))).toBe(true));
+
+    // The inset is no longer inside the picture SQUARE — the output frame is
+    // wider than it, so the bottom-right corner of the frame is out over the
+    // padding. What must hold is that it is still drawn, and still to the
+    // lower right of the picture's centre.
+    const canvas = canvasElement.querySelector("canvas")!;
+    const context = canvas.getContext("2d")!;
+    const found: Array<[number, number]> = [];
+    for (let x = 0; x < canvas.width; x += 8) {
+      for (let y = 0; y < canvas.height; y += 8) {
+        const [r, g, b] = context.getImageData(x, y, 1, 1).data;
+        if (b! > 150 && r! < 120) found.push([x, y]);
+      }
+    }
+    expect(found.length).toBeGreaterThan(0);
+    const minX = Math.min(...found.map(([x]) => x));
+    const minY = Math.min(...found.map(([, y]) => y));
+    expect(minX).toBeGreaterThan(canvas.width / 2);
+    expect(minY).toBeGreaterThan(canvas.height / 2);
+  },
+};
+
+/**
+ * THE REAL CASE: a 16:9 picture in a 2.4:1 render.
+ *
+ * The fixture above uses a 1x1 source, so its picture box is square and the
+ * output frame extends absurdly past it. Every real source here is 16:9, and
+ * this is what that actually looks like — the shape to judge the default inset
+ * by, and the one that decides whether it sits on the picture or off it.
+ */
+const RED_169 =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAIAAAC0SDtlAAAAFElEQVR42mO4IydHEmIY1TAoNAAAHVGdgV3m+aoAAAAASUVORK5CYII=";
+
+export const ARealisticSixteenNineSource: Story = {
+  render: () => (
+    <main className="min-h-[900px] bg-zinc-950 p-4 text-zinc-100">
+      <WorkbenchDisplaySurface
+        clips={[
+          laneClip("picture", 0, 10, 0, { src: RED_169, poster: RED_169 }),
+          laneClip("pip", 0, 10, 1, { src: BLUE, poster: BLUE, layerFrame: PIP_FRAME }),
+        ]}
+        currentTime={4}
+        onCurrentTimeChange={() => {}}
+        outputAspect={1152 / 480}
+        className="h-[320px]"
+      />
+    </main>
+  ),
+  play: async ({ canvasElement }) => {
+    await waitFor(async () => expect(isRed(await pixelAt(canvasElement, 0.5, 0.5))).toBe(true));
+    expect(isBlue(await pixelAt(canvasElement, 0.5, 0.5))).toBe(false);
+  },
+};

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -29,7 +29,12 @@ import { useTimelineDocuments } from "../timeline-document-store";
 
 import { createAudioMixer, type AudioMixer } from "./audio-graph";
 
-import { layerFrameOf, layerFrameRect, type LayerFrame } from "@storyboard/timeline-model/layer-frame";
+import {
+  layerFrameOf,
+  layerFrameRect,
+  outputFrameRect,
+  type LayerFrame,
+} from "@storyboard/timeline-model/layer-frame";
 import type { CollectionTimelineClip, TimelineClip } from "../types";
 import { formatSeconds } from "../utils";
 import {
@@ -142,6 +147,21 @@ type WorkbenchDisplaySurfaceProps = {
    * A consumer cannot move the playhead through this prop, by construction.
    */
   frameOverride?: Readonly<{ src: string; poster?: string; sourceTime: number }> | null;
+  /**
+   * The RENDER's frame shape (width / height), for placing under-layer insets.
+   *
+   * A layer's rectangle is normalized to the OUTPUT frame, not to the picture,
+   * and the two differ whenever the source's shape differs from the render's —
+   * the export fits the source in and pads the rest. Without this the preview
+   * composes against the picture box and puts the inset somewhere the finished
+   * file will not: for the default bottom-right inset, 22px and 68px of margin
+   * against a 16:9 picture where the render gives 40px and 40px.
+   *
+   * Optional because the surface is generic and a consumer with no render
+   * target has no answer; absent means compose against the picture, which is
+   * the best available guess and what this did before.
+   */
+  outputAspect?: number;
 };
 
 const BUFFER_WINDOW_SIZE = 4;
@@ -688,6 +708,7 @@ export function WorkbenchDisplaySurface({
   onMutedChange,
   onClose,
   frameOverride = null,
+  outputAspect,
 }: WorkbenchDisplaySurfaceProps) {
   const { getCollectionClipFramePreview } = useTimelineDocuments();
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -698,6 +719,10 @@ export function WorkbenchDisplaySurface({
   // The under-layers audible right now. The picture is `activeMediaRef`; these
   // play alongside it and, in this phase, are heard and not seen.
   const liveLayerMediaRef = useRef<LiveLayer[]>([]);
+  // A ref, so `drawDrawable` keeps its stable identity — it is reached from a
+  // dozen async media listeners that would be orphaned if it were rebuilt.
+  const outputAspectRef = useRef(outputAspect);
+  outputAspectRef.current = outputAspect;
   const animationFrameRef = useRef<number | null>(null);
   const timeoutFrameRef = useRef<number | null>(null);
   // PER ELEMENT, keyed by media key. This was a single slot, which was correct
@@ -936,7 +961,15 @@ export function WorkbenchDisplaySurface({
     // close enough to position by eye and exact in x and in size.
     const picture = playbackSurfaceRectRef.current;
     if (picture === null) return;
-    const frameAspect = picture.height > 0 ? picture.width / picture.height : 1;
+    // THE OUTPUT FRAME, not the picture. See `outputAspect` — an inset near an
+    // edge can legitimately land over where the render's padding will be, and
+    // showing that is the point rather than a glitch.
+    const aspect = outputAspectRef.current;
+    const frame =
+      aspect === undefined || !(aspect > 0)
+        ? { left: picture.left, top: picture.top, width: picture.width, height: picture.height }
+        : outputFrameRect(picture, aspect);
+    const frameAspect = frame.height > 0 ? frame.width / frame.height : 1;
     for (const layer of liveLayerMediaRef.current) {
       if (layer.frame === undefined) continue;
       const cached = cacheRef.current.get(layer.media.key);
@@ -958,10 +991,10 @@ export function WorkbenchDisplaySurface({
       const rect = layerFrameRect(layer.frame, layer.aspect, frameAspect);
       context.drawImage(
         element,
-        picture.left + rect.x * picture.width,
-        picture.top + rect.y * picture.height,
-        rect.width * picture.width,
-        rect.height * picture.height,
+        frame.left + rect.x * frame.width,
+        frame.top + rect.y * frame.height,
+        rect.width * frame.width,
+        rect.height * frame.height,
       );
     }
   }, []);


### PR DESCRIPTION
Follow-up to #408–#411. Two bugs found by **screenshotting the UI** rather than asserting about it. Both were invisible to the tests, because the tests check what a thing *does* and these were about what it *looks like*.

## The picker marked its selection with nothing

Measured, not guessed — the selected cell computed to:

```
background-color: rgba(0, 0, 0, 0)     ← transparent
border-color:     rgb(255, 255, 255)   ← currentColor fallback
```

A transparent fill and a fallback border, near enough identical to the unselected cells beside it.

**The cause is a scope gap worth knowing about.** The design tokens are declared only under `.graph-view-theme` — `app/globals.css` says so, and why: defining them globally would repaint the legacy views. The details modal is **portaled to `document.body`**, outside that element. So inside it `--gv-primary` doesn't resolve, `bg-primary/30` computes to transparent and `border-primary` falls back to `currentColor`.

Every other control in that modal is already written in literal zinc/sky, which is why nothing had hit this before — the picker was the first thing in there to use a token class. It's literal sky now, matching `HEADER_TOGGLE_ACTIVE` and its neighbours.

And while looking: nine gapped chips didn't read as a frame, so "bottom right" was a word rather than a place. It's one bordered box at the output's own 2.4:1 proportion now, hairline-divided, with the chosen cell filled.

## The inset was drawn in the wrong box

A layer's rectangle is normalized to the **output frame**, and that's a different box from the picture whenever the source's shape differs from the render's — the export fits the source in and pads the rest. The preview composed against the *picture*, so it put the inset somewhere the finished file wouldn't.

The numbers, which turned *"close enough to position by eye"* (my own words, in the PR that shipped it) into a fix:

| | right margin | bottom margin |
| --- | --- | --- |
| **render** (2.4:1 frame) | 40.3px | 40.3px |
| preview, 16:9 source | 22.4px | 68.0px |

Three times off. Visible in a screenshot before it was visible in a number.

The surface takes an optional `outputAspect` and composes against the frame containing the letterboxed picture. Absent, it behaves exactly as before, so no consumer changes.

## What that then exposed — filed, not fixed here

The truthful preview immediately showed something the old one hid: **the default inset lands 30% off the picture.** The render format is 1152×480 (2.4:1) while every source in the project is 16:9, so every export is pillarboxed and an inset anchored to the output frame's corner sits partly on the bar.

Confirmed in the finished mp4 rather than inferred — sampling the real render at y=361 gives orange at x=1020 and x=1080, past the picture's right edge at x=1003.

That's a product call (change the render format, or move the default), so it's #412. The preview showing it honestly is what a preview is for.

## Verified

- app + UI `tsc` clean; lint clean (same 5 pre-existing `<img>` warnings)
- **1135** app tests
- **725** shared unit tests (+6)
- **226** story interaction tests (+2)
- **173** graph-view e2e — a clean run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
