### PR TITLE
Stop legacy clips from making a document unwritable forever

### DIFF
--- a/packages/timeline-domain/src/adapter.test.ts
+++ b/packages/timeline-domain/src/adapter.test.ts
@@ -5,6 +5,9 @@ import {
   packTimelineClips,
 } from "@storyboard/ui/timeline/timeline-documents";
 import type { TimelineClip, TimelineDocument } from "@storyboard/ui/timeline/types";
+// The REAL write gate, so "the server would accept this projection" is
+// asserted rather than approximated by an expected array.
+import { isStoredTimelineDocument } from "@storyboard/timeline-model/validate";
 
 import {
   buildFocusedGraph,
@@ -591,7 +594,21 @@ describe("duplicate collection-reference demotion", () => {
     });
   });
 
-  it("round-trips both references back to their stored id and child pointer", () => {
+  it("writes the duplicate back as a REFERENCE, not a second owning placement", () => {
+    // This expectation used to be the opposite — both clips round-tripped to
+    // the stored id, on the rule that a synthetic id must never leak into
+    // storage. That was right until the batch endpoint grew its duplicate-owner
+    // guard, because ownership is SPELT `id === childTimelineId`: writing the
+    // stored id back spells a second owning placement, and the server now
+    // refuses the whole batch with
+    //
+    //   409 Refusing to give <id> a second owning placement.
+    //
+    // A document that already contains one (a real one sat in the trash bin,
+    // from an item trashed, restored and trashed again) could then never be
+    // written again — which stopped every delete, everywhere, since the bin is
+    // per-user and every delete rewrites it. Keeping the stored id was
+    // faithful; it was faithful to something the model no longer permits.
     const built = buildFocusedGraph({ scene: DOUBLED }, "scene", 2);
     if (!built.ok) throw new Error(built.error);
 
@@ -601,11 +618,42 @@ describe("duplicate collection-reference demotion", () => {
       parseNodeId("scene"),
     );
 
-    // A demoted node must not leak its synthetic id into storage.
-    expect(clips.map((clip) => clip.id)).toEqual([SAME, SAME]);
+    // The first placement OWNS the child and keeps the stored id untouched.
+    // The second points at the same child under its own id, which is exactly
+    // what "must be a reference, not an owning placement" asks for.
+    expect(clips.map((clip) => clip.id)).toEqual([SAME, `dup:scene:${SAME}`]);
     expect(
       clips.map((clip) => (clip.kind === "collection" ? clip.childTimelineId : null)),
     ).toEqual([SAME, SAME]);
+
+    // The server's rule, applied to the projection: one owner per child.
+    const owners = clips.filter(
+      (clip) => clip.kind === "collection" && clip.id === clip.childTimelineId,
+    );
+    expect(owners).toHaveLength(1);
+  });
+
+  it("re-reads to the same id, so the repair does not churn on every save", () => {
+    // The written id is derived from the document id and the stored clip id,
+    // and re-reading demotes to that same synthetic id — so a second save
+    // produces identical bytes rather than minting `dup:...~` forever.
+    const built = buildFocusedGraph({ scene: DOUBLED }, "scene", 2);
+    if (!built.ok) throw new Error(built.error);
+    const once = graphChildrenToClips(built.value.graph, built.value.details, parseNodeId("scene"));
+
+    const reread = buildFocusedGraph(
+      { scene: { id: "scene", title: "Scene", clips: once } },
+      "scene",
+      2,
+    );
+    if (!reread.ok) throw new Error(reread.error);
+    const twice = graphChildrenToClips(
+      reread.value.graph,
+      reread.value.details,
+      parseNodeId("scene"),
+    );
+
+    expect(twice.map((clip) => clip.id)).toEqual(once.map((clip) => clip.id));
   });
 });
 
@@ -857,6 +905,41 @@ describe("hydrated collection previewItems", () => {
     expect(clip.previewItems).toEqual([
       { id: "p1", kind: "image", src: "https://example.com/p1.jpg", alt: "p1" },
     ]);
+  });
+
+  // A placeholder's stored frames are carried through UNTOUCHED — which is
+  // right for a stale frame and wrong for an impossible one. A legacy AUDIO
+  // frame (written before either deriver learned to skip audio) is refused by
+  // the write gate, so carrying it back out made the document unwritable: the
+  // batch 400ed, and because the collection in question lived in the TRASH
+  // BIN, which every delete rewrites, deleting anything failed.
+  //
+  // The projection is checked against the REAL gate rather than an expected
+  // array, because "the server would accept this" is the actual claim.
+  it("drops an unpaintable stored frame instead of re-emitting it", () => {
+    const documents = docsWithStalePreview();
+    delete documents.kid; // still a placeholder — nothing live to re-derive from
+    const poisoned = documents["stale-root"].clips[0];
+    if (poisoned?.kind !== "collection") throw new Error("expected a collection clip");
+    // Assigned through an untyped view on purpose: this frame is not
+    // expressible in the current model, which is exactly its history — it was
+    // written when the model was looser, and no writer can produce one today.
+    (poisoned as { previewItems: unknown }).previewItems = [
+      // Audio has a `src`, so every check except the kind passes.
+      { id: "audio-80b79709", kind: "audio", src: "https://example.com/vo.flac", alt: "VO" },
+      { id: "p1", kind: "image", src: "https://example.com/p1.jpg", alt: "p1" },
+    ];
+
+    const focused = buildFocusedGraph(documents, "stale-root");
+    if (!focused.ok) throw new Error(focused.error);
+    const clips = graphChildrenToClips(focused.value.graph, focused.value.details, "stale-root");
+
+    expect(clips[0]?.kind === "collection" && clips[0].previewItems).toEqual([
+      { id: "p1", kind: "image", src: "https://example.com/p1.jpg", alt: "p1" },
+    ]);
+    expect(
+      isStoredTimelineDocument({ id: "stale-root", title: "Stale root", clips }),
+    ).toBe(true);
   });
 });
 

