### PR TITLE
The server renders the rail it was asked for

### DIFF
--- a/apps/timeline-gstudio001/app/layout.tsx
+++ b/apps/timeline-gstudio001/app/layout.tsx
@@ -6,7 +6,19 @@ import { SpeedInsights } from '@vercel/speed-insights/next';
 import { AuthGate } from '@/components/auth/auth-gate';
 import { AuthProvider } from '@/components/auth/auth-provider';
 import { getAuthUser } from '@/lib/firebase-auth-session';
+import { cookies } from 'next/headers';
 import { TimelineSidebar } from '@/components/timeline/timeline-sidebar';
+// From the framework-neutral module, NOT from `timeline-sidebar` — that one is
+// a client component, and the server calling into it fails at request time
+// while typechecking perfectly.
+import {
+  RAIL_WIDTH_VAR,
+  railExpandedFromCookies,
+} from '@/components/timeline/sidebar-rail-preference';
+import {
+  RAIL_OPEN_WIDTH_PX,
+  RAIL_WIDTH_PX,
+} from '@/components/timeline/sidebar-icon-styles';
 import { Toaster } from '@/components/core/sonner';
 import './globals.css'; // Global styles
 
@@ -49,11 +61,31 @@ export const metadata: Metadata = {
 // blocking the whole tree on a client fetch for it — see `initialUser`.
 export default async function RootLayout({children}: {children: React.ReactNode}) {
   const user = await getAuthUser();
+  // THE RAIL'S WIDTH, BEFORE ANYTHING PAINTS.
+  //
+  // The preference used to live only in `localStorage`, which the server
+  // cannot read — so the rail rendered collapsed on every load and widened on
+  // hydration, shoving `main` 188px sideways. That one shift was 0.135 of a
+  // 0.16 CLS (#471). A cookie is the only copy of the preference that travels
+  // with the REQUEST, which is what makes a correct first paint possible at
+  // all; this layout was already dynamic for the session, so reading it costs
+  // nothing extra.
+  const railExpanded = railExpandedFromCookies((await cookies()).toString());
   // `dark` is what switches on every `dark:` utility — the variant is rebound
   // to this class in globals.css, precisely so the app stops following the
   // reader's OS theme.
   return (
-    <html lang="en" className={`dark ${grandstander.variable}`}>
+    <html
+      lang="en"
+      className={`dark ${grandstander.variable}`}
+      // PUBLISHED HERE so the surfaces BESIDE the rail are offset correctly in
+      // the server's own markup. The sidebar keeps writing this on every
+      // toggle — the server will not hear about one until the next request —
+      // but it can no longer be the FIRST writer, because an effect runs after
+      // paint and anything reading the variable would have spent that paint at
+      // the wrong offset.
+      style={{ [RAIL_WIDTH_VAR]: `${railExpanded ? RAIL_OPEN_WIDTH_PX : RAIL_WIDTH_PX}px` } as React.CSSProperties}
+    >
       <body suppressHydrationWarning>
         {/* App-wide: the sidebar renders on every route, so anything it
             toasts needs a surface here rather than inside one view. */}
@@ -62,7 +94,7 @@ export default async function RootLayout({children}: {children: React.ReactNode}
           <AuthGate>
             <div className="relative flex min-h-screen overflow-x-clip bg-zinc-950 font-sans text-white">
               <Suspense fallback={null}>
-                <TimelineSidebar />
+                <TimelineSidebar initialRailExpanded={railExpanded} />
               </Suspense>
               {/* Scroll anchoring is disabled page-wide (see globals.css):
                   the preview pane mounting at main's top must not scroll

--- a/apps/timeline-gstudio001/components/timeline/sidebar-rail-preference.test.ts
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-rail-preference.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  RAIL_EXPANDED_COOKIE,
+  railExpandedFromCookies,
+} from "./sidebar-rail-preference";
+
+// THE PARSE THE SERVER DOES, covered where it actually lives.
+//
+// This runs on both sides of the app from one implementation — the root layout
+// hands it a request header, the rail hands it `document.cookie` — and it is
+// the only thing standing between the stored preference and the width the
+// first paint uses. Get it wrong and the rail renders collapsed for someone
+// who left it open, which is #471 all over again.
+//
+// A UNIT test rather than a story, because `useSyncExternalStore` consults its
+// server snapshot only while hydrating and a story renders client-only: the
+// branch this feeds cannot be exercised there at all.
+describe("railExpandedFromCookies", () => {
+  it("reads the preference out of a header carrying nothing else", () => {
+    expect(railExpandedFromCookies(`${RAIL_EXPANDED_COOKIE}=true`)).toBe(true);
+    expect(railExpandedFromCookies(`${RAIL_EXPANDED_COOKIE}=false`)).toBe(false);
+  });
+
+  it("finds it among the other cookies, in any position", () => {
+    const first = `${RAIL_EXPANDED_COOKIE}=true; session=abc; theme=dark`;
+    const middle = `session=abc; ${RAIL_EXPANDED_COOKIE}=true; theme=dark`;
+    const last = `session=abc; theme=dark; ${RAIL_EXPANDED_COOKIE}=true`;
+    for (const header of [first, middle, last]) {
+      expect(railExpandedFromCookies(header)).toBe(true);
+    }
+  });
+
+  // ABSENT IS COLLAPSED. No cookie means nobody has ever toggled the rail,
+  // which is the narrow default — and it has to be reached without throwing,
+  // because it is the state every first-time visitor arrives in.
+  it("treats an absent or empty header as collapsed", () => {
+    expect(railExpandedFromCookies(undefined)).toBe(false);
+    expect(railExpandedFromCookies("")).toBe(false);
+    expect(railExpandedFromCookies("session=abc; theme=dark")).toBe(false);
+  });
+
+  // ONLY THE EXACT NAME. A prefix match would let an unrelated cookie decide
+  // the layout, and the failure would be a rail that opens on its own for the
+  // one person whose session happens to carry the wrong key.
+  it("does not match a cookie whose name merely contains it", () => {
+    expect(railExpandedFromCookies(`not_${RAIL_EXPANDED_COOKIE}=true`)).toBe(false);
+    expect(railExpandedFromCookies(`${RAIL_EXPANDED_COOKIE}_other=true`)).toBe(false);
+  });
+
+  // Only the literal `true` opens it. Anything else is a value this app did not
+  // write, and guessing what it meant is how a display preference turns into a
+  // layout that nobody chose.
+  it("opens on the literal true and on nothing else", () => {
+    for (const value of ["1", "yes", "TRUE", "", "truthy"]) {
+      expect(railExpandedFromCookies(`${RAIL_EXPANDED_COOKIE}=${value}`)).toBe(false);
+    }
+  });
+
+  // Cookies are written `name=value` with optional spaces after the
+  // semicolons; `document.cookie` and a request header differ on that, and one
+  // parser serves both.
+  it("tolerates the spacing of both sources", () => {
+    expect(railExpandedFromCookies(`a=1;${RAIL_EXPANDED_COOKIE}=true;b=2`)).toBe(true);
+    expect(railExpandedFromCookies(`a=1;   ${RAIL_EXPANDED_COOKIE}=true;   b=2`)).toBe(true);
+  });
+});

--- a/apps/timeline-gstudio001/components/timeline/sidebar-rail-preference.ts
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-rail-preference.ts
@@ -1,0 +1,65 @@
+// The rail's width preference, as the two sides of the app share it.
+//
+// NO `"use client"`, and that is the whole reason this file exists. These
+// constants and the parser lived in `timeline-sidebar.tsx`, which is a client
+// module — so the root layout importing `railExpandedFromCookies` from there
+// typechecked cleanly and then failed at request time with "Attempted to call
+// railExpandedFromCookies() from the server but it is on the client". Next
+// replaces a client module with a reference proxy for the server graph, so
+// every export of one is unusable server-side, not just its components.
+//
+// A neutral module is the seam: the server reads the cookie through it, the
+// rail writes the cookie through it, and there is exactly one spelling of the
+// cookie's name for them to agree on.
+
+/**
+ * The rail preference as a COOKIE, because the server has to know it.
+ *
+ * localStorage is invisible to the server, so every load rendered the rail
+ * collapsed and expanded it on hydration — a 188px shove of everything beside
+ * it, and 0.135 of a 0.16 CLS on its own (#471). No amount of client-side
+ * cleverness fixes that: the first paint has to be right, and only something
+ * that travels with the REQUEST can make it right.
+ *
+ * READ AS THE SOURCE OF TRUTH on both sides, rather than mirrored alongside
+ * localStorage. Two stores that can disagree are a hydration mismatch waiting
+ * for the first person whose copies drift — cleared site data, an old tab, a
+ * private window. One store cannot disagree with itself. localStorage is still
+ * WRITTEN, and still read as a fallback, purely so a rail already open before
+ * this change stays open on the load that introduces it.
+ *
+ * SEMANTICS ARE UNCHANGED. A cookie is per-browser and so is localStorage, and
+ * this is read at LOAD, never live — so two windows still keep their own
+ * widths. What a cookie adds is only that the server can see it.
+ *
+ * `SameSite=Lax` and a year: a display preference, sent on top-level
+ * navigations, which is exactly when the server needs it.
+ */
+export const RAIL_EXPANDED_COOKIE = "sw_rail_expanded";
+export const RAIL_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+/**
+ * Published to the document so surfaces BESIDE the rail can be offset by it.
+ *
+ * The trash drawer hardcoded `ml-[72px]`, which is correct exactly while the
+ * rail cannot change width — so opening the rail would have slid it
+ * underneath. A variable is the seam: one writer, and any number of readers
+ * that keep working when this number moves again.
+ */
+export const RAIL_WIDTH_VAR = "--sw-rail-width";
+
+/**
+ * Parse the rail cookie out of a `document.cookie` or request header string.
+ *
+ * One parser for both, because they are the same format and a second one is a
+ * second thing to get wrong. Absent means collapsed: no cookie is nobody
+ * having toggled it.
+ */
+export function railExpandedFromCookies(header: string | undefined): boolean {
+  if (!header) return false;
+  for (const part of header.split(";")) {
+    const [name, ...rest] = part.trim().split("=");
+    if (name === RAIL_EXPANDED_COOKIE) return rest.join("=") === "true";
+  }
+  return false;
+}

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.stories.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.stories.tsx
@@ -28,6 +28,23 @@ import { RAIL_OPEN_WIDTH_PX, RAIL_WIDTH_PX } from "./sidebar-icon-styles";
 
 const STORAGE_KEY = "sw:sidebar-expanded";
 
+/**
+ * FORGET THE RAIL COMPLETELY, both stores.
+ *
+ * The preference is a COOKIE now, because the server has to render the right
+ * width on the first paint (#471) — and a cookie outlives the story that set
+ * it, where `localStorage.removeItem` alone does not. Clearing only the old
+ * store left a toggled-open rail behind for whatever ran next, which failed as
+ * `expected 260 to be 72` in a story that had done nothing wrong.
+ *
+ * `max-age=0` on the same path it was written with: a cookie is only cleared
+ * by a cookie, and only if the path matches.
+ */
+function forgetRailPreference(): void {
+  document.cookie = "sw_rail_expanded=; path=/; max-age=0";
+  window.localStorage.removeItem(STORAGE_KEY);
+}
+
 const USER = {
   uid: "u-story",
   email: "editor@example.test",
@@ -98,7 +115,7 @@ const settledWidth = async (element: HTMLElement, expected: number) => {
 export const Collapsed: Story = {
   render: () => {
     stubFetch();
-    window.localStorage.removeItem(STORAGE_KEY);
+    forgetRailPreference();
     return <Harness />;
   },
   play: async ({ canvasElement }) => {
@@ -113,11 +130,64 @@ export const Collapsed: Story = {
   },
 };
 
-/** OPENED, so the names sit beside the glyphs. */
+/**
+ * OPENED, so the names sit beside the glyphs — FROM `localStorage` ALONE.
+ *
+ * Which is now the MIGRATION path rather than the ordinary one. The cookie is
+ * the source of truth (#471), and this sets only the old store, so it stands
+ * for the rail of someone who last toggled it before the cookie existed: their
+ * preference has to survive the upgrade rather than silently reset to
+ * collapsed. Cleared first, so the assertion cannot be met by a cookie some
+ * earlier story left behind.
+ */
 export const Expanded: Story = {
   render: () => {
     stubFetch();
+    forgetRailPreference();
     window.localStorage.setItem(STORAGE_KEY, "true");
+    return <Harness />;
+  },
+  play: async ({ canvasElement }) => {
+    const aside = rail(canvasElement);
+    expect(aside).toHaveAttribute("data-sidebar-expanded", "true");
+    await settledWidth(aside, RAIL_OPEN_WIDTH_PX);
+    // AND THE UPGRADE IS WRITTEN DOWN. The rail backfills the cookie on mount,
+    // so this is the LAST load that renders from `localStorage` — without it
+    // the server would go on guessing collapsed forever for anyone who never
+    // touches the toggle again, and the shift this all exists to remove would
+    // survive for exactly the people who had already chosen the open rail.
+    await waitFor(() => {
+      expect(document.cookie).toContain("sw_rail_expanded=true");
+    });
+  },
+};
+
+/**
+ * THE COOKIE WINS, and it is what the first client render reads.
+ *
+ * The preference moved to a cookie so the SERVER could render the right width
+ * on the first paint (#471) — the rail used to read `localStorage`, which the
+ * server cannot see, so every load painted it collapsed and widened it on
+ * hydration: 188px of `main` moving sideways, and 0.135 of a 0.16 CLS from
+ * that one shift.
+ *
+ * The two stores are set to DISAGREE here. A rail still reading the old one
+ * would come up collapsed, which is exactly the state that used to cause the
+ * shift, so this fails if the precedence is ever put back.
+ *
+ * NOT AN ASSERTION ABOUT `initialRailExpanded`, deliberately.
+ * `useSyncExternalStore` only consults its server snapshot while hydrating,
+ * and a story renders client-only — so a story asserting the prop would be
+ * asserting a branch that never runs here. The parse the server actually does
+ * is covered in `sidebar-rail-preference.test.ts`, and the rendered markup was
+ * measured against the running app.
+ */
+export const TheCookieDecidesTheWidth: Story = {
+  render: () => {
+    stubFetch();
+    forgetRailPreference();
+    window.localStorage.setItem(STORAGE_KEY, "false");
+    document.cookie = "sw_rail_expanded=true; path=/; max-age=31536000; samesite=lax";
     return <Harness />;
   },
   play: async ({ canvasElement }) => {
@@ -141,7 +211,7 @@ export const Expanded: Story = {
 export const TheToggleOpensAndCloses: Story = {
   render: () => {
     stubFetch();
-    window.localStorage.removeItem(STORAGE_KEY);
+    forgetRailPreference();
     return <Harness />;
   },
   play: async ({ canvasElement }) => {
@@ -188,7 +258,7 @@ export const TheToggleOpensAndCloses: Story = {
 export const RepeatedTogglingStaysInStep: Story = {
   render: () => {
     stubFetch();
-    window.localStorage.removeItem(STORAGE_KEY);
+    forgetRailPreference();
     return <Harness />;
   },
   play: async ({ canvasElement }) => {

--- a/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
+++ b/apps/timeline-gstudio001/components/timeline/timeline-sidebar.tsx
@@ -53,6 +53,12 @@ import { withViewTransition } from "@/lib/view-transition";
 
 import { SidebarCollectionShortcuts } from "./sidebar-collection-shortcuts";
 import {
+  RAIL_COOKIE_MAX_AGE_SECONDS,
+  RAIL_EXPANDED_COOKIE,
+  RAIL_WIDTH_VAR,
+  railExpandedFromCookies,
+} from "./sidebar-rail-preference";
+import {
   SidebarLabelsInlineContext,
   SidebarTooltipLabel,
 } from "./sidebar-tooltip-label";
@@ -61,52 +67,10 @@ import {
  *  be a preference in name only. */
 const RAIL_EXPANDED_STORAGE_KEY = "sw:sidebar-expanded";
 
-/**
- * The same preference, as a COOKIE, because the server has to know it.
- *
- * localStorage is invisible to the server, so every load rendered the rail
- * collapsed and expanded it on hydration — a 187px shove of everything beside
- * it, and 0.135 of a 0.16 CLS on its own (#471). No amount of client-side
- * cleverness fixes that: the first paint has to be right, and only something
- * that travels with the REQUEST can make it right.
- *
- * READ AS THE SOURCE OF TRUTH on both sides, rather than mirrored alongside
- * localStorage. Two stores that can disagree are a hydration mismatch waiting
- * for the first person whose copies drift — cleared site data, an old tab, a
- * private window. One store cannot disagree with itself. localStorage is still
- * WRITTEN, and still read as a fallback, purely so a rail already open before
- * this change stays open on the load that introduces it.
- *
- * SEMANTICS ARE UNCHANGED. A cookie is per-browser and so is localStorage, and
- * this is read at LOAD, never live — so the note below about two windows
- * keeping their own widths still holds. What a cookie adds is only that the
- * server can see it.
- *
- * `SameSite=Lax` and a year: a display preference, sent on top-level
- * navigations, which is exactly when the server needs it.
- */
-const RAIL_EXPANDED_COOKIE = "sw_rail_expanded";
-const RAIL_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
-
-/** Parse the rail cookie out of a `document.cookie` / request header string. */
-export function railExpandedFromCookies(header: string | undefined): boolean {
-  if (!header) return false;
-  for (const part of header.split(";")) {
-    const [name, ...rest] = part.trim().split("=");
-    if (name === RAIL_EXPANDED_COOKIE) return rest.join("=") === "true";
-  }
-  return false;
-}
-
-/**
- * Published to the document so surfaces BESIDE the rail can be offset by it.
- *
- * The trash drawer hardcoded `ml-[72px]`, which is correct exactly while the
- * rail cannot change width — so opening the rail would have slid it
- * underneath. A variable is the seam: one writer here, and any number of
- * readers that keep working when this number moves again.
- */
-const RAIL_WIDTH_VAR = "--sw-rail-width";
+// The cookie, the CSS variable and the parser live in `sidebar-rail-preference`
+// — a module with no `"use client"`, so the root layout can read the same
+// preference this file writes. See the note at the top of that file for why
+// importing them from here instead fails only at request time.
 
 /** Fires when THIS window toggles the rail — the only notification there is,
  *  see below. Without it the toggle would not re-render the window that
@@ -767,7 +731,19 @@ const UTILITY_ITEMS: UtilityItem[] = [
   },
 ];
 
-export function TimelineSidebar() {
+export function TimelineSidebar({
+  initialRailExpanded = false,
+}: Readonly<{
+  /**
+   * What the SERVER rendered the rail as, read from the cookie in the root
+   * layout.
+   *
+   * Defaulted rather than required so a story or a test can mount the rail
+   * without one, and `false` is the honest default: no cookie means nobody has
+   * ever toggled it, which is the collapsed rail.
+   */
+  initialRailExpanded?: boolean;
+}> = {}) {
   const pathname = usePathname();
   const { user, logout } = useAuth();
   const [isTrashOpen, setIsTrashOpen] = useState(false);
@@ -868,21 +844,38 @@ export function TimelineSidebar() {
   // `useState(false)` corrected by a mount effect — is a synchronous setState
   // inside an effect, which lints as a cascading render and is a real one: the
   // rail paints collapsed and then jumps. `useSyncExternalStore` reads the
-  // stored value during the first client render instead, and its SERVER
-  // snapshot is the collapsed default, which is what keeps SSR and hydration
-  // agreeing about a value the server cannot see.
+  // stored value during the first client render instead.
   //
-  // Subscribing to `storage` is what an effect could not have done at all: two
-  // tabs open on this app now agree about the rail.
+  // ITS SERVER SNAPSHOT IS WHAT THE SERVER ACTUALLY RENDERED, not a hard-coded
+  // `false`. That constant was the whole of #471: the preference lived only in
+  // `localStorage`, so every load painted the rail collapsed and widened it on
+  // hydration — an 188px shove of everything beside it, and 0.135 of a 0.16
+  // CLS on its own. The cookie is what made a first paint possible; passing it
+  // in here is what makes the first paint AGREE with it.
   const railExpanded = useSyncExternalStore(
     subscribeRailExpanded,
     readRailExpanded,
-    () => false,
+    () => initialRailExpanded,
   );
+  useEffect(() => {
+    // MIGRATION, ONE LOAD ONLY. A rail left open before the cookie existed has
+    // the preference in `localStorage` where the server cannot see it, so that
+    // one load still renders collapsed and still shifts. Writing the cookie
+    // now is what makes it the last load that does — without this the shift
+    // survives forever for anyone who never touches the toggle again.
+    if (railExpanded && !document.cookie.includes(RAIL_EXPANDED_COOKIE)) {
+      writeRailCookie(true);
+    }
+  }, [railExpanded]);
   useEffect(() => {
     // The offset every surface beside the rail reads. Written on the document
     // rather than the aside because those surfaces are its SIBLINGS, not its
     // descendants — a variable set here would not inherit to them.
+    //
+    // The LAYOUT sets this too, from the same cookie, so it is already correct
+    // in the server's markup and nothing beside the rail moves on hydration.
+    // This effect is what keeps it correct AFTER a toggle, which the server
+    // will not hear about until the next request.
     document.documentElement.style.setProperty(
       RAIL_WIDTH_VAR,
       `${railExpanded ? RAIL_OPEN_WIDTH_PX : RAIL_WIDTH_PX}px`,


### PR DESCRIPTION
Closes #471.

## What was actually wrong

The cookie half of this **already landed** — the cookie name, the parser, the write on toggle, and a doc comment describing the fix as done. The server half did not. `useSyncExternalStore`'s third argument was still a hard-coded `() => false`, and nothing outside the client module ever read the cookie. The preference travelled with the request and was then ignored, while the comment above the snapshot still explained why the server "cannot see" a value it was by then being sent.

## Measured, against the running app

Authenticated, Toon Town, with `sw_rail_expanded=true` genuinely sent:

| | before | after |
|---|---|---|
| `data-sidebar-expanded` | `false` | **`true`** |
| aside width class | `w-[72px]` | **`w-[260px]`** |
| `--sw-rail-width` on `<html>` | **absent** | **`260px`** |

The rail then widened to 260px on hydration — **188px of `main` moving sideways**, which is the 0.135 of a 0.16 CLS #471 attributes to it, on every load for anyone whose rail is open.

After: server and client both report `260px`, and the variable is `260px` in the markup *and* on the live document — nothing left to reconcile. `cookie=false` and no-cookie both still render `72px`.

> Measured structurally (server HTML) rather than from a `layout-shift` trace, because the shift is structural — the issue says so — and it is deterministic and reproducible this way.

## The trap this hit

`railExpandedFromCookies` was exported from `timeline-sidebar.tsx`, which carries `"use client"`. The layout importing it **typechecked perfectly** and failed at request time:

```
Attempted to call railExpandedFromCookies() from the server but
railExpandedFromCookies is on the client.
```

Next replaces a client module with a reference proxy for the server graph, so *every* export of one is unusable server-side, not just its components. `sidebar-rail-preference.ts` is the neutral seam both sides import.

## Migration is written down, not just read

A rail left open before the cookie existed has its preference in `localStorage`, so that load still renders collapsed and still shifts. The rail now backfills the cookie on mount, making it the **last** such load. Without it the shift survived forever for precisely the people who had already chosen the open rail and had no reason to touch the toggle again.

## Coverage

The stories cleared `localStorage` but not the cookie, so a toggled-open rail outlived the story that opened it and the next one failed as `expected 260 to be 72`. They forget both stores now. `Expanded` keeps setting only `localStorage`, which makes it the migration case, and asserts the backfill.

**No story asserts the prop itself, deliberately** — `useSyncExternalStore` consults its server snapshot only while hydrating and a story renders client-only, so such a story would cover a branch that never runs there (I wrote one first; it failed for exactly that reason). What *does* run on the client — the cookie beating a disagreeing `localStorage` — is a story, and the parse the server does is a unit test.

## Checks

- `tsc --noEmit` — clean
- `eslint` on all five files — 0 errors (2 pre-existing `<img>` warnings, untouched)
- app `vitest` — **1446/1446 passed** (112 files), including 6 new parser tests
- `vitest --project=storybook timeline-sidebar.stories.tsx` — **5/5 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)