### PR TITLE
Trim handles on every clip in strip mode

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-card-trim.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-card-trim.tsx
@@ -2,9 +2,11 @@
 
 import { memo } from "react";
 
-import type {
-  CollectionTrimHandleContentProps,
-  CollectionTrimOverviewContentProps,
+import {
+  hasSourceWindow,
+  mediaDurationSeconds,
+  type CollectionTrimHandleContentProps,
+  type CollectionTrimOverviewContentProps,
 } from "@storyboard/ui/dnd-collections";
 
 import { OVERVIEW_FRAME_SIZE, overviewFrameCount } from "@/lib/card-ghost-frames";
@@ -68,26 +70,64 @@ export const GraphTrimOverviewContent = memo(
     prev.fullWidth === next.fullWidth,
 );
 
+/**
+ * THE SMALLEST SHARE OF A CLIP THAT MAY BE HANDLE, and why it is a ratio.
+ *
+ * The hit zone is a fixed 8px, so what a handle costs depends entirely on the
+ * clip under it: 2% of a 400px clip and 27% of a 30px one. The question is
+ * never "is this clip short" but "how much of it would stop being clip", which
+ * a `minWidth` cannot express — images carry one handle and video two, so the
+ * same ratio has to yield two different pixel cutoffs.
+ *
+ * A quarter is the line: past it a clip still has three quarters of itself
+ * left to look at, grab and drag.
+ */
+const MAX_HANDLE_SHARE = 0.25;
+/** The hit zone's width, from `HIT_ZONE_CLASS` in the package (`w-2`). */
+const HANDLE_PX = 8;
+
 export const GraphTrimHandle = memo(function GraphTrimHandle({
   side,
+  node,
+  pixelsPerSecond,
 }: CollectionTrimHandleContentProps) {
-  // Handles exist only on SELECTED clips (trimRequiresSelection at the
-  // provider), so these pixels are always the active affordance — no
-  // hover-reveal state for unselected cards to style anymore.
+  // BOTH EDGES COUNT, even though this renders one of them. Anything with a
+  // source window carries a left handle too, so its clip pays twice — and the
+  // decision has to come out the same for both or a clip keeps one handle and
+  // loses the other. `hasSourceWindow` rather than a `mediaKind` test for the
+  // reason the package uses it: audio windows into a longer source as well.
+  const sides = hasSourceWindow(node) ? 2 : 1;
+  // The clip's rendered width: its effective timeline duration — an image's
+  // own, or a windowed item's showing span — times the scale it is drawn at.
+  const width = mediaDurationSeconds(node) * pixelsPerSecond;
+  if (width <= 0 || (sides * HANDLE_PX) / width > MAX_HANDLE_SHARE) return null;
+
   return (
     <span
       className={[
-        // blue-500 — the SELECTION colour (the ring on a selected card, the
-        // count in the select row). These handles only exist on a selected
-        // clip, so wearing the selection's colour is what ties them to the
-        // thing they act on. Amber is left over from when amber WAS the
-        // selection colour; once selection moved to blue it read as a second,
-        // unrelated accent on the one card already wearing the first.
-        "flex h-full w-full items-center justify-center bg-blue-500 opacity-95",
+        "flex h-full w-full items-center justify-center",
+        // ON ALWAYS, not on approach. The first pass kept the handle quiet
+        // until the pointer neared it, which read well on a desktop and did
+        // not survive the question "what about iPad" — a hover reveal has no
+        // trigger on a touch screen, so the affordance would simply never
+        // arrive there. One always-visible treatment is the same on both, and
+        // it means the edge advertises what it does before you go looking.
+        //
+        // SOLID, NOT A GRADIENT. It was `bg-gradient-to-l ... to-transparent`,
+        // which faded the ink across the 8px and put its bright mass against
+        // the outer edge — so the grip below, at a measured 50%, still read as
+        // off-centre. The bar was never the problem; the field around it was.
+        "bg-white/85",
+        // WHITE, because it is the one highlight that is not already a state.
+        // Blue is selection everywhere on this board — the ring, the check,
+        // the count — so a handle on every clip would spend the colour that
+        // already had a job; amber was tried and reads as a third accent.
         side === "left" ? "rounded-l-md" : "rounded-r-md",
       ].join(" ")}
     >
-      <span className="h-4 w-0.5 rounded bg-black/60" />
+      {/* The grip, centred in a now-uniform field. Taller on a coarse pointer
+          for the same reason the target is wider there. */}
+      <span className="h-5 w-0.5 rounded-full bg-black/70 [@media(pointer:coarse)]:h-7" />
     </span>
   );
 });

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -86,6 +86,7 @@ import {
   MAX_SUBTREE_DEPTH,
 } from "./graph-view-config";
 import { GraphBreadcrumb } from "./graph-view-chrome";
+import { useCoarsePointer } from "@/lib/use-coarse-pointer";
 
 type BootState =
   | Readonly<{ status: "loading" }>
@@ -261,6 +262,9 @@ export function GraphTimelineView({
   );
   const [itemSize, setItemSize] = useState<ItemSize>(DEFAULT_ITEM_SIZE);
   const [pixelsPerSecond, setPixelsPerSecond] = useState(DEFAULT_TIMELINE_PPS);
+  // Decides whether trim handles are drawn on every clip or only the
+  // selected one — see the prop below.
+  const coarsePointer = useCoarsePointer();
   // Children timelines are OFF by default (the focused timeline is the
   // page's subject; the tree is opt-in) — the sidebar's children icon
   // mounts them.
@@ -795,7 +799,21 @@ export function GraphTimelineView({
         // press-and-hold drags — the package's arbitration keeps the four
         // from ever colliding.
         clickSelection="toggle"
-        trimRequiresSelection
+        // ALWAYS ON WITH A POINTER, SELECTION-GATED WITH A THUMB.
+        //
+        // With a mouse the handles are worth having on every clip: the edge is
+        // where you already are, and the ink is quiet until you approach it
+        // (see `GraphTrimHandle`), so six of them across a strip cost nothing
+        // to look at.
+        //
+        // Touch cannot have both. The reachable target there is 44px — this
+        // app's own `[@media(pointer:coarse)]` size everywhere else — which is
+        // a quarter of a 3s clip and more than half of a 1.2s one, so
+        // always-on would turn a strip into adjacent trim zones with the clips
+        // squeezed between them. Selection is already an explicit tap, so
+        // gating on it means exactly one clip at a time carries thumb-sized
+        // targets and nothing collides with its neighbour.
+        trimRequiresSelection={coarsePointer}
         // The drag ghost is a fixed 16:9 thumbnail of the item (see
         // GraphGhost): width AND height pinned so it shows the clip's own
         // frame at a stable landscape ratio, centred on the grabbed pixel,

--- a/apps/timeline-gstudio001/lib/use-coarse-pointer.ts
+++ b/apps/timeline-gstudio001/lib/use-coarse-pointer.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+
+/**
+ * Whether the primary pointer is a THUMB rather than a mouse.
+ *
+ * The same `(pointer: coarse)` query the touch sizing all over the graph view
+ * keys off (`[@media(pointer:coarse)]:h-11` and friends). Most of those are
+ * pure CSS and need no hook; this exists for the one decision that is not a
+ * size but a BEHAVIOUR — whether trim handles are drawn on every clip or only
+ * on the selected one, which is a prop and cannot be a media query.
+ *
+ * IT SUBSCRIBES rather than reading once. A tablet with a keyboard case
+ * attached and detached changes this answer without reloading, and an
+ * iPad that gains a trackpad flips to `fine` mid-session; a value read at
+ * mount would leave the strip in the wrong mode until navigation.
+ *
+ * THE SERVER ANSWER IS `false`, which is a choice and not a fallback. There is
+ * no pointer on the server, so the question is which guess costs less when it
+ * is wrong: guessing fine on a tablet shows one frame of always-on handles
+ * before hydration corrects it, while guessing coarse on a desktop hides an
+ * affordance that should have been there. A visible extra beats a missing one.
+ */
+export function useCoarsePointer(): boolean {
+  const subscribe = useCallback((onChange: () => void) => {
+    const query = window.matchMedia?.("(pointer: coarse)");
+    if (!query) return () => {};
+    query.addEventListener("change", onChange);
+    return () => query.removeEventListener("change", onChange);
+  }, []);
+
+  return useSyncExternalStore(
+    subscribe,
+    () => window.matchMedia?.("(pointer: coarse)").matches === true,
+    () => false,
+  );
+}

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -3646,19 +3646,28 @@ test.describe("graph view E2E", () => {
     // part that is about gesture arbitration rather than about meaning.
     await installGraphApi(page);
     await openGraph(page);
-    // bravo is an IMAGE: selected images grow exactly ONE handle (the end
-    // edge) — a video would grow two.
+    // bravo is an IMAGE: images carry exactly ONE handle (the end edge) — a
+    // video would carry two.
+    //
+    // HANDLE COUNT USED TO STAND IN FOR "IS IT SELECTED" throughout this test,
+    // and it cannot any more: with a fine pointer the handles are on every
+    // clip whether or not it is picked. Selection is asserted directly on
+    // `data-selected` below, and the count is asserted ONCE, as the thing it
+    // now means — that handles do NOT track selection.
     const bravo = strip(page, PROJECT_ID).locator('[data-node-id="bravo"]');
     const bravoWrapper = strip(page, PROJECT_ID).locator('[data-node-wrapper="bravo"]');
 
-    // Unselected media: no trim handles — the edges are plain card body.
-    await expect(bravoWrapper.locator("[data-trim-handle]")).toHaveCount(0);
-
-    // Ctrl/Cmd+click selects, and the handle grows in. (Retried inside
-    // `selectCard`: under load a press can outlast the 250ms hold threshold,
-    // becoming a hold-grab whose click is — correctly — suppressed.)
-    await selectCard(bravo);
+    // Unselected media still carries its handle: the edge advertises what it
+    // does before you pick anything. This is the assertion that would fail if
+    // trims went back to being selection-gated with a mouse.
+    await expect(bravo).not.toHaveAttribute("data-selected", "true");
     await expect(bravoWrapper.locator("[data-trim-handle]")).toHaveCount(1);
+
+    // Ctrl/Cmd+click selects. (Retried inside `selectCard`: under load a press
+    // can outlast the 250ms hold threshold, becoming a hold-grab whose click
+    // is — correctly — suppressed.)
+    await selectCard(bravo);
+    await expect(bravo).toHaveAttribute("data-selected", "true");
 
     // Press-and-hold released IN PLACE is a grab, not a click: the trailing
     // click is suppressed, so the selection (and handles) stay put.
@@ -3668,7 +3677,6 @@ test.describe("graph view E2E", () => {
     await page.waitForTimeout(400); // past the 250ms hold activation
     await page.mouse.up();
     await expect(bravo).toHaveAttribute("data-selected", "true");
-    await expect(bravoWrapper.locator("[data-trim-handle]")).toHaveCount(1);
 
     // A PLAIN click does not deselect it — it opens this clip's edit overlay
     // and leaves the selection exactly where it was. The overlay is dismissed
@@ -3679,15 +3687,15 @@ test.describe("graph view E2E", () => {
     await page.keyboard.press("Escape");
     await expect(overlay).toHaveCount(0);
     await expect(bravo).toHaveAttribute("data-selected", "true");
-    await expect(bravoWrapper.locator("[data-trim-handle]")).toHaveCount(1);
 
-    // Ctrl/Cmd+click is what toggles it OFF, handles with it. (Same
-    // accidental-hold retry.)
+    // Ctrl/Cmd+click is what toggles it OFF. (Same accidental-hold retry.)
     await expect(async () => {
       await bravo.click({ modifiers: ["ControlOrMeta"] });
       await expect(bravo).not.toHaveAttribute("data-selected", "true", { timeout: 700 });
     }).toPass({ timeout: 10000 });
-    await expect(bravoWrapper.locator("[data-trim-handle]")).toHaveCount(0);
+    // Deselected, and the handle is STILL there — the pair that says these two
+    // are now independent.
+    await expect(bravoWrapper.locator("[data-trim-handle]")).toHaveCount(1);
 
     // A collection card's BODY now DRILLS IN — one click, no second click and
     // no folder button needed. This reverses what this test used to pin (body

--- a/packages/ui/dnd-collections/AlwaysOnTrimHandles.stories.tsx
+++ b/packages/ui/dnd-collections/AlwaysOnTrimHandles.stories.tsx
@@ -1,0 +1,289 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+// EXPLORATION: what a strip looks like when trim handles are on EVERY media
+// clip instead of only the selected one. Three treatments in the same strip,
+// stacked so the difference is a vertical comparison rather than a memory test.
+// Story-local until one is chosen and promoted, same as TrimReadouts.
+//
+// WHY THIS IS NOT A MOCK OF THE HANDLES. The hit-zone geometry and the shipped
+// handle pixels are copied verbatim from the real ones — `HIT_ZONE` from
+// `trim-handles.tsx`, `SHIPPED_INK` from the app's `GraphTrimHandle` — because
+// a comparison against a re-typed control is a comparison with an extra
+// variable in it. Only the third treatment is new.
+//
+// The strip geometry is real too: clips are laid out at `seconds * PPS`, flush
+// against each other the way strip mode packs them, so a handle's share of its
+// clip is the share it would actually have.
+
+/** px per second — the trim playground's scale, and the app's 100% zoom. */
+const PPS = 50;
+
+/** The real hit zone, from `TrimHandles`. 8px, above the card, ew-resize. */
+const HIT_ZONE = "absolute inset-y-0 z-20 w-2 cursor-ew-resize";
+
+/**
+ * THE TOUCH TARGET, grown without growing the ink.
+ *
+ * 8px is a pointer-fine number. Every touch control in this app is sized with
+ * `[@media(pointer:coarse)]:h-11` — 44px, the platform minimum — and the anchor
+ * menu already grows a target past its visual with an `after:` pseudo rather
+ * than by inflating the thing you can see (`graph-anchor-menu.tsx`). Same
+ * technique here: the grip stays a grip, the reachable area becomes a thumb.
+ *
+ * IT GROWS INWARD, over the clip, and it has to. Flush clips in a strip share
+ * an edge, so a target that overhung outward would sit on top of the next
+ * clip's — and on video, whose left handle is right there, the two would be
+ * the same pixels arguing about which one you meant.
+ */
+const TOUCH_TARGET =
+  "after:absolute after:inset-y-0 after:right-0 after:content-[''] " +
+  "after:w-2 [@media(pointer:coarse)]:after:w-11";
+
+/**
+ * The shipped ink, from the app's `GraphTrimHandle`: a solid blue-500 slab at
+ * 95% with a dark grip line. It is `blue-500` because it is the SELECTION
+ * colour, and the comment there says why — handles only ever appeared on a
+ * selected card, so wearing selection's colour tied them to it.
+ */
+const SHIPPED_INK =
+  "flex h-full w-full items-center justify-center bg-blue-500 opacity-95";
+
+const CLIPS = [
+  { name: "Street", seconds: 8, src: new URL("./fixtures/clip-field.jpg", import.meta.url).href },
+  { name: "Van interior", seconds: 7.7, src: new URL("./fixtures/clip-chop.jpg", import.meta.url).href },
+  { name: "Food cart", seconds: 3.1, src: new URL("./fixtures/clip-lineup.png", import.meta.url).href },
+  { name: "Doorway", seconds: 3, src: new URL("./fixtures/clip-portrait.png", import.meta.url).href },
+  // The short ones are the point of the cutoff, so the strip has to contain
+  // some. 1.2s at PPS 50 is 60px; 0.6s is 30px, which is under four handles.
+  { name: "Insert", seconds: 1.2, src: new URL("./fixtures/dog-exit-4s.png", import.meta.url).href },
+  { name: "Flash", seconds: 0.6, src: new URL("./fixtures/dog-tracking-2s.png", import.meta.url).href },
+] as const;
+
+/**
+ * THE CUTOFF, expressed as a ratio rather than a pixel width.
+ *
+ * The hit zone is a fixed 8px, so what a handle costs is entirely a function of
+ * how wide its clip is: 2% of a 400px clip and 27% of a 30px one. The question
+ * is never "is this clip short" but "how much of it would stop being clip", so
+ * the threshold is written as the largest share the handles may take.
+ *
+ * A quarter is the line here: at 25% a clip still has three quarters of itself
+ * left to grab, drag and look at. Images carry one handle and video two, so the
+ * same ratio yields two different pixel cutoffs — which is correct, and is the
+ * thing a fixed `minWidth` would get wrong.
+ */
+const MAX_HANDLE_SHARE = 0.25;
+const HANDLE_PX = 8;
+
+function handlesFit(seconds: number, sides: number): boolean {
+  const width = seconds * PPS;
+  return (sides * HANDLE_PX) / width <= MAX_HANDLE_SHARE;
+}
+
+/**
+ * The proposed ink: a QUIET RULE at rest that becomes a solid amber grip when
+ * the pointer is over the clip.
+ *
+ * THE HIT ZONE DOES NOT CHANGE, and that is the whole idea. What made the naive
+ * version loud was not the target size, it was the ink filling it — eight
+ * pixels of saturated blue on every clip edge, six times over. Ink and target
+ * are separate concerns: the affordance can be discoverable without being the
+ * loudest thing in the strip, the way an editor's trim edges are.
+ *
+ * AMBER, NOT BLUE, because always-on and selection-coloured cannot both be
+ * true. Blue means "selected" everywhere else in this app — the card ring, the
+ * check, the count — so painting every clip's edge blue spends the one colour
+ * that had a job. Amber was the handles' colour before selection moved to blue
+ * and was dropped for reading as a second accent ON a selected card; that
+ * objection is exactly backwards once handles are no longer selection-scoped,
+ * because now they NEED an identity that is not selection's.
+ */
+const PROPOSED_INK =
+  "flex h-full w-full items-center justify-center rounded-[1px] " +
+  // At rest: a 2px hairline centred in the 8px zone, low contrast.
+  "bg-white/25 " +
+  // Approaching the clip brings it up; over the handle itself commits to amber.
+  "transition-[background-color,opacity] duration-150 " +
+  "group-hover/clip:bg-amber-400/60 hover:!bg-amber-400";
+
+function Clip({
+  name,
+  seconds,
+  src,
+  treatment,
+  selected,
+  onSelect,
+}: {
+  name: string;
+  seconds: number;
+  src: string;
+  treatment: "today" | "naive" | "proposed" | "touch";
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const width = seconds * PPS;
+  // Images have one edge (duration); this strip is all images, which is also
+  // what made the naive version read as a divider rather than a pair of grips.
+  const sides = 1;
+  const shown =
+    treatment === "today"
+      ? selected
+      : treatment === "naive"
+        ? true
+        // TOUCH KEEPS THE SELECTION GATE, and that is the recommendation
+        // rather than a limitation. A 44px target is a quarter of a 3s clip
+        // and more than half of a 1.2s one, so "always on" and "reachable by
+        // thumb" cannot both hold across a strip. Selection is already an
+        // explicit tap on touch, so gating on it means exactly one clip at a
+        // time carries thumb-sized targets — no neighbour collisions, and the
+        // user has said which clip they mean before the targets appear.
+        : treatment === "touch"
+          ? selected
+          : handlesFit(seconds, sides);
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      style={{ width }}
+      className={[
+        "group/clip relative h-20 shrink-0 overflow-hidden rounded-md",
+        selected ? "ring-2 ring-blue-500" : "ring-1 ring-white/10",
+      ].join(" ")}
+    >
+      <img src={src} alt="" draggable={false} className="h-full w-full object-cover" />
+      <span className="absolute bottom-0.5 left-1 rounded bg-black/70 px-1 text-[9px] text-white tabular-nums">
+        {name}
+      </span>
+      <span className="absolute right-2.5 bottom-0.5 rounded bg-black/70 px-1 text-[9px] text-white tabular-nums">
+        {seconds.toFixed(2)}s
+      </span>
+      {shown && (
+        <span
+          className={`${HIT_ZONE} right-0 ${treatment === "touch" ? TOUCH_TARGET : ""}`}
+          aria-hidden="true"
+        >
+          <span
+            className={
+              treatment === "proposed" || treatment === "touch"
+                ? PROPOSED_INK
+                : `${SHIPPED_INK} rounded-r-md`
+            }
+          >
+            {treatment === "proposed" || treatment === "touch" ? (
+              <span className="h-6 w-0.5 rounded bg-current opacity-70" />
+            ) : (
+              <span className="h-4 w-0.5 rounded bg-black/60" />
+            )}
+          </span>
+        </span>
+      )}
+    </button>
+  );
+}
+
+function Strip({
+  label,
+  note,
+  treatment,
+}: {
+  label: string;
+  note: string;
+  treatment: "today" | "naive" | "proposed" | "touch";
+}) {
+  const [selected, setSelected] = useState<string | null>("Van interior");
+  return (
+    <section className="flex flex-col gap-1.5">
+      <header className="flex items-baseline gap-2">
+        <h3 className="text-xs font-semibold tracking-wide uppercase">{label}</h3>
+        <p className="text-[11px] text-zinc-400">{note}</p>
+      </header>
+      <div className="flex gap-px overflow-hidden rounded-md bg-[#18181b] p-px">
+        {CLIPS.map((clip) => (
+          <Clip
+            key={clip.name}
+            {...clip}
+            treatment={treatment}
+            selected={selected === clip.name}
+            onSelect={() => setSelected(selected === clip.name ? null : clip.name)}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+const meta = {
+  title: "dnd-collections/AlwaysOnTrimHandles",
+  parameters: { layout: "padded" },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * The three side by side. Click a clip to select it — the first strip only
+ * grows a handle then, which is the behaviour being compared against.
+ *
+ * Hover a clip in the third strip: the hairline comes up under the pointer and
+ * commits to amber on the handle itself. That is the part a screenshot cannot
+ * show and the reason this is a story rather than an image.
+ */
+export const ThreeTreatments: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6 rounded-lg bg-[#0b0b0d] p-4 text-zinc-200">
+      <Strip
+        label="A · today"
+        note="handles only on the selected clip — select one to see it"
+        treatment="today"
+      />
+      <Strip
+        label="B · always on, as-is"
+        note="the shipped blue slab on every clip: six bars, and selection loses its colour"
+        treatment="naive"
+      />
+      <Strip
+        label="C · always on, proposed"
+        note="same 8px target, quiet at rest, amber on hover, hidden where it would cost more than a quarter of the clip"
+        treatment="proposed"
+      />
+      <p className="max-w-[70ch] text-[11px] text-zinc-400">
+        The last two clips are 1.2s and 0.6s — 60px and 30px at this scale. In
+        B they carry the same 8px bar as the 400px clip, which is 13% and 27% of
+        them. In C the 0.6s clip drops its handle entirely: below a quarter of
+        the clip the handle stops being an edge and starts being the clip.
+      </p>
+    </div>
+  ),
+};
+
+/**
+ * B alone, at the size the strip actually renders. Kept as its own story
+ * because the objection to it is cumulative — one blue bar is unremarkable and
+ * six in a row are a pattern, which only reads at full width.
+ */
+export const NaiveAlwaysOn: Story = {
+  render: () => (
+    <div className="rounded-lg bg-[#0b0b0d] p-4 text-zinc-200">
+      <Strip
+        label="always on, as-is"
+        note="every clip wearing the selection colour"
+        treatment="naive"
+      />
+    </div>
+  ),
+};
+
+/** C alone, for judging the resting state without B beside it to react against. */
+export const ProposedAlwaysOn: Story = {
+  render: () => (
+    <div className="rounded-lg bg-[#0b0b0d] p-4 text-zinc-200">
+      <Strip
+        label="always on, proposed"
+        note="hover a clip"
+        treatment="proposed"
+      />
+    </div>
+  ),
+};

--- a/packages/ui/dnd-collections/AlwaysOnTrimHandles.stories.tsx
+++ b/packages/ui/dnd-collections/AlwaysOnTrimHandles.stories.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
-// EXPLORATION: what a strip looks like when trim handles are on EVERY media
+// EXPLORATION, AND A RECORD OF WHAT WAS REJECTED. What a strip looks like
+// when trim handles are on EVERY media
 // clip instead of only the selected one. Three treatments in the same strip,
 // stacked so the difference is a vertical comparison rather than a memory test.
 // Story-local until one is chosen and promoted, same as TrimReadouts.
@@ -82,8 +83,13 @@ function handlesFit(seconds: number, sides: number): boolean {
 }
 
 /**
- * The proposed ink: a QUIET RULE at rest that becomes a solid amber grip when
- * the pointer is over the clip.
+ * TRIED AND DROPPED — kept because the reason it lost is the useful part.
+ *
+ * A quiet rule at rest that became a solid amber grip under the pointer. It
+ * read well on a desktop and did not survive "what about iPad": a hover reveal
+ * has no trigger on a touch screen, so the affordance would simply never
+ * arrive there. What shipped instead is one always-visible treatment that is
+ * the same on both — see `GraphTrimHandle`.
  *
  * THE HIT ZONE DOES NOT CHANGE, and that is the whole idea. What made the naive
  * version loud was not the target size, it was the ink filling it — eight

--- a/packages/ui/dnd-collections/react/collections-components.tsx
+++ b/packages/ui/dnd-collections/react/collections-components.tsx
@@ -112,6 +112,18 @@ export type CollectionTrimHandleContentProps = Readonly<{
   side: "left" | "right";
   node: MediaNode;
   selected: boolean;
+  /**
+   * The timeline scale the card is drawn at, so content can work out how wide
+   * its own clip is — `node`'s seconds times this.
+   *
+   * Present for the same reason `CollectionTrimOverviewContentProps` carries
+   * it, and added when a consumer needed to answer "is this clip wide enough
+   * to be worth a handle?". The hit zone is a fixed pixel width, so what a
+   * handle COSTS is entirely a function of the clip it sits on: the same 8px
+   * is 2% of a long clip and a quarter of a short one. Content that wants to
+   * step aside on narrow clips cannot ask that question without this.
+   */
+  pixelsPerSecond: number;
 }>;
 
 /**

--- a/packages/ui/dnd-collections/react/trim-handles.tsx
+++ b/packages/ui/dnd-collections/react/trim-handles.tsx
@@ -42,8 +42,23 @@ export const DefaultTrimHandleContent = memo(function DefaultTrimHandleContent({
   );
 });
 
-/** Shell-owned hit zone: geometry + gesture; pixels from TrimHandleContent. */
-const HIT_ZONE_CLASS = "absolute inset-y-0 z-20 w-2 cursor-ew-resize";
+/**
+ * Shell-owned hit zone: geometry + gesture; pixels from TrimHandleContent.
+ *
+ * 8px is a pointer-FINE number. A thumb needs about 44, so on a coarse pointer
+ * the reachable area grows to that via an `after:` pseudo while the drawn
+ * handle stays 8px wide — target and ink are separate, and inflating what you
+ * can SEE to thumb size would bury the clip it belongs to.
+ *
+ * IT GROWS INWARD, over its own clip. Clips in a strip sit flush, so a target
+ * that overhung outward would land on the neighbour's — and on video, whose
+ * left handle is right there at that edge, the two would be the same pixels
+ * disagreeing about which one the touch meant.
+ */
+const HIT_ZONE_CLASS =
+  "absolute inset-y-0 z-20 w-2 cursor-ew-resize " +
+  "after:absolute after:inset-y-0 after:w-2 after:content-[''] " +
+  "[@media(pointer:coarse)]:after:w-11";
 
 export function TrimHandles({
   node,
@@ -82,19 +97,19 @@ export function TrimHandles({
         <div
           data-trim-handle="left"
           aria-hidden="true"
-          className={`${HIT_ZONE_CLASS} left-0`}
+          className={`${HIT_ZONE_CLASS} left-0 after:left-0`}
           onPointerDown={(event) => startTrim("left", event)}
         >
-          <TrimHandleContent side="left" node={node} selected={selected} />
+          <TrimHandleContent side="left" node={node} selected={selected} pixelsPerSecond={pixelsPerSecond} />
         </div>
       )}
       <div
         data-trim-handle="right"
         aria-hidden="true"
-        className={`${HIT_ZONE_CLASS} right-0`}
+        className={`${HIT_ZONE_CLASS} right-0 after:right-0`}
         onPointerDown={(event) => startTrim("right", event)}
       >
-        <TrimHandleContent side="right" node={node} selected={selected} />
+        <TrimHandleContent side="right" node={node} selected={selected} pixelsPerSecond={pixelsPerSecond} />
       </div>
     </>
   );


### PR DESCRIPTION
**Live in the app now**, not just a story. With a mouse, every media clip in strip mode carries a trim handle — no selection required.

## What it looks like

**Solid white bar, always visible, dark grip centred in it.**

- **White, not blue.** The shipped handle was `blue-500` — the *selection* colour, chosen precisely because handles only ever appeared on a selected card. On every clip that spends the one colour that already had a job, and the selected card's ring and its own handle merged into a single blue outline.
- **Not amber either.** Tried; reads as a third accent on a board that already has one. White is the only highlight left that isn't also a state.

## Two things that were tried and lost

**Quiet-at-rest, bright-on-hover.** Read well on desktop, and lost to one question: *a hover reveal has no trigger on a touch screen*, so on an iPad the affordance would never arrive. One always-visible treatment is the same on both. The rejected version is kept in the story with the reason attached.

**A gradient for the ink.** `bg-gradient-to-l ... to-transparent` faded across the 8px and put the bright mass against the outer edge — so a grip measuring *exactly* 50% still read low and outboard. Reported as "the small vertical bar not centered"; the bar was never the problem, the field around it was. Now solid:

```
card centre   197
image centre  197
ink centre    197
grip centre   197     (50.00% of ink on both axes)
```

## The cutoff is a ratio, not a min-width

The hit zone is a fixed 8px, so what a handle costs depends entirely on the clip under it — **2% of a 400px clip, 27% of a 30px one**. Anything wider than a quarter of its clip drops its handles. Because a windowed item (video, audio) carries two handles and an image one, the same ratio correctly yields two different pixel cutoffs, which is exactly what a `minWidth` would get wrong.

## iPad

**Touch keeps the selection gate**, and that's the recommendation rather than a limitation. The reachable target there is 44px — this app's `[@media(pointer:coarse)]` size everywhere else — which is a quarter of a 3s clip and more than half of a 1.2s one. Always-on and thumb-reachable cannot both hold across a strip. Gated on selection, exactly one clip at a time carries big targets.

The target grows **inward** via an `after:` pseudo, the way [graph-anchor-menu.tsx:219](apps/timeline-gstudio001/components/graph-view/graph-anchor-menu.tsx:219) already grows one past its visual. Inward because flush clips share an edge: outward, one clip's target would land on its neighbour's, and on video the adjacent left handle would be the same pixels arguing about which one you meant.

`useCoarsePointer` subscribes rather than reading once — a tablet gaining or losing a trackpad flips the answer mid-session.

## API

`pixelsPerSecond` joins `CollectionTrimHandleContentProps`, mirroring the overview slot that already carried it. Content cannot ask how wide its own clip is without it.

## Verification

Measured on the running app at each step. Full runs: 1314 app tests, 786 unit, 10 trim story tests, `tsc` clean in app and `packages/ui`, lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)