### PR TITLE
Shape the board skeleton like the board

### DIFF
--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -373,7 +373,7 @@ html {
    held opaque and given the same pose, which reads as one object moving. */
 ::view-transition-old(sw-monster),
 ::view-transition-new(sw-monster) {
-  animation: sw-monster-hop 620ms cubic-bezier(0.34, 0.8, 0.28, 1) both;
+  animation: sw-monster-hop 680ms cubic-bezier(0.34, 0.8, 0.28, 1) both;
   mix-blend-mode: normal;
   height: 100%;
   object-fit: contain;
@@ -387,40 +387,59 @@ html {
    SOLID DRAWING is the rotation. A body that only scales on two axes reads as
    a flat sticker; tipping it into and out of the arc gives it a front and a
    back, and the tip reverses on the way down the way a real body rotates
-   around its own mass. */
+   around its own mass.
+
+   THE LEAN IS SIGNED. `--sw-hop-dir` is +1 when the creature travels right
+   (opening the rail, out of the centre and into the word) and -1 when it
+   travels left, so every rotation and sideways drift below multiplies by it and
+   the body leans INTO the jump either way. Fixed the other way round it reads
+   as being blown sideways rather than as choosing to go.
+
+   Kept small on purpose — a few degrees and a couple of percent. At ~20px a
+   lean big enough to notice as a lean is big enough to look like a wobble. */
 @keyframes sw-monster-hop {
   /* Standing. */
   0% {
-    transform: translateY(0) scale(1, 1) rotate(0deg);
+    transform: translate(0, 0) scale(1, 1) rotate(0deg);
   }
-  /* ANTICIPATION: the crouch. Wider and shorter, sinking slightly. */
+  /* ANTICIPATION: the crouch. Wider and shorter, sinking slightly, and already
+     shifting a hair AGAINST the direction of travel — you rock back before you
+     go. */
   14% {
-    transform: translateY(8%) scale(1.22, 0.78) rotate(0deg);
+    transform: translate(calc(var(--sw-hop-dir, 1) * -1%), 8%) scale(1.22, 0.78)
+      rotate(calc(var(--sw-hop-dir, 1) * -1deg));
   }
   /* The push-off — already stretching before it leaves the ground, and tipping
      into the direction of travel. */
   26% {
-    transform: translateY(-14%) scale(0.84, 1.22) rotate(-5deg);
+    transform: translate(calc(var(--sw-hop-dir, 1) * 2%), -22%) scale(0.84, 1.22)
+      rotate(calc(var(--sw-hop-dir, 1) * 4deg));
   }
-  /* Top of the arc: fully stretched, highest lift, tip at its greatest. */
+  /* Top of the arc: fully stretched, highest lift, lean at its greatest.
+     The lift is a share of the creature's OWN height, so it clears its own body
+     and a bit more — enough that the jump reads as a jump at 15px rather than
+     as a bounce, without throwing it out of the rail. */
   46% {
-    transform: translateY(-42%) scale(0.82, 1.24) rotate(-7deg);
+    transform: translate(calc(var(--sw-hop-dir, 1) * 3%), -64%) scale(0.82, 1.24)
+      rotate(calc(var(--sw-hop-dir, 1) * 6deg));
   }
-  /* Falling, gathering, and rotating back through level. */
+  /* Falling, gathering, and rotating back THROUGH level — the counter-rotation
+     is what makes the landing read as absorbed rather than dropped. */
   66% {
-    transform: translateY(-12%) scale(0.92, 1.1) rotate(3deg);
+    transform: translate(calc(var(--sw-hop-dir, 1) * 1%), -20%) scale(0.92, 1.1)
+      rotate(calc(var(--sw-hop-dir, 1) * -2deg));
   }
   /* Landing: the squash absorbs it, the tip flattens out. */
   80% {
-    transform: translateY(4%) scale(1.2, 0.8) rotate(1deg);
+    transform: translate(0, 4%) scale(1.2, 0.8) rotate(calc(var(--sw-hop-dir, 1) * -1deg));
   }
   /* FOLLOW-THROUGH: a small rebound past the resting pose... */
   91% {
-    transform: translateY(-3%) scale(0.95, 1.06) rotate(0deg);
+    transform: translate(0, -3%) scale(0.95, 1.06) rotate(0deg);
   }
   /* ...and settle. */
   100% {
-    transform: translateY(0) scale(1, 1) rotate(0deg);
+    transform: translate(0, 0) scale(1, 1) rotate(0deg);
   }
 }
 
@@ -435,25 +454,45 @@ html {
   }
 }
 
-/* ── The settle, after the creature lands ─────────────────────────────────────
+/* ── The eye and the feet ─────────────────────────────────────────────────────
    SECONDARY ACTION and OVERLAPPING ACTION, and the reason they live here rather
    than in the hop above: a view transition rasterises the creature into a
    single IMAGE, so nothing inside it can move independently while it is in
    flight. The eye and the feet are parts of that picture, not elements.
 
-   So they act once the transition hands control back to the live element. The
-   body has arrived; the parts have not finished. The eye jolts and re-centres
-   (secondary action — a reaction that comments on the main one without
-   competing with it), and the feet keep spreading a beat after the landing and
-   draw back (overlapping action — loose parts trail the mass that carried
-   them).
+   That constraint splits them in two, and the split is the whole design:
 
-   TIMING is what keeps them from reading as one event: the eye leads by 50ms,
-   the feet lag by 110ms and run longer. Simultaneous would look like a single
-   twitch. */
+   A POSE CAN BE CAPTURED INTO THE IMAGE even though motion cannot. So the eye's
+   AIM is set before the transition begins and held until it ends — the pupil is
+   already pointing along the arc in both snapshots, and the creature flies
+   looking where it is going rather than staring straight ahead the whole way.
+
+   MOTION WAITS for the live element. Once the body has arrived the parts have
+   not finished: the eye takes the landing and eases back to centre (secondary
+   action — a reaction that comments on the main one without competing with it),
+   and the feet keep spreading a beat after the landing and draw back
+   (overlapping action — loose parts trail the mass that carried them).
+
+   TIMING is what keeps those two from reading as one event: the eye picks up
+   the instant the flight ends, the feet lag by 110ms and run longer.
+   Simultaneous would look like a single twitch. */
+
+/* THE AIM, which is on for the whole flight rather than after it.
+   `data-aiming` is set BEFORE the transition starts and cleared when it
+   finishes, so both snapshots — the crouch it leaves and the pose it lands in —
+   are rasterised with the pupil already pointing along the arc. The eye leads
+   the body, which is what makes the hop read as chosen: it looks where it is
+   going before it goes, and is still looking there when it arrives.
+
+   It is a plain declaration, not an animation, precisely because the creature
+   is a static image mid-flight — there is nothing to animate then, only a pose
+   to be captured in. */
+[data-storyboard-monster][data-aiming] [data-monster-pupil] {
+  transform: translate(calc(var(--sw-hop-dir, 1) * 26%), -12%);
+}
 
 [data-storyboard-monster][data-settling] [data-monster-pupil] {
-  animation: sw-pupil-settle 380ms cubic-bezier(0.22, 1, 0.36, 1) 50ms both;
+  animation: sw-pupil-settle 440ms cubic-bezier(0.32, 0.72, 0.3, 1) both;
 }
 
 [data-storyboard-monster][data-settling] [data-monster-foot] {
@@ -462,19 +501,43 @@ html {
 
 /* The eye is thrown by the landing, overshoots, and comes back level. It moves
    FURTHER than the body did, which is the exaggeration that makes a small mark
-   read as alive at 15px. */
+   read as alive at 15px.
+
+   IT NEVER LOOKS BACK. The horizontal component is signed by `--sw-hop-dir` and
+   DECAYS on that one side — it does not cross the centre. An earlier version
+   let the eye overshoot horizontally the way a loose part does, which is
+   correct physics and wrong acting: for the few frames it sat on the far side
+   the creature was looking back the way it came, at the exact moment it was
+   meant to be arriving somewhere. The overshoot lives in the vertical instead,
+   where it still reads as a landing jolt.
+
+   So the pupil picks up where the flight left it — aimed ahead and high — takes
+   the impact downward, bounces, and eases back to centre only once the creature
+   has stopped. Watching the reader again is the resting pose, not the arrival.
+
+   Kept inside the white: the pupil is 0.28em within a 0.46em eye, so a quarter
+   of its own width is about as far as it can travel before it would clip. */
 @keyframes sw-pupil-settle {
+  /* Exactly the aim it flew with, so the handover from image to element is
+     invisible — the same pose, now on an element that can move. */
   0% {
-    transform: translateY(-22%);
+    transform: translate(calc(var(--sw-hop-dir, 1) * 26%), -12%);
   }
-  45% {
-    transform: translateY(9%);
+  /* The impact drives it down. Still looking ahead. */
+  30% {
+    transform: translate(calc(var(--sw-hop-dir, 1) * 22%), 12%);
   }
-  75% {
-    transform: translateY(-3%);
+  /* Bounce, and the aim begins to relax. */
+  58% {
+    transform: translate(calc(var(--sw-hop-dir, 1) * 14%), -6%);
   }
+  /* A last small correction, still on the travel side. */
+  80% {
+    transform: translate(calc(var(--sw-hop-dir, 1) * 6%), 2%);
+  }
+  /* Level, centred, watching the reader again. */
   100% {
-    transform: translateY(0);
+    transform: translate(0, 0);
   }
 }
 
@@ -499,5 +562,9 @@ html {
   [data-storyboard-monster][data-settling] [data-monster-pupil],
   [data-storyboard-monster][data-settling] [data-monster-foot] {
     animation: none;
+  }
+
+  [data-storyboard-monster][data-aiming] [data-monster-pupil] {
+    transform: none;
   }
 }

--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -319,3 +319,185 @@ html {
     animation: none;
   }
 }
+
+/* ── The storyboard monster's hop ─────────────────────────────────────────────
+   Collapsing the rail re-lays the creature out rather than moving it: inline in
+   "m…nster" when open, alone and larger when closed. A view transition is what
+   gives the browser two snapshots to interpolate; these rules turn that
+   interpolation into a jump instead of a slide.
+
+   The animation principles it is built from, since the numbers otherwise look
+   arbitrary:
+
+   ANTICIPATION — it squashes DOWN before it goes up. Nothing jumps without
+   crouching first, and without it the launch reads as the creature being
+   yanked rather than deciding to leave.
+
+   SQUASH AND STRETCH — width and height trade against each other and the
+   product stays near 1, so the body keeps its volume. A squash that only
+   flattens looks like a dropped object; one that also widens looks alive.
+
+   SLOW IN AND SLOW OUT — the group's easing is fast out of the crouch and
+   settles into the landing, rather than moving at one speed.
+
+   ARC — the browser interpolates position in a straight line, so the lift is
+   added on top as a translate that peaks mid-flight. A creature that travels
+   flat between two points reads as a sprite being dragged.
+
+   FOLLOW-THROUGH — it overshoots the landing and settles back. The body
+   arrives before the pose does.
+
+   EXAGGERATION — the scales are past what a real body would do (0.72 / 1.24 at
+   the extremes) because at ~20px anything subtler is invisible. */
+
+::view-transition-group(sw-monster) {
+  /* The travel itself: out of the crouch quickly, easing into the landing. */
+  animation-duration: 620ms;
+  animation-timing-function: cubic-bezier(0.34, 0.8, 0.28, 1);
+  /* STAGING: the creature is the only thing that should be moving, so it sits
+     above the rest of the transition rather than under the rail's own chrome. */
+  z-index: 10;
+}
+
+/* STAGING, the other half. Everything else in the page is snapshotted as `root`
+   and cross-faded by default, so the whole app would dip while the creature
+   jumps — the eye would not know where to look. The rest of the UI cuts
+   instantly and the only thing animating is the thing worth watching. */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+}
+
+/* The two snapshots are the SAME drawing, so they must not cross-fade — a
+   dissolve between identical images just dims the creature mid-jump. Both are
+   held opaque and given the same pose, which reads as one object moving. */
+::view-transition-old(sw-monster),
+::view-transition-new(sw-monster) {
+  animation: sw-monster-hop 620ms cubic-bezier(0.34, 0.8, 0.28, 1) both;
+  mix-blend-mode: normal;
+  height: 100%;
+  object-fit: contain;
+}
+
+/* POSE TO POSE, which is what keyframes are: these eight are the extremes and
+   the browser draws the in-betweens. They are written as poses — crouch,
+   push-off, apex, fall, landing, rebound, settle — not as an interpolation
+   between a start and an end.
+
+   SOLID DRAWING is the rotation. A body that only scales on two axes reads as
+   a flat sticker; tipping it into and out of the arc gives it a front and a
+   back, and the tip reverses on the way down the way a real body rotates
+   around its own mass. */
+@keyframes sw-monster-hop {
+  /* Standing. */
+  0% {
+    transform: translateY(0) scale(1, 1) rotate(0deg);
+  }
+  /* ANTICIPATION: the crouch. Wider and shorter, sinking slightly. */
+  14% {
+    transform: translateY(8%) scale(1.22, 0.78) rotate(0deg);
+  }
+  /* The push-off — already stretching before it leaves the ground, and tipping
+     into the direction of travel. */
+  26% {
+    transform: translateY(-14%) scale(0.84, 1.22) rotate(-5deg);
+  }
+  /* Top of the arc: fully stretched, highest lift, tip at its greatest. */
+  46% {
+    transform: translateY(-42%) scale(0.82, 1.24) rotate(-7deg);
+  }
+  /* Falling, gathering, and rotating back through level. */
+  66% {
+    transform: translateY(-12%) scale(0.92, 1.1) rotate(3deg);
+  }
+  /* Landing: the squash absorbs it, the tip flattens out. */
+  80% {
+    transform: translateY(4%) scale(1.2, 0.8) rotate(1deg);
+  }
+  /* FOLLOW-THROUGH: a small rebound past the resting pose... */
+  91% {
+    transform: translateY(-3%) scale(0.95, 1.06) rotate(0deg);
+  }
+  /* ...and settle. */
+  100% {
+    transform: translateY(0) scale(1, 1) rotate(0deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* The toggle already skips `startViewTransition` entirely under this query —
+     this is the belt to that braces, for a transition started by some other
+     path. */
+  ::view-transition-group(sw-monster),
+  ::view-transition-old(sw-monster),
+  ::view-transition-new(sw-monster) {
+    animation: none;
+  }
+}
+
+/* ── The settle, after the creature lands ─────────────────────────────────────
+   SECONDARY ACTION and OVERLAPPING ACTION, and the reason they live here rather
+   than in the hop above: a view transition rasterises the creature into a
+   single IMAGE, so nothing inside it can move independently while it is in
+   flight. The eye and the feet are parts of that picture, not elements.
+
+   So they act once the transition hands control back to the live element. The
+   body has arrived; the parts have not finished. The eye jolts and re-centres
+   (secondary action — a reaction that comments on the main one without
+   competing with it), and the feet keep spreading a beat after the landing and
+   draw back (overlapping action — loose parts trail the mass that carried
+   them).
+
+   TIMING is what keeps them from reading as one event: the eye leads by 50ms,
+   the feet lag by 110ms and run longer. Simultaneous would look like a single
+   twitch. */
+
+[data-storyboard-monster][data-settling] [data-monster-pupil] {
+  animation: sw-pupil-settle 380ms cubic-bezier(0.22, 1, 0.36, 1) 50ms both;
+}
+
+[data-storyboard-monster][data-settling] [data-monster-foot] {
+  animation: sw-foot-settle 460ms cubic-bezier(0.22, 1, 0.36, 1) 110ms both;
+}
+
+/* The eye is thrown by the landing, overshoots, and comes back level. It moves
+   FURTHER than the body did, which is the exaggeration that makes a small mark
+   read as alive at 15px. */
+@keyframes sw-pupil-settle {
+  0% {
+    transform: translateY(-22%);
+  }
+  45% {
+    transform: translateY(9%);
+  }
+  75% {
+    transform: translateY(-3%);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+
+/* The feet splay under the weight, then gather. Volume again: they widen as
+   they flatten. */
+@keyframes sw-foot-settle {
+  0% {
+    transform: scale(1.3, 0.7);
+  }
+  40% {
+    transform: scale(0.88, 1.16);
+  }
+  70% {
+    transform: scale(1.06, 0.95);
+  }
+  100% {
+    transform: scale(1, 1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-storyboard-monster][data-settling] [data-monster-pupil],
+  [data-storyboard-monster][data-settling] [data-monster-foot] {
+    animation: none;
+  }
+}

--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -395,51 +395,57 @@ html {
    the body leans INTO the jump either way. Fixed the other way round it reads
    as being blown sideways rather than as choosing to go.
 
+   THE STRETCH LEANS, and the ORDER of the functions is the whole reason it
+   does. CSS composes left to right as successive coordinate transforms, so
+   `scale() rotate()` rotates the point first and then scales along the GLOBAL
+   axes — the drawing shears and stays upright. `rotate() scale()` stretches
+   along the element's OWN axis and then turns that axis, which is what tips the
+   elongation into the direction of travel: at the top of the arc the body is
+   not a taller egg, it is a taller egg leaning the way it is going. Swap the
+   two back and the lean survives on the outline while the stretch quietly stops
+   pointing anywhere.
+
    Kept small on purpose — a few degrees and a couple of percent. At ~20px a
    lean big enough to notice as a lean is big enough to look like a wobble. */
 @keyframes sw-monster-hop {
   /* Standing. */
   0% {
-    transform: translate(0, 0) scale(1, 1) rotate(0deg);
+    transform: translate(0, 0) rotate(0deg) scale(1, 1);
   }
   /* ANTICIPATION: the crouch. Wider and shorter, sinking slightly, and already
      shifting a hair AGAINST the direction of travel — you rock back before you
      go. */
   14% {
-    transform: translate(calc(var(--sw-hop-dir, 1) * -1%), 8%) scale(1.22, 0.78)
-      rotate(calc(var(--sw-hop-dir, 1) * -1deg));
+    transform: translate(calc(var(--sw-hop-dir, 1) * -1%), 8%) rotate(calc(var(--sw-hop-dir, 1) * -1deg)) scale(1.22, 0.78);
   }
   /* The push-off — already stretching before it leaves the ground, and tipping
      into the direction of travel. */
   26% {
-    transform: translate(calc(var(--sw-hop-dir, 1) * 2%), -22%) scale(0.84, 1.22)
-      rotate(calc(var(--sw-hop-dir, 1) * 4deg));
+    transform: translate(calc(var(--sw-hop-dir, 1) * 2%), -22%) rotate(calc(var(--sw-hop-dir, 1) * 4deg)) scale(0.84, 1.22);
   }
   /* Top of the arc: fully stretched, highest lift, lean at its greatest.
      The lift is a share of the creature's OWN height, so it clears its own body
      and a bit more — enough that the jump reads as a jump at 15px rather than
      as a bounce, without throwing it out of the rail. */
   46% {
-    transform: translate(calc(var(--sw-hop-dir, 1) * 3%), -64%) scale(0.82, 1.24)
-      rotate(calc(var(--sw-hop-dir, 1) * 6deg));
+    transform: translate(calc(var(--sw-hop-dir, 1) * 3%), -64%) rotate(calc(var(--sw-hop-dir, 1) * 6deg)) scale(0.82, 1.24);
   }
   /* Falling, gathering, and rotating back THROUGH level — the counter-rotation
      is what makes the landing read as absorbed rather than dropped. */
   66% {
-    transform: translate(calc(var(--sw-hop-dir, 1) * 1%), -20%) scale(0.92, 1.1)
-      rotate(calc(var(--sw-hop-dir, 1) * -2deg));
+    transform: translate(calc(var(--sw-hop-dir, 1) * 1%), -20%) rotate(calc(var(--sw-hop-dir, 1) * -2deg)) scale(0.92, 1.1);
   }
   /* Landing: the squash absorbs it, the tip flattens out. */
   80% {
-    transform: translate(0, 4%) scale(1.2, 0.8) rotate(calc(var(--sw-hop-dir, 1) * -1deg));
+    transform: translate(0, 4%) rotate(calc(var(--sw-hop-dir, 1) * -1deg)) scale(1.2, 0.8);
   }
   /* FOLLOW-THROUGH: a small rebound past the resting pose... */
   91% {
-    transform: translate(0, -3%) scale(0.95, 1.06) rotate(0deg);
+    transform: translate(0, -3%) rotate(0deg) scale(0.95, 1.06);
   }
   /* ...and settle. */
   100% {
-    transform: translate(0, 0) scale(1, 1) rotate(0deg);
+    transform: translate(0, 0) rotate(0deg) scale(1, 1);
   }
 }
 
@@ -488,56 +494,173 @@ html {
    is a static image mid-flight — there is nothing to animate then, only a pose
    to be captured in. */
 [data-storyboard-monster][data-aiming] [data-monster-pupil] {
-  transform: translate(calc(var(--sw-hop-dir, 1) * 26%), -12%);
+  /* THREE PROPERTIES, ONE POSE. `translate`, `scale` and `transform` are
+     separate animatable properties that compose in that order, which is what
+     lets the horizontal flick, the dilation and the vertical bump each run on
+     their own clock below. One `transform` could not: they would have to share
+     a duration and an easing, and all three want different ones. */
+  translate: calc(var(--sw-hop-dir, 1) * 26%) 0;
+  scale: 1.2;
+  transform: translateY(-12%);
+}
+
+/* THE HAT FLIES TRAILING, for the same reason and by the same mechanism.
+   DRAG: a hat is not attached to the head, it rests on it, so when the head
+   leaves the ground the hat is still where the head used to be — lifted a hair
+   clear of the fur and rotated BACK against the direction of travel. It is the
+   one pose that says "this creature jumped" rather than "this creature was
+   moved".
+
+   Signed the opposite way to the body's lean on purpose: the body leans INTO
+   the jump, the hat leans away from it. Loose things trail; that difference
+   between the two is the whole read. */
+[data-storyboard-monster][data-aiming] [data-monster-hat] {
+  transform: translateY(-0.012em) rotate(calc(var(--sw-hop-dir, 1) * -3deg));
 }
 
 [data-storyboard-monster][data-settling] [data-monster-pupil] {
-  animation: sw-pupil-settle 440ms cubic-bezier(0.32, 0.72, 0.3, 1) both;
+  /* The horizontal is a SACCADE and the vertical is a bump, so they cannot
+     share a timing function — see the two keyframe blocks. `linear` on the
+     saccade is deliberate: its stops carry the velocity profile, and an easing
+     on top would smear the very shape they exist to draw. */
+  animation:
+    sw-pupil-saccade 320ms linear both,
+    sw-pupil-bob 440ms cubic-bezier(0.32, 0.72, 0.3, 1) both,
+    sw-pupil-constrict 900ms cubic-bezier(0.22, 0.6, 0.3, 1) 140ms both;
 }
 
 [data-storyboard-monster][data-settling] [data-monster-foot] {
   animation: sw-foot-settle 460ms cubic-bezier(0.22, 1, 0.36, 1) 110ms both;
 }
 
-/* The eye is thrown by the landing, overshoots, and comes back level. It moves
-   FURTHER than the body did, which is the exaggeration that makes a small mark
-   read as alive at 15px.
+/* LAST TO SETTLE, which is the timing point. The eye reacts at once (it is the
+   creature paying attention), the feet lag 110ms (they carried the mass), and
+   the hat — the only part not attached to anything — is still moving after both
+   have stopped. Finishing them together would read as one twitch. */
+[data-storyboard-monster][data-settling] [data-monster-hat] {
+  animation: sw-hat-settle 640ms cubic-bezier(0.3, 0.7, 0.28, 1) 40ms both;
+}
 
-   IT NEVER LOOKS BACK. The horizontal component is signed by `--sw-hop-dir` and
-   DECAYS on that one side — it does not cross the centre. An earlier version
-   let the eye overshoot horizontally the way a loose part does, which is
-   correct physics and wrong acting: for the few frames it sat on the far side
-   the creature was looking back the way it came, at the exact moment it was
-   meant to be arriving somewhere. The overshoot lives in the vertical instead,
-   where it still reads as a landing jolt.
+/* ── The eye, horizontally: a SACCADE ────────────────────────────────────────
+   A human eye does not glide back. It FIXATES — holds dead still on what it was
+   looking at — and then flicks, ballistically, in a single movement it cannot
+   correct halfway. The flick has a shape worth copying: it is not linear and it
+   is not a UI ease. Position runs as a skewed sigmoid — slow to break away,
+   peak speed a little before the midpoint, then a decelerating tail noticeably
+   longer than the acceleration was. And it does NOT overshoot; the eye lands on
+   its target and stops, then holds again.
 
-   So the pupil picks up where the flight left it — aimed ahead and high — takes
-   the impact downward, bounces, and eases back to centre only once the creature
-   has stopped. Watching the reader again is the resting pose, not the arrival.
+   That is the whole reason the horizontal is on its own animation. The stops
+   below ARE the velocity profile, sampled: 10% of the distance in the first
+   fifth of the flick, 62% by the midpoint, and the last 6% spread across the
+   final fifth. `linear` between them keeps them honest.
 
-   Kept inside the white: the pupil is 0.28em within a 0.46em eye, so a quarter
-   of its own width is about as far as it can travel before it would clip. */
-@keyframes sw-pupil-settle {
-  /* Exactly the aim it flew with, so the handover from image to element is
-     invisible — the same pose, now on an element that can move. */
-  0% {
-    transform: translate(calc(var(--sw-hop-dir, 1) * 26%), -12%);
+   THE PROPORTIONS, in the 320ms this runs: 128ms of fixation still aimed where
+   it jumped, a 122ms flick, then stillness for the remainder while the vertical
+   is still settling. Holding first is what makes it read as an eye deciding to
+   look back rather than a dot sliding home.
+
+   IT NEVER LOOKS BACK PAST CENTRE. An earlier version let the eye overshoot
+   horizontally the way a loose part does, which is correct for a pendulum and
+   wrong for an eye — for the few frames it sat on the far side the creature was
+   looking back the way it came at the moment it was meant to be arriving. Real
+   saccades do not do that either. The overshoot lives in the vertical instead,
+   where it reads as the landing. */
+@keyframes sw-pupil-saccade {
+  /* Fixation: still aimed along the jump. */
+  0%,
+  40% {
+    translate: calc(var(--sw-hop-dir, 1) * 26%) 0;
   }
-  /* The impact drives it down. Still looking ahead. */
-  30% {
-    transform: translate(calc(var(--sw-hop-dir, 1) * 22%), 12%);
+  /* Breaking away — barely moving yet. */
+  47.6% {
+    translate: calc(var(--sw-hop-dir, 1) * 23.4%) 0;
   }
-  /* Bounce, and the aim begins to relax. */
-  58% {
-    transform: translate(calc(var(--sw-hop-dir, 1) * 14%), -6%);
+  /* Through peak velocity. */
+  55.2% {
+    translate: calc(var(--sw-hop-dir, 1) * 16.1%) 0;
   }
-  /* A last small correction, still on the travel side. */
-  80% {
-    transform: translate(calc(var(--sw-hop-dir, 1) * 6%), 2%);
+  60.9% {
+    translate: calc(var(--sw-hop-dir, 1) * 9.9%) 0;
   }
-  /* Level, centred, watching the reader again. */
+  /* The long decelerating tail. */
+  66.6% {
+    translate: calc(var(--sw-hop-dir, 1) * 4.7%) 0;
+  }
+  72.3% {
+    translate: calc(var(--sw-hop-dir, 1) * 1.6%) 0;
+  }
+  /* Landed, and then held — fixation again, not a drift. */
+  78%,
   100% {
-    transform: translate(0, 0);
+    translate: 0 0;
+  }
+}
+
+/* ── The eye, autonomically: the pupil comes back down ───────────────────────
+   The creature flies WIDE-EYED. Arousal dilates a pupil — sympathetic drive on
+   the radial dilator plus the parasympathetic sphincter letting go — and a jump
+   is the most exciting thing that happens to this mark, so the dilation is
+   baked into the aim pose above and both snapshots carry it. The pupil cannot
+   change size mid-flight for the same reason nothing else can: the creature is
+   one rasterised image then.
+
+   WHAT COMES BACK IS THE INTERESTING HALF, and it is nothing like the other two
+   animations on this element:
+
+   IT IS LATE. A pupil does not respond the instant the stimulus ends. The
+   pupillary latency is roughly 200ms in life; 140ms here, which is long enough
+   to read as a beat and short enough not to look stuck. The creature lands, the
+   eye flicks back, the hat settles — and only then does the pupil begin.
+
+   IT IS SLOW. 900ms against the saccade's 320 and the bob's 440, so it is still
+   going when everything else has stopped. That is the right relationship: the
+   mechanical parts stop when the body stops, and the autonomic one keeps going
+   because it is not attached to the landing at all. A task-evoked pupil response
+   takes seconds to return to baseline in life; this is that, compressed.
+
+   IT DOES NOT BOUNCE. Smooth muscle cannot overshoot the way a hat or an eyeball
+   can, so the curve is a decay: gentle onset, most of the change early-middle,
+   and a long tail into baseline. Give this an elastic easing and the eye reads
+   as a shutter rather than as a pupil.
+
+   THE SIZE is 20% of diameter — near the top of what arousal actually produces,
+   which is what it takes to be visible on a pupil 6px across. The glint scales
+   with it, which is not quite true to life (a corneal reflection holds its size
+   while the pupil moves under it) and is not worth fixing at 1px. */
+@keyframes sw-pupil-constrict {
+  0% {
+    scale: 1.2;
+  }
+  100% {
+    scale: 1;
+  }
+}
+
+/* ── The eye, vertically: the landing ────────────────────────────────────────
+   This half is not eye physiology, it is the head the eye is riding in. It gets
+   thrown by the impact, overshoots, and comes back level, moving FURTHER than
+   the body did — the exaggeration that makes a 15px mark read as alive.
+
+   Kept inside the white: the pupil is 0.39em within a 0.64em eye, so this can
+   spend about a quarter of the pupil's own width before it would clip. */
+@keyframes sw-pupil-bob {
+  0% {
+    transform: translateY(-12%);
+  }
+  /* The impact drives it down. */
+  30% {
+    transform: translateY(12%);
+  }
+  /* Bounce. */
+  58% {
+    transform: translateY(-6%);
+  }
+  80% {
+    transform: translateY(2%);
+  }
+  100% {
+    transform: translateY(0);
   }
 }
 
@@ -558,13 +681,82 @@ html {
   }
 }
 
+/* The hat takes the landing and gives it back.
+   OVERLAPPING ACTION and FOLLOW-THROUGH, and nothing else — the principles that
+   apply to a loose garment, not the whole twelve. It is drawn about 10px wide,
+   so squash and stretch is unavailable (a felt hat barely deforms, and one
+   pixel of it is a flicker, not a squash); arcs are not a separate dial here
+   because the pivot IS the arc, down at the brim where the hat meets the fur.
+   What is left is drag, weight, and the time it takes to stop.
+
+   These are DELTAS from rest — the fixed -14deg cock lives on an inner element,
+   so 0 here means "sitting normally".
+
+   DELIBERATELY UNDER-PLAYED, and the two channels are dialled SEPARATELY
+   because they fail differently.
+
+   ROTATION is what reads as a hat: the crown's top sits about an em above the
+   pivot, so a few degrees swing it a couple of pixels and the shape of the
+   event — trail, jam, rebound — survives at 8px. It is held at roughly six
+   tenths of the first pass.
+
+   VERTICAL is what reads as VIBRATION. A hat bobbing straight up and down has
+   no silhouette change to sell it, so the eye registers the motion without
+   reading a cause, and two bounces of it look like a rendering glitch rather
+   than like weight. It is cut to about a third again — the whole excursion is
+   now near ±0.2px in the rail, which is felt more than seen. That also puts the
+   flight lift (0.012em) well inside the brim's ~0.03em overhang on the body, so
+   the hat keeps its purchase on the fur instead of appearing to hover. */
+@keyframes sw-hat-settle {
+  /* Where the flight left it: lifted clear, trailing behind the direction of
+     travel. Identical to the aim pose, so the handover from image to element
+     shows no seam. */
+  0% {
+    transform: translateY(-0.012em) rotate(calc(var(--sw-hop-dir, 1) * -3deg));
+  }
+  /* THE JAM. The head stops and the hat does not, so it drives DOWN onto the
+     fur, past where it rests, and its own momentum carries it forward — the
+     rotation crosses through rest to the far side, which is the opposite of
+     where it spent the whole flight. */
+  20% {
+    transform: translateY(0.015em) rotate(calc(var(--sw-hop-dir, 1) * 3.5deg));
+  }
+  /* The rebound: the fur gives it back, and the hat lifts and rocks back the
+     way it came. Smaller than the jam, because energy leaves the system. */
+  46% {
+    transform: translateY(-0.007em) rotate(calc(var(--sw-hop-dir, 1) * -1.8deg));
+  }
+  /* A second, much shorter bounce — one is a bump, two is a hat. */
+  70% {
+    transform: translateY(0.004em) rotate(calc(var(--sw-hop-dir, 1) * 0.9deg));
+  }
+  88% {
+    transform: translateY(-0.002em) rotate(0deg);
+  }
+  /* Seated. */
+  100% {
+    transform: translateY(0) rotate(0deg);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   [data-storyboard-monster][data-settling] [data-monster-pupil],
-  [data-storyboard-monster][data-settling] [data-monster-foot] {
+  [data-storyboard-monster][data-settling] [data-monster-foot],
+  [data-storyboard-monster][data-settling] [data-monster-hat] {
     animation: none;
   }
 
-  [data-storyboard-monster][data-aiming] [data-monster-pupil] {
+  /* Rest for both is no transform: the pupil has none of its own, and the hat's
+     tilt lives on an inner element that this never touches. */
+  [data-storyboard-monster][data-aiming] [data-monster-pupil],
+  [data-storyboard-monster][data-aiming] [data-monster-hat] {
     transform: none;
+  }
+
+  /* The pupil's aim spends three properties; clearing one would leave it
+     staring sideways, or stuck dilated. */
+  [data-storyboard-monster][data-aiming] [data-monster-pupil] {
+    translate: none;
+    scale: none;
   }
 }

--- a/apps/timeline-gstudio001/app/layout.tsx
+++ b/apps/timeline-gstudio001/app/layout.tsx
@@ -1,4 +1,5 @@
 import type {Metadata} from 'next';
+import { Caprasimo } from 'next/font/google';
 import { Suspense } from 'react';
 import { AuthGate } from '@/components/auth/auth-gate';
 import { AuthProvider } from '@/components/auth/auth-provider';
@@ -6,6 +7,22 @@ import { getAuthUser } from '@/lib/firebase-auth-session';
 import { TimelineSidebar } from '@/components/timeline/timeline-sidebar';
 import { Toaster } from '@/components/core/sonner';
 import './globals.css'; // Global styles
+
+/**
+ * The wordmark's face, and the only custom font in the app — everything else
+ * rides Tailwind's `font-sans`.
+ *
+ * Exposed as a VARIABLE rather than applied to the body: it is a display face
+ * for one lockup, not a UI font. It carries a single weight (400), which is why
+ * the logo drops `font-bold` — asking for 700 would only get a synthesised
+ * bold, and Caprasimo is already heavy.
+ */
+const caprasimo = Caprasimo({
+  weight: '400',
+  subsets: ['latin'],
+  variable: '--font-caprasimo',
+  display: 'swap',
+});
 
 export const metadata: Metadata = {
   title: 'Storyboard Flow',
@@ -22,7 +39,7 @@ export default async function RootLayout({children}: {children: React.ReactNode}
   // to this class in globals.css, precisely so the app stops following the
   // reader's OS theme.
   return (
-    <html lang="en" className="dark">
+    <html lang="en" className={`dark ${caprasimo.variable}`}>
       <body suppressHydrationWarning>
         {/* App-wide: the sidebar renders on every route, so anything it
             toasts needs a surface here rather than inside one view. */}

--- a/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
+++ b/apps/timeline-gstudio001/components/assets/trash-drawer.tsx
@@ -103,7 +103,7 @@ export function TrashDrawer({ isOpen, onClose }: TrashDrawerProps) {
   const documents = useSyncExternalStore(
     graphDocumentsGateway.subscribe,
     graphDocumentsGateway.read,
-    graphDocumentsGateway.read,
+    graphDocumentsGateway.readServerSnapshot,
   );
   const trashId = user ? `trash-${user.uid}` : null;
   const cachedClips = trashId ? documents[trashId]?.clips : undefined;

--- a/apps/timeline-gstudio001/components/graph-view/graph-breadcrumb-drop.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-breadcrumb-drop.tsx
@@ -56,7 +56,7 @@ function useDropDestination(): DropDestination | null {
   const documents = useSyncExternalStore(
     graphDocumentsGateway.subscribe,
     graphDocumentsGateway.read,
-    graphDocumentsGateway.read,
+    graphDocumentsGateway.readServerSnapshot,
   );
   const id = useCollectionsSelector((s) => {
     const intent = s.interaction.dropIntent;

--- a/apps/timeline-gstudio001/components/graph-view/graph-collection-card.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-collection-card.tsx
@@ -115,11 +115,24 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
           can then be trashed with Delete alongside media. */}
       <CollectionItem.SelectionSurface
         dragActivation={dragActivation === "hold" ? "hold" : "body"}
+        // STARTS WITH THE NAME, so a speech-input user saying what they see
+        // ("Scenes") matches — the substance of WCAG 2.5.3 "Label in Name".
+        //
+        // Lighthouse's `label-content-name-mismatch` still flags this, and
+        // deliberately not chased: the caption's spans carry no whitespace
+        // between them, so axe compares against the concatenation
+        // "Scenes1:29/1 item". Satisfying that literally means an accessible
+        // name no one would want spoken. Two other routes were tried and are
+        // worse — folding the duration in makes the name CHANGE when a branch
+        // finishes loading (announced mid-read), and hiding the readouts from
+        // assistive tech changes nothing, because an `aria-label` on a button
+        // already replaces its content for AT.
+        //
         // Announce the count the card actually SHOWS — the stored summary for a
         // placeholder, the live children once hydrated. The primitive's default
         // reads live childCount alone, which speaks "0 items" over a card
         // displaying "9" until its clips load.
-        ariaLabel={`${displayName} (collection, ${count} ${count === 1 ? "item" : "items"})`}
+        ariaLabel={`${displayName}, collection, ${count} ${count === 1 ? "item" : "items"}`}
         className={[
           // `relative` so the disabled chip below can pin to this card's own
           // top-right corner rather than some ancestor's.

--- a/apps/timeline-gstudio001/components/graph-view/graph-collection-card.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-collection-card.tsx
@@ -272,7 +272,31 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
                 src={collectionPreviewFrameUrl(preview)}
                 alt=""
                 draggable={false}
-                loading="lazy"
+                // EAGER, because the grid is virtualized. `VirtualGrid` renders
+                // only the rows at or near the viewport, so a card that exists
+                // in the DOM has already been judged on-screen — `loading=lazy`
+                // then defers a request the browser could have started, and
+                // waits for layout to re-decide what virtualization just
+                // decided. Below-the-fold cards are not lazy, they are absent.
+                //
+                // Measured: this element was the LCP on a board open, and its
+                // request was queued at 1,495ms having taken 0.4ms to download.
+                // The delay was discovery, not transfer.
+                loading="eager"
+                // Only the FIRST frame. All three are visible, but a hint that
+                // marks everything high marks nothing — the leading frame is
+                // the one that carries the card, and on the measured board it
+                // was the LCP element.
+                {...(index === 0 ? { fetchPriority: "high" as const } : {})}
+                // INTRINSIC SIZE, so the browser can reserve the box before the
+                // bytes arrive. CSS already fixes the rendered size (`h-full`,
+                // `flex-1`), but with no width/height the element has no aspect
+                // ratio until decode, and the trace attributed two layout
+                // shifts to exactly that ("An unsized image"). 16:9 is what the
+                // Cloudinary transform emits (w_640,h_360) — see
+                // `collectionPreviewFrameUrl`.
+                width={640}
+                height={360}
                 className="h-full min-w-0 flex-1 rounded-sm object-cover"
               />
             ))

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -261,7 +261,11 @@ export const PlaceholderAriaCountMatchesBadge: Story = {
   play: async ({ canvasElement }) => {
     const surface = canvasElement.querySelector<HTMLElement>("[data-node-id]")!;
     // The stored summary (itemCount 2), not the live childCount (0).
-    await expect(surface.getAttribute("aria-label")).toBe("A timeline (collection, 2 items)");
+    //
+    // NAME FIRST, then context — a speech-input user says what they see.
+    // The duration is deliberately absent: folding it in makes the accessible
+    // name change when a branch finishes loading (see the card).
+    await expect(surface.getAttribute("aria-label")).toBe("A timeline, collection, 2 items");
     // The COUNT survives on a placeholder and the time does not, which is the
     // asymmetry worth pinning: one level of reading settles a count exactly
     // (measured 0/3 wrong), while a duration sums the whole subtree and cannot
@@ -526,7 +530,7 @@ export const ComposedCardStructure: Story = {
     await userEvent.clear(editor!);
     await userEvent.type(editor!, "Renamed timeline{Enter}");
     await waitFor(() =>
-      expect(surface!.getAttribute("aria-label")).toMatch(/^Renamed timeline \(collection/),
+      expect(surface!.getAttribute("aria-label")).toMatch(/^Renamed timeline,/),
     );
   },
 };

--- a/apps/timeline-gstudio001/components/graph-view/graph-render-format.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-render-format.tsx
@@ -137,7 +137,7 @@ export function GraphRenderFormat({ timelineId }: Readonly<{ timelineId: string 
   const documents = useSyncExternalStore(
     graphDocumentsGateway.subscribe,
     graphDocumentsGateway.read,
-    graphDocumentsGateway.read,
+    graphDocumentsGateway.readServerSnapshot,
   );
   return (
     <RenderFormatOptions

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-chrome.tsx
@@ -67,7 +67,7 @@ function useGraphPathTitles() {
   return useSyncExternalStore(
     graphDocumentsGateway.subscribe,
     graphDocumentsGateway.read,
-    graphDocumentsGateway.read,
+    graphDocumentsGateway.readServerSnapshot,
   );
 }
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-view-loading.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-view-loading.tsx
@@ -1,43 +1,89 @@
 import { Skeleton } from "@/components/core/skeleton";
 
 /**
- * The board's stand-in while it loads.
+ * The board's stand-in while it loads, shaped like the board.
  *
  * ONE SHAPE, RENDERED TWICE. Opening a project passes through two separate
  * fallbacks: the route's `loading.tsx` while the graph LAYOUT awaits its
- * session and boot payloads, and this one while the dynamic `GraphTimelineView`
- * chunk arrives. They used to look different — a bordered card grid with two
- * text lines, then bare rounded rectangles — so the eight cards visibly changed
- * shape mid-load and it read as two separate loads rather than one.
+ * session and boot payloads, and this one while the dynamic
+ * `GraphTimelineView` chunk arrives. Both stand in for the same pixels — the
+ * layout renders no chrome of its own, just `ClientGraphView` — so they render
+ * the same component and the handover is invisible.
  *
- * The layout renders no chrome of its own (see `graph/layout.tsx`), so both
- * fallbacks stand in for the same pixels and there is no reason for them to
- * differ. `graph/loading.tsx` renders this inside the layout's own container
- * classes, which makes the handover invisible.
+ * MEASURED FROM THE RUNNING BOARD rather than sketched, because a placeholder
+ * that does not match is just a second layout the eye has to re-read:
  *
- * The card carries a caption row because the real one does. A bare rectangle
- * pops a second time when the board arrives and the captions appear.
+ *   header band        57px, bottom border   breadcrumb left, controls right
+ *   panel              rounded-xl, bg-zinc-900/60, ring-1 ring-white/10
+ *     controls row     49px                  Collection · Media · total · icons
+ *     grid             p-3, gap-3            cards 332x220 at 1400 wide
+ *
+ * The card is a fixed 220 tall with the image area taking the remaining space,
+ * which is how the real one is built — its image is flex-sized, NOT
+ * `aspect-video`. An aspect-ratio placeholder came out 190 tall against the
+ * real 152 and the whole grid shifted when the board arrived.
+ *
+ * Everything here is a rectangle on purpose. It stands in for chrome whose
+ * labels are not known yet, and guessing at "Preview" or "Select" in grey text
+ * would read as content that then changes.
  */
 export function GraphViewLoadingSkeleton() {
   return (
     <div
       aria-busy="true"
       aria-label="Loading graph view"
-      className="grid gap-2"
+      className="flex flex-col gap-4"
       data-graph-loading-skeleton=""
     >
-      <div className="flex h-12 items-center justify-between gap-4 border-b border-zinc-800/70 py-3">
-        <Skeleton className="h-4 w-1/3 max-w-64" />
-        <Skeleton className="h-4 w-28" />
-        <Skeleton className="h-8 w-44" />
+      {/* Breadcrumb row + the view controls that sit opposite it. */}
+      <div className="flex h-14 min-w-0 items-center justify-between gap-3 border-b border-zinc-800/70">
+        <div className="flex min-w-0 items-center gap-2">
+          <Skeleton className="h-8 w-8 shrink-0 rounded-md" />
+          <Skeleton className="h-4 w-32" />
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Skeleton className="h-8 w-24 rounded-md" />
+          <Skeleton className="h-8 w-20 rounded-md" />
+          <Skeleton className="h-8 w-8 rounded-md" />
+          <Skeleton className="h-8 w-8 rounded-md" />
+          <Skeleton className="h-8 w-8 rounded-md" />
+        </div>
       </div>
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
-        {Array.from({ length: 8 }, (_, index) => (
-          <div key={index} data-graph-loading-card="" className="grid gap-2">
-            <Skeleton className="aspect-video w-full rounded-lg" />
-            <Skeleton className="h-3 w-2/3" />
-          </div>
-        ))}
+
+      {/* The board panel — same surface, radius and ring the real one wears, so
+          the container does not appear or change shape on handover. */}
+      <div className="overflow-hidden rounded-xl bg-zinc-900/60 ring-1 ring-white/10">
+        {/* Add-collection / add-media on the left, the focused total centred,
+            filter and board options on the right. */}
+        <div className="flex h-[49px] min-w-0 items-center gap-2 border-b border-zinc-800/40 px-3">
+          <Skeleton className="h-7 w-28 shrink-0 rounded-md" />
+          <Skeleton className="h-7 w-20 shrink-0 rounded-md" />
+          <Skeleton className="h-7 w-7 shrink-0 rounded-md" />
+          <Skeleton className="mx-auto h-3 w-28" />
+          <Skeleton className="h-7 w-7 shrink-0 rounded-md" />
+          <Skeleton className="h-7 w-7 shrink-0 rounded-md" />
+        </div>
+
+        {/* ONE ROW, not two. The count is unknowable before the read, so the
+            choice is which way to be wrong: a short skeleton lets content grow
+            downward, a tall one collapses the page when a small board arrives.
+            Growing is the quieter of the two, and boards of three or four are
+            the common case here. */}
+        <div className="grid grid-cols-2 gap-3 p-3 sm:grid-cols-3 lg:grid-cols-4">
+          {Array.from({ length: 4 }, (_, index) => (
+            <div
+              key={index}
+              data-graph-loading-card=""
+              className="grid h-[220px] grid-rows-[1fr_auto] gap-2 rounded-lg bg-zinc-950/40 p-2 ring-1 ring-white/10"
+            >
+              <Skeleton className="w-full rounded-md" />
+              <div className="flex items-center justify-between gap-2">
+                <Skeleton className="h-3 w-1/2" />
+                <Skeleton className="h-3 w-10" />
+              </div>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/apps/timeline-gstudio001/components/timeline/sidebar-collection-shortcuts.tsx
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-collection-shortcuts.tsx
@@ -287,7 +287,7 @@ export function SidebarCollectionShortcuts({
   const documents = useSyncExternalStore(
     graphDocumentsGateway.subscribe,
     graphDocumentsGateway.read,
-    graphDocumentsGateway.read,
+    graphDocumentsGateway.readServerSnapshot,
   );
   return (
     <CollectionShortcutsGroup

--- a/apps/timeline-gstudio001/components/timeline/sidebar-collection-shortcuts.tsx
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-collection-shortcuts.tsx
@@ -157,7 +157,11 @@ function ShortcutsHeading({
         // label arriving.
         "transition-[height,background-color,color] duration-200 motion-reduce:transition-none",
         inline
-          ? "h-4 bg-transparent text-zinc-500"
+          ? // zinc-400, not zinc-500. At 10px this is small text, so it needs
+            // 4.5:1 and zinc-500 on the rail's #111113 measures 3.9 — Lighthouse
+            // failed it. zinc-400 measures 7.2. The rule state below keeps
+            // zinc-500 because there it is a BACKGROUND band, not text.
+            "h-4 bg-transparent text-zinc-400"
           : // The rule state: a 1px band of the divider's own colour, with the
             // text still present and simply too short to show.
             "h-px bg-zinc-500 text-transparent",

--- a/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.stories.tsx
+++ b/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.stories.tsx
@@ -1,0 +1,120 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, within } from "storybook/test";
+
+import { StoryboardMonsterMark, STORYBOARD_MONSTER_ACCENT } from "./storyboard-monster-mark";
+
+// The creature in the rail's wordmark.
+//
+// WHY THIS EXISTS AS A STORY. Every judgement this drawing has ever needed —
+// are the feet visible on the rail's black, is the band separate from the
+// crown, does the eye still read at 15px — is a judgement made by LOOKING, and
+// it was being made by hand-injecting clones into the running app each time.
+// The two sizes below are the two the sidebar actually renders, and the blown-up
+// one is where a colour or a geometry change is legible before it ships.
+//
+// The rail's own ground, not Storybook's, because half the decisions here are
+// contrast decisions against exactly this value.
+const RAIL_BG = "#0a0a0a";
+
+function Plate({
+  children,
+  label,
+}: Readonly<{ children: React.ReactNode; label: string }>) {
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <div className="flex min-h-[132px] items-center justify-center">{children}</div>
+      <span className="font-mono text-[11px] text-white/70">{label}</span>
+    </div>
+  );
+}
+
+const meta = {
+  title: "Timeline/StoryboardMonsterMark",
+  component: StoryboardMonsterMark,
+  parameters: { layout: "centered" },
+  decorators: [
+    (Story) => (
+      <div
+        className="flex items-end gap-9 rounded-xl p-10 text-[19px]"
+        style={{ background: RAIL_BG }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof StoryboardMonsterMark>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The two sizes the rail renders, side by side, at the rail's 19px type size. */
+export const RailSizes: Story = {
+  args: { scale: 1.1 },
+  render: () => (
+    <>
+      <Plate label="in the word (1.1)">
+        <StoryboardMonsterMark scale={1.1} />
+      </Plate>
+      <Plate label="alone, collapsed (1.6)">
+        <StoryboardMonsterMark scale={1.6} />
+      </Plate>
+    </>
+  ),
+  play: async ({ canvasElement }) => {
+    const marks = Array.from(canvasElement.querySelectorAll("[data-storyboard-monster]"));
+    expect(marks).toHaveLength(2);
+    const [inWord, alone] = marks as [Element, Element];
+    // The collapsed mark is the bigger of the two — the rail loses the word, so
+    // the creature has to carry the corner on its own. A regression that swaps
+    // or equalises the scales is invisible in a screenshot diff of one state.
+    expect(inWord.getBoundingClientRect().width).toBeLessThan(
+      alone.getBoundingClientRect().width,
+    );
+    // Both feet, both eyes' worth of parts, and the hat — the drawing is only
+    // ever wrong by a piece going missing.
+    expect(alone.querySelectorAll("[data-monster-foot]")).toHaveLength(2);
+    expect(alone.querySelector("[data-monster-pupil]")).toBeTruthy();
+    expect(alone.querySelector("[data-monster-hat]")).toBeTruthy();
+  },
+};
+
+/** Big enough to judge the hat's band against its crown, and the egg's stretch. */
+export const BlownUp: Story = {
+  args: { scale: 1 },
+  render: () => (
+    <Plate label="7x">
+      <span className="text-[7em]">
+        <StoryboardMonsterMark scale={1} />
+      </span>
+    </Plate>
+  ),
+};
+
+/**
+ * The mark beside the word it belongs to, in the wordmark's own colour.
+ *
+ * Not a duplicate of the sidebar's lockup — that one is a flex row of revealed
+ * letters mid-animation. This is the static relationship the colours were
+ * chosen for: band and letters sharing one token, creature standing on the line.
+ */
+export const InTheWordmark: Story = {
+  args: { scale: 1.1 },
+  render: () => (
+    <span
+      className="flex items-center font-[family-name:var(--font-caprasimo)] text-[19px] text-white"
+      style={{ lineHeight: 1 }}
+    >
+      storyboard&nbsp;
+      <span style={{ color: STORYBOARD_MONSTER_ACCENT }}>
+        m
+        <StoryboardMonsterMark scale={1.1} />
+        nster
+      </span>
+    </span>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByText(/storyboard/)).toBeTruthy();
+    expect(canvasElement.querySelector("[data-storyboard-monster]")).toBeTruthy();
+  },
+};

--- a/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.stories.tsx
+++ b/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.stories.tsx
@@ -1,7 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { expect, within } from "storybook/test";
 
-import { StoryboardMonsterMark, STORYBOARD_MONSTER_ACCENT } from "./storyboard-monster-mark";
+import {
+  StoryboardMonsterMark,
+  STORYBOARD_MONSTER_ACCENT,
+} from "./storyboard-monster-mark";
 
 // The creature in the rail's wordmark.
 //
@@ -22,10 +25,26 @@ function Plate({
 }: Readonly<{ children: React.ReactNode; label: string }>) {
   return (
     <div className="flex flex-col items-center gap-3">
-      <div className="flex min-h-[132px] items-center justify-center">{children}</div>
+      <div className="flex min-h-[132px] items-center justify-center">
+        {children}
+      </div>
       <span className="font-mono text-[11px] text-white/70">{label}</span>
     </div>
   );
+}
+
+/**
+ * Poses one rendered hat by writing straight to its style.
+ *
+ * A callback ref rather than a prop, because the component deliberately does
+ * not take one: the hat's transform belongs to the stylesheet, and adding a
+ * prop so a story could set it would put a second owner on the same property.
+ */
+function hatPose(transform: string) {
+  return (node: HTMLElement | null) => {
+    const hat = node?.querySelector<HTMLElement>("[data-monster-hat]");
+    if (hat) hat.style.transform = transform;
+  };
 }
 
 const meta = {
@@ -52,16 +71,18 @@ export const RailSizes: Story = {
   args: { scale: 1.1 },
   render: () => (
     <>
-      <Plate label="in the word (1.1)">
-        <StoryboardMonsterMark scale={1.1} />
+      <Plate label="in the word (1.1, looking ahead)">
+        <StoryboardMonsterMark scale={1.1} gaze="ahead" />
       </Plate>
-      <Plate label="alone, collapsed (1.6)">
-        <StoryboardMonsterMark scale={1.6} />
+      <Plate label="alone, collapsed (1.6, at the breadcrumb)">
+        <StoryboardMonsterMark scale={1.6} gaze="breadcrumb" />
       </Plate>
     </>
   ),
   play: async ({ canvasElement }) => {
-    const marks = Array.from(canvasElement.querySelectorAll("[data-storyboard-monster]"));
+    const marks = Array.from(
+      canvasElement.querySelectorAll("[data-storyboard-monster]"),
+    );
     expect(marks).toHaveLength(2);
     const [inWord, alone] = marks as [Element, Element];
     // The collapsed mark is the bigger of the two — the rail loses the word, so
@@ -72,6 +93,21 @@ export const RailSizes: Story = {
     );
     // Both feet, both eyes' worth of parts, and the hat — the drawing is only
     // ever wrong by a piece going missing.
+    // The two states differ by where the eye rests, and the difference is about
+    // 1.6px — small enough that only a measurement can tell whether the prop is
+    // still wired. In the word the pupil must be CENTRED, because the creature
+    // is the letter's counter there.
+    const pupilOffset = (mark: Element) => {
+      const pupil = mark.querySelector("[data-monster-pupil]");
+      if (!pupil) return NaN;
+      const white = pupil.parentElement;
+      if (!white) return NaN;
+      const p = pupil.getBoundingClientRect();
+      const w = white.getBoundingClientRect();
+      return p.x + p.width / 2 - (w.x + w.width / 2);
+    };
+    expect(Math.abs(pupilOffset(inWord))).toBeLessThan(0.5);
+    expect(pupilOffset(alone)).toBeGreaterThan(0.5);
     expect(alone.querySelectorAll("[data-monster-foot]")).toHaveLength(2);
     expect(alone.querySelector("[data-monster-pupil]")).toBeTruthy();
     expect(alone.querySelector("[data-monster-hat]")).toBeTruthy();
@@ -115,6 +151,54 @@ export const InTheWordmark: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     expect(canvas.getByText(/storyboard/)).toBeTruthy();
-    expect(canvasElement.querySelector("[data-storyboard-monster]")).toBeTruthy();
+    expect(
+      canvasElement.querySelector("[data-storyboard-monster]"),
+    ).toBeTruthy();
+  },
+};
+
+/**
+ * The hat's four poses across a jump, laid out side by side.
+ *
+ * The motion itself lives in `globals.css` (`sw-hat-settle`) and only runs
+ * inside a real view transition, which a story cannot stage. What a story CAN
+ * do is hold each pose still, which is the only way to see whether the jam
+ * actually presses the brim into the head rather than detaching it — the one
+ * failure a 640ms animation hides by being fast.
+ *
+ * The transforms are the keyframes' own values at `--sw-hop-dir: 1`. If they
+ * drift from the stylesheet this story stops describing the animation, which is
+ * the trade for being able to look at it at all.
+ */
+export const HatPoses: Story = {
+  args: { scale: 1 },
+  render: () => (
+    <>
+      {(
+        [
+          ["rest", "none"],
+          ["in flight (drag)", "translateY(-0.035em) rotate(-3deg)"],
+          ["the jam", "translateY(0.042em) rotate(3.5deg)"],
+          ["rebound", "translateY(-0.02em) rotate(-1.8deg)"],
+        ] as const
+      ).map(([label, transform]) => (
+        <Plate key={label} label={label}>
+          <span className="text-[4em]" ref={hatPose(transform)}>
+            <StoryboardMonsterMark scale={1} />
+          </span>
+        </Plate>
+      ))}
+    </>
+  ),
+  play: async ({ canvasElement }) => {
+    const hats = canvasElement.querySelectorAll("[data-monster-hat]");
+    expect(hats).toHaveLength(4);
+    const y = (n: Element) => n.getBoundingClientRect().top;
+    const [rest, flight, jam] = Array.from(hats) as [Element, Element, Element];
+    // The jam is BELOW rest and the flight pose is ABOVE it. Signs, not
+    // magnitudes: a keyframe edit that inverts the bounce is the regression
+    // worth catching, and it is invisible in a still screenshot.
+    expect(y(flight)).toBeLessThan(y(rest));
+    expect(y(jam)).toBeGreaterThan(y(rest));
   },
 };

--- a/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.tsx
+++ b/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.tsx
@@ -1,110 +1,187 @@
 /**
  * The storyboard monster — the creature that sits in the "o" of "monster".
  *
- * Ported from the logo design document's final direction (turn 21, "20a on
- * dark", FIRST treatment: near-black ground, pale terracotta feet — the two
- * dark options differ only in the feet). It is drawn in CSS
- * rather than SVG, exactly as the source is: a masked `repeating-conic-gradient`
- * makes the fur spikes, and the eye is four nested circles.
+ * Ported from the logo design document's TURN 34 ("28c hat, denim feet"), its
+ * latest direction: the same one-eyed fuzzball, now in a pinched-crown hat and
+ * standing on denim-blue feet. It is drawn in CSS rather than SVG, exactly as
+ * the source is: a masked `repeating-conic-gradient` makes the fur spikes, the
+ * eye is four nested circles, and the hat is three boxes — a clip-path crown, a
+ * pill brim and a band — inside one rotated group.
  *
- * SIZED IN `em`, so it scales with whatever font-size the lockup uses and can
- * sit inline in the wordmark. `scale` multiplies that — the document's turn 19
- * ("a bigger monster in the o") establishes that growing the creature past the
- * letter is a sanctioned move, and the rail needs it: the source drawing is
- * 0.72em, which at a font-size small enough for "storyboard monster" to fit a
- * 239px rail would put the creature under the legibility floor the document
- * itself measured — "below about 19px the fur spikes and the glint start to
- * merge".
+ * THE GEOMETRY IS THE SOURCE'S, VERBATIM. Turn 34 re-expresses the drawing
+ * against a 1em box where earlier turns used 0.72em; every inner number is the
+ * old one times 1/0.72, so the creature itself did not change size, only the
+ * unit it is quoted in. Keeping the source's numbers rather than re-deriving
+ * them is what lets the next turn be diffed against this file.
  *
- * COLOURS ARE APPROXIMATED. The design document referenced its own design
- * system (`var(--color-bg)`, `var(--color-accent-2-900)`, …) and shipped
- * without that stylesheet, so only the sage is the source's literal value. The
- * cream and the pupil are matched by eye to the document's dark-mode frames and
- * are the two worth checking against the real palette.
+ * WHICH IS WHY `scale` IS FOLDED INTO THE FONT-SIZE AT 0.72. `scale` keeps
+ * meaning what it has always meant to the callers — 1.1 in the word, 1.6 alone
+ * in the rail — and the 0.72 converts that expectation into turn 34's basis.
+ * Drop it and every call site silently grows by 39%.
+ *
+ * COLOURS: the file gives two as literals and the rest as design-system tokens
+ * it does not ship — `_ds/organic-…/styles.css` is not in the export, and the
+ * document renders black-on-black without it, so there are no frames to sample
+ * either. The sage and the feet below are therefore the source's own values;
+ * the cream, the pupil and the hat are matched to those tokens' roles in the
+ * ramp and are the three worth checking against the real palette.
  */
+
+/** The source's literal, unchanged since turn 9: fur and body. */
 const SAGE = "oklch(0.86 0.17 128)";
-/** The document's `--color-bg` on its dark frames: a warm off-white. */
+/** `--color-bg`: the eye white and the glint. A warm off-white. */
 const CREAM = "oklch(0.96 0.02 95)";
-/** The document's `--color-accent-2-900`: the pupil, near-black. */
+/** `--color-accent-2-900`: the pupil, near-black. */
 const PUPIL = "oklch(0.27 0.03 145)";
 /**
- * The document's `--color-accent-300`: pale terracotta.
+ * `--color-accent-300`: pale terracotta.
  *
- * The feet AND the word "monster" are this same token — turn 18 chose it as
- * "terracotta feet, matches the wordmark", and turn 21 kept it for dark. Export
- * it so the lockup cannot drift from the creature.
+ * The word "monster" AND the hat band are this one token in the source, which
+ * is what ties the hat to the wordmark. Export it so the lockup cannot drift
+ * from the creature.
  */
 export const STORYBOARD_MONSTER_ACCENT = "oklch(0.78 0.10 45)";
-
-/** The fur ring: spikes radiating from the body, masked to an annulus so the
- *  gradient only shows outside the circle. */
-const FUR: React.CSSProperties = {
-  position: "absolute",
-  left: "-0.14em",
-  top: "-0.14em",
-  width: "1em",
-  height: "1em",
-  background: `repeating-conic-gradient(from 0deg, ${SAGE} 0deg 11deg, transparent 11deg 22deg)`,
-  WebkitMaskImage:
-    "radial-gradient(circle at 50% 50%, transparent 0 35%, #000 35% 50%, transparent 50%)",
-  maskImage:
-    "radial-gradient(circle at 50% 50%, transparent 0 35%, #000 35% 50%, transparent 50%)",
-};
+/**
+ * `--color-accent`: the crown and the brim.
+ *
+ * The base step of the ramp that `STORYBOARD_MONSTER_ACCENT` is the 300 of, so
+ * it has to sit deeper and stronger than the band it carries — level with it
+ * and the band disappears into the crown, leaving the hat one flat shape. It
+ * also has to clear the rail's own ~0.19 lightness, the constraint that already
+ * killed two candidate foot colours.
+ */
+const HAT = "oklch(0.62 0.16 42)";
+/**
+ * The source's literal denim (turn 32, kept by turn 34).
+ *
+ * Arrived at by elimination, and the reasoning is worth keeping because it
+ * applies to anything drawn under the body: terracotta is the same value as the
+ * word the creature stands in, so the feet read as part of the letters; cream is
+ * the brightest thing in the rail, so the feet end up louder than the eye they
+ * belong to; and anything near-black vanishes outright — the feet sit BELOW the
+ * body, against the rail rather than against the sage, so there is nothing
+ * behind them to separate from. They are also about 4px tall here, and a small
+ * shape needs MORE contrast than a large one, not less.
+ */
+const FEET = "oklch(0.68 0.115 245)";
 
 /**
- * A LIGHT BLUE, off the document's palette and arrived at by elimination.
+ * THE BODY IS AN EGG, not the source's circle.
  *
- * Terracotta (turn 21's first dark treatment) is the same value as the word the
- * creature stands in, so the feet read as part of the letters. Cream (its
- * second) separates cleanly but is the brightest thing in the rail — the feet
- * ended up louder than the eye they belong to. Dark navy disappeared outright,
- * which is the failure turn 21 already documented for near-black: "the
- * near-black feet can't survive on a dark ground".
+ * Turn 34 draws it round at 0.98em square. Stretched a seventh taller and
+ * anchored at the bottom — the feet have to stay where they stand — it gains
+ * headroom between the eye and the brim, which is the difference between a
+ * creature wearing a hat and a creature with a hat resting on its eyeball.
  *
- * The constraint the document is pointing at: the feet sit BELOW the body,
- * against the rail rather than against the sage, so anything near the rail's own
- * value has nothing behind it to separate from. And they are small — about 3px
- * tall at this size — which needs MORE contrast than a large shape, not less.
- *
- * So the value is chosen for LIGHTNESS first and hue second: 0.72 against the
- * rail's ~0.19. A dark blue was tried at 0.34 and vanished, which is the same
- * failure as the near-black. The hue also has to stay clear of the sage body it
- * sits under and the terracotta type it sits beside, which a blue does.
+ * Everything that has to follow the shape derives from these three numbers: the
+ * fur collar, the eye's vertical centring, and the lift the hat needs so it
+ * still sits on the head rather than sinking into it.
  */
-const FEET = "oklch(0.72 0.13 250)";
+const BODY_W = 0.98;
+const BODY_H = 1.12;
+/** Bottom edge pinned where the round body had it (0.99em), top pulled up. */
+const BODY_TOP = 0.99 - BODY_H;
+/** How much taller than the source, and so how far the hat rides up with it. */
+const BODY_LIFT = BODY_H - BODY_W;
+
+/**
+ * The fur ring: a conic gradient of spikes, masked to an annulus.
+ *
+ * IT RENDERS NOTHING, AND THAT IS THE SOURCE'S OWN BEHAVIOUR — left verbatim
+ * rather than "fixed", because the fix is not ours to make.
+ *
+ * The document reads its stops as shares of the fur BOX: 35%–50% of 1.38em is a
+ * ring from 0.483em to 0.69em, starting at the body's edge (0.49em radius) and
+ * reaching 0.2em past it. CSS resolves them against the GRADIENT's radius
+ * instead, and an unsized `circle` is farthest-corner — so the ring lands
+ * roughly 0.36em–0.51em and sits under the body, which is painted after it.
+ * Measured on this build: at a 133px mark the fur box is 184px, its gradient
+ * radius 130px, and the ring falls at 45.6–65px against a body radius of
+ * 65.2px.
+ *
+ * Re-expressing it as `ellipse closest-side` with 71%/100% DOES produce the
+ * document's intended geometry, and the result is a starburst — 0.2em of spike
+ * on a 0.49em body is a 40% overhang, which reads as a sun, not as fur. At rail
+ * size the honest range is worse: a collar small enough to read as fuzz is
+ * about 1px and invisible, which is presumably why every legibility turn in the
+ * document (16, 17) solves smallness with the glint and never with the fur.
+ *
+ * So the creature is smooth, here and in the document. Worth raising against
+ * the source rather than papering over locally — the element is kept so that a
+ * later turn changing the ratios brings the fur back on its own.
+ */
+
+const FUR_MASK =
+  "radial-gradient(circle at 50% 50%, transparent 0 35%, #000 35% 50%, transparent 50%)";
+
+const FUR: React.CSSProperties = {
+  position: "absolute",
+  // Held a uniform 0.2em outside the body on every side, tracking the egg the
+  // way the source held it around the circle. Nothing shows today (above), but
+  // a box that has drifted out of register with the body is a worse starting
+  // point for whoever picks the fur back up.
+  left: "-0.19em",
+  top: `${BODY_TOP - 0.2}em`,
+  width: `${BODY_W + 0.4}em`,
+  height: `${BODY_H + 0.4}em`,
+  background: `repeating-conic-gradient(from 0deg, ${SAGE} 0deg 11deg, transparent 11deg 22deg)`,
+  WebkitMaskImage: FUR_MASK,
+  maskImage: FUR_MASK,
+};
 
 /** Marked so the settle can move the feet after the body has stopped — see
  *  `sw-foot-settle` in globals.css. */
 const foot = (left: string): React.CSSProperties => ({
   position: "absolute",
   left,
-  bottom: "-0.08em",
-  width: "0.28em",
-  height: "0.15em",
+  bottom: "-0.1em",
+  width: "0.38em",
+  height: "0.2em",
   background: FEET,
   borderRadius: "999px",
 });
 
+/**
+ * The hat, as one rotated group.
+ *
+ * The tilt is on the GROUP rather than on each piece, so crown, brim and band
+ * stay registered to each other however far it is cocked — turn 28's whole
+ * point. The origin sits low, down at the brim line, so the hat pivots where it
+ * touches the head instead of swinging about its own middle; that is what keeps
+ * the brim resting on the fur rather than lifting off it.
+ */
+const HAT_GROUP: React.CSSProperties = {
+  position: "absolute",
+  left: 0,
+  width: "1em",
+  height: "1em",
+  // Raised by exactly what the body grew, so the brim keeps the same purchase
+  // on the fur that turn 34 drew it with.
+  top: `${-BODY_LIFT}em`,
+  transform: "rotate(-14deg)",
+  transformOrigin: "50% 72%",
+};
+
 export function StoryboardMonsterMark({ scale = 1 }: Readonly<{ scale?: number }>) {
-  // 0.72em of the element's OWN font-size, which `scale` has already set below.
-  // Multiplying here as well applied the scale twice — a 1.6 scale rendered a
-  // 33px creature beside 18px text instead of the intended 21px, which left a
-  // visible gap where the box overhung the word.
-  const size = "0.72em";
   return (
     <span
       data-storyboard-monster=""
       // The growth between rail states. Everything about the creature is sized
       // off its own font-size, so animating that one property scales the whole
-      // drawing — fur, eye, glint and feet together.
+      // drawing — fur, eye, glint, hat and feet together.
       className="transition-[font-size] duration-200 motion-reduce:transition-none"
       style={{
         display: "inline-block",
-        width: size,
-        height: size,
+        width: "1em",
+        height: "1em",
+        // Never let the lockup's flex row squeeze the drawing; it has no text of
+        // its own to establish a min-content width.
+        flex: "none",
+        lineHeight: 1,
         // The creature's own box drives its parts, so one number scales the
-        // whole drawing without touching the geometry below.
-        fontSize: `${scale}em`,
+        // whole drawing without touching the geometry below. See the 0.72 note
+        // in the header: it converts `scale` into turn 34's 1em basis.
+        fontSize: `${scale * 0.72}em`,
         // NAMED FOR THE VIEW TRANSITION. Collapsing the rail does not move this
         // element, it re-lays it out — inline in the word, then alone and
         // larger — so there is nothing for a normal transition to animate
@@ -120,7 +197,7 @@ export function StoryboardMonsterMark({ scale = 1 }: Readonly<{ scale?: number }
         // own size is what puts the body on the line and the feet just under
         // it, which is where the source drawing sits inside the "o".
         position: "relative",
-        top: `${0.1 * scale}em`,
+        top: `${0.14 * scale}em`,
       }}
     >
       <span style={FUR} />
@@ -128,9 +205,9 @@ export function StoryboardMonsterMark({ scale = 1 }: Readonly<{ scale?: number }
         style={{
           position: "absolute",
           left: "0.01em",
-          top: "0.01em",
-          width: "0.7em",
-          height: "0.7em",
+          top: `${BODY_TOP}em`,
+          width: `${BODY_W}em`,
+          height: `${BODY_H}em`,
           borderRadius: "999px",
           background: SAGE,
         }}
@@ -139,10 +216,13 @@ export function StoryboardMonsterMark({ scale = 1 }: Readonly<{ scale?: number }
         <span
           style={{
             position: "absolute",
-            left: "0.12em",
-            top: "0.12em",
-            width: "0.46em",
-            height: "0.46em",
+            left: "0.17em",
+            // CENTRED IN THE EGG, not held at the source's 0.17em. Keeping that
+            // number would have pinned the eye to the top of a taller head and
+            // spent the whole stretch below it, where nothing needed the room.
+            top: `${(BODY_H - 0.64) / 2}em`,
+            width: "0.64em",
+            height: "0.64em",
             borderRadius: "999px",
             background: CREAM,
           }}
@@ -152,10 +232,10 @@ export function StoryboardMonsterMark({ scale = 1 }: Readonly<{ scale?: number }
             data-monster-pupil=""
             style={{
               position: "absolute",
-              left: "0.09em",
-              top: "0.09em",
-              width: "0.28em",
-              height: "0.28em",
+              left: "0.125em",
+              top: "0.125em",
+              width: "0.39em",
+              height: "0.39em",
               borderRadius: "999px",
               background: PUPIL,
             }}
@@ -165,10 +245,10 @@ export function StoryboardMonsterMark({ scale = 1 }: Readonly<{ scale?: number }
             <span
               style={{
                 position: "absolute",
-                left: "0.035em",
-                top: "0.035em",
-                width: "0.1em",
-                height: "0.1em",
+                left: "0.05em",
+                top: "0.05em",
+                width: "0.14em",
+                height: "0.14em",
                 borderRadius: "999px",
                 background: CREAM,
               }}
@@ -176,8 +256,49 @@ export function StoryboardMonsterMark({ scale = 1 }: Readonly<{ scale?: number }
           </span>
         </span>
       </span>
-      <span data-monster-foot="" style={foot("0.04em")} />
-      <span data-monster-foot="" style={foot("0.4em")} />
+      <span data-monster-foot="" style={foot("0.08em")} />
+      <span data-monster-foot="" style={foot("0.55em")} />
+      <span data-monster-hat="" style={HAT_GROUP}>
+        {/* The pinched crown. The polygon dents the top twice — up one side, a
+            dip in the middle, up the other — which is the whole difference
+            between a cowboy hat and a bucket. */}
+        <span
+          style={{
+            position: "absolute",
+            left: "0.23em",
+            top: "-0.3em",
+            width: "0.54em",
+            height: "0.42em",
+            background: HAT,
+            clipPath: "polygon(0 100%, 0 34%, 22% 8%, 50% 26%, 78% 8%, 100% 34%, 100% 100%)",
+          }}
+        />
+        {/* The brim, wider than the head so it overlaps the fur on both sides —
+            turn 27's rule, and the reason the hat sits ON the creature instead
+            of hovering above it. */}
+        <span
+          style={{
+            position: "absolute",
+            left: "-0.02em",
+            top: "0.08em",
+            width: "1.04em",
+            height: "0.16em",
+            background: HAT,
+            borderRadius: "999px",
+          }}
+        />
+        {/* The band, in the wordmark's own colour. */}
+        <span
+          style={{
+            position: "absolute",
+            left: "0.23em",
+            top: "0.01em",
+            width: "0.54em",
+            height: "0.08em",
+            background: STORYBOARD_MONSTER_ACCENT,
+          }}
+        />
+      </span>
     </span>
   );
 }

--- a/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.tsx
+++ b/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.tsx
@@ -42,15 +42,31 @@ const PUPIL = "oklch(0.27 0.03 145)";
  */
 export const STORYBOARD_MONSTER_ACCENT = "oklch(0.78 0.10 45)";
 /**
- * `--color-accent`: the crown and the brim.
+ * The crown and the brim.
  *
- * The base step of the ramp that `STORYBOARD_MONSTER_ACCENT` is the 300 of, so
- * it has to sit deeper and stronger than the band it carries — level with it
- * and the band disappears into the crown, leaving the hat one flat shape. It
- * also has to clear the rail's own ~0.19 lightness, the constraint that already
- * killed two candidate foot colours.
+ * STANDS OFF THE SOURCE'S RAMP ON PURPOSE. The document paints both from
+ * `--color-accent` with `--color-accent-300` as the band — a darker hat wearing
+ * a lighter stripe, which is right on its own pale ground. On the rail's
+ * near-black it is not: a 0.62-lightness crown sits closer to the rail than to
+ * the 0.86 sage body directly beneath it, so the hat reads as a shadow ON the
+ * creature rather than as something the creature is wearing. Collapsed, where
+ * the whole mark is 22px and the crown about 8, it half-disappeared.
+ *
+ * So the pair is lifted TOGETHER and the contrast between them is what is
+ * preserved, not the absolute values: crown to 0.70 with the chroma pushed to
+ * hold its identity against the sage, band to 0.89 so it stays the lighter
+ * stripe the source drew. Raising only the crown would have closed the gap to
+ * the band and flattened the hat into one shape, which is the failure the old
+ * comment here was guarding against from the other direction.
+ *
+ * The wordmark keeps `STORYBOARD_MONSTER_ACCENT` untouched. It sits on the same
+ * black but at 19px with letterforms behind it, which is a different legibility
+ * problem and one it was already solving.
  */
-const HAT = "oklch(0.62 0.16 42)";
+const HAT = "oklch(0.70 0.18 45)";
+/** The band. Lighter than the crown by more than the source needed — see above.
+ *  Still terracotta, so the hat stays one object rather than two stacked ones. */
+const HAT_BAND = "oklch(0.89 0.08 48)";
 /**
  * The source's literal denim (turn 32, kept by turn 34).
  *
@@ -83,6 +99,53 @@ const BODY_H = 1.12;
 const BODY_TOP = 0.99 - BODY_H;
 /** How much taller than the source, and so how far the hat rides up with it. */
 const BODY_LIFT = BODY_H - BODY_W;
+
+/**
+ * WHERE THE CREATURE IS LOOKING WHEN NOTHING IS HAPPENING.
+ *
+ * At rest it watches the breadcrumb — the back arrow and project name at the
+ * top of the board, which is the thing a reader arriving at this corner is
+ * about to use. Measured rather than guessed, in both rail states: from the
+ * eye's centre to the project title is +161px x by -2px y with the rail open
+ * and +155 by -3 collapsed. Both are within a degree of straight right, so the
+ * gaze does NOT need to flip with the rail — a fact worth writing down, because
+ * "it must need to mirror when it collapses" is the obvious wrong assumption.
+ *
+ * IT IS A POSITION, NOT A TRANSFORM, and that is the whole reason it composes.
+ * The aim and the settle in `globals.css` are transforms, so they read as
+ * deltas from wherever the pupil sits — the eye still throws itself along the
+ * jump and still comes home to `translate(0, 0)`, which now means "back to
+ * watching the breadcrumb" instead of "dead centre". Putting the gaze in the
+ * transform would have meant every keyframe carrying it too.
+ *
+ * ONLY WHEN THE RAIL IS COLLAPSED. Open, the creature stands inside the word —
+ * it IS the "o" of "monster" — and a letterform with its counter shoved to one
+ * side stops being a letter. So it looks front and centre there, the way the
+ * source draws it, and turns its head only once the word is gone and it is
+ * alone in the corner with nothing left to be part of.
+ *
+ * THE WHOLE RANGE IS ABOUT 2.7px, which is why this number is larger than
+ * "slightly" sounds. The pupil can travel (0.64 - 0.39) / 2 = 0.125em before it
+ * reaches the white's rim, and on the collapsed mark that is 2.7px end to end.
+ * At 60% of it the gaze is about 1.6px — the smallest offset that survives
+ * rounding at this size. Anything genuinely subtle here is simply invisible.
+ *
+ * NO VERTICAL COMPONENT, because the measurement did not ask for one: the
+ * breadcrumb sits within a degree of level with the eye in both rail states. A
+ * tilt would be invention dressed as observation, and the glint already keeps
+ * the eye from reading flat.
+ *
+ * It composes cleanly with the jump, and only because it is collapsed-only: the
+ * aim in `globals.css` throws the pupil 26% of its own width ALONG travel, and
+ * the creature only ever ARRIVES collapsed by travelling left — so the aim
+ * subtracts from a rightward gaze rather than stacking onto it, and the pupil
+ * never reaches the rim. The eye white keeps its `overflow: hidden` regardless:
+ * a pupil cannot leave an eye, and the next person to touch these numbers
+ * should not have to rediscover that.
+ */
+const PUPIL_CENTRED = (0.64 - 0.39) / 2;
+const GAZE_X = 0.075;
+const GAZE_Y = 0;
 
 /**
  * The fur ring: a conic gradient of spikes, masked to an annulus.
@@ -142,13 +205,22 @@ const foot = (left: string): React.CSSProperties => ({
 });
 
 /**
- * The hat, as one rotated group.
+ * The hat, as TWO nested groups — and the split is load-bearing.
  *
- * The tilt is on the GROUP rather than on each piece, so crown, brim and band
- * stay registered to each other however far it is cocked — turn 28's whole
- * point. The origin sits low, down at the brim line, so the hat pivots where it
- * touches the head instead of swinging about its own middle; that is what keeps
- * the brim resting on the fur rather than lifting off it.
+ * The outer one holds no transform of its own. That is what lets `globals.css`
+ * own the hat's motion: an inline `transform` beats any stylesheet rule, so a
+ * hat whose resting tilt lives on the animated element cannot be animated from
+ * CSS at all. The outer group therefore expresses DELTAS from rest — the lag,
+ * the jam-down, the bounce — and rest is simply no transform.
+ *
+ * The inner one carries turn 34's fixed -14deg cock. Keeping the tilt on the
+ * group rather than on each piece is turn 28's point: crown, brim and band stay
+ * registered to each other however far it leans.
+ *
+ * BOTH pivot about the same low origin, down at the brim line where the hat
+ * touches the head, so it swings where it actually rests instead of about its
+ * own middle. That one number is why the brim stays on the fur through a lean
+ * that would otherwise lift it clear.
  */
 const HAT_GROUP: React.CSSProperties = {
   position: "absolute",
@@ -158,11 +230,32 @@ const HAT_GROUP: React.CSSProperties = {
   // Raised by exactly what the body grew, so the brim keeps the same purchase
   // on the fur that turn 34 drew it with.
   top: `${-BODY_LIFT}em`,
+  transformOrigin: "50% 72%",
+};
+
+/** Turn 34's fixed cock, held off the animated element — see above. */
+const HAT_TILT: React.CSSProperties = {
+  position: "absolute",
+  left: 0,
+  top: 0,
+  width: "1em",
+  height: "1em",
   transform: "rotate(-14deg)",
   transformOrigin: "50% 72%",
 };
 
-export function StoryboardMonsterMark({ scale = 1 }: Readonly<{ scale?: number }>) {
+export function StoryboardMonsterMark({
+  scale = 1,
+  gaze = "ahead",
+}: Readonly<{
+  scale?: number;
+  /** Where the pupil rests. `"ahead"` is the source's centred eye, which is what
+   *  the wordmark needs; `"breadcrumb"` turns it toward the board's header and
+   *  belongs to the collapsed rail. See the GAZE_X note above. */
+  gaze?: "ahead" | "breadcrumb";
+}>) {
+  const gazeX = gaze === "breadcrumb" ? GAZE_X : 0;
+  const gazeY = gaze === "breadcrumb" ? GAZE_Y : 0;
   return (
     <span
       data-storyboard-monster=""
@@ -225,6 +318,12 @@ export function StoryboardMonsterMark({ scale = 1 }: Readonly<{ scale?: number }
             height: "0.64em",
             borderRadius: "999px",
             background: CREAM,
+            // A PUPIL CANNOT LEAVE THE EYE. With the resting gaze offset added
+            // to the settle's own excursion, the far edge of the pupil reaches
+            // about half a pixel past the white and would otherwise be drawn on
+            // the sage. Clipping it to the circle is both the fix and what
+            // actually happens to an eye looking hard to one side.
+            overflow: "hidden",
           }}
         >
           {/* pupil */}
@@ -232,8 +331,8 @@ export function StoryboardMonsterMark({ scale = 1 }: Readonly<{ scale?: number }
             data-monster-pupil=""
             style={{
               position: "absolute",
-              left: "0.125em",
-              top: "0.125em",
+              left: `${PUPIL_CENTRED + gazeX}em`,
+              top: `${PUPIL_CENTRED + gazeY}em`,
               width: "0.39em",
               height: "0.39em",
               borderRadius: "999px",
@@ -259,45 +358,48 @@ export function StoryboardMonsterMark({ scale = 1 }: Readonly<{ scale?: number }
       <span data-monster-foot="" style={foot("0.08em")} />
       <span data-monster-foot="" style={foot("0.55em")} />
       <span data-monster-hat="" style={HAT_GROUP}>
-        {/* The pinched crown. The polygon dents the top twice — up one side, a
+        <span style={HAT_TILT}>
+          {/* The pinched crown. The polygon dents the top twice — up one side, a
             dip in the middle, up the other — which is the whole difference
             between a cowboy hat and a bucket. */}
-        <span
-          style={{
-            position: "absolute",
-            left: "0.23em",
-            top: "-0.3em",
-            width: "0.54em",
-            height: "0.42em",
-            background: HAT,
-            clipPath: "polygon(0 100%, 0 34%, 22% 8%, 50% 26%, 78% 8%, 100% 34%, 100% 100%)",
-          }}
-        />
-        {/* The brim, wider than the head so it overlaps the fur on both sides —
+          <span
+            style={{
+              position: "absolute",
+              left: "0.23em",
+              top: "-0.3em",
+              width: "0.54em",
+              height: "0.42em",
+              background: HAT,
+              clipPath:
+                "polygon(0 100%, 0 34%, 22% 8%, 50% 26%, 78% 8%, 100% 34%, 100% 100%)",
+            }}
+          />
+          {/* The brim, wider than the head so it overlaps the fur on both sides —
             turn 27's rule, and the reason the hat sits ON the creature instead
             of hovering above it. */}
-        <span
-          style={{
-            position: "absolute",
-            left: "-0.02em",
-            top: "0.08em",
-            width: "1.04em",
-            height: "0.16em",
-            background: HAT,
-            borderRadius: "999px",
-          }}
-        />
-        {/* The band, in the wordmark's own colour. */}
-        <span
-          style={{
-            position: "absolute",
-            left: "0.23em",
-            top: "0.01em",
-            width: "0.54em",
-            height: "0.08em",
-            background: STORYBOARD_MONSTER_ACCENT,
-          }}
-        />
+          <span
+            style={{
+              position: "absolute",
+              left: "-0.02em",
+              top: "0.08em",
+              width: "1.04em",
+              height: "0.16em",
+              background: HAT,
+              borderRadius: "999px",
+            }}
+          />
+          {/* The band. */}
+          <span
+            style={{
+              position: "absolute",
+              left: "0.23em",
+              top: "0.01em",
+              width: "0.54em",
+              height: "0.08em",
+              background: HAT_BAND,
+            }}
+          />
+        </span>
       </span>
     </span>
   );

--- a/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.tsx
+++ b/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.tsx
@@ -1,0 +1,148 @@
+/**
+ * The storyboard monster — the creature that sits in the "o" of "monster".
+ *
+ * Ported from the logo design document's final direction (turn 21, "20a on
+ * dark", FIRST treatment: near-black ground, pale terracotta feet — the two
+ * dark options differ only in the feet). It is drawn in CSS
+ * rather than SVG, exactly as the source is: a masked `repeating-conic-gradient`
+ * makes the fur spikes, and the eye is four nested circles.
+ *
+ * SIZED IN `em`, so it scales with whatever font-size the lockup uses and can
+ * sit inline in the wordmark. `scale` multiplies that — the document's turn 19
+ * ("a bigger monster in the o") establishes that growing the creature past the
+ * letter is a sanctioned move, and the rail needs it: the source drawing is
+ * 0.72em, which at a font-size small enough for "storyboard monster" to fit a
+ * 239px rail would put the creature under the legibility floor the document
+ * itself measured — "below about 19px the fur spikes and the glint start to
+ * merge".
+ *
+ * COLOURS ARE APPROXIMATED. The design document referenced its own design
+ * system (`var(--color-bg)`, `var(--color-accent-2-900)`, …) and shipped
+ * without that stylesheet, so only the sage is the source's literal value. The
+ * cream and the pupil are matched by eye to the document's dark-mode frames and
+ * are the two worth checking against the real palette.
+ */
+const SAGE = "oklch(0.86 0.17 128)";
+/** The document's `--color-bg` on its dark frames: a warm off-white. */
+const CREAM = "oklch(0.96 0.02 95)";
+/** The document's `--color-accent-2-900`: the pupil, near-black. */
+const PUPIL = "oklch(0.27 0.03 145)";
+/**
+ * The document's `--color-accent-300`: pale terracotta.
+ *
+ * The feet AND the word "monster" are this same token — turn 18 chose it as
+ * "terracotta feet, matches the wordmark", and turn 21 kept it for dark. Export
+ * it so the lockup cannot drift from the creature.
+ */
+export const STORYBOARD_MONSTER_ACCENT = "oklch(0.78 0.10 45)";
+
+/** The fur ring: spikes radiating from the body, masked to an annulus so the
+ *  gradient only shows outside the circle. */
+const FUR: React.CSSProperties = {
+  position: "absolute",
+  left: "-0.14em",
+  top: "-0.14em",
+  width: "1em",
+  height: "1em",
+  background: `repeating-conic-gradient(from 0deg, ${SAGE} 0deg 11deg, transparent 11deg 22deg)`,
+  WebkitMaskImage:
+    "radial-gradient(circle at 50% 50%, transparent 0 35%, #000 35% 50%, transparent 50%)",
+  maskImage:
+    "radial-gradient(circle at 50% 50%, transparent 0 35%, #000 35% 50%, transparent 50%)",
+};
+
+const foot = (left: string): React.CSSProperties => ({
+  position: "absolute",
+  left,
+  bottom: "-0.08em",
+  width: "0.28em",
+  height: "0.15em",
+  background: STORYBOARD_MONSTER_ACCENT,
+  borderRadius: "999px",
+});
+
+export function StoryboardMonsterMark({ scale = 1 }: Readonly<{ scale?: number }>) {
+  // 0.72em of the element's OWN font-size, which `scale` has already set below.
+  // Multiplying here as well applied the scale twice — a 1.6 scale rendered a
+  // 33px creature beside 18px text instead of the intended 21px, which left a
+  // visible gap where the box overhung the word.
+  const size = "0.72em";
+  return (
+    <span
+      data-storyboard-monster=""
+      style={{
+        display: "inline-block",
+        width: size,
+        height: size,
+        // The creature's own box drives its parts, so one number scales the
+        // whole drawing without touching the geometry below.
+        fontSize: `${scale}em`,
+        // NUDGED, NOT BASELINE-ALIGNED. The lockup is a flex row, and the
+        // pieces around this are `RevealedLetters` — `display: grid`, so they
+        // can only be flex items and the whole row is laid out by flex, not by
+        // inline text. `align-self: baseline` on an item with no text of its
+        // own resolves to its bottom margin edge and threw the creature to the
+        // top of the 72px row. Centring it and dropping it by a fraction of its
+        // own size is what puts the body on the line and the feet just under
+        // it, which is where the source drawing sits inside the "o".
+        position: "relative",
+        top: `${0.1 * scale}em`,
+      }}
+    >
+      <span style={FUR} />
+      <span
+        style={{
+          position: "absolute",
+          left: "0.01em",
+          top: "0.01em",
+          width: "0.7em",
+          height: "0.7em",
+          borderRadius: "999px",
+          background: SAGE,
+        }}
+      >
+        {/* eye white */}
+        <span
+          style={{
+            position: "absolute",
+            left: "0.12em",
+            top: "0.12em",
+            width: "0.46em",
+            height: "0.46em",
+            borderRadius: "999px",
+            background: CREAM,
+          }}
+        >
+          {/* pupil */}
+          <span
+            style={{
+              position: "absolute",
+              left: "0.09em",
+              top: "0.09em",
+              width: "0.28em",
+              height: "0.28em",
+              borderRadius: "999px",
+              background: PUPIL,
+            }}
+          >
+            {/* the glint — the document's turn 17 exists for this one dot, and
+                it is the first thing to disappear at small sizes */}
+            <span
+              style={{
+                position: "absolute",
+                left: "0.035em",
+                top: "0.035em",
+                width: "0.1em",
+                height: "0.1em",
+                borderRadius: "999px",
+                background: CREAM,
+              }}
+            />
+          </span>
+        </span>
+      </span>
+      <span style={foot("0.04em")} />
+      <span style={foot("0.4em")} />
+    </span>
+  );
+}

--- a/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.tsx
+++ b/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.tsx
@@ -73,6 +73,8 @@ const FUR: React.CSSProperties = {
  */
 const FEET = "oklch(0.72 0.13 250)";
 
+/** Marked so the settle can move the feet after the body has stopped — see
+ *  `sw-foot-settle` in globals.css. */
 const foot = (left: string): React.CSSProperties => ({
   position: "absolute",
   left,
@@ -103,6 +105,12 @@ export function StoryboardMonsterMark({ scale = 1 }: Readonly<{ scale?: number }
         // The creature's own box drives its parts, so one number scales the
         // whole drawing without touching the geometry below.
         fontSize: `${scale}em`,
+        // NAMED FOR THE VIEW TRANSITION. Collapsing the rail does not move this
+        // element, it re-lays it out — inline in the word, then alone and
+        // larger — so there is nothing for a normal transition to animate
+        // between. A name lets the browser snapshot both and interpolate; the
+        // hop itself is styled in `globals.css`.
+        viewTransitionName: "sw-monster",
         // NUDGED, NOT BASELINE-ALIGNED. The lockup is a flex row, and the
         // pieces around this are `RevealedLetters` — `display: grid`, so they
         // can only be flex items and the whole row is laid out by flex, not by
@@ -141,6 +149,7 @@ export function StoryboardMonsterMark({ scale = 1 }: Readonly<{ scale?: number }
         >
           {/* pupil */}
           <span
+            data-monster-pupil=""
             style={{
               position: "absolute",
               left: "0.09em",
@@ -167,8 +176,8 @@ export function StoryboardMonsterMark({ scale = 1 }: Readonly<{ scale?: number }
           </span>
         </span>
       </span>
-      <span style={foot("0.04em")} />
-      <span style={foot("0.4em")} />
+      <span data-monster-foot="" style={foot("0.04em")} />
+      <span data-monster-foot="" style={foot("0.4em")} />
     </span>
   );
 }

--- a/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.tsx
+++ b/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.tsx
@@ -51,13 +51,35 @@ const FUR: React.CSSProperties = {
     "radial-gradient(circle at 50% 50%, transparent 0 35%, #000 35% 50%, transparent 50%)",
 };
 
+/**
+ * A LIGHT BLUE, off the document's palette and arrived at by elimination.
+ *
+ * Terracotta (turn 21's first dark treatment) is the same value as the word the
+ * creature stands in, so the feet read as part of the letters. Cream (its
+ * second) separates cleanly but is the brightest thing in the rail — the feet
+ * ended up louder than the eye they belong to. Dark navy disappeared outright,
+ * which is the failure turn 21 already documented for near-black: "the
+ * near-black feet can't survive on a dark ground".
+ *
+ * The constraint the document is pointing at: the feet sit BELOW the body,
+ * against the rail rather than against the sage, so anything near the rail's own
+ * value has nothing behind it to separate from. And they are small — about 3px
+ * tall at this size — which needs MORE contrast than a large shape, not less.
+ *
+ * So the value is chosen for LIGHTNESS first and hue second: 0.72 against the
+ * rail's ~0.19. A dark blue was tried at 0.34 and vanished, which is the same
+ * failure as the near-black. The hue also has to stay clear of the sage body it
+ * sits under and the terracotta type it sits beside, which a blue does.
+ */
+const FEET = "oklch(0.72 0.13 250)";
+
 const foot = (left: string): React.CSSProperties => ({
   position: "absolute",
   left,
   bottom: "-0.08em",
   width: "0.28em",
   height: "0.15em",
-  background: STORYBOARD_MONSTER_ACCENT,
+  background: FEET,
   borderRadius: "999px",
 });
 
@@ -70,6 +92,10 @@ export function StoryboardMonsterMark({ scale = 1 }: Readonly<{ scale?: number }
   return (
     <span
       data-storyboard-monster=""
+      // The growth between rail states. Everything about the creature is sized
+      // off its own font-size, so animating that one property scales the whole
+      // drawing — fur, eye, glint and feet together.
+      className="transition-[font-size] duration-200 motion-reduce:transition-none"
       style={{
         display: "inline-block",
         width: size,

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -140,7 +140,8 @@ function writeRailExpanded(next: boolean): void {
   const doc = document as Document & {
     startViewTransition?: (callback: () => void) => unknown;
   };
-  const reduced = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true;
+  const reduced =
+    window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true;
   if (typeof doc.startViewTransition !== "function" || reduced) {
     commitRailExpanded(next);
     return;
@@ -193,7 +194,13 @@ function writeRailExpanded(next: boolean): void {
       // captured image to live element is invisible.
       mark.removeAttribute("data-aiming");
       mark.setAttribute("data-settling", "");
-      window.setTimeout(() => mark.removeAttribute("data-settling"), 620);
+      // Outlasts the longest part, which is now the PUPIL: it constricts over
+      // 900ms after a 140ms autonomic latency, so it is still moving 400ms
+      // after the hat has stopped. Pulling the attribute early does not shorten
+      // the flourish, it truncates it — at the old 620ms the hat's final bounce
+      // was cut mid-air, and at 760ms the eye would snap the last of its
+      // dilation off in one frame.
+      window.setTimeout(() => mark.removeAttribute("data-settling"), 1160);
     })
     .catch(() => {
       // A transition skipped or superseded by a faster second click. The rail
@@ -229,7 +236,9 @@ function writeRailExpanded(next: boolean): void {
  * click with no pointer anywhere near the tile, so no `pointerenter` would ever
  * arrive to clear the flag and that tile would go quiet for good.
  */
-function suppressTipUntilPointerReturns(event: React.MouseEvent<HTMLElement>): void {
+function suppressTipUntilPointerReturns(
+  event: React.MouseEvent<HTMLElement>,
+): void {
   if (event.detail === 0) return;
   const tile = (event.target as HTMLElement | null)?.closest("button, a");
   if (!(tile instanceof HTMLElement)) return;
@@ -242,7 +251,6 @@ function suppressTipUntilPointerReturns(event: React.MouseEvent<HTMLElement>): v
     { once: true },
   );
 }
-
 
 /**
  * Letters that grow from nothing to their natural width, and back.
@@ -767,7 +775,9 @@ export function TimelineSidebar() {
               `display: contents` so hiding them costs no layout — the letters
               keep participating in the link's own flex box. */}
           <span aria-hidden="true" className="contents">
-            <RevealedLetters show={railExpanded}>storyboard&nbsp;</RevealedLetters>
+            <RevealedLetters show={railExpanded}>
+              storyboard&nbsp;
+            </RevealedLetters>
             {/* The creature takes the monogram's place: it is what survives the
                 collapse, exactly as "SW" did. The word rebuilds around it —
                 "m" before, "nster" after — so opening the rail grows the name
@@ -776,7 +786,10 @@ export function TimelineSidebar() {
                 the link rather than becoming one narrow item that wraps inside
                 itself — the same reason the wrapper above uses it. Colour still
                 inherits through a `display: contents` box. */}
-            <span className="contents" style={{ color: STORYBOARD_MONSTER_ACCENT }}>
+            <span
+              className="contents"
+              style={{ color: STORYBOARD_MONSTER_ACCENT }}
+            >
               <RevealedLetters show={railExpanded}>m</RevealedLetters>
               {/* SMALL IN THE WORD, BIG ALONE. Expanded it is the source's own
                   proportion (0.72em), which is what makes it read as the "o" of
@@ -785,7 +798,10 @@ export function TimelineSidebar() {
                   the rail needs — and past the 19px floor the design document
                   measured, below which "the fur spikes and the glint start to
                   merge". */}
-              <StoryboardMonsterMark scale={railExpanded ? 1.1 : 1.6} />
+              <StoryboardMonsterMark
+                scale={railExpanded ? 1.1 : 1.6}
+                gaze={railExpanded ? "ahead" : "breadcrumb"}
+              />
               <RevealedLetters show={railExpanded}>nster</RevealedLetters>
             </span>
           </span>
@@ -841,10 +857,10 @@ export function TimelineSidebar() {
             const tooltipId = `sidebar-tooltip-utility-${item.id}`;
             const isPressed = isTrashOpen;
             // Through a view transition, so the drawer RISES instead of
-          // appearing. Same helper the trim modal uses — including the root
-          // flag the e2e waits on.
-          const handleClick = () =>
-            void withViewTransition(() => setIsTrashOpen(!isTrashOpen));
+            // appearing. Same helper the trim modal uses — including the root
+            // flag the e2e waits on.
+            const handleClick = () =>
+              void withViewTransition(() => setIsTrashOpen(!isTrashOpen));
 
             // WARM THE BIN ON INTENT, so the drawer opens at its final height
             // rather than growing when the fetch lands.
@@ -967,9 +983,9 @@ export function TimelineSidebar() {
                 alt={user.name || user.email || "Profile"}
                 className={cn(
                   // `relative` for the same reason the glyphs carry it: the tile's pill is
-                // an absolute ::before and would otherwise paint a 40% black veil over
-                // this face. Same bug the collection thumbnails had.
-                "relative h-8 w-8 shrink-0 rounded-full object-cover border border-zinc-700 group-hover/sidebar-item:border-zinc-500 transition-colors",
+                  // an absolute ::before and would otherwise paint a 40% black veil over
+                  // this face. Same bug the collection thumbnails had.
+                  "relative h-8 w-8 shrink-0 rounded-full object-cover border border-zinc-700 group-hover/sidebar-item:border-zinc-500 transition-colors",
                   SIDEBAR_AVATAR_INSET,
                 )}
               />

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -18,6 +18,10 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import {
+  StoryboardMonsterMark,
+  STORYBOARD_MONSTER_ACCENT,
+} from "./storyboard-monster-mark";
 import { TrashDrawer } from "@/components/assets/trash-drawer";
 import { useAuth } from "@/components/auth/auth-provider";
 import {
@@ -650,10 +654,20 @@ export function TimelineSidebar() {
               `display: contents` so hiding them costs no layout — the letters
               keep participating in the link's own flex box. */}
           <span aria-hidden="true" className="contents">
-            S
-            <RevealedLetters show={railExpanded}>toryboard&nbsp;</RevealedLetters>
-            W
-            <RevealedLetters show={railExpanded}>orkbench</RevealedLetters>
+            <RevealedLetters show={railExpanded}>storyboard&nbsp;</RevealedLetters>
+            {/* The creature takes the monogram's place: it is what survives the
+                collapse, exactly as "SW" did. The word rebuilds around it —
+                "m" before, "nster" after — so opening the rail grows the name
+                out of the mark rather than swapping one thing for another. */}
+            {/* `contents`, so "m", the creature and "nster" stay FLEX ITEMS of
+                the link rather than becoming one narrow item that wraps inside
+                itself — the same reason the wrapper above uses it. Colour still
+                inherits through a `display: contents` box. */}
+            <span className="contents" style={{ color: STORYBOARD_MONSTER_ACCENT }}>
+              <RevealedLetters show={railExpanded}>m</RevealedLetters>
+              <StoryboardMonsterMark scale={1.6} />
+              <RevealedLetters show={railExpanded}>nster</RevealedLetters>
+            </span>
           </span>
         </Link>
 

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -145,6 +145,27 @@ function writeRailExpanded(next: boolean): void {
     commitRailExpanded(next);
     return;
   }
+  // WHICH WAY IT IS GOING, for the lean. Opening, the creature travels RIGHT —
+  // out of the collapsed rail's centre and into the middle of the word.
+  // Closing, it travels left. The keyframes multiply their rotation and drift
+  // by this, so the body leans into the direction of the jump instead of
+  // always tipping the same way. A creature that leans the wrong way reads as
+  // being blown sideways rather than as choosing to go.
+  document.documentElement.style.setProperty("--sw-hop-dir", next ? "1" : "-1");
+
+  // AIM THE EYE BEFORE THE BODY GOES. Both snapshots are captured with this
+  // attribute set — the pose it leaves from and the pose it lands in — so the
+  // pupil points along the arc for the WHOLE flight rather than only reacting
+  // once it is over. That ordering is the whole effect: an eye that moves first
+  // reads as a creature deciding to jump, and an eye that only moves on landing
+  // reads as one that was thrown.
+  //
+  // It has to be an attribute set here rather than a keyframe in the hop,
+  // because mid-flight the creature is a rasterised image and nothing inside it
+  // can move. A pose can still be captured INTO that image; motion cannot.
+  const mark = document.querySelector("[data-storyboard-monster]");
+  mark?.setAttribute("data-aiming", "");
+
   const transition = doc.startViewTransition(() => {
     flushSync(() => commitRailExpanded(next));
   }) as { finished?: Promise<unknown> };
@@ -157,16 +178,28 @@ function writeRailExpanded(next: boolean): void {
   //
   // Attribute rather than React state on purpose: this is a 500ms flourish, and
   // routing it through the store would re-render the sidebar twice more for it.
-  void transition.finished
-    ?.then(() => {
-      const mark = document.querySelector("[data-storyboard-monster]");
+  const finished = transition.finished;
+  if (!finished) {
+    // Nothing to hang the settle off. Drop the aim on a timer regardless — a
+    // pupil left staring sideways is worse than no flourish at all.
+    window.setTimeout(() => mark?.removeAttribute("data-aiming"), 620);
+    return;
+  }
+  void finished
+    .then(() => {
       if (!mark) return;
+      // Swapped in ONE frame, and the settle's first pose is the aim, so the
+      // pupil is never briefly re-centred between the two — the handover from
+      // captured image to live element is invisible.
+      mark.removeAttribute("data-aiming");
       mark.setAttribute("data-settling", "");
       window.setTimeout(() => mark.removeAttribute("data-settling"), 620);
     })
     .catch(() => {
       // A transition skipped or superseded by a faster second click. The rail
-      // still moved; only the flourish is lost.
+      // still moved; only the flourish is lost — but the aim must come off, or
+      // the eye is left pointing at a jump that never happened.
+      mark?.removeAttribute("data-aiming");
     });
 }
 

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -638,11 +638,23 @@ export function TimelineSidebar() {
               contracting instead of a label being replaced by an abbreviation.
 
               The accessible name comes from `aria-label` on the link, so the
-              split spans are never read out letter by letter. */}
-          S
-          <RevealedLetters show={railExpanded}>toryboard&nbsp;</RevealedLetters>
-          W
-          <RevealedLetters show={railExpanded}>orkbench</RevealedLetters>
+              split spans are never read out letter by letter.
+
+              HIDDEN FROM ASSISTIVE TECH, for the same reason. Collapsed, the
+              mark reads "SW", which is not contained in "Storyboard Workbench
+              home" — Lighthouse flags that as `label-content-name-mismatch`
+              (WCAG 2.5.3 "Label in Name"): someone driving by voice says what
+              they see and matches nothing. The mark is branding, not a label,
+              so the label carries the name and the letters carry none.
+
+              `display: contents` so hiding them costs no layout — the letters
+              keep participating in the link's own flex box. */}
+          <span aria-hidden="true" className="contents">
+            S
+            <RevealedLetters show={railExpanded}>toryboard&nbsp;</RevealedLetters>
+            W
+            <RevealedLetters show={railExpanded}>orkbench</RevealedLetters>
+          </span>
         </Link>
 
         {activeProjectId && (

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -18,6 +18,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { flushSync } from "react-dom";
 import {
   StoryboardMonsterMark,
   STORYBOARD_MONSTER_ACCENT,
@@ -106,7 +107,7 @@ function subscribeRailExpanded(onChange: () => void): () => void {
   };
 }
 
-function writeRailExpanded(next: boolean): void {
+function commitRailExpanded(next: boolean): void {
   try {
     window.localStorage.setItem(RAIL_EXPANDED_STORAGE_KEY, String(next));
   } catch {
@@ -114,6 +115,59 @@ function writeRailExpanded(next: boolean): void {
     // the event still fires, so the rail still moves for this session.
   }
   window.dispatchEvent(new Event(RAIL_EXPANDED_EVENT));
+}
+
+/**
+ * Toggle the rail INSIDE a view transition, so the monster can jump between its
+ * two homes rather than teleport.
+ *
+ * The creature's two positions are genuinely different DOM layouts — inline in
+ * "m…nster" when open, alone and larger when closed — so nothing about the
+ * change is animatable by ordinary means: the element does not move, it is
+ * re-laid-out. A view transition snapshots both states and gives the browser
+ * something to interpolate between, and `globals.css` styles that interpolation
+ * as a hop (see the `sw-monster-*` keyframes).
+ *
+ * `flushSync` is not optional. `startViewTransition` captures the "after" state
+ * when its callback returns, and the callback here only dispatches an event —
+ * React's re-render would land after the capture, so the transition would
+ * animate from a state to itself.
+ *
+ * Falls back to a plain commit where the API is missing or the reader asked for
+ * less motion; the rail still moves, it just cuts.
+ */
+function writeRailExpanded(next: boolean): void {
+  const doc = document as Document & {
+    startViewTransition?: (callback: () => void) => unknown;
+  };
+  const reduced = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true;
+  if (typeof doc.startViewTransition !== "function" || reduced) {
+    commitRailExpanded(next);
+    return;
+  }
+  const transition = doc.startViewTransition(() => {
+    flushSync(() => commitRailExpanded(next));
+  }) as { finished?: Promise<unknown> };
+
+  // THE SETTLE, once the flight is over. The eye and the feet cannot move
+  // during the transition — the creature is a rasterised snapshot then, not
+  // elements — so the parts that should still be moving when the body stops are
+  // handed back to the live element here. See `sw-pupil-settle` and
+  // `sw-foot-settle`.
+  //
+  // Attribute rather than React state on purpose: this is a 500ms flourish, and
+  // routing it through the store would re-render the sidebar twice more for it.
+  void transition.finished
+    ?.then(() => {
+      const mark = document.querySelector("[data-storyboard-monster]");
+      if (!mark) return;
+      mark.setAttribute("data-settling", "");
+      window.setTimeout(() => mark.removeAttribute("data-settling"), 620);
+    })
+    .catch(() => {
+      // A transition skipped or superseded by a faster second click. The rail
+      // still moved; only the flourish is lost.
+    });
 }
 
 /**
@@ -193,11 +247,22 @@ function RevealedLetters({
     <span
       aria-hidden="true"
       className={cn(
-        "grid transition-[grid-template-columns] duration-200 motion-reduce:transition-none",
+        // OVERLAPPING ACTION. The word does not move in lockstep with the rail:
+        // opening, it trails the creature's launch by a beat, so the name reads
+        // as being pulled out behind it; closing, it goes FIRST and quickly,
+        // clearing the space before the creature jumps back into it. Loose parts
+        // lag the thing driving them, and which part is loose depends on which
+        // way the motion runs.
+        "grid transition-[grid-template-columns] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
+        show ? "delay-[90ms] duration-[420ms]" : "delay-0 duration-[220ms]",
         show ? "grid-cols-[1fr]" : "grid-cols-[0fr]",
       )}
     >
-      <span className="overflow-hidden font-semibold opacity-90">{children}</span>
+      {/* NO WEIGHT of its own. This was `font-semibold`, which was right when
+          the mark was two capitals in the UI's sans face — but Caprasimo ships
+          a single 400, so 600 only bought a synthesised bold smeared over a
+          face that is already heavy. */}
+      <span className="overflow-hidden opacity-90">{children}</span>
     </span>
   );
 }
@@ -617,7 +682,15 @@ export function TimelineSidebar() {
           // Width alone is animated. `transition-all` here would also catch the
           // backdrop filter, which is expensive to interpolate over a sticky
           // full-height surface.
-          "transition-[width] duration-200 motion-reduce:transition-none",
+          // Paced against the creature's 620ms hop rather than left at the
+          // default 200ms — the rail used to finish long before the creature
+          // landed, so it jumped to a place that had already stopped moving.
+          //
+          // SLOW IN AND SLOW OUT, weighted to the out: a decisive move that
+          // eases hard into rest, which is what a drawer pulled open and let go
+          // of does. The default `ease` is symmetric and reads mechanical
+          // against a body that accelerates and settles.
+          "transition-[width] duration-[440ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
           // From RAIL_WIDTH_CLASS, which holds the literals Tailwind's scanner
           // needs — see the note there on why these cannot be built by template.
           railExpanded
@@ -636,7 +709,10 @@ export function TimelineSidebar() {
           // at 18px, so there was room, and at 18px "storyboard monster" was
           // hard to read against everything else in the rail. Measured after:
           // see the note on the creature's scale for the other half of the fit.
-          className="flex h-[72px] w-full items-center justify-start overflow-hidden whitespace-nowrap pl-[22px] text-[22px] font-bold text-white transition-colors hover:text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-zinc-500"
+          // CAPRASIMO, the face the logo document is set in, and no
+          // `font-bold`: it ships a single 400 weight, so asking for 700 buys a
+          // synthesised bold on top of a face that is already heavy.
+          className="flex h-[72px] w-full items-center justify-start overflow-hidden whitespace-nowrap pl-[22px] font-[family-name:var(--font-caprasimo)] text-[19px] text-white transition-colors hover:text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-zinc-500"
         >
           {/* THE INITIALS NEVER LEAVE. The rest of each word collapses to
               nothing, so closing slides the S and the W together into "SW"

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -632,7 +632,11 @@ export function TimelineSidebar() {
           // in the 72px rail already put it within a pixel of 22px, so pinning
           // it there costs nothing closed and is what lets the name grow to the
           // right rather than the whole mark sliding.
-          className="flex h-[72px] w-full items-center justify-start overflow-hidden whitespace-nowrap pl-[22px] text-lg font-bold text-white transition-colors hover:text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-zinc-500"
+          // 22px, not `text-lg`. The wordmark used 186px of the rail's 239px
+          // at 18px, so there was room, and at 18px "storyboard monster" was
+          // hard to read against everything else in the rail. Measured after:
+          // see the note on the creature's scale for the other half of the fit.
+          className="flex h-[72px] w-full items-center justify-start overflow-hidden whitespace-nowrap pl-[22px] text-[22px] font-bold text-white transition-colors hover:text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-zinc-500"
         >
           {/* THE INITIALS NEVER LEAVE. The rest of each word collapses to
               nothing, so closing slides the S and the W together into "SW"
@@ -665,7 +669,14 @@ export function TimelineSidebar() {
                 inherits through a `display: contents` box. */}
             <span className="contents" style={{ color: STORYBOARD_MONSTER_ACCENT }}>
               <RevealedLetters show={railExpanded}>m</RevealedLetters>
-              <StoryboardMonsterMark scale={1.6} />
+              {/* SMALL IN THE WORD, BIG ALONE. Expanded it is the source's own
+                  proportion (0.72em), which is what makes it read as the "o" of
+                  "monster" rather than a creature parked beside it. Collapsed
+                  there is no word left to belong to, so it grows into the mark
+                  the rail needs — and past the 19px floor the design document
+                  measured, below which "the fur spikes and the glint start to
+                  merge". */}
+              <StoryboardMonsterMark scale={railExpanded ? 1.1 : 1.6} />
               <RevealedLetters show={railExpanded}>nster</RevealedLetters>
             </span>
           </span>

--- a/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
+++ b/apps/timeline-gstudio001/lib/graph-documents-gateway.ts
@@ -64,9 +64,29 @@ export type GraphServerPayload = Readonly<{
   forUid: string;
 }>;
 
+/** The empty snapshot the server rendered with — one frozen object, so
+ *  `useSyncExternalStore` sees a stable value. */
+const EMPTY_DOCUMENTS: DocumentsById = Object.freeze({});
+
 export type GraphDocumentsGateway = Readonly<{
   /** Snapshot of every document the session has loaded or written. */
   read: () => DocumentsById;
+  /**
+   * What the SERVER rendered: nothing.
+   *
+   * The third argument to `useSyncExternalStore` has to describe the HTML the
+   * server produced, and every caller was passing `read` — the live store. That
+   * store is EMPTY during SSR and PRIMED by the time hydration runs (the RSC
+   * payloads install themselves during render), so React compared a server tree
+   * built from no documents against a client tree built from all of them.
+   *
+   * In the sidebar that difference is structural — the shortcuts section exists
+   * in one tree and not the other — and Next reported a hydration mismatch.
+   *
+   * Always the same object, because `useSyncExternalStore` re-renders forever if
+   * the snapshot is a fresh value each call.
+   */
+  readServerSnapshot: () => DocumentsById;
   /** The document if already cached, without triggering IO. */
   peek: (timelineId: string) => TimelineDocument | null;
   /**
@@ -1212,6 +1232,7 @@ export function createGraphDocumentsGateway(
 
   return {
     read: () => documents,
+    readServerSnapshot: () => EMPTY_DOCUMENTS,
     peek: (timelineId) => documents[timelineId] ?? null,
     ensure,
     ensureClosure,

--- a/apps/timeline-gstudio001/scripts/remove-dangling-collection-references.ts
+++ b/apps/timeline-gstudio001/scripts/remove-dangling-collection-references.ts
@@ -17,14 +17,54 @@
  *   node scripts/remove-dangling-collection-references.ts <rootId> [--fixture] [--apply]
  */
 import { readFileSync, writeFileSync } from "node:fs";
-import { config } from "dotenv";
 import { cert, applicationDefault, initializeApp } from "firebase-admin/app";
 import { getFirestore } from "firebase-admin/firestore";
 
 import { packTimelineClips } from "@storyboard/timeline-model";
 import type { TimelineDocument } from "@storyboard/timeline-model/types";
 
-config({ path: ".env" });
+/**
+ * `.env` into `process.env`, without `dotenv`.
+ *
+ * The `.mjs` scripts beside this one import `dotenv`, and it is declared in NO
+ * package.json — it only resolves because something else pulled it into
+ * `node_modules`. That works locally and does not survive a clean install:
+ * this file is TypeScript, so `next build` type-checks it, and Vercel failed
+ * with "Cannot find module 'dotenv'". Adding the dependency would fix the
+ * import and risk the per-workspace nesting that breaks the dev server, for a
+ * loader this small.
+ *
+ * Existing environment wins, so a real environment variable is never
+ * overwritten by the file.
+ */
+function loadDotEnv(path: string): void {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    return;
+  }
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "" || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    if (key === "" || process.env[key] !== undefined) continue;
+    let value = trimmed.slice(eq + 1).trim();
+    // Quoted values keep their inner whitespace; the private key arrives this
+    // way, and its escaped newlines are unescaped at the point of use.
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    process.env[key] = value;
+  }
+}
+
+loadDotEnv(".env");
 
 const COLLECTION = "gstudioTimelineDocuments";
 const FIRESTORE_BATCH_LIMIT = 500;

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -790,7 +790,7 @@ async function openSelectionMenu(page: Page): Promise<void> {
  * corner button was a second way to do the easy thing, sitting permanently over
  * the artwork. This keeps the call sites reading the same.
  *
- * Matches the card's own accessible name (`Scene A (collection, 2 items)`)
+ * Matches the card's own accessible name (`Scene A, collection, 2 items`)
  * rather than its node id, because the id is not what a test knows.
  */
 /**
@@ -827,7 +827,7 @@ async function selectCard(card: Locator): Promise<void> {
 const drillButton = (page: Page, timelineName: string): Locator =>
   page
     .getByRole("button", {
-      name: new RegExp(`^${timelineName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")} \\(collection`),
+      name: new RegExp(`^${timelineName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}, collection`),
     })
     .first();
 
@@ -1035,11 +1035,11 @@ test.describe("graph view E2E", () => {
     // update only the document, so the visible title changed while screen
     // readers kept hearing "Scene A" indefinitely.
     const card = strip(page, PROJECT_ID).locator(`[data-node-id="${CHILD_ID}"]`);
-    await expect(card).toHaveAttribute("aria-label", /^Opening Scene \(collection/);
+    await expect(card).toHaveAttribute("aria-label", /^Opening Scene, collection/);
 
     // Undo restores BOTH representations rather than splitting them again.
     await undoButton(page).click();
-    await expect(card).toHaveAttribute("aria-label", /^Scene A \(collection/);
+    await expect(card).toHaveAttribute("aria-label", /^Scene A, collection/);
     await expect
       .poll(() => api.documents.get(CHILD_ID)?.title, { timeout: 5000 })
       .toBe("Scene A");
@@ -1051,7 +1051,7 @@ test.describe("graph view E2E", () => {
     const api = await installGraphApi(page);
     await openGraph(page);
     const card = strip(page, PROJECT_ID).locator(`[data-node-id="${CHILD_ID}"]`);
-    await expect(card).toHaveAttribute("aria-label", /^Scene A \(collection/);
+    await expect(card).toHaveAttribute("aria-label", /^Scene A, collection/);
 
     // ONE click on the card's name label → inline editor; commit with Enter.
     await card.getByText("Scene A", { exact: true }).click();
@@ -1060,7 +1060,7 @@ test.describe("graph view E2E", () => {
     await editor.press("Enter");
 
     // node.name (the accessible name, ghost, and announcements) updates at once.
-    await expect(card).toHaveAttribute("aria-label", /^Heist Plan \(collection/);
+    await expect(card).toHaveAttribute("aria-label", /^Heist Plan, collection/);
 
     // THE HOVER AFFORDANCE. A one-click target that looks exactly like static
     // text is a trap in both directions — nobody finds the rename, and anyone
@@ -1099,7 +1099,7 @@ test.describe("graph view E2E", () => {
     const api = await installGraphApi(page);
     await openGraph(page);
     const card = strip(page, PROJECT_ID).locator(`[data-node-id="${CHILD_ID}"]`);
-    await expect(card).toHaveAttribute("aria-label", /^Scene A \(collection/);
+    await expect(card).toHaveAttribute("aria-label", /^Scene A, collection/);
 
     // F2 on a focused collection card is the pointerless twin of double-clicking
     // the label: OpenKeyBoundary turns it into this rename request, which the
@@ -1125,7 +1125,7 @@ test.describe("graph view E2E", () => {
     await editor.fill("Heist Plan");
     await editor.press("Enter");
 
-    await expect(card).toHaveAttribute("aria-label", /^Heist Plan \(collection/);
+    await expect(card).toHaveAttribute("aria-label", /^Heist Plan, collection/);
     await expect
       .poll(() => api.documents.get(CHILD_ID)?.title, { timeout: 5000 })
       .toBe("Heist Plan");

--- a/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
@@ -445,6 +445,13 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
                 Math.floor(childIds.length / cols) === row.index && (
                   <div
                     data-virtual-trailing-slot
+                    // A `role="row"` may only contain cell-ish children, and
+                    // this slot sat in one with no role at all — Lighthouse's
+                    // `aria-required-children` failed on whichever row holds it
+                    // (row 0 whenever the cards do not fill a row). It IS a cell
+                    // of the grid: it occupies a cell position and starts a new
+                    // row when the last one is full.
+                    role="gridcell"
                     style={{
                       order: childIds.length % cols,
                       width: fillCellWidth,


### PR DESCRIPTION
Follow-up to #466, which made the two load fallbacks render the same component. This makes that component actually resemble the board.

It stood in for the grid and nothing else — no breadcrumb, no view controls, no panel, no controls row — so a load went bare-cards → full chrome and the whole page re-laid-out on handover.

## Measured, not sketched

Taken from the running board rather than guessed:

```
header band     57px, bottom border   breadcrumb + back left, 5 controls right
panel           rounded-xl, bg-zinc-900/60, ring-1 ring-white/10
  controls row  49px                  three pills left, total centred, two icons right
  grid          p-3, gap-3            cards 332x220 at 1400 wide
```

## Two details that only came from measuring

**The card image is flex-sized, not `aspect-video`.** An aspect-ratio placeholder came out 190 tall against the real 152, and the whole grid shifted when the board arrived. The skeleton card is now a fixed 220 with the image taking the remaining space, which is how the real card is built.

**One row of cards, not two.** The count is unknowable before the read, so the only choice is which way to be wrong: a short skeleton lets content grow downward, a tall one collapses the page when a small board arrives. Growing is quieter. Eight cards dropped a 3-card board by a full row.

Everything stays a rectangle — it stands in for chrome whose labels aren't known yet, and grey text reading "Preview" or "Select" would be content that then changes.

## Verification

Checked against the running app under **Slow 3G** throttling, which is the only way to hold the skeleton on screen long enough to compare it with the loaded board. The panel's bottom edge now lands within a few pixels of the real one's.

Typecheck · lint · app 1308 · unit 783 · stories 257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)