### PR TITLE
The creature loads up before the rail moves

### DIFF
--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -570,6 +570,13 @@ html {
      animation. The impact and the rebound now belong to `sw-body-settle` and
      `sw-antennae-settle`, which run on live elements and can actually deform.
 
+     IT NO LONGER CROUCHES EITHER, for the mirror of that reason. The crouch is
+     the 300ms live ANTICIPATION beat that now runs before the transition ever
+     starts (see `[data-anticipating]`), so the creature this animation receives
+     is ALREADY squashed inside its snapshot. A crouch keyframe here would
+     square that with a second one. The stops are rescaled again so the launch
+     begins where the old 17% left off.
+
      THE LAST POSE MUST BE NEUTRAL SCALE, because the settle's own 0% is
      `scale(1, 1)` and any difference between them is a pop at the handover. The
      yaw is the exception and is carried over deliberately — `sw-monster-untwist`
@@ -577,16 +584,13 @@ html {
   0% {
     transform: translate(0, 0) rotate(0deg) scale(1, 1);
   }
-  17% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * -1%), 8%) rotateY(calc(var(--sw-hop-dir, 1) * -3deg)) rotate(calc(var(--sw-hop-dir, 1) * -1deg)) skewX(calc(var(--sw-hop-dir, 1) * 1.5deg)) scale(1.22, 0.78);
-  }
-  32% {
+  18% {
     transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2%), -22%) rotateY(calc(var(--sw-hop-dir, 1) * 9deg)) rotate(calc(var(--sw-hop-dir, 1) * 4deg)) skewX(calc(var(--sw-hop-dir, 1) * -4deg)) scale(0.84, 1.22);
   }
-  58% {
+  49% {
     transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 3%), -64%) rotateY(calc(var(--sw-hop-dir, 1) * 16deg)) rotate(calc(var(--sw-hop-dir, 1) * 6deg)) skewX(calc(var(--sw-hop-dir, 1) * -7deg)) scale(0.82, 1.24);
   }
