### PR TITLE
The bar's controls sit between its two bars

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -2282,6 +2282,78 @@ export const ThePlaybarIsGreyUnlessAsked: Story = {
 };
 
 /**
+ * THE BAR'S OWN CONTROLS SIT BETWEEN ITS TWO BARS.
+ *
+ * The scrub bar is the cut, the minimap is the project, and the row between
+ * them drives both: the transport, the clock, and the two settings that say
+ * how much the bar shows and what its boxes are made of. Everything that acts
+ * on the bar is in one place, and it is the place both bars can be read from.
+ *
+ * THE TRANSPORT IS CENTRED ON THE TRACK, not between its neighbours. A flex
+ * row would centre it against whatever sits either side, so it would drift as
+ * the settings changed width — and a play button that moves when you change a
+ * setting is a play button you have to look for. The three-column grid puts it
+ * in the middle of the bar and leaves it there.
+ */
+export const TheBarsControlsSitBetweenIts: Story = {
+  render: () => <SeamHarness scene={TWO_ROOMS_SCENE} />,
+  play: async () => {
+    await waitFor(() => expect(document.querySelector("[data-seam-controls]")).not.toBeNull());
+    await settleStrip();
+    const box = (selector: string) =>
+      document.querySelector<HTMLElement>(selector)!.getBoundingClientRect();
+
+    // ── ORDER: cut, controls, project ─────────────────────────────────────
+    const track = box("[data-seam-track]");
+    const controls = box("[data-seam-controls]");
+    const minimap = box("[data-seam-minimap]");
+    expect(track.bottom).toBeLessThanOrEqual(controls.top + 0.5);
+    expect(controls.bottom).toBeLessThanOrEqual(minimap.top + 0.5);
+
+    // ── THE TRANSPORT IS CENTRED ON THE TRACK ─────────────────────────────
+    const transport = box("[data-seam-transport]");
+    expect(Math.abs(
+      transport.left + transport.width / 2 - (track.left + track.width / 2),
+    )).toBeLessThan(2);
+
+    // ── AND EVERYTHING ELSE IS IN THAT ROW WITH IT ────────────────────────
+    const row = document.querySelector<HTMLElement>("[data-seam-controls]")!;
+    expect(row.querySelector("[data-details-bar-frames]")).not.toBeNull();
+    expect(row.querySelector("[data-details-bar-reach]")).not.toBeNull();
+    expect(row.querySelector("[data-seam-transport]")).not.toBeNull();
+    // The clock, which used to sit at the far right of the scrub bar itself.
+    expect(row.textContent).toMatch(/[\d.]+s\s*\/\s*[\d.]+s/);
+
+    // ── AND THE TRACK GOT THE WIDTH THE TRANSPORT AND CLOCK GAVE UP ───────
+    // They were siblings of the track, so the bar was as wide as the modal
+    // minus both of them; now they are below it and the track is the whole
+    // width. Stated as a floor rather than a number, so it survives a change
+    // of viewport instead of being calibrated to one.
+    expect(track.width).toBeGreaterThan(window.innerWidth * 0.9);
+
+    // ── AND THE ROW BELOW STILL CLEARS IT ─────────────────────────────────
+    // The top band is RESERVED by the scrim's padding, not shared: the bar is
+    // absolutely positioned and takes no space, so the strip would centre
+    // straight up underneath it. Every time the bar grows a row that padding
+    // has to grow with it, and the symptom of it not doing so is the minimap
+    // resting on the top edge of the middle card — a quiet eight pixels rather
+    // than an obvious fault. This moved the transport and the clock INTO that
+    // band, so it is exactly the change that would do it.
+    const panel = box('[data-item-details-panel="centre"]');
+    //
+    // BOUNDED BOTH WAYS, because only one of the two is a fault you would
+    // notice. Too little and the minimap rests on the card — the code calls
+    // that "a quiet eight pixels", and eight is exactly what an 11rem band
+    // leaves, so the floor is set above it. Too much and the band is holding
+    // space for a row that is no longer there, which nothing would ever
+    // report: the view just sits lower than it needs to.
+    const slack = panel.top - minimap.bottom;
+    expect(slack).toBeGreaterThan(16);
+    expect(slack).toBeLessThan(80);
+  },
+};
+
+/**
  * THE BAR SAYS WHEN IT HAS ACTUALLY RUN OUT.
  *
  * Running out of boxes and running out of PROJECT look identical, and at any

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -871,7 +871,12 @@ function DetailsFilmstripModal({
           className="pointer-events-auto absolute inset-x-0 top-16 z-20 px-6 pt-4"
           onPointerDown={(event) => event.stopPropagation()}
         >
-          <div className="mx-auto w-full max-w-5xl">
+          {/* WIDER THAN THE ROW BELOW IT, deliberately. The panels are
+              sized to be worked in and cap out; the bar is a map and gets
+              more useful the more of the project it can show at a legible
+              scale — at `5xl` a twenty-clip reach was boxes a few pixels
+              wide. */}
+          <div className="mx-auto w-full max-w-7xl">
             <PlaybarThumbnailsProvider shown={frames.shown} style={frames.style}>
             <SeamStripBar
               clips={barClips}
