### PR TITLE
Render at 16:9, and let a project choose otherwise

### DIFF
--- a/apps/timeline-gstudio001/app/api/renders/route.ts
+++ b/apps/timeline-gstudio001/app/api/renders/route.ts
@@ -107,7 +107,10 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Timeline was not found." }, { status: 404 });
     }
 
-    const cutList = compileCutList(compiled.manifest, DEFAULT_RENDER_FORMAT);
+    // The PROJECT's shape when it has chosen one — set from the board — and
+    // the default otherwise. A render started here and one started by an agent
+    // must produce the same file.
+    const cutList = compileCutList(compiled.manifest, compiled.renderFormat ?? DEFAULT_RENDER_FORMAT);
     if (cutList.cuts.length === 0) {
       // Nothing enabled to render. A refusal rather than an empty file: an
       // export that silently produced zero seconds would look like a failure

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -116,6 +116,7 @@ import { ActiveTagFilters, TagFilterControl } from "./graph-tag-filter-control";
 import { ItemDetailsProvider } from "./graph-item-details-context";
 import { useGraphDetailsSnapshot } from "./graph-details-context";
 import { GraphSaveStatus } from "./graph-save-status";
+import { GraphRenderFormat } from "./graph-render-format";
 import { GraphRenderStatus } from "./graph-render-status";
 import { GraphShortcuts, requestGraphShortcuts } from "./graph-shortcuts";
 import { GraphItemDetailsModal } from "./graph-item-details-modal";
@@ -1742,6 +1743,14 @@ export function GraphBoard({
                   without this the only sign one had finished was a card
                   appearing in Renders. */}
               <GraphRenderStatus timelineId={projectId} />
+              {/* The SHAPE the project exports at. Beside the render status
+                  because it answers the question that one raises — a render
+                  finished, at what size? — and because there is no render
+                  dialog in this app to put it in: renders start from the MCP
+                  tools. Unlike its two neighbours it is always present, since
+                  "what will this export as" is a standing fact rather than a
+                  transient status. */}
+              <GraphRenderFormat timelineId={projectId} />
             </div>
             {/* Middle summary and the right-hand controls fade out under the
                 drag readout that overlays this row, and fade back on drop. The

--- a/apps/timeline-gstudio001/components/graph-view/graph-layer-frame-picker.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-layer-frame-picker.stories.tsx
@@ -9,7 +9,14 @@ import {
   type NodeId,
 } from "@storyboard/ui/dnd-collections";
 
+import { defaultLayerFrame } from "@/lib/default-layer-frame";
+
 import { LayerFramePicker } from "./graph-layer-frame-picker";
+
+// The fixture rectangle is DERIVED, not hardcoded. These stories used a
+// literal { x: 0.665, y: 0.511 } — what the default produced when the output
+// was 2.4:1 — and it silently stopped being the default the day the render
+// format changed to 16:9, so "shows the current preset" started showing none.
 
 // The first FORM control for a placement field — lane and placed start are
 // drag-only. Deterministic and offline: an in-memory graph, no network, no
@@ -68,7 +75,7 @@ const frameOf = (canvasElement: HTMLElement) =>
  *  opens with a button already lit rather than looking untouched. */
 export const ShowsTheCurrentPreset: Story = {
   render: () => (
-    <DndCollections initialGraph={graphWith({ x: 0.665, y: 0.511, width: 0.3 })}>
+    <DndCollections initialGraph={graphWith(defaultLayerFrame(16 / 9))}>
       <Harness />
     </DndCollections>
   ),
@@ -88,7 +95,7 @@ export const ShowsTheCurrentPreset: Story = {
 /** Picking a corner writes the rectangle, and the button follows. */
 export const PickingACornerMovesTheInset: Story = {
   render: () => (
-    <DndCollections initialGraph={graphWith({ x: 0.665, y: 0.511, width: 0.3 })}>
+    <DndCollections initialGraph={graphWith(defaultLayerFrame(16 / 9))}>
       <Harness />
     </DndCollections>
   ),
@@ -116,7 +123,7 @@ export const PickingACornerMovesTheInset: Story = {
  *  reset the other. */
 export const ChangingSizeKeepsThePosition: Story = {
   render: () => (
-    <DndCollections initialGraph={graphWith({ x: 0.665, y: 0.511, width: 0.3 })}>
+    <DndCollections initialGraph={graphWith(defaultLayerFrame(16 / 9))}>
       <Harness />
     </DndCollections>
   ),
@@ -139,7 +146,7 @@ export const ChangingSizeKeepsThePosition: Story = {
  *  contributing audio and no picture, which is what a bed wants. */
 export const SoundOnlyClearsTheInset: Story = {
   render: () => (
-    <DndCollections initialGraph={graphWith({ x: 0.665, y: 0.511, width: 0.3 })}>
+    <DndCollections initialGraph={graphWith(defaultLayerFrame(16 / 9))}>
       <Harness />
     </DndCollections>
   ),

--- a/apps/timeline-gstudio001/components/graph-view/graph-render-format.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-render-format.stories.tsx
@@ -1,0 +1,86 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+
+import type { RenderFormat } from "@storyboard/timeline-model/render-format";
+
+import { RenderFormatMenu } from "./graph-render-format";
+
+// The shape a project exports at. The first render setting in the app, and the
+// first render UI of any kind — renders still start from the MCP tools.
+//
+// Driven through the PRESENTATIONAL half: the connected wrapper reads a module
+// singleton, which a story could only exercise by seeding global state.
+
+function Harness({ initial }: Readonly<{ initial?: RenderFormat }>) {
+  const [format, setFormat] = useState<RenderFormat | undefined>(initial);
+  return (
+    <div className="graph-view-theme flex min-h-[280px] items-start bg-zinc-950 p-4">
+      <RenderFormatMenu
+        format={format}
+        onChange={(next) => setFormat(next ?? undefined)}
+      />
+    </div>
+  );
+}
+
+const meta: Meta<typeof RenderFormatMenu> = {
+  title: "graph-view/RenderFormatMenu",
+  component: RenderFormatMenu,
+};
+export default meta;
+type Story = StoryObj<typeof RenderFormatMenu>;
+
+/** By the data attribute, not the label — the label is what several of these
+ *  stories are ABOUT, and a selector that depended on its shape would stop
+ *  finding the control in exactly the case that changes it. */
+const trigger = (canvasElement: HTMLElement) =>
+  canvasElement.querySelector("[data-render-format]") as HTMLElement;
+
+/** A project that has never chosen shows the DEFAULT, not an empty control —
+ *  "what will this export as" always has an answer. */
+export const UnsetShowsTheDefault: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    expect(trigger(canvasElement)).toHaveTextContent("16:9 · 720p");
+    expect(trigger(canvasElement)).toHaveAttribute("data-render-format", "1280x720");
+  },
+};
+
+/** Choosing writes the format and the readout follows. */
+export const ChoosingAPresetChangesTheFormat: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const user = userEvent.setup();
+    await user.click(trigger(canvasElement));
+
+    // The menu is PORTALED, so it is not inside `canvasElement`.
+    const menu = within(document.body);
+    await waitFor(() => expect(menu.getByText("Scope")).toBeInTheDocument());
+    await user.click(menu.getByText("Scope"));
+
+    await waitFor(() =>
+      expect(trigger(canvasElement)).toHaveAttribute("data-render-format", "1152x480"),
+    );
+    expect(trigger(canvasElement)).toHaveTextContent("2.4:1 · Scope");
+  },
+};
+
+/** A stored format that matches no preset shows its NUMBERS rather than
+ *  claiming to be one of them — the render tool takes any size, so this is
+ *  reachable without the menu. */
+export const ACustomSizeShowsItsNumbers: Story = {
+  render: () => <Harness initial={{ width: 1440, height: 810, fps: 30 }} />,
+  play: async ({ canvasElement }) => {
+    // 1440x810 IS 16:9, so it names the ratio it recognises and gives the size.
+    expect(trigger(canvasElement)).toHaveTextContent("16:9 · 1440×810");
+  },
+};
+
+/** A size matching no known ratio falls back to the bare dimensions. */
+export const AnUnknownRatioShowsOnlyTheSize: Story = {
+  render: () => <Harness initial={{ width: 1000, height: 700, fps: 24 }} />,
+  play: async ({ canvasElement }) => {
+    expect(trigger(canvasElement)).toHaveTextContent("1000×700");
+  },
+};

--- a/apps/timeline-gstudio001/components/graph-view/graph-render-format.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-render-format.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+import {
+  DEFAULT_RENDER_FORMAT,
+  RENDER_FORMAT_PRESETS,
+  renderFormatPresetOf,
+  type RenderFormat,
+} from "@storyboard/timeline-model/render-format";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/core/dropdown-menu";
+import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
+import { cn } from "@/lib/utils";
+
+// THE SHAPE THIS PROJECT EXPORTS AT.
+//
+// The first render SETTING in the app, and the first render UI of any kind —
+// renders are still started from the MCP tools, and this board only reports
+// on them. It is here rather than in a dialog for that reason: there is no
+// render dialog to put it in, and the shape of the deliverable is a standing
+// fact about the project rather than a per-render choice.
+//
+// Stored on the DOCUMENT (`TimelineDocument.renderFormat`), so a render an
+// agent starts produces the same file as one started here, and the choice
+// survives a reload.
+//
+// Literal zinc/sky rather than token classes, matching its neighbours in this
+// header — and see the note in graph-layer-frame-picker.tsx for the way tokens
+// fail silently in a portaled surface. This one is not portaled, but the menu
+// CONTENT is.
+
+const RATIO_TOLERANCE = 0.01;
+
+/** "16:9" for anything close enough, otherwise the raw numbers. */
+function describe(format: RenderFormat): string {
+  const preset = renderFormatPresetOf(format);
+  if (preset) return `${preset.ratio} · ${preset.label}`;
+  const ratio = format.height > 0 ? format.width / format.height : 0;
+  const named = RENDER_FORMAT_PRESETS.find(
+    (candidate) =>
+      Math.abs(candidate.format.width / candidate.format.height - ratio) < RATIO_TOLERANCE,
+  );
+  return named
+    ? `${named.ratio} · ${format.width}×${format.height}`
+    : `${format.width}×${format.height}`;
+}
+
+/**
+ * The menu itself, with no idea where the format is stored.
+ *
+ * Split from the connected wrapper below so it can be driven by a story: the
+ * gateway is a module singleton, and a component that reached for it directly
+ * could only be exercised by seeding global state.
+ */
+export function RenderFormatMenu({
+  format,
+  onChange,
+}: Readonly<{
+  /** The project's stored format, or undefined when it has never chosen one. */
+  format: RenderFormat | undefined;
+  onChange: (next: RenderFormat | null) => void;
+}>) {
+  // No optimistic state: `setRenderFormat` updates the gateway's cache and
+  // notifies synchronously, so this re-reads the new value on the same tick.
+  // Only the network flush is debounced.
+  const shown = format ?? DEFAULT_RENDER_FORMAT;
+  const current = renderFormatPresetOf(shown);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        data-render-format={`${shown.width}x${shown.height}`}
+        title={`Renders at ${shown.width}×${shown.height} at ${shown.fps}fps. Click to change.`}
+        className={cn(
+          "rounded-sm px-1.5 py-0.5 font-mono text-[11px] tabular-nums transition-colors",
+          "text-zinc-500 hover:bg-white/5 hover:text-zinc-300",
+          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-500/70",
+        )}
+      >
+        {describe(shown)}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="min-w-44">
+        {RENDER_FORMAT_PRESETS.map((preset) => {
+          const active = current?.id === preset.id;
+          return (
+            <DropdownMenuItem
+              key={preset.id}
+              data-render-format-option={preset.id}
+              onSelect={() => onChange(preset.format)}
+              className={cn("gap-3 font-mono text-[11px]", active && "text-sky-300")}
+            >
+              <span className="w-10 shrink-0">{preset.ratio}</span>
+              <span className="flex-1">{preset.label}</span>
+              <span className="text-zinc-500">
+                {preset.format.width}×{preset.format.height}
+              </span>
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+/** Reads and writes the project's own format, so the board only has to place
+ *  this — the same shape as `GraphSaveStatus` and `GraphRenderStatus` beside
+ *  it, both of which own their own source. */
+export function GraphRenderFormat({ timelineId }: Readonly<{ timelineId: string }>) {
+  const documents = useSyncExternalStore(
+    graphDocumentsGateway.subscribe,
+    graphDocumentsGateway.read,
+    graphDocumentsGateway.read,
+  );
+  return (
+    <RenderFormatMenu
+      format={documents[timelineId]?.renderFormat}
+      onChange={(next) => void graphDocumentsGateway.setRenderFormat(timelineId, next)}
+    />
+  );
+}

--- a/apps/timeline-gstudio001/lib/compile-timeline-manifest.ts
+++ b/apps/timeline-gstudio001/lib/compile-timeline-manifest.ts
@@ -1,3 +1,4 @@
+import { renderFormatOf, type RenderFormat } from "@storyboard/timeline-model/render-format";
 import "server-only";
 
 import { compilePlaybackManifest, type PlaybackManifest } from "@storyboard/timeline-domain";
@@ -27,7 +28,14 @@ import { loadTimelineClosure } from "./load-timeline-closure";
 export async function compileTimelineManifest(
   timelineId: string,
   uid: string,
-): Promise<Readonly<{ manifest: PlaybackManifest; missing: readonly string[] }> | null> {
+): Promise<Readonly<{
+  manifest: PlaybackManifest;
+  missing: readonly string[];
+  /** The project's own output shape, when it has set one. Returned here
+   *  because both render entry points already call this and would otherwise
+   *  re-read the root document just to learn the size. */
+  renderFormat?: RenderFormat;
+}> | null> {
   const entry = await readStoredTimelineEntry(timelineId, uid);
   if (!entry) return null;
 
@@ -46,5 +54,8 @@ export async function compileTimelineManifest(
     new Date().toISOString(),
     revisions,
   );
-  return { manifest, missing };
+  // Defended, not trusted — a stored format that is not a usable one falls
+  // back to the default rather than reaching ffmpeg.
+  const renderFormat = renderFormatOf(documents[timelineId]?.renderFormat);
+  return { manifest, missing, ...(renderFormat === undefined ? {} : { renderFormat }) };
 }

--- a/apps/timeline-gstudio001/lib/default-layer-frame.test.ts
+++ b/apps/timeline-gstudio001/lib/default-layer-frame.test.ts
@@ -157,15 +157,20 @@ describe("presetForLayerFrame", () => {
   });
 
   it("collapses onto the FIRST match when a clip is too tall to move vertically", () => {
-    // A 9:16 clip at 30% of a 2.4:1 frame's width is taller than the frame, so
-    // every vertical position clamps to the same rectangle — top-right and
-    // bottom-right become the same picture. Reading order decides, and the
-    // picker lights up the top row. Not a defect: there is genuinely nowhere
-    // else for that inset to sit, and the alternative would be a picker whose
-    // buttons all do the same thing while pretending otherwise.
-    const tall = layerFrameForChoice("bottom-right", "medium", 9 / 16);
-    expect(layerFrameForChoice("top-right", "medium", 9 / 16)).toEqual(tall);
-    expect(presetForLayerFrame(tall, 9 / 16)?.position).toBe("top-right");
+    // A clip tall enough to fill the frame's height leaves no room to move
+    // vertically, so every vertical position clamps to the same rectangle and
+    // top-right and bottom-right become the same picture. Reading order
+    // decides, and the picker lights the top row. Not a defect: there is
+    // genuinely nowhere else for that inset to sit.
+    //
+    // The aspect is pinned HERE rather than borrowed from the output format,
+    // which changed under this test once already — at 16:9 a 9:16 clip no
+    // longer quite fills the height, and the case silently stopped being the
+    // one the name describes.
+    const SLIVER = 1 / 4;
+    const tall = layerFrameForChoice("bottom-right", "medium", SLIVER);
+    expect(layerFrameForChoice("top-right", "medium", SLIVER)).toEqual(tall);
+    expect(presetForLayerFrame(tall, SLIVER)?.position).toBe("top-right");
   });
 
   it("matches the default the write path stamps", () => {

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
@@ -1,4 +1,9 @@
 import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
+import {
+  renderFormatOf,
+  sameRenderFormat,
+  type RenderFormat,
+} from "@storyboard/timeline-model/render-format";
 import type { DocumentsById } from "@storyboard/timeline-domain";
 
 // The graph view's ONLY coupling to persistence: GET /api/timelines/[id]
@@ -84,6 +89,16 @@ export type GraphDocumentsGateway = Readonly<{
    * Ensures the document is loaded first, then joins the debounce window.
    */
   renameTimeline: (timelineId: string, title: string) => Promise<void>;
+  /**
+   * Set the shape this project renders at, or clear it back to the default.
+   *
+   * A DOCUMENT-level write, exactly like `renameTimeline`: it spreads the
+   * cached document and replaces one field, so the clips — and every other
+   * document field — ride through untouched. That spread is what makes adding
+   * a document field safe here at all; a write that rebuilt the document from
+   * its clips would drop this on the next save.
+   */
+  setRenderFormat: (timelineId: string, format: RenderFormat | null) => Promise<void>;
   /**
    * Insert a BRAND-NEW document into the cache (a collection minted
    * client-side, e.g. a sidebar-tool drop) with an expected revision of 0 —
@@ -874,6 +889,31 @@ export function createGraphDocumentsGateway(): GraphDocumentsGateway {
       const current = documents[timelineId];
       if (!current || current.title === title) return;
       documents = { ...documents, [timelineId]: { ...current, title } };
+      notify();
+      dirtyIds.add(timelineId);
+      scheduleFlush();
+    },
+    setRenderFormat: async (timelineId, format) => {
+      const gen = generation;
+      if (!documents[timelineId]) await ensure(timelineId);
+      if (gen !== generation) return;
+      const current = documents[timelineId];
+      if (!current) return;
+      // Defended on the way in, so a bad value cannot reach ffmpeg through the
+      // stored document — and `null` clears the field rather than storing a
+      // default, since absence IS the default everywhere in this model.
+      const next = format === null ? undefined : renderFormatOf(format);
+      if (format !== null && next === undefined) return;
+      const unchanged =
+        next === undefined
+          ? current.renderFormat === undefined
+          : current.renderFormat !== undefined && sameRenderFormat(current.renderFormat, next);
+      if (unchanged) return;
+      const { renderFormat: _dropped, ...rest } = current;
+      documents = {
+        ...documents,
+        [timelineId]: next === undefined ? rest : { ...rest, renderFormat: next },
+      };
       notify();
       dirtyIds.add(timelineId);
       scheduleFlush();

--- a/apps/timeline-gstudio001/lib/mcp/render.ts
+++ b/apps/timeline-gstudio001/lib/mcp/render.ts
@@ -49,10 +49,14 @@ export async function handleRenderTimeline(
   const compiled = await compileTimelineManifest(args.timelineId, ctx.requesterUid);
   if (!compiled) return toolError(`No timeline with id "${args.timelineId}".`);
 
+  // An explicit argument wins; then the PROJECT's stored shape; then the
+  // default. Per-argument rather than all-or-nothing so `fps` alone can be
+  // overridden without discarding the project's size.
+  const base = compiled.renderFormat ?? DEFAULT_RENDER_FORMAT;
   const format = {
-    width: args.width ?? DEFAULT_RENDER_FORMAT.width,
-    height: args.height ?? DEFAULT_RENDER_FORMAT.height,
-    fps: args.fps ?? DEFAULT_RENDER_FORMAT.fps,
+    width: args.width ?? base.width,
+    height: args.height ?? base.height,
+    fps: args.fps ?? base.fps,
   };
   const cutList = compileCutList(compiled.manifest, format);
   if (cutList.cuts.length === 0) {

--- a/apps/timeline-gstudio001/lib/render/cut-list.test.ts
+++ b/apps/timeline-gstudio001/lib/render/cut-list.test.ts
@@ -158,10 +158,14 @@ describe("compileCutList", () => {
     expect(list.cuts.map((cut) => cut.src)).toEqual(["https://cdn.test/a.mp4"]);
   });
 
-  it("defaults to the format the cuts use today, and takes an override", () => {
+  it("defaults to 16:9, and takes an override", () => {
+    // The default is a DELIVERABLE decision, not a description of the sources
+    // — this project's material is mostly ~2.35:1 — and a project that wants
+    // something else stores its own (`TimelineDocument.renderFormat`).
     const manifest = manifestOf(packed([{ id: "a" }]));
     expect(compileCutList(manifest).format).toEqual(DEFAULT_RENDER_FORMAT);
-    expect(DEFAULT_RENDER_FORMAT).toEqual({ width: 1152, height: 480, fps: 24 });
+    expect(DEFAULT_RENDER_FORMAT).toEqual({ width: 1280, height: 720, fps: 24 });
+    expect(DEFAULT_RENDER_FORMAT.width / DEFAULT_RENDER_FORMAT.height).toBeCloseTo(16 / 9, 6);
 
     const square = compileCutList(manifest, { width: 1080, height: 1080, fps: 30 });
     expect(square.format).toEqual({ width: 1080, height: 1080, fps: 30 });

--- a/apps/timeline-gstudio001/lib/render/cut-list.ts
+++ b/apps/timeline-gstudio001/lib/render/cut-list.ts
@@ -9,19 +9,14 @@
 
 import type { PlaybackLeaf, PlaybackManifest } from "@storyboard/timeline-domain";
 
+import { DEFAULT_RENDER_FORMAT } from "@storyboard/timeline-model/render-format";
+
 import type { RenderCut, RenderCutList, RenderFormat } from "./types";
 
-/**
- * What the 35s cuts use today, and the default until export grows a settings
- * surface. Deliberately a constant with a name rather than a literal at the
- * call site: the first thing anyone will want to change is the size, and the
- * second is to know what it was when a given file was made.
- */
-export const DEFAULT_RENDER_FORMAT: RenderFormat = {
-  width: 1152,
-  height: 480,
-  fps: 24,
-};
+// The default lives with the stored model now, because a project can override
+// it — see `TimelineDocument.renderFormat`. Re-exported here so the many
+// existing importers of `DEFAULT_RENDER_FORMAT` keep working.
+export { DEFAULT_RENDER_FORMAT };
 
 /** Below this, a cut cannot survive rounding to a frame boundary and is more
  *  likely a packing artefact than an intended shot. */

--- a/apps/timeline-gstudio001/lib/render/types.ts
+++ b/apps/timeline-gstudio001/lib/render/types.ts
@@ -72,11 +72,13 @@ export type RenderCut = Readonly<{
 /** Output format. Fixed per job rather than per cut: the worker normalises
  *  every source to this before concatenating, because ffmpeg's concat
  *  demuxer requires identical parameters and produces garbage without it. */
-export type RenderFormat = Readonly<{
-  width: number;
-  height: number;
-  fps: number;
-}>;
+// Re-exported from the MODEL, not declared here: a project stores the format
+// it renders at, so the shape belongs with the stored document. Two
+// declarations of "how big is the output" is how a preview and a render come
+// to disagree.
+import type { RenderFormat } from "@storyboard/timeline-model/render-format";
+
+export type { RenderFormat };
 
 /**
  * The finished cut list — everything a renderer needs and nothing about how it

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -34,7 +34,14 @@ const PIXEL =
 // ── Fixture documents ───────────────────────────────────────────────────────
 
 type FixtureClip = Record<string, unknown> & { id: string };
-type FixtureDocument = { id: string; title: string; clips: FixtureClip[] };
+type FixtureDocument = {
+  id: string;
+  title: string;
+  clips: FixtureClip[];
+  /** The project's own output shape. Absent until something sets it, which is
+   *  what every fixture starts as. */
+  renderFormat?: { width: number; height: number; fps: number };
+};
 
 function mediaClip(
   id: string,
@@ -8406,4 +8413,28 @@ test.describe("graph view E2E", () => {
       await expect(canvas).toHaveAttribute("aria-label", "alpha preview", { timeout: 700 });
     }).toPass({ timeout: 10000 });
   });
+
+  // THE RENDER FORMAT. A project's own output shape, stored on its document —
+  // the first render setting in the app, and the first render UI of any kind
+  // (renders still start from the MCP tools; this board only reports on them).
+  test("the render format is shown, changeable, and PERSISTS", async ({ page }) => {
+    const api = await installGraphApi(page);
+    await openGraph(page);
+
+    const control = page.locator("[data-render-format]");
+    // A project that has never chosen still says what it will export as.
+    await expect(control).toHaveAttribute("data-render-format", "1280x720");
+    await expect(control).toContainText("16:9");
+
+    await control.click();
+    await page.locator('[data-render-format-option="scope"]').click();
+    await expect(control).toHaveAttribute("data-render-format", "1152x480");
+
+    // And it REACHES THE DOCUMENT, which is the half that matters — the
+    // control could show anything; the render reads the stored value.
+    await expect
+      .poll(() => api.documents.get(PROJECT_ID)?.renderFormat ?? null)
+      .toEqual({ width: 1152, height: 480, fps: 24 });
+  });
+
 });

--- a/packages/timeline-model/index.ts
+++ b/packages/timeline-model/index.ts
@@ -4,5 +4,6 @@ export * from "./constants";
 export * from "./documents";
 export * from "./placement";
 export * from "./layer-frame";
+export * from "./render-format";
 export * from "./validate";
 export * from "./clip-display";

--- a/packages/timeline-model/render-format.test.ts
+++ b/packages/timeline-model/render-format.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_RENDER_FORMAT,
+  RENDER_FORMAT_PRESETS,
+  renderFormatOf,
+  renderFormatPresetOf,
+  sameRenderFormat,
+} from "./render-format";
+
+describe("DEFAULT_RENDER_FORMAT", () => {
+  it("is 16:9", () => {
+    // A DELIVERABLE decision, not a description of the sources — this
+    // project's material is mostly ~2.35:1. A project that wants something
+    // else stores its own.
+    expect(DEFAULT_RENDER_FORMAT.width / DEFAULT_RENDER_FORMAT.height).toBeCloseTo(16 / 9, 6);
+  });
+
+  it("is even in both dimensions, or nothing renders", () => {
+    // libx264 refuses an odd width or height in yuv420p outright.
+    expect(DEFAULT_RENDER_FORMAT.width % 2).toBe(0);
+    expect(DEFAULT_RENDER_FORMAT.height % 2).toBe(0);
+  });
+
+  it("is one of the presets, so the board can name it", () => {
+    expect(renderFormatPresetOf(DEFAULT_RENDER_FORMAT)).toBeDefined();
+  });
+});
+
+describe("RENDER_FORMAT_PRESETS", () => {
+  it("are all even-dimensioned and encodable", () => {
+    for (const preset of RENDER_FORMAT_PRESETS) {
+      expect(renderFormatOf(preset.format)).toEqual(preset.format);
+    }
+  });
+
+  it("keeps the SCOPE size this project's shots come out at", () => {
+    // 1152x480 is the verified MiniMax H3 output size, and what every render
+    // before the setting existed used. Losing it would strand that material.
+    expect(RENDER_FORMAT_PRESETS.map((p) => `${p.format.width}x${p.format.height}`)).toContain(
+      "1152x480",
+    );
+  });
+
+  it("has distinct ids", () => {
+    const ids = RENDER_FORMAT_PRESETS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe("renderFormatOf", () => {
+  it("takes a real format", () => {
+    expect(renderFormatOf({ width: 1280, height: 720, fps: 24 })).toEqual({
+      width: 1280,
+      height: 720,
+      fps: 24,
+    });
+  });
+
+  it("REFUSES AN ODD DIMENSION, which cannot be encoded", () => {
+    // Storing one would produce a project that simply fails to render, and
+    // the failure would surface as an opaque ffmpeg error minutes later.
+    expect(renderFormatOf({ width: 1281, height: 720, fps: 24 })).toBeUndefined();
+    expect(renderFormatOf({ width: 1280, height: 721, fps: 24 })).toBeUndefined();
+  });
+
+  it("drops anything that is not a usable format", () => {
+    for (const bad of [
+      undefined,
+      null,
+      "1280x720",
+      { width: 1280, height: 720 },
+      { width: 0, height: 720, fps: 24 },
+      { width: -1280, height: 720, fps: 24 },
+      { width: 1280.5, height: 720, fps: 24 },
+      { width: Number.NaN, height: 720, fps: 24 },
+      { width: 1280, height: 720, fps: 0 },
+      { width: 1280, height: 720, fps: 1000 },
+      { width: 99999, height: 720, fps: 24 },
+    ]) {
+      expect(renderFormatOf(bad)).toBeUndefined();
+    }
+  });
+
+  it("keeps only the three fields", () => {
+    expect(renderFormatOf({ width: 1280, height: 720, fps: 24, bitrate: 9000 })).toEqual({
+      width: 1280,
+      height: 720,
+      fps: 24,
+    });
+  });
+
+  it("allows an ODD fps — 25 and 30 are ordinary", () => {
+    expect(renderFormatOf({ width: 1280, height: 720, fps: 25 })?.fps).toBe(25);
+  });
+});
+
+describe("sameRenderFormat", () => {
+  it("compares by value", () => {
+    const a = { width: 1280, height: 720, fps: 24 };
+    expect(sameRenderFormat(a, { ...a })).toBe(true);
+    expect(sameRenderFormat(a, { ...a, fps: 30 })).toBe(false);
+  });
+});

--- a/packages/timeline-model/render-format.ts
+++ b/packages/timeline-model/render-format.ts
@@ -1,0 +1,80 @@
+// THE SHAPE OF THE FINISHED FILE.
+//
+// Here rather than in the app's render code because it is STORED now: a
+// project carries the format it exports at, so the choice survives a reload
+// and every render of that project agrees. The app's `lib/render/types.ts`
+// aliases this rather than declaring a second one — two shapes for "how big is
+// the output" is exactly how a preview and a render come to disagree.
+
+export type RenderFormat = Readonly<{
+  width: number;
+  height: number;
+  fps: number;
+}>;
+
+/**
+ * What a project renders at when it has not said otherwise.
+ *
+ * 16:9, which is a DELIVERABLE decision rather than a description of the
+ * sources. Worth writing down because the sources argue the other way: the
+ * reference film is 2.379:1, the assembled 35s cut 2.333:1, and the verified
+ * MiniMax H3 output size is 1152x480, which is 2.4:1 exactly — so a 2.4:1
+ * render is what fills the frame with no bars today.
+ *
+ * 16:9 is the default anyway because it is what the finished thing is FOR, and
+ * because the per-project setting is the answer to "but this project isn't".
+ * Anything scope-shaped letterboxes into it, which is the ordinary cost of
+ * delivering scope content to a 16:9 target.
+ */
+export const DEFAULT_RENDER_FORMAT: RenderFormat = {
+  width: 1280,
+  height: 720,
+  fps: 24,
+};
+
+/** The named formats the board offers. Free values are still legal — the MCP
+ *  render tool takes any width/height/fps — these are just the ones worth one
+ *  click. */
+export const RENDER_FORMAT_PRESETS: readonly Readonly<{
+  id: string;
+  label: string;
+  ratio: string;
+  format: RenderFormat;
+}>[] = [
+  { id: "hd", label: "720p", ratio: "16:9", format: { width: 1280, height: 720, fps: 24 } },
+  { id: "fhd", label: "1080p", ratio: "16:9", format: { width: 1920, height: 1080, fps: 24 } },
+  // The size this project's generated shots actually come out at, and what
+  // every render before this used.
+  { id: "scope", label: "Scope", ratio: "2.4:1", format: { width: 1152, height: 480, fps: 24 } },
+  { id: "vertical", label: "Vertical", ratio: "9:16", format: { width: 720, height: 1280, fps: 24 } },
+];
+
+/**
+ * A stored format defended rather than trusted.
+ *
+ * HONOURED, not derived — whatever is here decides the size of the file — so
+ * anything that is not a usable format has to fall back to the default rather
+ * than reach ffmpeg. An odd dimension is rejected along with the nonsense
+ * ones: libx264 refuses odd width or height in yuv420p outright, so storing
+ * one would produce a project that simply cannot render.
+ */
+export function renderFormatOf(value: unknown): RenderFormat | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const { width, height, fps } = value as Record<string, unknown>;
+  const usable = (n: unknown, min: number, max: number, even: boolean): n is number =>
+    typeof n === "number" && Number.isInteger(n) && n >= min && n <= max && (!even || n % 2 === 0);
+  if (!usable(width, 2, 7680, true)) return undefined;
+  if (!usable(height, 2, 4320, true)) return undefined;
+  if (!usable(fps, 1, 120, false)) return undefined;
+  return { width, height, fps };
+}
+
+export function sameRenderFormat(a: RenderFormat, b: RenderFormat): boolean {
+  return a.width === b.width && a.height === b.height && a.fps === b.fps;
+}
+
+/** The preset a stored format came from, or undefined for a custom one — the
+ *  board names what it can and shows the numbers otherwise. */
+export function renderFormatPresetOf(format: RenderFormat) {
+  return RENDER_FORMAT_PRESETS.find((preset) => sameRenderFormat(preset.format, format));
+}

--- a/packages/timeline-model/types.ts
+++ b/packages/timeline-model/types.ts
@@ -8,6 +8,7 @@
 // through view state in the legacy pipeline.
 
 import type { LayerFrame } from "./layer-frame";
+import type { RenderFormat } from "./render-format";
 
 export type MediaKind = "image" | "video";
 export type CollectionEndpoint = "first" | "last";
@@ -264,4 +265,18 @@ export type TimelineDocument = {
   title: string;
   description?: string;
   clips: TimelineClip[];
+  /**
+   * The shape this project exports at.
+   *
+   * ABSENT MEANS THE DEFAULT (`DEFAULT_RENDER_FORMAT`, 16:9 720p), so no
+   * stored project needs migrating and one that never touches the setting
+   * never grows the field — the same rule `placedStart`, `disabled` and
+   * `layerFrame` follow.
+   *
+   * On the DOCUMENT rather than a user preference because it describes the
+   * deliverable, not the person: two projects can legitimately want different
+   * shapes, and a render started by an agent must produce the same file as one
+   * started from the board.
+   */
+  renderFormat?: RenderFormat;
 };

--- a/packages/timeline-model/validate.ts
+++ b/packages/timeline-model/validate.ts
@@ -8,6 +8,7 @@
 // numeric must be a finite number (NaN/Infinity poison packing).
 
 import { layerFrameOf } from "./layer-frame";
+import { renderFormatOf } from "./render-format";
 import { areTagsValid } from "./tags";
 import type { TimelineClip, TimelineDocument } from "./types";
 
@@ -210,6 +211,13 @@ export function isStoredTimelineDocument(value: unknown): value is TimelineDocum
     document.id.length > 0 &&
     typeof document.title === "string" &&
     isOptionalString(document.description) &&
+    // Absent, or a format `renderFormatOf` recognises. Delegated for the same
+    // reason `layerFrame` is: the WRITE gate and the READ normalizer must not
+    // drift apart, or a format that saved and then vanished would look like
+    // the setting simply not working.
+    (document.renderFormat === undefined ||
+      document.renderFormat === null ||
+      renderFormatOf(document.renderFormat) !== undefined) &&
     Array.isArray(document.clips) &&
     document.clips.every(isTimelineClip)
   );


### PR DESCRIPTION
The default output was 1152×480 (2.4:1). It's **1280×720** now, and a project can store its own shape — set from the board, honoured by every render of that project. Closes #412.

## The default is a deliverable decision, not a description of the sources

Worth stating because the sources argue the other way. Measured from the actual files rather than the stored metadata:

| clip | real size | aspect |
| --- | --- | --- |
| reference film | 2864×1204 | 2.379 |
| assembled 35s cut | 896×384 | 2.333 |
| Comfy Cloud render | 1152×480 | **2.400 exactly** |
| S01 Pat briefing | 832×480 | 1.733 |

The `aspect: 1.7777` on every clip is **a default nobody measured**. It's what led me to report "every source is 16:9" in #412, which isn't true.

So scope material letterboxes into the new default. That's the ordinary cost of delivering scope content to a 16:9 target, and the setting is the answer for a project that doesn't want to pay it. **The Scope preset keeps 1152×480 exactly** — it's the verified MiniMax H3 output size, and losing it would strand that material.

## Stored on the document

Not on a user, not per render. Two projects can want different shapes, and a render an agent starts must produce the same file as one started from the board. Absent means the default, so nothing needs migrating.

Safe to add because `writeClips` **spreads** the cached document and replaces only `clips` — a write that rebuilt the document from its clips would drop this on the next save, which is the trap `layerFrame` hit twice.

Precedence: an explicit `render_timeline` argument wins, then the project's stored shape, then the default — per field, so `fps` alone can be overridden without discarding the project's size.

## Three consequences fixed at the cause, not re-baselined

- **`renderFormatOf` refuses an odd dimension.** libx264 won't encode odd width or height in yuv420p, so storing one would produce a project that simply cannot render — surfacing minutes later as an opaque ffmpeg error.
- **The layer-frame stories hardcoded `{ x: 0.665, y: 0.511 }`** — the rectangle the default inset produced at 2.4:1. It silently stopped being the default the moment the format changed, so *"shows the current preset"* showed none. Derived from the resolver now. The too-tall-to-move test had the same shape: it pinned a 9:16 clip, which no longer fills the height at 16:9, so the case quietly stopped being the one its name describes.
- **The control's optimistic state was a lint error and unnecessary.** `setRenderFormat` updates the gateway cache and notifies synchronously, so the readout already follows on the same tick; only the network flush is debounced.

## Verified

- app + UI `tsc` clean; lint clean (same 5 pre-existing `<img>` warnings)
- **1135** app tests
- **737** shared unit tests (+12)
- **235** story interaction tests (+4)
- **174** graph-view e2e (+1) — a clean run

And a **real render at the new default**: 1280×720 out, a 16:9 source filling it exactly with no bars, and the default inset landing at x 844..1228 inside a 1280 frame — **0px overhang**, orange at every sample across it including the right edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
