### PR TITLE
The collections divider is as long as the words it replaces

### DIFF
--- a/apps/timeline-gstudio001/components/timeline/sidebar-collection-shortcuts.stories.tsx
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-collection-shortcuts.stories.tsx
@@ -134,6 +134,50 @@ export const ExpandedShowsNames: Story = {
   },
 };
 
+/**
+ * THE HEADING IS AS WIDE AS ITS WORDS, and nothing wider.
+ *
+ * It collapses into the divider, and the divider is this same element with a
+ * 1px height and a background — so its width IS the rule's length. Left to
+ * stretch it filled the rail's gutter (207px measured, against 125px of
+ * lettering), and the collapse drew a bar 82px longer than the label it was
+ * replacing. Reported twice; the first fix made the morph one element, which
+ * was right and did not touch the length.
+ *
+ * Asserted as a RELATIONSHIP — box against its own text — rather than against
+ * a pixel count, which would only pin today's font and today's wording.
+ *
+ * Two rules make it hold and BOTH are load-bearing, which is why this checks
+ * the outcome rather than the class list: `self-start` (the rail is a column
+ * flex with `items-stretch`, so `w-fit` alone is inert) and a max-width (a
+ * `truncate`d box cannot shrink below `min-content`, which `nowrap` makes
+ * equal to `max-content`).
+ */
+export const TheHeadingIsAsWideAsItsWords: Story = {
+  render: () => (
+    <Rail open>
+      <CollectionShortcutsGroup
+        shortcuts={[shortcut({ nodeId: "a", title: "Scenes" })]}
+        onOpen={() => {}}
+      />
+    </Rail>
+  ),
+  play: async ({ canvasElement }) => {
+    const heading = canvasElement.querySelector<HTMLElement>(
+      '[data-sidebar-section="collections"]',
+    )!;
+    const rail = heading.parentElement!;
+    const headingWidth = heading.getBoundingClientRect().width;
+    const gutter = rail.getBoundingClientRect().width;
+
+    // It fits its own lettering: no leftover box either side of the words.
+    expect(headingWidth).toBeCloseTo(heading.scrollWidth, 0);
+    // And it is meaningfully NARROWER than the space it is allowed, which is
+    // the part stretching broke — the numbers were identical before.
+    expect(headingWidth).toBeLessThan(gutter - 32);
+  },
+};
+
 /** A collection with nothing in it yet keeps a target the same size as its
  *  neighbours — a gap in the column reads as a MISSING item, not an empty one. */
 export const EmptyCollectionGetsAStandIn: Story = {

--- a/apps/timeline-gstudio001/components/timeline/sidebar-collection-shortcuts.tsx
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-collection-shortcuts.tsx
@@ -131,7 +131,26 @@ function ShortcutsHeading({
       data-sidebar-section="collections"
       data-sidebar-section-state={inline ? "heading" : "rule"}
       className={cn(
-        "mx-4 my-2 shrink-0 overflow-hidden truncate text-[10px] font-semibold uppercase tracking-wider",
+        // THE RULE IS AS LONG AS THE WORDS, and `w-fit` alone does not get
+        // there. The rail is a column flex with `items-stretch`, so it was
+        // stretching this box to the full 207px gutter while the lettering is
+        // 125px — and the rule state paints the BOX, not the text. Collapsing
+        // therefore drew a bar 82px longer than the label it replaces, which
+        // is the "divider starts at the full width of the sidebar" it kept
+        // looking like. It was not starting wide and shrinking; it was always
+        // that long, and only the collapse made it obvious.
+        //
+        // `self-start` is the half that matters — measured: 207px stretched,
+        // 125px once the stretch is off, which is exactly `max-content`.
+        //
+        // The max-width is the OTHER half, and `w-fit` cannot do it alone.
+        // `fit-content` never goes below `min-content`, and `truncate` sets
+        // `white-space: nowrap`, so min-content IS max-content here: the rule
+        // stayed 125px all the way down and hung 85px out of a 40px gutter.
+        // Capping at the gutter (100% less the 2rem of `mx-4`) gives the two
+        // ends the behaviour they each need — the words decide the length
+        // while there is room for them, the gutter decides once there is not.
+        "mx-4 my-2 w-fit max-w-[calc(100%-2rem)] shrink-0 self-start overflow-hidden truncate text-[10px] font-semibold uppercase tracking-wider",
         // Height, colour and background are the morph. Not `transition-all`:
         // that would also animate the margins, and a divider whose gaps grow
         // as it becomes a word reads as the rail breathing rather than as a


### PR DESCRIPTION
The rail's "TOP LEVEL COLLECTIONS" heading collapses **into** the divider — it is the same element, 1px high with a background — so its width *is* the rule's length.

It was stretching to the rail's full gutter: **207px measured, against 125px of actual lettering.** The collapse drew a bar 82px longer than the label it replaces, which is why it looked like "the divider starts at the full width of the sidebar". It was never starting wide and shrinking; it was always that long, and only the collapse made it obvious.

Reported twice. The first fix made the morph one element instead of two swapped ones — correct, and unrelated to the length.

## Two rules, and the first alone does nothing

| | Why |
| --- | --- |
| `self-start` | The rail is a column flex with `items-stretch`, and a stretched item ignores `w-fit`. Measured live: **207px** stretched, **125px** with the stretch off — exactly `max-content`. |
| `max-w-[calc(100%-2rem)]` | `fit-content` never goes below `min-content`, and `truncate` sets `white-space: nowrap`, making min-content equal max-content. Without this the rule stayed 125px all the way down and hung 85px outside a 40px gutter. |

Measured across the transition — never longer than the words, never wider than the gutter:

| Rail | Rule | Gutter |
| --- | --- | --- |
| 240 | 125 | 208 |
| 160 | 125 | 128 |
| 120 | 87 | 88 |
| 72 | 39 | 40 |

## Verification

The story asserts the **relationship** — the box against its own text, and against the space it is allowed — rather than a pixel count that would pin today's font and wording. **Proven to fail first:** `expected 208 to be less than 208`; the two numbers being identical is precisely the defect.

6 stories pass, `tsc` clean, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)