### PR TITLE
Card transport in the grid, a way home in the sidebar, and a rail you can see

### DIFF
--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -99,6 +99,34 @@ body {
   opacity: 1;
 }
 
+/* THE SCROLL LOCK MUST NOT ALSO COMPENSATE, because the gutter above already did.
+ *
+ * Radix menus and dialogs lock the page with react-remove-scroll, which sets
+ * `overflow: hidden` on BODY and then adds a margin equal to the scrollbar it
+ * just removed — the standard trick for keeping content still while a modal is
+ * open. It is correct on a normal page and wrong on this one: the gutter holds
+ * that space permanently, so nothing was lost to give back, and the margin is
+ * pure double-count. Right-clicking a card pulled the whole board 15px left.
+ *
+ * IT ALSO COSTS THE GUTTER ITSELF. `overflow` propagates to the viewport from
+ * BODY once body's value stops being `visible`, and body carries no gutter, so
+ * the lock takes the reserved strip away at the same moment it compensates for
+ * it. That is the second half of the jump, and it is why setting the gutter on
+ * `body` as well fixes nothing — measured, it moved the shift not one pixel.
+ *
+ * SPECIFICITY, DELIBERATELY. Their rule is `!important` and is injected into
+ * the head WHEN THE MENU OPENS, so it lands after this stylesheet and wins any
+ * tie on order; `html body[...]` outranks it regardless of who got there first.
+ * A matching-specificity `!important` was tried and lost exactly this way.
+ *
+ * Only the gap is cancelled — `overflow: hidden` is untouched, so the page is
+ * still locked behind the menu. Measured: board shift on right-click 15px -> 0.
+ */
+html body[data-scroll-locked] {
+  margin-right: 0 !important;
+  padding-right: 0 !important;
+}
+
 [data-testid="timeline-scroll-viewport"] {
   color-scheme: dark;
   scrollbar-color: #52525b #09090b;

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -116,6 +116,7 @@ import {
 import { useCollectionSubtreeHydrated } from "./graph-card-derivations";
 import { splitLaneRows } from "./graph-lane-rows";
 import { AddCollectionSlot } from "./graph-add-collection-slot";
+import { GridPlayStarts, gridPlayButtonFor } from "./graph-grid-play-button";
 import { CollectionHoverProvider } from "./graph-collection-hover";
 import { TagFilterProvider } from "./graph-tag-filter";
 import { ActiveTagFilters, TagFilterControl } from "./graph-tag-filter-control";
@@ -1994,6 +1995,12 @@ export function GraphBoard({
   // (R7 #1). Read here, not threaded from the page: the graph tree mounts
   // client-only (`ssr: false` in client-graph-view), so useSearchParams has
   // no prerender/Suspense implications.
+  // MEMOISED: a fresh function each render would be a new prop on every
+  // VirtualGrid render, for a value that only depends on the channel.
+  const playButtonCell = useMemo(
+    () => (previewOn ? gridPlayButtonFor(timeChannel) : undefined),
+    [previewOn, timeChannel],
+  );
   const devParam = useSearchParams().get("dev");
   const devPanelsOn = devParam !== null && !["", "0", "false"].includes(devParam);
 
@@ -2773,6 +2780,10 @@ export function GraphBoard({
               data-focused-surface-shell="grid"
               className="relative"
             >
+              {/* The starts are computed once for the surface and read by each
+                  card's play button — see the note in that file for why they
+                  come from `childSpans` rather than the spans context. */}
+              <GridPlayStarts focusedId={focusedId} pixelsPerSecond={deferredPixelsPerSecond}>
               <NativeDropGrid collectionId={focusedId} projectId={projectId}>
                 <VirtualGrid
                   collectionId={parseNodeId(focusedId)}
@@ -2785,6 +2796,11 @@ export function GraphBoard({
                   // drag. "body" (the default) drags instantly, which ate the
                   // drill click and made drags ambiguous.
                   itemDragActivation="hold"
+                  // A PLAY BUTTON ON EVERY CARD WHILE THE PREVIEW IS OPEN.
+                  // Only while it is open: the button starts playback in the
+                  // pane, so without a pane there is nowhere for it to play
+                  // and it would be a control that does nothing.
+                  cellOverlay={playButtonCell}
                   // NO TRAILING ADD SLOT IN THE GRID.
                   //
                   // It costs a whole cell, and when it wraps it costs a whole
@@ -2851,6 +2867,7 @@ export function GraphBoard({
                   ].join(" ")}
                 />
               </NativeDropGrid>
+              </GridPlayStarts>
               {previewOn && (
                 <AfterPreviewOpens>
                   <GraphSeekRails

--- a/apps/timeline-gstudio001/components/graph-view/graph-clip-card.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-clip-card.tsx
@@ -235,7 +235,18 @@ export const GraphClipContent = memo(function GraphClipContent({
           frame to opacity-30, and a checkbox that went with it would make the
           selection unreadable exactly while someone is picking through a
           filtered board. */}
-      <span className="relative flex h-full min-h-0 w-full overflow-hidden rounded-sm [[data-virtual-grid]_&]:flex-1">
+      <span
+        // NAMED so a layer OUTSIDE the card can measure this box. The grid's
+        // play buttons ride the bottom-left of the picture, and they cannot be
+        // children of the card (its shell is a `<button>`), so they are an
+        // overlay that computes cell positions arithmetically — which needs one
+        // real answer to "where does the picture end inside a cell". The
+        // caption's top would give the same number by coincidence; this says it
+        // on purpose, and only media cards carry it, which is the only kind
+        // those buttons appear on.
+        data-clip-artwork
+        className="relative flex h-full min-h-0 w-full overflow-hidden rounded-sm [[data-virtual-grid]_&]:flex-1"
+      >
         <span
           data-disabled-visuals={disabledVisualsAttr(disabledVisuals)}
           data-filter-miss={filterMiss ? "true" : undefined}

--- a/apps/timeline-gstudio001/components/graph-view/graph-collection-card.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-collection-card.tsx
@@ -182,6 +182,12 @@ const GraphCollectionItemParts = memo(function GraphCollectionItemParts({
         <span
           data-disabled-visuals={disabledVisualsAttr(disabledVisuals)}
           data-filter-miss={filterMiss ? "true" : undefined}
+          // The SAME artwork marker the media card carries, so the grid's play
+          // button lands on the picture here too. Without it the button fell
+          // back to the cell's bottom, which on a collection is under the
+          // name-and-count row — a play control sitting below the card it
+          // belongs to.
+          data-clip-artwork
           // `relative`, so the checkbox below anchors to the PREVIEW FRAMES
           // rather than to the whole card. Anchored to the card it landed on
           // the name-and-count row underneath and truncated it ("51.8s / 5

--- a/apps/timeline-gstudio001/components/graph-view/graph-grid-play-button.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-grid-play-button.tsx
@@ -240,7 +240,23 @@ export function GraphGridPlayButton({
   ].join(" ");
 
   return (
-    <div ref={anchorRef} className="pointer-events-none absolute inset-0">
+    // GONE WHILE SELECTING. In that mode a card is a thing you are picking,
+    // not a thing you are watching, and two transport controls sitting on it
+    // are two places a press does something other than select — on a surface
+    // where every press is supposed to mean the same thing.
+    //
+    // `hidden` rather than an opacity or a pointer-events trick, so they leave
+    // the tab order too: a control you cannot see should not be one you can
+    // still reach by keyboard.
+    //
+    // Driven off the panel's `data-select-mode` rather than a store read here,
+    // for the same reason the cards' rings are: this is a whole-surface state,
+    // and subscribing every card to it would re-render all of them on a toggle
+    // to hide two buttons.
+    <div
+      ref={anchorRef}
+      className="pointer-events-none absolute inset-0 [[data-select-mode]_&]:hidden"
+    >
       {/* A ROW, so the two controls share one corner and one baseline rather
           than each finding its own. */}
       <div

--- a/apps/timeline-gstudio001/components/graph-view/graph-grid-play-button.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-grid-play-button.tsx
@@ -10,7 +10,7 @@ import {
   useSyncExternalStore,
   type ReactNode,
 } from "react";
-import { Pause, Play, SkipBack } from "lucide-react";
+import { Pause, Play, SkipForward } from "lucide-react";
 
 import {
   getChildren,
@@ -41,6 +41,10 @@ import type { PreviewTimeChannel } from "./preview-time-channel";
  * exactly how this was first found.
  */
 type CardStart = Readonly<{ start: number; end: number; disabled: boolean }>;
+
+/** Near enough to a clip's start to call it there. A frame at 25fps is 0.04s,
+ *  so this is "within a frame" without pretending the clock is exact. */
+const AT_START_SECONDS = 0.05;
 
 const ClipStartsContext = createContext<ReadonlyMap<string, CardStart> | null>(null);
 
@@ -116,7 +120,11 @@ export function GraphGridPlayButton({
   // timeline re-renders exactly two buttons per crossing rather than the whole
   // grid on every tick. That was the objection to a toggle; a boolean snapshot
   // answers it.
-  const playingHere = useSyncExternalStore(
+  // ONE STRING, not two booleans. Both facts come from the same two values and
+  // are mutually exclusive, so a single snapshot means one subscription and one
+  // bail-out check — and, more usefully, makes it impossible to render a card
+  // that claims to be playing AND parked at its own start.
+  const cardState = useSyncExternalStore(
     (onChange) => {
       const stopTime = channel.subscribe(onChange);
       const stopPlaying = channel.subscribePlaying(onChange);
@@ -126,12 +134,18 @@ export function GraphGridPlayButton({
       };
     },
     () => {
-      if (card === undefined || !channel.isPlaying()) return false;
+      if (card === undefined) return "idle";
       const now = channel.get();
-      return now >= card.start && now < card.end;
+      if (channel.isPlaying() && now >= card.start && now < card.end) return "playing";
+      return Math.abs(now - card.start) < AT_START_SECONDS ? "at-start" : "idle";
     },
-    () => false,
+    () => "idle",
   );
+  const playingHere = cardState === "playing";
+  // ALREADY THERE, so the cue has nothing to do. Disabled rather than hidden:
+  // a control that vanishes when you have just used it takes its own
+  // explanation with it, and the gap left behind moves the button beside it.
+  const alreadyAtStart = cardState === "at-start";
   const node = useCollectionsSelector((snapshot) => snapshot.graph.nodesById.get(nodeId) ?? null);
   const anchorRef = useRef<HTMLDivElement | null>(null);
 
@@ -260,9 +274,17 @@ export function GraphGridPlayButton({
       </button>
 
       {/* CUE, not play: the playhead moves to this clip's start and stops
-          there. The transport's own "go to start" glyph, reused deliberately —
-          it means the same thing here, and inventing a second symbol for one
-          action is how two controls end up disagreeing about what they do.
+          there. The transport's own skip glyph, reused rather than invented —
+          a second symbol for one action is how two controls end up disagreeing
+          about what they do.
+
+          POINTING FORWARD. The back-facing twin was the literal reading — "go
+          to the start of this" — but from the board the gesture is a jump
+          ACROSS the timeline to a card you can see, and most of the cards you
+          reach for are ahead of where the playhead is sitting. Facing it
+          backwards made a forward jump look like a rewind. It is the same
+          glyph rotated; the direction it points is the only thing being said
+          here, and it should agree with the direction you are travelling.
 
           Hidden while THIS clip is playing: the playhead is already inside it,
           so "go to its start" during playback would be a rewind nobody asked
@@ -272,16 +294,21 @@ export function GraphGridPlayButton({
         <button
           type="button"
           data-grid-cue={nodeId as string}
+          disabled={alreadyAtStart}
           aria-label={`Move the playhead to the start of ${node.name}`}
-          title={`Go to the start of ${node.name}`}
+          title={
+            alreadyAtStart
+              ? `The playhead is already at the start of ${node.name}`
+              : `Go to the start of ${node.name}`
+          }
           onPointerDown={(event) => event.stopPropagation()}
           onClick={(event) => {
             event.stopPropagation();
             channel.set(card.start);
           }}
-          className={discClass}
+          className={`${discClass} disabled:pointer-events-none disabled:opacity-40`}
         >
-          <SkipBack aria-hidden="true" className="size-3.5" fill="currentColor" />
+          <SkipForward aria-hidden="true" className="size-3.5" fill="currentColor" />
         </button>
       )}
       </div>

--- a/apps/timeline-gstudio001/components/graph-view/graph-grid-play-button.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-grid-play-button.tsx
@@ -10,7 +10,7 @@ import {
   useSyncExternalStore,
   type ReactNode,
 } from "react";
-import { Pause, Play } from "lucide-react";
+import { Pause, Play, SkipBack } from "lucide-react";
 
 import {
   getChildren,
@@ -193,8 +193,26 @@ export function GraphGridPlayButton({
   if (!settled || node === null) return null;
   if (card === undefined || card.disabled) return null;
 
+  const discClass = [
+    "pointer-events-auto flex size-7 items-center justify-center",
+    "rounded-full bg-zinc-950/70 text-zinc-100 ring-1 ring-white/25 backdrop-blur-sm",
+    "transition-colors hover:bg-zinc-950/90 hover:text-white",
+    "focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:outline-none",
+  ].join(" ");
+
   return (
     <div ref={anchorRef} className="pointer-events-none absolute inset-0">
+      {/* A ROW, so the two controls share one corner and one baseline rather
+          than each finding its own. */}
+      <div
+        style={artworkBottom === null ? undefined : { bottom: `${8 - artworkBottom}px` }}
+        className={[
+          // left-3.5 = the card's own 6px padding plus 8px, so the pair sits
+          // inside the PICTURE's corner rather than on its edge.
+          "pointer-events-none absolute left-3.5 z-20 flex items-center gap-1.5",
+          artworkBottom === null ? "bottom-2" : "",
+        ].join(" ")}
+      >
       <button
         type="button"
         data-grid-play={nodeId as string}
@@ -217,21 +235,21 @@ export function GraphGridPlayButton({
           // ALWAYS FROM THIS CARD'S OWN START, even if the clock is already
           // inside it — "play this" means this clip from its beginning, not
           // "resume wherever the playhead happens to be sitting".
+          //
+          // SEEK, THEN START A FRAME LATER, and the frame is the whole point.
+          // Both writes land in one React batch, so the pane received the new
+          // time and `playing: true` together — and a controlled player
+          // ignores an incoming time while it is playing, or it would fight
+          // its own progress. The seek was dropped and playback ran from
+          // wherever the pane already was: measured, pressing the third card
+          // played from 0.0s instead of its 16.5s start, and because the pause
+          // state is derived from the same window, the button never flipped
+          // either. Letting the seek land while the pane is still paused fixes
+          // both.
           channel.set(card.start);
-          channel.setPlaying(true);
+          requestAnimationFrame(() => channel.setPlaying(true));
         }}
-        style={artworkBottom === null ? undefined : { bottom: `${8 - artworkBottom}px` }}
-        className={[
-          // left-3.5 = the card's own 6px padding plus 8px, so the button sits
-          // inside the PICTURE's corner rather than on its edge.
-          "pointer-events-auto absolute left-3.5 z-20 flex size-7 items-center justify-center",
-          "rounded-full bg-zinc-950/70 text-zinc-100 ring-1 ring-white/25 backdrop-blur-sm",
-          "transition-colors hover:bg-zinc-950/90 hover:text-white",
-          "focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:outline-none",
-          // Until the measurement lands it sits at the cell's bottom, which is
-          // close enough for one frame and never off-screen.
-          artworkBottom === null ? "bottom-2" : "",
-        ].join(" ")}
+        className={discClass}
       >
         {playingHere ? (
           <Pause aria-hidden="true" className="size-3.5" fill="currentColor" />
@@ -240,6 +258,33 @@ export function GraphGridPlayButton({
           <Play aria-hidden="true" className="size-3.5 translate-x-px" fill="currentColor" />
         )}
       </button>
+
+      {/* CUE, not play: the playhead moves to this clip's start and stops
+          there. The transport's own "go to start" glyph, reused deliberately —
+          it means the same thing here, and inventing a second symbol for one
+          action is how two controls end up disagreeing about what they do.
+
+          Hidden while THIS clip is playing: the playhead is already inside it,
+          so "go to its start" during playback would be a rewind nobody asked
+          for, and the pause button beside it is the thing you actually want at
+          that moment. */}
+      {!playingHere && (
+        <button
+          type="button"
+          data-grid-cue={nodeId as string}
+          aria-label={`Move the playhead to the start of ${node.name}`}
+          title={`Go to the start of ${node.name}`}
+          onPointerDown={(event) => event.stopPropagation()}
+          onClick={(event) => {
+            event.stopPropagation();
+            channel.set(card.start);
+          }}
+          className={discClass}
+        >
+          <SkipBack aria-hidden="true" className="size-3.5" fill="currentColor" />
+        </button>
+      )}
+      </div>
     </div>
   );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-grid-play-button.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-grid-play-button.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react";
+import { Pause, Play } from "lucide-react";
+
+import {
+  getChildren,
+  parseNodeId,
+  useCollectionsSelector,
+  type NodeId,
+} from "@storyboard/ui/dnd-collections";
+
+import { usePreviewSettled } from "@storyboard/ui/timeline/viewport/workbench-display-surface";
+
+import { useGraphDetailsStore } from "./graph-details-context";
+import { childSpans } from "./graph-playhead-model";
+import { clipWidthAt } from "./preview-card-geometry";
+import { PreviewCardSpansContext } from "./preview-contexts";
+import type { PreviewTimeChannel } from "./preview-time-channel";
+
+/**
+ * When each card starts, on the clock the pane is actually playing.
+ *
+ * COMPUTED ONCE FOR THE SURFACE, not once per card: `childSpans` walks the
+ * focused collection's children, so a card doing it for itself would do the
+ * whole walk N times to read one number out of it.
+ *
+ * It goes through `childSpans` rather than the spans context directly because
+ * that context is NULL until the manifest lands — the pane plays a live
+ * projection first, and for a couple of seconds after every edit. Reading the
+ * context alone meant no buttons at all on a freshly opened board, which is
+ * exactly how this was first found.
+ */
+type CardStart = Readonly<{ start: number; end: number; disabled: boolean }>;
+
+const ClipStartsContext = createContext<ReadonlyMap<string, CardStart> | null>(null);
+
+export function GridPlayStarts({
+  focusedId,
+  pixelsPerSecond,
+  children,
+}: Readonly<{ focusedId: string; pixelsPerSecond: number; children: ReactNode }>) {
+  const graph = useCollectionsSelector((snapshot) => snapshot.graph);
+  const detailsStore = useGraphDetailsStore();
+  const details = useSyncExternalStore(
+    detailsStore.subscribe,
+    detailsStore.read,
+    detailsStore.read,
+  );
+  const spans = useContext(PreviewCardSpansContext);
+
+  const starts = useMemo(() => {
+    const ids = getChildren(graph, parseNodeId(focusedId));
+    // `laneScope` left at its default: one card per child, which is the
+    // pairing this index alignment depends on.
+    const cards = childSpans(graph, details, focusedId, spans, clipWidthAt(pixelsPerSecond, 0));
+    const map = new Map<string, CardStart>();
+    ids.forEach((id, index) => {
+      const card = cards[index];
+      if (card === undefined) return;
+      // `disabled` here already folds in a disabled ANCESTOR — the rails draw
+      // no distinction either, because in both cases nothing reaches the
+      // viewer.
+      map.set(id as string, {
+        start: card.startTime,
+        end: card.endTime,
+        disabled: card.disabled === true,
+      });
+    });
+    return map;
+  }, [graph, details, spans, focusedId, pixelsPerSecond]);
+
+  return <ClipStartsContext.Provider value={starts}>{children}</ClipStartsContext.Provider>;
+}
+
+/**
+ * Start this clip playing IN THE PREVIEW PANE, from its own beginning.
+ *
+ * A SIBLING OF THE CARD, not a child of it. A card's shell is a `<button>` and
+ * nested interactive content is invalid — the tag editor lives in the details
+ * modal for the same reason — so this rides the grid's per-cell slot, which is
+ * the nearest place that is both valid markup and card-shaped. Nothing has to
+ * measure where a card is; the cell already knows.
+ *
+ * PLAY, NOT PLAY/PAUSE. Making each button a toggle means every card has to
+ * know whether IT is the clip currently playing, which means subscribing every
+ * card to the clock and re-rendering the grid as the playhead moves — a real
+ * cost for a second pause button, when the transport sitting in the preview
+ * pane above is already the obvious place to stop.
+ */
+export function GraphGridPlayButton({
+  nodeId,
+  channel,
+}: Readonly<{ nodeId: NodeId; channel: PreviewTimeChannel }>) {
+  const starts = useContext(ClipStartsContext);
+  // NOT UNTIL THE PANE HAS LANDED. These buttons appear when the preview does,
+  // which means their first paint would otherwise fall in the middle of the
+  // reveal — one per card, all at once, over a board that is still moving. The
+  // rails wait for the same signal and for the same reason.
+  const settled = usePreviewSettled();
+  const card = starts?.get(nodeId as string);
+
+  // IS THIS THE CARD PLAYING RIGHT NOW.
+  //
+  // Subscribed per card, but the snapshot is a BOOLEAN — so React bails out
+  // unless this particular card's answer flips, and a playhead sweeping the
+  // timeline re-renders exactly two buttons per crossing rather than the whole
+  // grid on every tick. That was the objection to a toggle; a boolean snapshot
+  // answers it.
+  const playingHere = useSyncExternalStore(
+    (onChange) => {
+      const stopTime = channel.subscribe(onChange);
+      const stopPlaying = channel.subscribePlaying(onChange);
+      return () => {
+        stopTime();
+        stopPlaying();
+      };
+    },
+    () => {
+      if (card === undefined || !channel.isPlaying()) return false;
+      const now = channel.get();
+      return now >= card.start && now < card.end;
+    },
+    () => false,
+  );
+  const node = useCollectionsSelector((snapshot) => snapshot.graph.nodesById.get(nodeId) ?? null);
+  const anchorRef = useRef<HTMLDivElement | null>(null);
+
+  // WHERE THE PICTURE ENDS INSIDE THE CELL.
+  //
+  // The button belongs at the bottom-left of the THUMBNAIL, and a grid cell is
+  // thumbnail plus caption — so the cell's own bottom is the wrong edge by
+  // however tall the caption is. That height is real layout, not a number this
+  // file should own a copy of: the caption carries a name row and a tag row
+  // that is present even when empty, and any constant here would be a second
+  // opinion about it that silently rots.
+  //
+  // So it is measured, once per card and again on resize, from the artwork
+  // marker the card publishes. Local to one cell, not a sweep of the grid.
+  const [artworkBottom, setArtworkBottom] = useState<number | null>(null);
+  useEffect(() => {
+    const anchor = anchorRef.current;
+    const cell = anchor?.parentElement;
+    if (!cell || typeof ResizeObserver === "undefined") return;
+    // RETRIED UNTIL THE PICTURE IS THERE. A collection card fills its frames
+    // from child previews that arrive after mount, so the first measurement
+    // finds nothing and a ResizeObserver on the CELL never fires — the cell's
+    // own size did not change. The button then sat at its fallback, which on a
+    // collection is below the name-and-count row: a play control under the
+    // card it belongs to. Measured at 53px out, every time.
+    let frame = 0;
+    let tries = 0;
+    const measure = () => {
+      const artwork = cell.querySelector("[data-clip-artwork]");
+      const box = artwork?.getBoundingClientRect();
+      if (box === undefined || box.height === 0) {
+        if (tries++ < 40) frame = requestAnimationFrame(measure);
+        return;
+      }
+      setArtworkBottom(box.bottom - cell.getBoundingClientRect().bottom);
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(cell);
+    return () => {
+      cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
+    // DEPENDS ON `settled`, and that is not incidental. This component returns
+    // null until the preview has finished opening, so on first render there is
+    // no element for the ref — an effect with an empty dependency list runs
+    // once, against that null, and never again. The button then kept its
+    // fallback position forever, which put it under the card instead of on the
+    // picture. Re-running when the button actually mounts is the whole fix.
+  }, [settled]);
+
+  // COLLECTIONS GET ONE TOO. Its window is the union of every leaf beneath it,
+  // so its start IS its first clip's start — pressing play on a collection
+  // plays the collection, which is the only thing it could sensibly mean.
+  //
+  // DISABLED CARDS DO NOT. Playback jumps them, so the button would be a
+  // control that visibly does nothing — the playhead would land past it and
+  // the card it was pressed on would never appear.
+  if (!settled || node === null) return null;
+  if (card === undefined || card.disabled) return null;
+
+  return (
+    <div ref={anchorRef} className="pointer-events-none absolute inset-0">
+      <button
+        type="button"
+        data-grid-play={nodeId as string}
+        aria-label={
+          playingHere ? `Pause ${node.name}` : `Play ${node.name} in the preview`
+        }
+        title={playingHere ? `Pause ${node.name}` : `Play ${node.name} in the preview`}
+        onPointerDown={(event) => event.stopPropagation()}
+        onClick={(event) => {
+          // Stopped, or the press also reaches the card underneath and selects
+          // it — or, held a moment, starts a reorder drag.
+          event.stopPropagation();
+          if (playingHere) {
+            // Pause where it is, rather than rewinding: stopping to look at a
+            // frame and being thrown back to the clip's start would make the
+            // button useless for the thing you stop for.
+            channel.setPlaying(false);
+            return;
+          }
+          // ALWAYS FROM THIS CARD'S OWN START, even if the clock is already
+          // inside it — "play this" means this clip from its beginning, not
+          // "resume wherever the playhead happens to be sitting".
+          channel.set(card.start);
+          channel.setPlaying(true);
+        }}
+        style={artworkBottom === null ? undefined : { bottom: `${8 - artworkBottom}px` }}
+        className={[
+          // left-3.5 = the card's own 6px padding plus 8px, so the button sits
+          // inside the PICTURE's corner rather than on its edge.
+          "pointer-events-auto absolute left-3.5 z-20 flex size-7 items-center justify-center",
+          "rounded-full bg-zinc-950/70 text-zinc-100 ring-1 ring-white/25 backdrop-blur-sm",
+          "transition-colors hover:bg-zinc-950/90 hover:text-white",
+          "focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:outline-none",
+          // Until the measurement lands it sits at the cell's bottom, which is
+          // close enough for one frame and never off-screen.
+          artworkBottom === null ? "bottom-2" : "",
+        ].join(" ")}
+      >
+        {playingHere ? (
+          <Pause aria-hidden="true" className="size-3.5" fill="currentColor" />
+        ) : (
+          // Nudged right: a triangle's optical centre is left of its box.
+          <Play aria-hidden="true" className="size-3.5 translate-x-px" fill="currentColor" />
+        )}
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Convenience for the board's `cellOverlay`, which hands over a raw id.
+ *
+ * NAMED, because eslint reads any arrow returning JSX as a component and
+ * `react/display-name` is an ERROR in this repo — one that fails the Vercel
+ * build while tsc and vitest stay green, so it has to be caught here.
+ */
+export function gridPlayButtonFor(channel: PreviewTimeChannel) {
+  const CellPlayButton = (id: NodeId) => (
+    <GraphGridPlayButton nodeId={parseNodeId(id as string)} channel={channel} />
+  );
+  CellPlayButton.displayName = "GridCellPlayButton";
+  return CellPlayButton;
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-grid-play-button.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-grid-play-button.tsx
@@ -134,18 +134,43 @@ export function GraphGridPlayButton({
       };
     },
     () => {
-      if (card === undefined) return "idle";
+      if (card === undefined) return "at-start";
       const now = channel.get();
       if (channel.isPlaying() && now >= card.start && now < card.end) return "playing";
-      return Math.abs(now - card.start) < AT_START_SECONDS ? "at-start" : "idle";
+      if (Math.abs(now - card.start) < AT_START_SECONDS) return "at-start";
+      // WHICH WAY THE JUMP GOES. Note that a playhead sitting INSIDE this clip
+      // but past its start counts as "back" — pressing cue would rewind to the
+      // clip's opening, and that is what the arrow should say.
+      return card.start < now ? "back" : "forward";
     },
-    () => "idle",
+    () => "at-start",
   );
   const playingHere = cardState === "playing";
   // ALREADY THERE, so the cue has nothing to do. Disabled rather than hidden:
   // a control that vanishes when you have just used it takes its own
   // explanation with it, and the gap left behind moves the button beside it.
   const alreadyAtStart = cardState === "at-start";
+
+  // WHICH WAY THE ARROW POINTS, remembered across the moment it arrives.
+  //
+  // Rotating is the whole signal: forward for a card ahead of the playhead,
+  // turned around for one behind it — the same glyph, saying "fetch the
+  // playhead back" instead of "run on to there".
+  //
+  // The ref exists for the instant the jump COMPLETES. At that point the card
+  // is at-start with no direction of its own, and recomputing would snap a
+  // backward arrow forward at the exact moment it went quiet — the control
+  // contradicting the trip you just watched it make. Holding the last real
+  // direction lets it arrive pointing the way it went.
+  // STATE ADJUSTED DURING RENDER, which React sanctions for exactly this —
+  // deriving from a prop or a store value that has changed — and which a ref
+  // cannot do here, since reading one during render is neither allowed nor
+  // reliable.
+  const [lastDirection, setLastDirection] = useState<"back" | "forward">("forward");
+  if ((cardState === "back" || cardState === "forward") && cardState !== lastDirection) {
+    setLastDirection(cardState);
+  }
+  const pointsBack = (cardState === "at-start" ? lastDirection : cardState) === "back";
   const node = useCollectionsSelector((snapshot) => snapshot.graph.nodesById.get(nodeId) ?? null);
   const anchorRef = useRef<HTMLDivElement | null>(null);
 
@@ -295,7 +320,11 @@ export function GraphGridPlayButton({
           type="button"
           data-grid-cue={nodeId as string}
           disabled={alreadyAtStart}
-          aria-label={`Move the playhead to the start of ${node.name}`}
+          aria-label={
+            pointsBack
+              ? `Move the playhead back to the start of ${node.name}`
+              : `Move the playhead forward to the start of ${node.name}`
+          }
           title={
             alreadyAtStart
               ? `The playhead is already at the start of ${node.name}`
@@ -308,7 +337,18 @@ export function GraphGridPlayButton({
           }}
           className={`${discClass} disabled:pointer-events-none disabled:opacity-40`}
         >
-          <SkipForward aria-hidden="true" className="size-3.5" fill="currentColor" />
+          {/* TRANSITIONED, because the turn is the message. A glyph that
+              simply appears facing the other way says the same thing without
+              anyone noticing it changed; watching it swing is what teaches the
+              rule. */}
+          <SkipForward
+            aria-hidden="true"
+            fill="currentColor"
+            className={[
+              "size-3.5 transition-transform duration-200 ease-out motion-reduce:transition-none",
+              pointsBack ? "rotate-180" : "rotate-0",
+            ].join(" ")}
+          />
         </button>
       )}
       </div>

--- a/apps/timeline-gstudio001/components/graph-view/graph-seek-rails.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seek-rails.tsx
@@ -83,7 +83,19 @@ export const SEEK_RAIL_BAND_INSET_PX = 0;
  *  thickens behind the thumb. The HIT TARGET is unchanged — the whole
  *  SEEK_RAIL_TRACK_PX-tall box stays grabbable; only this visible line is
  *  slim. */
-const SEEK_RAIL_GROOVE_PX = 2;
+/**
+ * The hairline that says the rail is there at all.
+ *
+ * ONE PIXEL, against the old groove's two-plus-ring-plus-inset-shadow. The
+ * track went because it duplicated the playhead line and cost a 16px band to
+ * live in; what it also carried, and what went with it, was the only sign that
+ * this strip of the card does anything. A dot that appears where you last left
+ * it does not advertise that the space around it is draggable.
+ *
+ * The HIT AREA is unchanged at `SEEK_RAIL_TRACK_PX` — eight times this. What
+ * you can see is a hint; what you can hit is a control.
+ */
+const SEEK_RAIL_GROOVE_PX = 1;
 
 type SeekRailGeometry = Readonly<{
   columns: number;
@@ -304,8 +316,18 @@ function SeekRailRow({
         height: SEEK_RAIL_TRACK_PX,
       }}
     >
-      {/* NO GROOVE, NO FILL, NO TICKS — the rail is invisible and only its
-          thumb shows.
+      {/* THE HINT. Barely present at rest — it rides the top edge of the
+          artwork, and anything stronger would read as a border the cards do
+          not have — and it warms under the pointer, which is where "this is
+          draggable" is actually learned. The whole rail is the hit target, so
+          hovering anywhere over the band lights it. */}
+      <div
+        aria-hidden="true"
+        className="absolute inset-x-0 top-1/2 -translate-y-1/2 rounded-full bg-white/15 transition-colors group-hover:bg-sky-300/70"
+        style={{ height: SEEK_RAIL_GROOVE_PX }}
+      />
+      {/* NO FILL AND NO TICKS — what the rail shows is the hairline above and
+          its thumb, and nothing else.
           A track drawn across every row was a lot of furniture for a control
           that is used occasionally, and it duplicated what the playhead line
           already says: where you are. The dot is the part that carries
@@ -910,7 +932,17 @@ export function GraphStripSeekRail({
           : { left: 9, top: 1 + SEEK_RAIL_BAND_INSET_PX, right: 9, height: SEEK_RAIL_TRACK_PX }
       }
     >
-      {/* NO TRACK HERE EITHER — see the grid rail above for why the fill
+      {/* THE HINT. Barely present at rest — it rides the top edge of the
+          artwork, and anything stronger would read as a border the cards do
+          not have — and it warms under the pointer, which is where "this is
+          draggable" is actually learned. The whole rail is the hit target, so
+          hovering anywhere over the band lights it. */}
+      <div
+        aria-hidden="true"
+        className="absolute inset-x-0 top-1/2 -translate-y-1/2 rounded-full bg-white/15 transition-colors group-hover:bg-sky-300/70"
+        style={{ height: SEEK_RAIL_GROOVE_PX }}
+      />
+      {/* NO FILL HERE EITHER — see the grid rail above for why the fill
           element survives while its background does not: the paint loop bails
           if the fill is missing and would take the thumb with it.
 

--- a/apps/timeline-gstudio001/components/timeline/sidebar-collection-shortcuts.stories.tsx
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-collection-shortcuts.stories.tsx
@@ -259,3 +259,43 @@ export const NoCollectionsDrawsNothing: Story = {
     expect(canvasElement.querySelector("[data-sidebar-collection-shortcuts]")).toBeNull();
   },
 };
+
+/**
+ * HOME IS THE FIRST ENTRY, and the group survives on it alone.
+ *
+ * The group used to vanish when a project had no top-level collections, on the
+ * reasoning that a heading with nothing under it reads as something that
+ * failed to load. That reasoning still holds — but "nothing" changed meaning
+ * when Home moved inside: a project with no collections still has a root to go
+ * back to, so there IS something under the heading.
+ *
+ * First, because the root is what contains the rest: a list of a project's
+ * collections that does not begin with the project reads as a list of
+ * unrelated places.
+ */
+export const HomeLeadsTheGroup: Story = {
+  render: () => (
+    <CollectionShortcutsGroup shortcuts={[]} onOpen={() => {}} projectId="project-1" />
+  ),
+  play: async ({ canvasElement }) => {
+    const group = canvasElement.querySelector("[data-sidebar-collection-shortcuts]");
+    await expect(group).not.toBeNull();
+
+    const home = canvasElement.querySelector("[data-sidebar-project-home]");
+    await expect(home).not.toBeNull();
+    // FIRST, not merely present.
+    await expect(group!.firstElementChild).toBe(home);
+    // A route, so the back button understands it.
+    await expect(home!.getAttribute("href")).toBe("/timeline/project-1/graph");
+  },
+};
+
+/** With no project there is no root to go to, and the empty group disappears
+ *  exactly as it always did. */
+export const NoProjectMeansNoGroup: Story = {
+  render: () => <CollectionShortcutsGroup shortcuts={[]} onOpen={() => {}} />,
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelector("[data-sidebar-collection-shortcuts]")).toBeNull();
+    await expect(canvasElement.querySelector("[data-sidebar-project-home]")).toBeNull();
+  },
+};

--- a/apps/timeline-gstudio001/components/timeline/sidebar-collection-shortcuts.tsx
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-collection-shortcuts.tsx
@@ -3,7 +3,6 @@
 import { useContext, useSyncExternalStore } from "react";
 import { Home, Layers } from "lucide-react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
 
 import {
   collectionShortcuts,
@@ -18,7 +17,6 @@ import {
   SIDEBAR_GLYPH,
   SIDEBAR_ICON_BASE,
   SIDEBAR_ICON_IDLE,
-  SIDEBAR_ICON_PRESSED,
 } from "./sidebar-icon-styles";
 import {
   SidebarLabelsInlineContext,
@@ -191,21 +189,24 @@ function ShortcutsHeading({
  * understands it.
  */
 function ProjectHomeShortcut({ projectId }: Readonly<{ projectId: string }>) {
-  const pathname = usePathname();
-  const href = `/timeline/${projectId}/graph`;
-  // ALREADY HOME is worth showing: every other control in this rail marks
-  // where you are, and a home button that looks identical at the root and six
-  // collections deep is the one that makes you check the breadcrumb instead.
-  const isHome = pathname === href;
   const tooltipId = "sidebar-tooltip-project-home";
+  // NO "YOU ARE HERE" STATE, and that is a decision about which group this
+  // belongs to rather than an oversight. The tiles ABOVE the divider mark
+  // where you are — they are the surfaces, and which one is showing is a fact
+  // about the board. Everything in THIS group is a shortcut: somewhere to go,
+  // not somewhere you are. The collections beside it mark nothing, so a home
+  // that lit up would be the one item here claiming a different kind of
+  // meaning, which reads as inconsistency long before it reads as helpful.
+  //
+  // `aria-current` goes with it. Announcing a state that is deliberately not
+  // drawn would tell a screen reader something the screen does not say.
   return (
     <Link
-      href={href}
-      data-sidebar-project-home={isHome ? "current" : ""}
+      href={`/timeline/${projectId}/graph`}
+      data-sidebar-project-home=""
       aria-label="Project home"
-      aria-current={isHome ? "page" : undefined}
       aria-describedby={tooltipId}
-      className={cn(SIDEBAR_ICON_BASE, isHome ? SIDEBAR_ICON_PRESSED : SIDEBAR_ICON_IDLE)}
+      className={cn(SIDEBAR_ICON_BASE, SIDEBAR_ICON_IDLE)}
     >
       <Home className={SIDEBAR_GLYPH} />
       <SidebarTooltipLabel id={tooltipId} label="Home" description="The top of this project" />

--- a/apps/timeline-gstudio001/components/timeline/sidebar-collection-shortcuts.tsx
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-collection-shortcuts.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useContext, useSyncExternalStore } from "react";
-import { Layers } from "lucide-react";
+import { Home, Layers } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
 
 import {
   collectionShortcuts,
@@ -13,8 +15,10 @@ import { cn } from "@/lib/utils";
 
 import {
   SIDEBAR_AVATAR_INSET,
+  SIDEBAR_GLYPH,
   SIDEBAR_ICON_BASE,
   SIDEBAR_ICON_IDLE,
+  SIDEBAR_ICON_PRESSED,
 } from "./sidebar-icon-styles";
 import {
   SidebarLabelsInlineContext,
@@ -172,20 +176,67 @@ function ShortcutsHeading({
   );
 }
 
+/**
+ * Back to the top of the project — the first entry in this group.
+ *
+ * IT BELONGS HERE rather than beside the surface toggles above, because it
+ * answers the same question the shortcuts do: not "where am I" but "where
+ * else", and it is the answer they all fall back to. First, because the root
+ * is what contains them — a list of a project's collections that does not
+ * start with the project reads as a list of unrelated places.
+ *
+ * A LINK, not the graph event the shortcuts use. They open a node inside the
+ * board that is already loaded; the root is a route in its own right — the URL
+ * a project starts at — and going there by link means the back button
+ * understands it.
+ */
+function ProjectHomeShortcut({ projectId }: Readonly<{ projectId: string }>) {
+  const pathname = usePathname();
+  const href = `/timeline/${projectId}/graph`;
+  // ALREADY HOME is worth showing: every other control in this rail marks
+  // where you are, and a home button that looks identical at the root and six
+  // collections deep is the one that makes you check the breadcrumb instead.
+  const isHome = pathname === href;
+  const tooltipId = "sidebar-tooltip-project-home";
+  return (
+    <Link
+      href={href}
+      data-sidebar-project-home={isHome ? "current" : ""}
+      aria-label="Project home"
+      aria-current={isHome ? "page" : undefined}
+      aria-describedby={tooltipId}
+      className={cn(SIDEBAR_ICON_BASE, isHome ? SIDEBAR_ICON_PRESSED : SIDEBAR_ICON_IDLE)}
+    >
+      <Home className={SIDEBAR_GLYPH} />
+      <SidebarTooltipLabel id={tooltipId} label="Home" description="The top of this project" />
+    </Link>
+  );
+}
+
 export function CollectionShortcutsGroup({
   shortcuts,
   onOpen,
+  projectId,
 }: Readonly<{
   shortcuts: readonly CollectionShortcut[];
   onOpen: (nodeId: string) => void;
+  /** Present on a graph route, which is the only place a root exists to go to.
+   *  Its absence is what makes the group disappear entirely on a new project. */
+  projectId?: string;
 }>) {
   // The same signal the labels use — "is the rail wide enough for words".
   const inline = useContext(SidebarLabelsInlineContext);
   const headingId = "sidebar-section-collections";
-  // NOTHING AT ALL when there are no top-level collections — not an empty group,
-  // and the caller draws no separator either. A new project has none, and a
-  // rule with nothing under it reads as something that failed to load.
-  if (shortcuts.length === 0) return null;
+  // NOTHING AT ALL when there is nothing to show — not an empty group, and the
+  // caller draws no separator either: a rule with nothing under it reads as
+  // something that failed to load.
+  //
+  // "Nothing" now means no collections AND no home, because Home is an entry
+  // in this group rather than a neighbour of it. A project with no top-level
+  // collections still has a root to go back to, so the group survives on that
+  // alone — which is right, and is why the old test for emptiness was the
+  // shortcut count by itself.
+  if (shortcuts.length === 0 && projectId === undefined) return null;
 
   return (
     <>
@@ -196,6 +247,7 @@ export function CollectionShortcutsGroup({
         data-sidebar-collection-shortcuts={shortcuts.length}
         className="flex w-full flex-col items-stretch gap-0"
       >
+        {projectId === undefined ? null : <ProjectHomeShortcut projectId={projectId} />}
         {shortcuts.map((shortcut) => {
           const tooltipId = `sidebar-tooltip-collection-${shortcut.nodeId}`;
           return (
@@ -293,6 +345,7 @@ export function SidebarCollectionShortcuts({
     <CollectionShortcutsGroup
       shortcuts={collectionShortcuts(documents[projectId])}
       onOpen={requestGraphOpenItem}
+      projectId={projectId}
     />
   );
 }

--- a/apps/timeline-gstudio001/components/timeline/sidebar-icon-styles.ts
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-icon-styles.ts
@@ -133,5 +133,35 @@ export const SIDEBAR_GLYPH =
  *  still for the same reason. */
 export const SIDEBAR_AVATAR_INSET = "[.rail_&]:ml-5";
 
+/**
+ * The active tile: an INDICATOR BAR at the rail's edge, over a quietly lifted
+ * pill.
+ *
+ * This is the nav treatment. The rail answers "where am I", and a bar riding
+ * the edge reads as a POSITION in a list — the same signal a browser tab or an
+ * IDE gutter uses — where a filled tile only reads as a button someone pressed.
+ *
+ * It replaces a full inversion (near-white pill, near-black glyph). That was
+ * legible, but it made the active tile the brightest object on the screen,
+ * competing with the board it was only labelling; with several toggles lit at
+ * once the rail became the loudest thing in the app. The bar is louder in the
+ * only way that matters — position — while the tile itself stays quiet.
+ *
+ * The bar is anchored to the TILE edge, not the pill: it belongs to the rail's
+ * left boundary, so it stays put while the pill floats inset from it.
+ *
+ * No `translate-y-px`: a pressed tile nudging down by a pixel opened a hairline
+ * seam above it and read as misalignment rather than as a press.
+ *
+ * `h-9` (36px) against the 56px pill: long enough to read as a bar rather than
+ * a tick, short enough that it still marks a position instead of drawing a
+ * second edge down the rail.
+ */
+export const SIDEBAR_ICON_PRESSED = [
+  "text-zinc-50 before:bg-zinc-800",
+  "after:absolute after:left-0 after:top-1/2 after:h-9 after:w-[3px]",
+  "after:-translate-y-1/2 after:rounded-r-full after:bg-sky-300 after:content-['']",
+].join(" ");
+
 export const SIDEBAR_ICON_IDLE =
   "text-zinc-400 before:bg-zinc-900/40 hover:text-zinc-100 hover:before:bg-zinc-800/80";

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -44,6 +44,7 @@ import {
   SIDEBAR_GLYPH,
   SIDEBAR_ICON_BASE,
   SIDEBAR_ICON_IDLE,
+  SIDEBAR_ICON_PRESSED,
 } from "./sidebar-icon-styles";
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 import { toast } from "@/components/core/sonner";
@@ -621,35 +622,6 @@ function MediaFolderIcon({ className }: Readonly<{ className?: string }>) {
 // SIDEBAR_ICON_BASE / SIDEBAR_GLYPH / SIDEBAR_ICON_IDLE now live in
 // ./sidebar-icon-styles, so the graph's portalled board-options trigger can
 // wear the rail's treatment without importing this module (PL14-005).
-/**
- * The active tile: an INDICATOR BAR at the rail's edge, over a quietly lifted
- * pill.
- *
- * This is the nav treatment. The rail answers "where am I", and a bar riding
- * the edge reads as a POSITION in a list — the same signal a browser tab or an
- * IDE gutter uses — where a filled tile only reads as a button someone pressed.
- *
- * It replaces a full inversion (near-white pill, near-black glyph). That was
- * legible, but it made the active tile the brightest object on the screen,
- * competing with the board it was only labelling; with several toggles lit at
- * once the rail became the loudest thing in the app. The bar is louder in the
- * only way that matters — position — while the tile itself stays quiet.
- *
- * The bar is anchored to the TILE edge, not the pill: it belongs to the rail's
- * left boundary, so it stays put while the pill floats inset from it.
- *
- * No `translate-y-px`: a pressed tile nudging down by a pixel opened a hairline
- * seam above it and read as misalignment rather than as a press.
- *
- * `h-9` (36px) against the 56px pill: long enough to read as a bar rather than
- * a tick, short enough that it still marks a position instead of drawing a
- * second edge down the rail.
- */
-const SIDEBAR_ICON_PRESSED = [
-  "text-zinc-50 before:bg-zinc-800",
-  "after:absolute after:left-0 after:top-1/2 after:h-9 after:w-[3px]",
-  "after:-translate-y-1/2 after:rounded-r-full after:bg-sky-300 after:content-['']",
-].join(" ");
 
 /**
  * The active state for a rail tile that is a TOGGLE rather than a place.
@@ -1138,6 +1110,7 @@ export function TimelineSidebar() {
         {activeProjectId && onGraphRoute && (
           <SidebarCollectionShortcuts projectId={activeProjectId} />
         )}
+
 
         <div className="relative mt-auto flex w-full flex-col items-stretch gap-0">
           {UTILITY_ITEMS.map((item) => {

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -3156,6 +3156,82 @@ test.describe("graph view E2E", () => {
     }).toPass({ timeout: 15000 });
   });
 
+  test("a grid card's play starts THAT card, and its cue only seeks", async ({ page }) => {
+    // The bug this exists for: play wrote the seek and the play flag in one
+    // React batch, and the pane — a controlled player — ignores an incoming
+    // time while it is playing. The seek was dropped, so pressing any card
+    // played from wherever the pane already was; and because the pause state
+    // is derived from "is the playhead inside this clip", the button never
+    // flipped either. One dropped write, two broken controls, and no suite
+    // noticed.
+    await installGraphApi(page);
+    await page.goto(`${GRAPH_URL}?surface=grid`);
+    await expect(page.locator(`[data-virtual-grid="${PROJECT_ID}"]`)).toHaveCount(1);
+    await previewToggle(page).click();
+    // The buttons wait for the pane to stop moving, like the rails do.
+    await page.locator("[data-preview-settled]").waitFor({ state: "attached" });
+
+    // Seconds off the transport's readout. It renders the value twice (a
+    // visible span and a screen-reader one), so the FIRST match is the clock.
+    const clock = async () => {
+      const text = (await page.getByTestId("workbench-preview-time").textContent()) ?? "";
+      const match = text.match(/([\d.]+)\s*s/);
+      return match === null ? Number.NaN : Number(match[1]);
+    };
+
+    // BRAVO, not the first card: a clip whose start is not zero is the only
+    // one that can tell "went to this clip" apart from "did nothing".
+    const cue = page.locator('[data-grid-cue="bravo"]');
+    const play = page.locator('[data-grid-play="bravo"]');
+    await expect(cue).toBeVisible();
+    await expect(play).toBeVisible();
+
+    // CUE: lands on bravo's start and STAYS there.
+    await cue.click();
+    await expect.poll(clock).toBeGreaterThan(0);
+    const start = await clock();
+    await page.waitForTimeout(600);
+    expect(await clock()).toBe(start);
+    // And having arrived, the cue has nothing left to do — disabled rather
+    // than hidden, so it does not take its own explanation away with it or
+    // shift the button beside it.
+    await expect(cue).toBeDisabled();
+
+    // MOVE THE PLAYHEAD AWAY FIRST, and this is the step that gives the test
+    // its teeth. Written the obvious way — cue bravo, then play bravo — the
+    // clock is ALREADY at bravo's start when play is pressed, so a play that
+    // drops its seek entirely still plays from the right place and the test
+    // passes against the very bug it exists for. Confirmed: it did.
+    await page.locator('[data-grid-cue="alpha"]').click();
+    await expect.poll(clock).toBeLessThan(start);
+    // Moved away, so bravo's cue is live again.
+    await expect(cue).toBeEnabled();
+
+    // PLAY: jumps back to bravo's own start — the two controls have to agree
+    // about where a clip begins — and then actually advances.
+    await play.click();
+    await expect.poll(clock).toBeGreaterThanOrEqual(start);
+    // Near it, not somewhere else entirely: a dropped seek leaves the clock
+    // back at alpha's start, and a generous window still catches that while
+    // tolerating the frames spent getting here.
+    expect(await clock()).toBeLessThan(start + 2);
+
+    // While it plays this card offers PAUSE and no cue — the playhead is
+    // already inside it, so "go to its start" would be a rewind nobody asked
+    // for.
+    // THIS card's button, not any button reading "Pause" — the transport has
+    // one too, and matching by role alone finds both.
+    await expect(play).toHaveAttribute("aria-label", /^Pause /);
+    await expect(cue).toHaveCount(0);
+
+    // Pressing again holds where it is rather than rewinding.
+    await play.click();
+    const held = await clock();
+    await page.waitForTimeout(500);
+    expect(await clock()).toBe(held);
+    await expect(cue).toBeVisible();
+  });
+
   test("a trashed item restores into the timeline you are looking at", async ({ page }) => {
     const api = await installGraphApi(page);
     await openGraph(page);

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -3207,8 +3207,24 @@ test.describe("graph view E2E", () => {
     // Moved away, so bravo's cue is live again.
     await expect(cue).toBeEnabled();
 
+    // AND ITS ARROW SAYS WHICH WAY THE JUMP GOES. The playhead is at alpha
+    // now, so bravo is ahead of it and the glyph faces forward; alpha's own
+    // cue is the one that would fetch the playhead back, and it is turned
+    // around. Same icon, rotated — which is the whole signal, so it is worth
+    // asserting rather than trusting.
+    const glyph = (locator: Locator) => locator.locator("svg");
+    await expect(glyph(cue)).not.toHaveClass(/rotate-180/);
+
+    await play.click();
+    await expect.poll(clock).toBeGreaterThanOrEqual(start);
+    await play.click();
+    // Parked inside bravo, so alpha is behind the playhead and its arrow has
+    // turned.
+    await expect(glyph(page.locator('[data-grid-cue="alpha"]'))).toHaveClass(/rotate-180/);
+
     // PLAY: jumps back to bravo's own start — the two controls have to agree
     // about where a clip begins — and then actually advances.
+    await page.locator('[data-grid-cue="alpha"]').click();
     await play.click();
     await expect.poll(clock).toBeGreaterThanOrEqual(start);
     // Near it, not somewhere else entirely: a dropped seek leaves the clock

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -3222,6 +3222,18 @@ test.describe("graph view E2E", () => {
     // turned.
     await expect(glyph(page.locator('[data-grid-cue="alpha"]'))).toHaveClass(/rotate-180/);
 
+    // SELECT MODE TAKES THEM AWAY. Picking things and playing things are
+    // different jobs, and a card being picked should not carry two controls
+    // that do something else. Hidden outright, so they leave the tab order
+    // rather than lurking behind an opacity.
+    await page.locator("[data-select-mode-toggle]").click();
+    await expect(play).toBeHidden();
+    await expect(page.locator('[data-grid-cue="alpha"]')).toBeHidden();
+
+    // And they come back when it is switched off.
+    await page.locator("[data-select-mode-toggle]").click();
+    await expect(play).toBeVisible();
+
     // PLAY: jumps back to bravo's own start — the two controls have to agree
     // about where a clip begins — and then actually advances.
     await page.locator('[data-grid-cue="alpha"]').click();

--- a/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualGrid.tsx
@@ -100,6 +100,20 @@ export type VirtualGridProps = Readonly<{
    * a tab stop; it only lengthens the row spacer when it starts a new row.
    */
   trailingSlot?: ReactNode;
+  /**
+   * Rendered inside each cell, as a SIBLING of the item.
+   *
+   * A card's shell is a `<button>`, so anything interactive a consumer wants
+   * on a card cannot live in its content — nested interactive content is
+   * invalid, and this package already refuses it. The cell is the nearest
+   * place that is both valid and card-shaped: it knows exactly where one card
+   * is, without anyone measuring anything.
+   *
+   * The cell is `position: relative` for this, which is safe because the drop
+   * indicator positions against the ITEM rather than the cell (it hangs on a
+   * negative offset outside its own relative ancestor inside `node-views`).
+   */
+  cellOverlay?: (id: NodeId) => ReactNode;
   className?: string;
 }>;
 
@@ -123,6 +137,7 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
       itemDragActivation = "body",
       overlay,
       trailingSlot,
+      cellOverlay,
       className,
     },
     ref
@@ -473,6 +488,7 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
                       onFocus={() => onItemFocus(id)}
                       style={
                         {
+                          position: "relative",
                           width: fillCellWidth,
                           height: cellHeight,
                           // A row-EDGE boundary is the grid's own edge, not the
@@ -499,6 +515,7 @@ export const VirtualGrid = forwardRef<VirtualGridHandle, VirtualGridProps>(
                         itemContent={itemContent}
                         dragActivation={itemDragActivation}
                       />
+                      {cellOverlay?.(id)}
                     </div>
                   );
                 })}


### PR DESCRIPTION
Eight commits that were left behind when #486's auto-merge fired on the rail
commit alone.

**Transport on the cards.** Every grid card gets a play button at the bottom
left of its thumbnail, playing THAT card into the preview pane rather than
whatever the clock happened to be on — seek and play in one React batch does
not work, because the controlled player ignores an incoming time while it is
playing, so the play is deferred a frame. Beside it a cue button seeks to the
card's start without playing, disabled once the playhead is already there. Its
arrow rotates to face the way the playhead will actually travel, with a visible
transition, so the direction is readable before the click. Both disappear in
select mode, where the card means something else.

**A way home.** A Home entry at the head of the collection shortcuts, going to
the project root. No active state — the shortcuts around it do not have one.

**A rail you can see.** Taking the track away left nothing to say the strip
above a card does anything. One pixel of hairline restores that, against a hit
area eight times its height.

**Right-click no longer drags the board 15px left.** The permanent scrollbar
gutter and Radix's scroll-lock compensation were each holding the same space,
and the lock was taking the gutter away at the same moment it compensated for
it. Cancelled the gap, kept the lock.

Measured: board shift on right-click 15px -> 0. 1350 unit tests, lint clean,
and the play/cue, rail and context-menu e2e all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)