### PR TITLE
The preview gives media back instead of hoarding it

### DIFF
--- a/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
+++ b/packages/ui/timeline/viewport/WorkbenchSplitPane.stories.tsx
@@ -1139,3 +1139,59 @@ export const HoveringThePictureHintsAtPlay: Story = {
     await expect(hint).toHaveAttribute("data-hint", "play");
   },
 };
+
+/**
+ * THE MEDIA CACHE IS CAPPED, however far the playhead travels.
+ *
+ * Every clip the playhead touched used to be held for the surface's whole
+ * life — element, decoder, buffered file and a branch of the audio graph — so
+ * the cost of a session was the number of DISTINCT clips visited, not the
+ * number on screen. On a short timeline that is invisible; on a real cut it is
+ * one media element per clip in the project.
+ *
+ * Thirty clips through a cache of twenty-four, so the prune has to run and be
+ * seen to run. `data-media-cache-size` exists because a ref's size cannot be
+ * observed from outside the component, and "did the cap hold" is precisely
+ * what needs asserting.
+ */
+function CappedCacheFixture() {
+  const [currentTime, setCurrentTime] = useState(0);
+  const clips = Array.from({ length: 30 }, (_, index) =>
+    laneClip(`clip-${index}`, index, 1, 0),
+  );
+
+  return (
+    <main className="bg-zinc-950 p-4 text-zinc-100">
+      <button type="button" data-testid="advance" onClick={() => setCurrentTime((t) => t + 1)}>
+        Advance
+      </button>
+      <WorkbenchDisplaySurface
+        clips={clips}
+        currentTime={currentTime}
+        onCurrentTimeChange={setCurrentTime}
+        className="h-[240px]"
+      />
+    </main>
+  );
+}
+
+export const TheMediaCacheStopsGrowing: Story = {
+  render: () => <CappedCacheFixture />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const surface = canvas.getByTestId("workbench-display-surface");
+    const advance = canvas.getByTestId("advance");
+    const size = () => Number(surface.getAttribute("data-media-cache-size") ?? "0");
+
+    for (let step = 0; step < 30; step += 1) {
+      await userEvent.click(advance);
+    }
+
+    await waitFor(async () => {
+      // It really did cache along the way — a cap that holds because nothing
+      // was ever cached would pass while proving nothing.
+      await expect(size()).toBeGreaterThan(1);
+    });
+    await expect(size()).toBeLessThanOrEqual(24);
+  },
+};

