### PR TITLE
The map marks the subject, and a step slides instead of cutting

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-details-motion.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-details-motion.ts
@@ -1,0 +1,71 @@
+// ONE PRESS, ONE MOTION.
+//
+// Stepping the details view moves three things at once: the row of panels
+// slides, the outgoing centre narrows while the incoming one widens, and the
+// film strip above travels to bring the new subject into view.
+//
+// They were on four clocks — 300ms for the panel widths, 300ms for the row,
+// 520ms for the strip, 200ms for the panel chrome — and every one of them on
+// a plain `ease-out`. That is what made the transition read as amateur, and
+// neither half of it is a bug: nothing was janky and nothing was wrong. It
+// simply looked like four things reacting to the same press rather than one
+// thing happening.
+//
+// ── WHY ONE DURATION AND NOT FOUR SCALED ONES ───────────────────────────────
+//
+// The obvious alternative is to keep the strip longer because it travels much
+// further — around 986px against the row's ~350. But a duration is not a
+// speed: giving the far-travelling element more time is how you make it move
+// at the same PACE as the near one, and pace is not what the eye reads here.
+// What it reads is whether the press produced one event or several, and
+// several things settling 220ms apart is the answer "several" no matter how
+// well each one is tuned. One duration, different distances, therefore
+// different speeds — which is what actually happens when one gesture moves a
+// near thing and a far thing.
+//
+// ── THE CURVE ───────────────────────────────────────────────────────────────
+//
+// `ease-out` is the curve you get for free, and it looks it: a soft start and
+// a long lazy tail that never quite commits. This is an emphasized
+// decelerate — it leaves hard, covers most of the distance in the first third,
+// and spends the rest settling. Motion that commits early and settles slowly
+// reads as weight; motion that eases evenly reads as a tween.
+//
+// It is deliberately NOT a spring or an overshoot. These panels are frames of
+// film with pictures in them, and a picture that bounces past its mark and
+// comes back says the software is pleased with itself. The confidence is in
+// the departure, not in the arrival.
+const DETAILS_STEP_EASE = "cubic-bezier(0.32, 0.72, 0, 1)";
+
+/**
+ * How long a step takes, everywhere it is visible.
+ *
+ * Longer than the 300ms it replaces, which is the counter-intuitive half:
+ * quick reads as cheap here because the distance is large and the curve does
+ * most of its work early — at 300ms the settle is over before the eye has
+ * followed it, so the motion registers as a jump that happened to be animated.
+ * 420ms with this curve is still well inside "immediate" and leaves room for
+ * the deceleration to be seen, which is the part that reads as considered.
+ */
+export const DETAILS_STEP_MS = 420;
+
+/** The step's easing, as a CSS value. */
+export const DETAILS_STEP_EASING = DETAILS_STEP_EASE;
+
+/** `transition` shorthand for a property that moves with a step. */
+export function detailsStepTransition(properties: string): string {
+  return properties
+    .split(",")
+    .map((property) => `${property.trim()} ${DETAILS_STEP_MS}ms ${DETAILS_STEP_EASE}`)
+    .join(", ");
+}
+
+/**
+ * The chrome's own timing — a ring brightening, a shadow lifting.
+ *
+ * Deliberately SHORTER and on the same curve. These do not travel, so matching
+ * the step's duration would leave a border still resolving long after the thing
+ * it borders had arrived. Half the step, so it lands inside it rather than
+ * alongside it.
+ */
+export const DETAILS_CHROME_MS = 210;

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -2477,23 +2477,76 @@ export const TheBarSlidesIntoPositionOnAMove: Story = {
     // stays where it was put — so asserting on the first press would assert
     // against a bar that correctly did nothing.
     let travelled = false;
+    let clocks: readonly Readonly<{ duration: string; easing: string }>[] = [];
     for (let attempt = 0; attempt < 12 && !travelled; attempt++) {
       const before = stripX();
       const wasOn = subject();
       forward.click();
       await waitFor(() => expect(subject()).not.toBe(wasOn));
       // Read the easing while the transition is still on the node: the effect
-      // clears it once the slide is over.
+      // clears it once the slide is over, so everything about the motion has
+      // to be sampled MID-FLIGHT. That is also why the agreement below is
+      // measured here rather than after `settleStrip` — at rest the strip
+      // genuinely carries no transition at all, and three things that are not
+      // moving agree about nothing.
       await new Promise((resolve) => setTimeout(resolve, 30));
       const easing = strip().style.transition;
+      const inFlight = [
+        getComputedStyle(strip()),
+        getComputedStyle(document.querySelector<HTMLElement>("[data-details-strip]")!),
+        getComputedStyle(
+          document.querySelector<HTMLElement>('[data-item-details-panel="centre"]')!
+            .parentElement!,
+        ),
+      ].map((style) => ({
+        duration: style.transitionDuration,
+        easing: style.transitionTimingFunction,
+      }));
       await settleStrip();
       if (Math.abs(stripX() - before) > 20) {
         travelled = true;
         expect(easing).toContain("transform");
+        clocks = inFlight;
       }
     }
     // The loop proving nothing would be the quiet failure here.
     expect(travelled).toBe(true);
+
+    // ── ONE PRESS, ONE MOTION ────────────────────────────────────────────
+    //
+    // The three things a step moves — the film strip, the row of panels, and
+    // the width the centre grows to — ran on 520ms, 300ms and 300ms, every
+    // one of them on a plain `ease-out`. Nothing was janky and nothing was
+    // wrong; it simply looked like three things reacting to the same press
+    // rather than one thing happening, which is most of what reads as amateur
+    // in a transition.
+    //
+    // Asserted as AGREEMENT rather than against the numbers, so retuning the
+    // step is one edit in `graph-details-motion` and not a story to update —
+    // what must not drift is that they are the same.
+    expect(clocks.length).toBe(3);
+    // EVERY ONE OF THEM ON A CURVE SOMEBODY CHOSE. `ease-out` is what a
+    // transition gets for free and is what all three carried before; a named
+    // cubic-bezier is the thing that cannot happen by default.
+    for (const clock of clocks) {
+      expect(clock.easing).toContain("cubic-bezier");
+    }
+
+    // THE SHARED 420ms IS NOT ASSERTED HERE, deliberately, and the reason is
+    // worth writing down rather than leaving as a gap.
+    //
+    // Driven from the browser the three agree exactly — `0.42s`, `0.42s,
+    // 0.42s` and `0.42s`, on one curve. Sampled from this story they do not
+    // reliably: what is mid-flight at the instant after `waitFor` resolves
+    // depends on how long the poll took, and a transition that has finished
+    // reports its resting value rather than its animating one. An assertion
+    // that fails on polling latency is worse than none — it teaches people to
+    // re-run the suite.
+    //
+    // The curve above is the durable half and the one that actually regressed:
+    // durations drifting apart is a number to notice in review, where four
+    // things silently on `ease-out` is not. The clock lives in one place
+    // (`graph-details-motion`) so there is a single value to read.
   },
 };
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -1805,6 +1805,39 @@ export const TheMinimapMovesTheWindow: Story = {
     reachTo("10");
     await waitFor(() => expect(segments()).toBe(21));
 
+    // AND THE SUBJECT IS MARKED HERE TOO, on exactly one segment and on the
+    // same clip the bar marks. The two strips answer different questions —
+    // which shot, and where in the project that shot is — and the subject is
+    // the fact they share; marked on only one of them the map showed a window
+    // a dozen clips wide and left you to work out which was yours.
+    const live = document.querySelectorAll("[data-seam-mini-segment-live]");
+    expect(live.length).toBe(1);
+    expect(live[0]!.getAttribute("data-seam-mini-segment")).toBe(
+      centreBox().getAttribute("data-seam-segment"),
+    );
+    // WHITE, AT FULL STRENGTH, AND A LITTLE TALLER. Colour rather than an
+    // edge, because a segment here can be one pixel wide: a border would eat
+    // into a width that means duration, and an outline around a one-pixel clip
+    // stands in for the thing rather than marking it.
+    const marked = getComputedStyle(live[0]!);
+    expect(Number(marked.opacity)).toBe(1);
+    const ink = marked.backgroundColor.match(/[\d.]+/g)!.slice(0, 3).map(Number);
+    expect(Math.min(...ink)).toBeGreaterThan(200);
+
+    // Taller than its neighbours, and on the SAME CENTRE LINE — grown both
+    // ways rather than hanging off the bottom of the run.
+    const others = Array.from(
+      document.querySelectorAll<HTMLElement>("[data-seam-mini-segment]"),
+    ).filter((segment) => !segment.hasAttribute("data-seam-mini-segment-live"));
+    const markedBox = live[0]!.getBoundingClientRect();
+    const plainBox = others[0]!.getBoundingClientRect();
+    expect(markedBox.height).toBeGreaterThan(plainBox.height);
+    expect(
+      Math.abs(
+        (markedBox.top + markedBox.height / 2) - (plainBox.top + plainBox.height / 2),
+      ),
+    ).toBeLessThan(0.6);
+
     // The window is a PART of it, not all of it: if it covered the whole
     // minimap there would be nothing off the sides and nothing to say.
     const map = minimap.getBoundingClientRect();
@@ -2414,6 +2447,53 @@ export const TheBarSlidesIntoPositionOnAMove: Story = {
     // a wobble.
     await settleStrip();
     expect(Math.abs(stripX() - from)).toBeGreaterThan(20);
+
+    // ── AND THE SAME IS TRUE OF THE STEP BUTTONS ─────────────────────────
+    //
+    // A different path to the same move, and the one that was broken: a click
+    // on a box commits the clip and the travel together, while a STEP changes
+    // the subject and only then decides whether the bar has to follow. Those
+    // are separate commits, so the slide had nothing to interpolate on the
+    // first and no move left to claim on the second — the strip cut 986px with
+    // no transition property set at all.
+    //
+    // Everything above passed throughout, which is why this is here: the story
+    // covered the path that worked.
+    //
+    // AND THIS IS COVERAGE, NOT A REGRESSION GUARD — said plainly because the
+    // difference matters. Reverting the fix and re-running this leaves it
+    // GREEN: whether the subject change and the nudge land in one commit or
+    // two is React's scheduling, and under the story runner they arrive
+    // together, which is exactly the case the old code handled. The split is
+    // real in the app and was measured there — 986px with no transition
+    // property at all, against `transform 520ms ease-out` after. What follows
+    // asserts the step path eases at all, which nothing did before.
+    const strip = () => document.querySelector<HTMLElement>("[data-seam-strip]")!;
+    const forward = document.querySelector<HTMLElement>('[data-seam-step="forward"]')!;
+    expect(forward).not.toBeNull();
+
+    // STEP UNTIL THE BAR ACTUALLY HAS TO TRAVEL. Most steps move nothing —
+    // the next clip is usually already on screen and the bar deliberately
+    // stays where it was put — so asserting on the first press would assert
+    // against a bar that correctly did nothing.
+    let travelled = false;
+    for (let attempt = 0; attempt < 12 && !travelled; attempt++) {
+      const before = stripX();
+      const wasOn = subject();
+      forward.click();
+      await waitFor(() => expect(subject()).not.toBe(wasOn));
+      // Read the easing while the transition is still on the node: the effect
+      // clears it once the slide is over.
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      const easing = strip().style.transition;
+      await settleStrip();
+      if (Math.abs(stripX() - before) > 20) {
+        travelled = true;
+        expect(easing).toContain("transform");
+      }
+    }
+    // The loop proving nothing would be the quiet failure here.
+    expect(travelled).toBe(true);
   },
 };
 
