### PR TITLE
The Cloudinary listing was 98% of the board load

### DIFF
--- a/apps/timeline-gstudio001/lib/cloudinary-media-store.test.ts
+++ b/apps/timeline-gstudio001/lib/cloudinary-media-store.test.ts
@@ -150,3 +150,69 @@ describe("Cloudinary project folders", () => {
     expect(((at(requests, 1).body as FormData).get("file") as Blob).size).toBe(1);
   });
 });
+
+describe("the asset listing must not block a render", () => {
+  /** A listing that never answers, standing in for the slow paginated call. */
+  const hangingFetch = () => {
+    let started = 0;
+    vi.stubGlobal(
+      "fetch",
+      (async () => {
+        started += 1;
+        return new Promise<Response>(() => {});
+      }) as typeof fetch,
+    );
+    return () => started;
+  };
+
+  it("gives up on a COLD listing rather than holding the render", async () => {
+    // Measured on a real board open: 1844ms of a 1887ms serve, for a listing
+    // that only feeds a best-effort repair. An empty list means "nothing to
+    // repair against", and the document passes through untouched.
+    const started = hangingFetch();
+    vi.useFakeTimers();
+    try {
+      const pending = listCloudinaryAssets("user-cold", "project-a");
+      await vi.advanceTimersByTimeAsync(500);
+      expect(await pending).toEqual([]);
+      // It still ASKED — the refresh it started is what populates the cache for
+      // the next load. Giving up on waiting is not giving up on fetching.
+      expect(started()).toBeGreaterThan(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("serves a STALE listing immediately instead of re-learning it", async () => {
+    // Warm the cache with a real answer.
+    vi.stubGlobal(
+      "fetch",
+      (async (input: string | URL | Request) => {
+        if (String(input).endsWith("/resources/search")) return Response.json({ resources: [] });
+        return Response.json({
+          resources: [
+            {
+              public_id: "timeline-gstudio001/user-stale/project-a/Scenes/frame-1",
+              resource_type: "image",
+              secure_url: "https://cdn.test/frame-1.png",
+            },
+          ],
+        });
+      }) as typeof fetch,
+    );
+    const first = await listCloudinaryAssets("user-stale", "project-a");
+    expect(first).toHaveLength(1);
+
+    // Expire it, then make any refresh hang. The stale answer must come back
+    // WITHOUT waiting on that: the entry expiring does not make it wrong —
+    // uploads and deletes invalidate this cache explicitly.
+    vi.setSystemTime(Date.now() + 10 * 60_000);
+    hangingFetch();
+    const stale = await Promise.race([
+      listCloudinaryAssets("user-stale", "project-a"),
+      new Promise((resolve) => setTimeout(() => resolve("blocked"), 50)),
+    ]);
+    expect(stale).not.toBe("blocked");
+    expect(stale).toHaveLength(1);
+  });
+});

--- a/apps/timeline-gstudio001/lib/cloudinary-media-store.ts
+++ b/apps/timeline-gstudio001/lib/cloudinary-media-store.ts
@@ -322,7 +322,21 @@ async function searchCloudinaryVideos(
 // PROMISE also dedupes the burst: concurrent callers share one in-flight
 // listing. Uploads and deletes invalidate, so a fresh listing follows any
 // change a user makes through this app.
-const ASSET_LIST_TTL_MS = 60_000;
+const ASSET_LIST_TTL_MS = 300_000;
+
+/**
+ * How long a COLD listing may block a render before it is given up on.
+ *
+ * Measured on a real board open: the listing took 1844ms of a 1887ms serve —
+ * 98% of it — for 311 assets, while the closure walk it sat beside took 35ms.
+ * It is fetched to HEAL the root document's `src` urls, which is a repair, not
+ * the content; a render that skips it shows what is stored, and the refresh it
+ * started still populates the cache for the next one.
+ *
+ * So the trade is explicit: at worst one load's thumbnails go unrepaired,
+ * instead of every cold load costing two seconds.
+ */
+const COLD_ASSET_LIST_WAIT_MS = 400;
 const assetListCache = new Map<string, { at: number; promise: Promise<CloudinaryAsset[]> }>();
 
 const assetListCacheKey = (userId: string, projectId?: string) =>
@@ -359,9 +373,34 @@ export async function listCloudinaryAssets(userId: string, projectId?: string) {
 
   const promise = listCloudinaryAssetsUncached(userId, projectId);
   assetListCache.set(key, { at: Date.now(), promise });
-  // Failures are never cached — the next caller retries immediately.
-  promise.catch(() => assetListCache.delete(key));
-  return promise;
+  // Failures are never cached — the next caller retries immediately. A failed
+  // REFRESH puts the stale entry back rather than deleting it: an answer from
+  // five minutes ago beats none, and deleting would make the next caller pay
+  // the cold path for a listing we already have.
+  promise.catch(() => {
+    if (assetListCache.get(key)?.promise === promise) {
+      if (cached) assetListCache.set(key, cached);
+      else assetListCache.delete(key);
+    }
+  });
+
+  // STALE IS SERVED IMMEDIATELY while the refresh runs behind it. The entry
+  // expiring does not mean it is wrong — uploads and deletes invalidate this
+  // cache explicitly, so the TTL is a backstop against drift from outside the
+  // app, not the thing keeping it correct. Blocking a render on it was costing
+  // 1844ms to re-learn something that had not changed.
+  if (cached) return cached.promise;
+
+  // COLD: nothing to serve, so wait — but not indefinitely. Losing the race
+  // yields an empty list, which `healTimelineDocument` treats as "nothing to
+  // repair against" and passes the document through untouched.
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const bounded = new Promise<CloudinaryAsset[]>((resolve) => {
+    timer = setTimeout(() => resolve([]), COLD_ASSET_LIST_WAIT_MS);
+  });
+  return Promise.race([promise, bounded]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
 }
 
 async function listCloudinaryAssetsUncached(userId: string, projectId?: string) {

--- a/apps/timeline-gstudio001/lib/graph-rsc-payloads.ts
+++ b/apps/timeline-gstudio001/lib/graph-rsc-payloads.ts
@@ -70,6 +70,8 @@ export async function loadGraphBootstrapPayloads(
     //
     // A closure too large to walk returns null, and the caller falls back to
     // the project alone — the old behaviour, which still works, just slower.
+    const probing = process.env.GSTUDIO_COUNT_READS === "1";
+    const startedAt = Date.now();
     const read = createTimelineEntryReader(requesterUid);
     // TOGETHER, because the trash is not under the project and never was.
     //
@@ -97,6 +99,7 @@ export async function loadGraphBootstrapPayloads(
         missing: [],
       };
     }
+    if (probing) console.log(`[SERVEPROBE] bootstrap total ${Date.now() - startedAt}ms`);
     // forUid lets the client's prime refuse payloads that survive an auth
     // transition in the router cache.
     return {

--- a/apps/timeline-gstudio001/lib/serve-timeline.ts
+++ b/apps/timeline-gstudio001/lib/serve-timeline.ts
@@ -259,12 +259,34 @@ export async function serveTimelineClosure(
   // BEFORE the root read, so the root arrives in the same query as everything
   // else. After it, this would be a second sequential round trip to save nine —
   // still a win, but a needless one when the ordering is free.
+  // PHASE TIMINGS, behind the read counter's own flag.
+  //
+  // Added because a board render reporting "application-code: 1525ms" looked
+  // like a data problem for a whole evening, and was not: warm, this serve is
+  // 60ms of a 339ms request — 43ms walk, 2ms derive, 1ms heal — and the 1525ms
+  // belonged to a COLD render compiling the route (`next.js: 2.2s` on the same
+  // line). One line of log now answers what took an evening to guess at.
+  //
+  // Kept rather than deleted for that reason: the numbers are small, so the
+  // next person who suspects this path can rule it out in one load instead of
+  // instrumenting it again.
+  const probing = process.env.GSTUDIO_COUNT_READS === "1";
+  const mark = (label: string, since: number) => {
+    if (probing) console.log(`[SERVEPROBE] ${label} ${Date.now() - since}ms`);
+    return Date.now();
+  };
+  let at = Date.now();
+
   await read.prefetchProject?.(id).catch(() => 0);
+  at = mark("prefetch", at);
   const entry = await read(id);
   if (!entry) return null;
+  at = mark("root read", at);
 
   const cloudinaryAssets = await listCloudinaryAssets(requesterUid).catch(() => []);
+  at = mark(`cloudinary list (${cloudinaryAssets.length} assets)`, at);
   const { document: healedDocument } = healTimelineDocument(entry.document, cloudinaryAssets);
+  at = mark("heal root", at);
 
   const closure = await loadTimelineClosure(id, requesterUid, {
     rootEntry: entry,
@@ -276,16 +298,19 @@ export async function serveTimelineClosure(
   if (closure === null) return null;
 
   const missing = new Set(closure.missing);
+  at = mark("closure walk", at);
   const summarized = deriveClosureSummaries(
     { ...closure.documents, [id]: healedDocument },
     missing,
   );
 
   const documents: Record<string, ServedTimeline> = {};
+  at = mark("derive summaries", at);
   for (const [documentId, document] of Object.entries(summarized)) {
     if (missing.has(documentId)) continue;
     documents[documentId] = { document, revision: closure.revisions[documentId] ?? 0 };
   }
+  mark("heal + assemble", at);
   return { documents, missing: [...missing] };
 }
 

--- a/apps/timeline-gstudio001/lib/serve-timeline.ts
+++ b/apps/timeline-gstudio001/lib/serve-timeline.ts
@@ -254,7 +254,9 @@ export async function serveTimelineClosure(
   documents: Record<string, ServedTimeline>;
   missing: string[];
 }> | null> {
-  // ONE reader for the whole walk — the property this endpoint exists for.
+  // ONE reader for the whole walk — the property this endpoint exists for, and
+  // what makes a document read for its parent's summaries free when it becomes
+  // a payload of its own.
   const read = createTimelineEntryReader(requesterUid);
   // BEFORE the root read, so the root arrives in the same query as everything
   // else. After it, this would be a second sequential round trip to save nine —
@@ -283,22 +285,28 @@ export async function serveTimelineClosure(
   if (!entry) return null;
   at = mark("root read", at);
 
-  const cloudinaryAssets = await listCloudinaryAssets(requesterUid).catch(() => []);
-  at = mark(`cloudinary list (${cloudinaryAssets.length} assets)`, at);
-  const { document: healedDocument } = healTimelineDocument(entry.document, cloudinaryAssets);
-  at = mark("heal root", at);
+  // STARTED, not awaited. The listing feeds the root's heal and nothing else,
+  // so it has no bearing on the walk — and it was awaited in front of it,
+  // putting a network call to Cloudinary on the critical path ahead of work
+  // that never needed it. Measured before this: 1844ms of an 1887ms serve.
+  const assets = listCloudinaryAssets(requesterUid).catch(() => []);
 
-  const closure = await loadTimelineClosure(id, requesterUid, {
-    rootEntry: entry,
-    read,
-  }).catch((error: unknown) => {
-    if (error instanceof TimelineClosureTooLargeError) return null;
-    throw error;
-  });
+  const [cloudinaryAssets, closure] = await Promise.all([
+    assets,
+    loadTimelineClosure(id, requesterUid, {
+      rootEntry: entry,
+      read,
+    }).catch((error: unknown) => {
+      if (error instanceof TimelineClosureTooLargeError) return null;
+      throw error;
+    }),
+  ]);
   if (closure === null) return null;
+  at = mark(`walk + cloudinary list (${cloudinaryAssets.length} assets), in parallel`, at);
 
+  const { document: healedDocument } = healTimelineDocument(entry.document, cloudinaryAssets);
   const missing = new Set(closure.missing);
-  at = mark("closure walk", at);
+  at = mark("heal root", at);
   const summarized = deriveClosureSummaries(
     { ...closure.documents, [id]: healedDocument },
     missing,


### PR DESCRIPTION
Phase timings on a **warm** render — `next.js: 16ms`, nothing compiling:

```
[SERVEPROBE] prefetch                         3ms
[SERVEPROBE] root read                        1ms
[SERVEPROBE] cloudinary list (311 assets)  1844ms   ←
[SERVEPROBE] heal root                        1ms
[SERVEPROBE] closure walk                    35ms
[SERVEPROBE] derive summaries                 2ms
[SERVEPROBE] bootstrap total               1887ms
```

An HTTP call to Cloudinary, on the critical path, for a listing that feeds a best-effort repair of the **root document only** — sitting in front of a closure walk that takes 35ms. Every round trip removed from that walk this week was worth a fiftieth of the line above it.

## Three things were wrong

**A hard TTL with no stale fallback.** Sixty seconds after any listing, the next *render* paid a full paginated re-fetch to re-learn 311 assets that had not changed. Stale is served immediately now and the refresh runs behind it, so an expired entry costs nothing. That is also why the TTL moves to five minutes — uploads and deletes invalidate this cache **explicitly**, so the TTL is a backstop against drift from outside the app, not the thing keeping it correct.

**A cold miss could block indefinitely.** Bounded at 400ms; losing that race yields an empty list, which `healTimelineDocument` reads as "nothing to repair against" and passes the document through untouched. The fetch is not abandoned — it still populates the cache for the next load. The trade is explicit: at worst one render's thumbnails go unrepaired, instead of every cold render costing two seconds.

**It was awaited in front of the walk.** It has no bearing on the closure, so it now runs alongside — the same critical-path mistake as the trash read, made twice in the same function.

A failed refresh restores the stale entry rather than deleting it: an answer from five minutes ago beats none, and deleting would send the next caller down the cold path for a listing we already have.

## Also here: the phase timings themselves

Kept behind `GSTUDIO_COUNT_READS`, because they are what found this. They also correct the record on a number I misread twice: a render reporting `application-code: 1525ms` was **cold** (`next.js: 2.2s` beside it), not a steady-state cost — warm and cache-hit, this serve is 60ms of a 339ms request.

## Tests

Both new ones fail against the old code by **timing out**, which is the right shape of failure for "this used to block".

`tsc` clean · lint 0 errors · **1306** unit · **178** e2e.

---

Found late, and worth recording why: I had decided the problem was read volume and spent the week optimising the walk — 150 round trips to 1, all real, all measured, all ~2% of the load. The probe that found this took ten minutes and should have come first.