### PR TITLE
The step transition: nothing snaps, and the height follows

### DIFF
--- a/apps/timeline-gstudio001/components/graph-view/graph-details-motion.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-details-motion.ts
@@ -53,50 +53,33 @@ export const DETAILS_STEP_MS = 420;
 export const DETAILS_STEP_EASING = DETAILS_STEP_EASE;
 
 /**
- * A STEP IS TWO PHASES NOW: THE CARDS RESIZE, AND THEN THE ROW SLIDES.
+ * WIDTH, HEIGHT AND THE ROW'S TRAVEL ALL MOVE TOGETHER, ON THIS CLOCK.
  *
- * They used to happen together, and the reason that read badly was not the
- * overlap itself — it was that only HALF of the resize was animated. Width
- * eased over the step; height was in nobody's transition list and snapped.
- * Measured at 1920: a card going from neighbour to subject is 368px tall and
- * becomes 519, and since the cards hang from a common bottom that is a 151px
- * jump of the top edge, in one frame, at the exact moment the row began to
- * travel. One dimension gliding while the other teleports is what the eye was
- * catching.
+ * Both orderings were built and looked at. Resize-then-slide made the subject
+ * grow before it had anywhere to go; slide-then-resize landed it 184px right of
+ * centre — half the 368px between the two widths, because the row's offset is
+ * computed from a uniform neighbour width and only centres the subject once the
+ * subject IS the wide card — and left it to close that gap by growing.
  *
- * Animating height alongside width would have fixed the snap and left three
- * things moving at once. Separating them is the better answer, and it is free:
- * the two cards that change size are ADJACENT and swap the same number of
- * pixels, so while they resize nothing else in the row moves at all. The
- * subject grows in place; then the row slides to centre it.
+ * Simultaneous was right all along. What was actually wrong was that only HALF
+ * of it was animated: width eased over the step and HEIGHT was in nobody's
+ * transition list, so a card promoted to subject jumped from 368px tall to 519
+ * in a single frame — and because the cards hang from a common bottom, that
+ * moved its top edge 151px at the exact moment the row began to travel. One
+ * dimension gliding while the other teleported is the whole of what looked
+ * wrong; the ordering was never the problem.
  *
- * Sequenced with a plain transition-delay rather than a state machine — the
- * slide simply does not begin until the resize has finished.
+ * WIDTH TRAVELS WITH THE ROW; HEIGHT WAITS. The card has to be the right WIDTH
+ * when it lands — the row's offset is computed from a uniform neighbour width
+ * and only centres the subject once the subject is the wide card, so a width
+ * that arrived late would leave the card 184px off centre and creeping. Height
+ * is under no such obligation: nothing about the horizontal landing depends on
+ * it, and it is the change that was jarring, because the cards hang from a
+ * common bottom and 151px of it lands on the top edge.
+ *
+ * So the vertical change is held back until the horizontal one has effectively
+ * finished, and gets a clock of its own.
  */
