### PR TITLE
The details view collapses onto one control and three surfaces

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-details-design.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-details-design.ts
@@ -1,0 +1,112 @@
+/**
+ * ONE SET OF SURFACES, HAIRLINES AND TYPE FOR THE DETAILS VIEW.
+ *
+ * The view had grown about a dozen slightly different greys, four radii and
+ * three ways of drawing the same toggle — and that variance, rather than any
+ * one wrong value, is what read as untidy. Nothing here is new design; it is
+ * the set of values already in use, deduplicated down to the smallest number
+ * that still says everything the view needs to say, and given names so the
+ * next control added reaches for an existing value instead of inventing a
+ * thirteenth grey.
+ *
+ * THE RULE THAT MAKES IT A SYSTEM: depth comes from THREE surfaces and TWO
+ * hairlines, never from a fourth of either. A thing is the page, a card on the
+ * page, or a well cut into a card. If something seems to need a level between
+ * two of these, it wants a different position on the page, not a new grey.
+ */
+
+/* ── SURFACES ──────────────────────────────────────────────────────────── */
+
+/** The page a card sits on. */
+export const SURFACE_PAGE = "bg-zinc-950";
+
+/** A card. Opaque rather than a white wash, because these sit over the board
+ *  and a translucent card would let the board's own cards read through the
+ *  frame you are trying to judge. */
+export const SURFACE_CARD = "bg-[#0d0d10]";
+
+/** The SAME card, in focus. Two clicks of lightness — enough that the eye
+ *  reads the centre as nearer without it becoming a different component. */
+export const SURFACE_CARD_FOCUS = "bg-[#141418]";
+
+/** A well cut INTO a card: the transport bar, and the tray a control group
+ *  sits in. Darker than the card, so it reads as recessed rather than as a
+ *  second card stacked on the first. */
+export const SURFACE_WELL = "bg-[#08080a]";
+
+/* ── HAIRLINES ─────────────────────────────────────────────────────────── */
+
+/** Ordinary separation. */
+export const HAIRLINE = "border-white/[0.07]";
+
+/** The focused card only. Focus falloff is carried by BOTH the surface and
+ *  the border moving together; either alone is too quiet to survive a screen
+ *  full of pictures. */
+export const HAIRLINE_STRONG = "border-white/[0.16]";
+
+/* ── TYPE ──────────────────────────────────────────────────────────────── */
+
+/* FOUR SIZES, and the split between them is by JOB, not by size: mono for
+ * anything the machine knows (times, counts, control labels), sans for the
+ * one thing a person wrote (the clip's name). That is why a 13px title and a
+ * 13px readout look nothing alike and never need to be told apart by size. */
+
+/** A control's name, and any word that labels a value rather than being one. */
+export const TEXT_LABEL = "font-mono text-[11px] text-zinc-600";
+
+/** A value the machine produced: a duration, a count, a clip number. */
+export const TEXT_VALUE = "font-mono text-[11px] tabular-nums text-zinc-200";
+
+/** The same, when it is the second and lesser half of a pair — the source
+ *  length beside the cut length, the total beside the clock. */
+export const TEXT_VALUE_DIM = "font-mono text-[11px] tabular-nums text-zinc-500";
+
+/** BLUE IS RESERVED, and this is the whole of what it means: a number you can
+ *  edit. In and out points, the clock, the source time. It is not decoration
+ *  and it is not "important" — a duration you cannot type into stays grey, and
+ *  that consistency is what makes the blue ones findable. */
+export const TEXT_DATA = "font-mono text-[11px] tabular-nums text-blue-300";
+
+/** The clip's name on the card in focus. */
+export const TITLE_FOCUS = "text-[15px] font-semibold text-zinc-100";
+
+/** The clip's name on a card beside it. Dimmer AND smaller: a neighbour's
+ *  name is there to tell you which clip it is, not to be read. */
+export const TITLE_SIDE = "text-[13px] font-semibold text-zinc-400";
+
+/* ── RADII ─────────────────────────────────────────────────────────────── */
+
+/** A card. */
+export const RADIUS_CARD = "rounded-xl";
+/** A well, and a control group's tray. */
+export const RADIUS_WELL = "rounded-lg";
+/** Anything inside a well: a segment, a field, a chip. */
+export const RADIUS_INNER = "rounded-md";
+/** Picture. Tighter than its card, so the frame reads as mounted IN the card
+ *  rather than as the card's own edge. */
+export const RADIUS_MEDIA = "rounded-md";
+
+/* ── ACCENTS ───────────────────────────────────────────────────────────── */
+
+/* Three, each with exactly one meaning, none of them shared:
+ *   BLUE  — a value you can edit (TEXT_DATA above).
+ *   RED   — the playhead. Never anything else, so a red mark anywhere in the
+ *           view means "play is here" without being labelled.
+ *   AMBER — a judgement someone made. Today that is the keeper tag: the one
+ *           chip in a row of factual ones that says what a person decided.
+ * WHITE is not an accent — it is spent entirely on the play button, which is
+ * why that button is findable at a glance on a screen of grey furniture. */
+
+/** The keeper tag, and any tag that later comes to mean the same kind of
+ *  judgement. Quiet on purpose: it should be findable in the row, not the
+ *  loudest thing on the card. */
+export const TAG_JUDGEMENT =
+  "bg-amber-400/[0.08] text-amber-300/90 ring-amber-400/25";
+
+/** Every other tag: what the clip IS, not what anyone thought of it. */
+export const TAG_FACT = "bg-white/[0.04] text-zinc-300 ring-white/10";
+
+/** Tags that carry a judgement, and so wear {@link TAG_JUDGEMENT}.
+ *  A set rather than a single name so the vocabulary can grow without another
+ *  branch appearing at the call site. */
+export const JUDGEMENT_TAGS: ReadonlySet<string> = new Set(["keeper"]);

