### PR TITLE
Panning the strip no longer trims the clip you started on

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -2736,6 +2736,15 @@ export function GraphBoard({
                 // the visible width whatever the content does.
                 className={[
                   "rounded-none border-0 p-0",
+                  // pb-1.5: the cards sat directly ON the horizontal
+                  // scrollbar. Bottom padding on a horizontal scroller is part
+                  // of the scrollable area and lands ABOVE the bar, so this is
+                  // a gap between the filmstrip and its scrollbar rather than
+                  // one under the whole strip. Small on purpose — the strip's
+                  // height is the picture's, and every pixel here is a pixel
+                  // the frames do not get. Must follow `p-0`: twMerge keeps
+                  // the later of two conflicting spacing utilities.
+                  "pb-1.5",
                   GRAPH_STRIP_TRACK_CLASS,
                   // Same 16px, same wait, same one-step landing as the grid's
                   // — see the note there. Ruler and waveform have no reveal to

--- a/apps/timeline-gstudio001/components/graph-view/graph-card-trim.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-card-trim.tsx
@@ -117,17 +117,33 @@ export const GraphTrimHandle = memo(function GraphTrimHandle({
         // which faded the ink across the 8px and put its bright mass against
         // the outer edge — so the grip below, at a measured 50%, still read as
         // off-centre. The bar was never the problem; the field around it was.
-        "bg-white/85",
-        // WHITE, because it is the one highlight that is not already a state.
-        // Blue is selection everywhere on this board — the ring, the check,
-        // the count — so a handle on every clip would spend the colour that
-        // already had a job; amber was tried and reads as a third accent.
+        //
+        // QUIET AT REST, and the armed state below is what pays for it. This
+        // was a solid `white/85` — what an affordance looks like when it has
+        // to announce itself unaided, on every clip, forever. It no longer
+        // does: a press on the strip has to settle before it trims (the same
+        // drag is how the strip pans), so the handle now has a MOMENT to speak
+        // at, and at rest it can recede into the clip instead of sitting on
+        // six edges shouting. GREY rather than a dimmer white because it has
+        // to hold against a bright frame as well as a dark one, and because
+        // grey is the one value here that is not already a state — blue is
+        // selection everywhere on this board (the ring, the check, the count)
+        // and amber reads as a third accent.
+        "bg-zinc-400/45",
+        // ARMED: the press settled, and the next pull edits rather than
+        // scrolls. Those two outcomes are far enough apart that the handle has
+        // to say which one it is holding — the one moment it goes full
+        // strength. Colour only, no geometry: it must not move under the
+        // finger already on it.
+        "transition-colors group-data-[trim-armed=true]/trim:bg-white/95",
         side === "left" ? "rounded-l-md" : "rounded-r-md",
       ].join(" ")}
     >
       {/* The grip, centred in a now-uniform field. Taller on a coarse pointer
-          for the same reason the target is wider there. */}
-      <span className="h-5 w-0.5 rounded-full bg-black/70 [@media(pointer:coarse)]:h-7" />
+          for the same reason the target is wider there — and full-height and
+          darker once armed, the one geometry change allowed here because it
+          happens INSIDE the handle rather than to it. */}
+      <span className="h-5 w-0.5 rounded-full bg-black/45 transition-[height,background-color] group-data-[trim-armed=true]/trim:h-full group-data-[trim-armed=true]/trim:bg-black/70 [@media(pointer:coarse)]:h-7" />
     </span>
   );
 });

--- a/apps/timeline-gstudio001/tests/e2e/dnd-collections.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/dnd-collections.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Locator, type Page } from '@playwright/test';
 import { at } from "../../lib/test-support/at";
+import { TRIM_ARM_DELAY_MS } from "@storyboard/ui/dnd-collections/react/gesture-thresholds";
 
 // E2E coverage for packages/ui/dnd-collections, driven with REAL mouse input
 // against the Storybook iframe (the vitest story tests dispatch synthetic
@@ -8,6 +9,25 @@ import { at } from "../../lib/test-support/at";
 //   panel-a: [alpha, bravo, charlie, folder-f(f1), delta]
 //   panel-b: [xray, yankee]
 // with folder-f also mounted as its own panel.
+
+
+/**
+ * Press a trim handle and hold until the trim ARMS.
+ *
+ * On a VirtualStrip the surface pans, so a press on a handle does not begin an
+ * edit until it has settled — move first and the press is handed to the pan,
+ * which is the point (scrolling must not change a clip's duration). The
+ * threshold is the package's `TRIM_ARM_DELAY_MS`; this waits it out with room
+ * for a loaded CI machine.
+ *
+ * Panel and grid stories need no dwell: nothing pans there, so their trims stay
+ * instant — see `trimArmDelayFor`.
+ */
+async function pressTrimHandle(page: Page, x: number, y: number): Promise<void> {
+  await page.mouse.move(x, y);
+  await page.mouse.down();
+  await page.waitForTimeout(TRIM_ARM_DELAY_MS + 160);
+}
 
 const storyPath = (storyId: string) => `/iframe.html?id=${storyId}&viewMode=story`;
 const PLAYGROUND = 'ui-dndcollections--playground';
