### PR TITLE
The body leans on its own, with no second body behind it

### DIFF
--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -499,10 +499,18 @@ html {
    stretched body leans it as one rigid shape — the middle travels as far as the
    head, which reads as the whole creature tipping rather than as the head
    leading. `skewX` about the foot pivot displaces the top WITHOUT moving the
-   base, so the head arcs over ahead of the body: the tallest point is furthest
-   along, the feet are still where they pushed off, and the silhouette curves
-   between them. The sign is negative for a rightward hop because CSS y grows
-   downward, so a negative skew is the one that throws the TOP forward.
+   base, so the head gets out ahead of the body: the tallest point is furthest
+   along and the feet are still where they pushed off. The sign is negative for
+   a rightward hop because CSS y grows downward, so a negative skew is the one
+   that throws the TOP forward.
+
+   IT LEANS, IT DOES NOT CURVE, and that is now the whole of it. A skew is
+   affine — every straight line stays straight and every ellipse stays an
+   ellipse — so the silhouette between the feet and the head is a slant, not an
+   arc. A second sage ellipse used to be leaned over the base to fake the curve;
+   it broke the outline instead (see the note where it was, in
+   `storyboard-monster-mark.tsx`), and a straight lean from one honest shape
+   turned out to read better than a bend made of two.
 
    It peaks at the apex and reverses at the crouch and the landing, where the
    body is compressing rather than reaching — a bend held flat through those
@@ -738,19 +746,6 @@ html {
    Signed the opposite way to the body's lean on purpose: the body leans INTO
    the jump, the hat leans away from it. Loose things trail; that difference
    between the two is the whole read. */
-/* THE BEND, held for the flight.
-   `skewX` in the hop leans the whole body as one straight shape, which gets the
-   head out in front but leaves the middle travelling just as far. This is the
-   part that curves: the crown of the head swings over the base while the body's
-   own outline stays put beneath it, so the silhouette bends from about the
-   midpoint up and the feet keep their place. Baked rather than keyframed for
-   the usual reason — geometry cannot change inside a snapshot, only be captured
-   in it. */
-[data-storyboard-monster][data-aiming] [data-monster-crown] {
-  transform: translateX(calc(var(--sw-hop-dir, 1) * 5%))
-    rotate(calc(var(--sw-hop-dir, 1) * 7deg));
-}
-
 [data-storyboard-monster][data-aiming] [data-monster-hat] {
   transform: translateY(-0.012em) rotate(calc(var(--sw-hop-dir, 1) * -1.4deg));
 }
@@ -851,10 +846,6 @@ html {
    creature paying attention), the feet lag 110ms (they carried the mass), and
    the hat — the only part not attached to anything — is still moving after both
    have stopped. Finishing them together would read as one twitch. */
-[data-storyboard-monster][data-settling] [data-monster-crown] {
-  animation: sw-crown-unbend 380ms cubic-bezier(0.3, 0.75, 0.3, 1) both;
-}
-
 [data-storyboard-monster][data-settling] [data-monster-hat] {
   animation: sw-hat-settle 640ms cubic-bezier(0.3, 0.7, 0.28, 1) 40ms both;
 }
@@ -912,24 +903,6 @@ html {
   78%,
   100% {
     translate: 0 0;
-  }
-}
-
-/* The head straightens once it lands. Quick — it is a stretch coming out of a
-   body, not a part with mass of its own — and it goes slightly PAST straight
-   before settling, which is the same follow-through the hat and the eye get.
-   Starts from the flight pose exactly, so the handover shows no seam. */
-@keyframes sw-crown-unbend {
-  0% {
-    transform: translateX(calc(var(--sw-hop-dir, 1) * 5%))
-      rotate(calc(var(--sw-hop-dir, 1) * 7deg));
-  }
-  55% {
-    transform: translateX(calc(var(--sw-hop-dir, 1) * -1%))
-      rotate(calc(var(--sw-hop-dir, 1) * -1.5deg));
-  }
-  100% {
-    transform: translateX(0) rotate(0deg);
   }
 }
 
@@ -1102,12 +1075,10 @@ html {
   [data-storyboard-monster][data-settling],
   [data-storyboard-monster][data-settling] [data-monster-pupil],
   [data-storyboard-monster][data-settling] [data-monster-foot],
-  [data-storyboard-monster][data-settling] [data-monster-crown],
   [data-storyboard-monster][data-settling] [data-monster-hat] {
     animation: none;
   }
 
-  [data-storyboard-monster][data-aiming] [data-monster-crown],
   [data-storyboard-monster][data-aiming] [data-monster-eye],
   [data-storyboard-monster][data-aiming] [data-monster-foot] {
     transform: none;

--- a/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.stories.tsx
+++ b/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.stories.tsx
@@ -251,9 +251,7 @@ export const WithoutTheHat: Story = {
     // body. Measured on the body itself rather than the mark, whose box also
     // contains the hat's overhang.
     const bodyOf = (mark: Element) =>
-      mark.querySelector("[data-monster-crown]")?.parentElement ??
-      mark.querySelector("[data-monster-eye]")?.parentElement ??
-      null;
+      mark.querySelector("[data-monster-eye]")?.parentElement ?? null;
     const hattedBody = bodyOf(hatted);
     const bareBody = bodyOf(bare);
     expect(hattedBody).toBeTruthy();

--- a/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.tsx
+++ b/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.tsx
@@ -369,39 +369,30 @@ export function StoryboardMonsterMark({
           background: SAGE,
         }}
       >
-        {/* THE CROWN OF THE HEAD, and the only way this drawing can BEND.
-            Every transform is affine, so no amount of rotating or skewing turns
-            an ellipse into a banana — it maps ellipses to ellipses. A curve
-            needs geometry, and a view transition freezes the geometry, so it
-            has to be here rather than in a keyframe.
+        {/* NO SECOND ELLIPSE HERE, and the empty space is the point.
 
-            This is a second ellipse in the SAME sage, sitting entirely inside
-            the body at rest and therefore invisible. Lean it over the body's
-            base and the union of the two is a curve: it juts out on the leading
-            side above the midpoint while the body's own outline still shows
-            below and behind, which is exactly the shape of a head arcing over
-            feet that have not moved.
+            There used to be one: a narrower sage ellipse hidden inside the body
+            that the flight pose leaned over the base, so the union of the two
+            read as a head arcing over feet that had not moved. It was the only
+            way this drawing could BEND -- every transform is affine, so no
+            amount of rotating or skewing turns an ellipse into a banana, and a
+            view transition freezes the geometry, so a curve could not be
+            keyframed either.
 
-            Narrower than the body on purpose. Same width would put its widest
-            point outside the body's own edge at that height — the body is
-            0.98 x 1.12, so at this ellipse's centre the body has only about
-            0.92 of width to give — and the crown would show as a bulge at rest
-            rather than hiding. */}
-        <span
-          data-monster-crown=""
-          style={{
-            position: "absolute",
-            left: `${(BODY_W - 0.9) / 2}em`,
-            top: 0,
-            width: "0.9em",
-            height: "0.74em",
-            borderRadius: "999px",
-            background: SAGE,
-            // Pivots where it meets the body it grows out of, so leaning it
-            // swings the top and leaves the join alone.
-            transformOrigin: "50% 100%",
-          }}
-        />
+            It did not survive being looked at. The body is 0.98 x 1.12 and the
+            ellipse was 0.9 wide, which leaves it about 0.01em of clearance at
+            its widest point -- so the moment the pose translated it 5% and
+            rotated it 7deg it broke the silhouette, measured at 0.049-0.092em
+            past the body's leading edge and up to 0.049em over the top, for
+            EVERY frame of the flight including the first. At rail size that is
+            a ~3px green lump beside the head, and it reads as a second body
+            showing through rather than as a bend.
+
+            So the lean is the body's own, carried by the `rotate` and `skewX`
+            already in `sw-monster-hop`. Straight rather than curved, and
+            honest: one shape, one outline. Anything that wants a real arc back
+            has to change the GEOMETRY -- a border-radius that differs per
+            corner, or a clip-path -- not stack a second copy behind it. */}
         {/* eye white — marked because the WHOLE eye turns before a jump, not
             just the pupil sliding inside a fixed one. See the departure pose in
             globals.css. */}


### PR DESCRIPTION
The green lump beside the monster's head during the jump was a second sage
ellipse — `data-monster-crown` — hidden inside the body and leaned over the
base by the flight pose, there to fake a bend the body itself cannot do
(every transform is affine, and a view transition freezes the geometry).

Measured across every frame of the flight, it protruded past the body's own
silhouette by **0.049–0.092em on the leading side** and up to **0.049em over
the top**, starting at frame 0. At rail size that is a ~3px lump, and it reads
as a second body showing through rather than as a bend.

Removed: the element, the aim pose, `sw-crown-unbend`, and the two
reduced-motion selectors. The lean is now the body's own, carried by the
`rotate` and `skewX` already in `sw-monster-hop`.

The comment where the ellipse stood records what it cost and what a real arc
would actually need — geometry (per-corner radii or a clip-path), not a second
copy behind the first. The `skewX` note in `globals.css` was claiming the
silhouette "curves"; corrected, since a skew leans and does not curve.

## Checks

- `npm run lint` — clean (6 pre-existing `no-img-element` warnings)
- `npx tsc --noEmit` in `packages/ui` — clean
- `npx vitest run --project=storybook storyboard-monster-mark.stories.tsx` — 5/5 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)