### PR TITLE
The picture keeps up with the playhead again

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-preview.tsx
@@ -98,6 +98,7 @@ import {
 } from "@storyboard/ui/timeline/timeline-document-store";
 import { createTimelineDocumentsState } from "@storyboard/ui/timeline/timeline-documents";
 import { formatSeconds } from "@storyboard/ui/timeline/utils";
+import { cloudinaryScrubProxySrc } from "@/lib/cloudinary-scrub-proxy";
 import type { TimelineClip, TimelineDocument } from "@storyboard/ui/timeline/types";
 
 import {
@@ -1238,6 +1239,11 @@ export function PreviewShell({
           enabled ? (
             <WorkbenchDisplaySurface
               clips={clips}
+              // A small twin of each clip, seeked alongside the real element so
+              // the picture keeps up with a dragging playhead. The surface has
+              // no idea what Cloudinary is; it only knows some sources have a
+              // faster one behind them.
+              getScrubProxySrc={cloudinaryScrubProxySrc}
               // So a layered clip's inset lands where the RENDER will put it.
               // Its rectangle is normalized to the output frame, which is a
               // different box from the picture whenever the source's shape

--- a/apps/timeline-gstudio001/lib/cloudinary-scrub-proxy.test.ts
+++ b/apps/timeline-gstudio001/lib/cloudinary-scrub-proxy.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { cloudinaryScrubProxySrc } from "./cloudinary-scrub-proxy";
+
+const VIDEO = "https://res.cloudinary.com/drrxyckxi/video/upload/project/S01_briefing.mp4";
+
+describe("cloudinaryScrubProxySrc", () => {
+  it("inserts the transform right after the delivery prefix", () => {
+    expect(cloudinaryScrubProxySrc(VIDEO)).toBe(
+      "https://res.cloudinary.com/drrxyckxi/video/upload/w_480,q_auto:low/project/S01_briefing.mp4",
+    );
+  });
+
+  it("puts the transform BEFORE a version segment", () => {
+    // Cloudinary rejects `upload/v123/w_480/...` — transforms precede the
+    // version, and getting this backwards yields a 400 for every scrub.
+    expect(
+      cloudinaryScrubProxySrc(
+        "https://res.cloudinary.com/c/video/upload/v1786244111/project/clip.mp4",
+      ),
+    ).toBe("https://res.cloudinary.com/c/video/upload/w_480,q_auto:low/v1786244111/project/clip.mp4");
+  });
+
+  it("is IDEMPOTENT, so a proxy is never wrapped in a second one", () => {
+    const once = cloudinaryScrubProxySrc(VIDEO)!;
+    expect(cloudinaryScrubProxySrc(once)).toBe(once);
+  });
+
+  it("returns null for anything that is not a Cloudinary VIDEO source", () => {
+    // Null is the ordinary answer, and the caller reads it as "scrub the real
+    // thing" — which is exactly the behaviour that shipped before proxies
+    // existed. A source this cannot transform is never made worse.
+    expect(cloudinaryScrubProxySrc("https://res.cloudinary.com/c/image/upload/a.png")).toBeNull();
+    expect(cloudinaryScrubProxySrc("blob:http://localhost:3000/abc-123")).toBeNull();
+    expect(cloudinaryScrubProxySrc("/fixtures/sample.mp4")).toBeNull();
+    expect(cloudinaryScrubProxySrc("")).toBeNull();
+  });
+
+  it("keeps the cloud name it was given rather than assuming one", () => {
+    expect(cloudinaryScrubProxySrc("https://res.cloudinary.com/other-cloud/video/upload/x.mp4"))
+      .toContain("/other-cloud/video/upload/w_480,q_auto:low/");
+  });
+});

--- a/apps/timeline-gstudio001/lib/cloudinary-scrub-proxy.ts
+++ b/apps/timeline-gstudio001/lib/cloudinary-scrub-proxy.ts
@@ -1,0 +1,48 @@
+/**
+ * A small, fast-seeking stand-in for a full-res clip, used only while the
+ * playhead is MOVING.
+ *
+ * Seeking an <video> is asynchronous and keyframe-bound: landing mid-GOP means
+ * decoding forward from the preceding keyframe, and the cost scales with frame
+ * size. Measured on this project's own asset (832x480, 10s, Cloudinary):
+ *
+ *   full-res original      p50  67-128ms
+ *   w_480,q_auto:low       p50  14-20ms
+ *
+ * That is the difference between roughly eight frame updates a second under a
+ * drag and fifty — between a scrubber that sticks and one that tracks the hand.
+ *
+ * DERIVED, NOT STORED. The proxy is a delivery transform, so it costs nothing
+ * to mint and nothing to keep in sync: the same asset, asked for smaller.
+ * Cloudinary builds it on first request and caches it thereafter.
+ *
+ * RESOLUTION IS THE LEVER, not keyframe interval. Forcing an all-intra proxy
+ * (`ki_0.04`) was measured too: it reaches the same floor while costing 2.8-3.3x
+ * the bytes, because at these frame sizes decoding forward through a GOP is
+ * already cheap. Small beats seekable here.
+ */
+const SCRUB_PROXY_TRANSFORM = "w_480,q_auto:low";
+
+/** Cloudinary VIDEO delivery URLs only — the one shape this transform is valid for. */
+const CLOUDINARY_VIDEO_UPLOAD = /^(https?:\/\/res\.cloudinary\.com\/[^/]+\/video\/upload\/)(.+)$/i;
+
+/**
+ * The proxy URL for a full-res source, or null when there isn't one.
+ *
+ * Null is the normal answer for anything not served as a Cloudinary video —
+ * a blob: URL from an in-progress upload, a fixture asset in Storybook, an
+ * image clip. Callers treat null as "scrub the real thing", which is exactly
+ * today's behaviour, so a source this cannot transform is never made worse.
+ */
+export function cloudinaryScrubProxySrc(src: string): string | null {
+  const match = CLOUDINARY_VIDEO_UPLOAD.exec(src);
+  if (!match) return null;
+  const delivery = match[1]!;
+  const rest = match[2]!;
+  // ALREADY A PROXY. Re-wrapping would chain the transform onto itself, and a
+  // second `w_480` on an already-480 derivative is a pointless round trip.
+  if (rest.startsWith(`${SCRUB_PROXY_TRANSFORM}/`)) return src;
+  // BEFORE any version segment (`v1786…`): Cloudinary requires transforms to
+  // precede the version, and rejects the other order.
+  return `${delivery}${SCRUB_PROXY_TRANSFORM}/${rest}`;
+}

--- a/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
+++ b/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
@@ -1028,3 +1028,114 @@ export const TheChromeFadesInOnceThePreviewIsOpen: Story = {
     });
   },
 };
+
+/**
+ * A STILL HAS NOTHING TO SEEK, so it must never ask for a scrub proxy.
+ *
+ * The proxy exists because seeking a video element is slow enough to lose a
+ * drag; an image has no seek at all, and minting a second element for one
+ * would be a download and a decoder for a picture already on screen.
+ *
+ * WHAT THIS CAN AND CANNOT COVER. It guards the gate — that the surface only
+ * reaches for a proxy on the video path — and it would fail the moment that
+ * call moved somewhere every clip kind flows through. It deliberately does NOT
+ * claim the proxy paints correctly: stories have only data-URI images, nothing
+ * here decodes real video, and a story asserting the coarse-then-fine handoff
+ * would pass without ever exercising it. That behaviour was verified by
+ * measuring the real app instead (frame updates under a drag went from none to
+ * one per animation frame, still resting on full resolution).
+ */
+function ScrubProxyGateFixture() {
+  const [currentTime, setCurrentTime] = useState(0);
+  const [asked, setAsked] = useState<string[]>([]);
+
+  return (
+    <main className="bg-zinc-950 p-4 text-zinc-100">
+      <button type="button" data-testid="jump" onClick={() => setCurrentTime(7)}>
+        Jump
+      </button>
+      <output data-testid="proxy-asks">{asked.length}</output>
+      <WorkbenchDisplaySurface
+        clips={[laneClip("still-a", 0, 5, 0), laneClip("still-b", 5, 5, 0)]}
+        currentTime={currentTime}
+        onCurrentTimeChange={setCurrentTime}
+        getScrubProxySrc={(src) => {
+          setAsked((previous) => [...previous, src]);
+          return null;
+        }}
+        className="h-[320px]"
+      />
+    </main>
+  );
+}
+
+export const StillsNeverAskForAScrubProxy: Story = {
+  render: () => <ScrubProxyGateFixture />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByTestId("jump"));
+    await waitFor(async () => {
+      await expect(canvas.getByTestId("proxy-asks")).toHaveTextContent("0");
+    });
+  },
+};
+
+/**
+ * HOVERING THE PICTURE SAYS WHAT CLICKING IT WILL DO.
+ *
+ * The frame has been a play/pause target for a long time with nothing to say
+ * so. The hint is deliberately near-invisible — it sits on top of the shot
+ * being judged — so what is asserted here is the STATE, not the styling:
+ * that it is hidden at rest, that hovering reveals it, and that the glyph
+ * agrees with the transport rather than tracking anything of its own.
+ */
+function HoverTransportHintFixture() {
+  const [currentTime, setCurrentTime] = useState(0);
+
+  return (
+    <main className="bg-zinc-950 p-4 text-zinc-100">
+      <WorkbenchDisplaySurface
+        clips={[laneClip("a", 0, 5, 0), laneClip("b", 5, 5, 0)]}
+        currentTime={currentTime}
+        onCurrentTimeChange={setCurrentTime}
+        className="h-[320px]"
+      />
+    </main>
+  );
+}
+
+export const HoveringThePictureHintsAtPlay: Story = {
+  render: () => <HoverTransportHintFixture />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const hint = canvas.getByTestId("workbench-hover-transport-hint");
+
+    // Hidden until asked for, and never a click target — the canvas beneath
+    // has to keep receiving the press this is advertising.
+    await expect(hint).toHaveAttribute("data-hint", "play");
+    await expect(getComputedStyle(hint).pointerEvents).toBe("none");
+    await expect(getComputedStyle(hint).opacity).toBe("0");
+
+    // HOVER IS RETRIED, because the hint answers for the drawn PICTURE rather
+    // than the element: the surface only counts a pointer as over the picture
+    // once it has drawn one and knows where it landed. A single hover fired
+    // before the first paint lands on a letterbox that is still the whole box.
+    const surface = canvas.getByTestId("workbench-display-canvas");
+    await waitFor(async () => {
+      const box = surface.getBoundingClientRect();
+      const at = {
+        bubbles: true,
+        clientX: box.x + box.width / 2,
+        clientY: box.y + box.height / 2,
+        pointerId: 1,
+        pointerType: "mouse",
+        isPrimary: true,
+      };
+      surface.dispatchEvent(new PointerEvent("pointerover", at));
+      surface.dispatchEvent(new PointerEvent("pointermove", at));
+      await expect(Number(getComputedStyle(hint).opacity)).toBeGreaterThan(0);
+    });
+    // Still the paused glyph: hovering advertises the action, it does not take it.
+    await expect(hint).toHaveAttribute("data-hint", "play");
+  },
+};

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -104,6 +104,22 @@ type WorkbenchDisplaySurfaceProps = {
   onCurrentTimeChange: (time: number) => void;
   className?: string;
   preferredClipId?: string | null;
+  /**
+   * A SMALL STAND-IN for a full-res source, seeked alongside it while the
+   * playhead is moving. Return null (or omit the prop entirely) and the
+   * surface scrubs the real element exactly as it always has.
+   *
+   * Seeking a video element is asynchronous and keyframe-bound, and the cost
+   * scales with frame size: measured on this project's own assets, a full-res
+   * clip lands a seek in ~67-128ms while a 480-wide derivative lands in
+   * ~14-20ms. Under a drag that is the difference between roughly eight frame
+   * updates a second and fifty.
+   *
+   * INJECTED, because building one is a delivery-CDN concern and this package
+   * does not know about any CDN. The app maps a source URL to its proxy; the
+   * surface only knows that some sources have a faster twin.
+   */
+  getScrubProxySrc?: (src: string) => string | null;
   /** Controlled playback. When supplied, the surface plays iff this is true and
    *  reports intent through `onPlayingChange` (the play button and the
    *  end-of-timeline auto-stop call it) instead of holding play state itself.
@@ -704,6 +720,7 @@ export function WorkbenchDisplaySurface({
   onCurrentTimeChange,
   className,
   preferredClipId,
+  getScrubProxySrc,
   playing,
   onPlayingChange,
   volume,
@@ -718,6 +735,32 @@ export function WorkbenchDisplaySurface({
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const playbackSurfaceRectRef = useRef<PlaybackSurfaceRect | null>(null);
   const cacheRef = useRef(new Map<string, CachedMedia>());
+  // The proxies, keyed the same way as the real elements so the two are always
+  // asked about together. Separate from `cacheRef` on purpose: these are never
+  // played, never mixed, and never the thing a consumer is watching — they
+  // exist only to have a frame ready sooner than the real element can.
+  const scrubProxyRef = useRef(new Map<string, HTMLVideoElement>());
+  const getScrubProxySrcRef = useRef(getScrubProxySrc);
+  getScrubProxySrcRef.current = getScrubProxySrc;
+  // Read by the proxies' `seeked` listeners, which outlive any one render.
+  const drawActiveFrameRef = useRef<(() => void) | null>(null);
+  /**
+   * Which pictures have a seek IN FLIGHT — the one question the elements
+   * cannot be asked directly.
+   *
+   * The obvious test, "is this element already showing the target frame",
+   * cannot be built from the media API. Assigning `currentTime` makes it read
+   * back as the TARGET at once, while the frame on screen is still the old
+   * one, and `seeking` does not reliably flip in the same turn — so an element
+   * that has merely been ASKED for a frame is indistinguishable from one that
+   * HAS it. Measured consequence: the real element claimed to be ready every
+   * time, the proxy was never preferred, and the whole mechanism sat inert
+   * while looking wired up correctly.
+   *
+   * Recording the seek where it is ISSUED, and clearing it where it LANDS,
+   * answers it exactly.
+   */
+  const pictureSeekInFlightRef = useRef(new Map<string, boolean>());
   const activeMediaRef = useRef<DisplayMedia | null>(null);
   const activeClipDisabledRef = useRef(false);
   // The under-layers audible right now. The picture is `activeMediaRef`; these
@@ -903,6 +946,45 @@ export function WorkbenchDisplaySurface({
     cacheRef.current.set(media.key, nextCached);
     return nextCached;
   }, [getMixer]);
+
+  /**
+   * The proxy for one video clip, built on first use, or null when there is
+   * none to build.
+   *
+   * Null is the ordinary answer and costs nothing: a consumer that passes no
+   * `getScrubProxySrc`, a source the app cannot transform (a blob: upload, a
+   * fixture asset), or a proxy URL identical to the original all land here and
+   * leave the existing single-element behaviour untouched.
+   *
+   * NOT ATTACHED TO THE MIXER, unlike every element in `cacheRef`. This one
+   * never plays and must never be audible; attaching it would put a second,
+   * half-second-offset copy of the same dialogue into the graph.
+   */
+  const ensureScrubProxy = useCallback((media: DisplayMedia): HTMLVideoElement | null => {
+    if (media.kind !== "video") return null;
+    const existing = scrubProxyRef.current.get(media.key);
+    if (existing) return existing;
+
+    const proxySrc = getScrubProxySrcRef.current?.(media.src) ?? null;
+    if (proxySrc === null || proxySrc === media.src) return null;
+
+    const proxy = document.createElement("video");
+    proxy.preload = "auto";
+    proxy.playsInline = true;
+    // Belt and braces against ever being heard, on top of not being mixed.
+    proxy.muted = true;
+    if (/^https?:\/\//i.test(proxySrc)) proxy.crossOrigin = "anonymous";
+    proxy.src = proxySrc;
+    proxy.load();
+    // A PERSISTENT listener rather than one per seek. The proxy is seeked
+    // continuously under a drag, and per-seek listeners would mean adding and
+    // removing one fifty times a second; `drawActiveFrame` is already the
+    // thing that decides whether the proxy is what should be on screen, so it
+    // is safe to simply ask it every time one lands.
+    proxy.addEventListener("seeked", () => drawActiveFrameRef.current?.());
+    scrubProxyRef.current.set(media.key, proxy);
+    return proxy;
+  }, []);
 
   const drawDrawable = useCallback((drawable: HTMLImageElement | HTMLVideoElement) => {
     const canvas = canvasRef.current;
@@ -1112,10 +1194,34 @@ export function WorkbenchDisplaySurface({
       return;
     }
 
+    // COARSE, THEN FINE. While the real element's seek is in flight its
+    // picture is stale by however long the decode takes, and under a drag that
+    // is most of the time — so the proxy, which lands far sooner, is simply
+    // what there is to show. A soft frame on time reads as a scrubber that
+    // tracks the hand; a sharp frame three frames late reads as one that
+    // sticks. When the drag stops, the real seek completes, clears the flag
+    // and repaints over it, so what anyone comes to REST on is full
+    // resolution.
+    //
+    // NOT WHILE PLAYING: a playing element runs its own clock and never seeks,
+    // so a flag left over from the last scrub must not put the small copy on
+    // screen for the whole take.
+    const proxy = scrubProxyRef.current.get(media.key);
+    if (
+      proxy !== undefined &&
+      !isPlayingRef.current &&
+      pictureSeekInFlightRef.current.get(media.key) === true &&
+      proxy.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA
+    ) {
+      drawDrawable(proxy);
+      return;
+    }
+
     if (cached.element.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
       drawDrawable(cached.element);
     }
   }, [drawAudioFrame, drawDrawable, drawEmptyFrame]);
+  drawActiveFrameRef.current = drawActiveFrame;
 
   const frameOverrideRef = useRef(frameOverride);
 
@@ -1211,6 +1317,7 @@ export function WorkbenchDisplaySurface({
 
         if (draws) {
           const drawAfterSeek = () => {
+            pictureSeekInFlightRef.current.set(media.key, false);
             pending.get(media.key)?.();
             pending.delete(media.key);
             drawActiveFrame();
@@ -1223,6 +1330,26 @@ export function WorkbenchDisplaySurface({
             video.removeEventListener("loadeddata", drawAfterSeek);
           });
         }
+        // The proxy chases the same target — but only for the PICTURE, and
+        // only while it is not playing. A playing element runs its own clock
+        // and never seeks, so a second decode alongside it would be waste; an
+        // under-layer never repaints the canvas, so a proxy for one would
+        // decode frames nobody looks at.
+        if (draws && !shouldPlay) {
+          const proxy = ensureScrubProxy(media);
+          if (
+            proxy !== null &&
+            proxy.readyState >= HTMLMediaElement.HAVE_METADATA &&
+            !proxy.seeking
+          ) {
+            try {
+              proxy.currentTime = targetTime;
+            } catch {
+              // Metadata raced away; the next seek retries.
+            }
+          }
+        }
+        if (draws) pictureSeekInFlightRef.current.set(media.key, true);
         video.currentTime = targetTime;
       }
       if (shouldPlay && video.paused) {
@@ -1247,7 +1374,7 @@ export function WorkbenchDisplaySurface({
 
     video.addEventListener("loadedmetadata", seek, { once: true });
     if (draws) video.addEventListener("loadeddata", drawActiveFrame, { once: true });
-  }, [applyGain, drawActiveFrame, ensureCachedMedia]);
+  }, [applyGain, drawActiveFrame, ensureCachedMedia, ensureScrubProxy]);
 
   const renderFrameAtTime = useCallback((timelineTime: number, shouldPlay: boolean, forceSeek = false) => {
     // An override owns the picture while it is set. Guarding HERE rather than
@@ -1738,6 +1865,40 @@ export function WorkbenchDisplaySurface({
             if (isPointerOverPlaybackSurface(event)) setPlaying(!isPlaying);
           }}
         />
+        {/*
+          A QUIET SIGN OF WHAT THE CLICK WILL DO.
+          The whole picture has been a play/pause target for a while, and
+          nothing said so — the cursor changed and that was all. This says it in
+          the one place the eye is already resting.
+
+          IT MIRRORS THE REAL CONTROL rather than holding an opinion of its own:
+          the glyph is whatever the transport's button is showing, so the two
+          can never disagree about what is happening.
+
+          FAINT ON PURPOSE. It sits on top of the frame being judged, and a
+          confident white triangle over someone's shot is a thing in the shot.
+          One opacity knob drives the whole overlay, so "less noticeable" is a
+          single number rather than a negotiation between fill and stroke.
+
+          POINTER-TRANSPARENT, so it can never eat the click it is advertising —
+          the canvas underneath stays the target, letterbox rules included.
+        */}
+        <div
+          aria-hidden="true"
+          data-testid="workbench-hover-transport-hint"
+          data-hint={isPlaying ? "pause" : "play"}
+          className={cn(
+            "pointer-events-none absolute inset-0 grid place-items-center",
+            "transition-opacity duration-200 ease-out motion-reduce:transition-none",
+            canPlay && previewHovered ? "opacity-[0.10]" : "opacity-0",
+          )}
+        >
+          {isPlaying ? (
+            <Pause className="h-20 w-20 fill-white text-white sm:h-28 sm:w-28" />
+          ) : (
+            <Play className="h-20 w-20 fill-white text-white sm:h-28 sm:w-28" />
+          )}
+        </div>
         <WorkbenchAudioControls
           volume={activeVolume}
           muted={activeMuted}


### PR DESCRIPTION
Scrubbing the preview over video clips was losing the drag: a full-res seek
costs 67-128ms on this project's own assets, a drag issues a new target every
animation frame, and the first pass over a clip drew nothing at all because it
ended before any seek landed.

**What changed.** Each video clip gets a small twin (`w_480,q_auto:low` — a
Cloudinary delivery transform, so it costs nothing to mint and cannot drift).
Both elements chase the same target; the canvas draws the proxy while the real
seek is in flight and repaints full-res when it lands. Moving tracks the hand,
resting is always full resolution.

Resolution was the lever, not keyframes — all-intra proxies were measured and
reach the same floor for 2.8-3.3x the bytes.

**The subtle part.** "Is this element showing this frame?" cannot be answered
through the media API: assigning `currentTime` makes it read back as the target
immediately while the old frame is still on screen, and `seeking` does not
reliably flip in the same turn. Built that way the proxy was never preferred and
the mechanism sat inert while looking wired. Recording the seek where it is
issued and clearing it where it lands answers it exactly.

**Also:** hovering the picture now hints at play/pause — mirrors the transport's
glyph, 10% opacity, pointer-transparent.

Measured, same fast drag across the video-heavy region:

| | before | after |
|---|---|---|
| frame updates, first pass | 0 | 15 |
| frame updates, warm | 12-18 | 24-35 |
| median gap | — | 16ms (one per frame) |
| resting frame | full-res | full-res |

**Coverage.** Unit tests for the URL transform; two stories for what stories can
reach here (stills never build a proxy; the hover hint's states) — both confirmed
to fail without their fix. The coarse-then-fine handoff is measured in the real
app, since no story has real video to decode.

Green locally: app + UI tsc, 786 unit, 1355 app tests, 22 stories in the surface
file, lint clean, 21 preview/rail/play e2e passed.

**Known follow-ups, not in this PR:** the proxy is built lazily on first seek, so
the first pass over a clip still gets nothing (pre-building it with the existing
prefetch window would fix that); and the media cache still never evicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)