### PR TITLE
Close the front door: an allowlist for sign-in

### DIFF
--- a/apps/timeline-gstudio001/app/api/auth/login/complete/route.ts
+++ b/apps/timeline-gstudio001/app/api/auth/login/complete/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
+import { isEmailAllowed } from "@/lib/auth-allowlist";
 import { completeFirebaseEmailSignInLink } from "@/lib/firebase-auth-rest";
 import { createSessionCookie, setSessionCookie } from "@/lib/firebase-auth-session";
 import { readJsonObject } from "@/lib/read-json-body";
@@ -18,6 +19,23 @@ export async function POST(request: Request) {
     }
 
     const authResult = await completeFirebaseEmailSignInLink(email, oobCode);
+
+    // A VALID LINK IS NOT A TICKET. The send path refuses addresses that are
+    // not on the list, but links already in an inbox outlive that check — and
+    // so does a link mailed before the list existed, or before an address was
+    // taken off it. Refused HERE too, so the only thing a stale link buys is
+    // this message.
+    //
+    // Checked against the address Firebase just authenticated, not the one the
+    // request claimed, since the two need not agree.
+    if (!isEmailAllowed(authResult.email)) {
+      console.warn("[GSTUDIO_AUTH_COMPLETE_REFUSED]", { reason: "not-allowlisted" });
+      return NextResponse.json(
+        { error: "This account does not have access." },
+        { status: 403 },
+      );
+    }
+
     const sessionCookie = await createSessionCookie(authResult.idToken);
 
     return setSessionCookie(

--- a/apps/timeline-gstudio001/app/api/auth/login/route.ts
+++ b/apps/timeline-gstudio001/app/api/auth/login/route.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
+import { isEmailAllowed } from "@/lib/auth-allowlist";
 import { sendFirebaseEmailSignInLink } from "@/lib/firebase-auth-rest";
 import { clientAddress, createRateLimiter } from "@/lib/rate-limit";
 import { readJsonObject } from "@/lib/read-json-body";
@@ -74,6 +75,15 @@ export async function POST(request: Request) {
   // link: answering "that one is rate-limited" would confirm the address is
   // worth hammering.
   if (!perAddress.check(bucketKey(email)).allowed) {
+    return acceptedResponse();
+  }
+
+  // NOT ON THE LIST, NO LINK — and the same answer as every other outcome, so
+  // this does not become the enumeration oracle the rest of this route exists
+  // to avoid. Silent by design: a would-be signer-up learns nothing, and the
+  // owner sees it in the log.
+  if (!isEmailAllowed(email)) {
+    console.warn("[GSTUDIO_AUTH_LOGIN_REFUSED]", { reason: "not-allowlisted" });
     return acceptedResponse();
   }
 

--- a/apps/timeline-gstudio001/lib/auth-allowlist.test.ts
+++ b/apps/timeline-gstudio001/lib/auth-allowlist.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { allowedEmails, isEmailAllowed } from "./auth-allowlist";
+
+const ENV_KEY = "AUTH_ALLOWED_EMAILS";
+const original = process.env[ENV_KEY];
+
+afterEach(() => {
+  if (original === undefined) delete process.env[ENV_KEY];
+  else process.env[ENV_KEY] = original;
+});
+
+const withList = (value: string | undefined) => {
+  if (value === undefined) delete process.env[ENV_KEY];
+  else process.env[ENV_KEY] = value;
+};
+
+describe("when the list is not set", () => {
+  // The default has to be OPEN, and this pins why: local development, the
+  // Playwright suite and every preview deployment run without the variable,
+  // and a default of "deny everyone" would lock all three out.
+  it("allows anyone", () => {
+    withList(undefined);
+    expect(allowedEmails()).toBeNull();
+    expect(isEmailAllowed("anyone@example.test")).toBe(true);
+    expect(isEmailAllowed(null)).toBe(true);
+  });
+
+  it.each([
+    ["an empty string", ""],
+    ["only whitespace", "   "],
+    ["only separators", " , , "],
+  ])("treats %s as not set, rather than as deny-all", (_name, value) => {
+    withList(value);
+    // A variable set to nothing is a deployment accident. Reading it as "no
+    // address may sign in" turns a typo into an outage nobody can undo from
+    // the outside — including the owner.
+    expect(allowedEmails()).toBeNull();
+    expect(isEmailAllowed("anyone@example.test")).toBe(true);
+  });
+});
+
+describe("when the list is set", () => {
+  it("admits an address on it and refuses one that is not", () => {
+    withList("owner@example.test");
+    expect(isEmailAllowed("owner@example.test")).toBe(true);
+    expect(isEmailAllowed("stranger@example.test")).toBe(false);
+  });
+
+  it("ignores case and surrounding whitespace on both sides", () => {
+    // Nobody types a comma-separated list tidily, and an address is not
+    // case-sensitive in a way anyone relies on.
+    withList("  Owner@Example.test ,  second@example.test  ");
+    expect(isEmailAllowed("owner@EXAMPLE.TEST")).toBe(true);
+    expect(isEmailAllowed(" second@example.test ")).toBe(true);
+  });
+
+  it("refuses a missing address rather than defaulting to allowed", () => {
+    // A session token without an email reaches `getAuthUser`; it must not
+    // pass a list it cannot be checked against.
+    withList("owner@example.test");
+    expect(isEmailAllowed(null)).toBe(false);
+    expect(isEmailAllowed(undefined)).toBe(false);
+    expect(isEmailAllowed("")).toBe(false);
+  });
+
+  it("does NOT match a domain or a prefix", () => {
+    // The list is short and personal. "@example.test" is not an allowlist,
+    // and a substring match would make "owner@example.test.evil.com" pass.
+    withList("owner@example.test");
+    expect(isEmailAllowed("owner@example.test.evil.test")).toBe(false);
+    expect(isEmailAllowed("notowner@example.test")).toBe(false);
+    expect(isEmailAllowed("@example.test")).toBe(false);
+  });
+
+  it("refuses the account that actually turned up", () => {
+    // 2026-08-14: a stranger signed in, made a project called "gggg" and five
+    // empty timelines. Ownership kept them out of everyone else's work; this
+    // keeps them out of the door.
+    withList("josulliv101@gmail.com");
+    expect(isEmailAllowed("josulliv101@gmail.com")).toBe(true);
+    expect(isEmailAllowed("someone.else@gmail.com")).toBe(false);
+  });
+});

--- a/apps/timeline-gstudio001/lib/auth-allowlist.ts
+++ b/apps/timeline-gstudio001/lib/auth-allowlist.ts
@@ -1,0 +1,58 @@
+// WHO IS ALLOWED TO SIGN IN.
+//
+// Sign-in was open to anyone who found the site: `/api/auth/login` mails a
+// link to any address that asks. That is not a bug in the sense of something
+// misbehaving — access was simply never restricted — and on 2026-08-14 a
+// stranger used it, made a project called "gggg" and five empty timelines,
+// and left. Ownership held (`resolveOwnership` denies every read and write
+// whose `ownerUid` is not the requester's), so nothing of anyone else's was
+// reachable. What an account DOES get is this project's Firestore reads and
+// Cloudinary storage, and the daily read quota has already run out once.
+//
+// UNSET MEANS OPEN, deliberately. Local development, the Playwright suite and
+// every preview deployment run without this variable, and a default of "deny
+// everyone" would lock all three out the moment this shipped — a change that
+// breaks the machine you are standing on is a change nobody trusts. The
+// consequence is that PRODUCTION IS ONLY CLOSED ONCE `AUTH_ALLOWED_EMAILS` IS
+// SET THERE, which is a deployment step, not a code one.
+//
+// Matching is case-insensitive and whitespace-tolerant, because an address is
+// not case-sensitive in its domain and nobody types a comma-separated list
+// tidily. No wildcards or domain patterns: this list is short and personal,
+// and "@gmail.com" is not an allowlist.
+
+const ENV_KEY = "AUTH_ALLOWED_EMAILS";
+
+/** The parsed list, or null when the variable is unset or holds nothing
+ *  usable — both of which mean "do not restrict". */
+export function allowedEmails(): readonly string[] | null {
+  const raw = process.env[ENV_KEY];
+  if (typeof raw !== "string") return null;
+  const entries = raw
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry) => entry.length > 0);
+  // A variable set to "" or "  ,  " is a configuration accident, not an
+  // instruction to lock everyone out.
+  return entries.length > 0 ? entries : null;
+}
+
+/**
+ * Whether this address may hold a session here.
+ *
+ * Called in THREE places, and all three are needed:
+ *
+ *   - `/api/auth/login`, so no link is ever mailed to an address that could
+ *     not use it;
+ *   - `/api/auth/login/complete`, so a link mailed before the list existed —
+ *     or before an address was removed from it — cannot still mint a session;
+ *   - `getAuthUser`, so a session cookie ALREADY held stops working. Without
+ *     that one, restricting the list would not evict anyone already signed in;
+ *     their cookie stays valid for its full lifetime.
+ */
+export function isEmailAllowed(email: string | null | undefined): boolean {
+  const list = allowedEmails();
+  if (list === null) return true;
+  if (typeof email !== "string" || email.length === 0) return false;
+  return list.includes(email.trim().toLowerCase());
+}

