### PR TITLE
Keep media local in offline mode, and make the drag tools look grabbable

### DIFF
--- a/apps/timeline-gstudio001/.gitignore
+++ b/apps/timeline-gstudio001/.gitignore
@@ -25,3 +25,7 @@ fixtures/scale-probe.json
 # i.e. somebody's exported project. Personal working state, and the one fixture
 # that IS meant to be overwritten — the import route refuses the generated ones.
 fixtures/local.json
+
+# Offline-mode media: files the upload route writes when GSTUDIO_FIXTURE_TIMELINES
+# is set, served statically at /offline-media. Local testing artefacts.
+public/offline-media/

--- a/apps/timeline-gstudio001/app/api/timeline-media/upload/route.ts
+++ b/apps/timeline-gstudio001/app/api/timeline-media/upload/route.ts
@@ -15,6 +15,8 @@ import {
   toMediaUrl,
   uploadMedia,
 } from "@/lib/firebase-media-store";
+import { fixtureStoreEnabled } from "@/lib/fixture-timeline-store";
+import { writeOfflineMedia } from "@/lib/offline-media-store";
 import { requireAuthUser } from "@/lib/firebase-auth-session";
 import {
   ProjectAssetScopeError,
@@ -168,6 +170,64 @@ export async function POST(request: Request) {
     }
     const mediaBuffer = Buffer.from(await file.arrayBuffer());
     const folderPath = readText(formData, "folderPath");
+
+    // OFFLINE MODE FIRST, ahead of Cloudinary.
+    //
+    // Without this branch, uploading with GSTUDIO_FIXTURE_TIMELINES set reached
+    // real Cloudinary: offline mode intercepted the timeline store and nothing
+    // else, so the one part of an upload that leaves the machine was never
+    // covered. Ahead of the Cloudinary check rather than after it because
+    // `hasCloudinaryConfig()` is true whenever the env is present — which it is,
+    // on the machine doing the offline testing.
+    //
+    // Same response shape as the other two, carrying a URL. Nothing downstream
+    // learns where the bytes went.
+    if (fixtureStoreEnabled()) {
+      const pathname = scopeStoragePathname(
+        uniqueStoragePathname(getUploadPathname(filename, contentType)),
+        user.uid,
+        projectId,
+        folderPath,
+      );
+      // The same rule the Firebase path enforces: a video with no thumbnail has
+      // nothing to draw on its card, and the client already generates one.
+      if (isVideoUpload(pathname, contentType) && !thumbnailFile) {
+        return NextResponse.json(
+          { error: "Video uploads require a generated thumbnail." },
+          { status: 400 },
+        );
+      }
+
+      const storedMedia = writeOfflineMedia(pathname, mediaBuffer);
+
+      let offlineThumbnail: { pathname: string; url: string } | undefined;
+      if (thumbnailFile) {
+        const thumbPathname = scopeStoragePathname(
+          uniqueStoragePathname(
+            thumbnailFilename
+              ? sanitizeStoragePathname(thumbnailFilename, "timeline-thumbnails")
+              : createThumbnailPathname(pathname),
+          ),
+          user.uid,
+          projectId,
+          folderPath,
+        );
+        offlineThumbnail = writeOfflineMedia(
+          thumbPathname,
+          Buffer.from(await thumbnailFile.arrayBuffer()),
+        );
+      }
+
+      return NextResponse.json({
+        pathname: storedMedia.pathname,
+        url: storedMedia.url,
+        thumbnailPathname: offlineThumbnail?.pathname,
+        thumbnailUrl: offlineThumbnail?.url,
+        width: storedMedia.width,
+        height: storedMedia.height,
+      });
+    }
+
     if (hasCloudinaryConfig()) {
       const storedMedia = await uploadCloudinaryMedia(
         filename,

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -19,8 +19,8 @@ import {
   ClipboardPaste,
   Command,
   EllipsisVertical,
-  FolderPlus,
   FolderTree,
+  Image as ImageIcon,
   Layers,
   Redo2,
   Ruler,
@@ -1538,6 +1538,7 @@ function BoardAddTools({
         testId="collection"
         label="Collection"
         payload="collection"
+        icon={Layers}
         title="Collection — click to add one at the end, or drag onto the board to place it"
         onActivate={() => {
           requestGraphAddItem({ collectionId, kind: "collection" });
@@ -1562,6 +1563,7 @@ function BoardAddTools({
         testId="media"
         label="Media"
         payload={MEDIA_TOOL_PAYLOAD}
+        icon={ImageIcon}
         title="Media — click to browse and add at the end, or drag onto the board to place what you pick"
         onActivate={() => mediaInputRef.current?.click()}
       />

--- a/apps/timeline-gstudio001/components/graph-view/graph-tool-buttons.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-tool-buttons.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef } from "react";
-import { GripVertical } from "lucide-react";
+import { GripVertical, type LucideIcon } from "lucide-react";
 
 import { MEDIA_TOOL, TOOL_MIME } from "./graph-native-drop-model";
 
@@ -24,12 +24,35 @@ import { MEDIA_TOOL, TOOL_MIME } from "./graph-native-drop-model";
  * `MediaDropTarget` for how that second half lands.
  */
 
-/** Grip, then the word. Shared so the two cannot drift apart. */
+/**
+ * Grip, glyph, then the word. Shared so the two cannot drift apart.
+ *
+ * THE GLYPH MATCHES THE THING, not the other add affordance. `Layers` is what a
+ * collection card draws in the middle of its thumbnail, and `Image` is the clip
+ * card's picture glyph — so the tool that makes one looks like what it makes.
+ *
+ * That is a choice between two defensible consistencies, and worth recording
+ * because the other one is also written down: the end-of-row add slot draws
+ * `FolderPlus`, and its comment claims that glyph is "the same FolderPlus the
+ * controls row uses". These buttons had no glyph at all when they became
+ * grip-and-label, so that claim was already stale; matching the CARD keeps it
+ * stale on purpose. The pairing that matters more is button-to-object — you
+ * look at collection cards constantly and at the add slot rarely.
+ *
+ * Three elements need the spacing to say what belongs together. The grip is a
+ * different KIND of thing from the other two — it is the drag affordance, not
+ * part of the name — so it sits tight to the left edge (`pl-1.5`) while a
+ * uniform `gap-1.5` keeps glyph and word reading as one label rather than as
+ * two more controls. `pr-2.5` against `pl-1.5` is deliberate optical balance:
+ * a glyph carries less visual weight than text, so equal padding would look
+ * lopsided.
+ */
 export function ToolButton({
   label,
   payload,
   title,
   testId,
+  icon: Icon,
   onActivate,
 }: Readonly<{
   label: string;
@@ -37,6 +60,8 @@ export function ToolButton({
   payload: string;
   title: string;
   testId: string;
+  /** The kind this tool adds, as a lucide component. */
+  icon: LucideIcon;
   onActivate: () => void;
 }>) {
   return (
@@ -48,17 +73,44 @@ export function ToolButton({
       title={title}
       onDragStart={(event) => beginToolDrag(event, payload)}
       onClick={onActivate}
-      // NO BORDER at rest, matching every toggle in this row — a bordered box
-      // would read as a different KIND of control rather than as one of the
-      // row's tools. `cursor-grab` says it is draggable; the grip says so
-      // before you hover.
+      // A FILL AT REST, which reverses what this used to say.
+      //
+      // It carried "NO BORDER at rest, matching every toggle in this row — a
+      // bordered box would read as a different KIND of control". The intent was
+      // right and the result was not: with no fill, three elements and no edge,
+      // you cannot see where one button ends and the next begins, and the pair
+      // read as loose icons dropped in the row rather than as two things you can
+      // pick up.
+      //
+      // Still not a border — a fill, and NO ring or outline at rest either.
+      // These two ARE a different kind of control from the toggles beside them:
+      // the toggles change what the board shows, these are things you drag onto
+      // it, and being visibly grabbable is the point.
+      //
+      // `zinc-700/70`, and the number was measured rather than picked. The row's
+      // panel is `bg-zinc-900/60` over a near-black page, so the first attempt
+      // (`zinc-800/40`) resolved to about SEVEN levels of brightness above its
+      // own backdrop — present in the computed style, invisible on screen. A
+      // lighter base at a higher alpha lands ~30 levels up, which is what it
+      // takes for a fill alone to bound a control on this surface.
+      //
+      // Hover has to go LIGHTER than that, not darker: `sky-950` was a fine
+      // hover against nothing and would read as a press against this fill, so
+      // the hover moved up the sky ramp to stay a lift.
       //
       // `h-8` is load-bearing: the row pins every control to one height.
       // `whitespace-nowrap` so a label cannot wrap and take the row's height
       // with it when the viewport tightens.
-      className="flex h-8 shrink-0 cursor-grab items-center gap-2 rounded-md pr-2 pl-1 text-[11px] font-medium whitespace-nowrap text-zinc-400 transition-colors hover:bg-sky-950/30 hover:text-sky-400 active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+      className="flex h-8 shrink-0 cursor-grab items-center gap-1.5 rounded-md bg-zinc-700/70 pr-2.5 pl-1.5 text-[11px] font-medium whitespace-nowrap text-zinc-200 transition-colors hover:bg-sky-800/60 hover:text-sky-200 active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
     >
-      <GripVertical aria-hidden="true" className="size-3.5 shrink-0 opacity-60" />
+      {/* Smaller than the kind glyph beside it, deliberately: the grip is an
+          affordance, not information. At the same size the two competed and the
+          button read as having two icons. */}
+      <GripVertical aria-hidden="true" className="size-3 shrink-0 opacity-60" />
+      {/* 3.5 rather than the slot's 4: this sits beside an 11px label and a
+          3.5 grip, and a 16px glyph between them reads as the loudest thing in
+          a row of quiet controls. */}
+      <Icon aria-hidden="true" className="size-3.5 shrink-0" />
       {label}
     </button>
   );

--- a/apps/timeline-gstudio001/lib/offline-media-store.test.ts
+++ b/apps/timeline-gstudio001/lib/offline-media-store.test.ts
@@ -1,0 +1,124 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { imageDimensions, writeOfflineMedia } from "./offline-media-store";
+
+// Offline media: files on local disk, so an upload in offline mode makes no
+// network call at all.
+//
+// `writeOfflineMedia` resolves against `process.cwd()`, so these run in a temp
+// directory rather than writing into the repo's own public/.
+
+const scratch = mkdtempSync(join(tmpdir(), "gstudio-media-"));
+const cwd = process.cwd();
+
+beforeEach(() => {
+  vi.spyOn(process, "cwd").mockReturnValue(scratch);
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+  rmSync(scratch, { recursive: true, force: true });
+  expect(process.cwd()).toBe(cwd);
+});
+
+/** A real 3x2 PNG. Deliberately NOT 16:9, so a parser that guessed a default
+ *  aspect instead of reading the header would be caught rather than flattered. */
+const png3x2 = Buffer.from([
+  137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82,
+  0, 0, 0, 3, 0, 0, 0, 2, 8, 6, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 10, 73, 68, 65, 84, 120, 156, 99, 0, 1, 0, 0, 5, 0, 1, 13, 10, 45, 180,
+  0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
+]);
+
+/** GIF87a, 4x7. */
+const gif4x7 = Buffer.concat([
+  Buffer.from("GIF87a", "ascii"),
+  Buffer.from([4, 0, 7, 0, 0, 0, 0]),
+]);
+
+/** A JPEG whose SOF0 sits behind an APP0 segment, so the walk has to skip one
+ *  rather than read a fixed offset — which is the only reason this parser is a
+ *  loop instead of two `readUInt16BE` calls. */
+const jpeg5x9 = Buffer.concat([
+  Buffer.from([0xff, 0xd8]), // SOI
+  Buffer.from([0xff, 0xe0, 0x00, 0x06, 0x4a, 0x46, 0x49, 0x46]), // APP0, length 6
+  Buffer.from([0xff, 0xc0, 0x00, 0x11, 0x08, 0x00, 0x09, 0x00, 0x05]), // SOF0: h=9, w=5
+  Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]),
+]);
+
+describe("imageDimensions", () => {
+  it("reads a PNG header", () => {
+    expect(imageDimensions(png3x2)).toEqual({ width: 3, height: 2 });
+  });
+
+  it("reads a GIF header", () => {
+    expect(imageDimensions(gif4x7)).toEqual({ width: 4, height: 7 });
+  });
+
+  it("walks past a JPEG's APP0 to the frame header", () => {
+    expect(imageDimensions(jpeg5x9)).toEqual({ width: 5, height: 9 });
+  });
+
+  it("reads an extended WebP canvas, which stores size minus one", () => {
+    const webp = Buffer.concat([
+      Buffer.from("RIFF", "ascii"),
+      Buffer.from([0, 0, 0, 0]),
+      Buffer.from("WEBPVP8X", "ascii"),
+      Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]),
+      // 10x20, each stored as value-1 across three little-endian bytes.
+      Buffer.from([9, 0, 0, 19, 0, 0]),
+    ]);
+    expect(imageDimensions(webp)).toEqual({ width: 10, height: 20 });
+  });
+
+  it("returns undefined rather than guessing for anything it cannot read", () => {
+    // A clip with no dimensions keeps its default shape; a clip with WRONG ones
+    // is drawn wrong. Undefined is the safe answer for video, audio and the
+    // simple-VP8 WebP form.
+    expect(imageDimensions(Buffer.from("not an image at all", "ascii"))).toBeUndefined();
+    expect(imageDimensions(Buffer.alloc(0))).toBeUndefined();
+    // Truncated PNG: signature present, header not.
+    expect(imageDimensions(png3x2.subarray(0, 12))).toBeUndefined();
+  });
+});
+
+describe("writeOfflineMedia", () => {
+  it("writes the bytes and returns the URL they are served at", () => {
+    const stored = writeOfflineMedia("projects/u1/p1/shot.png", png3x2);
+
+    expect(stored.url).toBe("/offline-media/projects/u1/p1/shot.png");
+    expect(stored.pathname).toBe("projects/u1/p1/shot.png");
+    // Parsed on the way through, so the client can mint a real aspect.
+    expect(stored).toMatchObject({ width: 3, height: 2 });
+
+    const onDisk = join(scratch, "public", "offline-media", "projects", "u1", "p1", "shot.png");
+    expect(existsSync(onDisk)).toBe(true);
+    expect(readFileSync(onDisk).equals(png3x2)).toBe(true);
+  });
+
+  it("creates nested directories that do not exist yet", () => {
+    const stored = writeOfflineMedia("a/deeply/nested/path/frame.gif", gif4x7);
+    expect(existsSync(join(scratch, "public", "offline-media", stored.pathname))).toBe(true);
+  });
+
+  it("refuses to escape the media directory", () => {
+    // `pathname` derives from a client-supplied filename. A `..` that survived
+    // sanitising would otherwise write anywhere the dev server can reach.
+    expect(() => writeOfflineMedia("../../escaped.png", png3x2)).toThrow(/Refusing to write/);
+    expect(existsSync(join(scratch, "escaped.png"))).toBe(false);
+    expect(existsSync(join(scratch, "public", "escaped.png"))).toBe(false);
+  });
+
+  it("omits dimensions for a non-image, leaving the clip its default shape", () => {
+    const stored = writeOfflineMedia("projects/u1/p1/clip.mp4", Buffer.from("not really a video"));
+    expect(stored.width).toBeUndefined();
+    expect(stored.height).toBeUndefined();
+    expect(stored.url).toBe("/offline-media/projects/u1/p1/clip.mp4");
+  });
+});

--- a/apps/timeline-gstudio001/lib/offline-media-store.ts
+++ b/apps/timeline-gstudio001/lib/offline-media-store.ts
@@ -1,0 +1,149 @@
+import "server-only";
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join, sep } from "node:path";
+
+/**
+ * Media storage for OFFLINE MODE: files on local disk, served as ordinary
+ * static assets.
+ *
+ * The third leg of the upload route, beside Cloudinary and the Firebase Storage
+ * fallback, and the one that makes offline mode actually offline. Uploading with
+ * `GSTUDIO_FIXTURE_TIMELINES` set used to reach real Cloudinary — the same shape
+ * of leak as the render poller: offline mode covered the timeline store and
+ * nothing else, so the part of the app that costs money by the request was never
+ * intercepted at all.
+ *
+ * WHAT DOWNSTREAM SEES IS A URL, exactly as it is for a third party. A clip
+ * stores `src` and nothing about where the bytes live, so `/offline-media/…`
+ * substitutes for a Cloudinary URL with no other change anywhere — no provider
+ * id, no branch in the client, no special case in the model.
+ *
+ * `public/` rather than a served route, because Next already serves that
+ * directory statically in dev and a route would be a second way to do the same
+ * thing. Which also means these files are reachable without auth — the same
+ * property Cloudinary delivery already has and which is a documented, accepted
+ * call in this app.
+ *
+ * NOT PORTABLE, deliberately. A project exported with local media points at
+ * local paths, so loading it elsewhere shows missing images. That is the right
+ * trade for testing the UI offline: the alternative — inlining bytes as data
+ * URIs — makes exports self-contained and turns a 300-item project into tens of
+ * megabytes of fixture that gets parsed on every read. Real usage points at the
+ * third party, where a URL travels.
+ *
+ * DEV ONLY, by construction: the sole caller gates on `fixtureStoreEnabled()`,
+ * which is false in production and not overridable. Nothing here should ever run
+ * against a read-only serverless filesystem.
+ */
+
+/** Where files land, and the URL prefix they are served under. Both halves of
+ *  one fact: `public/offline-media/x` is served at `/offline-media/x`. */
+const PUBLIC_DIR = "public";
+const OFFLINE_SEGMENT = "offline-media";
+
+export type OfflineStoredMedia = Readonly<{
+  pathname: string;
+  url: string;
+  width?: number;
+  height?: number;
+}>;
+
+/**
+ * Intrinsic pixel size, read from the file's own header.
+ *
+ * The client mints a clip's `aspect` from these, and treats their absence as
+ * "keep the default shape" — so returning nothing is safe and returning a wrong
+ * number is not. Which is why this parses the container rather than guessing:
+ * PNG, GIF, JPEG and the extended WebP form. Anything else — video, audio, a
+ * simple-VP8 WebP — reports undefined and the clip keeps 16:9, the same
+ * behaviour as the Firebase path when its probe comes back empty.
+ */
+export function imageDimensions(
+  buffer: Buffer,
+): { width: number; height: number } | undefined {
+  // PNG: 8-byte signature, then IHDR with width/height as big-endian uint32.
+  if (buffer.length >= 24 && buffer.toString("ascii", 1, 4) === "PNG") {
+    return { width: buffer.readUInt32BE(16), height: buffer.readUInt32BE(20) };
+  }
+  // GIF: little-endian uint16 pair straight after the 6-byte header.
+  if (buffer.length >= 10 && buffer.toString("ascii", 0, 3) === "GIF") {
+    return { width: buffer.readUInt16LE(6), height: buffer.readUInt16LE(8) };
+  }
+  // WebP, extended form only (VP8X): a 24-bit canvas size, stored minus one.
+  if (
+    buffer.length >= 30 &&
+    buffer.toString("ascii", 0, 4) === "RIFF" &&
+    buffer.toString("ascii", 8, 12) === "WEBP" &&
+    buffer.toString("ascii", 12, 16) === "VP8X"
+  ) {
+    return {
+      width: 1 + (buffer[24]! | (buffer[25]! << 8) | (buffer[26]! << 16)),
+      height: 1 + (buffer[27]! | (buffer[28]! << 8) | (buffer[29]! << 16)),
+    };
+  }
+  // JPEG: walk the segment chain to a start-of-frame marker. Sizes live in the
+  // frame header, not at a fixed offset, because any number of application and
+  // comment segments can precede it.
+  if (buffer.length >= 4 && buffer.readUInt16BE(0) === 0xffd8) {
+    let offset = 2;
+    while (offset + 9 < buffer.length) {
+      if (buffer[offset] !== 0xff) {
+        offset += 1;
+        continue;
+      }
+      const marker = buffer[offset + 1]!;
+      // SOF0-SOF3, SOF5-SOF7, SOF9-SOF11, SOF13-SOF15. The excluded ones are
+      // DHT/JPG/DAC, which share the 0xC_ range and are not frame headers.
+      const isFrame =
+        marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc;
+      if (isFrame) {
+        return { height: buffer.readUInt16BE(offset + 5), width: buffer.readUInt16BE(offset + 7) };
+      }
+      // Standalone markers carry no length; everything else is length-prefixed.
+      if (marker === 0xd8 || (marker >= 0xd0 && marker <= 0xd9)) {
+        offset += 2;
+        continue;
+      }
+      offset += 2 + buffer.readUInt16BE(offset + 2);
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Write one file and return where it can be fetched.
+ *
+ * `pathname` arrives already scoped and uniquified by the route, using the same
+ * helpers the Firebase path uses — so offline files sit under the same
+ * uid/project/folder layout as hosted ones, and a name collision is impossible
+ * for the same reason it is there.
+ *
+ * The traversal check is not defensive theatre. `pathname` derives from a
+ * client-supplied filename, and a `..` that survived sanitising would let an
+ * upload write anywhere the dev server can reach. Checked against the resolved
+ * prefix rather than by inspecting the string, because that is the check that
+ * cannot be fooled by encoding.
+ */
+export function writeOfflineMedia(
+  pathname: string,
+  buffer: Buffer,
+): OfflineStoredMedia {
+  const root = join(process.cwd(), PUBLIC_DIR, OFFLINE_SEGMENT);
+  const target = join(root, pathname);
+  if (target !== root && !target.startsWith(root + sep)) {
+    throw new Error(`Refusing to write outside ${OFFLINE_SEGMENT}: "${pathname}".`);
+  }
+
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, buffer);
+
+  const dimensions = imageDimensions(buffer);
+  return {
+    pathname,
+    // Forward slashes always: this is a URL, and `pathname` may have been joined
+    // with a platform separator on the way in.
+    url: `/${OFFLINE_SEGMENT}/${pathname.split(sep).join("/")}`,
+    ...(dimensions ?? {}),
+  };
+}


### PR DESCRIPTION
Two pieces: closing the last place offline mode leaked to the network, and a
visual pass on the two drag tools.

## Offline media

Uploading with `GSTUDIO_FIXTURE_TIMELINES` set reached **real Cloudinary**. Same
shape of leak as the render poller in #439: offline mode intercepted the timeline
store and nothing else, so the one part of an upload that actually leaves the
machine was never covered.

A third branch in the upload route, **ahead of** the Cloudinary check —
`hasCloudinaryConfig()` is true whenever the env is present, which it is on the
machine doing the offline testing.

| Mode | Where bytes go | What the clip stores |
| --- | --- | --- |
| Offline | `public/offline-media/…` on local disk | `/offline-media/…` |
| Real usage | Cloudinary (unchanged) | a Cloudinary URL |

**Downstream sees only a URL either way** — no provider id, no client branch, no
model change.

Dimensions come from a small header parser (PNG, GIF, JPEG, extended WebP)
rather than a dependency or a probe, since the client mints a clip's `aspect`
from them. Anything unreadable reports `undefined` and the clip keeps its default
shape: a missing dimension is safe, a wrong one draws the clip wrong.

**Not portable, deliberately.** An export with local media points at local paths,
so loading it elsewhere shows missing images. That is the right trade for testing
the UI offline; the alternative — inlining bytes as data URIs — makes exports
self-contained and turns a 300-item project into tens of megabytes of fixture
parsed on every read.

Verified end to end through the real route: `200`, the file on disk at 67 bytes,
the returned URL fetching back as `image/png`, and `width: 3 / height: 2` read
from a deliberately non-16:9 PNG so a parser that guessed a default would be
caught rather than flattered.

## Tool button visuals

The Collection and Media tools were a grip and a word on no background — you
could not tell where one ended and the next began.

- **A kind glyph before each label**, matching the thing it makes: `Layers` is what a collection card draws in its thumbnail, `Image` is the clip card's picture glyph.
- **A fill at rest**, which reverses this file's old comment ("NO BORDER at rest, matching every toggle in this row"). Still no border and no ring — these genuinely are a different kind of control from the toggles beside them.
- **`zinc-700/70`, measured not picked.** The row's panel is `bg-zinc-900/60` over a near-black page, so a first attempt at `zinc-800/40` resolved to ~7 levels of brightness above its own backdrop: present in the computed style, invisible on screen. Verified after at rest `L 0.37` against the panel's `0.21`, `borderWidth: 0px`, `outlineStyle: none`.
- **Hover moved up the sky ramp** — `sky-950` was fine against nothing and would read as a *press* against a fill.
- **Grip smaller than the kind glyph** (12px vs 14px): it is an affordance, not information.

## Verification

**1279 tests / 101 files**, tsc and eslint clean. 9 of those tests are new,
including path traversal (a `..` surviving sanitising would write anywhere the
dev server can reach) and a JPEG whose frame header sits behind an `APP0`.

## Noted

`graph-board.tsx` had an unused `FolderPlus` import, left behind when "Add item"
became these two buttons. That is the **second unused binding today eslint did
not flag**, after an orphaned `useRouter()` call in #439 that only `tsc` caught.
Worth a rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)