### PR TITLE
The seek rail is just its dot now

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -2733,7 +2733,11 @@ export function GraphBoard({
                   // Same 16px, same wait, same one-step landing as the grid's
                   // — see the note there. Ruler and waveform have no reveal to
                   // wait for, so they still spend it immediately.
-                  rulerOn || waveformOn ? "pt-4" : "[[data-preview-settled]_&]:pt-4",
+                  // The RULER and the WAVEFORM still need their band — they
+                  // ARE bands, drawn above the cards. The preview's rail no
+                  // longer does: it rides the cards' own top padding. See the
+                  // grid's note below.
+                  rulerOn || waveformOn ? "pt-4" : "",
                 ].join(" ")}
               />
               {/* The strip's scrub control — the same rail treatment as the
@@ -2832,7 +2836,18 @@ export function GraphBoard({
                     //
                     // One step, at a moment when nothing else is moving and the
                     // user is watching the pane arrive, is both calmer and safe.
-                    "[[data-preview-settled]_&]:pt-4",
+                    // NO BAND FOR THE RAIL ANY MORE. It rides the top edge of
+                    // the cards now, over the ~6px of padding they already
+                    // carry above their artwork, so there is nothing to make
+                    // room for. This 16px used to be spent whenever the
+                    // preview came on, and the whole surface moved down for it
+                    // — for a control that is a single dot.
+                    //
+                    // Which also retires the timing problem the 16px created:
+                    // spent at the click it was a jolt against a moving pane;
+                    // deferred to the settle it moved a drag surface's layout
+                    // half a second after the click. Space you never take
+                    // needs no schedule.
                   ].join(" ")}
                 />
               </NativeDropGrid>

--- a/apps/timeline-gstudio001/components/graph-view/graph-seek-rails.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seek-rails.tsx
@@ -59,7 +59,25 @@ const SEEK_RAIL_STEP_SECONDS = 1;
  *  visible (the old design filled the band edge-to-edge and sat flush on
  *  the card tops). */
 const SEEK_RAIL_TRACK_PX = 8;
-export const SEEK_RAIL_BAND_INSET_PX = (GRID_GAP - SEEK_RAIL_TRACK_PX) / 2;
+/**
+ * Where the rail sits relative to the row it scrubs — ZERO now, meaning it
+ * rides the top of the cards rather than a band reserved above them.
+ *
+ * It used to centre the rail in a 16px gap, and that gap had to be BOUGHT: the
+ * grid and the strip both spent `pt-4` above row zero to make room, and the
+ * whole surface moved down for it whenever the preview came on. For a control
+ * that is now a single 12px dot, that was an expensive frame.
+ *
+ * A card already carries ~6px of padding above its artwork, so a rail sitting
+ * at the row's top edge lands on padding rather than on picture. Nothing has
+ * to move to make room for it.
+ *
+ * It is also the offset the playhead LINE uses to reach up to the rail's
+ * underside (see GraphGridPlayhead). At zero the line simply starts at the
+ * row's top edge, which is where the dot now is — so the dot caps the line
+ * instead of floating above it with a gap between them.
+ */
+export const SEEK_RAIL_BAND_INSET_PX = 0;
 /** The UNPLAYED groove is a slim centred line; the PLAYED fill grows to the
  *  full track height as the scrub sweeps through it, so the rail visibly
  *  thickens behind the thumb. The HIT TARGET is unchanged — the whole
@@ -286,49 +304,30 @@ function SeekRailRow({
         height: SEEK_RAIL_TRACK_PX,
       }}
     >
-      {/* UNPLAYED groove: a slim centred line. Solid, not translucent — a
-          see-through track melted into the grid's dark backdrop (R7). */}
-      <div
-        aria-hidden="true"
-        className="absolute inset-x-0 top-1/2 -translate-y-1/2 rounded-full bg-sky-900 shadow-[inset_0_1px_2px_rgba(0,0,0,0.6)] ring-1 ring-sky-400/40 transition-shadow group-hover:ring-sky-300/60"
-        style={{ height: SEEK_RAIL_GROOVE_PX }}
-      />
-      {/* PLAYED fill (full track height), then boundary ticks, then thumb. */}
-      <div
-        ref={fillRef}
-        data-rail-fill
-        aria-hidden="true"
-        className="absolute inset-y-0 left-0 rounded-full bg-sky-300/80"
-      />
-      {/* SKIP marks: the cells playback will jump over. One per disabled card
-          in THIS row, laid on the row's own cell pitch — a grid cell is a
-          fixed width, so the mark is the cell, not a time range. */}
-      {rowCards.map((card, index) =>
-        card.disabled === true ? (
-          <span
-            key={`skip-${index}`}
-            data-rail-skip
-            aria-hidden="true"
-            className="absolute inset-y-0 bg-zinc-600/70"
-            style={{
-              left: `${((index * pitch) / extent) * 100}%`,
-              width: `${(cellWidth / extent) * 100}%`,
-            }}
-          />
-        ) : null,
-      )}
-      {rowCards.slice(1).map((_, index) => (
-        <span
-          key={index}
-          aria-hidden="true"
-          className="absolute inset-y-0 w-px bg-white/30"
-          style={{ left: `${(((index + 1) * pitch - GRID_GAP / 2) / extent) * 100}%` }}
-        />
-      ))}
-      {/* h-3: the head is visibly bigger than the slim track (2px past it
-          each side), and the band's inset keeps even that overhang clear of
-          the cards — thumb and items never touch. The whole rail is the hit
-          target anyway. */}
+      {/* NO GROOVE, NO FILL, NO TICKS — the rail is invisible and only its
+          thumb shows.
+          A track drawn across every row was a lot of furniture for a control
+          that is used occasionally, and it duplicated what the playhead line
+          already says: where you are. The dot is the part that carries
+          information you cannot get elsewhere, so the dot is what is left. The
+          box itself stays exactly as grabbable as it was. */}
+      {/* THE FILL STAYS IN THE DOM AND PAINTS NOTHING.
+          It carries no background any more, but it cannot simply go: the paint
+          loop above bails on `if (!rail || !fill || !thumb) return`, so
+          deleting it would take the THUMB down with it — the one part being
+          kept. Invisible, same element, same ref, loop intact.
+
+          The skip marks and the cell-boundary ticks are gone with the track
+          they lived on. Both described the rail rather than the timeline, and
+          floating them over the tops of cards with no groove behind them would
+          read as damage rather than as information. Skips are still visible on
+          the cards themselves, which is where they were always clearer. */}
+      <div ref={fillRef} data-rail-fill aria-hidden="true" className="absolute inset-y-0 left-0" />
+      {/* THE WHOLE CONTROL, now. It rides the top edge of the cards, capping
+          the playhead line that runs down from it — the dot and the line read
+          as one object, which is what they always were. `ring-2 ring-zinc-950`
+          is what keeps it legible against artwork rather than against a track:
+          a dark halo, so it holds its shape over a bright frame. */}
       <div
         ref={thumbRef}
         data-rail-thumb
