### PR TITLE
Holding the ball at an edge runs the strip under it

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -160,6 +160,31 @@ const LONG_SCENE: GraphNodeSpec = {
   })),
 };
 
+/**
+ * A collection whose TIMELINE IS WIDER THAN THE BAR THAT DRAWS IT.
+ *
+ * `LONG_SCENE` has plenty of clips but only ~63s of them, and the bar draws at
+ * a fixed 9px a second — so its whole strip fits inside the track with room to
+ * spare, and both ends of the rail already point past the end of the footage.
+ * Nothing about running out of track can be shown on it.
+ *
+ * 30 clips of 8s is 240s, or ~2160px of strip against a track of well under a
+ * thousand — so most of the order is off the side at any moment, which is the
+ * only condition under which "hold the ball at the edge" means anything.
+ */
+const OVERFLOWING_SCENE: GraphNodeSpec = {
+  kind: "collection",
+  id: "root",
+  name: "Root",
+  children: Array.from({ length: 30 }, (_, index) => ({
+    kind: "media" as const,
+    id: index === 15 ? "subject" : `clip-${index}`,
+    name: index === 15 ? "Subject" : `Clip ${index}`,
+    src: plate(String(index), `hsl(${index * 11}, 60%, 70%)`),
+    durationSeconds: 8,
+  })),
+};
+
 function graphOfRoot(root: GraphNodeSpec): CollectionsGraph {
   const result = buildGraph([root]);
   if (!result.ok) throw new Error(JSON.stringify(result.error));
@@ -1465,5 +1490,102 @@ export const PlayingFromANeighbourRunsItOnTheMonitor: Story = {
     );
     expect(at()).toBeGreaterThanOrEqual(6);
     expect(playOf(panels()[2]!).getAttribute("aria-label")).toMatch(/^Play /);
+  },
+};
+
+/**
+ * HOLDING THE BALL AT AN EDGE RUNS THE STRIP UNDER IT.
+ *
+ * The rail spans what is ON SCREEN, not what exists: on a collection longer
+ * than the bar, the end of the rail was the end of the timeline you could
+ * reach, and the rest of the order sat an inch off the side of the track with
+ * no way to scrub into it. You could step to it with the arrows or push the
+ * boxes there by hand first, both of which mean abandoning the drag you are
+ * in the middle of.
+ *
+ * So the two ends of the rail are a throttle. Hold the ball inside 40px of
+ * the right edge and the strip travels forward underneath it; hold it at the
+ * left and it reverses. THE HAND DOES NOT MOVE during any of that, which is
+ * why this is a frame loop and not something hung off pointermove — an
+ * implementation reading the moves travels only while the hand jitters.
+ *
+ * Four claims, and the last two are the ones that make it a control rather
+ * than a hazard: the middle of the rail does nothing, and letting go stops it.
+ */
+export const HoldingTheBallAtAnEdgeRunsTheStrip: Story = {
+  render: () => <SeamHarness scene={OVERFLOWING_SCENE} />,
+  play: async () => {
+    const at = () => Number(seamTrack().getAttribute("aria-valuenow"));
+    const stripLeft = () =>
+      document.querySelector<HTMLElement>("[data-seam-strip]")!.getBoundingClientRect().left;
+
+    const press = (clientX: number) => {
+      const rail = seamRail();
+      const box = rail.getBoundingClientRect();
+      fireEvent.pointerDown(rail, {
+        clientX,
+        clientY: box.top + box.height / 2,
+        isPrimary: true,
+        pointerId: 1,
+        button: 0,
+      });
+    };
+    const release = () => {
+      const rail = seamRail();
+      const box = rail.getBoundingClientRect();
+      fireEvent.pointerUp(rail, {
+        clientX: box.left + box.width / 2,
+        clientY: box.top + box.height / 2,
+        isPrimary: true,
+        pointerId: 1,
+        button: 0,
+      });
+    };
+    const rest = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+    await waitFor(() => expect(document.querySelector("[data-seam-strip]")).not.toBeNull());
+    await settleStrip();
+
+    // THE PRECONDITION THIS STORY IS ABOUT. If the strip fitted in the track
+    // there would be nothing off the side to reach, and every assertion below
+    // would pass for the wrong reason.
+    const railWidth = seamRail().getBoundingClientRect().width;
+    const totalPx = Number(seamTrack().getAttribute("aria-valuemax")) * 9;
+    expect(totalPx).toBeGreaterThan(railWidth * 1.5);
+
+    // ── THE MIDDLE OF THE RAIL IS AN ORDINARY SCRUBBER ────────────────────
+    const railBox = seamRail().getBoundingClientRect();
+    press(railBox.left + railBox.width / 2);
+    const middleT = at();
+    const middleX = stripLeft();
+    await rest(300);
+    expect(at()).toBe(middleT);
+    expect(stripLeft()).toBe(middleX);
+    release();
+
+    // ── THE RIGHT EDGE RUNS FORWARD ───────────────────────────────────────
+    press(railBox.right - 12);
+    const startedAt = at();
+    const startedX = stripLeft();
+    await waitFor(() => expect(at()).toBeGreaterThan(startedAt + 2), { timeout: 2000 });
+    // The clock advanced BECAUSE THE STRIP MOVED, not because the press
+    // landed further along: the boxes travelled left under a stationary hand.
+    expect(stripLeft()).toBeLessThan(startedX - 20);
+
+    // ── LETTING GO STOPS IT ───────────────────────────────────────────────
+    release();
+    const stoppedAt = at();
+    const stoppedX = stripLeft();
+    await rest(300);
+    expect(at()).toBe(stoppedAt);
+    expect(stripLeft()).toBe(stoppedX);
+
+    // ── AND THE LEFT EDGE REVERSES ────────────────────────────────────────
+    press(railBox.left + 12);
+    const backFrom = at();
+    const backFromX = stripLeft();
+    await waitFor(() => expect(at()).toBeLessThan(backFrom - 2), { timeout: 2000 });
+    expect(stripLeft()).toBeGreaterThan(backFromX + 20);
+    release();
   },
 };

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -68,6 +68,36 @@ const BOX_INSET_PX = 2.5;
 /** Travel that turns a press on the boxes from a click into a pan. */
 const CLICK_SLOP_PX = 4;
 