-  82% {
+  78% {
     transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1%), -20%) rotateY(calc(var(--sw-hop-dir, 1) * 14deg)) rotate(calc(var(--sw-hop-dir, 1) * -2deg)) skewX(calc(var(--sw-hop-dir, 1) * -3deg)) scale(0.92, 1.1);
   }
   /* CONTACT. Standing on its feet, still yawed, not yet deformed — the next
@@ -732,6 +736,97 @@ html {
   translate: calc(var(--sw-hop-dir, 1) * 26%) 0;
   scale: 1.2;
   transform: translateY(-5%);
+}
+
+/* ANTICIPATION, and it is the only part of this jump that happens on the LIVE
+   page rather than inside a snapshot.
+
+   THE PROBLEM IT SOLVES. `::view-transition-old/new(root)` are set to
+   `animation: none` further up, so everything except the creature CUTS at
+   t=0 — the rail is fully shut before the hop has moved a pixel, and the jump
+   plays out over a layout that already finished changing. It reads as
+   "collapse, then a creature animates", which is backwards.
+
+   WHY NOT JUST DELAY THE CUT. Holding `::view-transition-old(root)` for 300ms
+   looks like the obvious fix and reintroduces the dark-rectangle bug: the root
+   snapshot has the mark CUT OUT of it at its layout position, and the thing
+   that fills that hole is the group's own background, which travels with the
+   creature. Hold the OLD root while the group moves toward the NEW position and
+   the old hole is progressively bared — about half the travel by 300ms.
+
+   SO THE BEAT GOES BEFORE THE TRANSITION, where the page is still live and
+   there are no snapshots to cut holes in. `writeRailExpanded` sets this
+   attribute, waits, and only then calls `startViewTransition`. The creature
+   crouches, turns its eye and bends its antennae back in real elements; the
+   rail then collapses under a jump that is already committed.
+
+   IT ALSO MAKES THE CLICK FEEL ANSWERED. A control that does nothing for 300ms
+   reads as broken. This one responds on the frame of the press — just not with
+   the layout change. */
+[data-storyboard-monster][data-anticipating] [data-monster-body],
+[data-storyboard-monster][data-anticipating] [data-monster-fur] {
+  /* Down and wide, about the feet. Modest: the creature has to be recognisably
+     itself in the snapshot this pose gets captured into. */
+  transform: scale(1.06, 0.94);
+}
+
+/* Everything the aim pose sets, eased in over the beat instead of snapped.
+   Same properties, so when `data-aiming` replaces this attribute the values are
+   already where the snapshot wants them and the capture shows no jump.
+
+   FAST OUT OF THE GATE, because the press has to be answered on the frame it
+   happens. The first curve here was a slow load-up (0.32, 0.06, 0.24, 1) and
+   measured on the live app it was 2% of the way after one frame and 9% after
+   25ms — technically moving, visibly nothing. This one is 26% after a single
+   frame and half done by the second, so the creature reacts to the click and
+   not to some moment after it.
+
+   The tail is what makes it still read as anticipation rather than as a snap:
+   the crouch is ~96% there by 130ms and then HOLDS for the rest of the beat.
+   Load, hold, release — the hold is the tension, and it is only available
+   because the pose arrives early. */
+[data-storyboard-monster][data-anticipating] [data-monster-body],
+[data-storyboard-monster][data-anticipating] [data-monster-fur],
+[data-storyboard-monster][data-anticipating] [data-monster-eye],
+[data-storyboard-monster][data-anticipating] [data-monster-foot],
+[data-storyboard-monster][data-anticipating] [data-monster-antennae] {
+  transition:
+    transform 260ms cubic-bezier(0.22, 1, 0.36, 1),
+    --sw-antenna-bend 260ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* The aim poses themselves, hoisted onto the anticipation as well. Written as a
+   second selector list rather than by loosening the `[data-aiming]` rules,
+   because those also have to hold through the flight and this must not. */
+[data-storyboard-monster][data-anticipating] [data-monster-eye] {
+  transform: translateX(calc(var(--sw-hop-dir, 1) * 0.06em));
+}
+
+[data-storyboard-monster][data-anticipating] [data-monster-pupil] {
+  --monster-gaze-x: calc(var(--sw-hop-dir, 1) * 0.02em);
+  translate: calc(var(--sw-hop-dir, 1) * 26%) 0;
+  scale: 1.2;
+  transform: translateY(-5%);
+  transition:
+    translate 260ms cubic-bezier(0.22, 1, 0.36, 1),
+    scale 260ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 260ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+[data-storyboard-monster][data-anticipating] [data-monster-antennae] {
+  /* Bending back BEFORE the leap, which is what anticipation means: the loose
+     parts load up against the direction of travel and are released by it. */
+  --sw-antenna-bend: calc(var(--sw-hop-dir, 1) * -10deg);
+}
+
+[data-storyboard-monster][data-anticipating] [data-monster-foot="left"] {
+  transform-origin: 100% 0;
+  transform: rotate(-22deg);
+}
+
+[data-storyboard-monster][data-anticipating] [data-monster-foot="right"] {
+  transform-origin: 0 0;
+  transform: rotate(22deg);
 }
 
 /* THE BEND HAS TO BE DECLARED BEFORE IT CAN BE ANIMATED.

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -136,12 +136,66 @@ function commitRailExpanded(next: boolean): void {
  * Falls back to a plain commit where the API is missing or the reader asked for
  * less motion; the rail still moves, it just cuts.
  */
+/**
+ * How long the creature gets to load up before the rail moves.
+ *
+ * The collapse used to be instantaneous: `::view-transition-old/new(root)` are
+ * set to `animation: none`, so every part of the page except the creature CUTS
+ * at t=0 and the jump then played out over a layout that had already finished
+ * changing. Backwards — the leap should come first and the rail should shut
+ * under it.
+ *
+ * Delaying the CUT is the obvious fix and is wrong: the root snapshot has the
+ * mark cut out of it at its layout position, and the only thing filling that
+ * hole is the group's own background, which travels with the creature. Holding
+ * the old root while the group moves bares the hole (see the `sw-monster` notes
+ * in `globals.css`). So the beat goes BEFORE the transition instead, where the
+ * page is still live and there are no snapshots to punch holes in.
+ *
+ * 300ms is the ask and it is also about the ceiling: it is spent on visible
+ * motion — the crouch, the eye turning, the antennae bending back — so the
+ * click still reads as answered on the frame it happens, but a control whose
+ * LAYOUT waits much longer than this starts to feel unresponsive.
+ */
+const ANTICIPATION_MS = 300;
+
+/**
+ * The pending beat, so a second click during it cannot stack a second
+ * transition on the first. Clearing the timer and re-entering means the newest
+ * click wins, which is what a reader jabbing the toggle expects; letting both
+ * run would start a transition whose "before" state is another transition.
+ */
+let anticipationTimer: number | undefined;
+
+/**
+ * Which interaction owns the creature's pose right now.
+ *
+ * A transition's `finished` handler strips `data-aiming`/`data-landing` and
+ * hands over to the settle. Traced on the live app, one of those handlers fired
+ * 8ms AFTER a newer click had already set its own aim — stripping it, so the
+ * new jump flew with a centred eye and un-splayed feet, then settled twice.
+ *
+ * The 300ms beat makes this ordinary rather than exotic: there is now a visible
+ * window in which a second click is a natural thing to do. Every handler reads
+ * the generation it was created under and does nothing if a newer one has
+ * started, so the newest interaction always owns the mark.
+ */
+let railGeneration = 0;
+
 function writeRailExpanded(next: boolean): void {
   const doc = document as Document & {
     startViewTransition?: (callback: () => void) => unknown;
   };
   const reduced =
     window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true;
+  const generation = ++railGeneration;
+  if (anticipationTimer !== undefined) {
+    window.clearTimeout(anticipationTimer);
+    anticipationTimer = undefined;
+    document
+      .querySelector("[data-storyboard-monster]")
+      ?.removeAttribute("data-anticipating");
+  }
   if (typeof doc.startViewTransition !== "function" || reduced) {
     commitRailExpanded(next);
     return;
@@ -165,9 +219,36 @@ function writeRailExpanded(next: boolean): void {
   // because mid-flight the creature is a rasterised image and nothing inside it
   // can move. A pose can still be captured INTO that image; motion cannot.
   const mark = document.querySelector("[data-storyboard-monster]");
-  mark?.setAttribute("data-aiming", "");
 
-  const transition = doc.startViewTransition(() => {
+  // THE BEAT. Live elements, eased by the `[data-anticipating]` rules — this is
+  // the only motion in the whole jump that is not inside a snapshot. Without a
+  // mark to pose there is nothing to wait for, so that path goes straight
+  // through.
+  if (!mark) {
+    beginRailTransition(doc, next, null, generation);
+    return;
+  }
+  mark.setAttribute("data-anticipating", "");
+  anticipationTimer = window.setTimeout(() => {
+    anticipationTimer = undefined;
+    if (generation !== railGeneration) return;
+    // Swapped in ONE frame. The aim rules restate every value the anticipation
+    // just eased into, so the capture that happens moments later sees the pose
+    // already settled rather than mid-transition.
+    mark.removeAttribute("data-anticipating");
+    mark.setAttribute("data-aiming", "");
+    beginRailTransition(doc, next, mark, generation);
+  }, ANTICIPATION_MS);
+}
+
+/** The transition itself, once the creature has finished loading up. */
+function beginRailTransition(
+  doc: Document & { startViewTransition?: (callback: () => void) => unknown },
+  next: boolean,
+  mark: Element | null,
+  generation: number,
+): void {
+  const transition = doc.startViewTransition!(() => {
     flushSync(() => commitRailExpanded(next));
     // THE SECOND POSE, and the reason there is one at all. The browser captures
     // the OLD state before this callback runs and the NEW state after it
@@ -195,6 +276,7 @@ function writeRailExpanded(next: boolean): void {
     // Nothing to hang the settle off. Drop the aim on a timer regardless — a
     // pupil left staring sideways is worse than no flourish at all.
     window.setTimeout(() => {
+      if (generation !== railGeneration) return;
       mark?.removeAttribute("data-aiming");
       mark?.removeAttribute("data-landing");
     }, 620);
@@ -202,7 +284,10 @@ function writeRailExpanded(next: boolean): void {
   }
   void finished
     .then(() => {
-      if (!mark) return;
+      // A NEWER CLICK OWNS THE MARK NOW. Without this the settle strips an aim
+      // that belongs to a jump still in the air -- traced 8ms after the newer
+      // pose was set, which flew it with a centred eye and settled it twice.
+      if (!mark || generation !== railGeneration) return;
       // Swapped in ONE frame, and the settle's first pose is the aim, so the
       // pupil is never briefly re-centred between the two — the handover from
       // captured image to live element is invisible.
@@ -215,12 +300,17 @@ function writeRailExpanded(next: boolean): void {
       // not shorten the flourish, it truncates it — at 620ms the hat's final
       // bounce was cut mid-air, and anything under 1260 snaps the last of the
       // dilation off in one frame.
-      window.setTimeout(() => mark.removeAttribute("data-settling"), 1360);
+      window.setTimeout(() => {
+        if (generation !== railGeneration) return;
+        mark.removeAttribute("data-settling");
+      }, 1360);
     })
     .catch(() => {
       // A transition skipped or superseded by a faster second click. The rail
       // still moved; only the flourish is lost — but the aim must come off, or
-      // the eye is left pointing at a jump that never happened.
+      // the eye is left pointing at a jump that never happened. Unless the
+      // superseding click is already posing it, in which case leave it alone.
+      if (generation !== railGeneration) return;
       mark?.removeAttribute("data-aiming");
       mark?.removeAttribute("data-landing");
     });


### PR DESCRIPTION
The rail used to be fully shut before the jump had moved a pixel:
`::view-transition-old/new(root)` are `animation: none`, so everything except
the creature cuts at t=0 and the hop then plays out over a layout that already
finished changing.

## Why not just delay the cut

The root snapshot has the mark **cut out** of it at its layout position, and the
only thing filling that hole is the group's own background — which travels with
the creature. Holding the old root while the group moves bares the hole,
progressively, about half the travel by 300ms. That is the dark-rectangle
artifact again.

So the beat goes **before** the transition, where the page is live and there are
no snapshots to punch holes in.

## Measured on the running app

| | before | after |
|---|---|---|
| creature responds | t=0 (invisible) | **t=1ms** |
| beat ends | — | 302ms |
| **rail starts moving** | **t≈0** | **352ms** |
| `data-settling` | — | 1017ms, aim held the whole flight |

## It starts on the click, not shortly after

The first easing was a slow load-up and measured **2% after one frame, 9% after
25ms** — technically moving, visibly nothing. `cubic-bezier(0.22, 1, 0.36, 1)`:

| | 16ms | 33ms | 80ms | 130ms |
|---|---|---|---|---|
| old `0.32, 0.06, 0.24, 1` | 2% | 9% | 46% | 78% |
| **new `0.22, 1, 0.36, 1`** | **26%** | **49%** | **85%** (confirmed live at 79ms) | 96% |

Then it *holds* at full crouch for the rest of the beat. Load, hold, release —
the hold is the tension, and it is only affordable because the pose arrives
early.

## Two things this forced

- **The hop loses its crouch keyframe.** That crouch now happens live and is
  already baked into the snapshot; keeping it would have squared the squash.
  Remaining stops rescale so the launch begins where the old 17% left off.
- **A generation token on every deferred handler.** The beat makes a second
  click ordinary rather than exotic. Traced live: a stale `finished` handler
  stripped `data-aiming` **8ms after** a newer click had set its own, flying
  that jump with a centred eye and settling it twice.

The fur rides the crouch as well as the landing squash — verified at zero
drift, reach ratio 1.204 both posed and unposed.

## Checks

- `npm run lint` — clean (6 pre-existing `no-img-element` warnings)
- `npx tsc --noEmit` in the app and `packages/ui` — both clean
- `npx vitest run --project=storybook` — 262/262
- `npx vitest run` in the app — 1308/1308
- No e2e test references the rail toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)