@@ -507,7 +506,13 @@ export function GraphSeekRails({
           offsetX={row * geometry.columns * (geometry.cellWidth + GRID_GAP)}
           cellWidth={geometry.cellWidth}
           x={geometry.left}
-          y={geometry.top + row * (cellHeight + GRID_GAP) - GRID_GAP}
+          // NO `- GRID_GAP`. That subtraction put the rail in the gap ABOVE
+          // its row, which is where it lived when a band was reserved for it.
+          // The rail rides the row's own top edge now — over the ~6px of
+          // padding a card already carries above its artwork — so its row
+          // offset is simply the row's offset, and the dot ends up capping the
+          // playhead line that runs down from the same point.
+          y={geometry.top + row * (cellHeight + GRID_GAP)}
           channel={channel}
           rowIndex={row}
           columns={geometry.columns}
@@ -625,7 +630,7 @@ export function GraphStripSeekRail({
   // one tick per card boundary plus one mark per disabled card is a DOM node
   // PER ITEM, which is exactly what the strip's virtualizer exists to avoid.
   // `extent` stays the full width — it sizes the layer the marks live in.
-  const { extent, boundaryTicks: ticks, skips } = useMemo(
+  const { extent } = useMemo(
     () => buildStripOverlay(cards, tickWindow),
     [cards, tickWindow],
   );
@@ -905,52 +910,17 @@ export function GraphStripSeekRail({
           : { left: 9, top: 1 + SEEK_RAIL_BAND_INSET_PX, right: 9, height: SEEK_RAIL_TRACK_PX }
       }
     >
-      {/* UNPLAYED groove: a slim centred line across the visible rail (static
-          — the track itself is uniform, only the fill scrolls). */}
-      <div
-        aria-hidden="true"
-        className="absolute inset-x-0 top-1/2 -translate-y-1/2 rounded-full bg-sky-900 shadow-[inset_0_1px_2px_rgba(0,0,0,0.6)] ring-1 ring-sky-400/40 transition-shadow group-hover:ring-sky-300/60"
-        style={{ height: SEEK_RAIL_GROOVE_PX }}
-      />
-      {/* PLAYED fill + ticks clip to the pill (full track height); transparent
-          so the slim groove behind shows through the unplayed stretch. */}
-      <div
-        aria-hidden="true"
-        className="absolute inset-0 overflow-hidden rounded-full"
-      >
-        {/* Content-space layer: as wide as the timeline, translated against
-            the scroller so fill and ticks stay glued to their cards. */}
+      {/* NO TRACK HERE EITHER — see the grid rail above for why the fill
+          element survives while its background does not: the paint loop bails
+          if the fill is missing and would take the thumb with it.
+
+          The clip layer and the content-space inner div stay too. `innerRef`
+          is translated against the scroller every frame to keep the fill glued
+          to its cards, and while the fill paints nothing, the machinery that
+          positions it is the same machinery the thumb's own maths reads. */}
+      <div aria-hidden="true" className="absolute inset-0 overflow-hidden rounded-full">
         <div ref={innerRef} className="relative h-full" style={{ width: extent }}>
-          <div
-            ref={fillRef}
-            data-rail-fill
-            aria-hidden="true"
-            className="absolute inset-y-0 left-0 rounded-full bg-sky-300/80"
-          />
-          {/* SKIP marks, over the fill: the stretches playback will jump. A
-              neutral scrim rather than a colour of its own — the point is
-              that this part of the rail is dead, and a dead stretch should
-              look drained next to the live fill, not decorated. */}
-          {/* Keyed by POSITION, not index: the list is windowed, so indices
-              shift as the strip scrolls and index keys would remount every
-              mark on each chunk crossing. */}
-          {skips.map((segment) => (
-            <span
-              key={`skip-${segment.x}`}
-              data-rail-skip
-              aria-hidden="true"
-              className="absolute inset-y-0 bg-zinc-600/70"
-              style={{ left: segment.x, width: segment.width }}
-            />
-          ))}
-          {ticks.map((x) => (
-            <span
-              key={x}
-              aria-hidden="true"
-              className="absolute inset-y-0 w-px bg-white/30"
-              style={{ left: x }}
-            />
-          ))}
+          <div ref={fillRef} data-rail-fill aria-hidden="true" className="absolute inset-y-0 left-0" />
         </div>
       </div>
       {/* h-3 like the grid rails: the head is visibly bigger than the slim

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -3414,8 +3414,12 @@ test.describe("graph view E2E", () => {
     await previewToggle(page).click();
     const rail = page.locator("[data-graph-seek-rail]").first();
     await expect(rail).toBeVisible();
-    // The skip is visible in the scrubber before anything is played.
-    await expect(page.locator("[data-rail-skip]").first()).toBeVisible();
+    // The skip used to be marked on the rail itself. The rail is invisible
+    // now — the track went and the marks went with it — so the disabled span
+    // is read where it was always clearer: on the card, which dims and wears
+    // a chip. What this test is actually about is below, and unchanged:
+    // scrubbing INTO a disabled clip is allowed and the frame reads as
+    // excluded.
 
     // SCRUB into the disabled clip: allowed, and the frame reads as excluded.
     // Its span is the second card's, so a press around 40% of the rail lands
@@ -6529,9 +6533,7 @@ test.describe("graph view E2E", () => {
   // the cost the strip's card virtualizer exists to avoid. It matters most for
   // a flattened all-items strip, where the count is a whole project's rather
   // than one collection's.
-  test("seek rail marks are windowed to the visible strip, not the whole timeline", async ({
-    page,
-  }) => {
+  test("the seek rail's DOM does not grow with the timeline", async ({ page }) => {
     const api = await installGraphApi(page);
     const project = api.documents.get(PROJECT_ID)!;
     project.clips = [
@@ -6544,22 +6546,25 @@ test.describe("graph view E2E", () => {
 
     const rail = page.locator("[data-graph-seek-rail][data-strip-rail]");
     await expect(rail).toHaveCount(1);
-    // The rail's content layer holds the boundary ticks; each is absolutely
-    // positioned at a content x.
-    const markCount = () => rail.locator("span[aria-hidden='true']").count();
 
-    // 300 cards would be 299 boundary ticks unwindowed. Windowed, the count
-    // follows the viewport — generously bounded so this pins the ORDER of
-    // magnitude rather than an exact layout.
-    await expect.poll(markCount).toBeLessThan(120);
-    await expect.poll(markCount).toBeGreaterThan(0);
+    // THIS USED TO COUNT BOUNDARY TICKS, one per card, and pinned that they
+    // were WINDOWED to the visible scroll range — 300 cards would otherwise
+    // have meant 299 absolutely-positioned marks in the rail.
+    //
+    // The rail has no marks at all now: it is invisible, and only its thumb
+    // shows. That makes the old assertion unfalsifiable — zero marks passes a
+    // "fewer than 120" test for the wrong reason — so it is replaced by the
+    // stronger claim the windowing was always a means to. The rail's DOM is
+    // CONSTANT: whatever the timeline's length, and wherever it is scrolled,
+    // the node count does not move.
+    const nodeCount = () => rail.locator("*").count();
+    const atRest = await nodeCount();
+    expect(atRest).toBeLessThan(12);
 
-    // Scrolling deep into the timeline keeps it bounded — the window moves,
-    // it does not accumulate.
     await strip(page, PROJECT_ID).evaluate((el) => {
       el.scrollLeft = 30_000;
     });
-    await expect.poll(markCount).toBeLessThan(120);
+    await expect.poll(nodeCount).toBe(atRest);
   });
 
   // ── Selection actions on the card ─────────────────────────────────────────


### PR DESCRIPTION
The rail drew a groove across every row to say where playback was — which is
what the playhead line, running down the same rows, already said. A track that
duplicates the thing beside it is furniture, and this one was expensive: 16px
of `pt-4` bought above row zero on both surfaces purely to give it a band, so
the whole board moved down whenever the preview came on.

**What's left is the dot**, riding the cards' own top edge. A card already
carries ~6px of padding above its artwork, so the rail lands on padding rather
than picture and nothing has to move to make room. The dot caps the playhead
line instead of floating above it.

Measured: rail box top and card top both at 555, grid `padding-top` now 0.

The control is exactly as grabbable as before — an invisible rail is still a
rail, and its hit box is unchanged.

## Two things went with the track

- **Cell-boundary ticks** — they described the rail, not the timeline.
- **Skip marks**, which said which stretches playback will jump. That one is
  real information, and it now lives only on the cards themselves (which dim
  and wear a chip). Easy to restore if it's missed.

## Tests

Two asserted the track. The disabled-clip test looked for a skip mark; what it
is actually about — scrubbing into a disabled clip is allowed and the frame
reads as excluded — is unchanged. The other counted boundary ticks to pin that
they were *windowed*, and with no marks that assertion passes for the wrong
reason (zero is fewer than 120). Replaced by the stronger claim windowing was
always a means to: **the rail's DOM is constant**, whatever the timeline's
length and wherever it's scrolled.

Verified: app 1350, storybook 290 (one known VirtualStrip full-run flake that
passes alone), lint and typecheck clean, and the five rail/preview e2e specs
pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)