### PR TITLE
An expandable icon rail, with the name beside each icon

### DIFF
--- a/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
+++ b/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
@@ -327,7 +327,18 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
           therefore covered the panel's own controls — every click inside the
           drawer hit the backdrop and closed it, which is why Empty Trash
           "did nothing". Positioning the panel puts it back on top. */}
-      <div className="asset-library-panel pointer-events-auto relative ml-[72px] flex max-h-[48vh] flex-col border-t border-zinc-800 bg-zinc-950 text-white shadow-2xl shadow-black/50">
+      {/* CLEARS THE RAIL, whatever width it currently is.
+          This was a hardcoded `ml-[72px]`, correct exactly while the rail
+          could not change size — so opening the rail slid the drawer under
+          it. The sidebar publishes its width on the document root; the
+          fallback is the collapsed width, which is what any surface rendering
+          before the sidebar's effect runs should assume.
+          A style rather than an arbitrary Tailwind value because it is a live
+          value that transitions, not a class the scanner could emit. */}
+      <div
+        style={{ marginLeft: "var(--sw-rail-width, 72px)" }}
+        className="asset-library-panel pointer-events-auto relative flex max-h-[48vh] flex-col border-t border-zinc-800 bg-zinc-950 text-white shadow-2xl shadow-black/50 transition-[margin-left] duration-200 motion-reduce:transition-none"
+      >
         <header className="flex shrink-0 items-center justify-between gap-3 border-b border-zinc-800 px-5 py-3">
           <div className="min-w-0">
             <h2 className="text-sm font-semibold text-zinc-50 flex items-center gap-2">

--- a/apps/timeline-gstudio001/components/timeline/sidebar-icon-styles.test.ts
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-icon-styles.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  RAIL_CLASS,
+  RAIL_OPEN_CLASS,
+  RAIL_OPEN_WIDTH_PX,
+  RAIL_WIDTH_CLASS,
+  RAIL_WIDTH_PX,
+  SIDEBAR_AVATAR_INSET,
+  SIDEBAR_GLYPH,
+  SIDEBAR_ICON_BASE,
+} from "./sidebar-icon-styles";
+
+// THE RAIL'S TWO WIDTHS ARE WRITTEN TWICE — once as a number, which the CSS
+// variable and the drawer offset are published from, and once as a literal
+// Tailwind class, because Tailwind scans source text and cannot see a class
+// built by template. Nothing in the type system connects them, and the failure
+// when they drift is silent: the rail animates to a width nothing beside it
+// moved to, or the class compiles to nothing and the toggle looks dead.
+
+describe("rail widths", () => {
+  it.each([
+    ["collapsed", RAIL_WIDTH_CLASS.collapsed, RAIL_WIDTH_PX],
+    ["open", RAIL_WIDTH_CLASS.open, RAIL_OPEN_WIDTH_PX],
+  ])("the %s class names the same number the variable publishes", (_name, className, px) => {
+    expect(className).toBe(`w-[${px}px]`);
+  });
+
+  it("opens wider than it is closed", () => {
+    expect(RAIL_OPEN_WIDTH_PX).toBeGreaterThan(RAIL_WIDTH_PX);
+  });
+});
+
+describe("the glyph never moves", () => {
+  // The rail leads its glyphs rather than centring them, and the inset has to
+  // reproduce what centring already produced at 72px. That equality is the
+  // whole reason the geometry can be state-INDEPENDENT: get it wrong and the
+  // icons sit off-centre when closed, tie it back to the open state and they
+  // fly across the rail on every collapse.
+  const inset = (classes: string) => {
+    const match = /\[\.rail_&\]:ml-(?:\[(\d+)px\]|(\d+))/.exec(classes);
+    if (!match) throw new Error(`no expanded inset in: ${classes}`);
+    // Tailwind's numeric scale is quarter-rem: ml-5 is 20px.
+    return match[1] ? Number(match[1]) : Number(match[2]) * 4;
+  };
+
+  it.each([
+    ["the 28px glyph", SIDEBAR_GLYPH, 28],
+    ["the 32px avatar", SIDEBAR_AVATAR_INSET, 32],
+  ])("%s keeps the x that centring gave it", (_name, classes, size) => {
+    expect(inset(classes)).toBe((RAIL_WIDTH_PX - size) / 2);
+  });
+});
+
+describe("the expanded tile", () => {
+  it("keeps the collapsed tile's HEIGHT, so the rail's rhythm is unchanged", () => {
+    // `aspect-square` gives a 72px-tall tile at 72px wide. Dropping the ratio
+    // means the height has to be stated — and stated as the same number, or
+    // every tile grows taller as the rail widens.
+    expect(SIDEBAR_ICON_BASE).toContain(`[.rail_&]:h-[${RAIL_WIDTH_PX}px]`);
+    expect(SIDEBAR_ICON_BASE).toContain("[.rail_&]:aspect-auto");
+  });
+
+  it("hangs its geometry off the ALWAYS class, never the open one", () => {
+    // THE COLLAPSE BUG, pinned. A class flips in one frame and the width takes
+    // 200ms, so any layout keyed to `rail-open` is briefly applied against the
+    // wrong width: collapsing re-centred every glyph inside a still-232px tile
+    // and the icons flew back across the rail. Only the ASIDE'S OWN WIDTH may
+    // depend on the open state.
+    expect(SIDEBAR_ICON_BASE).not.toContain(RAIL_OPEN_CLASS);
+    expect(SIDEBAR_GLYPH).not.toContain(RAIL_OPEN_CLASS);
+    expect(SIDEBAR_AVATAR_INSET).not.toContain(RAIL_OPEN_CLASS);
+  });
+
+  it("drives its variants off the class the rail actually sets", () => {
+    // The variants are literal selectors (Tailwind scans text), so renaming a
+    // constant alone would leave them pointing at a class nothing applies —
+    // and every tile would stay square while the rail widened.
+    expect(RAIL_CLASS).toBe("rail");
+    expect(RAIL_OPEN_CLASS).toBe("rail-open");
+    expect(SIDEBAR_ICON_BASE).toContain(`[.${RAIL_CLASS}_&]:`);
+  });
+});

--- a/apps/timeline-gstudio001/components/timeline/sidebar-icon-styles.ts
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-icon-styles.ts
@@ -6,20 +6,118 @@
 // whole sidebar module. Style constants are the only thing it needs, and they
 // are the only thing here.
 
