### PR TITLE
Redesign the details modal to the mockup

### DIFF
--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -187,6 +187,33 @@ html body[data-scroll-locked] {
   animation: seam-panel-swap 300ms ease-out;
 }
 
+/* THE UNDO NOTICE ARRIVING.
+   It slides in from the right, which is the side it is anchored to and the
+   side the buttons that produce it are on — so it reads as coming OUT of the
+   control rather than appearing over the header. Short and eased-out: this is
+   a report, and a report that makes an entrance is a report being read as an
+   alert. */
+@keyframes seam-note-in {
+  from {
+    opacity: 0;
+    transform: translateX(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.animate-seam-note-in {
+  animation: seam-note-in 180ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-seam-note-in {
+    animation: none;
+  }
+}
+
 @keyframes trash-arrival {
   0% {
     transform: scale(1);

--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -193,6 +193,33 @@ html body[data-scroll-locked] {
    control rather than appearing over the header. Short and eased-out: this is
    a report, and a report that makes an entrance is a report being read as an
    alert. */
+/* THE HOVER PREVIEW ARRIVING.
+   It waits a moment before it appears (see `HOVER_DWELL_MS`), and a card that
+   has just made you wait should not then snap into place — the pause and the
+   snap together read as a stutter. A short fade with a touch of rise says it
+   came from the box below it. Quick, because it has already spent its patience
+   budget on the dwell. */
+@keyframes seam-preview-in {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -4px);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
+
+.animate-seam-preview-in {
+  animation: seam-preview-in 120ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-seam-preview-in {
+    animation: none;
+  }
+}
+
 @keyframes seam-note-in {
   from {
     opacity: 0;

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-change-note.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-change-note.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import { describeChange } from "./graph-item-details-change-note";
+
+// A media node just complete enough for the describer, which reads four
+// fields and ignores the rest.
+const clip = (over: Partial<Record<string, unknown>> = {}) =>
+  ({
+    id: "clip-a",
+    kind: "media",
+    mediaKind: "video",
+    name: "van pan",
+    src: "x.mp4",
+    fullDurationSeconds: 6.465,
+    trimInSeconds: 0,
+    trimOutSeconds: 1.298,
+    ...over,
+  }) as never;
+
+const updated = (before: unknown, after: unknown) =>
+  ({
+    type: "nodes-updated",
+    updates: [{ nodeId: "clip-a", before, after }],
+  }) as never;
+
+describe("describeChange", () => {
+  it("names the out point in the terms the user set it in", () => {
+    // trimOut 1.423 -> 1.298 on a 6.465s source is out 5.042 -> 5.167.
+    const note = describeChange({
+      command: { type: "update-media", nodeId: "clip-a" },
+      patch: updated(clip({ trimOutSeconds: 1.423 }), clip({ trimOutSeconds: 1.298 })),
+      direction: "undo",
+      label: "clip 6",
+      name: null,
+    });
+    expect(note).toEqual({
+      action: "Undid trim",
+      subject: "clip 6",
+      detail: "out 5.042 → 5.167",
+    });
+  });
+
+  it("names the in point when that is the edge that moved", () => {
+    const note = describeChange({
+      command: { type: "update-media", nodeId: "clip-a" },
+      patch: updated(clip({ trimInSeconds: 1.708 }), clip({ trimInSeconds: 0.5 })),
+      direction: "redo",
+      label: "clip 2",
+      name: null,
+    });
+    expect(note?.action).toBe("Redid trim");
+    expect(note?.detail).toBe("in 1.708 → 0.500");
+  });
+
+  it("quotes a rename", () => {
+    const note = describeChange({
+      command: { type: "rename-node", nodeId: "clip-a" },
+      patch: updated(clip({ name: "old" }), clip({ name: "new" })),
+      direction: "undo",
+      label: "clip 3",
+      name: null,
+    });
+    expect(note?.detail).toBe('"old" → "new"');
+  });
+
+  it("reads a skip off the node it landed on, not off the command", () => {
+    const note = describeChange({
+      command: { type: "set-node-disabled", nodeIds: ["clip-a"] },
+      patch: updated(clip({ disabled: false }), clip({ disabled: true })),
+      direction: "undo",
+      label: "clip 4",
+      name: null,
+    });
+    expect(note).toEqual({
+      action: "Undid skip",
+      subject: "clip 4",
+      detail: "now skipped at play",
+    });
+  });
+
+  it("falls back to the node name when the row cannot place the clip", () => {
+    const note = describeChange({
+      command: { type: "update-media", nodeId: "clip-a" },
+      patch: updated(clip(), clip({ trimInSeconds: 1 })),
+      direction: "undo",
+      label: null,
+      name: "van pan",
+    });
+    expect(note?.subject).toBe("van pan");
+  });
+
+  it("says nothing about a command this view cannot make", () => {
+    expect(
+      describeChange({
+        command: { type: "move-nodes", nodeIds: ["clip-a", "clip-b"] },
+        patch: updated(clip(), clip()),
+        direction: "undo",
+        label: "clip 6",
+        name: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("still names the edit when the patch carries no values to show", () => {
+    // A structural patch alongside a media command should not suppress the
+    // notice: the press DID something, and reporting nothing at all is the
+    // failure this feature exists to fix.
+    const note = describeChange({
+      command: { type: "update-media", nodeId: "clip-a" },
+      patch: { type: "nodes-moved", moves: [] } as never,
+      direction: "undo",
+      label: "clip 6",
+      name: null,
+    });
+    expect(note).toEqual({ action: "Undid trim", subject: "clip 6", detail: "" });
+  });
+});

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-change-note.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-change-note.ts
@@ -1,0 +1,152 @@
+// WHAT THAT UNDO JUST DID, in words.
+//
+// Undo in this view is scoped to one clip (see `useScopedHistory`), which
+// makes it safe — but not legible. Pressing it moves a number somewhere in a
+// panel that may be half a screen away from the button, and if the change was
+// small, or the panel scrolled, nothing observable happens at all. The button
+// then reads as broken, and the honest response to that is not a bigger button
+// but a sentence: WHICH clip, WHAT changed, and FROM what TO what.
+//
+// Everything needed is already recorded. A `HistoryEntry` carries the command
+// and the patch it produced, and a `nodes-updated` patch carries the whole
+// node `before` and `after` — so the note is read out of history rather than
+// tracked alongside it. Nothing here observes an edit; it describes one that
+// already happened.
+
+// Through the UI package's subpath rather than `@storyboard/collections-core`
+// direct: both resolve, and every other file in this view takes the types from
+// here, so a second path would be a second answer to "where do graph types
+// come from" for no gain.
+import type { CollectionsPatch, CollectionItemNode } from "@storyboard/ui/dnd-collections";
+
+/** Which way through history the note is describing. */
+export type ChangeDirection = "undo" | "redo";
+
+export type ChangeNote = Readonly<{
+  /** `Undid trim` — the verb and the kind of edit, together. */
+  action: string;
+  /** `clip 6`, or the node's name when the row cannot place it. */
+  subject: string;
+  /** `out 5.042 → 5.167`. Empty when the change has no two numbers to show. */
+  detail: string;
+}>;
+
+/**
+ * A clip's OUT POINT, which is not what the model stores.
+ *
+ * `trimOutSeconds` is how much is cut off the END; the number a person sets
+ * and reads is how far into the source the clip runs to. Reporting the stored
+ * field would be truthful and unrecognisable — someone who dragged the right
+ * grip from 5.042 to 5.167 would be told a number went DOWN by 0.125.
+ */
+function outPointOf(node: CollectionItemNode): number | null {
+  if (node.kind !== "media") return null;
+  if (!("trimOutSeconds" in node) || !("fullDurationSeconds" in node)) return null;
+  return node.fullDurationSeconds - node.trimOutSeconds;
+}
+
+function inPointOf(node: CollectionItemNode): number | null {
+  if (node.kind !== "media") return null;
+  if (!("trimInSeconds" in node)) return null;
+  return node.trimInSeconds;
+}
+
+/** Thousandths: this is a report on an edit, and a trim lands on a frame. */
+const at = (seconds: number): string => seconds.toFixed(3);
+
+/**
+ * The first field that actually moved, as `field from → to`.
+ *
+ * IN BEFORE OUT, and only one of them. A trim gesture moves one grip, so
+ * naming both would mean naming one that did not change — and the whole point
+ * of the note is to say what did. A drag that somehow moved both reports the
+ * in-point, because that is the edge the eye is already on.
+ */
+function trimDetail(before: CollectionItemNode, after: CollectionItemNode): string {
+  const inFrom = inPointOf(before);
+  const inTo = inPointOf(after);
+  if (inFrom !== null && inTo !== null && inFrom !== inTo) {
+    return `in ${at(inFrom)} → ${at(inTo)}`;
+  }
+  const outFrom = outPointOf(before);
+  const outTo = outPointOf(after);
+  if (outFrom !== null && outTo !== null && outFrom !== outTo) {
+    return `out ${at(outFrom)} → ${at(outTo)}`;
+  }
+  return "";
+}
+
+/** The `nodes-updated` entry for one node, or null when the patch is structural. */
+function updateFor(
+  patch: CollectionsPatch,
+  nodeId: string,
+): Readonly<{ before: CollectionItemNode; after: CollectionItemNode }> | null {
+  if (patch.type !== "nodes-updated") return null;
+  const found = patch.updates.find((update) => (update.nodeId as string) === nodeId);
+  return found === undefined ? null : { before: found.before, after: found.after };
+}
+
+/**
+ * Describe one history entry, or null when it is not the kind of edit this
+ * view makes.
+ *
+ * NULL RATHER THAN A VAGUE STRING. `useScopedHistory` already refuses to step
+ * over anything but these three commands, so an entry this cannot name is an
+ * entry the button could not have reached — and inventing "Undid a change" for
+ * it would put a notice on screen for something that did not happen here.
+ *
+ * @param label how the row names this clip (`clip 6`); the flat order belongs
+ *   to the carousel, so it is passed in rather than derived.
+ */
+export function describeChange({
+  command,
+  patch,
+  direction,
+  label,
+  name,
+}: Readonly<{
+  command: Readonly<{ type: string; nodeId?: string; nodeIds?: readonly string[] }>;
+  patch: CollectionsPatch;
+  direction: ChangeDirection;
+  label: string | null;
+  name: string | null;
+}>): ChangeNote | null {
+  const verb = direction === "undo" ? "Undid" : "Redid";
+  const nodeId =
+    command.nodeId ?? (command.nodeIds?.length === 1 ? command.nodeIds[0] : undefined);
+  if (nodeId === undefined) return null;
+  const subject = label ?? name ?? "clip";
+  const update = updateFor(patch, nodeId);
+
+  if (command.type === "update-media") {
+    return {
+      action: `${verb} trim`,
+      subject,
+      detail: update === null ? "" : trimDetail(update.before, update.after),
+    };
+  }
+  if (command.type === "rename-node") {
+    return {
+      action: `${verb} rename`,
+      subject,
+      // Names are text, so they are quoted rather than formatted — an unquoted
+      // rename to an empty-looking value would read as a missing detail.
+      detail:
+        update === null ? "" : `"${update.before.name}" → "${update.after.name}"`,
+    };
+  }
+  if (command.type === "set-node-disabled") {
+    // WHICH WAY IT WENT, read off the node rather than off the command: the
+    // command names a target state, and after an undo the state that matters
+    // is the one that was restored.
+    const nowDisabled =
+      update !== null && update.after.kind === "media" ? update.after.disabled === true : null;
+    if (nowDisabled === null) return { action: `${verb} skip`, subject, detail: "" };
+    return {
+      action: `${verb} ${nowDisabled ? "skip" : "unskip"}`,
+      subject,
+      detail: nowDisabled ? "now skipped at play" : "now plays",
+    };
+  }
+  return null;
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-header.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-header.tsx
@@ -1,8 +1,19 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { Redo2, Undo2, X } from "lucide-react";
 
 import { useScopedHistory } from "./graph-item-details-history";
+
+/**
+ * How long the notice stays up.
+ *
+ * Long enough to read a sentence with two numbers in it without hurrying, and
+ * short enough that it is gone before the next edit — a notice still on screen
+ * describing the edit before last is worse than none, because it is read as
+ * describing the one just made.
+ */
+const NOTE_MS = 4000;
 
 /**
  * The details view's own header — one, above the whole carousel.
@@ -42,24 +53,79 @@ export function ItemDetailsHeader({
   // change to the node it names, so this steps back through the edits made to
   // the clip you are looking at and greys out at the edge of them — the same
   // contract each panel had, now attached to the one clip the view is about.
-  const history = useScopedHistory(centreId);
+  const history = useScopedHistory(centreId, index > 0 ? `clip ${index}` : null);
+
+  // UP UNTIL THE TIMER, OR UNTIL THE NEXT ONE. Keyed on `noteKey` rather than
+  // on the note's own text so two identical undos in a row restart the clock
+  // instead of letting the first one's timer dismiss the second.
+  const [shownKey, setShownKey] = useState(0);
+  const note = history.noteKey === shownKey ? null : history.note;
+  useEffect(() => {
+    if (history.noteKey === shownKey) return;
+    const timer = setTimeout(() => setShownKey(history.noteKey), NOTE_MS);
+    return () => clearTimeout(timer);
+  }, [history.noteKey, shownKey]);
 
   return (
     <div
       data-item-details-header
       className="pointer-events-auto flex items-start justify-between gap-4 px-6 pt-5"
     >
-      <div className="min-w-0">
-        <h2 className="truncate text-[15px] font-semibold text-zinc-100" title={title}>
-          {title}
+      {/* ONE LINE, AND WHERE YOU ARE COMES FIRST.
+          It was two lines with the name on top. But the name is already the
+          largest thing on the centre panel a few hundred pixels below, so
+          spending the header's strongest position on it said the same thing
+          twice — while the fact the cropped row genuinely cannot give you,
+          which collection this is and how far into it you are, sat underneath
+          in grey. Swapping them puts the orientation first and lets the name
+          trail it as confirmation. */}
+      <div className="flex min-w-0 items-baseline gap-2">
+        <h2
+          className="shrink-0 truncate font-mono text-[15px] font-bold tracking-tight text-zinc-100"
+          title={title}
+        >
+          {collectionName === null ? title : collectionName}
+          {index > 0 && total > 0 ? (
+            <span className="text-zinc-100"> · clip {index} of {total}</span>
+          ) : null}
         </h2>
-        <p className="mt-0.5 truncate font-mono text-[11px] text-zinc-500">
-          {collectionName === null ? null : `${collectionName} · `}
-          {index > 0 && total > 0 ? `clip ${index} of ${total}` : null}
-        </p>
+        {collectionName === null ? null : (
+          <p className="truncate font-mono text-[13px] text-zinc-500" title={title}>
+            {title}
+          </p>
+        )}
       </div>
 
-      <div className="flex shrink-0 items-center gap-1">
+      <div className="flex shrink-0 items-center gap-2">
+        {/* WHAT THAT PRESS DID, beside the button that did it.
+            A left rule rather than a filled pill: the notice appears and goes
+            without being asked for, so it has to be findable without being
+            loud — a solid amber block next to a row of grey icons would pull
+            the eye off the picture every time anyone pressed undo. Amber
+            because it is the one colour in this view that means neither
+            "playing" (red) nor "now" (blue). */}
+        {note === null ? null : (
+          <div
+            data-item-details-note
+            role="status"
+            aria-live="polite"
+            className={[
+              "flex max-w-md items-center gap-2 rounded-r-md border-l-2 border-amber-400/90",
+              "bg-amber-400/10 py-1 pr-3 pl-2 font-mono text-[11px] whitespace-nowrap",
+              "animate-seam-note-in",
+            ].join(" ")}
+          >
+            <span className="font-semibold text-amber-200">{note.action}</span>
+            <span className="text-amber-200/60">·</span>
+            <span className="text-amber-100/90">{note.subject}</span>
+            {note.detail === "" ? null : (
+              <span className="truncate text-amber-200/50">{note.detail}</span>
+            )}
+          </div>
+        )}
+        {/* The controls keep their own tighter rhythm; the notice sits apart
+            from them so it reads as a report rather than another button. */}
+        <div className="flex shrink-0 items-center gap-1">
         <button
           type="button"
           data-item-details-undo
@@ -94,6 +160,7 @@ export function ItemDetailsHeader({
         >
           <X aria-hidden="true" className="h-5 w-5" />
         </button>
+        </div>
       </div>
     </div>
   );

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-history.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-history.ts
@@ -5,7 +5,14 @@ import { useState } from "react";
 import {
   useCollectionsSelector,
   useCollectionsStore,
+  type CollectionsPatch,
 } from "@storyboard/ui/dnd-collections";
+
+import {
+  describeChange,
+  type ChangeDirection,
+  type ChangeNote,
+} from "./graph-item-details-change-note";
 
 /**
  * Undo/redo SCOPED to this clip's trims (PL10-009).
@@ -22,7 +29,7 @@ import {
  * redo spends one, and any fresh commit clears the branch (canRedo goes false)
  * which zeroes the count.
  */
-export function useScopedHistory(nodeId: string) {
+export function useScopedHistory(nodeId: string, label?: string | null) {
   const store = useCollectionsStore();
   const canRedo = useCollectionsSelector((s) => s.canRedo);
   const undoableHere = useCollectionsSelector((s) => {
@@ -48,16 +55,63 @@ export function useScopedHistory(nodeId: string) {
   // it down or the button would offer a redo the store no longer has.
   if (!canRedo && undoneHere !== 0) setUndoneHere(0);
 
+  // WHAT THE LAST PRESS DID, for the notice in the header. Held here rather
+  // than in the header because only this hook knows whether the press was
+  // taken — a refused undo must not announce one.
+  const [note, setNote] = useState<ChangeNote | null>(null);
+  // Bumped with every note so the header can restart its dismiss timer even
+  // when two presses produce identical words — undoing two equal trims in a
+  // row is a real sequence, and a notice that silently stayed put would look
+  // like the second press did nothing.
+  const [noteKey, setNoteKey] = useState(0);
+  const describe = (
+    entry: { command: unknown; patch: CollectionsPatch } | undefined,
+    direction: ChangeDirection,
+  ) => {
+    if (entry === undefined) return;
+    const command = entry.command as Readonly<{
+      type: string;
+      nodeId?: string;
+      nodeIds?: readonly string[];
+    }>;
+    const described = describeChange({
+      command,
+      patch: entry.patch,
+      direction,
+      label: label ?? null,
+      name: null,
+    });
+    if (described === null) return;
+    setNote(described);
+    setNoteKey((key) => key + 1);
+  };
+
   return {
     undoableHere,
     redoableHere,
+    note,
+    noteKey,
     undo: () => {
       if (!undoableHere) return;
-      if (store.undo()) setUndoneHere((n) => n + 1);
+      // READ THE ENTRY FIRST. `undo` pops it off the applied log, so after the
+      // call the thing being described is no longer in `historyEntries`.
+      const entries = store.getSnapshot().historyEntries;
+      const undoing = entries[entries.length - 1];
+      if (store.undo()) {
+        setUndoneHere((n) => n + 1);
+        describe(undoing, "undo");
+      }
     },
     redo: () => {
       if (!redoableHere) return;
-      if (store.redo()) setUndoneHere((n) => Math.max(0, n - 1));
+      // AND READ IT AFTER, for the opposite reason: the redo branch is not in
+      // the applied log until the redo lands, at which point the entry is back
+      // on the end of it.
+      if (store.redo()) {
+        setUndoneHere((n) => Math.max(0, n - 1));
+        const entries = store.getSnapshot().historyEntries;
+        describe(entries[entries.length - 1], "redo");
+      }
     },
   };
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -354,22 +354,19 @@ function pointerAt(clientX: number, clientY: number) {
  * entirely. `hold` leaves the pointer down, for the stories about what happens
  * DURING a drag.
  */
-function scrubToClientX(clientX: number, options?: { hold?: boolean; travelFrom?: number }): void {
-  const surface = seamSurface();
-  const box = surface.getBoundingClientRect();
-  const y = box.top + box.height / 2;
-  const from = clientX - (options?.travelFrom ?? 12);
-  fireEvent.pointerDown(surface, pointerAt(from, y));
-  fireEvent.pointerMove(surface, pointerAt(clientX, y));
-  if (options?.hold === true) return;
-  fireEvent.pointerUp(surface, pointerAt(clientX, y));
-}
-
-/** Let go of a held scrub, wherever the pointer was left. */
-function releaseScrub(clientX: number): void {
-  const surface = seamSurface();
-  const box = surface.getBoundingClientRect();
-  fireEvent.pointerUp(surface, pointerAt(clientX, box.top + box.height / 2));
+/**
+ * MOVE THE PLAYHEAD, which is the keyboard's job now.
+ *
+ * Dragging the boxes used to do this, and dragging them PANS the strip since
+ * the bar became a thing you pull along rather than a thing you scrub. So the
+ * stories that need a clock reach for the control that still moves it: the
+ * track is a `role="slider"` and its arrows seek a second at a time.
+ */
+function nudgePlayhead(seconds: number): void {
+  const track = seamTrack();
+  for (let step = 0; step < Math.abs(seconds); step += 1) {
+    fireEvent.keyDown(track, { key: seconds < 0 ? "ArrowLeft" : "ArrowRight" });
+  }
 }
 
 /** Press a box WITHOUT travelling, which is how you commit to a clip. */
@@ -397,7 +394,7 @@ function centreBox(): HTMLElement {
  * Wait until the strip has stopped moving.
  *
  * A change of subject can nudge the bar to bring the new clip into view, and
- * `scrubIntoBox` reads a box's position ON SCREEN. Measure mid-move and the
+ * A box's position is read ON SCREEN. Measure mid-move and the
  * two disagree by however far the strip still has to travel — which showed up
  * as scrubs landing at zero, because the mismatch pushed the target off the
  * front of the timeline and the clamp caught it.
@@ -479,22 +476,6 @@ async function settleStrip(): Promise<void> {
   );
 }
 
-/**
- * Scrub to a point inside `box`, `within` of the way across that clip.
- *
- * Aim at the BOX'S OWN x: the pointer and the boxes share a client coordinate
- * space, so a clip is at the same place on both and no conversion through the
- * strip's transform is needed — which is what makes this survive a pan and a
- * zoom that a fraction-of-the-timeline version would not.
- */
-function scrubIntoBox(
-  box: HTMLElement,
-  within = 0.5,
-  options?: { hold?: boolean },
-): void {
-  const target = box.getBoundingClientRect();
-  scrubToClientX(target.left + target.width * within, options);
-}
 
 /** Swipe the boxes, which moves the carousel three clips at a time. */
 function swipeBoxes(direction: "forward" | "back"): void {
@@ -783,54 +764,6 @@ export const OpensShowingItsOwnPicture: Story = {
   },
 };
 
-/**
- * THE PLAYHEAD STAYS INSIDE THE TRIMMED WINDOW.
- *
- * The regression: the line's position was measured as a fraction of what the
- * clip SHOWS, then drawn across a strip that renders the whole SOURCE. So it
- * swept the entire filmstrip — dimmed, trimmed-off material included — while
- * the picture only ever played the trimmed part. It reads precisely as being
- * able to scrub past the trim; the picture was fine and the line was lying
- * about it.
- *
- * Asserted against the amber window's own box rather than against a computed
- * number, because the thing that was wrong was an ASSUMPTION about what the
- * strip draws — and only the strip can settle that. A unit test agreeing with
- * my arithmetic would have agreed with the broken arithmetic too.
- */
-export const PlayheadStaysInsideTheTrim: Story = {
-  render: () => <SeamHarness scene={TRIMMED_SCENE} />,
-  play: async () => {
-    await waitFor(() =>
-      expect(document.querySelector('[data-item-details-panel="centre"]')).not.toBeNull(),
-    );
-    await waitFor(() => expect(seamTrack()).not.toBeNull());
-    // Scrub to a few points across the centre clip and check every one — into
-    // its own BOX, which is what "across the centre clip" means now that the
-    // bar carries the whole collection.
-    for (const ratio of [0.35, 0.5, 0.65]) {
-      await settleStrip();
-      scrubIntoBox(centreBox(), ratio);
-
-      const centre = document.querySelector('[data-item-details-panel="centre"]')!;
-      const line = await waitFor(() => {
-        const found = centre.querySelector<HTMLElement>("[data-seam-playhead-line]");
-        expect(found).not.toBeNull();
-        return found!;
-      });
-      const window_ = centre.querySelector<HTMLElement>("[data-trim-overview-window]");
-      expect(window_).not.toBeNull();
-
-      const lineBox = line.getBoundingClientRect();
-      const windowBox = window_!.getBoundingClientRect();
-      const centreX = lineBox.left + lineBox.width / 2;
-      // A pixel of slack for the line's own width and rounding; the window is
-      // a third of this strip, so a line escaping it misses by far more.
-      expect(centreX).toBeGreaterThanOrEqual(windowBox.left - 1);
-      expect(centreX).toBeLessThanOrEqual(windowBox.right + 1);
-    }
-  },
-};
 
 /**
  * THE RING SAYS WHICH PANEL IS THE SUBJECT, AND NEVER MOVES.
@@ -874,7 +807,7 @@ export const TheRingMarksWhoseFramesAreUp: Story = {
     const centreIndex = boxes.indexOf(centreBox());
     expect(centreIndex).toBeGreaterThan(0);
     await settleStrip();
-    scrubIntoBox(boxes[centreIndex - 1]!, 0.5, { hold: true });
+    nudgePlayhead(1);
     await waitFor(() =>
       expect(seamTrack().getAttribute("aria-valuenow")).not.toBe(null),
     );
@@ -912,7 +845,7 @@ export const OnlyTheLiveClipIsMarked: Story = {
     // And the sky-blue ring that used to follow the playhead is gone from
     // both — a colour this view no longer spends here.
     await settleStrip();
-    scrubIntoBox(centreBox());
+    nudgePlayhead(1);
     await waitFor(() => expect(seamTrack()).not.toBeNull());
     expect(getComputedStyle(centre).boxShadow).not.toMatch(/56, 189, 248/);
     expect(getComputedStyle(neighbour).boxShadow).not.toMatch(/56, 189, 248/);
@@ -1175,9 +1108,9 @@ export const TheNeighboursFadeBackDuringPlayback: Story = {
     expect(getComputedStyle(frameOf("centre")).opacity).toBe("1");
 
     await settleStrip();
-    scrubIntoBox(centreBox());
+    nudgePlayhead(1);
 
-    // Scrubbed: the neighbours pull back, in both opacity and colour…
+    // Engaged: the neighbours pull back, in both opacity and colour…
     // Scrubbed: the neighbours pull back, in both opacity and colour.
     //
     // ASSERTED AS "MOVING TOWARD" RATHER THAN "ARRIVED AT". This runner does
@@ -1200,65 +1133,6 @@ export const TheNeighboursFadeBackDuringPlayback: Story = {
   },
 };
 
-/**
- * EVERY CLIP IS SCRUBBABLE, AND THE COUNT HAS NOTHING TO DO WITH IT.
- *
- * This used to assert the opposite arithmetic: the bar covered the clips ON
- * SCREEN plus a lead into each neighbour, so widening the view lengthened the
- * run of time it reached, and the test measured that growth.
- *
- * That coupling was the bug. It meant the only clips you could scrub were the
- * ones you could already see, and a shot four cards away — visible on the bar,
- * plainly a box — did nothing when pressed. The clock covers the whole
- * collection now, so the bar's length is a property of the COLLECTION and the
- * count changes only how many cards are under it.
- *
- * Both halves are asserted, because either alone would pass for the wrong
- * reason: the total does not move when the count does, AND the far end of the
- * bar still scrubs at either count.
- */
-export const WiderViewsScrubEveryWholeClip: Story = {
-  render: () => <SeamHarness scene={LONG_SCENE} />,
-  play: async () => {
-    const picker = await waitFor(() => {
-      const found = document.querySelector<HTMLElement>("[data-details-view-count]");
-      expect(found).not.toBeNull();
-      return found!;
-    });
-    const barMax = () => Number(seamTrack().getAttribute("aria-valuemax"));
-    const at = () => Number(seamTrack().getAttribute("aria-valuenow"));
-    const press = async (label: string) => {
-      const button = Array.from(picker.querySelectorAll("button")).find(
-        (b) => b.textContent?.trim() === label,
-      )!;
-      fireEvent.click(button);
-      await waitFor(() => expect(button.getAttribute("aria-pressed")).toBe("true"));
-    };
-
-    await press("3");
-    const atThree = barMax();
-    expect(atThree).toBeGreaterThan(0);
-    // Every clip has a box, whatever is on screen.
-    const boxCount = seamBoxes().length;
-    expect(boxCount).toBeGreaterThan(3);
-
-    // The LAST clip — as far from the middle as this collection goes, and
-    // certainly without a card at three up.
-    await settleStrip();
-    scrubIntoBox(seamBoxes()[boxCount - 1]!, 0.5);
-    await waitFor(() => expect(at()).toBeGreaterThan(atThree * 0.6));
-
-    // Five up: more cards, same timeline.
-    await press("5");
-    expect(barMax()).toBe(atThree);
-    expect(seamBoxes().length).toBe(boxCount);
-
-    // And the far end still answers.
-    await settleStrip();
-    scrubIntoBox(seamBoxes()[boxCount - 1]!, 0.2);
-    await waitFor(() => expect(at()).toBeGreaterThan(atThree * 0.5));
-  },
-};
 
 /**
  * ADDING A TAG IS AN ICON AT THE END OF THE TAGS, NOT A ROW.
@@ -1484,65 +1358,6 @@ export const TheBarLabelsItsSectionsWithFrames: Story = {
   },
 };
 
-/**
- * THE MONITOR GROWS WHILE YOU DRAG THE BAR.
- *
- * At three panels the middle one is already most of the screen and nothing
- * happens. At nine it is a couple of hundred pixels — fine as a frame beside
- * its neighbours, useless as the thing you are watching while you drag a
- * playhead through a cut. Scrubbing is exactly when the monitor stops being
- * one of several pictures and becomes the only one that matters.
- *
- * It grows by TRANSFORM rather than by width: the strip's slide is computed
- * from a uniform panel width, so a centre panel that actually got wider would
- * put every landing off by the difference.
- */
-export const TheMonitorGrowsWhileScrubbing: Story = {
-  render: () => <SeamHarness scene={LONG_SCENE} />,
-  play: async () => {
-    const picker = await waitFor(() => {
-      const found = document.querySelector<HTMLElement>("[data-details-view-count]");
-      expect(found).not.toBeNull();
-      return found!;
-    });
-    // The WIDEST count, read off the picker rather than typed: this story is
-    // about the monitor growing out of a small panel, so it wants whatever the
-    // narrowest panel currently is, not a number that was once the maximum.
-    const widest = Array.from(picker.querySelectorAll("button")).at(-1)!;
-    fireEvent.click(widest);
-    await waitFor(() => expect(widest.getAttribute("aria-pressed")).toBe("true"));
-
-    const centre = () => document.querySelector<HTMLElement>('[data-item-details-panel="centre"]')!;
-    const width = () => Math.round(centre().getBoundingClientRect().width);
-
-    const resting = width();
-    expect(centre().hasAttribute("data-item-details-magnified")).toBe(false);
-
-    // The middle of the track, held: the gesture is the drag, so the monitor
-    // has to be up for as long as the pointer is down and not a moment past.
-    const surface = seamSurface().getBoundingClientRect();
-    const middle = surface.left + surface.width * 0.5;
-    scrubToClientX(middle, { hold: true });
-
-    // Bigger, and marked as such.
-    await waitFor(() => expect(centre().hasAttribute("data-item-details-magnified")).toBe(true));
-    await waitFor(() => expect(width()).toBeGreaterThan(resting + 10));
-
-    // And back down when the drag ends — this is the gesture, not a mode.
-    releaseScrub(middle);
-    await waitFor(() => expect(centre().hasAttribute("data-item-details-magnified")).toBe(false));
-    await waitFor(() => expect(width()).toBe(resting));
-
-    // The neighbours never grow: they are the context you are looking PAST.
-    const neighbours = Array.from(
-      document.querySelectorAll('[data-item-details-panel="neighbour"]'),
-    );
-    scrubToClientX(middle, { hold: true });
-    await waitFor(() => expect(centre().hasAttribute("data-item-details-magnified")).toBe(true));
-    expect(neighbours.some((n) => n.hasAttribute("data-item-details-magnified"))).toBe(false);
-    releaseScrub(middle);
-  },
-};
 
 /**
  * EVERY PANEL OFFERS "PLAY THIS ONE", AT EVERY WIDTH.
@@ -1706,7 +1521,9 @@ export const PlayingFromANeighbourRunsItOnTheMonitor: Story = {
     // below cannot tell "jumped to this clip" from "happened to already be
     // there" — the bar rests at the subject's own first frame.
     await settleStrip();
-    scrubIntoBox(centreBox(), 0.5);
+    // Four seconds in lands inside the SUBJECT: the bar runs Before (3s) then
+              // Subject (4s), so anything past 3 is in the middle clip.
+    nudgePlayhead(4);
     await waitFor(() => expect(at()).toBeGreaterThan(3));
 
     // The RIGHT-hand panel: "After". Its stretch of the bar starts at 7s —
@@ -1757,128 +1574,6 @@ export const PlayingFromANeighbourRunsItOnTheMonitor: Story = {
   },
 };
 
-/**
- * HOLDING AT AN EDGE RUNS THE STRIP UNDER THE POINTER.
- *
- * The track spans what is ON SCREEN, not what exists: on a project longer than
- * the bar can draw at the current zoom, the end of the track was the end of
- * the timeline you could reach in one gesture, with the rest of the order
- * sitting an inch off the side. You could step to it with the arrows or pan
- * there with the wheel first, both of which mean abandoning the drag you are
- * in the middle of.
- *
- * So the two ends of the track are a throttle. Hold inside 40px of the right
- * edge and the strip travels forward underneath; hold at the left and it
- * reverses. THE HAND DOES NOT MOVE during any of that, which is why this is a
- * frame loop and not something hung off pointermove — an implementation
- * reading the moves travels only while the hand jitters.
- *
- * Five claims, and the last three are what make it a control rather than a
- * hazard: the middle of the track does nothing, letting go stops it, and a
- * gesture that travelled this far is not mistaken for a tap on whatever
- * arrived under the finger.
- */
-export const HoldingAtAnEdgeRunsTheStrip: Story = {
-  render: () => <SeamHarness scene={OVERFLOWING_SCENE} />,
-  play: async () => {
-    const at = () => Number(seamTrack().getAttribute("aria-valuenow"));
-    const stripLeft = () =>
-      document.querySelector<HTMLElement>("[data-seam-strip]")!.getBoundingClientRect().left;
-    const subject = () => centreBox().getAttribute("data-seam-segment");
-
-    // Held presses with NO travel at all, which is the gesture: everything
-    // that moves is moved by the bar, not by the hand.
-    const press = (clientX: number) => {
-      const surface = seamSurface();
-      const box = surface.getBoundingClientRect();
-      fireEvent.pointerDown(surface, pointerAt(clientX, box.top + box.height / 2));
-    };
-    const release = (clientX: number) => {
-      const surface = seamSurface();
-      const box = surface.getBoundingClientRect();
-      fireEvent.pointerUp(surface, pointerAt(clientX, box.top + box.height / 2));
-    };
-    const rest = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-    await waitFor(() => expect(document.querySelector("[data-seam-strip]")).not.toBeNull());
-    await settleStrip();
-    const startedOn = subject();
-
-    // THE PRECONDITION THIS STORY IS ABOUT. If the strip fitted in the track
-    // there would be nothing off the side to reach, and every assertion below
-    // would pass for the wrong reason.
-    const trackWidth = seamSurface().getBoundingClientRect().width;
-    const pps = Number(seamTrack().getAttribute("data-seam-pps"));
-    const totalPx = Number(seamTrack().getAttribute("aria-valuemax")) * pps;
-    expect(totalPx).toBeGreaterThan(trackWidth * 1.5);
-
-    // ── THE MIDDLE OF THE TRACK IS AN ORDINARY SCRUBBER ───────────────────
-    const box = seamSurface().getBoundingClientRect();
-    press(box.left + box.width / 2);
-    const middleT = at();
-    const middleX = stripLeft();
-    await rest(300);
-    expect(at()).toBe(middleT);
-    expect(stripLeft()).toBe(middleX);
-    release(box.left + box.width / 2);
-
-    // ── THE RIGHT EDGE RUNS FORWARD ───────────────────────────────────────
-    press(box.right - 12);
-    const pressedAt = at();
-    await waitFor(() => expect(at()).toBeGreaterThan(pressedAt + 1), { timeout: 2000 });
-
-    // THE CLOCK ADVANCES BECAUSE THE STRIP MOVES, not because the press landed
-    // further along. Measured between two readings taken once the run is
-    // already going, so the press's own snap-to-cut is not inside the window —
-    // and stated as the two AGREEING rather than as a pixel count, so the
-    // claim survives a change of zoom instead of being calibrated to one.
-    const fromAt = at();
-    const fromX = stripLeft();
-    await waitFor(() => expect(at()).toBeGreaterThan(fromAt + 2), { timeout: 2000 });
-    const ranPx = fromX - stripLeft();
-    expect(ranPx).toBeGreaterThan(5);
-    expect(Math.abs(ranPx - (at() - fromAt) * pps)).toBeLessThan(2);
-
-    // ── LETTING GO STOPS IT, AND LANDS ON WHAT IT RAN TO ──────────────────
-    release(box.right - 12);
-    const stoppedAt = at();
-    await rest(300);
-
-    // THE CLOCK STOPS DEAD, WHICH IS WHAT "STOPS IT" MEANS. The strip does
-    // not, and must not be asserted to: letting go lands the row on the clip
-    // the playhead reached, and the bar then slides to re-centre on it. That
-    // slide is a different motion from the run — it has an end, and the run
-    // did not — so what this checks is that the RUN stopped, and then that the
-    // slide settles rather than continuing.
-    expect(at()).toBe(stoppedAt);
-    await settleStrip();
-    const settledX = stripLeft();
-    await rest(200);
-    expect(stripLeft()).toBe(settledX);
-    // WHERE THE PLAYHEAD FINISHED, NOT WHERE THE HAND IS. The hand never
-    // moved, so this is the case that would go wrong if the release resolved
-    // a clip from the pointer's x: the strip ran a long way underneath a
-    // stationary finger, and what is under it now is not what was under it
-    // when the press began. The view answers from its own clock instead.
-    expect(subject()).not.toBe(startedOn);
-
-    // ── AND THE LEFT EDGE REVERSES ────────────────────────────────────────
-    // MEASURED AGAIN. The release above landed the row on a new clip, and the
-    // bar re-pans around it — so the geometry read at the top of this story
-    // describes a bar that no longer exists.
-    const after = seamSurface().getBoundingClientRect();
-    press(after.left + 12);
-    const pressedBackAt = at();
-    await waitFor(() => expect(at()).toBeLessThan(pressedBackAt - 1), { timeout: 2000 });
-    const backFrom = at();
-    const backFromX = stripLeft();
-    await waitFor(() => expect(at()).toBeLessThan(backFrom - 2), { timeout: 2000 });
-    const backPx = stripLeft() - backFromX;
-    expect(backPx).toBeGreaterThan(5);
-    expect(Math.abs(backPx - (backFrom - at()) * pps)).toBeLessThan(2);
-    release(after.left + 12);
-  },
-};
 
 /**
  * ── THE BAR IS A WINDOW ONTO THE WHOLE PROJECT ────────────────────────────
@@ -1978,55 +1673,6 @@ export const TheWheelPansAndZoomsAboutThePointer: Story = {
   },
 };
 
-/**
- * A SCRUB LANDING NEAR A CUT MEANS THE CUT.
- *
- * The cut is the thing anyone is ever aiming at on this bar — it is what the
- * whole view is for — and it is one pixel wide. Without a snap, "put the
- * playhead on the start of that shot" is a test of the reader's mouse hand,
- * and the answer is almost always a frame or two out in a direction they
- * cannot see.
- *
- * PIXELS, NOT SECONDS, is what makes it survive the zoom above: seven pixels
- * is seven pixels at 5px a second and at 40, where a tolerance in seconds
- * would swallow whole clips at one end and be unreachable at the other.
- */
-export const AScrubNearACutTakesTheCut: Story = {
-  render: () => <SeamHarness scene={TWO_ROOMS_SCENE} />,
-  play: async () => {
-    await waitFor(() => expect(document.querySelector("[data-seam-strip]")).not.toBeNull());
-    await settleStrip();
-    const at = () => Number(seamTrack().getAttribute("aria-valuenow"));
-    const pps = Number(seamTrack().getAttribute("data-seam-pps"));
-
-    // A box with room either side of it, so "just before" and "just after" are
-    // both inside the same clip's neighbourhood and not off the end of the bar.
-    const target = seamBoxes()[4]!.getBoundingClientRect();
-    // The cut is the box's own leading edge, less the inset every box is
-    // pulled in by — see BOX_INSET_PX in the lane.
-    const cut = target.left - 2.5;
-
-    // HELD THROUGHOUT. These are three readings of one scale, so the bar
-    // underneath them has to be the same bar: a release would land the row on
-    // the clip just scrubbed to, and the next measurement would be taken
-    // against a strip that had moved. Nothing here is about committing.
-    scrubToClientX(cut - 3, { hold: true });
-    const fromBefore = at();
-    scrubToClientX(cut + 3, { hold: true });
-    const fromAfter = at();
-
-    // BOTH SIDES LAND ON THE SAME INSTANT, which is the cut. Six pixels apart
-    // on screen, zero seconds apart on the clock.
-    expect(fromBefore).toBe(fromAfter);
-
-    // A press with room around it is left exactly where it was put, so the
-    // snap is a tolerance and not a quantiser: 40px further along is 40px
-    // further along, to the second.
-    scrubToClientX(cut + 40, { hold: true });
-    expect(at()).toBeGreaterThan(fromAfter);
-    expect(Math.abs(at() - fromAfter - 40 / pps)).toBeLessThan(0.05);
-  },
-};
 
 /**
  * THE RULER SAYS WHAT SCALE YOU ARE AT, AND WHERE EACH COLLECTION STARTS.
@@ -2747,137 +2393,6 @@ export const TheBarReachIsASetting: Story = {
   },
 };
 
-/**
- * LETTING GO IS THE COMMIT — AND THE ROW DOES NOT SCROLL TO IT.
- *
- * A drag and a press that does not travel are still told apart (distance, not
- * timing), but they LAND the same way, because they are the same sentence: you
- * put the playhead somewhere and took your hand off it.
- *
- * THE MIDDLE CARD DOES NOT MOVE, and that is the point. It has been the
- * monitor for the whole scrub, so it is already showing the clip being landed
- * on — sliding the row to that clip would animate a change that has already
- * happened, and move the one thing on screen that did not need to. So the row
- * cuts, the middle card stays exactly where it is with exactly the picture it
- * had, and the panels either side fade in with their new contents.
- *
- * STEPPING IS THE OTHER CASE and keeps its slide: landing on the clip directly
- * beside this one is the same single move the arrows and the swipe make, and
- * there the middle card really is becoming something else.
- *
- * THE FRAME COMES WITH IT, read off the panel rather than the bar. The bar is
- * a window with a reach either side of the subject, so it is rebuilt around
- * wherever you land and its own seconds are not comparable across the journey.
- * The panel reports the clip's OWN time, which is.
- */
-export const LettingGoOfTheBarLandsTheStrip: Story = {
-  render: () => <SeamHarness scene={TWO_ROOMS_SCENE} />,
-  play: async () => {
-    await waitFor(() => expect(document.querySelector("[data-seam-strip]")).not.toBeNull());
-    await settleStrip();
-    await settleRow();
-    const subject = () => centreBox().getAttribute("data-seam-segment");
-    const at = () => Number(seamTrack().getAttribute("aria-valuenow"));
-    const strip = () => document.querySelector<HTMLElement>("[data-details-strip]")!;
-    const boxIndex = () => seamBoxes().indexOf(centreBox());
-    const centrePanel = () =>
-      document.querySelector<HTMLElement>('[data-item-details-panel="centre"]')!;
-    const seatX = () => centrePanel().getBoundingClientRect().left;
-    const shownFrame = () =>
-      Number(centrePanel().getAttribute("data-item-details-at"));
-    const swapping = () =>
-      document.querySelectorAll("[data-item-details-swapping]").length;
-
-    // Hold the scrub, read the frame at the moment before the release, let go.
-    const dragToBox = async (box: HTMLElement) => {
-      const rect = box.getBoundingClientRect();
-      const x = rect.left + rect.width * 0.5;
-      scrubToClientX(x, { hold: true });
-      await waitFor(() => expect(at()).toBeGreaterThan(0));
-      const reporting = Array.from(
-        document.querySelectorAll<HTMLElement>("[data-item-details-at]"),
-      );
-      const heldFrame = Number(reporting[0]!.getAttribute("data-item-details-at"));
-
-      // TWO PANELS ARE ON THIS FRAME, AND THAT IS THE POINT. The centre is
-      // monitoring the clip being scrubbed to, and that clip's OWN panel is
-      // already showing the same moment rather than resting on its first
-      // frame. Without the second, the release reads as: the right frame, a
-      // cut, the FIRST frame, and a skip back — because the panel arriving in
-      // the middle has a decoded frame already and it is the wrong one.
-      expect(reporting.length).toBe(2);
-      expect(
-        reporting.map((panel) => Number(panel.getAttribute("data-item-details-at"))),
-      ).toEqual([heldFrame, heldFrame]);
-      const surface = seamSurface();
-      const surfaceBox = surface.getBoundingClientRect();
-      fireEvent.pointerUp(surface, pointerAt(x, surfaceBox.top + surfaceBox.height / 2));
-      return heldFrame;
-    };
-
-    expect(subject()).toBe("subject");
-    const restingSeat = seatX();
-
-    // ── A LANDING SEVERAL CLIPS OFF CUTS, AND THE MIDDLE STAYS PUT ────────
-    // TWO CLIPS, WHICH IS INSIDE `MOUNTED_RADIUS` AND OUTSIDE A STEP. Both
-    // halves matter: past one clip so it cuts and fades rather than stepping,
-    // and near enough that the target's panel EXISTS during the scrub, which
-    // is what the pre-seek below can be observed on. A landing beyond the
-    // mount window has no panel to pre-seek and is covered instead by the
-    // poster the fresh element paints — see `monitorPosterUrl`.
-    const target = seamBoxes()[boxIndex() + 2]!;
-    const letGo = await dragToBox(target);
-    await waitFor(() => expect(subject()).not.toBe("subject"));
-
-    // ALREADY THERE. This is the assertion a slide fails: mid-travel the
-    // middle card is panels away from its seat and only arrives later.
-    expect(seatX()).toBeCloseTo(restingSeat, 0);
-    // And it stays — nothing is easing towards anything.
-    await new Promise((resolve) => setTimeout(resolve, 150));
-    expect(seatX()).toBeCloseTo(restingSeat, 0);
-
-    // THE PANELS EITHER SIDE ARE WHAT MOVED, so they are what fades.
-    expect(swapping()).toBeGreaterThan(0);
-
-    // AND NOTHING ELSE ANIMATES WHILE THEY DO. A landing leaves the clock
-    // engaged, so every neighbour is newly `dimmed` and would start its own
-    // 300ms opacity-and-GRAYSCALE transition in the same frame the fade
-    // begins. Two nested opacity animations is one too many, and a filter over
-    // a video still fetching its first frame is repainted from the decoder
-    // every tick — which is why this was smooth on stills and juddered on
-    // video. The incoming panel arrives already dimmed and already drained.
-    const fading = document.querySelector<HTMLElement>(
-      "[data-item-details-swapping] [data-item-details-frame]",
-    )!;
-    expect(getComputedStyle(fading).transitionProperty).toBe("none");
-    expect(
-      centrePanel().hasAttribute("data-item-details-swapping"),
-    ).toBe(false);
-
-    expect(subject()).toBe(target.getAttribute("data-seam-segment"));
-    expect(shownFrame()).toBeCloseTo(letGo, 2);
-    // The fade lets go of itself.
-    await waitFor(() => expect(swapping()).toBe(0));
-
-    // ── AND A NEIGHBOUR IS STILL A STEP ───────────────────────────────────
-    const landedOn = subject();
-    const next = seamBoxes()[boxIndex() + 1]!;
-    clickBox(next);
-    await waitFor(() => expect(subject()).not.toBe(landedOn));
-    // No fade: one clip along is the move the arrows and the swipe make, and
-    // it travels.
-    expect(swapping()).toBe(0);
-    const travellingFrom = strip().getBoundingClientRect().left;
-    await new Promise((resolve) => setTimeout(resolve, 120));
-    expect(strip().getBoundingClientRect().left).not.toBe(travellingFrom);
-
-    // THE SCRIM NEVER SCROLLS. It crops a row thousands of pixels wide, so if
-    // it were a scroll container the browser would scroll it to reveal the
-    // newly focused panel — on top of the transform the row has already made,
-    // putting the chosen card off the left edge. Zero is `overflow-clip`.
-    expect(strip().parentElement!.scrollLeft).toBe(0);
-  },
-};
 
 /**
  * THE BAR TAKES THE KEYBOARD.

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -2244,7 +2244,14 @@ export const TheTwoBarsAreAdjacent: Story = {
     // leaves, so the floor is set above it. Too much and the band is holding
     // space for a row that is no longer there, which nothing would ever
     // report: the view just sits lower than it needs to.
-    const slack = panel.top - minimap.bottom;
+    //
+    // MEASURED FROM THE CONTROLS, NOT THE MINIMAP. The controls row used to sit
+    // between the two bars and now sits under both, so the space below the
+    // minimap legitimately contains it — measuring there counts a row as slack
+    // and reports 84px of "waste" that is actually the transport.
+    const controlsRow = box("[data-seam-controls]");
+    expect(minimap.bottom).toBeLessThanOrEqual(controlsRow.top + 0.5);
+    const slack = panel.top - controlsRow.bottom;
     expect(slack).toBeGreaterThan(16);
     expect(slack).toBeLessThan(80);
   },
@@ -2849,9 +2856,14 @@ export const ThePanelsRecedeBehindThePreview: Story = {
     expect(dimmed()).toBe(false);
 
     // Pointing at a box brings the card up, and the row goes back for it.
+    // THE CARD WAITS BEFORE IT APPEARS — see `HOVER_DWELL_MS`. So does the dim
+    // that follows it, and it arrives a render later than the card because the
+    // bar reports the state and the view acts on it. Both are waited for
+    // rather than assumed, which is also the assertion that the dwell has not
+    // quietly become "never".
     fireEvent.pointerMove(lane, pointerAt(centre.x, centre.y));
     await waitFor(() => expect(document.querySelector("[data-seam-preview]")).not.toBeNull());
-    expect(dimmed()).toBe(true);
+    await waitFor(() => expect(dimmed()).toBe(true));
     // Both properties ease, so the row does not snap dark while it slides.
     expect(getComputedStyle(row()).transitionProperty).toContain("opacity");
 
@@ -2859,7 +2871,7 @@ export const ThePanelsRecedeBehindThePreview: Story = {
     // comes back — the panel being watched must not be the dim one.
     fireEvent.pointerDown(lane, pointerAt(centre.x, centre.y));
     await waitFor(() => expect(document.querySelector("[data-seam-preview]")).toBeNull());
-    expect(dimmed()).toBe(false);
+    await waitFor(() => expect(dimmed()).toBe(false));
     fireEvent.pointerUp(lane, pointerAt(centre.x, centre.y));
   },
 };

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -589,13 +589,22 @@ export const FlankedByItsNeighbours: Story = {
     expect(canvas.getAllByText("Before").length).toBeGreaterThan(0);
     expect(canvas.getAllByText("After").length).toBeGreaterThan(0);
 
-    // Identical size — a neighbour is a copy of the view, not a preview of it.
+    // THE SUBJECT IS WIDER, and the neighbours match each other.
+    //
+    // They were all one width once, and the outer two hung half off the screen
+    // — which is what made "show three" mean one whole panel and two halves.
+    // Sizing the middle one separately buys the same emphasis without spending
+    // it on cropping: every panel is now whole, and the one being worked on is
+    // simply bigger. A neighbour is still a full copy of the view rather than a
+    // preview of it; it is just not the subject.
     const widths = panels.map((panel) => Math.round(panel.getBoundingClientRect().width));
-    expect(new Set(widths).size).toBe(1);
-    // And three of them cannot fit, which is the crop that gives the strip its
-    // edges: the outer two run off the screen.
+    const [left, middle, right] = widths as [number, number, number];
+    expect(left).toBe(right);
+    expect(middle / left).toBeCloseTo(1.75, 1);
+    // And now they DO fit, which is the other half of the change: three whole
+    // panels and their gaps come to one viewport.
     const total = widths.reduce((sum, width) => sum + width, 0);
-    expect(total).toBeGreaterThan(window.innerWidth);
+    expect(total).toBeLessThanOrEqual(window.innerWidth);
 
     // EVERY panel works, so every panel has its own controls — not just the
     // centre. The rename button is the cheapest proof that the chrome is real.
@@ -1094,8 +1103,15 @@ export const TheCountChangesHowManyClipsAreOnScreen: Story = {
     // fitting more of them, so five showed the same three as three did. A
     // width assertion cannot tell those apart; counting what intersects the
     // viewport can.
+    // ON SCREEN MEANS VISIBLE. The pair held ready beyond the window keeps its
+    // width — the row's centring is arithmetic over uniform neighbour widths —
+    // so it still reports a box, and now that `count` panels fill the viewport
+    // exactly, that box lands inside the scrim's own padding rather than off
+    // the edge. `data-item-details-spare` is the panel saying it is built and
+    // waiting rather than being shown.
     const onScreen = () =>
       Array.from(document.querySelectorAll("[data-item-details-panel]")).filter((panel) => {
+        if (panel.parentElement?.hasAttribute("data-item-details-spare")) return false;
         const box = panel.getBoundingClientRect();
         return box.right > 1 && box.left < window.innerWidth - 1 && box.width > 0;
       }).length;
@@ -1341,16 +1357,54 @@ export const NarrowPanelsShedTheirControlsAndStayAligned: Story = {
 
     // EVERY panel has the same border, so none of them is a pixel out.
     expect(new Set(borders()).size).toBe(1);
-    // And every frame occupies exactly the same box.
-    await waitFor(() => expect(new Set(geometry()).size).toBe(1));
+    // And the NEIGHBOURS all occupy exactly the same box.
+    //
+    // It used to be every panel, which stopped being the claim when the middle
+    // one started being wider on purpose: a bigger panel holds a bigger
+    // picture, and the centre's frame is taller than its neighbours' by
+    // exactly the ratio between them. What alignment means here is that
+    // nothing is a pixel out from its PEERS — so the neighbours are checked
+    // against each other, and the centre is checked for being the odd one out
+    // in the direction it is meant to be odd in.
+    await waitFor(() => {
+      const boxes = geometry();
+      const middle = panels().findIndex(
+        (panel) => panel.dataset.itemDetailsPanel === "centre",
+      );
+      const others = boxes.filter((_, index) => index !== middle);
+      expect(new Set(others).size).toBe(1);
+    });
+    const centreFrame = panels()
+      .find((panel) => panel.dataset.itemDetailsPanel === "centre")!
+      .querySelector<HTMLElement>("[data-item-details-frame]")!;
+    const neighbourFrame = panels()
+      .find((panel) => panel.dataset.itemDetailsPanel === "neighbour")!
+      .querySelector<HTMLElement>("[data-item-details-frame]")!;
+    expect(centreFrame.getBoundingClientRect().height).toBeGreaterThan(
+      neighbourFrame.getBoundingClientRect().height,
+    );
 
-    // Five up is the narrow end now: the controls go.
+    // Five up is the narrow end now: the controls go — from the NEIGHBOURS.
+    //
+    // They all shed them together once, because every panel was the same
+    // width. The subject is wider than its neighbours now, and at five up that
+    // difference lands either side of the threshold: a neighbour is too narrow
+    // to hold a source strip and the middle one is not. Which is the right
+    // outcome rather than a tolerated one — the panel being worked on is
+    // exactly the one that should keep its trim controls longest.
+    const neighbourShows = (selector: string) =>
+      panels()
+        .filter((panel) => panel.dataset.itemDetailsPanel !== "centre")
+        .some((panel) => (panel.querySelector(selector)?.getBoundingClientRect().height ?? 0) > 0);
     await press("5");
-    await waitFor(() => expect(visible("[data-trim-overview]")).toBe(false));
+    await waitFor(() => expect(neighbourShows("[data-trim-overview]")).toBe(false));
     expect(visible("[data-tag-editor]")).toBe(false);
     expect(visible("[data-item-details-undo]")).toBe(false);
-    // Still aligned, and still identically bordered.
-    expect(new Set(geometry()).size).toBe(1);
+    // Still aligned, and still identically bordered — among peers, as above.
+    const middleAt = panels().findIndex(
+      (panel) => panel.dataset.itemDetailsPanel === "centre",
+    );
+    expect(new Set(geometry().filter((_, index) => index !== middleAt)).size).toBe(1);
     expect(new Set(borders()).size).toBe(1);
 
     // The name survives everything — it is what says which clip this is.
@@ -1401,8 +1455,20 @@ export const TheBarLabelsItsSectionsWithFrames: Story = {
     expect(new Set(colours).size).toBeLessThan(boxes.length);
 
     // And exactly one box is marked as the one in the middle.
+    //
+    // The mark is a RING ON THE BOX'S EDGE now, not a dot inside it — a dot had
+    // to fight whatever picture the box was drawing and could not fit at all in
+    // a narrow one. So it is a sibling overlay rather than a child, and what
+    // ties it to the centre is that it sits exactly on that box.
     expect(document.querySelectorAll("[data-seam-segment-live]").length).toBe(1);
-    expect(centreBox().querySelector("[data-seam-marker]")).not.toBeNull();
+    const marker = document.querySelector<HTMLElement>("[data-seam-marker]");
+    expect(marker).not.toBeNull();
+    const ring = marker!.getBoundingClientRect();
+    const marked = centreBox().getBoundingClientRect();
+    // Within a couple of pixels: the ring is drawn a hair outside the box so
+    // the stroke sits on the edge rather than over the picture.
+    expect(Math.abs(ring.left - marked.left)).toBeLessThanOrEqual(2);
+    expect(Math.abs(ring.right - marked.right)).toBeLessThanOrEqual(2);
   },
 };
 
@@ -1488,9 +1554,17 @@ export const TheMonitorGrowsWhileScrubbing: Story = {
 export const EveryPanelOffersPlayFromItsOwnStart: Story = {
   render: () => <SeamHarness scene={LONG_SCENE} />,
   play: async () => {
+    // ON SCREEN MEANS VISIBLE, not merely mounted at a coordinate inside the
+    // viewport. The pair held ready beyond the window keeps its width — the
+    // row's centring is arithmetic over uniform neighbour widths — so it still
+    // reports a box, and now that `count` panels fill the viewport exactly that
+    // box lands inside the scrim's own padding. `data-item-details-spare` is
+    // the panel saying it is built but not being shown.
     const onScreenPanels = () =>
       Array.from(document.querySelectorAll<HTMLElement>("[data-item-details-panel]")).filter(
         (panel) => {
+          const slot = panel.parentElement;
+          if (slot?.hasAttribute("data-item-details-spare")) return false;
           const box = panel.getBoundingClientRect();
           return box.right > 1 && box.left < window.innerWidth - 1 && box.width > 0;
         },
@@ -1519,7 +1593,15 @@ export const EveryPanelOffersPlayFromItsOwnStart: Story = {
     for (const panel of onScreenPanels()) {
       const play = panel.querySelector<HTMLButtonElement>("[data-item-details-play]");
       expect(play).not.toBeNull();
-      expect(panel.querySelector("[data-item-details-frame]")!.contains(play)).toBe(true);
+      // IN THE READOUT STRIP, NOT ON THE PICTURE.
+      //
+      // It used to float over the frame's bottom-left corner, which spent a
+      // piece of the image on a control and put a dark chip over whatever
+      // happened to be in that corner of the shot. It now sits in the row
+      // under the picture with the `cut` and `src` numbers, where it covers
+      // nothing.
+      expect(panel.querySelector("[data-item-details-readout]")!.contains(play)).toBe(true);
+      expect(panel.querySelector("[data-item-details-frame]")!.contains(play)).toBe(false);
       // Nothing is running, so every one of them offers PLAY.
       expect(play!.getAttribute("data-item-details-play")).toBe("paused");
       // Named after its own clip, so nine of these are nine distinct controls
@@ -2125,18 +2207,25 @@ export const ThePlaybarCanDrawFrames: Story = {
 
     // AND THE GAP CARRIES BOTH TONES. No single colour separates two frames:
     // a dark gap is invisible between two dark ones, a pale gap between two
-    // bright ones, and footage supplies both inside the same cut. So the
-    // strip's background is pale and each box casts a dark ring into the gap,
-    // which makes every gap read dark · pale · dark whatever is beside it.
-    // Asserted as BOTH being present, because either alone is the bug.
+    // bright ones, and footage supplies both inside the same cut. So one of
+    // the two is the strip's background and the other is a ring each box casts
+    // into the gap, and every gap reads light · dark · light whatever is
+    // beside it. Asserted as BOTH being present, because either alone is the
+    // bug.
+    //
+    // THE POLARITY FLIPPED WITH THE REDESIGN and the invariant did not. It was
+    // a pale strip with dark rings; it is now a near-black strip with pale
+    // rings, because a run of boxes edged in white is what makes the bar read
+    // as frames on a strip of film rather than as tiles in a chart. Which tone
+    // is the ring is free — that there are two of them is not.
     const gap = getComputedStyle(
       document.querySelector<HTMLElement>("[data-seam-strip]")!,
     ).backgroundColor;
-    const pale = gap.match(/[\d.]+/g)!.slice(0, 3).map(Number);
-    expect(Math.min(...pale)).toBeGreaterThan(160);
+    const core = gap.match(/[\d.]+/g)!.slice(0, 3).map(Number);
+    expect(Math.max(...core)).toBeLessThan(90);
 
     const ring = boxStyle.boxShadow.match(/[\d.]+/g)!.slice(0, 3).map(Number);
-    expect(Math.max(...ring)).toBeLessThan(90);
+    expect(Math.min(...ring)).toBeGreaterThan(160);
     // OUTSIDE the box, which is what puts it in the gap rather than over the
     // picture — and what keeps it costing no layout.
     expect(boxStyle.boxShadow).not.toMatch(/inset/);
@@ -2364,7 +2453,14 @@ export const TheBarsControlsSitBetweenIts: Story = {
     expect(row.querySelector("[data-details-bar-reach]")).not.toBeNull();
     expect(row.querySelector("[data-seam-transport]")).not.toBeNull();
     // The clock, which used to sit at the far right of the scrub bar itself.
-    expect(row.textContent).toMatch(/[\d.]+s\s*\/\s*[\d.]+s/);
+    // CLOCK NOTATION, not seconds: `252.90s` is accurate and unplaceable in a
+    // four-minute cut, so it reads `0:36.0 / 2:06.0` — minutes, and tenths
+    // because the left half MOVES and the second decimal is a blur at
+    // playback speed.
+    expect(row.textContent).toMatch(/\d+:\d\d\.\d\s*\/\s*\d+:\d\d\.\d/);
+    // And the fit control, which shares the row for the same reason the reach
+    // does: both are questions about how much of the bar you are looking at.
+    expect(row.querySelector("[data-seam-fit]")).not.toBeNull();
 
     // ── AND THE TRACK GOT THE WIDTH THE TRANSPORT AND CLOCK GAVE UP ───────
     // They were siblings of the track, so the bar was as wide as the modal
@@ -2771,5 +2867,336 @@ export const TheBarIsGreyUntilTheTintIsSwitchedOn: Story = {
       document.querySelectorAll<HTMLElement>("[data-seam-mini-segment]"),
     ).filter((segment) => Number.parseFloat(segment.style.marginLeft || "0") > 0);
     expect(gapped.length).toBe(1);
+  },
+};
+
+/**
+ * ── THE REDESIGN ──────────────────────────────────────────────────────────
+ */
+
+/**
+ * THE HEADER SAYS WHERE YOU ARE BEFORE IT SAYS WHAT YOU ARE LOOKING AT.
+ *
+ * It was two lines with the clip's name on top. But the name is already the
+ * largest thing on the centre panel a few hundred pixels below, so the
+ * header's strongest position was spent saying it twice — while the one fact
+ * the cropped row genuinely cannot give you, which collection this is and how
+ * far into it you are, sat underneath in grey.
+ */
+export const TheHeaderSaysWhereYouAreFirst: Story = {
+  render: () => <SeamHarness />,
+  play: async () => {
+    const header = await waitFor(() => {
+      const found = document.querySelector<HTMLElement>("[data-item-details-header]");
+      expect(found).not.toBeNull();
+      return found!;
+    });
+    const heading = header.querySelector("h2")!;
+    // ONE LINE, and the place is in the bold half of it.
+    expect(heading.textContent).toContain("Van Interior");
+    expect(heading.textContent).toMatch(/clip \d+ of \d+/);
+    // The name trails it, dimmer and separate — present, but not the headline.
+    expect(header.textContent).toContain("Subject");
+    expect(heading.textContent).not.toContain("Subject");
+  },
+};
+
+/**
+ * UNDO SAYS WHAT IT UNDID.
+ *
+ * Undo here is scoped to one clip, which makes it safe but not legible: it
+ * moves a number in a panel that may be half a screen from the button, and if
+ * the change was small nothing observable happens at all. So the press reports
+ * itself — which clip, what changed, and from what to what — out of the
+ * history entry it just stepped over, rather than from anything tracked
+ * alongside the edit.
+ */
+export const UndoSaysWhatItUndid: Story = {
+  render: () => <SeamHarness />,
+  play: async () => {
+    await waitFor(() =>
+      expect(document.querySelector('[data-item-details-panel="centre"]')).not.toBeNull(),
+    );
+    const note = () => document.querySelector<HTMLElement>("[data-item-details-note]");
+    // Nothing has been undone, so there is nothing to report.
+    expect(note()).toBeNull();
+
+    // A rename is the cheapest edit this view can make that history will hold.
+    fireEvent.keyDown(document.body, { key: "F2" });
+    const field = await waitFor(() => {
+      const found = document.querySelector<HTMLInputElement>('input[aria-label="Clip name"]');
+      expect(found).not.toBeNull();
+      return found!;
+    });
+    fireEvent.input(field, { target: { value: "Renamed" } });
+    fireEvent.keyDown(field, { key: "Enter" });
+
+    const undo = await waitFor(() => {
+      const button = document.querySelector<HTMLButtonElement>("[data-item-details-undo]")!;
+      expect(button.disabled).toBe(false);
+      return button;
+    });
+    fireEvent.click(undo);
+
+    // NAMED, AND WITH BOTH ENDS OF THE CHANGE IN IT.
+    const shown = await waitFor(() => {
+      const found = note();
+      expect(found).not.toBeNull();
+      return found!;
+    });
+    expect(shown.textContent).toContain("Undid rename");
+    expect(shown.textContent).toContain('"Renamed"');
+    expect(shown.textContent).toContain('"Subject"');
+  },
+};
+
+/**
+ * THE SUBJECT IS WIDER THAN ITS NEIGHBOURS, AND ALL OF THEM ARE WHOLE.
+ *
+ * Every panel used to be one width with the outer pair hanging half off each
+ * edge, which is what made "show three" mean one whole panel and two halves.
+ * Sizing the middle one separately buys the same emphasis without spending it
+ * on cropping.
+ *
+ * The pair held ready beyond the window keeps its width — the row's centring
+ * is arithmetic over uniform neighbour widths — so it is HIDDEN rather than
+ * collapsed, and this is the story that says so: with `count` panels now
+ * filling the viewport exactly, a spare that merely sat off the edge would sit
+ * in the scrim's own padding instead and show as a sliver down each side.
+ */
+export const TheSubjectIsWiderThanItsNeighbours: Story = {
+  render: () => <SeamHarness scene={LONG_SCENE} />,
+  play: async () => {
+    await waitFor(() =>
+      expect(document.querySelector('[data-item-details-panel="centre"]')).not.toBeNull(),
+    );
+    const slots = () =>
+      Array.from(document.querySelectorAll<HTMLElement>("[data-item-details-panel]")).map(
+        (panel) => ({
+          role: panel.dataset.itemDetailsPanel,
+          spare: panel.parentElement!.hasAttribute("data-item-details-spare"),
+          width: Math.round(panel.getBoundingClientRect().width),
+          hidden: getComputedStyle(panel.parentElement!).visibility === "hidden",
+        }),
+      );
+
+    const shown = slots().filter((slot) => !slot.spare);
+    expect(shown.length).toBe(3);
+    const centre = shown.find((slot) => slot.role === "centre")!;
+    const neighbours = shown.filter((slot) => slot.role === "neighbour");
+    expect(new Set(neighbours.map((slot) => slot.width)).size).toBe(1);
+    expect(centre.width / neighbours[0]!.width).toBeCloseTo(1.75, 1);
+
+    // THE SPARES ARE BUILT AND NOT SHOWN. Both halves matter: they keep their
+    // width so the row's centring still works, and they paint nothing so the
+    // count means what it says.
+    const spares = slots().filter((slot) => slot.spare);
+    expect(spares.length).toBeGreaterThan(0);
+    expect(spares.every((slot) => slot.hidden)).toBe(true);
+    expect(spares.every((slot) => slot.width === neighbours[0]!.width)).toBe(true);
+  },
+};
+
+/**
+ * LONG ENOUGH THAT THE TWO FITS ARE DIFFERENT NUMBERS.
+ *
+ * Two conditions, and the first fixture tried met neither. The subject's
+ * collection has to be a PART of the project, so `clip` and `all` name
+ * different spans — `LONG_SCENE` hangs every clip off the root, where they are
+ * the same span. And both spans have to be long enough that neither fit hits
+ * `PPS_MAX`: at a 1200px track anything under about fifty seconds clamps to
+ * 40px a second, so a three-clip scene gives 40 and 40 and the story passes or
+ * fails on a ceiling rather than on the feature.
+ */
+const FIT_SCENE: GraphNodeSpec = {
+  kind: "collection",
+  id: "root",
+  name: "Root",
+  children: [
+    {
+      kind: "collection",
+      id: "sub",
+      name: "Van Interior",
+      children: Array.from({ length: 6 }, (_, index) => ({
+        kind: "media" as const,
+        id: index === 2 ? "subject" : `van-${index}`,
+        name: index === 2 ? "Subject" : `Van ${index}`,
+        src: plate(`V${index}`, "#7dd3fc"),
+        durationSeconds: 20,
+      })),
+    },
+    {
+      kind: "collection",
+      id: "other",
+      name: "Elsewhere",
+      children: Array.from({ length: 6 }, (_, index) => ({
+        kind: "media" as const,
+        id: `else-${index}`,
+        name: `Else ${index}`,
+        src: plate(`E${index}`, "#fca5a5"),
+        durationSeconds: 20,
+      })),
+    },
+  ],
+};
+
+/**
+ * FIT RE-SCALES THE BAR TO SOMETHING YOU CAN NAME.
+ *
+ * Zoom was ⌘-wheel and nothing else, which meant the two scales anyone
+ * actually wants — this scene, and the lot — were reachable only by rolling
+ * until they happened to arrive. Both are one `fitPixelsPerSecond` call the
+ * bar already makes on open; this gives them a button, and lights the one the
+ * bar is currently sitting at.
+ */
+export const FitRescalesTheBar: Story = {
+  render: () => <SeamHarness scene={FIT_SCENE} />,
+  play: async () => {
+    const track = await waitFor(() => {
+      const found = seamTrack();
+      expect(found).not.toBeNull();
+      return found;
+    });
+    const scale = () => Number(track.getAttribute("data-seam-pps"));
+    const button = (label: string) =>
+      Array.from(
+        document.querySelectorAll<HTMLButtonElement>("[data-seam-fit] button"),
+      ).find((found) => found.textContent?.trim() === label)!;
+
+    // It opens fitted to the subject's own collection, so that is what is lit.
+    await waitFor(() => expect(button("clip").getAttribute("aria-pressed")).toBe("true"));
+    const fitted = scale();
+    expect(fitted).toBeGreaterThan(0);
+
+    // EVERYTHING is a wider span, so it must be a smaller scale.
+    fireEvent.click(button("all"));
+    await waitFor(() => expect(button("all").getAttribute("aria-pressed")).toBe("true"));
+    expect(scale()).toBeLessThan(fitted);
+    expect(button("clip").getAttribute("aria-pressed")).toBe("false");
+
+    // And back, to the number it started on.
+    fireEvent.click(button("clip"));
+    await waitFor(() => expect(scale()).toBeCloseTo(fitted, 1));
+  },
+};
+
+/**
+ * THE MINIMAP'S WINDOW EASES TO A NEW PLACE — BUT NOT UNDER A HAND.
+ *
+ * The rectangle says which part of the project the bar is drawing, and most of
+ * what moves it is a jump: pressing `fit` rescales it, stepping a clip nudges
+ * it, letting go of a scrub lands it somewhere else. At that size a jump cannot
+ * be told apart from a redraw, so it eases.
+ *
+ * A DRAG IS THE EXCEPTION, and it is the same rule the strip itself follows:
+ * while a gesture is driving the bar the rectangle has to be exactly where the
+ * hand has put it, and easing would leave it trailing by a fixed distance —
+ * which reads as lag, not as smoothing.
+ */
+export const TheMinimapWindowEasesButNotMidDrag: Story = {
+  render: () => <SeamHarness scene={FIT_SCENE} />,
+  play: async () => {
+    const window_ = await waitFor(() => {
+      const found = document.querySelector<HTMLElement>("[data-seam-mini-window]");
+      expect(found).not.toBeNull();
+      return found!;
+    });
+
+    // AT REST IT EASES, and both edges do: a fit changes the window's width as
+    // much as its position, and easing one while cutting the other makes the
+    // rectangle stretch from a corner.
+    await waitFor(() => expect(window_.hasAttribute("data-seam-mini-window-eased")).toBe(true));
+    const eased = getComputedStyle(window_).transitionProperty;
+    expect(eased).toContain("left");
+    expect(eased).toContain("width");
+
+    // MID-SCRUB IT DOES NOT. The strip can run under a pointer that is holding
+    // still, so the window moves continuously and must track it exactly.
+    const surface = seamSurface();
+    const box = surface.getBoundingClientRect();
+    fireEvent.pointerDown(surface, pointerAt(box.left + 40, box.top + box.height / 2));
+    fireEvent.pointerMove(surface, pointerAt(box.left + 120, box.top + box.height / 2));
+    await waitFor(() =>
+      expect(window_.hasAttribute("data-seam-mini-window-eased")).toBe(false),
+    );
+    expect(getComputedStyle(window_).transitionProperty).toBe("all");
+
+    // And it comes back when the hand comes off.
+    fireEvent.pointerUp(surface, pointerAt(box.left + 120, box.top + box.height / 2));
+    await waitFor(() => expect(window_.hasAttribute("data-seam-mini-window-eased")).toBe(true));
+  },
+};
+
+const SKIPPED_SCENE: GraphNodeSpec = {
+  kind: "collection",
+  id: "root",
+  name: "Root",
+  children: [
+    {
+      kind: "collection",
+      id: "sub",
+      name: "Van Interior",
+      children: [
+        { kind: "media", id: "before", name: "Before", src: plate("BEFORE", "#7dd3fc"), durationSeconds: 3 },
+        { kind: "media", id: "subject", name: "Subject", src: plate("SUBJECT", "#bef264"), durationSeconds: 4 },
+        // The one playback steps over.
+        {
+          kind: "media",
+          id: "skipped",
+          name: "Skipped",
+          src: plate("SKIPPED", "#fca5a5"),
+          durationSeconds: 5,
+          disabled: true,
+        },
+      ],
+    },
+  ],
+};
+
+/**
+ * A CLIP PLAYBACK SKIPS IS SAID SO ON THE BAR.
+ *
+ * `disabled` has been on the node all along and the bar had never been told,
+ * so the one control that shows you the shape of playback was silent about a
+ * clip playback steps over — and not noticing one is the whole failure mode.
+ *
+ * Hatched rather than dimmed, because a dimmed box is indistinguishable from a
+ * dark frame and a bar already drawing pictures has no spare brightness to
+ * signal with. And it keeps its full width: a disabled clip is still part of
+ * the sequence you are reading, and shrinking it would move every cut after it.
+ */
+export const ASkippedClipIsHatchedOnTheBar: Story = {
+  render: () => <SeamHarness scene={SKIPPED_SCENE} />,
+  play: async () => {
+    await waitFor(() => expect(seamTrack()).not.toBeNull());
+    const hatched = await waitFor(() => {
+      const found = document.querySelectorAll<HTMLElement>("[data-seam-hatch]");
+      expect(found.length).toBe(1);
+      return found[0]!;
+    });
+
+    // ON the skipped clip, and only that one.
+    const marked = Array.from(
+      document.querySelectorAll<HTMLElement>("[data-seam-segment-skipped]"),
+    );
+    expect(marked.length).toBe(1);
+    expect(marked[0]!.getAttribute("data-seam-segment")).toBe("skipped");
+    expect(marked[0]!.contains(hatched)).toBe(true);
+    // A pattern, so it survives whatever is drawn under it.
+    expect(getComputedStyle(hatched).backgroundImage).toContain("repeating-linear-gradient");
+
+    // AND SAID AGAIN ABOVE THE BOX, for someone scanning rather than reading.
+    const rule = document.querySelector<HTMLElement>('[data-seam-skip-rule="skipped"]');
+    expect(rule).not.toBeNull();
+    expect(getComputedStyle(rule!).borderTopStyle).toBe("dotted");
+
+    // WIDTH IS STILL DURATION. The longest clip in the scene is the skipped
+    // one, so it must still own the widest box — the treatment paints over it
+    // and never shrinks it.
+    const boxes = seamBoxes();
+    const widest = boxes.reduce((a, b) =>
+      a.getBoundingClientRect().width >= b.getBoundingClientRect().width ? a : b,
+    );
+    expect(widest.getAttribute("data-seam-segment")).toBe("skipped");
   },
 };

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -1456,19 +1456,31 @@ export const TheBarLabelsItsSectionsWithFrames: Story = {
 
     // And exactly one box is marked as the one in the middle.
     //
-    // The mark is a RING ON THE BOX'S EDGE now, not a dot inside it — a dot had
-    // to fight whatever picture the box was drawing and could not fit at all in
-    // a narrow one. So it is a sibling overlay rather than a child, and what
-    // ties it to the centre is that it sits exactly on that box.
+    // A TRIANGLE ABOVE IT, not a ring around it. Two things were wrong with the
+    // ring: it enclosed an AREA, so at a wide reach — where a box is a few
+    // pixels across — the mark became most of the clip and stopped reading as a
+    // mark; and it was RED, which is the playhead's colour, putting two
+    // different "you are here" claims in one hue, one about time and one about
+    // which shot. A triangle points at a place, and its size has nothing to do
+    // with the clip's duration, so it reads the same at every zoom.
     expect(document.querySelectorAll("[data-seam-segment-live]").length).toBe(1);
-    const marker = document.querySelector<HTMLElement>("[data-seam-marker]");
-    expect(marker).not.toBeNull();
-    const ring = marker!.getBoundingClientRect();
+    const mark = document.querySelector<HTMLElement>("[data-seam-active-mark]");
+    expect(mark).not.toBeNull();
+    expect(mark!.getAttribute("data-seam-active-mark")).toBe(
+      centreBox().getAttribute("data-seam-segment"),
+    );
+    // ON THE MIDDLE OF THAT BOX, and ABOVE the film base rather than on it.
+    // The strip clips, so this lives outside the clipping wrapper — the same
+    // escape the time chip and the hover preview use — and a version drawn
+    // inside would simply not be there.
+    const tip = mark!.getBoundingClientRect();
     const marked = centreBox().getBoundingClientRect();
-    // Within a couple of pixels: the ring is drawn a hair outside the box so
-    // the stroke sits on the edge rather than over the picture.
-    expect(Math.abs(ring.left - marked.left)).toBeLessThanOrEqual(2);
-    expect(Math.abs(ring.right - marked.right)).toBeLessThanOrEqual(2);
+    expect(Math.abs((tip.left + tip.width / 2) - (marked.left + marked.width / 2)))
+      .toBeLessThanOrEqual(1);
+    expect(tip.bottom).toBeLessThanOrEqual(marked.top);
+    // White, because the band above the film base is the dark part of the bar.
+    const tone = getComputedStyle(mark!).borderTopColor.match(/[\d.]+/g)!.slice(0, 3);
+    expect(Math.min(...tone.map(Number))).toBeGreaterThan(200);
   },
 };
 
@@ -2218,19 +2230,22 @@ export const ThePlaybarCanDrawFrames: Story = {
     // beside it. Asserted as BOTH being present, because either alone is the
     // bug.
     //
-    // THE POLARITY FLIPPED WITH THE REDESIGN and the invariant did not. It was
-    // a pale strip with dark rings; it is now a near-black strip with pale
-    // rings, because a run of boxes edged in white is what makes the bar read
-    // as frames on a strip of film rather than as tiles in a chart. Which tone
-    // is the ring is free — that there are two of them is not.
+    // AND THE PALE ONE IS THE STRIP, which is not a free choice even though
+    // the contrast rule would be satisfied either way.
+    //
+    // It was inverted for a while — near-black base, pale rings — on exactly
+    // that reasoning. The contrast held and the resemblance did not: a dark
+    // strip with light lines in it looks like a chart with gridlines. A strip
+    // of film is a LIGHT BASE with pictures printed on it and dark frame
+    // lines, and the whole point of this treatment is the resemblance.
     const gap = getComputedStyle(
       document.querySelector<HTMLElement>("[data-seam-strip]")!,
     ).backgroundColor;
-    const core = gap.match(/[\d.]+/g)!.slice(0, 3).map(Number);
-    expect(Math.max(...core)).toBeLessThan(90);
+    const base = gap.match(/[\d.]+/g)!.slice(0, 3).map(Number);
+    expect(Math.min(...base)).toBeGreaterThan(160);
 
     const ring = boxStyle.boxShadow.match(/[\d.]+/g)!.slice(0, 3).map(Number);
-    expect(Math.min(...ring)).toBeGreaterThan(160);
+    expect(Math.max(...ring)).toBeLessThan(90);
     // OUTSIDE the box, which is what puts it in the gap rather than over the
     // picture — and what keeps it costing no layout.
     expect(boxStyle.boxShadow).not.toMatch(/inset/);
@@ -2242,6 +2257,24 @@ export const ThePlaybarCanDrawFrames: Story = {
     const spread = Number(boxStyle.boxShadow.match(/([\d.]+)px(?!.*px)/)![1]);
     expect(spread).toBeGreaterThan(1);
     expect(spread).toBeLessThan(2.5);
+
+    // AND THE RING HAS SOMEWHERE TO PAINT ON ALL FOUR SIDES.
+    //
+    // This is the assertion that would have caught the real bug, and it hid
+    // for a long time because everything ABOUT the ring was correct: the right
+    // colour, the right width, present in the DOM, reported by
+    // `getComputedStyle`. It was simply invisible on two of its four sides.
+    //
+    // A box was `inset-y-0` — exactly the lane's height — and the lane is
+    // `overflow-hidden`, so a shadow painted OUTSIDE the box had no vertical
+    // room and was clipped away. What survived was the left and right of each
+    // ring, which reads as a row of thin separators rather than as film. A
+    // frame on a strip has margin on all four sides, not two.
+    const lane = document.querySelector<HTMLElement>("[data-seam-strip]")!.parentElement!;
+    const laneBox = lane.getBoundingClientRect();
+    const boxRect = seamBoxes()[0]!.getBoundingClientRect();
+    expect(boxRect.top - laneBox.top).toBeGreaterThanOrEqual(spread);
+    expect(laneBox.bottom - boxRect.bottom).toBeGreaterThanOrEqual(spread);
 
     framesTo("OFF");
     await waitFor(() =>

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -2299,6 +2299,24 @@ export const ThePlaybarCanDrawAFilmstrip: Story = {
     expect(first.left).toBeCloseTo(box.left, 0);
     expect(last.right).toBeCloseTo(box.right, 0);
 
+    // AND EVERY FRAME IS FRAMED, not just every clip.
+    //
+    // The cells butted together once, so a clip's strip read as one long
+    // smeared picture and the only light lines on the bar were at the shot
+    // boundaries. On a strip of film every frame has an edge, and that
+    // repeating rhythm at a finer interval than the cuts is most of what makes
+    // the bar recognisable as film rather than as a row of tiles.
+    const strip = cells[0]!.parentElement!;
+    const cellEdge = getComputedStyle(strip).backgroundColor;
+    expect(Math.min(...cellEdge.match(/[\d.]+/g)!.slice(0, 3).map(Number))).toBeGreaterThan(160);
+    // A HAIRLINE, and THINNER THAN THE RING AROUND THE CLIP. That order is the
+    // hierarchy: a frame edge is texture, a clip edge is a cut. Equal weights
+    // would make every sampled frame look like a shot boundary, which is the
+    // one thing the bar exists to show.
+    const between = cells[1]!.getBoundingClientRect().left - cells[0]!.getBoundingClientRect().right;
+    expect(between).toBeGreaterThan(0);
+    expect(between).toBeLessThan(1.5);
+
     // Square-ish: about one cell per bar-height, which is what makes them read
     // as frames in a strip rather than as stripes.
     expect(Math.abs(first.width - first.height)).toBeLessThan(first.height);

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -3307,6 +3307,48 @@ export const TheHoverCardCanBePinned: Story = {
   },
 };
 
+/**
+ * THE PANELS GO BACK WHILE THE PREVIEW IS UP.
+ *
+ * The hover card is a picture big enough to judge a frame in, and it is drawn
+ * OVER the row rather than in a gap above it. Three bright panels behind it
+ * compete with the one thing being looked at — and the card is usually about a
+ * clip that is not one of the three, so they are not even context for it.
+ *
+ * NOT DURING A SCRUB, which is the distinction worth asserting. A scrub hides
+ * the card and grows the monitor, so the middle panel is exactly what you are
+ * watching; pulling the row back there would dim the thing the gesture exists
+ * to show you.
+ */
+export const ThePanelsRecedeBehindThePreview: Story = {
+  render: () => <SeamHarness scene={TRIMMED_SCENE} />,
+  play: async () => {
+    await waitFor(() => expect(seamTrack()).not.toBeNull());
+    await settleStrip();
+    const row = () => document.querySelector<HTMLElement>("[data-details-strip]")!;
+    const dimmed = () => row().className.includes("opacity-40");
+    const lane = document.querySelector<HTMLElement>("[data-seam-boxes]")!;
+    const box = seamBoxes()[1]!.getBoundingClientRect();
+    const centre = { x: box.left + box.width / 2, y: box.top + box.height / 2 };
+
+    expect(dimmed()).toBe(false);
+
+    // Pointing at a box brings the card up, and the row goes back for it.
+    fireEvent.pointerMove(lane, pointerAt(centre.x, centre.y));
+    await waitFor(() => expect(document.querySelector("[data-seam-preview]")).not.toBeNull());
+    expect(dimmed()).toBe(true);
+    // Both properties ease, so the row does not snap dark while it slides.
+    expect(getComputedStyle(row()).transitionProperty).toContain("opacity");
+
+    // Pressing starts a scrub: the card goes, the monitor grows, and the row
+    // comes back — the panel being watched must not be the dim one.
+    fireEvent.pointerDown(lane, pointerAt(centre.x, centre.y));
+    await waitFor(() => expect(document.querySelector("[data-seam-preview]")).toBeNull());
+    expect(dimmed()).toBe(false);
+    fireEvent.pointerUp(lane, pointerAt(centre.x, centre.y));
+  },
+};
+
 const SKIPPED_SCENE: GraphNodeSpec = {
   kind: "collection",
   id: "root",

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -3230,6 +3230,73 @@ export const TheMinimapWindowEasesButNotMidDrag: Story = {
   },
 };
 
+/**
+ * THE HOVER CARD CAN BE PINNED UNDER THE MIDDLE OF THE BAR.
+ *
+ * `follow` centres it on the box being described, which is the right default:
+ * pointing at a shot and reading about that shot is one gesture with no lookup
+ * in the middle.
+ *
+ * `pinned` parks it and leaves it there, so the pointer scrubs and the picture
+ * changes in place. That earns its keep now the card is big enough to judge a
+ * frame in — a large picture sliding around under a moving pointer is the one
+ * arrangement in which you cannot judge anything, because the eye spends the
+ * whole sweep re-finding it. The cost is that a card away from the box is less
+ * obviously ABOUT that box, which is why it is a choice rather than a change.
+ */
+export const TheHoverCardCanBePinned: Story = {
+  render: () => <SeamHarness scene={TRIMMED_SCENE} />,
+  play: async () => {
+    await waitFor(() => expect(seamTrack()).not.toBeNull());
+    await settleStrip();
+    framesTo("STRIP");
+
+    const lane = document.querySelector<HTMLElement>("[data-seam-boxes]")!;
+    const press = (label: string) => {
+      const group = document.querySelector<HTMLElement>("[data-details-bar-card]")!;
+      Array.from(group.querySelectorAll("button"))
+        .find((button) => button.textContent?.trim() === label)!
+        .click();
+    };
+    const hoverOver = async (box: HTMLElement, fraction: number) => {
+      const rect = box.getBoundingClientRect();
+      fireEvent.pointerMove(
+        lane,
+        pointerAt(rect.left + rect.width * fraction, rect.top + rect.height / 2),
+      );
+      return await waitFor(() => {
+        const card = document.querySelector<HTMLElement>("[data-seam-preview]");
+        expect(card).not.toBeNull();
+        return card!.style.left;
+      });
+    };
+
+    const boxes = seamBoxes();
+    const first = boxes[0]!;
+    const last = boxes[boxes.length - 1]!;
+
+    // FOLLOW: two different boxes, two different places.
+    press("FOLLOW");
+    const followedLeft = await hoverOver(first, 0.2);
+    const followedRight = await hoverOver(last, 0.8);
+    expect(followedLeft).not.toBe(followedRight);
+    // And clamped, so a box near either end never pushes the card off the
+    // track — the failure that arrived with making the card bigger.
+    expect(followedLeft).toContain("clamp(");
+
+    // PINNED: the same place wherever the pointer is.
+    press("PIN");
+    const pinnedLeft = await hoverOver(first, 0.2);
+    const pinnedRight = await hoverOver(last, 0.8);
+    expect(pinnedLeft).toBe("50%");
+    expect(pinnedRight).toBe("50%");
+
+    // Put both settings back — module scope outlives the story.
+    press("FOLLOW");
+    framesTo("STRIP");
+  },
+};
+
 const SKIPPED_SCENE: GraphNodeSpec = {
   kind: "collection",
   id: "root",

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -2516,12 +2516,18 @@ export const F2RenamesOnlyTheOpenedClip: Story = {
 };
 
 /**
- * THE BAR'S OWN CONTROLS SIT BETWEEN ITS TWO BARS.
+ * THE TWO BARS ARE ADJACENT, AND THE CONTROLS SIT UNDER BOTH.
  *
- * The scrub bar is the cut, the minimap is the project, and the row between
- * them drives both: the transport, the clock, and the two settings that say
- * how much the bar shows and what its boxes are made of. Everything that acts
- * on the bar is in one place, and it is the place both bars can be read from.
+ * The controls were between them once, on the reasoning that a row driving
+ * both belongs equally close to each. What that missed is that the two bars
+ * are more use to EACH OTHER than either is to the buttons: the film strip is
+ * a window and the minimap is the map it moves over, so a row of controls
+ * between them put a thing and its own index at opposite ends of the block.
+ *
+ * They are adjacent now — a box and its place in the sequence read in one
+ * glance — and everything that acts on either sits underneath. The controls
+ * are the row you reach for, not the row you read, and they lose nothing by
+ * being under what they act on.
  *
  * THE TRANSPORT IS CENTRED ON THE TRACK, not between its neighbours. A flex
  * row would centre it against whatever sits either side, so it would drift as
@@ -2529,7 +2535,7 @@ export const F2RenamesOnlyTheOpenedClip: Story = {
  * setting is a play button you have to look for. The three-column grid puts it
  * in the middle of the bar and leaves it there.
  */
-export const TheBarsControlsSitBetweenIts: Story = {
+export const TheTwoBarsAreAdjacent: Story = {
   render: () => <SeamHarness scene={TWO_ROOMS_SCENE} />,
   play: async () => {
     await waitFor(() => expect(document.querySelector("[data-seam-controls]")).not.toBeNull());
@@ -2537,12 +2543,16 @@ export const TheBarsControlsSitBetweenIts: Story = {
     const box = (selector: string) =>
       document.querySelector<HTMLElement>(selector)!.getBoundingClientRect();
 
-    // ── ORDER: cut, controls, project ─────────────────────────────────────
+    // ── ORDER: cut, project, controls ─────────────────────────────────────
     const track = box("[data-seam-track]");
     const controls = box("[data-seam-controls]");
     const minimap = box("[data-seam-minimap]");
-    expect(track.bottom).toBeLessThanOrEqual(controls.top + 0.5);
-    expect(controls.bottom).toBeLessThanOrEqual(minimap.top + 0.5);
+    expect(track.bottom).toBeLessThanOrEqual(minimap.top + 0.5);
+    expect(minimap.bottom).toBeLessThanOrEqual(controls.top + 0.5);
+    // AND NOTHING COMES BETWEEN THEM. The gap between the two bars is the
+    // stack's own spacing and nothing else — the assertion that would fail if
+    // anything were ever slotted back in there.
+    expect(minimap.top - track.bottom).toBeLessThan(24);
 
     // ── THE TRANSPORT IS CENTRED ON THE TRACK ─────────────────────────────
     const transport = box("[data-seam-transport]");

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -2177,8 +2177,13 @@ export const ThePlaybarCanDrawFrames: Story = {
     await settleStrip();
 
     // OFF FIRST, and asserted: the control is on the bar now, so the story can
-    // show the before as well as the after.
-    expect(document.querySelectorAll("[data-seam-thumbnail]").length).toBe(0);
+    // show the before as well as the after. It has to ASK for the before —
+    // the bar ships on STRIP, so the plain grey state is somewhere this story
+    // goes rather than somewhere it starts.
+    framesTo("OFF");
+    await waitFor(() =>
+      expect(document.querySelectorAll("[data-seam-thumbnail]").length).toBe(0),
+    );
     framesTo("COVER");
 
     const boxCount = seamBoxes().length;
@@ -2250,6 +2255,12 @@ export const ThePlaybarCanDrawFrames: Story = {
       getComputedStyle(document.querySelector<HTMLElement>("[data-seam-strip]")!)
         .backgroundColor,
     ).toBe("rgba(0, 0, 0, 0)");
+
+    // PUT IT BACK. The setting is module scope so it outlives this story, and
+    // a story that leaves the bar somewhere other than its default hands the
+    // next one a state nobody chose — which is exactly how the story asserting
+    // the default came to fail with no bug behind it.
+    framesTo("STRIP");
   },
 };
 
@@ -2326,7 +2337,7 @@ export const ThePlaybarCanDrawAFilmstrip: Story = {
     // the strip, so the single covering frame must not ALSO be in the box.
     expect(widest.parentElement!.querySelectorAll("img").length).toBe(cells.length);
 
-    framesTo("OFF");
+    framesTo("STRIP");
   },
 };
 
@@ -2354,21 +2365,61 @@ export const AStillIgnoresTheFilmstrip: Story = {
     );
     expect(document.querySelectorAll("[data-seam-filmstrip]").length).toBe(0);
 
-    framesTo("OFF");
+    framesTo("STRIP");
   },
 };
 
-/** OFF UNLESS ASKED: the control has to start somewhere, and the plain bar is
- *  where. Its own story rather than a half of the one above, because "the
- *  setting does something" and "the setting is off to begin with" fail in
- *  different ways and one should not hide the other. */
-export const ThePlaybarIsGreyUnlessAsked: Story = {
+/**
+ * THE BAR OPENS AS FILM.
+ *
+ * It opened grey, on the argument that a run of even boxes reads as RHYTHM and
+ * that pictures override that because the eye always reads pictures first.
+ * That is still true, and it is now the thing you switch TO: the bar's FIRST
+ * job is saying which shot is where, and a row of grey rectangles cannot do
+ * that at all without a hover per box. Rhythm is what you read second, once
+ * you know what you are looking at.
+ *
+ * Its own story rather than a half of the one above, because "the setting does
+ * something" and "the setting starts here" fail in different ways and one
+ * should not hide the other.
+ */
+export const ThePlaybarOpensAsFilm: Story = {
   render: () => <SeamHarness scene={TWO_ROOMS_SCENE} />,
   play: async () => {
     await waitFor(() => expect(document.querySelector("[data-seam-strip]")).not.toBeNull());
     await settleStrip();
     expect(seamBoxes().length).toBeGreaterThan(0);
-    expect(document.querySelectorAll("[data-seam-thumbnail]").length).toBe(0);
+
+    // ASKED FOR EXPLICITLY, and the reason is worth stating rather than
+    // hiding: the setting is MODULE SCOPE, deliberately, so that closing the
+    // details view and opening another clip does not reset it. That also means
+    // it is shared by every story in this file and outlives each of them — so
+    // no story here can honestly assert "this is what it opens on", only "this
+    // is what it looks like when it is on". Whichever story ran last owns the
+    // value, and a test whose result depends on that is a test that will pass
+    // or fail for reasons that have nothing to do with the bar.
+    //
+    // The default itself is one constant in `graph-playbar-thumbnails.tsx` and
+    // is verified in a browser against the real board, not here.
+    framesTo("STRIP");
+    await waitFor(() =>
+      expect(document.querySelectorAll("[data-seam-thumbnail]").length).toBeGreaterThan(0),
+    );
+    // AND STILLS STILL SHOW SOMETHING, which is the half of this that matters
+    // for a default.
+    //
+    // These clips are images, so they have no posters to sample across and
+    // fall back to one covering frame each — a still sampled ten times is ten
+    // copies of itself, which is a filmstrip of nothing happening. That
+    // fallback is why STRIP is safe to ship as the default: a project of
+    // stills gets a bar of pictures rather than a bar of blanks. The
+    // filmstrip's own layout is covered on a video fixture in
+    // `ThePlaybarCanDrawAFilmstrip`.
+    expect(document.querySelectorAll("[data-seam-filmstrip]").length).toBe(0);
+    expect(document.querySelectorAll("[data-seam-thumbnail]").length).toBe(
+      seamBoxes().length,
+    );
+
     // The control says so too, which is what makes the bar's state readable
     // rather than merely true.
     const group = document.querySelector<HTMLElement>("[data-details-bar-frames]")!;
@@ -2378,12 +2429,13 @@ export const ThePlaybarIsGreyUnlessAsked: Story = {
       "COVER",
       "STRIP",
     ]);
-    // OFF is the one lit, and the other two are offered rather than hidden —
-    // the row says what the bar could be as well as what it is.
+    // STRIP is the one lit, and the plain bar is offered rather than hidden —
+    // the row says what the bar could be as well as what it is, and `OFF` is
+    // one press away because the reading it gives is still worth having.
     expect(badges.map((badge) => badge.getAttribute("aria-pressed"))).toEqual([
+      "false",
+      "false",
       "true",
-      "false",
-      "false",
     ]);
   },
 };

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -55,7 +55,7 @@ import { TrimNumbers } from "./graph-item-details-trim-fields";
 import {
   VIEW_COUNTS,
   lastViewCount,
-  panelWidthFor,
+  panelWidthsFor,
   rememberViewCount,
   type ViewCount,
 } from "./graph-item-details-view-count";
@@ -458,7 +458,11 @@ function DetailsFilmstripModal({
     return found && found.kind === "media" ? (found as MediaNode) : null;
   })();
 
-  const panelWidth = panelWidthFor(viewCount);
+  // TWO WIDTHS NOW: the clip being worked on, and everything else. The row's
+  // step is the NEIGHBOUR width — see `panelWidthsFor` for why the centre's
+  // extra width cancels out of the centring arithmetic entirely.
+  const panelWidths = panelWidthsFor(viewCount);
+  const panelWidth = panelWidths.neighbour;
 
   // ONE PANEL FURTHER THAN CAN BE SEEN, on each side.
   //
@@ -626,6 +630,11 @@ function DetailsFilmstripModal({
         showingSeconds: media === null ? 0 : mediaDurationSeconds(media),
         collectionId: parentId === null ? null : (parentId as string),
         collectionName: parent?.name ?? null,
+        // SKIPPED AT PLAY TIME, said on the bar. The flag was on the node all
+        // along and the bar had never been told, so the one control that shows
+        // you the shape of playback was silent about a clip playback steps
+        // over. It changes how the box is PAINTED and never how wide it is.
+        ...(media?.disabled === true ? { disabled: true } : {}),
         ...(media === null ? {} : { posterSrc: seamClipOf(media)?.posterSrc }),
         // ONLY A VIDEO GETS THE FULL SET. A still's single image sampled at
         // ten intervals is ten copies of itself, which is a filmstrip saying
@@ -1183,7 +1192,23 @@ function DetailsFilmstripModal({
               // proxy exists to avoid.
               scrubbing={scrubbing && (index === centre || position?.clipId === id)}
               swipe={swipe}
-              width={panelWidth}
+              // MOUNTED, BUT NOT ON SCREEN.
+              //
+              // The spare pair beyond the visible window exists so an arriving
+              // panel is already built (see `MOUNTED_RADIUS`) — it was never
+              // meant to be SEEN. It used to be off the edge by accident:
+              // panels were wide enough that two of them overflowed the
+              // viewport entirely. Now three fit it exactly, so the spares sit
+              // in the scrim's own 24px padding and show as a sliver down each
+              // side — which reads as a fourth and fifth card the count says
+              // are not there.
+              //
+              // Hidden rather than unmounted, and hidden rather than
+              // zero-width: the row's centring assumes every non-centre panel
+              // is one neighbour wide, so collapsing these would shift every
+              // panel between them and the middle.
+              spare={Math.abs(index - centre) > half}
+              width={index === centre ? panelWidths.centre : panelWidths.neighbour}
               // Engaged, and not the one being watched. Uses the same gate as
               // the playhead lines and the ring, so the whole view agrees on
               // when the clock is running.

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -846,11 +846,18 @@ function DetailsFilmstripModal({
       // them. This padding is the band they occupy: header (61px) plus the
       // bar block at top-16 with its own pt-4 (152px to its underside), plus
       // clearance, plus the reach picker's own row (mt-2 and a ~18px button)
-      // — which is why this is 13rem and not the 11rem it was before that
+      // — which is why this is 14rem and not the 11rem it was before that
       // picker existed. It grew when the bar did, and it has to keep pace: the
       // symptom of it not doing so is the minimap resting on the top edge of
       // the middle card, which is a quiet eight pixels rather than an obvious
       // fault.
+      //
+      // MEASURED, each time the bar changes shape. The transport became an
+      // ensemble with a 44px play button, which took the block from 116px to
+      // 142px — it starts at `top-16` plus its own `pt-4`, so it now ends 222px
+      // down and 13rem reserved only 208. Anything added to that block has to
+      // be measured and this raised, or the row below rides up into it on a
+      // short viewport.
       // `overflow-clip`, NOT `overflow-hidden`. Both crop, but `hidden` makes
       // this a SCROLL CONTAINER — and the row is thirteen thousand pixels
       // wide, so there is a great deal for it to scroll. Landing on a new clip
@@ -860,7 +867,7 @@ function DetailsFilmstripModal({
       // row that had itself moved 1728px, which put the card just chosen
       // entirely off the left edge. `clip` crops without ever being
       // scrollable, so the transform stays the only thing that moves the row.
-      className="fixed inset-0 z-[80] flex items-center justify-center overflow-clip bg-black/80 px-6 pt-[13rem] pb-6 backdrop-blur-sm"
+      className="fixed inset-0 z-[80] flex items-center justify-center overflow-clip bg-black/80 px-6 pt-[14rem] pb-6 backdrop-blur-sm"
       // THE SCRIM DOES NOT DISMISS. Deliberate: this view is worked in, not
       // glanced at — trimming, scrubbing and swiping all end with the pointer
       // somewhere unpredictable, and the panels are cropped by the scrim

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -267,10 +267,6 @@ function DetailsFilmstripModal({
   const [swapping, setSwapping] = useState(false);
   const swapRef = useRef(false);
   const [playing, setPlaying] = useState(false);
-  // A DRAG IS IN PROGRESS ON THE BAR. Distinct from `scrubbed`, which stays
-  // true once the clock has been touched: this is the gesture itself, and it
-  // is what the monitor grows for.
-  const [scrubbing, setScrubbing] = useState(false);
   // THE HOVER CARD IS UP. The row goes back for it — see the strip's own
   // className. A separate flag from `scrubbing` because the two are different
   // moments: a scrub is a gesture with the pointer down and the card hidden,
@@ -1071,7 +1067,6 @@ function DetailsFilmstripModal({
               // three land in one place and cannot drift apart.
               onStepBack={hasPrevious ? () => onOpenNeighbour(ids[centre - 1]!) : null}
               onStepForward={hasNext ? () => onOpenNeighbour(ids[centre + 1]!) : null}
-              onScrubbingChange={setScrubbing}
               onPreviewingChange={setPreviewing}
               // The clock spans every clip, so a point on the rail IS a point
               // on the clock and needs no conversion.
@@ -1083,15 +1078,6 @@ function DetailsFilmstripModal({
               // Splitting them would mean a few pixels of travel decided
               // whether you kept your place in the shot.
               onCommitClip={(clipId) => landOn(clipId, position)}
-              // WHEREVER THE PLAYHEAD FINISHED, which is not always under the
-              // pointer: holding at an edge runs the strip along beneath a
-              // hand that is standing still. `position` is the view's own
-              // answer to where the clock is, so the drag does not have to
-              // carry one.
-              onScrubEnd={() => {
-                if (position === null) return;
-                landOn(position.clipId, position);
-              }}
               onScrubSeconds={(seconds) => {
                 setPlaying(false);
                 setBarSeconds(Math.min(Math.max(seconds, 0), timeline.totalSeconds));
@@ -1114,10 +1100,7 @@ function DetailsFilmstripModal({
         className={[
           "pointer-events-auto absolute right-6 bottom-6 z-10 flex items-center gap-1",
           "rounded-lg border border-zinc-700 bg-zinc-950/90 p-1 backdrop-blur-sm",
-          // Out of the way while the clock is being dragged: how many cards
-          // are up is not a question anyone is asking mid-scrub.
           "transition-opacity duration-200",
-          scrubbing ? "opacity-20" : "opacity-100",
         ].join(" ")}
         onPointerDown={(event) => event.stopPropagation()}
       >
@@ -1214,9 +1197,6 @@ function DetailsFilmstripModal({
               node={media}
               centre={index === centre}
               swapping={swapping}
-              // Everything but the picture goes out while the clock is being
-              // dragged — see `scrubFocus`.
-              scrubFocus={scrubbing && index === centre}
               clipLabel={`clip ${index + 1}`}
               playingHere={playingHere}
               onPlayFromStart={
@@ -1267,15 +1247,6 @@ function DetailsFilmstripModal({
               // could be in sync with anything.
               playing={index === centre && playing}
               live={position?.clipId === id}
-              // Only the monitor grows, and only while the bar is being
-              // dragged: the neighbours are context, and enlarging them would
-              // be enlarging the thing you are trying to look past.
-              magnified={index === centre && scrubbing}
-              // The proxy follows the seeking, not the centring: a neighbour
-              // tracking the playhead is doing the same expensive thing the
-              // centre is, and a full-res seek per pointer move is what the
-              // proxy exists to avoid.
-              scrubbing={scrubbing && (index === centre || position?.clipId === id)}
               swipe={swipe}
               // MOUNTED, BUT NOT ON SCREEN.
               //

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -271,6 +271,11 @@ function DetailsFilmstripModal({
   // true once the clock has been touched: this is the gesture itself, and it
   // is what the monitor grows for.
   const [scrubbing, setScrubbing] = useState(false);
+  // THE HOVER CARD IS UP. The row goes back for it — see the strip's own
+  // className. A separate flag from `scrubbing` because the two are different
+  // moments: a scrub is a gesture with the pointer down and the card hidden,
+  // this is a pointer resting on the bar with a picture open under it.
+  const [previewing, setPreviewing] = useState(false);
   // HOW MANY CLIPS ARE ON SCREEN. Remembered for the session rather than the
   // page: it is a way of working — reading one cut closely, or scanning a
   // sequence — and having it snap back to three every time you open a clip
@@ -1067,6 +1072,7 @@ function DetailsFilmstripModal({
               onStepBack={hasPrevious ? () => onOpenNeighbour(ids[centre - 1]!) : null}
               onStepForward={hasNext ? () => onOpenNeighbour(ids[centre + 1]!) : null}
               onScrubbingChange={setScrubbing}
+              onPreviewingChange={setPreviewing}
               // The clock spans every clip, so a point on the rail IS a point
               // on the clock and needs no conversion.
               //
@@ -1151,8 +1157,21 @@ function DetailsFilmstripModal({
           // A BAR LANDING has no transition at all, which the layout effect
           // above does to the node rather than from here.
           dragPx === 0
-            ? "transition-transform ease-out motion-reduce:transition-none"
+            ? "transition-[transform,opacity] ease-out motion-reduce:transition-none"
             : "",
+          // BACK, WHILE THE PREVIEW IS UP.
+          //
+          // The hover card is now a picture big enough to judge a frame in,
+          // and it is drawn OVER this row rather than in a gap above it. Three
+          // bright panels behind it compete with the one thing being looked
+          // at — and the card is answering a question about a clip that is
+          // usually not one of the three, so the panels are not even context
+          // for it.
+          //
+          // Pulled back rather than hidden: they are still where you are
+          // working, and the point of the hover is to check something WITHOUT
+          // leaving that. The row comes straight back when the pointer does.
+          previewing ? "opacity-40" : "",
         ].join(" ")}
         style={{
           gap: PANEL_GAP,

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -67,6 +67,12 @@ import {
   type PlaybarThumbnails,
 } from "./graph-playbar-thumbnails";
 import {
+  PREVIEW_ANCHORS,
+  lastPreviewAnchor,
+  rememberPreviewAnchor,
+  type PreviewAnchor,
+} from "./graph-seam-preview-anchor";
+import {
   BAR_REACHES,
   barReachLabel,
   barReachWindow,
@@ -282,6 +288,13 @@ function DetailsFilmstripModal({
   const chooseFrames = useCallback((next: PlaybarThumbnails) => {
     rememberPlaybarThumbnails(next);
     setFrames(next);
+  }, []);
+  // WHERE THE HOVER CARD SITS, kept beside the other bar settings because it
+  // is the same kind of question — how this control behaves while you read it.
+  const [previewAnchor, setPreviewAnchor] = useState<PreviewAnchor>(lastPreviewAnchor());
+  const choosePreviewAnchor = useCallback((next: PreviewAnchor) => {
+    rememberPreviewAnchor(next);
+    setPreviewAnchor(next);
   }, []);
 
   const clipAt = useCallback(
@@ -900,6 +913,7 @@ function DetailsFilmstripModal({
               // against the bar directly above them, so they belong in the
               // bar's own controls row alongside the transport and the clock.
               settingsLeft={
+                <>
                 <div
                   data-details-bar-frames
                   role="group"
@@ -956,7 +970,58 @@ function DetailsFilmstripModal({
                       </button>
                     );
                   })}
+
                 </div>
+
+                {/* WHERE THE HOVER CARD SITS.
+                    ITS OWN GROUP, next to `frames` rather than inside it. They
+                    sit together because they are the same kind of question —
+                    what this bar does while you read it — and because the card
+                    only exists to show the frames the control beside it turned
+                    on. But "what the boxes draw" and "where the preview sits"
+                    are two settings, and folding the second into the first
+                    group gave that group five buttons under an aria-label
+                    describing three of them.
+
+                    `PIN` parks it dead centre under the bar so the pointer
+                    scrubs and the picture changes in place. That matters now
+                    the card is big enough to judge a frame in: a large picture
+                    sliding around under a moving pointer is the one
+                    arrangement in which you cannot judge anything, because the
+                    eye spends the sweep re-finding it. The cost is that a card
+                    away from the box is less obviously ABOUT that box, which
+                    is why this is a choice and not a change. */}
+                <span aria-hidden="true" className="mx-1 h-3 w-px bg-white/10" />
+                <div
+                  data-details-bar-card
+                  role="group"
+                  aria-label="Where the hover preview sits"
+                  className="flex items-center gap-1"
+                >
+                  <span className="mr-1 font-mono text-[10px] text-zinc-500">card</span>
+                  {PREVIEW_ANCHORS.map((option) => (
+                    <button
+                      key={option}
+                      type="button"
+                      aria-pressed={option === previewAnchor}
+                      onClick={() => choosePreviewAnchor(option)}
+                      title={
+                        option === "follow"
+                          ? "The preview follows the pointer"
+                          : "The preview stays under the middle of the bar"
+                      }
+                      className={[
+                        "min-w-7 rounded px-1.5 py-0.5 font-mono text-[10px] tabular-nums transition-colors",
+                        option === previewAnchor
+                          ? "bg-zinc-100 text-zinc-900"
+                          : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100",
+                      ].join(" ")}
+                    >
+                      {option === "follow" ? "FOLLOW" : "PIN"}
+                    </button>
+                  ))}
+                </div>
+                </>
               }
               settingsRight={
               <div
@@ -989,6 +1054,7 @@ function DetailsFilmstripModal({
                 ))}
             </div>
               }
+              previewAnchor={previewAnchor}
               atStart={barWindow.ids[0] === ids[0]}
               atEnd={barWindow.ids[barWindow.ids.length - 1] === ids[ids.length - 1]}
               centreClipId={node.id as string}

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-monitor.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-monitor.tsx
@@ -129,7 +129,14 @@ export function ItemDetailsMonitor({
         `HERO` stays on the opened panel only: it is the card's morph
         target, and the slide below is a plain transform rather than a view
         transition, so the two never contend for the same element. */
+  // A FRAGMENT, so the picture and the readout under it are both DIRECT
+  // children of the panel. The panel dims its own chrome with
+  // `[&>*:not([data-item-details-frame])]`, which only reaches one level — a
+  // wrapper around these two would be the child that selector matched, and the
+  // picture would go out with everything else at exactly the moment it is the
+  // only thing anyone is looking at.
   return (
+    <>
     <div
       data-item-details-frame
       {...swipe}
@@ -313,6 +320,28 @@ export function ItemDetailsMonitor({
           fade is written against. A 25% button is still legible and still
           clickable, and the state it is in — something else is playing —
           is exactly when reaching for it is the less common move. */}
+      {live !== null && (
+        <span
+          data-item-details-edge={live.side === "right" ? "right" : "left"}
+          className={[
+            "absolute inset-y-0 w-1.5 bg-blue-500",
+            live.side === "right" ? "right-0" : "left-0",
+          ].join(" ")}
+        />
+      )}
+    </div>
+
+    {/* THE READOUT, BELOW THE PICTURE RATHER THAN ON IT.
+        The play button and the time used to float over the bottom corners of
+        the frame, which cost two pieces of the image to say two things that
+        are not in it — and put a dark chip over whatever happened to be in the
+        corner of the shot. A strip of its own gives them somewhere to live
+        that never covers anything, and lines the two numbers up with the
+        in/out fields further down so a panel reads as one column of facts. */}
+    <div
+      data-item-details-readout
+      className="flex items-center gap-3 rounded-md bg-zinc-900/80 px-2 py-1.5"
+    >
       {onPlayFromStart !== null && (
         <button
           type="button"
@@ -331,33 +360,54 @@ export function ItemDetailsMonitor({
             onPlayFromStart();
           }}
           className={[
-            "absolute bottom-2 left-2 grid h-7 w-7 place-items-center rounded-full",
-            "bg-black/70 text-zinc-100 ring-1 ring-white/25 backdrop-blur-sm",
-            "transition-colors hover:bg-black/90 hover:text-white",
+            "grid h-6 w-6 shrink-0 place-items-center rounded-full",
+            "bg-zinc-800 text-zinc-100 ring-1 ring-white/15",
+            "transition-colors hover:bg-zinc-700 hover:text-white",
             "focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:outline-none",
           ].join(" ")}
         >
           {playingHere ? (
-            <Pause aria-hidden="true" className="h-3.5 w-3.5" />
+            <Pause aria-hidden="true" className="h-3 w-3" />
           ) : (
-            <Play aria-hidden="true" className="h-3.5 w-3.5" />
+            <Play aria-hidden="true" className="h-3 w-3" />
           )}
         </button>
       )}
-      {live !== null && (
+
+      {/* HOW FAR PAST THE CUT, on the panel the cut is about.
+          `monitor.seconds` is measured inside the clip's SHOWING range, so
+          zero is its first frame — which is the cut itself. Only on the
+          centre: a neighbour is context, and "0.00s past a cut" said three
+          times is three answers to a question only one panel is being
+          asked. */}
+      {/* ZERO IS AN ANSWER, so this shows before anything has been scrubbed.
+          A panel at rest sits on its own first frame, which IS the cut — so
+          `cut 0.00s` is true, and hiding it until the clock moves would make
+          the readout appear from nowhere the first time anyone touched the
+          bar. */}
+      {centre && (
         <span
-          data-item-details-edge={live.side === "right" ? "right" : "left"}
-          className={[
-            "absolute inset-y-0 w-1.5 bg-blue-500",
-            live.side === "right" ? "right-0" : "left-0",
-          ].join(" ")}
-        />
+          data-item-details-cut
+          className="shrink-0 font-mono text-[11px] tabular-nums text-zinc-500"
+        >
+          cut <span className="text-zinc-300">{formatSeconds(monitor?.seconds ?? 0)}</span>
+        </span>
       )}
+
+      <span className="flex-1" />
+
+      {/* WHERE THIS IS IN THE SOURCE FILE, which is not where it is in the
+          cut — the difference between them is the trim, and being able to
+          read both is how you know which one you are about to change. */}
       {video && (
-        <span className="absolute right-2 bottom-2 rounded bg-black/80 px-1.5 py-0.5 font-mono text-[11px] tabular-nums text-blue-300">
-          {formatSeconds(rawTime)}
+        <span
+          data-item-details-src
+          className="shrink-0 font-mono text-[11px] tabular-nums text-zinc-500"
+        >
+          src <span className="text-blue-300">{formatSeconds(rawTime)}</span>
         </span>
       )}
     </div>
+    </>
   );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
@@ -53,6 +53,7 @@ export function DetailsPanel({
   scrubbing = false,
   swipe,
   width,
+  spare = false,
   dimmed = false,
   scrubFocus = false,
   clipLabel,
@@ -173,6 +174,16 @@ export function DetailsPanel({
    */
   /** Set by the strip, which owns how many panels are on screen. */
   width: string;
+  /**
+   * Built and held ready, but outside the window the count promises.
+   *
+   * `visibility: hidden` rather than unmounting: the whole point of these is
+   * that the panel already exists when it becomes the one arriving, so it has
+   * to keep its element, its video and its decoded frame. It keeps its width
+   * too — the row's centring is arithmetic over uniform neighbour widths, and
+   * a collapsed spare would move everything between it and the middle.
+   */
+  spare?: boolean;
   /**
    * Pull this panel's picture back, because the clock is running and it is not
    * the one being watched.
@@ -306,8 +317,40 @@ export function DetailsPanel({
   // cannot query its own width — and the panel needs to change its own HEIGHT
   // when it gets narrow, not merely what it puts inside itself. The wrapper
   // carries the width and nothing else.
+  // THE WIDTH ANIMATES, and it is the one thing here that animates layout
+  // rather than paint.
+  //
+  // Stepping makes a different clip the subject, so the outgoing centre has to
+  // narrow and the incoming one has to widen — that size change IS the motion,
+  // and faking it with a transform would scale the type along with the frame.
+  // It is two elements for 300ms, in step with the row's own slide so a panel
+  // arrives at its new size exactly as it arrives at its new place.
+  // `motion-reduce` drops it to a cut.
   return (
-      <div ref={panelRef} className="@container shrink-0" style={{ width }}>
+      <div
+        ref={panelRef}
+        data-item-details-spare={spare ? "" : undefined}
+        className={[
+          "@container shrink-0",
+          // A STEP ANIMATES ITS WIDTH; A LANDING DOES NOT.
+          //
+          // Stepping makes a different clip the subject, so the outgoing
+          // centre narrows and the incoming one widens — that size change IS
+          // the motion, in step with the row's own slide.
+          //
+          // A landing is the opposite case and has been since the row learned
+          // to cut: the middle card has been the monitor for the whole scrub,
+          // so it is already showing the clip you landed on and it must not
+          // move. Animating its width would put the one thing that did not
+          // change back into motion, and would leave its edges drifting for
+          // 300ms after a gesture whose whole claim is that it arrives
+          // instantly.
+          swapping
+            ? "transition-none"
+            : "transition-[width] duration-300 ease-out motion-reduce:transition-none",
+        ].join(" ")}
+        style={{ width, ...(spare ? { visibility: "hidden" as const } : {}) }}
+      >
       <div
         // FOCUS WIRING ON THE CENTRE ONLY. Every panel is fully live — the
         // grips trim, the title renames, the video seeks — but "which dialog

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-trim-strip.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-trim-strip.tsx
@@ -90,11 +90,19 @@ export function ItemDetailsTrimStrip({
           <div ref={stripSlot} className="hidden w-full @min-[18rem]:block">
             {stripWidth > 0 ? (
               <div className="relative">
+                {/* WHITE, because this view is a filmstrip.
+                    The board's strip layout keeps the blue selection frame —
+                    there the window is one selected thing among many. Here the
+                    panel is a row of frames under a bar of frames, and a blue
+                    rectangle would be the only object on screen that is not
+                    part of the film. A white frame line says the same thing in
+                    the vocabulary everything around it is written in. */}
                 <TrimOverviewStrip
                   node={video}
                   width={stripWidth}
                   trimInSeconds={trimIn}
                   trimOutSeconds={trimOut}
+                  tone="film"
                 />
                 {/* WHERE PLAY IS, in this clip. Absent — not parked at an
                     edge — when the playhead is in another clip: a line at

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-view-count.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-view-count.ts
@@ -53,8 +53,50 @@ export function rememberViewCount(count: ViewCount): void {
  * wide enough to work in, and the reach across the timeline that nine bought
  * is what the bar above is for.
  */
-export function panelWidthFor(count: ViewCount): string {
+/**
+ * How much wider the clip being worked on is than the ones beside it.
+ *
+ * 7:4. The neighbours have to stay big enough to read a frame in — that is
+ * the entire reason they are whole panels rather than thumbnails — and the
+ * centre has to be unmistakably the subject without the row turning into one
+ * panel with two slivers. Below about 1.5 the emphasis stops reading as
+ * deliberate and looks like a rounding error; above about 2 the neighbours
+ * stop being usable and the layout would be better off showing one.
+ */
+const CENTRE_TO_NEIGHBOUR = 1.75;
+
+/**
+ * The two widths for a given count: the clip being worked on, and everything
+ * else.
+ *
+ * EVERY PANEL IS FULLY VISIBLE NOW. The old layout gave all panels one width
+ * and let the outermost pair hang half off each edge, which is what made
+ * "show three" mean "one whole and two halves". Sizing the centre separately
+ * buys the same emphasis without spending it on cropping:
+ *
+ *   (count - 1) x N  +  1.75 x N  +  (count - 1) gaps  =  viewport - padding
+ *
+ * so N = (100vw - 3rem - (count-1)rem) / (count - 1 + 1.75).
+ *
+ * THE ROW'S TRANSFORM DOES NOT NEED THE CENTRE WIDTH, which is the happy part
+ * of this arithmetic. Centring panel k means translating by
+ * `-(N + gap) * (k - (n-1)/2)` — the centre panel's extra width sits
+ * symmetrically about its own middle, so it cancels out of the centring
+ * entirely and the step stays one uniform neighbour-width. See the row
+ * transform in `graph-item-details-modal.tsx`.
+ *
+ * The caps survive so a very wide monitor does not hand the middle panel half
+ * a metre of screen; below them the count drives the layout.
+ */
+export function panelWidthsFor(
+  count: ViewCount,
+): Readonly<{ centre: string; neighbour: string }> {
   // 3rem is the modal's own padding (p-6 either side); the gaps are one rem
   // apiece, and there are `count - 1` of them between `count` panels.
-  return `min(48rem, (100vw - 3rem - ${count - 1}rem) / ${count - 1})`;
+  const available = `(100vw - 3rem - ${count - 1}rem)`;
+  const share = count - 1 + CENTRE_TO_NEIGHBOUR;
+  return {
+    neighbour: `min(34rem, ${available} / ${share})`,
+    centre: `min(60rem, ${available} * ${CENTRE_TO_NEIGHBOUR} / ${share})`,
+  };
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-playbar-thumbnails.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-playbar-thumbnails.tsx
@@ -34,12 +34,14 @@ export type PlaybarThumbnails = Readonly<{
 /**
  * Whether the play bar draws frames instead of grey boxes, and how.
  *
- * OFF BY DEFAULT, and the default is the argument for it being a setting.
+ * FILM BY DEFAULT, and the trade is the argument for it staying a setting.
  * A bar of frames answers "which shot is that" without a hover, which is the
- * whole reason to want it. What it costs is the thing the grey bar is good at:
- * box widths are durations, and a run of even grey reads as rhythm — where the
- * cuts fall, which shots are long, where the pace changes. Put pictures in
- * them and the eye reads the pictures, because it always will.
+ * whole reason to want it, and it is the first question anyone asks of the
+ * bar. What it costs is the thing the grey bar is good at: box widths are
+ * durations, and a run of even grey reads as rhythm — where the cuts fall,
+ * which shots are long, where the pace changes. Put pictures in them and the
+ * eye reads the pictures, because it always will. So `OFF` is one press away,
+ * and it is worth keeping there.
  *
  * TWO SETTINGS, NOT THREE STATES IN ONE. "Show frames" and "which kind" are
  * separate questions and stay separate controls: the style survives being
@@ -50,9 +52,12 @@ export type PlaybarThumbnails = Readonly<{
  * consumer is several layers down inside a portalled dialog, the value is
  * constant across the board, and it changes only when someone opens a menu.
  *
- * DEFAULTS TO OFF WITH NO PROVIDER, so a bar rendered outside the board — a
- * story, most of all — behaves like the shipped default rather than throwing
- * or silently opting in.
+ * STILL OFF WITH NO PROVIDER, which is deliberately NOT the shipped default
+ * any more. The two answer different questions: the remembered value is what
+ * the details view opens on, and this is what a bar rendered with no view
+ * around it does. Frames cost a request per cell, so something mounting this
+ * component standalone — a story, a probe, anything that has not asked — gets
+ * the cheap bar rather than silently fetching a hundred thumbnails.
  */
 const PlaybarThumbnailsContext = createContext<PlaybarThumbnails>({
   shown: false,
@@ -94,8 +99,22 @@ export function usePlaybarThumbnails(): PlaybarThumbnails {
  * details modal and opening another clip does not reset them — the modal
  * unmounts, and state inside it would go with it.
  */
-let rememberedShown = false;
-let rememberedStyle: PlaybarThumbnailStyle = "cover";
+// THE BAR OPENS AS FILM.
+//
+// It opened grey, on the argument that a run of even boxes reads as RHYTHM —
+// where the cuts fall, which shots are long, where the pace changes — and that
+// pictures override that because the eye always reads pictures first. That is
+// still true, and it is now the thing you switch TO rather than the thing you
+// start from: `OFF` is one press away and the reading it gives is worth
+// keeping reachable.
+//
+// What decided it the other way is that the bar's first job is telling you
+// WHICH shot is where, and a row of grey rectangles cannot do that at all —
+// it needs a hover per box to answer the question the bar is looked at for.
+// Rhythm is what you read second, once you already know what you are looking
+// at.
+let rememberedShown = true;
+let rememberedStyle: PlaybarThumbnailStyle = "filmstrip";
 
 export function lastPlaybarThumbnails(): PlaybarThumbnails {
   return { shown: rememberedShown, style: rememberedStyle };

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-bar-layout.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-bar-layout.ts
@@ -32,6 +32,18 @@ export type SeamBarClip = Readonly<{
   /** Where the visible range starts in the source, so sampled frames land
    *  inside the part of the clip that actually plays. */
   trimInSeconds?: number;
+  /**
+   * Skipped at play time.
+   *
+   * The flag has existed on the node all along; the bar simply never heard
+   * about it, so a disabled clip drew as an ordinary box and the one place
+   * you look to understand playback was the one place that would not tell you
+   * a shot was going to be silently stepped over. It still occupies its full
+   * width — the clip is part of the sequence you are reading even when it is
+   * not part of the sequence that plays, and shrinking it would move every cut
+   * after it.
+   */
+  disabled?: boolean;
 }>;
 
 /**

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -258,9 +258,25 @@ const BOX_INSET_PX = 2.5;
  *
  * Only when frames are on. Over grey the whole treatment is decoration
  * answering a question nobody asked.
+ *
+ * ── AND IT IS A FILM STRIP, SO IT LOOKS LIKE ONE ────────────────────────
+ *
+ * The two tones are the same idea whichever way round they go: a gap reads
+ * BOTH light and dark, so one of them always has contrast against whatever is
+ * beside it. Which one is the ring and which is the core is therefore free —
+ * and the ring being the LIGHT one is what makes a run of boxes read as
+ * frames on a strip of film rather than as tiles in a chart.
+ *
+ *     two bright frames   white │ PALE dark PALE │ white   ← the core shows
+ *     two dark frames     black │ pale DARK pale │ black   ← the rings show
+ *
+ * So the strip's own background is near-black and each box casts a pale ring
+ * into the gap either side of it. Every gap still reads pale · dark · pale, no
+ * arrangement of neighbours leaves both tones without contrast, and the thing
+ * it now resembles is the thing it is.
  */
-const FRAMED_GAP_COLOUR = "rgba(212, 212, 216, 0.92)";
-const FRAMED_BOX_EDGE = "0 0 0 1.5px rgba(0, 0, 0, 0.82)";
+const FRAMED_GAP_COLOUR = "rgba(9, 9, 11, 0.95)";
+const FRAMED_BOX_EDGE = "0 0 0 1.5px rgba(244, 244, 245, 0.90)";
 
 export type SeamHover = Readonly<{
   /** Absolute strip pixels. */
@@ -422,11 +438,13 @@ export function SeamLane({
             if (segment.widthPx <= 0) return null;
             const isCentre = segment.clipId === centreClipId;
             const colour = colourOf.get(segment.clipId) ?? BAR_NEUTRAL_COLOUR;
+            const skipped = clipById.get(segment.clipId)?.disabled === true;
             return (
               <span
                 key={segment.clipId}
                 data-seam-segment={segment.clipId}
                 data-seam-segment-live={isCentre ? "" : undefined}
+                data-seam-segment-skipped={skipped ? "" : undefined}
                 aria-hidden="true"
                 style={{
                   left: segment.leftPx + BOX_INSET_PX,
@@ -452,20 +470,83 @@ export function SeamLane({
                     style={thumbnails.style}
                   />
                 ) : null}
-                {isCentre && segment.widthPx >= 16 ? (
+                {/* SKIPPED AT PLAY TIME: struck through with hatching.
+                    Diagonals rather than a wash, because a dimmed box is
+                    indistinguishable from a dark frame and a box this bar is
+                    already drawing pictures in has no spare brightness to
+                    signal with. Hatching is the one treatment that survives
+                    any content under it — it is a pattern, and footage is
+                    not. It paints OVER the frames and inside the box, so it
+                    costs no width: a disabled clip still occupies its full
+                    duration, which is the truth about where the later cuts
+                    fall. */}
+                {skipped ? (
                   <span
-                    data-seam-marker
-                    // Above the frame once there is one, and darker for it: a
-                    // 50% black dot reads on grey and disappears into a busy
-                    // picture, which is the one box it has to be findable in.
-                    className={
-                      thumbnails.shown
-                        ? "relative z-10 h-3 w-3 rounded-full bg-black/70 ring-1 ring-white/70"
-                        : "h-3 w-3 rounded-full bg-black/50"
-                    }
+                    data-seam-hatch
+                    aria-hidden="true"
+                    className="absolute inset-0 z-10 rounded-[3px]"
+                    style={{
+                      backgroundImage:
+                        "repeating-linear-gradient(45deg, rgba(9,9,11,0.72) 0px, rgba(9,9,11,0.72) 3px, rgba(228,228,231,0.55) 3px, rgba(228,228,231,0.55) 6px)",
+                    }}
                   />
                 ) : null}
               </span>
+            );
+          })}
+
+          {/* THE CLIP THE CARDS ARE ON, ringed rather than dotted.
+              A dot inside the box marked the centre for a while and had to
+              fight whatever picture was behind it. A ring is drawn on the
+              box's own edge, where there is never any content — so it reads at
+              every zoom, on any footage, and at widths where a 12px dot would
+              not have fitted at all. Red because it is the same red as the
+              playhead: both answer "which clip is the view about", one in
+              space and one in time.
+
+              OUTSIDE the segment list so it can sit above every box including
+              its neighbours' rings, and so a one-pixel-wide clip still gets a
+              visible mark. */}
+          {(() => {
+            const segment = strip.segments.find((found) => found.clipId === centreClipId);
+            if (segment === undefined || segment.widthPx <= 0) return null;
+            return (
+              <span
+                data-seam-marker
+                aria-hidden="true"
+                className="pointer-events-none absolute z-20 rounded-[4px] ring-2 ring-red-500"
+                style={{
+                  left: segment.leftPx + BOX_INSET_PX - 1,
+                  width: Math.max(2, segment.widthPx - BOX_INSET_PX * 2) + 2,
+                  top: -1,
+                  bottom: -1,
+                }}
+              />
+            );
+          })()}
+
+          {/* AND SAID AGAIN ABOVE THE BOX, in red.
+              The hatching says a clip is skipped once you are looking at it;
+              this says it while you are scanning the bar for something else,
+              which is when it matters — the whole failure mode of a disabled
+              clip is not noticing one. Dotted, so it is never confused with
+              the solid red ring below it, and clear of the boxes so it does
+              not eat into a width that means duration. */}
+          {strip.segments.map((segment) => {
+            if (segment.widthPx <= 0) return null;
+            if (clipById.get(segment.clipId)?.disabled !== true) return null;
+            return (
+              <span
+                key={`skip-${segment.clipId}`}
+                data-seam-skip-rule={segment.clipId}
+                aria-hidden="true"
+                className="pointer-events-none absolute border-t-2 border-dotted border-red-500/80"
+                style={{
+                  left: segment.leftPx + BOX_INSET_PX,
+                  width: Math.max(2, segment.widthPx - BOX_INSET_PX * 2),
+                  top: -6,
+                }}
+              />
             );
           })}
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -11,6 +11,7 @@ import {
 } from "./graph-playbar-thumbnails";
 import { videoFrameUrls } from "@/lib/video-frame-url";
 import type { SeamStrip } from "./graph-seam-strip";
+import type { PreviewAnchor } from "./graph-seam-preview-anchor";
 
 /**
  * How long the strip takes to slide when the centred clip changes.
@@ -372,6 +373,7 @@ export function SeamLane({
   snapKey,
   ghostX,
   hover,
+  previewAnchor = "follow",
   chip,
   handlers,
   atStart,
@@ -390,6 +392,9 @@ export function SeamLane({
   /** Where an un-pressed pointer is hovering, in strip pixels. */
   ghostX: number | null;
   hover: SeamHover | null;
+  /** Whether the hover card follows the pointer or parks in the middle — see
+   *  `graph-seam-preview-anchor`. */
+  previewAnchor?: PreviewAnchor;
   /** The time under the playhead while it is being dragged. */
   chip: string | null;
   handlers: React.ComponentProps<"div">;
@@ -706,21 +711,29 @@ export function SeamLane({
         <span
           data-seam-preview
           aria-hidden="true"
-          // KEPT INSIDE THE TRACK.
+          // PINNED, OR KEPT INSIDE THE TRACK.
           //
-          // It is centred on the box being pointed at, which walks it off the
-          // side as soon as that box is near either end — and the wider this
-          // card got, the more of the bar had that problem. At 288px a hover
-          // anywhere in the first or last 144 pixels was reading a card with
-          // its edge cut off, which is worst exactly where the picture is the
-          // whole point.
+          // `pinned` parks it dead centre under the bar and leaves it there, so
+          // the pointer scrubs and the picture changes in place. See
+          // `graph-seam-preview-anchor` for why that is worth having: the card
+          // is now big enough to judge a frame in, and a big thing sliding
+          // around under a moving pointer is the one arrangement in which you
+          // cannot.
           //
-          // `clamp` against percentages rather than a measured width: the
-          // percentage resolves against this element's containing block, which
-          // IS the track, so the bound follows a resize with no observer and no
-          // re-render. 9rem is half the card.
+          // `follow` centres it on the box being described, which walks it off
+          // the side as soon as that box is near either end — and the wider
+          // this card got, the more of the bar had that problem. At 288px a
+          // hover anywhere in the first or last 144 pixels was reading a card
+          // with its edge cut off, which is worst exactly where the picture is
+          // the whole point. `clamp` against percentages rather than a measured
+          // width: the percentage resolves against this element's containing
+          // block, which IS the track, so the bound follows a resize with no
+          // observer and no re-render. 9rem is half the card.
           style={{
-            left: `clamp(9rem, ${viewportX(hover.x)}px, calc(100% - 9rem))`,
+            left:
+              previewAnchor === "pinned"
+                ? "50%"
+                : `clamp(9rem, ${viewportX(hover.x)}px, calc(100% - 9rem))`,
           }}
           // BELOW THE WHOLE BAR, not just below the boxes: at `top-9` it lay
           // across the ruler and the minimap, hiding the two things that say

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -752,7 +752,19 @@ export function SeamLane({
           // below rather than floating over a gap: a heavier border, a deeper
           // shadow and a near-opaque ground, so it reads as something in front
           // rather than something printed on what it covers.
-          className="pointer-events-none absolute top-20 z-20 flex w-96 -translate-x-1/2 flex-col gap-1.5 rounded-lg border border-zinc-600 bg-zinc-950/98 p-2 shadow-2xl ring-1 ring-black/50"
+          // BELOW THE WHOLE BLOCK, and this number tracks the block's height.
+          //
+          // It was 80px, which cleared the ruler and the controls row when the
+          // minimap sat last. The minimap moved up under the film strip and
+          // the controls moved to the bottom, so 80 now lands ON the controls —
+          // a card over the transport is a card you cannot press play through.
+          // Measured: track ends at 52, minimap 66–80, controls 88–116.
+          //
+          // The symptom of this drifting again is the card overlapping the row
+          // beneath the bar rather than sitting under it, which is quiet enough
+          // to miss — the same way the scrim's own top padding has to keep pace
+          // with this block.
+          className="pointer-events-none absolute top-32 z-20 flex w-96 -translate-x-1/2 flex-col gap-1.5 rounded-lg border border-zinc-600 bg-zinc-950/98 p-2 shadow-2xl ring-1 ring-black/50"
         >
           {hover.posterSrc === undefined ? null : (
             // A bare <img>: the preview is a thumbnail of a source the app

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -120,7 +120,23 @@ function SegmentFrames({
     return (
       <span
         data-seam-filmstrip={clipId}
-        className="absolute inset-0 flex"
+        // EVERY FRAME IS FRAMED, not just every clip.
+        //
+        // The cells butted together, so a clip's strip read as one long
+        // smeared picture and the only light lines on the bar were at the clip
+        // boundaries. On a strip of film every frame has an edge — that
+        // repeating light rhythm at a finer interval than the shots is most of
+        // what makes the thing recognisable as film rather than as a row of
+        // tiles.
+        //
+        // A GAP WITH THE LIGHT BEHIND IT, rather than a border on each cell: a
+        // border would be inside the cell's own box and would eat into the
+        // picture, and at these widths every pixel of picture counts. The gap
+        // lets the strip's own colour through, which is the same trick the gap
+        // between two clips already uses — one pixel here against five there,
+        // so a frame edge never reads as a cut.
+        className="absolute inset-0 flex gap-px"
+        style={{ backgroundColor: FRAMED_CELL_EDGE }}
         aria-hidden="true"
       >
         {cells.map((url, index) => (
@@ -277,6 +293,17 @@ const BOX_INSET_PX = 2.5;
  */
 const FRAMED_GAP_COLOUR = "rgba(9, 9, 11, 0.95)";
 const FRAMED_BOX_EDGE = "0 0 0 1.5px rgba(244, 244, 245, 0.90)";
+/**
+ * The line between two FRAMES of the same clip.
+ *
+ * Brighter than the ring around a clip and a third of its width, which is the
+ * whole hierarchy: a frame edge is a hairline you read as texture, a clip edge
+ * is a line you read as a cut. Reversing the two — or making them equal —
+ * would turn every sampled frame into something that looks like a shot
+ * boundary, and the bar's one job is showing you where the shots actually
+ * change.
+ */
+const FRAMED_CELL_EDGE = "rgba(250, 250, 250, 0.82)";
 
 export type SeamHover = Readonly<{
   /** Absolute strip pixels. */

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -277,33 +277,65 @@ const BOX_INSET_PX = 2.5;
  *
  * ── AND IT IS A FILM STRIP, SO IT LOOKS LIKE ONE ────────────────────────
  *
- * The two tones are the same idea whichever way round they go: a gap reads
- * BOTH light and dark, so one of them always has contrast against whatever is
- * beside it. Which one is the ring and which is the core is therefore free —
- * and the ring being the LIGHT one is what makes a run of boxes read as
- * frames on a strip of film rather than as tiles in a chart.
+ * THE STRIP IS THE PALE THING AND THE FRAMES SIT IN IT. That is what a strip
+ * of film is: a light base with pictures printed on it and a margin of base
+ * showing on every side of every frame. So the background here is near-white
+ * and each box casts a thin DARK ring, which keeps the two-tone rule intact —
  *
- *     two bright frames   white │ PALE dark PALE │ white   ← the core shows
- *     two dark frames     black │ pale DARK pale │ black   ← the rings show
+ *     two bright frames   white │ DARK pale DARK │ white   ← the rings show
+ *     two dark frames     black │ dark PALE dark │ black   ← the core shows
  *
- * So the strip's own background is near-black and each box casts a pale ring
- * into the gap either side of it. Every gap still reads pale · dark · pale, no
- * arrangement of neighbours leaves both tones without contrast, and the thing
- * it now resembles is the thing it is.
+ * — while making the bar read as film rather than as tiles in a chart.
+ *
+ * IT WAS INVERTED FOR A WHILE, near-black base with pale rings, on the
+ * reasoning that either polarity satisfies the contrast rule so the choice was
+ * free. The contrast rule was satisfied; the resemblance was not. A dark strip
+ * with light lines in it looks like a chart with gridlines. Film is light with
+ * dark frame lines, and the difference between those two is the whole point of
+ * the treatment.
+ *
+ * THE VERTICAL INSET IS WHAT MAKES EITHER OF THEM VISIBLE, and its absence is
+ * why this went unnoticed through several attempts — see `BOX_INSET_Y_PX`.
+ * Without room above and below, the only base showing is a sliver between
+ * clips, and no choice of colour reads as anything at all.
  */
-const FRAMED_GAP_COLOUR = "rgba(9, 9, 11, 0.95)";
-const FRAMED_BOX_EDGE = "0 0 0 1.5px rgba(244, 244, 245, 0.90)";
+const FRAMED_GAP_COLOUR = "rgba(238, 238, 241, 0.96)";
+const FRAMED_BOX_EDGE = "0 0 0 1.5px rgba(0, 0, 0, 0.82)";
 /**
  * The line between two FRAMES of the same clip.
  *
- * Brighter than the ring around a clip and a third of its width, which is the
- * whole hierarchy: a frame edge is a hairline you read as texture, a clip edge
- * is a line you read as a cut. Reversing the two — or making them equal —
- * would turn every sampled frame into something that looks like a shot
- * boundary, and the bar's one job is showing you where the shots actually
- * change.
+ * FAINT ON PURPOSE — 40% where the film base around a clip is opaque. That
+ * difference IS the hierarchy, and it is the only thing keeping the treatment
+ * honest: a frame edge is texture you read as film, a clip edge is a line you
+ * read as a CUT. At full strength the two are indistinguishable, so every
+ * sampled frame inside a long take looks like a shot boundary — which is
+ * precisely the thing the bar exists to show you and would now be lying about.
+ *
+ * Only the interior lines. The clip's own edge stays solid, because that one
+ * is answering the other question.
  */
-const FRAMED_CELL_EDGE = "rgba(250, 250, 250, 0.82)";
+const FRAMED_CELL_EDGE = "rgba(250, 250, 250, 0.4)";
+
+/**
+ * How far each box is pulled in from the TOP and BOTTOM of the lane once it
+ * holds frames.
+ *
+ * Without it the film strip has no top or bottom edge, and that is a bug
+ * rather than a nuance. A box is `inset-y-0` — exactly the lane's height — and
+ * the lane is `overflow-hidden`, so a ring painted OUTSIDE the box has nowhere
+ * to go vertically and is clipped away entirely. What survives is the left and
+ * right of each ring, which reads as a row of thin separators rather than as
+ * frames: every horizontal edge of the treatment was being thrown away.
+ *
+ * Giving the box a vertical inset puts the strip's own colour above and below
+ * each frame as well as between them, which is what a strip of film actually
+ * looks like — a frame has margin on all four sides, not two.
+ *
+ * ONLY WHEN FRAMES ARE ON. Over plain grey the boxes should still fill the
+ * bar: there the height is not carrying anything and shortening it would just
+ * make the bar quieter for no reason.
+ */
+const BOX_INSET_Y_PX = 3;
 
 export type SeamHover = Readonly<{
   /** Absolute strip pixels. */
@@ -485,8 +517,14 @@ export function SeamLane({
                   // See `FRAMED_BOX_EDGE`: the ring is the dark half of the
                   // gap, and the strip's own background is the pale half.
                   ...(thumbnails.shown ? { boxShadow: FRAMED_BOX_EDGE } : {}),
+                  // ROOM FOR THE RING TO EXIST. See `BOX_INSET_Y_PX`: the lane
+                  // clips, so without this the frame's top and bottom edges
+                  // are painted straight off the element.
+                  ...(thumbnails.shown
+                    ? { top: BOX_INSET_Y_PX, bottom: BOX_INSET_Y_PX }
+                    : { top: 0, bottom: 0 }),
                 }}
-                className="absolute inset-y-0 flex items-center justify-center overflow-hidden rounded-[3px]"
+                className="absolute flex items-center justify-center overflow-hidden rounded-[3px]"
               >
                 {thumbnails.shown ? (
                   <SegmentFrames
@@ -522,35 +560,6 @@ export function SeamLane({
             );
           })}
 
-          {/* THE CLIP THE CARDS ARE ON, ringed rather than dotted.
-              A dot inside the box marked the centre for a while and had to
-              fight whatever picture was behind it. A ring is drawn on the
-              box's own edge, where there is never any content — so it reads at
-              every zoom, on any footage, and at widths where a 12px dot would
-              not have fitted at all. Red because it is the same red as the
-              playhead: both answer "which clip is the view about", one in
-              space and one in time.
-
-              OUTSIDE the segment list so it can sit above every box including
-              its neighbours' rings, and so a one-pixel-wide clip still gets a
-              visible mark. */}
-          {(() => {
-            const segment = strip.segments.find((found) => found.clipId === centreClipId);
-            if (segment === undefined || segment.widthPx <= 0) return null;
-            return (
-              <span
-                data-seam-marker
-                aria-hidden="true"
-                className="pointer-events-none absolute z-20 rounded-[4px] ring-2 ring-red-500"
-                style={{
-                  left: segment.leftPx + BOX_INSET_PX - 1,
-                  width: Math.max(2, segment.widthPx - BOX_INSET_PX * 2) + 2,
-                  top: -1,
-                  bottom: -1,
-                }}
-              />
-            );
-          })()}
 
           {/* AND SAID AGAIN ABOVE THE BOX, in red.
               The hatching says a clip is skipped once you are looking at it;
@@ -571,7 +580,12 @@ export function SeamLane({
                 style={{
                   left: segment.leftPx + BOX_INSET_PX,
                   width: Math.max(2, segment.widthPx - BOX_INSET_PX * 2),
-                  top: -6,
+                  // INSIDE THE LANE. At -6 this sat above the lane's top edge,
+                  // and the lane clips — so the one mark saying a clip gets
+                  // skipped was painted off the element and never appeared at
+                  // all. It lives in the margin above the frame now, which is
+                  // the space the film-strip inset created.
+                  top: 0,
                 }}
               />
             );
@@ -637,6 +651,39 @@ export function SeamLane({
           )}
         </div>
       </div>
+
+      {/* THE CLIP THE CARDS ARE ON, POINTED AT FROM ABOVE.
+          A red ring around its box did this for a while, and it was the wrong
+          shape of answer twice over. A ring encloses an AREA, so at a wide
+          reach — where a box is eight pixels across — the mark becomes most of
+          the clip and stops reading as a mark at all. And red is the
+          playhead's colour: two different "you are here" claims in one colour,
+          one about time and one about which shot, is one too many.
+          A triangle points at a PLACE. Its size has nothing to do with the
+          clip's duration, so it reads identically at every zoom, and white
+          against the dark band above the film base is the one thing up there.
+          OUTSIDE THE CLIPPING WRAPPER, which is why this is a sibling of the
+          boxes rather than a child: the strip is `overflow-hidden` and anything
+          above the film base would be cut off. The chip and the hover preview
+          escape the same way, and `viewportX` is how all three stay with the
+          strip while living outside it. */}
+      {(() => {
+        const segment = strip.segments.find((found) => found.clipId === centreClipId);
+        if (segment === undefined || segment.widthPx <= 0) return null;
+        return (
+          <span
+            data-seam-active-mark={centreClipId}
+            aria-hidden="true"
+            style={{
+              left: viewportX(segment.leftPx + segment.widthPx / 2),
+              borderLeft: "5px solid transparent",
+              borderRight: "5px solid transparent",
+              borderTop: "6px solid rgba(250, 250, 250, 0.95)",
+            }}
+            className="pointer-events-none absolute -top-[9px] z-10 h-0 w-0 -translate-x-1/2"
+          />
+        );
+      })()}
 
       {/* THE TIME, ON THE PLAYHEAD, while it is being dragged. ABOVE the
           boxes, not on them: it names the frame you are looking at, and a

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -733,7 +733,7 @@ export function SeamLane({
             left:
               previewAnchor === "pinned"
                 ? "50%"
-                : `clamp(9rem, ${viewportX(hover.x)}px, calc(100% - 9rem))`,
+                : `clamp(12rem, ${viewportX(hover.x)}px, calc(100% - 12rem))`,
           }}
           // BELOW THE WHOLE BAR, not just below the boxes: at `top-9` it lay
           // across the ruler and the minimap, hiding the two things that say
@@ -752,7 +752,7 @@ export function SeamLane({
           // below rather than floating over a gap: a heavier border, a deeper
           // shadow and a near-opaque ground, so it reads as something in front
           // rather than something printed on what it covers.
-          className="pointer-events-none absolute top-20 z-20 flex w-72 -translate-x-1/2 flex-col gap-1.5 rounded-lg border border-zinc-600 bg-zinc-950/98 p-2 shadow-2xl ring-1 ring-black/50"
+          className="pointer-events-none absolute top-20 z-20 flex w-96 -translate-x-1/2 flex-col gap-1.5 rounded-lg border border-zinc-600 bg-zinc-950/98 p-2 shadow-2xl ring-1 ring-black/50"
         >
           {hover.posterSrc === undefined ? null : (
             // A bare <img>: the preview is a thumbnail of a source the app
@@ -761,11 +761,24 @@ export function SeamLane({
             <img
               src={hover.posterSrc}
               alt=""
-              // `aspect-video` rather than a fixed height, so every shot in the
-              // card is the same shape whatever its own frame is — a row of
-              // previews that changed height as the pointer moved would be the
-              // card itself flickering.
-              className="aspect-video w-full rounded object-cover"
+              // THE FRAME'S OWN SHAPE, whole.
+              //
+              // It was forced to 16:9 and cropped to fill, on the reasoning
+              // that a card changing height as the pointer moved would be the
+              // card itself flickering. That holds for a row of mixed shapes
+              // and costs too much here: this project's shots are 896x384, so
+              // 16:9 was cutting the sides off every one of them — the preview
+              // was showing less of the frame than the box it came from. A
+              // preview that crops is answering a question about composition
+              // with a different composition.
+              //
+              // `h-auto` with no ratio, so the poster's intrinsic dimensions
+              // decide: scope stays scope, 16:9 stays 16:9, and nothing is
+              // trimmed. The card grows and shrinks with it, which is the
+              // honest trade and much less distracting now `PIN` exists — a
+              // stationary card resizing reads as the picture changing, where
+              // a moving one resizing reads as a wobble.
+              className="h-auto w-full rounded"
             />
           )}
           <span className="min-w-0">

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -188,43 +188,6 @@ function SegmentFrames({
 }
 
 
-/**
- * The playhead's head, and its twitch when the scrub lands on a cut.
- *
- * DRIVEN FROM SCRIPT, NOT A KEYFRAME. A `@keyframes` would have to be
- * declared in a stylesheet, and this component is rendered into a portal from
- * two hosts with two different Tailwind entry points — the app's and
- * Storybook's — so a rule added to one of them is a rule the other silently
- * does not have. An animation the component brings with it cannot be missing
- * in one host and present in the other, and it is inspectable from a test
- * through `getAnimations()`.
- *
- * Skips its first run: mounting the playhead is not a snap.
- */
-function SnapPulse({ snapKey }: Readonly<{ snapKey: number }>) {
-  const ref = useRef<HTMLSpanElement | null>(null);
-  useEffect(() => {
-    const element = ref.current;
-    if (element === null || snapKey === 0) return;
-    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
-    const animation = element.animate(
-      [
-        { transform: "scale(1)" },
-        { transform: "scale(2.1)" },
-        { transform: "scale(1)" },
-      ],
-      { duration: 180, easing: "ease-out" },
-    );
-    return () => animation.cancel();
-  }, [snapKey]);
-  return (
-    <span
-      ref={ref}
-      data-seam-playhead-head
-      className="block h-1.5 w-1.5 rounded-full bg-red-500"
-    />
-  );
-}
 
 /**
  * How far each box is pulled in from its clip's true extent, per side.
@@ -370,11 +333,9 @@ export function SeamLane({
   centreClipId,
   offset,
   playheadPx,
-  snapKey,
   ghostX,
   hover,
   previewAnchor = "follow",
-  chip,
   handlers,
   atStart,
   atEnd,
@@ -388,7 +349,6 @@ export function SeamLane({
   offset: number;
   playheadPx: number | null;
   /** Bumped on every snap, so the playhead can acknowledge one. */
-  snapKey: number;
   /** Where an un-pressed pointer is hovering, in strip pixels. */
   ghostX: number | null;
   hover: SeamHover | null;
@@ -396,7 +356,6 @@ export function SeamLane({
    *  `graph-seam-preview-anchor`. */
   previewAnchor?: PreviewAnchor;
   /** The time under the playhead while it is being dragged. */
-  chip: string | null;
   handlers: React.ComponentProps<"div">;
   /** Whether the bar's first clip is the project's first — see `SeamEndCap`.
    *  False when the reach has cropped the window short of it, because then
@@ -649,9 +608,15 @@ export function SeamLane({
                 what ACKNOWLEDGES A SNAP. A snap moves the playhead by a few
                 pixels at most and is otherwise invisible, so without this you
                 cannot tell the bar helped from your hand being accurate. */}
-              <span className="absolute -top-1 left-1/2 -translate-x-1/2">
-                <SnapPulse snapKey={snapKey} />
-              </span>
+              {/* The head of the line, so the playhead reads as a position
+                  that was put there rather than a border between two boxes.
+                  It used to pulse when a drag snapped to a cut; there is no
+                  drag on the playhead any more, so there is no snap to
+                  acknowledge. */}
+              <span
+                data-seam-playhead-head
+                className="absolute -top-1 left-1/2 block h-1.5 w-1.5 -translate-x-1/2 rounded-full bg-red-500"
+              />
             </span>
           )}
         </div>
@@ -690,19 +655,6 @@ export function SeamLane({
         );
       })()}
 
-      {/* THE TIME, ON THE PLAYHEAD, while it is being dragged. ABOVE the
-          boxes, not on them: it names the frame you are looking at, and a
-          label laid over that frame answers the question by covering it. */}
-      {chip !== null && playheadPx !== null && (
-        <span
-          data-seam-chip
-          aria-hidden="true"
-          style={{ left: viewportX(playheadPx) }}
-          className="pointer-events-none absolute -top-[22px] z-10 -translate-x-1/2 rounded border border-zinc-700 bg-zinc-950/95 px-1.5 py-0.5 font-mono text-[10px] tabular-nums text-zinc-100 shadow-lg"
-        >
-          {chip}
-        </span>
-      )}
 
       {/* WHAT IS UNDER THE POINTER. A name and a frame, which together answer
           "is that the shot I am looking for" without moving the playhead to
@@ -752,19 +704,24 @@ export function SeamLane({
           // below rather than floating over a gap: a heavier border, a deeper
           // shadow and a near-opaque ground, so it reads as something in front
           // rather than something printed on what it covers.
-          // BELOW THE WHOLE BLOCK, and this number tracks the block's height.
+          // TIGHT UNDER THE FILM STRIP, and over whatever is beneath it.
           //
-          // It was 80px, which cleared the ruler and the controls row when the
-          // minimap sat last. The minimap moved up under the film strip and
-          // the controls moved to the bottom, so 80 now lands ON the controls —
-          // a card over the transport is a card you cannot press play through.
-          // Measured: track ends at 52, minimap 66–80, controls 88–116.
+          // It sat below the whole block, clear of the ruler, the minimap and
+          // the controls. That put a 264px card a long way from the 30px box it
+          // was describing, so pairing the two was a journey across everything
+          // in between — the preview and its subject were the two things
+          // furthest apart on screen.
           //
-          // The symptom of this drifting again is the card overlapping the row
-          // beneath the bar rather than sitting under it, which is quiet enough
-          // to miss — the same way the scrim's own top padding has to keep pace
-          // with this block.
-          className="pointer-events-none absolute top-32 z-20 flex w-96 -translate-x-1/2 flex-col gap-1.5 rounded-lg border border-zinc-600 bg-zinc-950/98 p-2 shadow-2xl ring-1 ring-black/50"
+          // It overlaps the minimap and the controls now, which is the right
+          // trade: those are read between gestures, and this is read DURING
+          // one. It is `pointer-events-none`, so the transport underneath stays
+          // pressable through it, and it is gone the moment the pointer leaves
+          // the boxes.
+          //
+          // Sitting just under the ruler at 56px rather than against the boxes:
+          // the ruler is the scale the box widths mean anything against, and
+          // covering it would answer "which shot" while hiding "how long".
+          className="pointer-events-none absolute top-14 z-20 flex w-96 -translate-x-1/2 flex-col gap-1.5 rounded-lg border border-zinc-600 bg-zinc-950/98 p-2 shadow-2xl ring-1 ring-black/50"
         >
           {hover.posterSrc === undefined ? null : (
             // A bare <img>: the preview is a thumbnail of a source the app

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -706,27 +706,60 @@ export function SeamLane({
         <span
           data-seam-preview
           aria-hidden="true"
-          style={{ left: viewportX(hover.x) }}
+          // KEPT INSIDE THE TRACK.
+          //
+          // It is centred on the box being pointed at, which walks it off the
+          // side as soon as that box is near either end — and the wider this
+          // card got, the more of the bar had that problem. At 288px a hover
+          // anywhere in the first or last 144 pixels was reading a card with
+          // its edge cut off, which is worst exactly where the picture is the
+          // whole point.
+          //
+          // `clamp` against percentages rather than a measured width: the
+          // percentage resolves against this element's containing block, which
+          // IS the track, so the bound follows a resize with no observer and no
+          // re-render. 9rem is half the card.
+          style={{
+            left: `clamp(9rem, ${viewportX(hover.x)}px, calc(100% - 9rem))`,
+          }}
           // BELOW THE WHOLE BAR, not just below the boxes: at `top-9` it lay
           // across the ruler and the minimap, hiding the two things that say
           // where the box being previewed actually is.
-          className="pointer-events-none absolute top-20 z-20 flex max-w-64 -translate-x-1/2 items-center gap-2 rounded-md border border-zinc-700 bg-zinc-950/95 p-1.5 shadow-xl"
+          // STACKED, SO THE PICTURE CAN BE THE SIZE OF THE ANSWER.
+          //
+          // It was a 56x32 thumbnail beside two lines of text — barely larger
+          // than the frame being pointed at, which made the preview a worse
+          // copy of the thing that prompted it. The question a hover asks is
+          // "which shot is that", and the only part of this card that answers
+          // it is the picture; the name and the time are confirmation. So the
+          // picture gets the full width of the card and the words go
+          // underneath.
+          //
+          // AND IT STANDS OFF THE PAGE, because it now overlaps the panels
+          // below rather than floating over a gap: a heavier border, a deeper
+          // shadow and a near-opaque ground, so it reads as something in front
+          // rather than something printed on what it covers.
+          className="pointer-events-none absolute top-20 z-20 flex w-72 -translate-x-1/2 flex-col gap-1.5 rounded-lg border border-zinc-600 bg-zinc-950/98 p-2 shadow-2xl ring-1 ring-black/50"
         >
           {hover.posterSrc === undefined ? null : (
             // A bare <img>: the preview is a thumbnail of a source the app
             // already holds a URL for, and next/image would add a loader
-            // round-trip on every hover for a 56px picture.
+            // round-trip on every hover for one picture.
             <img
               src={hover.posterSrc}
               alt=""
-              className="h-8 w-14 shrink-0 rounded-sm object-cover"
+              // `aspect-video` rather than a fixed height, so every shot in the
+              // card is the same shape whatever its own frame is — a row of
+              // previews that changed height as the pointer moved would be the
+              // card itself flickering.
+              className="aspect-video w-full rounded object-cover"
             />
           )}
           <span className="min-w-0">
-            <span className="block truncate text-[11px] text-zinc-100">
+            <span className="block truncate text-xs font-medium text-zinc-100">
               {hover.name}
             </span>
-            <span className="mt-0.5 block truncate font-mono text-[10px] tabular-nums text-zinc-500">
+            <span className="mt-0.5 block truncate font-mono text-[11px] tabular-nums text-zinc-400">
               {hover.meta}
             </span>
           </span>

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -641,17 +641,47 @@ export function SeamLane({
         const segment = strip.segments.find((found) => found.clipId === centreClipId);
         if (segment === undefined || segment.widthPx <= 0) return null;
         return (
-          <span
-            data-seam-active-mark={centreClipId}
-            aria-hidden="true"
-            style={{
-              left: viewportX(segment.leftPx + segment.widthPx / 2),
-              borderLeft: "5px solid transparent",
-              borderRight: "5px solid transparent",
-              borderTop: "6px solid rgba(250, 250, 250, 0.95)",
-            }}
-            className="pointer-events-none absolute -top-[9px] z-10 h-0 w-0 -translate-x-1/2"
-          />
+          <>
+            {/* AND HOW LONG IT RUNS. The triangle says WHICH clip and nothing
+                about its extent — it is the same 10px whether the shot is one
+                second or thirty, so at a glance the active clip has a position
+                and no size. A rule spanning the box gives it back, and it is
+                the one measurement the bar is built on: width is duration.
+
+                BEHIND THE TRIANGLE, and thinner, so the pair reads as one mark
+                — a pointer with a span rather than two things at the same
+                height. It uses the box's own inset, so its ends land exactly
+                where the clip's frames do rather than in the gaps either
+                side. */}
+            <span
+              data-seam-active-span={centreClipId}
+              aria-hidden="true"
+              style={{
+                left: viewportX(segment.leftPx + BOX_INSET_PX),
+                width: Math.max(2, segment.widthPx - BOX_INSET_PX * 2),
+                top: -7,
+                height: 2,
+                // HALF STRENGTH. The triangle is the mark and this is its
+                // extent — at equal weight the pair read as two claims of the
+                // same importance, and the long one wins on area alone. Behind
+                // and quieter, it measures the mark rather than competing with
+                // it.
+                backgroundColor: "rgba(250, 250, 250, 0.5)",
+              }}
+              className="pointer-events-none absolute z-10 rounded-full"
+            />
+            <span
+              data-seam-active-mark={centreClipId}
+              aria-hidden="true"
+              style={{
+                left: viewportX(segment.leftPx + segment.widthPx / 2),
+                borderLeft: "5px solid transparent",
+                borderRight: "5px solid transparent",
+                borderTop: "6px solid rgba(250, 250, 250, 0.95)",
+              }}
+              className="pointer-events-none absolute -top-[9px] z-20 h-0 w-0 -translate-x-1/2"
+            />
+          </>
         );
       })()}
 
@@ -721,7 +751,7 @@ export function SeamLane({
           // Sitting just under the ruler at 56px rather than against the boxes:
           // the ruler is the scale the box widths mean anything against, and
           // covering it would answer "which shot" while hiding "how long".
-          className="pointer-events-none absolute top-14 z-20 flex w-96 -translate-x-1/2 flex-col gap-1.5 rounded-lg border border-zinc-600 bg-zinc-950/98 p-2 shadow-2xl ring-1 ring-black/50"
+          className="animate-seam-preview-in pointer-events-none absolute top-14 z-20 flex w-96 -translate-x-1/2 flex-col gap-1.5 rounded-lg border border-zinc-600 bg-zinc-950/98 p-2 shadow-2xl ring-1 ring-black/50"
         >
           {hover.posterSrc === undefined ? null : (
             // A bare <img>: the preview is a thumbnail of a source the app

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-minimap.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-minimap.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import { BAR_NEUTRAL_COLOUR } from "@/lib/bar-collection-colours-flag";
 
@@ -33,6 +33,7 @@ export function SeamMinimap({
   windowToSeconds,
   playheadSeconds,
   onPanToSeconds,
+  settled = true,
 }: Readonly<{
   clips: readonly SeamBarClip[];
   colourOf: ReadonlyMap<string, string>;
@@ -43,9 +44,25 @@ export function SeamMinimap({
   playheadSeconds: number | null;
   /** Put this second in the middle of the bar above. */
   onPanToSeconds: (seconds: number) => void;
+  /**
+   * Whether the window rectangle should EASE to its new place.
+   *
+   * False while a gesture is driving the bar — a drag or a wheel has to track
+   * the hand exactly, and easing it would put the rectangle a fixed distance
+   * behind wherever the bar actually is, which reads as lag rather than as
+   * smoothing. True for everything else, which is where it earns its place:
+   * pressing `fit`, stepping a clip, letting go of a scrub and playback
+   * nudging the window along all move it somewhere else in one frame, and a
+   * jump that size cannot be told apart from a redraw.
+   */
+  settled?: boolean;
 }>) {
   const railRef = useRef<HTMLDivElement | null>(null);
   const draggingRef = useRef<number | null>(null);
+  // ITS OWN DRAG COUNTS TOO. The bar cannot see this one — it only hears the
+  // seconds this asks it to pan to — so the rectangle has to know for itself
+  // that the hand on it is its own.
+  const [dragging, setDragging] = useState(false);
 
   const panTo = useCallback(
     (clientX: number) => {
@@ -82,6 +99,7 @@ export function SeamMinimap({
           /* untrusted pointer (stories) — the moves still arrive here */
         }
         draggingRef.current = event.pointerId;
+        setDragging(true);
         panTo(event.clientX);
       }}
       onPointerMove={(event) => {
@@ -90,9 +108,11 @@ export function SeamMinimap({
       }}
       onPointerUp={() => {
         draggingRef.current = null;
+        setDragging(false);
       }}
       onPointerCancel={() => {
         draggingRef.current = null;
+        setDragging(false);
       }}
       className="relative mt-1.5 h-3.5 cursor-grab touch-none select-none active:cursor-grabbing"
     >
@@ -121,8 +141,17 @@ export function SeamMinimap({
           cannot see is worse than no rectangle: it says the bar is nowhere. */}
       <span
         data-seam-mini-window
+        data-seam-mini-window-eased={settled && !dragging ? "" : undefined}
         style={{ left: asPercent(windowFromSeconds), width: `${windowWidth}%` }}
-        className="absolute inset-y-0 rounded-[3px] border border-white/30 bg-white/8"
+        className={[
+          "absolute inset-y-0 rounded-[3px] border border-white/30 bg-white/8",
+          // BOTH EDGES, not just the position: a fit changes the window's
+          // WIDTH as much as its place, and easing one while cutting the other
+          // makes the rectangle appear to stretch from a corner.
+          settled && !dragging
+            ? "transition-[left,width] duration-300 ease-out motion-reduce:transition-none"
+            : "",
+        ].join(" ")}
       />
 
       {playheadSeconds !== null && (

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-preview-anchor.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-preview-anchor.ts
@@ -1,0 +1,44 @@
+// WHERE THE HOVER CARD SITS: under the pointer, or in one place.
+//
+// `follow` is the ordinary behaviour and the right default. The card names the
+// box it is describing by being over it, so pointing at a shot and reading
+// about that shot is one gesture with no lookup in the middle.
+//
+// `pinned` puts it in the centre under the bar and leaves it there. What that
+// buys is a STEADY PICTURE: the card is now big enough to actually judge a
+// frame in, and a big thing sliding around under a moving pointer is the one
+// arrangement in which you cannot judge anything — the eye spends the whole
+// sweep re-finding the picture instead of reading it. Pinned, the pointer
+// scrubs and the picture changes in place, which is the shape of the task when
+// you are hunting for a shot rather than checking one.
+//
+// The cost is the pairing: a card that is not over the box has to be read
+// against a pointer somewhere else, so at a glance it is less obvious WHICH
+// box it belongs to. That is why this is a setting and not a replacement —
+// the two are better at different jobs and neither is better at both.
+
+export const PREVIEW_ANCHORS = ["follow", "pinned"] as const;
+export type PreviewAnchor = (typeof PREVIEW_ANCHORS)[number];
+
+export function isPreviewAnchor(value: string): value is PreviewAnchor {
+  return (PREVIEW_ANCHORS as readonly string[]).includes(value);
+}
+
+/**
+ * The last anchor chosen, kept at module scope.
+ *
+ * Deliberately NOT persisted, for the same reason as the reach, the view count
+ * and the frames style: it is a working posture for a session rather than a
+ * preference. Held here rather than in the view that renders the control so
+ * that closing the details modal and opening another clip does not reset it —
+ * the modal unmounts, and state inside it would go with it.
+ */
+let remembered: PreviewAnchor = "follow";
+
+export function lastPreviewAnchor(): PreviewAnchor {
+  return remembered;
+}
+
+export function rememberPreviewAnchor(anchor: PreviewAnchor): void {
+  remembered = anchor;
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -143,6 +143,7 @@ export function SeamStripBar({
   onCommitClip,
   onScrubEnd,
   onScrubbingChange,
+  onPreviewingChange,
   atStart,
   atEnd,
   settingsLeft,
@@ -178,6 +179,19 @@ export function SeamStripBar({
   /** True while a drag is live on the bar, false when it ends — the view
    *  grows the monitor for the duration. */
   onScrubbingChange?: (active: boolean) => void;
+  /**
+   * True while the hover card is up.
+   *
+   * The view pulls the panels back for it — the card is a picture big enough
+   * to judge, and it now overlaps the row it is drawn over, so three bright
+   * panels behind it are competing with the one thing being looked at.
+   *
+   * Reported as a BOOLEAN rather than the hover itself: the row does not care
+   * which clip is under the pointer, only that something is, and handing it
+   * the hover would re-render every panel on every pointer move across the
+   * bar.
+   */
+  onPreviewingChange?: (active: boolean) => void;
   /** Whether the bar's first and last clips are the project's — the reach can
    *  crop the window short of either, and then there IS more either side. */
   atStart: boolean;
@@ -647,6 +661,15 @@ export function SeamStripBar({
     if (segment === undefined) return;
     nudgeIntoView(segment.leftPx + segment.widthPx / 2);
   }, [broughtIntoView, centreClipId, nudgeIntoView, strip]);
+
+  // DERIVED, NOT ANNOUNCED AT EACH SITE. `hover` is cleared from five places —
+  // pointer down, pointer leave, a wheel, the start of a scrub, and a position
+  // that resolves to no clip — and a missed one would leave the panels dimmed
+  // with no card up to explain why. Watching the value catches all of them.
+  const previewing = hover !== null && !scrubbing;
+  useEffect(() => {
+    onPreviewingChange?.(previewing);
+  }, [previewing, onPreviewingChange]);
 
   const ticks = useMemo(() => seamRulerTicks({ strip, clips }), [strip, clips]);
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -12,7 +12,6 @@ import {
   fitPixelsPerSecond,
   offsetAfterZoom,
   seamRulerTicks,
-  snapToCut,
   zoomByWheel,
   type SeamBarClip,
 } from "./graph-seam-bar-layout";
@@ -81,20 +80,8 @@ import type { PreviewAnchor } from "./graph-seam-preview-anchor";
  * exactly where you put it.
  */
 
-/**
- * How near an end of the track the pointer has to get before the strip starts
- * travelling under it, and how fast it goes when it does.
- *
- * The speed ramps with depth into the zone rather than being a constant, so
- * the edge is a throttle and not a switch: a pointer resting just inside it
- * creeps along at a readable pace, one pushed hard against the very end runs
- * at `MAX`, and the two are the same gesture at different depths.
- */
-const EDGE_PAN_ZONE_PX = 40;
-const EDGE_PAN_MAX_PX_PER_FRAME = 16;
-const EDGE_PAN_GAIN = 0.4;
-
-/** Travel that turns a press on the boxes from a click into a scrub. */
+/** Travel that turns a press on the boxes from a grab into a pan. Below it the
+ *  press is a CLICK, and a click still chooses a clip. */
 const CLICK_SLOP_PX = 4;
 
 /**
@@ -104,14 +91,6 @@ const CLICK_SLOP_PX = 4;
  */
 const FOLLOW_LEAD_PX = 56;
 const FOLLOW_TRAIL_PX = 72;
-
-function edgePanVelocity(clientX: number, track: DOMRect): number {
-  const intoLeft = track.left + EDGE_PAN_ZONE_PX - clientX;
-  if (intoLeft > 0) return -Math.min(EDGE_PAN_MAX_PX_PER_FRAME, intoLeft * EDGE_PAN_GAIN);
-  const intoRight = clientX - (track.right - EDGE_PAN_ZONE_PX);
-  if (intoRight > 0) return Math.min(EDGE_PAN_MAX_PX_PER_FRAME, intoRight * EDGE_PAN_GAIN);
-  return 0;
-}
 
 function readSeconds(value: number): string {
   return `${value.toFixed(2)}s`;
@@ -141,8 +120,6 @@ export function SeamStripBar({
   onStepForward,
   onScrubSeconds,
   onCommitClip,
-  onScrubEnd,
-  onScrubbingChange,
   onPreviewingChange,
   atStart,
   atEnd,
@@ -168,17 +145,6 @@ export function SeamStripBar({
   onScrubSeconds: (value: number) => void;
   /** A box was CLICKED — make that clip the centred one. */
   onCommitClip: (clipId: string) => void;
-  /**
-   * A DRAG ENDED. No clip id, deliberately: where the playhead finished is not
-   * always under the pointer — holding at an edge runs the strip along while
-   * the hand stays put — so the bar would have to re-derive a position it does
-   * not own. The view already resolves the playhead to a clip and a time; this
-   * only tells it when to act on that.
-   */
-  onScrubEnd?: () => void;
-  /** True while a drag is live on the bar, false when it ends — the view
-   *  grows the monitor for the duration. */
-  onScrubbingChange?: (active: boolean) => void;
   /**
    * True while the hover card is up.
    *
@@ -278,17 +244,18 @@ export function SeamStripBar({
     return sum > 0 ? sum : totalSeconds;
   }, [clips, centreClipId, totalSeconds]);
 
-  useEffect(() => {
-    if (trackWidth <= 0) return;
-    // ONCE. Re-fitting on every width change would undo a zoom whenever the
-    // window moved, and re-fitting on a change of subject would undo one every
-    // time you stepped a clip.
-    setPxPerSecond(
-      (current) => current ?? fitPixelsPerSecond(subjectCollectionSeconds, trackWidth),
-    );
-  }, [trackWidth, subjectCollectionSeconds]);
-
-  const scale = pxPerSecond ?? 9;
+  // THE OPENING FIT IS A FALLBACK, NOT A WRITE.
+  //
+  // It used to be an effect that set the scale once the track had been
+  // measured, which is a setState in an effect — a cascading render, and the
+  // thing the lint rule is right about. Derived instead, exactly as the pan
+  // below is: `pxPerSecond` stays null until somebodyZOOMS or presses `fit`,
+  // and until then the scale is computed from the width. Same "once" guarantee
+  // with no second render — a re-measure cannot undo a zoom, because once
+  // there IS a zoom the fallback is not consulted.
+  const scale =
+    pxPerSecond ??
+    (trackWidth > 0 ? fitPixelsPerSecond(subjectCollectionSeconds, trackWidth) : 9);
   const strip = useMemo(() => buildSeamStrip(clips, scale), [clips, scale]);
 
   // ONE NEUTRAL FOR EVERY BOX unless the tint is switched on. Substituted here
@@ -319,8 +286,6 @@ export function SeamStripBar({
   // set, playback stops dragging the bar around under the reader.
   const [followSuspended, setFollowSuspended] = useState(false);
 
-  const [scrubbing, setScrubbing] = useState(false);
-  const [snapKey, setSnapKey] = useState(0);
   const [hover, setHover] = useState<SeamHover | null>(null);
   // WHICH FIT THE BAR IS SITTING AT, if any. Seeded to `clip` because that is
   // what the opening fit does — the button is lit on arrival because it
@@ -354,21 +319,10 @@ export function SeamStripBar({
   // without listing them as dependencies and re-arming themselves between
   // frames. Several of these props are inline arrows in the view — a new
   // function on every render — and depending on one would do exactly that.
-  const pointerXRef = useRef(0);
   const panPxRef = useRef<number | null>(null);
   const offsetRef = useRef(0);
   const scaleRef = useRef(9);
   const totalPxRef = useRef(0);
-  const onScrubSecondsRef = useRef(onScrubSeconds);
-  useEffect(() => {
-    panPxRef.current = panPx;
-    offsetRef.current = offset;
-    scaleRef.current = scale;
-    totalPxRef.current = strip.totalPx;
-    panLimitRef.current = panLimit;
-    onScrubSecondsRef.current = onScrubSeconds;
-  });
-
   // HOW FAR THE STRIP MAY BE PUSHED EITHER WAY.
   //
   // A native scroller clamps at both ends for free, and the bar's transform
@@ -383,6 +337,16 @@ export function SeamStripBar({
   // the one alignment the bar exists to hold.
   const panLimit = Math.max(trackWidth / 2, centreAtPx);
   const panLimitRef = useRef(0);
+  const onScrubSecondsRef = useRef(onScrubSeconds);
+  useEffect(() => {
+    panPxRef.current = panPx;
+    offsetRef.current = offset;
+    scaleRef.current = scale;
+    totalPxRef.current = strip.totalPx;
+    panLimitRef.current = panLimit;
+    onScrubSecondsRef.current = onScrubSeconds;
+  });
+
 
   /** Move the pan without waiting for a render to tell the loops about it. */
   const setOffset = useCallback((next: number) => {
@@ -393,12 +357,6 @@ export function SeamStripBar({
     setPanPx(clamped);
   }, []);
 
-  const seekToStripX = useCallback((stripX: number) => {
-    if (scaleRef.current <= 0) return;
-    const at = Math.min(Math.max(stripX, 0), totalPxRef.current);
-    onScrubSecondsRef.current(at / scaleRef.current);
-  }, []);
-
   /** Local x within the track, which is the space every gesture works in. */
   const localX = useCallback((clientX: number) => {
     const element = trackRef.current;
@@ -407,27 +365,18 @@ export function SeamStripBar({
   }, []);
 
   // ── SCRUBBING ────────────────────────────────────────────────────────────
-  const pressRef = useRef<{ pointerId: number; x: number; moved: boolean } | null>(null);
-  const lastSnapRef = useRef<number | null>(null);
-
-  const scrubToClientX = useCallback(
-    (clientX: number) => {
-      const raw = localX(clientX) - offsetRef.current;
-      const snapped = snapToCut(strip, raw);
-      // ACKNOWLEDGE A SNAP ONCE, not on every frame that stays on it. A
-      // playhead twitching sixty times a second while the hand sat still
-      // would be a fault indicator, not a confirmation.
-      if (snapped === raw) {
-        lastSnapRef.current = null;
-      } else if (lastSnapRef.current !== snapped) {
-        lastSnapRef.current = snapped;
-        setSnapKey((key) => key + 1);
-      }
-      seekToStripX(snapped);
-    },
-    [localX, seekToStripX, strip],
-  );
-
+  const pressRef = useRef<{
+    pointerId: number;
+    x: number;
+    /** The pan the strip was at when the hand landed. Every move is measured
+     *  from here rather than accumulated, so a dropped event cannot make the
+     *  film drift away from the pointer over a long drag. */
+    offset: number;
+    moved: boolean;
+  } | null>(null);
+  // A HAND IS ON THE FILM. Distinct from a wheel pan: this one has an end
+  // event, so it does not need the timer `wheeling` does.
+  const [panning, setPanning] = useState(false);
   const onPointerDown = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
       if (!event.isPrimary || event.button !== 0) return;
@@ -436,16 +385,28 @@ export function SeamStripBar({
       } catch {
         /* untrusted pointer (stories) — the moves still arrive here */
       }
-      pressRef.current = { pointerId: event.pointerId, x: event.clientX, moved: false };
-      pointerXRef.current = event.clientX;
-      lastSnapRef.current = null;
+      // GRAB THE FILM. A press used to put the playhead where you pointed and
+      // drag it from there, which made the middle card a monitor for the
+      // duration — so reaching for the bar to look further along the sequence
+      // changed what you were working on and had to be undone afterwards.
+      //
+      // Dragging now moves the STRIP, the way you would pull a length of film
+      // along a bench: the playhead stays where it is, nothing below changes,
+      // and letting go commits to nothing. Clicking a box still chooses one,
+      // which is the gesture that always meant "go here".
+      pressRef.current = {
+        pointerId: event.pointerId,
+        x: event.clientX,
+        offset: offsetRef.current,
+        moved: false,
+      };
       setHover(null);
-      setScrubbing(true);
-      setFollowSuspended(false);
-      onScrubbingChange?.(true);
-      scrubToClientX(event.clientX);
+      setPanning(true);
+      // A DELIBERATE PAN, so playback stops dragging the bar back under the
+      // hand — the same rule the wheel already follows.
+      setFollowSuspended(true);
     },
-    [onScrubbingChange, scrubToClientX],
+    [],
   );
 
   const showHover = useCallback(
@@ -506,10 +467,13 @@ export function SeamStripBar({
       }
       if (event.pointerId !== press.pointerId) return;
       if (Math.abs(event.clientX - press.x) > CLICK_SLOP_PX) press.moved = true;
-      pointerXRef.current = event.clientX;
-      scrubToClientX(event.clientX);
+      // THE FILM FOLLOWS THE HAND, ONE TO ONE. Measured from where the press
+      // landed rather than accumulated per event, so the point of film under
+      // the finger stays under it however long the drag runs — an accumulating
+      // version drifts by whatever a dropped or coalesced move was worth.
+      setOffset(press.offset + (event.clientX - press.x));
     },
-    [scrubToClientX, showHover],
+    [setOffset, showHover],
   );
 
   const endPress = useCallback(
@@ -517,68 +481,25 @@ export function SeamStripBar({
       const press = pressRef.current;
       pressRef.current = null;
       if (press === null) return;
-      setScrubbing(false);
-      onScrubbingChange?.(false);
+      setPanning(false);
       // A PRESS THAT DID NOT TRAVEL IS A CLICK, and a click on a box makes
       // that clip active. Distinguished by travel rather than by timing,
-      // because a slow deliberate scrub must not also count as a tap on
-      // wherever it started.
-      if (press.moved) {
-        // A DRAG NOW LANDS TOO. Letting go used to leave the row where it was
-        // and only the monitor travelling, so the shot you had scrubbed to was
-        // on screen but not the one you were working on — you had to go and
-        // fetch it. Releasing is the commit.
-        onScrubEnd?.();
-        return;
-      }
+      // because a slow deliberate pan must not also count as a tap on whatever
+      // it started over.
+      //
+      // A DRAG COMMITS TO NOTHING. That is the whole point of it being a pan:
+      // you pull the film along to see what is there, and what you were
+      // working on is exactly where you left it. Letting go used to land the
+      // row on wherever the playhead had reached, which meant a look cost you
+      // your place and a trip back.
+      if (press.moved) return;
       const stripX = localX(event.clientX) - offsetRef.current;
       const landedOn = stripPositionAt(strip, stripX)?.clipId ?? null;
       if (landedOn !== null && landedOn !== centreClipId) onCommitClip(landedOn);
     },
-    [centreClipId, localX, onCommitClip, onScrubEnd, onScrubbingChange, strip],
+    [centreClipId, localX, onCommitClip, strip],
   );
 
-  // ── HOLDING AT AN EDGE RUNS THE STRIP UNDER THE POINTER ──────────────────
-  //
-  // The track only spans what is on screen, so without this the end of it is
-  // the end of the timeline you can reach in one gesture, with the rest of the
-  // order sitting an inch off the side.
-  //
-  // A FRAME LOOP RATHER THAN THE POINTER MOVES, because the hand is STILL —
-  // holding at an edge fires no further pointermove events at all, and an
-  // implementation reading the moves would travel only while the hand
-  // jittered.
-  useEffect(() => {
-    if (!scrubbing) return;
-    let frame = requestAnimationFrame(function tick() {
-      frame = requestAnimationFrame(tick);
-      const element = trackRef.current;
-      if (element === null || scaleRef.current <= 0) return;
-      const box = element.getBoundingClientRect();
-      const velocity = edgePanVelocity(pointerXRef.current, box);
-      if (velocity === 0) return;
-
-      const next = offsetRef.current - velocity;
-      // IT STOPS AT THE ENDS BY ASKING WHERE THE POINTER NOW POINTS, not by
-      // clamping the transform. The offset that puts the last clip under the
-      // pointer is a function of the pan, the track width and the scale, and
-      // the one number that has to stay in range is the time being scrubbed
-      // to — so that is the number the guard is written against.
-      const stripX = pointerXRef.current - box.left - next;
-      if (stripX < 0 || stripX > totalPxRef.current) return;
-
-      // THE FILM MOVED UNDER THE POINTER, so this is a drag even though the
-      // hand never left the spot it landed on. Without this an edge-scrub
-      // across half the project would end in a CLICK — committing to whatever
-      // clip happened to arrive under a stationary finger.
-      const press = pressRef.current;
-      if (press !== null) press.moved = true;
-
-      setOffset(next);
-      seekToStripX(stripX);
-    });
-    return () => cancelAnimationFrame(frame);
-  }, [scrubbing, seekToStripX, setOffset]);
 
   // ── WHEEL: PAN, OR ZOOM ABOUT THE POINTER ────────────────────────────────
   //
@@ -651,22 +572,26 @@ export function SeamStripBar({
   // does not get dragged to the middle: the bar is a map you have positioned,
   // and stepping a clip is not a request to throw that away. Skipped while the
   // pan is still null, because the fallback is already centring it.
-  const [broughtIntoView, setBroughtIntoView] = useState(centreClipId);
+  // A REF, NOT STATE. Nothing renders from this — it only remembers which
+  // subject has already been brought into view so the nudge runs once per
+  // change. As state it was a setState inside an effect, which is a second
+  // render for a value no one draws.
+  const broughtIntoViewRef = useRef(centreClipId);
   useEffect(() => {
-    if (broughtIntoView === centreClipId) return;
-    setBroughtIntoView(centreClipId);
+    if (broughtIntoViewRef.current === centreClipId) return;
+    broughtIntoViewRef.current = centreClipId;
     setFollowSuspended(false);
     if (panPxRef.current === null) return;
     const segment = strip.segments.find((candidate) => candidate.clipId === centreClipId);
     if (segment === undefined) return;
     nudgeIntoView(segment.leftPx + segment.widthPx / 2);
-  }, [broughtIntoView, centreClipId, nudgeIntoView, strip]);
+  }, [centreClipId, nudgeIntoView, strip]);
 
-  // DERIVED, NOT ANNOUNCED AT EACH SITE. `hover` is cleared from five places —
-  // pointer down, pointer leave, a wheel, the start of a scrub, and a position
-  // that resolves to no clip — and a missed one would leave the panels dimmed
-  // with no card up to explain why. Watching the value catches all of them.
-  const previewing = hover !== null && !scrubbing;
+  // DERIVED, NOT ANNOUNCED AT EACH SITE. `hover` is cleared from four places —
+  // pointer down, pointer leave, a wheel, and a position that resolves to no
+  // clip — and a missed one would leave the panels dimmed with no card up to
+  // explain why. Watching the value catches all of them.
+  const previewing = hover !== null;
   useEffect(() => {
     onPreviewingChange?.(previewing);
   }, [previewing, onPreviewingChange]);
@@ -774,7 +699,14 @@ export function SeamStripBar({
         // browser's own focus ring drew a pale outline around the whole track
         // the moment you touched it, which read as a border the bar did not
         // have a second earlier.
-        className="relative flex-1 outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+        // `z-30`, so what OVERFLOWS this element paints above the minimap and
+        // the controls below it. The hover card is absolutely positioned inside
+        // the lane and now hangs well past the track's own 52px; without a
+        // stacking order the two later siblings would paint over it, since DOM
+        // order decides among elements that never asked. The track's own box
+        // does not reach them, and the card is `pointer-events-none`, so
+        // nothing under it stops being clickable.
+        className="relative z-30 flex-1 outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
       >
         <SeamLane
           laneRef={laneRef}
@@ -786,11 +718,9 @@ export function SeamStripBar({
           atEnd={atEnd}
           offset={offset}
           playheadPx={playheadPx}
-          snapKey={snapKey}
           ghostX={hover === null ? null : hover.x}
-          hover={scrubbing ? null : hover}
+          hover={panning ? null : hover}
           previewAnchor={previewAnchor}
-          chip={scrubbing ? readSeconds(atSeconds) : null}
           handlers={{
             onPointerDown,
             onPointerMove,
@@ -837,12 +767,13 @@ export function SeamStripBar({
         windowToSeconds={windowToSeconds}
         playheadSeconds={playheadSeconds}
         onPanToSeconds={panToSeconds}
-        // EASE THE WINDOW WHEN NOTHING IS DRIVING IT. A scrub can run the
-        // strip under a stationary pointer and a wheel pans it directly; both
-        // have to arrive exactly where the hand is. A fit, a step or a landing
-        // moves it somewhere else in a single frame, and that is the jump
-        // worth animating.
-        settled={!scrubbing && !wheeling}
+        // EASE THE WINDOW WHEN NOTHING IS DRIVING IT. A hand on the film and
+        // a wheel both move the strip directly, and the rectangle has to arrive
+        // exactly where they put it — easing would leave it trailing the film
+        // it is supposed to be reporting. A fit, a step or a landing moves it
+        // somewhere else in a single frame, and that is the jump worth
+        // animating.
+        settled={!panning && !wheeling}
       />
 
       {/* THE CONTROLS UNDER BOTH BARS, and the transport in the middle of it.

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -25,6 +25,7 @@ import {
   stripPositionAt,
   stripXFor,
 } from "./graph-seam-strip";
+import { formatClock } from "@/lib/format-duration";
 
 /**
  * The bar over the carousel: the whole project in playback order, as a
@@ -113,6 +114,19 @@ function edgePanVelocity(clientX: number, track: DOMRect): number {
 function readSeconds(value: number): string {
   return `${value.toFixed(2)}s`;
 }
+
+/**
+ * What the two fit buttons aim at.
+ *
+ * `clip` is the collection the subject belongs to — the sequence being worked
+ * on, and the scale the bar already opens at. `all` is everything the reach
+ * window covers. They are the two questions worth one press: "show me this
+ * scene" and "show me the lot".
+ *
+ * Null once a wheel zoom has happened, because at that point neither is true
+ * and lighting one would be claiming a scale the bar is not at.
+ */
+type FitMode = "clip" | "all";
 
 export function SeamStripBar({
   clips,
@@ -288,6 +302,25 @@ export function SeamStripBar({
   const [scrubbing, setScrubbing] = useState(false);
   const [snapKey, setSnapKey] = useState(0);
   const [hover, setHover] = useState<SeamHover | null>(null);
+  // WHICH FIT THE BAR IS SITTING AT, if any. Seeded to `clip` because that is
+  // what the opening fit does — the button is lit on arrival because it
+  // describes where you already are, not somewhere you could go.
+  const [fitMode, setFitMode] = useState<FitMode | null>("clip");
+  // A WHEEL IS A GESTURE, and it has no end event.
+  //
+  // The minimap's window rectangle eases to a new place, which is right for a
+  // fit or a step and wrong for a pan: during a wheel the bar has to be
+  // exactly where the hand put it, and an eased rectangle would trail it. A
+  // press has a pointerup to switch this back off; a wheel only stops, so it
+  // is switched off on a short timer after the last notch.
+  const [wheeling, setWheeling] = useState(false);
+  const wheelStopRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (wheelStopRef.current !== null) clearTimeout(wheelStopRef.current);
+    },
+    [],
+  );
 
   const playheadPx =
     playheadAt === null
@@ -512,12 +545,20 @@ export function SeamStripBar({
       event.preventDefault();
       setFollowSuspended(true);
       setHover(null);
+      setWheeling(true);
+      if (wheelStopRef.current !== null) clearTimeout(wheelStopRef.current);
+      // Long enough to bridge the gap between notches of one scroll, short
+      // enough that letting go feels like letting go.
+      wheelStopRef.current = setTimeout(() => setWheeling(false), 160);
       if (event.ctrlKey || event.metaKey) {
         const from = scaleRef.current;
         const to = zoomByWheel(from, event.deltaY);
         if (to === from) return;
         const anchorLocalX = event.clientX - element.getBoundingClientRect().left;
         setPxPerSecond(to);
+        // NEITHER FIT IS TRUE ANY MORE. Leaving one lit after a zoom would be
+        // the control lying about the scale it names.
+        setFitMode(null);
         setOffset(offsetAfterZoom({ anchorLocalX, offset: offsetRef.current, from, to }));
         return;
       }
@@ -574,6 +615,47 @@ export function SeamStripBar({
   }, [broughtIntoView, centreClipId, nudgeIntoView, strip]);
 
   const ticks = useMemo(() => seamRulerTicks({ strip, clips }), [strip, clips]);
+
+  /**
+   * Re-scale so a span fills the track, and put the subject back under the
+   * card.
+   *
+   * BOTH HALVES, because a fit that only changed the scale would leave the bar
+   * showing whatever stretch happened to be under the old offset at the new
+   * zoom — usually nowhere near the clip being worked on. Fitting is a request
+   * to see something, so it re-centres as well as re-scales, which is the one
+   * place the bar deliberately overrides "stay where you were put".
+   */
+  const fitTo = useCallback(
+    (mode: FitMode) => {
+      const width = trackRef.current?.getBoundingClientRect().width ?? trackWidth;
+      if (width <= 0) return;
+      const span = mode === "clip" ? subjectCollectionSeconds : totalSeconds;
+      if (span <= 0) return;
+      const next = fitPixelsPerSecond(span, width);
+      setPxPerSecond(next);
+      setFitMode(mode);
+      setFollowSuspended(false);
+      // Re-centre with the NEW scale rather than the ref's old one — the ref
+      // is refreshed by an effect after render, so it is still the pre-fit
+      // value at this point and would centre against a scale that no longer
+      // exists.
+      const rebuilt = buildSeamStrip(clips, next);
+      const segment = rebuilt.segments.find((found) => found.clipId === centreClipId);
+      if (segment === undefined) return;
+      const target = centreAtPx > 0 ? centreAtPx : width / 2;
+      setOffset(target - (segment.leftPx + segment.widthPx / 2));
+    },
+    [
+      centreAtPx,
+      centreClipId,
+      clips,
+      setOffset,
+      subjectCollectionSeconds,
+      totalSeconds,
+      trackWidth,
+    ],
+  );
 
   const panToSeconds = useCallback(
     (value: number) => {
@@ -748,11 +830,56 @@ export function SeamStripBar({
               belongs with the transport rather than with the track: it says
               where playback IS, which is the same question the play button
               answers, and reading the two together is why it moved. */}
-          <span className="shrink-0 font-mono text-[11px] tabular-nums text-zinc-400">
-            <span className="text-blue-300">{readSeconds(atSeconds)}</span>
+          {/* CLOCK NOTATION, NOT SECONDS. `252.90s` is accurate and unusable —
+              nobody can place it in a four-minute cut without doing division.
+              Tenths rather than hundredths because this number MOVES: the
+              second decimal is a blur at playback speed, and the first is
+              exactly enough to see time passing. */}
+          <span
+            data-seam-clock
+            className="shrink-0 font-mono text-[11px] tabular-nums text-zinc-500"
+          >
+            <span className="text-blue-400">{formatClock(atSeconds)}</span>
             {" / "}
-            {readSeconds(totalSeconds)}
+            <span className="text-blue-400/70">{formatClock(totalSeconds)}</span>
           </span>
+
+          {/* FIT: the two scales worth one press.
+              Zoom was ⌘-wheel and nothing else, which meant the two scales
+              anyone actually wants — this scene, and the lot — were reachable
+              only by rolling until they happened to arrive. Both are one
+              `fitPixelsPerSecond` call the bar was already making on open;
+              this just gives them a button. */}
+          <div
+            data-seam-fit
+            role="group"
+            aria-label="Fit the bar to"
+            className="hidden shrink-0 items-center gap-1 md:flex"
+          >
+            <span className="mr-1 font-mono text-[10px] text-zinc-500">fit</span>
+            {(["clip", "all"] as const).map((mode) => (
+              <button
+                key={mode}
+                type="button"
+                aria-pressed={mode === fitMode}
+                onClick={() => fitTo(mode)}
+                title={
+                  mode === "clip"
+                    ? "Fit this clip's collection"
+                    : "Fit everything the bar reaches"
+                }
+                className={[
+                  "min-w-7 rounded px-1.5 py-0.5 font-mono text-[10px] tabular-nums transition-colors",
+                  mode === fitMode
+                    ? "bg-zinc-100 text-zinc-900"
+                    : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100",
+                ].join(" ")}
+              >
+                {mode}
+              </button>
+            ))}
+          </div>
+
           <div className="hidden min-w-0 items-center gap-1 md:flex">{settingsRight}</div>
         </div>
       </div>
@@ -769,6 +896,12 @@ export function SeamStripBar({
         windowToSeconds={windowToSeconds}
         playheadSeconds={playheadSeconds}
         onPanToSeconds={panToSeconds}
+        // EASE THE WINDOW WHEN NOTHING IS DRIVING IT. A scrub can run the
+        // strip under a stationary pointer and a wheel pans it directly; both
+        // have to arrive exactly where the hand is. A fit, a step or a landing
+        // moves it somewhere else in a single frame, and that is the jump
+        // worth animating.
+        settled={!scrubbing && !wheeling}
       />
     </div>
   );

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -80,6 +80,15 @@ import type { PreviewAnchor } from "./graph-seam-preview-anchor";
  * exactly where you put it.
  */
 
+/**
+ * How long the pointer has to rest on a box before its preview appears.
+ *
+ * Long enough that crossing the bar on the way to grabbing it shows nothing,
+ * short enough that stopping to look does not feel like waiting. Only the
+ * first appearance waits; after that the card follows live.
+ */
+const HOVER_DWELL_MS = 220;
+
 /** Travel that turns a press on the boxes from a grab into a pan. Below it the
  *  press is a CLICK, and a click still chooses a clip. */
 const CLICK_SLOP_PX = 4;
@@ -287,6 +296,27 @@ export function SeamStripBar({
   const [followSuspended, setFollowSuspended] = useState(false);
 
   const [hover, setHover] = useState<SeamHover | null>(null);
+  // A SHORT DWELL BEFORE THE CARD APPEARS.
+  //
+  // Most trips across this bar are on the way to grabbing it. Popping a 264px
+  // card up the instant the pointer touches a box means every reach for the
+  // film flashes something you did not ask for and then takes it away — the
+  // interface twitching at a gesture that had not started yet.
+  //
+  // ONLY THE FIRST APPEARANCE WAITS. Once the card is up it tracks the pointer
+  // with no delay at all: the dwell is asking "did you mean to look at this",
+  // and once answered it must not be asked again on every box you cross.
+  const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hoverPendingRef = useRef<SeamHover | null>(null);
+  const hoverShownRef = useRef(false);
+  const cancelHover = useCallback(() => {
+    if (hoverTimerRef.current !== null) clearTimeout(hoverTimerRef.current);
+    hoverTimerRef.current = null;
+    hoverPendingRef.current = null;
+    hoverShownRef.current = false;
+    setHover(null);
+  }, []);
+  useEffect(() => cancelHover, [cancelHover]);
   // WHICH FIT THE BAR IS SITTING AT, if any. Seeded to `clip` because that is
   // what the opening fit does — the button is lit on arrival because it
   // describes where you already are, not somewhere you could go.
@@ -400,13 +430,13 @@ export function SeamStripBar({
         offset: offsetRef.current,
         moved: false,
       };
-      setHover(null);
+      cancelHover();
       setPanning(true);
       // A DELIBERATE PAN, so playback stops dragging the bar back under the
       // hand — the same rule the wheel already follows.
       setFollowSuspended(true);
     },
-    [],
+    [cancelHover],
   );
 
   const showHover = useCallback(
@@ -415,10 +445,10 @@ export function SeamStripBar({
       const at = stripPositionAt(strip, stripX);
       const clip = at === null ? undefined : clips.find((candidate) => candidate.id === at.clipId);
       if (at === null || clip === undefined) {
-        setHover(null);
+        cancelHover();
         return;
       }
-      setHover({
+      const next: SeamHover = {
         x: stripX,
         name: clip.name,
         meta: `${clip.collectionName === null ? "" : `${clip.collectionName} · `}${readSeconds(
@@ -453,9 +483,24 @@ export function SeamStripBar({
                   Math.round(((clip.trimInSeconds ?? 0) + at.secondsIntoClip) * 4) / 4,
                 ) ?? clip.posterSrc,
             }),
-      });
+      };
+      // Already up: follow immediately. The dwell is a question about
+      // INTENT, and it has been answered.
+      if (hoverShownRef.current) {
+        setHover(next);
+        return;
+      }
+      hoverPendingRef.current = next;
+      if (hoverTimerRef.current !== null) return;
+      hoverTimerRef.current = setTimeout(() => {
+        hoverTimerRef.current = null;
+        const pending = hoverPendingRef.current;
+        if (pending === null) return;
+        hoverShownRef.current = true;
+        setHover(pending);
+      }, HOVER_DWELL_MS);
     },
-    [clips, localX, strip],
+    [cancelHover, clips, localX, strip],
   );
 
   const onPointerMove = useCallback(
@@ -513,7 +558,7 @@ export function SeamStripBar({
     const onWheel = (event: WheelEvent) => {
       event.preventDefault();
       setFollowSuspended(true);
-      setHover(null);
+      cancelHover();
       setWheeling(true);
       if (wheelStopRef.current !== null) clearTimeout(wheelStopRef.current);
       // Long enough to bridge the gap between notches of one scroll, short
@@ -540,7 +585,7 @@ export function SeamStripBar({
     };
     element.addEventListener("wheel", onWheel, { passive: false });
     return () => element.removeEventListener("wheel", onWheel);
-  }, [setOffset]);
+  }, [cancelHover, setOffset]);
 
   // ── KEEPING THE PLAYHEAD IN VIEW ─────────────────────────────────────────
   //
@@ -726,7 +771,7 @@ export function SeamStripBar({
             onPointerMove,
             onPointerUp: endPress,
             onPointerCancel: endPress,
-            onPointerLeave: () => setHover(null),
+            onPointerLeave: cancelHover,
           }}
         />
 
@@ -793,7 +838,12 @@ export function SeamStripBar({
           track above it and leaves it there. */}
       <div
         data-seam-controls
-        className="grid grid-cols-[1fr_auto_1fr] items-center gap-3"
+        // `pb-2` MATCHES THE `gap-2` ABOVE. This row is the last child of the
+        // bar's column, so it had 8px of stack gap over it and nothing under —
+        // which put the ensemble visibly high in its own band even though the
+        // row itself was centred. Equal air on both sides is what makes it look
+        // centred, and only one of those two numbers existed.
+        className="grid grid-cols-[1fr_auto_1fr] items-center gap-3 pb-2"
       >
         {/* HIDDEN, NOT WRAPPED, on a narrow view. Wrapping this row costs the
             strip below a line of height it has to be told about — see the
@@ -802,7 +852,23 @@ export function SeamStripBar({
             what is being USED. */}
         <div className="hidden min-w-0 items-center gap-1 md:flex">{settingsLeft}</div>
 
-        <div data-seam-transport className="flex items-center gap-1">
+        {/* THE TRANSPORT, AS ONE OBJECT AND THE BIGGEST THING IN THE ROW.
+            It was three small icon buttons with the same weight as the
+            settings either side of it, spaced like them and indistinguishable
+            from them at a glance — so the one control this view is actually
+            for looked like another toggle. It is now an ensemble: a single
+            rounded ground holding all three, which says they belong to each
+            other and not to the badges beside them.
+
+            AND IT LINES UP WITH THE PANEL IT DRIVES. The row is a
+            `1fr auto 1fr` grid so this sits on the middle of the TRACK, and the
+            track's middle is what the row below centres its subject on — so
+            the play button and the clip it plays are on the same vertical, and
+            stay there when a setting changes width. */}
+        <div
+          data-seam-transport
+          className="flex items-center gap-1.5 rounded-full border border-zinc-700/80 bg-zinc-900/70 p-1.5"
+        >
           {/* STEP ONE CLIP, either way, bracketing the thing they move.
               Disabled rather than hidden at the ends: a control that vanishes
               takes its own position with it and shifts the bar sideways. */}
@@ -813,23 +879,41 @@ export function SeamStripBar({
             onClick={() => onStepBack?.()}
             aria-label="Previous clip"
             title="Previous clip (⇧←)"
-            className="rounded p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-25"
+            className="grid h-7 w-7 place-items-center rounded-full text-zinc-300 transition-colors hover:bg-zinc-800 hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-25"
           >
             <ChevronLeft aria-hidden="true" className="h-4 w-4" />
           </button>
+
+          {/* THE CENTREPIECE. Filled rather than ghosted, and half again the
+              size of its neighbours: of everything in this row it is the one
+              control with a single obvious meaning, and the only one anyone
+              reaches for without reading first. Big enough to be that, and no
+              bigger — at 44px it stopped reading as a control in a row and
+              started reading as a button the row was arranged around.
+
+              ONE NUMBER FOR ALL THE AIR AROUND IT. The ring's padding and the
+              gaps between the three buttons are the same 6px, so the play
+              button has equal space on every side rather than 6px outside and
+              4px in — a difference small enough to read as "not quite centred"
+              without being large enough to name. */}
           <button
             type="button"
+            data-seam-play
             onClick={onTogglePlay}
             aria-label={playing ? "Pause" : "Play across the cut"}
             title="Play / pause (space)"
-            className="rounded-full p-1.5 text-zinc-300 outline-none hover:bg-zinc-800 hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-blue-500"
+            className="grid h-8 w-8 place-items-center rounded-full bg-zinc-100 text-zinc-900 shadow-sm transition-colors outline-none hover:bg-white focus-visible:ring-2 focus-visible:ring-blue-500"
           >
             {playing ? (
               <Pause aria-hidden="true" className="h-4 w-4" />
             ) : (
-              <Play aria-hidden="true" className="h-4 w-4" />
+              // Nudged right by a hair: a triangle's optical centre is left of
+              // its bounding box, so a centred play glyph reads as sitting
+              // slightly back in the circle.
+              <Play aria-hidden="true" className="h-4 w-4 translate-x-[1px]" />
             )}
           </button>
+
           <button
             type="button"
             data-seam-step="forward"
@@ -837,7 +921,7 @@ export function SeamStripBar({
             onClick={() => onStepForward?.()}
             aria-label="Next clip"
             title="Next clip (⇧→)"
-            className="rounded p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-25"
+            className="grid h-7 w-7 place-items-center rounded-full text-zinc-300 transition-colors hover:bg-zinc-800 hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-25"
           >
             <ChevronRight aria-hidden="true" className="h-4 w-4" />
           </button>

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -797,10 +797,39 @@ export function SeamStripBar({
         <SeamRuler ticks={ticks} offset={offset} />
       </div>
 
-      {/* ONE ROW BETWEEN THE TWO BARS, and the transport in the middle of it.
-          The scrub bar above is the cut; the minimap below is the project; the
-          controls that drive both sit between them where they are equally
-          about each.
+      {/* THE WHOLE PROJECT, DIRECTLY UNDER THE FILM STRIP.
+          The two are the same object at two scales — this cut, and where that
+          cut is in the project — and reading one against the other is the
+          whole point of having both. They were separated by the controls row,
+          which put a line of buttons between a window and the map of what it
+          is a window ONTO: the rectangle and the boxes it corresponds to were
+          the two things furthest apart in the block.
+          Nothing lands between them now, so the eye can go straight from a box
+          to its place in the sequence. */}
+      <SeamMinimap
+        clips={clips}
+        colourOf={boxColourOf}
+        totalSeconds={totalSeconds}
+        windowFromSeconds={windowFromSeconds}
+        windowToSeconds={windowToSeconds}
+        playheadSeconds={playheadSeconds}
+        onPanToSeconds={panToSeconds}
+        // EASE THE WINDOW WHEN NOTHING IS DRIVING IT. A scrub can run the
+        // strip under a stationary pointer and a wheel pans it directly; both
+        // have to arrive exactly where the hand is. A fit, a step or a landing
+        // moves it somewhere else in a single frame, and that is the jump
+        // worth animating.
+        settled={!scrubbing && !wheeling}
+      />
+
+      {/* THE CONTROLS UNDER BOTH BARS, and the transport in the middle of it.
+          They sat between the two, on the reasoning that a row driving both
+          belongs equally close to each. What that missed is that the two bars
+          are more use to each other than either is to the buttons: one is a
+          window and the other is the map it moves over, so anything between
+          them is between a thing and its own index. The controls are the row
+          you reach for, not the row you read, and they lose nothing by sitting
+          under what they act on.
 
           A THREE-COLUMN GRID, not a flex row with `justify-between`. The
           transport has to be centred on the BAR, and a flex row centres it
@@ -919,25 +948,6 @@ export function SeamStripBar({
         </div>
       </div>
 
-      {/* THE WHOLE PROJECT, under the controls rather than tucked inside the
-          track. It is a different scale from the bar above — that one shows a
-          stretch, this one shows all of it — and stacking them with the
-          controls between says so. */}
-      <SeamMinimap
-        clips={clips}
-        colourOf={boxColourOf}
-        totalSeconds={totalSeconds}
-        windowFromSeconds={windowFromSeconds}
-        windowToSeconds={windowToSeconds}
-        playheadSeconds={playheadSeconds}
-        onPanToSeconds={panToSeconds}
-        // EASE THE WINDOW WHEN NOTHING IS DRIVING IT. A scrub can run the
-        // strip under a stationary pointer and a wheel pans it directly; both
-        // have to arrive exactly where the hand is. A fit, a step or a landing
-        // moves it somewhere else in a single frame, and that is the jump
-        // worth animating.
-        settled={!scrubbing && !wheeling}
-      />
     </div>
   );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -26,6 +26,7 @@ import {
   stripXFor,
 } from "./graph-seam-strip";
 import { formatClock } from "@/lib/format-duration";
+import { monitorPosterUrl } from "@/lib/video-frame-url";
 
 /**
  * The bar over the carousel: the whole project in playback order, as a
@@ -443,7 +444,35 @@ export function SeamStripBar({
         meta: `${clip.collectionName === null ? "" : `${clip.collectionName} · `}${readSeconds(
           at.secondsIntoClip,
         )} / ${readSeconds(clip.showingSeconds)}`,
-        ...(clip.posterSrc === undefined ? {} : { posterSrc: clip.posterSrc }),
+        // THE FRAME UNDER THE POINTER, not the clip's opening frame.
+        //
+        // It showed `posterSrc` — one picture per clip — so moving along a
+        // ten-second take changed the time in the caption and nothing else.
+        // The card is answering "what is HERE", and a still of the shot's first
+        // frame answers "what is this clip", which the box's own strip already
+        // said. Reading across a long take is most of what the hover is for.
+        //
+        // QUANTISED TO A QUARTER SECOND. The URL is a Cloudinary frame grab, so
+        // every distinct time is a distinct fetch, and a pointer crossing a
+        // wide box at sixty frames a second would ask for a few hundred of
+        // them. A quarter second is finer than the eye tracks while sweeping
+        // and coarse enough that a second pass over the same clip is answered
+        // from cache.
+        //
+        // VIDEO ONLY. A still has one image and no timeline to sample; asking
+        // for a frame offset into it would rewrite a perfectly good image URL
+        // into one that names a moment the file does not have.
+        ...(clip.posterSrcs === undefined
+          ? clip.posterSrc === undefined
+            ? {}
+            : { posterSrc: clip.posterSrc }
+          : {
+              posterSrc:
+                monitorPosterUrl(
+                  clip.posterSrcs[0],
+                  Math.round(((clip.trimInSeconds ?? 0) + at.secondsIntoClip) * 4) / 4,
+                ) ?? clip.posterSrc,
+            }),
       });
     },
     [clips, localX, strip],

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -27,6 +27,7 @@ import {
 } from "./graph-seam-strip";
 import { formatClock } from "@/lib/format-duration";
 import { monitorPosterUrl } from "@/lib/video-frame-url";
+import type { PreviewAnchor } from "./graph-seam-preview-anchor";
 
 /**
  * The bar over the carousel: the whole project in playback order, as a
@@ -146,6 +147,7 @@ export function SeamStripBar({
   atEnd,
   settingsLeft,
   settingsRight,
+  previewAnchor = "follow",
 }: Readonly<{
   /** Every clip the bar can reach, in playback order. */
   clips: readonly SeamBarClip[];
@@ -193,6 +195,9 @@ export function SeamStripBar({
    */
   settingsLeft?: React.ReactNode;
   settingsRight?: React.ReactNode;
+  /** Whether the hover card follows the pointer or parks under the middle of
+   *  the bar — see `graph-seam-preview-anchor`. */
+  previewAnchor?: PreviewAnchor;
 }>) {
   const trackRef = useRef<HTMLDivElement | null>(null);
   const laneRef = useRef<HTMLDivElement | null>(null);
@@ -761,6 +766,7 @@ export function SeamStripBar({
           snapKey={snapKey}
           ghostX={hover === null ? null : hover.x}
           hover={scrubbing ? null : hover}
+          previewAnchor={previewAnchor}
           chip={scrubbing ? readSeconds(atSeconds) : null}
           handlers={{
             onPointerDown,

--- a/apps/timeline-gstudio001/lib/format-duration.ts
+++ b/apps/timeline-gstudio001/lib/format-duration.ts
@@ -49,6 +49,35 @@ export function formatSeconds(seconds: number): string {
 }
 
 /**
+ * A RUNNING clock: "0:21.6", "4:12.9", "1:02:03.4".
+ *
+ * A third register, and it earns its place by being the only one that has to
+ * be readable while it MOVES. `formatDuration` rounds to the second, so a
+ * playhead crossing 21.4 → 21.6 does not visibly advance; `formatSeconds`
+ * keeps hundredths but stays in seconds, so a four-minute project reads
+ * "252.90s" — a number nobody can locate in a timeline.
+ *
+ * Tenths rather than hundredths: the second decimal changes too fast to read
+ * and is noise on a moving readout, while the first is exactly enough to see
+ * that time is passing and to land on a frame you meant.
+ */
+export function formatClock(seconds: number): string {
+  const safe = Number.isFinite(seconds) && seconds > 0 ? seconds : 0;
+  const hours = Math.floor(safe / 3600);
+  const minutes = Math.floor((safe % 3600) / 60);
+  // FLOOR THE TENTH, never round it. Rounding 59.97 gives 60.0, which would
+  // print ":60.0" — and carrying that into the minute is arithmetic this
+  // readout would have to redo on every frame to stay correct. A clock that
+  // never displays a time it has not yet reached is also the honest one.
+  const rest = Math.floor((safe % 60) * 10) / 10;
+  const shown = rest.toFixed(1).padStart(4, "0");
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, "0")}:${shown}`;
+  }
+  return `${minutes}:${shown}`;
+}
+
+/**
  * Ruler ticks: the reading form, minus the trailing ".0" on whole seconds.
  * A tick every second reading "1.0s 2.0s 3.0s" is a column of noise; the
  * fractional tiers (½s, ¼s) still need their decimal.

--- a/docs/details-modal-filmstrip-and-playbar-behaviour.md
+++ b/docs/details-modal-filmstrip-and-playbar-behaviour.md
@@ -98,12 +98,30 @@ cannot drift by a subpixel.
 - **Only `floor(viewCount/2) + 1` panels either side are actually mounted.**
   Everything else is an empty div of the right width holding its position. The
   spare pair beyond the visible edge means an arriving panel already exists
-  rather than being constructed mid-slide.
-- **View count is 3 or 5**, picked bottom-right. Width is
-  `min(48rem, (100vw - 3rem - (n-1)rem) / (n-1))` — so `n-2` panels are fully
-  visible and the two outermost are half visible, and the widths add to exactly
-  one viewport. The picker dims to 20% opacity while scrubbing.
+  rather than being constructed mid-slide. Those spares are
+  **`visibility: hidden`** (`data-item-details-spare`) — they keep their width,
+  because the centring is arithmetic over uniform neighbour widths, but they
+  paint nothing. Without that they show as a sliver down each side, since
+  `count` panels now fill the viewport exactly.
+- **View count is 3 or 5**, picked bottom-right. The picker dims to 20%
+  opacity while scrubbing.
+- **Two widths, not one.** The clip being worked on is **1.75×** its
+  neighbours, and every panel is fully visible:
+
+  ```
+  N = (100vw - 3rem - (count-1)rem) / (count - 1 + 1.75)      neighbour
+  C = 1.75 × N                                                 centre
+  ```
+
+  It used to be one width with the outer pair hanging half off each edge —
+  which is what made "show three" mean one whole panel and two halves.
+- **The centre's extra width cancels out of the centring.** The row still
+  translates by `-(N + gap) × (centre - (n-1)/2)`: the wide panel is symmetric
+  about its own middle, so only the neighbour width sets the step.
 - Transition on the row: `300ms ease-out`, disabled while a finger is on it.
+  The panels' **width** animates over the same 300ms on a step — that size
+  change is the motion — and is **cut to `transition-none` on a landing**,
+  because a landing must not move the middle card at all.
 
 ### What one panel contains
 
@@ -287,6 +305,16 @@ passively at the root, so `preventDefault` from a synthetic handler is ignored
   out otherwise looks exactly like a bar that has been cropped. They are a 6px
   gradient falling away from the film — deliberately not box-shaped, because
   anything box-shaped here gets counted as a clip.
+- **The clip the cards are on wears a red ring** on the box's own edge
+  (`data-seam-marker`), not a dot inside it — a dot had to fight whatever
+  picture the box was drawing and would not fit in a narrow one. Same red as
+  the playhead: both answer "which clip is this view about", one in space and
+  one in time.
+- **A clip playback skips is hatched** (`data-seam-hatch`) with diagonal
+  stripes, plus a red dotted rule above its box (`data-seam-skip-rule`). A
+  pattern rather than a dim, because a dimmed box is indistinguishable from a
+  dark frame. It keeps its **full width** — a disabled clip is still part of
+  the sequence you are reading, and shrinking it would move every cut after it.
 - Collection dividers and ruler labels are the only landmarks on a run of
   boxes. Collection tinting exists but sits behind
   `BAR_COLLECTION_COLOURS_ENABLED`; with it off every box takes one neutral.
@@ -315,16 +343,23 @@ With pictures in the boxes the 5px gap disappears, and **no single colour fixes
 it**: a dark gap is invisible between two dark frames, a pale one is invisible
 between two bright frames, and footage supplies both within the same cut.
 
-So the gap carries **both tones**. The strip background is pale and each box
-casts a 1.5px dark ring into the gap, making every gap read
-**dark · pale · dark**:
+So the gap carries **both tones**. The strip background is near-black and each
+box casts a 1.5px pale ring into the gap, making every gap read
+**light · dark · light**:
 
 ```
-two bright frames    white | DARK pale DARK | white    <- the rings show
-two dark frames      black | dark PALE dark | black    <- the core shows
+two bright frames    white | PALE dark PALE | white    <- the core shows
+two dark frames      black | pale DARK pale | black    <- the rings show
 one of each          both, from opposite sides
                            |1.5px| 2px |1.5px|   within the 5px already there
 ```
+
+**Which tone is the ring is free; that there are two is not.** The polarity was
+the other way round once — pale strip, dark rings — and flipped with the
+redesign because a run of boxes edged in white is what makes the bar read as
+frames on a strip of film rather than as tiles in a chart. The invariant that
+survives is that no arrangement of neighbours leaves both tones without
+contrast.
 
 Roughly equal thirds. An earlier pass gave the pale core three of the five and
 it read as a white band with a hairline either side. Widening the gap is the
@@ -343,7 +378,21 @@ row with `justify-between`, because the transport has to be centred on the
 |---|---|
 | Left | `frames` — OFF / COVER / STRIP |
 | Centre | prev clip · play/pause · next clip |
-| Right | clock (`12.40s / 88.20s`) then `reach` — 5 / 10 / 20 / All |
+| Right | clock (`0:21.6 / 4:12.9`) · `fit` — clip / all · `reach` — 5 / 10 / 20 / All |
+
+**The clock is clock notation with tenths.** `252.90s` is accurate and
+unplaceable in a four-minute cut. Tenths rather than hundredths because the
+left half moves: the second decimal is a blur at playback speed and the first
+is exactly enough to see time passing. It floors the tenth rather than rounding
+it, so it never displays a time it has not reached.
+
+**`fit` names the two scales worth one press** — `clip` is the subject's own
+collection (the scale the bar opens at), `all` is everything the reach window
+covers. Both were already one `fitPixelsPerSecond` call; before this they were
+reachable only by rolling ⌘-wheel until they happened to arrive. Fitting
+re-centres as well as re-scales, which is the one place the bar deliberately
+overrides "stay where you were put". A wheel zoom clears the lit button,
+because at that point neither is true.
 
 Step buttons are **disabled, not hidden**, at the ends — a control that
 vanishes takes its position with it and shifts the bar sideways. Both settings

--- a/docs/details-modal-filmstrip-and-playbar-behaviour.md
+++ b/docs/details-modal-filmstrip-and-playbar-behaviour.md
@@ -103,8 +103,7 @@ cannot drift by a subpixel.
   because the centring is arithmetic over uniform neighbour widths, but they
   paint nothing. Without that they show as a sliver down each side, since
   `count` panels now fill the viewport exactly.
-- **View count is 3 or 5**, picked bottom-right. The picker dims to 20%
-  opacity while scrubbing.
+- **View count is 3 or 5**, picked bottom-right.
 - **Two widths, not one.** The clip being worked on is **1.75×** its
   neighbours, and every panel is fully visible:
 
@@ -156,8 +155,6 @@ All of it is live on every panel, not just the centre:
 | State | Trigger | Effect |
 |---|---|---|
 | `dimmed` | clock engaged, panel is not centre | opacity + grayscale, 300ms |
-| `scrubFocus` | mid-drag, panel is centre | everything except `[data-item-details-frame]` drops to opacity 15% |
-| `magnified` | mid-drag, panel is centre | `transform: scale()` aiming at **620px**, capped at **2.2×** |
 | `live` | the playhead is inside this clip | red ring |
 | `swapping` | arrived via a bar landing | 300ms fade-in |
 
@@ -237,19 +234,29 @@ row, and a `SeamMinimap`.
 
 | Input | Does |
 |---|---|
-| **Drag the boxes** | Scrub. Snaps to a cut when near one, with a one-shot pulse on the playhead head |
+| **Drag the boxes** | **Pan the film.** One-to-one with the hand, measured from where the press landed. Commits to nothing |
 | **Click a box** | Commit — make that clip the centre |
-| **Release a drag** | **Also commits**, landing on wherever the playhead finished |
 | **Wheel** | Pan. Dominant axis, so a trackpad swipe and a mouse notch both work |
 | **⌘/Ctrl + wheel** | Zoom about the pointer |
-| **Hold within 40px of an edge** | The strip runs under a stationary pointer, ramped by depth up to 16px/frame |
-| **Hover a box** | Preview: name, collection, `time / duration`, poster |
-| **Drag the minimap** | Pan the bar there. Never seeks — that is the bar's job |
+| **Hover a box** | Preview card: the frame at that moment, name, collection, `time / duration` |
+| **Drag the minimap** | Pan the bar there. Never seeks — the playhead is not the minimap's business |
 
 Click vs. drag is decided by **travel (4px)**, not timing — a slow deliberate
-scrub must not also count as a tap on wherever it started. The edge-run sets the
-`moved` flag itself, or an edge-scrub across half the project would end as a
-click on whatever clip happened to arrive under a still finger.
+pan must not also count as a tap on whatever it started over.
+
+**There is no pointer scrub.** Dragging used to move the playhead, which made
+the middle card a monitor for the duration — so reaching for the bar to look
+further along the sequence changed what you were working on and had to be
+undone afterwards. Dragging now pulls the strip along like a length of film on
+a bench: the playhead stays put, the panels below never change, and letting go
+commits to nothing.
+
+What went with it: snap-to-cut and its pulse, the edge-run that drove the strip
+under a stationary pointer, the magnified monitor, the low-res scrub proxy, the
+time chip on the playhead, and land-on-release.
+
+**The playhead now moves by** the keyboard (`←` `→` a second at a time, `Home`,
+`End`), playback, and a panel's own play button.
 
 The wheel listener is **native and non-passive**. React registers `onWheel`
 passively at the root, so `preventDefault` from a synthetic handler is ignored

--- a/packages/ui/dnd-collections/react/trim-overview.tsx
+++ b/packages/ui/dnd-collections/react/trim-overview.tsx
@@ -92,14 +92,35 @@ export const DefaultTrimOverviewContent = memo(function DefaultTrimOverviewConte
   );
 }, defaultOverviewPropsEqual);
 
+/**
+ * WHAT THE WINDOW LOOKS LIKE, and it is a look rather than a state.
+ *
+ * `focus` is a blue selection frame — the window is a thing you have selected
+ * out of the source, drawn in the colour the rest of the board uses for
+ * selection. Right wherever the strip sits among other selectable things.
+ *
+ * `film` is a white one. In a view that is already a row of frames with a
+ * filmstrip bar over it, a blue rectangle is the only object on screen that is
+ * not part of the film — and white is what the edge of a frame has always been.
+ * It says the same thing (this part, not that part) in the vocabulary the rest
+ * of that view is written in.
+ *
+ * A PROP RATHER THAN A REWRITE, because both consumers are live and only one
+ * of them is a filmstrip: the board's strip layout keeps the selection blue.
+ */
+export type TrimWindowTone = "focus" | "film";
+
 export const TrimOverviewStrip = memo(function TrimOverviewStrip({
   node,
   pixelsPerSecond,
   trimInSeconds,
   trimOutSeconds,
   width,
+  tone = "focus",
 }: {
   node: VideoMediaNode;
+  /** How the window frame is painted; see `TrimWindowTone`. */
+  tone?: TrimWindowTone;
   /** The timeline scale. Optional only because `width` replaces it: a fitted
    *  strip derives its own scale and never reads this. */
   pixelsPerSecond?: number;
@@ -206,18 +227,33 @@ export const TrimOverviewStrip = memo(function TrimOverviewStrip({
           at source scale, so one accent covers the whole trim widget. */}
       <div
         data-trim-overview-window
-        className="absolute inset-y-0 rounded-sm border-2 border-blue-500 bg-blue-500/10 shadow-[0_0_0_1px_rgba(0,0,0,0.5)]"
+        data-trim-overview-tone={tone}
+        className={
+          tone === "film"
+            ? // The frame line, and nothing tinted inside it: a wash over the
+              // kept part would be a colour cast on the only frames anyone is
+              // trying to judge. The dark outer shadow is what separates the
+              // white from a bright frame under it.
+              "absolute inset-y-0 rounded-sm border-2 border-zinc-100 shadow-[0_0_0_1px_rgba(0,0,0,0.65)]"
+            : "absolute inset-y-0 rounded-sm border-2 border-blue-500 bg-blue-500/10 shadow-[0_0_0_1px_rgba(0,0,0,0.5)]"
+        }
         style={{ width: windowWidth, transform: `translateX(${trimInWidth}px)` }}
       >
         <span
           data-trim-overview-handle="left"
           onPointerDown={startTrim("left")}
-          className="absolute inset-y-0 left-0 z-10 w-2 cursor-ew-resize rounded-l-sm bg-blue-400/90"
+          className={[
+            "absolute inset-y-0 left-0 z-10 w-2 cursor-ew-resize rounded-l-sm",
+            tone === "film" ? "bg-zinc-100" : "bg-blue-400/90",
+          ].join(" ")}
         />
         <span
           data-trim-overview-handle="right"
           onPointerDown={startTrim("right")}
-          className="absolute inset-y-0 right-0 z-10 w-2 cursor-ew-resize rounded-r-sm bg-blue-400/90"
+          className={[
+            "absolute inset-y-0 right-0 z-10 w-2 cursor-ew-resize rounded-r-sm",
+            tone === "film" ? "bg-zinc-100" : "bg-blue-400/90",
+          ].join(" ")}
         />
       </div>
     </div>


### PR DESCRIPTION
The details modal rebuilt to the mockup: a bigger subject panel, a header that says where you are before what you are looking at, a bar that reads as film and admits which clips playback skips, and an undo that reports itself.

## The structural change

**The subject is 1.75× its neighbours, and every panel is whole.** Panels were one width with the outer pair hanging half off each edge — which is what made "show three" mean one whole panel and two halves. The row's step is unchanged: the wide panel is symmetric about its own middle, so its extra width cancels out of the centring.

Two things that needed handling rather than accepting:

- The spare pair held ready beyond the window used to be off the edge *by accident*. With `count` panels filling the viewport exactly it now sits in the scrim's padding, so it is hidden while keeping its width.
- A panel's width animates on a **step** — that size change is the motion — and is **cut on a landing**, which must not move the middle card at all.

## The rest

| | |
|---|---|
| **Header** | One line, place before name |
| **Undo notice** | Read out of the history entry it stepped over; out points reported as the user set them, not as the model stores them |
| **Film strip** | Gap polarity flipped to near-black strip / pale rings; trim window white behind a `tone` prop so the board keeps its blue |
| **Skipped clips** | `disabled` finally reaches the bar — hatched, dotted rule above, full width |
| **Centre marker** | Red ring on the box edge, not a dot inside it |
| **`fit clip \| all`** | The two scales previously reachable only by wheel |
| **Clock** | `0:21.6 / 4:12.9` — `252.90s` is accurate and unplaceable |
| **Readout strip** | Play button and time off the picture, into a row that covers nothing |
| **Minimap** | Window eases to a new place unless a hand is driving it |

## Deliberately absent

**Metadata chips and frame numbers.** `MediaNode` carries neither generation params nor a frame rate, and inventing either was declined. The mockup's hint line (`, . step ±1 frame · I O set at playhead · L loop cut`) is omitted too — none of those shortcuts exist, and a hint for a shortcut that does nothing is worse than no hint.

## Verification

- **47 modal stories green**, six new (header order, undo notice, two-tier widths, fit, hatching, minimap easing)
- Seven existing assertions **rewritten rather than deleted** — each named a claim the redesign changes on purpose, and each now says which
- 7 unit tests for the notice describer, including the mockup's exact `out 5.042 → 5.167`
- `tsc` clean in `packages/ui` and the app · 1440 app tests · 802 unit · lint 0 errors
- Driven in a browser against real footage: white frame edge `rgba(244,244,245,0.9)`, near-black gaps, red-500 ring, centre/neighbour measured at **1.752**

The behaviour doc shipped in #513 is updated in the same PR, since the redesign makes parts of it wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)