### PR TITLE
The three trim windows sit on one line

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -1225,7 +1225,17 @@ export const TagsAreAddedFromAnIcon: Story = {
     const add = editor.querySelector<HTMLButtonElement>("[data-tag-add]")!;
     expect(add).not.toBeNull();
     // It sits AFTER the chips, which is where the next tag would go.
-    expect(add.previousElementSibling?.hasAttribute("data-tag-chip") ?? true).toBe(true);
+    //
+    // Asked as a question about DOCUMENT ORDER rather than about who the
+    // previous sibling is. The chips now live in a scroller of their own, so
+    // that the row can be exactly one line high without clipping this
+    // button's popover — which makes the button's previous sibling the
+    // scroller, not a chip, while the thing being claimed is unchanged.
+    for (const chip of Array.from(editor.querySelectorAll("[data-tag-chip]"))) {
+      expect(
+        Boolean(chip.compareDocumentPosition(add) & Node.DOCUMENT_POSITION_FOLLOWING),
+      ).toBe(true);
+    }
 
     fireEvent.click(add);
     const field = await waitFor(() => {
@@ -1382,9 +1392,22 @@ export const NarrowPanelsShedTheirControlsAndStayAligned: Story = {
     // that changed anything.
     await waitFor(() => {
       expect(neighbourShows("[data-trim-overview]")).toBe(false);
-      expect(visible("[data-tag-editor]")).toBe(false);
       expect(visible("[data-item-details-undo]")).toBe(false);
     });
+
+    // THE TAG ROW IS THE ONE CONTROL THAT NO LONGER SHEDS, and it stopped
+    // for the sake of something this story is also about: alignment.
+    //
+    // It used to be gated at 30rem like the rest, which meant that at a 1280
+    // canvas the wide centre kept its tags while the narrow neighbours
+    // dropped theirs. Everything below the filmstrip then differed in height
+    // by that row, and because the cards hang from a common bottom, the
+    // neighbours' strips sat 37px off the centre's — the three trim windows
+    // this view exists to compare were on three different lines.
+    //
+    // So it is always present and always one line high. A narrow panel could
+    // not be tagged at all before, so this shed nothing to gain it.
+    expect(visible("[data-tag-editor]")).toBe(true);
     // AND THE FILMSTRIP FILLS THE BOX IT WAS MEASURED FROM.
     //
     // Its width is a NUMBER, handed down so frames can be laid out, and it was
@@ -3777,5 +3800,179 @@ export const TheBarThumbnailStartsAfterTheTrim: Story = {
 
     // Left as it was found, for whichever story runs next in this browser.
     framesTo("STRIP");
+  },
+};
+
+/**
+ * THE THREE TRIM STRIPS SIT ON ONE LINE.
+ *
+ * The pictures are deliberately different sizes — the subject's is bigger
+ * because it is the one being judged — but the CONTROLS beneath them are
+ * identical in size and purpose, and comparing a trim against its neighbours'
+ * is most of what this view is for.
+ *
+ * Centred, they were not comparable. The taller subject extended equally above
+ * and below its neighbours, and every row below the picture inherited half the
+ * height difference: measured at 1920, the well, the filmstrip, the in/out
+ * fields and the tags all sat 76px lower on the centre than on the clips either
+ * side of it. Three filmstrips on three different lines.
+ *
+ * Hanging the cards from a common bottom fixes it for free, because everything
+ * from the strip down is the same height in every card. Asserted on the STRIP
+ * rather than on the card box, because the card box agreeing is the mechanism
+ * and the strips agreeing is the point — a future layout that aligned them some
+ * other way should still pass.
+ *
+ * A DELIBERATE DEPARTURE from the design this view follows, which top-aligns
+ * the three and lets the strips fall wherever the picture heights leave them.
+ */
+export const TheTrimStripsShareOneLine: Story = {
+  render: () => <SeamHarness scene={TRIMMED_SCENE} />,
+  play: async () => {
+    await waitFor(() => expect(seamTrack()).not.toBeNull());
+    const panels = () =>
+      Array.from(document.querySelectorAll<HTMLElement>("[data-item-details-panel]"));
+    await waitFor(() => expect(panels().length).toBeGreaterThan(2));
+
+    const topsOf = (selector: string) =>
+      panels()
+        .map((panel) => panel.querySelector<HTMLElement>(selector))
+        .filter((el): el is HTMLElement => el !== null)
+        .map((el) => el.getBoundingClientRect().top);
+
+    // THE MECHANISM, asserted unconditionally: the cards hang from one line.
+    const bottoms = panels().map((panel) => panel.getBoundingClientRect().bottom);
+    expect(Math.max(...bottoms) - Math.min(...bottoms)).toBeLessThan(1);
+
+    // Every clip in this scene is a windowed video, so every panel draws a strip.
+    const strips = topsOf("[data-trim-strip-slot]");
+    expect(strips.length).toBe(panels().length);
+
+    // AND THE CONSEQUENCE. This holds only while the rows BELOW the strip
+    // are the same height in every card, so those rows were made invariant
+    // rather than hoped about:
+    //
+    //   - the layer picker moved ABOVE the strip, because it appears only on
+    //     a clip that is on a lane, so below it would push one card's strip
+    //     up by its own height;
+    //   - the tag row lost its 30rem gate and stopped wrapping, because at a
+    //     1280 canvas the 560px centre kept its tags while the 320px
+    //     neighbours dropped theirs and their strips sat 37px lower — the tag
+    //     row and its gap, exactly.
+    //
+    // Asserted at whatever width the runner gives us, which is the point:
+    // this used to be a claim that was only true on a wide canvas.
+    const belowStrip = panels().map((panel) => {
+      const strip = panel.querySelector<HTMLElement>("[data-trim-strip-slot]")!;
+      return panel.getBoundingClientRect().bottom - strip.getBoundingClientRect().top;
+    });
+    expect(Math.max(...belowStrip) - Math.min(...belowStrip)).toBeLessThan(1);
+
+    // Sub-pixel tolerance: laid out by flex, not from a shared number.
+    expect(Math.max(...strips) - Math.min(...strips)).toBeLessThan(1);
+    const wells = topsOf("[data-item-details-readout]");
+    expect(Math.max(...wells) - Math.min(...wells)).toBeLessThan(1);
+
+    // The tag row is there on EVERY card, not just the wide one — the fix
+    // added capability rather than removing it, and a revert to the gate
+    // would show up here first.
+    const tagRows = panels().map((panel) => panel.querySelector("[data-tag-editor]"));
+    expect(tagRows.filter(Boolean).length).toBe(panels().length);
+
+    // And the pictures are still allowed to differ. If THIS fails, the strips
+    // line up because the cards became identical — which is a different view
+    // from the one being tested here.
+    const pictures = panels()
+      .map((panel) => panel.querySelector<HTMLElement>("[data-item-details-frame]"))
+      .filter((el): el is HTMLElement => el !== null)
+      .map((el) => el.getBoundingClientRect().height);
+    expect(Math.max(...pictures) - Math.min(...pictures)).toBeGreaterThan(20);
+  },
+};
+
+/**
+ * THE BAR REACHES AS FAR AS THE CARDS DO.
+ *
+ * The bar was capped at `7xl` on the reasoning that it is a map and should be
+ * WIDER than the panels it describes — true while the panels were capped too.
+ * Once the app stopped limiting its own width the panels went full-viewport and
+ * the cap stayed, inverting the intent: measured at 1920, the cards ran 1872px
+ * against the bar's 1280, so the cards overhung the ruler that measures them by
+ * 296px on each side and the top of the view read as a floating island.
+ *
+ * Asserted against the SCRIM's padded width rather than against the card row,
+ * because that is the edge both are supposed to meet — and a card row that
+ * narrowed for its own reasons should not quietly take the bar with it.
+ */
+export const TheBarSpansTheFullWidth: Story = {
+  render: () => <SeamHarness scene={TRIMMED_SCENE} />,
+  play: async () => {
+    await waitFor(() => expect(seamTrack()).not.toBeNull());
+    const scale = document.querySelector<HTMLElement>("[data-seam-ruler-scale]")!;
+    const controls = document.querySelector<HTMLElement>("[data-seam-controls]")!;
+
+    // `px-6` on the scrim — 24px each side, and nothing else may narrow them.
+    // Compared as strings so a failure names which edge of which row moved.
+    const PAD = 24;
+    for (const [name, element] of [
+      ["ruler", scale],
+      ["controls", controls],
+    ] as const) {
+      const box = element.getBoundingClientRect();
+      expect(`${name} left ${Math.round(box.left)}`).toBe(`${name} left ${PAD}`);
+      expect(`${name} right ${Math.round(box.right)}`).toBe(
+        `${name} right ${window.innerWidth - PAD}`,
+      );
+    }
+  },
+};
+
+/**
+ * THE TRANSPORT IS ON THE CONTROL ROW, NOT UNDER IT.
+ *
+ * The play assembly carried a 36px top margin, put there to drop it clear of
+ * the bars above while the badges either side stayed where the ruler left them.
+ * What that produced was a control row with a hole in the middle: `frames`,
+ * `card`, the clock, `fit` and `reach` on one line, and the one control anyone
+ * reaches for without reading sitting 36px below them on a second.
+ *
+ * Asserted as SHARED CENTRES rather than shared tops, because the transport is
+ * legitimately taller than the badges — it is a 42px pill against a 28px tray,
+ * and a shared top would be the wrong shape of alignment to ask for.
+ */
+export const TheTransportSitsOnTheControlRow: Story = {
+  render: () => <SeamHarness scene={TRIMMED_SCENE} />,
+  play: async () => {
+    await waitFor(() => expect(seamTrack()).not.toBeNull());
+    const centreY = (selector: string) => {
+      const box = document.querySelector<HTMLElement>(selector)!.getBoundingClientRect();
+      return box.top + box.height / 2;
+    };
+    const transport = centreY("[data-seam-transport]");
+    for (const group of [
+      "[data-details-bar-frames]",
+      "[data-details-bar-card]",
+      "[data-seam-fit]",
+      "[data-details-bar-reach]",
+    ]) {
+      expect(`${group} offset ${Math.round(centreY(group) - transport)}`).toBe(
+        `${group} offset 0`,
+      );
+    }
+
+    // The transport IS the tallest thing on the row — if this stops being true
+    // the row has been rebuilt around something else and the centring above is
+    // no longer describing what it thinks it is.
+    const rowHeight = document
+      .querySelector<HTMLElement>("[data-seam-controls]")!
+      .getBoundingClientRect().height;
+    const pill = document
+      .querySelector<HTMLElement>("[data-seam-transport]")!
+      .getBoundingClientRect().height;
+    expect(pill).toBeGreaterThan(
+      document.querySelector<HTMLElement>("[data-details-bar-reach]")!.getBoundingClientRect()
+        .height,
+    );
+    expect(rowHeight).toBeGreaterThanOrEqual(pill);
   },
 };

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -926,7 +926,18 @@ function DetailsFilmstripModal({
       // straight through it and 16px past the bottom of the window besides.
       // 4.875rem is 78px: the control's 24px offset, its own 34px, and 20px of
       // clearance so the panel stops short of it rather than against it.
-      className="fixed inset-0 z-[80] flex items-center justify-center overflow-clip bg-black/80 px-6 pt-[21.75rem] pb-[4.875rem] backdrop-blur-sm"
+      // 14.75rem, DOWN FROM 21.75. The band was sized to clear the bar with
+      // room to spare and left 62px of air between the controls row and the
+      // card under it — inside the 16..80 the guard allows, but at the loose
+      // end of it, and the guard's own note says the failure nobody reports
+      // is the view sitting lower than it needs to. The design this follows
+      // runs about 27px there. Four rem buys 32px of movement, not 64: this
+      // box is `items-center`, so padding at the top is shared with the
+      // bottom when the row re-centres in what is left. That halving is why
+      // the number looks too large for the space it controls. Three further rem
+      // came off when the transport lost its 36px margin and joined the control
+      // row: a shorter bar leaves more slack, in the same doubled proportion.
+      className="fixed inset-0 z-[80] flex items-center justify-center overflow-clip bg-black/80 px-6 pt-[14.75rem] pb-[4.875rem] backdrop-blur-sm"
       // THE SCRIM DOES NOT DISMISS. Deliberate: this view is worked in, not
       // glanced at — trimming, scrubbing and swiping all end with the pointer
       // somewhere unpredictable, and the panels are cropped by the scrim
@@ -960,12 +971,21 @@ function DetailsFilmstripModal({
           className="pointer-events-auto absolute inset-x-0 top-16 z-20 px-6 pt-4"
           onPointerDown={(event) => event.stopPropagation()}
         >
-          {/* WIDER THAN THE ROW BELOW IT, deliberately. The panels are
-              sized to be worked in and cap out; the bar is a map and gets
-              more useful the more of the project it can show at a legible
-              scale — at `5xl` a twenty-clip reach was boxes a few pixels
-              wide. */}
-          <div className="mx-auto w-full max-w-7xl">
+          {/* THE SAME WIDTH AS THE ROW BELOW IT.
+
+              This was capped at `7xl` on the reasoning that the bar is a
+              map and gets more useful the more of the project it can show,
+              so it should be WIDER than the panels — which was true while
+              the panels were capped too.
+
+              They are not any more, and the cap inverted the intent it was
+              written for: measured at 1920 the cards ran 1872px and the bar
+              1280, so the cards overhung the thing they belong to by 296px
+              on each side. A ruler that does not reach as far as the row it
+              measures reads as a floating island rather than as the top of
+              one panel. Sharing the edge costs the bar nothing — it only
+              ever gets wider. */}
+          <div className="mx-auto w-full">
             <PlaybarThumbnailsProvider shown={frames.shown} style={frames.style}>
             <SeamStripBar
               clips={barClips}
@@ -1128,7 +1148,30 @@ function DetailsFilmstripModal({
         ref={stripRef}
         data-details-strip
         className={[
-          "flex items-center",
+          // BOTTOM-ALIGNED, so the trim strips share a line.
+          //
+          // Centred, the taller subject extended equally above and below
+          // its neighbours — measured at 1920: 76px each way — and every
+          // row BELOW the picture inherited that offset. The transport
+          // well, the filmstrip, the in/out fields and the tags each sat
+          // 76px lower on the centre than on the clips either side of it.
+          //
+          // That is the wrong thing to centre. The pictures are different
+          // sizes on purpose — the subject's is bigger because it is the
+          // one being judged — but the CONTROLS under them are identical
+          // in size and function, and comparing a trim against its
+          // neighbours' is most of what this view is for. Reading three
+          // filmstrips on three different lines makes that a hunt.
+          //
+          // Hanging the cards from a common bottom lands them all on one
+          // line for free: everything from the strip down is the same
+          // height in every card (126px from strip-top to card-bottom,
+          // measured), so a shared bottom IS a shared strip line.
+          //
+          // This is a deliberate departure from the design it follows,
+          // which top-aligns the three and lets the strips fall where the
+          // picture heights leave them.
+          "flex items-end",
           // NO TRANSITION WHILE A FINGER IS ON IT. A drag has to track the
           // hand exactly; easing it would put the film a fixed distance
           // behind wherever the pointer actually is, which reads as lag

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
@@ -609,17 +609,16 @@ export function DetailsPanel({
           trimOut={trimOut}
         />
 
-        <ItemDetailsTrimStrip
-          node={node}
-          windowed={windowed}
-          video={video}
-          trimIn={trimIn}
-          trimOut={trimOut}
-          showing={showing}
-          live={live}
-          playhead={playhead}
-        />
+        {/* ABOVE THE TRIM BLOCK, and that placement is load-bearing.
 
+            Everything below the filmstrip has to be the SAME HEIGHT in every
+            panel, because the cards hang from a common bottom and that is
+            what puts the three strips on one line. This control appears only
+            for a clip on a lane with a picture — so it is present on some
+            cards and not others, and underneath the strip it would push one
+            card's strip up by its own height and break the line it sits on.
+            Above the strip it lands in the part of the card that is already
+            allowed to differ. */}
         {/* WHERE IT DRAWS, for a clip that is under the picture. Only shown
             when it is actually on a lane and actually has a picture: the
             control describes a rectangle inside the frame, and neither the
@@ -637,6 +636,18 @@ export function DetailsPanel({
           </div>
         )}
 
+        <ItemDetailsTrimStrip
+          node={node}
+          windowed={windowed}
+          video={video}
+          trimIn={trimIn}
+          trimOut={trimOut}
+          showing={showing}
+          live={live}
+          playhead={playhead}
+        />
+
+
         {/* Tags. Here rather than on the card because the card's content
             renders inside a <button>, where these remove buttons and the text
             field would be invalid HTML — the card shows them, this edits them.
@@ -649,7 +660,23 @@ export function DetailsPanel({
             the control describes itself, and at nine panels the heading was
             nine lines of the word. One hairline stays, because the panel still
             needs a foot to sit on. */}
-        <div className="hidden border-t border-white/10 pt-2 @min-[30rem]:block">
+        {/* ALWAYS, AND ALWAYS ONE LINE HIGH.
+
+            This was gated at 30rem, which made it the last thing standing
+            between the three filmstrips and a shared line: at a 1280 canvas
+            the 560px centre kept its tags and the 320px neighbours dropped
+            theirs, so the neighbours' strips sat 37px lower — the tag row and
+            its gap, exactly. A row that is present on one card and absent on
+            another cannot sit under something that has to align.
+
+            Un-gating it is not enough on its own: tags wrap, and a clip may
+            carry up to MAX_TAGS_PER_CLIP of them, so a wrapping row is a
+            variable-height row and breaks the line just as thoroughly. The
+            chips scroll sideways instead — see graph-tag-editor.tsx.
+
+            Both changes ADD capability rather than removing it: a narrow
+            panel could not be tagged at all before. */}
+        <div className="border-t border-white/10 pt-2">
           <TagEditor nodeId={node.id} />
         </div>
       </div>

--- a/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-seam-strip-bar.tsx
@@ -1200,7 +1200,10 @@ export function SeamStripBar({
         // which put the ensemble visibly high in its own band even though the
         // row itself was centred. Equal air on both sides is what makes it look
         // centred, and only one of those two numbers existed.
-        className="grid grid-cols-[1fr_auto_1fr] items-center gap-3 pb-2"
+        // `pt-3 pb-2` — the row needs air ABOVE it now that the transport no
+        // longer brings its own. Measured against the design: about 23px
+        // between the minimap and the top of the controls.
+        className="grid grid-cols-[1fr_auto_1fr] items-center gap-3 pt-3 pb-2"
       >
         {/* HIDDEN, NOT WRAPPED, on a narrow view. Wrapping this row costs the
             strip below a line of height it has to be told about — see the
@@ -1224,12 +1227,18 @@ export function SeamStripBar({
             stay there when a setting changes width. */}
         <div
           data-seam-transport
-          // DROPPED CLEAR OF THE BARS ABOVE. `mt-9` is 36px, on the assembly
-          // rather than on the row: the badges either side keep sitting where
-          // the ruler leaves them, and only the transport takes the air.
+          // ON THE ROW, NOT BELOW IT. This carried `mt-9` — 36px on the
+          // assembly rather than on the row — to drop the transport clear of
+          // the bars above while the badges either side stayed where the
+          // ruler left them. What it actually produced was a control row
+          // with a hole in the middle: two groups on one line and the play
+          // button on a second, 36px lower, reading as its own half-row.
           //
-          // Landed at 20 first and went to 36. Whatever this number becomes,
-          // the scrim's top padding owes it TWICE over — see the note there.
+          // The row is already `items-center`, so with the margin gone the
+          // transport centres against `frames`, `card`, the clock, `fit` and
+          // `reach` — one line of controls, which is what the design it
+          // follows has. The air the margin was buying now comes from the
+          // row's own spacing, where it applies to everything equally.
           // TIGHT AROUND THE BUTTON. Six pixels of padding and a 32px button put
           // the transport in a 46px pill where the white circle occupied
           // barely two thirds of the height — it read as a small control
@@ -1237,7 +1246,7 @@ export function SeamStripBar({
           // arranged around. Three pixels and a 36px button takes it to
           // 42, and the circle now fills the pill the way it does in the
           // design it came from.
-          className={["mt-9 flex items-center gap-1 rounded-full border p-[3px]", HAIRLINE, SURFACE_WELL].join(" ")}
+          className={["flex items-center gap-1 rounded-full border p-[3px]", HAIRLINE, SURFACE_WELL].join(" ")}
         >
           {/* STEP ONE CLIP, either way, bracketing the thing they move.
               Disabled rather than hidden at the ends: a control that vanishes

--- a/apps/timeline-gstudio001/components/graph-view/graph-tag-editor.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-tag-editor.tsx
@@ -135,13 +135,28 @@ export function TagEditor({ nodeId }: Readonly<{ nodeId: NodeId }>) {
   };
 
   return (
-    <div className="relative flex flex-wrap items-center gap-1.5" data-tag-editor>
+    <div className="relative flex items-center gap-1.5" data-tag-editor>
       {/* NO EMPTY-STATE SENTENCE. The field below it says "Add a tag…" in
             its own placeholder, so the line was telling you what the control
             already tells you — and in the details strip it appeared once per
             panel, up to nine times on one screen, which is how a helpful
             sentence turns into noise. An empty row of chips reads as empty
             without being told. */}
+        {/* THE CHIPS SCROLL; THE CONTROLS DO NOT.
+
+            ONE LINE, ALWAYS, so this row's height cannot change with the
+            number of tags. The panel above hangs its filmstrip on that being
+            true: the three cards share a bottom edge, so anything of varying
+            height below the strip moves one card's strip off the line the
+            other two are on. Wrapping was the alternative, and wrapping is
+            exactly what broke it.
+
+            THE `+` BUTTON AND ITS POPOVER STAY OUTSIDE THIS BOX. An overflow
+            container clips on BOTH axes — `overflow-x: auto` makes the block
+            direction `auto` too — so a popover anchored inside one opens into
+            a scroll box a few pixels tall and is never seen. That is the
+            whole reason the chips are wrapped here rather than the row. */}
+        <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         {tags.map((tag) => (
           <span
             key={tag}
@@ -155,7 +170,7 @@ export function TagEditor({ nodeId }: Readonly<{ nodeId: NodeId }>) {
             // something exact here, and a judgement is neither editable
             // data nor the playhead.
             className={[
-              "flex items-center gap-1 rounded py-0.5 pr-0.5 pl-1.5",
+              "flex shrink-0 items-center gap-1 rounded py-0.5 pr-0.5 pl-1.5",
               "text-[11px] leading-none font-medium ring-1",
               JUDGEMENT_TAGS.has(tag) ? TAG_JUDGEMENT : TAG_FACT,
             ].join(" ")}
@@ -172,6 +187,7 @@ export function TagEditor({ nodeId }: Readonly<{ nodeId: NodeId }>) {
             </button>
           </span>
         ))}
+        </div>
 
         {/* AT THE END OF THE TAGS, which is where the next one would go. A
             control that adds to a list belongs at the end of that list; parked
@@ -190,7 +206,7 @@ export function TagEditor({ nodeId }: Readonly<{ nodeId: NodeId }>) {
           // it was a sixth tag in a row of five, and the eye had to read
           // the glyph to find out it was not one. A broken outline says
           // empty-and-fillable before anything is read.
-          className="flex size-5 items-center justify-center rounded border border-dashed border-white/20 text-zinc-500 transition-colors hover:border-white/30 hover:bg-white/5 hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-sky-500/70 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40"
+          className="flex size-5 shrink-0 items-center justify-center rounded border border-dashed border-white/20 text-zinc-500 transition-colors hover:border-white/30 hover:bg-white/5 hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-sky-500/70 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40"
         >
           <Plus aria-hidden="true" className="size-3" />
         </button>

--- a/apps/timeline-gstudio001/components/graph-view/graph-tag-editor.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-tag-editor.tsx
@@ -155,8 +155,13 @@ export function TagEditor({ nodeId }: Readonly<{ nodeId: NodeId }>) {
             container clips on BOTH axes — `overflow-x: auto` makes the block
             direction `auto` too — so a popover anchored inside one opens into
             a scroll box a few pixels tall and is never seen. That is the
-            whole reason the chips are wrapped here rather than the row. */}
-        <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+            whole reason the chips are wrapped here rather than the row.
+
+            NOT `flex-1`. Grown to fill, an EMPTY scroller takes the whole row
+            and strands the `+` button against the far edge of the card, yards
+            from the chips it appends to. Shrink-only leaves it hugging its
+            content and still scrolling once there is too much. */}
+        <div className="flex min-w-0 items-center gap-1.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         {tags.map((tag) => (
           <span
             key={tag}


### PR DESCRIPTION
Follow-up to #526. Comparing a trim against its neighbours' is most of what this view is for, and the three filmstrips were on three different lines.

## The cause

The row was `items-center`, so the taller subject extended equally above **and** below its neighbours, and every row under the picture inherited half the height difference. Measured at 1920: the transport well, the filmstrip, the in/out fields and the tags all sat **76px lower** on the centre.

Hanging the cards from a common bottom puts them on one line for free — everything from the strip down is the same height in every card.

## Except it wasn't

Two rows below the strip varied, so bottom-alignment alone only worked on a wide canvas:

- **The layer picker** appears only for a clip on a lane. Moved **above** the strip, into the part of the card already allowed to differ.
- **The tag row** was gated at 30rem, so at a 1280 canvas the 560px centre kept its tags and the 320px neighbours dropped theirs — their strips then sat **37px lower**, the row and its gap exactly. Un-gating alone wouldn't fix it either: tags wrap, and a clip may carry 32. The chips now scroll sideways, so the row is one line high whatever it holds. The `+` trigger stays **outside** that scroller, because an overflow box clips on both axes and would open its popover into a strip of pixels.

Both changes **add** capability — a narrow panel couldn't be tagged at all before.

## Also measured against the design

- **The bar was capped at `7xl`** while the cards ran full-viewport, so the cards overhung the ruler that measures them by **296px each side**. That cap's own comment said the bar should be *wider* than the panels — true until the app stopped limiting its width, which inverted it. Both now span 24..1896.
- **The transport carried a 36px top margin** and sat on a second line below `frames`, `card`, `fit` and `reach` — a control row with a hole in the middle. All four groups now share a centre line, delta 0.
- **Controls-to-card gap 62px → 30** (the design runs ~27). The scrim is `items-center`, so padding buys half its value in movement — hence 21.75rem → 14.75rem for a 32px change.

## Verification

- `tsc` clean · `eslint` 0 errors · **1447/1447** app · **48/48** modal stories
- Spread at the 1280 canvas that was failing: **0** (strips at 459.5, footers 127 each)
- **Proved the new guard bites** by restoring the tag gate — `expected 37 to be less than 1`
- Two existing stories asserted the behaviour that changed and were updated rather than deleted: narrow panels still shed the filmstrip and the history pair, and the add button still follows the chips (now a document-order question, since the chips gained a scroller)

🤖 Generated with [Claude Code](https://claude.com/claude-code)