### PR TITLE
Collapse the closure waterfall: one query instead of nine round trips

### DIFF
--- a/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
@@ -564,9 +564,31 @@ function countRequest(documents: number, kind: "batch" | "single"): void {
   );
 }
 
-function countRead(): number | null {
+/**
+ * TWO COUNTERS, because one number cannot mean two things.
+ *
+ * This used to increment a single total for both stores and tag the SOURCE per
+ * line — so the running number conflated billable Firestore reads with free
+ * reads of a local JSON file. Opening a project offline printed "[READTOTAL
+ * 150]" while touching no quota at all, and flipping fixtures off mid-session
+ * carried the fixture count forward, so the number kept looking like Firestore
+ * usage it had never been.
+ *
+ * `[READTOTAL n]` is now FIRESTORE ONLY and is the billing figure — the one to
+ * compare against the 50,000/day free tier. Fixture reads count under
+ * `[FIXTUREREAD n]`, which costs nothing and is only useful for seeing that the
+ * same code path ran.
+ */
+function countRead(source: "fixture" | "firestore"): number | null {
   if (!process.env.GSTUDIO_COUNT_READS) return null;
-  const scope = globalThis as unknown as { __gstudioReads?: number };
+  const scope = globalThis as unknown as {
+    __gstudioReads?: number;
+    __gstudioFixtureReads?: number;
+  };
+  if (source === "fixture") {
+    scope.__gstudioFixtureReads = (scope.__gstudioFixtureReads ?? 0) + 1;
+    return scope.__gstudioFixtureReads;
+  }
   scope.__gstudioReads = (scope.__gstudioReads ?? 0) + 1;
   return scope.__gstudioReads;
 }
@@ -604,7 +626,11 @@ function logRead(
     : note === "denied"
       ? "DENIED"
       : "MISSING";
-  console.log(`[READTOTAL ${total}] ${id} ${detail} (${source})`);
+  // The LABEL carries the meaning now, not a tag at the end of the line: one is
+  // money, the other is not.
+  console.log(
+    `[${source === "fixture" ? "FIXTUREREAD" : "READTOTAL"} ${total}] ${id} ${detail}`,
+  );
 }
 
 /**
@@ -639,13 +665,14 @@ export async function readStoredTimelineEntry(
   // Counted HERE, before the fixture branch and before the fetch: the metric is
   // read ATTEMPTS, so a miss, a denial and a fixture hit all count. What each
   // attempt turned out to be is reported by `logRead` once it resolves.
-  const readTotal = countRead();
+  const usingFixtures = fixtureStoreEnabled();
+  const readTotal = countRead(usingFixtures ? "fixture" : "firestore");
   // OFFLINE MODE. Dev-only, refused outright in production — see
   // `fixture-timeline-store`. Intercepted HERE rather than per route because
   // this is the single read seam: `serveTimelineDocument`, `serveTrashDocument`,
   // the RSC focus-path loader and the closure walker all come through it, so
   // one branch covers every reader and none of them can drift.
-  if (fixtureStoreEnabled()) {
+  if (usingFixtures) {
     const fixtureEntry = fixtureReadEntry(id);
     logRead(readTotal, id, fixtureEntry, "fixture");
     return fixtureEntry;
@@ -714,10 +741,11 @@ export async function readStoredTimelineEntries(
 
   // Counted BEFORE the fetch, per id, so the metric stays "read attempts" —
   // the same rule the single-document path follows.
+  const usingFixtures = fixtureStoreEnabled();
   const totals = new Map<string, number | null>();
-  for (const id of unique) totals.set(id, countRead());
+  for (const id of unique) totals.set(id, countRead(usingFixtures ? "fixture" : "firestore"));
 
-  if (fixtureStoreEnabled()) {
+  if (usingFixtures) {
     for (const id of unique) {
       const entry = fixtureReadEntry(id);
       logRead(totals.get(id) ?? null, id, entry, "fixture");

--- a/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
@@ -542,6 +542,28 @@ export async function collectOwnedTimelineClips(
  * The count lives on `globalThis` so it survives the dev server's module
  * re-evaluation, which would otherwise reset it on every file save.
  */
+/**
+ * REQUESTS, which is a different number from reads since #449.
+ *
+ * `countRead` counts DOCUMENTS, because that is what Firestore bills and what
+ * the 50,000/day free tier is denominated in. Batching cut round trips without
+ * touching that number — correctly — but it also made the log silent about the
+ * thing it changed: 148 lines either way, and no way to see whether a level
+ * went out as one request or as 148.
+ *
+ * So requests are counted separately and printed per call. The two numbers
+ * answer different questions and are meant to be read together: reads are the
+ * bill, requests are the latency.
+ */
+function countRequest(documents: number, kind: "batch" | "single"): void {
+  if (!process.env.GSTUDIO_COUNT_READS) return;
+  const scope = globalThis as unknown as { __gstudioRequests?: number };
+  scope.__gstudioRequests = (scope.__gstudioRequests ?? 0) + 1;
+  console.log(
+    `[READREQ ${scope.__gstudioRequests}] ${kind} — ${documents} document${documents === 1 ? "" : "s"} in 1 request`,
+  );
+}
+
 function countRead(): number | null {
   if (!process.env.GSTUDIO_COUNT_READS) return null;
   const scope = globalThis as unknown as { __gstudioReads?: number };
@@ -629,6 +651,9 @@ export async function readStoredTimelineEntry(
     return fixtureEntry;
   }
 
+  // One document, one request — the case the batch exists to replace, and the
+  // one worth being able to spot in the log when it happens outside a walk.
+  countRequest(1, "single");
   const snapshot = await withFirebaseTimeout(
     collection().doc(id).get(),
     "Loading timeline document",
@@ -710,12 +735,13 @@ export async function readStoredTimelineEntries(
   }
   const snapshots = (
     await Promise.all(
-      chunks.map((chunk) =>
-        withFirebaseTimeout(
+      chunks.map((chunk) => {
+        countRequest(chunk.length, "batch");
+        return withFirebaseTimeout(
           getFirebaseDb().getAll(...chunk.map((id) => collection().doc(id))),
           "Loading timeline documents",
-        ),
-      ),
+        );
+      }),
     )
   ).flat();
 


### PR DESCRIPTION
Started as "why does `[READTOTAL]` still say 150?" and ended up removing the waterfall behind it. Six commits, each measured.

## The instrument first, because it was lying by omission

- **`[READREQ n]`** — requests are now counted and printed. `countRead()` fires per *document* (correctly — that is what Firestore bills), so after #449 the log showed 150 lines whether the walk sent 148 requests or 9. The change #449 actually made was invisible in the one place you would look to confirm it.
- **`[READTOTAL]` means Firestore, and nothing else.** One counter served both stores and tagged the source at the end of each line, so the running total mixed billable reads with free reads of a local JSON file — a project opened offline printed "150" while touching no quota. Fixture reads now count under `[FIXTUREREAD n]`.

Read together the log says three separate true things: **what it cost, what it cost nothing, and how many round trips it took.**

## Then the latency itself

- **The trash is read alongside the closure, not after it.** A separate root that depended on nothing, awaited behind all nine levels. 10 sequential rounds → 9, no data-model change.
- **`projectId` stamped on every write**, batch-wide, via a `bindProject` on the gateway. Omitting it leaves the stored value alone, so the MCP tools and trash routes cannot erase a correct hint. Backfilled: **169 documents, 4 roots, 49 reachable from no project** (left alone).
- **One query replaces the walk's round trips.**

```
walk    3025ms   148 documents read   9 requests over 9 sequential rounds
query    784ms   143 documents read   1 request  over 1 round

walk found 143, query found 143 — 0 unstamped, 0 stale
```

**3.9× faster, and five reads cheaper** — the walk pays for five dangling references (a `get()` on a missing document is still billed); the query does not return them.

## The property that makes it safe

**`projectId` is a hint; the walk still decides.** The query primes the shared reader's inflight map and the *unchanged* walk resolves from memory. Anything the prime missed — a stale hint, an unstamped document — the walk fetches exactly as before. So a wrong hint costs latency and never a wrong board, which is also why accepting the field from a client is acceptable at all: it could only mis-file the caller's own documents into their own other project's prefetch.

Ordering cost a bug on the way: the prime runs **before** the root read, so the root arrives in the same query. After it, this would have been a second sequential round to save nine. It is idempotent because both `serveTimelineClosure` and the walk ask.

## Known limit, stated rather than buried

**Not a flat one round.** A query cannot return documents that do not exist, so the five dangling ids are found uncached and fetched at whatever level they appear. One gap-filling batch after the prime would collapse that too — a contained follow-up.

## Verified

`tsc` clean · lint 0 errors · **1304** unit · **178** e2e · both measurement scripts committed, and the query-vs-walk one asserts the two find the same documents so future drift shows up as a number.