### PR TITLE
Board option for clip names, lane tracks behind a flag, wider rail

### DIFF
--- a/apps/timeline-gstudio001/components/core/dropdown-menu.tsx
+++ b/apps/timeline-gstudio001/components/core/dropdown-menu.tsx
@@ -98,6 +98,38 @@ const DropdownMenuRadioItem = React.forwardRef<
 DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
 
 /**
+ * A row that toggles ONE independent setting on or off.
+ *
+ * The radio item above answers "which of these"; this answers "is this on".
+ * Same geometry deliberately — the same 7px left gutter holding the same
+ * check — so a menu mixing the two reads as one column of rows rather than
+ * two competing shapes, and the gutter alone tells you which question a row is
+ * asking: a check that can stand alone, versus one of a set.
+ */
+const DropdownMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-7 pr-2 text-xs outline-none transition-colors",
+      "focus:bg-zinc-800 focus:text-zinc-50 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Check className="h-3.5 w-3.5 text-blue-500" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+));
+DropdownMenuCheckboxItem.displayName = DropdownMenuPrimitive.CheckboxItem.displayName;
+
+/**
  * A radio item shaped like a BADGE instead of a row.
  *
  * For small enumerated values — sizes, densities — where a stack of five
@@ -139,6 +171,7 @@ const DropdownMenuRadioBadge = React.forwardRef<
 DropdownMenuRadioBadge.displayName = "DropdownMenuRadioBadge";
 
 export {
+  DropdownMenuCheckboxItem,
   DropdownMenu,
   DropdownMenuTrigger,
   DropdownMenuContent,

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -61,9 +61,11 @@ import {
   SIDEBAR_ICON_IDLE,
 } from "@/components/timeline/sidebar-icon-styles";
 import { cn } from "@/lib/utils";
+import { ClipNamesProvider } from "./graph-clip-names";
 import { Button } from "@/components/core/button";
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
@@ -153,10 +155,16 @@ export type { FocusSurface, ItemSize };
 function BoardMenu({
   itemSize,
   onItemSizeChange,
+  clipNamesShown,
+  onClipNamesChange,
   projectId,
 }: Readonly<{
   itemSize: ItemSize;
   onItemSizeChange: (size: ItemSize) => void;
+  /** Whether clip cards stamp their name over the artwork. Off by default —
+   *  see `graph-clip-names.tsx`. */
+  clipNamesShown: boolean;
+  onClipNamesChange: (shown: boolean) => void;
   /** Whose render format this menu edits. The section reads and writes the
    *  document itself, so the menu only has to say WHICH one. */
   projectId: string;
@@ -207,6 +215,23 @@ function BoardMenu({
               </DropdownMenuRadioBadge>
             ))}
           </DropdownMenuRadioGroup>
+          {/* WHAT A CARD SHOWS, under HOW BIG IT IS — the two questions the
+              eye asks about the same object, in that order. Off by default:
+              the board is for reading frames, and a name stamped on the
+              artwork covers the frame it names. On a strip that cost is not
+              even: a clip's width is its duration, so the shortest clips —
+              the ones with the least picture to spare — lose the most of it. */}
+          <DropdownMenuCheckboxItem
+            className="mt-2"
+            checked={clipNamesShown}
+            onCheckedChange={(next) => onClipNamesChange(next === true)}
+            // The menu stays open: this is a setting you judge by looking at
+            // the board behind it, and closing on select would make comparing
+            // the two states a matter of reopening the menu each time.
+            onSelect={(event) => event.preventDefault()}
+          >
+            Show name over item
+          </DropdownMenuCheckboxItem>
         </DropdownMenuGroup>
         {/* RENDER FORMAT, moved in from the header row.
             It read "16:9 · 720p" beside the breadcrumbs — a standing fact
@@ -1852,6 +1877,8 @@ export function GraphBoard({
   surface,
   itemSize,
   onItemSizeChange,
+  clipNamesShown,
+  onClipNamesChange,
   pixelsPerSecond,
   onPixelsPerSecondChange,
   previewOn,
@@ -1878,6 +1905,11 @@ export function GraphBoard({
   surface: FocusSurface;
   itemSize: ItemSize;
   onItemSizeChange: (size: ItemSize) => void;
+  /** Whether clip cards stamp their name over the artwork — the board menu's
+   *  toggle, off by default. Published to the cards as a context rather than
+   *  threaded down; see `graph-clip-names.tsx`. */
+  clipNamesShown: boolean;
+  onClipNamesChange: (shown: boolean) => void;
   pixelsPerSecond: number;
   onPixelsPerSecondChange: (pixelsPerSecond: number) => void;
   /** The preview pane above the board. The board renders it AND carries its
@@ -2049,6 +2081,10 @@ export function GraphBoard({
       {/* Spans the header AND the surfaces: the toolbar toggle sets the mode,
           the selected card's panel reads it. */}
       <ItemDetailsProvider>
