### PR TITLE
The row lands where it should, and travels up to five clips to get there

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -402,6 +402,28 @@ function centreBox(): HTMLElement {
  * as scrubs landing at zero, because the mismatch pushed the target off the
  * front of the timeline and the clamp caught it.
  */
+/**
+ * Past the PANEL ROW's own transition — a different element from the bar's
+ * strip, and on its own clock. `settleStrip` watches `[data-seam-strip]`, so a
+ * row easing across three panels is invisible to it and a measurement taken
+ * straight after reads a card mid-flight.
+ */
+async function settleRow(): Promise<void> {
+  const row = document.querySelector<HTMLElement>("[data-details-strip]");
+  expect(row).not.toBeNull();
+  await new Promise((resolve) => setTimeout(resolve, 360));
+  let previous = Number.NaN;
+  await waitFor(
+    () => {
+      const now = row!.getBoundingClientRect().left;
+      const settled = Math.abs(now - previous) < 0.5;
+      previous = now;
+      expect(settled).toBe(true);
+    },
+    { timeout: 3000 },
+  );
+}
+
 async function settleStrip(): Promise<void> {
   const strip = document.querySelector<HTMLElement>("[data-seam-strip]");
   expect(strip).not.toBeNull();
@@ -2025,66 +2047,99 @@ export const LettingGoOfTheBarLandsTheStrip: Story = {
     await settleStrip();
     const subject = () => centreBox().getAttribute("data-seam-segment");
     const at = () => Number(seamTrack().getAttribute("aria-valuenow"));
+    const strip = () => document.querySelector<HTMLElement>("[data-details-strip]")!;
+    const stripX = () => strip().getBoundingClientRect().left;
+    const panels = () => document.querySelectorAll("[data-item-details-panel]").length;
+    const boxIndex = () => seamBoxes().indexOf(centreBox());
 
-    const startedOn = subject();
-    expect(startedOn).toBe("subject");
+    // Hold the scrub, read the clock at the moment before the release, let go.
+    const dragToBox = async (box: HTMLElement) => {
+      const rect = box.getBoundingClientRect();
+      const x = rect.left + rect.width * 0.5;
+      scrubToClientX(x, { hold: true });
+      await waitFor(() => expect(at()).toBeGreaterThan(0));
+      const letGoAt = at();
+      const surface = seamSurface();
+      const surfaceBox = surface.getBoundingClientRect();
+      fireEvent.pointerUp(surface, pointerAt(x, surfaceBox.top + surfaceBox.height / 2));
+      return letGoAt;
+    };
 
-    // ── A DRAG ONTO ANOTHER CLIP LANDS THERE ──────────────────────────────
-    // Held first, so the clock can be read at the moment before the release
-    // — the number the release has to preserve.
-    const target = seamBoxes()[2]!;
-    const box = target.getBoundingClientRect();
-    const restingOn = box.left + box.width * 0.5;
-    scrubToClientX(restingOn, { hold: true });
-    await waitFor(() => expect(at()).toBeGreaterThan(0));
-    const letGoAt = at();
-    // Still where it was: the row moves on release, not during.
-    expect(subject()).toBe(startedOn);
+    expect(subject()).toBe("subject");
+    const restingPanels = panels();
 
-    const surface = seamSurface();
-    const surfaceBox = surface.getBoundingClientRect();
-    fireEvent.pointerUp(
-      surface,
-      pointerAt(restingOn, surfaceBox.top + surfaceBox.height / 2),
-    );
+    // ── A SHORT LANDING TRAVELS, AND NOTHING EMPTY GOES PAST ──────────────
+    const from = boxIndex();
+    const near = seamBoxes()[from + 3]!;
+    const letGoNear = await dragToBox(near);
+    await waitFor(() => expect(subject()).not.toBe("subject"));
 
-    // The row advanced...
-    await waitFor(() => expect(subject()).not.toBe(startedOn));
+    // Still moving a beat later: three panels is a step you can follow, so it
+    // is shown as one.
+    const travellingFrom = stripX();
+    // MORE PANELS ARE REAL THAN USUALLY ARE. The resting mount window is two
+    // either side; the cards being crossed live outside it, and without the
+    // widening they would be the empty placeholders the row is made of —
+    // including the one you just left, which would blink out and slide away.
+    expect(panels()).toBeGreaterThan(restingPanels);
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(stripX()).not.toBe(travellingFrom);
 
-    // ── AND IT ARRIVED RATHER THAN TRAVELLED ──────────────────────────────
-    // The row eases across ONE panel width for a swipe or a step. A landing
-    // can be twenty clips away, and spending the same 300ms crossing twenty
-    // panel widths is every card on screen leaving to the left with the one
-    // you asked for turning up at the end of it.
-    //
-    // ASSERTED AS "IT DOES NOT MOVE" rather than by reading a transition
-    // duration off the element, because the cut lasts a single render and
-    // catching that one frame would be a race. Two readings a beat apart
-    // cannot be fooled: mid-flight they differ, arrived they do not.
-    const centrePanel = () =>
-      document.querySelector<HTMLElement>('[data-item-details-panel="centre"]')!;
-    const landedX = centrePanel().getBoundingClientRect().left;
-    await new Promise((resolve) => setTimeout(resolve, 150));
-    expect(centrePanel().getBoundingClientRect().left).toBe(landedX);
+    await settleStrip();
+    await settleRow();
+    expect(subject()).toBe(near.getAttribute("data-seam-segment"));
+    // THE CLOCK DID NOT MOVE. Every panel derives its picture from
+    // `seamAt(timeline, barSeconds)`, so a bar reading the same second before
+    // and after the row advances IS the centre panel holding the frame.
+    expect(at()).toBe(letGoNear);
+    // And the window let go again once it had arrived.
+    await waitFor(() => expect(panels()).toBe(restingPanels));
 
-    // And it arrived in the MIDDLE, which is what says the offset it cut to
-    // was the right one rather than merely a still one.
-    const panelBox = centrePanel().getBoundingClientRect();
-    expect(Math.abs(panelBox.left + panelBox.width / 2 - window.innerWidth / 2)).toBeLessThan(2);
-
-    // ...onto the clip the playhead was actually on...
-    expect(subject()).toBe(target.getAttribute("data-seam-segment"));
-    // ...and the clock did not move a frame in the process.
-    expect(at()).toBe(letGoAt);
-
-    // ── AND A PRESS THAT DID NOT TRAVEL DOES THE SAME ─────────────────────
-    // The two gestures are a few pixels of hand movement apart, so they must
-    // not be a whole behaviour apart.
+    // ── A LONG ONE ARRIVES INSTEAD ────────────────────────────────────────
+    // THE SEAT IS READ HERE, not at the top of the story. The row is a
+    // different shape on its first paint — panels are still arriving — so its
+    // resting x then is not the resting x it keeps. Taken between the two
+    // landings, both readings describe the same row.
+    const seatX = () =>
+      document
+        .querySelector<HTMLElement>('[data-item-details-panel="centre"]')!
+        .getBoundingClientRect().left;
+    const restingCentreX = seatX();
     const landedOn = subject();
-    const next = seamBoxes()[4]!;
-    clickBox(next);
+    const far = seamBoxes()[boxIndex() + 12]!;
+    // THE PRECONDITION. Past `STEPPED_MAX`, or this measures the easing path
+    // twice and the cut not at all.
+    expect(12).toBeGreaterThan(5);
+    const letGoFar = await dragToBox(far);
     await waitFor(() => expect(subject()).not.toBe(landedOn));
-    expect(subject()).toBe(next.getAttribute("data-seam-segment"));
+
+    // ASSERTED AS "IT DOES NOT MOVE" rather than by reading a transition
+    // duration off the element: the cut lasts a single render and catching
+    // that frame would be a race, while two readings a beat apart cannot be
+    // fooled — mid-flight they differ, arrived they do not.
+    const landedX = seatX();
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(seatX()).toBe(landedX);
+
+    // Arrived in the MIDDLE, which is what says the offset it cut to was the
+    // right one rather than merely a still one.
+    // Arrived in the CENTRE SEAT — measured against where the centre panel sat
+    // at rest at the top of this story rather than against the middle of the
+    // window, because the row's resting x is a product of panel width, gap and
+    // the scrim's padding and this assertion should not have to know any of
+    // them. Landing still but one seat out would otherwise read as success.
+    expect(seatX()).toBeCloseTo(restingCentreX, 0);
+
+    // THE SCRIM NEVER SCROLLS. It crops a row thirteen thousand pixels wide,
+    // so if it were a scroll container there would be a great deal for the
+    // browser to scroll it by — and it would, because landing moves focus to
+    // the new panel's menu button and a hidden overflow is still scrolled to
+    // reveal what is focused. That scroll would land on top of the transform
+    // the row has already made and put the chosen card off the left edge.
+    // Zero here is `overflow-clip` doing its job.
+    expect(strip().parentElement!.scrollLeft).toBe(0);
+    expect(subject()).toBe(far.getAttribute("data-seam-segment"));
+    expect(at()).toBe(letGoFar);
   },
 };
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -654,6 +654,17 @@ export const ClickingANeighbourAdvancesTheStrip: Story = {
     const rightHero = panels[2]!.querySelector<HTMLElement>("[data-item-details-frame]")!;
     rightHero.click();
 
+    // ONE STEP STILL EASES. The counterpart to the cut in
+    // `LettingGoOfTheBarLandsTheStrip`: a landing more than a panel away
+    // arrives without travelling, and the guard that does it is a distance
+    // test — so the thing to protect is the case just under the line. A step
+    // is a gesture finishing itself and has to be seen to move.
+    const strip = () => document.querySelector<HTMLElement>("[data-details-strip]")!;
+    const movingX = strip().getBoundingClientRect().left;
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    // Still in flight a third of the way through a 300ms ease.
+    expect(strip().getBoundingClientRect().left).not.toBe(movingX);
+
     await waitFor(() => expect(centreName()).toBe("Rename After"));
 
     // THE ROW MOVED, rather than the panels swapping content where they stood.
@@ -2039,6 +2050,28 @@ export const LettingGoOfTheBarLandsTheStrip: Story = {
 
     // The row advanced...
     await waitFor(() => expect(subject()).not.toBe(startedOn));
+
+    // ── AND IT ARRIVED RATHER THAN TRAVELLED ──────────────────────────────
+    // The row eases across ONE panel width for a swipe or a step. A landing
+    // can be twenty clips away, and spending the same 300ms crossing twenty
+    // panel widths is every card on screen leaving to the left with the one
+    // you asked for turning up at the end of it.
+    //
+    // ASSERTED AS "IT DOES NOT MOVE" rather than by reading a transition
+    // duration off the element, because the cut lasts a single render and
+    // catching that one frame would be a race. Two readings a beat apart
+    // cannot be fooled: mid-flight they differ, arrived they do not.
+    const centrePanel = () =>
+      document.querySelector<HTMLElement>('[data-item-details-panel="centre"]')!;
+    const landedX = centrePanel().getBoundingClientRect().left;
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(centrePanel().getBoundingClientRect().left).toBe(landedX);
+
+    // And it arrived in the MIDDLE, which is what says the offset it cut to
+    // was the right one rather than merely a still one.
+    const panelBox = centrePanel().getBoundingClientRect();
+    expect(Math.abs(panelBox.left + panelBox.width / 2 - window.innerWidth / 2)).toBeLessThan(2);
+
     // ...onto the clip the playhead was actually on...
     expect(subject()).toBe(target.getAttribute("data-seam-segment"));
     // ...and the clock did not move a frame in the process.

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -230,6 +230,9 @@ function DetailsFilmstripModal({
   // on the way out of one subject and read once on the way into the next, and
   // a re-render in between would be a render nobody needs.
   const carryClockRef = useRef<number | null>(null);
+  // WHERE AN EASING JUMP STARTED, while it is still easing. Null the rest of
+  // the time, which is nearly all of the time.
+  const [easingFrom, setEasingFrom] = useState<number | null>(null);
   const [playing, setPlaying] = useState(false);
   // A DRAG IS IN PROGRESS ON THE BAR. Distinct from `scrubbed`, which stays
   // true once the clock has been touched: this is the gesture itself, and it
@@ -391,7 +394,7 @@ function DetailsFilmstripModal({
   const centreWasRef = useRef(centre);
   useLayoutEffect(() => {
     const strip = stripRef.current;
-    const jumped = Math.abs(centre - centreWasRef.current) > 1;
+    const jumped = Math.abs(centre - centreWasRef.current) > STEPPED_MAX;
     centreWasRef.current = centre;
     if (!jumped || strip === null) return;
     strip.style.transition = "none";
@@ -454,6 +457,21 @@ function DetailsFilmstripModal({
   // which is all the row needs from it — the geometry that keeps the step
   // honest.
   const MOUNTED_RADIUS = Math.floor(viewCount / 2) + 1;
+
+  // HOW FAR THE ROW WILL TRAVEL RATHER THAN CUT.
+  //
+  // One panel is a step; beyond about five the ease stops reading as travel
+  // and starts reading as a whip, and the cards in between go past too fast to
+  // be anything but noise. Five is the last distance where you can still watch
+  // the row move and know where you went.
+  //
+  // THE MOUNT WINDOW IS WHY THIS IS NOT JUST A NUMBER. `MOUNTED_RADIUS` is
+  // two panels either side at three-up, so a five-panel ease would slide three
+  // EMPTY boxes past — including the card you were just on, which would blink
+  // out and leave as a placeholder. `easingFrom` widens the window to cover
+  // the whole span for the length of the animation and then lets it go again,
+  // so the travel is paid for only while it is being watched.
+  const STEPPED_MAX = 5;
 
   const chooseViewCount = useCallback((next: ViewCount) => {
     rememberViewCount(next);
@@ -589,6 +607,34 @@ function DetailsFilmstripModal({
     });
   }, [ids, graph]);
 
+  // ONE WAY TO LAND, whichever gesture asked for it. A click on a box and a
+  // released scrub differ only in how the clip was chosen; what happens next
+  // — carry the clock, widen the mount window if the row is about to travel,
+  // move — is the same sentence and is written once.
+  const landOn = useCallback(
+    (clipId: string, seconds: number | null) => {
+      if (clipId === (node.id as string)) return;
+      const to = ids.indexOf(clipId);
+      const distance = to < 0 ? Number.POSITIVE_INFINITY : Math.abs(to - centre);
+      carryClockRef.current = seconds;
+      // Only a jump that will actually be animated needs the panels in
+      // between: one step already has them, and a cut never shows them.
+      if (distance > 1 && distance <= STEPPED_MAX) setEasingFrom(centre);
+      onOpenNeighbour(clipId);
+    },
+    [STEPPED_MAX, centre, ids, node.id, onOpenNeighbour],
+  );
+
+  // LET GO AGAIN once the row has arrived. Slightly longer than the 300ms
+  // ease, so the last frame is still covered; cleared on a timer rather than
+  // on `transitionend`, which does not fire when a second landing interrupts
+  // the first and would strand the window open.
+  useEffect(() => {
+    if (easingFrom === null) return;
+    const timer = setTimeout(() => setEasingFrom(null), 360);
+    return () => clearTimeout(timer);
+  }, [easingFrom]);
+
   const offset = centre < 0 ? 0 : centre - (ids.length - 1) / 2;
 
   // SWIPING THE STRIP. The same instruction as clicking a neighbour, held:
@@ -720,7 +766,16 @@ function DetailsFilmstripModal({
       // symptom of it not doing so is the minimap resting on the top edge of
       // the middle card, which is a quiet eight pixels rather than an obvious
       // fault.
-      className="fixed inset-0 z-[80] flex items-center justify-center overflow-hidden bg-black/80 px-6 pt-[11rem] pb-6 backdrop-blur-sm"
+      // `overflow-clip`, NOT `overflow-hidden`. Both crop, but `hidden` makes
+      // this a SCROLL CONTAINER — and the row is thirteen thousand pixels
+      // wide, so there is a great deal for it to scroll. Landing on a new clip
+      // moves focus to that panel's menu button, the browser scrolls the
+      // container to reveal it, and that scroll lands ON TOP of the transform
+      // the row has already made: measured, 1981px of `scrollLeft` against a
+      // row that had itself moved 1728px, which put the card just chosen
+      // entirely off the left edge. `clip` crops without ever being
+      // scrollable, so the transform stays the only thing that moves the row.
+      className="fixed inset-0 z-[80] flex items-center justify-center overflow-clip bg-black/80 px-6 pt-[11rem] pb-6 backdrop-blur-sm"
       // THE SCRIM DOES NOT DISMISS. Deliberate: this view is worked in, not
       // glanced at — trimming, scrubbing and swiping all end with the pointer
       // somewhere unpredictable, and the panels are cropped by the scrim
@@ -776,20 +831,15 @@ function DetailsFilmstripModal({
               // both re-centre the row, and both bring the frame with them.
               // Splitting them would mean a few pixels of travel decided
               // whether you kept your place in the shot.
-              onCommitClip={(clipId) => {
-                if (clipId === (node.id as string)) return;
-                carryClockRef.current = barSeconds;
-                onOpenNeighbour(clipId);
-              }}
+              onCommitClip={(clipId) => landOn(clipId, barSeconds)}
               // WHEREVER THE PLAYHEAD FINISHED, which is not always under the
               // pointer: holding at an edge runs the strip along beneath a
               // hand that is standing still. `position` is the view's own
               // answer to where the clock is, so the drag does not have to
               // carry one.
               onScrubEnd={() => {
-                if (position === null || position.clipId === (node.id as string)) return;
-                carryClockRef.current = shownSeconds;
-                onOpenNeighbour(position.clipId);
+                if (position === null) return;
+                landOn(position.clipId, shownSeconds);
               }}
               onScrubSeconds={(seconds) => {
                 setPlaying(false);
@@ -852,9 +902,9 @@ function DetailsFilmstripModal({
           // landing on the next clip is animated and letting go short of the
           // threshold springs back.
           //
-          // A LANDING FURTHER OFF THAN ONE PANEL is cut rather than eased,
-          // but not from here — see the layout effect above, which suppresses
-          // this for the single frame the jump paints in.
+          // A LANDING FURTHER OFF THAN `STEPPED_MAX` is cut rather than
+          // eased, but not from here — see the layout effect above, which
+          // suppresses this for the single frame the jump paints in.
           dragPx === 0
             ? "transition-transform duration-300 ease-out motion-reduce:transition-none"
             : "",
@@ -865,7 +915,13 @@ function DetailsFilmstripModal({
         }}
       >
         {ids.map((id, index) => {
-          const mounted = Math.abs(index - centre) <= MOUNTED_RADIUS;
+          // Within the resting window, OR anywhere along a span the row is
+          // currently easing across — see `easingFrom`.
+          const mounted =
+            Math.abs(index - centre) <= MOUNTED_RADIUS ||
+            (easingFrom !== null &&
+              index >= Math.min(easingFrom, centre) &&
+              index <= Math.max(easingFrom, centre));
           const panel = mounted ? graph.nodesById.get(parseNodeId(id)) : null;
           const media =
             panel && panel.kind === "media" && (panel as MediaNode).src

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { AudioLines, Pause, Play, Redo2, Undo2, X } from "lucide-react";
 
@@ -368,6 +368,39 @@ function DetailsFilmstripModal({
     setBarSeconds(carryClockRef.current);
     carryClockRef.current = null;
   }
+
+  // A LANDING THAT IS NOT A STEP IS A CUT.
+  //
+  // The row eases across one panel width for a swipe, a neighbour click or a
+  // step arrow, and that easing is the gesture finishing itself. A scrub
+  // release can land twenty clips away, and the same 300ms spent crossing
+  // twenty panel widths is not a move — it is every card on screen leaving to
+  // the left, most of them unmounted placeholders, with the one you asked for
+  // turning up at the end of it. Going somewhere else in the timeline is a
+  // cut, so it cuts.
+  //
+  // DONE TO THE NODE, NOT THROUGH STATE. A `cutTo` flag would have to be
+  // cleared again a render later, which is a cascading render for one frame of
+  // styling — and the frame it is trying to influence has already been
+  // decided by then. A layout effect runs after the transform is in the DOM
+  // and before the browser paints it, which is exactly the window where
+  // "arrive, do not travel" can still be said. The reflow read is what makes
+  // it stick: without it the two style writes coalesce and the transition
+  // never goes away.
+  const stripRef = useRef<HTMLDivElement | null>(null);
+  const centreWasRef = useRef(centre);
+  useLayoutEffect(() => {
+    const strip = stripRef.current;
+    const jumped = Math.abs(centre - centreWasRef.current) > 1;
+    centreWasRef.current = centre;
+    if (!jumped || strip === null) return;
+    strip.style.transition = "none";
+    void strip.offsetWidth;
+    const frame = requestAnimationFrame(() => {
+      strip.style.transition = "";
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [centre]);
 
   // Where the BAR draws its playhead when nothing has moved it: the cut at the
   // head of the centre clip, which is the moment this view is about.
@@ -808,6 +841,7 @@ function DetailsFilmstripModal({
       {/* The STRIP: one row, translated. Centred by the scrim, then offset by
           the subject's index so the clip being worked on lands mid-screen. */}
       <div
+        ref={stripRef}
         data-details-strip
         className={[
           "flex items-center",
@@ -817,6 +851,10 @@ function DetailsFilmstripModal({
           // rather than as smoothing. It comes back for the release, so
           // landing on the next clip is animated and letting go short of the
           // threshold springs back.
+          //
+          // A LANDING FURTHER OFF THAN ONE PANEL is cut rather than eased,
+          // but not from here — see the layout effect above, which suppresses
+          // this for the single frame the jump paints in.
           dragPx === 0
             ? "transition-transform duration-300 ease-out motion-reduce:transition-none"
             : "",


### PR DESCRIPTION
Two things, one of which is a bug that was **already on `main`** — #504 merged before the fix commit landed, so the slide is live right now.

### The slide off the left edge was the scrim scrolling

`overflow-hidden` makes an element a scroll container. This one crops a row ~13,800px wide, so there was plenty for the browser to scroll — and landing on a new clip moves focus to that panel's menu button, at which point the browser scrolls the container to reveal it. That scroll lands **on top of** the transform the row has already made.

Measured at the moment of failure:

```
scrimScrollLeft: 1981     row transform moved: 1728px
centre panel:    x = -1661, width 560   → entirely off the left edge
```

`overflow-clip` crops without ever being scrollable, so the transform stays the only thing that moves the row. This was reachable before the release-to-land change — that change only made landings long enough to see it.

### Travel up to five clips, cut beyond

Per your ask. One panel is a step; past about five the ease stops reading as travel and becomes a whip.

The mount window is why this isn't just a number: `MOUNTED_RADIUS` is two panels either side at three-up, so a five-panel ease would slide *empty placeholders* past — including the card you just left, which would blink out and leave as a box. `easingFrom` widens the window across the span for the length of the animation and releases it after, so the travel is paid for only while it's being watched.

Both gestures now go through one `landOn` — a click on a box and a released scrub differ only in how the clip was chosen.

### Proof

`LettingGoOfTheBarLandsTheStrip` now covers both sides: a 3-clip landing **travels** (row still moving a beat later, and more panels mounted than at rest), a 12-clip landing **arrives** (two readings 150ms apart identical). Both assert the clock is unchanged and the row comes back to the same seat, plus an explicit `scrollLeft === 0` guard on the scrim.

Green: 32/32 modal stories · 802/802 unit · 1418/1418 app · `tsc` clean · lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)