### PR TITLE
Letting go of the bar lands the strip, on the frame you let go on

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -430,9 +430,13 @@ async function settleStrip(): Promise<void> {
  * strip's transform is needed — which is what makes this survive a pan and a
  * zoom that a fraction-of-the-timeline version would not.
  */
-function scrubIntoBox(box: HTMLElement, within = 0.5): void {
+function scrubIntoBox(
+  box: HTMLElement,
+  within = 0.5,
+  options?: { hold?: boolean },
+): void {
   const target = box.getBoundingClientRect();
-  scrubToClientX(target.left + target.width * within);
+  scrubToClientX(target.left + target.width * within, options);
 }
 
 /** Swipe the boxes, which moves the carousel three clips at a time. */
@@ -781,11 +785,17 @@ export const TheRingMarksWhoseFramesAreUp: Story = {
 
     // Move the clock right across a seam and onto another clip's frames. The
     // monitor changes; the ring does not.
+    //
+    // HELD, NOT RELEASED. Letting go now lands the row on whatever the
+    // playhead reached, and this story is about the ring during the look —
+    // the state where the monitor is showing one clip and the subject is
+    // still another. Releasing would collapse the two and the assertion
+    // would be trivially true.
     const boxes = seamBoxes();
     const centreIndex = boxes.indexOf(centreBox());
     expect(centreIndex).toBeGreaterThan(0);
     await settleStrip();
-    scrubIntoBox(boxes[centreIndex - 1]!);
+    scrubIntoBox(boxes[centreIndex - 1]!, 0.5, { hold: true });
     await waitFor(() =>
       expect(seamTrack().getAttribute("aria-valuenow")).not.toBe(null),
     );
@@ -1665,21 +1675,27 @@ export const HoldingAtAnEdgeRunsTheStrip: Story = {
     expect(ranPx).toBeGreaterThan(5);
     expect(Math.abs(ranPx - (at() - fromAt) * pps)).toBeLessThan(2);
 
-    // ── LETTING GO STOPS IT, AND CHOOSES NOTHING ──────────────────────────
+    // ── LETTING GO STOPS IT, AND LANDS ON WHAT IT RAN TO ──────────────────
     release(box.right - 12);
     const stoppedAt = at();
     const stoppedX = stripLeft();
     await rest(300);
     expect(at()).toBe(stoppedAt);
     expect(stripLeft()).toBe(stoppedX);
-    // The hand never moved, so by travel alone this looks like a tap — and a
-    // tap commits to a clip. The edge loop has to declare the drag on the
-    // bar's behalf, or scrubbing across the project ends by opening whatever
-    // shot happened to arrive under a stationary finger.
-    expect(subject()).toBe(startedOn);
+    // WHERE THE PLAYHEAD FINISHED, NOT WHERE THE HAND IS. The hand never
+    // moved, so this is the case that would go wrong if the release resolved
+    // a clip from the pointer's x: the strip ran a long way underneath a
+    // stationary finger, and what is under it now is not what was under it
+    // when the press began. The view answers from its own clock instead.
+    expect(subject()).not.toBe(startedOn);
 
     // ── AND THE LEFT EDGE REVERSES ────────────────────────────────────────
-    press(box.left + 12);
+    // MEASURED AGAIN. The release above landed the row on a new clip, and the
+    // bar re-pans around it — so the geometry read at the top of this story
+    // describes a bar that no longer exists.
+    await settleStrip();
+    const after = seamSurface().getBoundingClientRect();
+    press(after.left + 12);
     const pressedBackAt = at();
     await waitFor(() => expect(at()).toBeLessThan(pressedBackAt - 1), { timeout: 2000 });
     const backFrom = at();
@@ -1688,7 +1704,7 @@ export const HoldingAtAnEdgeRunsTheStrip: Story = {
     const backPx = stripLeft() - backFromX;
     expect(backPx).toBeGreaterThan(5);
     expect(Math.abs(backPx - (backFrom - at()) * pps)).toBeLessThan(2);
-    release(box.left + 12);
+    release(after.left + 12);
   },
 };
 
@@ -1818,9 +1834,13 @@ export const AScrubNearACutTakesTheCut: Story = {
     // pulled in by — see BOX_INSET_PX in the lane.
     const cut = target.left - 2.5;
 
-    scrubToClientX(cut - 3);
+    // HELD THROUGHOUT. These are three readings of one scale, so the bar
+    // underneath them has to be the same bar: a release would land the row on
+    // the clip just scrubbed to, and the next measurement would be taken
+    // against a strip that had moved. Nothing here is about committing.
+    scrubToClientX(cut - 3, { hold: true });
     const fromBefore = at();
-    scrubToClientX(cut + 3);
+    scrubToClientX(cut + 3, { hold: true });
     const fromAfter = at();
 
     // BOTH SIDES LAND ON THE SAME INSTANT, which is the cut. Six pixels apart
@@ -1830,7 +1850,7 @@ export const AScrubNearACutTakesTheCut: Story = {
     // A press with room around it is left exactly where it was put, so the
     // snap is a tolerance and not a quantiser: 40px further along is 40px
     // further along, to the second.
-    scrubToClientX(cut + 40);
+    scrubToClientX(cut + 40, { hold: true });
     expect(at()).toBeGreaterThan(fromAfter);
     expect(Math.abs(at() - fromAfter - 40 / pps)).toBeLessThan(0.05);
   },
@@ -1968,18 +1988,26 @@ export const PointingAtABoxSaysWhatItIs: Story = {
 };
 
 /**
- * A DRAG SCRUBS; A PRESS THAT DOES NOT TRAVEL COMMITS.
+ * LETTING GO IS THE COMMIT — AND YOU KEEP THE FRAME YOU LET GO ON.
  *
- * One surface, two gestures, told apart by distance rather than by timing — a
- * slow deliberate scrub must not also count as a tap on wherever it started,
- * and a decisive tap must not have to be held.
+ * A drag and a press that does not travel are still told apart (distance, not
+ * timing: a slow deliberate scrub must not count as a tap on wherever it
+ * started). But they now LAND the same way, because they are the same
+ * sentence: you put the playhead somewhere and took your hand off it.
  *
- * WHY THE SCRUB CHOOSES NOTHING. Scrubbing is a look: you check what is
- * coming up and go back to what you were doing. A release that made the
- * landing point the active clip would have already moved you, so checking
- * would cost you your place — which is the one thing looking must not do.
+ * Scrubbing used to choose nothing, on the reasoning that looking ahead must
+ * not cost you your place. The place is what changed: the row follows the
+ * playhead now, and the clock comes WITH it rather than snapping to the new
+ * clip's head — so you arrive on the exact frame you were judging, which is
+ * the frame you went there to see. Losing it was what made the old rule feel
+ * like a look rather than a move.
+ *
+ * THE CLOCK NOT MOVING IS THE ASSERTION. Every panel derives its picture from
+ * `position`, which is `seamAt(timeline, barSeconds)` — so a bar reading the
+ * same second before and after the row advances IS the centre panel holding
+ * the frame. A jump here would be the reset this change removes.
  */
-export const ADragScrubsAndAClickCommits: Story = {
+export const LettingGoOfTheBarLandsTheStrip: Story = {
   render: () => <SeamHarness scene={TWO_ROOMS_SCENE} />,
   play: async () => {
     await waitFor(() => expect(document.querySelector("[data-seam-strip]")).not.toBeNull());
@@ -1990,14 +2018,40 @@ export const ADragScrubsAndAClickCommits: Story = {
     const startedOn = subject();
     expect(startedOn).toBe("subject");
 
-    // A DRAG onto another clip moves the clock and nothing else.
-    scrubIntoBox(seamBoxes()[2]!);
+    // ── A DRAG ONTO ANOTHER CLIP LANDS THERE ──────────────────────────────
+    // Held first, so the clock can be read at the moment before the release
+    // — the number the release has to preserve.
+    const target = seamBoxes()[2]!;
+    const box = target.getBoundingClientRect();
+    const restingOn = box.left + box.width * 0.5;
+    scrubToClientX(restingOn, { hold: true });
     await waitFor(() => expect(at()).toBeGreaterThan(0));
+    const letGoAt = at();
+    // Still where it was: the row moves on release, not during.
     expect(subject()).toBe(startedOn);
 
-    // A PRESS on the same clip commits to it.
-    clickBox(seamBoxes()[2]!);
+    const surface = seamSurface();
+    const surfaceBox = surface.getBoundingClientRect();
+    fireEvent.pointerUp(
+      surface,
+      pointerAt(restingOn, surfaceBox.top + surfaceBox.height / 2),
+    );
+
+    // The row advanced...
     await waitFor(() => expect(subject()).not.toBe(startedOn));
+    // ...onto the clip the playhead was actually on...
+    expect(subject()).toBe(target.getAttribute("data-seam-segment"));
+    // ...and the clock did not move a frame in the process.
+    expect(at()).toBe(letGoAt);
+
+    // ── AND A PRESS THAT DID NOT TRAVEL DOES THE SAME ─────────────────────
+    // The two gestures are a few pixels of hand movement apart, so they must
+    // not be a whole behaviour apart.
+    const landedOn = subject();
+    const next = seamBoxes()[4]!;
+    clickBox(next);
+    await waitFor(() => expect(subject()).not.toBe(landedOn));
+    expect(subject()).toBe(next.getAttribute("data-seam-segment"));
   },
 };
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -221,6 +221,15 @@ function DetailsFilmstripModal({
   // needed loaded. Null says "not scrubbed", which is a different state from
   // "scrubbed to the beginning" and the one an untouched view is in.
   const [barSeconds, setBarSeconds] = useState<number | null>(null);
+  // THE ONE SECOND THAT SURVIVES AN ADVANCE, and only the advance it caused.
+  //
+  // Letting go of the bar re-centres the row on whatever the playhead landed
+  // on, and the frame you released on is the whole point of having gone there
+  // — so it has to arrive with you rather than being reset to the new clip's
+  // head. A ref rather than state because nothing renders from it: it is set
+  // on the way out of one subject and read once on the way into the next, and
+  // a re-render in between would be a render nobody needs.
+  const carryClockRef = useRef<number | null>(null);
   const [playing, setPlaying] = useState(false);
   // A DRAG IS IN PROGRESS ON THE BAR. Distinct from `scrubbed`, which stays
   // true once the clock has been touched: this is the gesture itself, and it
@@ -331,9 +340,19 @@ function DetailsFilmstripModal({
     [collectionSeamClips, subjectSeamIndex],
   );
 
-  // ADVANCING RESETS THE CLOCK TO THIS CLIP'S START, because the bar is rebuilt
-  // around a different cut — the old seconds would name a moment in a run of
-  // time that no longer exists.
+  // ADVANCING RESETS THE CLOCK TO THIS CLIP'S START — unless the advance was
+  // the clock's own doing, in which case it KEEPS its place. See
+  // `carryClockRef` below: the seconds survive exactly one subject change, the
+  // one they caused.
+  //
+  // Carrying them is only sound because every clip is on the bar in full and
+  // the spans do not depend on the subject: `buildSeamTimeline` is handed the
+  // whole collection with no leads, and the subject index moves `centreStart`
+  // and nothing else. So a second on the old bar is the same second on the new
+  // one. (It was NOT always so. The bar used to be a window with run-ups
+  // around the subject, and then the old seconds really did name a moment in a
+  // run of time that no longer existed — which is why this reset was
+  // unconditional.)
   //
   // ADJUSTED DURING RENDER rather than in an effect, which is React's own
   // answer for "this state derives from a prop that changed". An effect would
@@ -346,7 +365,8 @@ function DetailsFilmstripModal({
   if (clockFor !== (node.id as string)) {
     setClockFor(node.id as string);
     setPlaying(false);
-    setBarSeconds(null);
+    setBarSeconds(carryClockRef.current);
+    carryClockRef.current = null;
   }
 
   // Where the BAR draws its playhead when nothing has moved it: the cut at the
@@ -716,12 +736,27 @@ function DetailsFilmstripModal({
               onScrubbingChange={setScrubbing}
               // The clock spans every clip, so a point on the rail IS a point
               // on the clock and needs no conversion.
-              // The other direction of the same binding: the cards follow the
-              // scrubber when it is let go, and the scrubber follows the cards
-              // whenever the subject changes (the clock resets to that clip's
-              // own start — see `clockFor` above).
+              //
+              // THE CARDS FOLLOW THE SCRUBBER WHEN IT IS LET GO — however it
+              // was let go. A click and a two-pixel drag are the same gesture
+              // as far as the hand is concerned, so they land the same way:
+              // both re-centre the row, and both bring the frame with them.
+              // Splitting them would mean a few pixels of travel decided
+              // whether you kept your place in the shot.
               onCommitClip={(clipId) => {
-                if (clipId !== (node.id as string)) onOpenNeighbour(clipId);
+                if (clipId === (node.id as string)) return;
+                carryClockRef.current = barSeconds;
+                onOpenNeighbour(clipId);
+              }}
+              // WHEREVER THE PLAYHEAD FINISHED, which is not always under the
+              // pointer: holding at an edge runs the strip along beneath a
+              // hand that is standing still. `position` is the view's own
+              // answer to where the clock is, so the drag does not have to
+              // carry one.
+              onScrubEnd={() => {
+                if (position === null || position.clipId === (node.id as string)) return;
+                carryClockRef.current = shownSeconds;
+                onOpenNeighbour(position.clipId);
               }}
               onScrubSeconds={(seconds) => {
                 setPlaying(false);

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -125,6 +125,7 @@ export function SeamStripBar({
   onStepForward,
   onScrubSeconds,
   onCommitClip,
+  onScrubEnd,
   onScrubbingChange,
 }: Readonly<{
   /** Every clip the bar can reach, in playback order. */
@@ -145,6 +146,14 @@ export function SeamStripBar({
   onScrubSeconds: (value: number) => void;
   /** A box was CLICKED — make that clip the centred one. */
   onCommitClip: (clipId: string) => void;
+  /**
+   * A DRAG ENDED. No clip id, deliberately: where the playhead finished is not
+   * always under the pointer — holding at an edge runs the strip along while
+   * the hand stays put — so the bar would have to re-derive a position it does
+   * not own. The view already resolves the playhead to a clip and a time; this
+   * only tells it when to act on that.
+   */
+  onScrubEnd?: () => void;
   /** True while a drag is live on the bar, false when it ends — the view
    *  grows the monitor for the duration. */
   onScrubbingChange?: (active: boolean) => void;
@@ -412,12 +421,19 @@ export function SeamStripBar({
       // that clip active. Distinguished by travel rather than by timing,
       // because a slow deliberate scrub must not also count as a tap on
       // wherever it started.
-      if (press.moved) return;
+      if (press.moved) {
+        // A DRAG NOW LANDS TOO. Letting go used to leave the row where it was
+        // and only the monitor travelling, so the shot you had scrubbed to was
+        // on screen but not the one you were working on — you had to go and
+        // fetch it. Releasing is the commit.
+        onScrubEnd?.();
+        return;
+      }
       const stripX = localX(event.clientX) - offsetRef.current;
       const landedOn = stripPositionAt(strip, stripX)?.clipId ?? null;
       if (landedOn !== null && landedOn !== centreClipId) onCommitClip(landedOn);
     },
-    [centreClipId, localX, onCommitClip, onScrubbingChange, strip],
+    [centreClipId, localX, onCommitClip, onScrubEnd, onScrubbingChange, strip],
   );
 
   // ── HOLDING AT AN EDGE RUNS THE STRIP UNDER THE POINTER ──────────────────


### PR DESCRIPTION
Scrub the play bar in the details modal, let go, and the strip now forwards to the clip the playhead finished on — with the middle panel sitting on the exact frame the scrub ended on, not reset to that clip's first frame.

### What changed

- **`graph-seam-strip-bar.tsx`** — a drag that travels now fires a new `onScrubEnd()` on release instead of returning early. It carries **no clip id** deliberately: holding at an edge runs the strip along under a stationary hand, so what is under the pointer at release is not where the clock ended up. The view already resolves the playhead to a clip and a time; this only says *when*.
- **`graph-item-details-modal.tsx`** — `carryClockRef` lets the bar's seconds survive exactly one subject change, the one they caused. The clock-reset-on-advance is otherwise untouched.

Carrying the seconds is only sound because the bar stopped being a window: `buildSeamTimeline` now gets the whole collection with no leads, and the subject index moves `centreStart` and nothing else — so a second on the old bar is the same second on the new one. The unconditional reset dated from when that wasn't true; its comment said so and is now corrected.

A click and a two-pixel drag land identically. Splitting them would mean a few pixels of hand travel decided whether you kept your place in the shot.

### Behaviour you may not have pictured

An **edge-hold** is a scrub too, so letting go after one now lands the strip on whatever ran past. Previously it deliberately chose nothing. Say the word if you want edge-holds exempt.

### Proof

New `LettingGoOfTheBarLandsTheStrip` story. The clock not moving across the commit **is** the frame assertion — every panel derives its picture from `seamAt(timeline, barSeconds)`, so a bar reading the same second before and after the row advances is the centre panel holding the frame.

Run both ways: without the change it fails on `expected 'subject' not to be 'subject'`.

Three existing stories encoded the old contract and were rewritten, not patched — `AScrubNearACutTakesTheCut` and `TheRingMarksWhoseFramesAreUp` now scrub with `hold: true` (both are about the *look* — the snap, the ring — and a release would collapse the state they observe), and `HoldingAtAnEdgeRunsTheStrip` keeps its stationary-finger case, which is exactly what would break if the release resolved a clip from the pointer's x.

Green: 32/32 modal stories · 802/802 unit · 1418/1418 app · `tsc` clean · lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)