### PR TITLE
The Renders collection is found by role, not by its name

### DIFF
--- a/apps/timeline-gstudio001/lib/render/attach-output.ts
+++ b/apps/timeline-gstudio001/lib/render/attach-output.ts
@@ -8,7 +8,8 @@ import { readStoredTimelineEntry } from "@/lib/firebase-timeline-store";
 
 import {
   RENDERS_COLLECTION_NAME,
-  findRendersCollectionId,
+  RENDERS_COLLECTION_ROLE,
+  findRendersCollection,
   renderClipName,
 } from "./renders-collection";
 import type { StoredRenderJob } from "./job-store";
@@ -54,12 +55,23 @@ function mintTimelineId(): string {
 async function ensureRendersCollection(
   timelineId: string,
   uid: string,
-): Promise<Readonly<{ ok: true; id: string }> | Readonly<{ ok: false; reason: string }>> {
+): Promise<
+  | Readonly<{ ok: true; id: string; needsRoleStamp: boolean }>
+  | Readonly<{ ok: false; reason: string }>
+> {
   const entry = await readStoredTimelineEntry(timelineId, uid);
   if (!entry) return { ok: false, reason: `No timeline with id "${timelineId}".` };
 
-  const existing = findRendersCollectionId(entry.document.clips);
-  if (existing !== null) return { ok: true, id: existing };
+  const existing = findRendersCollection(entry.document.clips);
+  if (existing !== null) {
+    // FOUND BY NAME MEANS IT PREDATES THE MARKER, and this is the moment to
+    // fix that: the caller is about to write into this collection anyway, so
+    // the stamp costs no extra round trip and the NEXT render resolves by role
+    // — after which the collection can be renamed freely. A project that never
+    // renders again is never migrated, which is correct: nothing is wrong with
+    // it until something looks for its Renders collection.
+    return { ok: true, id: existing.id, needsRoleStamp: existing.matchedBy === "title" };
+  }
 
   const childId = mintTimelineId();
   const outcome = await applyCollectionsCommand(
@@ -91,6 +103,11 @@ async function ensureRendersCollection(
             aspect: 16 / 9,
             trackIndex: 0,
             itemCount: 0,
+            // WHAT MAKES IT THE RENDERS COLLECTION. Set at creation so a
+            // collection minted here is never identified by its name — it can
+            // be renamed the minute after it appears and renders keep landing
+            // in it.
+            role: RENDERS_COLLECTION_ROLE,
             duration: 3,
             sourceDuration: 3,
             trimIn: 0,
@@ -112,7 +129,8 @@ async function ensureRendersCollection(
       reason: outcome.kind === "rejected" ? outcome.rejection.reason : outcome.message,
     };
   }
-  return { ok: true, id: childId };
+  // Created carrying its role already, so there is nothing to migrate.
+  return { ok: true, id: childId, needsRoleStamp: false };
 }
 
 export async function attachRenderOutput(
@@ -130,11 +148,33 @@ export async function attachRenderOutput(
     // The ROOT is the timeline whose closure gets loaded; the Renders
     // collection is a child of it, so it is in the graph.
     job.timelineId,
-    (graph: CollectionsGraph) => {
+    (graph: CollectionsGraph, existingDetails) => {
       const parentId = parseNodeId(collection.id);
       if (!graph.nodesById.has(parentId)) {
         return { ok: false, message: `Renders collection "${collection.id}" is not loaded.` } as const;
       }
+      // THE MIGRATION, folded into a write that was happening anyway. Adding
+      // this clip already rewrites the Renders collection's own document AND
+      // its parent's — a new child changes the collection's `itemCount` and
+      // duration, which are denormalized onto the root's clip for it — so the
+      // stamp rides along for free.
+      //
+      // The whole existing detail is respread because details merge PER NODE
+      // and not per field: parking `{role}` alone would replace this
+      // collection's entry outright and drop its `alt`, `aspect`, `itemCount`
+      // and preview frames on the floor.
+      //
+      // NO DETAIL MEANS NO STAMP, rather than a synthesized one. `alt` and
+      // `aspect` are required on a detail, so inventing an entry here would
+      // write a card that had lost whatever it was actually showing — and a
+      // Renders collection loaded into the graph always has one, so an absent
+      // detail is a broken assumption, not a case to paper over. The title
+      // fallback still resolves it, so this costs correctness nothing.
+      const current = existingDetails[collection.id];
+      const stamp =
+        collection.needsRoleStamp && current !== undefined
+          ? { [collection.id]: { ...current, role: RENDERS_COLLECTION_ROLE } }
+          : {};
       return {
         ok: true,
         command: {
@@ -158,6 +198,7 @@ export async function attachRenderOutput(
           ],
         },
         details: {
+          ...stamp,
           [clipId]: {
             alt: name,
             title: name,

--- a/apps/timeline-gstudio001/lib/render/renders-collection.test.ts
+++ b/apps/timeline-gstudio001/lib/render/renders-collection.test.ts
@@ -4,6 +4,8 @@ import type { TimelineClip } from "@storyboard/timeline-model/types";
 
 import {
   RENDERS_COLLECTION_NAME,
+  RENDERS_COLLECTION_ROLE,
+  findRendersCollection,
   findRendersCollectionId,
   renderClipName,
 } from "./renders-collection";
@@ -12,6 +14,7 @@ function collectionClip(
   title: string,
   childTimelineId: string,
   clipId = childTimelineId,
+  role?: "renders",
 ): TimelineClip {
   return {
     id: clipId,
@@ -19,6 +22,7 @@ function collectionClip(
     kind: "collection",
     childTimelineId,
     title,
+    ...(role === undefined ? {} : { role }),
     itemCount: 0,
     previewItems: [],
     alt: `${title} collection`,
@@ -98,6 +102,54 @@ describe("findRendersCollectionId", () => {
 
   it("uses the same name it looks for", () => {
     expect(findRendersCollectionId([collectionClip(RENDERS_COLLECTION_NAME, "t-r")])).toBe("t-r");
+  });
+});
+
+describe("findRendersCollection — the role marker", () => {
+  it("finds a marked collection whatever it is called", () => {
+    // THE BUG THIS CLOSES. Renaming the collection used to send the next
+    // render into a newly created "Renders" beside it, splitting the output.
+    const clips = [collectionClip("Final cuts", "timeline-renders", "timeline-renders", "renders")];
+    expect(findRendersCollection(clips)).toEqual({
+      id: "timeline-renders",
+      matchedBy: "role",
+    });
+  });
+
+  it("reports a title match as one, so the caller knows to stamp it", () => {
+    expect(findRendersCollection([collectionClip("Renders", "t-r")])).toEqual({
+      id: "t-r",
+      matchedBy: "title",
+    });
+  });
+
+  it("prefers the MARKED collection over one merely named Renders", () => {
+    // The other half of the bug: naming any top-level collection "Renders"
+    // used to capture the project's output. Order matters here — the impostor
+    // is first, so a single pass that took the first match would fail.
+    const clips = [
+      collectionClip("Renders", "timeline-impostor"),
+      collectionClip("Final cuts", "timeline-real", "timeline-real", "renders"),
+    ];
+    expect(findRendersCollection(clips)?.id).toBe("timeline-real");
+  });
+
+  it("ignores a marker on a duplicate REFERENCE, like the title pass does", () => {
+    // clip id != childTimelineId: writing here files renders under a timeline
+    // this project does not own. A role does not buy past that.
+    const clips = [
+      collectionClip("Renders", "timeline-elsewhere", "ref-clip-1", "renders"),
+    ];
+    expect(findRendersCollection(clips)).toBeNull();
+  });
+
+  it("falls back to the title for every project that predates the marker", () => {
+    expect(findRendersCollectionId([collectionClip("Renders", "t-r")])).toBe("t-r");
+  });
+
+  it("looks for the role the app stamps", () => {
+    const clips = [collectionClip("anything", "t-r", "t-r", RENDERS_COLLECTION_ROLE)];
+    expect(findRendersCollection(clips)?.matchedBy).toBe("role");
   });
 });
 

--- a/apps/timeline-gstudio001/lib/render/renders-collection.ts
+++ b/apps/timeline-gstudio001/lib/render/renders-collection.ts
@@ -1,42 +1,86 @@
 import type { TimelineClip } from "@storyboard/timeline-model/types";
 
 /**
- * Where finished renders land: a collection named "Renders" at the top of the
- * project, which is the convention this project already follows for finished
- * cuts.
+ * The name a Renders collection is CREATED with, and the one the fallback
+ * below recognises.
  *
- * Resolved BY NAME rather than by a configured id. A hardcoded id would tie
- * the app to one owner's project, and an env var would be one more thing to
- * set correctly before an export could work at all. A name is self-configuring
- * — it finds an existing Renders collection, and creates one if there is none.
+ * Not a configured id and not an env var, for the reasons that have always
+ * applied: a hardcoded id would tie the app to one owner's project, and an env
+ * var would be one more thing to set correctly before an export could work at
+ * all. Self-configuring is the property worth keeping.
+ *
+ * WHAT CHANGED IS THAT THE NAME IS NO LONGER THE IDENTITY. It is a default and
+ * a legacy fallback; `role: "renders"` on the clip is what actually resolves
+ * the collection now. So this string may be renamed by a person without
+ * anything breaking, which is the whole point (#464).
  */
 export const RENDERS_COLLECTION_NAME = "Renders";
 
+/** The marker that identifies the collection, independent of what it is
+ *  called. See `CollectionTimelineClip["role"]`. */
+export const RENDERS_COLLECTION_ROLE = "renders" as const;
+
 /**
- * The child timeline id of the project's Renders collection, or null.
+ * How the collection was identified — which is worth reporting rather than
+ * hiding, because it is what the caller needs to decide whether to stamp.
  *
- * Matches case-insensitively on the trimmed title, because this name is typed
- * by a human: "renders" and "Renders " are the same intent, and creating a
- * second collection because of a capital letter is the kind of thing that
- * quietly splits a project's output in two.
+ * `"role"` is the answer this function wants to give. `"title"` means it fell
+ * back, and the caller should mark the clip so the next lookup does not have
+ * to (see `attachRenderOutput`).
+ */
+export type RendersCollectionMatch = Readonly<{
+  id: string;
+  matchedBy: "role" | "title";
+}>;
+
+/**
+ * The project's Renders collection, or null.
  *
- * OWNING PLACEMENTS ONLY. A collection clip whose id differs from its
- * `childTimelineId` is a duplicate REFERENCE to a collection that lives
- * somewhere else — writing renders into it would file them under a timeline
- * this project does not own, and the first one would look fine.
+ * TWO PASSES, AND THE ORDER IS THE FIX. The role marker wins outright; the
+ * title is consulted only when nothing carries one. That ordering is what
+ * makes a rename safe — a marked collection keeps receiving renders under any
+ * name — and it has to be two full passes rather than one loop preferring a
+ * role, because a project mid-migration can hold both: the real (marked)
+ * Renders collection sitting after some other collection a person happened to
+ * name "Renders". Deciding on the first match in document order would hand
+ * that project's output to the impostor, which is one of the two bugs this
+ * exists to close.
+ *
+ * The title pass keeps matching case-insensitively on the trimmed name,
+ * because that name was typed by a human: "renders" and "Renders " are the
+ * same intent, and creating a second collection over a capital letter is the
+ * kind of thing that quietly splits a project's output in two.
+ *
+ * OWNING PLACEMENTS ONLY, in both passes. A collection clip whose id differs
+ * from its `childTimelineId` is a duplicate REFERENCE to a collection that
+ * lives somewhere else — writing renders into it would file them under a
+ * timeline this project does not own, and the first one would look fine.
  *
  * Direct children only, not a recursive search: "the project's Renders
  * collection" is a specific place, and a nested one belonging to some scene is
  * a different thing that happens to share a name.
  */
-export function findRendersCollectionId(clips: readonly TimelineClip[]): string | null {
+export function findRendersCollection(
+  clips: readonly TimelineClip[],
+): RendersCollectionMatch | null {
+  for (const clip of clips) {
+    if (clip.kind !== "collection") continue;
+    if (clip.childTimelineId !== clip.id) continue;
+    if (clip.role !== RENDERS_COLLECTION_ROLE) continue;
+    return { id: clip.childTimelineId, matchedBy: "role" };
+  }
   for (const clip of clips) {
     if (clip.kind !== "collection") continue;
     if (clip.childTimelineId !== clip.id) continue;
     if (clip.title.trim().toLowerCase() !== RENDERS_COLLECTION_NAME.toLowerCase()) continue;
-    return clip.childTimelineId;
+    return { id: clip.childTimelineId, matchedBy: "title" };
   }
   return null;
+}
+
+/** The id alone, for callers with nothing to decide. */
+export function findRendersCollectionId(clips: readonly TimelineClip[]): string | null {
+  return findRendersCollection(clips)?.id ?? null;
 }
 
 /**

--- a/packages/timeline-domain/src/adapter.ts
+++ b/packages/timeline-domain/src/adapter.ts
@@ -118,6 +118,10 @@ export type ClipDetail = Readonly<{
   trashedAt?: string;
   trashedFrom?: TrashOrigin;
   itemCount?: number;
+  /** What a collection is FOR — see `CollectionTimelineClip["role"]`. Rides
+   *  the side-table for the same reason `tags` and `sourceAsset` do: the
+   *  engine never reads it, so no graph command is needed to carry it. */
+  role?: CollectionTimelineClip["role"];
   previewItems?: CollectionTimelineClip["previewItems"];
   /** The collection clip's own display duration in its parent timeline — its
    *  LAYOUT span, disabled descendants included. */
@@ -250,6 +254,7 @@ function collectionDetail(clip: CollectionTimelineClip, hydrated: boolean): Clip
     ...(clip.trashedFrom === undefined ? {} : { trashedFrom: clip.trashedFrom }),
     sourceClipId: clip.id,
     itemCount: clip.itemCount,
+    ...(clip.role === undefined ? {} : { role: clip.role }),
     ...(clip.previewItems === undefined ? {} : { previewItems: clip.previewItems }),
     duration: clip.duration,
     ...(clip.playableDuration === undefined
@@ -1154,6 +1159,7 @@ export function graphChildrenToClips(
       itemCount: detail?.hydrated
         ? getChildren(graph, node.id).length
         : (detail?.itemCount ?? getChildren(graph, node.id).length),
+      ...(detail?.role === undefined ? {} : { role: detail.role }),
       ...(previewItems === undefined ? {} : { previewItems }),
       ...(playableDuration === undefined ? {} : { playableDuration }),
       alt: detail?.alt ?? `${node.name} collection`,

--- a/packages/timeline-domain/src/role-roundtrip.test.ts
+++ b/packages/timeline-domain/src/role-roundtrip.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import type { TimelineDocument } from "@storyboard/timeline-model/types";
+
+import { buildFocusedGraph, graphChildrenToClips } from "./adapter";
+
+// A collection's `role` lives only on the DETAIL side-table, the same seam
+// `tags` and `sourceAsset` use: the engine never reads it, so no graph command
+// carries it and the write-back in `graphChildrenToClips` is the only thing
+// keeping it alive.
+//
+// That makes this loop load-bearing AND invisible. Drop the write-back and
+// there is no type error and nothing to notice — the marker simply disappears
+// on the next ordinary save, the resolver silently falls back to matching the
+// title again, and the bug it was added for (#464) is back with a field in the
+// database that looks like it should be preventing it.
+
+function collectionDoc(
+  role: "renders" | undefined,
+  extra: Partial<TimelineDocument> = {},
+): TimelineDocument {
+  return {
+    id: "root",
+    title: "Project",
+    clips: [
+      {
+        id: "timeline-r",
+        index: 0,
+        kind: "collection",
+        title: "Final cuts",
+        childTimelineId: "timeline-r",
+        ...(role === undefined ? {} : { role }),
+        itemCount: 0,
+        alt: "Final cuts collection",
+        aspect: 16 / 9,
+        trackIndex: 0,
+        startTime: 0,
+        duration: 3,
+        sourceDuration: 3,
+        trimIn: 0,
+        trimOut: 0,
+      },
+    ],
+    ...extra,
+  };
+}
+
+function roundTrip(doc: TimelineDocument) {
+  const built = buildFocusedGraph({ [doc.id]: doc }, doc.id, 1);
+  expect(built.ok).toBe(true);
+  if (!built.ok) throw new Error(built.error);
+  return graphChildrenToClips(built.value.graph, built.value.details, doc.id);
+}
+
+describe("a collection's role survives the graph round-trip", () => {
+  it("keeps the marker on a collection whose TITLE says nothing about it", () => {
+    // The title is deliberately not "Renders": if the round-trip lost the role
+    // and something later re-derived it from the name, this collection would
+    // stop being findable at all rather than appear to still work.
+    const out = roundTrip(collectionDoc("renders"));
+    expect(out).toHaveLength(1);
+    expect(out[0].kind).toBe("collection");
+    expect(out[0]).toMatchObject({ title: "Final cuts", role: "renders" });
+  });
+
+  it("does not invent one for an ordinary collection", () => {
+    // Absent is the normal case — every collection a person makes — so the
+    // field must not appear merely because the clip went through the adapter.
+    const out = roundTrip(collectionDoc(undefined));
+    expect(out[0]).not.toHaveProperty("role");
+  });
+
+  it("survives a rename, which is the whole point of the marker", () => {
+    const first = roundTrip(collectionDoc("renders"));
+    const renamed: TimelineDocument = {
+      id: "root",
+      title: "Project",
+      clips: [{ ...first[0], title: "Outputs 2026" }],
+    };
+    expect(roundTrip(renamed)[0]).toMatchObject({
+      title: "Outputs 2026",
+      role: "renders",
+    });
+  });
+});

--- a/packages/timeline-model/types.ts
+++ b/packages/timeline-model/types.ts
@@ -234,6 +234,28 @@ export type CollectionTimelineClip = TimelineItemBase & {
   kind: "collection";
   title: string;
   childTimelineId: string;
+  /**
+   * What this collection is FOR, when the app needs to find it again.
+   *
+   * Only `"renders"` today: the place finished renders are filed. It exists
+   * because that collection used to be resolved by matching its TITLE, which
+   * made the name load-bearing in a way nothing told the reader — rename it and
+   * the next render created a second "Renders" beside the first, silently
+   * splitting a project's output; call any top-level collection "Renders" and
+   * output landed in it.
+   *
+   * ABSENT IS NORMAL and always will be. Every collection a person makes has no
+   * role, so this is not a migration anyone has to run: the resolver falls back
+   * to the title when nothing carries the marker, and stamps it on the next
+   * render (see `findRendersCollectionId` and `attachRenderOutput`).
+   *
+   * ON THE CLIP, NOT THE CHILD DOCUMENT, because the lookup runs over a
+   * parent's clips — a marker on the child would cost a read per candidate to
+   * ask a question the parent can already answer. That is denormalization, but
+   * the safe kind: unlike `itemCount` or `duration` a role is not DERIVED from
+   * anything, so there is nothing for it to drift out of agreement with.
+   */
+  role?: "renders";
   itemCount: number;
   /**
    * Seconds of this collection that actually PLAY — its child's enabled clips

--- a/packages/timeline-model/validate.ts
+++ b/packages/timeline-model/validate.ts
@@ -173,6 +173,14 @@ export function isTimelineClip(value: unknown): value is TimelineClip {
     }
     // A count of children: integral and never negative.
     if (!isNonNegativeInteger(clip.itemCount)) return false;
+    // What the collection is FOR. Absent on every collection a person makes,
+    // so only the known values are refused-if-wrong — and checked BEFORE the
+    // `previewItems` early return below, which would otherwise wave a
+    // malformed role straight through. A role the app does not recognise is
+    // worse than none: the resolver would skip the marked collection and fall
+    // back to the title, i.e. exactly the bug the marker exists to fix, except
+    // now with a stored field that looks like it should be working.
+    if (clip.role !== undefined && clip.role !== "renders") return false;
     // The playable half of a collection's span. Optional, and never longer
     // than the layout span it is derived from — it counts the ENABLED subset.
     if (!isOptionalNonNegative(clip.playableDuration)) return false;


### PR DESCRIPTION
Closes #464.

`findRendersCollectionId` resolved the project's Renders collection with a case-insensitive **title match**, which made the name load-bearing in a way nothing told the reader:

- rename the collection → the next render created a second "Renders" beside it, silently splitting the project's output
- name *any* top-level collection "Renders" → renders landed there instead

## What changed

A collection clip can carry `role?: "renders"`, and the resolver prefers it over the title.

**Two full passes, not one loop that prefers a role.** A project mid-migration can hold both — the real (marked) collection sitting after some other collection a person happened to name "Renders" — and deciding on the first match in document order would hand that project's output to the impostor. That case is covered by a test.

**On the clip, not the child document**, because the lookup runs over a parent's clips; a marker on the child would cost a read per candidate to answer a question the parent already can. Denormalized, but the safe kind: unlike `itemCount` or `duration`, a role is not *derived* from anything, so there is nothing for it to drift out of agreement with.

**It rides the detail side-table** like `tags` and `sourceAsset` — the engine never reads it, so no graph command carries it, and the write-back in `graphChildrenToClips` is the only thing keeping it alive.

## Migration: none by hand

The title match stays as the fallback, and `findRendersCollection` reports *how* it matched so the caller knows to stamp. `attachRenderOutput` folds the stamp into a write that was already happening — adding the render clip rewrites the collection's own document and its parent's anyway, so it costs no extra round trip. A project that never renders again is never migrated, which is correct: nothing is wrong with it until something looks for its Renders collection.

The whole existing detail is respread when stamping, because details merge per NODE and not per field — parking `{role}` alone would have dropped the collection's `alt`, `aspect`, `itemCount` and preview frames.

## Verification

Both regression suites were confirmed to fail without the fix, not just to pass with it:

- resolver, with the role pass removed → 3 failed / 15 passed (the 15 are the title behaviour, which must keep working)
- round-trip, with the adapter write-back removed → 2 failed / 1 passed

Full runs: 1314 app tests, 786 unit tests, `tsc` clean in the app and `packages/ui`, lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)