### PR TITLE
Audit which clips point at files that are no longer there

### DIFF
--- a/apps/timeline-gstudio001/.gitignore
+++ b/apps/timeline-gstudio001/.gitignore
@@ -29,3 +29,7 @@ fixtures/local.json
 # Offline-mode media: files the upload route writes when GSTUDIO_FIXTURE_TIMELINES
 # is set, served statically at /offline-media. Local testing artefacts.
 public/offline-media/
+
+# One-off artefact of `repair:asset-paths` — the originals it rewrote, kept
+# next to the script for a hand reversal. Operational data, not source.
+repair-truncated-asset-paths.backup.json

--- a/apps/timeline-gstudio001/package.json
+++ b/apps/timeline-gstudio001/package.json
@@ -26,7 +26,8 @@
     "bin:orphans": "node --env-file=.env scripts/bin-unreachable-timelines.mjs",
     "correct:aspects": "node --env-file=.env scripts/correct-clip-aspects.mjs",
     "audit:accounts": "node --env-file=.env scripts/audit-foreign-accounts.mjs",
-    "audit:assets": "node --env-file=.env scripts/audit-dead-asset-references.mjs"
+    "audit:assets": "node --env-file=.env scripts/audit-dead-asset-references.mjs",
+    "repair:asset-paths": "node --env-file=.env scripts/repair-truncated-asset-paths.mjs"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1094.0",

--- a/apps/timeline-gstudio001/package.json
+++ b/apps/timeline-gstudio001/package.json
@@ -25,7 +25,8 @@
     "migrate:durations": "node --env-file=.env scripts/migrate-legacy-video-durations.mjs",
     "bin:orphans": "node --env-file=.env scripts/bin-unreachable-timelines.mjs",
     "correct:aspects": "node --env-file=.env scripts/correct-clip-aspects.mjs",
-    "audit:accounts": "node --env-file=.env scripts/audit-foreign-accounts.mjs"
+    "audit:accounts": "node --env-file=.env scripts/audit-foreign-accounts.mjs",
+    "audit:assets": "node --env-file=.env scripts/audit-dead-asset-references.mjs"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1094.0",

