### PR TITLE
Gain moves are ramped, so a cut does not click

### DIFF
--- a/packages/ui/timeline/viewport/audio-graph.test.ts
+++ b/packages/ui/timeline/viewport/audio-graph.test.ts
@@ -15,6 +15,10 @@ import { at } from "../../test-support/at";
 function createFakeContext() {
   const gains: MinimalGainNode[] = [];
   const disconnected: MinimalGainNode[] = [];
+  /** Every scheduled gain move. The fake also applies the target immediately so
+   *  assertions about the resulting LEVEL still read naturally; what this adds
+   *  is whether the move was scheduled or stepped. */
+  const ramps: { target: number; timeConstant: number }[] = [];
   const sourceCalls: HTMLMediaElement[] = [];
   let state = "suspended";
   let closed = false;
@@ -23,10 +27,18 @@ function createFakeContext() {
     get state() {
       return state;
     },
+    currentTime: 0,
     destination: {},
     createGain: () => {
       const node: MinimalGainNode = {
-        gain: { value: 1 },
+        gain: {
+          value: 1,
+          setTargetAtTime: (target, _startTime, timeConstant) => {
+            ramps.push({ target, timeConstant });
+            node.gain.value = target;
+          },
+          cancelScheduledValues: () => undefined,
+        },
         connect: () => undefined,
         disconnect: () => {
           disconnected.push(node);
@@ -54,6 +66,7 @@ function createFakeContext() {
     context,
     gains,
     disconnected,
+    ramps,
     sourceCalls,
     isClosed: () => closed,
     getState: () => state,
@@ -243,7 +256,11 @@ describe("release", () => {
     const mixer = createAudioMixer(() => fake.context);
     const element = fakeElement();
     mixer.attach(element);
-    const gain = at(fake.gains, 0);
+    // INDEX 1, not 0: `ensureContext` creates the master gain first, so the
+    // source's node is the second one. Asserting against index 0 tests the
+    // master — which `release` never touches — and passes whether or not the
+    // release worked at all.
+    const gain = at(fake.gains, 1);
 
     mixer.release(element);
     gain.gain.value = 0.42;
@@ -278,5 +295,85 @@ describe("release", () => {
     const fake = createFakeContext();
     const mixer = createAudioMixer(() => fake.context);
     expect(() => mixer.release(fakeElement())).not.toThrow();
+  });
+});
+
+describe("gain ramping", () => {
+  it("SCHEDULES a level change rather than stepping it", () => {
+    // A gain assigned outright moves the waveform between two adjacent samples,
+    // and that discontinuity is what a click IS — the ear hears the edge, not
+    // the level. It fires at every cut: the outgoing clip drops to zero mid
+    // waveform while the incoming one starts at full.
+    const fake = createFakeContext();
+    const mixer = createAudioMixer(() => fake.context);
+    const element = fakeElement();
+    mixer.attach(element);
+    const before = fake.ramps.length;
+
+    mixer.setSourceGain(element, 1);
+
+    expect(fake.ramps.length).toBe(before + 1);
+    expect(at(fake.ramps, fake.ramps.length - 1).target).toBe(1);
+  });
+
+  it("ramps FAST — a cut, not a fade", () => {
+    // Long enough to span hundreds of samples, short enough that the sound
+    // still lands on the frame it belongs to.
+    const fake = createFakeContext();
+    const mixer = createAudioMixer(() => fake.context);
+    const element = fakeElement();
+    mixer.attach(element);
+    mixer.setSourceGain(element, 1);
+
+    const { timeConstant } = at(fake.ramps, fake.ramps.length - 1);
+    expect(timeConstant).toBeGreaterThan(0);
+    expect(timeConstant).toBeLessThanOrEqual(0.02);
+  });
+
+  it("ramps the MASTER too, so mute does not click", () => {
+    const fake = createFakeContext();
+    const mixer = createAudioMixer(() => fake.context);
+    mixer.attach(fakeElement());
+    const before = fake.ramps.length;
+
+    mixer.setMuted(true);
+
+    expect(fake.ramps.length).toBe(before + 1);
+    expect(at(fake.ramps, fake.ramps.length - 1).target).toBe(0);
+  });
+
+  it("still lands on the value, so levels behave exactly as before", () => {
+    const fake = createFakeContext();
+    const mixer = createAudioMixer(() => fake.context);
+    const element = fakeElement();
+    mixer.attach(element);
+
+    // The source's own node — index 1, behind the master. See the note above.
+    mixer.setSourceGain(element, 1);
+    expect(at(fake.gains, 1).gain.value).toBe(volumeToGain(1));
+
+    mixer.setSourceGain(element, 0);
+    expect(at(fake.gains, 1).gain.value).toBe(0);
+  });
+
+  it("falls back to assignment when the param cannot schedule", () => {
+    // An AudioParam without `setTargetAtTime` is not a real one, but the mixer
+    // degrades to its old behaviour rather than throwing at it.
+    const fake = createFakeContext();
+    const stepping = {
+      ...fake.context,
+      createGain: () => ({
+        gain: { value: 1 },
+        connect: () => undefined,
+        disconnect: () => undefined,
+      }),
+    } as MinimalAudioContext;
+    const mixer = createAudioMixer(() => stepping);
+    const element = fakeElement();
+
+    expect(() => {
+      mixer.attach(element);
+      mixer.setSourceGain(element, 1);
+    }).not.toThrow();
   });
 });

--- a/packages/ui/timeline/viewport/audio-graph.ts
+++ b/packages/ui/timeline/viewport/audio-graph.ts
@@ -43,7 +43,14 @@ export function volumeToGain(volume: number): number {
 /** The subset of `AudioContext` this module uses — narrow so a test can fake it
  *  without standing up Web Audio, and so no `any` is needed. */
 export type MinimalGainNode = {
-  gain: { value: number };
+  gain: {
+    value: number;
+    /** Present on a real `AudioParam`. Optional here because the type exists to
+     *  be fakeable, and because a param without it still works — see
+     *  `writeGain`, which falls back to assignment. */
+    setTargetAtTime?: (target: number, startTime: number, timeConstant: number) => void;
+    cancelScheduledValues?: (startTime: number) => void;
+  };
   connect: (destination: MinimalGainNode | MinimalAudioDestination) => void;
   disconnect: () => void;
 };
@@ -52,6 +59,9 @@ export type MinimalAudioDestination = { readonly __brand?: "destination" };
 
 export type MinimalAudioContext = {
   readonly state: string;
+  /** The audio clock. Absent on an older fake, which `writeGain` reads as
+   *  "cannot schedule" and handles. */
+  readonly currentTime?: number;
   readonly destination: MinimalAudioDestination;
   createGain: () => MinimalGainNode;
   createMediaElementSource: (element: HTMLMediaElement) => { connect: (node: MinimalGainNode) => void };
@@ -102,6 +112,47 @@ function resolveAudioContextConstructor(): AudioContextConstructor | null {
     webkitAudioContext?: AudioContextConstructor;
   };
   return scope.AudioContext ?? scope.webkitAudioContext ?? null;
+}
+
+/**
+ * How quickly a gain change reaches its target, as `setTargetAtTime`'s time
+ * constant.
+ *
+ * FIVE MILLISECONDS, which is not a fade — it is the shortest ramp that is
+ * still a ramp. A gain assigned outright steps the waveform from one value to
+ * another between two adjacent samples, and a discontinuity is exactly what a
+ * click IS: the ear hears the edge, not the level. That happens here at every
+ * cut (the outgoing clip drops to zero mid-waveform while the incoming one
+ * starts at full), on every mute, and on every step of a volume drag.
+ *
+ * Short enough that a cut still lands on the frame it belongs to — five
+ * milliseconds is an eighth of a frame at 24fps — and long enough that the
+ * transition spans hundreds of samples instead of one.
+ */
+const GAIN_RAMP_SECONDS = 0.005;
+
+/**
+ * Move a gain to a new value without stepping it.
+ *
+ * Falls back to assignment when the param cannot schedule — an old fake, a
+ * context that never came up — so the mixer's behaviour degrades to what it
+ * was rather than throwing.
+ */
+function writeGain(
+  node: MinimalGainNode,
+  target: number,
+  context: MinimalAudioContext | null,
+): void {
+  const param = node.gain;
+  const now = context?.currentTime;
+  if (typeof param.setTargetAtTime === "function" && typeof now === "number") {
+    // Anything still scheduled is a ramp toward a level that is no longer
+    // wanted; leaving it queued would have the new target fight it.
+    param.cancelScheduledValues?.(now);
+    param.setTargetAtTime(target, now, GAIN_RAMP_SECONDS);
+    return;
+  }
+  param.value = target;
 }
 
 /**
@@ -195,7 +246,7 @@ export function createAudioMixer(
       levels.set(element, level);
       const gain = gains.get(element);
       if (gain) {
-        gain.gain.value = volumeToGain(level);
+        writeGain(gain, volumeToGain(level), context);
         return;
       }
       if (fallbackElements.has(element)) applyFallback(element);
@@ -220,13 +271,13 @@ export function createAudioMixer(
 
     setMasterVolume(volume) {
       masterVolume = clampVolume(volume);
-      if (master && !muted) master.gain.value = volumeToGain(masterVolume);
+      if (master && !muted) writeGain(master, volumeToGain(masterVolume), context);
       applyAllFallbacks();
     },
 
     setMuted(next) {
       muted = next;
-      if (master) master.gain.value = next ? 0 : volumeToGain(masterVolume);
+      if (master) writeGain(master, next ? 0 : volumeToGain(masterVolume), context);
       applyAllFallbacks();
     },
 


### PR DESCRIPTION
From the research pass on video/audio playback performance.

Every gain change in the mixer was an outright assignment. A gain assigned
outright steps the waveform between two adjacent samples, and that
discontinuity is what a click *is* — the ear hears the edge, not the level.

It fires at exactly the moments that matter:

- **every cut** — the outgoing clip drops to zero mid-waveform while the
  incoming one starts at full
- **mute** — 1 → 0 in an instant
- **a volume drag** — a step on every pointermove

Five milliseconds, which is not a fade — it's the shortest ramp that is still a
ramp. An eighth of a frame at 24fps, so a cut still lands on the frame it
belongs to, and it spans hundreds of samples instead of one. Falls back to
assignment when the param can't schedule, so the mixer degrades to its previous
behaviour rather than throwing at an incomplete `AudioParam`.

**It fixed a vacuous test on the way**, which is the part worth reading. The
release test from #489 asserted against `gains[0]` — but `ensureContext` creates
the **master** gain first, so index 0 is the master and the source's node is
index 1. It was asserting that releasing an element leaves the master alone,
which is true whether or not `release` does anything. Now mutation-tested both
ways: dropping the `gains.delete` fails it, and stepping instead of ramping
fails the three new ones.

**Not verified by ear.** The click is inferred from the discontinuity — well
established, but I did not record it off the output.

Verified: 802 unit, 1376 app tests, 21 audio/preview e2e, tsc and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)