@@ -2534,7 +2614,15 @@ export const TheBarIsGreyUntilTheTintIsSwitchedOn: Story = {
     // ONE colour across two collections, on both rows.
     const boxColours = colours("[data-seam-segment]");
     expect(boxColours.size).toBe(1);
-    const miniColours = colours("[data-seam-mini-segment]");
+    // THE SUBJECT IS EXCLUDED, and only it. The map marks the active clip
+    // white, which is a claim about WHICH CLIP rather than which collection —
+    // the flag withholds the second and has nothing to say about the first.
+    // Scoped with `:not()` rather than by filtering afterwards so a mark that
+    // silently stopped being applied would take the exclusion with it and
+    // leave this asserting over everything again.
+    const miniColours = colours(
+      "[data-seam-mini-segment]:not([data-seam-mini-segment-live])",
+    );
     expect(miniColours.size).toBe(1);
     // And the SAME one, so the strip and the map read as one object.
     expect([...miniColours]).toEqual([...boxColours]);

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -32,6 +32,7 @@ import { TagEditor } from "./graph-tag-editor";
 import { CollectionDetailsBody } from "./graph-collection-details";
 import { ItemDisableToggle } from "./graph-item-disable-toggle";
 import { useItemDetails } from "./graph-item-details-context";
+import { detailsStepTransition } from "./graph-details-motion";
 import { withViewTransition } from "@/lib/view-transition";
 import { detailsWindow, flatOrderRootId } from "./graph-details-neighbours";
 import { useSeamTransport } from "./graph-seam-bar";
@@ -1167,7 +1168,7 @@ function DetailsFilmstripModal({
           // A BAR LANDING has no transition at all, which the layout effect
           // above does to the node rather than from here.
           dragPx === 0
-            ? "transition-[transform,opacity] ease-out motion-reduce:transition-none"
+            ? "transition-[transform,opacity] motion-reduce:transition-none"
             : "",
           // BACK, WHILE THE PREVIEW IS UP.
           //
@@ -1186,7 +1187,9 @@ function DetailsFilmstripModal({
         style={{
           gap: PANEL_GAP,
           transform: rowTransform,
-          transitionDuration: "300ms",
+          // THE STEP'S OWN TIMING, shared with the panel widths and the film
+          // strip — see . One press, one motion.
+          transition: dragPx === 0 ? detailsStepTransition("transform, opacity") : undefined,
         }}
       >
         {ids.map((id, index) => {

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -875,10 +875,13 @@ function DetailsFilmstripModal({
       // added 20 for 20 and recovered half the slack (2 → 12, still short of
       // the 16 floor).
       //
-      // So the arithmetic is 224 + 2 × margin: 20px of margin took this to
-      // 16.5rem, and 36px takes it to 18.5rem (224 + 72 = 296). Move the
-      // transport again and this moves by twice as much, in the same
-      // direction.
+      // So the arithmetic is 224 + 2 × (whatever the block grew by): 20px of
+      // transport margin took this to 16.5rem, 36px to 18.5rem (224 + 72 =
+      // 296), and the film strip growing from 36px to 48px takes it to 20rem
+      // (296 + 24 = 320). Anything that makes the bar taller moves this by
+      // twice as much, in the same direction — and the failure is always the
+      // same one, `TheTwoBarsAreAdjacent` reporting the gap to the centre card
+      // collapsing below its floor.
       // `overflow-clip`, NOT `overflow-hidden`. Both crop, but `hidden` makes
       // this a SCROLL CONTAINER — and the row is thirteen thousand pixels
       // wide, so there is a great deal for it to scroll. Landing on a new clip
@@ -888,7 +891,7 @@ function DetailsFilmstripModal({
       // row that had itself moved 1728px, which put the card just chosen
       // entirely off the left edge. `clip` crops without ever being
       // scrollable, so the transform stays the only thing that moves the row.
-      className="fixed inset-0 z-[80] flex items-center justify-center overflow-clip bg-black/80 px-6 pt-[18.5rem] pb-6 backdrop-blur-sm"
+      className="fixed inset-0 z-[80] flex items-center justify-center overflow-clip bg-black/80 px-6 pt-[20rem] pb-6 backdrop-blur-sm"
       // THE SCRIM DOES NOT DISMISS. Deliberate: this view is worked in, not
       // glanced at — trimming, scrubbing and swiping all end with the pointer
       // somewhere unpredictable, and the panels are cropped by the scrim

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
@@ -13,6 +13,7 @@ import {
 } from "@storyboard/ui/dnd-collections";
 
 import { DETAILS_PANEL_HEIGHT_CLASS } from "./graph-view-config";
+import { DETAILS_CHROME_MS, detailsStepTransition } from "./graph-details-motion";
 import { useDialogFocus } from "@/hooks/use-dialog-focus";
 import { formatSeconds } from "@/lib/format-duration";
 import { useInlineRename } from "./graph-inline-rename";
@@ -345,11 +346,18 @@ export function DetailsPanel({
           // change back into motion, and would leave its edges drifting for
           // 300ms after a gesture whose whole claim is that it arrives
           // instantly.
-          swapping
-            ? "transition-none"
-            : "transition-[width] duration-300 ease-out motion-reduce:transition-none",
+          swapping ? "transition-none" : "motion-reduce:transition-none",
         ].join(" ")}
-        style={{ width, ...(spare ? { visibility: "hidden" as const } : {}) }}
+        style={{
+          width,
+          // THE STEP'S OWN TIMING, shared with the row and the film strip
+          // above — see `graph-details-motion`. Written as a style rather than
+          // a `duration-*`/`ease-*` pair so the curve is the one value all
+          // three read, instead of a cubic-bezier copied into three class
+          // strings and drifting from two of them.
+          ...(swapping ? {} : { transition: detailsStepTransition("width") }),
+          ...(spare ? { visibility: "hidden" as const } : {}),
+        }}
       >
       <div
         // FOCUS WIRING ON THE CENTRE ONLY. Every panel is fully live — the
@@ -377,6 +385,8 @@ export function DetailsPanel({
           // bigger and leaves the geometry alone — the row still knows exactly
           // where everything is.
           transform: magnification > 1 ? `scale(${magnification})` : undefined,
+          // See the class above: the curve is a utility, the clock is here.
+          transitionDuration: `${DETAILS_CHROME_MS}ms`,
           zIndex: magnification > 1 ? 20 : undefined,
         }}
         data-item-details-live={onScreen ? "" : undefined}
@@ -434,7 +444,13 @@ export function DetailsPanel({
           // large monitor have more room each than three on an iPad, and a
           // rule counting panels gets that backwards.
           "relative flex w-full flex-col gap-2 rounded-lg bg-zinc-950 p-4 focus-visible:outline-none",
-          "transition-[box-shadow,border-color,transform] duration-200 ease-out motion-reduce:transition-none",
+          // THE CHROME, on the step's curve but half its clock. A ring and a
+          // shadow do not travel, so matching the step's duration would leave
+          // a border still resolving after the panel it borders had arrived —
+          // it lands INSIDE the motion rather than alongside it. The duration
+          // is set in the style below, because Tailwind's default is 150ms and
+          // a bare `ease-*` would silently take it.
+          "transition-[box-shadow,border-color,transform] ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
           // EVERY PANEL WEARS THE SAME BORDER, including the one you opened.
           //
           // It carried a heavier white one for a while, on the reasoning that

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 
 import { BAR_NEUTRAL_COLOUR } from "@/lib/bar-collection-colours-flag";
 
+import { DETAILS_STEP_MS, detailsStepTransition } from "./graph-details-motion";
 import { collectionSeams, type SeamBarClip } from "./graph-seam-bar-layout";
 import {
   usePlaybarThumbnails,
@@ -20,7 +21,7 @@ import type { PreviewAnchor } from "./graph-seam-preview-anchor";
  * pictures — the whole reason to animate this is that the bar re-centres on
  * somewhere else and a jump cannot be told apart from a redraw.
  */
-const SEAM_SLIDE_MS = 520;
+const SEAM_SLIDE_MS = DETAILS_STEP_MS;
 
 /**
  * How long a change of subject stays claimable by the travel that follows it.
@@ -452,7 +453,7 @@ export function SeamLane({
     node.style.transition = "none";
     node.style.transform = `translateX(${previous}px)`;
     void node.offsetWidth;
-    node.style.transition = `transform ${SEAM_SLIDE_MS}ms ease-out`;
+    node.style.transition = detailsStepTransition("transform");
     node.style.transform = `translateX(${offset}px)`;
 
     // Only the easing is cleared at the end. The transform is left exactly

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -83,8 +83,34 @@ function SeamEndCap({ side, atPx }: Readonly<{ side: "start" | "end"; atPx: numb
 }
 
 
-/** Roughly the bar's own height (`h-9`), so a cell reads as a square. */
-const FILMSTRIP_CELL_PX = 36;
+/**
+ * HOW TALL THE FILM IS.
+ *
+ * 36px for a long time, which made the frames inside it 30 — small enough
+ * that a thumbnail told you a shot was dark or bright and very little else,
+ * and the strip is the one place you are meant to recognise a shot by looking
+ * at it. 48 puts the pictures at 42, which is where a face in a medium shot
+ * stops being a smudge.
+ *
+ * ONE NUMBER, because four things are measured from it: the lane itself, the
+ * fades over its ends, the filmstrip cell size that keeps a cell square, and
+ * the hover card's offset below it. They were four literals, and a bar that
+ * grew while its fades did not is a gradient floating in the middle of the
+ * film.
+ */
+export const SEAM_LANE_HEIGHT_PX = 48;
+
+/**
+ * How far below the film the hover card hangs.
+ *
+ * Measured from the lane's BOTTOM rather than written as one offset from its
+ * top, so the card keeps its distance when the film changes height instead of
+ * climbing into it.
+ */
+export const SEAM_PREVIEW_GAP_PX = 20;
+
+/** One cell per bar-height, so a filmstrip cell reads as a square. */
+const FILMSTRIP_CELL_PX = SEAM_LANE_HEIGHT_PX;
 /** Past this the cells stretch rather than multiply — see `SegmentFrames`. */
 const MAX_FILMSTRIP_CELLS = 12;
 
@@ -490,7 +516,8 @@ export function SeamLane({
       // have to escape it: a time chip drawn INSIDE the boxes covers the frames
       // it is reporting on, which is the one thing you are looking at while you
       // drag.
-      className="relative h-9 cursor-ew-resize touch-none select-none"
+      style={{ height: SEAM_LANE_HEIGHT_PX }}
+      className="relative cursor-ew-resize touch-none select-none"
     >
       <div className="absolute inset-0 overflow-hidden">
         <div
@@ -861,6 +888,7 @@ function SeamPreviewCard({
       // block, which IS the track, so the bound follows a resize with no
       // observer and no re-render. 9rem is half the card.
       style={{
+        top: SEAM_LANE_HEIGHT_PX + SEAM_PREVIEW_GAP_PX,
         left:
           previewAnchor === "pinned"
             ? "50%"
@@ -910,7 +938,7 @@ function SeamPreviewCard({
       // The entrance animation is withheld with it. Left running it would
       // play out against a card nobody can see and arrive already over.
       className={[
-        "pointer-events-none absolute top-14 z-20 flex w-96 -translate-x-1/2 flex-col gap-1.5 rounded-lg border border-zinc-600 bg-zinc-950/98 p-2 shadow-2xl ring-1 ring-black/50",
+        "pointer-events-none absolute z-20 flex w-96 -translate-x-1/2 flex-col gap-1.5 rounded-lg border border-zinc-600 bg-zinc-950/98 p-2 shadow-2xl ring-1 ring-black/50",
         hover.posterSrc === undefined || posterReady
           ? "animate-seam-preview-in visible"
           : "invisible",

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -22,6 +22,17 @@ import type { PreviewAnchor } from "./graph-seam-preview-anchor";
  */
 const SEAM_SLIDE_MS = 520;
 
+/**
+ * How long a change of subject stays claimable by the travel that follows it.
+ *
+ * The step and the nudge it causes are separate commits, so the slide has to
+ * survive the gap between them — see the effect below. Bounded so an unspent
+ * intent cannot be picked up by a later gesture: a wheel pan or a drag must
+ * track the hand exactly, and easing one because a step happened a few seconds
+ * ago is the lag every other path here is careful to avoid.
+ */
+const SEAM_MOVE_CLAIM_MS = 120;
+
 /** How wide the end-of-project stop is. Wider than the hairline between two
  *  boxes, so it is read as an edge rather than as another gap. */
 const CAP_WIDTH_PX = 6;
@@ -397,13 +408,39 @@ export function SeamLane({
   const stripRef = useRef<HTMLDivElement | null>(null);
   const centreWasRef = useRef(centreClipId);
   const offsetWasRef = useRef(offset);
+  /** When the subject last changed, so the nudge that follows can claim it. */
+  const movedAtRef = useRef(0);
   useLayoutEffect(() => {
     const node = stripRef.current;
-    const moved = centreWasRef.current !== centreClipId;
+    // THE MOVE AND THE TRAVEL ARRIVE IN DIFFERENT RENDERS, which is why this
+    // used to animate nothing.
+    //
+    // A step changes the subject; the bar then decides whether that subject is
+    // off the side and, if it is, nudges the strip to bring it in. Those are
+    // two state changes and React commits them separately, so this effect ran
+    // twice: once with the new `centreClipId` and the OLD offset — nothing to
+    // interpolate, so it returned, having already recorded the new centre —
+    // and again with the new offset and `moved` now false. Both runs bailed
+    // and the strip cut.
+    //
+    // Measured on a 21-clip scene: a step moved the strip 986px with no
+    // transition property set at all.
+    //
+    // So the move is REMEMBERED rather than consumed, and spent on whichever
+    // render actually brings the travel with it. Time-bounded, because a step
+    // that needs no nudge leaves the intent unspent — and without a bound the
+    // next wheel pan, seconds later, would inherit it and ease when it must
+    // track the hand exactly. A nudge follows its step within a render or two;
+    // 120ms is generous for that and far short of a separate gesture.
+    if (centreWasRef.current !== centreClipId) {
+      centreWasRef.current = centreClipId;
+      movedAtRef.current = performance.now();
+    }
     const previous = offsetWasRef.current;
-    centreWasRef.current = centreClipId;
     offsetWasRef.current = offset;
-    if (!moved || node === null || previous === offset) return;
+    if (node === null || previous === offset) return;
+    if (performance.now() - movedAtRef.current > SEAM_MOVE_CLAIM_MS) return;
+    movedAtRef.current = 0;
 
     // PUT IT BACK, THEN LET IT GO. A transition cannot be added to a value
     // that has ALREADY changed: by the time a layout effect runs, React has

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-minimap.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-minimap.tsx
@@ -28,6 +28,7 @@ import { collectionSeams, type SeamBarClip } from "./graph-seam-bar-layout";
 export function SeamMinimap({
   clips,
   colourOf,
+  centreClipId,
   totalSeconds,
   windowFromSeconds,
   windowToSeconds,
@@ -37,6 +38,17 @@ export function SeamMinimap({
 }: Readonly<{
   clips: readonly SeamBarClip[];
   colourOf: ReadonlyMap<string, string>;
+  /**
+   * The clip the middle panel is on — marked here as well as on the bar.
+   *
+   * The two strips answer different questions and the subject is the one fact
+   * they share: the bar says which shot you are on, and this says WHERE in the
+   * project that shot is. Marked on only one of them, the second question went
+   * unanswered — the map showed the window's position, which at most zooms is
+   * a stretch of a dozen clips, and left you to work out which of them was
+   * yours.
+   */
+  centreClipId: string;
   totalSeconds: number;
   /** The span the bar above is showing, in absolute seconds. */
   windowFromSeconds: number;
@@ -119,18 +131,46 @@ export function SeamMinimap({
       <div className="absolute inset-x-0 top-1 flex h-1.5 gap-px">
         {clips.map((clip, index) => {
           if (clip.showingSeconds <= 0) return null;
+          const isCentre = clip.id === centreClipId;
           return (
             <span
               key={clip.id}
               data-seam-mini-segment={clip.id}
+              data-seam-mini-segment-live={isCentre ? "" : undefined}
               style={{
                 flexGrow: clip.showingSeconds,
-                backgroundColor: colourOf.get(clip.id) ?? BAR_NEUTRAL_COLOUR,
+                // THE SUBJECT IS WHITE, and that is the whole mark.
+                //
+                // COLOUR RATHER THAN AN EDGE, because a segment here can be a
+                // single pixel wide: a border eats into a width that means
+                // duration, and an outline around a one-pixel clip is a ring
+                // standing in for the thing rather than marking it. Changing
+                // what the pixel IS works at every width.
+                //
+                // White because that is what the bar above marks its active
+                // clip with — the triangle and its rule. The same claim in the
+                // same ink, said twice at two scales, rather than a second
+                // colour to learn.
+                backgroundColor: isCentre
+                  ? "rgb(250, 250, 250)"
+                  : (colourOf.get(clip.id) ?? BAR_NEUTRAL_COLOUR),
                 // A real gap where the collection changes, so the runs read
                 // as runs at a scale far too small for a label.
                 marginLeft: index > 0 && seams.has(index) ? 3 : undefined,
               }}
-              className="min-w-px flex-shrink rounded-[1px] opacity-70"
+              className={[
+                "min-w-px flex-shrink rounded-[1px]",
+                // Full strength as well, so the white is white rather than a
+                // 70% wash of it against the dimmed run either side.
+                //
+                // AND SLIGHTLY TALLER. `-my-px` rather than a height, so it
+                // grows a pixel BOTH WAYS and stays on the same centre line as
+                // the run it sits in — a segment that only grew downward would
+                // read as hanging off the strip rather than as the one raised
+                // out of it. 6px to 8px inside a 14px rail, so it has the room
+                // and nothing clips.
+                isCentre ? "-my-px opacity-100" : "opacity-70",
+              ].join(" ")}
             />
           );
         })}

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -974,6 +974,7 @@ export function SeamStripBar({
       <SeamMinimap
         clips={clips}
         colourOf={boxColourOf}
+        centreClipId={centreClipId}
         totalSeconds={totalSeconds}
         windowFromSeconds={windowFromSeconds}
         windowToSeconds={windowToSeconds}

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -15,7 +15,7 @@ import {
   zoomByWheel,
   type SeamBarClip,
 } from "./graph-seam-bar-layout";
-import { SeamLane, type SeamHover } from "./graph-seam-lane";
+import { SEAM_LANE_HEIGHT_PX, SeamLane, type SeamHover } from "./graph-seam-lane";
 import { SeamMinimap } from "./graph-seam-minimap";
 import { SEAM_RULER_HEIGHT_PX, SeamRuler } from "./graph-seam-ruler";
 import {
@@ -950,15 +950,15 @@ export function SeamStripBar({
           aria-hidden="true"
           data-seam-fade="left"
           hidden={offset >= -0.5}
-          style={{ top: SEAM_RULER_HEIGHT_PX }}
-          className="pointer-events-none absolute left-0 h-9 w-6 bg-gradient-to-r from-zinc-950 to-transparent"
+          style={{ top: SEAM_RULER_HEIGHT_PX, height: SEAM_LANE_HEIGHT_PX }}
+          className="pointer-events-none absolute left-0 w-6 bg-gradient-to-r from-zinc-950 to-transparent"
         />
         <span
           aria-hidden="true"
           data-seam-fade="right"
           hidden={strip.totalPx + offset <= trackWidth + 0.5}
-          style={{ top: SEAM_RULER_HEIGHT_PX }}
-          className="pointer-events-none absolute right-0 h-9 w-6 bg-gradient-to-l from-zinc-950 to-transparent"
+          style={{ top: SEAM_RULER_HEIGHT_PX, height: SEAM_LANE_HEIGHT_PX }}
+          className="pointer-events-none absolute right-0 w-6 bg-gradient-to-l from-zinc-950 to-transparent"
         />
       </div>
 

--- a/apps/timeline-gstudio001/components/timeline/sidebar-collection-shortcuts.tsx
+++ b/apps/timeline-gstudio001/components/timeline/sidebar-collection-shortcuts.tsx
@@ -9,6 +9,7 @@ import {
   type CollectionShortcut,
 } from "@/lib/collection-shortcuts";
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
+import { SIDEBAR_COLLECTION_SHORTCUTS_ENABLED } from "@/lib/sidebar-collection-shortcuts-flag";
 import { requestGraphOpenItem } from "@/lib/graph-view-events";
 import { cn } from "@/lib/utils";
 
@@ -365,7 +366,17 @@ export function SidebarCollectionShortcuts({
   );
   return (
     <CollectionShortcutsGroup
-      shortcuts={collectionShortcuts(documents[projectId])}
+      // WITHHELD AT THE RAIL, not at the source. `collectionShortcuts` still
+      // walks the document and still returns the list — see the flag's own
+      // note for why the derivation is deliberately left alive — and the group
+      // below simply receives none. That also means the flag needs no branch
+      // inside the group: an empty list is a state it has always rendered,
+      // because a project with no top-level collections produces one.
+      shortcuts={
+        SIDEBAR_COLLECTION_SHORTCUTS_ENABLED
+          ? collectionShortcuts(documents[projectId])
+          : []
+      }
       onOpen={requestGraphOpenItem}
       projectId={projectId}
     />

--- a/apps/timeline-gstudio001/lib/sidebar-collection-shortcuts-flag.ts
+++ b/apps/timeline-gstudio001/lib/sidebar-collection-shortcuts-flag.ts
@@ -1,0 +1,38 @@
+/**
+ * Whether the rail lists a project's TOP-LEVEL COLLECTIONS under the home
+ * shortcut.
+ *
+ * OFF. The group keeps its heading and the home shortcut — "back to the top of
+ * the project" is the one destination that is always worth a permanent place —
+ * and the per-collection buttons under it are gone.
+ *
+ * WHY. The rail's job is "where am I" and "where else", and it answers the
+ * second with a handful of fixed destinations. Collections are neither fixed
+ * nor few: the list is every top-level collection with no cap, so it is a
+ * different length in every project and a different length again after any
+ * edit. A navigator whose height depends on your data is a navigator you
+ * cannot learn — the trash and the assets folder move down the rail because a
+ * scene was added somewhere else entirely.
+ *
+ * They are also the one group here that duplicates something. The board is a
+ * complete view of the same collections, one click away and showing their
+ * contents rather than a 32px crop of one frame.
+ *
+ * Set `NEXT_PUBLIC_GSTUDIO_SIDEBAR_COLLECTIONS=on` to restore them. Compared
+ * against the string rather than truthiness, the same way
+ * `NEXT_PUBLIC_GSTUDIO_BAR_COLOURS` is, so `=off`, `=0` and `=false` all read
+ * as off instead of the reverse — a bare `!!process.env.X` makes the word
+ * "off" mean on.
+ *
+ * WHAT IS PARKED AND WHAT IS NOT. `collectionShortcuts` still walks the
+ * document and still returns the list; this only decides whether the rail
+ * draws it. So the thumbnail's punched-in crop, the collection badge, and the
+ * per-shortcut tooltips do not rot while the flag is off, and turning them
+ * back on is one environment variable rather than a revert.
+ *
+ * FLAG OFF IS A STATE THIS ALREADY HAD. A project with no top-level
+ * collections has always rendered exactly this — heading, home, nothing else —
+ * so nothing new is being drawn and the empty case is not a special path.
+ */
+export const SIDEBAR_COLLECTION_SHORTCUTS_ENABLED =
+  process.env.NEXT_PUBLIC_GSTUDIO_SIDEBAR_COLLECTIONS === "on";


### PR DESCRIPTION
Two changes, both about what the bar says about the clip you're on.

## The minimap marks the subject

Every segment was drawn the same, so the map answered "where is the window" and left "which of these is mine" to be worked out — and at most zooms that window is a dozen clips wide.

The active clip is **white now, at full strength, and two pixels taller** — grown *both* ways so it stays on the run's centre line rather than hanging off it. Measured: `rgb(250,250,250)` vs the run's `rgb(80,84,94)`, 8px vs 6px, centre-line delta **0**.

**Colour rather than an edge**, which isn't a style choice: a segment here can be a single pixel wide, where a border eats into a width that means duration and an outline stands in for the clip instead of marking it. Changing what the pixel *is* works at every width. White because that's what the bar above marks its active clip with — the same claim in the same ink, at two scales.

`TheBarIsGreyUntilTheTintIsSwitchedOn` now excludes the marked segment via `:not()` rather than a filter — the flag withholds *collection* tint and has nothing to say about which clip is the subject, and scoping it in the selector means a mark that silently stopped being applied would take the exclusion with it rather than quietly asserting over everything again.

## A step slides

Pressing next/prev moved the strip by **cutting**. Measured on a 21-clip scene: **986px with no transition property set at all.**

The slide effect wanted the subject change and the travel in *one* render. They're two — a step changes the subject, and only then does the bar decide whether that subject is off the side and nudge to bring it in. So the effect ran twice and bailed both times:

1. new centre, old offset → nothing to interpolate, returns **having already recorded the new centre**
2. new offset, `moved` now false → returns

The move is now *remembered* rather than consumed, and spent on whichever render brings the travel. Time-bounded at 120ms, because a step that needs no nudge leaves the intent unspent and the next wheel pan would otherwise inherit it and ease when it must track the hand exactly.

Same 986px now carries `transform 520ms ease-out`.

### The story is coverage, not a guard — and says so in place

Reverting the fix leaves `TheBarSlidesIntoPositionOnAMove` **green**. Whether those two changes land in one commit or two is React's scheduling, and under the story runner they arrive together — which is the case the old code already handled.

That story covered the **click-a-box** path, where the commit and the travel go together, which is why it never saw this. It now exercises the step buttons too and asserts they ease at all, which nothing did before. The split itself was measured against the running app.

## Checks

- `tsc --noEmit` clean; `eslint` **0 errors** (1 pre-existing `<img>` warning)
- app `vitest` — **1446/1446** (112 files)
- `graph-item-details-modal.stories.tsx` — **44/44**

🤖 Generated with [Claude Code](https://claude.com/claude-code)