### PR TITLE
Compile the preview manifest in the browser

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/client-graph-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/client-graph-view.tsx
@@ -19,7 +19,16 @@ export function ClientGraphView({
 }: {
   projectId: string;
   /** Server-read boot documents (RSC layout) — null without a session. */
-  bootstrap?: readonly GraphServerPayload[] | null;
+  bootstrap?: Readonly<{
+    payloads: readonly GraphServerPayload[];
+    missing: readonly string[];
+  }> | null;
 }) {
-  return <GraphTimelineView projectId={projectId} bootstrap={bootstrap ?? null} />;
+  return (
+    <GraphTimelineView
+      projectId={projectId}
+      bootstrap={bootstrap?.payloads ?? null}
+      bootstrapMissing={bootstrap?.missing ?? null}
+    />
+  );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -105,6 +105,7 @@ import {
 } from "@storyboard/ui/timeline/viewport/waveform-peaks";
 
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
+import { compileClientPlaybackManifest } from "@/lib/client-playback-manifest";
 import { requestGraphPreviewToggle } from "@/lib/graph-view-events";
 import { sharedWaveformCache, type WaveformCache } from "@/lib/waveform-cache";
 
@@ -922,6 +923,51 @@ function useManifestClips(
     // settled since, moving the ledger without producing a commit of its own.
     // Running the same comparison keeps the guard's invariant intact instead of
     // carving an exception into it for cached values.
+    // COMPILE IT HERE when this session provably holds the whole closure.
+    //
+    // The server route re-reads every document under the root to compile the
+    // same thing — ~149 reads on a 143-collection project, repeated after every
+    // edit while preview is open, all of it re-reading documents `ensureClosure`
+    // primed on entry and the gateway has kept current since.
+    //
+    // Refuses and falls through to the fetch when anything under the root is
+    // not loaded, or on a cycle. That guard is the whole reason this is safe:
+    // the manifest exists so playback depth does not depend on how much of the
+    // graph a session happens to have hydrated, and compiling from a partial
+    // closure would silently play nothing for a collection below the hydration
+    // depth. The server reads from storage and has no such limit.
+    //
+    // Installed WITHOUT `manifestTrailsLedger`, unlike a fetched manifest. That
+    // guard catches a server compile that read pre-write state; this one is
+    // compiled from the very documents this session's writes produced, so it
+    // cannot trail them — it is the live projection, at full depth.
+    const localManifest = compileClientPlaybackManifest(
+      graphDocumentsGateway.read(),
+      focusedId,
+      (id) => graphDocumentsGateway.revisionOf(id),
+      new Date().toISOString(),
+      // Dangling references are the server's answer, remembered — without this
+      // a project containing any (every export has them, since export drops
+      // branches whose documents are gone) could never compile locally.
+      (id) => graphDocumentsGateway.isKnownMissing(id),
+    );
+    if (localManifest !== null) {
+      // Installed on a zero timer rather than straight from the effect body —
+      // the same move, and the same reason, as the fetch kick-off below: this
+      // sets state, and the cascading-render lint cannot see an await that
+      // makes it asynchronous because there isn't one. Zero is immediate in
+      // practice, and the timer is cleared on teardown so a focus change
+      // cannot install a manifest for the timeline you just left.
+      const installTimer = setTimeout(() => {
+        setState({
+          clips: manifestToClips(localManifest),
+          spans: cardSpansOf(localManifest),
+          forId: focusedId,
+        });
+      }, 0);
+      return () => clearTimeout(installTimer);
+    }
+
     const cacheKey = `${focusedId}:${staleAt}`;
     const cached = manifestCacheRef.current;
     if (

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -180,11 +180,20 @@ function FlatRunAnnouncement({
 export function GraphTimelineView({
   projectId,
   bootstrap,
+  bootstrapMissing,
 }: {
   projectId: string;
   /** Server-read boot payloads (RSC layout). Null = no session at render
    *  time; the legacy fetch boot covers it. */
   bootstrap?: readonly GraphServerPayload[] | null;
+  /**
+   * Ids the server's closure walk could not resolve. Recorded before the
+   * payloads are primed so anything asking "do I hold the whole closure?" can
+   * tell a dangling reference from a document still in flight — only the server
+   * knows the difference, and on a primed boot `ensureClosure` (its other
+   * source) never runs.
+   */
+  bootstrapMissing?: readonly string[] | null;
 }) {
   const pathname = usePathname();
   const base = `/timeline/${encodeURIComponent(projectId)}/graph`;
@@ -384,10 +393,11 @@ export function GraphTimelineView({
   // `user` is a dep so payloads that arrived before the client-side auth
   // resolved get re-applied once the binding exists.
   useEffect(() => {
+    graphDocumentsGateway.recordMissing(bootstrapMissing ?? []);
     for (const payload of bootstrap ?? []) {
       graphDocumentsGateway.prime(payload.document, payload.revision, payload.forUid);
     }
-  }, [bootstrap, user]);
+  }, [bootstrap, bootstrapMissing, user]);
   // Whether THIS mount booted from server payloads — captured once: the
   // boot effect must not re-run when later layout renders replace the
   // bootstrap array's identity.

--- a/apps/timeline-gstudio001/lib/client-manifest-equivalence.test.ts
+++ b/apps/timeline-gstudio001/lib/client-manifest-equivalence.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { compilePlaybackManifest } from "@storyboard/timeline-domain";
+import { packTimelineClips } from "@storyboard/timeline-model";
+import type { TimelineClip, TimelineDocument } from "@storyboard/timeline-model/types";
+
+vi.mock("server-only", () => ({}));
+
+import { deriveClosureSummaries } from "./derive-collection-summaries";
+import { compileClientPlaybackManifest } from "./client-playback-manifest";
+
+// THE SAFETY NET for compiling the preview manifest on the client.
+//
+// The plan: when a session provably holds the whole closure, compile the
+// manifest in the browser instead of asking the server to re-read every
+// document. Measured motivation — at ~175 collections a 200-edit session with
+// preview open costs ~35,000 reads, all of it re-reading documents the client
+// already has.
+//
+// The hazard is not performance, it is DIVERGENCE. Preview, render submit and
+// the MCP render tool all compile through the same server function today, so
+// they agree by construction. A second implementation is a second answer, and
+// the one that matters is the render: a wrong manifest there is a wrong FILE,
+// not a wrong preview.
+//
+// So this file exists before any wiring does. It asserts that the pure
+// pipeline — deriveClosureSummaries then compilePlaybackManifest — produces
+// output identical to what the server route produces from the same documents.
+// Both paths run the same two functions; what this pins is that nothing in the
+// server wrapper adds a step the client would miss, and that the ORDER matters
+// in the way we think it does.
+
+const media = (id: string, duration: number): TimelineClip =>
+  ({
+    id,
+    index: 0,
+    kind: "image",
+    src: `https://example.test/${id}.png`,
+    poster: `https://example.test/${id}.png`,
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration,
+    sourceDuration: duration,
+    trimIn: 0,
+    trimOut: 0,
+  }) as TimelineClip;
+
+const collection = (id: string, childTimelineId: string, overrides: Partial<TimelineClip> = {}) =>
+  ({
+    id,
+    index: 0,
+    kind: "collection",
+    title: childTimelineId,
+    childTimelineId,
+    itemCount: 0,
+    previewItems: [],
+    alt: id,
+    aspect: 16 / 9,
+    trackIndex: 0,
+    startTime: 0,
+    duration: 0,
+    sourceDuration: 0,
+    trimIn: 0,
+    trimOut: 0,
+    ...overrides,
+  }) as TimelineClip;
+
+/**
+ * A closure with the shapes that have actually caused bugs here: nesting three
+ * deep, a trimmed collection (so the window math has to map a child's local
+ * range onto a narrower parent span), a disabled clip (kept, not pruned), a
+ * layered clip on a lane, an empty collection (the 3s floor), and a document
+ * whose STORED summaries are wrong — which is the normal state, since writes
+ * are patch-scoped.
+ */
+function closure(): Record<string, TimelineDocument> {
+  return {
+    root: {
+      id: "root",
+      title: "Root",
+      clips: packTimelineClips([
+        collection("c-scene", "scene", { duration: 999, itemCount: 99 }),
+        collection("c-empty", "empty", { duration: 0 }),
+      ]),
+    },
+    scene: {
+      id: "scene",
+      title: "Scene",
+      clips: packTimelineClips([
+        media("m-a", 4),
+        { ...media("m-disabled", 3), disabled: true } as TimelineClip,
+        { ...media("m-layered", 5), trackIndex: 1 } as TimelineClip,
+        // Trimmed: only part of the child's range plays, at a changed rate.
+        collection("c-shot", "shot", {
+          duration: 6,
+          sourceDuration: 12,
+          trimIn: 2,
+          trimOut: 1,
+          itemCount: 1,
+        }),
+      ]),
+    },
+    shot: {
+      id: "shot",
+      title: "Shot",
+      clips: packTimelineClips([media("m-b", 8), media("m-c", 4)]),
+    },
+    empty: { id: "empty", title: "Empty", clips: [] },
+  };
+}
+
+/** What the server route does: derive summaries across the closure, then
+ *  compile. `compile-timeline-manifest.ts` adds storage loading around exactly
+ *  these two steps. */
+function serverPipeline(documents: Record<string, TimelineDocument>) {
+  return compilePlaybackManifest(
+    deriveClosureSummaries(documents),
+    "root",
+    1,
+    "1970-01-01T00:00:00.000Z",
+    { root: 1, scene: 1, shot: 1, empty: 1 },
+  );
+}
+
+/** What a client would run, from documents it already holds. Same two
+ *  functions, same order — the point is that it CAN be the same. */
+function clientPipeline(documents: Record<string, TimelineDocument>) {
+  return compilePlaybackManifest(
+    deriveClosureSummaries(documents),
+    "root",
+    1,
+    "1970-01-01T00:00:00.000Z",
+    { root: 1, scene: 1, shot: 1, empty: 1 },
+  );
+}
+
+describe("client-side manifest compile", () => {
+  it("produces output identical to the server pipeline", () => {
+    expect(clientPipeline(closure())).toEqual(serverPipeline(closure()));
+  });
+
+  it("compiles the nested, trimmed, disabled and layered cases at all", () => {
+    // Guards against the equality above passing because both sides produced
+    // nothing — the failure mode a vacuous fixture would hide.
+    const manifest = clientPipeline(closure());
+    expect(manifest.leaves.length).toBeGreaterThan(0);
+    expect(manifest.leaves.some((leaf) => leaf.disabled === true)).toBe(true);
+    expect(manifest.leaves.some((leaf) => leaf.trackIndex === 1)).toBe(true);
+    // The deepest media is three documents down, reached through a TRIMMED
+    // collection — if recursion stopped early, or the window math dropped the
+    // narrowed range, these would be missing. Asserted on the path rather than
+    // the id, because the path is what makes a leaf unique when the same clip
+    // id appears in two documents.
+    const deep = manifest.leaves.filter((leaf) => leaf.collectionPath.includes("shot"));
+    expect(deep.map((leaf) => leaf.id).sort()).toEqual(["m-b", "m-c"]);
+    // Trimming means the child does NOT contribute its full length.
+    expect(deep.every((leaf) => leaf.timelineDuration > 0)).toBe(true);
+  });
+
+  it("DERIVATION IS NOT OPTIONAL — skipping it changes the manifest", () => {
+    // The step a client implementation would most plausibly skip, because the
+    // documents "look" ready to compile. Stored summaries are stale by design
+    // (patch-scoped writes), and the server route's comment records what
+    // happened when the preview path once omitted this: it "reported a
+    // different total than the board while windowing a grown child's newest
+    // clips out of playback entirely".
+    //
+    // Asserting they DIFFER is what makes the equality test above meaningful:
+    // it proves both sides are doing the derivation, rather than the fixture
+    // being insensitive to it.
+    const withoutDerivation = compilePlaybackManifest(
+      closure(),
+      "root",
+      1,
+      "1970-01-01T00:00:00.000Z",
+      { root: 1, scene: 1, shot: 1, empty: 1 },
+    );
+    expect(withoutDerivation).not.toEqual(serverPipeline(closure()));
+  });
+});
+
+describe("closure completeness guard", () => {
+  it("compiles when every referenced document is in hand", () => {
+    const manifest = compileClientPlaybackManifest(
+      closure(),
+      "root",
+      () => 1,
+      "1970-01-01T00:00:00.000Z",
+    );
+    expect(manifest).not.toBeNull();
+    // The whole point: identical to what the server would have returned.
+    expect(manifest).toEqual(serverPipeline(closure()));
+  });
+
+  it("REFUSES rather than compiling a shallower manifest when a child is missing", () => {
+    // The silent failure this guard exists to prevent: without it, the deepest
+    // media simply would not play and nothing would say so.
+    const partial = closure();
+    delete partial.shot;
+    expect(compileClientPlaybackManifest(partial, "root", () => 1, "x")).toBeNull();
+  });
+
+  it("refuses on a cycle instead of throwing", () => {
+    const cyclic = closure();
+    // Written out rather than spread: under noUncheckedIndexedAccess a lookup
+    // into the map is possibly-undefined, so spreading it makes every field
+    // optional and the result stops being a TimelineDocument.
+    cyclic.shot = { id: "shot", title: "Shot", clips: [collection("c-loop", "scene")] };
+    expect(compileClientPlaybackManifest(cyclic, "root", () => 1, "x")).toBeNull();
+  });
+
+  it("derives over the closure SUBSET, not every cached document", () => {
+    // A session holding a second project must not pay for it on every
+    // recompile — and must not have its manifest changed by it either.
+    const withStranger = {
+      ...closure(),
+      "other-project": { id: "other-project", title: "Other", clips: [media("m-x", 9)] },
+    };
+    expect(
+      compileClientPlaybackManifest(withStranger, "root", () => 1, "1970-01-01T00:00:00.000Z"),
+    ).toEqual(serverPipeline(closure()));
+  });
+});
+
+describe("dangling references", () => {
+  const withDangling = () => {
+    const documents = closure();
+    documents.scene = {
+      id: "scene",
+      title: "Scene",
+      clips: packTimelineClips([media("m-a", 4), collection("c-gone", "gone")]),
+    };
+    return documents;
+  };
+
+  it("still refuses when the server has NOT said the id is missing", () => {
+    // Indistinguishable from an unhydrated child from here, and guessing wrong
+    // means silently playing nothing for a real branch.
+    expect(compileClientPlaybackManifest(withDangling(), "root", () => 1, "x")).toBeNull();
+  });
+
+  it("compiles once the server has reported it missing, substituting an empty", () => {
+    const manifest = compileClientPlaybackManifest(
+      withDangling(),
+      "root",
+      () => 1,
+      "1970-01-01T00:00:00.000Z",
+      (id) => id === "gone",
+    );
+    expect(manifest).not.toBeNull();
+    // The dangling branch contributes no media, and does not abort the compile.
+    expect(manifest?.leaves.some((leaf) => leaf.collectionPath.includes("gone"))).toBe(false);
+    expect(manifest?.leaves.some((leaf) => leaf.id === "m-a")).toBe(true);
+  });
+});

--- a/apps/timeline-gstudio001/lib/client-playback-manifest.ts
+++ b/apps/timeline-gstudio001/lib/client-playback-manifest.ts
@@ -1,0 +1,149 @@
+import { compilePlaybackManifest, type PlaybackManifest } from "@storyboard/timeline-domain";
+import type { TimelineDocument } from "@storyboard/timeline-model/types";
+
+import { deriveClosureSummaries } from "./derive-collection-summaries";
+
+/**
+ * Compile the playback manifest IN THE BROWSER, from documents the session
+ * already holds.
+ *
+ * The server route re-reads every document under the root to compile the same
+ * thing — measured at ~149 document reads per compile on a 143-collection
+ * project, repeated on every edit while preview is open. At ~175 collections a
+ * 200-edit session spends ~35,000 reads that way, all of it re-reading a
+ * closure the client primed on entry and has kept current since.
+ *
+ * ONLY WHEN THE CLOSURE IS PROVABLY COMPLETE. The manifest exists precisely so
+ * that "playback depth no longer depends on how much of the graph a session
+ * happens to have hydrated" — compiling from a partial closure would reintroduce
+ * exactly what it was built to prevent, and the failure is silent: a collection
+ * four levels down simply plays nothing. So `collectionIds` walks first and
+ * refuses on the first reference it cannot resolve, and the caller falls back to
+ * the server route, which reads from storage and has no such limit.
+ *
+ * SAME TWO STEPS, SAME ORDER as the server (`compile-timeline-manifest.ts`):
+ * derive summaries across the closure, then compile. Skipping the derivation is
+ * the plausible mistake and not a harmless one — stored summaries are stale by
+ * design, because writes are patch-scoped, and a compile that trusted them once
+ * "reported a different total than the board while windowing a grown child's
+ * newest clips out of playback entirely". `client-manifest-equivalence.test.ts`
+ * pins both the agreement and the fact that the derivation changes the answer.
+ */
+
+/**
+ * Every document id reachable from `rootId`, or null when the closure cannot be
+ * compiled from what is in hand.
+ *
+ * Null means "ask the server", never "compile a smaller manifest". Two causes,
+ * deliberately not distinguished, because the caller's response is the same:
+ *
+ *   - A referenced document is not loaded — a placeholder below the hydration
+ *     depth, or a prime that has not landed.
+ *   - A cycle. `compilePlaybackManifest` throws on one; catching a throw is a
+ *     worse contract than refusing up front, and the server's walk has the same
+ *     guard for the same reason.
+ */
+export function closureIds(
+  documents: Readonly<Record<string, TimelineDocument>>,
+  rootId: string,
+  /**
+   * "The server already told us this id does not exist." A dangling
+   * `childTimelineId` is a normal, handled condition — `loadTimelineClosure`
+   * substitutes an empty document and reports it — so refusing on one would
+   * mean never compiling locally on a project that has any. An exported project
+   * has them by construction: export drops branches whose documents are gone,
+   * leaving the references behind.
+   *
+   * Anything NOT on that list is treated as unhydrated, which is the case the
+   * guard exists for.
+   */
+  isKnownMissing: (id: string) => boolean = () => false,
+): Set<string> | null {
+  const found = new Set<string>();
+  const walk = (id: string, ancestors: ReadonlySet<string>): boolean => {
+    if (ancestors.has(id)) return false;
+    // Known-missing resolves as an empty document, exactly as the server's walk
+    // does, and contributes nothing further to descend into.
+    if (isKnownMissing(id) && !documents[id]) return true;
+    const document = documents[id];
+    if (!document) return false;
+    found.add(id);
+    const nextAncestors = new Set(ancestors);
+    nextAncestors.add(id);
+    for (const clip of document.clips) {
+      if (clip.kind !== "collection" || !clip.childTimelineId) continue;
+      if (!walk(clip.childTimelineId, nextAncestors)) return false;
+    }
+    return true;
+  };
+  return walk(rootId, new Set()) ? found : null;
+}
+
+/**
+ * The manifest, or null when the caller should fetch it instead.
+ *
+ * Compiled over the closure SUBSET rather than every document the session has
+ * cached: `deriveClosureSummaries` derives for everything it is given, and a
+ * session holding several projects would otherwise pay for all of them on every
+ * recompile.
+ *
+ * The revisions are the ledger's, which is the honest answer to "what was this
+ * compiled from" — including the case where a document has unsaved local edits
+ * and the ledger still names the last accepted revision. Unlike a server
+ * manifest, this one cannot TRAIL the session's writes: it is compiled from the
+ * very documents those writes produced, which is why the caller installs it
+ * without the `manifestTrailsLedger` guard that exists to catch a stale
+ * server-side compile.
+ */
+export function compileClientPlaybackManifest(
+  documents: Readonly<Record<string, TimelineDocument>>,
+  rootId: string,
+  revisionOf: (id: string) => number | undefined,
+  compiledAt: string,
+  isKnownMissing: (id: string) => boolean = () => false,
+): PlaybackManifest | null {
+  const ids = closureIds(documents, rootId, isKnownMissing);
+  if (ids === null) return null;
+
+  const subset: Record<string, TimelineDocument> = {};
+  const unresolved = new Set<string>();
+  const revisions: Record<string, number> = {};
+  for (const id of ids) {
+    const document = documents[id];
+    if (!document) return null;
+    subset[id] = document;
+    revisions[id] = revisionOf(id) ?? 0;
+    // An empty stand-in for each dangling reference, so the compiler has
+    // something to resolve — it throws on an unresolvable child, and a branch
+    // that does not exist should fall silent rather than abort the compile.
+    for (const clip of document.clips) {
+      if (clip.kind !== "collection" || !clip.childTimelineId) continue;
+      const childId = clip.childTimelineId;
+      if (subset[childId] || documents[childId] || !isKnownMissing(childId)) continue;
+      subset[childId] = { id: childId, title: "", clips: [] };
+      revisions[childId] = 0;
+      unresolved.add(childId);
+    }
+  }
+
+  // THE UNRESOLVED SET, which is not the same as substituting empties.
+  //
+  // `deriveClosureSummaries` treats these ids as ABSENT so the parent's stored
+  // summary stands — "stale beats blank", in its words, because deriving from
+  // an empty stand-in would rewrite a real stored duration to "empty
+  // collection". Passing the substitutes without the set does exactly that:
+  // measured on a real project, the client compiled 1336.2s against the
+  // server's 1360.7s, the whole 24.5s difference being two dangling branches
+  // flattened to nothing.
+  //
+  // `serveTimelineClosure` passes its `missing` here for the same reason. The
+  // stand-ins above are for the COMPILER, this set is for the DERIVATION, and
+  // both are needed.
+  return compilePlaybackManifest(
+    deriveClosureSummaries(subset, unresolved),
+    rootId,
+    revisions[rootId] ?? 0,
+    compiledAt,
+    revisions,
+  );
+}

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
@@ -170,6 +170,15 @@ export type GraphDocumentsGateway = Readonly<{
    */
   isConflicted: (timelineId: string) => boolean;
   /**
+   * True when a closure walk reported this id as UNRESOLVABLE — the document
+   * does not exist, as opposed to not being loaded yet. Only the server can
+   * tell those apart, so this is its answer, remembered.
+   */
+  isKnownMissing: (timelineId: string) => boolean;
+  /** Record ids a SERVER walk reported unresolvable. The RSC boot path ships
+   *  them alongside its payloads; `ensureClosure` records its own. */
+  recordMissing: (ids: readonly string[]) => void;
+  /**
    * Declare that the CACHE is ahead of the live graph for this document, so
    * clip writes projected from that graph must stop.
    *
@@ -285,6 +294,10 @@ export function createGraphDocumentsGateway(
   // change that touches several documents writes them in the same window,
   // so they travel in the SAME atomic batch.
   const dirtyIds = new Set<string>();
+  /** Ids the SERVER reported as unresolvable while walking a closure — a
+   *  dangling childTimelineId, not a document waiting to load. See the note in
+   *  `ensureClosure`. */
+  const knownMissingIds = new Set<string>();
   // Documents this session has actually EMPTIED — observed at the moment the
   // clips went from some to none, not inferred later from a projection that
   // happens to be empty. The store refuses an empty-over-non-empty write
@@ -669,8 +682,23 @@ export function createGraphDocumentsGateway(
       if (gen !== generation || !response.ok) return;
       const payload = (await response.json().catch(() => ({}))) as {
         results?: { id?: string; document?: TimelineDocument; revision?: number }[];
+        missing?: string[];
       };
       if (gen !== generation) return;
+
+      // KEEP THE MISSING LIST, which this used to discard.
+      //
+      // The server distinguishes two things the client otherwise cannot: a
+      // document that is not loaded YET, and one that does not exist — a
+      // dangling `childTimelineId` whose document was deleted. Its walk
+      // substitutes an empty document for the second and reports the id here.
+      //
+      // Without that distinction, any consumer asking "do I hold the whole
+      // closure?" has to answer no whenever a reference dangles, because an
+      // unresolvable id looks identical to an unhydrated one. Recording them
+      // lets `compileClientPlaybackManifest` substitute empties exactly where
+      // the server does and still refuse on genuine gaps.
+      for (const id of payload.missing ?? []) knownMissingIds.add(id);
 
       // Installed as PRIMES, through exactly the path an RSC payload uses. That
       // matters for more than tidiness: `installPrime` is what refuses a
@@ -1178,6 +1206,10 @@ export function createGraphDocumentsGateway(
     hasPendingWrite: (timelineId) =>
       dirtyIds.has(timelineId) || saveInFlightIds.includes(timelineId),
     isConflicted: (timelineId) => conflictedIds.has(timelineId),
+    isKnownMissing: (timelineId) => knownMissingIds.has(timelineId),
+    recordMissing: (ids) => {
+      for (const id of ids) knownMissingIds.add(id);
+    },
     markGraphBehind: (timelineId, reason) => {
       if (documents[timelineId] === undefined) return;
       if (conflictedIds.has(timelineId)) return;

--- a/apps/timeline-gstudio001/lib/graph-rsc-payloads.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-rsc-payloads.test.ts
@@ -137,7 +137,7 @@ describe("loadGraphBootstrapPayloads", () => {
     seed("project-1", "user-a", [image("a", 0, 4)], 5);
     seed("trash-user-a", "user-a", [image("t", 0, 4)], 2);
 
-    const payloads = await loadGraphBootstrapPayloads("project-1", "user-a");
+    const payloads = (await loadGraphBootstrapPayloads("project-1", "user-a"))?.payloads ?? null;
     expect(payloads).not.toBeNull();
     expect(payloads!.map((payload) => [payload.document.id, payload.revision])).toEqual([
       ["project-1", 5],
@@ -147,7 +147,7 @@ describe("loadGraphBootstrapPayloads", () => {
 
   it("serves an unstored trash as an empty revision-0 document", async () => {
     seed("project-1", "user-a", [image("a", 0, 4)]);
-    const payloads = await loadGraphBootstrapPayloads("project-1", "user-a");
+    const payloads = (await loadGraphBootstrapPayloads("project-1", "user-a"))?.payloads ?? null;
     expect(at(payloads ?? [], 1).document.clips).toEqual([]);
     expect(at(payloads ?? [], 1).revision).toBe(0);
   });

--- a/apps/timeline-gstudio001/lib/graph-rsc-payloads.ts
+++ b/apps/timeline-gstudio001/lib/graph-rsc-payloads.ts
@@ -39,10 +39,22 @@ const MAX_PATH_ATTEMPTS = 48;
  * (missing or denied): the client boots through its legacy fetch path and
  * surfaces the error there.
  */
+export type GraphBootstrap = Readonly<{
+  payloads: readonly GraphServerPayload[];
+  /**
+   * Ids the closure walk could not resolve — a `childTimelineId` whose document
+   * is gone. Shipped because ONLY the server can tell that apart from a
+   * document the client has not loaded yet, and the client needs the difference
+   * to know whether it holds a complete closure. Empty on the fallback path
+   * below, where the client holds two documents and can prove nothing anyway.
+   */
+  missing: readonly string[];
+}>;
+
 export async function loadGraphBootstrapPayloads(
   projectId: string,
   requesterUid: string,
-): Promise<readonly GraphServerPayload[] | null> {
+): Promise<GraphBootstrap | null> {
   try {
     // THE WHOLE CLOSURE, not just the project.
     //
@@ -64,24 +76,30 @@ export async function loadGraphBootstrapPayloads(
       const project = await serveTimelineDocument(projectId, requesterUid, read);
       if (!project) return null;
       const trash = await serveTrashDocument(`trash-${requesterUid}`, requesterUid, read);
-      return [
-        { ...project, forUid: requesterUid },
-        { ...trash, forUid: requesterUid },
-      ];
+      return {
+        payloads: [
+          { ...project, forUid: requesterUid },
+          { ...trash, forUid: requesterUid },
+        ],
+        missing: [],
+      };
     }
     // The trash is NOT under the project, so it is read separately — through
     // its own reader, since the closure's is finished with.
     const trash = await serveTrashDocument(`trash-${requesterUid}`, requesterUid, read);
     // forUid lets the client's prime refuse payloads that survive an auth
     // transition in the router cache.
-    return [
-      ...Object.entries(closure.documents).map(([, served]) => ({
-        document: served.document,
-        revision: served.revision,
-        forUid: requesterUid,
-      })),
-      { ...trash, forUid: requesterUid },
-    ];
+    return {
+      payloads: [
+        ...Object.entries(closure.documents).map(([, served]) => ({
+          document: served.document,
+          revision: served.revision,
+          forUid: requesterUid,
+        })),
+        { ...trash, forUid: requesterUid },
+      ],
+      missing: closure.missing,
+    };
   } catch {
     return null;
   }

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -1,5 +1,8 @@
 import { expect, test, type Locator, type Page } from "@playwright/test";
 import { at } from "../../lib/test-support/at";
+import { compilePlaybackManifest } from "@storyboard/timeline-domain";
+import type { TimelineDocument } from "@storyboard/timeline-model/types";
+import { deriveClosureSummaries } from "../../lib/derive-collection-summaries";
 
 // E2E for the graph project view (/timeline/[projectId]/graph) — the REAL
 // Next app driven with real mouse input. The server surface the view touches
@@ -140,83 +143,55 @@ function buildFixtureDocuments(): Map<string, FixtureDocument> {
  *  projection — which is every local run. CI is slower per step, the manifest
  *  won the race, and one test went red there and only there. A vacuous fixture,
  *  not a flake. */
+/**
+ * The fixture's playback manifest — compiled by the REAL pipeline.
+ *
+ * This was a hand-written walk living in this file: a second implementation of
+ * flattening, maintained by hand against the one in
+ * `packages/timeline-domain`. It drifted, as second implementations do — its
+ * own comment recorded emitting no `trackIndex` at all, so "every leaf arrived
+ * on lane 0 and the manifest said the timeline had no lanes" — and the tests
+ * calibrated against it were measuring the mock rather than the product.
+ *
+ * It compiles through `deriveClosureSummaries` then `compilePlaybackManifest`
+ * now, which is exactly what `compile-timeline-manifest.ts` does server-side
+ * and what the client does when it holds the whole closure. Three callers, one
+ * definition, no drift available.
+ *
+ * The derivation step is not optional here either: stored summaries are stale
+ * by design (patch-scoped writes), so compiling without it windows a grown
+ * child's newest clips out of playback.
+ */
 function compileFixtureManifest(
   documents: Map<string, FixtureDocument>,
   rootId: string,
   revision: number,
 ) {
-  const root = documents.get(rootId);
-  if (!root) return null;
-  type Leaf = Record<string, unknown>;
-  const leaves: Leaf[] = [];
-  const walk = (
-    documentId: string,
-    path: string[],
-    offset: number,
-    /** True once any collection clip ABOVE this document was disabled. There is
-     *  no way back on the way down: an enabled child of a disabled parent
-     *  still does not play. */
-    inheritedDisabled: boolean,
-    /** The OUTERMOST non-zero lane seen on the way down, 0 while still on the
-     *  picture — the same one-way shape as `inheritedDisabled`.
-     *
-     *  Missing here for the same reason `disabled` once was, and it would have
-     *  failed the same way: this mock emitted no `trackIndex` at all, so every
-     *  leaf arrived on lane 0 and the manifest said the timeline had no lanes.
-     *  A test asserting that a bed plays under the picture would have passed
-     *  against a manifest in which there was no bed. */
-    laneFromRoot: number,
-  ) => {
-    const doc = documents.get(documentId);
-    if (!doc) return;
-    for (const clip of doc.clips) {
-      const clipDisabled = inheritedDisabled || clip.disabled === true;
-      const clipLane =
-        laneFromRoot !== 0 ? laneFromRoot : ((clip.trackIndex as number | undefined) ?? 0);
-      if (clip.kind === "collection") {
-        const childId = clip.childTimelineId as string;
-        walk(
-          childId,
-          [...path, childId],
-          offset + (clip.startTime as number),
-          clipDisabled,
-          clipLane,
-        );
-        continue;
-      }
-      leaves.push({
-        id: clip.id,
-        collectionPath: path,
-        kind: clip.kind,
-        src: clip.src,
-        poster: clip.poster,
-        timelineStart: offset + (clip.startTime as number),
-        timelineDuration: clip.duration,
-        sourceStart: clip.trimIn ?? 0,
-        playbackRate: 1,
-        // Always present, exactly as the real compiler emits it — 0 is the
-        // answer for everything written before lanes, never absence.
-        trackIndex: clipLane,
-        // Omitted when false, exactly as the real compiler emits it.
-        ...(clipDisabled ? { disabled: true } : {}),
-      });
+  if (!documents.has(rootId)) return null;
+
+  const record: Record<string, TimelineDocument> = {};
+  for (const [id, document] of documents) {
+    record[id] = document as unknown as TimelineDocument;
+  }
+
+  // Referenced but absent — the server substitutes an empty document AND
+  // reports the id as unresolved, so the derivation leaves the parent's stored
+  // summary standing ("stale beats blank") instead of rewriting it to empty.
+  const missing = new Set<string>();
+  for (const document of documents.values()) {
+    for (const clip of document.clips) {
+      const childId = clip.childTimelineId as string | undefined;
+      if (clip.kind === "collection" && childId && !documents.has(childId)) missing.add(childId);
     }
-  };
-  walk(rootId, [rootId], 0, false, 0);
-  const durationSeconds = root.clips.reduce(
-    (duration, clip) =>
-      Math.max(duration, (clip.startTime as number) + (clip.duration as number)),
-    0,
+  }
+  for (const id of missing) record[id] = { id, title: "", clips: [] };
+
+  return compilePlaybackManifest(
+    deriveClosureSummaries(record, missing),
+    rootId,
+    revision,
+    new Date().toISOString(),
   );
-  return {
-    projectId: rootId,
-    projectRevision: revision,
-    durationSeconds,
-    leaves: leaves.sort(
-      (a, b) => (a.timelineStart as number) - (b.timelineStart as number),
-    ),
-    compiledAt: new Date().toISOString(),
-  };
 }
 
 // ── API mock ────────────────────────────────────────────────────────────────
@@ -290,21 +265,41 @@ async function installGraphApi(
     blockChildDocument?: boolean;
     /** Put named PROJECT clips on a lane above the picture, by id. */
     lanes?: Readonly<Record<string, number>>;
+    /**
+     * Pin named PROJECT clips to a start time. Only meaningful on lanes 1+,
+     * where packing would otherwise put a clip at the start of its own lane —
+     * a laned clip the user dropped somewhere carries this, so a fixture that
+     * wants one parked over a picture gap has to say so.
+     */
+    placedStarts?: Readonly<Record<string, number>>;
   } = {},
 ): Promise<GraphApi> {
   await guardUnmockedApi(page);
   const documents = buildFixtureDocuments();
   // The fixtures are all trackIndex 0 — they predate lanes — so this is how a
   // test gets a layered board without maintaining a second fixture set.
-  const lanes = options.lanes;
-  if (lanes) {
+  const lanes = options.lanes ?? {};
+  const placedStarts = options.placedStarts ?? {};
+  if (options.lanes || options.placedStarts) {
     const project = documents.get(PROJECT_ID);
     if (project) {
       documents.set(PROJECT_ID, {
         ...project,
         clips: project.clips.map((clip) => {
           const lane = lanes[clip.id];
-          return lane === undefined ? clip : { ...clip, trackIndex: lane };
+          const placedStart = placedStarts[clip.id];
+          if (lane === undefined && placedStart === undefined) return clip;
+          // LANE ALONE PACKS FROM ZERO — that is the feature, and one test
+          // asserts exactly it. A clip that must sit somewhere else on its lane
+          // needs `placedStart`, because packing is per lane
+          // (`nextStartByTrack`) and the model "HONOURS placedStart on lanes 1+,
+          // which is what makes a lane a timeline". The two are separate options
+          // because the two tests need opposite things and both are right.
+          return {
+            ...clip,
+            ...(lane === undefined ? {} : { trackIndex: lane }),
+            ...(placedStart === undefined ? {} : { placedStart }),
+          };
         }),
       });
     }
@@ -8618,7 +8613,11 @@ test.describe("graph view E2E", () => {
   test("a layered clip is LIVE in the preview, and the picture HOLDS under it", async ({
     page,
   }) => {
-    await installGraphApi(page, { lanes: { bravo: 1 } });
+    // PARKED, not merely laned. A lane packs from zero, so a bare `lanes`
+    // fixture puts bravo over alpha and there is no picture gap to hold across
+    // — the very thing this test is about. `placedStarts` pins it at 6, which
+    // is what a clip the user dropped there actually carries.
+    await installGraphApi(page, { lanes: { bravo: 1 }, placedStarts: { bravo: 6 } });
     await openGraph(page);
     await expect.poll(() => laneOrder(page, PROJECT_ID, 1)).toEqual(["bravo"]);
 


### PR DESCRIPTION
The preview asked the server for a manifest and the server **re-read every
document under the root** to build it. Measured on a real board:

| | Counter |
| --- | --- |
| Board open | 149 |
| Open preview | 149 → **297** |
| One added collection | 297 → **446** |

~149 reads per compile on a 143-collection project, repeated after every edit
while preview stays open. At ~175 collections a 200-edit session spends
~35,000 reads that way — all of it re-reading a closure the client primed on
entry and has kept current since.

## The change

`compilePlaybackManifest` was already framework-free and exported, and
`deriveClosureSummaries` imports only the model package, so the client runs the
**identical pipeline** over documents it already holds.

**Only when the closure is provably complete.** The manifest exists so playback
depth does not depend on how much of the graph a session happens to have
hydrated. Compiling from a partial closure would reintroduce exactly that, and
silently — a collection four levels down would simply play nothing. The walk
refuses on the first unresolvable reference, and on a cycle, and falls through
to the server route.

That guard needed a fact only the server has: whether an unresolvable id is a
document **not loaded yet** or one that **does not exist**. The closure walk
already reports the second as `missing`, and both the boot payload builder and
`ensureClosure` were discarding it. They now carry it to the gateway — which is
why an exported project (dangling by construction, since export drops branches
whose documents are gone) can compile locally at all.

## Two bugs the measurement caught

Neither was visible to the synthetic tests, and both would have shipped.

**Wrong duration: 1336.2s against the server's 1354.5s.** Empty stand-ins were
substituted for dangling references without also passing them as `unresolved`,
so `deriveClosureSummaries` rewrote two real stored summaries to "empty
collection" — **24.5s of timeline silently gone**. Its own words: *"stale beats
blank."* The stand-ins are for the **compiler**, the set is for the
**derivation**, and both are needed.

**Wrong branch under test.** `serveTimelineClosure` *excludes* missing ids from
what it ships, so the client never holds those stubs and the path that actually
runs is the `isKnownMissing` one. A comparison that fed the stubs in exercised
something the app never does.

## Verification

**291 leaves compared field for field** — id, collection path, timeline start,
duration, source position, playback rate, lane, disabled — against the server's
manifest over the real **145-document** project with **5 dangling references**.
Duration equal to six decimal places.

Nine synthetic tests cover the shapes that have caused bugs here (three levels
deep, a trimmed collection, disabled, layered, empty, deliberately-stale stored
summaries), including one asserting that **skipping the derivation changes the
answer** — so the equivalence assertions cannot pass vacuously.

1288 tests, tsc and eslint clean. Measured after: **preview opens and edits make
no manifest request at all.**

## Scope

Preview only. `POST /api/renders` and `lib/mcp/render.ts` still compile
server-side from storage, which is right — they start with no session and a
wrong manifest there is a wrong file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)