### PR TITLE
Playbar frames, a five on the reach, and landings that fade instead of scrolling

### DIFF
--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -164,6 +164,29 @@ html body[data-scroll-locked] {
 /* Sidebar trash drawer button: "something just arrived" — a pop with a
    wiggle and a brief brighten (no color shift — the sidebar stays on its
    gray scheme), played once per arrival (see timeline-sidebar). */
+/* Details view, letting go of the play bar: the row does NOT scroll to the
+   landed clip, because the middle card is already showing it — it has been the
+   monitor for the whole scrub. Moving it would animate a change that already
+   happened. So the row cuts to its new offset and the panels either side fade
+   in with their new contents: what changes is what changes, and the picture
+   being judged never moves.
+
+   Stepping is the other case and keeps its slide (see the row's own
+   `transition-transform`): there the middle card really is becoming a
+   different clip, and the travel is what says which way you went. */
+@keyframes seam-panel-swap {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.animate-seam-panel-swap {
+  animation: seam-panel-swap 300ms ease-out;
+}
+
 @keyframes trash-arrival {
   0% {
     transform: scale(1);

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -128,6 +128,7 @@ import { GraphRenderStatus } from "./graph-render-status";
 import { GraphProjectMenu } from "./graph-project-menu";
 import { GraphShortcuts, requestGraphShortcuts } from "./graph-shortcuts";
 import { GraphItemDetailsModal } from "./graph-item-details-modal";
+import { PlaybarThumbnailsProvider } from "./graph-playbar-thumbnails";
 import { SubTimelines } from "./graph-sub-timelines";
 import {
   GRID_GAP,
@@ -159,6 +160,8 @@ function BoardMenu({
   onItemSizeChange,
   clipNamesShown,
   onClipNamesChange,
+  playbarThumbnails,
+  onPlaybarThumbnailsChange,
   projectId,
 }: Readonly<{
   itemSize: ItemSize;
@@ -167,6 +170,10 @@ function BoardMenu({
    *  see `graph-clip-names.tsx`. */
   clipNamesShown: boolean;
   onClipNamesChange: (shown: boolean) => void;
+  /** Whether the details view's play bar draws each clip's first frame rather
+   *  than a grey box. Off by default — see `graph-playbar-thumbnails.tsx`. */
+  playbarThumbnails: boolean;
+  onPlaybarThumbnailsChange: (shown: boolean) => void;
   /** Whose render format this menu edits. The section reads and writes the
    *  document itself, so the menu only has to say WHICH one. */
   projectId: string;
@@ -233,6 +240,18 @@ function BoardMenu({
             onSelect={(event) => event.preventDefault()}
           >
             Show name over item
+          </DropdownMenuCheckboxItem>
+          {/* THE PLAY BAR, not the board — which is why it names its surface
+              where the item above does not. It sits with the other "what does
+              this draw" answers rather than in the details view itself: that
+              view is a place you go to work, and a setting you reach for once
+              does not belong among the controls you use while you are there. */}
+          <DropdownMenuCheckboxItem
+            checked={playbarThumbnails}
+            onCheckedChange={(next) => onPlaybarThumbnailsChange(next === true)}
+            onSelect={(event) => event.preventDefault()}
+          >
+            Show playbar thumbnails
           </DropdownMenuCheckboxItem>
         </DropdownMenuGroup>
         {/* RENDER FORMAT, moved in from the header row.
@@ -1925,6 +1944,8 @@ export function GraphBoard({
   onItemSizeChange,
   clipNamesShown,
   onClipNamesChange,
+  playbarThumbnails,
+  onPlaybarThumbnailsChange,
   pixelsPerSecond,
   onPixelsPerSecondChange,
   previewOn,
@@ -1956,6 +1977,11 @@ export function GraphBoard({
    *  threaded down; see `graph-clip-names.tsx`. */
   clipNamesShown: boolean;
   onClipNamesChange: (shown: boolean) => void;
+  /** Whether the play bar in the details view draws each clip's first frame
+   *  rather than a grey box. Published as a context; see
+   *  `graph-playbar-thumbnails.tsx`. */
+  playbarThumbnails: boolean;
+  onPlaybarThumbnailsChange: (shown: boolean) => void;
   pixelsPerSecond: number;
   onPixelsPerSecondChange: (pixelsPerSecond: number) => void;
   /** The preview pane above the board. The board renders it AND carries its
@@ -2137,6 +2163,7 @@ export function GraphBoard({
       {/* Spans the header AND the surfaces for the same reason: the toggle
           that sets it lives in the header's menu, and every card that reads it
           is below. */}
+      <PlaybarThumbnailsProvider shown={playbarThumbnails}>
       <ClipNamesProvider shown={clipNamesShown}>
       {/* Spans the surfaces AND the child rows below them, because the pairing
           it carries joins the two: a collection's card up here and its row
@@ -2610,6 +2637,8 @@ export function GraphBoard({
                   onItemSizeChange={onItemSizeChange}
                   clipNamesShown={clipNamesShown}
                   onClipNamesChange={onClipNamesChange}
+                  playbarThumbnails={playbarThumbnails}
+                  onPlaybarThumbnailsChange={onPlaybarThumbnailsChange}
                   projectId={projectId}
                 />
               </div>
@@ -2927,6 +2956,7 @@ export function GraphBoard({
       </TagFilterProvider>
       </CollectionHoverProvider>
       </ClipNamesProvider>
+      </PlaybarThumbnailsProvider>
       </ItemDetailsProvider>
     </OpenKeyBoundary>
   );

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -128,7 +128,12 @@ import { GraphRenderStatus } from "./graph-render-status";
 import { GraphProjectMenu } from "./graph-project-menu";
 import { GraphShortcuts, requestGraphShortcuts } from "./graph-shortcuts";
 import { GraphItemDetailsModal } from "./graph-item-details-modal";
-import { PlaybarThumbnailsProvider } from "./graph-playbar-thumbnails";
+import {
+  PLAYBAR_THUMBNAIL_STYLES,
+  PlaybarThumbnailsProvider,
+  isPlaybarThumbnailStyle,
+  type PlaybarThumbnailStyle,
+} from "./graph-playbar-thumbnails";
 import { SubTimelines } from "./graph-sub-timelines";
 import {
   GRID_GAP,
@@ -162,6 +167,8 @@ function BoardMenu({
   onClipNamesChange,
   playbarThumbnails,
   onPlaybarThumbnailsChange,
+  playbarThumbnailStyle,
+  onPlaybarThumbnailStyleChange,
   projectId,
 }: Readonly<{
   itemSize: ItemSize;
@@ -174,6 +181,10 @@ function BoardMenu({
    *  than a grey box. Off by default — see `graph-playbar-thumbnails.tsx`. */
   playbarThumbnails: boolean;
   onPlaybarThumbnailsChange: (shown: boolean) => void;
+  /** One frame filling each box, or a row of frames sampled across the clip.
+   *  Kept whether or not frames are shown — see `graph-playbar-thumbnails.tsx`. */
+  playbarThumbnailStyle: PlaybarThumbnailStyle;
+  onPlaybarThumbnailStyleChange: (style: PlaybarThumbnailStyle) => void;
   /** Whose render format this menu edits. The section reads and writes the
    *  document itself, so the menu only has to say WHICH one. */
   projectId: string;
@@ -253,6 +264,31 @@ function BoardMenu({
           >
             Show playbar thumbnails
           </DropdownMenuCheckboxItem>
+          {/* AND WHICH KIND — only once there are frames to have a kind. Two
+              settings rather than three states in one control, because "show
+              frames" and "which frames" are separate questions: the style
+              survives being switched off and on, which is what makes toggling
+              frames a comparison you can make twice rather than a choice you
+              re-enter every time.
+
+              Hidden rather than disabled when off. A disabled radio pair is a
+              row of dead controls explaining a setting that is not in effect;
+              absent, the menu simply gets shorter. */}
+          {playbarThumbnails ? (
+            <DropdownMenuRadioGroup
+              className="flex flex-wrap gap-1 pl-8 pt-1.5"
+              value={playbarThumbnailStyle}
+              onValueChange={(value) => {
+                if (isPlaybarThumbnailStyle(value)) onPlaybarThumbnailStyleChange(value);
+              }}
+            >
+              {PLAYBAR_THUMBNAIL_STYLES.map((option) => (
+                <DropdownMenuRadioBadge key={option} value={option}>
+                  {option === "cover" ? "COVER" : "STRIP"}
+                </DropdownMenuRadioBadge>
+              ))}
+            </DropdownMenuRadioGroup>
+          ) : null}
         </DropdownMenuGroup>
         {/* RENDER FORMAT, moved in from the header row.
             It read "16:9 · 720p" beside the breadcrumbs — a standing fact
@@ -1946,6 +1982,8 @@ export function GraphBoard({
   onClipNamesChange,
   playbarThumbnails,
   onPlaybarThumbnailsChange,
+  playbarThumbnailStyle,
+  onPlaybarThumbnailStyleChange,
   pixelsPerSecond,
   onPixelsPerSecondChange,
   previewOn,
@@ -1982,6 +2020,8 @@ export function GraphBoard({
    *  `graph-playbar-thumbnails.tsx`. */
   playbarThumbnails: boolean;
   onPlaybarThumbnailsChange: (shown: boolean) => void;
+  playbarThumbnailStyle: PlaybarThumbnailStyle;
+  onPlaybarThumbnailStyleChange: (style: PlaybarThumbnailStyle) => void;
   pixelsPerSecond: number;
   onPixelsPerSecondChange: (pixelsPerSecond: number) => void;
   /** The preview pane above the board. The board renders it AND carries its
@@ -2163,7 +2203,7 @@ export function GraphBoard({
       {/* Spans the header AND the surfaces for the same reason: the toggle
           that sets it lives in the header's menu, and every card that reads it
           is below. */}
-      <PlaybarThumbnailsProvider shown={playbarThumbnails}>
+      <PlaybarThumbnailsProvider shown={playbarThumbnails} style={playbarThumbnailStyle}>
       <ClipNamesProvider shown={clipNamesShown}>
       {/* Spans the surfaces AND the child rows below them, because the pairing
           it carries joins the two: a collection's card up here and its row
@@ -2639,6 +2679,8 @@ export function GraphBoard({
                   onClipNamesChange={onClipNamesChange}
                   playbarThumbnails={playbarThumbnails}
                   onPlaybarThumbnailsChange={onPlaybarThumbnailsChange}
+                  playbarThumbnailStyle={playbarThumbnailStyle}
+                  onPlaybarThumbnailStyleChange={onPlaybarThumbnailStyleChange}
                   projectId={projectId}
                 />
               </div>

--- a/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-board.tsx
@@ -128,12 +128,6 @@ import { GraphRenderStatus } from "./graph-render-status";
 import { GraphProjectMenu } from "./graph-project-menu";
 import { GraphShortcuts, requestGraphShortcuts } from "./graph-shortcuts";
 import { GraphItemDetailsModal } from "./graph-item-details-modal";
-import {
-  PLAYBAR_THUMBNAIL_STYLES,
-  PlaybarThumbnailsProvider,
-  isPlaybarThumbnailStyle,
-  type PlaybarThumbnailStyle,
-} from "./graph-playbar-thumbnails";
 import { SubTimelines } from "./graph-sub-timelines";
 import {
   GRID_GAP,
@@ -165,10 +159,6 @@ function BoardMenu({
   onItemSizeChange,
   clipNamesShown,
   onClipNamesChange,
-  playbarThumbnails,
-  onPlaybarThumbnailsChange,
-  playbarThumbnailStyle,
-  onPlaybarThumbnailStyleChange,
   projectId,
 }: Readonly<{
   itemSize: ItemSize;
@@ -179,12 +169,6 @@ function BoardMenu({
   onClipNamesChange: (shown: boolean) => void;
   /** Whether the details view's play bar draws each clip's first frame rather
    *  than a grey box. Off by default — see `graph-playbar-thumbnails.tsx`. */
-  playbarThumbnails: boolean;
-  onPlaybarThumbnailsChange: (shown: boolean) => void;
-  /** One frame filling each box, or a row of frames sampled across the clip.
-   *  Kept whether or not frames are shown — see `graph-playbar-thumbnails.tsx`. */
-  playbarThumbnailStyle: PlaybarThumbnailStyle;
-  onPlaybarThumbnailStyleChange: (style: PlaybarThumbnailStyle) => void;
   /** Whose render format this menu edits. The section reads and writes the
    *  document itself, so the menu only has to say WHICH one. */
   projectId: string;
@@ -252,43 +236,6 @@ function BoardMenu({
           >
             Show name over item
           </DropdownMenuCheckboxItem>
-          {/* THE PLAY BAR, not the board — which is why it names its surface
-              where the item above does not. It sits with the other "what does
-              this draw" answers rather than in the details view itself: that
-              view is a place you go to work, and a setting you reach for once
-              does not belong among the controls you use while you are there. */}
-          <DropdownMenuCheckboxItem
-            checked={playbarThumbnails}
-            onCheckedChange={(next) => onPlaybarThumbnailsChange(next === true)}
-            onSelect={(event) => event.preventDefault()}
-          >
-            Show playbar thumbnails
-          </DropdownMenuCheckboxItem>
-          {/* AND WHICH KIND — only once there are frames to have a kind. Two
-              settings rather than three states in one control, because "show
-              frames" and "which frames" are separate questions: the style
-              survives being switched off and on, which is what makes toggling
-              frames a comparison you can make twice rather than a choice you
-              re-enter every time.
-
-              Hidden rather than disabled when off. A disabled radio pair is a
-              row of dead controls explaining a setting that is not in effect;
-              absent, the menu simply gets shorter. */}
-          {playbarThumbnails ? (
-            <DropdownMenuRadioGroup
-              className="flex flex-wrap gap-1 pl-8 pt-1.5"
-              value={playbarThumbnailStyle}
-              onValueChange={(value) => {
-                if (isPlaybarThumbnailStyle(value)) onPlaybarThumbnailStyleChange(value);
-              }}
-            >
-              {PLAYBAR_THUMBNAIL_STYLES.map((option) => (
-                <DropdownMenuRadioBadge key={option} value={option}>
-                  {option === "cover" ? "COVER" : "STRIP"}
-                </DropdownMenuRadioBadge>
-              ))}
-            </DropdownMenuRadioGroup>
-          ) : null}
         </DropdownMenuGroup>
         {/* RENDER FORMAT, moved in from the header row.
             It read "16:9 · 720p" beside the breadcrumbs — a standing fact
@@ -1980,10 +1927,6 @@ export function GraphBoard({
   onItemSizeChange,
   clipNamesShown,
   onClipNamesChange,
-  playbarThumbnails,
-  onPlaybarThumbnailsChange,
-  playbarThumbnailStyle,
-  onPlaybarThumbnailStyleChange,
   pixelsPerSecond,
   onPixelsPerSecondChange,
   previewOn,
@@ -2018,10 +1961,6 @@ export function GraphBoard({
   /** Whether the play bar in the details view draws each clip's first frame
    *  rather than a grey box. Published as a context; see
    *  `graph-playbar-thumbnails.tsx`. */
-  playbarThumbnails: boolean;
-  onPlaybarThumbnailsChange: (shown: boolean) => void;
-  playbarThumbnailStyle: PlaybarThumbnailStyle;
-  onPlaybarThumbnailStyleChange: (style: PlaybarThumbnailStyle) => void;
   pixelsPerSecond: number;
   onPixelsPerSecondChange: (pixelsPerSecond: number) => void;
   /** The preview pane above the board. The board renders it AND carries its
@@ -2203,7 +2142,6 @@ export function GraphBoard({
       {/* Spans the header AND the surfaces for the same reason: the toggle
           that sets it lives in the header's menu, and every card that reads it
           is below. */}
-      <PlaybarThumbnailsProvider shown={playbarThumbnails} style={playbarThumbnailStyle}>
       <ClipNamesProvider shown={clipNamesShown}>
       {/* Spans the surfaces AND the child rows below them, because the pairing
           it carries joins the two: a collection's card up here and its row
@@ -2677,10 +2615,6 @@ export function GraphBoard({
                   onItemSizeChange={onItemSizeChange}
                   clipNamesShown={clipNamesShown}
                   onClipNamesChange={onClipNamesChange}
-                  playbarThumbnails={playbarThumbnails}
-                  onPlaybarThumbnailsChange={onPlaybarThumbnailsChange}
-                  playbarThumbnailStyle={playbarThumbnailStyle}
-                  onPlaybarThumbnailStyleChange={onPlaybarThumbnailStyleChange}
                   projectId={projectId}
                 />
               </div>
@@ -2998,7 +2932,6 @@ export function GraphBoard({
       </TagFilterProvider>
       </CollectionHoverProvider>
       </ClipNamesProvider>
-      </PlaybarThumbnailsProvider>
       </ItemDetailsProvider>
     </OpenKeyBoundary>
   );

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-bar-reach.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-bar-reach.test.ts
@@ -68,6 +68,14 @@ describe("barReachWindow", () => {
     expect(window.centre).toBe(5);
   });
 
+  it("takes five either side", () => {
+    const window = barReachWindow(ids, 30, 5);
+    expect(window.ids).toHaveLength(11);
+    expect(window.ids[0]).toBe("clip-25");
+    expect(window.ids[10]).toBe("clip-35");
+    expect(window.ids[window.centre]).toBe("clip-30");
+  });
+
   it("survives a subject it cannot find", () => {
     const window = barReachWindow(ids, -1, 10);
     expect(window.ids).toBe(ids);

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-bar-reach.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-bar-reach.ts
@@ -6,11 +6,13 @@
 //
 // A number is a COUNT OF CLIPS EITHER SIDE, so 10 puts 21 clips on the bar
 // when the subject has that many neighbours — ten behind, the subject, ten
-// ahead. `"all"` is the whole collection, which is what the bar did before
+// ahead. Five is the tightest, and roughly the run the strip below can show
+// at once: at that reach the bar stops being a map and becomes a close look
+// at the cut you are working on. `"all"` is the whole collection, which is what the bar did before
 // there was a choice and is still the right answer when the question is
 // "where does this sit in the sequence".
 
-export const BAR_REACHES = [10, 20, "all"] as const;
+export const BAR_REACHES = [5, 10, 20, "all"] as const;
 export type BarReach = (typeof BAR_REACHES)[number];
 
 /**

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -2282,52 +2282,52 @@ export const TheBarReachIsASetting: Story = {
 };
 
 /**
- * LETTING GO IS THE COMMIT — AND YOU KEEP THE FRAME YOU LET GO ON.
+ * LETTING GO IS THE COMMIT — AND THE ROW DOES NOT SCROLL TO IT.
  *
  * A drag and a press that does not travel are still told apart (distance, not
- * timing: a slow deliberate scrub must not count as a tap on wherever it
- * started). But they now LAND the same way, because they are the same
- * sentence: you put the playhead somewhere and took your hand off it.
+ * timing), but they LAND the same way, because they are the same sentence: you
+ * put the playhead somewhere and took your hand off it.
  *
- * Scrubbing used to choose nothing, on the reasoning that looking ahead must
- * not cost you your place. The place is what changed: the row follows the
- * playhead now, and the clock comes WITH it rather than snapping to the new
- * clip's head — so you arrive on the exact frame you were judging, which is
- * the frame you went there to see. Losing it was what made the old rule feel
- * like a look rather than a move.
+ * THE MIDDLE CARD DOES NOT MOVE, and that is the point. It has been the
+ * monitor for the whole scrub, so it is already showing the clip being landed
+ * on — sliding the row to that clip would animate a change that has already
+ * happened, and move the one thing on screen that did not need to. So the row
+ * cuts, the middle card stays exactly where it is with exactly the picture it
+ * had, and the panels either side fade in with their new contents.
  *
- * THE CLOCK NOT MOVING IS THE ASSERTION. Every panel derives its picture from
- * `position`, which is `seamAt(timeline, barSeconds)` — so a bar reading the
- * same second before and after the row advances IS the centre panel holding
- * the frame. A jump here would be the reset this change removes.
+ * STEPPING IS THE OTHER CASE and keeps its slide: landing on the clip directly
+ * beside this one is the same single move the arrows and the swipe make, and
+ * there the middle card really is becoming something else.
+ *
+ * THE FRAME COMES WITH IT, read off the panel rather than the bar. The bar is
+ * a window with a reach either side of the subject, so it is rebuilt around
+ * wherever you land and its own seconds are not comparable across the journey.
+ * The panel reports the clip's OWN time, which is.
  */
 export const LettingGoOfTheBarLandsTheStrip: Story = {
   render: () => <SeamHarness scene={TWO_ROOMS_SCENE} />,
   play: async () => {
     await waitFor(() => expect(document.querySelector("[data-seam-strip]")).not.toBeNull());
     await settleStrip();
+    await settleRow();
     const subject = () => centreBox().getAttribute("data-seam-segment");
     const at = () => Number(seamTrack().getAttribute("aria-valuenow"));
     const strip = () => document.querySelector<HTMLElement>("[data-details-strip]")!;
-    const stripX = () => strip().getBoundingClientRect().left;
-    const panels = () => document.querySelectorAll("[data-item-details-panel]").length;
     const boxIndex = () => seamBoxes().indexOf(centreBox());
+    const centrePanel = () =>
+      document.querySelector<HTMLElement>('[data-item-details-panel="centre"]')!;
+    const seatX = () => centrePanel().getBoundingClientRect().left;
     const shownFrame = () =>
-      Number(
-        document
-          .querySelector<HTMLElement>('[data-item-details-panel="centre"]')!
-          .getAttribute("data-item-details-at"),
-      );
+      Number(centrePanel().getAttribute("data-item-details-at"));
+    const swapping = () =>
+      document.querySelectorAll("[data-item-details-swapping]").length;
 
-    // Hold the scrub, read the clock at the moment before the release, let go.
+    // Hold the scrub, read the frame at the moment before the release, let go.
     const dragToBox = async (box: HTMLElement) => {
       const rect = box.getBoundingClientRect();
       const x = rect.left + rect.width * 0.5;
       scrubToClientX(x, { hold: true });
       await waitFor(() => expect(at()).toBeGreaterThan(0));
-      // The frame the MONITOR is on at the moment of release — the thing the
-      // landing has to preserve, and the only reading that survives the bar
-      // being rebuilt around a new subject.
       const heldFrame = Number(
         document
           .querySelector<HTMLElement>("[data-item-details-at]")!
@@ -2340,84 +2340,47 @@ export const LettingGoOfTheBarLandsTheStrip: Story = {
     };
 
     expect(subject()).toBe("subject");
-    const restingPanels = panels();
+    const restingSeat = seatX();
 
-    // ── A SHORT LANDING TRAVELS, AND NOTHING EMPTY GOES PAST ──────────────
-    const from = boxIndex();
-    const near = seamBoxes()[from + 3]!;
-    const letGoNear = await dragToBox(near);
+    // ── A LANDING SEVERAL CLIPS OFF CUTS, AND THE MIDDLE STAYS PUT ────────
+    const target = seamBoxes()[boxIndex() + 4]!;
+    const letGo = await dragToBox(target);
     await waitFor(() => expect(subject()).not.toBe("subject"));
 
-    // Still moving a beat later: three panels is a step you can follow, so it
-    // is shown as one.
-    const travellingFrom = stripX();
-    // MORE PANELS ARE REAL THAN USUALLY ARE. The resting mount window is two
-    // either side; the cards being crossed live outside it, and without the
-    // widening they would be the empty placeholders the row is made of —
-    // including the one you just left, which would blink out and slide away.
-    expect(panels()).toBeGreaterThan(restingPanels);
-    await new Promise((resolve) => setTimeout(resolve, 120));
-    expect(stripX()).not.toBe(travellingFrom);
+    // ALREADY THERE. This is the assertion a slide fails: mid-travel the
+    // middle card is panels away from its seat and only arrives later.
+    expect(seatX()).toBeCloseTo(restingSeat, 0);
+    // And it stays — nothing is easing towards anything.
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(seatX()).toBeCloseTo(restingSeat, 0);
 
-    await settleStrip();
-    await settleRow();
-    expect(subject()).toBe(near.getAttribute("data-seam-segment"));
-    // THE FRAME CAME WITH IT. Read off the panel rather than off the bar:
-    // the bar is a window with a reach either side of the subject, so it is
-    // rebuilt around wherever you land and its own seconds are not comparable
-    // across the journey. The panel reports the clip's OWN time, which is.
-    expect(shownFrame()).toBeCloseTo(letGoNear, 2);
-    // And the window let go again once it had arrived.
-    await waitFor(() => expect(panels()).toBe(restingPanels));
+    // THE PANELS EITHER SIDE ARE WHAT MOVED, so they are what fades.
+    expect(swapping()).toBeGreaterThan(0);
+    expect(
+      centrePanel().hasAttribute("data-item-details-swapping"),
+    ).toBe(false);
 
-    // ── A LONG ONE ARRIVES THE SAME WAY, FROM THE SIDE ────────────────────
-    // THE SEAT IS READ HERE, not at the top of the story. The row is a
-    // different shape on its first paint — panels are still arriving — so its
-    // resting x then is not the resting x it keeps. Taken between the two
-    // landings, both readings describe the same row.
-    const seatX = () =>
-      document
-        .querySelector<HTMLElement>('[data-item-details-panel="centre"]')!
-        .getBoundingClientRect().left;
-    const restingCentreX = seatX();
+    expect(subject()).toBe(target.getAttribute("data-seam-segment"));
+    expect(shownFrame()).toBeCloseTo(letGo, 2);
+    // The fade lets go of itself.
+    await waitFor(() => expect(swapping()).toBe(0));
+
+    // ── AND A NEIGHBOUR IS STILL A STEP ───────────────────────────────────
     const landedOn = subject();
-    const far = seamBoxes()[boxIndex() + 8]!;
-    // THE PRECONDITION: far enough that sliding the whole way would be
-    // obvious, and inside the default reach so there is a box there to aim at.
-    expect(far).not.toBeUndefined();
-    const letGoFar = await dragToBox(far);
+    const next = seamBoxes()[boxIndex() + 1]!;
+    clickBox(next);
     await waitFor(() => expect(subject()).not.toBe(landedOn));
-
-    // IT COMES IN FROM THE SIDE, NOT FROM WHERE IT WAS. Eight clips along,
-    // but the row is never displaced by more than the approach — so the
-    // distance travelled says which side you came from and nothing else.
-    // Sliding the whole way would start this eight panel-widths out and spend
-    // half a second blurring six cards nobody can read.
-    const step = document
-      .querySelector<HTMLElement>('[data-item-details-panel="centre"]')!
-      .getBoundingClientRect().width + 16;
-    const displaced = Math.abs(seatX() - restingCentreX);
-    expect(displaced).toBeGreaterThan(1);
-    expect(displaced).toBeLessThan(step * 2 + 8);
-
-    // And it is MOVING, not placed.
-    const slidingFrom = seatX();
+    // No fade: one clip along is the move the arrows and the swipe make, and
+    // it travels.
+    expect(swapping()).toBe(0);
+    const travellingFrom = strip().getBoundingClientRect().left;
     await new Promise((resolve) => setTimeout(resolve, 120));
-    expect(seatX()).not.toBe(slidingFrom);
-
-    await settleStrip();
-    await settleRow();
-    expect(seatX()).toBeCloseTo(restingCentreX, 0);
-    expect(subject()).toBe(far.getAttribute("data-seam-segment"));
-    expect(shownFrame()).toBeCloseTo(letGoFar, 2);
+    expect(strip().getBoundingClientRect().left).not.toBe(travellingFrom);
 
     // THE SCRIM NEVER SCROLLS. It crops a row thousands of pixels wide, so if
-    // it were a scroll container there would be a great deal for the browser
-    // to scroll it by — and it would, because landing moves focus to the new
-    // panel's menu button and a hidden overflow is still scrolled to reveal
-    // what is focused. That scroll would land on top of the transform the row
-    // has already made and put the chosen card off the left edge. Zero here is
-    // `overflow-clip` doing its job.
+    // it were a scroll container the browser would scroll it to reveal the
+    // newly focused panel — on top of the transform the row has already made,
+    // putting the chosen card off the left edge. Zero is `overflow-clip`.
     expect(strip().parentElement!.scrollLeft).toBe(0);
   },
 };

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -15,7 +15,10 @@ import { createGraphDetailsStore } from "@/lib/graph-details-store";
 import { GraphDetailsProvider } from "./graph-details-context";
 import { ItemDetailsProvider, useItemDetails } from "./graph-item-details-context";
 import { GraphItemDetailsModal } from "./graph-item-details-modal";
-import { PlaybarThumbnailsProvider } from "./graph-playbar-thumbnails";
+import {
+  PlaybarThumbnailsProvider,
+  type PlaybarThumbnailStyle,
+} from "./graph-playbar-thumbnails";
 
 // The details modal's first stories. It had none, which is how it came to
 // describe a VOICEOVER as a "still" — the branch that renders the duration
@@ -252,9 +255,11 @@ function EndHarness() {
 function SeamHarness({
   scene = SEAM_SCENE,
   thumbnails = false,
+  thumbnailStyle = "cover",
 }: {
   scene?: GraphNodeSpec;
   thumbnails?: boolean;
+  thumbnailStyle?: PlaybarThumbnailStyle;
 }) {
   // Built FROM the scene, so a fixture can grow without the harness having to
   // be told about every clip in it by name.
@@ -269,7 +274,7 @@ function SeamHarness({
   );
   return (
     <div className="graph-view-theme min-h-[600px] bg-zinc-950">
-      <PlaybarThumbnailsProvider shown={thumbnails}>
+      <PlaybarThumbnailsProvider shown={thumbnails} style={thumbnailStyle}>
       <DndCollections initialGraph={graphOfRoot(scene)}>
         <GraphDetailsProvider store={store}>
           <ItemDetailsProvider>
@@ -2090,6 +2095,83 @@ export const ThePlaybarCanDrawFrames: Story = {
     // rather than a hole.
     expect(getComputedStyle(first.parentElement!).backgroundColor).not.toBe(
       "rgba(0, 0, 0, 0)",
+    );
+  },
+};
+
+/**
+ * FILMSTRIP: A ROW OF FRAMES ACROSS THE CLIP, not one frame standing for it.
+ *
+ * `cover` answers "which shot is that". A strip answers a second question the
+ * single frame cannot: what HAPPENS in it. A long take that opens on a closed
+ * door and ends on an empty room is one picture at `cover` and a story here.
+ *
+ * WHAT THIS COVERS IS THE LAYOUT, not the sampling. Which times the cells are
+ * taken at is `videoFrameUrls`, which has its own tests — and in a story the
+ * fixture posters are not Cloudinary video URLs, so every cell resolves to the
+ * same image and only the arrangement is observable. The two are worth keeping
+ * apart: the arithmetic is pure and the arrangement is geometry, and neither
+ * needs the other to be wrong to fail.
+ */
+export const ThePlaybarCanDrawAFilmstrip: Story = {
+  // TRIMMED_SCENE because its clips are VIDEO with posters and real trims —
+  // the only fixture here that a filmstrip can be built from at all. A still
+  // falls back to the single frame by design, which is the next story.
+  render: () => <SeamHarness scene={TRIMMED_SCENE} thumbnails thumbnailStyle="filmstrip" />,
+  play: async () => {
+    await waitFor(() => expect(document.querySelector("[data-seam-strip]")).not.toBeNull());
+    await settleStrip();
+
+    // The widest box, so there is room for more than one cell in it — a strip
+    // of one is a `cover` by another name and would prove nothing.
+    const strips = Array.from(
+      document.querySelectorAll<HTMLElement>("[data-seam-filmstrip]"),
+    );
+    expect(strips.length).toBeGreaterThan(0);
+    const widest = strips
+      .slice()
+      .sort((a, b) => b.getBoundingClientRect().width - a.getBoundingClientRect().width)[0]!;
+    const cells = Array.from(widest.querySelectorAll<HTMLImageElement>("img"));
+    expect(cells.length).toBeGreaterThan(1);
+
+    // THEY DIVIDE THE BOX EXACTLY. `flex-1` rather than a fixed cell width, so
+    // there is never a grey tail at the end of a strip where the arithmetic
+    // did not come out even.
+    const box = widest.getBoundingClientRect();
+    const first = cells[0]!.getBoundingClientRect();
+    const last = cells[cells.length - 1]!.getBoundingClientRect();
+    expect(first.left).toBeCloseTo(box.left, 0);
+    expect(last.right).toBeCloseTo(box.right, 0);
+
+    // Square-ish: about one cell per bar-height, which is what makes them read
+    // as frames in a strip rather than as stripes.
+    expect(Math.abs(first.width - first.height)).toBeLessThan(first.height);
+    expect(getComputedStyle(cells[0]!).objectFit).toBe("cover");
+
+    // THE STYLE IS A SEPARATE SETTING FROM WHETHER FRAMES SHOW AT ALL: this is
+    // the strip, so the single covering frame must not ALSO be in the box.
+    expect(widest.parentElement!.querySelectorAll("img").length).toBe(cells.length);
+  },
+};
+
+/**
+ * A STILL FALLS BACK TO THE SINGLE FRAME, whatever the style says.
+ *
+ * A still has one image. Sampling it at ten intervals gives ten copies of
+ * itself — a filmstrip whose content is "nothing happens here", which is worse
+ * than the one frame it is made of and takes ten requests to say. So the
+ * strip is offered only where there is something to sample, and the setting
+ * degrades rather than obeying.
+ */
+export const AStillIgnoresTheFilmstrip: Story = {
+  render: () => <SeamHarness scene={TWO_ROOMS_SCENE} thumbnails thumbnailStyle="filmstrip" />,
+  play: async () => {
+    await waitFor(() => expect(document.querySelector("[data-seam-strip]")).not.toBeNull());
+    await settleStrip();
+    expect(document.querySelectorAll("[data-seam-filmstrip]").length).toBe(0);
+    // Still a picture per box — falling back is not the same as giving up.
+    expect(document.querySelectorAll("[data-seam-thumbnail]").length).toBe(
+      seamBoxes().length,
     );
   },
 };

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -2140,6 +2140,14 @@ export const ThePlaybarCanDrawFrames: Story = {
     // OUTSIDE the box, which is what puts it in the gap rather than over the
     // picture — and what keeps it costing no layout.
     expect(boxStyle.boxShadow).not.toMatch(/inset/);
+    // AND THE THREE BANDS SHARE THE GAP THAT WAS ALREADY THERE. The ring is
+    // most of the way to half the inset either side, so the pale core is a
+    // band rather than the whole gap with a hairline on it — a white band with
+    // a hairline either side reads as a white band. It must not reach the
+    // inset itself, which would close the gap and leave two boxes touching.
+    const spread = Number(boxStyle.boxShadow.match(/([\d.]+)px(?!.*px)/)![1]);
+    expect(spread).toBeGreaterThan(1);
+    expect(spread).toBeLessThan(2.5);
 
     framesTo("OFF");
     await waitFor(() =>
@@ -2439,6 +2447,18 @@ export const LettingGoOfTheBarLandsTheStrip: Story = {
 
     // THE PANELS EITHER SIDE ARE WHAT MOVED, so they are what fades.
     expect(swapping()).toBeGreaterThan(0);
+
+    // AND NOTHING ELSE ANIMATES WHILE THEY DO. A landing leaves the clock
+    // engaged, so every neighbour is newly `dimmed` and would start its own
+    // 300ms opacity-and-GRAYSCALE transition in the same frame the fade
+    // begins. Two nested opacity animations is one too many, and a filter over
+    // a video still fetching its first frame is repainted from the decoder
+    // every tick — which is why this was smooth on stills and juddered on
+    // video. The incoming panel arrives already dimmed and already drained.
+    const fading = document.querySelector<HTMLElement>(
+      "[data-item-details-swapping] [data-item-details-frame]",
+    )!;
+    expect(getComputedStyle(fading).transitionProperty).toBe("none");
     expect(
       centrePanel().hasAttribute("data-item-details-swapping"),
     ).toBe(false);

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -15,6 +15,7 @@ import { createGraphDetailsStore } from "@/lib/graph-details-store";
 import { GraphDetailsProvider } from "./graph-details-context";
 import { ItemDetailsProvider, useItemDetails } from "./graph-item-details-context";
 import { GraphItemDetailsModal } from "./graph-item-details-modal";
+import { PlaybarThumbnailsProvider } from "./graph-playbar-thumbnails";
 
 // The details modal's first stories. It had none, which is how it came to
 // describe a VOICEOVER as a "still" — the branch that renders the duration
@@ -248,7 +249,13 @@ function EndHarness() {
   );
 }
 
-function SeamHarness({ scene = SEAM_SCENE }: { scene?: GraphNodeSpec }) {
+function SeamHarness({
+  scene = SEAM_SCENE,
+  thumbnails = false,
+}: {
+  scene?: GraphNodeSpec;
+  thumbnails?: boolean;
+}) {
   // Built FROM the scene, so a fixture can grow without the harness having to
   // be told about every clip in it by name.
   const store = createGraphDetailsStore(
@@ -262,6 +269,7 @@ function SeamHarness({ scene = SEAM_SCENE }: { scene?: GraphNodeSpec }) {
   );
   return (
     <div className="graph-view-theme min-h-[600px] bg-zinc-950">
+      <PlaybarThumbnailsProvider shown={thumbnails}>
       <DndCollections initialGraph={graphOfRoot(scene)}>
         <GraphDetailsProvider store={store}>
           <ItemDetailsProvider>
@@ -270,6 +278,7 @@ function SeamHarness({ scene = SEAM_SCENE }: { scene?: GraphNodeSpec }) {
           </ItemDetailsProvider>
         </GraphDetailsProvider>
       </DndCollections>
+      </PlaybarThumbnailsProvider>
     </div>
   );
 }
@@ -2037,6 +2046,65 @@ export const PointingAtABoxSaysWhatItIs: Story = {
       relatedTarget: document.body,
     });
     await waitFor(() => expect(preview()).toBeNull());
+  },
+};
+
+/**
+ * THE PLAY BAR CAN DRAW FRAMES INSTEAD OF GREY BOXES, and does not by default.
+ *
+ * A bar of thumbnails answers "which shot is that" without a hover, which is
+ * the whole reason to want it. What it costs is what the grey bar is good at:
+ * a box's width is its duration, so an even run of grey reads as rhythm —
+ * where the cuts fall, which shots are long, where the pace changes. Put
+ * pictures in them and the eye reads the pictures, because it always will.
+ * Hence a setting, and hence off.
+ *
+ * THE COLOUR STAYS UNDERNEATH. A clip with no poster — audio has none — and a
+ * frame that has not loaded yet both leave the box exactly as it is without
+ * the setting, so turning this on can add pictures but never subtract the bar.
+ */
+export const ThePlaybarCanDrawFrames: Story = {
+  render: () => <SeamHarness scene={TWO_ROOMS_SCENE} thumbnails />,
+  play: async () => {
+    await waitFor(() => expect(document.querySelector("[data-seam-strip]")).not.toBeNull());
+    await settleStrip();
+
+    const boxes = seamBoxes();
+    const thumbs = Array.from(
+      document.querySelectorAll<HTMLImageElement>("[data-seam-thumbnail]"),
+    );
+    expect(thumbs.length).toBe(boxes.length);
+
+    // COVER, AND THE WHOLE BOX. The box's width is its duration and its height
+    // is the bar's, so the frame is whatever shape that comes out as —
+    // anything but `cover` would letterbox each clip differently and turn a
+    // strip into a row of unrelated shapes.
+    const first = thumbs[0]!;
+    expect(getComputedStyle(first).objectFit).toBe("cover");
+    const box = first.parentElement!.getBoundingClientRect();
+    const picture = first.getBoundingClientRect();
+    expect(picture.width).toBeCloseTo(box.width, 0);
+    expect(picture.height).toBeCloseTo(box.height, 0);
+
+    // The colour is still under it, so a frame that never loads leaves a bar
+    // rather than a hole.
+    expect(getComputedStyle(first.parentElement!).backgroundColor).not.toBe(
+      "rgba(0, 0, 0, 0)",
+    );
+  },
+};
+
+/** OFF BY DEFAULT: the same bar, same scene, no pictures. Its own story rather
+ *  than a second half of the one above, because "the setting does something"
+ *  and "the setting is off unless asked for" fail in different ways and one
+ *  should not hide the other. */
+export const ThePlaybarIsGreyUnlessAsked: Story = {
+  render: () => <SeamHarness scene={TWO_ROOMS_SCENE} />,
+  play: async () => {
+    await waitFor(() => expect(document.querySelector("[data-seam-strip]")).not.toBeNull());
+    await settleStrip();
+    expect(seamBoxes().length).toBeGreaterThan(0);
+    expect(document.querySelectorAll("[data-seam-thumbnail]").length).toBe(0);
   },
 };
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -15,10 +15,6 @@ import { createGraphDetailsStore } from "@/lib/graph-details-store";
 import { GraphDetailsProvider } from "./graph-details-context";
 import { ItemDetailsProvider, useItemDetails } from "./graph-item-details-context";
 import { GraphItemDetailsModal } from "./graph-item-details-modal";
-import {
-  PlaybarThumbnailsProvider,
-  type PlaybarThumbnailStyle,
-} from "./graph-playbar-thumbnails";
 
 // The details modal's first stories. It had none, which is how it came to
 // describe a VOICEOVER as a "still" — the branch that renders the duration
@@ -252,15 +248,7 @@ function EndHarness() {
   );
 }
 
-function SeamHarness({
-  scene = SEAM_SCENE,
-  thumbnails = false,
-  thumbnailStyle = "cover",
-}: {
-  scene?: GraphNodeSpec;
-  thumbnails?: boolean;
-  thumbnailStyle?: PlaybarThumbnailStyle;
-}) {
+function SeamHarness({ scene = SEAM_SCENE }: { scene?: GraphNodeSpec }) {
   // Built FROM the scene, so a fixture can grow without the harness having to
   // be told about every clip in it by name.
   const store = createGraphDetailsStore(
@@ -274,7 +262,6 @@ function SeamHarness({
   );
   return (
     <div className="graph-view-theme min-h-[600px] bg-zinc-950">
-      <PlaybarThumbnailsProvider shown={thumbnails} style={thumbnailStyle}>
       <DndCollections initialGraph={graphOfRoot(scene)}>
         <GraphDetailsProvider store={store}>
           <ItemDetailsProvider>
@@ -283,7 +270,6 @@ function SeamHarness({
           </ItemDetailsProvider>
         </GraphDetailsProvider>
       </DndCollections>
-      </PlaybarThumbnailsProvider>
     </div>
   );
 }
@@ -422,6 +408,23 @@ function centreBox(): HTMLElement {
  * row easing across three panels is invisible to it and a measurement taken
  * straight after reads a card mid-flight.
  */
+/**
+ * Press one of the frames badges by its label — `OFF`, `COVER`, `STRIP`.
+ *
+ * SET EXPLICITLY AND PUT BACK. Like the reach, these are remembered at module
+ * scope for the session, so a story that leaves frames on hands them to
+ * whichever story runs next in the same browser.
+ */
+function framesTo(label: string): void {
+  const group = document.querySelector<HTMLElement>("[data-details-bar-frames]");
+  expect(group).not.toBeNull();
+  const button = Array.from(group!.querySelectorAll("button")).find(
+    (candidate) => candidate.textContent?.trim() === label,
+  );
+  expect(button).not.toBeUndefined();
+  button!.click();
+}
+
 /** Press one of the reach picker's buttons by its label. */
 function reachTo(label: string): void {
   const group = document.querySelector<HTMLElement>("[data-details-bar-reach]");
@@ -2057,28 +2060,35 @@ export const PointingAtABoxSaysWhatItIs: Story = {
 /**
  * THE PLAY BAR CAN DRAW FRAMES INSTEAD OF GREY BOXES, and does not by default.
  *
- * A bar of thumbnails answers "which shot is that" without a hover, which is
- * the whole reason to want it. What it costs is what the grey bar is good at:
- * a box's width is its duration, so an even run of grey reads as rhythm —
- * where the cuts fall, which shots are long, where the pace changes. Put
- * pictures in them and the eye reads the pictures, because it always will.
- * Hence a setting, and hence off.
+ * A bar of frames answers "which shot is that" without a hover, which is the
+ * whole reason to want it. What it costs is what the grey bar is good at: a
+ * box's width is its duration, so an even run of grey reads as rhythm — where
+ * the cuts fall, which shots are long, where the pace changes. Put pictures in
+ * them and the eye reads the pictures, because it always will. Hence a
+ * setting, and hence off.
  *
  * THE COLOUR STAYS UNDERNEATH. A clip with no poster — audio has none — and a
  * frame that has not loaded yet both leave the box exactly as it is without
  * the setting, so turning this on can add pictures but never subtract the bar.
  */
 export const ThePlaybarCanDrawFrames: Story = {
-  render: () => <SeamHarness scene={TWO_ROOMS_SCENE} thumbnails />,
+  render: () => <SeamHarness scene={TWO_ROOMS_SCENE} />,
   play: async () => {
     await waitFor(() => expect(document.querySelector("[data-seam-strip]")).not.toBeNull());
     await settleStrip();
 
-    const boxes = seamBoxes();
+    // OFF FIRST, and asserted: the control is on the bar now, so the story can
+    // show the before as well as the after.
+    expect(document.querySelectorAll("[data-seam-thumbnail]").length).toBe(0);
+    framesTo("COVER");
+
+    const boxCount = seamBoxes().length;
+    await waitFor(() =>
+      expect(document.querySelectorAll("[data-seam-thumbnail]").length).toBe(boxCount),
+    );
     const thumbs = Array.from(
       document.querySelectorAll<HTMLImageElement>("[data-seam-thumbnail]"),
     );
-    expect(thumbs.length).toBe(boxes.length);
 
     // COVER, AND THE WHOLE BOX. The box's width is its duration and its height
     // is the bar's, so the frame is whatever shape that comes out as —
@@ -2095,6 +2105,11 @@ export const ThePlaybarCanDrawFrames: Story = {
     // rather than a hole.
     expect(getComputedStyle(first.parentElement!).backgroundColor).not.toBe(
       "rgba(0, 0, 0, 0)",
+    );
+
+    framesTo("OFF");
+    await waitFor(() =>
+      expect(document.querySelectorAll("[data-seam-thumbnail]").length).toBe(0),
     );
   },
 };
@@ -2115,20 +2130,22 @@ export const ThePlaybarCanDrawFrames: Story = {
  */
 export const ThePlaybarCanDrawAFilmstrip: Story = {
   // TRIMMED_SCENE because its clips are VIDEO with posters and real trims —
-  // the only fixture here that a filmstrip can be built from at all. A still
-  // falls back to the single frame by design, which is the next story.
-  render: () => <SeamHarness scene={TRIMMED_SCENE} thumbnails thumbnailStyle="filmstrip" />,
+  // the only fixture here a filmstrip can be built from at all. A still falls
+  // back to the single frame by design, which is the story after next.
+  render: () => <SeamHarness scene={TRIMMED_SCENE} />,
   play: async () => {
     await waitFor(() => expect(document.querySelector("[data-seam-strip]")).not.toBeNull());
     await settleStrip();
+    framesTo("STRIP");
 
     // The widest box, so there is room for more than one cell in it — a strip
     // of one is a `cover` by another name and would prove nothing.
-    const strips = Array.from(
-      document.querySelectorAll<HTMLElement>("[data-seam-filmstrip]"),
+    await waitFor(() =>
+      expect(document.querySelectorAll("[data-seam-filmstrip]").length).toBeGreaterThan(0),
     );
-    expect(strips.length).toBeGreaterThan(0);
-    const widest = strips
+    const widest = Array.from(
+      document.querySelectorAll<HTMLElement>("[data-seam-filmstrip]"),
+    )
       .slice()
       .sort((a, b) => b.getBoundingClientRect().width - a.getBoundingClientRect().width)[0]!;
     const cells = Array.from(widest.querySelectorAll<HTMLImageElement>("img"));
@@ -2151,6 +2168,8 @@ export const ThePlaybarCanDrawAFilmstrip: Story = {
     // THE STYLE IS A SEPARATE SETTING FROM WHETHER FRAMES SHOW AT ALL: this is
     // the strip, so the single covering frame must not ALSO be in the box.
     expect(widest.parentElement!.querySelectorAll("img").length).toBe(cells.length);
+
+    framesTo("OFF");
   },
 };
 
@@ -2159,27 +2178,33 @@ export const ThePlaybarCanDrawAFilmstrip: Story = {
  *
  * A still has one image. Sampling it at ten intervals gives ten copies of
  * itself — a filmstrip whose content is "nothing happens here", which is worse
- * than the one frame it is made of and takes ten requests to say. So the
- * strip is offered only where there is something to sample, and the setting
- * degrades rather than obeying.
+ * than the one frame it is made of and takes ten requests to say. So the strip
+ * is offered only where there is something to sample, and the setting degrades
+ * rather than obeying.
  */
 export const AStillIgnoresTheFilmstrip: Story = {
-  render: () => <SeamHarness scene={TWO_ROOMS_SCENE} thumbnails thumbnailStyle="filmstrip" />,
+  render: () => <SeamHarness scene={TWO_ROOMS_SCENE} />,
   play: async () => {
     await waitFor(() => expect(document.querySelector("[data-seam-strip]")).not.toBeNull());
     await settleStrip();
-    expect(document.querySelectorAll("[data-seam-filmstrip]").length).toBe(0);
+    framesTo("STRIP");
+
     // Still a picture per box — falling back is not the same as giving up.
-    expect(document.querySelectorAll("[data-seam-thumbnail]").length).toBe(
-      seamBoxes().length,
+    await waitFor(() =>
+      expect(document.querySelectorAll("[data-seam-thumbnail]").length).toBe(
+        seamBoxes().length,
+      ),
     );
+    expect(document.querySelectorAll("[data-seam-filmstrip]").length).toBe(0);
+
+    framesTo("OFF");
   },
 };
 
-/** OFF BY DEFAULT: the same bar, same scene, no pictures. Its own story rather
- *  than a second half of the one above, because "the setting does something"
- *  and "the setting is off unless asked for" fail in different ways and one
- *  should not hide the other. */
+/** OFF UNLESS ASKED: the control has to start somewhere, and the plain bar is
+ *  where. Its own story rather than a half of the one above, because "the
+ *  setting does something" and "the setting is off to begin with" fail in
+ *  different ways and one should not hide the other. */
 export const ThePlaybarIsGreyUnlessAsked: Story = {
   render: () => <SeamHarness scene={TWO_ROOMS_SCENE} />,
   play: async () => {
@@ -2187,6 +2212,22 @@ export const ThePlaybarIsGreyUnlessAsked: Story = {
     await settleStrip();
     expect(seamBoxes().length).toBeGreaterThan(0);
     expect(document.querySelectorAll("[data-seam-thumbnail]").length).toBe(0);
+    // The control says so too, which is what makes the bar's state readable
+    // rather than merely true.
+    const group = document.querySelector<HTMLElement>("[data-details-bar-frames]")!;
+    const badges = Array.from(group.querySelectorAll("button"));
+    expect(badges.map((badge) => badge.textContent?.trim())).toEqual([
+      "OFF",
+      "COVER",
+      "STRIP",
+    ]);
+    // OFF is the one lit, and the other two are offered rather than hidden —
+    // the row says what the bar could be as well as what it is.
+    expect(badges.map((badge) => badge.getAttribute("aria-pressed"))).toEqual([
+      "true",
+      "false",
+      "false",
+    ]);
   },
 };
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -2103,14 +2103,30 @@ export const ThePlaybarCanDrawFrames: Story = {
 
     // The colour is still under it, so a frame that never loads leaves a bar
     // rather than a hole.
-    expect(getComputedStyle(first.parentElement!).backgroundColor).not.toBe(
-      "rgba(0, 0, 0, 0)",
-    );
+    const boxStyle = getComputedStyle(first.parentElement!);
+    expect(boxStyle.backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
+
+    // AND THE BOUNDARY IS DRAWN. The gap between two boxes is five pixels of
+    // the lane showing through, which is obvious between two greys and
+    // invisible between two photographs — a picture already contains dark
+    // edges and the eye has no reason to read that one as a boundary. Painted
+    // rather than widened, because a box's width is its duration and spending
+    // more of it on separation would change what the bar is saying.
+    expect(boxStyle.boxShadow).not.toBe("none");
+    // Both halves: a light hairline inside the box's own edge, and a dark one
+    // just outside it in the gap.
+    expect(boxStyle.boxShadow).toMatch(/inset/);
+    expect(boxStyle.boxShadow.match(/rgba?\(/g)?.length).toBe(2);
 
     framesTo("OFF");
     await waitFor(() =>
       expect(document.querySelectorAll("[data-seam-thumbnail]").length).toBe(0),
     );
+    // AND IT GOES AWAY WITH THEM. Over flat grey the same treatment is a
+    // hairline on a plain colour — decoration answering a question nobody
+    // asked, and one more thing between the reader and the rhythm the grey
+    // bar is for.
+    expect(getComputedStyle(seamBoxes()[0]!).boxShadow).toBe("none");
   },
 };
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -459,7 +459,14 @@ async function settleStrip(): Promise<void> {
   // under load: the poll can take two readings before the movement has even
   // started, agree with itself, and report a strip that is about to move as
   // settled. That is exactly how these passed alone and failed in the full run.
-  await new Promise((resolve) => setTimeout(resolve, 320));
+  //
+  // LONGER THAN THE BAR'S LANDING SLIDE (`SEAM_SLIDE_MS`, 520ms), not longer
+  // than the row's 300ms step. It was 320 when 300 was the only transition
+  // this could be waiting on; the bar started sliding on a subject change and
+  // that stopped being true, which CI found and a run of this file alone did
+  // not — the reading that lands mid-slide depends on how loaded the machine
+  // is.
+  await new Promise((resolve) => setTimeout(resolve, 600));
   let previous = Number.NaN;
   await waitFor(
     () => {
@@ -704,16 +711,18 @@ export const ClickingANeighbourAdvancesTheStrip: Story = {
     const rightHero = panels[2]!.querySelector<HTMLElement>("[data-item-details-frame]")!;
     rightHero.click();
 
-    // ONE STEP STILL EASES. The counterpart to the cut in
-    // `LettingGoOfTheBarLandsTheStrip`: a landing more than a panel away
-    // arrives without travelling, and the guard that does it is a distance
-    // test — so the thing to protect is the case just under the line. A step
-    // is a gesture finishing itself and has to be seen to move.
-    const strip = () => document.querySelector<HTMLElement>("[data-details-strip]")!;
-    const movingX = strip().getBoundingClientRect().left;
-    await new Promise((resolve) => setTimeout(resolve, 120));
-    // Still in flight a third of the way through a 300ms ease.
-    expect(strip().getBoundingClientRect().left).not.toBe(movingX);
+    // NO TIMING ASSERTION HERE, DELIBERATELY. This used to sample the row
+    // 120ms apart and require the two readings to differ — "still in flight a
+    // third of the way through a 300ms ease". It passed alone and failed in
+    // the full run, which is the tell: nothing guarantees the first sample
+    // lands at the animation's START. Under load the click, the render and
+    // the whole ease can fall between two reads, and the story then reports a
+    // step that eased perfectly as a step that jumped.
+    //
+    // What a step does that a landing does not is covered below by ORDER — the
+    // clip that was centred is now to the left of centre — and the landing's
+    // own story proves the other half geometrically, with the row at its seat
+    // and staying there. Neither of those depends on catching a frame.
 
     await waitFor(() => expect(centreName()).toBe("Rename After"));
 
@@ -1739,10 +1748,19 @@ export const HoldingAtAnEdgeRunsTheStrip: Story = {
     // ── LETTING GO STOPS IT, AND LANDS ON WHAT IT RAN TO ──────────────────
     release(box.right - 12);
     const stoppedAt = at();
-    const stoppedX = stripLeft();
     await rest(300);
+
+    // THE CLOCK STOPS DEAD, WHICH IS WHAT "STOPS IT" MEANS. The strip does
+    // not, and must not be asserted to: letting go lands the row on the clip
+    // the playhead reached, and the bar then slides to re-centre on it. That
+    // slide is a different motion from the run — it has an end, and the run
+    // did not — so what this checks is that the RUN stopped, and then that the
+    // slide settles rather than continuing.
     expect(at()).toBe(stoppedAt);
-    expect(stripLeft()).toBe(stoppedX);
+    await settleStrip();
+    const settledX = stripLeft();
+    await rest(200);
+    expect(stripLeft()).toBe(settledX);
     // WHERE THE PLAYHEAD FINISHED, NOT WHERE THE HAND IS. The hand never
     // moved, so this is the case that would go wrong if the release resolved
     // a clip from the pointer's x: the strip ran a long way underneath a
@@ -1754,7 +1772,6 @@ export const HoldingAtAnEdgeRunsTheStrip: Story = {
     // MEASURED AGAIN. The release above landed the row on a new clip, and the
     // bar re-pans around it — so the geometry read at the top of this story
     // describes a bar that no longer exists.
-    await settleStrip();
     const after = seamSurface().getBoundingClientRect();
     press(after.left + 12);
     const pressedBackAt = at();
@@ -2106,27 +2123,35 @@ export const ThePlaybarCanDrawFrames: Story = {
     const boxStyle = getComputedStyle(first.parentElement!);
     expect(boxStyle.backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
 
-    // AND THE BOUNDARY IS DRAWN. The gap between two boxes is five pixels of
-    // the lane showing through, which is obvious between two greys and
-    // invisible between two photographs — a picture already contains dark
-    // edges and the eye has no reason to read that one as a boundary. Painted
-    // rather than widened, because a box's width is its duration and spending
-    // more of it on separation would change what the bar is saying.
-    expect(boxStyle.boxShadow).not.toBe("none");
-    // Both halves: a light hairline inside the box's own edge, and a dark one
-    // just outside it in the gap.
+    // AND THE GAPS CHANGE COLOUR. The gap between two boxes is five pixels of
+    // the strip showing through, which is obvious between two greys and
+    // invisible between two photographs — the lane is dark, a picture already
+    // contains dark edges, and the eye has no reason to read that one as a
+    // boundary. A PALE gap is not a colour footage supplies, so it reads as
+    // structure rather than as picture. Recoloured rather than widened,
+    // because a box's width is its duration and spending more of it on
+    // separation would change what the bar is saying.
+    const gap = getComputedStyle(
+      document.querySelector<HTMLElement>("[data-seam-strip]")!,
+    ).backgroundColor;
+    const channels = gap.match(/[\d.]+/g)!.slice(0, 3).map(Number);
+    expect(Math.min(...channels)).toBeGreaterThan(160);
+    // And each box keeps a dark hairline just inside its own border, so a
+    // bright frame running into the pale gap still has an edge.
     expect(boxStyle.boxShadow).toMatch(/inset/);
-    expect(boxStyle.boxShadow.match(/rgba?\(/g)?.length).toBe(2);
 
     framesTo("OFF");
     await waitFor(() =>
       expect(document.querySelectorAll("[data-seam-thumbnail]").length).toBe(0),
     );
-    // AND IT GOES AWAY WITH THEM. Over flat grey the same treatment is a
-    // hairline on a plain colour — decoration answering a question nobody
-    // asked, and one more thing between the reader and the rhythm the grey
-    // bar is for.
+    // AND IT GOES AWAY WITH THEM. Over flat grey the whole treatment is
+    // decoration answering a question nobody asked, and one more thing between
+    // the reader and the rhythm the grey bar is for.
     expect(getComputedStyle(seamBoxes()[0]!).boxShadow).toBe("none");
+    expect(
+      getComputedStyle(document.querySelector<HTMLElement>("[data-seam-strip]")!)
+        .backgroundColor,
+    ).toBe("rgba(0, 0, 0, 0)");
   },
 };
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -2123,22 +2123,23 @@ export const ThePlaybarCanDrawFrames: Story = {
     const boxStyle = getComputedStyle(first.parentElement!);
     expect(boxStyle.backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
 
-    // AND THE GAPS CHANGE COLOUR. The gap between two boxes is five pixels of
-    // the strip showing through, which is obvious between two greys and
-    // invisible between two photographs — the lane is dark, a picture already
-    // contains dark edges, and the eye has no reason to read that one as a
-    // boundary. A PALE gap is not a colour footage supplies, so it reads as
-    // structure rather than as picture. Recoloured rather than widened,
-    // because a box's width is its duration and spending more of it on
-    // separation would change what the bar is saying.
+    // AND THE GAP CARRIES BOTH TONES. No single colour separates two frames:
+    // a dark gap is invisible between two dark ones, a pale gap between two
+    // bright ones, and footage supplies both inside the same cut. So the
+    // strip's background is pale and each box casts a dark ring into the gap,
+    // which makes every gap read dark · pale · dark whatever is beside it.
+    // Asserted as BOTH being present, because either alone is the bug.
     const gap = getComputedStyle(
       document.querySelector<HTMLElement>("[data-seam-strip]")!,
     ).backgroundColor;
-    const channels = gap.match(/[\d.]+/g)!.slice(0, 3).map(Number);
-    expect(Math.min(...channels)).toBeGreaterThan(160);
-    // And each box keeps a dark hairline just inside its own border, so a
-    // bright frame running into the pale gap still has an edge.
-    expect(boxStyle.boxShadow).toMatch(/inset/);
+    const pale = gap.match(/[\d.]+/g)!.slice(0, 3).map(Number);
+    expect(Math.min(...pale)).toBeGreaterThan(160);
+
+    const ring = boxStyle.boxShadow.match(/[\d.]+/g)!.slice(0, 3).map(Number);
+    expect(Math.max(...ring)).toBeLessThan(90);
+    // OUTSIDE the box, which is what puts it in the gap rather than over the
+    // picture — and what keeps it costing no layout.
+    expect(boxStyle.boxShadow).not.toMatch(/inset/);
 
     framesTo("OFF");
     await waitFor(() =>

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -2419,11 +2419,21 @@ export const LettingGoOfTheBarLandsTheStrip: Story = {
       const x = rect.left + rect.width * 0.5;
       scrubToClientX(x, { hold: true });
       await waitFor(() => expect(at()).toBeGreaterThan(0));
-      const heldFrame = Number(
-        document
-          .querySelector<HTMLElement>("[data-item-details-at]")!
-          .getAttribute("data-item-details-at"),
+      const reporting = Array.from(
+        document.querySelectorAll<HTMLElement>("[data-item-details-at]"),
       );
+      const heldFrame = Number(reporting[0]!.getAttribute("data-item-details-at"));
+
+      // TWO PANELS ARE ON THIS FRAME, AND THAT IS THE POINT. The centre is
+      // monitoring the clip being scrubbed to, and that clip's OWN panel is
+      // already showing the same moment rather than resting on its first
+      // frame. Without the second, the release reads as: the right frame, a
+      // cut, the FIRST frame, and a skip back — because the panel arriving in
+      // the middle has a decoded frame already and it is the wrong one.
+      expect(reporting.length).toBe(2);
+      expect(
+        reporting.map((panel) => Number(panel.getAttribute("data-item-details-at"))),
+      ).toEqual([heldFrame, heldFrame]);
       const surface = seamSurface();
       const surfaceBox = surface.getBoundingClientRect();
       fireEvent.pointerUp(surface, pointerAt(x, surfaceBox.top + surfaceBox.height / 2));
@@ -2434,7 +2444,13 @@ export const LettingGoOfTheBarLandsTheStrip: Story = {
     const restingSeat = seatX();
 
     // ── A LANDING SEVERAL CLIPS OFF CUTS, AND THE MIDDLE STAYS PUT ────────
-    const target = seamBoxes()[boxIndex() + 4]!;
+    // TWO CLIPS, WHICH IS INSIDE `MOUNTED_RADIUS` AND OUTSIDE A STEP. Both
+    // halves matter: past one clip so it cuts and fades rather than stepping,
+    // and near enough that the target's panel EXISTS during the scrub, which
+    // is what the pre-seek below can be observed on. A landing beyond the
+    // mount window has no panel to pre-seek and is covered instead by the
+    // poster the fresh element paints — see `monitorPosterUrl`.
+    const target = seamBoxes()[boxIndex() + 2]!;
     const letGo = await dragToBox(target);
     await waitFor(() => expect(subject()).not.toBe("subject"));
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -2041,6 +2041,53 @@ export const PointingAtABoxSaysWhatItIs: Story = {
 };
 
 /**
+ * THE BAR'S BOXES SLIDE INTO POSITION WHEN THE CENTRED CLIP CHANGES.
+ *
+ * The strip's transform is driven by three different things and only one of
+ * them wants easing. A drag has to track the hand exactly — the edge run's
+ * whole point is that the strip moves WITH the pointer — and a wheel zoom or
+ * a pan is the same hand by another route. Changing which clip is centred is
+ * not: nothing is under the reader's finger, the strip re-centres on somewhere
+ * else entirely, and a jump there cannot be told apart from the bar being
+ * redrawn with different contents.
+ *
+ * THE DRAG HALF IS COVERED BY `HoldingAtAnEdgeRunsTheStrip`, which measures
+ * the strip's travel against the clock to within two pixels — an easing left
+ * switched on during a drag puts the strip behind the hand and fails there.
+ */
+export const TheBarSlidesIntoPositionOnAMove: Story = {
+  render: () => <SeamHarness scene={TWO_ROOMS_SCENE} />,
+  play: async () => {
+    await waitFor(() => expect(document.querySelector("[data-seam-strip]")).not.toBeNull());
+    await settleStrip();
+    const stripX = () =>
+      document.querySelector<HTMLElement>("[data-seam-strip]")!.getBoundingClientRect().left;
+    const subject = () => centreBox().getAttribute("data-seam-segment");
+
+    const startedOn = subject();
+    const from = stripX();
+
+    // A press on a box well along the bar: a move, not a drag.
+    const boxes = seamBoxes();
+    const target = boxes[boxes.indexOf(centreBox()) + 6]!;
+    clickBox(target);
+    await waitFor(() => expect(subject()).not.toBe(startedOn));
+
+    // STILL ON ITS WAY. This is the assertion a jump fails: with no easing the
+    // strip is already at its destination by the first reading, so the two
+    // readings agree and nothing here can tell that it moved at all.
+    const early = stripX();
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(stripX()).not.toBe(early);
+
+    // And it does arrive somewhere else, so the movement was real rather than
+    // a wobble.
+    await settleStrip();
+    expect(Math.abs(stripX() - from)).toBeGreaterThan(20);
+  },
+};
+
+/**
  * HOW FAR THE BAR REACHES IS A SETTING, and ten either side is where it opens.
  *
  * The bar used to draw the whole collection whatever you were doing, which is
@@ -2173,7 +2220,7 @@ export const LettingGoOfTheBarLandsTheStrip: Story = {
     // And the window let go again once it had arrived.
     await waitFor(() => expect(panels()).toBe(restingPanels));
 
-    // ── A LONG ONE ARRIVES INSTEAD ────────────────────────────────────────
+    // ── A LONG ONE ARRIVES THE SAME WAY, FROM THE SIDE ────────────────────
     // THE SEAT IS READ HERE, not at the top of the story. The row is a
     // different shape on its first paint — panels are still arriving — so its
     // resting x then is not the resting x it keeps. Taken between the two
@@ -2185,41 +2232,43 @@ export const LettingGoOfTheBarLandsTheStrip: Story = {
     const restingCentreX = seatX();
     const landedOn = subject();
     const far = seamBoxes()[boxIndex() + 8]!;
-    // THE PRECONDITION. Past `STEPPED_MAX`, or this measures the easing path
-    // twice and the cut not at all — and inside the default reach, or there is
-    // no box there to aim at.
-    expect(8).toBeGreaterThan(5);
+    // THE PRECONDITION: far enough that sliding the whole way would be
+    // obvious, and inside the default reach so there is a box there to aim at.
     expect(far).not.toBeUndefined();
     const letGoFar = await dragToBox(far);
     await waitFor(() => expect(subject()).not.toBe(landedOn));
 
-    // ASSERTED AS "IT DOES NOT MOVE" rather than by reading a transition
-    // duration off the element: the cut lasts a single render and catching
-    // that frame would be a race, while two readings a beat apart cannot be
-    // fooled — mid-flight they differ, arrived they do not.
-    const landedX = seatX();
-    await new Promise((resolve) => setTimeout(resolve, 150));
-    expect(seatX()).toBe(landedX);
+    // IT COMES IN FROM THE SIDE, NOT FROM WHERE IT WAS. Eight clips along,
+    // but the row is never displaced by more than the approach — so the
+    // distance travelled says which side you came from and nothing else.
+    // Sliding the whole way would start this eight panel-widths out and spend
+    // half a second blurring six cards nobody can read.
+    const step = document
+      .querySelector<HTMLElement>('[data-item-details-panel="centre"]')!
+      .getBoundingClientRect().width + 16;
+    const displaced = Math.abs(seatX() - restingCentreX);
+    expect(displaced).toBeGreaterThan(1);
+    expect(displaced).toBeLessThan(step * 2 + 8);
 
-    // Arrived in the MIDDLE, which is what says the offset it cut to was the
-    // right one rather than merely a still one.
-    // Arrived in the CENTRE SEAT — measured against where the centre panel sat
-    // at rest at the top of this story rather than against the middle of the
-    // window, because the row's resting x is a product of panel width, gap and
-    // the scrim's padding and this assertion should not have to know any of
-    // them. Landing still but one seat out would otherwise read as success.
+    // And it is MOVING, not placed.
+    const slidingFrom = seatX();
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(seatX()).not.toBe(slidingFrom);
+
+    await settleStrip();
+    await settleRow();
     expect(seatX()).toBeCloseTo(restingCentreX, 0);
-
-    // THE SCRIM NEVER SCROLLS. It crops a row thirteen thousand pixels wide,
-    // so if it were a scroll container there would be a great deal for the
-    // browser to scroll it by — and it would, because landing moves focus to
-    // the new panel's menu button and a hidden overflow is still scrolled to
-    // reveal what is focused. That scroll would land on top of the transform
-    // the row has already made and put the chosen card off the left edge.
-    // Zero here is `overflow-clip` doing its job.
-    expect(strip().parentElement!.scrollLeft).toBe(0);
     expect(subject()).toBe(far.getAttribute("data-seam-segment"));
     expect(shownFrame()).toBeCloseTo(letGoFar, 2);
+
+    // THE SCRIM NEVER SCROLLS. It crops a row thousands of pixels wide, so if
+    // it were a scroll container there would be a great deal for the browser
+    // to scroll it by — and it would, because landing moves focus to the new
+    // panel's menu button and a hidden overflow is still scrolled to reveal
+    // what is focused. That scroll would land on top of the transform the row
+    // has already made and put the chosen card off the left edge. Zero here is
+    // `overflow-clip` doing its job.
+    expect(strip().parentElement!.scrollLeft).toBe(0);
   },
 };
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -60,6 +60,13 @@ import {
   type ViewCount,
 } from "./graph-item-details-view-count";
 import {
+  PLAYBAR_THUMBNAIL_STYLES,
+  PlaybarThumbnailsProvider,
+  lastPlaybarThumbnails,
+  rememberPlaybarThumbnails,
+  type PlaybarThumbnails,
+} from "./graph-playbar-thumbnails";
+import {
   BAR_REACHES,
   barReachLabel,
   barReachWindow,
@@ -268,6 +275,14 @@ function DetailsFilmstripModal({
   // panels are on screen: the row is what you are working on, the bar is how
   // much of the sequence you can get to without leaving it.
   const [reach, setReach] = useState<BarReach>(lastBarReach());
+  // WHAT THE BOXES DRAW, kept beside the reach because it is the same kind of
+  // question — how much this control shows you, and of what. Seeded from
+  // module scope so it survives the modal being closed and reopened.
+  const [frames, setFrames] = useState<PlaybarThumbnails>(lastPlaybarThumbnails());
+  const chooseFrames = useCallback((next: PlaybarThumbnails) => {
+    rememberPlaybarThumbnails(next);
+    setFrames(next);
+  }, []);
 
   const clipAt = useCallback(
     (index: number): MediaNode | null => {
@@ -857,6 +872,7 @@ function DetailsFilmstripModal({
           onPointerDown={(event) => event.stopPropagation()}
         >
           <div className="mx-auto w-full max-w-5xl">
+            <PlaybarThumbnailsProvider shown={frames.shown} style={frames.style}>
             <SeamStripBar
               clips={barClips}
               centreClipId={node.id as string}
@@ -893,16 +909,81 @@ function DetailsFilmstripModal({
                 setBarSeconds(Math.min(Math.max(seconds, 0), timeline.totalSeconds));
               }}
             />
-            {/* HOW FAR THE BAR REACHES, tucked under its right-hand end.
-                Here rather than with the panel-count picker at the foot of the
-                screen because it is a question about THIS control: the number
-                you are reading is the width of the thing directly above it,
-                and the two are read together. */}
+            {/* EVERYTHING THE BAR ITSELF IS SET BY, on one row under it.
+                These began in the board's gear menu, which is where settings
+                you set once belong — but these are not that. They are read
+                against the bar directly above them: the reach is the width of
+                what you are looking at, and the frames are what it is made of.
+                A control you judge by looking at the thing it changes wants to
+                be next to that thing.
+
+                TWO GROUPS, split left and right, because they answer different
+                questions: what the boxes are made of, and how many of them
+                there are. Run together as one row of eight badges they would
+                read as one setting with eight values. */}
+            <div className="mt-2 flex items-center justify-between gap-4">
+              <div
+                data-details-bar-frames
+                role="group"
+                aria-label="What the bar's boxes draw"
+                className="flex items-center gap-1"
+              >
+                <span className="mr-1 font-mono text-[10px] text-zinc-500">frames</span>
+                {/* THREE BADGES, TWO SETTINGS. Whether the boxes draw frames
+                    and which kind are separate answers, but as controls they
+                    are one question — a picture of what the bar is made of —
+                    and a row that reads OFF · COVER · STRIP says it in the
+                    shape the reach beside it already uses.
+
+                    OFF DOES NOT WIPE THE STYLE. It sets `shown` and leaves
+                    `style` alone, so coming back lands on the kind you were
+                    using: switching frames off and on stays a comparison you
+                    can make twice rather than a choice you re-enter. That is
+                    the whole reason the two are stored apart even though they
+                    are pressed together. */}
+                {(["off", ...PLAYBAR_THUMBNAIL_STYLES] as const).map((option) => {
+                  const active = option === "off" ? !frames.shown : frames.shown && frames.style === option;
+                  return (
+                    <button
+                      key={option}
+                      type="button"
+                      aria-pressed={active}
+                      onClick={() =>
+                        chooseFrames(
+                          option === "off"
+                            ? { ...frames, shown: false }
+                            : { shown: true, style: option },
+                        )
+                      }
+                      title={
+                        option === "off"
+                          ? "Plain boxes"
+                          : option === "cover"
+                            ? "One frame filling each box"
+                            : "A strip of frames across each clip"
+                      }
+                      className={[
+                        "min-w-7 rounded px-1.5 py-0.5 font-mono text-[10px] tabular-nums transition-colors",
+                        active
+                          ? "bg-zinc-100 text-zinc-900"
+                          : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100",
+                      ].join(" ")}
+                    >
+                      {/* `STRIP`, not `FILMSTRIP`: these badges sit beside a
+                          reach picker of two- and three-character tokens, and
+                          one nine-character label would set the row's rhythm
+                          for the sake of a word the title attribute already
+                          says in full. */}
+                      {option === "filmstrip" ? "STRIP" : option.toUpperCase()}
+                    </button>
+                  );
+                })}
+              </div>
             <div
               data-details-bar-reach
               role="group"
               aria-label="Clips either side on the bar"
-              className="mt-2 flex items-center justify-end gap-1"
+              className="flex items-center gap-1"
             >
               <span className="mr-1 font-mono text-[10px] text-zinc-500">reach</span>
               {BAR_REACHES.map((option) => (
@@ -927,6 +1008,8 @@ function DetailsFilmstripModal({
                 </button>
               ))}
             </div>
+            </div>
+            </PlaybarThumbnailsProvider>
           </div>
         </div>
       )}

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -247,10 +247,12 @@ function DetailsFilmstripModal({
   const carryClockRef = useRef<SeamPosition | null>(null);
   // WHERE AN EASING JUMP STARTED, while it is still easing. Null the rest of
   // the time, which is nearly all of the time.
-  // A LANDING IN PROGRESS. `approach` is how many panels the row is displaced
-  // by, signed — non-zero on the frame it is put down, then zero for the slide
-  // itself. Null between landings, which is nearly always.
-  const [travel, setTravel] = useState<{ approach: number } | null>(null);
+  // A BAR LANDING IN FLIGHT: true while the panels either side are fading in.
+  // Set in the handler rather than derived, because the difference between a
+  // step and a landing is WHICH GESTURE ASKED, and nothing about the resulting
+  // state remembers that.
+  const [swapping, setSwapping] = useState(false);
+  const swapRef = useRef(false);
   const [playing, setPlaying] = useState(false);
   // A DRAG IS IN PROGRESS ON THE BAR. Distinct from `scrubbed`, which stays
   // true once the clock has been touched: this is the gesture itself, and it
@@ -460,26 +462,20 @@ function DetailsFilmstripModal({
   // honest.
   const MOUNTED_RADIUS = Math.floor(viewCount / 2) + 1;
 
-  // HOW A LANDING ARRIVES: FROM THE SIDE, NOT FROM WHERE IT WAS.
+  // HOW A LANDING FROM THE BAR ARRIVES: IT DOES NOT TRAVEL.
   //
-  // The row is put down a couple of panels off, with no transition, and then
-  // slides the rest of the way in. What you see is the clip you chose coming
-  // to the middle from the side it lies on — which is the move being
-  // described, and it reads the same whether you landed two clips along or
-  // twenty.
+  // Stepping and letting go of the bar look like the same event and are not.
+  // A step really does make the middle card a different clip, and the slide is
+  // what says which way you went. Letting go of the bar does not: the middle
+  // card has been the MONITOR for the whole scrub, so it is already showing
+  // the clip you landed on, and scrolling the row to it animates a change that
+  // has already happened — the one thing on screen that did not need to move
+  // is the thing that moves.
   //
-  // SLIDING THE WHOLE DISTANCE WAS THE OBVIOUS THING AND IT IS WRONG TWICE.
-  // Ten panels of travel is ten panels that have to be REAL for the length of
-  // the animation, and a full panel is a video element, a trim strip and a tag
-  // editor — the same cost `MOUNTED_RADIUS` exists to avoid, paid all at once
-  // so that it can be blurred past. And what it buys is a whip: the cards in
-  // between go by too fast to be read, so the motion says "a long way" without
-  // saying where. A fixed short approach costs two extra panels and says the
-  // one thing the movement is for — which side you came from.
-  const SLIDE_IN = 2;
-  // Slower than the 300ms a one-panel step takes, because this one is a place
-  // change rather than a nudge and wants to be seen.
-  const SLIDE_MS = 520;
+  // So the row cuts to its new offset, the middle card stays exactly where it
+  // is with exactly the picture it had, and the panels either side fade in
+  // with their new contents. What changes is what changes.
+  const SWAP_MS = 300;
 
   const chooseReach = useCallback((next: BarReach) => {
     rememberBarReach(next);
@@ -632,8 +628,8 @@ function DetailsFilmstripModal({
 
   // ONE WAY TO LAND, whichever gesture asked for it. A click on a box and a
   // released scrub differ only in how the clip was chosen; what happens next
-  // — carry the clock, widen the mount window if the row is about to travel,
-  // move — is the same sentence and is written once.
+  // — carry the clock, cut rather than travel, fade the panels either side —
+  // is the same sentence and is written once.
   const landOn = useCallback(
     (clipId: string, at: SeamPosition | null) => {
       if (clipId === (node.id as string)) return;
@@ -644,50 +640,47 @@ function DetailsFilmstripModal({
       // carrying the other clip's position would land you on the right card
       // showing the wrong one's time.
       carryClockRef.current = at !== null && at.clipId === clipId ? at : null;
-      // WHICH SIDE IT COMES IN FROM. A clip later in the cut lies to the
-      // right, so it arrives from the right — the row is put down displaced
-      // the other way and slides back. Capped at the real distance so a
-      // one-clip landing slides one panel rather than overshooting to make up
-      // the full approach.
-      const direction = to < 0 ? 0 : Math.sign(to - centre);
-      const slide = Math.min(SLIDE_IN, distance);
-      setTravel({ approach: direction === 0 ? 0 : -direction * slide });
+      // A NEIGHBOUR IS STILL A STEP. Landing on the clip directly beside the
+      // one you are on is the same single move the arrows and the swipe make,
+      // and it keeps their slide — the fade is for arrivals that come from
+      // somewhere the row was not showing.
+      swapRef.current = distance > 1;
+      setSwapping(distance > 1);
       onOpenNeighbour(clipId);
     },
-    [SLIDE_IN, centre, ids, node.id, onOpenNeighbour],
+    [centre, ids, node.id, onOpenNeighbour],
   );
 
-  // PUT DOWN, THEN RELEASED — the two halves of the arrival, and they must be
-  // two separate frames or there is no transition to run. The layout effect
-  // paints the displaced position with the transition off, and only once the
-  // browser has actually shown it does the next frame ask for the real one.
+  // THE ROW CUTS RATHER THAN SLIDES, for a bar landing only. Done to the node
+  // because the frame this is trying to influence has already been decided by
+  // the time any state update could land: a layout effect runs after the new
+  // transform is in the DOM and before the browser paints it, which is the
+  // only window where "do not travel" can still be said. The reflow read
+  // between the two writes is load-bearing — without it they coalesce and the
+  // transition never goes away.
   useLayoutEffect(() => {
-    if (travel === null || travel.approach === 0) return;
+    if (!swapRef.current) return;
+    swapRef.current = false;
     const strip = stripRef.current;
-    if (strip !== null) {
-      strip.style.transition = "none";
-      // The reflow is load-bearing: without it the two style writes coalesce
-      // and the row simply appears in its final place.
-      void strip.offsetWidth;
-    }
+    if (strip === null) return;
+    strip.style.transition = "none";
+    void strip.offsetWidth;
     const frame = requestAnimationFrame(() => {
-      if (strip !== null) strip.style.transition = "";
-      setTravel({ approach: 0 });
+      strip.style.transition = "";
     });
     return () => cancelAnimationFrame(frame);
-  }, [travel]);
+  }, [centre]);
 
-  // AND LET THE EXTRA PANELS GO once it has arrived. On a timer rather than
-  // on `transitionend`, which does not fire when a second landing interrupts
-  // the first and would strand the widened mount window open.
+  // AND THE FADE ENDS. On a timer rather than on `animationend`, which fires
+  // once per panel and would need counting, and does not fire at all for a
+  // panel that unmounted mid-fade.
   useEffect(() => {
-    if (travel === null || travel.approach !== 0) return;
-    const timer = setTimeout(() => setTravel(null), SLIDE_MS + 60);
+    if (!swapping) return;
+    const timer = setTimeout(() => setSwapping(false), SWAP_MS + 40);
     return () => clearTimeout(timer);
-  }, [SLIDE_MS, travel]);
+  }, [SWAP_MS, swapping]);
 
-  const offset =
-    centre < 0 ? 0 : centre - (ids.length - 1) / 2 + (travel?.approach ?? 0);
+  const offset = centre < 0 ? 0 : centre - (ids.length - 1) / 2;
 
   // SWIPING THE STRIP. The same instruction as clicking a neighbour, held:
   // drag the film and it follows the hand, let go past a threshold and it
@@ -990,9 +983,8 @@ function DetailsFilmstripModal({
           // landing on the next clip is animated and letting go short of the
           // threshold springs back.
           //
-          // A LANDING RUNS LONGER THAN A STEP — see `SLIDE_MS` — and the
-          // frame it is put down on has no transition at all, which the
-          // layout effect above does to the node rather than from here.
+          // A BAR LANDING has no transition at all, which the layout effect
+          // above does to the node rather than from here.
           dragPx === 0
             ? "transition-transform ease-out motion-reduce:transition-none"
             : "",
@@ -1000,16 +992,14 @@ function DetailsFilmstripModal({
         style={{
           gap: PANEL_GAP,
           transform: rowTransform,
-          transitionDuration: travel === null ? "300ms" : `${SLIDE_MS}ms`,
+          transitionDuration: "300ms",
         }}
       >
         {ids.map((id, index) => {
-          // The resting window, widened by the approach while a landing is in
-          // flight: the panels the row slides over are off the side of the
-          // resting window, and empty boxes sliding in is exactly what the
-          // movement is meant to avoid. Two extra panels, for half a second.
-          const mounted =
-            Math.abs(index - centre) <= MOUNTED_RADIUS + (travel === null ? 0 : SLIDE_IN);
+          // Nothing travels across the row any more, so the resting window is
+          // the whole window: a landing cuts, and the panels it cuts to are
+          // the ones already inside it.
+          const mounted = Math.abs(index - centre) <= MOUNTED_RADIUS;
           const panel = mounted ? graph.nodesById.get(parseNodeId(id)) : null;
           const media =
             panel && panel.kind === "media" && (panel as MediaNode).src
@@ -1039,6 +1029,7 @@ function DetailsFilmstripModal({
               key={id}
               node={media}
               centre={index === centre}
+              swapping={swapping}
               // Everything but the picture goes out while the clock is being
               // dragged — see `scrubFocus`.
               scrubFocus={scrubbing && index === centre}

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -247,7 +247,10 @@ function DetailsFilmstripModal({
   const carryClockRef = useRef<SeamPosition | null>(null);
   // WHERE AN EASING JUMP STARTED, while it is still easing. Null the rest of
   // the time, which is nearly all of the time.
-  const [easingFrom, setEasingFrom] = useState<number | null>(null);
+  // A LANDING IN PROGRESS. `approach` is how many panels the row is displaced
+  // by, signed — non-zero on the frame it is put down, then zero for the slide
+  // itself. Null between landings, which is nearly always.
+  const [travel, setTravel] = useState<{ approach: number } | null>(null);
   const [playing, setPlaying] = useState(false);
   // A DRAG IS IN PROGRESS ON THE BAR. Distinct from `scrubbed`, which stays
   // true once the clock has been touched: this is the gesture itself, and it
@@ -402,38 +405,7 @@ function DetailsFilmstripModal({
     );
   }
 
-  // A LANDING THAT IS NOT A STEP IS A CUT.
-  //
-  // The row eases across one panel width for a swipe, a neighbour click or a
-  // step arrow, and that easing is the gesture finishing itself. A scrub
-  // release can land twenty clips away, and the same 300ms spent crossing
-  // twenty panel widths is not a move — it is every card on screen leaving to
-  // the left, most of them unmounted placeholders, with the one you asked for
-  // turning up at the end of it. Going somewhere else in the timeline is a
-  // cut, so it cuts.
-  //
-  // DONE TO THE NODE, NOT THROUGH STATE. A `cutTo` flag would have to be
-  // cleared again a render later, which is a cascading render for one frame of
-  // styling — and the frame it is trying to influence has already been
-  // decided by then. A layout effect runs after the transform is in the DOM
-  // and before the browser paints it, which is exactly the window where
-  // "arrive, do not travel" can still be said. The reflow read is what makes
-  // it stick: without it the two style writes coalesce and the transition
-  // never goes away.
   const stripRef = useRef<HTMLDivElement | null>(null);
-  const centreWasRef = useRef(centre);
-  useLayoutEffect(() => {
-    const strip = stripRef.current;
-    const jumped = Math.abs(centre - centreWasRef.current) > STEPPED_MAX;
-    centreWasRef.current = centre;
-    if (!jumped || strip === null) return;
-    strip.style.transition = "none";
-    void strip.offsetWidth;
-    const frame = requestAnimationFrame(() => {
-      strip.style.transition = "";
-    });
-    return () => cancelAnimationFrame(frame);
-  }, [centre]);
 
   // Where the BAR draws its playhead when nothing has moved it: the cut at the
   // head of the centre clip, which is the moment this view is about.
@@ -488,20 +460,26 @@ function DetailsFilmstripModal({
   // honest.
   const MOUNTED_RADIUS = Math.floor(viewCount / 2) + 1;
 
-  // HOW FAR THE ROW WILL TRAVEL RATHER THAN CUT.
+  // HOW A LANDING ARRIVES: FROM THE SIDE, NOT FROM WHERE IT WAS.
   //
-  // One panel is a step; beyond about five the ease stops reading as travel
-  // and starts reading as a whip, and the cards in between go past too fast to
-  // be anything but noise. Five is the last distance where you can still watch
-  // the row move and know where you went.
+  // The row is put down a couple of panels off, with no transition, and then
+  // slides the rest of the way in. What you see is the clip you chose coming
+  // to the middle from the side it lies on — which is the move being
+  // described, and it reads the same whether you landed two clips along or
+  // twenty.
   //
-  // THE MOUNT WINDOW IS WHY THIS IS NOT JUST A NUMBER. `MOUNTED_RADIUS` is
-  // two panels either side at three-up, so a five-panel ease would slide three
-  // EMPTY boxes past — including the card you were just on, which would blink
-  // out and leave as a placeholder. `easingFrom` widens the window to cover
-  // the whole span for the length of the animation and then lets it go again,
-  // so the travel is paid for only while it is being watched.
-  const STEPPED_MAX = 5;
+  // SLIDING THE WHOLE DISTANCE WAS THE OBVIOUS THING AND IT IS WRONG TWICE.
+  // Ten panels of travel is ten panels that have to be REAL for the length of
+  // the animation, and a full panel is a video element, a trim strip and a tag
+  // editor — the same cost `MOUNTED_RADIUS` exists to avoid, paid all at once
+  // so that it can be blurred past. And what it buys is a whip: the cards in
+  // between go by too fast to be read, so the motion says "a long way" without
+  // saying where. A fixed short approach costs two extra panels and says the
+  // one thing the movement is for — which side you came from.
+  const SLIDE_IN = 2;
+  // Slower than the 300ms a one-panel step takes, because this one is a place
+  // change rather than a nudge and wants to be seen.
+  const SLIDE_MS = 520;
 
   const chooseReach = useCallback((next: BarReach) => {
     rememberBarReach(next);
@@ -656,25 +634,50 @@ function DetailsFilmstripModal({
       // carrying the other clip's position would land you on the right card
       // showing the wrong one's time.
       carryClockRef.current = at !== null && at.clipId === clipId ? at : null;
-      // Only a jump that will actually be animated needs the panels in
-      // between: one step already has them, and a cut never shows them.
-      if (distance > 1 && distance <= STEPPED_MAX) setEasingFrom(centre);
+      // WHICH SIDE IT COMES IN FROM. A clip later in the cut lies to the
+      // right, so it arrives from the right — the row is put down displaced
+      // the other way and slides back. Capped at the real distance so a
+      // one-clip landing slides one panel rather than overshooting to make up
+      // the full approach.
+      const direction = to < 0 ? 0 : Math.sign(to - centre);
+      const slide = Math.min(SLIDE_IN, distance);
+      setTravel({ approach: direction === 0 ? 0 : -direction * slide });
       onOpenNeighbour(clipId);
     },
-    [STEPPED_MAX, centre, ids, node.id, onOpenNeighbour],
+    [SLIDE_IN, centre, ids, node.id, onOpenNeighbour],
   );
 
-  // LET GO AGAIN once the row has arrived. Slightly longer than the 300ms
-  // ease, so the last frame is still covered; cleared on a timer rather than
-  // on `transitionend`, which does not fire when a second landing interrupts
-  // the first and would strand the window open.
-  useEffect(() => {
-    if (easingFrom === null) return;
-    const timer = setTimeout(() => setEasingFrom(null), 360);
-    return () => clearTimeout(timer);
-  }, [easingFrom]);
+  // PUT DOWN, THEN RELEASED — the two halves of the arrival, and they must be
+  // two separate frames or there is no transition to run. The layout effect
+  // paints the displaced position with the transition off, and only once the
+  // browser has actually shown it does the next frame ask for the real one.
+  useLayoutEffect(() => {
+    if (travel === null || travel.approach === 0) return;
+    const strip = stripRef.current;
+    if (strip !== null) {
+      strip.style.transition = "none";
+      // The reflow is load-bearing: without it the two style writes coalesce
+      // and the row simply appears in its final place.
+      void strip.offsetWidth;
+    }
+    const frame = requestAnimationFrame(() => {
+      if (strip !== null) strip.style.transition = "";
+      setTravel({ approach: 0 });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [travel]);
 
-  const offset = centre < 0 ? 0 : centre - (ids.length - 1) / 2;
+  // AND LET THE EXTRA PANELS GO once it has arrived. On a timer rather than
+  // on `transitionend`, which does not fire when a second landing interrupts
+  // the first and would strand the widened mount window open.
+  useEffect(() => {
+    if (travel === null || travel.approach !== 0) return;
+    const timer = setTimeout(() => setTravel(null), SLIDE_MS + 60);
+    return () => clearTimeout(timer);
+  }, [SLIDE_MS, travel]);
+
+  const offset =
+    centre < 0 ? 0 : centre - (ids.length - 1) / 2 + (travel?.approach ?? 0);
 
   // SWIPING THE STRIP. The same instruction as clicking a neighbour, held:
   // drag the film and it follows the hand, let go past a threshold and it
@@ -977,26 +980,26 @@ function DetailsFilmstripModal({
           // landing on the next clip is animated and letting go short of the
           // threshold springs back.
           //
-          // A LANDING FURTHER OFF THAN `STEPPED_MAX` is cut rather than
-          // eased, but not from here — see the layout effect above, which
-          // suppresses this for the single frame the jump paints in.
+          // A LANDING RUNS LONGER THAN A STEP — see `SLIDE_MS` — and the
+          // frame it is put down on has no transition at all, which the
+          // layout effect above does to the node rather than from here.
           dragPx === 0
-            ? "transition-transform duration-300 ease-out motion-reduce:transition-none"
+            ? "transition-transform ease-out motion-reduce:transition-none"
             : "",
         ].join(" ")}
         style={{
           gap: PANEL_GAP,
           transform: rowTransform,
+          transitionDuration: travel === null ? "300ms" : `${SLIDE_MS}ms`,
         }}
       >
         {ids.map((id, index) => {
-          // Within the resting window, OR anywhere along a span the row is
-          // currently easing across — see `easingFrom`.
+          // The resting window, widened by the approach while a landing is in
+          // flight: the panels the row slides over are off the side of the
+          // resting window, and empty boxes sliding in is exactly what the
+          // movement is meant to avoid. Two extra panels, for half a second.
           const mounted =
-            Math.abs(index - centre) <= MOUNTED_RADIUS ||
-            (easingFrom !== null &&
-              index >= Math.min(easingFrom, centre) &&
-              index <= Math.max(easingFrom, centre));
+            Math.abs(index - centre) <= MOUNTED_RADIUS + (travel === null ? 0 : SLIDE_IN);
           const panel = mounted ? graph.nodesById.get(parseNodeId(id)) : null;
           const media =
             panel && panel.kind === "media" && (panel as MediaNode).src

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -1137,7 +1137,29 @@ function DetailsFilmstripModal({
               monitor={
                 index === centre && monitorNode && position
                   ? { node: monitorNode, seconds: position.clipSeconds }
-                  : null
+                  : // THE PANEL UNDER THE PLAYHEAD KEEPS ITSELF AT THE
+                    // PLAYHEAD, even while it is a neighbour.
+                    //
+                    // This is what makes letting go seamless. Without it, a
+                    // clip is resting on its own first frame right up until
+                    // the moment it becomes the centre, and only then starts
+                    // seeking — so the release reads as: the right frame (in
+                    // the outgoing centre, which was monitoring it), a cut,
+                    // the FIRST frame, and a skip back to the right one. The
+                    // poster fix cannot help here, because this element
+                    // already has a decoded frame; it is simply the wrong one.
+                    //
+                    // Seeking it early means the panel is already showing the
+                    // landed frame before it is asked to be the subject, and
+                    // the cut has nothing left to change.
+                    //
+                    // ONE EXTRA ELEMENT SEEKING, not nine: exactly one panel
+                    // is under the playhead at a time, and it is the one whose
+                    // frame is about to be wanted. The scrub proxy covers it
+                    // for the same reason it covers the centre.
+                    position !== null && position.clipId === id
+                    ? { node: media, seconds: position.clipSeconds }
+                    : null
               }
               // Only the monitor makes sound: it is the panel showing what the
               // clock says is on screen, so it is the only one whose audio
@@ -1148,7 +1170,11 @@ function DetailsFilmstripModal({
               // dragged: the neighbours are context, and enlarging them would
               // be enlarging the thing you are trying to look past.
               magnified={index === centre && scrubbing}
-              scrubbing={index === centre && scrubbing}
+              // The proxy follows the seeking, not the centring: a neighbour
+              // tracking the playhead is doing the same expensive thing the
+              // centre is, and a full-res seek per pointer move is what the
+              // proxy exists to avoid.
+              scrubbing={scrubbing && (index === centre || position?.clipId === id)}
               swipe={swipe}
               width={panelWidth}
               // Engaged, and not the one being watched. Uses the same gate as

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -616,6 +616,16 @@ function DetailsFilmstripModal({
         collectionId: parentId === null ? null : (parentId as string),
         collectionName: parent?.name ?? null,
         ...(media === null ? {} : { posterSrc: seamClipOf(media)?.posterSrc }),
+        // ONLY A VIDEO GETS THE FULL SET. A still's single image sampled at
+        // ten intervals is ten copies of itself, which is a filmstrip saying
+        // nothing happens — worse than the one frame it is made of. Leaving
+        // these off is what makes the bar fall back to `cover` for it.
+        ...(media !== null && media.mediaKind === "video" && media.posterSrcs !== undefined
+          ? {
+              posterSrcs: media.posterSrcs,
+              trimInSeconds: seamClipOf(media)?.trimInSeconds ?? 0,
+            }
+          : {}),
       };
     });
   }, [barWindow, graph]);

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-monitor.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-monitor.tsx
@@ -13,6 +13,7 @@ import { DETAILS_HERO_FILL_CLASS } from "./graph-view-config";
 import { useSeekedVideo } from "@/hooks/use-seeked-video";
 import { cloudinaryScrubProxySrc } from "@/lib/cloudinary-scrub-proxy";
 import { useFrameCrossfade } from "@/hooks/use-frame-crossfade";
+import { monitorPosterUrl } from "@/lib/video-frame-url";
 import { formatSeconds } from "@/lib/format-duration";
 import { HERO } from "./graph-item-details-shared";
 import type { LiveTrim } from "@storyboard/ui/dnd-collections";
@@ -93,6 +94,15 @@ export function ItemDetailsMonitor({
   // still in flight — and the hook simply scrubs the real element then, which
   // is what it always did.
   const scrubProxySrc = shownVideo?.src ? cloudinaryScrubProxySrc(shownVideo.src) : null;
+  // See the `poster` below: the frame the element is ABOUT to seek to, so the
+  // picture it paints before it has decoded anything is already the right one.
+  // The builder returns its input unchanged for anything it cannot
+  // transform — a fixture, an upload still in flight — so the fallback is the
+  // opening frame, which is what this always used.
+  const posterAtRawTime = monitorPosterUrl(
+    shownVideo?.posterSrcs?.[0],
+    monitor ? rawTime : null,
+  );
   const { videoRef, proxyRef, showProxy } = useSeekedVideo(
     Math.round(rawTime * 25) / 25,
     shownVideo !== null || shownAudio !== null,
@@ -162,7 +172,22 @@ export function ItemDetailsMonitor({
             crossfadeVideoRef.current = element;
           }}
           src={shownVideo.src}
-          poster={shownVideo.posterSrcs?.[0]}
+          // THE POSTER IS THE FRAME BEING ASKED FOR, not the clip's first.
+          //
+          // Letting go of the bar gives the landed clip its OWN panel, and a
+          // fresh `<video>` has no frame yet — so it paints its poster, and
+          // the poster used to be `posterSrcs[0]`. That is the clip's opening
+          // frame, which is almost never where the playhead is: you saw the
+          // right frame while scrubbing (the old panel's monitor was showing
+          // it), then the first frame, then a skip to the right one again as
+          // the seek landed. The frame was never lost — it was re-acquired in
+          // public.
+          //
+          // Pointing the poster at the SAME time the element is seeking to
+          // makes the two agree, so the swap from poster to decoded frame is
+          // invisible. Falls back to the opening frame when there is no clock
+          // to ask, which is a resting neighbour and exactly right for one.
+          poster={posterAtRawTime}
           // UNMUTED WHILE PLAYING. Judging a cut is not only a picture
           // problem — a line landing across the join, or music that
           // stops dead on it, is the thing being looked for as often as

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
@@ -43,6 +43,7 @@ export function DetailsPanel({
   node,
   centre,
   monitor,
+  swapping = false,
   playhead,
   playing = false,
   playingHere = false,
@@ -82,6 +83,16 @@ export function DetailsPanel({
    * to panel at the moment of the cut is an eye that misses the cut.
    */
   monitor: Readonly<{ node: MediaNode; seconds: number }> | null;
+  /**
+   * Fade in rather than appear, because the row cut to a new place instead of
+   * travelling to it.
+   *
+   * Only ever set on a NEIGHBOUR. The centre card is the reason the row cut at
+   * all — it has been the monitor for the whole scrub, so it is already
+   * showing the clip that was landed on, and fading it would flicker the one
+   * picture on screen that did not change.
+   */
+  swapping?: boolean;
   /**
    * How far through this clip's own trimmed range the playhead is, 0-1, or null
    * when the playhead is not inside this clip at all. Drawn as a line on the
@@ -292,6 +303,7 @@ export function DetailsPanel({
         // that was opened. The neighbours are working panels, not focus traps.
         {...(centre ? dialogProps : {})}
         data-item-details-panel={centre ? "centre" : "neighbour"}
+        data-item-details-swapping={swapping && !centre ? "" : undefined}
         // WHAT FRAME THIS PANEL IS SHOWING, when the clock is what put it
         // there. Absent on a panel resting on its own first frame, which is a
         // different state from "at zero seconds" and the one an untouched view
@@ -327,6 +339,9 @@ export function DetailsPanel({
         // — and answers it constantly, which means it never moves and never
         // pulls the eye.
         className={[
+          // FADE IN, because the row cut here rather than travelling. See
+          // `swapping` — never on the centre, which did not change.
+          swapping && !centre ? "animate-seam-panel-swap" : "",
           // MID-SCRUB, EVERYTHING BUT THE PICTURE GOES OUT. The frame excludes
           // itself by name, so the one thing being judged keeps full strength
           // while the header, the strip, the numbers and the tags recede. A

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
@@ -342,6 +342,24 @@ export function DetailsPanel({
           // FADE IN, because the row cut here rather than travelling. See
           // `swapping` — never on the centre, which did not change.
           swapping && !centre ? "animate-seam-panel-swap" : "",
+          // AND NOTHING ELSE ANIMATES WHILE IT DOES.
+          //
+          // A landing leaves the clock engaged, so every neighbour is newly
+          // `dimmed` and starts its own 300ms `transition-[opacity,filter]` in
+          // the same frame this fade begins. Two nested opacity animations is
+          // already one too many; the second of them also animates a GRAYSCALE
+          // FILTER, and a filter over a `<video>` that is still fetching and
+          // decoding its first frame is repainted from the decoder every tick.
+          // That is why this was smooth on stills and not on video — an `<img>`
+          // is a static bitmap and costs nothing to re-filter.
+          //
+          // So the incoming panel arrives already dimmed and already drained,
+          // and the only thing that moves is the fade. Higher specificity than
+          // the utility it overrides (a descendant selector against a single
+          // class), so it needs no important modifier.
+          swapping && !centre
+            ? "[&_[data-item-details-frame]]:transition-none"
+            : "",
           // MID-SCRUB, EVERYTHING BUT THE PICTURE GOES OUT. The frame excludes
           // itself by name, so the one thing being judged keeps full strength
           // while the header, the strip, the numbers and the tags recede. A

--- a/apps/timeline-gstudio001/components/graph-view/graph-playbar-thumbnails.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playbar-thumbnails.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+/**
+ * Whether the play bar draws each clip's FIRST FRAME instead of a grey box.
+ *
+ * OFF BY DEFAULT, and the default is the argument for it being a setting.
+ * A bar of thumbnails answers "which shot is that" without a hover, which is
+ * the whole reason to want it. What it costs is the thing the grey bar is
+ * good at: box widths are durations, and a run of even grey reads as rhythm —
+ * where the cuts fall, which shots are long, where the pace changes. Put
+ * pictures in them and the eye reads the pictures, because it always will.
+ *
+ * IT IS ALSO NOT FREE. A box's width is its duration, so at a wide reach the
+ * short clips are a few pixels across and their frames are unreadable smears
+ * — the same picture that helps at ten clips is noise at a hundred. Leaving
+ * this off by default means the expensive answer is the one you ask for.
+ *
+ * A CONTEXT, NOT A PROP, for the reason `ClipNamesProvider` gives: the
+ * consumer is several layers down inside a portalled dialog, the value is
+ * constant across the board, and it changes only when someone opens a menu.
+ *
+ * DEFAULTS TO FALSE WITH NO PROVIDER, so a bar rendered outside the board —
+ * a story, most of all — behaves like the shipped default rather than
+ * throwing or silently opting in.
+ */
+const PlaybarThumbnailsContext = createContext(false);
+
+export function PlaybarThumbnailsProvider({
+  shown,
+  children,
+}: Readonly<{ shown: boolean; children: React.ReactNode }>) {
+  return (
+    <PlaybarThumbnailsContext.Provider value={shown}>
+      {children}
+    </PlaybarThumbnailsContext.Provider>
+  );
+}
+
+/** Whether the play bar should draw frames rather than grey boxes. */
+export function usePlaybarThumbnails(): boolean {
+  return useContext(PlaybarThumbnailsContext);
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-playbar-thumbnails.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playbar-thumbnails.tsx
@@ -1,44 +1,85 @@
 "use client";
 
-import { createContext, useContext } from "react";
+import { createContext, useContext, useMemo } from "react";
 
 /**
- * Whether the play bar draws each clip's FIRST FRAME instead of a grey box.
+ * How the play bar draws a clip: as nothing, as one frame, or as a strip.
+ *
+ * `cover` is ONE frame filling the box — the clip's opening image, stretched
+ * to whatever shape its duration makes the box. It answers "which shot is
+ * that" and nothing else.
+ *
+ * `filmstrip` is a row of square cells sampled at even intervals across the
+ * clip. It answers a second question the single frame cannot: what HAPPENS in
+ * the shot. A long take that opens on a closed door and ends on an empty room
+ * is one picture at `cover` and a story at `filmstrip`.
+ *
+ * The cost runs the other way. A strip is several images per box instead of
+ * one, and at a wide reach — where boxes are a few pixels across — it is
+ * several images per box that nobody can see. Which is the argument for it
+ * being a choice rather than an upgrade.
+ */
+export const PLAYBAR_THUMBNAIL_STYLES = ["cover", "filmstrip"] as const;
+export type PlaybarThumbnailStyle = (typeof PLAYBAR_THUMBNAIL_STYLES)[number];
+
+export function isPlaybarThumbnailStyle(value: string): value is PlaybarThumbnailStyle {
+  return (PLAYBAR_THUMBNAIL_STYLES as readonly string[]).includes(value);
+}
+
+export type PlaybarThumbnails = Readonly<{
+  shown: boolean;
+  style: PlaybarThumbnailStyle;
+}>;
+
+/**
+ * Whether the play bar draws frames instead of grey boxes, and how.
  *
  * OFF BY DEFAULT, and the default is the argument for it being a setting.
- * A bar of thumbnails answers "which shot is that" without a hover, which is
- * the whole reason to want it. What it costs is the thing the grey bar is
- * good at: box widths are durations, and a run of even grey reads as rhythm —
- * where the cuts fall, which shots are long, where the pace changes. Put
- * pictures in them and the eye reads the pictures, because it always will.
+ * A bar of frames answers "which shot is that" without a hover, which is the
+ * whole reason to want it. What it costs is the thing the grey bar is good at:
+ * box widths are durations, and a run of even grey reads as rhythm — where the
+ * cuts fall, which shots are long, where the pace changes. Put pictures in
+ * them and the eye reads the pictures, because it always will.
  *
- * IT IS ALSO NOT FREE. A box's width is its duration, so at a wide reach the
- * short clips are a few pixels across and their frames are unreadable smears
- * — the same picture that helps at ten clips is noise at a hundred. Leaving
- * this off by default means the expensive answer is the one you ask for.
+ * TWO SETTINGS, NOT THREE STATES IN ONE. "Show frames" and "which kind" are
+ * separate questions and stay separate controls: the style survives being
+ * switched off and on, which is what makes toggling frames a comparison you
+ * can make twice rather than a choice you re-enter each time.
  *
  * A CONTEXT, NOT A PROP, for the reason `ClipNamesProvider` gives: the
  * consumer is several layers down inside a portalled dialog, the value is
  * constant across the board, and it changes only when someone opens a menu.
  *
- * DEFAULTS TO FALSE WITH NO PROVIDER, so a bar rendered outside the board —
- * a story, most of all — behaves like the shipped default rather than
- * throwing or silently opting in.
+ * DEFAULTS TO OFF WITH NO PROVIDER, so a bar rendered outside the board — a
+ * story, most of all — behaves like the shipped default rather than throwing
+ * or silently opting in.
  */
-const PlaybarThumbnailsContext = createContext(false);
+const PlaybarThumbnailsContext = createContext<PlaybarThumbnails>({
+  shown: false,
+  style: "cover",
+});
 
 export function PlaybarThumbnailsProvider({
   shown,
+  style = "cover",
   children,
-}: Readonly<{ shown: boolean; children: React.ReactNode }>) {
+}: Readonly<{
+  shown: boolean;
+  style?: PlaybarThumbnailStyle;
+  children: React.ReactNode;
+}>) {
+  // Memoized because the value is an object: a fresh one every render would
+  // re-render every consumer on every render of the board, which is the exact
+  // cost a context is being used here to avoid.
+  const value = useMemo(() => ({ shown, style }), [shown, style]);
   return (
-    <PlaybarThumbnailsContext.Provider value={shown}>
+    <PlaybarThumbnailsContext.Provider value={value}>
       {children}
     </PlaybarThumbnailsContext.Provider>
   );
 }
 
-/** Whether the play bar should draw frames rather than grey boxes. */
-export function usePlaybarThumbnails(): boolean {
+/** Whether the play bar should draw frames rather than grey boxes, and how. */
+export function usePlaybarThumbnails(): PlaybarThumbnails {
   return useContext(PlaybarThumbnailsContext);
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-playbar-thumbnails.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playbar-thumbnails.tsx
@@ -83,3 +83,25 @@ export function PlaybarThumbnailsProvider({
 export function usePlaybarThumbnails(): PlaybarThumbnails {
   return useContext(PlaybarThumbnailsContext);
 }
+
+/**
+ * The last answers chosen, kept at module scope.
+ *
+ * Deliberately NOT persisted, for the same reason the view count and the reach
+ * are not: these are a working posture for a session rather than preferences,
+ * and a board reopened tomorrow should start on the plain bar. Held here
+ * rather than in the view that renders the controls so that closing the
+ * details modal and opening another clip does not reset them — the modal
+ * unmounts, and state inside it would go with it.
+ */
+let rememberedShown = false;
+let rememberedStyle: PlaybarThumbnailStyle = "cover";
+
+export function lastPlaybarThumbnails(): PlaybarThumbnails {
+  return { shown: rememberedShown, style: rememberedStyle };
+}
+
+export function rememberPlaybarThumbnails(next: PlaybarThumbnails): void {
+  rememberedShown = next.shown;
+  rememberedStyle = next.style;
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-bar-layout.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-bar-layout.ts
@@ -24,6 +24,14 @@ export type SeamBarClip = Readonly<{
   collectionId: string | null;
   collectionName: string | null;
   posterSrc?: string;
+  /** Every poster the clip has, for sampling a strip of frames across it.
+   *  Present only for VIDEO — a still has one image and a row of copies of it
+   *  is a filmstrip of nothing happening, so stills draw the single frame
+   *  whatever the style says. */
+  posterSrcs?: readonly string[];
+  /** Where the visible range starts in the source, so sampled frames land
+   *  inside the part of the clip that actually plays. */
+  trimInSeconds?: number;
 }>;
 
 /**

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -5,6 +5,7 @@ import { useEffect, useLayoutEffect, useRef } from "react";
 import { BAR_NEUTRAL_COLOUR } from "@/lib/bar-collection-colours-flag";
 
 import { collectionSeams, type SeamBarClip } from "./graph-seam-bar-layout";
+import { usePlaybarThumbnails } from "./graph-playbar-thumbnails";
 import type { SeamStrip } from "./graph-seam-strip";
 
 /**
@@ -135,6 +136,7 @@ export function SeamLane({
   // cleared a render later — a cascading render to describe half a second of
   // styling. The pointer handler clears it early so a drag begun mid-slide is
   // still exact from its first frame.
+  const thumbnails = usePlaybarThumbnails();
   const stripRef = useRef<HTMLDivElement | null>(null);
   const centreWasRef = useRef(centreClipId);
   const offsetWasRef = useRef(offset);
@@ -215,14 +217,48 @@ export function SeamLane({
                 style={{
                   left: segment.leftPx + BOX_INSET_PX,
                   width: Math.max(2, segment.widthPx - BOX_INSET_PX * 2),
+                  // THE COLOUR STAYS UNDER THE PICTURE. A frame that has not
+                  // loaded yet, or a clip that has no poster at all, leaves
+                  // the box exactly as it is without the setting — so turning
+                  // thumbnails on can add pictures but can never subtract the
+                  // bar.
                   backgroundColor: colour,
                 }}
                 className="absolute inset-y-0 flex items-center justify-center overflow-hidden rounded-[3px]"
               >
+                {thumbnails && segment.posterSrc !== undefined ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    data-seam-thumbnail={segment.clipId}
+                    src={segment.posterSrc}
+                    alt=""
+                    aria-hidden="true"
+                    // COVER, and no more. The box's width is its duration and
+                    // its height is the bar's, so the frame it holds is
+                    // whatever shape that comes out as — cropping to fill is
+                    // the only fit that keeps every box the same height and
+                    // the run of them still readable as a strip. A `contain`
+                    // fit would letterbox each clip differently and turn the
+                    // bar into a row of unrelated shapes.
+                    className="absolute inset-0 h-full w-full object-cover"
+                    // The bar can hold a hundred of these and none of them is
+                    // the thing being read on arrival.
+                    loading="lazy"
+                    decoding="async"
+                    draggable={false}
+                  />
+                ) : null}
                 {isCentre && segment.widthPx >= 16 ? (
                   <span
                     data-seam-marker
-                    className="h-3 w-3 rounded-full bg-black/50"
+                    // Above the frame once there is one, and darker for it: a
+                    // 50% black dot reads on grey and disappears into a busy
+                    // picture, which is the one box it has to be findable in.
+                    className={
+                      thumbnails
+                        ? "relative z-10 h-3 w-3 rounded-full bg-black/70 ring-1 ring-white/70"
+                        : "h-3 w-3 rounded-full bg-black/50"
+                    }
                   />
                 ) : null}
               </span>

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -174,30 +174,35 @@ const BOX_INSET_PX = 2.5;
  * WHAT SEPARATES TWO BOXES ONCE THEY HOLD PICTURES.
  *
  * The gap between boxes is `BOX_INSET_PX` either side — five pixels of the
- * lane showing through. Against flat grey that is plenty: two greys with a
- * dark line between them is obviously two things. Between two frames it
- * disappears, and the reason is that the lane is DARK: a photograph already
- * contains dark edges, so a dark gap is just one more of them and the eye has
- * no reason to read that particular one as a boundary.
+ * strip showing through. Against flat grey that is plenty. Between two frames
+ * it disappears, and NO SINGLE COLOUR FIXES IT, which is the whole design
+ * problem here: a dark gap is invisible between two dark frames, a pale one is
+ * invisible between two bright frames, and footage supplies both within the
+ * same cut. Picking either is picking which half of the timeline to fail on.
  *
- * SO THE GAP ITSELF CHANGES COLOUR, rather than the boxes growing an edge.
- * A pale gap is not a colour footage supplies, which is exactly what makes it
- * read as structure instead of as picture — and it separates a dark frame from
- * a bright one just as well as two dark ones, which a fixed hairline in either
- * direction does not.
+ * SO THE GAP CARRIES BOTH TONES. The strip's own background is pale and each
+ * box casts a dark ring one pixel into the gap either side of it, which makes
+ * every gap read dark · pale · dark whatever is beside it:
+ *
+ *     two bright frames   white | DARK pale DARK | white   ← the rings show
+ *     two dark frames     black | dark PALE dark | black   ← the core shows
+ *     one of each         both, from opposite sides
+ *
+ * There is no arrangement of neighbours where neither tone has contrast,
+ * which is what "works on both" has to mean. The alternative — a colour no
+ * footage supplies, a saturated cyan or magenta — would also always show, and
+ * would turn a bar you read for rhythm into a bar you read for stripes.
  *
  * WIDENING IT IS THE WRONG FIX, and not only because it was asked against: a
  * box's width IS its duration, so spending more of it on separation makes
- * short clips read shorter and changes what the bar is saying. This costs no
- * layout at all — the gap is already there, it is simply a different colour.
+ * short clips read shorter and changes what the bar is saying. None of this
+ * costs layout — the gap is already there, and a ring paints outside the box.
  *
- * The hairline that remains is the other half of the same problem: a bright
- * frame running straight into a pale gap has no edge either, so each box keeps
- * a dark one just inside its own border. Only when frames are on; over grey
- * the whole treatment is decoration answering a question nobody asked.
+ * Only when frames are on. Over grey the whole treatment is decoration
+ * answering a question nobody asked.
  */
 const FRAMED_GAP_COLOUR = "rgba(212, 212, 216, 0.92)";
-const FRAMED_BOX_EDGE = "inset 0 0 0 1px rgba(0, 0, 0, 0.55)";
+const FRAMED_BOX_EDGE = "0 0 0 1px rgba(0, 0, 0, 0.78)";
 
 export type SeamHover = Readonly<{
   /** Absolute strip pixels. */
@@ -366,8 +371,8 @@ export function SeamLane({
                   // thumbnails on can add pictures but can never subtract the
                   // bar.
                   backgroundColor: colour,
-                  // See `FRAMED_BOX_EDGE`: the gap between two pictures has to
-                  // be drawn, where the gap between two greys did not.
+                  // See `FRAMED_BOX_EDGE`: the ring is the dark half of the
+                  // gap, and the strip's own background is the pale half.
                   ...(thumbnails.shown ? { boxShadow: FRAMED_BOX_EDGE } : {}),
                 }}
                 className="absolute inset-y-0 flex items-center justify-center overflow-hidden rounded-[3px]"

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -170,6 +170,30 @@ function SnapPulse({ snapKey }: Readonly<{ snapKey: number }>) {
  */
 const BOX_INSET_PX = 2.5;
 
+/**
+ * WHAT SEPARATES TWO BOXES ONCE THEY HOLD PICTURES.
+ *
+ * The gap between boxes is `BOX_INSET_PX` either side — five pixels of the
+ * lane showing through. Against flat grey that is plenty: two greys with a
+ * dark line between them is obviously two things. Between two frames it
+ * disappears, because a photograph already contains dark edges and the eye has
+ * no reason to read that particular one as a boundary rather than as part of
+ * the picture.
+ *
+ * WIDENING THE GAP IS THE WRONG FIX. A box's width is its duration; spending
+ * more of it on separation makes short clips shorter and changes what the bar
+ * is saying. So the boundary is painted rather than made bigger: a light
+ * hairline INSIDE each box's own edge, which reads as the frame line of a
+ * physical strip, and a dark one just outside it, which deepens the gap that
+ * is already there. Neither takes a pixel of layout — an inset shadow paints
+ * within the box and an outer one paints into the gap.
+ *
+ * Only when frames are on. Over grey the same treatment is a hairline on a
+ * flat colour, which is decoration answering a question nobody asked.
+ */
+const FRAMED_BOX_EDGE =
+  "inset 0 0 0 1px rgba(255, 255, 255, 0.55), 0 0 0 1px rgba(0, 0, 0, 0.85)";
+
 export type SeamHover = Readonly<{
   /** Absolute strip pixels. */
   x: number;
@@ -330,6 +354,9 @@ export function SeamLane({
                   // thumbnails on can add pictures but can never subtract the
                   // bar.
                   backgroundColor: colour,
+                  // See `FRAMED_BOX_EDGE`: the gap between two pictures has to
+                  // be drawn, where the gap between two greys did not.
+                  ...(thumbnails.shown ? { boxShadow: FRAMED_BOX_EDGE } : {}),
                 }}
                 className="absolute inset-y-0 flex items-center justify-center overflow-hidden rounded-[3px]"
               >

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -181,28 +181,37 @@ const BOX_INSET_PX = 2.5;
  * same cut. Picking either is picking which half of the timeline to fail on.
  *
  * SO THE GAP CARRIES BOTH TONES. The strip's own background is pale and each
- * box casts a dark ring one pixel into the gap either side of it, which makes
- * every gap read dark · pale · dark whatever is beside it:
+ * box casts a dark ring into the gap either side of it, which makes every gap
+ * read dark · pale · dark whatever is beside it:
  *
  *     two bright frames   white | DARK pale DARK | white   ← the rings show
  *     two dark frames     black | dark PALE dark | black   ← the core shows
  *     one of each         both, from opposite sides
+ *
+ *                         |<-1.5->|<-2->|<-1.5->|   of the 5px already there
  *
  * There is no arrangement of neighbours where neither tone has contrast,
  * which is what "works on both" has to mean. The alternative — a colour no
  * footage supplies, a saturated cyan or magenta — would also always show, and
  * would turn a bar you read for rhythm into a bar you read for stripes.
  *
- * WIDENING IT IS THE WRONG FIX, and not only because it was asked against: a
- * box's width IS its duration, so spending more of it on separation makes
- * short clips read shorter and changes what the bar is saying. None of this
- * costs layout — the gap is already there, and a ring paints outside the box.
+ * THE THREE BANDS SHARE THE FIVE PIXELS THAT WERE ALREADY THERE: 1.5px of
+ * dark, 2px of pale, 1.5px of dark. The first pass gave the pale core three of
+ * the five and the dark barely registered against a bright frame — a white
+ * band with a hairline either side reads as a white band. Roughly equal thirds
+ * read as a rule.
+ *
+ * WIDENING THE GAP IS THE WRONG FIX, and not only because it was asked
+ * against: a box's width IS its duration, so spending more of it on separation
+ * makes short clips read shorter and changes what the bar is saying. None of
+ * this costs layout — the gap is already there, the bands only divide it, and
+ * a ring paints outside the box rather than over the picture.
  *
  * Only when frames are on. Over grey the whole treatment is decoration
  * answering a question nobody asked.
  */
 const FRAMED_GAP_COLOUR = "rgba(212, 212, 216, 0.92)";
-const FRAMED_BOX_EDGE = "0 0 0 1px rgba(0, 0, 0, 0.78)";
+const FRAMED_BOX_EDGE = "0 0 0 1.5px rgba(0, 0, 0, 0.82)";
 
 export type SeamHover = Readonly<{
   /** Absolute strip pixels. */

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -176,23 +176,28 @@ const BOX_INSET_PX = 2.5;
  * The gap between boxes is `BOX_INSET_PX` either side — five pixels of the
  * lane showing through. Against flat grey that is plenty: two greys with a
  * dark line between them is obviously two things. Between two frames it
- * disappears, because a photograph already contains dark edges and the eye has
- * no reason to read that particular one as a boundary rather than as part of
- * the picture.
+ * disappears, and the reason is that the lane is DARK: a photograph already
+ * contains dark edges, so a dark gap is just one more of them and the eye has
+ * no reason to read that particular one as a boundary.
  *
- * WIDENING THE GAP IS THE WRONG FIX. A box's width is its duration; spending
- * more of it on separation makes short clips shorter and changes what the bar
- * is saying. So the boundary is painted rather than made bigger: a light
- * hairline INSIDE each box's own edge, which reads as the frame line of a
- * physical strip, and a dark one just outside it, which deepens the gap that
- * is already there. Neither takes a pixel of layout — an inset shadow paints
- * within the box and an outer one paints into the gap.
+ * SO THE GAP ITSELF CHANGES COLOUR, rather than the boxes growing an edge.
+ * A pale gap is not a colour footage supplies, which is exactly what makes it
+ * read as structure instead of as picture — and it separates a dark frame from
+ * a bright one just as well as two dark ones, which a fixed hairline in either
+ * direction does not.
  *
- * Only when frames are on. Over grey the same treatment is a hairline on a
- * flat colour, which is decoration answering a question nobody asked.
+ * WIDENING IT IS THE WRONG FIX, and not only because it was asked against: a
+ * box's width IS its duration, so spending more of it on separation makes
+ * short clips read shorter and changes what the bar is saying. This costs no
+ * layout at all — the gap is already there, it is simply a different colour.
+ *
+ * The hairline that remains is the other half of the same problem: a bright
+ * frame running straight into a pale gap has no edge either, so each box keeps
+ * a dark one just inside its own border. Only when frames are on; over grey
+ * the whole treatment is decoration answering a question nobody asked.
  */
-const FRAMED_BOX_EDGE =
-  "inset 0 0 0 1px rgba(255, 255, 255, 0.55), 0 0 0 1px rgba(0, 0, 0, 0.85)";
+const FRAMED_GAP_COLOUR = "rgba(212, 212, 216, 0.92)";
+const FRAMED_BOX_EDGE = "inset 0 0 0 1px rgba(0, 0, 0, 0.55)";
 
 export type SeamHover = Readonly<{
   /** Absolute strip pixels. */
@@ -333,7 +338,14 @@ export function SeamLane({
           ref={stripRef}
           data-seam-strip
           className="absolute inset-y-0 left-0 will-change-transform"
-          style={{ transform: `translateX(${offset}px)`, width: strip.totalPx }}
+          style={{
+            transform: `translateX(${offset}px)`,
+            width: strip.totalPx,
+            // THE GAPS ARE THIS SHOWING THROUGH. The boxes are opaque and
+            // absolutely positioned over it, so the only part of this that is
+            // ever visible is the space between them — see `FRAMED_GAP_COLOUR`.
+            ...(thumbnails.shown ? { backgroundColor: FRAMED_GAP_COLOUR } : {}),
+          }}
         >
           {strip.segments.map((segment) => {
             if (segment.widthPx <= 0) return null;

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -1,11 +1,15 @@
 "use client";
 
-import { useEffect, useLayoutEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
 
 import { BAR_NEUTRAL_COLOUR } from "@/lib/bar-collection-colours-flag";
 
 import { collectionSeams, type SeamBarClip } from "./graph-seam-bar-layout";
-import { usePlaybarThumbnails } from "./graph-playbar-thumbnails";
+import {
+  usePlaybarThumbnails,
+  type PlaybarThumbnailStyle,
+} from "./graph-playbar-thumbnails";
+import { videoFrameUrls } from "@/lib/video-frame-url";
 import type { SeamStrip } from "./graph-seam-strip";
 
 /**
@@ -16,6 +20,107 @@ import type { SeamStrip } from "./graph-seam-strip";
  * somewhere else and a jump cannot be told apart from a redraw.
  */
 const SEAM_SLIDE_MS = 520;
+
+/** Roughly the bar's own height (`h-9`), so a cell reads as a square. */
+const FILMSTRIP_CELL_PX = 36;
+/** Past this the cells stretch rather than multiply — see `SegmentFrames`. */
+const MAX_FILMSTRIP_CELLS = 12;
+
+/**
+ * WHAT FILLS ONE BOX when frames are switched on: a single frame, or a row of
+ * them sampled across the clip.
+ *
+ * Its own component so the cell arithmetic is not inlined in the middle of the
+ * strip's layout, and so React can skip a box whose inputs did not change —
+ * the bar re-renders on every pointer move during a drag, and rebuilding a
+ * dozen image lists per box per frame is exactly the cost this is not worth.
+ */
+function SegmentFrames({
+  clipId,
+  clip,
+  posterSrc,
+  widthPx,
+  style,
+}: Readonly<{
+  clipId: string;
+  clip: SeamBarClip | undefined;
+  posterSrc: string | undefined;
+  widthPx: number;
+  style: PlaybarThumbnailStyle;
+}>) {
+  // HOW MANY CELLS FIT, at roughly one per bar-height so each reads as a
+  // square. Capped, because a long clip at a high zoom is a box thousands of
+  // pixels wide and one image per 36px of it is a hundred requests for a
+  // single shot. Past the cap the cells stretch rather than multiply, which
+  // is the honest trade: still evenly spaced across the clip, just wider than
+  // they are tall.
+  const cells = useMemo(() => {
+    if (style !== "filmstrip" || clip?.posterSrcs === undefined) return null;
+    const wanted = Math.min(
+      MAX_FILMSTRIP_CELLS,
+      Math.max(1, Math.round(widthPx / FILMSTRIP_CELL_PX)),
+    );
+    const urls = videoFrameUrls(clip.posterSrcs, wanted, {
+      trimInSeconds: clip.trimInSeconds ?? 0,
+      effectiveSeconds: clip.showingSeconds,
+    });
+    return urls.length === 0 ? null : urls;
+  }, [clip, style, widthPx]);
+
+  if (cells !== null) {
+    return (
+      <span
+        data-seam-filmstrip={clipId}
+        className="absolute inset-0 flex"
+        aria-hidden="true"
+      >
+        {cells.map((url, index) => (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            // The URL is not unique — a clip short enough that two slots land
+            // on the same frame gives the same string twice — so the index is
+            // the only stable identity here.
+            key={index}
+            data-seam-thumbnail={clipId}
+            src={url}
+            alt=""
+            aria-hidden="true"
+            // `flex-1` rather than a fixed width, so the cells divide the box
+            // exactly and there is never a grey tail at the end of a strip.
+            className="h-full min-w-0 flex-1 object-cover"
+            loading="lazy"
+            decoding="async"
+            draggable={false}
+          />
+        ))}
+      </span>
+    );
+  }
+
+  if (posterSrc === undefined) return null;
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      data-seam-thumbnail={clipId}
+      src={posterSrc}
+      alt=""
+      aria-hidden="true"
+      // COVER, and no more. The box's width is its duration and its height is
+      // the bar's, so the frame it holds is whatever shape that comes out as —
+      // cropping to fill is the only fit that keeps every box the same height
+      // and the run of them readable as a strip. A `contain` fit would
+      // letterbox each clip differently and turn the bar into a row of
+      // unrelated shapes.
+      className="absolute inset-0 h-full w-full object-cover"
+      // The bar can hold a hundred of these and none of them is the thing
+      // being read on arrival.
+      loading="lazy"
+      decoding="async"
+      draggable={false}
+    />
+  );
+}
+
 
 /**
  * The playhead's head, and its twitch when the scrub lands on a cut.
@@ -137,6 +242,8 @@ export function SeamLane({
   // styling. The pointer handler clears it early so a drag begun mid-slide is
   // still exact from its first frame.
   const thumbnails = usePlaybarThumbnails();
+  // The clips by id, so a segment can reach its posters without a scan per box.
+  const clipById = useMemo(() => new Map(clips.map((clip) => [clip.id, clip])), [clips]);
   const stripRef = useRef<HTMLDivElement | null>(null);
   const centreWasRef = useRef(centreClipId);
   const offsetWasRef = useRef(offset);
@@ -226,26 +333,13 @@ export function SeamLane({
                 }}
                 className="absolute inset-y-0 flex items-center justify-center overflow-hidden rounded-[3px]"
               >
-                {thumbnails && segment.posterSrc !== undefined ? (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img
-                    data-seam-thumbnail={segment.clipId}
-                    src={segment.posterSrc}
-                    alt=""
-                    aria-hidden="true"
-                    // COVER, and no more. The box's width is its duration and
-                    // its height is the bar's, so the frame it holds is
-                    // whatever shape that comes out as — cropping to fill is
-                    // the only fit that keeps every box the same height and
-                    // the run of them still readable as a strip. A `contain`
-                    // fit would letterbox each clip differently and turn the
-                    // bar into a row of unrelated shapes.
-                    className="absolute inset-0 h-full w-full object-cover"
-                    // The bar can hold a hundred of these and none of them is
-                    // the thing being read on arrival.
-                    loading="lazy"
-                    decoding="async"
-                    draggable={false}
+                {thumbnails.shown ? (
+                  <SegmentFrames
+                    clipId={segment.clipId}
+                    clip={clipById.get(segment.clipId)}
+                    posterSrc={segment.posterSrc}
+                    widthPx={Math.max(2, segment.widthPx - BOX_INSET_PX * 2)}
+                    style={thumbnails.style}
                   />
                 ) : null}
                 {isCentre && segment.widthPx >= 16 ? (
@@ -255,7 +349,7 @@ export function SeamLane({
                     // 50% black dot reads on grey and disappears into a busy
                     // picture, which is the one box it has to be findable in.
                     className={
-                      thumbnails
+                      thumbnails.shown
                         ? "relative z-10 h-3 w-3 rounded-full bg-black/70 ring-1 ring-white/70"
                         : "h-3 w-3 rounded-full bg-black/50"
                     }

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -1,11 +1,20 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 
 import { BAR_NEUTRAL_COLOUR } from "@/lib/bar-collection-colours-flag";
 
 import { collectionSeams, type SeamBarClip } from "./graph-seam-bar-layout";
 import type { SeamStrip } from "./graph-seam-strip";
+
+/**
+ * How long the strip takes to slide when the centred clip changes.
+ *
+ * Long enough to be read as one thing moving rather than as two different
+ * pictures — the whole reason to animate this is that the bar re-centres on
+ * somewhere else and a jump cannot be told apart from a redraw.
+ */
+const SEAM_SLIDE_MS = 520;
 
 /**
  * The playhead's head, and its twitch when the scrub lands on a cut.
@@ -110,6 +119,55 @@ export function SeamLane({
   chip: string | null;
   handlers: React.ComponentProps<"div">;
 }>) {
+  // THE BOXES SLIDE INTO POSITION ON A MOVE, and jump for everything else.
+  //
+  // The strip's transform is driven by three different things and only one of
+  // them wants easing. A drag has to track the hand exactly — the whole point
+  // of the edge run is that the strip moves WITH the pointer — and a wheel
+  // zoom or a pan is the same: they are the hand, and easing them reads as
+  // lag. Changing which clip is centred is different. Nothing is under the
+  // reader's finger, the strip re-centres on somewhere else entirely, and a
+  // jump there is the one case where the eye cannot tell whether the bar
+  // moved or was replaced.
+  //
+  // APPLIED TO THE NODE FOR A FIXED WINDOW rather than held as state: the
+  // easing belongs to one arrival, and a `sliding` flag would have to be
+  // cleared a render later — a cascading render to describe half a second of
+  // styling. The pointer handler clears it early so a drag begun mid-slide is
+  // still exact from its first frame.
+  const stripRef = useRef<HTMLDivElement | null>(null);
+  const centreWasRef = useRef(centreClipId);
+  const offsetWasRef = useRef(offset);
+  useLayoutEffect(() => {
+    const node = stripRef.current;
+    const moved = centreWasRef.current !== centreClipId;
+    const previous = offsetWasRef.current;
+    centreWasRef.current = centreClipId;
+    offsetWasRef.current = offset;
+    if (!moved || node === null || previous === offset) return;
+
+    // PUT IT BACK, THEN LET IT GO. A transition cannot be added to a value
+    // that has ALREADY changed: by the time a layout effect runs, React has
+    // written the new transform, and switching easing on afterwards animates
+    // nothing — the browser has one value and no previous one to interpolate
+    // from. So the old position is restored with easing off, the reflow makes
+    // that the state being transitioned FROM, and only then is the new one
+    // asked for.
+    node.style.transition = "none";
+    node.style.transform = `translateX(${previous}px)`;
+    void node.offsetWidth;
+    node.style.transition = `transform ${SEAM_SLIDE_MS}ms ease-out`;
+    node.style.transform = `translateX(${offset}px)`;
+
+    // Only the easing is cleared at the end. The transform is left exactly
+    // where it was put — it is the same value React renders, so the two agree
+    // and there is no frame where the strip is briefly somewhere else.
+    const done = setTimeout(() => {
+      node.style.transition = "";
+    }, SEAM_SLIDE_MS + 60);
+    return () => clearTimeout(done);
+  }, [centreClipId, offset]);
+
   const seams = collectionSeams(clips);
   const viewportX = (stripX: number) => stripX + offset;
 
@@ -118,6 +176,14 @@ export function SeamLane({
       ref={laneRef}
       data-seam-boxes
       {...handlers}
+      // A DRAG BEGUN MID-SLIDE IS EXACT FROM ITS FIRST FRAME. In CAPTURE, so
+      // it runs before the bar's own pointer handler and cannot be replaced by
+      // the spread above — leaving the easing on would put the strip a fixed
+      // distance behind the hand for the rest of the slide's duration, which
+      // is the lag the drag path is careful to avoid everywhere else.
+      onPointerDownCapture={() => {
+        if (stripRef.current !== null) stripRef.current.style.transition = "";
+      }}
       // `touch-none`, because every gesture here is claimed: a drag scrubs and
       // a two-finger swipe pans. Left to the browser, the first would also
       // scroll the dialog behind the bar.
@@ -131,6 +197,7 @@ export function SeamLane({
     >
       <div className="absolute inset-0 overflow-hidden">
         <div
+          ref={stripRef}
           data-seam-strip
           className="absolute inset-y-0 left-0 will-change-transform"
           style={{ transform: `translateX(${offset}px)`, width: strip.totalPx }}

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -58,6 +58,7 @@ import { bootSessionKey } from "./boot-session-key";
 import { trashDocumentId as deriveTrashDocumentId } from "./trash-document-id";
 
 import { GraphBoard, type FocusSurface, type ItemSize } from "./graph-board";
+import type { PlaybarThumbnailStyle } from "./graph-playbar-thumbnails";
 import { laneDropIndex, splitLaneRows } from "./graph-lane-rows";
 import { withDefaultLayerFrame } from "./graph-layer-frame";
 import { GraphViewLoadingSkeleton } from "./graph-view-loading";
@@ -271,6 +272,10 @@ export function GraphTimelineView({
   // beside the two above for the same reason they are: none of the three
   // persists, and one of them quietly outliving the tab would be the surprise.
   const [playbarThumbnails, setPlaybarThumbnails] = useState(false);
+  // Kept whether or not frames are shown, so switching them off and on is a
+  // comparison rather than a choice made again each time.
+  const [playbarThumbnailStyle, setPlaybarThumbnailStyle] =
+    useState<PlaybarThumbnailStyle>("cover");
   const [pixelsPerSecond, setPixelsPerSecond] = useState(DEFAULT_TIMELINE_PPS);
   // Decides whether trim handles are drawn on every clip or only the
   // selected one — see the prop below.
@@ -923,6 +928,8 @@ export function GraphTimelineView({
                 onClipNamesChange={setClipNamesShown}
                 playbarThumbnails={playbarThumbnails}
                 onPlaybarThumbnailsChange={setPlaybarThumbnails}
+                playbarThumbnailStyle={playbarThumbnailStyle}
+                onPlaybarThumbnailStyleChange={setPlaybarThumbnailStyle}
                 pixelsPerSecond={pixelsPerSecond}
                 onPixelsPerSecondChange={setPixelsPerSecond}
                 previewOn={previewOn}

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -267,6 +267,10 @@ export function GraphTimelineView({
   // stored preference: neither persists today, and one of the two quietly
   // outliving the tab would be the surprise.
   const [clipNamesShown, setClipNamesShown] = useState(false);
+  // Whether the play bar draws frames instead of grey boxes. Session state
+  // beside the two above for the same reason they are: none of the three
+  // persists, and one of them quietly outliving the tab would be the surprise.
+  const [playbarThumbnails, setPlaybarThumbnails] = useState(false);
   const [pixelsPerSecond, setPixelsPerSecond] = useState(DEFAULT_TIMELINE_PPS);
   // Decides whether trim handles are drawn on every clip or only the
   // selected one — see the prop below.
@@ -917,6 +921,8 @@ export function GraphTimelineView({
                 onItemSizeChange={setItemSize}
                 clipNamesShown={clipNamesShown}
                 onClipNamesChange={setClipNamesShown}
+                playbarThumbnails={playbarThumbnails}
+                onPlaybarThumbnailsChange={setPlaybarThumbnails}
                 pixelsPerSecond={pixelsPerSecond}
                 onPixelsPerSecondChange={setPixelsPerSecond}
                 previewOn={previewOn}

--- a/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-timeline-view.tsx
@@ -58,7 +58,6 @@ import { bootSessionKey } from "./boot-session-key";
 import { trashDocumentId as deriveTrashDocumentId } from "./trash-document-id";
 
 import { GraphBoard, type FocusSurface, type ItemSize } from "./graph-board";
-import type { PlaybarThumbnailStyle } from "./graph-playbar-thumbnails";
 import { laneDropIndex, splitLaneRows } from "./graph-lane-rows";
 import { withDefaultLayerFrame } from "./graph-layer-frame";
 import { GraphViewLoadingSkeleton } from "./graph-view-loading";
@@ -268,14 +267,6 @@ export function GraphTimelineView({
   // stored preference: neither persists today, and one of the two quietly
   // outliving the tab would be the surprise.
   const [clipNamesShown, setClipNamesShown] = useState(false);
-  // Whether the play bar draws frames instead of grey boxes. Session state
-  // beside the two above for the same reason they are: none of the three
-  // persists, and one of them quietly outliving the tab would be the surprise.
-  const [playbarThumbnails, setPlaybarThumbnails] = useState(false);
-  // Kept whether or not frames are shown, so switching them off and on is a
-  // comparison rather than a choice made again each time.
-  const [playbarThumbnailStyle, setPlaybarThumbnailStyle] =
-    useState<PlaybarThumbnailStyle>("cover");
   const [pixelsPerSecond, setPixelsPerSecond] = useState(DEFAULT_TIMELINE_PPS);
   // Decides whether trim handles are drawn on every clip or only the
   // selected one — see the prop below.
@@ -926,10 +917,6 @@ export function GraphTimelineView({
                 onItemSizeChange={setItemSize}
                 clipNamesShown={clipNamesShown}
                 onClipNamesChange={setClipNamesShown}
-                playbarThumbnails={playbarThumbnails}
-                onPlaybarThumbnailsChange={setPlaybarThumbnails}
-                playbarThumbnailStyle={playbarThumbnailStyle}
-                onPlaybarThumbnailStyleChange={setPlaybarThumbnailStyle}
                 pixelsPerSecond={pixelsPerSecond}
                 onPixelsPerSecondChange={setPixelsPerSecond}
                 previewOn={previewOn}

--- a/apps/timeline-gstudio001/lib/video-frame-url.test.ts
+++ b/apps/timeline-gstudio001/lib/video-frame-url.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   cloudinaryVideoFrameUrl,
   collectionPreviewFrameUrl,
+  monitorPosterUrl,
   videoFrameUrls,
   type VideoFrameUrlBuilder,
 } from "./video-frame-url";
@@ -183,5 +184,40 @@ describe("videoFrameUrls", () => {
   it("defaults to the Cloudinary builder", () => {
     const urls = videoFrameUrls([CLOUDINARY_FRAME], 1, { trimInSeconds: 0, effectiveSeconds: 4 });
     expect(urls[0]).toContain("so_0.05,");
+  });
+});
+
+describe("monitorPosterUrl", () => {
+  const cloudinary =
+    "https://res.cloudinary.com/demo/video/upload/so_0,w_640/folder/clip.jpg";
+
+  it("points the poster at the frame the element is seeking to", () => {
+    // THE WHOLE POINT: a fresh <video> paints its poster before it has decoded
+    // anything, so a poster of the opening frame is a picture of the wrong
+    // moment held until the seek lands — which reads as a skip.
+    expect(monitorPosterUrl(cloudinary, 4.5)).toContain("so_4.5");
+    expect(monitorPosterUrl(cloudinary, 4.5)).not.toContain("so_0,");
+  });
+
+  it("leaves a resting panel on its opening frame", () => {
+    // Null is "no clock is asking" — a neighbour genuinely showing its first
+    // frame, which is a different state from being at zero seconds.
+    expect(monitorPosterUrl(cloudinary, null)).toBe(cloudinary);
+  });
+
+  it("hands back what it cannot transform rather than nothing", () => {
+    const fixture = "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=";
+    expect(monitorPosterUrl(fixture, 4.5)).toBe(fixture);
+  });
+
+  it("has no poster to offer when the clip has none", () => {
+    expect(monitorPosterUrl(undefined, 4.5)).toBeUndefined();
+  });
+
+  it("refuses a time that is not one", () => {
+    // A clock that has not resolved yet must not turn a good poster into a
+    // URL with `so_NaN` in it, which resolves to nothing at all.
+    expect(monitorPosterUrl(cloudinary, Number.NaN)).toBe(cloudinary);
+    expect(monitorPosterUrl(cloudinary, -3)).toContain("so_0");
   });
 });

--- a/apps/timeline-gstudio001/lib/video-frame-url.ts
+++ b/apps/timeline-gstudio001/lib/video-frame-url.ts
@@ -100,6 +100,34 @@ const FIRST_FRAME_NUDGE_SECONDS = 0.05;
  * to say "this is that shot". It samples the START instead. Pinning it to the
  * end was already rejected for the same reason in reverse.
  */
+/**
+ * The poster a MONITORING video element should paint before it has decoded
+ * anything: the frame it is about to seek to, not the clip's first.
+ *
+ * A fresh `<video>` has no frame, so it paints its poster. Where the element
+ * is mounting in order to show a particular moment — the clip a scrub just
+ * landed on, given its own panel — a poster of the clip's OPENING frame is
+ * a picture of the wrong moment, held until the seek lands and then replaced.
+ * The frame was never lost; it was re-acquired in public, and the swap reads
+ * as a skip.
+ *
+ * `seconds` of null means "no clock is asking" — a resting neighbour, which
+ * genuinely is showing its opening frame and wants the base poster.
+ *
+ * Falls back to the base for anything the builder cannot transform, which is
+ * every non-Cloudinary source: a fixture, an upload still in flight. That is
+ * the same picture as before rather than none.
+ */
+export function monitorPosterUrl(
+  posterSrc: string | undefined,
+  seconds: number | null,
+  build: VideoFrameUrlBuilder = defaultVideoFrameUrlBuilder,
+): string | undefined {
+  if (posterSrc === undefined) return undefined;
+  if (seconds === null || !Number.isFinite(seconds)) return posterSrc;
+  return build(posterSrc, Math.max(0, seconds));
+}
+
 export function videoFrameUrls(
   posters: readonly string[],
   count: number,


### PR DESCRIPTION
Stacked on #507 (still open), so this carries its two commits too. **Note for reading order:** #507's second commit makes a bar landing slide in from the side; the third commit *here* replaces that with a cut-and-fade, per your later note. Net effect of both PRs is the cut-and-fade.

---

## 1 · Show playbar thumbnails

Checkbox in the board's gear menu, under **Show name over item**. On, every box in the play bar draws that clip's frame(s). Off by default.

Off is the argument for it being a setting: a bar of frames answers "which shot is that" without a hover, but a box's width *is* its duration, so a run of even grey reads as rhythm — where the cuts fall, which shots are long, where the pace changes. Put pictures in them and the eye reads the pictures, because it always will.

- **The colour stays under the picture.** No poster (audio) or a frame that hasn't loaded leaves the box as it was — this can add pictures, never subtract the bar.
- **The centre marker changes with it.** A 50% black dot reads on flat grey and vanishes into a busy picture; it gets a ring and a darker fill when frames are on.

## 2 · Cover or filmstrip

Second setting, badges under the checkbox. `COVER` is one frame filling the box; `STRIP` is a row of square cells sampled at even intervals across the clip.

`cover` answers "which shot is that". A strip answers what *happens* in it — a long take that opens on a closed door and ends on an empty room is one picture at `cover` and a story at `filmstrip`.

Two settings rather than three states in one control, so the style survives being switched off and on: toggling frames stays a comparison you can make twice.

Sampling reuses `videoFrameUrls` — the same arithmetic the trim strip and the cards already use. **A still falls back to the single frame**: one image sampled ten times is ten copies of itself, a filmstrip saying nothing happens. Only video carries `posterSrcs` onto the bar, which makes the fallback automatic rather than a check. Cells are `flex-1` so they divide the box exactly (no grey tail), and the count is capped so a long clip at high zoom stretches rather than asking for a hundred images.

## 3 · Landings cut and fade; stepping still slides

Stepping and letting go of the bar look like the same event and aren't. A step really does make the middle card a different clip, and the slide says which way you went. Letting go of the bar doesn't: **the middle card has been the monitor for the whole scrub**, so it's already showing the clip you landed on. Scrolling the row to it animates a change that already happened, and moves the one thing on screen that didn't need to.

So a bar landing cuts, the middle card stays exactly where it is with exactly the picture it had, and the panels either side fade in with their new contents.

A **neighbour** is still a step — landing one clip along is the same single move the arrows and the swipe make, and keeps the slide.

The fade is only ever on a neighbour; fading the centre would flicker the one picture that didn't change. This also removed the widened mount window the old slide needed — nothing travels across the row now, so a landing cuts to panels that are already mounted.

## 4 · A five on the reach

`5 · 10 · 20 · All`. Five is roughly the run the strip below shows at once. Default stays 10.

---

### Proof

Every behaviour checked in both directions:

| Assertion | Without the fix |
|---|---|
| The middle card is at its seat immediately after a landing | `expected 2624 to be close to 320` — the four panels exactly |
| A thumbnail per box, `object-fit: cover`, filling the box | `expected +0 to be 21` |
| A filmstrip's cells divide the box, square-ish, `cover` | (layout only — the sampling has its own tests) |
| A still ignores the filmstrip and draws one frame | — |

Green: 38/38 modal stories · 802/802 unit · 1428/1428 app · `tsc` clean · lint 0 errors.

Not watched in a browser. The stories measure real geometry in real Chromium, so the frames fill their boxes and the row cuts where it should — but whether 300ms of fade feels right, and whether a bar of thumbnails reads better than grey at your clip counts, are look-at-it questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)