### PR TITLE
The names get their own line, and the seconds stop being eaten

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -1751,10 +1751,16 @@ export const TheRulerNamesTheCollections: Story = {
     await waitFor(() => expect(document.querySelector("[data-seam-ruler]")).not.toBeNull());
     await settleStrip();
 
+    // A COLLECTION NAME LIVES IN ITS OWN BAND now, above the scale — the two
+    // rows say one thing each, names and numbers. The tick MARK keeps the
+    // `data-seam-tick` name down in the scale, so the label needs a selector of
+    // its own rather than a marker that carries text only some of the time.
     const labels = (kind: string) =>
-      Array.from(document.querySelectorAll<HTMLElement>("[data-seam-tick=" + kind + "]")).map(
-        (tick) => tick.textContent?.trim() ?? "",
-      );
+      Array.from(
+        document.querySelectorAll<HTMLElement>(
+          kind === "collection" ? "[data-seam-tick-name]" : `[data-seam-tick=${kind}]`,
+        ),
+      ).map((tick) => tick.textContent?.trim() ?? "");
 
     expect(labels("collection")).toEqual(["Kitchen Interior", "Loading Dock"]);
 
@@ -1853,12 +1859,29 @@ export const TheRulerNamesTheCollections: Story = {
     // Hung from the top they read as text with a margin under it rather than
     // as a scale; centred, each sits in the middle of the block it names and
     // the tick mark keeps the bottom edge to itself.
-    const anyLabel = document.querySelector<HTMLElement>("[data-seam-tick] span:nth-child(2)");
+    // A TIME label, centred in the SCALE band — which is no longer the whole
+    // ruler. The names have a band of their own above it, so measuring against
+    // the outer box would put the target 7px out and fail for a reason that is
+    // not about centring.
+    const scale = document
+      .querySelector<HTMLElement>("[data-seam-ruler-scale]")!
+      .getBoundingClientRect();
+    const anyLabel = document.querySelector<HTMLElement>('[data-seam-tick="time"] span:last-child');
     expect(anyLabel).not.toBeNull();
     const labelBox = anyLabel!.getBoundingClientRect();
     expect(
-      Math.abs((labelBox.top + labelBox.height / 2) - (band.top + band.height / 2)),
+      Math.abs((labelBox.top + labelBox.height / 2) - (scale.top + scale.height / 2)),
     ).toBeLessThan(1.5);
+
+    // AND THE NAMES SIT ABOVE THE SCALE, which is the whole point of the split:
+    // two rows saying one thing each rather than two kinds of label competing
+    // for one line.
+    const names = document
+      .querySelector<HTMLElement>("[data-seam-ruler-names]")!
+      .getBoundingClientRect();
+    expect(names.bottom).toBeLessThanOrEqual(scale.top + 0.5);
+    const aName = document.querySelector<HTMLElement>("[data-seam-tick-name]")!;
+    expect(names.top <= aName.getBoundingClientRect().top + 0.5).toBe(true);
 
     // Seconds, and enough of them to read a scale from.
     const times = labels("time");
@@ -2880,7 +2903,7 @@ export const TheBarIsGreyUntilTheTintIsSwitchedOn: Story = {
     // alone: the strip, the ruler and the minimap.
     expect(document.querySelectorAll("[data-seam-divider]").length).toBe(1);
     expect(
-      Array.from(document.querySelectorAll<HTMLElement>('[data-seam-tick="collection"]')).map(
+      Array.from(document.querySelectorAll<HTMLElement>('[data-seam-tick-name]')).map(
         (tick) => tick.textContent?.trim(),
       ),
     ).toEqual(["Kitchen Interior", "Loading Dock"]);

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -918,7 +918,7 @@ function DetailsFilmstripModal({
       // row that had itself moved 1728px, which put the card just chosen
       // entirely off the left edge. `clip` crops without ever being
       // scrollable, so the transform stays the only thing that moves the row.
-      className="fixed inset-0 z-[80] flex items-center justify-center overflow-clip bg-black/80 px-6 pt-[20rem] pb-6 backdrop-blur-sm"
+      className="fixed inset-0 z-[80] flex items-center justify-center overflow-clip bg-black/80 px-6 pt-[21.75rem] pb-6 backdrop-blur-sm"
       // THE SCRIM DOES NOT DISMISS. Deliberate: this view is worked in, not
       // glanced at — trimming, scrubbing and swiping all end with the pointer
       // somewhere unpredictable, and the panels are cropped by the scrim

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-bar-layout.test.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-bar-layout.test.ts
@@ -178,13 +178,18 @@ describe("seamRulerTicks", () => {
     ]);
   });
 
-  it("clears the whole WIDTH of a collection label, not just its mark", () => {
-    // The label is left-aligned on its tick, so it reaches to the RIGHT — and
-    // a clash zone measured around the mark alone let the next time tick print
-    // straight through the end of the word. Forty seconds at 10px a second:
-    // the 5s ladder wants a tick every 50px, "Van Interior" starts at x=200
-    // and reaches about 75px past it, so the two ticks inside that reach give
-    // way and the one beyond it does not.
+  // ── NOTHING IS SUPPRESSED ANY MORE ──────────────────────────────────────
+  //
+  // Two tests used to live here asserting the opposite: that a time tick was
+  // dropped wherever a collection name would have printed over it, both on the
+  // mark itself and across the width the word was estimated to take.
+  //
+  // That was right while the names shared a line with the seconds, and the
+  // cost was a scale with holes in it exactly where a collection starts —
+  // which is where you are most likely to be reading it. The names moved to
+  // their own band above the scale, so there is nothing to collide with and
+  // nothing up here has to guess how wide a word renders.
+  it("keeps every time tick, including under a collection label", () => {
     const clips: readonly SeamBarClip[] = [
       clip("a", 20, "kitchen", "Kitchen"),
       clip("b", 20, "van", "Van Interior"),
@@ -192,18 +197,37 @@ describe("seamRulerTicks", () => {
     const times = seamRulerTicks({ strip: buildSeamStrip(clips, 10), clips })
       .filter((tick) => tick.kind === "time")
       .map((tick) => tick.x);
-    expect(times).not.toContain(200);
-    expect(times).not.toContain(250);
+    // "Van Interior" starts at x=200 and used to clear 200 and 250 with it.
+    expect(times).toContain(200);
+    expect(times).toContain(250);
     expect(times).toContain(300);
   });
 
-  it("gives way to a collection tick on its own mark as well", () => {
+  it("keeps the tick beside a seam, which the clash zone used to eat", () => {
     const times = seamRulerTicks({ strip: STRIP, clips: CLIPS })
       .filter((tick) => tick.kind === "time")
       .map((tick) => tick.x);
-    // 60 is the seam itself; 50 is inside the mark's own clash zone.
-    expect(times).not.toContain(60);
-    expect(times).not.toContain(50);
+    // The seam is at x=60 and the ladder steps by 50px here, so no time tick
+    // ever landed ON it — 50 is the one that did, and it sat inside the old
+    // mark's 26px clash zone and was dropped.
+    expect(times).toContain(50);
+    expect(times).toContain(100);
+    // And the seam still gets its own mark, from the collection pass.
+    expect(
+      seamRulerTicks({ strip: STRIP, clips: CLIPS })
+        .filter((tick) => tick.kind === "collection")
+        .map((tick) => tick.x),
+    ).toContain(60);
+  });
+
+  it("runs the ladder unbroken, so the scale has no holes in it", () => {
+    const times = seamRulerTicks({ strip: STRIP, clips: CLIPS })
+      .filter((tick) => tick.kind === "time")
+      .map((tick) => tick.x)
+      .sort((a, b) => a - b);
+    // Every gap is the same step — the shape a suppressed tick breaks.
+    const gaps = new Set(times.slice(1).map((x, index) => x - times[index]!));
+    expect(gaps.size).toBe(1);
   });
 
   it("never runs a tick past the end of the strip", () => {

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-bar-layout.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-bar-layout.ts
@@ -179,24 +179,13 @@ export type SeamTick = Readonly<{
  */
 const TICK_LADDER = [1, 2, 5, 10, 15, 30, 60, 120, 300] as const;
 const MIN_TICK_GAP_PX = 46;
-/** How close a time tick may come to a collection tick's own mark. */
-const TICK_CLASH_PX = 26;
-/**
- * Roughly how wide a collection label renders, per character, at the ruler's
- * 9px type — and the ceiling the label is truncated at.
- *
- * An estimate, because this is arithmetic and the text is not measurable from
- * here. It only has to be close: the label is LEFT-ALIGNED on its tick, so a
- * long name like "Loading Dock" reaches ~70px to the right of a mark whose
- * clash zone was 26, and the first time tick past that zone printed its "75s"
- * straight through the end of the word. Over-reserving costs one time tick on
- * a ruler that has a dozen; under-reserving costs the collection name, which
- * is the label that cannot be worked out from anything else on screen.
- */
-const LABEL_PX_PER_CHAR = 5.6;
-const LABEL_MAX_PX = 128;
-/** The breathing room a time tick keeps past the end of a name. */
-const LABEL_TAIL_PX = 8;
+// THE CLASH CONSTANTS ARE GONE, with the suppression that used them.
+//
+// They reserved the width a collection name would take so a time tick could be
+// dropped rather than printed through it — an estimate of rendered text, made
+// in a module with no DOM, and the kind of number that is wrong on the day the
+// type changes. The names have their own band above the scale now, so nothing
+// up here has to guess how wide a word is.
 
 export function tickStepSeconds(pxPerSecond: number): number {
   if (!Number.isFinite(pxPerSecond) || pxPerSecond <= 0) return TICK_LADDER.at(-1)!;
@@ -207,10 +196,17 @@ export function tickStepSeconds(pxPerSecond: number): number {
 /**
  * Every mark the ruler draws, in one pass.
  *
- * COLLECTION TICKS WIN TIES. A time tick says "ninety seconds", which you can
- * work out; a collection tick says "Van Interior starts here", which you
- * cannot. When they land within `TICK_CLASH_PX` of each other the time tick
- * is dropped, rather than both being drawn into the same smudge.
+ * ONE TICK PER STEP, AND EVERY COLLECTION BOUNDARY — nothing is dropped.
+ *
+ * Time ticks used to be suppressed wherever a collection name would have been
+ * printed over one. The name won, on the reasoning that a second is derivable
+ * and "Van Interior starts here" is not, and that was right while both shared
+ * a line. The cost was a scale with holes in it exactly where a collection
+ * starts, which is where you are most likely to be reading it.
+ *
+ * The names have their own band above the scale now, so there is nothing to
+ * collide with: names up there, seconds down here, and the tick marks between
+ * them belonging to both.
  */
 export function seamRulerTicks(params: {
   strip: SeamStrip;
@@ -228,18 +224,10 @@ export function seamRulerTicks(params: {
     collectionTicks.push({ x: segment.leftPx, label: clip.collectionName, kind: "collection" });
   }
 
-  // The span each collection tick claims: its mark, plus the width its name
-  // takes up to the right of it.
-  const claimed = collectionTicks.map((tick) => ({
-    from: tick.x - TICK_CLASH_PX,
-    to: tick.x + Math.min(LABEL_MAX_PX, tick.label.length * LABEL_PX_PER_CHAR) + LABEL_TAIL_PX,
-  }));
-
   const step = tickStepSeconds(strip.pxPerSecond);
   const timeTicks: SeamTick[] = [];
   for (let seconds = step; seconds * strip.pxPerSecond <= strip.totalPx; seconds += step) {
     const x = seconds * strip.pxPerSecond;
-    if (claimed.some((span) => x > span.from && x < span.to)) continue;
     timeTicks.push({ x, label: `${Math.round(seconds)}s`, kind: "time" });
   }
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-metrics.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-metrics.ts
@@ -20,9 +20,30 @@
  */
 export const BOX_INSET_PX = 2.5;
 
-/** How tall the ruler's band is. The fades over the film begin where it ends,
- *  and the active clip's mark sits above it. */
+/** How tall the SCALE band is — the numbers, the tick marks, the blocks. */
 export const SEAM_RULER_HEIGHT_PX = 20;
+
+/**
+ * The band above the scale, holding the collection names and nothing else.
+ *
+ * They used to sit in the scale among the seconds, which put two kinds of
+ * label — one naming a place, one measuring time — on one line competing for
+ * the same pixels. Lifted out, each row says one thing: names above, numbers
+ * below, and the tick marks in between belonging to both.
+ *
+ * 14px is the 10px lettering plus its leading and no more; this is a caption
+ * strip, not a second scale.
+ */
+export const SEAM_COLLECTION_BAND_PX = 14;
+
+/**
+ * The whole ruler block, names and scale together.
+ *
+ * What everything OUTSIDE measures from: the fades over the film begin where
+ * this ends, and the active clip's mark sits above it. Derived, so moving
+ * either band moves them with it.
+ */
+export const SEAM_RULER_TOTAL_PX = SEAM_COLLECTION_BAND_PX + SEAM_RULER_HEIGHT_PX;
 
 /**
  * How tall the film is.
@@ -80,4 +101,4 @@ export const MARK_RULER_GAP_PX = 2;
  * of burying it.
  */
 export const MARK_TOP_OFFSET_PX =
-  SEAM_RULER_HEIGHT_PX + MARK_HEIGHT_PX + MARK_RULER_GAP_PX;
+  SEAM_RULER_TOTAL_PX + MARK_HEIGHT_PX + MARK_RULER_GAP_PX;

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-ruler.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-ruler.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { BOX_INSET_PX, SEAM_RULER_HEIGHT_PX } from "./graph-seam-metrics";
+import {
+  BOX_INSET_PX,
+  SEAM_COLLECTION_BAND_PX,
+  SEAM_RULER_HEIGHT_PX,
+  SEAM_RULER_TOTAL_PX,
+} from "./graph-seam-metrics";
 import type { SeamTick } from "./graph-seam-bar-layout";
 
 /**
@@ -11,7 +16,7 @@ import type { SeamTick } from "./graph-seam-bar-layout";
  * begin exactly where the ruler stops or they cover the last row of labels.
  * Two places, one number.
  */
-export { SEAM_RULER_HEIGHT_PX };
+export { SEAM_RULER_HEIGHT_PX, SEAM_RULER_TOTAL_PX };
 
 /**
  * ── THE CLIPS, DRAWN AGAIN IN THE SCALE ─────────────────────────────────────
@@ -151,9 +156,9 @@ export function SeamRuler({
       // control, but hiding an element you can interact with is the one thing
       // `aria-hidden` must never do.
       aria-hidden={interactive ? undefined : "true"}
-      style={{ height: SEAM_RULER_HEIGHT_PX }}
+      style={{ height: SEAM_RULER_TOTAL_PX }}
       className={[
-        "relative overflow-hidden",
+        "relative",
         // `pointer-events-none` ONLY while it is decoration. As the hover
         // target it has to receive the pointer — and `touch-none`, because the
         // strip below claims every gesture and a ruler that scrolled the
@@ -162,6 +167,48 @@ export function SeamRuler({
       ].join(" ")}
       {...(handlers ?? {})}
     >
+      {/* ── THE NAMES, ON THEIR OWN LINE ABOVE THE SCALE ─────────────────
+          Same x as ever — the same `offset` and the same tick position — so a
+          name still starts exactly where its collection does. Only the height
+          changed.
+
+          ITS OWN CLIPPING BOX, so a long name running off the end of the bar
+          is cut at the bar's edge rather than at the scale's. The two bands
+          scroll as one and crop as one. */}
+      <div
+        data-seam-ruler-names
+        className="absolute inset-x-0 top-0 overflow-hidden"
+        style={{ height: SEAM_COLLECTION_BAND_PX }}
+      >
+        <div
+          className="absolute inset-y-0 left-0 w-full"
+          style={{ transform: `translateX(${offset}px)` }}
+        >
+          {ticks.map((tick) =>
+            tick.kind !== "collection" ? null : (
+              <span
+                key={`name-${tick.x}-${tick.label}`}
+                data-seam-tick-name={tick.kind}
+                style={{ left: tick.x }}
+                // Left-ALIGNED to the tick rather than centred on it. A
+                // collection label names the thing that starts HERE, and a
+                // centred one hangs half of itself over the collection that
+                // just ended — which reads as belonging to the wrong side of
+                // the seam.
+                className="absolute top-1/2 max-w-32 -translate-y-1/2 truncate font-mono text-[10px] leading-none tracking-wider whitespace-nowrap text-zinc-200"
+              >
+                {tick.label}
+              </span>
+            ),
+          )}
+        </div>
+      </div>
+
+      <div
+        data-seam-ruler-scale
+        className="absolute inset-x-0 bottom-0 overflow-hidden"
+        style={{ height: SEAM_RULER_HEIGHT_PX }}
+      >
       <div
         className="absolute inset-y-0 left-0 w-full"
         style={{ transform: `translateX(${offset}px)` }}
@@ -230,43 +277,31 @@ export function SeamRuler({
                 tick.kind === "collection" ? "h-1.5 bg-white/45" : "h-1 bg-white/25",
               ].join(" ")}
             />
-            {/* Left-ALIGNED to the tick rather than centred on it. A
-                collection label names the thing that starts HERE, and a
-                centred one hangs half of itself over the collection that just
-                ended — which reads as belonging to the wrong side of the
-                seam. */}
-            <span
-              className={[
-                // CENTRED IN THE BAND, not hung from its top.
+            {/* THE SECONDS, AND ONLY THE SECONDS. A collection's name is drawn
+                in the band above — see there for why the two rows are
+                separate. Rendering it here as well would be the same word
+                twice at two heights. */}
+            {tick.kind === "collection" ? null : (
+              <span
+                // CENTRED IN THE BAND, not hung from its top. At the top it sat
+                // against the edge with the rest of the band empty beneath it,
+                // so the row read as text with a margin under it rather than
+                // as a scale. `-translate-y-1/2` against `top-1/2` rather than
+                // a flex box, because the tick container is a zero-width
+                // anchor at the boundary with no box to centre anything in.
                 //
-                // At the top it sat against the edge with the whole rest of
-                // the band empty beneath it, so the row read as text with a
-                // margin under it rather than as a scale. Centred, the label
-                // sits in the middle of the block it names and the tick mark
-                // still has the bottom edge to itself — `-translate-y-1/2`
-                // against `top-1/2` rather than a flex box, because the tick
-                // container is a zero-width anchor at the boundary and has no
-                // box to centre anything in.
-                "absolute top-1/2 left-0 max-w-32 -translate-y-1/2 truncate text-[10px] leading-none whitespace-nowrap",
-                // READABLE, which the time labels were not. They were
-                // `text-zinc-600` at 9px — grey on near-black, at a size where
-                // the strokes are a pixel wide, so the numbers were legible
-                // only by being where numbers were expected. 10px and
-                // `zinc-400` is still quiet enough to stay a scale rather than
-                // a row of content, and can actually be read.
-                //
-                // The collection names keep their extra weight and letter
-                // spacing: they are the landmark, and the numbers are the
-                // grid they sit on.
-                tick.kind === "collection"
-                  ? "font-mono tracking-wider text-zinc-200"
-                  : "font-mono tabular-nums text-zinc-400",
-              ].join(" ")}
-            >
-              {tick.label}
-            </span>
+                // READABLE, which these were not. They were `text-zinc-600` at
+                // 9px — grey on near-black at a size where the strokes are a
+                // pixel wide, so the numbers were legible only by being where
+                // numbers were expected.
+                className="absolute top-1/2 left-0 max-w-32 -translate-y-1/2 truncate font-mono text-[10px] leading-none tabular-nums whitespace-nowrap text-zinc-400"
+              >
+                {tick.label}
+              </span>
+            )}
           </span>
         ))}
+      </div>
       </div>
     </div>
   );

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -17,7 +17,7 @@ import {
 } from "./graph-seam-bar-layout";
 import { SEAM_LANE_HEIGHT_PX, SeamLane, type SeamHover } from "./graph-seam-lane";
 import { SeamMinimap } from "./graph-seam-minimap";
-import { SEAM_RULER_HEIGHT_PX, SeamRuler } from "./graph-seam-ruler";
+import { SEAM_RULER_TOTAL_PX, SeamRuler } from "./graph-seam-ruler";
 import {
   buildSeamStrip,
   stripCentreOffset,
@@ -1040,14 +1040,14 @@ export function SeamStripBar({
           aria-hidden="true"
           data-seam-fade="left"
           hidden={offset >= -0.5}
-          style={{ top: SEAM_RULER_HEIGHT_PX, height: SEAM_LANE_HEIGHT_PX }}
+          style={{ top: SEAM_RULER_TOTAL_PX, height: SEAM_LANE_HEIGHT_PX }}
           className="pointer-events-none absolute left-0 w-6 bg-gradient-to-r from-zinc-950 to-transparent"
         />
         <span
           aria-hidden="true"
           data-seam-fade="right"
           hidden={strip.totalPx + offset <= trackWidth + 0.5}
-          style={{ top: SEAM_RULER_HEIGHT_PX, height: SEAM_LANE_HEIGHT_PX }}
+          style={{ top: SEAM_RULER_TOTAL_PX, height: SEAM_LANE_HEIGHT_PX }}
           className="pointer-events-none absolute right-0 w-6 bg-gradient-to-l from-zinc-950 to-transparent"
         />
       </div>


### PR DESCRIPTION
## The collection names move above the scale

Same x — same offset, same tick position — so a name still starts exactly where its collection does. Only the height changed.

They shared a line with the seconds before, which put two kinds of label (one naming a place, one measuring time) competing for the same pixels. Each row says one thing now: **names above, numbers below**, and the tick marks between them belonging to both.

## And every time tick survives

This is what the split was actually worth. A time tick used to be **dropped** wherever a collection name would have printed over it — the name won, on the reasoning that a second is derivable and "Van Interior starts here" is not. That was right while they shared a line. The cost was a scale with holes in it *exactly where a collection starts*, which is where you're most likely to be reading it.

Nothing collides now, so nothing is suppressed.

**The clash constants went with it** rather than being left unused. They reserved the width a name would take by estimating rendered text — 5.6px per character — from a module with no DOM. That's the kind of number that's wrong the day the type changes, and nothing up here has to guess how wide a word is any more.

## Is the scale honest about the gaps?

Checked, because it's the obvious thing to get wrong. Measured live at 29.17px/s:

| label | actual x on strip | seconds × pps | drift |
|---|---|---|---|
| 2s | 58.3 | 58.3 | **0** |
| 6s | 175.0 | 175.0 | **0** |
| 12s | 350.0 | 350.0 | **0** |

`buildSeamStrip` lays clips end to end with no gap; the 5px you see between boxes is carved *inside* each clip's own span by the 2.5px inset. It consumes no timeline, so a mark at 8s really is at 8×pps.

*Pre-existing caveat worth knowing:* because the gap is carved out of the span, every box paints 5px narrower than its true duration (2px floor). Invisible at normal zoom; at a wide reach where a clip is ~8px, box widths stop being reliably proportional and the ruler is the thing to read.

## Coverage

Two unit tests asserted the old suppression and are replaced by three: every time tick kept including under a label, the tick beside a seam kept, and **the ladder running unbroken** — that last one asserted as "every gap is the same step" rather than against a list of positions, because an unbroken ladder is the shape a reintroduced suppression would break.

The stories' label helper now reads collection names from their own band; the tick mark keeps `data-seam-tick` in the scale, so the label has a selector of its own rather than a marker carrying text only some of the time.

## Geometry

The band is 14px — the 10px lettering plus its leading; a caption strip, not a second scale. Everything outside measures from `SEAM_RULER_TOTAL_PX` now (the fades over the film, the active mark above it), so moving either band moves them with it. The scrim's padding owes twice the growth again: `20rem` → `21.75rem`.

## Checks

- `tsc --noEmit` clean; `eslint` **0 errors, 0 warnings**
- app `vitest` — **1447/1447** (112 files)
- `graph-item-details-modal.stories.tsx` — **44/44**

🤖 Generated with [Claude Code](https://claude.com/claude-code)