### PR TITLE
Each direction of the monster's jump gets its own arc, and the rail its own close

### DIFF
--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -366,20 +366,36 @@ html {
      a slight bump in it, which is exactly what "skimming" describes. No amount
      of extra height fixes a launch that has already happened.
 
-     So it is a variable now, and the closing direction gets its own travel —
-     a `linear()` shaped to hold the ground under the creature until it has
-     actually left it, and then to put the APEX near the landing instead of back
-     over the middle of the trip. The three points it is solved for, and why a
-     cubic-bezier could not hit all three, are in `CLOSE_TRAVEL` in
-     `timeline-sidebar.tsx`.
+     So it is shaped rather than eased. Three things have to be true of the
+     travel at once, and no cubic-bezier holds all three:
 
-     Opening keeps this one — it reads correctly, and the fallback here is that
-     same value so a missing property cannot change it. */
+       17%    3% across   the crouch happens IN PLACE, not while sliding
+       32%   13% across   paired with the rise, a ~37deg climb out of the ground
+       58%   82% across   the apex sits near the landing, not back over the
+                          middle of the trip
+
+     Anything slow enough for the first two decelerates through the third.
+     `cubic-bezier(0.65, 0, 0.35, 1)` held the launch beautifully and then put
+     the apex at 71% of the travel, so the creature topped out over open ground.
+     A slow start AND a fast middle AND a settle is not a shape a single cubic
+     has; `linear()` is.
+
+     BOTH DIRECTIONS USE IT, which is why this is a literal and not a variable
+     any more. Travel is a progress curve — it says how much of the trip has
+     happened, not which way — so the same shape serves the jump out of the rail
+     and the jump back into the word. The only thing that differs by direction
+     is `--sw-hop-rise`, and it differs for a reason that is about the snapshot
+     SIZES rather than about the arc (see the 32% stop below).
+
+     Generated as a monotone cubic through those control points and sampled at
+     19 stops: monotone so the interpolation can never overshoot and send the
+     creature briefly backwards, and 19 so the segments sit below the eye's
+     resolution at this speed. Regenerate it rather than hand-editing a stop. */
   animation-duration: 620ms;
-  animation-timing-function: var(
-    --sw-group-ease,
-    cubic-bezier(0.34, 0.8, 0.28, 1)
-  );
+  animation-timing-function: linear(0 0%, 0.008508 6%, 0.01694 11%, 0.02907 17%, 0.0522 22%,
+    0.09105 28%, 0.1467 33%, 0.2732 39%, 0.4545 44%, 0.6412 50%,
+    0.7839 56%, 0.8508 61%, 0.8965 67%, 0.9309 72%, 0.9543 78%,
+    0.9693 83%, 0.9804 89%, 0.9898 94%, 1 100%);
   /* STAGING: the creature is the only thing that should be moving, so it sits
      above the rest of the transition rather than under the rail's own chrome. */
   z-index: 10;
@@ -620,22 +636,25 @@ html {
      same 131px of travel, which reads as skimming the ground rather than
      jumping off it.
 
-     `--sw-hop-rise` is the close's own number for this one stop, and it is 1
-     when opening so that direction resolves to the -22% it always had.
+     `--sw-hop-rise` is how hard it leaves, and it is the ONE number in this
+     animation that has to differ by direction.
 
-     It carries TWO corrections at once. 1.4545 of it (= 1.6 / 1.1, the two
-     `scale` values the sidebar renders the mark at) is pure compensation, and
-     brings the close's 3.3px up to the open's 4.8px. The rest is the LAUNCH:
-     paired with the slow-start group curve above, 2.6 puts the creature 17px
-     across and 8.6px up at this stop, which is a 36deg climb out of the crouch
-     where it used to be 98px across and 4.8px up, a 8deg slide.
+     Not because the two jumps should look different — they should look
+     identical, and now do — but because the percentage means different things
+     in each. The creature is two sizes (`scale` 1.1 inside the word, 1.6 alone
+     in the rail), and early in the flight you are looking at the OLD snapshot,
+     so the same 22% buys 4.8px leaving the rail and only 3.3px leaving the
+     word. The sidebar sets one LAUNCH constant and multiplies it by the size
+     ratio for the direction that leaves the smaller snapshot; both then rise
+     8.6px here, for a ~37deg climb where the old flat 22% gave 27deg and 8deg
+     respectively.
 
      ONLY THIS STOP IS SCALED. By the apex the cross-fade has handed most of the
-     way to the NEW snapshot — the larger one when closing — so the apex is
-     already 12.4px and needs nothing; scaling it too would put the creature
-     through the ceiling and flatten the arc's second half into a drop. A steep
-     rise into an unchanged apex is what makes it read as ballistic: fast out of
-     the ground, decelerating into the top. */
+     way to the NEW snapshot, so the apexes already sit at 12.4px and 11.2px and
+     need nothing; scaling them too would put the creature through the ceiling
+     and flatten the arc's second half into a drop. A steep rise into an
+     unchanged apex is what makes it read as ballistic: fast out of the ground,
+     decelerating into the top. */
   32% {
     transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2%), calc(-22% * var(--sw-hop-rise, 1))) rotateY(calc(var(--sw-hop-dir, 1) * 9deg)) rotate(calc(var(--sw-hop-dir, 1) * 4deg)) skewX(calc(var(--sw-hop-dir, 1) * -4deg)) scale(0.84, 1.22);
   }

--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -580,8 +580,28 @@ html {
   17% {
     transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * -1%), 8%) rotateY(calc(var(--sw-hop-dir, 1) * -3deg)) rotate(calc(var(--sw-hop-dir, 1) * -1deg)) skewX(calc(var(--sw-hop-dir, 1) * 1.5deg)) scale(1.22, 0.78);
   }
+  /* THE LAUNCH, and the one stop that needs a per-direction number.
+
+     A percentage here resolves against the SNAPSHOT it is transforming, and
+     the two snapshots are different sizes: the mark is 15.05px inside the word
+     and 21.88px alone in the rail, a ratio of 1.454. Before the cross-fade
+     starts at 34% you are looking at the OLD snapshot, so this stop's rise is
+     22% of whichever size the creature is LEAVING.
+
+     Which made the two directions physically different jumps. Opening, it
+     leaves the collapsed rail and rises 22% of 21.88px = 4.8px. Closing, it
+     leaves the word and rises 22% of 15.05px = 3.3px — a third lower, over the
+     same 131px of travel, which reads as skimming the ground rather than
+     jumping off it.
+
+     `--sw-hop-rise` is 1.4545 (= 1.6 / 1.1, the two `scale` values the sidebar
+     renders the mark at) when closing and 1 when opening, so the close leaves
+     the ground at the same 4.8px the open always did. Only this stop is scaled:
+     by the apex the cross-fade has handed most of the way to the NEW snapshot,
+     which is the larger one when closing, so the two apexes already agree
+     within a pixel (12.4 against 11.2) and scaling that too would overshoot. */
   32% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2%), -22%) rotateY(calc(var(--sw-hop-dir, 1) * 9deg)) rotate(calc(var(--sw-hop-dir, 1) * 4deg)) skewX(calc(var(--sw-hop-dir, 1) * -4deg)) scale(0.84, 1.22);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2%), calc(-22% * var(--sw-hop-rise, 1))) rotateY(calc(var(--sw-hop-dir, 1) * 9deg)) rotate(calc(var(--sw-hop-dir, 1) * 4deg)) skewX(calc(var(--sw-hop-dir, 1) * -4deg)) scale(0.84, 1.22);
   }
   58% {
     transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 3%), -64%) rotateY(calc(var(--sw-hop-dir, 1) * 16deg)) rotate(calc(var(--sw-hop-dir, 1) * 6deg)) skewX(calc(var(--sw-hop-dir, 1) * -7deg)) scale(0.82, 1.24);

--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -734,43 +734,43 @@ html {
     transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * -0.8929%), 7.143%) rotateY(calc(var(--sw-hop-dir, 1) * -2.679deg)) rotate(calc(var(--sw-hop-dir, 1) * -0.8929deg)) skewX(calc(var(--sw-hop-dir, 1) * 1.339deg)) scale(1.196, 0.8036);
   }
   18.75% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * -0.1094%), -24.65%) rotateY(calc(var(--sw-hop-dir, 1) * 0.5625deg)) rotate(calc(var(--sw-hop-dir, 1) * 0.4844deg)) skewX(calc(var(--sw-hop-dir, 1) * -0.1328deg)) scale(1.041, 0.9835);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * -0.1094%), -15.28%) rotateY(calc(var(--sw-hop-dir, 1) * 0.5625deg)) rotate(calc(var(--sw-hop-dir, 1) * 0.4844deg)) skewX(calc(var(--sw-hop-dir, 1) * -0.1328deg)) scale(1.041, 0.9835);
   }
   25% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1.062%), -51.77%) rotateY(calc(var(--sw-hop-dir, 1) * 5.25deg)) rotate(calc(var(--sw-hop-dir, 1) * 2.438deg)) skewX(calc(var(--sw-hop-dir, 1) * -2.281deg)) scale(0.875, 1.167);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1.062%), -32.1%) rotateY(calc(var(--sw-hop-dir, 1) * 5.25deg)) rotate(calc(var(--sw-hop-dir, 1) * 2.438deg)) skewX(calc(var(--sw-hop-dir, 1) * -2.281deg)) scale(0.875, 1.167);
   }
   31.25% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.062%), -72.87%) rotateY(calc(var(--sw-hop-dir, 1) * 9.438deg)) rotate(calc(var(--sw-hop-dir, 1) * 4.125deg)) skewX(calc(var(--sw-hop-dir, 1) * -4.188deg)) scale(0.9062, 1.125);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.062%), -45.18%) rotateY(calc(var(--sw-hop-dir, 1) * 9.438deg)) rotate(calc(var(--sw-hop-dir, 1) * 4.125deg)) skewX(calc(var(--sw-hop-dir, 1) * -4.188deg)) scale(0.9062, 1.125);
   }
   37.5% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.375%), -87.94%) rotateY(calc(var(--sw-hop-dir, 1) * 11.62deg)) rotate(calc(var(--sw-hop-dir, 1) * 4.75deg)) skewX(calc(var(--sw-hop-dir, 1) * -5.125deg)) scale(0.9375, 1.083);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.375%), -54.53%) rotateY(calc(var(--sw-hop-dir, 1) * 11.62deg)) rotate(calc(var(--sw-hop-dir, 1) * 4.75deg)) skewX(calc(var(--sw-hop-dir, 1) * -5.125deg)) scale(0.9375, 1.083);
   }
   43.75% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.688%), -96.99%) rotateY(calc(var(--sw-hop-dir, 1) * 13.81deg)) rotate(calc(var(--sw-hop-dir, 1) * 5.375deg)) skewX(calc(var(--sw-hop-dir, 1) * -6.062deg)) scale(0.9688, 1.042);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.688%), -60.13%) rotateY(calc(var(--sw-hop-dir, 1) * 13.81deg)) rotate(calc(var(--sw-hop-dir, 1) * 5.375deg)) skewX(calc(var(--sw-hop-dir, 1) * -6.062deg)) scale(0.9688, 1.042);
   }
   50% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 3%), -100%) rotateY(calc(var(--sw-hop-dir, 1) * 16deg)) rotate(calc(var(--sw-hop-dir, 1) * 6deg)) skewX(calc(var(--sw-hop-dir, 1) * -7deg)) scale(1, 1);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 3%), -62%) rotateY(calc(var(--sw-hop-dir, 1) * 16deg)) rotate(calc(var(--sw-hop-dir, 1) * 6deg)) skewX(calc(var(--sw-hop-dir, 1) * -7deg)) scale(1, 1);
   }
   56.25% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.554%), -98.44%) rotateY(calc(var(--sw-hop-dir, 1) * 15.55deg)) rotate(calc(var(--sw-hop-dir, 1) * 4.214deg)) skewX(calc(var(--sw-hop-dir, 1) * -6.107deg)) scale(0.9838, 1.022);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.554%), -61.03%) rotateY(calc(var(--sw-hop-dir, 1) * 15.55deg)) rotate(calc(var(--sw-hop-dir, 1) * 4.214deg)) skewX(calc(var(--sw-hop-dir, 1) * -6.107deg)) scale(0.9838, 1.022);
   }
   62.5% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.107%), -93.75%) rotateY(calc(var(--sw-hop-dir, 1) * 15.11deg)) rotate(calc(var(--sw-hop-dir, 1) * 2.429deg)) skewX(calc(var(--sw-hop-dir, 1) * -5.214deg)) scale(0.9676, 1.043);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.107%), -58.13%) rotateY(calc(var(--sw-hop-dir, 1) * 15.11deg)) rotate(calc(var(--sw-hop-dir, 1) * 2.429deg)) skewX(calc(var(--sw-hop-dir, 1) * -5.214deg)) scale(0.9676, 1.043);
   }
   68.75% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1.661%), -85.94%) rotateY(calc(var(--sw-hop-dir, 1) * 14.66deg)) rotate(calc(var(--sw-hop-dir, 1) * 0.6429deg)) skewX(calc(var(--sw-hop-dir, 1) * -4.321deg)) scale(0.9514, 1.065);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1.661%), -53.28%) rotateY(calc(var(--sw-hop-dir, 1) * 14.66deg)) rotate(calc(var(--sw-hop-dir, 1) * 0.6429deg)) skewX(calc(var(--sw-hop-dir, 1) * -4.321deg)) scale(0.9514, 1.065);
   }
   75% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1.214%), -75%) rotateY(calc(var(--sw-hop-dir, 1) * 14.21deg)) rotate(calc(var(--sw-hop-dir, 1) * -1.143deg)) skewX(calc(var(--sw-hop-dir, 1) * -3.429deg)) scale(0.9352, 1.086);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1.214%), -46.5%) rotateY(calc(var(--sw-hop-dir, 1) * 14.21deg)) rotate(calc(var(--sw-hop-dir, 1) * -1.143deg)) skewX(calc(var(--sw-hop-dir, 1) * -3.429deg)) scale(0.9352, 1.086);
   }
   81.25% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0.8523%), -60.94%) rotateY(calc(var(--sw-hop-dir, 1) * 13.41deg)) rotate(calc(var(--sw-hop-dir, 1) * -1.705deg)) skewX(calc(var(--sw-hop-dir, 1) * -2.557deg)) scale(0.919, 1.108);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0.8523%), -37.78%) rotateY(calc(var(--sw-hop-dir, 1) * 13.41deg)) rotate(calc(var(--sw-hop-dir, 1) * -1.705deg)) skewX(calc(var(--sw-hop-dir, 1) * -2.557deg)) scale(0.919, 1.108);
   }
   87.5% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0.5682%), -43.75%) rotateY(calc(var(--sw-hop-dir, 1) * 12.27deg)) rotate(calc(var(--sw-hop-dir, 1) * -1.136deg)) skewX(calc(var(--sw-hop-dir, 1) * -1.705deg)) scale(0.9241, 1.101);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0.5682%), -27.12%) rotateY(calc(var(--sw-hop-dir, 1) * 12.27deg)) rotate(calc(var(--sw-hop-dir, 1) * -1.136deg)) skewX(calc(var(--sw-hop-dir, 1) * -1.705deg)) scale(0.9241, 1.101);
   }
   93.75% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0.2841%), -23.44%) rotateY(calc(var(--sw-hop-dir, 1) * 11.14deg)) rotate(calc(var(--sw-hop-dir, 1) * -0.5682deg)) skewX(calc(var(--sw-hop-dir, 1) * -0.8523deg)) scale(0.9557, 1.059);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0.2841%), -14.53%) rotateY(calc(var(--sw-hop-dir, 1) * 11.14deg)) rotate(calc(var(--sw-hop-dir, 1) * -0.5682deg)) skewX(calc(var(--sw-hop-dir, 1) * -0.8523deg)) scale(0.9557, 1.059);
   }
   100% {
     transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0%), -0%) rotateY(calc(var(--sw-hop-dir, 1) * 10deg)) rotate(calc(var(--sw-hop-dir, 1) * 0deg)) skewX(calc(var(--sw-hop-dir, 1) * 0deg)) scale(1, 1);

