### PR TITLE
The jump pivots at the feet, and the body bends over them

### DIFF
--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -377,6 +377,13 @@ html {
   mix-blend-mode: normal;
   height: 100%;
   object-fit: contain;
+  /* PIVOT AT THE FEET. A jump turns about the ground, not about the creature's
+     waist: the landing squash has to compress DOWN onto the floor, and the lean
+     has to swing the head while the feet hold their place. About the default
+     centre, the squash lifts the feet as much as it drops the head and the lean
+     slides the whole body sideways — both read as a sticker being manipulated
+     rather than as a body pushing off something. */
+  transform-origin: 50% 88%;
 }
 
 /* POSE TO POSE, which is what keyframes are: these eight are the extremes and
@@ -405,6 +412,24 @@ html {
    two back and the lean survives on the outline while the stretch quietly stops
    pointing anywhere.
 
+   AND IT BENDS, which no amount of rotation could do on its own. Rotating a
+   stretched body leans it as one rigid shape — the middle travels as far as the
+   head, which reads as the whole creature tipping rather than as the head
+   leading. `skewX` about the foot pivot displaces the top WITHOUT moving the
+   base, so the head arcs over ahead of the body: the tallest point is furthest
+   along, the feet are still where they pushed off, and the silhouette curves
+   between them. The sign is negative for a rightward hop because CSS y grows
+   downward, so a negative skew is the one that throws the TOP forward.
+
+   It peaks at the apex and reverses at the crouch and the landing, where the
+   body is compressing rather than reaching — a bend held flat through those
+   would read as a permanent deformity instead of as a stretch.
+
+   Written BEFORE scale on purpose: transforms apply right to left, so this
+   order stretches the body vertically first and then bends the stretched
+   shape. The other way round it bends a round body and then stretches the bend
+   out of it.
+
    Kept small on purpose — a few degrees and a couple of percent. At ~20px a
    lean big enough to notice as a lean is big enough to look like a wobble. */
 @keyframes sw-monster-hop {
@@ -416,32 +441,32 @@ html {
      shifting a hair AGAINST the direction of travel — you rock back before you
      go. */
   14% {
-    transform: translate(calc(var(--sw-hop-dir, 1) * -1%), 8%) rotate(calc(var(--sw-hop-dir, 1) * -1deg)) scale(1.22, 0.78);
+    transform: translate(calc(var(--sw-hop-dir, 1) * -1%), 8%) rotate(calc(var(--sw-hop-dir, 1) * -1deg)) skewX(calc(var(--sw-hop-dir, 1) * 1.5deg)) scale(1.22, 0.78);
   }
   /* The push-off — already stretching before it leaves the ground, and tipping
      into the direction of travel. */
   26% {
-    transform: translate(calc(var(--sw-hop-dir, 1) * 2%), -22%) rotate(calc(var(--sw-hop-dir, 1) * 4deg)) scale(0.84, 1.22);
+    transform: translate(calc(var(--sw-hop-dir, 1) * 2%), -22%) rotate(calc(var(--sw-hop-dir, 1) * 4deg)) skewX(calc(var(--sw-hop-dir, 1) * -4deg)) scale(0.84, 1.22);
   }
   /* Top of the arc: fully stretched, highest lift, lean at its greatest.
      The lift is a share of the creature's OWN height, so it clears its own body
      and a bit more — enough that the jump reads as a jump at 15px rather than
      as a bounce, without throwing it out of the rail. */
   46% {
-    transform: translate(calc(var(--sw-hop-dir, 1) * 3%), -64%) rotate(calc(var(--sw-hop-dir, 1) * 6deg)) scale(0.82, 1.24);
+    transform: translate(calc(var(--sw-hop-dir, 1) * 3%), -64%) rotate(calc(var(--sw-hop-dir, 1) * 6deg)) skewX(calc(var(--sw-hop-dir, 1) * -7deg)) scale(0.82, 1.24);
   }
   /* Falling, gathering, and rotating back THROUGH level — the counter-rotation
      is what makes the landing read as absorbed rather than dropped. */
   66% {
-    transform: translate(calc(var(--sw-hop-dir, 1) * 1%), -20%) rotate(calc(var(--sw-hop-dir, 1) * -2deg)) scale(0.92, 1.1);
+    transform: translate(calc(var(--sw-hop-dir, 1) * 1%), -20%) rotate(calc(var(--sw-hop-dir, 1) * -2deg)) skewX(calc(var(--sw-hop-dir, 1) * -3deg)) scale(0.92, 1.1);
   }
   /* Landing: the squash absorbs it, the tip flattens out. */
   80% {
-    transform: translate(0, 4%) rotate(calc(var(--sw-hop-dir, 1) * -1deg)) scale(1.2, 0.8);
+    transform: translate(0, 4%) rotate(calc(var(--sw-hop-dir, 1) * -1deg)) skewX(calc(var(--sw-hop-dir, 1) * 2deg)) scale(1.2, 0.8);
   }
   /* FOLLOW-THROUGH: a small rebound past the resting pose... */
   91% {
-    transform: translate(0, -3%) rotate(0deg) scale(0.95, 1.06);
+    transform: translate(0, -3%) rotate(0deg) skewX(calc(var(--sw-hop-dir, 1) * 0.5deg)) scale(0.95, 1.06);
   }
   /* ...and settle. */
   100% {
@@ -514,6 +539,19 @@ html {
    Signed the opposite way to the body's lean on purpose: the body leans INTO
    the jump, the hat leans away from it. Loose things trail; that difference
    between the two is the whole read. */
+/* THE BEND, held for the flight.
+   `skewX` in the hop leans the whole body as one straight shape, which gets the
+   head out in front but leaves the middle travelling just as far. This is the
+   part that curves: the crown of the head swings over the base while the body's
+   own outline stays put beneath it, so the silhouette bends from about the
+   midpoint up and the feet keep their place. Baked rather than keyframed for
+   the usual reason — geometry cannot change inside a snapshot, only be captured
+   in it. */
+[data-storyboard-monster][data-aiming] [data-monster-crown] {
+  transform: translateX(calc(var(--sw-hop-dir, 1) * 5%))
+    rotate(calc(var(--sw-hop-dir, 1) * 7deg));
+}
+
 [data-storyboard-monster][data-aiming] [data-monster-hat] {
   transform: translateY(-0.012em) rotate(calc(var(--sw-hop-dir, 1) * -3deg));
 }
@@ -537,6 +575,10 @@ html {
    creature paying attention), the feet lag 110ms (they carried the mass), and
    the hat — the only part not attached to anything — is still moving after both
    have stopped. Finishing them together would read as one twitch. */
+[data-storyboard-monster][data-settling] [data-monster-crown] {
+  animation: sw-crown-unbend 380ms cubic-bezier(0.3, 0.75, 0.3, 1) both;
+}
+
 [data-storyboard-monster][data-settling] [data-monster-hat] {
   animation: sw-hat-settle 640ms cubic-bezier(0.3, 0.7, 0.28, 1) 40ms both;
 }
@@ -594,6 +636,24 @@ html {
   78%,
   100% {
     translate: 0 0;
+  }
+}
+
+/* The head straightens once it lands. Quick — it is a stretch coming out of a
+   body, not a part with mass of its own — and it goes slightly PAST straight
+   before settling, which is the same follow-through the hat and the eye get.
+   Starts from the flight pose exactly, so the handover shows no seam. */
+@keyframes sw-crown-unbend {
+  0% {
+    transform: translateX(calc(var(--sw-hop-dir, 1) * 5%))
+      rotate(calc(var(--sw-hop-dir, 1) * 7deg));
+  }
+  55% {
+    transform: translateX(calc(var(--sw-hop-dir, 1) * -1%))
+      rotate(calc(var(--sw-hop-dir, 1) * -1.5deg));
+  }
+  100% {
+    transform: translateX(0) rotate(0deg);
   }
 }
 
@@ -742,8 +802,13 @@ html {
 @media (prefers-reduced-motion: reduce) {
   [data-storyboard-monster][data-settling] [data-monster-pupil],
   [data-storyboard-monster][data-settling] [data-monster-foot],
+  [data-storyboard-monster][data-settling] [data-monster-crown],
   [data-storyboard-monster][data-settling] [data-monster-hat] {
     animation: none;
+  }
+
+  [data-storyboard-monster][data-aiming] [data-monster-crown] {
+    transform: none;
   }
 
   /* Rest for both is no transform: the pupil has none of its own, and the hat's

--- a/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.tsx
+++ b/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.tsx
@@ -305,6 +305,39 @@ export function StoryboardMonsterMark({
           background: SAGE,
         }}
       >
+        {/* THE CROWN OF THE HEAD, and the only way this drawing can BEND.
+            Every transform is affine, so no amount of rotating or skewing turns
+            an ellipse into a banana — it maps ellipses to ellipses. A curve
+            needs geometry, and a view transition freezes the geometry, so it
+            has to be here rather than in a keyframe.
+
+            This is a second ellipse in the SAME sage, sitting entirely inside
+            the body at rest and therefore invisible. Lean it over the body's
+            base and the union of the two is a curve: it juts out on the leading
+            side above the midpoint while the body's own outline still shows
+            below and behind, which is exactly the shape of a head arcing over
+            feet that have not moved.
+
+            Narrower than the body on purpose. Same width would put its widest
+            point outside the body's own edge at that height — the body is
+            0.98 x 1.12, so at this ellipse's centre the body has only about
+            0.92 of width to give — and the crown would show as a bulge at rest
+            rather than hiding. */}
+        <span
+          data-monster-crown=""
+          style={{
+            position: "absolute",
+            left: `${(BODY_W - 0.9) / 2}em`,
+            top: 0,
+            width: "0.9em",
+            height: "0.74em",
+            borderRadius: "999px",
+            background: SAGE,
+            // Pivots where it meets the body it grows out of, so leaning it
+            // swings the top and leaves the join alone.
+            transformOrigin: "50% 100%",
+          }}
+        />
         {/* eye white */}
         <span
           style={{


### PR DESCRIPTION
Two changes to the rail toggle's jump, both about where the motion is anchored.

**The pivot moves to the feet.** `::view-transition-*(sw-monster)` now sets `transform-origin: 50% 88%`. A jump turns about the ground, not about the creature's waist: at the default centre the landing squash lifts the feet as much as it drops the head, and the lean slides the whole body sideways. Both read as a sticker being manipulated rather than as a body pushing off something.

**And the body bends**, which needed two mechanisms because one was not enough.

`skewX` in the hop displaces the top without moving the base, so the head arcs out ahead while the feet stay where they pushed off. It peaks at the apex and reverses at the crouch and the landing, where the body is compressing rather than reaching — held flat through those it would read as a deformity instead of a stretch. Written before `scale`, so it bends a body that is already stretched rather than stretching the bend back out.

But skew is affine, and no affine map turns an ellipse into anything but another ellipse — it leans as one rigid shape, with the middle travelling as far as the head. The curve needs geometry, and a view transition freezes geometry, so it is a **pose**: a second sage ellipse inside the head, invisible at rest, leaning over the body's base while the body's own outline still shows beneath and behind it. The union of the two curves from about the midpoint up. It straightens on landing with the same follow-through the hat and the eye get.

The crown is narrower than the body on purpose: at equal width its widest point would sit outside the body's edge at that height and show as a bulge at rest rather than hiding.

Gate: tsc, lint (0 errors), app 1308, unit 783, storybook 261 — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)