### PR TITLE
Park the bar's collection tint behind a flag; grey by default

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -1995,3 +1995,67 @@ export const TheBarTakesTheKeyboard: Story = {
     await waitFor(() => expect(subject()).not.toBe(startedOn));
   },
 };
+
+/**
+ * THE BAR IS GREY, AND THE SEAMS STILL SHOW.
+ *
+ * The collection tint is parked behind `NEXT_PUBLIC_GSTUDIO_BAR_COLOURS`, off
+ * by default, so every box on the strip and every segment of the minimap draws
+ * in one neutral. This is the DEFAULT that is pinned here — the tinted path
+ * cannot be exercised from a story, because the flag is a compile-time
+ * constant; turn it on and this is the story that should fail.
+ *
+ * THE SECOND HALF IS THE POINT. A bar in which every clip looks alike is only
+ * acceptable because the structure it used to carry in colour is carried
+ * elsewhere: a dashed divider on the strip, a named tick on the ruler, and a
+ * real gap in the minimap. So this asserts the greyness AND the three
+ * landmarks together — losing either half is what would make the flag a
+ * regression rather than a parking space.
+ */
+export const TheBarIsGreyUntilTheTintIsSwitchedOn: Story = {
+  render: () => <SeamHarness scene={TWO_ROOMS_SCENE} />,
+  play: async () => {
+    await waitFor(() => expect(document.querySelector("[data-seam-strip]")).not.toBeNull());
+    await settleStrip();
+
+    const colours = (selector: string) =>
+      new Set(
+        Array.from(document.querySelectorAll<HTMLElement>(selector)).map(
+          (el) => el.style.backgroundColor,
+        ),
+      );
+
+    // ONE colour across two collections, on both rows.
+    const boxColours = colours("[data-seam-segment]");
+    expect(boxColours.size).toBe(1);
+    const miniColours = colours("[data-seam-mini-segment]");
+    expect(miniColours.size).toBe(1);
+    // And the SAME one, so the strip and the map read as one object.
+    expect([...miniColours]).toEqual([...boxColours]);
+
+    // GREY rather than merely uniform: one saturated hue for everything would
+    // pass the count above while being exactly what the flag withholds. The
+    // measure is how far the channels spread — the neutral spans 14 of 255,
+    // and a collection tint at 52% saturation spans about 90, so 24 separates
+    // them with room either side rather than sitting on top of one.
+    const [only] = [...boxColours];
+    const [, r, g, b] = /rgb\((\d+), (\d+), (\d+)\)/.exec(only ?? "") ?? [];
+    const channels = [Number(r), Number(g), Number(b)];
+    expect(Math.max(...channels) - Math.min(...channels)).toBeLessThan(24);
+
+    // THE SEAMS ARE STILL THERE, in the three places that now carry them
+    // alone: the strip, the ruler and the minimap.
+    expect(document.querySelectorAll("[data-seam-divider]").length).toBe(1);
+    expect(
+      Array.from(document.querySelectorAll<HTMLElement>('[data-seam-tick="collection"]')).map(
+        (tick) => tick.textContent?.trim(),
+      ),
+    ).toEqual(["Kitchen Interior", "Loading Dock"]);
+    // The minimap's own crossing: a real left margin on the first clip of the
+    // second collection, and on nothing else.
+    const gapped = Array.from(
+      document.querySelectorAll<HTMLElement>("[data-seam-mini-segment]"),
+    ).filter((segment) => Number.parseFloat(segment.style.marginLeft || "0") > 0);
+    expect(gapped.length).toBe(1);
+  },
+};

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-bar-layout.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-bar-layout.test.ts
@@ -178,16 +178,32 @@ describe("seamRulerTicks", () => {
     ]);
   });
 
