### PR TITLE
Move the view toggles to the board, and open the strip flat

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -21,9 +21,11 @@ import {
   EllipsisVertical,
   FolderPlus,
   FolderTree,
+  Layers,
   Redo2,
   Ruler,
   Settings,
+  TvMinimal,
   Undo2,
   X,
 } from "lucide-react";
@@ -490,6 +492,7 @@ function HeaderToggle({
   icon: Icon,
   label,
   title,
+  busy = false,
 }: Readonly<{
   active: boolean;
   onToggle: () => void;
@@ -502,6 +505,10 @@ function HeaderToggle({
    */
   label: string;
   title: string;
+  /** Work is in flight and the state shown is not settled yet. Only flat mode
+   *  needs it — loading a deep closure takes a moment, and a half-built run
+   *  would otherwise look like the real answer. */
+  busy?: boolean;
 }>) {
   return (
     <Button
@@ -510,11 +517,12 @@ function HeaderToggle({
       size="icon"
       aria-label={label}
       aria-pressed={active}
+      aria-busy={busy || undefined}
       title={title}
       onClick={onToggle}
       className={cn("h-8 w-8", active ? HEADER_TOGGLE_ACTIVE : HEADER_TOGGLE_IDLE)}
     >
-      <Icon aria-hidden className="h-4 w-4" />
+      <Icon aria-hidden className={cn("h-4 w-4", busy && "motion-safe:animate-pulse")} />
     </Button>
   );
 }
@@ -1461,11 +1469,14 @@ export function GraphBoard({
   pixelsPerSecond,
   onPixelsPerSecondChange,
   previewOn,
+  onPreviewToggle,
   rulerOn,
   onRulerToggle,
   waveformOn,
   onWaveformToggle,
   flatOn,
+  flatLoading,
+  onFlatToggle,
   childrenShown,
   onChildrenToggle,
   timeChannel,
@@ -1483,11 +1494,13 @@ export function GraphBoard({
   onItemSizeChange: (size: ItemSize) => void;
   pixelsPerSecond: number;
   onPixelsPerSecondChange: (pixelsPerSecond: number) => void;
-  /** The preview pane above the board. The board RENDERS it; the toggle
-   *  lives in the icon rail (timeline-sidebar) and reaches this state through
-   *  the window-event bus, which the pane's own close button and the WebMCP
-   *  `set_preview` tool already share. */
+  /** The preview pane above the board. The board renders it AND carries its
+   *  toggle now, in the header beside Select — the same shape as the ruler and
+   *  waveform below. The window-event bus still reaches the same state (the
+   *  pane's own close button and the WebMCP `set_preview` tool arrive that
+   *  way), so this prop is a second caller rather than a replacement. */
   previewOn: boolean;
+  onPreviewToggle: () => void;
   /** The strip's time ruler. Its toggle lives in this header now (see
    *  `GraphRulerToggle`) and only mounts in flat mode, so the board both
    *  renders the state and asks for the change. */
@@ -1498,6 +1511,9 @@ export function GraphBoard({
   /** Strip's flat mode: render the whole closure in order, not this
    *  collection's direct children. */
   flatOn: boolean;
+  /** The closure is still loading. Strip-only, like `flatOn` itself. */
+  flatLoading: boolean;
+  onFlatToggle: () => void;
   /** Whether the nested-timeline tree renders below the focused surface. The
    *  toggle for it lives in this header now (see `GraphChildrenToggle`), so
    *  unlike the sidebar-driven flags around it the board both renders the
@@ -1780,16 +1796,29 @@ export function GraphBoard({
                   here is the row's original job: where you are, what you have
                   picked, and what you can do to it. */}
               <SelectModeButton />
+              {/* PREVIEW, beside Select. It was a tile in the icon rail, which
+                  gave it prominence but put it a long way from the board it
+                  opens over — and it is a VIEW toggle, which is what this end
+                  of the row is for. Ungated by surface deliberately: the pane
+                  plays the focused timeline in grid as well as strip, so
+                  hiding it in grid would remove a working control.
+
+                  Inside the fence with Select rather than out with the ruler
+                  pair, because those two are flat-mode only and come and go;
+                  these two are always here. */}
+              <HeaderToggle
+                active={previewOn}
+                onToggle={onPreviewToggle}
+                icon={TvMinimal}
+                label={previewOn ? "Hide preview" : "Show preview"}
+                title="Preview — play the focused timeline"
+              />
               <div aria-hidden="true" className="h-5 w-px shrink-0 bg-zinc-700" />
               {/* Ruler and waveform stay: they draw ONTO the strip rather than
                   changing what is on it, they are flat-mode only, and pairing
                   them with the surface controls to the right is what keeps
                   them out of the way in grid mode. The fence travels with them
-                  — an empty group between two fences is just a doubled line.
-
-                  PREVIEW is deliberately not here. It lives in the icon rail
-                  (see timeline-sidebar) because it is one of the two controls
-                  worth promoting to rail scale. */}
+                  — an empty group between two fences is just a doubled line. */}
               {flatOn ? (
                 <>
                   <HeaderToggle
@@ -1910,6 +1939,36 @@ export function GraphBoard({
                   group still sits right when the aggregate renders nothing —
                   an empty timeline would otherwise let it slide to the left. */}
               <div className="ml-auto flex min-w-0 items-center gap-2">
+                {/* COLLECTIONS leads this group. It came out of the icon rail:
+                    it qualifies WHAT THE BOARD SHOWS, which is this row's job,
+                    and it belongs beside the count and duration it changes —
+                    the flat run turns "3 clips" into every clip in the
+                    closure, and the two now move together.
+
+                    INVERTED against the state it drives. The strip opens flat
+                    (see `flatOn`'s default), so the thing left to offer is the
+                    nesting, and `active` is `!flatOn` — pressed means you have
+                    left the flat run for the collections. Writing it the other
+                    way round would give the strip a control that is lit on
+                    arrival and whose job is to turn itself off.
+
+                    Strip only, unchanged from the rail: grid keeps its nesting,
+                    so there is nothing to flatten there. */}
+                {surface === "strip" ? (
+                  <HeaderToggle
+                    active={!flatOn}
+                    onToggle={onFlatToggle}
+                    // `Layers` — the SAME glyph the collection mark uses in
+                    // the middle of every collection thumbnail (see
+                    // `data-collection-mark` in graph-collection-card). The
+                    // control that gives you the collections back should wear
+                    // the sign that marks one.
+                    icon={Layers}
+                    busy={flatLoading}
+                    label={flatOn ? "Show collections" : "Show all items in order"}
+                    title="Collections — group the run back into its collections. Flat, everything is in order and reordering is off."
+                  />
+                ) : null}
                 <TagFilterControl />
                 <GraphAddCollectionButton />
                 <HeaderToggle

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -259,7 +259,15 @@ export function GraphTimelineView({
   const [waveformOn, setWaveformOn] = useState(false);
   // Flat mode: every item in the focused closure, in order, no nesting.
   // Strip-only — grid has no equivalent, and leaving grid turns it off below.
-  const [flatOn, setFlatOn] = useState(false);
+  // STRIP OPENS FLAT. The strip is a time axis, and a run of every shot in
+  // order is what a time axis is for — collections are a way to ORGANISE that
+  // run, not the default way to read it. So the control below is inverted: it
+  // offers "Collections", and turning it on is what leaves the flat run.
+  //
+  // The cost, stated plainly: flat mode refuses `move-nodes` (see
+  // `commandPolicy`), so a strip that opens flat opens without drag-to-reorder
+  // until you switch to Collections.
+  const [flatOn, setFlatOn] = useState(initialSurface === "strip");
   const [flatLoading, setFlatLoading] = useState(false);
   const [timeChannel] = useState(createPreviewTimeChannel);
   // The sidebar owns the layout switch and the ruler toggle (its top icons /
@@ -287,6 +295,14 @@ export function GraphTimelineView({
   // window-event bridge exists only to reach the SIDEBAR across React trees —
   // a control that no longer lives there has no reason to pay for it.
   const toggleChildren = useCallback(() => setChildrenShown((current) => !current), []);
+  // The board's header owns this control now (it used to be a rail tile that
+  // reached in over the event bus). The bus listener above stays regardless —
+  // the pane's own close button and the WebMCP `set_preview` tool both still
+  // arrive that way, so this is a second caller, not a replacement.
+  const togglePreview = useCallback(() => setPreviewOn((current) => !current), []);
+  // Same move as preview: the control is in the board's controls row now, so
+  // it calls down through a prop. The bus listener stays for the WebMCP tool.
+  const toggleFlat = useCallback(() => setFlatOn((current) => !current), []);
   const toggleRuler = useCallback(() => setRulerOn((current) => !current), []);
   const toggleWaveform = useCallback(() => setWaveformOn((current) => !current), []);
 
@@ -311,7 +327,10 @@ export function GraphTimelineView({
   const [prevSurface, setPrevSurface] = useState(surface);
   if (prevSurface !== surface) {
     setPrevSurface(surface);
-    if (surface !== "strip" && flatOn) setFlatOn(false);
+    // Leaving the strip drops flat (grid has no flat run to show); arriving at
+    // it restores the strip's default rather than whatever the grid left
+    // behind. Both directions, so the strip is the same on every arrival.
+    setFlatOn(surface === "strip");
   }
 
   // The ruler is scoped to flat mode (its toggle only mounts there), so flat
@@ -826,11 +845,14 @@ export function GraphTimelineView({
                 pixelsPerSecond={pixelsPerSecond}
                 onPixelsPerSecondChange={setPixelsPerSecond}
                 previewOn={previewOn}
+                onPreviewToggle={togglePreview}
                 rulerOn={rulerOn}
                 onRulerToggle={toggleRuler}
                 waveformOn={waveformOn}
                 onWaveformToggle={toggleWaveform}
                 flatOn={flatOn}
+                flatLoading={flatLoading}
+                onFlatToggle={toggleFlat}
                 childrenShown={childrenShown}
                 onChildrenToggle={toggleChildren}
                 timeChannel={timeChannel}

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -7,7 +7,6 @@ import React, {
   useSyncExternalStore,
 } from "react";
 import {
-  ChevronsLeftRightEllipsis,
   Film,
   Folder,
   Image as ImageIcon,
@@ -16,7 +15,6 @@ import {
   PanelLeftClose,
   PanelLeftOpen,
   Trash2,
-  TvMinimal,
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -27,8 +25,6 @@ import {
   GRAPH_TRASH_HOVER_EVENT,
   GRAPH_VIEW_STATE_EVENT,
   isGraphViewRoute,
-  requestGraphFlatToggle,
-  requestGraphPreviewToggle,
   requestGraphSurface,
   type GraphSurface,
   type GraphViewStateDetail,
@@ -266,36 +262,10 @@ const SIDEBAR_ICON_PRESSED = [
  */
 const SIDEBAR_ICON_TOGGLE_ON =
   "text-sky-300 before:bg-sky-400/15 hover:text-sky-200 hover:before:bg-sky-400/25";
-/**
- * The rule between tile groups: longer than the glyphs it separates, with air
- * above and below.
- *
- * It has been both extremes. Flush against the tiles it disappeared into them;
- * as a short 28px hairline with 8px of margin it read as a gap the tiles had
- * fallen out of. What makes it work is the pill treatment above — the tiles no
- * longer run edge to edge either, so a wider rule with matching breathing room
- * sits in the same rhythm instead of interrupting one.
- */
-// Stated as an INSET, not a width, so it follows the rail.
-//
-// It was `mx-auto w-10` — 40px centred in the 72px rail, which is the same
-// thing as 16px of margin each side. Written that way it stayed 40px when the
-// rail opened to 232px, and a 40px rule adrift in the middle of a 232px column
-// reads as a mistake rather than as a divider. As an inset it is 40px closed
-// (identical to before) and 200px open, with no second value to keep in step
-// and nothing keyed to the open state — which is what stops it animating
-// separately from the width, the way the glyphs used to.
-const SIDEBAR_SEPARATOR_CLASS = "mx-4 my-2 h-px shrink-0";
-
-function SidebarSeparator() {
-  return (
-    <div
-      aria-hidden="true"
-      data-sidebar-separator="normal"
-      className={cn(SIDEBAR_SEPARATOR_CLASS, "bg-zinc-500")}
-    />
-  );
-}
+// The tile-group separator went with the tool group it divided (see the note
+// in the rail below). Nothing draws a rule between groups now: the layout
+// switch at the top and the utility stack at the bottom are already held apart
+// by the `mt-auto` that pins the latter to the floor.
 
 /**
  * The strip layout's glyph: lucide's `Film`, turned on its side.
@@ -624,102 +594,18 @@ export function TimelineSidebar() {
           </div>
         )}
 
-        {activeProjectId && (
-          <>
-            {/* zinc-500: the old zinc-800/80 vanished against the rail. */}
-            <SidebarSeparator />
+        {/* NO TOOL GROUP HERE ANY MORE — the separator went with its
+            contents.
 
-            <div className="flex w-full flex-col items-stretch gap-0">
-              {/* PREVIEW leads this group, directly under the separator.
+            Preview moved to the board's breadcrumb row beside Select; flat
+            mode moved to the controls row under it, leading the group that
+            already carried the filter, the tree and the zoom. Both were here
+            for prominence, and both are VIEW toggles that belong next to the
+            board they change — flat mode especially, since it rewrites the
+            very count and duration it now sits beside.
 
-                It is a toggle, not a destination, so it wears the tint rather
-                than the indicator bar — but it sits in the rail rather than
-                with the other toggles in the breadcrumb row because it is one
-                of the two controls worth calling out at rail scale. The rail
-                is where the eye goes first; giving up a slot there is how a
-                control gets promoted above the toolbar's noise.
-
-                Ungated by surface deliberately: the pane plays the focused
-                timeline in grid as well as strip, so hiding it in grid would
-                remove a working control. */}
-              {onGraphRoute && (
-                <button
-                  type="button"
-                  aria-pressed={graphView.previewOn}
-                  aria-label={
-                    graphView.previewOn ? "Hide preview" : "Show preview"
-                  }
-                  aria-describedby="sidebar-tooltip-preview"
-                  onClick={requestGraphPreviewToggle}
-                  className={cn(
-                    SIDEBAR_ICON_BASE,
-                    graphView.previewOn
-                      ? SIDEBAR_ICON_TOGGLE_ON
-                      : SIDEBAR_ICON_IDLE,
-                  )}
-                >
-                  <TvMinimal className={SIDEBAR_GLYPH} />
-                  <SidebarTooltipLabel
-                    id="sidebar-tooltip-preview"
-                    label="Preview"
-                    description="Play the focused timeline"
-                  />
-                </button>
-              )}
-
-              {/* The children-timelines toggle is in the board's breadcrumb row
-                (see graph-board), alongside the ruler. */}
-
-              {/* Flat mode — strip only. Grid keeps its nesting, so there is
-                nothing to flatten there. */}
-              {onGraphRoute && graphView.surface === "strip" && (
-                <button
-                  type="button"
-                  aria-pressed={graphView.flatOn}
-                  aria-label={
-                    graphView.flatOn
-                      ? "Show collections"
-                      : "Show all items in order"
-                  }
-                  aria-describedby="sidebar-tooltip-flat"
-                  aria-busy={graphView.flatLoading}
-                  onClick={requestGraphFlatToggle}
-                  className={cn(
-                    SIDEBAR_ICON_BASE,
-                    // TOGGLE, not a destination — see SIDEBAR_ICON_TOGGLE_ON.
-                    graphView.flatOn
-                      ? SIDEBAR_ICON_TOGGLE_ON
-                      : SIDEBAR_ICON_IDLE,
-                  )}
-                >
-                  <ChevronsLeftRightEllipsis
-                    className={cn(
-                      SIDEBAR_GLYPH,
-                      // Loading the closure can take a moment on a deep project,
-                      // and a half-built run would otherwise look like the real
-                      // answer.
-                      graphView.flatLoading ? "motion-safe:animate-pulse" : "",
-                    )}
-                  />
-                  <SidebarTooltipLabel
-                    id="sidebar-tooltip-flat"
-                    label="All items in order"
-                    description={
-                      graphView.flatLoading
-                        ? "Loading every collection…"
-                        : "One flat run — no collections. Reordering is off."
-                    }
-                  />
-                </button>
-              )}
-
-              {/* The time-ruler toggle moved to the board's breadcrumb row,
-                sitting left of the children toggle. It is still scoped to flat
-                mode and still appears and disappears with it — only its home
-                changed, joining the view controls it belongs with. */}
-            </div>
-          </>
-        )}
+            What the rail keeps is what says WHERE you are: the layout switch
+            at the top, the trash and the account at the bottom. */}
 
         <div className="relative mt-auto flex w-full flex-col items-stretch gap-0">
           {UTILITY_ITEMS.map((item) => {


### PR DESCRIPTION
Two controls leave the icon rail for the board they act on, and flat mode is inverted while it moves.

## Where things went

| control | was | now |
| --- | --- | --- |
| Preview | icon rail tile | breadcrumb row, **beside Select** |
| Flat / Collections | icon rail tile | controls row, **first in the right-hand group** (before the filter), strip only |

Preview sits inside the fence with Select rather than out with the ruler pair — those two are flat-only and come and go; these two are always there. Still ungated by surface, since the pane plays the focused timeline in grid as well as strip.

Flat mode now sits beside the count and duration it rewrites: **3 clips → 282 clips**.

## The strip opens flat

A strip is a time axis, and a run of every shot in order is what a time axis is for — collections organise that run rather than being the default way to read it.

So the control is **inverted**: it offers *Collections*, and `active` is `!flatOn`. Writing it the other way round would give the strip a control that is lit on arrival and whose only job is to turn itself off.

**The cost, stated plainly:** flat mode refuses `move-nodes` (`commandPolicy`), so a strip that opens flat opens **without drag-to-reorder** until you press Collections. Flagging it rather than burying it — it is a real change to what the strip does on arrival.

## The icon

`Layers` — the same glyph the collection mark uses in the middle of every collection thumbnail (`data-collection-mark` in `graph-collection-card`). Verified in the browser by comparing the rendered SVG paths, not just the import name:

```
collection card:  M12.83 2.18a2 2 0 0 0-1.66 0L2 | M2 12a1 1 0 0 0 .58.91l8.6 3.9 | …
toggle:           M12.83 2.18a2 2 0 0 0-1.66 0L2 | M2 12a1 1 0 0 0 .58.91l8.6 3.9 | …
sameGlyph: true
```

## Plumbing

Both toggles call down through props (`onPreviewToggle`, `onFlatToggle`) the way the ruler and children toggles already did. The window-event bus listeners stay — the pane's own close button and the WebMCP tools still arrive that way — so these are second callers, not replacements.

`HeaderToggle` grew an optional `busy`, so flat keeps the loading pulse it had in the rail: a deep closure takes a moment, and a half-built run would otherwise look like the real answer.

The rail's middle group is gone along with its contents, and the separator with it. What the rail keeps is what says *where you are*.

## Verified in the running app

- rail is down to Grid / Strip / Trash / Expand / Account
- breadcrumb row: `Select`, `Show preview`, then the flat-only ruler + waveform, then undo/redo
- controls row right group: `Show collections`, `Filter by tag`, `Add Collection`, `Show children timelines`, `Board options`
- arrival: **282 clips**, Collections `aria-pressed=false` → one press: **3 clips**, `aria-pressed=true` → press again: back

app **1177 passed**, `tsc --noEmit` clean, lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)