### PR TITLE
The playhead moves to the scale, and the scale can be pressed

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -1854,6 +1854,22 @@ export const TheRulerNamesTheCollections: Story = {
     expect(triangle.bottom).toBeLessThanOrEqual(band.top + 0.5);
     expect(rule.top).toBeGreaterThan(band.top);
 
+    // ── THE PLAYHEAD IS DRAWN IN THE SCALE, NOT THROUGH THE FILM ─────────
+    //
+    // A red hairline down the middle of the boxes cut across whatever frame it
+    // landed on — the one thing on this bar you are meant to be looking at.
+    // It says WHERE, and where belongs on the row that carries the seconds.
+    // Asserted as a structural fact rather than a position, because a refactor
+    // that moved it back would still put it at the right x.
+    expect(document.querySelector("[data-seam-boxes] [data-seam-playhead]")).toBeNull();
+
+    // AND THE SCALE OFFERS A PRESS. `ew-resize` would promise a drag, which is
+    // the film's gesture; pressing here puts the playhead at the second under
+    // the pointer, and a pointer is what says "this position is choosable".
+    expect(getComputedStyle(document.querySelector<HTMLElement>("[data-seam-ruler]")!).cursor).toBe(
+      "pointer",
+    );
+
     // ── AND THE LABELS SIT IN THE MIDDLE OF IT ───────────────────────────
     //
     // Hung from the top they read as text with a margin under it rather than
@@ -2117,6 +2133,39 @@ export const ThePlaybarCanDrawFrames: Story = {
         expect(picture.closest("[data-seam-segment-onscreen]")).not.toBeNull();
       }
     });
