### PR TITLE
Stop the dev watcher charging reads for data the app wrote

### DIFF
--- a/apps/timeline-gstudio001/next.config.ts
+++ b/apps/timeline-gstudio001/next.config.ts
@@ -45,6 +45,32 @@ const nextConfig: NextConfig = {
       config.watchOptions = {
         ignored: /.*/,
       };
+      return config;
+    }
+    if (dev) {
+      // DATA THE APP WRITES IS NOT SOURCE, and watching it costs reads.
+      //
+      // Offline mode persists every save to its fixture JSON, and offline media
+      // uploads land under public/. Both live inside the app, so the watcher
+      // treated each one as a source change: adding a collection produced
+      // `POST /api/timelines/batch` -> `✓ Compiled` -> a full page reload -> the
+      // board re-rendering, which walks the whole closure. One edit, ~16 reads
+      // of pure feedback, none of it anything to do with the edit.
+      //
+      // Ignoring them loses nothing. The fixture store does NOT rely on webpack
+      // to notice a changed fixture — it stats the file on every read and
+      // rebuilds on a new mtime, which is how regenerating scale-probe.json is
+      // picked up without a restart. Uploaded media is served statically by
+      // path and never imported, so a recompile could not affect it either.
+      config.watchOptions = {
+        ...(config.watchOptions ?? {}),
+        ignored: [
+          '**/node_modules/**',
+          '**/.git/**',
+          '**/fixtures/*.json',
+          '**/public/offline-media/**',
+        ],
+      };
     }
     return config;
   },


### PR DESCRIPTION
Adding **one collection** cost about **sixteen document reads** that had nothing
to do with the edit. Straight from the dev log:

```
POST /api/timelines/batch 200      <- the actual save
✓ Compiled in 296ms                <- the watcher firing
[READTOTAL 304…319]                <- two closure walks
GET /timeline/…/graph/…  200       <- the page reloading itself
```

Offline mode persists every save to its fixture JSON, and offline media uploads
land under `public/` — **both inside the app**, so the watcher read each write as
a source change and reloaded the page, and the reload re-rendered the board,
which walks the whole closure.

A feedback loop introduced by the two features that made offline mode useful
(#440's local uploads and the auto-flush that made "Saved" mean saved), and
invisible until the read counter learned to name what it was reading.

## The fix

`watchOptions.ignored` now excludes `**/fixtures/*.json` and
`**/public/offline-media/**` in dev.

Nothing is lost by ignoring them:

- **The fixture store never relied on webpack** to notice a changed fixture. It stats the file on every read and rebuilds on a new mtime — which is how regenerating `scale-probe.json` is picked up without a restart.
- **Uploaded media is served statically by path** and never imported, so a recompile could not affect it either.

The `DISABLE_HMR` branch now returns early rather than falling through, so that
"ignore everything" mode keeps meaning exactly that.

## Scope

Dev-only — the `webpack` hook's `dev` branch. Nothing here runs in a production
build.

Follows the `autoPort` fix in #442: the same afternoon's worth of
dev-environment sharp edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)