### PR TITLE
The panel stops short of the view-count control

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -3656,3 +3656,91 @@ export const TheActiveRuleIsClippedToTheBar: Story = {
     expect(markBox.right).toBeLessThanOrEqual(ruleBox.right + 0.5);
   },
 };
+
+/**
+ * A CLIP WHOSE POSTER CAN ACTUALLY BE ADDRESSED BY TIME.
+ *
+ * Every other seam fixture uses `plate()`, which is a data URI — and the frame
+ * builder is deliberately provider-neutral, returning anything it cannot
+ * address unchanged. So a data-URI poster proves nothing about trim: it comes
+ * back identical whether the trim was applied or ignored.
+ *
+ * These posters are Cloudinary-SHAPED — `/video/upload/` with a public id —
+ * which is the one thing `cloudinaryVideoFrameUrl` looks for. Nothing is
+ * fetched: the assertion reads the `so_` transform in the URL, and a broken
+ * image in the story canvas is the expected state.
+ *
+ * 2.5s of trim on a 10s source, so the offset is unmistakable — a thumbnail
+ * taken before the trim reads `so_0` or carries no offset at all.
+ */
+const CLOUDINARY_TRIMMED_SCENE: GraphNodeSpec = {
+  kind: "collection",
+  id: "root",
+  name: "Root",
+  children: [
+    {
+      kind: "media" as const,
+      mediaKind: "video" as const,
+      id: "subject",
+      name: "Trimmed",
+      src: "https://res.cloudinary.com/demo/video/upload/trimmed.mp4",
+      posterSrcs: ["https://res.cloudinary.com/demo/video/upload/trimmed.jpg"],
+      fullDurationSeconds: 10,
+      trimInSeconds: 2.5,
+      trimOutSeconds: 1,
+    },
+  ],
+};
+
+/**
+ * THE BAR'S THUMBNAIL IS THE FIRST FRAME OF THE CUT, NOT OF THE FILE.
+ *
+ * The cover thumbnail drew the encode's opening frame, so a clip trimmed past
+ * a slate, a countdown or a second of black showed exactly the thing the trim
+ * exists to discard — the box says "this shot" and the picture was one the cut
+ * does not contain.
+ *
+ * THE FILMSTRIP ALREADY GOT THIS RIGHT, which is what gave it away: it samples
+ * across the visible range, so switching a bar from STRIP to COVER moved the
+ * picture backwards in time. Both styles are asserted here for that reason —
+ * agreeing with each other is the property, not just each being trimmed.
+ */
+export const TheBarThumbnailStartsAfterTheTrim: Story = {
+  render: () => <SeamHarness scene={CLOUDINARY_TRIMMED_SCENE} />,
+  play: async () => {
+    await waitFor(() => expect(seamTrack()).not.toBeNull());
+    await settleStrip();
+
+    const offsets = () =>
+      Array.from(document.querySelectorAll<HTMLImageElement>("[data-seam-thumbnail]")).map(
+        (frame) => {
+          const found = /[/,]so_([\d.]+)/.exec(frame.getAttribute("src") ?? "");
+          return found === null ? null : Number(found[1]);
+        },
+      );
+
+    framesTo("COVER");
+    const cover = await waitFor(() => {
+      const found = offsets();
+      expect(found.length).toBe(1);
+      return found;
+    });
+    // AT THE TRIM, not at the file's head. The single-slot rule samples the
+    // START of the visible range deliberately — a lone thumbnail says "this is
+    // that shot", where the slot-centre rule would show its midpoint.
+    expect(cover[0]).toBe(2.5);
+
+    framesTo("STRIP");
+    await waitFor(() => expect(offsets().length).toBeGreaterThan(1));
+    const strip = offsets().filter((value): value is number => value !== null);
+    // EVERY cell inside the cut, and the first no earlier than the trim. The
+    // clip is 10s with 2.5 off the front and 1 off the back, so the visible
+    // range is 2.5 to 9.
+    expect(strip.length).toBeGreaterThan(1);
+    expect(Math.min(...strip)).toBeGreaterThanOrEqual(2.5);
+    expect(Math.max(...strip)).toBeLessThanOrEqual(9);
+
+    // Left as it was found, for whichever story runs next in this browser.
+    framesTo("STRIP");
+  },
+};

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -918,7 +918,14 @@ function DetailsFilmstripModal({
       // row that had itself moved 1728px, which put the card just chosen
       // entirely off the left edge. `clip` crops without ever being
       // scrollable, so the transform stays the only thing that moves the row.
-      className="fixed inset-0 z-[80] flex items-center justify-center overflow-clip bg-black/80 px-6 pt-[21.75rem] pb-6 backdrop-blur-sm"
+      // THE BOTTOM BAND IS RESERVED TOO, for the same reason the top one is.
+      //
+      // `pb-6` matched the view-count control's own `bottom-6`, which reserved
+      // the control's OFFSET and not the control — so the centre panel ran
+      // straight through it and 16px past the bottom of the window besides.
+      // 4.875rem is 78px: the control's 24px offset, its own 34px, and 20px of
+      // clearance so the panel stops short of it rather than against it.
+      className="fixed inset-0 z-[80] flex items-center justify-center overflow-clip bg-black/80 px-6 pt-[21.75rem] pb-[4.875rem] backdrop-blur-sm"
       // THE SCRIM DOES NOT DISMISS. Deliberate: this view is worked in, not
       // glanced at — trimming, scrubbing and swiping all end with the pointer
       // somewhere unpredictable, and the panels are cropped by the scrim

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
@@ -522,9 +522,39 @@ export function DetailsPanel({
           // Both keep the container query, so a genuinely NARROW panel still
           // fits its picture — that is the five-up case the original rule was
           // written for, and it is a different question from this one.
+          // `min-h-0` IS WHAT MAKES `max-h-full` MEAN ANYTHING. A flex item's
+          // default `min-height: auto` refuses to shrink below its content, so
+          // the cap was quietly losing to a panel whose header, frame and
+          // controls added up to more — the height was honoured and the LIMIT
+          // was not. Measured before: a 619px panel in a 484px band, ending
+          // 16px past the bottom of the window and 75px into the view-count
+          // control.
+          //
+          // The same fix `DETAILS_HERO_FILL_CLASS` already applies one level
+          // down, for the same reason and with the same failure mode.
+          "min-h-0",
+          // AND THE CAP IS AGAINST THE VIEWPORT, not against `100%`.
+          //
+          // `max-h-full` was inert here and the reason is worth keeping: a
+          // percentage max-height resolves against the PARENT, and this
+          // panel's parent is auto-sized to the panel — both measured 619px,
+          // so the cap was 100% of the thing it was meant to be capping.
+          // Circular, and silently so.
+          //
+          // The scrim reserves two bands, `pt-[21.75rem]` for the bar above
+          // and `pb-[4.875rem]` to clear the view-count control below. Their
+          // sum is what a panel may not exceed, and it is written here as one
+          // number because the alternative — threading `min-h-0 max-h-full`
+          // through the two auto-sized ancestors — puts a height constraint on
+          // the row that carries the strip's pan transform.
+          //
+          // KEEP IN STEP WITH THE SCRIM. 21.75 + 4.875 = 26.625rem. The
+          // failure if they drift is the panel running into the control again,
+          // which is what this fixed.
+          "max-h-[calc(100vh-26.625rem)]",
           centre
-            ? "@min-[30rem]:h-[68vh] @min-[30rem]:max-h-full h-auto"
-            : "@min-[30rem]:h-[38.9vh] @min-[30rem]:max-h-full h-auto",
+            ? "@min-[30rem]:h-[68vh] h-auto"
+            : "@min-[30rem]:h-[38.9vh] h-auto",
         ].join(" ")}
         onPointerDown={(event) => event.stopPropagation()}
       >

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-lane.tsx
@@ -166,6 +166,36 @@ function SegmentFrames({
     return urls.length === 0 ? null : urls;
   }, [clip, style, widthPx]);
 
+  /**
+   * THE ONE FRAME, TAKEN AFTER THE TRIM RATHER THAN BEFORE IT.
+   *
+   * The cover thumbnail drew `posterSrc` — the encode's opening frame — so a
+   * clip trimmed past a slate, a countdown, or a second of black showed
+   * exactly the thing the trim exists to discard. The box says "this shot",
+   * and the frame it showed was one the cut does not contain.
+   *
+   * THE FILMSTRIP ALREADY GOT THIS RIGHT, which is the tell: it samples across
+   * `[trimIn, trimIn + showing]`, so switching a bar from STRIP to COVER moved
+   * the picture backwards in time. Same range, same helper, one slot.
+   *
+   * A SINGLE SLOT IS ALREADY DEFINED TO SAMPLE THE START — see
+   * `videoFrameUrls`, where it is the documented exception to the
+   * slot-centre rule precisely so a lone thumbnail says "this is that shot"
+   * rather than showing its midpoint. Nothing new is asked of it here.
+   *
+   * Falls back to the base poster for anything with no frame list: a still, a
+   * fixture, an upload still in flight. That is the picture it had before.
+   */
+  const cover = useMemo(() => {
+    if (clip?.posterSrcs === undefined) return posterSrc;
+    return (
+      videoFrameUrls(clip.posterSrcs, 1, {
+        trimInSeconds: clip.trimInSeconds ?? 0,
+        effectiveSeconds: clip.showingSeconds,
+      })[0] ?? posterSrc
+    );
+  }, [clip, posterSrc]);
+
   if (cells !== null) {
     return (
       <span
@@ -212,12 +242,12 @@ function SegmentFrames({
     );
   }
 
-  if (posterSrc === undefined) return null;
+  if (cover === undefined) return null;
   return (
     // eslint-disable-next-line @next/next/no-img-element
     <img
       data-seam-thumbnail={clipId}
-      src={posterSrc}
+      src={cover}
       alt=""
       aria-hidden="true"
       // COVER, and no more. The box's width is its duration and its height is


### PR DESCRIPTION
The centre panel ran through the 3/5 control and **16px past the bottom of the window** besides. It stops 20px above the control now, and so do the neighbours.

## Two things were wrong

**The bottom band was not reserved.** `pb-6` matched the control's own `bottom-6` — which reserves the control's *offset* and not the control: 24px of padding for a thing that occupies 58. It's `4.875rem` now: the 24px offset, the control's own 34px, and 20px of clearance so the panel stops short of it rather than against it.

**And `max-h-full` was inert, silently.** A percentage max-height resolves against the **parent**, and this panel's parent is auto-sized to the panel — both measured 619px, so the cap was 100% of the thing it was meant to be capping. Circular, and nothing about it looks wrong in the class list.

`min-h-0` was my first fix and it wasn't enough alone: a flex item's `min-height: auto` refusing to shrink was *also* true, so the panel moved inside the window and still ran into the control. Both had to go.

## The cap is against the viewport now

`calc(100vh - 26.625rem)` — the sum of the two bands the scrim reserves. Written as one number rather than threaded down as `min-h-0 max-h-full` through the two auto-sized ancestors, because one of them is the row carrying the strip's pan transform, and a height constraint there is a different class of risk than an arithmetic one. The coupling is documented on both sides.

## Measured

At 1902×910:

| | |
|---|---|
| centre | 348 → **832** |
| view-count control | 852 |
| **gap** | **20px** |
| neighbours | 767 — also clear |
| outside the window | none |

Above ~1331px of viewport height the `68vh` takes over and the gap **grows** rather than shrinking — 37px at 1440.

## Checks

- `tsc --noEmit` clean; `eslint` 0 errors
- app `vitest` — **1447/1447** (112 files)
- `graph-item-details-modal.stories.tsx` — **44/44**

🤖 Generated with [Claude Code](https://claude.com/claude-code)