--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -351,9 +351,30 @@ html {
    the extremes) because at ~20px anything subtler is invisible. */
 
 ::view-transition-group(sw-monster) {
-  /* The travel itself: out of the crouch quickly, easing into the landing. */
+  /* THE HORIZONTAL LIVES HERE, and it is the reason one direction skimmed.
+
+     This animation carries the group's POSITION and SIZE — where the creature
+     is — while `sw-monster-hop` on the snapshots inside it carries the lift and
+     the squash. Two clocks, and only this one decides how much ground has gone
+     by when the lift arrives.
+
+     `cubic-bezier(0.34, 0.8, 0.28, 1)` is heavily front-loaded, and measured on
+     the closing jump that meant 55px of a 131px travel — 42% of the way across
+     — while the creature was still 1.2px BELOW the ground, mid-crouch. By the
+     time it had risen 4.8px it was 75% of the way there. The launch angle over
+     those two stops was -1.2deg and then 8deg: a creature sliding sideways with
+     a slight bump in it, which is exactly what "skimming" describes. No amount
+     of extra height fixes a launch that has already happened.
+
+     So it is a variable now, and the closing direction gets a slow-start curve
+     that keeps the ground under the creature until it has actually left it.
+     Opening keeps this one — it reads correctly, and the fallback here is that
+     same value so a missing property cannot change it. */
   animation-duration: 620ms;
-  animation-timing-function: cubic-bezier(0.34, 0.8, 0.28, 1);
+  animation-timing-function: var(
+    --sw-group-ease,
+    cubic-bezier(0.34, 0.8, 0.28, 1)
+  );
   /* STAGING: the creature is the only thing that should be moving, so it sits
      above the rest of the transition rather than under the rail's own chrome. */
   z-index: 10;
@@ -594,12 +615,22 @@ html {
      same 131px of travel, which reads as skimming the ground rather than
      jumping off it.
 
-     `--sw-hop-rise` is 1.4545 (= 1.6 / 1.1, the two `scale` values the sidebar
-     renders the mark at) when closing and 1 when opening, so the close leaves
-     the ground at the same 4.8px the open always did. Only this stop is scaled:
-     by the apex the cross-fade has handed most of the way to the NEW snapshot,
-     which is the larger one when closing, so the two apexes already agree
-     within a pixel (12.4 against 11.2) and scaling that too would overshoot. */
+     `--sw-hop-rise` is the close's own number for this one stop, and it is 1
+     when opening so that direction resolves to the -22% it always had.
+
+     It carries TWO corrections at once. 1.4545 of it (= 1.6 / 1.1, the two
+     `scale` values the sidebar renders the mark at) is pure compensation, and
+     brings the close's 3.3px up to the open's 4.8px. The rest is the LAUNCH:
+     paired with the slow-start group curve above, 2.6 puts the creature 17px
+     across and 8.6px up at this stop, which is a 36deg climb out of the crouch
+     where it used to be 98px across and 4.8px up, a 8deg slide.
+
+     ONLY THIS STOP IS SCALED. By the apex the cross-fade has handed most of the
+     way to the NEW snapshot — the larger one when closing — so the apex is
+     already 12.4px and needs nothing; scaling it too would put the creature
+     through the ceiling and flatten the arc's second half into a drop. A steep
+     rise into an unchanged apex is what makes it read as ballistic: fast out of
+     the ground, decelerating into the top. */
   32% {
     transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2%), calc(-22% * var(--sw-hop-rise, 1))) rotateY(calc(var(--sw-hop-dir, 1) * 9deg)) rotate(calc(var(--sw-hop-dir, 1) * 4deg)) skewX(calc(var(--sw-hop-dir, 1) * -4deg)) scale(0.84, 1.22);
   }

--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -366,32 +366,28 @@ html {
      a slight bump in it, which is exactly what "skimming" describes. No amount
      of extra height fixes a launch that has already happened.
 
-     A JUMP HAS NO HORIZONTAL FORCE, so its horizontal velocity is CONSTANT
-     and only the vertical accelerates. That one fact is the whole specification
-     for this curve, and two earlier attempts got it wrong in opposite
-     directions.
+     IT IS PER-DIRECTION, because the two jumps are. Travel is a progress
+     curve — it says how much of the trip has happened, not which way — so a
+     single one would serve both if both wanted the same shape. They do not.
 
-     `cubic-bezier(0.34, 0.8, 0.28, 1)` was heavily front-loaded: the creature
-     was 42% of the way across while still below the ground in its crouch, and
-     75% of the way by the time it had risen at all. That is a skim.
+     The CLOSING direction was signed off on a shaped `linear()` that holds the
+     ground under the creature and then puts its apex near the landing; see
+     `CLOSE_TRAVEL` in `timeline-sidebar.tsx` for the three points it is solved
+     for. The OPENING direction is ballistic: a jump has no horizontal force, so
+     its horizontal velocity is constant and only the vertical accelerates, and
+     it gets a near-linear curve whose peak speed is 1.22x its mean.
 
-     Over-correcting with a shaped `linear()` that held the ground until 32% of
-     the time then caught up made it worse in a subtler way — peak speed 3.4x
-     the mean around the midpoint, against 0.15x at the start. It read as a
-     creature being fired out of something.
-
-     So: near-linear, with only enough ease at the ends to cover the crouch and
-     the landing. Peak speed is 1.22x the mean across the whole flight, which is
-     as close to ballistic as a transition with a start and a stop gets. The
-     ARC comes from the keyframes now, not from a distorted clock — which is
-     where it belonged all along.
-
-     BOTH DIRECTIONS USE IT. Travel is a progress curve; it says how much of the
-     trip has happened, not which way. The only thing that differs by direction
-     is `--sw-hop-rise`, and it differs because of the snapshot SIZES rather
-     than because the two arcs should differ (see the launch stop below). */
+     The fallback is the closing curve, so a missing property cannot silently
+     turn either of them into the front-loaded easing this replaced — that one
+     had the creature 42% of the way across while still crouching. */
   animation-duration: 620ms;
-  animation-timing-function: cubic-bezier(0.42, 0.3, 0.58, 0.72);
+  animation-timing-function: var(
+    --sw-group-ease,
+    linear(0 0%, 0.008508 6%, 0.01694 11%, 0.02907 17%, 0.0522 22%,
+      0.09105 28%, 0.1467 33%, 0.2732 39%, 0.4545 44%, 0.6412 50%,
+      0.7839 56%, 0.8508 61%, 0.8965 67%, 0.9309 72%, 0.9543 78%,
+      0.9693 83%, 0.9804 89%, 0.9898 94%, 1 100%)
+  );
   /* STAGING: the creature is the only thing that should be moving, so it sits
      above the rest of the transition rather than under the rail's own chrome. */
   z-index: 10;
@@ -458,31 +454,39 @@ html {
    in it. */
 ::view-transition-old(sw-monster) {
   animation:
-    /* LINEAR ON PURPOSE, and this was the single largest distortion in the
-       whole jump. `animation-timing-function` applies between EVERY pair of
-       keyframes, not once across the animation, so an eased hop re-eased each
-       leg of the arc: with the old easeOutQuint the creature was 77% of the way
-       to a stop a third into the segment and 92% of the way half way through.
-       Every leg landed early and then held, which is exactly what "reaches the
-       apex too early" describes — it reached every stop too early.
-       Linear hands the shape back to the keyframe values, where it can be read
-       and reasoned about. */
-    sw-monster-hop 680ms linear both,
+    /* NAME AND CLOCK BOTH COME FROM THE DIRECTION.
+
+       `animation-timing-function` applies between EVERY pair of keyframes, not
+       once across the animation, so it is part of the arc's shape rather than a
+       finish on top of it: with an eased hop each leg is re-eased and lands
+       early. The closing arc was authored WITH that and reads correctly; the
+       opening one is authored against `linear` so its keyframe values are the
+       trajectory. Neither survives being given the other's clock, which is why
+       this is a variable and not a constant.
+
+       Defaults are the closing pair, so a missing property degrades to the
+       signed-off shape rather than to a new one. */
+    var(--sw-hop-name, sw-monster-hop) 680ms
+      var(--sw-hop-ease, cubic-bezier(0.34, 0.8, 0.28, 1)) both,
     sw-monster-depart 680ms linear both;
 }
 
 ::view-transition-new(sw-monster) {
   animation:
-    /* LINEAR ON PURPOSE, and this was the single largest distortion in the
-       whole jump. `animation-timing-function` applies between EVERY pair of
-       keyframes, not once across the animation, so an eased hop re-eased each
-       leg of the arc: with the old easeOutQuint the creature was 77% of the way
-       to a stop a third into the segment and 92% of the way half way through.
-       Every leg landed early and then held, which is exactly what "reaches the
-       apex too early" describes — it reached every stop too early.
-       Linear hands the shape back to the keyframe values, where it can be read
-       and reasoned about. */
-    sw-monster-hop 680ms linear both,
+    /* NAME AND CLOCK BOTH COME FROM THE DIRECTION.
+
+       `animation-timing-function` applies between EVERY pair of keyframes, not
+       once across the animation, so it is part of the arc's shape rather than a
+       finish on top of it: with an eased hop each leg is re-eased and lands
+       early. The closing arc was authored WITH that and reads correctly; the
+       opening one is authored against `linear` so its keyframe values are the
+       trajectory. Neither survives being given the other's clock, which is why
+       this is a variable and not a constant.
+
+       Defaults are the closing pair, so a missing property degrades to the
+       signed-off shape rather than to a new one. */
+    var(--sw-hop-name, sw-monster-hop) 680ms
+      var(--sw-hop-ease, cubic-bezier(0.34, 0.8, 0.28, 1)) both,
     sw-monster-arrive 680ms linear both;
 }
 
@@ -610,28 +614,67 @@ html {
    Kept small on purpose — a few degrees and a couple of percent. At ~20px a
    lean big enough to notice as a lean is big enough to look like a wobble. */
 @keyframes sw-monster-hop {
-  /* IT ENDS ON CONTACT, and that is a timing decision rather than a trim.
+  /* THE CLOSING ARC, and it is deliberately NOT the opening one.
 
-     This animation used to run through the landing: the squash, the rebound and
-     standing were all keyframes here. All three were BAKED, because the flight
-     is a view-transition snapshot and a snapshot cannot deform. Worse, they cost
-     176ms — the feet touched down at 80% of 680ms and the live element did not
-     take over until 680, so the body's real squash and the antennae's whip both
-     began long after the impact they were reacting to. It read as land, pause,
-     sway. The impact and the rebound belong to `sw-body-settle` and
-     `sw-antennae-settle`, which run on live elements and can actually deform.
+     The two directions were unified for a while and then split again, because
+     unified they could not both be right: this shape was signed off, the
+     opening one was not, and the fix the opening needed changed the shape
+     rather than a parameter. Sharing a set of keyframes meant every correction
+     to one silently rewrote the other. Two sets, two names, two clocks — the
+     sidebar picks by direction.
 
-     THE LAST POSE MUST BE NEUTRAL SCALE, because the settle's own 0% is
-     `scale(1, 1)` and any difference between them is a pop at the handover. The
-     yaw is the exception and is carried over deliberately —
-     `sw-monster-untwist` picks it up from exactly this value.
+     -57.216% at the launch is 22% times 2.6007, and that multiplier used to be
+     a custom property. It exists because a percentage here resolves against the
+     SNAPSHOT being transformed, and this direction leaves the 15.05px mark
+     inside the word rather than the 21.88px one alone in the rail — so the same
+     percentage buys a third less lift. With a keyframe set per direction there
+     is nothing left for it to vary, so it is folded in. It puts the creature
+     8.61px up at this stop.
 
-     THE STOPS ARE THE ARC NOW. Paired with the near-constant travel on the
-     group and `linear` above, the vertical values below are read directly as a
-     trajectory rather than being re-eased into one: the apex lands 18.1px up at
-     57% of the travel, which is a jump. The previous numbers put it 11.2px up
-     while the creature was already three quarters of the way across, and the
-     per-segment easing then delivered even that early. */
+     Read with `--sw-hop-ease: cubic-bezier(0.34, 0.8, 0.28, 1)` and the shaped
+     `linear()` travel — see `CLOSE_TRAVEL`. Change any of the three and this
+     shape is gone. */
+  0% {
+    transform: translate(0, 0) rotate(0deg) scale(1, 1);
+  }
+  17% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * -1%), 8%) rotateY(calc(var(--sw-hop-dir, 1) * -3deg)) rotate(calc(var(--sw-hop-dir, 1) * -1deg)) skewX(calc(var(--sw-hop-dir, 1) * 1.5deg)) scale(1.22, 0.78);
+  }
+  32% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2%), -57.216%) rotateY(calc(var(--sw-hop-dir, 1) * 9deg)) rotate(calc(var(--sw-hop-dir, 1) * 4deg)) skewX(calc(var(--sw-hop-dir, 1) * -4deg)) scale(0.84, 1.22);
+  }
+  58% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 3%), -64%) rotateY(calc(var(--sw-hop-dir, 1) * 16deg)) rotate(calc(var(--sw-hop-dir, 1) * 6deg)) skewX(calc(var(--sw-hop-dir, 1) * -7deg)) scale(0.82, 1.24);
+  }
+  82% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1%), -20%) rotateY(calc(var(--sw-hop-dir, 1) * 14deg)) rotate(calc(var(--sw-hop-dir, 1) * -2deg)) skewX(calc(var(--sw-hop-dir, 1) * -3deg)) scale(0.92, 1.1);
+  }
+  100% {
+    transform: perspective(140px) translate(0, 0)
+      rotateY(calc(var(--sw-hop-dir, 1) * 10deg)) rotate(0deg) scale(1, 1);
+  }
+}
+
+@keyframes sw-monster-hop-open {
+  /* THE OPENING ARC: ballistic, where the closing one is shaped.
+
+     A jump has no horizontal force, so its horizontal velocity is CONSTANT and
+     only the vertical accelerates. This set is authored to be read against that
+     — a near-linear travel curve and `linear` between keyframes — so the values
+     below ARE the trajectory rather than a starting point a clock then
+     distorts. The apex lands ~18px up at 57% of the travel.
+
+     TWO DISTORTIONS ARE ABSENT ON PURPOSE, and both were in the opening jump
+     before this. `animation-timing-function` applies between EVERY pair of
+     keyframes, so the eased hop the closing direction uses re-eases each leg:
+     77% of the way to a stop a third into the segment, 92% half way through.
+     Every leg landed early and held, which is what "reaches the apex too early"
+     described. And the travel curve was front-loaded, putting the creature 42%
+     of the way across while still crouching.
+
+     No `--sw-hop-rise` here: this set is authored for the size this direction
+     actually leaves (21.88px, the mark alone in the rail), so there is nothing
+     to compensate. The closing set does the same for its own size. */
   0% {
     transform: translate(0, 0) rotate(0deg) scale(1, 1);
   }
@@ -639,35 +682,21 @@ html {
   14% {
     transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * -1%), 8%) rotateY(calc(var(--sw-hop-dir, 1) * -3deg)) rotate(calc(var(--sw-hop-dir, 1) * -1deg)) skewX(calc(var(--sw-hop-dir, 1) * 1.5deg)) scale(1.22, 0.78);
   }
-  /* THE LAUNCH, and the one stop that needs a per-direction number.
-
-     A percentage here resolves against the SNAPSHOT it is transforming, and the
-     two snapshots are different sizes: the mark is 15.05px inside the word and
-     21.88px alone in the rail. Before the cross-fade starts at 34% you are
-     looking at the OLD snapshot, so this stop's rise is a share of whichever
-     size the creature is LEAVING — which made the two directions physically
-     different jumps until `--sw-hop-rise` compensated for it. The sidebar sets
-     one launch constant and multiplies it by the size ratio for the direction
-     that leaves the smaller snapshot; both then rise 12px here, a 33deg climb
-     out of the crouch.
-
-     ONLY THIS STOP IS SCALED. By the apex the cross-fade has handed most of the
-     way across, so the two apexes land within a pixel of each other on their
-     own (18.1 and 18.8) and scaling them would pull them apart again. */
+  /* The launch: 27% across, 12px up, a 33deg climb out of the crouch. */
   30% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2%), calc(-55% * var(--sw-hop-rise, 1))) rotateY(calc(var(--sw-hop-dir, 1) * 9deg)) rotate(calc(var(--sw-hop-dir, 1) * 4deg)) skewX(calc(var(--sw-hop-dir, 1) * -4deg)) scale(0.84, 1.22);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2%), -55%) rotateY(calc(var(--sw-hop-dir, 1) * 9deg)) rotate(calc(var(--sw-hop-dir, 1) * 4deg)) skewX(calc(var(--sw-hop-dir, 1) * -4deg)) scale(0.84, 1.22);
   }
