### PR TITLE
Only Escape and the close button leave the details view

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -542,6 +542,51 @@ export const FlankedByItsNeighbours: Story = {
   },
 };
 
+/**
+ * THE SCRIM IS NOT A WAY OUT. Only Escape and the close button are.
+ *
+ * This view is worked in rather than glanced at, and the row is CROPPED by the
+ * scrim rather than surrounded by it — so the dark area is where the hand
+ * lands at the end of a trim, a scrub or a swipe, not somewhere it goes on
+ * purpose. Dismissing there loses the position in the cut for a gesture nobody
+ * meant to make.
+ *
+ * The Escape half is what stops this passing vacuously: it proves closing is
+ * wired at all, so the scrim half is measuring a refusal rather than a modal
+ * that could not close either way.
+ */
+export const TheScrimDoesNotDismiss: Story = {
+  render: () => <SeamHarness />,
+  play: async () => {
+    await waitFor(() =>
+      expect(document.querySelectorAll("[data-item-details-panel]").length).toBe(3),
+    );
+    const scrim = document.querySelector<HTMLElement>("[data-item-details]")!;
+
+    // A press that both starts AND ends on the scrim — the strongest form of
+    // the gesture that used to close it.
+    fireEvent.pointerDown(scrim, { isPrimary: true, button: 0, pointerId: 1 });
+    fireEvent.pointerUp(scrim, { isPrimary: true, button: 0, pointerId: 1 });
+    fireEvent.click(scrim);
+
+    // A FIXED WAIT, not a `waitFor`. The assertion is that something does NOT
+    // happen, and closing is a view transition rather than a re-render: a
+    // `waitFor` would find three panels still on screen in the very first
+    // check — mid-transition, on their way out — and pass while the modal was
+    // in the act of closing. This has to outlast the transition to mean
+    // anything.
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    // Still open, and still showing the same three panels.
+    expect(document.querySelectorAll("[data-item-details-panel]").length).toBe(3);
+
+    // Escape still closes, which is the half that keeps the assertion above
+    // honest.
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => expect(document.querySelector("[data-item-details]")).toBeNull());
+  },
+};
+
 /** Clicking a neighbour re-centres on it, and the strip re-resolves around the
  *  new subject — the previous clip becomes the next one. */
 /**

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -668,11 +668,14 @@ function DetailsFilmstripModal({
       // the middle card, which is a quiet eight pixels rather than an obvious
       // fault.
       className="fixed inset-0 z-[80] flex items-center justify-center overflow-hidden bg-black/80 px-6 pt-[11rem] pb-6 backdrop-blur-sm"
-      onPointerDown={(event) => {
-        // Scrim only: a press that starts on a panel must never close it,
-        // including one that ends outside after a trim drag.
-        if (event.target === event.currentTarget) onClose();
-      }}
+      // THE SCRIM DOES NOT DISMISS. Deliberate: this view is worked in, not
+      // glanced at — trimming, scrubbing and swiping all end with the pointer
+      // somewhere unpredictable, and the panels are cropped by the scrim
+      // rather than surrounded by it, so "outside" is a place the hand lands
+      // by accident. Escape and the close button are the only two ways out,
+      // and both are explicit. The stopPropagation guards below are older
+      // than this and are left alone: they keep presses on the header and the
+      // bar from reaching anything listening further up.
     >
       {/* THE BAR, above everything and spanning it: the cut's clock. Outside
           the strip because it must not travel with it — the row slides, and a


### PR DESCRIPTION
Clicking the scrim no longer closes the media-item details modal. Escape and the top-right × are the only two ways out, and both are explicit.

The row is cropped *by* the scrim rather than surrounded by it, so "outside" is where the hand lands at the end of a trim, a scrub or a swipe — not somewhere you go on purpose. Dismissing there costs your place in the cut for a gesture nobody meant to make.

Escape lives in `graph-item-details-panel.tsx` on a document capture listener and is untouched; the close button goes through the same `onClose`.

**Proof:** new `TheScrimDoesNotDismiss` story. Run both ways — with the change 3 panels survive the press and Escape still closes; with the scrim handler restored it fails on `expected +0 to be 3`. Full file: 32/32 pass. `tsc` clean, `npm run lint` 0 errors.

Not touched: the *collection* details modal (`graph-collection-details.tsx:112`) still dismisses on its scrim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)