### PR TITLE
A duplicate card not loading is not an error

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-hydration.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-hydration.tsx
@@ -54,12 +54,28 @@ export async function hydrateTimeline(
   // that could never have succeeded.
   const documentId = hydrationDocumentId(detailsStore.get(timelineId), timelineId);
   if (documentId !== timelineId) {
-    reportHydrationIssue(
-      timelineId,
-      documentId === null
-        ? "it references another timeline and the reference is missing"
-        : `it references ${documentId}, which is not loaded from here`,
-    );
+    // NOT AN ERROR, and saying so out loud was a regression of its own.
+    //
+    // A duplicate reference card does not hydrate here — deliberately, and it
+    // never did. Removing the request that could not succeed was right; giving
+    // its absence a red banner was not. A board with five duplicate cards on
+    // it grew five alarms describing routine behaviour, which is worse than
+    // the 400 in the network tab it replaced: that at least stayed out of the
+    // way of the work.
+    //
+    // The two cases still differ, and the difference belongs in the console
+    // rather than on the board. A recorded reference means the card is doing
+    // exactly what a reference card does. A MISSING one means stored data
+    // nobody can resolve — worth a developer's attention, still not worth
+    // interrupting the person editing.
+    if (documentId === null) {
+      console.warn(
+        `[GSTUDIO_HYDRATION] "${timelineId}" is a duplicate placement with no recorded reference; its card cannot load contents.`,
+      );
+    }
+    // Clear any banner this id left behind, so a card that WAS unresolvable
+    // and now is not stops being reported.
+    reportHydrationIssue(timelineId, null);
     return;
   }
 

--- a/apps/timeline-gstudio001/components/timeline/sidebar-collection-shortcuts.stories.tsx
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-collection-shortcuts.stories.tsx
@@ -104,7 +104,7 @@ export const CollapsedShowsThumbnails: Story = {
     expect(heading).toHaveAttribute("data-sidebar-section-state", "rule");
     // Still real text, so the group is named for a screen reader even when the
     // words are only one pixel tall.
-    expect(heading).toHaveTextContent("Top level collections");
+    expect(heading).toHaveTextContent("Collection shortcuts");
   },
 };
 

--- a/apps/timeline-gstudio001/components/timeline/sidebar-collection-shortcuts.tsx
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-collection-shortcuts.tsx
@@ -97,7 +97,7 @@ const THUMBNAIL_IMAGE_CLASS =
 /**
  * The section's heading and its divider are ONE ELEMENT that changes shape.
  *
- * Wide it is "TOP LEVEL COLLECTIONS"; narrow it is the hairline those words
+ * Wide it is "COLLECTION SHORTCUTS"; narrow it is the hairline those words
  * cannot fit into. Because it is a single element the whole way through, the
  * change between them is an ordinary CSS transition on height, colour and
  * background — a real morph, not two things swapped and animated to look like
@@ -163,7 +163,7 @@ function ShortcutsHeading({
             "h-px bg-zinc-500 text-transparent",
       )}
     >
-      Top level collections
+      Collection shortcuts
     </h2>
   );
 }


### PR DESCRIPTION
Yesterday's "Invalid timeline id" fix traded a 400 in the network tab for a **red banner on the board**:

> Timeline `"dup:timeline-x:timeline-y"` could not load its clips: it references `timeline-y`, which is not loaded from here

Five duplicate cards produced five alarms — all describing behaviour that is exactly correct. A duplicate reference card **does not hydrate here**, deliberately, and never did. Removing the request that could not succeed was right; giving its absence an alert was not. The banner is worse than the 400 it replaced, because a 400 at least stays out of the way of the work.

The two cases still differ, and the difference belongs in the console:

| Case | Now |
| --- | --- |
| Reference **recorded** | Silent — the card is doing what a reference card does |
| Reference **missing** | `console.warn` — stored data nobody can resolve, worth a developer's attention, not worth interrupting an edit |

Any banner the id left behind is also cleared, so a card that once was unresolvable and now isn't stops being reported.

Also: the rail's heading becomes **"Collection shortcuts"**, which is what the group is, with its story assertion moved to match.

## Verification

Confirmed in the app that the heading reads "Collection shortcuts". On the banners — I could not reproduce the original five (the board I loaded had no duplicate cards on it), so this rests on the code path rather than on a before/after observation: previously *every* `documentId !== timelineId` reported, and now none do. There is no branch left that can emit that message.

6 stories pass, `tsc` clean, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)