### PR TITLE
Make the closure guard structural instead of positional

### DIFF
--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
@@ -1017,4 +1017,91 @@ describe("graph-documents-gateway", () => {
     await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
     expect(gateway.lastError()).toBeNull();
   });
+
+  describe("ensureClosure", () => {
+    /** A collection clip, which is what makes one document part of another's
+     *  closure. The `clip()` helper above builds media clips. */
+    const child = (id: string, childTimelineId: string): TimelineClip => {
+      // BUILT, not spread from `clip()`: a collection clip is a different
+      // member of the union, and a media clip with its `kind` overwritten
+      // carries `src`/`sourceDuration` that `CollectionTimelineClip` refuses.
+      const { id: _id, kind: _kind, ...common } = clip(id);
+      return {
+        ...common,
+        id,
+        kind: "collection",
+        title: `Collection ${id}`,
+        childTimelineId,
+        itemCount: 1,
+      };
+    };
+
+    it("does not walk a closure the session already holds, fresh", async () => {
+      const calls = installFetch(() => jsonResponse({}));
+      const gateway = createGraphDocumentsGateway();
+      gateway.bindUser("user-a");
+      // Exactly what a server-primed boot arrives with: every document under
+      // the root, installed through the prime path.
+      gateway.prime(doc("root", [child("c1", "kid")]), 1, "user-a");
+      gateway.prime(doc("kid", [clip("k1")]), 1, "user-a");
+
+      await gateway.ensureClosure("root");
+
+      // THE WHOLE POINT: no request at all. Asking again walked all 151
+      // documents a second time — 465 reads against the 237 it was meant to
+      // beat (#437).
+      expect(calls).toEqual([]);
+    });
+
+    it("walks it anyway once the cache is marked stale, because stale is why refresh exists", async () => {
+      const calls = installFetch(() => jsonResponse({ results: [], missing: [] }));
+      const gateway = createGraphDocumentsGateway();
+      gateway.bindUser("user-a");
+      gateway.prime(doc("root", [child("c1", "kid")]), 1, "user-a");
+      gateway.prime(doc("kid", [clip("k1")]), 1, "user-a");
+
+      // The legacy boot's first act. It exists to stop an edit made in another
+      // view or another tab being overwritten by a write built from stale
+      // content — so skipping the fetch on PRESENCE alone would trade a
+      // data-loss bug for a saved request.
+      gateway.refresh();
+      await gateway.ensureClosure("root");
+
+      expect(calls.map((call) => `${call.method} ${call.id}`)).toEqual(["POST closure"]);
+    });
+
+    it("walks it when any document under the root is missing from the cache", async () => {
+      const calls = installFetch(() => jsonResponse({ results: [], missing: [] }));
+      const gateway = createGraphDocumentsGateway();
+      gateway.bindUser("user-a");
+      // The root points at a child this session has never loaded — a partial
+      // prime, which is the ordinary state after a focus-path boot that ships
+      // one eager level rather than the whole tree.
+      gateway.prime(doc("root", [child("c1", "kid")]), 1, "user-a");
+
+      await gateway.ensureClosure("root");
+
+      expect(calls.map((call) => `${call.method} ${call.id}`)).toEqual(["POST closure"]);
+    });
+
+    it("treats a dangling reference as resolved, so it does not refetch forever", async () => {
+      const gone = installFetch(() =>
+        jsonResponse({ results: [], missing: ["ghost"] }),
+      );
+      const gateway = createGraphDocumentsGateway();
+      gateway.bindUser("user-a");
+      gateway.prime(doc("root", [child("c1", "ghost")]), 1, "user-a");
+
+      // First walk learns that `ghost` does not exist...
+      await gateway.ensureClosure("root");
+      expect(gone.map((call) => `${call.method} ${call.id}`)).toEqual(["POST closure"]);
+
+      // ...and the second must not go looking again. A deleted document's id
+      // stays in its parent's clips, so without the missing list an
+      // unresolvable reference is indistinguishable from an unhydrated one and
+      // the closure never counts as complete.
+      await gateway.ensureClosure("root");
+      expect(gone.map((call) => `${call.method} ${call.id}`)).toEqual(["POST closure"]);
+    });
+  });
 });

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
@@ -667,7 +667,49 @@ export function createGraphDocumentsGateway(
     }
   };
 
