### PR TITLE
The filmstrip and the trim handles get the small copy too

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -22,6 +22,7 @@ import {
 import { useDialogFocus } from "@/hooks/use-dialog-focus";
 import { DETAILS_HERO_FILL_CLASS, DETAILS_PANEL_HEIGHT_CLASS } from "./graph-view-config";
 import { useSeekedVideo } from "@/hooks/use-seeked-video";
+import { cloudinaryScrubProxySrc } from "@/lib/cloudinary-scrub-proxy";
 import { useFrameCrossfade } from "@/hooks/use-frame-crossfade";
 import { formatSeconds } from "@/lib/format-duration";
 import { InlineNameEditor, useInlineRename } from "./graph-inline-rename";
@@ -370,6 +371,7 @@ function DetailsPanel({
   onPlayFromStart = null,
   live: onScreen = false,
   magnified = false,
+  scrubbing = false,
   swipe,
   seamLabel = null,
   width,
@@ -455,6 +457,10 @@ function DetailsPanel({
    * stops being one of three pictures and becomes the only one that matters.
    */
   magnified?: boolean;
+  /** True while this panel is the one the seam clock is driving AND the bar is
+   *  being dragged — the only moment a panel seeks fast enough to need the
+   *  small copy. A resting neighbour holds one still frame and never seeks. */
+  scrubbing?: boolean;
   /**
    * Pointer handlers for dragging the whole strip, spread onto the PICTURE.
    *
@@ -553,10 +559,15 @@ function DetailsPanel({
   // Gated on `video`: an image has no source window and no element to seek, so
   // the settle loop had nothing to do but spin for as long as the modal stayed
   // open.
-  const videoRef = useSeekedVideo(
+  // Null for anything not served as a Cloudinary video — a fixture, an upload
+  // still in flight — and the hook simply scrubs the real element then, which
+  // is what it always did.
+  const scrubProxySrc = shownVideo?.src ? cloudinaryScrubProxySrc(shownVideo.src) : null;
+  const { videoRef, proxyRef, showProxy } = useSeekedVideo(
     Math.round(rawTime * 25) / 25,
     shownVideo !== null || shownAudio !== null,
     audible,
+    { proxySrc: scrubProxySrc, scrubbing },
   );
   // A panel crossing the centre swaps which end of its clip it rests on, and
   // the two frames are seconds of story apart — cut between them and the eye
@@ -950,6 +961,36 @@ function DetailsPanel({
               // reads as the page misbehaving even when the swipe does work.
               draggable={false}
               className="h-full w-full bg-black object-contain select-none"
+            />
+          )}
+          {/* THE SMALL COPY, shown only while the bar is being dragged.
+              A full-res seek costs 67-128ms on these sources and this view
+              mounts an element PER PANEL, so a nine-up strip of video was
+              asking for nine of them at once — measured at 714ms a seek, which
+              is a picture that changes about once a second under a hand moving
+              far faster than that.
+
+              ABSOLUTE, AFTER the real element in the DOM, so it paints over it
+              without either one moving: same box, same `object-contain`, so
+              the swap is a change of sharpness and nothing else. It sits UNDER
+              the crossfade canvas below, which must stay on top to cover a cut.
+
+              No `poster`: a poster would flash the clip's first frame at the
+              start of every drag, which is precisely the wrong frame. */}
+          {shownVideo && scrubProxySrc !== null && (
+            <video
+              key={`scrub-proxy:${scrubProxySrc}`}
+              ref={proxyRef}
+              src={scrubProxySrc}
+              aria-hidden="true"
+              muted
+              playsInline
+              preload="auto"
+              draggable={false}
+              className={[
+                "pointer-events-none absolute inset-0 h-full w-full bg-black object-contain select-none",
+                showProxy ? "opacity-100" : "opacity-0",
+              ].join(" ")}
             />
           )}
           {/* THE OUTGOING FRAME, held over the picture while the incoming one
@@ -1649,6 +1690,7 @@ function DetailsFilmstripModal({
               // dragged: the neighbours are context, and enlarging them would
               // be enlarging the thing you are trying to look past.
               magnified={index === centre && scrubbing}
+              scrubbing={index === centre && scrubbing}
               swipe={swipe}
               width={panelWidth}
               // Engaged, and not the one being watched. Uses the same gate as

--- a/apps/timeline-gstudio001/components/graph-view/graph-trim-panel.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-trim-panel.tsx
@@ -62,7 +62,7 @@ function LiveEdgeFrame({
   // Quantized to ~25fps so a slow pixel-level drag doesn't issue a seek per
   // pointer event for sub-frame deltas.
   const time = Math.round(edgeSourceTime(node, live) * 25) / 25;
-  const videoRef = useSeekedVideo(time);
+  const { videoRef } = useSeekedVideo(time);
 
   const frameRef = useRef<HTMLDivElement | null>(null);
   useLayoutEffect(() => {

--- a/apps/timeline-gstudio001/hooks/use-seeked-video.ts
+++ b/apps/timeline-gstudio001/hooks/use-seeked-video.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 /**
  * Keeps a preview media element seeked to `time`, one in-flight seek at a time
@@ -27,16 +27,74 @@ import { useCallback, useEffect, useRef } from "react";
  * element at all — so opening the details view spun a 60fps loop checking a
  * null ref for as long as it stayed open.
  */
-export function useSeekedVideo(time: number, enabled = true, playing = false) {
+export function useSeekedVideo(
+  time: number,
+  enabled = true,
+  playing = false,
+  scrub: Readonly<{ proxySrc?: string | null; scrubbing?: boolean }> = {},
+) {
+  const { proxySrc = null, scrubbing = false } = scrub;
   const mediaRef = useRef<HTMLMediaElement | null>(null);
+  const proxyElementRef = useRef<HTMLVideoElement | null>(null);
   const targetRef = useRef(time);
+  const scrubbingRef = useRef(scrubbing);
+  const hasProxy = proxySrc !== null;
+
+  /**
+   * WHICH ELEMENT IS ON SCREEN.
+   *
+   * Mostly derived: while a scrub is running the answer is simply "the proxy".
+   * The only thing that needs remembering is the tail — after the hand stops,
+   * the proxy has to stay up until the real element has actually caught up, or
+   * the swap reveals whatever frame it was left on when the drag STARTED.
+   *
+   * Adjusted during render rather than in an effect. Setting state from an
+   * effect for this is a lint error in this repo and deserves to be: it renders
+   * the wrong element first and corrects it on a second pass, which for one
+   * frame is exactly the stale picture this exists to avoid.
+   */
+  const [heldAfterScrub, setHeldAfterScrub] = useState(false);
+  const [previousScrubbing, setPreviousScrubbing] = useState(scrubbing);
+  const [previousProxySrc, setPreviousProxySrc] = useState(proxySrc);
+  const heldRef = useRef(false);
+
+  if (previousScrubbing !== scrubbing) {
+    setPreviousScrubbing(scrubbing);
+    // Entering a scrub needs no flag — `scrubbing` itself answers. LEAVING one
+    // does: this is the hand-back, and it is not finished until the real
+    // element lands.
+    if (!scrubbing) setHeldAfterScrub(true);
+  }
+  if (previousProxySrc !== proxySrc) {
+    setPreviousProxySrc(proxySrc);
+    // A proxy for a source that has since changed is a picture of another clip.
+    setHeldAfterScrub(false);
+  }
+
+  const showProxy = hasProxy && (scrubbing || heldAfterScrub);
 
   useEffect(() => {
     targetRef.current = time;
   }, [time]);
 
+  useEffect(() => {
+    scrubbingRef.current = scrubbing;
+  }, [scrubbing]);
+
+  // Mirrored for the settle loop, which must not be rebuilt when this flips —
+  // and written in an EFFECT for the same reason `targetRef` above is: a ref
+  // assignment during render is a side effect in a function React may call
+  // speculatively and discard.
+  useEffect(() => {
+    heldRef.current = heldAfterScrub;
+  }, [heldAfterScrub]);
+
   const attachVideo = useCallback((media: HTMLMediaElement | null) => {
     mediaRef.current = media;
+  }, []);
+
+  const attachProxy = useCallback((element: HTMLVideoElement | null) => {
+    proxyElementRef.current = element;
   }, []);
 
   useEffect(() => {
@@ -75,12 +133,49 @@ export function useSeekedVideo(time: number, enabled = true, playing = false) {
           }
         } else {
           if (!media.paused) media.pause();
+          const proxy = proxyElementRef.current;
+
+          if (scrubbingRef.current && proxy !== null) {
+            // ONLY THE PROXY MOVES UNDER A DRAG. Seeking both would put two
+            // decodes per frame on the same GPU for every panel that is a
+            // video — and this view mounts one element PER PANEL, so at nine
+            // up that is the difference between a handful of decoders and
+            // twenty. The real element is left exactly where it was; it
+            // catches up once the hand stops.
+            if (
+              proxy.readyState >= 1 &&
+              !proxy.seeking &&
+              Math.abs(proxy.currentTime - targetRef.current) > 0.03
+            ) {
+              try {
+                proxy.currentTime = targetRef.current;
+              } catch {
+                // metadata raced away; next frame retries
+              }
+            }
+            raf = requestAnimationFrame(tick);
+            return;
+          }
+
           if (!media.seeking && Math.abs(media.currentTime - targetRef.current) > 0.03) {
             try {
               media.currentTime = targetRef.current;
             } catch {
               // metadata raced away; next frame retries
             }
+          } else if (
+            heldRef.current &&
+            !media.seeking &&
+            media.readyState >= 2 &&
+            Math.abs(media.currentTime - targetRef.current) <= 0.03
+          ) {
+            // THE HANDOVER, and the reason it waits: swapping back the moment
+            // the drag ends would reveal whatever frame the real element was
+            // left on, which is wherever the scrub STARTED. It stays on the
+            // proxy until the real one is genuinely showing the frame that was
+            // landed on.
+            heldRef.current = false;
+            setHeldAfterScrub(false);
           }
         }
       }
@@ -94,10 +189,11 @@ export function useSeekedVideo(time: number, enabled = true, playing = false) {
       // mid-play, and an element nobody can see is still an element making
       // noise.
       mediaRef.current?.pause();
+      proxyElementRef.current?.pause();
     };
   }, [enabled, playing]);
 
-  return attachVideo;
+  return { videoRef: attachVideo, proxyRef: attachProxy, showProxy };
 }
 
 /**

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -1674,15 +1674,43 @@ export function WorkbenchDisplaySurface({
       const cached = cacheRef.current.get(media.key);
       if (!isPlayable(cached)) return;
       const video = cached.element;
-      if (video.readyState < HTMLMediaElement.HAVE_METADATA || video.seeking) return;
+      if (video.readyState < HTMLMediaElement.HAVE_METADATA) return;
 
       const maxTime = Number.isFinite(video.duration)
         ? Math.max(0, video.duration - 0.001)
         : media.sourceTime;
       const target = clamp(media.sourceTime, 0, maxTime);
+
+      // THE PROXY CHASES EVEN WHILE THE REAL ELEMENT IS BUSY, which matters
+      // more here than anywhere else. The comment above this loop describes a
+      // cold trim seek taking the better part of a second — that is a second
+      // with no new frame, on the one gesture whose entire purpose is choosing
+      // a frame. The proxy is not subject to the wait, so the handle has
+      // something to show the whole way down.
+      //
+      // Deliberately BEFORE the `seeking` bail below: gating it on the real
+      // element being idle would silence it during exactly the long seeks it
+      // exists to cover.
+      const proxy = ensureScrubProxy(media);
+      if (
+        proxy !== null &&
+        proxy.readyState >= HTMLMediaElement.HAVE_METADATA &&
+        !proxy.seeking &&
+        Math.abs(proxy.currentTime - target) > 0.03
+      ) {
+        try {
+          proxy.currentTime = target;
+        } catch {
+          // Metadata raced away; the next frame retries.
+        }
+      }
+
+      if (video.seeking) return;
+
       // `currentTime` reads back as the seek TARGET mid-seek, so this does not
       // re-issue while the browser is still decoding.
       if (Math.abs(video.currentTime - target) > 0.03) {
+        pictureSeekInFlightRef.current.set(media.key, true);
         try {
           video.currentTime = target;
         } catch {
@@ -1690,11 +1718,13 @@ export function WorkbenchDisplaySurface({
         }
         return;
       }
+      // Landed: the real frame is the one to show again.
+      pictureSeekInFlightRef.current.set(media.key, false);
       if (video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) drawActiveFrame();
     };
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
-  }, [overrideActive, drawActiveFrame]);
+  }, [overrideActive, drawActiveFrame, ensureScrubProxy]);
 
   useEffect(() => {
     bufferedMedia.forEach((media) => {


### PR DESCRIPTION
#488 put a scrub proxy behind the preview pane and left the other two surfaces
on full-res seeks. This finishes the job.

**The filmstrip is the worse case**, because it mounts a `<video>` per panel
rather than sharing one. Measured on these sources: one element seeks in
67–128ms, nine in 714ms — a nine-up strip of video was a picture changing about
once a second under a hand moving far faster.

Seeking a proxy *alongside* each full element would have made that worse, not
better (twenty-odd decoders on one GPU), so under a drag **only the proxy
moves** and the real element is left where it was:

| drag on the seam bar | proxy seeks | full-res seeks |
|---|---|---|
| 6 panels, during drag | 17 | **0** |
| 3-up, during drag | 27 | **0** |
| after release | 1 | 1 |

**The handover waits for the real frame.** Swapping back when the drag ends
would reveal whatever the full element was parked on — wherever the scrub
*started*. It holds the proxy until the real one is genuinely showing the frame
that was landed on. Derived during render, not set from an effect: an effect
renders the wrong element first and corrects on a second pass, which for one
frame is exactly the stale picture this exists to avoid. (It was written that
way first; `react-hooks/set-state-in-effect` is an error in this repo and was
right to be.)

**The trim handles needed no app change** — the trim preview doesn't render a
surface, it feeds `frameOverride` into the pane that already had the proxy. Its
override loop chases the proxy *before* the "is the real element busy" bail,
deliberately: the comment above that loop describes a cold trim seek taking the
better part of a second, and gating the proxy on the real element being idle
would silence it during exactly the long seeks it covers.

**Known limit, unchanged from #488 and now visible in a second place:** the
monitor's element is keyed by source, so each cut mints a fresh, unloaded proxy.
Dragging fast across many cuts gets less from this than dragging within a clip.
Pre-building proxies for neighbouring clips is the fix and is not in here.

Stories cannot exercise this — fixtures aren't Cloudinary sources, so
`cloudinaryScrubProxySrc` returns null and no proxy is minted. That null path is
unit-tested; the behaviour above is measured in the running app.

Verified: 790 unit, 1359 app tests, 22 modal stories, 28 details/trim/preview
e2e, tsc and lint clean on both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)