### PR TITLE
The bar says when it has actually run out

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -2282,6 +2282,58 @@ export const ThePlaybarIsGreyUnlessAsked: Story = {
 };
 
 /**
+ * THE BAR SAYS WHEN IT HAS ACTUALLY RUN OUT.
+ *
+ * Running out of boxes and running out of PROJECT look identical, and at any
+ * reach short of `All` they are usually different things: the window is
+ * cropped at both ends nearly everywhere in a long cut, so the last box on
+ * screen is just the last one the reach allowed. A stop is drawn only where
+ * the window has reached a real end.
+ *
+ * BOTH DIRECTIONS ARE ASSERTED FROM THE SAME SCENE, by changing the reach
+ * rather than the subject: at `All` this collection fits, so both ends are
+ * real ends; at `5` the subject sits far enough inside that neither is.
+ */
+export const TheBarMarksTheEndsOfTheProject: Story = {
+  render: () => <SeamHarness scene={TWO_ROOMS_SCENE} />,
+  play: async () => {
+    await waitFor(() => expect(document.querySelector("[data-seam-strip]")).not.toBeNull());
+    await settleStrip();
+    const caps = () =>
+      Array.from(document.querySelectorAll<HTMLElement>("[data-seam-cap]")).map(
+        (cap) => cap.dataset.seamCap,
+      );
+
+    // EVERYTHING ON THE BAR: both ends are the project's own.
+    reachTo("All");
+    await waitFor(() => expect(seamBoxes().length).toBe(24));
+    expect(caps().sort()).toEqual(["end", "start"]);
+
+    // The start cap sits OUTSIDE the first box rather than over it — it is a
+    // mark about the film, not a mark on a clip.
+    const first = seamBoxes()[0]!.getBoundingClientRect();
+    const startCap = document
+      .querySelector<HTMLElement>('[data-seam-cap="start"]')!
+      .getBoundingClientRect();
+    expect(startCap.right).toBeLessThanOrEqual(first.left + 0.5);
+
+    const last = seamBoxes()[23]!.getBoundingClientRect();
+    const endCap = document
+      .querySelector<HTMLElement>('[data-seam-cap="end"]')!
+      .getBoundingClientRect();
+    expect(endCap.left).toBeGreaterThanOrEqual(last.right - 0.5);
+
+    // CROPPED AT BOTH ENDS: the subject is ten clips in and five either side
+    // reaches neither, so neither stop is true and neither is drawn.
+    reachTo("5");
+    await waitFor(() => expect(seamBoxes().length).toBe(11));
+    expect(caps()).toEqual([]);
+
+    reachTo("10");
+  },
+};
+
+/**
  * THE BAR'S BOXES SLIDE INTO POSITION WHEN THE CENTRED CLIP CHANGES.
  *
  * The strip's transform is driven by three different things and only one of

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -875,6 +875,14 @@ function DetailsFilmstripModal({
             <PlaybarThumbnailsProvider shown={frames.shown} style={frames.style}>
             <SeamStripBar
               clips={barClips}
+              // WHETHER THE BAR HAS ACTUALLY RUN OUT, which is a different
+              // question from whether it has run out of boxes. At a reach of
+              // ten the window is cropped at both ends nearly everywhere in a
+              // long project, and the last box on screen is simply the last
+              // one the reach allowed. These are true only when the window has
+              // reached the real ends.
+              atStart={barWindow.ids[0] === ids[0]}
+              atEnd={barWindow.ids[barWindow.ids.length - 1] === ids[ids.length - 1]}
               centreClipId={node.id as string}
               colourOf={clipColourOf}
               playheadAt={playheadAt}

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -21,6 +21,55 @@ import type { SeamStrip } from "./graph-seam-strip";
  */
 const SEAM_SLIDE_MS = 520;
 
+/** How wide the end-of-project stop is. Wider than the hairline between two
+ *  boxes, so it is read as an edge rather than as another gap. */
+const CAP_WIDTH_PX = 6;
+
+/**
+ * WHERE THE PROJECT ENDS, drawn just outside the first and last boxes.
+ *
+ * The bar is a window: at most reaches it shows a stretch with more either
+ * side, and running out of boxes means only that you have reached the edge of
+ * what is on screen. Once the window actually reaches the first or last clip
+ * that stops being true, and there is no way to tell the two situations apart
+ * from the boxes alone — a bar that has run out looks exactly like a bar that
+ * has been cropped.
+ *
+ * SO IT IS DRAWN, AND ONLY THEN. A solid stop with the light falling away
+ * from it: the bar reads left to right as film, so the end of the film is a
+ * hard edge with nothing after it. Deliberately not another box — anything
+ * box-shaped here would be counted as a clip.
+ *
+ * INSIDE THE STRIP, so it travels with the boxes rather than sitting at the
+ * end of the track. The track's end is a fact about scrolling; this is a fact
+ * about the project, and the two are not in the same place at most zooms.
+ */
+function SeamEndCap({ side, atPx }: Readonly<{ side: "start" | "end"; atPx: number }>) {
+  return (
+    <span
+      data-seam-cap={side}
+      aria-hidden="true"
+      style={{
+        // Just outside the box's own edge, using the same inset the gap
+        // between two boxes is made of — so the stop sits at the distance the
+        // eye already reads as "next thing along".
+        left: side === "start" ? atPx - CAP_WIDTH_PX - BOX_INSET_PX : atPx + BOX_INSET_PX,
+        width: CAP_WIDTH_PX,
+      }}
+      className={[
+        "absolute inset-y-1 rounded-[2px]",
+        // The gradient runs AWAY from the film: solid against the last frame,
+        // gone by the outer edge. A flat bar would read as one more clip in a
+        // colour nobody chose.
+        side === "start"
+          ? "bg-gradient-to-l from-zinc-300/85 to-zinc-300/0"
+          : "bg-gradient-to-r from-zinc-300/85 to-zinc-300/0",
+      ].join(" ")}
+    />
+  );
+}
+
+
 /** Roughly the bar's own height (`h-9`), so a cell reads as a square. */
 const FILMSTRIP_CELL_PX = 36;
 /** Past this the cells stretch rather than multiply — see `SegmentFrames`. */
