### PR TITLE
One request per level instead of one per document

### DIFF
--- a/apps/timeline-gstudio001/app/api/timelines/timelines-batch-get.test.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/timelines-batch-get.test.ts
@@ -20,7 +20,10 @@ const state = vi.hoisted(() => {
   const current = {
     user: { uid: "user-a", email: null as string | null, name: null, picture: null },
   };
-  /** Every `doc(id).get()` the store performs — one Firestore document read. */
+  /** Every document the store reads, however it read it — one Firestore
+   *  document read each, whether it arrived via `doc(id).get()` or in a
+   *  `getAll` batch. Batching changes the number of REQUESTS, never the number
+   *  of documents, so these assertions hold across both. */
   const reads: string[] = [];
 
   const snapshot = (id: string) => {
@@ -42,6 +45,11 @@ const state = vi.hoisted(() => {
         },
       }),
     }),
+    getAll: async (...refs: { id: string }[]) =>
+      refs.map((ref) => {
+        reads.push(ref.id);
+        return snapshot(ref.id);
+      }),
   };
   return { docs, current, db, reads };
 });

--- a/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
@@ -191,6 +191,11 @@ export type TimelineProjectSummary = {
 };
 
 const TIMELINE_COLLECTION = "gstudioTimelineDocuments";
+
+/** Documents per batched read. Firestore's `getAll` takes a stream of refs
+ *  rather than a fixed maximum, so this is about keeping any one request a
+ *  reasonable size — not a platform limit like the 500-op write transaction. */
+const MAX_BATCH_READ_DOCUMENTS = 200;
 const FIREBASE_TIMEOUT_MS = 8_000;
 
 /**
@@ -649,6 +654,95 @@ export async function readStoredTimelineEntry(
   };
   logRead(readTotal, id, entry, "firestore");
   return entry;
+}
+
+/**
+ * MANY documents in ONE Firestore round trip.
+ *
+ * The closure walk read a document at a time — `mapWithConcurrency` over
+ * `doc(id).get()`, twelve in flight — so a 500-document closure was ~42
+ * sequential rounds. Firestore takes a batched read, which makes it one call
+ * per BFS level: depth rather than breadth. Measured before: 3,701ms to export
+ * a 143-document project, most of it round trips rather than Firestore work.
+ *
+ * THE BILL DOES NOT MOVE. Firestore charges per document returned, so 500
+ * documents cost 500 reads however they arrive. `countRead` still fires once
+ * per id, before the fetch, exactly as the single-document path does — if
+ * [READTOTAL] changes after this, something broke rather than got faster.
+ *
+ * DENIED IS NULL HERE, where the single-document read throws. Its callers map
+ * that throw to a 404; this one's caller is the closure walk, which already
+ * wrote `.catch(() => null)` around every child read — a subtree you cannot see
+ * is a dangling branch, not a failed page. Returning null keeps that behaviour
+ * without making the whole frontier fail because one document in it was
+ * someone else's.
+ */
+export async function readStoredTimelineEntries(
+  ids: readonly string[],
+  requesterUid: string,
+): Promise<Map<string, TimelineEntry | null>> {
+  const out = new Map<string, TimelineEntry | null>();
+  // Deduped before counting: a repeated id would otherwise be billed twice in
+  // the log and passed to `getAll` twice.
+  const unique = [...new Set(ids)];
+  if (unique.length === 0) return out;
+
+  // Counted BEFORE the fetch, per id, so the metric stays "read attempts" —
+  // the same rule the single-document path follows.
+  const totals = new Map<string, number | null>();
+  for (const id of unique) totals.set(id, countRead());
+
+  if (fixtureStoreEnabled()) {
+    for (const id of unique) {
+      const entry = fixtureReadEntry(id);
+      logRead(totals.get(id) ?? null, id, entry, "fixture");
+      out.set(id, entry);
+    }
+    return out;
+  }
+
+  // CHUNKED, because one `getAll` is one request and a BFS level can be most of
+  // a 500-document closure. The chunks go out together, so the round trips still
+  // overlap; the bound is on request size, not on parallelism.
+  const chunks: string[][] = [];
+  for (let index = 0; index < unique.length; index += MAX_BATCH_READ_DOCUMENTS) {
+    chunks.push(unique.slice(index, index + MAX_BATCH_READ_DOCUMENTS));
+  }
+  const snapshots = (
+    await Promise.all(
+      chunks.map((chunk) =>
+        withFirebaseTimeout(
+          getFirebaseDb().getAll(...chunk.map((id) => collection().doc(id))),
+          "Loading timeline documents",
+        ),
+      ),
+    )
+  ).flat();
+
+  for (const snapshot of snapshots) {
+    const id = snapshot.id;
+    const total = totals.get(id) ?? null;
+    if (!snapshot.exists) {
+      logRead(total, id, null, "firestore");
+      out.set(id, null);
+      continue;
+    }
+    const data = snapshot.data() as TimelineDocumentRecord;
+    // Per SNAPSHOT, never per request: one readable document in a batch must
+    // not carry the rest past the ownership boundary.
+    if (resolveOwnership(data.ownerUid, requesterUid) !== "owned") {
+      logRead(total, id, null, "firestore", "denied");
+      out.set(id, null);
+      continue;
+    }
+    const entry = {
+      document: toTimelineDocument(snapshot.id, data),
+      revision: data.revision ?? 0,
+    };
+    logRead(total, id, entry, "firestore");
+    out.set(id, entry);
+  }
+  return out;
 }
 
 /** `readStoredTimelineEntry` without the revision — same caveats, read them there. */

