### PR TITLE
Make the bar behave like the playbar-redesign artifact

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -1716,6 +1716,32 @@ export const TheWheelPansAndZoomsAboutThePointer: Story = {
     });
     await waitFor(() => expect(pps()).toBeLessThan(zoomedIn * 0.9));
     expect(Math.abs(secondsUnder(anchor) - heldSecond)).toBeLessThan(0.05);
+
+    // ── AND THE STRIP CANNOT BE THROWN AWAY ───────────────────────────────
+    //
+    // A native scroller clamps for free; a transform does not. Twenty hard
+    // notches one way and twenty back is a firm two-finger flick in each
+    // direction, and neither may end with the bar empty and the strip
+    // somewhere off the side of the track.
+    const strip = document.querySelector<HTMLElement>("[data-seam-strip]")!;
+    const stillOnScreen = () => {
+      const s = strip.getBoundingClientRect();
+      const t = seamTrack().getBoundingClientRect();
+      return Math.min(s.right, t.right) - Math.max(s.left, t.left);
+    };
+    for (const direction of [1, -1]) {
+      for (let notch = 0; notch < 20; notch += 1) {
+        fireEvent.wheel(surface, {
+          deltaY: 600 * direction,
+          clientX: anchor,
+          clientY: box.top + 4,
+        });
+      }
+      await waitFor(() => expect(stillOnScreen()).toBeGreaterThan(0));
+      // Not a sliver, either: half the track is the far end of the clamp, so
+      // there is always something to grab hold of and read.
+      expect(stillOnScreen()).toBeGreaterThan(box.width * 0.4);
+    }
   },
 };
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -185,6 +185,47 @@ const OVERFLOWING_SCENE: GraphNodeSpec = {
   })),
 };
 