-  /* THE APEX, over the middle of the trip where a thrown thing has it. */
+  /* The apex, over the middle of the trip where a thrown thing has it. */
   55% {
     transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 3%), -100%) rotateY(calc(var(--sw-hop-dir, 1) * 16deg)) rotate(calc(var(--sw-hop-dir, 1) * 6deg)) skewX(calc(var(--sw-hop-dir, 1) * -7deg)) scale(0.82, 1.24);
   }
-  /* Coming down, and steeper than it went up — which is what landing ON a spot
-     looks like as opposed to sailing past one. */
+  /* Coming down, steeper than it went up — landing ON a spot rather than
+     sailing past one. */
   80% {
     transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1%), -42%) rotateY(calc(var(--sw-hop-dir, 1) * 14deg)) rotate(calc(var(--sw-hop-dir, 1) * -2deg)) skewX(calc(var(--sw-hop-dir, 1) * -3deg)) scale(0.92, 1.1);
   }
-  /* CONTACT. Standing on its feet, still yawed, not yet deformed — the next
-     frame is a live element and the squash starts there. */
+  /* CONTACT. Standing, still yawed, not yet deformed — the next frame is a live
+     element and the squash starts there. */
   100% {
     transform: perspective(140px) translate(0, 0)
       rotateY(calc(var(--sw-hop-dir, 1) * 10deg)) rotate(0deg) scale(1, 1);

--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -678,102 +678,48 @@ html {
 }
 
 @keyframes sw-monster-hop-open {
-  /* THE OPENING ARC: ballistic, where the closing one is shaped.
+  /* THE OPENING ARC: the closing one's SHAPE, foreshortened.
 
-     A jump has no horizontal force, so its horizontal velocity is CONSTANT and
-     only the vertical accelerates. Everything about this set follows from that
-     — a near-linear travel curve on the group, `linear` between these stops,
-     and a lift that carries gravity in its VALUES.
+     It used to be derived from scratch — a symmetric ballistic parabola, a
+     near-linear travel, `linear` between stops so gravity lived in the values.
+     All of that was defensible and all of it read wrong, and tracing the two
+     body centres said why: they were different SILHOUETTES, not different
+     heights. The closing arc peaks at 80% of its travel and DROPS onto the
+     spot at 38 degrees. The opening one peaked at 45% and glided in at 12 —
+     not landing, approaching down a long shallow slope.
 
-     THAT LAST PART IS WHY THERE ARE SEVENTEEN OF THEM. `linear` between five
-     stops was the right fix for one problem and the cause of another: it stops
-     the clock re-easing each leg (an eased hop is 92% of the way to a stop half
-     way through the segment, so every leg lands early), but it also makes the
-     vertical velocity piecewise CONSTANT — a rise at one fixed speed, a corner,
-     a fall at another. That is a balloon, not a body, and it read as floaty.
+     Depth should change how BIG a jump looks, not what shape it is. So this is
+     the closing set's stops, read on the closing set's clock
+     (`--sw-hop-ease: cubic-bezier(0.34, 0.8, 0.28, 1)`) over the closing set's
+     travel — and only the lift is scaled, by 0.70, because this direction ends
+     about 1.45x further from the reader.
 
-     So the lift is sampled from a parabola instead: decelerating up, then
-     accelerating down. Measured across the flight the rise goes +4.34 to +0.48
-     into the apex and the fall +0.75 to -3.75 into the ground, where the five
-     stops gave a flat +2.78 and a flat -2.00. Seventeen samples put the
-     straight segments below the eye's resolution.
+     THE LAUNCH LOSES A COMPENSATION THE CLOSE NEEDS. A percentage here resolves
+     against the snapshot being transformed, and the close leaves the 15.05px
+     mark inside the word while this one leaves the 21.88px mark alone in the
+     rail. The close's -57.216% is 22% times 2.6007 for exactly that reason;
+     dividing it back out by 1.6/1.1 is what makes both launches the same number
+     of PIXELS rather than the same percentage.
 
-     The fall gets more of the clock than the rise (0.36 up, 0.50 down), which
-     is the usual cartoon cheat and also what puts the apex at the middle of the
-     TRAVEL rather than past it.
-
-     THE SQUASH TRACKS THE SPEED, NOT THE CLOCK, and that is the second thing
-     gravity exposed. Keyed to time, the stretch peaked at the apex — the
-     creature was at its most elongated exactly where its vertical velocity is
-     ZERO, ballooning at the top of the arc and rounding up as it accelerated
-     down. It was always inverted; it was only invisible while the lift moved at
-     a constant speed, because then nothing contradicted it.
-
-     So the scale is computed from |dy/dt| instead: 1.22 x 0.78 crouched on the
-     ground, unfolding to 0.82 x 1.24 at full speed just after the push-off,
-     ROUND at the apex, and stretching again into the landing as the fall
-     accelerates. The extremes are the ones the arc already used — only what
-     they are keyed to changed.
-
-     It TAPERS BACK TO NEUTRAL over the last sixth, because the settle's own 0%
-     is `scale(1, 1)` on a live element: hand over a stretched creature to a
-     round one and that is a pop in a single frame. Tracking speed alone would
-     have arrived at 1.17. The impact squash is `sw-body-settle`'s job anyway,
-     and it can do it properly, being an element rather than a photograph.
-
-     The yaw and the lean still come from the original control stops,
-     interpolated at the new sample points. Regenerate this block rather than
-     editing a stop by hand. */
+     Regenerate with `mirror.py <scale>` rather than editing a stop. */
   0% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0%), 0%) rotateY(calc(var(--sw-hop-dir, 1) * 0deg)) rotate(calc(var(--sw-hop-dir, 1) * 0deg)) skewX(calc(var(--sw-hop-dir, 1) * 0deg)) scale(1, 1);
+    transform: translate(0, 0) rotate(0deg) scale(1, 1);
   }
-  6.25% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * -0.4464%), 3.571%) rotateY(calc(var(--sw-hop-dir, 1) * -1.339deg)) rotate(calc(var(--sw-hop-dir, 1) * -0.4464deg)) skewX(calc(var(--sw-hop-dir, 1) * 0.6696deg)) scale(1.098, 0.9018);
+  17% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * -1%), 8%) rotateY(calc(var(--sw-hop-dir, 1) * -3deg)) rotate(calc(var(--sw-hop-dir, 1) * -1deg)) skewX(calc(var(--sw-hop-dir, 1) * 1.5deg)) scale(1.22, 0.78);
   }
-  12.5% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * -0.8929%), 7.143%) rotateY(calc(var(--sw-hop-dir, 1) * -2.679deg)) rotate(calc(var(--sw-hop-dir, 1) * -0.8929deg)) skewX(calc(var(--sw-hop-dir, 1) * 1.339deg)) scale(1.196, 0.8036);
+  32% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2%), -27.54%) rotateY(calc(var(--sw-hop-dir, 1) * 9deg)) rotate(calc(var(--sw-hop-dir, 1) * 4deg)) skewX(calc(var(--sw-hop-dir, 1) * -4deg)) scale(0.84, 1.22);
   }
-  18.75% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * -0.1094%), -15.28%) rotateY(calc(var(--sw-hop-dir, 1) * 0.5625deg)) rotate(calc(var(--sw-hop-dir, 1) * 0.4844deg)) skewX(calc(var(--sw-hop-dir, 1) * -0.1328deg)) scale(1.041, 0.9835);
+  58% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 3%), -44.8%) rotateY(calc(var(--sw-hop-dir, 1) * 16deg)) rotate(calc(var(--sw-hop-dir, 1) * 6deg)) skewX(calc(var(--sw-hop-dir, 1) * -7deg)) scale(0.82, 1.24);
   }
-  25% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1.062%), -32.1%) rotateY(calc(var(--sw-hop-dir, 1) * 5.25deg)) rotate(calc(var(--sw-hop-dir, 1) * 2.438deg)) skewX(calc(var(--sw-hop-dir, 1) * -2.281deg)) scale(0.875, 1.167);
-  }
-  31.25% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.062%), -45.18%) rotateY(calc(var(--sw-hop-dir, 1) * 9.438deg)) rotate(calc(var(--sw-hop-dir, 1) * 4.125deg)) skewX(calc(var(--sw-hop-dir, 1) * -4.188deg)) scale(0.9062, 1.125);
-  }
-  37.5% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.375%), -54.53%) rotateY(calc(var(--sw-hop-dir, 1) * 11.62deg)) rotate(calc(var(--sw-hop-dir, 1) * 4.75deg)) skewX(calc(var(--sw-hop-dir, 1) * -5.125deg)) scale(0.9375, 1.083);
-  }
-  43.75% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.688%), -60.13%) rotateY(calc(var(--sw-hop-dir, 1) * 13.81deg)) rotate(calc(var(--sw-hop-dir, 1) * 5.375deg)) skewX(calc(var(--sw-hop-dir, 1) * -6.062deg)) scale(0.9688, 1.042);
-  }
-  50% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 3%), -62%) rotateY(calc(var(--sw-hop-dir, 1) * 16deg)) rotate(calc(var(--sw-hop-dir, 1) * 6deg)) skewX(calc(var(--sw-hop-dir, 1) * -7deg)) scale(1, 1);
-  }
-  56.25% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.554%), -61.03%) rotateY(calc(var(--sw-hop-dir, 1) * 15.55deg)) rotate(calc(var(--sw-hop-dir, 1) * 4.214deg)) skewX(calc(var(--sw-hop-dir, 1) * -6.107deg)) scale(0.9838, 1.022);
-  }
-  62.5% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.107%), -58.13%) rotateY(calc(var(--sw-hop-dir, 1) * 15.11deg)) rotate(calc(var(--sw-hop-dir, 1) * 2.429deg)) skewX(calc(var(--sw-hop-dir, 1) * -5.214deg)) scale(0.9676, 1.043);
-  }
-  68.75% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1.661%), -53.28%) rotateY(calc(var(--sw-hop-dir, 1) * 14.66deg)) rotate(calc(var(--sw-hop-dir, 1) * 0.6429deg)) skewX(calc(var(--sw-hop-dir, 1) * -4.321deg)) scale(0.9514, 1.065);
-  }
-  75% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1.214%), -46.5%) rotateY(calc(var(--sw-hop-dir, 1) * 14.21deg)) rotate(calc(var(--sw-hop-dir, 1) * -1.143deg)) skewX(calc(var(--sw-hop-dir, 1) * -3.429deg)) scale(0.9352, 1.086);
-  }
-  81.25% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0.8523%), -37.78%) rotateY(calc(var(--sw-hop-dir, 1) * 13.41deg)) rotate(calc(var(--sw-hop-dir, 1) * -1.705deg)) skewX(calc(var(--sw-hop-dir, 1) * -2.557deg)) scale(0.919, 1.108);
-  }
-  87.5% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0.5682%), -27.12%) rotateY(calc(var(--sw-hop-dir, 1) * 12.27deg)) rotate(calc(var(--sw-hop-dir, 1) * -1.136deg)) skewX(calc(var(--sw-hop-dir, 1) * -1.705deg)) scale(0.9241, 1.101);
-  }
-  93.75% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0.2841%), -14.53%) rotateY(calc(var(--sw-hop-dir, 1) * 11.14deg)) rotate(calc(var(--sw-hop-dir, 1) * -0.5682deg)) skewX(calc(var(--sw-hop-dir, 1) * -0.8523deg)) scale(0.9557, 1.059);
+  82% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1%), -14%) rotateY(calc(var(--sw-hop-dir, 1) * 14deg)) rotate(calc(var(--sw-hop-dir, 1) * -2deg)) skewX(calc(var(--sw-hop-dir, 1) * -3deg)) scale(0.92, 1.1);
   }
   100% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0%), -0%) rotateY(calc(var(--sw-hop-dir, 1) * 10deg)) rotate(calc(var(--sw-hop-dir, 1) * 0deg)) skewX(calc(var(--sw-hop-dir, 1) * 0deg)) scale(1, 1);
+    transform: perspective(140px) translate(0, 0)
+      rotateY(calc(var(--sw-hop-dir, 1) * 10deg)) rotate(0deg) scale(1, 1);
   }
 }
 

--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -380,7 +380,7 @@ html {
      The fallback is the closing curve, so a missing property cannot silently
      turn either of them into the front-loaded easing this replaced — that one
      had the creature 42% of the way across while still crouching. */
-  animation-duration: 620ms;
+  animation-duration: var(--sw-group-ms, 620ms);
   animation-timing-function: var(
     --sw-group-ease,
     linear(0 0%, 0.008508 6%, 0.01694 11%, 0.02907 17%, 0.0522 22%,
@@ -424,9 +424,31 @@ html {
    body's own if either ever moves — and the failure mode is at least loud, since
    a mismatch shows up as this same square rather than as nothing. */
 ::view-transition-group(sw-monster) {
-  background-color: rgb(9 9 11);
-  background-image: linear-gradient(
-    oklab(0.21 0.00164225 -0.00577088 / 0.5) 0 100%
+  /* AND IT IS NOT ALWAYS A FIX, which is why it is a variable.
+
+     This is an OPAQUE rectangle at `z-index: 10`, sized to the mark's box and
+     TRAVELLING with the group. It hides the hole only while the hole is under
+     it — and the hole is at the mark's LAYOUT position while the group is
+     wherever the interpolation has got to, so the two coincide at the ends of
+     the flight and nowhere in between.
+
+     That went unnoticed for as long as the creature stayed inside its own box:
+     the filler was behind the drawing, so whatever it covered was covered
+     anyway. The opening arc lifts the creature a full box height clear, and the
+     filler came out from under it — measured mid-flight as a 19.4px opaque
+     `rgb(9 9 11)` rectangle dragging across the wordmark and blanking the
+     letters the transition was in the middle of revealing.
+
+     So the OPENING direction sets it to `transparent`, which was verified by
+     eye: with the filler off the lockup reads "storyboard m nster" with the
+     creature airborne over the gap and no dark square anywhere. The hole this
+     was added for does not occur in that direction.
+
+     The CLOSING direction keeps it, and the default below is that value, so a
+     missing property cannot silently reintroduce the black square it fixed. */
+  background: var(
+    --sw-group-fill,
+    rgb(9 9 11) linear-gradient(oklab(0.21 0.00164225 -0.00577088 / 0.5) 0 100%)
   );
 }
 
@@ -686,13 +708,17 @@ html {
   30% {
     transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2%), -55%) rotateY(calc(var(--sw-hop-dir, 1) * 9deg)) rotate(calc(var(--sw-hop-dir, 1) * 4deg)) skewX(calc(var(--sw-hop-dir, 1) * -4deg)) scale(0.84, 1.22);
   }
-  /* The apex, over the middle of the trip where a thrown thing has it. */
-  55% {
+  /* The apex, and it sits over the MIDDLE of the trip -- 51% of the travel at
+     51% of the time, which is where a thrown thing has it. It was at 57% and
+     moved back slightly; the arc gets a touch taller as a side effect (19.0px
+     against 18.1) because the climb now finishes sooner against the same
+     stops. */
+  50% {
     transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 3%), -100%) rotateY(calc(var(--sw-hop-dir, 1) * 16deg)) rotate(calc(var(--sw-hop-dir, 1) * 6deg)) skewX(calc(var(--sw-hop-dir, 1) * -7deg)) scale(0.82, 1.24);
   }
   /* Coming down, steeper than it went up — landing ON a spot rather than
      sailing past one. */
-  80% {
+  78% {
     transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1%), -42%) rotateY(calc(var(--sw-hop-dir, 1) * 14deg)) rotate(calc(var(--sw-hop-dir, 1) * -2deg)) skewX(calc(var(--sw-hop-dir, 1) * -3deg)) scale(0.92, 1.1);
   }
   /* CONTACT. Standing, still yawed, not yet deformed — the next frame is a live

--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -681,51 +681,81 @@ html {
   /* THE OPENING ARC: ballistic, where the closing one is shaped.
 
      A jump has no horizontal force, so its horizontal velocity is CONSTANT and
-     only the vertical accelerates. This set is authored to be read against that
-     — a near-linear travel curve and `linear` between keyframes — so the values
-     below ARE the trajectory rather than a starting point a clock then
-     distorts. The apex lands ~18px up at 57% of the travel.
+     only the vertical accelerates. Everything about this set follows from that
+     — a near-linear travel curve on the group, `linear` between these stops,
+     and a lift that carries gravity in its VALUES.
 
-     TWO DISTORTIONS ARE ABSENT ON PURPOSE, and both were in the opening jump
-     before this. `animation-timing-function` applies between EVERY pair of
-     keyframes, so the eased hop the closing direction uses re-eases each leg:
-     77% of the way to a stop a third into the segment, 92% half way through.
-     Every leg landed early and held, which is what "reaches the apex too early"
-     described. And the travel curve was front-loaded, putting the creature 42%
-     of the way across while still crouching.
+     THAT LAST PART IS WHY THERE ARE SEVENTEEN OF THEM. `linear` between five
+     stops was the right fix for one problem and the cause of another: it stops
+     the clock re-easing each leg (an eased hop is 92% of the way to a stop half
+     way through the segment, so every leg lands early), but it also makes the
+     vertical velocity piecewise CONSTANT — a rise at one fixed speed, a corner,
+     a fall at another. That is a balloon, not a body, and it read as floaty.
 
-     No `--sw-hop-rise` here: this set is authored for the size this direction
-     actually leaves (21.88px, the mark alone in the rail), so there is nothing
-     to compensate. The closing set does the same for its own size. */
+     So the lift is sampled from a parabola instead: decelerating up, then
+     accelerating down. Measured across the flight the rise goes +4.34 to +0.48
+     into the apex and the fall +0.75 to -3.75 into the ground, where the five
+     stops gave a flat +2.78 and a flat -2.00. Seventeen samples put the
+     straight segments below the eye's resolution.
+
+     The fall gets more of the clock than the rise (0.36 up, 0.50 down), which
+     is the usual cartoon cheat and also what puts the apex at the middle of the
+     TRAVEL rather than past it.
+
+     Every other channel — the yaw, the lean, the squash — keeps the values it
+     had at the original control stops and is simply interpolated at the new
+     ones, so only the lift changed. Regenerate this block rather than editing a
+     stop by hand. */
   0% {
-    transform: translate(0, 0) rotate(0deg) scale(1, 1);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0%), 0%) rotateY(calc(var(--sw-hop-dir, 1) * 0deg)) rotate(calc(var(--sw-hop-dir, 1) * 0deg)) skewX(calc(var(--sw-hop-dir, 1) * 0deg)) scale(1, 1);
   }