-/** A rail tile: the square hit area plus the pill drawn behind the glyph. */
+/**
+ * The rail's collapsed width, and the tile edge that follows from it. Exported
+ * because the glyph insets below are derived from it and the drawers beside
+ * the rail are offset by it — several places that must agree, and did not when
+ * the number was typed into each of them.
+ */
+export const RAIL_WIDTH_PX = 72;
+
+/**
+ * The rail's width with labels showing.
+ *
+ * 232px = the 72px icon column, the label's 16px gutter, and room for the
+ * longest label the rail carries ("All items in order") without truncating.
+ * Labels truncate rather than wrap, so a longer one added later degrades to an
+ * ellipsis instead of shoving the rail's rhythm out of line.
+ */
+export const RAIL_OPEN_WIDTH_PX = 232;
+
+/**
+ * On the rail ALWAYS, open or closed — and the hook every tile style below
+ * selects on.
+ *
+ * A descendant selector rather than props, so widening the rail does not mean
+ * editing every tile's call site (there are seven, and one missed would be a
+ * tile that stayed square while its neighbours grew). It is also what protects
+ * the ONE tile that is not in the rail: the graph portals its board-options
+ * trigger out of the board wearing `SIDEBAR_ICON_BASE` (PL14-005), and it is
+ * not inside `.rail`, so none of this reaches it by construction rather than
+ * by remembering.
+ *
+ * The geometry hangs off THIS rather than off `rail-open`, and the reason is
+ * the collapse animation. Width transitions over 200ms; a class is added and
+ * removed in one frame. So when the tile's layout depended on `rail-open`,
+ * collapsing re-centred every glyph INSTANTLY inside a tile that was still
+ * 232px wide, and each icon flew from the middle back to the edge while the
+ * rail caught up. Expanding looked fine because the same race runs the
+ * harmless way round.
+ *
+ * The trick is that leading and centred are the SAME PIXEL at 72px wide:
+ * `justify-start` with a 22px inset puts a 28px glyph exactly where centring
+ * it did. So the tile can wear one geometry in both states, nothing has to be
+ * timed against the transition, and the icons simply never move.
+ */
+export const RAIL_CLASS = "rail";
+
+/**
+ * On the rail only while it is OPEN — a state marker, deliberately not a
+ * geometry hook.
+ *
+ * Nothing below selects on it, and that is the point rather than an oversight:
+ * see `RAIL_CLASS`. Anything laid out from this class is laid out against a
+ * width that has not finished animating. It stays because the open state is
+ * worth naming in the DOM beside `data-sidebar-expanded`, and because the test
+ * that forbids the tile styles from mentioning it needs something to name.
+ */
+export const RAIL_OPEN_CLASS = "rail-open";
+
+/**
+ * The two widths as LITERAL Tailwind classes.
+ *
+ * Tailwind scans source text, so `w-[${RAIL_OPEN_WIDTH_PX}px]` compiles to
+ * nothing at all and the rail silently refuses to open — the failure looks
+ * like a broken toggle, not like a missing class. These have to be written
+ * out; `sidebar-icon-styles.test.ts` is what keeps them equal to the numbers
+ * above, which are what the CSS variable is published from.
+ */
+export const RAIL_WIDTH_CLASS = {
+  collapsed: "w-[72px]",
+  open: "w-[232px]",
+} as const;
+
+/**
+ * A tile's BOX, which is not the same thing as the shape you see.
+ *
+ * The box is a full-width square at rail width — that is what keeps the rail's
+ * rhythm even and the tiles on one grid. What you actually see is the
+ * `::before` layer, inset from that box, so every fill (idle, hover, pressed,
+ * disabled) paints as a rounded pill floating inside its square rather than a
+ * band running edge to edge.
+ *
+ * ON THE RAIL the square becomes a row of the same HEIGHT and the glyph leads
+ * rather than centring — unconditionally, in both states. The pill follows the
+ * row, which is what makes an expanded item read as one target with its label
+ * rather than as an icon with text loose beside it.
+ */
 export const SIDEBAR_ICON_BASE = [
   "group/sidebar-item relative flex w-full aspect-square items-center justify-center",
   "transition-all duration-200 focus-visible:outline-none",
   "before:absolute before:inset-2 before:rounded-2xl before:transition-colors before:content-['']",
   "focus-visible:before:ring-2 focus-visible:before:ring-zinc-400",
+  // Not keyed to the open state — see RAIL_CLASS. 72px is exactly what
+  // `aspect-square` already gave at 72px wide.
+  "[.rail_&]:aspect-auto [.rail_&]:h-[72px] [.rail_&]:justify-start",
 ].join(" ");
 
 /** The glyph inside a tile. Larger than the old h-4: legibility is the point
  *  of the bigger tiles, and a 16px icon in a 72px square reads as a dot.
  *
  *  `relative` is load-bearing: the pill above is an absolutely-positioned
- *  pseudo-element, so a statically-positioned glyph would paint UNDER it. */
-export const SIDEBAR_GLYPH = "relative h-7 w-7 [stroke-width:1.5] transition-colors";
+ *  pseudo-element, so a statically-positioned glyph would paint UNDER it.
+ *
+ *  THE GLYPH NEVER MOVES — not opening, and not closing. 22px is exactly where
+ *  centring a 28px glyph in the 72px tile already put it — `(72 - 28) / 2` — so
+ *  leading it lands on the same pixel, and the column of icons stays put while
+ *  the labels appear beside them. */
+export const SIDEBAR_GLYPH =
+  "relative h-7 w-7 [stroke-width:1.5] transition-colors [.rail_&]:ml-[22px]";
+
+/** The avatar's twin of `SIDEBAR_GLYPH`'s inset. It is 32px rather than 28,
+ *  so it sits 20px in — `(72 - 32) / 2` — and needs its own number to hold
+ *  still for the same reason. */
+export const SIDEBAR_AVATAR_INSET = "[.rail_&]:ml-5";
 
 export const SIDEBAR_ICON_IDLE =
   "text-zinc-400 before:bg-zinc-900/40 hover:text-zinc-100 hover:before:bg-zinc-800/80";

--- a/apps/timeline-gstudio001/components/timeline/sidebar-tooltip-label.tsx
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-tooltip-label.tsx
@@ -1,23 +1,96 @@
 "use client";
 