+/**
+ * TWO COLLECTIONS, LONG ENOUGH TO NEED A WINDOW.
+ *
+ * Two rooms of twelve six-second shots. The bar opens fitted to the
+ * collection you are in, so 72s across the track puts the other 72 off the
+ * sides — which is the condition every claim about panning, zooming, the
+ * minimap and the edges is actually about. The two names are what the ruler
+ * and the dividers have to find.
+ */
+const TWO_ROOMS_SCENE: GraphNodeSpec = {
+  kind: "collection",
+  id: "root",
+  name: "Root",
+  children: [
+    {
+      kind: "collection",
+      id: "kitchen",
+      name: "Kitchen Interior",
+      children: Array.from({ length: 12 }, (_, index) => ({
+        kind: "media" as const,
+        id: index === 6 ? "subject" : `kitchen-${index}`,
+        name: index === 6 ? "Subject" : `Kitchen ${index}`,
+        src: plate(`K${index}`, `hsl(${index * 13}, 60%, 70%)`),
+        durationSeconds: 6,
+      })),
+    },
+    {
+      kind: "collection",
+      id: "dock",
+      name: "Loading Dock",
+      children: Array.from({ length: 12 }, (_, index) => ({
+        kind: "media" as const,
+        id: `dock-${index}`,
+        name: `Dock ${index}`,
+        src: plate(`D${index}`, `hsl(${180 + index * 13}, 60%, 70%)`),
+        durationSeconds: 6,
+      })),
+    },
+  ],
+};
+
 function graphOfRoot(root: GraphNodeSpec): CollectionsGraph {
   const result = buildGraph([root]);
   if (!result.ok) throw new Error(JSON.stringify(result.error));
@@ -276,17 +317,16 @@ type Story = StoryObj<typeof GraphItemDetailsModal>;
 /**
  * ── AIMING AT THE BAR ─────────────────────────────────────────────────────
  *
- * The bar has two surfaces and they do different things, which is why these
- * helpers exist rather than a single "click the bar".
+ * ONE SURFACE NOW. The boxes ARE the scrubber: a drag across them puts the
+ * playhead where you point, and there is no separate rail underneath. What
+ * were two helpers aimed at two surfaces are now two ways of describing the
+ * same gesture.
  *
- * The BOXES are a filmstrip you push: a swipe there moves the carousel three
- * clips. Pressing one does nothing at all — it used to scrub, and several of
- * the stories below were written against that.
- *
- * The RAIL underneath is the scrubber. It spans the whole timeline linearly,
- * and so does the strip of boxes, so a clip's position is the SAME fraction of
- * both — which is what lets `scrubIntoBox` say "scrub to that clip" while
- * driving the control that actually scrubs.
+ * THE DISTINCTION THAT MATTERS IS TRAVEL, not position. A press that does not
+ * move is a CLICK, and a click commits to a clip; a press that moves more than
+ * a few pixels is a SCRUB, and a scrub commits to nothing. So every scrub
+ * helper here deliberately travels, and a story that wants the click has to
+ * ask for it — see `clickBox`.
  */
 function seamTrack(): HTMLElement {
   const found = document.querySelector<HTMLElement>("[data-seam-track]");
@@ -294,10 +334,51 @@ function seamTrack(): HTMLElement {
   return found!;
 }
 
-function seamRail(): HTMLElement {
-  const found = document.querySelector<HTMLElement>("[data-seam-rail]");
+/** The surface every gesture on the bar lands on. */
+function seamSurface(): HTMLElement {
+  const found = document.querySelector<HTMLElement>("[data-seam-boxes]");
   expect(found).not.toBeNull();
   return found!;
+}
+
+function pointerAt(clientX: number, clientY: number) {
+  return { clientX, clientY, isPrimary: true, pointerId: 1, button: 0 };
+}
+
+/**
+ * Drag the playhead to `clientX`.
+ *
+ * Approaches from `travelFrom` px away so the press registers as a drag: the
+ * bar tells a scrub from a click by distance travelled, and a helper that
+ * pressed and released on one pixel would be asking for the other gesture
+ * entirely. `hold` leaves the pointer down, for the stories about what happens
+ * DURING a drag.
+ */
+function scrubToClientX(clientX: number, options?: { hold?: boolean; travelFrom?: number }): void {
+  const surface = seamSurface();
+  const box = surface.getBoundingClientRect();
+  const y = box.top + box.height / 2;
+  const from = clientX - (options?.travelFrom ?? 12);
+  fireEvent.pointerDown(surface, pointerAt(from, y));
+  fireEvent.pointerMove(surface, pointerAt(clientX, y));
+  if (options?.hold === true) return;
+  fireEvent.pointerUp(surface, pointerAt(clientX, y));
+}
+
+/** Let go of a held scrub, wherever the pointer was left. */
+function releaseScrub(clientX: number): void {
+  const surface = seamSurface();
+  const box = surface.getBoundingClientRect();
+  fireEvent.pointerUp(surface, pointerAt(clientX, box.top + box.height / 2));
+}
+
+/** Press a box WITHOUT travelling, which is how you commit to a clip. */
+function clickBox(box: HTMLElement): void {
+  const surface = seamSurface();
+  const target = box.getBoundingClientRect();
+  const args = pointerAt(target.left + target.width / 2, target.top + target.height / 2);
+  fireEvent.pointerDown(surface, args);
+  fireEvent.pointerUp(surface, args);
 }
 
 /** Every clip's box, in timeline order. */
@@ -312,40 +393,22 @@ function centreBox(): HTMLElement {
   return found!;
 }
 
-/** Press the rail at `fraction` of the way along the timeline. */
-function scrubToFraction(fraction: number): void {
-  const rail = seamRail();
-  const box = rail.getBoundingClientRect();
-  const args = {
-    clientX: box.left + box.width * Math.min(Math.max(fraction, 0), 1),
-    clientY: box.top + box.height / 2,
-    isPrimary: true,
-    pointerId: 1,
-    button: 0,
-  };
-  fireEvent.pointerDown(rail, args);
-  fireEvent.pointerUp(rail, args);
-}
-
 /**
  * Wait until the strip has stopped moving.
  *
- * The strip eases to a new position over 260ms whenever the subject changes,
- * and `scrubIntoBox` reads a box's position ON SCREEN while the rail converts
- * through the strip's FINAL offset. Measure mid-animation and those two
- * disagree by however far the strip still has to travel — which showed up as
- * scrubs landing at zero, because the mismatch pushed the target off the
+ * A change of subject can nudge the bar to bring the new clip into view, and
+ * `scrubIntoBox` reads a box's position ON SCREEN. Measure mid-move and the
+ * two disagree by however far the strip still has to travel — which showed up
+ * as scrubs landing at zero, because the mismatch pushed the target off the
  * front of the timeline and the clamp caught it.
  */
 async function settleStrip(): Promise<void> {
   const strip = document.querySelector<HTMLElement>("[data-seam-strip]");
   expect(strip).not.toBeNull();
-  // PAST THE TRANSITION FIRST, then confirm. Watching alone is not enough
-  // under load: the poll can take two readings before the animation has even
+  // PAST ANY TRANSITION FIRST, then confirm. Watching alone is not enough
+  // under load: the poll can take two readings before the movement has even
   // started, agree with itself, and report a strip that is about to move as
-  // settled. That is exactly how these passed alone and failed in the full
-  // run. The dwell clears the 260ms transition; the watch below then covers a
-  // machine slow enough for that not to be sufficient.
+  // settled. That is exactly how these passed alone and failed in the full run.
   await new Promise((resolve) => setTimeout(resolve, 320));
   let previous = Number.NaN;
   await waitFor(
@@ -362,26 +425,14 @@ async function settleStrip(): Promise<void> {
 /**
  * Scrub to a point inside `box`, `within` of the way across that clip.
  *
- * Press the rail at the BOX'S OWN x. The rail reads through the strip's
- * transform — that is what makes the ball sit under the playhead — so the two
- * share a horizontal coordinate space and a clip is at the same x on both. An
- * earlier version converted to a fraction of the timeline and pressed there,
- * which was right while the rail was a proportional slider and silently
- * scrubbed to the wrong clip once it stopped being one.
+ * Aim at the BOX'S OWN x: the pointer and the boxes share a client coordinate
+ * space, so a clip is at the same place on both and no conversion through the
+ * strip's transform is needed — which is what makes this survive a pan and a
+ * zoom that a fraction-of-the-timeline version would not.
  */
 function scrubIntoBox(box: HTMLElement, within = 0.5): void {
-  const rail = seamRail();
-  const railBox = rail.getBoundingClientRect();
   const target = box.getBoundingClientRect();
-  const args = {
-    clientX: target.left + target.width * within,
-    clientY: railBox.top + railBox.height / 2,
-    isPrimary: true,
-    pointerId: 1,
-    button: 0,
-  };
-  fireEvent.pointerDown(rail, args);
-  fireEvent.pointerUp(rail, args);
+  scrubToClientX(target.left + target.width * within);
 }
 
 /** Swipe the boxes, which moves the carousel three clips at a time. */
@@ -1259,28 +1310,23 @@ export const TheMonitorGrowsWhileScrubbing: Story = {
     await waitFor(() => expect(widest.getAttribute("aria-pressed")).toBe("true"));
 
     const centre = () => document.querySelector<HTMLElement>('[data-item-details-panel="centre"]')!;
-    const rail = seamRail();
     const width = () => Math.round(centre().getBoundingClientRect().width);
 
     const resting = width();
     expect(centre().hasAttribute("data-item-details-magnified")).toBe(false);
 
-    const box = rail.getBoundingClientRect();
-    const args = {
-      clientX: box.left + box.width * 0.5,
-      clientY: box.top + box.height / 2,
-      isPrimary: true,
-      pointerId: 1,
-      button: 0,
-    };
-    fireEvent.pointerDown(rail, args);
+    // The middle of the track, held: the gesture is the drag, so the monitor
+    // has to be up for as long as the pointer is down and not a moment past.
+    const surface = seamSurface().getBoundingClientRect();
+    const middle = surface.left + surface.width * 0.5;
+    scrubToClientX(middle, { hold: true });
 
     // Bigger, and marked as such.
     await waitFor(() => expect(centre().hasAttribute("data-item-details-magnified")).toBe(true));
     await waitFor(() => expect(width()).toBeGreaterThan(resting + 10));
 
     // And back down when the drag ends — this is the gesture, not a mode.
-    fireEvent.pointerUp(rail, args);
+    releaseScrub(middle);
     await waitFor(() => expect(centre().hasAttribute("data-item-details-magnified")).toBe(false));
     await waitFor(() => expect(width()).toBe(resting));
 
@@ -1288,10 +1334,10 @@ export const TheMonitorGrowsWhileScrubbing: Story = {
     const neighbours = Array.from(
       document.querySelectorAll('[data-item-details-panel="neighbour"]'),
     );
-    fireEvent.pointerDown(rail, args);
+    scrubToClientX(middle, { hold: true });
     await waitFor(() => expect(centre().hasAttribute("data-item-details-magnified")).toBe(true));
     expect(neighbours.some((n) => n.hasAttribute("data-item-details-magnified"))).toBe(false);
-    fireEvent.pointerUp(rail, args);
+    releaseScrub(middle);
   },
 };
 
@@ -1420,7 +1466,6 @@ export const PlayingFromANeighbourRunsItOnTheMonitor: Story = {
     fireEvent.click(three);
     await waitFor(() => expect(three.getAttribute("aria-pressed")).toBe("true"));
 
-    const rail = seamRail();
     const at = () => Number(seamTrack().getAttribute("aria-valuenow"));
     const panels = () =>
       Array.from(document.querySelectorAll<HTMLElement>("[data-item-details-panel]"));
@@ -1494,98 +1539,433 @@ export const PlayingFromANeighbourRunsItOnTheMonitor: Story = {
 };
 
 /**
- * HOLDING THE BALL AT AN EDGE RUNS THE STRIP UNDER IT.
+ * HOLDING AT AN EDGE RUNS THE STRIP UNDER THE POINTER.
  *
- * The rail spans what is ON SCREEN, not what exists: on a collection longer
- * than the bar, the end of the rail was the end of the timeline you could
- * reach, and the rest of the order sat an inch off the side of the track with
- * no way to scrub into it. You could step to it with the arrows or push the
- * boxes there by hand first, both of which mean abandoning the drag you are
+ * The track spans what is ON SCREEN, not what exists: on a project longer than
+ * the bar can draw at the current zoom, the end of the track was the end of
+ * the timeline you could reach in one gesture, with the rest of the order
+ * sitting an inch off the side. You could step to it with the arrows or pan
+ * there with the wheel first, both of which mean abandoning the drag you are
  * in the middle of.
  *
- * So the two ends of the rail are a throttle. Hold the ball inside 40px of
- * the right edge and the strip travels forward underneath it; hold it at the
- * left and it reverses. THE HAND DOES NOT MOVE during any of that, which is
- * why this is a frame loop and not something hung off pointermove — an
- * implementation reading the moves travels only while the hand jitters.
+ * So the two ends of the track are a throttle. Hold inside 40px of the right
+ * edge and the strip travels forward underneath; hold at the left and it
+ * reverses. THE HAND DOES NOT MOVE during any of that, which is why this is a
+ * frame loop and not something hung off pointermove — an implementation
+ * reading the moves travels only while the hand jitters.
  *
- * Four claims, and the last two are the ones that make it a control rather
- * than a hazard: the middle of the rail does nothing, and letting go stops it.
+ * Five claims, and the last three are what make it a control rather than a
+ * hazard: the middle of the track does nothing, letting go stops it, and a
+ * gesture that travelled this far is not mistaken for a tap on whatever
+ * arrived under the finger.
  */
-export const HoldingTheBallAtAnEdgeRunsTheStrip: Story = {
+export const HoldingAtAnEdgeRunsTheStrip: Story = {
   render: () => <SeamHarness scene={OVERFLOWING_SCENE} />,
   play: async () => {
     const at = () => Number(seamTrack().getAttribute("aria-valuenow"));
     const stripLeft = () =>
       document.querySelector<HTMLElement>("[data-seam-strip]")!.getBoundingClientRect().left;
+    const subject = () => centreBox().getAttribute("data-seam-segment");
 
+    // Held presses with NO travel at all, which is the gesture: everything
+    // that moves is moved by the bar, not by the hand.
     const press = (clientX: number) => {
-      const rail = seamRail();
-      const box = rail.getBoundingClientRect();
-      fireEvent.pointerDown(rail, {
-        clientX,
-        clientY: box.top + box.height / 2,
-        isPrimary: true,
-        pointerId: 1,
-        button: 0,
-      });
+      const surface = seamSurface();
+      const box = surface.getBoundingClientRect();
+      fireEvent.pointerDown(surface, pointerAt(clientX, box.top + box.height / 2));
     };
-    const release = () => {
-      const rail = seamRail();
-      const box = rail.getBoundingClientRect();
-      fireEvent.pointerUp(rail, {
-        clientX: box.left + box.width / 2,
-        clientY: box.top + box.height / 2,
-        isPrimary: true,
-        pointerId: 1,
-        button: 0,
-      });
+    const release = (clientX: number) => {
+      const surface = seamSurface();
+      const box = surface.getBoundingClientRect();
+      fireEvent.pointerUp(surface, pointerAt(clientX, box.top + box.height / 2));
     };
     const rest = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
     await waitFor(() => expect(document.querySelector("[data-seam-strip]")).not.toBeNull());
     await settleStrip();
+    const startedOn = subject();
 
     // THE PRECONDITION THIS STORY IS ABOUT. If the strip fitted in the track
     // there would be nothing off the side to reach, and every assertion below
     // would pass for the wrong reason.
-    const railWidth = seamRail().getBoundingClientRect().width;
-    const totalPx = Number(seamTrack().getAttribute("aria-valuemax")) * 9;
-    expect(totalPx).toBeGreaterThan(railWidth * 1.5);
+    const trackWidth = seamSurface().getBoundingClientRect().width;
+    const pps = Number(seamTrack().getAttribute("data-seam-pps"));
+    const totalPx = Number(seamTrack().getAttribute("aria-valuemax")) * pps;
+    expect(totalPx).toBeGreaterThan(trackWidth * 1.5);
 
-    // ── THE MIDDLE OF THE RAIL IS AN ORDINARY SCRUBBER ────────────────────
-    const railBox = seamRail().getBoundingClientRect();
-    press(railBox.left + railBox.width / 2);
+    // ── THE MIDDLE OF THE TRACK IS AN ORDINARY SCRUBBER ───────────────────
+    const box = seamSurface().getBoundingClientRect();
+    press(box.left + box.width / 2);
     const middleT = at();
     const middleX = stripLeft();
     await rest(300);
     expect(at()).toBe(middleT);
     expect(stripLeft()).toBe(middleX);
-    release();
+    release(box.left + box.width / 2);
 
     // ── THE RIGHT EDGE RUNS FORWARD ───────────────────────────────────────
-    press(railBox.right - 12);
-    const startedAt = at();
-    const startedX = stripLeft();
-    await waitFor(() => expect(at()).toBeGreaterThan(startedAt + 2), { timeout: 2000 });
-    // The clock advanced BECAUSE THE STRIP MOVED, not because the press
-    // landed further along: the boxes travelled left under a stationary hand.
-    expect(stripLeft()).toBeLessThan(startedX - 20);
+    press(box.right - 12);
+    const pressedAt = at();
+    await waitFor(() => expect(at()).toBeGreaterThan(pressedAt + 1), { timeout: 2000 });
 
-    // ── LETTING GO STOPS IT ───────────────────────────────────────────────
-    release();
+    // THE CLOCK ADVANCES BECAUSE THE STRIP MOVES, not because the press landed
+    // further along. Measured between two readings taken once the run is
+    // already going, so the press's own snap-to-cut is not inside the window —
+    // and stated as the two AGREEING rather than as a pixel count, so the
+    // claim survives a change of zoom instead of being calibrated to one.
+    const fromAt = at();
+    const fromX = stripLeft();
+    await waitFor(() => expect(at()).toBeGreaterThan(fromAt + 2), { timeout: 2000 });
+    const ranPx = fromX - stripLeft();
+    expect(ranPx).toBeGreaterThan(5);
+    expect(Math.abs(ranPx - (at() - fromAt) * pps)).toBeLessThan(2);
+
+    // ── LETTING GO STOPS IT, AND CHOOSES NOTHING ──────────────────────────
+    release(box.right - 12);
     const stoppedAt = at();
     const stoppedX = stripLeft();
     await rest(300);
     expect(at()).toBe(stoppedAt);
     expect(stripLeft()).toBe(stoppedX);
+    // The hand never moved, so by travel alone this looks like a tap — and a
+    // tap commits to a clip. The edge loop has to declare the drag on the
+    // bar's behalf, or scrubbing across the project ends by opening whatever
+    // shot happened to arrive under a stationary finger.
+    expect(subject()).toBe(startedOn);
 
     // ── AND THE LEFT EDGE REVERSES ────────────────────────────────────────
-    press(railBox.left + 12);
+    press(box.left + 12);
+    const pressedBackAt = at();
+    await waitFor(() => expect(at()).toBeLessThan(pressedBackAt - 1), { timeout: 2000 });
     const backFrom = at();
     const backFromX = stripLeft();
     await waitFor(() => expect(at()).toBeLessThan(backFrom - 2), { timeout: 2000 });
-    expect(stripLeft()).toBeGreaterThan(backFromX + 20);
-    release();
+    const backPx = stripLeft() - backFromX;
+    expect(backPx).toBeGreaterThan(5);
+    expect(Math.abs(backPx - (backFrom - at()) * pps)).toBeLessThan(2);
+    release(box.left + 12);
+  },
+};
+
+/**
+ * ── THE BAR IS A WINDOW ONTO THE WHOLE PROJECT ────────────────────────────
+ *
+ * The stories below are about what follows from that, and none of them were
+ * possible while the bar drew everything at one fixed scale.
+ */
+
+/**
+ * THE WHEEL PANS; ⌘ OR CTRL AND THE WHEEL ZOOMS ABOUT THE POINTER.
+ *
+ * Two gestures on the same input, and the second is the one that matters: at
+ * a single fixed scale a bar is either a smear of a long project or a keyhole
+ * onto a short one, and which you get depends on nothing but how much footage
+ * happens to exist.
+ *
+ * ZOOMING ABOUT THE POINTER IS THE WHOLE CLAIM. A zoom that scaled about the
+ * left edge would throw away the thing you were looking at every time you
+ * pushed in, which makes it a control you have to undo rather than one you
+ * aim. So this asserts the time under the cursor before and after, and lets
+ * everything else move around it.
+ */
+export const TheWheelPansAndZoomsAboutThePointer: Story = {
+  render: () => <SeamHarness scene={TWO_ROOMS_SCENE} />,
+  play: async () => {
+    await waitFor(() => expect(document.querySelector("[data-seam-strip]")).not.toBeNull());
+    await settleStrip();
+
+    const pps = () => Number(seamTrack().getAttribute("data-seam-pps"));
+    const stripLeft = () =>
+      document.querySelector<HTMLElement>("[data-seam-strip]")!.getBoundingClientRect().left;
+    /** The second of footage sitting under a given screen x. */
+    const secondsUnder = (clientX: number) => (clientX - stripLeft()) / pps();
+
+    const surface = seamSurface();
+    const box = surface.getBoundingClientRect();
+    const anchor = box.left + box.width * 0.7;
+
+    // ── PAN ───────────────────────────────────────────────────────────────
+    const beforePanX = stripLeft();
+    const beforePanPps = pps();
+    fireEvent.wheel(surface, { deltaY: 160, clientX: anchor, clientY: box.top + 4 });
+    await waitFor(() => expect(stripLeft()).toBeLessThan(beforePanX - 100));
+    // A pan is not a zoom: the scale is untouched, so every box keeps its size.
+    expect(pps()).toBe(beforePanPps);
+
+    // ── ZOOM ──────────────────────────────────────────────────────────────
+    const heldSecond = secondsUnder(anchor);
+    const beforeZoom = pps();
+    fireEvent.wheel(surface, {
+      deltaY: -240,
+      ctrlKey: true,
+      clientX: anchor,
+      clientY: box.top + 4,
+    });
+    await waitFor(() => expect(pps()).toBeGreaterThan(beforeZoom * 1.2));
+    // THE SAME SECOND IS STILL UNDER THE CURSOR. Everything else on the bar
+    // has moved and been redrawn at a new size; this one point has not.
+    expect(Math.abs(secondsUnder(anchor) - heldSecond)).toBeLessThan(0.05);
+
+    // And back out again, about the same point.
+    const zoomedIn = pps();
+    fireEvent.wheel(surface, {
+      deltaY: 240,
+      ctrlKey: true,
+      clientX: anchor,
+      clientY: box.top + 4,
+    });
+    await waitFor(() => expect(pps()).toBeLessThan(zoomedIn * 0.9));
+    expect(Math.abs(secondsUnder(anchor) - heldSecond)).toBeLessThan(0.05);
+  },
+};
+
+/**
+ * A SCRUB LANDING NEAR A CUT MEANS THE CUT.
+ *
+ * The cut is the thing anyone is ever aiming at on this bar — it is what the
+ * whole view is for — and it is one pixel wide. Without a snap, "put the
+ * playhead on the start of that shot" is a test of the reader's mouse hand,
+ * and the answer is almost always a frame or two out in a direction they
+ * cannot see.
+ *
+ * PIXELS, NOT SECONDS, is what makes it survive the zoom above: seven pixels
+ * is seven pixels at 5px a second and at 40, where a tolerance in seconds
+ * would swallow whole clips at one end and be unreachable at the other.
+ */
+export const AScrubNearACutTakesTheCut: Story = {
+  render: () => <SeamHarness scene={TWO_ROOMS_SCENE} />,
+  play: async () => {
+    await waitFor(() => expect(document.querySelector("[data-seam-strip]")).not.toBeNull());
+    await settleStrip();
+    const at = () => Number(seamTrack().getAttribute("aria-valuenow"));
+    const pps = Number(seamTrack().getAttribute("data-seam-pps"));
+
+    // A box with room either side of it, so "just before" and "just after" are
+    // both inside the same clip's neighbourhood and not off the end of the bar.
+    const target = seamBoxes()[4]!.getBoundingClientRect();
+    // The cut is the box's own leading edge, less the inset every box is
+    // pulled in by — see BOX_INSET_PX in the lane.
+    const cut = target.left - 2.5;
+
+    scrubToClientX(cut - 3);
+    const fromBefore = at();
+    scrubToClientX(cut + 3);
+    const fromAfter = at();
+
+    // BOTH SIDES LAND ON THE SAME INSTANT, which is the cut. Six pixels apart
+    // on screen, zero seconds apart on the clock.
+    expect(fromBefore).toBe(fromAfter);
+
+    // A press with room around it is left exactly where it was put, so the
+    // snap is a tolerance and not a quantiser: 40px further along is 40px
+    // further along, to the second.
+    scrubToClientX(cut + 40);
+    expect(at()).toBeGreaterThan(fromAfter);
+    expect(Math.abs(at() - fromAfter - 40 / pps)).toBeLessThan(0.05);
+  },
+};
+
+/**
+ * THE RULER SAYS WHAT SCALE YOU ARE AT, AND WHERE EACH COLLECTION STARTS.
+ *
+ * A box's width means "this long" only against a scale, and the scale now
+ * moves — so two bars showing the same picture can be a minute apart in what
+ * they are describing. The time ticks are the fix for that.
+ *
+ * THE COLLECTION LABELS ARE THE MORE IMPORTANT HALF. Time is derivable; "the
+ * Loading Dock starts here" is not, and it is the only landmark on a run of
+ * boxes that otherwise looks the same all the way along. They win a collision
+ * with a time tick for the same reason.
+ */
+export const TheRulerNamesTheCollections: Story = {
+  render: () => <SeamHarness scene={TWO_ROOMS_SCENE} />,
+  play: async () => {
+    await waitFor(() => expect(document.querySelector("[data-seam-ruler]")).not.toBeNull());
+    await settleStrip();
+
+    const labels = (kind: string) =>
+      Array.from(document.querySelectorAll<HTMLElement>("[data-seam-tick=" + kind + "]")).map(
+        (tick) => tick.textContent?.trim() ?? "",
+      );
+
+    expect(labels("collection")).toEqual(["Kitchen Interior", "Loading Dock"]);
+
+    // Seconds, and enough of them to read a scale from.
+    const times = labels("time");
+    expect(times.length).toBeGreaterThan(3);
+    expect(times.every((label) => /^[0-9]+s$/.test(label))).toBe(true);
+
+    // A DASHED LINE AT THE SEAM, one per crossing and none before the first
+    // clip — there is no seam at a beginning, only a start.
+    expect(document.querySelectorAll("[data-seam-divider]").length).toBe(1);
+  },
+};
+
+/**
+ * THE MINIMAP IS THE WHOLE SEQUENCE, AND DRAGGING IT MOVES THE WINDOW.
+ *
+ * The bar is a window, and at any useful zoom most of the project is off the
+ * sides of it. That is the right trade for working on a cut and the wrong one
+ * for knowing where you are, so the two questions get two objects: this one
+ * never zooms and never scrolls, and every clip is always on it.
+ *
+ * IT PANS, IT DOES NOT SEEK. Pressing a map means "show me there". Moving the
+ * playhead from here would make one gesture do two different things depending
+ * on which of the two strips your finger happened to land on.
+ */
+export const TheMinimapMovesTheWindow: Story = {
+  render: () => <SeamHarness scene={TWO_ROOMS_SCENE} />,
+  play: async () => {
+    await waitFor(() => expect(document.querySelector("[data-seam-minimap]")).not.toBeNull());
+    await settleStrip();
+
+    const minimap = document.querySelector<HTMLElement>("[data-seam-minimap]")!;
+    const windowRect = () =>
+      document.querySelector<HTMLElement>("[data-seam-mini-window]")!.getBoundingClientRect();
+    const at = () => Number(seamTrack().getAttribute("aria-valuenow"));
+
+    // EVERY clip is on it, both collections' worth — this is the one thing on
+    // screen that never crops.
+    expect(document.querySelectorAll("[data-seam-mini-segment]").length).toBe(24);
+
+    // The window is a PART of it, not all of it: if it covered the whole
+    // minimap there would be nothing off the sides and nothing to say.
+    const map = minimap.getBoundingClientRect();
+    expect(windowRect().width).toBeLessThan(map.width * 0.8);
+
+    const before = windowRect().left;
+    const clock = at();
+    const press = pointerAt(map.left + map.width * 0.85, map.top + map.height / 2);
+    fireEvent.pointerDown(minimap, press);
+    await waitFor(() => expect(windowRect().left).toBeGreaterThan(before + 40));
+
+    // AND THE PLAYHEAD DID NOT MOVE. Panning is a change of view, not a change
+    // of position — the difference between looking somewhere and going there.
+    expect(at()).toBe(clock);
+    fireEvent.pointerUp(minimap, press);
+  },
+};
+
+/**
+ * POINTING AT A BOX SAYS WHICH SHOT IT IS.
+ *
+ * A box is a coloured rectangle. Colour groups it by collection and width
+ * gives its length, and neither answers the question anyone actually has,
+ * which is whether that is the shot they are looking for — the bar spans the
+ * whole project, so most of what is on it is unidentifiable by construction.
+ *
+ * The preview answers it WITHOUT MOVING THE PLAYHEAD, which is the point:
+ * checking costs you nothing and leaves you where you were.
+ */
+export const PointingAtABoxSaysWhatItIs: Story = {
+  render: () => <SeamHarness scene={TWO_ROOMS_SCENE} />,
+  play: async () => {
+    await waitFor(() => expect(document.querySelector("[data-seam-strip]")).not.toBeNull());
+    await settleStrip();
+    const at = () => Number(seamTrack().getAttribute("aria-valuenow"));
+    const preview = () => document.querySelector<HTMLElement>("[data-seam-preview]");
+
+    expect(preview()).toBeNull();
+
+    const surface = seamSurface();
+    const target = seamBoxes()[3]!.getBoundingClientRect();
+    const before = at();
+    fireEvent.pointerMove(
+      surface,
+      pointerAt(target.left + target.width / 2, target.top + target.height / 2),
+    );
+
+    await waitFor(() => expect(preview()).not.toBeNull());
+    expect(preview()!.textContent).toContain("Kitchen 3");
+    // Which collection, and how far into the clip — the two facts a box
+    // cannot carry itself.
+    expect(preview()!.textContent).toContain("Kitchen Interior");
+    // A ghost line marks WHERE, so the words and the position are one object.
+    expect(document.querySelector("[data-seam-ghost]")).not.toBeNull();
+    // LOOKING IS FREE.
+    expect(at()).toBe(before);
+
+    // `pointerOut` with a relatedTarget, not `pointerLeave`: React synthesises
+    // enter/leave from delegated over/out events, so a bare `pointerleave`
+    // reaches no handler and the preview would look sticky in a way it is not.
+    fireEvent.pointerOut(surface, {
+      ...pointerAt(target.left, target.top),
+      relatedTarget: document.body,
+    });
+    await waitFor(() => expect(preview()).toBeNull());
+  },
+};
+
+/**
+ * A DRAG SCRUBS; A PRESS THAT DOES NOT TRAVEL COMMITS.
+ *
+ * One surface, two gestures, told apart by distance rather than by timing — a
+ * slow deliberate scrub must not also count as a tap on wherever it started,
+ * and a decisive tap must not have to be held.
+ *
+ * WHY THE SCRUB CHOOSES NOTHING. Scrubbing is a look: you check what is
+ * coming up and go back to what you were doing. A release that made the
+ * landing point the active clip would have already moved you, so checking
+ * would cost you your place — which is the one thing looking must not do.
+ */
+export const ADragScrubsAndAClickCommits: Story = {
+  render: () => <SeamHarness scene={TWO_ROOMS_SCENE} />,
+  play: async () => {
+    await waitFor(() => expect(document.querySelector("[data-seam-strip]")).not.toBeNull());
+    await settleStrip();
+    const subject = () => centreBox().getAttribute("data-seam-segment");
+    const at = () => Number(seamTrack().getAttribute("aria-valuenow"));
+
+    const startedOn = subject();
+    expect(startedOn).toBe("subject");
+
+    // A DRAG onto another clip moves the clock and nothing else.
+    scrubIntoBox(seamBoxes()[2]!);
+    await waitFor(() => expect(at()).toBeGreaterThan(0));
+    expect(subject()).toBe(startedOn);
+
+    // A PRESS on the same clip commits to it.
+    clickBox(seamBoxes()[2]!);
+    await waitFor(() => expect(subject()).not.toBe(startedOn));
+  },
+};
+
+/**
+ * THE BAR TAKES THE KEYBOARD.
+ *
+ * It is a `role="slider"` and it is focusable, so it owes the reader the keys
+ * a slider answers to — and the ones a transport answers to, since it is also
+ * the only transport in the view. Arrows nudge a second, shift and an arrow
+ * steps a whole clip, Home and End are the two places you jump to without
+ * aiming.
+ */
+export const TheBarTakesTheKeyboard: Story = {
+  render: () => <SeamHarness scene={TWO_ROOMS_SCENE} />,
+  play: async () => {
+    await waitFor(() => expect(document.querySelector("[data-seam-strip]")).not.toBeNull());
+    await settleStrip();
+    const track = seamTrack();
+    const at = () => Number(track.getAttribute("aria-valuenow"));
+    const max = Number(track.getAttribute("aria-valuemax"));
+    track.focus();
+
+    fireEvent.keyDown(track, { key: "End" });
+    await waitFor(() => expect(at()).toBe(max));
+
+    fireEvent.keyDown(track, { key: "ArrowLeft" });
+    await waitFor(() => expect(at()).toBeCloseTo(max - 1, 1));
+
+    fireEvent.keyDown(track, { key: "Home" });
+    await waitFor(() => expect(at()).toBe(0));
+
+    fireEvent.keyDown(track, { key: "ArrowRight" });
+    await waitFor(() => expect(at()).toBeCloseTo(1, 1));
+
+    // Shift and an arrow is the same step the two chevrons make, so the two
+    // ways of asking cannot drift apart.
+    const subject = () => centreBox().getAttribute("data-seam-segment");
+    const startedOn = subject();
+    fireEvent.keyDown(track, { key: "ArrowRight", shiftKey: true });
+    await waitFor(() => expect(subject()).not.toBe(startedOn));
   },
 };

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -35,8 +35,8 @@ import { useItemDetails } from "./graph-item-details-context";
 import { withViewTransition } from "@/lib/view-transition";
 import { detailsWindow, flatOrderRootId } from "./graph-details-neighbours";
 import { useSeamTransport } from "./graph-seam-bar";
+import type { SeamBarClip } from "./graph-seam-bar-layout";
 import { SeamStripBar } from "./graph-seam-strip-bar";
-import { buildSeamStrip, stripXFor } from "./graph-seam-strip";
 import {
   buildSeamTimeline,
   seamAt,
@@ -57,17 +57,6 @@ import {
   rememberViewCount,
   type ViewCount,
 } from "./graph-item-details-view-count";
-
-/**
- * How many pixels a second of clip is worth ON THE BAR.
- *
- * Fixed, which is the whole point: it is what makes a box the size of its
- * clip rather than a share of whatever else happens to be on screen, so the
- * same shot is the same width whether three cards are up or five. At 9px a
- * ten-second shot is 90px — long enough to aim a pointer at, short enough
- * that a minute and a half of material still reads as a shape.
- */
-const BAR_PIXELS_PER_SECOND = 9;
 
 // The trim MODAL (PL10-008, an experiment replacing the docked map).
 //
@@ -519,16 +508,32 @@ function DetailsFilmstripModal({
     return colours;
   }, [ids, graph]);
 
-  const strip = useMemo(() => {
-    const clips = ids.map((id) => {
+  // EVERY CLIP THE BAR CAN REACH, with the two things the bar cannot work out
+  // for itself: what a clip is called, and which collection it belongs to.
+  //
+  // The names are for the hover preview — a box is otherwise anonymous, and
+  // "which shot is that" is the question a bar of coloured rectangles is worst
+  // at. The collection is what the dividers and the ruler's labels are drawn
+  // from: the row walks the whole project in playback order and crosses
+  // collection edges on purpose, so those edges are the only landmarks on it.
+  //
+  // The bar owns the SCALE now, so it also owns the layout — this hands it
+  // clips, not pixels.
+  const barClips = useMemo<readonly SeamBarClip[]>(() => {
+    return ids.map((id) => {
       const found = graph.nodesById.get(parseNodeId(id));
       const media = found && found.kind === "media" ? (found as MediaNode) : null;
+      const parentId = graph.parentById.get(parseNodeId(id)) ?? null;
+      const parent = parentId === null ? undefined : graph.nodesById.get(parentId);
       return {
         id,
+        name: found?.name ?? id,
         showingSeconds: media === null ? 0 : mediaDurationSeconds(media),
+        collectionId: parentId === null ? null : (parentId as string),
+        collectionName: parent?.name ?? null,
+        ...(media === null ? {} : { posterSrc: seamClipOf(media)?.posterSrc }),
       };
     });
-    return buildSeamStrip(clips, BAR_PIXELS_PER_SECOND);
   }, [ids, graph]);
 
   const offset = centre < 0 ? 0 : centre - (ids.length - 1) / 2;
@@ -631,10 +636,12 @@ function DetailsFilmstripModal({
   // WHERE THE PLAYHEAD IS, read across from the clock. The clock says "this
   // clip, this far in"; the strip says where that clip begins. Neither has to
   // know the other's coordinates, and there is still only one answer.
-  const playheadPx = (() => {
-    const at = position ?? (centreClip === null ? null : { clipId: centreClip.id as string, clipSeconds: 0 });
+  const playheadAt = (() => {
+    const at =
+      position ??
+      (centreClip === null ? null : { clipId: centreClip.id as string, clipSeconds: 0 });
     if (at === null) return null;
-    return stripXFor(strip, at.clipId, at.clipSeconds);
+    return { clipId: at.clipId, secondsIntoClip: at.clipSeconds };
   })();
 
   const rowTransform =
@@ -650,7 +657,17 @@ function DetailsFilmstripModal({
       // panels overflow, so the centre lands in the middle and the other two
       // are clipped symmetrically. `overflow-hidden` is what makes that a crop
       // instead of a scrollbar.
-      className="fixed inset-0 z-[80] flex items-center justify-center overflow-hidden bg-black/80 p-6 backdrop-blur-sm"
+      // THE TOP BAND IS RESERVED, not shared. The header and the bar are
+      // absolutely positioned so the row can be centred and cropped
+      // symmetrically without them affecting its width — which also means
+      // they take no space, and the row would centre straight up underneath
+      // them. This padding is the band they occupy: header (61px) plus the
+      // bar block at top-16 with its own pt-4 (152px to its underside), plus
+      // clearance. It grew when the bar did, and it has to keep pace: the
+      // symptom of it not doing so is the minimap resting on the top edge of
+      // the middle card, which is a quiet eight pixels rather than an obvious
+      // fault.
+      className="fixed inset-0 z-[80] flex items-center justify-center overflow-hidden bg-black/80 px-6 pt-[11rem] pb-6 backdrop-blur-sm"
       onPointerDown={(event) => {
         // Scrim only: a press that starts on a panel must never close it,
         // including one that ends outside after a trim drag.
@@ -683,10 +700,10 @@ function DetailsFilmstripModal({
         >
           <div className="mx-auto w-full max-w-5xl">
             <SeamStripBar
-              strip={strip}
+              clips={barClips}
               centreClipId={node.id as string}
               colourOf={clipColourOf}
-              playheadPx={playheadPx}
+              playheadAt={playheadAt}
               playing={playing}
               onTogglePlay={() => setPlaying((was) => !was)}
               // The same step the swipe and the neighbour-click make, so all

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-bar-layout.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-bar-layout.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSeamStrip } from "./graph-seam-strip";
+import {
+  clampPixelsPerSecond,
+  collectionSeams,
+  fitPixelsPerSecond,
+  offsetAfterZoom,
+  PPS_MAX,
+  PPS_MIN,
+  seamRulerTicks,
+  snapToCut,
+  tickStepSeconds,
+  zoomByWheel,
+  type SeamBarClip,
+} from "./graph-seam-bar-layout";
+
+const clip = (
+  id: string,
+  showingSeconds: number,
+  collectionId: string,
+  collectionName: string,
+): SeamBarClip => ({ id, name: id.toUpperCase(), showingSeconds, collectionId, collectionName });
+
+// Two collections, four clips: a=0..40, b=40..60 | c=60..120, d=120..140.
+const CLIPS: readonly SeamBarClip[] = [
+  clip("a", 4, "kitchen", "Kitchen"),
+  clip("b", 2, "kitchen", "Kitchen"),
+  clip("c", 6, "van", "Van Interior"),
+  clip("d", 2, "van", "Van Interior"),
+];
+const PPS = 10;
+const STRIP = buildSeamStrip(CLIPS, PPS);
+
+describe("clampPixelsPerSecond", () => {
+  it("holds the zoom inside its range", () => {
+    expect(clampPixelsPerSecond(0.1)).toBe(PPS_MIN);
+    expect(clampPixelsPerSecond(1000)).toBe(PPS_MAX);
+    expect(clampPixelsPerSecond(12)).toBe(12);
+  });
+
+  it("answers the floor for a nonsense scale rather than passing NaN on", () => {
+    expect(clampPixelsPerSecond(Number.NaN)).toBe(PPS_MIN);
+  });
+});
+
+describe("zoomByWheel", () => {
+  it("zooms in on a wheel-up and out on a wheel-down", () => {
+    expect(zoomByWheel(10, -100)).toBeGreaterThan(10);
+    expect(zoomByWheel(10, 100)).toBeLessThan(10);
+  });
+
+  it("is a RATIO, so a notch feels the same at either end of the range", () => {
+    // The thing a linear step gets wrong: +2px a second is a doubling down at
+    // the floor and a rounding error up at the ceiling.
+    const low = zoomByWheel(4, -100) / 4;
+    const high = zoomByWheel(20, -100) / 20;
+    expect(Math.abs(low - high)).toBeLessThan(0.001);
+  });
+
+  it("cannot be wheeled past either limit", () => {
+    expect(zoomByWheel(PPS_MAX, -5000)).toBe(PPS_MAX);
+    expect(zoomByWheel(PPS_MIN, 5000)).toBe(PPS_MIN);
+  });
+});
+
+describe("fitPixelsPerSecond", () => {
+  it("lays the footage across MORE than one trackful", () => {
+    // 60s into an 600px track at 1.65 overflow is 16.5px a second — so the
+    // bar opens showing about three fifths of it, and the rest is off the
+    // sides where the eye can be told it exists.
+    expect(fitPixelsPerSecond(60, 600)).toBeCloseTo(16.5, 5);
+  });
+
+  it("clamps rather than proposing an unusable scale", () => {
+    expect(fitPixelsPerSecond(0.01, 600)).toBe(PPS_MAX);
+    expect(fitPixelsPerSecond(100_000, 600)).toBe(PPS_MIN);
+  });
+
+  it("falls back for a track that has not been measured yet", () => {
+    expect(fitPixelsPerSecond(60, 0)).toBe(9);
+  });
+});
+
+describe("collectionSeams", () => {
+  it("names the first clip of every collection, the first one included", () => {
+    expect(collectionSeams(CLIPS)).toEqual([0, 2]);
+  });
+
+  it("is one seam for one collection", () => {
+    expect(collectionSeams(CLIPS.slice(0, 2))).toEqual([0]);
+  });
+
+  it("re-seams a collection the order returns to", () => {
+    // The row walks playback order, which may leave a collection and come
+    // back; the second run is a second landmark, not a duplicate to drop.
+    const wandering = [CLIPS[0]!, CLIPS[2]!, CLIPS[1]!];
+    expect(collectionSeams(wandering)).toEqual([0, 1, 2]);
+  });
+
+  it("is empty for no clips", () => {
+    expect(collectionSeams([])).toEqual([]);
+  });
+});
+
+describe("snapToCut", () => {
+  it("pulls onto a nearby cut", () => {
+    expect(snapToCut(STRIP, 43)).toBe(40);
+    expect(snapToCut(STRIP, 57)).toBe(60);
+  });
+
+  it("leaves a press in the middle of a clip alone", () => {
+    expect(snapToCut(STRIP, 20)).toBe(20);
+  });
+
+  it("snaps to the far end of the timeline as well as to interior cuts", () => {
+    expect(snapToCut(STRIP, 137)).toBe(140);
+  });
+
+  it("takes the NEARER of two cuts inside tolerance", () => {
+    const tight = buildSeamStrip(
+      [clip("a", 0.4, "k", "K"), clip("b", 0.4, "k", "K"), clip("c", 4, "k", "K")],
+      10,
+    );
+    // Cuts at 0, 4 and 8. From 5 the nearer is 4, not 8.
+    expect(snapToCut(tight, 5, 7)).toBe(4);
+  });
+
+  it("measures in PIXELS, so the same tolerance survives a zoom", () => {
+    // 3px from a cut is inside tolerance at both scales, even though at 40px
+    // a second that is a tenth of the seconds it is at 4.
+    const wide = buildSeamStrip(CLIPS, 40);
+    const narrow = buildSeamStrip(CLIPS, 4);
+    expect(snapToCut(wide, 40 * 4 + 3)).toBe(160);
+    expect(snapToCut(narrow, 4 * 4 + 3)).toBe(16);
+  });
+});
+
+describe("offsetAfterZoom", () => {
+  it("keeps the time under the cursor under the cursor", () => {
+    // Cursor 300px into the track, strip pushed 100px left: the cursor is on
+    // strip x 400, which at 10px a second is 40s. At 20 that second is at 800,
+    // so the strip has to sit at 300 - 800 = -500 for it not to move.
+    expect(offsetAfterZoom({ anchorLocalX: 300, offset: -100, from: 10, to: 20 })).toBe(-500);
+  });
+
+  it("is a no-op when the scale does not change", () => {
+    expect(offsetAfterZoom({ anchorLocalX: 300, offset: -100, from: 10, to: 10 })).toBe(-100);
+  });
+
+  it("refuses to divide by a scale of zero", () => {
+    expect(offsetAfterZoom({ anchorLocalX: 300, offset: -100, from: 0, to: 20 })).toBe(-100);
+  });
+});
+
+describe("tickStepSeconds", () => {
+  it("climbs the ladder as the bar is pulled back", () => {
+    // 46px minimum spacing: at 50px a second a 1s step already clears it; at
+    // 2.5 nothing under 30s does.
+    expect(tickStepSeconds(50)).toBe(1);
+    expect(tickStepSeconds(10)).toBe(5);
+    expect(tickStepSeconds(2.5)).toBe(30);
+  });
+
+  it("answers its coarsest step rather than dividing by nothing", () => {
+    expect(tickStepSeconds(0)).toBe(300);
+  });
+});
+
+describe("seamRulerTicks", () => {
+  it("labels each collection where it starts", () => {
+    const collections = seamRulerTicks({ strip: STRIP, clips: CLIPS }).filter(
+      (tick) => tick.kind === "collection",
+    );
+    expect(collections).toEqual([
+      { x: 0, label: "Kitchen", kind: "collection" },
+      { x: 60, label: "Van Interior", kind: "collection" },
+    ]);
+  });
+
+  it("drops a time tick that would land on a collection label", () => {
+    // 60s is a collection seam at x=60; at 10px a second the 5s ladder puts a
+    // time tick at 60 too, and 50 and 70 are both inside the 26px clash zone.
+    const times = seamRulerTicks({ strip: STRIP, clips: CLIPS })
+      .filter((tick) => tick.kind === "time")
+      .map((tick) => tick.x);
+    expect(times).not.toContain(60);
+    expect(times).not.toContain(50);
+    expect(times).not.toContain(70);
+    expect(times).toContain(100);
+  });
+
+  it("never runs a tick past the end of the strip", () => {
+    const xs = seamRulerTicks({ strip: STRIP, clips: CLIPS }).map((tick) => tick.x);
+    expect(Math.max(...xs)).toBeLessThanOrEqual(STRIP.totalPx);
+  });
+
+  it("is empty for an empty strip rather than looping forever", () => {
+    expect(seamRulerTicks({ strip: buildSeamStrip([], 10), clips: [] })).toEqual([]);
+  });
+
+  it("skips a collection with no name instead of labelling it blank", () => {
+    const unnamed: readonly SeamBarClip[] = [
+      { id: "a", name: "A", showingSeconds: 4, collectionId: "x", collectionName: null },
+    ];
+    expect(
+      seamRulerTicks({ strip: buildSeamStrip(unnamed, 10), clips: unnamed }).filter(
+        (tick) => tick.kind === "collection",
+      ),
+    ).toEqual([]);
+  });
+});

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-bar-layout.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-bar-layout.ts
@@ -1,0 +1,204 @@
+// THE BAR'S ARITHMETIC: zoom, cut-snapping, collection seams, ruler ticks.
+//
+// Pure and framework-free (a .ts, not a .tsx) so the app's vitest can parse
+// it, and separate from `graph-seam-strip` because that module answers "where
+// does each clip sit" and this one answers "what does the bar draw around
+// them". Both are arithmetic over the same running total; neither needs a DOM.
+
+import { segmentFor, type SeamStrip } from "./graph-seam-strip";
+
+/**
+ * A clip as the BAR sees it — its length, and which collection it came from.
+ *
+ * The collection is not decoration. The bar spans the whole project in
+ * playback order, so it crosses collection edges, and those edges are the
+ * only landmarks on an otherwise uniform run of boxes: they are where the
+ * dividers go and what the ruler labels.
+ */
+export type SeamBarClip = Readonly<{
+  id: string;
+  /** For the hover preview — the only place the bar can say what a box IS. */
+  name: string;
+  /** The trimmed length — what the clip contributes to playback. */
+  showingSeconds: number;
+  collectionId: string | null;
+  collectionName: string | null;
+  posterSrc?: string;
+}>;
+
+/**
+ * How far the bar can be zoomed, in pixels per second of footage.
+ *
+ * The floor is set by legibility of the WHOLE: at 2.5px a second a ten-minute
+ * project is 1500px, which is a bar you can see the shape of. The ceiling is
+ * set by the other end of the same question — past 40px a second a two-second
+ * clip is wider than the track and the bar has stopped being a map.
+ */
+export const PPS_MIN = 2.5;
+export const PPS_MAX = 40;
+
+/** How hard a wheel notch moves the zoom. Exponential, so a notch is a RATIO
+ *  and zooming feels the same at either end of the range. */
+export const ZOOM_WHEEL_GAIN = 0.0016;
+
+/** How near a cut a scrub has to land before it is taken to mean that cut. */
+export const SNAP_TOLERANCE_PX = 7;
+
+export function clampPixelsPerSecond(value: number): number {
+  if (!Number.isFinite(value)) return PPS_MIN;
+  return Math.min(PPS_MAX, Math.max(PPS_MIN, value));
+}
+
+export function zoomByWheel(current: number, deltaY: number): number {
+  return clampPixelsPerSecond(current * Math.exp(-deltaY * ZOOM_WHEEL_GAIN));
+}
+
+/**
+ * The scale that lays `seconds` of footage across `overflow` × the track.
+ *
+ * Deliberately MORE than one trackful. Opening at exactly fit-to-width says
+ * "this is all of it" about a bar whose whole point is that there is more
+ * either side; opening a little over says "there is more, and it is that
+ * way", which is the thing a first glance has to get right.
+ */
+export function fitPixelsPerSecond(
+  seconds: number,
+  trackPx: number,
+  overflow = 1.65,
+): number {
+  if (seconds <= 0 || trackPx <= 0) return clampPixelsPerSecond(9);
+  return clampPixelsPerSecond((trackPx * overflow) / seconds);
+}
+
+/**
+ * Where the strip crosses from one collection into the next.
+ *
+ * Indexes into `clips`, naming the FIRST clip of each new collection — the
+ * clip a divider is drawn before, and the clip whose collection the ruler
+ * labels. Index 0 is included: the run has to be named where it starts, or
+ * the first collection on the bar is the only one without a label.
+ */
+export function collectionSeams(clips: readonly SeamBarClip[]): readonly number[] {
+  const seams: number[] = [];
+  for (let index = 0; index < clips.length; index += 1) {
+    if (index === 0 || clips[index]!.collectionId !== clips[index - 1]!.collectionId) {
+      seams.push(index);
+    }
+  }
+  return seams;
+}
+
+/**
+ * Pull `x` onto a cut if there is one within `tolerancePx`.
+ *
+ * Returns the snapped x, or the x it was given when nothing is near. Cuts are
+ * where a clip STARTS, plus the very end of the timeline — the two ends of
+ * the run are positions you aim for as much as any interior seam.
+ *
+ * TOLERANCE IS IN PIXELS, NOT SECONDS, which is the whole reason this is not
+ * a fixed number of frames: the bar zooms, and at 2.5px a second a snap
+ * measured in seconds would swallow whole clips while at 40 it would be
+ * unreachable. Seven pixels is seven pixels at every scale.
+ */
+export function snapToCut(
+  strip: SeamStrip,
+  x: number,
+  tolerancePx = SNAP_TOLERANCE_PX,
+): number {
+  let best: number | null = null;
+  let bestDistance = tolerancePx;
+  const consider = (candidate: number) => {
+    const distance = Math.abs(candidate - x);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = candidate;
+    }
+  };
+  for (const segment of strip.segments) {
+    if (segment.widthPx <= 0) continue;
+    consider(segment.leftPx);
+  }
+  consider(strip.totalPx);
+  return best ?? x;
+}
+
+/**
+ * The offset that keeps the time under the cursor under the cursor.
+ *
+ * Zooming about a point is the difference between a control and a lurch: the
+ * clip you were looking at when you started is the clip you want to still be
+ * looking at when you stop. All coordinates are LOCAL to the track (client x
+ * minus the track's left edge), so this never has to know where on the page
+ * the bar is.
+ */
+export function offsetAfterZoom(params: {
+  anchorLocalX: number;
+  offset: number;
+  from: number;
+  to: number;
+}): number {
+  const { anchorLocalX, offset, from, to } = params;
+  if (from <= 0 || !Number.isFinite(from)) return offset;
+  const seconds = (anchorLocalX - offset) / from;
+  return anchorLocalX - seconds * to;
+}
+
+export type SeamTick = Readonly<{
+  /** Absolute strip pixels — the same space the boxes are laid out in. */
+  x: number;
+  label: string;
+  kind: "time" | "collection";
+}>;
+
+/**
+ * The rungs of the ladder the ruler may step by, in seconds.
+ *
+ * The smallest whose spacing clears `MIN_TICK_GAP_PX` wins, so the ruler
+ * carries about as many labels at every zoom instead of thinning to nothing
+ * when you pull back and crowding into a smear when you push in.
+ */
+const TICK_LADDER = [1, 2, 5, 10, 15, 30, 60, 120, 300] as const;
+const MIN_TICK_GAP_PX = 46;
+/** How close a time tick may come to a collection label before it gives way. */
+const TICK_CLASH_PX = 26;
+
+export function tickStepSeconds(pxPerSecond: number): number {
+  if (!Number.isFinite(pxPerSecond) || pxPerSecond <= 0) return TICK_LADDER.at(-1)!;
+  const found = TICK_LADDER.find((step) => step * pxPerSecond >= MIN_TICK_GAP_PX);
+  return found ?? TICK_LADDER.at(-1)!;
+}
+
+/**
+ * Every mark the ruler draws, in one pass.
+ *
+ * COLLECTION TICKS WIN TIES. A time tick says "ninety seconds", which you can
+ * work out; a collection tick says "Van Interior starts here", which you
+ * cannot. When they land within `TICK_CLASH_PX` of each other the time tick
+ * is dropped, rather than both being drawn into the same smudge.
+ */
+export function seamRulerTicks(params: {
+  strip: SeamStrip;
+  clips: readonly SeamBarClip[];
+}): readonly SeamTick[] {
+  const { strip, clips } = params;
+  if (strip.pxPerSecond <= 0 || strip.totalPx <= 0) return [];
+
+  const collectionTicks: SeamTick[] = [];
+  for (const index of collectionSeams(clips)) {
+    const clip = clips[index];
+    if (clip === undefined || clip.collectionName === null) continue;
+    const segment = segmentFor(strip, clip.id);
+    if (segment === null) continue;
+    collectionTicks.push({ x: segment.leftPx, label: clip.collectionName, kind: "collection" });
+  }
+
+  const step = tickStepSeconds(strip.pxPerSecond);
+  const timeTicks: SeamTick[] = [];
+  for (let seconds = step; seconds * strip.pxPerSecond <= strip.totalPx; seconds += step) {
+    const x = seconds * strip.pxPerSecond;
+    if (collectionTicks.some((tick) => Math.abs(tick.x - x) < TICK_CLASH_PX)) continue;
+    timeTicks.push({ x, label: `${Math.round(seconds)}s`, kind: "time" });
+  }
+
+  return [...timeTicks, ...collectionTicks];
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { collectionSeams, type SeamBarClip } from "./graph-seam-bar-layout";
+import type { SeamStrip } from "./graph-seam-strip";
+
+/**
+ * The playhead's head, and its twitch when the scrub lands on a cut.
+ *
+ * DRIVEN FROM SCRIPT, NOT A KEYFRAME. A `@keyframes` would have to be
+ * declared in a stylesheet, and this component is rendered into a portal from
+ * two hosts with two different Tailwind entry points — the app's and
+ * Storybook's — so a rule added to one of them is a rule the other silently
+ * does not have. An animation the component brings with it cannot be missing
+ * in one host and present in the other, and it is inspectable from a test
+ * through `getAnimations()`.
+ *
+ * Skips its first run: mounting the playhead is not a snap.
+ */
+function SnapPulse({ snapKey }: Readonly<{ snapKey: number }>) {
+  const ref = useRef<HTMLSpanElement | null>(null);
+  useEffect(() => {
+    const element = ref.current;
+    if (element === null || snapKey === 0) return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    const animation = element.animate(
+      [
+        { transform: "scale(1)" },
+        { transform: "scale(2.1)" },
+        { transform: "scale(1)" },
+      ],
+      { duration: 180, easing: "ease-out" },
+    );
+    return () => animation.cancel();
+  }, [snapKey]);
+  return (
+    <span
+      ref={ref}
+      data-seam-playhead-head
+      className="block h-1.5 w-1.5 rounded-full bg-red-500"
+    />
+  );
+}
+
+/**
+ * How far each box is pulled in from its clip's true extent, per side.
+ *
+ * The gap between two boxes is therefore twice this. It is an inset rather
+ * than a margin because the box's MIDDLE has to stay exactly on the clip's
+ * middle — that is what the centring arithmetic aligns to the card below —
+ * and trimming only the width would shift it by half the gap.
+ */
+const BOX_INSET_PX = 2.5;
+
+export type SeamHover = Readonly<{
+  /** Absolute strip pixels. */
+  x: number;
+  name: string;
+  meta: string;
+  posterSrc?: string;
+}>;
+
+/**
+ * THE FILMSTRIP ITSELF: every clip as a box, the cut lines between
+ * collections, and the playhead.
+ *
+ * Presentational. Every gesture on it — scrub, zoom, pan, hover — is decided
+ * by the bar that owns the strip's offset and scale, and arrives here as
+ * handlers. That split is what lets this file be read as "what the bar looks
+ * like" without also being the answer to "what happens when you drag it".
+ *
+ * THE OVERLAYS ARE PINNED, THE BOXES TRAVEL. Boxes, dividers, playhead and
+ * ghost live inside the translated layer, so they share one coordinate space
+ * and cannot drift apart at any pan or zoom. The chip and the preview are
+ * outside it and positioned in viewport pixels, because a label that scrolled
+ * off the side of the track with the thing it labels would be a label you
+ * cannot read exactly when you need it.
+ */
+export function SeamLane({
+  laneRef,
+  strip,
+  clips,
+  colourOf,
+  centreClipId,
+  offset,
+  playheadPx,
+  snapKey,
+  ghostX,
+  hover,
+  chip,
+  handlers,
+}: Readonly<{
+  /** The element the bar attaches its non-passive wheel listener to. */
+  laneRef: React.RefObject<HTMLDivElement | null>;
+  strip: SeamStrip;
+  clips: readonly SeamBarClip[];
+  colourOf: ReadonlyMap<string, string>;
+  centreClipId: string;
+  offset: number;
+  playheadPx: number | null;
+  /** Bumped on every snap, so the playhead can acknowledge one. */
+  snapKey: number;
+  /** Where an un-pressed pointer is hovering, in strip pixels. */
+  ghostX: number | null;
+  hover: SeamHover | null;
+  /** The time under the playhead while it is being dragged. */
+  chip: string | null;
+  handlers: React.ComponentProps<"div">;
+}>) {
+  const seams = collectionSeams(clips);
+  const viewportX = (stripX: number) => stripX + offset;
+
+  return (
+    <div
+      ref={laneRef}
+      data-seam-boxes
+      {...handlers}
+      // `touch-none`, because every gesture here is claimed: a drag scrubs and
+      // a two-finger swipe pans. Left to the browser, the first would also
+      // scroll the dialog behind the bar.
+      //
+      // NOT `overflow-hidden` ITSELF — the clip lives on the inner wrapper
+      // below. The chip and the preview are children of this element and both
+      // have to escape it: a time chip drawn INSIDE the boxes covers the frames
+      // it is reporting on, which is the one thing you are looking at while you
+      // drag.
+      className="relative h-9 cursor-ew-resize touch-none select-none"
+    >
+      <div className="absolute inset-0 overflow-hidden">
+        <div
+          data-seam-strip
+          className="absolute inset-y-0 left-0 will-change-transform"
+          style={{ transform: `translateX(${offset}px)`, width: strip.totalPx }}
+        >
+          {strip.segments.map((segment) => {
+            if (segment.widthPx <= 0) return null;
+            const isCentre = segment.clipId === centreClipId;
+            const colour = colourOf.get(segment.clipId) ?? "hsl(220 8% 34%)";
+            return (
+              <span
+                key={segment.clipId}
+                data-seam-segment={segment.clipId}
+                data-seam-segment-live={isCentre ? "" : undefined}
+                aria-hidden="true"
+                style={{
+                  left: segment.leftPx + BOX_INSET_PX,
+                  width: Math.max(2, segment.widthPx - BOX_INSET_PX * 2),
+                  backgroundColor: colour,
+                }}
+                className="absolute inset-y-0 flex items-center justify-center overflow-hidden rounded-[3px]"
+              >
+                {isCentre && segment.widthPx >= 16 ? (
+                  <span
+                    data-seam-marker
+                    className="h-3 w-3 rounded-full bg-black/50"
+                  />
+                ) : null}
+              </span>
+            );
+          })}
+
+          {/* WHERE ONE COLLECTION ENDS AND THE NEXT BEGINS. A dashed hairline
+            rather than a gap: a gap is what the bar already puts between
+            every pair of boxes, so widening one would say "a slightly longer
+            pause here" instead of "a different place". Skipped at index 0 —
+            there is no seam before the first clip, only a beginning. */}
+          {seams.map((index) => {
+            const clip = clips[index];
+            if (index === 0 || clip === undefined) return null;
+            const segment = strip.segments.find(
+              (candidate) => candidate.clipId === clip.id,
+            );
+            if (segment === undefined) return null;
+            return (
+              <span
+                key={`seam-${clip.id}`}
+                data-seam-divider={clip.collectionId ?? ""}
+                aria-hidden="true"
+                style={{ left: segment.leftPx - BOX_INSET_PX }}
+                className="absolute inset-y-1 w-px border-l border-dashed border-white/30"
+              />
+            );
+          })}
+
+          {/* WHERE THE POINTER IS, before it has committed to anything. The
+            playhead says where you ARE; this says where a press would put
+            you, which is the question you are asking while you look. */}
+          {ghostX !== null && (
+            <span
+              aria-hidden="true"
+              data-seam-ghost
+              style={{ transform: `translateX(${ghostX}px)` }}
+              className="absolute inset-y-0 left-0 w-px bg-white/35"
+            />
+          )}
+
+          {playheadPx !== null && (
+            <span
+              data-seam-playhead
+              aria-hidden="true"
+              style={{ transform: `translateX(${playheadPx}px)` }}
+              // A HAIRLINE. One physical pixel wherever the display allows it:
+              // the playhead's job is to name an instant, and a 2px line spans
+              // two of them at this scale.
+              className="absolute inset-y-0 left-0 w-px -translate-x-1/2 bg-red-500"
+            >
+              {/* The head of the line, so the playhead reads as a position that
+                was put there rather than a border between two boxes — and
+                what ACKNOWLEDGES A SNAP. A snap moves the playhead by a few
+                pixels at most and is otherwise invisible, so without this you
+                cannot tell the bar helped from your hand being accurate. */}
+              <span className="absolute -top-1 left-1/2 -translate-x-1/2">
+                <SnapPulse snapKey={snapKey} />
+              </span>
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* THE TIME, ON THE PLAYHEAD, while it is being dragged. ABOVE the
+          boxes, not on them: it names the frame you are looking at, and a
+          label laid over that frame answers the question by covering it. */}
+      {chip !== null && playheadPx !== null && (
+        <span
+          data-seam-chip
+          aria-hidden="true"
+          style={{ left: viewportX(playheadPx) }}
+          className="pointer-events-none absolute -top-[22px] z-10 -translate-x-1/2 rounded border border-zinc-700 bg-zinc-950/95 px-1.5 py-0.5 font-mono text-[10px] tabular-nums text-zinc-100 shadow-lg"
+        >
+          {chip}
+        </span>
+      )}
+
+      {/* WHAT IS UNDER THE POINTER. A name and a frame, which together answer
+          "is that the shot I am looking for" without moving the playhead to
+          find out — the thing a bar of anonymous boxes cannot do. */}
+      {hover !== null && (
+        <span
+          data-seam-preview
+          aria-hidden="true"
+          style={{ left: viewportX(hover.x) }}
+          // BELOW THE WHOLE BAR, not just below the boxes: at `top-9` it lay
+          // across the ruler and the minimap, hiding the two things that say
+          // where the box being previewed actually is.
+          className="pointer-events-none absolute top-20 z-20 flex max-w-64 -translate-x-1/2 items-center gap-2 rounded-md border border-zinc-700 bg-zinc-950/95 p-1.5 shadow-xl"
+        >
+          {hover.posterSrc === undefined ? null : (
+            // A bare <img>: the preview is a thumbnail of a source the app
+            // already holds a URL for, and next/image would add a loader
+            // round-trip on every hover for a 56px picture.
+            <img
+              src={hover.posterSrc}
+              alt=""
+              className="h-8 w-14 shrink-0 rounded-sm object-cover"
+            />
+          )}
+          <span className="min-w-0">
+            <span className="block truncate text-[11px] text-zinc-100">
+              {hover.name}
+            </span>
+            <span className="mt-0.5 block truncate font-mono text-[10px] tabular-nums text-zinc-500">
+              {hover.meta}
+            </span>
+          </span>
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-minimap.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-minimap.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+
+import { collectionSeams, type SeamBarClip } from "./graph-seam-bar-layout";
+
+/**
+ * THE WHOLE SEQUENCE, IN MINIATURE — and the only thing on screen that is.
+ *
+ * The bar above it is a window: it zooms, it pans, and at any useful scale
+ * most of the project is off the sides of it. That is the right trade for
+ * working on a cut and the wrong one for knowing where you are, so the two
+ * questions get two objects. This one never zooms and never scrolls; every
+ * clip in playback order is always on it, at a width proportional to its
+ * length, tinted by the collection it belongs to.
+ *
+ * The rectangle is what the bar above is currently showing. Reading the two
+ * together is the whole point: the boxes tell you about this cut, the
+ * rectangle tells you which twentieth of the project this cut is in.
+ *
+ * DRAG IT TO GO THERE. It is a map, so pressing a point on it means "show me
+ * that part" — a pan, not a seek. Scrubbing is the bar's job and moving the
+ * playhead from here would make one gesture do two things depending on which
+ * strip your finger happened to land on.
+ */
+export function SeamMinimap({
+  clips,
+  colourOf,
+  totalSeconds,
+  windowFromSeconds,
+  windowToSeconds,
+  playheadSeconds,
+  onPanToSeconds,
+}: Readonly<{
+  clips: readonly SeamBarClip[];
+  colourOf: ReadonlyMap<string, string>;
+  totalSeconds: number;
+  /** The span the bar above is showing, in absolute seconds. */
+  windowFromSeconds: number;
+  windowToSeconds: number;
+  playheadSeconds: number | null;
+  /** Put this second in the middle of the bar above. */
+  onPanToSeconds: (seconds: number) => void;
+}>) {
+  const railRef = useRef<HTMLDivElement | null>(null);
+  const draggingRef = useRef<number | null>(null);
+
+  const panTo = useCallback(
+    (clientX: number) => {
+      const rail = railRef.current;
+      if (rail === null || totalSeconds <= 0) return;
+      const box = rail.getBoundingClientRect();
+      if (box.width <= 0) return;
+      const fraction = Math.min(Math.max((clientX - box.left) / box.width, 0), 1);
+      onPanToSeconds(fraction * totalSeconds);
+    },
+    [onPanToSeconds, totalSeconds],
+  );
+
+  if (totalSeconds <= 0) return null;
+
+  const seams = new Set(collectionSeams(clips));
+  const asPercent = (seconds: number) =>
+    `${Math.min(Math.max((seconds / totalSeconds) * 100, 0), 100)}%`;
+  const windowWidth = Math.max(
+    0.8,
+    ((windowToSeconds - windowFromSeconds) / totalSeconds) * 100,
+  );
+
+  return (
+    <div
+      ref={railRef}
+      data-seam-minimap
+      aria-hidden="true"
+      onPointerDown={(event) => {
+        if (!event.isPrimary || event.button !== 0) return;
+        try {
+          event.currentTarget.setPointerCapture(event.pointerId);
+        } catch {
+          /* untrusted pointer (stories) — the moves still arrive here */
+        }
+        draggingRef.current = event.pointerId;
+        panTo(event.clientX);
+      }}
+      onPointerMove={(event) => {
+        if (draggingRef.current !== event.pointerId) return;
+        panTo(event.clientX);
+      }}
+      onPointerUp={() => {
+        draggingRef.current = null;
+      }}
+      onPointerCancel={() => {
+        draggingRef.current = null;
+      }}
+      className="relative mt-1.5 h-3.5 cursor-grab touch-none select-none active:cursor-grabbing"
+    >
+      <div className="absolute inset-x-0 top-1 flex h-1.5 gap-px">
+        {clips.map((clip, index) => {
+          if (clip.showingSeconds <= 0) return null;
+          return (
+            <span
+              key={clip.id}
+              data-seam-mini-segment={clip.id}
+              style={{
+                flexGrow: clip.showingSeconds,
+                backgroundColor: colourOf.get(clip.id) ?? "hsl(220 8% 34%)",
+                // A real gap where the collection changes, so the runs read
+                // as runs at a scale far too small for a label.
+                marginLeft: index > 0 && seams.has(index) ? 3 : undefined,
+              }}
+              className="min-w-px flex-shrink rounded-[1px] opacity-70"
+            />
+          );
+        })}
+      </div>
+
+      {/* WHAT THE BAR IS SHOWING. A floor on the width because at a hundred
+          clips a single-clip window rounds to nothing, and a rectangle you
+          cannot see is worse than no rectangle: it says the bar is nowhere. */}
+      <span
+        data-seam-mini-window
+        style={{ left: asPercent(windowFromSeconds), width: `${windowWidth}%` }}
+        className="absolute inset-y-0 rounded-[3px] border border-white/30 bg-white/8"
+      />
+
+      {playheadSeconds !== null && (
+        <span
+          data-seam-mini-playhead
+          style={{ left: asPercent(playheadSeconds) }}
+          className="absolute inset-y-0 w-px -translate-x-1/2 bg-red-500"
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-ruler.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-ruler.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import type { SeamTick } from "./graph-seam-bar-layout";
+
+/**
+ * The scale under the boxes: seconds, and where each collection starts.
+ *
+ * WHY A RULER AT ALL, when the boxes are already proportional. Because the
+ * bar zooms. A box's width means "this long" only against a scale, and
+ * without one a ten-second clip at 4px a second and a one-second clip at 40
+ * are the same object on screen — the reader has no way to tell which of the
+ * two bars in front of them they are looking at.
+ *
+ * The collection ticks are the other half, and the more important half. Time
+ * is derivable; "Van Interior begins here" is not, and it is the only
+ * landmark on a run of boxes that otherwise looks the same all the way along.
+ * They are drawn in the ink the bar reserves for structure, and they are the
+ * ones that win a collision — see `seamRulerTicks`.
+ */
+export function SeamRuler({
+  ticks,
+  offset,
+}: Readonly<{
+  ticks: readonly SeamTick[];
+  /** The strip's own transform, so the ruler travels with the boxes. */
+  offset: number;
+}>) {
+  if (ticks.length === 0) return null;
+  return (
+    <div
+      data-seam-ruler
+      aria-hidden="true"
+      className="pointer-events-none relative h-4 overflow-hidden"
+    >
+      <div
+        className="absolute inset-y-0 left-0 w-full"
+        style={{ transform: `translateX(${offset}px)` }}
+      >
+        {ticks.map((tick) => (
+          <span
+            key={`${tick.kind}-${tick.x}-${tick.label}`}
+            data-seam-tick={tick.kind}
+            style={{ left: tick.x }}
+            className="absolute top-0"
+          >
+            <span
+              className={[
+                "absolute top-0 left-0 w-px",
+                tick.kind === "collection" ? "h-1.5 bg-white/45" : "h-1 bg-white/20",
+              ].join(" ")}
+            />
+            {/* Left-ALIGNED to the tick rather than centred on it. A
+                collection label names the thing that starts HERE, and a
+                centred one hangs half of itself over the collection that just
+                ended — which reads as belonging to the wrong side of the
+                seam. */}
+            <span
+              className={[
+                "absolute top-2 left-0 max-w-32 truncate font-mono text-[9px] leading-none whitespace-nowrap",
+                tick.kind === "collection"
+                  ? "tracking-wider text-zinc-300"
+                  : "tabular-nums text-zinc-600",
+              ].join(" ")}
+            >
+              {tick.label}
+            </span>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -1,108 +1,116 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronLeft, ChevronRight, Pause, Play } from "lucide-react";
 
 import {
+  fitPixelsPerSecond,
+  offsetAfterZoom,
+  seamRulerTicks,
+  snapToCut,
+  zoomByWheel,
+  type SeamBarClip,
+} from "./graph-seam-bar-layout";
+import { SeamLane, type SeamHover } from "./graph-seam-lane";
+import { SeamMinimap } from "./graph-seam-minimap";
+import { SeamRuler } from "./graph-seam-ruler";
+import {
+  buildSeamStrip,
   stripCentreOffset,
   stripPositionAt,
-  type SeamStrip,
+  stripXFor,
 } from "./graph-seam-strip";
 
 /**
- * The bar over the carousel: every clip in the collection as a box, with the
- * one you are looking at centred over the card in the middle.
+ * The bar over the carousel: the whole project in playback order, as a
+ * zoomable, pannable, scrubbable timeline.
  *
- * ── HOW IT DIFFERS FROM THE BAR IT REPLACES ──────────────────────────────
+ * ── ONE SURFACE, THREE GESTURES, EACH WITH ITS OWN INPUT ─────────────────
  *
- * The old bar drew the clock's own window — three clips and two leads —
- * stretched across the full width. Two consequences, both of which this
- * exists to undo. Its boxes had no fixed meaning: the same clip was wide in a
- * three-up view and narrow in a five-up one, because the width was a share of
- * whatever else was on screen. And advancing REBUILT it, so the boxes that
- * stayed jumped to new coordinates instead of moving.
+ * DRAG THE BOXES TO SCRUB. The film is the control — you put the playhead on
+ * the frame you want by pointing at it, and it snaps to a cut when you land
+ * near one. There was a rail and ball under the boxes doing this, on the
+ * theory that a filmstrip and a scrubber are different objects; they are not,
+ * and separating them cost a whole second strip to say what the boxes were
+ * already showing.
  *
- * Here the layout is absolute (see `graph-seam-strip`) and the only thing that
- * changes on an advance is the transform. So a box is the size of its clip,
- * always; the clips that stay put travel exactly the distance the cards below
- * them travel; and the clips that arrive slide in from the edge rather than
- * appearing there.
+ * WHEEL TO PAN. Panning is the gesture you make while reading, so it belongs
+ * on the input you can use without committing to anything — and it frees the
+ * press for the job above.
  *
- * ── ONE BOX IS LIT, AND THE REST ARE TINTED BY COLLECTION ────────────────
+ * ⌘ OR CTRL AND WHEEL TO ZOOM, about the pointer, so the clip you were
+ * looking at when you started is the clip you are looking at when you stop.
+ * This is the part the bar could not do at all before: at one fixed scale a
+ * four-minute project is either a smear or a thing you can see a tenth of,
+ * and which you get depends on nothing but the length of the project.
  *
- * MARKED means centred — one box, the clip under the middle card, wearing a
- * check and a thin ring. It is not a colour, and that is the point: colour is
- * spoken for by the collection tints, so spending blue on "you are here" would
- * make one channel carry two meanings and quietly break the grouping. An
- * earlier version did exactly that, and before it lit every clip with a card
- * on screen — which answered a question nobody was asking, since you can see
- * which cards are up by looking at them.
+ * ── AND THREE THINGS THAT SAY WHERE YOU ARE ─────────────────────────────
  *
- * Everything else is tinted by the collection it came from, which is how the
- * bar can span the whole playback order without becoming an undifferentiated
- * run of boxes: a change of colour is a change of collection, and it lands
- * exactly where the row will cross into one.
+ * A RULER, because a box's width means "this long" only against a scale, and
+ * the scale now moves. It carries the collection names too, which are the
+ * only landmarks on a run of boxes that otherwise looks the same throughout.
  *
- * NESTING IS IN THE COLOUR ITSELF. A collection directly under the root takes
- * a hue far from its neighbours; every level below shifts a little from its
- * parent and lifts, so a collection inside an orange one is a near-orange.
- * Depth reads as a family, the top level reads as a difference, and none of it
- * costs a second channel — an earlier version drew the ancestors as bars
- * across the top of each box, which was a stripe explaining what the colour
- * had failed to say.
+ * A MINIMAP, because the bar is a window and that is most of the reason to
+ * have one. It shows the whole sequence, always, with a rectangle marking the
+ * part the bar is currently drawing.
  *
- * The tints are deliberately MUTED and deliberately not blue. They are
- * grouping, not state — the only saturated thing on this bar should be the
- * box you are on, and the only red should be the playhead.
+ * A HOVER PREVIEW, because a box is anonymous. Pointing at one and being told
+ * what it is answers "is that the shot I want" without moving the playhead to
+ * find out.
+ *
+ * ── WHAT IT DELIBERATELY DOES NOT DO ────────────────────────────────────
+ *
+ * LETTING GO CHOOSES NOTHING. A scrub is a look: you check what is coming up
+ * and go back to what you were doing, and a release that made the landing
+ * point the active clip would have already moved you. A CLICK on a box is how
+ * you commit to one, and the arrows are how you step.
+ *
+ * THE ACTIVE CLIP IS NOT DRAGGED TO THE MIDDLE. A change of subject brings
+ * the new clip into VIEW if it is off the side, and otherwise leaves the bar
+ * exactly where you put it.
  */
-/**
- * How far each box is pulled in from its clip's true extent, per side.
- *
- * The gap between two boxes is therefore twice this. It is an inset rather
- * than a margin because the box's MIDDLE has to stay exactly on the clip's
- * middle — that is what the centring arithmetic aligns to the card below —
- * and trimming only the width would shift it by half the gap.
- */
-const BOX_INSET_PX = 2.5;
-
-/** Travel that turns a press on the boxes from a click into a pan. */
-const CLICK_SLOP_PX = 4;
 
 /**
- * How near an end of the track the ball has to get before the strip starts
+ * How near an end of the track the pointer has to get before the strip starts
  * travelling under it, and how fast it goes when it does.
  *
  * The speed ramps with depth into the zone rather than being a constant, so
- * the edge is a throttle and not a switch: a ball resting just inside it
+ * the edge is a throttle and not a switch: a pointer resting just inside it
  * creeps along at a readable pace, one pushed hard against the very end runs
- * at `MAX`, and the two are the same gesture at different depths. At a flat
- * speed the only way to travel a little would be to touch the edge and
- * immediately back off, which is a flinch rather than a control.
+ * at `MAX`, and the two are the same gesture at different depths.
  */
 const EDGE_PAN_ZONE_PX = 40;
 const EDGE_PAN_MAX_PX_PER_FRAME = 16;
 const EDGE_PAN_GAIN = 0.4;
 
+/** Travel that turns a press on the boxes from a click into a scrub. */
+const CLICK_SLOP_PX = 4;
+
 /**
- * How fast the strip should travel for a ball at `clientX`, in px per frame.
- *
- * Positive means the strip moves LEFT — later clips come in from the right,
- * which is the direction the ball is being pushed. Zero anywhere but the two
- * zones, so the ordinary middle of the rail is an ordinary scrubber.
+ * How much clear track the playhead keeps either side of it while the bar is
+ * following playback. Wider on the trailing side because playback runs that
+ * way and the point of following is to show what is COMING.
  */
-function edgePanVelocity(clientX: number, rail: DOMRect): number {
-  const intoLeft = rail.left + EDGE_PAN_ZONE_PX - clientX;
+const FOLLOW_LEAD_PX = 56;
+const FOLLOW_TRAIL_PX = 72;
+
+function edgePanVelocity(clientX: number, track: DOMRect): number {
+  const intoLeft = track.left + EDGE_PAN_ZONE_PX - clientX;
   if (intoLeft > 0) return -Math.min(EDGE_PAN_MAX_PX_PER_FRAME, intoLeft * EDGE_PAN_GAIN);
-  const intoRight = clientX - (rail.right - EDGE_PAN_ZONE_PX);
+  const intoRight = clientX - (track.right - EDGE_PAN_ZONE_PX);
   if (intoRight > 0) return Math.min(EDGE_PAN_MAX_PX_PER_FRAME, intoRight * EDGE_PAN_GAIN);
   return 0;
 }
 
+function readSeconds(value: number): string {
+  return `${value.toFixed(2)}s`;
+}
+
 export function SeamStripBar({
-  strip,
+  clips,
   centreClipId,
   colourOf,
-  playheadPx,
+  playheadAt,
   playing,
   onTogglePlay,
   onStepBack,
@@ -111,35 +119,32 @@ export function SeamStripBar({
   onCommitClip,
   onScrubbingChange,
 }: Readonly<{
-  strip: SeamStrip;
-  /** The clip to centre — the one under the middle card. */
+  /** Every clip the bar can reach, in playback order. */
+  clips: readonly SeamBarClip[];
+  /** The clip under the middle card — marked, not centred. */
   centreClipId: string;
   /** Each clip's box colour, derived from where its collection sits in the
    *  tree — see `clipColourOf` in the carousel. */
   colourOf: ReadonlyMap<string, string>;
-
-  /** Where the playhead sits, in absolute strip pixels; null when untouched. */
-  playheadPx: number | null;
+  /** Where playback is, as the clock reports it; null when untouched. */
+  playheadAt: Readonly<{ clipId: string; secondsIntoClip: number }> | null;
   playing: boolean;
   onTogglePlay: () => void;
   /** Step the carousel one clip. Null at the end it cannot go. */
   onStepBack: (() => void) | null;
   onStepForward: (() => void) | null;
   /** Scrub to an absolute point on the timeline, in seconds. */
-  onScrubSeconds: (seconds: number) => void;
+  onScrubSeconds: (value: number) => void;
   /** A box was CLICKED — make that clip the centred one. */
   onCommitClip: (clipId: string) => void;
-
   /** True while a drag is live on the bar, false when it ends — the view
    *  grows the monitor for the duration. */
   onScrubbingChange?: (active: boolean) => void;
 }>) {
   const trackRef = useRef<HTMLDivElement | null>(null);
+  const laneRef = useRef<HTMLDivElement | null>(null);
   const [trackWidth, setTrackWidth] = useState(0);
 
-  // The container's width is half the centring arithmetic, so it has to be
-  // measured rather than assumed — and re-measured, because the view count
-  // and the window both change it.
   useEffect(() => {
     const element = trackRef.current;
     if (element === null) return;
@@ -153,7 +158,7 @@ export function SeamStripBar({
 
   // WHERE "CENTRED" IS — computed, not measured off the moving cards.
   //
-  // It is not the middle of this track: the play button and the readout inset
+  // It is not the middle of this track: the transport and the readout inset
   // it, so its own middle sits ~30px left of the card it must sit above.
   //
   // It IS the middle of the LAYOUT viewport. The scrim centres the row and the
@@ -161,12 +166,6 @@ export function SeamStripBar({
   // centre card lands on that middle by construction — and `clientWidth`
   // rather than `innerWidth` because the latter counts the scrollbar, which is
   // the entire 8px the first version of this was out by.
-  //
-  // Two earlier attempts measured the card instead, and both were wrong in the
-  // same way: the card MOVES, so any read is a race with the row's slide. A
-  // timer version stuck ~650px out after a count change; a settle-on-two-equal-
-  // frames version stopped early mid-slide and drifted by thousands. The
-  // geometry was knowable the whole time.
   const [centreAtPx, setCentreAtPx] = useState(0);
   useEffect(() => {
     const element = trackRef.current;
@@ -180,431 +179,486 @@ export function SeamStripBar({
     return () => window.removeEventListener("resize", measure);
   }, [trackWidth]);
 
+  // ── SCALE ────────────────────────────────────────────────────────────────
+  //
+  // Null until the track has been measured, because the opening scale is a
+  // question about width and there is no honest answer before there is one.
+  const [pxPerSecond, setPxPerSecond] = useState<number | null>(null);
 
+  const totalSeconds = useMemo(
+    () => clips.reduce((sum, clip) => sum + Math.max(0, clip.showingSeconds), 0),
+    [clips],
+  );
+
+  // OPENS FITTED TO THE COLLECTION YOU ARE IN, not to the whole project.
+  //
+  // The bar spans everything, and everything is the wrong unit for a first
+  // glance: on a fifty-minute project a fit-to-all scale draws the shot you
+  // opened as two pixels. The collection is the sequence you are working on,
+  // so it gets the width — and at 1.65 trackfuls a little of it is off each
+  // side, which is how the bar says there is more.
+  const subjectCollectionSeconds = useMemo(() => {
+    const subject = clips.find((clip) => clip.id === centreClipId);
+    if (subject === undefined) return totalSeconds;
+    const sum = clips
+      .filter((clip) => clip.collectionId === subject.collectionId)
+      .reduce((total, clip) => total + Math.max(0, clip.showingSeconds), 0);
+    return sum > 0 ? sum : totalSeconds;
+  }, [clips, centreClipId, totalSeconds]);
+
+  useEffect(() => {
+    if (trackWidth <= 0) return;
+    // ONCE. Re-fitting on every width change would undo a zoom whenever the
+    // window moved, and re-fitting on a change of subject would undo one every
+    // time you stepped a clip.
+    setPxPerSecond(
+      (current) => current ?? fitPixelsPerSecond(subjectCollectionSeconds, trackWidth),
+    );
+  }, [trackWidth, subjectCollectionSeconds]);
+
+  const scale = pxPerSecond ?? 9;
+  const strip = useMemo(() => buildSeamStrip(clips, scale), [clips, scale]);
+
+  // ── PAN ──────────────────────────────────────────────────────────────────
+  //
+  // Null until something places it, then owned outright by the user. The
+  // fallback centres the subject, which is the right thing to do exactly once
+  // — on open. After that the bar stays where it was put.
   const [panPx, setPanPx] = useState<number | null>(null);
-  const [panning, setPanning] = useState(false);
-  const panRef = useRef<{ pointerId: number; x: number; from: number; moved: boolean } | null>(null);
-
-  // PARKED ONCE, THEN LEFT ALONE.
-  //
-  // The centring is computed against the clip the view OPENED on, captured
-  // here and never updated. It used to follow the subject, which sounds
-  // helpful and is not: the bar jumped under the hand every time the cards
-  // moved, and a strip you had just pushed somewhere useful threw your
-  // position away. The active clip does not need to be in the middle — it is
-  // marked, which is what makes it findable.
-  //
-  // A state initialiser rather than an effect that freezes it later: an effect
-  // would set state during the first commit, which is a cascading render, and
-  // the compiler's lint refuses it outright.
-  const [parkedOn] = useState(centreClipId);
   const centredOffset = stripCentreOffset(
     strip,
-    parkedOn,
+    centreClipId,
     centreAtPx > 0 ? centreAtPx * 2 : trackWidth,
   );
   const offset = panPx ?? centredOffset;
 
-  const onBoxesPointerDown = useCallback(
+  // Set by any deliberate pan, cleared by any deliberate seek. While it is
+  // set, playback stops dragging the bar around under the reader.
+  const [followSuspended, setFollowSuspended] = useState(false);
+
+  const [scrubbing, setScrubbing] = useState(false);
+  const [snapKey, setSnapKey] = useState(0);
+  const [hover, setHover] = useState<SeamHover | null>(null);
+
+  const playheadPx =
+    playheadAt === null
+      ? null
+      : stripXFor(strip, playheadAt.clipId, playheadAt.secondsIntoClip);
+  const playheadSeconds = playheadPx === null || scale <= 0 ? null : playheadPx / scale;
+
+  // ── MIRRORS ──────────────────────────────────────────────────────────────
+  //
+  // So the frame loop and the native wheel listener can read live values
+  // without listing them as dependencies and re-arming themselves between
+  // frames. Several of these props are inline arrows in the view — a new
+  // function on every render — and depending on one would do exactly that.
+  const pointerXRef = useRef(0);
+  const panPxRef = useRef<number | null>(null);
+  const offsetRef = useRef(0);
+  const scaleRef = useRef(9);
+  const totalPxRef = useRef(0);
+  const onScrubSecondsRef = useRef(onScrubSeconds);
+  useEffect(() => {
+    panPxRef.current = panPx;
+    offsetRef.current = offset;
+    scaleRef.current = scale;
+    totalPxRef.current = strip.totalPx;
+    onScrubSecondsRef.current = onScrubSeconds;
+  });
+
+  /** Move the pan without waiting for a render to tell the loops about it. */
+  const setOffset = useCallback((next: number) => {
+    offsetRef.current = next;
+    panPxRef.current = next;
+    setPanPx(next);
+  }, []);
+
+  const seekToStripX = useCallback((stripX: number) => {
+    if (scaleRef.current <= 0) return;
+    const at = Math.min(Math.max(stripX, 0), totalPxRef.current);
+    onScrubSecondsRef.current(at / scaleRef.current);
+  }, []);
+
+  /** Local x within the track, which is the space every gesture works in. */
+  const localX = useCallback((clientX: number) => {
+    const element = trackRef.current;
+    if (element === null) return 0;
+    return clientX - element.getBoundingClientRect().left;
+  }, []);
+
+  // ── SCRUBBING ────────────────────────────────────────────────────────────
+  const pressRef = useRef<{ pointerId: number; x: number; moved: boolean } | null>(null);
+  const lastSnapRef = useRef<number | null>(null);
+
+  const scrubToClientX = useCallback(
+    (clientX: number) => {
+      const raw = localX(clientX) - offsetRef.current;
+      const snapped = snapToCut(strip, raw);
+      // ACKNOWLEDGE A SNAP ONCE, not on every frame that stays on it. A
+      // playhead twitching sixty times a second while the hand sat still
+      // would be a fault indicator, not a confirmation.
+      if (snapped === raw) {
+        lastSnapRef.current = null;
+      } else if (lastSnapRef.current !== snapped) {
+        lastSnapRef.current = snapped;
+        setSnapKey((key) => key + 1);
+      }
+      seekToStripX(snapped);
+    },
+    [localX, seekToStripX, strip],
+  );
+
+  const onPointerDown = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
       if (!event.isPrimary || event.button !== 0) return;
       try {
         event.currentTarget.setPointerCapture(event.pointerId);
       } catch {
-        /* untrusted pointer (stories) — moves still arrive on the element */
+        /* untrusted pointer (stories) — the moves still arrive here */
       }
-      panRef.current = {
-        pointerId: event.pointerId,
-        x: event.clientX,
-        from: offset,
-        moved: false,
-      };
-      setPanning(true);
+      pressRef.current = { pointerId: event.pointerId, x: event.clientX, moved: false };
+      pointerXRef.current = event.clientX;
+      lastSnapRef.current = null;
+      setHover(null);
+      setScrubbing(true);
+      setFollowSuspended(false);
+      onScrubbingChange?.(true);
+      scrubToClientX(event.clientX);
     },
-    [offset],
+    [onScrubbingChange, scrubToClientX],
   );
 
-  const onBoxesPointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
-    const pan = panRef.current;
-    if (pan === null || event.pointerId !== pan.pointerId) return;
-    const travel = event.clientX - pan.x;
-    if (Math.abs(travel) > CLICK_SLOP_PX) pan.moved = true;
-    setPanPx(pan.from + travel);
-  }, []);
+  const showHover = useCallback(
+    (clientX: number) => {
+      const stripX = localX(clientX) - offsetRef.current;
+      const at = stripPositionAt(strip, stripX);
+      const clip = at === null ? undefined : clips.find((candidate) => candidate.id === at.clipId);
+      if (at === null || clip === undefined) {
+        setHover(null);
+        return;
+      }
+      setHover({
+        x: stripX,
+        name: clip.name,
+        meta: `${clip.collectionName === null ? "" : `${clip.collectionName} · `}${readSeconds(
+          at.secondsIntoClip,
+        )} / ${readSeconds(clip.showingSeconds)}`,
+        ...(clip.posterSrc === undefined ? {} : { posterSrc: clip.posterSrc }),
+      });
+    },
+    [clips, localX, strip],
+  );
 
-  const endPan = useCallback(
+  const onPointerMove = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
-      const pan = panRef.current;
-      panRef.current = null;
-      setPanning(false);
-      if (pan === null || pan.moved) return;
+      const press = pressRef.current;
+      if (press === null) {
+        showHover(event.clientX);
+        return;
+      }
+      if (event.pointerId !== press.pointerId) return;
+      if (Math.abs(event.clientX - press.x) > CLICK_SLOP_PX) press.moved = true;
+      pointerXRef.current = event.clientX;
+      scrubToClientX(event.clientX);
+    },
+    [scrubToClientX, showHover],
+  );
+
+  const endPress = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const press = pressRef.current;
+      pressRef.current = null;
+      if (press === null) return;
+      setScrubbing(false);
+      onScrubbingChange?.(false);
       // A PRESS THAT DID NOT TRAVEL IS A CLICK, and a click on a box makes
       // that clip active. Distinguished by travel rather than by timing,
-      // because the surface's other job is a pan and a slow deliberate push
-      // must not also count as a tap on wherever it started.
-      const rail = railRef.current;
-      if (rail === null) return;
-      const stripX = event.clientX - rail.getBoundingClientRect().left - offset;
+      // because a slow deliberate scrub must not also count as a tap on
+      // wherever it started.
+      if (press.moved) return;
+      const stripX = localX(event.clientX) - offsetRef.current;
       const landedOn = stripPositionAt(strip, stripX)?.clipId ?? null;
       if (landedOn !== null && landedOn !== centreClipId) onCommitClip(landedOn);
     },
-    [strip, centreClipId, onCommitClip, offset],
+    [centreClipId, localX, onCommitClip, onScrubbingChange, strip],
   );
 
-
-
-
-
-
-
-  // ── THE BOXES ARE PUSHED, NOT STEPPED ──────────────────────────────────
+  // ── HOLDING AT AN EDGE RUNS THE STRIP UNDER THE POINTER ──────────────────
   //
-  // Grab and shove: the strip follows the hand for as far as it is dragged and
-  // stays where it is let go. It briefly moved three clips per swipe, which
-  // was wrong twice over — it did not work at all (the gesture only fired on a
-  // clean release past a threshold, so a slow drag did nothing), and tying it
-  // to a NUMBER was the wrong idea anyway. This is a map you are moving
-  // around, not a control that advances.
+  // The track only spans what is on screen, so without this the end of it is
+  // the end of the timeline you can reach in one gesture, with the rest of the
+  // order sitting an inch off the side.
   //
-  // The pan is REMEMBERED once touched. Until then the strip auto-centres on
-  // the subject; after, it stays where it was put, and only a change of
-  // subject re-centres it.
-
-  // ── THE RAIL SCRUBS ─────────────────────────────────────────────────────
-  //
-  // A plain proportional slider over the whole timeline: the clock spans every
-  // clip, so a fraction of the rail is a fraction of the running time and
-  // needs none of the strip's transform arithmetic.
-  const railRef = useRef<HTMLDivElement | null>(null);
-
-  const [scrubbing, setScrubbing] = useState(false);
-
-  // Read out as primitives: the loop below depends on them, and `strip` is
-  // rebuilt by the view on every render.
-  const { totalPx, pxPerSecond } = strip;
-
-  // THE RAIL SHARES THE STRIP'S COORDINATES, which is what makes the ball sit
-  // under the playhead.
-  //
-  // It was a proportional slider over the whole timeline: a fraction of the
-  // rail meant a fraction of the running time. That is a perfectly good
-  // scrubber and it did not LINE UP — the boxes above are drawn at a fixed
-  // scale and panned, so the same instant was at two different x positions and
-  // the ball drifted away from the mark it was supposed to be holding.
-  //
-  // Now a point on the rail is converted through the strip's own transform, so
-  // the two agree by construction at any pan.
-  const secondsAt = useCallback(
-    (clientX: number) => {
-      const rail = railRef.current;
-      if (rail === null || strip.pxPerSecond <= 0) return null;
-      const box = rail.getBoundingClientRect();
-      const stripX = clientX - box.left - offset;
-      return Math.min(Math.max(stripX / strip.pxPerSecond, 0), strip.totalPx / strip.pxPerSecond);
-    },
-    [strip, offset],
-  );
-
-  // Where the ball was last seen, so the frame loop below can keep working a
-  // hand that has stopped moving.
-  const scrubXRef = useRef(0);
-
-  // MIRRORS, so the frame loop can read live values without listing them as
-  // dependencies and restarting itself. `onScrubSeconds` is an inline arrow in
-  // the view, so it is a new function on every render — depending on it would
-  // tear down and re-arm the loop between every pair of frames.
-  const panPxRef = useRef<number | null>(null);
-  const centredOffsetRef = useRef(0);
-  const onScrubSecondsRef = useRef(onScrubSeconds);
+  // A FRAME LOOP RATHER THAN THE POINTER MOVES, because the hand is STILL —
+  // holding at an edge fires no further pointermove events at all, and an
+  // implementation reading the moves would travel only while the hand
+  // jittered.
   useEffect(() => {
-    panPxRef.current = panPx;
-    centredOffsetRef.current = centredOffset;
-    onScrubSecondsRef.current = onScrubSeconds;
-  });
-
-  // ── HOLDING THE BALL AT AN EDGE RUNS THE STRIP UNDER IT ─────────────────
-  //
-  // The rail only spans what is on screen, so without this the end of the
-  // rail is the end of the timeline you can reach: push the ball against the
-  // right edge and the scrub simply stops, with the rest of the order sitting
-  // an inch off the side of the track. Now holding it there pulls the strip
-  // along underneath — forward at the right edge, back at the left — and the
-  // seek follows the clips that arrive, so one gesture crosses the whole
-  // collection instead of the window you happened to open on.
-  //
-  // A FRAME LOOP RATHER THAN THE POINTER MOVES, because the hand is STILL.
-  // The gesture is holding the ball against an edge, which fires no further
-  // pointermove events at all — an implementation hung off the moves would
-  // travel only while the hand jittered, which is precisely the wrong feel.
-  useEffect(() => {
-    if (!scrubbing || pxPerSecond <= 0) return;
+    if (!scrubbing) return;
     let frame = requestAnimationFrame(function tick() {
       frame = requestAnimationFrame(tick);
-      const rail = railRef.current;
-      if (rail === null) return;
-      const box = rail.getBoundingClientRect();
-      const velocity = edgePanVelocity(scrubXRef.current, box);
+      const element = trackRef.current;
+      if (element === null || scaleRef.current <= 0) return;
+      const box = element.getBoundingClientRect();
+      const velocity = edgePanVelocity(pointerXRef.current, box);
       if (velocity === 0) return;
 
-      const next = (panPxRef.current ?? centredOffsetRef.current) - velocity;
-      // IT STOPS AT THE ENDS BY ASKING WHERE THE BALL NOW POINTS, not by
+      const next = offsetRef.current - velocity;
+      // IT STOPS AT THE ENDS BY ASKING WHERE THE POINTER NOW POINTS, not by
       // clamping the transform. The offset that puts the last clip under the
-      // ball is a function of the pan, the track width and the scale, and the
-      // one number that actually has to stay in range is the time being
-      // scrubbed to — so that is the number the guard is written against.
-      const stripX = scrubXRef.current - box.left - next;
-      if (stripX < 0 || stripX > totalPx) return;
+      // pointer is a function of the pan, the track width and the scale, and
+      // the one number that has to stay in range is the time being scrubbed
+      // to — so that is the number the guard is written against.
+      const stripX = pointerXRef.current - box.left - next;
+      if (stripX < 0 || stripX > totalPxRef.current) return;
 
-      panPxRef.current = next;
-      setPanPx(next);
-      onScrubSecondsRef.current(stripX / pxPerSecond);
+      // THE FILM MOVED UNDER THE POINTER, so this is a drag even though the
+      // hand never left the spot it landed on. Without this an edge-scrub
+      // across half the project would end in a CLICK — committing to whatever
+      // clip happened to arrive under a stationary finger.
+      const press = pressRef.current;
+      if (press !== null) press.moved = true;
+
+      setOffset(next);
+      seekToStripX(stripX);
     });
     return () => cancelAnimationFrame(frame);
-  }, [scrubbing, pxPerSecond, totalPx]);
+  }, [scrubbing, seekToStripX, setOffset]);
 
-  const releaseScrub = useCallback(() => {
-    setScrubbing(false);
-    onScrubbingChange?.(false);
-    // LETTING GO CHOOSES NOTHING. It briefly made whatever the scrub landed on
-    // the active clip, which put a decision on the end of a gesture whose
-    // whole purpose is to look around: you could not check what was coming up
-    // and then go back to what you were doing, because looking had already
-    // moved you. Scrubbing is a look; a CLICK on a box is how you commit to
-    // one, and the arrows are how you step.
-  }, [onScrubbingChange]);
+  // ── WHEEL: PAN, OR ZOOM ABOUT THE POINTER ────────────────────────────────
+  //
+  // A NATIVE, NON-PASSIVE LISTENER. React registers `onWheel` passively at the
+  // root, so `preventDefault` from a synthetic handler is ignored — which
+  // would leave a zoom gesture also zooming the browser and a pan gesture also
+  // scrolling the dialog behind the bar.
+  useEffect(() => {
+    const element = laneRef.current;
+    if (element === null) return;
+    const onWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      setFollowSuspended(true);
+      setHover(null);
+      if (event.ctrlKey || event.metaKey) {
+        const from = scaleRef.current;
+        const to = zoomByWheel(from, event.deltaY);
+        if (to === from) return;
+        const anchorLocalX = event.clientX - element.getBoundingClientRect().left;
+        setPxPerSecond(to);
+        setOffset(offsetAfterZoom({ anchorLocalX, offset: offsetRef.current, from, to }));
+        return;
+      }
+      // The dominant axis, so a trackpad's horizontal swipe and a mouse
+      // wheel's vertical notch both mean the same thing on a horizontal bar.
+      const delta =
+        Math.abs(event.deltaX) > Math.abs(event.deltaY) ? event.deltaX : event.deltaY;
+      if (delta === 0) return;
+      setOffset(offsetRef.current - delta);
+    };
+    element.addEventListener("wheel", onWheel, { passive: false });
+    return () => element.removeEventListener("wheel", onWheel);
+  }, [setOffset]);
 
+  // ── KEEPING THE PLAYHEAD IN VIEW ─────────────────────────────────────────
+  //
+  // NUDGED, NOT CENTRED, and only once it has actually reached an edge. A bar
+  // that recentres every frame is a bar whose contents are permanently
+  // sliding, which makes the one thing it is for — reading where you are —
+  // the one thing it is bad at.
+  const nudgeIntoView = useCallback(
+    (targetPx: number) => {
+      const width = trackRef.current?.getBoundingClientRect().width ?? trackWidth;
+      if (width <= 0) return;
+      const current = offsetRef.current;
+      const onScreen = targetPx + current;
+      let next = current;
+      if (onScreen < FOLLOW_LEAD_PX) next = FOLLOW_LEAD_PX - targetPx;
+      else if (onScreen > width - FOLLOW_TRAIL_PX) next = width - FOLLOW_TRAIL_PX - targetPx;
+      if (next === current) return;
+      setOffset(next);
+    },
+    [setOffset, trackWidth],
+  );
+
+  useEffect(() => {
+    if (!playing || followSuspended || playheadPx === null) return;
+    nudgeIntoView(playheadPx);
+  }, [playing, followSuspended, playheadPx, nudgeIntoView]);
+
+  // A CHANGE OF SUBJECT BRINGS THE NEW CLIP INTO VIEW — and no further. It
+  // does not get dragged to the middle: the bar is a map you have positioned,
+  // and stepping a clip is not a request to throw that away. Skipped while the
+  // pan is still null, because the fallback is already centring it.
+  const [broughtIntoView, setBroughtIntoView] = useState(centreClipId);
+  useEffect(() => {
+    if (broughtIntoView === centreClipId) return;
+    setBroughtIntoView(centreClipId);
+    setFollowSuspended(false);
+    if (panPxRef.current === null) return;
+    const segment = strip.segments.find((candidate) => candidate.clipId === centreClipId);
+    if (segment === undefined) return;
+    nudgeIntoView(segment.leftPx + segment.widthPx / 2);
+  }, [broughtIntoView, centreClipId, nudgeIntoView, strip]);
+
+  const ticks = useMemo(() => seamRulerTicks({ strip, clips }), [strip, clips]);
+
+  const panToSeconds = useCallback(
+    (value: number) => {
+      const width = trackRef.current?.getBoundingClientRect().width ?? trackWidth;
+      setFollowSuspended(true);
+      setOffset(width / 2 - value * scaleRef.current);
+    },
+    [setOffset, trackWidth],
+  );
 
   if (strip.totalPx <= 0) return null;
 
-  const totalSeconds = strip.totalPx / strip.pxPerSecond;
-  const atSeconds = playheadPx === null ? null : playheadPx / strip.pxPerSecond;
-  // Where the ball sits: exactly under the playhead, because it is the same
-  // number — the playhead's x on the strip, which the rail now measures in too.
-  const ballPx = playheadPx === null ? null : playheadPx + offset;
+  const atSeconds = playheadSeconds ?? 0;
+  const windowFromSeconds = scale <= 0 ? 0 : -offset / scale;
+  const windowToSeconds = scale <= 0 ? 0 : (-offset + trackWidth) / scale;
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const seekBy = (delta: number) => {
+      event.preventDefault();
+      setFollowSuspended(false);
+      onScrubSeconds(Math.min(Math.max(atSeconds + delta, 0), totalSeconds));
+    };
+    if (event.code === "Space") {
+      event.preventDefault();
+      onTogglePlay();
+    } else if (event.key === "ArrowLeft") {
+      if (event.shiftKey) {
+        event.preventDefault();
+        onStepBack?.();
+      } else seekBy(-1);
+    } else if (event.key === "ArrowRight") {
+      if (event.shiftKey) {
+        event.preventDefault();
+        onStepForward?.();
+      } else seekBy(1);
+    } else if (event.key === "Home") {
+      seekBy(-Infinity);
+    } else if (event.key === "End") {
+      seekBy(Infinity);
+    }
+  };
 
   return (
-    <div data-seam-bar className="flex w-full items-center gap-3">
-      <button
-        type="button"
-        onClick={onTogglePlay}
-        aria-label={playing ? "Pause" : "Play across the cut"}
-        className="shrink-0 rounded-full p-1.5 text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100 outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-      >
-        {playing ? (
-          <Pause aria-hidden="true" className="h-4 w-4" />
-        ) : (
-          <Play aria-hidden="true" className="h-4 w-4" />
-        )}
-      </button>
-
-      {/* STEP ONE CLIP, either way.
-          The bar is a map of the whole order and the cards move by gesture —
-          swipe, or click a neighbour — which is fine when the next clip is on
-          screen and awkward when you just want the next one. Two arrows are
-          the plainest possible statement of "one forward, one back", and they
-          bracket the thing they move.
-          Disabled rather than hidden at the ends: a control that vanishes
-          takes its own position with it and shifts the bar sideways. */}
-      <button
-        type="button"
-        data-seam-step="back"
-        disabled={onStepBack === null}
-        onClick={() => onStepBack?.()}
-        aria-label="Previous clip"
-        title="Previous clip"
-        className="shrink-0 rounded p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100 disabled:pointer-events-none disabled:opacity-25 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
-      >
-        <ChevronLeft aria-hidden="true" className="h-4 w-4" />
-      </button>
+    <div data-seam-bar className="flex w-full items-start gap-3">
+      <div className="flex shrink-0 items-center gap-1">
+        {/* STEP ONE CLIP, either way, bracketing the thing they move.
+            Disabled rather than hidden at the ends: a control that vanishes
+            takes its own position with it and shifts the bar sideways. */}
+        <button
+          type="button"
+          data-seam-step="back"
+          disabled={onStepBack === null}
+          onClick={() => onStepBack?.()}
+          aria-label="Previous clip"
+          title="Previous clip (⇧←)"
+          className="rounded p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-25"
+        >
+          <ChevronLeft aria-hidden="true" className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          onClick={onTogglePlay}
+          aria-label={playing ? "Pause" : "Play across the cut"}
+          title="Play / pause (space)"
+          className="rounded-full p-1.5 text-zinc-300 outline-none hover:bg-zinc-800 hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-blue-500"
+        >
+          {playing ? (
+            <Pause aria-hidden="true" className="h-4 w-4" />
+          ) : (
+            <Play aria-hidden="true" className="h-4 w-4" />
+          )}
+        </button>
+        <button
+          type="button"
+          data-seam-step="forward"
+          disabled={onStepForward === null}
+          onClick={() => onStepForward?.()}
+          aria-label="Next clip"
+          title="Next clip (⇧→)"
+          className="rounded p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-25"
+        >
+          <ChevronRight aria-hidden="true" className="h-4 w-4" />
+        </button>
+      </div>
 
       <div
         ref={trackRef}
         data-seam-track
         data-seam-centre-at={Math.round(centreAtPx)}
+        data-seam-pps={Math.round(scale * 100) / 100}
         role="slider"
         tabIndex={0}
         aria-label="Scrub across the cut"
         aria-valuemin={0}
         aria-valuemax={Math.round(totalSeconds * 100) / 100}
-        aria-valuenow={Math.round((atSeconds ?? 0) * 100) / 100}
+        aria-valuenow={Math.round(atSeconds * 100) / 100}
+        onKeyDown={onKeyDown}
         // `outline-none` on the BASE, not only on focus-visible. It is a
         // role="slider" with a tabIndex, so pressing it focuses it — and the
-        // browser's own focus ring was drawing a pale outline around the whole
-        // track the moment you touched it, which read as a border the bar did
-        // not have a second earlier. Keyboard focus still gets a visible ring,
-        // in blue, from the focus-visible rule.
+        // browser's own focus ring drew a pale outline around the whole track
+        // the moment you touched it, which read as a border the bar did not
+        // have a second earlier.
         className="relative flex-1 outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
       >
-        <div
-          data-seam-boxes
-          onPointerDown={onBoxesPointerDown}
-          onPointerMove={onBoxesPointerMove}
-          onPointerUp={endPan}
-          onPointerCancel={endPan}
-          className="relative h-9 cursor-grab overflow-hidden active:cursor-grabbing"
-        >
-        <div
-          data-seam-strip
-          className="absolute inset-y-0 left-0 will-change-transform"
-          style={{
-            transform: `translateX(${offset}px)`,
-            width: strip.totalPx,
-            // EASED WHEN IT MOVES ITSELF, INSTANT WHEN YOU MOVE IT.
-            //
-            // A change of subject re-centres the strip, and that should glide.
-            // A hand pushing it should not: with the transition left on, every
-            // pointer move started a 260ms animation toward a target the next
-            // move replaced, so the strip lagged the hand and — measured — a
-            // second shove inside that window looked like no movement at all.
-            // Off for a scrub as well as a pan: the edge loop moves the strip
-            // every frame, and a 260ms ease toward a target the next frame
-            // replaces is the same lag the pan had, one gesture over.
-            transition:
-              panning || scrubbing ? "none" : "transform 260ms cubic-bezier(0.22, 0.61, 0.36, 1)",
+        <SeamLane
+          laneRef={laneRef}
+          strip={strip}
+          clips={clips}
+          colourOf={colourOf}
+          centreClipId={centreClipId}
+          offset={offset}
+          playheadPx={playheadPx}
+          snapKey={snapKey}
+          ghostX={hover === null ? null : hover.x}
+          hover={scrubbing ? null : hover}
+          chip={scrubbing ? readSeconds(atSeconds) : null}
+          handlers={{
+            onPointerDown,
+            onPointerMove,
+            onPointerUp: endPress,
+            onPointerCancel: endPress,
+            onPointerLeave: () => setHover(null),
           }}
-        >
-          {strip.segments.map((segment) => {
-            if (segment.widthPx <= 0) return null;
-            const isCentre = segment.clipId === centreClipId;
-            const colour = colourOf.get(segment.clipId) ?? "hsl(220 8% 34%)";
-            return (
-              <span
-                key={segment.clipId}
-                data-seam-segment={segment.clipId}
-                data-seam-segment-live={isCentre ? "" : undefined}
-                aria-hidden="true"
-                // Inset from BOTH sides — see BOX_INSET_PX. The floor keeps a
-                // very short clip as a visible sliver rather than letting the
-                // gap eat it.
-                style={{
-                  left: segment.leftPx + BOX_INSET_PX,
-                  width: Math.max(2, segment.widthPx - BOX_INSET_PX * 2),
-                  backgroundColor: colour,
-                }}
-                className={[
-                  "absolute inset-y-0 flex items-center justify-center overflow-hidden rounded-[3px]",
-                  // NO RING. The centred box was outlined as well as checked,
-                  // which at a box's width read as two stray white edges
-                  // rather than as an outline — the corners round away and
-                  // only the left and right sides survive. The check alone
-                  // says it, and the box keeps its collection's colour because
-                  // colour is spoken for: it says which collection a clip
-                  // belongs to, and one channel cannot carry two meanings.
-                ].join(" ")}
-              >
-                {/* WHICH ONE YOU ARE ON, as a mark rather than a hue. Hidden
-                    on a box too narrow to hold it: a check crushed into 10px
-                    is a smudge, and the ring already says the same thing. */}
-                {isCentre && segment.widthPx >= 16 ? (
-                  // A DISC, NOT A GLYPH. A check said "done" — a state this
-                  // clip is not in — and being white it was the brightest
-                  // thing on the bar, louder than the playhead, which is the
-                  // mark that actually moves. A hole punched in the box reads
-                  // as "this one" without introducing a second shape or a
-                  // second colour: it is black at half strength, so the clip's
-                  // own colour comes through it and the disc stays a shade of
-                  // the box rather than a mark laid on top of it.
-                  <span
-                    data-seam-marker
-                    className="h-3 w-3 rounded-full bg-black/50"
-                  />
-                ) : null}
-              </span>
-            );
-          })}
-        </div>
+        />
 
-        {playheadPx !== null && (
-          <span
-            data-seam-playhead
-            aria-hidden="true"
-            style={{ transform: `translateX(${playheadPx + offset}px)` }}
-            // A HAIRLINE. One physical pixel wherever the display allows it:
-            // the playhead's job is to name an instant, and a 2px line spans
-            // two of them at this scale. `w-px` rather than a fraction of a
-            // rem so it does not thicken with the type scale.
-            className="absolute inset-y-0 left-0 w-px -translate-x-1/2 bg-red-500"
-          >
-            {/* The head of the line, so the playhead reads as a position that
-                was put there rather than a border between two boxes. */}
-            <span className="absolute -top-1 left-1/2 h-1.5 w-1.5 -translate-x-1/2 rounded-full bg-red-500" />
-          </span>
-        )}
-        </div>
+        {/* THERE IS MORE THAT WAY. The boxes are clipped hard at the track's
+            edges, and a hard edge is indistinguishable from an end — these say
+            which of the two you are looking at, and disappear when there is
+            nothing beyond. */}
+        <span
+          aria-hidden="true"
+          data-seam-fade="left"
+          hidden={offset >= -0.5}
+          className="pointer-events-none absolute top-0 left-0 h-9 w-6 bg-gradient-to-r from-zinc-950 to-transparent"
+        />
+        <span
+          aria-hidden="true"
+          data-seam-fade="right"
+          hidden={strip.totalPx + offset <= trackWidth + 0.5}
+          className="pointer-events-none absolute top-0 right-0 h-9 w-6 bg-gradient-to-l from-zinc-950 to-transparent"
+        />
 
-        {/* THE SCRUBBER: a rail and a ball.
-            Separated from the boxes so each surface does one thing — the boxes
-            are a filmstrip you push, this is a control you drag. It spans the
-            whole timeline, so a fraction of the rail is a fraction of the
-            running time and none of the strip's transform arithmetic applies.
-        */}
-        <div
-          ref={railRef}
-          data-seam-rail
-          onPointerDown={(event) => {
-            if (!event.isPrimary || event.button !== 0) return;
-            try {
-              event.currentTarget.setPointerCapture(event.pointerId);
-            } catch {
-              /* untrusted pointer (stories) — the moves still arrive here */
-            }
-            scrubXRef.current = event.clientX;
-            setScrubbing(true);
-            onScrubbingChange?.(true);
-            const at = secondsAt(event.clientX);
-            if (at !== null) onScrubSeconds(at);
-          }}
-          onPointerMove={(event) => {
-            if (!scrubbing) return;
-            // Recorded on every move so the frame loop keeps travelling after
-            // the hand stops — the edge gesture is a HOLD, not a drag.
-            scrubXRef.current = event.clientX;
-            const at = secondsAt(event.clientX);
-            if (at !== null) onScrubSeconds(at);
-          }}
-          onPointerUp={releaseScrub}
-          onPointerCancel={releaseScrub}
-          className="relative mt-1.5 flex h-4 cursor-ew-resize items-center"
-        >
-          <span aria-hidden="true" className="absolute inset-x-0 h-0.5 rounded-full bg-white/20" />
-          {/* Played so far, so the rail reads as a clock and not only as a
-              track with a dot on it. */}
-          {ballPx !== null && (
-            <>
-              {/* Played so far, so the rail reads as a clock and not only as a
-                  track with a dot on it. */}
-              <span
-                aria-hidden="true"
-                style={{ width: Math.max(0, ballPx) }}
-                className="absolute left-0 h-0.5 rounded-full bg-white/45"
-              />
-              <span
-                data-seam-ball
-                aria-hidden="true"
-                style={{ left: ballPx }}
-                className="absolute h-3 w-3 -translate-x-1/2 rounded-full bg-white shadow-[0_1px_3px_rgba(0,0,0,0.6)]"
-              />
-            </>
-          )}
-        </div>
+        <SeamRuler ticks={ticks} offset={offset} />
+
+        <SeamMinimap
+          clips={clips}
+          colourOf={colourOf}
+          totalSeconds={totalSeconds}
+          windowFromSeconds={windowFromSeconds}
+          windowToSeconds={windowToSeconds}
+          playheadSeconds={playheadSeconds}
+          onPanToSeconds={panToSeconds}
+        />
       </div>
 
-      <button
-        type="button"
-        data-seam-step="forward"
-        disabled={onStepForward === null}
-        onClick={() => onStepForward?.()}
-        aria-label="Next clip"
-        title="Next clip"
-        className="shrink-0 rounded p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100 disabled:pointer-events-none disabled:opacity-25 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
-      >
-        <ChevronRight aria-hidden="true" className="h-4 w-4" />
-      </button>
-
       <span className="shrink-0 font-mono text-[11px] tabular-nums text-zinc-400">
-        <span className="text-blue-300">{(atSeconds ?? 0).toFixed(2)}s</span>
+        <span className="text-blue-300">{readSeconds(atSeconds)}</span>
         {" / "}
-        {totalSeconds.toFixed(2)}s
+        {readSeconds(totalSeconds)}
       </span>
     </div>
   );

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -263,14 +263,32 @@ export function SeamStripBar({
     offsetRef.current = offset;
     scaleRef.current = scale;
     totalPxRef.current = strip.totalPx;
+    panLimitRef.current = panLimit;
     onScrubSecondsRef.current = onScrubSeconds;
   });
 
+  // HOW FAR THE STRIP MAY BE PUSHED EITHER WAY.
+  //
+  // A native scroller clamps at both ends for free, and the bar's transform
+  // does not — without this a firm two-finger swipe throws the whole strip off
+  // the side of the track and leaves you looking at an empty bar, with the
+  // minimap as the only clue where it went.
+  //
+  // The bound is the CENTRE OF THE TRACK rather than its edges: the opening
+  // position centres the marked box, so an early clip legitimately sits with
+  // the strip pushed right and empty space before it — that space is the truth
+  // that there is nothing before the first clip. Clamping to zero would undo
+  // the one alignment the bar exists to hold.
+  const panLimit = Math.max(trackWidth / 2, centreAtPx);
+  const panLimitRef = useRef(0);
+
   /** Move the pan without waiting for a render to tell the loops about it. */
   const setOffset = useCallback((next: number) => {
-    offsetRef.current = next;
-    panPxRef.current = next;
-    setPanPx(next);
+    const most = panLimitRef.current;
+    const clamped = Math.min(most, Math.max(most - totalPxRef.current, next));
+    offsetRef.current = clamped;
+    panPxRef.current = clamped;
+    setPanPx(clamped);
   }, []);
 
   const seekToStripX = useCallback((stripX: number) => {


### PR DESCRIPTION
Working from the `playbar-redesign.html` artifact. The bar was a fixed-scale strip you pushed with one hand and scrubbed with a rail under it. It is now a **window onto the whole project** that you can zoom, pan and read.

## One surface, three gestures

| gesture | does |
| --- | --- |
| drag the boxes | **scrub** — snaps to a cut within 7px |
| wheel / trackpad | **pan** |
| ⌘ or ctrl + wheel | **zoom about the pointer**, 2.5–40 px/s |
| hold near either edge while scrubbing | run the strip under the pointer (from #500) |
| press without travelling | commit to that clip |
| drag the minimap | move the window |
| space / ⇧←→ / ←→ / Home / End | play, step a clip, ±1s, ends |

The rail and ball are gone. A filmstrip and a scrubber are not two objects, and separating them cost a whole second strip to say what the boxes already showed.

## Three things that say where you are

- **A ruler** — a box's width means "this long" only against a scale, and the scale now moves. It carries the collection names too, which are the only landmarks on an otherwise uniform run of boxes.
- **A minimap** — the bar is a window, and that is most of the reason to have one. Every clip is always on it, with a rectangle marking what the bar is drawing.
- **A hover preview** — a box is anonymous. "Is that the shot I want" should not cost you your position to answer.

## Two places the artifact is deliberately not followed

Both were reversed by hand earlier in the session, and a design document does not un-reverse them:

- **Letting go of a scrub still chooses nothing.** The artifact re-centres the carousel on release.
- **The boxes keep their nesting-derived collection colours.** The artifact is one clay tone plus seams.

A press that does *not* travel still commits to a clip, which is how the drag and the click coexist on one surface.

## Measured

819px track, 144s of footage, two collections:

| | |
| --- | --- |
| opening scale | 18.77 px/s — the subject's own collection across 1.65 trackfuls, so the window holds 43.6s of the 144 |
| three ⌘-wheel notches | 18.77 → 40 px/s, second under the cursor 38.668 → 38.642 (**26 ms drift across a 2.1× zoom**) |
| ruler ladder follows | 5s ticks at 18.77 px/s, 2s ticks at 40 |
| snap | presses 3px either side of a cut land on the *same* clock value; 40px inside a clip lands 40/pps later, to within 0.05s |
| pan clamp | 20 hard notches each way still leaves >40% of the track covered |
| chip clearance | chip bottom 79, lane top 80 — it no longer covers the frames it reports on |
| preview clearance | preview top 160, minimap bottom 152 — clear of the ruler and minimap |

The edge throttle from #500 still runs, and no longer ends in an accidental commit: the film moving under a still hand now counts as travel.

## A layout fault the taller bar exposed

The row is centred in the scrim while the header and bar are absolutely positioned, so they took no space and the minimap came to rest **8px over the top edge of the middle card**. The band is now reserved: 68px clear at 900px tall, 36px at 700px.

## Tests

7 new stories, 27 new unit tests for the layout arithmetic (`graph-seam-bar-layout.ts`). Storybook 1108 ✓, app 1417 ✓, lint 0 errors, e2e `graph-view` 175 passed / 4 skipped — one flake ("cut items from BEFORE the destination still land after it") which passes on its own and is unrelated to the bar.

The bar now owns the scale, so it owns the layout: the view hands it clips, not pixels, and `BAR_PIXELS_PER_SECOND` is gone. Split into `graph-seam-bar-layout.ts` (pure), `graph-seam-lane.tsx`, `graph-seam-ruler.tsx`, `graph-seam-minimap.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)