### PR TITLE
Landings slide instead of jumping — the bar's boxes, and the row from the side

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -2041,6 +2041,53 @@ export const PointingAtABoxSaysWhatItIs: Story = {
 };
 
 /**
+ * THE BAR'S BOXES SLIDE INTO POSITION WHEN THE CENTRED CLIP CHANGES.
+ *
+ * The strip's transform is driven by three different things and only one of
+ * them wants easing. A drag has to track the hand exactly — the edge run's
+ * whole point is that the strip moves WITH the pointer — and a wheel zoom or
+ * a pan is the same hand by another route. Changing which clip is centred is
+ * not: nothing is under the reader's finger, the strip re-centres on somewhere
+ * else entirely, and a jump there cannot be told apart from the bar being
+ * redrawn with different contents.
+ *
+ * THE DRAG HALF IS COVERED BY `HoldingAtAnEdgeRunsTheStrip`, which measures
+ * the strip's travel against the clock to within two pixels — an easing left
+ * switched on during a drag puts the strip behind the hand and fails there.
+ */
+export const TheBarSlidesIntoPositionOnAMove: Story = {
+  render: () => <SeamHarness scene={TWO_ROOMS_SCENE} />,
+  play: async () => {
+    await waitFor(() => expect(document.querySelector("[data-seam-strip]")).not.toBeNull());
+    await settleStrip();
+    const stripX = () =>
+      document.querySelector<HTMLElement>("[data-seam-strip]")!.getBoundingClientRect().left;
+    const subject = () => centreBox().getAttribute("data-seam-segment");
+
+    const startedOn = subject();
+    const from = stripX();
+
+    // A press on a box well along the bar: a move, not a drag.
+    const boxes = seamBoxes();
+    const target = boxes[boxes.indexOf(centreBox()) + 6]!;
+    clickBox(target);
+    await waitFor(() => expect(subject()).not.toBe(startedOn));
+
+    // STILL ON ITS WAY. This is the assertion a jump fails: with no easing the
+    // strip is already at its destination by the first reading, so the two
+    // readings agree and nothing here can tell that it moved at all.
+    const early = stripX();
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(stripX()).not.toBe(early);
+
+    // And it does arrive somewhere else, so the movement was real rather than
+    // a wobble.
+    await settleStrip();
+    expect(Math.abs(stripX() - from)).toBeGreaterThan(20);
+  },
+};
+
+/**
  * HOW FAR THE BAR REACHES IS A SETTING, and ten either side is where it opens.
  *
  * The bar used to draw the whole collection whatever you were doing, which is
@@ -2173,7 +2220,7 @@ export const LettingGoOfTheBarLandsTheStrip: Story = {
     // And the window let go again once it had arrived.
     await waitFor(() => expect(panels()).toBe(restingPanels));
 
-    // ── A LONG ONE ARRIVES INSTEAD ────────────────────────────────────────
+    // ── A LONG ONE ARRIVES THE SAME WAY, FROM THE SIDE ────────────────────
     // THE SEAT IS READ HERE, not at the top of the story. The row is a
     // different shape on its first paint — panels are still arriving — so its
     // resting x then is not the resting x it keeps. Taken between the two
@@ -2185,41 +2232,43 @@ export const LettingGoOfTheBarLandsTheStrip: Story = {
     const restingCentreX = seatX();
     const landedOn = subject();
     const far = seamBoxes()[boxIndex() + 8]!;
-    // THE PRECONDITION. Past `STEPPED_MAX`, or this measures the easing path
-    // twice and the cut not at all — and inside the default reach, or there is
-    // no box there to aim at.
-    expect(8).toBeGreaterThan(5);
+    // THE PRECONDITION: far enough that sliding the whole way would be
+    // obvious, and inside the default reach so there is a box there to aim at.
     expect(far).not.toBeUndefined();
     const letGoFar = await dragToBox(far);
     await waitFor(() => expect(subject()).not.toBe(landedOn));
 
-    // ASSERTED AS "IT DOES NOT MOVE" rather than by reading a transition
-    // duration off the element: the cut lasts a single render and catching
-    // that frame would be a race, while two readings a beat apart cannot be
-    // fooled — mid-flight they differ, arrived they do not.
-    const landedX = seatX();
-    await new Promise((resolve) => setTimeout(resolve, 150));
-    expect(seatX()).toBe(landedX);
+    // IT COMES IN FROM THE SIDE, NOT FROM WHERE IT WAS. Eight clips along,
+    // but the row is never displaced by more than the approach — so the
+    // distance travelled says which side you came from and nothing else.
+    // Sliding the whole way would start this eight panel-widths out and spend
+    // half a second blurring six cards nobody can read.
+    const step = document
+      .querySelector<HTMLElement>('[data-item-details-panel="centre"]')!
+      .getBoundingClientRect().width + 16;
+    const displaced = Math.abs(seatX() - restingCentreX);
+    expect(displaced).toBeGreaterThan(1);
+    expect(displaced).toBeLessThan(step * 2 + 8);
 
-    // Arrived in the MIDDLE, which is what says the offset it cut to was the
-    // right one rather than merely a still one.
-    // Arrived in the CENTRE SEAT — measured against where the centre panel sat
-    // at rest at the top of this story rather than against the middle of the
-    // window, because the row's resting x is a product of panel width, gap and
-    // the scrim's padding and this assertion should not have to know any of
-    // them. Landing still but one seat out would otherwise read as success.
+    // And it is MOVING, not placed.
+    const slidingFrom = seatX();
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(seatX()).not.toBe(slidingFrom);
+
+    await settleStrip();
+    await settleRow();
     expect(seatX()).toBeCloseTo(restingCentreX, 0);
-
-    // THE SCRIM NEVER SCROLLS. It crops a row thirteen thousand pixels wide,
-    // so if it were a scroll container there would be a great deal for the
-    // browser to scroll it by — and it would, because landing moves focus to
-    // the new panel's menu button and a hidden overflow is still scrolled to
-    // reveal what is focused. That scroll would land on top of the transform
-    // the row has already made and put the chosen card off the left edge.
-    // Zero here is `overflow-clip` doing its job.
-    expect(strip().parentElement!.scrollLeft).toBe(0);
     expect(subject()).toBe(far.getAttribute("data-seam-segment"));
     expect(shownFrame()).toBeCloseTo(letGoFar, 2);
+
+    // THE SCRIM NEVER SCROLLS. It crops a row thousands of pixels wide, so if
+    // it were a scroll container there would be a great deal for the browser
+    // to scroll it by — and it would, because landing moves focus to the new
+    // panel's menu button and a hidden overflow is still scrolled to reveal
+    // what is focused. That scroll would land on top of the transform the row
+    // has already made and put the chosen card off the left edge. Zero here is
+    // `overflow-clip` doing its job.
+    expect(strip().parentElement!.scrollLeft).toBe(0);
   },
 };
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -247,7 +247,10 @@ function DetailsFilmstripModal({
   const carryClockRef = useRef<SeamPosition | null>(null);
   // WHERE AN EASING JUMP STARTED, while it is still easing. Null the rest of
   // the time, which is nearly all of the time.
-  const [easingFrom, setEasingFrom] = useState<number | null>(null);
+  // A LANDING IN PROGRESS. `approach` is how many panels the row is displaced
+  // by, signed — non-zero on the frame it is put down, then zero for the slide
+  // itself. Null between landings, which is nearly always.
+  const [travel, setTravel] = useState<{ approach: number } | null>(null);
   const [playing, setPlaying] = useState(false);
   // A DRAG IS IN PROGRESS ON THE BAR. Distinct from `scrubbed`, which stays
   // true once the clock has been touched: this is the gesture itself, and it
@@ -402,38 +405,7 @@ function DetailsFilmstripModal({
     );
   }
 
-  // A LANDING THAT IS NOT A STEP IS A CUT.
-  //
-  // The row eases across one panel width for a swipe, a neighbour click or a
-  // step arrow, and that easing is the gesture finishing itself. A scrub
-  // release can land twenty clips away, and the same 300ms spent crossing
-  // twenty panel widths is not a move — it is every card on screen leaving to
-  // the left, most of them unmounted placeholders, with the one you asked for
-  // turning up at the end of it. Going somewhere else in the timeline is a
-  // cut, so it cuts.
-  //
-  // DONE TO THE NODE, NOT THROUGH STATE. A `cutTo` flag would have to be
-  // cleared again a render later, which is a cascading render for one frame of
-  // styling — and the frame it is trying to influence has already been
-  // decided by then. A layout effect runs after the transform is in the DOM
-  // and before the browser paints it, which is exactly the window where
-  // "arrive, do not travel" can still be said. The reflow read is what makes
-  // it stick: without it the two style writes coalesce and the transition
-  // never goes away.
   const stripRef = useRef<HTMLDivElement | null>(null);
-  const centreWasRef = useRef(centre);
-  useLayoutEffect(() => {
-    const strip = stripRef.current;
-    const jumped = Math.abs(centre - centreWasRef.current) > STEPPED_MAX;
-    centreWasRef.current = centre;
-    if (!jumped || strip === null) return;
-    strip.style.transition = "none";
-    void strip.offsetWidth;
-    const frame = requestAnimationFrame(() => {
-      strip.style.transition = "";
-    });
-    return () => cancelAnimationFrame(frame);
-  }, [centre]);
 
   // Where the BAR draws its playhead when nothing has moved it: the cut at the
   // head of the centre clip, which is the moment this view is about.
@@ -488,20 +460,26 @@ function DetailsFilmstripModal({
   // honest.
   const MOUNTED_RADIUS = Math.floor(viewCount / 2) + 1;
 
-  // HOW FAR THE ROW WILL TRAVEL RATHER THAN CUT.
+  // HOW A LANDING ARRIVES: FROM THE SIDE, NOT FROM WHERE IT WAS.
   //
-  // One panel is a step; beyond about five the ease stops reading as travel
-  // and starts reading as a whip, and the cards in between go past too fast to
-  // be anything but noise. Five is the last distance where you can still watch
-  // the row move and know where you went.
+  // The row is put down a couple of panels off, with no transition, and then
+  // slides the rest of the way in. What you see is the clip you chose coming
+  // to the middle from the side it lies on — which is the move being
+  // described, and it reads the same whether you landed two clips along or
+  // twenty.
   //
-  // THE MOUNT WINDOW IS WHY THIS IS NOT JUST A NUMBER. `MOUNTED_RADIUS` is
-  // two panels either side at three-up, so a five-panel ease would slide three
-  // EMPTY boxes past — including the card you were just on, which would blink
-  // out and leave as a placeholder. `easingFrom` widens the window to cover
-  // the whole span for the length of the animation and then lets it go again,
-  // so the travel is paid for only while it is being watched.
-  const STEPPED_MAX = 5;
+  // SLIDING THE WHOLE DISTANCE WAS THE OBVIOUS THING AND IT IS WRONG TWICE.
+  // Ten panels of travel is ten panels that have to be REAL for the length of
+  // the animation, and a full panel is a video element, a trim strip and a tag
+  // editor — the same cost `MOUNTED_RADIUS` exists to avoid, paid all at once
+  // so that it can be blurred past. And what it buys is a whip: the cards in
+  // between go by too fast to be read, so the motion says "a long way" without
+  // saying where. A fixed short approach costs two extra panels and says the
+  // one thing the movement is for — which side you came from.
+  const SLIDE_IN = 2;
+  // Slower than the 300ms a one-panel step takes, because this one is a place
+  // change rather than a nudge and wants to be seen.
+  const SLIDE_MS = 520;
 
   const chooseReach = useCallback((next: BarReach) => {
     rememberBarReach(next);
@@ -656,25 +634,50 @@ function DetailsFilmstripModal({
       // carrying the other clip's position would land you on the right card
       // showing the wrong one's time.
       carryClockRef.current = at !== null && at.clipId === clipId ? at : null;
-      // Only a jump that will actually be animated needs the panels in
-      // between: one step already has them, and a cut never shows them.
-      if (distance > 1 && distance <= STEPPED_MAX) setEasingFrom(centre);
+      // WHICH SIDE IT COMES IN FROM. A clip later in the cut lies to the
+      // right, so it arrives from the right — the row is put down displaced
+      // the other way and slides back. Capped at the real distance so a
+      // one-clip landing slides one panel rather than overshooting to make up
+      // the full approach.
+      const direction = to < 0 ? 0 : Math.sign(to - centre);
+      const slide = Math.min(SLIDE_IN, distance);
+      setTravel({ approach: direction === 0 ? 0 : -direction * slide });
       onOpenNeighbour(clipId);
     },
-    [STEPPED_MAX, centre, ids, node.id, onOpenNeighbour],
+    [SLIDE_IN, centre, ids, node.id, onOpenNeighbour],
   );
 
-  // LET GO AGAIN once the row has arrived. Slightly longer than the 300ms
-  // ease, so the last frame is still covered; cleared on a timer rather than
-  // on `transitionend`, which does not fire when a second landing interrupts
-  // the first and would strand the window open.
-  useEffect(() => {
-    if (easingFrom === null) return;
-    const timer = setTimeout(() => setEasingFrom(null), 360);
-    return () => clearTimeout(timer);
-  }, [easingFrom]);
+  // PUT DOWN, THEN RELEASED — the two halves of the arrival, and they must be
+  // two separate frames or there is no transition to run. The layout effect
+  // paints the displaced position with the transition off, and only once the
+  // browser has actually shown it does the next frame ask for the real one.
+  useLayoutEffect(() => {
+    if (travel === null || travel.approach === 0) return;
+    const strip = stripRef.current;
+    if (strip !== null) {
+      strip.style.transition = "none";
+      // The reflow is load-bearing: without it the two style writes coalesce
+      // and the row simply appears in its final place.
+      void strip.offsetWidth;
+    }
+    const frame = requestAnimationFrame(() => {
+      if (strip !== null) strip.style.transition = "";
+      setTravel({ approach: 0 });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [travel]);
 
-  const offset = centre < 0 ? 0 : centre - (ids.length - 1) / 2;
+  // AND LET THE EXTRA PANELS GO once it has arrived. On a timer rather than
+  // on `transitionend`, which does not fire when a second landing interrupts
+  // the first and would strand the widened mount window open.
+  useEffect(() => {
+    if (travel === null || travel.approach !== 0) return;
+    const timer = setTimeout(() => setTravel(null), SLIDE_MS + 60);
+    return () => clearTimeout(timer);
+  }, [SLIDE_MS, travel]);
+
+  const offset =
+    centre < 0 ? 0 : centre - (ids.length - 1) / 2 + (travel?.approach ?? 0);
 
   // SWIPING THE STRIP. The same instruction as clicking a neighbour, held:
   // drag the film and it follows the hand, let go past a threshold and it
@@ -977,26 +980,26 @@ function DetailsFilmstripModal({
           // landing on the next clip is animated and letting go short of the
           // threshold springs back.
           //
-          // A LANDING FURTHER OFF THAN `STEPPED_MAX` is cut rather than
-          // eased, but not from here — see the layout effect above, which
-          // suppresses this for the single frame the jump paints in.
+          // A LANDING RUNS LONGER THAN A STEP — see `SLIDE_MS` — and the
+          // frame it is put down on has no transition at all, which the
+          // layout effect above does to the node rather than from here.
           dragPx === 0
-            ? "transition-transform duration-300 ease-out motion-reduce:transition-none"
+            ? "transition-transform ease-out motion-reduce:transition-none"
             : "",
         ].join(" ")}
         style={{
           gap: PANEL_GAP,
           transform: rowTransform,
+          transitionDuration: travel === null ? "300ms" : `${SLIDE_MS}ms`,
         }}
       >
         {ids.map((id, index) => {
-          // Within the resting window, OR anywhere along a span the row is
-          // currently easing across — see `easingFrom`.
+          // The resting window, widened by the approach while a landing is in
+          // flight: the panels the row slides over are off the side of the
+          // resting window, and empty boxes sliding in is exactly what the
+          // movement is meant to avoid. Two extra panels, for half a second.
           const mounted =
-            Math.abs(index - centre) <= MOUNTED_RADIUS ||
-            (easingFrom !== null &&
-              index >= Math.min(easingFrom, centre) &&
-              index <= Math.max(easingFrom, centre));
+            Math.abs(index - centre) <= MOUNTED_RADIUS + (travel === null ? 0 : SLIDE_IN);
           const panel = mounted ? graph.nodesById.get(parseNodeId(id)) : null;
           const media =
             panel && panel.kind === "media" && (panel as MediaNode).src

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -1,11 +1,20 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 
 import { BAR_NEUTRAL_COLOUR } from "@/lib/bar-collection-colours-flag";
 
 import { collectionSeams, type SeamBarClip } from "./graph-seam-bar-layout";
 import type { SeamStrip } from "./graph-seam-strip";
+
+/**
+ * How long the strip takes to slide when the centred clip changes.
+ *
+ * Long enough to be read as one thing moving rather than as two different
+ * pictures — the whole reason to animate this is that the bar re-centres on
+ * somewhere else and a jump cannot be told apart from a redraw.
+ */
+const SEAM_SLIDE_MS = 520;
 
 /**
  * The playhead's head, and its twitch when the scrub lands on a cut.
@@ -110,6 +119,55 @@ export function SeamLane({
   chip: string | null;
   handlers: React.ComponentProps<"div">;
 }>) {
+  // THE BOXES SLIDE INTO POSITION ON A MOVE, and jump for everything else.
+  //
+  // The strip's transform is driven by three different things and only one of
+  // them wants easing. A drag has to track the hand exactly — the whole point
+  // of the edge run is that the strip moves WITH the pointer — and a wheel
+  // zoom or a pan is the same: they are the hand, and easing them reads as
+  // lag. Changing which clip is centred is different. Nothing is under the
+  // reader's finger, the strip re-centres on somewhere else entirely, and a
+  // jump there is the one case where the eye cannot tell whether the bar
+  // moved or was replaced.
+  //
+  // APPLIED TO THE NODE FOR A FIXED WINDOW rather than held as state: the
+  // easing belongs to one arrival, and a `sliding` flag would have to be
+  // cleared a render later — a cascading render to describe half a second of
+  // styling. The pointer handler clears it early so a drag begun mid-slide is
+  // still exact from its first frame.
+  const stripRef = useRef<HTMLDivElement | null>(null);
+  const centreWasRef = useRef(centreClipId);
+  const offsetWasRef = useRef(offset);
+  useLayoutEffect(() => {
+    const node = stripRef.current;
+    const moved = centreWasRef.current !== centreClipId;
+    const previous = offsetWasRef.current;
+    centreWasRef.current = centreClipId;
+    offsetWasRef.current = offset;
+    if (!moved || node === null || previous === offset) return;
+
+    // PUT IT BACK, THEN LET IT GO. A transition cannot be added to a value
+    // that has ALREADY changed: by the time a layout effect runs, React has
+    // written the new transform, and switching easing on afterwards animates
+    // nothing — the browser has one value and no previous one to interpolate
+    // from. So the old position is restored with easing off, the reflow makes
+    // that the state being transitioned FROM, and only then is the new one
+    // asked for.
+    node.style.transition = "none";
+    node.style.transform = `translateX(${previous}px)`;
+    void node.offsetWidth;
+    node.style.transition = `transform ${SEAM_SLIDE_MS}ms ease-out`;
+    node.style.transform = `translateX(${offset}px)`;
+
+    // Only the easing is cleared at the end. The transform is left exactly
+    // where it was put — it is the same value React renders, so the two agree
+    // and there is no frame where the strip is briefly somewhere else.
+    const done = setTimeout(() => {
+      node.style.transition = "";
+    }, SEAM_SLIDE_MS + 60);
+    return () => clearTimeout(done);
+  }, [centreClipId, offset]);
+
   const seams = collectionSeams(clips);
   const viewportX = (stripX: number) => stripX + offset;
 
@@ -118,6 +176,14 @@ export function SeamLane({
       ref={laneRef}
       data-seam-boxes
       {...handlers}
+      // A DRAG BEGUN MID-SLIDE IS EXACT FROM ITS FIRST FRAME. In CAPTURE, so
+      // it runs before the bar's own pointer handler and cannot be replaced by
+      // the spread above — leaving the easing on would put the strip a fixed
+      // distance behind the hand for the rest of the slide's duration, which
+      // is the lag the drag path is careful to avoid everywhere else.
+      onPointerDownCapture={() => {
+        if (stripRef.current !== null) stripRef.current.style.transition = "";
+      }}
       // `touch-none`, because every gesture here is claimed: a drag scrubs and
       // a two-finger swipe pans. Left to the browser, the first would also
       // scroll the dialog behind the bar.
@@ -131,6 +197,7 @@ export function SeamLane({
     >
       <div className="absolute inset-0 overflow-hidden">
         <div
+          ref={stripRef}
           data-seam-strip
           className="absolute inset-y-0 left-0 will-change-transform"
           style={{ transform: `translateX(${offset}px)`, width: strip.totalPx }}


### PR DESCRIPTION
Follow-up to #506, which merged before these two commits were pushed (same race as #504 → #505 — worth noting the auto-merge keeps beating my follow-up pushes).

### The bar's grey boxes slide into position

The thing you actually meant. The strip's transform is driven by three different things and only one wants easing: a drag must track the hand exactly (the edge run's whole point is that the strip moves *with* the pointer), a wheel zoom or pan is the same hand by another route — but changing which clip is centred is neither. Nothing is under your finger, the strip re-centres somewhere else entirely, and a jump there can't be told apart from the bar being redrawn with different contents.

**The first attempt animated nothing**, and it took a story to see why: by the time a layout effect runs, React has already written the new transform, and a transition added to a value that has *already changed* has no previous value to interpolate from. So it now restores the old offset with easing off, forces a reflow to make that the state being transitioned *from*, and only then asks for the new one. A pointer-down in capture clears the easing early, so a drag begun mid-slide is exact from its first frame.

### And the row arrives from the side

Sliding the row the whole distance is the obvious fix and it's wrong twice: ten panels of travel is ten panels that must be **real** for the animation's duration — a full panel being a video element, a trim strip and a tag editor, which is the cost `MOUNTED_RADIUS` exists to avoid, paid all at once so it can be blurred past — and what it buys is a whip, the cards between going by too fast to read.

So the row is put down two panels off with no transition and slides the rest of the way in: the clip you chose coming to the middle from the side it lies on, reading the same whether you landed two clips along or twenty. This replaces the cut-beyond-five rule from #505, which existed because a long ease looked wrong — it did, but for two reasons now fixed (the empty placeholders, and the scrim scrolling under it).

### Proof

Both stories assert the *bound*, not the mechanism:

- `TheBarSlidesIntoPositionOnAMove` — two readings after a move differ. With the FLIP disabled it reads the identical value twice, which is the jump.
- `LettingGoOfTheBarLandsTheStrip` — eight clips along, the row is never displaced more than two panel widths. With the approach removed it reads **4608px**, exactly the eight panels.

Green: 34/34 modal stories · 802/802 unit · 1427/1427 app · `tsc` clean · lint 0 errors. Two `dnd-collections` stories failed in the full storybook run and pass in isolation — the known under-load flakes, in a package this branch doesn't touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)