### PR TITLE
A lane card resizes while you drag its trim handle

### DIFF
--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -8437,4 +8437,62 @@ test.describe("graph view E2E", () => {
       .toEqual({ width: 1152, height: 480, fps: 24 });
   });
 
+
+  /**
+   * A LANE CARD RESIZES WHILE YOU DRAG ITS HANDLE.
+   *
+   * It did not. Layer cards are deliberately not virtualized, so `indexById` —
+   * built from the PICTURE row's ids — did not know them, and `previewTrim`
+   * fell into its abort branch on every pointer move. The trim still committed
+   * correctly on release, which is exactly what made it hard to see: the
+   * gesture looked wired, but you dragged a handle, nothing moved, and the
+   * card jumped when you let go.
+   *
+   * Both edges, because a lane clip is pinned by its placed start and trimming
+   * EITHER edge holds the left and shrinks the width — so a left-handle drag
+   * has no distinguishing landmark other than this width, and a preview that
+   * only tracked the right edge would look right in half the cases.
+   *
+   * The commit is asserted against the LAST previewed width rather than a
+   * fixed number: the package's rule is that a preview equals its commit
+   * outcome, and pinning both to one constant would let them drift together.
+   */
+  for (const side of ["left", "right"] as const) {
+    test(`a lane card follows the pointer during a ${side} trim`, async ({ page }) => {
+      const api = await installGraphApi(page);
+      api.documents.get(PROJECT_ID)!.clips = [
+        mediaClip("alpha", "video", 0, 6, 20),
+        { ...mediaClip("bed", "audio", 1, 8, 20), trackIndex: 1, placedStart: 2 },
+      ];
+      await openGraph(page);
+
+      const wrapper = strip(page, PROJECT_ID).locator('[data-node-wrapper="bed"]');
+      await selectCard(strip(page, PROJECT_ID).locator('[data-node-id="bed"]'));
+      const started = Math.round((await wrapper.boundingBox())!.width);
+
+      const hb = (await wrapper.locator(`[data-trim-handle="${side}"]`).boundingBox())!;
+      const y = hb.y + hb.height / 2;
+      // Left shortens by dragging RIGHT, right by dragging left.
+      const dir = side === "left" ? 1 : -1;
+
+      await page.mouse.move(hb.x + hb.width / 2, y);
+      await page.mouse.down();
+      const widths: number[] = [];
+      for (const step of [20, 40]) {
+        await page.mouse.move(hb.x + hb.width / 2 + dir * step, y, { steps: 3 });
+        widths.push(Math.round((await wrapper.boundingBox())!.width));
+      }
+
+      // THE ASSERTION THAT WAS MISSING: it narrows AS YOU DRAG, monotonically,
+      // rather than sitting at its committed width until release.
+      expect(widths[0]).toBeLessThan(started);
+      expect(widths[1]).toBeLessThan(widths[0]!);
+
+      await page.mouse.up();
+      await expect
+        .poll(async () => Math.round((await wrapper.boundingBox())!.width))
+        .toBe(widths[1]);
+    });
+  }
+
 });

--- a/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
@@ -710,6 +710,24 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
       const s = trimStateRef.current;
       const index = s.indexById.get(nodeId) ?? -1;
 
