### PR TITLE
Grey boxes, except for the clips you are looking at

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -1933,9 +1933,39 @@ export const ThePlaybarCanDrawFrames: Story = {
     // the bar ships on STRIP, so the plain grey state is somewhere this story
     // goes rather than somewhere it starts.
     framesTo("OFF");
-    await waitFor(() =>
-      expect(document.querySelectorAll("[data-seam-thumbnail]").length).toBe(0),
-    );
+    // GREY EXCEPT WHAT IS ON SCREEN. `OFF` is not "no pictures anywhere" — it
+    // is "no pictures in the RUN of the bar", which is the thing grey boxes
+    // are for: width is duration, and an even run of grey shows where the cuts
+    // fall and where the pace changes. That argument says nothing about the
+    // two or three clips whose frames are already filling the screen below,
+    // and drawing those anonymous is the bar declining to answer a question
+    // nobody is asking of it.
+    //
+    // So the count settles at the number of panels on screen, and every one of
+    // them is a box the row is showing.
+    await waitFor(() => {
+      const framed = Array.from(
+        document.querySelectorAll<HTMLElement>("[data-seam-thumbnail]"),
+      );
+      expect(framed.length).toBeGreaterThan(0);
+      expect(framed.length).toBeLessThan(seamBoxes().length);
+      // Each one belongs to a box marked as being on screen — the marker and
+      // the picture cannot drift apart.
+      for (const picture of framed) {
+        expect(picture.closest("[data-seam-segment-onscreen]")).not.toBeNull();
+      }
+    });
+    // AND THE REST ARE STILL GREY. The claim is about the run, so it is
+    // asserted over the run rather than over the total.
+    expect(
+      document.querySelectorAll("[data-seam-segment]:not([data-seam-segment-onscreen])")
+        .length,
+    ).toBeGreaterThan(0);
+    for (const plain of document.querySelectorAll(
+      "[data-seam-segment]:not([data-seam-segment-onscreen])",
+    )) {
+      expect(plain.querySelector("[data-seam-thumbnail]")).toBeNull();
+    }
     framesTo("COVER");
 
     const boxCount = seamBoxes().length;
@@ -2017,13 +2047,30 @@ export const ThePlaybarCanDrawFrames: Story = {
     expect(laneBox.bottom - boxRect.bottom).toBeGreaterThanOrEqual(spread);
 
     framesTo("OFF");
-    await waitFor(() =>
-      expect(document.querySelectorAll("[data-seam-thumbnail]").length).toBe(0),
-    );
-    // AND IT GOES AWAY WITH THEM. Over flat grey the whole treatment is
+    // BACK TO THE RUN BEING GREY — every box except the panels on screen, as
+    // above. The pictures that remain are the clips you are looking at, which
+    // `OFF` was never an argument against.
+    const plainBoxes = () =>
+      Array.from(
+        document.querySelectorAll<HTMLElement>(
+          "[data-seam-segment]:not([data-seam-segment-onscreen])",
+        ),
+      );
+    await waitFor(() => {
+      expect(plainBoxes().length).toBeGreaterThan(0);
+      for (const plain of plainBoxes()) {
+        expect(plain.querySelector("[data-seam-thumbnail]")).toBeNull();
+      }
+    });
+    // AND THE TREATMENT GOES AWAY WITH THEM. Over flat grey the ring is
     // decoration answering a question nobody asked, and one more thing between
     // the reader and the rhythm the grey bar is for.
-    expect(getComputedStyle(seamBoxes()[0]!).boxShadow).toBe("none");
+    //
+    // Read off a box that is NOT on screen: the ring follows the PICTURE now
+    // rather than the setting, so the handful of boxes still drawing a frame
+    // keep their edge — a picture with no margin is the very thing that
+    // treatment exists to prevent.
+    expect(getComputedStyle(plainBoxes()[0]!).boxShadow).toBe("none");
     expect(
       getComputedStyle(document.querySelector<HTMLElement>("[data-seam-strip]")!)
         .backgroundColor,

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -1758,6 +1758,63 @@ export const TheRulerNamesTheCollections: Story = {
 
     expect(labels("collection")).toEqual(["Kitchen Interior", "Loading Dock"]);
 
+    // ── A BLOCK PER CLIP, AND THE GAPS LEFT ALONE ────────────────────────
+    //
+    // The scale carries a faint block per clip so "how long is that shot" can
+    // be read in one place instead of two — the run of blocks IS the run of
+    // boxes. Which only works if they agree EXACTLY: a block off by a couple
+    // of pixels at these sizes is the difference between a scale and a smear.
+    const blocks = Array.from(
+      document.querySelectorAll<HTMLElement>("[data-seam-ruler-block]"),
+    );
+    expect(blocks.length).toBeGreaterThan(1);
+    for (const block of blocks) {
+      const id = block.getAttribute("data-seam-ruler-block")!;
+      const box = document.querySelector<HTMLElement>(
+        `[data-seam-segment="${CSS.escape(id)}"]`,
+      );
+      if (box === null) continue;
+      const blockAt = block.getBoundingClientRect();
+      const boxAt = box.getBoundingClientRect();
+      expect(Math.abs(blockAt.left - boxAt.left)).toBeLessThan(0.5);
+      expect(Math.abs(blockAt.right - boxAt.right)).toBeLessThan(0.5);
+    }
+
+    // AND NOTHING REACHES INTO THE GAP. The gap between two clips is the one
+    // part of the bar that says "these are separate", and it is drawn by
+    // absence — so a block that overran it by a pixel would close the seam the
+    // whole layout depends on. Asserted as clearance BETWEEN blocks rather
+    // than against a number, which is what "the gap stays empty" means.
+    const inOrder = [...blocks].sort(
+      (a, b) => a.getBoundingClientRect().left - b.getBoundingClientRect().left,
+    );
+    for (let index = 0; index < inOrder.length - 1; index += 1) {
+      const gap =
+        inOrder[index + 1]!.getBoundingClientRect().left -
+        inOrder[index]!.getBoundingClientRect().right;
+      expect(gap).toBeGreaterThan(1);
+    }
+
+    // ── AND ONE OF THEM IS THE ACTIVE CLIP ───────────────────────────────
+    //
+    // The only saturated thing in the band, which is what makes it findable on
+    // a bar of two dozen blocks. Asserted as "different from the others" and
+    // as having a hue at all, rather than against an rgba string nobody would
+    // notice going stale.
+    const live = document.querySelectorAll<HTMLElement>("[data-seam-ruler-block-live]");
+    expect(live.length).toBe(1);
+    expect(live[0]!.getAttribute("data-seam-ruler-block")).toBe(
+      centreBox().getAttribute("data-seam-segment"),
+    );
+    const plain = blocks.find(
+      (block) => !block.hasAttribute("data-seam-ruler-block-live"),
+    )!;
+    const activeInk = getComputedStyle(live[0]!).backgroundColor;
+    expect(activeInk).not.toBe(getComputedStyle(plain).backgroundColor);
+    // A HUE, not a brighter grey: the channels have to disagree.
+    const [red, green, blue] = activeInk.match(/[\d.]+/g)!.slice(0, 3).map(Number);
+    expect(Math.max(red!, green!, blue!) - Math.min(red!, green!, blue!)).toBeGreaterThan(40);
+
     // Seconds, and enough of them to read a scale from.
     const times = labels("time");
     expect(times.length).toBeGreaterThan(3);

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -1815,6 +1815,58 @@ export const TheRulerNamesTheCollections: Story = {
     const [red, green, blue] = activeInk.match(/[\d.]+/g)!.slice(0, 3).map(Number);
     expect(Math.max(red!, green!, blue!) - Math.min(red!, green!, blue!)).toBeGreaterThan(40);
 
+    // ── EVERY OTHER ONE IS FILLED ────────────────────────────────────────
+    //
+    // A block on every clip made a continuous band broken only by the gaps,
+    // and at a wide reach those gaps are a couple of pixels — so the row read
+    // as one long rectangle with notches. Alternate fills give each boundary a
+    // change of TONE as well as a gap.
+    const striped = blocks.filter((block) =>
+      block.hasAttribute("data-seam-ruler-block-striped"),
+    );
+    expect(striped.length).toBeGreaterThan(0);
+    // Roughly half, which is what "alternate" means and what a run of blocks
+    // all filled or all bare would fail.
+    expect(striped.length).toBeLessThan(blocks.length);
+    for (const bare of blocks) {
+      if (bare.hasAttribute("data-seam-ruler-block-striped")) continue;
+      if (bare.hasAttribute("data-seam-ruler-block-live")) continue;
+      expect(getComputedStyle(bare).backgroundColor).toBe("rgba(0, 0, 0, 0)");
+    }
+
+    // AND THE ACTIVE ONE IGNORES THE PATTERN. Its parity is an accident of
+    // where it sits in the order, so a mark that appeared for only half the
+    // clips you could select would be worse than no mark at all.
+    expect(live[0]!.hasAttribute("data-seam-ruler-block-striped")).toBe(false);
+    expect(activeInk).not.toBe("rgba(0, 0, 0, 0)");
+
+    // ── THE TRIANGLE CLEARED THE BAND, THE RULE DID NOT ──────────────────
+    //
+    // The mark used to sit inside the scale among its labels, three things
+    // claiming the same 20px. The rule stays: it measures the BOXES — width is
+    // duration — so it belongs against the film rather than above the scale.
+    const band = document.querySelector<HTMLElement>("[data-seam-ruler]")!.getBoundingClientRect();
+    const triangle = document
+      .querySelector<HTMLElement>("[data-seam-active-mark]")!
+      .getBoundingClientRect();
+    const rule = document
+      .querySelector<HTMLElement>("[data-seam-active-span]")!
+      .getBoundingClientRect();
+    expect(triangle.bottom).toBeLessThanOrEqual(band.top + 0.5);
+    expect(rule.top).toBeGreaterThan(band.top);
+
+    // ── AND THE LABELS SIT IN THE MIDDLE OF IT ───────────────────────────
+    //
+    // Hung from the top they read as text with a margin under it rather than
+    // as a scale; centred, each sits in the middle of the block it names and
+    // the tick mark keeps the bottom edge to itself.
+    const anyLabel = document.querySelector<HTMLElement>("[data-seam-tick] span:nth-child(2)");
+    expect(anyLabel).not.toBeNull();
+    const labelBox = anyLabel!.getBoundingClientRect();
+    expect(
+      Math.abs((labelBox.top + labelBox.height / 2) - (band.top + band.height / 2)),
+    ).toBeLessThan(1.5);
+
     // Seconds, and enough of them to read a scale from.
     const times = labels("time");
     expect(times.length).toBeGreaterThan(3);

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -1824,6 +1824,43 @@ export const TheMinimapMovesTheWindow: Story = {
     const ink = marked.backgroundColor.match(/[\d.]+/g)!.slice(0, 3).map(Number);
     expect(Math.min(...ink)).toBeGreaterThan(200);
 
+    // ── AND THE PANELS EITHER SIDE, ONE TIER DOWN ────────────────────────
+    //
+    // The map marks what is ON SCREEN, the same set the film strip draws
+    // pictures for — but as a lesser mark, and lesser is the point. Marking
+    // three clips the way the subject is marked would replace one answer with
+    // three and leave "which is mine" to be worked out from position. So these
+    // come up to full strength and keep their own colour and height:
+    // brightness groups them, and white plus the extra pixel still single out
+    // the one inside.
+    const onScreenSegments = Array.from(
+      document.querySelectorAll<HTMLElement>("[data-seam-mini-segment-onscreen]"),
+    );
+    const flanking = onScreenSegments.filter(
+      (segment) => !segment.hasAttribute("data-seam-mini-segment-live"),
+    );
+    expect(flanking.length).toBeGreaterThan(0);
+    for (const segment of flanking) {
+      const style = getComputedStyle(segment);
+      // Undimmed, so they read as a group against the run…
+      expect(Number(style.opacity)).toBe(1);
+      // …and NOT white, so they never read as the subject.
+      expect(style.backgroundColor).not.toBe(getComputedStyle(live[0]!).backgroundColor);
+    }
+
+    // THE MAP AND THE STRIP AGREE ABOUT WHAT IS ON SCREEN. Two components, one
+    // set, and nothing would tell you they had drifted — the bar would draw a
+    // picture for one clip while the map brightened another, and both would
+    // look deliberate.
+    const named = (nodes: readonly HTMLElement[], attribute: string) =>
+      nodes.map((node) => node.getAttribute(attribute)).sort();
+    expect(named(onScreenSegments, "data-seam-mini-segment")).toEqual(
+      named(
+        Array.from(document.querySelectorAll<HTMLElement>("[data-seam-segment-onscreen]")),
+        "data-seam-segment",
+      ),
+    );
+
     // Taller than its neighbours, and on the SAME CENTRE LINE — grown both
     // ways rather than hanging off the bottom of the run.
     const others = Array.from(

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -1815,29 +1815,22 @@ export const TheRulerNamesTheCollections: Story = {
     const [red, green, blue] = activeInk.match(/[\d.]+/g)!.slice(0, 3).map(Number);
     expect(Math.max(red!, green!, blue!) - Math.min(red!, green!, blue!)).toBeGreaterThan(40);
 
-    // ── EVERY OTHER ONE IS FILLED ────────────────────────────────────────
+    // ── ONE TONE FOR THE RUN ─────────────────────────────────────────────
     //
-    // A block on every clip made a continuous band broken only by the gaps,
-    // and at a wide reach those gaps are a couple of pixels — so the row read
-    // as one long rectangle with notches. Alternate fills give each boundary a
-    // change of TONE as well as a gap.
-    const striped = blocks.filter((block) =>
-      block.hasAttribute("data-seam-ruler-block-striped"),
+    // Alternate fills were tried and dropped: they gave every boundary a
+    // change of tone, but they made the band a pattern in its own right — a
+    // rhythm of light and dark that is not the film's rhythm, competing with
+    // the one thing the widths are actually saying. Asserted as EVERY
+    // non-active block agreeing, which is what a stripe reintroduced by
+    // accident would fail.
+    const runInks = new Set(
+      blocks
+        .filter((block) => !block.hasAttribute("data-seam-ruler-block-live"))
+        .map((block) => getComputedStyle(block).backgroundColor),
     );
-    expect(striped.length).toBeGreaterThan(0);
-    // Roughly half, which is what "alternate" means and what a run of blocks
-    // all filled or all bare would fail.
-    expect(striped.length).toBeLessThan(blocks.length);
-    for (const bare of blocks) {
-      if (bare.hasAttribute("data-seam-ruler-block-striped")) continue;
-      if (bare.hasAttribute("data-seam-ruler-block-live")) continue;
-      expect(getComputedStyle(bare).backgroundColor).toBe("rgba(0, 0, 0, 0)");
-    }
-
-    // AND THE ACTIVE ONE IGNORES THE PATTERN. Its parity is an accident of
-    // where it sits in the order, so a mark that appeared for only half the
-    // clips you could select would be worse than no mark at all.
-    expect(live[0]!.hasAttribute("data-seam-ruler-block-striped")).toBe(false);
+    expect(runInks.size).toBe(1);
+    // And it is a fill, not nothing — the blocks exist to be seen.
+    expect([...runInks][0]).not.toBe("rgba(0, 0, 0, 0)");
     expect(activeInk).not.toBe("rgba(0, 0, 0, 0)");
 
     // ── THE TRIANGLE CLEARED THE BAND, THE RULE DID NOT ──────────────────

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -496,6 +496,33 @@ function DetailsFilmstripModal({
   // honest.
   const MOUNTED_RADIUS = Math.floor(viewCount / 2) + 1;
 
+  /**
+   * The clips actually ON SCREEN as panels — the two or three you are looking
+   * at, not the spares built one either side of them.
+   *
+   * The bar draws these as pictures even with frames switched off. Grey boxes
+   * are for reading RHYTHM — width is duration, and a run of even grey shows
+   * where the cuts fall and where the pace changes, which pictures destroy
+   * because the eye reads pictures whatever else is there. That argument is
+   * about the RUN of the bar. It says nothing about the two or three clips
+   * whose frames are already filling the screen below, and drawing those as
+   * anonymous grey while their pictures sit underneath is the bar declining to
+   * answer a question it is not being asked.
+   *
+   * `MOUNTED_RADIUS` is deliberately not reused: it is one wider, so the row
+   * has a built panel to slide to, and those spares are never seen. Marking
+   * them would put a picture on the bar for a clip that is not on the screen.
+   */
+  const panelClipIds = useMemo(() => {
+    const radius = Math.floor(viewCount / 2);
+    const onScreen = new Set<string>();
+    for (let index = centre - radius; index <= centre + radius; index += 1) {
+      const id = ids[index];
+      if (id !== undefined) onScreen.add(id);
+    }
+    return onScreen;
+  }, [centre, ids, viewCount]);
+
   // HOW A LANDING FROM THE BAR ARRIVES: IT DOES NOT TRAVEL.
   //
   // Stepping and letting go of the bar look like the same event and are not.
@@ -934,6 +961,7 @@ function DetailsFilmstripModal({
             <PlaybarThumbnailsProvider shown={frames.shown} style={frames.style}>
             <SeamStripBar
               clips={barClips}
+              panelClipIds={panelClipIds}
               // WHETHER THE BAR HAS ACTUALLY RUN OUT, which is a different
               // question from whether it has run out of boxes. At a reach of
               // ten the window is cropped at both ends nearly everywhere in a

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -5,6 +5,14 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { BAR_NEUTRAL_COLOUR } from "@/lib/bar-collection-colours-flag";
 
 import { DETAILS_STEP_MS, detailsStepTransition } from "./graph-details-motion";
+import {
+  BOX_INSET_PX,
+  MARK_HALF_PX,
+  MARK_HEIGHT_PX,
+  MARK_TOP_OFFSET_PX,
+  SEAM_LANE_HEIGHT_PX,
+  SEAM_PREVIEW_GAP_PX,
+} from "./graph-seam-metrics";
 import { collectionSeams, type SeamBarClip } from "./graph-seam-bar-layout";
 import {
   usePlaybarThumbnails,
@@ -83,31 +91,13 @@ function SeamEndCap({ side, atPx }: Readonly<{ side: "start" | "end"; atPx: numb
 }
 
 
-/**
- * HOW TALL THE FILM IS.
- *
- * 36px for a long time, which made the frames inside it 30 — small enough
- * that a thumbnail told you a shot was dark or bright and very little else,
- * and the strip is the one place you are meant to recognise a shot by looking
- * at it. 48 puts the pictures at 42, which is where a face in a medium shot
- * stops being a smudge.
- *
- * ONE NUMBER, because four things are measured from it: the lane itself, the
- * fades over its ends, the filmstrip cell size that keeps a cell square, and
- * the hover card's offset below it. They were four literals, and a bar that
- * grew while its fades did not is a gradient floating in the middle of the
- * film.
- */
-export const SEAM_LANE_HEIGHT_PX = 48;
-
-/**
- * How far below the film the hover card hangs.
- *
- * Measured from the lane's BOTTOM rather than written as one offset from its
- * top, so the card keeps its distance when the film changes height instead of
- * climbing into it.
- */
-export const SEAM_PREVIEW_GAP_PX = 20;
+// RE-EXPORTED, not defined here. These live in `graph-seam-metrics` because
+// the ruler needs the film's box inset and the film needs the ruler's height —
+// which as two component modules importing each other is a cycle, and the kind
+// that fails as a layout built from `undefined` rather than as an error. The
+// re-export is so nothing that already imported them from the lane had to
+// move.
+export { BOX_INSET_PX, SEAM_LANE_HEIGHT_PX, SEAM_PREVIEW_GAP_PX };
 
 /** One cell per bar-height, so a filmstrip cell reads as a square. */
 const FILMSTRIP_CELL_PX = SEAM_LANE_HEIGHT_PX;
@@ -235,7 +225,6 @@ function SegmentFrames({
  * middle — that is what the centring arithmetic aligns to the card below —
  * and trimming only the width would shift it by half the gap.
  */
-export const BOX_INSET_PX = 2.5;
 
 /**
  * Half the active-clip triangle's width.
@@ -245,7 +234,6 @@ export const BOX_INSET_PX = 2.5;
  * three places have to agree on it — both borders and the clamp that keeps the
  * mark inside the bar — and they were three separate `5`s.
  */
-const MARK_HALF_PX = 5;
 
 /**
  * WHAT SEPARATES TWO BOXES ONCE THEY HOLD PICTURES.
@@ -820,9 +808,28 @@ export function SeamLane({
                 )}px, calc(100% - ${MARK_HALF_PX}px))`,
                 borderLeft: `${MARK_HALF_PX}px solid transparent`,
                 borderRight: `${MARK_HALF_PX}px solid transparent`,
-                borderTop: "6px solid rgba(250, 250, 250, 0.95)",
+                borderTop: `${MARK_HEIGHT_PX}px solid rgba(250, 250, 250, 0.95)`,
+                // ABOVE THE RULER, not inside it.
+                //
+                // It used to sit immediately over the film, which put it in
+                // the scale's band among the scale's own labels — three things
+                // claiming the same 20px, and the crowding is what made the
+                // band hard to read. Lifted clear, the ruler's contents have
+                // sole possession of the ruler and the mark reads as pointing
+                // AT the band rather than as part of it.
+                //
+                // Derived from the ruler's height, so a taller scale moves the
+                // mark with it instead of burying it. It still travels with
+                // the strip: the `left` above is unchanged, so the triangle
+                // stays over its clip through every pan.
+                //
+                // THE RULE DOES NOT COME WITH IT. That is a measurement of the
+                // BOXES — width is duration — so it stays against the film it
+                // measures. The pair is a pointer and a span, and only the
+                // pointer was in the way.
+                top: -MARK_TOP_OFFSET_PX,
               }}
-              className="pointer-events-none absolute -top-[9px] z-20 h-0 w-0 -translate-x-1/2"
+              className="pointer-events-none absolute z-20 h-0 w-0 -translate-x-1/2"
             />
           </>
         );

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -377,6 +377,7 @@ export function SeamLane({
   laneRef,
   strip,
   clips,
+  panelClipIds,
   colourOf,
   centreClipId,
   offset,
@@ -392,6 +393,21 @@ export function SeamLane({
   laneRef: React.RefObject<HTMLDivElement | null>;
   strip: SeamStrip;
   clips: readonly SeamBarClip[];
+  /**
+   * The clips on screen as PANELS below the bar.
+   *
+   * These draw a frame whatever the setting says. Grey boxes are for reading
+   * rhythm — width is duration, and an even run of grey shows where the cuts
+   * fall — and that argument is about the RUN of the bar, not about the two or
+   * three clips whose pictures are already filling the screen underneath.
+   * Drawing those anonymous is the bar declining to answer a question nobody
+   * is asking of it.
+   *
+   * Optional, because the lane is rendered by stories and probes with no
+   * carousel under it at all; an empty set is "nothing is on screen", which is
+   * the honest answer for those.
+   */
+  panelClipIds?: ReadonlySet<string>;
   colourOf: ReadonlyMap<string, string>;
   centreClipId: string;
   offset: number;
@@ -538,11 +554,26 @@ export function SeamLane({
             const isCentre = segment.clipId === centreClipId;
             const colour = colourOf.get(segment.clipId) ?? BAR_NEUTRAL_COLOUR;
             const skipped = clipById.get(segment.clipId)?.disabled === true;
+            // A PICTURE HERE, WHATEVER THE SETTING SAYS — for the handful of
+            // clips whose frames are on screen below. Everything else stays
+            // grey, which is the whole of what `OFF` is for.
+            const onScreen = panelClipIds?.has(segment.clipId) === true;
+            const framed = thumbnails.shown || onScreen;
+            // COVER FOR THESE, not the chosen style. A filmstrip answers "what
+            // happens in the shot", and these are the shots you are already
+            // watching happen. One frame is the question the bar is being
+            // asked about them — which of these boxes is the one below — and
+            // it is also the cheap answer: a cell per 48px of a long box, on a
+            // bar that was switched to grey partly to stop asking for them.
+            const frameStyle: PlaybarThumbnailStyle = thumbnails.shown
+              ? thumbnails.style
+              : "cover";
             return (
               <span
                 key={segment.clipId}
                 data-seam-segment={segment.clipId}
                 data-seam-segment-live={isCentre ? "" : undefined}
+                data-seam-segment-onscreen={onScreen ? "" : undefined}
                 data-seam-segment-skipped={skipped ? "" : undefined}
                 aria-hidden="true"
                 style={{
@@ -556,23 +587,23 @@ export function SeamLane({
                   backgroundColor: colour,
                   // See `FRAMED_BOX_EDGE`: the ring is the dark half of the
                   // gap, and the strip's own background is the pale half.
-                  ...(thumbnails.shown ? { boxShadow: FRAMED_BOX_EDGE } : {}),
+                  ...(framed ? { boxShadow: FRAMED_BOX_EDGE } : {}),
                   // ROOM FOR THE RING TO EXIST. See `BOX_INSET_Y_PX`: the lane
                   // clips, so without this the frame's top and bottom edges
                   // are painted straight off the element.
-                  ...(thumbnails.shown
+                  ...(framed
                     ? { top: BOX_INSET_Y_PX, bottom: BOX_INSET_Y_PX }
                     : { top: 0, bottom: 0 }),
                 }}
                 className="absolute flex items-center justify-center overflow-hidden rounded-[3px]"
               >
-                {thumbnails.shown ? (
+                {framed ? (
                   <SegmentFrames
                     clipId={segment.clipId}
                     clip={clipById.get(segment.clipId)}
                     posterSrc={segment.posterSrc}
                     widthPx={Math.max(2, segment.widthPx - BOX_INSET_PX * 2)}
-                    style={thumbnails.style}
+                    style={frameStyle}
                   />
                 ) : null}
                 {/* SKIPPED AT PLAY TIME: struck through with hatching.

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -235,7 +235,7 @@ function SegmentFrames({
  * middle — that is what the centring arithmetic aligns to the card below —
  * and trimming only the width would shift it by half the gap.
  */
-const BOX_INSET_PX = 2.5;
+export const BOX_INSET_PX = 2.5;
 
 /**
  * Half the active-clip triangle's width.

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-metrics.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-metrics.ts
@@ -1,0 +1,83 @@
+// THE BAR'S SHARED NUMBERS, in one module because they are shared in BOTH
+// directions.
+//
+// The ruler needs the film's box inset, so its blocks land on the same edges
+// as the boxes below. The film needs the ruler's height, so the active
+// clip's triangle can sit above it. Those two imports are a cycle, and a cycle
+// between two component modules is the kind that works until a bundler orders
+// them the other way and one side reads `undefined` at module scope — as a
+// layout built from NaN rather than as an error anyone could search for.
+//
+// So the numbers live apart from both. Nothing here imports anything.
+
+/**
+ * How far a box is inset from its segment, each side.
+ *
+ * The gap between two clips is twice this, and it is drawn by ABSENCE — the
+ * one part of the bar that says "these are separate". Both rows measure from
+ * it: the film's boxes and the scale's blocks, so a block cannot reach into a
+ * gap without the box below it doing the same.
+ */
+export const BOX_INSET_PX = 2.5;
+
+/** How tall the ruler's band is. The fades over the film begin where it ends,
+ *  and the active clip's mark sits above it. */
+export const SEAM_RULER_HEIGHT_PX = 20;
+
+/**
+ * How tall the film is.
+ *
+ * 36px for a long time, which made the frames inside it 30 — enough to tell
+ * you a shot was dark or bright and very little else, and the strip is the one
+ * place you are meant to know a shot by looking at it. 48 puts the pictures at
+ * 42, where a face in a medium shot stops being a smudge.
+ *
+ * Four things are measured from it: the lane, the fades over its ends, the
+ * filmstrip cell size that keeps a cell square, and the hover card's offset
+ * below it.
+ */
+export const SEAM_LANE_HEIGHT_PX = 48;
+
+/**
+ * How far below the film the hover card hangs.
+ *
+ * Measured from the lane's BOTTOM rather than as one offset from its top, so
+ * the card keeps its distance when the film changes height instead of climbing
+ * into it.
+ */
+export const SEAM_PREVIEW_GAP_PX = 20;
+
+/**
+ * Half the active-clip triangle's width, and its height.
+ *
+ * It is drawn as two transparent side borders under a solid top one, so the
+ * glyph is twice `MARK_HALF_PX` wide and `MARK_HEIGHT_PX` tall, with its tip
+ * at its own centre. Named because the borders, the clamp that keeps the mark
+ * inside the bar, and the offset that lifts it above the ruler all have to
+ * agree.
+ */
+export const MARK_HALF_PX = 5;
+export const MARK_HEIGHT_PX = 6;
+
+/**
+ * The gap between the triangle's tip and the top of the ruler.
+ *
+ * The mark used to sit immediately over the film, inside the ruler's band and
+ * among its labels — three things claiming the same 20px. Lifting it clear
+ * puts the scale's own contents back in sole possession of the scale, and the
+ * mark reads as pointing AT the band rather than as part of it.
+ *
+ * Small, because it still has to belong to the clip it points at. The rule
+ * stays where it was, against the film: the pair is a pointer and a span, and
+ * the span is a measurement of the boxes rather than of the scale.
+ */
+export const MARK_RULER_GAP_PX = 2;
+
+/**
+ * How far above the lane's top the triangle's box starts.
+ *
+ * Derived rather than typed, so a taller ruler moves the mark with it instead
+ * of burying it.
+ */
+export const MARK_TOP_OFFSET_PX =
+  SEAM_RULER_HEIGHT_PX + MARK_HEIGHT_PX + MARK_RULER_GAP_PX;

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-minimap.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-minimap.tsx
@@ -29,6 +29,7 @@ export function SeamMinimap({
   clips,
   colourOf,
   centreClipId,
+  panelClipIds,
   totalSeconds,
   windowFromSeconds,
   windowToSeconds,
@@ -49,6 +50,24 @@ export function SeamMinimap({
    * yours.
    */
   centreClipId: string;
+  /**
+   * The clips on screen as panels — the same set the film strip draws pictures
+   * for with frames switched off.
+   *
+   * A SECOND, LESSER TIER, and it has to be lesser. The map already answers
+   * "which one is mine" in white, and marking two or three clips the same way
+   * would replace one answer with three and leave the subject to be worked out
+   * from position. So these come up to full strength and keep their own
+   * colour: enough to read as a group against a dimmed run, not enough to
+   * compete with the thing inside them.
+   *
+   * NOT PICTURES, which is where this stops being "the same as the strip". A
+   * segment here is a few pixels tall and often one wide — the film strip can
+   * answer "which shot" with a frame because it has room for one, and the map
+   * cannot, so it answers the only question it has room for: which part of the
+   * sequence you are in.
+   */
+  panelClipIds?: ReadonlySet<string>;
   totalSeconds: number;
   /** The span the bar above is showing, in absolute seconds. */
   windowFromSeconds: number;
@@ -132,11 +151,14 @@ export function SeamMinimap({
         {clips.map((clip, index) => {
           if (clip.showingSeconds <= 0) return null;
           const isCentre = clip.id === centreClipId;
+          // ON SCREEN BUT NOT THE SUBJECT — the panels either side of it.
+          const isFlanking = !isCentre && panelClipIds?.has(clip.id) === true;
           return (
             <span
               key={clip.id}
               data-seam-mini-segment={clip.id}
               data-seam-mini-segment-live={isCentre ? "" : undefined}
+              data-seam-mini-segment-onscreen={isCentre || isFlanking ? "" : undefined}
               style={{
                 flexGrow: clip.showingSeconds,
                 // THE SUBJECT IS WHITE, and that is the whole mark.
@@ -169,7 +191,18 @@ export function SeamMinimap({
                 // read as hanging off the strip rather than as the one raised
                 // out of it. 6px to 8px inside a 14px rail, so it has the room
                 // and nothing clips.
-                isCentre ? "-my-px opacity-100" : "opacity-70",
+                //
+                // THE FLANKING PANELS COME UP TO FULL STRENGTH AND NO FURTHER:
+                // their own colour, the run's own height. Against a dimmed run
+                // that is enough to read the three as a group, and it leaves
+                // the two things that say SUBJECT — white, and the extra
+                // pixel — belonging to one segment. Brightness groups; shape
+                // and colour single out.
+                isCentre
+                  ? "-my-px opacity-100"
+                  : isFlanking
+                    ? "opacity-100"
+                    : "opacity-70",
               ].join(" ")}
             />
           );

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-ruler.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-ruler.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { BOX_INSET_PX } from "./graph-seam-lane";
+import { BOX_INSET_PX, SEAM_RULER_HEIGHT_PX } from "./graph-seam-metrics";
 import type { SeamTick } from "./graph-seam-bar-layout";
 
 /**
@@ -11,7 +11,7 @@ import type { SeamTick } from "./graph-seam-bar-layout";
  * begin exactly where the ruler stops or they cover the last row of labels.
  * Two places, one number.
  */
-export const SEAM_RULER_HEIGHT_PX = 20;
+export { SEAM_RULER_HEIGHT_PX };
 
 /**
  * ── THE CLIPS, DRAWN AGAIN IN THE SCALE ─────────────────────────────────────
@@ -22,13 +22,17 @@ export const SEAM_RULER_HEIGHT_PX = 20;
  * width and the same x, puts the two in one place: the run of blocks IS the
  * run of boxes, and the numbers land on it.
  *
- * FAINT ENOUGH TO BE A GROUND. This is a scale, not a second film strip — the
- * blocks are there to make divisions findable and to give the labels something
- * to sit against, and anything with real presence would compete with the film
- * it is describing. White at 7% is a shape you notice when you look for it and
- * a texture when you do not.
+ * FAINT ENOUGH TO BE A GROUND, and no fainter. This is a scale rather than a
+ * second film strip, so the blocks make divisions findable and give the labels
+ * something to sit against without competing with the film they describe.
+ *
+ * 7% was past the point of being either: against this ground it read as an
+ * unevenness in the black rather than as a row of rectangles, so the thing it
+ * was drawn to make legible could not itself be seen. 16% is a shape you can
+ * find without hunting and still quiet enough that the eye goes to the film
+ * first.
  */
-const RULER_BLOCK_COLOUR = "rgba(250, 250, 250, 0.07)";
+const RULER_BLOCK_COLOUR = "rgba(250, 250, 250, 0.16)";
 
 /**
  * The active clip's block, and the one thing in this band with a hue.
@@ -166,21 +170,42 @@ export function SeamRuler({
             on. A tick, its label and the pointer's line all have to stay
             readable over them, and the paint order is what guarantees that
             rather than a stack of z-indexes to keep in step. */}
-        {segments.map((segment) => {
+        {segments.map((segment, index) => {
           if (segment.widthPx <= 0) return null;
           const isCentre = segment.clipId === centreClipId;
+          // EVERY OTHER ONE, like the ruled lines on a ledger.
+          //
+          // A block on every clip made a continuous band broken only by the
+          // gaps, and at a wide reach those gaps are a couple of pixels — so
+          // the row read as one long rectangle with notches rather than as a
+          // run of clips. Filling alternate clips gives each boundary a change
+          // of TONE as well as a gap, which is the pair the eye actually
+          // counts by.
+          //
+          // Parity comes from the clip's place in playback order, not from
+          // anything about the view, so a block does not change tone when the
+          // bar pans or the reach changes. It is a property of the film.
+          const striped = index % 2 === 0;
           return (
             <span
               key={segment.clipId}
               data-seam-ruler-block={segment.clipId}
               data-seam-ruler-block-live={isCentre ? "" : undefined}
+              data-seam-ruler-block-striped={striped && !isCentre ? "" : undefined}
               aria-hidden="true"
               style={{
                 left: segment.leftPx + BOX_INSET_PX,
                 width: Math.max(2, segment.widthPx - BOX_INSET_PX * 2),
+                // THE ACTIVE CLIP IGNORES THE PATTERN. Its parity is an
+                // accident of where it sits in the order, and a mark that
+                // appeared for half the clips you could select would be worse
+                // than no mark — the one thing this colour has to do is be
+                // there whenever it is true.
                 backgroundColor: isCentre
                   ? RULER_BLOCK_ACTIVE_COLOUR
-                  : RULER_BLOCK_COLOUR,
+                  : striped
+                    ? RULER_BLOCK_COLOUR
+                    : "transparent",
               }}
               // INSET FROM THE BOTTOM, not flush to it. The tick marks hang
               // from that edge and a block reaching it would have them ending
@@ -225,7 +250,17 @@ export function SeamRuler({
                 seam. */}
             <span
               className={[
-                "absolute top-0 left-0 max-w-32 truncate text-[10px] leading-none whitespace-nowrap",
+                // CENTRED IN THE BAND, not hung from its top.
+                //
+                // At the top it sat against the edge with the whole rest of
+                // the band empty beneath it, so the row read as text with a
+                // margin under it rather than as a scale. Centred, the label
+                // sits in the middle of the block it names and the tick mark
+                // still has the bottom edge to itself — `-translate-y-1/2`
+                // against `top-1/2` rather than a flex box, because the tick
+                // container is a zero-width anchor at the boundary and has no
+                // box to centre anything in.
+                "absolute top-1/2 left-0 max-w-32 -translate-y-1/2 truncate text-[10px] leading-none whitespace-nowrap",
                 // READABLE, which the time labels were not. They were
                 // `text-zinc-600` at 9px — grey on near-black, at a size where
                 // the strokes are a pixel wide, so the numbers were legible

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-ruler.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-ruler.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { BOX_INSET_PX } from "./graph-seam-lane";
 import type { SeamTick } from "./graph-seam-bar-layout";
 
 /**
@@ -11,6 +12,38 @@ import type { SeamTick } from "./graph-seam-bar-layout";
  * Two places, one number.
  */
 export const SEAM_RULER_HEIGHT_PX = 20;
+
+/**
+ * ── THE CLIPS, DRAWN AGAIN IN THE SCALE ─────────────────────────────────────
+ *
+ * The ruler carried numbers and collection names and nothing about the film
+ * under it, so reading "how long is that shot" meant finding a box's edges on
+ * one row and reading a number off another. A block per clip, at the same
+ * width and the same x, puts the two in one place: the run of blocks IS the
+ * run of boxes, and the numbers land on it.
+ *
+ * FAINT ENOUGH TO BE A GROUND. This is a scale, not a second film strip — the
+ * blocks are there to make divisions findable and to give the labels something
+ * to sit against, and anything with real presence would compete with the film
+ * it is describing. White at 7% is a shape you notice when you look for it and
+ * a texture when you do not.
+ */
+const RULER_BLOCK_COLOUR = "rgba(250, 250, 250, 0.07)";
+
+/**
+ * The active clip's block, and the one thing in this band with a hue.
+ *
+ * Sky is what the app already says "live" in — the seek rail's played time,
+ * the board's readout — so the active clip's block is that colour rather than
+ * a new one to learn. Kept translucent for the same reason the others are
+ * faint: it marks the stretch of scale belonging to the clip being worked on,
+ * and a solid bar would be a second claim competing with the white triangle
+ * and rule immediately below it.
+ *
+ * It is the only saturated thing up here, which is what makes it findable at a
+ * glance on a bar of two dozen blocks.
+ */
+const RULER_BLOCK_ACTIVE_COLOUR = "rgba(56, 189, 248, 0.30)";
 
 /**
  * The scale ABOVE the boxes: seconds, and where each collection starts.
@@ -54,10 +87,25 @@ export const SEAM_RULER_HEIGHT_PX = 20;
 export function SeamRuler({
   ticks,
   offset,
+  segments = [],
+  centreClipId = null,
   ghostX = null,
   handlers,
 }: Readonly<{
   ticks: readonly SeamTick[];
+  /**
+   * The film's own layout, so the scale can draw a block per clip at exactly
+   * the width and position of the box below it.
+   *
+   * The SAME numbers the lane lays its boxes out from, inset the same way —
+   * a block that agreed about width but not about the gap would sit a couple
+   * of pixels off every boundary, which at these sizes is the difference
+   * between a scale and a smear.
+   */
+  segments?: readonly Readonly<{ clipId: string; leftPx: number; widthPx: number }>[];
+  /** Which block wears the active treatment. Null draws none, which is what a
+   *  ruler rendered without a film under it should do. */
+  centreClipId?: string | null;
   /** The strip's own transform, so the ruler travels with the boxes. */
   offset: number;
   /**
@@ -114,10 +162,40 @@ export function SeamRuler({
         className="absolute inset-y-0 left-0 w-full"
         style={{ transform: `translateX(${offset}px)` }}
       >
-        {/* UNDER THE POINTER, and the same hairline the film draws. First in
-            the container so a tick mark and its label paint over it rather
-            than under — the line says where you are, and the label is what it
-            is pointing at. */}
+        {/* THE BLOCKS FIRST, so they are the GROUND the rest of the band sits
+            on. A tick, its label and the pointer's line all have to stay
+            readable over them, and the paint order is what guarantees that
+            rather than a stack of z-indexes to keep in step. */}
+        {segments.map((segment) => {
+          if (segment.widthPx <= 0) return null;
+          const isCentre = segment.clipId === centreClipId;
+          return (
+            <span
+              key={segment.clipId}
+              data-seam-ruler-block={segment.clipId}
+              data-seam-ruler-block-live={isCentre ? "" : undefined}
+              aria-hidden="true"
+              style={{
+                left: segment.leftPx + BOX_INSET_PX,
+                width: Math.max(2, segment.widthPx - BOX_INSET_PX * 2),
+                backgroundColor: isCentre
+                  ? RULER_BLOCK_ACTIVE_COLOUR
+                  : RULER_BLOCK_COLOUR,
+              }}
+              // INSET FROM THE BOTTOM, not flush to it. The tick marks hang
+              // from that edge and a block reaching it would have them ending
+              // inside a filled rectangle rather than against the film — the
+              // marks are what point at the boundary, and they need the gap to
+              // point ACROSS.
+              className="absolute top-0 bottom-1.5 rounded-[2px]"
+            />
+          );
+        })}
+
+        {/* UNDER THE POINTER, and the same hairline the film draws. Painted
+            after the blocks so it reads over them — the line says where you
+            are, and a ground that covered it would be answering a quieter
+            question more loudly. */}
         {ghostX !== null && (
           <span
             aria-hidden="true"

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-ruler.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-ruler.tsx
@@ -170,42 +170,29 @@ export function SeamRuler({
             on. A tick, its label and the pointer's line all have to stay
             readable over them, and the paint order is what guarantees that
             rather than a stack of z-indexes to keep in step. */}
-        {segments.map((segment, index) => {
+        {segments.map((segment) => {
           if (segment.widthPx <= 0) return null;
           const isCentre = segment.clipId === centreClipId;
-          // EVERY OTHER ONE, like the ruled lines on a ledger.
-          //
-          // A block on every clip made a continuous band broken only by the
-          // gaps, and at a wide reach those gaps are a couple of pixels — so
-          // the row read as one long rectangle with notches rather than as a
-          // run of clips. Filling alternate clips gives each boundary a change
-          // of TONE as well as a gap, which is the pair the eye actually
-          // counts by.
-          //
-          // Parity comes from the clip's place in playback order, not from
-          // anything about the view, so a block does not change tone when the
-          // bar pans or the reach changes. It is a property of the film.
-          const striped = index % 2 === 0;
           return (
             <span
               key={segment.clipId}
               data-seam-ruler-block={segment.clipId}
               data-seam-ruler-block-live={isCentre ? "" : undefined}
-              data-seam-ruler-block-striped={striped && !isCentre ? "" : undefined}
               aria-hidden="true"
               style={{
                 left: segment.leftPx + BOX_INSET_PX,
                 width: Math.max(2, segment.widthPx - BOX_INSET_PX * 2),
-                // THE ACTIVE CLIP IGNORES THE PATTERN. Its parity is an
-                // accident of where it sits in the order, and a mark that
-                // appeared for half the clips you could select would be worse
-                // than no mark — the one thing this colour has to do is be
-                // there whenever it is true.
+                // ONE TONE FOR THE RUN, and the active clip apart from it.
+                //
+                // Alternate fills were tried and dropped: they gave every
+                // boundary a change of tone, but they also made the band a
+                // pattern in its own right — a rhythm of light and dark that
+                // is not the film's rhythm, competing with the one thing the
+                // widths are actually saying. An even run is a ground, and a
+                // ground is what a scale wants to be.
                 backgroundColor: isCentre
                   ? RULER_BLOCK_ACTIVE_COLOUR
-                  : striped
-                    ? RULER_BLOCK_COLOUR
-                    : "transparent",
+                  : RULER_BLOCK_COLOUR,
               }}
               // INSET FROM THE BOTTOM, not flush to it. The tick marks hang
               // from that edge and a block reaching it would have them ending

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -159,6 +159,7 @@ type FitMode = "clip" | "all";
 
 export function SeamStripBar({
   clips,
+  panelClipIds,
   centreClipId,
   colourOf,
   playheadAt,
@@ -177,6 +178,11 @@ export function SeamStripBar({
 }: Readonly<{
   /** Every clip the bar can reach, in playback order. */
   clips: readonly SeamBarClip[];
+  /**
+   * The clips on screen as panels below — drawn as pictures even with frames
+   * switched off. See the note where this is built in the modal.
+   */
+  panelClipIds: ReadonlySet<string>;
   /** The clip under the middle card — marked, not centred. */
   centreClipId: string;
   /** Each clip's box colour, derived from where its collection sits in the
@@ -918,6 +924,7 @@ export function SeamStripBar({
 
         <SeamLane
           laneRef={laneRef}
+          panelClipIds={panelClipIds}
           strip={strip}
           clips={clips}
           colourOf={boxColourOf}

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -776,15 +776,96 @@ export function SeamStripBar({
   // change. As state it was a setState inside an effect, which is a second
   // render for a value no one draws.
   const broughtIntoViewRef = useRef(centreClipId);
+  /**
+   * BRING THE WHOLE ROW ON, not just the clip in the middle of it.
+   *
+   * The panels below are three clips, or five — and stepping used to bring
+   * only the subject onto the bar, which left the neighbours you are looking
+   * at with no box you could point to. The row and the bar disagreed about
+   * what "here" is, and the bar is the thing that says where here sits.
+   *
+   * The span is the first on-screen clip's left edge to the last one's right,
+   * found by walking the segments rather than by index: `panelClipIds` is a
+   * set, and the two ends are all this needs.
+   */
+  const panelSpan = useMemo(() => {
+    let from = Number.POSITIVE_INFINITY;
+    let to = Number.NEGATIVE_INFINITY;
+    for (const segment of strip.segments) {
+      if (!panelClipIds.has(segment.clipId)) continue;
+      from = Math.min(from, segment.leftPx);
+      to = Math.max(to, segment.leftPx + segment.widthPx);
+    }
+    return Number.isFinite(from) ? { from, to } : null;
+  }, [panelClipIds, strip]);
+
+  /**
+   * Pan the least distance that puts `from`..`to` on the track.
+   *
+   * WHEN IT WILL NOT FIT, IT FALLS BACK RATHER THAN GIVING UP. Five panels of
+   * a long cut, or three on a phone, can be wider than the track at the
+   * current zoom — and the honest answer there is not "show none of it". The
+   * span is centred instead, which puts as much of the row on screen as there
+   * is room for and keeps the subject among it.
+   *
+   * THE ZOOM IS LEFT ALONE. Fitting the row by zooming out would change the
+   * scale under someone who was reading it, and the scale is the one thing on
+   * this bar that a step must not touch — a box's width means a duration, and
+   * a step is not a request to re-measure the film.
+   */
+  const bringSpanIntoView = useCallback(
+    (from: number, to: number) => {
+      const width = trackRef.current?.getBoundingClientRect().width ?? trackWidth;
+      if (width <= 0) return;
+      const room = width - FOLLOW_LEAD_PX - FOLLOW_TRAIL_PX;
+      const current = offsetRef.current;
+      let next = current;
+      if (to - from > room) {
+        // Too wide for the track: centre what there is.
+        next = width / 2 - (from + to) / 2;
+      } else if (from + current < FOLLOW_LEAD_PX) {
+        next = FOLLOW_LEAD_PX - from;
+      } else if (to + current > width - FOLLOW_TRAIL_PX) {
+        next = width - FOLLOW_TRAIL_PX - to;
+      }
+      if (Math.abs(next - current) < 0.5) return;
+      setOffset(next);
+    },
+    [setOffset, trackWidth],
+  );
+
   useEffect(() => {
     if (broughtIntoViewRef.current === centreClipId) return;
     broughtIntoViewRef.current = centreClipId;
     setFollowSuspended(false);
     if (panPxRef.current === null) return;
+    if (panelSpan !== null) {
+      bringSpanIntoView(panelSpan.from, panelSpan.to);
+      return;
+    }
+    // No panels reported — a bar rendered without a carousel under it. The
+    // subject alone is the best "here" there is.
     const segment = strip.segments.find((candidate) => candidate.clipId === centreClipId);
     if (segment === undefined) return;
     nudgeIntoView(segment.leftPx + segment.widthPx / 2);
-  }, [centreClipId, nudgeIntoView, strip]);
+  }, [bringSpanIntoView, centreClipId, nudgeIntoView, panelSpan, strip]);
+
+  // AND CHANGING HOW MANY PANELS THERE ARE IS THE SAME REQUEST.
+  //
+  // Going from three up to five puts two more clips on screen, and they are on
+  // screen whether or not the bar is showing them — so the count is as much a
+  // "bring the row into view" as a step is. Keyed on the SIZE rather than the
+  // set: the members change on every step, which the effect above already
+  // handles, and re-fitting on both would fight a deliberate pan made between
+  // one step and the next.
+  const panelCount = panelClipIds.size;
+  const fittedCountRef = useRef(panelCount);
+  useEffect(() => {
+    if (fittedCountRef.current === panelCount) return;
+    fittedCountRef.current = panelCount;
+    if (panPxRef.current === null || panelSpan === null) return;
+    bringSpanIntoView(panelSpan.from, panelSpan.to);
+  }, [bringSpanIntoView, panelCount, panelSpan]);
 
   // DERIVED, NOT ANNOUNCED AT EACH SITE. `hover` is cleared from four places —
   // pointer down, pointer leave, a wheel, and a position that resolves to no

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -982,6 +982,7 @@ export function SeamStripBar({
         clips={clips}
         colourOf={boxColourOf}
         centreClipId={centreClipId}
+        panelClipIds={panelClipIds}
         totalSeconds={totalSeconds}
         windowFromSeconds={windowFromSeconds}
         windowToSeconds={windowToSeconds}

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -914,6 +914,8 @@ export function SeamStripBar({
         <SeamRuler
           ticks={ticks}
           offset={offset}
+          segments={strip.segments}
+          centreClipId={centreClipId}
           // The same x the lane's ghost uses, so the two are one line. Dropped
           // while panning for the same reason the lane drops its card: the bar
           // is moving under the pointer, and a mark claiming to be "here" is


### PR DESCRIPTION
`OFF` drew the whole bar grey — including the two or three clips whose frames were filling the screen directly below it. Those now draw a picture.

## Why this doesn't contradict what `OFF` is for

Grey boxes are for reading **rhythm**: width is duration, so an even run of grey shows where the cuts fall, which shots are long, where the pace changes. Pictures destroy that, because the eye reads pictures whatever else is on offer.

But that argument is about the **run** of the bar. It says nothing about the handful of clips already on screen as panels — and drawing those anonymous is the bar declining to answer a question nobody is asking of it. The run stays grey, which is the whole of the setting.

## Three decisions inside it

**Cover, not the chosen style.** A filmstrip answers "what happens in this shot", and these are the shots you're watching happen. One frame is the question actually being asked — *which box is the one below* — and it's the cheap answer too: a strip is a cell per 48px of box, on a bar switched to grey partly to stop asking for them.

**The panels on screen, not the ones mounted.** `MOUNTED_RADIUS` is deliberately one wider so the row has something built to slide to, and those spares are never seen — marking them would put a picture on the bar for a clip that isn't on screen. At the start or end of the order the outer slot is a spare with no clip behind it at all, which is why the set is built with a guard rather than a slice.

**The ring follows the picture, not the setting.** The framed treatment — the edge, and the inset that gives it room — was keyed to the global toggle. A lone picture in a grey bar would have been painted hard against the top and bottom of the lane, which is exactly what that treatment exists to prevent. It's per box now. The strip's own gap colour stays global: it's the ground behind every box, not a property of one.

## Measured in the app, frames OFF

| | |
|---|---|
| boxes on the bar | 21 |
| marked as on screen | 2 |
| pictures on those | 2 |
| pictures on the other 19 | **0** |
| ring on marked / on rest | present / absent |

2 rather than 3 because that subject sits at **index 0** — there is no previous clip, so the row's left slot is a hidden spare. The guard handles it; elsewhere in the order all three mark.

## Coverage

`ThePlaybarCanDrawFrames` asserted `OFF` meant *zero* thumbnails, which is the contract this changes. It now asserts the real one, in both places it checks: some pictures but fewer than the box count, every picture inside a box marked on-screen, and every unmarked box with no picture and no ring.

## Checks

- `tsc --noEmit` clean; `eslint` **0 errors** (1 pre-existing `<img>` warning)
- app `vitest` — **1446/1446** (112 files)
- `graph-item-details-modal.stories.tsx` — **44/44**

🤖 Generated with [Claude Code](https://claude.com/claude-code)