### PR TITLE
The small copy is ready before the hand arrives

### DIFF
--- a/packages/ui/timeline/viewport/workbench-display-surface.tsx
+++ b/packages/ui/timeline/viewport/workbench-display-surface.tsx
@@ -1792,8 +1792,17 @@ export function WorkbenchDisplaySurface({
       if (cached.kind === "image" && !cached.element.complete) {
         cached.element.addEventListener("load", drawActiveFrame, { once: true });
       }
+      // THE SMALL COPY IS BUILT HERE TOO, not on the first seek that wants it.
+      //
+      // Built lazily, a proxy is created mid-drag and spends the rest of that
+      // gesture loading — so the FIRST scrub over any clip got nothing from it,
+      // which is the pass where the full-res element is coldest and the picture
+      // needs it most. This is the same window that already decides which clips
+      // are worth downloading ahead; a proxy is a fraction of the file it sits
+      // beside, and it is now ready before the hand arrives.
+      ensureScrubProxy(media);
     });
-  }, [bufferedMedia, drawActiveFrame, ensureCachedMedia]);
+  }, [bufferedMedia, drawActiveFrame, ensureCachedMedia, ensureScrubProxy]);
 
   // Repaint on a new CLIP LIST as well as a new time. `renderFrameAtTime`
   // reads the clips through a ref (so playback doesn't re-create it every


### PR DESCRIPTION
Last known gap in the scrub work. A proxy was built by the first seek that
wanted one — so it was created **mid-drag** and spent the rest of that gesture
loading. The first scrub over any clip therefore got nothing from it, which is
exactly the pass where the full-res element is coldest.

They are built in the prefetch window now: the same window that already decides
which clips are worth downloading ahead, and a proxy is a fraction of the file
it sits beside.

| first drag on a freshly loaded page | before | after |
|---|---|---|
| proxies standing by | 0 | **8**, all fully buffered |
| frame updates during the drag | **0** | 8, every one from the proxy |
| resting frame | full-res | full-res |

Only *when* the resting frame arrives changed, not what it is.

**Forward only**, worth knowing rather than discovering: the prefetch window
looks ahead, so scrubbing *backwards* into a clip whose proxy has been evicted
still finds it cold. Widening the window both ways is the fix and is not here.

**On coverage.** `ensureScrubProxy` is now called for every buffered clip
including stills, so the existing "stills never ask for a scrub proxy" story
guards a live path rather than an unreachable one. Mutation-testing that guard
made the suite **hang** rather than fail cleanly (images reach the consumer
callback and drive a re-render loop), so treat it as a weaker check than the
green tick suggests — the guard is load-bearing, the test just reports it badly.

Verified: 797 unit, 1366 app tests, 23 stories, 22 preview/play/rail e2e, tsc
and lint clean on both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)