### PR TITLE
Bump the revision when the dangling-reference cleanup rewrites a document

### DIFF
--- a/apps/timeline-gstudio001/scripts/remove-dangling-collection-references.ts
+++ b/apps/timeline-gstudio001/scripts/remove-dangling-collection-references.ts
@@ -39,7 +39,15 @@ if (!rootId) {
   process.exit(2);
 }
 
-type Loaded = { documents: Map<string, TimelineDocument>; fixturePath?: string; raw?: unknown };
+type Loaded = {
+  documents: Map<string, TimelineDocument>;
+  /** Stored revision per id — the compare-and-set counter the app writes
+   *  through. A raw write that leaves it alone lets a client still holding the
+   *  OLD revision save over this change and win. */
+  revisions: Map<string, number>;
+  fixturePath?: string;
+  raw?: unknown;
+};
 
 async function load(): Promise<Loaded> {
   if (useFixture) {
@@ -47,7 +55,12 @@ async function load(): Promise<Loaded> {
     const raw = JSON.parse(readFileSync(path, "utf8")) as {
       documents: Record<string, TimelineDocument>;
     };
-    return { documents: new Map(Object.entries(raw.documents)), fixturePath: path, raw };
+    return {
+      documents: new Map(Object.entries(raw.documents)),
+      revisions: new Map(),
+      fixturePath: path,
+      raw,
+    };
   }
   const projectId = process.env.FIREBASE_PROJECT_ID;
   const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
@@ -65,25 +78,34 @@ async function load(): Promise<Loaded> {
     .where("projectId", "==", rootId)
     .get();
   const documents = new Map<string, TimelineDocument>();
+  const revisions = new Map<string, number>();
   for (const doc of snapshot.docs) {
-    const data = doc.data() as { document?: TimelineDocument; clips?: TimelineDocument["clips"] };
+    const data = doc.data() as {
+      document?: TimelineDocument;
+      clips?: TimelineDocument["clips"];
+      revision?: number;
+    };
     const document = data.document ?? { id: doc.id, title: "", clips: data.clips ?? [] };
     documents.set(doc.id, document);
+    revisions.set(doc.id, data.revision ?? 0);
   }
   // The root itself carries its own id as projectId only if stamped; fetch it
   // directly so a partially stamped project still reports honestly.
   if (!documents.has(rootId)) {
     const root = await db.collection(COLLECTION).doc(rootId).get();
     if (root.exists) {
-      const data = root.data() as { document?: TimelineDocument };
-      if (data.document) documents.set(rootId, data.document);
+      const data = root.data() as { document?: TimelineDocument; revision?: number };
+      if (data.document) {
+        documents.set(rootId, data.document);
+        revisions.set(rootId, data.revision ?? 0);
+      }
     }
   }
-  return { documents };
+  return { documents, revisions };
 }
 
 async function main(): Promise<void> {
-  const { documents, fixturePath, raw } = await load();
+  const { documents, revisions, fixturePath, raw } = await load();
   if (!documents.has(rootId)) {
     console.error(`No document "${rootId}" (loaded ${documents.size}).`);
     process.exit(1);
@@ -150,9 +172,14 @@ async function main(): Promise<void> {
       for (const [id, document] of entries.slice(i, i + FIRESTORE_BATCH_LIMIT)) {
         // Both shapes, because readers resolve from either — see
         // `toTimelineDocument`'s precedence.
+        // REVISION BUMPED, not left alone. The app's writes are compare-and-set
+        // against this counter; a raw edit that leaves it unchanged lets a
+        // client still holding the old revision save over this and win
+        // silently. Bumping it means their next save is refused with "changed
+        // in another view", which is the truth — it did.
         batch.set(
           db.collection(COLLECTION).doc(id),
-          { document, clips: document.clips },
+          { document, clips: document.clips, revision: (revisions.get(id) ?? 0) + 1 },
           { merge: true },
         );
       }


### PR DESCRIPTION
Follow-up to #466, found while preparing the production run.

`scripts/remove-dangling-collection-references.ts` wrote `document` and `clips` straight through and left `revision` untouched. That counter is what the app's writes compare-and-set against — so a client still holding the pre-cleanup revision would have saved over the change and won, silently restoring the dangling references it had just removed.

Bumping it means such a save is refused with "changed in another view", which is accurate: the document did change.

## Production run

Applied to Toon Town after this fix:

```
5 dangling reference(s) across 2 document(s)
  "Run 1 — woman aligned"  revision 13 -> 14, clips 3 -> 0
  "Davis Square street"    revision 12 -> 13, clips 3 -> 1

re-run: 0 dangling reference(s), from 143 reachable  (was 148)
```

The 148 → 143 difference is the five phantom ids the walk can no longer follow. Both documents were backed up before the write.

`"Run 1 — woman aligned"` is now empty — all three of its children were dangling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)