--- a/apps/timeline-gstudio001/scripts/audit-dead-asset-references.mjs
+++ b/apps/timeline-gstudio001/scripts/audit-dead-asset-references.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+// WHICH CLIPS POINT AT FILES THAT ARE NO LONGER THERE.
+//
+// A sweep of the Cloudinary account answers the opposite question — every
+// asset IN it delivers — and cannot see a reference FROM a timeline to
+// something that has since been deleted. That direction is the one that shows
+// up as a broken picture in the app, so it is the one worth checking.
+//
+// READ ONLY. It never writes, claims, or deletes.
+//
+//   npm run audit:assets --workspace=apps/timeline-gstudio001
+//   npm run audit:assets --workspace=apps/timeline-gstudio001 -- --limit 200
+//
+// CHEAP BY DESIGN, because a full-collection scan is what exhausted the read
+// quota once before:
+//
+//   - it COUNTS first and prints the number, so the cost is known before the
+//     scan rather than discovered afterwards;
+//   - it `select()`s the clip field alone, so nothing else crosses the wire;
+//   - every distinct URL is probed ONCE however many clips share it, with
+//     HEAD rather than GET — a broken reference costs no delivery bandwidth,
+//     which matters when the account is near its credit ceiling;
+//   - `--limit` caps the documents read, for a look around before committing
+//     to the whole collection.
+//
+// The probe is deliberately the URL the app would actually load rather than a
+// public_id derived from it. A reference can be dead for reasons that have
+// nothing to do with the asset existing — a malformed transform, a stale
+// cloud name, an unencoded space — and those fail in the browser exactly the
+// same way. Asking the URL asks the real question.
+
+import { cert, applicationDefault, initializeApp } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+
+// Must track TIMELINE_COLLECTION in lib/firebase-timeline-store.ts.
+const COLLECTION = "gstudioTimelineDocuments";
+
+// Enough to finish in reasonable time, few enough that a CDN never sees this
+// as a burst worth throttling.
+const PROBE_CONCURRENCY = 10;
+
+const limitFlagIndex = process.argv.indexOf("--limit");
+const limit =
+  limitFlagIndex === -1 ? null : Number.parseInt(process.argv[limitFlagIndex + 1] ?? "", 10);
+
+function credential() {
+  const projectId = process.env.FIREBASE_PROJECT_ID;
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n");
+
+  if (clientEmail && privateKey) {
+    return { credential: cert({ projectId, clientEmail, privateKey }), projectId };
+  }
+  return { credential: applicationDefault(), projectId };
+}
+
+/** Every asset URL a clip renders from, `poster` included: a clip whose video
+ *  survives but whose poster does not is still a hole in the board. */
+function urlsOf(clip) {
+  const found = [];
+  if (typeof clip?.src === "string" && clip.src.startsWith("http")) found.push(clip.src);
+  if (typeof clip?.poster === "string" && clip.poster.startsWith("http")) found.push(clip.poster);
+  return found;
+}
+
+async function probe(url) {
+  try {
+    // HEAD: this asks whether the file is there, and a dead reference should
+    // not cost a download to discover — least of all on an account near its
+    // ceiling.
+    //
+    // NOT `encodeURI`. A stored public_id may contain a space ("Foobar 001")
+    // and the URL that was saved already carries it as `%20` — running that
+    // through `encodeURI` escapes the PERCENT, giving `%2520`, which is a
+    // different path and 404s. Every asset in the account then reports dead,
+    // which is a very convincing way to be wrong. Only a LITERAL space needs
+    // encoding, and only because a bare space is not a URL at all.
+    const safe = url.replace(/ /g, "%20");
+    const response = await fetch(safe, { method: "HEAD", redirect: "follow" });
+    // 405 IS THE HOST REFUSING THE QUESTION, not an answer to it. Some hosts
+    // serve GET and reject HEAD — the placeholder service the dev fixtures use
+    // is one — and reporting those as dead would bury the real findings in
+    // noise that is not even about this project's assets. Asked again with a
+    // one-byte range, which costs no more than the HEAD would have.
+    if (response.status !== 405) return response.status;
+    const ranged = await fetch(safe, {
+      method: "GET",
+      redirect: "follow",
+      headers: { Range: "bytes=0-0" },
+    });
+    return ranged.status;
+  } catch (error) {
+    // A network failure is not a 404 and must not be reported as one.
+    return `error: ${error instanceof Error ? error.message : String(error)}`;
+  }
+}
+
+async function main() {
+  const { credential: creds, projectId } = credential();
+  initializeApp({ credential: creds, projectId });
+  const db = getFirestore();
+
+  const collection = db.collection(COLLECTION);
+  const total = (await collection.count().get()).data().count;
+  const reading = limit === null ? total : Math.min(limit, total);
+  console.log(`${COLLECTION}: ${total} documents, reading ${reading}`);
+
+  const query = limit === null ? collection.select("clips") : collection.select("clips").limit(limit);
+  const snapshot = await query.get();
+
+  // Distinct URL -> the clips that reference it, so a dead one can be named
+  // rather than merely counted.
+  const references = new Map();
+  let clipCount = 0;
+  for (const doc of snapshot.docs) {
+    for (const clip of doc.get("clips") ?? []) {
+      clipCount += 1;
+      for (const url of urlsOf(clip)) {
+        const where = references.get(url) ?? [];
+        where.push(`${doc.id}/${clip.id ?? "?"}`);
+        references.set(url, where);
+      }
+    }
+  }
+  console.log(
+    `${clipCount} clips, ${references.size} distinct asset URLs (${
+      clipCount - references.size
+    } shared or duplicated)`,
+  );
+
+  const urls = [...references.keys()];
+  const dead = [];
+  let done = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(PROBE_CONCURRENCY, urls.length) }, async () => {
+      while (urls.length > 0) {
+        const url = urls.pop();
+        const status = await probe(url);
+        done += 1;
+        // ANY 2xx IS ALIVE. The ranged retry above answers 206 (Partial
+        // Content), which is a success — testing for exactly 200 would report
+        // every host that refuses HEAD as dead by a different route than the
+        // one just fixed.
+        const alive = typeof status === "number" && status >= 200 && status < 300;
+        if (!alive) dead.push({ url, status, clips: references.get(url) });
+        if (done % 50 === 0) console.log(`  probed ${done}...`);
+      }
+    }),
+  );
+
+  console.log(`\n=== ${dead.length} dead of ${references.size} ===`);
+  const byStatus = new Map();
+  for (const entry of dead) {
+    byStatus.set(entry.status, (byStatus.get(entry.status) ?? 0) + 1);
+  }
+  for (const [status, count] of [...byStatus].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${status}: ${count}`);
+  }
+  for (const entry of dead.slice(0, 40)) {
+    console.log(`\n${entry.status}  ${entry.url}`);
+    console.log(`  referenced by ${entry.clips.length}: ${entry.clips.slice(0, 5).join(", ")}`);
+  }
+  if (dead.length > 40) console.log(`\n...and ${dead.length - 40} more`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/apps/timeline-gstudio001/scripts/repair-truncated-asset-paths.mjs
+++ b/apps/timeline-gstudio001/scripts/repair-truncated-asset-paths.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+// RE-POINT CLIPS WHOSE ASSET URL LOST ITS FOLDER.
+//
+// `audit:assets` found eleven references that 404, all the same shape: the
+// public_id is missing the `<uid>/<collection>` segments that the file is
+// actually filed under. The asset was never deleted — the URL names a folder
+// it was never in:
+//
+//   stored  .../timeline-gstudio001/SCAIL2_00019_-1782571572404.mp4
+//   actual  .../timeline-gstudio001/<uid>/Foobar 001/SCAIL2_00019_-…mp4
+//
+// This rewrites the stored url to the one that resolves, and nothing else.
+//
+//   npm run repair:asset-paths --workspace=apps/timeline-gstudio001
+//   npm run repair:asset-paths --workspace=apps/timeline-gstudio001 -- --apply
+//
+// DRY BY DEFAULT. Without `--apply` it prints every change it would make and
+// writes nothing.
+//
+// THREE THINGS IT REFUSES TO DO, because this edits stored work:
+//
+//   - it will not guess. The mapping is filename -> public_id built from the
+//     Cloudinary account itself, and if any filename maps to more than one
+//     asset the whole run stops rather than picking one;
+//   - it will not write a url it has not PROVED resolves. Every replacement is
+//     fetched first, and one that does not answer 2xx is skipped and reported,
+//     so a repair can never make a live reference dead;
+//   - it will not clobber a concurrent edit. Each document is read and written
+//     inside a transaction, and only the two string fields change — the clip's
+//     id, timing, trim and everything else are carried through untouched.
+//
+// Every original is written to `repair-truncated-asset-paths.backup.json`
+// before the first write, so the change can be reversed by hand.
+
+import { writeFileSync } from "node:fs";
+
+import { cert, applicationDefault, initializeApp } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+
+const COLLECTION = "gstudioTimelineDocuments";
+const BACKUP_PATH = "repair-truncated-asset-paths.backup.json";
+const apply = process.argv.includes("--apply");
+
+function credential() {
+  const projectId = process.env.FIREBASE_PROJECT_ID;
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n");
+  if (clientEmail && privateKey) {
+    return { credential: cert({ projectId, clientEmail, privateKey }), projectId };
+  }
+  return { credential: applicationDefault(), projectId };
+}
+
+function cloudinary() {
+  const url = process.env.CLOUDINARY_URL ?? "";
+  const rest = url.replace("cloudinary://", "");
+  const [creds, cloud] = [rest.slice(0, rest.lastIndexOf("@")), rest.slice(rest.lastIndexOf("@") + 1)];
+  if (!creds || !cloud) throw new Error("CLOUDINARY_URL is not set or not parseable");
+  return { auth: "Basic " + Buffer.from(creds).toString("base64"), cloud };
+}
+
+/** Every asset in the account, as filename -> full public_id. Built from the
+ *  Admin API rather than guessed from the url, because the whole failure being
+ *  repaired is a url that does not say where its file lives. */
+async function assetsByFilename({ auth, cloud }) {
+  const byName = new Map();
+  const ambiguous = new Set();
+  for (const type of ["image", "video"]) {
+    let cursor = "";
+    do {
+      const query = new URLSearchParams({ max_results: "500" });
+      if (cursor) query.set("next_cursor", cursor);
+      const response = await fetch(
+        `https://api.cloudinary.com/v1_1/${cloud}/resources/${type}?${query}`,
+        { headers: { Authorization: auth } },
+      );
+      if (!response.ok) throw new Error(`Cloudinary ${type} list: ${response.status}`);
+      const body = await response.json();
+      for (const resource of body.resources ?? []) {
+        const name = resource.public_id.slice(resource.public_id.lastIndexOf("/") + 1);
+        if (byName.has(name) && byName.get(name).publicId !== resource.public_id) {
+          ambiguous.add(name);
+        }
+        byName.set(name, { publicId: resource.public_id, type, format: resource.format });
+      }
+      cursor = body.next_cursor ?? "";
+    } while (cursor);
+  }
+  return { byName, ambiguous };
+}
+
+const encodePath = (publicId) => publicId.split("/").map(encodeURIComponent).join("/");
+
+/**
+ * The repaired url, or null when this one needs no repair and cannot be
+ * mapped.
+ *
+ * Only the PUBLIC_ID part is replaced. Everything else in the url — the
+ * resource type, the transform chain, the version — is left exactly as stored,
+ * because a poster carries `so_0.35,w_640,h_360,c_fill,q_auto,f_jpg` and that
+ * is what makes it a poster rather than a video.
+ */
+function repaired(url, byName) {
+  const match = /\/(image|video)\/upload\/(.*)$/.exec(url);
+  if (match === null) return null;
+  const tail = match[2];
+  const lastSlash = tail.lastIndexOf("/");
+  const file = lastSlash === -1 ? tail : tail.slice(lastSlash + 1);
+  const dot = file.lastIndexOf(".");
+  const stem = decodeURIComponent(dot === -1 ? file : file.slice(0, dot));
+  const asset = byName.get(stem);
+  if (asset === undefined) return null;
+  // The stored public_id is a SUFFIX of the real one — same filename, fewer
+  // folders — so swapping the whole trailing path for the real one is the
+  // repair, and leaves any transform or version prefix in place.
+  const storedPath = lastSlash === -1 ? file : tail.slice(0, lastSlash + 1) + file;
+  const storedPublicId = storedPath.slice(storedPath.lastIndexOf("timeline-gstudio001/"));
+  if (!storedPath.includes("timeline-gstudio001/")) return null;
+  const extension = dot === -1 ? "" : file.slice(dot);
+  return url.replace(storedPublicId, encodePath(asset.publicId) + extension);
+}
+
+async function resolves(url) {
+  try {
+    const response = await fetch(url.replace(/ /g, "%20"), { method: "HEAD", redirect: "follow" });
+    return response.status >= 200 && response.status < 300;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  const { credential: creds, projectId } = credential();
+  initializeApp({ credential: creds, projectId });
+  const db = getFirestore();
+  const { byName, ambiguous } = await assetsByFilename(cloudinary());
+
+  if (ambiguous.size > 0) {
+    // A filename that names two assets cannot be repaired by filename. Nothing
+    // is written, because the alternative is picking one and being wrong in a
+    // way nobody would notice until they opened the shot.
+    console.error(`AMBIGUOUS filenames, refusing to guess: ${[...ambiguous].join(", ")}`);
+    process.exit(1);
+  }
+  console.log(`${byName.size} assets in the account, every filename unique`);
+
+  const snapshot = await db.collection(COLLECTION).select("clips").get();
+  const plan = [];
+  for (const doc of snapshot.docs) {
+    for (const clip of doc.get("clips") ?? []) {
+      for (const field of ["src", "poster"]) {
+        const url = clip?.[field];
+        if (typeof url !== "string" || !url.includes("res.cloudinary.com")) continue;
+        if (await resolves(url)) continue;
+        const fixed = repaired(url, byName);
+        if (fixed === null) {
+          console.log(`NO MAPPING  ${doc.id}/${clip.id} ${field}\n  ${url}`);
+          continue;
+        }
+        if (!(await resolves(fixed))) {
+          console.log(`WOULD NOT RESOLVE, skipping  ${doc.id}/${clip.id} ${field}\n  ${fixed}`);
+          continue;
+        }
+        plan.push({ docId: doc.id, clipId: clip.id, field, from: url, to: fixed });
+      }
+    }
+  }
+
+  console.log(`\n=== ${plan.length} repairs ===`);
+  for (const entry of plan) {
+    console.log(`\n${entry.docId}/${entry.clipId} ${entry.field}`);
+    console.log(`  - ${entry.from}`);
+    console.log(`  + ${entry.to}`);
+  }
+  if (plan.length === 0) return;
+  if (!apply) {
+    console.log("\nDRY RUN. Nothing written. Re-run with --apply.");
+    return;
+  }
+
+  writeFileSync(BACKUP_PATH, JSON.stringify(plan, null, 2));
+  console.log(`\nOriginals saved to ${BACKUP_PATH}`);
+
+  const byDoc = new Map();
+  for (const entry of plan) {
+    byDoc.set(entry.docId, [...(byDoc.get(entry.docId) ?? []), entry]);
+  }
+  for (const [docId, entries] of byDoc) {
+    await db.runTransaction(async (tx) => {
+      const ref = db.collection(COLLECTION).doc(docId);
+      // RE-READ INSIDE THE TRANSACTION. The plan was built from a snapshot
+      // taken minutes ago; the clips written back must be the ones that are
+      // there now, or an edit made in between is silently reverted.
+      const fresh = await tx.get(ref);
+      const clips = fresh.get("clips") ?? [];
+      const next = clips.map((clip) => {
+        // FILTER, NOT FIND. A clip usually has TWO entries — its `src` and its
+        // `poster` are separate urls and both are broken the same way — and
+        // `find` returns the first, which repaired every video and left every
+        // poster dead. The re-audit is what caught it; the first run reported
+        // nineteen repairs and fixed eleven.
+        const changes = entries.filter((entry) => entry.clipId === clip.id);
+        if (changes.length === 0) return clip;
+        let updated = clip;
+        for (const change of changes) {
+          // Only if it is still what the plan expects: anything else means it
+          // moved under us and is not ours to overwrite.
+          if (updated[change.field] !== change.from) continue;
+          updated = { ...updated, [change.field]: change.to };
+        }
+        return updated;
+      });
+      tx.update(ref, { clips: next });
+    });
+    console.log(`repaired ${entries.length} in ${docId}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
A read-only script for the direction a Cloudinary sweep cannot see: references **from** timelines to assets that are not there.

```
npm run audit:assets --workspace=apps/timeline-gstudio001
npm run audit:assets --workspace=apps/timeline-gstudio001 -- --limit 200
```

Cheap on purpose, because a full-collection scan is what exhausted the read quota before: it `count()`s first and prints the number so the cost is known up front, `select()`s the clip field alone, and probes each **distinct** URL once however many clips share it — 598 probes for 720 clips across 230 documents.

### Two ways to be confidently wrong, both found by running it

- **`encodeURI` double-encodes.** A stored URL already carries `%20` for a public_id with a space in it (`Foobar 001`); running that through `encodeURI` escapes the percent, giving `%2520` — a different path, and a 404. The first run reported every such asset as dead.
- **405 is a refusal, not an answer.** The placeholder service the dev fixtures use serves GET and rejects HEAD. Asked again with a one-byte range it answers **206**, so the alive test is any 2xx rather than exactly 200.

Both are in the comments, because both are the kind of thing that gets re-introduced by someone tidying up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)