### PR TITLE
Fetch a project's board when the pointer settles on its card

### DIFF
--- a/apps/timeline-gstudio001/app/page.tsx
+++ b/apps/timeline-gstudio001/app/page.tsx
@@ -18,6 +18,7 @@ import { Button } from "@/components/core/button";
 import { Skeleton } from "@/components/core/skeleton";
 import { toast } from "@/components/core/sonner";
 import { LoadProjectButton } from "@/components/projects/load-project-button";
+import { useHoverPrefetch } from "@/components/projects/use-hover-prefetch";
 import { cn } from "@/lib/utils";
 
 type TimelineProjectSummary = {
@@ -67,6 +68,7 @@ function ProjectCardSkeleton() {
 
 export default function Home() {
   const router = useRouter();
+  const hoverPrefetch = useHoverPrefetch();
   const [projects, setProjects] = useState<TimelineProjectSummary[]>([]);
   const [projectTitle, setProjectTitle] = useState("");
   const [isLoading, setIsLoading] = useState(true);
@@ -311,9 +313,22 @@ export default function Home() {
           </div>
         ) : (
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-            {projects.map((project) => (
+            {projects.map((project) => {
+              const href = `/timeline/${encodeURIComponent(project.id)}/graph`;
+              return (
               <div
                 key={project.id}
+                // FETCH ON INTENT. The Link below already prefetches the
+                // skeleton on viewport entry, which costs nothing; this fetches
+                // the BOARD once the pointer settles, so the click has nothing
+                // left to wait for. See `useHoverPrefetch` for why this is not
+                // `<Link prefetch>`: that fires on viewport entry, and a full
+                // prefetch is 149 Firestore reads per card.
+                onMouseEnter={() => hoverPrefetch.onEnter(href)}
+                onMouseLeave={() => hoverPrefetch.onLeave(href)}
+                // Keyboard users get the same head start on focus — the anchor
+                // is inside this box, so focus bubbles to it.
+                onFocus={() => hoverPrefetch.onEnter(href)}
                 className="relative group overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900/55 shadow-xl shadow-black/20 transition-all duration-200 hover:border-blue-500/55 hover:bg-zinc-900"
               >
                 {/* Link overlay covering the whole card area. It NEEDS a name:
@@ -323,7 +338,7 @@ export default function Home() {
                     (WCAG 2.4.4). The visible <h3> below is a heading, not this
                     control's label. */}
                 <Link
-                  href={`/timeline/${encodeURIComponent(project.id)}/graph`}
+                  href={href}
                   className="absolute inset-0 z-10 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                 >
                   <span className="sr-only">Open project {project.title}</span>
@@ -378,7 +393,8 @@ export default function Home() {
                   </div>
                 </div>
               </div>
-            ))}
+            );
+            })}
           </div>
         )}
       </section>

--- a/apps/timeline-gstudio001/components/projects/use-hover-prefetch.test.ts
+++ b/apps/timeline-gstudio001/components/projects/use-hover-prefetch.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const prefetch = vi.fn();
+vi.mock("next/navigation", () => ({ useRouter: () => ({ prefetch }) }));
+
+import { HOVER_PREFETCH_DELAY_MS, useHoverPrefetch } from "./use-hover-prefetch";
+
+/**
+ * The hover-intent RULES, which is the part worth pinning here.
+ *
+ * What this cannot cover is whether a prefetch actually reaches the network —
+ * that is Next's router, a real browser, and a real deployment. The reason to
+ * test the rules at all is that each one exists to stop a Firestore bill: a
+ * full prefetch of a project is a complete server render, measured at 149
+ * reads, so "fires once", "does not fire on a pass-through" and "does not fire
+ * twice for the same card" are each worth ~149 reads of correctness.
+ *
+ * Driven through the hook's returned callbacks rather than a rendered
+ * component, because the app's vitest project is node-env and cannot parse TSX
+ * — see the note in CLAUDE.md. The hook is plain functions over refs, so the
+ * callbacks are the whole surface.
+ */
+vi.mock("react", async () => {
+  const actual = await vi.importActual<typeof import("react")>("react");
+  const refs = new Map<number, { current: unknown }>();
+  let index = 0;
+  return {
+    ...actual,
+    useRef: <T,>(initial: T) => {
+      const key = index++;
+      if (!refs.has(key)) refs.set(key, { current: initial });
+      return refs.get(key) as { current: T };
+    },
+    useCallback: <T,>(fn: T) => fn,
+    useEffect: (fn: () => void) => {
+      void fn;
+    },
+    __resetHookState: () => {
+      refs.clear();
+      index = 0;
+    },
+  };
+});
+
+const resetHookState = async () => {
+  const react = (await import("react")) as unknown as { __resetHookState: () => void };
+  react.__resetHookState();
+};
+
+beforeEach(async () => {
+  vi.useFakeTimers();
+  prefetch.mockClear();
+  await resetHookState();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useHoverPrefetch", () => {
+  it("fetches the board once the pointer settles", async () => {
+    const { onEnter } = useHoverPrefetch();
+    onEnter("/timeline/project-a/graph");
+
+    // Nothing yet: a cursor crossing a card must not spend a server render.
+    expect(prefetch).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(HOVER_PREFETCH_DELAY_MS);
+    expect(prefetch).toHaveBeenCalledTimes(1);
+    // FULL, not the default — `auto` is what the Link already did, and asking
+    // again would spend a request to re-fetch the same skeleton.
+    expect(prefetch).toHaveBeenCalledWith("/timeline/project-a/graph", { kind: "full" });
+  });
+
+  it("does not fetch a card the pointer only passed over", async () => {
+    // The case the delay exists for: sweeping across a grid to reach one card
+    // crosses every card before it, and each crossing would otherwise be 149
+    // Firestore reads.
+    const { onEnter, onLeave } = useHoverPrefetch();
+    onEnter("/timeline/project-a/graph");
+    await vi.advanceTimersByTimeAsync(HOVER_PREFETCH_DELAY_MS - 40);
+    onLeave("/timeline/project-a/graph");
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(prefetch).not.toHaveBeenCalled();
+  });
+
+  it("fetches a card at most once, however often it is hovered", async () => {
+    const { onEnter, onLeave } = useHoverPrefetch();
+    onEnter("/timeline/project-a/graph");
+    await vi.advanceTimersByTimeAsync(HOVER_PREFETCH_DELAY_MS);
+    onLeave("/timeline/project-a/graph");
+
+    // Back and forth between two cards is the ordinary way someone reads this
+    // page, and it must not re-bill the first one.
+    onEnter("/timeline/project-a/graph");
+    await vi.advanceTimersByTimeAsync(HOVER_PREFETCH_DELAY_MS);
+
+    expect(prefetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats each project separately", async () => {
+    const { onEnter } = useHoverPrefetch();
+    onEnter("/timeline/project-a/graph");
+    onEnter("/timeline/project-b/graph");
+    await vi.advanceTimersByTimeAsync(HOVER_PREFETCH_DELAY_MS);
+
+    expect(prefetch).toHaveBeenCalledTimes(2);
+    expect(prefetch.mock.calls.map((call) => call[0])).toEqual([
+      "/timeline/project-a/graph",
+      "/timeline/project-b/graph",
+    ]);
+  });
+});

--- a/apps/timeline-gstudio001/components/projects/use-hover-prefetch.ts
+++ b/apps/timeline-gstudio001/components/projects/use-hover-prefetch.ts
@@ -1,0 +1,81 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { PrefetchKind } from "next/dist/client/components/router-reducer/router-reducer-types";
+
+/** How long the pointer must rest on a card before its board is fetched.
+ *
+ *  Sweeping a cursor across a grid crosses every card on the way to one of
+ *  them, and each crossing would otherwise cost a full server render. The delay
+ *  is what separates "moving past" from "looking at", and it is short enough
+ *  that a deliberate hover still finishes the fetch before the click lands. */
+export const HOVER_PREFETCH_DELAY_MS = 120;
+
+/**
+ * Fetch a project's board when the pointer settles on its card.
+ *
+ * WHY NOT `prefetch` ON THE LINK. `<Link prefetch>` fires on VIEWPORT ENTRY,
+ * and a full prefetch of a project is a complete server render: the closure
+ * query, the trash, the dangling ids — 149 Firestore reads, measured. Every
+ * card on screen would pay that for merely being scrolled past:
+ *
+ *     4 project cards × 149 reads = ~600 reads to LOOK at the list
+ *
+ * which is the shape of the incident that started all of this (#437) rebuilt on
+ * purpose. The DEFAULT (`auto`) prefetch is safe precisely because it stops at
+ * the `loading.tsx` boundary and touches no data — that is what paints the
+ * skeleton instantly — but it leaves the board itself to be fetched on click,
+ * measured at ~926ms of server work in production.
+ *
+ * Hover is where those two meet: the full payload, but only once someone aims
+ * at a card. Intent usually becomes a click, so the read is rarely wasted, and
+ * `staleTimes.dynamic` (30s) keeps the result fresh long enough for the click
+ * to land on it.
+ *
+ * IT SCALES WITH THE LIST, which is the honest limit. Four cards is nothing; a
+ * page of fifty invites a user to spend reads while scanning. The delay is what
+ * keeps that bounded, and it is the number to revisit if the projects page ever
+ * grows.
+ */
+export function useHoverPrefetch() {
+  const router = useRouter();
+  const timers = useRef(new Map<string, ReturnType<typeof setTimeout>>());
+  // Prefetched THIS mount, so re-entering a card does not re-ask. Next's own
+  // router cache would mostly absorb a repeat, but only within its window and
+  // only after the first has landed — a user moving back and forth between two
+  // cards can outrun it.
+  const requested = useRef(new Set<string>());
+
+  useEffect(() => {
+    const pending = timers.current;
+    return () => {
+      for (const timer of pending.values()) clearTimeout(timer);
+      pending.clear();
+    };
+  }, []);
+
+  const onEnter = useCallback(
+    (href: string) => {
+      if (requested.current.has(href) || timers.current.has(href)) return;
+      const timer = setTimeout(() => {
+        timers.current.delete(href);
+        requested.current.add(href);
+        // FULL, not the default. `auto` is what the Link already does; asking
+        // for it again here would spend a request to re-fetch the same shell.
+        router.prefetch(href, { kind: PrefetchKind.FULL });
+      }, HOVER_PREFETCH_DELAY_MS);
+      timers.current.set(href, timer);
+    },
+    [router],
+  );
+
+  const onLeave = useCallback((href: string) => {
+    const timer = timers.current.get(href);
+    if (timer === undefined) return;
+    clearTimeout(timer);
+    timers.current.delete(href);
+  }, []);
+
+  return { onEnter, onLeave };
+}


### PR DESCRIPTION
Clicking a project costs a full server render — measured **in production** at **926ms** warm, **1549ms** on a cold container. `<Link>`'s default prefetch does not help: it is `auto`, which stops at the `loading.tsx` boundary, so it fetches the skeleton and no data. That is exactly why the board paints a skeleton instantly and then waits.

## Why not `prefetch={true}`

It fetches the real payload — and fires on **viewport entry**. A full prefetch of a project is a complete server render:

```
4 project cards × 149 reads = ~600 reads to LOOK at the list
```

That is the incident this whole thread started from (#437) rebuilt on purpose.

## Hover instead

The full payload, but only once someone aims at a card. Intent usually becomes a click, so the read is rarely wasted — and `staleTimes.dynamic` (30s) keeps the result fresh long enough for the click to land on it. That part is already **verified in production**: a revisit inside 30 seconds produced no server render at all.

**120ms of intent** before firing. Sweeping a cursor across a grid crosses every card on the way to one of them, and each crossing would otherwise be 149 reads. Leaving cancels it. Focus fires it too, so keyboard users get the same head start.

**Deduped per mount.** Next's router cache would mostly absorb a repeat, but only within its window and only after the first has landed — a user moving back and forth between two cards can outrun it.

**It scales with the list**, which is the honest limit: four cards is nothing, fifty invites a user to spend reads while scanning. The delay is what bounds that, and it is the number to revisit if the projects page grows.

## Tests

Four, on the rules, each proven to fail against the guard it covers — remove the delay and the pass-through test fails; remove the dedupe and the repeat-hover test fails.

What they **cannot** cover is whether a prefetch reaches the network: that is Next's router in a real browser against a real deployment. That gets checked by hovering on the live site and reading the function logs for a `[SERVEPROBE]` block arriving *before* the click.

`tsc` clean · lint 0 errors · **1299** unit.