### PR TITLE
Collapse the closure waterfall: one query instead of nine round trips

### DIFF
--- a/apps/timeline-gstudio001/app/api/timelines/batch/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/batch/route.ts
@@ -53,6 +53,28 @@ export async function POST(request: Request) {
       );
     }
 
+    // OPTIONAL, and validated like any other id the client sends. A batch that
+    // knows its board stamps every document in it with that project, which is
+    // what lets one query later address a whole subtree in one round trip
+    // (#458).
+    //
+    // TRUST IS NOT REQUIRED HERE, which is why an optional client-supplied
+    // field is acceptable at all: nothing reads `projectId` to decide what a
+    // project contains — the closure walk still does that. A client that sent
+    // the wrong one would mis-file its OWN documents into its OWN other
+    // project's prefetch, costing that board a slower first paint and nothing
+    // else. The user-scoped check keeps it inside the caller's own data.
+    const projectIdRaw = body.projectId;
+    if (projectIdRaw !== undefined) {
+      if (typeof projectIdRaw !== "string" || !isValidTimelineId(projectIdRaw)) {
+        return NextResponse.json({ error: "Invalid projectId." }, { status: 400 });
+      }
+      if (checkUserScopedId(projectIdRaw, user.uid) === false) {
+        return NextResponse.json({ error: "Timeline was not found." }, { status: 404 });
+      }
+    }
+    const projectId = typeof projectIdRaw === "string" ? projectIdRaw : undefined;
+
     const writes: TimelineBatchWrite[] = [];
     for (const entry of requested) {
       // Each element is untrusted too — an array of nulls used to throw on the
@@ -118,7 +140,7 @@ export async function POST(request: Request) {
       });
     }
 
-    const results = await saveFirebaseTimelineDocumentsAtomic(writes, user.uid);
+    const results = await saveFirebaseTimelineDocumentsAtomic(writes, user.uid, { projectId });
     // After the commit, never inside it — the log must not be able to fail a
     // save, and must not claim a change that did not land.
     await recordChange({

--- a/apps/timeline-gstudio001/app/api/timelines/timelines-batch.test.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/timelines-batch.test.ts
@@ -160,11 +160,13 @@ function batchRequest(
     expectedRevision?: number;
     allowEmptying?: unknown;
   }[],
+  /** Batch-wide, as the board sends it — see the `projectId` tests below. */
+  projectId?: unknown,
 ) {
   return new Request("http://test.local/api/timelines/batch", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ writes }),
+    body: JSON.stringify(projectId === undefined ? { writes } : { writes, projectId }),
   });
 }
 
