### PR TITLE
How far the bar reaches is a setting: ten either side, twenty, or all

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-bar-reach.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-bar-reach.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { barReachWindow, lastBarReach, rememberBarReach } from "./graph-item-details-bar-reach";
+
+const ids = Array.from({ length: 60 }, (_, index) => `clip-${index}`);
+
+describe("the remembered reach", () => {
+  it("opens at ten either side", () => {
+    // ASSERTED HERE rather than in a story: the value lives at module scope
+    // for the session, so in a browser running many stories the "default" a
+    // story sees is whoever reached for the picker last. This is the only
+    // place nothing can have moved it.
+    expect(lastBarReach()).toBe(10);
+  });
+
+  it("keeps what it is given", () => {
+    rememberBarReach("all");
+    expect(lastBarReach()).toBe("all");
+    rememberBarReach(10);
+  });
+});
+
+describe("barReachWindow", () => {
+  it("hands back the whole list untouched for 'all'", () => {
+    const window = barReachWindow(ids, 30, "all");
+    expect(window.ids).toBe(ids);
+    expect(window.centre).toBe(30);
+  });
+
+  it("takes `reach` either side of the subject", () => {
+    const window = barReachWindow(ids, 30, 10);
+    expect(window.ids).toHaveLength(21);
+    expect(window.ids[0]).toBe("clip-20");
+    expect(window.ids[20]).toBe("clip-40");
+    // And the subject is still the subject, at its new index.
+    expect(window.ids[window.centre]).toBe("clip-30");
+  });
+
+  it("keeps the window the same size at the start of the list", () => {
+    // Three clips in, there are not ten behind — so the ten it cannot take
+    // backwards are made up forwards. A window that shrank instead would
+    // change the scale under the playhead as you walked towards the end.
+    const window = barReachWindow(ids, 3, 10);
+    expect(window.ids).toHaveLength(21);
+    expect(window.ids[0]).toBe("clip-0");
+    expect(window.centre).toBe(3);
+    expect(window.ids[window.centre]).toBe("clip-3");
+  });
+
+  it("keeps the window the same size at the end of the list", () => {
+    const window = barReachWindow(ids, 58, 10);
+    expect(window.ids).toHaveLength(21);
+    expect(window.ids[20]).toBe("clip-59");
+    expect(window.ids[window.centre]).toBe("clip-58");
+  });
+
+  it("does not pad a list shorter than the window", () => {
+    const few = ids.slice(0, 9);
+    const window = barReachWindow(few, 4, 10);
+    expect(window.ids).toBe(few);
+    expect(window.centre).toBe(4);
+  });
+
+  it("leaves a list exactly the window's size alone", () => {
+    const exact = ids.slice(0, 21);
+    const window = barReachWindow(exact, 5, 10);
+    expect(window.ids).toBe(exact);
+    expect(window.centre).toBe(5);
+  });
+
+  it("survives a subject it cannot find", () => {
+    const window = barReachWindow(ids, -1, 10);
+    expect(window.ids).toBe(ids);
+    expect(window.centre).toBe(-1);
+  });
+});

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-bar-reach.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-bar-reach.ts
@@ -1,0 +1,58 @@
+// HOW FAR THE BAR REACHES either side of the clip being worked on.
+//
+// Its own module for the same reason the view count has one: the reach is a
+// layout decision shared by the thing that lays the bar out and the picker
+// that sets it, and neither should own the other's constant.
+//
+// A number is a COUNT OF CLIPS EITHER SIDE, so 10 puts 21 clips on the bar
+// when the subject has that many neighbours — ten behind, the subject, ten
+// ahead. `"all"` is the whole collection, which is what the bar did before
+// there was a choice and is still the right answer when the question is
+// "where does this sit in the sequence".
+
+export const BAR_REACHES = [10, 20, "all"] as const;
+export type BarReach = (typeof BAR_REACHES)[number];
+
+/**
+ * The last reach chosen, kept at module scope.
+ *
+ * Deliberately NOT persisted, and for the same reason as the view count: it
+ * is a working posture for a session rather than a preference, and a board
+ * reopened tomorrow should start close in.
+ */
+let rememberedReach: BarReach = 10;
+
+export function lastBarReach(): BarReach {
+  return rememberedReach;
+}
+
+export function rememberBarReach(reach: BarReach): void {
+  rememberedReach = reach;
+}
+
+/** How a reach reads in the picker: a bare number, or the word. */
+export function barReachLabel(reach: BarReach): string {
+  return reach === "all" ? "All" : String(reach);
+}
+
+/**
+ * The slice of `ids` a reach exposes, and where the subject sits inside it.
+ *
+ * CLAMPED RATHER THAN CENTRED. A subject three clips from the start with a
+ * reach of ten cannot have ten behind it, and the obvious alternative —
+ * shrinking the window to the smaller side — would make the bar change width
+ * as you walked towards an end. Taking what is available on the short side and
+ * making it up on the long side keeps the window the same size wherever it is,
+ * so the scale under the playhead does not shift as you move.
+ */
+export function barReachWindow(
+  ids: readonly string[],
+  centre: number,
+  reach: BarReach,
+): Readonly<{ ids: readonly string[]; centre: number }> {
+  if (reach === "all" || centre < 0) return { ids, centre };
+  const span = reach * 2 + 1;
+  if (ids.length <= span) return { ids, centre };
+  const from = Math.min(Math.max(0, centre - reach), ids.length - span);
+  return { ids: ids.slice(from, from + span), centre: centre - from };
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -408,6 +408,17 @@ function centreBox(): HTMLElement {
  * row easing across three panels is invisible to it and a measurement taken
  * straight after reads a card mid-flight.
  */
+/** Press one of the reach picker's buttons by its label. */
+function reachTo(label: string): void {
+  const group = document.querySelector<HTMLElement>("[data-details-bar-reach]");
+  expect(group).not.toBeNull();
+  const button = Array.from(group!.querySelectorAll("button")).find(
+    (candidate) => candidate.textContent?.trim() === label,
+  );
+  expect(button).not.toBeUndefined();
+  button!.click();
+}
+
 async function settleRow(): Promise<void> {
   const row = document.querySelector<HTMLElement>("[data-details-strip]");
   expect(row).not.toBeNull();
@@ -1948,9 +1959,18 @@ export const TheMinimapMovesTheWindow: Story = {
       document.querySelector<HTMLElement>("[data-seam-mini-window]")!.getBoundingClientRect();
     const at = () => Number(seamTrack().getAttribute("aria-valuenow"));
 
-    // EVERY clip is on it, both collections' worth — this is the one thing on
-    // screen that never crops.
-    expect(document.querySelectorAll("[data-seam-mini-segment]").length).toBe(24);
+    // AS FAR AS THE BAR REACHES, which is the default ten either side — the
+    // minimap draws the stretch the clock covers, not the whole project. It
+    // used to be the one thing on screen that never cropped; the reach picker
+    // is what changed that, and `All` is still there for when the question is
+    // where this sits in the sequence.
+    const segments = () => document.querySelectorAll("[data-seam-mini-segment]").length;
+    expect(segments()).toBe(21);
+    reachTo("All");
+    await waitFor(() => expect(segments()).toBe(24));
+    // Left as it was found, for whichever story runs next in this browser.
+    reachTo("10");
+    await waitFor(() => expect(segments()).toBe(21));
 
     // The window is a PART of it, not all of it: if it covered the whole
     // minimap there would be nothing off the sides and nothing to say.
@@ -2021,6 +2041,50 @@ export const PointingAtABoxSaysWhatItIs: Story = {
 };
 
 /**
+ * HOW FAR THE BAR REACHES IS A SETTING, and ten either side is where it opens.
+ *
+ * The bar used to draw the whole collection whatever you were doing, which is
+ * the right answer to "where does this sit in the sequence" and the wrong one
+ * to "what is around this cut" — at a hundred clips a box is a hairline and
+ * the thing you are working on is indistinguishable from the thing you are
+ * not. The reach is the dial between those two questions.
+ *
+ * TWENTY AND ALL ARE THE SAME PICTURE HERE, because this scene is 24 clips
+ * long and twenty either side reaches past both ends. That is the window
+ * clamping rather than the setting failing — `barReachWindow` has its own
+ * tests for the arithmetic, and this covers the wiring.
+ */
+export const TheBarReachIsASetting: Story = {
+  render: () => <SeamHarness scene={TWO_ROOMS_SCENE} />,
+  play: async () => {
+    await waitFor(() => expect(document.querySelector("[data-seam-strip]")).not.toBeNull());
+    await settleStrip();
+    const boxes = () => seamBoxes().length;
+    const subject = () => centreBox().getAttribute("data-seam-segment");
+
+    // SET EXPLICITLY RATHER THAN ASSUMED. The reach is remembered at module
+    // scope for the session, so a story that ran earlier in this browser and
+    // reached for `All` would leave it there — and a story that reads the
+    // default is really reading whoever went last. What the default IS belongs
+    // in the module's own test, where nothing can have moved it.
+    reachTo("10");
+    await waitFor(() => expect(boxes()).toBe(21));
+    const startedOn = subject();
+
+    reachTo("All");
+    await waitFor(() => expect(boxes()).toBe(24));
+
+    reachTo("10");
+    await waitFor(() => expect(boxes()).toBe(21));
+
+    // CHANGING THE REACH IS NOT A MOVE. It changes how much you can get to,
+    // not where you are — losing your place to a change of view would make
+    // the control cost more than it is worth.
+    expect(subject()).toBe(startedOn);
+  },
+};
+
+/**
  * LETTING GO IS THE COMMIT — AND YOU KEEP THE FRAME YOU LET GO ON.
  *
  * A drag and a press that does not travel are still told apart (distance, not
@@ -2051,6 +2115,12 @@ export const LettingGoOfTheBarLandsTheStrip: Story = {
     const stripX = () => strip().getBoundingClientRect().left;
     const panels = () => document.querySelectorAll("[data-item-details-panel]").length;
     const boxIndex = () => seamBoxes().indexOf(centreBox());
+    const shownFrame = () =>
+      Number(
+        document
+          .querySelector<HTMLElement>('[data-item-details-panel="centre"]')!
+          .getAttribute("data-item-details-at"),
+      );
 
     // Hold the scrub, read the clock at the moment before the release, let go.
     const dragToBox = async (box: HTMLElement) => {
@@ -2058,11 +2128,18 @@ export const LettingGoOfTheBarLandsTheStrip: Story = {
       const x = rect.left + rect.width * 0.5;
       scrubToClientX(x, { hold: true });
       await waitFor(() => expect(at()).toBeGreaterThan(0));
-      const letGoAt = at();
+      // The frame the MONITOR is on at the moment of release — the thing the
+      // landing has to preserve, and the only reading that survives the bar
+      // being rebuilt around a new subject.
+      const heldFrame = Number(
+        document
+          .querySelector<HTMLElement>("[data-item-details-at]")!
+          .getAttribute("data-item-details-at"),
+      );
       const surface = seamSurface();
       const surfaceBox = surface.getBoundingClientRect();
       fireEvent.pointerUp(surface, pointerAt(x, surfaceBox.top + surfaceBox.height / 2));
-      return letGoAt;
+      return heldFrame;
     };
 
     expect(subject()).toBe("subject");
@@ -2088,10 +2165,11 @@ export const LettingGoOfTheBarLandsTheStrip: Story = {
     await settleStrip();
     await settleRow();
     expect(subject()).toBe(near.getAttribute("data-seam-segment"));
-    // THE CLOCK DID NOT MOVE. Every panel derives its picture from
-    // `seamAt(timeline, barSeconds)`, so a bar reading the same second before
-    // and after the row advances IS the centre panel holding the frame.
-    expect(at()).toBe(letGoNear);
+    // THE FRAME CAME WITH IT. Read off the panel rather than off the bar:
+    // the bar is a window with a reach either side of the subject, so it is
+    // rebuilt around wherever you land and its own seconds are not comparable
+    // across the journey. The panel reports the clip's OWN time, which is.
+    expect(shownFrame()).toBeCloseTo(letGoNear, 2);
     // And the window let go again once it had arrived.
     await waitFor(() => expect(panels()).toBe(restingPanels));
 
@@ -2106,10 +2184,12 @@ export const LettingGoOfTheBarLandsTheStrip: Story = {
         .getBoundingClientRect().left;
     const restingCentreX = seatX();
     const landedOn = subject();
-    const far = seamBoxes()[boxIndex() + 12]!;
+    const far = seamBoxes()[boxIndex() + 8]!;
     // THE PRECONDITION. Past `STEPPED_MAX`, or this measures the easing path
-    // twice and the cut not at all.
-    expect(12).toBeGreaterThan(5);
+    // twice and the cut not at all — and inside the default reach, or there is
+    // no box there to aim at.
+    expect(8).toBeGreaterThan(5);
+    expect(far).not.toBeUndefined();
     const letGoFar = await dragToBox(far);
     await waitFor(() => expect(subject()).not.toBe(landedOn));
 
@@ -2139,7 +2219,7 @@ export const LettingGoOfTheBarLandsTheStrip: Story = {
     // Zero here is `overflow-clip` doing its job.
     expect(strip().parentElement!.scrollLeft).toBe(0);
     expect(subject()).toBe(far.getAttribute("data-seam-segment"));
-    expect(at()).toBe(letGoFar);
+    expect(shownFrame()).toBeCloseTo(letGoFar, 2);
   },
 };
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -40,6 +40,8 @@ import { SeamStripBar } from "./graph-seam-strip-bar";
 import {
   buildSeamTimeline,
   seamAt,
+  seamSecondsAt,
+  type SeamPosition,
   seamSpanFor,
   seamStripProgress,
   type SeamClip,
@@ -57,6 +59,14 @@ import {
   rememberViewCount,
   type ViewCount,
 } from "./graph-item-details-view-count";
+import {
+  BAR_REACHES,
+  barReachLabel,
+  barReachWindow,
+  lastBarReach,
+  rememberBarReach,
+  type BarReach,
+} from "./graph-item-details-bar-reach";
 
 // The trim MODAL (PL10-008, an experiment replacing the docked map).
 //
@@ -229,7 +239,12 @@ function DetailsFilmstripModal({
   // head. A ref rather than state because nothing renders from it: it is set
   // on the way out of one subject and read once on the way into the next, and
   // a re-render in between would be a render nobody needs.
-  const carryClockRef = useRef<number | null>(null);
+  // CARRIED AS A POSITION, NOT A SECOND. The bar is a window with a reach
+  // either side of the subject, so it is rebuilt around wherever you land and
+  // the same frame of the same clip is a different number of seconds along on
+  // the bar you left and the bar you arrive on. A raw second would survive the
+  // journey and mean something else at the end of it.
+  const carryClockRef = useRef<SeamPosition | null>(null);
   // WHERE AN EASING JUMP STARTED, while it is still easing. Null the rest of
   // the time, which is nearly all of the time.
   const [easingFrom, setEasingFrom] = useState<number | null>(null);
@@ -244,6 +259,10 @@ function DetailsFilmstripModal({
   // would make the wider views something you re-choose rather than something
   // you use.
   const [viewCount, setViewCount] = useState<ViewCount>(lastViewCount());
+  // HOW FAR THE BAR REACHES, which is a different question from how many
+  // panels are on screen: the row is what you are working on, the bar is how
+  // much of the sequence you can get to without leaving it.
+  const [reach, setReach] = useState<BarReach>(lastBarReach());
 
   const clipAt = useCallback(
     (index: number): MediaNode | null => {
@@ -318,15 +337,23 @@ function DetailsFilmstripModal({
   // got the approach to the cut and no more. With every clip present in full
   // there is no partial neighbour to lead into; the run-up to any cut is just
   // the clip before it, which is now on the bar in its entirety.
+  // THE SLICE THE BAR ACTUALLY COVERS. `ids` is the whole flat order and the
+  // ROW still walks all of it; this is only how far the clock reaches, so the
+  // two can disagree and the row can be scrolled past the end of the bar by
+  // stepping. Everything the bar is built from comes through here, so the
+  // track, the ruler, the strip and the minimap cannot end up describing
+  // different stretches of time.
+  const barWindow = useMemo(() => barReachWindow(ids, centre, reach), [ids, centre, reach]);
+
   const collectionSeamClips = useMemo(
     () =>
-      ids
+      barWindow.ids
         .map((id) => {
           const found = graph.nodesById.get(parseNodeId(id));
           return found && found.kind === "media" ? seamClipOf(found as MediaNode) : null;
         })
         .filter((clip): clip is SeamClip => clip !== null),
-    [ids, graph],
+    [barWindow, graph],
   );
 
   // WHERE THE BAR RESTS, as an index into what `buildSeamTimeline` will
@@ -368,8 +395,11 @@ function DetailsFilmstripModal({
   if (clockFor !== (node.id as string)) {
     setClockFor(node.id as string);
     setPlaying(false);
-    setBarSeconds(carryClockRef.current);
+    const carried = carryClockRef.current;
     carryClockRef.current = null;
+    setBarSeconds(
+      carried === null ? null : seamSecondsAt(timeline, carried.clipId, carried.clipSeconds),
+    );
   }
 
   // A LANDING THAT IS NOT A STEP IS A CUT.
@@ -472,6 +502,11 @@ function DetailsFilmstripModal({
   // the whole span for the length of the animation and then lets it go again,
   // so the travel is paid for only while it is being watched.
   const STEPPED_MAX = 5;
+
+  const chooseReach = useCallback((next: BarReach) => {
+    rememberBarReach(next);
+    setReach(next);
+  }, []);
 
   const chooseViewCount = useCallback((next: ViewCount) => {
     rememberViewCount(next);
@@ -591,7 +626,7 @@ function DetailsFilmstripModal({
   // The bar owns the SCALE now, so it also owns the layout — this hands it
   // clips, not pixels.
   const barClips = useMemo<readonly SeamBarClip[]>(() => {
-    return ids.map((id) => {
+    return barWindow.ids.map((id) => {
       const found = graph.nodesById.get(parseNodeId(id));
       const media = found && found.kind === "media" ? (found as MediaNode) : null;
       const parentId = graph.parentById.get(parseNodeId(id)) ?? null;
@@ -605,18 +640,22 @@ function DetailsFilmstripModal({
         ...(media === null ? {} : { posterSrc: seamClipOf(media)?.posterSrc }),
       };
     });
-  }, [ids, graph]);
+  }, [barWindow, graph]);
 
   // ONE WAY TO LAND, whichever gesture asked for it. A click on a box and a
   // released scrub differ only in how the clip was chosen; what happens next
   // — carry the clock, widen the mount window if the row is about to travel,
   // move — is the same sentence and is written once.
   const landOn = useCallback(
-    (clipId: string, seconds: number | null) => {
+    (clipId: string, at: SeamPosition | null) => {
       if (clipId === (node.id as string)) return;
       const to = ids.indexOf(clipId);
       const distance = to < 0 ? Number.POSITIVE_INFINITY : Math.abs(to - centre);
-      carryClockRef.current = seconds;
+      // Only a position ON the clip being landed on is worth carrying. At a
+      // seam the playhead and the clicked box can disagree by a frame, and
+      // carrying the other clip's position would land you on the right card
+      // showing the wrong one's time.
+      carryClockRef.current = at !== null && at.clipId === clipId ? at : null;
       // Only a jump that will actually be animated needs the panels in
       // between: one step already has them, and a cut never shows them.
       if (distance > 1 && distance <= STEPPED_MAX) setEasingFrom(centre);
@@ -762,7 +801,9 @@ function DetailsFilmstripModal({
       // they take no space, and the row would centre straight up underneath
       // them. This padding is the band they occupy: header (61px) plus the
       // bar block at top-16 with its own pt-4 (152px to its underside), plus
-      // clearance. It grew when the bar did, and it has to keep pace: the
+      // clearance, plus the reach picker's own row (mt-2 and a ~18px button)
+      // — which is why this is 13rem and not the 11rem it was before that
+      // picker existed. It grew when the bar did, and it has to keep pace: the
       // symptom of it not doing so is the minimap resting on the top edge of
       // the middle card, which is a quiet eight pixels rather than an obvious
       // fault.
@@ -775,7 +816,7 @@ function DetailsFilmstripModal({
       // row that had itself moved 1728px, which put the card just chosen
       // entirely off the left edge. `clip` crops without ever being
       // scrollable, so the transform stays the only thing that moves the row.
-      className="fixed inset-0 z-[80] flex items-center justify-center overflow-clip bg-black/80 px-6 pt-[11rem] pb-6 backdrop-blur-sm"
+      className="fixed inset-0 z-[80] flex items-center justify-center overflow-clip bg-black/80 px-6 pt-[13rem] pb-6 backdrop-blur-sm"
       // THE SCRIM DOES NOT DISMISS. Deliberate: this view is worked in, not
       // glanced at — trimming, scrubbing and swiping all end with the pointer
       // somewhere unpredictable, and the panels are cropped by the scrim
@@ -831,7 +872,7 @@ function DetailsFilmstripModal({
               // both re-centre the row, and both bring the frame with them.
               // Splitting them would mean a few pixels of travel decided
               // whether you kept your place in the shot.
-              onCommitClip={(clipId) => landOn(clipId, barSeconds)}
+              onCommitClip={(clipId) => landOn(clipId, position)}
               // WHEREVER THE PLAYHEAD FINISHED, which is not always under the
               // pointer: holding at an edge runs the strip along beneath a
               // hand that is standing still. `position` is the view's own
@@ -839,13 +880,47 @@ function DetailsFilmstripModal({
               // carry one.
               onScrubEnd={() => {
                 if (position === null) return;
-                landOn(position.clipId, shownSeconds);
+                landOn(position.clipId, position);
               }}
               onScrubSeconds={(seconds) => {
                 setPlaying(false);
                 setBarSeconds(Math.min(Math.max(seconds, 0), timeline.totalSeconds));
               }}
             />
+            {/* HOW FAR THE BAR REACHES, tucked under its right-hand end.
+                Here rather than with the panel-count picker at the foot of the
+                screen because it is a question about THIS control: the number
+                you are reading is the width of the thing directly above it,
+                and the two are read together. */}
+            <div
+              data-details-bar-reach
+              role="group"
+              aria-label="Clips either side on the bar"
+              className="mt-2 flex items-center justify-end gap-1"
+            >
+              <span className="mr-1 font-mono text-[10px] text-zinc-500">reach</span>
+              {BAR_REACHES.map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  aria-pressed={option === reach}
+                  onClick={() => chooseReach(option)}
+                  title={
+                    option === "all"
+                      ? "Reach the whole sequence"
+                      : `Reach ${option} clips either side`
+                  }
+                  className={[
+                    "min-w-7 rounded px-1.5 py-0.5 font-mono text-[10px] tabular-nums transition-colors",
+                    option === reach
+                      ? "bg-zinc-100 text-zinc-900"
+                      : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100",
+                  ].join(" ")}
+                >
+                  {barReachLabel(option)}
+                </button>
+              ))}
+            </div>
           </div>
         </div>
       )}

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
@@ -292,6 +292,14 @@ export function DetailsPanel({
         // that was opened. The neighbours are working panels, not focus traps.
         {...(centre ? dialogProps : {})}
         data-item-details-panel={centre ? "centre" : "neighbour"}
+        // WHAT FRAME THIS PANEL IS SHOWING, when the clock is what put it
+        // there. Absent on a panel resting on its own first frame, which is a
+        // different state from "at zero seconds" and the one an untouched view
+        // is in. Exposed because it is the one fact about a landing that
+        // cannot be read any other way: the bar is a window, so its own
+        // seconds mean different things on different bars, while this is the
+        // clip's own time and travels.
+        data-item-details-at={monitor === null ? undefined : monitor.seconds.toFixed(3)}
         data-item-details-scrub-focus={scrubFocus ? "" : undefined}
         data-item-details-magnified={magnification > 1 ? "" : undefined}
         style={{

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-scrub.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-scrub.ts
@@ -168,6 +168,34 @@ export type SeamPosition = Readonly<{ clipId: string; clipSeconds: number }>;
  * The very end of the bar is the one exception: there is no next span to hand
  * it to, so it resolves to the last clip's final moment rather than to nothing.
  */
+/**
+ * The other direction: a clip and a time inside it, back to a bar time.
+ *
+ * The inverse of `seamAt`, and needed because the bar is a WINDOW again — it
+ * shows a fixed reach either side of the subject, so the same frame of the
+ * same clip is a different number of seconds along on two different bars.
+ * Anything that has to survive the window moving (the clock carried across a
+ * landing, most of all) has to travel as a position and be converted here,
+ * not as a raw second.
+ *
+ * Null when the clip is not on this bar at all, which is a real answer rather
+ * than a failure: a caller holding a position from a wider window has to be
+ * able to find out that the narrower one cannot show it.
+ */
+export function seamSecondsAt(
+  timeline: SeamTimeline,
+  clipId: string,
+  secondsIntoClip: number,
+): number | null {
+  const span = timeline.spans.find((candidate) => candidate.clipId === clipId);
+  if (span === undefined) return null;
+  // Clamped to the span: a trim can have shortened the clip since the position
+  // was taken, and a second past its end would resolve onto the NEXT clip and
+  // silently land somewhere else.
+  const within = Math.min(Math.max(secondsIntoClip - span.sourceOffset, 0), span.to - span.from);
+  return span.from + within;
+}
+
 export function seamAt(timeline: SeamTimeline, barSeconds: number): SeamPosition | null {
   if (timeline.spans.length === 0) return null;
   const time = Math.min(Math.max(barSeconds, 0), timeline.totalSeconds);


### PR DESCRIPTION
The navigation bar showed every clip in the collection. There's now a small `reach` picker under its right-hand end: **10 · 20 · All**, opening on 10 (ten behind, the clip itself, ten ahead).

Placed under the bar rather than beside the panel-count picker at the foot of the screen, because it's a question about *this* control — the number you're reading is the width of the thing directly above it.

### The whole bar narrows, not just the strip

Track, ruler, boxes and minimap are one coordinate space. A minimap describing a different stretch of time from the clock above it would be worse than no minimap, so everything the bar is built from now comes through `barReachWindow`.

The row is unaffected — it still walks the whole flat order, so stepping can take you past the end of the bar's reach and the bar re-windows around where you land.

### The window is clamped, not centred

A subject three clips from the start can't have ten behind it. Shrinking the window on the short side would make the bar change scale as you walk towards an end, so it takes what's there and makes it up on the long side — one size wherever it sits.

### The carried clock had to become a position

This is the part worth reviewing. A windowed bar is rebuilt around wherever you land, so the same frame of the same clip is a **different number of seconds along** on the bar you left and the bar you arrive on. The absolute second that survived a landing in #504 now means something else at the end of the journey — which is exactly the failure the pre-window bar had, and the reason its clock reset was unconditional back then.

`seamSecondsAt` (the inverse of `seamAt`) converts a carried position onto whichever bar is current, clamped into its span so a trim since the position was taken can't resolve onto the next clip.

A panel now reports the frame the clock put it on via `data-item-details-at`, absent when it's resting on its own first frame. That's the only way to observe a preserved frame now that the bar's seconds aren't comparable across a landing — and it's a better assertion for the caveat in #504 than the clock proxy that story was using.

### Proof

- `barReachWindow` has its own unit tests: both ends of the list, a list shorter than the window, one exactly the window's size, and a subject it can't find.
- The default lives in a unit test rather than a story — the reach is remembered at module scope for the session, so in a browser running many stories the "default" a story sees is whoever reached for the picker last. Both stories that touch it now set it explicitly and leave it as they found it.
- `TheBarReachIsASetting` covers the wiring and that changing the reach doesn't move you. `TheMinimapMovesTheWindow` lost its "the one thing that never crops" claim, which the picker made false.

Green: 33/33 modal stories · 802/802 unit · 1427/1427 app · `tsc` clean · lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)