### PR TITLE
Stop a collection's duration changing when you reload

### DIFF
--- a/packages/timeline-domain/src/adapter.test.ts
+++ b/packages/timeline-domain/src/adapter.test.ts
@@ -745,6 +745,76 @@ describe("hydrated collection durations", () => {
     expect(clips[0].duration).toBe(999);
   });
 
+  it("gives an EMPTY hydrated collection the same floor the model does", () => {
+    // Where the zeroes come from in the first place, and the root of the
+    // reload-changes-the-number bug.
+    //
+    // `hydratedCollectionDuration` starts at TIMELINE_LEADING_PADDING_SECONDS
+    // (zero) and adds a term per child, so a collection with no children
+    // returns 0 — while `collectionSpanSeconds`, the model's own answer to the
+    // same question, returns 3 for an empty list because "a zero-width
+    // collection card cannot be seen or clicked".
+    //
+    // It is not only a display bug: the write path persists documents THROUGH
+    // this projection, so every empty collection wrote a stored duration of 0,
+    // which is then the value every later reader has to defend against.
+    const documents: Record<string, TimelineDocument> = {
+      "empty-root": {
+        id: "empty-root",
+        title: "Empty root",
+        clips: [{ ...collectionClip("clip-empty", "empty", "Empty"), duration: 999 }],
+      },
+      empty: { id: "empty", title: "Empty", clips: [] },
+    };
+    const focused = buildFocusedGraph(documents, "empty-root");
+    if (!focused.ok) throw new Error(focused.error);
+
+    const clips = graphChildrenToClips(focused.value.graph, focused.value.details, "empty-root");
+    expect(clips[0].duration).toBeCloseTo(3, 5);
+  });
+
+  it("floors a placeholder's ZERO summary rather than counting it as no time", () => {
+    // The disagreement this fixes, reproduced from a real board: the same
+    // collection read 12.4s on a cold load and 3.4s after navigating to it and
+    // back, so the number changed on reload.
+    //
+    // The server ignores stored summaries and re-derives bottom-up, where
+    // `collectionSpanSeconds` floors an empty collection at 3 — "a zero-width
+    // collection card cannot be seen or clicked". The client trusted the stored
+    // value for placeholders, and the stored value was `0`: the write path
+    // persists a duration it does not know, and `?? 3` never fires because zero
+    // is not nullish. Three children contributing nothing collapsed the parent's
+    // badge to one child's worth.
+    //
+    // Storing 0 is worse than storing nothing, and until the write path stops
+    // doing it, every reader has to defend against it.
+    const documents: Record<string, TimelineDocument> = {
+      "zero-root": {
+        id: "zero-root",
+        title: "Zero root",
+        clips: [{ ...collectionClip("clip-parent", "parent", "Parent"), duration: 999 }],
+      },
+      parent: {
+        id: "parent",
+        title: "Parent",
+        clips: packTimelineClips([
+          { ...collectionClip("clip-a", "a", "A"), duration: 3 },
+          { ...collectionClip("clip-b", "b", "B"), duration: 0 },
+          { ...collectionClip("clip-c", "c", "C"), duration: 0 },
+        ]),
+      },
+      // a, b and c never load: placeholders, so their stored summaries are all
+      // anyone knows about them.
+    };
+    const focused = buildFocusedGraph(documents, "zero-root");
+    if (!focused.ok) throw new Error(focused.error);
+
+    const clips = graphChildrenToClips(focused.value.graph, focused.value.details, "zero-root");
+    // 3 + gap + 3 + gap + 3 — the two zeroes floored to the same 3 seconds the
+    // server's derivation gives them. Counting them as 0 yields 3.24.
+    expect(clips[0].duration).toBeCloseTo(9.24, 5);
+  });
+
   it("recurses through hydrated nesting and stops at placeholders", () => {
     const documents: Record<string, TimelineDocument> = {
       "nest-root": {

--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -451,6 +451,44 @@ export function buildFocusedGraph(
  * from the live graph makes the projection agree with the manifest wherever
  * the session has real knowledge, and writes become self-healing.
  */
+/**
+ * What a PLACEHOLDER collection is worth, in seconds.
+ *
+ * All anyone knows about an un-hydrated child is its stored summary — but a
+ * stored `0` is not knowledge, it is the write path persisting a duration it
+ * did not have. Zero survives `??` (it is not nullish), so every reader that
+ * wrote `summary ?? 3` was silently counting those children as no time at all.
+ *
+ * Found as a number that changed on reload: a collection read 12.4s on a cold
+ * load, where the server ignores stored summaries and re-derives bottom-up, and
+ * 3.4s after navigating to it and back, where the client trusted three stored
+ * zeroes. The floor is not invented here either — `collectionSpanSeconds` gives
+ * an empty collection the same 3 seconds, because "a zero-width collection card
+ * cannot be seen or clicked", and the `?? 3` this replaces was plainly reaching
+ * for that same rule.
+ *
+ * One helper, three callers (duration, playable duration, and the projection's
+ * own clip), so a fourth reader cannot reintroduce the gap.
+ */
+function placeholderSeconds(...candidates: readonly (number | undefined)[]): number {
+  for (const candidate of candidates) {
+    // Positive AND finite: a stored NaN or Infinity is the same kind of
+    // non-knowledge as a zero, and either would poison every ancestor's total.
+    if (candidate !== undefined && Number.isFinite(candidate) && candidate > 0) return candidate;
+  }
+  return EMPTY_COLLECTION_SECONDS;
+}
+
+/**
+ * What a collection with nothing countable in it is worth.
+ *
+ * The model's own number, from `collectionSpanSeconds`: "An EMPTY list is 3
+ * seconds, not zero: a zero-width collection card cannot be seen or clicked."
+ * Named here rather than repeated as a literal, because the two walks below and
+ * the placeholder fallback above are three chances to disagree with it.
+ */
+const EMPTY_COLLECTION_SECONDS = 3;
+
 export function hydratedCollectionDuration(
   graph: CollectionsGraph,
   details: DetailsById,
@@ -470,9 +508,18 @@ export function hydratedCollectionDuration(
     const detail = details[childId as string];
     total += detail?.hydrated
       ? hydratedCollectionDuration(graph, details, childId)
-      : (detail?.duration ?? 3);
+      : placeholderSeconds(detail?.duration);
   }
-  return total;
+  // NOTHING COUNTABLE means the model's empty floor, not the padding constant.
+  //
+  // This walk started at TIMELINE_LEADING_PADDING_SECONDS — which is zero — and
+  // added a term per child, so an empty collection returned 0 while
+  // `collectionSpanSeconds` returned 3 for the same question. That is where the
+  // stored zeroes came from: the write path persists documents THROUGH this
+  // projection, so every empty collection wrote a duration of 0, and every
+  // reader downstream then had to defend against a value that was never a
+  // measurement.
+  return first ? EMPTY_COLLECTION_SECONDS : total;
 }
 
 /**
@@ -510,8 +557,21 @@ export function hydratedCollectionPlayableDuration(
     const detail = details[childId as string];
     total += detail?.hydrated
       ? hydratedCollectionPlayableDuration(graph, details, childId)
-      : (detail?.playableDuration ?? detail?.duration ?? 3);
+      : placeholderSeconds(detail?.playableDuration, detail?.duration);
   }
+  // NO FLOOR HERE, unlike its twin, and the difference is the whole point of
+  // there being two walks.
+  //
+  // I put one here first and an existing test refused it: "returns ZERO when
+  // every child is disabled — a real answer, not 'unknown'". That is right.
+  // Geometry needs a floor because a zero-width card cannot be seen or clicked;
+  // a READOUT of what a viewer would sit through has no such need, and zero is
+  // a legitimate live value for a collection that plays nothing. Flooring it
+  // would also re-break what that test guards: a reader treating 0 as "unknown"
+  // falls back on a stale nonzero summary and re-quotes it.
+  //
+  // The placeholder fallback above still defaults to 3, and that is consistent:
+  // an UN-HYDRATED child is unknown, an all-disabled one is measured.
   return total;
 }
 
@@ -836,7 +896,7 @@ export function graphChildrenToClips(
     // anyone knows about them.
     const duration = detail?.hydrated
       ? hydratedCollectionDuration(graph, details, node.id)
-      : (detail?.duration ?? 3);
+      : placeholderSeconds(detail?.duration);
     // Hydrated collections DERIVE their preview frames from live children (see
     // hydratedCollectionPreviewItems) — same stale-summary rule duration and
     // itemCount already follow; placeholders keep the stored summary.


### PR DESCRIPTION
The same collection read **12.4s on a cold load** and **3.4s after navigating to it and back** — the server and the client disagreeing about what a collection lasts, with the number flipping depending on how you got there.

## Two defects, the first causing the second

**An empty collection projected `0`.** `hydratedCollectionDuration` starts at `TIMELINE_LEADING_PADDING_SECONDS` (which is `0`) and adds a term per child, so a childless collection returned `0` — while the model's own `collectionSpanSeconds` returns `3` for an empty list, because *"a zero-width collection card cannot be seen or clicked."*

That is not only a display bug. **The write path persists documents through this projection**, so every empty collection wrote a stored duration of `0`.

**Readers then trusted that zero.** Three sites used `summary ?? 3`, and `??` does not catch zero — it is not nullish. A parent with three zero-duration children collapsed to one child's worth. A shared `placeholderSeconds` helper now covers all three (and rejects `NaN`/`Infinity`, the same kind of non-knowledge), so a fourth reader cannot reintroduce the gap.

Both reproduce exactly against the real board:

| | Formula | Result |
| --- | --- | --- |
| Server (cold) | re-derives bottom-up, empty floors at 3 | `12.36s` -> **12.4s** |
| Client (after nav) | `3 + 0.12 + 0 + 0.12 + 0 + 0.12 + 0` | `3.36s` -> **3.4s** |

Stored zeroes **self-heal** — the projection now yields `3` and the next write of that parent persists it. No migration.

## Where I was wrong

I floored the playable-duration twin as well, and an existing test refused it: *"returns ZERO when every child is disabled — a real answer, not 'unknown'"*. That test is right. Geometry needs a floor so a card stays clickable; a readout of what a viewer would sit through does not — and flooring it would re-break what that test guards, a reader treating `0` as unknown and re-quoting a stale nonzero summary. Reverted, with the reason recorded beside it.

## Not done

The two formulas remain structurally different: the client sums children plus gaps, the server takes `max(startTime + duration)` over the child's clips. They agree on a packed single lane and **part company with layered clips**. Collapsing them onto one shared span function is the durable fix and a riskier refactor than this bug warranted — worth doing separately, with lane coverage.

## Verification

Both new tests were **proved to fail first**, at `+0` and at `3.24`.

- **771 unit tests**, **1279 app tests**, tsc clean on the app and `packages/ui`.
- **No read or write cost either way** — this is arithmetic on data already in memory.

Note for local checking: this lands in a workspace package symlinked into `node_modules`, which webpack does not watch, so a **dev server restart** is needed before the browser reflects it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