--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -35,6 +35,7 @@ import { tagsField } from "@storyboard/timeline-model/tags";
 // answers to "which lane is this clip on" would move layered clips on save.
 import { placedStartOf, trackIndexOf } from "@storyboard/timeline-model/documents";
 import { layerFrameOf } from "@storyboard/timeline-model/layer-frame";
+import { previewItemsOf } from "@storyboard/timeline-model/preview-items";
 import type {
   AssetSourceRef,
   CollectionTimelineClip,
@@ -816,9 +817,21 @@ export function graphChildrenToClips(
     // Hydrated collections DERIVE their preview frames from live children (see
     // hydratedCollectionPreviewItems) — same stale-summary rule duration and
     // itemCount already follow; placeholders keep the stored summary.
+    //
+    // The stored summary is DEFENDED before either branch reads it, because
+    // this is where it re-enters a write. A placeholder's frames are carried
+    // through verbatim (there are no live children to re-derive from) and the
+    // hydrated branch can still fall back to them, so both paths could put a
+    // stored frame back on the wire. One legacy AUDIO frame — written before
+    // either deriver learned to skip audio — is refused by the write gate, and
+    // because it was on a collection sitting in the TRASH BIN, which every
+    // delete rewrites, it made deleting anything fail with a 400 that named
+    // three innocent documents. Dropping it here lets the next write heal the
+    // document instead of failing on it forever.
+    const storedPreviewItems = previewItemsOf(detail?.previewItems);
     const previewItems = detail?.hydrated
-      ? hydratedCollectionPreviewItems(graph, details, node.id, detail.previewItems)
-      : detail?.previewItems;
+      ? hydratedCollectionPreviewItems(graph, details, node.id, storedPreviewItems)
+      : storedPreviewItems;
     // The playable READOUT beside the layout duration above, derived live for
     // the same self-healing reason. Omitted when it equals the layout span, so
     // a closure with nothing disabled never grows the field.
@@ -827,12 +840,36 @@ export function graphChildrenToClips(
       : detail?.playableDuration;
     const playableDuration = playable === duration ? undefined : playable;
     advance(trackIndex, startTime + duration + CLIP_GAP_SECONDS);
+    const childTimelineId = detail?.duplicateOfTimelineId ?? (node.id as string);
+    const storedClipId = detail?.sourceClipId ?? (node.id as string);
     return {
-      id: detail?.sourceClipId ?? (node.id as string),
+      // OWNERSHIP IS SPELT `id === childTimelineId`, so a demoted duplicate
+      // must not be spelt that way.
+      //
+      // Reading one already demotes it to a non-navigable reference card, but
+      // that demotion lived only in memory: `sourceClipId` round-tripped the
+      // stored clip id back out, and a duplicate's stored id normally IS its
+      // child pointer (both minting paths make them equal). So the write
+      // faithfully reproduced two owning placements of one collection — which
+      // is what the batch endpoint's duplicate-owner guard exists to refuse:
+      //
+      //   409 Refusing to give <id> a second owning placement.
+      //
+      // Faithful round-tripping was right before that guard existed. Now it
+      // makes the document permanently unwritable, and a trash bin holding one
+      // (an item trashed, restored, and trashed again) blocked every delete in
+      // every project, because the bin is per-user and every delete rewrites
+      // it. The synthetic node id is what this card is already identified by
+      // here, it is stable across reads of the same document, and re-reading it
+      // demotes to the same id again — so the repair is idempotent rather than
+      // minting a fresh id on every save.
+      id: detail?.duplicateOfTimelineId !== undefined && storedClipId === childTimelineId
+        ? (node.id as string)
+        : storedClipId,
       index,
       kind: "collection",
       title: node.name,
-      childTimelineId: detail?.duplicateOfTimelineId ?? (node.id as string),
+      childTimelineId,
       // Hydrated collections report their LIVE child count (nesting a clip
       // into one must not persist the stale stored count); placeholders keep
       // the stored count — their emptiness is unhydrated, not real.

--- a/packages/timeline-model/index.ts
+++ b/packages/timeline-model/index.ts
@@ -4,6 +4,7 @@ export * from "./constants";
 export * from "./documents";
 export * from "./placement";
 export * from "./layer-frame";
+export * from "./preview-items";
 export * from "./render-format";
 export * from "./validate";
 export * from "./clip-display";

--- a/packages/timeline-model/preview-items.test.ts
+++ b/packages/timeline-model/preview-items.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+
+import { isPreviewItem, previewItemsOf, type PreviewItemKind } from "./preview-items";
+import type { MediaKind } from "./types";
+import { isStoredTimelineDocument } from "./validate";
+
+// The frame that broke deleting, copied from the batch payload the app actually
+// sent. A collection of audio clips, trashed months ago, carrying a preview
+// item minted before either deriver learned to skip audio.
+const AUDIO_FRAME = {
+  id: "audio-80b79709",
+  kind: "audio",
+  src: "https://res.cloudinary.com/drrxyckxi/video/upload/v1786295742/x.flac",
+  alt: "Audio collection",
+};
+
+const PICTURE_FRAME = {
+  id: "video-ms3r9bxk5v9z47",
+  kind: "video" as const,
+  src: "https://res.cloudinary.com/drrxyckxi/video/upload/v1/shot.mp4",
+  poster: "https://res.cloudinary.com/drrxyckxi/video/upload/v1/shot.jpg",
+  trimIn: 1.5,
+  alt: "Cold open",
+};
+
+// `PreviewItemKind` restates `MediaKind` so this module stays a leaf. These two
+// lines are the restatement's guard: if either union grows a member the other
+// lacks, one of them stops being assignable and this file fails to compile.
+type Extends<A, B> = A extends B ? true : false;
+const _previewKindsAreMediaKinds: Extends<PreviewItemKind, MediaKind> = true;
+const _mediaKindsArePreviewKinds: Extends<MediaKind, PreviewItemKind> = true;
+
+describe("isPreviewItem", () => {
+  it("accepts a picture, with and without its optional fields", () => {
+    expect(isPreviewItem(PICTURE_FRAME)).toBe(true);
+    expect(isPreviewItem({ id: "i", kind: "image", src: "s", alt: "a" })).toBe(true);
+    // Optional fields tolerate null as well as undefined — Firestore
+    // round-trips produce nulls, the same leniency every optional field here
+    // is given.
+    expect(isPreviewItem({ ...PICTURE_FRAME, poster: null, trimIn: null })).toBe(true);
+  });
+
+  it("REFUSES an audio frame", () => {
+    // The whole reason this module exists. Audio has a `src`, so every check
+    // except the kind passes — which is how one reached storage and stayed
+    // there.
+    expect(isPreviewItem(AUDIO_FRAME)).toBe(false);
+  });
+
+  it.each([
+    ["a missing id", { ...PICTURE_FRAME, id: undefined }],
+    ["a non-string src", { ...PICTURE_FRAME, src: 42 }],
+    ["a missing alt", { ...PICTURE_FRAME, alt: undefined }],
+    ["a non-string poster", { ...PICTURE_FRAME, poster: 7 }],
+    ["a negative trimIn", { ...PICTURE_FRAME, trimIn: -1 }],
+    ["a NaN trimIn", { ...PICTURE_FRAME, trimIn: Number.NaN }],
+    ["an unknown kind", { ...PICTURE_FRAME, kind: "collection" }],
+    ["null", null],
+    ["a string", "video"],
+  ])("refuses %s", (_name, value) => {
+    expect(isPreviewItem(value)).toBe(false);
+  });
+
+  it("does NOT require id, src or alt to be non-empty", () => {
+    // Deliberately as lenient as the gate was before this module existed.
+    // Tightening it would start refusing documents that save fine today, which
+    // is a separate decision from the one made here.
+    expect(isPreviewItem({ id: "", kind: "image", src: "", alt: "" })).toBe(true);
+  });
+});
+
+describe("previewItemsOf", () => {
+  it("drops the unpaintable frame and keeps the rest, in order", () => {
+    const kept = previewItemsOf([PICTURE_FRAME, AUDIO_FRAME, { ...PICTURE_FRAME, id: "b" }]);
+    expect(kept?.map((item) => item.id)).toEqual(["video-ms3r9bxk5v9z47", "b"]);
+  });
+
+  it("returns the ORIGINAL array when nothing is dropped", () => {
+    // The common path must not allocate or change identity.
+    const stored = [PICTURE_FRAME];
+    expect(previewItemsOf(stored)).toBe(stored);
+  });
+
+  it("keeps EMPTY and ABSENT apart", () => {
+    // `resolveCollectionPreviews` chooses with `stored ?? live`, so collapsing
+    // [] to undefined would change which one wins for a collection that
+    // genuinely stores no frames.
+    expect(previewItemsOf([])).toEqual([]);
+    expect(previewItemsOf(undefined)).toBeUndefined();
+    expect(previewItemsOf(null)).toBeUndefined();
+  });
+
+  it("returns an EMPTY list when every frame is unpaintable", () => {
+    // Still a stored answer, and the honest one: an audio-only collection has
+    // no frame, so its card goes blank rather than painting a .flac as an
+    // <img> — which is what it did before.
+    expect(previewItemsOf([AUDIO_FRAME])).toEqual([]);
+  });
+
+  it("treats a non-list as absent", () => {
+    expect(previewItemsOf("frames")).toBeUndefined();
+    expect(previewItemsOf({ 0: PICTURE_FRAME })).toBeUndefined();
+  });
+});
+
+describe("the write gate and the normalizer agree", () => {
+  const documentWith = (previewItems: unknown) => ({
+    id: "trash-LIdEO2P4EwWsn0ux1WmRAOvTDXu2",
+    title: "Trash Bin",
+    clips: [
+      {
+        id: "timeline-msrk3310t3k7n7",
+        index: 0,
+        kind: "collection",
+        title: "Audio collection",
+        childTimelineId: "timeline-msrk3310t3k7n7",
+        itemCount: 2,
+        alt: "Audio collection",
+        aspect: 16 / 9,
+        trackIndex: 0,
+        startTime: 0,
+        duration: 4,
+        sourceDuration: 4,
+        trimIn: 0,
+        trimOut: 0,
+        previewItems,
+      },
+    ],
+  });
+
+  it("refuses the document the app could not save", () => {
+    // The 400 the batch endpoint returned, reproduced. Every delete rewrites
+    // the trash bin, so this one clip made deleting anything impossible.
+    expect(isStoredTimelineDocument(documentWith([AUDIO_FRAME]))).toBe(false);
+  });
+
+  it("accepts the same document once the normalizer has been through it", () => {
+    // The pair that matters: what the gate refuses, `previewItemsOf` removes —
+    // so a write can heal the document instead of failing on it forever.
+    expect(isStoredTimelineDocument(documentWith(previewItemsOf([AUDIO_FRAME])))).toBe(true);
+  });
+});

--- a/packages/timeline-model/preview-items.ts
+++ b/packages/timeline-model/preview-items.ts
@@ -1,0 +1,96 @@
+// THE FRAMES A COLLECTION CARD BORROWS, defended rather than trusted.
+//
+// A collection has no art of its own, so it stores up to three frames taken
+// from its media descendants. Both writers that DERIVE those frames already
+// refuse audio — `previewItemsFrom` filters to `isVisualClip`, and the graph
+// adapter's live walk skips `mediaKind === "audio"` — because an audio source
+// has a `src` and would otherwise be painted as an <img> pointing at a .flac.
+//
+// Neither of those guards helps a document that already contains one. An
+// UNHYDRATED collection's stored frames are carried through to the next write
+// verbatim (nobody has loaded its children, so there is nothing to re-derive
+// from), and the write gate rejects a preview item whose kind is not a picture.
+// So one legacy audio frame, written before those guards existed, made every
+// batch containing that collection fail:
+//
+//   POST /api/timelines/batch -> 400 Every batch write needs a valid timeline
+//                                    document.
+//
+// The collection in question sat in the TRASH BIN, which every delete rewrites.
+// The delete applied to the board, the save 400ed, and the whole batch — the
+// source collection, the project, the bin — rolled back. Deleting anything was
+// impossible, and the reason was one unpaintable frame on an unrelated item
+// nobody had opened in weeks.
+//
+// A stored value that the write gate will reject must never be carried forward
+// untouched. So the predicate lives HERE and is shared: `validate` refuses a
+// document that contains a bad frame (a writer that produced one skipped a
+// step, and waving it through is how it spreads), while `previewItemsOf` drops
+// it on the way through, so the next write self-heals the document instead of
+// failing forever.
+
+/**
+ * Mirrors `MediaKind`, declared here rather than imported so this module stays
+ * a leaf that `types.ts` can depend on — the shape `layer-frame.ts` and
+ * `render-format.ts` already follow.
+ *
+ * Restating it is also the point: a preview item is a PICTURE. If `MediaKind`
+ * ever grows a third kind, that kind has to be admitted here deliberately
+ * rather than inherited into a slot that gets painted as an image. The test
+ * pins the two together so the restatement cannot silently drift.
+ */
+export type PreviewItemKind = "image" | "video";
+
+/** One borrowed frame: exactly the fields a collection card paints. */
+export type CollectionPreviewItem = {
+  id: string;
+  kind: PreviewItemKind;
+  src: string;
+  poster?: string;
+  /** Source-time offset represented by a video preview. Absent means 0. */
+  trimIn?: number;
+  alt: string;
+};
+
+/**
+ * Whether one stored entry is a frame this app can paint.
+ *
+ * The rules are exactly the ones the write gate applied before this module
+ * existed — deliberately not tightened. `id`, `src` and `alt` may be empty
+ * strings here; refusing those would start rejecting documents that save fine
+ * today, which is a separate decision from the one this file exists to make.
+ */
+export function isPreviewItem(value: unknown): value is CollectionPreviewItem {
+  if (!value || typeof value !== "object") return false;
+  const item = value as Record<string, unknown>;
+  return (
+    typeof item.id === "string" &&
+    (item.kind === "image" || item.kind === "video") &&
+    typeof item.src === "string" &&
+    typeof item.alt === "string" &&
+    (item.poster == null || typeof item.poster === "string") &&
+    (item.trimIn == null ||
+      (typeof item.trimIn === "number" && Number.isFinite(item.trimIn) && item.trimIn >= 0))
+  );
+}
+
+/**
+ * Stored preview frames with anything unpaintable removed.
+ *
+ * ABSENT AND EMPTY STAY DIFFERENT. `resolveCollectionPreviews` chooses between
+ * the stored frames and a live walk with `stored ?? live`, so collapsing an
+ * empty list to `undefined` would change which one wins for a collection that
+ * genuinely stores none. A list that loses every entry therefore returns `[]`
+ * — it is still a stored answer, and the honest one for a collection whose
+ * only frame was a sound file: the card goes blank, which is what an audio
+ * collection looks like.
+ *
+ * Returns the ORIGINAL array when nothing was dropped, so the common path
+ * neither allocates nor changes identity.
+ */
+export function previewItemsOf(value: unknown): CollectionPreviewItem[] | undefined {
+  // Not a list at all — including null/undefined — is the same as having none.
+  if (!Array.isArray(value)) return undefined;
+  const kept = value.filter(isPreviewItem);
+  return kept.length === value.length ? (value as CollectionPreviewItem[]) : kept;
+}

--- a/packages/timeline-model/types.ts
+++ b/packages/timeline-model/types.ts
@@ -8,6 +8,7 @@
 // through view state in the legacy pipeline.
 
 import type { LayerFrame } from "./layer-frame";
+import type { CollectionPreviewItem } from "./preview-items";
 import type { RenderFormat } from "./render-format";
 
 export type MediaKind = "image" | "video";
@@ -247,15 +248,7 @@ export type CollectionTimelineClip = TimelineItemBase & {
    * collection is disabled — then `duration` already is the playable time.
    */
   playableDuration?: number;
-  previewItems?: Array<{
-    id: string;
-    kind: MediaKind;
-    src: string;
-    poster?: string;
-    /** Source-time offset represented by a video preview. Absent means 0. */
-    trimIn?: number;
-    alt: string;
-  }>;
+  previewItems?: CollectionPreviewItem[];
 };
 
 export type TimelineClip = MediaTimelineClip | CollectionTimelineClip;

--- a/packages/timeline-model/validate.ts
+++ b/packages/timeline-model/validate.ts
@@ -8,6 +8,7 @@
 // numeric must be a finite number (NaN/Infinity poison packing).
 
 import { layerFrameOf } from "./layer-frame";
+import { isPreviewItem } from "./preview-items";
 import { renderFormatOf } from "./render-format";
 import { areTagsValid } from "./tags";
 import type { TimelineClip, TimelineDocument } from "./types";
@@ -184,19 +185,15 @@ export function isTimelineClip(value: unknown): value is TimelineClip {
     }
     if (clip.previewItems == null) return true;
     if (!Array.isArray(clip.previewItems)) return false;
-    return clip.previewItems.every((item) => {
-      if (!item || typeof item !== "object") return false;
-      const preview = item as Record<string, unknown>;
-      return (
-        typeof preview.id === "string" &&
-        (preview.kind === "image" || preview.kind === "video") &&
-        typeof preview.src === "string" &&
-        typeof preview.alt === "string" &&
-        isOptionalString(preview.poster) &&
-        // A source offset, so the same rule its clip-level twin follows.
-        isOptionalNonNegative(preview.trimIn)
-      );
-    });
+    // Delegated for the same reason `layerFrame` and `renderFormat` are: the
+    // WRITE gate and the READ normalizer must agree about which stored frames
+    // are real. They did not, and the disagreement was unrecoverable — a
+    // legacy AUDIO frame failed here while `previewItemsOf` did not yet exist
+    // to drop it, so the document could not be rewritten and every batch
+    // carrying it 400ed forever. Still a REFUSAL rather than a filter: a bad
+    // frame arriving at this gate means a writer skipped the normalizer, and
+    // waving it through is how one spreads.
+    return clip.previewItems.every(isPreviewItem);
   }
 
   return false;


### PR DESCRIPTION
Deleting anything failed, at any item count. The board applied the delete, the save came back 400, and three documents announced they could not be saved.

Two stored clips, both written when the model was looser, both carried back out verbatim by the write projection, and both now refused by a gate that did not exist when they were written. Neither could ever be repaired, because repairing a document means writing it.

| Stored shape | Refused with | Why the write path reproduced it |
| --- | --- | --- |
| A preview frame of `kind: "audio"` | `400 Every batch write needs a valid timeline document.` | Both derivers already skip audio, but an UNHYDRATED collection has no live children to re-derive from, so its stored frames are carried through untouched. |
| One collection filed twice as an OWNING placement | `409 Refusing to give <id> a second owning placement.` | Reading demotes the second to a reference card in memory only; `sourceClipId` wrote the stored id back out, and a collection clip's stored id IS its child pointer — which is how ownership is spelt. |

Both sat in the trash bin, which is per-user and rewritten by every delete, so one bad clip from 4 August stopped deleting in every project.

## The fix

- `previewItemsOf` defends stored frames the way `layerFrameOf` and `renderFormatOf` already defend theirs, **sharing one predicate with the write gate** so the two cannot drift apart again. Still a refusal at the gate — a bad frame arriving there means a writer skipped the normalizer.
- A demoted duplicate writes under **its own id**, which is what "must be a reference, not an owning placement" asks for. Re-reading demotes to that same id, so the repair is idempotent rather than minting a new one per save.

No migration script: the next successful write heals the document.

## Verification

Both regression tests were **proven to fail first** against the unfixed adapter.

- 769 unit, 1227 app tests, `tsc` clean in `packages/ui` and the app, lint clean.
- Against the real project: delete → `200`, "All changes saved"; deleting the **last** item leaves the collection empty and it is still empty after a reload (`clips: 0`, revision advanced). The bin now reports `stillDuplicated: []` and zero unpaintable frames — both legacy defects healed themselves through the normal write path.

The round-trip test that pinned the old duplicate behaviour is updated rather than deleted; it was faithful to a model that no longer permits what it asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)