### PR TITLE
The transport drops clear of the bars, and both marks stop at the film's end

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -1271,9 +1271,20 @@ export const NarrowPanelsShedTheirControlsAndStayAligned: Story = {
         .filter((panel) => panel.dataset.itemDetailsPanel !== "centre")
         .some((panel) => (panel.querySelector(selector)?.getBoundingClientRect().height ?? 0) > 0);
     await press("5");
-    await waitFor(() => expect(neighbourShows("[data-trim-overview]")).toBe(false));
-    expect(visible("[data-tag-editor]")).toBe(false);
-    expect(visible("[data-item-details-undo]")).toBe(false);
+    // ALL THREE IN ONE WAIT, because they all describe the SAME settled state.
+    //
+    // Only the first used to wait and the other two read whatever frame they
+    // landed on. Pressing "5" re-renders three panels and their controls drop
+    // out as the width crosses each threshold — the trim strip goes first, so
+    // waiting on it alone can return while a tag editor or an undo button is
+    // still mounted. It passed almost always and failed under load, which is
+    // the shape that costs an afternoon: the run that fails is never the run
+    // that changed anything.
+    await waitFor(() => {
+      expect(neighbourShows("[data-trim-overview]")).toBe(false);
+      expect(visible("[data-tag-editor]")).toBe(false);
+      expect(visible("[data-item-details-undo]")).toBe(false);
+    });
     // Still aligned, and still identically bordered — among peers, as above.
     const middleAt = panels().findIndex(
       (panel) => panel.dataset.itemDetailsPanel === "centre",
@@ -2965,14 +2976,31 @@ export const ASkippedClipIsHatchedOnTheBar: Story = {
  * hundred, so the subject cannot fit no matter where the strip stops, and the
  * overhang is a property of the fixture rather than of the timing.
  */
-const OVERSIZED_SUBJECT_SCENE: GraphNodeSpec = {
+/**
+ * A subject too wide for the track, whose MIDDLE is off the end of it too.
+ *
+ * One scene for both marks, because they fail under different conditions and
+ * only this shape poses both at once.
+ *
+ * THE RULE runs the clip's whole width, so any clip longer than the track
+ * over-runs it. THE TRIANGLE sits at the clip's middle, and a centred clip's
+ * middle is the track's middle however long the clip is — so it only leaves
+ * the bar when the strip is HELD AT AN EDGE and cannot centre. Hence the
+ * subject FIRST: the strip stops at the start of the film, and the mark is
+ * drawn wherever the clip's middle lands.
+ *
+ * 400s is ~3600px against a track of about 1280, so the rule over-runs by a
+ * couple of screens and the triangle wants to be some 1800px in — a screen's
+ * width past the end of the film.
+ */
+const SUBJECT_AT_THE_EDGE_SCENE: GraphNodeSpec = {
   kind: "collection",
   id: "root",
   name: "Root",
   children: [
-    { kind: "media" as const, id: "clip-before", name: "Before", src: plate("B", "hsl(20, 60%, 70%)"), durationSeconds: 6 },
-    { kind: "media" as const, id: "subject", name: "Subject", src: plate("S", "hsl(200, 60%, 70%)"), durationSeconds: 240 },
-    { kind: "media" as const, id: "clip-after", name: "After", src: plate("A", "hsl(120, 60%, 70%)"), durationSeconds: 6 },
+    { kind: "media" as const, id: "subject", name: "Subject", src: plate("S", "hsl(200, 60%, 70%)"), durationSeconds: 400 },
+    { kind: "media" as const, id: "clip-b", name: "B", src: plate("B", "hsl(20, 60%, 70%)"), durationSeconds: 6 },
+    { kind: "media" as const, id: "clip-c", name: "C", src: plate("C", "hsl(120, 60%, 70%)"), durationSeconds: 6 },
   ],
 };
 
@@ -2991,7 +3019,7 @@ const OVERSIZED_SUBJECT_SCENE: GraphNodeSpec = {
  * and through every frame of a pan.
  */
 export const TheActiveRuleIsClippedToTheBar: Story = {
-  render: () => <SeamHarness scene={OVERSIZED_SUBJECT_SCENE} />,
+  render: () => <SeamHarness scene={SUBJECT_AT_THE_EDGE_SCENE} />,
   play: async () => {
     await waitFor(() => expect(seamTrack()).not.toBeNull());
     await waitFor(() => expect(seamBoxes().length).toBeGreaterThan(0));
@@ -2999,7 +3027,9 @@ export const TheActiveRuleIsClippedToTheBar: Story = {
 
     const lane = seamSurface().getBoundingClientRect();
     const rule = document.querySelector<HTMLElement>("[data-seam-active-span]");
+    const mark = document.querySelector<HTMLElement>("[data-seam-active-mark]");
     expect(rule).not.toBeNull();
+    expect(mark).not.toBeNull();
 
     // THE FIXTURE ACTUALLY POSES THE PROBLEM. Without this the containment
     // below would pass on a clip that fit all along, which is how every other
@@ -3007,14 +3037,39 @@ export const TheActiveRuleIsClippedToTheBar: Story = {
     const marked = centreBox().getBoundingClientRect();
     expect(marked.width).toBeGreaterThan(lane.width);
 
-    // BOTH ENDS. Half a pixel of slack for subpixel rounding, and no more —
-    // the bug this covers was 235px of overhang.
-    const drawn = rule!.getBoundingClientRect();
-    expect(drawn.left).toBeGreaterThanOrEqual(lane.left - 0.5);
-    expect(drawn.right).toBeLessThanOrEqual(lane.right + 0.5);
+    // WHAT THIS STORY CANNOT POSE, said plainly: the TRIANGLE leaving the bar.
+    // It sits at the clip's middle, and the bar CENTRES the active clip — so
+    // that middle is the track's middle however long the clip is (measured
+    // here: 600 in a track ending at 1176). The triangle only leaves the bar
+    // once the bar has been PANNED away from the active clip, which the bar
+    // deliberately allows: "a change of subject brings the new clip into view
+    // if it is off the side, and otherwise leaves the bar exactly where you
+    // put it".
+    //
+    // So the containment below is an INVARIANT here rather than a regression
+    // test for the triangle — it holds either way in this fixture. The
+    // triangle's clamp was verified by driving its `left` past both ends and
+    // measuring: at 5000px it lands flush with the track's right edge, at
+    // -3000px flush with the left. Reproducing it as a story needs a simulated
+    // pan, which belongs with the e2e that already drives real drags.
 
-    // AND IT IS STILL A RULE. Clamped to nothing would also satisfy the two
-    // bounds above, so the mark has to survive the clamping that trimmed it.
-    expect(drawn.width).toBeGreaterThan(0);
+    // BOTH ENDS, BOTH MARKS. Half a pixel of slack for subpixel rounding and
+    // no more — the bug this covers was 326px of overhang on the rule, and the
+    // triangle was left hanging off the end in the same way afterwards.
+    for (const drawn of [rule!.getBoundingClientRect(), mark!.getBoundingClientRect()]) {
+      expect(drawn.left).toBeGreaterThanOrEqual(lane.left - 0.5);
+      expect(drawn.right).toBeLessThanOrEqual(lane.right + 0.5);
+      // AND THEY ARE STILL MARKS. Clamped to nothing would satisfy the two
+      // bounds above, so each has to survive the clamping that trimmed it.
+      expect(drawn.width).toBeGreaterThan(0);
+    }
+
+    // THE TRIANGLE STAYS ON ITS RULE. They are one mark — a pointer with a
+    // span — so a triangle clamped to the track while the rule stopped
+    // somewhere else would read as two unrelated things at the same height.
+    const ruleBox = rule!.getBoundingClientRect();
+    const markBox = mark!.getBoundingClientRect();
+    expect(markBox.left).toBeGreaterThanOrEqual(ruleBox.left - 0.5);
+    expect(markBox.right).toBeLessThanOrEqual(ruleBox.right + 0.5);
   },
 };

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -858,6 +858,21 @@ function DetailsFilmstripModal({
       // down and 13rem reserved only 208. Anything added to that block has to
       // be measured and this raised, or the row below rides up into it on a
       // short viewport.
+      //
+      // 14rem → 16.5rem when the transport took a 20px top margin, dropping it
+      // clear of the two bars above. This is exactly the failure the note above
+      // predicts, and it was caught the way it was meant to be:
+      // `TheTwoBarsAreAdjacent` measures the gap between this row and the
+      // centre card, and it fell from 22px to 2 — the "quiet eight pixels"
+      // arriving as a red test rather than as a screenshot nobody looked at
+      // twice.
+      //
+      // AND THE COMPENSATION IS TWICE THE GROWTH, which is the part worth
+      // writing down. This box is `items-center`, so padding added at the top
+      // is shared with the bottom when the row is re-centred in what is left —
+      // 20px of padding buys only 10px of downward movement. The first attempt
+      // added 20 and recovered half the slack (2 → 12, still short of the 16
+      // floor). 40px is what 20px of bar costs here: 224 + 40 = 264 = 16.5rem.
       // `overflow-clip`, NOT `overflow-hidden`. Both crop, but `hidden` makes
       // this a SCROLL CONTAINER — and the row is thirteen thousand pixels
       // wide, so there is a great deal for it to scroll. Landing on a new clip
@@ -867,7 +882,7 @@ function DetailsFilmstripModal({
       // row that had itself moved 1728px, which put the card just chosen
       // entirely off the left edge. `clip` crops without ever being
       // scrollable, so the transform stays the only thing that moves the row.
-      className="fixed inset-0 z-[80] flex items-center justify-center overflow-clip bg-black/80 px-6 pt-[14rem] pb-6 backdrop-blur-sm"
+      className="fixed inset-0 z-[80] flex items-center justify-center overflow-clip bg-black/80 px-6 pt-[16.5rem] pb-6 backdrop-blur-sm"
       // THE SCRIM DOES NOT DISMISS. Deliberate: this view is worked in, not
       // glanced at — trimming, scrubbing and swiping all end with the pointer
       // somewhere unpredictable, and the panels are cropped by the scrim

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -200,6 +200,16 @@ function SegmentFrames({
 const BOX_INSET_PX = 2.5;
 
 /**
+ * Half the active-clip triangle's width.
+ *
+ * It is drawn as two transparent side borders under a solid top one, so the
+ * glyph's width is twice this and its tip sits at its centre. Named because
+ * three places have to agree on it — both borders and the clamp that keeps the
+ * mark inside the bar — and they were three separate `5`s.
+ */
+const MARK_HALF_PX = 5;
+
+/**
  * WHAT SEPARATES TWO BOXES ONCE THEY HOLD PICTURES.
  *
  * The gap between boxes is `BOX_INSET_PX` either side — five pixels of the
@@ -692,9 +702,27 @@ export function SeamLane({
               data-seam-active-mark={centreClipId}
               aria-hidden="true"
               style={{
-                left: viewportX(segment.leftPx + segment.widthPx / 2),
-                borderLeft: "5px solid transparent",
-                borderRight: "5px solid transparent",
+                // HELD INSIDE THE BAR, like the rule under it.
+                //
+                // The rule was clamped first and the triangle deliberately was
+                // not: it points at a PLACE, and an off-screen place seemed a
+                // different question from an over-long measurement. It is not.
+                // A mark drawn past the end of the bar is not reporting a
+                // position at all — there is no track under it to be a position
+                // ON, so it reads as a stray glyph sitting on the panel beside
+                // the bar.
+                //
+                // CENTRED ON `left` because of the `-translate-x-1/2` below, so
+                // the inset is the triangle's HALF-width: 5px either side of
+                // centre is exactly what the two 5px transparent borders draw.
+                // Clamped to that, the tip stops flush with the end of the bar
+                // instead of hanging over it, and it lands on the clamped end
+                // of the rule rather than off the end of it.
+                left: `clamp(${MARK_HALF_PX}px, ${viewportX(
+                  segment.leftPx + segment.widthPx / 2,
+                )}px, calc(100% - ${MARK_HALF_PX}px))`,
+                borderLeft: `${MARK_HALF_PX}px solid transparent`,
+                borderRight: `${MARK_HALF_PX}px solid transparent`,
                 borderTop: "6px solid rgba(250, 250, 250, 0.95)",
               }}
               className="pointer-events-none absolute -top-[9px] z-20 h-0 w-0 -translate-x-1/2"

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -867,7 +867,10 @@ export function SeamStripBar({
             stay there when a setting changes width. */}
         <div
           data-seam-transport
-          className="flex items-center gap-1.5 rounded-full border border-zinc-700/80 bg-zinc-900/70 p-1.5"
+          // DROPPED CLEAR OF THE BARS ABOVE. `mt-5` is 20px, on the assembly
+          // rather than on the row: the badges either side keep sitting where
+          // the ruler leaves them, and only the transport takes the air.
+          className="mt-5 flex items-center gap-1.5 rounded-full border border-zinc-700/80 bg-zinc-900/70 p-1.5"
         >
           {/* STEP ONE CLIP, either way, bracketing the thing they move.
               Disabled rather than hidden at the ends: a control that vanishes

--- a/apps/timeline-gstudio001/components/timeline/sidebar-collection-shortcuts.tsx
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-collection-shortcuts.tsx
@@ -249,7 +249,7 @@ export function CollectionShortcutsGroup({
         className="flex w-full flex-col items-stretch gap-0"
       >
         {projectId === undefined ? null : <ProjectHomeShortcut projectId={projectId} />}
-        {shortcuts.map((shortcut) => {
+        {shortcuts.map((shortcut, index) => {
           const tooltipId = `sidebar-tooltip-collection-${shortcut.nodeId}`;
           return (
             <button
@@ -290,7 +290,28 @@ export function CollectionShortcutsGroup({
                       // Decorative: the button already says "Open <title>", and
                       // a second reading of the same collection would be noise.
                       alt=""
-                      loading="lazy"
+                      // THE ONES ALREADY ON SCREEN ARE NOT DEFERRED.
+                      //
+                      // The rail is `h-screen` and these sit near its top, so
+                      // the leading few are inside the first viewport on every
+                      // load — and `loading=lazy` on an image the browser can
+                      // already see delays a request it could have started
+                      // immediately, waiting for layout to decide something
+                      // that is not in question (#470).
+                      //
+                      // COUNTED, not blanket. The list is every TOP-LEVEL
+                      // collection with no cap, so a large project could put
+                      // dozens here and eager-loading all of them would trade
+                      // one deferred request for dozens of competing ones.
+                      // Four is what clears the fold at the rail's spacing;
+                      // past that they are genuinely below it and lazy is
+                      // right.
+                      //
+                      // No `fetchpriority`: these are 32px and will never be
+                      // the LCP element — the board's card artwork is, and it
+                      // carries the hint. Marking these high would only take
+                      // bandwidth from it.
+                      loading={index < 4 ? "eager" : "lazy"}
                       decoding="async"
                       className={THUMBNAIL_IMAGE_CLASS}
                     />


### PR DESCRIPTION
Four changes and one flake fix, all in the details bar.

## The transport

20px top margin, on the assembly rather than the row, so the badges either side keep sitting where the ruler leaves them.

**The band under it had to grow by 40px, not 20.** The header and the bar are absolutely positioned and take no space — the scrim's top padding is the band they occupy, and its own comment says outright that anything added to that block has to be measured and the padding raised. It was, by exactly the failure that comment predicts: `TheTwoBarsAreAdjacent` measures the gap between the controls row and the centre card, and it fell from **22px to 2**.

The doubling is the part worth knowing: the box is `items-center`, so padding added at the top is shared with the bottom when the row re-centres. 20px of padding bought only 10px of movement (2 → 12, still under the 16 floor). `14rem` → `16.5rem`.

## The triangle

Now held inside the bar like the rule under it. The rule was clamped in #516 and the mark deliberately was not, on the reasoning that it points at a *place* and an off-screen place is a different question from an over-long measurement. That was wrong — a mark past the end of the bar has no track under it to be a position *on*, so it reads as a stray glyph on the panel beside the film.

**Honest about what the story does not prove.** The triangle only escapes once the bar has been *panned* away from the active clip; the bar centres it otherwise, so its middle is the track's middle however long the clip is (measured: 600 in a track ending at 1176). The story asserts containment as an invariant and says so in a comment rather than pretending to reproduce it. The clamp itself was verified by driving `left` past both ends — flush at 1338.5 and at 58.5 against a track of exactly those bounds. A real pan belongs with the e2e.

The seam fixture moved to a 400s subject **first**, which poses the rule case at the opposite edge. Re-proved without the clamp: fails at **-320.2px against a track starting at 23.5 — 344px of overhang**.

## A flake, fixed rather than filed

`NarrowPanelsShedTheirControlsAndStayAligned` waited for the trim strip to disappear, then read the tag editor and undo button on whatever frame it landed on. Pressing "5" drops those controls as the width crosses each threshold and the trim strip goes first, so the wait could return with the other two still mounted.

It failed on clean `main` as often as not, passed in isolation and under `--reporter=verbose`, and adding a 44th story to the file was enough to change how often. All three assertions now share one `waitFor` — **44/44, four runs in a row**.

## #470, the measured half

Checked before changing anything, and most of it was already done:

- `graph-collection-card.tsx` — already `loading="eager"` + `fetchPriority="high"` on the first frame + intrinsic `width`/`height`. Nothing to do.
- `packages/ui/.../node-thumbnail.tsx` — the issue lists it, but **the app never renders it** (`[data-node-thumbnail]` count on a real board: **0**). It is the package's stock fallback, reached only by package stories. Left alone — and with #285 open (the grid mounts every card), going eager there could be actively worse.
- The rail's collection shortcuts *were* above the fold and lazy. The leading four are eager now — counted rather than blanket, since the list is every top-level collection with no cap. No `fetchpriority`: at 32px these will never be LCP, and marking them high would only take bandwidth from the card artwork that is.

**Above-the-fold lazy images on a board open: 3 → 0.**

## Checks

- `tsc --noEmit` clean; `eslint` 0 errors (2 pre-existing `<img>` warnings)
- app `vitest` — **1446/1446** (112 files)
- `graph-item-details-modal.stories.tsx` — **44/44**, four consecutive runs
- `timeline-sidebar.stories.tsx` — 5/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)