### PR TITLE
Let the dev server own port 3000 rather than dodge to another

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "timeline-gstudio001",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["--prefix", "apps/timeline-gstudio001", "run", "dev"],
-      "port": 3000
+      "port": 3000,
+      "autoPort": false
     },
     {
       "name": "timeline-gstudio001-attach",


### PR DESCRIPTION
Starting a preview while a dev server was already up offered to move the new one
to a free port. Taking that offer is the wrong move here: **two `next dev`
processes sharing one `.next` directory corrupt each other**, which is why
`playwright.config.ts` forces `reuseExistingServer: true` even in CI and says so
in a comment.

`autoPort: false` states that this configuration owns 3000, so a port clash
**reports the conflict** instead of quietly starting a second server against the
same build directory.

The right response to that conflict is to attach — the `timeline-gstudio001-attach`
entry beside it exists for exactly that, and is what this session used throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)