--- a/apps/timeline-gstudio001/lib/graph-rsc-payloads.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-rsc-payloads.test.ts
@@ -42,7 +42,14 @@ const state = vi.hoisted(() => {
       docs.delete(id);
     },
   });
+  const readOnce = (id: string) => {
+    reads.set(id, (reads.get(id) ?? 0) + 1);
+    return snapshot(id);
+  };
   const db = {
+    // Counted per DOCUMENT, same as `doc(id).get()` — a batched read is one
+    // request but still one billed read per document in it.
+    getAll: async (...refs: { id: string }[]) => refs.map((ref) => readOnce(ref.id)),
     collection: () => ({
       doc: docRef,
       where: (field: string, _op: string, value: unknown) => ({

--- a/apps/timeline-gstudio001/lib/load-timeline-closure.ts
+++ b/apps/timeline-gstudio001/lib/load-timeline-closure.ts
@@ -4,6 +4,19 @@ import type { TimelineDocument } from "@storyboard/timeline-model/types";
 
 import { readStoredTimelineEntry, type TimelineEntry } from "./firebase-timeline-store";
 
+/**
+ * How a caller reads documents.
+ *
+ * Declared HERE rather than in `serve-timeline`, which re-exports it: the
+ * closure walk is what consumes `many`, and this module must not import from
+ * its own caller.
+ */
+export type TimelineEntryReader = ((id: string) => Promise<TimelineEntry | null>) & {
+  /** Optional bulk path — see `createTimelineEntryReader`. A plain function
+   *  still satisfies this type, which is what test readers hand in. */
+  many?: (ids: readonly string[]) => Promise<Map<string, TimelineEntry | null>>;
+};
+
 // The nested document closure for a timeline: the root plus every document
 // reachable through collection clips, breadth-first with a visited set (a
 // reference cycle in stored data terminates the WALK here; the manifest
@@ -77,7 +90,7 @@ export async function loadTimelineClosure(
      * closure walk that bypassed it would re-fetch documents the caller had
      * just loaded. It is also the seam its tests inject through.
      */
-    read?: (id: string) => Promise<TimelineEntry | null>;
+    read?: TimelineEntryReader;
   }>,
 ): Promise<{
   documents: Record<string, TimelineDocument>;
@@ -118,7 +131,7 @@ export async function loadTimelineClosure(
   // `rootEntry: null` is a caller that looked and found nothing — honour it
   // rather than re-reading to rediscover the same absence. `undefined` means
   // the caller has no opinion.
-  const read =
+  const read: TimelineEntryReader =
     options?.read ?? ((childId: string) => readStoredTimelineEntry(childId, requesterUid));
   const rootEntry =
     options?.rootEntry !== undefined
@@ -128,10 +141,20 @@ export async function loadTimelineClosure(
   let frontier: readonly string[] = record(rootId, rootEntry);
 
   while (frontier.length > 0) {
-    const entries = await mapWithConcurrency(frontier, READ_CONCURRENCY, async (id) => ({
-      id,
-      entry: await read(id).catch(() => null),
-    }));
+    // ONE ROUND TRIP PER LEVEL when the reader can batch, twelve-at-a-time when
+    // it cannot (hand-written readers in tests, and the un-shared default). The
+    // shape of the walk is identical either way — a level is read, then
+    // recorded in frontier order — so only the number of network calls moves.
+    const batched = await read.many?.(frontier);
+    const entries = batched
+      ? frontier.map((id) => ({ id, entry: batched.get(id) ?? null }))
+      : await mapWithConcurrency(frontier, READ_CONCURRENCY, async (id) => ({
+          id,
+          // A read that throws is a document this requester cannot see. It is
+          // recorded as missing, exactly as a document that does not exist:
+          // one unreadable branch must not fail the whole closure.
+          entry: await read(id).catch(() => null),
+        }));
     // Recorded in frontier order, so `documents` and `missing` keep the
     // deterministic ordering the sequential walk produced.
     frontier = entries.flatMap(({ id, entry }) => record(id, entry));

--- a/apps/timeline-gstudio001/lib/serve-timeline.ts
+++ b/apps/timeline-gstudio001/lib/serve-timeline.ts
@@ -10,9 +10,11 @@ import {
 } from "./derive-collection-summaries";
 import {
   loadTimelineClosure,
+  type TimelineEntryReader,
   TimelineClosureTooLargeError,
 } from "./load-timeline-closure";
 import {
+  readStoredTimelineEntries,
   readStoredTimelineEntry,
   type TimelineEntry,
 } from "./firebase-timeline-store";
@@ -43,17 +45,56 @@ export type ServedTimeline = Readonly<{
  * `TimelineAccessDeniedError` is a stable answer for the life of a request,
  * and re-reading to rediscover it would defeat the point.
  */
-export type TimelineEntryReader = (id: string) => Promise<TimelineEntry | null>;
+export type { TimelineEntryReader } from "./load-timeline-closure";
 
 export function createTimelineEntryReader(requesterUid: string): TimelineEntryReader {
   const inflight = new Map<string, Promise<TimelineEntry | null>>();
-  return (id) => {
+  const read: TimelineEntryReader = (id) => {
     const cached = inflight.get(id);
     if (cached) return cached;
     const request = readStoredTimelineEntry(id, requesterUid);
     inflight.set(id, request);
     return request;
   };
+
+  // The BATCH GOES THROUGH THE SAME `inflight` MAP, which is the whole point:
+  // batch-get shares one reader across several roots, so an id already being
+  // read for one root must not be re-read for the next. Ids already in flight
+  // are awaited, only the rest are fetched, and the results are recorded so a
+  // later single read joins this batch instead of issuing its own get().
+  read.many = async (ids) => {
+    const out = new Map<string, TimelineEntry | null>();
+    const wanted: string[] = [];
+    const joined: Promise<void>[] = [];
+    for (const id of new Set(ids)) {
+      const cached = inflight.get(id);
+      if (cached) {
+        // A rejected read is a document this caller cannot see; the walk turns
+        // that into "missing" rather than failing the level (see below).
+        joined.push(cached.then((entry) => void out.set(id, entry), () => void out.set(id, null)));
+      } else {
+        wanted.push(id);
+      }
+    }
+
+    const batch = wanted.length
+      ? readStoredTimelineEntries(wanted, requesterUid)
+      : Promise.resolve(new Map<string, TimelineEntry | null>());
+    // Seeded BEFORE the await so a concurrent reader joins rather than races.
+    // Falling back to null on a failed batch keeps a doomed request from
+    // leaving unhandled rejections behind it — the failure itself still
+    // propagates through the await below.
+    for (const id of wanted) {
+      inflight.set(id, batch.then((entries) => entries.get(id) ?? null, () => null));
+    }
+
+    const entries = await batch;
+    for (const id of wanted) out.set(id, entries.get(id) ?? null);
+    await Promise.all(joined);
+    return out;
+  };
+
+  return read;
 }
 
 /** Null when the document doesn't exist; throws TimelineAccessDeniedError

--- a/apps/timeline-gstudio001/scripts/measure-closure-batched-vs-per-document-reads.mjs
+++ b/apps/timeline-gstudio001/scripts/measure-closure-batched-vs-per-document-reads.mjs
@@ -1,0 +1,142 @@
+/**
+ * Times the closure walk BOTH ways against the live database: one `get()` per
+ * document at concurrency 12 (what the walk did), and chunked `getAll` (what it
+ * does now). Same root, same order, back to back.
+ *
+ * WHAT IT IS MEASURING, and what it is not. The change is transport only —
+ * Firestore bills per document returned, so both runs read the same documents
+ * and cost the same. The script prints both counts precisely so that claim can
+ * be checked rather than asserted: a difference in DOCUMENTS would mean the
+ * walk changed shape, which is a bug, not a speedup.
+ *
+ * COSTS ONE CLOSURE OF READS PER RUN — ~150 on the project this was written
+ * for, ~300 for the pair. It is a benchmark against production data; run it
+ * deliberately, not in a loop (see the quota note in timeline-snapshot.mjs).
+ *
+ *   node scripts/measure-closure-batched-vs-per-document-reads.mjs <rootId> [--repeat 2]
+ */
+import { config } from "dotenv";
+import { cert, applicationDefault, initializeApp } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+
+config({ path: ".env" });
+
+const COLLECTION = "gstudioTimelineDocuments";
+/** Mirrors READ_CONCURRENCY in lib/load-timeline-closure.ts. */
+const READ_CONCURRENCY = 12;
+/** Mirrors MAX_BATCH_READ_DOCUMENTS in lib/firebase-timeline-store.ts. */
+const CHUNK = 200;
+
+const rootId = process.argv[2];
+if (!rootId) {
+  console.error("Usage: node scripts/measure-closure-batched-vs-per-document-reads.mjs <rootId>");
+  process.exit(2);
+}
+const repeatIndex = process.argv.indexOf("--repeat");
+const repeat = repeatIndex === -1 ? 1 : Number(process.argv[repeatIndex + 1]);
+
+const projectId = process.env.FIREBASE_PROJECT_ID;
+const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
+const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n");
+initializeApp(
+  clientEmail && privateKey
+    ? { credential: cert({ projectId, clientEmail, privateKey }), projectId }
+    : { credential: applicationDefault(), projectId },
+);
+const db = getFirestore();
+
+const childIds = (data) => {
+  const clips = data?.document?.clips ?? data?.clips ?? [];
+  return clips
+    .filter((clip) => clip?.kind === "collection" && clip?.childTimelineId)
+    .map((clip) => clip.childTimelineId);
+};
+
+async function mapWithConcurrency(items, limit, fn) {
+  const out = new Array(items.length);
+  let cursor = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, async () => {
+      while (cursor < items.length) {
+        const index = cursor++;
+        out[index] = await fn(items[index]);
+      }
+    }),
+  );
+  return out;
+}
+
+/** The walk, parameterised by how one LEVEL is fetched. Everything else —
+ *  ordering, the seen set, how children are queued — is identical, so the only
+ *  difference between the two runs is the number of requests. */
+async function walk(readLevel) {
+  const seen = new Set([rootId]);
+  let documents = 0;
+  let missing = 0;
+  let requests = 0;
+  let frontier = [rootId];
+  let levels = 0;
+
+  while (frontier.length > 0) {
+    levels += 1;
+    const { snapshots, calls } = await readLevel(frontier);
+    requests += calls;
+    const next = [];
+    for (const snapshot of snapshots) {
+      if (!snapshot.exists) {
+        missing += 1;
+        continue;
+      }
+      documents += 1;
+      for (const childId of childIds(snapshot.data())) {
+        if (seen.has(childId)) continue;
+        seen.add(childId);
+        next.push(childId);
+      }
+    }
+    frontier = next;
+  }
+  return { documents, missing, requests, levels, read: documents + missing };
+}
+
+const perDocument = (ids) =>
+  mapWithConcurrency(ids, READ_CONCURRENCY, (id) => db.collection(COLLECTION).doc(id).get()).then(
+    (snapshots) => ({ snapshots, calls: ids.length }),
+  );
+
+const batched = async (ids) => {
+  const chunks = [];
+  for (let index = 0; index < ids.length; index += CHUNK) {
+    chunks.push(ids.slice(index, index + CHUNK));
+  }
+  const results = await Promise.all(
+    chunks.map((chunk) => db.getAll(...chunk.map((id) => db.collection(COLLECTION).doc(id)))),
+  );
+  return { snapshots: results.flat(), calls: chunks.length };
+};
+
+const time = async (label, readLevel) => {
+  const started = Date.now();
+  const result = await walk(readLevel);
+  const elapsed = Date.now() - started;
+  console.log(
+    `${label.padEnd(14)} ${String(elapsed).padStart(6)}ms  ` +
+      `${result.read} documents read (${result.documents} found, ${result.missing} missing)  ` +
+      `${result.requests} requests over ${result.levels} levels`,
+  );
+  return { elapsed, ...result };
+};
+
+for (let run = 1; run <= repeat; run += 1) {
+  if (repeat > 1) console.log(`--- run ${run} ---`);
+  // Per-document FIRST so it cannot benefit from anything the batched run warms.
+  const before = await time("per-document", perDocument);
+  const after = await time("batched", batched);
+  const sameReads = before.read === after.read;
+  console.log(
+    `${sameReads ? "SAME" : "DIFFERENT"} read count (${before.read} vs ${after.read}); ` +
+      `${before.requests} requests -> ${after.requests}; ` +
+      `${(before.elapsed / after.elapsed).toFixed(1)}x faster`,
+  );
+  if (!sameReads) process.exitCode = 1;
+}


### PR DESCRIPTION
The closure walk read a document at a time — `mapWithConcurrency` over `doc(id).get()`, twelve in flight — so walking a 143-document project meant **148 round trips**. Firestore takes a batched read, which turns each BFS level into a single request: **148 → 9** on that project. Nine is now the floor, because that graph is nine levels deep — depth-bound rather than breadth-bound.

### Measured, warm, against the live project

`scripts/measure-closure-batched-vs-per-document-reads.mjs` is committed here so the claim can be rechecked rather than believed. It walks the same root both ways, back to back, per-document first so nothing warms in the batch's favour:

```
per-document     2225ms  148 documents read (143 found, 5 missing)  148 requests over 9 levels
batched          1447ms  148 documents read (143 found, 5 missing)    9 requests over 9 levels
SAME read count (148 vs 148); 148 requests -> 9; 1.5x faster
```

**The bill does not move.** Firestore charges per document returned, so both walks read exactly 148 documents and cost exactly 148 reads. The script asserts that equality and exits non-zero if it ever stops holding — a change in the *read* count would mean the walk changed shape, not that it got faster.

### Two things had to survive intact

- **The shared reader's dedupe.** `batch-get` serves several roots through one `createTimelineEntryReader` precisely so a document in two closures is read once (#437). The batch therefore goes *through* that map rather than around it: ids already in flight are awaited, only the rest are fetched, and results are recorded so a later single read joins the batch instead of issuing its own `get()`. The existing *"reads each underlying document ONCE, however many closures contain it"* test passes unchanged — that is the regression proof.
- **Per-snapshot ownership.** Checked per document inside the batch, never once per request: one readable document must not carry the rest past the ownership boundary.

### Denied resolves to null here

Unlike the single-document read, which throws. Its callers map that throw to a 404; *this* one's caller is the closure walk, which already wrapped every child read in `.catch(() => null)` — an unreadable subtree is a dangling branch, not a failed page. Returning null keeps that behaviour without one foreign document failing an entire level.

Chunked at 200: one `getAll` is one request and a level can be most of a 500-document closure. The chunks go out together, so the bound is on request size, not on parallelism.

The fakes in two test files learned `getAll`, counting one read per document in the batch exactly as `doc().get()` did — which is what kept the read-count assertions meaningful across the change.

Closes #448