### PR TITLE
The active clip's rule stops where the bar does

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -2949,3 +2949,72 @@ export const ASkippedClipIsHatchedOnTheBar: Story = {
     expect(widest.getAttribute("data-seam-segment")).toBe("skipped");
   },
 };
+
+/**
+ * A clip WIDER THAN THE TRACK THAT DRAWS IT.
+ *
+ * The active clip's rule is a sibling of the boxes, not a child, because the
+ * strip is `overflow-hidden` and a mark above the film base would be cut off
+ * by it. That escape is what the triangle needs and it is also what let the
+ * rule run past the ends of the bar: nothing was left to trim it.
+ *
+ * Every other seam fixture hides this. `LONG_SCENE`'s clips are 2-4s (~18-36px
+ * at the bar's fixed 9px a second) and `OVERFLOWING_SCENE`'s are 8s (~72px) —
+ * all far narrower than the track, so their rules sit comfortably inside it
+ * however the strip is panned. 240s is ~2160px against a track of a few
+ * hundred, so the subject cannot fit no matter where the strip stops, and the
+ * overhang is a property of the fixture rather than of the timing.
+ */
+const OVERSIZED_SUBJECT_SCENE: GraphNodeSpec = {
+  kind: "collection",
+  id: "root",
+  name: "Root",
+  children: [
+    { kind: "media" as const, id: "clip-before", name: "Before", src: plate("B", "hsl(20, 60%, 70%)"), durationSeconds: 6 },
+    { kind: "media" as const, id: "subject", name: "Subject", src: plate("S", "hsl(200, 60%, 70%)"), durationSeconds: 240 },
+    { kind: "media" as const, id: "clip-after", name: "After", src: plate("A", "hsl(120, 60%, 70%)"), durationSeconds: 6 },
+  ],
+};
+
+/**
+ * THE ACTIVE CLIP'S RULE STOPS WHERE THE BAR DOES.
+ *
+ * The rule says how long the marked clip runs, and it is the one mark on the
+ * bar whose width is a measurement. When the clip is longer than the track,
+ * that measurement has nowhere to go — and it used to simply keep drawing,
+ * out past the first box and off under the panels either side, which reads as
+ * a clip that starts somewhere off-screen rather than one that continues.
+ *
+ * Asserted as CONTAINMENT rather than against a number: the clamp is CSS
+ * (`max(0px, …)` and `min(100%, …)` against the lane's own box), so there is
+ * no measured width to compare to and the invariant holds through a resize
+ * and through every frame of a pan.
+ */
+export const TheActiveRuleIsClippedToTheBar: Story = {
+  render: () => <SeamHarness scene={OVERSIZED_SUBJECT_SCENE} />,
+  play: async () => {
+    await waitFor(() => expect(seamTrack()).not.toBeNull());
+    await waitFor(() => expect(seamBoxes().length).toBeGreaterThan(0));
+    await settleStrip();
+
+    const lane = seamSurface().getBoundingClientRect();
+    const rule = document.querySelector<HTMLElement>("[data-seam-active-span]");
+    expect(rule).not.toBeNull();
+
+    // THE FIXTURE ACTUALLY POSES THE PROBLEM. Without this the containment
+    // below would pass on a clip that fit all along, which is how every other
+    // seam story passes it today.
+    const marked = centreBox().getBoundingClientRect();
+    expect(marked.width).toBeGreaterThan(lane.width);
+
+    // BOTH ENDS. Half a pixel of slack for subpixel rounding, and no more —
+    // the bug this covers was 235px of overhang.
+    const drawn = rule!.getBoundingClientRect();
+    expect(drawn.left).toBeGreaterThanOrEqual(lane.left - 0.5);
+    expect(drawn.right).toBeLessThanOrEqual(lane.right + 0.5);
+
+    // AND IT IS STILL A RULE. Clamped to nothing would also satisfy the two
+    // bounds above, so the mark has to survive the clamping that trimmed it.
+    expect(drawn.width).toBeGreaterThan(0);
+  },
+};

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -640,6 +640,20 @@ export function SeamLane({
       {(() => {
         const segment = strip.segments.find((found) => found.clipId === centreClipId);
         if (segment === undefined || segment.widthPx <= 0) return null;
+        // WHERE THE SPAN WOULD REACH, before the lane gets a say.
+        //
+        // Living outside the clipping wrapper is what keeps the triangle from
+        // being cut off, and it is the same reason the rule under it ran past
+        // the ends of the bar: nothing was trimming it. So it trims itself.
+        //
+        // CLAMPED IN CSS rather than from a measured width. This span's
+        // containing block is the lane, so `100%` IS the visible playbar — the
+        // ends stay honest through a resize and through every frame of a pan
+        // without this component observing either, and there is no width held
+        // in state that could fall behind the truth.
+        const spanLeftPx = viewportX(segment.leftPx + BOX_INSET_PX);
+        const spanRightPx =
+          spanLeftPx + Math.max(2, segment.widthPx - BOX_INSET_PX * 2);
         return (
           <>
             {/* AND HOW LONG IT RUNS. The triangle says WHICH clip and nothing
@@ -657,8 +671,12 @@ export function SeamLane({
               data-seam-active-span={centreClipId}
               aria-hidden="true"
               style={{
-                left: viewportX(segment.leftPx + BOX_INSET_PX),
-                width: Math.max(2, segment.widthPx - BOX_INSET_PX * 2),
+                // BOTH ENDS HELD INSIDE THE LANE. `max(0px, …)` is the start,
+                // `min(100%, …)` the end, and the width is what survives
+                // between them — which collapses to zero rather than going
+                // negative once the clip is entirely past an edge.
+                left: `max(0px, ${spanLeftPx}px)`,
+                width: `max(0px, calc(min(100%, ${spanRightPx}px) - max(0px, ${spanLeftPx}px)))`,
                 top: -7,
                 height: 2,
                 // HALF STRENGTH. The triangle is the mark and this is its


### PR DESCRIPTION
The white rule under the active-clip triangle ran past the ends of the playbar. Reported from the details bar, where the marked clip starts off-screen left.

## Why it happened

The rule is a **sibling** of the boxes, not a child — the strip is `overflow-hidden`, so a mark drawn above the film base from inside it would be cut off. That escape is what the triangle needs, and it is also what left the rule with nothing to trim it.

The rule is the one mark on the bar whose **width is a measurement**, so a width running past the ends is the mark lying about the only thing it says. It reads as a clip that *starts* somewhere off-screen rather than one that continues.

## The fix

Clamped in CSS rather than from a measured width. The span's containing block is the lane, so `100%` there **is** the visible playbar:

```
left:  max(0px, L)
width: max(0px, calc(min(100%, R) - max(0px, L)))
```

The ends stay honest through a resize and through every frame of a pan without this component observing either, and there is no width held in state that could fall behind the truth. Width collapses to zero rather than going negative once the clip is entirely past an edge.

The triangle is deliberately **untouched** — it points at a PLACE, and where that place is off-screen is a different question from how far the rule reaches.

## Coverage, and proving it fails first

Every existing seam fixture hides this: `LONG_SCENE`'s clips are 2-4s and `OVERFLOWING_SCENE`'s are 8s — all far narrower than the track, so their rules sit inside it however the strip is panned. So the story adds a 240s subject, which cannot fit at any pan; the overhang is a property of the fixture rather than of the timing.

Reverting just the component and re-running the new story:

```
× The Active Rule Is Clipped To The Bar
  expected -302.640625 to be greater than or equal to 23.5
```

**326px of overhang.** With the fix, measured live in the story: lane `24 → 1196`, rule `24 → 1196`, `overhangLeft: 0`, `overhangRight: 0`.

## Checks

- `tsc --noEmit` — clean
- `eslint` on both changed files — 0 errors (1 pre-existing `<img>` warning at graph-seam-lane.tsx:778, untouched)
- `vitest --project=storybook graph-item-details-modal.stories.tsx` — **44/44 passed**, three consecutive runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)