### PR TITLE
Handle the promise registerTool returns

### DIFF
--- a/apps/timeline-gstudio001/lib/webmcp/webmcp-adapter.test.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/webmcp-adapter.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { registerWebMcpTools } from "./webmcp-adapter";
+import type { ToolDef } from "./types";
+
+/**
+ * What the adapter does with the promise `registerTool` returns.
+ *
+ * That promise was discarded, which is the entire bug this suite exists for.
+ * Chrome settles a registration asynchronously and REJECTS it with the signal's
+ * reason when the signal aborts first — so tearing the registration down before
+ * it settles produced an unhandled rejection PER TOOL. Measured in Chrome 151:
+ * six tools registered and the controller aborted in the same tick gave six
+ * `AbortError: signal is aborted without reason`; aborting one turn of the
+ * event loop later gave none.
+ *
+ * It surfaced on the `controller.abort()` line, which is misleading and worth
+ * knowing: the rejection reason is the DOMException that `abort()` CREATES, and
+ * a DOMException's stack points at where it was created rather than where it
+ * was thrown.
+ */
+
+const tool = (name: string): ToolDef => ({
+  name,
+  description: `${name} tool`,
+  inputSchema: { type: "object", properties: {} },
+  execute: async () => ({ content: [] }),
+});
+
+/** The reason `AbortController.abort()` produces with no argument — the exact
+ *  object Chrome rejects a torn-down registration with. */
+const abortReason = () => new DOMException("signal is aborted without reason", "AbortError");
+
+function installModelContext(
+  registerTool: (tool: unknown, options?: { signal?: AbortSignal }) => Promise<void> | void,
+) {
+  const navigatorStub = { modelContext: { registerTool } };
+  vi.stubGlobal("navigator", navigatorStub);
+  return navigatorStub;
+}
+
+/** Rejections nothing awaited, which is what the browser reports. Node fires
+ *  `unhandledRejection` only after the microtask queue drains, so the assertion
+ *  has to wait for a macrotask — an immediate check passes vacuously. */
+function watchUnhandledRejections() {
+  const seen: unknown[] = [];
+  const onUnhandled = (reason: unknown) => seen.push(reason);
+  process.on("unhandledRejection", onUnhandled);
+  return {
+    seen,
+    settle: async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      process.off("unhandledRejection", onUnhandled);
+      return seen;
+    },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("registerWebMcpTools", () => {
+  it("absorbs the rejection a torn-down registration produces, per tool", async () => {
+    // Exactly Chrome's behaviour: the registration settles later, and rejects
+    // with the signal's reason if the signal went first.
+    installModelContext((_tool, options) =>
+      new Promise<void>((resolve, reject) => {
+        options?.signal?.addEventListener("abort", () => reject(abortReason()));
+        setTimeout(resolve, 50);
+      }),
+    );
+    const watcher = watchUnhandledRejections();
+
+    const unregister = registerWebMcpTools([tool("a"), tool("b"), tool("c")]);
+    // In the SAME TICK, which is the case that produced one rejection per tool.
+    unregister();
+
+    expect(await watcher.settle()).toEqual([]);
+  });
+
+  it("reports a registration that failed for any other reason", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // `Duplicate tool name` is one Chrome actually returns. Swallowing it would
+    // leave an agent tool silently absent, which is the hardest kind of missing
+    // thing to notice.
+    installModelContext(() => Promise.reject(new Error("Duplicate tool name")));
+    const watcher = watchUnhandledRejections();
+
+    registerWebMcpTools([tool("clashing")]);
+
+    expect(await watcher.settle()).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(
+      '[webmcp] "clashing" failed to register',
+      expect.objectContaining({ message: "Duplicate tool name" }),
+    );
+  });
+
+  it("still works when registerTool returns nothing", async () => {
+    // The API is experimental; a build that returns void must not become a
+    // TypeError inside the adapter's own error handling.
+    const registered: unknown[] = [];
+    installModelContext((registration) => {
+      registered.push(registration);
+    });
+    const watcher = watchUnhandledRejections();
+
+    const unregister = registerWebMcpTools([tool("a"), tool("b")]);
+    unregister();
+
+    expect(registered).toHaveLength(2);
+    expect(await watcher.settle()).toEqual([]);
+  });
+
+  it("is a no-op without a provider, so callers can register unconditionally", () => {
+    vi.stubGlobal("navigator", {});
+    expect(() => registerWebMcpTools([tool("a")])()).not.toThrow();
+  });
+});