-export const DETAILS_RESIZE_MS = 190;
-
-/** The travel, once the sizes have settled. */
-export const DETAILS_SLIDE_MS = 260;
-
-/** Phase TWO: the cards change size, once the row has stopped moving. */
-export function detailsResizeTransition(properties: string): string {
-  return properties
-    .split(",")
-    .map(
-      (property) =>
-        `${property.trim()} ${DETAILS_RESIZE_MS}ms ${DETAILS_STEP_EASE} ${DETAILS_SLIDE_MS}ms`,
-    )
-    .join(", ");
-}
-
-/** Phase ONE: the row travels, at the old sizes. */
-export function detailsSlideTransition(properties: string): string {
-  return properties
-    .split(",")
-    .map((property) => `${property.trim()} ${DETAILS_SLIDE_MS}ms ${DETAILS_STEP_EASE}`)
-    .join(", ");
-}
-
 /** `transition` shorthand for a property that moves with a step. */
 export function detailsStepTransition(properties: string): string {
   return properties
@@ -114,6 +97,20 @@ export function detailsStepTransition(properties: string): string {
  * alongside it.
  */
 export const DETAILS_CHROME_MS = 210;
+
+/**
+ * When the height change starts, measured from the top of the step.
+ *
+ * Not the full {@link DETAILS_STEP_MS}, which would read as a pause. The step's
+ * curve is a hard ease-out — it does most of its travel early — so by 300ms the
+ * row has visibly stopped even though it has 120ms of settle left. Starting
+ * here reads as the card adjusting once it has arrived, rather than as two
+ * animations with a gap between them.
+ */
+export const DETAILS_HEIGHT_DELAY_MS = 300;
+
+/** And how long it then takes. Short: it is a correction, not a journey. */
+export const DETAILS_HEIGHT_MS = 200;
 
 /**
  * How long the subject's chrome takes to LEAVE the card losing it, and how

--- a/apps/timeline-gstudio001/components/graph-view/graph-details-motion.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-details-motion.ts
@@ -78,22 +78,22 @@ export const DETAILS_RESIZE_MS = 190;
 /** The travel, once the sizes have settled. */
 export const DETAILS_SLIDE_MS = 260;
 
-/** Phase one: the cards change size, in place. */
+/** Phase TWO: the cards change size, once the row has stopped moving. */
 export function detailsResizeTransition(properties: string): string {
-  return properties
-    .split(",")
-    .map((property) => `${property.trim()} ${DETAILS_RESIZE_MS}ms ${DETAILS_STEP_EASE}`)
-    .join(", ");
-}
-
-/** Phase two: the row travels, after phase one has finished. */
-export function detailsSlideTransition(properties: string): string {
   return properties
     .split(",")
     .map(
       (property) =>
-        `${property.trim()} ${DETAILS_SLIDE_MS}ms ${DETAILS_STEP_EASE} ${DETAILS_RESIZE_MS}ms`,
+        `${property.trim()} ${DETAILS_RESIZE_MS}ms ${DETAILS_STEP_EASE} ${DETAILS_SLIDE_MS}ms`,
     )
+    .join(", ");
+}
+
+/** Phase ONE: the row travels, at the old sizes. */
+export function detailsSlideTransition(properties: string): string {
+  return properties
+    .split(",")
+    .map((property) => `${property.trim()} ${DETAILS_SLIDE_MS}ms ${DETAILS_STEP_EASE}`)
     .join(", ");
 }
 

--- a/apps/timeline-gstudio001/components/graph-view/graph-details-motion.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-details-motion.ts
@@ -52,6 +52,51 @@ export const DETAILS_STEP_MS = 420;
 /** The step's easing, as a CSS value. */
 export const DETAILS_STEP_EASING = DETAILS_STEP_EASE;
 
+/**
+ * A STEP IS TWO PHASES NOW: THE CARDS RESIZE, AND THEN THE ROW SLIDES.
+ *
+ * They used to happen together, and the reason that read badly was not the
+ * overlap itself — it was that only HALF of the resize was animated. Width
+ * eased over the step; height was in nobody's transition list and snapped.
+ * Measured at 1920: a card going from neighbour to subject is 368px tall and
+ * becomes 519, and since the cards hang from a common bottom that is a 151px
+ * jump of the top edge, in one frame, at the exact moment the row began to
+ * travel. One dimension gliding while the other teleports is what the eye was
+ * catching.
+ *
+ * Animating height alongside width would have fixed the snap and left three
+ * things moving at once. Separating them is the better answer, and it is free:
+ * the two cards that change size are ADJACENT and swap the same number of
+ * pixels, so while they resize nothing else in the row moves at all. The
+ * subject grows in place; then the row slides to centre it.
+ *
+ * Sequenced with a plain transition-delay rather than a state machine — the
+ * slide simply does not begin until the resize has finished.
+ */
+export const DETAILS_RESIZE_MS = 190;
+
+/** The travel, once the sizes have settled. */
+export const DETAILS_SLIDE_MS = 260;
+
+/** Phase one: the cards change size, in place. */
+export function detailsResizeTransition(properties: string): string {
+  return properties
+    .split(",")
+    .map((property) => `${property.trim()} ${DETAILS_RESIZE_MS}ms ${DETAILS_STEP_EASE}`)
+    .join(", ");
+}
+
+/** Phase two: the row travels, after phase one has finished. */
+export function detailsSlideTransition(properties: string): string {
+  return properties
+    .split(",")
+    .map(
+      (property) =>
+        `${property.trim()} ${DETAILS_SLIDE_MS}ms ${DETAILS_STEP_EASE} ${DETAILS_RESIZE_MS}ms`,
+    )
+    .join(", ");
+}
+
 /** `transition` shorthand for a property that moves with a step. */
 export function detailsStepTransition(properties: string): string {
   return properties

--- a/apps/timeline-gstudio001/components/graph-view/graph-details-motion.ts
+++ b/apps/timeline-gstudio001/components/graph-view/graph-details-motion.ts
@@ -69,3 +69,30 @@ export function detailsStepTransition(properties: string): string {
  * alongside it.
  */
 export const DETAILS_CHROME_MS = 210;
+
+/**
+ * How long the subject's chrome takes to LEAVE the card losing it, and how
+ * long the card gaining it waits before claiming it.
+ *
+ * A step grows one card and shrinks another at the same time, and for the few
+ * frames either side of the crossing they are near enough the same size that
+ * neither reads as the subject. Watched back frame by frame, the eye has
+ * nothing to follow through the middle of the step.
+ *
+ * THE FIX IS NOT TO STAGGER THE WIDTHS. Both cards change by exactly the same
+ * amount in opposite directions, so animating them together keeps the row's
+ * total width invariant; offsetting them makes it dip by that amount — 236px
+ * at 1920 — and every card to the right of the pair slides out and back. The
+ * geometry has to stay simultaneous.
+ *
+ * So the HANDOFF is staggered instead, which costs no layout at all. The
+ * outgoing card drops its surface and border inside this window; the incoming
+ * one waits it out before taking them. The two never wear the mark at once,
+ * so there is exactly one subject at every frame of the step even while the
+ * sizes are crossing.
+ *
+ * A third of the step. Long enough to read as a handoff rather than a
+ * simultaneous swap, short enough that the arriving card is fully marked well
+ * before it stops moving.
+ */
+export const DETAILS_HANDOFF_MS = 140;

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -4028,3 +4028,69 @@ export const TheOutgoingCardKeepsItsPictureWhileItLeaves: Story = {
     expect(getComputedStyle(leaving!).visibility).toBe("visible");
   },
 };
+
+/**
+ * ONLY ONE CARD WEARS THE MARK AT A TIME, INCLUDING MID-STEP.
+ *
+ * A step grows one card and shrinks another simultaneously, and around the
+ * crossing they are near enough the same size that neither reads as the
+ * subject. On a frame-by-frame playback the eye has nothing to follow through
+ * the middle of the step.
+ *
+ * THE WIDTHS ARE NOT WHAT GOT STAGGERED, and that is the interesting part.
+ * Both cards change by exactly the same amount in opposite directions, so
+ * animating them together holds the row's total width constant; offsetting them
+ * would make it dip by that amount — 236px, measured at 1920 — and every card
+ * to the right of the pair would slide out and back. The geometry has to stay
+ * simultaneous.
+ *
+ * So the CHROME is handed off instead, which costs no layout: the outgoing card
+ * drops its surface and border inside the handoff window, and the incoming one
+ * waits exactly that long before taking them.
+ *
+ * Asserted as timings rather than as painted colour, because the thing being
+ * claimed is about ORDER, and a colour sampled mid-transition is a race.
+ */
+export const TheSubjectMarkIsHandedOverNotSwapped: Story = {
+  render: () => <SeamHarness scene={TRIMMED_SCENE} />,
+  play: async () => {
+    await waitFor(() => expect(seamTrack()).not.toBeNull());
+    const panels = () =>
+      Array.from(document.querySelectorAll<HTMLElement>("[data-item-details-panel]"));
+    const timing = (panel: HTMLElement) => {
+      const style = getComputedStyle(panel);
+      return { duration: style.transitionDuration, delay: style.transitionDelay };
+    };
+
+    // Settled: nobody is waiting on anybody.
+    for (const panel of panels()) {
+      expect(timing(panel).delay).toBe("0s");
+    }
+    // The surface is part of the mark, so it has to be part of the transition —
+    // it used to snap while the border eased.
+    expect(getComputedStyle(panels()[0]!).transitionProperty).toContain("background-color");
+
+    const before = panels().find(
+      (panel) => panel.getAttribute("data-item-details-panel") === "centre",
+    )!;
+    fireEvent.click(document.querySelector<HTMLButtonElement>('[data-seam-step="back"]')!);
+
+    // DEPARTING drops it immediately, over the shorter window.
+    const departing = timing(before);
+    expect(`departing delay ${departing.delay}`).toBe("departing delay 0s");
+    expect(`departing duration ${departing.duration}`).toBe("departing duration 0.14s");
+
+    // ARRIVING waits that window out before taking anything.
+    const arriving = panels().find(
+      (panel) => panel.getAttribute("data-item-details-panel") === "centre",
+    )!;
+    expect(arriving).not.toBe(before);
+    expect(`arriving delay ${timing(arriving).delay}`).toBe("arriving delay 0.14s");
+
+    // The one does not begin until the other has finished: no frame of the step
+    // has two marked cards, which is the whole claim.
+    expect(Number.parseFloat(departing.duration)).toBeLessThanOrEqual(
+      Number.parseFloat(timing(arriving).delay) + 0.001,
+    );
+  },
+};

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -4106,7 +4106,7 @@ export const TheSubjectMarkIsHandedOverNotSwapped: Story = {
 };
 
 /**
- * THE CARDS FINISH RESIZING BEFORE THE ROW STARTS MOVING.
+ * THE ROW FINISHES MOVING BEFORE THE CARDS RESIZE.
  *
  * A step used to do both at once, and what made that read wrong was not the
  * overlap — it was that only half the resize was animated. Width eased over the
@@ -4115,15 +4115,22 @@ export const TheSubjectMarkIsHandedOverNotSwapped: Story = {
  * from a common bottom that is a 151px jump of its top edge, in one frame, at
  * the moment the row began to travel.
  *
- * Separating the two is free: the cards that change size are ADJACENT and swap
- * the same number of pixels, so nothing else in the row moves while they do it.
- * The subject grows in place, then the row slides to centre it.
+ * Separated, then ordered by eye: resize-then-slide was tried first and still
+ * read wrong, so the row travels first and the cards change size once it has
+ * stopped.
+ *
+ * WHAT THAT COSTS, measured rather than assumed. The row's offset is computed
+ * from a uniform neighbour width, so it lands the subject centred only once the
+ * subject is the wide card. Slide first and the subject arrives 184px right of
+ * centre — exactly half the 368px between the two widths — and closes that gap
+ * as it grows. Both phases carry it the same way, so there is no reversal: it
+ * travels, then grows into position.
  *
  * Asserted as declarations rather than as sampled geometry. The claim is about
  * ORDER, and sampling positions mid-flight is a race — worse here than usual,
  * because the interesting window is 190ms long.
  */
-export const TheResizeFinishesBeforeTheSlideBegins: Story = {
+export const TheRowSlidesBeforeTheCardsResize: Story = {
   render: () => <SeamHarness scene={TRIMMED_SCENE} />,
   play: async () => {
     await waitFor(() => expect(seamTrack()).not.toBeNull());
@@ -4144,20 +4151,23 @@ export const TheResizeFinishesBeforeTheSlideBegins: Story = {
       `height ${getComputedStyle(outer).transitionDuration.split(",")[0]!.trim()}`,
     );
 
-    // AND THE SLIDE WAITS FOR IT. The strip's transform is delayed by exactly
-    // the resize, which is what makes this a sequence rather than an overlap.
-    const stripProperties = getComputedStyle(strip)
-      .transitionProperty.split(",")
+    // THE SLIDE GOES FIRST, so it waits for nothing.
+    const stripStyle = getComputedStyle(strip);
+    const stripProperties = stripStyle.transitionProperty
+      .split(",")
       .map((name) => name.trim());
-    const stripDelays = getComputedStyle(strip)
-      .transitionDelay.split(",")
+    const stripDelays = stripStyle.transitionDelay.split(",").map((value) => value.trim());
+    const stripDurations = stripStyle.transitionDuration
+      .split(",")
       .map((value) => value.trim());
-    const transformDelay = stripDelays[stripProperties.indexOf("transform")];
-    expect(`slide waits ${transformDelay}`).toBe(`slide waits ${heightDuration}`);
+    const at = stripProperties.indexOf("transform");
+    expect(`slide waits ${stripDelays[at]}`).toBe("slide waits 0s");
 
-    // The resize must not itself be waiting on anything, or the card would
-    // still be growing after the row had begun to move.
+    // AND THE RESIZE WAITS FOR THE SLIDE — by exactly its duration, which is
+    // what makes this a sequence rather than an overlap.
     const delays = panelStyle.transitionDelay.split(",").map((value) => value.trim());
-    expect(`height delay ${delays[properties.indexOf("height")]}`).toBe("height delay 0s");
+    expect(`height waits ${delays[properties.indexOf("height")]}`).toBe(
+      `height waits ${stripDurations[at]}`,
+    );
   },
 };

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -4106,31 +4106,28 @@ export const TheSubjectMarkIsHandedOverNotSwapped: Story = {
 };
 
 /**
- * THE ROW FINISHES MOVING BEFORE THE CARDS RESIZE.
+ * THE WIDTH TRAVELS WITH THE ROW; ONLY THE HEIGHT WAITS.
  *
- * A step used to do both at once, and what made that read wrong was not the
- * overlap — it was that only half the resize was animated. Width eased over the
- * step; HEIGHT was in nobody's transition list and snapped. Measured at 1920, a
- * card promoted to subject goes from 368px tall to 519, and since the cards hang
- * from a common bottom that is a 151px jump of its top edge, in one frame, at
- * the moment the row began to travel.
+ * A step used to animate width while HEIGHT snapped — it was in nobody's
+ * transition list. Measured at 1920, a card promoted to subject goes from 368px
+ * tall to 519, and since the cards hang from a common bottom that is a 151px
+ * jump of its top edge, in a single frame, exactly as the row began to travel.
+ * One dimension gliding while the other teleported is what looked wrong.
  *
- * Separated, then ordered by eye: resize-then-slide was tried first and still
- * read wrong, so the row travels first and the cards change size once it has
- * stopped.
+ * Both full orderings were built and rejected before landing here. Resize-first
+ * made the subject grow before it had anywhere to go. Slide-first left it 184px
+ * right of centre — half the 368px between the two widths, because the row's
+ * offset is computed from a uniform neighbour width and only centres the subject
+ * once the subject IS the wide card — and made it close that gap by growing.
  *
- * WHAT THAT COSTS, measured rather than assumed. The row's offset is computed
- * from a uniform neighbour width, so it lands the subject centred only once the
- * subject is the wide card. Slide first and the subject arrives 184px right of
- * centre — exactly half the 368px between the two widths — and closes that gap
- * as it grows. Both phases carry it the same way, so there is no reversal: it
- * travels, then grows into position.
+ * So WIDTH has to travel with the row: the landing position depends on it.
+ * HEIGHT does not, and it is the jarring one, so it is the only thing held back.
  *
- * Asserted as declarations rather than as sampled geometry. The claim is about
- * ORDER, and sampling positions mid-flight is a race — worse here than usual,
- * because the interesting window is 190ms long.
+ * Asserted as declarations. The claim is about ORDER, and neither browser pane
+ * will sample a transition — requestAnimationFrame is throttled in both, so a
+ * timed probe returns one frame and then nothing.
  */
-export const TheRowSlidesBeforeTheCardsResize: Story = {
+export const TheWidthTravelsWithTheRowAndTheHeightFollows: Story = {
   render: () => <SeamHarness scene={TRIMMED_SCENE} />,
   play: async () => {
     await waitFor(() => expect(seamTrack()).not.toBeNull());
@@ -4138,36 +4135,35 @@ export const TheRowSlidesBeforeTheCardsResize: Story = {
     const outer = panel.parentElement!;
     const strip = document.querySelector<HTMLElement>("[data-details-strip]")!;
 
-    // HEIGHT IS ANIMATED AT ALL. This is the whole bug, in one assertion.
-    const panelStyle = getComputedStyle(panel);
-    expect(panelStyle.transitionProperty).toContain("height");
+    const entry = (element: HTMLElement, property: string) => {
+      const style = getComputedStyle(element);
+      const at = style.transitionProperty
+        .split(",")
+        .map((name) => name.trim())
+        .indexOf(property);
+      const pick = (value: string) => value.split(",").map((v) => v.trim())[at] ?? "";
+      return { duration: pick(style.transitionDuration), delay: pick(style.transitionDelay) };
+    };
 
-    // Width and height run on the same clock, so the card changes shape as one
-    // thing rather than as two.
-    const properties = panelStyle.transitionProperty.split(",").map((name) => name.trim());
-    const durations = panelStyle.transitionDuration.split(",").map((value) => value.trim());
-    const heightDuration = durations[properties.indexOf("height")];
-    expect(`height ${heightDuration}`).toBe(
-      `height ${getComputedStyle(outer).transitionDuration.split(",")[0]!.trim()}`,
+    // HEIGHT IS ANIMATED AT ALL. This is the original bug, in one assertion.
+    expect(getComputedStyle(panel).transitionProperty).toContain("height");
+
+    // WIDTH AND THE ROW TRAVEL TOGETHER — same clock, neither waiting.
+    const travel = entry(strip, "transform");
+    const width = entry(outer, "width");
+    expect(`width ${width.duration}/${width.delay}`).toBe(
+      `width ${travel.duration}/${travel.delay}`,
     );
+    expect(`row waits ${travel.delay}`).toBe("row waits 0s");
 
-    // THE SLIDE GOES FIRST, so it waits for nothing.
-    const stripStyle = getComputedStyle(strip);
-    const stripProperties = stripStyle.transitionProperty
-      .split(",")
-      .map((name) => name.trim());
-    const stripDelays = stripStyle.transitionDelay.split(",").map((value) => value.trim());
-    const stripDurations = stripStyle.transitionDuration
-      .split(",")
-      .map((value) => value.trim());
-    const at = stripProperties.indexOf("transform");
-    expect(`slide waits ${stripDelays[at]}`).toBe("slide waits 0s");
-
-    // AND THE RESIZE WAITS FOR THE SLIDE — by exactly its duration, which is
-    // what makes this a sequence rather than an overlap.
-    const delays = panelStyle.transitionDelay.split(",").map((value) => value.trim());
-    expect(`height waits ${delays[properties.indexOf("height")]}`).toBe(
-      `height waits ${stripDurations[at]}`,
+    // AND THE HEIGHT FOLLOWS, on its own shorter clock.
+    const height = entry(panel, "height");
+    expect(Number.parseFloat(height.delay)).toBeGreaterThan(0);
+    expect(Number.parseFloat(height.duration)).toBeLessThan(
+      Number.parseFloat(travel.duration),
     );
+    // It starts as the travel is finishing rather than after a gap — most of a
+    // hard ease-out's distance is covered early.
+    expect(Number.parseFloat(height.delay)).toBeLessThan(Number.parseFloat(travel.duration));
   },
 };

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -3976,3 +3976,55 @@ export const TheTransportSitsOnTheControlRow: Story = {
     expect(rowHeight).toBeGreaterThanOrEqual(pill);
   },
 };
+
+/**
+ * THE CARD THAT IS LEAVING KEEPS ITS PICTURE UNTIL IT HAS GONE.
+ *
+ * Whether a panel draws its contents or renders as an empty box of the right
+ * width was read straight off the current centre, so a step blanked the far
+ * card instantly — while it was still on screen, in full view, sliding out as
+ * an empty rectangle. A black hole opened on one side of the row for the whole
+ * 420ms and read as a rendering fault rather than as motion.
+ *
+ * Caught on a screen recording rather than by a test, which is the reason this
+ * one exists: nothing about it is visible in a settled frame, and both ends of
+ * the step are correct.
+ *
+ * Asserted DURING the slide, so the assertion has to happen before the timer
+ * that releases the union expires — hence no `waitFor` around it. What it
+ * checks is the panel's contents, not its box: a spare still occupies its
+ * width, so geometry alone cannot tell the two apart.
+ */
+export const TheOutgoingCardKeepsItsPictureWhileItLeaves: Story = {
+  render: () => <SeamHarness scene={TRIMMED_SCENE} />,
+  play: async () => {
+    await waitFor(() => expect(seamTrack()).not.toBeNull());
+    const panelFor = (name: string) =>
+      Array.from(document.querySelectorAll<HTMLElement>("[data-item-details-panel]")).find(
+        (panel) => panel.textContent?.includes(name),
+      ) ?? null;
+
+    // Settled on the middle clip: the clip to its right is a real panel.
+    await waitFor(() => expect(panelFor("Subject")).not.toBeNull());
+    expect(panelFor("After")).not.toBeNull();
+
+    // Step BACK, which sends "After" out of the window on the right.
+    const back = document.querySelector<HTMLButtonElement>('[data-seam-step="back"]')!;
+    fireEvent.click(back);
+
+    // IMMEDIATELY — this is the frame the bug lived in. The card has left the
+    // window around the new centre and must still be drawing itself.
+    const leaving = panelFor("After");
+    expect(leaving).not.toBeNull();
+
+    // ASKED OF VISIBILITY, not of the children. A spare keeps its whole
+    // subtree and its box — the row's centring is arithmetic over uniform
+    // neighbour widths, so collapsing one would shift every panel between it
+    // and the middle — and hides it with `visibility: hidden`. So the picture
+    // and the readout are still in the DOM either way, and a test that looked
+    // for them passed against the bug it was written for.
+    const box = leaving!.closest("[data-item-details-spare]");
+    expect(`spare while leaving: ${box !== null}`).toBe("spare while leaving: false");
+    expect(getComputedStyle(leaving!).visibility).toBe("visible");
+  },
+};

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.stories.tsx
@@ -4057,9 +4057,19 @@ export const TheSubjectMarkIsHandedOverNotSwapped: Story = {
     await waitFor(() => expect(seamTrack()).not.toBeNull());
     const panels = () =>
       Array.from(document.querySelectorAll<HTMLElement>("[data-item-details-panel]"));
-    const timing = (panel: HTMLElement) => {
+    // PER PROPERTY, because this element now runs several clocks at once:
+    // the chrome on the handoff, height on the resize phase. A bare
+    // `transitionDelay` is a comma-separated list of five values here, and
+    // reading it whole compares the wrong things.
+    const timing = (panel: HTMLElement, property = "box-shadow") => {
       const style = getComputedStyle(panel);
-      return { duration: style.transitionDuration, delay: style.transitionDelay };
+      const at = style.transitionProperty.split(",").map((name) => name.trim()).indexOf(property);
+      const pick = (value: string) =>
+        value.split(",").map((entry) => entry.trim())[at] ?? "";
+      return {
+        duration: pick(style.transitionDuration),
+        delay: pick(style.transitionDelay),
+      };
     };
 
     // Settled: nobody is waiting on anybody.
@@ -4092,5 +4102,62 @@ export const TheSubjectMarkIsHandedOverNotSwapped: Story = {
     expect(Number.parseFloat(departing.duration)).toBeLessThanOrEqual(
       Number.parseFloat(timing(arriving).delay) + 0.001,
     );
+  },
+};
+
+/**
+ * THE CARDS FINISH RESIZING BEFORE THE ROW STARTS MOVING.
+ *
+ * A step used to do both at once, and what made that read wrong was not the
+ * overlap — it was that only half the resize was animated. Width eased over the
+ * step; HEIGHT was in nobody's transition list and snapped. Measured at 1920, a
+ * card promoted to subject goes from 368px tall to 519, and since the cards hang
+ * from a common bottom that is a 151px jump of its top edge, in one frame, at
+ * the moment the row began to travel.
+ *
+ * Separating the two is free: the cards that change size are ADJACENT and swap
+ * the same number of pixels, so nothing else in the row moves while they do it.
+ * The subject grows in place, then the row slides to centre it.
+ *
+ * Asserted as declarations rather than as sampled geometry. The claim is about
+ * ORDER, and sampling positions mid-flight is a race — worse here than usual,
+ * because the interesting window is 190ms long.
+ */
+export const TheResizeFinishesBeforeTheSlideBegins: Story = {
+  render: () => <SeamHarness scene={TRIMMED_SCENE} />,
+  play: async () => {
+    await waitFor(() => expect(seamTrack()).not.toBeNull());
+    const panel = document.querySelector<HTMLElement>("[data-item-details-panel]")!;
+    const outer = panel.parentElement!;
+    const strip = document.querySelector<HTMLElement>("[data-details-strip]")!;
+
+    // HEIGHT IS ANIMATED AT ALL. This is the whole bug, in one assertion.
+    const panelStyle = getComputedStyle(panel);
+    expect(panelStyle.transitionProperty).toContain("height");
+
+    // Width and height run on the same clock, so the card changes shape as one
+    // thing rather than as two.
+    const properties = panelStyle.transitionProperty.split(",").map((name) => name.trim());
+    const durations = panelStyle.transitionDuration.split(",").map((value) => value.trim());
+    const heightDuration = durations[properties.indexOf("height")];
+    expect(`height ${heightDuration}`).toBe(
+      `height ${getComputedStyle(outer).transitionDuration.split(",")[0]!.trim()}`,
+    );
+
+    // AND THE SLIDE WAITS FOR IT. The strip's transform is delayed by exactly
+    // the resize, which is what makes this a sequence rather than an overlap.
+    const stripProperties = getComputedStyle(strip)
+      .transitionProperty.split(",")
+      .map((name) => name.trim());
+    const stripDelays = getComputedStyle(strip)
+      .transitionDelay.split(",")
+      .map((value) => value.trim());
+    const transformDelay = stripDelays[stripProperties.indexOf("transform")];
+    expect(`slide waits ${transformDelay}`).toBe(`slide waits ${heightDuration}`);
+
+    // The resize must not itself be waiting on anything, or the card would
+    // still be growing after the row had begun to move.
+    const delays = panelStyle.transitionDelay.split(",").map((value) => value.trim());
+    expect(`height delay ${delays[properties.indexOf("height")]}`).toBe("height delay 0s");
   },
 };

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -32,7 +32,12 @@ import { TagEditor } from "./graph-tag-editor";
 import { CollectionDetailsBody } from "./graph-collection-details";
 import { ItemDisableToggle } from "./graph-item-disable-toggle";
 import { useItemDetails } from "./graph-item-details-context";
-import { DETAILS_STEP_MS, detailsStepTransition } from "./graph-details-motion";
+import {
+  DETAILS_RESIZE_MS,
+  DETAILS_SLIDE_MS,
+  detailsSlideTransition,
+  detailsStepTransition,
+} from "./graph-details-motion";
 import { SegmentedControl } from "./graph-details-segmented";
 import { withViewTransition } from "@/lib/view-transition";
 import { detailsWindow, flatOrderRootId } from "./graph-details-neighbours";
@@ -370,7 +375,10 @@ function DetailsFilmstripModal({
     // The slide's own clock, plus a frame — releasing on the same tick can
     // blank the card on its last painted frame, which is the bug in
     // miniature.
-    const timer = setTimeout(() => setLeavingCentre(null), DETAILS_STEP_MS + 40);
+    const timer = setTimeout(
+      () => setLeavingCentre(null),
+      DETAILS_RESIZE_MS + DETAILS_SLIDE_MS + 40,
+    );
     return () => clearTimeout(timer);
   }, [centre]);
 
@@ -1240,7 +1248,14 @@ function DetailsFilmstripModal({
           transform: rowTransform,
           // THE STEP'S OWN TIMING, shared with the panel widths and the film
           // strip — see . One press, one motion.
-          transition: dragPx === 0 ? detailsStepTransition("transform, opacity") : undefined,
+          // PHASE TWO. The row does not begin travelling until the cards have
+          // finished resizing — see `detailsSlideTransition`. Opacity is not
+          // part of the choreography (it is the hover-preview fade), so it
+          // keeps the plain step timing and starts immediately.
+          transition:
+            dragPx === 0
+              ? `${detailsSlideTransition("transform")}, ${detailsStepTransition("opacity")}`
+              : undefined,
         }}
       >
         {ids.map((id, index) => {

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -1345,6 +1345,18 @@ function DetailsFilmstripModal({
               // is one neighbour wide, so collapsing these would shift every
               // panel between them and the middle.
               spare={isSpare(index)}
+              // WHO IS TAKING THE MARK AND WHO IS GIVING IT UP, for as long as
+              // the step runs. Null once it has settled, so a panel that simply
+              // IS the centre transitions like anything else.
+              focusHandoff={
+                leavingCentre === null || leavingCentre === centre
+                  ? null
+                  : index === centre
+                    ? "arriving"
+                    : index === leavingCentre
+                      ? "departing"
+                      : null
+              }
               width={index === centre ? panelWidths.centre : panelWidths.neighbour}
               // Engaged, and not the one being watched. Uses the same gate as
               // the playhead lines and the ring, so the whole view agrees on

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -33,9 +33,8 @@ import { CollectionDetailsBody } from "./graph-collection-details";
 import { ItemDisableToggle } from "./graph-item-disable-toggle";
 import { useItemDetails } from "./graph-item-details-context";
 import {
-  DETAILS_RESIZE_MS,
-  DETAILS_SLIDE_MS,
-  detailsSlideTransition,
+  DETAILS_HEIGHT_DELAY_MS,
+  DETAILS_HEIGHT_MS,
   detailsStepTransition,
 } from "./graph-details-motion";
 import { SegmentedControl } from "./graph-details-segmented";
@@ -377,7 +376,7 @@ function DetailsFilmstripModal({
     // miniature.
     const timer = setTimeout(
       () => setLeavingCentre(null),
-      DETAILS_RESIZE_MS + DETAILS_SLIDE_MS + 40,
+      DETAILS_HEIGHT_DELAY_MS + DETAILS_HEIGHT_MS + 40,
     );
     return () => clearTimeout(timer);
   }, [centre]);
@@ -1252,10 +1251,7 @@ function DetailsFilmstripModal({
           // finished resizing — see `detailsSlideTransition`. Opacity is not
           // part of the choreography (it is the hover-preview fade), so it
           // keeps the plain step timing and starts immediately.
-          transition:
-            dragPx === 0
-              ? `${detailsSlideTransition("transform")}, ${detailsStepTransition("opacity")}`
-              : undefined,
+          transition: dragPx === 0 ? detailsStepTransition("transform, opacity") : undefined,
         }}
       >
         {ids.map((id, index) => {

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-modal.tsx
@@ -32,7 +32,7 @@ import { TagEditor } from "./graph-tag-editor";
 import { CollectionDetailsBody } from "./graph-collection-details";
 import { ItemDisableToggle } from "./graph-item-disable-toggle";
 import { useItemDetails } from "./graph-item-details-context";
-import { detailsStepTransition } from "./graph-details-motion";
+import { DETAILS_STEP_MS, detailsStepTransition } from "./graph-details-motion";
 import { SegmentedControl } from "./graph-details-segmented";
 import { withViewTransition } from "@/lib/view-transition";
 import { detailsWindow, flatOrderRootId } from "./graph-details-neighbours";
@@ -344,6 +344,43 @@ function DetailsFilmstripModal({
   // whole clip between two leads — exactly what this always did — and the same
   // rule gives seven at nine.
   const half = Math.floor(viewCount / 2);
+
+  // THE PANEL THAT IS LEAVING STAYS A PANEL UNTIL IT HAS LEFT.
+  //
+  // Whether a panel draws its contents or renders as an empty box of the
+  // right width was read straight off the CURRENT centre — so the moment a
+  // step changed it, the far card fell outside the window and blanked. It
+  // was still on screen for the whole 420ms slide, in full view, sliding out
+  // as an empty rectangle: a black hole opening on one side of the row for
+  // the entire transition, which is the most visible thing wrong with the
+  // step and reads as a rendering fault rather than as motion.
+  //
+  // It is NOT a mounting problem — `MOUNTED_RADIUS` already keeps a spare
+  // pair built either side, so the card exists throughout. It was only ever
+  // being told it was off screen a third of a second too early.
+  //
+  // So the window is the UNION of where it was and where it is going, held
+  // for as long as the slide takes. The card leaves with its picture on.
+  const [leavingCentre, setLeavingCentre] = useState<number | null>(null);
+  const centreWas = useRef(centre);
+  useEffect(() => {
+    if (centreWas.current === centre) return;
+    setLeavingCentre(centreWas.current);
+    centreWas.current = centre;
+    // The slide's own clock, plus a frame — releasing on the same tick can
+    // blank the card on its last painted frame, which is the bug in
+    // miniature.
+    const timer = setTimeout(() => setLeavingCentre(null), DETAILS_STEP_MS + 40);
+    return () => clearTimeout(timer);
+  }, [centre]);
+
+  /** Off screen for BOTH the centre it left and the one it is arriving at. */
+  const isSpare = useCallback(
+    (index: number) =>
+      Math.abs(index - centre) > half &&
+      (leavingCentre === null || Math.abs(index - leavingCentre) > half),
+    [centre, half, leavingCentre],
+  );
   const wholeClips = useMemo(() => {
     const clips: MediaNode[] = [];
     for (let index = centre - half + 1; index <= centre + half - 1; index += 1) {
@@ -1307,7 +1344,7 @@ function DetailsFilmstripModal({
               // zero-width: the row's centring assumes every non-centre panel
               // is one neighbour wide, so collapsing these would shift every
               // panel between them and the middle.
-              spare={Math.abs(index - centre) > half}
+              spare={isSpare(index)}
               width={index === centre ? panelWidths.centre : panelWidths.neighbour}
               // Engaged, and not the one being watched. Uses the same gate as
               // the playhead lines and the ring, so the whole view agrees on

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
@@ -20,7 +20,11 @@ import {
   SURFACE_CARD,
   SURFACE_CARD_FOCUS,
 } from "./graph-details-design";
-import { DETAILS_CHROME_MS, detailsStepTransition } from "./graph-details-motion";
+import {
+  DETAILS_CHROME_MS,
+  DETAILS_HANDOFF_MS,
+  detailsStepTransition,
+} from "./graph-details-motion";
 import { useDialogFocus } from "@/hooks/use-dialog-focus";
 import { formatSeconds } from "@/lib/format-duration";
 import { useInlineRename } from "./graph-inline-rename";
@@ -61,6 +65,7 @@ export function DetailsPanel({
   scrubbing = false,
   swipe,
   width,
+  focusHandoff = null,
   spare = false,
   dimmed = false,
   scrubFocus = false,
@@ -192,6 +197,14 @@ export function DetailsPanel({
    * a collapsed spare would move everything between it and the middle.
    */
   spare?: boolean;
+  /**
+   * This panel's part in a subject handoff, while one is running.
+   *
+   * `"departing"` is losing the mark and drops it immediately;
+   * `"arriving"` is taking it and waits for the other to finish. Null
+   * everywhere else, including on both cards once the step has settled.
+   */
+  focusHandoff?: "arriving" | "departing" | null;
   /**
    * Pull this panel's picture back, because the clock is running and it is not
    * the one being watched.
@@ -393,7 +406,17 @@ export function DetailsPanel({
           // where everything is.
           transform: magnification > 1 ? `scale(${magnification})` : undefined,
           // See the class above: the curve is a utility, the clock is here.
-          transitionDuration: `${DETAILS_CHROME_MS}ms`,
+          // THE HANDOFF, as two numbers on one property list.
+          //
+          // Departing drops the mark inside the handoff window; arriving waits
+          // exactly that long and then takes the full chrome clock. Neither
+          // wears it in between, so there is one subject at every frame of the
+          // step — which is the point, because the SIZES are crossing at that
+          // moment and cannot say which card is which.
+          transitionDuration: `${focusHandoff === "departing" ? DETAILS_HANDOFF_MS : DETAILS_CHROME_MS}ms`,
+          ...(focusHandoff === "arriving"
+            ? { ["--focus-delay" as string]: `${DETAILS_HANDOFF_MS}ms` }
+            : {}),
           zIndex: magnification > 1 ? 20 : undefined,
         }}
         data-item-details-live={onScreen ? "" : undefined}
@@ -464,7 +487,19 @@ export function DetailsPanel({
           // it lands INSIDE the motion rather than alongside it. The duration
           // is set in the style below, because Tailwind's default is 150ms and
           // a bare `ease-*` would silently take it.
-          "transition-[box-shadow,border-color,transform] ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
+          // BACKGROUND-COLOUR IS IN THE LIST NOW. The subject sits on a lighter
+          // surface as well as behind a brighter edge, and only the edge was
+          // ever transitioned — so the two halves of one mark arrived by
+          // different means, one eased over 210ms and the other snapping in a
+          // single frame.
+          //
+          // The delay is a CSS VARIABLE rather than an inline style so that
+          // `motion-reduce:transition-none` still wins — an inline
+          // `transition-delay` would outrank the utility that turns the whole
+          // thing off.
+          "transition-[box-shadow,border-color,background-color,transform]",
+          "ease-[cubic-bezier(0.32,0.72,0,1)] [transition-delay:var(--focus-delay,0ms)]",
+          "motion-reduce:transition-none",
           // EVERY PANEL WEARS THE SAME BORDER, including the one you opened.
           //
           // It carried a heavier white one for a while, on the reasoning that

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
@@ -23,9 +23,9 @@ import {
 import {
   DETAILS_CHROME_MS,
   DETAILS_HANDOFF_MS,
-  DETAILS_RESIZE_MS,
-  DETAILS_SLIDE_MS,
-  detailsResizeTransition,
+  DETAILS_HEIGHT_DELAY_MS,
+  DETAILS_HEIGHT_MS,
+  detailsStepTransition,
 } from "./graph-details-motion";
 import { useDialogFocus } from "@/hooks/use-dialog-focus";
 import { formatSeconds } from "@/lib/format-duration";
@@ -377,7 +377,7 @@ export function DetailsPanel({
           // a `duration-*`/`ease-*` pair so the curve is the one value all
           // three read, instead of a cubic-bezier copied into three class
           // strings and drifting from two of them.
-          ...(swapping ? {} : { transition: detailsResizeTransition("width") }),
+          ...(swapping ? {} : { transition: detailsStepTransition("width") }),
           ...(spare ? { visibility: "hidden" as const } : {}),
         }}
       >
@@ -416,8 +416,12 @@ export function DetailsPanel({
           // step — which is the point, because the SIZES are crossing at that
           // moment and cannot say which card is which.
           ["--chrome-ms" as string]: `${focusHandoff === "departing" ? DETAILS_HANDOFF_MS : DETAILS_CHROME_MS}ms`,
-          ["--resize-ms" as string]: swapping ? "0ms" : `${DETAILS_RESIZE_MS}ms`,
-          ["--resize-delay" as string]: swapping ? "0ms" : `${DETAILS_SLIDE_MS}ms`,
+          // HEIGHT IS THE ONE THING THAT WAITS. Width travels with the row
+          // because the landing position depends on it; height does not, and it
+          // is the change that was jarring — 151px of it lands on the top edge,
+          // since the cards hang from a common bottom.
+          ["--resize-ms" as string]: swapping ? "0ms" : `${DETAILS_HEIGHT_MS}ms`,
+          ["--height-delay" as string]: swapping ? "0ms" : `${DETAILS_HEIGHT_DELAY_MS}ms`,
           ...(focusHandoff === "arriving"
             ? { ["--focus-delay" as string]: `${DETAILS_HANDOFF_MS}ms` }
             : {}),
@@ -517,7 +521,7 @@ export function DetailsPanel({
           "transition-[box-shadow,border-color,background-color,transform,height]",
           "ease-[cubic-bezier(0.32,0.72,0,1)]",
           "[transition-duration:var(--chrome-ms),var(--chrome-ms),var(--chrome-ms),var(--chrome-ms),var(--resize-ms)]",
-          "[transition-delay:var(--focus-delay,0ms),var(--focus-delay,0ms),var(--focus-delay,0ms),0ms,var(--resize-delay,0ms)]",
+          "[transition-delay:var(--focus-delay,0ms),var(--focus-delay,0ms),var(--focus-delay,0ms),0ms,var(--height-delay,0ms)]",
           "motion-reduce:transition-none",
           // EVERY PANEL WEARS THE SAME BORDER, including the one you opened.
           //

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
@@ -24,6 +24,7 @@ import {
   DETAILS_CHROME_MS,
   DETAILS_HANDOFF_MS,
   DETAILS_RESIZE_MS,
+  DETAILS_SLIDE_MS,
   detailsResizeTransition,
 } from "./graph-details-motion";
 import { useDialogFocus } from "@/hooks/use-dialog-focus";
@@ -416,6 +417,7 @@ export function DetailsPanel({
           // moment and cannot say which card is which.
           ["--chrome-ms" as string]: `${focusHandoff === "departing" ? DETAILS_HANDOFF_MS : DETAILS_CHROME_MS}ms`,
           ["--resize-ms" as string]: swapping ? "0ms" : `${DETAILS_RESIZE_MS}ms`,
+          ["--resize-delay" as string]: swapping ? "0ms" : `${DETAILS_SLIDE_MS}ms`,
           ...(focusHandoff === "arriving"
             ? { ["--focus-delay" as string]: `${DETAILS_HANDOFF_MS}ms` }
             : {}),
@@ -515,7 +517,7 @@ export function DetailsPanel({
           "transition-[box-shadow,border-color,background-color,transform,height]",
           "ease-[cubic-bezier(0.32,0.72,0,1)]",
           "[transition-duration:var(--chrome-ms),var(--chrome-ms),var(--chrome-ms),var(--chrome-ms),var(--resize-ms)]",
-          "[transition-delay:var(--focus-delay,0ms),var(--focus-delay,0ms),var(--focus-delay,0ms),0ms,0ms]",
+          "[transition-delay:var(--focus-delay,0ms),var(--focus-delay,0ms),var(--focus-delay,0ms),0ms,var(--resize-delay,0ms)]",
           "motion-reduce:transition-none",
           // EVERY PANEL WEARS THE SAME BORDER, including the one you opened.
           //

--- a/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
+++ b/apps/timeline-gstudio001/components/graph-view/graph-item-details-panel.tsx
@@ -23,7 +23,8 @@ import {
 import {
   DETAILS_CHROME_MS,
   DETAILS_HANDOFF_MS,
-  detailsStepTransition,
+  DETAILS_RESIZE_MS,
+  detailsResizeTransition,
 } from "./graph-details-motion";
 import { useDialogFocus } from "@/hooks/use-dialog-focus";
 import { formatSeconds } from "@/lib/format-duration";
@@ -375,7 +376,7 @@ export function DetailsPanel({
           // a `duration-*`/`ease-*` pair so the curve is the one value all
           // three read, instead of a cubic-bezier copied into three class
           // strings and drifting from two of them.
-          ...(swapping ? {} : { transition: detailsStepTransition("width") }),
+          ...(swapping ? {} : { transition: detailsResizeTransition("width") }),
           ...(spare ? { visibility: "hidden" as const } : {}),
         }}
       >
@@ -413,7 +414,8 @@ export function DetailsPanel({
           // wears it in between, so there is one subject at every frame of the
           // step — which is the point, because the SIZES are crossing at that
           // moment and cannot say which card is which.
-          transitionDuration: `${focusHandoff === "departing" ? DETAILS_HANDOFF_MS : DETAILS_CHROME_MS}ms`,
+          ["--chrome-ms" as string]: `${focusHandoff === "departing" ? DETAILS_HANDOFF_MS : DETAILS_CHROME_MS}ms`,
+          ["--resize-ms" as string]: swapping ? "0ms" : `${DETAILS_RESIZE_MS}ms`,
           ...(focusHandoff === "arriving"
             ? { ["--focus-delay" as string]: `${DETAILS_HANDOFF_MS}ms` }
             : {}),
@@ -497,8 +499,23 @@ export function DetailsPanel({
           // `motion-reduce:transition-none` still wins — an inline
           // `transition-delay` would outrank the utility that turns the whole
           // thing off.
-          "transition-[box-shadow,border-color,background-color,transform]",
-          "ease-[cubic-bezier(0.32,0.72,0,1)] [transition-delay:var(--focus-delay,0ms)]",
+          // HEIGHT IS IN THE LIST NOW, and it is the reason a step used to look
+          // wrong. It was in nobody's transition, so a card promoted to subject
+          // grew from 368px to 519 — measured at 1920 — in a single frame,
+          // moving its top edge 151px while its width was easing over the step
+          // and the row was starting to travel. One dimension gliding and the
+          // other teleporting is what the eye caught.
+          //
+          // FOUR CLOCKS ON ONE ELEMENT, so the lists are written per property.
+          // The chrome runs on the handoff (and waits its delay when arriving);
+          // height runs on the resize phase and must NOT wait, or the card
+          // would still be growing after the row had begun to move. Driven by
+          // variables rather than an inline `transition` so that
+          // `motion-reduce:transition-none` still outranks the lot.
+          "transition-[box-shadow,border-color,background-color,transform,height]",
+          "ease-[cubic-bezier(0.32,0.72,0,1)]",
+          "[transition-duration:var(--chrome-ms),var(--chrome-ms),var(--chrome-ms),var(--chrome-ms),var(--resize-ms)]",
+          "[transition-delay:var(--focus-delay,0ms),var(--focus-delay,0ms),var(--focus-delay,0ms),0ms,0ms]",
           "motion-reduce:transition-none",
           // EVERY PANEL WEARS THE SAME BORDER, including the one you opened.
           //


### PR DESCRIPTION
Diagnosed frame by frame from a screen recording of the real app. Five commits, all about the prev/next step.

## The two real faults

**A hole opened on one side for the whole slide.** Whether a panel draws itself or renders as an empty box was read off the *current* centre, so the instant you stepped, the far card blanked — while still in full view with 420ms of travel left. It didn't slide out; it vanished. Not a mounting problem (`MOUNTED_RADIUS` already keeps spares built either side) — it was being told it was off screen too early. The window is now the union of where the row was and where it's going.

**Height was in nobody's transition list.** Width eased over the step; height snapped. Measured at 1920, a card promoted to subject goes from **368px tall to 519** — and since the cards hang from a common bottom, that's a **151px jump of its top edge in a single frame**, exactly as the row began to travel. One dimension gliding while the other teleported.

## The ordering, which took three attempts

| | result |
| --- | --- |
| resize, then slide | the card grows before it has anywhere to go |
| slide, then resize | subject lands **184px** right of centre and closes the gap by growing |
| **width with the row, height after** | ✅ |

Width *has* to travel with the row: the row's offset is computed from a uniform neighbour width, so it only centres the subject once the subject **is** the wide card — 184px is exactly half the 368px between the two widths. Height is under no such obligation, and it's the jarring one, so it's the only thing held back.

```
0..420ms   the row travels and the cards change width, together
300..500ms the height follows
```

300ms rather than 420 because ending-of-step would read as a pause — the curve is a hard ease-out and has visibly stopped by then.

## Also

**The subject mark is handed over, not swapped.** Around the crossing both cards are near enough the same size that neither reads as the subject. The outgoing drops its chrome inside 140ms; the incoming waits that out. Staggering the *widths* would have been wrong — both change by the same delta in opposite directions, so simultaneous keeps the row's total width invariant; offsetting it would dip the row by 236px and shove every card to the right sideways.

`background-color` also joined the transition list — the subject sits on a lighter surface *and* behind a brighter edge, and only the edge was ever animated.

## Verification

- `tsc` clean · `eslint` 0 errors · **51/51** modal stories
- Every guard proved to fail first: `expected 'spare while leaving: true' to be '...false'`, `expected 'departing duration 0.21s' to be '...0.14s'`, `expected 0 to be greater than 0`

**Worth knowing for anyone measuring this next:** neither browser pane will sample a transition — `requestAnimationFrame` is throttled in both, so a timed probe returns one frame and then nothing, and a reading at 900ms showed a step that hadn't started, which looks exactly like a broken transition rather than a paused one. Applying the post-step transform against pre-step sizes measures the same thing statically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)