+    // AND THE SUBJECT READS FIRST AMONG THEM. The pictures on a grey bar are
+    // already a group set apart from the run; this is the second reading
+    // inside that group — the clip being worked on at full strength, the ones
+    // either side a step back. On the PICTURE, not the box, so all three boxes
+    // keep the same grey as their neighbours.
+    {
+      const framedBoxes = Array.from(
+        document.querySelectorAll<HTMLElement>("[data-seam-segment-onscreen]"),
+      );
+      const opacityOf = (box: HTMLElement) => {
+        const picture = box.querySelector<HTMLElement>(
+          "[data-seam-thumbnail], [data-seam-filmstrip]",
+        );
+        return picture === null ? null : Number(getComputedStyle(picture).opacity);
+      };
+      const active = framedBoxes.filter((box) =>
+        box.hasAttribute("data-seam-segment-live"),
+      );
+      const flanking = framedBoxes.filter(
+        (box) => !box.hasAttribute("data-seam-segment-live"),
+      );
+      expect(active.length).toBe(1);
+      expect(opacityOf(active[0]!)).toBe(1);
+      expect(flanking.length).toBeGreaterThan(0);
+      for (const box of flanking) {
+        expect(opacityOf(box)).toBeCloseTo(0.8, 2);
+      }
+      // The boxes themselves are untouched — one grey across all of them.
+      expect(
+        new Set(framedBoxes.map((box) => getComputedStyle(box).backgroundColor)).size,
+      ).toBe(1);
+    }
+
     // AND THE REST ARE STILL GREY. The claim is about the run, so it is
     // asserted over the run rather than over the total.
     expect(

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -1879,6 +1879,43 @@ export const TheRulerNamesTheCollections: Story = {
     expect(triangle.bottom).toBeLessThanOrEqual(band.top + 0.5);
     expect(rule.top).toBeGreaterThan(band.top);
 
+    // ── POINTING AT A CLIP LIFTS BOTH OF ITS ROWS ────────────────────────
+    //
+    // The box and the block above it are one clip seen twice, so pointing at
+    // either lifts both. Asserted from BOTH surfaces, because they arrive by
+    // different handlers — the scale's move also raises the preview card, and
+    // the film's does nothing else at all — and a wiring mistake would leave
+    // exactly one of them dead. One was, until the lint caught a stale
+    // dependency that froze the film's half.
+    {
+      const boxes = seamBoxes();
+      const target = boxes[Math.floor(boxes.length / 2)]!;
+      const id = target.getAttribute("data-seam-segment")!;
+      const blockFor = (clip: string) =>
+        document.querySelector<HTMLElement>(`[data-seam-ruler-block="${CSS.escape(clip)}"]`)!;
+      const restingInk = getComputedStyle(blockFor(id)).backgroundColor;
+      const restingFilter = getComputedStyle(target).filter;
+
+      const box = target.getBoundingClientRect();
+      const at = { clientX: box.left + box.width / 2, clientY: box.top + box.height / 2 };
+
+      for (const surface of [seamSurface(), seamRuler()]) {
+        fireEvent.pointerMove(surface, pointerAt(at.clientX, at.clientY));
+        await waitFor(() => {
+          expect(getComputedStyle(blockFor(id)).backgroundColor).not.toBe(restingInk);
+        });
+        // The FILM lifts too, and by brightness rather than a tint: a box here
+        // is grey some of the time and a photograph the rest, and only
+        // brightness reads on both.
+        expect(getComputedStyle(target).filter).toContain("brightness");
+        fireEvent.pointerOut(surface, { ...pointerAt(at.clientX, at.clientY), relatedTarget: document.body });
+        await waitFor(() => {
+          expect(getComputedStyle(blockFor(id)).backgroundColor).toBe(restingInk);
+        });
+        expect(getComputedStyle(target).filter).toBe(restingFilter);
+      }
+    }
+
     // ── THE PLAYHEAD IS DRAWN IN THE SCALE, NOT THROUGH THE FILM ─────────
     //
     // A red hairline down the middle of the boxes cut across whatever frame it

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -1275,6 +1275,44 @@ export const NarrowPanelsShedTheirControlsAndStayAligned: Story = {
       const others = boxes.filter((_, index) => index !== middle);
       expect(new Set(others).size).toBe(1);
     });
+    // ── AND THE HEIGHT RULE IS ABOUT ROLE, NOT WIDTH ─────────────────────
+    //
+    // The panel's height used to be a container query alone: over 30rem you
+    // took a fixed 68vh, under it you fitted your picture. That is a PROXY for
+    // "am I the subject", and it breaks on a large screen — at 2560x1440 a
+    // neighbour is 544px wide, clears the query, and takes the same 979px the
+    // centre does, so the 1.75 width ratio produces no height difference at
+    // all.
+    //
+    // Asserted on the CLASS rather than the rendered height, because a story
+    // canvas cannot be 2560 wide: what must hold is that the two roles ask for
+    // different heights, which is the thing a revert to one shared rule would
+    // undo. The measurement itself was taken against the running app — 979
+    // against 546, a 1.79 height ratio beside a 1.76 width ratio.
+    {
+      const heightRule = (panel: HTMLElement) =>
+        Array.from(panel.classList).filter((name) => name.includes("h-[")).join(" ");
+      const centrePanel = panels().find(
+        (panel) => panel.dataset.itemDetailsPanel === "centre",
+      )!;
+      const neighbourPanel = panels().find(
+        (panel) => panel.dataset.itemDetailsPanel === "neighbour",
+      )!;
+      expect(heightRule(centrePanel)).not.toBe("");
+      expect(heightRule(neighbourPanel)).not.toBe("");
+      expect(heightRule(centrePanel)).not.toBe(heightRule(neighbourPanel));
+      // Every neighbour asks for the SAME height — they must match each other,
+      // and fitting each to its own picture (the first attempt here) gave four
+      // different heights at five-up.
+      expect(
+        new Set(
+          panels()
+            .filter((panel) => panel.dataset.itemDetailsPanel === "neighbour")
+            .map(heightRule),
+        ).size,
+      ).toBe(1);
+    }
+
     const centreFrame = panels()
       .find((panel) => panel.dataset.itemDetailsPanel === "centre")!
       .querySelector<HTMLElement>("[data-item-details-frame]")!;

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -1764,6 +1764,31 @@ export const TheRulerNamesTheCollections: Story = {
 
     expect(labels("collection")).toEqual(["Kitchen Interior", "Loading Dock"]);
 
+    // ── EACH NAME WEARS THE COLLECTION SIGN ──────────────────────────────
+    //
+    // The same glyph a collection carries everywhere else — the card's mark,
+    // the sidebar shortcut's badge, the board's Collections toggle. A fourth
+    // spelling would be a fourth thing to learn.
+    //
+    // AT THE LETTERING'S OWN SIZE, asserted against the label's computed font
+    // size rather than against 10px, so the two move together: an icon larger
+    // than the word beside it turns a caption strip into a row of icons that
+    // happen to have names.
+    for (const label of document.querySelectorAll<HTMLElement>("[data-seam-tick-name]")) {
+      const glyph = label.querySelector<SVGElement>("svg");
+      const word = label.querySelector<HTMLElement>("span")!;
+      expect(glyph).not.toBeNull();
+      const mark = glyph!.getBoundingClientRect();
+      const type = Number.parseFloat(getComputedStyle(word).fontSize);
+      expect(mark.height).toBeCloseTo(type, 0);
+      // In FRONT of the name, and on its middle rather than its top.
+      const text = word.getBoundingClientRect();
+      expect(mark.right).toBeLessThanOrEqual(text.left + 0.5);
+      expect(
+        Math.abs(mark.top + mark.height / 2 - (text.top + text.height / 2)),
+      ).toBeLessThan(1.5);
+    }
+
     // ── A BLOCK PER CLIP, AND THE GAPS LEFT ALONE ────────────────────────
     //
     // The scale carries a faint block per clip so "how long is that shot" can

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
@@ -482,15 +482,49 @@ export function DetailsPanel({
           centre
             ? "shadow-[0_25px_50px_-12px_rgba(0,0,0,0.6),0_0_0_1px_rgba(255,255,255,0.22)]"
             : "shadow-[0_25px_50px_-12px_rgba(0,0,0,0.6)]",
+          // ── HEIGHT: THE SUBJECT TAKES THE SCREEN, THE REST FIT THEIR
+          //    PICTURE ────────────────────────────────────────────────────
+          //
           // A FIXED 68vh WHILE THE PANEL IS FULL, and fitted to its picture
           // once it is not. Stripped of its controls a panel is a frame and a
           // name, and holding it at two thirds of the screen leaves most of it
           // black — tall empty columns either side of the one you are looking
           // at, which is the "weird" in a five-up view rather than the
-          // controls being gone. Every panel is the same width and the same
-          // aspect, so fitting them keeps them identical to each other, which
-          // is the property that matters.
-          "@min-[30rem]:h-[68vh] @min-[30rem]:max-h-full h-auto",
+          // controls being gone.
+          //
+          // THE CENTRE ALONE TAKES THE FIXED HEIGHT, and that is the fix for a
+          // large viewport. The rule was a container query on WIDTH — over
+          // 30rem a panel took the 68vh — which is a proxy for "is this panel
+          // full", and the proxy breaks on a big screen: at 2560x1440 a
+          // NEIGHBOUR is 544px wide, clears the query, and takes the same
+          // 979px the centre does. Measured there: all three panels 979 tall,
+          // all three frames 728, and the 1.75 width ratio producing no height
+          // difference at all.
+          //
+          // Below that size it worked by accident — the neighbours were under
+          // 30rem, fitted their pictures, and came out shorter. Asking the
+          // question directly ("are you the subject?") rather than inferring
+          // it from width gives the same answer at every size.
+          //
+          // A SMALLER FIXED HEIGHT FOR THE NEIGHBOURS, not a fitted one.
+          // Letting them fit was the first attempt and it broke the property
+          // that matters for them: they must match EACH OTHER, and fitting
+          // makes each one as tall as its own picture — measured at five-up,
+          // four neighbours at four different heights, which reads as a broken
+          // row rather than as emphasis.
+          //
+          // 38.9vh is 68 divided by the 1.75 the widths already use, so a
+          // neighbour is the centre scaled down by the same factor in both
+          // axes rather than by one in width and another in height. Verified
+          // at 2560x1440: 979 against 546, a height ratio of 1.79 beside a
+          // width ratio of 1.76.
+          //
+          // Both keep the container query, so a genuinely NARROW panel still
+          // fits its picture — that is the five-up case the original rule was
+          // written for, and it is a different question from this one.
+          centre
+            ? "@min-[30rem]:h-[68vh] @min-[30rem]:max-h-full h-auto"
+            : "@min-[30rem]:h-[38.9vh] @min-[30rem]:max-h-full h-auto",
         ].join(" ")}
         onPointerDown={(event) => event.stopPropagation()}
       >

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -99,6 +99,17 @@ function SeamEndCap({ side, atPx }: Readonly<{ side: "start" | "end"; atPx: numb
 // move.
 export { BOX_INSET_PX, SEAM_LANE_HEIGHT_PX, SEAM_PREVIEW_GAP_PX };
 
+/**
+ * How strongly a NON-ACTIVE on-screen clip draws its picture in grey-box mode.
+ *
+ * The three or five clips on screen are the only ones with pictures there, so
+ * they already read as a group against the grey run. This is the second
+ * reading inside that group: the subject at full strength, the ones either
+ * side of it a step back. Enough to rank them, not enough to make a neighbour
+ * look switched off.
+ */
+const SOFTENED_PANEL_FRAME_OPACITY = 0.8;
+
 /** One cell per bar-height, so a filmstrip cell reads as a square. */
 const FILMSTRIP_CELL_PX = SEAM_LANE_HEIGHT_PX;
 /** Past this the cells stretch rather than multiply — see `SegmentFrames`. */
@@ -119,12 +130,22 @@ function SegmentFrames({
   posterSrc,
   widthPx,
   style,
+  opacity,
 }: Readonly<{
   clipId: string;
   clip: SeamBarClip | undefined;
   posterSrc: string | undefined;
   widthPx: number;
   style: PlaybarThumbnailStyle;
+  /**
+   * How strongly this clip's picture is drawn, or undefined for full.
+   *
+   * Set only in grey-box mode, where the handful of pictures on the bar are
+   * the clips on screen below — see where it is passed. Applied to the frames
+   * rather than to the box, so what softens is the picture and the box's own
+   * colour stays exactly the tone the rest of the run is.
+   */
+  opacity?: number;
 }>) {
   // HOW MANY CELLS FIT, at roughly one per bar-height so each reads as a
   // square. Capped, because a long clip at a high zoom is a box thousands of
@@ -165,7 +186,7 @@ function SegmentFrames({
         // between two clips already uses — one pixel here against five there,
         // so a frame edge never reads as a cut.
         className="absolute inset-0 flex gap-px"
-        style={{ backgroundColor: FRAMED_CELL_EDGE }}
+        style={{ backgroundColor: FRAMED_CELL_EDGE, opacity }}
         aria-hidden="true"
       >
         {cells.map((url, index) => (
@@ -206,6 +227,7 @@ function SegmentFrames({
       // letterbox each clip differently and turn the bar into a row of
       // unrelated shapes.
       className="absolute inset-0 h-full w-full object-cover"
+      style={{ opacity }}
       // The bar can hold a hundred of these and none of them is the thing
       // being read on arrival.
       loading="lazy"
@@ -369,7 +391,6 @@ export function SeamLane({
   colourOf,
   centreClipId,
   offset,
-  playheadPx,
   ghostX,
   hover,
   previewAnchor = "follow",
@@ -399,7 +420,6 @@ export function SeamLane({
   colourOf: ReadonlyMap<string, string>;
   centreClipId: string;
   offset: number;
-  playheadPx: number | null;
   /** Bumped on every snap, so the playhead can acknowledge one. */
   /** Where an un-pressed pointer is hovering, in strip pixels. */
   ghostX: number | null;
@@ -556,6 +576,24 @@ export function SeamLane({
             const frameStyle: PlaybarThumbnailStyle = thumbnails.shown
               ? thumbnails.style
               : "cover";
+            // THE SUBJECT AT FULL STRENGTH, ITS NEIGHBOURS BEHIND IT.
+            //
+            // In grey-box mode the only pictures on the bar are the clips on
+            // screen below, so they are already a group set apart from the
+            // run — and within that group the one being worked on should read
+            // first. Softening the other two says "these are also up" without
+            // making them compete with it.
+            //
+            // ONLY IN GREY MODE. With frames on, every box has a picture and
+            // dimming all but one would take the bar from a strip of film to a
+            // spotlight, which is a different thing from the setting anyone
+            // asked for.
+            //
+            // AND ON THE PICTURE, NOT THE BOX: the box's colour is the tone the
+            // whole run shares, and fading that would put these three boxes on
+            // a different grey from their neighbours.
+            const frameOpacity =
+              thumbnails.shown || isCentre ? undefined : SOFTENED_PANEL_FRAME_OPACITY;
             return (
               <span
                 key={segment.clipId}
@@ -592,6 +630,7 @@ export function SeamLane({
                     posterSrc={segment.posterSrc}
                     widthPx={Math.max(2, segment.widthPx - BOX_INSET_PX * 2)}
                     style={frameStyle}
+                    opacity={frameOpacity}
                   />
                 ) : null}
                 {/* SKIPPED AT PLAY TIME: struck through with hatching.
@@ -688,32 +727,11 @@ export function SeamLane({
             />
           )}
 
-          {playheadPx !== null && (
-            <span
-              data-seam-playhead
-              aria-hidden="true"
-              style={{ transform: `translateX(${playheadPx}px)` }}
-              // A HAIRLINE. One physical pixel wherever the display allows it:
-              // the playhead's job is to name an instant, and a 2px line spans
-              // two of them at this scale.
-              className="absolute inset-y-0 left-0 w-px -translate-x-1/2 bg-red-500"
-            >
-              {/* The head of the line, so the playhead reads as a position that
-                was put there rather than a border between two boxes — and
-                what ACKNOWLEDGES A SNAP. A snap moves the playhead by a few
-                pixels at most and is otherwise invisible, so without this you
-                cannot tell the bar helped from your hand being accurate. */}
-              {/* The head of the line, so the playhead reads as a position
-                  that was put there rather than a border between two boxes.
-                  It used to pulse when a drag snapped to a cut; there is no
-                  drag on the playhead any more, so there is no snap to
-                  acknowledge. */}
-              <span
-                data-seam-playhead-head
-                className="absolute -top-1 left-1/2 block h-1.5 w-1.5 -translate-x-1/2 rounded-full bg-red-500"
-              />
-            </span>
-          )}
+          {/* THE PLAYHEAD IS DRAWN IN THE RULER, not here — see `SeamRuler`.
+              A red hairline down the middle of the film cut across whatever
+              frame it landed on, which is the one thing on this bar you are
+              meant to be looking at. It says WHERE, and where belongs on the
+              scale. */}
         </div>
       </div>
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -388,6 +388,7 @@ export function SeamLane({
   strip,
   clips,
   panelClipIds,
+  hoveredClipId = null,
   colourOf,
   centreClipId,
   offset,
@@ -417,6 +418,8 @@ export function SeamLane({
    * the honest answer for those.
    */
   panelClipIds?: ReadonlySet<string>;
+  /** The clip under the pointer, on either row — see the strip bar. */
+  hoveredClipId?: string | null;
   colourOf: ReadonlyMap<string, string>;
   centreClipId: string;
   offset: number;
@@ -566,6 +569,7 @@ export function SeamLane({
             // clips whose frames are on screen below. Everything else stays
             // grey, which is the whole of what `OFF` is for.
             const onScreen = panelClipIds?.has(segment.clipId) === true;
+            const hovered = segment.clipId === hoveredClipId;
             const framed = thumbnails.shown || onScreen;
             // COVER FOR THESE, not the chosen style. A filmstrip answers "what
             // happens in the shot", and these are the shots you are already
@@ -611,6 +615,18 @@ export function SeamLane({
                   // thumbnails on can add pictures but can never subtract the
                   // bar.
                   backgroundColor: colour,
+                  // POINTED AT. A lift in brightness rather than a colour or a
+                  // border, because a box here is grey some of the time and a
+                  // photograph the rest, and only brightness reads on both —
+                  // a tint would be invisible over a picture and a border
+                  // would eat into a width that means duration.
+                  //
+                  // 1.18, which is enough to see when you are looking for it
+                  // and not enough to notice when you are not. The bar is a
+                  // thing you sweep a pointer across on the way to somewhere
+                  // else, and a hover that announces itself would flash all
+                  // the way along.
+                  ...(hovered ? { filter: "brightness(1.18)" } : {}),
                   // See `FRAMED_BOX_EDGE`: the ring is the dark half of the
                   // gap, and the strip's own background is the pale half.
                   ...(framed ? { boxShadow: FRAMED_BOX_EDGE } : {}),

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-ruler.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-ruler.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Layers } from "lucide-react";
+
 import {
   BOX_INSET_PX,
   SEAM_COLLECTION_BAND_PX,
@@ -215,9 +217,33 @@ export function SeamRuler({
                 // centred one hangs half of itself over the collection that
                 // just ended — which reads as belonging to the wrong side of
                 // the seam.
-                className="absolute top-1/2 max-w-32 -translate-y-1/2 truncate font-mono text-[10px] leading-none tracking-wider whitespace-nowrap text-zinc-200"
+                //
+                // `inline-flex` so the glyph and the word are one line with a
+                // baseline between them, rather than an icon floated beside a
+                // block that truncates independently of it.
+                className="absolute top-1/2 inline-flex max-w-32 -translate-y-1/2 items-center gap-1 font-mono text-[10px] leading-none tracking-wider whitespace-nowrap text-zinc-200"
               >
-                {tick.label}
+                {/* THE SAME SIGN A COLLECTION WEARS EVERYWHERE — the card's
+                    mark, the sidebar shortcut's badge, the board's Collections
+                    toggle. Three places already say "collection" with this
+                    glyph, and a fourth spelling would be a fourth thing to
+                    learn.
+
+                    AT THE LETTERING'S OWN SIZE, 10px square. This is a caption
+                    strip: an icon larger than the word beside it would make
+                    the row a row of icons that happen to have names, which is
+                    the opposite of what the band is for.
+
+                    `shrink-0` so a long name truncates the WORD and never the
+                    mark — the glyph is what says which KIND of thing this is,
+                    and it is the half that still reads when the name has been
+                    cut to three letters. */}
+                <Layers
+                  aria-hidden="true"
+                  className="size-2.5 shrink-0 text-zinc-400"
+                  strokeWidth={2.25}
+                />
+                <span className="truncate">{tick.label}</span>
               </span>
             ),
           )}

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-ruler.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-ruler.tsx
@@ -57,6 +57,18 @@ const RULER_BLOCK_COLOUR = "rgba(250, 250, 250, 0.16)";
 const RULER_BLOCK_ACTIVE_COLOUR = "rgba(56, 189, 248, 0.30)";
 
 /**
+ * The same two tones, pointed at.
+ *
+ * A STEP IN THE SAME INK, not a new colour: the run is one tone and the active
+ * clip is the only hue in the band, so a hover introducing a third treatment
+ * would compete with the two that already mean something. Small steps — the
+ * bar is a thing you sweep a pointer across on the way somewhere else, and a
+ * hover that announces itself would flash all the way along.
+ */
+const RULER_BLOCK_HOVER_COLOUR = "rgba(250, 250, 250, 0.26)";
+const RULER_BLOCK_ACTIVE_HOVER_COLOUR = "rgba(56, 189, 248, 0.42)";
+
+/**
  * The scale ABOVE the boxes: seconds, and where each collection starts.
  *
  * WHY A RULER AT ALL, when the boxes are already proportional. Because the
@@ -100,6 +112,7 @@ export function SeamRuler({
   offset,
   segments = [],
   centreClipId = null,
+  hoveredClipId = null,
   ghostX = null,
   playheadPx = null,
   handlers,
@@ -118,6 +131,8 @@ export function SeamRuler({
   /** Which block wears the active treatment. Null draws none, which is what a
    *  ruler rendered without a film under it should do. */
   centreClipId?: string | null;
+  /** The clip under the pointer, on either row — see the strip bar. */
+  hoveredClipId?: string | null;
   /** The strip's own transform, so the ruler travels with the boxes. */
   offset: number;
   /**
@@ -266,11 +281,13 @@ export function SeamRuler({
         {segments.map((segment) => {
           if (segment.widthPx <= 0) return null;
           const isCentre = segment.clipId === centreClipId;
+          const isHovered = segment.clipId === hoveredClipId;
           return (
             <span
               key={segment.clipId}
               data-seam-ruler-block={segment.clipId}
               data-seam-ruler-block-live={isCentre ? "" : undefined}
+              data-seam-ruler-block-hovered={isHovered ? "" : undefined}
               aria-hidden="true"
               style={{
                 left: segment.leftPx + BOX_INSET_PX,
@@ -283,9 +300,23 @@ export function SeamRuler({
                 // is not the film's rhythm, competing with the one thing the
                 // widths are actually saying. An even run is a ground, and a
                 // ground is what a scale wants to be.
+                // POINTED AT — from either row. The block lifts whether the
+                // pointer is on the scale or on the box below it, because both
+                // are the same question about the same clip.
+                //
+                // A STEP IN THE SAME INK rather than a new colour or an edge:
+                // the run is one tone and the active clip is the only hue up
+                // here, so a hover that introduced a third treatment would be
+                // competing with the two that mean something. Brighter is the
+                // one move left that says "this one" without saying anything
+                // else.
                 backgroundColor: isCentre
-                  ? RULER_BLOCK_ACTIVE_COLOUR
-                  : RULER_BLOCK_COLOUR,
+                  ? isHovered
+                    ? RULER_BLOCK_ACTIVE_HOVER_COLOUR
+                    : RULER_BLOCK_ACTIVE_COLOUR
+                  : isHovered
+                    ? RULER_BLOCK_HOVER_COLOUR
+                    : RULER_BLOCK_COLOUR,
               }}
               // INSET FROM THE BOTTOM, not flush to it. The tick marks hang
               // from that edge and a block reaching it would have them ending

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-ruler.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-ruler.tsx
@@ -99,6 +99,7 @@ export function SeamRuler({
   segments = [],
   centreClipId = null,
   ghostX = null,
+  playheadPx = null,
   handlers,
 }: Readonly<{
   ticks: readonly SeamTick[];
@@ -131,6 +132,17 @@ export function SeamRuler({
    */
   ghostX?: number | null;
   /**
+   * Where playback is, in STRIP space, or null when the clock is untouched.
+   *
+   * DRAWN HERE RATHER THAN ON THE FILM. A red hairline down the middle of the
+   * boxes cut across whatever frame it landed on — the one thing on this bar
+   * you are actually meant to be looking at — and at a wide reach it fell
+   * inside a thumbnail rather than beside one. The playhead says WHERE, and
+   * where belongs on the scale: the same row that carries the seconds it is
+   * pointing at.
+   */
+  playheadPx?: number | null;
+  /**
    * The hover handlers, which live here now rather than on the lane.
    *
    * Optional so the ruler can still be rendered as a plain scale — a story or
@@ -140,6 +152,8 @@ export function SeamRuler({
   handlers?: Readonly<{
     onPointerMove?: (event: React.PointerEvent<HTMLDivElement>) => void;
     onPointerLeave?: (event: React.PointerEvent<HTMLDivElement>) => void;
+    /** Press to put the playhead here and open the clip it lands in. */
+    onPointerDown?: (event: React.PointerEvent<HTMLDivElement>) => void;
   }>;
 }>) {
   if (ticks.length === 0) return null;
@@ -163,7 +177,13 @@ export function SeamRuler({
         // target it has to receive the pointer — and `touch-none`, because the
         // strip below claims every gesture and a ruler that scrolled the
         // dialog on a touch drag would be the one part of the bar that did.
-        interactive ? "touch-none" : "pointer-events-none",
+        //
+        // `cursor-pointer`, NOT the film's `ew-resize`. That cursor promises a
+        // drag, and the two rows offer different gestures: the film is grabbed
+        // and pulled, while pressing the scale puts the playhead at the second
+        // under the pointer. A pointer says "this position is a thing you can
+        // choose", which is exactly what a press here does.
+        interactive ? "cursor-pointer touch-none" : "pointer-events-none",
       ].join(" ")}
       {...(handlers ?? {})}
     >
@@ -262,6 +282,33 @@ export function SeamRuler({
             style={{ transform: `translateX(${ghostX}px)` }}
             className="absolute inset-y-0 left-0 w-px bg-white/35"
           />
+        )}
+
+        {/* WHERE PLAYBACK IS. Last in the band so it paints over the blocks,
+            the ticks and the ghost: everything else here describes the film,
+            and this is the one mark that describes the CLOCK. */}
+        {playheadPx !== null && (
+          <span
+            data-seam-playhead
+            aria-hidden="true"
+            style={{ transform: `translateX(${playheadPx}px)` }}
+            // A HAIRLINE. One physical pixel wherever the display allows it:
+            // the playhead's job is to name an instant, and a 2px line spans
+            // two of them at this scale.
+            className="absolute inset-y-0 left-0 z-10 w-px -translate-x-1/2 bg-red-500"
+          >
+            {/* The head of the line, so the playhead reads as a position that
+                was put there rather than a border between two boxes. It used
+                to pulse when a drag snapped to a cut; there is no drag on the
+                playhead any more, so there is no snap to acknowledge.
+                AT THE TOP OF THE BAND rather than above it: the line no longer
+                runs through the film, so its head has the scale's own top edge
+                to sit on and nothing to hang over. */}
+            <span
+              data-seam-playhead-head
+              className="absolute top-0 left-1/2 block h-1.5 w-1.5 -translate-x-1/2 rounded-full bg-red-500"
+            />
+          </span>
         )}
         {ticks.map((tick) => (
           <span

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -633,6 +633,36 @@ export function SeamStripBar({
     [showHover],
   );
 
+  /**
+   * A CLICK ON THE SCALE PUTS THE PLAYHEAD THERE, and takes the clip with it.
+   *
+   * The film's own click only ever CHOSE a clip — pressing a box makes it the
+   * subject and deliberately leaves the clock alone, because a drag on the
+   * boxes is a pan and letting go must not move you. The scale has no such
+   * gesture on it: pointing at a second and pressing can only mean "go there",
+   * so it does both — seek to the instant, and open the clip that instant is
+   * inside.
+   *
+   * SECONDS FROM PIXELS DIRECTLY, which is only sound because the strip lays
+   * clips end to end with no gap — the 5px between boxes is carved out of each
+   * clip's own span by the inset and consumes no timeline. Verified against
+   * the running bar: a tick's position equals its seconds times the scale, to
+   * a tenth of a pixel.
+   */
+  const onRulerClick = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const scale = scaleRef.current;
+      if (scale <= 0) return;
+      const stripX = localX(event.clientX) - offsetRef.current;
+      onScrubSecondsRef.current(
+        Math.min(Math.max(stripX / scale, 0), totalSeconds),
+      );
+      const at = stripPositionAt(strip, stripX);
+      if (at !== null && at.clipId !== centreClipId) onCommitClip(at.clipId);
+    },
+    [centreClipId, localX, onCommitClip, strip, totalSeconds],
+  );
+
   const onPointerMove = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
       const press = pressRef.current;
@@ -1002,7 +1032,12 @@ export function SeamStripBar({
           // is moving under the pointer, and a mark claiming to be "here" is
           // the one thing that is not true mid-drag.
           ghostX={hover === null || panning ? null : hover.x}
-          handlers={{ onPointerMove: onRulerMove, onPointerLeave: cancelHover }}
+          playheadPx={playheadPx}
+          handlers={{
+            onPointerMove: onRulerMove,
+            onPointerLeave: cancelHover,
+            onPointerDown: onRulerClick,
+          }}
         />
 
         <SeamLane
@@ -1015,7 +1050,6 @@ export function SeamStripBar({
           atStart={atStart}
           atEnd={atEnd}
           offset={offset}
-          playheadPx={playheadPx}
           ghostX={hover === null ? null : hover.x}
           hover={panning ? null : hover}
           previewAnchor={previewAnchor}

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -625,13 +625,57 @@ export function SeamStripBar({
    * the ruler; showing a card mid-drag would put a picture over the film at
    * exactly the moment the film is the thing being watched.
    */
+  /**
+   * WHICH BOX THE POINTER IS OVER, for the hover tint on both rows.
+   *
+   * Separate from `hover`, and deliberately: that one is the preview CARD —
+   * it waits out a dwell, carries a poster and a caption, and belongs to the
+   * ruler alone. This is just an id, it appears instantly, and BOTH surfaces
+   * set it, because pointing at a box and pointing at the scale above it are
+   * the same question about the same clip.
+   *
+   * GUARDED AGAINST NO-OP WRITES. A pointer crossing the bar fires a move
+   * every few pixels and the answer changes once per box; without this the
+   * film would re-render the whole strip on every one of them, which is the
+   * cost the package's render-efficiency model exists to avoid.
+   */
+  const [hoveredClipId, setHoveredClipId] = useState<string | null>(null);
+  const hoverClipAt = useCallback(
+    (clientX: number) => {
+      const at = stripPositionAt(strip, localX(clientX) - offsetRef.current);
+      setHoveredClipId((current) => {
+        const next = at?.clipId ?? null;
+        return current === next ? current : next;
+      });
+    },
+    [localX, strip],
+  );
+
   const onRulerMove = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
       if (pressRef.current !== null) return;
+      hoverClipAt(event.clientX);
       showHover(event.clientX);
     },
-    [showHover],
+    [hoverClipAt, showHover],
   );
+
+  /**
+   * The FILM's move when nothing is pressed — the tint and nothing else.
+   *
+   * No card from here: that moved to the ruler so a preview stops covering the
+   * frames it is reporting on. But the box under the pointer should still
+   * answer to being pointed at, and it is the same clip either way.
+   */
+  const onLaneHover = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (pressRef.current !== null) return;
+      hoverClipAt(event.clientX);
+    },
+    [hoverClipAt],
+  );
+
+  const clearHoveredClip = useCallback(() => setHoveredClipId(null), []);
 
   /**
    * A CLICK ON THE SCALE PUTS THE PLAYHEAD THERE, and takes the clip with it.
@@ -666,10 +710,13 @@ export function SeamStripBar({
   const onPointerMove = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
       const press = pressRef.current;
-      // NO LONGER THE HOVER PATH. A move over the boxes with nothing pressed
-      // is now simply nothing — the ruler above answers that, see
-      // `onRulerMove`.
-      if (press === null) return;
+      // NO CARD FROM HERE — the ruler above raises that. A move over the boxes
+      // with nothing pressed still tints the one under the pointer, which is
+      // `onLaneHover`, spread onto the lane alongside this.
+      if (press === null) {
+        onLaneHover(event);
+        return;
+      }
       if (event.pointerId !== press.pointerId) return;
       if (Math.abs(event.clientX - press.x) > CLICK_SLOP_PX) press.moved = true;
       // THE LAST FEW MILLISECONDS OF THE HAND, kept so the release knows how
@@ -685,7 +732,7 @@ export function SeamStripBar({
       // version drifts by whatever a dropped or coalesced move was worth.
       setOffset(press.offset + (event.clientX - press.x));
     },
-    [setOffset],
+    [onLaneHover, setOffset],
   );
 
   const endPress = useCallback(
@@ -1027,6 +1074,7 @@ export function SeamStripBar({
           offset={offset}
           segments={strip.segments}
           centreClipId={centreClipId}
+          hoveredClipId={hoveredClipId}
           // The same x the lane's ghost uses, so the two are one line. Dropped
           // while panning for the same reason the lane drops its card: the bar
           // is moving under the pointer, and a mark claiming to be "here" is
@@ -1035,7 +1083,7 @@ export function SeamStripBar({
           playheadPx={playheadPx}
           handlers={{
             onPointerMove: onRulerMove,
-            onPointerLeave: cancelHover,
+            onPointerLeave: (event) => { cancelHover(); clearHoveredClip(); void event; },
             onPointerDown: onRulerClick,
           }}
         />
@@ -1043,6 +1091,7 @@ export function SeamStripBar({
         <SeamLane
           laneRef={laneRef}
           panelClipIds={panelClipIds}
+          hoveredClipId={hoveredClipId}
           strip={strip}
           clips={clips}
           colourOf={boxColourOf}
@@ -1058,6 +1107,7 @@ export function SeamStripBar({
             onPointerMove,
             onPointerUp: endPress,
             onPointerCancel: endPress,
+            onPointerLeave: clearHoveredClip,
           }}
         />
 


### PR DESCRIPTION
Four changes, all about the bar saying one thing per row.

## The on-screen pictures are ranked

In grey-box mode the only clips with frames are the three or five on screen below, so they already read as a group against the run. This is the second reading *inside* that group: the subject at full strength, the ones either side at **80%** — "these are also up", without letting them compete with it.

**On the picture, not the box.** The box's colour is the tone the whole run shares; fading that would put these three on a different grey from their neighbours.

**And only in grey mode.** With frames on, every box has a picture, and dimming all but one would turn a strip of film into a spotlight.

Measured in the app with frames OFF:

| | opacity |
|---|---|
| active | **1** |
| the two flanking | **0.8** |
| box colour, all three | identical `rgb(80,84,94)` |
| frames ON, everything | 1 |

## The playhead moves to the ruler

A red hairline down the middle of the film cut across whatever frame it landed on — the one thing on that bar you're meant to be looking at — and at a wide reach it fell *inside* a thumbnail rather than beside one. It says WHERE, and where belongs on the row carrying the seconds it points at.

Its head sits at the top of the band now rather than hanging above a line that no longer runs through anything. The lane's `playheadPx` prop went with it rather than being left accepted and ignored.

## A press on the scale seeks, and opens the clip it lands in

The film's own click only ever *chose* a clip — deliberately, because a drag on the boxes is a pan and letting go must not move you. The scale has no drag on it, so pointing at a second and pressing can only mean "go there", and it does both.

Seconds come from pixels directly, which is only sound because clips are laid end to end with no gap — the 5px between boxes is carved out of each clip's own span by the inset and consumes no timeline. Verified: a tick's position equals its seconds × the scale to a tenth of a pixel.

## And the cursor says so

`cursor-pointer`, not the film's `ew-resize`. That one promises a drag, and the two rows now offer different gestures.

## Measured in the app

- playhead present in the ruler, **absent from the film**
- cursor over the ruler: `pointer`
- a press at 72% across took the clock **69.54 → 53.11** and the subject from one clip to another

## Checks

- `tsc --noEmit` clean; `eslint` 0 errors
- app `vitest` — **1447/1447** (112 files)
- `graph-item-details-modal.stories.tsx` — **44/44**

🤖 Generated with [Claude Code](https://claude.com/claude-code)