### PR TITLE
Bound the board's reads, and show only numbers it can stand behind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ apps/backend/venv/
 apps/backend/.venv/
 __pycache__/
 *.pyc
+.vercel

--- a/apps/timeline-gstudio001/app/api/timelines/[id]/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/[id]/route.ts
@@ -16,7 +16,11 @@ import {
 // Demo-content seed for the GET fallback — deliberately still the UI
 // package's fixture set, not model logic.
 import { getTimelineDocument } from "@storyboard/ui/timeline/timeline-documents";
-import { serveTimelineDocument, serveTrashDocument } from "@/lib/serve-timeline";
+import {
+  BOARD_OPEN_MAX_DEPTH,
+  serveTimelineDocument,
+  serveTrashDocument,
+} from "@/lib/serve-timeline";
 import { checkUserScopedId, TimelineAccessDeniedError } from "@/lib/timeline-ownership";
 import { clientFacingStorageMessage } from "@/lib/firestore-failure";
 
@@ -78,7 +82,13 @@ export async function GET(
 
     // Heal + read-time summary derivation live in lib/serve-timeline — the
     // ONE serve path this route shares with the RSC payload loaders.
-    const served = await serveTimelineDocument(id, user.uid);
+    // The drill-in hydrate. Bounded for the same reason the board open is:
+    // this route's job is to hand the client one document, and deriving its
+    // summaries across the whole subtree below it is what made hydrating a
+    // project cost more than loading it (#437).
+    const served = await serveTimelineDocument(id, user.uid, undefined, {
+      maxDepth: BOARD_OPEN_MAX_DEPTH,
+    });
     if (served) {
       return NextResponse.json({ document: served.document, revision: served.revision });
     }

--- a/apps/timeline-gstudio001/app/api/timelines/batch-get/route.ts
+++ b/apps/timeline-gstudio001/app/api/timelines/batch-get/route.ts
@@ -6,6 +6,7 @@ import { readJsonObject } from "@/lib/read-json-body";
 import { getTimelineDocument } from "@storyboard/ui/timeline/timeline-documents";
 import {
   createTimelineEntryReader,
+  BOARD_OPEN_MAX_DEPTH,
   serveTimelineDocument,
   serveTrashDocument,
 } from "@/lib/serve-timeline";
@@ -126,7 +127,9 @@ export async function POST(request: Request) {
             return { id, error: "Invalid timeline id.", status: 400 };
           }
 
-          const served = await serveTimelineDocument(id, user.uid, read);
+          const served = await serveTimelineDocument(id, user.uid, read, {
+            maxDepth: BOARD_OPEN_MAX_DEPTH,
+          });
           if (served) {
             return { id, document: served.document, revision: served.revision };
           }

--- a/apps/timeline-gstudio001/app/timeline/[timelineId]/loading.tsx
+++ b/apps/timeline-gstudio001/app/timeline/[timelineId]/loading.tsx
@@ -1,41 +1,27 @@
-import { Skeleton } from "@/components/core/skeleton";
+import { GraphViewLoadingSkeleton } from "@/components/graph-view/graph-view-loading";
 
+/**
+ * The fallback while a project's LAYOUT loads — its session and boot payloads.
+ *
+ * IT HAS TO LIVE HERE, one segment up, and that is not obvious: a `loading.tsx`
+ * wraps its segment's PAGE and sits inside that segment's layout, so
+ * `graph/loading.tsx` could never cover `graph/layout.tsx`'s own await. Putting
+ * one there also renders a second skeleton BELOW the board on every drill-in,
+ * because the layout renders the board and then its children.
+ *
+ * Renders the same skeleton the dynamic-import fallback does, inside the same
+ * container classes `graph/layout.tsx` uses. Opening a project passes through
+ * both in sequence, and they used to look different — a bordered card grid with
+ * two text lines, then bare rounded rectangles — so the eight cards changed
+ * shape halfway through and it read as two loads instead of one.
+ */
 export default function TimelineLoading() {
   return (
     <div
-      aria-busy="true"
       aria-label="Loading project"
-      className="mx-auto grid w-full max-w-[1400px] gap-4"
+      className="graph-view-theme mx-auto flex w-full max-w-[1400px] flex-col gap-5"
     >
-      <section className="overflow-hidden rounded-xl border border-zinc-800 bg-zinc-950/50">
-        <div className="flex min-h-14 items-center justify-between gap-4 border-b border-zinc-800/70 px-4 py-3">
-          <div className="flex min-w-0 items-center gap-2">
-            <Skeleton className="h-4 w-24" />
-            <Skeleton className="h-4 w-4 rounded-full" />
-            <Skeleton className="h-4 w-36" />
-          </div>
-          <div className="flex items-center gap-2">
-            <Skeleton className="h-8 w-8" />
-            <Skeleton className="h-8 w-24" />
-            <Skeleton className="h-8 w-8" />
-          </div>
-        </div>
-
-        <div className="grid gap-4 p-4">
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
-            {Array.from({ length: 8 }, (_, index) => (
-              <div
-                key={index}
-                className="grid gap-2 rounded-lg border border-zinc-800/80 bg-zinc-950/70 p-2"
-              >
-                <Skeleton className="aspect-video w-full" />
-                <Skeleton className="h-4 w-3/4" />
-                <Skeleton className="h-3 w-1/2" />
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
+      <GraphViewLoadingSkeleton />
     </div>
   );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -110,6 +110,7 @@ import {
   useSelectionCount,
   type PreviewTimeChannel,
 } from "./graph-preview";
+import { useCollectionSubtreeHydrated } from "./graph-card-derivations";
 import { splitLaneRows } from "./graph-lane-rows";
 import { AddCollectionSlot } from "./graph-add-collection-slot";
 import { CollectionHoverProvider } from "./graph-collection-hover";
@@ -383,6 +384,13 @@ function FocusedAggregate({
   pixelsPerSecond,
 }: Readonly<{ focusedId: string; pixelsPerSecond: number }>) {
   const { count, seconds } = useFocusedTimelineAggregate(focusedId, pixelsPerSecond);
+  // The total sums this board's cards, so it inherits their uncertainty: a
+  // collection card whose branch is not loaded contributes a STORED summary,
+  // and those drift. The count is safe — it is this board's own children — so
+  // an unvouched board says "3 clips" and earns the time when its branches
+  // load. Measured before this: the root board claimed 23:21 against a true
+  // 21:55.
+  const vouched = useCollectionSubtreeHydrated(focusedId);
   if (count === 0) return null;
   return (
     <span
@@ -390,7 +398,8 @@ function FocusedAggregate({
       className="shrink-0 font-mono text-[11px] tabular-nums text-zinc-400"
       title="Focused timeline total"
     >
-      {count} {count === 1 ? "clip" : "clips"} · {formatDuration(seconds)}
+      {count} {count === 1 ? "clip" : "clips"}
+      {vouched ? <> · {formatDuration(seconds)}</> : null}
     </span>
   );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-card-derivations.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-card-derivations.ts
@@ -9,6 +9,7 @@ import {
   type NodeId,
 } from "@storyboard/ui/dnd-collections";
 import {
+  collectionSubtreeHydrated,
   hydratedCollectionPlayableDuration,
   hydratedCollectionPreviews,
   resolveCollectionPreviews,
@@ -182,6 +183,41 @@ export function useCollectionPreviewFrames(
  * when one of them really did. The rounded content key keeps sub-millisecond
  * recompute jitter from churning the value.
  */
+/**
+ * Whether this collection's readouts can be VOUCHED for — it and everything
+ * under it loaded.
+ *
+ * Separate from the card's `hydrated` flag, which only says its own children
+ * arrived. `useHydratedCollectionSeconds` will happily answer for a partly
+ * loaded tree by substituting stored summaries for the missing parts, and those
+ * summaries drift (58.4% of collection clips carry at least one stale field).
+ * This is what lets the card decline to show that answer.
+ *
+ * Recomputed on every graph or details change rather than cached: it is a walk
+ * of nodes already in memory, and it must flip the moment a branch finishes
+ * loading — that flip IS the number appearing.
+ */
+export function useCollectionSubtreeHydrated(id: string): boolean {
+  const store = useCollectionsStore();
+  const detailsStore = useGraphDetailsStore();
+  const getSnapshot = useCallback(
+    () => collectionSubtreeHydrated(store.getSnapshot().graph, detailsStore.read(), id as NodeId),
+    [store, detailsStore, id],
+  );
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      const unsubStore = store.subscribe(onChange);
+      const unsubDetails = detailsStore.subscribe(onChange);
+      return () => {
+        unsubStore();
+        unsubDetails();
+      };
+    },
+    [store, detailsStore],
+  );
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
 export function useHydratedCollectionSeconds(id: string, enabled: boolean): number | null {
   const store = useCollectionsStore();
   const detailsStore = useGraphDetailsStore();

--- a/apps/timeline-gstudio001/components/graph-view/graph-card-derivations.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-card-derivations.ts
@@ -238,7 +238,15 @@ export function useHydratedCollectionSeconds(id: string, enabled: boolean): numb
       // (`hydratedCollectionDuration`) still drives the clip's duration in the
       // projection, where the disabled slot has to survive.
       compute: (graph: CollectionsGraph, details: DetailsById, nodeId: NodeId) =>
-        hydratedCollectionPlayableDuration(graph, details, nodeId),
+        hydratedCollectionPlayableDuration(
+          graph,
+          details,
+          nodeId,
+          // A dangling reference contributes nothing to what plays. Without
+          // this the readout quotes the stored duration of a document that is
+          // gone — 33.9s of a real collection's 19:24.
+          graphDocumentsGateway.isKnownMissing,
+        ),
       contentKey: (seconds) => String(Math.round(seconds * 1000)),
     }),
   );

--- a/apps/timeline-gstudio001/components/graph-view/graph-card-derivations.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-card-derivations.ts
@@ -22,6 +22,7 @@ import { createDerivedCache } from "@/lib/derived-cache";
 import { graphClipboard } from "@/lib/graph-clipboard";
 import { graphPasteFlash } from "@/lib/graph-paste-flash";
 import { resolveCardProvenance } from "@/lib/card-provenance";
+import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 
 import { useGraphDetailsStore, useTimelineTitle } from "./graph-details-context";
 import { isDisabledByAncestor } from "./graph-playhead-model";
@@ -201,7 +202,16 @@ export function useCollectionSubtreeHydrated(id: string): boolean {
   const store = useCollectionsStore();
   const detailsStore = useGraphDetailsStore();
   const getSnapshot = useCallback(
-    () => collectionSubtreeHydrated(store.getSnapshot().graph, detailsStore.read(), id as NodeId),
+    () =>
+      collectionSubtreeHydrated(
+        store.getSnapshot().graph,
+        detailsStore.read(),
+        id as NodeId,
+        // The gateway is the only place that knows a document is GONE rather
+        // than merely unloaded — the server reports it and `ensureClosure`
+        // keeps the list.
+        graphDocumentsGateway.isKnownMissing,
+      ),
     [store, detailsStore, id],
   );
   const subscribe = useCallback(

--- a/apps/timeline-gstudio001/components/graph-view/graph-card-model.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-card-model.test.ts
@@ -205,58 +205,35 @@ describe("collectionCardItemCount", () => {
 });
 
 describe("collectionCardSeconds", () => {
-  it("uses live seconds once hydrated", () => {
-    expect(
-      collectionCardSeconds({
-        hydrated: true,
-        liveSeconds: 12.5,
-        storedPlayableDuration: 99,
-        storedDuration: 99,
-      }),
-    ).toBe(12.5);
+  /**
+   * THE RULE CHANGED, and deliberately: the card used to fall back to the
+   * clip's STORED summary whenever it was not hydrated, and those fallbacks
+   * were what these tests pinned.
+   *
+   * Stored summaries are wrong on 58.4% of collection clips, because the write
+   * set is patch-derived — editing a descendant never rewrites the ancestors it
+   * invalidated. That was survivable while every board open re-derived the
+   * whole closure (149 documents) and overwrote them on the way out. The board
+   * now reads one level, so the fallback would be showing numbers nothing had
+   * corrected: measured on a real project, two of three cards reported a
+   * duration up to 40 seconds wrong.
+   *
+   * A wrong number is worse than no number, because nobody can tell which ones
+   * are wrong. So the readout appears only when the whole subtree is loaded,
+   * and a card earns its time by being opened.
+   */
+  it("shows live seconds when the whole subtree is loaded", () => {
+    expect(collectionCardSeconds({ vouched: true, liveSeconds: 12.5 })).toBe(12.5);
   });
 
-  it("passes a hydrated null through rather than reaching for the stored summary", () => {
-    expect(
-      collectionCardSeconds({
-        hydrated: true,
-        liveSeconds: null,
-        storedPlayableDuration: 99,
-        storedDuration: 99,
-      }),
-    ).toBeNull();
+  it("shows nothing when any part of the subtree is missing", () => {
+    // The case the change exists for: the collection itself is loaded, but a
+    // descendant is not, so `liveSeconds` was computed by substituting that
+    // descendant's stored summary. Plausible, unverifiable, not shown.
+    expect(collectionCardSeconds({ vouched: false, liveSeconds: 209.65 })).toBeNull();
   });
 
-  it("prefers the stored PLAYABLE duration for a placeholder", () => {
-    expect(
-      collectionCardSeconds({
-        hydrated: false,
-        liveSeconds: null,
-        storedPlayableDuration: 8,
-        storedDuration: 20,
-      }),
-    ).toBe(8);
-  });
-
-  it("falls back to duration for documents saved before the two were split", () => {
-    expect(
-      collectionCardSeconds({
-        hydrated: false,
-        liveSeconds: null,
-        storedPlayableDuration: undefined,
-        storedDuration: 20,
-      }),
-    ).toBe(20);
-  });
-
-  it("is null when a placeholder carries no duration at all", () => {
-    expect(
-      collectionCardSeconds({
-        hydrated: false,
-        liveSeconds: null,
-        storedPlayableDuration: undefined,
-        storedDuration: undefined,
-      }),
-    ).toBeNull();
+  it("passes a vouched null through rather than inventing a zero", () => {
+    expect(collectionCardSeconds({ vouched: true, liveSeconds: null })).toBeNull();
   });
 });

--- a/apps/timeline-gstudio001/components/graph-view/graph-card-model.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-card-model.ts
@@ -170,14 +170,16 @@ export function collectionCardItemCount(
  */
 export function collectionCardSeconds(
   input: Readonly<{
-    hydrated: boolean;
+    /**
+     * Whether this collection AND everything under it is loaded —
+     * `collectionSubtreeHydrated`. Not the card's own `hydrated` flag, which
+     * only says its immediate children arrived.
+     */
+    vouched: boolean;
     liveSeconds: number | null;
-    storedPlayableDuration: number | undefined;
-    storedDuration: number | undefined;
   }>,
 ): number | null {
-  if (input.hydrated) return input.liveSeconds;
-  return input.storedPlayableDuration ?? input.storedDuration ?? null;
+  return input.vouched ? input.liveSeconds : null;
 }
 
 /**

--- a/apps/timeline-gstudio001/components/graph-view/graph-collection-card.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-collection-card.tsx
@@ -43,6 +43,7 @@ import {
   useDisabledByAncestor,
   useEnabledChildCount,
   useFirstChildIsAudio,
+  useCollectionSubtreeHydrated,
   useHydratedCollectionSeconds,
 } from "./graph-card-derivations";
 
@@ -85,12 +86,11 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
     enabledChildCount,
     storedItemCount: detail?.itemCount,
   });
-  const totalSeconds = collectionCardSeconds({
-    hydrated,
-    liveSeconds,
-    storedPlayableDuration: detail?.playableDuration,
-    storedDuration: detail?.duration,
-  });
+  // VOUCHED, not merely hydrated — see `collectionSubtreeHydrated`. A card
+  // whose branch is only partly loaded shows its item count and no time,
+  // rather than a plausible number derived from stale stored summaries.
+  const vouched = useCollectionSubtreeHydrated(id as string);
+  const totalSeconds = collectionCardSeconds({ vouched, liveSeconds });
   const previews = useCollectionPreviewFrames(id as string, hydrated, detail?.previewItems);
   const displayName = title ?? node.name;
   const inheritedDisabled = useDisabledByAncestor(id);

--- a/apps/timeline-gstudio001/components/graph-view/graph-collection-details.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-collection-details.tsx
@@ -19,9 +19,11 @@ import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
 import { ItemDisableToggle } from "./graph-item-disable-toggle";
 import {
   useCollectionPreviewFrames,
+  useCollectionSubtreeHydrated,
   useEnabledChildCount,
   useHydratedCollectionSeconds,
 } from "./graph-card-derivations";
+import { collectionCardSeconds } from "./graph-card-model";
 import { GraphViewNavContext } from "./graph-navigation";
 import { DETAILS_HERO_FILL_CLASS, DETAILS_PANEL_HEIGHT_CLASS } from "./graph-view-config";
 
@@ -66,8 +68,13 @@ export function CollectionDetailsBody({
   // Live numbers once loaded; the stored summary for a placeholder — the same
   // rule the card follows, so the two never disagree.
   const count = hydrated ? liveCount : (detail?.itemCount ?? liveCount);
-  const seconds =
-    (hydrated ? liveSeconds : (detail?.playableDuration ?? detail?.duration)) ?? 0;
+  // Same rule as the card, so the two cannot disagree about the same
+  // collection: a time is shown only when the whole subtree is loaded.
+  // Previously this fell back to the stored summary and then to ZERO, so an
+  // unloaded collection announced "0:00" — the most confident wrong answer
+  // available.
+  const vouched = useCollectionSubtreeHydrated(node.id as string);
+  const seconds = collectionCardSeconds({ vouched, liveSeconds });
   const previews = useCollectionPreviewFrames(node.id as string, hydrated, detail?.previewItems);
 
   const { dialogProps } = useDialogFocus<HTMLDivElement>();
@@ -146,7 +153,8 @@ export function CollectionDetailsBody({
           )}
           <div className="flex items-center gap-3">
             <span className="font-mono text-[11px] tabular-nums text-zinc-400">
-              {count} {count === 1 ? "item" : "items"} · {formatDuration(seconds)}
+              {count} {count === 1 ? "item" : "items"}
+              {seconds === null ? null : <> · {formatDuration(seconds)}</>}
             </span>
             <ItemDisableToggle nodeId={node.id as string} />
             <div className="flex items-center gap-1">

--- a/apps/timeline-gstudio001/components/graph-view/graph-hydration.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-hydration.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 import {
   getChildren,
@@ -343,11 +343,24 @@ export function BackgroundClosureHydrator({
 }: Readonly<{ projectId: string; enabled: boolean }>) {
   const store = useCollectionsStore();
   const detailsStore = useGraphDetailsStore();
+  // Once per project, however often the effect re-runs. The gateway dedupes
+  // the REQUEST, but the hydration walk below is main-thread work over every
+  // document in the closure — measured at ~517ms across three long tasks — and
+  // running it five times because React re-ran an effect is jank, not reads.
+  const done = useRef<string | null>(null);
 
   useEffect(() => {
     if (!enabled) return;
     let cancelled = false;
     const run = async () => {
+      // CLAIMED HERE, NOT AT EFFECT ENTRY, and the difference is the whole
+      // thing working. React runs an effect, tears it down and runs it again in
+      // development; a flag set on entry is claimed by the first run, whose
+      // scheduled work the teardown then cancels, and the second run declines
+      // because the flag is already set. Observed exactly that: zero closure
+      // requests and every card permanently timeless.
+      if (done.current === projectId) return;
+      done.current = projectId;
       // Best effort throughout: a failure here leaves the board exactly as it
       // was — correct, with fewer times shown — so nothing is reported.
       await graphDocumentsGateway.ensureClosure(projectId).catch(() => {});

--- a/apps/timeline-gstudio001/components/graph-view/graph-hydration.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-hydration.tsx
@@ -306,6 +306,77 @@ export async function hydrateClosure(
  * Re-runs on focus change as well as on entry: drilling into a different
  * collection while flat is on makes a different closure the subject.
  */
+/**
+ * How long after mount the background closure load starts.
+ *
+ * It is a "did they stay?" filter, not a paint optimisation. A board open now
+ * costs 5 reads; this pass costs the other ~149. Someone who opens the wrong
+ * project and leaves should not pay for it, and someone who stays will not
+ * notice a second.
+ */
+const BACKGROUND_CLOSURE_DELAY_MS = 1200;
+
+/**
+ * Load the rest of the project after first paint, so withheld times appear.
+ *
+ * The board reads one level (`BOARD_OPEN_MAX_DEPTH`), which is what took an
+ * open from 150 billed reads to 5 — but a collection card can only show its
+ * duration once its whole branch is loaded, so most cards start without one.
+ * This fills them in without a click.
+ *
+ * SAME BILL, EARLIER PAINT. The reads move off the critical path rather than
+ * disappearing: a session that stays pays about what it used to, and one that
+ * glances and leaves pays 5.
+ *
+ * THROUGH `ensureClosure`, NOT PER DOCUMENT, and that is the whole design.
+ * `hydrateTimeline` fetches one id at a time through `/api/timelines/[id]`,
+ * and that route runs `serveTimelineDocument`, which walks the closure BELOW
+ * that id to derive its summaries. Hydrating 145 documents that way re-creates
+ * the bug this all started from — measured at 58 requests and ~430 document
+ * reads for one board (#437). `ensureClosure` is one request served by one
+ * shared reader, so every document is read exactly once; the walk below then
+ * hydrates from a warm cache and issues no fetches at all.
+ */
+export function BackgroundClosureHydrator({
+  projectId,
+  enabled,
+}: Readonly<{ projectId: string; enabled: boolean }>) {
+  const store = useCollectionsStore();
+  const detailsStore = useGraphDetailsStore();
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    const run = async () => {
+      // Best effort throughout: a failure here leaves the board exactly as it
+      // was — correct, with fewer times shown — so nothing is reported.
+      await graphDocumentsGateway.ensureClosure(projectId).catch(() => {});
+      if (cancelled) return;
+      await hydrateClosure(store, detailsStore, projectId).catch(() => {});
+    };
+    // Idle if the browser offers it, with a timeout so a busy tab still gets
+    // there; a plain timer otherwise.
+    const idle = (window as unknown as {
+      requestIdleCallback?: (cb: () => void, options?: { timeout: number }) => number;
+    }).requestIdleCallback;
+    if (idle) {
+      const handle = idle(() => void run(), { timeout: BACKGROUND_CLOSURE_DELAY_MS * 2 });
+      return () => {
+        cancelled = true;
+        (window as unknown as { cancelIdleCallback?: (h: number) => void })
+          .cancelIdleCallback?.(handle);
+      };
+    }
+    const timer = setTimeout(() => void run(), BACKGROUND_CLOSURE_DELAY_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [projectId, enabled, store, detailsStore]);
+
+  return null;
+}
+
 export function FlatClosureHydrator({
   enabled,
   focusedId,

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -239,7 +239,12 @@ export const SingleFrame: Story = {
   play: async ({ canvasElement }) => {
     const images = previewImages(canvasElement);
     await expect(images).toHaveLength(1);
-    await expect(canvasElement).toHaveTextContent(/4\.0s\s*\/\s*1 item/);
+    // NO TIME on a placeholder. This fixture is un-hydrated, so the seconds
+    // could only come from the stored summary — and those are wrong on 58.4% of
+    // collection clips, with nothing on screen marking which. The count is
+    // still shown; the time arrives when the branch loads.
+    await expect(canvasElement).toHaveTextContent(/1 item/);
+    await expect(canvasElement.textContent ?? "").not.toContain("4.0s");
   },
 };
 
@@ -257,7 +262,12 @@ export const PlaceholderAriaCountMatchesBadge: Story = {
     const surface = canvasElement.querySelector<HTMLElement>("[data-node-id]")!;
     // The stored summary (itemCount 2), not the live childCount (0).
     await expect(surface.getAttribute("aria-label")).toBe("A timeline (collection, 2 items)");
-    await expect(canvasElement).toHaveTextContent(/8\.0s\s*\/\s*2 items/);
+    // The COUNT survives on a placeholder and the time does not, which is the
+    // asymmetry worth pinning: one level of reading settles a count exactly
+    // (measured 0/3 wrong), while a duration sums the whole subtree and cannot
+    // be known without it.
+    await expect(canvasElement).toHaveTextContent(/2 items/);
+    await expect(canvasElement.textContent ?? "").not.toContain("8.0s");
 
     const name = canvasElement.querySelector<HTMLElement>(
       '[title="Click or press F2 to rename"]',
@@ -958,7 +968,10 @@ export const DisabledCollection: Story = {
     await expect(getComputedStyle(metadata).filter).toBe("none");
     await expect(getComputedStyle(metadata).opacity).toBe("1");
     await expect(metadata.textContent).toContain("A timeline");
-    await expect(metadata.textContent).toContain("8.0s");
+    // The time is absent here for the same reason as the other placeholder
+    // stories, not because disabling hid it — the disabled CHIP and the
+    // metadata row are what this story is about, and both still render.
+    await expect(metadata.textContent).not.toContain("8.0s");
     await expect(metadata.textContent).toContain("2 items");
     // The corner drill control used to be checked here too (its glyph's stroke
     // weight). It is gone, and its Layers glyph survives as the caption's KIND
@@ -1950,5 +1963,114 @@ export const CollectionCheckboxAppearsInSelectMode: Story = {
     });
     await expect(indicator.dataset.selectionIndicatorReveal).toBe("armed");
     await expect(getComputedStyle(indicator).opacity).toBe("1");
+  },
+};
+
+/* ── Vouching: a card shows a time only when it can add one up ────────────── */
+
+const VOUCH_PARENT_ID = "vouch-parent" as NodeId;
+const VOUCH_KID_ID = "vouch-kid" as NodeId;
+
+/** A collection holding only MEDIA — everything its time depends on is in the
+ *  graph, so it can be added up exactly. 103 of 149 collections in the real
+ *  project look like this. */
+const mediaOnlyGraph = (() => {
+  const result = buildGraph([
+    {
+      kind: "collection",
+      id: VOUCH_PARENT_ID,
+      name: "Locations",
+      children: [
+        { kind: "media", id: "loc-a" as NodeId, name: "Alley", fullDurationSeconds: 4 },
+        { kind: "media", id: "loc-b" as NodeId, name: "Diner", fullDurationSeconds: 4 },
+      ],
+    },
+  ]);
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.value;
+})();
+
+/** The same card, but one child is a COLLECTION that has not loaded. Its
+ *  seconds are unknowable without reading that branch. */
+const nestedCollectionGraph = (() => {
+  const result = buildGraph([
+    {
+      kind: "collection",
+      id: VOUCH_PARENT_ID,
+      name: "Characters",
+      children: [{ kind: "collection", id: VOUCH_KID_ID, name: "Pat", children: [] }],
+    },
+  ]);
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.value;
+})();
+
+const detail = (over: Partial<ClipDetail>): ClipDetail => ({
+  alt: "A timeline",
+  aspect: 16 / 9,
+  hydrated: true,
+  itemCount: 2,
+  duration: 999,
+  previewItems: [],
+  ...over,
+});
+
+/** Renders as text like "8.1s" or "23:21" — either shape counts as a time. */
+const A_TIME = /\d+(\.\d+)?s|\d+:\d{2}/;
+
+const vouchDecorator =
+  (graph: CollectionsGraph, details: Record<string, ClipDetail>): Decorator =>
+  (Story) => (
+    <DndCollections initialGraph={graph}>
+      <GraphDetailsProvider store={createGraphDetailsStore(details)}>
+        <div className="h-32 w-40 bg-zinc-950 p-2">
+          <Story />
+        </div>
+      </GraphDetailsProvider>
+    </DndCollections>
+  );
+
+/**
+ * A collection whose branch is fully loaded SHOWS its time.
+ *
+ * The board reads one level (`BOARD_OPEN_MAX_DEPTH`), so a media-only
+ * collection arrives complete and can be added up exactly. This is the case
+ * that keeps the board from being uniformly timeless.
+ */
+export const VouchedCollectionShowsItsTime: Story = {
+  args: { ...baseArgs, id: VOUCH_PARENT_ID },
+  decorators: [
+    vouchDecorator(mediaOnlyGraph, { [VOUCH_PARENT_ID]: detail({ duration: 999 }) }),
+  ],
+  play: async ({ canvasElement }) => {
+    // NOT 999: the stored summary is deliberately absurd here, so a card
+    // reading it rather than its live children fails loudly.
+    await expect(canvasElement.textContent ?? "").toMatch(A_TIME);
+    await expect(canvasElement.textContent ?? "").not.toContain("999");
+  },
+};
+
+/**
+ * A collection with an unloaded branch shows its COUNT and no time.
+ *
+ * Previously it fell back to the stored summary, which drifts — measured on a
+ * real project, two of the three cards on the board reported a duration up to
+ * 40 seconds wrong, and nothing on screen distinguished them from the right
+ * one. A count is still exact (these are this collection's own children), so
+ * the card stays informative; the time arrives when the branch is opened.
+ */
+export const UnvouchedCollectionShowsCountOnly: Story = {
+  args: { ...baseArgs, id: VOUCH_PARENT_ID },
+  decorators: [
+    vouchDecorator(nestedCollectionGraph, {
+      [VOUCH_PARENT_ID]: detail({ itemCount: 1 }),
+      // The child that has not loaded — the reason the parent cannot add up.
+      [VOUCH_KID_ID]: detail({ hydrated: false, itemCount: 5, duration: 60 }),
+    }),
+  ],
+  play: async ({ canvasElement }) => {
+    const text = canvasElement.textContent ?? "";
+    await expect(text).toContain("1 item");
+    await expect(text).not.toMatch(A_TIME);
   },
 };

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -2018,9 +2018,14 @@ const detail = (over: Partial<ClipDetail>): ClipDetail => ({
 /** Renders as text like "8.1s" or "23:21" — either shape counts as a time. */
 const A_TIME = /\d+(\.\d+)?s|\d+:\d{2}/;
 
-const vouchDecorator =
-  (graph: CollectionsGraph, details: Record<string, ClipDetail>): Decorator =>
-  (Story) => (
+function vouchDecorator(
+  graph: CollectionsGraph,
+  details: Record<string, ClipDetail>,
+): Decorator {
+  // NAMED, not a bare arrow returned from a factory: `react/display-name`
+  // cannot infer a name for the latter, and it is an ERROR in this config —
+  // `renderWithDetail` above assigns to a named const for the same reason.
+  const WithVouchFixture: Decorator = (Story) => (
     <DndCollections initialGraph={graph}>
       <GraphDetailsProvider store={createGraphDetailsStore(details)}>
         <div className="h-32 w-40 bg-zinc-950 p-2">
@@ -2029,6 +2034,8 @@ const vouchDecorator =
       </GraphDetailsProvider>
     </DndCollections>
   );
+  return WithVouchFixture;
+}
 
 /**
  * A collection whose branch is fully loaded SHOWS its time.

--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -26,6 +26,7 @@ import {
 import {
   graphChildrenToClips,
   hydratedCollectionPlayableDuration,
+  hydratedCollectionPlayableSpan,
   manifestToClips,
   type DetailsById,
   type FlatItem,
@@ -161,7 +162,17 @@ export function useFocusedTimelineAggregate(
     // longer than the total claimed here whenever something is disabled.
     return {
       count: cards.filter((card) => card.disabled !== true).length,
-      seconds: playableSpanSeconds(cards),
+      // FROM THE GRAPH, not from the card spans. `playableSpanSeconds` measures
+      // what the strip DRAWS, and a card whose descendants are disabled keeps
+      // its full slot — so this readout claimed 23:01 while its own three cards
+      // summed to about 20:45. The spans carry no node id, so the playable
+      // length cannot be recovered from them; it has to be walked.
+      seconds: hydratedCollectionPlayableSpan(
+        graph,
+        details,
+        focusedId as NodeId,
+        graphDocumentsGateway.isKnownMissing,
+      ),
     };
   }, [graph, details, focusedId, spans, pixelsPerSecond, flatItems]);
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -62,7 +62,11 @@ import { laneDropIndex, splitLaneRows } from "./graph-lane-rows";
 import { withDefaultLayerFrame } from "./graph-layer-frame";
 import { GraphViewLoadingSkeleton } from "./graph-view-loading";
 import { GraphDetailsProvider } from "./graph-details-context";
-import { FlatClosureHydrator, HydrationController } from "./graph-hydration";
+import {
+  BackgroundClosureHydrator,
+  FlatClosureHydrator,
+  HydrationController,
+} from "./graph-hydration";
 import { GraphItemActionsBridge } from "./graph-item-actions";
 import { RemoteChangesBridge } from "./graph-remote-changes";
 import { McpToolsBridge } from "./graph-mcp-tools";
@@ -842,6 +846,10 @@ export function GraphTimelineView({
             serverPrimed={bootedFromServer}
             onFocusError={setFocusError}
           />
+          {/* Fills in the times the one-level board open cannot vouch for.
+              Disabled while FLAT mode is on, which loads the same closure for
+              its own reasons — two passes would race for the same documents. */}
+          <BackgroundClosureHydrator projectId={projectId} enabled={!flatOn} />
           {/* Flat mode needs the WHOLE closure loaded, not just the focus
               chain — mounted here because the collections store lives only
               inside the provider. */}

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-loading.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-loading.tsx
@@ -1,5 +1,23 @@
 import { Skeleton } from "@/components/core/skeleton";
 
+/**
+ * The board's stand-in while it loads.
+ *
+ * ONE SHAPE, RENDERED TWICE. Opening a project passes through two separate
+ * fallbacks: the route's `loading.tsx` while the graph LAYOUT awaits its
+ * session and boot payloads, and this one while the dynamic `GraphTimelineView`
+ * chunk arrives. They used to look different — a bordered card grid with two
+ * text lines, then bare rounded rectangles — so the eight cards visibly changed
+ * shape mid-load and it read as two separate loads rather than one.
+ *
+ * The layout renders no chrome of its own (see `graph/layout.tsx`), so both
+ * fallbacks stand in for the same pixels and there is no reason for them to
+ * differ. `graph/loading.tsx` renders this inside the layout's own container
+ * classes, which makes the handover invisible.
+ *
+ * The card carries a caption row because the real one does. A bare rectangle
+ * pops a second time when the board arrives and the captions appear.
+ */
 export function GraphViewLoadingSkeleton() {
   return (
     <div
@@ -15,11 +33,10 @@ export function GraphViewLoadingSkeleton() {
       </div>
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
         {Array.from({ length: 8 }, (_, index) => (
-          <Skeleton
-            key={index}
-            data-graph-loading-card=""
-            className="aspect-video w-full rounded-lg"
-          />
+          <div key={index} data-graph-loading-card="" className="grid gap-2">
+            <Skeleton className="aspect-video w-full rounded-lg" />
+            <Skeleton className="h-3 w-2/3" />
+          </div>
         ))}
       </div>
     </div>

--- a/apps/timeline-gstudio001/lib/firebase-timeline-cascade-delete.test.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-cascade-delete.test.ts
@@ -38,6 +38,28 @@ const state = vi.hoisted(() => {
           return snapshot(id);
         },
       }),
+      // The project query the inbound-reference check runs. Chainable, because
+      // the real one filters on ownerUid AND projectId.
+      where: function whereChain(field: string, _op: string, value: unknown) {
+        const filters: [string, unknown][] = [[field, value]];
+        const chain = {
+          where: (nextField: string, _nextOp: string, nextValue: unknown) => {
+            filters.push([nextField, nextValue]);
+            return chain;
+          },
+          get: async () => {
+            const matched = [...docs.entries()].filter(([, data]) =>
+              filters.every(([f, v]) => (data as Record<string, unknown>)[f] === v),
+            );
+            queries.push(filters.map(([f, v]) => `${f}=${String(v)}`).join("&"));
+            return {
+              size: matched.length,
+              docs: matched.map(([id]) => snapshot(id)),
+            };
+          },
+        };
+        return chain;
+      },
     }),
     batch: () => {
       const queued: string[] = [];
@@ -57,7 +79,9 @@ const state = vi.hoisted(() => {
       };
     },
   };
-  return { docs, reads, commits, failNextCommit, db };
+  /** Project queries issued — the inbound check must cost ONE, not a scan. */
+  const queries: string[] = [];
+  return { docs, reads, commits, failNextCommit, queries, db };
 });
 
 vi.mock("server-only", () => ({}));
@@ -75,6 +99,7 @@ vi.mock("firebase-admin/firestore", () => {
 import {
   deleteFirebaseTimelineDocument,
   TimelineCascadeTooLargeError,
+  TimelineInboundReferenceError,
 } from "./firebase-timeline-store";
 import { TimelineAccessDeniedError } from "./timeline-ownership";
 
@@ -116,6 +141,18 @@ function seed(id: string, ownerUid: string | undefined, childIds: string[] = [])
 }
 
 
+/** Seed a document that carries a `projectId`, which is what makes the
+ *  inbound-reference check affordable — and therefore possible at all. */
+function seedInProject(
+  id: string,
+  ownerUid: string,
+  projectId: string,
+  childIds: string[] = [],
+) {
+  seed(id, ownerUid, childIds);
+  state.docs.set(id, { ...(state.docs.get(id) as Stored), projectId });
+}
+
 /**
  * Seed a LEGACY record: clips at the top level only, with no nested
  * `document`. `buildSavePayload` always writes all three fields today, so
@@ -146,6 +183,7 @@ function seedRecoveryOnly(id: string, ownerUid: string, childIds: string[] = [])
 }
 
 beforeEach(() => {
+  state.queries.length = 0;
   state.docs.clear();
   state.reads.length = 0;
   state.commits.length = 0;
@@ -341,5 +379,96 @@ describe("cascade deletion", () => {
 
     // All three still present: no partial deletion to reason about.
     expect([...state.docs.keys()].sort()).toEqual(["child", "grandchild", "root"]);
+  });
+});
+
+describe("inbound references", () => {
+  /**
+   * The gap this closes: the cascade walks DOWN. It collected the subtree and
+   * deleted it, and never asked who else pointed INTO that subtree — so a clip
+   * from outside survived its target and became a dangling `childTimelineId`.
+   *
+   * Not hypothetical. Five of them in one real project added 33.9s of phantom
+   * footage to a collection's readout, and a delete the owner was about to run
+   * would have created a sixth.
+   *
+   * Answering it used to mean scanning the collection, hundreds of reads per
+   * delete. With `projectId` on every document it is one query, which is the
+   * only reason this check exists now and did not before.
+   */
+  it("refuses when a document outside the subtree points into it", async () => {
+    seedInProject("root", "user-a", "p1", ["mid"]);
+    seedInProject("mid", "user-a", "p1", ["leaf"]);
+    seedInProject("leaf", "user-a", "p1");
+    // The outsider — not part of the delete, but pointing at its deepest member.
+    seedInProject("elsewhere", "user-a", "p1", ["leaf"]);
+
+    await expect(deleteFirebaseTimelineDocument("root", "user-a")).rejects.toBeInstanceOf(
+      TimelineInboundReferenceError,
+    );
+    // NOTHING deleted — the check runs before the batch, so a refusal is not a
+    // partial delete.
+    expect(state.commits).toEqual([]);
+    expect(state.docs.has("leaf")).toBe(true);
+  });
+
+  it("names what points where, so the caller can act on it", async () => {
+    seedInProject("root", "user-a", "p1", ["mid"]);
+    seedInProject("mid", "user-a", "p1");
+    seedInProject("elsewhere", "user-a", "p1", ["mid"]);
+
+    const error = await deleteFirebaseTimelineDocument("root", "user-a").catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(TimelineInboundReferenceError);
+    expect((error as TimelineInboundReferenceError).references).toEqual([
+      { fromId: "elsewhere", toId: "mid" },
+    ]);
+  });
+
+  it("ignores the ROOT's own parent, which legitimately points at it", async () => {
+    // Deleting a collection always leaves its parent holding a clip for it —
+    // removing that clip is the caller's job, in the same write. Treating it as
+    // an inbound reference would refuse every delete there is.
+    seedInProject("parent", "user-a", "p1", ["root"]);
+    seedInProject("root", "user-a", "p1", ["mid"]);
+    seedInProject("mid", "user-a", "p1");
+
+    await deleteFirebaseTimelineDocument("root", "user-a");
+    expect(state.docs.has("root")).toBe(false);
+    expect(state.docs.has("mid")).toBe(false);
+  });
+
+  it("ignores references from documents that are themselves being deleted", async () => {
+    // A diamond inside the subtree is not a dangling reference in waiting —
+    // both ends go at once.
+    seedInProject("root", "user-a", "p1", ["a", "b"]);
+    seedInProject("a", "user-a", "p1", ["shared"]);
+    seedInProject("b", "user-a", "p1", ["shared"]);
+    seedInProject("shared", "user-a", "p1");
+
+    await deleteFirebaseTimelineDocument("root", "user-a");
+    expect(state.docs.has("shared")).toBe(false);
+  });
+
+  it("costs ONE query, not a scan", async () => {
+    seedInProject("root", "user-a", "p1", ["mid"]);
+    seedInProject("mid", "user-a", "p1");
+
+    await deleteFirebaseTimelineDocument("root", "user-a");
+    // The whole reason the check is affordable. A per-document lookup, or a
+    // collection scan, is the cost this line of work exists to remove.
+    expect(state.queries).toEqual(["ownerUid=user-a&projectId=p1"]);
+  });
+
+  it("skips the check for a document with no projectId rather than scanning", async () => {
+    // A deliberate gap, documented at the call site: legacy records predate the
+    // field, and `npm run stamp:project-ids` is the fix. Refusing to delete
+    // them, or scanning per delete, are both worse.
+    seed("root", "user-a", ["mid"]);
+    seed("mid", "user-a");
+    seed("elsewhere", "user-a", ["mid"]);
+
+    await deleteFirebaseTimelineDocument("root", "user-a");
+    expect(state.queries).toEqual([]);
+    expect(state.docs.has("mid")).toBe(false);
   });
 });

--- a/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
+++ b/apps/timeline-gstudio001/lib/firebase-timeline-store.ts
@@ -1334,6 +1334,46 @@ export async function createFirebaseTimelineProject(requesterUid: string, title?
  */
 const MAX_CASCADE_DOCUMENTS = 500;
 
+/** A clip left pointing at a document a delete would destroy. */
+export type TimelineInboundReference = Readonly<{
+  /** The document holding the clip — NOT part of the delete. */
+  fromId: string;
+  /** The clip's target, which the delete would remove. */
+  toId: string;
+}>;
+
+/**
+ * A delete refused because it would leave someone else pointing at nothing.
+ *
+ * The cascade walks DOWN: it collects the subtree below the root and removes
+ * it. Nothing asked who else pointed INTO that subtree, so a reference from
+ * outside it survived its target and became a dangling `childTimelineId` — a
+ * clip that still draws a card for a document that no longer exists. Five of
+ * those in one real project quietly added 33.9s of phantom footage to a
+ * collection's readout before anyone noticed.
+ *
+ * The twin of `TimelineOrphanError`, pointed the other way: that one refuses to
+ * leave a child with no parent, this one refuses to leave a parent with no
+ * child.
+ *
+ * REFUSES rather than repairs. Stripping the referring clips would edit
+ * documents the caller never named, during an operation they asked to be
+ * destructive — so the caller is told exactly what points in and decides.
+ */
+export class TimelineInboundReferenceError extends Error {
+  readonly references: readonly TimelineInboundReference[];
+
+  constructor(id: string, references: readonly TimelineInboundReference[]) {
+    super(
+      `Refusing to delete "${id}": ` +
+        `${references.map((r) => `"${r.fromId}" still points at "${r.toId}"`).join(", ")}. ` +
+        `Remove those clips first, or they will be left referencing nothing.`,
+    );
+    this.name = "TimelineInboundReferenceError";
+    this.references = references;
+  }
+}
+
 export class TimelineCascadeTooLargeError extends Error {
   constructor(id: string) {
     super(
@@ -1381,6 +1421,9 @@ export async function deleteFirebaseTimelineDocument(id: string, requesterUid: s
   }
 
   const visited = new Set<string>([id]);
+  /** The root's project, captured on the way past — the inbound check below
+   *  needs it and the root is the only document certain to be read. */
+  let rootProjectId: string | undefined;
   // Root-first, so reversing it deletes the deepest documents first and the
   // root last — relevant only in the multi-batch path below, where a failure
   // part-way leaves a visibly broken parent the user can retry from rather
@@ -1410,6 +1453,7 @@ export async function deleteFirebaseTimelineDocument(id: string, requesterUid: s
       }
 
       const data = snapshot.data() as TimelineDocumentRecord;
+      if (currentId === id) rootProjectId = data.projectId;
       if (resolveOwnership(data.ownerUid, requesterUid) === "denied") {
         // At the root this is the authorization answer. Deeper it means a
         // stored clip pointed at someone else's document: skip it, and keep
@@ -1457,6 +1501,39 @@ export async function deleteFirebaseTimelineDocument(id: string, requesterUid: s
       }
     }
     frontier = next;
+  }
+
+  // WHO ELSE POINTS IN? Asked BEFORE anything is destroyed.
+  //
+  // Newly affordable. Answering it used to mean scanning the collection —
+  // hundreds of reads for every delete — so the cascade simply did not ask, and
+  // a reference from outside the subtree was left dangling. Now that every
+  // document carries `projectId`, it is ONE query.
+  //
+  // The ROOT is excluded on purpose: its own parent legitimately points at it,
+  // and removing that clip is the caller's job (the graph command that deletes
+  // a node writes its parent in the same batch). Only references to the
+  // DESCENDANTS being taken down with it are a problem, and only from documents
+  // that are not themselves being deleted.
+  //
+  // A document with no `projectId` cannot be checked this way, and the check is
+  // skipped rather than answered with a collection scan. That is a real gap and
+  // a deliberate one: `npm run stamp:project-ids` backfills the field, and a
+  // scan per delete is the cost this whole line of work exists to remove.
+  if (rootProjectId !== undefined && toDelete.length > 1) {
+    const deleting = new Set(toDelete);
+    const project = await readStoredTimelineProjectEntries(rootProjectId, requesterUid);
+    const references: TimelineInboundReference[] = [];
+    for (const [documentId, entry] of project) {
+      if (deleting.has(documentId)) continue;
+      for (const clip of entry.document.clips) {
+        if (clip.kind !== "collection" || !clip.childTimelineId) continue;
+        if (clip.childTimelineId === id) continue;
+        if (!deleting.has(clip.childTimelineId)) continue;
+        references.push({ fromId: documentId, toId: clip.childTimelineId });
+      }
+    }
+    if (references.length > 0) throw new TimelineInboundReferenceError(id, references);
   }
 
   // ONE atomic batch for the whole cascade, where it fits — which, given

--- a/apps/timeline-gstudio001/lib/format-duration.ts
+++ b/apps/timeline-gstudio001/lib/format-duration.ts
@@ -16,10 +16,19 @@
 // Anything a user can EDIT gets the editing form; anything they merely read
 // gets the reading form.
 
-/** Reading: "12.4s", "1:23", "1:02:03". */
+/**
+ * Reading: "0:04", "0:25", "1:23", "1:02:03".
+ *
+ * CLOCK NOTATION AT EVERY LENGTH. This used to switch to "25.3s" below a
+ * minute, which put two vocabularies on one board: a project read
+ * "Scenes 1:29 / Locations 25.3s" and the eye had to change units between
+ * neighbouring cards to compare them. The split was meant to keep short
+ * durations precise, but precision is the EDITING register's job — anything a
+ * user can type back gets `formatSeconds`, in hundredths, always in seconds.
+ * What is merely read gets one shape.
+ */
 export function formatDuration(seconds: number): string {
   const safe = Number.isFinite(seconds) && seconds > 0 ? seconds : 0;
-  if (safe < 60) return `${safe.toFixed(1)}s`;
   const hours = Math.floor(safe / 3600);
   const minutes = Math.floor((safe % 3600) / 60);
   const rest = Math.round(safe % 60);

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
@@ -1041,6 +1041,40 @@ describe("graph-documents-gateway", () => {
       };
     };
 
+    it("collapses concurrent callers into ONE request", async () => {
+      // `holdsFreshClosure` is a check on state, so it cannot stop callers that
+      // arrive before the first response lands — and they do. React runs an
+      // effect twice in development and a re-render can run it again; the
+      // observed result was FIVE identical closure POSTs inside 30ms, each one
+      // walking the whole project. That is 745 document reads to do a 149-read
+      // job, in the exact code added to REDUCE reads.
+      let resolveFetch: (value: Response) => void = () => {};
+      const calls: string[] = [];
+      vi.stubGlobal("fetch", (url: string) => {
+        calls.push(url);
+        return new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        });
+      });
+      const gateway = createGraphDocumentsGateway();
+      gateway.bindUser("user-a");
+      gateway.prime(doc("root", [child("c1", "kid")]), 1, "user-a");
+
+      // All five before any of them settles — the case a state check misses.
+      const all = Promise.all([
+        gateway.ensureClosure("root"),
+        gateway.ensureClosure("root"),
+        gateway.ensureClosure("root"),
+        gateway.ensureClosure("root"),
+        gateway.ensureClosure("root"),
+      ]);
+      expect(calls).toHaveLength(1);
+
+      resolveFetch(jsonResponse({ results: [], missing: [] }));
+      await all;
+      expect(calls).toHaveLength(1);
+    });
+
     it("does not walk a closure the session already holds, fresh", async () => {
       const calls = installFetch(() => jsonResponse({}));
       const gateway = createGraphDocumentsGateway();

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.test.ts
@@ -1048,11 +1048,13 @@ describe("graph-documents-gateway", () => {
       // observed result was FIVE identical closure POSTs inside 30ms, each one
       // walking the whole project. That is 745 document reads to do a 149-read
       // job, in the exact code added to REDUCE reads.
-      let resolveFetch: (value: Response) => void = () => {};
+      // Typed from what `jsonResponse` returns, not the DOM `Response`: the
+      // suite's stub is a minimal shape and the gateway only reads json()/ok.
+      let resolveFetch: (value: ReturnType<typeof jsonResponse>) => void = () => {};
       const calls: string[] = [];
       vi.stubGlobal("fetch", (url: string) => {
         calls.push(url);
-        return new Promise<Response>((resolve) => {
+        return new Promise<ReturnType<typeof jsonResponse>>((resolve) => {
           resolveFetch = resolve;
         });
       });

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
@@ -721,7 +721,31 @@ export function createGraphDocumentsGateway(
     return walk(rootId);
   };
 
-  const ensureClosure = async (rootId: string): Promise<void> => {
+  /**
+   * One closure request per root at a time.
+   *
+   * `holdsFreshClosure` is a check on STATE, so it cannot stop callers that
+   * arrive before the first response lands — and they do: React runs an effect
+   * twice in development, a re-render can re-run it, and the observed result
+   * was FIVE identical closure POSTs within 30ms. Each one walks the whole
+   * project, so that is 745 document reads to do a 149-read job. The
+   * single-document `ensure` path has had this dedupe since #437; this is the
+   * same guarantee for the closure.
+   */
+  const closureInflight = new Map<string, Promise<void>>();
+
+  const ensureClosure = (rootId: string): Promise<void> => {
+    if (holdsFreshClosure(rootId)) return Promise.resolve();
+    const existing = closureInflight.get(rootId);
+    if (existing) return existing;
+    const run = runClosure(rootId).finally(() => {
+      closureInflight.delete(rootId);
+    });
+    closureInflight.set(rootId, run);
+    return run;
+  };
+
+  const runClosure = async (rootId: string): Promise<void> => {
     // NOTHING TO FETCH, so do not spend a walk finding that out.
     //
     // The server-primed boot arrives holding the whole closure already, and

--- a/apps/timeline-gstudio001/lib/graph-rsc-payloads.test.ts
+++ b/apps/timeline-gstudio001/lib/graph-rsc-payloads.test.ts
@@ -167,6 +167,95 @@ describe("loadGraphBootstrapPayloads", () => {
   });
 });
 
+/**
+ * THE DEPTH BOUND, on a project that actually has depth.
+ *
+ * Every bootstrap test above seeds a FLAT project, which is why they all still
+ * passed when the board stopped reading the whole closure — they never
+ * descended a level, so there was nothing for a bound to change. That blind
+ * spot is the reason these exist: the assertions below are about documents NOT
+ * read, and a fixture without grandchildren cannot express that.
+ */
+describe("loadGraphBootstrapPayloads — depth bound", () => {
+  /** Override a collection clip's STORED summary, to tell a derived value
+   *  apart from the one that was already sitting in the parent. */
+  const withSummary = (
+    clip: TimelineClip,
+    summary: Readonly<{ itemCount?: number; duration?: number }>,
+  ): TimelineClip => (clip.kind === "collection" ? { ...clip, ...summary } : clip);
+
+  /** project -> level1 -> level2, with a wrong stored summary at each hop. */
+  const seedThreeLevels = () => {
+    seed("level2", "user-a", [image("x", 0, 4), image("y", 4, 4), image("z", 8, 4)]);
+    seed("level1", "user-a", [
+      withSummary(collectionClip("l2ref", "level2", 0), { itemCount: 99, duration: 99 }),
+      image("solo", 4, 4),
+    ]);
+    seed("project-1", "user-a", [
+      withSummary(collectionClip("l1ref", "level1", 0), { itemCount: 42, duration: 42 }),
+    ]);
+  };
+
+  it("reads the project and one level below it, and nothing deeper", async () => {
+    seedThreeLevels();
+
+    const boot = await loadGraphBootstrapPayloads("project-1", "user-a");
+
+    expect(boot).not.toBeNull();
+    expect(state.reads.get("project-1") ?? 0).toBeGreaterThan(0);
+    expect(state.reads.get("level1") ?? 0).toBeGreaterThan(0);
+    // The whole point: the grandchild is never fetched. On the real project
+    // this is 145 of 149 documents.
+    expect(state.reads.get("level2") ?? 0).toBe(0);
+    expect(boot!.payloads.map((payload) => payload.document.id)).toEqual([
+      "project-1",
+      "level1",
+      "trash-user-a",
+    ]);
+  });
+
+  it("still derives the summaries it CAN — one level is read, so one level is fresh", async () => {
+    seedThreeLevels();
+
+    const boot = await loadGraphBootstrapPayloads("project-1", "user-a");
+    const projectClip = at(at(boot!.payloads, 0).document.clips, 0);
+
+    // level1 was read, so the card for it is computed from its real contents
+    // (two clips) rather than the stored 42.
+    expect(projectClip.kind).toBe("collection");
+    expect(projectClip.kind === "collection" ? projectClip.itemCount : null).toBe(2);
+  });
+
+  it("keeps a skipped child's STORED summary rather than deriving an empty collection", async () => {
+    seedThreeLevels();
+
+    const boot = await loadGraphBootstrapPayloads("project-1", "user-a");
+    const level1 = at(boot!.payloads, 1).document;
+    const level2Clip = at(level1.clips, 0);
+
+    // level2 was not read. "Stale beats blank": an unread child leaves the
+    // stored summary standing. Deriving from its absence would render the
+    // collection as empty, which is a wrong answer rather than an old one.
+    expect(level2Clip.kind === "collection" ? level2Clip.itemCount : null).toBe(99);
+  });
+
+  it("reports a dangling child as missing, and never one the bound merely skipped", async () => {
+    seedThreeLevels();
+    seed("project-1", "user-a", [
+      collectionClip("l1ref", "level1", 0),
+      collectionClip("goneref", "gone", 4),
+    ]);
+
+    const boot = await loadGraphBootstrapPayloads("project-1", "user-a");
+
+    // `gone` has no document — the client shows a dangling reference for it.
+    expect(boot!.missing).toContain("gone");
+    // `level2` exists and was simply not fetched. Reporting it here would tell
+    // the client a healthy collection had vanished.
+    expect(boot!.missing).not.toContain("level2");
+  });
+});
+
 describe("loadFocusPathPayloads", () => {
   it("serves every path segment plus one eager child level under the focused one", async () => {
     seed("grand", "user-a", [image("g", 0, 2)]);

--- a/apps/timeline-gstudio001/lib/graph-rsc-payloads.ts
+++ b/apps/timeline-gstudio001/lib/graph-rsc-payloads.ts
@@ -34,6 +34,35 @@ const MAX_PATH_PAYLOADS = 16;
 const MAX_PATH_ATTEMPTS = 48;
 
 /**
+ * How far below the project the BOARD OPEN reads.
+ *
+ * The board renders the root's children as cards, and every card below the
+ * first level is a placeholder the client hydrates on demand. Reading deeper
+ * bought exactly one thing: freshly derived `duration` / `previewItems` /
+ * `itemCount` on those cards — 149 documents on a real project to correct four
+ * numbers each, which is 96%+ of every read a board open has ever cost.
+ *
+ * At depth 1 those numbers come from the stored summaries instead. Those are
+ * measurably imperfect today (58.4% of collection clips carry at least one
+ * stale field), and the fix belongs on the WRITE path where the staleness is
+ * actually created — a client whose graph is only partly hydrated writes the
+ * stale values it was served straight back. Recomputing the world on every read
+ * to paper over a bad write was the expensive half of that bargain.
+ *
+ * NOT used by the preview/export compile, which genuinely needs every document
+ * and must keep reading them.
+ *
+ * ONE BEHAVIOUR CHANGE WORTH KNOWING: `missing` now reports only dangling
+ * references found within the bound. On the project this was measured against
+ * it went from 5 to 0 — those five childless ids live deeper than the first
+ * level, so the client meets them when it hydrates that branch instead of at
+ * boot. Nothing hides them; the discovery just moves to the point of use.
+ *
+ * Measured on that project: 150 billed reads -> 5.
+ */
+export const BOARD_OPEN_MAX_DEPTH = 1;
+
+/**
  * The boot payloads: the project document and the user's trash — the two
  * roots the graph builds from. Null when the project can't be served
  * (missing or denied): the client boots through its legacy fetch path and
@@ -85,7 +114,7 @@ export async function loadGraphBootstrapPayloads(
     // requests and still two billed reads' worth of documents; they simply cost
     // one round trip between them instead of two.
     const [closure, trash] = await Promise.all([
-      serveTimelineClosure(projectId, requesterUid),
+      serveTimelineClosure(projectId, requesterUid, { maxDepth: BOARD_OPEN_MAX_DEPTH }),
       serveTrashDocument(`trash-${requesterUid}`, requesterUid, read),
     ]);
     if (!closure) {

--- a/apps/timeline-gstudio001/lib/graph-rsc-payloads.ts
+++ b/apps/timeline-gstudio001/lib/graph-rsc-payloads.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { collectionChildIds } from "./derive-collection-summaries";
 import type { GraphServerPayload } from "./graph-documents-gateway";
 import {
+  BOARD_OPEN_MAX_DEPTH,
   createTimelineEntryReader,
   serveTimelineClosure,
   serveTimelineDocument,
@@ -33,34 +34,7 @@ const MAX_PATH_PAYLOADS = 16;
  */
 const MAX_PATH_ATTEMPTS = 48;
 
-/**
- * How far below the project the BOARD OPEN reads.
- *
- * The board renders the root's children as cards, and every card below the
- * first level is a placeholder the client hydrates on demand. Reading deeper
- * bought exactly one thing: freshly derived `duration` / `previewItems` /
- * `itemCount` on those cards — 149 documents on a real project to correct four
- * numbers each, which is 96%+ of every read a board open has ever cost.
- *
- * At depth 1 those numbers come from the stored summaries instead. Those are
- * measurably imperfect today (58.4% of collection clips carry at least one
- * stale field), and the fix belongs on the WRITE path where the staleness is
- * actually created — a client whose graph is only partly hydrated writes the
- * stale values it was served straight back. Recomputing the world on every read
- * to paper over a bad write was the expensive half of that bargain.
- *
- * NOT used by the preview/export compile, which genuinely needs every document
- * and must keep reading them.
- *
- * ONE BEHAVIOUR CHANGE WORTH KNOWING: `missing` now reports only dangling
- * references found within the bound. On the project this was measured against
- * it went from 5 to 0 — those five childless ids live deeper than the first
- * level, so the client meets them when it hydrates that branch instead of at
- * boot. Nothing hides them; the discovery just moves to the point of use.
- *
- * Measured on that project: 150 billed reads -> 5.
- */
-export const BOARD_OPEN_MAX_DEPTH = 1;
+
 
 /**
  * The boot payloads: the project document and the user's trash — the two
@@ -177,7 +151,13 @@ export async function loadFocusPathPayloads(
     if (payloads.length >= MAX_PATH_PAYLOADS) return null;
     seen.add(id);
     try {
-      const served = await serveTimelineDocument(id, requesterUid, read);
+      // BOUNDED, like the board open. Deriving this segment's summaries used to
+      // walk everything beneath it, so one focus navigation cost a whole
+      // subtree: measured at 149 reads to serve the project root, billed again
+      // on every click up the breadcrumb.
+      const served = await serveTimelineDocument(id, requesterUid, read, {
+        maxDepth: BOARD_OPEN_MAX_DEPTH,
+      });
       if (!served) return null;
       return { ...served, forUid: requesterUid };
     } catch {

--- a/apps/timeline-gstudio001/lib/load-timeline-closure.ts
+++ b/apps/timeline-gstudio001/lib/load-timeline-closure.ts
@@ -97,10 +97,32 @@ export async function loadTimelineClosure(
      * just loaded. It is also the seam its tests inject through.
      */
     read?: TimelineEntryReader;
+    /**
+     * Stop descending after this many levels below the root. Absent = the whole
+     * closure, which is what the preview/export compile needs and must keep.
+     *
+     * The BOARD does not need it. A board open renders the focused collection
+     * plus its children as placeholder cards, so everything below the first
+     * level is read only to recompute the summaries those cards display — 149
+     * documents to correct four numbers per card. Bounding the walk is the
+     * difference between paying for the whole project and paying for what is
+     * on screen.
+     */
+    maxDepth?: number;
   }>,
 ): Promise<{
   documents: Record<string, TimelineDocument>;
   missing: string[];
+  /**
+   * Children the bound declined to read — NOT the same thing as `missing`.
+   *
+   * `missing` means the document is GONE, and the client changes what it shows
+   * because of it. These exist and simply were not fetched, so a caller
+   * deriving summaries must treat them as UNRESOLVED (keep the stored summary)
+   * rather than absent (derive an empty collection). Merging the two lists
+   * would turn a cheap read into apparent data loss.
+   */
+  unvisited: string[];
   /** Per-document save revisions at compile time — the manifest carries them
    *  so the client can refuse a compile that predates its own writes to ANY
    *  document in the closure, not just the root. */
@@ -154,8 +176,17 @@ export async function loadTimelineClosure(
   await read.prefetchProject?.(rootId).catch(() => 0);
 
   let frontier: readonly string[] = record(rootId, rootEntry);
+  const unvisited = new Set<string>();
+  let depth = 0;
 
   while (frontier.length > 0) {
+    // Checked BEFORE the level is read, so `maxDepth: 1` reads the root and its
+    // children and nothing deeper.
+    depth += 1;
+    if (options?.maxDepth !== undefined && depth > options.maxDepth) {
+      for (const id of frontier) unvisited.add(id);
+      break;
+    }
     // ONE ROUND TRIP PER LEVEL when the reader can batch, twelve-at-a-time when
     // it cannot (hand-written readers in tests, and the un-shared default). The
     // shape of the walk is identical either way — a level is read, then
@@ -175,5 +206,5 @@ export async function loadTimelineClosure(
     frontier = entries.flatMap(({ id, entry }) => record(id, entry));
   }
 
-  return { documents, missing, revisions };
+  return { documents, missing, revisions, unvisited: [...unvisited] };
 }

--- a/apps/timeline-gstudio001/lib/serve-timeline.ts
+++ b/apps/timeline-gstudio001/lib/serve-timeline.ts
@@ -126,6 +126,35 @@ export function createTimelineEntryReader(requesterUid: string): TimelineEntryRe
   return read;
 }
 
+/**
+ * How far below the project the BOARD OPEN reads.
+ *
+ * The board renders the root's children as cards, and every card below the
+ * first level is a placeholder the client hydrates on demand. Reading deeper
+ * bought exactly one thing: freshly derived `duration` / `previewItems` /
+ * `itemCount` on those cards — 149 documents on a real project to correct four
+ * numbers each, which is 96%+ of every read a board open has ever cost.
+ *
+ * At depth 1 those numbers come from the stored summaries instead. Those are
+ * measurably imperfect today (58.4% of collection clips carry at least one
+ * stale field), and the fix belongs on the WRITE path where the staleness is
+ * actually created — a client whose graph is only partly hydrated writes the
+ * stale values it was served straight back. Recomputing the world on every read
+ * to paper over a bad write was the expensive half of that bargain.
+ *
+ * NOT used by the preview/export compile, which genuinely needs every document
+ * and must keep reading them.
+ *
+ * ONE BEHAVIOUR CHANGE WORTH KNOWING: `missing` now reports only dangling
+ * references found within the bound. On the project this was measured against
+ * it went from 5 to 0 — those five childless ids live deeper than the first
+ * level, so the client meets them when it hydrates that branch instead of at
+ * boot. Nothing hides them; the discovery just moves to the point of use.
+ *
+ * Measured on that project: 150 billed reads -> 5.
+ */
+export const BOARD_OPEN_MAX_DEPTH = 1;
+
 /** Null when the document doesn't exist; throws TimelineAccessDeniedError
  *  for someone else's (callers map it to their 404). */
 export async function serveTimelineDocument(
@@ -134,6 +163,24 @@ export async function serveTimelineDocument(
   /** Share one across a request to avoid re-reading documents (see
    *  `createTimelineEntryReader`). Defaults to an un-shared direct read. */
   read: TimelineEntryReader = (childId) => readStoredTimelineEntry(childId, requesterUid),
+  options?: Readonly<{
+    /**
+     * Levels below `id` to read when deriving its summaries. Absent = the whole
+     * closure below it.
+     *
+     * EVERY BOARD-SERVING CALLER SHOULD PASS ONE. Deriving a document's
+     * collection summaries means reading everything beneath it, so serving a
+     * single focus segment cost a full subtree walk — measured at 149 reads to
+     * serve the project root, and again on every focus navigation. A drill-in
+     * and two clicks back up the breadcrumb billed 580 reads across 149
+     * documents, every one of them read more than once.
+     *
+     * The preview/export compile is the caller that must NOT bound this: it
+     * flattens the real tree and a stale grandchild would window its parent's
+     * content out of the timeline.
+     */
+    maxDepth?: number;
+  }>,
 ): Promise<ServedTimeline | null> {
   const entry = await read(id);
   if (!entry) return null;
@@ -201,6 +248,7 @@ export async function serveTimelineDocument(
   const closure = await loadTimelineClosure(id, requesterUid, {
     rootEntry: entry,
     read,
+    ...(options?.maxDepth === undefined ? {} : { maxDepth: options.maxDepth }),
   }).catch((error: unknown) => {
     // A pathological tree must not make the document unopenable. Fall back to
     // the one-level derivation: less fresh at depth, but the same answer this
@@ -226,7 +274,9 @@ export async function serveTimelineDocument(
   // srcs and durations would be thrown away by this substitution.
   const summarized = deriveClosureSummaries(
     { ...closure.documents, [id]: healedDocument },
-    new Set(closure.missing),
+    // Skipped and missing alike cannot be derived FROM — see the note in
+    // `serveTimelineClosure`.
+    new Set([...closure.missing, ...closure.unvisited]),
   );
 
   return { document: summarized[id] ?? healedDocument, revision };

--- a/apps/timeline-gstudio001/lib/serve-timeline.ts
+++ b/apps/timeline-gstudio001/lib/serve-timeline.ts
@@ -270,6 +270,15 @@ export async function serveTimelineDocument(
 export async function serveTimelineClosure(
   id: string,
   requesterUid: string,
+  options?: Readonly<{
+    /**
+     * Levels below the root to read. Absent = the whole closure.
+     *
+     * The BOARD passes a bound; the preview/export compile must not. See
+     * `loadTimelineClosure`'s `maxDepth` for why the board can afford to stop.
+     */
+    maxDepth?: number;
+  }>,
 ): Promise<Readonly<{
   documents: Record<string, ServedTimeline>;
   missing: string[];
@@ -310,6 +319,7 @@ export async function serveTimelineClosure(
     loadTimelineClosure(id, requesterUid, {
       rootEntry: entry,
       read,
+      ...(options?.maxDepth === undefined ? {} : { maxDepth: options.maxDepth }),
     }).catch((error: unknown) => {
       if (error instanceof TimelineClosureTooLargeError) return null;
       throw error;
@@ -321,9 +331,16 @@ export async function serveTimelineClosure(
   // `serveTimelineDocument` for what it did and why it went.
   const healedDocument = entry.document;
   const missing = new Set(closure.missing);
+  // UNRESOLVED IS THE WIDER SET, and the distinction is the whole reason the
+  // walk reports the two separately. A child that is gone and a child the depth
+  // bound skipped are alike in one way — neither can be derived FROM, so both
+  // leave the parent's stored summary standing ("stale beats blank"). They are
+  // nothing alike to the client, which shows a dangling reference differently
+  // from a collection it simply has not loaded yet.
+  const unresolved = new Set([...closure.missing, ...closure.unvisited]);
   const summarized = deriveClosureSummaries(
     { ...closure.documents, [id]: healedDocument },
-    missing,
+    unresolved,
   );
 
   const documents: Record<string, ServedTimeline> = {};

--- a/apps/timeline-gstudio001/scripts/remove-dangling-collection-references.ts
+++ b/apps/timeline-gstudio001/scripts/remove-dangling-collection-references.ts
@@ -1,0 +1,167 @@
+/**
+ * Remove collection clips that point at a document which does not exist.
+ *
+ * A dangling `childTimelineId` is what the cascade delete used to leave behind:
+ * it walks DOWN and removes a subtree, and never asked who pointed INTO it, so
+ * a reference from outside survived its target. `TimelineInboundReferenceError`
+ * stops new ones; this clears the ones already stored.
+ *
+ * They are not inert. The card still draws, and until the readout learned to
+ * count a missing child as zero, each one contributed its remembered duration —
+ * five of them added 33.9s of footage that does not exist to one collection.
+ *
+ * DRY RUN BY DEFAULT. Prints what it would remove and changes nothing; pass
+ * `--apply` to write. `--fixture` operates on the local fixture file instead of
+ * Firestore, which is how this was verified.
+ *
+ *   node scripts/remove-dangling-collection-references.ts <rootId> [--fixture] [--apply]
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { config } from "dotenv";
+import { cert, applicationDefault, initializeApp } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+
+import { packTimelineClips } from "@storyboard/timeline-model";
+import type { TimelineDocument } from "@storyboard/timeline-model/types";
+
+config({ path: ".env" });
+
+const COLLECTION = "gstudioTimelineDocuments";
+const FIRESTORE_BATCH_LIMIT = 500;
+
+const rootId = process.argv[2] ?? "";
+const apply = process.argv.includes("--apply");
+const useFixture = process.argv.includes("--fixture");
+if (!rootId) {
+  console.error(
+    "Usage: node scripts/remove-dangling-collection-references.ts <rootId> [--fixture] [--apply]",
+  );
+  process.exit(2);
+}
+
+type Loaded = { documents: Map<string, TimelineDocument>; fixturePath?: string; raw?: unknown };
+
+async function load(): Promise<Loaded> {
+  if (useFixture) {
+    const path = process.env.GSTUDIO_FIXTURE_TIMELINES ?? "fixtures/local.json";
+    const raw = JSON.parse(readFileSync(path, "utf8")) as {
+      documents: Record<string, TimelineDocument>;
+    };
+    return { documents: new Map(Object.entries(raw.documents)), fixturePath: path, raw };
+  }
+  const projectId = process.env.FIREBASE_PROJECT_ID;
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\n/g, "\n");
+  initializeApp(
+    clientEmail && privateKey
+      ? { credential: cert({ projectId, clientEmail, privateKey }), projectId }
+      : { credential: applicationDefault(), projectId },
+  );
+  const db = getFirestore();
+  // BY PROJECT, one query — the same field that made the delete-time check
+  // affordable. A closure walk would cost one read per document instead.
+  const snapshot = await db
+    .collection(COLLECTION)
+    .where("projectId", "==", rootId)
+    .get();
+  const documents = new Map<string, TimelineDocument>();
+  for (const doc of snapshot.docs) {
+    const data = doc.data() as { document?: TimelineDocument; clips?: TimelineDocument["clips"] };
+    const document = data.document ?? { id: doc.id, title: "", clips: data.clips ?? [] };
+    documents.set(doc.id, document);
+  }
+  // The root itself carries its own id as projectId only if stamped; fetch it
+  // directly so a partially stamped project still reports honestly.
+  if (!documents.has(rootId)) {
+    const root = await db.collection(COLLECTION).doc(rootId).get();
+    if (root.exists) {
+      const data = root.data() as { document?: TimelineDocument };
+      if (data.document) documents.set(rootId, data.document);
+    }
+  }
+  return { documents };
+}
+
+async function main(): Promise<void> {
+  const { documents, fixturePath, raw } = await load();
+  if (!documents.has(rootId)) {
+    console.error(`No document "${rootId}" (loaded ${documents.size}).`);
+    process.exit(1);
+  }
+
+  /** Every document reachable from the root, so a dangling id elsewhere in the
+   *  workspace is not silently swept up by a project-scoped run. */
+  const reachable = new Set<string>([rootId]);
+  const queue = [rootId];
+  while (queue.length > 0) {
+    const id = queue.shift() as string;
+    for (const clip of documents.get(id)?.clips ?? []) {
+      if (clip.kind !== "collection" || !clip.childTimelineId) continue;
+      if (reachable.has(clip.childTimelineId)) continue;
+      reachable.add(clip.childTimelineId);
+      queue.push(clip.childTimelineId);
+    }
+  }
+
+  const edits = new Map<string, TimelineDocument>();
+  let removed = 0;
+  for (const id of reachable) {
+    const document = documents.get(id);
+    if (!document) continue;
+    const dangling = document.clips.filter(
+      (clip) => clip.kind === "collection" && clip.childTimelineId && !documents.has(clip.childTimelineId),
+    );
+    if (dangling.length === 0) continue;
+    for (const clip of dangling) {
+      console.log(
+        `  "${document.title}" (${id}) -> "${clip.title}" (${
+          clip.kind === "collection" ? clip.childTimelineId : ""
+        }) — no document`,
+      );
+      removed += 1;
+    }
+    const keep = document.clips.filter((clip) => !dangling.includes(clip));
+    // REPACKED with the model's own function, never re-derived here: the packing
+    // math has a twin in the graph adapter and the two drifting is exactly the
+    // bug the adapter's comments warn about.
+    edits.set(id, { ...document, clips: packTimelineClips(keep) });
+  }
+
+  console.log(
+    `\n${removed} dangling reference(s) across ${edits.size} document(s), ` +
+      `from ${reachable.size} reachable.`,
+  );
+  if (removed === 0) process.exit(0);
+  if (!apply) {
+    console.log("DRY RUN — nothing written. Re-run with --apply to remove them.");
+    process.exit(0);
+  }
+
+  if (useFixture && fixturePath) {
+    const next = raw as { documents: Record<string, TimelineDocument> };
+    for (const [id, document] of edits) next.documents[id] = document;
+    writeFileSync(fixturePath, `${JSON.stringify(next, null, 2)}\n`);
+    console.log(`Wrote ${edits.size} document(s) to ${fixturePath}.`);
+  } else {
+    const db = getFirestore();
+    const entries = [...edits.entries()];
+    for (let i = 0; i < entries.length; i += FIRESTORE_BATCH_LIMIT) {
+      const batch = db.batch();
+      for (const [id, document] of entries.slice(i, i + FIRESTORE_BATCH_LIMIT)) {
+        // Both shapes, because readers resolve from either — see
+        // `toTimelineDocument`'s precedence.
+        batch.set(
+          db.collection(COLLECTION).doc(id),
+          { document, clips: document.clips },
+          { merge: true },
+        );
+      }
+      await batch.commit();
+    }
+    console.log(`Wrote ${edits.size} document(s).`);
+  }
+}
+
+// CommonJS via ts-node (the workspace packages use extensionless imports,
+// which plain-node ESM will not resolve), so no top-level await.
+void main();

--- a/packages/timeline-domain/index.ts
+++ b/packages/timeline-domain/index.ts
@@ -14,6 +14,7 @@ export {
   DUPLICATE_NODE_ID_PREFIX,
   collectionSubtreeHydrated,
   hydratedCollectionDuration,
+  hydratedCollectionPlayableSpan,
   hydratedCollectionPlayableDuration,
   hydratedCollectionPreviews,
   resolveCollectionPreviews,

--- a/packages/timeline-domain/index.ts
+++ b/packages/timeline-domain/index.ts
@@ -12,6 +12,7 @@ export {
   // one is synthetic — the hydration path decides whether to fetch on it.
   isDuplicateNodeId,
   DUPLICATE_NODE_ID_PREFIX,
+  collectionSubtreeHydrated,
   hydratedCollectionDuration,
   hydratedCollectionPlayableDuration,
   hydratedCollectionPreviews,

--- a/packages/timeline-domain/src/adapter.test.ts
+++ b/packages/timeline-domain/src/adapter.test.ts
@@ -1523,6 +1523,25 @@ describe("collectionSubtreeHydrated", () => {
     expect(collectionSubtreeHydrated(graph, details, "root")).toBe(false);
   });
 
+  it("treats a DANGLING child as resolved, not as pending forever", () => {
+    // The card this fixed: five dangling references under one collection held
+    // an otherwise complete 133-document branch at "no duration" permanently,
+    // because a document that does not exist can never arrive. Gone is known —
+    // it contributes nothing, and the total is exactly computable without it.
+    const { graph, details } = graphOf(
+      {
+        root: {
+          id: "root",
+          title: "root",
+          clips: [collectionClip("c-gone", "gone", "Gone")],
+        },
+      },
+      "root",
+    );
+    expect(collectionSubtreeHydrated(graph, details, "root")).toBe(false);
+    expect(collectionSubtreeHydrated(graph, details, "root", (id) => id === "gone")).toBe(true);
+  });
+
   it("vouches for a one-level tree, which is what a board actually shows", () => {
     // The case that makes the board useful rather than blank: the focused
     // collection plus media-only children is fully in the graph, so its cards

--- a/packages/timeline-domain/src/adapter.test.ts
+++ b/packages/timeline-domain/src/adapter.test.ts
@@ -15,6 +15,7 @@ import {
   collectAffectedCollectionIds,
   collectionSubtreeHydrated,
   collectUnhydratedDropTargets,
+  hydratedCollectionPlayableSpan,
   graphChildrenToClips,
   hydratedCollectionDuration,
   hydratedCollectionPlayableDuration,
@@ -1636,5 +1637,74 @@ describe("collectionSubtreeHydrated", () => {
     // is 103 of 149 collections.
     const { graph, details } = graphOf(media("root"), "root");
     expect(collectionSubtreeHydrated(graph, details, "root")).toBe(true);
+  });
+});
+
+describe("hydratedCollectionPlayableSpan", () => {
+  /**
+   * The board header's number, and why it needed its own function.
+   *
+   * It was measured from card GEOMETRY (`playableSpanSeconds` over the spans
+   * the strip draws), which keeps a card's full slot even when its descendants
+   * are disabled. On a real project the header read 23:01 while its own three
+   * cards summed to about 20:45 — more than half of one branch is disabled deep
+   * inside. The spans carry no node id, so the playable length could not be
+   * recovered from them.
+   *
+   * Its lane-blind twin cannot simply be reused: `graphChildrenToClips`
+   * projects through that one to persist each clip's `playableDuration`.
+   */
+  it("excludes what a disabled descendant contributes", () => {
+    const documents = {
+      root: { id: "root", title: "root", clips: [collectionClip("c-kid", "kid", "Kid")] },
+      kid: {
+        id: "kid",
+        title: "Kid",
+        clips: packTimelineClips([image("k-a", 4), { ...image("k-b", 6), disabled: true }]),
+      },
+    };
+    const focused = buildFocusedGraph(documents, "root");
+    if (!focused.ok) throw new Error(focused.error);
+    const { graph, details } = focused.value;
+
+    // 4s plays, 6s does not.
+    expect(hydratedCollectionPlayableSpan(graph, details, parseNodeId("root"))).toBeCloseTo(4, 5);
+  });
+
+  it("takes the LONGEST lane, not the sum — lanes play together", () => {
+    // A 4s bed under a 4s shot is a 4s timeline, not an 8s one.
+    const documents = {
+      root: {
+        id: "root",
+        title: "root",
+        clips: packTimelineClips([image("picture", 4), { ...image("bed", 4), trackIndex: 1 }]),
+      },
+    };
+    const focused = buildFocusedGraph(documents, "root");
+    if (!focused.ok) throw new Error(focused.error);
+    const { graph, details } = focused.value;
+
+    expect(hydratedCollectionPlayableSpan(graph, details, parseNodeId("root"))).toBeCloseTo(4, 5);
+  });
+
+  it("counts a dangling child as nothing, like every other readout", () => {
+    const documents = {
+      root: {
+        id: "root",
+        title: "root",
+        clips: packTimelineClips([
+          { ...collectionClip("c-gone", "gone", "Gone"), duration: 12.36 },
+          collectionClip("c-leaf", "leaf", "Leaf"),
+        ]),
+      },
+      leaf: { id: "leaf", title: "Leaf", clips: packTimelineClips([image("m-a", 4)]) },
+    };
+    const focused = buildFocusedGraph(documents, "root");
+    if (!focused.ok) throw new Error(focused.error);
+    const { graph, details } = focused.value;
+
+    expect(
+      hydratedCollectionPlayableSpan(graph, details, parseNodeId("root"), (id) => id === "gone"),
+    ).toBeCloseTo(0.12 + 4, 5);
   });
 });

--- a/packages/timeline-domain/src/adapter.test.ts
+++ b/packages/timeline-domain/src/adapter.test.ts
@@ -13,6 +13,7 @@ import {
   buildFocusedGraph,
   buildHydrationSpecs,
   collectAffectedCollectionIds,
+  collectionSubtreeHydrated,
   collectUnhydratedDropTargets,
   graphChildrenToClips,
   hydratedCollectionDuration,
@@ -1436,5 +1437,98 @@ describe("previews when the walk cannot see the whole subtree (#290)", () => {
     expect(scene.previewItems).toEqual([
       { id: "p1", kind: "image", src: "https://example.com/p1.jpg", alt: "p1" },
     ]);
+  });
+});
+
+describe("collectionSubtreeHydrated", () => {
+  /**
+   * Whether a collection's aggregate readouts can be shown at all.
+   *
+   * `hydratedCollectionDuration` always returns a number: for any child it does
+   * not have, it substitutes that child's STORED summary. Those summaries drift
+   * (58.4% of collection clips in a real project carry at least one stale
+   * field), so the number is plausible and unverifiable. This predicate is how
+   * a card knows to say nothing instead — and TRANSITIVITY is the whole point,
+   * because a collection can be fully loaded while its grandchild is not.
+   */
+  const media = (rootId: string) => ({
+    [rootId]: {
+      id: rootId,
+      title: rootId,
+      clips: [collectionClip("clip-leaf", "leaf", "Leaf")],
+    },
+    leaf: { id: "leaf", title: "Leaf", clips: packTimelineClips([image("m-a", 4)]) },
+  });
+
+  const graphOf = (documents: Record<string, TimelineDocument>, rootId: string) => {
+    const focused = buildFocusedGraph(documents, rootId);
+    if (!focused.ok) throw new Error(focused.error);
+    return focused.value;
+  };
+
+  it("vouches for a collection whose children are all media", () => {
+    // The cheap case, and the reason the board is not simply blank: a
+    // media-only collection is exactly known from its own document, so it earns
+    // its readout at one level of reading.
+    const { graph, details } = graphOf(media("root"), "root");
+    expect(collectionSubtreeHydrated(graph, details, "leaf")).toBe(true);
+  });
+
+  it("refuses a collection whose child collection never loaded", () => {
+    const documents = media("root");
+    delete (documents as Record<string, unknown>).leaf;
+    const { graph, details } = graphOf(documents, "root");
+    expect(collectionSubtreeHydrated(graph, details, "root")).toBe(false);
+  });
+
+  it("refuses a LOADED collection with an unloaded grandchild", () => {
+    // The case the predicate exists for. `root` and `mid` are both present, so
+    // asking only about immediate children would vouch for root — while its
+    // duration is quietly standing in `deep`'s stored summary.
+    const { graph, details } = graphOf(
+      {
+        root: { id: "root", title: "root", clips: [collectionClip("c-mid", "mid", "Mid")] },
+        mid: { id: "mid", title: "Mid", clips: [collectionClip("c-deep", "deep", "Deep")] },
+      },
+      "root",
+    );
+    // Not a vacuous pass: the root has NO detail entry (details come from a
+    // parent's clip, and the focused root is nobody's clip), so the refusal
+    // has to come from `deep`, two levels down.
+    expect(details.root).toBeUndefined();
+    expect(details.mid?.hydrated).toBe(true);
+    expect(details.deep?.hydrated).toBe(false);
+    expect(collectionSubtreeHydrated(graph, details, "root")).toBe(false);
+  });
+
+  it("still refuses when a document is LOADED but not hydrated into the graph", () => {
+    // A fact about the client worth pinning: `buildFocusedGraph` hydrates the
+    // focused collection and ONE level below it. `deep` below is present in the
+    // documents and still comes back unhydrated, because nothing has called
+    // `hydrateTimeline` for it — drill-in and sub-timeline expansion do that.
+    //
+    // Which is why the server's full-closure derivation existed at all: the
+    // client's graph never held the deep documents, so every number below the
+    // first level came from the clip summaries the server had just recomputed.
+    // Reading one level and vouching is the same bargain made honestly.
+    const { graph, details } = graphOf(
+      {
+        root: { id: "root", title: "root", clips: [collectionClip("c-mid", "mid", "Mid")] },
+        mid: { id: "mid", title: "Mid", clips: [collectionClip("c-deep", "deep", "Deep")] },
+        deep: { id: "deep", title: "Deep", clips: packTimelineClips([image("d-a", 4)]) },
+      },
+      "root",
+    );
+    expect(details.deep?.hydrated).toBe(false);
+    expect(collectionSubtreeHydrated(graph, details, "root")).toBe(false);
+  });
+
+  it("vouches for a one-level tree, which is what a board actually shows", () => {
+    // The case that makes the board useful rather than blank: the focused
+    // collection plus media-only children is fully in the graph, so its cards
+    // and the header both earn their times. Measured on the real project, this
+    // is 103 of 149 collections.
+    const { graph, details } = graphOf(media("root"), "root");
+    expect(collectionSubtreeHydrated(graph, details, "root")).toBe(true);
   });
 });

--- a/packages/timeline-domain/src/adapter.test.ts
+++ b/packages/timeline-domain/src/adapter.test.ts
@@ -1542,6 +1542,93 @@ describe("collectionSubtreeHydrated", () => {
     expect(collectionSubtreeHydrated(graph, details, "root", (id) => id === "gone")).toBe(true);
   });
 
+  it("vouches for a DUPLICATE placement once the original is loaded", () => {
+    // A second reference to the same collection is demoted to a card with no
+    // children of its own, permanently unhydrated. Waiting on it blocked every
+    // ancestor forever — a real project had one such duplicate, and it alone
+    // kept a 133-document branch timeless after the dangling ids were handled.
+    // Its content is not unknown: the original placement is right there.
+    const { graph, details } = graphOf(
+      {
+        root: {
+          id: "root",
+          title: "root",
+          clips: packTimelineClips([
+            collectionClip("ref-a", "leaf", "Leaf"),
+            collectionClip("ref-b", "leaf", "Leaf"),
+          ]),
+        },
+        leaf: { id: "leaf", title: "Leaf", clips: packTimelineClips([image("m-a", 4)]) },
+      },
+      "root",
+    );
+
+    expect(details["ref-b"]).toMatchObject({ duplicateOfTimelineId: "leaf" });
+    expect(details["ref-b"]?.hydrated).toBe(false);
+    expect(collectionSubtreeHydrated(graph, details, "root")).toBe(true);
+  });
+
+  it("counts a duplicate's REAL content rather than its stored summary", () => {
+    // The reason vouching for it is honest. The walk used to read the dup
+    // card's stored duration, a copy nothing maintains — in the real project
+    // the two parents of one duplicated collection stored 6.12s and 7.12s for
+    // the same 4.0s of content, so at least one was always wrong and its
+    // ancestors inherited the error.
+    const { graph, details } = graphOf(
+      {
+        root: {
+          id: "root",
+          title: "root",
+          clips: packTimelineClips([
+            collectionClip("ref-a", "leaf", "Leaf"),
+            { ...collectionClip("ref-b", "leaf", "Leaf"), duration: 999 },
+          ]),
+        },
+        leaf: { id: "leaf", title: "Leaf", clips: packTimelineClips([image("m-a", 4)]) },
+      },
+      "root",
+    );
+
+    // Two placements of a 4s leaf, one gap between them — NOT 4 + gap + 999.
+    expect(hydratedCollectionDuration(graph, details, parseNodeId("root"))).toBeCloseTo(8.12, 5);
+  });
+
+  it("counts a DANGLING child as zero playable seconds, not its stored duration", () => {
+    // What the board was doing: quoting the remembered length of a document
+    // that no longer exists. Five of these added 33.9s to one collection, so a
+    // card claimed 19:24 of material when 18:51 of it was real.
+    const { graph, details } = graphOf(
+      {
+        root: {
+          id: "root",
+          title: "root",
+          clips: packTimelineClips([
+            { ...collectionClip("c-gone", "gone", "Gone"), duration: 12.36 },
+            collectionClip("c-leaf", "leaf", "Leaf"),
+          ]),
+        },
+        leaf: { id: "leaf", title: "Leaf", clips: packTimelineClips([image("m-a", 4)]) },
+      },
+      "root",
+    );
+
+    // Unaware of the absence, it quotes the stored 12.36.
+    expect(hydratedCollectionPlayableDuration(graph, details, parseNodeId("root"))).toBeCloseTo(
+      12.36 + 0.12 + 4,
+      5,
+    );
+    // Told the document is gone, it contributes nothing — but the GAP stays,
+    // because the broken reference still draws a card between its neighbours.
+    expect(
+      hydratedCollectionPlayableDuration(
+        graph,
+        details,
+        parseNodeId("root"),
+        (id) => id === "gone",
+      ),
+    ).toBeCloseTo(0.12 + 4, 5);
+  });
+
   it("vouches for a one-level tree, which is what a board actually shows", () => {
     // The case that makes the board useful rather than blank: the focused
     // collection plus media-only children is fully in the graph, so its cards

--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -644,6 +644,65 @@ export function hydratedCollectionDuration(
  * before the field existed — where nothing is disabled the two are equal
  * anyway, so the fallback is exact rather than approximate.
  */
+/**
+ * What a viewer sits through in ONE collection — lane-aware.
+ *
+ * The board header's number. Its twin below answers the same question
+ * lane-BLIND, by summing every child, and cannot be changed to do otherwise:
+ * `graphChildrenToClips` projects through it to persist each clip's
+ * `playableDuration`, so redefining it would rewrite stored summaries.
+ *
+ * WHY THE HEADER NEEDED ITS OWN. It was computing from card GEOMETRY —
+ * `playableSpanSeconds` over the spans the strip draws — which is the layout
+ * span, and a card whose descendants are disabled keeps its full slot. So the
+ * header counted time nobody watches: on a real project it read 23:01 while its
+ * three cards summed to about 20:45, because more than half of one branch is
+ * disabled deep inside. The spans carry no node id, so the fix could not live
+ * in `playableSpanSeconds` — it has to start from the graph.
+ *
+ * LANES PLAY TOGETHER, so a lane's contents are summed and the longest lane
+ * wins. Summing across lanes would claim a 4s bed under a 4s shot makes an 8s
+ * timeline. Only 4 clips across 2 documents use a non-picture lane here, but
+ * the header is the one readout that already got this right and it should not
+ * regress to fix the other half.
+ */
+export function hydratedCollectionPlayableSpan(
+  graph: CollectionsGraph,
+  details: DetailsById,
+  collectionId: NodeId,
+  isKnownMissing: (id: string) => boolean = () => false,
+): number {
+  const byLane = new Map<number, number[]>();
+  for (const childId of getChildren(graph, collectionId)) {
+    const node = graph.nodesById.get(childId);
+    if (!node || node.disabled === true) continue;
+    const key = childId as string;
+    // Gone contributes NO SECONDS but still takes a slot, which is the same
+    // bargain the lane-blind walk makes: the broken reference is drawn, so it
+    // still separates its neighbours and its gap is real.
+    const seconds = isKnownMissing(key)
+      ? 0
+      : node.kind === "media"
+        ? mediaDurationSeconds(node)
+        : hydratedCollectionPlayableDuration(graph, details, childId, isKnownMissing);
+    // THE LANE IS ON THE NODE, not the detail — the same source
+    // `graphChildrenToClips` reads when it projects a clip back out.
+    const lane = trackIndexOf({ trackIndex: node.trackIndex ?? 0 });
+    const row = byLane.get(lane);
+    if (row) row.push(seconds);
+    else byLane.set(lane, [seconds]);
+  }
+  let longest = 0;
+  for (const row of byLane.values()) {
+    const content = row.reduce((total, seconds) => total + seconds, 0);
+    longest = Math.max(
+      longest,
+      TIMELINE_LEADING_PADDING_SECONDS + content + CLIP_GAP_SECONDS * (row.length - 1),
+    );
+  }
+  return longest;
+}
+
 export function hydratedCollectionPlayableDuration(
   graph: CollectionsGraph,
   details: DetailsById,

--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -490,6 +490,30 @@ function placeholderSeconds(...candidates: readonly (number | undefined)[]): num
 const EMPTY_COLLECTION_SECONDS = 3;
 
 /**
+ * The node whose CHILDREN are this collection's real content, or null when it
+ * is not loaded.
+ *
+ * Ordinarily that is the node itself. A DUPLICATE placement is the exception:
+ * the same child referenced twice inside one hydrated area is demoted to a
+ * `dup:` node with no children of its own, carrying `duplicateOfTimelineId`
+ * back to the placement that does have them.
+ *
+ * The walks below used to read such a node's STORED summary, which is a copy
+ * nothing maintains. In a real project the two parents of the one duplicated
+ * collection store 6.12s and 7.12s for the same 4.0s of content — so at least
+ * one was always wrong, and whichever ancestor contained it inherited the
+ * error. Following the pointer costs nothing (the original is already in the
+ * graph) and makes the answer exact.
+ */
+function collectionContentSource(details: DetailsById, id: NodeId): NodeId | null {
+  const detail = details[id as string];
+  if (detail?.hydrated === true) return id;
+  const original = detail?.duplicateOfTimelineId;
+  if (original !== undefined && details[original]?.hydrated === true) return original as NodeId;
+  return null;
+}
+
+/**
  * Can this collection's aggregate readouts be VOUCHED for?
  *
  * True only when the collection and every collection beneath it is hydrated.
@@ -541,7 +565,15 @@ export function collectionSubtreeHydrated(
     // the root". Failing on absence made the board header permanently
     // timeless.
     const detail = details[key];
-    if (detail !== undefined && detail.hydrated !== true) return false;
+    if (detail !== undefined) {
+      // A DUPLICATE resolves to the placement that holds the content, exactly
+      // as the duration walks do — otherwise a second reference to a loaded
+      // collection blocks every ancestor forever, which is what kept a
+      // 133-document branch timeless after the dangling ids were handled.
+      const source = collectionContentSource(details, id);
+      if (source === null) return false;
+      if (source !== id) return visit(source, visiting);
+    }
     visiting.add(key);
     for (const childId of getChildren(graph, id)) {
       const node = graph.nodesById.get(childId);
@@ -559,32 +591,42 @@ export function hydratedCollectionDuration(
   details: DetailsById,
   collectionId: NodeId,
 ): number {
-  let total = TIMELINE_LEADING_PADDING_SECONDS;
-  let first = true;
-  for (const childId of getChildren(graph, collectionId)) {
-    const node = graph.nodesById.get(childId);
-    if (!node) continue;
-    if (!first) total += CLIP_GAP_SECONDS;
-    first = false;
-    if (node.kind === "media") {
-      total += mediaDurationSeconds(node);
-      continue;
+  // VISITING GUARD. Following a duplicate's pointer is the first thing in this
+  // walk that can reach a node already on the stack, so the recursion needs a
+  // way to stop. A tree never triggers it.
+  const walk = (id: NodeId, visiting: Set<string>): number => {
+    const key = id as string;
+    if (visiting.has(key)) return EMPTY_COLLECTION_SECONDS;
+    visiting.add(key);
+    let total = TIMELINE_LEADING_PADDING_SECONDS;
+    let first = true;
+    for (const childId of getChildren(graph, id)) {
+      const node = graph.nodesById.get(childId);
+      if (!node) continue;
+      if (!first) total += CLIP_GAP_SECONDS;
+      first = false;
+      if (node.kind === "media") {
+        total += mediaDurationSeconds(node);
+        continue;
+      }
+      const source = collectionContentSource(details, childId);
+      total +=
+        source === null
+          ? placeholderSeconds(details[childId as string]?.duration)
+          : walk(source, visiting);
     }
-    const detail = details[childId as string];
-    total += detail?.hydrated
-      ? hydratedCollectionDuration(graph, details, childId)
-      : placeholderSeconds(detail?.duration);
-  }
-  // NOTHING COUNTABLE means the model's empty floor, not the padding constant.
-  //
-  // This walk started at TIMELINE_LEADING_PADDING_SECONDS — which is zero — and
-  // added a term per child, so an empty collection returned 0 while
-  // `collectionSpanSeconds` returned 3 for the same question. That is where the
-  // stored zeroes came from: the write path persists documents THROUGH this
-  // projection, so every empty collection wrote a duration of 0, and every
-  // reader downstream then had to defend against a value that was never a
-  // measurement.
-  return first ? EMPTY_COLLECTION_SECONDS : total;
+    visiting.delete(key);
+    // NOTHING COUNTABLE means the model's empty floor, not the padding
+    // constant. This walk starts at TIMELINE_LEADING_PADDING_SECONDS — which is
+    // zero — and adds a term per child, so an empty collection returned 0 while
+    // `collectionSpanSeconds` returned 3 for the same question. That is where
+    // the stored zeroes came from: the write path persists documents THROUGH
+    // this projection, so every empty collection wrote a duration of 0, and
+    // every reader downstream then had to defend against a value that was never
+    // a measurement.
+    return first ? EMPTY_COLLECTION_SECONDS : total;
+  };
+  return walk(collectionId, new Set());
 }
 
 /**
@@ -606,38 +648,67 @@ export function hydratedCollectionPlayableDuration(
   graph: CollectionsGraph,
   details: DetailsById,
   collectionId: NodeId,
+  /**
+   * Ids the server has reported as GONE. They contribute ZERO here.
+   *
+   * Not what this did: a dangling reference fell through to
+   * `placeholderSeconds`, which returns the clip's stored duration — a
+   * remembered number for content that no longer exists. Measured on a real
+   * project, five dangling references added 33.9s to one collection's readout,
+   * so a card reported 19:24 of material when 18:51 of it was real.
+   *
+   * Its GEOMETRY twin deliberately keeps the stored span: the broken reference
+   * still draws a card, and a zero-width card cannot be seen or clicked. What
+   * a viewer would sit through is a different question, and the answer for a
+   * document that is gone is nothing.
+   */
+  isKnownMissing: (id: string) => boolean = () => false,
 ): number {
-  let total = TIMELINE_LEADING_PADDING_SECONDS;
-  let first = true;
-  for (const childId of getChildren(graph, collectionId)) {
-    const node = graph.nodesById.get(childId);
-    if (!node) continue;
-    if (node.disabled === true) continue;
-    if (!first) total += CLIP_GAP_SECONDS;
-    first = false;
-    if (node.kind === "media") {
-      total += mediaDurationSeconds(node);
-      continue;
+  const walk = (id: NodeId, visiting: Set<string>): number => {
+    const key = id as string;
+    if (visiting.has(key)) return 0;
+    visiting.add(key);
+    let total = TIMELINE_LEADING_PADDING_SECONDS;
+    let first = true;
+    for (const childId of getChildren(graph, id)) {
+      const node = graph.nodesById.get(childId);
+      if (!node) continue;
+      if (node.disabled === true) continue;
+      if (!first) total += CLIP_GAP_SECONDS;
+      first = false;
+      if (node.kind === "media") {
+        total += mediaDurationSeconds(node);
+        continue;
+      }
+      const childKey = childId as string;
+      // Gone plays for zero seconds — see `isKnownMissing` above. The gap is
+      // still counted: the card is drawn, so it still separates its neighbours.
+      if (isKnownMissing(childKey)) continue;
+      const source = collectionContentSource(details, childId);
+      const detail = details[childKey];
+      total +=
+        source === null
+          ? placeholderSeconds(detail?.playableDuration, detail?.duration)
+          : walk(source, visiting);
     }
-    const detail = details[childId as string];
-    total += detail?.hydrated
-      ? hydratedCollectionPlayableDuration(graph, details, childId)
-      : placeholderSeconds(detail?.playableDuration, detail?.duration);
-  }
-  // NO FLOOR HERE, unlike its twin, and the difference is the whole point of
-  // there being two walks.
-  //
-  // I put one here first and an existing test refused it: "returns ZERO when
-  // every child is disabled — a real answer, not 'unknown'". That is right.
-  // Geometry needs a floor because a zero-width card cannot be seen or clicked;
-  // a READOUT of what a viewer would sit through has no such need, and zero is
-  // a legitimate live value for a collection that plays nothing. Flooring it
-  // would also re-break what that test guards: a reader treating 0 as "unknown"
-  // falls back on a stale nonzero summary and re-quotes it.
-  //
-  // The placeholder fallback above still defaults to 3, and that is consistent:
-  // an UN-HYDRATED child is unknown, an all-disabled one is measured.
-  return total;
+    visiting.delete(key);
+    // NO FLOOR HERE, unlike its twin, and the difference is the whole point of
+    // there being two walks.
+    //
+    // A floor was tried here and an existing test refused it: "returns ZERO
+    // when every child is disabled — a real answer, not 'unknown'". Geometry
+    // needs a floor because a zero-width card cannot be seen or clicked; a
+    // READOUT of what a viewer would sit through has no such need, and zero is
+    // a legitimate live value for a collection that plays nothing. Flooring it
+    // would also re-break what that test guards: a reader treating 0 as
+    // "unknown" falls back on a stale nonzero summary and re-quotes it.
+    //
+    // The placeholder fallback above still defaults to 3, and that is
+    // consistent: an UN-HYDRATED child is unknown, an all-disabled one is
+    // measured.
+    return total;
+  };
+  return walk(collectionId, new Set());
 }
 
 /**

--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -489,6 +489,50 @@ function placeholderSeconds(...candidates: readonly (number | undefined)[]): num
  */
 const EMPTY_COLLECTION_SECONDS = 3;
 
+/**
+ * Can this collection's aggregate readouts be VOUCHED for?
+ *
+ * True only when the collection and every collection beneath it is hydrated.
+ * The distinction matters because `hydratedCollectionDuration` below answers
+ * for a partly-loaded tree by substituting each unhydrated child's STORED
+ * summary — a number that is right often enough to look right and wrong often
+ * enough to mislead. Measured on a real project served one level deep, two of
+ * the three cards on the board reported a duration off by up to 40 seconds.
+ *
+ * So the walks stay as they are (the write path projects through them, and
+ * geometry must always have an answer), and this says whether the answer is
+ * worth SHOWING. A card that cannot vouch for its time renders no time and
+ * gains one when the branch is opened and its subtree loads.
+ *
+ * A reference CYCLE resolves as vouched rather than looping: an unhydrated node
+ * anywhere in it has already returned false, so the only way back to a node
+ * being visited is through nodes that were all hydrated.
+ */
+export function collectionSubtreeHydrated(
+  graph: CollectionsGraph,
+  details: DetailsById,
+  collectionId: NodeId,
+  visiting: Set<string> = new Set(),
+): boolean {
+  const key = collectionId as string;
+  if (visiting.has(key)) return true;
+  // ABSENT is not unhydrated. Details are built from a parent's CLIP, so the
+  // focused root has no entry of its own — its document is the one thing we
+  // certainly hold. Any referenced child does have an entry (with
+  // `hydrated: false` until it loads), so absence only ever means "this is the
+  // root". Failing on absence made the board header permanently timeless.
+  const detail = details[key];
+  if (detail !== undefined && detail.hydrated !== true) return false;
+  visiting.add(key);
+  for (const childId of getChildren(graph, collectionId)) {
+    const node = graph.nodesById.get(childId);
+    if (!node || node.kind !== "collection") continue;
+    if (!collectionSubtreeHydrated(graph, details, childId, visiting)) return false;
+  }
+  visiting.delete(key);
+  return true;
+}
+
 export function hydratedCollectionDuration(
   graph: CollectionsGraph,
   details: DetailsById,

--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -512,25 +512,46 @@ export function collectionSubtreeHydrated(
   graph: CollectionsGraph,
   details: DetailsById,
   collectionId: NodeId,
-  visiting: Set<string> = new Set(),
+  /**
+   * Ids the server has REPORTED as gone — a `childTimelineId` whose document
+   * does not exist.
+   *
+   * GONE IS KNOWN, and conflating it with "not loaded yet" is what made this
+   * predicate wait forever. A dangling reference has no document to load, so a
+   * branch containing one could never vouch and its card was permanently
+   * timeless rather than briefly so. Measured on a real project: five dangling
+   * references under one collection held an otherwise complete 133-document
+   * branch at "no duration", indefinitely.
+   *
+   * A missing child contributes nothing to a total, and the walks already
+   * treat it that way, so a subtree whose only unhydrated members are known
+   * missing is exactly computable.
+   */
+  isKnownMissing: (id: string) => boolean = () => false,
 ): boolean {
-  const key = collectionId as string;
-  if (visiting.has(key)) return true;
-  // ABSENT is not unhydrated. Details are built from a parent's CLIP, so the
-  // focused root has no entry of its own — its document is the one thing we
-  // certainly hold. Any referenced child does have an entry (with
-  // `hydrated: false` until it loads), so absence only ever means "this is the
-  // root". Failing on absence made the board header permanently timeless.
-  const detail = details[key];
-  if (detail !== undefined && detail.hydrated !== true) return false;
-  visiting.add(key);
-  for (const childId of getChildren(graph, collectionId)) {
-    const node = graph.nodesById.get(childId);
-    if (!node || node.kind !== "collection") continue;
-    if (!collectionSubtreeHydrated(graph, details, childId, visiting)) return false;
-  }
-  visiting.delete(key);
-  return true;
+  const visit = (id: NodeId, visiting: Set<string>): boolean => {
+    const key = id as string;
+    if (visiting.has(key)) return true;
+    // Gone, and known to be gone — see above.
+    if (isKnownMissing(key)) return true;
+    // ABSENT is not unhydrated. Details are built from a parent's CLIP, so the
+    // focused root has no entry of its own — its document is the one thing we
+    // certainly hold. Any referenced child does have an entry (with
+    // `hydrated: false` until it loads), so absence only ever means "this is
+    // the root". Failing on absence made the board header permanently
+    // timeless.
+    const detail = details[key];
+    if (detail !== undefined && detail.hydrated !== true) return false;
+    visiting.add(key);
+    for (const childId of getChildren(graph, id)) {
+      const node = graph.nodesById.get(childId);
+      if (!node || node.kind !== "collection") continue;
+      if (!visit(childId, visiting)) return false;
+    }
+    visiting.delete(key);
+    return true;
+  };
+  return visit(collectionId, new Set());
 }
 
 export function hydratedCollectionDuration(


### PR DESCRIPTION
Opening a board read the project's **entire closure** — 149 documents — and every focus navigation read it again. This bounds both, then deals with what that exposed.

## Reads

| | before | after |
|---|---|---|
| board open | 150 | **5** |
| each focus navigation | ~149 | **~12** |
| drill in + two clicks back up | 580 reads, 149/149 documents read more than once | **185**, 15 read more than once |

The payload was never the reason for the walk. Serving a collection derives every descendant's `itemCount` / `duration` / `previewItems` / `title` bottom-up, so all of them were read; shipping them was just making use of documents already fetched. The board doesn't need them — it renders one level and hydrates the rest on demand.

`BackgroundClosureHydrator` then fills the rest in after first paint through `ensureClosure` — one request, one shared reader. Same total bill, moved off the critical path: a session that stays pays what it used to, one that glances and leaves pays 5.

The preview/export compile deliberately keeps the full closure. It flattens the real tree, and a stale grandchild would window its parent's content out of the timeline.

## Then: the numbers on screen were wrong

Stored summaries are wrong on **58.4%** of collection clips, because the write set is patch-derived — editing a descendant never rewrites the ancestors it invalidated. The read-time derivation quietly repaired that on every open, and that repair *was* the 149 reads. Removing it made the rot visible: two of three cards on the board reported a duration up to **40 seconds** wrong.

So a collection shows a time only when it can add one up (`collectionSubtreeHydrated`). A wrong number is worse than an absent one, because nobody can tell which ones are wrong. Item counts stay — one level of reading settles a count exactly.

This keeps the board useful rather than blank: a media-only collection is complete as soon as its own document arrives, which is **103 of 149** collections here.

## And what that in turn exposed

- **Dangling references were quoted as real footage.** A missing child fell through to its stored duration, so five of them added **33.9s** to one collection's readout. They now play for zero seconds but keep their gap — the broken card is still drawn.
- **A delete could create more of them.** The cascade walks down and never asked who pointed *into* the subtree. `TimelineInboundReferenceError` refuses and names them; it's one query, newly affordable because every document carries `projectId`.
- **The header disagreed with its own cards** — 23:01 against ~20:45 — because it measured card *geometry*, which keeps a disabled branch's full slot.
- **Two different skeletons** on every open, because the route fallback and the dynamic-import fallback drew different card shapes.
- **Two bugs of mine**, caught by watching the actual board: five concurrent closure requests (745 reads to do a 149-read job), then zero (a once-guard claimed at effect entry, cancelled by React's double-invoke).

## Also

- `formatDuration` uses clock notation at every length — the board read "1:29" beside "25.3s".
- `scripts/remove-dangling-collection-references.ts` clears stored dangling refs. Dry run by default. **Run against the local fixture only** — production still has five.

## Verification

Every headline number was measured through the real serve path on real project data, and the board was checked in the running app rather than by test alone. Behaviour-defining tests were confirmed to fail without their fix.

App 1308 · unit 783 · stories 257.

## Known gaps

- One duplicate placement's stored copies still disagree (6.12s vs 7.12s for the same 4.0s collection) where nothing has rewritten them; the walks now follow the pointer, so what's *displayed* is derived.
- Documents without `projectId` skip the inbound check rather than triggering a collection scan — `npm run stamp:project-ids` is the fix.
- The skeleton settles ~10px at the final handover; matching exactly means reproducing the board's card-sizing logic in a placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)