### PR TITLE
The selection checkbox only exists in select mode

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-card-badges.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-card-badges.tsx
@@ -160,46 +160,38 @@ export const CARD_CONTROL_INSET_RIGHT = "right-5";
  *  8px the controls sat tight under the card's edge once they grew to 28px. */
 export const CARD_CONTROL_INSET_TOP = "top-3";
 
-// Hover-reveal, per card kind. Whole literal class names: Tailwind's JIT scans
-// source text, so a computed `group-hover/${kind}` is a class that never gets
-// generated and the checkbox would silently never appear.
-//
-// `pointer-events-none` travels WITH the opacity and is not decoration: the
-// checkbox is a click target now, and an invisible one would be a trap. On
-// touch the `@media (hover: hover)` gate never opens, so without this a tap in
-// the card's bottom-right corner would toggle a selection through a control the
-// user cannot see. Hidden means unclickable, in the same rule, so the two can
-// never drift apart.
-export const SELECT_HOVER_REVEAL_MEDIA = [
-  "pointer-events-none opacity-0 motion-safe:transition-opacity motion-safe:duration-150",
-  "[@media(hover:hover)]:group-hover/media-item:pointer-events-auto",
-  "[@media(hover:hover)]:group-hover/media-item:opacity-100",
-].join(" ");
-
-/** The same, for a COLLECTION card's group. */
-export const SELECT_HOVER_REVEAL_COLLECTION = [
-  "pointer-events-none opacity-0 motion-safe:transition-opacity motion-safe:duration-150",
-  "[@media(hover:hover)]:group-hover/collection-item:pointer-events-auto",
-  "[@media(hover:hover)]:group-hover/collection-item:opacity-100",
-].join(" ");
+// The hover-reveal class pairs lived here, one per card kind, and are gone with
+// the hover checkbox they revealed. They carried a rule worth remembering if
+// anything is ever revealed on hover again: `pointer-events-none` has to travel
+// WITH the opacity, because an invisible click target is a trap — on touch the
+// `@media (hover: hover)` gate never opens, so a tap in the card's bottom-right
+// corner would otherwise toggle a selection through a control nobody can see.
 
 /**
- * The selection checkbox, bottom-right, while select mode is armed.
+ * The selection checkbox, bottom-right. ONLY IN SELECT MODE.
+ *
+ * It used to appear on HOVER outside the mode as well, and clicking it both
+ * toggled and ARMED the mode — which made it the only pointer route to picking
+ * a collection, since the rest of that card drills in.
+ *
+ * REMOVED BECAUSE THIS IS A DRAGGING BOARD. The ordinary way to work here is
+ * grabbing and moving things, so the cursor is over cards constantly and not
+ * because anyone is choosing them — and a checkbox that materialises under it
+ * on every card you pass is noise during the gesture the board is actually for.
+ *
+ * It also had less to offer than it looked: most of what select mode does is
+ * already covered by drag and drop. The mode earns its place on the edge cases —
+ * acting on several things at once — and those are worth an explicit step.
+ *
+ * So the route is not lost, only staged: press Select, then click. That is one
+ * more step to select a collection, and it is the accepted trade, not an
+ * oversight.
  *
  * DECORATIVE as far as the a11y tree is concerned, and that is forced, not a
  * shortcut. This renders inside NodeCard's real `<button>`, and a button may
  * not contain interactive content: browsers auto-close the outer one at the
  * first nested button, which ejects the rest of the card out of its own box.
- *
- * Nothing is lost in select mode, because the whole card is already the toggle
- * there. OUTSIDE the mode it appears on HOVER, and CLICKING IT TOGGLES *and
- * ARMS the mode*. That matters most on a collection: the rest of that card
- * drills in, so this circle is the only pointer route to picking one at all.
- *
- * DESKTOP ONLY, via `@media (hover: hover)`. A touch device has no hover state
- * to reveal it with, and without the query a tap would leave the checkbox
- * stuck on the last-tapped card — the sticky-hover bug — where it would read as
- * a selection that is not there.
+ * Nothing is lost by it, because in select mode the whole card is the toggle.
  *
  * Two details worth keeping if this is ever restyled. The check is ALWAYS
  * rendered and only its opacity changes, so the circle never resizes as it
@@ -211,24 +203,28 @@ export function SelectionIndicator({
   id,
   selected,
   armed,
-  revealOnHover,
 }: Readonly<{
   selected: boolean;
-  /** Select mode is on, so the checkbox is permanent rather than hover-only. */
+  /** Select mode is on. The checkbox does not exist otherwise. */
   armed: boolean;