-  /* The crouch, and it barely moves: 11% of the trip, still on the ground. */
-  14% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * -1%), 8%) rotateY(calc(var(--sw-hop-dir, 1) * -3deg)) rotate(calc(var(--sw-hop-dir, 1) * -1deg)) skewX(calc(var(--sw-hop-dir, 1) * 1.5deg)) scale(1.22, 0.78);
+  6.25% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * -0.4464%), 3.571%) rotateY(calc(var(--sw-hop-dir, 1) * -1.339deg)) rotate(calc(var(--sw-hop-dir, 1) * -0.4464deg)) skewX(calc(var(--sw-hop-dir, 1) * 0.6696deg)) scale(1.098, 0.9018);
   }
-  /* The launch: 27% across, 12px up, a 33deg climb out of the crouch. */
-  30% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2%), -55%) rotateY(calc(var(--sw-hop-dir, 1) * 9deg)) rotate(calc(var(--sw-hop-dir, 1) * 4deg)) skewX(calc(var(--sw-hop-dir, 1) * -4deg)) scale(0.84, 1.22);
+  12.5% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * -0.8929%), 7.143%) rotateY(calc(var(--sw-hop-dir, 1) * -2.679deg)) rotate(calc(var(--sw-hop-dir, 1) * -0.8929deg)) skewX(calc(var(--sw-hop-dir, 1) * 1.339deg)) scale(1.196, 0.8036);
   }
-  /* The apex, and it sits over the MIDDLE of the trip -- 51% of the travel at
-     51% of the time, which is where a thrown thing has it. It was at 57% and
-     moved back slightly; the arc gets a touch taller as a side effect (19.0px
-     against 18.1) because the climb now finishes sooner against the same
-     stops. */
+  18.75% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * -0.1094%), -24.65%) rotateY(calc(var(--sw-hop-dir, 1) * 0.5625deg)) rotate(calc(var(--sw-hop-dir, 1) * 0.4844deg)) skewX(calc(var(--sw-hop-dir, 1) * -0.1328deg)) scale(1.107, 0.9106);
+  }
+  25% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1.062%), -51.77%) rotateY(calc(var(--sw-hop-dir, 1) * 5.25deg)) rotate(calc(var(--sw-hop-dir, 1) * 2.438deg)) skewX(calc(var(--sw-hop-dir, 1) * -2.281deg)) scale(0.9587, 1.083);
+  }
+  31.25% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.062%), -72.87%) rotateY(calc(var(--sw-hop-dir, 1) * 9.438deg)) rotate(calc(var(--sw-hop-dir, 1) * 4.125deg)) skewX(calc(var(--sw-hop-dir, 1) * -4.188deg)) scale(0.8387, 1.221);
+  }
+  37.5% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.375%), -87.94%) rotateY(calc(var(--sw-hop-dir, 1) * 11.62deg)) rotate(calc(var(--sw-hop-dir, 1) * 4.75deg)) skewX(calc(var(--sw-hop-dir, 1) * -5.125deg)) scale(0.8325, 1.228);
+  }
+  43.75% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.688%), -96.99%) rotateY(calc(var(--sw-hop-dir, 1) * 13.81deg)) rotate(calc(var(--sw-hop-dir, 1) * 5.375deg)) skewX(calc(var(--sw-hop-dir, 1) * -6.062deg)) scale(0.8262, 1.234);
+  }
   50% {
     transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 3%), -100%) rotateY(calc(var(--sw-hop-dir, 1) * 16deg)) rotate(calc(var(--sw-hop-dir, 1) * 6deg)) skewX(calc(var(--sw-hop-dir, 1) * -7deg)) scale(0.82, 1.24);
   }
-  /* Coming down, steeper than it went up — landing ON a spot rather than
-     sailing past one. */
-  78% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1%), -42%) rotateY(calc(var(--sw-hop-dir, 1) * 14deg)) rotate(calc(var(--sw-hop-dir, 1) * -2deg)) skewX(calc(var(--sw-hop-dir, 1) * -3deg)) scale(0.92, 1.1);
+  56.25% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.554%), -98.44%) rotateY(calc(var(--sw-hop-dir, 1) * 15.55deg)) rotate(calc(var(--sw-hop-dir, 1) * 4.214deg)) skewX(calc(var(--sw-hop-dir, 1) * -6.107deg)) scale(0.8423, 1.209);
   }
-  /* CONTACT. Standing, still yawed, not yet deformed — the next frame is a live
-     element and the squash starts there. */
+  62.5% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.107%), -93.75%) rotateY(calc(var(--sw-hop-dir, 1) * 15.11deg)) rotate(calc(var(--sw-hop-dir, 1) * 2.429deg)) skewX(calc(var(--sw-hop-dir, 1) * -5.214deg)) scale(0.8646, 1.177);
+  }
+  68.75% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1.661%), -85.94%) rotateY(calc(var(--sw-hop-dir, 1) * 14.66deg)) rotate(calc(var(--sw-hop-dir, 1) * 0.6429deg)) skewX(calc(var(--sw-hop-dir, 1) * -4.321deg)) scale(0.887, 1.146);
+  }
+  75% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1.214%), -75%) rotateY(calc(var(--sw-hop-dir, 1) * 14.21deg)) rotate(calc(var(--sw-hop-dir, 1) * -1.143deg)) skewX(calc(var(--sw-hop-dir, 1) * -3.429deg)) scale(0.9093, 1.115);
+  }
+  81.25% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0.8523%), -60.94%) rotateY(calc(var(--sw-hop-dir, 1) * 13.41deg)) rotate(calc(var(--sw-hop-dir, 1) * -1.705deg)) skewX(calc(var(--sw-hop-dir, 1) * -2.557deg)) scale(0.9318, 1.085);
+  }
+  87.5% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0.5682%), -43.75%) rotateY(calc(var(--sw-hop-dir, 1) * 12.27deg)) rotate(calc(var(--sw-hop-dir, 1) * -1.136deg)) skewX(calc(var(--sw-hop-dir, 1) * -1.705deg)) scale(0.9545, 1.057);
+  }
+  93.75% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0.2841%), -23.44%) rotateY(calc(var(--sw-hop-dir, 1) * 11.14deg)) rotate(calc(var(--sw-hop-dir, 1) * -0.5682deg)) skewX(calc(var(--sw-hop-dir, 1) * -0.8523deg)) scale(0.9773, 1.028);
+  }
   100% {
-    transform: perspective(140px) translate(0, 0)
-      rotateY(calc(var(--sw-hop-dir, 1) * 10deg)) rotate(0deg) scale(1, 1);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0%), -0%) rotateY(calc(var(--sw-hop-dir, 1) * 10deg)) rotate(calc(var(--sw-hop-dir, 1) * 0deg)) skewX(calc(var(--sw-hop-dir, 1) * 0deg)) scale(1, 1);
   }
 }
 

