### PR TITLE
Cuts stop dropping frames: the next clip is put in position first

### DIFF
--- a/packages/ui/timeline/viewport/playback-skip.test.ts
+++ b/packages/ui/timeline/viewport/playback-skip.test.ts
@@ -7,6 +7,7 @@ import {
   getPictureClip,
   getTimelineDuration,
   nextPlayableTime,
+  clipToPreroll,
 } from "./playback-skip";
 
 function image(
@@ -279,5 +280,53 @@ describe("getLiveLayerClips", () => {
     // case — a timeline with no lanes at all — is the kind of per-frame garbage
     // getContainingClip's manual loop exists to avoid.
     expect(getLiveLayerClips(clips, 2)).toBe(getLiveLayerClips(clips, 5));
+  });
+});
+
+describe("clipToPreroll", () => {
+  // a: 0-4, b: 4-8 (disabled), c: 8-12 — the same fixture the rest of this
+  // file uses, so the disabled-clip case is the one already modelled here.
+  const LEAD = 1;
+
+  it("names the next clip once the cut is inside the lead", () => {
+    expect(clipToPreroll(clips, clips[0]!, 3.5, LEAD)?.id).toBe("c");
+  });
+
+  it("is null while the cut is still far off", () => {
+    // Seeking a clip four seconds early buys nothing and takes a decoder off
+    // the one that is playing.
+    expect(clipToPreroll(clips, clips[0]!, 2.5, LEAD)).toBeNull();
+  });
+
+  it("SKIPS A DISABLED CLIP, because playback skips it too", () => {
+    // `b` starts at 4 and would be the next clip by position. Preparing it
+    // would put an element in position for a cut that never comes AND leave
+    // `c` — the clip actually next — still cold, which is the failure this
+    // whole change exists to remove.
+    const at = clipToPreroll(clips, clips[0]!, 3.5, LEAD);
+    expect(at?.id).not.toBe("b");
+  });
+
+  it("ignores a cut already reached", () => {
+    // Exactly on the boundary the clip is the ACTIVE one, not the next one;
+    // returning it here would re-seek the element that is currently playing.
+    expect(clipToPreroll(clips, clips[0]!, 8, LEAD)).toBeNull();
+  });
+
+  it("never looks backwards", () => {
+    // Late in the timeline there is nothing ahead to prepare.
+    expect(clipToPreroll(clips, clips[2]!, 11.5, LEAD)).toBeNull();
+  });
+
+  it("takes the SOONEST cut when several are in the window", () => {
+    const dense = [image("a", 0, 4), image("x", 4.5, 1), image("y", 4.2, 1)];
+    expect(clipToPreroll(dense, dense[0]!, 3.6, LEAD)?.id).toBe("y");
+  });
+
+  it("does not mistake a clip sharing the active clip's start for the next one", () => {
+    // A layered timeline has clips starting together; the one under the
+    // picture is not the thing after it.
+    const layered = [image("pic", 0, 4), image("bed", 0, 4), image("next", 4, 4)];
+    expect(clipToPreroll(layered, layered[0]!, 3.5, LEAD)?.id).toBe("next");
   });
 });

--- a/packages/ui/timeline/viewport/playback-skip.ts
+++ b/packages/ui/timeline/viewport/playback-skip.ts
@@ -195,3 +195,57 @@ export function nextPlayableTime(
 
   return earliest === null ? duration : clamp(earliest, 0, duration);
 }
+
+/**
+ * The clip whose media should be put in position NOW, or null.
+ *
+ * A cut used to cost a seek: the prefetch window downloaded the next clips but
+ * left their elements paused wherever they happened to be, so the switch could
+ * not show a frame until it had seeked. Measured against a steady 17ms frame
+ * interval, that was 32-46ms at a cut into an untrimmed clip and 90-98ms into
+ * one trimmed 1.7s in — the gap tracked the trim, which is what identified the
+ * seek as the cost.
+ *
+ * `lead` is how far ahead to start. Only the SEEK is moved earlier by the
+ * caller; the clip stays paused and silent, so nothing about when playback
+ * switches changes.
+ *
+ * DISABLED CLIPS ARE SKIPPED, because playback skips them: pre-rolling one
+ * would put an element in position for a cut that never comes, and leave the
+ * clip that IS next still cold.
+ */
+export function clipToPreroll(
+  clips: readonly TimelineClip[],
+  active: TimelineClip,
+  currentTime: number,
+  lead: number,
+): TimelineClip | null {
+  const activeStart = getClipPlaybackStart(active);
+
+  let soonest: TimelineClip | null = null;
+  for (const clip of clips) {
+    if (clip.disabled === true) continue;
+    const start = getClipPlaybackStart(clip);
+    // STRICTLY AFTER the active clip's start, so a clip sharing a start time
+    // with the one on screen — a bed under the picture — is never mistaken for
+    // the thing that follows it.
+    if (start <= activeStart) continue;
+    if (soonest === null || start < getClipPlaybackStart(soonest)) soonest = clip;
+  }
+  if (soonest === null) return null;
+
+  // WHEN THE PICTURE ACTUALLY CHANGES, which is not simply the next clip's
+  // start. A DISABLED span between them is skipped rather than played, so the
+  // switch happens when the playhead leaves the active clip — measuring to the
+  // next clip's start would put the window seconds late and never prepare it,
+  // leaving precisely the cut that jumps furthest still cold. Taking the
+  // EARLIER of the two is safe in the other direction too: across a real gap
+  // the picture holds and this merely prepares early, which costs one seek
+  // nobody is waiting on.
+  const activeEnd = activeStart + getClipPlaybackDuration(active);
+  const switchesNoLaterThan = Math.min(activeEnd, getClipPlaybackStart(soonest));
+  const untilCut = switchesNoLaterThan - currentTime;
+  // A cut already reached is not a cut to prepare for.
+  if (untilCut <= 0 || untilCut > lead) return null;
+  return soonest;
+}