--- a/apps/timeline-gstudio001/lib/webmcp/webmcp-adapter.ts
+++ b/apps/timeline-gstudio001/lib/webmcp/webmcp-adapter.ts
@@ -14,7 +14,23 @@ type WebMcpToolRegistration = Readonly<{
 }>;
 
 type ModelContext = Readonly<{
-  registerTool: (tool: WebMcpToolRegistration, options?: { signal?: AbortSignal }) => void;
+  /**
+   * RETURNS A PROMISE, which is the whole reason this file has a catch in it.
+   *
+   * It was declared `void` here, so the return was discarded — and Chrome
+   * settles the registration asynchronously and REJECTS it with the signal's
+   * reason if the signal aborts first. Measured in Chrome 151: six tools
+   * registered and the controller aborted in the same tick produced six
+   * unhandled rejections, one per tool. Aborting a turn of the event loop later
+   * produced none.
+   *
+   * `void` is kept in the union because the shape is experimental and a build
+   * that returns nothing must not become a TypeError here.
+   */
+  registerTool: (
+    tool: WebMcpToolRegistration,
+    options?: { signal?: AbortSignal },
+  ) => Promise<void> | void;
 }>;
 
 declare global {
@@ -36,7 +52,7 @@ export function registerWebMcpTools(tools: readonly ToolDef[]): () => void {
 
   const controller = new AbortController();
   for (const tool of tools) {
-    modelContext.registerTool(
+    const registered = modelContext.registerTool(
       {
         name: tool.name,
         description: tool.description,
@@ -46,6 +62,22 @@ export function registerWebMcpTools(tools: readonly ToolDef[]): () => void {
       },
       { signal: controller.signal },
     );
+
+    // AN ABORT IS THE ORDINARY ENDING, not a failure. A registration torn down
+    // before it settles rejects with the signal's reason, and the reason is a
+    // DOMException created by `controller.abort()` below — which is why the
+    // report for this landed on the abort line rather than on anything to do
+    // with tools. Unhandled, it reaches the dev overlay as
+    // `AbortError: signal is aborted without reason`.
+    //
+    // ANYTHING ELSE IS REAL and says so. A registration can fail for reasons
+    // worth knowing about — `Duplicate tool name` is one Chrome actually
+    // returns — and the symptom otherwise is an agent tool that is silently
+    // absent, which is the hardest kind of missing thing to notice.
+    void Promise.resolve(registered).catch((error: unknown) => {
+      if (error instanceof DOMException && error.name === "AbortError") return;
+      console.warn(`[webmcp] "${tool.name}" failed to register`, error);
+    });
   }
   return () => controller.abort();
 }


### PR DESCRIPTION
Reported from the live site:

```
Runtime AbortError: signal is aborted without reason
  at lib/webmcp/webmcp-adapter.ts:50:27   ← controller.abort()
```

**The abort is not the fault, and the line number is a red herring.** Chrome settles `registerTool` *asynchronously* and rejects it with the signal's reason if the signal aborts first — and that reason is the DOMException `abort()` creates. A DOMException's stack points at where it was **created**, not where it was thrown, so every report of this lands on the abort line, in a file that has nothing else to do with it.

We declared `registerTool` as returning `void` and discarded the result, so nothing ever handled that rejection.

## Measured in Chrome 151, against the real API

Not reasoned from the spec — run in the browser that reported it:

| what happened | unhandled rejections |
|---|---|
| signal already aborted before `registerTool` | 1 |
| abort in the **same tick** as the registrations | **6 — one per tool** |
| abort a turn of the event loop later | 0 |

Six tools, six rejections — and six is what `McpToolsBridge` registers. Its effect re-runs on every `focusedId` change, so any teardown landing before the registrations settle produces one per tool. Attaching a catch absorbs it completely; verified in the same browser, the reason arrives at the handler and nothing reaches the page.

Also confirmed there, so the fix is aimed at the right thing: a bare `abort()` produces **no** error, correctly unregisters the tools, and aborting *mid tool-execution* is likewise clean. The only shape that leaks is the unsettled registration.

## What it does now

An abort is the ordinary ending, and is swallowed. **Anything else is reported** — `Duplicate tool name` is one Chrome actually returns, and the symptom of swallowing that would be an agent tool silently absent, which is the hardest kind of missing thing to notice.

## Tests

The adapter had none. It has four, modelling Chrome's timing exactly, and the two that matter were run against a discarded promise first:

```
× absorbs the rejection a torn-down registration produces, per tool
× reports a registration that failed for any other reason
Tests  2 failed | 2 passed (4)
```

The `void` case stays in the return-type union because the API is experimental and a build that returns nothing must not become a TypeError inside the error handling itself.