--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -701,21 +701,29 @@ html {
      dividing it back out by 1.6/1.1 is what makes both launches the same number
      of PIXELS rather than the same percentage.
 
+     ONE THING IS NOT THE CLOSE'S: THE SQUASH. Its scales are keyed to the
+     clock and peak at its apex -- most stretched exactly where the vertical
+     velocity reverses through zero -- and copying the shape copied that too.
+     Here the stretch comes from the lift's own segment speeds instead: round at
+     the top, stretched where the creature is actually moving, neutral at
+     contact because the settle's 0% is scale(1, 1) on a live element and
+     anything else is a pop.
+
      Regenerate with `mirror.py <scale>` rather than editing a stop. */
   0% {
     transform: translate(0, 0) rotate(0deg) scale(1, 1);
   }
   17% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * -1%), 8%) rotateY(calc(var(--sw-hop-dir, 1) * -3deg)) rotate(calc(var(--sw-hop-dir, 1) * -1deg)) skewX(calc(var(--sw-hop-dir, 1) * 1.5deg)) scale(1.22, 0.78);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * -1%), 8%) rotateY(calc(var(--sw-hop-dir, 1) * -3deg)) rotate(calc(var(--sw-hop-dir, 1) * -1deg)) skewX(calc(var(--sw-hop-dir, 1) * 1.5deg)) scale(1.220, 0.780);
   }
   32% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2%), -27.54%) rotateY(calc(var(--sw-hop-dir, 1) * 9deg)) rotate(calc(var(--sw-hop-dir, 1) * 4deg)) skewX(calc(var(--sw-hop-dir, 1) * -4deg)) scale(0.84, 1.22);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2%), -27.54%) rotateY(calc(var(--sw-hop-dir, 1) * 9deg)) rotate(calc(var(--sw-hop-dir, 1) * 4deg)) skewX(calc(var(--sw-hop-dir, 1) * -4deg)) scale(0.820, 1.240);
   }
   58% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 3%), -44.8%) rotateY(calc(var(--sw-hop-dir, 1) * 16deg)) rotate(calc(var(--sw-hop-dir, 1) * 6deg)) skewX(calc(var(--sw-hop-dir, 1) * -7deg)) scale(0.82, 1.24);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 3%), -44.8%) rotateY(calc(var(--sw-hop-dir, 1) * 16deg)) rotate(calc(var(--sw-hop-dir, 1) * 6deg)) skewX(calc(var(--sw-hop-dir, 1) * -7deg)) scale(1.000, 1.000);
   }
   82% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1%), -14%) rotateY(calc(var(--sw-hop-dir, 1) * 14deg)) rotate(calc(var(--sw-hop-dir, 1) * -2deg)) skewX(calc(var(--sw-hop-dir, 1) * -3deg)) scale(0.92, 1.1);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1%), -14%) rotateY(calc(var(--sw-hop-dir, 1) * 14deg)) rotate(calc(var(--sw-hop-dir, 1) * -2deg)) skewX(calc(var(--sw-hop-dir, 1) * -3deg)) scale(0.902, 1.130);
   }
   100% {
     transform: perspective(140px) translate(0, 0)

--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -366,8 +366,13 @@ html {
      a slight bump in it, which is exactly what "skimming" describes. No amount
      of extra height fixes a launch that has already happened.
 
-     So it is a variable now, and the closing direction gets a slow-start curve
-     that keeps the ground under the creature until it has actually left it.
+     So it is a variable now, and the closing direction gets its own travel —
+     a `linear()` shaped to hold the ground under the creature until it has
+     actually left it, and then to put the APEX near the landing instead of back
+     over the middle of the trip. The three points it is solved for, and why a
+     cubic-bezier could not hit all three, are in `CLOSE_TRAVEL` in
+     `timeline-sidebar.tsx`.
+
      Opening keeps this one — it reads correctly, and the fallback here is that
      same value so a missing property cannot change it. */
   animation-duration: 620ms;

--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -702,10 +702,28 @@ html {
      is the usual cartoon cheat and also what puts the apex at the middle of the
      TRAVEL rather than past it.
 
-     Every other channel — the yaw, the lean, the squash — keeps the values it
-     had at the original control stops and is simply interpolated at the new
-     ones, so only the lift changed. Regenerate this block rather than editing a
-     stop by hand. */
+     THE SQUASH TRACKS THE SPEED, NOT THE CLOCK, and that is the second thing
+     gravity exposed. Keyed to time, the stretch peaked at the apex — the
+     creature was at its most elongated exactly where its vertical velocity is
+     ZERO, ballooning at the top of the arc and rounding up as it accelerated
+     down. It was always inverted; it was only invisible while the lift moved at
+     a constant speed, because then nothing contradicted it.
+
+     So the scale is computed from |dy/dt| instead: 1.22 x 0.78 crouched on the
+     ground, unfolding to 0.82 x 1.24 at full speed just after the push-off,
+     ROUND at the apex, and stretching again into the landing as the fall
+     accelerates. The extremes are the ones the arc already used — only what
+     they are keyed to changed.
+
+     It TAPERS BACK TO NEUTRAL over the last sixth, because the settle's own 0%
+     is `scale(1, 1)` on a live element: hand over a stretched creature to a
+     round one and that is a pop in a single frame. Tracking speed alone would
+     have arrived at 1.17. The impact squash is `sw-body-settle`'s job anyway,
+     and it can do it properly, being an element rather than a photograph.
+
+     The yaw and the lean still come from the original control stops,
+     interpolated at the new sample points. Regenerate this block rather than
+     editing a stop by hand. */
   0% {
     transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0%), 0%) rotateY(calc(var(--sw-hop-dir, 1) * 0deg)) rotate(calc(var(--sw-hop-dir, 1) * 0deg)) skewX(calc(var(--sw-hop-dir, 1) * 0deg)) scale(1, 1);
   }
@@ -716,43 +734,43 @@ html {
     transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * -0.8929%), 7.143%) rotateY(calc(var(--sw-hop-dir, 1) * -2.679deg)) rotate(calc(var(--sw-hop-dir, 1) * -0.8929deg)) skewX(calc(var(--sw-hop-dir, 1) * 1.339deg)) scale(1.196, 0.8036);
   }
   18.75% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * -0.1094%), -24.65%) rotateY(calc(var(--sw-hop-dir, 1) * 0.5625deg)) rotate(calc(var(--sw-hop-dir, 1) * 0.4844deg)) skewX(calc(var(--sw-hop-dir, 1) * -0.1328deg)) scale(1.107, 0.9106);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * -0.1094%), -24.65%) rotateY(calc(var(--sw-hop-dir, 1) * 0.5625deg)) rotate(calc(var(--sw-hop-dir, 1) * 0.4844deg)) skewX(calc(var(--sw-hop-dir, 1) * -0.1328deg)) scale(1.041, 0.9835);
   }
   25% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1.062%), -51.77%) rotateY(calc(var(--sw-hop-dir, 1) * 5.25deg)) rotate(calc(var(--sw-hop-dir, 1) * 2.438deg)) skewX(calc(var(--sw-hop-dir, 1) * -2.281deg)) scale(0.9587, 1.083);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1.062%), -51.77%) rotateY(calc(var(--sw-hop-dir, 1) * 5.25deg)) rotate(calc(var(--sw-hop-dir, 1) * 2.438deg)) skewX(calc(var(--sw-hop-dir, 1) * -2.281deg)) scale(0.875, 1.167);
   }
   31.25% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.062%), -72.87%) rotateY(calc(var(--sw-hop-dir, 1) * 9.438deg)) rotate(calc(var(--sw-hop-dir, 1) * 4.125deg)) skewX(calc(var(--sw-hop-dir, 1) * -4.188deg)) scale(0.8387, 1.221);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.062%), -72.87%) rotateY(calc(var(--sw-hop-dir, 1) * 9.438deg)) rotate(calc(var(--sw-hop-dir, 1) * 4.125deg)) skewX(calc(var(--sw-hop-dir, 1) * -4.188deg)) scale(0.9062, 1.125);
   }
   37.5% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.375%), -87.94%) rotateY(calc(var(--sw-hop-dir, 1) * 11.62deg)) rotate(calc(var(--sw-hop-dir, 1) * 4.75deg)) skewX(calc(var(--sw-hop-dir, 1) * -5.125deg)) scale(0.8325, 1.228);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.375%), -87.94%) rotateY(calc(var(--sw-hop-dir, 1) * 11.62deg)) rotate(calc(var(--sw-hop-dir, 1) * 4.75deg)) skewX(calc(var(--sw-hop-dir, 1) * -5.125deg)) scale(0.9375, 1.083);
   }
   43.75% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.688%), -96.99%) rotateY(calc(var(--sw-hop-dir, 1) * 13.81deg)) rotate(calc(var(--sw-hop-dir, 1) * 5.375deg)) skewX(calc(var(--sw-hop-dir, 1) * -6.062deg)) scale(0.8262, 1.234);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.688%), -96.99%) rotateY(calc(var(--sw-hop-dir, 1) * 13.81deg)) rotate(calc(var(--sw-hop-dir, 1) * 5.375deg)) skewX(calc(var(--sw-hop-dir, 1) * -6.062deg)) scale(0.9688, 1.042);
   }
   50% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 3%), -100%) rotateY(calc(var(--sw-hop-dir, 1) * 16deg)) rotate(calc(var(--sw-hop-dir, 1) * 6deg)) skewX(calc(var(--sw-hop-dir, 1) * -7deg)) scale(0.82, 1.24);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 3%), -100%) rotateY(calc(var(--sw-hop-dir, 1) * 16deg)) rotate(calc(var(--sw-hop-dir, 1) * 6deg)) skewX(calc(var(--sw-hop-dir, 1) * -7deg)) scale(1, 1);
   }
   56.25% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.554%), -98.44%) rotateY(calc(var(--sw-hop-dir, 1) * 15.55deg)) rotate(calc(var(--sw-hop-dir, 1) * 4.214deg)) skewX(calc(var(--sw-hop-dir, 1) * -6.107deg)) scale(0.8423, 1.209);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.554%), -98.44%) rotateY(calc(var(--sw-hop-dir, 1) * 15.55deg)) rotate(calc(var(--sw-hop-dir, 1) * 4.214deg)) skewX(calc(var(--sw-hop-dir, 1) * -6.107deg)) scale(0.9838, 1.022);
   }
   62.5% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.107%), -93.75%) rotateY(calc(var(--sw-hop-dir, 1) * 15.11deg)) rotate(calc(var(--sw-hop-dir, 1) * 2.429deg)) skewX(calc(var(--sw-hop-dir, 1) * -5.214deg)) scale(0.8646, 1.177);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.107%), -93.75%) rotateY(calc(var(--sw-hop-dir, 1) * 15.11deg)) rotate(calc(var(--sw-hop-dir, 1) * 2.429deg)) skewX(calc(var(--sw-hop-dir, 1) * -5.214deg)) scale(0.9676, 1.043);
   }
   68.75% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1.661%), -85.94%) rotateY(calc(var(--sw-hop-dir, 1) * 14.66deg)) rotate(calc(var(--sw-hop-dir, 1) * 0.6429deg)) skewX(calc(var(--sw-hop-dir, 1) * -4.321deg)) scale(0.887, 1.146);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1.661%), -85.94%) rotateY(calc(var(--sw-hop-dir, 1) * 14.66deg)) rotate(calc(var(--sw-hop-dir, 1) * 0.6429deg)) skewX(calc(var(--sw-hop-dir, 1) * -4.321deg)) scale(0.9514, 1.065);
   }
   75% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1.214%), -75%) rotateY(calc(var(--sw-hop-dir, 1) * 14.21deg)) rotate(calc(var(--sw-hop-dir, 1) * -1.143deg)) skewX(calc(var(--sw-hop-dir, 1) * -3.429deg)) scale(0.9093, 1.115);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1.214%), -75%) rotateY(calc(var(--sw-hop-dir, 1) * 14.21deg)) rotate(calc(var(--sw-hop-dir, 1) * -1.143deg)) skewX(calc(var(--sw-hop-dir, 1) * -3.429deg)) scale(0.9352, 1.086);
   }
   81.25% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0.8523%), -60.94%) rotateY(calc(var(--sw-hop-dir, 1) * 13.41deg)) rotate(calc(var(--sw-hop-dir, 1) * -1.705deg)) skewX(calc(var(--sw-hop-dir, 1) * -2.557deg)) scale(0.9318, 1.085);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0.8523%), -60.94%) rotateY(calc(var(--sw-hop-dir, 1) * 13.41deg)) rotate(calc(var(--sw-hop-dir, 1) * -1.705deg)) skewX(calc(var(--sw-hop-dir, 1) * -2.557deg)) scale(0.919, 1.108);
   }
   87.5% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0.5682%), -43.75%) rotateY(calc(var(--sw-hop-dir, 1) * 12.27deg)) rotate(calc(var(--sw-hop-dir, 1) * -1.136deg)) skewX(calc(var(--sw-hop-dir, 1) * -1.705deg)) scale(0.9545, 1.057);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0.5682%), -43.75%) rotateY(calc(var(--sw-hop-dir, 1) * 12.27deg)) rotate(calc(var(--sw-hop-dir, 1) * -1.136deg)) skewX(calc(var(--sw-hop-dir, 1) * -1.705deg)) scale(0.9241, 1.101);
   }
   93.75% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0.2841%), -23.44%) rotateY(calc(var(--sw-hop-dir, 1) * 11.14deg)) rotate(calc(var(--sw-hop-dir, 1) * -0.5682deg)) skewX(calc(var(--sw-hop-dir, 1) * -0.8523deg)) scale(0.9773, 1.028);
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0.2841%), -23.44%) rotateY(calc(var(--sw-hop-dir, 1) * 11.14deg)) rotate(calc(var(--sw-hop-dir, 1) * -0.5682deg)) skewX(calc(var(--sw-hop-dir, 1) * -0.8523deg)) scale(0.9557, 1.059);
   }
   100% {
     transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0%), -0%) rotateY(calc(var(--sw-hop-dir, 1) * 10deg)) rotate(calc(var(--sw-hop-dir, 1) * 0deg)) skewX(calc(var(--sw-hop-dir, 1) * 0deg)) scale(1, 1);

--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -366,36 +366,32 @@ html {
      a slight bump in it, which is exactly what "skimming" describes. No amount
      of extra height fixes a launch that has already happened.
 
-     So it is shaped rather than eased. Three things have to be true of the
-     travel at once, and no cubic-bezier holds all three:
+     A JUMP HAS NO HORIZONTAL FORCE, so its horizontal velocity is CONSTANT
+     and only the vertical accelerates. That one fact is the whole specification
+     for this curve, and two earlier attempts got it wrong in opposite
+     directions.
 
-       17%    3% across   the crouch happens IN PLACE, not while sliding
-       32%   13% across   paired with the rise, a ~37deg climb out of the ground
-       58%   82% across   the apex sits near the landing, not back over the
-                          middle of the trip
+     `cubic-bezier(0.34, 0.8, 0.28, 1)` was heavily front-loaded: the creature
+     was 42% of the way across while still below the ground in its crouch, and
+     75% of the way by the time it had risen at all. That is a skim.
 
-     Anything slow enough for the first two decelerates through the third.
-     `cubic-bezier(0.65, 0, 0.35, 1)` held the launch beautifully and then put
-     the apex at 71% of the travel, so the creature topped out over open ground.
-     A slow start AND a fast middle AND a settle is not a shape a single cubic
-     has; `linear()` is.
+     Over-correcting with a shaped `linear()` that held the ground until 32% of
+     the time then caught up made it worse in a subtler way — peak speed 3.4x
+     the mean around the midpoint, against 0.15x at the start. It read as a
+     creature being fired out of something.
 
-     BOTH DIRECTIONS USE IT, which is why this is a literal and not a variable
-     any more. Travel is a progress curve — it says how much of the trip has
-     happened, not which way — so the same shape serves the jump out of the rail
-     and the jump back into the word. The only thing that differs by direction
-     is `--sw-hop-rise`, and it differs for a reason that is about the snapshot
-     SIZES rather than about the arc (see the 32% stop below).
+     So: near-linear, with only enough ease at the ends to cover the crouch and
+     the landing. Peak speed is 1.22x the mean across the whole flight, which is
+     as close to ballistic as a transition with a start and a stop gets. The
+     ARC comes from the keyframes now, not from a distorted clock — which is
+     where it belonged all along.
 
-     Generated as a monotone cubic through those control points and sampled at
-     19 stops: monotone so the interpolation can never overshoot and send the
-     creature briefly backwards, and 19 so the segments sit below the eye's
-     resolution at this speed. Regenerate it rather than hand-editing a stop. */
+     BOTH DIRECTIONS USE IT. Travel is a progress curve; it says how much of the
+     trip has happened, not which way. The only thing that differs by direction
+     is `--sw-hop-rise`, and it differs because of the snapshot SIZES rather
+     than because the two arcs should differ (see the launch stop below). */
   animation-duration: 620ms;
-  animation-timing-function: linear(0 0%, 0.008508 6%, 0.01694 11%, 0.02907 17%, 0.0522 22%,
-    0.09105 28%, 0.1467 33%, 0.2732 39%, 0.4545 44%, 0.6412 50%,
-    0.7839 56%, 0.8508 61%, 0.8965 67%, 0.9309 72%, 0.9543 78%,
-    0.9693 83%, 0.9804 89%, 0.9898 94%, 1 100%);
+  animation-timing-function: cubic-bezier(0.42, 0.3, 0.58, 0.72);
   /* STAGING: the creature is the only thing that should be moving, so it sits
      above the rest of the transition rather than under the rail's own chrome. */
   z-index: 10;
@@ -462,13 +458,31 @@ html {
    in it. */
 ::view-transition-old(sw-monster) {
   animation:
-    sw-monster-hop 680ms cubic-bezier(0.34, 0.8, 0.28, 1) both,
+    /* LINEAR ON PURPOSE, and this was the single largest distortion in the
+       whole jump. `animation-timing-function` applies between EVERY pair of
+       keyframes, not once across the animation, so an eased hop re-eased each
+       leg of the arc: with the old easeOutQuint the creature was 77% of the way
+       to a stop a third into the segment and 92% of the way half way through.
+       Every leg landed early and then held, which is exactly what "reaches the
+       apex too early" describes — it reached every stop too early.
+       Linear hands the shape back to the keyframe values, where it can be read
+       and reasoned about. */
+    sw-monster-hop 680ms linear both,
     sw-monster-depart 680ms linear both;
 }
 
 ::view-transition-new(sw-monster) {
   animation:
-    sw-monster-hop 680ms cubic-bezier(0.34, 0.8, 0.28, 1) both,
+    /* LINEAR ON PURPOSE, and this was the single largest distortion in the
+       whole jump. `animation-timing-function` applies between EVERY pair of
+       keyframes, not once across the animation, so an eased hop re-eased each
+       leg of the arc: with the old easeOutQuint the creature was 77% of the way
+       to a stop a third into the segment and 92% of the way half way through.
+       Every leg landed early and then held, which is exactly what "reaches the
+       apex too early" describes — it reached every stop too early.
+       Linear hands the shape back to the keyframe values, where it can be read
+       and reasoned about. */
+    sw-monster-hop 680ms linear both,
     sw-monster-arrive 680ms linear both;
 }
 
@@ -598,71 +612,59 @@ html {
 @keyframes sw-monster-hop {
   /* IT ENDS ON CONTACT, and that is a timing decision rather than a trim.
 
-     This animation used to run through the landing: 80% was the squash, 91% the
-     rebound, 100% standing. All three were BAKED, because the flight is a
-     view-transition snapshot and a snapshot cannot deform. Worse, they cost
+     This animation used to run through the landing: the squash, the rebound and
+     standing were all keyframes here. All three were BAKED, because the flight
+     is a view-transition snapshot and a snapshot cannot deform. Worse, they cost
      176ms — the feet touched down at 80% of 680ms and the live element did not
      take over until 680, so the body's real squash and the antennae's whip both
      began long after the impact they were reacting to. It read as land, pause,
-     sway.
-
-     So the flight is cut at the moment of contact and hands over there, with the
-     same 680ms and the same apex: every stop below is the old one divided by
-     0.8, which stretches what used to be the airborne 80% across the whole
-     animation. The impact and the rebound now belong to `sw-body-settle` and
+     sway. The impact and the rebound belong to `sw-body-settle` and
      `sw-antennae-settle`, which run on live elements and can actually deform.
 
      THE LAST POSE MUST BE NEUTRAL SCALE, because the settle's own 0% is
      `scale(1, 1)` and any difference between them is a pop at the handover. The
-     yaw is the exception and is carried over deliberately — `sw-monster-untwist`
-     picks it up from exactly this value. */
+     yaw is the exception and is carried over deliberately —
+     `sw-monster-untwist` picks it up from exactly this value.
+
+     THE STOPS ARE THE ARC NOW. Paired with the near-constant travel on the
+     group and `linear` above, the vertical values below are read directly as a
+     trajectory rather than being re-eased into one: the apex lands 18.1px up at
+     57% of the travel, which is a jump. The previous numbers put it 11.2px up
+     while the creature was already three quarters of the way across, and the
+     per-segment easing then delivered even that early. */
   0% {
     transform: translate(0, 0) rotate(0deg) scale(1, 1);
   }
-  17% {
+  /* The crouch, and it barely moves: 11% of the trip, still on the ground. */
+  14% {
     transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * -1%), 8%) rotateY(calc(var(--sw-hop-dir, 1) * -3deg)) rotate(calc(var(--sw-hop-dir, 1) * -1deg)) skewX(calc(var(--sw-hop-dir, 1) * 1.5deg)) scale(1.22, 0.78);
   }
   /* THE LAUNCH, and the one stop that needs a per-direction number.
 
-     A percentage here resolves against the SNAPSHOT it is transforming, and
-     the two snapshots are different sizes: the mark is 15.05px inside the word
-     and 21.88px alone in the rail, a ratio of 1.454. Before the cross-fade
-     starts at 34% you are looking at the OLD snapshot, so this stop's rise is
-     22% of whichever size the creature is LEAVING.
-
-     Which made the two directions physically different jumps. Opening, it
-     leaves the collapsed rail and rises 22% of 21.88px = 4.8px. Closing, it
-     leaves the word and rises 22% of 15.05px = 3.3px — a third lower, over the
-     same 131px of travel, which reads as skimming the ground rather than
-     jumping off it.
-
-     `--sw-hop-rise` is how hard it leaves, and it is the ONE number in this
-     animation that has to differ by direction.
-
-     Not because the two jumps should look different — they should look
-     identical, and now do — but because the percentage means different things
-     in each. The creature is two sizes (`scale` 1.1 inside the word, 1.6 alone
-     in the rail), and early in the flight you are looking at the OLD snapshot,
-     so the same 22% buys 4.8px leaving the rail and only 3.3px leaving the
-     word. The sidebar sets one LAUNCH constant and multiplies it by the size
-     ratio for the direction that leaves the smaller snapshot; both then rise
-     8.6px here, for a ~37deg climb where the old flat 22% gave 27deg and 8deg
-     respectively.
+     A percentage here resolves against the SNAPSHOT it is transforming, and the
+     two snapshots are different sizes: the mark is 15.05px inside the word and
+     21.88px alone in the rail. Before the cross-fade starts at 34% you are
+     looking at the OLD snapshot, so this stop's rise is a share of whichever
+     size the creature is LEAVING — which made the two directions physically
+     different jumps until `--sw-hop-rise` compensated for it. The sidebar sets
+     one launch constant and multiplies it by the size ratio for the direction
+     that leaves the smaller snapshot; both then rise 12px here, a 33deg climb
+     out of the crouch.
 
      ONLY THIS STOP IS SCALED. By the apex the cross-fade has handed most of the
-     way to the NEW snapshot, so the apexes already sit at 12.4px and 11.2px and
-     need nothing; scaling them too would put the creature through the ceiling
-     and flatten the arc's second half into a drop. A steep rise into an
-     unchanged apex is what makes it read as ballistic: fast out of the ground,
-     decelerating into the top. */
-  32% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2%), calc(-22% * var(--sw-hop-rise, 1))) rotateY(calc(var(--sw-hop-dir, 1) * 9deg)) rotate(calc(var(--sw-hop-dir, 1) * 4deg)) skewX(calc(var(--sw-hop-dir, 1) * -4deg)) scale(0.84, 1.22);
+     way across, so the two apexes land within a pixel of each other on their
+     own (18.1 and 18.8) and scaling them would pull them apart again. */
+  30% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2%), calc(-55% * var(--sw-hop-rise, 1))) rotateY(calc(var(--sw-hop-dir, 1) * 9deg)) rotate(calc(var(--sw-hop-dir, 1) * 4deg)) skewX(calc(var(--sw-hop-dir, 1) * -4deg)) scale(0.84, 1.22);
   }