--- a/packages/ui/timeline/viewport/audio-graph.test.ts
+++ b/packages/ui/timeline/viewport/audio-graph.test.ts
@@ -14,6 +14,7 @@ import { at } from "../../test-support/at";
  *  `createMediaElementSource` throws on a second call for one element. */
 function createFakeContext() {
   const gains: MinimalGainNode[] = [];
+  const disconnected: MinimalGainNode[] = [];
   const sourceCalls: HTMLMediaElement[] = [];
   let state = "suspended";
   let closed = false;
@@ -27,7 +28,9 @@ function createFakeContext() {
       const node: MinimalGainNode = {
         gain: { value: 1 },
         connect: () => undefined,
-        disconnect: () => undefined,
+        disconnect: () => {
+          disconnected.push(node);
+        },
       };
       gains.push(node);
       return node;
@@ -50,6 +53,7 @@ function createFakeContext() {
   return {
     context,
     gains,
+    disconnected,
     sourceCalls,
     isClosed: () => closed,
     getState: () => state,
@@ -214,5 +218,65 @@ describe("createAudioMixer", () => {
     mixer.dispose();
 
     expect(fake.isClosed()).toBe(true);
+  });
+});
+
+describe("release", () => {
+  it("DISCONNECTS the element's branch, which is what actually frees it", () => {
+    // The WeakMaps above never held the element strongly; the AUDIO GRAPH did.
+    // A source node stays connected until someone disconnects it, and keeps
+    // the element and its decoder alive for as long as it is — so dropping the
+    // caller's reference without this frees nothing and still looks correct.
+    const fake = createFakeContext();
+    const mixer = createAudioMixer(() => fake.context);
+    const element = fakeElement();
+
+    mixer.attach(element);
+    expect(fake.disconnected).toHaveLength(0);
+
+    mixer.release(element);
+    expect(fake.disconnected).toHaveLength(1);
+  });
+
+  it("stops steering a released element's level", () => {
+    const fake = createFakeContext();
+    const mixer = createAudioMixer(() => fake.context);
+    const element = fakeElement();
+    mixer.attach(element);
+    const gain = at(fake.gains, 0);
+
+    mixer.release(element);
+    gain.gain.value = 0.42;
+    mixer.setSourceGain(element, 1);
+
+    // Untouched: the mixer has forgotten this element rather than holding a
+    // gain node it can still write through.
+    expect(gain.gain.value).toBe(0.42);
+  });
+
+  it("drops a FALLBACK element — the module's one strong reference", () => {
+    // Elements on the fallback path live in a Set, not a WeakMap, so without
+    // this they are retained for the mixer's whole life.
+    const mixer = createAudioMixer(() => null);
+    const element = fakeElement();
+    mixer.attach(element);
+
+    mixer.setSourceGain(element, 1);
+    mixer.setMasterVolume(1);
+    const heldVolume = element.volume;
+    expect(heldVolume).toBeGreaterThan(0);
+
+    mixer.release(element);
+    element.volume = 0.33;
+    mixer.setMasterVolume(0.1);
+
+    // A still-tracked element would have been re-levelled by that master move.
+    expect(element.volume).toBe(0.33);
+  });
+
+  it("is safe on an element that was never attached", () => {
+    const fake = createFakeContext();
+    const mixer = createAudioMixer(() => fake.context);
+    expect(() => mixer.release(fakeElement())).not.toThrow();
   });
 });

--- a/packages/ui/timeline/viewport/audio-graph.ts
+++ b/packages/ui/timeline/viewport/audio-graph.ts
@@ -66,6 +66,22 @@ export type AudioMixer = {
   /** Per-source level, 0..1. This is how the active clip is heard and the
    *  prefetched and disabled ones are held silent. */
   setSourceGain: (element: HTMLMediaElement, volume: number) => void;
+  /**
+   * Let go of an element the caller is discarding.
+   *
+   * The counterpart to `attach`, and the reason eviction is possible at all: a
+   * `MediaElementAudioSourceNode` stays connected to the graph for as long as
+   * nobody disconnects it, and while connected it keeps the element — and its
+   * decoder — alive no matter what the caller does with its own references.
+   * The `WeakMap`s cannot help here, because the audio graph IS the strong
+   * reference.
+   *
+   * ONE-WAY. Web Audio gives an element exactly one source node for the
+   * lifetime of the context, so a released element can never be attached
+   * again. Callers must be finished with it — the surface clears `src` and
+   * drops the element in the same breath.
+   */
+  release: (element: HTMLMediaElement) => void;
   setMasterVolume: (volume: number) => void;
   setMuted: (muted: boolean) => void;
   /** Browsers start the context suspended until a user gesture. Call from the
@@ -183,6 +199,23 @@ export function createAudioMixer(
         return;
       }
       if (fallbackElements.has(element)) applyFallback(element);
+    },
+
+    release(element) {
+      const gain = gains.get(element);
+      if (gain) {
+        // Disconnecting the GAIN detaches this element's whole branch: the
+        // source node upstream has nowhere left to reach, so the graph stops
+        // holding it. `createMediaElementSource` cannot be undone, which is
+        // precisely why the caller must be done with the element.
+        gain.disconnect();
+        gains.delete(element);
+      }
+      levels.delete(element);
+      // A Set, unlike the maps above, is a STRONG reference — an element that
+      // fell back to element-level volume would otherwise be retained here for
+      // the mixer's whole life, which is the one leak in this module.
+      fallbackElements.delete(element);
     },
 
     setMasterVolume(volume) {

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -183,6 +183,23 @@ type WorkbenchDisplaySurfaceProps = {
 };
 
 const BUFFER_WINDOW_SIZE = 4;
+
+/**
+ * How many clips' media may be held at once.
+ *
+ * Every clip the playhead has ever touched used to be kept for the life of the
+ * surface — an element with `preload="auto"` (so the whole file), a decoder,
+ * and a branch of the audio graph, none of which were ever given back. On a
+ * short timeline that is invisible and was measured so: 21 distinct sources,
+ * saturating, heap flat. On a real cut it is one media element per clip in the
+ * project, held because the playhead once passed over it.
+ *
+ * Sized off the prefetch window rather than guessed: the live picture, its
+ * layers, and BUFFER_WINDOW_SIZE clips ahead must all survive a prune or this
+ * would evict exactly the clips the surface just decided to warm up. The rest
+ * is headroom for scrubbing back and forth across a join without churning.
+ */
+const MEDIA_CACHE_LIMIT = 24;
 const DEFAULT_SURFACE_HEIGHT = 380;
 const MIN_SURFACE_HEIGHT = 120;
 const MIN_TIMELINE_SPACE = 260;
@@ -733,6 +750,7 @@ export function WorkbenchDisplaySurface({
 }: WorkbenchDisplaySurfaceProps) {
   const { getCollectionClipFramePreview } = useTimelineDocuments();
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const surfaceRef = useRef<HTMLElement | null>(null);
   const playbackSurfaceRectRef = useRef<PlaybackSurfaceRect | null>(null);
   const cacheRef = useRef(new Map<string, CachedMedia>());
   // The proxies, keyed the same way as the real elements so the two are always
@@ -740,6 +758,14 @@ export function WorkbenchDisplaySurface({
   // played, never mixed, and never the thing a consumer is watching — they
   // exist only to have a frame ready sooner than the real element can.
   const scrubProxyRef = useRef(new Map<string, HTMLVideoElement>());
+  /**
+   * Cache keys in least-recently-used order.
+   *
+   * A `Set` rather than timestamps because insertion order is already the
+   * answer: touching a key deletes and re-adds it, which moves it to the back,
+   * so the front is always the coldest thing holding a decoder.
+   */
+  const recentKeysRef = useRef(new Set<string>());
   const getScrubProxySrcRef = useRef(getScrubProxySrc);
   getScrubProxySrcRef.current = getScrubProxySrc;
   // Read by the proxies' `seeked` listeners, which outlive any one render.
@@ -891,7 +917,37 @@ export function WorkbenchDisplaySurface({
     sortedClips,
   ]);
 
+  /**
+   * How many clips' media are held right now, as a DOM witness.
+   *
+   * The cache is a ref, so its size is invisible to anything outside this
+   * component — and "did the cap hold" is exactly the question a test, or a
+   * measurement in the running app, needs to ask. Written imperatively rather
+   * than rendered, because a cache eviction is not a reason to re-render the
+   * preview.
+   */
+  const publishCacheSize = useCallback(() => {
+    surfaceRef.current?.setAttribute("data-media-cache-size", String(cacheRef.current.size));
+  }, []);
+
+  // What the prefetch window is currently holding warm, reachable from the
+  // prune without threading it through every caller. Written during render like
+  // `outputAspectRef` above, for the same reason: the readers are callbacks
+  // that must not be rebuilt when this changes.
+  const bufferedKeysRef = useRef<ReadonlySet<string>>(new Set<string>());
+  bufferedKeysRef.current = useMemo(
+    () => new Set(bufferedMedia.map((media) => media.key)),
+    [bufferedMedia],
+  );
+
   const ensureCachedMedia = useCallback((media: DisplayMedia) => {
+    // TOUCHED ON EVERY ACCESS, hit or miss — this is the only place that sees
+    // all of them, and a key that stops being asked for is exactly the one the
+    // prune should take.
+    const recent = recentKeysRef.current;
+    recent.delete(media.key);
+    recent.add(media.key);
+
     const cached = cacheRef.current.get(media.key);
     if (cached) return cached;
 
@@ -915,6 +971,7 @@ export function WorkbenchDisplaySurface({
       getMixer().attach(video);
       const nextCached: CachedMedia = { kind: "video", element: video };
       cacheRef.current.set(media.key, nextCached);
+      publishCacheSize();
       return nextCached;
     }
 
@@ -936,6 +993,7 @@ export function WorkbenchDisplaySurface({
       getMixer().attach(audio);
       const nextCached: CachedMedia = { kind: "audio", element: audio };
       cacheRef.current.set(media.key, nextCached);
+      publishCacheSize();
       return nextCached;
     }
 
@@ -944,8 +1002,9 @@ export function WorkbenchDisplaySurface({
     image.src = media.src;
     const nextCached: CachedMedia = { kind: "image", element: image };
     cacheRef.current.set(media.key, nextCached);
+    publishCacheSize();
     return nextCached;
-  }, [getMixer]);
+  }, [getMixer, publishCacheSize]);
 
   /**
    * The proxy for one video clip, built on first use, or null when there is
@@ -985,6 +1044,62 @@ export function WorkbenchDisplaySurface({
     scrubProxyRef.current.set(media.key, proxy);
     return proxy;
   }, []);
+
+  /**
+   * Give one clip's media back: its element, its decoder, its buffered file and
+   * its branch of the audio graph.
+   *
+   * ORDER MATTERS. The mixer has to let go BEFORE the element is dropped,
+   * because a connected source node keeps it alive regardless of what this
+   * cache does — releasing the reference without disconnecting the graph would
+   * free nothing at all and look exactly like a working eviction.
+   *
+   * `removeAttribute` then `load()` is what actually stops the download and
+   * tears the decoder down; setting `src = ""` re-resolves against the document
+   * URL and has the element fetch the PAGE instead.
+   */
+  const releaseCachedMedia = useCallback((key: string) => {
+    const cached = cacheRef.current.get(key);
+    if (cached && isPlayable(cached)) {
+      cached.element.pause();
+      mixerRef.current?.release(cached.element);
+      cached.element.removeAttribute("src");
+      cached.element.load();
+    }
+    const proxy = scrubProxyRef.current.get(key);
+    if (proxy) {
+      proxy.pause();
+      proxy.removeAttribute("src");
+      proxy.load();
+      scrubProxyRef.current.delete(key);
+    }
+    // Its pending seek listeners would otherwise fire against a torn-down
+    // element and repaint the canvas from nothing.
+    const pending = pendingSeekDrawCleanupRef.current;
+    pending.get(key)?.();
+    pending.delete(key);
+    pictureSeekInFlightRef.current.delete(key);
+    cacheRef.current.delete(key);
+    recentKeysRef.current.delete(key);
+    publishCacheSize();
+  }, [publishCacheSize]);
+
+  /**
+   * Drop the coldest media until the cache is back inside its limit.
+   *
+   * `protectedKeys` is the live picture, its layers, and the prefetch window —
+   * everything the surface has just decided it needs. Anything protected is
+   * skipped rather than counted out, so a moment where more clips are live than
+   * the limit allows simply prunes nothing instead of evicting the picture.
+   */
+  const pruneMediaCache = useCallback((protectedKeys: ReadonlySet<string>) => {
+    if (cacheRef.current.size <= MEDIA_CACHE_LIMIT) return;
+    for (const key of [...recentKeysRef.current]) {
+      if (cacheRef.current.size <= MEDIA_CACHE_LIMIT) return;
+      if (protectedKeys.has(key)) continue;
+      releaseCachedMedia(key);
+    }
+  }, [releaseCachedMedia]);
 
   const drawDrawable = useCallback((drawable: HTMLImageElement | HTMLVideoElement) => {
     const canvas = canvasRef.current;
@@ -1415,6 +1530,12 @@ export function WorkbenchDisplaySurface({
     if (media) liveKeys.add(media.key);
     for (const layer of layers) liveKeys.add(layer.media.key);
     pauseClipsNotLive(liveKeys);
+    // The prefetch window is protected alongside the live set: those clips were
+    // deliberately warmed a moment ago, and evicting them here would have the
+    // surface fighting its own read-ahead.
+    const keepWarm = new Set(liveKeys);
+    for (const key of bufferedKeysRef.current) keepWarm.add(key);
+    pruneMediaCache(keepWarm);
 
     for (const layer of layers) {
       // Never `draws`: a layer does not own the canvas, so it must not trigger
@@ -1740,6 +1861,7 @@ export function WorkbenchDisplaySurface({
 
   useEffect(() => {
     const mediaCache = cacheRef.current;
+    const scrubProxies = scrubProxyRef.current;
     return () => {
       mediaCache.forEach((cached) => {
         if (isPlayable(cached)) {
@@ -1748,6 +1870,13 @@ export function WorkbenchDisplaySurface({
           cached.element.load();
         }
       });
+      // Proxies are not in `mediaCache` and would otherwise outlive it.
+      scrubProxies.forEach((proxy) => {
+        proxy.pause();
+        proxy.removeAttribute("src");
+        proxy.load();
+      });
+      scrubProxies.clear();
       const pending = pendingSeekDrawCleanupRef.current;
       pending.forEach((cleanup) => cleanup());
       pending.clear();
@@ -1807,6 +1936,7 @@ export function WorkbenchDisplaySurface({
 
   return (
     <section
+      ref={surfaceRef}
       aria-label="Workbench display surface"
       // BORDERLESS. The rounded corners, the near-black fill, and the shadow
       // already separate the preview from the page; the outline on top read as


### PR DESCRIPTION
Follow-up to #488. The preview's media cache never evicted: every clip the
playhead touched was kept for the surface's whole life — an element with
`preload="auto"` (the whole file), a decoder, and a branch of the audio graph.
The cost of a session was the number of **distinct clips visited**, not the
number in play.

**Capped, least-recently-used.** The live picture, its layers and the prefetch
window are protected — otherwise this evicts exactly what the surface just
warmed. Protected keys are skipped rather than counted, so a moment with more
live clips than the cap prunes nothing instead of dropping the picture.

**The mixer had to learn to let go**, and this is the load-bearing part. The
element maps were already `WeakMap`s, so they never retained anything — the
*audio graph* did. `createMediaElementSource` connects a node that keeps its
element and decoder alive as long as it stays connected, whatever the cache
does with its own reference. Dropping the reference without disconnecting frees
nothing and looks exactly like a working eviction. `release` disconnects the
branch and takes the fallback `Set` — the module's one strong reference — too.

**Two smaller leaks found on the way:** the scrub proxies from #488 were never
torn down on unmount, and `src = ""` (the obvious way to stop a download)
re-resolves against the document URL and makes the element fetch the *page*.
It has to be `removeAttribute` then `load()`.

Measured in the running app, six collection visits with full scrubs:

| | cache entries |
|---|---|
| before | grew with every distinct clip |
| after | **24, flat** |

**Coverage.** Four mixer unit tests for `release`, and a story driving 30 clips
through a cache of 24. Both confirmed to fail without their fix — the mixer
tests on a release that doesn't disconnect, the story with the prune disabled
("expected 30 to be less than or equal to 24").

`data-media-cache-size` is a test witness, same rationale as the audio and
frame-override witnesses beside it: a ref's size is unobservable from outside
the component.

Green locally: app + UI tsc, 790 unit, 1359 app tests, 23 stories, lint clean,
23 preview/audio/rail e2e passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)