+  /**
+   * Does the session already hold every document under `rootId`, all of it
+   * fresh?
+   *
+   * BOTH HALVES MATTER, and the second is the one with teeth. Holding the
+   * documents is not enough: `refresh()` marks the whole cache stale on the
+   * legacy boot precisely so they get refetched, because an edit made in
+   * another view or another tab between graph sessions would otherwise be
+   * overwritten by a full-document write built from stale content. Skipping the
+   * fetch on presence alone would delete that protection — which is a data-loss
+   * bug, not a slow path.
+   *
+   * A known-missing id resolves as an empty document, exactly as the server's
+   * walk does, so a dangling `childTimelineId` does not make the closure look
+   * permanently incomplete and refetch it forever.
+   */
+  const holdsFreshClosure = (rootId: string): boolean => {
+    const seen = new Set<string>();
+    const walk = (id: string): boolean => {
+      if (seen.has(id)) return true;
+      seen.add(id);
+      if (!documents[id]) return knownMissingIds.has(id);
+      if (staleIds.has(id)) return false;
+      for (const clip of documents[id].clips) {
+        if (clip.kind !== "collection" || !clip.childTimelineId) continue;
+        if (!walk(clip.childTimelineId)) return false;
+      }
+      return true;
+    };
+    return walk(rootId);
+  };
+
   const ensureClosure = async (rootId: string): Promise<void> => {
+    // NOTHING TO FETCH, so do not spend a walk finding that out.
+    //
+    // The server-primed boot arrives holding the whole closure already, and
+    // asking again walked all 151 documents a SECOND time — measured at 465
+    // reads against the 237 it was meant to beat (#437). The caller guards that
+    // case too, by not calling this on a primed boot; this is the same
+    // guarantee made STRUCTURAL rather than positional, so deleting the
+    // caller's flag costs a redundant call rather than a doubled bill (#451).
+    if (holdsFreshClosure(rootId)) return;
+
     const gen = generation;
     try {
       const response = await fetch("/api/timelines/closure", {


### PR DESCRIPTION
**Recovered from #452.** This commit was pushed to that branch after auto-merge had already been armed, so auto-merge merged the head as of when its checks passed and left this behind. It is unchanged from what was reviewed there, cherry-picked onto current main.

---

`ensureClosure` walked the closure unconditionally. Nothing stopped it walking one the session already held — except the CALLER remembering to skip it, via `if (!bootedFromServer)` in `graph-timeline-view`. That flag is what keeps a server-primed boot from walking all 151 documents a second time (**465 reads against the 237 it was meant to beat**, #437), and nothing tested it: delete it and the bill doubles silently, with no failing test and no error.

So the guarantee moves into the gateway, where it is structural. `ensureClosure` returns without a request when the session already holds every document under the root. The caller's flag stays and is now belt-and-braces — deleting it costs a redundant call rather than a doubled bill.

**Both halves of "already holds" matter, and the second has the teeth.** Presence is not enough: `refresh()` marks the whole cache stale on the legacy boot precisely so it gets refetched, because an edit made in another view or another tab between graph sessions would otherwise be overwritten by a full-document write built from stale content. A guard keyed on presence alone would trade a data-loss bug for a saved request — so a stale document fails the check and the walk happens.

A known-missing id resolves as an empty document, exactly as the server's walk does. Without that, one dangling `childTimelineId` makes the closure look permanently incomplete and every entry re-walks it forever — the id stays in its parent's clips after the document is gone, so an unresolvable reference is otherwise indistinguishable from an unhydrated one.

### Tests

`ensureClosure` had **none**. It has four, and the two asserting the SKIP were run against a disabled guard first:

```
× does not walk a closure the session already holds, fresh
× treats a dangling reference as resolved, so it does not refetch forever
Tests  2 failed | 33 passed (35)
```

The other two assert the walk still happens — stale cache, and a child never loaded — and pass either way, which is correct: they exist to stop the skip being widened, not to prove it.

This is **half of #451**. The `refresh()` call site is still positional: deleting the flag there marks primed documents stale, which sends this guard down the fetch path legitimately — same doubled walk, different route.