### PR TITLE
Lift the monster's animation into its frames page by script

### DIFF
--- a/scratch/monster-jump-frames.html
+++ b/scratch/monster-jump-frames.html
@@ -1,0 +1,1425 @@
+<title>Monster Jump Frames</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link
+  rel="stylesheet"
+  href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,600;12..96,800&family=Martian+Mono:wght@400;600&display=swap"
+>
+
+<style>
+  /* Palette taken from the creature: sage is its body, rust its hat, denim its
+     feet, cream its eye. Every colour on this page is already on the drawing it
+     describes. */
+  :root {
+    --sage: oklch(0.86 0.17 128);
+    --rust: oklch(0.7 0.18 45);
+    --denim: oklch(0.68 0.115 245);
+    --cream: oklch(0.96 0.02 95);
+
+    /* The stage never follows the theme. Half the mark's colours were chosen
+       AGAINST near-black, so on paper it would be a different drawing. */
+    --stage: #080b08;
+    --stage-line: #1e2a1c;
+
+    --ground: #eeeee7;
+    --panel: #f7f7f1;
+    --ink: #161911;
+    --muted: #5b6353;
+    --rule: #d9dace;
+    --shadow: 0 1px 2px rgb(20 26 16 / 0.07), 0 8px 24px -12px rgb(20 26 16 / 0.2);
+
+    /* The instrument face, for anything measured. */
+    --mono: "Martian Mono", ui-monospace, "Cascadia Code", Menlo, Consolas,
+      monospace;
+    /* The voice, for anything said. */
+    --prose: "Bricolage Grotesque", ui-sans-serif, system-ui, -apple-system,
+      "Segoe UI", sans-serif;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --ground: #0f130f;
+      --panel: #161b15;
+      --ink: #e3e8dc;
+      --muted: #8b9381;
+      --rule: #262d24;
+      --shadow: 0 1px 2px rgb(0 0 0 / 0.4), 0 8px 24px -12px rgb(0 0 0 / 0.7);
+    }
+  }
+
+  :root[data-theme="dark"] {
+    --ground: #0f130f;
+    --panel: #161b15;
+    --ink: #e3e8dc;
+    --muted: #8b9381;
+    --rule: #262d24;
+    --shadow: 0 1px 2px rgb(0 0 0 / 0.4), 0 8px 24px -12px rgb(0 0 0 / 0.7);
+  }
+
+  body {
+    margin: 0;
+    background: var(--ground);
+    color: var(--ink);
+    font-family: var(--prose);
+    font-size: 15px;
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wrap {
+    max-width: 68rem;
+    margin: 0 auto;
+    padding: clamp(1.5rem, 4vw, 3.5rem) clamp(1rem, 4vw, 2rem) 4rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2.5rem;
+  }
+
+  header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .eyebrow {
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+
+  h1 {
+    margin: 0;
+    font-size: clamp(2rem, 6vw, 3.25rem);
+    font-weight: 800;
+    letter-spacing: -0.035em;
+    text-wrap: balance;
+    line-height: 1.05;
+  }
+
+  h1 em {
+    font-style: normal;
+    color: var(--sage);
+  }
+
+  .standfirst {
+    font-size: 17px;
+    color: var(--muted);
+    max-width: 62ch;
+    margin: 0;
+  }
+
+  section {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  h2 {
+    margin: 0;
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--muted);
+    font-weight: 600;
+  }
+
+  .note {
+    font-size: 15px;
+    color: var(--muted);
+    max-width: 68ch;
+    margin: 0;
+  }
+
+  .note b {
+    color: var(--ink);
+    font-weight: 600;
+  }
+
+  /* -- The contact sheet ----------------------------------------------------
+     Every cell is a REAL creature with the shipped animations paused at its own
+     millisecond, not a redrawing. That is the only way the sheet can be trusted:
+     change a keyframe and every frame here changes with it. */
+  .sheet {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(7rem, 1fr));
+    gap: 1px;
+    background: var(--stage-line);
+    border: 1px solid var(--stage-line);
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: var(--shadow);
+  }
+
+  .frame {
+    position: relative;
+    background: var(--stage);
+    aspect-ratio: 3 / 4;
+  }
+
+  /* The ground the creature leaves, drawn in every cell so the arc reads across
+     the sheet rather than each frame floating on its own. */
+  .frame .floor {
+    position: absolute;
+    left: 14%;
+    right: 14%;
+    bottom: 32%;
+    height: 1px;
+    background: var(--stage-line);
+  }
+
+  .frame .rig {
+    position: absolute;
+    left: 50%;
+    margin-left: -1.4rem;
+    bottom: calc(32% + 0.25rem);
+    font-size: 2.8rem;
+    line-height: 1;
+    transform-origin: 50% 88%;
+  }
+
+  .t {
+    position: absolute;
+    left: 0.5rem;
+    bottom: 0.45rem;
+    z-index: 1;
+    font-family: var(--mono);
+    font-size: 8px;
+    color: #6b7768;
+    font-variant-numeric: tabular-nums;
+  }
+
+  [data-phase="flight"] .t {
+    color: var(--sage);
+  }
+
+  [data-phase="settle"] .t {
+    color: var(--rust);
+  }
+
+  .beat {
+    position: absolute;
+    right: 0.5rem;
+    bottom: 0.45rem;
+    z-index: 1;
+    font-family: var(--mono);
+    font-size: 8px;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    color: #7d8a79;
+  }
+
+  /* -- The eye, magnified -------------------------------------------------
+     The back half of the jump is almost entirely a 2.7px pupil, which at
+     contact-sheet size is below the resolution of the sheet above. Same
+     creatures, same clock, cropped to the eye. */
+  .eyesheet {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(4.5rem, 1fr));
+    gap: 1px;
+    background: var(--stage-line);
+    border: 1px solid var(--stage-line);
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: var(--shadow);
+  }
+
+  .eyeframe {
+    position: relative;
+    background: var(--stage);
+    aspect-ratio: 1;
+    overflow: hidden;
+    /* So the crop scales with the cell instead of pinning to one rem size. */
+    container-type: inline-size;
+  }
+
+  .eyeframe .rig {
+    position: absolute;
+    line-height: 1;
+    /* 0.64em of eye at 125% of the cell width fills 80% of it, and the offsets
+       are the eye's centre measured from the MARK's origin rather than the
+       body's: 0.01 body + 0.17 eye + 0.32 radius = 0.50em, the same on both
+       axes now that the head is round. */
+    font-size: 125cqi;
+    left: calc(50% - 0.5em);
+    top: calc(50% - 0.5em);
+  }
+
+  /* -- The arc, traced -----------------------------------------------------
+     Not a plot of what the numbers SHOULD do. A real creature runs the real
+     animation and its body centre is sampled every frame; the line is what was
+     observed. If the keyframes and the trajectory ever disagree, this is the
+     one that is right. */
+  .arcstage {
+    position: relative;
+    background: var(--stage);
+    border-radius: 14px;
+    overflow: hidden;
+    box-shadow: var(--shadow);
+    height: 21rem;
+  }
+
+  .arcstage svg {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  #arc-rig {
+    position: absolute;
+    left: 0;
+    top: 0;
+    line-height: 1;
+    /* The creature is driven by the same two clocks the app uses: the hop on
+       itself, the travel on this wrapper. */
+    will-change: transform;
+  }
+
+  .arc-readout {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.25rem;
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--muted);
+  }
+
+  .arc-readout b {
+    color: var(--ink);
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* -- Controls ----------------------------------------------------------- */
+  .phasebar {
+    display: flex;
+    gap: 2px;
+    font-family: var(--mono);
+    font-size: 10px;
+    line-height: 1.4;
+  }
+
+  .ph {
+    padding: 0.5rem 0.7rem;
+    border-radius: 8px;
+    color: var(--stage);
+    /* The two phases are different lengths; let the flex basis say so. */
+    flex-grow: var(--ms);
+    flex-basis: 0;
+    min-width: 0;
+  }
+
+  .ph b {
+    display: block;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .ph span {
+    display: block;
+    font-family: var(--prose);
+    font-size: 12px;
+    opacity: 0.72;
+    text-wrap: pretty;
+  }
+
+  .ph.flight {
+    background: var(--sage);
+  }
+
+  .ph.settle {
+    background: var(--rust);
+  }
+
+  .transport {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  button {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.02em;
+    color: var(--ink);
+    background: var(--panel);
+    border: 1px solid var(--rule);
+    border-radius: 8px;
+    padding: 0.5rem 0.9rem;
+    cursor: pointer;
+  }
+
+  button:hover {
+    border-color: var(--muted);
+  }
+
+  button:focus-visible {
+    outline: 2px solid var(--sage);
+    outline-offset: 2px;
+  }
+
+  .seg {
+    display: flex;
+    gap: 2px;
+    padding: 2px;
+    background: var(--panel);
+    border: 1px solid var(--rule);
+    border-radius: 10px;
+  }
+
+  .seg button {
+    border: 0;
+    background: transparent;
+    border-radius: 7px;
+    padding: 0.4rem 0.7rem;
+  }
+
+  /* SPECIFICITY, not source order. `.seg button` and `button[aria-pressed]` tie
+     at (0,1,1), so the later transparent background would silently win and the
+     selected rate would render identically to the others. */
+  .seg button[aria-pressed="true"] {
+    background: var(--sage);
+    color: #0d1206;
+  }
+
+  #antennae-toggle[aria-pressed="false"] {
+    color: var(--muted);
+  }
+
+  .spacer {
+    flex: 1 1 auto;
+  }
+
+  .clock {
+    font-family: var(--mono);
+    font-variant-numeric: tabular-nums;
+    font-size: 11px;
+    color: var(--muted);
+  }
+
+  .clock b {
+    color: var(--ink);
+    font-weight: 600;
+  }
+
+  /* -- The single-frame stage --------------------------------------------- */
+  .stage {
+    position: relative;
+    background: var(--stage);
+    border-radius: 14px;
+    overflow: hidden;
+    min-height: 22rem;
+    box-shadow: var(--shadow);
+  }
+
+  .stage .floor {
+    position: absolute;
+    left: 12%;
+    right: 12%;
+    bottom: 3.2rem;
+    height: 1px;
+    background: linear-gradient(
+      to right,
+      transparent,
+      var(--stage-line) 12%,
+      var(--stage-line) 88%,
+      transparent
+    );
+  }
+
+  #rig {
+    position: absolute;
+    left: 50%;
+    /* A negative margin rather than a translate: the hop owns `transform` on
+       this element and would overwrite it. */
+    margin-left: -3.5rem;
+    bottom: 4rem;
+    font-size: 7rem;
+    line-height: 1;
+    /* The pivot the shipped rule uses -- a jump turns about the ground. */
+    transform-origin: 50% 88%;
+  }
+
+  .stage-meta {
+    position: absolute;
+    top: 0.9rem;
+    left: 1rem;
+    right: 1rem;
+    display: flex;
+    justify-content: space-between;
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: #4a5647;
+  }
+
+  .stage-meta b {
+    font-weight: 500;
+    color: var(--sage);
+    font-variant-numeric: tabular-nums;
+  }
+
+  input[type="range"] {
+    width: 100%;
+    accent-color: var(--sage);
+    cursor: pointer;
+  }
+
+  input[type="range"]:focus-visible {
+    outline: 2px solid var(--sage);
+    outline-offset: 4px;
+  }
+
+  footer {
+    border-top: 1px solid var(--rule);
+    padding-top: 1.25rem;
+    font-size: 14px;
+    color: var(--muted);
+    max-width: 68ch;
+  }
+
+  code {
+    font-family: var(--mono);
+    font-size: 0.9em;
+    color: var(--ink);
+  }
+
+  /* -- The shipped rules, lifted out of globals.css by name ---------------
+     Regenerated by `remark.py` rather than retyped, so a keyframe edit in the
+     app reaches this page on the next run. Anything between the two markers is
+     machine-written; edit the stylesheet, not this. */
+  /* SW_LIFTED_START */
+  [data-storyboard-monster][data-aiming]:not([data-landing]) [data-monster-eye] {
+    transform: translateX(calc(var(--sw-hop-dir, 1) * 0.06em));
+  }
+
+  [data-storyboard-monster][data-aiming]:not([data-landing]) [data-monster-pupil] {
+
+    --monster-gaze-x: calc(var(--sw-hop-dir, 1) * 0.02em);
+  }
+
+  [data-storyboard-monster][data-aiming] [data-monster-pupil] {
+
+    translate: calc(var(--sw-hop-dir, 1) * 26%) 0;
+    scale: 1.2;
+    transform: translateY(-5%);
+  }
+
+  [data-storyboard-monster][data-aiming] [data-monster-antennae] {
+    --sw-antenna-bend: calc(var(--sw-hop-dir, 1) * -10deg);
+  }
+
+  [data-storyboard-monster][data-settling] [data-monster-pupil] {
+
+    animation:
+      sw-pupil-saccade 320ms linear both,
+      sw-pupil-bob 440ms cubic-bezier(0.32, 0.72, 0.3, 1) both,
+      sw-pupil-constrict 800ms cubic-bezier(0.22, 0.6, 0.3, 1) 460ms both;
+  }
+
+  [data-storyboard-monster] [data-monster-foot] {
+    transform-origin: 50% 100%;
+  }
+
+  [data-storyboard-monster][data-aiming]:not([data-landing]) [data-monster-foot="left"] {
+    transform-origin: 100% 0;
+    transform: rotate(-22deg);
+  }
+
+  [data-storyboard-monster][data-aiming]:not([data-landing]) [data-monster-foot="right"] {
+    transform-origin: 0 0;
+    transform: rotate(22deg);
+  }
+
+  [data-storyboard-monster][data-settling] [data-monster-foot] {
+
+    animation: sw-foot-settle 460ms cubic-bezier(0.22, 1, 0.36, 1) 40ms both;
+  }
+
+  [data-storyboard-monster][data-settling] [data-monster-body],
+  [data-storyboard-monster][data-settling] [data-monster-fur] {
+    animation: sw-body-settle 640ms cubic-bezier(0.3, 0.7, 0.28, 1) both;
+  }
+
+  [data-storyboard-monster][data-settling] [data-monster-antennae] {
+    animation: sw-antennae-settle 640ms cubic-bezier(0.3, 0.7, 0.28, 1) both;
+  }
+
+  @property --sw-antenna-bend {
+    syntax: "<angle>";
+    inherits: true;
+    initial-value: 0deg;
+  }
+
+  @keyframes sw-monster-hop {
+
+    0% {
+      transform: translate(0, 0) rotate(0deg) scale(1, 1);
+    }
+    17% {
+      transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * -1%), 8%) rotateY(calc(var(--sw-hop-dir, 1) * -3deg)) rotate(calc(var(--sw-hop-dir, 1) * -1deg)) skewX(calc(var(--sw-hop-dir, 1) * 1.5deg)) scale(1.22, 0.78);
+    }
+    32% {
+      transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2%), -57.216%) rotateY(calc(var(--sw-hop-dir, 1) * 9deg)) rotate(calc(var(--sw-hop-dir, 1) * 4deg)) skewX(calc(var(--sw-hop-dir, 1) * -4deg)) scale(0.84, 1.22);
+    }
+    58% {
+      transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 3%), -64%) rotateY(calc(var(--sw-hop-dir, 1) * 16deg)) rotate(calc(var(--sw-hop-dir, 1) * 6deg)) skewX(calc(var(--sw-hop-dir, 1) * -7deg)) scale(0.82, 1.24);
+    }
+    82% {
+      transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1%), -20%) rotateY(calc(var(--sw-hop-dir, 1) * 14deg)) rotate(calc(var(--sw-hop-dir, 1) * -2deg)) skewX(calc(var(--sw-hop-dir, 1) * -3deg)) scale(0.92, 1.1);
+    }
+    100% {
+      transform: perspective(140px) translate(0, 0)
+        rotateY(calc(var(--sw-hop-dir, 1) * 10deg)) rotate(0deg) scale(1, 1);
+    }
+  }
+
+  @keyframes sw-monster-hop-open {
+
+    0% {
+      transform: translate(0, 0) rotate(0deg) scale(1, 1);
+    }
+    17% {
+      transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * -1%), 8%) rotateY(calc(var(--sw-hop-dir, 1) * -3deg)) rotate(calc(var(--sw-hop-dir, 1) * -1deg)) skewX(calc(var(--sw-hop-dir, 1) * 1.5deg)) scale(1.220, 0.780);
+    }
+    32% {
+      transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2%), -27.54%) rotateY(calc(var(--sw-hop-dir, 1) * 9deg)) rotate(calc(var(--sw-hop-dir, 1) * 4deg)) skewX(calc(var(--sw-hop-dir, 1) * -4deg)) scale(0.820, 1.240);
+    }
+    58% {
+      transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 3%), -44.8%) rotateY(calc(var(--sw-hop-dir, 1) * 16deg)) rotate(calc(var(--sw-hop-dir, 1) * 6deg)) skewX(calc(var(--sw-hop-dir, 1) * -7deg)) scale(1.000, 1.000);
+    }
+    66% {
+      transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 2.333%), -43.17%) rotateY(calc(var(--sw-hop-dir, 1) * 15.33deg)) rotate(calc(var(--sw-hop-dir, 1) * 3.333deg)) skewX(calc(var(--sw-hop-dir, 1) * -5.667deg)) scale(0.966, 1.046);
+    }
+    73% {
+      transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1.75%), -39.09%) rotateY(calc(var(--sw-hop-dir, 1) * 14.75deg)) rotate(calc(var(--sw-hop-dir, 1) * 1deg)) skewX(calc(var(--sw-hop-dir, 1) * -4.5deg)) scale(0.936, 1.086);
+    }
+    80% {
+      transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 1.167%), -32.51%) rotateY(calc(var(--sw-hop-dir, 1) * 14.17deg)) rotate(calc(var(--sw-hop-dir, 1) * -1.333deg)) skewX(calc(var(--sw-hop-dir, 1) * -3.333deg)) scale(0.906, 1.126);
+    }
+    86% {
+      transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0.7778%), -24.89%) rotateY(calc(var(--sw-hop-dir, 1) * 13.11deg)) rotate(calc(var(--sw-hop-dir, 1) * -1.556deg)) skewX(calc(var(--sw-hop-dir, 1) * -2.333deg)) scale(0.880, 1.160);
+    }
+    91% {
+      transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0.5%), -17.14%) rotateY(calc(var(--sw-hop-dir, 1) * 12deg)) rotate(calc(var(--sw-hop-dir, 1) * -1deg)) skewX(calc(var(--sw-hop-dir, 1) * -1.5deg)) scale(0.859, 1.189);
+    }
+    96% {
+      transform: perspective(140px) translate(calc(var(--sw-hop-dir, 1) * 0.2222%), -8.127%) rotateY(calc(var(--sw-hop-dir, 1) * 10.89deg)) rotate(calc(var(--sw-hop-dir, 1) * -0.4444deg)) skewX(calc(var(--sw-hop-dir, 1) * -0.6667deg)) scale(0.837, 1.217);
+    }
+    100% {
+      transform: perspective(140px) translate(0, 0)
+        rotateY(calc(var(--sw-hop-dir, 1) * 10deg)) rotate(0deg) scale(1, 1);
+    }
+  }
+
+  @keyframes sw-monster-untwist {
+    0% {
+      transform: perspective(140px) rotateY(calc(var(--sw-hop-dir, 1) * 10deg));
+    }
+    62% {
+      transform: perspective(140px) rotateY(calc(var(--sw-hop-dir, 1) * -2.5deg));
+    }
+    100% {
+      transform: perspective(140px) rotateY(0deg);
+    }
+  }
+
+  @keyframes sw-pupil-saccade {
+
+    0%,
+    40% {
+      translate: calc(var(--sw-hop-dir, 1) * 26%) 0;
+    }
+
+    47.6% {
+      translate: calc(var(--sw-hop-dir, 1) * 23.4%) 0;
+    }
+
+    55.2% {
+      translate: calc(var(--sw-hop-dir, 1) * 16.1%) 0;
+    }
+    60.9% {
+      translate: calc(var(--sw-hop-dir, 1) * 9.9%) 0;
+    }
+
+    66.6% {
+      translate: calc(var(--sw-hop-dir, 1) * 4.7%) 0;
+    }
+    72.3% {
+      translate: calc(var(--sw-hop-dir, 1) * 1.6%) 0;
+    }
+
+    78%,
+    100% {
+      translate: 0 0;
+    }
+  }
+
+  @keyframes sw-pupil-constrict {
+    0% {
+      scale: 1.2;
+    }
+    100% {
+      scale: 1;
+    }
+  }
+
+  @keyframes sw-pupil-bob {
+    0% {
+      transform: translateY(-5%);
+    }
+
+    30% {
+      transform: translateY(5%);
+    }
+
+    58% {
+      transform: translateY(-2.5%);
+    }
+    80% {
+      transform: translateY(1%);
+    }
+    100% {
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes sw-foot-settle {
+    0% {
+      scale: 1.08 0.93;
+    }
+    40% {
+      scale: 0.97 1.04;
+    }
+    70% {
+      scale: 1.015 0.99;
+    }
+    100% {
+      scale: 1 1;
+    }
+  }
+
+  @keyframes sw-body-settle {
+
+    0% {
+      transform: scale(1, 1);
+    }
+
+    12% {
+      transform: scale(1.1, 0.9);
+    }
+
+    38% {
+      transform: scale(0.96, 1.05);
+    }
+
+    64% {
+      transform: scale(1.02, 0.98);
+    }
+    84% {
+      transform: scale(0.995, 1.005);
+    }
+
+    100% {
+      transform: scale(1, 1);
+    }
+  }
+
+  @keyframes sw-antennae-settle {
+
+    0% {
+      --sw-antenna-bend: calc(var(--sw-hop-dir, 1) * -10deg);
+      transform: translateY(0);
+    }
+
+    12% {
+      --sw-antenna-bend: calc(var(--sw-hop-dir, 1) * 7deg);
+      transform: translateY(0.098em);
+    }
+
+    38% {
+      --sw-antenna-bend: calc(var(--sw-hop-dir, 1) * -3.5deg);
+      transform: translateY(-0.049em);
+    }
+
+    64% {
+      --sw-antenna-bend: calc(var(--sw-hop-dir, 1) * 1.75deg);
+      transform: translateY(0.0196em);
+    }
+    84% {
+      --sw-antenna-bend: 0deg;
+      transform: translateY(-0.0049em);
+    }
+
+    100% {
+      --sw-antenna-bend: 0deg;
+      transform: translateY(0);
+    }
+  }
+
+  /* THE FLIGHT, off the two directions' own settings. Each arc is a
+     keyframe set AND the clock between its stops: an
+     `animation-timing-function` applies between every PAIR of keyframes,
+     so it shapes the arc rather than finishing it, and neither direction
+     survives being given the other's. The app picks the same pair by
+     direction in `timeline-sidebar.tsx`. */
+  .rig.flying {
+    animation: sw-monster-hop-open 680ms cubic-bezier(0.34, 0.8, 0.28, 1) both;
+  }
+
+  .rig.dir-close.flying {
+    animation: sw-monster-hop 680ms cubic-bezier(0.34, 0.8, 0.28, 1) both;
+  }
+
+  /* The untwist, which the app runs on the mark itself. Here the mark is
+     inside a rig that carries the flight transform, so it moves up one
+     element; the duration and the easing are the shipped ones. */
+  .rig.settling {
+    animation: sw-monster-untwist 520ms cubic-bezier(0.3, 0.72, 0.3, 1) both;
+  }
+  /* SW_LIFTED_END */
+
+
+  @media (prefers-reduced-motion: reduce) {
+    .rig,
+    .rig * {
+      animation: none !important;
+    }
+  }
+</style>
+
+<div class="wrap">
+  <header>
+    <div class="eyebrow">Storyboard Monster &middot; the rail toggle</div>
+    <h1>Every frame of the <em>jump</em></h1>
+    <p class="standfirst">
+      2,040ms from crouch to stillness. Each cell is a real creature with the
+      shipped keyframes paused at its own millisecond &mdash; not a redrawing &mdash; so if
+      a keyframe moves, every frame here moves with it. The two directions are
+      two different jumps now; the toggle below swaps between them.
+    </p>
+  </header>
+
+  <section>
+    <h2>Frame by frame</h2>
+    <div class="phasebar">
+      <div class="ph flight" style="--ms: 680">
+        <b>Flight &middot; 680ms</b>
+        <span>One rasterised snapshot. Geometry is frozen; only baked poses show.</span>
+      </div>
+      <div class="ph settle" style="--ms: 1360">
+        <b>Settle &middot; 1360ms</b>
+        <span>A live element again. Eye, feet and hat each finish on their own clock.</span>
+      </div>
+    </div>
+    <p class="note">
+      <b>Opening and closing are no longer the same arc.</b> Both crouch at 17%
+      and leave the ground at 32% and peak at 58% &mdash; the opening one is the
+      closing one's shape, foreshortened, because it ends about 1.45&times;
+      further from the reader. What differs is the fall. The close carries it on
+      a single stop at 82%; the open samples it at six, because an
+      <code>animation-timing-function</code> applies between every PAIR of
+      keyframes, so a long segment front-loads its own motion and then coasts.
+      Carried by two stops the descent measured 24.7&deg;, 9.3, 4.0, 0.1, then
+      46.0, 23.1, 3.3 &mdash; drop, flatten, drop, flatten, arriving almost
+      horizontal. Sampled, each segment is too short for the easing to shape it
+      and the speed grows all the way into contact.
+    </p>
+    <div class="transport">
+      <div class="seg" role="group" aria-label="Frame rate">
+        <button type="button" data-fps="12" aria-pressed="false">12 fps</button>
+        <button type="button" data-fps="24" aria-pressed="true">24 fps</button>
+        <button type="button" data-fps="60" aria-pressed="false">60 fps</button>
+      </div>
+      <button id="dir-toggle" type="button" aria-pressed="false">
+        Opening &rarr;
+      </button>
+      <button id="antennae-toggle" type="button" aria-pressed="true">
+        Antennae on
+      </button>
+      <span class="spacer"></span>
+      <span class="clock"
+        ><b id="sheet-count">0</b> frames &middot; every
+        <b id="sheet-step">0</b> ms</span
+      >
+    </div>
+    <div class="sheet" id="sheet"></div>
+  </section>
+
+  <section>
+    <h2>The eye, magnified</h2>
+    <p class="note">
+      Same creatures, same clock, cropped to the eye &mdash; because after the
+      landing almost nothing else is still moving. <b>The body is held still
+      here</b> so the eye stays in frame; every part inside it runs on its real
+      timing. The pupil is thrown along the jump, flicks home in one ballistic
+      move with no overshoot, and only then starts to shrink.
+    </p>
+    <div class="eyesheet" id="eyesheet"></div>
+  </section>
+
+  <section>
+    <h2>The arc, traced</h2>
+    <p class="note">
+      A real creature running the real animation, with its <b>body centre</b>
+      sampled every frame — the line is observed, not computed. The dotted line
+      is the ground; the ring marks the apex. Sizes and distances are the app's
+      own, scaled 3&times; so the shape is legible. <b>The two clocks are not
+      the same length</b>: the hop runs 680ms while the group carries the
+      creature across in 620, so the last 60ms are a fall with the ground no
+      longer going by underneath.
+    </p>
+    <div class="transport">
+      <div class="seg" role="group" aria-label="Direction to trace">
+        <button type="button" data-arc="open" aria-pressed="true">
+          Opening &rarr;
+        </button>
+        <button type="button" data-arc="close" aria-pressed="false">
+          Closing &larr;
+        </button>
+      </div>
+      <button id="arc-replay" type="button">Replay</button>
+      <span class="spacer"></span>
+      <span class="arc-readout">
+        <span>apex <b id="arc-apex">—</b></span>
+        <span>at <b id="arc-apex-at">—</b> of travel</span>
+        <span>in body-heights <b id="arc-bh">—</b></span>
+        <span>descent <b id="arc-descent">—</b></span>
+      </span>
+    </div>
+    <div class="arcstage">
+      <svg id="arc-svg" viewBox="0 0 900 320" preserveAspectRatio="none"
+           aria-label="Traced trajectory of the creature's body centre"></svg>
+      <div id="arc-rig"></div>
+    </div>
+  </section>
+
+  <section>
+    <h2>One frame, larger</h2>
+    <p class="note">
+      The arrows step a single frame at whichever rate is selected above; the
+      slider goes anywhere.
+    </p>
+    <div class="stage">
+      <div class="stage-meta">
+        <span>Direction <b id="dir-read">opening &rarr;</b></span>
+        <span><b id="phase-read">flight</b></span>
+      </div>
+      <div class="floor"></div>
+      <div class="rig" id="rig"><!-- MARK_START --><span data-storyboard-monster="" data-monster-gaze="ahead" style="--monster-gaze-x:0em;display:inline-block;width:1em;height:1em;flex:none;line-height:1;font-size:1em;position:relative">
+  <span data-monster-fur="" style="position:absolute;left:-0.19em;top:-0.19em;width:1.38em;height:1.38em;background:repeating-conic-gradient(from 0deg, oklch(0.86 0.17 128) 0deg 11deg, transparent 11deg 22deg);-webkit-mask-image:radial-gradient(circle at 50% 50%, transparent 0 35%, #000 35% 50%, transparent 50%);mask-image:radial-gradient(circle at 50% 50%, transparent 0 35%, #000 35% 50%, transparent 50%);transform-origin:50% 85.5%"></span>
+  <span data-monster-body="" style="position:absolute;left:0.01em;top:0.01em;width:0.98em;height:0.98em;border-radius:999px;background:oklch(0.86 0.17 128);transform-origin:50% 100%">
+    <span data-monster-eye="" style="position:absolute;left:0.17em;top:0.17em;width:0.64em;height:0.64em;border-radius:999px;background:oklch(0.96 0.02 95);overflow:hidden">
+      <span data-monster-pupil="" style="position:absolute;left:calc(0.125em + var(--monster-gaze-x, 0em));top:0.125em;width:0.39em;height:0.39em;border-radius:999px;background:oklch(0.27 0.03 145)">
+        <span style="position:absolute;left:0.05em;top:0.05em;width:0.14em;height:0.14em;border-radius:999px;background:oklch(0.96 0.02 95)"></span>
+      </span>
+    </span>
+  </span>
+  <span data-monster-foot="left" style="position:absolute;left:0.08em;bottom:-0.1em;width:0.38em;height:0.2em;background:oklch(0.89 0.08 48);border-radius:999px"></span>
+  <span data-monster-foot="right" style="position:absolute;left:0.55em;bottom:-0.1em;width:0.38em;height:0.2em;background:oklch(0.89 0.08 48);border-radius:999px"></span>
+  <span data-monster-antennae="" style="position:absolute;left:0;top:0;width:1em;height:1em;transform-origin:50% 6%">
+    <span data-monster-antenna="left" style="position:absolute;left:0.3275em;top:0.06em;width:0;height:0;transform:rotate(-12.34deg);transform-origin:0 0"><span style="position:absolute;left:-0.0275em;bottom:0;width:0.055em;height:0.1365em;background:oklch(0.70 0.18 45);border-radius:999px;transform:rotate(var(--sw-antenna-bend, 0deg));transform-origin:50% 100%"><span style="position:absolute;left:0;bottom:100%;width:100%;height:0.1365em;background:oklch(0.70 0.18 45);border-radius:999px;transform:rotate(var(--sw-antenna-bend, 0deg));transform-origin:50% 100%"><span style="position:absolute;left:0;bottom:100%;width:100%;height:0.1365em;background:oklch(0.70 0.18 45);border-radius:999px;transform:rotate(var(--sw-antenna-bend, 0deg));transform-origin:50% 100%"><span data-monster-knob="" style="position:absolute;left:50%;bottom:100%;width:0.16em;height:0.16em;margin-left:-0.08em;margin-bottom:-0.08em;border-radius:999px;background:oklch(0.89 0.08 48)"></span></span></span></span></span><span data-monster-antenna="right" style="position:absolute;left:0.6775em;top:0.06em;width:0;height:0;transform:rotate(14.37deg);transform-origin:0 0"><span style="position:absolute;left:-0.0275em;bottom:0;width:0.055em;height:0.1376em;background:oklch(0.70 0.18 45);border-radius:999px;transform:rotate(var(--sw-antenna-bend, 0deg));transform-origin:50% 100%"><span style="position:absolute;left:0;bottom:100%;width:100%;height:0.1376em;background:oklch(0.70 0.18 45);border-radius:999px;transform:rotate(var(--sw-antenna-bend, 0deg));transform-origin:50% 100%"><span style="position:absolute;left:0;bottom:100%;width:100%;height:0.1376em;background:oklch(0.70 0.18 45);border-radius:999px;transform:rotate(var(--sw-antenna-bend, 0deg));transform-origin:50% 100%"><span data-monster-knob="" style="position:absolute;left:50%;bottom:100%;width:0.16em;height:0.16em;margin-left:-0.08em;margin-bottom:-0.08em;border-radius:999px;background:oklch(0.89 0.08 48)"></span></span></span></span></span>
+  </span>
+</span><!-- MARK_END --></div>
+    </div>
+    <div class="transport">
+      <button id="step-back" type="button" aria-label="Previous frame">
+        &#9664;
+      </button>
+      <button id="play" type="button">Play</button>
+      <button id="step-fwd" type="button" aria-label="Next frame">
+        &#9654;
+      </button>
+      <span class="spacer"></span>
+      <span class="clock"><b id="ms-read">0</b> / <span id="total-read">2040</span> ms</span>
+    </div>
+    <input
+      id="scrub"
+      type="range"
+      min="0"
+      max="2040"
+      step="1"
+      value="0"
+      aria-label="Scrub the jump, in milliseconds"
+    />
+  </section>
+
+  <footer>
+    Copied verbatim from <code>apps/timeline-gstudio001/app/globals.css</code>
+    and the rendered mark. Two things this page cannot reproduce: the layout
+    change underneath &mdash; in the app the creature is also travelling between the
+    wordmark and the collapsed rail &mdash; and the cross-fade between the two
+    snapshots, approximated here by swapping the departure pose for the arrival
+    one at 72% of the flight, the point the real handover completes.
+  </footer>
+</div>
+
+<script>
+  (function () {
+    /* Machine-written by `scratch/remark.py` — the two directions' keyframe
+       names, clocks and travel curves, read out of the sidebar. Edit the app,
+       not this. */
+    /* SW_ARCS_START */
+    /* Each direction is three settings that only mean anything together --
+       the keyframes, the clock between them, and how the ground goes by
+       underneath. Lifted from the sidebar's `OPENING` and `CLOSING`
+       literals; the flight's own duration comes off `globals.css`. */
+    var ARCS = {
+      open: {
+        hop: "sw-monster-hop-open",
+        ease: "cubic-bezier(0.34, 0.8, 0.28, 1)",
+        travel: "linear(0 0%, 0.008508 6%, 0.01694 11%, 0.02907 17%, 0.0522 22%, 0.09105 28%, 0.1467 33%, 0.2732 39%, 0.4545 44%, 0.6412 50%, 0.7839 56%, 0.8508 61%, 0.8965 67%, 0.9309 72%, 0.9543 78%, 0.9693 83%, 0.9804 89%, 0.9898 94%, 1 100%)",
+        travelMs: 620,
+      },
+      close: {
+        hop: "sw-monster-hop",
+        ease: "cubic-bezier(0.34, 0.8, 0.28, 1)",
+        travel: "linear(0 0%, 0.008508 6%, 0.01694 11%, 0.02907 17%, 0.0522 22%, 0.09105 28%, 0.1467 33%, 0.2732 39%, 0.4545 44%, 0.6412 50%, 0.7839 56%, 0.8508 61%, 0.8965 67%, 0.9309 72%, 0.9543 78%, 0.9693 83%, 0.9804 89%, 0.9898 94%, 1 100%)",
+        travelMs: 620,
+      },
+    };
+    var FLIGHT = 680;
+    /* SW_ARCS_END */
+
+    /* How long the parts keep moving after the body stops: the attribute the
+       app pulls at 1360ms, which outlasts the pupil's 460ms wait plus its
+       800ms constrict. */
+    var SETTLE = 1360;
+    var TOTAL = FLIGHT + SETTLE;
+    var HANDOVER = 0.72;
+
+    var rig = document.getElementById("rig");
+    var MARK_HTML = rig.innerHTML;
+
+    var t = 0,
+      fps = 24,
+      dir = 1,
+      antennae = true,
+      playing = false;
+
+    /* Put one creature into whichever pose belongs at `ms`, by running the real
+       animations and pausing them. Everything on this page derives from this. */
+    function poseAt(rigEl, ms, still) {
+      var m = rigEl.querySelector("[data-storyboard-monster]");
+      var flight = ms < FLIGHT;
+      if (flight) {
+        m.setAttribute("data-aiming", "");
+        if (ms >= FLIGHT * HANDOVER) m.setAttribute("data-landing", "");
+        else m.removeAttribute("data-landing");
+        m.removeAttribute("data-settling");
+        rigEl.classList.add("flying");
+        rigEl.classList.remove("settling");
+      } else {
+        m.removeAttribute("data-aiming");
+        m.removeAttribute("data-landing");
+        m.setAttribute("data-settling", "");
+        rigEl.classList.remove("flying");
+        rigEl.classList.add("settling");
+      }
+      if (still) {
+        rigEl.classList.remove("flying");
+        rigEl.classList.remove("settling");
+      }
+      var local = flight ? ms : ms - FLIGHT;
+      var anims = rigEl.getAnimations ? rigEl.getAnimations({ subtree: true }) : [];
+      for (var i = 0; i < anims.length; i++) {
+        anims[i].pause();
+        try {
+          anims[i].currentTime = local;
+        } catch (e) {
+          /* an animation removed mid-frame; the next pose re-establishes it */
+        }
+      }
+      return flight ? "flight" : "settle";
+    }
+
+    /* Taking the antennae off is now ONLY taking the antennae off. The hat's
+       version of this also had to un-stretch the head and re-fit the fur,
+       because the body was an egg to clear a brim; antennae leave the skull
+       from a point, so the body is the same circle either way. */
+    function bare(rigEl) {
+      var pair = rigEl.querySelector("[data-monster-antennae]");
+      if (pair) pair.remove();
+    }
+
+    /* -- Contact sheet ----------------------------------------------------- */
+    var sheet = document.getElementById("sheet");
+
+    /* Labelled where something actually happens, not on a grid -- the point of
+       naming a frame is to say what changed at it. */
+    /* Every one of these is a shipped number read back out, not a guess:
+       the flight percentages times 680, and the settle's own delays. */
+    /* THE TWO DIRECTIONS ARE LABELLED SEPARATELY, because they are no longer
+       the same arc. Both crouch at 17% and push off at 32% and peak at 58%,
+       but the closing set carries its fall on ONE stop at 82% while the
+       opening set samples it at six -- 66, 73, 80, 86, 91, 96 -- so that the
+       easing between stops stops shaping it and the descent can accelerate all
+       the way into contact. Naming a frame is saying what changed at it, so a
+       label the direction does not have is worse than no label. */
+    function beatsFor(which) {
+      var pct = which === "open"
+        ? [[17, "crouch"], [32, "push off"], [58, "apex"], [72, "feet down"],
+           [80, "falling"], [91, "dropping"], [96, "about to land"]]
+        : [[17, "crouch"], [32, "push off"], [58, "apex"], [72, "feet down"],
+           [82, "falling"]];
+      var out = [[0, "aim"]];
+      for (var i = 0; i < pct.length; i++) {
+        out.push([Math.round((pct[i][0] / 100) * FLIGHT), pct[i][1]]);
+      }
+      /* After contact the creature is a live element again and both directions
+         run the same settle: the body's squash at 12% and 38% of 640ms, and
+         the untwist finishing at 520. */
+      return out.concat([
+        [FLIGHT, "contact"],
+        [FLIGHT + 77, "impact"],
+        [FLIGHT + 243, "rebound"],
+        [FLIGHT + 410, "2nd beat"],
+        [FLIGHT + 520, "untwisted"],
+      ]);
+    }
+
+    /* The eye keeps going long after the body has stopped, so it gets its own
+       marks: 40-78% of a 320ms saccade, and a constrict that starts 460ms in
+       and runs 800ms. */
+    var EYE_BEATS = [
+      [0, "thrown"],
+      [Math.round(FLIGHT * HANDOVER), "held"],
+      [FLIGHT + 128, "flick"],
+      [FLIGHT + 250, "home"],
+      [FLIGHT + 460, "shrinks"],
+      [FLIGHT + 460 + 800, "still"],
+    ];
+
+    /* THE NEAREST BEAT WINS, not the first one in range. The opening arc
+       samples its descent at six stops, so two of them can fall inside the
+       same frame's half-step -- and taking the first silently ate "contact",
+       which sat 13ms from a frame that "about to land" had already claimed
+       from 14ms away. */
+    function beatAt(list, ms, step) {
+      var best = "", d = step / 2;
+      for (var i = 0; i < list.length; i++) {
+        var gap = Math.abs(list[i][0] - ms);
+        if (gap <= d) {
+          d = gap;
+          best = list[i][1];
+        }
+      }
+      return best;
+    }
+
+    var eyesheet = document.getElementById("eyesheet");
+
+    function cellFor(ms, step, cls, beats, still) {
+      var cell = document.createElement("div");
+      cell.className = cls;
+
+      var r = document.createElement("div");
+      r.className = dir === 1 ? "rig" : "rig dir-close";
+      r.innerHTML = MARK_HTML;
+      if (!antennae) bare(r);
+
+      var label = document.createElement("span");
+      label.className = "t";
+      label.textContent = ms + "ms";
+
+      var beat = document.createElement("span");
+      beat.className = "beat";
+      beat.textContent = beatAt(beats, ms, step);
+
+      cell.appendChild(r);
+      cell.appendChild(label);
+      cell.appendChild(beat);
+      return cell;
+    }
+
+    function buildSheet() {
+      var step = 1000 / fps;
+      var count = Math.floor(TOTAL / step) + 1;
+      sheet.textContent = "";
+      eyesheet.textContent = "";
+      document.documentElement.style.setProperty("--sw-hop-dir", String(dir));
+      var beats = beatsFor(dir === 1 ? "open" : "close");
+
+      for (var i = 0; i < count; i++) {
+        var ms = Math.round(i * step);
+
+        var cell = cellFor(ms, step, "frame", beats, false);
+        var floor = document.createElement("div");
+        floor.className = "floor";
+        cell.insertBefore(floor, cell.firstChild);
+        sheet.appendChild(cell);
+        cell.setAttribute("data-phase", poseAt(cell.querySelector(".rig"), ms, false));
+
+        var eye = cellFor(ms, step, "eyeframe", EYE_BEATS, true);
+        eyesheet.appendChild(eye);
+        eye.setAttribute("data-phase", poseAt(eye.querySelector(".rig"), ms, true));
+      }
+
+      document.getElementById("sheet-count").textContent = String(count);
+      document.getElementById("sheet-step").textContent = String(Math.round(step));
+    }
+
+    /* -- Single frame ------------------------------------------------------ */
+    var scrub = document.getElementById("scrub");
+    var msRead = document.getElementById("ms-read");
+    var phaseRead = document.getElementById("phase-read");
+    var dirRead = document.getElementById("dir-read");
+    var playBtn = document.getElementById("play");
+
+    function seek(next) {
+      t = Math.max(0, Math.min(TOTAL, next));
+      document.documentElement.style.setProperty("--sw-hop-dir", String(dir));
+      rig.classList.toggle("dir-close", dir !== 1);
+      var p = poseAt(rig, t);
+      scrub.value = String(Math.round(t));
+      msRead.textContent = String(Math.round(t));
+      phaseRead.textContent = p;
+    }
+
+    var last = 0;
+    function frame(now) {
+      if (!playing) return;
+      var dt = last ? now - last : 16;
+      last = now;
+      if (t + dt >= TOTAL) {
+        seek(TOTAL);
+        stop();
+        return;
+      }
+      seek(t + dt);
+      requestAnimationFrame(frame);
+    }
+
+    function start() {
+      if (t >= TOTAL) seek(0);
+      playing = true;
+      last = 0;
+      playBtn.textContent = "Pause";
+      requestAnimationFrame(frame);
+    }
+
+    function stop() {
+      playing = false;
+      playBtn.textContent = t >= TOTAL ? "Replay" : "Play";
+    }
+
+    playBtn.addEventListener("click", function () {
+      if (playing) stop();
+      else start();
+    });
+
+    scrub.addEventListener("input", function () {
+      stop();
+      seek(Number(scrub.value));
+    });
+
+    document.getElementById("step-back").addEventListener("click", function () {
+      stop();
+      seek(t - 1000 / fps);
+    });
+
+    document.getElementById("step-fwd").addEventListener("click", function () {
+      stop();
+      seek(t + 1000 / fps);
+    });
+
+    /* -- Shared controls --------------------------------------------------- */
+    var fpsBtns = document.querySelectorAll("[data-fps]");
+    Array.prototype.forEach.call(fpsBtns, function (b) {
+      b.addEventListener("click", function () {
+        fps = Number(b.getAttribute("data-fps"));
+        Array.prototype.forEach.call(fpsBtns, function (o) {
+          o.setAttribute("aria-pressed", o === b ? "true" : "false");
+        });
+        buildSheet();
+      });
+    });
+
+    var dirBtn = document.getElementById("dir-toggle");
+    dirBtn.addEventListener("click", function () {
+      dir = dir === 1 ? -1 : 1;
+      dirBtn.setAttribute("aria-pressed", dir === -1 ? "true" : "false");
+      dirBtn.innerHTML = dir === 1 ? "Opening &rarr;" : "Closing &larr;";
+      dirRead.innerHTML = dir === 1 ? "opening &rarr;" : "closing &larr;";
+      buildSheet();
+      seek(t);
+    });
+
+    var antennaeBtn = document.getElementById("antennae-toggle");
+    antennaeBtn.addEventListener("click", function () {
+      antennae = !antennae;
+      antennaeBtn.setAttribute("aria-pressed", antennae ? "true" : "false");
+      antennaeBtn.textContent = antennae ? "Antennae on" : "Antennae off";
+      if (antennae) rig.innerHTML = MARK_HTML;
+      else bare(rig);
+      buildSheet();
+      seek(t);
+    });
+
+    /* -- The arc, traced ---------------------------------------------------
+       The app drives the creature with TWO clocks: `sw-monster-hop*` on the
+       mark itself, and the group's position/size interpolation underneath. This
+       reproduces both on real elements — the hop as an animation, the travel and
+       the size change on a wrapper — and then simply watches where the body
+       ends up each frame. Nothing here re-derives the trajectory; it is read
+       off the same engine the app runs on. */
+    /* WHAT THE PAGE MEASURES rather than lifts: the two rail states' rendered
+       sizes, and which way the creature is pointed. `from`/`to` are the mark's
+       font-size in each state -- 21.88px alone in the collapsed rail, 15.05px
+       inside the word -- measured off the running app. They matter because a
+       percentage in the keyframes resolves against the SNAPSHOT, so the same
+       percentage buys different pixels in each direction. */
+    var STAGE = {
+      open: { dir: 1, from: 21.88, to: 15.05 },
+      close: { dir: -1, from: 15.05, to: 21.88 },
+    };
+
+    var ZOOM = 3;
+    var TRAVEL_PX = 131 * ZOOM;
+    var arcRig = document.getElementById("arc-rig");
+    var arcSvg = document.getElementById("arc-svg");
+    var arcWhich = "open";
+
+    function traceArc(which) {
+      var cfg = STAGE[which];
+      var arc = ARCS[which];
+      arcRig.innerHTML = MARK_HTML;
+      var mark = arcRig.querySelector("[data-storyboard-monster]");
+      var body = arcRig.querySelector("[data-monster-body]");
+      document.documentElement.style.setProperty("--sw-hop-dir", String(cfg.dir));
+
+      // Left-to-right on the page whichever way the app travels, so the two
+      // shapes can be compared without mentally mirroring one of them.
+      var x0 = 60, ground = 250;
+      arcRig.style.left = x0 + "px";
+      arcRig.style.top = ground - cfg.from * ZOOM + "px";
+      mark.style.fontSize = cfg.from * ZOOM + "px";
+
+      var hop = mark.animate([], { duration: FLIGHT });
+      hop.cancel();
+      mark.style.animation = arc.hop + " " + FLIGHT + "ms " + arc.ease + " both";
+      var hopAnim = mark.getAnimations()[0];
+
+      // THE TWO CLOCKS ARE NOT THE SAME LENGTH, and the page used to run both
+      // at 680. The group carries position and size for `travelMs` -- 620 --
+      // while the hop above runs the full 680, so the creature is still
+      // dropping for 60ms after the ground has stopped going by underneath it.
+      // Traced at one duration the apex lands at the wrong share of the travel
+      // and the descent angle comes out shallower than the app's.
+      var move = arcRig.animate(
+        [{ transform: "translateX(0px)" }, { transform: "translateX(" + TRAVEL_PX + "px)" }],
+        { duration: arc.travelMs, easing: arc.travel, fill: "both" });
+      var size = mark.animate(
+        [{ fontSize: cfg.from * ZOOM + "px" }, { fontSize: cfg.to * ZOOM + "px" }],
+        { duration: arc.travelMs, easing: arc.travel, fill: "both" });
+
+      if (!hopAnim) return;
+      hopAnim.pause(); move.pause(); size.pause();
+
+      var pts = [], sizes = [];
+      var stageBox = arcSvg.getBoundingClientRect();
+      for (var k = 0; k <= 120; k++) {
+        var t = (k / 120) * FLIGHT;
+        hopAnim.currentTime = t; move.currentTime = t; size.currentTime = t;
+        var b = body.getBoundingClientRect();
+        pts.push([b.x + b.width / 2 - stageBox.x, b.y + b.height / 2 - stageBox.y]);
+        sizes.push(b.height);
+      }
+      hopAnim.cancel(); move.cancel(); size.cancel();
+      mark.style.animation = "";
+      /* NOTHING IS MEASURABLE IN A BOX WITH NO WIDTH. Traced before the stage
+         has been laid out -- which happens in an iframe that is sized after
+         its first paint -- every sampled x divides by a zero-width box and
+         comes back Infinity, so the path is `MInfinity ...` and the apex reads
+         NaN%. Bail rather than draw it; the observer below re-traces once the
+         stage has a size. */
+      if (!arcSvg.getBoundingClientRect().width) return;
+      drawArc(pts, sizes, ground, x0);
+    }
+
+    function drawArc(pts, sizes, ground, x0) {
+      var svgW = arcSvg.viewBox.baseVal.width;
+      var box = arcSvg.getBoundingClientRect();
+      var sx = svgW / box.width, sy = arcSvg.viewBox.baseVal.height / box.height;
+      var P = pts.map(function (p) { return [p[0] * sx, p[1] * sy]; });
+
+      // the apex, and how far along the travel it is
+      var top = 0;
+      for (var i = 1; i < P.length; i++) if (P[i][1] < P[top][1]) top = i;
+      var startX = P[0][0], endX = P[P.length - 1][0];
+      // RISE ABOVE THE RESTING CENTRE, not above the ground line. The body's
+      // centre already sits half a body height up, so measuring from the floor
+      // silently adds that in -- it read 24.6px for a 12px jump.
+      var apexPx = P[0][1] - P[top][1];
+      var apexAt = (P[top][0] - startX) / (endX - startX);
+      // descent angle over the last fifth, in the page's own pixels
+      var a = pts[Math.floor(pts.length * 0.8)], b = pts[pts.length - 1];
+      var descent = Math.atan2(b[1] - a[1], b[0] - a[0]) * 180 / Math.PI;
+
+      var d = P.map(function (p, i) { return (i ? "L" : "M") + p[0].toFixed(1) + " " + p[1].toFixed(1); }).join(" ");
+      var ticks = "";
+      for (var k = 12; k < P.length; k += 12) {
+        ticks += '<circle cx="' + P[k][0].toFixed(1) + '" cy="' + P[k][1].toFixed(1) +
+          '" r="2" fill="var(--sage)" opacity="0.5"/>';
+      }
+      arcSvg.innerHTML =
+        '<line x1="0" y1="' + (ground * sy) + '" x2="' + svgW + '" y2="' + (ground * sy) +
+        '" stroke="var(--stage-line)" stroke-width="1.5" stroke-dasharray="5 5"/>' +
+        '<path d="' + d + '" fill="none" stroke="var(--sage)" stroke-width="2" ' +
+        'stroke-linecap="round" opacity="0.85"/>' + ticks +
+        '<circle cx="' + P[top][0].toFixed(1) + '" cy="' + P[top][1].toFixed(1) +
+        '" r="7" fill="none" stroke="var(--rust)" stroke-width="2"/>';
+
+      var apexReal = apexPx / sy / 3;   // back out the 3x zoom
+      var bodyAtApex = sizes[top] / 3;
+      document.getElementById("arc-apex").textContent = apexReal.toFixed(1) + "px";
+      document.getElementById("arc-apex-at").textContent = Math.round(apexAt * 100) + "%";
+      document.getElementById("arc-bh").textContent = (apexReal / bodyAtApex).toFixed(2);
+      document.getElementById("arc-descent").textContent = descent.toFixed(1) + "\u00b0";
+    }
+
+    var arcBtns = document.querySelectorAll("[data-arc]");
+    Array.prototype.forEach.call(arcBtns, function (b) {
+      b.addEventListener("click", function () {
+        arcWhich = b.getAttribute("data-arc");
+        Array.prototype.forEach.call(arcBtns, function (o) {
+          o.setAttribute("aria-pressed", o === b ? "true" : "false");
+        });
+        traceArc(arcWhich);
+      });
+    });
+    document.getElementById("arc-replay")
+      .addEventListener("click", function () { traceArc(arcWhich); });
+
+    /* The trace is measured in the stage's own pixels, so it has to be redone
+       whenever the stage changes size -- on a resize, and on the first layout
+       if the page was traced before it had one. */
+    if (window.ResizeObserver) {
+      var seen = 0;
+      new ResizeObserver(function (entries) {
+        var w = entries[0].contentRect.width;
+        if (w && w !== seen) {
+          seen = w;
+          traceArc(arcWhich);
+        }
+      }).observe(document.querySelector(".arcstage"));
+    }
+
+    // The clock is the lifted one, so the markup's numbers are written from it
+    // rather than typed beside it.
+    scrub.max = String(TOTAL);
+    document.getElementById("total-read").textContent = String(TOTAL);
+
+    document.documentElement.style.setProperty("--sw-hop-dir", "1");
+    buildSheet();
+    seek(0);
+    traceArc("open");
+  })();
+</script>
+

--- a/scratch/remark.py
+++ b/scratch/remark.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Re-lift the shipped monster animation into the frame-by-frame artifact page.
+
+    python scratch/remark.py [--check]
+
+The page at `scratch/monster-jump-frames.html` is a contact sheet of the rail
+toggle's jump: every cell is a REAL creature with the shipped keyframes paused
+at its own millisecond. That only means anything if the keyframes on the page
+are the ones the app ships, so they are not typed there — they are copied out
+of `globals.css` and `timeline-sidebar.tsx` by this script, into two marked
+regions the page treats as machine-written.
+
+WHY THE SCRIPT EXISTS AT ALL, rather than a note saying "keep these in sync":
+it already drifted. The page carried the six-stop opening arc for a day after
+the shipped one grew to eleven stops and a sampled descent, and it ran that arc
+on `linear` while the app ran it on the closing cubic-bezier. Both are exactly
+the kind of thing the page is FOR, and neither is visible by looking at it.
+
+WHAT IS LIFTED, and the rule for each:
+
+  CSS   every top-level rule whose selector mentions `[data-storyboard-monster]`,
+        the `--sw-antenna-bend` property registration, and the named keyframe
+        sets below. Comments are dropped — the page has its own prose, and the
+        stylesheet's is written for someone editing it.
+
+  JS    each direction's keyframe name, the clock between its stops, and its
+        travel curve, read out of the `CLOSING` / `OPENING` literals in the
+        sidebar. Those three are one setting in three parts; the page needs all
+        of them or it draws an arc the app never runs.
+
+THE ONE RULE THAT IS REWRITTEN rather than copied is
+`[data-storyboard-monster][data-settling]`, the untwist. In the app it sits on
+the mark; on the page the mark is inside a `.rig` that carries the flight
+transform, so it is re-emitted as `.rig.settling` with its duration and easing
+intact. Same for the flight itself, which the app expresses as custom
+properties on `::view-transition-old/new` and the page as `.rig.flying`.
+
+`--check` exits non-zero if the page is out of date, without writing to it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CSS = ROOT / "apps/timeline-gstudio001/app/globals.css"
+SIDEBAR = ROOT / "apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx"
+PAGE = ROOT / "scratch/monster-jump-frames.html"
+
+# The sets the page pauses. `sw-monster-depart` / `-arrive` are deliberately
+# absent: they are the opacity cross-fade between two view-transition snapshots,
+# which the page cannot have (it has one element, not two images). It
+# approximates the handover by swapping the departure pose for the arrival one
+# at the same 72%.
+KEYFRAMES = [
+    "sw-monster-hop",
+    "sw-monster-hop-open",
+    "sw-monster-untwist",
+    "sw-pupil-saccade",
+    "sw-pupil-constrict",
+    "sw-pupil-bob",
+    "sw-foot-settle",
+    "sw-body-settle",
+    "sw-antennae-settle",
+]
+
+# Re-emitted against the page's own rig instead of copied — see the module note.
+REWRITTEN = "[data-storyboard-monster][data-settling]"
+
+
+def strip_comments(text: str) -> str:
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    # Collapse the runs of blank lines the comments left behind, but keep the
+    # single blank line that separates one rule from the next.
+    text = re.sub(r"\n[ \t]*\n[ \t]*\n+", "\n\n", text)
+    return re.sub(r"[ \t]+\n", "\n", text)
+
+
+def block_at(text: str, open_brace: int) -> int:
+    """Index just past the `}` matching the `{` at `open_brace`."""
+    depth = 0
+    for i in range(open_brace, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return i + 1
+    raise SystemExit("remark: unbalanced braces in the stylesheet")
+
+
+def top_level_rules(css: str):
+    """Yield (selector, rule text) for every rule starting at column 0.
+
+    Column 0 is what keeps the reduced-motion guard out: its copies of these
+    same selectors are indented inside an `@media`, and the page ships its own.
+
+    A SELECTOR IS NOT A LINE, which is what the first version of this assumed
+    and what cost an hour. Two of the rules here are a comma-separated list
+    split across lines, and one has a comment between the two halves; matching
+    up to the first `{` on a single line silently dropped `[data-monster-body]`
+    from the settle and both flight foot poses entirely — a page where the fur
+    squashed and the head it is masked to did not. So the text is de-commented
+    first and the selector is allowed to run over newlines, and it is
+    re-emitted one selector per line rather than however the source wrapped it.
+    """
+    # `[^\s@]` rather than `[^ \t@]`: a BLANK line is a line start too, and one
+    # sitting above an indented rule let a selector match run down into the
+    # reduced-motion guard and lift ITS overrides — the rules whose whole job is
+    # to switch this animation off.
+    for m in re.finditer(r"^(?=[^\s@])([^{};]+?)\s*\{", css, flags=re.M):
+        end = block_at(css, m.end() - 1)
+        parts = [p.strip() for p in m.group(1).split(",")]
+        selector = ",\n".join(" ".join(p.split()) for p in parts)
+        yield selector, selector + " " + css[m.end() - 1 : end]
+
+
+def at_rule(css: str, prelude: str) -> str:
+    m = re.search(r"^" + re.escape(prelude) + r"\s*\{", css, flags=re.M)
+    if not m:
+        raise SystemExit("remark: `" + prelude + "` is gone from " + CSS.name)
+    return css[m.start() : block_at(css, m.end() - 1)]
+
+
+def declaration(rule: str, prop: str) -> str:
+    m = re.search(re.escape(prop) + r"\s*:\s*(.+?);", rule, flags=re.S)
+    if not m:
+        raise SystemExit("remark: no `" + prop + "` in " + repr(rule[:60]))
+    return " ".join(m.group(1).split())
+
+
+def jump_arcs(tsx: str) -> dict:
+    """The two `JumpArc` literals, with `CLOSING.x` back-references resolved."""
+    arcs: dict = {}
+    for name in ("CLOSING", "OPENING"):
+        m = re.search(r"const " + name + r": JumpArc = \{(.*?)\n\};", tsx, flags=re.S)
+        if not m:
+            raise SystemExit("remark: no `" + name + "` literal in " + SIDEBAR.name)
+        body = strip_comments(m.group(1))
+        fields: dict = {}
+        for key in ("hop", "hopEase", "travel", "travelMs"):
+            f = re.search(key + r":\s*(.+?),\n", body, flags=re.S)
+            if not f:
+                raise SystemExit("remark: `" + name + "." + key + "` is missing")
+            raw = f.group(1).strip()
+            if raw.startswith("CLOSING."):
+                fields[key] = arcs["CLOSING"][raw.split(".", 1)[1]]
+                continue
+            # A string literal, possibly concatenated across several lines.
+            parts = re.findall(r'"((?:[^"\\]|\\.)*)"', raw)
+            if not parts:
+                raise SystemExit(
+                    "remark: `" + name + "." + key + "` is not a string literal"
+                )
+            fields[key] = " ".join("".join(parts).split())
+        arcs[name] = fields
+    return {"open": arcs["OPENING"], "close": arcs["CLOSING"]}
+
+
+def flight_ms(css: str) -> str:
+    """The hop's duration, off the `::view-transition-old` shorthand."""
+    m = re.search(r"var\(--sw-hop-name,[^)]*\)\s*(\d+)ms", strip_comments(css))
+    if not m:
+        raise SystemExit("remark: could not read the flight duration")
+    return m.group(1)
+
+
+def build_css(css: str, arcs: dict) -> str:
+    out = []
+    settle = ""
+    for selector, rule in top_level_rules(strip_comments(css)):
+        if "[data-storyboard-monster]" not in selector:
+            continue
+        if selector == REWRITTEN:
+            settle = declaration(rule, "animation")
+            continue
+        out.append(rule.strip())
+    if not settle:
+        raise SystemExit("remark: `" + REWRITTEN + "` is gone from " + CSS.name)
+
+    # A DROPPED RULE LOOKS LIKE A DESIGN CHOICE, which is why these are checked
+    # by hand. Each is a part that has to move WITH something else, so losing
+    # one leaves the page rendering a creature that comes apart in a way the
+    # app never does — and rendering it confidently.
+    body = "\n".join(out)
+    for needed in (
+        "[data-monster-body]",  # squashes with the fur, or the ring shows
+        '[data-monster-foot="left"]',  # the flight poses; both or neither
+        '[data-monster-foot="right"]',
+    ):
+        if needed not in body:
+            raise SystemExit("remark: `" + needed + "` did not survive the lift")
+
+    out.append(strip_comments(at_rule(css, "@property --sw-antenna-bend")).strip())
+    for name in KEYFRAMES:
+        out.append(strip_comments(at_rule(css, "@keyframes " + name)).strip())
+
+    ms = flight_ms(css) + "ms"
+    out.append(
+        "/* THE FLIGHT, off the two directions' own settings. Each arc is a\n"
+        "   keyframe set AND the clock between its stops: an\n"
+        "   `animation-timing-function` applies between every PAIR of keyframes,\n"
+        "   so it shapes the arc rather than finishing it, and neither direction\n"
+        "   survives being given the other's. The app picks the same pair by\n"
+        "   direction in `timeline-sidebar.tsx`. */\n"
+        ".rig.flying {\n  animation: "
+        + arcs["open"]["hop"] + " " + ms + " " + arcs["open"]["hopEase"] + " both;\n}\n\n"
+        ".rig.dir-close.flying {\n  animation: "
+        + arcs["close"]["hop"] + " " + ms + " " + arcs["close"]["hopEase"] + " both;\n}"
+    )
+    out.append(
+        "/* The untwist, which the app runs on the mark itself. Here the mark is\n"
+        "   inside a rig that carries the flight transform, so it moves up one\n"
+        "   element; the duration and the easing are the shipped ones. */\n"
+        ".rig.settling {\n  animation: " + settle + ";\n}"
+    )
+    return "\n\n".join(out)
+
+
+def build_js(arcs: dict, ms: str) -> str:
+    def row(which: str) -> str:
+        a = arcs[which]
+        return (
+            "  " + which + ": {\n"
+            '    hop: "' + a["hop"] + '",\n'
+            '    ease: "' + a["hopEase"] + '",\n'
+            '    travel: "' + a["travel"] + '",\n'
+            "    travelMs: " + a["travelMs"].removesuffix("ms") + ",\n"
+            "  },"
+        )
+
+    return (
+        "/* Each direction is three settings that only mean anything together --\n"
+        "   the keyframes, the clock between them, and how the ground goes by\n"
+        "   underneath. Lifted from the sidebar's `OPENING` and `CLOSING`\n"
+        "   literals; the flight's own duration comes off `globals.css`. */\n"
+        "var ARCS = {\n" + row("open") + "\n" + row("close") + "\n};\n"
+        "var FLIGHT = " + ms + ";"
+    )
+
+
+def splice(page: str, marker: str, body: str) -> str:
+    """Replace one marked region, keeping the indentation its opener sits at."""
+    start, end = "/* " + marker + "_START */", "/* " + marker + "_END */"
+    a, b = page.find(start), page.find(end)
+    if a < 0 or b < 0:
+        raise SystemExit("remark: the page has no " + marker + " markers")
+    pad = page[page.rfind("\n", 0, a) + 1 : a]
+    lines = [pad + line if line.strip() else line for line in body.split("\n")]
+    return page[: a + len(start)] + "\n" + "\n".join(lines) + "\n" + pad + page[b:]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--check", action="store_true", help="report drift, write nothing")
+    args = ap.parse_args()
+
+    css = CSS.read_text(encoding="utf-8")
+    tsx = SIDEBAR.read_text(encoding="utf-8")
+    page = PAGE.read_text(encoding="utf-8")
+    arcs = jump_arcs(tsx)
+
+    updated = splice(page, "SW_LIFTED", build_css(css, arcs))
+    updated = splice(updated, "SW_ARCS", build_js(arcs, flight_ms(css)))
+
+    if updated == page:
+        print("remark: the page is current")
+        return 0
+    if args.check:
+        print("remark: the page is STALE — run `python scratch/remark.py`")
+        return 1
+    PAGE.write_text(updated, encoding="utf-8")
+    print("remark: rewrote " + str(PAGE.relative_to(ROOT)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The frame-by-frame contact sheet at the [monster jump artifact](https://claude.ai/code/artifact/50d47308-859e-495a-957a-11e52affc8f5) is only worth looking at if the keyframes it pauses are the ones the app ships. They were copied by hand, and they had **already drifted** — a day after the page was built it carried the six-stop opening arc against the shipped eleven, and ran that arc on `linear` while the app runs it on the closing cubic-bezier.

`scratch/remark.py` copies, into two marked regions the page treats as machine-written:

- every top-level `[data-storyboard-monster]` rule, the `--sw-antenna-bend` registration, and the nine `sw-*` keyframe sets, out of `globals.css`
- each direction's hop name, clock and travel curve, out of the sidebar's `OPENING` / `CLOSING` literals

`python scratch/remark.py --check` exits non-zero when the page is stale.

## Two traps, both of which produced a confident wrong page

Neither raised an error — the page rendered and looked plausible.

**A selector is not a line.** Two rules here are comma lists split across lines, one with a comment between the halves. Matching to the first `{` on a single line dropped `[data-monster-body]` from the settle and both flight foot poses — a page where the fur squashed and the head it is masked to did not.

**A blank line is a line start.** A `^(?![ \t@])` anchor let a selector match run down into the `prefers-reduced-motion` guard and lift the rules whose whole job is to switch the animation off.

Both were caught by *measuring the rendered page*, not by reading the script's output: the fur-box-to-body ratio swung 1.35–1.55 across frames where it is 1.38/0.98 = **1.4082 by construction**. It is flat at 1.4082 across all 49 frames now. The lift also fails loudly if `[data-monster-body]` or either foot pose does not survive.

## One measurement correction

The page traced the travel at 680ms. The group carries position and size for `--sw-group-ms` (**620ms**) while the hop runs 680, so the last 60ms are a fall with the ground no longer going by underneath. Traced at one duration the opening apex read ~79% of travel; at the real two it is **87%** (closing 86%, descent 61.2° / 54.3°).

Worth knowing separately: the *"peaks at 80% of its travel and DROPS at 38deg"* figures in `timeline-sidebar.tsx`'s `OPENING` comment were measured on the old one-clock trace. Left alone here rather than edited on the way past.

## Also verified on the shipped animation

Nothing wrong found: knobs stay clear above the skull on every frame, no foot rides up into the body, and the eye's aim is baked into frame 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)