+import { createContext, useContext } from "react";
+
+import { cn } from "@/lib/utils";
+
 /**
- * The sidebar's hover/focus tooltip. Shared by every sidebar affordance —
- * nav links, the tool palette, and the utility row — so the three cannot
- * drift apart visually. Referenced by `aria-describedby`, which is why it
- * carries an id and `role="tooltip"` rather than being decorative.
+ * Whether the rail is showing its labels inline.
+ *
+ * Geometry elsewhere is done with descendant variants off `RAIL_CLASS`, which
+ * keeps seven tile call sites untouched — but this one thing CSS cannot do. A
+ * floating tooltip and a permanent label are different things to a screen
+ * reader (`role="tooltip"` vs a plain label), and the description line is
+ * dropped rather than hidden, so the choice has to be made in React.
+ *
+ * Defaults to false, which is the collapsed rail — the shape every consumer
+ * outside the sidebar gets, and the one that was here before.
+ */
+export const SidebarLabelsInlineContext = createContext(false);
+
+/**
+ * The sidebar's affordance label. Shared by every sidebar affordance — nav
+ * links, the tool palette, and the utility row — so the three cannot drift
+ * apart visually.
+ *
+ * COLLAPSED it is a hover/focus tooltip flying out to the right of the rail,
+ * referenced by `aria-describedby`, which is why it carries an id and
+ * `role="tooltip"` rather than being decorative.
+ *
+ * EXPANDED it stops flying and simply sits beside the glyph: the same text,
+ * always visible, which is the whole point of widening the rail. It sheds the
+ * tooltip's chrome (border, panel background, shadow) because a permanent
+ * label inside its own tile does not need to look like a thing that appeared.
  */
 export function SidebarTooltipLabel({
   id,
   label,
   description,
 }: Readonly<{ id: string; label: string; description?: string }>) {
+  const inline = useContext(SidebarLabelsInlineContext);
+
+  if (inline) {
+    return (
+      // KEYED APART from the tooltip below so React REPLACES the node rather
+      // than patching it. Patched, the same element kept the tooltip's
+      // `transition-opacity` and faded from the visible label down to hidden
+      // over 150ms — every label ghosting across the rail as it collapsed. A
+      // fresh node mounts already hidden, with nothing to transition from.
+      //
+      // No `role="tooltip"`: it is not one any more. It keeps the id so the
+      // buttons' `aria-describedby` still resolves rather than dangling.
+      //
+      // The DESCRIPTION is dropped, not hidden. Two lines per row would make
+      // the rail a settings list; the second line exists to explain a glyph
+      // with no words next to it, and expanded there is no such glyph.
+      <span
+        key="inline"
+        id={id}
+        className="pointer-events-none relative ml-4 min-w-0 flex-1 truncate text-left text-xs font-semibold text-current"
+      >
+        {label}
+      </span>
+    );
+  }
+
   return (
     <span
+      key="tooltip"
       id={id}
       role="tooltip"
-      className="pointer-events-none absolute left-full top-1/2 z-50 ml-3 min-w-max -translate-y-1/2 rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-left opacity-0 shadow-xl shadow-black/30 transition-opacity duration-150 group-hover/sidebar-item:opacity-100 group-focus-visible/sidebar-item:opacity-100"
+      className={cn(
+        "pointer-events-none absolute left-full top-1/2 z-50 ml-3 min-w-max -translate-y-1/2",
+        "rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-left opacity-0",
+        "shadow-xl shadow-black/30 transition-opacity duration-150",
+        "group-hover/sidebar-item:opacity-100 group-focus-visible/sidebar-item:opacity-100",
+        // SILENT AFTER A CLICK, until the pointer leaves and comes back.
+        //
+        // Pressing a rail tile leaves the pointer sitting on it, so the tooltip
+        // faded up the instant the thing you pressed finished happening —
+        // loudest on the rail's own collapse toggle, where it captions a
+        // control you are still touching and have just used. You know what you
+        // pressed; the tooltip is answering a question nobody has.
+        //
+        // `invisible`, not another opacity: visibility is a DIFFERENT property
+        // from the one `group-hover` sets, so this cannot lose a specificity
+        // race with it whatever order the utilities land in. The attribute is
+        // stamped by the rail on pointer clicks and cleared on pointerleave.
+        "group-data-[tip-suppressed]/sidebar-item:invisible",
+      )}
     >
-      <span className="block whitespace-nowrap text-xs font-semibold text-zinc-100">{label}</span>
+      <span className="block whitespace-nowrap text-xs font-semibold text-zinc-100">
+        {label}
+      </span>
       {description ? (
         <span className="mt-0.5 block whitespace-nowrap text-[10px] font-medium text-zinc-500">
           {description}

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import React, { useState, useEffect, useRef } from "react";
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useSyncExternalStore,
+} from "react";
 import {
   ChevronsLeftRightEllipsis,
   Film,
@@ -8,6 +13,8 @@ import {
   Image as ImageIcon,
   Layers,
   LogOut,
+  PanelLeftClose,
+  PanelLeftOpen,
   Trash2,
   TvMinimal,
 } from "lucide-react";
@@ -27,6 +34,12 @@ import {
   type GraphViewStateDetail,
 } from "@/lib/graph-view-events";
 import {
+  RAIL_CLASS,
+  RAIL_OPEN_CLASS,
+  RAIL_OPEN_WIDTH_PX,
+  RAIL_WIDTH_CLASS,
+  RAIL_WIDTH_PX,
+  SIDEBAR_AVATAR_INSET,
   SIDEBAR_GLYPH,
   SIDEBAR_ICON_BASE,
   SIDEBAR_ICON_IDLE,
@@ -34,14 +47,98 @@ import {
 import { toast } from "@/components/core/sonner";
 import { cn } from "@/lib/utils";
 
-import { SidebarTooltipLabel } from "./sidebar-tooltip-label";
+import {
+  SidebarLabelsInlineContext,
+  SidebarTooltipLabel,
+} from "./sidebar-tooltip-label";
+
+/** Survives a reload — a rail that collapsed itself on every navigation would
+ *  be a preference in name only. */
+const RAIL_EXPANDED_STORAGE_KEY = "sw:sidebar-expanded";
+
+/**
+ * Published to the document so surfaces BESIDE the rail can be offset by it.
+ *
+ * The trash drawer hardcoded `ml-[72px]`, which is correct exactly while the
+ * rail cannot change width — so opening the rail would have slid it
+ * underneath. A variable is the seam: one writer here, and any number of
+ * readers that keep working when this number moves again.
+ */
+const RAIL_WIDTH_VAR = "--sw-rail-width";
+
+/** Fires when THIS tab toggles the rail. `storage` only notifies other tabs,
+ *  so without this the toggle would not re-render the tab that pressed it. */
+const RAIL_EXPANDED_EVENT = "sw:sidebar-expanded-changed";
+
+function readRailExpanded(): boolean {
+  try {
+    return window.localStorage.getItem(RAIL_EXPANDED_STORAGE_KEY) === "true";
+  } catch {
+    // Private mode or a blocked origin: the rail still works, it just forgets.
+    return false;
+  }
+}
+
+function subscribeRailExpanded(onChange: () => void): () => void {
+  window.addEventListener("storage", onChange);
+  window.addEventListener(RAIL_EXPANDED_EVENT, onChange);
+  return () => {
+    window.removeEventListener("storage", onChange);
+    window.removeEventListener(RAIL_EXPANDED_EVENT, onChange);
+  };
+}
+
+function writeRailExpanded(next: boolean): void {
+  try {
+    window.localStorage.setItem(RAIL_EXPANDED_STORAGE_KEY, String(next));
+  } catch {
+    // A quota or private-mode failure costs the preference, not the toggle —
+    // the event still fires, so the rail still moves for this session.
+  }
+  window.dispatchEvent(new Event(RAIL_EXPANDED_EVENT));
+}
+
+/**
+ * After a POINTER press on a rail tile, keep that tile's tooltip shut until
+ * the pointer leaves it.
+ *
+ * Clicking a tile leaves the pointer sitting on it, so its tooltip faded up
+ * the moment the thing you pressed finished happening — captioning a control
+ * you are still touching and have just used. Leaving and coming back shows it
+ * again, which is the case where you might actually want it.
+ *
+ * Delegated on the rail rather than added to seven call sites, and the flag is
+ * a DOM attribute rather than React state: it must not re-render the rail, and
+ * nothing else needs to know.
+ *
+ * `detail > 0` is what keeps this to real pointer presses. A keyboard Enter
+ * also fires click, with no pointer anywhere near the tile — so no
+ * `pointerleave` would ever arrive to clear the flag, and that tile's tooltip
+ * would be suppressed for good.
+ */
+function suppressTipAfterPointerPress(
+  event: React.MouseEvent<HTMLElement>,
+): void {
+  if (event.detail === 0) return;
+  const tile = (event.target as HTMLElement | null)?.closest("button, a");
+  if (!(tile instanceof HTMLElement)) return;
+  tile.dataset.tipSuppressed = "";
+  tile.addEventListener(
+    "pointerleave",
+    () => {
+      delete tile.dataset.tipSuppressed;
+    },
+    { once: true },
+  );
+}
 
 /** The avatar letter. Written once because the same nested ternary appeared in
  *  two places, and an empty name string made `name[0]` undefined in both. */
-function initialOf(user: { name?: string | null; email?: string | null } | null | undefined): string {
+function initialOf(
+  user: { name?: string | null; email?: string | null } | null | undefined,
+): string {
   return (user?.name?.[0] ?? user?.email?.[0] ?? "U").toUpperCase();
 }
-
 
 type UtilityItem = {
   id: "assets" | "trash";
@@ -59,7 +156,10 @@ function TrashAreaIcon({ className }: Readonly<{ className?: string }>) {
       // The sidebar hands its drop-hover / arrival classes to this wrapper,
       // which is also what the e2e watches.
       data-sidebar-icon="trash"
-      className={cn("relative inline-flex shrink-0 overflow-visible", className)}
+      className={cn(
+        "relative inline-flex shrink-0 overflow-visible",
+        className,
+      )}
     >
       <Folder className="h-full w-full" strokeWidth={1.5} />
       <span className="absolute -bottom-1.5 -right-1.5 flex size-6 items-center justify-center rounded-full bg-zinc-950 ring-1 ring-zinc-600">
@@ -75,7 +175,10 @@ function MediaFolderIcon({ className }: Readonly<{ className?: string }>) {
   return (
     <span
       aria-hidden="true"
-      className={cn("relative inline-flex shrink-0 overflow-visible", className)}
+      className={cn(
+        "relative inline-flex shrink-0 overflow-visible",
+        className,
+      )}
     >
       <Folder className="h-full w-full" strokeWidth={1.5} />
       <span className="absolute -bottom-1.5 -right-1.5 flex size-6 items-center justify-center rounded-full bg-zinc-950 ring-1 ring-zinc-600">
@@ -166,17 +269,23 @@ const SIDEBAR_ICON_TOGGLE_ON =
  * longer run edge to edge either, so a wider rule with matching breathing room
  * sits in the same rhythm instead of interrupting one.
  */
-const SIDEBAR_SEPARATOR_CLASS = "mx-auto my-2 h-px w-10 shrink-0";
+// Stated as an INSET, not a width, so it follows the rail.
+//
+// It was `mx-auto w-10` — 40px centred in the 72px rail, which is the same
+// thing as 16px of margin each side. Written that way it stayed 40px when the
+// rail opened to 232px, and a 40px rule adrift in the middle of a 232px column
+// reads as a mistake rather than as a divider. As an inset it is 40px closed
+// (identical to before) and 200px open, with no second value to keep in step
+// and nothing keyed to the open state — which is what stops it animating
+// separately from the width, the way the glyphs used to.
+const SIDEBAR_SEPARATOR_CLASS = "mx-4 my-2 h-px shrink-0";
 
 function SidebarSeparator() {
   return (
     <div
       aria-hidden="true"
       data-sidebar-separator="normal"
-      className={cn(
-        SIDEBAR_SEPARATOR_CLASS,
-        "bg-zinc-500",
-      )}
+      className={cn(SIDEBAR_SEPARATOR_CLASS, "bg-zinc-500")}
     />
   );
 }
@@ -261,7 +370,11 @@ function SurfaceIconControl({
   const content = (
     <>
       <Icon className={SIDEBAR_GLYPH} />
-      <SidebarTooltipLabel id={tooltipId} label={label} description={description} />
+      <SidebarTooltipLabel
+        id={tooltipId}
+        label={label}
+        description={description}
+      />
     </>
   );
 
@@ -345,7 +458,7 @@ export function TimelineSidebar() {
     rulerOn: false,
     childrenShown: false,
     previewOn: false,
-      flatOn: false,
+    flatOn: false,
     flatLoading: false,
   });
   useEffect(() => {
@@ -365,7 +478,8 @@ export function TimelineSidebar() {
   useEffect(() => {
     const handleArrival = () => setTrashArrival((n) => n + 1);
     window.addEventListener(GRAPH_TRASH_ARRIVAL_EVENT, handleArrival);
-    return () => window.removeEventListener(GRAPH_TRASH_ARRIVAL_EVENT, handleArrival);
+    return () =>
+      window.removeEventListener(GRAPH_TRASH_ARRIVAL_EVENT, handleArrival);
   }, []);
 
   // A dragged card is (or is not) currently over the breadcrumb's trash drop
@@ -376,7 +490,8 @@ export function TimelineSidebar() {
     const handleHover = (event: Event) =>
       setTrashDropHover((event as CustomEvent<boolean>).detail === true);
     window.addEventListener(GRAPH_TRASH_HOVER_EVENT, handleHover);
-    return () => window.removeEventListener(GRAPH_TRASH_HOVER_EVENT, handleHover);
+    return () =>
+      window.removeEventListener(GRAPH_TRASH_HOVER_EVENT, handleHover);
   }, []);
 
   // The rail is a VIEW rail, and stays one. It used to swap these controls for
@@ -392,6 +507,30 @@ export function TimelineSidebar() {
   // orphaned by unmounting the control the user had just pressed.
   const onGraphRoute = isGraphViewRoute(pathname);
   const railRef = useRef<HTMLElement>(null);
+  // Read through an EXTERNAL STORE rather than an effect. The naive shape — a
+  // `useState(false)` corrected by a mount effect — is a synchronous setState
+  // inside an effect, which lints as a cascading render and is a real one: the
+  // rail paints collapsed and then jumps. `useSyncExternalStore` reads the
+  // stored value during the first client render instead, and its SERVER
+  // snapshot is the collapsed default, which is what keeps SSR and hydration
+  // agreeing about a value the server cannot see.
+  //
+  // Subscribing to `storage` is what an effect could not have done at all: two
+  // tabs open on this app now agree about the rail.
+  const railExpanded = useSyncExternalStore(
+    subscribeRailExpanded,
+    readRailExpanded,
+    () => false,
+  );
+  useEffect(() => {
+    // The offset every surface beside the rail reads. Written on the document
+    // rather than the aside because those surfaces are its SIBLINGS, not its
+    // descendants — a variable set here would not inherit to them.
+    document.documentElement.style.setProperty(
+      RAIL_WIDTH_VAR,
+      `${railExpanded ? RAIL_OPEN_WIDTH_PX : RAIL_WIDTH_PX}px`,
+    );
+  }, [railExpanded]);
 
   const handleLogout = async () => {
     try {
@@ -409,54 +548,82 @@ export function TimelineSidebar() {
   // outrank them (R7 #8). Nothing overlaps the 72px rail itself, so raising
   // it hides nothing.
   return (
-    <aside
-      ref={railRef}
-      // No horizontal padding and `items-stretch`: the tiles ARE the rail's
-      // width, which is what makes them full-width squares. Vertical padding
-      // stays — it separates the rail's contents from the screen edges, which
-      // the side padding was not doing for the tiles.
-      className="sticky top-0 z-50 flex h-screen w-[72px] shrink-0 flex-col items-stretch gap-0 overflow-visible border-r border-zinc-800 bg-zinc-900/50 pt-1.5 pb-5 backdrop-blur-md"
-    >
-      <Link
-        href="/"
-        aria-label="Storyboard Workbench home"
-        className="flex w-full aspect-square items-center justify-center text-lg font-black text-white transition-colors hover:text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-zinc-500"
+    // The provider is what turns each tile's tooltip into a permanent label.
+    // Geometry is done with descendant variants off `RAIL_CLASS` so the seven
+    // tile call sites stay untouched; this carries the ONE thing CSS cannot —
+    // that an always-visible label is not a `role="tooltip"`.
+    <SidebarLabelsInlineContext.Provider value={railExpanded}>
+      <aside
+        ref={railRef}
+        data-sidebar-expanded={railExpanded}
+        onClickCapture={suppressTipAfterPointerPress}
+        // No horizontal padding and `items-stretch`: the tiles ARE the rail's
+        // width, which is what makes them full-width squares. Vertical padding
+        // stays — it separates the rail's contents from the screen edges, which
+        // the side padding was not doing for the tiles.
+        //
+        // OPEN, only the WIDTH changes. Every tile keeps its 72px height and its
+        // glyph keeps its x — see RAIL_CLASS — so this reads as labels arriving
+        // rather than as a different rail redrawing itself.
+        className={cn(
+          // Unconditional: it carries the tile geometry, which must NOT change
+          // when the width does. See the note on RAIL_CLASS.
+          RAIL_CLASS,
+          "sticky top-0 z-50 flex h-screen shrink-0 flex-col items-stretch gap-0 overflow-visible border-r border-zinc-800 bg-zinc-900/50 pt-1.5 pb-5 backdrop-blur-md",
+          // Width alone is animated. `transition-all` here would also catch the
+          // backdrop filter, which is expensive to interpolate over a sticky
+          // full-height surface.
+          "transition-[width] duration-200 motion-reduce:transition-none",
+          // From RAIL_WIDTH_CLASS, which holds the literals Tailwind's scanner
+          // needs — see the note there on why these cannot be built by template.
+          railExpanded
+            ? `${RAIL_WIDTH_CLASS.open} ${RAIL_OPEN_CLASS}`
+            : RAIL_WIDTH_CLASS.collapsed,
+        )}
       >
-        SW
-      </Link>
+        <Link
+          href="/"
+          aria-label="Storyboard Workbench home"
+          // Pinned to the icon column's width. Everything else here widens
+          // because it gains a label; the mark has none, and a 232px-wide "SW"
+          // centred over the rail would read as a banner.
+          className="flex w-full aspect-square items-center justify-center text-lg font-black text-white transition-colors hover:text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-zinc-500 [.rail_&]:w-[72px]"
+        >
+          SW
+        </Link>
 
-      {activeProjectId && (
-        <div className="flex w-full flex-col items-stretch gap-0">
-          {/* The graph's layout switch (was the breadcrumb row's strip/grid
-              toggle). Grid first: it is the initial-load default. */}
-          <SurfaceIconControl
-            surface="grid"
-            onGraphRoute={onGraphRoute}
-            href={graphHref}
-            icon={GridLayoutGlyph}
-            isActive={onGraphRoute && graphView.surface === "grid"}
-            label="Grid layout"
-            description="Graph timelines as grids"
-          />
-          <SurfaceIconControl
-            surface="strip"
-            onGraphRoute={onGraphRoute}
-            href={`${graphHref}?surface=strip`}
-            icon={FilmStripGlyph}
-            isActive={onGraphRoute && graphView.surface === "strip"}
-            label="Strip layout"
-            description="Graph timelines as strips"
-          />
-        </div>
-      )}
-
-      {activeProjectId && (
-        <>
-          {/* zinc-500: the old zinc-800/80 vanished against the rail. */}
-          <SidebarSeparator />
-
+        {activeProjectId && (
           <div className="flex w-full flex-col items-stretch gap-0">
-            {/* PREVIEW leads this group, directly under the separator.
+            {/* The graph's layout switch (was the breadcrumb row's strip/grid
+              toggle). Grid first: it is the initial-load default. */}
+            <SurfaceIconControl
+              surface="grid"
+              onGraphRoute={onGraphRoute}
+              href={graphHref}
+              icon={GridLayoutGlyph}
+              isActive={onGraphRoute && graphView.surface === "grid"}
+              label="Grid layout"
+              description="Graph timelines as grids"
+            />
+            <SurfaceIconControl
+              surface="strip"
+              onGraphRoute={onGraphRoute}
+              href={`${graphHref}?surface=strip`}
+              icon={FilmStripGlyph}
+              isActive={onGraphRoute && graphView.surface === "strip"}
+              label="Strip layout"
+              description="Graph timelines as strips"
+            />
+          </div>
+        )}
+
+        {activeProjectId && (
+          <>
+            {/* zinc-500: the old zinc-800/80 vanished against the rail. */}
+            <SidebarSeparator />
+
+            <div className="flex w-full flex-col items-stretch gap-0">
+              {/* PREVIEW leads this group, directly under the separator.
 
                 It is a toggle, not a destination, so it wears the tint rather
                 than the indicator bar — but it sits in the rail rather than
@@ -468,208 +635,266 @@ export function TimelineSidebar() {
                 Ungated by surface deliberately: the pane plays the focused
                 timeline in grid as well as strip, so hiding it in grid would
                 remove a working control. */}
-            {onGraphRoute && (
-              <button
-                type="button"
-                aria-pressed={graphView.previewOn}
-                aria-label={graphView.previewOn ? "Hide preview" : "Show preview"}
-                aria-describedby="sidebar-tooltip-preview"
-                onClick={requestGraphPreviewToggle}
-                className={cn(
-                  SIDEBAR_ICON_BASE,
-                  graphView.previewOn ? SIDEBAR_ICON_TOGGLE_ON : SIDEBAR_ICON_IDLE,
-                )}
-              >
-                <TvMinimal className={SIDEBAR_GLYPH} />
-                <SidebarTooltipLabel
-                  id="sidebar-tooltip-preview"
-                  label="Preview"
-                  description="Play the focused timeline"
-                />
-              </button>
-            )}
+              {onGraphRoute && (
+                <button
+                  type="button"
+                  aria-pressed={graphView.previewOn}
+                  aria-label={
+                    graphView.previewOn ? "Hide preview" : "Show preview"
+                  }
+                  aria-describedby="sidebar-tooltip-preview"
+                  onClick={requestGraphPreviewToggle}
+                  className={cn(
+                    SIDEBAR_ICON_BASE,
+                    graphView.previewOn
+                      ? SIDEBAR_ICON_TOGGLE_ON
+                      : SIDEBAR_ICON_IDLE,
+                  )}
+                >
+                  <TvMinimal className={SIDEBAR_GLYPH} />
+                  <SidebarTooltipLabel
+                    id="sidebar-tooltip-preview"
+                    label="Preview"
+                    description="Play the focused timeline"
+                  />
+                </button>
+              )}
 
-            {/* The children-timelines toggle is in the board's breadcrumb row
+              {/* The children-timelines toggle is in the board's breadcrumb row
                 (see graph-board), alongside the ruler. */}
 
-            {/* Flat mode — strip only. Grid keeps its nesting, so there is
+              {/* Flat mode — strip only. Grid keeps its nesting, so there is
                 nothing to flatten there. */}
-            {onGraphRoute && graphView.surface === "strip" && (
-              <button
-                type="button"
-                aria-pressed={graphView.flatOn}
-                aria-label={graphView.flatOn ? "Show collections" : "Show all items in order"}
-                aria-describedby="sidebar-tooltip-flat"
-                aria-busy={graphView.flatLoading}
-                onClick={requestGraphFlatToggle}
-                className={cn(
-                  SIDEBAR_ICON_BASE,
-                  // TOGGLE, not a destination — see SIDEBAR_ICON_TOGGLE_ON.
-                  graphView.flatOn ? SIDEBAR_ICON_TOGGLE_ON : SIDEBAR_ICON_IDLE,
-                )}
-              >
-                <ChevronsLeftRightEllipsis
-                  className={cn(
-                    SIDEBAR_GLYPH,
-                    // Loading the closure can take a moment on a deep project,
-                    // and a half-built run would otherwise look like the real
-                    // answer.
-                    graphView.flatLoading ? "motion-safe:animate-pulse" : "",
-                  )}
-                />
-                <SidebarTooltipLabel
-                  id="sidebar-tooltip-flat"
-                  label="All items in order"
-                  description={
-                    graphView.flatLoading
-                      ? "Loading every collection…"
-                      : "One flat run — no collections. Reordering is off."
+              {onGraphRoute && graphView.surface === "strip" && (
+                <button
+                  type="button"
+                  aria-pressed={graphView.flatOn}
+                  aria-label={
+                    graphView.flatOn
+                      ? "Show collections"
+                      : "Show all items in order"
                   }
-                />
-              </button>
-            )}
+                  aria-describedby="sidebar-tooltip-flat"
+                  aria-busy={graphView.flatLoading}
+                  onClick={requestGraphFlatToggle}
+                  className={cn(
+                    SIDEBAR_ICON_BASE,
+                    // TOGGLE, not a destination — see SIDEBAR_ICON_TOGGLE_ON.
+                    graphView.flatOn
+                      ? SIDEBAR_ICON_TOGGLE_ON
+                      : SIDEBAR_ICON_IDLE,
+                  )}
+                >
+                  <ChevronsLeftRightEllipsis
+                    className={cn(
+                      SIDEBAR_GLYPH,
+                      // Loading the closure can take a moment on a deep project,
+                      // and a half-built run would otherwise look like the real
+                      // answer.
+                      graphView.flatLoading ? "motion-safe:animate-pulse" : "",
+                    )}
+                  />
+                  <SidebarTooltipLabel
+                    id="sidebar-tooltip-flat"
+                    label="All items in order"
+                    description={
+                      graphView.flatLoading
+                        ? "Loading every collection…"
+                        : "One flat run — no collections. Reordering is off."
+                    }
+                  />
+                </button>
+              )}
 
-            {/* The time-ruler toggle moved to the board's breadcrumb row,
+              {/* The time-ruler toggle moved to the board's breadcrumb row,
                 sitting left of the children toggle. It is still scoped to flat
                 mode and still appears and disappears with it — only its home
                 changed, joining the view controls it belongs with. */}
-          </div>
-        </>
-      )}
+            </div>
+          </>
+        )}
 
-      <div className="relative mt-auto flex w-full flex-col items-stretch gap-0">
-        {UTILITY_ITEMS.map((item) => {
-          if (item.id === "trash" && pathname === "/") return null;
+        <div className="relative mt-auto flex w-full flex-col items-stretch gap-0">
+          {UTILITY_ITEMS.map((item) => {
+            if (item.id === "trash" && pathname === "/") return null;
 
-          const Icon = item.icon;
-          const tooltipId = `sidebar-tooltip-utility-${item.id}`;
-          const isPressed = isTrashOpen;
-          const handleClick = () => setIsTrashOpen(!isTrashOpen);
+            const Icon = item.icon;
+            const tooltipId = `sidebar-tooltip-utility-${item.id}`;
+            const isPressed = isTrashOpen;
+            const handleClick = () => setIsTrashOpen(!isTrashOpen);
 
-          return (
-            <button
-              key={item.id}
-              type="button"
-              aria-label={item.label}
-              aria-describedby={tooltipId}
-              aria-pressed={isPressed}
-              onClick={handleClick}
-              className={cn(
-                SIDEBAR_ICON_BASE,
-                // Trash opens a DRAWER over the board; it does not take you
-                // anywhere, and the board behind it is still the page you are
-                // on. That makes it state, not location — the tint, like flat
-                // mode above (see SIDEBAR_ICON_TOGGLE_ON).
-                isPressed ? SIDEBAR_ICON_TOGGLE_ON : SIDEBAR_ICON_IDLE,
-              )}
-            >
-              <Icon
-                // Remount per arrival so the one-shot pop animation replays
-                // even when drops land back-to-back.
-                key={item.id === "trash" ? trashArrival : undefined}
+            return (
+              <button
+                key={item.id}
+                type="button"
+                aria-label={item.label}
+                aria-describedby={tooltipId}
+                aria-pressed={isPressed}
+                onClick={handleClick}
                 className={cn(
-                  SIDEBAR_GLYPH,
-                  // Continuous wiggle while a card hovers the trash drop zone;
-                  // the one-shot arrival pop takes over on the actual drop.
-                  item.id === "trash" && trashDropHover && "animate-trash-hover-attention",
-                  item.id === "trash" && trashArrival > 0 && "animate-trash-arrival",
+                  SIDEBAR_ICON_BASE,
+                  // Trash opens a DRAWER over the board; it does not take you
+                  // anywhere, and the board behind it is still the page you are
+                  // on. That makes it state, not location — the tint, like flat
+                  // mode above (see SIDEBAR_ICON_TOGGLE_ON).
+                  isPressed ? SIDEBAR_ICON_TOGGLE_ON : SIDEBAR_ICON_IDLE,
                 )}
-              />
-              <SidebarTooltipLabel
-                id={tooltipId}
-                label={item.label}
-                description={item.description}
-              />
-            </button>
-          );
-        })}
+              >
+                <Icon
+                  // Remount per arrival so the one-shot pop animation replays
+                  // even when drops land back-to-back.
+                  key={item.id === "trash" ? trashArrival : undefined}
+                  className={cn(
+                    SIDEBAR_GLYPH,
+                    // Continuous wiggle while a card hovers the trash drop zone;
+                    // the one-shot arrival pop takes over on the actual drop.
+                    item.id === "trash" &&
+                      trashDropHover &&
+                      "animate-trash-hover-attention",
+                    item.id === "trash" &&
+                      trashArrival > 0 &&
+                      "animate-trash-arrival",
+                  )}
+                />
+                <SidebarTooltipLabel
+                  id={tooltipId}
+                  label={item.label}
+                  description={item.description}
+                />
+              </button>
+            );
+          })}
 
-        {/* The board-options slot used to sit here, below the trash
+          {/* THE RAIL'S OWN WIDTH CONTROL.
+
+            Under the trash and above the account tile. Bottom of the rail
+            because it is the one control here about the RAIL rather than about
+            the work — the same place an IDE puts it — and above the account,
+            which stays pinned last.
+
+            It wears the plain idle treatment in BOTH states, alone among the
+            toggles. `SIDEBAR_ICON_TOGGLE_ON` means "this changes what the
+            board shows"; the rail's own width changes nothing about the work,
+            and lighting it up would leave a permanent accent in the rail for a
+            preference you can already see in the rail's width. The glyph
+            flipping direction is the state readout. */}
+          <button
+            type="button"
+            aria-expanded={railExpanded}
+            aria-label={railExpanded ? "Collapse sidebar" : "Expand sidebar"}
+            aria-describedby="sidebar-tooltip-rail-width"
+            data-sidebar-rail-toggle={railExpanded ? "expanded" : "collapsed"}
+            onClick={() => writeRailExpanded(!railExpanded)}
+            className={cn(SIDEBAR_ICON_BASE, SIDEBAR_ICON_IDLE)}
+          >
+            {railExpanded ? (
+              <PanelLeftClose className={SIDEBAR_GLYPH} />
+            ) : (
+              <PanelLeftOpen className={SIDEBAR_GLYPH} />
+            )}
+            <SidebarTooltipLabel
+              id="sidebar-tooltip-rail-width"
+              label={railExpanded ? "Collapse" : "Expand"}
+              description="Show the name beside each icon"
+            />
+          </button>
+
+          {/* The board-options slot used to sit here, below the trash
             (PL14-005): an address the rail published for the graph to portal
             its settings menu into. That menu is back in the board's own
             controls row, under the divider, so the slot had nothing left to
             receive — an empty publishing div is worse than no seam at all,
             because the next reader has to prove nothing fills it. */}
 
-        <button
-          ref={buttonRef}
-          type="button"
-          aria-label="Account"
-          aria-describedby="sidebar-tooltip-utility-account"
-          aria-pressed={isProfileOpen}
-          onClick={() => setIsProfileOpen((open) => !open)}
-          className={cn(
-            SIDEBAR_ICON_BASE,
-            isProfileOpen ? SIDEBAR_ICON_PRESSED : SIDEBAR_ICON_IDLE
-          )}
-        >
-          {user?.picture ? (
-            <img
-              src={user.picture}
-              alt={user.name || user.email || "Profile"}
-              className="h-8 w-8 rounded-full object-cover border border-zinc-700 group-hover/sidebar-item:border-zinc-500 transition-colors"
-            />
-          ) : (
-            <div className="flex h-8 w-8 items-center justify-center rounded-full border border-zinc-700 bg-zinc-800/60 text-xs font-bold text-zinc-400 transition-colors select-none group-hover/sidebar-item:border-zinc-600 group-hover/sidebar-item:bg-zinc-800 group-hover/sidebar-item:text-zinc-100">
-              {initialOf(user)}
-            </div>
-          )}
-          <SidebarTooltipLabel
-            id="sidebar-tooltip-utility-account"
-            label="Account"
-            description={user?.email ? `Signed in as ${user.email}` : "Signed in"}
-          />
-        </button>
-
-        {isProfileOpen && (
-          <div
-            ref={profileMenuRef}
-            className="absolute bottom-0 left-full z-50 ml-2 w-64 rounded-xl border border-zinc-800/80 bg-zinc-950/90 p-4 shadow-[0_10px_40px_rgba(0,0,0,0.7)] backdrop-blur-md profile-popover-animate"
+          <button
+            ref={buttonRef}
+            type="button"
+            aria-label="Account"
+            aria-describedby="sidebar-tooltip-utility-account"
+            aria-pressed={isProfileOpen}
+            onClick={() => setIsProfileOpen((open) => !open)}
+            className={cn(
+              SIDEBAR_ICON_BASE,
+              isProfileOpen ? SIDEBAR_ICON_PRESSED : SIDEBAR_ICON_IDLE,
+            )}
           >
-            <div className="flex items-center gap-3 border-b border-zinc-800/60 pb-3">
-              {user?.picture ? (
-                <img
-                  src={user.picture}
-                  alt={user.name || user.email || "Profile"}
-                  className="h-10 w-10 rounded-full object-cover border border-zinc-800"
-                />
-              ) : (
-                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-zinc-700 bg-zinc-800/60 text-sm font-bold text-zinc-300">
-                  {initialOf(user)}
+            {user?.picture ? (
+              <img
+                src={user.picture}
+                alt={user.name || user.email || "Profile"}
+                className={cn(
+                  "h-8 w-8 shrink-0 rounded-full object-cover border border-zinc-700 group-hover/sidebar-item:border-zinc-500 transition-colors",
+                  SIDEBAR_AVATAR_INSET,
+                )}
+              />
+            ) : (
+              <div
+                className={cn(
+                  "flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-zinc-700 bg-zinc-800/60 text-xs font-bold text-zinc-400 transition-colors select-none group-hover/sidebar-item:border-zinc-600 group-hover/sidebar-item:bg-zinc-800 group-hover/sidebar-item:text-zinc-100",
+                  SIDEBAR_AVATAR_INSET,
+                )}
+              >
+                {initialOf(user)}
+              </div>
+            )}
+            <SidebarTooltipLabel
+              id="sidebar-tooltip-utility-account"
+              label="Account"
+              description={
+                user?.email ? `Signed in as ${user.email}` : "Signed in"
+              }
+            />
+          </button>
+
+          {isProfileOpen && (
+            <div
+              ref={profileMenuRef}
+              className="absolute bottom-0 left-full z-50 ml-2 w-64 rounded-xl border border-zinc-800/80 bg-zinc-950/90 p-4 shadow-[0_10px_40px_rgba(0,0,0,0.7)] backdrop-blur-md profile-popover-animate"
+            >
+              <div className="flex items-center gap-3 border-b border-zinc-800/60 pb-3">
+                {user?.picture ? (
+                  <img
+                    src={user.picture}
+                    alt={user.name || user.email || "Profile"}
+                    className="h-10 w-10 rounded-full object-cover border border-zinc-800"
+                  />
+                ) : (
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-zinc-700 bg-zinc-800/60 text-sm font-bold text-zinc-300">
+                    {initialOf(user)}
+                  </div>
+                )}
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-xs font-semibold text-zinc-100">
+                    {user?.name || "User"}
+                  </p>
+                  <p className="truncate text-[10px] font-medium text-zinc-500">
+                    {user?.email}
+                  </p>
                 </div>
-              )}
-              <div className="min-w-0 flex-1">
-                <p className="truncate text-xs font-semibold text-zinc-100">
-                  {user?.name || "User"}
-                </p>
-                <p className="truncate text-[10px] font-medium text-zinc-500">
-                  {user?.email}
-                </p>
+              </div>
+              <div className="mt-3 flex flex-col gap-1">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setIsProfileOpen(false);
+                    void handleLogout();
+                  }}
+                  className="flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-xs font-semibold text-zinc-400 hover:bg-red-500/10 hover:text-red-400 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-red-500/30 cursor-pointer"
+                >
+                  <LogOut className="h-3.5 w-3.5" />
+                  Sign Out
+                </button>
               </div>
             </div>
-            <div className="mt-3 flex flex-col gap-1">
-              <button
-                type="button"
-                onClick={() => {
-                  setIsProfileOpen(false);
-                  void handleLogout();
-                }}
-                className="flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-xs font-semibold text-zinc-400 hover:bg-red-500/10 hover:text-red-400 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-red-500/30 cursor-pointer"
-              >
-                <LogOut className="h-3.5 w-3.5" />
-                Sign Out
-              </button>
-            </div>
-          </div>
-        )}
-      </div>
+          )}
+        </div>
 
-      <TrashDrawer
-        isOpen={isTrashOpen}
-        onClose={() => setIsTrashOpen(false)}
-      />
+        <TrashDrawer
+          isOpen={isTrashOpen}
+          onClose={() => setIsTrashOpen(false)}
+        />
 
-      <style>{`
+        <style>{`
         @keyframes slideInLeft {
           from {
             transform: translateX(-8px);
@@ -684,7 +909,7 @@ export function TimelineSidebar() {
           animation: slideInLeft 0.2s cubic-bezier(0.16, 1, 0.3, 1) forwards;
         }
       `}</style>
-
-    </aside>
+      </aside>
+    </SidebarLabelsInlineContext.Provider>
   );
 }

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -100,37 +100,44 @@ function writeRailExpanded(next: boolean): void {
 
 /**
  * After a POINTER press on a rail tile, keep that tile's tooltip shut until
- * the pointer leaves it.
+ * the pointer LEAVES AND COMES BACK.
  *
- * Clicking a tile leaves the pointer sitting on it, so its tooltip faded up
- * the moment the thing you pressed finished happening — captioning a control
- * you are still touching and have just used. Leaving and coming back shows it
- * again, which is the case where you might actually want it.
+ * Clicking a tile leaves the pointer sitting on it, so its tooltip faded up the
+ * moment the thing you pressed finished happening — captioning a control you
+ * are still touching and have just used.
+ *
+ * CLEARED ON RE-ENTRY, not on leaving, and the difference is the whole fix.
+ * Pressing the collapse toggle by its LABEL puts the pointer ~150px out, and
+ * the rail then shrinks to 72px — so the tile is pulled out from under a
+ * pointer that never moved. That fires `pointerleave`, which cleared the flag,
+ * while `:hover` stayed stale-true (browsers recompute hover on pointer
+ * movement, not on layout). Flag off plus hover still on is exactly the flash:
+ * a tooltip for a control that had just slid away. Waiting for `pointerenter`
+ * cannot be tricked by geometry moving, because nothing enters an element the
+ * pointer never left.
  *
  * Delegated on the rail rather than added to seven call sites, and the flag is
  * a DOM attribute rather than React state: it must not re-render the rail, and
  * nothing else needs to know.
  *
- * `detail > 0` is what keeps this to real pointer presses. A keyboard Enter
- * also fires click, with no pointer anywhere near the tile — so no
- * `pointerleave` would ever arrive to clear the flag, and that tile's tooltip
- * would be suppressed for good.
+ * `detail > 0` keeps this to real pointer presses. A keyboard Enter also fires
+ * click with no pointer anywhere near the tile, so no `pointerenter` would ever
+ * arrive to clear the flag and that tile would go quiet for good.
  */
-function suppressTipAfterPointerPress(
-  event: React.MouseEvent<HTMLElement>,
-): void {
+function suppressTipUntilPointerReturns(event: React.MouseEvent<HTMLElement>): void {
   if (event.detail === 0) return;
   const tile = (event.target as HTMLElement | null)?.closest("button, a");
   if (!(tile instanceof HTMLElement)) return;
   tile.dataset.tipSuppressed = "";
   tile.addEventListener(
-    "pointerleave",
+    "pointerenter",
     () => {
       delete tile.dataset.tipSuppressed;
     },
     { once: true },
   );
 }
+
 
 /** The avatar letter. Written once because the same nested ternary appeared in
  *  two places, and an empty name string made `name[0]` undefined in both. */
@@ -556,7 +563,7 @@ export function TimelineSidebar() {
       <aside
         ref={railRef}
         data-sidebar-expanded={railExpanded}
-        onClickCapture={suppressTipAfterPointerPress}
+        onClickCapture={suppressTipUntilPointerReturns}
         // No horizontal padding and `items-stretch`: the tiles ARE the rail's
         // width, which is what makes them full-width squares. Vertical padding
         // stays — it separates the rail's contents from the screen edges, which


### PR DESCRIPTION
A toggle under the trash widens the rail to 232px and puts each tile's name beside its glyph.

The labels are not new text — every tile already carried a `label` for its tooltip, so expanding just shows what the rail already knew.

## What does not move

Only the aside's width changes. Sampled frame by frame through a collapse:

| frame | rail width | glyph x | separator | label opacity |
| --- | --- | --- | --- | --- |
| 0 | 232 | **22** | 199 | 1.00 |
| 1 | 229 | **22** | 196 | 0.00 |
| 3 | 129 | **22** | 96 | 0.00 |
| 5 | 79 | **22** | 46 | 0.00 |
| 8 | 72 | **22** | 39 | 0.00 |

The glyph holds x=22 in every frame because leading and centred are the *same pixel* at 72px wide: `justify-start` with a 22px inset is exactly `(72 - 28) / 2`. The avatar has its own 20px twin.

## The collapse bug that equality fixes

Keyed to the open class, collapsing looked wrong in a way expanding did not. A class flips in one frame; the width takes 200ms. So removing `rail-open` re-centred every glyph inside a tile that was still 232px wide, and the icons flew back across the rail while it caught up — expanding raced the harmless way round.

Now nothing but the aside's own width depends on the open state, and a test forbids the tile styles from mentioning it.

## Three more things testing turned up

- **Labels ghosted on collapse.** React patched the single span from inline label to tooltip, so it inherited the tooltip's `transition-opacity` and faded 1 → 0 over 150ms. Keyed apart, a fresh node mounts already hidden.
- **The separator stayed 40px in a 232px column.** It was `mx-auto w-10` — which in a 72px rail is just 16px of margin each side. Restated as the inset it follows the rail for free: 40px closed, 200px open, one value, nothing keyed to the open state.
- **Clicking a tile left its tooltip captioning a control you had just used.** Suppressed until the pointer leaves and comes back. Delegated on the rail, a DOM attribute rather than state (it must not re-render), and gated on `detail > 0` — a keyboard Enter has no pointer, so no `pointerleave` would ever arrive to clear the flag and that tile would go quiet for good.

## Two traps

- **Tailwind scans source text**, so `w-[${RAIL_OPEN_WIDTH_PX}px]` compiles to nothing and the rail silently refuses to open — a failure that looks like a dead toggle, not a missing class. The literals live in `RAIL_WIDTH_CLASS`, and a test keeps them equal to the numbers the CSS variable is published from.
- **The trash drawer hardcoded `ml-[72px]`**, correct exactly while the rail cannot resize. It reads `--sw-rail-width` now, with the collapsed width as fallback.

The preference persists through `useSyncExternalStore` rather than a mount effect — the naive version is a `setState` inside an effect, which both lints and visibly jumps — and subscribing to `storage` means two tabs agree about the rail.

## Testing

- app **1177 passed**, `tsc --noEmit` clean, lint 0 errors
- 8 new unit tests on the geometry constants, including the one that pins the collapse bug
- Verified in the running app: widths, glyph x per frame, separator growth, and the tooltip suppression cycle (click → `hidden`, pointer leaves → cleared, hover again → allowed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)