@@ -271,6 +273,54 @@ describe("timeline batch writes", () => {
     const { results } = (await response.json()) as { results: { id: string; revision: number }[] };
     expect(results).toEqual([{ id: "doc-new", revision: 1 }]);
     expect(state.docs.get("doc-new")?.ownerUid).toBe("user-a");
+  });
+
+  it("stamps projectId on every document in the batch", async () => {
+    // The prefetch hint that lets one query address a whole subtree in one
+    // round trip instead of nine sequential ones (#458). Batch-wide because a
+    // batch IS one board's edit — a cross-timeline move touches two documents
+    // and both belong to the same project.
+    const response = await batchWrite(
+      batchRequest(
+        [
+          { document: docOf("doc-new", "c1"), expectedRevision: 0 },
+          { document: docOf("doc-two", "c2"), expectedRevision: 0 },
+        ],
+        "project-a",
+      ),
+    );
+    expect(response.status).toBe(200);
+    expect(state.docs.get("doc-new")?.projectId).toBe("project-a");
+    expect(state.docs.get("doc-two")?.projectId).toBe("project-a");
+  });
+
+  it("a write without a projectId leaves the stored one alone", async () => {
+    // The MCP tools and the trash routes write without a board's context, and a
+    // correct hint has to survive them — writing undefined over it would send
+    // the next board open back to the nine-level walk for no reason.
+    seedTimeline("doc-1", "user-a", 3);
+    state.docs.set("doc-1", { ...state.docs.get("doc-1"), projectId: "project-a" });
+
+    const response = await batchWrite(batchRequest([{ document: docOf("doc-1", "lww") }]));
+    expect(response.status).toBe(200);
+    expect(state.docs.get("doc-1")?.projectId).toBe("project-a");
+  });
+
+  it("rejects a malformed projectId, and another user's as not-found", async () => {
+    // Validated like any other id the client sends. It carries no authorization
+    // weight — nothing reads it to decide what a project contains — but it must
+    // still stay inside the caller's own scope.
+    const malformed = await batchWrite(
+      batchRequest([{ document: docOf("doc-new", "c1"), expectedRevision: 0 }], 42),
+    );
+    expect(malformed.status).toBe(400);
+    expect(state.docs.has("doc-new")).toBe(false);
+
+    const foreign = await batchWrite(
+      batchRequest([{ document: docOf("doc-new", "c1"), expectedRevision: 0 }], "trash-user-b"),
+    );
+    expect(foreign.status).toBe(404);
+    expect(state.docs.has("doc-new")).toBe(false);
   });
 
   it("expectation-less writes keep last-write-wins semantics", async () => {

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -388,6 +388,14 @@ export function GraphTimelineView({
     }
   }, [user]);
 
+  // The board this session is editing, so writes can carry it and the server
+  // can stamp `projectId` (#458). Its own effect, keyed on the project rather
+  // than the user: drilling into a different project changes this and nothing
+  // else, and a re-bind must not reset the cache the way `bindUser` does.
+  useEffect(() => {
+    graphDocumentsGateway.bindProject(projectId);
+  }, [projectId]);
+
   // RSC payloads prime the gateway (guarded inside it: only for the bound
   // user, never over local edits, never regressing the revision ledger).
   // `user` is a dep so payloads that arrived before the client-side auth

--- a/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
@@ -27,6 +27,20 @@ type TimelineDocumentRecord = {
   lastNonEmptyDocument?: TimelineDocument;
   clips?: TimelineClip[];
   isProject?: boolean;
+  /**
+   * The PROJECT this document belongs to — its root's id, and its own id on the
+   * root itself.
+   *
+   * A PREFETCH HINT, never the source of truth. Nothing reads it to decide what
+   * a project contains; the closure walk still does that, and still decides.
+   * Its only job is to let one query address a whole subtree in one round trip
+   * instead of nine sequential ones, so a stale or missing value costs latency
+   * and never correctness (#458).
+   *
+   * Optional because every document written before this existed lacks it, and
+   * because that has to be survivable rather than migrated-or-broken.
+   */
+  projectId?: string;
   /** Authorization boundary. Optional only because Firestore documents are
    *  untyped at rest — every live record carries one, and a record without an
    *  owner is unreachable rather than up for grabs (see lib/timeline-ownership). */
@@ -807,6 +821,9 @@ export async function readStoredTimelineDocument(id: string, requesterUid: strin
 
 export type SaveOptions = Readonly<{
   isProject?: boolean;
+  /** Stamp `projectId` on this write. Absent leaves whatever is stored alone —
+   *  a write that does not know its project must not erase a correct value. */
+  projectId?: string;
   /**
    * Permit a save that leaves the document with NO clips, and clear the
    * `lastNonEmptyDocument` recovery snapshot with it. Off by default: an empty
@@ -847,6 +864,13 @@ function buildSavePayload(
         ? { lastNonEmptyDocument: FieldValue.delete() }
         : {}),
     isProject: options?.isProject ?? existing?.isProject === true,
+    // KEPT when the caller does not know it. A write that omits `projectId`
+    // leaves the stored value alone rather than writing undefined over it: the
+    // MCP tools and the trash routes write documents without a board's project
+    // context, and a correct hint must survive them.
+    ...(options?.projectId ?? existing?.projectId
+      ? { projectId: options?.projectId ?? existing?.projectId }
+      : {}),
     // Ownership: a save CREATES with the requester as owner, CLAIMS a legacy
     // unowned record, and was refused earlier on someone else's. Children
     // minted implicitly through writes (collection drops) are stamped too.
@@ -1020,6 +1044,15 @@ export async function saveFirebaseTimelineDocument(
 export async function saveFirebaseTimelineDocumentsAtomic(
   writes: readonly TimelineBatchWrite[],
   requesterUid: string,
+  /**
+   * The board that produced this batch, stamped onto every document in it.
+   *
+   * Batch-wide rather than per-write because a batch IS one board's edit — a
+   * cross-timeline move touches two documents and both belong to the same
+   * project. Callers without a board (the MCP tools, the trash routes) omit it,
+   * and omitting leaves any stored value alone.
+   */
+  options?: Readonly<{ projectId?: string }>,
 ): Promise<{ id: string; revision: number }[]> {
   for (const write of writes) {
     if (isUnsavedProjectPlaceholder(write.document)) {
@@ -1145,12 +1178,14 @@ export async function saveFirebaseTimelineDocumentsAtomic(
             existingData,
             requesterUid,
             actualRevision + 1,
+            // `projectId` rides alongside `allowEmptying`: batch-wide, and only
+            // when the caller knows it.
             // Carries through to `lastNonEmptyDocument`, which MUST be dropped
             // for a deliberate empty: `toTimelineDocument` reads that snapshot
             // back whenever a stored document has no clips, so leaving it would
             // re-hydrate the very clips this write removed and the empty would
             // never stick.
-            { allowEmptying: write.allowEmptying },
+            { allowEmptying: write.allowEmptying, projectId: options?.projectId },
           ),
         });
       }

--- a/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
@@ -813,6 +813,68 @@ export async function readStoredTimelineEntries(
   return out;
 }
 
+/**
+ * Every document stamped with this project, in ONE query.
+ *
+ * THE WATERFALL IS THE POINT. The closure walk can only ask for a level once
+ * the previous level's documents have named it, so opening the 143-document
+ * project costs nine SEQUENTIAL round trips — latency proportional to DEPTH,
+ * independent of width (#458). A query addresses documents by attribute instead
+ * of by walking to them, so it needs nobody's answer first: one round trip,
+ * whatever the shape.
+ *
+ * THE BILL IS UNCHANGED, as ever. Firestore charges per document returned, so
+ * 148 documents cost 148 reads here exactly as they did across nine `getAll`s.
+ * What collapses is the round trips.
+ *
+ * A PREFETCH, NOT AN ANSWER. Callers must not treat this as "what the project
+ * contains" — `projectId` is a hint that can be stale, absent on anything
+ * written before it existed, or wrong. It primes the cache; the closure walk
+ * still decides, and still fetches whatever the prime did not cover. That is
+ * what keeps a bad hint costing latency instead of correctness.
+ *
+ * Empty under fixtures: offline mode has no query engine and no round trips to
+ * save, so the walk simply does its usual work against the local file.
+ */
+export async function readStoredTimelineProjectEntries(
+  projectId: string,
+  requesterUid: string,
+): Promise<Map<string, TimelineEntry>> {
+  const found = new Map<string, TimelineEntry>();
+  if (fixtureStoreEnabled()) return found;
+
+  const snapshot = await withFirebaseTimeout(
+    collection()
+      .where("ownerUid", "==", requesterUid)
+      .where("projectId", "==", projectId)
+      .get(),
+    "Loading project documents",
+  );
+  // Counted AFTER, because the size is only known once it answers — and the
+  // whole point of the line is that one request carried all of them.
+  countRequest(snapshot.size, "batch");
+
+  for (const doc of snapshot.docs) {
+    const total = countRead("firestore");
+    const data = doc.data() as TimelineDocumentRecord;
+    // The query already filtered on `ownerUid`, so this cannot return someone
+    // else's — but the check stays rather than being assumed away: it is the
+    // same boundary every other read enforces, and a query is a longer way to
+    // be wrong about who owns what.
+    if (resolveOwnership(data.ownerUid, requesterUid) !== "owned") {
+      logRead(total, doc.id, null, "firestore", "denied");
+      continue;
+    }
+    const entry = {
+      document: toTimelineDocument(doc.id, data),
+      revision: data.revision ?? 0,
+    };
+    logRead(total, doc.id, entry, "firestore");
+    found.set(doc.id, entry);
+  }
+  return found;
+}
+
 /** `readStoredTimelineEntry` without the revision — same caveats, read them there. */
 export async function readStoredTimelineDocument(id: string, requesterUid: string) {
   const entry = await readStoredTimelineEntry(id, requesterUid);

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
@@ -56,6 +56,8 @@ type FetchCall = {
   /** GET: the timeline id from the url. POST: "batch". */
   id: string;
   writes?: BatchWrite[];
+  /** The board a write batch declares, so the server can stamp it (#458). */
+  projectId?: string;
   keepalive?: boolean;
   /** Kept so tests can assert a batch was abandoned (unload takeover). */
   signal?: AbortSignal;
@@ -121,6 +123,9 @@ function installFetch(handler: (call: FetchCall) => Promise<MockResponse> | Mock
       method: init?.method ?? "GET",
       id: decodeURIComponent(url.split("/").pop() ?? ""),
       writes: body ? (JSON.parse(body) as { writes: BatchWrite[] }).writes : undefined,
+      projectId: body
+        ? (JSON.parse(body) as { projectId?: string }).projectId
+        : undefined,
       keepalive: init?.keepalive,
       signal: init?.signal ?? undefined,
       bodyBytes: body ? new TextEncoder().encode(body).length : undefined,
@@ -1169,6 +1174,29 @@ describe("graph-documents-gateway", () => {
 
       expect(clipIds(await gateway.ensure("ghost"))).toEqual(["g1"]);
       expect(getsOf(calls)).toHaveLength(0);
+    });
+  });
+
+  describe("bindProject", () => {
+    it("sends the bound project with a write batch, and nothing when unbound", async () => {
+      // The board's id rides with the batch so the server can stamp `projectId`
+      // — the prefetch hint that lets one query address a whole subtree in one
+      // round trip instead of nine sequential ones (#458).
+      const calls = installFetch(() => jsonResponse({ results: [{ id: "a", revision: 1 }] }));
+      const gateway = createGraphDocumentsGateway();
+      gateway.bindUser("user-a");
+      gateway.prime(doc("a", [clip("a1")]), 0, "user-a");
+
+      // UNBOUND first: the field is absent rather than null or empty, which is
+      // what the server reads as "leave whatever is stored alone".
+      gateway.writeClips("a", [clip("a1"), clip("a2")]);
+      await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+      expect(at(batchesOf(calls), 0).projectId).toBeUndefined();
+
+      gateway.bindProject("project-a");
+      gateway.writeClips("a", [clip("a1")]);
+      await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS);
+      expect(at(batchesOf(calls), 1).projectId).toBe("project-a");
     });
   });
 });

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
@@ -151,6 +151,16 @@ export type GraphDocumentsGateway = Readonly<{
    * prime/ensure in an authenticated session.
    */
   bindUser: (uid: string) => void;
+  /**
+   * The board this session is editing, sent with every write so the server can
+   * stamp `projectId` (#458).
+   *
+   * Separate from `bindUser` because it changes far more often — every drill
+   * into a different project — and because it carries no authorization weight:
+   * it is a prefetch hint, and the server validates it against the caller's own
+   * scope regardless.
+   */
+  bindProject: (projectId: string) => void;
   /** The compare-and-set ledger's revision for a document, if known. */
   revisionOf: (timelineId: string) => number | undefined;
   /**
@@ -298,6 +308,8 @@ export function createGraphDocumentsGateway(
    *  dangling childTimelineId, not a document waiting to load. See the note in
    *  `ensureClosure`. */
   const knownMissingIds = new Set<string>();
+  /** The board whose writes this session is sending — see `bindProject`. */
+  let boundProjectId: string | null = null;
   // Documents this session has actually EMPTIED — observed at the moment the
   // clips went from some to none, not inferred later from a projection that
   // happens to be empty. The store refuses an empty-over-non-empty write
@@ -933,7 +945,13 @@ export function createGraphDocumentsGateway(
       }
     };
 
-    const body = JSON.stringify({ writes });
+    // The project rides with the batch, not per write: a batch IS one board's
+    // edit, and a cross-timeline move touches two documents that belong to the
+    // same project. Omitted when unbound, which the server treats as "leave
+    // whatever is stored alone".
+    const body = JSON.stringify(
+      boundProjectId === null ? { writes } : { writes, projectId: boundProjectId },
+    );
     // The keepalive quota is 64 KiB across ALL in-flight keepalive requests,
     // and a request over it is not merely truncated — the fetch is a network
     // error, so asking for keepalive on an oversized body GUARANTEES the loss
@@ -1259,6 +1277,9 @@ export function createGraphDocumentsGateway(
         if (documents[id] !== undefined && !staleIds.has(id)) continue;
         expectedPrimes.set(id, deadline);
       }
+    },
+    bindProject: (projectId) => {
+      boundProjectId = projectId;
     },
     bindUser: (uid) => {
       if (boundUid === uid) return;

--- a/apps/timeline-gstudio001/lib/graph-rsc-payloads.ts
+++ b/apps/timeline-gstudio001/lib/graph-rsc-payloads.ts
@@ -71,11 +71,24 @@ export async function loadGraphBootstrapPayloads(
     // A closure too large to walk returns null, and the caller falls back to
     // the project alone — the old behaviour, which still works, just slower.
     const read = createTimelineEntryReader(requesterUid);
-    const closure = await serveTimelineClosure(projectId, requesterUid);
+    // TOGETHER, because the trash is not under the project and never was.
+    //
+    // It was read AFTER the closure, so it waited out all nine levels of the
+    // walk for an answer that depended on none of them — one whole round trip
+    // (~160ms against Firestore) of pure serialisation on every board open.
+    // Nothing orders these: the walk cannot reach `trash-<uid>` (it is a
+    // separate root) and the trash cannot contain the project.
+    //
+    // Latency is the CRITICAL PATH, not the request count. These are still two
+    // requests and still two billed reads' worth of documents; they simply cost
+    // one round trip between them instead of two.
+    const [closure, trash] = await Promise.all([
+      serveTimelineClosure(projectId, requesterUid),
+      serveTrashDocument(`trash-${requesterUid}`, requesterUid, read),
+    ]);
     if (!closure) {
       const project = await serveTimelineDocument(projectId, requesterUid, read);
       if (!project) return null;
-      const trash = await serveTrashDocument(`trash-${requesterUid}`, requesterUid, read);
       return {
         payloads: [
           { ...project, forUid: requesterUid },
@@ -84,9 +97,6 @@ export async function loadGraphBootstrapPayloads(
         missing: [],
       };
     }
-    // The trash is NOT under the project, so it is read separately — through
-    // its own reader, since the closure's is finished with.
-    const trash = await serveTrashDocument(`trash-${requesterUid}`, requesterUid, read);
     // forUid lets the client's prime refuse payloads that survive an auth
     // transition in the router cache.
     return {

--- a/apps/timeline-gstudio001/lib/load-timeline-closure.ts
+++ b/apps/timeline-gstudio001/lib/load-timeline-closure.ts
@@ -15,6 +15,12 @@ export type TimelineEntryReader = ((id: string) => Promise<TimelineEntry | null>
   /** Optional bulk path — see `createTimelineEntryReader`. A plain function
    *  still satisfies this type, which is what test readers hand in. */
   many?: (ids: readonly string[]) => Promise<Map<string, TimelineEntry | null>>;
+  /**
+   * Optional single-query prime of a whole project, resolving the returned
+   * count. See `readStoredTimelineProjectEntries` — it collapses the walk's
+   * round trips without changing what the walk decides.
+   */
+  prefetchProject?: (projectId: string) => Promise<number>;
 };
 
 // The nested document closure for a timeline: the root plus every document
@@ -137,6 +143,15 @@ export async function loadTimelineClosure(
     options?.rootEntry !== undefined
       ? options.rootEntry
       : await read(rootId).catch(() => null);
+
+  // ONE QUERY BEFORE THE WALK, when the reader can do it.
+  //
+  // The walk below is unchanged and still authoritative: it decides what the
+  // closure IS. This only puts the documents where it will look, so its nine
+  // sequential levels resolve from memory instead of from nine round trips.
+  // Anything the prime missed — a document written before `projectId` existed,
+  // or one whose hint is stale — the walk fetches exactly as it always did.
+  await read.prefetchProject?.(rootId).catch(() => 0);
 
   let frontier: readonly string[] = record(rootId, rootEntry);
 

--- a/apps/timeline-gstudio001/lib/serve-timeline.ts
+++ b/apps/timeline-gstudio001/lib/serve-timeline.ts
@@ -16,6 +16,7 @@ import {
 import {
   readStoredTimelineEntries,
   readStoredTimelineEntry,
+  readStoredTimelineProjectEntries,
   type TimelineEntry,
 } from "./firebase-timeline-store";
 import { healTimelineDocument } from "./heal-timeline-document";
@@ -92,6 +93,36 @@ export function createTimelineEntryReader(requesterUid: string): TimelineEntryRe
     for (const id of wanted) out.set(id, entries.get(id) ?? null);
     await Promise.all(joined);
     return out;
+  };
+
+  // PRIME FROM ONE QUERY, through the same `inflight` map everything else uses
+  // — so the walk that follows resolves from memory and issues nothing.
+  //
+  // Recorded as already-resolved promises rather than as documents, because
+  // that is the shape `read` and `read.many` already consult: nothing
+  // downstream needs to know a prefetch happened, and a document the query
+  // missed simply is not there, so the walk fetches it exactly as before.
+  //
+  // Best effort. A query failure, a missing index, or a project whose documents
+  // predate `projectId` all land the same way — nothing primed, and the walk
+  // does its nine round trips. That is the whole safety property: the hint can
+  // fail and only latency changes.
+  const prefetched = new Set<string>();
+  read.prefetchProject = async (projectId) => {
+    // ONCE PER PROJECT PER REQUEST. Both `serveTimelineClosure` and the closure
+    // walk itself ask — the first so the ROOT comes from the query too, the
+    // second so any other caller of the walk gets the same benefit — and two
+    // asks must not mean two queries.
+    if (prefetched.has(projectId)) return 0;
+    prefetched.add(projectId);
+    const entries = await readStoredTimelineProjectEntries(projectId, requesterUid).catch(
+      () => new Map<string, TimelineEntry>(),
+    );
+    for (const [id, entry] of entries) {
+      if (inflight.has(id)) continue;
+      inflight.set(id, Promise.resolve(entry));
+    }
+    return entries.size;
   };
 
   return read;
@@ -225,6 +256,10 @@ export async function serveTimelineClosure(
 }> | null> {
   // ONE reader for the whole walk — the property this endpoint exists for.
   const read = createTimelineEntryReader(requesterUid);
+  // BEFORE the root read, so the root arrives in the same query as everything
+  // else. After it, this would be a second sequential round trip to save nine —
+  // still a win, but a needless one when the ordering is free.
+  await read.prefetchProject?.(id).catch(() => 0);
   const entry = await read(id);
   if (!entry) return null;
 

--- a/apps/timeline-gstudio001/package.json
+++ b/apps/timeline-gstudio001/package.json
@@ -21,6 +21,7 @@
     "audit:review-findings": "node --env-file=.env scripts/audit-review-findings.mjs",
     "inspect:squatted": "node --env-file=.env scripts/inspect-squatted-fixtures.mjs",
     "stamp:ownership": "node --env-file=.env scripts/stamp-ownerless-timelines.mjs",
+    "stamp:project-id": "node --env-file=.env scripts/stamp-project-id-on-timeline-documents.mjs",
     "bin:orphans": "node --env-file=.env scripts/bin-unreachable-timelines.mjs",
     "correct:aspects": "node --env-file=.env scripts/correct-clip-aspects.mjs",
     "audit:accounts": "node --env-file=.env scripts/audit-foreign-accounts.mjs"

--- a/apps/timeline-gstudio001/scripts/measure-project-query-vs-closure-walk.mjs
+++ b/apps/timeline-gstudio001/scripts/measure-project-query-vs-closure-walk.mjs
@@ -1,0 +1,131 @@
+/**
+ * Times the two ways to load a project's documents, back to back, live:
+ * the BFS walk (batched per level — nine sequential round trips) and ONE query
+ * on `ownerUid + projectId`.
+ *
+ *   node scripts/measure-project-query-vs-closure-walk.mjs <rootId>
+ *
+ * WHAT IT PROVES, and what it cannot. The query's document count must MATCH the
+ * walk's, or the prefetch is not a prefetch — it is a different answer, and the
+ * whole safety argument (a hint that can only cost latency) depends on the walk
+ * remaining authoritative over it. A mismatch here means documents are unstamped
+ * or mis-stamped, not that the walk is wrong.
+ *
+ * COSTS ONE CLOSURE OF READS PER RUN — ~150 on the project this was written
+ * for, ~300 for the pair. Firestore bills per document returned, so the query
+ * costs exactly what the walk does; only the round trips differ.
+ */
+import { config } from "dotenv";
+import { cert, applicationDefault, initializeApp } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+
+config({ path: ".env" });
+
+const COLLECTION = "gstudioTimelineDocuments";
+const CHUNK = 200;
+
+const rootId = process.argv[2];
+if (!rootId) {
+  console.error("Usage: node scripts/measure-project-query-vs-closure-walk.mjs <rootId>");
+  process.exit(2);
+}
+
+const projectId = process.env.FIREBASE_PROJECT_ID;
+const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
+const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n");
+initializeApp(
+  clientEmail && privateKey
+    ? { credential: cert({ projectId, clientEmail, privateKey }), projectId }
+    : { credential: applicationDefault(), projectId },
+);
+const db = getFirestore();
+
+const childIds = (data) => {
+  const clips = data?.document?.clips ?? data?.clips ?? [];
+  return clips
+    .filter((clip) => clip?.kind === "collection" && clip?.childTimelineId)
+    .map((clip) => clip.childTimelineId);
+};
+
+/** The walk, batched per level — what ships today. */
+async function walk() {
+  const seen = new Set([rootId]);
+  const found = new Set();
+  let frontier = [rootId];
+  let requests = 0;
+  let levels = 0;
+  let read = 0;
+
+  while (frontier.length > 0) {
+    levels += 1;
+    const chunks = [];
+    for (let at = 0; at < frontier.length; at += CHUNK) chunks.push(frontier.slice(at, at + CHUNK));
+    requests += chunks.length;
+    const results = await Promise.all(
+      chunks.map((chunk) => db.getAll(...chunk.map((id) => db.collection(COLLECTION).doc(id)))),
+    );
+    const next = [];
+    for (const snapshot of results.flat()) {
+      read += 1;
+      if (!snapshot.exists) continue;
+      found.add(snapshot.id);
+      for (const childId of childIds(snapshot.data())) {
+        if (seen.has(childId)) continue;
+        seen.add(childId);
+        next.push(childId);
+      }
+    }
+    frontier = next;
+  }
+  return { found, requests, levels, read };
+}
+
+/** One query on the stamped hint. */
+async function query(ownerUid) {
+  const snapshot = await db
+    .collection(COLLECTION)
+    .where("ownerUid", "==", ownerUid)
+    .where("projectId", "==", rootId)
+    .get();
+  const found = new Set(snapshot.docs.map((doc) => doc.id));
+  return { found, requests: 1, levels: 1, read: snapshot.size };
+}
+
+const time = async (label, run) => {
+  const started = Date.now();
+  const result = await run();
+  const elapsed = Date.now() - started;
+  console.log(
+    `${label.padEnd(12)} ${String(elapsed).padStart(6)}ms  ` +
+      `${result.read} documents read  ${result.requests} request(s) over ${result.levels} sequential round(s)`,
+  );
+  return { elapsed, ...result };
+};
+
+// The walk FIRST, so the query cannot benefit from anything it warmed.
+const walked = await time("walk", walk);
+const root = await db.collection(COLLECTION).doc(rootId).get();
+const ownerUid = root.data()?.ownerUid;
+if (!ownerUid) {
+  console.error(`No ownerUid on ${rootId} — cannot run the query half.`);
+  process.exit(1);
+}
+const queried = await time("query", () => query(ownerUid));
+
+const missing = [...walked.found].filter((id) => !queried.found.has(id));
+const extra = [...queried.found].filter((id) => !walked.found.has(id));
+console.log(
+  `\nwalk found ${walked.found.size}, query found ${queried.found.size} — ` +
+    `${missing.length} unstamped, ${extra.length} stamped but unreachable`,
+);
+if (missing.length > 0) {
+  console.log(`  unstamped (the walk still fetches these): ${missing.slice(0, 10).join(", ")}`);
+}
+if (extra.length > 0) {
+  console.log(`  stale hint (primed but not in the closure): ${extra.slice(0, 10).join(", ")}`);
+}
+console.log(
+  `\n${walked.requests} requests over ${walked.levels} rounds -> ${queried.requests} over 1; ` +
+    `${(walked.elapsed / queried.elapsed).toFixed(1)}x faster, ` +
+    `${walked.read} reads vs ${queried.read} (the bill should not move)`,
+);

--- a/apps/timeline-gstudio001/scripts/stamp-project-id-on-timeline-documents.mjs
+++ b/apps/timeline-gstudio001/scripts/stamp-project-id-on-timeline-documents.mjs
@@ -1,0 +1,141 @@
+// Backfill `projectId` onto every timeline document, from the project that
+// actually reaches it.
+//
+//   npm run stamp:project-id --workspace=apps/timeline-gstudio001            # dry run
+//   npm run stamp:project-id --workspace=apps/timeline-gstudio001 -- --apply # write
+//
+// WHY IT EXISTS. The closure walk is a waterfall — a level's ids live inside
+// the previous level's documents, so opening a 143-document project costs nine
+// SEQUENTIAL round trips (#458). A `projectId` on each document lets one query
+// address the whole subtree in one trip. New writes stamp it themselves; every
+// document written before that shipped needs this.
+//
+// IT IS A HINT, NOT TRUTH. Nothing reads `projectId` to decide what a project
+// contains — the closure walk still does, and still decides. So a document this
+// script misses simply keeps today's behaviour, and a document it stamps wrongly
+// costs a slower first paint rather than a wrong board. That is the property
+// that makes a backfill safe to run before the read path uses it at all.
+//
+// Reads the whole collection once (~350 documents here), which is a real cost
+// — see the quota note in timeline-snapshot.mjs. `--offline` runs the same walk
+// against a saved snapshot for free.
+import { getFirestore } from "firebase-admin/firestore";
+
+import { dryRunNotice, readApplyFlag } from "./apply-flag.mjs";
+import {
+  COLLECTION,
+  announceSnapshot,
+  childIdsOf,
+  isAssetLibrary,
+  isTrashBin,
+  loadDocuments,
+  refuseOfflineWrite,
+  snapshotFlags,
+} from "./timeline-snapshot.mjs";
+
+const apply = readApplyFlag("stamp:project-id", "STAMP_PROJECT_APPLY");
+const { offline, snapshotPath } = snapshotFlags();
+
+/** Firestore's hard ceiling on operations in one batched write. */
+const MAX_BATCH_OPS = 500;
+
+/**
+ * Every document reachable from `rootId`, and the root itself.
+ *
+ * The same walk the server does, run once per project here rather than once per
+ * page load. Cycles are guarded by `seen`, which is not paranoia: a cycle is
+ * what `MAX_CLOSURE_DOCUMENTS` protects the server from, and this script has no
+ * such ceiling.
+ */
+function closureOf(documents, rootId) {
+  const found = new Set();
+  const queue = [rootId];
+  while (queue.length > 0) {
+    const id = queue.shift();
+    if (found.has(id)) continue;
+    const data = documents.get(id);
+    if (data === undefined) continue;
+    found.add(id);
+    for (const childId of childIdsOf(data)) queue.push(childId);
+  }
+  return found;
+}
+
+async function main() {
+  if (refuseOfflineWrite({ offline, apply, script: "stamp:project-id" })) return;
+
+  const loaded = await loadDocuments({ offline, snapshotPath });
+  if (loaded === null) return;
+  announceSnapshot(loaded);
+  const { documents } = loaded;
+
+  const roots = [...documents.entries()]
+    .filter(([id, data]) => data?.isProject === true && !isTrashBin(id) && !isAssetLibrary(id))
+    .map(([id]) => id);
+  console.log(`${roots.length} project roots.`);
+
+  // CLAIMED BY WHICH ROOT, tracked so a document reachable from two projects is
+  // reported rather than silently stamped with whichever walk ran last. That
+  // should be impossible — a collection belongs to exactly one parent, enforced
+  // by the orphan and duplicate-owner guards — so if it happens the data is
+  // already wrong and quietly picking a winner would hide it.
+  const claimedBy = new Map();
+  const contested = [];
+  for (const rootId of roots) {
+    for (const id of closureOf(documents, rootId)) {
+      const existing = claimedBy.get(id);
+      if (existing !== undefined && existing !== rootId) {
+        contested.push({ id, roots: [existing, rootId] });
+        continue;
+      }
+      claimedBy.set(id, rootId);
+    }
+  }
+
+  const pending = [];
+  for (const [id, rootId] of claimedBy) {
+    if (documents.get(id)?.projectId === rootId) continue;
+    pending.push({ id, projectId: rootId });
+  }
+
+  const unreachable = [...documents.keys()].filter(
+    (id) => !claimedBy.has(id) && !isTrashBin(id) && !isAssetLibrary(id),
+  );
+
+  console.log(`${pending.length} documents to stamp.`);
+  if (contested.length > 0) {
+    console.log(`\n${contested.length} document(s) reachable from TWO projects — NOT stamped:`);
+    for (const entry of contested) console.log(`  ${entry.id}: ${entry.roots.join(" and ")}`);
+    console.log("  A collection belongs to exactly one parent; this is data to fix, not to stamp.");
+  }
+  if (unreachable.length > 0) {
+    // Not an error: the trash and the asset library are excluded above, and a
+    // genuinely orphaned document is what `audit:orphans` is for.
+    console.log(`\n${unreachable.length} document(s) reachable from no project (left alone).`);
+  }
+
+  if (!apply) {
+    for (const entry of pending.slice(0, 20)) console.log(`  ${entry.id} -> ${entry.projectId}`);
+    if (pending.length > 20) console.log(`  … and ${pending.length - 20} more`);
+    dryRunNotice("stamp:project-id");
+    return;
+  }
+
+  const db = getFirestore();
+  let written = 0;
+  for (let at = 0; at < pending.length; at += MAX_BATCH_OPS) {
+    const chunk = pending.slice(at, at + MAX_BATCH_OPS);
+    const batch = db.batch();
+    for (const entry of chunk) {
+      // MERGE, and only this field. These documents are live; a full set would
+      // race an editor and overwrite real work with a snapshot read minutes ago.
+      batch.set(db.collection(COLLECTION).doc(entry.id), { projectId: entry.projectId }, { merge: true });
+    }
+    await batch.commit();
+    written += chunk.length;
+    console.log(`  committed ${written}/${pending.length}`);
+  }
+  console.log(`Stamped ${written} document(s).`);
+}
+
+await main();


### PR DESCRIPTION
The three commits from #459 that auto-merge left behind. #459 landed only the two logging commits — it was armed early, and every push after that merged the older head. Nothing here changed since it was measured; it is the same work, re-proposed.

## The waterfall

The closure walk can only ask for a level once the previous level's documents have named it, so latency was proportional to **depth**: nine sequential rounds for the 143-document project, independent of how wide it is. A query addresses documents by attribute instead of by walking to them, so it needs nobody's answer first.

Measured live, walk first so the query could not benefit from anything it warmed:

```
walk    3025ms   148 documents read   9 requests over 9 sequential rounds
query    784ms   143 documents read   1 request  over 1 round

walk found 143, query found 143 — 0 unstamped, 0 stale
```

**3.9× faster, and five reads cheaper** — the walk pays for five dangling references (a `get()` on a missing document is still billed); the query does not return them.

## The property that makes it safe

**`projectId` is a hint; the walk still decides.** The query primes the shared reader's inflight map and the *unchanged* walk resolves from memory. Anything the prime missed — a stale hint, an unstamped document — the walk fetches exactly as before. A wrong hint costs latency, never a wrong board.

That is also why accepting the field from a client is acceptable: nothing reads it to decide what a project *contains*, so a client sending the wrong one could only mis-file its own documents into its own other project's prefetch. The route still validates it as a user-scoped id.

Ordering cost a bug on the way: the prime runs **before** the root read, so the root arrives in the same query. After it, this would have been a second sequential round to save nine. It is idempotent because both `serveTimelineClosure` and the walk ask.

## Also here

- **The trash is read alongside the closure, not after it** — a separate root that depended on nothing, awaited behind all nine levels. 10 sequential rounds → 9, with no data-model change.
- **`projectId` stamped batch-wide on write**, via `bindProject` on the gateway. Omitting it leaves the stored value alone, so the MCP tools and trash routes cannot erase a correct hint. Backfill run against production: **169 documents stamped, 4 roots, 49 reachable from no project** (left alone).

## Known limit, stated rather than buried

**Not a flat one round.** A query cannot return documents that do not exist, so the five dangling ids are found uncached and fetched at whatever level they appear. One gap-filling batch after the prime would collapse that too — a contained follow-up.

## Verified

`tsc` clean · lint 0 errors · **1304** unit · **178** e2e · `measure-project-query-vs-closure-walk.mjs` ships with it and asserts the query and the walk find the same documents, so future drift surfaces as a number rather than a mystery.

Closes #458.