### PR TITLE
Pin two composite rules that only a pixel can prove

### DIFF
--- a/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
+++ b/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
@@ -826,3 +826,65 @@ export const ARealisticSixteenNineSource: Story = {
     expect(isBlue(await pixelAt(canvasElement, 0.5, 0.5))).toBe(false);
   },
 };
+
+const GREEN =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR42mOQ22cDAAIWARkpb7gwAAAAAElFTkSuQmCC";
+
+/**
+ * TWO LAYERS, OVERLAPPING: the LOWEST lane ends up on top.
+ *
+ * The same rule as everywhere else here — `getContainingClip` prefers the
+ * lowest lane, the ffmpeg overlay chain draws the highest lane first — so the
+ * canvas has to agree or the preview and the render disagree about which of
+ * two insets is in front.
+ */
+export const TheLowestLaneDrawsOnTop: Story = {
+  render: () => (
+    <LayeredFixture
+      time={4}
+      clips={[
+        PICTURE,
+        // Same rectangle on both, so whichever is drawn LAST wins the pixels.
+        laneClip("under", 0, 10, 2, { src: GREEN, poster: GREEN, layerFrame: PIP_FRAME }),
+        laneClip("over", 0, 10, 1, { src: BLUE, poster: BLUE, layerFrame: PIP_FRAME }),
+      ]}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    await waitFor(async () => expect(isRed(await pixelAt(canvasElement, 0.5, 0.5))).toBe(true));
+    // Lane 1 over lane 2: blue, not green.
+    await waitFor(async () => expect(isBlue(await pixelAt(canvasElement, 0.8, 0.68))).toBe(true));
+    const pixel = await pixelAt(canvasElement, 0.8, 0.68);
+    expect(Number(pixel.split(",")[1])).toBeLessThan(150);
+  },
+};
+
+/**
+ * A DISABLED PICTURE is drawn grayed — and the inset over it is NOT.
+ *
+ * `drawDrawable` sets `context.filter` for the disabled treatment, and the
+ * composite runs in the same function. Resetting the filter BEFORE compositing
+ * rather than only after is what keeps a perfectly ordinary layer from being
+ * grayed for the picture's sake; nothing but a pixel can prove it.
+ */
+export const ADisabledPictureDoesNotGrayItsInset: Story = {
+  render: () => (
+    <LayeredFixture
+      time={4}
+      clips={[
+        laneClip("picture", 0, 10, 0, { src: RED, poster: RED, disabled: true }),
+        PIP,
+      ]}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    // The picture is grayed, so its red is washed out — no longer "red" by the
+    // saturation test the other stories use.
+    await waitFor(async () =>
+      expect(await pixelAt(canvasElement, 0.5, 0.5)).not.toBe("5,5,5"),
+    );
+    expect(isRed(await pixelAt(canvasElement, 0.5, 0.5))).toBe(false);
+    // The inset keeps its own colour at full strength.
+    await waitFor(async () => expect(isBlue(await pixelAt(canvasElement, 0.8, 0.68))).toBe(true));
+  },
+};


### PR DESCRIPTION
Both were coded against deliberately and neither had ever been looked at. Found while re-auditing my own feature after the visual pass in #413.

## The lowest lane draws on top

Two insets on the same rectangle, lanes 1 and 2 — whichever is drawn last wins the pixels. It has to be **lane 1**, matching `getContainingClip` preferring the lowest lane and the ffmpeg overlay chain drawing the highest lane first. Otherwise the preview and the render disagree about which of two insets is in front.

## A disabled picture must not gray its inset

`drawDrawable` sets `context.filter` for the grayed treatment, and the composite runs in the same function — so the reset has to happen **before** the loop, not only after.

Confirmed by breaking it: with the reset moved after the composite the story goes red, so the inset really would have been grayed for the picture's sake.

## Verified

- app + UI `tsc` clean; lint clean (same 5 pre-existing `<img>` warnings)
- **1135** app tests
- **725** shared unit tests
- **18** in this story file (+2)
- **173** graph-view e2e — a clean run

---

Also audited this round, and **found correct** — no changes needed: the snap indicator, the target-row tint, and the new-lane band, all re-shot mid-drag in the real app. They resolve to sky properly because the strip renders inside `.graph-view-theme`; only the portaled modals were affected by the token gap #413 fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)