--- a/apps/timeline-gstudio001/lib/firebase-auth-session.ts
+++ b/apps/timeline-gstudio001/lib/firebase-auth-session.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { cookies } from "next/headers";
 import { type DecodedIdToken } from "firebase-admin/auth";
 
+import { isEmailAllowed } from "./auth-allowlist";
 import { getFirebaseAuth } from "./firebase-admin";
 
 export const AUTH_COOKIE_NAME = "__Host-gstudio_session";
@@ -42,7 +43,18 @@ export async function getAuthUser(): Promise<AuthUser | null> {
 
   try {
     const decodedToken = await getFirebaseAuth().verifySessionCookie(sessionCookie, true);
-    return toAuthUser(decodedToken);
+    const user = toAuthUser(decodedToken);
+    // THE GATE THAT EVICTS. Refusing to mail links, and refusing to mint new
+    // sessions, does nothing to a cookie somebody already holds — it stays
+    // valid for its full lifetime, and every request it makes is authorised.
+    // Checking here is what makes removing an address take effect on the next
+    // request rather than whenever their session happens to expire.
+    //
+    // Every authenticated path runs through this function, so this is the one
+    // place that cannot be gone around; it costs a string compare against an
+    // already-decoded token.
+    if (!isEmailAllowed(user.email)) return null;
+    return user;
   } catch {
     return null;
   }

--- a/apps/timeline-gstudio001/package.json
+++ b/apps/timeline-gstudio001/package.json
@@ -21,7 +21,8 @@
     "inspect:squatted": "node --env-file=.env scripts/inspect-squatted-fixtures.mjs",
     "stamp:ownership": "node --env-file=.env scripts/stamp-ownerless-timelines.mjs",
     "bin:orphans": "node --env-file=.env scripts/bin-unreachable-timelines.mjs",
-    "correct:aspects": "node --env-file=.env scripts/correct-clip-aspects.mjs"
+    "correct:aspects": "node --env-file=.env scripts/correct-clip-aspects.mjs",
+    "audit:accounts": "node --env-file=.env scripts/audit-foreign-accounts.mjs"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1094.0",

--- a/apps/timeline-gstudio001/scripts/audit-foreign-accounts.mjs
+++ b/apps/timeline-gstudio001/scripts/audit-foreign-accounts.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+// WHO ELSE HAS AN ACCOUNT, and what did they make.
+//
+// Sign-in is open: `app/api/auth/login/route.ts` mails a link to any address
+// that asks, with no allowlist, so anyone who finds the site can create an
+// account. Ownership still holds — `resolveOwnership` denies every read and
+// write whose `ownerUid` is not the requester's — so a stranger gets an empty
+// workspace of their own and cannot see anyone else's work. What they CAN do
+// is spend this project's Firestore and Cloudinary quota, which is not
+// theoretical: the daily read quota ran out yesterday.
+//
+// READ ONLY. It never writes, claims, or deletes.
+//
+//   npm run audit:accounts --workspace=apps/timeline-gstudio001
+//   npm run audit:accounts --workspace=apps/timeline-gstudio001 -- --uid <uid>
+//
+// CHEAP ON PURPOSE, because a full-collection scan is what exhausted the quota:
+//
+//   - the sweep reads PROJECTS only (`isProject == true`), which is a small
+//     fraction of the collection — every scene, shot and bin is a document too;
+//   - it `select()`s four fields, so no clip arrays cross the wire;
+//   - per-owner totals come from `count()`, an aggregation billed per ~1000
+//     index entries rather than per document.
+//
+// `--uid` then lists one owner's projects, for when the summary says something
+// worth looking at.
+
+import { cert, applicationDefault, initializeApp } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+
+// Must track TIMELINE_COLLECTION in lib/firebase-timeline-store.ts.
+const COLLECTION = "gstudioTimelineDocuments";
+
+const uidFlagIndex = process.argv.indexOf("--uid");
+const focusUid = uidFlagIndex === -1 ? null : process.argv[uidFlagIndex + 1];
+
+function credential() {
+  const projectId = process.env.FIREBASE_PROJECT_ID;
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n");
+
+  if (clientEmail && privateKey) {
+    return { credential: cert({ projectId, clientEmail, privateKey }), projectId };
+  }
+  return { credential: applicationDefault(), projectId };
+}
+
+function toIso(value) {
+  if (!value) return "unknown";
+  if (typeof value.toDate === "function") return value.toDate().toISOString();
+  return String(value);
+}
+
+async function main() {
+  const { credential: cred, projectId } = credential();
+  initializeApp({ credential: cred, projectId });
+  const db = getFirestore();
+
+  if (focusUid) {
+    const snapshot = await db
+      .collection(COLLECTION)
+      .where("ownerUid", "==", focusUid)
+      .select("title", "isProject", "createdAt", "updatedAt")
+      .get();
+    console.log(`\nDocuments owned by ${focusUid}: ${snapshot.size}\n`);
+    for (const doc of snapshot.docs) {
+      const d = doc.data();
+      console.log(
+        `  ${d.isProject ? "PROJECT " : "        "}${doc.id}` +
+          `\n            title=${JSON.stringify(d.title ?? "")}` +
+          `  created=${toIso(d.createdAt)}  updated=${toIso(d.updatedAt)}`,
+      );
+    }
+    return;
+  }
+
+  // PROJECTS ONLY — the question is "did anyone make anything", and a project
+  // is the root of everything a person makes here.
+  const projects = await db
+    .collection(COLLECTION)
+    .where("isProject", "==", true)
+    .select("ownerUid", "title", "createdAt", "updatedAt")
+    .get();
+
+  const byOwner = new Map();
+  for (const doc of projects.docs) {
+    const data = doc.data();
+    const owner = data.ownerUid ?? "(ownerless)";
+    if (!byOwner.has(owner)) byOwner.set(owner, []);
+    byOwner.get(owner).push({
+      id: doc.id,
+      title: data.title ?? "",
+      createdAt: toIso(data.createdAt),
+      updatedAt: toIso(data.updatedAt),
+    });
+  }
+
+  console.log(`\nProjects read: ${projects.size}   Distinct owners: ${byOwner.size}\n`);
+
+  for (const [owner, list] of [...byOwner.entries()].sort(
+    (a, b) => b[1].length - a[1].length,
+  )) {
+    // Total documents for this owner, WITHOUT reading them.
+    const total = await db
+      .collection(COLLECTION)
+      .where("ownerUid", "==", owner)
+      .count()
+      .get();
+    console.log(`OWNER ${owner}`);
+    console.log(`  projects: ${list.length}   documents in total: ${total.data().count}`);
+    for (const p of list.sort((a, b) => a.createdAt.localeCompare(b.createdAt))) {
+      console.log(
+        `    ${p.id}  ${JSON.stringify(p.title)}  created=${p.createdAt}  updated=${p.updatedAt}`,
+      );
+    }
+    console.log("");
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Anyone who found the site could sign in — access was never restricted. On **14 August** someone did: one account, a project called "gggg", five empty timelines, gone in 34 minutes.

**Nothing of yours was reachable.** `resolveOwnership` denies every read and write whose `ownerUid` isn't the requester's, enforced at the store, so a stranger gets an empty workspace of their own. What an account *does* get is this project's Firestore reads and Cloudinary storage — and the daily read quota has already run out once.

## Three gates, because any one alone leaves a way in

| Gate | Why it's needed |
| --- | --- |
| `/api/auth/login` | No link is mailed to an address that couldn't use it. Answers **exactly as on success** — this route's whole design is to not be an enumeration oracle, and refusing loudly would make it one. |
| `/api/auth/login/complete` | A link already sitting in an inbox outlives the send check, as does one mailed before the list existed. |
| `getAuthUser` | Refuses a cookie **already held**. Without this, restricting the list evicts nobody — an existing session stays authorised for its full lifetime. Every authenticated path runs through it. |

## Unset means open — deliberately

Local development, the Playwright suite and every preview deployment run without the variable. A default of deny-all would lock out all three the moment this shipped. A variable set to `""` or `" , "` reads as unset for the same reason: a deployment typo shouldn't become an outage nobody outside can undo. Both are pinned by tests.

⚠️ **This has a deployment step.** Production stays open until `AUTH_ALLOWED_EMAILS` is set in Vercel — e.g. `josulliv101@gmail.com`.

## Also included

The read-only audit that found the account, alongside the existing ones (`npm run audit:accounts`). Deliberately cheap — projects only, four fields selected, `count()` aggregation for per-owner totals — because a full-collection scan is what exhausted the read quota in the first place.

9 allowlist tests, 1235 app tests, `tsc` clean, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)