-  it("drops a time tick that would land on a collection label", () => {
-    // 60s is a collection seam at x=60; at 10px a second the 5s ladder puts a
-    // time tick at 60 too, and 50 and 70 are both inside the 26px clash zone.
+  it("clears the whole WIDTH of a collection label, not just its mark", () => {
+    // The label is left-aligned on its tick, so it reaches to the RIGHT — and
+    // a clash zone measured around the mark alone let the next time tick print
+    // straight through the end of the word. Forty seconds at 10px a second:
+    // the 5s ladder wants a tick every 50px, "Van Interior" starts at x=200
+    // and reaches about 75px past it, so the two ticks inside that reach give
+    // way and the one beyond it does not.
+    const clips: readonly SeamBarClip[] = [
+      clip("a", 20, "kitchen", "Kitchen"),
+      clip("b", 20, "van", "Van Interior"),
+    ];
+    const times = seamRulerTicks({ strip: buildSeamStrip(clips, 10), clips })
+      .filter((tick) => tick.kind === "time")
+      .map((tick) => tick.x);
+    expect(times).not.toContain(200);
+    expect(times).not.toContain(250);
+    expect(times).toContain(300);
+  });
+
+  it("gives way to a collection tick on its own mark as well", () => {
     const times = seamRulerTicks({ strip: STRIP, clips: CLIPS })
       .filter((tick) => tick.kind === "time")
       .map((tick) => tick.x);
+    // 60 is the seam itself; 50 is inside the mark's own clash zone.
     expect(times).not.toContain(60);
     expect(times).not.toContain(50);
-    expect(times).not.toContain(70);
-    expect(times).toContain(100);
   });
 
   it("never runs a tick past the end of the strip", () => {

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-bar-layout.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-bar-layout.ts
@@ -159,8 +159,24 @@ export type SeamTick = Readonly<{
  */
 const TICK_LADDER = [1, 2, 5, 10, 15, 30, 60, 120, 300] as const;
 const MIN_TICK_GAP_PX = 46;
-/** How close a time tick may come to a collection label before it gives way. */
+/** How close a time tick may come to a collection tick's own mark. */
 const TICK_CLASH_PX = 26;
+/**
+ * Roughly how wide a collection label renders, per character, at the ruler's
+ * 9px type — and the ceiling the label is truncated at.
+ *
+ * An estimate, because this is arithmetic and the text is not measurable from
+ * here. It only has to be close: the label is LEFT-ALIGNED on its tick, so a
+ * long name like "Loading Dock" reaches ~70px to the right of a mark whose
+ * clash zone was 26, and the first time tick past that zone printed its "75s"
+ * straight through the end of the word. Over-reserving costs one time tick on
+ * a ruler that has a dozen; under-reserving costs the collection name, which
+ * is the label that cannot be worked out from anything else on screen.
+ */
+const LABEL_PX_PER_CHAR = 5.6;
+const LABEL_MAX_PX = 128;
+/** The breathing room a time tick keeps past the end of a name. */
+const LABEL_TAIL_PX = 8;
 
 export function tickStepSeconds(pxPerSecond: number): number {
   if (!Number.isFinite(pxPerSecond) || pxPerSecond <= 0) return TICK_LADDER.at(-1)!;
@@ -192,11 +208,18 @@ export function seamRulerTicks(params: {
     collectionTicks.push({ x: segment.leftPx, label: clip.collectionName, kind: "collection" });
   }
 
+  // The span each collection tick claims: its mark, plus the width its name
+  // takes up to the right of it.
+  const claimed = collectionTicks.map((tick) => ({
+    from: tick.x - TICK_CLASH_PX,
+    to: tick.x + Math.min(LABEL_MAX_PX, tick.label.length * LABEL_PX_PER_CHAR) + LABEL_TAIL_PX,
+  }));
+
   const step = tickStepSeconds(strip.pxPerSecond);
   const timeTicks: SeamTick[] = [];
   for (let seconds = step; seconds * strip.pxPerSecond <= strip.totalPx; seconds += step) {
     const x = seconds * strip.pxPerSecond;
-    if (collectionTicks.some((tick) => Math.abs(tick.x - x) < TICK_CLASH_PX)) continue;
+    if (claimed.some((span) => x > span.from && x < span.to)) continue;
     timeTicks.push({ x, label: `${Math.round(seconds)}s`, kind: "time" });
   }
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useRef } from "react";
 
+import { BAR_NEUTRAL_COLOUR } from "@/lib/bar-collection-colours-flag";
+
 import { collectionSeams, type SeamBarClip } from "./graph-seam-bar-layout";
 import type { SeamStrip } from "./graph-seam-strip";
 
@@ -136,7 +138,7 @@ export function SeamLane({
           {strip.segments.map((segment) => {
             if (segment.widthPx <= 0) return null;
             const isCentre = segment.clipId === centreClipId;
-            const colour = colourOf.get(segment.clipId) ?? "hsl(220 8% 34%)";
+            const colour = colourOf.get(segment.clipId) ?? BAR_NEUTRAL_COLOUR;
             return (
               <span
                 key={segment.clipId}

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-minimap.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-minimap.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useRef } from "react";
 
+import { BAR_NEUTRAL_COLOUR } from "@/lib/bar-collection-colours-flag";
+
 import { collectionSeams, type SeamBarClip } from "./graph-seam-bar-layout";
 
 /**
@@ -103,7 +105,7 @@ export function SeamMinimap({
               data-seam-mini-segment={clip.id}
               style={{
                 flexGrow: clip.showingSeconds,
-                backgroundColor: colourOf.get(clip.id) ?? "hsl(220 8% 34%)",
+                backgroundColor: colourOf.get(clip.id) ?? BAR_NEUTRAL_COLOUR,
                 // A real gap where the collection changes, so the runs read
                 // as runs at a scale far too small for a label.
                 marginLeft: index > 0 && seams.has(index) ? 3 : undefined,

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -4,6 +4,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronLeft, ChevronRight, Pause, Play } from "lucide-react";
 
 import {
+  BAR_COLLECTION_COLOURS_ENABLED,
+  BAR_NEUTRAL_COLOUR,
+} from "@/lib/bar-collection-colours-flag";
+
+import {
   fitPixelsPerSecond,
   offsetAfterZoom,
   seamRulerTicks,
@@ -47,8 +52,11 @@ import {
  * ── AND THREE THINGS THAT SAY WHERE YOU ARE ─────────────────────────────
  *
  * A RULER, because a box's width means "this long" only against a scale, and
- * the scale now moves. It carries the collection names too, which are the
- * only landmarks on a run of boxes that otherwise looks the same throughout.
+ * the scale now moves. It carries the collection names too, and with the
+ * collection tint parked behind a flag (see `bar-collection-colours-flag`)
+ * those names and the dashed dividers are the ONLY landmarks on a run of
+ * boxes that otherwise looks the same throughout — which is why both are
+ * structural rather than decorative.
  *
  * A MINIMAP, because the bar is a window and that is most of the reason to
  * have one. It shows the whole sequence, always, with a rectangle marking the
@@ -218,6 +226,17 @@ export function SeamStripBar({
 
   const scale = pxPerSecond ?? 9;
   const strip = useMemo(() => buildSeamStrip(clips, scale), [clips, scale]);
+
+  // ONE NEUTRAL FOR EVERY BOX unless the tint is switched on. Substituted here
+  // rather than at the derivation, so the collection tones are still computed
+  // and still handed over — the flag decides whether the bar PAINTS with them,
+  // which is what makes turning it back on one environment variable. Both the
+  // strip and the minimap read this, so they cannot end up disagreeing about
+  // whether the bar is a coloured object.
+  const boxColourOf = useMemo(() => {
+    if (BAR_COLLECTION_COLOURS_ENABLED) return colourOf;
+    return new Map(clips.map((clip) => [clip.id, BAR_NEUTRAL_COLOUR] as const));
+  }, [clips, colourOf]);
 
   // ── PAN ──────────────────────────────────────────────────────────────────
   //
@@ -626,7 +645,7 @@ export function SeamStripBar({
           laneRef={laneRef}
           strip={strip}
           clips={clips}
-          colourOf={colourOf}
+          colourOf={boxColourOf}
           centreClipId={centreClipId}
           offset={offset}
           playheadPx={playheadPx}
@@ -664,7 +683,7 @@ export function SeamStripBar({
 
         <SeamMinimap
           clips={clips}
-          colourOf={colourOf}
+          colourOf={boxColourOf}
           totalSeconds={totalSeconds}
           windowFromSeconds={windowFromSeconds}
           windowToSeconds={windowToSeconds}

--- a/apps/timeline-gstudio001/lib/bar-collection-colours-flag.ts
+++ b/apps/timeline-gstudio001/lib/bar-collection-colours-flag.ts
@@ -1,0 +1,41 @@
+/**
+ * Whether the details bar TINTS ITS BOXES BY COLLECTION — the playbar's clip
+ * boxes and the minimap row under it, which are the two places the tint is
+ * spent.
+ *
+ * OFF. Every box and every minimap segment draws in one neutral instead, and
+ * the bar says where one collection ends and the next begins the way it
+ * already does without colour: a dashed divider on the strip and a named tick
+ * on the ruler. Those two are structural rather than decorative, so nothing is
+ * lost from a bar in which every clip looks alike — it is the difference
+ * between a landmark and a wash.
+ *
+ * Set `NEXT_PUBLIC_GSTUDIO_BAR_COLOURS=on` to restore it. Compared against the
+ * string rather than truthiness, the same way `NEXT_PUBLIC_GSTUDIO_LANE_TRACKS`
+ * is, so that `=off`, `=0` and `=false` all read as off instead of the reverse
+ * — a bare `!!process.env.X` makes the word "off" mean on.
+ *
+ * WHAT IS PARKED AND WHAT IS NOT. The derivation stays exactly where it is:
+ * `clipColourOf` in the details modal still walks the collection tree and
+ * still hands the bar a tone per clip, and this only decides whether the bar
+ * paints with it. So turning the tint back on is one environment variable, and
+ * the hue-family arithmetic — top-level hues 45° apart, siblings a few degrees
+ * either side of their parent, depth carried by lightness — does not rot in
+ * the meantime.
+ *
+ * WHAT THIS DOES NOT TOUCH. Colour elsewhere in the view is a different
+ * decision and stays: the cards' own pictures, the blue of the readout, the
+ * red of the playhead. The playhead in particular is deliberately still the
+ * only saturated thing on the bar — which is easier to see now, not harder.
+ */
+export const BAR_COLLECTION_COLOURS_ENABLED =
+  process.env.NEXT_PUBLIC_GSTUDIO_BAR_COLOURS === "on";
+
+/**
+ * What a box is when it is not saying which collection it came from.
+ *
+ * The same tone both consumers already fell back to for a clip with no
+ * collection, so "flag off" and "no answer" look alike on purpose — there is
+ * one neutral, not a default and a fallback that differ by a few percent.
+ */
+export const BAR_NEUTRAL_COLOUR = "hsl(220 8% 34%)";


### PR DESCRIPTION
`NEXT_PUBLIC_GSTUDIO_BAR_COLOURS`, **off**. Every box on the strip and every segment of the minimap under it draws in one neutral instead of being tinted by the collection it came from. Same shape as the lane-tracks flag: compared against the string, so `=off`, `=0` and `=false` all read as off rather than the reverse.

**I have not turned it on anywhere** — no `.env`, no config, no default.

## What is parked and what is not

`clipColourOf` still walks the collection tree and still hands the bar a tone per clip; the flag only decides whether the bar *paints* with it. So turning the tint back on is one environment variable, and the hue-family arithmetic — top-level hues 45° apart, siblings a few degrees either side of their parent, depth carried by lightness — does not rot in the meantime.

Both consumers read one substituted map, so the strip and the minimap cannot end up disagreeing about whether the bar is a coloured object. The neutral is also the tone both already fell back to for a clip with no collection, so "flag off" and "no answer" look alike on purpose.

## The seams still show

That is the only reason a bar where every clip looks alike is acceptable — the structure colour used to carry is carried in three other places, all of which survive:

- a dashed divider on the strip
- a named tick on the ruler
- a real gap in the minimap

The new story asserts the greyness **and** those three landmarks together. Losing either half is what would make this a regression rather than a parking space.

Greyness is measured as channel spread rather than by string comparison: the neutral spans **14** of 255, a collection tint at 52% saturation spans about **90**, so the assertion sits at 24 with room either side.

## One fix the grey bar made obvious

A collection label is left-aligned on its tick and reaches to the *right* — "Loading Dock" runs about 70px past a mark whose clash zone was 26 — so the next time tick printed its `75s` straight through the end of the word. Visible in grey because the ruler is no longer competing with colour for attention. The clash zone is now the label's estimated width plus a tail; measured after the fix, the visible ticks run `50 55 60 65 70 · 80 85 90` with `75` given up to the name.

## Tests

1 new story, 1 new unit test (and one rewritten to the corrected clash contract). Storybook 1109 ✓, app 1418 ✓, lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)