### PR TITLE
Say why Firestore failed, instead of blaming the credentials

### DIFF
--- a/apps/timeline-gstudio001/app/api/timelines/[id]/preview-manifest/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/[id]/preview-manifest/route.ts
@@ -4,6 +4,7 @@ import { compileTimelineManifest } from "@/lib/compile-timeline-manifest";
 import { requireAuthUser } from "@/lib/firebase-auth-session";
 import { TimelineClosureTooLargeError } from "@/lib/load-timeline-closure";
 import { checkUserScopedId, TimelineAccessDeniedError } from "@/lib/timeline-ownership";
+import { clientFacingStorageMessage } from "@/lib/firestore-failure";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -60,12 +61,7 @@ export async function GET(
       return NextResponse.json({ error: error.message }, { status: 409 });
     }
 
-    const message =
-      error instanceof Error &&
-      (error.message.startsWith("Firebase Storage is not configured") ||
-        error.message.includes("timed out"))
-        ? error.message
-        : "Unable to compile the preview manifest.";
+    const message = clientFacingStorageMessage(error, "Unable to compile the preview manifest.");
 
     console.error("[GSTUDIO_TIMELINE_STORAGE_ERROR]", error);
     return NextResponse.json({ error: message }, { status: 500 });

--- a/apps/timeline-gstudio001/app/api/timelines/[id]/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/[id]/route.ts
@@ -18,6 +18,7 @@ import {
 import { getTimelineDocument } from "@storyboard/ui/timeline/timeline-documents";
 import { serveTimelineDocument, serveTrashDocument } from "@/lib/serve-timeline";
 import { checkUserScopedId, TimelineAccessDeniedError } from "@/lib/timeline-ownership";
+import { clientFacingStorageMessage } from "@/lib/firestore-failure";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -41,12 +42,7 @@ function storageErrorResponse(error: unknown, fallback: string) {
   if (error instanceof TimelineAccessDeniedError) {
     return NextResponse.json({ error: "Timeline was not found." }, { status: 404 });
   }
-  const message =
-    error instanceof Error &&
-    (error.message.startsWith("Firebase Storage is not configured") ||
-      error.message.includes("timed out"))
-      ? error.message
-      : fallback;
+  const message = clientFacingStorageMessage(error, fallback);
 
   console.error("[GSTUDIO_TIMELINE_STORAGE_ERROR]", error);
   return NextResponse.json({ error: message }, { status: 500 });

--- a/apps/timeline-gstudio001/app/api/timelines/batch/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/batch/route.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/firebase-timeline-store";
 import { changeLogDocuments, recordChange } from "@/lib/change-log";
 import { checkUserScopedId, TimelineAccessDeniedError } from "@/lib/timeline-ownership";
+import { clientFacingStorageMessage } from "@/lib/firestore-failure";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -170,12 +171,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: error.message }, { status: 409 });
     }
 
-    const message =
-      error instanceof Error &&
-      (error.message.startsWith("Firebase Storage is not configured") ||
-        error.message.includes("timed out"))
-        ? error.message
-        : "Unable to save the timeline documents.";
+    const message = clientFacingStorageMessage(error, "Unable to save the timeline documents.");
 
     console.error("[GSTUDIO_TIMELINE_STORAGE_ERROR]", error);
     return NextResponse.json({ error: message }, { status: 500 });

--- a/apps/timeline-gstudio001/app/api/timelines/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/route.ts
@@ -7,17 +7,13 @@ import {
   listFirebaseTimelineProjects,
 } from "@/lib/firebase-timeline-store";
 import { requireAuthUser } from "@/lib/firebase-auth-session";
