### PR TITLE
The ruler moves above the film, and becomes the thing you point at

### DIFF
--- a/apps/timeline-gstudio001/app/globals.css
+++ b/apps/timeline-gstudio001/app/globals.css
@@ -199,14 +199,27 @@ html body[data-scroll-locked] {
    snap together read as a stutter. A short fade with a touch of rise says it
    came from the box below it. Quick, because it has already spent its patience
    budget on the dwell. */
+/* THE Y ONLY. THE X IS NOT THIS ANIMATION'S TO STATE.
+   The card carries `-translate-x-1/2`, and in Tailwind v4 that compiles to the
+   standalone `translate` property (`translate: -50%`), NOT to `transform`.
+   The two are separate channels and both apply — so a keyframe that also said
+   `transform: translate(-50%, …)` was not restating the shift, it was ADDING a
+   second one, and the card spent the animation a full card-width to the left
+   before snapping into place when the animation ended and `transform` went
+   back to `none`.
+   Measured on a 384px card: -7.6px while animating, 184.4px at rest — a 192px
+   jump, which is exactly the -50% applied twice. That is the whole of "it
+   shows in the wrong position first and then corrects".
+   Anything here that needs the card's own offset must leave the X alone and
+   let the class own it. */
 @keyframes seam-preview-in {
   from {
     opacity: 0;
-    transform: translate(-50%, -4px);
+    transform: translateY(-4px);
   }
   to {
     opacity: 1;
-    transform: translate(-50%, 0);
+    transform: translateY(0);
   }
 }
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -341,6 +341,33 @@ function seamSurface(): HTMLElement {
   return found!;
 }
 
+/**
+ * The RULER, which is what raises the preview now.
+ *
+ * Hovering used to be the film's job, and the card appeared over the frames it
+ * was describing with the pointer resting on them. It moved to the scale above
+ * (see `graph-seam-ruler`), so every story that raises a card points here —
+ * the film keeps only the gestures that move it.
+ */
+function seamRuler(): HTMLElement {
+  const found = document.querySelector<HTMLElement>("[data-seam-ruler]");
+  expect(found).not.toBeNull();
+  return found!;
+}
+
+/**
+ * Point at the ruler directly above a given x on the film.
+ *
+ * The ruler sits immediately over the strip and is translated by the same
+ * offset, so an x that lands on a box lands on that box's scale — which is
+ * what lets these stories go on describing their targets in terms of boxes.
+ */
+function hoverRulerAt(clientX: number): void {
+  const ruler = seamRuler();
+  const box = ruler.getBoundingClientRect();
+  fireEvent.pointerMove(ruler, pointerAt(clientX, box.top + box.height / 2));
+}
+
 function pointerAt(clientX: number, clientY: number) {
   return { clientX, clientY, isPrimary: true, pointerId: 1, button: 0 };
 }
@@ -1285,6 +1312,27 @@ export const NarrowPanelsShedTheirControlsAndStayAligned: Story = {
       expect(visible("[data-tag-editor]")).toBe(false);
       expect(visible("[data-item-details-undo]")).toBe(false);
     });