@@ -250,6 +299,8 @@ export function SeamLane({
   hover,
   chip,
   handlers,
+  atStart,
+  atEnd,
 }: Readonly<{
   /** The element the bar attaches its non-passive wheel listener to. */
   laneRef: React.RefObject<HTMLDivElement | null>;
@@ -267,6 +318,12 @@ export function SeamLane({
   /** The time under the playhead while it is being dragged. */
   chip: string | null;
   handlers: React.ComponentProps<"div">;
+  /** Whether the bar's first clip is the project's first — see `SeamEndCap`.
+   *  False when the reach has cropped the window short of it, because then
+   *  there IS more to the left and saying otherwise would be a lie. */
+  atStart: boolean;
+  /** The same question at the other end. */
+  atEnd: boolean;
 }>) {
   // THE BOXES SLIDE INTO POSITION ON A MOVE, and jump for everything else.
   //
@@ -411,6 +468,9 @@ export function SeamLane({
               </span>
             );
           })}
+
+          {atStart && <SeamEndCap side="start" atPx={0} />}
+          {atEnd && <SeamEndCap side="end" atPx={strip.totalPx} />}
 
           {/* WHERE ONE COLLECTION ENDS AND THE NEXT BEGINS. A dashed hairline
             rather than a gap: a gap is what the bar already puts between

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -127,6 +127,8 @@ export function SeamStripBar({
   onCommitClip,
   onScrubEnd,
   onScrubbingChange,
+  atStart,
+  atEnd,
 }: Readonly<{
   /** Every clip the bar can reach, in playback order. */
   clips: readonly SeamBarClip[];
@@ -157,6 +159,10 @@ export function SeamStripBar({
   /** True while a drag is live on the bar, false when it ends — the view
    *  grows the monitor for the duration. */
   onScrubbingChange?: (active: boolean) => void;
+  /** Whether the bar's first and last clips are the project's — the reach can
+   *  crop the window short of either, and then there IS more either side. */
+  atStart: boolean;
+  atEnd: boolean;
 }>) {
   const trackRef = useRef<HTMLDivElement | null>(null);
   const laneRef = useRef<HTMLDivElement | null>(null);
@@ -663,6 +669,8 @@ export function SeamStripBar({
           clips={clips}
           colourOf={boxColourOf}
           centreClipId={centreClipId}
+          atStart={atStart}
+          atEnd={atEnd}
           offset={offset}
           playheadPx={playheadPx}
           snapKey={snapKey}


### PR DESCRIPTION
A stop either side of the strip when the bar has reached the project's real first or last clip.

### Why it needs the condition

Running out of boxes and running out of *project* look identical — and at any reach short of `All` they're usually different things. The window is cropped at both ends nearly everywhere in a long cut, so the last box on screen is just the last one the reach allowed. Drawing a stop unconditionally would answer the question wrongly rather than not at all.

So it's drawn only where the window's first clip **is** the project's first, not merely the first one shown.

### What it looks like

A solid stop with the light falling away from it, just outside the first/last box at the same inset the gap between two boxes uses. The bar reads left to right as film, so the end of the film is a hard edge with nothing after it. Deliberately not box-shaped — anything box-shaped here gets counted as a clip, and a flat bar would read as one more of them in a colour nobody chose.

It lives **inside** the strip so it travels with the boxes: the track's end is a fact about scrolling, this is a fact about the project, and at most zooms the two are nowhere near each other.

### Proof

`TheBarMarksTheEndsOfTheProject` asserts both directions from one scene by changing the reach rather than the subject — at `All` the 24-clip collection fits and both ends are real; at `5` the subject sits far enough inside that neither is, and no stop is drawn. It also checks each cap sits outside its box rather than over it.

Pinning both flags to `true` makes the cropped half fail, which is the half that matters.

Green: 39/39 modal stories · 1433/1433 app · `tsc` clean · lint 0 errors.

Not watched in a browser — the geometry is measured, but whether the gradient reads as "the end" at your zoom levels is a look-at-it question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)