@@ -303,8 +323,7 @@ test.describe('DndCollections E2E', () => {
     const startX = handleBox!.x + handleBox!.width / 2;
     const startY = handleBox!.y + handleBox!.height / 2;
 
-    await page.mouse.move(startX, startY);
-    await page.mouse.down();
+    await pressTrimHandle(page, startX, startY);
     await page.mouse.move(startX + 48, startY, { steps: 12 });
     await page.waitForTimeout(150); // dwell: let the live preview settle
 
@@ -460,8 +479,7 @@ test.describe('DndCollections E2E', () => {
     const startX = hb.x + hb.width / 2;
     const startY = hb.y + hb.height / 2;
 
-    await page.mouse.move(startX, startY);
-    await page.mouse.down();
+    await pressTrimHandle(page, startX, startY);
     await page.mouse.move(startX - 48, startY, { steps: 12 }); // trim-in 3s -> 1s
     await page.waitForTimeout(150); // dwell
 
@@ -515,8 +533,7 @@ test.describe('DndCollections E2E', () => {
     const startX = hb.x + hb.width / 2;
     const startY = hb.y + hb.height / 2;
 
-    await page.mouse.move(startX, startY);
-    await page.mouse.down();
+    await pressTrimHandle(page, startX, startY);
     await page.mouse.move(startX + 48, startY, { steps: 12 }); // trim-in 3s -> 5s
     await page.waitForTimeout(150);
 
@@ -603,8 +620,7 @@ test.describe('DndCollections E2E', () => {
     const handleBox = (await leftHandle.boundingBox())!;
     const startX = handleBox.x + handleBox.width / 2;
     const startY = handleBox.y + handleBox.height / 2;
-    await page.mouse.move(startX, startY);
-    await page.mouse.down();
+    await pressTrimHandle(page, startX, startY);
     await page.mouse.move(startX - 48, startY, { steps: 10 });
 
     await expect.poll(async () => Math.round((await video.boundingBox())!.width)).toBe(240);

--- a/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
+++ b/apps/timeline-gstudio001/tests/e2e/graph-view.spec.ts
@@ -3,6 +3,10 @@ import { at } from "../../lib/test-support/at";
 import { compilePlaybackManifest } from "@storyboard/timeline-domain";
 import type { TimelineDocument } from "@storyboard/timeline-model/types";
 import { deriveClosureSummaries } from "../../lib/derive-collection-summaries";
+// Deep subpath, not the UI barrel: a file of plain numeric constants with no
+// React in it, so the spec can share the gesture thresholds it has to wait out
+// without pulling the component tree into the Playwright process.
+import { TRIM_ARM_DELAY_MS } from "@storyboard/ui/dnd-collections/react/gesture-thresholds";
 
 // E2E for the graph project view (/timeline/[projectId]/graph) — the REAL
 // Next app driven with real mouse input. The server surface the view touches
@@ -701,6 +705,28 @@ async function holdDragToPoint(
   await page.waitForTimeout(150); // dwell: let collision/intent settle
   await page.mouse.up();
   await page.waitForTimeout(80); // outlast dnd-kit's click suppressor
+}
+
+/**
+ * Press a trim handle and hold until the trim ARMS.
+ *
+ * On the strip the surface pans, so a press on a handle does not begin an edit
+ * until it has settled — move first and the press is handed to the pan, which
+ * is the whole point (a clip's duration must not change because someone
+ * scrolled). Real mouse input makes this the honest place to prove it: these
+ * are trusted events on the actual app, and the trim tests below would all be
+ * measuring the pan without this dwell.
+ *
+ * The wait DERIVES from the package's own threshold rather than repeating a
+ * number: it is being tuned by hand, and a settle frozen at an old value would
+ * quietly turn every trim assertion below into a scroll one. Trims through the
+ * OVERVIEW grips need no dwell — that panel floats outside the pannable
+ * surface and keeps instant trims.
+ */
+async function pressTrimHandle(page: Page, x: number, y: number): Promise<void> {
+  await page.mouse.move(x, y);
+  await page.mouse.down();
+  await page.waitForTimeout(TRIM_ARM_DELAY_MS + 160);
 }
 
 const undoButton = (page: Page): Locator => page.getByRole("button", { name: /undo/i });
@@ -1457,7 +1483,19 @@ test.describe("graph view E2E", () => {
       right: gutterBox.right - Number.parseFloat(gutterBox.padding[1]!),
     };
     const stripBox = await boxStyles(`[data-virtual-strip="${PROJECT_ID}"]`);
-    expect(stripBox.padding).toEqual(["0px", "0px", "0px", "0px"]);
+    // Top, right and left only. The BOTTOM edge carries a deliberate 6px
+    // (`pb-1.5` in graph-board): on a horizontal scroller, bottom padding is
+    // part of the scrollable area and lands above the scrollbar, so it is the
+    // gap between the filmstrip and its own bar — the cards used to sit
+    // directly on it. It cannot touch what this test is about, which is the
+    // HORIZONTAL claim that the surface's edges are the panel's gutter and
+    // nothing of its own insets them; the two `toBeCloseTo` checks below are
+    // that claim, and the zeroes here are how it is kept true.
+    expect([stripBox.padding[0], stripBox.padding[1], stripBox.padding[3]]).toEqual([
+      "0px",
+      "0px",
+      "0px",
+    ]);
     expect(stripBox.border).toEqual(["0px", "0px", "0px", "0px"]);
     expect(stripBox.left).toBeCloseTo(gutter.left, 1);
     expect(stripBox.right).toBeCloseTo(gutter.right, 1);
@@ -5381,8 +5419,7 @@ test.describe("graph view E2E", () => {
     await selectCard(alpha);
     const handle = wrapper.locator("[data-trim-handle]").last();
     const handleBox = (await handle.boundingBox())!;
-    await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2);
-    await page.mouse.down();
+    await pressTrimHandle(page, handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2);
     await page.mouse.move(handleBox.x - 30, handleBox.y + handleBox.height / 2, { steps: 6 });
     await page.mouse.up();
 
@@ -5436,8 +5473,7 @@ test.describe("graph view E2E", () => {
     // Trim the out edge in, which commits on release.
     const handle = wrapper.locator("[data-trim-handle]").last();
     const handleBox = (await handle.boundingBox())!;
-    await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2);
-    await page.mouse.down();
+    await pressTrimHandle(page, handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2);
     await page.mouse.move(handleBox.x - 40, handleBox.y + handleBox.height / 2, { steps: 6 });
     await page.mouse.up();
     await expect.poll(widthNow).toBeLessThan(original - 10);
@@ -5471,8 +5507,7 @@ test.describe("graph view E2E", () => {
     await selectCard(bravo);
     const bravoHandle = bravoWrapper.locator("[data-trim-handle]").last();
     const bravoBox = (await bravoHandle.boundingBox())!;
-    await page.mouse.move(bravoBox.x + bravoBox.width / 2, bravoBox.y + bravoBox.height / 2);
-    await page.mouse.down();
+    await pressTrimHandle(page, bravoBox.x + bravoBox.width / 2, bravoBox.y + bravoBox.height / 2);
     await page.mouse.move(bravoBox.x - 30, bravoBox.y + bravoBox.height / 2, { steps: 6 });
     await page.mouse.up();
     const bravoWidth = (await bravo.boundingBox())!.width;
@@ -5604,8 +5639,7 @@ test.describe("graph view E2E", () => {
 
     const handle = wrapper.locator("[data-trim-handle]").last();
     const box = (await handle.boundingBox())!;
-    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
-    await page.mouse.down();
+    await pressTrimHandle(page, box.x + box.width / 2, box.y + box.height / 2);
     await page.mouse.move(box.x - 24, box.y + box.height / 2, { steps: 6 });
 
     // The PANE was asked for the frame, and the floating panel stood down.
@@ -5693,6 +5727,59 @@ test.describe("graph view E2E", () => {
     expect(api.patchesFor(PROJECT_ID).length).toBe(patchesBefore);
   });
 
+  test("panning the strip from a trim handle scrolls instead of trimming", async ({ page }) => {
+    // THE REPORTED BUG, with the input that produced it: a real mouse, on the
+    // real strip, panning from a press that happened to land on a clip edge.
+    //
+    // Trim handles are 8px and always on with a mouse, so in a strip where
+    // clips sit flush every cut carries a 16px band. Panning is a plain drag
+    // anywhere on the surface. Those two were the same gesture on the same
+    // pixels, and the edge won every time — so scrolling the timeline silently
+    // shortened whichever clip you happened to start on.
+    //
+    // Only a trusted mouse proves this. The pan hook takes a real pointer
+    // capture and the handoff runs across two independent listener sets
+    // (native on the scroller, window from the gesture); a synthetic sequence
+    // exercises a different path through both.
+    await installGraphApi(page);
+    await openGraph(page);
+
+    const stripEl = strip(page, PROJECT_ID);
+    const alpha = stripEl.locator('[data-node-id="alpha"]');
+    const wrapper = stripEl.locator('[data-node-wrapper="alpha"]');
+    await selectCard(alpha);
+
+    const handle = wrapper.locator("[data-trim-handle]").last();
+    const handleBox = (await handle.boundingBox())!;
+    const widthBefore = (await alpha.boundingBox())!.width;
+    const scrollLeft = () => stripEl.evaluate((el: HTMLElement) => el.scrollLeft);
+    // The premise, stated so a fixture that stops overflowing fails HERE with
+    // a reason rather than below as a mysteriously unscrolled strip.
+    expect(
+      await stripEl.evaluate((el: HTMLElement) => el.scrollWidth - el.clientWidth),
+    ).toBeGreaterThan(80);
+    expect(await scrollLeft()).toBe(0);
+
+    // Press and GO — no dwell. This is the hand that was already moving.
+    const y = handleBox.y + handleBox.height / 2;
+    await page.mouse.move(handleBox.x + handleBox.width / 2, y);
+    await page.mouse.down();
+    await page.mouse.move(handleBox.x - 80, y, { steps: 8 });
+    await page.mouse.up();
+    await page.waitForTimeout(80); // outlast dnd-kit's click suppressor
+
+    // It scrolled, and it did not edit. The width is the assertion that
+    // matters: the card MOVED with the scroll, so position proves nothing,
+    // but only a trim can change how wide it is.
+    expect(await scrollLeft()).toBeGreaterThan(0);
+    expect((await alpha.boundingBox())!.width).toBeCloseTo(widthBefore, 0);
+    await expect(handle).not.toHaveAttribute("data-trim-armed", "true");
+
+    // And the pan did not open the clip on the way past either — the press
+    // began on a handle, whose preventDefault swallows the trailing click.
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+  });
+
   test("a trim drag floats the edge frame above the clip", async ({ page }) => {
     // PL10-005/007. The live frame is its own small surface: sized to the
     // breadcrumb row (a size reference, not a location — it follows the CLIP,
@@ -5710,8 +5797,7 @@ test.describe("graph view E2E", () => {
     // edge (the first is the front/in edge).
     const handle = wrapper.locator("[data-trim-handle]").last();
     const handleBox = (await handle.boundingBox())!;
-    await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2);
-    await page.mouse.down();
+    await pressTrimHandle(page, handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2);
     await page.mouse.move(handleBox.x - 24, handleBox.y + handleBox.height / 2, { steps: 6 });
 
     const frame = page.locator('[data-trim-edge-frame="right"]');
@@ -8935,8 +9021,7 @@ test.describe("graph view E2E", () => {
       // Left shortens by dragging RIGHT, right by dragging left.
       const dir = side === "left" ? 1 : -1;
 
-      await page.mouse.move(hb.x + hb.width / 2, y);
-      await page.mouse.down();
+      await pressTrimHandle(page, hb.x + hb.width / 2, y);
       const widths: number[] = [];
       for (const step of [20, 40]) {
         await page.mouse.move(hb.x + hb.width / 2 + dir * step, y, { steps: 3 });

--- a/packages/ui/dnd-collections/ARCHITECTURE.md
+++ b/packages/ui/dnd-collections/ARCHITECTURE.md
@@ -412,6 +412,38 @@ Everything semantic happens in `core/`.
   dimmed; the `DragOverlay` ghost carries a "+N" badge. The reducer sorts
   the set into document order and prunes ids whose ancestor is also moving.
 
+## Pointer arbitration on a pannable surface
+
+A `VirtualStrip` with `panToScroll` on has three gestures competing for one
+horizontal drag, and the rule between them is that **panning is the default
+and everything else has to declare itself**:
+
+- **Item drag.** From a grip bar it activates on distance; from a card body
+  in `itemDragActivation="hold"` it needs a still press of 250ms, and a fast
+  move cancels the pending activation and hands the press to the pan
+  (`CollectionsPointerSensor`).
+- **Trim.** A press on a handle publishes its zero-delta preview at once — it
+  shows a frame, which is not the same as beginning an edit — but does not
+  become an edit until it has settled for `TRIM_ARM_DELAY_MS` (200ms). Move
+  past `HOLD_DRAG_TOLERANCE_PX` first and the trim drops itself and the pan
+  takes over, one pixel later at `PAN_START_SLOP_PX`; those two constants are
+  defined one apart so the handoff can never leave both live or neither.
+  Arming sets `data-trim-armed` on the pressed element (content styles off it
+  through the hit zone's `group/trim`) and claims the pointer, which the pan
+  reads through `isGestureClaimed` and stands down for.
+- **Pan.** Anything else, past the slop.
+
+The dwell exists because trim handles are 8px at each clip edge and always on
+with a mouse, so in a strip where clips sit flush every cut carries a 16px
+band where a pan silently became an edit — the first thing that shipped here
+that could destroy work by accident. Which surfaces owe the dwell is asked of
+the DOM (`PAN_SURFACE_ATTR`, written by the view that installs the pan hook),
+not passed down: a handle in a panel or a grid has nothing to arbitrate
+against and keeps instant trims, and so does the overview panel, which floats
+outside the scroller. Coverage is
+`GestureArbitration.stories.tsx` plus a trusted-mouse e2e test, since the
+handoff runs across two independent listener sets and a real pointer capture.
+
 ## Click arbitration and the interaction policy
 
 A card's `onClick` only ever sees the residue the gesture pipeline leaves

--- a/packages/ui/dnd-collections/CustomItemContent.stories.tsx
+++ b/packages/ui/dnd-collections/CustomItemContent.stories.tsx
@@ -31,6 +31,7 @@ import {
   rectCenter,
   rectPoint,
   releaseAt,
+  TRIM_ARM_SETTLE_MS,
   waitForLayout,
 } from "./stories-helpers";
 
@@ -763,7 +764,7 @@ export const LiveTrimReadout: Story = {
       .querySelector<HTMLElement>('[data-trim-handle="right"]')!;
     const start = rectCenter(handle);
     await dispatchPointerSequence([
-      { element: handle, type: "pointerdown", clientX: start.x, clientY: start.y },
+      { element: handle, type: "pointerdown", clientX: start.x, clientY: start.y, delayAfterMs: TRIM_ARM_SETTLE_MS },
       { element: document, type: "pointermove", clientX: start.x - 24, clientY: start.y, delayAfterMs: 30 },
       { element: document, type: "pointermove", clientX: start.x - 48, clientY: start.y, delayAfterMs: 30 },
     ]);

--- a/packages/ui/dnd-collections/GestureArbitration.stories.tsx
+++ b/packages/ui/dnd-collections/GestureArbitration.stories.tsx
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { expect } from "storybook/test";
 
-import { buildGraph, parseNodeId, type GraphNodeSpec } from "./core/graph";
+import {
+  buildGraph,
+  mediaDurationSeconds,
+  parseNodeId,
+  type GraphNodeSpec,
+} from "./core/graph";
 import { DndCollections } from "./react/DndCollections";
 import { VirtualStrip } from "./virtual/VirtualStrip";
 import {
   dispatchPointerSequence,
   nodeCard,
   rectCenter,
+  TRIM_ARM_SETTLE_MS,
   waitForLayout,
 } from "./stories-helpers";
 
@@ -90,5 +96,144 @@ export const PanMovementCancelsPendingHoldDrag: Story = {
         clientY: start.y,
       },
     ]);
+  },
+};
+
+/** The right handle of `m1`, which in this strip is a plain image clip. */
+function trimHandle(canvasElement: HTMLElement): HTMLElement {
+  return nodeCard(canvasElement, "m1")
+    .closest("[data-node-wrapper]")!
+    .querySelector<HTMLElement>('[data-trim-handle="right"]')!;
+}
+
+/** Card width IS duration at this scale, so a trim shows up as a width. */
+const TRIM_PPS = 24;
+
+/**
+ * Trim handles need a TIME SCALE to exist — `trimPixelsPerSecond` is what
+ * turns pointer pixels into seconds — and `itemWidthFor` is what makes the
+ * strip draw clips at that scale instead of a fixed size. Twelve 4s clips at
+ * 24px/s is 1152px inside a 480px viewport, so there is room to pan and the
+ * scroll position means something.
+ */
+function TrimArbitrationStrip() {
+  return (
+    <DndCollections initialGraph={graph()} animateMoves={false}>
+      <div className="w-[480px]">
+        <VirtualStrip
+          collectionId={parseNodeId("strip")}
+          itemDragActivation="hold"
+          itemWidthFor={(node) =>
+            node.kind === "media" ? mediaDurationSeconds(node) * TRIM_PPS : undefined
+          }
+          trimPixelsPerSecond={TRIM_PPS}
+        />
+      </div>
+    </DndCollections>
+  );
+}
+
+/**
+ * THE BUG THIS PAIR EXISTS FOR: panning the strip changed a clip's duration.
+ *
+ * Trim handles are 8px at each clip edge and always on with a mouse, so in a
+ * flush strip every cut carries 16px where a press meant for the pan landed on
+ * an edit instead. The cursor was the only warning, and touch has none.
+ *
+ * Here the press starts ON the handle and moves straight away — the shape of a
+ * pan, not of an aim. The strip must scroll and the clip must come out exactly
+ * as wide as it went in.
+ */
+export const MovingOffATrimHandlePansInstead: Story = {
+  render: () => <TrimArbitrationStrip />,
+  play: async ({ canvasElement }) => {
+    const strip = canvasElement.querySelector<HTMLElement>('[data-virtual-strip="strip"]')!;
+    const card = nodeCard(canvasElement, "m1");
+    await waitForLayout(card);
+    const handle = trimHandle(canvasElement);
+    const start = rectCenter(handle);
+    const widthBefore = Math.round(card.getBoundingClientRect().width);
+
+    // Ten pixels, immediately: past the trim's 4px tolerance and past the
+    // pan's 5px slop, with no dwell in between for the handle to arm in.
+    await dispatchPointerSequence([
+      { element: handle, type: "pointerdown", clientX: start.x, clientY: start.y },
+      {
+        element: document,
+        type: "pointermove",
+        clientX: start.x - 10,
+        clientY: start.y,
+        delayAfterMs: 320,
+      },
+      {
+        element: document,
+        type: "pointerup",
+        clientX: start.x - 10,
+        clientY: start.y,
+        delayAfterMs: 40,
+      },
+    ]);
+
+    expect(strip.scrollLeft).toBeGreaterThan(0);
+    expect(handle.dataset.trimArmed).toBeUndefined();
+    // The card moved with the scroll, so measure the WIDTH, which a trim
+    // would have changed and a pan cannot.
+    expect(Math.round(nodeCard(canvasElement, "m1").getBoundingClientRect().width)).toBe(
+      widthBefore
+    );
+  },
+};
+
+/**
+ * The other half: a press that SETTLES on the handle still trims, and once it
+ * has, the pan stands down rather than scrolling underneath the edit.
+ */
+export const SettledTrimHandlePressStillTrims: Story = {
+  render: () => <TrimArbitrationStrip />,
+  play: async ({ canvasElement }) => {
+    const strip = canvasElement.querySelector<HTMLElement>('[data-virtual-strip="strip"]')!;
+    const card = nodeCard(canvasElement, "m1");
+    await waitForLayout(card);
+    const handle = trimHandle(canvasElement);
+    const start = rectCenter(handle);
+    const widthBefore = Math.round(card.getBoundingClientRect().width);
+
+    await dispatchPointerSequence([
+      // Hold still past the arm delay. The dwell is the whole gesture — take
+      // it out and this story becomes the one above.
+      {
+        element: handle,
+        type: "pointerdown",
+        clientX: start.x,
+        clientY: start.y,
+        delayAfterMs: TRIM_ARM_SETTLE_MS,
+      },
+      {
+        element: document,
+        type: "pointermove",
+        clientX: start.x - 40,
+        clientY: start.y,
+        delayAfterMs: 60,
+      },
+    ]);
+
+    expect(handle.dataset.trimArmed).toBe("true");
+
+    await dispatchPointerSequence([
+      {
+        element: document,
+        type: "pointerup",
+        clientX: start.x - 40,
+        clientY: start.y,
+        delayAfterMs: 60,
+      },
+    ]);
+
+    expect(Math.round(nodeCard(canvasElement, "m1").getBoundingClientRect().width)).toBeLessThan(
+      widthBefore
+    );
+    // The armed trim claimed the pointer, so the 40px never reached the pan.
+    expect(strip.scrollLeft).toBe(0);
+    expect(handle.dataset.trimArmed).toBeUndefined();
   },
 };

--- a/packages/ui/dnd-collections/VirtualStrip.stories.tsx
+++ b/packages/ui/dnd-collections/VirtualStrip.stories.tsx
@@ -27,6 +27,7 @@ import {
   nodeHandle,
   rectCenter,
   releaseAt,
+  TRIM_ARM_SETTLE_MS,
   waitForLayout,
 } from "./stories-helpers";
 
@@ -1167,7 +1168,7 @@ export const TrimMediaWithHandles: Story = {
       const y = r.top + r.height / 2;
       const x = r.left + r.width / 2;
       await dispatchPointerSequence([
-        { element: el, type: "pointerdown", clientX: x, clientY: y },
+        { element: el, type: "pointerdown", clientX: x, clientY: y, delayAfterMs: TRIM_ARM_SETTLE_MS },
         { element: document, type: "pointermove", clientX: x + dx, clientY: y, delayAfterMs: 30 },
       ]);
     };
@@ -1538,7 +1539,7 @@ export const LeftHandleGrowsLeft: Story = {
       const y = r.top + r.height / 2;
       const x = r.left + r.width / 2;
       await dispatchPointerSequence([
-        { element: el, type: "pointerdown", clientX: x, clientY: y },
+        { element: el, type: "pointerdown", clientX: x, clientY: y, delayAfterMs: TRIM_ARM_SETTLE_MS },
         { element: document, type: "pointermove", clientX: x + dx, clientY: y, delayAfterMs: 40 },
       ]);
     };
@@ -1622,7 +1623,7 @@ export const LeftHandleShrinkStaysAnchored: Story = {
       const y = r.top + r.height / 2;
       const x = r.left + r.width / 2;
       await dispatchPointerSequence([
-        { element: el, type: "pointerdown", clientX: x, clientY: y },
+        { element: el, type: "pointerdown", clientX: x, clientY: y, delayAfterMs: TRIM_ARM_SETTLE_MS },
         { element: document, type: "pointermove", clientX: x + dx, clientY: y, delayAfterMs: 40 },
       ]);
     };
@@ -1943,7 +1944,7 @@ export const PixelsPerSecondSizing: Story = {
       .querySelector<HTMLElement>('[data-trim-handle="right"]')!;
     const start = rectCenter(handleEl);
     await dispatchPointerSequence([
-      { element: handleEl, type: "pointerdown", clientX: start.x, clientY: start.y },
+      { element: handleEl, type: "pointerdown", clientX: start.x, clientY: start.y, delayAfterMs: TRIM_ARM_SETTLE_MS },
       { element: document, type: "pointermove", clientX: start.x - 48, clientY: start.y, delayAfterMs: 30 },
     ]);
     await waitFor(() => expect(width("vid")).toBe(192));
@@ -2081,7 +2082,7 @@ export const ConsumerFloorLivePreview: Story = {
     // Over-drag far past the floor and HOLD: the LIVE width clamps at the
     // consumer's 60px, not the package's 12px minimum.
     await dispatchPointerSequence([
-      { element: handleEl, type: "pointerdown", clientX: start.x, clientY: start.y },
+      { element: handleEl, type: "pointerdown", clientX: start.x, clientY: start.y, delayAfterMs: TRIM_ARM_SETTLE_MS },
       { element: document, type: "pointermove", clientX: start.x - 600, clientY: start.y, delayAfterMs: 30 },
     ]);
     await waitFor(() => expect(width()).toBe(60));
@@ -2192,7 +2193,7 @@ export const OverlayRidesLeftTrimTransform: Story = {
     // Grow left by 48px (trim-in 3s -> 1s): the content layer translates
     // -48 to anchor the right edge, and the playhead rides it.
     await dispatchPointerSequence([
-      { element: handleEl, type: "pointerdown", clientX: start.x, clientY: start.y },
+      { element: handleEl, type: "pointerdown", clientX: start.x, clientY: start.y, delayAfterMs: TRIM_ARM_SETTLE_MS },
       { element: document, type: "pointermove", clientX: start.x - 48, clientY: start.y, delayAfterMs: 40 },
     ]);
     await waitFor(() => expect(vidWidth()).toBe(9 * 24));

--- a/packages/ui/dnd-collections/react/gesture-thresholds.ts
+++ b/packages/ui/dnd-collections/react/gesture-thresholds.ts
@@ -3,3 +3,46 @@
 // delayed hold-to-drag activation is still pending.
 export const HOLD_DRAG_TOLERANCE_PX = 4;
 export const PAN_START_SLOP_PX = HOLD_DRAG_TOLERANCE_PX + 1;
+
+/**
+ * Marks a scroll container whose surface PANS on a plain press.
+ *
+ * Written by the view that installs the pan hook (VirtualStrip, when
+ * `panToScroll` is on) and read by the trim gesture, which needs the dwell
+ * below on exactly the surfaces where a press is ambiguous. One marker, set by
+ * the same condition that enables panning, so the two cannot drift apart —
+ * a strip with panning off keeps instant trims because there is nothing to
+ * arbitrate against.
+ */
+export const PAN_SURFACE_ATTR = "data-pan-surface";
+
+/**
+ * How long a press on a trim handle must SETTLE before it becomes a trim, on a
+ * surface that pans.
+ *
+ * The strip's law is that everything pans and anything else declares itself:
+ * a card body in hold mode is an item drag only after a still press, and a
+ * fast move hands it back to the pan. Trim handles were the one surface exempt
+ * from that — they committed on the raw pointerdown — so an 8px band at every
+ * clip edge (16px at every cut, where two clips sit flush) silently turned a
+ * pan into an edit. The cursor was the only warning, and touch does not have
+ * one.
+ *
+ * The bail-out is what makes this safe rather than merely slower: a press that
+ * moves past `HOLD_DRAG_TOLERANCE_PX` before this elapses drops the trim
+ * entirely, and the pan commits at `PAN_START_SLOP_PX` — one pixel later, by
+ * construction — so the handoff can never leave both live or neither.
+ *
+ * Shorter than hold-to-drag's 250ms on purpose. That delay guards picking a
+ * card UP, a bigger commitment than arming an edge, and trimming is the more
+ * frequent act of the two — the dwell is a tax on every deliberate trim, so it
+ * buys separation at the lowest price that still reads as a settle rather than
+ * a stutter. Tried at 1000ms by hand first, which made the two outcomes
+ * unmistakable and the gesture tiring; 200 is the value that keeps the
+ * separation without charging for it.
+ *
+ * This is the ONLY place the number lives — the story and e2e settles derive
+ * from it (`TRIM_ARM_SETTLE_MS` in stories-helpers, `pressTrimHandle` in
+ * graph-view.spec.ts), so tuning it cannot strand a suite on a stale wait.
+ */
+export const TRIM_ARM_DELAY_MS = 200;

--- a/packages/ui/dnd-collections/react/trim-gesture.ts
+++ b/packages/ui/dnd-collections/react/trim-gesture.ts
@@ -15,6 +15,11 @@ import {
 } from "../core/graph";
 import { type MediaUpdate } from "../core/commands";
 import { useCollectionsStore } from "./collections-store";
+import {
+  HOLD_DRAG_TOLERANCE_PX,
+  PAN_SURFACE_ATTR,
+  TRIM_ARM_DELAY_MS,
+} from "./gesture-thresholds";
 import { useLiveTrimPublisher } from "./live-trim";
 import { useTrimPreview, type LiveTrim } from "./trim-preview-context";
 
@@ -29,6 +34,37 @@ export type TrimSide = "left" | "right";
 
 function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(value, max));
+}
+
+/**
+ * Whether a trim currently OWNS the pointer, for the pan hook's
+ * `isGestureClaimed`.
+ *
+ * Module-scoped for the reason `interaction-policy`'s pending selection is:
+ * pointer gestures are serial. One primary pointer produces one press at a
+ * time, so there is never a second armed trim to track, and keeping the flag
+ * here means the pan can ask without either side holding a reference to the
+ * other.
+ */
+let armedTrimGesture = false;
+
+export function isTrimGestureArmed(): boolean {
+  return armedTrimGesture;
+}
+
+/**
+ * The dwell this press owes before it may trim: the full delay on a surface
+ * that pans, nothing anywhere else.
+ *
+ * Asked of the pressed element rather than passed in by each handle, so every
+ * trim surface — the card's edge handles, the overview's window grips, a
+ * consumer's own `CollectionItem.TrimHandle` — inherits the same law from
+ * where it is MOUNTED. A handle inside a pannable strip dwells; the same
+ * component in a panel or a grid stays instant, because there is no competing
+ * gesture there to protect.
+ */
+function trimArmDelayFor(target: Element): number {
+  return target.closest(`[${PAN_SURFACE_ATTR}]`) === null ? 0 : TRIM_ARM_DELAY_MS;
 }
 
 // Pointer trims capture CONTINUOUS pixels ((clientX - startX) / pps), so a raw
@@ -133,6 +169,15 @@ export function resolveMove(
  * delta-seconds to the update + live split; `onLive` is an optional hook for
  * local UI (e.g. the card's readout pill), called with the live split per
  * move and `null` on end.
+ *
+ * On a surface that PANS (see `trimArmDelayFor`) the press does not begin an
+ * edit until it has settled for `TRIM_ARM_DELAY_MS`: an early move drops the
+ * trim and lets the pan have the pointer, and arming publishes
+ * `data-trim-armed` on the pressed element so content can show that the next
+ * pull will trim. Arming is also where the zero-delta preview goes out, so a
+ * press that turns out to be a pan never sends the preview pane to an edge
+ * frame and back — nothing at all happens until the gesture has said what it
+ * is. Off a pannable surface arming is immediate and none of this is visible.
  */
 export function useTrimPointerDrag(
   node: MediaNode
@@ -170,19 +215,87 @@ export function useTrimPointerDrag(
       )
         return;
       activeCleanupRef.current?.();
-      // Keep the gesture off dnd-kit's item drag, the strip's pan, and (for
-      // an overview grip) the overview's own move handler.
+      // Keep the gesture off dnd-kit's item drag and (for an overview grip)
+      // the overview's own move handler. NOT off the pan: that listener is
+      // native and sits on the scroll container, an ancestor React dispatches
+      // BELOW, so it has already run by the time this does — which is exactly
+      // what the arbitration below needs. Both presses arm; only one survives.
+      //
+      // preventDefault stays unconditional and stays HERE, on the down. It is
+      // what suppresses the compatibility click, and so what keeps a trim from
+      // also opening the card it trimmed — and a click cannot be prevented
+      // after the fact, so deferring it until the gesture arms would be too
+      // late. A press that ends up a pan loses a click the pan would have
+      // squashed anyway.
       event.preventDefault();
       event.stopPropagation();
-      const startX = event.clientX;
       const pointerId = event.pointerId;
       const pointerTarget = event.currentTarget;
+      // The arm marker is written imperatively rather than through state: it
+      // lives for one press, and re-rendering the pressed card mid-gesture to
+      // paint it would cost more than it shows. Content styles off it (see
+      // `group/trim` on the hit zone in trim-handles.tsx).
+      const armTarget = pointerTarget instanceof HTMLElement ? pointerTarget : null;
+      const armDelayMs = trimArmDelayFor(pointerTarget);
+      const downX = event.clientX;
+      const downY = event.clientY;
+      // Where the trim measures its delta FROM. Re-baselined at arm time so a
+      // press that drifted inside the tolerance does not open with a jump.
+      let startX = downX;
+      let lastX = downX;
+      let armed = false;
+      let armTimer = 0;
       let pending: MediaUpdate | null = null;
       let finished = false;
-      try {
-        pointerTarget.setPointerCapture(pointerId);
-      } catch {
-        /* untrusted pointer (tests) — window listeners below suffice */
+
+      function arm() {
+        if (armed || finished) return;
+        armed = true;
+        if (armTimer) window.clearTimeout(armTimer);
+        armTimer = 0;
+        startX = lastX;
+        armedTrimGesture = true;
+        if (armTarget) armTarget.dataset.trimArmed = "true";
+        try {
+          pointerTarget.setPointerCapture(pointerId);
+        } catch {
+          /* untrusted pointer (tests) — window listeners below suffice */
+        }
+
+        // Publish the edge's CURRENT split at zero delta, so anything showing
+        // the live frame has something to show from the moment the gesture
+        // begins rather than from the first move.
+        //
+        // It matters most where it is least visible: the preview pane seeks to
+        // this frame, and a cold seek near the out point can take the better
+        // part of a second. Starting it here spends the pause while the user
+        // is still deciding where to drag, rather than at the start of the
+        // drag itself.
+        //
+        // ARMING, NOT THE PRESS, is where this belongs. It fired on
+        // pointerdown back when a press could only mean a trim — but a press
+        // that turns out to be a PAN would send the pane off to the edge frame
+        // and straight back, a visible flinch from a gesture that never
+        // touched the clip. The dwell is the moment the press says what it is,
+        // and the warm-up is worth just as much from here, because the drag
+        // still has not started.
+        //
+        // `pending` stays null deliberately. A press with no movement
+        // therefore still takes onUp's no-op branch — nothing dispatches, and
+        // the live preview clears on release exactly as an aborted gesture
+        // does. This shows a frame; it does not begin an edit.
+        const initial = resolve(0);
+        onLive?.(initial.live);
+        publishLive(node.id, initial.live);
+        trimPreview.previewTrim(node.id, initial.live);
+      }
+
+      function disarm() {
+        if (armTimer) window.clearTimeout(armTimer);
+        armTimer = 0;
+        armed = false;
+        armedTrimGesture = false;
+        if (armTarget) delete armTarget.dataset.trimArmed;
       }
 
       function removeListeners() {
@@ -208,6 +321,7 @@ export function useTrimPointerDrag(
       function abortGesture() {
         if (finished) return;
         finished = true;
+        disarm();
         removeListeners();
         releasePointerCapture();
         clearActiveCleanup(abortGesture);
@@ -223,6 +337,21 @@ export function useTrimPointerDrag(
       function onMove(moveEvent: PointerEvent) {
         // Ignore every pointer but the one that started this gesture.
         if (finished || moveEvent.pointerId !== pointerId) return;
+        if (!armed) {
+          // Still deciding. Movement past normal jitter means the hand was
+          // already travelling when it landed — a pan, not an aim — so the
+          // trim stands down and the pan (armed on the same press, one pixel
+          // further out) takes it. Distance, not axis: a diagonal press is
+          // not a trim either, and erring toward the pan is the safe way to
+          // be wrong.
+          if (Math.hypot(moveEvent.clientX - downX, moveEvent.clientY - downY) >
+            HOLD_DRAG_TOLERANCE_PX) {
+            abortGesture();
+            return;
+          }
+          lastX = moveEvent.clientX;
+          return;
+        }
         const { update, live } = resolve((moveEvent.clientX - startX) / pixelsPerSecond);
         pending = update;
         onLive?.(live);
@@ -234,6 +363,7 @@ export function useTrimPointerDrag(
         // A different pointer's release/cancel must not end this gesture.
         if (finished || upEvent.pointerId !== pointerId) return;
         finished = true;
+        disarm();
         removeListeners();
         releasePointerCapture();
         clearActiveCleanup(abortGesture);
@@ -259,29 +389,17 @@ export function useTrimPointerDrag(
         if (!dispatched.ok) trimPreview.previewTrim(node.id, null);
       }
 
-      // Publish the edge's CURRENT split immediately, at zero delta, so
-      // anything showing the live frame has something to show from the press
-      // rather than from the first move.
-      //
-      // It matters most where it is least visible: the preview pane seeks to
-      // this frame, and a cold seek near the out point can take the better
-      // part of a second. Starting that on pointerdown spends the pause while
-      // the user is still deciding where to drag, instead of at the start of
-      // the drag itself.
-      //
-      // `pending` stays null deliberately. A press with no movement therefore
-      // still takes onUp's no-op branch — nothing dispatches, and the live
-      // preview clears on release exactly as an aborted gesture does. This
-      // shows a frame; it does not begin an edit.
-      const initial = resolve(0);
-      onLive?.(initial.live);
-      publishLive(node.id, initial.live);
-      trimPreview.previewTrim(node.id, initial.live);
-
       activeCleanupRef.current = abortGesture;
       window.addEventListener("pointermove", onMove);
       window.addEventListener("pointerup", onUp);
       window.addEventListener("pointercancel", onUp);
+
+      // Off a pannable surface there is nothing to arbitrate against, so the
+      // press owns the pointer from the first pixel — the behaviour every trim
+      // surface had before the strip learned to pan. On one, it has to settle
+      // first; `onMove` above is what ends the wait early.
+      if (armDelayMs <= 0) arm();
+      else armTimer = window.setTimeout(arm, armDelayMs);
     },
     [node, store, trimPreview, publishLive]
   );

--- a/packages/ui/dnd-collections/react/trim-handles.tsx
+++ b/packages/ui/dnd-collections/react/trim-handles.tsx
@@ -34,10 +34,14 @@ export const DefaultTrimHandleContent = memo(function DefaultTrimHandleContent({
     <span
       className={[
         "flex h-full w-full items-center justify-center bg-blue-500 opacity-70 transition-opacity hover:opacity-100 group-hover:opacity-100",
+        // Armed: the press settled and the next pull trims. Full opacity is
+        // the smallest thing that reads as a state change without moving any
+        // geometry — the handle must not resize under the finger holding it.
+        "group-data-[trim-armed=true]/trim:opacity-100",
         side === "left" ? "rounded-l-md" : "rounded-r-md",
       ].join(" ")}
     >
-      <span className="h-4 w-0.5 rounded bg-black/45" />
+      <span className="h-4 w-0.5 rounded bg-black/45 transition-[height] group-data-[trim-armed=true]/trim:h-full" />
     </span>
   );
 });
@@ -56,7 +60,13 @@ export const DefaultTrimHandleContent = memo(function DefaultTrimHandleContent({
  * disagreeing about which one the touch meant.
  */
 const HIT_ZONE_CLASS =
-  "absolute inset-y-0 z-20 w-2 cursor-ew-resize " +
+  // `group/trim` is the seam for the ARMED state. On a pannable surface a
+  // press does not trim until it settles (see `trimArmDelayFor`), and the
+  // gesture writes `data-trim-armed` here when it does; content reads it as
+  // `group-data-[trim-armed=true]/trim:…`. Named so it cannot be confused with
+  // the card-level group content already uses for hover. Still shell-only —
+  // the shell publishes the state, content decides what it looks like.
+  "group/trim absolute inset-y-0 z-20 w-2 cursor-ew-resize " +
   "after:absolute after:inset-y-0 after:w-2 after:content-[''] " +
   "[@media(pointer:coarse)]:after:w-11";
 

--- a/packages/ui/dnd-collections/stories-helpers.ts
+++ b/packages/ui/dnd-collections/stories-helpers.ts
@@ -1,5 +1,7 @@
 import { expect, waitFor } from "storybook/test";
 
+import { TRIM_ARM_DELAY_MS } from "./react/gesture-thresholds";
+
 // Pointer simulation for dnd-kit's PointerSensor. `isPrimary: true` is
 // load-bearing: PointerSensor ignores non-primary pointers entirely, and
 // PointerEventInit defaults it to false — a sequence without it dispatches
@@ -43,6 +45,25 @@ export async function dispatchPointerSequence(steps: readonly PointerStep[]): Pr
     }
   }
 }
+
+/**
+ * How long a story must HOLD a trim-handle press before the trim arms.
+ *
+ * On a surface that PANS — any VirtualStrip with `panToScroll` on — a trim does
+ * not begin on the pointerdown. The press has to settle for
+ * `TRIM_ARM_DELAY_MS` or it is handed to the pan, because otherwise the two
+ * are the same horizontal drag on the same 8px of screen and the strip cannot
+ * tell which one was meant. A story that moves straight off a handle is
+ * therefore exercising the PAN — see
+ * `GestureArbitration.stories.tsx` › MovingOffATrimHandlePansInstead, which
+ * does exactly that on purpose.
+ *
+ * DERIVED, not typed out: the threshold is being tuned by hand, and a settle
+ * frozen at an old value would quietly turn every trim assertion into a scroll
+ * one. The margin is for a loaded machine, which must not be able to land
+ * inside the window.
+ */
+export const TRIM_ARM_SETTLE_MS = TRIM_ARM_DELAY_MS + 160;
 
 export async function waitForLayout(element: HTMLElement): Promise<void> {
   await waitFor(() => {

--- a/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
+++ b/packages/ui/dnd-collections/virtual/VirtualStrip.tsx
@@ -39,6 +39,8 @@ import {
 import { useCollectionsSelector, useCollectionsStore } from "../react/collections-store";
 import { findNodeElement, isEditableKeyboardTarget } from "../react/node-dom";
 import { NodeCard, type NodeCardDragActivation } from "../react/node-views";
+import { PAN_SURFACE_ATTR } from "../react/gesture-thresholds";
+import { isTrimGestureArmed } from "../react/trim-gesture";
 import { TrimOverviewStrip } from "../react/trim-overview";
 import { TrimPreviewContext, type LiveTrim, type TrimPreview } from "../react/trim-preview-context";
 import { useBackgroundSelectionClear } from "../react/use-background-clear";
@@ -124,8 +126,15 @@ function resolveStripIndex(key: string, current: number, count: number): number 
 // editable/opted-out targets the keyboard delegation defers to (inputs,
 // contenteditable, and anything marked data-collections-keyboard-ignore —
 // e.g. the graph's drill button) own their pointer gestures too.
+//
+// TRIM HANDLES PAN TOO, and that is the whole point of them being here. They
+// used to be excluded alongside the grip bars, which made an 8px band at every
+// clip edge — 16px at every cut, where two clips sit flush — a place where a
+// pan silently became an edit. Now both gestures arm on the same press and the
+// trim yields unless it settles (see `trimArmDelayFor`); the pan learns the
+// outcome through `isGestureClaimed` below.
 const isPannableStripSurface = (target: Element): boolean =>
-  !target.closest("[data-drag-handle], [data-trim-handle], [data-trim-overview]") &&
+  !target.closest("[data-drag-handle], [data-trim-overview]") &&
   !isEditableKeyboardTarget(target);
 const STRIP_PAN_DISABLED: PanWithMomentumOptions = { disabled: true };
 
@@ -1019,8 +1028,11 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
         panToScroll
           ? {
               shouldStartPan: isPannableStripSurface,
-              // Hold-to-drag can claim a press mid-slop; the pan stands down.
-              isGestureClaimed: () => store.getSnapshot().interaction.isDragging,
+              // Hold-to-drag can claim a press mid-slop; so can a trim handle
+              // that settled long enough to arm. Either way the pan stands
+              // down — it is the gesture that costs nothing to lose.
+              isGestureClaimed: () =>
+                store.getSnapshot().interaction.isDragging || isTrimGestureArmed(),
             }
           : STRIP_PAN_DISABLED,
       [panToScroll, store]
@@ -1426,6 +1438,10 @@ export const VirtualStrip = forwardRef<VirtualStripHandle, VirtualStripProps>(
           <div
             ref={setContainerRef}
             data-virtual-strip={collectionId}
+            // Tells the trim gesture that a plain press here means PAN unless
+            // it settles. Keyed off the same flag that installs the pan hook,
+            // so a strip with panning off keeps instant trims.
+            {...(panToScroll ? { [PAN_SURFACE_ATTR]: "" } : {})}
             // One-row grid: arrow keys rove across columns, and aria-colcount /
             // aria-colindex expose the true position ("column 500 of 1000") even
             // though only a handful of cells are mounted.


### PR DESCRIPTION
Trim handles were the one surface that began editing on the raw `pointerdown`, and the strip's pan was told to skip them. Handles are 8px and always on with a mouse, so in a strip where clips sit flush **every cut carried a 16px band where a press meant for the pan became an edit instead**. The cursor was the only warning, and touch has none.

## The fix

The strip's law is already *everything pans; anything else declares itself* — a card body in hold mode needs a still press, and a fast move hands it back to the pan. Trim was the exception. Now both gestures arm on the same press:

- Settle for `TRIM_ARM_DELAY_MS` (200ms) → the handle arms, claims the pointer, and the pan stands down via `isGestureClaimed`.
- Move past `HOLD_DRAG_TOLERANCE_PX` (4px) first → the trim drops itself and the pan takes over at `PAN_START_SLOP_PX` (5px). One pixel later **by construction**, so the handoff can never leave both live or neither.

Which surfaces owe the dwell is asked of the DOM (`PAN_SURFACE_ATTR`, written by whatever installs the pan hook) rather than passed down — so a handle in a grid or panel, and the overview panel floating outside the scroller, keep instant trims, and every trim surface inherits the law from where it is mounted.

Arming also carries the zero-delta preview now. It used to fire on the press, which was fine when a press could only mean a trim — but a press that turned out to be a pan sent the preview pane off to an edge frame and straight back.

## Appearance

With a moment to speak at, the handle no longer has to announce itself unaided: `white/85` on six edges becomes `zinc-400/45` at rest, going white with a full-height grip only once armed. The strip also gets 6px of bottom padding — on a horizontal scroller that lands above the scrollbar, which the cards were sitting directly on.

The delay lives in exactly one constant; the story and e2e settles derive from it, so retuning it cannot strand a suite on a stale wait.

## Verification

| Suite | Result |
| --- | --- |
| e2e `graph-view` (real mouse) | 176/176 |
| Storybook interaction | 298/298 |
| Unit | 797/797 |
| `tsc` (packages/ui + app), `eslint` | clean |

New coverage: two stories pinning the pair (press-and-go pans with the width unchanged; press-settle-pull trims with `scrollLeft` still 0) and a trusted-mouse e2e that pans 80px off a handle and asserts the clip does not change width — the handoff runs across two independent listener sets and a real pointer capture, which a synthetic sequence does not exercise.

One existing e2e asserted the strip had no padding on *any* edge. Its subject is the horizontal claim that the surface's edges are the panel's gutter, so it now checks top/right/left and documents why bottom is 6px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