--- a/apps/timeline-gstudio001/components/graph-view/graph-details-segmented.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-details-segmented.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import {
+  HAIRLINE,
+  RADIUS_INNER,
+  RADIUS_WELL,
+  SURFACE_WELL,
+  TEXT_LABEL,
+} from "./graph-details-design";
+
+/** One choice in a group. */
+export type Segment<T> = Readonly<{
+  value: T;
+  /** What the segment says. Short — these sit four to a row. */
+  label: ReactNode;
+  /** The long form, which is where the actual explanation lives. */
+  title: string;
+  /**
+   * Whether this is the current choice — ASKED OF THE CALLER rather than
+   * derived from a `value` prop, because not every group is a plain
+   * one-of-N. The frames group is three buttons over two settings (whether
+   * boxes draw frames, and which kind), so "is this the active one" is a
+   * question only its owner can answer.
+   */
+  active: boolean;
+}>;
+
+/**
+ * THE toggle. Not "a" toggle — the details view has exactly one, and every
+ * choice in it is this: what the bar's boxes draw, where the hover card sits,
+ * how far the bar reaches, how many clips are on screen.
+ *
+ * WHY ONE. There were four renditions of this control, differing in text size,
+ * padding, whether the group sat in a tray, and how the active choice was
+ * marked. Read individually each was fine; read together — and they are always
+ * read together, since three of them share a row — the differences said there
+ * was some distinction between them, and there is none. Collapsing them is
+ * most of what stops the row looking accidental.
+ *
+ * THE ACTIVE SEGMENT IS RAISED, NOT INVERTED. It used to be a solid white chip
+ * on black, which is the loudest mark the palette has, and it was being spent
+ * four times over on settings you change once a session. White now belongs to
+ * the play button alone. A segment lifts by one step of surface and one
+ * hairline instead — enough to be unambiguous in a group of two to four, and
+ * quiet enough that the pictures stay the bright things on screen.
+ *
+ * THE TRAY IS THE GROUP. Boxing the whole set (rather than only the active
+ * member) is what makes four labels read as one control with one answer.
+ * Without it a row of bare words has to be parsed before it can be used.
+ */
+export function SegmentedControl<T>({
+  label,
+  ariaLabel,
+  segments,
+  onSelect,
+  groupAttribute,
+}: Readonly<{
+  /** The control's name, drawn outside the tray. Omitted where the segments
+   *  name themselves — the view-count pager is `3 · 5`, and a "clips" label
+   *  in front of it would be the third place on screen saying so. */
+  label?: string;
+  ariaLabel: string;
+  segments: ReadonlyArray<Segment<T>>;
+  onSelect: (value: T) => void;
+  /** e.g. `data-details-bar-reach` — the handle tests and e2e reach for. */
+  groupAttribute?: string;
+}>) {
+  return (
+    <div className="flex items-center gap-1.5">
+      {label === undefined ? null : <span className={TEXT_LABEL}>{label}</span>}
+      <div
+        {...(groupAttribute === undefined ? {} : { [groupAttribute]: "" })}
+        role="group"
+        aria-label={ariaLabel}
+        className={[
+          "inline-flex items-center gap-0.5 border p-0.5",
+          RADIUS_WELL,
+          HAIRLINE,
+          SURFACE_WELL,
+        ].join(" ")}
+      >
+        {segments.map((segment) => (
+          <button
+            key={String(segment.value)}
+            type="button"
+            aria-pressed={segment.active}
+            onClick={() => onSelect(segment.value)}
+            title={segment.title}
+            className={[
+              // `min-w-7` so a two-character segment and a five-character one
+              // sit on the same rhythm — without it `5 · 10 · 20 · All` steps
+              // unevenly and reads as four unrelated buttons.
+              "min-w-7 px-2 py-[3px] text-center font-mono text-[11px] tabular-nums",
+              "transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70",
+              RADIUS_INNER,
+              // MEASURED AGAINST THE TRAY IT SITS IN, not chosen in the
+              // abstract. The tray is near-black, so a 10% white fill
+              // lands at about #1b1b1d and the active segment reads as a
+              // slightly different dark rather than as the chosen one. At
+              // 14% with an 18% edge it separates cleanly and is still
+              // nowhere near the play button's solid white.
+              segment.active
+                ? "bg-white/[0.14] text-zinc-50 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.18)]"
+                // IDLE IS STILL A LABEL YOU HAVE TO READ. zinc-500 on this
+                // tray is legible in isolation and mush at a glance in a
+                // row of four; a segment nobody can read is not a choice.
+                : "text-zinc-400 hover:bg-white/[0.06] hover:text-zinc-100",
+            ].join(" ")}
+          >
+            {segment.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -793,40 +793,61 @@ export const OpensShowingItsOwnPicture: Story = {
 
 
 /**
- * THE RING SAYS WHICH PANEL IS THE SUBJECT, AND NEVER MOVES.
+ * HOW A PANEL IS MARKED AS THE SUBJECT, read the way the eye reads it.
+ *
+ * The mark is the border's ALPHA — 0.16 on the subject against 0.07 on a
+ * neighbour — so the question "is this one marked" is really "is its edge
+ * brighter than the others". Comparing the two rather than matching a colour
+ * string keeps the assertion about the DIFFERENCE, which is the only part
+ * anyone can see, and keeps it honest if the palette is ever retuned.
+ *
+ * Tailwind emits these as `oklab(... / A)`, so the alpha is the last number in
+ * the string; a colour with no alpha at all is fully opaque.
+ */
+function borderAlpha(panel: HTMLElement): number {
+  const parts = getComputedStyle(panel).borderTopColor.match(/[\d.]+/g) ?? [];
+  return parts.length >= 4 ? Number(parts[parts.length - 1]) : 1;
+}
+
+/** The subject's edge, against the brightest edge any neighbour is wearing. */
+function subjectIsMarked(): boolean {
+  const centre = document.querySelector<HTMLElement>('[data-item-details-panel="centre"]')!;
+  const neighbours = Array.from(
+    document.querySelectorAll<HTMLElement>('[data-item-details-panel="neighbour"]'),
+  );
+  if (neighbours.length === 0) return borderAlpha(centre) > 0;
+  return borderAlpha(centre) > Math.max(...neighbours.map(borderAlpha));
+}
+
+/**
+ * THE MARK SAYS WHICH PANEL IS THE SUBJECT, AND NEVER MOVES.
  *
  * It used to follow the playhead: whichever clip's frames were on the monitor
- * wore the ring, so during a run-up it sat on a neighbour. The idea was to tie
- * the line moving through the bar to the panel it belonged to.
+ * wore it, so during a run-up it sat on a neighbour. The idea was to tie the
+ * line moving through the bar to the panel it belonged to.
  *
  * In use it read as flicker — a halo hopping between panels as the clock
  * crossed a seam, drawing the eye to the frame it was meant to be quietly
  * identifying. The bar has a playhead and a marked box for saying where
  * playback is, and two answers to one question is one too many.
  *
- * So the ring answers the simpler question it is well shaped for, constantly:
+ * So the mark answers the simpler question it is well shaped for, constantly:
  * which of these panels is the one you opened. Asserted as an INVARIANT rather
  * than a transition — it must not move when the clock does, which is the whole
  * change.
  */
-export const TheRingMarksWhoseFramesAreUp: Story = {
+export const TheSubjectMarkStandsStillWhileTheClockMoves: Story = {
   render: () => <SeamHarness scene={TRIMMED_SCENE} />,
   play: async () => {
     await waitFor(() => expect(seamTrack()).not.toBeNull());
-    const centre = () => document.querySelector<HTMLElement>('[data-item-details-panel="centre"]')!;
-    const neighbours = () =>
-      Array.from(document.querySelectorAll<HTMLElement>('[data-item-details-panel="neighbour"]'));
-    const ringed = (panel: HTMLElement) =>
-      getComputedStyle(panel).boxShadow.includes("255, 255, 255");
 
-    expect(ringed(centre())).toBe(true);
-    expect(neighbours().some(ringed)).toBe(false);
+    expect(subjectIsMarked()).toBe(true);
 
     // Move the clock right across a seam and onto another clip's frames. The
-    // monitor changes; the ring does not.
+    // monitor changes; the mark does not.
     //
     // HELD, NOT RELEASED. Letting go now lands the row on whatever the
-    // playhead reached, and this story is about the ring during the look —
+    // playhead reached, and this story is about the mark during the look —
     // the state where the monitor is showing one clip and the subject is
     // still another. Releasing would collapse the two and the assertion
     // would be trivially true.
@@ -838,44 +859,58 @@ export const TheRingMarksWhoseFramesAreUp: Story = {
     await waitFor(() =>
       expect(seamTrack().getAttribute("aria-valuenow")).not.toBe(null),
     );
-    expect(ringed(centre())).toBe(true);
-    expect(neighbours().some(ringed)).toBe(false);
+    expect(subjectIsMarked()).toBe(true);
   },
 };
 
 /**
  * ONE MARK, AND IT DOES NOT COMPETE WITH THE PICTURES.
  *
- * Panels are identical but for the ring on the subject. The opened clip wore a
+ * Panels are identical but for their focus falloff: the subject sits on a
+ * lighter surface behind a brighter edge, and its neighbours recede. It wore a
  * heavy white border for a while — the loudest mark on the screen, spent on
- * the one fact the layout already tells you — and then two pixels of sky with
- * a 36px halo, which had to shout because it was moving. Standing still, a
- * hairline is enough.
+ * the one fact the layout already tells you — then two pixels of sky with a
+ * 36px halo, which had to shout because it was moving, and then a white ring.
+ * Standing still, two clicks of contrast are enough.
  *
- * Geometry is untouched by it either way: a box-shadow paints outside the box,
- * so the panel that wears one is exactly as wide as the ones that do not.
+ * GEOMETRY IS UNTOUCHED. Only the border's COLOUR changes with focus, never
+ * its width: a 2px edge on the subject would push its picture down a pixel and
+ * shorten it by two, and comparing frames ACROSS panels is what this view is
+ * for.
+ *
+ * BOTH HALVES ARE ASSERTED. Surface and border move together because either
+ * alone is too quiet to survive a screen full of pictures, so a change that
+ * silently dropped one would leave a mark that still technically exists and no
+ * longer reads.
  */
-export const OnlyTheLiveClipIsMarked: Story = {
+export const OnlyTheSubjectPanelIsMarked: Story = {
   render: () => <SeamHarness scene={TRIMMED_SCENE} />,
   play: async () => {
     await waitFor(() => expect(seamTrack()).not.toBeNull());
     const centre = document.querySelector<HTMLElement>('[data-item-details-panel="centre"]')!;
     const neighbour = document.querySelector<HTMLElement>('[data-item-details-panel="neighbour"]')!;
 
-    // Same box, different shadow: the ring costs no width.
+    // Same box, brighter edge: the mark costs no width.
     expect(getComputedStyle(centre).borderTopWidth).toBe(
       getComputedStyle(neighbour).borderTopWidth,
     );
-    expect(getComputedStyle(centre).boxShadow).toMatch(/255, 255, 255/);
-    expect(getComputedStyle(neighbour).boxShadow).not.toMatch(/255, 255, 255/);
+    expect(borderAlpha(centre)).toBeGreaterThan(borderAlpha(neighbour));
 
-    // And the sky-blue ring that used to follow the playhead is gone from
-    // both — a colour this view no longer spends here.
+    // ...and a lighter surface under it.
+    expect(getComputedStyle(centre).backgroundColor).not.toBe(
+      getComputedStyle(neighbour).backgroundColor,
+    );
+
+    // The white ring and the sky-blue one that used to follow the playhead are
+    // both gone: the shadow lifts the row off the board and says nothing about
+    // which panel you are in, so it is the SAME on every panel.
     await settleStrip();
     nudgePlayhead(1);
     await waitFor(() => expect(seamTrack()).not.toBeNull());
+    expect(getComputedStyle(centre).boxShadow).toBe(
+      getComputedStyle(neighbour).boxShadow,
+    );
     expect(getComputedStyle(centre).boxShadow).not.toMatch(/56, 189, 248/);
-    expect(getComputedStyle(neighbour).boxShadow).not.toMatch(/56, 189, 248/);
   },
 };
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -33,6 +33,7 @@ import { CollectionDetailsBody } from "./graph-collection-details";
 import { ItemDisableToggle } from "./graph-item-disable-toggle";
 import { useItemDetails } from "./graph-item-details-context";
 import { detailsStepTransition } from "./graph-details-motion";
+import { SegmentedControl } from "./graph-details-segmented";
 import { withViewTransition } from "@/lib/view-transition";
 import { detailsWindow, flatOrderRootId } from "./graph-details-neighbours";
 import { useSeamTransport } from "./graph-seam-bar";
@@ -981,145 +982,86 @@ function DetailsFilmstripModal({
               // bar's own controls row alongside the transport and the clock.
               settingsLeft={
                 <>
-                <div
-                  data-details-bar-frames
-                  role="group"
-                  aria-label="What the bar's boxes draw"
-                  className="flex items-center gap-1"
-                >
-                  <span className="mr-1 font-mono text-[10px] text-zinc-500">frames</span>
-                  {/* THREE BADGES, TWO SETTINGS. Whether the boxes draw frames
-                      and which kind are separate answers, but as controls they
-                      are one question — a picture of what the bar is made of —
-                      and a row that reads OFF · COVER · STRIP says it in the
-                      shape the reach beside it already uses.
+                  {/* THREE SEGMENTS, TWO SETTINGS. Whether the boxes draw
+                      frames and which kind are separate answers, but as
+                      controls they are one question — a picture of what the
+                      bar is made of — and OFF · COVER · STRIP says it in the
+                      shape every other group in this row now uses.
 
                       OFF DOES NOT WIPE THE STYLE. It sets `shown` and leaves
                       `style` alone, so coming back lands on the kind you were
                       using: switching frames off and on stays a comparison you
                       can make twice rather than a choice you re-enter. That is
-                      the whole reason the two are stored apart even though they
-                      are pressed together. */}
-                  {(["off", ...PLAYBAR_THUMBNAIL_STYLES] as const).map((option) => {
-                    const active = option === "off" ? !frames.shown : frames.shown && frames.style === option;
-                    return (
-                      <button
-                        key={option}
-                        type="button"
-                        aria-pressed={active}
-                        onClick={() =>
-                          chooseFrames(
-                            option === "off"
-                              ? { ...frames, shown: false }
-                              : { shown: true, style: option },
-                          )
-                        }
-                        title={
-                          option === "off"
-                            ? "Plain boxes"
-                            : option === "cover"
-                              ? "One frame filling each box"
-                              : "A strip of frames across each clip"
-                        }
-                        className={[
-                          "min-w-7 rounded px-1.5 py-0.5 font-mono text-[10px] tabular-nums transition-colors",
-                          active
-                            ? "bg-zinc-100 text-zinc-900"
-                            : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100",
-                        ].join(" ")}
-                      >
-                        {/* `STRIP`, not `FILMSTRIP`: these badges sit beside a
-                            reach picker of two- and three-character tokens, and
-                            one nine-character label would set the row's rhythm
-                            for the sake of a word the title attribute already
-                            says in full. */}
-                        {option === "filmstrip" ? "STRIP" : option.toUpperCase()}
-                      </button>
-                    );
-                  })}
+                      the whole reason the two are stored apart even though
+                      they are pressed together. */}
+                  <SegmentedControl
+                    label="frames"
+                    ariaLabel="What the bar's boxes draw"
+                    groupAttribute="data-details-bar-frames"
+                    segments={(["off", ...PLAYBAR_THUMBNAIL_STYLES] as const).map((option) => ({
+                      value: option,
+                      // `STRIP`, not `FILMSTRIP`: these sit beside a reach
+                      // picker of two- and three-character tokens, and one
+                      // nine-character label would set the row's rhythm for
+                      // the sake of a word the title already says in full.
+                      label: option === "filmstrip" ? "STRIP" : option.toUpperCase(),
+                      title:
+                        option === "off"
+                          ? "Plain boxes"
+                          : option === "cover"
+                            ? "One frame filling each box"
+                            : "A strip of frames across each clip",
+                      active:
+                        option === "off" ? !frames.shown : frames.shown && frames.style === option,
+                    }))}
+                    onSelect={(option) =>
+                      chooseFrames(
+                        option === "off" ? { ...frames, shown: false } : { shown: true, style: option },
+                      )
+                    }
+                  />
 
-                </div>
-
-                {/* WHERE THE HOVER CARD SITS.
-                    ITS OWN GROUP, next to `frames` rather than inside it. They
-                    sit together because they are the same kind of question —
-                    what this bar does while you read it — and because the card
-                    only exists to show the frames the control beside it turned
-                    on. But "what the boxes draw" and "where the preview sits"
-                    are two settings, and folding the second into the first
-                    group gave that group five buttons under an aria-label
-                    describing three of them.
-
-                    `PIN` parks it dead centre under the bar so the pointer
-                    scrubs and the picture changes in place. That matters now
-                    the card is big enough to judge a frame in: a large picture
-                    sliding around under a moving pointer is the one
-                    arrangement in which you cannot judge anything, because the
-                    eye spends the sweep re-finding it. The cost is that a card
-                    away from the box is less obviously ABOUT that box, which
-                    is why this is a choice and not a change. */}
-                <span aria-hidden="true" className="mx-1 h-3 w-px bg-white/10" />
-                <div
-                  data-details-bar-card
-                  role="group"
-                  aria-label="Where the hover preview sits"
-                  className="flex items-center gap-1"
-                >
-                  <span className="mr-1 font-mono text-[10px] text-zinc-500">card</span>
-                  {PREVIEW_ANCHORS.map((option) => (
-                    <button
-                      key={option}
-                      type="button"
-                      aria-pressed={option === previewAnchor}
-                      onClick={() => choosePreviewAnchor(option)}
-                      title={
+                  {/* WHERE THE HOVER CARD SITS — its own group, next to
+                      `frames` rather than inside it. They sit together because
+                      they are the same kind of question (what this bar does
+                      while you read it), but "what the boxes draw" and "where
+                      the preview sits" are two settings, and folding the
+                      second into the first gave that group five buttons under
+                      an aria-label describing three of them. */}
+                  <span aria-hidden="true" className="mx-1 h-3 w-px bg-white/10" />
+                  <SegmentedControl
+                    label="card"
+                    ariaLabel="Where the hover preview sits"
+                    groupAttribute="data-details-bar-card"
+                    segments={PREVIEW_ANCHORS.map((option) => ({
+                      value: option,
+                      label: option === "follow" ? "FOLLOW" : "PIN",
+                      title:
                         option === "follow"
                           ? "The preview follows the pointer"
-                          : "The preview stays under the middle of the bar"
-                      }
-                      className={[
-                        "min-w-7 rounded px-1.5 py-0.5 font-mono text-[10px] tabular-nums transition-colors",
-                        option === previewAnchor
-                          ? "bg-zinc-100 text-zinc-900"
-                          : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100",
-                      ].join(" ")}
-                    >
-                      {option === "follow" ? "FOLLOW" : "PIN"}
-                    </button>
-                  ))}
-                </div>
+                          : "The preview stays under the middle of the bar",
+                      active: option === previewAnchor,
+                    }))}
+                    onSelect={choosePreviewAnchor}
+                  />
                 </>
               }
               settingsRight={
-              <div
-                  data-details-bar-reach
-                role="group"
-                aria-label="Clips either side on the bar"
-                className="flex items-center gap-1"
-            >
-                <span className="mr-1 font-mono text-[10px] text-zinc-500">reach</span>
-                {BAR_REACHES.map((option) => (
-                  <button
-                    key={option}
-                    type="button"
-                    aria-pressed={option === reach}
-                    onClick={() => chooseReach(option)}
-                    title={
+                <SegmentedControl
+                  label="reach"
+                  ariaLabel="Clips either side on the bar"
+                  groupAttribute="data-details-bar-reach"
+                  segments={BAR_REACHES.map((option) => ({
+                    value: option,
+                    label: barReachLabel(option),
+                    title:
                       option === "all"
                         ? "Reach the whole sequence"
-                        : `Reach ${option} clips either side`
-                    }
-                    className={[
-                      "min-w-7 rounded px-1.5 py-0.5 font-mono text-[10px] tabular-nums transition-colors",
-                      option === reach
-                        ? "bg-zinc-100 text-zinc-900"
-                        : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100",
-                    ].join(" ")}
-                  >
-                    {barReachLabel(option)}
-                  </button>
-                ))}
-            </div>
+                        : "Reach " + option + " clips either side",
+                    active: option === reach,
+                  }))}
+                  onSelect={chooseReach}
+                />
               }
               previewAnchor={previewAnchor}
               atStart={barWindow.ids[0] === ids[0]}
@@ -1160,33 +1102,24 @@ function DetailsFilmstripModal({
           timeline is on screen — a question you answer once and then work,
           not a control you reach for while judging a seam. */}
       <div
-        data-details-view-count
-        role="group"
-        aria-label="Clips on screen"
-        className={[
-          "pointer-events-auto absolute right-6 bottom-6 z-10 flex items-center gap-1",
-          "rounded-lg border border-zinc-700 bg-zinc-950/90 p-1 backdrop-blur-sm",
-          "transition-opacity duration-200",
-        ].join(" ")}
+        className="pointer-events-auto absolute right-6 bottom-6 z-10 transition-opacity duration-200"
         onPointerDown={(event) => event.stopPropagation()}
       >
-        {VIEW_COUNTS.map((count) => (
-          <button
-            key={count}
-            type="button"
-            aria-pressed={count === viewCount}
-            onClick={() => chooseViewCount(count)}
-            title={`Show ${count} clips`}
-            className={[
-              "min-w-8 rounded px-2 py-1 font-mono text-[11px] tabular-nums transition-colors",
-              count === viewCount
-                ? "bg-zinc-100 text-zinc-900"
-                : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100",
-            ].join(" ")}
-          >
-            {count}
-          </button>
-        ))}
+        {/* NO LABEL. Every other group in the view wears one, and this is the
+            single exception: `3 · 5` sits alone in a corner with nothing to be
+            confused with, and the words "clips on screen" are already in its
+            aria-label and in every segment's title. */}
+        <SegmentedControl
+          ariaLabel="Clips on screen"
+          groupAttribute="data-details-view-count"
+          segments={VIEW_COUNTS.map((count) => ({
+            value: count,
+            label: count,
+            title: "Show " + count + " clips",
+            active: count === viewCount,
+          }))}
+          onSelect={chooseViewCount}
+        />
       </div>
 
       {/* The STRIP: one row, translated. Centred by the scrim, then offset by

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-monitor.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-monitor.tsx
@@ -4,6 +4,15 @@ import { useRef } from "react";
 import { AudioLines, Pause, Play } from "lucide-react";
 
 import {
+  RADIUS_MEDIA,
+  RADIUS_WELL,
+  SURFACE_WELL,
+  TEXT_DATA,
+  TEXT_LABEL,
+  TEXT_VALUE,
+} from "./graph-details-design";
+
+import {
   hasSourceWindow,
   type MediaNode,
   type VideoMediaNode,
@@ -150,13 +159,22 @@ export function ItemDetailsMonitor({
       }}
       onClick={centre ? undefined : () => onAdvance(node.id as string)}
       className={[
-        "relative overflow-hidden rounded-md bg-black",
+        "relative overflow-hidden bg-black",
+        RADIUS_MEDIA,
         // `flex-1` only makes sense against a fixed panel height. Once the
         // panel fits its content there is nothing to fill, so the picture
         // states its own shape instead.
         "aspect-video w-full @min-[30rem]:aspect-auto @min-[30rem]:w-auto",
         DETAILS_HERO_FILL_CLASS,
         centre ? "" : "cursor-pointer",
+        // A NEIGHBOUR'S PICTURE SITS BACK, by a single step of brightness.
+        // Dimming the card's chrome alone is not enough — the pictures are
+        // the brightest things in the view, so three at equal strength read
+        // as three subjects. Eight percent is under the threshold where you
+        // would call it dimmed and over the one where the eye stops
+        // treating them as equals. Composes with the playback fade below:
+        // both are filters, so they multiply rather than fight.
+        centre ? "" : "brightness-[0.92]",
         // FADED, AND THE COLOUR GOES WITH IT. Opacity alone still leaves a
         // recognisable picture competing for the eye; draining the colour
         // as well puts the neighbours firmly in the past tense while the
@@ -340,7 +358,7 @@ export function ItemDetailsMonitor({
         in/out fields further down so a panel reads as one column of facts. */}
     <div
       data-item-details-readout
-      className="flex items-center gap-3 rounded-md bg-zinc-900/80 px-2 py-1.5"
+      className={["flex items-center gap-3 px-2 py-1.5", RADIUS_WELL, SURFACE_WELL].join(" ")}
     >
       {onPlayFromStart !== null && (
         <button
@@ -361,8 +379,13 @@ export function ItemDetailsMonitor({
           }}
           className={[
             "grid h-6 w-6 shrink-0 place-items-center rounded-full",
-            "bg-zinc-800 text-zinc-100 ring-1 ring-white/15",
-            "transition-colors hover:bg-zinc-700 hover:text-white",
+            // A GLYPH, NOT A CHIP. This used to be a filled circle with a
+            // ring — at three or five panels that is three to five little
+            // buttons competing with the one big play control the row is
+            // built around. White belongs to that button; this one is a
+            // mark that brightens when you reach for it.
+            "text-zinc-500",
+            "transition-colors hover:bg-white/10 hover:text-zinc-100",
             "focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:outline-none",
           ].join(" ")}
         >
@@ -388,9 +411,9 @@ export function ItemDetailsMonitor({
       {centre && (
         <span
           data-item-details-cut
-          className="shrink-0 font-mono text-[11px] tabular-nums text-zinc-500"
+          className={["shrink-0", TEXT_LABEL].join(" ")}
         >
-          cut <span className="text-zinc-300">{formatSeconds(monitor?.seconds ?? 0)}</span>
+          cut <span className={TEXT_VALUE}>{formatSeconds(monitor?.seconds ?? 0)}</span>
         </span>
       )}
 
@@ -402,9 +425,9 @@ export function ItemDetailsMonitor({
       {video && (
         <span
           data-item-details-src
-          className="shrink-0 font-mono text-[11px] tabular-nums text-zinc-500"
+          className={["shrink-0", TEXT_LABEL].join(" ")}
         >
-          src <span className="text-blue-300">{formatSeconds(rawTime)}</span>
+          src <span className={TEXT_DATA}>{formatSeconds(rawTime)}</span>
         </span>
       )}
     </div>

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel-header.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel-header.tsx
@@ -3,6 +3,14 @@
 import { useState } from "react";
 import { MoreHorizontal } from "lucide-react";
 
+import {
+  TEXT_LABEL,
+  TEXT_VALUE,
+  TEXT_VALUE_DIM,
+  TITLE_FOCUS,
+  TITLE_SIDE,
+} from "./graph-details-design";
+
 import { InlineNameEditor } from "./graph-inline-rename";
 import { ItemDisableToggle } from "./graph-item-disable-toggle";
 import {
@@ -30,15 +38,24 @@ import {
 export function ItemDetailsPanelHeader({
   name,
   clipLabel,
-  trimReadout,
+  showingLabel,
+  sourceLabel,
+  focused,
   nodeId,
   rename,
 }: Readonly<{
   name: string;
   /** `clip 4` — its position in playback order, not its index in the row. */
   clipLabel: string | null;
-  /** `7.83 / 10.13s`, or just the duration where there is no source window. */
-  trimReadout: string;
+  /** How much of the clip is in play — the bright half. */
+  showingLabel: string;
+  /** How long the whole source runs, or null where there is no source
+   *  window to be a fraction of. */
+  sourceLabel: string | null;
+  /** Whether this is the panel being worked in. Drives the title's weight
+   *  and nothing else: a neighbour's name is there to say which clip it
+   *  is, not to be read. */
+  focused: boolean;
   nodeId: string;
   rename: Readonly<{
     editing: boolean;
@@ -60,9 +77,17 @@ export function ItemDetailsPanelHeader({
   return (
     <div className="flex flex-col gap-1">
       <div className="flex items-center justify-between gap-2">
-        <span className="truncate font-mono text-[11px] text-zinc-500">{clipLabel}</span>
+        <span className={["truncate", TEXT_LABEL].join(" ")}>{clipLabel}</span>
         <div className="flex shrink-0 items-center gap-1.5">
-          <span className="font-mono text-[11px] tabular-nums text-zinc-400">{trimReadout}</span>
+          {/* The pair reads as one value — `3.47s / 5.17s` — so the
+              separator stays inside the wrapper and the whole thing is one
+              run of text to anything reading it. */}
+          <span>
+            <span className={TEXT_VALUE}>{showingLabel}</span>
+            {sourceLabel === null ? null : (
+              <span className={TEXT_VALUE_DIM}>{" / " + sourceLabel}</span>
+            )}
+          </span>
           <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
             <DropdownMenuTrigger
               data-item-details-menu
@@ -107,7 +132,8 @@ export function ItemDetailsPanelHeader({
           title={`Rename ${name}`}
           className={[
             "w-full cursor-text truncate rounded-md px-1 py-0.5 text-left",
-            "text-sm font-semibold text-zinc-100 transition-colors hover:bg-zinc-800/70",
+            focused ? TITLE_FOCUS : TITLE_SIDE,
+            "transition-colors hover:bg-zinc-800/70",
             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70",
           ].join(" ")}
         >

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
@@ -13,6 +13,13 @@ import {
 } from "@storyboard/ui/dnd-collections";
 
 import { DETAILS_PANEL_HEIGHT_CLASS } from "./graph-view-config";
+import {
+  HAIRLINE,
+  HAIRLINE_STRONG,
+  RADIUS_CARD,
+  SURFACE_CARD,
+  SURFACE_CARD_FOCUS,
+} from "./graph-details-design";
 import { DETAILS_CHROME_MS, detailsStepTransition } from "./graph-details-motion";
 import { useDialogFocus } from "@/hooks/use-dialog-focus";
 import { formatSeconds } from "@/lib/format-duration";
@@ -443,7 +450,14 @@ export function DetailsPanel({
           // actually IS rather than on how many there are. Five panels on a
           // large monitor have more room each than three on an iPad, and a
           // rule counting panels gets that backwards.
-          "relative flex w-full flex-col gap-2 rounded-lg bg-zinc-950 p-4 focus-visible:outline-none",
+          "relative flex w-full flex-col gap-2 p-4 focus-visible:outline-none",
+          RADIUS_CARD,
+          // FOCUS FALLOFF, carried by the surface and the border moving
+          // together. Either alone is too quiet to survive a screen full of
+          // pictures; both together are still quieter than the white ring
+          // this replaces, which was the loudest mark in the view and was
+          // spent on the one fact the layout already tells you.
+          centre ? SURFACE_CARD_FOCUS : SURFACE_CARD,
           // THE CHROME, on the step's curve but half its clock. A ring and a
           // shadow do not travel, so matching the step's duration would leave
           // a border still resolving after the panel it borders had arrived —
@@ -466,7 +480,13 @@ export function DetailsPanel({
           // The one mark that survives is the red one, and it earns its place
           // by saying something that changes: whose frames are on screen right
           // now. It is a box-shadow, so it costs no layout either.
-          "border border-zinc-700",
+          // ONE PIXEL ON EVERY PANEL, always. A 2px border on the centre pushed
+          // its picture down a pixel and shortened it by two, which matters
+          // precisely because comparing frames ACROSS panels is what this
+          // view is for. Only the colour changes with focus, and colour
+          // costs no layout.
+          "border",
+          centre ? HAIRLINE_STRONG : HAIRLINE,
           // ONE shadow utility per state, both spelled out. Layering a glow on
           // top of `shadow-2xl` would mean two classes setting `box-shadow`,
           // and which one wins is a question about stylesheet order rather
@@ -479,9 +499,10 @@ export function DetailsPanel({
           // not: one hairline of white at low opacity is enough to say which
           // panel is the subject, and it leaves the pictures to be the bright
           // things on screen.
-          centre
-            ? "shadow-[0_25px_50px_-12px_rgba(0,0,0,0.6),0_0_0_1px_rgba(255,255,255,0.22)]"
-            : "shadow-[0_25px_50px_-12px_rgba(0,0,0,0.6)]",
+          // THE DROP SHADOW IS THE SAME ON EVERY PANEL now that the border
+          // carries focus. It lifts the row off the board; it does not say
+          // which panel you are working in.
+          "shadow-[0_25px_50px_-12px_rgba(0,0,0,0.6)]",
           // ── HEIGHT: THE SUBJECT TAKES THE SCREEN, THE REST FIT THEIR
           //    PICTURE ────────────────────────────────────────────────────
           //
@@ -561,11 +582,13 @@ export function DetailsPanel({
         <ItemDetailsPanelHeader
           name={node.name}
           clipLabel={clipLabel ?? null}
-          trimReadout={
-            video
-              ? `${formatSeconds(showing)} / ${formatSeconds(fullDuration)}`
-              : formatSeconds(showing)
-          }
+          // TWO HALVES, NOT ONE STRING. How much of the clip is in play
+          // and how long the source runs are a bright fact and a dim one,
+          // and joining them here would have forced the header to draw
+          // them in one weight.
+          showingLabel={formatSeconds(showing)}
+          sourceLabel={video ? formatSeconds(fullDuration) : null}
+          focused={centre}
           nodeId={node.id as string}
           rename={rename}
         />

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-trim-fields.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-trim-fields.tsx
@@ -10,6 +10,14 @@ import {
   type VideoMediaNode,
 } from "@storyboard/ui/dnd-collections";
 
+import {
+  RADIUS_INNER,
+  SURFACE_WELL,
+  TEXT_DATA,
+  TEXT_LABEL,
+  TEXT_VALUE,
+} from "./graph-details-design";
+
 // The typed half of trimming: the same `update-media` the grips dispatch,
 // reached with a keyboard instead of a pointer. Lifted out of the modal so
 // the panel is layout and these are the input rules.
@@ -81,9 +89,9 @@ export function TrimNumbers({
   };
 
   return (
-    <div className="flex items-center gap-3 font-mono text-[11px] text-zinc-400">
+    <div className="flex items-center gap-3">
       <SecondsField label="in" value={inPoint} disabled={disabled} onCommit={(raw) => commit("in", raw)} />
-      <span aria-hidden="true" className="text-zinc-600">
+      <span aria-hidden="true" className={TEXT_LABEL}>
         →
       </span>
       <SecondsField label="out" value={outPoint} disabled={disabled} onCommit={(raw) => commit("out", raw)} />
@@ -94,7 +102,7 @@ export function TrimNumbers({
           the source is in play". Same value, two questions; `ml-auto` rather
           than a spacer so it stays put when the fields resize. */}
       {durationLabel === undefined ? null : (
-        <span className="ml-auto tabular-nums text-zinc-300">{durationLabel}</span>
+        <span className={["ml-auto", TEXT_VALUE].join(" ")}>{durationLabel}</span>
       )}
       {/* "of 12.00s" used to trail this row. The panel's own header already
           reads "4.00s of 12.00s", two inches above and in the same units, so
@@ -125,7 +133,7 @@ function SecondsField({
   // drag, an undo).
   return (
     <label className="flex items-center gap-1.5">
-      <span className="text-zinc-500">{label}</span>
+      <span className={TEXT_LABEL}>{label}</span>
       <input
         key={value}
         type="text"
@@ -145,7 +153,17 @@ function SecondsField({
           }
         }}
         onBlur={(event) => onCommit(event.target.value)}
-        className="w-14 rounded-sm bg-zinc-900 px-1.5 py-0.5 text-right tabular-nums text-blue-300/90 outline-none ring-1 ring-zinc-700 focus:ring-blue-500/70 disabled:opacity-40"
+        // A FIELD, AND IT LOOKS LIKE ONE. Same well, same radius and the
+        // same hairline as every other recessed thing in the view — the
+        // blue is what says you can type in it, so the box only has to say
+        // "box".
+        className={[
+          "w-14 px-1.5 py-0.5 text-right outline-none focus:ring-blue-500/70 disabled:opacity-40",
+          RADIUS_INNER,
+          SURFACE_WELL,
+          "ring-1 ring-white/[0.07]",
+          TEXT_DATA,
+        ].join(" ")}
       />
 
     </label>

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-trim-strip.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-trim-strip.tsx
@@ -10,6 +10,7 @@ import {
 } from "@storyboard/ui/dnd-collections";
 
 import { formatSeconds } from "@/lib/format-duration";
+import { TEXT_VALUE_DIM } from "./graph-details-design";
 import { TrimNumbers } from "./graph-item-details-trim-fields";
 
 /**
@@ -185,9 +186,7 @@ export function ItemDetailsTrimStrip({
             since a waveformless black card and a still look alike. That is
             two words now, on the row that was already there. */}
         {!video && (
-          <span className="font-mono text-[11px] text-blue-300/90">
-            sound · {formatSeconds(showing)} long
-          </span>
+          <span className={TEXT_VALUE_DIM}>sound · {formatSeconds(showing)} long</span>
         )}
       </>
     ) : (
@@ -195,7 +194,7 @@ export function ItemDetailsTrimStrip({
       // audio — so it cannot say "still" for both. A voiceover is not a
       // still, and calling it one is the kind of wrong label nobody
       // reports and everybody notices.
-      <span className="font-mono text-[11px] text-blue-300/90">
+      <span className={TEXT_VALUE_DIM}>
         {node.mediaKind === "audio"
           ? `sound · ${formatSeconds(showing)} long`
           : `still · ${formatSeconds(showing)} on screen`}

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-ruler.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-ruler.tsx
@@ -317,6 +317,16 @@ export function SeamRuler({
                   : isHovered
                     ? RULER_BLOCK_HOVER_COLOUR
                     : RULER_BLOCK_COLOUR,
+                // A STROKE ALONG THE TOP OF THE ACTIVE BLOCK, and only
+                // there. The clip below it wears a white outline; this is
+                // the same line, continued up into the scale, so the two
+                // read as one column rather than as a tinted rectangle
+                // that happens to sit above an outlined box. Inset rather
+                // than a border because a border would change the block's
+                // size and shift every tick beside it.
+                boxShadow: isCentre
+                  ? "inset 0 1px 0 0 rgba(255, 255, 255, 0.55)"
+                  : undefined,
               }}
               // INSET FROM THE BOTTOM, not flush to it. The tick marks hang
               // from that edge and a block reaching it would have them ending

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -16,6 +16,8 @@ import {
   type SeamBarClip,
 } from "./graph-seam-bar-layout";
 import { SEAM_LANE_HEIGHT_PX, SeamLane, type SeamHover } from "./graph-seam-lane";
+import { HAIRLINE, SURFACE_WELL } from "./graph-details-design";
+import { SegmentedControl } from "./graph-details-segmented";
 import { SeamMinimap } from "./graph-seam-minimap";
 import { SEAM_RULER_TOTAL_PX, SeamRuler } from "./graph-seam-ruler";
 import {
@@ -1228,7 +1230,14 @@ export function SeamStripBar({
           //
           // Landed at 20 first and went to 36. Whatever this number becomes,
           // the scrim's top padding owes it TWICE over — see the note there.
-          className="mt-9 flex items-center gap-1.5 rounded-full border border-zinc-700/80 bg-zinc-900/70 p-1.5"
+          // TIGHT AROUND THE BUTTON. Six pixels of padding and a 32px button put
+          // the transport in a 46px pill where the white circle occupied
+          // barely two thirds of the height — it read as a small control
+          // parked in a large tray rather than as the thing the row is
+          // arranged around. Three pixels and a 36px button takes it to
+          // 42, and the circle now fills the pill the way it does in the
+          // design it came from.
+          className={["mt-9 flex items-center gap-1 rounded-full border p-[3px]", HAIRLINE, SURFACE_WELL].join(" ")}
         >
           {/* STEP ONE CLIP, either way, bracketing the thing they move.
               Disabled rather than hidden at the ends: a control that vanishes
@@ -1263,15 +1272,15 @@ export function SeamStripBar({
             onClick={onTogglePlay}
             aria-label={playing ? "Pause" : "Play across the cut"}
             title="Play / pause (space)"
-            className="grid h-8 w-8 place-items-center rounded-full bg-zinc-100 text-zinc-900 shadow-sm transition-colors outline-none hover:bg-white focus-visible:ring-2 focus-visible:ring-blue-500"
+            className="grid h-9 w-9 place-items-center rounded-full bg-zinc-100 text-zinc-900 shadow-sm transition-colors outline-none hover:bg-white focus-visible:ring-2 focus-visible:ring-blue-500"
           >
             {playing ? (
-              <Pause aria-hidden="true" className="h-4 w-4" />
+              <Pause aria-hidden="true" className="h-4 w-4 fill-current" />
             ) : (
               // Nudged right by a hair: a triangle's optical centre is left of
               // its bounding box, so a centred play glyph reads as sitting
               // slightly back in the circle.
-              <Play aria-hidden="true" className="h-4 w-4 translate-x-[1px]" />
+              <Play aria-hidden="true" className="h-4 w-4 translate-x-[1px] fill-current" />
             )}
           </button>
 
@@ -1302,9 +1311,9 @@ export function SeamStripBar({
             data-seam-clock
             className="shrink-0 font-mono text-[11px] tabular-nums text-zinc-500"
           >
-            <span className="text-blue-400">{formatClock(atSeconds)}</span>
+            <span className="text-blue-300">{formatClock(atSeconds)}</span>
             {" / "}
-            <span className="text-blue-400/70">{formatClock(totalSeconds)}</span>
+            <span>{formatClock(totalSeconds)}</span>
           </span>
 
           {/* FIT: the two scales worth one press.
@@ -1313,34 +1322,22 @@ export function SeamStripBar({
               only by rolling until they happened to arrive. Both are one
               `fitPixelsPerSecond` call the bar was already making on open;
               this just gives them a button. */}
-          <div
-            data-seam-fit
-            role="group"
-            aria-label="Fit the bar to"
-            className="hidden shrink-0 items-center gap-1 md:flex"
-          >
-            <span className="mr-1 font-mono text-[10px] text-zinc-500">fit</span>
-            {(["clip", "all"] as const).map((mode) => (
-              <button
-                key={mode}
-                type="button"
-                aria-pressed={mode === fitMode}
-                onClick={() => fitTo(mode)}
-                title={
+          <div className="hidden shrink-0 md:flex">
+            <SegmentedControl
+              label="fit"
+              ariaLabel="Fit the bar to"
+              groupAttribute="data-seam-fit"
+              segments={(["clip", "all"] as const).map((mode) => ({
+                value: mode,
+                label: mode,
+                title:
                   mode === "clip"
                     ? "Fit this clip's collection"
-                    : "Fit everything the bar reaches"
-                }
-                className={[
-                  "min-w-7 rounded px-1.5 py-0.5 font-mono text-[10px] tabular-nums transition-colors",
-                  mode === fitMode
-                    ? "bg-zinc-100 text-zinc-900"
-                    : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100",
-                ].join(" ")}
-              >
-                {mode}
-              </button>
-            ))}
+                    : "Fit everything the bar reaches",
+                active: mode === fitMode,
+              }))}
+              onSelect={fitTo}
+            />
           </div>
 
           <div className="hidden min-w-0 items-center gap-1 md:flex">{settingsRight}</div>

--- a/apps/timeline-gstudio001/components/graph-view/graph-tag-editor.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-tag-editor.tsx
@@ -10,6 +10,7 @@ import { MAX_TAGS_PER_CLIP, MAX_TAG_LENGTH, normalizeTags } from "@storyboard/ti
 import { graphDocumentsGateway } from "@/lib/graph-documents-gateway";
 import { isTagWriteRefusal, planTagWrite } from "@/lib/tag-write-plan";
 
+import { JUDGEMENT_TAGS, TAG_FACT, TAG_JUDGEMENT } from "./graph-details-design";
 import { useClipDetail, useGraphDetailsStore } from "./graph-details-context";
 
 // Editing tags is the ONE mutation in this view that does not go through a
@@ -145,7 +146,19 @@ export function TagEditor({ nodeId }: Readonly<{ nodeId: NodeId }>) {
           <span
             key={tag}
             data-tag-chip={tag}
-            className="flex items-center gap-1 rounded bg-zinc-800 py-0.5 pr-0.5 pl-1.5 text-[11px] leading-none font-medium text-zinc-200 ring-1 ring-white/10"
+            // ONE CHIP IN THE ROW MEANS SOMETHING DIFFERENT. Most tags
+            // say what the clip IS — its scene, its model, its prompt
+            // version — and those are facts, all equal, all grey. A tag
+            // like `keeper` says what somebody DECIDED, and that is the
+            // one thing on the card worth finding without reading. Amber
+            // rather than blue or red: both of those already mean
+            // something exact here, and a judgement is neither editable
+            // data nor the playhead.
+            className={[
+              "flex items-center gap-1 rounded py-0.5 pr-0.5 pl-1.5",
+              "text-[11px] leading-none font-medium ring-1",
+              JUDGEMENT_TAGS.has(tag) ? TAG_JUDGEMENT : TAG_FACT,
+            ].join(" ")}
           >
             {tag}
             <button
@@ -173,7 +186,11 @@ export function TagEditor({ nodeId }: Readonly<{ nodeId: NodeId }>) {
           title={full ? `Limit of ${MAX_TAGS_PER_CLIP} tags reached` : "Add a tag"}
           data-tag-add
           onClick={() => setOpen((was) => !was)}
-          className="flex size-5 items-center justify-center rounded text-zinc-500 ring-1 ring-white/10 transition-colors hover:bg-zinc-800 hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-sky-500/70 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40"
+          // DASHED, because it is a SLOT rather than a chip. Drawn solid
+          // it was a sixth tag in a row of five, and the eye had to read
+          // the glyph to find out it was not one. A broken outline says
+          // empty-and-fillable before anything is read.
+          className="flex size-5 items-center justify-center rounded border border-dashed border-white/20 text-zinc-500 transition-colors hover:border-white/30 hover:bg-white/5 hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-sky-500/70 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40"
         >
           <Plus aria-hidden="true" className="size-3" />
         </button>


### PR DESCRIPTION
Follows the redesign mockup: one control component, three surface levels, two hairlines, one type scale, and accents with exactly one meaning each.

## What changed

**One toggle, five uses.** `frames`, `card`, `fit`, `reach` and the `3/5` pager were four different renditions of the same control. They are now `SegmentedControl`. The active segment **raises instead of inverting** — it was a solid white chip, the loudest mark in the palette, spent on settings you change once a session. White is now the play button's alone (which also gets a filled glyph; lucide draws `Play` as an outline, so a white circle around an outlined triangle read as a ring).

**Hierarchy by focus falloff, not a ring.** Subject on a lighter surface (`#141418` vs `#0d0d10`) behind a brighter edge (α 0.16 vs 0.07); neighbours' pictures at `brightness(0.92)`. Only the border's *colour* changes — never its width, because a 2px edge would push the subject's picture down a pixel and comparing frames across panels is the point of this view.

**Accents mean one thing each.** Blue = a value you can edit (which is what makes the in/out fields findable — the `still · 3.00s on screen` line was the last blue text a click couldn't change). Red = the playhead. Amber = the one chip in the tag row that says what somebody *decided*. The active ruler block gains an inset top stroke continuing the outline of the clip below it.

## Not taken from the mockup

The ruler **stays two bands**. Their fixture is a single collection so it has no name band; ours does, by request, and raising the scale band would disturb spacing tuned by hand.

The layer frame picker's `S/M/L` row is still outside the system — it needs per-segment `aria-label`, `disabled` and `data-` support the shared control doesn't have, and its stories query by aria-label. Flagged rather than converted.

## Verification

- `tsc` clean · `eslint` 0 errors (7 pre-existing `<img>` warnings)
- **1447/1447** app tests · **322/322** story tests (all 30 files)
- Five-up measured: centre 550×519 / `rgb(20,20,24)` / α 0.16 / no filter; neighbours 314×320 / `rgb(13,13,16)` / α 0.07 / `brightness(0.92)`
- The two stories guarding the old white ring were re-pointed at the border alpha and surface. **Proved they bite** by flattening the falloff first — `expected 0.07 to be greater than 0.07`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)