### PR TITLE
Measure a clip's aspect instead of assuming 16:9

### DIFF
--- a/apps/timeline-gstudio001/.gitignore
+++ b/apps/timeline-gstudio001/.gitignore
@@ -15,3 +15,7 @@ mcp-app/dist/
 # Written by `npm run audit:orphans` so --offline can re-answer questions
 # without re-reading the collection. Local cache; never committed.
 .orphan-snapshot.json
+
+# Written by `npm run correct:aspects` — one ffprobe reading per source URL, so
+# a re-run does not hit the media host again. Local cache; never committed.
+.aspect-probe-cache.json

--- a/apps/timeline-gstudio001/app/api/timeline-media/upload/route.ts
+++ b/apps/timeline-gstudio001/app/api/timeline-media/upload/route.ts
@@ -244,6 +244,10 @@ export async function POST(request: Request) {
       url: storedMedia.url,
       thumbnailPathname,
       thumbnailUrl,
+      // The source's real pixel size, so the client can mint a clip's `aspect`
+      // from it rather than assuming 16:9. Absent for audio.
+      width: storedMedia.width,
+      height: storedMedia.height,
     });
   } catch (error) {
     if (error instanceof ProjectAssetScopeError) {

--- a/apps/timeline-gstudio001/components/graph-view/graph-native-drop-engine.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-native-drop-engine.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { aspectFromDimensions } from "@storyboard/timeline-model/documents";
 import {
   createContext,
   useCallback,
@@ -247,7 +248,7 @@ export function useNativeDrop(collectionId: string, projectId: string) {
                 node,
                 detail: {
                   alt: file.name,
-                  aspect: 16 / 9,
+                  aspect: aspectFromDimensions(hosted.width, hosted.height) ?? 16 / 9,
                   poster: hosted.thumbnailUrl,
                   ...(sourceAsset === undefined ? {} : { sourceAsset }),
                 },
@@ -266,7 +267,7 @@ export function useNativeDrop(collectionId: string, projectId: string) {
               node,
               detail: {
                 alt: file.name,
-                aspect: 16 / 9,
+                aspect: aspectFromDimensions(hosted.width, hosted.height) ?? 16 / 9,
                 sourceDuration: IMAGE_CLIP_SECONDS,
                 trimIn: 0,
                 trimOut: 0,

--- a/apps/timeline-gstudio001/lib/aspect-correction.test.ts
+++ b/apps/timeline-gstudio001/lib/aspect-correction.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it } from "vitest";
+
+// The corrector runs as a standalone script, so its decisions are a .mjs
+// module — but they decide what gets WRITTEN to the user's real documents, so
+// they are covered by the app suite rather than only by reading the dry run.
+// Same arrangement as lib/render/ffmpeg-plan.test.ts over the render worker.
+import {
+  aspectOf,
+  classify,
+  correctableClips,
+  scopeFrom,
+  updateForDocument,
+} from "../scripts/aspect-correction.mjs";
+
+const SIXTEEN_NINE = 16 / 9;
+
+const clip = (over: Record<string, unknown> = {}) => ({
+  id: "c1",
+  kind: "video",
+  src: "https://cdn.test/a.mp4",
+  aspect: SIXTEEN_NINE,
+  ...over,
+});
+
+/** A stored record in the shape `buildSavePayload` writes: the live document
+ *  and the denormalized copy of its clips. */
+const record = (clips: Record<string, unknown>[], over: Record<string, unknown> = {}) => ({
+  title: "A",
+  revision: 3,
+  document: { id: "d1", title: "A", clips },
+  clips,
+  ...over,
+});
+
+describe("aspectOf", () => {
+  // The four real sources in this project, all of which stored 1.778 and none
+  // of which is 16:9. This is the measurement that made #417 worth doing — the
+  // claim "every source here is 16:9" came from the stored default, not the
+  // files.
+  it.each([
+    [2864, 1204, 2.379],
+    [896, 384, 2.333],
+    [1152, 480, 2.4],
+    [832, 480, 1.733],
+  ])("measures %ix%i as %f, not 16:9", (width, height, expected) => {
+    expect(aspectOf(width, height)).toBeCloseTo(expected, 3);
+    expect(aspectOf(width, height)).not.toBeCloseTo(SIXTEEN_NINE, 3);
+  });
+
+  // Declining is the whole point: `aspect` is a DIVISOR, so a zero or a NaN
+  // reaching storage is an infinity in layout math later.
+  it.each([
+    [0, 100],
+    [100, 0],
+    [-16, 9],
+    [Number.NaN, 9],
+    [Number.POSITIVE_INFINITY, 9],
+  ])("declines %s x %s rather than inventing a ratio", (width, height) => {
+    expect(aspectOf(width, height)).toBeUndefined();
+  });
+
+  it("declines a non-number, which is what a provider omitting the field sends", () => {
+    expect(aspectOf(undefined, 9)).toBeUndefined();
+    expect(aspectOf("1920", "1080")).toBeUndefined();
+  });
+});
+
+describe("scopeFrom", () => {
+  const documents = new Map<string, unknown>([
+    ["p", record([{ kind: "collection", childTimelineId: "a" }])],
+    ["a", record([{ kind: "collection", childTimelineId: "b" }, clip()])],
+    ["b", record([clip()])],
+    ["elsewhere", record([clip()])],
+  ]);
+
+  it("takes the whole subtree and nothing beside it", () => {
+    expect(scopeFrom(documents, "p")).toEqual(new Set(["p", "a", "b"]));
+  });
+
+  it("returns null for an id that is not there, rather than an empty scope", () => {
+    // An empty scope would print the same reassuring "nothing to do" as a
+    // clean project, so a typo'd id has to be distinguishable.
+    expect(scopeFrom(documents, "typo")).toBeNull();
+  });
+
+  it("terminates on a cycle", () => {
+    const cyclic = new Map<string, unknown>([
+      ["x", record([{ kind: "collection", childTimelineId: "y" }])],
+      ["y", record([{ kind: "collection", childTimelineId: "x" }])],
+    ]);
+    expect(scopeFrom(cyclic, "x")).toEqual(new Set(["x", "y"]));
+  });
+});
+
+describe("correctableClips", () => {
+  it("skips collections — a container has no source file to measure", () => {
+    const documents = new Map<string, unknown>([
+      [
+        "d",
+        record([
+          { kind: "collection", childTimelineId: "c", id: "col", aspect: SIXTEEN_NINE },
+          clip({ id: "v" }),
+        ]),
+      ],
+    ]);
+    expect(correctableClips(documents).map((found) => found.clipId)).toEqual(["v"]);
+  });
+
+  it("skips a clip with no src, which there is no way to probe", () => {
+    const documents = new Map<string, unknown>([["d", record([clip({ id: "v", src: "" })])]]);
+    expect(correctableClips(documents)).toEqual([]);
+  });
+
+  it("keeps the INDEX from the array it read, which is what the write addresses", () => {
+    const documents = new Map<string, unknown>([
+      ["d", record([clip({ id: "a" }), clip({ id: "b" }), clip({ id: "c" })])],
+    ]);
+    expect(correctableClips(documents).map((found) => [found.clipId, found.index])).toEqual([
+      ["a", 0],
+      ["b", 1],
+      ["c", 2],
+    ]);
+  });
+
+  it("tells a clip storing no aspect apart from one storing a wrong one", () => {
+    // A snapshot taken before the field was carried has no `aspect` KEY.
+    // Reporting those as "wrong" would print every clip in the collection.
+    const documents = new Map<string, unknown>([
+      ["d", record([clip({ id: "has" }), { id: "none", kind: "video", src: "https://cdn.test/b.mp4" }])],
+    ]);
+    const found = correctableClips(documents);
+    expect(found[0].stored).toBe(SIXTEEN_NINE);
+    expect(found[1].stored).toBeUndefined();
+  });
+
+  it("reads a record that carries only the denormalized copy", () => {
+    const documents = new Map<string, unknown>([
+      ["d", { title: "legacy", clips: [clip({ id: "v" })] }],
+    ]);
+    expect(correctableClips(documents).map((found) => found.clipId)).toEqual(["v"]);
+  });
+});
+
+describe("classify", () => {
+  const measurements = new Map([
+    ["https://cdn.test/scope.mp4", { width: 1152, height: 480, aspect: 2.4 }],
+  ]);
+  const found = (over: Record<string, unknown>) => ({
+    documentId: "d",
+    title: "A",
+    index: 0,
+    clipId: "c",
+    alt: "",
+    src: "https://cdn.test/scope.mp4",
+    ...over,
+  });
+
+  it("calls a 16:9 default over a 2.4:1 source wrong", () => {
+    const { wrong } = classify([found({ stored: SIXTEEN_NINE })], measurements);
+    expect(wrong).toHaveLength(1);
+    expect(wrong[0].measured.aspect).toBe(2.4);
+  });
+
+  it("leaves an already-correct clip alone", () => {
+    const { wrong, alreadyRight } = classify([found({ stored: 2.4 })], measurements);
+    expect(wrong).toHaveLength(0);
+    expect(alreadyRight).toHaveLength(1);
+  });
+
+  it("does not call float noise a difference", () => {
+    // 1920x1080 and 1280x720 are the same shape, and a stored ratio that came
+    // from a divide will not land bit-identical on one that came from another.
+    const { alreadyRight } = classify([found({ stored: 2.4000001 })], measurements);
+    expect(alreadyRight).toHaveLength(1);
+  });
+
+  it("counts an unprobed source as unreadable rather than wrong", () => {
+    // Audio, a 404, a timeout. Leaving a clip alone is always safe; writing a
+    // number nothing measured is what this exists to undo.
+    const { wrong, unreadable } = classify(
+      [found({ stored: SIXTEEN_NINE, src: "https://cdn.test/vo.mp3" })],
+      measurements,
+    );
+    expect(wrong).toHaveLength(0);
+    expect(unreadable).toHaveLength(1);
+  });
+
+  it("corrects a clip that stores no aspect at all", () => {
+    const { wrong } = classify([found({ stored: undefined })], measurements);
+    expect(wrong).toHaveLength(1);
+  });
+});
+
+/**
+ * Narrow a value the .mjs module returns as nullable, failing the test if it
+ * really is absent.
+ *
+ * `updateForDocument` genuinely returns `null` when nothing is safe to write,
+ * and its keys are genuinely optional — the tests below have each just
+ * asserted which case they are in, but TypeScript cannot see an `expect`. This
+ * carries that knowledge across without reaching for a cast.
+ */
+function present<T>(value: T | null | undefined): T {
+  if (value === null || value === undefined) throw new Error("expected a value, got none");
+  return value;
+}
+
+describe("updateForDocument", () => {
+  const target = (over: Record<string, unknown> = {}) => ({
+    documentId: "d",
+    title: "A",
+    index: 1,
+    clipId: "b",
+    alt: "",
+    src: "https://cdn.test/a.mp4",
+    stored: SIXTEEN_NINE,
+    measured: { width: 1152, height: 480, aspect: 2.4 },
+    ...over,
+  });
+
+  it("nests under `document`, because a dotted key in a merge is NOT a path", () => {
+    // `set({"document.clips": …}, {merge: true})` writes a top-level field
+    // whose NAME contains a dot and leaves the real clips untouched — only
+    // `update()` walks a dotted path. It would look like it worked.
+    const { update } = updateForDocument(record([clip({ id: "a" }), clip({ id: "b" })]), [target()]);
+    expect(Object.keys(present(update))).toEqual(["document", "clips"]);
+    expect(present(update)).not.toHaveProperty(["document.clips"]);
+    expect(present(present(update).document).clips[1].aspect).toBe(2.4);
+  });
+
+  it("writes BOTH copies, so no reader can find them disagreeing", () => {
+    const { update, applied } = updateForDocument(record([clip({ id: "a" }), clip({ id: "b" })]), [
+      target(),
+    ]);
+    expect(present(present(update).document).clips[1].aspect).toBe(2.4);
+    expect(present(present(update).clips)[1].aspect).toBe(2.4);
+    expect(applied).toBe(1);
+  });
+
+  it("changes only the aspect, leaving the rest of the clip as it was", () => {
+    const original = clip({ id: "b", trimIn: 1.5, tags: ["keeper"], trackIndex: 2 });
+    const { update } = updateForDocument(record([clip({ id: "a" }), original]), [target()]);
+    expect(present(present(update).clips)[1]).toEqual({ ...original, aspect: 2.4 });
+    expect(present(present(update).clips)[0]).toEqual(clip({ id: "a" }));
+  });
+
+  it("REFUSES a clip whose index now names something else", () => {
+    // The document was re-ordered between the read and the write. Writing a
+    // measured aspect onto whatever now sits at that index would corrupt the
+    // very field this came to repair.
+    const { update, skipped, applied } = updateForDocument(
+      record([clip({ id: "a" }), clip({ id: "somethingElse" })]),
+      [target()],
+    );
+    expect(update).toBeNull();
+    expect(skipped).toHaveLength(1);
+    expect(applied).toBe(0);
+  });
+
+  it("writes the clips that still match while refusing the one that does not", () => {
+    const { update, skipped, applied } = updateForDocument(
+      record([clip({ id: "a" }), clip({ id: "b" }), clip({ id: "moved" })]),
+      [target(), target({ index: 2, clipId: "c" })],
+    );
+    expect(present(present(update).clips)[1].aspect).toBe(2.4);
+    expect(present(present(update).clips)[2].aspect).toBe(SIXTEEN_NINE);
+    expect(skipped).toHaveLength(1);
+    expect(applied).toBe(1);
+  });
+
+  it("leaves a drifted denormalized copy alone rather than scrambling it", () => {
+    const live = [clip({ id: "a" }), clip({ id: "b" })];
+    const drifted = [clip({ id: "b" })];
+    const { update } = updateForDocument({ document: { clips: live }, clips: drifted }, [target()]);
+    expect(present(present(update).document).clips[1].aspect).toBe(2.4);
+    expect(present(update)).not.toHaveProperty("clips");
+  });
+
+  it("writes a record that carries only the denormalized copy", () => {
+    const { update } = updateForDocument({ clips: [clip({ id: "a" }), clip({ id: "b" })] }, [
+      target(),
+    ]);
+    expect(present(update)).not.toHaveProperty("document");
+    expect(present(present(update).clips)[1].aspect).toBe(2.4);
+  });
+
+  it("never mutates the record it was given", () => {
+    // The caller holds these documents for the whole run and reports from
+    // them; a write that edited them in place would make the summary describe
+    // a state that was never stored if a later batch failed.
+    const stored = record([clip({ id: "a" }), clip({ id: "b" })]);
+    updateForDocument(stored, [target()]);
+    expect(present(stored.document.clips[1]).aspect).toBe(SIXTEEN_NINE);
+    expect(present(stored.clips[1]).aspect).toBe(SIXTEEN_NINE);
+  });
+});

--- a/apps/timeline-gstudio001/lib/cloudinary-media-store.ts
+++ b/apps/timeline-gstudio001/lib/cloudinary-media-store.ts
@@ -13,6 +13,10 @@ export type CloudinaryMediaUpload = {
   thumbnailUrl?: string;
   contentType?: string;
   size?: number;
+  /** The source's real pixel size, for minting a clip's `aspect`. Absent for
+   *  audio. Dropped here until now, which is why every clip claimed 16:9. */
+  width?: number;
+  height?: number;
 };
 
 export class CloudinaryUploadError extends Error {
@@ -58,6 +62,10 @@ type CloudinaryUploadResponse = {
   public_id: string;
   resource_type: "image" | "video" | "raw";
   secure_url: string;
+  /** Returned on every image and video upload. Absent for audio, which has no
+   *  dimensions — and for a chunked upload's non-final chunk. */
+  width?: number;
+  height?: number;
 };
 
 type CloudinaryUploadApiResponse = Partial<CloudinaryUploadResponse> & {
@@ -548,6 +556,12 @@ export async function uploadCloudinaryMedia(
     thumbnailUrl,
     contentType,
     size: body.bytes ?? data.byteLength,
+    // The source's REAL pixel size, which Cloudinary returns on every upload
+    // and this dropped on the floor. Without it the caller has nothing to mint
+    // a clip's `aspect` from and defaults to 16:9 — which is how every clip in
+    // every project came to claim a shape it did not have.
+    width: body.width,
+    height: body.height,
   };
 }
 

--- a/apps/timeline-gstudio001/lib/firebase-media-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-media-store.ts
@@ -10,6 +10,11 @@ export type StoredMedia = {
   bucketName?: string;
   contentType?: string;
   size?: number;
+  /** The source's real pixel size, when the store reports it — Cloudinary does
+   *  for images and video, and there is nothing to report for audio. Used to
+   *  mint a clip's `aspect`; absent means the caller keeps its default. */
+  width?: number;
+  height?: number;
 };
 
 const ALLOWED_MEDIA_PREFIXES = [

--- a/apps/timeline-gstudio001/lib/mcp/upload.ts
+++ b/apps/timeline-gstudio001/lib/mcp/upload.ts
@@ -1,3 +1,4 @@
+import { aspectFromDimensions } from "@storyboard/timeline-model/documents";
 import { randomUUID } from "node:crypto";
 
 import { parseNodeId, type CollectionsGraph, type NodeId } from "@storyboard/collections-core";
@@ -223,7 +224,11 @@ export async function attachMedia(
       // It matters most for AUDIO: an audio card has no thumbnail, so the title
       // is the only thing distinguishing one take from another.
       ...(item.name?.trim() ? { title: item.name.trim() } : {}),
-      aspect: 16 / 9,
+      // MEASURED, not assumed. The listing has carried `width`/`height` all
+      // along; this asked for neither and stamped 16:9 on everything.
+      // Audio has no dimensions, so it keeps the default — nothing reads a
+      // sound's aspect, and a card still needs a box.
+      aspect: aspectFromDimensions(asset.width, asset.height) ?? 16 / 9,
       trackIndex: 0,
       sourceAsset: { providerId: CLOUDINARY_PROVIDER_ID, assetId: asset.pathname },
       // Tagged at mint time so agent-uploaded media arrives filed. This is the

--- a/apps/timeline-gstudio001/lib/timeline-media-client.test.ts
+++ b/apps/timeline-gstudio001/lib/timeline-media-client.test.ts
@@ -45,6 +45,45 @@ describe("uploadTimelineMedia", () => {
     });
   });
 
+  // 2864x1204 is a real source in this project — 2.379:1, not the 16:9 every
+  // clip used to claim. A .png name to stay off the local video-probe branch,
+  // which the block below covers; the parse is the same either way.
+  it("keeps the source DIMENSIONS, which a clip's aspect is minted from", async () => {
+    stubUpload(
+      response({ pathname: "m/a.png", url: "https://cdn.test/a.png", width: 2864, height: 1204 }),
+    );
+    await expect(uploadTimelineMedia("a.png", png(), "project-a")).resolves.toEqual({
+      pathname: "m/a.png",
+      url: "https://cdn.test/a.png",
+      width: 2864,
+      height: 1204,
+    });
+  });
+
+  it("DROPS a malformed dimension rather than failing the upload", async () => {
+    // Unlike the strings above, which reject the whole payload — a bad
+    // thumbnail url is a server bug worth surfacing, but a bad width only
+    // means the clip keeps its default shape, and losing the file over a
+    // cosmetic field would be the worse trade.
+    stubUpload(
+      response({ pathname: "m/a.png", url: "https://cdn.test/a.png", width: -1, height: "tall" }),
+    );
+    await expect(uploadTimelineMedia("a.png", png(), "project-a")).resolves.toEqual({
+      pathname: "m/a.png",
+      url: "https://cdn.test/a.png",
+    });
+  });
+
+  it("is ABSENT rather than zero when the provider reports no dimensions", async () => {
+    // Audio is the everyday case. Absent has to survive as absent: a stored
+    // `aspect` of 0 would be a divisor of zero in layout, and `aspectFromDimensions`
+    // is only able to decline because nothing invented a number on the way here.
+    stubUpload(response({ pathname: "m/vo.wav", url: "https://cdn.test/vo.wav" }));
+    const result = await uploadTimelineMedia("vo.wav", png(), "project-a");
+    expect("width" in result).toBe(false);
+    expect("height" in result).toBe(false);
+  });
+
   it("keeps optional thumbnail fields when they are present and valid", async () => {
     stubUpload(
       response({

--- a/apps/timeline-gstudio001/lib/timeline-media-client.ts
+++ b/apps/timeline-gstudio001/lib/timeline-media-client.ts
@@ -5,6 +5,10 @@ export type TimelineMediaUploadResult = {
   thumbnailUrl?: string;
   providerId?: string;
   assetId?: string;
+  /** The source's real pixel size, for minting `aspect`. Absent for audio, and
+   *  for any server that does not report it. */
+  width?: number;
+  height?: number;
 };
 
 // A `Promise<TimelineMediaUploadResult>` annotation on a function that returns
@@ -27,6 +31,14 @@ function parseUploadResult(value: unknown): TimelineMediaUploadResult | null {
   for (const key of ["thumbnailPathname", "thumbnailUrl", "providerId", "assetId"] as const) {
     if (candidate[key] !== undefined && !nonEmptyString(candidate[key])) return null;
   }
+  // Dimensions are DROPPED rather than rejected when malformed, unlike the
+  // strings above. A bad thumbnail url is a server bug worth surfacing; a bad
+  // width just means the clip keeps its default shape, and refusing the whole
+  // upload over it would lose the file for a cosmetic field.
+  const dimension = (value: unknown): number | undefined =>
+    typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+  const width = dimension(candidate.width);
+  const height = dimension(candidate.height);
   return {
     pathname: candidate.pathname,
     url: candidate.url,
@@ -40,6 +52,8 @@ function parseUploadResult(value: unknown): TimelineMediaUploadResult | null {
       ? { providerId: candidate.providerId as string }
       : {}),
     ...(candidate.assetId !== undefined ? { assetId: candidate.assetId as string } : {}),
+    ...(width === undefined ? {} : { width }),
+    ...(height === undefined ? {} : { height }),
   };
 }
 

--- a/apps/timeline-gstudio001/package.json
+++ b/apps/timeline-gstudio001/package.json
@@ -20,7 +20,8 @@
     "audit:review-findings": "node --env-file=.env scripts/audit-review-findings.mjs",
     "inspect:squatted": "node --env-file=.env scripts/inspect-squatted-fixtures.mjs",
     "stamp:ownership": "node --env-file=.env scripts/stamp-ownerless-timelines.mjs",
-    "bin:orphans": "node --env-file=.env scripts/bin-unreachable-timelines.mjs"
+    "bin:orphans": "node --env-file=.env scripts/bin-unreachable-timelines.mjs",
+    "correct:aspects": "node --env-file=.env scripts/correct-clip-aspects.mjs"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1094.0",

--- a/apps/timeline-gstudio001/scripts/aspect-correction.mjs
+++ b/apps/timeline-gstudio001/scripts/aspect-correction.mjs
@@ -1,0 +1,191 @@
+// The DECISIONS behind `correct-clip-aspects.mjs`, with no Firestore, no
+// ffprobe and no argv — so the app suite can exercise them.
+//
+// Split out for the same reason `ffmpeg-plan.mjs` is split from the worker
+// that runs it: this half decides what to WRITE to the user's real documents,
+// which is the part most able to be quietly wrong, and a runner that opens a
+// database connection at import time cannot be tested.
+
+import { clipsOf, srcOf } from "./timeline-snapshot.mjs";
+
+/** Two clips of the same shape are the same shape. A stored
+ *  1.7777777777777777 against a computed one must not read as a difference,
+ *  and neither should 1920x1080 against 1280x720. */
+export const ASPECT_EPSILON = 1e-4;
+
+/**
+ * The ratio, or undefined when the inputs are not a measurement.
+ *
+ * Mirrors `aspectFromDimensions` in the model. Duplicated rather than imported
+ * because that is TypeScript and this is a plain .mjs the worker-style scripts
+ * can run without a build step; the model's own test pins the same rule.
+ */
+export function aspectOf(width, height) {
+  if (typeof width !== "number" || !Number.isFinite(width) || width <= 0) return undefined;
+  if (typeof height !== "number" || !Number.isFinite(height) || height <= 0) return undefined;
+  return width / height;
+}
+
+/**
+ * Every document reachable from one project, that project included.
+ *
+ * Returns null when there is no such document — the caller reports it rather
+ * than silently correcting nothing, since a typo'd id and a project with no
+ * wrong clips would otherwise print the same reassuring result.
+ */
+export function scopeFrom(documents, projectId) {
+  if (!documents.has(projectId)) return null;
+  const scope = new Set();
+  const queue = [projectId];
+  while (queue.length > 0) {
+    const id = queue.pop();
+    if (scope.has(id)) continue;
+    scope.add(id);
+    for (const clip of clipsOf(documents.get(id))) {
+      if (clip?.kind === "collection" && typeof clip.childTimelineId === "string") {
+        queue.push(clip.childTimelineId);
+      }
+    }
+  }
+  return scope;
+}
+
+/**
+ * The clips whose aspect is a measurement of a file, and could therefore be
+ * wrong about one.
+ *
+ * COLLECTIONS ARE EXCLUDED. A container has no source file, so its aspect is
+ * not a reading of anything — deriving one from its children is a different
+ * question with a different right answer, and answering it here would write a
+ * number no probe supports.
+ */
+export function correctableClips(documents, scope = null) {
+  const found = [];
+  for (const [id, data] of documents) {
+    if (scope !== null && !scope.has(id)) continue;
+    clipsOf(data).forEach((clip, index) => {
+      if (clip?.kind === "collection") return;
+      const src = srcOf(clip);
+      if (src === null) return;
+      found.push({
+        documentId: id,
+        title: data?.title ?? "(untitled)",
+        index,
+        clipId: clip?.id ?? `#${index}`,
+        alt: clip?.alt ?? "",
+        src,
+        // A snapshot written before this script existed carries no aspect KEY,
+        // which is not the same as a clip that stores none — the caller tells
+        // the user its snapshot is too old rather than reporting every clip as
+        // wrong.
+        stored: clip !== null && clip !== undefined && "aspect" in clip ? clip.aspect : undefined,
+      });
+    });
+  }
+  return found;
+}
+
+/**
+ * Sort the clips against what the probe actually read.
+ *
+ * `unreadable` is not a failure: audio has no video stream, and a source that
+ * 404s or times out reads the same way. Leaving a clip alone is always safe;
+ * writing a number nothing measured is the thing this exists to undo.
+ */
+export function classify(clips, measurements) {
+  const wrong = [];
+  const alreadyRight = [];
+  const unreadable = [];
+  for (const clip of clips) {
+    const measured = measurements.get(clip.src);
+    if (!measured) {
+      unreadable.push(clip);
+      continue;
+    }
+    if (
+      typeof clip.stored === "number" &&
+      Math.abs(clip.stored - measured.aspect) < ASPECT_EPSILON
+    ) {
+      alreadyRight.push(clip);
+      continue;
+    }
+    wrong.push({ ...clip, measured });
+  }
+  return { wrong, alreadyRight, unreadable };
+}
+
+/**
+ * The merge payload for one document, or null when there is nothing safe to
+ * write. The caller adds `revision` and `updatedAt`.
+ *
+ * BOTH clip arrays are updated. `document.clips` is the live copy and `clips`
+ * the denormalized one — `buildSavePayload` writes both on every save, and
+ * `clipsOf` reads whichever exists, so touching only one would leave two
+ * records disagreeing about the same clip and the answer would depend on which
+ * reader got there first.
+ *
+ * NESTED, not dotted. A `set(..., {merge: true})` treats `"document.clips"` as
+ * a field name that happens to contain a dot, NOT as a path — only `update()`
+ * walks one. Writing the dotted form would leave the real clips untouched and
+ * add a junk top-level key, and it would look like it worked.
+ *
+ * `lastNonEmptyDocument` is deliberately left alone. It is a recovery snapshot
+ * of content since removed, so its clips need not line up with these at all,
+ * and an index-addressed write into it could land anywhere. A document emptied
+ * and later recovered comes back with its old aspects; re-running this fixes
+ * them, which is a better trade than writing blind into a backup.
+ *
+ * Each write is IDENTITY-CHECKED, not just positional. Indexes come from the
+ * read that produced the report, and a document edited in between would be
+ * re-indexed underneath us — writing a measured aspect onto whatever now sits
+ * at that index would corrupt the very field this came to repair. A mismatch
+ * skips that clip and says so.
+ */
+export function updateForDocument(data, clips) {
+  // Decided ONCE, against the array `clipsOf` reads — the same one whose
+  // indexes are in the report. Checking per-array instead would let the two
+  // copies disagree about which clips are safe to touch, and would count every
+  // clip twice.
+  const canonical = clipsOf(data);
+  const agreed = [];
+  const skipped = [];
+  for (const clip of clips) {
+    const target = canonical[clip.index];
+    if (!target || (target.id ?? `#${clip.index}`) !== clip.clipId) {
+      skipped.push(clip);
+      continue;
+    }
+    agreed.push(clip);
+  }
+
+  /** The array with the agreed aspects written in, or null when this copy does
+   *  not exist or has drifted out of step with the one we measured. */
+  const corrected = (array) => {
+    if (!Array.isArray(array)) return null;
+    const next = array.map((clip) => ({ ...clip }));
+    let touched = false;
+    for (const clip of agreed) {
+      const target = next[clip.index];
+      // The two copies are the same clips in the same order in practice, but
+      // "in practice" is not a guarantee about someone's stored data — a
+      // denormalized copy that has drifted is left alone, not scrambled.
+      if (!target || (target.id ?? `#${clip.index}`) !== clip.clipId) continue;
+      target.aspect = clip.measured.aspect;
+      touched = true;
+    }
+    return touched ? next : null;
+  };
+
+  const live = agreed.length === 0 ? null : corrected(data?.document?.clips);
+  const denormalized = agreed.length === 0 ? null : corrected(data?.clips);
+  if (live === null && denormalized === null) return { update: null, skipped, applied: 0 };
+
+  return {
+    update: {
+      ...(live === null ? {} : { document: { clips: live } }),
+      ...(denormalized === null ? {} : { clips: denormalized }),
+    },
+    skipped,
+    applied: agreed.length,
+  };
+}

--- a/apps/timeline-gstudio001/scripts/correct-clip-aspects.mjs
+++ b/apps/timeline-gstudio001/scripts/correct-clip-aspects.mjs
@@ -1,0 +1,300 @@
+#!/usr/bin/env node
+// Repair stored clip aspects that were never measured.
+//
+// Until #417, every clip minted in this app was stamped `aspect: 16/9` — a
+// hardcoded literal at both write paths, never a reading of the file. The
+// upload routes now carry width/height through and `aspectFromDimensions`
+// mints from them, but that only fixes clips minted AFTER the change. Every
+// clip already stored still claims 1.7778 whatever its source actually is.
+//
+// It is not cosmetic. `aspect` is a DIVISOR:
+//
+//   - a lane clip's picture-in-picture inset derives its HEIGHT from it
+//     (`layerFrameHeight`), so a wrong aspect is a wrong-shaped inset;
+//   - the strip sizes a card from it (`getItemWidth`);
+//   - it is what a human reads to answer "what shape is this shot", and it
+//     answered that question wrongly here once already.
+//
+// Measured, not guessed: ffprobe reads the exact URL the player loads and
+// reports the exact dimensions the player will see. No Cloudinary credentials,
+// no public_id parsing, no transformation guessing — the src is the answer.
+// Header-only, so a probe is one range request (~0.16s against Cloudinary).
+//
+//   npm run correct:aspects                          dry run, every project
+//   npm run correct:aspects -- --project <id>        one subtree
+//   npm run correct:aspects -- --offline             re-run the dry run, ZERO reads
+//   npm run correct:aspects -- --apply               write it
+//
+// DRY RUN BY DEFAULT, and --apply is refused offline (see `refuseOfflineWrite`
+// — deciding a write from a stale snapshot is the bug these scripts clean up
+// after). The probe results are cached on disk, so the second dry run costs no
+// network either.
+//
+// A LIVE RUN IS NOT FREE: `loadDocuments` reads the whole collection, ~350
+// documents. Run it live once, then iterate with --offline. See the long note
+// in audit-orphaned-timelines.mjs for what exhausting the read quota did.
+//
+// WHAT IT WILL NOT TOUCH, all three deliberately:
+//
+//   collections   their aspect is not a measurement of anything — a container
+//                 has no source file. Deriving one from its children is a
+//                 different question with a different right answer.
+//   audio         nothing to measure; ffprobe finds no video stream. The
+//                 default is as good as it gets, and the surface draws a
+//                 stand-in rather than the clip anyway.
+//   anything the probe could not read
+//                 a 404, a timeout, a src that is not media. Leaving a clip
+//                 alone is always safe; writing a number we did not measure is
+//                 the thing this script exists to undo.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import { FieldValue, getFirestore } from "firebase-admin/firestore";
+
+import {
+  COLLECTION,
+  announceSnapshot,
+  loadDocuments,
+  refuseOfflineWrite,
+  snapshotFlags,
+  walkReachable,
+} from "./timeline-snapshot.mjs";
+// Every decision this makes about the user's stored data lives there, pure and
+// covered by the app suite. This file is the plumbing: argv, ffprobe, batches.
+import {
+  aspectOf,
+  classify,
+  correctableClips,
+  scopeFrom,
+  updateForDocument,
+} from "./aspect-correction.mjs";
+
+const execFileAsync = promisify(execFile);
+
+const apply = process.argv.includes("--apply");
+const listAll = process.argv.includes("--list");
+const projectIndex = process.argv.indexOf("--project");
+const onlyProject = projectIndex === -1 ? null : process.argv[projectIndex + 1];
+const { offline, snapshotPath } = snapshotFlags();
+
+const PROBE_CACHE = ".aspect-probe-cache.json";
+/** Probes run against a CDN, so a handful at once is the difference between
+ *  seconds and minutes. Kept low deliberately: this is someone's media host,
+ *  not a load target. */
+const PROBE_CONCURRENCY = 6;
+
+/**
+ * The real dimensions of whatever is at this URL, or null.
+ *
+ * `-select_streams v:0` is what makes this work uniformly: a png has one video
+ * stream of one frame, an mp4 has a real one, and an mp3 has none — so audio
+ * falls out as null without the script having to know the kind in advance.
+ */
+async function probe(src) {
+  try {
+    const { stdout } = await execFileAsync(
+      "ffprobe",
+      [
+        "-v",
+        "error",
+        "-select_streams",
+        "v:0",
+        "-show_entries",
+        "stream=width,height",
+        "-of",
+        "csv=p=0",
+        src,
+      ],
+      { timeout: 30_000 },
+    );
+    const [width, height] = stdout.trim().split(",").map(Number);
+    const aspect = aspectOf(width, height);
+    return aspect === undefined ? null : { width, height, aspect };
+  } catch {
+    return null;
+  }
+}
+
+/** Every probe, keyed by src. Written back after each run so a re-run — the
+ *  dry run you do before deciding to --apply — costs nothing. */
+function loadProbeCache() {
+  try {
+    return new Map(Object.entries(JSON.parse(readFileSync(PROBE_CACHE, "utf8"))));
+  } catch {
+    return new Map();
+  }
+}
+
+async function probeAll(sources, cache) {
+  const pending = [...sources].filter((src) => !cache.has(src));
+  if (pending.length > 0) {
+    console.log(`Probing ${pending.length} source${pending.length === 1 ? "" : "s"}…`);
+  }
+  let next = 0;
+  let done = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(PROBE_CONCURRENCY, pending.length) }, async () => {
+      while (next < pending.length) {
+        const src = pending[next++];
+        cache.set(src, await probe(src));
+        done += 1;
+        if (done % 25 === 0) console.log(`  …${done}/${pending.length}`);
+      }
+    }),
+  );
+  try {
+    writeFileSync(PROBE_CACHE, JSON.stringify(Object.fromEntries(cache)));
+  } catch (error) {
+    console.error(`(could not write ${PROBE_CACHE}: ${error.message})`);
+  }
+}
+
+async function main() {
+  if (refuseOfflineWrite({ offline, apply, script: "correct:aspects" })) return;
+
+  const loaded = await loadDocuments({ offline, snapshotPath });
+  if (loaded === null) return;
+  const { documents } = loaded;
+  announceSnapshot(loaded);
+
+  const scope = onlyProject === null ? null : scopeFrom(documents, onlyProject);
+  if (onlyProject !== null && scope === null) {
+    console.error(`No document ${onlyProject} in the collection.`);
+    process.exitCode = 2;
+    return;
+  }
+  if (scope === null) {
+    // Unreachable documents are excluded on purpose: they are the audit
+    // script's problem, and repairing a clip nothing can reach spends a write
+    // to improve a document that is already lost.
+    const { reachable } = walkReachable(documents);
+    console.log(`${reachable.size} reachable documents.`);
+  } else {
+    console.log(`Scoped to ${onlyProject}: ${scope.size} documents in its subtree.`);
+  }
+
+  const clips = correctableClips(documents, scope);
+  if (clips.length === 0) {
+    console.log("No media clips in scope.");
+    return;
+  }
+
+  const missingField = clips.filter((clip) => clip.stored === undefined).length;
+  if (missingField === clips.length && !loaded.live) {
+    console.error("This snapshot predates the aspect field — it cannot answer this.");
+    console.error("Run it live once (without --offline) to take a fresh one.");
+    process.exitCode = 2;
+    return;
+  }
+
+  const cache = loadProbeCache();
+  await probeAll(new Set(clips.map((clip) => clip.src)), cache);
+
+  const { wrong, alreadyRight, unreadable } = classify(clips, cache);
+
+  console.log("");
+  console.log(
+    `${clips.length} media clips: ${wrong.length} wrong, ${alreadyRight.length} already right, ${unreadable.length} unreadable.`,
+  );
+
+  if (wrong.length > 0) {
+    console.log("");
+    const shown = listAll ? wrong : wrong.slice(0, 25);
+    for (const clip of shown) {
+      const from = typeof clip.stored === "number" ? clip.stored.toFixed(3) : String(clip.stored);
+      const { width, height, aspect } = clip.measured;
+      console.log(
+        `  ${from} → ${aspect.toFixed(3)}  (${width}x${height})  ${clip.title} / ${clip.alt || clip.clipId}`,
+      );
+    }
+    if (shown.length < wrong.length) {
+      console.log(`  … and ${wrong.length - shown.length} more (--list for all)`);
+    }
+  }
+
+  if (unreadable.length > 0) {
+    console.log("");
+    console.log(`${unreadable.length} left alone — audio, or a source ffprobe could not read.`);
+  }
+
+  if (!apply) {
+    console.log("");
+    console.log(wrong.length === 0 ? "Nothing to do." : "DRY RUN. Re-run with --apply to write.");
+    return;
+  }
+  if (wrong.length === 0) return;
+
+  await write(wrong, documents);
+}
+
+/**
+ * Write the measured aspects back.
+ *
+ * One `set(..., {merge: true})` per document, carrying both clip copies and a
+ * BUMPED REVISION. The bump is the point: the gateway sends the revision it
+ * read as `expectedRevision`, so a tab still holding the pre-correction
+ * document now hits a conflict instead of quietly saving its cached 16:9 back
+ * over the fix. Losing the correction to an open tab would be the likeliest
+ * way for this to appear not to have worked.
+ *
+ * Batched in 400s — Firestore's limit is 500 writes, and this is one per
+ * document.
+ */
+async function write(wrong, documents) {
+  // No `initializeApp` here: `loadDocuments` did it, and --apply cannot reach
+  // this without having gone live. A second call throws "already exists".
+  const db = getFirestore();
+
+  const byDocument = new Map();
+  for (const clip of wrong) {
+    if (!byDocument.has(clip.documentId)) byDocument.set(clip.documentId, []);
+    byDocument.get(clip.documentId).push(clip);
+  }
+
+  let batch = db.batch();
+  let queued = 0;
+  let written = 0;
+  let skipped = 0;
+  let touchedDocuments = 0;
+
+  for (const [documentId, clips] of byDocument) {
+    const data = documents.get(documentId);
+    const { update, skipped: missed, applied } = updateForDocument(data, clips);
+    skipped += missed.length;
+    if (update === null) continue;
+
+    batch.set(
+      db.collection(COLLECTION).doc(documentId),
+      {
+        ...update,
+        revision: (typeof data?.revision === "number" ? data.revision : 0) + 1,
+        updatedAt: FieldValue.serverTimestamp(),
+      },
+      { merge: true },
+    );
+    written += applied;
+    touchedDocuments += 1;
+    queued += 1;
+    if (queued === 400) {
+      await batch.commit();
+      batch = db.batch();
+      queued = 0;
+    }
+  }
+
+  if (queued > 0) await batch.commit();
+  console.log("");
+  console.log(`Wrote ${written} clip aspects across ${touchedDocuments} documents.`);
+  if (skipped > 0) {
+    console.log(`${skipped} skipped — the clip at that index is no longer the one measured.`);
+  }
+  console.log("Reload any open tab: it is holding the old values, and its next");
+  console.log("save will now be refused as a revision conflict until it does.");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/timeline-gstudio001/scripts/timeline-snapshot.mjs
+++ b/apps/timeline-gstudio001/scripts/timeline-snapshot.mjs
@@ -141,6 +141,11 @@ function toSnapshotEntry(data) {
       childTimelineId: clip?.childTimelineId ?? null,
       src: srcOf(clip),
       duration: typeof clip?.duration === "number" ? clip.duration : null,
+      // Carried so `correct:aspects` can dry-run offline. A snapshot taken
+      // before this line has no `aspect` KEY at all, which is why that script
+      // tests for the key rather than for undefined — "the snapshot cannot
+      // answer this" and "the clip stores nothing" are different answers.
+      ...(typeof clip?.aspect === "number" ? { aspect: clip.aspect } : {}),
     })),
   };
 }

--- a/packages/timeline-model/aspect.test.ts
+++ b/packages/timeline-model/aspect.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { aspectFromDimensions } from "./documents";
+
+describe("aspectFromDimensions", () => {
+  it("measures the real shapes this project actually contains", () => {
+    // The four that disproved "every source is 16:9" — a claim read off the
+    // stored `aspect` field, which was a default nobody had measured.
+    expect(aspectFromDimensions(2864, 1204)).toBeCloseTo(2.379, 3);
+    expect(aspectFromDimensions(896, 384)).toBeCloseTo(2.333, 3);
+    expect(aspectFromDimensions(1152, 480)).toBeCloseTo(2.4, 6);
+    expect(aspectFromDimensions(832, 480)).toBeCloseTo(1.733, 3);
+  });
+
+  it("is undefined for anything that cannot be divided by", () => {
+    // `aspect` is a DIVISOR in layout and inset geometry — a zero is an
+    // infinity and a negative inverts the box — so a bad reading has to become
+    // "no answer" and let the caller keep its own default.
+    for (const [w, h] of [
+      [0, 480],
+      [1152, 0],
+      [-1152, 480],
+      [1152, -480],
+      [Number.NaN, 480],
+      [1152, Number.POSITIVE_INFINITY],
+    ] as const) {
+      expect(aspectFromDimensions(w, h)).toBeUndefined();
+    }
+  });
+
+  it("is undefined for a missing or non-numeric reading", () => {
+    for (const bad of [undefined, null, "1152", {}]) {
+      expect(aspectFromDimensions(bad, 480)).toBeUndefined();
+      expect(aspectFromDimensions(1152, bad)).toBeUndefined();
+    }
+  });
+
+  it("keeps the full ratio rather than snapping to a known one", () => {
+    // 1.733 is not 16:9 and must not be rounded into it — the whole point is
+    // that the real shape reaches the inset geometry.
+    expect(aspectFromDimensions(832, 480)).not.toBeCloseTo(16 / 9, 2);
+  });
+});

--- a/packages/timeline-model/documents.ts
+++ b/packages/timeline-model/documents.ts
@@ -267,3 +267,27 @@ export function getFolderPathFromTimelineId(id: string, userId: string): string 
   }
   return "";
 }
+
+/**
+ * A clip's shape from its source's real pixel dimensions.
+ *
+ * `undefined` when they cannot be trusted, so every caller falls back to its
+ * own default rather than storing the answer. That matters more than it looks:
+ * `aspect` is a DIVISOR in layout and in inset geometry, so a zero is an
+ * infinity waiting to happen and a negative one inverts the box — which is why
+ * `validate` already demands `aspect > 0`.
+ *
+ * This exists because the field was never measured at all. Every clip was
+ * minted at 16/9 regardless of its source, and the value only stopped being
+ * decorative when compositing began deriving an inset's HEIGHT from it. It had
+ * already produced one wrong conclusion by then: a whole project read as "16:9
+ * throughout" off this field while its media was 2.379, 2.333, 2.400 and 1.733.
+ */
+export function aspectFromDimensions(
+  width: unknown,
+  height: unknown,
+): number | undefined {
+  if (typeof width !== "number" || !Number.isFinite(width) || width <= 0) return undefined;
+  if (typeof height !== "number" || !Number.isFinite(height) || height <= 0) return undefined;
+  return width / height;
+}


### PR DESCRIPTION
Closes #417.

## The bug

Every clip minted in this app was stamped `aspect: 16/9` — a hardcoded literal at both write paths, never a reading of the file. Nothing checked it, so it looked right.

Measured with ffprobe against the real Cloudinary URLs in the working project — **8 of 8 wrong**:

| source | real | stored |
| --- | --- | --- |
| `S01_pat_briefing` | 832×480 → **1.733** | 1.778 |
| `S02_cloud_s884` | 1152×480 → **2.400** | 1.778 |
| `loc_street_row` | 1152×480 → **2.400** | 1.778 |
| `loc_van_interior` | 1152×480 → **2.400** | 1.778 |
| `loc_bank_lobby` | 1152×480 → **2.400** | 1.778 |
| `PAT_base_283` | 1328×800 → **1.660** | 1.778 |
| `wiry_v3_angry_glare` | 1328×800 → **1.660** | 1.778 |
| `ref_wiry_closeup_f129` | 1204×1204 → **1.000** | 1.778 |

The last one is square and stored as widescreen.

It is not cosmetic. `aspect` is a **divisor**: a lane clip's picture-in-picture inset takes its height from it (`layerFrameHeight`), and the strip sizes a card from it. It also already produced one wrong conclusion in conversation — "every source here is 16:9" came from the stored default, not the files.

## Measuring at the mint sites

- `aspectFromDimensions` in the model, defended rather than trusting — zero, negative and NaN decline rather than returning a divisor that becomes an infinity in layout math.
- Both write paths use it. Cloudinary's listing has carried `width`/`height` all along, so the MCP attach path only had to read them; the UI native-drop path takes them from the hosted upload.
- `width`/`height` threaded through `CloudinaryUploadResponse`, `StoredMedia`, the upload route and `TimelineMediaUploadResult`. A **malformed** dimension is dropped, not rejected — a bad thumbnail url is a server bug worth surfacing, but losing an upload over a cosmetic field is worse than a clip keeping its default shape.

## Correcting what is already stored

Fixing the mint sites does nothing for existing clips, so this adds a corrector:

```
npm run correct:aspects                     # dry run, every project
npm run correct:aspects -- --project <id>   # one subtree
npm run correct:aspects -- --offline        # re-run the dry run, zero reads
npm run correct:aspects -- --apply          # write it
```

- **ffprobe reads the exact URL the player loads**, so no Cloudinary credentials, no `public_id` parsing, no transformation guessing. Header-only — ~0.16s per source, cached on disk so a re-run costs no network.
- **Collections, audio, and anything the probe could not read are left alone.** A container has no source file; writing a number nothing measured is the thing this exists to undo.
- The write is **identity-checked, not positional** — a document re-ordered between the read and the write skips rather than corrupting the field it came to repair.
- It **bumps `revision`**, so a tab still holding the pre-correction document hits a conflict instead of quietly saving its cached 16:9 back over the fix.
- Dry-run by default; `--apply` is refused offline, per `refuseOfflineWrite`.

I have **not run `--apply`** against live data — it needs one full-collection read and writes to production, so that call is yours. The dry run tells you exactly what it would change first.

## Testing

The decisions live in a pure `scripts/aspect-correction.mjs` with 31 tests, split from the runner the same way `ffmpeg-plan.mjs` is split from the render worker — this half decides what gets written to real documents.

Each guard was proven by flipping it and watching the tests go red, including the trap it exists for: `set(..., {merge: true})` treats `"document.clips"` as a field name that happens to contain a dot, **not** as a path. The dotted form would have left the real clips untouched, added a junk key, and looked like it worked.

- app: **1169 passed** (was 1135)
- unit: **741 passed** · storybook: **235 passed**
- `tsc --noEmit` clean in `packages/ui` and the app; lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)