-  58% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 3%), -64%) rotateY(calc(var(--sw-hop-dir, 1) * 16deg)) rotate(calc(var(--sw-hop-dir, 1) * 6deg)) skewX(calc(var(--sw-hop-dir, 1) * -7deg)) scale(0.82, 1.24);
+  /* THE APEX, over the middle of the trip where a thrown thing has it. */
+  55% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 3%), -100%) rotateY(calc(var(--sw-hop-dir, 1) * 16deg)) rotate(calc(var(--sw-hop-dir, 1) * 6deg)) skewX(calc(var(--sw-hop-dir, 1) * -7deg)) scale(0.82, 1.24);
   }
-  82% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1%), -20%) rotateY(calc(var(--sw-hop-dir, 1) * 14deg)) rotate(calc(var(--sw-hop-dir, 1) * -2deg)) skewX(calc(var(--sw-hop-dir, 1) * -3deg)) scale(0.92, 1.1);
+  /* Coming down, and steeper than it went up — which is what landing ON a spot
+     looks like as opposed to sailing past one. */
+  80% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1%), -42%) rotateY(calc(var(--sw-hop-dir, 1) * 14deg)) rotate(calc(var(--sw-hop-dir, 1) * -2deg)) skewX(calc(var(--sw-hop-dir, 1) * -3deg)) scale(0.92, 1.1);
   }
   /* CONTACT. Standing on its feet, still yawed, not yet deformed — the next
      frame is a live element and the squash starts there. */