+      {/* Spans the header AND the surfaces for the same reason: the toggle
+          that sets it lives in the header's menu, and every card that reads it
+          is below. */}
+      <ClipNamesProvider shown={clipNamesShown}>
       {/* Spans the surfaces AND the child rows below them, because the pairing
           it carries joins the two: a collection's card up here and its row
           down there light each other up on hover. Inert unless the children
@@ -2501,6 +2537,8 @@ export function GraphBoard({
                 <BoardMenu
                   itemSize={itemSize}
                   onItemSizeChange={onItemSizeChange}
+                  clipNamesShown={clipNamesShown}
+                  onClipNamesChange={onClipNamesChange}
                   projectId={projectId}
                 />
               </div>
@@ -2730,6 +2768,7 @@ export function GraphBoard({
       </FlatItemsProvider>
       </TagFilterProvider>
       </CollectionHoverProvider>
+      </ClipNamesProvider>
       </ItemDetailsProvider>
     </OpenKeyBoundary>
   );

--- a/apps/timeline-gstudio001/components/graph-view/graph-clip-card.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-clip-card.tsx
@@ -38,6 +38,7 @@ import { useElementSize, useSettledFrameCount } from "./graph-card-measure";
 import { useVideoFrameLoading } from "./graph-card-frame-loading";
 import { useCardProvenance, useDisabledByAncestor } from "./graph-card-derivations";
 import { useClipNamesShown } from "./graph-clip-names";
+import { LANE_TRACKS_ENABLED } from "@/lib/lane-tracks-flag";
 
 /** Never sample more than this many frames for one card, however wide. */
 const VIDEO_FRAME_CAP = 16;
@@ -108,6 +109,15 @@ export const GraphClipContent = memo(function GraphClipContent({
 
   // MEDIA pixels only. This guard is defensive: nothing in the graph view
   // reaches it with a collection node.
+  // ABOVE THE EARLY RETURN. A collection card bails on the next line, so a
+  // hook read after it would run on some renders and not others — the
+  // rules-of-hooks error, and a real one: the hook order would change the
+  // first time a node's kind differed.
+  //
+  // OFF BY DEFAULT, from the board's options menu. A name over the artwork
+  // covers the artwork, and on a strip — where a clip's width IS its duration
+  // — a short clip is mostly name. See `graph-clip-names.tsx`.
+  const clipNamesShown = useClipNamesShown();
   if (node.kind === "collection") return null;
 
   const isVideo = node.mediaKind === "video";
@@ -161,10 +171,6 @@ export const GraphClipContent = memo(function GraphClipContent({
   // line, so an unnamed card's caption stays on the same grid as a named one's
   // and as a collection's.
   const captionName = detail?.title ?? null;
-  // OFF BY DEFAULT, from the board's options menu. A name over the artwork
-  // covers the artwork, and on a strip — where a clip's width IS its duration
-  // — a short clip is mostly name. See `graph-clip-names.tsx`.
-  const clipNamesShown = useClipNamesShown();
   const captionSeconds = Number(mediaDurationSeconds(node)) || 0;
   return (
     <span
@@ -310,7 +316,10 @@ export const GraphClipContent = memo(function GraphClipContent({
       {muted && <DisabledChip inherited={node.disabled !== true} />}
       {/* Lane 0 is the picture and says nothing; anything above it is a
           placement worth announcing on the card. */}
-      {lane > 0 && <LaneChip lane={lane} />}
+      {/* The chip names the ROW a clip sits on, so it says nothing once the
+          rows are off — and worse than nothing, since the number would point
+          at a lane the board no longer draws. */}
+      {LANE_TRACKS_ENABLED && lane > 0 && <LaneChip lane={lane} />}
       {provenance && (
         <ProvenanceLabel
           parentId={provenance.parentId}

--- a/apps/timeline-gstudio001/components/graph-view/graph-clip-card.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-clip-card.tsx
@@ -37,6 +37,7 @@ import { cardVideoFrameCount, laneOf } from "./graph-card-model";
 import { useElementSize, useSettledFrameCount } from "./graph-card-measure";
 import { useVideoFrameLoading } from "./graph-card-frame-loading";
 import { useCardProvenance, useDisabledByAncestor } from "./graph-card-derivations";
+import { useClipNamesShown } from "./graph-clip-names";
 
 /** Never sample more than this many frames for one card, however wide. */
 const VIDEO_FRAME_CAP = 16;
@@ -160,6 +161,10 @@ export const GraphClipContent = memo(function GraphClipContent({
   // line, so an unnamed card's caption stays on the same grid as a named one's
   // and as a collection's.
   const captionName = detail?.title ?? null;
+  // OFF BY DEFAULT, from the board's options menu. A name over the artwork
+  // covers the artwork, and on a strip — where a clip's width IS its duration
+  // — a short clip is mostly name. See `graph-clip-names.tsx`.
+  const clipNamesShown = useClipNamesShown();
   const captionSeconds = Number(mediaDurationSeconds(node)) || 0;
   return (
     <span
@@ -289,7 +294,7 @@ export const GraphClipContent = memo(function GraphClipContent({
           rendered "the name" would render something on all of them, and a
           library of two thousand machine-named clips reads as a rename
           backlog. Decorative for AT: the card's own aria-label already names it. */}
-      {detail?.title && !muted && (
+      {detail?.title && !muted && clipNamesShown && (
         <span
           aria-hidden="true"
           data-clip-title

--- a/apps/timeline-gstudio001/components/graph-view/graph-clip-names.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-clip-names.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+/**
+ * Whether a clip card stamps its NAME over the artwork.
+ *
+ * OFF BY DEFAULT, and the default is the whole reason this is a setting rather
+ * than a fact. A name over the picture covers the picture — on a strip, where a
+ * clip's width is its duration, a short clip is mostly name. The board is for
+ * reading FRAMES first; the name is there when you are looking for a
+ * particular clip rather than looking at the cut.
+ *
+ * It gates only the overlay on the artwork. The GRID caption underneath is a
+ * different surface with room of its own and keeps its name either way — which
+ * is also why the overlay was already hidden there: stamping it on the picture
+ * as well would repeat the line directly beneath it.
+ *
+ * A CONTEXT, NOT A PROP, because the consumer is a memoized leaf several
+ * layers down and the value changes only when someone opens a menu and clicks.
+ * Threading it would put a new prop through every card shell for a value that
+ * is constant across the whole board; a context re-renders exactly the cards
+ * that draw a name, exactly when the answer changes. It is the pattern this
+ * tree already uses for board-wide facts (`ItemDetailsProvider`,
+ * `TagFilterProvider`, `FlatItemsProvider`).
+ *
+ * DEFAULTS TO FALSE WITH NO PROVIDER, so a card rendered outside the board — a
+ * story, the drag ghost — behaves like the shipped default rather than
+ * throwing or silently opting in.
+ */
+const ClipNamesContext = createContext(false);
+
+export function ClipNamesProvider({
+  shown,
+  children,
+}: Readonly<{ shown: boolean; children: React.ReactNode }>) {
+  return <ClipNamesContext.Provider value={shown}>{children}</ClipNamesContext.Provider>;
+}
+
+/** Whether this card should stamp its name over the artwork. */
+export function useClipNamesShown(): boolean {
+  return useContext(ClipNamesContext);
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-collection-card.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-collection-card.tsx
@@ -46,6 +46,7 @@ import {
   useCollectionSubtreeHydrated,
   useHydratedCollectionSeconds,
 } from "./graph-card-derivations";
+import { LANE_TRACKS_ENABLED } from "@/lib/lane-tracks-flag";
 
 /**
  * The composed collection ITEM, rendered through the package's item-shell
@@ -164,7 +165,10 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
         {/* A whole collection can sit under the picture too — every leaf
             inside it then plays underneath, however its own children are
             arranged. */}
-        {laneOf(node) > 0 && <LaneChip lane={laneOf(node)} />}
+        {/* The chip names the ROW a clip sits on, so it says nothing once the
+            rows are off — and worse than nothing, since the number would point
+            at a lane the board no longer draws. */}
+        {LANE_TRACKS_ENABLED && laneOf(node) > 0 && <LaneChip lane={laneOf(node)} />}
         {/* Collections are taggable too — `tags` sits on TimelineItemBase, not
             on the media members — and they route through THIS component rather
             than GraphClipContent (which returns null for them at its guard).

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-content.stories.tsx
@@ -20,6 +20,7 @@ import { GRAPH_VIEW_COMPONENTS } from "./graph-item-content";
 import { VideoFrameLookAhead } from "./graph-card-frame-loading";
 import { GraphDetailsProvider } from "./graph-details-context";
 import { createGraphDetailsStore } from "@/lib/graph-details-store";
+import { ClipNamesProvider } from "./graph-clip-names";
 
 // The COMPOSED collection card, exactly as the graph renders it: the
 // registered ItemShell routes collections through CollectionItem primitives,
@@ -674,18 +675,30 @@ export const NoDisabledChipWhenEnabled: Story = {
 // will be heard rather than watched in turn.
 
 /**
- * A card on lane 1 says so. `L1`, sky rather than the disabled chip's amber —
- * a lane is a placement, not a warning.
+ * NO CHIP ON A LANE-1 CARD EITHER, while lane tracks are flagged off.
+ *
+ * This story used to assert the opposite — `L1` in sky, a lane being a
+ * placement rather than a warning — and the inversion is the point rather than
+ * a loss of coverage. The chip names the ROW a clip sits on, and with
+ * `LANE_TRACKS_ENABLED` false the board draws no such row: the clip is in the
+ * picture with everything else, so a badge pointing at lane 1 would describe a
+ * placement the board is not showing.
+ *
+ * WHERE THE ENABLED BEHAVIOUR IS COVERED INSTEAD: `graph-lane-rows.test.ts`,
+ * which drives the split both ways because it takes the flag as a parameter.
+ * A component reading a module constant cannot be driven that way from a
+ * story, which is exactly why the model takes it as an argument and this does
+ * not — the arithmetic is where the risk lives, and it is the half that stayed
+ * testable in both states.
+ *
+ * Turn `NEXT_PUBLIC_GSTUDIO_LANE_TRACKS=on` back on and this story is the one
+ * to invert again.
  */
-export const LaneChipOnAnUnderLayer: Story = {
+export const NoLaneChipWhileLanesAreOff: Story = {
   args: baseArgs,
   decorators: [renderWithDetail([ASSET_A, ASSET_B], 1)],
   play: async ({ canvasElement }) => {
-    const chip = canvasElement.querySelector<HTMLElement>("[data-lane-chip]")!;
-    await expect(chip).not.toBeNull();
-    await expect(chip.dataset.laneChip).toBe("1");
-    await expect(chip.textContent).toBe("L1");
-    await expect(getComputedStyle(chip).opacity).toBe("1");
+    await expect(canvasElement.querySelector("[data-lane-chip]")).toBeNull();
   },
 };
 
@@ -1381,7 +1394,69 @@ function renderMediaCard(
   };
 }
 
+/**
+ * The clip-name overlay's harness: a media card with an AUTHORED title, in the
+ * strip (the grid caption carries the name there instead), inside the provider
+ * that carries the board's setting.
+ */
+function renderNamedClip(shown: boolean): Decorator {
+  return function NamedClipDecorator(Story) {
+    const store = createGraphDetailsStore({
+      [VIDEO_ID as string]: {
+        alt: "A video",
+        // The overlay renders ONLY for a real authored name — an `alt` is a
+        // filename and deliberately does not count.
+        title: "S01 — Pat briefing",
+        aspect: 16 / 9,
+        hydrated: false,
+      },
+    });
+    return (
+      <DndCollections initialGraph={videoGraph} components={GRAPH_VIEW_COMPONENTS}>
+        <GraphDetailsProvider store={store}>
+          <ClipNamesProvider shown={shown}>
+            <VideoFrameLookAhead>
+              <div className="bg-zinc-950 p-2">
+                <div style={{ width: 260, height: 120 }}>
+                  <Story />
+                </div>
+              </div>
+            </VideoFrameLookAhead>
+          </ClipNamesProvider>
+        </GraphDetailsProvider>
+      </DndCollections>
+    );
+  };
+}
+
 const mediaArgs = { id: VIDEO_ID, className: "h-full w-full" };
+
+/**
+ * OFF BY DEFAULT: a named clip stamps nothing over its artwork.
+ *
+ * The pair below is the whole feature. It is covered here rather than by
+ * clicking the menu in the app because the two states have to be compared, and
+ * a story can hold both at once.
+ */
+export const ClipNameHiddenByDefault: Story = {
+  args: mediaArgs,
+  decorators: [renderNamedClip(false)],
+  play: async ({ canvasElement }) => {
+    // The clip HAS a name — this is the setting hiding it, not a missing title.
+    await expect(canvasElement.querySelector("[data-clip-title]")).toBeNull();
+  },
+};
+
+/** Turned on, the same clip wears it. */
+export const ClipNameShownWhenEnabled: Story = {
+  args: mediaArgs,
+  decorators: [renderNamedClip(true)],
+  play: async ({ canvasElement }) => {
+    const title = canvasElement.querySelector<HTMLElement>("[data-clip-title]");
+    await expect(title).not.toBeNull();
+    await expect(title!.textContent).toBe("S01 — Pat briefing");
+  },
+};
 
 /**
  * The collection twin of `renderMediaCard`, in the grid with select mode armed.

--- a/apps/timeline-gstudio001/components/graph-view/graph-lane-rows.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-lane-rows.test.ts
@@ -39,7 +39,7 @@ const NO_DETAILS = {} as DetailsById;
 describe("splitLaneRows", () => {
   it("puts everything on the picture when nothing has a lane", () => {
     const graph = graphOf([collection("scene", [media("a", 4), media("b", 4)])]);
-    const model = splitLaneRows(graph, NO_DETAILS, "scene");
+    const model = splitLaneRows(graph, NO_DETAILS, "scene", true);
 
     expect(model.pictureIds).toEqual(["a", "b"]);
     expect(model.layers).toEqual([]);
@@ -51,7 +51,7 @@ describe("splitLaneRows", () => {
 
   it("is empty for a collection with no children", () => {
     const graph = graphOf([collection("scene", [])]);
-    expect(splitLaneRows(graph, NO_DETAILS, "scene")).toEqual({
+    expect(splitLaneRows(graph, NO_DETAILS, "scene", true)).toEqual({
       pictureIds: [],
       pictureTimes: [],
       layers: [],
@@ -66,7 +66,7 @@ describe("splitLaneRows", () => {
         media("shot2", 4),
       ]),
     ]);
-    const model = splitLaneRows(graph, NO_DETAILS, "scene");
+    const model = splitLaneRows(graph, NO_DETAILS, "scene", true);
 
     expect(model.pictureIds).toEqual(["shot1", "shot2"]);
     expect(model.layers).toHaveLength(1);
@@ -86,7 +86,7 @@ describe("splitLaneRows", () => {
         media("shot2", 4),
       ]),
     ]);
-    const model = splitLaneRows(graph, NO_DETAILS, "scene");
+    const model = splitLaneRows(graph, NO_DETAILS, "scene", true);
 
     expect(model.pictureTimes[1]?.startSeconds).toBe(4 + CLIP_GAP_SECONDS);
   });
@@ -99,7 +99,7 @@ describe("splitLaneRows", () => {
         media("bed", 8, { trackIndex: 1 }),
       ]),
     ]);
-    const model = splitLaneRows(graph, NO_DETAILS, "scene");
+    const model = splitLaneRows(graph, NO_DETAILS, "scene", true);
 
     expect(model.pictureTimes[0]?.startSeconds).toBe(0);
     expect(model.layers[0]?.items[0]?.startSeconds).toBe(0);
@@ -113,7 +113,7 @@ describe("splitLaneRows", () => {
         media("vo2", 3, { trackIndex: 1 }),
       ]),
     ]);
-    const model = splitLaneRows(graph, NO_DETAILS, "scene");
+    const model = splitLaneRows(graph, NO_DETAILS, "scene", true);
 
     expect(model.layers[0]?.items).toEqual([
       { id: "vo1", startSeconds: 0, durationSeconds: 3 },
@@ -131,7 +131,7 @@ describe("splitLaneRows", () => {
         media("vo", 2, { trackIndex: 1, placedStart: 7.5 }),
       ]),
     ]);
-    const model = splitLaneRows(graph, NO_DETAILS, "scene");
+    const model = splitLaneRows(graph, NO_DETAILS, "scene", true);
 
     expect(model.layers[0]?.items).toEqual([
       { id: "vo", startSeconds: 7.5, durationSeconds: 2 },
@@ -148,7 +148,7 @@ describe("splitLaneRows", () => {
         media("tail", 2, { trackIndex: 1 }),
       ]),
     ]);
-    const model = splitLaneRows(graph, NO_DETAILS, "scene");
+    const model = splitLaneRows(graph, NO_DETAILS, "scene", true);
 
     expect(model.layers[0]?.items.map((item) => item.startSeconds)).toEqual([
       7.5,
@@ -164,7 +164,7 @@ describe("splitLaneRows", () => {
         media("vo", 4, { trackIndex: 2 }),
       ]),
     ]);
-    const model = splitLaneRows(graph, NO_DETAILS, "scene");
+    const model = splitLaneRows(graph, NO_DETAILS, "scene", true);
 
     expect(model.layers.map((layer) => layer.lane)).toEqual([1, 2]);
     expect(model.layers[0]?.items[0]?.id).toBe("music");
@@ -177,7 +177,7 @@ describe("splitLaneRows", () => {
     const graph = graphOf([
       collection("scene", [media("shot", 10), media("bed", 10, { trackIndex: 50 })]),
     ]);
-    const model = splitLaneRows(graph, NO_DETAILS, "scene");
+    const model = splitLaneRows(graph, NO_DETAILS, "scene", true);
 
     expect(model.layers).toHaveLength(1);
     expect(model.layers[0]?.lane).toBe(50);
@@ -191,7 +191,7 @@ describe("splitLaneRows", () => {
         media("c", 4, { trackIndex: -1 }),
       ]),
     ]);
-    const model = splitLaneRows(graph, NO_DETAILS, "scene");
+    const model = splitLaneRows(graph, NO_DETAILS, "scene", true);
 
     expect(model.pictureIds).toEqual(["a", "b", "c"]);
     expect(model.layers).toEqual([]);
@@ -209,7 +209,7 @@ describe("splitLaneRows", () => {
     // once a collection's contents have arrived. It is still a DETAIL: the
     // engine does not model hydration, only lane and placement moved.
     const details: DetailsById = { inner: detail({ hydrated: true }) };
-    const model = splitLaneRows(graph, details, "scene");
+    const model = splitLaneRows(graph, details, "scene", true);
 
     expect(model.pictureIds).toEqual(["inner"]);
     // A collection card is a fixed WIDTH holding an arbitrary span; the row
@@ -273,5 +273,36 @@ describe("laneDropIndex", () => {
 
   it("adds with no drag set at the translated boundary", () => {
     expect(laneDropIndex(pictureIds, siblings, 1, [])).toBe(2);
+  });
+});
+
+describe("with lanes flagged off", () => {
+  it("draws every clip in the picture row instead of hiding it", () => {
+    // THE FAILURE THIS PINS is a stored clip with nowhere to be. Hiding the
+    // lane rows and leaving their clips in them would drop a clip off the
+    // board while it still counts toward the timeline's duration and still
+    // composites into a render — present in the file, absent from the screen.
+    // Off means "no separate rows", not "no clips".
+    const graph = graphOf([
+      collection("scene", [
+        media("shot1", 4),
+        media("bed", 12, { trackIndex: 1 }),
+        media("shot2", 4),
+        media("vo", 3, { trackIndex: 2 }),
+      ]),
+    ]);
+    const on = splitLaneRows(graph, NO_DETAILS, "scene", true);
+    const off = splitLaneRows(graph, NO_DETAILS, "scene", false);
+
+    // On: two beds pulled onto two rows.
+    expect(on.layers.map((l) => l.lane)).toEqual([1, 2]);
+    // Off: no rows, and every one of those clips is in the picture instead.
+    expect(off.layers).toEqual([]);
+    expect(off.pictureIds).toEqual(["shot1", "bed", "shot2", "vo"]);
+    // Nothing lost: on-picture plus on-layers equals off-picture.
+    const laneItems = on.layers.flatMap((l) => l.items.map((i) => i.id));
+    expect(off.pictureIds.length).toBe(on.pictureIds.length + laneItems.length);
+    // Aligned 1:1 — the invariant every consumer of this model reads.
+    expect(off.pictureTimes.length).toBe(off.pictureIds.length);
   });
 });

--- a/apps/timeline-gstudio001/components/graph-view/graph-lane-rows.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-lane-rows.ts
@@ -2,6 +2,8 @@ import { getChildren, parseNodeId, type CollectionsGraph } from "@storyboard/col
 import { graphChildrenToClips, type DetailsById } from "@storyboard/timeline-domain";
 import { trackIndexOf } from "@storyboard/timeline-model/documents";
 
+import { LANE_TRACKS_ENABLED } from "@/lib/lane-tracks-flag";
+
 // Splitting a collection's children into the PICTURE and the lanes that run
 // under it — the read model behind the board's lane rows.
 //
@@ -51,6 +53,14 @@ export function splitLaneRows(
   graph: CollectionsGraph,
   details: DetailsById,
   collectionId: string,
+  /**
+   * Whether lanes are drawn at all. Defaults to the flag, so callers get the
+   * shipped answer without knowing there is one — but it is a PARAMETER
+   * because this module's whole claim is that it can be tested without a
+   * board, and a module that reads `process.env` for its main decision cannot
+   * be. The tests below drive both answers explicitly.
+   */
+  lanesEnabled: boolean = LANE_TRACKS_ENABLED,
 ): LaneRowsModel {
   const childIds = getChildren(graph, parseNodeId(collectionId));
   if (childIds.length === 0) return EMPTY;
@@ -67,7 +77,19 @@ export function splitLaneRows(
       startSeconds: clip.startTime,
       durationSeconds: clip.duration,
     };
-    const lane = trackIndexOf(clip);
+    // FLAGGED OFF MEANS EVERY CLIP IS PICTURE, not "lane clips are hidden".
+    // The rows are what the flag turns off; the clips in them are stored data
+    // and still have to be drawn somewhere. Reading every lane as 0 puts them
+    // in the picture row with everything else — the board a project had before
+    // lanes existed — rather than leaving a stored clip that counts toward the
+    // duration and composites into a render with nowhere on screen to be.
+    //
+    // Done HERE, at the split, because everything downstream of this function
+    // — the drop-boundary correction, the strip's item times, the layer rows —
+    // derives from what it returns. One `layers: []` at the source is the
+    // whole feature off; gating each consumer would be four chances to leave
+    // one on.
+    const lane = lanesEnabled ? trackIndexOf(clip) : 0;
     if (lane === 0) {
       pictureIds.push(childId as string);
       pictureTimes.push(slot);

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -261,6 +261,12 @@ export function GraphTimelineView({
     initialSurface === "strip" ? "strip" : "grid",
   );
   const [itemSize, setItemSize] = useState<ItemSize>(DEFAULT_ITEM_SIZE);
+  // OFF BY DEFAULT. A name stamped on the artwork covers the artwork, and on a
+  // strip — where a clip's width IS its duration — the shortest clips lose the
+  // most of themselves to it. Session state alongside `itemSize` rather than a
+  // stored preference: neither persists today, and one of the two quietly
+  // outliving the tab would be the surprise.
+  const [clipNamesShown, setClipNamesShown] = useState(false);
   const [pixelsPerSecond, setPixelsPerSecond] = useState(DEFAULT_TIMELINE_PPS);
   // Decides whether trim handles are drawn on every clip or only the
   // selected one — see the prop below.
@@ -909,6 +915,8 @@ export function GraphTimelineView({
                 surface={surface}
                 itemSize={itemSize}
                 onItemSizeChange={setItemSize}
+                clipNamesShown={clipNamesShown}
+                onClipNamesChange={setClipNamesShown}
                 pixelsPerSecond={pixelsPerSecond}
                 onPixelsPerSecondChange={setPixelsPerSecond}
                 previewOn={previewOn}

--- a/apps/timeline-gstudio001/components/timeline/sidebar-icon-styles.ts
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-icon-styles.ts
@@ -27,8 +27,16 @@ export const RAIL_WIDTH_PX = 72;
  * Collection names are the other tenant here and they are user-authored, so no
  * width could ever be "enough" for them; they truncate, which degrades to an
  * ellipsis rather than shoving the rail's rhythm out of line.
+ *
+ * 240 -> 260, asked for directly. The wordmark is not what needed the room
+ * this time — at Grandstander 700/21px its ink measures 208px against the 218
+ * available, so it already fit. The extra 20px is breathing room around it and
+ * for the collection names beside it, and it takes the wordmark's own slack
+ * from 10px to 30px, which is the margin the note above wanted when it warned
+ * that three pixels was "not enough to survive a font fallback rendering a
+ * fraction wider".
  */
-export const RAIL_OPEN_WIDTH_PX = 240;
+export const RAIL_OPEN_WIDTH_PX = 260;
 
 /**
  * On the rail ALWAYS, open or closed — and the hook every tile style below
@@ -80,7 +88,7 @@ export const RAIL_OPEN_CLASS = "rail-open";
  */
 export const RAIL_WIDTH_CLASS = {
   collapsed: "w-[72px]",
-  open: "w-[240px]",
+  open: "w-[260px]",
 } as const;
 
 /**

--- a/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.tsx
+++ b/apps/timeline-gstudio001/components/timeline/storyboard-monster-mark.tsx
@@ -475,12 +475,18 @@ export function StoryboardMonsterMark({
         // explicit offset at all.
         //
         // THE NUMBER IS WHERE THE FEET MEET THE BASELINE. Measured on the
-        // rendered lockup: with the old offset the feet's top edge sat 4.45px
-        // BELOW the baseline, so the creature read as standing in a hole
-        // beside letters it was supposed to share a line with. Lifting it by
-        // that much puts the top of the feet exactly on the baseline and
-        // leaves the feet hanging under it like a descender, with the body
-        // overshooting the line a little the way a round letter should.
+        // rendered lockup rather than derived: the feet's top edge has to land
+        // on the baseline, so the feet hang under it like a descender and the
+        // body overshoots it a little the way a round letter should.
+        //
+        // IT IS TIED TO `scale`, which is the thing to know before changing
+        // either. The offset is a constant em of the MARK, and the baseline
+        // belongs to the TEXT — so they do not move together, and every change
+        // to the in-word scale lands the feet somewhere new. This value goes
+        // with 0.97: at 1.1 it was -0.1136em, and shrinking the creature lifted
+        // its feet 0.55px clear of the line until this followed. Re-measure
+        // rather than re-derive; the probe is a zero-size inline-block, because
+        // a Range rect returns the line box and not the glyph.
         //
         // NO `* scale`, and removing it is a fix rather than a simplification.
         // `em` here resolves against this element's OWN font-size — set
@@ -489,7 +495,7 @@ export function StoryboardMonsterMark({
         // that is 1.45x larger in the collapsed rail was dropped 2.1x further.
         // A constant em is what keeps one optical relationship at every size.
         position: "relative",
-        top: "-0.1136em",
+        top: "-0.0758em",
       }}
     >
       {/* MARKED SO IT CAN FOLLOW THE BODY'S SQUASH, which is not decoration.

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -1015,9 +1015,21 @@ export function TimelineSidebar() {
                   there is no word left to belong to, so it grows into the mark
                   the rail needs — and past the 19px floor the design document
                   measured, below which "the fur spikes and the glint start to
-                  merge". */}
+                  merge".
+
+                  1.1 -> 0.97 IN THE WORD, and the number comes from the letters
+                  rather than from taste. Measured against Grandstander at 21px,
+                  the x-height is 13px and at 1.1 the creature's body drew
+                  16.3 — 1.254x the letter it is standing in for, which is why
+                  it read as parked beside the word rather than set into it.
+                  0.97 puts the body at about 1.1x the x-height: still the
+                  largest thing in the lockup, because it is a face and it has
+                  to hold the eye, but close enough to the "o" to belong to the
+                  same alphabet. The antennae above and the feet below stay
+                  outside that band on purpose — an ascender and a descender are
+                  what a letter is allowed to have. */}
               <StoryboardMonsterMark
-                scale={railExpanded ? 1.1 : 1.6}
+                scale={railExpanded ? 0.97 : 1.6}
                 gaze={railExpanded ? "ahead" : "breadcrumb"}
               />
               <RevealedLetters show={railExpanded}>nster</RevealedLetters>

--- a/apps/timeline-gstudio001/lib/lane-tracks-flag.ts
+++ b/apps/timeline-gstudio001/lib/lane-tracks-flag.ts
@@ -1,0 +1,34 @@
+/**
+ * Whether the board draws LANES — the extra track rows under the picture, for
+ * media that runs alongside it rather than after it (an audio bedding under a
+ * cut being the case it was built for).
+ *
+ * OFF. The feature does not work well enough to be on, and this parks it
+ * without deleting it: the model, the arithmetic, the drop targeting, the
+ * compositing and their tests all stay exactly where they are, so turning it
+ * back on is one environment variable rather than an archaeology exercise.
+ * Deleting it was the other option on the table and is the worse one — the
+ * lane data is in stored documents already (`trackIndex` on the clip), so the
+ * code that understands it is the thing keeping those documents readable.
+ *
+ * Set `NEXT_PUBLIC_GSTUDIO_LANE_TRACKS=on` to restore it. Compared against the
+ * string rather than truthiness, the same way `NEXT_PUBLIC_GSTUDIO_REMOTE_POLL`
+ * is, so that `=off`, `=0` and `=false` all read as off instead of the reverse
+ * — a bare `!!process.env.X` makes the word "off" mean on.
+ *
+ * WHAT HAPPENS TO A CLIP THAT IS ALREADY ON A LANE, which is the part worth
+ * being exact about: it is drawn in the picture row with everything else, and
+ * its lane badge is not drawn. It does NOT disappear. Hiding the lane rows and
+ * leaving those clips in them would make a stored clip invisible on the board
+ * while still counting toward the timeline's duration and still compositing
+ * into a render — present in the file, absent from the screen, which is the
+ * one outcome worse than the feature being wrong.
+ *
+ * WHAT THIS DOES NOT TURN OFF. The `set_lane` MCP tool still writes a lane,
+ * and the export still composites a clip that has one. Neither is a display
+ * decision, and both are reversible by the tool that made them; with the rows
+ * off, a clip an agent puts on lane 3 simply draws in the picture row. If the
+ * intent is to stop lanes being AUTHORED at all, that is a second change and a
+ * larger one — it means a write gate, not a flag.
+ */
+export const LANE_TRACKS_ENABLED = process.env.NEXT_PUBLIC_GSTUDIO_LANE_TRACKS === "on";

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -4947,10 +4947,18 @@ test.describe("graph view E2E", () => {
     await editor.fill("Jake looks up");
     await editor.press("Enter");
 
-    // The card carries it, and so does the stored document — as `title`.
+    // THE CARD NO LONGER CARRIES IT, and that is the board option rather than
+    // a broken rename: "Show name over item" is off by default, so the overlay
+    // is absent whatever the clip is called. The two states of the overlay are
+    // covered in `graph-item-content.stories.tsx`; what this test is about is
+    // the rename REACHING something durable, which is the document below.
+    //
+    // Worth saying plainly because it is a real cost of that default: renaming
+    // a clip in the strip now produces no visible change on the card. The grid
+    // caption and the details modal both still show it.
     await expect(
       strip(page, PROJECT_ID).locator('[data-node-wrapper="alpha"] [data-clip-title]'),
-    ).toHaveText("Jake looks up");
+    ).toHaveCount(0);
     await expect
       .poll(
         () => api.documents.get(PROJECT_ID)?.clips.find((clip) => clip.id === "alpha")?.title,
@@ -4964,9 +4972,14 @@ test.describe("graph view E2E", () => {
     const second = page.getByRole("textbox", { name: "Clip name" });
     await second.fill("Discarded");
     await second.press("Escape");
-    await expect(
-      strip(page, PROJECT_ID).locator('[data-node-wrapper="alpha"] [data-clip-title]'),
-    ).toHaveText("Jake looks up");
+    // The DOCUMENT still holds the committed name — the discarded edit never
+    // reached it. Asserted here rather than on the card for the reason above.
+    await expect
+      .poll(
+        () => api.documents.get(PROJECT_ID)?.clips.find((clip) => clip.id === "alpha")?.title,
+        { timeout: 5000 },
+      )
+      .toBe("Jake looks up");
   });
 
   test("typed in/out points trim exactly", async ({ page }) => {
@@ -5353,13 +5366,14 @@ test.describe("graph view E2E", () => {
     await expect.poll(storedTitle, { timeout: 5000 }).toBe("Belushi close-up");
     expect(storedClip()?.alt).toBe("alpha");
 
-    // And the card now shows it, because someone chose it. Unnamed cards
-    // stay bare — that is what keeps a two-thousand-clip library from
-    // reading as a rename backlog.
+    // NEITHER CARD SHOWS IT IN THE STRIP, named or not, because "Show name
+    // over item" is off by default (see the F2 test above for the same note).
+    // The named and unnamed cards agreeing is the point here: with the option
+    // off, the overlay is not a function of the name at all.
     await page.keyboard.press("Escape");
     await expect(page.locator("[data-item-details]")).toHaveCount(0);
     await expect(strip(page, PROJECT_ID).locator('[data-node-id="alpha"] [data-clip-title]'))
-      .toHaveText("Belushi close-up");
+      .toHaveCount(0);
     await expect(strip(page, PROJECT_ID).locator('[data-node-id="bravo"] [data-clip-title]'))
       .toHaveCount(0);
     await openItemDetails(page, "alpha");
@@ -8491,6 +8505,24 @@ test.describe("graph view E2E", () => {
   // draws it as its own time-aligned row instead of a slot in the shot
   // sequence. These drive the APP wiring — the lane split feeding the strip,
   // and the drop translation that filtering the strip's item source forces.
+  //
+  // SKIPPED WHILE THE FEATURE IS PARKED, and skipped rather than deleted or
+  // inverted. `NEXT_PUBLIC_GSTUDIO_LANE_TRACKS` is off by default, so the rows
+  // these four drive are not drawn; the code behind them is untouched and the
+  // flag brings both back together. Deleting them would throw away the most
+  // expensive coverage in the suite — four real-mouse drags over a layout that
+  // took several PRs to get right — to make a red suite green, and inverting
+  // them to assert "no rows" would spend the same four drags restating one
+  // fact the model's own unit test already pins in both directions
+  // (`graph-lane-rows.test.ts`).
+  //
+  // Turning the flag on here is what I tried first, via `env` on the e2e
+  // webServer. It does not work: `reuseExistingServer` is true even in CI, so
+  // a dev server already running is ridden as-is and the variable never
+  // reaches the build — green in CI, red locally, which is worse than either.
+  //
+  // TO BRING THEM BACK: set the flag on and delete this `describe.skip`.
+  test.describe.skip("lane rows — parked with NEXT_PUBLIC_GSTUDIO_LANE_TRACKS", () => {
   test("a layered clip leaves the shot sequence and draws as its own row", async ({
     page,
   }) => {
@@ -8639,6 +8671,7 @@ test.describe("graph view E2E", () => {
       // puts a gap like it at every cut.
       await expect(canvas).toHaveAttribute("aria-label", "alpha preview", { timeout: 700 });
     }).toPass({ timeout: 10000 });
+  });
   });
 
   // THE RENDER FORMAT. A project's own output shape, stored on its document —


### PR DESCRIPTION
Three requests in sequence, kept as three separate commits. They share `graph-clip-card.tsx`, which is why they are one branch rather than three — say the word and I'll split them.

## 1. Board option: show the media name over the item — off by default

A clip card always stamped its authored name over the artwork whenever it had one. Now it is a setting, and it starts **off**.

Off is the argument. A name over the picture covers the picture, and on a strip the cost is not evenly shared — a clip's width **is** its duration, so the shortest clips, the ones with the least frame to spare, lose the most of themselves to a label.

It gates only the overlay. The grid caption underneath is a different surface with room of its own and keeps its name either way — which is why the overlay was already hidden there.

A **context, not a prop**: the consumer is a memoized leaf several layers down, the value is constant across the board, and it changes only when someone opens a menu and clicks. It's the pattern this tree already uses for board-wide facts. With no provider it reads `false`, so a card outside the board — a story, the drag ghost — gets the shipped default.

New `DropdownMenuCheckboxItem`, shaped exactly like the radio item beside it. It deliberately does **not** close the menu on select: this is a setting you judge by looking at the board behind it.

## 2. Lane tracks behind a flag — off by default

The extra track rows under the picture (audio beddings and the like) are off. `NEXT_PUBLIC_GSTUDIO_LANE_TRACKS=on` restores them — same shape and same string comparison `NEXT_PUBLIC_GSTUDIO_REMOTE_POLL` already uses, so `=off` reads as off rather than the reverse.

**A flag rather than a deletion.** The lane data is already in stored documents (`trackIndex` on the clip), so the code that understands it is what keeps those documents readable. Deleting the reader wouldn't remove the lanes — only the app's ability to explain them.

**Off means "no separate rows", not "no clips".** A clip already on a lane draws in the picture row with everything else, the way the board worked before lanes existed. Hiding the rows and leaving their clips in them would strand a stored clip that still counts toward the timeline's duration and still composites into a render — present in the file, absent from the screen. A test pins it both directions.

Gated at `splitLaneRows`, because the drop-boundary correction, the strip's item times and the rows themselves all derive from what it returns — one decision at the source rather than four consumers each remembering. It reads the flag as a **default parameter** rather than from `process.env` directly: that module's stated claim is that it is testable without a board, and one reading the environment for its main decision would not be.

**Not turned off:** `set_lane` still writes a lane, and the export still composites one. Neither is a display decision. Stopping lanes being *authored* is a write gate, not a flag — a larger change, and worth deciding separately.

## 3. Wider open rail

240 → 260. `RAIL_OPEN_WIDTH_PX` and the literal `w-[260px]` move together (Tailwind never generates an interpolated width; `sidebar-icon-styles.test` keeps them equal). Everything beside the rail already follows `--sw-rail-width`.

The wordmark didn't need it — at Grandstander 700/21px its ink is 208px against 218 available. The extra 20 is margin, and takes the wordmark's slack from 10px to 30px.

## Verification

1315 app tests, 22 lane-row tests (including the new both-ways one), 8 sidebar-style tests, `tsc` clean, **eslint clean** — which caught a real `rules-of-hooks` error in commit 1 that tsc and vitest were both green over (`useClipNamesShown` sat below an early return). Fixed in commit 2 of the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)