### PR TITLE
Add item: one control for both kinds, placeable by drag

### DIFF
--- a/apps/timeline-gstudio001/.env.example
+++ b/apps/timeline-gstudio001/.env.example
@@ -84,3 +84,21 @@ MCP_OWNER_UID="MY_FIREBASE_UID"
 # by emptying the trash simply wait, which is the safe direction (storage
 # leaks; no file is lost).
 CRON_SECRET="MY_CRON_SECRET"
+
+# ── Offline board (development only) ────────────────────────────────────────
+#
+# Serve timelines from a JSON file instead of Firestore. Firestore's free tier
+# allows 50,000 document reads a day and a day of work on a large project
+# reaches it (see issue #437); when it runs out the app is unopenable until
+# midnight Pacific, and no UI work can be done at all. This is the way back in.
+#
+# Reads come from the file; writes are held in memory and are gone on restart.
+# Revision conflicts, the orphan guard, batch atomicity and the delete cascade
+# are NOT modelled — use it to look at the UI, never to trust the data layer.
+#
+# REFUSED when NODE_ENV=production, unconditionally: it bypasses the ownership
+# check (dummy documents have no owner), and a flag that fakes the database AND
+# disables access control must not be one variable away from being live.
+#
+# Regenerate the content with `npm run fixture:build`.
+GSTUDIO_FIXTURE_TIMELINES="fixtures/dev-timelines.json"

