### PR TITLE
The app takes the whole viewport, and the playhead only shows while playing

### DIFF
--- a/apps/timeline-gstudio001/app/error.tsx
+++ b/apps/timeline-gstudio001/app/error.tsx
@@ -35,7 +35,7 @@ export default function AppError({
   }, [error]);
 
   return (
-    <div className="mx-auto flex w-full max-w-[1400px] flex-col gap-5 p-6">
+    <div className="flex w-full flex-col gap-5 p-6">
       <div
         role="alert"
         className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-4 text-sm text-zinc-300"

--- a/apps/timeline-gstudio001/app/page.tsx
+++ b/apps/timeline-gstudio001/app/page.tsx
@@ -204,7 +204,7 @@ export default function Home() {
   const initialLoading = isLoading && projects.length === 0;
 
   return (
-    <div className="mx-auto grid w-full max-w-[1400px] gap-6 pt-7 animate-fade-in">
+    <div className="grid w-full gap-6 pt-7 animate-fade-in">
       <header className="flex flex-col gap-4 border-b border-zinc-800 pb-5 md:flex-row md:items-end md:justify-between">
         <div className="grid min-w-0 flex-1 gap-2">
           <div className="flex items-center gap-2 text-[10px] font-black uppercase tracking-[0.24em] text-blue-400">

--- a/apps/timeline-gstudio001/app/timeline/[timelineId]/graph/layout.tsx
+++ b/apps/timeline-gstudio001/app/timeline/[timelineId]/graph/layout.tsx
@@ -47,7 +47,21 @@ export default async function GraphViewLayout({
     // past the container instead of overflowing inside it, killing
     // pan-to-scroll. Column flex stretches children to this container's
     // definite width, which is what the strip's overflow-x needs.
-    <div className="graph-view-theme mx-auto flex w-full max-w-[1400px] flex-col gap-5">
+    //
+    // NO WIDTH CAP. This was `mx-auto max-w-[1400px]`, which is the right
+    // instinct for a page of prose and the wrong one for this: the board is a
+    // strip you pan and a bar you read along, and both are worth exactly as
+    // much horizontal room as the screen has. Capped, a 2560px monitor spent
+    // 1160px of itself on two black margins beside the one row anybody was
+    // looking at.
+    //
+    // The `mx-auto` went with it rather than being left in — centring is a
+    // no-op once nothing is narrower than its container, and a no-op that
+    // looks like a decision is the kind of thing that gets copied forward.
+    //
+    // The page gutter is the root layout's `px-8` on `<main>`, which is where
+    // it belongs: one number for every route rather than a cap per page.
+    <div className="graph-view-theme flex w-full flex-col gap-5">
       <ClientGraphView projectId={timelineId} bootstrap={bootstrap} />
       {children}
     </div>

--- a/apps/timeline-gstudio001/app/timeline/[timelineId]/loading.tsx
+++ b/apps/timeline-gstudio001/app/timeline/[timelineId]/loading.tsx
@@ -19,7 +19,7 @@ export default function TimelineLoading() {
   return (
     <div
       aria-label="Loading project"
-      className="graph-view-theme mx-auto flex w-full max-w-[1400px] flex-col gap-5"
+      className="graph-view-theme flex w-full flex-col gap-5"
     >
       <GraphViewLoadingSkeleton />
     </div>

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -1623,6 +1623,20 @@ export const PlayingFromANeighbourRunsItOnTheMonitor: Story = {
     nudgePlayhead(4);
     await waitFor(() => expect(at()).toBeGreaterThan(3));
 
+    // ── THE PLAYHEAD IS DRAWN ONLY WHILE SOMETHING RUNS ──────────────────
+    //
+    // The clock holds a position from the moment anything touches it, so the
+    // red line used to sit on the bar permanently — claiming "playback is
+    // here" about a transport stopped an hour ago. It is the only saturated
+    // thing up there, and a permanent alarm colour is one that has stopped
+    // meaning anything.
+    //
+    // Asserted HERE, after a nudge has moved the clock well off zero: the
+    // point is that a known position is deliberately not drawn, which a check
+    // taken before anything touched the clock could pass for the wrong reason.
+    expect(document.querySelector("[data-seam-playhead]")).toBeNull();
+    expect(document.querySelector("[data-seam-playhead-head]")).toBeNull();
+
     // The RIGHT-hand panel: "After". Its stretch of the bar starts at 7s —
     // "Before" whole (3s), then "Subject" whole (4s).
     //
@@ -1660,6 +1674,19 @@ export const PlayingFromANeighbourRunsItOnTheMonitor: Story = {
     // pressed. This is the whole shape of the feature: one clock, one screen.
     expect(decodeURIComponent(monitorSrc())).toContain("AFTER");
 
+    // AND NOW THE PLAYHEAD IS DRAWN, because something is actually running.
+    //
+    // SYNCHRONOUS, WITH NO WAIT. The transport has been running since the
+    // click above, so there is nothing to wait FOR — and a `waitFor` here is
+    // not free: it let playback advance between the assertions that follow and
+    // the moment they describe, which failed the pause check two lines down on
+    // a state that had moved on. The whole story is one running clock, so
+    // anything inserted into it has to cost nothing.
+    expect(document.querySelector("[data-seam-playhead]")).not.toBeNull();
+    expect(document.querySelector("[data-seam-playhead-head]")).not.toBeNull();
+    // In the SCALE, not through the film — the two facts travel together.
+    expect(document.querySelector("[data-seam-ruler] [data-seam-playhead]")).not.toBeNull();
+
     // PRESSED AGAIN, IT PAUSES — and does not rewind. Pausing is the same
     // contract as the bar's button, so the two controls cannot disagree.
     fireEvent.click(playOf(panels()[2]!));
@@ -1668,6 +1695,14 @@ export const PlayingFromANeighbourRunsItOnTheMonitor: Story = {
     );
     expect(at()).toBeGreaterThanOrEqual(6);
     expect(playOf(panels()[2]!).getAttribute("aria-label")).toMatch(/^Play /);
+
+    // AND THE PLAYHEAD GOES WITH THE PLAYBACK, not with the position. The
+    // clock is still at six seconds — the line above asserts it — and the red
+    // line is gone anyway, which is the point: it reports that something is
+    // RUNNING, and a permanent alarm colour on a stopped transport is one that
+    // has stopped meaning anything.
+    expect(document.querySelector("[data-seam-playhead]")).toBeNull();
+    expect(document.querySelector("[data-seam-playhead-head]")).toBeNull();
   },
 };
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -1080,7 +1080,19 @@ export function SeamStripBar({
           // is moving under the pointer, and a mark claiming to be "here" is
           // the one thing that is not true mid-drag.
           ghostX={hover === null || panning ? null : hover.x}
-          playheadPx={playheadPx}
+          // ONLY WHILE SOMETHING IS RUNNING. The clock holds a position from
+          // the moment anything touches it — a scrub, a step, a press on the
+          // scale — so the red line used to sit on the bar permanently,
+          // claiming "playback is here" about a transport that had been
+          // stopped for an hour. It is the only saturated thing on the bar,
+          // and a permanent alarm colour is one that has stopped meaning
+          // anything.
+          //
+          // GATED AT THE RULER, not at the clock. The position itself is still
+          // tracked and still correct — the follow effect below reads it to
+          // keep a playing bar under the playhead, and pressing play has to
+          // resume from somewhere. This decides only whether it is DRAWN.
+          playheadPx={playing ? playheadPx : null}
           handlers={{
             onPointerMove: onRulerMove,
             onPointerLeave: (event) => { cancelHover(); clearHoveredClip(); void event; },


### PR DESCRIPTION
## No width cap

Every page was `mx-auto max-w-[1400px]` — the right instinct for a column of prose, the wrong one here. The board is a strip you pan and a bar you read along, and both are worth exactly as much horizontal room as the screen has.

**Measured at 2560: the board went from 1400 to 2409px** — 1009px the app was spending on two black margins beside the one row anybody was looking at.

**Four routes, not one:** the graph view, its loading state, the projects list, the error page. The loading state matters as much as the view — capped while the view wasn't, every load would land with a visible jump.

`mx-auto` went with the cap rather than being left behind: centring is a no-op once nothing is narrower than its container, and a no-op that looks like a decision gets copied forward. The page gutter is the root layout's `px-8`, which is where it belongs — one number for every route instead of a cap per page.

Verified: **32px either side at both 1414 and 2560**, nothing else between the board and the viewport.

## The playhead is drawn only while something runs

The clock holds a position from the moment anything touches it — a scrub, a step, a press on the scale — so the red line sat on the bar permanently, claiming "playback is here" about a transport stopped an hour ago. It's the only saturated thing up there, and a permanent alarm colour is one that has stopped meaning anything.

**Gated at the ruler, not at the clock.** The position is still tracked and still correct: the follow effect still reads it to keep a playing bar under the playhead, and pressing play still resumes from it. This decides only whether it's *drawn*.

Measured: hidden at rest · hidden after a press on the scale moves the clock with nothing playing · **drawn while playing** · hidden again on pause.

> **Worth knowing:** seeking now moves a playhead you can't see. That's the honest consequence of the rule as asked for. The bar still says where the *subject* is — the white triangle, its rule, and the sky block on the scale all stay.

## Coverage

The story asserts both halves, and one of them cost two attempts. A `waitFor` inserted mid-story let playback advance between the assertions that follow and the moment they describe, failing a pause check on a state that had moved on. The whole story is one running clock, so anything added to it has to cost nothing — the presence check is synchronous, and the absence check went after the pause the story already performs.

## Checks

- `tsc --noEmit` clean; `eslint` 0 errors
- app `vitest` — **1447/1447** (112 files)
- `graph-item-details-modal.stories.tsx` — **44/44**, three consecutive runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)