+      // A LANE CARD IS NOT IN THE VIRTUALIZER'S INDEX SPACE. Layer cards are
+      // deliberately not virtualized (see `StripLayer`), so `indexById` — built
+      // from the picture row's `childIds` — does not know them, and this used
+      // to fall into the abort branch below on every pointer move. The trim
+      // still committed correctly on release, so the gesture LOOKED wired: you
+      // dragged a handle, nothing moved, and the card jumped when you let go.
+      //
+      // It has no virtualizer slot to resize, so its live width comes from
+      // `layerPlacements` reading `liveTrim` instead. Everything else — the
+      // duration readout, the commit effect's gesture identity — is the same.
+      if (live !== null && index === -1) {
+        if (gestureNodeRef.current?.nodeId !== nodeId) {
+          gestureNodeRef.current = { nodeId, node: s.nodesById.get(nodeId) ?? null };
+        }
+        setLiveTrim({ nodeId, trim: live });
+        return;
+      }
+
       if (live === null || index === -1) {
         // Abort/no-op: snap the item back to its committed size; clearing the
         // live split resets the anchor transform to 0 (scroll untouched, so
@@ -847,20 +865,33 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
 
     // Every layer card's box, plus the furthest right edge any of them reach —
     // the spacer has to cover a bed that outlasts the picture.
+    // The picture row gets its live trim width from `virtualizer.resizeItem`;
+    // a lane card has no slot to resize, so ITS live width is applied here.
+    //
+    // Only the DURATION moves. A lane clip is pinned by its placed start, so
+    // trimming either edge holds the left and shrinks the width — measured,
+    // both sides, and the same on commit. That is what keeps this preview
+    // equal to the commit outcome, which the package requires of every
+    // preview.
     const layerPlacements = useMemo(() => {
       const byId = new Map<NodeId, Readonly<{ left: number; width: number }>>();
       let right = 0;
       if (laneRows && laneTimeMap) {
         for (const layer of laneRows) {
           for (const item of layer.items) {
-            const placement = laneItemPlacement(laneTimeMap, item);
+            const placement = laneItemPlacement(
+              laneTimeMap,
+              liveTrim?.nodeId === item.id
+                ? { ...item, durationSeconds: liveTrim.trim.effectiveSeconds }
+                : item,
+            );
             byId.set(item.id, placement);
             right = Math.max(right, placement.left + placement.width);
           }
         }
       }
       return { byId, right };
-    }, [laneRows, laneTimeMap]);
+    }, [laneRows, laneTimeMap, liveTrim]);
 
     // What snapping measures against: the picture's cuts, each lane's own
     // clips, and which clip is being dragged (it must not snap to itself).


### PR DESCRIPTION
Reported from use: *"I'm dragging the trim handles of an audio. It's not working very well."*

It is not audio, and it is not the handles. It is **every card on a lane**.

## Measured

Dragging a right handle 40px in four steps, reading the card's width at each:

| card | during the drag | on release |
| --- | --- | --- |
| video on the picture (lane 0) | 300 → 290 → 280 → 270 → 260 | 260 |
| audio on a lane | 400 → 400 → 400 → 400 | **snaps to 360** |
| video on a lane | 250 → 250 → 250 → 250 | **snaps to 210** |

Audio trim shipping is only what made this reachable — the lane row was always like this.

## Cause

`previewTrim` resolves the node through `indexById`, built from `childIds` — the **picture row's** ids. Layer cards are deliberately not virtualized ("they are few and long where shots are many and short"), so they are absent from that map. The lookup returned `-1`, and `-1` shares a branch with `live === null`:

```ts
const index = s.indexById.get(nodeId) ?? -1;
if (live === null || index === -1) {  // abort
```

So every pointer move called `setLiveTrim(null)`. The commit path never went through that map, which is why the trim itself was always right — and why this looked wired.

## Fix

A lane card has no virtualizer slot to resize, so it takes its own path: set the live trim, skip `resizeItem`, and let `layerPlacements` apply the live duration to its width.

Only the **duration** moves. A lane clip is pinned by its placed start, so trimming either edge holds the left and shrinks the width — measured on both edges, and the same on commit. That is what keeps this preview equal to its commit outcome, which the package requires of every preview.

## Testing

Two e2e tests, one per edge, **proven red first** (`Expected: < 400, Received: 400`).

Both edges rather than just the obvious one: with the left edge pinned, a left-handle drag has no landmark other than this width, so a preview that only tracked the right edge would have looked correct in half the cases. The commit is asserted against the last *previewed* width rather than a constant — pinning both to one number would let them drift together and stop testing the relationship.

After: all six combinations (2 edges × 3 cards) track the pointer, and the preview matches the commit in every one. The picture row is unchanged.

- VirtualStrip stories **59 passed** (RenderEfficiency included)
- unit **741 passed** · `packages/ui` `tsc --noEmit` clean

## Noted while measuring, not changed

- Handles only exist once a card is **selected** — 0 before, 2 after. Every trim is click-then-grab.
- The hit zone is **8px** wide and full card height, which on a lane row is 44px vs 132px on the picture. An 8×44 target is small.

Both are taste calls rather than defects, so they are left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)