+/**
+ * How near an end of the track the ball has to get before the strip starts
+ * travelling under it, and how fast it goes when it does.
+ *
+ * The speed ramps with depth into the zone rather than being a constant, so
+ * the edge is a throttle and not a switch: a ball resting just inside it
+ * creeps along at a readable pace, one pushed hard against the very end runs
+ * at `MAX`, and the two are the same gesture at different depths. At a flat
+ * speed the only way to travel a little would be to touch the edge and
+ * immediately back off, which is a flinch rather than a control.
+ */
+const EDGE_PAN_ZONE_PX = 40;
+const EDGE_PAN_MAX_PX_PER_FRAME = 16;
+const EDGE_PAN_GAIN = 0.4;
+
+/**
+ * How fast the strip should travel for a ball at `clientX`, in px per frame.
+ *
+ * Positive means the strip moves LEFT — later clips come in from the right,
+ * which is the direction the ball is being pushed. Zero anywhere but the two
+ * zones, so the ordinary middle of the rail is an ordinary scrubber.
+ */
+function edgePanVelocity(clientX: number, rail: DOMRect): number {
+  const intoLeft = rail.left + EDGE_PAN_ZONE_PX - clientX;
+  if (intoLeft > 0) return -Math.min(EDGE_PAN_MAX_PX_PER_FRAME, intoLeft * EDGE_PAN_GAIN);
+  const intoRight = clientX - (rail.right - EDGE_PAN_ZONE_PX);
+  if (intoRight > 0) return Math.min(EDGE_PAN_MAX_PX_PER_FRAME, intoRight * EDGE_PAN_GAIN);
+  return 0;
+}
+
 export function SeamStripBar({
   strip,
   centreClipId,
@@ -106,7 +136,6 @@ export function SeamStripBar({
 }>) {
   const trackRef = useRef<HTMLDivElement | null>(null);
   const [trackWidth, setTrackWidth] = useState(0);
-  const [dragging, setDragging] = useState(false);
 
   // The container's width is half the centring arithmetic, so it has to be
   // measured rather than assumed — and re-measured, because the view count
@@ -250,6 +279,10 @@ export function SeamStripBar({
 
   const [scrubbing, setScrubbing] = useState(false);
 
+  // Read out as primitives: the loop below depends on them, and `strip` is
+  // rebuilt by the view on every render.
+  const { totalPx, pxPerSecond } = strip;
+
   // THE RAIL SHARES THE STRIP'S COORDINATES, which is what makes the ball sit
   // under the playhead.
   //
@@ -271,6 +304,63 @@ export function SeamStripBar({
     },
     [strip, offset],
   );
+
+  // Where the ball was last seen, so the frame loop below can keep working a
+  // hand that has stopped moving.
+  const scrubXRef = useRef(0);
+
+  // MIRRORS, so the frame loop can read live values without listing them as
+  // dependencies and restarting itself. `onScrubSeconds` is an inline arrow in
+  // the view, so it is a new function on every render — depending on it would
+  // tear down and re-arm the loop between every pair of frames.
+  const panPxRef = useRef<number | null>(null);
+  const centredOffsetRef = useRef(0);
+  const onScrubSecondsRef = useRef(onScrubSeconds);
+  useEffect(() => {
+    panPxRef.current = panPx;
+    centredOffsetRef.current = centredOffset;
+    onScrubSecondsRef.current = onScrubSeconds;
+  });
+
+  // ── HOLDING THE BALL AT AN EDGE RUNS THE STRIP UNDER IT ─────────────────
+  //
+  // The rail only spans what is on screen, so without this the end of the
+  // rail is the end of the timeline you can reach: push the ball against the
+  // right edge and the scrub simply stops, with the rest of the order sitting
+  // an inch off the side of the track. Now holding it there pulls the strip
+  // along underneath — forward at the right edge, back at the left — and the
+  // seek follows the clips that arrive, so one gesture crosses the whole
+  // collection instead of the window you happened to open on.
+  //
+  // A FRAME LOOP RATHER THAN THE POINTER MOVES, because the hand is STILL.
+  // The gesture is holding the ball against an edge, which fires no further
+  // pointermove events at all — an implementation hung off the moves would
+  // travel only while the hand jittered, which is precisely the wrong feel.
+  useEffect(() => {
+    if (!scrubbing || pxPerSecond <= 0) return;
+    let frame = requestAnimationFrame(function tick() {
+      frame = requestAnimationFrame(tick);
+      const rail = railRef.current;
+      if (rail === null) return;
+      const box = rail.getBoundingClientRect();
+      const velocity = edgePanVelocity(scrubXRef.current, box);
+      if (velocity === 0) return;
+
+      const next = (panPxRef.current ?? centredOffsetRef.current) - velocity;
+      // IT STOPS AT THE ENDS BY ASKING WHERE THE BALL NOW POINTS, not by
+      // clamping the transform. The offset that puts the last clip under the
+      // ball is a function of the pan, the track width and the scale, and the
+      // one number that actually has to stay in range is the time being
+      // scrubbed to — so that is the number the guard is written against.
+      const stripX = scrubXRef.current - box.left - next;
+      if (stripX < 0 || stripX > totalPx) return;
+
+      panPxRef.current = next;
+      setPanPx(next);
+      onScrubSecondsRef.current(stripX / pxPerSecond);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [scrubbing, pxPerSecond, totalPx]);
 
   const releaseScrub = useCallback(() => {
     setScrubbing(false);
@@ -366,7 +456,11 @@ export function SeamStripBar({
             // pointer move started a 260ms animation toward a target the next
             // move replaced, so the strip lagged the hand and — measured — a
             // second shove inside that window looked like no movement at all.
-            transition: panning ? "none" : "transform 260ms cubic-bezier(0.22, 0.61, 0.36, 1)",
+            // Off for a scrub as well as a pan: the edge loop moves the strip
+            // every frame, and a 260ms ease toward a target the next frame
+            // replaces is the same lag the pan had, one gesture over.
+            transition:
+              panning || scrubbing ? "none" : "transform 260ms cubic-bezier(0.22, 0.61, 0.36, 1)",
           }}
         >
           {strip.segments.map((segment) => {
@@ -454,6 +548,7 @@ export function SeamStripBar({
             } catch {
               /* untrusted pointer (stories) — the moves still arrive here */
             }
+            scrubXRef.current = event.clientX;
             setScrubbing(true);
             onScrubbingChange?.(true);
             const at = secondsAt(event.clientX);
@@ -461,6 +556,9 @@ export function SeamStripBar({
           }}
           onPointerMove={(event) => {
             if (!scrubbing) return;
+            // Recorded on every move so the frame loop keeps travelling after
+            // the hand stops — the edge gesture is a HOLD, not a drag.
+            scrubXRef.current = event.clientX;
             const at = secondsAt(event.clientX);
             if (at !== null) onScrubSeconds(at);
           }}


### PR DESCRIPTION
## What

The scrubber's rail spans what is **on screen**, not what exists. On a collection longer than the bar draws — anything past ~90s at 9px a second — the end of the rail was the end of the timeline you could reach, and the rest of the order sat off the side of the track with no way to scrub into it.

Now the two ends of the rail are a throttle. Hold the ball inside 40px of the right edge and the strip travels **forward** underneath it; hold it at the left and it **reverses**. Speed ramps with depth into the zone, so a ball resting just inside creeps and one against the very end runs.

## How

A **frame loop**, not the pointer moves — the hand is *still*, so the gesture fires no further `pointermove` events at all and an implementation reading the moves would travel only while the hand jittered.

It stops at the ends by asking where the ball now points rather than by clamping the transform: the offset that puts the last clip under the ball depends on the pan, the track width and the scale, and the one number that has to stay in range is the time being scrubbed to.

## Measured

30-clip / 240s fixture, rail 797px against 2160px of strip (63% of the order off-screen at any moment):

| | clock | strip x |
| --- | --- | --- |
| right edge, hand stationary | 162.79s → 165.28s | −516 → −538 (22px left) |
| left edge, hand stationary | 79.38s → 76.89s | −538 → −516 (22px right) |
| 300ms after release | 0s drift | 0px drift |
| 300ms holding mid-rail | 0s | 0px |

22px ÷ 9px-per-second = 2.44s — the clock moved *because the strip did*, which is the claim.

Covered by `HoldingTheBallAtAnEdgeRunsTheStrip`. Full details-modal story file: 23/23. tsc clean, lint 0 errors.

Also drops a dead `dragging` useState that nothing read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)