@@ -881,6 +886,100 @@ function DetailsFilmstripModal({
               // long project, and the last box on screen is simply the last
               // one the reach allowed. These are true only when the window has
               // reached the real ends.
+              // THE VIEW'S OWN SETTINGS, handed to the bar to place. They
+              // used to be a row of their own beneath it; they are read
+              // against the bar directly above them, so they belong in the
+              // bar's own controls row alongside the transport and the clock.
+              settingsLeft={
+                <div
+                  data-details-bar-frames
+                  role="group"
+                  aria-label="What the bar's boxes draw"
+                  className="flex items-center gap-1"
+                >
+                  <span className="mr-1 font-mono text-[10px] text-zinc-500">frames</span>
+                  {/* THREE BADGES, TWO SETTINGS. Whether the boxes draw frames
+                      and which kind are separate answers, but as controls they
+                      are one question — a picture of what the bar is made of —
+                      and a row that reads OFF · COVER · STRIP says it in the
+                      shape the reach beside it already uses.
+
+                      OFF DOES NOT WIPE THE STYLE. It sets `shown` and leaves
+                      `style` alone, so coming back lands on the kind you were
+                      using: switching frames off and on stays a comparison you
+                      can make twice rather than a choice you re-enter. That is
+                      the whole reason the two are stored apart even though they
+                      are pressed together. */}
+                  {(["off", ...PLAYBAR_THUMBNAIL_STYLES] as const).map((option) => {
+                    const active = option === "off" ? !frames.shown : frames.shown && frames.style === option;
+                    return (
+                      <button
+                        key={option}
+                        type="button"
+                        aria-pressed={active}
+                        onClick={() =>
+                          chooseFrames(
+                            option === "off"
+                              ? { ...frames, shown: false }
+                              : { shown: true, style: option },
+                          )
+                        }
+                        title={
+                          option === "off"
+                            ? "Plain boxes"
+                            : option === "cover"
+                              ? "One frame filling each box"
+                              : "A strip of frames across each clip"
+                        }
+                        className={[
+                          "min-w-7 rounded px-1.5 py-0.5 font-mono text-[10px] tabular-nums transition-colors",
+                          active
+                            ? "bg-zinc-100 text-zinc-900"
+                            : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100",
+                        ].join(" ")}
+                      >
+                        {/* `STRIP`, not `FILMSTRIP`: these badges sit beside a
+                            reach picker of two- and three-character tokens, and
+                            one nine-character label would set the row's rhythm
+                            for the sake of a word the title attribute already
+                            says in full. */}
+                        {option === "filmstrip" ? "STRIP" : option.toUpperCase()}
+                      </button>
+                    );
+                  })}
+                </div>
+              }
+              settingsRight={
+              <div
+                  data-details-bar-reach
+                role="group"
+                aria-label="Clips either side on the bar"
+                className="flex items-center gap-1"
+            >
+                <span className="mr-1 font-mono text-[10px] text-zinc-500">reach</span>
+                {BAR_REACHES.map((option) => (
+                  <button
+                    key={option}
+                    type="button"
+                    aria-pressed={option === reach}
+                    onClick={() => chooseReach(option)}
+                    title={
+                      option === "all"
+                        ? "Reach the whole sequence"
+                        : `Reach ${option} clips either side`
+                    }
+                    className={[
+                      "min-w-7 rounded px-1.5 py-0.5 font-mono text-[10px] tabular-nums transition-colors",
+                      option === reach
+                        ? "bg-zinc-100 text-zinc-900"
+                        : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100",
+                    ].join(" ")}
+                  >
+                    {barReachLabel(option)}
+                  </button>
+                ))}
+            </div>
+              }
               atStart={barWindow.ids[0] === ids[0]}
               atEnd={barWindow.ids[barWindow.ids.length - 1] === ids[ids.length - 1]}
               centreClipId={node.id as string}
@@ -917,106 +1016,6 @@ function DetailsFilmstripModal({
                 setBarSeconds(Math.min(Math.max(seconds, 0), timeline.totalSeconds));
               }}
             />
-            {/* EVERYTHING THE BAR ITSELF IS SET BY, on one row under it.
-                These began in the board's gear menu, which is where settings
-                you set once belong — but these are not that. They are read
-                against the bar directly above them: the reach is the width of
-                what you are looking at, and the frames are what it is made of.
-                A control you judge by looking at the thing it changes wants to
-                be next to that thing.
-
-                TWO GROUPS, split left and right, because they answer different
-                questions: what the boxes are made of, and how many of them
-                there are. Run together as one row of eight badges they would
-                read as one setting with eight values. */}
-            <div className="mt-2 flex items-center justify-between gap-4">
-              <div
-                data-details-bar-frames
-                role="group"
-                aria-label="What the bar's boxes draw"
-                className="flex items-center gap-1"
-              >
-                <span className="mr-1 font-mono text-[10px] text-zinc-500">frames</span>
-                {/* THREE BADGES, TWO SETTINGS. Whether the boxes draw frames
-                    and which kind are separate answers, but as controls they
-                    are one question — a picture of what the bar is made of —
-                    and a row that reads OFF · COVER · STRIP says it in the
-                    shape the reach beside it already uses.
-
-                    OFF DOES NOT WIPE THE STYLE. It sets `shown` and leaves
-                    `style` alone, so coming back lands on the kind you were
-                    using: switching frames off and on stays a comparison you
-                    can make twice rather than a choice you re-enter. That is
-                    the whole reason the two are stored apart even though they
-                    are pressed together. */}
-                {(["off", ...PLAYBAR_THUMBNAIL_STYLES] as const).map((option) => {
-                  const active = option === "off" ? !frames.shown : frames.shown && frames.style === option;
-                  return (
-                    <button
-                      key={option}
-                      type="button"
-                      aria-pressed={active}
-                      onClick={() =>
-                        chooseFrames(
-                          option === "off"
-                            ? { ...frames, shown: false }
-                            : { shown: true, style: option },
-                        )
-                      }
-                      title={
-                        option === "off"
-                          ? "Plain boxes"
-                          : option === "cover"
-                            ? "One frame filling each box"
-                            : "A strip of frames across each clip"
-                      }
-                      className={[
-                        "min-w-7 rounded px-1.5 py-0.5 font-mono text-[10px] tabular-nums transition-colors",
-                        active
-                          ? "bg-zinc-100 text-zinc-900"
-                          : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100",
-                      ].join(" ")}
-                    >
-                      {/* `STRIP`, not `FILMSTRIP`: these badges sit beside a
-                          reach picker of two- and three-character tokens, and
-                          one nine-character label would set the row's rhythm
-                          for the sake of a word the title attribute already
-                          says in full. */}
-                      {option === "filmstrip" ? "STRIP" : option.toUpperCase()}
-                    </button>
-                  );
-                })}
-              </div>
-            <div
-              data-details-bar-reach
-              role="group"
-              aria-label="Clips either side on the bar"
-              className="flex items-center gap-1"
-            >
-              <span className="mr-1 font-mono text-[10px] text-zinc-500">reach</span>
-              {BAR_REACHES.map((option) => (
-                <button
-                  key={option}
-                  type="button"
-                  aria-pressed={option === reach}
-                  onClick={() => chooseReach(option)}
-                  title={
-                    option === "all"
-                      ? "Reach the whole sequence"
-                      : `Reach ${option} clips either side`
-                  }
-                  className={[
-                    "min-w-7 rounded px-1.5 py-0.5 font-mono text-[10px] tabular-nums transition-colors",
-                    option === reach
-                      ? "bg-zinc-100 text-zinc-900"
-                      : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100",
-                  ].join(" ")}
-                >
-                  {barReachLabel(option)}
-                </button>
-              ))}
-            </div>
-            </div>
             </PlaybarThumbnailsProvider>
           </div>
         </div>

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -129,6 +129,8 @@ export function SeamStripBar({
   onScrubbingChange,
   atStart,
   atEnd,
+  settingsLeft,
+  settingsRight,
 }: Readonly<{
   /** Every clip the bar can reach, in playback order. */
   clips: readonly SeamBarClip[];
@@ -163,6 +165,19 @@ export function SeamStripBar({
    *  crop the window short of either, and then there IS more either side. */
   atStart: boolean;
   atEnd: boolean;
+  /**
+   * The view's own settings, dropped into the controls row either side of the
+   * transport.
+   *
+   * SLOTS RATHER THAN PROPS, because what belongs there is not the bar's
+   * business: it is `frames` and `reach` today and could be neither tomorrow,
+   * and the bar would have to grow a prop and a branch for each one. What the
+   * bar DOES own is the row — that the transport is centred in it, that the
+   * clock sits with the controls, and that the whole thing lands between the
+   * scrub bar and the minimap — and none of that changes with what is passed.
+   */
+  settingsLeft?: React.ReactNode;
+  settingsRight?: React.ReactNode;
 }>) {
   const trackRef = useRef<HTMLDivElement | null>(null);
   const laneRef = useRef<HTMLDivElement | null>(null);
@@ -602,48 +617,7 @@ export function SeamStripBar({
   };
 
   return (
-    <div data-seam-bar className="flex w-full items-start gap-3">
-      <div className="flex shrink-0 items-center gap-1">
-        {/* STEP ONE CLIP, either way, bracketing the thing they move.
-            Disabled rather than hidden at the ends: a control that vanishes
-            takes its own position with it and shifts the bar sideways. */}
-        <button
-          type="button"
-          data-seam-step="back"
-          disabled={onStepBack === null}
-          onClick={() => onStepBack?.()}
-          aria-label="Previous clip"
-          title="Previous clip (⇧←)"
-          className="rounded p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-25"
-        >
-          <ChevronLeft aria-hidden="true" className="h-4 w-4" />
-        </button>
-        <button
-          type="button"
-          onClick={onTogglePlay}
-          aria-label={playing ? "Pause" : "Play across the cut"}
-          title="Play / pause (space)"
-          className="rounded-full p-1.5 text-zinc-300 outline-none hover:bg-zinc-800 hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-blue-500"
-        >
-          {playing ? (
-            <Pause aria-hidden="true" className="h-4 w-4" />
-          ) : (
-            <Play aria-hidden="true" className="h-4 w-4" />
-          )}
-        </button>
-        <button
-          type="button"
-          data-seam-step="forward"
-          disabled={onStepForward === null}
-          onClick={() => onStepForward?.()}
-          aria-label="Next clip"
-          title="Next clip (⇧→)"
-          className="rounded p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-25"
-        >
-          <ChevronRight aria-hidden="true" className="h-4 w-4" />
-        </button>
-      </div>
-
+    <div data-seam-bar className="flex w-full flex-col gap-2">
       <div
         ref={trackRef}
         data-seam-track
@@ -704,23 +678,98 @@ export function SeamStripBar({
         />
 
         <SeamRuler ticks={ticks} offset={offset} />
-
-        <SeamMinimap
-          clips={clips}
-          colourOf={boxColourOf}
-          totalSeconds={totalSeconds}
-          windowFromSeconds={windowFromSeconds}
-          windowToSeconds={windowToSeconds}
-          playheadSeconds={playheadSeconds}
-          onPanToSeconds={panToSeconds}
-        />
       </div>
 
-      <span className="shrink-0 font-mono text-[11px] tabular-nums text-zinc-400">
-        <span className="text-blue-300">{readSeconds(atSeconds)}</span>
-        {" / "}
-        {readSeconds(totalSeconds)}
-      </span>
+      {/* ONE ROW BETWEEN THE TWO BARS, and the transport in the middle of it.
+          The scrub bar above is the cut; the minimap below is the project; the
+          controls that drive both sit between them where they are equally
+          about each.
+
+          A THREE-COLUMN GRID, not a flex row with `justify-between`. The
+          transport has to be centred on the BAR, and a flex row centres it
+          between whatever happens to be either side of it — so it would drift
+          left and right as the settings changed width, which is exactly what a
+          play button must not do. `1fr auto 1fr` puts it in the middle of the
+          track above it and leaves it there. */}
+      <div
+        data-seam-controls
+        className="grid grid-cols-[1fr_auto_1fr] items-center gap-3"
+      >
+        {/* HIDDEN, NOT WRAPPED, on a narrow view. Wrapping this row costs the
+            strip below a line of height it has to be told about — see the
+            scrim's top padding — and the two settings here are set once, while
+            the transport and the clock are used continuously. The row keeps
+            what is being USED. */}
+        <div className="hidden min-w-0 items-center gap-1 md:flex">{settingsLeft}</div>
+
+        <div data-seam-transport className="flex items-center gap-1">
+          {/* STEP ONE CLIP, either way, bracketing the thing they move.
+              Disabled rather than hidden at the ends: a control that vanishes
+              takes its own position with it and shifts the bar sideways. */}
+          <button
+            type="button"
+            data-seam-step="back"
+            disabled={onStepBack === null}
+            onClick={() => onStepBack?.()}
+            aria-label="Previous clip"
+            title="Previous clip (⇧←)"
+            className="rounded p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-25"
+          >
+            <ChevronLeft aria-hidden="true" className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={onTogglePlay}
+            aria-label={playing ? "Pause" : "Play across the cut"}
+            title="Play / pause (space)"
+            className="rounded-full p-1.5 text-zinc-300 outline-none hover:bg-zinc-800 hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-blue-500"
+          >
+            {playing ? (
+              <Pause aria-hidden="true" className="h-4 w-4" />
+            ) : (
+              <Play aria-hidden="true" className="h-4 w-4" />
+            )}
+          </button>
+          <button
+            type="button"
+            data-seam-step="forward"
+            disabled={onStepForward === null}
+            onClick={() => onStepForward?.()}
+            aria-label="Next clip"
+            title="Next clip (⇧→)"
+            className="rounded p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-25"
+          >
+            <ChevronRight aria-hidden="true" className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="flex min-w-0 items-center justify-end gap-3">
+          {/* THE CLOCK, which came from the far right of the scrub bar. It
+              belongs with the transport rather than with the track: it says
+              where playback IS, which is the same question the play button
+              answers, and reading the two together is why it moved. */}
+          <span className="shrink-0 font-mono text-[11px] tabular-nums text-zinc-400">
+            <span className="text-blue-300">{readSeconds(atSeconds)}</span>
+            {" / "}
+            {readSeconds(totalSeconds)}
+          </span>
+          <div className="hidden min-w-0 items-center gap-1 md:flex">{settingsRight}</div>
+        </div>
+      </div>
+
+      {/* THE WHOLE PROJECT, under the controls rather than tucked inside the
+          track. It is a different scale from the bar above — that one shows a
+          stretch, this one shows all of it — and stacking them with the
+          controls between says so. */}
+      <SeamMinimap
+        clips={clips}
+        colourOf={boxColourOf}
+        totalSeconds={totalSeconds}
+        windowFromSeconds={windowFromSeconds}
+        windowToSeconds={windowToSeconds}
+        playheadSeconds={playheadSeconds}
+        onPanToSeconds={panToSeconds}
+      />
     </div>
   );
 }


### PR DESCRIPTION
The transport, the clock and the two settings now share one row between the scrub bar and the minimap.

```
[ scrub bar — track, boxes, ruler ]              ← the cut
  frames OFF COVER STRIP   ◀ ▶ ▶   36.0s / 126.0s   reach 5 10 20 All
[ minimap ]                                      ← the project
```

They were in three places before — transport at the far left of the bar, clock at the far right, settings in a row of their own underneath — each one somewhere different from the thing it acts on.

### The grid is load-bearing

The transport has to be centred on the **track**, and a flex row centres it between whatever happens to sit either side — so it drifts as the settings change width, and a play button that moves when you change a setting is one you have to look for.

Measured: **56px out** with `justify-between`, **under 2px** with `1fr auto 1fr`. The story asserts it against the track's own centre, so swapping the grid back fails.

### Slots rather than props

What goes either side isn't the bar's business — it's `frames` and `reach` today and could be neither tomorrow. What the bar *does* own is the row: that the transport is centred in it, that the clock sits with the controls, that the whole thing lands between the two bars.

On a narrow view the settings drop rather than the row wrapping (your call). They're set once; the transport and clock are used continuously, and a wrapped row costs the strip below a line of height the scrim's reserved band would have to be told about.

### Both bars are wider

The track no longer shares its row with the transport and the clock, and the container went `5xl` → `7xl`. The panels are sized to be worked in and cap out; the bar is a map, and at a twenty-clip reach `5xl` was boxes a few pixels wide.

### The reserved band is now guarded

The band above the strip is padding on the *scrim*, so it doesn't follow the bar it reserves for — and this change moved two more things into it. The story bounds the clearance **both ways**:

- **too little** and the minimap rests on the middle card. The code calls that "a quiet eight pixels", and eight is exactly what an `11rem` band leaves — which is why the floor sits above it.
- **too much** and the band holds space for a row that isn't there, which nothing would ever report; the view just sits lower than it needs to.

Measured slack today: 40px.

Green: 40/40 modal stories · 1433/1433 app · `tsc` clean · lint 0 errors. `VirtualStrip > Nest Into Collection On Strip` failed in the full storybook run and passes in isolation — the known under-load flake, in a package this branch doesn't touch.

Not watched in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)