+    // AND THE FILMSTRIP FILLS THE BOX IT WAS MEASURED FROM.
+    //
+    // Its width is a NUMBER, handed down so frames can be laid out, and it was
+    // read once when the slot mounted and never again. Every width a panel
+    // actually has arrives after that: the same element is a neighbour one
+    // moment and the centre the next as the strip advances, the centre is
+    // deliberately wider, and pressing "5" — which this story has just done —
+    // changes both. So the strip drew at whichever width it happened to mount
+    // at. Measured here before the fix: 581px of film inside a 357px slot.
+    //
+    // Asserted for whatever still HAS a strip rather than for every panel,
+    // because shedding it is the other half of this story.
+    for (const panel of panels()) {
+      const strip = panel.querySelector<HTMLElement>("[data-trim-overview]");
+      if (strip === null) continue;
+      const slot = panel.querySelector<HTMLElement>("[data-trim-strip-slot]")!;
+      expect(
+        Math.abs(strip.getBoundingClientRect().width - slot.getBoundingClientRect().width),
+      ).toBeLessThan(1);
+    }
+
     // Still aligned, and still identically bordered — among peers, as above.
     const middleAt = panels().findIndex(
       (panel) => panel.dataset.itemDetailsPanel === "centre",
@@ -1796,13 +1844,10 @@ export const PointingAtABoxSaysWhatItIs: Story = {
 
     expect(preview()).toBeNull();
 
-    const surface = seamSurface();
     const target = seamBoxes()[3]!.getBoundingClientRect();
     const before = at();
-    fireEvent.pointerMove(
-      surface,
-      pointerAt(target.left + target.width / 2, target.top + target.height / 2),
-    );
+    // AT THE RULER, above that box. The film raises nothing now.
+    hoverRulerAt(target.left + target.width / 2);
 
     await waitFor(() => expect(preview()).not.toBeNull());
     expect(preview()!.textContent).toContain("Kitchen 3");
@@ -1810,14 +1855,19 @@ export const PointingAtABoxSaysWhatItIs: Story = {
     // cannot carry itself.
     expect(preview()!.textContent).toContain("Kitchen Interior");
     // A ghost line marks WHERE, so the words and the position are one object.
+    // TWO SEGMENTS OF ONE LINE, since the pointer is on the ruler and the clip
+    // it is asking about is below: the scale draws its own so that pointing at
+    // it visibly does something, and the film draws the half that lands on the
+    // frames.
     expect(document.querySelector("[data-seam-ghost]")).not.toBeNull();
+    expect(document.querySelector("[data-seam-ruler-ghost]")).not.toBeNull();
     // LOOKING IS FREE.
     expect(at()).toBe(before);
 
     // `pointerOut` with a relatedTarget, not `pointerLeave`: React synthesises
     // enter/leave from delegated over/out events, so a bare `pointerleave`
     // reaches no handler and the preview would look sticky in a way it is not.
-    fireEvent.pointerOut(surface, {
+    fireEvent.pointerOut(seamRuler(), {
       ...pointerAt(target.left, target.top),
       relatedTarget: document.body,
     });
@@ -2803,10 +2853,8 @@ export const TheHoverCardCanBePinned: Story = {
     };
     const hoverOver = async (box: HTMLElement, fraction: number) => {
       const rect = box.getBoundingClientRect();
-      fireEvent.pointerMove(
-        lane,
-        pointerAt(rect.left + rect.width * fraction, rect.top + rect.height / 2),
-      );
+      // The ruler above that point on the box — the film no longer hovers.
+      hoverRulerAt(rect.left + rect.width * fraction);
       return await waitFor(() => {
         const card = document.querySelector<HTMLElement>("[data-seam-preview]");
         expect(card).not.toBeNull();
@@ -2872,7 +2920,8 @@ export const ThePanelsRecedeBehindThePreview: Story = {
     // bar reports the state and the view acts on it. Both are waited for
     // rather than assumed, which is also the assertion that the dwell has not
     // quietly become "never".
-    fireEvent.pointerMove(lane, pointerAt(centre.x, centre.y));
+    // AT THE RULER above the box. Pressing, below, is still the film's.
+    hoverRulerAt(centre.x);
     await waitFor(() => expect(document.querySelector("[data-seam-preview]")).not.toBeNull());
     await waitFor(() => expect(dimmed()).toBe(true));
     // Both properties ease, so the row does not snap dark while it slides.

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -859,8 +859,8 @@ function DetailsFilmstripModal({
       // be measured and this raised, or the row below rides up into it on a
       // short viewport.
       //
-      // 14rem → 16.5rem when the transport took a 20px top margin, dropping it
-      // clear of the two bars above. This is exactly the failure the note above
+      // 14rem → 18.5rem, for the transport's 36px top margin dropping it clear
+      // of the two bars above. This is exactly the failure the note above
       // predicts, and it was caught the way it was meant to be:
       // `TheTwoBarsAreAdjacent` measures the gap between this row and the
       // centre card, and it fell from 22px to 2 — the "quiet eight pixels"
@@ -871,8 +871,13 @@ function DetailsFilmstripModal({
       // writing down. This box is `items-center`, so padding added at the top
       // is shared with the bottom when the row is re-centred in what is left —
       // 20px of padding buys only 10px of downward movement. The first attempt
-      // added 20 and recovered half the slack (2 → 12, still short of the 16
-      // floor). 40px is what 20px of bar costs here: 224 + 40 = 264 = 16.5rem.
+      // added 20 for 20 and recovered half the slack (2 → 12, still short of
+      // the 16 floor).
+      //
+      // So the arithmetic is 224 + 2 × margin: 20px of margin took this to
+      // 16.5rem, and 36px takes it to 18.5rem (224 + 72 = 296). Move the
+      // transport again and this moves by twice as much, in the same
+      // direction.
       // `overflow-clip`, NOT `overflow-hidden`. Both crop, but `hidden` makes
       // this a SCROLL CONTAINER — and the row is thirteen thousand pixels
       // wide, so there is a great deal for it to scroll. Landing on a new clip
@@ -882,7 +887,7 @@ function DetailsFilmstripModal({
       // row that had itself moved 1728px, which put the card just chosen
       // entirely off the left edge. `clip` crops without ever being
       // scrollable, so the transform stays the only thing that moves the row.
-      className="fixed inset-0 z-[80] flex items-center justify-center overflow-clip bg-black/80 px-6 pt-[16.5rem] pb-6 backdrop-blur-sm"
+      className="fixed inset-0 z-[80] flex items-center justify-center overflow-clip bg-black/80 px-6 pt-[18.5rem] pb-6 backdrop-blur-sm"
       // THE SCRIM DOES NOT DISMISS. Deliberate: this view is worked in, not
       // glanced at — trimming, scrubbing and swiping all end with the pointer
       // somewhere unpredictable, and the panels are cropped by the scrim

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-trim-strip.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-trim-strip.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import {
   TrimOverviewStrip,
@@ -48,9 +48,39 @@ export function ItemDetailsTrimStrip({
   // HOW WIDE THE STRIP MAY DRAW, measured from the slot it lands in rather
   // than assumed: the panel's width is a container query away from this file,
   // and the strip needs a NUMBER to lay frames out with.
+  //
+  // OBSERVED, NOT MEASURED ONCE. A bare ref callback fires when the element
+  // MOUNTS and never again, and every width this panel can have arrives after
+  // that: the same element is a neighbour one moment and the centre the next
+  // as the strip advances — and the centre is deliberately wider — so the
+  // number was whichever role the panel happened to mount in. Changing the
+  // view count and resizing the window are the same story.
+  //
+  // Both directions were visible at once. A panel that mounted narrow and
+  // became the centre drew a strip short of its container; measured on the
+  // five-up story, one that mounted wide and narrowed drew 581px of film into
+  // a 357px slot — 224px of overflow.
   const [stripWidth, setStripWidth] = useState(0);
+  const observerRef = useRef<ResizeObserver | null>(null);
   const stripSlot = useCallback((element: HTMLElement | null) => {
-    setStripWidth(element === null ? 0 : element.getBoundingClientRect().width);
+    observerRef.current?.disconnect();
+    observerRef.current = null;
+    if (element === null) {
+      setStripWidth(0);
+      return;
+    }
+    const measure = () => {
+      const next = element.getBoundingClientRect().width;
+      // UNCHANGED IS NOT A RENDER. A ResizeObserver fires for boxes that
+      // settled on the same number, and setting state from it would re-render
+      // every panel on any mutation that touched layout — the cost #468
+      // measured on the two effects that do exactly this.
+      setStripWidth((current) => (Math.abs(current - next) < 0.5 ? current : next));
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    observerRef.current = observer;
   }, []);
 
   /* The whole source, with the showing window and its grips — the trim
@@ -87,7 +117,14 @@ export function ItemDetailsTrimStrip({
             the gate sits below it and a genuinely tiny panel still sheds
             the strip. */}
         {video && (
-          <div ref={stripSlot} className="hidden w-full @min-[18rem]:block">
+          <div
+            ref={stripSlot}
+            // The box the strip is measured FROM, named so a test can compare
+            // the two without walking the DOM by parentElement — the whole
+            // bug was the strip disagreeing with this element's width.
+            data-trim-strip-slot
+            className="hidden w-full @min-[18rem]:block"
+          >
             {stripWidth > 0 ? (
               <div className="relative">
                 {/* WHITE, because this view is a filmstrip.

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import { BAR_NEUTRAL_COLOUR } from "@/lib/bar-collection-colours-flag";
 
@@ -391,6 +391,7 @@ export function SeamLane({
   // styling. The pointer handler clears it early so a drag begun mid-slide is
   // still exact from its first frame.
   const thumbnails = usePlaybarThumbnails();
+
   // The clips by id, so a segment can reach its posters without a scan per box.
   const clipById = useMemo(() => new Map(clips.map((clip) => [clip.id, clip])), [clips]);
   const stripRef = useRef<HTMLDivElement | null>(null);
@@ -736,106 +737,188 @@ export function SeamLane({
           "is that the shot I am looking for" without moving the playhead to
           find out — the thing a bar of anonymous boxes cannot do. */}
       {hover !== null && (
-        <span
-          data-seam-preview
-          aria-hidden="true"
-          // PINNED, OR KEPT INSIDE THE TRACK.
-          //
-          // `pinned` parks it dead centre under the bar and leaves it there, so
-          // the pointer scrubs and the picture changes in place. See
-          // `graph-seam-preview-anchor` for why that is worth having: the card
-          // is now big enough to judge a frame in, and a big thing sliding
-          // around under a moving pointer is the one arrangement in which you
-          // cannot.
-          //
-          // `follow` centres it on the box being described, which walks it off
-          // the side as soon as that box is near either end — and the wider
-          // this card got, the more of the bar had that problem. At 288px a
-          // hover anywhere in the first or last 144 pixels was reading a card
-          // with its edge cut off, which is worst exactly where the picture is
-          // the whole point. `clamp` against percentages rather than a measured
-          // width: the percentage resolves against this element's containing
-          // block, which IS the track, so the bound follows a resize with no
-          // observer and no re-render. 9rem is half the card.
-          style={{
-            left:
-              previewAnchor === "pinned"
-                ? "50%"
-                : `clamp(12rem, ${viewportX(hover.x)}px, calc(100% - 12rem))`,
-          }}
-          // BELOW THE WHOLE BAR, not just below the boxes: at `top-9` it lay
-          // across the ruler and the minimap, hiding the two things that say
-          // where the box being previewed actually is.
-          // STACKED, SO THE PICTURE CAN BE THE SIZE OF THE ANSWER.
-          //
-          // It was a 56x32 thumbnail beside two lines of text — barely larger
-          // than the frame being pointed at, which made the preview a worse
-          // copy of the thing that prompted it. The question a hover asks is
-          // "which shot is that", and the only part of this card that answers
-          // it is the picture; the name and the time are confirmation. So the
-          // picture gets the full width of the card and the words go
-          // underneath.
-          //
-          // AND IT STANDS OFF THE PAGE, because it now overlaps the panels
-          // below rather than floating over a gap: a heavier border, a deeper
-          // shadow and a near-opaque ground, so it reads as something in front
-          // rather than something printed on what it covers.
-          // TIGHT UNDER THE FILM STRIP, and over whatever is beneath it.
-          //
-          // It sat below the whole block, clear of the ruler, the minimap and
-          // the controls. That put a 264px card a long way from the 30px box it
-          // was describing, so pairing the two was a journey across everything
-          // in between — the preview and its subject were the two things
-          // furthest apart on screen.
-          //
-          // It overlaps the minimap and the controls now, which is the right
-          // trade: those are read between gestures, and this is read DURING
-          // one. It is `pointer-events-none`, so the transport underneath stays
-          // pressable through it, and it is gone the moment the pointer leaves
-          // the boxes.
-          //
-          // Sitting just under the ruler at 56px rather than against the boxes:
-          // the ruler is the scale the box widths mean anything against, and
-          // covering it would answer "which shot" while hiding "how long".
-          className="animate-seam-preview-in pointer-events-none absolute top-14 z-20 flex w-96 -translate-x-1/2 flex-col gap-1.5 rounded-lg border border-zinc-600 bg-zinc-950/98 p-2 shadow-2xl ring-1 ring-black/50"
-        >
-          {hover.posterSrc === undefined ? null : (
-            // A bare <img>: the preview is a thumbnail of a source the app
-            // already holds a URL for, and next/image would add a loader
-            // round-trip on every hover for one picture.
-            <img
-              src={hover.posterSrc}
-              alt=""
-              // THE FRAME'S OWN SHAPE, whole.
-              //
-              // It was forced to 16:9 and cropped to fill, on the reasoning
-              // that a card changing height as the pointer moved would be the
-              // card itself flickering. That holds for a row of mixed shapes
-              // and costs too much here: this project's shots are 896x384, so
-              // 16:9 was cutting the sides off every one of them — the preview
-              // was showing less of the frame than the box it came from. A
-              // preview that crops is answering a question about composition
-              // with a different composition.
-              //
-              // `h-auto` with no ratio, so the poster's intrinsic dimensions
-              // decide: scope stays scope, 16:9 stays 16:9, and nothing is
-              // trimmed. The card grows and shrinks with it, which is the
-              // honest trade and much less distracting now `PIN` exists — a
-              // stationary card resizing reads as the picture changing, where
-              // a moving one resizing reads as a wobble.
-              className="h-auto w-full rounded"
-            />
-          )}
-          <span className="min-w-0">
-            <span className="block truncate text-xs font-medium text-zinc-100">
-              {hover.name}
-            </span>
-            <span className="mt-0.5 block truncate font-mono text-[11px] tabular-nums text-zinc-400">
-              {hover.meta}
-            </span>
-          </span>
-        </span>
+        <SeamPreviewCard
+          hover={hover}
+          previewAnchor={previewAnchor}
+          leftPx={viewportX(hover.x)}
+        />
       )}
     </div>
   );
+}
+
+
+/**
+ * THE HOVER CARD, as its own component so its readiness state has a LIFETIME.
+ *
+ * It holds one piece of state — whether the poster has arrived — and that has
+ * to be false again for each new appearance. Kept in the lane it needed an
+ * effect watching  to clear it, which is a synchronous setState inside
+ * an effect: the cascading-render pattern this package rejects everywhere
+ * else, and eslint fails the build over it.
+ *
+ * Mounting IS the reset. The lane renders this only while something is
+ * hovered, so the state is born false with the card and dies with it, and
+ * there is no effect and nothing to keep in step.
+ */
+function SeamPreviewCard({
+  hover,
+  previewAnchor,
+  leftPx,
+}: Readonly<{
+  hover: SeamHover;
+  previewAnchor: PreviewAnchor;
+  /** Where the card points, already in the lane's coordinates. */
+  leftPx: number;
+}>) {
+  // WHETHER THE CARD HAS A PICTURE TO BE THE SIZE OF YET.
+  //
+  // The poster is a bare `<img>` with `h-auto` and no intrinsic dimensions,
+  // so until its bytes arrive the element measures zero and the card lays out
+  // at the height of its two lines of text. The picture then lands and the
+  // card roughly triples in height — which is what "it appears in the wrong
+  // place and then corrects itself" is: not a reposition, a resize, under a
+  // card whose entrance animation has already started.
+  //
+  // Nothing here can reserve the box in advance. The card deliberately takes
+  // the poster's OWN shape rather than forcing a ratio (see the note on the
+  // image), and the app does not know that shape until the file is decoded —
+  // an aspect-ratio guess would fix the flash by reintroducing the crop that
+  // note exists to prevent.
+  //
+  // So the card waits instead. It is mounted and laid out the whole time, so
+  // the browser is fetching the poster and the element has its final size the
+  // instant anything is visible; only the paint is held. HELD FOR THE FIRST
+  // FRAME ONLY — subsequent moves swap the src under a card that is already
+  // up, and gating those would make it blink on every quarter-second of
+  // travel, which is worse than the thing being fixed.
+  const [posterReady, setPosterReady] = useState(false);
+  // A CACHED POSTER FIRES NO `load`. Re-hovering the same frame serves it from
+  // memory and the element is already `complete` before React attaches the
+  // handler, so without this the card would wait for an event that has been
+  // and gone and never paint at all.
+  const posterRef = useCallback((element: HTMLImageElement | null) => {
+    if (element?.complete === true) setPosterReady(true);
+  }, []);
+  return (
+    <span
+      data-seam-preview
+      aria-hidden="true"
+      // PINNED, OR KEPT INSIDE THE TRACK.
+      //
+      // `pinned` parks it dead centre under the bar and leaves it there, so
+      // the pointer scrubs and the picture changes in place. See
+      // `graph-seam-preview-anchor` for why that is worth having: the card
+      // is now big enough to judge a frame in, and a big thing sliding
+      // around under a moving pointer is the one arrangement in which you
+      // cannot.
+      //
+      // `follow` centres it on the box being described, which walks it off
+      // the side as soon as that box is near either end — and the wider
+      // this card got, the more of the bar had that problem. At 288px a
+      // hover anywhere in the first or last 144 pixels was reading a card
+      // with its edge cut off, which is worst exactly where the picture is
+      // the whole point. `clamp` against percentages rather than a measured
+      // width: the percentage resolves against this element's containing
+      // block, which IS the track, so the bound follows a resize with no
+      // observer and no re-render. 9rem is half the card.
+      style={{
+        left:
+          previewAnchor === "pinned"
+            ? "50%"
+            : `clamp(12rem, ${leftPx}px, calc(100% - 12rem))`,
+      }}
+      // BELOW THE WHOLE BAR, not just below the boxes: at `top-9` it lay
+      // across the ruler and the minimap, hiding the two things that say
+      // where the box being previewed actually is.
+      // STACKED, SO THE PICTURE CAN BE THE SIZE OF THE ANSWER.
+      //
+      // It was a 56x32 thumbnail beside two lines of text — barely larger
+      // than the frame being pointed at, which made the preview a worse
+      // copy of the thing that prompted it. The question a hover asks is
+      // "which shot is that", and the only part of this card that answers
+      // it is the picture; the name and the time are confirmation. So the
+      // picture gets the full width of the card and the words go
+      // underneath.
+      //
+      // AND IT STANDS OFF THE PAGE, because it now overlaps the panels
+      // below rather than floating over a gap: a heavier border, a deeper
+      // shadow and a near-opaque ground, so it reads as something in front
+      // rather than something printed on what it covers.
+      // TIGHT UNDER THE FILM STRIP, and over whatever is beneath it.
+      //
+      // It sat below the whole block, clear of the ruler, the minimap and
+      // the controls. That put a 264px card a long way from the 30px box it
+      // was describing, so pairing the two was a journey across everything
+      // in between — the preview and its subject were the two things
+      // furthest apart on screen.
+      //
+      // It overlaps the minimap and the controls now, which is the right
+      // trade: those are read between gestures, and this is read DURING
+      // one. It is `pointer-events-none`, so the transport underneath stays
+      // pressable through it, and it is gone the moment the pointer leaves
+      // the boxes.
+      //
+      // Sitting just under the ruler at 56px rather than against the boxes:
+      // the ruler is the scale the box widths mean anything against, and
+      // covering it would answer "which shot" while hiding "how long".
+      // INVISIBLE UNTIL IT IS THE RIGHT SIZE, and only on the way in — see
+      // `posterReady`. `visibility` rather than unmounting or `display`,
+      // because the element has to stay laid out for the browser to be
+      // fetching the poster at all, and it has to have its final height
+      // before the first frame anyone sees. A card with no picture to wait
+      // for is shown immediately.
+      //
+      // The entrance animation is withheld with it. Left running it would
+      // play out against a card nobody can see and arrive already over.
+      className={[
+        "pointer-events-none absolute top-14 z-20 flex w-96 -translate-x-1/2 flex-col gap-1.5 rounded-lg border border-zinc-600 bg-zinc-950/98 p-2 shadow-2xl ring-1 ring-black/50",
+        hover.posterSrc === undefined || posterReady
+          ? "animate-seam-preview-in visible"
+          : "invisible",
+      ].join(" ")}
+    >
+      {hover.posterSrc === undefined ? null : (
+        // A bare <img>: the preview is a thumbnail of a source the app
+        // already holds a URL for, and next/image would add a loader
+        // round-trip on every hover for one picture.
+        <img
+          ref={posterRef}
+          src={hover.posterSrc}
+          alt=""
+          // EITHER OUTCOME REVEALS THE CARD. A poster that 404s or is
+          // blocked would otherwise hold it invisible forever, and the
+          // words underneath are still worth showing — the card answers
+          // "which shot" with a name as well as a picture.
+          onLoad={() => setPosterReady(true)}
+          onError={() => setPosterReady(true)}
+          // THE FRAME'S OWN SHAPE, whole.
+          //
+          // It was forced to 16:9 and cropped to fill, on the reasoning
+          // that a card changing height as the pointer moved would be the
+          // card itself flickering. That holds for a row of mixed shapes
+          // and costs too much here: this project's shots are 896x384, so
+          // 16:9 was cutting the sides off every one of them — the preview
+          // was showing less of the frame than the box it came from. A
+          // preview that crops is answering a question about composition
+          // with a different composition.
+          //
+          // `h-auto` with no ratio, so the poster's intrinsic dimensions
+          // decide: scope stays scope, 16:9 stays 16:9, and nothing is
+          // trimmed. The card grows and shrinks with it, which is the
+          // honest trade and much less distracting now `PIN` exists — a
+          // stationary card resizing reads as the picture changing, where
+          // a moving one resizing reads as a wobble.
+          className="h-auto w-full rounded"
+        />
+      )}
+      <span className="min-w-0">
+        <span className="block truncate text-xs font-medium text-zinc-100">
+          {hover.name}
+        </span>
+        <span className="mt-0.5 block truncate font-mono text-[11px] tabular-nums text-zinc-400">
+          {hover.meta}
+        </span>
+      </span>
+    </span>  );
 }

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-ruler.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-ruler.tsx
@@ -3,7 +3,17 @@
 import type { SeamTick } from "./graph-seam-bar-layout";
 
 /**
- * The scale under the boxes: seconds, and where each collection starts.
+ * How tall the ruler's own band is.
+ *
+ * Exported because the fades over the film strip are absolutely positioned
+ * against the track, and the strip no longer starts at its top — they have to
+ * begin exactly where the ruler stops or they cover the last row of labels.
+ * Two places, one number.
+ */
+export const SEAM_RULER_HEIGHT_PX = 20;
+
+/**
+ * The scale ABOVE the boxes: seconds, and where each collection starts.
  *
  * WHY A RULER AT ALL, when the boxes are already proportional. Because the
  * bar zooms. A box's width means "this long" only against a scale, and
@@ -16,37 +26,118 @@ import type { SeamTick } from "./graph-seam-bar-layout";
  * landmark on a run of boxes that otherwise looks the same all the way along.
  * They are drawn in the ink the bar reserves for structure, and they are the
  * ones that win a collision — see `seamRulerTicks`.
+ *
+ * ── ABOVE THE FILM, NOT UNDER IT ────────────────────────────────────────────
+ *
+ * It sat underneath, which put the scale on the far side of the thing it
+ * measures: the labels were separated from the boxes by the whole height of
+ * the strip, and reading "is that box two seconds or twenty" meant crossing
+ * the film to find out. A ruler belongs against what it measures, and the
+ * order of the block reads top-down — scale, then film, then the map of where
+ * the film is.
+ *
+ * So the tick MARKS moved with it. They hang from the bottom edge now, where
+ * they meet the top of the strip, with the label above them; upside down they
+ * would point away from the boxes and label the air.
+ *
+ * ── AND IT IS THE HOVER TARGET ──────────────────────────────────────────────
+ *
+ * Pointing at the ruler is what raises the preview card, rather than pointing
+ * at the boxes. The film is the thing being READ — a card that appears over it
+ * covers the frames it is reporting on, and the pointer that summoned it is
+ * sitting on them too. The ruler is the margin beside the text: near enough to
+ * mean the same place, and not made of anything you were looking at.
+ *
+ * The strip keeps every gesture that MOVES it — press to pan, drag to scrub,
+ * click to choose a clip. Only the hover moved.
  */
 export function SeamRuler({
   ticks,
   offset,
+  ghostX = null,
+  handlers,
 }: Readonly<{
   ticks: readonly SeamTick[];
   /** The strip's own transform, so the ruler travels with the boxes. */
   offset: number;
+  /**
+   * Where the pointer is, in STRIP space, or null when it is not over the bar.
+   *
+   * The film already drew this line; the ruler did not, so pointing at the
+   * scale gave no sign that the scale was the thing being pointed AT — the
+   * only feedback was a card appearing somewhere else. Drawn here in the same
+   * ink and at the same x, the two are one line running from under the
+   * pointer down into the frames it is asking about.
+   *
+   * Strip space, so it sits inside the translated container below and needs no
+   * arithmetic of its own: the same number the lane is given.
+   */
+  ghostX?: number | null;
+  /**
+   * The hover handlers, which live here now rather than on the lane.
+   *
+   * Optional so the ruler can still be rendered as a plain scale — a story or
+   * a consumer that only wants the marks should not have to invent pointer
+   * handlers to get them.
+   */
+  handlers?: Readonly<{
+    onPointerMove?: (event: React.PointerEvent<HTMLDivElement>) => void;
+    onPointerLeave?: (event: React.PointerEvent<HTMLDivElement>) => void;
+  }>;
 }>) {
   if (ticks.length === 0) return null;
+  const interactive = handlers !== undefined;
   return (
     <div
       data-seam-ruler
-      aria-hidden="true"
-      className="pointer-events-none relative h-4 overflow-hidden"
+      data-seam-ruler-interactive={interactive ? "" : undefined}
+      // NOT `aria-hidden` any more when it is the hover target. It was hidden
+      // as pure decoration beside a slider that carried the real value, and
+      // that was right while nothing here could be pointed at. The track above
+      // is still the `role="slider"` that reports the position — this only
+      // reveals a preview — so it stays out of the accessibility tree as a
+      // control, but hiding an element you can interact with is the one thing
+      // `aria-hidden` must never do.
+      aria-hidden={interactive ? undefined : "true"}
+      style={{ height: SEAM_RULER_HEIGHT_PX }}
+      className={[
+        "relative overflow-hidden",
+        // `pointer-events-none` ONLY while it is decoration. As the hover
+        // target it has to receive the pointer — and `touch-none`, because the
+        // strip below claims every gesture and a ruler that scrolled the
+        // dialog on a touch drag would be the one part of the bar that did.
+        interactive ? "touch-none" : "pointer-events-none",
+      ].join(" ")}
+      {...(handlers ?? {})}
     >
       <div
         className="absolute inset-y-0 left-0 w-full"
         style={{ transform: `translateX(${offset}px)` }}
       >
+        {/* UNDER THE POINTER, and the same hairline the film draws. First in
+            the container so a tick mark and its label paint over it rather
+            than under — the line says where you are, and the label is what it
+            is pointing at. */}
+        {ghostX !== null && (
+          <span
+            aria-hidden="true"
+            data-seam-ruler-ghost
+            style={{ transform: `translateX(${ghostX}px)` }}
+            className="absolute inset-y-0 left-0 w-px bg-white/35"
+          />
+        )}
         {ticks.map((tick) => (
           <span
             key={`${tick.kind}-${tick.x}-${tick.label}`}
             data-seam-tick={tick.kind}
             style={{ left: tick.x }}
-            className="absolute top-0"
+            className="absolute inset-y-0"
           >
+            {/* HANGING FROM THE BOTTOM, where the ruler meets the film. */}
             <span
               className={[
-                "absolute top-0 left-0 w-px",
-                tick.kind === "collection" ? "h-1.5 bg-white/45" : "h-1 bg-white/20",
+                "absolute bottom-0 left-0 w-px",
+                tick.kind === "collection" ? "h-1.5 bg-white/45" : "h-1 bg-white/25",
               ].join(" ")}
             />
             {/* Left-ALIGNED to the tick rather than centred on it. A
@@ -56,10 +147,20 @@ export function SeamRuler({
                 seam. */}
             <span
               className={[
-                "absolute top-2 left-0 max-w-32 truncate font-mono text-[9px] leading-none whitespace-nowrap",
+                "absolute top-0 left-0 max-w-32 truncate text-[10px] leading-none whitespace-nowrap",
+                // READABLE, which the time labels were not. They were
+                // `text-zinc-600` at 9px — grey on near-black, at a size where
+                // the strokes are a pixel wide, so the numbers were legible
+                // only by being where numbers were expected. 10px and
+                // `zinc-400` is still quiet enough to stay a scale rather than
+                // a row of content, and can actually be read.
+                //
+                // The collection names keep their extra weight and letter
+                // spacing: they are the landmark, and the numbers are the
+                // grid they sit on.
                 tick.kind === "collection"
-                  ? "tracking-wider text-zinc-300"
-                  : "tabular-nums text-zinc-600",
+                  ? "font-mono tracking-wider text-zinc-200"
+                  : "font-mono tabular-nums text-zinc-400",
               ].join(" ")}
             >
               {tick.label}

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -17,7 +17,7 @@ import {
 } from "./graph-seam-bar-layout";
 import { SeamLane, type SeamHover } from "./graph-seam-lane";
 import { SeamMinimap } from "./graph-seam-minimap";
-import { SeamRuler } from "./graph-seam-ruler";
+import { SEAM_RULER_HEIGHT_PX, SeamRuler } from "./graph-seam-ruler";
 import {
   buildSeamStrip,
   stripCentreOffset,
@@ -100,6 +100,45 @@ const CLICK_SLOP_PX = 4;
  */
 const FOLLOW_LEAD_PX = 56;
 const FOLLOW_TRAIL_PX = 72;
+
+/**
+ * ── THE FLICK, AND HOW IT DIES ──────────────────────────────────────────────
+ *
+ * How much of its speed the glide keeps per millisecond. Applied as
+ * `v *= DECAY ** dt`, so the curve is the same on a 60Hz panel and a 120Hz
+ * one — a per-FRAME factor would make the strip travel twice as far on the
+ * faster display, which is the usual way this is got wrong.
+ *
+ * 0.9965 is roughly a third of the speed left after 300ms: long enough that a
+ * flick clearly carries, short enough that the film never feels like it is
+ * getting away from you. The bar is a thing you read, not a wheel you spin.
+ */
+const GLIDE_DECAY_PER_MS = 0.9965;
+
+/** Below this the glide is over — a fifth of a pixel per frame is not motion,
+ *  it is a rounding error keeping a rAF alive. */
+const GLIDE_MIN_PX_PER_MS = 0.012;
+
+/**
+ * How much of the release has to be a THROW before anything glides.
+ *
+ * A pan that is placed — pulled somewhere and set down — ends slow, and
+ * carrying it on past where it was put would be the strip disagreeing with the
+ * hand. Only a release still moving at this speed reads as thrown.
+ */
+const GLIDE_MIN_LAUNCH_PX_PER_MS = 0.35;
+
+/**
+ * How far back the launch speed is measured.
+ *
+ * The last two events are too few — a pointer that stalls for one frame before
+ * release reports zero and the flick dies on the spot — and the whole gesture
+ * is too many, since a drag that paused in the middle and then flicked would
+ * launch at its average rather than its parting speed. ~70ms is about four
+ * frames: enough to survive one stutter, short enough to be the END of the
+ * gesture rather than a summary of it.
+ */
+const GLIDE_SAMPLE_MS = 70;
 
 function readSeconds(value: number): string {
   return `${value.toFixed(2)}s`;
@@ -387,6 +426,65 @@ export function SeamStripBar({
     setPanPx(clamped);
   }, []);
 
+  // ── INERTIA ──────────────────────────────────────────────────────────────
+  //
+  // A flick keeps going. The strip stopped dead on release, which is fine for
+  // a short pull and wrong for a long one: reaching the far end of a
+  // four-minute cut meant a row of separate drags, each one re-grabbing film
+  // that was already still.
+  //
+  // A rAF LOOP rather than a CSS transition, because the distance is not known
+  // when the hand leaves: the glide has to stop early if it reaches a pan
+  // limit, and a transition that has already been handed a destination cannot.
+  const glideRef = useRef<number | null>(null);
+  /** Recent pointer positions, for the speed the hand left at. */
+  const samplesRef = useRef<{ x: number; t: number }[]>([]);
+
+  const stopGlide = useCallback(() => {
+    if (glideRef.current === null) return;
+    cancelAnimationFrame(glideRef.current);
+    glideRef.current = null;
+  }, []);
+  // Nothing outlives the bar: a rAF still holding a closure over `setOffset`
+  // after unmount is a setState on a dead component every frame until it
+  // decays.
+  useEffect(() => stopGlide, [stopGlide]);
+
+  const startGlide = useCallback(
+    (velocityPxPerMs: number) => {
+      stopGlide();
+      // REDUCED MOTION TAKES THE GLIDE, not the pan. The strip still goes
+      // exactly where it is dragged; it simply stops when the hand does, which
+      // is what someone asking for less motion is asking for.
+      if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true) return;
+      if (Math.abs(velocityPxPerMs) < GLIDE_MIN_LAUNCH_PX_PER_MS) return;
+      let velocity = velocityPxPerMs;
+      let previous = performance.now();
+      const step = (now: number) => {
+        const dt = Math.min(64, now - previous);
+        previous = now;
+        velocity *= GLIDE_DECAY_PER_MS ** dt;
+        if (Math.abs(velocity) < GLIDE_MIN_PX_PER_MS) {
+          glideRef.current = null;
+          return;
+        }
+        const before = offsetRef.current;
+        setOffset(before + velocity * dt);
+        // CLAMPED IS STOPPED. `setOffset` holds the pan inside its limits, so
+        // a glide that has run into one would otherwise spend its remaining
+        // speed asking for a position it cannot have — the strip sitting still
+        // while a loop insists it is moving.
+        if (Math.abs(offsetRef.current - before) < 0.01) {
+          glideRef.current = null;
+          return;
+        }
+        glideRef.current = requestAnimationFrame(step);
+      };
+      glideRef.current = requestAnimationFrame(step);
+    },
+    [setOffset, stopGlide],
+  );
+
   /** Local x within the track, which is the space every gesture works in. */
   const localX = useCallback((clientX: number) => {
     const element = trackRef.current;
@@ -424,6 +522,11 @@ export function SeamStripBar({
       // along a bench: the playhead stays where it is, nothing below changes,
       // and letting go commits to nothing. Clicking a box still chooses one,
       // which is the gesture that always meant "go here".
+      // CATCHING A GLIDING STRIP STOPS IT, exactly like putting a hand on
+      // moving film. Before the press records its origin, because that origin
+      // is `offsetRef` and a glide is still writing to it.
+      stopGlide();
+      samplesRef.current = [];
       pressRef.current = {
         pointerId: event.pointerId,
         x: event.clientX,
@@ -436,7 +539,7 @@ export function SeamStripBar({
       // hand — the same rule the wheel already follows.
       setFollowSuspended(true);
     },
-    [cancelHover],
+    [cancelHover, stopGlide],
   );
 
   const showHover = useCallback(
@@ -503,30 +606,71 @@ export function SeamStripBar({
     [cancelHover, clips, localX, strip],
   );
 
+  /**
+   * The RULER's move handler, and the only thing that raises the preview.
+   *
+   * Hovering used to be the lane's job, which meant the card appeared over the
+   * frames it was reporting on with the pointer sitting on them. It answers
+   * from the ruler now — the same x, since both are translated by the same
+   * offset, so the clip under the mark is the clip the card describes.
+   *
+   * DEAD WHILE A DRAG IS RUNNING. The lane captures the pointer on press, so
+   * moves during a scrub are delivered here only if the finger travels up over
+   * the ruler; showing a card mid-drag would put a picture over the film at
+   * exactly the moment the film is the thing being watched.
+   */
+  const onRulerMove = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (pressRef.current !== null) return;
+      showHover(event.clientX);
+    },
+    [showHover],
+  );
+
   const onPointerMove = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
       const press = pressRef.current;
-      if (press === null) {
-        showHover(event.clientX);
-        return;
-      }
+      // NO LONGER THE HOVER PATH. A move over the boxes with nothing pressed
+      // is now simply nothing — the ruler above answers that, see
+      // `onRulerMove`.
+      if (press === null) return;
       if (event.pointerId !== press.pointerId) return;
       if (Math.abs(event.clientX - press.x) > CLICK_SLOP_PX) press.moved = true;
+      // THE LAST FEW MILLISECONDS OF THE HAND, kept so the release knows how
+      // fast it was going. Trimmed to the window rather than accumulated: the
+      // launch speed is the end of the gesture, not its average.
+      const now = performance.now();
+      const samples = samplesRef.current;
+      samples.push({ x: event.clientX, t: now });
+      while (samples.length > 2 && now - samples[0]!.t > GLIDE_SAMPLE_MS) samples.shift();
       // THE FILM FOLLOWS THE HAND, ONE TO ONE. Measured from where the press
       // landed rather than accumulated per event, so the point of film under
       // the finger stays under it however long the drag runs — an accumulating
       // version drifts by whatever a dropped or coalesced move was worth.
       setOffset(press.offset + (event.clientX - press.x));
     },
-    [setOffset, showHover],
+    [setOffset],
   );
 
   const endPress = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
       const press = pressRef.current;
       pressRef.current = null;
+      const samples = samplesRef.current;
+      samplesRef.current = [];
       if (press === null) return;
       setPanning(false);
+      // LET GO OF A MOVING FILM AND IT KEEPS GOING. Measured across the
+      // window rather than between the final pair, so one stalled frame
+      // before release does not report a dead stop — see `GLIDE_SAMPLE_MS`.
+      // Only a drag glides: a click has no speed to carry and the branch
+      // below turns it into a choice of clip instead.
+      if (press.moved && samples.length >= 2) {
+        const first = samples[0]!;
+        const last = samples[samples.length - 1]!;
+        const elapsed = last.t - first.t;
+        if (elapsed > 0) startGlide((last.x - first.x) / elapsed);
+      }
       // A PRESS THAT DID NOT TRAVEL IS A CLICK, and a click on a box makes
       // that clip active. Distinguished by travel rather than by timing,
       // because a slow deliberate pan must not also count as a tap on whatever
@@ -542,7 +686,7 @@ export function SeamStripBar({
       const landedOn = stripPositionAt(strip, stripX)?.clipId ?? null;
       if (landedOn !== null && landedOn !== centreClipId) onCommitClip(landedOn);
     },
-    [centreClipId, localX, onCommitClip, strip],
+    [centreClipId, localX, onCommitClip, startGlide, strip],
   );
 
 
@@ -557,6 +701,10 @@ export function SeamStripBar({
     if (element === null) return;
     const onWheel = (event: WheelEvent) => {
       event.preventDefault();
+      // A WHEEL IS A NEW INSTRUCTION, so it takes over from a glide rather
+      // than adding to one — otherwise the strip is being moved by two things
+      // at once and lands where neither asked.
+      stopGlide();
       setFollowSuspended(true);
       cancelHover();
       setWheeling(true);
@@ -585,7 +733,7 @@ export function SeamStripBar({
     };
     element.addEventListener("wheel", onWheel, { passive: false });
     return () => element.removeEventListener("wheel", onWheel);
-  }, [cancelHover, setOffset]);
+  }, [cancelHover, setOffset, stopGlide]);
 
   // ── KEEPING THE PLAYHEAD IN VIEW ─────────────────────────────────────────
   //
@@ -753,6 +901,21 @@ export function SeamStripBar({
         // nothing under it stops being clickable.
         className="relative z-30 flex-1 outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
       >
+        {/* THE SCALE, ABOVE THE FILM IT MEASURES — and the hover target.
+            See `graph-seam-ruler` for both: a ruler belongs against what it
+            measures, and a preview card belongs somewhere other than on top
+            of the frames it is reporting on. */}
+        <SeamRuler
+          ticks={ticks}
+          offset={offset}
+          // The same x the lane's ghost uses, so the two are one line. Dropped
+          // while panning for the same reason the lane drops its card: the bar
+          // is moving under the pointer, and a mark claiming to be "here" is
+          // the one thing that is not true mid-drag.
+          ghostX={hover === null || panning ? null : hover.x}
+          handlers={{ onPointerMove: onRulerMove, onPointerLeave: cancelHover }}
+        />
+
         <SeamLane
           laneRef={laneRef}
           strip={strip}
@@ -771,7 +934,6 @@ export function SeamStripBar({
             onPointerMove,
             onPointerUp: endPress,
             onPointerCancel: endPress,
-            onPointerLeave: cancelHover,
           }}
         />
 
@@ -779,20 +941,25 @@ export function SeamStripBar({
             edges, and a hard edge is indistinguishable from an end — these say
             which of the two you are looking at, and disappear when there is
             nothing beyond. */}
+        {/* THERE IS MORE THAT WAY, over the FILM only.
+            Offset by the ruler's height rather than pinned to the track's top:
+            the strip no longer starts there, and a fade left at `top-0` would
+            wash out the row of labels instead of the frames. One number, from
+            the ruler itself, so the two cannot drift. */}
         <span
           aria-hidden="true"
           data-seam-fade="left"
           hidden={offset >= -0.5}
-          className="pointer-events-none absolute top-0 left-0 h-9 w-6 bg-gradient-to-r from-zinc-950 to-transparent"
+          style={{ top: SEAM_RULER_HEIGHT_PX }}
+          className="pointer-events-none absolute left-0 h-9 w-6 bg-gradient-to-r from-zinc-950 to-transparent"
         />
         <span
           aria-hidden="true"
           data-seam-fade="right"
           hidden={strip.totalPx + offset <= trackWidth + 0.5}
-          className="pointer-events-none absolute top-0 right-0 h-9 w-6 bg-gradient-to-l from-zinc-950 to-transparent"
+          style={{ top: SEAM_RULER_HEIGHT_PX }}
+          className="pointer-events-none absolute right-0 h-9 w-6 bg-gradient-to-l from-zinc-950 to-transparent"
         />
-
-        <SeamRuler ticks={ticks} offset={offset} />
       </div>
 
       {/* THE WHOLE PROJECT, DIRECTLY UNDER THE FILM STRIP.
@@ -867,10 +1034,13 @@ export function SeamStripBar({
             stay there when a setting changes width. */}
         <div
           data-seam-transport
-          // DROPPED CLEAR OF THE BARS ABOVE. `mt-5` is 20px, on the assembly
+          // DROPPED CLEAR OF THE BARS ABOVE. `mt-9` is 36px, on the assembly
           // rather than on the row: the badges either side keep sitting where
           // the ruler leaves them, and only the transport takes the air.
-          className="mt-5 flex items-center gap-1.5 rounded-full border border-zinc-700/80 bg-zinc-900/70 p-1.5"
+          //
+          // Landed at 20 first and went to 36. Whatever this number becomes,
+          // the scrim's top padding owes it TWICE over — see the note there.
+          className="mt-9 flex items-center gap-1.5 rounded-full border border-zinc-700/80 bg-zinc-900/70 p-1.5"
         >
           {/* STEP ONE CLIP, either way, bracketing the thing they move.
               Disabled rather than hidden at the ends: a control that vanishes


### PR DESCRIPTION
Six changes to the details bar, all from looking at it this afternoon.

## The ruler

**Above the film strip**, not under it. It sat on the far side of the thing it measures — reading "is that box two seconds or twenty" meant crossing the whole strip to find out. The block now reads top-down: scale, film, then the map of where the film is. Tick marks hang from the bottom edge where they meet the boxes, labels above; upside down they'd point away from the film and label the air.

**Its numbers can be read.** They were `text-zinc-600` at 9px — grey on near-black at a size where the strokes are one pixel, legible only by being where numbers were expected. Now 10px / `zinc-400`, with collection names brighter at `zinc-200`: they're the landmark, the numbers are the grid they sit on.

**And it's the hover target.** The card used to be raised by pointing at the boxes, so it appeared over the frames it was reporting on with the pointer resting on them. The ruler is the margin beside the text. The strip keeps every gesture that *moves* it — press to pan, drag to scrub, click to choose.

**A ghost line under the pointer**, in the ruler as well as the film. Pointing at the scale gave no sign the scale was what you were pointing *at*. Same ink, same x, so the two are one continuous line — verified: ruler ghost and lane ghost both at x=635, 20px + 36px.

## The preview card no longer jumps

Its poster is a bare `<img>` with `h-auto` and no intrinsic size, so before the bytes arrive the card lays out at the height of its two lines of text and then roughly triples. "Appears in the wrong place then corrects itself" is a **resize, not a reposition** — with the entrance animation already running under it.

Nothing can reserve the box: the card deliberately takes the poster's own shape rather than forcing a ratio (an aspect-ratio guess would fix the flash by reintroducing the crop that decision exists to prevent). So it waits — mounted and laid out throughout, so the fetch is running and the size is final, with only the *paint* held, and only on the way in. Gating later frames would make it blink every quarter-second of travel.

Readiness moved into a new `SeamPreviewCard`. In the lane it needed an effect to clear the flag per appearance — a synchronous setState inside an effect, which **eslint fails the build over**. Mounting is the reset.

## The trim strip fills its box

Its width is a *number*, measured from the slot, and it was read **once on mount and never again** — while every width a panel actually has arrives later: the same element is a neighbour one moment and the centre the next as the strip advances, the centre is deliberately wider, and the view count changes both.

A `ResizeObserver` replaces the one-shot ref callback, skipping the setState when the number hasn't moved (#468's finding). Measured before the fix on the five-up story: **581px of film inside a 357px slot**. Regression-proved — the new assertion fails at 63px without it.

## The film strip has inertia

It stopped dead on release, which is fine for a short pull and wrong for a long one — crossing a four-minute cut was a row of separate drags, each re-grabbing film that was already still.

Measured: a 200px drag now glides a further **891px**, `-597 → -740 → -965 → -1184 → -1397 → -1488` over 1.2s.

- Decay is per **millisecond**, not per frame, so the curve is identical on 60Hz and 120Hz — the usual way this is got wrong.
- Launch speed is measured across ~70ms, not between the final two events, so one stalled frame before release doesn't report a dead stop.
- Only a *throw* glides. A pan that's placed ends slow, and carrying it past where it was put would be the strip disagreeing with the hand.
- A press, a wheel, or unmount stops it. Reduced motion takes the glide and leaves the pan.

## Coverage

The three hover stories point at the ruler now — the honest consequence of moving the target, not a workaround — and one asserts both halves of the ghost line.

## Checks

- `tsc --noEmit` clean; `eslint` **0 errors**
- app `vitest` — **1446/1446** (112 files)
- `graph-item-details-modal.stories.tsx` — **44/44**

🤖 Generated with [Claude Code](https://claude.com/claude-code)