--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -678,36 +678,35 @@ html {
 }
 
 @keyframes sw-monster-hop-open {
-  /* THE OPENING ARC: the closing one's SHAPE, foreshortened.
+  /* THE OPENING ARC: the closing one's SHAPE, foreshortened, with a descent
+     that actually accelerates.
 
-     It used to be derived from scratch — a symmetric ballistic parabola, a
-     near-linear travel, `linear` between stops so gravity lived in the values.
-     All of that was defensible and all of it read wrong, and tracing the two
-     body centres said why: they were different SILHOUETTES, not different
-     heights. The closing arc peaks at 80% of its travel and DROPS onto the
-     spot at 38 degrees. The opening one peaked at 45% and glided in at 12 —
-     not landing, approaching down a long shallow slope.
+     The rise is the closing set's, scaled by 0.70 because this direction ends
+     about 1.45x further from the reader. Tracing both body centres is what
+     settled that: every arc derived from scratch here peaked near the middle
+     and glided in at about 12deg, where the closing one peaks at 80% of its
+     travel and DROPS at 38. Depth belongs in how BIG an arc is, not in what
+     shape it is.
 
-     Depth should change how BIG a jump looks, not what shape it is. So this is
-     the closing set's stops, read on the closing set's clock
-     (`--sw-hop-ease: cubic-bezier(0.34, 0.8, 0.28, 1)`) over the closing set's
-     travel — and only the lift is scaled, by 0.70, because this direction ends
-     about 1.45x further from the reader.
+     THE DESCENT IS SAMPLED, which is the one place this departs from a copy.
+     `animation-timing-function` applies between EVERY pair of keyframes, so a
+     long segment front-loads its own motion and then coasts. Carried by two
+     stops the fall measured 24.7deg, 9.3, 4.0, 0.1, then 46.0, 23.1, 3.3 --
+     drop, flatten, drop, flatten, arriving almost HORIZONTAL. Sampled at eight,
+     each segment is short enough that the easing stops shaping it, and the
+     values carry a fall whose speed grows all the way into contact.
 
      THE LAUNCH LOSES A COMPENSATION THE CLOSE NEEDS. A percentage here resolves
      against the snapshot being transformed, and the close leaves the 15.05px
      mark inside the word while this one leaves the 21.88px mark alone in the
      rail. The close's -57.216% is 22% times 2.6007 for exactly that reason;
-     dividing it back out by 1.6/1.1 is what makes both launches the same number
-     of PIXELS rather than the same percentage.
+     dividing it back out by 1.6/1.1 makes both launches the same number of
+     PIXELS rather than the same percentage.
 
-     ONE THING IS NOT THE CLOSE'S: THE SQUASH. Its scales are keyed to the
-     clock and peak at its apex -- most stretched exactly where the vertical
-     velocity reverses through zero -- and copying the shape copied that too.
-     Here the stretch comes from the lift's own segment speeds instead: round at
-     the top, stretched where the creature is actually moving, neutral at
-     contact because the settle's 0% is scale(1, 1) on a live element and
-     anything else is a pop.
+     THE SQUASH IS KEYED TO SPEED. The close's scales peak at its apex, which is
+     where its vertical velocity reverses through zero, and copying its shape
+     once copied that inversion with it. Round at the top, stretched where the
+     creature is actually moving, neutral at contact.
 
      Regenerate with `mirror.py <scale>` rather than editing a stop. */
   0% {
@@ -722,8 +721,23 @@ html {
   58% {
     transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 3%), -44.8%) rotateY(calc(var(--sw-hop-dir, 1) * 16deg)) rotate(calc(var(--sw-hop-dir, 1) * 6deg)) skewX(calc(var(--sw-hop-dir, 1) * -7deg)) scale(1.000, 1.000);
   }
-  82% {
-    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1%), -14%) rotateY(calc(var(--sw-hop-dir, 1) * 14deg)) rotate(calc(var(--sw-hop-dir, 1) * -2deg)) skewX(calc(var(--sw-hop-dir, 1) * -3deg)) scale(0.902, 1.130);
+  66% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.333%), -43.17%) rotateY(calc(var(--sw-hop-dir, 1) * 15.33deg)) rotate(calc(var(--sw-hop-dir, 1) * 3.333deg)) skewX(calc(var(--sw-hop-dir, 1) * -5.667deg)) scale(0.966, 1.046);
+  }
+  73% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1.75%), -39.09%) rotateY(calc(var(--sw-hop-dir, 1) * 14.75deg)) rotate(calc(var(--sw-hop-dir, 1) * 1deg)) skewX(calc(var(--sw-hop-dir, 1) * -4.5deg)) scale(0.936, 1.086);
+  }
+  80% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1.167%), -32.51%) rotateY(calc(var(--sw-hop-dir, 1) * 14.17deg)) rotate(calc(var(--sw-hop-dir, 1) * -1.333deg)) skewX(calc(var(--sw-hop-dir, 1) * -3.333deg)) scale(0.906, 1.126);
+  }
+  86% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0.7778%), -24.89%) rotateY(calc(var(--sw-hop-dir, 1) * 13.11deg)) rotate(calc(var(--sw-hop-dir, 1) * -1.556deg)) skewX(calc(var(--sw-hop-dir, 1) * -2.333deg)) scale(0.880, 1.160);
+  }
+  91% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0.5%), -17.14%) rotateY(calc(var(--sw-hop-dir, 1) * 12deg)) rotate(calc(var(--sw-hop-dir, 1) * -1deg)) skewX(calc(var(--sw-hop-dir, 1) * -1.5deg)) scale(0.859, 1.189);
+  }
+  96% {
+    transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0.2222%), -8.127%) rotateY(calc(var(--sw-hop-dir, 1) * 10.89deg)) rotate(calc(var(--sw-hop-dir, 1) * -0.4444deg)) skewX(calc(var(--sw-hop-dir, 1) * -0.6667deg)) scale(0.837, 1.217);
   }
   100% {
     transform: perspective(140px) translate(0, 0)

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -154,6 +154,24 @@ function writeRailExpanded(next: boolean): void {
   // being blown sideways rather than as choosing to go.
   document.documentElement.style.setProperty("--sw-hop-dir", next ? "1" : "-1");
 
+  // HOW HARD IT LEAVES THE GROUND, which is not the same in both directions and
+  // has to be told so.
+  //
+  // The hop's rise is a PERCENTAGE, so it resolves against the snapshot being
+  // transformed — and the creature is two different sizes: `scale` 1.1 inside
+  // the word, 1.6 alone in the rail. Early in the flight the OLD snapshot is
+  // what is on screen, so opening (leaving the collapsed rail) rose 4.8px while
+  // closing (leaving the word) rose only 3.3px over the same travel. The close
+  // looked like it was skimming the ground instead of jumping off it.
+  //
+  // 1.6 / 1.1 is exactly the discrepancy, so closing gets it and opening gets
+  // 1. Written as the ratio rather than a tuned number: if either `scale` at
+  // the call site moves, this is the line that has to move with it.
+  document.documentElement.style.setProperty(
+    "--sw-hop-rise",
+    next ? "1" : String(1.6 / 1.1),
+  );
+
   // AIM THE EYE BEFORE THE BODY GOES. Both snapshots are captured with this
   // attribute set — the pose it leaves from and the pose it lands in — so the
   // pupil points along the arc for the WHOLE flight rather than only reacting
@@ -752,7 +770,7 @@ export function TimelineSidebar() {
             ? // OPENING: decisive, then eases hard into rest — what a drawer
               // pulled open and let go of does. Unchanged.
               `${RAIL_WIDTH_CLASS.open} ${RAIL_OPEN_CLASS} duration-[440ms] ease-[cubic-bezier(0.22,1,0.36,1)]`
-            : // CLOSING: a long slow ramp, then commit.
+            : // CLOSING: an early creep, then commit.
               //
               // It used to close on the opening curve, and that curve is
               // easeOutQuint — 62px of the 168px travel gone in the FIRST 40ms
@@ -770,7 +788,14 @@ export function TimelineSidebar() {
               // 440ms has to make the time up somewhere, and it did — 145px in
               // the 200ms through the middle, which read as a lurch rather than
               // as a drawer.
-              `${RAIL_WIDTH_CLASS.collapsed} duration-[660ms] ease-[cubic-bezier(0.8,0,0.3,1)]`,
+              //
+              // THE FIRST VERSION OF THIS RAMP WAS TOO DEAD. At (0.8, 0, 0.3, 1)
+              // the rail was 0% closed at 60ms and 7% at 200ms — a hold, not a
+              // ramp, and a control that visibly does nothing for a fifth of a
+              // second reads as one that missed the click. This one creeps: 1%
+              // at 60ms, 5% at 120ms, 16% at 200ms. Still nothing like the
+              // opening curve, which was 37% and 84% at those marks.
+              `${RAIL_WIDTH_CLASS.collapsed} duration-[660ms] ease-[cubic-bezier(0.6,0.04,0.3,1)]`,
         )}
       >
         <Link

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -136,6 +136,37 @@ function commitRailExpanded(next: boolean): void {
  * Falls back to a plain commit where the API is missing or the reader asked for
  * less motion; the rail still moves, it just cuts.
  */
+/** The opening travel, unchanged since it was first tuned. */
+const OPEN_TRAVEL = "cubic-bezier(0.34, 0.8, 0.28, 1)";
+
+/**
+ * The closing travel, and it is a `linear()` because no cubic-bezier does this
+ * shape.
+ *
+ * Three things have to be true of it at once, and they fight:
+ *
+ *   17%   3% across   the crouch happens in PLACE, not while sliding sideways
+ *   32%  13% across   paired with the rise, a 37deg climb out of the ground
+ *   58%  82% across   the apex sits near the landing rather than back over the
+ *                     middle of the trip
+ *
+ * A cubic-bezier slow enough for the first two decelerates through the third —
+ * `cubic-bezier(0.65, 0, 0.35, 1)` held the launch beautifully and then put the
+ * apex at 71% of the travel, so the creature topped out over open ground and
+ * came down a long way short of where it was going. `linear()` can hold a flat
+ * start AND a fast middle AND a settle, which is exactly a jump.
+ *
+ * Generated as a monotone cubic through those control points and sampled at 19
+ * stops — monotone so the interpolation can never overshoot and send the
+ * creature briefly backwards, and 19 so the segments are below the eye's
+ * resolution at this speed. Regenerate it rather than hand-editing a stop.
+ */
+const CLOSE_TRAVEL =
+  "linear(0 0%, 0.008508 6%, 0.01694 11%, 0.02907 17%, 0.0522 22%," +
+  " 0.09105 28%, 0.1467 33%, 0.2732 39%, 0.4545 44%, 0.6412 50%," +
+  " 0.7839 56%, 0.8508 61%, 0.8965 67%, 0.9309 72%, 0.9543 78%," +
+  " 0.9693 83%, 0.9804 89%, 0.9898 94%, 1 100%)";
+
 function writeRailExpanded(next: boolean): void {
   const doc = document as Document & {
     startViewTransition?: (callback: () => void) => unknown;
@@ -180,7 +211,7 @@ function writeRailExpanded(next: boolean): void {
   );
   document.documentElement.style.setProperty(
     "--sw-group-ease",
-    next ? "cubic-bezier(0.34, 0.8, 0.28, 1)" : "cubic-bezier(0.65, 0, 0.35, 1)",
+    next ? OPEN_TRAVEL : CLOSE_TRAVEL,
   );
 
   // AIM THE EYE BEFORE THE BODY GOES. Both snapshots are captured with this

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -830,9 +830,20 @@ export function TimelineSidebar() {
           // From RAIL_WIDTH_CLASS, which holds the literals Tailwind's scanner
           // needs — see the note there on why these cannot be built by template.
           railExpanded
-            ? // OPENING: decisive, then eases hard into rest — what a drawer
-              // pulled open and let go of does. Unchanged.
-              `${RAIL_WIDTH_CLASS.open} ${RAIL_OPEN_CLASS} duration-[440ms] ease-[cubic-bezier(0.22,1,0.36,1)]`
+            ? // OPENING: the rail arrives exactly as the creature lands, because
+              // it travels on the creature's own profile.
+              //
+              // It used to be 440ms of easeOutQuint, which is 99% done by 287ms
+              // against a jump that does not touch down until 680 — the rail
+              // was parked and waiting for most of the flight.
+              //
+              // MATCHING THE DURATION ALONE WOULD NOT HAVE FIXED IT. Stretched
+              // to 680ms that curve still LOOKS finished at 443ms; an ease-out
+              // spends its last 1% over a third of its time. So it takes the
+              // same near-linear travel the hop's group uses (see `OPENING`),
+              // which is 99% done at 670ms — the rail and the creature come to
+              // rest together rather than merely stopping at the same instant.
+              `${RAIL_WIDTH_CLASS.open} ${RAIL_OPEN_CLASS} duration-[680ms] ease-[cubic-bezier(0.42,0.3,0.58,0.72)]`
             : // CLOSING: an early creep, then commit.
               //
               // It used to close on the opening curve, and that curve is

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -157,6 +157,11 @@ type JumpArc = {
   hopEase: string;
   /** How the ground goes by underneath: the group's own position curve. */
   travel: string;
+  /** How long that travel takes. Ends with the hop, or short of it. */
+  travelMs: string;
+  /** The group's hole-filler: an opaque rect that travels with it, so it helps
+   *  only while the creature is on top of it. See the note in globals.css. */
+  fill: string;
 };
 
 /**
@@ -183,6 +188,8 @@ const CLOSING: JumpArc = {
     " 0.09105 28%, 0.1467 33%, 0.2732 39%, 0.4545 44%, 0.6412 50%," +
     " 0.7839 56%, 0.8508 61%, 0.8965 67%, 0.9309 72%, 0.9543 78%," +
     " 0.9693 83%, 0.9804 89%, 0.9898 94%, 1 100%)",
+  travelMs: "620ms",
+  fill: "rgb(9 9 11) linear-gradient(oklab(0.21 0.00164225 -0.00577088 / 0.5) 0 100%)",
 };
 
 /**
@@ -207,6 +214,15 @@ const OPENING: JumpArc = {
   hop: "sw-monster-hop-open",
   hopEase: "linear",
   travel: "cubic-bezier(0.42, 0.3, 0.58, 0.72)",
+  // ENDS WITH THE HOP, not 60ms short of it. At the shared 620ms the creature
+  // finished travelling and then dropped straight down for the remaining 60ms,
+  // which is a stop followed by a fall rather than a landing.
+  travelMs: "680ms",
+  // NO FILLER. It is an opaque rectangle that travels with the group, and this
+  // arc lifts the creature a full box height clear of it — so instead of
+  // hiding a hole it dragged across the wordmark and blanked the letters mid
+  // reveal. Verified by eye that nothing dark appears in its absence here.
+  fill: "transparent",
 };
 
 function writeRailExpanded(next: boolean): void {
@@ -234,6 +250,8 @@ function writeRailExpanded(next: boolean): void {
   root.setProperty("--sw-hop-name", arc.hop);
   root.setProperty("--sw-hop-ease", arc.hopEase);
   root.setProperty("--sw-group-ease", arc.travel);
+  root.setProperty("--sw-group-ms", arc.travelMs);
+  root.setProperty("--sw-group-fill", arc.fill);
 
   // AIM THE EYE BEFORE THE BODY GOES. Both snapshots are captured with this
   // attribute set — the pose it leaves from and the pose it lands in — so the

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -137,32 +137,77 @@ function commitRailExpanded(next: boolean): void {
  * less motion; the rail still moves, it just cuts.
  */
 /**
- * How hard the creature leaves the ground, as ONE number for both directions.
+ * THE TWO DIRECTIONS ARE TWO DIFFERENT JUMPS, and each is three settings.
  *
- * It is 1 because the ARC now lives in the keyframes where it belongs — see
- * `sw-monster-hop` — rather than being manufactured by multiplying one stop.
- * What survives here is the correction below, which is not about the arc at
- * all but about the two directions measuring their percentages against
- * different-sized snapshots.
+ * They were one for a while. Unifying them was tempting — the arithmetic worked
+ * out, one launch constant explained both — but it meant every correction to
+ * one silently rewrote the other, and the closing jump had already been signed
+ * off. The opening one needed a change of SHAPE rather than of parameter, so
+ * there was nothing left to share.
+ *
+ * Each direction therefore names its own keyframes, its own clock between them,
+ * and its own travel curve. All three have to move together: the arcs are
+ * authored against their own clocks and neither survives being given the
+ * other's.
  */
-const LAUNCH = 1;
+type JumpArc = {
+  /** The keyframe set that draws the arc. */
+  hop: string;
+  /** The clock BETWEEN its keyframes — part of the shape, not a finish on it. */
+  hopEase: string;
+  /** How the ground goes by underneath: the group's own position curve. */
+  travel: string;
+};
 
 /**
- * The two `scale` values the mark is rendered at, as a ratio — and the entire
- * reason `LAUNCH` cannot just be set and forgotten.
+ * CLOSING: shaped, and signed off as-is. Do not retune without being asked.
  *
- * The hop's rise is a PERCENTAGE, so it resolves against the snapshot being
- * transformed, and early in the flight that is the snapshot the creature is
- * LEAVING. Leaving the collapsed rail it is 21.88px; leaving the word it is
- * 15.05px. The same percentage therefore buys a third less lift in one
- * direction than the other, which is why the two jumps used to read as
- * different jumps.
+ * The travel is a `linear()` because three things have to be true at once and
+ * no cubic-bezier holds all three — anything slow enough to keep the crouch in
+ * place decelerates through the middle and parks the apex over open ground:
  *
- * The direction that leaves the smaller snapshot gets `LAUNCH` multiplied by
- * this, so both arrive at the same 8.6px. If either `scale` at the call site
- * moves, this is the line that moves with it.
+ *   17%    3% across   the crouch happens IN PLACE, not while sliding sideways
+ *   32%   13% across   paired with the rise, a ~37deg climb out of the ground
+ *   58%   82% across   the apex sits near the landing
+ *
+ * Generated as a monotone cubic through those points and sampled at 19 stops:
+ * monotone so the interpolation can never send the creature briefly backwards,
+ * 19 so the segments sit below the eye's resolution. Regenerate it rather than
+ * hand-editing a stop.
  */
-const MARK_SCALE_RATIO = 1.6 / 1.1;
+const CLOSING: JumpArc = {
+  hop: "sw-monster-hop",
+  hopEase: "cubic-bezier(0.34, 0.8, 0.28, 1)",
+  travel:
+    "linear(0 0%, 0.008508 6%, 0.01694 11%, 0.02907 17%, 0.0522 22%," +
+    " 0.09105 28%, 0.1467 33%, 0.2732 39%, 0.4545 44%, 0.6412 50%," +
+    " 0.7839 56%, 0.8508 61%, 0.8965 67%, 0.9309 72%, 0.9543 78%," +
+    " 0.9693 83%, 0.9804 89%, 0.9898 94%, 1 100%)",
+};
+
+/**
+ * OPENING: ballistic.
+ *
+ * A jump has no horizontal force, so its horizontal velocity is CONSTANT and
+ * only the vertical accelerates. Both settings here follow from that one fact:
+ * a near-linear travel whose peak speed is 1.22x its mean, and `linear` between
+ * keyframes so the arc is the keyframe VALUES rather than something a clock
+ * manufactures out of them.
+ *
+ * Both were wrong before, in opposite ways. The travel was front-loaded — 42%
+ * of the way across while still crouching. And `animation-timing-function`
+ * applies between EVERY pair of keyframes, so the eased hop re-eased each leg:
+ * 77% of the way to a stop a third into the segment, 92% half way through.
+ * Every leg landed early and held, which is what "reaches the apex too early"
+ * was describing.
+ *
+ * The result is an apex ~18px up at 57% of the travel, against 11.2px at ~20%.
+ */
+const OPENING: JumpArc = {
+  hop: "sw-monster-hop-open",
+  hopEase: "linear",
+  travel: "cubic-bezier(0.42, 0.3, 0.58, 0.72)",
+};
 
 function writeRailExpanded(next: boolean): void {
   const doc = document as Document & {
@@ -182,20 +227,13 @@ function writeRailExpanded(next: boolean): void {
   // being blown sideways rather than as choosing to go.
   document.documentElement.style.setProperty("--sw-hop-dir", next ? "1" : "-1");
 
-  // HOW HARD IT LEAVES THE GROUND. Both directions want the same launch; they
-  // need different numbers to get it, because the percentage resolves against
-  // the snapshot each one is LEAVING and those are different sizes. See
-  // `LAUNCH` and `MARK_SCALE_RATIO`.
-  //
-  // The horizontal is not set here at all any more — it is one shaped curve on
-  // the group, shared by both directions, and holding it back is what made the
-  // lift mean anything. Before it, the creature was 55px into a 131px trip while
-  // still below the ground in its crouch, and 75% of the way across by the time
-  // it had risen at all.
-  document.documentElement.style.setProperty(
-    "--sw-hop-rise",
-    String(next ? LAUNCH : LAUNCH * MARK_SCALE_RATIO),
-  );
+  // WHICH JUMP THIS IS. Three properties, set together, because the arc is all
+  // three: see `CLOSING` and `OPENING`.
+  const arc = next ? OPENING : CLOSING;
+  const root = document.documentElement.style;
+  root.setProperty("--sw-hop-name", arc.hop);
+  root.setProperty("--sw-hop-ease", arc.hopEase);
+  root.setProperty("--sw-group-ease", arc.travel);
 
   // AIM THE EYE BEFORE THE BODY GOES. Both snapshots are captured with this
   // attribute set — the pose it leaves from and the pose it lands in — so the

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -139,13 +139,13 @@ function commitRailExpanded(next: boolean): void {
 /**
  * How hard the creature leaves the ground, as ONE number for both directions.
  *
- * Paired with the travel curve on `::view-transition-group(sw-monster)`, this
- * puts the creature 17px along its 131px trip and 8.6px up at the hop's launch
- * stop — a climb of about 37deg. Flat at 1 it was 4.8px and 27deg leaving the
- * rail, 3.3px and 8deg leaving the word: a slide with a bump in it, which is
- * what "skimming" describes.
+ * It is 1 because the ARC now lives in the keyframes where it belongs — see
+ * `sw-monster-hop` — rather than being manufactured by multiplying one stop.
+ * What survives here is the correction below, which is not about the arc at
+ * all but about the two directions measuring their percentages against
+ * different-sized snapshots.
  */
-const LAUNCH = 1.788;
+const LAUNCH = 1;
 
 /**
  * The two `scale` values the mark is rendered at, as a ratio — and the entire

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -739,20 +739,38 @@ export function TimelineSidebar() {
           // Width alone is animated. `transition-all` here would also catch the
           // backdrop filter, which is expensive to interpolate over a sticky
           // full-height surface.
-          // Paced against the creature's 620ms hop rather than left at the
-          // default 200ms — the rail used to finish long before the creature
-          // landed, so it jumped to a place that had already stopped moving.
+          "transition-[width] motion-reduce:transition-none",
+          // OPENING AND CLOSING ARE NOT THE SAME MOVE, so the pacing lives on
+          // the state rather than here. A transition reads its duration and
+          // easing from the AFTER-change style, so whichever branch below is
+          // being switched TO is the one that times the move — which is what
+          // makes this direction-aware without a single line of JavaScript.
           //
-          // SLOW IN AND SLOW OUT, weighted to the out: a decisive move that
-          // eases hard into rest, which is what a drawer pulled open and let go
-          // of does. The default `ease` is symmetric and reads mechanical
-          // against a body that accelerates and settles.
-          "transition-[width] duration-[440ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
           // From RAIL_WIDTH_CLASS, which holds the literals Tailwind's scanner
           // needs — see the note there on why these cannot be built by template.
           railExpanded
-            ? `${RAIL_WIDTH_CLASS.open} ${RAIL_OPEN_CLASS}`
-            : RAIL_WIDTH_CLASS.collapsed,
+            ? // OPENING: decisive, then eases hard into rest — what a drawer
+              // pulled open and let go of does. Unchanged.
+              `${RAIL_WIDTH_CLASS.open} ${RAIL_OPEN_CLASS} duration-[440ms] ease-[cubic-bezier(0.22,1,0.36,1)]`
+            : // CLOSING: a long slow ramp, then commit.
+              //
+              // It used to close on the opening curve, and that curve is
+              // easeOutQuint — 62px of the 168px travel gone in the FIRST 40ms
+              // and 79% shut by 120ms. The rail was always going to beat the
+              // creature to a standstill, because it did most of its move
+              // before the creature had finished crouching.
+              //
+              // Measured against the hop's own beats, this one is 2% closed at
+              // the crouch (116ms), 9% at the push-off (218ms), 71% at the apex
+              // (394ms) and 100% at contact (680ms). The rail closes WITH the
+              // jump instead of ahead of it, and the slow start is what buys
+              // that: the creature gets the first fifth of a second to itself.
+              //
+              // 660ms rather than 440ms for the same reason. A slow ramp inside
+              // 440ms has to make the time up somewhere, and it did — 145px in
+              // the 200ms through the middle, which read as a lurch rather than
+              // as a drawer.
+              `${RAIL_WIDTH_CLASS.collapsed} duration-[660ms] ease-[cubic-bezier(0.8,0,0.3,1)]`,
         )}
       >
         <Link

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -213,7 +213,14 @@ const CLOSING: JumpArc = {
 const OPENING: JumpArc = {
   hop: "sw-monster-hop-open",
   hopEase: "linear",
-  travel: "cubic-bezier(0.42, 0.3, 0.58, 0.72)",
+  // ENDS AT CONSTANT VELOCITY, which is what stops the path hooking. The
+  // second control point sits at y == x, so the curve's slope at t=1 is 1
+  // rather than 0.67. With the old ease-out the horizontal SLOWED into the
+  // landing while the fall was still accelerating, and the trajectory bent
+  // sharply downward right at the spot -- the descent angle steepened 16.8deg
+  // over the last third, which reads as curving into the landing rather than
+  // arriving at it. It is 6.1deg now.
+  travel: "cubic-bezier(0.42, 0.3, 0.58, 0.58)",
   // ENDS WITH THE HOP, not 60ms short of it. At the shared 620ms the creature
   // finished travelling and then dropped straight down for the remaining 60ms,
   // which is a stop followed by a fall rather than a landing.
@@ -427,7 +434,7 @@ function RevealedLetters({
         // part is loose depends on which way the motion runs.
         "grid transition-[grid-template-columns] motion-reduce:transition-none",
         show
-          ? "delay-0 duration-[680ms] ease-[cubic-bezier(0.42,0.3,0.58,0.72)]"
+          ? "delay-0 duration-[680ms] ease-[cubic-bezier(0.42,0.3,0.58,0.58)]"
           : "delay-0 duration-[220ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
         show ? "grid-cols-[1fr]" : "grid-cols-[0fr]",
       )}

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -403,14 +403,32 @@ function RevealedLetters({
     <span
       aria-hidden="true"
       className={cn(
-        // OVERLAPPING ACTION. The word does not move in lockstep with the rail:
-        // opening, it trails the creature's launch by a beat, so the name reads
-        // as being pulled out behind it; closing, it goes FIRST and quickly,
-        // clearing the space before the creature jumps back into it. Loose parts
-        // lag the thing driving them, and which part is loose depends on which
-        // way the motion runs.
-        "grid transition-[grid-template-columns] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
-        show ? "delay-[90ms] duration-[420ms]" : "delay-0 duration-[220ms]",
+        // THE TWO DIRECTIONS DO DIFFERENT THINGS, so the pacing lives on the
+        // branch rather than above it.
+        //
+        // OPENING, THE WORD CARRIES THE CREATURE. It used to trail the launch by
+        // a beat and finish in 420ms against a jump that lands at 680, so the
+        // gap the creature is aiming for arrived first and sat waiting while the
+        // creature caught up. Matching the group's own travel — same curve, same
+        // 680ms, no delay — makes the creature sit IN the "o" slot the whole way
+        // across instead of merely ending up there.
+        //
+        // It works out exactly, which is worth writing down because it looks
+        // like a coincidence. The creature's group interpolates its box from
+        // x=22 (alone in the rail) to x=153 (inside the word), so its position
+        // is 22 + 131p. The slot's left edge is 22 plus the revealed width of
+        // "storyboard " and "m", and that width is 131 when fully revealed — so
+        // the slot is 22 + 131q. Same form: give p and q the same curve and the
+        // two are the same number at every instant.
+        //
+        // CLOSING IS STILL OVERLAPPING ACTION, and deliberately unchanged: the
+        // word goes FIRST and quickly, clearing the space before the creature
+        // jumps back into it. Loose parts lag the thing driving them, and which
+        // part is loose depends on which way the motion runs.
+        "grid transition-[grid-template-columns] motion-reduce:transition-none",
+        show
+          ? "delay-0 duration-[680ms] ease-[cubic-bezier(0.42,0.3,0.58,0.72)]"
+          : "delay-0 duration-[220ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
         show ? "grid-cols-[1fr]" : "grid-cols-[0fr]",
       )}
     >
@@ -876,10 +894,17 @@ export function TimelineSidebar() {
               // jump instead of ahead of it, and the slow start is what buys
               // that: the creature gets the first fifth of a second to itself.
               //
-              // 660ms rather than 440ms for the same reason. A slow ramp inside
+              // 680ms rather than 440ms for the same reason. A slow ramp inside
               // 440ms has to make the time up somewhere, and it did — 145px in
               // the 200ms through the middle, which read as a lurch rather than
               // as a drawer.
+              //
+              // It matches the opening rail exactly, and both match the jump:
+              // 680ms is the hop's own length, so neither direction of the
+              // toggle is a different length of event. The two still FEEL
+              // different, and that is the easing rather than the clock — this
+              // one ramps and commits, so it is visually done around 600ms
+              // while the opening one is still arriving at 670.
               //
               // THE FIRST VERSION OF THIS RAMP WAS TOO DEAD. At (0.8, 0, 0.3, 1)
               // the rail was 0% closed at 60ms and 7% at 200ms — a hold, not a
@@ -887,7 +912,7 @@ export function TimelineSidebar() {
               // second reads as one that missed the click. This one creeps: 1%
               // at 60ms, 5% at 120ms, 16% at 200ms. Still nothing like the
               // opening curve, which was 37% and 84% at those marks.
-              `${RAIL_WIDTH_CLASS.collapsed} duration-[660ms] ease-[cubic-bezier(0.6,0.04,0.3,1)]`,
+              `${RAIL_WIDTH_CLASS.collapsed} duration-[680ms] ease-[cubic-bezier(0.6,0.04,0.3,1)]`,
         )}
       >
         <Link

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -136,36 +136,33 @@ function commitRailExpanded(next: boolean): void {
  * Falls back to a plain commit where the API is missing or the reader asked for
  * less motion; the rail still moves, it just cuts.
  */
-/** The opening travel, unchanged since it was first tuned. */
-const OPEN_TRAVEL = "cubic-bezier(0.34, 0.8, 0.28, 1)";
+/**
+ * How hard the creature leaves the ground, as ONE number for both directions.
+ *
+ * Paired with the travel curve on `::view-transition-group(sw-monster)`, this
+ * puts the creature 17px along its 131px trip and 8.6px up at the hop's launch
+ * stop — a climb of about 37deg. Flat at 1 it was 4.8px and 27deg leaving the
+ * rail, 3.3px and 8deg leaving the word: a slide with a bump in it, which is
+ * what "skimming" describes.
+ */
+const LAUNCH = 1.788;
 
 /**
- * The closing travel, and it is a `linear()` because no cubic-bezier does this
- * shape.
+ * The two `scale` values the mark is rendered at, as a ratio — and the entire
+ * reason `LAUNCH` cannot just be set and forgotten.
  *
- * Three things have to be true of it at once, and they fight:
+ * The hop's rise is a PERCENTAGE, so it resolves against the snapshot being
+ * transformed, and early in the flight that is the snapshot the creature is
+ * LEAVING. Leaving the collapsed rail it is 21.88px; leaving the word it is
+ * 15.05px. The same percentage therefore buys a third less lift in one
+ * direction than the other, which is why the two jumps used to read as
+ * different jumps.
  *
- *   17%   3% across   the crouch happens in PLACE, not while sliding sideways
- *   32%  13% across   paired with the rise, a 37deg climb out of the ground
- *   58%  82% across   the apex sits near the landing rather than back over the
- *                     middle of the trip
- *
- * A cubic-bezier slow enough for the first two decelerates through the third —
- * `cubic-bezier(0.65, 0, 0.35, 1)` held the launch beautifully and then put the
- * apex at 71% of the travel, so the creature topped out over open ground and
- * came down a long way short of where it was going. `linear()` can hold a flat
- * start AND a fast middle AND a settle, which is exactly a jump.
- *
- * Generated as a monotone cubic through those control points and sampled at 19
- * stops — monotone so the interpolation can never overshoot and send the
- * creature briefly backwards, and 19 so the segments are below the eye's
- * resolution at this speed. Regenerate it rather than hand-editing a stop.
+ * The direction that leaves the smaller snapshot gets `LAUNCH` multiplied by
+ * this, so both arrive at the same 8.6px. If either `scale` at the call site
+ * moves, this is the line that moves with it.
  */
-const CLOSE_TRAVEL =
-  "linear(0 0%, 0.008508 6%, 0.01694 11%, 0.02907 17%, 0.0522 22%," +
-  " 0.09105 28%, 0.1467 33%, 0.2732 39%, 0.4545 44%, 0.6412 50%," +
-  " 0.7839 56%, 0.8508 61%, 0.8965 67%, 0.9309 72%, 0.9543 78%," +
-  " 0.9693 83%, 0.9804 89%, 0.9898 94%, 1 100%)";
+const MARK_SCALE_RATIO = 1.6 / 1.1;
 
 function writeRailExpanded(next: boolean): void {
   const doc = document as Document & {
@@ -185,33 +182,19 @@ function writeRailExpanded(next: boolean): void {
   // being blown sideways rather than as choosing to go.
   document.documentElement.style.setProperty("--sw-hop-dir", next ? "1" : "-1");
 
-  // HOW HARD IT LEAVES THE GROUND, and how much ground goes by while it does.
-  // Neither is the same in both directions, and both had to be told so.
+  // HOW HARD IT LEAVES THE GROUND. Both directions want the same launch; they
+  // need different numbers to get it, because the percentage resolves against
+  // the snapshot each one is LEAVING and those are different sizes. See
+  // `LAUNCH` and `MARK_SCALE_RATIO`.
   //
-  // THE HORIZONTAL WAS THE REAL PROBLEM. The group's own easing carries the
-  // travel, and it is front-loaded: measured on the closing jump, the creature
-  // was 55px into a 131px trip — 42% of the way — while still 1.2px BELOW the
-  // ground in its crouch, and 75% of the way by the time it had risen 4.8px.
-  // The launch read as -1.2deg then 8deg, which is a slide with a bump in it.
-  // Holding the horizontal back is what makes the lift mean anything.
-  //
-  // THE RISE THEN CARRIES TWO CORRECTIONS. The hop's lift is a PERCENTAGE, so
-  // it resolves against the snapshot being transformed, and the creature is two
-  // sizes: `scale` 1.1 inside the word, 1.6 alone in the rail. Early on you see
-  // the OLD snapshot, so opening rose 22% of 21.88px = 4.8px and closing only
-  // 22% of 15.05px = 3.3px. 1.6 / 1.1 = 1.4545 of the number below is that
-  // compensation; the rest is the steeper launch, and together they put the
-  // creature 17px across and 8.6px up at the same stop — a 36deg climb.
-  //
-  // Opening gets the identity values, so it resolves to exactly what it always
-  // did rather than to something newly computed.
+  // The horizontal is not set here at all any more — it is one shaped curve on
+  // the group, shared by both directions, and holding it back is what made the
+  // lift mean anything. Before it, the creature was 55px into a 131px trip while
+  // still below the ground in its crouch, and 75% of the way across by the time
+  // it had risen at all.
   document.documentElement.style.setProperty(
     "--sw-hop-rise",
-    next ? "1" : "2.6",
-  );
-  document.documentElement.style.setProperty(
-    "--sw-group-ease",
-    next ? OPEN_TRAVEL : CLOSE_TRAVEL,
+    String(next ? LAUNCH : LAUNCH * MARK_SCALE_RATIO),
   );
 
   // AIM THE EYE BEFORE THE BODY GOES. Both snapshots are captured with this

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -154,22 +154,33 @@ function writeRailExpanded(next: boolean): void {
   // being blown sideways rather than as choosing to go.
   document.documentElement.style.setProperty("--sw-hop-dir", next ? "1" : "-1");
 
-  // HOW HARD IT LEAVES THE GROUND, which is not the same in both directions and
-  // has to be told so.
+  // HOW HARD IT LEAVES THE GROUND, and how much ground goes by while it does.
+  // Neither is the same in both directions, and both had to be told so.
   //
-  // The hop's rise is a PERCENTAGE, so it resolves against the snapshot being
-  // transformed — and the creature is two different sizes: `scale` 1.1 inside
-  // the word, 1.6 alone in the rail. Early in the flight the OLD snapshot is
-  // what is on screen, so opening (leaving the collapsed rail) rose 4.8px while
-  // closing (leaving the word) rose only 3.3px over the same travel. The close
-  // looked like it was skimming the ground instead of jumping off it.
+  // THE HORIZONTAL WAS THE REAL PROBLEM. The group's own easing carries the
+  // travel, and it is front-loaded: measured on the closing jump, the creature
+  // was 55px into a 131px trip — 42% of the way — while still 1.2px BELOW the
+  // ground in its crouch, and 75% of the way by the time it had risen 4.8px.
+  // The launch read as -1.2deg then 8deg, which is a slide with a bump in it.
+  // Holding the horizontal back is what makes the lift mean anything.
   //
-  // 1.6 / 1.1 is exactly the discrepancy, so closing gets it and opening gets
-  // 1. Written as the ratio rather than a tuned number: if either `scale` at
-  // the call site moves, this is the line that has to move with it.
+  // THE RISE THEN CARRIES TWO CORRECTIONS. The hop's lift is a PERCENTAGE, so
+  // it resolves against the snapshot being transformed, and the creature is two
+  // sizes: `scale` 1.1 inside the word, 1.6 alone in the rail. Early on you see
+  // the OLD snapshot, so opening rose 22% of 21.88px = 4.8px and closing only
+  // 22% of 15.05px = 3.3px. 1.6 / 1.1 = 1.4545 of the number below is that
+  // compensation; the rest is the steeper launch, and together they put the
+  // creature 17px across and 8.6px up at the same stop — a 36deg climb.
+  //
+  // Opening gets the identity values, so it resolves to exactly what it always
+  // did rather than to something newly computed.
   document.documentElement.style.setProperty(
     "--sw-hop-rise",
-    next ? "1" : String(1.6 / 1.1),
+    next ? "1" : "2.6",
+  );
+  document.documentElement.style.setProperty(
+    "--sw-group-ease",
+    next ? "cubic-bezier(0.34, 0.8, 0.28, 1)" : "cubic-bezier(0.65, 0, 0.35, 1)",
   );
 
   // AIM THE EYE BEFORE THE BODY GOES. Both snapshots are captured with this

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -211,24 +211,29 @@ const CLOSING: JumpArc = {
  * The result is an apex ~18px up at 57% of the travel, against 11.2px at ~20%.
  */
 const OPENING: JumpArc = {
+  // THE CLOSING ARC, FORESHORTENED. Every setting here except the keyframe name
+  // is the closing one's, because the two directions want the same SHAPE and
+  // differ only in how big that shape reads.
+  //
+  // It was derived from scratch for several rounds — ballistic travel, `linear`
+  // between stops, gravity sampled from a parabola — and each version fixed the
+  // complaint it was aimed at and read wrong overall. Tracing both body centres
+  // is what settled it: the closing arc peaks at 80% of its travel and DROPS
+  // onto the spot at 38deg, while every from-scratch opening arc peaked near
+  // the middle and glided in at around 12deg. That is not a landing, it is an
+  // approach, and no amount of retuning a symmetric parabola makes it one.
+  //
+  // Depth belongs in the SIZE of the arc, which is why only the lift is scaled
+  // (see `sw-monster-hop-open`), and it is scaled DOWN because this direction
+  // ends about 1.45x further from the reader.
   hop: "sw-monster-hop-open",
-  hopEase: "linear",
-  // ENDS AT CONSTANT VELOCITY, which is what stops the path hooking. The
-  // second control point sits at y == x, so the curve's slope at t=1 is 1
-  // rather than 0.67. With the old ease-out the horizontal SLOWED into the
-  // landing while the fall was still accelerating, and the trajectory bent
-  // sharply downward right at the spot -- the descent angle steepened 16.8deg
-  // over the last third, which reads as curving into the landing rather than
-  // arriving at it. It is 6.1deg now.
-  travel: "cubic-bezier(0.42, 0.3, 0.58, 0.58)",
-  // ENDS WITH THE HOP, not 60ms short of it. At the shared 620ms the creature
-  // finished travelling and then dropped straight down for the remaining 60ms,
-  // which is a stop followed by a fall rather than a landing.
-  travelMs: "680ms",
+  hopEase: CLOSING.hopEase,
+  travel: CLOSING.travel,
+  travelMs: CLOSING.travelMs,
   // NO FILLER. It is an opaque rectangle that travels with the group, and this
-  // arc lifts the creature a full box height clear of it — so instead of
-  // hiding a hole it dragged across the wordmark and blanked the letters mid
-  // reveal. Verified by eye that nothing dark appears in its absence here.
+  // direction crosses the wordmark as the letters are revealing, so instead of
+  // hiding a hole it blanks them. Verified by eye that nothing dark appears in
+  // its absence here.
   fill: "transparent",
 };
 


### PR DESCRIPTION
The creature was skimming forward instead of jumping, and the rail was closing
on the curve tuned for opening.

## An arc is three things, not one

This is the load-bearing finding, and it took unifying the two directions and
then splitting them again to see it:

| | keyframes | clock between them | travel |
|---|---|---|---|
| **closing** | `sw-monster-hop` | `cubic-bezier(0.34, 0.8, 0.28, 1)` | shaped `linear()`, apex at 82% |
| **opening** | `sw-monster-hop-open` | `linear` | `cubic-bezier(0.42, 0.3, 0.58, 0.72)`, apex at 57% |

The middle column is the one that hides. `animation-timing-function` applies
between **every pair of keyframes**, not once across the animation — so it is
part of the shape rather than a finish on top of it. Measured: with easeOutQuint
the creature is **77% of the way to a stop a third into the segment, 92% half
way through**. Every leg lands early and holds, which is exactly what "reaches
the apex too early" describes. The closing arc was authored *with* that and
reads correctly; the opening one is authored against `linear` so its keyframe
values are the trajectory. Neither survives being given the other's clock.

## The opening jump, rebuilt ballistically

A jump has no horizontal force, so horizontal velocity is **constant** and only
the vertical accelerates. Both of the opening direction's faults follow from
ignoring that:

| | before | after |
|---|---|---|
| peak horizontal speed | **3.4× mean** | **1.22×** |
| apex position | ~20% of travel | **57%** |
| apex height | 11.2px | **~18px** |
| launch | 27° | 33° |

## The closing jump is untouched

Restored to the shape signed off in `962822c` and **verified identical, keyframe
for keyframe**. Every fallback in `globals.css` is the closing pair, so a missing
custom property degrades to the approved shape rather than to a new one.

## Splitting deleted code rather than duplicating it

`--sw-hop-rise`, `LAUNCH` and `MARK_SCALE_RATIO` are all gone. That mechanism
existed to compensate for the two directions leaving different-sized snapshots
(21.88px out of the rail, 15.05px out of the word) — with a keyframe set per
direction, each is authored for the size it actually leaves. The closing launch
is now the literal `-57.216%`, which renders the same 8.61px the variable used
to compute.

## And the rail closes on its own curve

It was closing on the *opening* curve — easeOutQuint, **62px of 168px in the
first 40ms**, 79% shut by 120ms.

| | curve | duration |
|---|---|---|
| opening | `cubic-bezier(0.22, 1, 0.36, 1)` — unchanged | 440ms |
| **closing** | `cubic-bezier(0.6, 0.04, 0.3, 1)` | 660ms |

Direction-aware with no JavaScript: a transition reads its duration and easing
from the **after-change** style, so the branch being switched *to* times the move.

## Verified in the browser, not assumed

- All three custom properties confirmed switching per direction on a live toggle.
- The restored closing keyframes diffed against the approved commit — identical.
- The `linear()` parses (an unsupported one falls back to `ease` silently), and
  driving a 131px translate with it measures within a pixel of the design.

## Checks

- `npm run lint` — clean (6 pre-existing `no-img-element` warnings)
- `npx tsc --noEmit` in the app and `packages/ui` — both clean
- `npx vitest run` in the app — 1308/1308
- `npx vitest run --project=storybook` — 261/262; `Nest Into Collection On Strip`
  is the known full-run flake and passes 59/59 alone. Nothing in this diff is
  reachable from `VirtualStrip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)