### PR TITLE
The trash drawer opens once, at the height it means to keep

### DIFF
--- a/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
+++ b/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
@@ -87,6 +87,27 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
   const [error, setError] = useState<string | null>(null);
   const isMounted = useIsMounted();
 
+  // THE BIN IS USUALLY ALREADY LOADED, and this is what stops the drawer
+  // opening twice.
+  //
+  // It used to open, show a spinner in a 128px block, and then GROW to its
+  // real height when the fetch answered — the panel's height is its content's,
+  // so the spinner was literally shorter than the list it stood in for. Two
+  // motions for one press.
+  //
+  // The graph view's boot already calls `ensure(trashDocumentId)`, so on any
+  // board the document is in this cache before the drawer is ever opened. The
+  // drawer was fetching it a SECOND time and staggering itself while it
+  // waited. Reading the cache removes that duplicate request as well as the
+  // stagger.
+  const documents = useSyncExternalStore(
+    graphDocumentsGateway.subscribe,
+    graphDocumentsGateway.read,
+    graphDocumentsGateway.read,
+  );
+  const trashId = user ? `trash-${user.uid}` : null;
+  const cachedClips = trashId ? documents[trashId]?.clips : undefined;
+
   // Opening resets the loading/error surface DURING the render that opens
   // (the documented adjust-state-on-prop-change pattern), so the spinner is
   // up before the fetch below even starts — the effect itself then only
@@ -95,7 +116,14 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
   if (isOpen !== prevOpen) {
     setPrevOpen(isOpen);
     if (isOpen && user) {
-      setIsLoading(true);
+      // A SPINNER ONLY WHEN THERE IS NOTHING TO SHOW. With the document
+      // cached the list is right there, so the drawer opens once, at the
+      // height it means to keep. The request below still runs — the cache can
+      // be a few seconds stale — but as a silent revalidation: showing the
+      // spinner over content we already have would collapse the panel and
+      // reintroduce the second motion this exists to remove.
+      if (cachedClips) setClips(cachedClips);
+      setIsLoading(!cachedClips);
       setError(null);
     }
   }

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -40,6 +40,7 @@ import {
   SIDEBAR_ICON_BASE,
   SIDEBAR_ICON_IDLE,
 } from "./sidebar-icon-styles";
+import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 import { toast } from "@/components/core/sonner";
 import { cn } from "@/lib/utils";
 import { withViewTransition } from "@/lib/view-transition";
@@ -699,6 +700,24 @@ export function TimelineSidebar() {
           const handleClick = () =>
             void withViewTransition(() => setIsTrashOpen(!isTrashOpen));
 
+            // WARM THE BIN ON INTENT, so the drawer opens at its final height
+            // rather than growing when the fetch lands.
+            //
+            // On a board this does nothing — the graph's boot already ensures
+            // the document. It is for everywhere else, where the drawer would
+            // otherwise open short, spin, and grow.
+            //
+            // On HOVER and FOCUS rather than on mount: a speculative read for
+            // every visitor who never opens the bin is a Firestore read spent
+            // on nothing, and this project has already run its daily quota out
+            // once. Approaching the control is the cheapest honest signal of
+            // intent, and the gateway dedupes, so leaning on the tile costs one
+            // request at most.
+            const warmTrash = () => {
+              if (item.id !== "trash" || !user) return;
+              void graphDocumentsGateway.ensure(`trash-${user.uid}`);
+            };
+
             return (
               <button
                 key={item.id}
@@ -707,6 +726,8 @@ export function TimelineSidebar() {
                 aria-describedby={tooltipId}
                 aria-pressed={isPressed}
                 onClick={handleClick}
+                onPointerEnter={warmTrash}
+                onFocus={warmTrash}
                 className={cn(
                   SIDEBAR_ICON_BASE,
                   // Trash opens a DRAWER over the board; it does not take you


### PR DESCRIPTION
It opened part way, showed a spinner, then **grew** when the fetch answered. The panel's height is its content's, and the spinner stood in a 128px block — literally shorter than the list it stood in for — so one press produced two motions.

## The document was already loaded

The graph view's boot calls `ensure(trashDocumentId)`, so on any board the bin is in `graphDocumentsGateway`'s cache **before the drawer is ever opened**. The drawer ignored that and fetched it a second time, staggering itself while it waited.

So reading the cache removes a duplicate request as well as the stagger — which matters, since this project ran its daily read quota out yesterday.

The request still runs, as a silent **revalidation**: the cache can be a few seconds stale, but showing a spinner over content already on screen would collapse the panel and put the second motion back. The spinner now appears only when there is genuinely nothing to show.

## The cold path

Off a board the cache can be empty, so the rail's trash tile warms it on **hover and focus** — not on mount. A speculative read for every visitor who never opens the bin is a Firestore read spent on nothing. Approaching the control is the cheapest honest signal of intent, and the gateway dedupes, so leaning on the tile costs one request at most.

## Verification

Sampled while opening: **no spinner at any sample, one height throughout** (432px) where there were previously two. Caveat on that measurement — the sampler was throttled by the non-compositing preview pane, so it is not frame-accurate; the visual confirms the drawer opens full, with all 109 items rendered.

1235 app tests pass, and the five e2e paths that touch the drawer pass unchanged. `tsc` and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)