--- a/apps/timeline-gstudio001/components/graph-view/graph-add-item-menu.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-add-item-menu.tsx
@@ -1,0 +1,376 @@
+"use client";
+
+import { useEffect, useRef, type ReactNode } from "react";
+import { FolderPlus, GripVertical, Image as ImageIcon } from "lucide-react";
+
+import { ADD_ITEM_TOOL, TOOL_MIME } from "./graph-native-drop-model";
+
+/**
+ * "Add item" — one control for the two things a timeline can hold.
+ *
+ * Two gestures, one question. CLICK it and you are asked which kind, and the
+ * answer lands at the END. DRAG it onto a strip or a grid and you are asked the
+ * same question at the spot you let go, and the answer lands THERE. The
+ * question is identical either way, which is the whole point of merging what
+ * used to be a collection-only tool with a media route that existed only at the
+ * end of a surface.
+ *
+ * The drag half rides the existing tool MIME with a payload of its own, so
+ * every drop surface accepts it, draws its indicator, and resolves its anchor
+ * with no changes at all — see ADD_ITEM_TOOL. Only the commit differs.
+ */
+
+/** Menu chrome, shared so the two callers cannot drift apart visually. */
+const MENU_CLASS =
+  "z-50 flex w-56 flex-col rounded-md bg-zinc-900 p-1.5 shadow-lg ring-1 ring-white/15";
+
+const ITEM_CLASS =
+  "flex h-8 w-full items-center gap-2 rounded px-1.5 text-left text-[11px] text-zinc-300 transition-colors hover:bg-zinc-800 hover:text-zinc-100 focus-visible:bg-zinc-800 focus-visible:text-zinc-100 focus-visible:outline-none";
+
+/**
+ * The two choices, plus the file input that backs the media one.
+ *
+ * `onFiles` is called with the picked files; `onDismiss` fires when the picker
+ * is CANCELLED. That second one matters: choosing media does not resolve the
+ * pending choice — the files have not arrived yet — so without a cancel signal
+ * a dismissed OS picker would leave the menu open over the board with no way to
+ * tell it nothing is coming. The `cancel` event on a file input is what says so.
+ */
+function AddItemChoices({
+  onCollection,
+  onFiles,
+  onDismiss,
+  hint,
+}: Readonly<{
+  onCollection: () => void;
+  onFiles: (files: readonly File[]) => void;
+  onDismiss: () => void;
+  /** Shown under the choices. The button's menu carries the drag hint; the
+   *  drop-point menu does not — you got there BY dragging. */
+  hint?: ReactNode;
+}>) {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  // `cancel` is bound imperatively: React's `InputHTMLAttributes` has no
+  // `onCancel`, so there is no JSX prop for it. Worth the effect — without it,
+  // dismissing the OS picker leaves the drop-point menu open over the board
+  // waiting for files that are never coming, and the only way out is to notice
+  // it and click elsewhere.
+  useEffect(() => {
+    const input = fileInputRef.current;
+    if (!input) return;
+    const onCancel = () => onDismiss();
+    input.addEventListener("cancel", onCancel);
+    return () => input.removeEventListener("cancel", onCancel);
+  }, [onDismiss]);
+
+  return (
+    <>
+      <button
+        type="button"
+        role="menuitem"
+        data-add-item-collection
+        onClick={onCollection}
+        className={ITEM_CLASS}
+      >
+        {/* The SAME glyphs the trailing add slot uses for the same two things,
+            so the two routes to one action look like one action. */}
+        <FolderPlus aria-hidden="true" className="size-3.5 shrink-0" strokeWidth={1.7} />
+        Add collection
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        data-add-item-media
+        onClick={() => fileInputRef.current?.click()}
+        className={ITEM_CLASS}
+      >
+        <ImageIcon aria-hidden="true" className="size-3.5 shrink-0" strokeWidth={1.7} />
+        Add media item
+      </button>
+      {hint}
+      {/* `sr-only` rather than `display:none`: it must stay a real form control
+          for the button above to be able to open it. */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        accept="image/*,video/*"
+        tabIndex={-1}
+        aria-hidden="true"
+        data-add-item-input
+        className="sr-only"
+        onChange={(event) => {
+          const files = [...(event.target.files ?? [])];
+          // Reset BEFORE handing off, so picking the same file twice running
+          // fires `change` again — the input compares against its own value,
+          // and an unchanged one is silently inert.
+          event.target.value = "";
+          onFiles(files);
+        }}
+      />
+    </>
+  );
+}
+
+/**
+ * Move focus to the first choice when a menu opens, and back to the trigger
+ * when it closes.
+ *
+ * THE KEYBOARD ROUTE, not a nicety. Activating the button used to insert
+ * outright; it now opens a menu, so without this the keystroke that used to add
+ * a collection leaves focus on the trigger and the answer an unknown number of
+ * Tabs away. With it the sequence is Enter, Enter.
+ *
+ * Returning focus matters just as much: a menu that closes while focus sits on
+ * a button that no longer exists drops focus to `<body>`, and the next Tab
+ * starts over at the top of the page.
+ */
+function useMenuFocus(
+  open: boolean,
+  menuRef: React.RefObject<HTMLElement | null>,
+  triggerRef: React.RefObject<HTMLElement | null>,
+) {
+  useEffect(() => {
+    if (!open) return;
+    menuRef.current?.querySelector<HTMLElement>('[role="menuitem"]')?.focus();
+    return () => {
+      // "Did focus fall to <body>", NOT "is focus still inside the menu".
+      //
+      // The obvious check — `menuRef.current?.contains(document.activeElement)`
+      // — cannot ever be true: React removes the menu from the DOM and detaches
+      // the ref BEFORE running this cleanup, so it reads null every time and
+      // silently restores focus never.
+      //
+      // Focus landing on <body> IS the signal, and it distinguishes the two
+      // cases exactly. Removing the focused element drops focus to the body, so
+      // that means the menu closed under it. Clicking a card elsewhere leaves
+      // focus on that card, so this does not fire and does not fight the user.
+      const active = document.activeElement;
+      if (active === null || active === document.body) triggerRef.current?.focus();
+    };
+  }, [open, menuRef, triggerRef]);
+}
+
+/** Escape, and a click anywhere outside `ref`, both dismiss. */
+function useDismiss(
+  open: boolean,
+  ref: React.RefObject<HTMLElement | null>,
+  onDismiss: () => void,
+) {
+  useEffect(() => {
+    if (!open) return;
+    const onDocPointerDown = (event: MouseEvent) => {
+      if (!ref.current?.contains(event.target as Node)) onDismiss();
+    };
+    // Captured, so it closes THIS before the key reaches the board — where the
+    // same key drops the selection or leaves select mode, which is not what
+    // someone with a menu open means by it.
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.stopPropagation();
+      onDismiss();
+    };
+    document.addEventListener("mousedown", onDocPointerDown);
+    document.addEventListener("keydown", onKey, true);
+    return () => {
+      document.removeEventListener("mousedown", onDocPointerDown);
+      document.removeEventListener("keydown", onKey, true);
+    };
+  }, [open, ref, onDismiss]);
+}
+
+/**
+ * The menu a DROPPED add-item opens, at the point it was let go.
+ *
+ * `fixed` at the drop's viewport coordinates, clamped in CSS rather than by
+ * measuring: `min(x, calc(100vw - …))` keeps it on screen without a layout
+ * pass, a ref, or the frame of "rendered off-screen, then corrected" that
+ * measuring would cost.
+ *
+ * No drag hint here — you arrived by dragging.
+ */
+export function AddItemDropMenu({
+  clientX,
+  clientY,
+  onCollection,
+  onFiles,
+  onDismiss,
+}: Readonly<{
+  clientX: number;
+  clientY: number;
+  onCollection: () => void;
+  onFiles: (files: readonly File[]) => void;
+  onDismiss: () => void;
+}>) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  useDismiss(true, ref, onDismiss);
+  // Focus the first choice, same as the button's menu. No trigger to return to
+  // — a drag has no focused element to go back to — so the ref is the menu's
+  // own, which the cleanup then finds detached and skips.
+  useMenuFocus(true, ref, ref);
+
+  return (
+    <div
+      ref={ref}
+      role="menu"
+      aria-label="Add an item here"
+      data-add-item-drop-menu
+      className={`fixed ${MENU_CLASS}`}
+      style={{
+        left: `min(${clientX}px, calc(100vw - 15rem))`,
+        top: `min(${clientY}px, calc(100vh - 8rem))`,
+      }}
+    >
+      <AddItemChoices
+        onCollection={onCollection}
+        onFiles={onFiles}
+        onDismiss={onDismiss}
+      />
+    </div>
+  );
+}
+
+/**
+ * The controls-row button: a GRIP and the words.
+ *
+ * LABELLED, unlike every other control in that row. It first shipped icon-only
+ * on the argument that a bare glyph is what the row's language is; the label is
+ * a deliberate reversal, and it earns the width — this is the only control in
+ * the row that WRITES rather than changing a view, and the only one carrying
+ * two different gestures. Being the odd one out is the point: it is the odd one
+ * out.
+ *
+ * The grip is the drag tell, and it is the ONE glyph left. A plus sat beside it
+ * for a while and was pure redundancy once the button said "Add item" in words —
+ * two symbols for the same verb, with the grip's own meaning competing against
+ * it. A control whose second gesture is invisible is a control whose second
+ * gesture nobody finds, so the glyph that survives is the one saying something
+ * the label cannot; the hint at the foot of the menu is the other half of it.
+ *
+ * The visible words do NOT replace `aria-label`: the label reads "Add an item
+ * to this timeline", which says WHERE, and an accessible name is the one place
+ * that context is free.
+ */
+export function AddItemButton({
+  onCollection,
+  onFiles,
+  open,
+  onOpenChange,
+}: Readonly<{
+  onCollection: () => void;
+  onFiles: (files: readonly File[]) => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}>) {
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  useDismiss(open, wrapRef, () => onOpenChange(false));
+  useMenuFocus(open, menuRef, triggerRef);
+
+  const handleDragStart = (event: React.DragEvent) => {
+    // A menu open while the drag begins would hang over the board for the
+    // whole gesture and then be answered at the wrong place.
+    onOpenChange(false);
+    event.dataTransfer.setData(TOOL_MIME, ADD_ITEM_TOOL);
+    event.dataTransfer.effectAllowed = "copy";
+    const img = new window.Image();
+    img.src = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
+    event.dataTransfer.setDragImage(img, 0, 0);
+
+    // The browser shows a "no-drop" cursor wherever a dragover handler doesn't
+    // preventDefault — i.e. everywhere except directly over a strip/grid — so
+    // the cursor flickers to no-drop as the pointer crosses the gaps between
+    // them (and at the very start, up here in the controls row). Claim EVERY
+    // dragover at the document level for the drag's lifetime so the cursor
+    // stays a valid "copy" throughout; the surfaces still own the drop position
+    // and the actual add. A matching document drop swallows a stray drop that
+    // misses every surface so the browser takes no default action.
+    const onDocDragOver = (e: DragEvent) => {
+      e.preventDefault();
+      if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+    };
+    const onDocDrop = (e: DragEvent) => {
+      e.preventDefault();
+    };
+    const cleanup = () => {
+      document.removeEventListener("dragover", onDocDragOver, true);
+      document.removeEventListener("drop", onDocDrop, true);
+      document.removeEventListener("dragend", cleanup);
+    };
+    // Capture before nested surfaces. Chromium can briefly expose an empty
+    // `types` list while crossing DOM boundaries, so the drag-lifetime guard
+    // must not depend on reading our MIME type back from each event.
+    document.addEventListener("dragover", onDocDragOver, true);
+    document.addEventListener("drop", onDocDrop, true);
+    document.addEventListener("dragend", cleanup, { once: true });
+  };
+
+  return (
+    <div ref={wrapRef} className="relative shrink-0">
+      <button
+        ref={triggerRef}
+        type="button"
+        draggable
+        data-add-item-button
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Add an item to this timeline"
+        title="Add item — click to add at the end, or drag onto the board to choose a spot"
+        onDragStart={handleDragStart}
+        onClick={() => onOpenChange(!open)}
+        // NO BORDER at rest, matching every toggle beside it — a bordered box
+        // would read as a different KIND of control rather than as this row's
+        // tool. `cursor-grab` is what says it is also draggable, and the grip
+        // glyph is what says it before you hover.
+        //
+        // `h-8` is load-bearing: the row pins every control to one height, and
+        // the last thing to break that was a single stray height on a labelled
+        // button. `whitespace-nowrap` so the label cannot wrap and take the
+        // row's height with it when the viewport tightens.
+        className="flex h-8 shrink-0 cursor-grab items-center gap-1 rounded-md pr-2 pl-1 text-[11px] font-medium whitespace-nowrap text-zinc-400 transition-colors hover:bg-sky-950/30 hover:text-sky-400 active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+      >
+        <GripVertical aria-hidden="true" className="size-3.5 shrink-0 opacity-60" />
+        Add item
+      </button>
+
+      {open ? (
+        <div
+          ref={menuRef}
+          role="menu"
+          aria-label="Add an item to the end"
+          data-add-item-menu
+          // `right-0`: the button sits at the left of a full-width row, but the
+          // menu is wider than it is, so an end-aligned drop is what keeps it
+          // from hanging off. `top-full` puts it under the row, over the board.
+          className={`absolute top-full left-0 mt-1.5 ${MENU_CLASS}`}
+        >
+          <AddItemChoices
+            onCollection={() => {
+              onOpenChange(false);
+              onCollection();
+            }}
+            onFiles={(files) => {
+              onOpenChange(false);
+              onFiles(files);
+            }}
+            onDismiss={() => onOpenChange(false)}
+            hint={
+              // THE DISCOVERABILITY HALF. The grip says "draggable" to someone
+              // already looking at the button; this says what dragging it is
+              // FOR, to someone who has just opened the menu and is therefore
+              // definitely paying attention.
+              <p
+                data-add-item-drag-hint
+                className="mt-1 border-t border-white/10 px-1.5 pt-1.5 text-[10px] leading-snug text-zinc-500"
+              >
+                Tip: drag this button onto the board to add at a specific spot.
+              </p>
+            }
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-add-item-menu.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-add-item-menu.tsx
@@ -329,7 +329,13 @@ export function AddItemButton({
         // the last thing to break that was a single stray height on a labelled
         // button. `whitespace-nowrap` so the label cannot wrap and take the
         // row's height with it when the viewport tightens.
-        className="flex h-8 shrink-0 cursor-grab items-center gap-1 rounded-md pr-2 pl-1 text-[11px] font-medium whitespace-nowrap text-zinc-400 transition-colors hover:bg-sky-950/30 hover:text-sky-400 active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+        //
+        // `gap-2` between the grip and the label, wider than the `gap-1` it
+        // started at. The grip is a column of dots roughly 4px wide sitting in
+        // a 14px icon box, so the box edge the gap measures from is not where
+        // the mark ends — 4px of gap read as almost none, and the label looked
+        // stuck to it.
+        className="flex h-8 shrink-0 cursor-grab items-center gap-2 rounded-md pr-2 pl-1 text-[11px] font-medium whitespace-nowrap text-zinc-400 transition-colors hover:bg-sky-950/30 hover:text-sky-400 active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
       >
         <GripVertical aria-hidden="true" className="size-3.5 shrink-0 opacity-60" />
         Add item

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -50,7 +50,7 @@ import {
 } from "@/lib/graph-item-action-specs";
 import {
   requestGraphItemAction,
-  requestGraphToolInsert,
+  requestGraphAddItem,
   type GraphItemAction,
   type GraphSurface,
 } from "@/lib/graph-view-events";
@@ -91,7 +91,7 @@ import {
 } from "./graph-selection-menu";
 import { NativeDropGrid } from "./graph-native-drop-grid";
 import { NativeDropStrip } from "./graph-native-drop-strip";
-import { SidebarToolInsertBridge } from "./graph-native-drop-insertion";
+import { AddItemButton } from "./graph-add-item-menu";
 import { VideoFrameLookAhead } from "./graph-card-frame-loading";
 import { BreadcrumbDropZones, DragChromeFade } from "./graph-breadcrumb-drop";
 import { OpenKeyBoundary } from "./graph-navigation";
@@ -131,6 +131,7 @@ import {
   ITEM_SIZE_DIMENSIONS,
   ITEM_SIZES,
   MAX_SUBTREE_DEPTH,
+  DEFAULT_TIMELINE_PPS,
   MAX_TIMELINE_PPS,
   MIN_TIMELINE_PPS,
   isItemSize,
@@ -394,6 +395,25 @@ function FocusedAggregate({
 }
 
 /**
+ * The zoom slider's reading, as a PERCENTAGE of the default.
+ *
+ * The stored value is pixels-per-second, which is the right unit for the layout
+ * maths and the wrong one to show a person: it is an implementation detail of
+ * how a strip is drawn, and "50" means nothing without knowing what the other
+ * numbers are. A percentage answers the only question the readout is asked —
+ * how far from normal is this — and needs no scale to interpret.
+ *
+ * `DEFAULT_TIMELINE_PPS` is the 100% mark, so the control opens reading 100%.
+ * The bounds (6..200 px/s) land at 12%..400%.
+ *
+ * DISPLAY ONLY. The slider's own value, its min/max and everything downstream
+ * stay in px/s — including the `aria-valuenow` an e2e test reads.
+ */
+function zoomPercent(pixelsPerSecond: number): number {
+  return Math.round((pixelsPerSecond / DEFAULT_TIMELINE_PPS) * 100);
+}
+
+/**
  * Horizontal zoom, as a real slider in the header's view group.
  *
  * It spent a while as a MENU ROW, and the comment there argued the shape was
@@ -429,14 +449,31 @@ function HeaderZoomControl({
       // you click to jump the value is the track beside it, which would
       // otherwise read as empty board and drop the selection.
       data-collections-control
-      className="flex shrink-0 items-center gap-2"
+      // `pl-1.5` on top of the row's `gap-2`, and only on the LEFT. Every
+      // neighbour is a button whose glyph sits inside its own padding, so the
+      // row's gap lands between two cushioned edges; the slider's track starts
+      // hard at its box edge, which put it visibly nearer the fence than any
+      // two other controls are to each other. This buys back the padding the
+      // buttons have and it does not.
+      className="flex shrink-0 items-center gap-2 pl-1.5"
     >
       <Slider
+        // A hook on the SLIDER, distinct from `data-header-zoom` on the wrapper
+        // around it. A pointer test aiming at "the left end of the track" has to
+        // measure the track — measuring the wrapper worked only while the two
+        // shared an edge, and a later `pl-1.5` on the wrapper silently moved the
+        // click into the padding, where it did nothing and the zoom never
+        // changed.
+        data-header-zoom-slider
         // The name and the READING both go to the thumb, which is where Radix
         // puts `role="slider"` (see components/core/slider). A bare number on
         // an axis like pixels-per-second announces nothing on its own.
         aria-label="Timeline zoom"
-        aria-valuetext={`${value} pixels per second`}
+        // Announced as the PERCENTAGE shown, not the raw pixels-per-second the
+        // slider stores. A bare number on an axis like px/s announces nothing
+        // on its own, and "100%" carries the one fact that matters — how far
+        // from the default you are.
+        aria-valuetext={`${zoomPercent(value)}%`}
         min={MIN_TIMELINE_PPS}
         max={MAX_TIMELINE_PPS}
         step={1}
@@ -451,9 +488,11 @@ function HeaderZoomControl({
       <span
         data-header-zoom-value
         aria-hidden="true"
-        className="w-[52px] shrink-0 font-mono text-[11px] tabular-nums text-zinc-500"
+        // Narrower than the `52px` "200 px/s" needed: the widest reading is
+        // now "400%".
+        className="w-[38px] shrink-0 font-mono text-[11px] tabular-nums text-zinc-500"
       >
-        {value} px/s
+        {zoomPercent(value)}%
       </span>
     </span>
   );
@@ -526,6 +565,7 @@ function HeaderToggle({
   label,
   title,
   busy = false,
+  text,
 }: Readonly<{
   active: boolean;
   onToggle: () => void;
@@ -542,6 +582,16 @@ function HeaderToggle({
    *  needs it — loading a deep closure takes a moment, and a half-built run
    *  would otherwise look like the real answer. */
   busy?: boolean;
+  /**
+   * A visible word beside the glyph. Absent for almost every toggle here — the
+   * row's language is bare glyphs — and present where a control has earned the
+   * width by being something other than one more view switch.
+   *
+   * It does NOT replace `label`: that stays the accessible name, and the two
+   * differ on purpose ("Preview" on screen, "Show preview"/"Hide preview" to a
+   * screen reader, which needs the STATE the pressed look conveys visually).
+   */
+  text?: string;
 }>) {
   return (
     <Button
@@ -568,9 +618,18 @@ function HeaderToggle({
       // `min-content` the real width of its controls, which is what the
       // header row's right column now sizes itself against — a squeezable
       // icon would report a smaller minimum and let the column collapse again.
-      className={cn("h-8 w-8 shrink-0", active ? HEADER_TOGGLE_ACTIVE : HEADER_TOGGLE_IDLE)}
+      className={cn(
+        "h-8 shrink-0",
+        // Square when it is a glyph alone; grown to fit when it carries a word.
+        // `size="icon"` sets a fixed square, so a labelled one has to opt out of
+        // the width and take its own padding — and `whitespace-nowrap` so the
+        // word cannot wrap and drag the row's pinned height with it.
+        text === undefined ? "w-8" : "w-auto gap-1.5 px-2 text-[11px] font-medium whitespace-nowrap",
+        active ? HEADER_TOGGLE_ACTIVE : HEADER_TOGGLE_IDLE,
+      )}
     >
       <Icon aria-hidden className={cn("h-4 w-4", busy && "motion-safe:animate-pulse")} />
+      {text}
     </Button>
   );
 }
@@ -1443,67 +1502,38 @@ function GraphUndoRedo() {
 }
 
 /**
- * The Collection tool, relocated from the icon sidebar into the board header
- * (right cluster). Same two affordances it always had: CLICK (or keyboard)
- * appends a nested timeline to the open collection through the insert bridge,
- * and native DRAG carries it onto a strip to pick a POSITION. The default
- * browser drag image is suppressed (1×1 transparent gif) so only the strip's
- * own drop indicator shows where it will land.
+ * The controls row's ADD ITEM control, and the click half of its behaviour.
+ *
+ * Replaces a Collection-only tool. That button offered exactly one kind of
+ * thing, while media had a route only at the very end of a surface (the
+ * trailing slot) or by dragging in from the OS — so "put a clip here" and "put
+ * a collection here" were two unrelated gestures with different reach. One
+ * control now asks WHICH, and both answers land the same way.
+ *
+ * Two gestures:
+ *
+ * - CLICK opens the menu; either answer APPENDS. That is a change from the
+ *   button this replaces, which landed next to the SELECTION (via
+ *   `resolveInsertPlacement`) — a rule that reads well from a sidebar palette
+ *   and poorly from a control sitting directly above the board, where "add one"
+ *   plainly means "at the end of this".
+ * - DRAG carries the add-item payload onto any surface, which parks the
+ *   position and asks the same question THERE (see `AddItemDropMenu`).
+ *
+ * The work happens in `useNativeDrop`, inside the drop surface below this row —
+ * that is where the mint-and-insert and the whole upload pipeline live, and
+ * context does not flow upward, so the click path crosses down by ADDRESSED
+ * event. See GRAPH_ADD_ITEM_EVENT for why addressed and not broadcast.
  */
-function GraphAddCollectionButton() {
-  const handleDragStart = (event: React.DragEvent) => {
-    // Same MIME the sidebar tool used, which NativeDropStrip/Grid accept.
-    event.dataTransfer.setData("application/x-gstudio-type", "collection");
-    event.dataTransfer.effectAllowed = "copy";
-    const img = new window.Image();
-    img.src = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
-    event.dataTransfer.setDragImage(img, 0, 0);
-
-    // The browser shows a "no-drop" cursor wherever a dragover handler doesn't
-    // preventDefault — i.e. everywhere except directly over a strip/grid — so
-    // the cursor flickers to no-drop as the pointer crosses the gaps between
-    // them (and at the very start, up in the header). Claim EVERY dragover at
-    // the document level for the drag's lifetime so the cursor stays a valid
-    // "copy" throughout; the strips/grids still own the drop position and the
-    // actual add. A matching document drop swallows a stray drop that misses
-    // every strip so the browser takes no default action.
-    const onDocDragOver = (e: DragEvent) => {
-      e.preventDefault();
-      if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
-    };
-    const onDocDrop = (e: DragEvent) => {
-      e.preventDefault();
-    };
-    const cleanup = () => {
-      document.removeEventListener("dragover", onDocDragOver, true);
-      document.removeEventListener("drop", onDocDrop, true);
-      document.removeEventListener("dragend", cleanup);
-    };
-    // Capture before nested surfaces. Chromium can briefly expose an empty
-    // `types` list while crossing DOM boundaries, so the drag-lifetime guard
-    // must not depend on reading our MIME type back from each event.
-    document.addEventListener("dragover", onDocDragOver, true);
-    document.addEventListener("drop", onDocDrop, true);
-    document.addEventListener("dragend", cleanup, { once: true });
-  };
-
+function BoardAddItemButton({ collectionId }: Readonly<{ collectionId: string }>) {
+  const [open, setOpen] = useState(false);
   return (
-    <button
-      type="button"
-      draggable
-      aria-label="Add Collection to the open timeline"
-      title="New collection — click to append, drag onto a strip to place"
-      onDragStart={handleDragStart}
-      onClick={() => requestGraphToolInsert("collection")}
-      // NO BORDER at rest. It was the only bordered control in this row —
-      // every toggle beside it is a bare ghost square — so the box read as a
-      // different KIND of thing rather than as the same row's tool. The
-      // hover still fills and tints, which is what says it is pressable, and
-      // `cursor-grab` is what says it is also draggable.
-      className="flex h-8 w-8 shrink-0 cursor-grab items-center justify-center rounded-md bg-zinc-900/40 text-zinc-400 transition-colors hover:bg-sky-950/30 hover:text-sky-400 active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
-    >
-      <FolderPlus aria-hidden="true" className="h-4 w-4" />
-    </button>
+    <AddItemButton
+      open={open}
+      onOpenChange={setOpen}
+      onCollection={() => requestGraphAddItem({ collectionId, kind: "collection" })}
+      onFiles={(files) => requestGraphAddItem({ collectionId, kind: "media", files })}
+    />
   );
 }
 
@@ -1883,6 +1913,7 @@ export function GraphBoard({
                 active={previewOn}
                 onToggle={onPreviewToggle}
                 icon={TvMinimal}
+                text="Preview"
                 label={previewOn ? "Hide preview" : "Show preview"}
                 title="Preview — play the focused timeline"
               />
@@ -1919,9 +1950,6 @@ export function GraphBoard({
           </div>
         }
       >
-        {/* Outside the surface branch on purpose: the sidebar's tool buttons
-            must insert in grid mode too, where no NativeDropStrip exists. */}
-        <SidebarToolInsertBridge collectionId={focusedId} />
         {/* Also outside it (PL10-012): details are not a strip idea. A grid
             card has no trim handles, but it has a name, a duration, and
             whatever an item grows next — so it opens the same view. The modal
@@ -2025,20 +2053,44 @@ export function GraphBoard({
                 the intended order. */}
             <div
               data-board-controls-row
-              className="grid min-h-7 grid-cols-[minmax(min-content,1fr)_auto_minmax(min-content,1fr)] items-center gap-3 border-b border-white/10 px-3 py-2"
+              // WRAPS when it cannot fit, three columns when it can.
+              //
+              // The row needs ~648px of content. Below roughly an 800px
+              // viewport the three columns overflow the panel, and every way of
+              // absorbing that inside one line is worse than a second line:
+              // clipping the sides would cut off the Add item and filter menus,
+              // which are absolutely positioned INSIDE those columns; letting
+              // the columns shrink puts their `shrink-0` contents on top of
+              // each other again; and `overflow-x-auto` on the row would
+              // establish a scroll container that clips those same menus
+              // vertically.
+              //
+              // Wrapping is available here in a way it is not one row up: the
+              // breadcrumb header is pinned to a single height that the preview
+              // pane measures itself against, and this row is deliberately not
+              // sticky and measured by nothing.
+              className="flex min-h-7 flex-wrap items-center gap-3 border-b border-white/10 px-3 py-2 lg:grid lg:grid-cols-[minmax(min-content,1fr)_auto_minmax(min-content,1fr)]"
             >
               {/* LEFT COLUMN — WHAT THE BOARD IS MADE OF. Two fenced groups:
-                  the toggles that change its shape, then the one control that
-                  adds to it.
+                  the one control that ADDS to it, then the toggles that change
+                  its shape.
+
+                  ADD LEADS. It is the only control in the row that writes, and
+                  the only one that is a verb rather than a view — so it opens
+                  the row rather than trailing the switches. It also carries the
+                  row's only label, and a labelled control reads as the start of
+                  a run far better than as something wedged after two glyphs.
 
                   `min-w-0` on the flex box inside the column, so its own
                   children may compress. The column's `min-content` floor
                   governs how far that can go. */}
               <div className="flex min-w-0 items-center gap-2">
-                {/* GROUP 1 — HOW THE BOARD IS STRUCTURED. Two toggles that
-                    change the shape of what is drawn, not its contents:
-                    whether this run is grouped into its collections, and
-                    whether the nested timelines draw below it. */}
+                <BoardAddItemButton collectionId={focusedId} />
+                <ControlFence />
+                {/* HOW THE BOARD IS STRUCTURED. Two toggles that change the
+                    shape of what is drawn, not its contents: whether this run
+                    is grouped into its collections, and whether the nested
+                    timelines draw below it. */}
                 {/* INVERTED against the state it drives. The strip opens flat
                     (see `flatOn`'s default), so the thing left to offer is the
                     nesting, and `active` is `!flatOn` — pressed means you have
@@ -2070,12 +2122,10 @@ export function GraphBoard({
                   label={childrenShown ? "Hide children timelines" : "Show children timelines"}
                   title="Children timelines — show the nested timeline tree"
                 />
-                <ControlFence />
-                {/* GROUP 2 — the one control here that CHANGES THE TIMELINE
-                    rather than the view of it, which is the whole reason it
-                    gets a fence to itself. Everything either side is a
-                    reading; this one writes. */}
-                <GraphAddCollectionButton />
+                {/* NO trailing fence. A fence is the edge BETWEEN two groups,
+                    and there is nothing after this one — the column ends here.
+                    One was briefly left behind when Add item moved to the front
+                    of the row, drawing a line against empty space. */}
               </div>
 
               {/* CENTRE COLUMN — WHAT THE BOARD AMOUNTS TO. One readout, and
@@ -2084,8 +2134,24 @@ export function GraphBoard({
 
                   `justify-center` inside an `auto` column is belt and braces:
                   the column is already exactly its content's width. It matters
-                  the moment anything joins the readout here. */}
-              <div className="flex items-center justify-center">
+                  the moment anything joins the readout here.
+
+                  `min-w-0 overflow-hidden` IS NOT decoration — it fixes a real
+                  bug this grid introduced. On a narrow viewport the three
+                  columns cannot all fit; the sides hold their `min-content`
+                  floors, so CSS squeezes the flexible `auto` track instead —
+                  measured at 30px against a 91px readout. The readout is
+                  `shrink-0`, so it kept its full width and, being centred,
+                  overhung its own column by 30px on EACH side, landing on top
+                  of the buttons either way. Not a cosmetic overlap: it
+                  intercepted their pointer events, and at 560px the children
+                  toggle became unclickable. Flex children cannot do this to
+                  each other, which is why the old flex row never could.
+
+                  Clipping is the right thing to lose first. Everything either
+                  side is a control; this is the one thing in the row you only
+                  read. */}
+              <div className="flex min-w-0 items-center justify-center overflow-hidden">
                 <FocusedAggregate
                   focusedId={focusedId}
                   pixelsPerSecond={deferredPixelsPerSecond}
@@ -2133,6 +2199,14 @@ export function GraphBoard({
                         />
                       </>
                     ) : null}
+                    {/* The ruler and the waveform are TOGGLES — things drawn
+                        onto the strip. The slider is a continuous control that
+                        changes the axis they are drawn against. Fenced apart
+                        because they read as one undifferentiated run
+                        otherwise, and only inside the flat branch: with the
+                        toggles gone this fence would open the group with a
+                        line against nothing. */}
+                    {flatOn ? <ControlFence /> : null}
                     <HeaderZoomControl
                       pixelsPerSecond={pixelsPerSecond}
                       onChange={onPixelsPerSecondChange}

--- a/apps/timeline-gstudio001/components/graph-view/graph-native-drop-engine.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-native-drop-engine.ts
@@ -23,6 +23,7 @@ import { resolveFlatDropTarget, type ClipDetail } from "@storyboard/timeline-dom
 
 import { mapWithConcurrency } from "@/lib/map-with-concurrency";
 import { probeVideoFile, uploadTimelineMedia } from "@/lib/timeline-media-client";
+import { GRAPH_ADD_ITEM_EVENT, type GraphAddItemDetail } from "@/lib/graph-view-events";
 
 import { useFlatItems } from "./graph-preview";
 import { classifyDroppedMedia, type DroppedMediaKind } from "./graph-dropped-media";
@@ -34,12 +35,30 @@ import {
   MAX_CONCURRENT_MEDIA,
   TOOL_MIME,
   aggregateDropStatus,
+  isAddItemTool,
   isSidebarTool,
   resolveAnchorIndex,
   type DropAnchor,
   type DropStatus,
   type DropSummary,
 } from "./graph-native-drop-model";
+
+/**
+ * A drop that has landed but not decided: WHERE it landed, and where on screen
+ * to ask WHAT it should be.
+ *
+ * The anchor is the same id-based `DropAnchor` a file drop carries, and for the
+ * same reason — it names its gap by the cards either side of it, so it still
+ * points at the place you dropped even if the board changes while the menu is
+ * open. That property was built for uploads finishing late; a menu waiting on a
+ * human is the same shape of wait, only longer and more likely.
+ */
+export type PendingAddChoice = Readonly<{
+  anchor: DropAnchor;
+  /** Viewport coordinates of the drop, for positioning the menu. */
+  clientX: number;
+  clientY: number;
+}>;
 
 /**
  * The surface-agnostic native-drop ENGINE: sidebar TOOL insertion, OS FILE
@@ -351,8 +370,14 @@ export function useNativeDrop(collectionId: string, projectId: string) {
     [addNodes, resolveAnchoredTarget, setDropStatus, projectId],
   );
 
+  // A dropped ADD ITEM, waiting on the user to say which kind. Null the rest
+  // of the time, which is what the surfaces render nothing from.
+  const [pendingChoice, setPendingChoice] = useState<PendingAddChoice | null>(null);
+  const cancelChoice = useCallback(() => setPendingChoice(null), []);
+
   /** Commit a drop whose insert boundary the surface already resolved. Tools
-   *  land synchronously; files hand the anchor over to the async upload. */
+   *  land synchronously; files hand the anchor over to the async upload; an
+   *  ADD ITEM drop lands nothing yet and opens its menu instead. */
   const commitDrop = useCallback(
     (event: DragEvent<HTMLElement>, anchor: DropAnchor) => {
       const tool = event.dataTransfer.getData(TOOL_MIME);
@@ -360,10 +385,61 @@ export function useNativeDrop(collectionId: string, projectId: string) {
         insertTool(tool, anchor.index);
         return;
       }
+      if (tool && isAddItemTool(tool)) {
+        // Park the position and ASK. Nothing is dispatched here — the graph is
+        // untouched until the menu is answered, so dismissing it leaves no
+        // trace, which is what makes Escape a real cancel rather than an undo.
+        setPendingChoice({ anchor, clientX: event.clientX, clientY: event.clientY });
+        return;
+      }
       const files = [...event.dataTransfer.files];
       if (files.length > 0) void dropFiles(files, anchor);
     },
     [insertTool, dropFiles],
+  );
+
+  /**
+   * Answer a pending choice with COLLECTION, at the position it was dropped.
+   *
+   * Re-resolves the anchor through `resolveAnchoredTarget` rather than reusing
+   * `anchor.index` the way the immediate tool path does. Both halves matter and
+   * neither is optional here:
+   *
+   * - TIME PASSED. A menu sat open while the board stayed live; a raw index
+   *   captured at drop time can name a different gap by the time it is used.
+   * - FLAT MODE. A flat boundary is not a parent-relative index, and
+   *   `resolveAnchoredTarget` is what converts it (see its own note). The
+   *   immediate path skipping that step is pre-existing behaviour this does not
+   *   touch — but a NEW path has no reason to inherit it.
+   *
+   * The insert runs OUTSIDE the state updater, reading the current choice from
+   * the closure. An updater must be pure — React calls it twice in StrictMode —
+   * and inserting from inside one adds two collections for one click.
+   */
+  const chooseCollection = useCallback(() => {
+    if (pendingChoice === null) return;
+    const target = resolveAnchoredTarget(pendingChoice.anchor);
+    setPendingChoice(null);
+    insertTool("collection", target.index, target.parentId);
+  }, [pendingChoice, insertTool, resolveAnchoredTarget]);
+
+  /**
+   * Answer a pending choice with MEDIA: the files go through the very same
+   * `dropFiles` an OS drop uses, at the parked anchor. One decode per video,
+   * bounded concurrency, per-file failure reporting, and ONE undoable commit
+   * all come along — none of it is reimplemented for this route.
+   *
+   * Outside the updater for the same reason as above: a StrictMode double-call
+   * would upload and insert every chosen file twice.
+   */
+  const chooseMedia = useCallback(
+    (files: readonly File[]) => {
+      if (pendingChoice === null) return;
+      const { anchor } = pendingChoice;
+      setPendingChoice(null);
+      if (files.length > 0) void dropFiles(files, anchor);
+    },
+    [pendingChoice, dropFiles],
   );
 
   /**
@@ -393,7 +469,43 @@ export function useNativeDrop(collectionId: string, projectId: string) {
     [dropFiles, store, collectionId],
   );
 
-  return { commitDrop, upload, appendFiles };
+  /**
+   * Append a collection to the end — the click half of "Add item".
+   *
+   * Reads the child count LIVE rather than taking an index from the caller: the
+   * button is in the controls row, several components away, and "the end" it
+   * meant when it rendered is not necessarily the end by the time it is
+   * pressed.
+   */
+  const appendCollection = useCallback(() => {
+    const children = getChildren(store.getSnapshot().graph, parseNodeId(collectionId));
+    insertTool("collection", children.length);
+  }, [store, collectionId, insertTool]);
+
+  // The controls row's Add item button, reaching down into this engine. See
+  // GRAPH_ADD_ITEM_EVENT for why it is ADDRESSED and not broadcast: every
+  // sub-timeline row mounts one of these, and an unaddressed event would add
+  // one item per row on screen.
+  useEffect(() => {
+    const onAddItem = (event: Event) => {
+      const detail = (event as CustomEvent<GraphAddItemDetail>).detail;
+      if (!detail || detail.collectionId !== collectionId) return;
+      if (detail.kind === "collection") appendCollection();
+      else appendFiles(detail.files);
+    };
+    window.addEventListener(GRAPH_ADD_ITEM_EVENT, onAddItem);
+    return () => window.removeEventListener(GRAPH_ADD_ITEM_EVENT, onAddItem);
+  }, [collectionId, appendCollection, appendFiles]);
+
+  return {
+    commitDrop,
+    upload,
+    appendFiles,
+    pendingChoice,
+    chooseCollection,
+    chooseMedia,
+    cancelChoice,
+  };
 }
 
 /**

--- a/apps/timeline-gstudio001/components/graph-view/graph-native-drop-grid.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-native-drop-grid.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef, useState, type DragEvent, type ReactNod
 import { getChildren, parseNodeId, useCollectionsStore } from "@storyboard/ui/dnd-collections";
 
 import { useNativeDragArmed } from "./graph-native-drag-signal";
+import { AddItemDropMenu } from "./graph-add-item-menu";
 import { AppendFilesContext, useNativeDrop } from "./graph-native-drop-engine";
 import {
   DROP_INDICATOR_CLASS,
@@ -45,7 +46,15 @@ export function NativeDropGrid({
   children,
 }: Readonly<{ collectionId: string; projectId: string; children: ReactNode }>) {
   const store = useCollectionsStore();
-  const { commitDrop, upload, appendFiles } = useNativeDrop(collectionId, projectId);
+  const {
+    commitDrop,
+    upload,
+    appendFiles,
+    pendingChoice,
+    chooseCollection,
+    chooseMedia,
+    cancelChoice,
+  } = useNativeDrop(collectionId, projectId);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const [indicator, setIndicator] = useState<GridIndicator | null>(null);
   const armed = useNativeDragArmed();
@@ -179,6 +188,16 @@ export function NativeDropGrid({
       onDrop={handleDrop}
     >
       <AppendFilesContext.Provider value={appendFiles}>{children}</AppendFilesContext.Provider>
+      {/* The strip's twin, from the same engine state — see the note there. */}
+      {pendingChoice !== null && (
+        <AddItemDropMenu
+          clientX={pendingChoice.clientX}
+          clientY={pendingChoice.clientY}
+          onCollection={chooseCollection}
+          onFiles={chooseMedia}
+          onDismiss={cancelChoice}
+        />
+      )}
       {indicator !== null && (
         <div
           data-native-drop-indicator

--- a/apps/timeline-gstudio001/components/graph-view/graph-native-drop-insertion.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-native-drop-insertion.ts
@@ -1,24 +1,16 @@
 "use client";
 
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
 
 import {
   parseNodeId,
-  useCollectionsContainer,
   useCollectionsStore,
   type CollectionItemNode,
   type NodeId,
 } from "@storyboard/ui/dnd-collections";
 
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
-import { resolveInsertPlacement } from "@/lib/graph-insert-placement";
-import {
-  GRAPH_INSERT_TOOL_EVENT,
-  isGraphInsertTool,
-  type GraphInsertToolDetail,
-} from "@/lib/graph-view-events";
-
-import { TOOL_LABELS, type SidebarTool } from "./graph-native-drop-model";
+import { type SidebarTool } from "./graph-native-drop-model";
 import { parkPendingDetail, unparkPendingDetail } from "./graph-pending-details";
 
 /** Mint an id with a time-ordered prefix. */
@@ -27,11 +19,19 @@ export function mintId(prefix: string): string {
 }
 
 /**
- * Mint-and-insert for the sidebar's tool palette, shared by the two ways a
- * tool can arrive: a native DRAG (which carries a pointer-derived index) and
- * plain ACTIVATION of the sidebar button (which appends). Extracted so the
- * keyboard path runs exactly the same code as the drop — an accessible route
- * that quietly diverges from the pointer one is how they drift apart.
+ * Mint-and-insert, shared by every way a collection can arrive: a native DROP
+ * (which carries a pointer-derived index), the Add item menu's answer at a drop
+ * point, its plain CLICK (which appends), and the trailing slot. Extracted so
+ * the keyboard path runs exactly the same code as the drop — an accessible
+ * route that quietly diverges from the pointer one is how they drift apart.
+ *
+ * There used to be a fifth caller here, `SidebarToolInsertBridge`: a window-event
+ * listener that inserted next to the SELECTION via `resolveInsertPlacement`. Its
+ * one dispatcher was the collection button in the controls row, and that button
+ * is now Add item, which appends. Nothing dispatched to it any more, so it went
+ * — a listener with no sender reads as live and is not. `resolveInsertPlacement`
+ * itself stays: PASTE uses it, which is where landing beside what you picked is
+ * unambiguously the right rule.
  */
 export function useToolInsertion(collectionId: string) {
   const store = useCollectionsStore();
@@ -116,58 +116,4 @@ export function useToolInsertion(collectionId: string) {
 export function useAppendCollection(collectionId: string): (toIndex: number) => boolean {
   const { insertTool } = useToolInsertion(collectionId);
   return useCallback((toIndex: number) => insertTool("collection", toIndex), [insertTool]);
-}
-
-/**
- * The KEYBOARD/click path for the sidebar tool palette. The sidebar is app
- * chrome living outside this provider, so it hands the tool off through a
- * window event (same pattern as the Assets launcher). SELECTION-AWARE via the
- * shared `resolveInsertPlacement`: the tool lands right after the most
- * recently selected card, inside THAT card's own timeline (any strip the
- * board is showing under the focused collection — clicking the tool never
- * clears selection, so this works for mouse and keyboard alike). With nothing
- * selected — or with a selection left BEHIND by a drill-in, which survives the
- * navigation and would otherwise plant the collection in the timeline the user
- * just left — it appends to the focused collection, the one spot that needs no
- * explanation. Dragging the tool remains the pointer-precision path either way.
- *
- * Mounted for BOTH surfaces, deliberately: `NativeDropStrip` only wraps the
- * strip, and an accessible control that silently does nothing in grid mode
- * would be worse than no control at all.
- */
-export function SidebarToolInsertBridge({
-  collectionId,
-}: Readonly<{ collectionId: string }>) {
-  const store = useCollectionsStore();
-  const { insertTool } = useToolInsertion(collectionId);
-  const { announce } = useCollectionsContainer();
-
-  useEffect(() => {
-    const handleInsert = (event: Event) => {
-      const tool = (event as CustomEvent<GraphInsertToolDetail>).detail?.tool;
-      if (!tool || !isGraphInsertTool(tool)) return;
-      const snapshot = store.getSnapshot();
-      const graph = snapshot.graph;
-      const { parentId, toIndex, afterId } = resolveInsertPlacement(
-        graph,
-        snapshot.interaction.selectedIds,
-        collectionId,
-      );
-      const landed = insertTool(tool, toIndex, parentId);
-      const target = graph.nodesById.get(parentId)?.name ?? "the timeline";
-      const afterName =
-        afterId !== null ? (graph.nodesById.get(afterId)?.name ?? "the selected clip") : null;
-      announce(
-        landed
-          ? afterName !== null
-            ? `Added a ${TOOL_LABELS[tool]} after "${afterName}" in "${target}".`
-            : `Added a ${TOOL_LABELS[tool]} to the end of "${target}".`
-          : `Could not add a ${TOOL_LABELS[tool]} to "${target}".`,
-      );
-    };
-    window.addEventListener(GRAPH_INSERT_TOOL_EVENT, handleInsert);
-    return () => window.removeEventListener(GRAPH_INSERT_TOOL_EVENT, handleInsert);
-  }, [store, collectionId, insertTool, announce]);
-
-  return null;
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-native-drop-model.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-native-drop-model.test.ts
@@ -8,7 +8,9 @@ import {
   cellFollowingPointer,
   gridDropAnchor,
   gridIndicatorGeometry,
+  ADD_ITEM_TOOL,
   indexOfChildId,
+  isAddItemTool,
   isSidebarTool,
   neighborsAt,
   resolveAnchorIndex,
@@ -64,6 +66,40 @@ describe("isSidebarTool", () => {
     expect(isSidebarTool("collection")).toBe(true);
     expect(isSidebarTool("image")).toBe(false);
     expect(isSidebarTool("")).toBe(false);
+  });
+});
+
+describe("isAddItemTool", () => {
+  it("admits the add-item payload only", () => {
+    expect(isAddItemTool(ADD_ITEM_TOOL)).toBe(true);
+    expect(isAddItemTool("collection")).toBe(false);
+    expect(isAddItemTool("")).toBe(false);
+  });
+
+  // THE POINT OF TWO PREDICATES. `commitDrop` branches on these in order, and
+  // a payload matching both would insert a collection immediately AND open the
+  // menu asking which kind to insert. Pinned as a test rather than left to
+  // reading, because the two live in different files from their caller.
+  it("is disjoint from isSidebarTool, both ways round", () => {
+    expect(isSidebarTool(ADD_ITEM_TOOL)).toBe(false);
+    expect(isAddItemTool("collection")).toBe(false);
+  });
+
+  // The value travels through the DOM as a `DataTransfer` string, so it is
+  // part of the wire format: an e2e that sets this payload by hand, and any
+  // drag begun before a deploy and dropped after it, both depend on the exact
+  // spelling.
+  it("has the spelling the drag payload carries", () => {
+    expect(ADD_ITEM_TOOL).toBe("add-item");
+  });
+});
+
+describe("acceptsDragTypes, for the add-item payload", () => {
+  // It rides the SAME mime as the collection tool, which is what lets every
+  // drop surface accept it, draw its indicator, and resolve its anchor without
+  // a single change. Only the commit differs.
+  it("is accepted by the surfaces without a new mime", () => {
+    expect(acceptsDragTypes([TOOL_MIME])).toBe(true);
   });
 });
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-native-drop-model.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-native-drop-model.ts
@@ -33,6 +33,31 @@ export const TOOL_LABELS: Readonly<Record<SidebarTool, string>> = {
   collection: "collection",
 };
 
+/**
+ * The ADD ITEM payload: a drag that asks a QUESTION rather than carrying an
+ * answer. Dropping it does not insert anything — it parks the drop position and
+ * opens a menu there, and what you pick is inserted at that position.
+ *
+ * Same MIME as the tool above, so every drop surface already accepts it
+ * (`acceptsDragTypes`), already draws its indicator, and already resolves its
+ * anchor. Only the commit differs, and that is one branch in `commitDrop`.
+ *
+ * DELIBERATELY NOT a member of `SidebarTool`. Every consumer of that union
+ * assumes its members are insertable — `TOOL_LABELS` names the thing that
+ * landed and `insertTool` mints a timeline for it — and "ask me which" is
+ * neither. Widening the union would have compiled and then quietly minted a
+ * collection for a payload whose entire purpose is that the kind is not yet
+ * known.
+ */
+export const ADD_ITEM_TOOL = "add-item";
+
+export function isAddItemTool(value: string): boolean {
+  return value === ADD_ITEM_TOOL;
+}
+
+/** What an add-item drop can resolve to, once the user picks. */
+export type AddItemKind = "collection" | "media";
+
 /** How many dropped files are decoded/uploaded at once. `Promise.all` over the
  *  whole drop meant N video decoders, canvases, blobs, and uploads existing
  *  simultaneously — dropping a folder of large videos produced a burst that

--- a/apps/timeline-gstudio001/components/graph-view/graph-native-drop-strip.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-native-drop-strip.tsx
@@ -6,6 +6,7 @@ import { getChildren, parseNodeId, useCollectionsStore } from "@storyboard/ui/dn
 
 import { useFlatItems } from "./graph-preview";
 import { useNativeDragArmed } from "./graph-native-drag-signal";
+import { AddItemDropMenu } from "./graph-add-item-menu";
 import { AppendFilesContext, useNativeDrop } from "./graph-native-drop-engine";
 import {
   DROP_INDICATOR_CLASS,
@@ -46,7 +47,15 @@ export function NativeDropStrip({
   // resolves its drop boundary in whatever order it is SHOWING, and in flat
   // mode that is not this collection's children.
   const flatItems = useFlatItems();
-  const { commitDrop, upload, appendFiles } = useNativeDrop(collectionId, projectId);
+  const {
+    commitDrop,
+    upload,
+    appendFiles,
+    pendingChoice,
+    chooseCollection,
+    chooseMedia,
+    cancelChoice,
+  } = useNativeDrop(collectionId, projectId);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const [indicatorX, setIndicatorX] = useState<number | null>(null);
   const armed = useNativeDragArmed();
@@ -192,6 +201,21 @@ export function NativeDropStrip({
       onDrop={handleDrop}
     >
       <AppendFilesContext.Provider value={appendFiles}>{children}</AppendFilesContext.Provider>
+      {/* A dropped "Add item" has landed a POSITION but not a kind; this asks
+          for the kind where it landed. Rendered from engine state rather than
+          from state of this component's own, so the grid gets the identical
+          behaviour from the identical code — the exact drift #30 was that only
+          the strip ever wired a drop target, and grid mode silently accepted
+          nothing. */}
+      {pendingChoice !== null && (
+        <AddItemDropMenu
+          clientX={pendingChoice.clientX}
+          clientY={pendingChoice.clientY}
+          onCollection={chooseCollection}
+          onFiles={chooseMedia}
+          onDismiss={cancelChoice}
+        />
+      )}
       {indicatorX !== null && (
         <div
           data-native-drop-indicator

--- a/apps/timeline-gstudio001/fixtures/dev-timelines.json
+++ b/apps/timeline-gstudio001/fixtures/dev-timelines.json
@@ -1,0 +1,282 @@
+{
+  "projectId": "project-dev-fixture",
+  "documents": {
+    "timeline-dev-scene-1": {
+      "id": "timeline-dev-scene-1",
+      "title": "Scene 1 — The Approach",
+      "clips": [
+        {
+          "id": "timeline-dev-scene-1-s1",
+          "index": 0,
+          "kind": "video",
+          "alt": "Wide, van pulls in",
+          "tags": [
+            "keeper"
+          ],
+          "src": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMjAiIGhlaWdodD0iMTgwIiB2aWV3Qm94PSIwIDAgMzIwIDE4MCI+PHJlY3Qgd2lkdGg9IjMyMCIgaGVpZ2h0PSIxODAiIGZpbGw9IiMxZTNhNWYiLz48dGV4dCB4PSIyNiIgeT0iOTYiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iNTQiIGZpbGw9IiM3ZGQzZmMiPuKWtjwvdGV4dD48dGV4dCB4PSI4NiIgeT0iODgiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTkiIGZpbGw9IiM3ZGQzZmMiPldpZGUsIHZhbiBwdWxscyBpbjwvdGV4dD48dGV4dCB4PSI4NiIgeT0iMTEyIiBmb250LWZhbWlseT0ibW9ub3NwYWNlIiBmb250LXNpemU9IjEzIiBmaWxsPSIjN2RkM2ZjIiBvcGFjaXR5PSIwLjY1Ij52aWRlbzwvdGV4dD48L3N2Zz4=",
+          "poster": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMjAiIGhlaWdodD0iMTgwIiB2aWV3Qm94PSIwIDAgMzIwIDE4MCI+PHJlY3Qgd2lkdGg9IjMyMCIgaGVpZ2h0PSIxODAiIGZpbGw9IiMxZTNhNWYiLz48dGV4dCB4PSIyNiIgeT0iOTYiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iNTQiIGZpbGw9IiM3ZGQzZmMiPuKWtjwvdGV4dD48dGV4dCB4PSI4NiIgeT0iODgiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTkiIGZpbGw9IiM3ZGQzZmMiPldpZGUsIHZhbiBwdWxscyBpbjwvdGV4dD48dGV4dCB4PSI4NiIgeT0iMTEyIiBmb250LWZhbWlseT0ibW9ub3NwYWNlIiBmb250LXNpemU9IjEzIiBmaWxsPSIjN2RkM2ZjIiBvcGFjaXR5PSIwLjY1Ij52aWRlbzwvdGV4dD48L3N2Zz4=",
+          "aspect": 1.7777777777777777,
+          "trackIndex": 0,
+          "startTime": 0,
+          "duration": 6,
+          "sourceDuration": 6,
+          "trimIn": 0,
+          "trimOut": 0
+        },
+        {
+          "id": "timeline-dev-scene-1-s2",
+          "index": 1,
+          "kind": "video",
+          "alt": "Pat at the wheel",
+          "tags": [
+            "wan2.1",
+            "keeper"
+          ],
+          "src": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMjAiIGhlaWdodD0iMTgwIiB2aWV3Qm94PSIwIDAgMzIwIDE4MCI+PHJlY3Qgd2lkdGg9IjMyMCIgaGVpZ2h0PSIxODAiIGZpbGw9IiMzZjJkNTYiLz48dGV4dCB4PSIyNiIgeT0iOTYiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iNTQiIGZpbGw9IiNjNGI1ZmQiPuKWtjwvdGV4dD48dGV4dCB4PSI4NiIgeT0iODgiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTkiIGZpbGw9IiNjNGI1ZmQiPlBhdCBhdCB0aGUgd2hlZWw8L3RleHQ+PHRleHQgeD0iODYiIHk9IjExMiIgZm9udC1mYW1pbHk9Im1vbm9zcGFjZSIgZm9udC1zaXplPSIxMyIgZmlsbD0iI2M0YjVmZCIgb3BhY2l0eT0iMC42NSI+dmlkZW88L3RleHQ+PC9zdmc+",
+          "poster": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMjAiIGhlaWdodD0iMTgwIiB2aWV3Qm94PSIwIDAgMzIwIDE4MCI+PHJlY3Qgd2lkdGg9IjMyMCIgaGVpZ2h0PSIxODAiIGZpbGw9IiMzZjJkNTYiLz48dGV4dCB4PSIyNiIgeT0iOTYiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iNTQiIGZpbGw9IiNjNGI1ZmQiPuKWtjwvdGV4dD48dGV4dCB4PSI4NiIgeT0iODgiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTkiIGZpbGw9IiNjNGI1ZmQiPlBhdCBhdCB0aGUgd2hlZWw8L3RleHQ+PHRleHQgeD0iODYiIHk9IjExMiIgZm9udC1mYW1pbHk9Im1vbm9zcGFjZSIgZm9udC1zaXplPSIxMyIgZmlsbD0iI2M0YjVmZCIgb3BhY2l0eT0iMC42NSI+dmlkZW88L3RleHQ+PC9zdmc+",
+          "aspect": 1.7777777777777777,
+          "trackIndex": 0,
+          "startTime": 0,
+          "duration": 4,
+          "sourceDuration": 4,
+          "trimIn": 0,
+          "trimOut": 0
+        },
+        {
+          "id": "timeline-dev-scene-1-s3",
+          "index": 2,
+          "kind": "image",
+          "alt": "Door plate",
+          "tags": [
+            "minimax-h3"
+          ],
+          "src": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMjAiIGhlaWdodD0iMTgwIiB2aWV3Qm94PSIwIDAgMzIwIDE4MCI+PHJlY3Qgd2lkdGg9IjMyMCIgaGVpZ2h0PSIxODAiIGZpbGw9IiMxNDUzMmQiLz48dGV4dCB4PSIyNiIgeT0iOTYiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iNTQiIGZpbGw9IiM4NmVmYWMiPuKWozwvdGV4dD48dGV4dCB4PSI4NiIgeT0iODgiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTkiIGZpbGw9IiM4NmVmYWMiPkRvb3IgcGxhdGU8L3RleHQ+PHRleHQgeD0iODYiIHk9IjExMiIgZm9udC1mYW1pbHk9Im1vbm9zcGFjZSIgZm9udC1zaXplPSIxMyIgZmlsbD0iIzg2ZWZhYyIgb3BhY2l0eT0iMC42NSI+aW1hZ2U8L3RleHQ+PC9zdmc+",
+          "poster": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMjAiIGhlaWdodD0iMTgwIiB2aWV3Qm94PSIwIDAgMzIwIDE4MCI+PHJlY3Qgd2lkdGg9IjMyMCIgaGVpZ2h0PSIxODAiIGZpbGw9IiMxNDUzMmQiLz48dGV4dCB4PSIyNiIgeT0iOTYiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iNTQiIGZpbGw9IiM4NmVmYWMiPuKWozwvdGV4dD48dGV4dCB4PSI4NiIgeT0iODgiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTkiIGZpbGw9IiM4NmVmYWMiPkRvb3IgcGxhdGU8L3RleHQ+PHRleHQgeD0iODYiIHk9IjExMiIgZm9udC1mYW1pbHk9Im1vbm9zcGFjZSIgZm9udC1zaXplPSIxMyIgZmlsbD0iIzg2ZWZhYyIgb3BhY2l0eT0iMC42NSI+aW1hZ2U8L3RleHQ+PC9zdmc+",
+          "aspect": 1.7777777777777777,
+          "trackIndex": 0,
+          "startTime": 0,
+          "duration": 3,
+          "sourceDuration": 3,
+          "trimIn": 0,
+          "trimOut": 0
+        }
+      ]
+    },
+    "timeline-dev-scene-2": {
+      "id": "timeline-dev-scene-2",
+      "title": "Scene 2 — The Briefing",
+      "clips": [
+        {
+          "id": "timeline-dev-scene-2-s1",
+          "index": 0,
+          "kind": "video",
+          "alt": "Pat, medium",
+          "tags": [
+            "needs-retake"
+          ],
+          "src": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMjAiIGhlaWdodD0iMTgwIiB2aWV3Qm94PSIwIDAgMzIwIDE4MCI+PHJlY3Qgd2lkdGg9IjMyMCIgaGVpZ2h0PSIxODAiIGZpbGw9IiM1YzJlMmUiLz48dGV4dCB4PSIyNiIgeT0iOTYiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iNTQiIGZpbGw9IiNmY2E1YTUiPuKWtjwvdGV4dD48dGV4dCB4PSI4NiIgeT0iODgiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTkiIGZpbGw9IiNmY2E1YTUiPlBhdCwgbWVkaXVtPC90ZXh0Pjx0ZXh0IHg9Ijg2IiB5PSIxMTIiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTMiIGZpbGw9IiNmY2E1YTUiIG9wYWNpdHk9IjAuNjUiPnZpZGVvPC90ZXh0Pjwvc3ZnPg==",
+          "poster": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMjAiIGhlaWdodD0iMTgwIiB2aWV3Qm94PSIwIDAgMzIwIDE4MCI+PHJlY3Qgd2lkdGg9IjMyMCIgaGVpZ2h0PSIxODAiIGZpbGw9IiM1YzJlMmUiLz48dGV4dCB4PSIyNiIgeT0iOTYiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iNTQiIGZpbGw9IiNmY2E1YTUiPuKWtjwvdGV4dD48dGV4dCB4PSI4NiIgeT0iODgiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTkiIGZpbGw9IiNmY2E1YTUiPlBhdCwgbWVkaXVtPC90ZXh0Pjx0ZXh0IHg9Ijg2IiB5PSIxMTIiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTMiIGZpbGw9IiNmY2E1YTUiIG9wYWNpdHk9IjAuNjUiPnZpZGVvPC90ZXh0Pjwvc3ZnPg==",
+          "aspect": 1.7777777777777777,
+          "trackIndex": 0,
+          "startTime": 0,
+          "duration": 5,
+          "sourceDuration": 5,
+          "trimIn": 0,
+          "trimOut": 0
+        },
+        {
+          "id": "timeline-dev-scene-2-s2",
+          "index": 1,
+          "kind": "video",
+          "alt": "Brian, reverse",
+          "tags": [
+            "wan2.1"
+          ],
+          "src": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMjAiIGhlaWdodD0iMTgwIiB2aWV3Qm94PSIwIDAgMzIwIDE4MCI+PHJlY3Qgd2lkdGg9IjMyMCIgaGVpZ2h0PSIxODAiIGZpbGw9IiM0YTNjMTciLz48dGV4dCB4PSIyNiIgeT0iOTYiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iNTQiIGZpbGw9IiNmZGUwNDciPuKWtjwvdGV4dD48dGV4dCB4PSI4NiIgeT0iODgiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTkiIGZpbGw9IiNmZGUwNDciPkJyaWFuLCByZXZlcnNlPC90ZXh0Pjx0ZXh0IHg9Ijg2IiB5PSIxMTIiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTMiIGZpbGw9IiNmZGUwNDciIG9wYWNpdHk9IjAuNjUiPnZpZGVvPC90ZXh0Pjwvc3ZnPg==",
+          "poster": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMjAiIGhlaWdodD0iMTgwIiB2aWV3Qm94PSIwIDAgMzIwIDE4MCI+PHJlY3Qgd2lkdGg9IjMyMCIgaGVpZ2h0PSIxODAiIGZpbGw9IiM0YTNjMTciLz48dGV4dCB4PSIyNiIgeT0iOTYiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iNTQiIGZpbGw9IiNmZGUwNDciPuKWtjwvdGV4dD48dGV4dCB4PSI4NiIgeT0iODgiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTkiIGZpbGw9IiNmZGUwNDciPkJyaWFuLCByZXZlcnNlPC90ZXh0Pjx0ZXh0IHg9Ijg2IiB5PSIxMTIiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTMiIGZpbGw9IiNmZGUwNDciIG9wYWNpdHk9IjAuNjUiPnZpZGVvPC90ZXh0Pjwvc3ZnPg==",
+          "aspect": 1.7777777777777777,
+          "trackIndex": 0,
+          "startTime": 0,
+          "duration": 5,
+          "sourceDuration": 5,
+          "trimIn": 0,
+          "trimOut": 0
+        },
+        {
+          "id": "timeline-dev-scene-2-s3",
+          "index": 2,
+          "kind": "video",
+          "alt": "Two-shot",
+          "tags": [
+            "minimax-h3",
+            "keeper"
+          ],
+          "src": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMjAiIGhlaWdodD0iMTgwIiB2aWV3Qm94PSIwIDAgMzIwIDE4MCI+PHJlY3Qgd2lkdGg9IjMyMCIgaGVpZ2h0PSIxODAiIGZpbGw9IiMxNjRlNjMiLz48dGV4dCB4PSIyNiIgeT0iOTYiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iNTQiIGZpbGw9IiM2N2U4ZjkiPuKWtjwvdGV4dD48dGV4dCB4PSI4NiIgeT0iODgiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTkiIGZpbGw9IiM2N2U4ZjkiPlR3by1zaG90PC90ZXh0Pjx0ZXh0IHg9Ijg2IiB5PSIxMTIiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTMiIGZpbGw9IiM2N2U4ZjkiIG9wYWNpdHk9IjAuNjUiPnZpZGVvPC90ZXh0Pjwvc3ZnPg==",
+          "poster": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMjAiIGhlaWdodD0iMTgwIiB2aWV3Qm94PSIwIDAgMzIwIDE4MCI+PHJlY3Qgd2lkdGg9IjMyMCIgaGVpZ2h0PSIxODAiIGZpbGw9IiMxNjRlNjMiLz48dGV4dCB4PSIyNiIgeT0iOTYiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iNTQiIGZpbGw9IiM2N2U4ZjkiPuKWtjwvdGV4dD48dGV4dCB4PSI4NiIgeT0iODgiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTkiIGZpbGw9IiM2N2U4ZjkiPlR3by1zaG90PC90ZXh0Pjx0ZXh0IHg9Ijg2IiB5PSIxMTIiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTMiIGZpbGw9IiM2N2U4ZjkiIG9wYWNpdHk9IjAuNjUiPnZpZGVvPC90ZXh0Pjwvc3ZnPg==",
+          "aspect": 1.7777777777777777,
+          "trackIndex": 0,
+          "startTime": 0,
+          "duration": 7,
+          "sourceDuration": 7,
+          "trimIn": 0,
+          "trimOut": 0
+        },
+        {
+          "id": "timeline-dev-scene-2-x1",
+          "index": 3,
+          "kind": "audio",
+          "alt": "Room tone bed",
+          "tags": [
+            "keeper"
+          ],
+          "src": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMjAiIGhlaWdodD0iMTgwIiB2aWV3Qm94PSIwIDAgMzIwIDE4MCI+PHJlY3Qgd2lkdGg9IjMyMCIgaGVpZ2h0PSIxODAiIGZpbGw9IiMxZTNhNWYiLz48dGV4dCB4PSIyNiIgeT0iOTYiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iNTQiIGZpbGw9IiM3ZGQzZmMiPuKZqjwvdGV4dD48dGV4dCB4PSI4NiIgeT0iODgiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTkiIGZpbGw9IiM3ZGQzZmMiPlJvb20gdG9uZSBiZWQ8L3RleHQ+PHRleHQgeD0iODYiIHk9IjExMiIgZm9udC1mYW1pbHk9Im1vbm9zcGFjZSIgZm9udC1zaXplPSIxMyIgZmlsbD0iIzdkZDNmYyIgb3BhY2l0eT0iMC42NSI+YXVkaW88L3RleHQ+PC9zdmc+",
+          "aspect": 1.7777777777777777,
+          "trackIndex": 1,
+          "placedStart": 5,
+          "startTime": 0,
+          "duration": 12,
+          "sourceDuration": 12,
+          "trimIn": 0,
+          "trimOut": 0
+        }
+      ]
+    },
+    "timeline-dev-scene-3": {
+      "id": "timeline-dev-scene-3",
+      "title": "Scene 3 — Outside",
+      "clips": [
+        {
+          "id": "timeline-dev-scene-3-s1",
+          "index": 0,
+          "kind": "image",
+          "alt": "Street, dusk",
+          "tags": [
+            "wan2.1",
+            "keeper"
+          ],
+          "src": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMjAiIGhlaWdodD0iMTgwIiB2aWV3Qm94PSIwIDAgMzIwIDE4MCI+PHJlY3Qgd2lkdGg9IjMyMCIgaGVpZ2h0PSIxODAiIGZpbGw9IiMzZjJkNTYiLz48dGV4dCB4PSIyNiIgeT0iOTYiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iNTQiIGZpbGw9IiNjNGI1ZmQiPuKWozwvdGV4dD48dGV4dCB4PSI4NiIgeT0iODgiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTkiIGZpbGw9IiNjNGI1ZmQiPlN0cmVldCwgZHVzazwvdGV4dD48dGV4dCB4PSI4NiIgeT0iMTEyIiBmb250LWZhbWlseT0ibW9ub3NwYWNlIiBmb250LXNpemU9IjEzIiBmaWxsPSIjYzRiNWZkIiBvcGFjaXR5PSIwLjY1Ij5pbWFnZTwvdGV4dD48L3N2Zz4=",
+          "poster": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMjAiIGhlaWdodD0iMTgwIiB2aWV3Qm94PSIwIDAgMzIwIDE4MCI+PHJlY3Qgd2lkdGg9IjMyMCIgaGVpZ2h0PSIxODAiIGZpbGw9IiMzZjJkNTYiLz48dGV4dCB4PSIyNiIgeT0iOTYiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iNTQiIGZpbGw9IiNjNGI1ZmQiPuKWozwvdGV4dD48dGV4dCB4PSI4NiIgeT0iODgiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTkiIGZpbGw9IiNjNGI1ZmQiPlN0cmVldCwgZHVzazwvdGV4dD48dGV4dCB4PSI4NiIgeT0iMTEyIiBmb250LWZhbWlseT0ibW9ub3NwYWNlIiBmb250LXNpemU9IjEzIiBmaWxsPSIjYzRiNWZkIiBvcGFjaXR5PSIwLjY1Ij5pbWFnZTwvdGV4dD48L3N2Zz4=",
+          "aspect": 1.7777777777777777,
+          "trackIndex": 0,
+          "startTime": 0,
+          "duration": 4,
+          "sourceDuration": 4,
+          "trimIn": 0,
+          "trimOut": 0
+        },
+        {
+          "id": "timeline-dev-scene-3-s2",
+          "index": 1,
+          "kind": "video",
+          "alt": "They leave",
+          "tags": [
+            "minimax-h3"
+          ],
+          "src": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMjAiIGhlaWdodD0iMTgwIiB2aWV3Qm94PSIwIDAgMzIwIDE4MCI+PHJlY3Qgd2lkdGg9IjMyMCIgaGVpZ2h0PSIxODAiIGZpbGw9IiMxNDUzMmQiLz48dGV4dCB4PSIyNiIgeT0iOTYiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iNTQiIGZpbGw9IiM4NmVmYWMiPuKWtjwvdGV4dD48dGV4dCB4PSI4NiIgeT0iODgiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTkiIGZpbGw9IiM4NmVmYWMiPlRoZXkgbGVhdmU8L3RleHQ+PHRleHQgeD0iODYiIHk9IjExMiIgZm9udC1mYW1pbHk9Im1vbm9zcGFjZSIgZm9udC1zaXplPSIxMyIgZmlsbD0iIzg2ZWZhYyIgb3BhY2l0eT0iMC42NSI+dmlkZW88L3RleHQ+PC9zdmc+",
+          "poster": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMjAiIGhlaWdodD0iMTgwIiB2aWV3Qm94PSIwIDAgMzIwIDE4MCI+PHJlY3Qgd2lkdGg9IjMyMCIgaGVpZ2h0PSIxODAiIGZpbGw9IiMxNDUzMmQiLz48dGV4dCB4PSIyNiIgeT0iOTYiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iNTQiIGZpbGw9IiM4NmVmYWMiPuKWtjwvdGV4dD48dGV4dCB4PSI4NiIgeT0iODgiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTkiIGZpbGw9IiM4NmVmYWMiPlRoZXkgbGVhdmU8L3RleHQ+PHRleHQgeD0iODYiIHk9IjExMiIgZm9udC1mYW1pbHk9Im1vbm9zcGFjZSIgZm9udC1zaXplPSIxMyIgZmlsbD0iIzg2ZWZhYyIgb3BhY2l0eT0iMC42NSI+dmlkZW88L3RleHQ+PC9zdmc+",
+          "aspect": 1.7777777777777777,
+          "trackIndex": 0,
+          "startTime": 0,
+          "duration": 5,
+          "sourceDuration": 5,
+          "trimIn": 0,
+          "trimOut": 0
+        }
+      ]
+    },
+    "project-dev-fixture": {
+      "id": "project-dev-fixture",
+      "title": "Dev Fixture — offline board",
+      "isProject": true,
+      "clips": [
+        {
+          "id": "dev-cold-open",
+          "index": 0,
+          "kind": "video",
+          "alt": "Cold open",
+          "tags": [
+            "needs-retake"
+          ],
+          "src": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMjAiIGhlaWdodD0iMTgwIiB2aWV3Qm94PSIwIDAgMzIwIDE4MCI+PHJlY3Qgd2lkdGg9IjMyMCIgaGVpZ2h0PSIxODAiIGZpbGw9IiM1YzJlMmUiLz48dGV4dCB4PSIyNiIgeT0iOTYiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iNTQiIGZpbGw9IiNmY2E1YTUiPuKWtjwvdGV4dD48dGV4dCB4PSI4NiIgeT0iODgiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTkiIGZpbGw9IiNmY2E1YTUiPkNvbGQgb3BlbjwvdGV4dD48dGV4dCB4PSI4NiIgeT0iMTEyIiBmb250LWZhbWlseT0ibW9ub3NwYWNlIiBmb250LXNpemU9IjEzIiBmaWxsPSIjZmNhNWE1IiBvcGFjaXR5PSIwLjY1Ij52aWRlbzwvdGV4dD48L3N2Zz4=",
+          "poster": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMjAiIGhlaWdodD0iMTgwIiB2aWV3Qm94PSIwIDAgMzIwIDE4MCI+PHJlY3Qgd2lkdGg9IjMyMCIgaGVpZ2h0PSIxODAiIGZpbGw9IiM1YzJlMmUiLz48dGV4dCB4PSIyNiIgeT0iOTYiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iNTQiIGZpbGw9IiNmY2E1YTUiPuKWtjwvdGV4dD48dGV4dCB4PSI4NiIgeT0iODgiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTkiIGZpbGw9IiNmY2E1YTUiPkNvbGQgb3BlbjwvdGV4dD48dGV4dCB4PSI4NiIgeT0iMTEyIiBmb250LWZhbWlseT0ibW9ub3NwYWNlIiBmb250LXNpemU9IjEzIiBmaWxsPSIjZmNhNWE1IiBvcGFjaXR5PSIwLjY1Ij52aWRlbzwvdGV4dD48L3N2Zz4=",
+          "aspect": 1.7777777777777777,
+          "trackIndex": 0,
+          "startTime": 0,
+          "duration": 5,
+          "sourceDuration": 5,
+          "trimIn": 0,
+          "trimOut": 0
+        },
+        {
+          "id": "dev-c1",
+          "index": 1,
+          "kind": "collection",
+          "title": "Scene 1 — The Approach",
+          "childTimelineId": "timeline-dev-scene-1",
+          "itemCount": 3,
+          "previewItems": [],
+          "alt": "Scene 1 — The Approach",
+          "aspect": 1.7777777777777777,
+          "trackIndex": 0,
+          "startTime": 0,
+          "duration": 3,
+          "sourceDuration": 3,
+          "trimIn": 0,
+          "trimOut": 0
+        },
+        {
+          "id": "dev-c2",
+          "index": 2,
+          "kind": "collection",
+          "title": "Scene 2 — The Briefing",
+          "childTimelineId": "timeline-dev-scene-2",
+          "itemCount": 4,
+          "previewItems": [],
+          "alt": "Scene 2 — The Briefing",
+          "aspect": 1.7777777777777777,
+          "trackIndex": 0,
+          "startTime": 0,
+          "duration": 3,
+          "sourceDuration": 3,
+          "trimIn": 0,
+          "trimOut": 0
+        },
+        {
+          "id": "dev-c3",
+          "index": 3,
+          "kind": "collection",
+          "title": "Scene 3 — Outside",
+          "childTimelineId": "timeline-dev-scene-3",
+          "itemCount": 2,
+          "previewItems": [],
+          "alt": "Scene 3 — Outside",
+          "aspect": 1.7777777777777777,
+          "trackIndex": 0,
+          "startTime": 0,
+          "duration": 3,
+          "sourceDuration": 3,
+          "trimIn": 0,
+          "trimOut": 0
+        },
+        {
+          "id": "dev-tail",
+          "index": 4,
+          "kind": "image",
+          "alt": "End card",
+          "tags": [
+            "wan2.1"
+          ],
+          "src": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMjAiIGhlaWdodD0iMTgwIiB2aWV3Qm94PSIwIDAgMzIwIDE4MCI+PHJlY3Qgd2lkdGg9IjMyMCIgaGVpZ2h0PSIxODAiIGZpbGw9IiM0YTNjMTciLz48dGV4dCB4PSIyNiIgeT0iOTYiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iNTQiIGZpbGw9IiNmZGUwNDciPuKWozwvdGV4dD48dGV4dCB4PSI4NiIgeT0iODgiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTkiIGZpbGw9IiNmZGUwNDciPkVuZCBjYXJkPC90ZXh0Pjx0ZXh0IHg9Ijg2IiB5PSIxMTIiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTMiIGZpbGw9IiNmZGUwNDciIG9wYWNpdHk9IjAuNjUiPmltYWdlPC90ZXh0Pjwvc3ZnPg==",
+          "poster": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMjAiIGhlaWdodD0iMTgwIiB2aWV3Qm94PSIwIDAgMzIwIDE4MCI+PHJlY3Qgd2lkdGg9IjMyMCIgaGVpZ2h0PSIxODAiIGZpbGw9IiM0YTNjMTciLz48dGV4dCB4PSIyNiIgeT0iOTYiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iNTQiIGZpbGw9IiNmZGUwNDciPuKWozwvdGV4dD48dGV4dCB4PSI4NiIgeT0iODgiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTkiIGZpbGw9IiNmZGUwNDciPkVuZCBjYXJkPC90ZXh0Pjx0ZXh0IHg9Ijg2IiB5PSIxMTIiIGZvbnQtZmFtaWx5PSJtb25vc3BhY2UiIGZvbnQtc2l6ZT0iMTMiIGZpbGw9IiNmZGUwNDciIG9wYWNpdHk9IjAuNjUiPmltYWdlPC90ZXh0Pjwvc3ZnPg==",
+          "aspect": 1.7777777777777777,
+          "trackIndex": 0,
+          "startTime": 0,
+          "duration": 3,
+          "sourceDuration": 3,
+          "trimIn": 0,
+          "trimOut": 0
+        }
+      ]
+    }
+  }
+}

--- a/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
@@ -5,6 +5,14 @@ import { FieldValue, Timestamp } from "firebase-admin/firestore";
 import type { TimelineDocument, TimelineClip } from "@storyboard/timeline-model/types";
 import { getFirebaseDb } from "./firebase-admin";
 import { firstFrameUrl } from "./project-thumbnail";
+import {
+  fixtureCreateProject,
+  fixtureDeleteDocument,
+  fixtureListProjects,
+  fixtureReadEntry,
+  fixtureStoreEnabled,
+  fixtureWriteDocuments,
+} from "./fixture-timeline-store";
 import { resolveOwnership, TimelineAccessDeniedError } from "./timeline-ownership";
 import {
   describeFirestoreFailure,
@@ -398,6 +406,8 @@ async function ownedProjectDocs(requesterUid: string) {
 }
 
 export async function listFirebaseTimelineProjects(requesterUid: string) {
+  if (fixtureStoreEnabled()) return fixtureListProjects();
+
   const docs = await ownedProjectDocs(requesterUid);
 
   // Listing is READ ONLY. It used to stamp `ownerUid` onto every ownerless
@@ -539,6 +549,13 @@ export async function readStoredTimelineEntry(
   id: string,
   requesterUid: string,
 ): Promise<TimelineEntry | null> {
+  // OFFLINE MODE. Dev-only, refused outright in production — see
+  // `fixture-timeline-store`. Intercepted HERE rather than per route because
+  // this is the single read seam: `serveTimelineDocument`, `serveTrashDocument`,
+  // the RSC focus-path loader and the closure walker all come through it, so
+  // one branch covers every reader and none of them can drift.
+  if (fixtureStoreEnabled()) return fixtureReadEntry(id);
+
   const snapshot = await withFirebaseTimeout(
     collection().doc(id).get(),
     "Loading timeline document",
@@ -625,6 +642,15 @@ export async function saveFirebaseTimelineEntry(
   }
 
   const normalizedDocument = normalizeDocument(document);
+
+  // OFFLINE MODE — see readStoredTimelineEntry. Last-write-wins, which is what
+  // this path already is, so nothing is lost by not modelling the transaction.
+  if (fixtureStoreEnabled()) {
+    fixtureWriteDocuments([normalizedDocument]);
+    const entry = fixtureReadEntry(normalizedDocument.id);
+    return entry ?? { document: normalizedDocument, revision: 1 };
+  }
+
   const ref = collection().doc(normalizedDocument.id);
 
   // ONE TRANSACTION for read, checks and write.
@@ -778,6 +804,21 @@ export async function saveFirebaseTimelineDocumentsAtomic(
   const ids = writes.map((write) => write.document.id);
   if (new Set(ids).size !== ids.length) {
     throw new Error("A batch write must not repeat a timeline id.");
+  }
+
+  // OFFLINE MODE. The two guards above still run — they are pure argument
+  // checks and catching a malformed batch offline is strictly better than
+  // discovering it later against the real store. What is NOT modelled below is
+  // everything the transaction does: revision compare-and-set, the orphan
+  // guard, the duplicate-owner guard. Offline writes always succeed, so a
+  // conflict or an orphan is invisible here BY CONSTRUCTION and has to be
+  // verified against Firestore.
+  if (fixtureStoreEnabled()) {
+    fixtureWriteDocuments(writes.map((write) => write.document));
+    return writes.map((write) => ({
+      id: write.document.id,
+      revision: (write.expectedRevision ?? 0) + 1,
+    }));
   }
 
   return withFirebaseTimeout(
@@ -957,7 +998,8 @@ export async function createFirebaseTimelineProject(requesterUid: string, title?
     description: "Custom timeline project.",
     clips: [],
   };
-  await saveFirebaseTimelineDocument(document, requesterUid, { isProject: true });
+  if (fixtureStoreEnabled()) fixtureCreateProject(id, cleanTitle);
+  else await saveFirebaseTimelineDocument(document, requesterUid, { isProject: true });
   return document;
 }
 
@@ -1008,6 +1050,14 @@ const CASCADE_READ_CONCURRENCY = 12;
 const FIRESTORE_BATCH_LIMIT = 500;
 
 export async function deleteFirebaseTimelineDocument(id: string, requesterUid: string) {
+  // OFFLINE MODE. The real path cascades through children with a size ceiling;
+  // this removes the one document and nothing else, so an offline delete leaves
+  // orphans the real one would have taken with it.
+  if (fixtureStoreEnabled()) {
+    fixtureDeleteDocument(id);
+    return;
+  }
+
   const visited = new Set<string>([id]);
   // Root-first, so reversing it deletes the deepest documents first and the
   // root last — relevant only in the multi-batch path below, where a failure

--- a/apps/timeline-gstudio001/lib/fixture-timeline-store.ts
+++ b/apps/timeline-gstudio001/lib/fixture-timeline-store.ts
@@ -1,0 +1,156 @@
+import "server-only";
+
+import { readFileSync, statSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
+
+import type { TimelineDocument } from "@storyboard/timeline-model/types";
+
+import type { TimelineEntry, TimelineProjectSummary } from "./firebase-timeline-store";
+
+/**
+ * An OFFLINE timeline store, backed by a JSON file instead of Firestore.
+ *
+ * Why it exists: Firestore's free tier allows 50,000 document reads a day, and
+ * a day of development on a large project reaches that (see #437 — entering the
+ * graph view invalidates every cached document). When it runs out, the app is
+ * unopenable until midnight Pacific and no UI work can be done at all. This is
+ * the way back in: a board full of dummy content that never touches the network.
+ *
+ * WHAT IT IS NOT. This is not a Firestore emulator and not a second source of
+ * truth. It answers reads from one file and holds writes in memory; nothing
+ * persists past a server restart, and no revision conflict, ownership rule, or
+ * batch atomicity is modelled. Use it to look at the UI, not to trust the data
+ * layer — anything about PERSISTENCE has to be verified against the real store.
+ *
+ * ── Refused in production, unconditionally ─────────────────────────────────
+ *
+ * This bypasses the ownership check that is the store's one authorization
+ * invariant, because dummy documents have no owner. A flag that both fakes the
+ * database and disables access control must not be one environment variable
+ * away from being live, so `NODE_ENV === "production"` refuses it outright and
+ * the variable is ignored rather than honoured.
+ */
+
+const ENV_PATH = "GSTUDIO_FIXTURE_TIMELINES";
+
+export function fixtureStoreEnabled(): boolean {
+  // Both halves, in this order. The NODE_ENV check is the one that matters and
+  // it is deliberately not overridable.
+  if (process.env.NODE_ENV === "production") return false;
+  return (process.env[ENV_PATH] ?? "").trim().length > 0;
+}
+
+type FixtureFile = Readonly<{
+  projectId?: string;
+  documents: Readonly<Record<string, TimelineDocument & { isProject?: boolean }>>;
+}>;
+
+type FixtureState = {
+  documents: Map<string, TimelineDocument & { isProject?: boolean }>;
+  revisions: Map<string, number>;
+  /** Modified time of the JSON this was built from — see `load`. */
+  sourceMtimeMs: number;
+};
+
+// On `globalThis`, not a module-level `let`. The dev server re-evaluates
+// modules on every edit, and a plain module variable would drop every write
+// made since the last save — turning "I added three clips" into an empty board
+// the moment an unrelated file was touched.
+const STATE_KEY = Symbol.for("gstudio.fixtureTimelineStore");
+
+function load(): FixtureState {
+  const globalScope = globalThis as unknown as Record<symbol, FixtureState | undefined>;
+  const configured = (process.env[ENV_PATH] ?? "").trim();
+  const path = isAbsolute(configured) ? configured : join(process.cwd(), configured);
+  // RELOAD WHEN THE FILE CHANGES, and keep the cache otherwise.
+  //
+  // The cache is what lets writes survive HMR, and it is also what made
+  // regenerating the JSON appear to do nothing: the state was built once per
+  // server process, so a fresh fixture needed a server restart to be seen —
+  // which reads exactly like the generator being broken. One stat per read is
+  // cheap next to the Firestore round trip this stands in for.
+  //
+  // The cost is honest and worth stating: reloading DISCARDS in-memory writes,
+  // because the file is the new truth. Editing the fixture resets the board.
+  const mtimeMs = statSync(path).mtimeMs;
+  const existing = globalScope[STATE_KEY];
+  if (existing && existing.sourceMtimeMs === mtimeMs) return existing;
+
+  const parsed = JSON.parse(readFileSync(path, "utf8")) as FixtureFile;
+
+  const state: FixtureState = {
+    documents: new Map(Object.entries(parsed.documents ?? {})),
+    revisions: new Map(),
+    sourceMtimeMs: mtimeMs,
+  };
+  // Revision 1, not 0: the client treats 0 as "this document does not exist
+  // yet, my first write creates it", and every fixture document plainly does
+  // exist. Starting at 0 makes the first save look like a create-collision.
+  for (const id of state.documents.keys()) state.revisions.set(id, 1);
+  globalScope[STATE_KEY] = state;
+  return state;
+}
+
+/** A DEEP copy, so a caller mutating what it was served cannot edit the store
+ *  underneath the next reader. The real store returns fresh objects from
+ *  Firestore every time; this has to imitate that or it teaches wrong lessons. */
+function copy<T>(value: T): T {
+  return structuredClone(value);
+}
+
+export function fixtureReadEntry(id: string): TimelineEntry | null {
+  const state = load();
+  const document = state.documents.get(id);
+  if (!document) return null;
+  return { document: copy(document), revision: state.revisions.get(id) ?? 1 };
+}
+
+export function fixtureWriteDocuments(documents: readonly TimelineDocument[]): void {
+  const state = load();
+  for (const document of documents) {
+    const previous = state.documents.get(document.id);
+    state.documents.set(document.id, {
+      ...copy(document),
+      // `isProject` is set once at creation and never travels on a clips write,
+      // so carrying it forward is what stops a save demoting the project into
+      // an ordinary timeline and dropping it out of the project list.
+      ...(previous?.isProject ? { isProject: true } : {}),
+    });
+    state.revisions.set(document.id, (state.revisions.get(document.id) ?? 0) + 1);
+  }
+}
+
+export function fixtureDeleteDocument(id: string): void {
+  const state = load();
+  state.documents.delete(id);
+  state.revisions.delete(id);
+}
+
+export function fixtureListProjects(): TimelineProjectSummary[] {
+  const state = load();
+  const out: TimelineProjectSummary[] = [];
+  for (const [id, document] of state.documents) {
+    if (document.isProject !== true) continue;
+    // No timestamps: the fixture has no clock (the generator is deterministic
+    // by design) and the field is optional. A fabricated date would sort the
+    // list by a number that means nothing.
+    out.push({
+      id,
+      title: document.title,
+      description: document.description,
+      clipCount: document.clips.length,
+    });
+  }
+  return out;
+}
+
+/** Whether the store already holds this id — the create path's existence check. */
+export function fixtureHasDocument(id: string): boolean {
+  return load().documents.has(id);
+}
+
+export function fixtureCreateProject(id: string, title: string): void {
+  const state = load();
+  state.documents.set(id, { id, title, clips: [], isProject: true });
+  state.revisions.set(id, 1);
+}

--- a/apps/timeline-gstudio001/lib/graph-view-events.ts
+++ b/apps/timeline-gstudio001/lib/graph-view-events.ts
@@ -8,31 +8,36 @@ export function isGraphViewRoute(pathname: string): boolean {
   return /^\/timeline\/[^/]+\/graph(\/|$)/.test(pathname);
 }
 
-// The sidebar's tool palette hands off the same way. Dragging a tool onto a
-// strip is a POINTER-only gesture (native HTML5 drag carrying a custom
-// DataTransfer), which left keyboard and assistive-tech users — and touch —
-// with no way to insert anything at all. Activating the tool now appends it
-// to the open timeline through this event; the drag stays as the way to
-// choose a POSITION.
+// ── Add item, appended to the end ───────────────────────────────────────────
+//
+// The controls row's "Add item" button sits ABOVE the drop surfaces in the
+// tree, and the machinery that adds things — the mint-and-insert, and the
+// upload pipeline with its bounded concurrency, per-file errors and single
+// undoable commit — lives INSIDE them (`useNativeDrop`). React context only
+// flows downward, so this event is how the button reaches it.
+//
+// Deliberately NOT a broadcast. Every sub-timeline row mounts its own drop
+// surface, so an unaddressed event would be handled once per mounted surface
+// and add one item per row on screen. `collectionId` is the address; a surface
+// ignores anything not aimed at it. The focused collection cannot also be one
+// of the rows below it — those render its CHILDREN, and the graph forbids a
+// cycle — so exactly one surface ever answers.
 
-export const GRAPH_INSERT_TOOL_EVENT = "graph-view:insert-tool";
+export const GRAPH_ADD_ITEM_EVENT = "graph-view:add-item";
 
-/** The palette tools, mirrored by `isSidebarTool` on the graph side.
- *  Collection only: the old image/video placeholder tools were removed —
- *  media enters through the Assets drawer or OS file drops. */
-export type GraphInsertTool = "collection";
+export type GraphAddItemDetail = Readonly<
+  { collectionId: string } & (
+    | { kind: "collection" }
+    /** Already-picked files. The button owns its own file input so the picker
+     *  opens inside the click that opened it — carrying the FILES rather than a
+     *  request to ask for them keeps user activation out of the question. */
+    | { kind: "media"; files: readonly File[] }
+  )
+>;
 
-export type GraphInsertToolDetail = Readonly<{ tool: GraphInsertTool }>;
-
-export function isGraphInsertTool(value: string): value is GraphInsertTool {
-  return value === "collection";
-}
-
-/** Ask the graph view to append a palette tool to the focused collection. */
-export function requestGraphToolInsert(tool: GraphInsertTool): void {
-  window.dispatchEvent(
-    new CustomEvent<GraphInsertToolDetail>(GRAPH_INSERT_TOOL_EVENT, { detail: { tool } }),
-  );
+/** Ask the surface showing `collectionId` to append an item to its end. */
+export function requestGraphAddItem(detail: GraphAddItemDetail): void {
+  window.dispatchEvent(new CustomEvent<GraphAddItemDetail>(GRAPH_ADD_ITEM_EVENT, { detail }));
 }
 
 // The sidebar's top two icons ARE the graph's layout switch (grid first —

--- a/apps/timeline-gstudio001/package.json
+++ b/apps/timeline-gstudio001/package.json
@@ -14,6 +14,7 @@
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
+    "fixture:build": "node scripts/make-dev-fixture.mjs",
     "audit:ownership": "node --env-file=.env scripts/audit-ownerless-timelines.mjs",
     "audit:orphans": "node --env-file=.env scripts/audit-orphaned-timelines.mjs",
     "prune:orphans": "node --env-file=.env scripts/prune-empty-orphans.mjs",

--- a/apps/timeline-gstudio001/scripts/make-dev-fixture.mjs
+++ b/apps/timeline-gstudio001/scripts/make-dev-fixture.mjs
@@ -1,0 +1,176 @@
+// Regenerates `fixtures/dev-timelines.json` — the offline board.
+//
+//   node scripts/make-dev-fixture.mjs
+//
+// The JSON is CHECKED IN, so running this is only needed when you want
+// different dummy content. Everything here is deterministic: no clock, no
+// randomness, no network. Re-running produces a byte-identical file, so a
+// regeneration shows up in a diff only when the content actually changed.
+//
+// Thumbnails are inline SVG data URIs rather than the 1x1 transparent pixel the
+// e2e fixtures use. That matters for the job this serves: e2e asserts against
+// the DOM and does not care what an image looks like, while this exists to be
+// LOOKED AT — a board of identical blank squares would tell you nothing about
+// whether a layout change worked.
+
+import { writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const OUT = join(dirname(fileURLToPath(import.meta.url)), "..", "fixtures", "dev-timelines.json");
+
+const PALETTE = [
+  ["#1e3a5f", "#7dd3fc"],
+  ["#3f2d56", "#c4b5fd"],
+  ["#14532d", "#86efac"],
+  ["#5c2e2e", "#fca5a5"],
+  ["#4a3c17", "#fde047"],
+  ["#164e63", "#67e8f9"],
+];
+
+/** A labelled 16:9 card as a data URI. Base64, not raw utf8: an inline SVG
+ *  carries `#` in every colour, which terminates a data URI early. */
+function thumbnail(label, seed, kind) {
+  const [bg, fg] = PALETTE[seed % PALETTE.length];
+  const glyph = kind === "audio" ? "♪" : kind === "video" ? "▶" : "▣";
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180" viewBox="0 0 320 180">` +
+    `<rect width="320" height="180" fill="${bg}"/>` +
+    `<text x="26" y="96" font-family="monospace" font-size="54" fill="${fg}">${glyph}</text>` +
+    `<text x="86" y="88" font-family="monospace" font-size="19" fill="${fg}">${label}</text>` +
+    `<text x="86" y="112" font-family="monospace" font-size="13" fill="${fg}" opacity="0.65">${kind}</text>` +
+    `</svg>`;
+  return `data:image/svg+xml;base64,${Buffer.from(svg, "utf8").toString("base64")}`;
+}
+
+let clipSeed = 0;
+
+// A few real-looking tags, spread deterministically. Without ANY tags the
+// board's filter control renders nothing at all — correct behaviour (an empty
+// filter menu is worse than no control), but it makes the control impossible to
+// look at offline, which is the one thing this fixture exists for.
+const TAGS = [
+  ["keeper"],
+  ["wan2.1", "keeper"],
+  ["minimax-h3"],
+  ["needs-retake"],
+  ["wan2.1"],
+  ["minimax-h3", "keeper"],
+];
+
+function mediaClip(id, label, kind, index, duration, options = {}) {
+  const seed = clipSeed++;
+  const sourceDuration = options.sourceDuration ?? duration;
+  return {
+    id,
+    index,
+    kind,
+    alt: label,
+    tags: TAGS[seed % TAGS.length],
+    src: thumbnail(label, seed, kind),
+    // Audio must NOT carry a poster: the field exists on the shared type, and a
+    // poster minted for a sound file is a broken image wherever a card paints
+    // one. Mirrors the same rule in the e2e fixtures.
+    ...(kind === "audio" ? {} : { poster: thumbnail(label, seed, kind) }),
+    aspect: 16 / 9,
+    trackIndex: options.lane ?? 0,
+    ...(options.placedStart === undefined ? {} : { placedStart: options.placedStart }),
+    startTime: 0,
+    duration,
+    sourceDuration,
+    trimIn: 0,
+    trimOut: sourceDuration - duration,
+  };
+}
+
+function collectionClip(id, childTimelineId, title, index, itemCount) {
+  return {
+    id,
+    index,
+    kind: "collection",
+    title,
+    childTimelineId,
+    itemCount,
+    // Left empty on purpose: the serve path DERIVES collection previews from
+    // the child documents bottom-up, so a stored value here would be the stale
+    // copy that derivation exists to replace.
+    previewItems: [],
+    alt: title,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 3,
+    sourceDuration: 3,
+    trimIn: 0,
+    trimOut: 0,
+  };
+}
+
+const PROJECT_ID = "project-dev-fixture";
+const documents = {};
+
+/** One scene: a few shots, and for scene 2 a bed on lane 1 so the lane rows,
+ *  the layered-playback path and the waveform lane all have something to draw
+ *  offline — those are the newest surfaces and the easiest to leave untested. */
+function scene(n, title, shots, extras = []) {
+  const id = `timeline-dev-scene-${n}`;
+  documents[id] = {
+    id,
+    title,
+    clips: [
+      ...shots.map((shot, i) =>
+        mediaClip(`${id}-s${i + 1}`, shot.label, shot.kind, i, shot.duration),
+      ),
+      ...extras.map((extra, i) =>
+        mediaClip(`${id}-x${i + 1}`, extra.label, extra.kind, shots.length + i, extra.duration, {
+          lane: extra.lane,
+          placedStart: extra.placedStart,
+        }),
+      ),
+    ],
+  };
+  return id;
+}
+
+const sceneOne = scene(1, "Scene 1 — The Approach", [
+  { label: "Wide, van pulls in", kind: "video", duration: 6 },
+  { label: "Pat at the wheel", kind: "video", duration: 4 },
+  { label: "Door plate", kind: "image", duration: 3 },
+]);
+
+const sceneTwo = scene(
+  2,
+  "Scene 2 — The Briefing",
+  [
+    { label: "Pat, medium", kind: "video", duration: 5 },
+    { label: "Brian, reverse", kind: "video", duration: 5 },
+    { label: "Two-shot", kind: "video", duration: 7 },
+  ],
+  [
+    // Lane 1, starting under the second shot rather than at zero — a bed that
+    // is time-placed is the case the picture-hold logic actually has to answer.
+    { label: "Room tone bed", kind: "audio", duration: 12, lane: 1, placedStart: 5 },
+  ],
+);
+
+const sceneThree = scene(3, "Scene 3 — Outside", [
+  { label: "Street, dusk", kind: "image", duration: 4 },
+  { label: "They leave", kind: "video", duration: 5 },
+]);
+
+documents[PROJECT_ID] = {
+  id: PROJECT_ID,
+  title: "Dev Fixture — offline board",
+  isProject: true,
+  clips: [
+    mediaClip("dev-cold-open", "Cold open", "video", 0, 5),
+    collectionClip("dev-c1", sceneOne, "Scene 1 — The Approach", 1, 3),
+    collectionClip("dev-c2", sceneTwo, "Scene 2 — The Briefing", 2, 4),
+    collectionClip("dev-c3", sceneThree, "Scene 3 — Outside", 3, 2),
+    mediaClip("dev-tail", "End card", "image", 4, 3),
+  ],
+};
+
+writeFileSync(OUT, `${JSON.stringify({ projectId: PROJECT_ID, documents }, null, 2)}\n`, "utf8");
+console.log(`wrote ${OUT}`);
+console.log(`  ${Object.keys(documents).length} documents, project ${PROJECT_ID}`);

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -424,6 +424,18 @@ async function openGraph(page: Page): Promise<void> {
  * collections" while flat. Leaving restores "Show all items in order", which
  * is what the flat-specific tests click to go back.
  */
+/**
+ * Add a collection through the Add item button — the CLICK route.
+ *
+ * Two steps now rather than one: the button asks which kind before it adds
+ * anything. Extracted because several tests only need "a collection exists"
+ * and should not each re-encode how the menu works.
+ */
+async function addCollectionViaButton(page: Page): Promise<void> {
+  await page.locator("[data-add-item-button]").click();
+  await page.locator("[data-add-item-menu] [data-add-item-collection]").click();
+}
+
 async function leaveFlatMode(page: Page): Promise<void> {
   await page.getByRole("button", { name: "Show collections" }).click();
 }
@@ -3801,6 +3813,114 @@ test.describe("graph view E2E", () => {
       .toBe(5);
   });
 
+  test("Add item asks WHICH, and appends the answer to the end", async ({ page }) => {
+    // One control for the two things a timeline can hold. It replaces a
+    // collection-only tool, so the assertions here are about the merge: the
+    // menu offers both kinds, and BOTH land at the end — a change from the old
+    // button, which landed next to the SELECTION.
+    const api = await installGraphApi(page);
+    let uploads = 0;
+    await page.route("**/api/timeline-media/upload", (route) => {
+      uploads += 1;
+      return route.fulfill({
+        json: { pathname: `added-${uploads}.png`, url: PIXEL, thumbnailUrl: PIXEL },
+      });
+    });
+    await openGraph(page);
+    const before = (await stripOrder(page, PROJECT_ID)).length;
+
+    const button = page.locator("[data-add-item-button]");
+    await expect(button).toHaveCount(1);
+    // DRAGGABLE, and it says so twice over: the attribute makes the gesture
+    // real, and the grip glyph is what makes it visible before you try.
+    await expect(button).toHaveAttribute("draggable", "true");
+
+    // 1) CLICK opens the menu, with both kinds and the drag hint.
+    await button.click();
+    const menu = page.locator("[data-add-item-menu]");
+    await expect(menu).toBeVisible();
+    await expect(menu.locator("[data-add-item-collection]")).toBeVisible();
+    await expect(menu.locator("[data-add-item-media]")).toBeVisible();
+    // THE DISCOVERABILITY HALF. Without it the second gesture is invisible to
+    // anyone who has not already found it, which for a control whose whole
+    // point is that you can drag it somewhere means most people.
+    await expect(menu.locator("[data-add-item-drag-hint]")).toContainText(/drag/i);
+
+    // 2) Add collection APPENDS — last, not next to any selection.
+    await menu.locator("[data-add-item-collection]").click();
+    await expect(menu).toHaveCount(0);
+    await expect.poll(() => stripOrder(page, PROJECT_ID).then((o) => o.length)).toBe(before + 1);
+    const afterCollection = await stripOrder(page, PROJECT_ID);
+    expect(afterCollection[afterCollection.length - 1]).toMatch(/^timeline-/);
+
+    // 3) Add media item goes through the SAME upload pipeline a drop uses, and
+    //    also appends. Files are set straight on the input: clicking the item
+    //    opens the OS picker, which a browser test cannot drive.
+    await button.click();
+    await page
+      .locator("[data-add-item-menu] [data-add-item-input]")
+      .setInputFiles([
+        { name: "added.png", mimeType: "image/png", buffer: Buffer.from([137, 80, 78, 71]) },
+      ]);
+    await expect
+      .poll(() => stripOrder(page, PROJECT_ID).then((o) => o.length), { timeout: 15000 })
+      .toBe(before + 2);
+    expect(uploads).toBe(1);
+    await expect.poll(() => api.patchesFor(PROJECT_ID).length, { timeout: 5000 }).toBeGreaterThan(0);
+  });
+
+  test("a dragged Add item asks at the spot it landed, and answers there", async ({ page }) => {
+    // The drag half. Dropping does NOT insert anything — it parks the position
+    // and asks; the answer lands where the drop did. Everything about that is
+    // new behaviour, and the position surviving the wait is the part most
+    // likely to rot, since nothing commits while the menu is open.
+    await installGraphApi(page);
+    await openGraph(page);
+    const before = await stripOrder(page, PROJECT_ID);
+    const dropZone = page.locator(`[data-native-drop="${PROJECT_ID}"]`);
+
+    const transfer = await page.evaluateHandle(() => {
+      const value = new DataTransfer();
+      value.setData("application/x-gstudio-type", "add-item");
+      return value;
+    });
+    // clientX 0 = before the first card, the same boundary the collection-tool
+    // test uses. clientY is what positions the menu.
+    await dropZone.dispatchEvent("drop", { dataTransfer: transfer, clientX: 0, clientY: 300 });
+
+    // NOTHING landed yet. This is the claim that makes dismissal a real cancel
+    // rather than something to undo — the graph is untouched until answered.
+    const menu = page.locator("[data-add-item-drop-menu]");
+    await expect(menu).toBeVisible();
+    expect(await stripOrder(page, PROJECT_ID)).toEqual(before);
+
+    // 1) Escape cancels, still leaving nothing behind.
+    await page.keyboard.press("Escape");
+    await expect(menu).toHaveCount(0);
+    expect(await stripOrder(page, PROJECT_ID)).toEqual(before);
+
+    // 2) Drop again and ANSWER: the collection lands at the dropped boundary
+    //    (first), not appended at the end where a click would put it. That is
+    //    the entire difference between the two gestures.
+    const second = await page.evaluateHandle(() => {
+      const value = new DataTransfer();
+      value.setData("application/x-gstudio-type", "add-item");
+      return value;
+    });
+    await dropZone.dispatchEvent("drop", { dataTransfer: second, clientX: 0, clientY: 300 });
+    await expect(menu).toBeVisible();
+    // No drag hint here — you arrived by dragging.
+    await expect(menu.locator("[data-add-item-drag-hint]")).toHaveCount(0);
+    await menu.locator("[data-add-item-collection]").click();
+
+    await expect.poll(() => stripOrder(page, PROJECT_ID).then((o) => o.length)).toBe(
+      before.length + 1,
+    );
+    const after = await stripOrder(page, PROJECT_ID);
+    expect(after[0]).toMatch(/^timeline-/);
+    expect(after.slice(1)).toEqual(before);
+  });
+
   test("the trailing slot browses for media — the only route that needs no pointer", async ({
     page,
   }) => {
@@ -3923,20 +4043,30 @@ test.describe("graph view E2E", () => {
       .toBe(5);
   });
 
-  test("sidebar tools insert from the KEYBOARD, with no pointer involved", async ({ page }) => {
-    // The palette used to be pointer-only: its tiles were <div role="button">
-    // whose Enter/Space did nothing but show a "drag this" toast, and actual
-    // insertion needed a native drag carrying a custom DataTransfer. Keyboard
-    // and assistive-tech users could not create anything at all.
+  test("Add item works from the KEYBOARD, with no pointer involved", async ({ page }) => {
+    // The palette this replaces was pointer-only: its tiles were
+    // <div role="button"> whose Enter/Space did nothing but show a "drag this"
+    // toast, and actual insertion needed a native drag carrying a custom
+    // DataTransfer. Keyboard and assistive-tech users could not create anything.
+    //
+    // Adding the menu put that at risk again — activating the control now opens
+    // a menu instead of inserting — so the route is asserted end to end here.
     await installGraphApi(page);
     await openGraph(page);
 
-    const collectionTool = page.getByRole("button", { name: /add collection/i });
-    await expect(collectionTool).toBeVisible();
+    const addItem = page.locator("[data-add-item-button]");
+    await expect(addItem).toBeVisible();
 
-    // Reach it by TABBING — it must be in the focus order, not just clickable.
-    await collectionTool.focus();
-    await expect(collectionTool).toBeFocused();
+    // Reach it by FOCUS — it must be in the focus order, not just clickable.
+    await addItem.focus();
+    await expect(addItem).toBeFocused();
+    await page.keyboard.press("Enter");
+
+    // Opening MOVES FOCUS to the first choice. Without that the menu is open
+    // but its answers are an unknown number of Tabs away, which is the whole
+    // difference between a keyboard route and a keyboard dead end.
+    const collectionItem = page.locator("[data-add-item-menu] [data-add-item-collection]");
+    await expect(collectionItem).toBeFocused();
     await page.keyboard.press("Enter");
 
     // Appended to the end of the focused timeline.
@@ -3944,9 +4074,14 @@ test.describe("graph view E2E", () => {
       .poll(() => stripOrder(page, PROJECT_ID))
       .toEqual(["alpha", "bravo", CHILD_ID, "charlie", expect.stringMatching(/^timeline-/)]);
 
+    // Focus RETURNS to the trigger, so the next Tab carries on from here rather
+    // than restarting at the top of the page.
+    await expect(addItem).toBeFocused();
+
     // Space is the other native activation key, and must not be swallowed.
-    await collectionTool.focus();
     await page.keyboard.press(" ");
+    await expect(collectionItem).toBeFocused();
+    await page.keyboard.press("Enter");
     await expect
       .poll(() => stripOrder(page, PROJECT_ID).then((order) => order.length))
       .toBe(6);
@@ -3963,70 +4098,77 @@ test.describe("graph view E2E", () => {
       .toMatch(/^timeline-/);
   });
 
-  test("the collection tool lands AFTER the selected card, in that card's own strip", async ({
+  test("Escape closes the menu without adding anything, and gives focus back", async ({ page }) => {
+    // The cancel path. It matters more than it looks: the menu is the only
+    // thing standing between a keystroke and a write, so an Escape that half
+    // works — closes but still inserts, or closes and strands focus on <body> —
+    // turns a change of mind into an edit to undo.
+    await installGraphApi(page);
+    await openGraph(page);
+    const before = await stripOrder(page, PROJECT_ID);
+
+    const addItem = page.locator("[data-add-item-button]");
+    await addItem.focus();
+    await page.keyboard.press("Enter");
+    await expect(page.locator("[data-add-item-menu]")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(page.locator("[data-add-item-menu]")).toHaveCount(0);
+    expect(await stripOrder(page, PROJECT_ID)).toEqual(before);
+    await expect(addItem).toBeFocused();
+
+    // And Escape did not travel on to the board behind it, where the same key
+    // clears the selection — a menu's dismissal is not a board gesture.
+    await expect(page.locator("[data-graph-shortcuts-sheet]")).toHaveCount(0);
+  });
+
+  test("Add item APPENDS, whatever is selected and wherever the selection lives", async ({
     page,
   }) => {
+    // A DELIBERATE CHANGE, and the reason it is pinned rather than deleted.
+    //
+    // The collection tool this replaces landed next to the SELECTION, in that
+    // card's own strip, via `resolveInsertPlacement` — a rule that reads well
+    // from a sidebar palette and poorly from a control sitting directly above
+    // the board, where "add one" plainly means "at the end of this". The rule
+    // itself is alive and still tested: PASTE uses it, which is where landing
+    // next to what you picked is unambiguously right.
     await installGraphApi(page);
     await openGraph(page);
 
-    // Select bravo (a media clip: click toggles selection, no drill)…
+    // Select bravo, in the middle of the run…
     await selectCard(strip(page, PROJECT_ID).locator('[data-node-id="bravo"]'));
     await expect(strip(page, PROJECT_ID).locator('[data-node-id="bravo"]')).toHaveAttribute(
       "data-selected",
       "true",
     );
 
-    // …then CLICK the sidebar tool: sidebar clicks never clear selection,
-    // so the new collection lands right after bravo, not at the end.
-    const collectionTool = page.getByRole("button", { name: /add collection/i });
-    await collectionTool.click();
+    // …and the collection still lands LAST, not after bravo.
+    await addCollectionViaButton(page);
     await expect
       .poll(() => stripOrder(page, PROJECT_ID))
       .toEqual([
         "alpha",
         "bravo",
-        expect.stringMatching(/^timeline-/),
         CHILD_ID,
         "charlie",
+        expect.stringMatching(/^timeline-/),
       ]);
 
-    // The selected card may live in ANY strip: select c1 in the CHILD
-    // timeline — the insert follows the selection there, not the focus.
+    // Not even when the selection lives in ANOTHER strip. This is the case the
+    // old rule existed for, so it is the one that proves the rule is gone: the
+    // add goes to the FOCUSED timeline's end, and the child is untouched.
     await expandSubGraph(page, "Scene A");
     await expect
       .poll(() => stripOrder(page, CHILD_ID), { timeout: 15000 })
       .toEqual(["c1", "c2"]);
     await selectCard(strip(page, CHILD_ID).locator('[data-node-id="c1"]'));
-    await collectionTool.click();
-    await expect
-      .poll(() => stripOrder(page, CHILD_ID))
-      .toEqual(["c1", expect.stringMatching(/^timeline-/), "c2"]);
+    await addCollectionViaButton(page);
 
-    // The focused root gained exactly the ONE insert from before.
+    await expect.poll(() => stripOrder(page, CHILD_ID)).toEqual(["c1", "c2"]);
     await expect
       .poll(() => stripOrder(page, PROJECT_ID).then((order) => order.length))
-      .toBe(5);
-
-    // …but only strips INSIDE the focused subtree count. Select charlie in the
-    // project, then drill into Scene A: the selection survives the navigation,
-    // and the tool must append into the collection now open rather than plant
-    // the new timeline back where the user came from (same rule as Paste).
-    await selectCard(strip(page, PROJECT_ID).locator('[data-node-id="charlie"]'));
-    await drillButton(page, "Scene A").click();
-    // Wait on the PROJECT strip leaving, not on a CHILD card appearing: the
-    // Scene A sub-row is expanded above, so its strip is already on the page
-    // and that wait would pass without the route having changed at all —
-    // letting the tool click race the navigation (it did, first run).
-    await expect(strip(page, PROJECT_ID)).toHaveCount(0);
-    await collectionTool.click();
-    await expect
-      .poll(() => stripOrder(page, CHILD_ID))
-      .toEqual([
-        "c1",
-        expect.stringMatching(/^timeline-/),
-        "c2",
-        expect.stringMatching(/^timeline-/),
-      ]);
+      .toBe(6);
   });
 
   test("keyboard insertion works in grid mode too", async ({ page }) => {
@@ -4038,7 +4180,11 @@ test.describe("graph view E2E", () => {
     await surfaceButton(page, "grid").click();
     await expect(page.locator(`[data-native-drop="${PROJECT_ID}"]`)).toHaveCount(1);
 
-    await page.getByRole("button", { name: /add collection/i }).focus();
+    // Enter to open, Enter to choose — the menu takes focus, so the whole
+    // route is two keystrokes with no Tabbing in between.
+    await page.locator("[data-add-item-button]").focus();
+    await page.keyboard.press("Enter");
+    await expect(page.locator("[data-add-item-menu] [data-add-item-collection]")).toBeFocused();
     await page.keyboard.press("Enter");
 
     await expect
@@ -5499,7 +5645,7 @@ test.describe("graph view E2E", () => {
     await expect(empty).toContainText(/no child timelines/i);
 
     // Adding a collection replaces it with the real row, no reload.
-    await page.getByRole("button", { name: /add collection/i }).click();
+    await addCollectionViaButton(page);
     await expect(empty).toHaveCount(0);
     await expect(page.locator('section[aria-label^="Sub-timeline"]')).toHaveCount(1);
 
@@ -5897,24 +6043,27 @@ test.describe("graph view E2E", () => {
     await expect(status).toHaveText("");
   });
 
-  test("the collection tool in the breadcrumb row is a drag source, uncovered by the drop-zone layer", async ({ page }) => {
-    // The tool keeps BOTH affordances after moving to the header: keyboard
-    // activation (covered elsewhere) and native drag. Playwright's synthetic
-    // mouse cannot drive a native HTML5 drag, so this asserts the next best
-    // thing: the element is still draggable and its dragstart still loads the
-    // DataTransfer the drop targets read.
+  test("the Add item button is a drag source, uncovered by the drop-zone layer", async ({ page }) => {
+    // The control keeps BOTH affordances: keyboard activation (covered
+    // elsewhere) and native drag. Playwright's synthetic mouse cannot drive a
+    // native HTML5 drag, so this asserts the next best thing: the element is
+    // still draggable and its dragstart still loads the DataTransfer the drop
+    // targets read.
     await installGraphApi(page);
     await openGraph(page);
 
-    const collectionTool = page.getByRole("button", { name: /add collection/i });
-    await expect(collectionTool).toHaveAttribute("draggable", "true");
+    const addItem = page.locator("[data-add-item-button]");
+    await expect(addItem).toHaveAttribute("draggable", "true");
 
-    const carried = await collectionTool.evaluate((el) => {
+    // The payload is `add-item`, NOT `collection`. That difference is the whole
+    // feature: a collection payload commits on drop, while this one parks the
+    // position and asks which kind to put there.
+    const carried = await addItem.evaluate((el) => {
       const transfer = new DataTransfer();
       el.dispatchEvent(new DragEvent("dragstart", { dataTransfer: transfer, bubbles: true }));
       return transfer.getData("application/x-gstudio-type");
     });
-    expect(carried).toBe("collection");
+    expect(carried).toBe("add-item");
 
     // ...and the button must actually RECEIVE that dragstart under a real
     // pointer. dispatchEvent above bypasses hit-testing, so it can't catch a
@@ -5922,7 +6071,7 @@ test.describe("graph view E2E", () => {
     // layer sits over this same row. Assert hit-testing: the topmost element at
     // the tool's own centre is the tool itself, which holds only while the idle
     // drop-zone layer stays pointer-events-none.
-    const onThisTool = await collectionTool.evaluate((el) => {
+    const onThisTool = await addItem.evaluate((el) => {
       const r = el.getBoundingClientRect();
       const top = document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2);
       return el.contains(top);
@@ -8306,7 +8455,11 @@ test.describe("graph view E2E", () => {
     // Dragged to the left end with the POINTER, which is how this control is
     // actually used and what the move out of the menu was for. Keyboard Home
     // is Radix's to implement and is not what this test is about.
-    const track = (await page.locator("[data-header-zoom]").boundingBox())!;
+    // The SLIDER's own box, not the wrapper's. They used to share a left edge,
+    // so measuring the wrapper worked by coincidence; a `pl-1.5` added to the
+    // wrapper for spacing then put this click 6px into the padding, where it
+    // hit nothing and the zoom stayed at its default.
+    const track = (await page.locator("[data-header-zoom-slider]").boundingBox())!;
     await page.mouse.click(track.x + 1, track.y + track.height / 2);
     // NEAR the floor, not exactly on it: the thumb has width, so a click at the
     // track's left edge lands a step or two in. What the test needs is "zoomed


### PR DESCRIPTION
The controls row carried a **Collection-only** tool. Media had a route only at the very end of a surface (the trailing slot) or by dragging in from the OS — so "put a clip here" and "put a collection here" were unrelated gestures with different reach. One control now asks *which*, and both answers land the same way.

| gesture | asks | lands |
|---|---|---|
| **click** | menu under the button | at the **end** |
| **drag** onto a strip or grid | menu at the drop point | **there** |

## Why the drag half is small

It rides the existing tool MIME with a payload of its own (`add-item`), so every drop surface already accepts it, already draws its indicator and already resolves its anchor. Only `commitDrop` branches.

And `DropAnchor` was already built for a deferred commit — it names its gap by the cards either side of it, because a file drop has to survive waiting for uploads. A menu waiting on a human is the same shape of wait, only longer and more likely. Nothing is dispatched until the menu is answered, so dismissing leaves no trace: **Escape is a true cancel, not something to undo.**

## Keyboard

Activating the control used to insert outright and now opens a menu, which put the accessible route at risk. The menu takes focus on open and returns it to the trigger on close — Enter, Enter, no Tabbing between. Two real bugs surfaced getting there:

- **Side effects inside a `setState` updater.** StrictMode calls it twice, so one click added two collections.
- **A focus-restore guarded on `menuRef.contains(activeElement)`** — which can never be true, because React detaches the ref *before* running cleanup. It read null every time and restored focus never. The signal is focus falling to `<body>`.

## The row, rearranged around it

Controls left, totals centred, controls right. Three columns rather than a flex run because "middle" has to mean the row's centre, not whatever the clusters leave over — half these controls are gated on surface or flat mode. **Measured 0px off centre in all four surface/flat states.**

That grid introduced a real bug, fixed in the same change: below ~800px the columns cannot fit, CSS squeezes the flexible `auto` track (measured **30px against a 91px readout**), and the `shrink-0` readout overhung its own column onto the buttons and **intercepted their pointer events** — the children toggle was unclickable at 560px. Flex children cannot do that to each other, which is why the old row never could.

The centre now clips instead of overhanging, and the row wraps below `lg`. Every alternative was worse: clipping the sides would cut off the Add item and filter menus (positioned *inside* those columns), shrinking the columns puts their contents back on top of each other, and `overflow-x-auto` establishes a scroll container that clips those same menus vertically.

## Also in here

- **Zoom reads as a percentage** of the default — 100% at rest, 12%–400%. `px/s` is an implementation detail of how a strip is drawn. Display only; the slider still stores px/s, so `aria-valuenow` and everything downstream are unchanged.
- **Preview is labelled**; the tag filter loses its word and becomes a 32px glyph like its neighbours.
- **`SidebarToolInsertBridge` and its event are deleted.** Its one dispatcher was the button this replaces. A listener with no sender reads as live and is not. `resolveInsertPlacement` stays — **paste** uses it, which is where landing beside your selection is unambiguously right.
- Four copies of the row divider folded into one `ControlFence`.

## An offline store, development only

`GSTUDIO_FIXTURE_TIMELINES=fixtures/dev-timelines.json` serves timelines from a JSON file instead of Firestore. Firestore's free tier allows 50,000 reads a day and a day of work on a large project reaches it (#437) — the app is then unopenable until midnight Pacific and no UI work can be done at all.

**Refused when `NODE_ENV=production`, unconditionally.** It bypasses the ownership check (dummy documents have no owner), and a flag that both fakes the database and disables access control must not be one environment variable away from being live.

Reads come from the file; writes are in memory and gone on restart. Revision conflicts, the orphan guard, batch atomicity and the delete cascade are **not** modelled — it is for looking at the UI, never for trusting the data layer. `npm run fixture:build` regenerates it, deterministically.

## Tests

Five existing tests broke, and none were deleted:

- three about **keyboard insertion** — rewritten for the two-step menu, which is what caught the focus bug above;
- one pinning **insert-next-to-selection** — rewritten to pin the *new* rule, including the case the old rule existed for (a selection in another strip), so the behaviour change is recorded rather than quietly dropped;
- one **drag-source** test, now asserting the `add-item` payload rather than `collection` — that difference is the whole feature.

Three added: the click route for both kinds, the drag-drop-choose route landing at the dragged boundary, and Escape cancelling with the graph untouched.

One unrelated fragility fixed on the way: the zoom test measured the slider's **wrapper** and clicked one pixel inside it. That worked only while wrapper and track shared an edge; a `pl-1.5` for spacing silently moved the click into the padding, where it did nothing and the zoom never changed. The slider now has its own `data-header-zoom-slider` hook. That test has been burned this way before — its own comment records an earlier version poking a selector that never existed.

## Verification

- `tsc --noEmit` clean; lint 0 errors (7 pre-existing `<img>` warnings)
- 1239 app tests pass
- **179/179 graph-view e2e**, run alone with nothing else on the machine, `exit 0`
- Every state measured in the running app: all four surface/flat combinations, the row at 560px and 1440px, the filter's idle/active/cleared widths, and the zoom at its default and bounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)