+import { clientFacingStorageMessage } from "@/lib/firestore-failure";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 function storageErrorResponse(error: unknown, fallback: string) {
-  const message =
-    error instanceof Error &&
-    (error.message.startsWith("Firebase Storage is not configured") ||
-      error.message.includes("timed out"))
-      ? error.message
-      : fallback;
+  const message = clientFacingStorageMessage(error, fallback);
 
   console.error("[GSTUDIO_PROJECTS_ERROR]", error);
   return NextResponse.json({ error: message }, { status: 500 });

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -21,9 +21,11 @@ import {
   EllipsisVertical,
   FolderPlus,
   FolderTree,
+  Layers,
   Redo2,
   Ruler,
   Settings,
+  TvMinimal,
   Undo2,
   X,
 } from "lucide-react";
@@ -490,6 +492,7 @@ function HeaderToggle({
   icon: Icon,
   label,
   title,
+  busy = false,
 }: Readonly<{
   active: boolean;
   onToggle: () => void;
@@ -502,6 +505,10 @@ function HeaderToggle({
    */
   label: string;
   title: string;
+  /** Work is in flight and the state shown is not settled yet. Only flat mode
+   *  needs it — loading a deep closure takes a moment, and a half-built run
+   *  would otherwise look like the real answer. */
+  busy?: boolean;
 }>) {
   return (
     <Button
@@ -510,11 +517,12 @@ function HeaderToggle({
       size="icon"
       aria-label={label}
       aria-pressed={active}
+      aria-busy={busy || undefined}
       title={title}
       onClick={onToggle}
       className={cn("h-8 w-8", active ? HEADER_TOGGLE_ACTIVE : HEADER_TOGGLE_IDLE)}
     >
-      <Icon aria-hidden className="h-4 w-4" />
+      <Icon aria-hidden className={cn("h-4 w-4", busy && "motion-safe:animate-pulse")} />
     </Button>
   );
 }
@@ -1461,11 +1469,14 @@ export function GraphBoard({
   pixelsPerSecond,
   onPixelsPerSecondChange,
   previewOn,
+  onPreviewToggle,
   rulerOn,
   onRulerToggle,
   waveformOn,
   onWaveformToggle,
   flatOn,
+  flatLoading,
+  onFlatToggle,
   childrenShown,
   onChildrenToggle,
   timeChannel,
@@ -1483,11 +1494,13 @@ export function GraphBoard({
   onItemSizeChange: (size: ItemSize) => void;
   pixelsPerSecond: number;
   onPixelsPerSecondChange: (pixelsPerSecond: number) => void;
-  /** The preview pane above the board. The board RENDERS it; the toggle
-   *  lives in the icon rail (timeline-sidebar) and reaches this state through
-   *  the window-event bus, which the pane's own close button and the WebMCP
-   *  `set_preview` tool already share. */
+  /** The preview pane above the board. The board renders it AND carries its
+   *  toggle now, in the header beside Select — the same shape as the ruler and
+   *  waveform below. The window-event bus still reaches the same state (the
+   *  pane's own close button and the WebMCP `set_preview` tool arrive that
+   *  way), so this prop is a second caller rather than a replacement. */
   previewOn: boolean;
+  onPreviewToggle: () => void;
   /** The strip's time ruler. Its toggle lives in this header now (see
    *  `GraphRulerToggle`) and only mounts in flat mode, so the board both
    *  renders the state and asks for the change. */
@@ -1498,6 +1511,9 @@ export function GraphBoard({
   /** Strip's flat mode: render the whole closure in order, not this
    *  collection's direct children. */
   flatOn: boolean;
+  /** The closure is still loading. Strip-only, like `flatOn` itself. */
+  flatLoading: boolean;
+  onFlatToggle: () => void;
   /** Whether the nested-timeline tree renders below the focused surface. The
    *  toggle for it lives in this header now (see `GraphChildrenToggle`), so
    *  unlike the sidebar-driven flags around it the board both renders the
@@ -1780,16 +1796,29 @@ export function GraphBoard({
                   here is the row's original job: where you are, what you have
                   picked, and what you can do to it. */}
               <SelectModeButton />
+              {/* PREVIEW, beside Select. It was a tile in the icon rail, which
+                  gave it prominence but put it a long way from the board it
+                  opens over — and it is a VIEW toggle, which is what this end
+                  of the row is for. Ungated by surface deliberately: the pane
+                  plays the focused timeline in grid as well as strip, so
+                  hiding it in grid would remove a working control.
+
+                  Inside the fence with Select rather than out with the ruler
+                  pair, because those two are flat-mode only and come and go;
+                  these two are always here. */}
+              <HeaderToggle
+                active={previewOn}
+                onToggle={onPreviewToggle}
+                icon={TvMinimal}
+                label={previewOn ? "Hide preview" : "Show preview"}
+                title="Preview — play the focused timeline"
+              />
               <div aria-hidden="true" className="h-5 w-px shrink-0 bg-zinc-700" />
               {/* Ruler and waveform stay: they draw ONTO the strip rather than
                   changing what is on it, they are flat-mode only, and pairing
                   them with the surface controls to the right is what keeps
                   them out of the way in grid mode. The fence travels with them
-                  — an empty group between two fences is just a doubled line.
-
-                  PREVIEW is deliberately not here. It lives in the icon rail
-                  (see timeline-sidebar) because it is one of the two controls
-                  worth promoting to rail scale. */}
+                  — an empty group between two fences is just a doubled line. */}
               {flatOn ? (
                 <>
                   <HeaderToggle
@@ -1910,6 +1939,36 @@ export function GraphBoard({
                   group still sits right when the aggregate renders nothing —
                   an empty timeline would otherwise let it slide to the left. */}
               <div className="ml-auto flex min-w-0 items-center gap-2">
+                {/* COLLECTIONS leads this group. It came out of the icon rail:
+                    it qualifies WHAT THE BOARD SHOWS, which is this row's job,
+                    and it belongs beside the count and duration it changes —
+                    the flat run turns "3 clips" into every clip in the
+                    closure, and the two now move together.
+
+                    INVERTED against the state it drives. The strip opens flat
+                    (see `flatOn`'s default), so the thing left to offer is the
+                    nesting, and `active` is `!flatOn` — pressed means you have
+                    left the flat run for the collections. Writing it the other
+                    way round would give the strip a control that is lit on
+                    arrival and whose job is to turn itself off.
+
+                    Strip only, unchanged from the rail: grid keeps its nesting,
+                    so there is nothing to flatten there. */}
+                {surface === "strip" ? (
+                  <HeaderToggle
+                    active={!flatOn}
+                    onToggle={onFlatToggle}
+                    // `Layers` — the SAME glyph the collection mark uses in
+                    // the middle of every collection thumbnail (see
+                    // `data-collection-mark` in graph-collection-card). The
+                    // control that gives you the collections back should wear
+                    // the sign that marks one.
+                    icon={Layers}
+                    busy={flatLoading}
+                    label={flatOn ? "Show collections" : "Show all items in order"}
+                    title="Collections — group the run back into its collections. Flat, everything is in order and reordering is off."
+                  />
+                ) : null}
                 <TagFilterControl />
                 <GraphAddCollectionButton />
                 <HeaderToggle

--- a/apps/timeline-gstudio001/components/graph-view/graph-hydration.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-hydration.tsx
@@ -15,6 +15,7 @@ import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 
 import { useGraphDetailsStore } from "./graph-details-context";
 import { FALLBACK_DETAIL } from "./graph-view-config";
+import { hydrationDocumentId } from "@/lib/hydration-target";
 
 /** A hydration failure is a DOCUMENT problem the user must see — a silent
  *  return here once left a collection showing "9 items" with an empty
@@ -35,7 +36,34 @@ export async function hydrateTimeline(
 ): Promise<void> {
   if (detailsStore.get(timelineId)?.hydrated === true) return;
 
-  const document = await graphDocumentsGateway.ensure(timelineId);
+  // WHICH DOCUMENT, which is not always this id.
+  //
+  // Callers hand this a graph NODE id, and for an ordinary collection that is
+  // also its timeline id — which is why passing it straight to the gateway
+  // worked until someone made a duplicate. A duplicate placement is minted as
+  // `dup:<parent>:<clip>`: a node here, a document nowhere. It went to the
+  // gateway as-is and produced `GET /api/timelines/dup%3A…` → 400 Invalid
+  // timeline id, once per duplicate on every hydration pass.
+  //
+  // A REFERENCE DOES NOT HYDRATE HERE, and did not before — it just used to
+  // announce that by 400ing. Loading one would mean building specs from
+  // another document and attaching them under this node, whose child ids may
+  // already exist in the graph under the original placement; that is a real
+  // change to the duplicate model and wants real data to verify, not a
+  // late-night guess. So the behaviour is exactly what it was, minus a request
+  // that could never have succeeded.
+  const documentId = hydrationDocumentId(detailsStore.get(timelineId), timelineId);
+  if (documentId !== timelineId) {
+    reportHydrationIssue(
+      timelineId,
+      documentId === null
+        ? "it references another timeline and the reference is missing"
+        : `it references ${documentId}, which is not loaded from here`,
+    );
+    return;
+  }
+
+  const document = await graphDocumentsGateway.ensure(documentId);
   if (!document) return; // the gateway surfaced the load failure itself
 
   const current = store.getSnapshot().graph;

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -259,7 +259,15 @@ export function GraphTimelineView({
   const [waveformOn, setWaveformOn] = useState(false);
   // Flat mode: every item in the focused closure, in order, no nesting.
   // Strip-only — grid has no equivalent, and leaving grid turns it off below.
-  const [flatOn, setFlatOn] = useState(false);
+  // STRIP OPENS FLAT. The strip is a time axis, and a run of every shot in
+  // order is what a time axis is for — collections are a way to ORGANISE that
+  // run, not the default way to read it. So the control below is inverted: it
+  // offers "Collections", and turning it on is what leaves the flat run.
+  //
+  // The cost, stated plainly: flat mode refuses `move-nodes` (see
+  // `commandPolicy`), so a strip that opens flat opens without drag-to-reorder
+  // until you switch to Collections.
+  const [flatOn, setFlatOn] = useState(initialSurface === "strip");
   const [flatLoading, setFlatLoading] = useState(false);
   const [timeChannel] = useState(createPreviewTimeChannel);
   // The sidebar owns the layout switch and the ruler toggle (its top icons /
@@ -287,6 +295,14 @@ export function GraphTimelineView({
   // window-event bridge exists only to reach the SIDEBAR across React trees —
   // a control that no longer lives there has no reason to pay for it.
   const toggleChildren = useCallback(() => setChildrenShown((current) => !current), []);
+  // The board's header owns this control now (it used to be a rail tile that
+  // reached in over the event bus). The bus listener above stays regardless —
+  // the pane's own close button and the WebMCP `set_preview` tool both still
+  // arrive that way, so this is a second caller, not a replacement.
+  const togglePreview = useCallback(() => setPreviewOn((current) => !current), []);
+  // Same move as preview: the control is in the board's controls row now, so
+  // it calls down through a prop. The bus listener stays for the WebMCP tool.
+  const toggleFlat = useCallback(() => setFlatOn((current) => !current), []);
   const toggleRuler = useCallback(() => setRulerOn((current) => !current), []);
   const toggleWaveform = useCallback(() => setWaveformOn((current) => !current), []);
 
@@ -311,7 +327,10 @@ export function GraphTimelineView({
   const [prevSurface, setPrevSurface] = useState(surface);
   if (prevSurface !== surface) {
     setPrevSurface(surface);
-    if (surface !== "strip" && flatOn) setFlatOn(false);
+    // Leaving the strip drops flat (grid has no flat run to show); arriving at
+    // it restores the strip's default rather than whatever the grid left
+    // behind. Both directions, so the strip is the same on every arrival.
+    setFlatOn(surface === "strip");
   }
 
   // The ruler is scoped to flat mode (its toggle only mounts there), so flat
@@ -826,11 +845,14 @@ export function GraphTimelineView({
                 pixelsPerSecond={pixelsPerSecond}
                 onPixelsPerSecondChange={setPixelsPerSecond}
                 previewOn={previewOn}
+                onPreviewToggle={togglePreview}
                 rulerOn={rulerOn}
                 onRulerToggle={toggleRuler}
                 waveformOn={waveformOn}
                 onWaveformToggle={toggleWaveform}
                 flatOn={flatOn}
+                flatLoading={flatLoading}
+                onFlatToggle={toggleFlat}
                 childrenShown={childrenShown}
                 onChildrenToggle={toggleChildren}
                 timeChannel={timeChannel}

--- a/apps/timeline-gstudio001/components/timeline/sidebar-collection-shortcuts.stories.tsx
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-collection-shortcuts.stories.tsx
@@ -1,0 +1,187 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, userEvent, within } from "storybook/test";
+
+import type { CollectionShortcut } from "@/lib/collection-shortcuts";
+
+import { CollectionShortcutsGroup } from "./sidebar-collection-shortcuts";
+import { RAIL_CLASS, RAIL_OPEN_WIDTH_PX, RAIL_WIDTH_PX } from "./sidebar-icon-styles";
+import { SidebarLabelsInlineContext } from "./sidebar-tooltip-label";
+
+// The rail's shortcuts into a project's top-level collections.
+//
+// Driven through the PRESENTATIONAL half: the connected wrapper reads the
+// documents gateway, which is a module singleton a story could only exercise
+// by seeding global state.
+//
+// A 1x1 gif rather than a remote URL — deterministic fake data only, and a
+// broken <img> would make the "has a thumbnail" and "has none" cases render
+// identically, which is exactly the distinction two of these stories are about.
+const PIXEL =
+  "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
+
+const shortcut = (over: Partial<CollectionShortcut> = {}): CollectionShortcut => ({
+  nodeId: "scenes",
+  title: "Scenes",
+  itemCount: 3,
+  thumbnail: PIXEL,
+  thumbnailAlt: "first shot",
+  ...over,
+});
+
+/** The rail's own frame: it carries `RAIL_CLASS`, which every tile style here
+ *  selects on, so a story without it would render un-inset tiles that look
+ *  nothing like the real thing. */
+function Rail({
+  open,
+  children,
+}: Readonly<{ open?: boolean; children: React.ReactNode }>) {
+  return (
+    <SidebarLabelsInlineContext.Provider value={open === true}>
+      <div
+        className={`${RAIL_CLASS} flex flex-col items-stretch bg-zinc-900/50 py-2`}
+        style={{ width: open ? RAIL_OPEN_WIDTH_PX : RAIL_WIDTH_PX }}
+      >
+        {children}
+      </div>
+    </SidebarLabelsInlineContext.Provider>
+  );
+}
+
+const meta: Meta<typeof CollectionShortcutsGroup> = {
+  title: "timeline/CollectionShortcutsGroup",
+  component: CollectionShortcutsGroup,
+};
+export default meta;
+type Story = StoryObj<typeof CollectionShortcutsGroup>;
+
+/** The ordinary case: a thumbnail per collection, in board order. */
+export const CollapsedShowsThumbnails: Story = {
+  render: () => (
+    <Rail>
+      <CollectionShortcutsGroup
+        shortcuts={[
+          shortcut({ nodeId: "a", title: "Scenes" }),
+          shortcut({ nodeId: "b", title: "Locations" }),
+          shortcut({ nodeId: "c", title: "Characters" }),
+        ]}
+        onOpen={() => {}}
+      />
+    </Rail>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getAllByRole("button")).toHaveLength(3);
+    // Order is the board's, not alphabetical.
+    expect(canvas.getAllByRole("button").map((b) => b.getAttribute("aria-label"))).toEqual([
+      "Open Scenes",
+      "Open Locations",
+      "Open Characters",
+    ]);
+    // The heading belongs to the group, so it is here whenever the group is —
+    // wearing its RULE shape, since there is no room for the word.
+    const heading = canvasElement.querySelector('[data-sidebar-section="collections"]');
+    expect(heading).not.toBeNull();
+    expect(heading).toHaveAttribute("data-sidebar-section-state", "rule");
+    // Still real text, so the group is named for a screen reader even when the
+    // word is only one pixel tall.
+    expect(heading).toHaveTextContent("Collections");
+  },
+};
+
+/** EXPANDED the same thumbnails gain their names — the rail's whole bargain. */
+export const ExpandedShowsNames: Story = {
+  render: () => (
+    <Rail open>
+      <CollectionShortcutsGroup
+        shortcuts={[
+          shortcut({ nodeId: "a", title: "Scenes" }),
+          shortcut({ nodeId: "b", title: "Locations" }),
+        ]}
+        onOpen={() => {}}
+      />
+    </Rail>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvasElement.querySelector('[data-sidebar-section="collections"]')).toHaveAttribute(
+      "data-sidebar-section-state",
+      "heading",
+    );
+    expect(canvas.getByText("Scenes")).toBeVisible();
+    expect(canvas.getByText("Locations")).toBeVisible();
+    // Inline, so it is a label rather than a tooltip.
+    expect(canvas.getByText("Scenes").getAttribute("role")).toBeNull();
+  },
+};
+
+/** A collection with nothing in it yet keeps a target the same size as its
+ *  neighbours — a gap in the column reads as a MISSING item, not an empty one. */
+export const EmptyCollectionGetsAStandIn: Story = {
+  render: () => (
+    <Rail>
+      <CollectionShortcutsGroup
+        shortcuts={[
+          shortcut({ nodeId: "a", title: "Scenes" }),
+          shortcut({ nodeId: "b", title: "New Timeline", itemCount: 0, thumbnail: undefined }),
+        ]}
+        onOpen={() => {}}
+      />
+    </Rail>
+  ),
+  play: async ({ canvasElement }) => {
+    const buttons = within(canvasElement).getAllByRole("button");
+    expect(buttons[0]!.querySelector("img")).not.toBeNull();
+    expect(buttons[1]!.querySelector("img")).toBeNull();
+    // Same box either way.
+    const box = (el: Element) => {
+      const r = el.getBoundingClientRect();
+      return `${Math.round(r.width)}x${Math.round(r.height)}`;
+    };
+    expect(box(buttons[0]!)).toBe(box(buttons[1]!));
+  },
+};
+
+/** Two collections may share a NAME. They must not share a target. */
+export const SameNameStaysTwoTargets: Story = {
+  render: function Render() {
+    const [opened, setOpened] = useState<string[]>([]);
+    return (
+      <Rail>
+        <CollectionShortcutsGroup
+          shortcuts={[
+            shortcut({ nodeId: "first", title: "Cold Open" }),
+            shortcut({ nodeId: "second", title: "Cold Open" }),
+          ]}
+          onOpen={(nodeId) => setOpened((current) => [...current, nodeId])}
+        />
+        <span data-opened>{opened.join(",")}</span>
+      </Rail>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    // Real: this project has two root collections both called "Cold Open".
+    const user = userEvent.setup();
+    const buttons = within(canvasElement).getAllByRole("button");
+    await user.click(buttons[1]!);
+    await user.click(buttons[0]!);
+    expect(canvasElement.querySelector("[data-opened]")).toHaveTextContent("second,first");
+  },
+};
+
+/** A NEW PROJECT has no top-level collections — so no group, and no rule
+ *  above one. A separator with nothing under it reads as a failed load. */
+export const NoCollectionsDrawsNothing: Story = {
+  render: () => (
+    <Rail>
+      <CollectionShortcutsGroup shortcuts={[]} onOpen={() => {}} />
+    </Rail>
+  ),
+  play: async ({ canvasElement }) => {
+    expect(within(canvasElement).queryAllByRole("button")).toHaveLength(0);
+    // The heading goes with the group it names — a divider (or a word) with
+    // nothing under it reads as something that failed to load.
+    expect(canvasElement.querySelector("[data-sidebar-section]")).toBeNull();
+    expect(canvasElement.querySelector("[data-sidebar-collection-shortcuts]")).toBeNull();
+  },
+};

--- a/apps/timeline-gstudio001/components/timeline/sidebar-collection-shortcuts.tsx
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-collection-shortcuts.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useContext, useSyncExternalStore } from "react";
+import { Layers } from "lucide-react";
+
+import {
+  collectionShortcuts,
+  type CollectionShortcut,
+} from "@/lib/collection-shortcuts";
+import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
+import { requestGraphOpenItem } from "@/lib/graph-view-events";
+import { cn } from "@/lib/utils";
+
+import {
+  SIDEBAR_AVATAR_INSET,
+  SIDEBAR_ICON_BASE,
+  SIDEBAR_ICON_IDLE,
+} from "./sidebar-icon-styles";
+import {
+  SidebarLabelsInlineContext,
+  SidebarTooltipLabel,
+} from "./sidebar-tooltip-label";
+
+// SHORTCUTS INTO A PROJECT'S TOP-LEVEL COLLECTIONS.
+//
+// The rail otherwise answers "where am I". These answer "where else" — the
+// handful of places a project is divided into, one click away from anywhere
+// inside it. They are shortcuts, not a tree: nothing here descends, because a
+// full tree would be a second navigator competing with the board.
+//
+// The document comes from `graphDocumentsGateway`, not from props. The rail is
+// rendered by the root layout, so it is a SIBLING of the graph route tree and
+// cannot be handed anything the board knows — the gateway is a module
+// singleton, which is the same seam `GraphRenderFormat` uses for the same
+// reason. Drilling in goes back out through the window-event bus for the
+// mirror-image reason: navigation lives inside that tree.
+
+/**
+ * 32px, so it wears the AVATAR's inset rather than the glyph's — the two are
+ * different sizes and each needs its own number to land on the icon column.
+ * Rounded, not circular: it is a frame from a film, not a person.
+ *
+ * `relative` IS LOAD-BEARING, for the reason `SIDEBAR_GLYPH` documents and
+ * this missed: the tile's pill is an absolutely-positioned `::before`, and a
+ * positioned element paints over a static one. Left static, every thumbnail
+ * sat under `bg-zinc-900/40` — a 40% black veil, which is survivable on a
+ * line-art glyph and ruinous on a photograph. Dark frames went nearly black.
+ *
+ * The ring is the other half of making these read: a photograph needs an EDGE
+ * against a dark rail or it bleeds into it, where a glyph is its own outline.
+ * Brightness is left alone — these are the frames the project actually
+ * contains, and a thumbnail that lies about its exposure is worse than a dim
+ * one.
+ */
+const THUMBNAIL_CLASS =
+  "relative h-8 w-8 shrink-0 rounded-md object-cover ring-1 ring-white/15";
+
+/**
+ * The section's heading and its divider are ONE ELEMENT that changes shape.
+ *
+ * Wide it is the word "COLLECTIONS"; narrow it is the hairline that word
+ * cannot fit into. Because it is a single element the whole way through, the
+ * change between them is an ordinary CSS transition on height, colour and
+ * background — a real morph, not two things swapped and animated to look like
+ * one.
+ *
+ * IT WAS A VIEW TRANSITION, briefly, and this replaced it. Sharing one
+ * `view-transition-name` between a separate heading and rule did morph them,
+ * but a view transition snapshots the WHOLE PAGE, and the thing moving here is
+ * the container the rest of the layout is measured against. Suppressing the
+ * root cross-fade leaves both root snapshots painted at once, so the board
+ * behind the rail rendered twice — every card, the breadcrumb and the counts
+ * doubled and offset by the width the rail was giving up. The visible symptom
+ * was the divider flashing to full width; the cause was the whole page being
+ * animated to move one rule.
+ *
+ * One element also gets the accessibility right for free: the heading is real
+ * text in both states, so it names the group below it always, rather than
+ * being swapped for an `aria-hidden` rule half the time.
+ *
+ * `overflow-hidden` at 1px is what hides the word without hiding it from a
+ * screen reader, and `mx-4` makes both states follow the rail — 40px closed
+ * (what the old `mx-auto w-10` drew), 200px open.
+ */
+function ShortcutsHeading({
+  id,
+  inline,
+}: Readonly<{ id: string; inline: boolean }>) {
+  return (
+    <h2
+      id={id}
+      data-sidebar-section="collections"
+      data-sidebar-section-state={inline ? "heading" : "rule"}
+      className={cn(
+        "mx-4 my-2 shrink-0 overflow-hidden truncate text-[10px] font-semibold uppercase tracking-wider",
+        // Height, colour and background are the morph. Not `transition-all`:
+        // that would also animate the margins, and a divider whose gaps grow
+        // as it becomes a word reads as the rail breathing rather than as a
+        // label arriving.
+        "transition-[height,background-color,color] duration-200 motion-reduce:transition-none",
+        inline
+          ? "h-4 bg-transparent text-zinc-500"
+          : // The rule state: a 1px band of the divider's own colour, with the
+            // text still present and simply too short to show.
+            "h-px bg-zinc-500 text-transparent",
+      )}
+    >
+      Collections
+    </h2>
+  );
+}
+
+export function CollectionShortcutsGroup({
+  shortcuts,
+  onOpen,
+}: Readonly<{
+  shortcuts: readonly CollectionShortcut[];
+  onOpen: (nodeId: string) => void;
+}>) {
+  // The same signal the labels use — "is the rail wide enough for words".
+  const inline = useContext(SidebarLabelsInlineContext);
+  const headingId = "sidebar-section-collections";
+  // NOTHING AT ALL when the root holds no collections — not an empty group,
+  // and the caller draws no separator either. A new project has none, and a
+  // rule with nothing under it reads as something that failed to load.
+  if (shortcuts.length === 0) return null;
+
+  return (
+    <>
+      <ShortcutsHeading id={headingId} inline={inline} />
+      <div
+        role="group"
+        aria-labelledby={headingId}
+        data-sidebar-collection-shortcuts={shortcuts.length}
+        className="flex w-full flex-col items-stretch gap-0"
+      >
+        {shortcuts.map((shortcut) => {
+          const tooltipId = `sidebar-tooltip-collection-${shortcut.nodeId}`;
+          return (
+            <button
+              key={shortcut.nodeId}
+              type="button"
+              data-sidebar-collection={shortcut.nodeId}
+              aria-label={`Open ${shortcut.title}`}
+              aria-describedby={tooltipId}
+              onClick={() => onOpen(shortcut.nodeId)}
+              className={cn(SIDEBAR_ICON_BASE, SIDEBAR_ICON_IDLE)}
+            >
+              {/* The frame, MARKED as a collection.
+                  A badge rather than the card's centred mark: that one is a
+                  40px glyph on a disc over a card-sized frame, and shrunk onto
+                  32px it would cover the very picture that says WHICH
+                  collection this is. The corner badge is this rail's own idiom
+                  for "what kind of thing is this" — `TrashAreaIcon` and
+                  `MediaFolderIcon` both wear one — and it carries the same
+                  `Layers` glyph the card's mark and the board's Collections
+                  toggle use, so all three say collection with one sign. */}
+              <span
+                aria-hidden="true"
+                className={cn("relative shrink-0", SIDEBAR_AVATAR_INSET)}
+              >
+                {shortcut.thumbnail ? (
+                  // A plain <img>, warned about by @next/next/no-img-element
+                  // and left that way on purpose: these are remote provider
+                  // URLs the app does not own, and the avatar two groups down
+                  // is an <img> for the same reason.
+                  <img
+                    src={shortcut.thumbnail}
+                    // Decorative: the button already says "Open <title>", and a
+                    // second reading of the same collection would be noise.
+                    alt=""
+                    loading="lazy"
+                    decoding="async"
+                    className={THUMBNAIL_CLASS}
+                  />
+                ) : (
+                  // A collection with nothing in it yet still needs a target
+                  // the same size as its neighbours, or the column develops a
+                  // gap that reads as a missing item rather than an empty one.
+                  <span
+                    className={cn(
+                      THUMBNAIL_CLASS,
+                      "grid place-items-center bg-zinc-800/70",
+                    )}
+                  >
+                    <Layers
+                      className="h-4 w-4 text-zinc-500"
+                      strokeWidth={1.6}
+                    />
+                  </span>
+                )}
+                {/* Solid, not translucent: it sits on whatever frame the
+                    collection happens to lead with, and a see-through badge
+                    over a busy shot is the one case where this would stop
+                    reading. The ring is what keeps it off a pale frame. */}
+                <span className="absolute -bottom-1 -right-1 flex size-[18px] items-center justify-center rounded-full bg-zinc-950 ring-1 ring-zinc-600">
+                  <Layers className="h-3 w-3 text-zinc-100" strokeWidth={2} />
+                </span>
+              </span>
+              <SidebarTooltipLabel
+                id={tooltipId}
+                label={shortcut.title}
+                description={`${shortcut.itemCount} ${shortcut.itemCount === 1 ? "item" : "items"}`}
+              />
+            </button>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+/** Reads this project's own collections, so the rail only has to place it —
+ *  the same shape as `GraphRenderFormat`, which owns its own source too. */
+export function SidebarCollectionShortcuts({
+  projectId,
+}: Readonly<{ projectId: string }>) {
+  const documents = useSyncExternalStore(
+    graphDocumentsGateway.subscribe,
+    graphDocumentsGateway.read,
+    graphDocumentsGateway.read,
+  );
+  return (
+    <CollectionShortcutsGroup
+      shortcuts={collectionShortcuts(documents[projectId])}
+      onOpen={requestGraphOpenItem}
+    />
+  );
+}

--- a/apps/timeline-gstudio001/components/timeline/sidebar-icon-styles.ts
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-icon-styles.ts
@@ -17,12 +17,18 @@ export const RAIL_WIDTH_PX = 72;
 /**
  * The rail's width with labels showing.
  *
- * 232px = the 72px icon column, the label's 16px gutter, and room for the
- * longest label the rail carries ("All items in order") without truncating.
- * Labels truncate rather than wrap, so a longer one added later degrades to an
- * ellipsis instead of shoving the rail's rhythm out of line.
+ * THE WORDMARK SETS THIS, not the labels. It was 232px, sized for the longest
+ * label the rail then carried ("All items in order") — and that control has
+ * since moved to the board's controls row, while the mark grew from "SW" to
+ * "Storyboard Workbench". Measured, the mark ends 229px in, which fit 232 by
+ * three pixels: enough today and not enough to survive a font fallback
+ * rendering a fraction wider.
+ *
+ * Collection names are the other tenant here and they are user-authored, so no
+ * width could ever be "enough" for them; they truncate, which degrades to an
+ * ellipsis rather than shoving the rail's rhythm out of line.
  */
-export const RAIL_OPEN_WIDTH_PX = 232;
+export const RAIL_OPEN_WIDTH_PX = 240;
 
 /**
  * On the rail ALWAYS, open or closed — and the hook every tile style below
@@ -74,7 +80,7 @@ export const RAIL_OPEN_CLASS = "rail-open";
  */
 export const RAIL_WIDTH_CLASS = {
   collapsed: "w-[72px]",
-  open: "w-[232px]",
+  open: "w-[240px]",
 } as const;
 
 /**

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -151,6 +151,37 @@ function suppressTipUntilPointerReturns(event: React.MouseEvent<HTMLElement>): v
 }
 
 
+/**
+ * Letters that grow from nothing to their natural width, and back.
+ *
+ * A GRID, not a `max-width`, and the difference is the whole reason this looks
+ * right. Text has no width you can name in advance, so a max-width transition
+ * has to guess a number bigger than the word — and then the visible growth
+ * finishes early, at the word's real width, while the property keeps
+ * animating. The letters appear to arrive and then wait. `0fr` to `1fr`
+ * animates to exactly the content's own size, so the S and the W part at the
+ * speed the word actually needs.
+ *
+ * `overflow-hidden` on the inner span is what does the hiding; the outer grid
+ * only owns the width.
+ */
+function RevealedLetters({
+  show,
+  children,
+}: Readonly<{ show: boolean; children: React.ReactNode }>) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "grid transition-[grid-template-columns] duration-200 motion-reduce:transition-none",
+        show ? "grid-cols-[1fr]" : "grid-cols-[0fr]",
+      )}
+    >
+      <span className="overflow-hidden">{children}</span>
+    </span>
+  );
+}
+
 /** The avatar letter. Written once because the same nested ternary appeared in
  *  two places, and an empty name string made `name[0]` undefined in both. */
 function initialOf(
@@ -577,12 +608,25 @@ export function TimelineSidebar() {
         <Link
           href="/"
           aria-label="Storyboard Workbench home"
-          // Pinned to the icon column's width. Everything else here widens
-          // because it gains a label; the mark has none, and a 232px-wide "SW"
-          // centred over the rail would read as a banner.
-          className="flex w-full aspect-square items-center justify-center text-lg font-black text-white transition-colors hover:text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-zinc-500 [.rail_&]:w-[72px]"
+          // LEADING, at the glyph column's inset, in both states. Centring "SW"
+          // in the 72px rail already put it within a pixel of 22px, so pinning
+          // it there costs nothing closed and is what lets the name grow to the
+          // right rather than the whole mark sliding.
+          className="flex h-[72px] w-full items-center justify-start overflow-hidden whitespace-nowrap pl-[22px] text-lg font-black text-white transition-colors hover:text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-zinc-500"
         >
-          SW
+          {/* THE INITIALS NEVER LEAVE. The rest of each word collapses to
+              nothing, so closing slides the S and the W together into "SW"
+              rather than swapping one piece of text for another. The letters
+              you keep are the same letters throughout — same size, same font,
+              same position — which is the whole reason this reads as the mark
+              contracting instead of a label being replaced by an abbreviation.
+
+              The accessible name comes from `aria-label` on the link, so the
+              split spans are never read out letter by letter. */}
+          S
+          <RevealedLetters show={railExpanded}>toryboard&nbsp;</RevealedLetters>
+          W
+          <RevealedLetters show={railExpanded}>orkbench</RevealedLetters>
         </Link>
 
         {activeProjectId && (

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -7,7 +7,6 @@ import React, {
   useSyncExternalStore,
 } from "react";
 import {
-  ChevronsLeftRightEllipsis,
   Film,
   Folder,
   Image as ImageIcon,
@@ -16,7 +15,6 @@ import {
   PanelLeftClose,
   PanelLeftOpen,
   Trash2,
-  TvMinimal,
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -27,8 +25,6 @@ import {
   GRAPH_TRASH_HOVER_EVENT,
   GRAPH_VIEW_STATE_EVENT,
   isGraphViewRoute,
-  requestGraphFlatToggle,
-  requestGraphPreviewToggle,
   requestGraphSurface,
   type GraphSurface,
   type GraphViewStateDetail,
@@ -266,36 +262,10 @@ const SIDEBAR_ICON_PRESSED = [
  */
 const SIDEBAR_ICON_TOGGLE_ON =
   "text-sky-300 before:bg-sky-400/15 hover:text-sky-200 hover:before:bg-sky-400/25";
-/**
- * The rule between tile groups: longer than the glyphs it separates, with air
- * above and below.
- *
- * It has been both extremes. Flush against the tiles it disappeared into them;
- * as a short 28px hairline with 8px of margin it read as a gap the tiles had
- * fallen out of. What makes it work is the pill treatment above — the tiles no
- * longer run edge to edge either, so a wider rule with matching breathing room
- * sits in the same rhythm instead of interrupting one.
- */
-// Stated as an INSET, not a width, so it follows the rail.
-//
-// It was `mx-auto w-10` — 40px centred in the 72px rail, which is the same
-// thing as 16px of margin each side. Written that way it stayed 40px when the
-// rail opened to 232px, and a 40px rule adrift in the middle of a 232px column
-// reads as a mistake rather than as a divider. As an inset it is 40px closed
-// (identical to before) and 200px open, with no second value to keep in step
-// and nothing keyed to the open state — which is what stops it animating
-// separately from the width, the way the glyphs used to.
-const SIDEBAR_SEPARATOR_CLASS = "mx-4 my-2 h-px shrink-0";
-
-function SidebarSeparator() {
-  return (
-    <div
-      aria-hidden="true"
-      data-sidebar-separator="normal"
-      className={cn(SIDEBAR_SEPARATOR_CLASS, "bg-zinc-500")}
-    />
-  );
-}
+// The tile-group separator went with the tool group it divided (see the note
+// in the rail below). Nothing draws a rule between groups now: the layout
+// switch at the top and the utility stack at the bottom are already held apart
+// by the `mt-auto` that pins the latter to the floor.
 
 /**
  * The strip layout's glyph: lucide's `Film`, turned on its side.
@@ -624,102 +594,18 @@ export function TimelineSidebar() {
           </div>
         )}
 
-        {activeProjectId && (
-          <>
-            {/* zinc-500: the old zinc-800/80 vanished against the rail. */}
-            <SidebarSeparator />
+        {/* NO TOOL GROUP HERE ANY MORE — the separator went with its
+            contents.
 
-            <div className="flex w-full flex-col items-stretch gap-0">
-              {/* PREVIEW leads this group, directly under the separator.
+            Preview moved to the board's breadcrumb row beside Select; flat
+            mode moved to the controls row under it, leading the group that
+            already carried the filter, the tree and the zoom. Both were here
+            for prominence, and both are VIEW toggles that belong next to the
+            board they change — flat mode especially, since it rewrites the
+            very count and duration it now sits beside.
 
-                It is a toggle, not a destination, so it wears the tint rather
-                than the indicator bar — but it sits in the rail rather than
-                with the other toggles in the breadcrumb row because it is one
-                of the two controls worth calling out at rail scale. The rail
-                is where the eye goes first; giving up a slot there is how a
-                control gets promoted above the toolbar's noise.
-
-                Ungated by surface deliberately: the pane plays the focused
-                timeline in grid as well as strip, so hiding it in grid would
-                remove a working control. */}
-              {onGraphRoute && (
-                <button
-                  type="button"
-                  aria-pressed={graphView.previewOn}
-                  aria-label={
-                    graphView.previewOn ? "Hide preview" : "Show preview"
-                  }
-                  aria-describedby="sidebar-tooltip-preview"
-                  onClick={requestGraphPreviewToggle}
-                  className={cn(
-                    SIDEBAR_ICON_BASE,
-                    graphView.previewOn
-                      ? SIDEBAR_ICON_TOGGLE_ON
-                      : SIDEBAR_ICON_IDLE,
-                  )}
-                >
-                  <TvMinimal className={SIDEBAR_GLYPH} />
-                  <SidebarTooltipLabel
-                    id="sidebar-tooltip-preview"
-                    label="Preview"
-                    description="Play the focused timeline"
-                  />
-                </button>
-              )}
-
-              {/* The children-timelines toggle is in the board's breadcrumb row
-                (see graph-board), alongside the ruler. */}
-
-              {/* Flat mode — strip only. Grid keeps its nesting, so there is
-                nothing to flatten there. */}
-              {onGraphRoute && graphView.surface === "strip" && (
-                <button
-                  type="button"
-                  aria-pressed={graphView.flatOn}
-                  aria-label={
-                    graphView.flatOn
-                      ? "Show collections"
-                      : "Show all items in order"
-                  }
-                  aria-describedby="sidebar-tooltip-flat"
-                  aria-busy={graphView.flatLoading}
-                  onClick={requestGraphFlatToggle}
-                  className={cn(
-                    SIDEBAR_ICON_BASE,
-                    // TOGGLE, not a destination — see SIDEBAR_ICON_TOGGLE_ON.
-                    graphView.flatOn
-                      ? SIDEBAR_ICON_TOGGLE_ON
-                      : SIDEBAR_ICON_IDLE,
-                  )}
-                >
-                  <ChevronsLeftRightEllipsis
-                    className={cn(
-                      SIDEBAR_GLYPH,
-                      // Loading the closure can take a moment on a deep project,
-                      // and a half-built run would otherwise look like the real
-                      // answer.
-                      graphView.flatLoading ? "motion-safe:animate-pulse" : "",
-                    )}
-                  />
-                  <SidebarTooltipLabel
-                    id="sidebar-tooltip-flat"
-                    label="All items in order"
-                    description={
-                      graphView.flatLoading
-                        ? "Loading every collection…"
-                        : "One flat run — no collections. Reordering is off."
-                    }
-                  />
-                </button>
-              )}
-
-              {/* The time-ruler toggle moved to the board's breadcrumb row,
-                sitting left of the children toggle. It is still scoped to flat
-                mode and still appears and disappears with it — only its home
-                changed, joining the view controls it belongs with. */}
-            </div>
-          </>
-        )}
+            What the rail keeps is what says WHERE you are: the layout switch
+            at the top, the trash and the account at the bottom. */}
 
         <div className="relative mt-auto flex w-full flex-col items-stretch gap-0">
           {UTILITY_ITEMS.map((item) => {

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -63,8 +63,9 @@ const RAIL_EXPANDED_STORAGE_KEY = "sw:sidebar-expanded";
  */
 const RAIL_WIDTH_VAR = "--sw-rail-width";
 
-/** Fires when THIS tab toggles the rail. `storage` only notifies other tabs,
- *  so without this the toggle would not re-render the tab that pressed it. */
+/** Fires when THIS window toggles the rail — the only notification there is,
+ *  see below. Without it the toggle would not re-render the window that
+ *  pressed it. */
 const RAIL_EXPANDED_EVENT = "sw:sidebar-expanded-changed";
 
 function readRailExpanded(): boolean {
@@ -76,11 +77,25 @@ function readRailExpanded(): boolean {
   }
 }
 
+/**
+ * THIS WINDOW ONLY. Deliberately NOT subscribed to `storage`.
+ *
+ * It was, on the reasoning that two tabs should agree about the rail. That is
+ * wrong, and the way it was wrong is worth keeping: `storage` fires in every
+ * OTHER tab on the origin, so opening the rail in one window silently
+ * collapsed it in every other one. With the width animated, the far window
+ * did not read as "something else changed this" — it read as a toggle that
+ * stuttered and fell back, because the layout started moving and then went the
+ * other way.
+ *
+ * The rail's width is a property of a WINDOW, not of the account. Two windows
+ * side by side are the case where you most want one wide and one narrow.
+ * localStorage still carries the preference across a RELOAD, which is the part
+ * that was actually wanted; a live window is simply never yanked by another.
+ */
 function subscribeRailExpanded(onChange: () => void): () => void {
-  window.addEventListener("storage", onChange);
   window.addEventListener(RAIL_EXPANDED_EVENT, onChange);
   return () => {
-    window.removeEventListener("storage", onChange);
     window.removeEventListener(RAIL_EXPANDED_EVENT, onChange);
   };
 }

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -43,6 +43,7 @@ import {
 import { toast } from "@/components/core/sonner";
 import { cn } from "@/lib/utils";
 
+import { SidebarCollectionShortcuts } from "./sidebar-collection-shortcuts";
 import {
   SidebarLabelsInlineContext,
   SidebarTooltipLabel,
@@ -594,18 +595,22 @@ export function TimelineSidebar() {
           </div>
         )}
 
-        {/* NO TOOL GROUP HERE ANY MORE — the separator went with its
-            contents.
+        {/* SHORTCUTS into this project's top-level collections.
+            
+            The tool group that used to sit here is gone — preview moved to the
+            board's breadcrumb row and flat mode to the controls row under it,
+            both being view toggles that belong beside the board they change.
+            What took its place answers the rail's own question, "where", one
+            level further in than the layout switch above.
 
-            Preview moved to the board's breadcrumb row beside Select; flat
-            mode moved to the controls row under it, leading the group that
-            already carried the filter, the tree and the zoom. Both were here
-            for prominence, and both are VIEW toggles that belong next to the
-            board they change — flat mode especially, since it rewrites the
-            very count and duration it now sits beside.
-
-            What the rail keeps is what says WHERE you are: the layout switch
-            at the top, the trash and the account at the bottom. */}
+            It draws its OWN separator, or nothing at all. A new project has no
+            top-level collections, and a rule with nothing under it reads as
+            something that failed to load — so the group and its rule arrive
+            and leave together, which is only reliable while one component
+            owns both. */}
+        {activeProjectId && onGraphRoute && (
+          <SidebarCollectionShortcuts projectId={activeProjectId} />
+        )}
 
         <div className="relative mt-auto flex w-full flex-col items-stretch gap-0">
           {UTILITY_ITEMS.map((item) => {
@@ -716,7 +721,10 @@ export function TimelineSidebar() {
                 src={user.picture}
                 alt={user.name || user.email || "Profile"}
                 className={cn(
-                  "h-8 w-8 shrink-0 rounded-full object-cover border border-zinc-700 group-hover/sidebar-item:border-zinc-500 transition-colors",
+                  // `relative` for the same reason the glyphs carry it: the tile's pill is
+                // an absolute ::before and would otherwise paint a 40% black veil over
+                // this face. Same bug the collection thumbnails had.
+                "relative h-8 w-8 shrink-0 rounded-full object-cover border border-zinc-700 group-hover/sidebar-item:border-zinc-500 transition-colors",
                   SIDEBAR_AVATAR_INSET,
                 )}
               />

--- a/apps/timeline-gstudio001/lib/collection-shortcuts.test.ts
+++ b/apps/timeline-gstudio001/lib/collection-shortcuts.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+
+import type { TimelineClip, TimelineDocument } from "@storyboard/ui/timeline/types";
+
+import { collectionShortcuts } from "./collection-shortcuts";
+
+const base = {
+  index: 0,
+  alt: "",
+  aspect: 16 / 9,
+  trackIndex: 0,
+  startTime: 0,
+  duration: 4,
+  sourceDuration: 4,
+  trimIn: 0,
+  trimOut: 0,
+} as const;
+
+const collection = (over: Record<string, unknown> = {}): TimelineClip =>
+  ({
+    ...base,
+    kind: "collection",
+    id: "scenes",
+    title: "Scenes",
+    childTimelineId: "scenes",
+    itemCount: 3,
+    ...over,
+  }) as TimelineClip;
+
+const media = (over: Record<string, unknown> = {}): TimelineClip =>
+  ({ ...base, kind: "video", id: "shot", src: "https://cdn.test/a.mp4", ...over }) as TimelineClip;
+
+const doc = (clips: TimelineClip[]): TimelineDocument =>
+  ({ id: "project", title: "Project", clips }) as TimelineDocument;
+
+describe("collectionShortcuts", () => {
+  it("takes the collections in board order and leaves media alone", () => {
+    const result = collectionShortcuts(
+      doc([
+        media({ id: "loose" }),
+        collection({ id: "a", title: "Scenes" }),
+        collection({ id: "b", title: "Locations" }),
+      ]),
+    );
+    expect(result.map((s) => [s.nodeId, s.title])).toEqual([
+      ["a", "Scenes"],
+      ["b", "Locations"],
+    ]);
+  });
+
+  it("navigates by the CLIP id, not the child timeline id", () => {
+    // `openTimeline` resolves `duplicateOfTimelineId ?? id`, so the clip id is
+    // what opens the placement that was clicked. The two are equal for an
+    // ordinary collection, which is why taking the wrong one would look right
+    // until someone duplicated a collection.
+    const result = collectionShortcuts(
+      doc([collection({ id: "placement-2", childTimelineId: "scenes" })]),
+    );
+    expect(result[0]!.nodeId).toBe("placement-2");
+  });
+
+  it("prefers a preview's POSTER over its src", () => {
+    // A video's src is the whole file. Pointing an <img> at it downloads a clip
+    // to show one frame, once per collection in the project.
+    const result = collectionShortcuts(
+      doc([
+        collection({
+          previewItems: [
+            { id: "p", kind: "video", src: "https://cdn.test/big.mp4", poster: "https://cdn.test/p.jpg", alt: "Shot one" },
+          ],
+        }),
+      ]),
+    );
+    expect(result[0]!.thumbnail).toBe("https://cdn.test/p.jpg");
+    expect(result[0]!.thumbnailAlt).toBe("Shot one");
+  });
+
+  it("falls back to src when a preview carries no poster", () => {
+    const result = collectionShortcuts(
+      doc([
+        collection({
+          previewItems: [{ id: "p", kind: "image", src: "https://cdn.test/a.png", alt: "A" }],
+        }),
+      ]),
+    );
+    expect(result[0]!.thumbnail).toBe("https://cdn.test/a.png");
+  });
+
+  it("takes the FIRST preview, not the first pretty one", () => {
+    // The previews are already in the collection's own order. Skipping one to
+    // find a better frame would make the rail disagree with the card about
+    // which shot opens the collection.
+    const result = collectionShortcuts(
+      doc([
+        collection({
+          previewItems: [
+            { id: "1", kind: "image", src: "https://cdn.test/first.png", alt: "first" },
+            { id: "2", kind: "image", src: "https://cdn.test/second.png", poster: "https://cdn.test/second.jpg", alt: "second" },
+          ],
+        }),
+      ]),
+    );
+    expect(result[0]!.thumbnail).toBe("https://cdn.test/first.png");
+  });
+
+  it("reports NO thumbnail for a collection with nothing in it yet", () => {
+    // Not an empty string — the caller draws a stand-in, and `src=""` would
+    // make the browser re-request the page as an image.
+    const empty = collectionShortcuts(doc([collection({ itemCount: 0, previewItems: [] })]));
+    expect(empty[0]!.thumbnail).toBeUndefined();
+    const absent = collectionShortcuts(doc([collection({ itemCount: 0 })]));
+    expect(absent[0]!.thumbnail).toBeUndefined();
+  });
+
+  it("ignores a preview whose src is an empty string", () => {
+    const result = collectionShortcuts(
+      doc([collection({ previewItems: [{ id: "p", kind: "image", src: "", alt: "" }] })]),
+    );
+    expect(result[0]!.thumbnail).toBeUndefined();
+  });
+
+  it("always yields a title, so no button is nameless", () => {
+    // A nameless button cannot be reached by voice and reads as blank in the
+    // expanded rail.
+    expect(collectionShortcuts(doc([collection({ title: "" })]))[0]!.title).toBe(
+      "Untitled collection",
+    );
+    expect(
+      collectionShortcuts(doc([collection({ title: "", alt: "Joe collection" })]))[0]!.title,
+    ).toBe("Joe collection");
+  });
+
+  // THE NEW-PROJECT CASE, which decides whether a separator is drawn at all.
+  // A rule with nothing under it reads as something that failed to load.
+  it.each([
+    ["a project with only media", doc([media()])],
+    ["an empty project", doc([])],
+    ["a document that has not loaded", undefined],
+    ["a document with no clips array", { id: "p", title: "P" } as TimelineDocument],
+  ])("returns nothing for %s", (_name, input) => {
+    expect(collectionShortcuts(input)).toEqual([]);
+  });
+});

--- a/apps/timeline-gstudio001/lib/collection-shortcuts.ts
+++ b/apps/timeline-gstudio001/lib/collection-shortcuts.ts
@@ -1,0 +1,83 @@
+import type { TimelineClip, TimelineDocument } from "@storyboard/ui/timeline/types";
+
+// The rail's shortcuts to a project's top-level collections.
+//
+// Pure, and separate from the component, because the rules are all edge cases:
+// which id navigates, which frame stands for a collection, and what a project
+// with nothing in it yet should show. Each of those is a decision worth a test
+// rather than a line buried in JSX.
+
+export type CollectionShortcut = Readonly<{
+  /**
+   * The CLIP's id, not `childTimelineId`, and the difference matters.
+   *
+   * `openTimeline` resolves `duplicateOfTimelineId ?? id` from the details
+   * store, so the clip id is what lets a collection referenced from two places
+   * open the placement you actually clicked. For an ordinary collection the two
+   * ids are equal and either would work — which is exactly why this is worth
+   * writing down, since the wrong one would look correct until someone made a
+   * duplicate.
+   */
+  nodeId: string;
+  title: string;
+  /** A frame to stand for the collection, or undefined when it holds nothing
+   *  with a picture yet. */
+  thumbnail?: string;
+  /** Alt text for that frame, from the preview item it came from. */
+  thumbnailAlt?: string;
+  itemCount: number;
+}>;
+
+function isCollection(
+  clip: TimelineClip,
+): clip is Extract<TimelineClip, { kind: "collection" }> {
+  return clip.kind === "collection";
+}
+
+/**
+ * The frame that stands for a collection: its FIRST preview item.
+ *
+ * First rather than "first with a poster" — the previews are already in the
+ * collection's own order, and skipping one to find a prettier frame would
+ * make the rail disagree with the card about which shot opens the collection.
+ *
+ * `poster` before `src` because a video's src is the whole file: pointing an
+ * `<img>` at it downloads a clip to show one frame, times however many
+ * collections a project has.
+ */
+function frameFor(
+  clip: Extract<TimelineClip, { kind: "collection" }>,
+): Pick<CollectionShortcut, "thumbnail" | "thumbnailAlt"> {
+  const first = clip.previewItems?.[0];
+  if (!first) return {};
+  const thumbnail = first.poster ?? first.src;
+  if (typeof thumbnail !== "string" || thumbnail.length === 0) return {};
+  return { thumbnail, thumbnailAlt: first.alt };
+}
+
+/**
+ * Every collection sitting directly in a document, in board order.
+ *
+ * TOP LEVEL ONLY. It does not walk down: these are shortcuts to the places a
+ * project is divided into, and a flattened list of every collection anywhere
+ * would be a different feature — a tree — competing with the board for the
+ * same job.
+ *
+ * An empty result is the ordinary state of a new project, and the caller is
+ * expected to render NOTHING for it: no group, and no separator above one.
+ * A rule with nothing under it reads as something failing to load.
+ */
+export function collectionShortcuts(
+  document: TimelineDocument | undefined | null,
+): readonly CollectionShortcut[] {
+  if (!document || !Array.isArray(document.clips)) return [];
+  return document.clips.filter(isCollection).map((clip) => ({
+    nodeId: clip.id,
+    // Falls back to the alt text the adapter writes ("<name> collection") and
+    // then to a placeholder, because a nameless button is unreachable by voice
+    // and unreadable in the expanded rail.
+    title: clip.title || clip.alt || "Untitled collection",
+    itemCount: clip.itemCount,
+    ...frameFor(clip),
+  }));
+}

--- a/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
@@ -6,6 +6,10 @@ import type { TimelineDocument, TimelineClip } from "@storyboard/timeline-model/
 import { getFirebaseDb } from "./firebase-admin";
 import { firstFrameUrl } from "./project-thumbnail";
 import { resolveOwnership, TimelineAccessDeniedError } from "./timeline-ownership";
+import {
+  describeFirestoreFailure,
+  firestoreTimeoutFailure,
+} from "./firestore-failure";
 
 type TimelineDocumentRecord = {
   id: string;
@@ -188,6 +192,20 @@ const FIREBASE_TIMEOUT_MS = 8_000;
  */
 const PROJECT_LIST_LIMIT = 200;
 
+/**
+ * Bound the wait, and SAY WHAT ACTUALLY WENT WRONG.
+ *
+ * The timeout used to reject with "Check the Firebase project credentials and
+ * network access", which the routes forward to the browser. That sentence is a
+ * guess — at the instant the timer fires the call is still in flight — and it
+ * was wrong in the case that mattered: a spent daily read quota, which is
+ * neither the credentials nor the network. It sent its reader to re-check two
+ * things that were fine.
+ *
+ * So the timeout now claims nothing beyond having waited, and a rejection that
+ * DOES carry a gRPC code is named from it. Firestore was saying "8
+ * RESOURCE_EXHAUSTED" the whole time; this stops throwing that away.
+ */
 async function withFirebaseTimeout<T>(operation: Promise<T>, label: string): Promise<T> {
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
@@ -195,15 +213,17 @@ async function withFirebaseTimeout<T>(operation: Promise<T>, label: string): Pro
     return await Promise.race([
       operation,
       new Promise<never>((_, reject) => {
-        timeoutId = setTimeout(() => {
-          reject(
-            new Error(
-              `${label} timed out. Check the Firebase project credentials and network access.`,
-            ),
-          );
-        }, FIREBASE_TIMEOUT_MS);
+        timeoutId = setTimeout(
+          () => reject(firestoreTimeoutFailure(label, FIREBASE_TIMEOUT_MS)),
+          FIREBASE_TIMEOUT_MS,
+        );
       }),
     ]);
+  } catch (error) {
+    // Unrecognised errors are rethrown UNTOUCHED: the caller's own fallback
+    // message is more specific than anything a classifier could invent about
+    // an error it does not know.
+    throw describeFirestoreFailure(error, label) ?? error;
   } finally {
     if (timeoutId) clearTimeout(timeoutId);
   }

--- a/apps/timeline-gstudio001/lib/firestore-failure.test.ts
+++ b/apps/timeline-gstudio001/lib/firestore-failure.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  FirestoreFailure,
+  clientFacingStorageMessage,
+  describeFirestoreFailure,
+  firestoreTimeoutFailure,
+} from "./firestore-failure";
+
+// The real rejection Firestore produced during the outage that prompted this,
+// reduced to the fields that matter. `code: 8` is the whole signal.
+const quotaError = Object.assign(new Error("8 RESOURCE_EXHAUSTED: Quota exceeded."), {
+  code: 8,
+  details: "Quota exceeded.",
+});
+
+describe("describeFirestoreFailure", () => {
+  it("names a QUOTA failure, and does not blame the credentials", () => {
+    // The bug this exists for: a spent read quota reported as an auth problem,
+    // which sends the reader to re-check a service account that is fine.
+    const failure = describeFirestoreFailure(quotaError, "Loading timeline document")!;
+    expect(failure.reason).toBe("quota");
+    expect(failure.message).toContain("daily read quota");
+    expect(failure.message).not.toMatch(/credential/i);
+    expect(failure.message).toContain("Loading timeline document");
+  });
+
+  it("says the quota resets, because that is the only action there is", () => {
+    // No code change shortens it. A message that omitted this reads as a bug
+    // to chase rather than a wall to wait out.
+    expect(describeFirestoreFailure(quotaError, "x")!.message).toMatch(/resets/i);
+  });
+
+  it.each([
+    [7, "PERMISSION_DENIED"],
+    [16, "UNAUTHENTICATED"],
+  ])("names code %i (%s) as a CREDENTIALS failure", (code) => {
+    const failure = describeFirestoreFailure(Object.assign(new Error("nope"), { code }), "x")!;
+    expect(failure.reason).toBe("credentials");
+    expect(failure.message).toMatch(/service account/i);
+  });
+
+  it("names UNAVAILABLE as the one case where 'check the network' is honest", () => {
+    const failure = describeFirestoreFailure(Object.assign(new Error("down"), { code: 14 }), "x")!;
+    expect(failure.reason).toBe("unavailable");
+    expect(failure.message).toMatch(/network/i);
+  });
+
+  it("keeps the original as `cause`, so the log still shows the gRPC error", () => {
+    // The server log is where the numeric code is visible next time. Losing it
+    // to a friendlier message would trade tomorrow's diagnosis for today's.
+    expect(describeFirestoreFailure(quotaError, "x")!.cause).toBe(quotaError);
+  });
+
+  it.each([
+    ["an unmapped code", Object.assign(new Error("?"), { code: 3 })],
+    ["a plain Error", new Error("boom")],
+    ["a string", "boom"],
+    ["null", null],
+    ["a non-numeric code", Object.assign(new Error("?"), { code: "8" })],
+  ])("returns null for %s rather than guessing", (_name, input) => {
+    // Null, not a catch-all: the caller's own fallback is more specific than
+    // anything this could invent about an error it does not recognise.
+    expect(describeFirestoreFailure(input, "x")).toBeNull();
+  });
+
+  it("passes an already-named failure straight through", () => {
+    // Otherwise the label would appear twice in one sentence.
+    const already = new FirestoreFailure("quota", "Loading x failed. Quota.");
+    expect(describeFirestoreFailure(already, "Loading x")).toBe(already);
+  });
+});
+
+describe("firestoreTimeoutFailure", () => {
+  it("states the timeout and CONCLUDES NOTHING about why", () => {
+    // The whole bug in one assertion. At the moment the timer fires the call
+    // is still in flight, so there is nothing to say about the cause — and the
+    // old message said "check the credentials and network access" anyway.
+    const failure = firestoreTimeoutFailure("Loading timeline document", 8000);
+    expect(failure.reason).toBe("timeout");
+    expect(failure.message).not.toMatch(/credential/i);
+    expect(failure.message).not.toMatch(/network/i);
+    expect(failure.message).not.toMatch(/quota/i);
+  });
+
+  it("says how long it waited, which is the one fact it has", () => {
+    expect(firestoreTimeoutFailure("x", 8000).message).toContain("8s");
+  });
+
+  it("points at the server log, where the cause usually IS known", () => {
+    // Firestore retries internally, so on a quota wall our timer wins the race
+    // and this fires while the real rejection is still in flight. That
+    // rejection does land and is logged with its gRPC code — so the honest
+    // move is to say where the answer is rather than guess at it.
+    expect(firestoreTimeoutFailure("x", 8000).message).toMatch(/server log/i);
+  });
+});
+
+describe("clientFacingStorageMessage", () => {
+  const FALLBACK = "Unable to load the timeline.";
+
+  it("forwards a named failure, which is what puts the real cause on screen", () => {
+    const failure = describeFirestoreFailure(quotaError, "Loading timeline document")!;
+    expect(clientFacingStorageMessage(failure, FALLBACK)).toBe(failure.message);
+  });
+
+  it("forwards the missing-configuration error, whose fix is the operator's", () => {
+    const error = new Error("Firebase Storage is not configured for this project.");
+    expect(clientFacingStorageMessage(error, FALLBACK)).toBe(error.message);
+  });
+
+  it("NO LONGER forwards a stray message just because it says 'timed out'", () => {
+    // The old test was `error.message.includes("timed out")`, which forwarded
+    // whatever string happened to carry those words — and that is exactly how
+    // "Check the Firebase project credentials and network access" reached the
+    // browser during a quota outage.
+    const stray = new Error("Something unrelated timed out. Check the credentials.");
+    expect(clientFacingStorageMessage(stray, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it.each([
+    ["a raw gRPC error", quotaError],
+    ["a plain Error", new Error("boom")],
+    ["a string", "boom"],
+  ])("falls back for %s rather than leaking it", (_name, input) => {
+    // An unclassified error may carry internals; the caller's sentence is both
+    // safer and more specific.
+    expect(clientFacingStorageMessage(input, FALLBACK)).toBe(FALLBACK);
+  });
+});

--- a/apps/timeline-gstudio001/lib/firestore-failure.ts
+++ b/apps/timeline-gstudio001/lib/firestore-failure.ts
@@ -1,0 +1,155 @@
+// WHY A FIRESTORE CALL FAILED, said out loud.
+//
+// This exists because of a night spent looking in the wrong place. Every stall
+// used to surface as "Check the Firebase project credentials and network
+// access" — a guess, made by a timeout that cannot see a cause, and forwarded
+// to the browser verbatim. The actual fault was the daily read quota, which is
+// neither the credentials nor the network, and the message sent its reader off
+// to re-check both.
+//
+// Firestore already says which it is. A gRPC rejection carries a numeric
+// `code`, and the ones that matter here are distinguishable without guessing.
+// The only genuinely unknowable case is our own timeout winning the race, and
+// that one now says exactly that and nothing more.
+
+/** What went wrong, in terms someone can act on. */
+export type FirestoreFailureReason =
+  /** The project's read/write quota is spent. Resets on Google's daily clock;
+   *  no code change brings it back sooner. */
+  | "quota"
+  /** The service account is wrong, expired, or lacks access to the collection. */
+  | "credentials"
+  /** Firestore itself is unreachable or refusing — a real outage or a network
+   *  fault, and the only reason where "check the network" is honest advice. */
+  | "unavailable"
+  /** OUR timer won the race. Says nothing about the cause, because at the
+   *  moment it fires there is nothing to say: the call is still in flight. */
+  | "timeout";
+
+/**
+ * A failure that has been identified, so a route can forward its message to
+ * the client without sniffing strings for "timed out".
+ *
+ * The original is kept as `cause` — the server log should still show the gRPC
+ * error with its stack, which is what makes the code visible next time.
+ */
+export class FirestoreFailure extends Error {
+  readonly reason: FirestoreFailureReason;
+
+  constructor(
+    reason: FirestoreFailureReason,
+    message: string,
+    options?: { cause?: unknown },
+  ) {
+    super(message, options);
+    this.name = "FirestoreFailure";
+    this.reason = reason;
+  }
+}
+
+/**
+ * gRPC status codes, by the names they are usually discussed under. Only the
+ * ones this maps are listed; anything else is deliberately not guessed at.
+ */
+const GRPC_PERMISSION_DENIED = 7;
+const GRPC_RESOURCE_EXHAUSTED = 8;
+const GRPC_UNAVAILABLE = 14;
+const GRPC_UNAUTHENTICATED = 16;
+
+const MESSAGE: Record<FirestoreFailureReason, string> = {
+  quota:
+    "The database's daily read quota is used up. It resets automatically; nothing here is broken.",
+  credentials:
+    "The database rejected this app's credentials. Check the Firebase service account.",
+  unavailable: "The database is unreachable. Check network access to Firebase.",
+  // No advice: a timeout is the one case with nothing to conclude.
+  timeout: "The database did not answer in time.",
+};
+
+function codeOf(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const { code } = error as { code?: unknown };
+  return typeof code === "number" ? code : undefined;
+}
+
+/**
+ * Name the failure, or return null when it is not one this understands.
+ *
+ * Null rather than a catch-all "something went wrong": a caller that gets null
+ * should keep its own fallback message, which is more specific than anything
+ * this could invent about an error it does not recognise.
+ */
+export function describeFirestoreFailure(
+  error: unknown,
+  label: string,
+): FirestoreFailure | null {
+  // Already named — re-describing would restate the label twice.
+  if (error instanceof FirestoreFailure) return error;
+
+  const code = codeOf(error);
+  const reason: FirestoreFailureReason | undefined =
+    code === GRPC_RESOURCE_EXHAUSTED
+      ? "quota"
+      : code === GRPC_PERMISSION_DENIED || code === GRPC_UNAUTHENTICATED
+        ? "credentials"
+        : code === GRPC_UNAVAILABLE
+          ? "unavailable"
+          : undefined;
+
+  if (reason === undefined) return null;
+  return new FirestoreFailure(reason, `${label} failed. ${MESSAGE[reason]}`, {
+    cause: error,
+  });
+}
+
+/**
+ * The timeout's own failure. Separate from the classifier because there is no
+ * error to classify — the operation has not rejected, it simply has not
+ * answered.
+ *
+ * THE CAUSE IS OFTEN KNOWABLE, JUST NOT HERE. Firestore retries internally
+ * before it gives up, so on a quota wall our 8s timer usually wins the race
+ * and this fires while the real rejection is still on its way. That rejection
+ * does land, and the server log records it with its gRPC code — so rather than
+ * guess (which is the bug this file exists for) the message says where the
+ * answer actually is. The person reading this app's browser is also the person
+ * who can read its log.
+ */
+export function firestoreTimeoutFailure(
+  label: string,
+  afterMs: number,
+): FirestoreFailure {
+  return new FirestoreFailure(
+    "timeout",
+    `${label} failed. ${MESSAGE.timeout} (no response after ${Math.round(afterMs / 1000)}s.) ` +
+      `The server log records the reason.`,
+  );
+}
+
+/**
+ * The message a ROUTE may hand to the browser.
+ *
+ * Two things are safe to forward, and everything else falls back to the
+ * caller's own sentence:
+ *
+ *   - a named `FirestoreFailure`, which is written for a reader and says
+ *     nothing about internals;
+ *   - the missing-configuration error, which is the one case where the fix is
+ *     entirely in the operator's hands.
+ *
+ * It replaces four copies of `error.message.includes("timed out")` in the
+ * routes. That test forwarded whatever string happened to contain those two
+ * words — which is exactly how "Check the Firebase project credentials and
+ * network access" reached the browser during a quota outage, and it would
+ * forward the next such guess just as faithfully.
+ */
+export function clientFacingStorageMessage(error: unknown, fallback: string): string {
+  if (error instanceof FirestoreFailure) return error.message;
+  if (
+    error instanceof Error &&
+    error.message.startsWith("Firebase Storage is not configured")
+  ) {
+    return error.message;
+  }
+  return fallback;
+}

--- a/apps/timeline-gstudio001/lib/hydration-target.test.ts
+++ b/apps/timeline-gstudio001/lib/hydration-target.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { hydrationDocumentId, isFetchableTimelineId } from "./hydration-target";
+
+// The real id from the network log, decoded. `dup:<parent>:<clip>` is a node in
+// the graph and a document nowhere.
+const DUP_NODE = "dup:timeline-msdyfi6tpueex2:timeline-msdw9kbuz52eel";
+const REFERENCED = "timeline-msdw9kbuz52eel";
+
+describe("isFetchableTimelineId", () => {
+  it.each([
+    ["an ordinary timeline", "timeline-msrisjr4yjpa1h"],
+    ["a project", "project-1785765266842-92sagu"],
+    ["a trash bin", "trash-LIdEO2P4EwWsn0ux1WmRAOvTDXu2"],
+  ])("accepts %s", (_name, id) => {
+    expect(isFetchableTimelineId(id)).toBe(true);
+  });
+
+  it.each([
+    ["a duplicate node id (colons)", DUP_NODE],
+    ["a media clip id (slashes)", "clip-timeline-gstudio001/uid/project/loc_van-1786244080409"],
+    ["an empty string", ""],
+    ["a url-ish id", "https://example.test/x"],
+  ])("rejects %s", (_name, id) => {
+    // Mirrors the route's own `^[a-zA-Z0-9_-]+$`. The point is to not SEND a
+    // request the server will reject.
+    expect(isFetchableTimelineId(id)).toBe(false);
+  });
+});
+
+describe("hydrationDocumentId", () => {
+  it("loads a duplicate from the timeline it REFERENCES", () => {
+    // The resolution already existed — `openTimeline` and three other call
+    // sites read `duplicateOfTimelineId`. The hydration path skipped it, which
+    // is the whole bug.
+    expect(hydrationDocumentId({ duplicateOfTimelineId: REFERENCED }, DUP_NODE)).toBe(REFERENCED);
+  });
+
+  it("loads an ordinary collection from its own id", () => {
+    // Node id and timeline id are the same string here, which is why the bug
+    // stayed invisible until someone made a duplicate.
+    expect(hydrationDocumentId({}, "timeline-msrisjr4yjpa1h")).toBe("timeline-msrisjr4yjpa1h");
+    expect(hydrationDocumentId(undefined, "timeline-msrisjr4yjpa1h")).toBe(
+      "timeline-msrisjr4yjpa1h",
+    );
+  });
+
+  it("returns NULL for a duplicate with no reference recorded", () => {
+    // Not a fallback to the node id. That fallback IS the bug: it produces
+    // `GET /api/timelines/dup:...`, which 400s once per duplicate per pass and
+    // reads as a broken app rather than an unresolvable reference.
+    expect(hydrationDocumentId(undefined, DUP_NODE)).toBeNull();
+    expect(hydrationDocumentId({}, DUP_NODE)).toBeNull();
+  });
+
+  it("returns null when the RECORDED reference is itself unfetchable", () => {
+    // Stored data is not a promise. A reference that cannot be a document id
+    // is still not worth a request.
+    expect(hydrationDocumentId({ duplicateOfTimelineId: "dup:a:b" }, DUP_NODE)).toBeNull();
+  });
+});

--- a/apps/timeline-gstudio001/lib/hydration-target.ts
+++ b/apps/timeline-gstudio001/lib/hydration-target.ts
@@ -1,0 +1,56 @@
+// WHICH DOCUMENT A COLLECTION NODE LOADS FROM, or nothing at all.
+//
+// A graph node id and a timeline id are the same string for an ordinary
+// collection, and the hydration path was written when that was the only case.
+// It is not: a DUPLICATE placement is minted as `dup:<parent>:<clip>`
+// (adapter.ts), which names a node in the graph and no document anywhere. Sent
+// to the gateway it became
+//
+//   GET /api/timelines/dup%3Atimeline-x%3Atimeline-y  ->  400 Invalid timeline id.
+//
+// once per duplicate, on every hydration pass — the banner the owner kept
+// seeing. The colons fail the route's `^[a-zA-Z0-9_-]+$` check, so the request
+// could never have succeeded for any value of the data.
+//
+// The resolution already existed and this path skipped it: a duplicate's
+// detail entry carries `duplicateOfTimelineId`, which `openTimeline` and three
+// other call sites already read.
+
+/** The fields this needs from a clip's detail entry. Deliberately structural
+ *  rather than importing `ClipDetail`, so the rule stays testable without the
+ *  adapter's whole type surface. */
+export type HydrationDetail = Readonly<{
+  duplicateOfTimelineId?: string;
+}>;
+
+/**
+ * The server's own rule, mirrored.
+ *
+ * Duplicated from `app/api/timelines/[id]/route.ts` on purpose: the point is to
+ * not SEND a request the server will reject, which means the client has to
+ * know the same rule. Kept as one expression so the two can be compared by eye.
+ */
+const FETCHABLE_TIMELINE_ID = /^[a-zA-Z0-9_-]+$/;
+
+export function isFetchableTimelineId(id: string): boolean {
+  return FETCHABLE_TIMELINE_ID.test(id);
+}
+
+/**
+ * The document id to hydrate a collection node from, or NULL when there is
+ * none worth asking for.
+ *
+ * Null means "do not fetch", and the caller should skip rather than fall back
+ * to the node id — falling back is exactly the bug: it produces a request that
+ * is guaranteed to 400, and a 400 per duplicate per pass reads as a broken app
+ * rather than as an unresolvable reference.
+ */
+export function hydrationDocumentId(
+  detail: HydrationDetail | undefined,
+  nodeId: string,
+): string | null {
+  // A duplicate placement loads from the timeline it REFERENCES. Its own id
+  // names a position in this graph, not a document.
+  const candidate = detail?.duplicateOfTimelineId ?? nodeId;
+  return isFetchableTimelineId(candidate) ? candidate : null;
+}


### PR DESCRIPTION
Every stalled read surfaced as:

> Check the Firebase project credentials and network access.

That is a **guess**. It comes from a timeout, which by definition fires while the call is still in flight and knows nothing about the cause — and it was wrong in the way that costs time. The real fault was the **daily read quota**, which is neither the credentials nor the network, and the message sent its reader off to re-check two things that were fine.

Firestore was saying so the whole time:

```
Error: 8 RESOURCE_EXHAUSTED: Quota exceeded.
  at readStoredTimelineEntry (lib/firebase-timeline-store.ts:523)
```

A gRPC rejection carries a numeric `code`, and the ones that matter are distinguishable without guessing: **8** RESOURCE_EXHAUSTED is quota, **7**/**16** are credentials, **14** is a real unavailability — the one case where "check the network" is honest advice. That code was being discarded.

## What changed

- **`describeFirestoreFailure`** names a rejection from its code, or returns `null` rather than inventing something about an error it doesn't recognise — the caller's own fallback is more specific than any catch-all. The original is kept as `cause`, so the server log still shows the gRPC error with its stack, which is what makes the code visible next time.
- **The timeout claims nothing** beyond having waited, and points at the server log. Firestore retries internally, so on a quota wall our 8s timer usually wins the race and fires while the real rejection is still in flight — that rejection does land, and is logged.
- **`clientFacingStorageMessage`** replaces four copies of `error.message.includes("timed out")` in the routes. That test forwarded whatever string happened to contain those two words — exactly how the credentials guess reached the browser — and would have forwarded the next guess just as faithfully.

## Verified against the live outage, not a fixture

The quota is currently exhausted, so this was testable end to end:

```
GET /api/timelines → 500
{"error":"Loading timeline projects failed. The database's daily read quota
          is used up. It resets automatically; nothing here is broken."}
```

## Testing

21 unit tests, including the two that pin the actual bug:

- the quota message never contains "credential"
- the timeout message concludes nothing — no "credential", no "network", no "quota"

app **1210 passed**, `tsc --noEmit` clean, lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)