### PR TITLE
The monster joins its own transition and nobody else's

### DIFF
--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -350,6 +350,30 @@ html {
    EXAGGERATION — the scales are past what a real body would do (0.72 / 1.24 at
    the extremes) because at ~20px anything subtler is invisible. */
 
+/* THE NAME IS THE PARTICIPATION, so it is only on the mark while the rail is
+   actually hopping.
+
+   It used to be an inline `viewTransitionName` on the element, set for the
+   creature's whole life. But a `view-transition-name` does not opt an element
+   into ONE transition — it opts it into EVERY transition the document runs,
+   and this app runs others: the item details modal and the trash drawer both
+   go through `withViewTransition`. Each of those lifted the creature out of
+   the root snapshot and ran every rule below on it, so opening a modal played
+   the full 680ms jump and covered it with the group's opaque hole-filler,
+   which falls back to a near-black rectangle because only the rail toggle sets
+   `--sw-group-fill`. Then it disappeared, because that transition ended on its
+   own clock rather than the jump's.
+
+   `writeRailExpanded` sets the attribute before it calls
+   `startViewTransition` and clears it on `finished` — both captures happen
+   inside that window, which is all the browser needs. Same lifecycle as
+   `data-aiming`, and deliberately its own attribute: one means "the eye is
+   pointed along the arc", this one means "this element is in a transition",
+   and a later change to either should not silently rewire the other. */
+[data-storyboard-monster][data-hopping] {
+  view-transition-name: sw-monster;
+}
+
 ::view-transition-group(sw-monster) {
   /* THE HORIZONTAL LIVES HERE, and it is the reason one direction skimmed.
 
@@ -396,9 +420,22 @@ html {
 /* STAGING, the other half. Everything else in the page is snapshotted as `root`
    and cross-faded by default, so the whole app would dip while the creature
    jumps — the eye would not know where to look. The rest of the UI cuts
-   instantly and the only thing animating is the thing worth watching. */
-::view-transition-old(root),
-::view-transition-new(root) {
+   instantly and the only thing animating is the thing worth watching.
+
+   SCOPED TO THE HOP, for the reason the name above is. `::view-transition-*`
+   pseudos belong to the document, not to whichever transition prompted them,
+   so an unqualified rule here suppressed the root cross-fade of EVERY
+   transition in the app — the details modal's and the trash drawer's included,
+   which is not a staging decision anyone made for those. Their own opening was
+   being cut by a rule written about a creature jumping across a rail.
+
+   Written on `:root` rather than as a descendant because these pseudos are
+   anchored to the document element: `::view-transition-old(root)` already
+   means `:root::view-transition-old(root)`, so the attribute goes on the same
+   compound. `writeRailExpanded` owns it, alongside the custom properties it
+   already sets there. */
+:root[data-sw-hop]::view-transition-old(root),
+:root[data-sw-hop]::view-transition-new(root) {
   animation: none;
 }
 

--- a/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.stories.tsx
+++ b/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.stories.tsx
@@ -95,6 +95,47 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 /** The two sizes the rail renders, side by side, at the rail's 19px type size. */
+/**
+ * THE MARK MUST NOT NAME ITSELF FOR A VIEW TRANSITION.
+ *
+ * It used to, inline and for its whole life, and the consequence was not local
+ * to the rail: a `view-transition-name` opts an element into EVERY view
+ * transition the document runs, and the app runs others (the item details
+ * modal, the trash drawer). Each one lifted the creature out of the root
+ * snapshot and played its 680ms jump under an opaque hole-filler, then dropped
+ * it when that unrelated transition ended.
+ *
+ * The name now lives in `globals.css` behind `[data-hopping]`, which the rail
+ * toggle sets for the length of its own transition. This story cannot see that
+ * stylesheet — Storybook loads its own Tailwind entry — so it pins the half
+ * that belongs to the component: an inline value would beat the stylesheet
+ * rule and put the bug straight back, silently and everywhere.
+ */
+export const NotNamedForViewTransitions: Story = {
+  args: { scale: 1.6 },
+  render: () => (
+    <Plate label="no inline view-transition-name">
+      <StoryboardMonsterMark scale={1.6} gaze="breadcrumb" />
+    </Plate>
+  ),
+  play: async ({ canvasElement }) => {
+    const mark = canvasElement.querySelector<HTMLElement>(
+      "[data-storyboard-monster]",
+    );
+    expect(mark).not.toBeNull();
+    if (!mark) return;
+    // The INLINE value specifically: that is the one that cannot be overridden
+    // and therefore the one that made this global.
+    expect(mark.style.viewTransitionName).toBe("");
+    // And nothing inside the drawing names itself either — a part lifted out on
+    // its own would be worse, since it would leave a hole in the creature.
+    const named = Array.from(mark.querySelectorAll<HTMLElement>("*")).filter(
+      (el) => el.style.viewTransitionName !== "",
+    );
+    expect(named).toHaveLength(0);
+  },
+};
+
 export const RailSizes: Story = {
   args: { scale: 1.1 },
   render: () => (

--- a/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.tsx
+++ b/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.tsx
@@ -443,12 +443,29 @@ export function StoryboardMonsterMark({
         // whole drawing without touching the geometry below. See the 0.72 note
         // in the header: it converts `scale` into the source's 1em basis.
         fontSize: `${scale * 0.72}em`,
-        // NAMED FOR THE VIEW TRANSITION. Collapsing the rail does not move this
-        // element, it re-lays it out — inline in the word, then alone and
-        // larger — so there is nothing for a normal transition to animate
-        // between. A name lets the browser snapshot both and interpolate; the
-        // hop itself is styled in `globals.css`.
-        viewTransitionName: "sw-monster",
+        // NOT NAMED HERE, and the absence is the fix rather than an omission.
+        //
+        // Collapsing the rail does not move this element, it re-lays it out —
+        // inline in the word, then alone and larger — so there is nothing for
+        // an ordinary transition to animate between, and it needs a
+        // `view-transition-name` for the browser to snapshot both states and
+        // interpolate. It had one here, inline and unconditional.
+        //
+        // A NAME IS PARTICIPATION IN EVERY TRANSITION, NOT JUST THIS ONE. The
+        // app starts view transitions elsewhere — the item details modal and
+        // the trash drawer both go through `withViewTransition` — and a named
+        // element is lifted out of the root snapshot by ALL of them. So opening
+        // a modal ran the creature's whole 680ms jump, and painted the group's
+        // opaque hole-filler over it on the way, because `--sw-group-fill` is
+        // only set by the rail toggle and falls back to a near-black rectangle.
+        // The jump then vanished mid-flight when the transition it had
+        // hitched a ride on finished on its own schedule.
+        //
+        // So the name lives in `globals.css` behind `[data-hopping]`, which
+        // `writeRailExpanded` sets before it starts the transition and clears
+        // when that transition finishes — the same lifecycle `data-aiming`
+        // already has. Inline would beat that rule outright, which is why this
+        // is a comment and not a value.
         // NUDGED, NOT BASELINE-ALIGNED. The lockup is a flex row, and the
         // pieces around this are `RevealedLetters` — `display: grid`, so they
         // can only be flex items and the whole row is laid out by flex, not by

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -278,6 +278,21 @@ function writeRailExpanded(next: boolean): void {
   const mark = document.querySelector("[data-storyboard-monster]");
   mark?.setAttribute("data-aiming", "");
 
+  // OPT INTO THE TRANSITION, and only this one. The `view-transition-name` that
+  // makes the creature a snapshot lives in `globals.css` behind these two
+  // attributes rather than inline on the element, because a name is not scoped
+  // to the transition you meant — it applies to every one the document runs,
+  // and this app runs others (the details modal, the trash drawer). Named for
+  // its whole life, the creature played its entire jump whenever a modal
+  // opened, under an opaque hole-filler, and then vanished when that unrelated
+  // transition finished.
+  //
+  // Set BEFORE `startViewTransition`, because the old state is captured the
+  // moment it is called, and held until `finished`, which covers the new
+  // capture too. Cleared on every exit below, next to the aim.
+  mark?.setAttribute("data-hopping", "");
+  document.documentElement.dataset.swHop = "";
+
   const transition = doc.startViewTransition(() => {
     flushSync(() => commitRailExpanded(next));
     // THE SECOND POSE, and the reason there is one at all. The browser captures
@@ -301,6 +316,16 @@ function writeRailExpanded(next: boolean): void {
   //
   // Attribute rather than React state on purpose: this is a 500ms flourish, and
   // routing it through the store would re-render the sidebar twice more for it.
+  // LEAVING THE TRANSITION, on every path out. Dropping these late is not a
+  // cosmetic slip: while `data-hopping` is on, the creature is still a named
+  // participant, so the NEXT transition anyone starts — a modal, the trash
+  // drawer — snapshots it and replays the jump. That is the bug this pair
+  // exists to prevent, so it must not survive the flight that set it.
+  const leaveTransition = () => {
+    mark?.removeAttribute("data-hopping");
+    delete document.documentElement.dataset.swHop;
+  };
+
   const finished = transition.finished;
   if (!finished) {
     // Nothing to hang the settle off. Drop the aim on a timer regardless — a
@@ -308,6 +333,7 @@ function writeRailExpanded(next: boolean): void {
     window.setTimeout(() => {
       mark?.removeAttribute("data-aiming");
       mark?.removeAttribute("data-landing");
+      leaveTransition();
     }, 620);
     return;
   }
@@ -319,6 +345,7 @@ function writeRailExpanded(next: boolean): void {
       // captured image to live element is invisible.
       mark.removeAttribute("data-aiming");
       mark.removeAttribute("data-landing");
+      leaveTransition();
       mark.setAttribute("data-settling", "");
       // Outlasts the longest part, which is the PUPIL: it now waits for the eye
       // to finish moving (460ms) and then constricts over 800ms, so it is still
@@ -334,6 +361,7 @@ function writeRailExpanded(next: boolean): void {
       // the eye is left pointing at a jump that never happened.
       mark?.removeAttribute("data-aiming");
       mark?.removeAttribute("data-landing");
+      leaveTransition();
     });
 }
 


### PR DESCRIPTION
**Reported:** opening a modal starts the monster's animation, then it's hidden a moment later.

The modal was never doing anything to the monster. `view-transition-name: sw-monster` was set **inline on the mark, unconditionally, for its whole life** — measured on the running app before the change:

```
markViewTransitionName: "sw-monster"
markHasInlineName:      "sw-monster"   // inline, always
```

A `view-transition-name` does not opt an element into *one* transition. It opts it into **every** transition the document runs, and this app runs others — `graph-item-details-modal` and `trash-drawer` both go through `withViewTransition`. Each of them lifted the creature out of the root snapshot and ran every `sw-monster` rule on it:

- the full 680ms hop keyframes
- `::view-transition-group(sw-monster)`'s hole-filler, which falls back to an **opaque near-black rectangle** because `--sw-group-fill` is only ever set by the rail toggle

That is "the animation starts", and then a dark box over it. It disappears when the modal's transition finishes on its own clock rather than the jump's.

## The fix

The name moves out of the component into `globals.css`, behind `[data-hopping]`:

```css
[data-storyboard-monster][data-hopping] { view-transition-name: sw-monster; }
```

`writeRailExpanded` sets it before calling `startViewTransition` and clears it on `finished` — both the old and new captures happen inside that window. Cleared on **all four** exit paths, including the abort/superseded one: while the attribute is on, the creature is still a participant, so a late cleanup just moves the bug to the next transition.

An inline value beats the rule, so the component now carries a comment where the value was, and a story pins it.

## Same defect, same scope, one line over

`::view-transition-old/new(root) { animation: none }` was also unqualified. It was written for the hop — nothing else should move while the creature is airborne — but it was suppressing the root cross-fade of **every** transition in the app, including the two that aren't about a creature. Now `:root[data-sw-hop]`.

I did not observe that one directly; flagging it as found-while-fixing rather than as part of the reported symptom.

## Verification

Measured on the running app:

| | `view-transition-name` |
|---|---|
| at rest | `none` |
| during a rail toggle | `sw-monster` |
| after it settles | `none` |

The "after" reading came down the **abort** path (the tab was backgrounded, so the transition rejected) — which is the path a superseded transition takes, so that cleanup is covered too.

New story `NotNamedForViewTransitions` was confirmed to fail with the inline name restored (1 failed / 5 passed), and pass without it. Full runs: 1314 app tests, 786 unit, 6 story tests on the mark, `tsc` clean, lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)