-  /** Literal hover-reveal classes for THIS card kind's group. */
-  revealOnHover: string;
   /** The card this toggles. */
   id: NodeId;
 }>) {
   const store = useCollectionsStore();
+  // Not rendered at all rather than hidden. A hover-revealed checkbox was also
+  // a click target that could be hit before it was visible; absent, it cannot
+  // be. It also drops the `@media (hover: hover)` guard the reveal needed, and
+  // with it the sticky-hover bug that left one stuck on the last-tapped card.
+  if (!armed) return null;
   return (
     <span
       aria-hidden="true"
       data-selection-indicator={selected ? "on" : "off"}
       // Distinguishes "permanently shown because the mode is armed" from
       // "revealed by the pointer", which a geometry-only assertion cannot see.
-      data-selection-indicator-reveal={armed ? "armed" : "hover"}
+      // Kept, and now constant: the tests read it, and "armed" is the only
+      // state this element can be in.
+      data-selection-indicator-reveal="armed"
       // A SPAN with its own click, not a <button>. This renders inside the
       // card's selection surface, which IS a button, and nesting interactive
       // semantics is invalid HTML — the composed-card tests pin that. The
@@ -245,26 +241,14 @@ export function SelectionIndicator({
       onClick={(event) => {
         event.stopPropagation();
         store.toggleSelected(id);
-        // PICKING IS ENTERING THE MODE. The header row is driven by
-        // `multiSelectMode` alone (see GraphBoard's `selectModeRow`), so
-        // toggling the selection without arming left the checkbox filling in
-        // while the breadcrumb trail sat there unchanged — a selection with no
-        // way to act on it and no visible way out. Since a plain click OPENS
-        // and never selects, this checkbox IS the pointer gesture that means
-        // "I am selecting now", and that is the same statement the Select
-        // button makes.
-        //
-        // Only on the way IN. Un-checking the last item leaves the mode armed
-        // at "0 selected · Done", which is exactly where pressing Select and
-        // picking nothing lands you — whereas disarming on empty would yank
-        // the row away mid-correction, the moment a mis-pick is undone.
-        if (!selected) store.setMultiSelectMode(true);
+        // NO `setMultiSelectMode(true)` any more. It used to arm the mode here,
+        // because this was reachable outside it; now it only exists once the
+        // mode is on, so arming would be a no-op restating the obvious.
       }}
       className={[
         "absolute right-2 bottom-2 z-20 grid size-[26px] cursor-pointer place-items-center",
         "rounded-full border-2 backdrop-blur-sm motion-safe:transition-colors",
         selected ? "border-blue-500 bg-blue-500" : "border-white/90 bg-black/35",
-        armed ? "" : revealOnHover,
       ].join(" ")}
     >
       <Check

--- a/apps/timeline-gstudio001/components/graph-view/graph-clip-card.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-clip-card.tsx
@@ -23,7 +23,6 @@ import {
   LaneChip,
   LiveDurationPill,
   ProvenanceLabel,
-  SELECT_HOVER_REVEAL_MEDIA,
   SelectionIndicator,
 } from "./graph-card-badges";
 import {
@@ -259,7 +258,6 @@ export const GraphClipContent = memo(function GraphClipContent({
           id={id}
           selected={selected}
           armed={selectMode}
-          revealOnHover={SELECT_HOVER_REVEAL_MEDIA}
         />
       </span>
       {/* Kind tag (R6 #7): a WORD, bottom-left. The glyph version (a 4px film

--- a/apps/timeline-gstudio001/components/graph-view/graph-collection-card.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-collection-card.tsx
@@ -28,7 +28,6 @@ import {
 import {
   DisabledChip,
   LaneChip,
-  SELECT_HOVER_REVEAL_COLLECTION,
   SelectionIndicator,
 } from "./graph-card-badges";
 import {
@@ -185,7 +184,6 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
             id={id}
             selected={selected}
             armed={selectMode}
-            revealOnHover={SELECT_HOVER_REVEAL_COLLECTION}
           />
           {/* THE COLLECTION MARK, dead centre over the frames.
               A collection's frames are its children's pictures, so at a glance

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -1144,7 +1144,11 @@ export const AnchorControlAndCountBadge: Story = {
  *  GraphCollectionItemParts rather than GraphClipContent, so they need their
  *  own cover — a media-only implementation would leave tagged collections
  *  showing nothing at all. */
-function renderWithTags(tags: string[], surface: "grid" | "strip" = "strip") {
+function renderWithTags(
+  tags: string[],
+  surface: "grid" | "strip" = "strip",
+  selectMode = false,
+) {
   const detail: ClipDetail = {
     alt: "A timeline",
     aspect: 16 / 9,
@@ -1155,8 +1159,15 @@ function renderWithTags(tags: string[], surface: "grid" | "strip" = "strip") {
   };
   const store = createGraphDetailsStore({ [COLLECTION_ID]: detail });
   const decorator: Decorator = (Story) => (
-    <DndCollections initialGraph={providerGraph}>
+    // `keepMultiSelectModeWhenEmpty` is REQUIRED for a select-mode story, not
+    // decoration: without it the store disarms the mode the moment the
+    // selection is empty, so arming it with nothing selected turns straight
+    // back off and the checkbox never appears. The media decorator has carried
+    // this from the start; this one did not need it until a story armed the
+    // mode here.
+    <DndCollections initialGraph={providerGraph} keepMultiSelectModeWhenEmpty>
       <GraphDetailsProvider store={store}>
+        {selectMode ? <ArmSelectMode /> : null}
         {/* The grid marker is what the card matches on, so a "grid" story sets
             it here exactly as VirtualGrid does — and gets the taller box a
             grid cell actually has, since the caption needs somewhere to go. */}
@@ -1723,32 +1734,41 @@ export const SelectModeShowsACheckbox: Story = {
 };
 
 /**
- * Idle, the checkbox is RENDERED but invisible, waiting on hover.
+ * Outside select mode there is NO checkbox — not a transparent one, none.
  *
- * The change from "absent" to "transparent" is the whole mechanism: hover is
- * owned by CSS so that no pointer state has to reach React, where a hover that
- * re-rendered every card would land on the drag/INP hot path. So the old
- * `toBeNull` is the wrong assertion now and would pass for the wrong reason if
- * the reveal ever broke — opacity is what to measure.
+ * It used to be rendered and revealed by CSS `:hover`, which made this story
+ * an opacity measurement. The element is gone now, so the assertion is back to
+ * presence — and presence is the stronger property: a transparent control is
+ * still a click target, which is why the old code had to keep
+ * `pointer-events-none` welded to the opacity in one rule.
  *
- * THE REVEAL ITSELF IS NOT TESTABLE HERE, and the first version of this story
- * pretended otherwise. `userEvent.hover` dispatches synthetic pointer events;
- * CSS `:hover` is a browser state driven by real pointer position, and no
- * synthetic event sets it. The story sat at opacity 0 and failed, which was the
- * test being wrong rather than the CSS. Real-mouse hover lives in the e2e suite
- * ("the select checkbox appears on hover…"), which is the layer this repo keeps
- * for trusted input.
+ * Why it went: this is a dragging board, the cursor is over cards constantly
+ * because things are being moved rather than chosen, and a checkbox appearing
+ * under it every time was noise during the gesture the board is for.
  */
-export const CheckboxWaitsForHoverOutsideSelectMode: Story = {
+export const NoCheckboxOutsideSelectMode: Story = {
   args: mediaArgs,
   decorators: [renderMediaCard({ surface: "grid" })],
   play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelector("[data-selection-indicator]")).toBeNull();
+  },
+};
+
+/**
+ * And in select mode it is there, opaque, with no pointer anywhere near it.
+ *
+ * The pair is the point: absence alone would pass just as well if the checkbox
+ * were broken in BOTH states, which is exactly the failure a one-sided test
+ * cannot see.
+ */
+export const CheckboxAppearsInSelectMode: Story = {
+  args: mediaArgs,
+  decorators: [renderMediaCard({ surface: "grid", selectMode: true })],
+  play: async ({ canvasElement }) => {
     const indicator = canvasElement.querySelector<HTMLElement>("[data-selection-indicator]");
     await expect(indicator).not.toBeNull();
-    await expect(indicator!.dataset.selectionIndicatorReveal).toBe("hover");
-    await expect(getComputedStyle(indicator!).opacity).toBe("0");
-    // Transparent, NOT display:none — it has to keep its box, or the reveal
-    // would relayout the card under the pointer.
+    await expect(indicator!.dataset.selectionIndicatorReveal).toBe("armed");
+    await expect(getComputedStyle(indicator!).opacity).toBe("1");
     await expect(indicator!.getBoundingClientRect().width).toBeGreaterThan(0);
   },
 };
@@ -1894,26 +1914,41 @@ export const CollectionSelectModeCheckboxClearsTheMetadata: Story = {
 };
 
 /**
- * The collection card's checkbox waits on hover too.
+ * The collection card, both ways — and it is the kind that pays for this.
  *
- * Its own story rather than a second case in the media one, because the two
- * card kinds carry DIFFERENT literal class strings
- * (`group-hover/collection-item` vs `group-hover/media-item`). Tailwind's JIT
- * scans source text, so a wrong or interpolated group name produces a class
- * that is never generated and a checkbox that silently never appears — and the
- * media story would still be green. Two kinds, two literals, two covers.
+ * A plain click on a collection DRILLS IN, so the checkbox was the only thing
+ * on the card saying it could be picked at all. Removing it outside select mode
+ * means there is no pointer route to selecting a collection until the mode is
+ * on. That is the accepted trade, and this pair is where it is visible.
  *
- * Collections are the kind that needs it most: a plain click drills IN, so this
- * circle is the only thing on the card that says it can be picked at all.
+ * Its own story rather than a case in the media one, because the two card kinds
+ * are rendered by DIFFERENT components — collections through the composed
+ * CollectionItem shell, media through NodeCard — so nothing structural forces
+ * them to agree, and they have diverged before.
  */
-export const CollectionCheckboxWaitsForHover: Story = {
+export const CollectionHasNoCheckboxOutsideSelectMode: Story = {
   args: baseArgs,
   decorators: [renderWithTags([], "grid")],
   play: async ({ canvasElement }) => {
-    const indicator = canvasElement.querySelector<HTMLElement>("[data-selection-indicator]");
-    await expect(indicator).not.toBeNull();
-    await expect(indicator!.dataset.selectionIndicatorReveal).toBe("hover");
-    await expect(getComputedStyle(indicator!).opacity).toBe("0");
-    await expect(indicator!.getBoundingClientRect().width).toBeGreaterThan(0);
+    await expect(canvasElement.querySelector("[data-selection-indicator]")).toBeNull();
+  },
+};
+
+export const CollectionCheckboxAppearsInSelectMode: Story = {
+  args: baseArgs,
+  decorators: [renderWithTags([], "grid", true)],
+  play: async ({ canvasElement }) => {
+    // Armed by an effect, so the first committed frame legitimately has no
+    // checkbox — `waitFor` covers that, and covers nothing else. It is NOT what
+    // made this story pass: it failed for a full second against a decorator
+    // missing `keepMultiSelectModeWhenEmpty`, which is the actual reason and is
+    // recorded there.
+    const indicator = await waitFor(() => {
+      const found = canvasElement.querySelector<HTMLElement>("[data-selection-indicator]");
+      if (!found) throw new Error("no selection indicator yet");
+      return found;
+    });
+    await expect(indicator.dataset.selectionIndicatorReveal).toBe("armed");
+    await expect(getComputedStyle(indicator).opacity).toBe("1");
   },
 };

--- a/apps/timeline-gstudio001/next-env.d.ts
+++ b/apps/timeline-gstudio001/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next-turbo-probe/dev/types/routes.d.ts";
-import "./.next-turbo-probe/dev/types/root-params.d.ts";
+import "./.next-dev/dev/types/routes.d.ts";
+import "./.next-dev/dev/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -7773,143 +7773,91 @@ test.describe("graph view E2E", () => {
     );
   });
 
+  test("NO checkbox outside select mode — not hidden, not on hover, absent", async ({
+    page,
+  }) => {
+    // THE WHOLE CHANGE, in one assertion. The checkbox used to be rendered on
+    // every card and revealed by CSS `:hover`, and clicking it armed the mode.
+    // It is gone outside the mode: this is a DRAGGING board, the cursor is over
+    // cards constantly because things are being grabbed and moved rather than
+    // chosen, and a control that materialised under it every time was noise
+    // during the gesture the board is actually for.
+    //
+    // ABSENT rather than transparent, which is the stronger property and the
+    // one worth pinning: a hidden click target is a trap, and three tests used
+    // to exist to prove the opacity and the pointer-events could never drift
+    // apart. Nothing to drift now.
+    await installGraphApi(page);
+    await openGraph(page);
+    const surface = strip(page, PROJECT_ID);
+    const card = surface.locator('[data-node-id="alpha"]');
+
+    await expect(card.locator("[data-selection-indicator]")).toHaveCount(0);
+
+    // A REAL hover, which is the only thing that could have revealed it — CSS
+    // `:hover` is browser state driven by pointer position, so no synthetic
+    // event can stand in for this and no story can cover it.
+    await card.hover();
+    await expect(card.locator("[data-selection-indicator]")).toHaveCount(0);
+    // Still nothing after the pointer has settled, so this is not a race with
+    // a transition that simply had not started.
+    await page.waitForTimeout(300);
+    await expect(card.locator("[data-selection-indicator]")).toHaveCount(0);
+
+    // And the card still does what a card does under an un-checkboxed cursor.
+    await card.click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+  });
+
+  test("select mode shows it on EVERY card, picked or not", async ({ page }) => {
+    // The mode needs every card to show its state at once — unpicked ones
+    // included — which is exactly what a hover reveal could never do for more
+    // than one card at a time, and why the mode pins them all on.
+    await installGraphApi(page);
+    await openGraph(page);
+    const surface = strip(page, PROJECT_ID);
+
+    await page.locator("[data-select-mode-toggle]").click();
+    const boxes = surface.locator("[data-selection-indicator]");
+    await expect.poll(() => boxes.count()).toBeGreaterThan(1);
+    // Pointer nowhere near any of them.
+    await page.mouse.move(0, 0);
+    await expect(boxes.first()).toBeVisible();
+    await expect(boxes.first()).toHaveAttribute("data-selection-indicator-reveal", "armed");
+    await expect
+      .poll(() => boxes.first().evaluate((el) => getComputedStyle(el).opacity))
+      .toBe("1");
+
+    // Leaving the mode takes them all away again.
+    await page.locator("[data-select-mode-toggle]").click();
+    await expect(surface.locator("[data-selection-indicator]")).toHaveCount(0);
+  });
+
   test("clicking the checkbox toggles — on a collection, where the rest of the card drills", async ({
     page,
   }) => {
     // THE COLLECTION CASE IS THE POINT. A plain click on a collection card
-    // drills in, so before this the only pointer route to picking one was to
-    // enter select mode first. The checkbox is that route, and it has to work
-    // WITHOUT navigating — a toggle that also drilled would be useless.
+    // drills into it, so inside select mode the checkbox is what says "pick
+    // this one" instead. Outside the mode there is no pointer route to
+    // selecting a collection at all any more — that is the accepted trade for
+    // losing the hover checkbox, and this test is where it is visible.
     await installGraphApi(page);
     await openGraph(page);
     const surface = strip(page, PROJECT_ID);
     const collection = surface.locator(`[data-node-id="${CHILD_ID}"]`);
+
+    await page.locator("[data-select-mode-toggle]").click();
     const checkbox = collection.locator("[data-selection-indicator]");
+    await expect(checkbox).toBeVisible();
 
-    // Hover to reveal it, then click IT rather than the card.
-    await collection.hover();
-    await expect.poll(() => checkbox.evaluate((e) => getComputedStyle(e).opacity)).toBe("1");
     await checkbox.click();
-
-    // Selected, and still on the project — the drill-in did not fire underneath.
     await expect(collection).toHaveAttribute("data-selected", "true");
-    await expect(page).toHaveURL(new RegExp(`${GRAPH_URL}(\\?.*)?$`));
-    await expect(strip(page, PROJECT_ID)).toHaveCount(1);
+    // It selected rather than drilling: the breadcrumb has not moved.
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+    await expect(surface).toBeVisible();
 
-    // And it TOGGLES: a second click takes it back off, still without drilling.
     await checkbox.click();
     await expect(collection).not.toHaveAttribute("data-selected", "true");
-    await expect(page).toHaveURL(new RegExp(`${GRAPH_URL}(\\?.*)?$`));
-
-    // The media card's checkbox toggles the same way — one grammar, both kinds.
-    const alpha = surface.locator('[data-node-id="alpha"]');
-    await alpha.hover();
-    await alpha.locator("[data-selection-indicator]").click();
-    await expect(alpha).toHaveAttribute("data-selected", "true");
-  });
-
-  test("the checkbox ARMS the mode — the header swaps its breadcrumbs for the select row", async ({
-    page,
-  }) => {
-    // THE HEADER IS THE BUG. The checkbox filled in, but the row above it is
-    // driven by `multiSelectMode` alone (GraphBoard's `selectModeRow`), and
-    // toggling a selection never armed that — so a picked card got no count, no
-    // verbs and no Done, while the breadcrumb trail sat there as if nothing had
-    // happened. Pressing Select produced the right row; the checkbox did not.
-    await installGraphApi(page);
-    await openGraph(page);
-    const surface = strip(page, PROJECT_ID);
-    const card = surface.locator('[data-node-id="alpha"]');
-    const header = page.locator("[data-graph-board-header]");
-    const checkbox = card.locator("[data-selection-indicator]");
-
-    // The premise: browsing, with the trail showing.
-    await expect(header).toHaveAttribute("data-header-mode", "browse");
-
-    await card.hover();
-    await checkbox.click();
-
-    await expect(card).toHaveAttribute("data-selected", "true");
-    await expect(header).toHaveAttribute("data-header-mode", "select");
-    await expect(page.locator("[data-select-mode-count]")).toHaveText("1 selected");
-
-    // Un-checking the last card does NOT throw you back out. It holds at
-    // "0 selected", which is where pressing Select and picking nothing lands
-    // too — disarming here would yank the row away at the exact moment someone
-    // is correcting a mis-pick, and Done is the deliberate way out.
-    await checkbox.click();
-    await expect(card).not.toHaveAttribute("data-selected", "true");
-    await expect(header).toHaveAttribute("data-header-mode", "select");
-    await expect(page.locator("[data-select-mode-count]")).toHaveText("0 selected");
-  });
-
-  test("a hidden checkbox is not a click trap", async ({ page }) => {
-    // The checkbox is a click target now, and it is revealed by opacity rather
-    // than by mounting — so `pointer-events` has to travel with the opacity or
-    // there is an invisible toggle sitting in every card's corner. Worst on
-    // touch, where the hover gate never opens at all and the control would be
-    // permanently invisible AND permanently clickable.
-    await installGraphApi(page);
-    await openGraph(page);
-    const alpha = strip(page, PROJECT_ID).locator('[data-node-id="alpha"]');
-    const checkbox = alpha.locator("[data-selection-indicator]");
-
-    await page.mouse.move(0, 0);
-    await expect
-      .poll(() => checkbox.evaluate((e) => getComputedStyle(e).pointerEvents))
-      .toBe("none");
-    await expect.poll(() => checkbox.evaluate((e) => getComputedStyle(e).opacity)).toBe("0");
-  });
-
-  test("the select checkbox is revealed by a real hover, and pinned on by select mode", async ({
-    page,
-  }) => {
-    // E2E RATHER THAN A STORY, and not by preference. The reveal is CSS
-    // `:hover`, which is browser state driven by real pointer position — no
-    // synthetic event sets it, so a story using `userEvent.hover` measures
-    // opacity 0 forever and fails for a reason that has nothing to do with the
-    // component. Trusted mouse input is this suite's job.
-    //
-    // It is also the only check that the Tailwind class is REAL. The reveal is
-    // a literal `[@media(hover:hover)]:group-hover/media-item:opacity-100`;
-    // Tailwind's JIT scans source text, so a mistyped or interpolated group
-    // name yields a class that is never generated and a checkbox that silently
-    // never appears. Nothing but a computed style catches that.
-    await installGraphApi(page);
-    await openGraph(page);
-    const surface = strip(page, PROJECT_ID);
-    const card = surface.locator('[data-node-id="alpha"]');
-    const checkbox = card.locator("[data-selection-indicator]");
-    const opacity = () =>
-      checkbox.evaluate((element) => getComputedStyle(element).opacity);
-
-    // RENDERED but transparent, with nothing selected and the pointer away. Not
-    // absent: it keeps its box so the reveal cannot relayout the card under the
-    // pointer, which is also why presence is the wrong thing to assert.
-    await expect(checkbox).toHaveAttribute("data-selection-indicator-reveal", "hover");
-    await page.mouse.move(0, 0);
-    await expect.poll(opacity).toBe("0");
-
-    await card.hover();
-    await expect.poll(opacity).toBe("1");
-
-    // And away again — a checkbox left behind would read as a selection that
-    // is not there.
-    await page.mouse.move(0, 0);
-    await expect.poll(opacity).toBe("0");
-
-    // SELECT MODE pins it on with the pointer nowhere near the card: the mode
-    // needs every card to show its state at once, unpicked ones included, which
-    // a hover reveal can never do for more than one card at a time.
-    //
-    // The mode toggle lives in the anchor's menu, so something has to be
-    // selected first — and a plain click would open this clip's editor rather
-    // than select it.
-    await selectCard(card);
-    await toggleMultiSelect(page);
-    await page.mouse.move(0, 0);
-    await expect(checkbox).toHaveAttribute("data-selection-indicator-reveal", "armed");
-    await expect.poll(opacity).toBe("1");
   });
 
   // Its own context: `hasTouch` sets maxTouchPoints, which is what makes
@@ -7917,47 +7865,34 @@ test.describe("graph view E2E", () => {
   test.describe(() => {
     test.use({ hasTouch: true });
 
-    test("touch gets NO hover checkbox — tapping a card never leaves one stuck on", async ({
+    test("touch reaches selection through the Select control, and a tap still opens", async ({
       page,
     }) => {
-      // The other half of the desktop-only reveal, and the reason the CSS
-      // carries an explicit `@media (hover: hover)` instead of trusting a
-      // framework default. Without the query, a tap sets `:hover` on the
-      // tapped card and Chromium LEAVES IT THERE until something else is
-      // touched — so the checkbox would sit on the last card tapped, saying
-      // "picked" about a card that is not.
+      // The desktop-only hover reveal is gone, so the sticky-hover bug it
+      // carried cannot happen and the `@media (hover: hover)` guard that
+      // existed for it is gone too. What still matters is that touch — the
+      // input that never had the hover route — reaches selection the same way
+      // everything else does now.
       await installGraphApi(page);
       await openGraph(page);
       const surface = strip(page, PROJECT_ID);
       const card = surface.locator('[data-node-id="alpha"]');
-      const checkbox = card.locator("[data-selection-indicator]");
-      const opacity = () =>
-        checkbox.evaluate((element) => getComputedStyle(element).opacity);
 
-      // The premise, asserted first — `hasTouch` is what makes Chromium report
-      // this, and without it the checks below would pass for the wrong reason.
-      expect(await page.evaluate(() => window.matchMedia("(hover: none)").matches)).toBe(true);
+      await expect(card.locator("[data-selection-indicator]")).toHaveCount(0);
 
-      await expect.poll(opacity).toBe("0");
-
-      // A tap OPENS rather than selects, and leaves no checkbox behind it —
-      // which is the sticky-hover case: without the media query the tap would
-      // set `:hover` on this card and Chromium would keep it there.
       await card.tap();
       await expect(page.getByRole("dialog")).toBeVisible();
       await page.keyboard.press("Escape");
       await expect(page.getByRole("dialog")).toHaveCount(0);
-      await expect.poll(opacity).toBe("0");
+      await expect(card.locator("[data-selection-indicator]")).toHaveCount(0);
 
-      // Select mode still works here — it is a mode, not a hover affordance,
-      // and touch is exactly the input that has no other way to select at all.
-      // Reached through the HEADER control, because the anchor menu route
-      // needs something already selected and on touch nothing can be.
       await page.locator("[data-select-mode-toggle]").tap();
+      const checkbox = card.locator("[data-selection-indicator]");
       await expect(checkbox).toHaveAttribute("data-selection-indicator-reveal", "armed");
-      await expect.poll(opacity).toBe("1");
+      await expect
+        .poll(() => checkbox.evaluate((el) => getComputedStyle(el).opacity))
+        .toBe("1");
     });
-
     test("touch gets 44px hit targets on every selection control", async ({ page }) => {
       await installGraphApi(page);
       await openGraph(page);


### PR DESCRIPTION
The checkbox used to render on every card and reveal itself on **hover**, and clicking it both toggled *and armed* the mode.

**Removed because this is a dragging board.** The ordinary way to work here is grabbing and moving things, so the cursor is over cards constantly and not because anyone is choosing them — a checkbox materialising under it on every card you pass is noise during the gesture the board is actually for. It also had less to offer than it looked: most of what select mode does is already covered by drag and drop, so the mode earns its place on the edge cases (acting on several things at once), and those are worth an explicit step.

## The trade, stated where it bites

Outside the mode there is now **no pointer route to selecting a collection at all** — a plain click on one drills in, and this circle was the only thing on the card saying it could be picked. Press Select, then click. That is accepted, not overlooked, and it is asserted in the test and story that carry it.

It also costs least where the mode matters most: **touch never had the hover route**, so the Select control was always its only path.

## Absent, not hidden

Which is the stronger property. A hover-revealed control is still a click target that can be hit before it is visible — the old code had to weld `pointer-events-none` to the opacity in one rule so the two could never drift apart, plus an `@media (hover: hover)` guard so a tap could not leave a checkbox stuck on the last-touched card. None of that can happen to an element that is not rendered. The guard, the sticky-hover bug, the two per-card-kind reveal class constants, and the arming click all go with it.

## Tests

**Five e2e tests became four.** Three described the hover route — revealed on a real hover, arms the mode, a hidden one is not a click trap — and collapse into one pinning the new invariant: no checkbox before hover, after a real hover, or after the pointer settles. Run against the old rendering first, where it fails (`Expected: 0, Received: 1`).

**Two stories became four**, in pairs per card kind. Absence alone would pass just as well if the checkbox were broken in *both* states, which is the one failure a one-sided assertion cannot see. `renderWithTags` learned to arm select mode and needed `keepMultiSelectModeWhenEmpty` to do it — without it the store disarms the moment the selection is empty, so arming with nothing selected turns straight back off. That, not the `waitFor` I first blamed, is what fixed the collection story, and the comment says so.

## Verified

`tsc` clean (app + `packages/ui`) · lint 0 errors · app unit **1300** · shared unit **771** · stories **255** · e2e **178**

Includes the merge of #456's root-vitest fix.