--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -41,6 +41,7 @@ import type { CollectionTimelineClip, TimelineClip } from "../types";
 import { formatSeconds } from "../utils";
 import {
   clipContainsPlaybackTime,
+  clipToPreroll,
   getClipPlaybackDuration,
   getClipPlaybackStart,
   getLiveLayerClips,
@@ -200,6 +201,21 @@ const BUFFER_WINDOW_SIZE = 4;
  * is headroom for scrubbing back and forth across a join without churning.
  */
 const MEDIA_CACHE_LIMIT = 24;
+
+/**
+ * How far ahead of a cut the incoming clip is seeked into position.
+ *
+ * The prefetch window downloads the next clips but leaves their elements
+ * PAUSED AT THE WRONG POSITION, so the switch at a cut had to pay for a seek
+ * before it could show anything. Measured across four cuts, warm, against a
+ * steady 17ms frame interval: 32-46ms where the incoming clip had no trim, and
+ * 90-98ms where it was trimmed 1.7s in — the gap tracked the trim, which is
+ * what named the seek as the cost. Cold it reached 369ms.
+ *
+ * A second is comfortably longer than the worst seek measured here and short
+ * enough that the playhead rarely crosses into the window and back out again.
+ */
+const PREROLL_LEAD_SECONDS = 1;
 const DEFAULT_SURFACE_HEIGHT = 380;
 const MIN_SURFACE_HEIGHT = 120;
 const MIN_TIMELINE_SPACE = 260;
@@ -1515,6 +1531,50 @@ export function WorkbenchDisplaySurface({
     // Only reachable while SCRUBBING: playing snaps the clock out of a
     // disabled span before anything is drawn (see nextPlayableTime).
     activeClipDisabledRef.current = active?.disabled === true;
+
+    // THE NEXT CLIP IS PUT IN POSITION BEFORE IT IS NEEDED.
+    //
+    // Only its SEEK is moved earlier — it stays paused and silent, and nothing
+    // about when playback switches changes. That is deliberate: starting it
+    // rolling early would have it arrive at the cut already past its first
+    // frame, and keeping it in step would mean playing from before the trim,
+    // which a clip trimmed to zero does not have. Seeking early costs nothing
+    // and is the half that was measurably expensive.
+    //
+    // WHILE PLAYING ONLY. Under a scrub the playhead is near a cut constantly
+    // and in both directions, so this would issue seeks against an element the
+    // scrub path is already driving.
+    if (shouldPlay && active) {
+      const next = clipToPreroll(
+        sortedClipsRef.current,
+        active,
+        timelineTime,
+        PREROLL_LEAD_SECONDS,
+      );
+      const nextMedia =
+        next === null
+          ? null
+          : resolveClipMedia(next, getClipPlaybackStart(next), getCollectionClipFramePreview);
+      if (nextMedia !== null) {
+        const cached = ensureCachedMedia(nextMedia);
+        if (isPlayable(cached)) {
+          const element = cached.element;
+          // The whole file, not just metadata: this one is about to play.
+          if (element.preload !== "auto") element.preload = "auto";
+          if (
+            element.readyState >= HTMLMediaElement.HAVE_METADATA &&
+            !element.seeking &&
+            Math.abs(element.currentTime - nextMedia.sourceTime) > 0.05
+          ) {
+            try {
+              element.currentTime = nextMedia.sourceTime;
+            } catch {
+              // Metadata raced away; the next frame retries.
+            }
+          }
+        }
+      }
+    }
 
     // The under-layers playing at this instant, alongside the picture rather
     // than instead of it. Resolved even when the picture is missing: a bed


### PR DESCRIPTION
Reported as "the seam feels a little jumpier than it needs to be, but I'm not
100% sure". It was real, and the uncertainty was warranted — some cuts were
clean and some froze for a fifth of a second.

**Measured.** Steady playback is 17ms between frames, with p95 and p99 also
17ms, so nothing else in the pipeline stutters. Only the cuts did, and the gap
tracked the incoming clip's **trim-in**:

| cut (trim-in) | before | after |
|---|---|---|
| → S01 (0.4s) | 46 / 30ms | 26 / 18ms |
| → S02SEB2 (0s) | 44 / 40ms | 17 / 17ms |
| → S02_h3_v7 (**1.7s**) | **90 / 98ms** | **17 / 26ms** |
| → S02_h3_v8 (0s) | 33 / 30ms | 27 / 17ms |
| cold pass | 59 / 164 / **369**ms | 31 / 32 / 18 / 17ms |

That correlation named the cause: the prefetch window downloads the next clips
but leaves their elements **paused at the wrong position**, so the switch had to
pay for a seek before it could show a frame — 22 frozen frames at worst.

**Only the seek moves earlier.** Within a second of a cut the incoming element
is put in position and left paused and silent; when playback switches is
unchanged. Starting it rolling early is wrong twice over — it would reach the
cut already past its first frame, and keeping it in step would mean playing from
*before* the trim, which a clip trimmed to zero doesn't have.

**The disabled-clip case is why this is a pure, tested helper.** A disabled clip
between two shots is skipped, so the switch happens when the playhead leaves the
*active* clip, not when the next one starts. Measuring to the next clip's start
would put the window seconds late and never prepare it — leaving precisely the
cut that jumps furthest still cold. That test failed against the first
implementation; buried in the render path it would have shipped.

Verified: 797 unit (7 new for `clipToPreroll`), 1366 app tests, 23 stories, 22
playback e2e, tsc and lint clean on both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)