### PR TITLE
Turn 54's antennae, on a chain that actually bends

### DIFF
--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -1135,10 +1135,15 @@ html {
    `--sw-antenna-bend` is the whip, and it is read by the six chain segments
    (see the `@property` note above). It carries the entire sway: bent back
    through the flight, whipping through rest to the far side as the head stops,
-   rocking back smaller, one short second beat, still. The four beats keep the
-   ratios that were tuned twice by eye on the hat this replaced; the size is
-   about seven times larger, because the part changed. A felt hat swinging
-   several degrees looks silly, and an antenna that does NOT is a wire.
+   rocking back smaller, one short second beat, still.
+
+   THE TAIL HALVES EACH TIME — 7, 3.5, 1.75 — which is what tempering the jam
+   bought besides a quieter landing. The hat's ratios this inherited decayed
+   0.5 from the jam and then only 0.5 again from a peak that was itself too
+   loud, so pulling the peak down without pulling the tail down with it left a
+   shallow 0.81 step that rang rather than settled. One constant ratio through
+   the whole decay is both simpler to reason about and the shape a damped
+   spring actually has.
 
    `translateY` is NOT part of the sway. It exists only to keep the pair rooted
    in a head that is squashing underneath them, and every value is derived from
@@ -1166,20 +1171,27 @@ html {
      over ON contact rather than 176ms after it, this beat is the impact itself
      and has to land close to it: 12% of 640ms is 77ms after touchdown, which
      reads as the same event. At 20% it was 128ms later and read as a separate
-     one. */
+     one.
+
+     AND SMALLER THAN THE POSE IT REACTS TO. At 11.4deg this was the single
+     loudest moment in the animation — the knob moved 3.43px against the flight
+     pose's 3.03px, and covered 6.46px of round trip inside 77ms, which read as
+     a snap rather than a landing. A reaction that overshoots its cause is the
+     tell. At 7deg it is 2.16px, comfortably under the flight, and the landing
+     reads as the antennae catching up rather than as a separate event. */
   12% {
-    --sw-antenna-bend: calc(var(--sw-hop-dir, 1) * 11.4deg);
+    --sw-antenna-bend: calc(var(--sw-hop-dir, 1) * 7deg);
     transform: translateY(0.098em);
   }
   /* The rebound: the stalks give it back and the knobs rock the way they came.
      Smaller than the jam, because energy leaves the system. */
   38% {
-    --sw-antenna-bend: calc(var(--sw-hop-dir, 1) * -5.7deg);
+    --sw-antenna-bend: calc(var(--sw-hop-dir, 1) * -3.5deg);
     transform: translateY(-0.049em);
   }
   /* A second, much shorter beat — one is a bump, two is a spring. */
   64% {
-    --sw-antenna-bend: calc(var(--sw-hop-dir, 1) * 2.9deg);
+    --sw-antenna-bend: calc(var(--sw-hop-dir, 1) * 1.75deg);
     transform: translateY(0.0196em);
   }
   84% {

--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -554,45 +554,43 @@ html {
    Kept small on purpose — a few degrees and a couple of percent. At ~20px a
    lean big enough to notice as a lean is big enough to look like a wobble. */
 @keyframes sw-monster-hop {
-  /* Standing. */
+  /* IT ENDS ON CONTACT, and that is a timing decision rather than a trim.
+
+     This animation used to run through the landing: 80% was the squash, 91% the
+     rebound, 100% standing. All three were BAKED, because the flight is a
+     view-transition snapshot and a snapshot cannot deform. Worse, they cost
+     176ms — the feet touched down at 80% of 680ms and the live element did not
+     take over until 680, so the body's real squash and the antennae's whip both
+     began long after the impact they were reacting to. It read as land, pause,
+     sway.
+
+     So the flight is cut at the moment of contact and hands over there, with the
+     same 680ms and the same apex: every stop below is the old one divided by
+     0.8, which stretches what used to be the airborne 80% across the whole
+     animation. The impact and the rebound now belong to `sw-body-settle` and
+     `sw-antennae-settle`, which run on live elements and can actually deform.
+
+     THE LAST POSE MUST BE NEUTRAL SCALE, because the settle's own 0% is
+     `scale(1, 1)` and any difference between them is a pop at the handover. The
+     yaw is the exception and is carried over deliberately — `sw-monster-untwist`
+     picks it up from exactly this value. */
   0% {
     transform: translate(0, 0) rotate(0deg) scale(1, 1);
   }
-  /* ANTICIPATION: the crouch. Wider and shorter, sinking slightly, and already
-     shifting a hair AGAINST the direction of travel — you rock back before you
-     go. */
-  14% {
+  17% {
     transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * -1%), 8%) rotateY(calc(var(--sw-hop-dir, 1) * -3deg)) rotate(calc(var(--sw-hop-dir, 1) * -1deg)) skewX(calc(var(--sw-hop-dir, 1) * 1.5deg)) scale(1.22, 0.78);
   }
-  /* The push-off — already stretching before it leaves the ground, and tipping
-     into the direction of travel. */
-  26% {
+  32% {
     transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2%), -22%) rotateY(calc(var(--sw-hop-dir, 1) * 9deg)) rotate(calc(var(--sw-hop-dir, 1) * 4deg)) skewX(calc(var(--sw-hop-dir, 1) * -4deg)) scale(0.84, 1.22);
   }
-  /* Top of the arc: fully stretched, highest lift, lean at its greatest.
-     The lift is a share of the creature's OWN height, so it clears its own body
-     and a bit more — enough that the jump reads as a jump at 15px rather than
-     as a bounce, without throwing it out of the rail. */
-  46% {
+  58% {
     transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 3%), -64%) rotateY(calc(var(--sw-hop-dir, 1) * 16deg)) rotate(calc(var(--sw-hop-dir, 1) * 6deg)) skewX(calc(var(--sw-hop-dir, 1) * -7deg)) scale(0.82, 1.24);
   }
-  /* Falling, gathering, and rotating back THROUGH level — the counter-rotation
-     is what makes the landing read as absorbed rather than dropped. */
-  66% {
+  82% {
     transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1%), -20%) rotateY(calc(var(--sw-hop-dir, 1) * 14deg)) rotate(calc(var(--sw-hop-dir, 1) * -2deg)) skewX(calc(var(--sw-hop-dir, 1) * -3deg)) scale(0.92, 1.1);
   }
-  /* Landing: the squash absorbs it, the tip flattens out. */
-  80% {
-    transform: perspective(140px) translate(0, 4%) rotateY(calc(var(--sw-hop-dir, 1) * 12deg)) rotate(calc(var(--sw-hop-dir, 1) * -1deg)) skewX(calc(var(--sw-hop-dir, 1) * 2deg)) scale(1.2, 0.8);
-  }
-  /* FOLLOW-THROUGH: a small rebound past the resting pose... */
-  91% {
-    transform: perspective(140px) translate(0, -3%) rotateY(calc(var(--sw-hop-dir, 1) * 11deg)) rotate(0deg) skewX(calc(var(--sw-hop-dir, 1) * 0.5deg)) scale(0.95, 1.06);
-  }
-  /* ...and settle. */
-  /* STILL TURNED. The hop ends mid-twist on purpose — squaring up is a beat of
-     its own, and it belongs after the landing rather than inside it. The live
-     element picks up from exactly this angle; see `sw-monster-untwist`. */
+  /* CONTACT. Standing on its feet, still yawed, not yet deformed — the next
+     frame is a live element and the squash starts there. */
   100% {
     transform: perspective(140px) translate(0, 0)
       rotateY(calc(var(--sw-hop-dir, 1) * 10deg)) rotate(0deg) scale(1, 1);
@@ -736,18 +734,49 @@ html {
   transform: translateY(-5%);
 }
 
-/* THE HAT FLIES TRAILING, for the same reason and by the same mechanism.
-   DRAG: a hat is not attached to the head, it rests on it, so when the head
-   leaves the ground the hat is still where the head used to be — lifted a hair
-   clear of the fur and rotated BACK against the direction of travel. It is the
-   one pose that says "this creature jumped" rather than "this creature was
-   moved".
+/* THE BEND HAS TO BE DECLARED BEFORE IT CAN BE ANIMATED.
 
-   Signed the opposite way to the body's lean on purpose: the body leans INTO
-   the jump, the hat leans away from it. Loose things trail; that difference
-   between the two is the whole read. */
-[data-storyboard-monster][data-aiming] [data-monster-hat] {
-  transform: translateY(-0.012em) rotate(calc(var(--sw-hop-dir, 1) * -1.4deg));
+   A plain custom property is a token to CSS, so it would JUMP from one keyframe
+   value to the next instead of interpolating. Registering it as an `<angle>`
+   makes the browser tween it like any other animatable value, which is what
+   turns the four beats below into a continuous whip. */
+@property --sw-antenna-bend {
+  syntax: "<angle>";
+  inherits: true;
+  initial-value: 0deg;
+}
+
+/* THE ANTENNAE FLY BENT BACK, for the same reason the pupil flies thrown.
+   DRAG: they are attached to the head but not stiff, so when the head leaves
+   the ground the knobs are still where the head used to be. It is the one pose
+   that says "this creature jumped" rather than "this creature was moved".
+
+   AN ARC, NOT A LEAN, and getting there took three tries worth recording. A
+   rotation swings the pair rigidly, which is what a hat brim does. A skew
+   shears it, which moves the tops further than the roots but leaves every edge
+   straight — both are affine, and an affine map takes a straight bar to a
+   straight bar. Neither is a bend. What bends is the CHAIN each stalk is built
+   from: three segments, each a child of the one below and each turned by this
+   same angle, so the turns compound (b, 2b, 3b) and the chords approximate an
+   arc. See `SEG_BEND` in `storyboard-monster-mark.tsx`.
+
+   ONE DECLARATION MOVES ALL SIX SEGMENTS, because they read it by inheritance
+   rather than being selected individually. That is also why it is set here on
+   the group and not on the segments: an inline `transform` beats any rule, and
+   every segment needs one to read this property at all.
+
+   MEASURED. Ten degrees a segment is thirty at the tip, and on the collapsed
+   21.9px mark that carries a knob 3.03px back from rest. The hat's inherited
+   1.4deg, which this replaces, moved it 0.34px.
+
+   NO CEILING ANY MORE, which is the third reason to prefer the chain. Both
+   earlier versions turned the whole GROUP, so each stalk's root travelled with
+   it and the root is buried only 0.05em in the head — past about 16deg the
+   stalk tore out of the skull. A segment turns about its own bottom edge, so
+   the root is a FIXED POINT of the bend and no angle can detach it. If a louder
+   version is ever wanted, it is safe to just raise this number. */
+[data-storyboard-monster][data-aiming] [data-monster-antennae] {
+  --sw-antenna-bend: calc(var(--sw-hop-dir, 1) * -10deg);
 }
 
 [data-storyboard-monster][data-settling] [data-monster-pupil] {
@@ -839,15 +868,48 @@ html {
      four pixels tall and read as the foot flailing rather than as weight. The
      handover between snapshots now puts it flat before the ground arrives, so
      all that is left to do here is take the impact. */
-  animation: sw-foot-settle 460ms cubic-bezier(0.22, 1, 0.36, 1) 110ms both;
+  animation: sw-foot-settle 460ms cubic-bezier(0.22, 1, 0.36, 1) 40ms both;
 }
 
 /* LAST TO SETTLE, which is the timing point. The eye reacts at once (it is the
-   creature paying attention), the feet lag 110ms (they carried the mass), and
+   creature paying attention), the feet lag 40ms (they carried the mass), and
    the hat — the only part not attached to anything — is still moving after both
    have stopped. Finishing them together would read as one twitch. */
-[data-storyboard-monster][data-settling] [data-monster-hat] {
-  animation: sw-hat-settle 640ms cubic-bezier(0.3, 0.7, 0.28, 1) 40ms both;
+/* THE WEIGHT LANDS ON THE BODY, not on everything equally.
+
+   Through the flight the whole creature is ONE BITMAP — a view-transition
+   snapshot — so `sw-monster-hop`'s squash and stretch necessarily applies to
+   the body, the antennae and the feet in exactly the same proportion. There is
+   no "inside" of a snapshot to weight differently, and a static counter-pose
+   cannot cancel a scale that changes over time. That ratio is fixed for those
+   680ms, and the only way to change it is to give the antennae their own
+   `view-transition-name` so they are snapshotted separately.
+
+   The SETTLE is a live element, and it is two thirds of the animation. Here the
+   parts ARE separable, and this is where the difference in weight is spent: the
+   body takes a real landing squash — a tenth wider and a tenth shorter at the
+   bottom of it — while the antennae above it only sway. A jump lands on the
+   mass, and the mass is the green part.
+
+   IT REACHES THE EYE AND NOTHING ELSE, which is a fact about the markup rather
+   than about this rule. The eye and its pupil are CHILDREN of the body, so they
+   squash with the head the way an eye in a squashing head should; the antennae
+   and the feet are siblings, so they are untouched. Splitting them any other
+   way would have needed a wrapper. */
+[data-storyboard-monster][data-settling] [data-monster-body],
+/* THE FUR RIDES THE SAME ANIMATION, and must. It is a sibling of the body, not
+   a child, and its masked ring clears the body's silhouette by 0.0021em — a
+   twentieth of a pixel at rail size. Squash the body without it and the head's
+   top edge drops out from under the ring: 2.10px of bare starburst above the
+   skull at the bottom of the squash. Same keyframes, same origin point
+   (expressed as 50%/85.5% of its own larger box), so the margin holds at every
+   frame instead of only at rest. */
+[data-storyboard-monster][data-settling] [data-monster-fur] {
+  animation: sw-body-settle 640ms cubic-bezier(0.3, 0.7, 0.28, 1) both;
+}
+
+[data-storyboard-monster][data-settling] [data-monster-antennae] {
+  animation: sw-antennae-settle 640ms cubic-bezier(0.3, 0.7, 0.28, 1) both;
 }
 
 /* ── The eye, horizontally: a SACCADE ────────────────────────────────────────
@@ -1010,64 +1072,124 @@ html {
   }
 }
 
-/* The hat takes the landing and gives it back.
-   OVERLAPPING ACTION and FOLLOW-THROUGH, and nothing else — the principles that
-   apply to a loose garment, not the whole twelve. It is drawn about 10px wide,
-   so squash and stretch is unavailable (a felt hat barely deforms, and one
-   pixel of it is a flicker, not a squash); arcs are not a separate dial here
-   because the pivot IS the arc, down at the brim where the hat meets the fur.
-   What is left is drag, weight, and the time it takes to stop.
+/* The body's landing, and the reason the antennae keyframes carry a
+   `translateY` they would otherwise have no use for.
 
-   These are DELTAS from rest — the fixed -14deg cock lives on an inner element,
-   so 0 here means "sitting normally".
+   Scaled about `50% 100%` — its own bottom edge, the line it shares with the
+   feet — so a squash presses the head DOWN onto its feet instead of sinking the
+   whole creature into the floor. Width and height are signed opposite at every
+   stop: volume is roughly conserved, which is the difference between a squash
+   and a shrink.
 
-   DELIBERATELY UNDER-PLAYED, and the two channels are dialled SEPARATELY
-   because they fail differently.
-
-   ROTATION is what reads as a hat: the crown's top sits about an em above the
-   pivot, so even a degree or two swings it visibly and the shape of the event —
-   trail, jam, rebound — survives at 8px. That leverage is also why it needed
-   cutting TWICE. Six tenths of the first pass still swung the crown tip about
-   1.3px at the collapsed mark, which at that size is a wobble rather than a
-   settle; it is now under half that. The hat should look like it is finding its
-   place again, not like it is loose.
-
-   VERTICAL is what reads as VIBRATION. A hat bobbing straight up and down has
-   no silhouette change to sell it, so the eye registers the motion without
-   reading a cause, and two bounces of it look like a rendering glitch rather
-   than like weight. It is cut to about a third again — the whole excursion is
-   now near ±0.2px in the rail, which is felt more than seen. That also puts the
-   flight lift (0.012em) well inside the brim's ~0.03em overhang on the body, so
-   the hat keeps its purchase on the fur instead of appearing to hover. */
-@keyframes sw-hat-settle {
-  /* Where the flight left it: lifted clear, trailing behind the direction of
-     travel. Identical to the aim pose, so the handover from image to element
-     shows no seam. */
+   SAME DURATION AND EASING AS `sw-antennae-settle`, AND NEITHER IS DELAYED. The
+   antennae have to stay rooted in a head whose top edge is moving, and the only
+   cheap way to guarantee that is to give both animations one clock and put the
+   correction at the same percentages. Each antenna keyframe's `translateY` is
+   exactly -0.98 * (sy - 1) em, the negative of how far this rule moves the
+   body's top: at 20% the head squashes to 0.90 and its top drops 0.098em, so
+   the antennae drop 0.098em with it. Change an `sy` here and the matching
+   `translateY` there has to change with it or the stalks tear out of the skull
+   — the root is buried only 0.05em (1.09px at rail size), which is less than a
+   single one of these stops moves it. */
+@keyframes sw-body-settle {
+  /* The flight ends at scale(1, 1), so this starts there and the handover from
+     image to element shows no seam. */
   0% {
-    transform: translateY(-0.012em) rotate(calc(var(--sw-hop-dir, 1) * -1.4deg));
+    transform: scale(1, 1);
   }
-  /* THE JAM. The head stops and the hat does not, so it drives DOWN onto the
-     fur, past where it rests, and its own momentum carries it forward — the
-     rotation crosses through rest to the far side, which is the opposite of
-     where it spent the whole flight. */
-  20% {
-    transform: translateY(0.015em) rotate(calc(var(--sw-hop-dir, 1) * 1.6deg));
+  /* THE IMPACT. Widest and shortest — the mass arrives and the head spreads
+     over the feet. */
+  12% {
+    transform: scale(1.1, 0.9);
   }
-  /* The rebound: the fur gives it back, and the hat lifts and rocks back the
-     way it came. Smaller than the jam, because energy leaves the system. */
-  46% {
-    transform: translateY(-0.007em) rotate(calc(var(--sw-hop-dir, 1) * -0.8deg));
+  /* The recoil: taller than rest and narrower, which is what a squashed thing
+     does on the way back. Smaller than the impact, because energy leaves the
+     system. */
+  38% {
+    transform: scale(0.96, 1.05);
   }
-  /* A second, much shorter bounce — one is a bump, two is a hat. */
-  70% {
-    transform: translateY(0.004em) rotate(calc(var(--sw-hop-dir, 1) * 0.4deg));
+  /* A second, much shorter beat — one is a bump, two is a body. */
+  64% {
+    transform: scale(1.02, 0.98);
   }
-  88% {
-    transform: translateY(-0.002em) rotate(0deg);
+  84% {
+    transform: scale(0.995, 1.005);
   }
-  /* Seated. */
+  /* Standing. */
   100% {
-    transform: translateY(0) rotate(0deg);
+    transform: scale(1, 1);
+  }
+}
+
+/* The antennae take the landing and give it back.
+   OVERLAPPING ACTION and FOLLOW-THROUGH, and nothing else — the principles that
+   apply to something light on the end of a springy stem, not the whole twelve.
+   A knob is drawn about 3.5px across, so squash and stretch is unavailable (one
+   pixel of it is a flicker, not a squash); arcs are not a separate dial here
+   because the whole animation IS an arc. What is left is drag, weight, and the
+   time it takes to stop.
+
+   TWO CHANNELS ON TWO DIFFERENT ELEMENTS, which is the thing to understand
+   before editing this.
+
+   `--sw-antenna-bend` is the whip, and it is read by the six chain segments
+   (see the `@property` note above). It carries the entire sway: bent back
+   through the flight, whipping through rest to the far side as the head stops,
+   rocking back smaller, one short second beat, still. The four beats keep the
+   ratios that were tuned twice by eye on the hat this replaced; the size is
+   about seven times larger, because the part changed. A felt hat swinging
+   several degrees looks silly, and an antenna that does NOT is a wire.
+
+   `translateY` is NOT part of the sway. It exists only to keep the pair rooted
+   in a head that is squashing underneath them, and every value is derived from
+   `sw-body-settle` rather than chosen: it is exactly -0.98 * (sy - 1) em, the
+   negative of how far that animation moves the body's top edge. At 20% the head
+   squashes to 0.90 and its top drops 0.098em, so the antennae drop 0.098em with
+   it. Change an `sy` there and the matching number here has to change or the
+   stalks tear out of the skull — the root is buried only 0.05em (1.09px at rail
+   size), which is less than a single one of these stops moves it. The two
+   animations share a duration, a delay and an easing for the same reason. */
+@keyframes sw-antennae-settle {
+  /* Where the flight left it: bent back behind the direction of travel.
+     Identical to the aim pose, so the handover from image to element shows no
+     seam. */
+  0% {
+    --sw-antenna-bend: calc(var(--sw-hop-dir, 1) * -10deg);
+    transform: translateY(0);
+  }
+  /* THE JAM. The head stops and the knobs do not, so they whip through to the
+     far side — the bend crosses rest and ends up opposite to where it spent the
+     whole flight. This is also the deepest point of the body's squash, hence
+     the largest tracking offset.
+
+     AT 12%, NOT 20%, and the flight's own trim is why. Now that the hop hands
+     over ON contact rather than 176ms after it, this beat is the impact itself
+     and has to land close to it: 12% of 640ms is 77ms after touchdown, which
+     reads as the same event. At 20% it was 128ms later and read as a separate
+     one. */
+  12% {
+    --sw-antenna-bend: calc(var(--sw-hop-dir, 1) * 11.4deg);
+    transform: translateY(0.098em);
+  }
+  /* The rebound: the stalks give it back and the knobs rock the way they came.
+     Smaller than the jam, because energy leaves the system. */
+  38% {
+    --sw-antenna-bend: calc(var(--sw-hop-dir, 1) * -5.7deg);
+    transform: translateY(-0.049em);
+  }
+  /* A second, much shorter beat — one is a bump, two is a spring. */
+  64% {
+    --sw-antenna-bend: calc(var(--sw-hop-dir, 1) * 2.9deg);
+    transform: translateY(0.0196em);
+  }
+  84% {
+    --sw-antenna-bend: 0deg;
+    transform: translateY(-0.0049em);
+  }
+  /* Still. */
+  100% {
+    --sw-antenna-bend: 0deg;
+    transform: translateY(0);
   }
 }
 
@@ -1075,7 +1197,9 @@ html {
   [data-storyboard-monster][data-settling],
   [data-storyboard-monster][data-settling] [data-monster-pupil],
   [data-storyboard-monster][data-settling] [data-monster-foot],
-  [data-storyboard-monster][data-settling] [data-monster-hat] {
+  [data-storyboard-monster][data-settling] [data-monster-body],
+  [data-storyboard-monster][data-settling] [data-monster-fur],
+  [data-storyboard-monster][data-settling] [data-monster-antennae] {
     animation: none;
   }
 
@@ -1087,7 +1211,10 @@ html {
   /* Rest for both is no transform: the pupil has none of its own, and the hat's
      tilt lives on an inner element that this never touches. */
   [data-storyboard-monster][data-aiming] [data-monster-pupil],
-  [data-storyboard-monster][data-aiming] [data-monster-hat] {
+  [data-storyboard-monster][data-aiming] [data-monster-antennae] {
+    /* The bend is a property, not a transform, so `transform: none` would leave
+       the chain arced with nothing animating it. */
+    --sw-antenna-bend: 0deg;
     transform: none;
   }
 

--- a/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.stories.tsx
+++ b/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.stories.tsx
@@ -9,8 +9,8 @@ import {
 // The creature in the rail's wordmark.
 //
 // WHY THIS EXISTS AS A STORY. Every judgement this drawing has ever needed —
-// are the feet visible on the rail's black, is the band separate from the
-// crown, does the eye still read at 15px — is a judgement made by LOOKING, and
+// are the feet visible on the rail's black, is a knob separate from its stalk,
+// does the eye still read at 15px — is a judgement made by LOOKING, and
 // it was being made by hand-injecting clones into the running app each time.
 // The two sizes below are the two the sidebar actually renders, and the blown-up
 // one is where a colour or a geometry change is legible before it ships.
@@ -34,16 +34,44 @@ function Plate({
 }
 
 /**
- * Poses one rendered hat by writing straight to its style.
+ * Poses one rendered pair of antennae by writing straight to the group.
+ *
+ * TWO CHANNELS, because the animation has two. `--sw-antenna-bend` is the whip:
+ * it inherits down to the six chain segments, each of which turns by it, so the
+ * turns compound into an arc. The transform is only the tracking offset that
+ * keeps the pair rooted in a squashing head. Setting a `transform` alone — as
+ * an earlier version of this story did — poses nothing at all now, because the
+ * group stopped carrying the sway when the chain took it over.
  *
  * A callback ref rather than a prop, because the component deliberately does
- * not take one: the hat's transform belongs to the stylesheet, and adding a
- * prop so a story could set it would put a second owner on the same property.
+ * not take one: both of these belong to the stylesheet, and adding a prop so a
+ * story could set them would put a second owner on the same properties.
  */
-function hatPose(transform: string) {
+function antennaPose(bend: string, transform: string) {
   return (node: HTMLElement | null) => {
-    const hat = node?.querySelector<HTMLElement>("[data-monster-hat]");
-    if (hat) hat.style.transform = transform;
+    const pair = node?.querySelector<HTMLElement>("[data-monster-antennae]");
+    if (!pair) return;
+    pair.style.setProperty("--sw-antenna-bend", bend);
+    pair.style.transform = transform;
+  };
+}
+
+/**
+ * The same, for the body's landing squash — a different element and a different
+ * property, which is the entire point of the pair of them.
+ *
+ * IT POSES THE FUR TOO, because the shipped rule does: they are siblings, and
+ * the fur's masked ring clears the body's silhouette by 0.05px at rail size, so
+ * a squash the fur does not follow drops the head out from under it and bares
+ * the starburst. Posing only the body here reproduced exactly that bug inside
+ * the story, which is how this comment came to exist.
+ */
+function bodyPose(transform: string) {
+  return (node: HTMLElement | null) => {
+    for (const sel of ["[data-monster-body]", "[data-monster-fur]"]) {
+      const el = node?.querySelector<HTMLElement>(sel);
+      if (el) el.style.transform = transform;
+    }
   };
 }
 
@@ -91,8 +119,8 @@ export const RailSizes: Story = {
     expect(inWord.getBoundingClientRect().width).toBeLessThan(
       alone.getBoundingClientRect().width,
     );
-    // Both feet, both eyes' worth of parts, and the hat — the drawing is only
-    // ever wrong by a piece going missing.
+    // Both feet, both eyes' worth of parts, and the antennae — the drawing is
+    // only ever wrong by a piece going missing.
     // The two states differ by where the eye rests, and the difference is about
     // 1.6px — small enough that only a measurement can tell whether the prop is
     // still wired. In the word the pupil must be CENTRED, because the creature
@@ -110,11 +138,11 @@ export const RailSizes: Story = {
     expect(pupilOffset(alone)).toBeGreaterThan(0.5);
     expect(alone.querySelectorAll("[data-monster-foot]")).toHaveLength(2);
     expect(alone.querySelector("[data-monster-pupil]")).toBeTruthy();
-    expect(alone.querySelector("[data-monster-hat]")).toBeTruthy();
+    expect(alone.querySelector("[data-monster-antennae]")).toBeTruthy();
   },
 };
 
-/** Big enough to judge the hat's band against its crown, and the egg's stretch. */
+/** Big enough to judge a knob against its stalk, and the lean of the pair. */
 export const BlownUp: Story = {
   args: { scale: 1 },
   render: () => (
@@ -131,7 +159,7 @@ export const BlownUp: Story = {
  *
  * Not a duplicate of the sidebar's lockup — that one is a flex row of revealed
  * letters mid-animation. This is the static relationship the colours were
- * chosen for: band and letters sharing one token, creature standing on the line.
+ * chosen for: knobs and feet sharing one token, creature standing on the line.
  */
 export const InTheWordmark: Story = {
   args: { scale: 1.1 },
@@ -158,32 +186,51 @@ export const InTheWordmark: Story = {
 };
 
 /**
- * The hat's four poses across a jump, laid out side by side.
+ * The four poses of a jump, laid out side by side — and BOTH parts at once.
  *
- * The motion itself lives in `globals.css` (`sw-hat-settle`) and only runs
- * inside a real view transition, which a story cannot stage. What a story CAN
- * do is hold each pose still, which is the only way to see whether the jam
- * actually presses the brim into the head rather than detaching it — the one
- * failure a 640ms animation hides by being fast.
+ * The motion itself lives in `globals.css` (`sw-antennae-settle` and
+ * `sw-body-settle`) and only runs inside a real view transition, which a story
+ * cannot stage. What a story CAN do is hold each pose still, which is the only
+ * way to see the thing the two animations exist to say: the body takes the
+ * landing and the antennae above it only sway. Side by side is also the only
+ * way to catch the failure that matters — a stalk tearing out of a head that
+ * squashed out from under it. The root is buried 0.05em, and one keyframe of
+ * body squash moves the head's top further than that.
  *
  * The transforms are the keyframes' own values at `--sw-hop-dir: 1`. If they
  * drift from the stylesheet this story stops describing the animation, which is
  * the trade for being able to look at it at all.
  */
-export const HatPoses: Story = {
+export const JumpPoses: Story = {
   args: { scale: 1 },
   render: () => (
     <>
       {(
         [
-          ["rest", "none"],
-          ["in flight (drag)", "translateY(-0.035em) rotate(-3deg)"],
-          ["the jam", "translateY(0.042em) rotate(3.5deg)"],
-          ["rebound", "translateY(-0.02em) rotate(-1.8deg)"],
+          ["rest", "0deg", "none", "none"],
+          ["in flight (bent back)", "-10deg", "none", "scale(1, 1)"],
+          [
+            "the impact",
+            "11.4deg",
+            "translateY(0.098em)",
+            "scale(1.1, 0.9)",
+          ],
+          [
+            "rebound",
+            "-5.7deg",
+            "translateY(-0.049em)",
+            "scale(0.96, 1.05)",
+          ],
         ] as const
-      ).map(([label, transform]) => (
+      ).map(([label, bend, track, body]) => (
         <Plate key={label} label={label}>
-          <span className="text-[4em]" ref={hatPose(transform)}>
+          <span
+            className="text-[4em]"
+            ref={(node) => {
+              antennaPose(bend, track)(node);
+              bodyPose(body)(node);
+            }}
+          >
             <StoryboardMonsterMark scale={1} />
           </span>
         </Plate>
@@ -191,44 +238,101 @@ export const HatPoses: Story = {
     </>
   ),
   play: async ({ canvasElement }) => {
-    const hats = canvasElement.querySelectorAll("[data-monster-hat]");
-    expect(hats).toHaveLength(4);
-    const y = (n: Element) => n.getBoundingClientRect().top;
-    const [rest, flight, jam] = Array.from(hats) as [Element, Element, Element];
-    // The jam is BELOW rest and the flight pose is ABOVE it. Signs, not
-    // magnitudes: a keyframe edit that inverts the bounce is the regression
-    // worth catching, and it is invisible in a still screenshot.
-    expect(y(flight)).toBeLessThan(y(rest));
-    expect(y(jam)).toBeGreaterThan(y(rest));
+    const marks = canvasElement.querySelectorAll("[data-storyboard-monster]");
+    expect(marks).toHaveLength(4);
+    const [restMark, flightMark, jamMark] = Array.from(marks) as [
+      Element,
+      Element,
+      Element,
+    ];
+    const box = (n: Element) => n.getBoundingClientRect();
+    const part = (mark: Element, sel: string) => {
+      const n = mark.querySelector(sel);
+      expect(n).toBeTruthy();
+      return n!;
+    };
+
+    // THE IMPACT IS SHORTER AND WIDER THAN REST. Signs, not magnitudes: a
+    // keyframe edit that inverts the squash is the regression worth catching,
+    // and it is invisible in a still screenshot.
+    const restBody = box(part(restMark, "[data-monster-body]"));
+    const jamBody = box(part(jamMark, "[data-monster-body]"));
+    expect(jamBody.height).toBeLessThan(restBody.height);
+    expect(jamBody.width).toBeGreaterThan(restBody.width);
+
+    // THE FUR GOES WITH IT, ABOUT THE SAME POINT. It clears the body by 0.05px
+    // at rail size, so a fur that does not track the squash bares its starburst
+    // above the head. Measuring both tops against the body's BOTTOM — the shared
+    // scale origin — is what tests the origin rather than just the scale: the
+    // ratio is 1.18 / 0.98 = 1.204 at rest and is preserved by any scale about
+    // a correctly matched pair of origins, but not by a mismatched one.
+    const reach = (mark: Element) => {
+      const b = box(part(mark, "[data-monster-body]"));
+      const f = box(part(mark, "[data-monster-fur]"));
+      return (b.bottom - f.top) / (b.bottom - b.top);
+    };
+    expect(reach(restMark)).toBeCloseTo(1.204, 2);
+    expect(reach(jamMark)).toBeCloseTo(reach(restMark), 2);
+
+    // The knobs lead the arc, and the two poses throw them to OPPOSITE sides of
+    // rest — the flight bends back behind the jump, the impact whips past it.
+    // Measured against each mark's own left edge, since the plates differ in x.
+    const knobOffset = (mark: Element) => {
+      const k = box(part(mark, "[data-monster-knob]"));
+      return k.x + k.width / 2 - box(mark).left;
+    };
+    expect(knobOffset(flightMark)).toBeLessThan(knobOffset(restMark));
+    expect(knobOffset(jamMark)).toBeGreaterThan(knobOffset(restMark));
+
+    // AND IT IS AN ARC, NOT A LEAN — the whole point of the chain. Each segment
+    // turns by the same angle and they compound, so under a bend the top
+    // segment must be turned further from vertical than the bottom one. A
+    // single-bar stalk, or a chain that lost its nesting, fails here while
+    // still passing the offset check above.
+    const angleOf = (n: Element) => {
+      const m = new DOMMatrix(getComputedStyle(n).transform);
+      return Math.round(Math.atan2(m.b, m.a) * (180 / Math.PI));
+    };
+    const chain = part(flightMark, '[data-monster-antenna="left"]');
+    const seg1 = chain.firstElementChild!;
+    const seg2 = seg1.firstElementChild!;
+    const seg3 = seg2.firstElementChild!;
+    expect(angleOf(seg1)).toBe(-10);
+    expect(angleOf(seg2)).toBe(-10);
+    expect(angleOf(seg3)).toBe(-10);
+    // Each is -10 in its PARENT's frame, so the tip is -30 from the mark's.
+    const tipVsRoot =
+      knobOffset(restMark) - knobOffset(flightMark);
+    expect(tipVsRoot).toBeGreaterThan(0);
   },
 };
 
 /**
- * Hatted and bare, side by side, at the size the rail actually renders.
+ * With and without the antennae, side by side, at the size the rail renders.
  *
- * The prop is free to use — every rule that animates the hat keys off
- * `[data-monster-hat]`, so with nothing rendered they match nothing.
+ * The prop is free to use — every rule that animates them keys off
+ * `[data-monster-antennae]`, so with nothing rendered they match nothing.
  *
- * It also RESHAPES THE HEAD, which is the part worth looking at here. The egg
- * (1.12 tall against a 0.98 width) exists for one reason: headroom between the
- * eye and the brim. With no brim to clear it buys nothing and just reads tall,
- * so the bare creature goes back to the source's own round body. Side by side
- * is the only way to check that the round one still looks like the same
- * character.
+ * AND IT NO LONGER RESHAPES THE HEAD, which is the part worth looking at here
+ * and the part that changed with turn 54. The hat's version of this prop also
+ * swapped an egg body (1.12 tall against a 0.98 width) for a round one, because
+ * the egg existed to open headroom under a BRIM. Antennae leave the skull from
+ * a point and need no clearance, so the body is the source's circle either way
+ * and the only difference between these two is whether two stalks are drawn.
  */
-export const WithoutTheHat: Story = {
+export const WithoutTheAntennae: Story = {
   args: { scale: 1.6 },
   render: () => (
     <>
-      <Plate label="with the hat">
+      <Plate label="with antennae">
         <StoryboardMonsterMark scale={1.6} />
       </Plate>
-      <Plate label="hat={false}">
-        <StoryboardMonsterMark scale={1.6} hat={false} />
+      <Plate label="antennae={false}">
+        <StoryboardMonsterMark scale={1.6} antennae={false} />
       </Plate>
       <Plate label="bare, blown up">
         <span className="text-[4em]">
-          <StoryboardMonsterMark scale={1} hat={false} />
+          <StoryboardMonsterMark scale={1} antennae={false} />
         </span>
       </Plate>
     </>
@@ -238,31 +342,27 @@ export const WithoutTheHat: Story = {
       canvasElement.querySelectorAll("[data-storyboard-monster]"),
     );
     expect(marks).toHaveLength(3);
-    const [hatted, bare] = marks as [Element, Element];
-    expect(hatted.querySelector("[data-monster-hat]")).toBeTruthy();
-    expect(bare.querySelector("[data-monster-hat]")).toBeNull();
-    // The parts all survive — the hat is its own layer, so dropping it must not
-    // cost the creature anything else.
-    expect(bare.querySelectorAll("[data-monster-foot]")).toHaveLength(2);
-    expect(bare.querySelector("[data-monster-eye]")).toBeTruthy();
+    const [withPair, without] = marks as [Element, Element];
+    expect(withPair.querySelector("[data-monster-antennae]")).toBeTruthy();
+    expect(without.querySelector("[data-monster-antennae]")).toBeNull();
+    // The parts all survive — the antennae are their own layer, so dropping
+    // them must not cost the creature anything else.
+    expect(without.querySelectorAll("[data-monster-foot]")).toHaveLength(2);
+    expect(without.querySelector("[data-monster-eye]")).toBeTruthy();
 
-    // But the HEAD is shorter, and that is the point of this story. The egg
-    // exists to clear the brim; with no brim it goes back to the source's round
-    // body. Measured on the body itself rather than the mark, whose box also
-    // contains the hat's overhang.
-    const bodyOf = (mark: Element) =>
-      mark.querySelector("[data-monster-eye]")?.parentElement ?? null;
-    const hattedBody = bodyOf(hatted);
-    const bareBody = bodyOf(bare);
-    expect(hattedBody).toBeTruthy();
-    expect(bareBody).toBeTruthy();
-    const hattedH = hattedBody!.getBoundingClientRect().height;
-    const bareH = bareBody!.getBoundingClientRect().height;
-    expect(bareH).toBeLessThan(hattedH);
-    // 0.98 against 1.12 — about an eighth shorter, and the width is untouched.
-    expect(bareH / hattedH).toBeCloseTo(0.98 / 1.12, 2);
-    expect(bareBody!.getBoundingClientRect().width).toBeCloseTo(
-      hattedBody!.getBoundingClientRect().width,
+    // AND THE HEAD IS THE SAME HEAD, which is the assertion this story exists
+    // for now. The hat used to change the body's height by an eighth; the
+    // antennae change nothing about it, so both boxes must match on BOTH axes.
+    const a = withPair.querySelector("[data-monster-body]");
+    const b = without.querySelector("[data-monster-body]");
+    expect(a).toBeTruthy();
+    expect(b).toBeTruthy();
+    expect(b!.getBoundingClientRect().height).toBeCloseTo(
+      a!.getBoundingClientRect().height,
+      1,
+    );
+    expect(b!.getBoundingClientRect().width).toBeCloseTo(
+      a!.getBoundingClientRect().width,
       1,
     );
   },

--- a/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.stories.tsx
+++ b/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.stories.tsx
@@ -211,13 +211,13 @@ export const JumpPoses: Story = {
           ["in flight (bent back)", "-10deg", "none", "scale(1, 1)"],
           [
             "the impact",
-            "11.4deg",
+            "7deg",
             "translateY(0.098em)",
             "scale(1.1, 0.9)",
           ],
           [
             "rebound",
-            "-5.7deg",
+            "-3.5deg",
             "translateY(-0.049em)",
             "scale(0.96, 1.05)",
           ],

--- a/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.tsx
+++ b/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.tsx
@@ -1,30 +1,42 @@
 /**
  * The storyboard monster — the creature that sits in the "o" of "monster".
  *
- * Ported from the logo design document's TURN 34 ("28c hat, denim feet"), its
- * latest direction: the same one-eyed fuzzball, now in a pinched-crown hat and
- * standing on denim-blue feet. It is drawn in CSS rather than SVG, exactly as
- * the source is: a masked `repeating-conic-gradient` makes the fur spikes, the
- * eye is four nested circles, and the hat is three boxes — a clip-path crown, a
- * pill brim and a band — inside one rotated group.
+ * Ported from the logo design document's TURN 54, variant 48a ("antenna pair"),
+ * its latest direction: the same one-eyed fuzzball, now with two stalks and
+ * round knobs where the pinched-crown hat used to be. It is drawn in CSS rather
+ * than SVG, exactly as the source is: a masked `repeating-conic-gradient` makes
+ * the fur spikes and the eye is four nested circles. The antennae are the one
+ * place this file departs from the source's construction — 48a draws each as a
+ * single leaning bar, and a single bar cannot bend, so each is rebuilt as a
+ * chain of three that arcs. It resolves to the same drawing at rest; see
+ * `SEG_BEND`.
  *
- * THE GEOMETRY IS THE SOURCE'S, VERBATIM. Turn 34 re-expresses the drawing
- * against a 1em box where earlier turns used 0.72em; every inner number is the
- * old one times 1/0.72, so the creature itself did not change size, only the
- * unit it is quoted in. Keeping the source's numbers rather than re-deriving
- * them is what lets the next turn be diffed against this file.
+ * THE GEOMETRY IS THE SOURCE'S, VERBATIM. 48a re-expresses the drawing against
+ * a 1em box where earlier turns used 0.72em; every inner number is the old one
+ * times 1/0.72, so the creature itself did not change size, only the unit it is
+ * quoted in. Keeping the source's numbers rather than re-deriving them is what
+ * lets the next turn be diffed against this file.
  *
  * WHICH IS WHY `scale` IS FOLDED INTO THE FONT-SIZE AT 0.72. `scale` keeps
  * meaning what it has always meant to the callers — 1.1 in the word, 1.6 alone
- * in the rail — and the 0.72 converts that expectation into turn 34's basis.
+ * in the rail — and the 0.72 converts that expectation into the source's basis.
  * Drop it and every call site silently grows by 39%.
  *
- * COLOURS: the file gives two as literals and the rest as design-system tokens
+ * THE HEAD IS ROUND AGAIN, and that is the largest thing this turn changed
+ * besides the antennae. The body was stretched into an egg (1.12 against a
+ * width of 0.98) for exactly one reason: headroom between the eye and the hat's
+ * BRIM. Antennae have no brim — they leave the top of the head from a point, so
+ * they need no clearance at all — and the stretch with nothing left to buy just
+ * reads as a tall head. So the body, the fur that tracks it and the eye centred
+ * in it all go back to the source's own circle, and `bodyTopFor`, `BODY_LIFT`
+ * and the hatted/bare pair of heights go with them.
+ *
+ * COLOURS: the file gives one as a literal and the rest as design-system tokens
  * it does not ship — `_ds/organic-…/styles.css` is not in the export, and the
  * document renders black-on-black without it, so there are no frames to sample
- * either. The sage and the feet below are therefore the source's own values;
- * the cream, the pupil and the hat are matched to those tokens' roles in the
- * ramp and are the three worth checking against the real palette.
+ * either. The sage below is the source's own value; the cream, the pupil, the
+ * antennae and the feet are matched to those tokens' roles in the ramp, and the
+ * last two are the ones worth checking against the real palette.
  */
 
 /** The source's literal, unchanged since turn 9: fur and body. */
@@ -38,93 +50,75 @@ const PUPIL = "oklch(0.27 0.03 145)";
  *
  * TAILWIND'S `blue-400`, RESOLVED, and deliberately not the source's colour.
  * The design document paints the word in `--color-accent-300`, the same pale
- * terracotta as the hat band. That reads beautifully in the document and makes
- * the wordmark a stranger in this app: the projects list already labels itself
- * `text-blue-400`, so that blue is what the product calls a heading, and the
- * rail's wordmark was the last place still speaking the logo's private dialect.
+ * terracotta as the antenna knobs. That reads beautifully in the document and
+ * makes the wordmark a stranger in this app: the projects list already labels
+ * itself `text-blue-400`, so that blue is what the product calls a heading, and
+ * the rail's wordmark was the last place still speaking the logo's private
+ * dialect.
  *
  * Written as the resolved value rather than the class because it is consumed as
  * an inline `color` on a span inside the lockup, not as a utility. If the app's
  * blue ever moves this has to move with it by hand — the PAIRING is the point,
  * not the number.
  *
- * The hat keeps its own terracotta (`HAT_BAND` below). One token in the source,
- * two here on purpose: the hat belongs to the creature, the word belongs to the
- * product.
+ * The antennae keep their own terracotta (`ANTENNA_KNOB` below). One token in
+ * the source, two here on purpose: the antennae belong to the creature, the
+ * word belongs to the product.
  */
 export const STORYBOARD_MONSTER_ACCENT = "oklch(0.707 0.165 254.624)";
 /**
- * The crown and the brim.
+ * The stalks.
  *
- * STANDS OFF THE SOURCE'S RAMP ON PURPOSE. The document paints both from
- * `--color-accent` with `--color-accent-300` as the band — a darker hat wearing
- * a lighter stripe, which is right on its own pale ground. On the rail's
- * near-black it is not: a 0.62-lightness crown sits closer to the rail than to
- * the 0.86 sage body directly beneath it, so the hat reads as a shadow ON the
- * creature rather than as something the creature is wearing. Collapsed, where
- * the whole mark is 22px and the crown about 8, it half-disappeared.
+ * STANDS OFF THE SOURCE'S RAMP ON PURPOSE, and the reasoning the hat needed is
+ * MORE pressing here, not less. The document paints the stalks from
+ * `--color-accent` with `--color-accent-300` as the knob — a darker stem under
+ * a lighter head, which is right on its own pale ground. On the rail's
+ * near-black it is not: a 0.62-lightness stalk sits closer to the rail than to
+ * anything it is attached to, and a stalk is 0.055em WIDE. On the collapsed
+ * mark that is about 1.2px, which is a single antialiased column of pixels —
+ * the thinnest thing in the whole drawing, and the first to disappear.
  *
  * So the pair is lifted TOGETHER and the contrast between them is what is
- * preserved, not the absolute values: crown to 0.70 with the chroma pushed to
- * hold its identity against the sage, band to 0.89 so it stays the lighter
- * stripe the source drew. Raising only the crown would have closed the gap to
- * the band and flattened the hat into one shape, which is the failure the old
- * comment here was guarding against from the other direction.
- *
- * The wordmark no longer follows the hat at all — see
- * `STORYBOARD_MONSTER_ACCENT`. It is the product's blue now, on the same black
- * but at 19px with letterforms, which is a different legibility problem from an
- * 8px crown and was already solved.
+ * preserved, not the absolute values: stalk to 0.70 with the chroma pushed to
+ * hold its identity against the near-black, knob to 0.89 so it stays the
+ * lighter head the source drew. Raising only the stalk would have closed the
+ * gap to the knob and flattened each antenna into one shape.
  */
-const HAT = "oklch(0.70 0.18 45)";
-/** The band. Lighter than the crown by more than the source needed — see above.
- *  Still terracotta, so the hat stays one object rather than two stacked ones. */
-const HAT_BAND = "oklch(0.89 0.08 48)";
+const ANTENNA_STALK = "oklch(0.70 0.18 45)";
+/** The knobs. Lighter than the stalks by more than the source needed — see
+ *  above. Still terracotta, so each antenna stays one object and not two. */
+const ANTENNA_KNOB = "oklch(0.89 0.08 48)";
 /**
- * The source's literal denim (turn 32, kept by turn 34).
+ * The feet: the SAME terracotta as the antenna knobs, which is the source's own
+ * scheme restored.
  *
- * Arrived at by elimination, and the reasoning is worth keeping because it
- * applies to anything drawn under the body: terracotta is the same value as the
- * word the creature stands in, so the feet read as part of the letters; cream is
- * the brightest thing in the rail, so the feet end up louder than the eye they
- * belong to; and anything near-black vanishes outright — the feet sit BELOW the
- * body, against the rail rather than against the sage, so there is nothing
- * behind them to separate from. They are also about 4px tall here, and a small
- * shape needs MORE contrast than a large one, not less.
+ * They were denim for a long time, and the argument for it had quietly expired
+ * before this turn removed it — worth recording so nobody re-derives the dead
+ * version. Denim was chosen when terracotta was also the WORD's colour, so
+ * terracotta feet read as part of the letters rather than as part of the
+ * creature. The word went blue (see `STORYBOARD_MONSTER_ACCENT`), and with it
+ * the only thing that clash was ever about.
+ *
+ * What the source's scheme buys instead is a BOOKEND: the same pale terracotta
+ * at the top of the creature and at the bottom of it, with the sage body
+ * between, so the drawing reads as one object with two ends rather than as
+ * three unrelated bands. It also means the two smallest shapes in the mark —
+ * a 3.5px knob and a 4px foot — carry the same value, so they hold or fail
+ * together instead of one of them going first.
+ *
+ * The rest of the old reasoning still applies as written, and is why this is
+ * the LIGHT terracotta and not the stalks' darker one: cream would make the
+ * feet the brightest thing in the rail, anything near-black vanishes outright
+ * because the feet sit BELOW the body against the rail rather than against the
+ * sage, and at about 4px tall a small shape needs MORE contrast than a large
+ * one, not less.
  */
-const FEET = "oklch(0.68 0.115 245)";
+const FEET = ANTENNA_KNOB;
 
-/**
- * THE BODY IS AN EGG, not the source's circle.
- *
- * Turn 34 draws it round at 0.98em square. Stretched a seventh taller and
- * anchored at the bottom — the feet have to stay where they stand — it gains
- * headroom between the eye and the brim, which is the difference between a
- * creature wearing a hat and a creature with a hat resting on its eyeball.
- *
- * Everything that has to follow the shape derives from these three numbers: the
- * fur collar, the eye's vertical centring, and the lift the hat needs so it
- * still sits on the head rather than sinking into it.
- */
-const BODY_W = 0.98;
-/**
- * TALLER ONLY WHEN THERE IS A BRIM TO CLEAR.
- *
- * 1.12 is the egg, and it exists for one reason: to open headroom between the
- * eye and the hat's brim. Take the hat off and that reason goes with it —
- * headroom over nothing reads as a tall head — so the bare creature goes back
- * to the source's own 0.98, which is turn 34's drawing exactly.
- *
- * Everything shaped by it follows: the fur collar, the eye's vertical centring,
- * and where the body's bottom sits. The hat's own lift is derived from the same
- * pair and is simply unused when there is no hat.
- */
-const BODY_H_HATTED = 1.12;
-const BODY_H_BARE = BODY_W;
-/** Bottom edge pinned where the round body had it (0.99em), top pulled up. */
-const bodyTopFor = (bodyH: number) => 0.99 - bodyH;
-/** How much taller than the source, and so how far the hat rides up with it. */
-const BODY_LIFT = BODY_H_HATTED - BODY_W;
+/** The source's circle, restored — see the head note in the header. */
+const BODY = 0.98;
+/** Bottom edge where it has always been (0.99em), so the feet keep their line. */
+const BODY_TOP = 0.99 - BODY;
 
 /**
  * WHERE THE CREATURE IS LOOKING WHEN NOTHING IS HAPPENING.
@@ -198,24 +192,29 @@ const BODY_LIFT = BODY_H_HATTED - BODY_W;
  * the source rather than papering over locally — the element is kept so that a
  * later turn changing the ratios brings the fur back on its own.
  */
-
 const FUR_MASK =
   "radial-gradient(circle at 50% 50%, transparent 0 35%, #000 35% 50%, transparent 50%)";
 
-const furFor = (bodyH: number): React.CSSProperties => ({
+const FUR: React.CSSProperties = {
   position: "absolute",
-  // Held a uniform 0.2em outside the body on every side, tracking the egg the
-  // way the source held it around the circle. Nothing shows today (above), but
-  // a box that has drifted out of register with the body is a worse starting
-  // point for whoever picks the fur back up.
+  // A uniform 0.2em outside the body on every side, the way the source holds it
+  // around the circle. Nothing shows today (above), but a box that has drifted
+  // out of register with the body is a worse starting point for whoever picks
+  // the fur back up.
   left: "-0.19em",
-  top: `${bodyTopFor(bodyH) - 0.2}em`,
-  width: `${BODY_W + 0.4}em`,
-  height: `${bodyH + 0.4}em`,
+  top: `${BODY_TOP - 0.2}em`,
+  width: `${BODY + 0.4}em`,
+  height: `${BODY + 0.4}em`,
   background: `repeating-conic-gradient(from 0deg, ${SAGE} 0deg 11deg, transparent 11deg 22deg)`,
   WebkitMaskImage: FUR_MASK,
   maskImage: FUR_MASK,
-});
+  // THE BODY'S SCALE ORIGIN, EXPRESSED IN THIS BOX. The body scales about its
+  // own bottom edge, at (0.5em, 0.99em) in the mark; this box runs from -0.19em
+  // for 1.38em, so the same point is 50% across and (0.99 + 0.19) / 1.38 =
+  // 85.5% down. Sharing the origin is what lets `sw-body-settle` drive both
+  // and keep them registered — see the marker note below.
+  transformOrigin: "50% 85.5%",
+};
 
 /** Marked so the settle can move the feet after the body has stopped — see
  *  `sw-foot-settle` in globals.css. The marker also carries WHICH foot: the two
@@ -232,49 +231,157 @@ const foot = (left: string): React.CSSProperties => ({
 });
 
 /**
- * The hat, as TWO nested groups — and the split is load-bearing.
+ * The pair, as ONE group — and the group being transform-free is load-bearing.
  *
- * The outer one holds no transform of its own. That is what lets `globals.css`
- * own the hat's motion: an inline `transform` beats any stylesheet rule, so a
- * hat whose resting tilt lives on the animated element cannot be animated from
- * CSS at all. The outer group therefore expresses DELTAS from rest — the lag,
- * the jam-down, the bounce — and rest is simply no transform.
+ * It holds no transform of its own. That is what lets `globals.css` own the
+ * antennae's motion: an inline `transform` beats any stylesheet rule, so a pair
+ * whose resting pose lived on the animated element could not be animated from
+ * CSS at all. The group therefore expresses DELTAS from rest, and rest is
+ * simply no transform.
  *
- * The inner one carries turn 34's fixed -14deg cock. Keeping the tilt on the
- * group rather than on each piece is turn 28's point: crown, brim and band stay
- * registered to each other however far it leans.
+ * IT CARRIES ONLY ONE THING NOW, and that is worth knowing before adding to it.
+ * The bend lives on the segments (see `SEG_BEND`), so the whole pair's swing
+ * and shear are gone from here; what is left is a `translateY` that tracks the
+ * body's landing squash, so the antennae ride a head whose top edge is moving.
+ * The two are derived from each other in `globals.css` and have to stay that
+ * way.
  *
- * BOTH pivot about the same low origin, down at the brim line where the hat
- * touches the head, so it swings where it actually rests instead of about its
- * own middle. That one number is why the brim stays on the fur through a lean
- * that would otherwise lift it clear.
+ * The origin is where the antennae attach — each stalk's root is 0.06em from
+ * the mark's top — so anything that IS added here turns about the right point
+ * rather than about the group's middle.
  */
-const HAT_GROUP: React.CSSProperties = {
-  position: "absolute",
-  left: 0,
-  width: "1em",
-  height: "1em",
-  // Raised by exactly what the body grew, so the brim keeps the same purchase
-  // on the fur that turn 34 drew it with.
-  top: `${-BODY_LIFT}em`,
-  transformOrigin: "50% 72%",
-};
-
-/** Turn 34's fixed cock, held off the animated element — see above. */
-const HAT_TILT: React.CSSProperties = {
+const ANTENNA_GROUP: React.CSSProperties = {
   position: "absolute",
   left: 0,
   top: 0,
   width: "1em",
   height: "1em",
-  transform: "rotate(-14deg)",
-  transformOrigin: "50% 72%",
+  transformOrigin: "50% 6%",
 };
+
+/**
+ * EACH STALK IS A CHAIN OF THREE, and that is what lets it ARC.
+ *
+ * A stalk drawn as one bar can lean and it can shear, but it cannot bend: both
+ * are affine, and an affine map takes a straight edge to a straight edge. What
+ * actually bends is a chain — three short segments, each a child of the one
+ * below it and each rotated by the SAME angle, so the rotations compound down
+ * the chain (b, 2b, 3b) and the three chords approximate an arc. Ten degrees a
+ * segment is thirty at the tip, which on the collapsed mark carries the knob
+ * 3.0px back from where it rests.
+ *
+ * THE ROOT IS A FIXED POINT OF IT, which is the second reason to prefer this
+ * over the shear it replaces. The first segment turns about its own bottom
+ * edge, so no amount of bend moves where the antenna enters the head — the
+ * root-lift ceiling that a rotating group has (see `sw-antennae-settle`) simply
+ * does not exist here. The knob rides the last segment and therefore ROTATES
+ * rather than shearing, so it stays a circle at every angle; the old skew
+ * ovalised it by a pixel at full lean.
+ *
+ * THE BEND ARRIVES AS A CUSTOM PROPERTY, `--sw-antenna-bend`, for the same
+ * reason the gaze does: an inline `transform` beats any stylesheet rule, and
+ * every one of these segments needs an inline transform to read the property at
+ * all. So the component owns the expression and `globals.css` owns the VALUE,
+ * set on an ancestor and inherited down. One declaration there bends all six
+ * segments at once.
+ */
+const SEG_BEND = "rotate(var(--sw-antenna-bend, 0deg))";
+
+/**
+ * Where each antenna leaves the head, and how long its chain is.
+ *
+ * DERIVED FROM THE SOURCE'S OWN NUMBERS rather than replacing them. 48a draws
+ * each stalk as a bar at a fixed lean and then FLOATS the knob near its tip,
+ * by eye and not quite symmetrically — the left knob sits 0.0875em outboard of
+ * its root and the right one 0.1025em, over the same 0.40em rise. Rebuilding
+ * the stalk as a chain means the knob has to ride it, so the chain's angle and
+ * length are solved from where the source put that knob: 12.34deg over 0.4095em
+ * on the left, 14.37deg over 0.4129em on the right. At rest this lands both
+ * knobs within 0.0015em of the source's own positions, asymmetry included.
+ *
+ * The chain is LONGER than the source's 0.32em bar because it runs to the knob's
+ * CENTRE rather than to its edge. The extra 0.09em is covered by the knob, which
+ * is painted after it, so the visible stalk is the source's length exactly.
+ */
+const ANTENNA = {
+  left: { x: 0.3275, splay: -12.34, seg: 0.1365 },
+  right: { x: 0.6775, splay: 14.37, seg: 0.1376 },
+} as const;
+
+/** The anchor each chain grows out of: a zero-size point at the root, carrying
+ *  the fixed splay. The splay is inline because nothing animates it — the bend
+ *  and the pair's tracking are separate channels on separate elements. */
+const antennaRoot = (side: keyof typeof ANTENNA): React.CSSProperties => ({
+  position: "absolute",
+  left: `${ANTENNA[side].x}em`,
+  top: "0.06em",
+  width: 0,
+  height: 0,
+  transform: `rotate(${ANTENNA[side].splay}deg)`,
+  transformOrigin: "0 0",
+});
+
+/** The first segment: bottom edge on the root point, centred across it. */
+const segRoot = (side: keyof typeof ANTENNA): React.CSSProperties => ({
+  position: "absolute",
+  left: "-0.0275em",
+  bottom: 0,
+  width: "0.055em",
+  height: `${ANTENNA[side].seg}em`,
+  background: ANTENNA_STALK,
+  borderRadius: "999px",
+  transform: SEG_BEND,
+  transformOrigin: "50% 100%",
+});
+
+/** Every segment after the first: same bar, standing on the one below. */
+const segNext = (side: keyof typeof ANTENNA): React.CSSProperties => ({
+  position: "absolute",
+  left: 0,
+  bottom: "100%",
+  width: "100%",
+  height: `${ANTENNA[side].seg}em`,
+  background: ANTENNA_STALK,
+  borderRadius: "999px",
+  transform: SEG_BEND,
+  transformOrigin: "50% 100%",
+});
+
+/** The knob, centred on the chain's tip: `bottom: 100%` puts its bottom edge
+ *  there and the negative margin pulls it down by its own radius. It inherits
+ *  the last segment's rotation, so it turns with the arc and stays circular. */
+const KNOB: React.CSSProperties = {
+  position: "absolute",
+  left: "50%",
+  bottom: "100%",
+  width: "0.16em",
+  height: "0.16em",
+  marginLeft: "-0.08em",
+  marginBottom: "-0.08em",
+  borderRadius: "999px",
+  background: ANTENNA_KNOB,
+};
+
+/** One antenna: the root anchor, three segments nested so their bends compound,
+ *  and the knob riding the last one. */
+function Antenna({ side }: Readonly<{ side: keyof typeof ANTENNA }>) {
+  return (
+    <span data-monster-antenna={side} style={antennaRoot(side)}>
+      <span style={segRoot(side)}>
+        <span style={segNext(side)}>
+          <span style={segNext(side)}>
+            <span data-monster-knob="" style={KNOB} />
+          </span>
+        </span>
+      </span>
+    </span>
+  );
+}
 
 export function StoryboardMonsterMark({
   scale = 1,
   gaze = "ahead",
-  hat = true,
+  antennae = true,
 }: Readonly<{
   scale?: number;
   /** Where the pupil rests. `"ahead"` is the source's centred eye, which is what
@@ -282,27 +389,24 @@ export function StoryboardMonsterMark({
    *  belongs to the collapsed rail. See the GAZE_X note above. */
   gaze?: "ahead" | "breadcrumb";
   /**
-   * Whether the creature wears its hat. Turn 34's direction, so `true` by
+   * Whether the creature has its antennae. Turn 54's direction, so `true` by
    * default.
    *
-   * Removing it is genuinely free: the hat is its own absolutely-positioned
-   * layer above the body, and every rule that animates it in `globals.css` —
-   * the flight pose, `sw-hat-settle`, the reduced-motion guard — keys off
-   * `[data-monster-hat]`, so with nothing rendered they match nothing and do
-   * nothing. No orphaned animation, no layout shift.
+   * Removing them is genuinely free, and freer than removing the hat was. The
+   * antennae are their own absolutely-positioned layer above the body, and
+   * every rule that animates them in `globals.css` — the flight pose,
+   * `sw-antennae-settle`, the reduced-motion guard — keys off
+   * `[data-monster-antennae]`, so with nothing rendered they match nothing and
+   * do nothing. No orphaned animation, no layout shift.
    *
-   * IT ALSO RESHAPES THE HEAD, which the first version of this prop deliberately
-   * did not. The body was stretched into an egg (1.12 against a source width of
-   * 0.98) for exactly one reason — headroom between the eye and the brim — so
-   * with no brim to clear, the stretch has nothing to buy and the creature just
-   * reads tall. Bare, it goes back to the source's own 0.98. See
-   * `BODY_H_HATTED`, and the `WithoutTheHat` story for the two side by side.
+   * AND IT NO LONGER RESHAPES THE HEAD, which the hat's version of this prop
+   * did. The egg existed to clear a brim; antennae leave the skull from a point
+   * and need no clearance, so the body is the source's circle either way and
+   * bare-versus-not is now purely a question of whether two stalks are drawn.
+   * See the `WithoutTheAntennae` story for the two side by side.
    */
-  hat?: boolean;
+  antennae?: boolean;
 }>) {
-  // The egg is the hat's, not the creature's — see BODY_H_HATTED.
-  const bodyH = hat ? BODY_H_HATTED : BODY_H_BARE;
-
   // THE GAZE TRAVELS AS A CUSTOM PROPERTY, which is the one channel a stylesheet
   // can still take back. Written as an inline `left` it worked everywhere and
   // could be overridden nowhere — inline beats any rule — so the pre-jump look
@@ -321,7 +425,7 @@ export function StoryboardMonsterMark({
       data-monster-gaze={gaze}
       // The growth between rail states. Everything about the creature is sized
       // off its own font-size, so animating that one property scales the whole
-      // drawing — fur, eye, glint, hat and feet together.
+      // drawing — fur, eye, glint, antennae and feet together.
       className="transition-[font-size] duration-200 motion-reduce:transition-none"
       style={{
         // Read by the pupil's `left`, and re-declared by the flight pose — see
@@ -337,7 +441,7 @@ export function StoryboardMonsterMark({
         lineHeight: 1,
         // The creature's own box drives its parts, so one number scales the
         // whole drawing without touching the geometry below. See the 0.72 note
-        // in the header: it converts `scale` into turn 34's 1em basis.
+        // in the header: it converts `scale` into the source's 1em basis.
         fontSize: `${scale * 0.72}em`,
         // NAMED FOR THE VIEW TRANSITION. Collapsing the rail does not move this
         // element, it re-lays it out — inline in the word, then alone and
@@ -357,16 +461,37 @@ export function StoryboardMonsterMark({
         top: `${0.14 * scale}em`,
       }}
     >
-      <span style={furFor(bodyH)} />
+      {/* MARKED SO IT CAN FOLLOW THE BODY'S SQUASH, which is not decoration.
+          The masked ring lands 0.4879em out against a body radius of 0.4900em,
+          so it clears the silhouette by 0.0021em — 0.05px at rail size. It is a
+          SIBLING of the body, so when `sw-body-settle` squashed the head and
+          the fur did not follow, the head's top dropped out from under it and
+          the ring showed: 2.10px of bare starburst above the skull at the
+          bottom of the squash, which is exactly the artifact that put this
+          marker here. Both elements now run the same animation about the same
+          point, so the 0.05px margin holds at every frame instead of only at
+          rest. */}
+      <span data-monster-fur="" style={FUR} />
+      {/* MARKED SO THE BODY CAN SQUASH WITHOUT THE ANTENNAE SQUASHING WITH IT.
+          The antenna group is a SIBLING of this element, not a child, so a
+          scale here reaches the eye and the glint inside the head and nothing
+          above it. That separation is the whole reason the landing can be
+          heavy on the body and light on the stalks — see `sw-body-settle` in
+          globals.css, and the tracking note beside it for how the antennae
+          stay rooted while this moves under them. */}
       <span
+        data-monster-body=""
         style={{
           position: "absolute",
           left: "0.01em",
-          top: `${bodyTopFor(bodyH)}em`,
-          width: `${BODY_W}em`,
-          height: `${bodyH}em`,
+          top: `${BODY_TOP}em`,
+          width: `${BODY}em`,
+          height: `${BODY}em`,
           borderRadius: "999px",
           background: SAGE,
+          // Stands on its own feet: a squash presses the head DOWN onto the
+          // line it shares with them rather than sinking the whole creature.
+          transformOrigin: "50% 100%",
         }}
       >
         {/* NO SECOND ELLIPSE HERE, and the empty space is the point.
@@ -379,14 +504,14 @@ export function StoryboardMonsterMark({
             view transition freezes the geometry, so a curve could not be
             keyframed either.
 
-            It did not survive being looked at. The body is 0.98 x 1.12 and the
-            ellipse was 0.9 wide, which leaves it about 0.01em of clearance at
-            its widest point -- so the moment the pose translated it 5% and
-            rotated it 7deg it broke the silhouette, measured at 0.049-0.092em
-            past the body's leading edge and up to 0.049em over the top, for
-            EVERY frame of the flight including the first. At rail size that is
-            a ~3px green lump beside the head, and it reads as a second body
-            showing through rather than as a bend.
+            It did not survive being looked at. The body is 0.98 wide and the
+            ellipse was 0.9, which leaves it about 0.01em of clearance at its
+            widest point -- so the moment the pose translated it 5% and rotated
+            it 7deg it broke the silhouette, measured at 0.049-0.092em past the
+            body's leading edge and up to 0.049em over the top, for EVERY frame
+            of the flight including the first. At rail size that is a ~3px green
+            lump beside the head, and it reads as a second body showing through
+            rather than as a bend.
 
             So the lean is the body's own, carried by the `rotate` and `skewX`
             already in `sw-monster-hop`. Straight rather than curved, and
@@ -401,10 +526,9 @@ export function StoryboardMonsterMark({
           style={{
             position: "absolute",
             left: "0.17em",
-            // CENTRED IN THE EGG, not held at the source's 0.17em. Keeping that
-            // number would have pinned the eye to the top of a taller head and
-            // spent the whole stretch below it, where nothing needed the room.
-            top: `${(bodyH - 0.64) / 2}em`,
+            // Centred in the body, which is the source's own 0.17em now that
+            // the head is round again.
+            top: `${(BODY - 0.64) / 2}em`,
             width: "0.64em",
             height: "0.64em",
             borderRadius: "999px",
@@ -450,50 +574,10 @@ export function StoryboardMonsterMark({
       </span>
       <span data-monster-foot="left" style={foot("0.08em")} />
       <span data-monster-foot="right" style={foot("0.55em")} />
-      {hat ? (
-        <span data-monster-hat="" style={HAT_GROUP}>
-          <span style={HAT_TILT}>
-            {/* The pinched crown. The polygon dents the top twice — up one side, a
-            dip in the middle, up the other — which is the whole difference
-            between a cowboy hat and a bucket. */}
-            <span
-              style={{
-                position: "absolute",
-                left: "0.23em",
-                top: "-0.3em",
-                width: "0.54em",
-                height: "0.42em",
-                background: HAT,
-                clipPath:
-                  "polygon(0 100%, 0 34%, 22% 8%, 50% 26%, 78% 8%, 100% 34%, 100% 100%)",
-              }}
-            />
-            {/* The brim, wider than the head so it overlaps the fur on both sides —
-            turn 27's rule, and the reason the hat sits ON the creature instead
-            of hovering above it. */}
-            <span
-              style={{
-                position: "absolute",
-                left: "-0.02em",
-                top: "0.08em",
-                width: "1.04em",
-                height: "0.16em",
-                background: HAT,
-                borderRadius: "999px",
-              }}
-            />
-            {/* The band. */}
-            <span
-              style={{
-                position: "absolute",
-                left: "0.23em",
-                top: "0.01em",
-                width: "0.54em",
-                height: "0.08em",
-                background: HAT_BAND,
-              }}
-            />
-          </span>
+      {antennae ? (
+        <span data-monster-antennae="" style={ANTENNA_GROUP}>
+          <Antenna side="left" />
+          <Antenna side="right" />
         </span>
       ) : null}
     </span>


### PR DESCRIPTION
Swaps the pinched-crown hat for the design document's antenna pair (turn 54,
variant 48a) and rebuilds the landing around it.

## The head is round again

The body was an egg (1.12 against a 0.98 width) for exactly one reason:
headroom under a **brim**. Antennae leave the skull from a point, so the
stretch buys nothing and just reads tall. `BODY_H_HATTED`/`BODY_H_BARE`,
`bodyTopFor`, `BODY_LIFT` and `furFor` go with it.

## Each stalk is a chain of three, because a single bar cannot bend

Rotation swings it rigidly; skew shears it. Both are affine, so both leave
every edge straight — neither is a bend. Three nested segments each turned by
the same angle compound (b, 2b, 3b) into an arc.

| | knob push-back (collapsed mark) | stalk root lift |
|---|---|---|
| hat's inherited 1.4° | 0.34px | 0.09px |
| rotation-led, 7° + 4° skew | 1.68px | 0.47px |
| **chain, 10°/segment = 30° at the tip** | **3.03px** | **0 — the root is a fixed point** |

The chain's angle and length are solved from where the source *floats* each
knob, so at rest both land within `0.0015em` of 48a, asymmetry included
(12.34°/0.4095em left, 14.37°/0.4129em right).

The bend is a registered `@property` angle so it can interpolate, set on the
group and inherited by all six segments — the same channel the gaze uses, and
for the same reason: every segment needs an inline transform to read it, and
an inline transform beats any rule.

## The weight lands on the body

Through the flight the creature is one bitmap, so the hop's squash necessarily
applies to everything equally — that ratio cannot be changed without a second
`view-transition-name`. The settle is live, so `sw-body-settle` gives the head
a real 10% landing squash while the antennae above it only sway. The eye is a
child of the body and squashes with it; the antennae and feet are siblings and
don't.

## The fur had to come with it

Its masked ring clears the body's silhouette by `0.0021em` — **0.05px** at rail
size — and it is a *sibling*, so the first squash dropped the head out from
under it and bared **2.10px of starburst** above the skull. Both now run the
same animation about the same point, expressed as 50%/85.5% of the fur's
larger box.

## And the flight ends on contact

It used to run through the landing: 80% squash, 91% rebound, 100% standing —
all baked into a snapshot that cannot deform, and all of it costing **176ms**
between touchdown and the live element taking over. It read as land, pause,
sway. Every stop is now divided by 0.8 so the airborne part fills the whole
680ms, the last pose is neutral scale so the handover shows no seam, and the
impact beat moved to 12% — 77ms after contact instead of 312ms.

Feet are the source's terracotta again, matching the knobs; the old denim
argument (terracotta was also the word's colour) expired when the word went
blue.

## Checks

- `npm run lint` — clean (6 pre-existing `no-img-element` warnings)
- `npx tsc --noEmit` in the app and in `packages/ui` — both clean
- `npx vitest run --project=storybook` — **262/262 pass, 29 files**

`JumpPoses` was rewritten to drive the real channels and now asserts the three
things that broke during this work: the squash is shorter *and* wider, the fur
keeps its `1.204` reach ratio against the shared origin, and each segment is
turned in its parent's frame so the chain is an arc rather than a lean.

Frame-by-frame teardown: https://claude.ai/code/artifact/50d47308-859e-495a-957a-11e52affc8f5

🤖 Generated with [Claude Code](https://claude.com/claude-code)